### PR TITLE
Fix : internal contact not displayed in rouget PDF

### DIFF
--- a/htdocs/core/modules/expedition/doc/pdf_expedition_rouget.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_expedition_rouget.modules.php
@@ -542,7 +542,7 @@ class pdf_expedition_rouget extends ModelePdfExpedition
 			// Sender properties
 			$carac_emetteur='';
 		 	// Add internal contact of proposal if defined
-			$arrayidcontact=$object->getIdContact('internal','SALESREPFOLL');
+			$arrayidcontact=$object->$origin->getIdContact('internal','SALESREPFOLL');
 		 	if (count($arrayidcontact) > 0)
 		 	{
 		 		$object->fetch_user($arrayidcontact[0]);


### PR DESCRIPTION
shipment PDF rouget wasn't using the right var to access related internal contact
