### PR TITLE
fixed bug when editing a supplier order line

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1802,7 +1802,7 @@ class CommandeFournisseur extends CommonOrder
             $sql.= ",total_localtax1='".price2num($total_localtax1)."'";
             $sql.= ",total_localtax2='".price2num($total_localtax2)."'";
             $sql.= ",total_ttc='".price2num($total_ttc)."'";
-            $sql.= ",product_type='".$type."'";
+            $sql.= ",product_type=".$type;
             $sql.= " WHERE rowid = ".$rowid;
 
             dol_syslog(get_class($this)."::updateline sql=".$sql);
@@ -2063,7 +2063,7 @@ class CommandeFournisseurLigne
         $sql.= ' cd.localtax1_tx, cd.localtax2_tx,';
         $sql.= ' cd.remise, cd.remise_percent, cd.subprice,';
         $sql.= ' cd.info_bits, cd.total_ht, cd.total_tva, cd.total_ttc,';
-        $sql.= ' cd.total_localtax1, cd.local_localtax2,';
+        $sql.= ' cd.total_localtax1, cd.total_localtax2,';
         $sql.= ' p.ref as product_ref, p.label as product_libelle, p.description as product_desc';
         $sql.= ' FROM '.MAIN_DB_PREFIX.'commande_fournisseurdet as cd';
         $sql.= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON cd.fk_product = p.rowid';
@@ -2096,10 +2096,12 @@ class CommandeFournisseurLigne
             $this->product_desc     = $objp->product_desc;
 
             $this->db->free($result);
+            return 1;
         }
         else
         {
             dol_print_error($this->db);
+            return -1;
         }
     }
 

--- a/htdocs/fourn/commande/fiche.php
+++ b/htdocs/fourn/commande/fiche.php
@@ -336,10 +336,11 @@ else if ($action == 'addline' && $user->rights->fournisseur->commande->creer)
  */
 else if ($action == 'updateligne' && $user->rights->fournisseur->commande->creer &&	$_POST['save'] == $langs->trans('Save'))
 {
-    $product=new Product($db);
     if ($_POST["elrowid"])
     {
-        if ($product->fetch($_POST["elrowid"]) < 0) dol_print_error($db);
+        $line = new CommandeFournisseurLigne($db);
+        $res = $line->fetch($_POST["elrowid"]); 
+        if (!$res) dol_print_error($db);
     }
 
     $localtax1_tx=get_localtax($_POST['tva_tx'],1,$mysoc,$object->thirdparty);
@@ -356,9 +357,18 @@ else if ($action == 'updateligne' && $user->rights->fournisseur->commande->creer
         $localtax2_tx,
         'HT',
         0,
-        isset($_POST["type"])?$_POST["type"]:$product->type
+        isset($_POST["type"])?$_POST["type"]:$line->product_type
     );
-
+    unset($_POST['qty']);
+    unset($_POST['type']);
+    unset($_POST['idprodfournprice']);
+    unset($_POST['remmise_percent']);
+    unset($_POST['dp_desc']);
+    unset($_POST['np_desc']);
+    unset($_POST['pu']);
+    unset($_POST['tva_tx']);
+    unset($localtax1_tx);
+    unset($localtax2_tx);
     if ($result	>= 0)
     {
         $outputlangs = $langs;


### PR DESCRIPTION
I had SQL errors when trying to edit a line in a supplier order.
fourn/commande/fiche.php was calling the updateline function with wrong parameters in some cases because it tried to fetch a Product object with a CommandeFournisseurLigne id.
Also, the CommandeFournisseurLigne fetch function requested from a field "local_localtax2" which doesn't exist in the database.
