### PR TITLE
Export MySQL en php only corrigé

### DIFF
--- a/htdocs/admin/customfields.php
+++ b/htdocs/admin/customfields.php
@@ -1,0 +1,354 @@
+<?php
+/* Copyright (C) 2011   Stephen Larroque <lrq3000@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *	\file       htdocs/admin/customfields.php
+ *	\ingroup    others
+ *	\brief          Configuring page for custom fields (add/delete/edit custom fields)
+ *	\version    $Id: customfields.php, v1.1.0
+ */
+
+// **** INIT ****
+require('../main.inc.php');
+require_once(DOL_DOCUMENT_ROOT."/customfields/class/customfields.class.php");
+require_once(DOL_DOCUMENT_ROOT."/lib/admin.lib.php");
+require_once(DOL_DOCUMENT_ROOT."/customfields/lib/customfields.lib.php");
+
+// **** EXPANSION VARIABLES ****
+$modulesarray = array("facture", "propal", "product"); // Edit me to add the support of another module
+
+// Edit me to add new data types to be supported in custom fields (then manage their output in forms in /htdocs/customfields/class/customfields.class.php in showOutputField() function and printField())
+// sqldatatype => long_name_you_choose_to_show_to_user
+$sql_datatypes = array( 'varchar' => $langs->trans("Textbox"),
+                                             'text' => $langs->trans("Areabox"),
+                                             'enum(\'Yes\',\'No\')' => $langs->trans("YesNoBox"),
+                                             'boolean' => $langs->trans("TrueFalseBox"),
+                                             'enum' => $langs->trans("DropdownBox"),
+                                             'other' => $langs->trans("Other").'/'.$langs->trans("Constraint"),
+                                                );
+
+// Security check
+if (!$user->admin)
+accessforbidden();
+
+// **** MAIN VARS ****
+// -- Getting the current active module
+if (!(GETPOST("module"))) {
+    $currentmodule = $modulesarray[0];
+} else {
+    if (in_array(GETPOST("module"), $modulesarray)) { // protection to avoid sql injection (can only request referenced modules)
+        $currentmodule = GETPOST("module");
+    } else {
+        $currentmodule = $modulesarray[0];
+    }
+}
+
+$action = GETPOST("action");
+
+if (count($_POST["nulloption"]) == 1)  {$nulloption = true;} else {$nulloption = false;}
+
+// **** INIT CUSTOMFIELD CLASS ****
+$customfields = new CustomFields($db, $currentmodule);
+
+// **** ACTIONS ****
+if ($action == "set")
+{
+    Header("Location: customfields.php");
+    exit;
+}
+
+// Initialization of the module's customfields (we create the customfields table for this module)
+if ($action == 'init') {
+    $rtncode = $customfields->initCustomFields();
+    if ($rtncode > 0) { // If no error, we refresh the page
+        Header("Location: ".$_SERVER["PHP_SELF"]."?module=".$currentmodule);
+        exit();
+    } else { // else we print the errors
+        $error++;
+        $mesg=$customfields->error;
+    }
+}
+
+// Add/Update a field
+if ($action == 'add' or $action == 'update') {
+    if ($_POST["button"] != $langs->trans("Cancel")) {
+        // Check values
+        if (GETPOST('size') < 0) { // We accept 0 for infinity (for text type)
+            $error++;
+            $langs->load("errors");
+            $mesg=$langs->trans("ErrorSizeTooLongForVarcharType");
+            if ($action == 'add') { // we set back the previous action so that the user can go back to edit and fix the mistakes
+                $action = 'create';
+            } elseif ($action == 'update') {
+                $action = 'edit';
+            }
+        }
+
+        if (! $error) {
+            // We check that the field name does not contain any special character (only alphanumeric)
+            if (isset($_POST["field"]) && preg_match("/^\w[a-zA-Z0-9-_]*$/",$_POST['field'])) {
+                // Calling the action function
+                if ($action == 'add') {
+                    $result=$customfields->addCustomField($_POST['field'],$_POST['type'],$_POST['size'],$nulloption,$_POST['defaultvalue'],$_POST['constraint'],$_POST['customtype'],$_POST['customdef'],$_POST['customsql']);
+                } elseif ($action == 'update') {
+                    $result=$customfields->updateCustomField($_POST['fieldid'], $_POST['field'],$_POST['type'],$_POST['size'],$nulloption,$_POST['defaultvalue'],$_POST['constraint'],$_POST['customtype'],$_POST['customdef'],$_POST['customsql']);
+                }
+                // Error ?
+                if ($result > 0) { // If no error, we refresh the page
+                    Header("Location: ".$_SERVER["PHP_SELF"]."?module=".$currentmodule);
+                    exit();
+                } else { // else we show the error
+                    $error++;
+                    $mesg=$customfields->error;
+                }
+            } else {
+                $error++;
+                $langs->load("errors");
+                $mesg=$langs->trans("ErrorFieldCanNotContainSpecialCharacters",$langs->transnoentities("FieldName"));
+                if ($action == 'add') { // we set back the previous action so that the user can go back to edit and fix the mistakes
+                    $action = 'create';
+                } elseif ($action == 'update') {
+                    $action = 'edit';
+                }
+            }
+        }
+    }
+}
+
+// Deleting a field
+if ($action == 'delete') {
+    if(isset($_GET["fieldid"])) {
+        $result=$customfields->deleteCustomField($_GET["fieldid"]);
+        if ($result >= 0) {
+            Header("Location: ".$_SERVER["PHP_SELF"]."?module=".$currentmodule);
+            exit();
+        } else {
+            $mesg=$customfields->error;
+        }
+    } else {
+        $error++;
+        $langs->load("errors");
+        $mesg=$langs->trans("ErrorFieldCanNotContainSpecialCharacters",$langs->transnoentities("AttributeCode"));
+    }
+}
+
+/*
+ *	View
+ */
+
+// necessary headers
+$html=new Form($db);
+
+llxHeader('',$langs->trans("CustomFieldsSetup"));
+
+$linkback='<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans("BackToModuleList").'</a>';
+
+print_fiche_titre($langs->trans("CustomFieldsSetup"),$linkback,'setup');
+
+$head = customfields_admin_prepare_head($modulesarray, $currentmodule); // draw modules tabs
+
+dol_htmloutput_errors($mesg); // Print error messages
+
+// Probing if the customfields table exists for this module
+$tableexists = $customfields->probeCustomFields();
+
+// if the table for this module is not created, we ask user if he wants to create it
+if (!$tableexists) {
+    print $langs->trans('The customfields table for this module is not yet created! Please create the table before creating fields.<br />Do you want to create it now?');
+    print "<br /><center><a class=\"butAction\" href=\"".$_SERVER["PHP_SELF"]."?module=".$currentmodule."&action=init\">".$langs->trans("CreateTable")."</a></center>";
+    dol_fiche_end();
+
+// else, the table exists and we can proceed to show the customfields
+} else {
+    // start of the form
+    //print '<form method="post" action="'.$_SERVER["PHP_SELF"].'?module='.$currentmodule.'">';
+    //print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+    // end of necessary headers
+
+    // start of the fields table
+    print '<table class="noborder" width="100%">';
+    print '<tr class="liste_titre">';
+    // table headers
+    print '<td width="30%">'.$langs->trans("Fieldname").'</td>';
+    print '<td width="30%">'.$langs->trans("Datatype").'</td>';
+    print '<td width="30%">'.$langs->trans("Variable").'</td>';
+    print '<td width="10%"></td>'; // Empty header because this column will be used to show the delete button
+    // end of table headers
+    print "</tr>";
+
+    // generating custom fields list
+    $fieldsarray = $customfields->fetchAllCustomFields();
+
+    if ($fieldsarray < 0) { // error
+        $error++;
+        $mesg=$customfields->error;
+        dol_htmloutput_errors($mesg); // Print error messages
+    } else {
+        // generated rows of the table
+        $i = 0; // used to alternate background color
+        if (count($fieldsarray) > 0) {
+            foreach ($fieldsarray as $obj) {
+                if ($obj->column_name != 'rowid' and $obj->column_name != 'fk_'.$currentmodule) // we skip the rowid and fk_facture rows which are not custom fields
+                {
+                    if ($i % 2  == 0) {$colorclass = 'impair';} else {$colorclass = 'pair';} // for more visibility, we switch the background color each row
+                    print '<tr class="'.$colorclass.'">';
+                    print '<td>'.$obj->column_name.'</td>';
+                    print '<td align="left">';
+                    print $obj->column_type;
+                    print '</td>';
+                    print '<td align="left">';
+                    print $customfields->varprefix.$obj->column_name;
+                    print '</td>';
+                    print '<td align="center">';
+                    print '<a href="'.$_SERVER["PHP_SELF"].'?module='.$currentmodule.'&action=edit&fieldid='.$obj->ordinal_position.'">'.img_edit().'</a>';
+                    print '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
+                    print '<a href="'.$_SERVER["PHP_SELF"].'?module='.$currentmodule.'&action=delete&fieldid='.$obj->ordinal_position.'">'.img_delete().'</a>';
+                    print '</td>';
+                    print '</tr>';
+                    $i++;
+                }
+            }
+        }
+        // end of the generated rows
+    }
+
+    print '</table>';
+    // end of the fields table
+    //print '</form>';
+    // end of the form
+
+?>
+
+<br>
+
+<?php
+    dol_fiche_end();
+    // end of necessary footers
+
+
+    /*
+     * Barre d'actions
+     *
+     */
+    if ($action != 'create')
+    {
+        print '<div class="tabsAction">';
+        print "<a class=\"butAction\" href=\"".$_SERVER["PHP_SELF"]."?module=".$currentmodule."&action=create\">".$langs->trans("NewField")."</a>";
+        print "</div>";
+    }
+}
+
+/* ************************************************************************** */
+/*                                                                            */
+/* Creation d'un champ optionnel
+ /*                                                                            */
+/* ************************************************************************** */
+;
+if ($action == 'create' or ($action == 'edit' and GETPOST('fieldid')) ) {
+    print "<br>";
+
+    // ** Page header title and field fetching from db
+    if ($action == 'create') {
+        print_titre($langs->trans('NewField'));
+    } elseif ($action == 'edit') {
+        $fieldobj = $customfields->fetchCustomField($_GET["fieldid"]); // fetching the field data
+        print_titre($langs->trans('FieldEdition',$fieldobj->column_name));
+    }
+
+    // ** Form and hidden fields
+    print '<form action="'.$_SERVER["PHP_SELF"].'" method="post">';
+    print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+    print '<input type="hidden" name="module" value="'.$currentmodule.'">';
+    print '<table summary="listofattributes" class="border" width="100%">';
+
+    if ($action == 'create') {
+        print '<input type="hidden" name="action" value="add">';
+    } elseif ($action == 'edit') {
+        print '<input type="hidden" name="fieldid" value="'.GETPOST('fieldid').'">';
+        print '<input type="hidden" name="action" value="update">';
+    }
+
+    // ** Variables initializing
+    if ($action == 'create') {
+        $field_name = GETPOST('field'); // if GETPOST is defined, $field_name will reload the data submitted by the admin, else if there's none it will just be empty (blank creation of a custom field). This is a clever way to avoid too many conditionnal statements
+        $field_type = GETPOST('type');
+        $field_size = GETPOST('size');
+        $field_constraint = GETPOST('constraint');
+        $field_customtype = GETPOST('customtype');
+        $checked = '';
+        if ($action=='create') $checked = "checked=checked"; //  By default a field can be null (necessary to have the field either possibly null or to have a default value if the user add a new field while he already saved an invoice/propal/whatever with custom fields, these already saved records must know what to set by default for the new column)
+        if (count($_POST["nulloption"]) == 1) $checked = "checked=checked"; // if the user created the custom field but there was an error submitting it, we must be able to reload the settings so that the user can fix the problem and resubmit
+    } elseif ($action == 'edit') {
+        if (GETPOST('field')) $field_name = GETPOST('field'); else $field_name = $fieldobj->column_name;
+        if (GETPOST('type')) $field_type = GETPOST('type'); else $field_type = $fieldobj->data_type;
+        if (!array_key_exists($field_type, $sql_datatypes)) { // if the admin supplied a custom field type, we assign it to the right field ($field_customtype)
+            $field_customtype = $field_type;
+            $field_type = 'other';
+        }
+        if (GETPOST('size')) $field_size = GETPOST('size'); else $field_size = $fieldobj->size;
+        if (count($_POST["nulloption"]) == 1) $checked = "checked=checked"; else $checked = '';
+        if (GETPOST('defaultvalue')) $field_defaultvalue = GETPOST('defaultvalue'); else $field_defaultvalue = $fieldobj->column_default;
+        if (GETPOST('constraint')) $field_constraint = GETPOST('constraint'); else $field_constraint = $fieldobj->referenced_table_name;
+    }
+
+    // ** User Fields
+    // Label (to be defined in lang file)
+    if ($customfields->findLabel($field_name) != $field_name) { // detecting if the label has been defined
+        $field_label = $customfields->findLabel($field_name); // if it's different, then it's been defined
+    } elseif ( !empty($field_name) )  { // else if the field has been defined but not the label, we show the code
+        $field_label = $field_name.'<br />('.$langs->trans("PleaseEditLangFile").' - code : <b>'.$customfields->varprefix.$field_name.'</b> '.$langs->trans("or").' <b>'.$field_name.'</b>)';
+    } else {
+        $field_label = $field_name.' ('.$langs->trans("PleaseEditLangFile").')'; // else if it's the same string returned by $langs->trans(), then it's probably because it's not defined
+    }
+    print '<tr><td class="field">'.$langs->trans("Label").'</td><td class="valeur">'.$field_label.'</td></tr>';
+    // Field name in sql table
+    print '<tr><td class="fieldrequired required">'.$langs->trans("FieldName").' ('.$langs->trans("AlphaNumOnlyCharsAndNoSpace").')</td><td class="valeur"><input type="text" name="field" size="10" value="'.$field_name.'"></td></tr>';
+    // Type and custom type
+    print '<tr><td class="fieldrequired required">'.$langs->trans("Type").'</td><td class="valeur">';
+    print $html->selectarray('type',$sql_datatypes,$field_type);
+    print '<br>'.$langs->trans('Other').' ('.$langs->trans('CustomSQL').'): <input type="text" name="customtype" size="10" value="'.$field_customtype.'">';
+    print '</td></tr>';
+    // Size
+    print '<tr><td class="fieldrequired required">'.$langs->trans("Size").' '.$langs->trans("or").' '.$langs->trans("EnumValues").' ('.$langs->trans("SizeDesc").')<br />'.$langs->trans("SizeNote").'</td><td><input type="text" name="size" size="10" value="'.$field_size.'"></td></tr>';
+    // Null?
+    print '<tr><td class="fieldrequired required">'.$langs->trans("CanBeNull?").'</td><td><input type="checkbox" name="nulloption[]" value="true" '.$checked.'></td></tr>';
+    // Default value
+    print '<tr><td class="field">'.$langs->trans("DefaultValue").' ('.$langs->trans("RequiredIfFieldCannotBeNull").')</td><td class="valeur"><input type="text" name="defaultvalue" size="10" value="'.$field_defaultvalue.'"></td></tr>';
+
+    // SQL constraints
+    print '<tr><td class="field">'.$langs->trans("Constraint").'</td><td class="valeur">';
+    $tables = $customfields->fetchAllTables();
+    $tables = array_merge(array('' => $langs->trans('None')), $tables); // Adding a none choice (to avoid choosing a constraint or just to delete one)
+    print $html->selectarray('constraint',$tables,$field_constraint);
+    print '</td></tr>';
+
+    // Custom SQL
+    print '<tr><td class="field">'.$langs->trans("CustomSQLDefinition").' ('.$langs->trans("CustomSQLDefinitionDesc").')</td><td class="valeur"><input type="text" name="customdef" size="50" value="'.GETPOST('customdef').'"></td></tr>';
+    print '<tr><td class="field">'.$langs->trans("CustomSQL").' ('.$langs->trans("CustomSQLDesc").')</td><td class="valeur"><input type="text" name="customsql" size="50" value="'.GETPOST('customsql').'"></td></tr>';
+
+    print '<tr><td colspan="2" align="center"><input type="submit" name="button" class="button" value="'.$langs->trans("Save").'"> &nbsp; ';
+    print '<input type="submit" name="button" class="button" value="'.$langs->trans("Cancel").'"></td></tr>';
+    print "</form>\n";
+    print "</table>\n";
+}
+
+// some other necessary footer and db closing
+$db->close();
+
+llxFooter('$Date: 2011/07/31 22:23:25 $ - $Revision: 0.1 $');
+// end of necessary footers
+?>

--- a/htdocs/admin/societe_extrafields.php
+++ b/htdocs/admin/societe_extrafields.php
@@ -250,7 +250,7 @@ if ($action == 'create')
     // Label
     print '<tr><td class="fieldrequired" required>'.$langs->trans("Label").'</td><td class="valeur"><input type="text" name="label" size="40" value="'.GETPOST('label').'"></td></tr>';
     // Code
-    print '<tr><td class="fieldrequired" required>'.$langs->trans("AttributeCode").' ('.$langs->trans("AlphaNumOnlyCharsAndNoSpace").')</td><td class="valeur"><input type="text" name="attrname" size="10" value"'.GETPOST('attrname').'"></td></tr>';
+    print '<tr><td class="fieldrequired" required>'.$langs->trans("AttributeCode").' ('.$langs->trans("AlphaNumOnlyCharsAndNoSpace").')</td><td class="valeur"><input type="text" name="attrname" size="10" value="'.GETPOST('attrname').'"></td></tr>';
     // Type
     print '<tr><td class="fieldrequired" required>'.$langs->trans("Type").'</td><td class="valeur">';
     print $form->selectarray('type',$type2label,GETPOST('type'));

--- a/htdocs/admin/tools/dolibarr_export.php
+++ b/htdocs/admin/tools/dolibarr_export.php
@@ -45,13 +45,25 @@ llxHeader('','','EN:Backups|FR:Sauvegardes|ES:Copias_de_seguridad');
 ?>
 <script type="text/javascript" language="javascript">
 jQuery(document).ready(function() {
-	jQuery("#mysql_options").hide();
-	jQuery("#postgresql_options").hide();
+
+	function hideoptions () {
+		jQuery("#mysql_options").hide();
+		jQuery("#mysql_options_nobin").hide();
+		jQuery("#postgresql_options").hide();
+	}
+
+	hideoptions();
 
 	jQuery("#radio_dump_mysql").click(function() {
+		hideoptions();
 		jQuery("#mysql_options").show();
 	});
+	jQuery("#radio_dump_mysql_nobin").click(function() {
+		hideoptions();
+		jQuery("#mysql_options_nobin").show();
+	});
 	jQuery("#radio_dump_postgresql").click(function() {
+		hideoptions();
 		jQuery("#postgresql_options").show();
 	});
 });
@@ -95,6 +107,9 @@ if ($_GET["msg"])
 			?>
 			<div class="formelementrow"><input type="radio" name="what" value="mysql" id="radio_dump_mysql" />
 			<label for="radio_dump_mysql">MySQL	Dump (mysqldump)</label>
+			</div>
+			<div class="formelementrow"><input type="radio" name="what" value="mysqlnobin" id="radio_dump_mysql_nobin" />
+			<label for="radio_dump_mysql">MySQL	Dump (php)</label>
 			</div>
 			<?php
 		}

--- a/htdocs/admin/tools/export.php
+++ b/htdocs/admin/tools/export.php
@@ -18,14 +18,12 @@
 /**
  *		\file 		htdocs/admin/tools/export.php
  *		\brief      Page to export a database into a dump file
- *		\version    $Id: export.php,v 1.45 2011/08/03 00:45:43 eldy Exp $
  */
 
 require("../../main.inc.php");
 require_once(DOL_DOCUMENT_ROOT."/lib/admin.lib.php");
 require_once(DOL_DOCUMENT_ROOT."/lib/files.lib.php");
 require_once(DOL_DOCUMENT_ROOT."/core/class/html.formfile.class.php");
-include_once $dolibarr_main_document_root."/lib/databases/".$conf->db->type.".lib.php";
 
 $what=$_REQUEST["what"];
 $export_type=$_REQUEST["export_type"];
@@ -33,19 +31,18 @@ $file=isset($_POST['filename_template']) ? $_POST['filename_template'] : '';
 
 $langs->load("admin");
 
-if (! $user->admin)
-  accessforbidden();
+if (! $user->admin) accessforbidden();
 
 
 if ($file && ! $what)
 {
-   //print DOL_URL_ROOT.'/dolibarr_export.php';
-	header("Location: ".DOL_URL_ROOT.'/admin/tools/dolibarr_export.php?msg='.urlencode($langs->trans("ErrorFieldRequired",$langs->transnoentities("ExportMethod"))));
-/*
-	print '<div class="error">'.$langs->trans("ErrorFieldRequired",$langs->trans("ExportMethod")).'</div>';
-	print '<br>';
-*/
-	exit;
+    //print DOL_URL_ROOT.'/dolibarr_export.php';
+    header("Location: ".DOL_URL_ROOT.'/admin/tools/dolibarr_export.php?msg='.urlencode($langs->trans("ErrorFieldRequired",$langs->transnoentities("ExportMethod"))));
+    /*
+     print '<div class="error">'.$langs->trans("ErrorFieldRequired",$langs->trans("ExportMethod")).'</div>';
+     print '<br>';
+     */
+    exit;
 }
 
 
@@ -86,248 +83,136 @@ $time_start = time();
 // MYSQL
 if ($what == 'mysql')
 {
-	$cmddump=$_POST["mysqldump"];
-	if ($cmddump)
-	{
-		dolibarr_set_const($db, 'SYSTEMTOOLS_MYSQLDUMP', $cmddump,'chaine',0,'',$conf->entity);
-	}
+    $cmddump=$_POST["mysqldump"];
+    if ($cmddump)
+    {
+        dolibarr_set_const($db, 'SYSTEMTOOLS_MYSQLDUMP', $cmddump,'chaine',0,'',$conf->entity);
+    }
 
-	$outputdir  = $conf->admin->dir_output.'/backup';
-	$outputfile = $outputdir.'/'.$file;
-	// for compression format, we add extension
-	$compression=isset($_POST['compression']) ? $_POST['compression'] : 'none';
-	if ($compression == 'gz') $outputfile.='.gz';
-	if ($compression == 'bz') $outputfile.='.bz2';
-	$outputerror = $outputfile.'.err';
-	dol_mkdir($conf->admin->dir_output.'/backup');
+    $outputdir  = $conf->admin->dir_output.'/backup';
+    $outputfile = $outputdir.'/'.$file;
+    // for compression format, we add extension
+    $compression=isset($_POST['compression']) ? $_POST['compression'] : 'none';
+    if ($compression == 'gz') $outputfile.='.gz';
+    if ($compression == 'bz') $outputfile.='.bz2';
+    $outputerror = $outputfile.'.err';
+    dol_mkdir($conf->admin->dir_output.'/backup');
 
-	// Parameteres execution
-	$command=$cmddump;
-	if (preg_match("/\s/",$command)) $command=escapeshellarg($command);	// Use quotes on command
+    // Parameteres execution
+    $command=$cmddump;
+    if (preg_match("/\s/",$command)) $command=escapeshellarg($command);	// Use quotes on command
 
-	//$param=escapeshellarg($dolibarr_main_db_name)." -h ".escapeshellarg($dolibarr_main_db_host)." -u ".escapeshellarg($dolibarr_main_db_user)." -p".escapeshellarg($dolibarr_main_db_pass);
-	$param=$dolibarr_main_db_name." -h ".$dolibarr_main_db_host;
-	$param.=" -u ".$dolibarr_main_db_user;
-	if (! empty($dolibarr_main_db_port)) $param.=" -P ".$dolibarr_main_db_port;
-	if (! $_POST["use_transaction"]) $param.=" -l --single-transaction";
-	if ($_POST["disable_fk"])        $param.=" -K";
-	if ($_POST["sql_compat"] && $_POST["sql_compat"] != 'NONE') $param.=" --compatible=".$_POST["sql_compat"];
-	if ($_POST["drop_database"])     $param.=" --add-drop-database";
-	if ($_POST["sql_structure"])
-	{
-		if ($_POST["drop"])			 $param.=" --add-drop-table";
-	}
-	else
-	{
-		$param.=" -t";
-	}
-	if ($_POST["sql_data"])
-	{
-		$param.=" --tables";
-		if ($_POST["showcolumns"])	$param.=" -c";
-		if ($_POST["extended_ins"])	$param.=" -e";
-		if ($_POST["delayed"])	 	$param.=" --delayed-insert";
-		if ($_POST["sql_ignore"])	$param.=" --insert-ignore";
-		if ($_POST["hexforbinary"])	$param.=" --hex-blob";
-	}
-	else
-	{
-		$param.=" -d";
-	}
-	$paramcrypted=$param;
-	$paramclear=$param;
-	if (! empty($dolibarr_main_db_pass))
-	{
-		$paramcrypted.=" -p".preg_replace('/./i','*',$dolibarr_main_db_pass);
-		$paramclear.=" -p".$dolibarr_main_db_pass;
-	}
+    //$param=escapeshellarg($dolibarr_main_db_name)." -h ".escapeshellarg($dolibarr_main_db_host)." -u ".escapeshellarg($dolibarr_main_db_user)." -p".escapeshellarg($dolibarr_main_db_pass);
+    $param=$dolibarr_main_db_name." -h ".$dolibarr_main_db_host;
+    $param.=" -u ".$dolibarr_main_db_user;
+    if (! empty($dolibarr_main_db_port)) $param.=" -P ".$dolibarr_main_db_port;
+    if (! $_POST["use_transaction"]) $param.=" -l --single-transaction";
+    if ($_POST["disable_fk"])        $param.=" -K";
+    if ($_POST["sql_compat"] && $_POST["sql_compat"] != 'NONE') $param.=" --compatible=".$_POST["sql_compat"];
+    if ($_POST["drop_database"])     $param.=" --add-drop-database";
+    if ($_POST["sql_structure"])
+    {
+        if ($_POST["drop"])			 $param.=" --add-drop-table";
+    }
+    else
+    {
+        $param.=" -t";
+    }
+    if ($_POST["sql_data"])
+    {
+        $param.=" --tables";
+        if ($_POST["showcolumns"])	$param.=" -c";
+        if ($_POST["extended_ins"])	$param.=" -e";
+        if ($_POST["delayed"])	 	$param.=" --delayed-insert";
+        if ($_POST["sql_ignore"])	$param.=" --insert-ignore";
+        if ($_POST["hexforbinary"])	$param.=" --hex-blob";
+    }
+    else
+    {
+        $param.=" -d";
+    }
+    $paramcrypted=$param;
+    $paramclear=$param;
+    if (! empty($dolibarr_main_db_pass))
+    {
+        $paramcrypted.=" -p".preg_replace('/./i','*',$dolibarr_main_db_pass);
+        $paramclear.=" -p".$dolibarr_main_db_pass;
+    }
 
-	print '<b>'.$langs->trans("RunCommandSummary").':</b><br>'."\n";
-	print '<textarea rows="'.ROWS_2.'" cols="120">'.$command." ".$paramcrypted.'</textarea><br>'."\n";
+    print '<b>'.$langs->trans("RunCommandSummary").':</b><br>'."\n";
+    print '<textarea rows="'.ROWS_2.'" cols="120">'.$command." ".$paramcrypted.'</textarea><br>'."\n";
 
-	print '<br>';
+    print '<br>';
 
 
-	// Now run command and show result
-	print '<b>'.$langs->trans("BackupResult").':</b> ';
+    // Now run command and show result
+    print '<b>'.$langs->trans("BackupResult").':</b> ';
 
-	$errormsg='';
+    $errormsg='';
 
-	$result=dol_mkdir($outputdir);
+    $result=dol_mkdir($outputdir);
 
-	// Debut appel methode execution
-	$fullcommandcrypted=$command." ".$paramcrypted." 2>&1";
-	$fullcommandclear=$command." ".$paramclear." 2>&1";
-	if ($compression == 'none') $handle = fopen($outputfile, 'w');
-	if ($compression == 'gz')   $handle = gzopen($outputfile, 'w');
-	if ($compression == 'bz')   $handle = bzopen($outputfile, 'w');
+    // Debut appel methode execution
+    $fullcommandcrypted=$command." ".$paramcrypted." 2>&1";
+    $fullcommandclear=$command." ".$paramclear." 2>&1";
+    if ($compression == 'none') $handle = fopen($outputfile, 'w');
+    if ($compression == 'gz')   $handle = gzopen($outputfile, 'w');
+    if ($compression == 'bz')   $handle = bzopen($outputfile, 'w');
 
-	if ($handle)
-	{
-	    $ok=0;
-		dol_syslog("Run command ".$fullcommandcrypted);
-		$handlein = popen($fullcommandclear, 'r');
-		while (!feof($handlein))
-		{
-			$read = fgets($handlein);
-			fwrite($handle,$read);
-			if (preg_match('/-- Dump completed/i',$read)) $ok=1;
-		}
-		pclose($handlein);
+    if ($handle)
+    {
+        $ok=0;
+        dol_syslog("Run command ".$fullcommandcrypted);
+        $handlein = popen($fullcommandclear, 'r');
+        while (!feof($handlein))
+        {
+            $read = fgets($handlein);
+            fwrite($handle,$read);
+            if (preg_match('/-- Dump completed/i',$read)) $ok=1;
+        }
+        pclose($handlein);
 
-		if ($compression == 'none') fclose($handle);
-		if ($compression == 'gz')   gzclose($handle);
-		if ($compression == 'bz')   bzclose($handle);
+        if ($compression == 'none') fclose($handle);
+        if ($compression == 'gz')   gzclose($handle);
+        if ($compression == 'bz')   bzclose($handle);
 
-		if (! empty($conf->global->MAIN_UMASK))
-			@chmod($outputfile, octdec($conf->global->MAIN_UMASK));
-	}
-	else
-	{
-		$langs->load("errors");
-		dol_syslog("Failed to open file ".$outputfile,LOG_ERR);
-		$errormsg=$langs->trans("ErrorFailedToWriteInDir");
-	}
-	// Get errorstring
-	if ($compression == 'none') $handle = fopen($outputfile, 'r');
-	if ($compression == 'gz')   $handle = gzopen($outputfile, 'r');
-	if ($compression == 'bz')   $handle = bzopen($outputfile, 'r');
-	if ($handle)
-	{
-		// Get 2048 first chars of error message.
-		$errormsg = fgets($handle,2048);
-		// Close file
-		if ($compression == 'none') fclose($handle);
-		if ($compression == 'gz')   gzclose($handle);
-		if ($compression == 'bz')   bzclose($handle);
-		if ($ok && preg_match('/^-- MySql/i',$errormsg)) $errormsg='';	// Pas erreur
-		else
-		{
-			// Renommer fichier sortie en fichier erreur
-			//print "$outputfile -> $outputerror";
-			@dol_delete_file($outputerror,1);
-			@rename($outputfile,$outputerror);
-			// Si safe_mode on et command hors du parametre exec, on a un fichier out vide donc errormsg vide
-			if (! $errormsg) $errormsg=$langs->trans("ErrorFailedToRunExternalCommand");
-		}
-	}
-	// Fin execution commande
+        if (! empty($conf->global->MAIN_UMASK))
+        @chmod($outputfile, octdec($conf->global->MAIN_UMASK));
+    }
+    else
+    {
+        $langs->load("errors");
+        dol_syslog("Failed to open file ".$outputfile,LOG_ERR);
+        $errormsg=$langs->trans("ErrorFailedToWriteInDir");
+    }
+    // Get errorstring
+    if ($compression == 'none') $handle = fopen($outputfile, 'r');
+    if ($compression == 'gz')   $handle = gzopen($outputfile, 'r');
+    if ($compression == 'bz')   $handle = bzopen($outputfile, 'r');
+    if ($handle)
+    {
+        // Get 2048 first chars of error message.
+        $errormsg = fgets($handle,2048);
+        // Close file
+        if ($compression == 'none') fclose($handle);
+        if ($compression == 'gz')   gzclose($handle);
+        if ($compression == 'bz')   bzclose($handle);
+        if ($ok && preg_match('/^-- MySql/i',$errormsg)) $errormsg='';	// Pas erreur
+        else
+        {
+            // Renommer fichier sortie en fichier erreur
+            //print "$outputfile -> $outputerror";
+            @dol_delete_file($outputerror,1);
+            @rename($outputfile,$outputerror);
+            // Si safe_mode on et command hors du parametre exec, on a un fichier out vide donc errormsg vide
+            if (! $errormsg) $errormsg=$langs->trans("ErrorFailedToRunExternalCommand");
+        }
+    }
+    // Fin execution commande
 }
 
