### PR TITLE
Fix first activation of some modules on PgSQL

### DIFF
--- a/htdocs/core/class/menubase.class.php
+++ b/htdocs/core/class/menubase.class.php
@@ -107,22 +107,22 @@ class Menubase
         // an insert with a forced id.
         if (in_array($this->db->type,array('pgsql')))
         {
-			$sql = "SELECT MAX(rowid) as maxrowid FROM ".MAIN_DB_PREFIX."menu";
-        	$resqlrowid=$this->db->query($sql);
-        	if ($resqlrowid)
-        	{
-        		$obj=$this->db->fetch_object($resqlrowid);
-        		$maxrowid=$obj->maxrowid;
+          $sql = "SELECT MAX(rowid) as maxrowid FROM ".MAIN_DB_PREFIX."menu";
+          $resqlrowid=$this->db->query($sql);
+          if ($resqlrowid)
+          {
+               $obj=$this->db->fetch_object($resqlrowid);
+               $maxrowid=$obj->maxrowid;
 
-                        // Max rowid can be empty if there is no record yet
-                        if(empty($maxrowid)) $maxrowid=1;
+               // Max rowid can be empty if there is no record yet
+               if(empty($maxrowid)) $maxrowid=1;
 
-                        $sql = "SELECT setval('".MAIN_DB_PREFIX."menu_rowid_seq', ".($maxrowid).")";
-                        //print $sql; exit;
-	        	$resqlrowidset=$this->db->query($sql);
-	     		if (! $resqlrowidset) dol_print_error($this->db);
-        	}
-        	else dol_print_error($this->db);
+               $sql = "SELECT setval('".MAIN_DB_PREFIX."menu_rowid_seq', ".($maxrowid).")";
+               //print $sql; exit;
+               $resqlrowidset=$this->db->query($sql);
+               if (! $resqlrowidset) dol_print_error($this->db);
+          }
+          else dol_print_error($this->db);
         }
 
         // Insert request

--- a/htdocs/core/class/menubase.class.php
+++ b/htdocs/core/class/menubase.class.php
@@ -114,7 +114,11 @@ class Menubase
         		$obj=$this->db->fetch_object($resqlrowid);
         		$maxrowid=$obj->maxrowid;
 
-        		$sql = "SELECT setval('".MAIN_DB_PREFIX."menu_rowid_seq', ".($maxrowid).")";
+                        // Max rowid can be empty if there is no record yet
+                        if(empty($maxrowid)) $maxrowid=1;
+
+                        $sql = "SELECT setval('".MAIN_DB_PREFIX."menu_rowid_seq', ".($maxrowid).")";
+                        //print $sql; exit;
 	        	$resqlrowidset=$this->db->query($sql);
 	     		if (! $resqlrowidset) dol_print_error($this->db);
         	}


### PR DESCRIPTION
This fixes the activation of some modules with PgSQL database.
Without, the resulting SQL query fails because the last parameter is empty.
This also applies to 3.2.

The main change is :

``` php
// Max rowid can be empty if there is no record yet
if(empty($maxrowid)) $maxrowid=1;
```

The rest is indentation madness…
