### PR TITLE
Add UK/ Ajout de UK

### DIFF
--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -974,7 +974,7 @@ class Account extends CommonObject
         $country_code=$this->getCountryCode();
 
         if (in_array($country_code,array('CH','DE','FR','ES','GA','IT'))) return 1; // France, Spain, Gabon
-        if (in_array($country_code,array('AU','BE','CA','DK','GR','GB','ID','IE','IR','KR','NL','NZ','US'))) return 2;      // Australia, Great Britain...
+        if (in_array($country_code,array('AU','BE','CA','DK','GR','GB','UK','ID','IE','IR','KR','NL','NZ','US'))) return 2;      // Australia, Great Britain...
         return 0;
     }
 

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -2220,6 +2220,7 @@ class Societe extends CommonObject
 
         if ($idprof == 1 && $soc->country_code == 'FR') $url='http://www.societe.com/cgi-bin/recherche?rncs='.$soc->idprof1;
         if ($idprof == 1 && $soc->country_code == 'GB') $url='http://www.companieshouse.gov.uk/WebCHeck/findinfolink/';
+        if ($idprof == 1 && $soc->country_code == 'UK') $url='http://www.companieshouse.gov.uk/WebCHeck/findinfolink/';
         if ($idprof == 1 && $soc->country_code == 'ES') $url='http://www.e-informa.es/servlet/app/portal/ENTP/screen/SProducto/prod/ETIQUETA_EMPRESA/nif/'.$soc->idprof1;
         if ($idprof == 1 && $soc->country_code == 'IN') $url='http://www.tinxsys.com/TinxsysInternetWeb/dealerControllerServlet?tinNumber='.$soc->idprof1.';&searchBy=TIN&backPage=searchByTin_Inter.jsp';
 


### PR DESCRIPTION
Bonjour

Mes clients anglais indiquent 'UK' ou 'United Kingdom' au lieu de 'GB' ou 'Great Brittain'.

Je propose donc d'ajouter 'UK' comme pays possiblem ce qui implique de multiples changements.

Pour le moment c'est un peu galère avec GITHUB pour moi, donc pas tous les modifs sont inclus ici.

Fichiers à changer:
- langs/*/dict.lang [ajout CountryUK]
- install/mysql/(migration|data);
- core/class/commonobject.class.php
- core/lib/functions.php
- societe/class/societe.class.php
- compta/bank/class/account.class.php
- ./install/mysql/data/llx_20_c_departements.sql
