### PR TITLE
Fix: Modify spanish VAT to new rates

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ English Dolibarr ChangeLog
 --------------------------------------------------------------
 
 
+***** ChangeLog for 3.2.2 compared to 3.2.1 *****
+Fix: Modify spanish VAT to new rates
 
 ***** ChangeLog for 3.2.1 compared to 3.2.0 *****
 - Fix: Edit of projects.

--- a/htdocs/install/mysql/data/llx_c_tva.sql
+++ b/htdocs/install/mysql/data/llx_c_tva.sql
@@ -181,8 +181,8 @@ INSERT INTO llx_c_tva(rowid, fk_pays, taux, recuperableonly, note, active) VALUE
 INSERT INTO llx_c_tva(rowid, fk_pays, taux, recuperableonly, note, active) VALUES (2023, 202,  '0', '0', 'VAT Rate 0', 1);
 
 -- SPAIN (id country=4)
-insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,localtax1,note,active) values ( 41, 4,  '18','0','4','VAT standard rate',1);
-insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,localtax1,note,active) values ( 42, 4,   '8','0','1','VAT reduced rate',1);
+insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,localtax1,note,active) values ( 41, 4,  '21','0','5.2','VAT standard rate',1);
+insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,localtax1,note,active) values ( 42, 4,   '10','0','1.4','VAT reduced rate',1);
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,localtax1,note,active) values ( 43, 4,   '4','0','0.5','VAT super-reduced rate',1);
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active)           values ( 44, 4,   '0','0','VAT Rate 0',1);
 

--- a/htdocs/install/mysql/migration/3.1.0-3.2.0.sql
+++ b/htdocs/install/mysql/migration/3.1.0-3.2.0.sql
@@ -464,3 +464,9 @@ UPDATE llx_product SET canvas = NULL where canvas = 'service@product';
 DELETE FROM llx_const WHERE __DECRYPT('name')__ = 'SOCIETE_CODECOMPTA_ADDON' AND __DECRYPT('value')__ = 'mod_codecompta_digitaria';
 
 ALTER TABLE llx_c_barcode_type ADD UNIQUE INDEX uk_c_barcode_type(code, entity);
+
+-- Remove old Spanish TVA
+UPDATE llx_c_tva SET taux = '21', localtax1='5.2' WHERE rowid = 41;
+UPDATE llx_c_tva SET taux = '10', localtax1='1.4' WHERE rowid = 42;
+DELETE FROM llx_c_tva WHERE rowid = 45;
+DELETE FROM llx_c_tva WHERE rowid = 46;

--- a/htdocs/install/mysql/migration/3.1.0-3.2.0.sql
+++ b/htdocs/install/mysql/migration/3.1.0-3.2.0.sql
@@ -464,9 +464,3 @@ UPDATE llx_product SET canvas = NULL where canvas = 'service@product';
 DELETE FROM llx_const WHERE __DECRYPT('name')__ = 'SOCIETE_CODECOMPTA_ADDON' AND __DECRYPT('value')__ = 'mod_codecompta_digitaria';
 
 ALTER TABLE llx_c_barcode_type ADD UNIQUE INDEX uk_c_barcode_type(code, entity);
-
--- Remove old Spanish TVA
-UPDATE llx_c_tva SET taux = '21', localtax1='5.2' WHERE rowid = 41;
-UPDATE llx_c_tva SET taux = '10', localtax1='1.4' WHERE rowid = 42;
-DELETE FROM llx_c_tva WHERE rowid = 45;
-DELETE FROM llx_c_tva WHERE rowid = 46;


### PR DESCRIPTION
Only modified llx_c_tva, because many products change the VAT rate (super-reduced or reduced to general) and must be the user who controls these changes in their products
