### PR TITLE
A lot of hooks and triggers implemented + custom substitution function for lines in ODT

### DIFF
--- a/htdocs/comm/action/fiche.php
+++ b/htdocs/comm/action/fiche.php
@@ -62,6 +62,11 @@ $actioncomm = new ActionComm($db);
 $contact = new Contact($db);
 //var_dump($_POST);
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('actioncard'));
+
 
 /*
  * Action creation de l'action
@@ -566,6 +571,10 @@ if ($action == 'create')
     $doleditor->Create();
     print '</td></tr>';
 
+        // Other attributes
+        $parameters=array();
+        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$actioncomm,$action);    // Note that $action and $object may have been modified by hook
+
 	print '</table>';
 
 	print '<center><br>';
@@ -943,6 +952,10 @@ if ($id)
 		print '<tr><td valign="top">'.$langs->trans("Description").'</td><td colspan="3">';
 		print dol_htmlentitiesbr($act->note);
 		print '</td></tr>';
+
+                // Other attributes
+                $parameters=array();
+                $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$act,$action);    // Note that $action and $object may have been modified by hook
 
 		print '</table>';
 	}

--- a/htdocs/compta/deplacement/class/deplacement.class.php
+++ b/htdocs/compta/deplacement/class/deplacement.class.php
@@ -122,6 +122,16 @@ class Deplacement extends CommonObject
 		if ($result)
 		{
 			$this->id = $this->db->last_insert_id(MAIN_DB_PREFIX."deplacement");
+
+                        // Appel des triggers
+			include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
+			$interface=new Interfaces($this->db);
+			$result=$interface->run_triggers('DEPLACEMENT_CREATE',$this,$user,$langs,$conf);
+			if ($result < 0) {
+				$error++; $this->errors=$interface->errors;
+			}
+			// Fin appel triggers
+
 			$result=$this->update($user);
 			if ($result > 0)
 			{

--- a/htdocs/compta/deplacement/fiche.php
+++ b/htdocs/compta/deplacement/fiche.php
@@ -48,6 +48,11 @@ $mesg = '';
 
 $object = new Deplacement($db);
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('tripsandexpensescard'));
+
 
 /*
  * Actions
@@ -317,6 +322,10 @@ if ($action == 'create')
         print '</td></tr>';
     }
 
+    // Other attributes
+    $parameters=array('colspan' => ' colspan="2"');
+    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
+
     print '</table>';
 
     print '<br><center><input class="button" type="submit" value="'.$langs->trans("Save").'"> &nbsp; &nbsp; ';
@@ -407,6 +416,10 @@ else if ($id)
 
                 print "</td></tr>";
             }
+
+            // Other attributes
+            $parameters=array('colspan' => ' colspan="3"');
+            $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
 
             print '</table>';
 
@@ -507,6 +520,10 @@ else if ($id)
 
             // Statut
             print '<tr><td>'.$langs->trans("Status").'</td><td>'.$object->getLibStatut(4).'</td></tr>';
+
+            // Other attributes
+            $parameters=array('colspan' => ' colspan="3"');
+            $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
 
             print "</table><br>";
 

--- a/htdocs/compta/dons/class/don.class.php
+++ b/htdocs/compta/dons/class/don.class.php
@@ -352,7 +352,18 @@ class Don extends CommonObject
         $result = $this->db->query($sql);
         if ($result)
         {
-            return $this->db->last_insert_id(MAIN_DB_PREFIX."don");
+            $this->id = $this->db->last_insert_id(MAIN_DB_PREFIX."don");
+
+            // Appel des triggers
+            include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
+            $interface=new Interfaces($this->db);
+            $result=$interface->run_triggers('DON_CREATE',$this,$user,$langs,$conf);
+            if ($result < 0) {
+                    $error++; $this->errors=$interface->errors;
+            }
+            // Fin appel triggers
+
+            return $this->id;
         }
         else
         {

--- a/htdocs/compta/dons/fiche.php
+++ b/htdocs/compta/dons/fiche.php
@@ -49,6 +49,11 @@ $donation_date=dol_mktime(12, 0, 0, GETPOST('remonth'), GETPOST('reday'), GETPOS
 // Security check
 $result = restrictedArea($user, 'don', $id);
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('doncard'));
+
 
 /*
  * Actions
@@ -321,6 +326,10 @@ if ($action == 'create')
         print "</td></tr>\n";
     }
 
+    // Other attributes
+    $parameters=array('colspan' => ' colspan="1"');
+    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$don,$action);    // Note that $action and $object may have been modified by hook
+
 	print "</table>\n";
 	print '<br><center><input type="submit" class="button" name="save" value="'.$langs->trans("Save").'"> &nbsp; &nbsp; <input type="submit" class="button" name="cancel" value="'.$langs->trans("Cancel").'"></center>';
 	print "</form>\n";
@@ -410,6 +419,10 @@ if (! empty($id) && $action == 'edit')
         print '</td></tr>';
     }
 
+    // Other attributes
+    $parameters=array('colspan' => ' colspan="1"');
+    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$don,$action);    // Note that $action and $object may have been modified by hook
+
 	print "</table>\n";
 
 	print '<br><center><input type="submit" class="button" name="save" value="'.$langs->trans("Save").'"> &nbsp; &nbsp; <input type="submit" class="button" name="cancel" value="'.$langs->trans("Cancel").'"></center>';
@@ -493,6 +506,10 @@ if (! empty($id) && $action != 'edit')
     {
         print "<tr>".'<td>'.$langs->trans("Project").'</td><td>'.$don->projet.'</td></tr>';
     }
+
+    // Other attributes
+    $parameters=array('colspan' => ' colspan="1"');
+    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$don,$action);    // Note that $action and $object may have been modified by hook
 
 	print "</table>\n";
 	print "</form>\n";

--- a/htdocs/compta/tva/class/tva.class.php
+++ b/htdocs/compta/tva/class/tva.class.php
@@ -60,6 +60,8 @@ class Tva extends CommonObject
     function __construct($db)
     {
         $this->db = $db;
+        $this->element = 'tva';
+        $this->table_element = 'tva';
         return 1;
     }
 
@@ -122,7 +124,7 @@ class Tva extends CommonObject
             // Appel des triggers
             include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
             $interface=new Interfaces($this->db);
-            $result=$interface->run_triggers('MYOBJECT_CREATE',$this,$user,$langs,$conf);
+            $result=$interface->run_triggers('TVA_CREATE',$this,$user,$langs,$conf);
             if ($result < 0) { $error++; $this->errors=$interface->errors; }
             // Fin appel triggers
 
@@ -189,7 +191,7 @@ class Tva extends CommonObject
             // Appel des triggers
             include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
             $interface=new Interfaces($this->db);
-            $result=$interface->run_triggers('MYOBJECT_MODIFY',$this,$user,$langs,$conf);
+            $result=$interface->run_triggers('TVA_MODIFY',$this,$user,$langs,$conf);
             if ($result < 0) { $error++; $this->errors=$interface->errors; }
             // Fin appel triggers
     	}
@@ -289,7 +291,7 @@ class Tva extends CommonObject
         // Appel des triggers
         include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
         $interface=new Interfaces($this->db);
-        $result=$interface->run_triggers('MYOBJECT_DELETE',$this,$user,$langs,$conf);
+        $result=$interface->run_triggers('TVA_DELETE',$this,$user,$langs,$conf);
         if ($result < 0) { $error++; $this->errors=$interface->errors; }
         // Fin appel triggers
 
@@ -512,6 +514,14 @@ class Tva extends CommonObject
         if ($result)
         {
             $this->id = $this->db->last_insert_id(MAIN_DB_PREFIX."tva");    // TODO devrait s'appeler paiementtva
+
+            // Appel des triggers
+            include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
+            $interface=new Interfaces($this->db);
+            $result=$interface->run_triggers('TVA_ADDPAYMENT',$this,$user,$langs,$conf);
+            if ($result < 0) { $error++; $this->errors=$interface->errors; }
+            // Fin appel triggers
+
             if ($this->id > 0)
             {
                 $ok=1;

--- a/htdocs/compta/tva/fiche.php
+++ b/htdocs/compta/tva/fiche.php
@@ -40,6 +40,11 @@ $socid = isset($_GET["socid"])?$_GET["socid"]:'';
 if ($user->societe_id) $socid=$user->societe_id;
 $result = restrictedArea($user, 'tax', '', '', 'charges');
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('taxvatcard'));
+
 
 /**
  * Action ajout paiement tva
@@ -178,6 +183,11 @@ if ($_GET["action"] == 'create')
 	    print "</td>\n";
 	    print "</tr>";
 	}
+
+    // Other attributes
+    $parameters=array('colspan' => ' colspan="1"');
+    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
+
     print '</table>';
 
 	print "<br>";
@@ -241,6 +251,10 @@ if ($id)
 	    	print '</tr>';
 		}
 	}
+
+        // Other attributes
+        $parameters=array('colspan' => ' colspan="3"');
+        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$vatpayment,$action);    // Note that $action and $object may have been modified by hook
 
 	print '</table>';
 

--- a/htdocs/contact/fiche.php
+++ b/htdocs/contact/fiche.php
@@ -492,6 +492,10 @@ else
             }
             print '</tr>';
 
+            // Other attributes
+            $parameters=array('colspan' => ' colspan="3"');
+            $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
+
             print "</table><br><br>";
 
 
@@ -672,6 +676,10 @@ else
             }
             else print $langs->trans("NoDolibarrAccess");
             print '</td></tr>';
+
+            // Other attributes
+            $parameters=array('colspan' => ' colspan="3"');
+            $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
 
             print '</table><br>';
 
@@ -857,6 +865,10 @@ else
         }
         else print $langs->trans("NoDolibarrAccess");
         print '</td></tr>';
+
+        // Other attributes
+        $parameters=array('colspan' => ' colspan="3"');
+        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
 
         print "</table>";
 

--- a/htdocs/contrat/fiche.php
+++ b/htdocs/contrat/fiche.php
@@ -58,6 +58,11 @@ $result=restrictedArea($user,'contrat',$id);
 
 $usehm=(! empty($conf->global->MAIN_USE_HOURMIN_IN_DATE_RANGE)?$conf->global->MAIN_USE_HOURMIN_IN_DATE_RANGE:0);
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('contractcard'));
+
 $object = new Contrat($db);
 
 
@@ -633,6 +638,10 @@ if ($action == 'create')
         print '</textarea></td></tr>';
     }
 
+    // Other attributes
+    $parameters=array('colspan' => ' colspan="3"');
+    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
+
     print "</table>\n";
 
     print '<br><center><input type="submit" class="button" value="'.$langs->trans("Create").'"></center>';
@@ -778,6 +787,10 @@ else
             }
             print "</td></tr>";
         }
+
+        // Other attributes
+        $parameters=array('colspan' => ' colspan="3"');
+        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
 
         print "</table>";
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3380,10 +3380,12 @@ function make_substitutions($chaine,$substitutionarray)
  *  @param  array		&$substitutionarray		Array substitution old value => new value value
  *  @param  Translate	$outputlangs            If we want substitution from special constants, we provide a language
  *  @param  Object		$object                 If we want substitution from special constants, we provide data in a source object
+ *  @param  Object/array  $parameters       Add more parameters (useful to pass product lines)
+ *  @param  string              $callfunc               What is the name of the custom function that will be called? (default: completesubstitutionarray)
  *  @return	void
  *  @see 	make_substitutions
  */
