### PR TITLE
Translateded missing entries "ThirdPartiesOfSaleRepresentative"

### DIFF
--- a/htdocs/langs/it_IT/commercial.lang
+++ b/htdocs/langs/it_IT/commercial.lang
@@ -86,3 +86,4 @@ TaskRDVWith					=Incontro con %s
 TasksHistoryForThisContact			=Storico del contatto
 ToDoActions					=Azioni da fare
 ToDoActionsFor					=Azioni da fare per %s
+ThirdPartiesOfSaleRepresentative=Terze parti con responsabile commerciale

--- a/htdocs/langs/it_IT/main.lang
+++ b/htdocs/langs/it_IT/main.lang
@@ -655,3 +655,4 @@ yes							   =sì
 Yes							   =Sì
 Yesterday						   =Ieri
 YouCanChangeValuesForThisListFromDictionnarySetup	   =È possibile modificare i valori di questo elenco dal menu Impostazioni - Dizionario
+LinkedToSpecificUsers=Con collegamento ad un utente specifico


### PR DESCRIPTION
Added and translateded missing entries:
- /langs/it_IT/commercial.lang - ThirdPartiesOfSaleRepresentative
- /langs/it_IT/main.lang - LinkedToSpecificUsers

Affected pages are (HTTP prefix, server and path were stripped):
- compta/facture/list.php?leftmenu=customers_bills
