### PR TITLE
Fixed a PHP fatal error warning in remisecheque.class.php

### DIFF
--- a/htdocs/compta/paiement/cheque/class/remisecheque.class.php
+++ b/htdocs/compta/paiement/cheque/class/remisecheque.class.php
@@ -47,7 +47,7 @@ class RemiseCheque extends CommonObject
 	 */
 	function RemiseCheque($db)
 	{
-		$this->db = $DB;
+		$this->db = $db;
 		$this->next_id = 0;
 		$this->previous_id = 0;
 	}


### PR DESCRIPTION
Fatal error: Call to a member function query() on a non-object in /htdocs/compta/paiement/cheque/class/remisecheque.class.php on line 453
