### PR TITLE
fix dol_buildpath failing when processing path such as file.php?id=__ID_...

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -285,7 +285,7 @@ function dol_buildpath($path, $type=0)
 			if (! empty($regs[1]))
 			{
 				//print $key.'-'.$dirroot.'/'.$path.'-'.$conf->file->dol_url_root[$type].'<br>'."\n";
-				if (file_exists($dirroot.'/'.$path))
+				if (file_exists($dirroot.'/'.$regs[1]))
 				{
 					if ($type == 1)
 					{


### PR DESCRIPTION
dol_buildpath fails to return the good path when the parameter is something like '/mymodule/mypage.php?id=**ID**'  with mymodule in the 'extensions' folder. It doesn't add the 'extensions' folder to the path.
The '?id=**ID**' part makes the file_exists test return false so I replaced $path by $regs[1] which value doesn't contain it.