-// MYSQL NO BINARIES (only php)
-/**	Backup the db OR just a table without mysqldump binary (does not require any exec permission)
- *	Author: David Walsh (http://davidwalsh.name/backup-mysql-database-php)
- *	Updated and enhanced by Stephen Larroque (lrq3000) and by the many commentators from the blog
- *	there's a mysqli version if needed on this page
- */
-function backup_tables($outputfile,$host='localhost',$port=3306,$user='root',$pass='',$name='',$tables = '*')
+if ($what == 'mysqlnobin')
 {
-
-  if (!($port > 0)) $port = 3306;
-  $link = mysql_connect($host.':'.$port,$user,$pass);
-  mysql_select_db($name,$link);
-
-  // Set to UTF-8
-  mysql_query('SET NAMES utf8');
-  mysql_query('SET CHARACTER SET utf8');
-
-  //get all of the tables
-  if ($tables == '*') {
-    $tables = array();
-    $result = mysql_query('SHOW FULL TABLES WHERE Table_type = \'BASE TABLE\'');
-    while($row = mysql_fetch_row($result)) {
-      $tables[] = $row[0];
-    }
-  } else {
-    $tables = is_array($tables) ? $tables : explode(',',$tables);
-  }
-
-  //cycle through
-  $handle = fopen($outputfile, 'w+');
-  if (fwrite($handle, '') === FALSE) {
-    global $langs, $errormsg;
-    $langs->load("errors");
-    dol_syslog("Failed to open file ".$outputfile,LOG_ERR);
-    $errormsg=$langs->trans("ErrorFailedToWriteInDir");
-    return -1;
-  }
-  foreach($tables as $table) {
-    $result = mysql_query('SELECT * FROM '.$table);
-    $num_fields = mysql_num_fields($result);
-
-    fwrite($handle,'DROP TABLE IF EXISTS '.$table.';');
-    $row2 = mysql_fetch_row(mysql_query('SHOW CREATE TABLE '.$table));
-    fwrite($handle,"\n\n".$row2[1].";\n\n");
-
-    while($row = mysql_fetch_row($result)) {
-      fwrite($handle,'INSERT INTO '.$table.' VALUES(');
-      $columns = count($row);
-      for($j=0; $j<$columns; $j++) {
-	$row[$j] = addslashes($row[$j]);
-	$row[$j] = preg_replace("#\n#", "\\n", $row[$j]);
-	if (isset($row[$j])) { fwrite($handle,'"'.$row[$j].'"'); } else { fwrite($handle,'""'); }
-	if (isset($row[$j])) {
-	  if ($row[$j] == null) {
-	      fwrite($handle,'"null"');
-	  } else {
-	      fwrite($handle,'"'.$row[$j].'"');
-	  }
-	} else {
-	  fwrite($handle,'""');
-	}
-	if ($j<($num_fields-1)) { fwrite($handle,','); }
-      }
-      fwrite($handle,");\n");
-    }
-    fwrite($handle,"\n\n\n");
-  }
-
-  //———— /* Backup Procedure structure*/
-    $result = mysql_query('SHOW PROCEDURE STATUS');
-    if (mysql_num_rows($result) > 0) {
-	while($row = mysql_fetch_row($result)) { $procedures[] = $row[1]; }
-	foreach($procedures as $proc)
-	{
-	fwrite($handle,"DELIMITER $$\n\n");
-	fwrite($handle,"DROP PROCEDURE IF EXISTS '$name'.'$proc'$$\n");
-	$row2 = mysql_fetch_row(mysql_query("SHOW CREATE PROCEDURE '$proc'"));
-	fwrite($handle,"\n".$row2[2]."$$\n\n");
-	fwrite($handle,"DELIMITER ;\n\n");
-	}
-    }
-    //———— /* Backup Procedure structure*/
-
-  //save file
-  //$handle = fopen('db-backup-'.time().'-'.(md5(implode(',',$tables))).'.sql','w+');
-  //fwrite($handle,$return);
-  fclose($handle);
-
-//Header(“Content-type: application/octet-stream”);
-//Header(“Content-Disposition: attachment; filename=$filename”);
-//echo $return;
-}
-
-function compress_gzip($inputfile, $outputfile, $mode="gz") {
-    try {
-	$data = implode("", file($inputfile));
-	if ($mode == 'gz') {
-	    $compressdata = gzencode($data, 9);
-	} elseif ($mode == 'bz') {
-	    $compressdata = bzcompress($data, 9);
-	}
-	$fp = fopen($outputfile, "w");
-	fwrite($fp, $compressdata);
-	fclose($fp);
-    } catch (Exception $e) {
-	global $langs, $errormsg;
-	$langs->load("errors");
-	dol_syslog("Failed to open file ".$outputfile,LOG_ERR);
-	$errormsg=$langs->trans("ErrorFailedToWriteInDir");
-	return -1;
-    }
-}
-
-if ($what == 'mysqlnobin') {
     $outputdir  = $conf->admin->dir_output.'/backup';
     $outputfile = $outputdir.'/'.$file;
     $outputfiletemp = $outputfile.'-TMP.sql';
@@ -338,80 +223,83 @@ if ($what == 'mysqlnobin') {
     $outputerror = $outputfile.'.err';
     dol_mkdir($conf->admin->dir_output.'/backup');
 
-    if ($compression == 'gz' or $compression == 'bz') {
-	backup_tables($outputfiletemp,$dolibarr_main_db_host,$dolibarr_main_db_port,$dolibarr_main_db_user,$dolibarr_main_db_pass,$dolibarr_main_db_name);
-	compress_gzip($outputfiletemp, $outputfile, $compression);
-	unlink($outputfiletemp);
-    } else {
-	backup_tables($outputfile,$dolibarr_main_db_host,$dolibarr_main_db_port,$dolibarr_main_db_user,$dolibarr_main_db_pass,$dolibarr_main_db_name);
+    if ($compression == 'gz' or $compression == 'bz')
+    {
+        backup_tables($outputfiletemp);
+        dol_compress_file($outputfiletemp, $outputfile, $compression);
+        unlink($outputfiletemp);
+    }
+    else
+    {
+        backup_tables($outputfile);
     }
 }
 
 // POSTGRESQL
 if ($what == 'postgresql')
 {
-	$cmddump=$_POST["postgresqldump"];
-	if ($cmddump)
-	{
-		dolibarr_set_const($db, 'SYSTEMTOOLS_POSTGRESQLDUMP', $cmddump,'chaine',0,'',$conf->entity);
-	}
+    $cmddump=$_POST["postgresqldump"];
+    if ($cmddump)
+    {
+        dolibarr_set_const($db, 'SYSTEMTOOLS_POSTGRESQLDUMP', $cmddump,'chaine',0,'',$conf->entity);
+    }
 
-	$outputdir  = $conf->admin->dir_output.'/backup';
-	$outputfile = $outputdir.'/'.$file;
-	// for compression format, we add extension
-	$compression=isset($_POST['compression']) ? $_POST['compression'] : 'none';
-	if ($compression == 'gz') $outputfile.='.gz';
-	if ($compression == 'bz') $outputfile.='.bz2';
-	$outputerror = $outputfile.'.err';
-	dol_mkdir($conf->admin->dir_output.'/backup');
+    $outputdir  = $conf->admin->dir_output.'/backup';
+    $outputfile = $outputdir.'/'.$file;
+    // for compression format, we add extension
+    $compression=isset($_POST['compression']) ? $_POST['compression'] : 'none';
+    if ($compression == 'gz') $outputfile.='.gz';
+    if ($compression == 'bz') $outputfile.='.bz2';
+    $outputerror = $outputfile.'.err';
+    dol_mkdir($conf->admin->dir_output.'/backup');
 
-	// Parameteres execution
-	$command=$cmddump;
-	if (preg_match("/\s/",$command)) $command=$command=escapeshellarg($command);	// Use quotes on command
+    // Parameteres execution
+    $command=$cmddump;
+    if (preg_match("/\s/",$command)) $command=$command=escapeshellarg($command);	// Use quotes on command
 
-	//$param=escapeshellarg($dolibarr_main_db_name)." -h ".escapeshellarg($dolibarr_main_db_host)." -u ".escapeshellarg($dolibarr_main_db_user)." -p".escapeshellarg($dolibarr_main_db_pass);
-	$param=" --no-tablespaces --inserts -h ".$dolibarr_main_db_host;
-	$param.=" -U ".$dolibarr_main_db_user;
-	if (! empty($dolibarr_main_db_port)) $param.=" -p ".$dolibarr_main_db_port;
-	if ($_POST["sql_compat"] && $_POST["sql_compat"] == 'ANSI') $param.="  --disable-dollar-quoting";
-	if ($_POST["drop_database"])     $param.=" -c -C";
-	if ($_POST["sql_structure"])
-	{
-		if ($_POST["drop"])			 $param.=" --add-drop-table";
-		if (empty($_POST["sql_data"])) $param.=" -s";
-	}
-	if ($_POST["sql_data"])
-	{
-		if (empty($_POST["sql_structure"]))	 	$param.=" -a";
-		if ($_POST["showcolumns"])	$param.=" -c";
-	}
-	$param.=' -f "'.$outputfile.'"';
-	//if ($compression == 'none')
-	if ($compression == 'gz')   $param.=' -Z 9';
-	//if ($compression == 'bz')
-	$paramcrypted=$param;
-	$paramclear=$param;
-	if (! empty($dolibarr_main_db_pass))
-	{
-		//$paramcrypted.=" -W".preg_replace('/./i','*',$dolibarr_main_db_pass);
-		//$paramclear.=" -W".$dolibarr_main_db_pass;
-	}
-	$paramcrypted.=" -w ".$dolibarr_main_db_name;
-	$paramclear.=" -w ".$dolibarr_main_db_name;
+    //$param=escapeshellarg($dolibarr_main_db_name)." -h ".escapeshellarg($dolibarr_main_db_host)." -u ".escapeshellarg($dolibarr_main_db_user)." -p".escapeshellarg($dolibarr_main_db_pass);
+    $param=" --no-tablespaces --inserts -h ".$dolibarr_main_db_host;
+    $param.=" -U ".$dolibarr_main_db_user;
+    if (! empty($dolibarr_main_db_port)) $param.=" -p ".$dolibarr_main_db_port;
+    if ($_POST["sql_compat"] && $_POST["sql_compat"] == 'ANSI') $param.="  --disable-dollar-quoting";
+    if ($_POST["drop_database"])     $param.=" -c -C";
+    if ($_POST["sql_structure"])
+    {
+        if ($_POST["drop"])			 $param.=" --add-drop-table";
+        if (empty($_POST["sql_data"])) $param.=" -s";
+    }
+    if ($_POST["sql_data"])
+    {
+        if (empty($_POST["sql_structure"]))	 	$param.=" -a";
+        if ($_POST["showcolumns"])	$param.=" -c";
+    }
+    $param.=' -f "'.$outputfile.'"';
+    //if ($compression == 'none')
+    if ($compression == 'gz')   $param.=' -Z 9';
+    //if ($compression == 'bz')
+    $paramcrypted=$param;
+    $paramclear=$param;
+    /*if (! empty($dolibarr_main_db_pass))
+     {
+     $paramcrypted.=" -W".preg_replace('/./i','*',$dolibarr_main_db_pass);
+     $paramclear.=" -W".$dolibarr_main_db_pass;
+     }*/
+    $paramcrypted.=" -w ".$dolibarr_main_db_name;
+    $paramclear.=" -w ".$dolibarr_main_db_name;
 
-	print $langs->trans("RunCommandSummaryToLaunch").':<br>'."\n";
-	print '<textarea rows="'.ROWS_3.'" cols="120">'.$command." ".$paramcrypted.'</textarea><br>'."\n";
+    print $langs->trans("RunCommandSummaryToLaunch").':<br>'."\n";
+    print '<textarea rows="'.ROWS_3.'" cols="120">'.$command." ".$paramcrypted.'</textarea><br>'."\n";
 
-	print '<br>';
+    print '<br>';
 
 
-	// Now show to ask to run command
-	print $langs->trans("YouMustRunCommandFromCommandLineAfterLoginToUser",$dolibarr_main_db_user,$dolibarr_main_db_user);
+    // Now show to ask to run command
+    print $langs->trans("YouMustRunCommandFromCommandLineAfterLoginToUser",$dolibarr_main_db_user,$dolibarr_main_db_user);
 
-	print '<br>';
-	print '<br>';
+    print '<br>';
+    print '<br>';
 
-	$what='';
+    $what='';
 }
 
 
@@ -420,34 +308,193 @@ if ($what == 'postgresql')
 // Si on a demande une generation
 if ($what)
 {
-	if ($errormsg)
-	{
-		print '<div class="error">'.$langs->trans("Error")." : ".$errormsg.'</div>';
-//		print '<a href="'.DOL_URL_ROOT.$relativepatherr.'">'.$langs->trans("DownloadErrorFile").'</a><br>';
-		print '<br>';
-		print '<br>';
-	}
-	else
-	{
-		print '<div class="ok">';
-		print $langs->trans("BackupFileSuccessfullyCreated").'.<br>';
-		print $langs->trans("YouCanDownloadBackupFile");
-		print '</div>';
-		print '<br>';
-	}
+    if ($errormsg)
+    {
+        print '<div class="error">'.$langs->trans("Error")." : ".$errormsg.'</div>';
+        //		print '<a href="'.DOL_URL_ROOT.$relativepatherr.'">'.$langs->trans("DownloadErrorFile").'</a><br>';
+        print '<br>';
+        print '<br>';
+    }
+    else
+    {
+        print '<div class="ok">';
+        print $langs->trans("BackupFileSuccessfullyCreated").'.<br>';
+        print $langs->trans("YouCanDownloadBackupFile");
+        print '</div>';
+        print '<br>';
+    }
 }
 
 $result=$formfile->show_documents('systemtools','backup',$conf->admin->dir_output.'/backup',$_SERVER['PHP_SELF'],0,1,'',1,0,0,54,0,'',$langs->trans("PreviousDumpFiles"));
 
 if ($result == 0)
 {
-	print $langs->trans("NoBackupFileAvailable").'<br>';
-	print $langs->trans("ToBuildBackupFileClickHere",DOL_URL_ROOT.'/admin/tools/dolibarr_export.php').'<br>';
+    print $langs->trans("NoBackupFileAvailable").'<br>';
+    print $langs->trans("ToBuildBackupFileClickHere",DOL_URL_ROOT.'/admin/tools/dolibarr_export.php').'<br>';
 }
 
 print '<br>';
 
 $time_end = time();
 
-llxFooter('$Date: 2011/08/03 00:45:43 $ - $Revision: 1.45 $');
+llxFooter();
+
+$db->close();
+
+
+
+// MYSQL NO BINARIES (only php)
+/**	Backup the db OR just a table without mysqldump binary (does not require any exec permission)
+ *	Author: David Walsh (http://davidwalsh.name/backup-mysql-database-php)
+ *	Updated and enhanced by Stephen Larroque (lrq3000) and by the many commentators from the blog
+ *
+ *	@param	string	$outputfile		Output file name
+ *	@param	string	$tables			Table name or '*' for all
+ *	@return	int						<0 if KO, >0 if OK
+ *
+ *	FIXME Must add directives to have restore working even with constraints not loaded into correct order, etc...
+ */
+function backup_tables($outputfile, $tables='*')
+{
+    global $db, $langs;
+    global $errormsg;
+
+    // Set to UTF-8
+    $db->query('SET NAMES utf8');
+    $db->query('SET CHARACTER SET utf8');
+
+    //get all of the tables
+    if ($tables == '*')
+    {
+        $tables = array();
+        $result = $db->query('SHOW FULL TABLES WHERE Table_type = \'BASE TABLE\'');
+        while($row = $db->fetch_row($result))
+        {
+            $tables[] = $row[0];
+        }
+    }
+    else
+    {
+        $tables = is_array($tables) ? $tables : explode(',',$tables);
+    }
+
+    //cycle through
+    $handle = fopen($outputfile, 'w+');
+    if (fwrite($handle, '') === FALSE)
+    {
+        $langs->load("errors");
+        dol_syslog("Failed to open file ".$outputfile,LOG_ERR);
+        $errormsg=$langs->trans("ErrorFailedToWriteInDir");
+        return -1;
+    }
+
+    // Print headers and global mysql config vars
+    $sqlhead = '';
+    $sqlhead .= "-- ".$db->label." dump via php
+--
+-- Host: ".$db->db->host_info."    Database: ".$db->database_name."
+-- ------------------------------------------------------
+-- Server version	".$db->db->server_info."
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+";
+    fwrite($handle, $sqlhead);
+
+    // Process each table and print their definition + their datas
+    foreach($tables as $table)
+    {
+	// Saving the table structure
+	fwrite($handle, "--\n-- Table structure for table `".$table."`\n--\n\n");
+
+        fwrite($handle,"DROP TABLE IF EXISTS `".$table."`;\n");
+	fwrite($handle,"/*!40101 SET @saved_cs_client     = @@character_set_client */;\n");
+	fwrite($handle,"/*!40101 SET character_set_client = utf8 */;\n");
+        $resqldrop=$db->query('SHOW CREATE TABLE '.$table);
+        $row2 = $db->fetch_row($resqldrop);
+        fwrite($handle,$row2[1].";\n");
+	fwrite($handle,"/*!40101 SET character_set_client = @saved_cs_client */;\n\n");
+
+
+	// Dumping the data (locking the table and disabling the keys check while doing the process)
+	fwrite($handle, "--\n-- Dumping data for table `".$table."`\n--\n\n");
+	fwrite($handle, "LOCK TABLES `".$table."` WRITE;\n");
+	fwrite($handle, "/*!40000 ALTER TABLE `".$table."` DISABLE KEYS */;\n");
+
+	$sql='SELECT * FROM '.$table;
+        $result = $db->query($sql);
+        $num_fields = $db->num_rows($result);
+        while($row = $db->fetch_row($result)) {
+	    // For each row of data we print a line of INSERT
+            fwrite($handle,'INSERT INTO `'.$table.'` VALUES (');
+            $columns = count($row);
+	    $rowsarr = array();
+            for($j=0; $j<$columns; $j++) {
+		// Processing each columns of the row to ensure that we correctly save the value (eg: add quotes for string - in fact we add quotes for everything, it's easier)
+		if ($row[$j] == null and !is_string($row[$j])) { // IMPORTANT: if the field is NULL we set it NULL
+		    $row[$j] = 'NULL';
+		} elseif(is_string($row[$j]) and $row[$j] == '') { // if it's an empty string, we set it as an empty string
+		    $row[$j] = "''";
+		} elseif(is_numeric($row[$j])) { // if it's a number, we return it as-is
+		    $row[$j] = $row[$j];
+		} else { // else for all other cases we escape the value and put quotes around
+		    $row[$j] = addslashes($row[$j]);
+		    $row[$j] = preg_replace("#\n#", "\\n", $row[$j]);
+		    $row[$j] = "'".$row[$j]."'";
+		}
+            }
+            fwrite($handle,implode(',', $row).");\n");
+        }
+	fwrite($handle, "/*!40000 ALTER TABLE `".$table."` ENABLE KEYS */;\n"); // Enabling back the keys/index checking
+	fwrite($handle, "UNLOCK TABLES;\n"); // Unlocking the tables
+        fwrite($handle,"\n\n\n");
+    }
+
+    /* Backup Procedure structure*/
+    /*
+    $result = $db->query('SHOW PROCEDURE STATUS');
+    if ($db->num_rows($result) > 0)
+    {
+        while ($row = $db->fetch_row($result)) { $procedures[] = $row[1]; }
+        foreach($procedures as $proc)
+        {
+            fwrite($handle,"DELIMITER $$\n\n");
+            fwrite($handle,"DROP PROCEDURE IF EXISTS '$name'.'$proc'$$\n");
+            $resqlcreateproc=$db->query("SHOW CREATE PROCEDURE '$proc'");
+            $row2 = $db->fetch_row($resqlcreateproc);
+            fwrite($handle,"\n".$row2[2]."$$\n\n");
+            fwrite($handle,"DELIMITER ;\n\n");
+        }
+    }
+    */
+    /* Backup Procedure structure*/
+
+    // Write the footer (restore the previous database settings)
+    $sqlfooter='';
+    $sqlfooter.="
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on ".date('Y-m-d G-i-s');
+    fwrite($handle, $sqlfooter);
+
+    fclose($handle);
+
+    return 1;
+}
 ?>

--- a/htdocs/comm/addpropal.php
+++ b/htdocs/comm/addpropal.php
@@ -206,6 +206,14 @@ if ($_GET["action"] == 'create')
 		print '</td></tr>';
 	}
 
+	// CustomFields : print fields at creation
+	if ($conf->global->MAIN_MODULE_CUSTOMFIELDS) { // if the customfields module is activated...
+	    $currentmodule = 'propal'; // EDIT THIS: var to edit for each module
+
+	    include_once(DOL_DOCUMENT_ROOT.'/customfields/lib/customfields.lib.php');
+	    customfields_print_creation_form($currentmodule);
+	}
+
 	// Model
 	print '<tr>';
 	print '<td>'.$langs->trans("DefaultModel").'</td>';

--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -184,7 +184,7 @@ if ($action == 'confirm_deleteline' && $confirm == 'yes')
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($newlang);
 		}
-		propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 		Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$object->id);
 		exit;
@@ -214,7 +214,7 @@ if ($action == 'confirm_validate' && $confirm == 'yes' && $user->rights->propale
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($newlang);
 		}
-		propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 	else
 	{
@@ -366,7 +366,7 @@ if ($_POST['action'] == 'add' && $user->rights->propale->creer)
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($newlang);
 			}
-			propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 			Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id);
 			exit;
@@ -625,7 +625,7 @@ if ($action == 'modif' && $user->rights->propale->creer)
 		$outputlangs->setDefaultLang($newlang);
 	}
 
-	propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 }
 
 if ($_POST['action'] == "setabsolutediscount" && $user->rights->propale->creer)
@@ -779,7 +779,7 @@ if ($_POST['action'] == "addline" && $user->rights->propale->creer)
 					$outputlangs = new Translate("",$conf);
 					$outputlangs->setDefaultLang($newlang);
 				}
-				propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+				if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 				unset($_POST['qty']);
 				unset($_POST['type']);
@@ -861,7 +861,7 @@ if ($_POST['action'] == 'updateligne' && $user->rights->propale->creer && $_POST
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($newlang);
 		}
-		propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 }
 
@@ -974,7 +974,7 @@ if ($action == 'up' && $user->rights->propale->creer)
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($newlang);
 	}
-	propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 	Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.'#'.GETPOST('rowid'));
 	exit;
@@ -996,7 +996,7 @@ if ($action == 'down' && $user->rights->propale->creer)
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($newlang);
 	}
-	propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 	Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.'#'.GETPOST('rowid'));
 	exit;

