### PR TITLE
Replaced "Seconds" for "seconds"

### DIFF
--- a/htdocs/admin/proxy.php
+++ b/htdocs/admin/proxy.php
@@ -123,7 +123,7 @@ print '<td>'.$langs->trans("ConnectionTimeout").'</td><td align="right">';
 print '</td>';
 print '<td nowrap="nowrap">';
 print '<input class="flat" name="MAIN_USE_CONNECT_TIMEOUT" type="text" size="4" value="'.$conf->global->MAIN_USE_CONNECT_TIMEOUT.'">';
-print ' '.$langs->trans("seconds");
+print ' '.strtolower($langs->trans("Seconds"));
 print '</td>';
 print '</tr>';
 
@@ -134,7 +134,7 @@ print '<td>'.$langs->trans("ResponseTimeout").'</td><td align="right">';
 print '</td>';
 print '<td nowrap="nowrap">';
 print '<input class="flat" name="MAIN_USE_RESPONSE_TIMEOUT" type="text" size="4" value="'.$conf->global->MAIN_USE_RESPONSE_TIMEOUT.'">';
-print ' '.$langs->trans("seconds");
+print ' '.strtolower($langs->trans("Seconds"));
 print '</td>';
 print '</tr>';
 

--- a/htdocs/admin/security_other.php
+++ b/htdocs/admin/security_other.php
@@ -171,7 +171,7 @@ print '<td>'.$langs->trans("SessionTimeOut").'</td><td align="right">';
 print $form->textwithpicto('',$langs->trans("SessionExplanation",ini_get("session.gc_probability"),ini_get("session.gc_divisor")));
 print '</td>';
 print '<td nowrap="nowrap">';
-print '<input class="flat" name="MAIN_SESSION_TIMEOUT" type="text" size="6" value="'.htmlentities($conf->global->MAIN_SESSION_TIMEOUT).'"> '.$langs->trans("seconds");
+print '<input class="flat" name="MAIN_SESSION_TIMEOUT" type="text" size="6" value="'.htmlentities($conf->global->MAIN_SESSION_TIMEOUT).'"> '.strtolower($langs->trans("Seconds"));
 print '</td>';
 print '<td align="right">';
 print '<input type="submit" class="button" name="button" value="'.$langs->trans("Modify").'">';


### PR DESCRIPTION
The string "seconds" was not being translated as it doesn't exist. Did the trick changing "seconds" to "Seconds" and doing `strtolower` on it.

I think this is the faster way to fix it.

Might affect develop branch.
