### PR TITLE
Fix: mysqlnobin export method now works better + more options...

### DIFF
--- a/htdocs/admin/tools/dolibarr_export.php
+++ b/htdocs/admin/tools/dolibarr_export.php
@@ -76,7 +76,7 @@ jQuery(document).ready(function() {
 
 	function hideoptions () {
 		jQuery("#mysql_options").hide();
-		jQuery("#mysql_options_nobin").hide();
+		jQuery("#mysql_nobin_options").hide();
 		jQuery("#postgresql_options").hide();
 	}
 
@@ -87,7 +87,7 @@ jQuery(document).ready(function() {
 	});
 	jQuery("#radio_dump_mysql_nobin").click(function() {
 		hideoptions();
-		jQuery("#mysql_options_nobin").show();
+		jQuery("#mysql_nobin_options").show();
 	});
 	jQuery("#radio_dump_postgresql").click(function() {
 		hideoptions();
@@ -255,6 +255,50 @@ print $langs->trans("BackupDescY").'<br><br>';
 
 			</fieldset>
 			</fieldset>
+
+                        <!--  Fieldset mysql_nobin -->
+			<fieldset id="mysql_nobin_options"><legend><?php echo $langs->trans("MySqlExportParameters"); ?></legend>
+                            <fieldset>
+                                <legend><?php echo $langs->trans("ExportOptions"); ?></legend>
+                                <div class="formelementrow"><input type="checkbox"
+                                        name="nobin_use_transaction" value="yes" id="checkbox_use_transaction" /> <label
+                                        for="checkbox_use_transaction"> <?php echo $langs->trans("UseTransactionnalMode"); ?></label>
+
+                                </div>
+
+                                <div class="formelementrow"><input type="checkbox" name="nobin_disable_fk"
+                                        value="yes" id="checkbox_disable_fk" checked="checked" /> <label
+                                        for="checkbox_disable_fk"> <?php echo $langs->trans("CommandsToDisableForeignKeysForImport"); ?><?php print img_warning('Mandatory if you want to be able to restore your sql dump later'); ?></label>
+                                </div>
+                            </fieldset>
+
+                            <br>
+                            <fieldset><legend>Structure</legend> <input
+                                    type="checkbox" name="nobin_drop" value="1" id="checkbox_dump_drop" /> <label
+                                    for="checkbox_dump_drop"><?php echo $langs->trans("AddDropTable"); ?></label><br>
+                            </fieldset>
+
+                            <br>
+                            <fieldset>
+                                <legend><?php echo $langs->trans("Datas"); ?></legend>
+
+                                <input type="checkbox" name="nobin_nolocks" value="no"
+                                        id="checkbox_dump_disable-add-locks" /> <label
+                                        for="checkbox_dump_disable-add-locks"> <?php echo $langs->trans("NoLockBeforeInsert"); ?></label><br>
+
+                                <input type="checkbox" name="nobin_delayed" value="yes"
+                                        id="checkbox_dump_delayed" /> <label for="checkbox_dump_delayed"> <?php echo $langs->trans("DelayedInsert"); ?></label><br>
+
+                                <input type="checkbox" name="nobin_sql_ignore" value="yes"
+                                        id="checkbox_dump_ignore" /> <label for="checkbox_dump_ignore"> <?php echo $langs->trans("IgnoreDuplicateRecords"); ?></label><br>
+
+                                <input type="checkbox" name="nobin_charset_utf8" value="yes"
+                                        id="checkbox_charset_utf8" checked="checked" disabled="disabled" /> <label
+                                        for="checkbox_charset_utf8"> <?php echo $langs->trans("UTF8"); ?></label><br>
+
+                            </fieldset>
+			</fieldset>
+
 		<?php
 		}
 

--- a/htdocs/admin/tools/export.php
+++ b/htdocs/admin/tools/export.php
@@ -422,23 +422,31 @@ function backup_tables($outputfile, $tables='*')
 -- ------------------------------------------------------
 -- Server version	".$db->db->server_info."
 
-SET FOREIGN_KEY_CHECKS=0;
-SET SQL_MODE=\"NO_AUTO_VALUE_ON_ZERO\";
-
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8 */;
+
 ";
+
+    if (GETPOST("nobin_disable_fk")) $sqlhead .= "SET FOREIGN_KEY_CHECKS=0;\n";
+    $sqlhead .= "SET SQL_MODE=\"NO_AUTO_VALUE_ON_ZERO\";\n";
+    if (GETPOST("nobin_use_transaction")) $sqlhead .= "SET AUTOCOMMIT=0;\nSTART TRANSACTION;\n";
+
     fwrite($handle, $sqlhead);
+
+    $ignore = '';
+    if (GETPOST("nobin_sql_ignore")) $ignore = 'IGNORE ';
+    $delayed = '';
+    if (GETPOST("nobin_delayed")) $delayed = 'DELAYED ';
 
     // Process each table and print their definition + their datas
     foreach($tables as $table)
     {
         // Saving the table structure
-        fwrite($handle, "--\n-- Table structure for table `".$table."`\n--\n\n");
+        fwrite($handle, "\n--\n-- Table structure for table `".$table."`\n--\n");
 
-        //fwrite($handle,"DROP TABLE IF EXISTS `".$table."`;\n"); // Dropping table if exists prior to re create it
+        if (GETPOST("nobin_drop")) fwrite($handle,"DROP TABLE IF EXISTS `".$table."`;\n"); // Dropping table if exists prior to re create it
         //fwrite($handle,"/*!40101 SET @saved_cs_client     = @@character_set_client */;\n");
         //fwrite($handle,"/*!40101 SET character_set_client = utf8 */;\n");
         $resqldrop=$db->query('SHOW CREATE TABLE '.$table);
@@ -448,18 +456,17 @@ SET SQL_MODE=\"NO_AUTO_VALUE_ON_ZERO\";
 
 
         // Dumping the data (locking the table and disabling the keys check while doing the process)
-        fwrite($handle, "--\n-- Dumping data for table `".$table."`\n--\n\n");
-        //fwrite($handle, "LOCK TABLES `".$table."` WRITE;\n"); // Lock the table before inserting data (when the data will be imported back)
-        fwrite($handle, "ALTER TABLE `".$table."` DISABLE KEYS;\n");
+        fwrite($handle, "\n--\n-- Dumping data for table `".$table."`\n--\n");
+        if (!GETPOST("nobin_nolocks")) fwrite($handle, "LOCK TABLES `".$table."` WRITE;\n"); // Lock the table before inserting data (when the data will be imported back)
+        if (GETPOST("nobin_disable_fk")) fwrite($handle, "ALTER TABLE `".$table."` DISABLE KEYS;\n");
 
         $sql='SELECT * FROM '.$table;
         $result = $db->query($sql);
         $num_fields = $db->num_rows($result);
         while($row = $db->fetch_row($result)) {
             // For each row of data we print a line of INSERT
-            fwrite($handle,'INSERT INTO `'.$table.'` VALUES (');
+            fwrite($handle,'INSERT '.$delayed.$ignore.'INTO `'.$table.'` VALUES (');
             $columns = count($row);
-            $rowsarr = array();
             for($j=0; $j<$columns; $j++) {
                 // Processing each columns of the row to ensure that we correctly save the value (eg: add quotes for string - in fact we add quotes for everything, it's easier)
                 if ($row[$j] == null and !is_string($row[$j])) {
@@ -479,8 +486,8 @@ SET SQL_MODE=\"NO_AUTO_VALUE_ON_ZERO\";
             }
             fwrite($handle,implode(',', $row).");\n");
         }
-        fwrite($handle, "ALTER TABLE `".$table."` ENABLE KEYS;\n"); // Enabling back the keys/index checking
-        //fwrite($handle, "UNLOCK TABLES;\n"); // Unlocking the table
+        if (GETPOST("nobin_disable_fk")) fwrite($handle, "ALTER TABLE `".$table."` ENABLE KEYS;\n"); // Enabling back the keys/index checking
+        if (!GETPOST("nobin_nolocks")) fwrite($handle, "UNLOCK TABLES;\n"); // Unlocking the table
         fwrite($handle,"\n\n\n");
     }
 
@@ -504,11 +511,10 @@ SET SQL_MODE=\"NO_AUTO_VALUE_ON_ZERO\";
     /* Backup Procedure structure*/
 
     // Write the footer (restore the previous database settings)
-    $sqlfooter='';
-    $sqlfooter.="
-SET FOREIGN_KEY_CHECKS=1;
-
--- Dump completed on ".date('Y-m-d G-i-s');
+    $sqlfooter="\n\n";
+    if (GETPOST("nobin_use_transaction")) $sqlfooter .= "COMMIT;\n";
+    if (GETPOST("nobin_disable_fk")) $sqlfooter .= "SET FOREIGN_KEY_CHECKS=1;\n";
+    $sqlfooter.="\n\n-- Dump completed on ".date('Y-m-d G-i-s');
     fwrite($handle, $sqlfooter);
 
     fclose($handle);


### PR DESCRIPTION
...(avoid duplicates values errors when a number is in fact a string and foreign keys checks are always disabled when restoring).

I also updated the wiki about saving and restoring Dolibarr's backups, particularly the database part (both in english and french).

Another thing: I wanted to add a mysqlnobin method to restore a backup, but I couldn't understand how dolibarr_import.php works (there's not even a <form> html element, does it really work?), but if you're interested this function would be based on this one:

http://dan.cx/blog/2006/12/restore-mysql-dump-using-php

Pretty simple but supports multi-line SQL statements, so in my books that should be ok.

/EDIT: added options for the mysqlnobin method (I tried to add as many options I could, for the rest, the user can just use phpMyAdmin or mysqldump).