--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -260,6 +260,10 @@ if ($_POST['action'] == 'set_ref_client' && $user->rights->propale->creer)
  */
 if ($_POST['action'] == 'add' && $user->rights->propale->creer)
 {
+	foreach ($_POST as $key=>$value) { // Generic way to fill all the fields to the object (particularly useful for triggers and customfields)
+		$object->$key = $value;
+	}
+
 	$object->socid=$_POST['socid'];
 	$object->fetch_thirdparty();
 
@@ -1469,6 +1473,17 @@ if ($id > 0 || ! empty($ref))
 	// Statut
 	print '<tr><td height="10">'.$langs->trans('Status').'</td><td align="left" colspan="3">'.$object->getLibStatut(4).'</td></tr>';
 	print '</table><br>';
+
+	// CUSTOMFIELDS : Main form printing and editing functions
+	if ($conf->global->MAIN_MODULE_CUSTOMFIELDS) { // if the customfields module is activated...
+	$currentmodule = 'propal'; // EDIT ME: var to edit for each module
+	$idvar = 'id'; // EDIT ME: the name of the POST or GET variable that contains the id of the object (look at the URL for something like module.php?modid=3&... when you edit a field)
+	$rights = 'propale'; // EDIT ME: try first to put it null, then if it doesn't work try to find the right name (search in the same file for something like $user->rights->modname where modname is the string you must put in $rights).
+
+	include_once(DOL_DOCUMENT_ROOT.'/customfields/lib/customfields.lib.php');
+	customfields_print_main_form($currentmodule, $object, $action, $user, $idvar, $rights);
+
+	}
 
 	/*
 	 * Lines

--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -184,7 +184,7 @@ if ($action == 'confirm_deleteline' && $confirm == 'yes')
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($newlang);
 		}
-		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 		Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$object->id);
 		exit;
@@ -214,7 +214,7 @@ if ($action == 'confirm_validate' && $confirm == 'yes' && $user->rights->propale
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($newlang);
 		}
-		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 	else
 	{
@@ -370,7 +370,7 @@ if ($_POST['action'] == 'add' && $user->rights->propale->creer)
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($newlang);
 			}
-			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+			if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 			Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id);
 			exit;
@@ -629,7 +629,7 @@ if ($action == 'modif' && $user->rights->propale->creer)
 		$outputlangs->setDefaultLang($newlang);
 	}
 
-	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 }
 
 if ($_POST['action'] == "setabsolutediscount" && $user->rights->propale->creer)
@@ -783,7 +783,7 @@ if ($_POST['action'] == "addline" && $user->rights->propale->creer)
 					$outputlangs = new Translate("",$conf);
 					$outputlangs->setDefaultLang($newlang);
 				}
-				if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+				if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 				unset($_POST['qty']);
 				unset($_POST['type']);
@@ -865,7 +865,7 @@ if ($_POST['action'] == 'updateligne' && $user->rights->propale->creer && $_POST
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($newlang);
 		}
-		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 }
 
@@ -978,7 +978,7 @@ if ($action == 'up' && $user->rights->propale->creer)
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($newlang);
 	}
-	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 	Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.'#'.GETPOST('rowid'));
 	exit;
@@ -1000,7 +1000,7 @@ if ($action == 'down' && $user->rights->propale->creer)
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($newlang);
 	}
-	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) propale_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 	Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.'#'.GETPOST('rowid'));
 	exit;

--- a/htdocs/commande/fiche.php
+++ b/htdocs/commande/fiche.php
@@ -181,7 +181,7 @@ if ($action == 'confirm_deleteline' && $confirm == 'yes')
                 $outputlangs = new Translate("",$conf);
                 $outputlangs->setDefaultLang($newlang);
             }
-            if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+            if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
         }
         else
         {
@@ -649,7 +649,7 @@ if ($action == 'addline' && $user->rights->commande->creer)
                         $outputlangs = new Translate("",$conf);
                         $outputlangs->setDefaultLang($newlang);
                     }
-                    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+                    if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
                     unset($_POST['qty']);
                     unset($_POST['type']);
@@ -757,7 +757,7 @@ if ($action == 'updateligne' && $user->rights->commande->creer && $_POST['save']
                 $outputlangs = new Translate("",$conf);
                 $outputlangs->setDefaultLang($newlang);
             }
-            if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+            if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
         }
         else
         {
@@ -791,7 +791,7 @@ if ($action == 'confirm_validate' && $confirm == 'yes' && $user->rights->command
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
 }
 
@@ -831,7 +831,7 @@ if ($action == 'modif' && $user->rights->commande->creer)
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
 }
 
@@ -856,7 +856,7 @@ if ($action == 'up' && $user->rights->commande->creer)
         $outputlangs->setDefaultLang($newlang);
     }
 
-    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+    if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
     Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.'#'.$_GET['rowid']);
     exit;
@@ -878,7 +878,7 @@ if ($action == 'down' && $user->rights->commande->creer)
         $outputlangs = new Translate("",$conf);
         $outputlangs->setDefaultLang($newlang);
     }
-    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+    if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
     Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.'#'.$_GET['rowid']);
     exit;

--- a/htdocs/commande/fiche.php
+++ b/htdocs/commande/fiche.php
@@ -181,7 +181,7 @@ if ($action == 'confirm_deleteline' && $confirm == 'yes')
                 $outputlangs = new Translate("",$conf);
                 $outputlangs->setDefaultLang($newlang);
             }
-            commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+            if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
         }
         else
         {
@@ -649,7 +649,7 @@ if ($action == 'addline' && $user->rights->commande->creer)
                         $outputlangs = new Translate("",$conf);
                         $outputlangs->setDefaultLang($newlang);
                     }
-                    commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+                    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
                     unset($_POST['qty']);
                     unset($_POST['type']);
@@ -757,7 +757,7 @@ if ($action == 'updateligne' && $user->rights->commande->creer && $_POST['save']
                 $outputlangs = new Translate("",$conf);
                 $outputlangs->setDefaultLang($newlang);
             }
-            commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+            if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
         }
         else
         {
@@ -791,7 +791,7 @@ if ($action == 'confirm_validate' && $confirm == 'yes' && $user->rights->command
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
 }
 
@@ -831,7 +831,7 @@ if ($action == 'modif' && $user->rights->commande->creer)
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
 }
 
@@ -856,7 +856,7 @@ if ($action == 'up' && $user->rights->commande->creer)
         $outputlangs->setDefaultLang($newlang);
     }
 
-    commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
     Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.'#'.$_GET['rowid']);
     exit;
@@ -878,7 +878,7 @@ if ($action == 'down' && $user->rights->commande->creer)
         $outputlangs = new Translate("",$conf);
         $outputlangs->setDefaultLang($newlang);
     }
-    commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) commande_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
     Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.'#'.$_GET['rowid']);
     exit;

--- a/htdocs/compta/facture.php
+++ b/htdocs/compta/facture.php
@@ -194,7 +194,7 @@ if ($action == 'confirm_deleteline' && $confirm == 'yes')
                 $outputlangs = new Translate("",$conf);
                 $outputlangs->setDefaultLang($newlang);
             }
-            if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) $result=facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+            if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) $result=facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
             if ($result > 0)
             {
                 Header('Location: '.$_SERVER["PHP_SELF"].'?facid='.$id);
@@ -355,7 +355,7 @@ if ($action == 'confirm_valid' && $confirm == 'yes' && $user->rights->facture->v
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
     else
     {
@@ -412,7 +412,7 @@ if ($action == 'modif' && ((empty($conf->global->MAIN_USE_ADVANCED_PERMS) && $us
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
 }
 
@@ -1062,7 +1062,7 @@ if (($action == 'addline' || $action == 'addline_predef') && $user->rights->fact
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
         unset($_POST['qty']);
         unset($_POST['type']);
@@ -1160,7 +1160,7 @@ if ($action == 'updateligne' && $user->rights->facture->creer && $_POST['save'] 
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
 }
 
@@ -1188,7 +1188,7 @@ if ($action == 'up' && $user->rights->facture->creer)
         $outputlangs = new Translate("",$conf);
         $outputlangs->setDefaultLang($newlang);
     }
-    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+    if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
     Header ('Location: '.$_SERVER["PHP_SELF"].'?facid='.$object->id.'#'.$_GET['rowid']);
     exit;
@@ -1210,7 +1210,7 @@ if ($action == 'down' && $user->rights->facture->creer)
         $outputlangs = new Translate("",$conf);
         $outputlangs->setDefaultLang($newlang);
     }
-    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+    if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
     Header ('Location: '.$_SERVER["PHP_SELF"].'?facid='.$object->id.'#'.$_GET['rowid']);
     exit;

--- a/htdocs/compta/facture.php
+++ b/htdocs/compta/facture.php
@@ -532,6 +532,10 @@ if ($action == 'confirm_converttoreduc' && $confirm == 'yes' && $user->rights->f
  */
 if ($action == 'add' && $user->rights->facture->creer)
 {
+    foreach ($_POST as $key=>$value) { // Generic way to fill all the fields to the object (particularly useful for triggers and customfields)
+	$object->$key = $value;
+    }
+
     $object->socid=GETPOST('socid');
 
     $db->begin();
@@ -1752,6 +1756,14 @@ if ($action == 'create')
         print '</td></tr>';
     }
 
+    // CustomFields : print fields at creation
+    if ($conf->global->MAIN_MODULE_CUSTOMFIELDS) { // if the customfields module is activated...
+	$currentmodule = 'facture'; // EDIT THIS: var to edit for each module
+
+	include_once(DOL_DOCUMENT_ROOT.'/customfields/lib/customfields.lib.php');
+	customfields_print_creation_form($currentmodule);
+    }
+
     // Modele PDF
     print '<tr><td>'.$langs->trans('Model').'</td>';
     print '<td>';
@@ -2613,6 +2625,16 @@ else
 
             print '</table><br>';
 
+
+	    // CUSTOMFIELDS : Main form printing and editing functions
+	    if ($conf->global->MAIN_MODULE_CUSTOMFIELDS) { // if the customfields module is activated...
+		$currentmodule = 'facture'; // EDIT ME: var to edit for each module
+		$idvar = 'id'; // EDIT ME: the name of the POST or GET variable that contains the id of the object (look at the URL for something like module.php?modid=3&...)
+
+		include_once(DOL_DOCUMENT_ROOT.'/customfields/lib/customfields.lib.php');
+		customfields_print_main_form($currentmodule, $object, $action, $user, $idvar);
+
+	    }
 
             /*
              * Lines

--- a/htdocs/compta/facture.php
+++ b/htdocs/compta/facture.php
@@ -194,7 +194,7 @@ if ($action == 'confirm_deleteline' && $confirm == 'yes')
                 $outputlangs = new Translate("",$conf);
                 $outputlangs->setDefaultLang($newlang);
             }
-            $result=facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+            if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) $result=facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
             if ($result > 0)
             {
                 Header('Location: '.$_SERVER["PHP_SELF"].'?facid='.$id);
@@ -355,7 +355,7 @@ if ($action == 'confirm_valid' && $confirm == 'yes' && $user->rights->facture->v
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
     else
     {
@@ -412,7 +412,7 @@ if ($action == 'modif' && ((empty($conf->global->MAIN_USE_ADVANCED_PERMS) && $us
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
 }
 
@@ -1058,7 +1058,7 @@ if (($action == 'addline' || $action == 'addline_predef') && $user->rights->fact
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
         unset($_POST['qty']);
         unset($_POST['type']);
@@ -1156,7 +1156,7 @@ if ($action == 'updateligne' && $user->rights->facture->creer && $_POST['save'] 
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($newlang);
         }
-        facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+        if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
     }
 }
 
@@ -1184,7 +1184,7 @@ if ($action == 'up' && $user->rights->facture->creer)
         $outputlangs = new Translate("",$conf);
         $outputlangs->setDefaultLang($newlang);
     }
-    facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
     Header ('Location: '.$_SERVER["PHP_SELF"].'?facid='.$object->id.'#'.$_GET['rowid']);
     exit;
@@ -1206,7 +1206,7 @@ if ($action == 'down' && $user->rights->facture->creer)
         $outputlangs = new Translate("",$conf);
         $outputlangs->setDefaultLang($newlang);
     }
-    facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+    if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $object, '', $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
     Header ('Location: '.$_SERVER["PHP_SELF"].'?facid='.$object->id.'#'.$_GET['rowid']);
     exit;

--- a/htdocs/compta/paiement/fiche.php
+++ b/htdocs/compta/paiement/fiche.php
@@ -113,7 +113,7 @@ if ($action == 'confirm_valide' && GETPOST('confirm') == 'yes' && $user->rights-
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 			}
-			facture_pdf_create($db, $fac, '', $fac->modelpdf, $outputlangs);
+			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $fac, '', $fac->modelpdf, $outputlangs);
 		}
 
 		Header('Location: fiche.php?id='.$paiement->id);

--- a/htdocs/compta/paiement/fiche.php
+++ b/htdocs/compta/paiement/fiche.php
@@ -113,7 +113,7 @@ if ($action == 'confirm_valide' && GETPOST('confirm') == 'yes' && $user->rights-
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 			}
-			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $fac, '', $fac->modelpdf, $outputlangs);
+			if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $fac, '', $fac->modelpdf, $outputlangs);
 		}
 
 		Header('Location: fiche.php?id='.$paiement->id);

--- a/htdocs/compta/payment_sc/fiche.php
+++ b/htdocs/compta/payment_sc/fiche.php
@@ -95,7 +95,7 @@ if ($_REQUEST['action'] == 'confirm_valide' && $_REQUEST['confirm'] == 'yes' && 
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 			}
-			facture_pdf_create($db, $fac, '', $fac->modelpdf, $outputlangs);
+			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $fac, '', $fac->modelpdf, $outputlangs);
 		}
 
 		Header('Location: fiche.php?id='.$paiement->id);

--- a/htdocs/compta/payment_sc/fiche.php
+++ b/htdocs/compta/payment_sc/fiche.php
@@ -95,7 +95,7 @@ if ($_REQUEST['action'] == 'confirm_valide' && $_REQUEST['confirm'] == 'yes' && 
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 			}
-			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $fac, '', $fac->modelpdf, $outputlangs);
+			if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) facture_pdf_create($db, $fac, '', $fac->modelpdf, $outputlangs);
 		}
 
 		Header('Location: fiche.php?id='.$paiement->id);

--- a/htdocs/contrat/fiche.php
+++ b/htdocs/contrat/fiche.php
@@ -327,7 +327,7 @@ if ($action == 'addline' && $user->rights->contrat->creer)
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($newlang);
 			}
-			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) contrat_pdf_create($db, $object->id, $object->modelpdf, $outputlangs);
+			if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) contrat_pdf_create($db, $object->id, $object->modelpdf, $outputlangs);
 		*/
 		}
 		else

--- a/htdocs/contrat/fiche.php
+++ b/htdocs/contrat/fiche.php
@@ -327,7 +327,7 @@ if ($action == 'addline' && $user->rights->contrat->creer)
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($newlang);
 			}
-			contrat_pdf_create($db, $object->id, $object->modelpdf, $outputlangs);
+			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) contrat_pdf_create($db, $object->id, $object->modelpdf, $outputlangs);
 		*/
 		}
 		else

