### PR TITLE
ODT fix + new feature (full control over ODF object)

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3504,7 +3504,7 @@ function make_substitutions($chaine,$substitutionarray)
  *  @param  array		&$substitutionarray		Array substitution old value => new value value
  *  @param  Translate	$outputlangs            If we want substitution from special constants, we provide a language
  *  @param  Object		$object                 If we want substitution from special constants, we provide data in a source object
- *  @param  Object/array  $parameters       Add more parameters (useful to pass product lines)
+ *  @param  Object/array  $parameters       Add more parameters (useful to pass product lines or odfHandler)
  *  @param  string              $callfunc               What is the name of the custom function that will be called? (default: completesubstitutionarray)
  *  @return	void
  *  @see 	make_substitutions
@@ -3533,7 +3533,9 @@ function complete_substitutions_array(&$substitutionarray,$outputlangs,$object='
 				$module=$reg[1];
 
 				dol_syslog("Library functions_".$substitfile['name']." found into ".$dir);
+                                // Include the user's functions file
 				require_once $dir.$substitfile['name'];
+                                // Call the user's function only if it is defined
 				$function_name=$module."_".$callfunc;
 				if (function_exists($function_name)) $function_name($substitutionarray,$outputlangs,$object,$parameters);
 			}

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -332,7 +332,8 @@ class doc_generic_order_odt extends ModelePDFCommandes
                     '__TOTAL_HT__' => $object->total_ht,
                     '__TOTAL_VAT__' => $object->total_vat
                 );
-                complete_substitutions_array($substitutionarray, $langs, $object);
+                $parameters = array('odfHandler'=>$odfHandler);
+                complete_substitutions_array($substitutionarray, $langs, $object, $parameters);
 
 				// Line of free text
 				$newfreetext='';
@@ -431,7 +432,8 @@ class doc_generic_order_odt extends ModelePDFCommandes
 				}
 				// Replace tags of object + external modules
 			    $tmparray=$this->get_substitutionarray_object($object,$outputlangs);
-			    complete_substitutions_array($tmparray, $outputlangs, $object);
+                            $parameters = array('odfHandler'=>$odfHandler);
+			    complete_substitutions_array($tmparray, $outputlangs, $object, $parameters);
                 foreach($tmparray as $key=>$value)
                 {
                     try {
@@ -456,7 +458,8 @@ class doc_generic_order_odt extends ModelePDFCommandes
                     foreach ($object->lines as $line)
                     {
                         $tmparray=$this->get_substitutionarray_lines($line,$outputlangs);
-                        complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
+                        $parameters = array('line'=>$line, 'odfHandler'=>$odfHandler);
+                        complete_substitutions_array($tmparray, $outputlangs, $object, $parameters, "completesubstitutionarray_lines");
                         foreach($tmparray as $key => $val)
                         {
                              try

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -344,7 +344,8 @@ class doc_generic_invoice_odt extends ModelePDFFactures
                     '__TOTAL_HT__' => $object->total_ht,
                     '__TOTAL_VAT__' => $object->total_tva
                 );
-                complete_substitutions_array($substitutionarray, $langs, $object);
+                $parameters = array('odfHandler'=>$odfHandler);
+                complete_substitutions_array($substitutionarray, $langs, $object, $parameters);
 
 				// Line of free text
 				$newfreetext='';
@@ -387,7 +388,8 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				$array_objet=$this->get_substitutionarray_object($object,$outputlangs);
 
 				$tmparray = array_merge($array_user,$array_soc,$array_thirdparty,$array_objet);
-				complete_substitutions_array($tmparray, $outputlangs, $object);
+                                $parameters = array('odfHandler'=>$odfHandler);
+				complete_substitutions_array($tmparray, $outputlangs, $object, $parameters);
 
                 //var_dump($tmparray); exit;
                 foreach($tmparray as $key=>$value)
@@ -415,7 +417,8 @@ class doc_generic_invoice_odt extends ModelePDFFactures
                     foreach ($object->lines as $line)
                     {
                         $tmparray=$this->get_substitutionarray_lines($line,$outputlangs);
-                        complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
+                        $parameters = array('line'=>$line, 'odfHandler'=>$odfHandler);
+                        complete_substitutions_array($tmparray, $outputlangs, $object, $parameters, "completesubstitutionarray_lines");
                         foreach($tmparray as $key => $val)
                         {
                              try

--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -331,7 +331,8 @@ class doc_generic_proposal_odt extends ModelePDFPropales
                     '__TOTAL_HT__' => $object->total_ht,
                     '__TOTAL_VAT__' => $object->total_vat
                 );
-                complete_substitutions_array($substitutionarray, $langs, $object);
+                $parameters = array('odfHandler'=>$odfHandler);
+                complete_substitutions_array($substitutionarray, $langs, $object, $parameters);
 
 				// Line of free text
 				$newfreetext='';
@@ -430,7 +431,8 @@ class doc_generic_proposal_odt extends ModelePDFPropales
 				}
 				// Replace tags of object + external modules
 			    $tmparray=$this->get_substitutionarray_object($object,$outputlangs);
-			    complete_substitutions_array($tmparray, $outputlangs, $object);
+                            $parameters = array('odfHandler'=>$odfHandler);
+			    complete_substitutions_array($tmparray, $outputlangs, $object, $parameters);
                 foreach($tmparray as $key=>$value)
                 {
                     try {
@@ -455,7 +457,8 @@ class doc_generic_proposal_odt extends ModelePDFPropales
                     foreach ($object->lines as $line)
                     {
                         $tmparray=$this->get_substitutionarray_lines($line,$outputlangs);
-                        complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
+                        $parameters = array('line'=>$line, 'odfHandler'=>$odfHandler);
+                        complete_substitutions_array($tmparray, $outputlangs, $object, $parameters, "completesubstitutionarray_lines");
                         foreach($tmparray as $key => $val)
                         {
                              try

--- a/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
+++ b/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
@@ -272,7 +272,8 @@ class doc_generic_odt extends ModeleThirdPartyDoc
 				}
                 // Make substitutions into odt of thirdparty + external modules
 				$tmparray=$this->get_substitutionarray_thirdparty($object,$outputlangs);
-                complete_substitutions_array($tmparray, $outputlangs, $object);
+                                $parameters = array('odfHandler'=>$odfHandler);
+                                complete_substitutions_array($tmparray, $outputlangs, $object, $parameters);
                 //var_dump($object->id); exit;
 				foreach($tmparray as $key=>$value)
 				{

--- a/htdocs/includes/odtphp/Segment.php
+++ b/htdocs/includes/odtphp/Segment.php
@@ -34,7 +34,7 @@ class Segment implements IteratorAggregate, Countable
         $this->xml = (string) $xml;
 		$this->odf = $odf;
         $zipHandler = $this->odf->getConfig('ZIP_PROXY');
-        $this->file = new $zipHandler();	
+        $this->file = new $zipHandler($this->odf->getConfig('PATH_TO_TMP'));
         $this->_analyseChildren($this->xml);
     }
     /**


### PR DESCRIPTION
Hello,

Here is a new commit which fix a problem with ODT segments temporary folders (which prevent odt with dynamic images to be generated), and adds an optional $odfHandler parameter for users' substitution functions, which extends ODT substitution functions to pretty much do anything because users now have full control over the ODF object.

For example, this allows to generate dynamic images for every products lines on-the-fly, which is not possible otherwise (except by modifying either the ODF class or Dolibarr generation classes...).

This patch is clean, small, and retrocompatible (if you didn't specify $odfHandler, the substitution function still works from my own tests).
