### PR TITLE
Fix: definition of all substitution functions is no more required

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3457,7 +3457,7 @@ function complete_substitutions_array(&$substitutionarray,$outputlangs,$object='
 				dol_syslog("Library functions_".$substitfile['name']." found into ".$dir);
 				require_once $dir.$substitfile['name'];
 				$function_name=$module."_".$callfunc;
-				$function_name($substitutionarray,$outputlangs,$object,$parameters);
+				if (function_exists($function_name)) $function_name($substitutionarray,$outputlangs,$object,$parameters);
 			}
 		}
 	}


### PR DESCRIPTION
A bug that has gone unnoticed: if one create an empty substitution file (functions_module.lib.php) or if only one function was defined but a script called 2 functions, the function would crash, because there was no function_exists() check.

Signed-off-by: Stephen L. lrq3000@gmail.com