--- a/htdocs/customfields/class/customfields.class.php
+++ b/htdocs/customfields/class/customfields.class.php
@@ -1,0 +1,1310 @@
+<?php
+/* Copyright (C) 2011   Stephen Larroque <lrq3000@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *      \file       htdocs/customfields/class/customfields.class.php
+ *      \ingroup    customfields
+ *      \brief      Core class file for the CustomFields module, all critical functions reside here
+ *		\version    $Id: customfields.class.php, v1.1.0
+ *		\author		Stephen Larroque
+ */
+
+// Put here all includes required by your class file
+$langs->load('customfields@customfields'); // customfields standard language support
+$langs->load('customfields-user@customfields'); // customfields language support for user's values (like enum, fields names, etc..)
+
+/**
+ *      \class      customfields
+ *      \brief      Core class for the CustomFields module, all critical functions reside here
+ */
+class CustomFields // extends CommonObject
+{
+	var $db;							//!< To store db handler
+	var $error;							//!< To return error code (or message)
+	var $errors=array();				//!< To return several error codes (or messages)
+	//var $element='customfields';			//!< Id that identify managed objects
+	//var $table_element='customfields';	//!< Name of table without prefix where object is stored
+
+
+	var $varprefix = 'cf_'; // prefix that will be prepended to the variables names for accessing the fields values
+
+	var $id;
+
+
+    /**
+     *      Constructor
+     *      @param      DB      Database handler
+     *      @param      currentmodule        	Current module (facture/propal/etc.)
+     */
+    function CustomFields($DB, $currentmodule)
+    {
+	$this->db = $DB;
+	$this->module = $currentmodule;
+	$this->moduletable = MAIN_DB_PREFIX.$this->module."_customfields";
+	return 1;
+    }
+
+
+	// ============ FIELDS RECORDS MANAGEMENT ===========/
+
+	//--------------- Lib Functions --------------------------
+
+	/**
+	 *	Similar to mysql_real_escape() but can be reversed and there's no need to be connected to the db
+	 */
+	function escape($str)
+        {
+		$search=array("\\","\0","\n","\r","\x1a","'",'"');
+		$replace=array("\\\\","\\0","\\n","\\r","\Z","\'",'\"');
+		return str_replace($search,$replace,$str);
+        }
+
+	/**
+	 *	Reverse msql_real_escape() or the function above
+	 *	UNUSED
+	 */
+	function reverse_escape($str)
+	{
+		$search=array("\\\\","\\0","\\n","\\r","\Z","\'",'\"');
+		$replace=array("\\","\0","\n","\r","\x1a","'",'"');
+		return str_replace($search,$replace,$str);
+	}
+
+	//--------------- Main Functions ---------------------
+
+	/**
+	 *      Fetch a record (or all records) from the database (meaning an instance of the custom fields, the values if you prefer)
+	 *      @param	   id				id of the record to find (NOT rowid but fk_moduleid) - can be left empty if you want to fetch all the records
+	 *      @param      notrigger	    0=launch triggers after, 1=disable triggers
+	 *      @return     int/null/obj/obj[]        	<0 if KO, null if no record is found, a record if only one is found, an array of records if OK
+	 */
+	function fetch($id=null, $notrigger=0)
+	{
+		// Get all the columns (custom fields), primary field included (that's why there's the true)
+		$fields = $this->fetchAllCustomFields(true);
+
+		// Forging the SQL statement - we set all the column_name to fetch (because Dolibarr wants to avoid SELECT *, so we must name the columns we fetch)
+		foreach ($fields as $field) {
+			$keys[] = $field->column_name;
+		}
+		$sqlfields = implode(',',$keys);
+
+		$sql = "SELECT ".$sqlfields." FROM ".$this->moduletable;
+
+		if ($id > 0) { // if we supplied an id, we fetch only this one record
+			$sql .= " WHERE fk_".$this->module."=".$id." LIMIT 1";
+		}
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_FETCHRECORD';
+		}
+
+		// Executing the SQL statement
+		$resql = $this->executeSQL($sql, 'fetchRecord_CustomFields',$trigger);
+
+		// Filling the record object
+		if ($resql < 0) { // if there's an error
+			return $resql; // we return the error code
+		} else { // else we fill the record
+			$num = $this->db->num_rows($resql); // number of results returned (number of records)
+			// Several records returned = array() of objects
+			if ($num > 1) {
+				// Find the primary field (so that we can set the record's id)
+				$prifield = $this->fetchPrimaryField($this->moduletable);
+				$rowid = $prifield->column_name;
+
+				$record = array();
+				for ($i=0;$i < $num;$i++) {
+					$obj = $this->db->fetch_object($resql);
+					$obj->id = $obj->$prifield; // set the record's id
+					$record[$obj->id] = $obj; // add the record to our records' array
+				}
+				$this->records = $record; // and we as well store the records as a property of the CustomFields class
+			// Only one record returned = one object
+			} elseif ($num == 1) {
+				$record = $this->db->fetch_object($resql);
+
+				// If we get only 1 result and $id is not set, this means that we are not looking for a particular record, we are fetching all records but we find only one. In this case, we must find the id by ourselves.
+				if (!isset($id)) {
+					$prifield = $this->fetchPrimaryField($this->moduletable); // find the primary field of the table
+					$id = $record->$prifield; // set the id
+				}
+
+				$record->id = $id; // set the record's id
+				$this->id = $id;
+			// No record returned = null
+			} else {
+				$record = null;
+			}
+			$this->db->free($resql);
+
+			// Return the field(s) or null
+			return $record;
+		}
+
+	}
+
+	/**	Fetch all the records from the database for the current module
+	 *	there's no argument, and it's just an alias for fetch()
+	 *	@return	int/null/obj[]		<0 if KO, null if no record found, an array of records if OK (even if only one record is found)
+	 */
+	function fetchAll($notrigger=0) {
+		$records = $this->fetch(null, $notrigger);
+		if ( !(is_array($records) or is_null($records) or is_integer($records)) ) { $records = array($records); } // we convert to an array if we've got only one field, and if it's not an error or null, functions relying on this one expect to get an array if OK
+		return $records;
+	}
+
+	/**
+	 *      Fetch any record in the database from any table (not just customfields)
+	 *      @param	columns		one or several columns (separated by commas) to fetch
+	 *      @param	table		table where to fetch from
+	 *      @param	where		where clause (format: column='value'). Can put several where clause separated by AND or OR
+	 *      @param	orderby	order by clause
+	 *      @return     int or object or array of objects         	<0 if KO, object if one record found, array of objects if several records found
+	 */
+	function fetchAny($columns, $table, $where='', $orderby='', $limitby='', $notrigger=0)
+	{
+
+		$sql = "SELECT ".$columns." FROM ".$table;
+		if (!empty($where)) {
+			$sql.= " WHERE ".$where;
+		}
+		if (!empty($orderby)) {
+			$sql.= " ORDER BY ".$orderby;
+		}
+		if (!empty($limitby)) {
+			$sql.= " LIMIT ".$limitby;
+		}
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_FETCHANY';
+		}
+
+		// Executing the SQL statement
+		$resql = $this->executeSQL($sql, 'fetchAnyRecord_CustomFields',$trigger);
+
+		// Filling the record object
+		if ($resql < 0) { // if there's no error
+			return $resql; // we return the error code
+		} else { // else we fill the record
+			$num = $this->db->num_rows($resql); // number of results returned (number of records)
+			// Several records returned = array() of objects
+			if ($num > 1) {
+				$record = array();
+				for ($i=0;$i < $num;$i++) {
+					$record[] = $this->db->fetch_object($resql);
+				}
+			// Only one record returned = one object
+			} elseif ($num == 1) {
+				$record = $this->db->fetch_object($resql);
+			// No record returned = null
+			} else {
+				$record = null;
+			}
+			$this->db->free($resql);
+
+			// Return the record(s) or null
+			return $record;
+		}
+
+	}
+
+
+	/**
+	 *      Insert/update a record in the database (meaning an instance of the custom fields, the values if you prefer)
+	 *      @param	   object				Object containing all the form inputs to be processed to the database (so it mus contain the custom fields)
+	 *      @param      notrigger	    0=launch triggers after, 1=disable triggers
+	 *      @return     int         	<0 if KO, >0 if OK
+	 */
+	function create($object, $notrigger=0)
+	{
+		// Get all the columns (custom fields)
+		$fields = $this->fetchAllCustomFields();
+
+		if (empty($fields)) return null;
+
+		// Forging the SQL statement
+		$sqlfields = '';
+		foreach ($fields as $field) {
+			$key = $this->varprefix.$field->column_name;
+			if (!isset($object->$key)) {
+				$key = $field->column_name;
+			}
+
+			if ($object->$key) { // Only insert/update this field if it was submitted
+				if ($sqlfields != '') { $sqlfields.=','; }
+				$sqlfields.=$field->column_name."='".$this->escape($object->$key)."'";
+			}
+		}
+		if ($sqlfields != '') { $sqlfields.=','; } // in the case that all fields are empty, this one can be the only one submitted, so we have to put the comma only if it's not alone (or else sql syntax error)
+		$sqlfields.="fk_".$this->module."=".$object->id; // we add the object id (filtered by fetchAllCustomFields)
+
+		$result = $this->fetch($object->id);
+
+		if (!empty($result) and count($result) > 0) { // if the record already exists for this facture id, we update it
+			$sql = "UPDATE ".$this->moduletable." SET ".$sqlfields." WHERE fk_".$this->module."=".$object->id;
+		} else { // else we insert a new record
+			$sql = "INSERT INTO ".$this->moduletable." SET ".$sqlfields;
+		}
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_CREATEUPDATERECORD';
+		}
+
+		// Executing the SQL statement
+		$rtncode = $this->executeSQL($sql, 'createOrUpdateRecord_CustomFields',$trigger);
+
+		$this->id = $this->db->last_insert_id($this->moduletable);
+
+		return $rtncode;
+	}
+
+
+	/**
+	 *      Insert/update a record in the database (meaning an instance of the custom fields, the values if you prefer)
+	 *      @param	   object				Object containing all the form inputs to be processed to the database (so it mus contain the custom fields)
+	 *      @param      notrigger	    0=launch triggers after, 1=disable triggers
+	 *      @return     int         	<0 if KO, >0 if OK
+	 */
+	function update($object, $notrigger=0)
+	{
+		return $this->create($object,$notrigger);
+	}
+
+	/**
+	 *      Delete a record in the database (meaning an instance of the custom fields, the values if you prefer)
+	 *      @param	   id				id of the record to find (NOT rowid but fk_moduleid)
+	 *      @param      notrigger	    0=launch triggers after, 1=disable triggers
+	 *      @return     int         	<0 if KO, >0 if OK
+	 */
+	function delete($id, $notrigger=0)
+	{
+		// Forging the SQL statement
+		$sql = "DELETE FROM ".$this->moduletable." WHERE fk_".$this->module."=".$id;
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_FETCHRECORD';
+		}
+
+		// Executing the SQL statement
+		$rtncode = $this->executeSQL($sql, 'fetchRecord_CustomFields',$trigger);
+
+		$this->id = $id;
+
+		return $rtncode;
+	}
+
+
+	/**
+	 *      Insert a record in the database from a clone, by duplicating an existing record (meaning an instance of the custom fields, the values if you prefer)
+	 *      @param	   id				ID of the object to clone
+	 *      @param	cloneid			ID of the new cloned object
+	 *      @param      notrigger	    0=launch triggers after, 1=disable triggers
+	 *      @return     int         	<0 if KO, >0 if OK
+	 */
+	function createFromClone($id, $cloneid, $notrigger=0)
+	{
+		// Get all the columns (custom fields)
+		$fields = $this->fetchAllCustomFields();
+
+		$object = $this->fetch($id);
+
+		$object->id = $cloneid; // Affecting the new id
+
+		$rtncode = $this->create($object); // creating the new record
+
+		return $rtncode;
+	}
+
+
+	// ============ FIELDS COLUMNS CONFIGURATION ===========/
+
+	// ------------ Lib functions ---------------/
+
+	/**
+	*	Extract the size or value (if type is enum) from the column_type of the database field
+	*  @param $column_type
+	*  @return $size_or_value
+	*/
+       function getFieldSizeOrValue($column_type) {
+	    preg_match('/[(]([^)]+)[)]/', $column_type, $matches);
+	    return $matches[1];
+       }
+
+	/*	Execute an SQL statement, add it to the logfile and add an event trigger (or not)
+	 *
+	 *
+	 *	@return -1 if error, object of the request if OK
+	 */
+	function executeSQL($sql, $eventname, $trigger=null) { // if $trigger is null, no trigger will be produced, else it will produce a trigger with the provided name
+		// Executing the SQL statement
+		dol_syslog(get_class($this)."::".$eventname." sql=".$sql, LOG_DEBUG); // Adding an event to the log
+		$resql=$this->db->query($sql); // Issuing the sql statement to the db
+
+		if (! $resql) { $error++; $this->errors[]="Error ".$this->db->lasterror(); } // Checking for errors
+
+		// Managing trigger (if there's no error)
+		if (! $error) {
+			$id = $this->db->last_insert_id($this->moduletable);
+
+			if (!empty($trigger)) {
+				global $user, $langs, $conf; // required vars for the trigger
+				//// Call triggers
+				include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
+				$interface=new Interfaces($this->db);
+				$result=$interface->run_triggers($trigger,$this,$user,$langs,$conf);
+				if ($result < 0) { $error++; $this->errors=$interface->errors; }
+				//// End call triggers
+			}
+		}
+
+		// Commit or rollback
+		if ($error)  {
+			foreach($this->errors as $errmsg) {
+				dol_syslog(get_class($this)."::".$eventname." ".$errmsg, LOG_ERR);
+				$this->error.=($this->error?', '.$errmsg:$errmsg);
+			}
+			$this->db->rollback();
+			return -1*$error; // error code : we return -1 multiplied by the number of errors (so if we have 5 errors we will get -5 as a return code)
+		} else {
+			$this->db->commit();
+			return $resql;
+		}
+	}
+
+	/*	Forge the sql command for createCustomFields and updateCustomFields (creation and update of a field's definition)
+	*
+	*
+	*	@return $sql containing the forged sql statement
+	*/
+	function forgeSQLCustomField($fieldname, $type, $size, $nulloption, $defaultvalue = null, $customtype = null, $customdef, $id = null) {
+
+		// Forging the SQL statement
+		$sql = '';
+		if (!empty($id)) { // if a field id was supplied, we forge an update sql statement, else we forge an add field sql statement
+			$field = $this->fetchCustomField($id); // fetch the field by id (ordinal_position) so we can get the field name
+			if ($fieldname != $field->column_name) { // if the name of the field changed, then we use the CHANGE keyword to rename the field and apply other statements
+				$sql = "ALTER TABLE ".$this->moduletable." CHANGE ".$field->column_name." ".$fieldname." ";
+			} else {
+				$sql = "ALTER TABLE ".$this->moduletable." MODIFY ".$field->column_name." "; // else we just modify the field (no renaming with MODIFY keyword)
+			}
+		} else {
+			$sql = "ALTER TABLE ".$this->moduletable." ADD ".$fieldname." ";
+		}
+		/*
+		if (trim($size) == '') {
+			$size = 0; // the default value for infinity is 0 (eg: text(0) equals unlimited text field)
+		}*/
+		if ($type == 'other' and !empty($customtype)) {
+			$sql .= ' '.$customtype;
+		} else {
+			$sql .= ' '.$type;
+		}
+		if (!empty($size)) {
+			$sql .= '('.$size.')'; // NOTE: $size can contain enum values too ! And some types (eg: text, boolean) do not need any size!
+		} else {
+			if ($type == 'varchar') $sql.= '(256)'; // One special case for the varchar : we define a specific default value of 256 chars (this is the only exception, non generic instruction in the  whole class! But it enhance a lot the ease of users who may forget to set a value)
+		}
+		if ($nulloption) {
+			$sql .= ' null';
+		} else {
+			$sql .= ' not null';
+		}
+		if (!empty($defaultvalue)) {
+			$defaultvalue = "'$defaultvalue'"; // we always quote the default value, for int the SGBD will automatically convert the string to an int value
+			$sql .= ' default '.$defaultvalue;
+		}
+		if (!empty($customdef)) {
+			$sql .= ' '.$customdef;
+		}
+		// Closing the SQL statement
+		$sql .= ';';
+
+		return $sql;
+	}
+
+
+	// ------------ Fields actions for management functions ---------------/
+
+	/**
+	 *      Initialize the customfields for this module (create the required table)
+	 *
+	 *
+	 *	@return -1 if KO, 1 if OK
+	 */
+	function initCustomFields($notrigger = 0) {
+
+		$reftable = MAIN_DB_PREFIX.$this->module; // the main module's table, we just add the dolibarr's prefix for db tables
+		$prifield = $this->fetchPrimaryField($reftable); // we fetch the name of primary column of this module's table
+
+		// Forging the SQL statement
+		$sql = "CREATE TABLE ".$this->moduletable."(
+		rowid                int(11) NOT NULL AUTO_INCREMENT,
+		fk_".$this->module."       int(11) NOT NULL, -- id of the associated invoice/document
+		PRIMARY KEY (rowid),
+		KEY fk_".$this->module." (fk_".$this->module."),
+		CONSTRAINT fk_".$this->module." FOREIGN KEY (fk_".$this->module.") REFERENCES ".$reftable." (".$prifield.") ON DELETE CASCADE ON UPDATE CASCADE
+		) ENGINE=InnoDB AUTO_INCREMENT=1 ;";
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_INITTABLE';
+		}
+
+		// Executing the SQL statement
+		$rtncode = $this->executeSQL($sql, 'initCustomField',$trigger);
+
+		// Good or bad returncode ?
+		if ($rtncode < 0) {
+			return $rtncode; // bad
+		} else {
+			return 1; // good
+		}
+	}
+
+	/**
+	 *      Check if the table exists
+	 *
+	 *	@return	< 0 if KO, false if false, true if OK
+	 *
+	 */
+	function probeCustomFields($notrigger = 0) {
+
+		// Forging the SQL statement
+		$sql = "SELECT 1
+		FROM INFORMATION_SCHEMA.TABLES
+		WHERE TABLE_TYPE='BASE TABLE'
+		AND TABLE_NAME='".$this->moduletable."'";
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_PROBETABLE';
+		}
+
+		// Executing the SQL statement
+		$resql = $this->executeSQL($sql, 'probeCustomField',$trigger);
+
+		// Forging the result
+		if ($resql < 0) { // if an error happened when executing the sql command, we return -1
+			return $resql;
+		} else { // else we check the result
+			if ($this->db->num_rows($resql) > 0) { // if there is a result, then we return true (the table exists)
+				return true;
+			} else { // else it doesn't
+				return false;
+			}
+		}
+	}
+
+	/**
+	*    Fetch the field sql definition for a particular field or for all fields from the database (not the records! See fetch and fetchAll to fetch records) and return it as an array or as a single object, and populate the CustomFields class $fields property
+	*    @param    id          			id of the field (ordinal_position of the sql column) OR string column_name of the field
+	*    @param    nohide				defines if the system fields (primary field and foreign key) must be hidden in the fetched results
+	*    @return     int/null/obj/obj[]         <0 if KO, null if no field found, one field object if only one field could be found, an array of fields objects if OK
+	*/
+       function fetchCustomField($id=null, $nohide=false, $notrigger=0) {
+
+		// Forging the SQL statement
+		$whereaddendum = '';
+		if (isset($id)) {
+			if (is_numeric($id) and $id > 0) { // if we supplied an id, we fetch only this one record
+			$whereaddendum .= " AND c.ordinal_position = ".$id;
+			} elseif (is_string($id) and !empty($id)) {
+				$whereaddendum .= " AND c.column_name = '".$id."'";
+			}
+		}
+
+		if (!$nohide) {
+			$whereaddendum .= " AND c.column_name != 'rowid' AND c.column_name != 'fk_".$this->module."'";
+		}
+
+		$sql = "SELECT c.ordinal_position,c.column_name,c.column_default,c.is_nullable,c.data_type,c.column_type,c.character_maximum_length,
+		k.referenced_table_name, k.referenced_column_name, k.constraint_name,
+                s.index_name
+		FROM information_schema.COLUMNS as c
+		LEFT JOIN information_schema.key_column_usage as k
+		ON (k.column_name=c.column_name AND k.table_name=c.table_name)
+                LEFT JOIN information_schema.statistics as s
+                ON (s.column_name=c.column_name AND s.table_name=c.table_name)
+		WHERE c.table_name = '".$this->moduletable."' ".$whereaddendum."
+		ORDER BY c.ordinal_position;"; // We filter the reserved columns so that the user  cannot alter them, even by mistake and we get only the specified field by id
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_FETCHFIELD';
+		}
+
+		// Executing the SQL statement
+		$resql = $this->executeSQL($sql,"fetchCustomField", $trigger);
+
+		// Filling the field object
+		if ($resql < 0) { // if there's no error
+			return $resql; // we return the error code
+
+		} else { // else we fill the field
+			$num = $this->db->num_rows($resql); // number of lines returned as a result to our sql statement
+
+			// Several fields columns returned = array() of field objects
+			if ($num > 1) {
+				$field = array();
+				for ($i=0;$i < $num;$i++) {
+					$obj = $this->db->fetch_object($resql); // we retrieve the data line
+					$obj->size = $this->getFieldSizeOrValue($obj->column_type); // add the real size of the field (character_maximum_length is not reliable for that goal)
+					$obj->id = $obj->ordinal_position; // set the id (ordinal position in the database's table)
+					$field[$obj->id] = $obj; // we store the field object in an array
+
+					$column_name = $obj->column_name; // we get the column name of the field
+					$this->fields->$column_name = $obj; // and we as well store the field as a property of the CustomFields class
+				}
+			// Only one field returned = one field object
+			} elseif ($num == 1) {
+				$field = $this->db->fetch_object($resql);
+
+				$field->size = $this->getFieldSizeOrValue($field->column_type); // add the real size of the field (character_maximum_length is not reliable for that goal)
+				$field->id = $field->ordinal_position; // set the id (ordinal position in the database's table)
+
+				$column_name = $field->column_name; // we get the column name of the field
+				$this->fields->$column_name = $field; // and we as well store the field as a property of the CustomFields class
+			// No field returned = null
+			} else {
+				$field = null;
+			}
+
+			$this->db->free($resql);
+
+			// Return the field
+			return $field;
+		}
+       }
+
+       /**
+	*    Fetch ALL the fields sql definitions from the database (not the records! See fetch and fetchAll to fetch records)
+	*    @param     nohide	defines if the system fields (primary field and foreign key) must be hidden in the fetched results
+	*    @return     int/null/obj[]         <0 if KO, null if no field found, an array of fields objects if OK (even if only one field is found)
+	*/
+       function fetchAllCustomFields($nohide=false, $notrigger=0) {
+		$fields = $this->fetchCustomField(null, $nohide, $notrigger);
+		if ( !(is_array($fields) or is_null($fields) or is_integer($fields)) ) { $fields = array($fields); } // we convert to an array if we've got only one field, functions relying on this one expect to get an array if OK
+		return $fields;
+       }
+
+	/**	Fetch constraints and foreign keys
+	 *	@return <0 if KO, constraints[] array of constrained fields if OK
+	 *	== UNUSED ==
+	 *
+	 */
+       function fetchConstraints($notrigger = 0) {
+
+		// Forging the SQL statement
+		$sql = "SELECT
+				CONCAT(table_name, '.', column_name) as 'foreign key',
+				CONCAT(referenced_table_name, '.', referenced_column_name) as 'references',
+				table_name, column_name, referenced_table_name, referenced_column_name
+				FROM information_schema.key_column_usage
+				WHERE referenced_table_name is not null
+					AND
+					table_name = '".$this->moduletable."';";
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_FETCHCONSTRAINTS';
+		}
+
+		// Executing the SQL statement
+		$resql = $this->executeSQL($sql,"fetchConstraints", $trigger);
+
+		// Filling in all the fetched fields into an array of fields objects
+		if ($resql < 0) { // if there's an error in the SQL
+			return $resql; // return the error code
+		} else {
+			$constraints = null;
+			if ($this->db->num_rows($resql) > 0) {
+				$num = $this->db->num_rows($resql);
+				for ($i=0;$i < $num;$i++) {
+					$obj = $this->db->fetch_object($resql); // we retrieve the data line
+					$name = $obj->column_name;
+					$constaints->$name = $obj; // we store the field object in an array
+				}
+			}
+			$this->db->free($resql);
+
+			return $constaints; // we return an array of constraints objects
+		}
+       }
+
+       /**
+	*    Load the sql informations about a field from the database
+	*    @param	    table		table where to search in
+	*    @param     name      column_name to search
+	*    @return     obj         <-1 if KO, field if OK
+	*/
+       function fetchReferencedField($table='', $name='', $notrigger = 0) {
+
+		if (!empty($table)) {
+			$sqltable = $table;
+		} else {
+			$sqltable = $this->moduletable;
+		}
+		if (!empty($name)) {
+			$sqlname = $name;
+		} else {
+			$sqlname = $this->fetchPrimaryField($sqltable); // if no referenced column name defined, we get the name of the primary field of the referenced table
+		}
+		// Forging the SQL statement
+		$sql = "SELECT c.ordinal_position,c.column_name,c.column_default,c.is_nullable,c.data_type,c.column_type,c.character_maximum_length,
+		k.referenced_table_name, k.referenced_column_name, k.constraint_name,
+                s.index_name
+		FROM information_schema.COLUMNS as c
+		LEFT JOIN information_schema.key_column_usage as k
+		ON (k.column_name=c.column_name AND k.table_name=c.table_name)
+                LEFT JOIN information_schema.statistics as s
+                ON (s.column_name=c.column_name AND s.table_name=c.table_name)
+		WHERE c.table_name = '".$sqltable."' AND c.column_name = '".$sqlname."'
+		ORDER BY c.ordinal_position;";
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_FETCHREFFIELD';
+		}
+
+		// Executing the SQL statement
+		$resql = $this->executeSQL($sql,"fetchReferencedField", $trigger);
+
+		// Filling the field object
+		if ($resql < 0) { // if there's no error
+			return $resql; // we return the error code
+
+		} else { // else we fill the field
+			$obj = null;
+			if ($this->db->num_rows($resql) > 0) {
+			    $obj = $this->db->fetch_object($resql);
+
+			    $obj->size = $this->getFieldSizeOrValue($obj->column_type); // add the real size of the field (character_maximum_length is not reliable for that goal)
+			}
+			$this->db->free($resql);
+
+			// Return the field
+			return $obj;
+		}
+       }
+
+	/**
+	 *	Check in the database if a field column name exists in a table
+	 *	@param	$table	table name
+	 *	@param	$name	column name
+	 *	@return	false if KO, true if OK
+	 */
+	function checkIfIdenticalFieldExistsInRefTable($table, $name) {
+		$fieldref = $this->fetchReferencedField($table, $name);
+		if (isset($fieldref)) {
+			if ( !($fieldref <= 0)) { // Special feature : if the customfield has a column name similar to one in the linked table, then we show the values of this field instead
+				return true;
+			 } else {
+				return false;
+			 }
+		} else {
+			return false;
+		}
+	}
+
+       /**
+	*    Load the records from a specified table and for the specified column name (plus another field with a column name identical to the $field->column_name)
+	*    @param	   field		the constrained field (which contains a non-null referenced_column_name property)
+	*    @return     obj[]         <-1 if KO, array of records if OK
+	*/
+       function fetchReferencedValuesList($field, $notrigger = 0) {
+
+		// -- Forging the sql statement
+
+		// First field : the referenced one
+		$sqlfields = $field->referenced_column_name;
+		$orderby = $field->referenced_column_name; // by default we order by this field (generally rowid)
+		// Second field (if it exists) : one that has the same name as the customfield
+		$realrefcolumn=explode('_', $field->column_name); // we take only the first part of the column name, before _ char (so you can name fkid_mylabel and it will look for the foreign fkid column)
+		if ( $this->checkIfIdenticalFieldExistsInRefTable($field->referenced_table_name, $realrefcolumn[0]) ) { // Special feature : if the customfield has a column name similar to one in the linked table, then we show the values of this field instead
+			$sqlfields.=','.$realrefcolumn[0];
+			$orderby = $realrefcolumn[0]; // if a second field is found, we order by this one (eg: a list of name is better ordered alphabetically)
+		}
+
+		$sql = 'SELECT '.$sqlfields.' FROM '.$field->referenced_table_name.' ORDER BY '.$orderby.';';
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_FETCHREFVALUES';
+		}
+
+		// -- Executing the sql statement (fetching the referenced list)
+		$resql = $this->executeSQL($sql,'fetchReferencedValuesList',$trigger);
+
+		// -- Filling in all the fetched fields into an array of records objects
+		if ($resql < 0) { // if there's an error in the SQL
+			return $resql; // return the error code
+		} else {
+			$refarray = array();
+			if ($this->db->num_rows($resql) > 0) {
+				$num = $this->db->num_rows($resql);
+				for ($i=0;$i < $num;$i++) {
+					$obj = $this->db->fetch_object($resql); // we retrieve the data line
+					$refarray[] = $obj; // we store the field object in an array
+				}
+			}
+			$this->db->free($resql);
+
+			return $refarray; // we return an array of records objects (for at least one field, maybe two because of the "special feature" - see above)
+		}
+	}
+
+        /**
+	*    Load a list of all the tables from dolibarr database
+	*    @return     obj[]         <-1 if KO, array of tables if OK
+	*/
+       function fetchAllTables($notrigger = 0) {
+
+		// Forging the SQL statement
+		$sql = "SHOW TABLES;";
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_FETCHALLTABLES';
+		}
+
+		// Executing the SQL statement
+		$resql = $this->executeSQL($sql,"fetchAllTables", $trigger);
+
+		// Filling in all the fetched fields into an array of fields objects
+		if ($resql < 0) { // if there's an error in the SQL
+			return $resql; // return the error code
+		} else {
+			$tables = array();
+			if ($this->db->num_rows($resql) > 0) {
+				$num = $this->db->num_rows($resql);
+				for ($i=0;$i < $num;$i++) {
+					$obj = $this->db->fetch_array($resql);
+					$tables[$obj[0]] = $obj[0]; // we store the first row (the column that contains all the table names)
+				}
+			}
+			$this->db->free($resql);
+
+			return $tables; // we return an array of tables
+		}
+       }
+
+        /**
+	*    Find the column that is the primary key of a table
+	*    @param      id          id object
+	*    @return     int or string         <-1 if KO, name of primary column if OK
+	*/
+       function fetchPrimaryField($table, $notrigger = 0) {
+
+		// Forging the SQL statement
+		$sql = "SELECT column_name
+		FROM information_schema.COLUMNS
+		WHERE TABLE_NAME = '".$table."' AND COLUMN_KEY = 'PRI';";
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_FETCHPRIMARYFIELD';
+		}
+
+		// Executing the SQL statement
+		$resql = $this->executeSQL($sql,"fetchPrimaryField", $trigger);
+
+		// Filling in all the fetched fields into an array of fields objects
+		if ($resql < 0) { // if there's an error in the SQL
+			return $resql; // return the error code
+		} else {
+			$tables = array();
+			if ($this->db->num_rows($resql) > 0) {
+				$obj = $this->db->fetch_array($resql);
+			}
+			$this->db->free($resql);
+
+			return $obj[0]; // we return the string value of the column name of the primary field
+		}
+       }
+
+	/*	Delete a custom field (and the associated foreign key and index if necessary)
+	*	@param 	id	id of the customfield (ordinal position in sql database)
+	*
+	*	@return	< 0 if KO, > 0 if OK
+	*/
+	function deleteCustomField($id, $notrigger = 0) {
+
+		// Fetch the customfield object (so that we get all required informations to proceed to deletion : column_name, index and foreign key constraints if any)
+		$field = $this->fetchCustomField($id);
+		// Get the column name from the id
+		$fieldname = $field->column_name;
+
+		// Delete the associated constraint if exists
+		$this->deleteConstraint($id);
+
+		// Forging the SQL statement
+		$sql = "ALTER TABLE ".$this->moduletable." DROP COLUMN ".$fieldname;
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_DELETEFIELD';
+		}
+
+		// Executing the SQL statement
+		$rtncode = $this->executeSQL($sql, 'deleteCustomField',$trigger);
+
+		return $rtncode;
+	}
+
+	/**	Delete a constraint for a customfield
+	 *	@param 	id	id of the customfield (ordinal position in sql database)
+	 *
+	 *	@return	-1 if KO, 1 if OK
+	 */
+	function deleteConstraint($id) {
+		$rtncode1 = 1;
+		$rtncode2 = 1;
+
+		// Fetch customfield's informations
+		$field = $this->fetchCustomField($id);
+
+		// Delete the associated constraint if exists
+		if (!empty($field->constraint_name)) {
+			$sql = "ALTER TABLE ".$this->moduletable." DROP FOREIGN KEY ".$field->constraint_name;
+			$rtncode1 = $this->executeSQL($sql, 'deleteCustomFieldConstsraint',null); // we need to execute this sql statement prior to any other one, because if we want to delete the column, we need first to delete the foreign key (this cannot be done with a single sql statement, you will get an error)
+		}
+		// Delete the associated index if exists
+		if (!empty($field->index_name)) {
+			$sql = "ALTER TABLE ".$this->moduletable." DROP INDEX ".$field->index_name;
+			$rtncode2 = $this->executeSQL($sql, 'deleteCustomFieldIndex',null); // same as above for the constraint
+		}
+
+		// Return code : -1 error or 1 OK
+		if ($rtncode1 < 0 or $rtncode2 < 0) {
+			return -1;
+		} else {
+			return 1;
+		}
+	}
+
+	/**	Create a field (column in the customfields table) (will update the field if it does not exists)
+	 *	@param	fieldname	name of the custom field (column name)
+	 *	@param	type		sql type of the custom field (column type)
+	 *	@param	size		bits size of the custom field type (data type)
+	 *	@param	nulloption	accepts null values?
+	 *	@param	defaultvalue	default value for this field? (null by default)
+	 *	@param	constraint	name of the table linked by foreign key (the referenced_table_name)
+	 *	@param	customtype	custom sql definition for the type (replaces type and size or just type parameter depending if the size is supplied in the def, ie: int(11) )
+	 *	@param	customdef	custom sql definition that will be appended to the definition generated automatically (so you can add sql parameters the author didn't foreseen)
+	 *	@param	customsql	custom sql statement that will be executed after the creation/update of the custom field (so that you can make complex statements)
+	 *	@param	fieldid		id of the field to update (ordinal position). Leave this null to create the custom field, supply it if you want to update (or just use updateCustomField which is a simpler alias)
+	 *	@param	notrigger	do not activate triggers?
+	 *
+	 *	@return -1 if KO, 1 if OK
+	 */
+	function addCustomField($fieldname, $type, $size, $nulloption, $defaultvalue = null, $constraint = null, $customtype = null, $customdef = null, $customsql = null, $fieldid = null, $notrigger = 0) {
+
+		// Cleaning input vars
+		$defaultvalue = $this->db->escape(trim($defaultvalue));
+		//$size = $this->db->escape(trim($size)); // NOTE: $size can contain enum values too !
+		//$customtype = $this->db->escape(trim($customtype));
+		//$customdef = $this->db->escape(trim($customdef));
+		//$customsql = $this->db->escape(trim($customsql));
+
+		if (!empty($fieldid)) {
+			$mode = "update";
+		} else {
+			$mode = "add";
+		}
+
+		// Delete the associated constraint if exists
+		if (!empty($fieldid)) {
+			$this->deleteConstraint($fieldid);
+		}
+
+		// Automatically get the type of the field from constraint
+		if (!empty($constraint)) {
+			$prfieldname = $this->fetchPrimaryField($constraint);
+			$prfield = $this->fetchReferencedField($constraint,$prfieldname);
+
+			$type = $prfield->data_type;
+			$nulloption = $prfield->is_nullable;
+			$size = $prfield->size;
+		}
+
+		// Forging the SQL statement
+		$sql = $this->forgeSQLCustomField($fieldname, $type, $size, $nulloption, $defaultvalue, $customtype, $customdef, $fieldid);
+
+		// Trigger or not?
+		if ($notrigger) {
+			$trigger = null;
+		} else {
+			$trigger = strtoupper($this->module).'_CUSTOMFIELD_'.strtoupper($mode).'FIELD';
+		}
+
+		// Executing the SQL statement
+		$rtncode1 = $this->executeSQL($sql, $mode.'CustomField',$trigger);
+
+		// Executing the custom sql request if defined
+		$rtncodec = 1;
+		if (!empty($constraint)) {
+			$sqlconstraint = 'ALTER TABLE '.$this->moduletable.' ADD CONSTRAINT fk_'.$fieldname.' FOREIGN KEY ('.$fieldname.') REFERENCES '.$constraint.'('.$prfield->column_name.');';
+			$rtncodec = $this->executeSQL($sqlconstraint, $mode.'CustomField',$trigger);
+		}
+
+		$rtncode2 = 1;
+		if (!empty($customsql)) {
+			$rtncode2 = $this->executeSQL($customsql, $mode.'CustomField',$trigger);
+		}
+
+		// Return code : -1 error or 1 OK
+		if ($rtncode1 < 0 or $rtncode2 < 0 or $rtncodec < 0) {
+			return -1;
+		} else {
+			return 1;
+		}
+	}
+
+	/*	Update a customfield's definition (will create the field if it does not exists)
+	*	@param	fieldid	id of the field to edit (the ordinal position)
+	*	@param	for the rest, see addCustomField
+	*
+	*	@return -1 if KO, 1 if OK
+	*/
+	function updateCustomField($fieldid, $fieldname, $type, $size, $nulloption, $defaultvalue, $constraint = null, $customtype = null, $customdef = null, $customsql = null, $notrigger = 0) {
+		return $this->addCustomField($fieldname, $type, $size, $nulloption, $defaultvalue, $constraint, $customtype, $customdef, $customsql, $fieldid, $notrigger);
+	}
+
+
+	// ============ FIELDS PRINTING FUNCTIONS ===========/
+
+	/**
+	 *     Return HTML string to put an input field into a page
+	 *     @param      field             Field object
+	 *     @param      currentvalue           Current value of the parameter (will be filled in the value attribute of the HTML field)
+	 *     @param      moreparam       To add more parametes on html input tag
+	 *     @return       out			An html string ready to be printed
+	 */
+	function showInputField($field,$currentvalue=null,$moreparam='') {
+		global $conf, $langs;
+
+		$key=$field->column_name;
+		$label=$langs->trans($key);
+		$type=$field->data_type;
+		if ($field->column_type == 'tinyint(1)') { $type = 'boolean'; }
+		$size=$this->character_maximum_length;
+		if (empty($currentvalue)) { $currentvalue = $field->column_default;}
+
+		if ($type == 'date') {
+		    $showsize=10;
+		} elseif ($type == 'datetime') {
+		    $showsize=19;
+		} elseif ($type == 'int') {
+		    $showsize=10;
+		} else {
+		    $showsize=round($size);
+		    if ($showsize > 48) $showsize=48; // max show size limited to 48
+		}
+
+		$out = ''; // var containing the html output
+		// Constrained field
+		if (!empty($field->referenced_column_name)) {
+
+			/*
+			$tables = $this->fetchAllTables();
+			$tables = array_merge(array('' => $langs->trans('None')), $tables); // Adding a none choice (to avoid choosing a constraint or just to delete one)
+			$html=new Form($this->db);
+			$out.=$html->selectarray($this->varprefix.$key,$tables,$field->referenced_table_name);
+			*/
+
+			// -- Fetch the records (list of values)
+			$refarray = $this->fetchReferencedValuesList($field);
+
+			// -- Print the list
+
+			// Special feature : if the customfield has a column name similar to one in the linked table, then we show the values of this field instead
+			$key1 = $field->referenced_column_name;
+			if (count((array)$refarray[0]) > 1) {
+				$realrefcolumn=explode('_', $field->column_name); // we take only the first part of the column name, before _ char (so you can name fkid_mylabel and it will look for the foreign fkid column)
+				$key2 = $realrefcolumn[0];
+			} else {
+				$key2 = $field->referenced_column_name;
+			}
+
+			$out.='<select name="'.$this->varprefix.$key.'">';
+			$out.='<option value=""></option>'; // Empty option
+			foreach ($refarray as $ref) {
+				if ($ref->$key1 == $currentvalue) {
+					$selected = 'selected="selected"';
+				} else {
+					$selected = '';
+				}
+				$out.='<option value="'.$ref->$key1.'" '.$selected.'>'.$ref->$key2.'</option>';
+			}
+			$out.='</select>';
+
+		// Normal non-constrained fields
+		} else {
+			if ($type == 'varchar') {
+				$out.='<input type="text" name="'.$this->varprefix.$key.'" size="'.$showsize.'" maxlength="'.$size.'" value="'.$currentvalue.'"'.($moreparam?$moreparam:'').'>';
+			} elseif ($type == 'text') {
+				require_once(DOL_DOCUMENT_ROOT."/lib/doleditor.class.php");
+				$doleditor=new DolEditor($this->varprefix.$key,$currentvalue,'',200,'dolibarr_notes','In',false,false,$conf->fckeditor->enabled && $conf->global->FCKEDITOR_ENABLE_SOCIETE,5,100);
+				$out.=$doleditor->Create(1);
+			} elseif ($type == 'date') {
+				//$out.=' (YYYY-MM-DD)';
+				$html=new Form($db);
+				$out.=$html->select_date($currentvalue,$this->varprefix.$key,0,0,1,$this->varprefix.$key);
+			} elseif ($type == 'datetime') {
+				//$out.=' (YYYY-MM-DD HH:MM:SS)';
+				if (empty($currentvalue)) { $currentvalue = 'YYYY-MM-DD HH:MM:SS'; }
+				$out.='<input type="text" name="'.$this->varprefix.$key.'" size="'.$showsize.'" maxlength="'.$size.'" value="'.$currentvalue.'"'.($moreparam?$moreparam:'').'>';
+			} elseif ($type == 'enum') {
+				$out.='<select name="'.$this->varprefix.$key.'">';
+				// cleaning out the enum values and exploding them into an array
+				$values = trim($field->size);
+				$values = str_replace("'", "", $values); // stripping single quotes
+				$values = str_replace('"', "", $values); // stripping double quotes
+				$values = explode(',', $values); // values of an enum are stored at the same place as the size of the other types. We explode them into an array (easier to walk and process)
+				foreach ($values as $value) {
+					if ($value == $currentvalue) {
+						$selected = 'selected="selected"';
+					} else {
+						$selected = '';
+					}
+					$out.='<option value="'.$value.'" '.$selected.'>'.$langs->trans($value).'</option>';
+				}
+				$out.='</select>';
+			} elseif ($type == 'boolean') {
+				$out.='<select name="'.$this->varprefix.$key.'">';
+				$out.='<option value="1" '.($currentvalue=='1'?'selected="selected"':'').'>'.$langs->trans("True").'</option>';
+				$out.='<option value="false" '.($currentvalue=='false'?'selected="selected"':'').'>'.$langs->trans("False").'</option>';
+				$out.='</select>';
+
+			// Any other field
+			} else { // for all other types (custom types and other undefined), we use a basic text input
+				$out.='<input type="text" name="'.$this->varprefix.$key.'" size="'.$showsize.'" maxlength="'.$size.'" value="'.$currentvalue.'"'.($moreparam?$moreparam:'').'>';
+			}
+		}
+
+	    return $out;
+	}
+
+	/**
+	 *	Draw an input form (same as showInputField but produce a full form with an edit button and an action)
+	 *	@param	$field	field object
+	 *	@param	$currentvalue	current value of the field (will be set in the value attribute of the HTML input field)
+	 *	@param	$page	URL of the page that will process the action (by default, the same page)
+	 *	@param	$moreparam	More parameters
+	 *	@return	$out			An html form ready to be printed
+	 */
+	function showInputForm($field, $currentvalue=null, $page=null, $moreparam='') {
+		global $langs;
+
+		$out = '';
+
+		if (empty($page)) { $page = $_SERVER["PHP_SELF"]; }
+		$name = $this->varprefix.$field->column_name;
+		$out.='<form method="post" action="'.$page.'" name="form_'.$name.'">';
+		$out.='<input type="hidden" name="action" value="set_'.$name.'">';
+		$out.='<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+		$out.='<table class="nobordernopadding" cellpadding="0" cellspacing="0">';
+		$out.='<tr><td>';
+		$out.=$this->showInputField($field, $currentvalue, $moreparam);
+		$out.='</td>';
+		$out.='<td align="left"><input type="submit" class="button" value="'.$langs->trans("Modify").'"></td>';
+		$out.='</tr></table></form>';
+
+		return $out;
+	}
+
+	/**
+	 *     Return HTML string to print a record's data
+	 *     @param	field	field object
+	 *     @param      	value           Value to show
+	 *     @param	outputlangs		the language to use to find the right translation
+	 *     @param      	moreparam       To add more parametes on html input tags
+	 *     @return	html				An html string ready to be printed (without input fields, just html text)
+	 */
+	function printField($field, $value, $outputlangs='', $moreparam='') {
+		if ($outputlangs == '') {
+			global $langs;
+			$outputlangs = $langs;
+		}
+
+		$out = '';
+		if (isset($value)) {
+			// Constrained field
+			if (!empty($field->referenced_column_name) and !empty($value)) {
+				// Special feature : if the customfield has a column name similar to one in the linked table, then we show the values of this field instead
+				$realrefcolumn=explode('_', $field->column_name); // we take only the first part of the column name, before _ char (so you can name fkid_mylabel and it will look for the foreign fkid column)
+				if ( $this->checkIfIdenticalFieldExistsInRefTable($field->referenced_table_name, $realrefcolumn[0]) ) {
+					// Constructing the sql statement
+					$column = $realrefcolumn[0];
+					$table = $field->referenced_table_name;
+					$where = $field->referenced_column_name.'='.$value;
+
+					// Fetching the record
+					$record = $this->fetchAny($column, $table, $where);
+
+					// Outputting the value
+					$out.= $record->$column;
+				// Else we just print out the value of the field
+				} else {
+					$out.=$value;
+				}
+			// Normal non-constrained field
+			} else {
+				// type enum (select box or yes/no box)
+				if ($field->data_type == 'enum') {
+					$out.=$outputlangs->trans($value);
+				// type true/false
+				} elseif ($field->column_type == 'tinyint(1)') {
+					if ($value == '1') {
+						$out.=$outputlangs->trans('True');
+					} else {
+						$out.=$outputlangs->trans('False');
+					}
+				// every other type
+				} else {
+					$out.=$value;
+				}
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 *     Return a non-HTML, simple text string ready to be printed into a PDF with the FPDF class or in ODT documents
+	 *     @param	field	field object
+	 *     @param      	value           Value to show
+	 *	@param	outputlangs	for multilingual support
+	 *     @param     	moreparam       To add more parameters on html input tags
+	 *     @return	string				A text string ready to be printed (without input fields and without html entities, just simple text)
+	 */
+	function printFieldPDF($field, $value, $outputlangs='', $moreparam='') {
+		$value=$this->printField($field, $value, $outputlangs, $moreparam);
+
+		// Cleaning the html characters if the field contained some
+		$value = preg_replace('/<br\s*\/?>/i', "", $value); // replace <br> into line breaks \n - fckeditor already outputs line returns, so we just remove the <br>
+		$value = html_entity_decode($value, ENT_QUOTES, 'UTF-8'); // replace all html characters into text ones (accents, quotes, etc.) and directly into UTF8
+
+		return $value;
+	}
+
+	/**
+	 *	Simplify the printing of the value of a field by accepting a string field name instead of an object
+	 *	@param	fieldname	string field name of the field to print
+	 *	@param	value		value to show (current value of the field)
+	 *	@param	outputlangs	for multilingual support
+	 *	@param	moreparam	to add more parameters on html input tags
+	 *	@return	html		An html string ready to be printed
+	 */
+	function simpleprintField($fieldname, $value, $outputlangs='', $moreparam='') {
+		if (!is_string($fieldname)) {
+			return -1;
+		} else {
+			if (!isset($this->fields->$fieldname)) {
+				$field = $this->fetchCustomField($fieldname, true);
+			} else {
+				$field = $this->fields->$fieldname;
+			}
+			return $this->printField($field, $value, $outputlangs, $moreparam);
+		}
+	}
+
+	/**
+	 *	Same as simpleprintField but for PDF (without html entities)
+	 *	@param	fieldname	string field name of the field to print
+	 *	@param	value		value to show (current value of the field)
+	 *	@param	outputlangs	for multilingual support
+	 *	@param	moreparam	to add more parameters on html input tags
+	 *     @return	string				A text string ready to be printed (without input fields and without html entities, just simple text)
+	 */
+	function simpleprintFieldPDF($fieldname, $value, $outputlangs='', $moreparam='') {
+		if (!is_string($fieldname)) {
+			return -1;
+		} else {
+			if (!isset($this->fields->$fieldname)) {
+				$field = $this->fetchCustomField($fieldname, true);
+			} else {
+				$field = $this->fields->$fieldname;
+			}
+			return $this->printFieldPDF($field, $value, $outputlangs, $moreparam);
+		}
+	}
+
+	/**
+	 *	Take a field name and returns the right label for the field, either with the prefix or without. If none is found, we return the normal field name.
+	 *	@param	fieldname	 a field name
+	 *	@param	outputlangs	the language to use to show the right translation of the label
+	 *	@return	string		a label for the field
+	 *
+	 */
+	function findLabel($fieldname, $outputlangs = '') {
+		if ($outputlangs == '') {
+			global $langs;
+			$outputlangs = $langs;
+		}
+
+		if ($outputlangs->trans($this->varprefix.$fieldname) != $this->varprefix.$fieldname) { // if we find a label for a code in the format : cf_something
+		    return $outputlangs->trans($this->varprefix.$fieldname);
+		} elseif ($outputlangs->trans($fieldname) != $fieldname) { // if we find a label for a code in the format : something
+		    return $outputlangs->trans($fieldname);
+		} else { // if no label could be found, we return the field name
+		    return $fieldname;
+		}
+	}
+
+	function findLabelPDF($fieldname, $outputlangs = '') {
+		$fieldname = $this->findLabel($fieldname, $outputlangs); // or use transnoentities()?
+
+		// Cleaning the html characters if the field contained some
+		$fieldname = preg_replace('/<br\s*\/?>/i', "", $fieldname); // replace <br> into line breaks \n - fckeditor already outputs line returns, so we just remove the <br>
+		$fieldname = html_entity_decode($fieldname, ENT_QUOTES, 'UTF-8'); // replace all html characters into text ones (accents, quotes, etc.) and directly into UTF8
+
+		return $fieldname;
+	}
+
+}
+?>

--- a/htdocs/customfields/langs/en_US/customfields-user.lang
+++ b/htdocs/customfields/langs/en_US/customfields-user.lang
@@ -1,0 +1,5 @@
+# Dolibarr language file - en_US - customfields user defined labels
+# Define here the labels of your own custom fields and their possible values (after having created them in the admin configuration interface)
+
+# Format:
+# cf_fieldname=label

--- a/htdocs/customfields/langs/en_US/customfields.lang
+++ b/htdocs/customfields/langs/en_US/customfields.lang
@@ -1,0 +1,51 @@
+﻿# Dolibarr language file - en_US - customfields standard labels
+CHARSET= UTF-8
+
+#### ADMIN CONFIG INTERFACE ####
+
+# Main title
+CustomFieldsSetup= CustomFields Setup
+
+# Modules tabs
+facture= Invoices
+propal= Estimate
+product= Products/Services
+
+# Table headers
+Fieldname= Field Name
+Datatype= Data Type
+Variable= Variable
+
+# Buttons
+NewField= New Field
+
+# Attributes labels
+FieldEdition= Field edition
+Label= Label
+FieldName= Field Name
+AlphaNumOnlyCharsAndNoSpace= only alphanumerical characters with no space allowed
+Type= Type
+EnumValues= Values for the DropdownBox
+CanBeNull?= Accept null values ?
+Constraint= Constraint
+CustomSQLDefinition= Custom SQL Definition
+CustomSQL= Custom SQL Statement
+
+# Fields values
+PleaseEditLangFile= Please edit the language file
+Textbox= Textbox
+Areabox= Areabox
+YesNoBox= YesNoBox
+TrueFalseBox= TrueFalseBox
+DropdownBox= DropdownBox
+
+True= True
+False= False
+
+# Attributes descriptions and notes
+RequiredIfFieldCannotBeNull=required if field cannot be null
+SizeDesc=eg: 256 for a varchar, or "firstval","secondval","thirdval" WITH the quotes and commas for an enum/selectbox
+SizeNote=Note: can be left empty if using customSQL in Type, Areabox or TrueFalseBox.
+CustomSQLDefinitionDesc=custom definition of the field to be appended after the above
+CustomSQLDesc=to be triggered after the creation/edition of the field
+##### COMMENT #####

--- a/htdocs/customfields/langs/fr_FR/customfields-user.lang
+++ b/htdocs/customfields/langs/fr_FR/customfields-user.lang
@@ -1,0 +1,5 @@
+# Dolibarr language file - fr_FR - customfields user defined labels
+# Vous pouvez ici définir les libellés de vos propres champs personnalisés et leurs valeurs (après les avoir créés dans l'interface admin)
+
+# Format:
+# cf_fieldname=label

--- a/htdocs/customfields/langs/fr_FR/customfields.lang
+++ b/htdocs/customfields/langs/fr_FR/customfields.lang
@@ -1,0 +1,51 @@
+﻿# Dolibarr language file - fr_FR - customfields standard labels
+CHARSET= UTF-8
+
+#### ADMIN CONFIG INTERFACE ####
+
+# Main title
+CustomFieldsSetup= Interface de configuration des champs personnalisés
+
+# Modules tabs
+facture= Facture
+propal= Proposition commerciale
+product= Produits/Services
+
+# Table headers
+Fieldname= Nom du champ
+Datatype= Type du champ
+Variable= Variable
+
+# Buttons
+NewField= Nouveau champ
+
+# Attributes labels
+FieldEdition= Modification d'un champ
+Label= Libellé
+FieldName= Nom du champ
+AlphaNumOnlyCharsAndNoSpace= seulement caractères alphanumériques sans espaces
+Type= Type
+EnumValues= Valeurs pour le type Liste déroulante
+CanBeNull?= Accepter les valeurs vides ?
+Constraint= Contrainte
+CustomSQLDefinition= Definition SQL personnalisée
+CustomSQL= Requête SQL personnalisée
+
+# Fields values
+PleaseEditLangFile= Veuillez éditer le ficher de langue
+Textbox= Zone de texte simple
+Areabox= Zone de texte étendue HTML
+YesNoBox= Choix Oui/Non
+TrueFalseBox= Choix Vrai/Faux
+DropdownBox= Liste déroulante
+
+True= Vrai
+False= Faux
+
+# Attributes descriptions and notes
+RequiredIfFieldCannotBeNull=requis si le champ n'accepte pas les valeurs vides
+SizeDesc=ex: 256 pour une zone de texte, <br />ou "premier","deuxio","tertio" AVEC les guillemets et virgules pour une liste déroulante
+SizeNote=Note: requis seulement pour Zone de text simple et Liste déroulante, pour les autres types on peut laisser ceci vide.
+CustomSQLDefinitionDesc=la définition personnalisée du champ sera ajoutée à la suite de toutes les définitions au-dessus - Type, Taille, etc.
+CustomSQLDesc=sera executée après la création/modification du champ selon les paramètres au-dessus
+##### COMMENT #####

--- a/htdocs/customfields/lib/customfields.lib.php
+++ b/htdocs/customfields/lib/customfields.lib.php
@@ -1,0 +1,180 @@
+<?php
+/* Copyright (C) 2011 Stephen Larroque  <lrq3000@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * or see http://www.gnu.org/
+ */
+
+/**
+ *	\file       htdocs/lib/customfields.lib.php
+ *	\brief      Printing library for the customfields module, very generic and useful (but no core database managing functions, they are in customfields.class.php)
+ *	\ingroup    customfields
+ *	\version    $Id: customfields.lib.php, v1.1.0
+ */
+
+/**
+ *  Return array head with list of tabs to view object informations
+ *  @param
+ *  modulesarray         list of modules (format: array(modulename1, modulename2, etc..))
+ *  currentmodule       modulename of the currently active module
+ *  @return     void
+ */
+function customfields_admin_prepare_head($modulesarray, $currentmodule = null)
+{
+    global $langs, $conf, $user;
+
+    $h = 0;
+    $head = array();
+    $currentmoduleindex = 0;
+
+    // preparing the tabs
+    foreach ($modulesarray as $module) {
+        if ($currentmodule == $module) { $currentmoduleindex = $h;} // detecting the index of the current tab
+        $head[$h][0] = DOL_URL_ROOT.'/admin/customfields.php?module='.$module;
+        $head[$h][1] = $langs->trans($module);
+        $head[$h][2] = 'general';
+        $h++;
+    }
+
+    /*
+     // detecting the index of the current tab
+     // almost identical to the code above , but this one is less logical since we here detect the index in the $modulesarray when we need the index in $h array. Concretely, we get the same result in the end, but this is not the right method here.
+    if (in_array($currentmodule, $modulesarray)) {
+        $currentmoduleindex = array_search($currentmodule, $modulesarray);
+    } else {
+        $currentmoduleindex = 0;
+    }
+    */
+
+    // Show more tabs from modules
+    // Entries must be declared in modules descriptor with line
+    // $this->tabs = array('entity:+tabname:Title:@mymodule:/mymodule/mypage.php?id=__ID__');   to add new tab
+    // $this->tabs = array('entity:-tabname:Title:@mymodule:/mymodule/mypage.php?id=__ID__');   to remove a tab
+    //complete_head_from_modules($conf,$langs,$object,$head,$h,'customfields_admin');
+    dol_fiche_head($head, $active="$currentmoduleindex", $title='', $notab=0, $picto=''); // draw the tabs
+
+    return $head;
+}
+
+/**
+ *      Print the customfields at the creation form of any table based module
+ *      @param      $currentmodule      the current module we are in (facture, propal, etc.)
+ *      @return     void        returns nothing because this is a procedure : it just does what we want
+ */
+function customfields_print_creation_form($currentmodule) {
+    global $db, $langs;
+
+    // Init and main vars
+    include_once(DOL_DOCUMENT_ROOT.'/customfields/class/customfields.class.php');
+    $customfields = new CustomFields($db, $currentmodule);
+
+    if ($customfields->probeCustomFields()) { // ... and if the table for this module exists, we show the custom fields
+        $fields = $customfields->fetchAllCustomFields();
+        foreach ($fields as $field) {
+            $name = $field->column_name;
+            print '<tr><td>'.$customfields->findLabel($name).'</td><td colspan="2">';
+            print $customfields->ShowInputField($field, GETPOST($customfields->varprefix.$name));
+            print '</td></tr>';
+        }
+    }
+}
+
+/**
+ *      Print the customfields at the main form of any table based module (with editable fields)
+ *      @param      currentmodule      the current module we are in (facture, propal, etc.)
+ *      @param      idvar                       the name of the POST or GET variable containing the id of the object
+ *      @param      object                     the object containing the required informations (if we are in facture's module, it will be the facture object, if we are in propal it will be the propal object etc..)
+ *      @return     void        returns nothing because this is a procedure : it just does what we want
+ */
+function customfields_print_main_form($currentmodule, $object, $action, $user, $idvar = 'id', $rights = null) {
+    global $db, $langs, $conf;
+
+    // Init and main vars
+    include_once(DOL_DOCUMENT_ROOT.'/customfields/class/customfields.class.php');
+    include_once(DOL_DOCUMENT_ROOT.'/lib/functions.lib.php'); // for images img_edit()
+    $customfields = new CustomFields($db, $currentmodule);
+
+    if ($customfields->probeCustomFields()) { // ... and if the table for this module exists, we show the custom fields
+        print '<table class="border" width="100%">';
+
+        // == Fetching customfields
+        $fields = $customfields->fetchAllCustomFields(); // fetching the customfields list
+        $datas = $customfields->fetch($object->id); // fetching the record - the values of the customfields for this id (if it exists)
+        $datas->id = $object->id; // in case the record does not yet exist for this id, we at least set the id property of the datas object (useful for the update later on)
+
+        foreach ($fields as $field) { // for each customfields, we will print/save the edits
+
+            // == Default values from database record
+            $name = $field->column_name; // the name of the customfield (which is the property of the record)
+            $value = ''; // by default the value of this property is empty
+            if (isset($datas->$name)) { $value = $datas->$name; } // if the property exists (the record is not empty), then we fill in this value
+
+            // == Save the edits
+            if ($action=='set_'.$customfields->varprefix.$name and isset($_POST[$customfields->varprefix.$name])) { // if we edited the value
+
+                // Forging the new record
+                $newrecord->$name = $_POST[$customfields->varprefix.$name]; // we create a new record object with the field and the id
+                $newrecord->id = $object->id;
+
+                // Insert/update the record into the database by trigger
+                //$customfields->update($newrecord); // update or create the record in the database (will check automatically) - this does the same as the trigger below, but the trigger is more consistent with the rest (we need to use triggers for creation)
+                include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
+                $interface=new Interfaces($db);
+                $newrecord->currentmodule = $currentmodule; // very important to pass the module as a property of the object
+                $result=$interface->run_triggers('CUSTOMFIELDS_MODIFY',$newrecord,$user,$langs,$conf);
+
+                // Updating the loaded record object
+                // deprecated, see below
+                // $datas->$name = $_POST[$customfields->varprefix.$name]; // we update the loaded record to the new value so that it gets printed asap
+                //$value = $datas->$name;
+                // Reloading the field from the database (we need to fetch from the database because there can be some not null fields with default values, and if we are creating the record, these will be filled it, and we have no way to know it when updating the database, so we need to fetch the record again)
+                $datas = $customfields->fetch($object->id); // fetching the record - the values of the customfields for this id (if it exists)
+                $value = $datas->$name;
+            }
+
+            // == Print the record
+
+            print '<tr><td width="20%">';
+            print $customfields->findLabel($name);
+            // checking the user's rights for edition
+            if (!empty($rights)) { // if a list of rights have been specified, we check the rights for creation/edition for each one
+                $rightok = true;
+                if (!is_array($rights)) { $rights = array($rights); }
+                foreach ($rights as $moduleright) {
+                    if (isset($user->rights->$moduleright->creer) and !$user->rights->$moduleright->creer) {
+                        $rightok = false;
+                        break;
+                    }
+                }
+            } else { // else by default we just check for the current module (in the hope the current module has the same name in the rights array... eg: product module is produit in the rights property...)
+                $rightok = $user->rights->$currentmodule->creer;
+            }
+            // print the edit button only if authorized
+            if (!($action == 'editcustomfields' && GETPOST('field') == $name) && !(isset($objet->brouillon) and $object->brouillon == false) && $rightok) print '<span align="right"><a href="'.$_SERVER["PHP_SELF"].'?'.$idvar.'='.$object->id.'&amp;action=editcustomfields&amp;field='.$field->column_name.'">'.img_edit("default",1).'</a></td>';
+            print '</td>';
+            print '<td>';
+            // print the editing form...
+            if ($action == 'editcustomfields' && GETPOST('field') == $name) {
+                print $customfields->showInputForm($field, $value, $_SERVER["PHP_SELF"].'?'.$idvar.'='.$object->id);
+            } else { // ... or print the field's value
+                print $customfields->printField($field, $value);
+            }
+            print '</td></tr>';
+        }
+
+        print '</table><br>';
+    }
+}
+
+?>

--- a/htdocs/customfields/sql/llx_facture_customfields.key.sql-NORUN
+++ b/htdocs/customfields/sql/llx_facture_customfields.key.sql-NORUN
@@ -1,0 +1,24 @@
+-- ========================================================================
+-- Copyright (C) 2011 Stephen LARROQUE <lrq3000@gmail.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+--
+-- $Id: llx_facture_customfields.sql,v 0.1 2011/01/01
+--
+-- Facture Custom Fields
+-- ========================================================================
+
+
+ALTER TABLE llx_facture_customfields  ADD CONSTRAINT fk_facture FOREIGN KEY (fk_facture) REFERENCES llx_facture (rowid) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/htdocs/customfields/sql/llx_facture_customfields.sql-NORUN
+++ b/htdocs/customfields/sql/llx_facture_customfields.sql-NORUN
@@ -1,0 +1,31 @@
+-- ========================================================================
+-- Copyright (C) 2011 Stephen LARROQUE <lrq3000@gmail.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+--
+-- $Id: llx_facture_customfields.sql,v 0.1 2011/01/01
+--
+-- Facture Custom Fields
+-- ========================================================================
+
+create table llx_facture_customfields
+(
+  rowid                int(11) NOT NULL AUTO_INCREMENT,
+  fk_facture       int(11) NOT NULL, -- id of the associated invoice
+  somefield        varchar(256) DEFAULT NULL, -- a dummy custom field
+
+  PRIMARY KEY (rowid),
+  KEY fk_facture (fk_facture)
+) ENGINE=InnoDB AUTO_INCREMENT=1 ;

--- a/htdocs/expedition/fiche.php
+++ b/htdocs/expedition/fiche.php
@@ -164,7 +164,7 @@ if ($action == 'confirm_valid' && $confirm == 'yes' && $user->rights->expedition
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($newlang);
 	}
-	$result=expedition_pdf_create($db,$object,$object->modelpdf,$outputlangs);
+	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) $result=expedition_pdf_create($db,$object,$object->modelpdf,$outputlangs);
 	if ($result <= 0)
 	{
 		dol_print_error($db,$result);

--- a/htdocs/expedition/fiche.php
+++ b/htdocs/expedition/fiche.php
@@ -164,7 +164,7 @@ if ($action == 'confirm_valid' && $confirm == 'yes' && $user->rights->expedition
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($newlang);
 	}
-	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) $result=expedition_pdf_create($db,$object,$object->modelpdf,$outputlangs);
+	if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) $result=expedition_pdf_create($db,$object,$object->modelpdf,$outputlangs);
 	if ($result <= 0)
 	{
 		dol_print_error($db,$result);

--- a/htdocs/fourn/commande/fiche.php
+++ b/htdocs/fourn/commande/fiche.php
@@ -235,7 +235,7 @@ if ($action == 'addline' && $user->rights->fournisseur->commande->creer)
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 			}
-			supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 			unset($_POST['qty']);
 			unset($_POST['type']);
