### PR TITLE
Project::setClose wasn't setting the new status

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -602,6 +602,7 @@ class Project extends CommonObject
 
                 if (!$error)
                 {
+                    $this->statut = 2;
                     $this->db->commit();
                     return 1;
                 }


### PR DESCRIPTION
**Should do cherry-pick for 3.2 branch**

Reported in http://www.dolibarr.org/forum/527-bugs-on-a-stable-version/20868-page-refresh-after-closing-project
