### PR TITLE
The tab Documents of the Contracts module wasn't being translated

### DIFF
--- a/htdocs/contrat/document.php
+++ b/htdocs/contrat/document.php
@@ -34,7 +34,7 @@ require_once(DOL_DOCUMENT_ROOT."/core/class/html.formfile.class.php");
 
 $langs->load("other");
 $langs->load("products");
-
+$langs->load("contracts");
 
 $action		= GETPOST('action','alpha');
 $confirm	= GETPOST('confirm','alpha');


### PR DESCRIPTION
The function `contract_prepare_head` wasn't getting the correct translation as in document.php the contract lang file wasn't being loaded.

Before:
![Before](http://box.jisko.net/i/28704e2f.png)

After:
![Before](http://box.jisko.net/i/44233fe1.png)