@@ -295,7 +295,7 @@ if ($action == 'updateligne' && $user->rights->fournisseur->commande->creer &&	$
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 		}
-		supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 	else
 	{
@@ -317,7 +317,7 @@ if ($action == 'confirm_deleteproductline' && $confirm == 'yes')
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 		}
-		supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 }
 
@@ -335,7 +335,7 @@ if ($action == 'confirm_valid' && $confirm == 'yes' && $user->rights->fournisseu
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 		}
-		supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 	else
 	{
@@ -469,7 +469,7 @@ if ($action	== 'up'	&& $user->rights->fournisseur->commande->creer)
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 	}
-	supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.(empty($conf->global->MAIN_JUMP_TAG)?'':'#'.$_GET['rowid']));
 	exit;
 }
@@ -485,7 +485,7 @@ if ($action	== 'down' && $user->rights->fournisseur->commande->creer)
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 	}
-	supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.(empty($conf->global->MAIN_JUMP_TAG)?'':'#'.$_GET['rowid']));
 	exit;
 }

--- a/htdocs/fourn/commande/fiche.php
+++ b/htdocs/fourn/commande/fiche.php
@@ -235,7 +235,7 @@ if ($action == 'addline' && $user->rights->fournisseur->commande->creer)
 				$outputlangs = new Translate("",$conf);
 				$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 			}
-			if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+			if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 
 			unset($_POST['qty']);
 			unset($_POST['type']);
@@ -295,7 +295,7 @@ if ($action == 'updateligne' && $user->rights->fournisseur->commande->creer &&	$
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 		}
-		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 	else
 	{
@@ -317,7 +317,7 @@ if ($action == 'confirm_deleteproductline' && $confirm == 'yes')
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 		}
-		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 }
 
@@ -335,7 +335,7 @@ if ($action == 'confirm_valid' && $confirm == 'yes' && $user->rights->fournisseu
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 		}
-		if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+		if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	}
 	else
 	{
@@ -469,7 +469,7 @@ if ($action	== 'up'	&& $user->rights->fournisseur->commande->creer)
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 	}
-	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.(empty($conf->global->MAIN_JUMP_TAG)?'':'#'.$_GET['rowid']));
 	exit;
 }
@@ -485,7 +485,7 @@ if ($action	== 'down' && $user->rights->fournisseur->commande->creer)
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($_REQUEST['lang_id']);
 	}
-	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
+	if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, GETPOST('hidedetails'), GETPOST('hidedesc'), GETPOST('hideref'));
 	Header ('Location: '.$_SERVER["PHP_SELF"].'?id='.$id.(empty($conf->global->MAIN_JUMP_TAG)?'':'#'.$_GET['rowid']));
 	exit;
 }

--- a/htdocs/fourn/facture/fiche.php
+++ b/htdocs/fourn/facture/fiche.php
@@ -517,7 +517,7 @@ if ($_GET['action'] == 'addline')
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($_REQUEST['lang_id']);
         }
-        //supplier_invoice_pdf_create($db, $fac->id, $fac->modelpdf, $outputlangs);
+        //if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_invoice_pdf_create($db, $fac->id, $fac->modelpdf, $outputlangs);
 
         unset($_POST['qty']);
         unset($_POST['type']);
@@ -588,7 +588,7 @@ if ($_GET['action'] == 'edit' && $user->rights->fournisseur->facture->creer)
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($_REQUEST['lang_id']);
         }
-        //supplier_invoice_pdf_create($db, $fac->id, $fac->modelpdf, $outputlangs);
+        //if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_invoice_pdf_create($db, $fac->id, $fac->modelpdf, $outputlangs);
     }
 }
 

--- a/htdocs/fourn/facture/fiche.php
+++ b/htdocs/fourn/facture/fiche.php
@@ -517,7 +517,7 @@ if ($_GET['action'] == 'addline')
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($_REQUEST['lang_id']);
         }
-        //if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_invoice_pdf_create($db, $fac->id, $fac->modelpdf, $outputlangs);
+        //if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_invoice_pdf_create($db, $fac->id, $fac->modelpdf, $outputlangs);
 
         unset($_POST['qty']);
         unset($_POST['type']);
@@ -588,7 +588,7 @@ if ($_GET['action'] == 'edit' && $user->rights->fournisseur->facture->creer)
             $outputlangs = new Translate("",$conf);
             $outputlangs->setDefaultLang($_REQUEST['lang_id']);
         }
-        //if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_invoice_pdf_create($db, $fac->id, $fac->modelpdf, $outputlangs);
+        //if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) supplier_invoice_pdf_create($db, $fac->id, $fac->modelpdf, $outputlangs);
     }
 }
 

--- a/htdocs/includes/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/includes/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -150,10 +150,12 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 
 			// if the customfield has a constraint, we fetch all the datas from this constraint in the referenced table
 			if (!empty($field->referenced_table_name)) {
-				$record = $customfields->fetchAny('*', $field->referenced_table_name, $field->referenced_column_name.'='.$object->$name); // we fetch the record in the referencd table
+				$record = $customfields->fetchAny('*', $field->referenced_table_name, $field->referenced_column_name."='".$object->$name."'"); // we fetch the record in the referencd table
 
-				foreach ($record as $column_name => $value) { // for each record, we add the value to an odt variable
-					$subarr[$name.'_'.$column_name] = $value;
+				if (!empty($record)) {
+					foreach ($record as $column_name => $value) { // for each record, we add the value to an odt variable
+						$subarr[$name.'_'.$column_name] = $value;
+					}
 				}
 			}
 		}
@@ -511,6 +513,8 @@ class doc_generic_invoice_odt extends ModelePDFFactures
                     dol_syslog($this->error, LOG_WARNING);
                     return -1;
                 }
+
+				$odfHandler->phpEval(); // Eval the php codes in the template
 
                 // Write new file
 				//$result=$odfHandler->exportAsAttachedFile('toto');

--- a/htdocs/includes/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/includes/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -85,7 +85,6 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 		if (! $this->emetteur->pays_code) $this->emetteur->pays_code=substr($langs->defaultlang,-2);    // Par defaut, si n'etait pas defini
 	}
 
-
     /**
      * Define array with couple substitution key => substitution value
      *
@@ -103,7 +102,17 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 		}
 		$alreadypayed=price($object->getSommePaiement(),'MT');
 
-        return array(
+	$subarr = array(); // initiating the substitution array
+
+	// Generically add each property of the $object into the substitution array
+	foreach ($object as $key=>$value) {
+		if (!is_object($value) and !is_resource($value)) {
+			$subarr['object_'.$key] = $value;
+		}
+	}
+
+	// Defining specific values
+        $subarr = array(
             'object_id'=>$object->id,
             'object_ref'=>$object->ref,
             'object_ref_ext'=>$object->ref_ext,
@@ -127,6 +136,31 @@ class doc_generic_invoice_odt extends ModelePDFFactures
             'object_already_payed'=>$alreadypayed,
             'object_remain_to_pay'=>price($object->total_ttc - $alreadypayed,'MT')
         );
+
+	// Adding customfields properties of the $object
+	// CustomFields
+	if ($conf->global->MAIN_MODULE_CUSTOMFIELDS) { // if the customfields module is activated...
+		include_once(DOL_DOCUMENT_ROOT.'/customfields/class/customfields.class.php');
+		$customfields = new CustomFields($this->db, '');
+		foreach ($object->customfields as $field) {
+			$name = $customfields->varprefix.$field->column_name; // name of the property (this is one customfield)
+			$translatedname = $customfields->findLabelPDF($field->column_name, $outputlangs); // label of the customfield
+			$value = $customfields->printFieldPDF($field, $object->$name, $outputlangs); // value (cleaned and properly formatted) of the customfield
+			$subarr[$name] = $value; // adding this value to an odt variable (format: {cf_customfield} by default if varprefix is default)
+
+			// if the customfield has a constraint, we fetch all the datas from this constraint in the referenced table
+			if (!empty($field->referenced_table_name)) {
+				$record = $customfields->fetchAny('*', $field->referenced_table_name, $field->referenced_column_name.'='.$object->$name); // we fetch the record in the referencd table
+
+				foreach ($record as $column_name => $value) { // for each record, we add the value to an odt variable
+					$subarr[$name.'_'.$column_name] = $value;
+				}
+			}
+		}
+	}
+
+	// Return the substitution array
+	return $subarr;
     }
 
     /**

--- a/htdocs/includes/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/includes/modules/facture/doc/pdf_crabe.modules.php
@@ -280,8 +280,8 @@ class pdf_crabe extends ModelePDFFactures
 
 					// Total HT ligne
 					$total_excl_tax = pdf_getlinetotalexcltax($object, $i, $outputlangs, $hidedetails);
-					$pdf->SetXY ($this->postotalht, $curY);
-					$pdf->MultiCell(26, 3, $total_excl_tax, 0, 'R', 0);
+					$pdf->SetXY ($this->postotalht-2, $curY);
+					$pdf->MultiCell($this->page_largeur-$this->marge_droite-$this->postotalht, 3, $total_excl_tax, 0, 'R', 0);
 
 					// Collecte des totaux par valeur de tva dans $this->tva["taux"]=total_tva
 					$tvaligne=$object->lines[$i]->total_tva;
@@ -734,7 +734,7 @@ class pdf_crabe extends ModelePDFFactures
 		// Total HT
 		$pdf->SetFillColor(255,255,255);
 		$pdf->SetXY ($col1x, $tab2_top + 0);
-		$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("TotalHT"), 0, 'L', 1);
+		$pdf->MultiCell($this->page_largeur-$this->marge_droite-$this->postotalht,2, $outputlangs->transnoentities("TotalHT"),'','C');
 		$pdf->SetXY ($col2x, $tab2_top + 0);
 		$pdf->MultiCell($largcol2, $tab2_hl, price($object->total_ht + $object->remise), 0, 'R', 1);
 

--- a/htdocs/includes/modules/facture/doc/pdf_customfields.modules.php
+++ b/htdocs/includes/modules/facture/doc/pdf_customfields.modules.php
@@ -281,8 +281,8 @@ class pdf_customfields extends ModelePDFFactures
 
 					// Total HT ligne
 					$total_excl_tax = pdf_getlinetotalexcltax($object, $i, $outputlangs, $hidedetails);
-					$pdf->SetXY ($this->postotalht, $curY);
-					$pdf->MultiCell(26, 3, $total_excl_tax, 0, 'R', 0);
+					$pdf->SetXY ($this->postotalht-2, $curY);
+					$pdf->MultiCell($this->page_largeur-$this->marge_droite-$this->postotalht, 3, $total_excl_tax, 0, 'R', 0);
 
 					// Collecte des totaux par valeur de tva dans $this->tva["taux"]=total_tva
 					$tvaligne=$object->lines[$i]->total_tva;
@@ -741,7 +741,7 @@ class pdf_customfields extends ModelePDFFactures
 		// Total HT
 		$pdf->SetFillColor(255,255,255);
 		$pdf->SetXY ($col1x, $tab2_top + 0);
-		$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("TotalHT"), 0, 'L', 1);
+		$pdf->MultiCell($this->page_largeur-$this->marge_droite-$this->postotalht,2, $outputlangs->transnoentities("TotalHT"),'','C');
 		$pdf->SetXY ($col2x, $tab2_top + 0);
 		$pdf->MultiCell($largcol2, $tab2_hl, price($object->total_ht + $object->remise), 0, 'R', 1);
 

--- a/htdocs/includes/modules/facture/doc/pdf_customfields.modules.php
+++ b/htdocs/includes/modules/facture/doc/pdf_customfields.modules.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2005-2011 Regis Houssin          <regis@dolibarr.fr>
  * Copyright (C) 2008      Raphael Bertrand       <raphael.bertrand@resultic.fr>
  * Copyright (C) 2010-2011 Juanjo Menent		  <jmenent@2byte.es>
+ * Copyright (C) 2011 Larroque Stephen		  <lrq3000@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,11 +21,11 @@
  */
 
 /**
- *	\file       htdocs/includes/modules/facture/doc/pdf_crabe.modules.php
+ *	\file       htdocs/includes/modules/facture/doc/pdf_customfields.modules.php
  *	\ingroup    facture
- *	\brief      File of class to generate invoices from crab model
- *	\author	    Laurent Destailleur
- *	\version    $Id: pdf_crabe.modules.php,v 1.12 2011/07/31 23:28:15 eldy Exp $
+ *	\brief      File of class to generate invoices from crab model with added customfields
+ *	\author	    Larroque Stephen
+ *	\version    $Id: pdf_customfields.modules.php,v 1.1.0
  */
 
 require_once(DOL_DOCUMENT_ROOT."/includes/modules/facture/modules_facture.php");
@@ -39,7 +40,7 @@ require_once(DOL_DOCUMENT_ROOT.'/lib/pdf.lib.php');
  *	\brief      Classe permettant de generer les factures au modele Crabe
  */
 
-class pdf_crabe extends ModelePDFFactures
+class pdf_customfields extends ModelePDFFactures
 {
 	var $emetteur;	// Objet societe qui emet
 
@@ -51,7 +52,7 @@ class pdf_crabe extends ModelePDFFactures
 	 *		Constructor
 	 *		@param		db		Database access handler
 	 */
-	function pdf_crabe($db)
+	function pdf_customfields($db)
 	{
 		global $conf,$langs,$mysoc;
 
@@ -59,8 +60,8 @@ class pdf_crabe extends ModelePDFFactures
 		$langs->load("bills");
 
 		$this->db = $db;
-		$this->name = "crabe";
-		$this->description = $langs->trans('PDFCrabeDescription');
+		$this->name = "customfields";
+		$this->description = $langs->trans('PDFCustomFieldsDescription');
 
 		// Dimension page pour format A4
 		$this->type = 'pdf';
@@ -421,10 +422,16 @@ class pdf_crabe extends ModelePDFFactures
 					}
 				}
 
-				// Close the pdf edition
+				// CustomFields
+				if ($conf->global->MAIN_MODULE_CUSTOMFIELDS) { // if the customfields module is activated...
+					// Add a page with the customfields
+					$pdf->AddPage();
+					$this->_pagecustomfields($pdf,$object,$outputlangs);
+					$pagenb++;
+				}
+
 				$pdf->Close();
 
-				// Save the pdf
 				$pdf->Output($file,'F');
 				if (! empty($conf->global->MAIN_UMASK))
 				@chmod($file, octdec($conf->global->MAIN_UMASK));
@@ -1225,6 +1232,41 @@ class pdf_crabe extends ModelePDFFactures
 			$pdf->SetXY($posx+2,$posy+8);
 			$pdf->MultiCell(86,4, $carac_client, 0, 'L');
 		}
