### PR TITLE
Trying to fix Substitution for core module propal & fcicheinter

### DIFF
--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -186,8 +186,6 @@ class Conf
 							if (! isset($this->$modulename) || ! is_object($this->$modulename)) $this->$modulename=new stdClass();
 							$this->$modulename->enabled=true;
 							$this->modules[]=$modulename;              // Add this module in list of enabled modules
-							if (in_array($modulename,array('propal','fcicheinter')))
-							$this->modules_parts['substitutions'] = array_merge($this->modules_parts['substitutions'], array($modulename => '/core/substitutions/'));
 						}
 					}
 				}

--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -186,6 +186,8 @@ class Conf
 							if (! isset($this->$modulename) || ! is_object($this->$modulename)) $this->$modulename=new stdClass();
 							$this->$modulename->enabled=true;
 							$this->modules[]=$modulename;              // Add this module in list of enabled modules
+							if (in_array($modulename,array('propal','fcicheinter')))
+							$this->modules_parts['substitutions'] = array_merge($this->modules_parts['substitutions'], array($modulename => '/core/substitutions/'));
 						}
 					}
 				}

--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -186,6 +186,8 @@ class Conf
 							if (! isset($this->$modulename) || ! is_object($this->$modulename)) $this->$modulename=new stdClass();
 							$this->$modulename->enabled=true;
 							$this->modules[]=$modulename;              // Add this module in list of enabled modules
+							if (in_array($modulename,array('propal','fcicheinter')))
+								$this->modules_parts['substitutions'] = array_merge($this->modules_parts['substitutions'], array($modulename => '/core/substitutions/'));
 						}
 					}
 				}


### PR DESCRIPTION
The module_parts['substitution'] never got set; this caused the customized substitution content never get loaded. Adding a work around here.
This PR doesn't seem to be the originally desired fix. 
Could someone help look into this ?
