### PR TITLE
Put the name before first name

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -78,9 +78,9 @@ abstract class CommonObject
 
         if ($nameorder)
         {
-            $ret.=$firstname;
-            if ($firstname && $lastname) $ret.=' ';
             $ret.=$lastname;
+            if ($firstname && $lastname) $ret.=' ';
+            $ret.=$firstname;
         }
         else
         {


### PR DESCRIPTION
Currently, you get the list sorted by surname, but firstname is displayed first. This make the list hard to understand.

Plus, in other areas (like mail sending), the display is already surname firstname.