+	}
+
+	/**
+	 *   	\brief      Show the customfields in a new page
+	 *   	\param      pdf     		PDF factory
+	 * 		\param		object			Object invoice
+	 *      \param      outputlangs		Object lang for output
+	 */
+	function _pagecustomfields(&$pdf,$object,$outputlangs)
+	{
+		$default_font_size = pdf_getPDFFontSize($outputlangs);
+
+		// Init and main vars
+		include_once(DOL_DOCUMENT_ROOT.'/customfields/class/customfields.class.php');
+		$customfields = new CustomFields($this->db, '');
+
+		// Fetching the list of fields columns
+		//$fields = $customfields->fetchAllCustomFields();
+
+		// Setting the starting position of the text cursor
+		$pdf->SetXY($this->page_largeur - $this->marge_droite - ($pdf->GetStringWidth($titre) + 3), $pdf->GetY()+4);
+		$pdf->SetY($pdf->GetY()+1);
+
+		// Printing the customfields
+		foreach ($object->customfields as $field) {
+			$name = $customfields->varprefix.$field->column_name; // name of the property (this is one customfield)
+			$translatedname = $customfields->findLabelPDF($field->column_name, $outputlangs); // label of the customfield
+			$value = $customfields->printFieldPDF($field, $object->$name, $outputlangs); // value (cleaned and properly formatted) of the customfield
+
+			$pdf->SetFont('','B', $default_font_size);
+			$pdf->MultiCell(0,3, $translatedname.': '.$value, 0, 'L'); // printing the customfield
+			$pdf->SetY($pdf->GetY()+1); // line return for the next printing
+		}
+
+		return 1;
 	}
 
 	/**

--- a/htdocs/includes/modules/modCustomFields.class.php
+++ b/htdocs/includes/modules/modCustomFields.class.php
@@ -1,0 +1,268 @@
+<?php
+/* Copyright (C) 2011   Stephen Larroque <lrq3000@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *	\file       htdocs/includes/modules/modCustomFields.class.php
+ * 	\defgroup   customfields     Module CustomFields
+ *     \brief      Dolibarr's module definition file for CustomFields (meta-informations file)
+ *	\version	$Id: modCustomFields.class.php, v1.1.0
+ */
+include_once(DOL_DOCUMENT_ROOT ."/includes/modules/DolibarrModules.class.php");
+
+
+/**
+ * 		\class      modCustomFields
+ *     	\brief      Dolibarr's module definition file for CustomFields (meta-informations file)
+ */
+class modCustomFields extends DolibarrModules
+{
+	/**
+	 *   \brief      Constructor. Define names, constants, directories, boxes, permissions
+	 *   \param      DB      Database handler
+	 */
+	function modCustomFields($DB)
+	{
+        global $langs,$conf;
+
+        $this->db = $DB;
+
+		// Id for module (must be unique).
+		// Use here a free id (See in Home -> System information -> Dolibarr for list of used modules id).
+		$this->numero = 8500;
+		// Key text used to identify module (for permissions, menus, etc...)
+		$this->rights_class = 'customfields';
+
+		// Family can be 'crm','financial','hr','projects','products','ecm','technic','other'
+		// It is used to group modules in module setup page
+		$this->family = "technic";
+		// Module label (no space allowed), used if translation string 'ModuleXXXName' not found (where XXX is value of numeric property 'numero' of module)
+		$this->name = preg_replace('/^mod/i','',get_class($this));
+		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
+		$this->description = "Add custom fields in invoices, propales, products and services";
+		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
+		$this->version = 'dolibarr';
+		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
+		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
+		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)
+		$this->special = 0;
+		// Name of image file used for this module.
+		// If file is in theme/yourtheme/img directory under name object_pictovalue.png, use this->picto='pictovalue'
+		// If file is in module/img directory under name object_pictovalue.png, use this->picto='pictovalue@module'
+		$this->picto='generic';
+
+		// Defined if the directory /mymodule/includes/triggers/ contains triggers or not
+		$this->triggers = 0;
+
+		// Data directories to create when module is enabled.
+		// Example: this->dirs = array("/mymodule/temp");
+		$this->dirs = array();
+		$r=0;
+
+		// Relative path to module style sheet if exists. Example: '/mymodule/css/mycss.css'.
+		//$this->style_sheet = '/mymodule/mymodule.css.php';
+
+		// Config pages. Put here list of php page names stored in admin directory used to setup module.
+		$this->config_page_url = array("customfields.php");
+
+		// Dependencies
+		$this->depends = array();		// List of modules id that must be enabled if this module is enabled
+		$this->requiredby = array();	// List of modules id to disable if this one is disabled
+		$this->phpmin = array(5,0);					// Minimum version of PHP required by module
+		$this->need_dolibarr_version = array(3,0);	// Minimum version of Dolibarr required by module
+		$this->langfiles = array("customfields@customfields", "customfields-user@customfields");
+
+		// Constants
+		// List of particular constants to add when module is enabled (key, 'chaine', value, desc, visible, 'current' or 'allentities', deleteonunactive)
+		// Example: $this->const=array(0=>array('MYMODULE_MYNEWCONST1','chaine','myvalue','This is a constant to add',1),
+		//                             1=>array('MYMODULE_MYNEWCONST2','chaine','myvalue','This is another constant to add',0) );
+		//                             2=>array('MAIN_MODULE_MYMODULE_NEEDSMARTY','chaine',1,'Constant to say module need smarty',1)
+		$this->const = array();
+
+		// Array to add new pages in new tabs
+		// Example: $this->tabs = array('objecttype:+tabname1:Title1:@mymodule:$user->rights->mymodule->read:/mymodule/mynewtab1.php?id=__ID__',  // To add a new tab identified by code tabname1
+        //                              'objecttype:+tabname2:Title2:@mymodule:$user->rights->othermodule->read:/mymodule/mynewtab2.php?id=__ID__',  // To add another new tab identified by code tabname2
+        //                              'objecttype:-tabname');                                                     // To remove an existing tab identified by code tabname
+		// where objecttype can be
+		// 'thirdparty'       to add a tab in third party view
+		// 'intervention'     to add a tab in intervention view
+		// 'order_supplier'   to add a tab in supplier order view
+		// 'invoice_supplier' to add a tab in supplier invoice view
+		// 'invoice'          to add a tab in customer invoice view
+		// 'order'            to add a tab in customer order view
+		// 'product'          to add a tab in product view
+		// 'stock'            to add a tab in stock view
+		// 'propal'           to add a tab in propal view
+		// 'member'           to add a tab in fundation member view
+		// 'contract'         to add a tab in contract view
+		// 'user'             to add a tab in user view
+		// 'group'            to add a tab in group view
+		// 'contact'          to add a tab in contact view
+		// 'categories_x'	  to add a tab in category view (replace 'x' by type of category (0=product, 1=supplier, 2=customer, 3=member)
+        $this->tabs = array();
+
+        // Dictionnaries
+        $this->dictionnaries=array();
+        /*
+        $this->dictionnaries=array(
+            'langs'=>'cabinetmed@cabinetmed',
+            'tabname'=>array(MAIN_DB_PREFIX."cabinetmed_diaglec",MAIN_DB_PREFIX."cabinetmed_examenprescrit",MAIN_DB_PREFIX."cabinetmed_motifcons"),
+            'tablib'=>array("DiagnostiqueLesionnel","ExamenPrescrit","MotifConsultation"),
+            'tabsql'=>array('SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'cabinetmed_diaglec as f','SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'cabinetmed_examenprescrit as f','SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'cabinetmed_motifcons as f'),
+            'tabsqlsort'=>array("label ASC","label ASC","label ASC"),
+            'tabfield'=>array("code,label","code,label","code,label"),
+            'tabfieldvalue'=>array("code,label","code,label","code,label"),
+            'tabfieldinsert'=>array("code,label","code,label","code,label"),
+            'tabrowid'=>array("rowid","rowid","rowid"),
+            'tabcond'=>array($conf->cabinetmed->enabled,$conf->cabinetmed->enabled,$conf->cabinetmed->enabled)
+        );
+        */
+
+        // Boxes
+		// Add here list of php file(s) stored in includes/boxes that contains class to show a box.
+        $this->boxes = array();			// List of boxes
+		$r=0;
+		// Example:
+		/*
+		$this->boxes[$r][1] = "myboxa.php";
+		$r++;
+		$this->boxes[$r][1] = "myboxb.php";
+		$r++;
+		*/
+
+		// Permissions
+		$this->rights = array();		// Permission array used by this module
+		$r=0;
+
+		// Add here list of permission defined by an id, a label, a boolean and two constant strings.
+		// Example:
+		// $this->rights[$r][0] = 2000; 				// Permission id (must not be already used)
+		// $this->rights[$r][1] = 'Permision label';	// Permission label
+		// $this->rights[$r][3] = 1; 					// Permission by default for new user (0/1)
+		// $this->rights[$r][4] = 'level1';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		// $this->rights[$r][5] = 'level2';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		// $r++;
+
+
+		// Main menu entries
+		$this->menus = array();			// List of menus to add
+		$r=0;
+
+		// Add here entries to declare new menus
+		// Example to declare the Top Menu entry:
+		// $this->menu[$r]=array(	'fk_menu'=>0,			// Put 0 if this is a top menu
+		//							'type'=>'top',			// This is a Top menu entry
+		//							'titre'=>'MyModule top menu',
+		//							'mainmenu'=>'mymodule',
+		//							'leftmenu'=>'1',		// Use 1 if you also want to add left menu entries using this descriptor.
+		//							'url'=>'/mymodule/pagetop.php',
+		//							'langs'=>'mylangfile',	// Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+		//							'position'=>100,
+		//							'enabled'=>'1',			// Define condition to show or hide menu entry. Use '$conf->mymodule->enabled' if entry must be visible if module is enabled.
+		//							'perms'=>'1',			// Use 'perms'=>'$user->rights->mymodule->level1->level2' if you want your menu with a permission rules
+		//							'target'=>'',
+		//							'user'=>2);				// 0=Menu for internal users, 1=external users, 2=both
+		// $r++;
+		//
+		// Example to declare a Left Menu entry:
+		// $this->menu[$r]=array(	'fk_menu'=>'r=0',		// Use r=value where r is index key used for the parent menu entry (higher parent must be a top menu entry)
+		//							'type'=>'left',			// This is a Left menu entry
+		//							'titre'=>'MyModule left menu 1',
+		//							'mainmenu'=>'mymodule',
+		//							'url'=>'/mymodule/pagelevel1.php',
+		//							'langs'=>'mylangfile',	// Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+		//							'position'=>100,
+		//							'enabled'=>'1',			// Define condition to show or hide menu entry. Use '$conf->mymodule->enabled' if entry must be visible if module is enabled.
+		//							'perms'=>'1',			// Use 'perms'=>'$user->rights->mymodule->level1->level2' if you want your menu with a permission rules
+		//							'target'=>'',
+		//							'user'=>2);				// 0=Menu for internal users, 1=external users, 2=both
+		// $r++;
+		//
+		// Example to declare another Left Menu entry:
+		// $this->menu[$r]=array(	'fk_menu'=>'r=1',		// Use r=value where r is index key used for the parent menu entry (higher parent must be a top menu entry)
+		//							'type'=>'left',			// This is a Left menu entry
+		//							'titre'=>'MyModule left menu 2',
+		//							'mainmenu'=>'mymodule',
+		//							'url'=>'/mymodule/pagelevel2.php',
+		//							'langs'=>'mylangfile',	// Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+		//							'position'=>100,
+		//							'enabled'=>'1',			// Define condition to show or hide menu entry. Use '$conf->mymodule->enabled' if entry must be visible if module is enabled.
+		//							'perms'=>'1',			// Use 'perms'=>'$user->rights->mymodule->level1->level2' if you want your menu with a permission rules
+		//							'target'=>'',
+		//							'user'=>2);				// 0=Menu for internal users, 1=external users, 2=both
+		// $r++;
+
+
+		// Exports
+		$r=1;
+
+		// Example:
+		// $this->export_code[$r]=$this->rights_class.'_'.$r;
+		// $this->export_label[$r]='CustomersInvoicesAndInvoiceLines';	// Translation key (used only if key ExportDataset_xxx_z not found)
+        // $this->export_enabled[$r]='1';                               // Condition to show export in list (ie: '$user->id==3'). Set to 1 to always show when module is enabled.
+		// $this->export_permission[$r]=array(array("facture","facture","export"));
+		// $this->export_fields_array[$r]=array('s.rowid'=>"IdCompany",'s.nom'=>'CompanyName','s.address'=>'Address','s.cp'=>'Zip','s.ville'=>'Town','s.fk_pays'=>'Country','s.tel'=>'Phone','s.siren'=>'ProfId1','s.siret'=>'ProfId2','s.ape'=>'ProfId3','s.idprof4'=>'ProfId4','s.code_compta'=>'CustomerAccountancyCode','s.code_compta_fournisseur'=>'SupplierAccountancyCode','f.rowid'=>"InvoiceId",'f.facnumber'=>"InvoiceRef",'f.datec'=>"InvoiceDateCreation",'f.datef'=>"DateInvoice",'f.total'=>"TotalHT",'f.total_ttc'=>"TotalTTC",'f.tva'=>"TotalVAT",'f.paye'=>"InvoicePaid",'f.fk_statut'=>'InvoiceStatus','f.note'=>"InvoiceNote",'fd.rowid'=>'LineId','fd.description'=>"LineDescription",'fd.price'=>"LineUnitPrice",'fd.tva_tx'=>"LineVATRate",'fd.qty'=>"LineQty",'fd.total_ht'=>"LineTotalHT",'fd.total_tva'=>"LineTotalTVA",'fd.total_ttc'=>"LineTotalTTC",'fd.date_start'=>"DateStart",'fd.date_end'=>"DateEnd",'fd.fk_product'=>'ProductId','p.ref'=>'ProductRef');
+		// $this->export_entities_array[$r]=array('s.rowid'=>"company",'s.nom'=>'company','s.address'=>'company','s.cp'=>'company','s.ville'=>'company','s.fk_pays'=>'company','s.tel'=>'company','s.siren'=>'company','s.siret'=>'company','s.ape'=>'company','s.idprof4'=>'company','s.code_compta'=>'company','s.code_compta_fournisseur'=>'company','f.rowid'=>"invoice",'f.facnumber'=>"invoice",'f.datec'=>"invoice",'f.datef'=>"invoice",'f.total'=>"invoice",'f.total_ttc'=>"invoice",'f.tva'=>"invoice",'f.paye'=>"invoice",'f.fk_statut'=>'invoice','f.note'=>"invoice",'fd.rowid'=>'invoice_line','fd.description'=>"invoice_line",'fd.price'=>"invoice_line",'fd.total_ht'=>"invoice_line",'fd.total_tva'=>"invoice_line",'fd.total_ttc'=>"invoice_line",'fd.tva_tx'=>"invoice_line",'fd.qty'=>"invoice_line",'fd.date_start'=>"invoice_line",'fd.date_end'=>"invoice_line",'fd.fk_product'=>'product','p.ref'=>'product');
+		// $this->export_sql_start[$r]='SELECT DISTINCT ';
+		// $this->export_sql_end[$r]  =' FROM ('.MAIN_DB_PREFIX.'facture as f, '.MAIN_DB_PREFIX.'facturedet as fd, '.MAIN_DB_PREFIX.'societe as s)';
+		// $this->export_sql_end[$r] .=' LEFT JOIN '.MAIN_DB_PREFIX.'product as p on (fd.fk_product = p.rowid)';
+		// $this->export_sql_end[$r] .=' WHERE f.fk_soc = s.rowid AND f.rowid = fd.fk_facture';
+		// $r++;
+	}
+
+	/**
+	 *		Function called when module is enabled.
+	 *		The init function add constants, boxes, permissions and menus (defined in constructor) into Dolibarr database.
+	 *		It also creates data directories.
+	 *      @return     int             1 if OK, 0 if KO
+	 */
+	function init()
+	{
+		$sql = array();
+
+		$result=$this->load_tables();
+
+		return $this->_init($sql);
+	}
+
+	/**
+	 *		Function called when module is disabled.
+	 *      Remove from database constants, boxes and permissions from Dolibarr database.
+	 *		Data directories are not deleted.
+	 *      @return     int             1 if OK, 0 if KO
+	 */
+	function remove()
+	{
+		$sql = array("DELETE FROM ".MAIN_DB_PREFIX."const WHERE name like '%_customfields';");
+
+		return $this->_remove($sql);
+	}
+
+
+	/**
+	 *		\brief		Create tables, keys and data required by module
+	 * 					Files llx_table1.sql, llx_table1.key.sql llx_data.sql with create table, create keys
+	 * 					and create data commands must be stored in directory /mymodule/sql/
+	 *					This function is called by this->init.
+	 * 		\return		int		<=0 if KO, >0 if OK
+	 */
+	function load_tables()
+	{
+		return $this->_load_tables('/customfields/sql/');
+	}
+}
+
+?>

--- a/htdocs/includes/modules/propale/modules_propale.php
+++ b/htdocs/includes/modules/propale/modules_propale.php
@@ -191,19 +191,27 @@ function propale_pdf_create($db, $object, $modele, $outputlangs, $hidedetails=0,
 		// We save charset_output to restore it because write_file can change it if needed for
 		// output format that does not support UTF8.
 		$sav_charset_output=$outputlangs->charset_output;
+
+		// Appel des triggers
+		include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
+		$interface=new Interfaces($db);
+		$result=$interface->run_triggers('PROPAL_PREBUILDDOC',$object,$user,$langs,$conf);
+		if ($result < 0) { $error++; $this->errors=$interface->errors; }
+		// Fin appel triggers
+
 		if ($obj->write_file($object, $outputlangs, $srctemplatepath, $hidedetails, $hidedesc) > 0)
 		{
 			$outputlangs->charset_output=$sav_charset_output;
 			// on supprime l'image correspondant au preview
 			propale_delete_preview($db, $object->id);
-			
+
 			// Appel des triggers
 			include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
 			$interface=new Interfaces($db);
 			$result=$interface->run_triggers('PROPAL_BUILDDOC',$object,$user,$langs,$conf);
 			if ($result < 0) { $error++; $this->errors=$interface->errors; }
 			// Fin appel triggers
-			
+
 			return 1;
 		}
 		else

--- a/htdocs/includes/modules/propale/pdf_propale_azur.modules.php
+++ b/htdocs/includes/modules/propale/pdf_propale_azur.modules.php
@@ -275,8 +275,8 @@ class pdf_propale_azur extends ModelePDFPropales
 
 					// Total HT ligne
 					$total_excl_tax = pdf_getlinetotalexcltax($object, $i, $outputlangs, $hidedetails);
-					$pdf->SetXY ($this->postotalht, $curY);
-					$pdf->MultiCell(26, 4, $total_excl_tax, 0, 'R', 0);
+					$pdf->SetXY ($this->postotalht-2, $curY);
+					$pdf->MultiCell($this->page_largeur-$this->marge_droite-$this->postotalht, 3, $total_excl_tax, 0, 'R', 0);
 
 					// Collecte des totaux par valeur de tva dans $this->tva["taux"]=total_tva
 					$tvaligne=$object->lines[$i]->total_tva;
@@ -632,7 +632,7 @@ class pdf_propale_azur extends ModelePDFPropales
 		// Total HT
 		$pdf->SetFillColor(255,255,255);
 		$pdf->SetXY ($col1x, $tab2_top + 0);
-		$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("TotalHT"), 0, 'L', 1);
+		$pdf->MultiCell($this->page_largeur-$this->marge_droite-$this->postotalht,2, $outputlangs->transnoentities("TotalHT"),'','C');
 
 		$pdf->SetXY ($col2x, $tab2_top + 0);
 		$pdf->MultiCell($largcol2, $tab2_hl, price($object->total_ht + $object->remise), 0, 'R', 1);

--- a/htdocs/includes/modules/propale/pdf_propale_azur.modules.php
+++ b/htdocs/includes/modules/propale/pdf_propale_azur.modules.php
@@ -377,8 +377,45 @@ class pdf_propale_azur extends ModelePDFPropales
 				$this->_pagefoot($pdf,$object,$outputlangs);
 				$pdf->AliasNbPages();
 
+				// Attach external pdf pages
+				$fileslist = array();
+				$attachfolderroot = DOL_DATA_ROOT.'/mycompany/attachedpdf/'; // can add a different subfolder for each module here
+				if (!is_dir($attachfolderroot)) mkdir($attachfolderroot); // if the folder does not exist, we create it
+				// we dig all the files in the specified folder and store their names in the $fileslist array (to later process only pdf files)
+				if ($handle = opendir($attachfolderroot)) {
+					/* This is the correct way to loop over the directory. */
+					while (false !== ($currfile = readdir($handle))) {
+						if ($currfile != '.' and $currfile != '..') {
+							$fileslist[] = $currfile;
+						}
+					}
+					closedir($handle);
+				}
+				sort($fileslist, SORT_LOCALE_STRING);
+				foreach ($fileslist as $filename) {
+					if ( !empty($filename) and (strpos($filename, '.pdf', strlen($filename)-4) !== false)) { // we check that it's a pdf file, not a folder or other
+						$pagecount = $pdf->setSourceFile($attachfolderroot.$filename); // loading the number of page and loading the external pdf file
+						$posy=$this->marge_haute;
+						// Special case made for tva attestations : we print them only if needed, if we have products or services with low vat
+						if ((strpos($filename, 'tva') !== false) or (strpos($filename, 'vat') !== false)) { // we search for the keyword tva or vat in the filename
+							$lowvatfound = false;
+							foreach($object->lines as $onearticle) { // for each product/service line, we test if the vat is below the normal legal value
+								if ($onearticle->tva_tx < 19.6) $lowvatfound = true;
+							}
+							if (!$lowvatfound) continue; // if now low vat found we continue the foreach loop without appending these documents, else if found we append
+						}
+						for ($n=1; $n <= $pagecount; $n++) { // we add each page to the current pdf document
+							$pdf->AddPage();
+							$tplidx = $pdf->ImportPage($n);
+							$pdf->useTemplate($tplidx, 10, 10, 190);
+						}
+					}
+				}
+
+				// Close the pdf edition
 				$pdf->Close();
 
+				// Save the pdf file
 				$pdf->Output($file,'F');
 				if (! empty($conf->global->MAIN_UMASK))
 				@chmod($file, octdec($conf->global->MAIN_UMASK));

--- a/htdocs/includes/modules/propale/pdf_propale_customfields.modules.php
+++ b/htdocs/includes/modules/propale/pdf_propale_customfields.modules.php
@@ -1,8 +1,9 @@
 <?php
-/* Copyright (C) 2004-2011 Laurent Destailleur    <eldy@users.sourceforge.net>
- * Copyright (C) 2005-2011 Regis Houssin          <regis@dolibarr.fr>
- * Copyright (C) 2008      Raphael Bertrand       <raphael.bertrand@resultic.fr>
- * Copyright (C) 2010-2011 Juanjo Menent		  <jmenent@2byte.es>
+/* Copyright (C) 2004-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2005-2011 Regis Houssin        <regis@dolibarr.fr>
+ * Copyright (C) 2008      Raphael Bertrand     <raphael.bertrand@resultic.fr>
+ * Copyright (C) 2010-2011 Juanjo Menent	    <jmenent@2byte.es>
+ * Copyright (C) 2011 Larroque Stephen		  <lrq3000@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,14 +21,13 @@
  */
 
 /**
- *	\file       htdocs/includes/modules/facture/doc/pdf_crabe.modules.php
- *	\ingroup    facture
- *	\brief      File of class to generate invoices from crab model
- *	\author	    Laurent Destailleur
- *	\version    $Id: pdf_crabe.modules.php,v 1.12 2011/07/31 23:28:15 eldy Exp $
+ *	\file       htdocs/includes/modules/propale/pdf_propale_customfields.modules.php
+ *	\ingroup    propale
+ *	\brief      Fichier de la classe permettant de generer les propales au modele Azur avec CustomFields
+ *	\author	    Larroque Stephen
+ *	\version    $Id: pdf_propale_customfields.modules.php,v 1.1.0
  */
-
-require_once(DOL_DOCUMENT_ROOT."/includes/modules/facture/modules_facture.php");
+require_once(DOL_DOCUMENT_ROOT."/includes/modules/propale/modules_propale.php");
 require_once(DOL_DOCUMENT_ROOT."/product/class/product.class.php");
 require_once(DOL_DOCUMENT_ROOT."/lib/company.lib.php");
 require_once(DOL_DOCUMENT_ROOT."/lib/functions2.lib.php");
@@ -35,23 +35,19 @@ require_once(DOL_DOCUMENT_ROOT.'/lib/pdf.lib.php');
 
 
 /**
- *	\class      pdf_crabe
- *	\brief      Classe permettant de generer les factures au modele Crabe
+ *	\class      pdf_propale_azur
+ *	\brief      Classe permettant de generer les propales au modele Azur
  */
