### PR TITLE
Propal stats weren't showing average total for more than 1 year

### DIFF
--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2003      Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (C) 2004-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012 Regis Houssin        <regis@dolibarr.fr>
+ * Copyright (C) 2012      Marcos García        <marcosgdf@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,7 +67,6 @@ $stats = new PropaleStats($db, $socid, $userid);
 
 // Build graphic number of object
 $data = $stats->getNbByMonthWithPrevYear($endyear,$startyear);
-//var_dump($data);
 // $data = array(array('Lib',val1,val2,val3),...)
 
 
@@ -110,7 +110,6 @@ if (! $mesg)
 
 // Build graphic amount of object
 $data = $stats->getAmountByMonthWithPrevYear($endyear,$startyear);
-//var_dump($data);
 // $data = array(array('Lib',val1,val2,val3),...)
 
 if (!$user->rights->societe->client->voir || $user->societe_id)
@@ -151,13 +150,7 @@ if (! $mesg)
     $px2->draw($filenameamount,$fileurlamount);
 }
 
-
-$res = $stats->getAverageByMonth($year);
-$data = array();
-for ($i = 1 ; $i < 13 ; $i++)
-{
-    $data[$i-1] = array(ucfirst(dol_substr(dol_print_date(dol_mktime(12,0,0,$i,1,$year),"%b"),0,3)), $res[$i]);
-}
+$data = $stats->getAverageByMonthWithPrevYear($endyear, $startyear);
 
 $fileurl_avg='';
 if (! isset($mode)) $mode=''; // TODO $mode not defined ?
@@ -179,8 +172,7 @@ $mesg = $px3->isGraphKo();
 if (! $mesg)
 {
     $px3->SetData($data);
-    //$i=$startyear;$legend=array();
-    $i=$endyear;$legend=array();
+    $i=$startyear;$legend=array();
     while ($i <= $endyear)
     {
         $legend[]=$i;

--- a/htdocs/core/class/stats.class.php
+++ b/htdocs/core/class/stats.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2003		Rodolphe Quiedeville	<rodolphe@quiedeville.org>
  * Copyright (c) 2008-2012	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2012		Regis Houssin			<regis@dolibarr.fr>
+ * Copyright (C) 2012       Marcos García           <marcosgdf@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -85,6 +86,42 @@ abstract class Stats
 		while($year <= $endyear)
 		{
 			$datay[$year] = $this->getAmountByMonth($year);
+			$year++;
+		}
+
+		$data = array();
+
+		for ($i = 0 ; $i < 12 ; $i++)
+		{
+			$data[$i][]=$datay[$endyear][$i][0];
+			$year=$startyear;
+			while($year <= $endyear)
+			{
+				$data[$i][]=$datay[$year][$i][1];
+				$year++;
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Return average of entity by month for several years
+	 *
+	 * @param	int		$endyear		Start year
+	 * @param	int		$startyear		End year
+	 * @return 	array					Array of values
+	 */
+	function getAverageByMonthWithPrevYear($endyear,$startyear)
+	{
+        if ($startyear > $endyear) return -1;
+
+        $datay=array();
+
+		$year=$startyear;
+		while($year <= $endyear)
+		{
+			$datay[$year] = $this->getAverageByMonth($year);
 			$year++;
 		}
 
@@ -299,7 +336,16 @@ abstract class Stats
 			$res[$i] = (isset($result[$i])?$result[$i]:0);
 		}
 
-		return $res;
+		$data = array();
+
+		for ($i = 1 ; $i < 13 ; $i++)
+		{
+			$month=dol_print_date(dol_mktime(12,0,0,$i,1,$year),"%b");
+			$month=dol_substr($month,0,3);
+			$data[$i-1] = array(ucfirst($month), $res[$i]);
+		}
+
+		return $data;
 	}
 }
 


### PR DESCRIPTION
When visiting http://dolibarr-fork.local/comm/propal/stats/index.php, the "AmountAverage" graph only shows the last year bars, it doesn't loads the previous year bars.

_Should do cherry-pick for 3.2.1_
