### PR TITLE
Fix : use lastname to test contact ldap synchro (not name)

### DIFF
--- a/htdocs/contact/class/contact.class.php
+++ b/htdocs/contact/class/contact.class.php
@@ -1013,7 +1013,7 @@ class Contact extends CommonObject
 		// Initialise parameters
 		$this->id=0;
 		$this->specimen=1;
-		$this->name = 'DOLIBARR';
+		$this->lastname = 'DOLIBARR';
 		$this->firstname = 'SPECIMEN';
 		$this->address = '61 jump street';
 		$this->zip = '75000';


### PR DESCRIPTION
Without lastname 'sn' attribute was empty but required by ldap object class (inetOrgPerson).