-
-class pdf_crabe extends ModelePDFFactures
+class pdf_propale_customfields extends ModelePDFPropales
 {
 	var $emetteur;	// Objet societe qui emet
 
-    var $phpmin = array(4,3,0); // Minimum version of PHP required by module
-    var $version = 'dolibarr';
-
 
 	/**
-	 *		Constructor
-	 *		@param		db		Database access handler
+	 *	\brief      Constructeur
+	 *	\param	    db		Handler acces base de donnee
 	 */
-	function pdf_crabe($db)
+	function pdf_propale_customfields($db)
 	{
 		global $conf,$langs,$mysoc;
 
@@ -59,8 +55,8 @@ class pdf_crabe extends ModelePDFFactures
 		$langs->load("bills");
 
 		$this->db = $db;
-		$this->name = "crabe";
-		$this->description = $langs->trans('PDFCrabeDescription');
+		$this->name = "customfields";
+		$this->description = $langs->trans('DocModelCustomFieldsDescription');
 
 		// Dimension page pour format A4
 		$this->type = 'pdf';
@@ -79,15 +75,15 @@ class pdf_crabe extends ModelePDFFactures
 		$this->option_codeproduitservice = 1;      // Affiche code produit-service
 		$this->option_multilang = 1;               // Dispo en plusieurs langues
 		$this->option_escompte = 1;                // Affiche si il y a eu escompte
-		$this->option_credit_note = 1;             // Support credit notes
+		$this->option_credit_note = 1;             // Gere les avoirs
 		$this->option_freetext = 1;				   // Support add of a personalised text
-		$this->option_draft_watermark = 1;		   // Support add of a watermark on drafts
+		$this->option_draft_watermark = 1;		   //Support add of a watermark on drafts
 
 		$this->franchise=!$mysoc->tva_assuj;
 
-		// Get source company
+		// Recupere emmetteur
 		$this->emetteur=$mysoc;
-		if (! $this->emetteur->pays_code) $this->emetteur->pays_code=substr($langs->defaultlang,-2);    // By default, if was not defined
+		if (! $this->emetteur->pays_code) $this->emetteur->pays_code=substr($langs->defaultlang,-2);    // Par defaut, si n'etait pas defini
 
 		// Defini position des colonnes
 		$this->posxdesc=$this->marge_gauche+1;
@@ -104,7 +100,6 @@ class pdf_crabe extends ModelePDFFactures
 		$this->atleastonediscount=0;
 	}
 
-
 	/**
      *  Function to build pdf onto disk
      *  @param      object          Id of object to generate
@@ -118,39 +113,39 @@ class pdf_crabe extends ModelePDFFactures
 	function write_file($object,$outputlangs,$srctemplatepath='',$hidedetails=0,$hidedesc=0,$hideref=0)
 	{
 		global $user,$langs,$conf;
+		$default_font_size = pdf_getPDFFontSize($outputlangs);
 
 		if (! is_object($outputlangs)) $outputlangs=$langs;
 		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
+		$sav_charset_output=$outputlangs->charset_output;
 		if (!class_exists('TCPDF')) $outputlangs->charset_output='ISO-8859-1';
 
 		$outputlangs->load("main");
 		$outputlangs->load("dict");
 		$outputlangs->load("companies");
 		$outputlangs->load("bills");
+		$outputlangs->load("propal");
 		$outputlangs->load("products");
 
-		$default_font_size = pdf_getPDFFontSize($outputlangs);
-
-		if ($conf->facture->dir_output)
+		if ($conf->propale->dir_output)
 		{
 			$object->fetch_thirdparty();
 
-			$deja_regle = $object->getSommePaiement();
-			$amount_credit_notes_included = $object->getSumCreditNotesUsed();
-			$amount_deposits_included = $object->getSumDepositsUsed();
+			$deja_regle = "";
 
-			// Definition of $dir and $file
+			// Definition de $dir et $file
 			if ($object->specimen)
 			{
-				$dir = $conf->facture->dir_output;
+				$dir = $conf->propale->dir_output;
 				$file = $dir . "/SPECIMEN.pdf";
 			}
 			else
 			{
 				$objectref = dol_sanitizeFileName($object->ref);
-				$dir = $conf->facture->dir_output . "/" . $objectref;
+				$dir = $conf->propale->dir_output . "/" . $objectref;
 				$file = $dir . "/" . $objectref . ".pdf";
 			}
+
 			if (! file_exists($dir))
 			{
 				if (create_exdir($dir) < 0)
@@ -164,6 +159,7 @@ class pdf_crabe extends ModelePDFFactures
 			{
 				$nblignes = sizeof($object->lines);
 
+				// Create pdf instance
                 $pdf=pdf_getInstance($this->format);
 
                 if (class_exists('TCPDF'))
@@ -178,10 +174,10 @@ class pdf_crabe extends ModelePDFFactures
 				$pdf->SetDrawColor(128,128,128);
 
 				$pdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
-				$pdf->SetSubject($outputlangs->transnoentities("Invoice"));
+				$pdf->SetSubject($outputlangs->transnoentities("CommercialProposal"));
 				$pdf->SetCreator("Dolibarr ".DOL_VERSION);
 				$pdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-				$pdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref)." ".$outputlangs->transnoentities("Invoice"));
+				$pdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref)." ".$outputlangs->transnoentities("CommercialProposal"));
 				if ($conf->global->MAIN_DISABLE_PDF_COMPRESSION) $pdf->SetCompression(false);
 
 				$pdf->SetMargins($this->marge_gauche, $this->marge_haute, $this->marge_droite);   // Left, Top, Right
@@ -201,30 +197,29 @@ class pdf_crabe extends ModelePDFFactures
 				$pagenb++;
 				$this->_pagehead($pdf, $object, 1, $outputlangs);
 				$pdf->SetFont('','', $default_font_size - 1);
-				$pdf->MultiCell(0, 3, '');		// Set interline to 3
+				$pdf->MultiCell(0, 4, '');		// Set interline to 4
 				$pdf->SetTextColor(0,0,0);
 
 				$tab_top = 90;
+				$tab_top_middlepage = 50;
 				$tab_top_newpage = 50;
-				$tab_height = 110;
-				$tab_height_newpage = 150;
+				$tab_height = 130;
+				$tab_height_middlepage = 200;
+				$tab_height_endpage = 170;
 
 				// Affiche notes
 				if (! empty($object->note_public))
 				{
 					$tab_top = 88;
 
-					$pdf->SetFont('','', $default_font_size - 1);
+					$pdf->SetFont('','', $default_font_size - 1);   // Dans boucle pour gerer multi-page
 					$pdf->SetXY ($this->posxdesc-1, $tab_top);
-                    //$pdf->MultiCell(190, 3, $outputlangs->convToOutputCharset($object->note_public), 0, 'J', false, 1, '', '', true, 0, false, false, 0, 'T', true);
-                    $pdf->MultiCell(190, 3, $outputlangs->convToOutputCharset($object->note_public), 0, 'L');    // FPDF
+					$pdf->MultiCell(190, 4, $outputlangs->convToOutputCharset($object->note_public), 0, 'L');
 					$nexY = $pdf->GetY();
 					$height_note=$nexY-$tab_top;
 
 					// Rect prend une longueur en 3eme param
 					$pdf->SetDrawColor(192,192,192);
-//print $pdf->getStringHeight(200,'SPECIMEN',false,false);
-//print "$this->marge_gauche, $tab_top-1, $this->page_largeur-$this->marge_gauche-$this->marge_droite, $height_note+1";exit;
 					$pdf->Rect($this->marge_gauche, $tab_top-1, $this->page_largeur-$this->marge_gauche-$this->marge_droite, $height_note+1);
 
 					$tab_height = $tab_height - $height_note;
@@ -244,44 +239,45 @@ class pdf_crabe extends ModelePDFFactures
 				{
 					$curY = $nexY;
 
-					// Description of product line
-					$pdf->SetFont('','', $default_font_size - 1);   // Into loop to work with multipage
+					$pdf->SetFont('','', $default_font_size - 1);   // Dans boucle pour gerer multi-page
+
+					// Description de la ligne produit
 					$curX = $this->posxdesc-1;
-					pdf_writelinedesc($pdf,$object,$i,$outputlangs,$this->posxtva-$curX,3,$curX,$curY,$hideref,$hidedesc);
+					pdf_writelinedesc($pdf,$object,$i,$outputlangs,$this->posxtva-$curX,4,$curX,$curY,$hideref,$hidedesc);
 
 					$pdf->SetFont('','', $default_font_size - 1);   // On repositionne la police par defaut
 					$nexY = $pdf->GetY();
 
-					// VAT Rate
+					// TVA
 					if (empty($conf->global->MAIN_GENERATE_DOCUMENTS_WITHOUT_VAT))
 					{
 						$vat_rate = pdf_getlinevatrate($object, $i, $outputlangs, $hidedetails);
 						$pdf->SetXY ($this->posxtva, $curY);
-						$pdf->MultiCell($this->posxup-$this->posxtva-1, 3, $vat_rate, 0, 'R');
+						$pdf->MultiCell($this->posxup-$this->posxtva-1, 4, $vat_rate, 0, 'R');
 					}
 
 					// Prix unitaire HT avant remise
 					$up_excl_tax = pdf_getlineupexcltax($object, $i, $outputlangs, $hidedetails);
 					$pdf->SetXY ($this->posxup, $curY);
-					$pdf->MultiCell($this->posxqty-$this->posxup-1, 3, $up_excl_tax, 0, 'R', 0);
+					$pdf->MultiCell($this->posxqty-$this->posxup-1, 4, $up_excl_tax, 0, 'R', 0);
 
 					// Quantity
 					$qty = pdf_getlineqty($object, $i, $outputlangs, $hidedetails);
 					$pdf->SetXY ($this->posxqty, $curY);
-					$pdf->MultiCell($this->posxdiscount-$this->posxqty-1, 3, $qty, 0, 'R');	// Enough for 6 chars
+					$pdf->MultiCell($this->posxdiscount-$this->posxqty-1, 4, $qty, 0, 'R');
 
-					// Discount
+					// Remise sur ligne
+					$pdf->SetXY ($this->posxdiscount, $curY);
 					if ($object->lines[$i]->remise_percent)
 					{
-                        $pdf->SetXY ($this->posxdiscount-2, $curY);
-					    $remise_percent = pdf_getlineremisepercent($object, $i, $outputlangs, $hidedetails);
-						$pdf->MultiCell($this->postotalht-$this->posxdiscount+2, 3, $remise_percent, 0, 'R');
+						$remise_percent = pdf_getlineremisepercent($object, $i, $outputlangs, $hidedetails);
+						$pdf->MultiCell($this->postotalht-$this->posxdiscount-1, 4, $remise_percent, 0, 'R');
 					}
 
 					// Total HT ligne
 					$total_excl_tax = pdf_getlinetotalexcltax($object, $i, $outputlangs, $hidedetails);
 					$pdf->SetXY ($this->postotalht, $curY);
-					$pdf->MultiCell(26, 3, $total_excl_tax, 0, 'R', 0);
+					$pdf->MultiCell(26, 4, $total_excl_tax, 0, 'R', 0);
 
 					// Collecte des totaux par valeur de tva dans $this->tva["taux"]=total_tva
 					$tvaligne=$object->lines[$i]->total_tva;
@@ -297,6 +293,7 @@ class pdf_crabe extends ModelePDFFactures
 					$localtax2rate=(string) $object->lines[$i]->localtax2_tx;
 
 					if (($object->lines[$i]->info_bits & 0x01) == 0x01) $vatrate.='*';
+
 					$this->tva[$vatrate] += $tvaligne;
 					$this->localtax1[$localtax1rate]+=$localtax1ligne;
 					$this->localtax2[$localtax2rate]+=$localtax2ligne;
@@ -309,12 +306,7 @@ class pdf_crabe extends ModelePDFFactures
 						//on recupere la description du produit suivant
 						$follow_descproduitservice = $object->lines[$i+1]->desc;
 						//on compte le nombre de ligne afin de verifier la place disponible (largeur de ligne 52 caracteres)
-						$nblineFollowDesc = dol_nboflines_bis($follow_descproduitservice,52,$outputlangs->charset_output)*4;
-						// Et si on affiche dates de validite, on ajoute encore une ligne
-						if ($object->lines[$i]->date_start && $object->lines[$i]->date_end)
-						{
-							$nblineFollowDesc += 4;
-						}
+						$nblineFollowDesc = (dol_nboflines_bis($follow_descproduitservice,52,$outputlangs->charset_output)*4);
 					}
 					else	// If it's last line
 					{
@@ -330,17 +322,17 @@ class pdf_crabe extends ModelePDFFactures
 					else
 					{
 						$tab_top_in_current_page=$tab_top_newpage;
-						$tab_height_in_current_page=$tab_height_newpage;
+						$tab_height_in_current_page=$tab_height_middlepage;
 					}
 					if (($nexY+$nblineFollowDesc) > ($tab_top_in_current_page+$tab_height_in_current_page) && $i < ($nblignes - 1))
 					{
-					    if ($pagenb == 1)
+						if ($pagenb == 1)
 						{
 							$this->_tableau($pdf, $tab_top, $tab_height + 20, $nexY, $outputlangs);
 						}
 						else
 						{
-							$this->_tableau($pdf, $tab_top_newpage, $tab_height_newpage, $nexY, $outputlangs);
+							$this->_tableau($pdf, $tab_top_newpage, $tab_height_middlepage, $nexY, $outputlangs);
 						}
 
 						$this->_pagefoot($pdf,$object,$outputlangs);
@@ -366,8 +358,8 @@ class pdf_crabe extends ModelePDFFactures
 				}
 				else
 				{
-					$this->_tableau($pdf, $tab_top_newpage, $tab_height_newpage, $nexY, $outputlangs);
-					$bottomlasttab=$tab_top_newpage + $tab_height_newpage + 1;
+					$this->_tableau($pdf, $tab_top_newpage, $tab_height_endpage, $nexY, $outputlangs);
+					$bottomlasttab=$tab_top_newpage + $tab_height_endpage + 1;
 				}
 
 				// Affiche zone infos
@@ -377,7 +369,7 @@ class pdf_crabe extends ModelePDFFactures
 				$posy=$this->_tableau_tot($pdf, $object, $deja_regle, $bottomlasttab, $outputlangs);
 
 				// Affiche zone versements
-				if ($deja_regle || $amount_credit_notes_included || $amount_deposits_included)
+				if ($deja_regle)
 				{
 					$posy=$this->_tableau_versements($pdf, $object, $posy, $outputlangs);
 				}
@@ -421,14 +413,28 @@ class pdf_crabe extends ModelePDFFactures
 					}
 				}
 
-				// Close the pdf edition
+				// CustomFields
+				if ($conf->global->MAIN_MODULE_CUSTOMFIELDS) { // if the customfields module is activated...
+					// Add a page with the customfields
+					$pdf->AddPage();
+					$this->_pagecustomfields($pdf,$object,$outputlangs);
+					$pagenb++;
+				}
+
 				$pdf->Close();
 
-				// Save the pdf
 				$pdf->Output($file,'F');
 				if (! empty($conf->global->MAIN_UMASK))
 				@chmod($file, octdec($conf->global->MAIN_UMASK));
 
+				// Add external file
+				//$pdfConcat = new concat_pdf();
+				//$pdfConcat->setFiles(array($file, DOL_DOCUMENT_ROOT."/includes/modules/propale/morefile.pdf"));
+				//$pdfConcat->concat();
+				//$pdf->AliasNbPages();
+				//$pdfConcat->Output($file,'F');
+
+				$outputlangs->charset_output=$sav_charset_output;
 				return 1;   // Pas d'erreur
 			}
 			else
@@ -439,133 +445,21 @@ class pdf_crabe extends ModelePDFFactures
 		}
 		else
 		{
-			$this->error=$langs->trans("ErrorConstantNotDefined","FAC_OUTPUTDIR");
+			$this->error=$langs->trans("ErrorConstantNotDefined","PROP_OUTPUTDIR");
 			return 0;
 		}
+
 		$this->error=$langs->trans("ErrorUnknown");
 		return 0;   // Erreur par defaut
 	}
 
-
-	/**
-	 *  Show payments table
-     *  @param      pdf             Object PDF
-     *  @param      object          Object invoice
-     *  @param      posy            Position y in PDF
-     *  @param      outputlangs     Object langs for output
-     *  @return     int             <0 if KO, >0 if OK
+	/*
+	 *   \brief      Affiche tableau des versement
+	 *   \param      pdf     	Objet PDF
+	 *   \param      object		Objet propale
 	 */
 	function _tableau_versements(&$pdf, $object, $posy, $outputlangs)
 	{
-		$tab3_posx = 120;
-		$tab3_top = $posy + 8;
-		$tab3_width = 80;
-		$tab3_height = 4;
-
-		$default_font_size = pdf_getPDFFontSize($outputlangs);
-
-		$pdf->SetFont('','', $default_font_size - 2);
-		$pdf->SetXY ($tab3_posx, $tab3_top - 5);
-		$pdf->MultiCell(60, 5, $outputlangs->transnoentities("PaymentsAlreadyDone"), 0, 'L', 0);
-
-		$pdf->line($tab3_posx, $tab3_top-1+$tab3_height, $tab3_posx+$tab3_width, $tab3_top-1+$tab3_height);
-
-		$pdf->SetFont('','', $default_font_size - 4);
-		$pdf->SetXY ($tab3_posx, $tab3_top );
-		$pdf->MultiCell(20, 3, $outputlangs->transnoentities("Payment"), 0, 'L', 0);
-		$pdf->SetXY ($tab3_posx+21, $tab3_top );
-		$pdf->MultiCell(20, 3, $outputlangs->transnoentities("Amount"), 0, 'L', 0);
-		$pdf->SetXY ($tab3_posx+40, $tab3_top );
-		$pdf->MultiCell(20, 3, $outputlangs->transnoentities("Type"), 0, 'L', 0);
-		$pdf->SetXY ($tab3_posx+58, $tab3_top );
-		$pdf->MultiCell(20, 3, $outputlangs->transnoentities("Num"), 0, 'L', 0);
-
-		$y=0;
-
-		$pdf->SetFont('','', $default_font_size - 4);
-
-		// Loop on each deposits and credit notes included
-		$sql = "SELECT re.rowid, re.amount_ht, re.amount_tva, re.amount_ttc,";
-		$sql.= " re.description, re.fk_facture_source, re.fk_facture_source,";
-		$sql.= " f.type, f.datef";
-		$sql.= " FROM ".MAIN_DB_PREFIX ."societe_remise_except as re, ".MAIN_DB_PREFIX ."facture as f";
-		$sql.= " WHERE re.fk_facture_source = f.rowid AND re.fk_facture = ".$object->id;
-		$resql=$this->db->query($sql);
-		if ($resql)
-		{
-			$num = $this->db->num_rows($resql);
-			$i=0;
-			$invoice=new Facture($this->db);
-			while ($i < $num)
-			{
-				$y+=3;
-				$obj = $this->db->fetch_object($resql);
-
-				if ($obj->type == 2) $text=$outputlangs->trans("CreditNote");
-				elseif ($obj->type == 3) $text=$outputlangs->trans("Deposit");
-				else $text=$outputlangs->trans("UnknownType");
-
-				$invoice->fetch($obj->fk_facture_source);
-
-				$pdf->SetXY ($tab3_posx, $tab3_top+$y );
-				$pdf->MultiCell(20, 3, dol_print_date($obj->datef,'day',false,$outputlangs,true), 0, 'L', 0);
-				$pdf->SetXY ($tab3_posx+21, $tab3_top+$y);
-				$pdf->MultiCell(20, 3, price($obj->amount_ttc), 0, 'L', 0);
-				$pdf->SetXY ($tab3_posx+40, $tab3_top+$y);
-				$pdf->MultiCell(20, 3, $text, 0, 'L', 0);
-				$pdf->SetXY ($tab3_posx+58, $tab3_top+$y);
-				$pdf->MultiCell(20, 3, $invoice->ref, 0, 'L', 0);
-
-				$pdf->line($tab3_posx, $tab3_top+$y+3, $tab3_posx+$tab3_width, $tab3_top+$y+3 );
-
-				$i++;
-			}
-		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			dol_syslog($this->db,$this->error, LOG_ERR);
-			return -1;
-		}
-
-		// Loop on each payment
-		$sql = "SELECT p.datep as date, p.fk_paiement as type, p.num_paiement as num, pf.amount as amount,";
-		$sql.= " cp.code";
-		$sql.= " FROM ".MAIN_DB_PREFIX."paiement_facture as pf, ".MAIN_DB_PREFIX."paiement as p";
-		$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."c_paiement as cp ON p.fk_paiement = cp.id";
-		$sql.= " WHERE pf.fk_paiement = p.rowid and pf.fk_facture = ".$object->id;
-		$sql.= " ORDER BY p.datep";
-		$resql=$this->db->query($sql);
-		if ($resql)
-		{
-			$num = $this->db->num_rows($resql);
-			$i=0;
-			while ($i < $num) {
-				$y+=3;
-				$row = $this->db->fetch_object($resql);
-
-				$pdf->SetXY ($tab3_posx, $tab3_top+$y );
-				$pdf->MultiCell(20, 3, dol_print_date($this->db->jdate($row->date),'day',false,$outputlangs,true), 0, 'L', 0);
-				$pdf->SetXY ($tab3_posx+21, $tab3_top+$y);
-				$pdf->MultiCell(20, 3, price($row->amount), 0, 'L', 0);
-				$pdf->SetXY ($tab3_posx+40, $tab3_top+$y);
-				$oper = $outputlangs->getTradFromKey("PaymentTypeShort" . $row->code);
-
-				$pdf->MultiCell(20, 3, $oper, 0, 'L', 0);
-				$pdf->SetXY ($tab3_posx+58, $tab3_top+$y);
-				$pdf->MultiCell(30, 3, $row->num, 0, 'L', 0);
-
-				$pdf->line($tab3_posx, $tab3_top+$y+3, $tab3_posx+$tab3_width, $tab3_top+$y+3 );
-
-				$i++;
-			}
-		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			dol_syslog($this->db,$this->error, LOG_ERR);
-			return -1;
-		}
 
 	}
 
@@ -581,7 +475,6 @@ class pdf_crabe extends ModelePDFFactures
 	function _tableau_info(&$pdf, $object, $posy, $outputlangs)
 	{
 		global $conf;
-
 		$default_font_size = pdf_getPDFFontSize($outputlangs);
 
 		$pdf->SetFont('','', $default_font_size - 1);
@@ -594,6 +487,23 @@ class pdf_crabe extends ModelePDFFactures
 			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("VATIsNotUsedForInvoice"), 0, 'L', 0);
 
 			$posy=$pdf->GetY()+4;
+		}
+
+		// Show availability conditions
+		if ($object->type != 2 && ($object->availability_code || $object->availability))
+		{
+			$pdf->SetFont('','B', $default_font_size - 2);
+			$pdf->SetXY($this->marge_gauche, $posy);
+			$titre = $outputlangs->transnoentities("AvailabilityPeriod").':';
+			$pdf->MultiCell(80, 4, $titre, 0, 'L');
+			$pdf->SetTextColor(0,0,0);
+			$pdf->SetFont('','', $default_font_size - 2);
+			$pdf->SetXY(82, $posy);
+			$lib_availability=$outputlangs->transnoentities("AvailabilityPeriod".$object->availability_code)!=('AvailabilityPeriod'.$object->availability_code)?$outputlangs->transnoentities("AvailabilityPeriod".$object->availability_code):$outputlangs->convToOutputCharset($object->availability);
+			$lib_availability=str_replace('\n',"\n",$lib_availability);
+			$pdf->MultiCell(80, 4, $lib_availability,0,'L');
+
+			$posy=$pdf->GetY()+1;
 		}
 
 		// Show payments conditions
@@ -630,7 +540,7 @@ class pdf_crabe extends ModelePDFFactures
 				$posy=$pdf->GetY()+1;
 			}
 
-			// Show payment mode
+			// Shown payment mode
 			if ($object->mode_reglement_code
 			&& $object->mode_reglement_code != 'CHQ'
 			&& $object->mode_reglement_code != 'VIR')
@@ -639,7 +549,6 @@ class pdf_crabe extends ModelePDFFactures
 				$pdf->SetXY($this->marge_gauche, $posy);
 				$titre = $outputlangs->transnoentities("PaymentMode").':';
 				$pdf->MultiCell(80, 5, $titre, 0, 'L');
-
 				$pdf->SetFont('','', $default_font_size - 2);
 				$pdf->SetXY(50, $posy);
 				$lib_mode_reg=$outputlangs->transnoentities("PaymentType".$object->mode_reglement_code)!=('PaymentType'.$object->mode_reglement_code)?$outputlangs->transnoentities("PaymentType".$object->mode_reglement_code):$outputlangs->convToOutputCharset($object->mode_reglement);
@@ -706,19 +615,18 @@ class pdf_crabe extends ModelePDFFactures
 	}
 
 
-	/**
+	/*
 	 *	\brief      Affiche le total a payer
-	 *	\param      pdf             Objet PDF
-	 *	\param      object          Objet facture
-	 *	\param      deja_regle      Montant deja regle
+	 *	\param      pdf         	Objet PDF
+	 *	\param      object       	Objet propale
+	 *	\param      deja_regle  	Montant deja regle
 	 *	\param		posy			Position depart
 	 *	\param		outputlangs		Objet langs
-	 *	\return     y               Position pour suite
+	 *	\return     y              Position pour suite
 	 */
 	function _tableau_tot(&$pdf, $object, $deja_regle, $posy, $outputlangs)
 	{
 		global $conf,$mysoc;
-
 		$default_font_size = pdf_getPDFFontSize($outputlangs);
 
 		$tab2_top = $posy;
@@ -728,15 +636,15 @@ class pdf_crabe extends ModelePDFFactures
 		// Tableau total
 		$lltot = 200; $col1x = 120; $col2x = 170; $largcol2 = $lltot - $col2x;
 
-		$useborder=0;
-		$index = 0;
-
 		// Total HT
 		$pdf->SetFillColor(255,255,255);
 		$pdf->SetXY ($col1x, $tab2_top + 0);
 		$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("TotalHT"), 0, 'L', 1);
+
 		$pdf->SetXY ($col2x, $tab2_top + 0);
 		$pdf->MultiCell($largcol2, $tab2_hl, price($object->total_ht + $object->remise), 0, 'R', 1);
+
+		$index = 0;
 
 		// Show VAT by rates and total
 		$pdf->SetFillColor(248,248,248);
@@ -752,6 +660,7 @@ class pdf_crabe extends ModelePDFFactures
 
 					$index++;
 					$pdf->SetXY ($col1x, $tab2_top + $tab2_hl * $index);
+
 					$tvacompl='';
 					if (preg_match('/\*/',$tvakey))
 					{
@@ -761,16 +670,18 @@ class pdf_crabe extends ModelePDFFactures
 					$totalvat =$outputlangs->transnoentities("TotalVAT").' ';
 					$totalvat.=vatrate($tvakey,1).$tvacompl;
 					$pdf->MultiCell($col2x-$col1x, $tab2_hl, $totalvat, 0, 'L', 1);
+
 					$pdf->SetXY ($col2x, $tab2_top + $tab2_hl * $index);
 					$pdf->MultiCell($largcol2, $tab2_hl, price($tvaval), 0, 'R', 1);
 				}
 			}
 
-			if (! $this->atleastoneratenotnull)	// If no vat at all
+			if (! $this->atleastoneratenotnull) // If not vat at all
 			{
 				$index++;
 				$pdf->SetXY ($col1x, $tab2_top + $tab2_hl * $index);
 				$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("TotalVAT"), 0, 'L', 1);
+
 				$pdf->SetXY ($col2x, $tab2_top + $tab2_hl * $index);
 				$pdf->MultiCell($largcol2, $tab2_hl, price($object->total_tva), 0, 'R', 1);
 
@@ -796,9 +707,9 @@ class pdf_crabe extends ModelePDFFactures
 			}
 			else
 			{
+				//Local tax 1
 				if (! empty($conf->global->FACTURE_LOCAL_TAX1_OPTION) && $conf->global->FACTURE_LOCAL_TAX1_OPTION=='localtax1on')
 				{
-					//Local tax 1
 					foreach( $this->localtax1 as $tvakey => $tvaval )
 					{
 						if ($tvakey>0)    // On affiche pas taux 0
@@ -814,7 +725,7 @@ class pdf_crabe extends ModelePDFFactures
 								$tvakey=str_replace('*','',$tvakey);
 								$tvacompl = " (".$outputlangs->transnoentities("NonPercuRecuperable").")";
 							}
-							$totalvat =$outputlangs->transnoentities("TotalLT1".$mysoc->pays_code).' ';
+							$totalvat = $outputlangs->transnoentities("TotalLT1".$mysoc->pays_code).' ';
 							$totalvat.=vatrate($tvakey,1).$tvacompl;
 							$pdf->MultiCell($col2x-$col1x, $tab2_hl, $totalvat, 0, 'L', 1);
 
@@ -824,14 +735,14 @@ class pdf_crabe extends ModelePDFFactures
 					}
 				}
 
+				//Local tax 2
 				if (! empty($conf->global->FACTURE_LOCAL_TAX2_OPTION) && $conf->global->FACTURE_LOCAL_TAX2_OPTION=='localtax2on')
-				{
-					//Local tax 2
+					{
 					foreach( $this->localtax2 as $tvakey => $tvaval )
 					{
 						if ($tvakey>0)    // On affiche pas taux 0
 						{
-						//$this->atleastoneratenotnull++;
+							//$this->atleastoneratenotnull++;
 
 							$index++;
 							$pdf->SetXY ($col1x, $tab2_top + $tab2_hl * $index);
@@ -842,17 +753,20 @@ class pdf_crabe extends ModelePDFFactures
 								$tvakey=str_replace('*','',$tvakey);
 								$tvacompl = " (".$outputlangs->transnoentities("NonPercuRecuperable").")";
 							}
-							$totalvat =$outputlangs->transnoentities("TotalLT2".$mysoc->pays_code).' ';
+							$totalvat = $outputlangs->transnoentities("TotalLT2".$mysoc->pays_code).' ';
 							$totalvat.=vatrate($tvakey,1).$tvacompl;
 							$pdf->MultiCell($col2x-$col1x, $tab2_hl, $totalvat, 0, 'L', 1);
 
 							$pdf->SetXY ($col2x, $tab2_top + $tab2_hl * $index);
 							$pdf->MultiCell($largcol2, $tab2_hl, price($tvaval), 0, 'R', 1);
+
 						}
 					}
-				}
+					}
 			}
 		}
+
+		$useborder=0;
 
 		// Total TTC
 		if (empty($conf->global->MAIN_GENERATE_DOCUMENTS_WITHOUT_VAT))
@@ -861,40 +775,26 @@ class pdf_crabe extends ModelePDFFactures
 			$pdf->SetXY ($col1x, $tab2_top + $tab2_hl * $index);
 			$pdf->SetTextColor(0,0,60);
 			$pdf->SetFillColor(224,224,224);
-			$text=$outputlangs->transnoentities("TotalTTC");
-			if ($object->type == 2) $text=$outputlangs->transnoentities("TotalTTCToYourCredit");
-			$pdf->MultiCell($col2x-$col1x, $tab2_hl, $text, $useborder, 'L', 1);
+			$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("TotalTTC"), $useborder, 'L', 1);
+
 			$pdf->SetXY ($col2x, $tab2_top + $tab2_hl * $index);
 			$pdf->MultiCell($largcol2, $tab2_hl, price($object->total_ttc), $useborder, 'R', 1);
+			$pdf->SetTextColor(0,0,0);
 		}
-		$pdf->SetTextColor(0,0,0);
 
-		$creditnoteamount=$object->getSumCreditNotesUsed();
-		$depositsamount=$object->getSumDepositsUsed();
-		//print "x".$creditnoteamount."-".$depositsamount;exit;
-		$resteapayer = price2num($object->total_ttc - $deja_regle - $creditnoteamount - $depositsamount, 'MT');
-		if ($object->paye) $resteapayer=0;
-
-		if ($deja_regle > 0 || $creditnoteamount > 0 || $depositsamount > 0)
+		if ($deja_regle > 0)
 		{
-			// Already paid + Deposits
 			$index++;
+
 			$pdf->SetXY ($col1x, $tab2_top + $tab2_hl * $index);
-			$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("Paid"), 0, 'L', 0);
+			$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("AlreadyPaid"), 0, 'L', 0);
+
 			$pdf->SetXY ($col2x, $tab2_top + $tab2_hl * $index);
-			$pdf->MultiCell($largcol2, $tab2_hl, price($deja_regle + $depositsamount), 0, 'R', 0);
+			$pdf->MultiCell($largcol2, $tab2_hl, price($deja_regle), 0, 'R', 0);
 
-			// Credit note
-			if ($creditnoteamount)
-			{
-				$index++;
-				$pdf->SetXY ($col1x, $tab2_top + $tab2_hl * $index);
-				$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("CreditNotes"), 0, 'L', 0);
-				$pdf->SetXY ($col2x, $tab2_top + $tab2_hl * $index);
-				$pdf->MultiCell($largcol2, $tab2_hl, price($creditnoteamount), 0, 'R', 0);
-			}
+			$resteapayer = $object->total_ttc - $deja_regle;
+			if ($object->paye) $resteapayer=0;
 
-			// Escompte
 			if ($object->close_code == 'discount_vat')
 			{
 				$index++;
@@ -902,8 +802,9 @@ class pdf_crabe extends ModelePDFFactures
 
 				$pdf->SetXY ($col1x, $tab2_top + $tab2_hl * $index);
 				$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("EscompteOffered"), $useborder, 'L', 1);
+
 				$pdf->SetXY ($col2x, $tab2_top + $tab2_hl * $index);
-				$pdf->MultiCell($largcol2, $tab2_hl, price($object->total_ttc - $deja_regle - $creditnoteamount - $depositsamount), $useborder, 'R', 1);
+				$pdf->MultiCell($largcol2, $tab2_hl, price($object->total_ttc - $deja_regle), $useborder, 'R', 1);
 
 				$resteapayer=0;
 			}
@@ -913,6 +814,7 @@ class pdf_crabe extends ModelePDFFactures
 			$pdf->SetFillColor(224,224,224);
 			$pdf->SetXY ($col1x, $tab2_top + $tab2_hl * $index);
 			$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("RemainderToPay"), $useborder, 'L', 1);
+
 			$pdf->SetXY ($col2x, $tab2_top + $tab2_hl * $index);
 			$pdf->MultiCell($largcol2, $tab2_hl, price($resteapayer), $useborder, 'R', 1);
 
@@ -926,30 +828,29 @@ class pdf_crabe extends ModelePDFFactures
 	}
 
 	/**
-	 *   Affiche la grille des lignes de factures
-	 *   @param      pdf     objet PDF
+	 *   \brief      Affiche la grille des lignes de propales
+	 *   \param      pdf     objet PDF
 	 */
 	function _tableau(&$pdf, $tab_top, $tab_height, $nexY, $outputlangs)
 	{
 		global $conf;
-
 		$default_font_size = pdf_getPDFFontSize($outputlangs);
 
-		// Amount in (at tab_top - 1)
+		// Montants exprimes en     (en tab_top - 1)
 		$pdf->SetTextColor(0,0,0);
-		$pdf->SetFont('','', $default_font_size - 2);
+		$pdf->SetFont('','',$default_font_size - 2);
 		$titre = $outputlangs->transnoentities("AmountInCurrency",$outputlangs->transnoentitiesnoconv("Currency".$conf->monnaie));
 		$pdf->SetXY($this->page_largeur - $this->marge_droite - ($pdf->GetStringWidth($titre) + 3), $tab_top-4);
 		$pdf->MultiCell(($pdf->GetStringWidth($titre) + 3), 2, $titre);
 
 		$pdf->SetDrawColor(128,128,128);
 
-		// Rect prend une longueur en 3eme param et 4eme param
+		// Rect prend une longueur en 3eme param
 		$pdf->Rect($this->marge_gauche, $tab_top, $this->page_largeur-$this->marge_gauche-$this->marge_droite, $tab_height);
-		// line prend une position y en 2eme param et 4eme param
+		// line prend une position y en 3eme param
 		$pdf->line($this->marge_gauche, $tab_top+5, $this->page_largeur-$this->marge_droite, $tab_top+5);
 
-		$pdf->SetFont('','', $default_font_size - 1);
+		$pdf->SetFont('','',$default_font_size - 1);
 
 		$pdf->SetXY ($this->posxdesc-1, $tab_top+1);
 		$pdf->MultiCell(108,2, $outputlangs->transnoentities("Designation"),'','L');
@@ -986,30 +887,31 @@ class pdf_crabe extends ModelePDFFactures
 	}
 
 	/**
-	 *   	\brief      Show header of page
-	 *      \param      pdf             Object PDF
-	 *      \param      object          Object invoice
-	 *      \param      showaddress     0=no, 1=yes
-	 *      \param      outputlangs		Object lang for output
+	 *   	Show header of document
+	 *   	@param      pdf     		Object PDF
+	 *   	@param      object			Object commercial proposal
+	 *      @param      showaddress     0=no, 1=yes
+	 *      @param      outputlangs    	Object lang for output
 	 */
 	function _pagehead(&$pdf, $object, $showaddress=1, $outputlangs)
 	{
 		global $conf,$langs;
+		$default_font_size = pdf_getPDFFontSize($outputlangs);
 
 		$outputlangs->load("main");
 		$outputlangs->load("bills");
 		$outputlangs->load("propal");
 		$outputlangs->load("companies");
 
-		$default_font_size = pdf_getPDFFontSize($outputlangs);
-
 		pdf_pagehead($pdf,$outputlangs,$this->page_hauteur);
 
-        if($object->statut==0 && (! empty($conf->global->FACTURE_DRAFT_WATERMARK)) )
-        {
-		      pdf_watermark($pdf,$outputlangs,$this->page_hauteur,$this->page_largeur,'mm',$conf->global->FACTURE_DRAFT_WATERMARK);
-        }
+		//Affiche le filigrane brouillon - Print Draft Watermark
+		if($object->statut==0 && (! empty($conf->global->PROPALE_DRAFT_WATERMARK)) )
+		{
+            pdf_watermark($pdf,$outputlangs,$this->page_hauteur,$this->page_largeur,'mm',$conf->global->PROPALE_DRAFT_WATERMARK);
+		}
 
+		//Prepare la suite
 		$pdf->SetTextColor(0,0,60);
 		$pdf->SetFont('','B', $default_font_size + 3);
 
@@ -1023,7 +925,7 @@ class pdf_crabe extends ModelePDFFactures
 		{
 			if (is_readable($logo))
 			{
-				$pdf->Image($logo, $this->marge_gauche, $posy, 0, 24);	// width=0 (auto), max height=24
+				$pdf->Image($logo, $this->marge_gauche, $posy, 0, 24);
 			}
 			else
 			{
@@ -1039,121 +941,65 @@ class pdf_crabe extends ModelePDFFactures
 			$pdf->MultiCell(100, 4, $outputlangs->convToOutputCharset($text), 0, 'L');
 		}
 
-		$pdf->SetFont('','B', $default_font_size + 3);
+		$pdf->SetFont('','B',$default_font_size + 3);
 		$pdf->SetXY(100,$posy);
 		$pdf->SetTextColor(0,0,60);
-		$title=$outputlangs->transnoentities("Invoice");
-		if ($object->type == 1) $title=$outputlangs->transnoentities("InvoiceReplacement");
-		if ($object->type == 2) $title=$outputlangs->transnoentities("InvoiceAvoir");
-		if ($object->type == 3) $title=$outputlangs->transnoentities("InvoiceDeposit");
-		if ($object->type == 4) $title=$outputlangs->transnoentities("InvoiceProFormat");
+		$title=$outputlangs->transnoentities("CommercialProposal");
 		$pdf->MultiCell(100, 4, $title, '' , 'R');
 
-		$pdf->SetFont('','B', $default_font_size + 2);
+		$pdf->SetFont('','B',$default_font_size + 2);
 
 		$posy+=6;
 		$pdf->SetXY(100,$posy);
 		$pdf->SetTextColor(0,0,60);
 		$pdf->MultiCell(100, 4, $outputlangs->transnoentities("Ref")." : " . $outputlangs->convToOutputCharset($object->ref), '', 'R');
 
-		$posy+=2;
-		$pdf->SetFont('','', $default_font_size - 1);
+		$posy+=1;
+		$pdf->SetFont('','', $default_font_size);
 
-		$objectidnext=$object->getIdReplacingInvoice('validated');
-		if ($object->type == 0 && $objectidnext)
+		if ($object->ref_client)
 		{
-			$objectreplacing=new Facture($this->db);
-			$objectreplacing->fetch($objectidnext);
-
-			$posy+=4;
+			$posy+=5;
 			$pdf->SetXY(100,$posy);
 			$pdf->SetTextColor(0,0,60);
-			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("ReplacementByInvoice").' : '.$outputlangs->convToOutputCharset($objectreplacing->ref), '', 'R');
-		}
-		if ($object->type == 1)
-		{
-			$objectreplaced=new Facture($this->db);
-			$objectreplaced->fetch($object->fk_facture_source);
-
-			$posy+=4;
-			$pdf->SetXY(100,$posy);
-			$pdf->SetTextColor(0,0,60);
-			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("ReplacementInvoice").' : '.$outputlangs->convToOutputCharset($objectreplaced->ref), '', 'R');
-		}
-		if ($object->type == 2)
-		{
-			$objectreplaced=new Facture($this->db);
-			$objectreplaced->fetch($object->fk_facture_source);
-
-			$posy+=4;
-			$pdf->SetXY(100,$posy);
-			$pdf->SetTextColor(0,0,60);
-			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("CorrectionInvoice").' : '.$outputlangs->convToOutputCharset($objectreplaced->ref), '', 'R');
+			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("RefCustomer")." : " . $outputlangs->convToOutputCharset($object->ref_client), '', 'R');
 		}
 