-function complete_substitutions_array(&$substitutionarray,$outputlangs,$object='')
+function complete_substitutions_array(&$substitutionarray,$outputlangs,$object='',$parameters=null,$callfunc="completesubstitutionarray")
 {
 	global $conf,$user;
 
@@ -3408,8 +3410,8 @@ function complete_substitutions_array(&$substitutionarray,$outputlangs,$object='
 
 				dol_syslog("Library functions_".$substitfile['name']." found into ".$dir);
 				require_once($dir.$substitfile['name']);
-				$function_name=$module."_completesubstitutionarray";
-				$function_name($substitutionarray,$outputlangs,$object);
+				$function_name=$module."_".$callfunc;
+				$function_name($substitutionarray,$outputlangs,$object,$parameters);
 			}
 		}
 	}

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -455,6 +455,7 @@ class doc_generic_order_odt extends ModelePDFCommandes
                     foreach ($object->lines as $line)
                     {
                         $tmparray=$this->get_substitutionarray_lines($line,$outputlangs);
+                        complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
                         foreach($tmparray as $key => $val)
                         {
                              try

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -465,6 +465,7 @@ class doc_generic_invoice_odt extends ModelePDFFactures
                     foreach ($object->lines as $line)
                     {
                         $tmparray=$this->get_substitutionarray_lines($line,$outputlangs);
+                        complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
                         foreach($tmparray as $key => $val)
                         {
                              try

--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -454,6 +454,7 @@ class doc_generic_proposal_odt extends ModelePDFPropales
                     foreach ($object->lines as $line)
                     {
                         $tmparray=$this->get_substitutionarray_lines($line,$outputlangs);
+                        complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
                         foreach($tmparray as $key => $val)
                         {
                              try

--- a/htdocs/core/tpl/freeproductline_edit.tpl.php
+++ b/htdocs/core/tpl/freeproductline_edit.tpl.php
@@ -41,7 +41,7 @@
 	<?php
 	if (is_object($hookmanager))
 	{
-	    $parameters=array('fk_parent_line'=>$line->fk_parent_line);
+	    $parameters=array('line'=>$line,'fk_parent_line'=>$line->fk_parent_line,'var'=>$var,'dateSelector'=>$dateSelector,'seller'=>$seller,'buyer'=>$buyer);
 	    echo $hookmanager->executeHooks('formEditProductOptions',$parameters,$this,$action);
 	}
 
@@ -75,7 +75,7 @@
 	</td>
 
 <?php
-if (! empty($conf->margin->enabled)) { 
+if (! empty($conf->margin->enabled)) {
 ?>
 	<td align="right"><input type="text" size="5" name="buying_price" value="<?php echo price($line->pa_ht,0,'',0); ?>"></td>
 <?php

--- a/htdocs/core/tpl/predefinedproductline_edit.tpl.php
+++ b/htdocs/core/tpl/predefinedproductline_edit.tpl.php
@@ -51,7 +51,7 @@
 		if (is_object($hookmanager))
 		{
 		    $fk_parent_line = ($_POST["fk_parent_line"] ? $_POST["fk_parent_line"] : $line->fk_parent_line);
-			$parameters=array('fk_parent_line'=>$fk_parent_line);
+		    $parameters=array('line'=>$line,'fk_parent_line'=>$fk_parent_line,'var'=>$var,'dateSelector'=>$dateSelector,'seller'=>$seller,'buyer'=>$buyer);
 		    echo $hookmanager->executeHooks('formEditProductOptions',$parameters,$this,$action);
 		}
 
@@ -162,4 +162,3 @@ $(document).ready(function() {
 </script>
 <?php } ?>
 <!-- END PHP TEMPLATE predefinedproductline_edit.tpl.php -->
-

--- a/htdocs/expedition/fiche.php
+++ b/htdocs/expedition/fiche.php
@@ -57,6 +57,11 @@ $ref=GETPOST('ref','alpha');
 if ($user->societe_id) $socid=$user->societe_id;
 $result=restrictedArea($user,$origin,$origin_id);
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('expeditioncard'));
+
 $action		= GETPOST('action','alpha');
 $confirm	= GETPOST('confirm','alpha');
 
@@ -663,6 +668,10 @@ if ($action == 'create')
             print '<input name="tracking_number" size="20" value="'.GETPOST('tracking_number','alpha').'">';
             print "</td></tr>\n";
 
+            // Other attributes
+            $parameters=array('colspan' => ' colspan="3"');
+            $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$expe,$action);    // Note that $action and $object may have been modified by hook
+
             print "</table>";
 
             /*
@@ -1122,6 +1131,10 @@ else
             print '<tr><td>'.$form->editfieldkey("TrackingNumber",'trackingnumber',$object->tracking_number,$object,$user->rights->expedition->creer).'</td><td colspan="3">';
             print $form->editfieldval("TrackingNumber",'trackingnumber',$object->tracking_url,$object,$user->rights->expedition->creer,'string',$object->tracking_number);
             print '</td></tr>';
+
+            // Other attributes
+            $parameters=array('colspan' => ' colspan="3"');
+            $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
 
             print "</table>\n";
 

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -156,6 +156,9 @@ class Fichinter extends CommonObject
 		$result=$this->db->query($sql);
 		if ($result)
 		{
+                        $this->id=$this->db->last_insert_id(MAIN_DB_PREFIX."fichinter");
+                        $this->db->commit();
+
 			// Appel des triggers
 			include_once(DOL_DOCUMENT_ROOT . "/core/class/interfaces.class.php");
 			$interface=new Interfaces($this->db);
@@ -165,8 +168,6 @@ class Fichinter extends CommonObject
 			}
 			// Fin appel triggers
 
-			$this->id=$this->db->last_insert_id(MAIN_DB_PREFIX."fichinter");
-			$this->db->commit();
 			return $this->id;
 		}
 		else

--- a/htdocs/fichinter/fiche.php
+++ b/htdocs/fichinter/fiche.php
@@ -59,6 +59,11 @@ $hideref 	 = (GETPOST('hideref','int') ? GETPOST('hideref','int') : (! empty($co
 if ($user->societe_id) $socid=$user->societe_id;
 $result = restrictedArea($user, 'ficheinter', $id, 'fichinter');
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('interventioncard'));
+
 $object = new Fichinter($db);
 
 
@@ -810,6 +815,10 @@ if ($action == 'create')
         	print '</td></tr>';
         }
 
+        // Other attributes
+        $parameters=array('colspan' => ' colspan="2"');
+        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
+
         print '</table>';
 
         print '<center><br>';
@@ -939,6 +948,10 @@ else if ($id > 0 || ! empty($ref))
 
     // Statut
     print '<tr><td>'.$langs->trans("Status").'</td><td>'.$object->getLibStatut(4).'</td></tr>';
+
+    // Other attributes
+    $parameters=array('colspan' => ' colspan="3"');
+    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
 
     print "</table><br>";
 

--- a/htdocs/fourn/commande/fiche.php
+++ b/htdocs/fourn/commande/fiche.php
@@ -1186,6 +1186,10 @@ if ($id > 0 || ! empty($ref))
             print '</tr>';
         }
 
+        // Other attributes
+        $parameters=array('socid'=>$socid, 'colspan' => ' colspan="3"');
+	$reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
+
         // Ligne de	3 colonnes
         print '<tr><td>'.$langs->trans("AmountHT").'</td>';
         print '<td align="right"><b>'.price($object->total_ht).'</b></td>';
@@ -1382,6 +1386,12 @@ if ($id > 0 || ! empty($ref))
                     if ($conf->product->enabled && $conf->service->enabled) print '<br>';
                 }
 
+                if (is_object($hookmanager))
+                {
+                    $parameters=array('fk_parent_line'=>$line->fk_parent_line, 'line'=>$line,'var'=>$var,'num'=>$num,'i'=>$i);
+                    echo $hookmanager->executeHooks('formEditProductOptions',$parameters,$object,$action);
+                }
+
                 // Description - Editor wysiwyg
                 require_once(DOL_DOCUMENT_ROOT."/core/class/doleditor.class.php");
                 $nbrows=ROWS_2;
@@ -1437,6 +1447,12 @@ if ($id > 0 || ! empty($ref))
             print $form->select_type_of_lines(isset($_POST["type"])?$_POST["type"]:-1,'type',1,0,$forceall);
             if ($forceall || ($conf->product->enabled && $conf->service->enabled)
             || (empty($conf->product->enabled) && empty($conf->service->enabled))) print '<br>';
+
+            if (is_object($hookmanager))
+            {
+                $parameters=array();
+                echo $hookmanager->executeHooks('formCreateProductOptions',$parameters,$object,$action);
+            }
 
             $nbrows=ROWS_2;
             if (! empty($conf->global->MAIN_INPUT_DESC_HEIGHT)) $nbrows=$conf->global->MAIN_INPUT_DESC_HEIGHT;

--- a/htdocs/fourn/facture/fiche.php
+++ b/htdocs/fourn/facture/fiche.php
@@ -1169,6 +1169,11 @@ if ($action == 'create')
             }
         }
     }
+
+    // Other options
+    $parameters=array();
+    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
+
     // Bouton "Create Draft"
     print "</table>\n";
 
@@ -1510,6 +1515,10 @@ else
             print '</tr>';
         }
 
+        // Other options
+        $parameters=array();
+        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
+
         print '</table><br>';
 
         if (! empty($conf->global->MAIN_DISABLE_CONTACTS_TAB))
@@ -1600,6 +1609,12 @@ else
                     print $form->select_type_of_lines($object->lines[$i]->product_type,'type',1);
                     if ($forceall || ($conf->product->enabled && $conf->service->enabled)
                     || (empty($conf->product->enabled) && empty($conf->service->enabled))) print '<br>';
+                }
+
+                if (is_object($hookmanager))
+                {
+                    $parameters=array('fk_parent_line'=>$line->fk_parent_line, 'line'=>$object->lines[$i],'var'=>$var,'num'=>$num,'i'=>$i);
+                    echo $hookmanager->executeHooks('formEditProductOptions',$parameters,$object,$action);
                 }
 
                 // Description - Editor wysiwyg
@@ -1731,6 +1746,12 @@ else
             print $form->select_type_of_lines(isset($_POST["type"])?$_POST["type"]:-1,'type',1,0,$forceall);
             if ($forceall || ($conf->product->enabled && $conf->service->enabled)
             || (empty($conf->product->enabled) && empty($conf->service->enabled))) print '<br>';
+
+            if (is_object($hookmanager))
+            {
+                $parameters=array();
+                echo $hookmanager->executeHooks('formCreateProductOptions',$parameters,$object,$action);
+            }
 
             // Editor wysiwyg
             require_once(DOL_DOCUMENT_ROOT."/core/class/doleditor.class.php");

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -11,7 +11,7 @@ class OdfException extends Exception
  * @copyright  GPL License 2008 - Julien Pauli - Cyril PIERRE de GEYER - Anaska (http://www.anaska.com)
  * @copyright  GPL License 2010 - Laurent Destailleur - eldy@users.sourceforge.net
  * @license    http://www.gnu.org/copyleft/gpl.html  GPL License
- * @version 1.4.3 (last update 2012-07-29)
+ * @version 1.4
  */
 class Odf
 {
@@ -185,43 +185,13 @@ IMG;
 		 * Merge template variables
 		 * Called automatically for a save
 		 *
-                 * @param  string	$type		'content' or 'styles'
+         * @param  string	$type		'content' or 'styles'
 		 * @return void
 		 */
 		private function _parse($type='content')
 		{
-                    // Conditionals substitution
-                    // Note: must be done before content substitution, else the variable will be replaced by its value and the conditional won't work anymore
-                    foreach($this->vars as $key => $value)
-                    {
-                        // If value is true (not 0 nor false nor null nor empty string)
-                        if($value)
-                        {
-                            // Remove the IF tag
-                            $this->contentXml = str_replace('[!-- IF '.$key.' --]', '', $this->contentXml);
-                            // Remove everything between the ELSE tag (if it exists) and the ENDIF tag
-                            $reg = '@(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
-                            $this->contentXml = preg_replace($reg, '', $this->contentXml);
-                        }
-                        // Else the value is false, then two cases: no ELSE and we're done, or there is at least one place where there is an ELSE clause, then we replace it
-                        else
-                        {
-                            // Find all conditional blocks for this variable: from IF to ELSE and to ENDIF
-                            $reg = '@\[!--\sIF\s' . $key . '\s--\](.*)(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
-                            preg_match_all($reg, $this->contentXml, $matches, PREG_SET_ORDER);
-                            foreach($matches as $match) { // For each match, if there is an ELSE clause, we replace the whole block by the value in the ELSE clause
-                                if (!empty($match[3])) $this->contentXml = str_replace($match[0], $match[3], $this->contentXml);
-                            }
-                            // Cleanup the other conditional blocks (all the others where there were no ELSE clause, we can just remove them altogether)
-                            $this->contentXml = preg_replace($reg, '', $this->contentXml);
-                        }
-                    }
-
-                    // Content (variable) substitution
-                    if ($type == 'content')	$this->contentXml = str_replace(array_keys($this->vars), array_values($this->vars), $this->contentXml);
-                    // Styles substitution
-                    if ($type == 'styles')	$this->stylesXml = str_replace(array_keys($this->vars), array_values($this->vars), $this->stylesXml);
-
+            if ($type == 'content')	$this->contentXml = str_replace(array_keys($this->vars), array_values($this->vars), $this->contentXml);
+            if ($type == 'styles')	$this->stylesXml = str_replace(array_keys($this->vars), array_values($this->vars), $this->stylesXml);
 		}
 
 		/**

--- a/htdocs/projet/fiche.php
+++ b/htdocs/projet/fiche.php
@@ -49,6 +49,11 @@ $socid=0;
 if ($user->societe_id > 0) $socid=$user->societe_id;
 $result = restrictedArea($user, 'projet', $id);
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('projectcard'));
+
 $object = new Project($db);
 $object->fetch($id,$ref);
 if ($object->id > 0)
@@ -396,6 +401,10 @@ if ($action == 'create' && $user->rights->projet->creer)
     print '<textarea name="description" wrap="soft" cols="80" rows="'.ROWS_3.'">'.$_POST["description"].'</textarea>';
     print '</td></tr>';
 
+    // Other options
+    $parameters=array();
+    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
+
     print '</table>';
 
     print '<br><center>';
@@ -527,6 +536,10 @@ else
         print '<textarea name="description" wrap="soft" cols="80" rows="'.ROWS_3.'">'.$object->description.'</textarea>';
         print '</td></tr>';
 
+        // Other options
+        $parameters=array();
+        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
+
         print '</table>';
 
         print '<div align="center"><br>';
@@ -584,6 +597,10 @@ else
         print '<td valign="top">'.$langs->trans("Description").'</td><td>';
         print nl2br($object->description);
         print '</td></tr>';
+
+        // Other options
+        $parameters=array();
+        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
 
         print '</table>';
     }

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -54,6 +54,11 @@ $socid=0;
 if ($user->societe_id > 0) $socid = $user->societe_id;
 $result = restrictedArea($user, 'projet', $id);
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('projecttaskcard'));
+
 $progress=GETPOST('progress', 'int');
 $label=GETPOST('label', 'alpha');
 $description=GETPOST('description');
@@ -276,6 +281,10 @@ if ($action == 'create' && $user->rights->projet->creer && (empty($object->socie
 	print '<td>';
 	print '<textarea name="description" wrap="soft" cols="80" rows="'.ROWS_3.'">'.$description.'</textarea>';
 	print '</td></tr>';
+
+        // Other options
+        $parameters=array();
+        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
 
 	print '</table>';
 

--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -41,6 +41,11 @@ $socid=0;
 if ($user->societe_id > 0) $socid = $user->societe_id;
 if (! $user->rights->projet->lire) accessforbidden();
 
+// Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
+$hookmanager=new HookManager($db);
+$hookmanager->initHooks(array('projecttaskcard'));
+
 $object = new Task($db);
 $projectstatic = new Project($db);
 
@@ -281,6 +286,10 @@ if ($id > 0 || ! empty($ref))
 			print '<textarea name="description" wrap="soft" cols="80" rows="'.ROWS_3.'">'.$object->description.'</textarea>';
 			print '</td></tr>';
 
+                        // Other options
+                        $parameters=array();
+                        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
+
 			print '</table>';
 
 			print '<center><br>';
@@ -356,6 +365,10 @@ if ($id > 0 || ! empty($ref))
 			print '<td valign="top">'.$langs->trans("Description").'</td><td colspan="3">';
 			print nl2br($object->description);
 			print '</td></tr>';
+
+                        // Other options
+                        $parameters=array();
+                        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
 
 			print '</table>';
 


### PR DESCRIPTION
Hello,

Here is a patch that implements a lot of hooks and triggers for a lot of core modules, here is the list:

action/calendrier, deplacement, dons, tva, contact/tiers, contrat, product lines, expedition, fournisseur commandes et factures (lines included), fiche intervention, projet et taches

This patch does not break any functionnality, and I tried to follow the nomenclatura the best I could:
- for hookmanager context, I took the english translation for the module's name
- for triggers, I took the french name as prefix + english suffix for the action

For order supplier and invoice supplier, I also implemented the lines hooks with the current templating system (for now, it seems these two modules have not yet moved to the new templating model using htdocs/core/tpl/freeproductline_action.tpl.php, but meanwhile I implemented the same hooks as they would be in the template).

Another thing: there are currently a few bugs in order supplier and invoice supplier, but they are not from my patch and I already filed 2 bugs on Doliforge about them (and my patch was done on Dolibarr v3.2.0 final and it works well there, I just ported the changes).

About lines, I added a few more $parameters, like 'line'=>$line because it is necessary in order to process correctly the line (else we have no way of telling which line is currently being processed).

This is a clean patch, there are a few fake mispatchs here and there (I don't know why, it shows a few lines as being changed when clearly there's no change, eg: htdocs/fourn/facture/fiche.php), so hopefully this should be a straightforward patch.

PS: don't take in account the conditional substitution for ODT, I reverted the change since it was filed in another pull request.
