### PR TITLE
Fix [ bug #668 ] Event created with a profile is not visible by the same

### DIFF
--- a/htdocs/comm/action/fiche.php
+++ b/htdocs/comm/action/fiche.php
@@ -555,7 +555,13 @@ if ($action == 'create')
 	}
 	else
 	{
-		print $form->select_company('','socid','',1,1);
+		//For external user force the company to user company
+		if (!empty($user->societe_id)) {
+			print $form->select_company($user->societe_id,'socid','',1,1);
+		} else {
+			print $form->select_company('','socid','',1,1);
+		}
+		
 	}
 	print '</td></tr>';
 


### PR DESCRIPTION
Fix [ bug #668 ] Event created with a profile is not visible by the same profile

If user is external user then the Evénement concernant la société field is predefaulted with users's company
