### PR TITLE
Fixed 2 fatal errors in commande/fiche.php and a SQL problem too

### DIFF
--- a/htdocs/commande/fiche.php
+++ b/htdocs/commande/fiche.php
@@ -620,10 +620,10 @@ else if ($action == 'addline' && $user->rights->commande->creer)
 
 		// ajout prix achat
 		$fk_fournprice = GETPOST('np_fournprice');
-		if (GETPOST('np_buying_price'))
-			$pa_ht = GETPOST('np_buying_price');
-		else
-			$pa_ht = null;
+		$pa_ht = GETPOST('np_buying_price');
+
+		if (!$fk_fournprice) $fk_fournprice = null;
+		if (!$pa_ht) $pa_ht = null;
 
 		$info_bits=0;
 		if ($tva_npr) $info_bits |= 0x01;


### PR DESCRIPTION
Fixed a SQL error that happened when adding a new line into commande/fiche.php. It was caused because fk_fournprice was empty and not being replaced by 'null'

Also, using `isset(GETPOST())` it's not allowed.

Maybe you should replace `(!$pa_ht)` for `(empty($pa_ht))`. I don't really know...
