### PR TITLE
bugfix saving LDAP-bound user

### DIFF
--- a/htdocs/includes/triggers/interface_modLdap_Ldapsynchro.class.php
+++ b/htdocs/includes/triggers/interface_modLdap_Ldapsynchro.class.php
@@ -431,6 +431,9 @@ class InterfaceLdapsynchro
         		$ldap=new Ldap();
         		$ldap->connect_bind();
 
+        		$class = get_class($object);
+        		$object->oldcopy = new $class($object->db);
+
         		$oldinfo=$object->oldcopy->_load_ldap_info();
         		$olddn=$object->oldcopy->_load_ldap_dn($oldinfo);
 


### PR DESCRIPTION
Fixes bug  while editing a LDAP-bound user's profile.

"Fatal error: Call to a member function _load_ldap_info() on a non-object in /var/www/abonne.rhizome-fai.net/dolibarr/htdocs/includes/triggers/interface_modLdap_Ldapsynchro.class.php on line 434

Similar to http://lists.gnu.org/archive/html/dolibarr-dev/2011-11/msg00010.html
