### PR TITLE
Add: ODTSubstitution and ODTSubstitutionLine hooks with $odfHandler for ...

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3597,7 +3597,9 @@ function complete_substitutions_array(&$substitutionarray,$outputlangs,$object='
 				$module=$reg[1];
 
 				dol_syslog("Library functions_".$substitfile['name']." found into ".$dir);
+				// Include the user's functions file
 				require_once $dir.$substitfile['name'];
+				// Call the user's function, and only if it is defined
 				$function_name=$module."_".$callfunc;
 				if (function_exists($function_name)) $function_name($substitutionarray,$outputlangs,$object,$parameters);
 			}

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -283,6 +283,15 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 			return -1;
 		}
 
+                // Add odtgeneration hook
+                if (! is_object($hookmanager))
+                {
+                        include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
+                        $hookmanager=new HookManager($this->db);
+                }
+                $hookmanager->initHooks(array('odtgeneration'));
+                global $action;
+
 		if (! is_object($outputlangs)) $outputlangs=$langs;
 		$sav_charset_output=$outputlangs->charset_output;
 		$outputlangs->charset_output='UTF-8';
@@ -375,6 +384,9 @@ class doc_generic_invoice_odt extends ModelePDFFactures
                     '__TOTAL_VAT__' => $object->total_tva
                 );
                 complete_substitutions_array($substitutionarray, $langs, $object);
+                // Call the ODTSubstitution hook
+                $parameters=array('file'=>$file,'object'=>$object,'outputlangs'=>$outputlangs,'substitutionarray'=>&$substitutionarray);
+                $reshook=$hookmanager->executeHooks('ODTSubstitution',$parameters,$this,$action);    // Note that $action and $object may have been modified by some hooks
 
 				// Line of free text
 				$newfreetext='';
@@ -417,9 +429,12 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				$array_objet=$this->get_substitutionarray_object($object,$outputlangs);
 				$array_propal=is_object($propal_object)?$this->get_substitutionarray_propal($propal_object,$outputlangs,'propal'):array();
 				$array_other=$this->get_substitutionarray_other($user,$outputlangs);
-				
+
 				$tmparray = array_merge($array_user,$array_soc,$array_thirdparty,$array_objet,$array_propal);
 				complete_substitutions_array($tmparray, $outputlangs, $object);
+                                // Call the ODTSubstitution hook
+                                $parameters=array('file'=>$file,'object'=>$object,'outputlangs'=>$outputlangs,'substitutionarray'=>&$tmparray);
+                                $reshook=$hookmanager->executeHooks('ODTSubstitution',$parameters,$this,$action);    // Note that $action and $object may have been modified by some hooks
 
                 //var_dump($tmparray); exit;
                 foreach($tmparray as $key=>$value)
@@ -448,6 +463,9 @@ class doc_generic_invoice_odt extends ModelePDFFactures
                     {
                         $tmparray=$this->get_substitutionarray_lines($line,$outputlangs);
                         complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
+                        // Call the ODTSubstitutionLine hook
+                        $parameters=array('odfHandler'=>&$odfHandler,'file'=>$file,'object'=>$object,'outputlangs'=>$outputlangs,'substitutionarray'=>&$tmparray,'line'=>$line);
+                        $reshook=$hookmanager->executeHooks('ODTSubstitutionLine',$parameters,$this,$action);    // Note that $action and $object may have been modified by some hooks
                         foreach($tmparray as $key => $val)
                         {
                              try
@@ -472,15 +490,8 @@ class doc_generic_invoice_odt extends ModelePDFFactures
                     return -1;
                 }
 
-				// Add odtgeneration hook
-				if (! is_object($hookmanager))
-				{
-					include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
-					$hookmanager=new HookManager($this->db);
-				}
-				$hookmanager->initHooks(array('odtgeneration'));
-				$parameters=array('odfHandler'=>$odfHandler,'file'=>$file,'object'=>$object,'outputlangs'=>$outputlangs);
-				global $action;
+                                // Call the beforeODTSave hook
+				$parameters=array('odfHandler'=>&$odfHandler,'file'=>$file,'object'=>$object,'outputlangs'=>$outputlangs);
 				$reshook=$hookmanager->executeHooks('beforeODTSave',$parameters,$this,$action);    // Note that $action and $object may have been modified by some hooks
 
                 // Write new file


### PR DESCRIPTION
...extended ODT substitution

This is a rework of a previous pull request:
https://github.com/Dolibarr/dolibarr/pull/554

This patch introduces a few new hooks instead of passing $odfHandler to the complete_substitution_array() function.

I have tested it with my own module and it works. People will now be able to do extended ODT substitution (images included) using these hooks.
