### PR TITLE
Minor changes related to commit 8ac33e9

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -60,7 +60,7 @@ For users:
 - New: [ task #210 ] Can choose cash account during POS login.
 - New: [ task #104 ] Can create an invoice from several orders.
 - New: Update libs/tools/logo for DoliWamp (now use PHP 5.3).
-- New: Added ODT Template tag {object_total_discount}
+- New: Added ODT Template tag {object_total_discount_ht}
 - New: Add new import options: Third parties bank details, warehouses and stocks, categories and suppliers prices
 - New: English bank account need a bank code (called sort code) to identify an account. 
 - New: Can choose menu entry to show with external site module.

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2255,11 +2255,11 @@ abstract class CommonObject
     /**
      * Function that returns the total amount HT of discounts applied for all lines.
      *
-     * @return 	in		0 if no discount
+     * @return 	float
      */
     function getTotalDiscount()
     {
-    	$total_discount=0; 
+    	$total_discount=0.00;
 
         $sql = "SELECT subprice as pu_ht, qty, remise_percent, total_ht";
         $sql.= " FROM ".MAIN_DB_PREFIX.$this->table_element."det";


### PR DESCRIPTION
- Updated changelog
- Function `getTotalDiscount` from commonobject.class.php should always return a float. Also removed comment that if there is no discount, 0.00 is returned as it is the expected result...

As usual, many changes are shown because of incorrect line endings.

Link to commit: 8ac33e98e7da9be90f08719e404c78b1dd16d50a
