### PR TITLE
Typo in skeleton module class

### DIFF
--- a/dev/skeletons/modMyModule.class.php
+++ b/dev/skeletons/modMyModule.class.php
@@ -178,7 +178,7 @@ class modMyModule extends DolibarrModules
 
 
 		// Main menu entries
-		$this->menus = array();			// List of menus to add
+		$this->menu = array();			// List of menus to add
 		$r=0;
 
 		// Add here entries to declare new menus


### PR DESCRIPTION
The change should be applied for 3.3, 3.4 and develop branches