-		$posy+=4;
+		$posy+=5;
 		$pdf->SetXY(100,$posy);
 		$pdf->SetTextColor(0,0,60);
-		$pdf->MultiCell(100, 3, $outputlangs->transnoentities("DateInvoice")." : " . dol_print_date($object->date,"day",false,$outputlangs), '', 'R');
+		$pdf->MultiCell(100, 3, $outputlangs->transnoentities("Date")." : " . dol_print_date($object->date,"day",false,$outputlangs,true), '', 'R');
 
-		if ($object->type != 2)
-		{
-			$posy+=4;
-			$pdf->SetXY(100,$posy);
-			$pdf->SetTextColor(0,0,60);
-			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("DateEcheance")." : " . dol_print_date($object->date_lim_reglement,"day",false,$outputlangs,true), '', 'R');
-		}
+		$posy+=5;
+		$pdf->SetXY(100,$posy);
+		$pdf->SetTextColor(0,0,60);
+		$pdf->MultiCell(100, 3, $outputlangs->transnoentities("DateEndPropal")." : " . dol_print_date($object->fin_validite,"day",false,$outputlangs,true), '', 'R');
 
 		if ($object->client->code_client)
 		{
-			$posy+=4;
+			$posy+=5;
 			$pdf->SetXY(100,$posy);
 			$pdf->SetTextColor(0,0,60);
 			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("CustomerCode")." : " . $outputlangs->transnoentities($object->client->code_client), '', 'R');
 		}
 
-		// Add list of linked orders and proposals
-		// TODO mutualiser
-	    $object->fetchObjectLinked();
-
-	    foreach($object->linkedObjects as $objecttype => $objects)
-	    {
-	    	if ($objecttype == 'propal')
-	    	{
-	    		$outputlangs->load('propal');
-	    		$num=sizeof($objects);
-	    		for ($i=0;$i<$num;$i++)
-	    		{
-	    			$posy+=4;
-	    			$pdf->SetXY(100,$posy);
-	    			$pdf->SetFont('','', $default_font_size - 1);
-	    			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("RefProposal")." : ".$outputlangs->transnoentities($objects[$i]->ref), '', 'R');
-	    		}
-			}
-			else if ($objecttype == 'commande')
-			{
-				$outputlangs->load('orders');
-				$num=sizeof($objects);
-	    		for ($i=0;$i<$num;$i++)
-	    		{
-	    			$posy+=4;
-	    			$pdf->SetXY(100,$posy);
-	    			$pdf->SetFont('','', $default_font_size - 1);
-	    			$text=$objects[$i]->ref;
-	    			if ($objects[$i]->ref_client) $text.=' ('.$objects[$i]->ref_client.')';
-	    			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("RefOrder")." : ".$outputlangs->transnoentities($text), '', 'R');
-	    		}
-	    	}
-		}
-
 		if ($showaddress)
 		{
 			// Sender properties
-			$carac_emetteur = pdf_build_address($outputlangs,$this->emetteur);
+			$carac_emetteur='';
+		 	// Add internal contact of proposal if defined
+			$arrayidcontact=$object->getIdContact('internal','SALESREPFOLL');
+		 	if (sizeof($arrayidcontact) > 0)
+		 	{
+		 		$object->fetch_user($arrayidcontact[0]);
+		 		$carac_emetteur .= ($carac_emetteur ? "\n" : '' ).$outputlangs->transnoentities("Name").": ".$outputlangs->convToOutputCharset($object->user->getFullName($outputlangs))."\n";
+		 	}
+
+		 	$carac_emetteur .= pdf_build_address($outputlangs,$this->emetteur);
 
 			// Show sender
-			$posy=42;
 			$posx=$this->marge_gauche;
+			$posy=42;
 			$hautcadre=40;
 			if (! empty($conf->global->MAIN_INVERT_SENDER_RECIPIENT)) $posx=118;
 
@@ -1165,23 +1011,22 @@ class pdf_crabe extends ModelePDFFactures
 			$pdf->SetXY($posx,$posy);
 			$pdf->SetFillColor(230,230,230);
 			$pdf->MultiCell(82, $hautcadre, "", 0, 'R', 1);
-			$pdf->SetTextColor(0,0,60);
 
 			// Show sender name
 			$pdf->SetXY($posx+2,$posy+3);
-			$pdf->SetFont('','B', $default_font_size);
-			$pdf->MultiCell(80, 4, $outputlangs->convToOutputCharset($this->emetteur->name), 0, 'L');
+			$pdf->SetTextColor(0,0,60);
+			$pdf->SetFont('','B',$default_font_size);
+			$pdf->MultiCell(80, 3, $outputlangs->convToOutputCharset($this->emetteur->name), 0, 'L');
 
 			// Show sender information
-			$pdf->SetXY($posx+2,$posy+8);
 			$pdf->SetFont('','', $default_font_size - 1);
+			$pdf->SetXY($posx+2,$posy+8);
 			$pdf->MultiCell(80, 4, $carac_emetteur, 0, 'L');
 
 
-
-			// If BILLING contact defined on invoice, we use it
+			// If CUSTOMER contact defined, we use it
 			$usecontact=false;
-			$arrayidcontact=$object->getIdContact('external','BILLING');
+			$arrayidcontact=$object->getIdContact('external','CUSTOMER');
 			if (sizeof($arrayidcontact) > 0)
 			{
 				$usecontact=true;
@@ -1211,9 +1056,10 @@ class pdf_crabe extends ModelePDFFactures
 			// Show recipient frame
 			$pdf->SetTextColor(0,0,0);
 			$pdf->SetFont('','', $default_font_size - 2);
-			$pdf->SetXY($posx+2,$posy-5);
-			$pdf->MultiCell(80,5, $outputlangs->transnoentities("BillTo").":",0,'L');
+			$pdf->SetXY($posx,$posy-5);
+			$pdf->MultiCell(80, 4, $outputlangs->transnoentities("BillTo").":", 0, 'L');
 			$pdf->rect($posx, $posy, 100, $hautcadre);
+			$pdf->SetTextColor(0,0,0);
 
 			// Show recipient name
 			$pdf->SetXY($posx+2,$posy+3);
@@ -1228,6 +1074,41 @@ class pdf_crabe extends ModelePDFFactures
 	}
 
 	/**
+	 *   	\brief      Show the customfields in a new page
+	 *   	\param      pdf     		PDF factory
+	 * 		\param		object			Object invoice
+	 *      \param      outputlangs		Object lang for output
+	 */
+	function _pagecustomfields(&$pdf,$object,$outputlangs)
+	{
+		$default_font_size = pdf_getPDFFontSize($outputlangs);
+
+		// Init and main vars
+		include_once(DOL_DOCUMENT_ROOT.'/customfields/class/customfields.class.php');
+		$customfields = new CustomFields($this->db, '');
+
+		// Fetching the list of fields columns
+		//$fields = $customfields->fetchAllCustomFields();
+
+		// Setting the starting position of the text cursor
+		$pdf->SetXY($this->page_largeur - $this->marge_droite - ($pdf->GetStringWidth($titre) + 3), $pdf->GetY()+4);
+		$pdf->SetY($pdf->GetY()+1);
+
+		// Printing the customfields
+		foreach ($object->customfields as $field) {
+			$name = $customfields->varprefix.$field->column_name; // name of the property (this is one customfield)
+			$translatedname = $customfields->findLabelPDF($field->column_name, $outputlangs); // label of the customfield
+			$value = $customfields->printFieldPDF($field, $object->$name, $outputlangs); // value (cleaned and properly formatted) of the customfield
+
+			$pdf->SetFont('','B', $default_font_size);
+			$pdf->MultiCell(0,3, $translatedname.': '.$value, 0, 'L'); // printing the customfield
+			$pdf->SetY($pdf->GetY()+1); // line return for the next printing
+		}
+
+		return 1;
+	}
+
+	/**
 	 *   	\brief      Show footer of page
 	 *   	\param      pdf     		PDF factory
 	 * 		\param		object			Object invoice
@@ -1236,7 +1117,7 @@ class pdf_crabe extends ModelePDFFactures
 	 */
 	function _pagefoot(&$pdf,$object,$outputlangs)
 	{
-		return pdf_pagefoot($pdf,$outputlangs,'FACTURE_FREE_TEXT',$this->emetteur,$this->marge_basse,$this->marge_gauche,$this->page_hauteur,$object);
+		return pdf_pagefoot($pdf,$outputlangs,'PROPALE_FREE_TEXT',$this->emetteur,$this->marge_basse,$this->marge_gauche,$this->page_hauteur,$object);
 	}
 
 }

--- a/htdocs/includes/modules/propale/pdf_propale_customfields.modules.php
+++ b/htdocs/includes/modules/propale/pdf_propale_customfields.modules.php
@@ -276,8 +276,8 @@ class pdf_propale_customfields extends ModelePDFPropales
 
 					// Total HT ligne
 					$total_excl_tax = pdf_getlinetotalexcltax($object, $i, $outputlangs, $hidedetails);
-					$pdf->SetXY ($this->postotalht, $curY);
-					$pdf->MultiCell(26, 4, $total_excl_tax, 0, 'R', 0);
+					$pdf->SetXY ($this->postotalht-2, $curY);
+					$pdf->MultiCell($this->page_largeur-$this->marge_droite-$this->postotalht, 3, $total_excl_tax, 0, 'R', 0);
 
 					// Collecte des totaux par valeur de tva dans $this->tva["taux"]=total_tva
 					$tvaligne=$object->lines[$i]->total_tva;
@@ -639,7 +639,7 @@ class pdf_propale_customfields extends ModelePDFPropales
 		// Total HT
 		$pdf->SetFillColor(255,255,255);
 		$pdf->SetXY ($col1x, $tab2_top + 0);
-		$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("TotalHT"), 0, 'L', 1);
+		$pdf->MultiCell($this->page_largeur-$this->marge_droite-$this->postotalht,2, $outputlangs->transnoentities("TotalHT"),'','C');
 
 		$pdf->SetXY ($col2x, $tab2_top + 0);
 		$pdf->MultiCell($largcol2, $tab2_hl, price($object->total_ht + $object->remise), 0, 'R', 1);

--- a/htdocs/includes/triggers/interface_modCustomFields_SaveFields.class.php
+++ b/htdocs/includes/triggers/interface_modCustomFields_SaveFields.class.php
@@ -1,0 +1,299 @@
+<?php
+/* Copyright (C) 2011   Stephen Larroque <lrq3000@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *      \file       htdocs/includes/triggers/interface_modCustomFields_SaveFields.class.php
+ *      \ingroup    core
+ *      \brief      Core triggers file for CustomFields module. Triggers actions for the customfields module. Necessary for actions to be comitted.
+ *		\version	$Id: interface_modCustomFields_SaveFields.class.php, v1.1.0
+ */
+
+
+/**
+ *      \class      InterfaceSaveFields
+ *      \brief      Class of triggers for demo module
+ */
+class InterfaceSaveFields
+{
+    var $db;
+
+    /**
+     *   Constructor.
+     *   @param      DB      Database handler
+     */
+    function InterfaceSaveFields($DB)
+    {
+        $this->db = $DB ;
+
+        $this->name = preg_replace('/^Interface/i','',get_class($this));
+        $this->family = "module";
+        $this->description = "Triggers actions for the customfields module. Necessary for actions to be comitted.";
+        $this->version = 'dolibarr';            // 'development', 'experimental', 'dolibarr' or version
+        $this->picto = 'technic';
+    }
+
+
+    /**
+     *   Return name of trigger file
+     *   @return     string      Name of trigger file
+     */
+    function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     *   Return description of trigger file
+     *   @return     string      Description of trigger file
+     */
+    function getDesc()
+    {
+        return $this->description;
+    }
+
+    /**
+     *   Return version of trigger file
+     *   @return     string      Version of trigger file
+     */
+    function getVersion()
+    {
+        global $langs;
+        $langs->load("admin");
+
+        if ($this->version == 'development') return $langs->trans("Development");
+        elseif ($this->version == 'experimental') return $langs->trans("Experimental");
+        elseif ($this->version == 'dolibarr') return DOL_VERSION;
+        elseif ($this->version) return $this->version;
+        else return $langs->trans("Unknown");
+    }
+
+    /**
+     *      Function called when a Dolibarrr business event is done.
+     *      All functions "run_trigger" are triggered if file is inside directory htdocs/includes/triggers
+     *      @param      action      Code de l'evenement
+     *      @param      object      Objet concerne
+     *      @param      user        Objet user
+     *      @param      langs       Objet langs
+     *      @param      conf        Objet conf
+     *      @return     int         <0 if KO, 0 if no triggered ran, >0 if OK
+     */
+	function run_trigger($action,$object,$user,$langs,$conf)
+    {
+        // Put here code you want to execute when a Dolibarr business events occurs.
+        // Data and type of action are stored into $object and $action
+
+        // Products and services
+        if($action == 'PRODUCT_CREATE') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            $action = 'CUSTOMFIELDS_CREATE';
+            $object->currentmodule = 'product';
+            return $this->run_trigger($action,$object,$user,$langs,$conf);
+        }
+        elseif ($action == 'PRODUCT_CLONE') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            $action = 'CUSTOMFIELDS_CLONE';
+            $object->currentmodule = 'product';
+            $object->origin_id = GETPOST('id'); // the clone functions do not store the origin_id in the standard dolibarr package (as of v3.1b)
+            return $this->run_trigger($action,$object,$user,$langs,$conf);
+        }
+
+        // Proposals
+        elseif ($action == 'PROPAL_CREATE') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            $action = 'CUSTOMFIELDS_CREATE';
+            $object->currentmodule = 'propal';
+            return $this->run_trigger($action,$object,$user,$langs,$conf);
+        }
+        elseif ($action == 'PROPAL_CLONE') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            $action = 'CUSTOMFIELDS_CLONE';
+            $object->currentmodule = 'propal';
+            $object->origin_id = GETPOST('id'); // the clone functions do not store the origin_id in the standard dolibarr package (as of v3.1b)
+            return $this->run_trigger($action,$object,$user,$langs,$conf);
+        }
+        /* Managed by the customfields.lib.php for edition and by the SQL cascading for deletion
+        elseif ($action == 'PROPAL_MODIFY') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+        }
+        elseif ($action == 'PROPAL_DELETE') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+        } */
+        elseif($action == 'PROPAL_PREBUILDDOC') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            $action = 'CUSTOMFIELDS_PREBUILDDOC';
+            $object->currentmodule = 'propal';
+            return $this->run_trigger($action,$object,$user,$langs,$conf);
+        }
+
+        // Bills
+        elseif ($action == 'BILL_CREATE') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            $action = 'CUSTOMFIELDS_CREATE';
+            $object->currentmodule = 'facture';
+            return $this->run_trigger($action,$object,$user,$langs,$conf);
+        }
+        elseif ($action == 'BILL_CLONE') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            $action = 'CUSTOMFIELDS_CLONE';
+            $object->currentmodule = 'facture';
+            $object->origin_id = GETPOST('facid'); // the clone functions do not store the origin_id in the standard dolibarr package (as of v3.1b)
+            return $this->run_trigger($action,$object,$user,$langs,$conf);
+        }
+        /* Managed by the customfields.lib.php for edition and by the SQL cascading for deletion
+        elseif ($action == 'BILL_MODIFY') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+        }
+        elseif ($action == 'BILL_DELETE') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+        }
+        */
+        elseif ($action == 'BILL_PREBUILDDOC') {
+            $action = 'CUSTOMFIELDS_PREBUILDDOC';
+            $object->currentmodule = 'facture';
+            return $this->run_trigger($action,$object,$user,$langs,$conf);
+        }
+
+
+        /********************************** GENERIC CUSTOMFIELDS ACTION TRIGGERS **********************************/
+        // Description: to avoid duplicating code in triggers, here are a few generic dummy customfields triggers, they are never triggered by any module but here you can use them to recursively activate them (eg: you get a BILL_CREATE trigger, just call run_trigger() with $action=CUSTOMFIELDS_CREATE and pass on the other arguments you received and you're done)
+
+        elseif ($action == 'CUSTOMFIELDS_CREATE') { // Create a record
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            // Vars
+            $currentmodule = $object->currentmodule;
+
+            // Init and main vars
+            include_once(DOL_DOCUMENT_ROOT.'/customfields/class/customfields.class.php');
+            $customfields = new CustomFields($this->db, $currentmodule);
+
+            // Saving the data (creating a record)
+            $rtncode = $customfields->create($object);
+
+            // Print errors (if there are)
+            if (!empty($customfields->error) and strpos(strtolower($customfields->error), "Table '".$customfields->moduletable."' doesn't exist")) { // if the error is that the table doesn't exists, we ignore it because it is probably because the user does not use CustomFields for this module
+                dol_print_error($this->db, $customfields->error);
+            }
+
+            return $rtncode;
+        }
+        /* DELETION is automatically managed by the SGBD (sql) thank's to the constraints
+        elseif ($action == 'CUSTOMFIELDS_DELETE') {
+        }*/
+        elseif ($action == 'CUSTOMFIELDS_MODIFY') { // Modify a record (UNUSED because automatically managed by the customfields lib, this function here is just for example or possible future use, but now it's not used)
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            // Vars
+            $currentmodule = $object->currentmodule;
+
+            // Init and main vars
+            include_once(DOL_DOCUMENT_ROOT.'/customfields/class/customfields.class.php');
+            $customfields = new CustomFields($this->db, $currentmodule);
+
+            // Saving the data (creating a record)
+            $rtncode = $customfields->update($object);
+
+            // Print errors (if there are)
+            if (!empty($customfields->error) and strpos(strtolower($customfields->error), "Table '".$customfields->moduletable."' doesn't exist")) { // if the error is that the table doesn't exists, we ignore it because it is probably because the user does not use CustomFields for this module
+                dol_print_error($this->db, $customfields->error);
+            }
+
+            return $rtncode;
+        }
+        elseif ($action == 'CUSTOMFIELDS_CLONE') { // Clone a record
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            // Vars
+            $currentmodule = $object->currentmodule;
+
+            // Init and main vars
+            include_once(DOL_DOCUMENT_ROOT.'/customfields/class/customfields.class.php');
+            $customfields = new CustomFields($this->db, $currentmodule);
+
+            // Saving the data (creating a record)
+            $rtncode = $customfields->createFromClone($object->origin_id, $object->id);
+
+            // Print errors (if there are)
+            if (!empty($customfields->error) and strpos(strtolower($customfields->error), "Table '".$customfields->moduletable."' doesn't exist")) { // if the error is that the table doesn't exists, we ignore it because it is probably because the user does not use CustomFields for this module
+                dol_print_error($this->db, $customfields->error);
+            }
+
+            return $rtncode;
+        }
+        elseif ($action == 'CUSTOMFIELDS_PREBUILDDOC') {
+            dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+
+            // Vars
+            $currentmodule = $object->currentmodule;
+
+            // Init and main vars
+            include_once(DOL_DOCUMENT_ROOT.'/customfields/class/customfields.class.php');
+            $customfields = new CustomFields($this->db, $currentmodule);
+
+            // Fetching the list of fields columns
+            $fields = $customfields->fetchAllCustomFields();
+
+            // Fetching customfields data
+            $record = $customfields->fetch($object->id);
+
+            // Appending these properties to the $object which will be passed to the invoice's template
+            foreach ($fields as $field) {
+                $name = $field->column_name;
+                $prefixedname = $customfields->varprefix.$field->column_name;
+                $object->$prefixedname = $record->$name;
+                $object->customfields->$name = $field; // we maintain a list of the customfields, so that later in the PDF or ODT we can easily list all the fields (we need the column_name and the column_type but we mirror the entire field)
+
+                /** A little example of the resulting  $object :
+                 *  you will get the usual $object with all the dolibar datas, then you add :
+                 *  $object->customfieldname gives you the value of customfieldname (replace customfieldname by your custom field - and don't forget the prefix!)
+                 *  $object->customfields->customfieldname gives you the sql parameter of this field (column_type, column_name, etc...). Eg:
+                 *  $object->customfields->customfieldname->column_type gives you the type of the field (needed to use printFieldPDF efficiently)
+                 *
+                 *  For example, you can loop through each field this way :
+                 *  foreach ($object->customfields as $field) {
+			$name = $customfields->varprefix.$field->column_name; // name of the property (this is one customfield)
+			$translatedname = $outputlangs->trans($field->column_name); // label of the customfield
+			$value = $customfields->printFieldPDF($field, $object->$name, $outputlangs); // value (cleaned and properly formatted) of the customfield
+
+                        $pdf->MultiCell(0,3, $translatedname.': '.$value, 0, 'L'); // printing the customfield
+			$pdf->SetY($pdf->GetY()+1); // line return for the next printing
+                    }
+
+                    Exactly as if you'd have fetched the record from the database :
+                    $fields = $customfields->fetchAllCustomFields();
+                    foreach ($fields as $field) {
+                        etc... same as above
+
+                    }
+                 */
+            }
+
+            return 1;
+        }
+
+	return 0;
+    }
+
+}
+?>

--- a/htdocs/langs/fr_FR/paybox.lang
+++ b/htdocs/langs/fr_FR/paybox.lang
@@ -4,7 +4,7 @@ PayBoxSetup=Configuration module PayBox
 PayBoxDesc=Ce module permet d'offrir une page de paiement via le prestataire <a href="http://www.paybox.com" target="_blank">Paybox</a> pour réaliser un paiement quelconque ou un paiement par rapport à un objet Dolibarr (factures, commande...)
 PaymentForm=Formulaire de paiement
 FollowingUrlAreAvailableToMakePayments=Les URL suivantes sont disponibles pour permettre à un client de faire un paiement
-WelcomeOnPaymentPage=Bienvenu sur notre service de paiement en ligne
+WelcomeOnPaymentPage=Bienvenue sur notre service de paiement en ligne
 ThisScreenAllowsYouToPay=Cet écran vous permet de réaliser votre paiement en ligne à destination de %s.
 ThisIsInformationOnPayment=Voici les informations sur le paiement à réaliser
 ToComplete=A compléter
@@ -22,8 +22,8 @@ ToOfferALinkForOnlinePaymentOnFreeAmount=URL offrant une interface de paiement e
 ToOfferALinkForOnlinePaymentOnMemberSubscription=URL offrant une interface de paiement en ligne %s sur la base d'une cotisation d'adhérent
 YouCanAddTagOnUrl=Vous pouvez de plus ajouter le paramètre url <b>&tag=<i>value</i></b> à n'importe quelles de ces URL (obligatoire pour le paiement libre uniquement) pour ajouter votre propre "code commentaire" du paiement.
 SetupPayBoxToHavePaymentCreatedAutomatically=Configurez votre url PayBox à <b>%s</b> pour avoir le paiement créé automatiquement si validé.
-YourPaymentHasBeenRecorded=Cette page confirme que votre paiement a bien été enregistré. Merci.
-YourPaymentHasNotBeenRecorded=Votre paiement n'a pas été enregistré et la transaction a été annulée. Merci.
+YourPaymentHasBeenRecorded=Cette page confirme que votre paiement a bien été enregistré.
+YourPaymentHasNotBeenRecorded=Votre paiement n'a pas été enregistré et la transaction a été annulée.
 AccountParameter=Paramètres du compte
 UsageParameter=Paramètres d'utilisation
 InformationToFindParameters=Informations pour trouver vos paramètres de compte %s

--- a/htdocs/langs/fr_FR/paypal.lang
+++ b/htdocs/langs/fr_FR/paypal.lang
@@ -14,5 +14,5 @@ PAYPAL_CSS_URL=Url optionnelle de la feuille de style CSS de la page de paiement
 ThisIsTransactionId=Voici l'identifiant de la transaction: <b>%s</b>
 PAYPAL_ADD_PAYMENT_URL=Ajouter l'url de paiement Paypal lors de l'envoi d'un document par mail
 PAYPAL_IPN_MAIL_ADDRESS=Adresse e-mail pour les notifications instantanées de paiement (IPN)
-PredefinedMailContentSendOrderWithPaypalLink=Veuillez trouver ci-joint la commande __ORDERREF__\n\nVous pouvez cliquer sur le lien sécurisé ci-dessous pour effectuer votre paiement via Paypal\n\n%s\n\nCordialement\n\n
-PredefinedMailContentSendInvoiceWithPaypalLink=Veuillez trouver ci-joint la facture __FACREF__\n\nVous pouvez cliquer sur le lien sécurisé ci-dessous pour effectuer votre paiement via Paypal\n\n%s\n\nCordialement\n\n
+PredefinedMailContentSendOrderWithPaypalLink=Bonjour,\nVeuillez trouver ci-joint la commande __ORDERREF__\n\nVous pouvez cliquer sur le lien sécurisé ci-dessous pour effectuer votre paiement via Paypal\n\n%s\n\nCordialement\n\n
+PredefinedMailContentSendInvoiceWithPaypalLink=Bonjour,\nVeuillez trouver ci-joint la facture __FACREF__\n\nVous pouvez cliquer sur le lien sécurisé ci-dessous pour effectuer votre paiement via Paypal\n\n%s\n\nCordialement\n\n

--- a/htdocs/livraison/fiche.php
+++ b/htdocs/livraison/fiche.php
@@ -117,7 +117,7 @@ if ($_REQUEST["action"] == 'confirm_valid' && $_REQUEST["confirm"] == 'yes' && $
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($newlang);
 	}
-	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) $result=delivery_order_pdf_create($db, $delivery,$_REQUEST['model'],$outputlangs);
+	if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) $result=delivery_order_pdf_create($db, $delivery,$_REQUEST['model'],$outputlangs);
 	if ($result <= 0)
 	{
 		dol_print_error($db,$result);

--- a/htdocs/livraison/fiche.php
+++ b/htdocs/livraison/fiche.php
@@ -117,7 +117,7 @@ if ($_REQUEST["action"] == 'confirm_valid' && $_REQUEST["confirm"] == 'yes' && $
 		$outputlangs = new Translate("",$conf);
 		$outputlangs->setDefaultLang($newlang);
 	}
-	$result=delivery_order_pdf_create($db, $delivery,$_REQUEST['model'],$outputlangs);
+	if (! empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) $result=delivery_order_pdf_create($db, $delivery,$_REQUEST['model'],$outputlangs);
 	if ($result <= 0)
 	{
 		dol_print_error($db,$result);

--- a/htdocs/product/fiche.php
+++ b/htdocs/product/fiche.php
@@ -130,6 +130,10 @@ if ($action == 'add' && ($user->rights->produit->creer || $user->rights->service
 
 	$product=new Product($db);
 
+	foreach ($_POST as $key=>$value) { // Generic way to fill all the fields to the object (particularly useful for triggers and customfields)
+		$product->$key = $value;
+	}
+
 	$usecanvas=$_POST["canvas"];
 	if (empty($conf->global->MAIN_USE_CANVAS)) $usecanvas=0;
 
@@ -768,6 +772,15 @@ if ($action == 'create' && ($user->rights->produit->creer || $user->rights->serv
 		$doleditor->Create();
 
 		print "</td></tr>";
+
+		// CustomFields : print fields at creation
+		if ($conf->global->MAIN_MODULE_CUSTOMFIELDS) { // if the customfields module is activated...
+		    $currentmodule = 'product';
+
+		    include_once(DOL_DOCUMENT_ROOT.'/customfields/lib/customfields.lib.php');
+		    customfields_print_creation_form($currentmodule);
+		}
+
 		print '</table>';
 
 		print '<br>';
@@ -1166,6 +1179,24 @@ if ($id || $ref)
 		{
 			$canvas->assign_values('view');
 			$canvas->display_canvas();
+		}
+
+		// CUSTOMFIELDS : Main form printing and editing functions
+		if ($conf->global->MAIN_MODULE_CUSTOMFIELDS) { // if the customfields module is activated...
+		print '<br>';
+		$currentmodule = 'product';
+		$idvar = 'id';
+
+		// We use different rights depending on the product type (product or service?)
+		// we need to supply it in the $rights var because product module has not the same name in rights property
+		if ($product->type == 0) {
+			$rights = 'produit';
+		} elseif ($product->type == 1) {
+			$rights = 'service';
+		}
+
+		include_once(DOL_DOCUMENT_ROOT.'/customfields/lib/customfields.lib.php');
+		customfields_print_main_form($currentmodule, $product, $action, $user, $idvar, $rights);
 		}
 
 		dol_fiche_end();

--- a/htdocs/public/paypal/newpayment.php
+++ b/htdocs/public/paypal/newpayment.php
@@ -80,8 +80,8 @@ if (! GETPOST("action"))
 }
 
 $urlwithouturlroot=preg_replace('/'.preg_quote(DOL_URL_ROOT,'/').'$/i','',$dolibarr_main_url_root);
-$urlok=$urlwithouturlroot.DOL_URL_ROOT.'/public/paypal/paymentok.php?';
-$urlko=$urlwithouturlroot.DOL_URL_ROOT.'/public/paypal/paymentko.php?';
+$urlok=$urlwithouturlroot.DOL_URL_ROOT.'/htdocs/public/paypal/paymentok.php?';
+$urlko=$urlwithouturlroot.DOL_URL_ROOT.'/htdocs/public/paypal/paymentko.php?';
 
 // Complete urls for post treatment
 $SOURCE=GETPOST("source",'alpha');
@@ -309,7 +309,7 @@ $valid=true;
 if (! empty($conf->global->PAYPAL_SECURITY_TOKEN) )
 {
 	$token = $conf->global->PAYPAL_SECURITY_TOKEN;
-	if ($SECUREKEY != $token) $valid=false;
+	if ($SECUREKEY != $token and $SECUREKEY != dol_hash($conf->global->PAYPAL_SECURITY_TOKEN.GETPOST("source").GETPOST("ref"), 2)) $valid=false;
 }
 
 // Free payment


### PR DESCRIPTION
J'ai corrigé la méthode d'export sans mysqldump, j'ai corrigé pas mal de bugs et ajouté pas mal de fonctionnalités. J'ai calqué les fichiers générés par mysqldump (avec les options par défaut), ce qui fait que cette méthode génère maintenant un dump quasi identique (la seule chose qui change ce sont les INSERT qui sont découpés en plusieurs au lieu d'être concaténés en un seul avec un Values multi dimensionnel). J'ai testé l'import, tout a semblé OK (testé sur une base utilisée en production).
