### PR TITLE
Display bug on FF while closing proposal

### DIFF
--- a/htdocs/theme/bureau2crea/style.css.php
+++ b/htdocs/theme/bureau2crea/style.css.php
@@ -2155,7 +2155,6 @@ div.tabsAction {
 table.noborder {
 	margin-bottom: 10px;
     position: relative;
-    float: left;
     border: none;
 }
 


### PR DESCRIPTION
With bureau2crea theme.
On FF when you click on "close" on a proposal, the close form is displayed on the right of the proposal lines list. I noticed that the noborder class here was using a useless "float: left;". I removed it and checked some other places where noborder is used. Seems to be working fine.
