### PR TITLE
Update mysql.class.php

### DIFF
--- a/htdocs/core/db/mysql.class.php
+++ b/htdocs/core/db/mysql.class.php
@@ -931,7 +931,7 @@ class DoliDBMysql
 		$sql .= ",".implode(',',$sqluq);
 		if($keys != "")
 		$sql .= ",".implode(',',$sqlk);
-		$sql .=") type=".$type;
+		$sql .=") engine=".$type;
 
 		dol_syslog($sql,LOG_DEBUG);
 		if(! $this -> query($sql))


### PR DESCRIPTION
Create Table 'type' not supported on recent mysql databases, need to use 'engine' instead 
