### PR TITLE
instanciation of Facture objects raised errors, deleted them

### DIFF
--- a/htdocs/core/boxes/box_graph_invoices_supplier_permonth.php
+++ b/htdocs/core/boxes/box_graph_invoices_supplier_permonth.php
@@ -67,7 +67,6 @@ class box_graph_invoices_supplier_permonth extends ModeleBoxes
 		$refreshaction='refresh_'.$this->boxcode;
 
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
-		$facturestatic=new Facture($db);
 
 		$text = $langs->trans("BoxSuppliersInvoicesPerMonth",$max);
 		$this->info_box_head = array(

--- a/htdocs/core/boxes/box_graph_orders_supplier_permonth.php
+++ b/htdocs/core/boxes/box_graph_orders_supplier_permonth.php
@@ -67,7 +67,6 @@ class box_graph_orders_supplier_permonth extends ModeleBoxes
 		$refreshaction='refresh_'.$this->boxcode;
 
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.commande.class.php';
-		$facturestatic=new Facture($db);
 
 		$text = $langs->trans("BoxSuppliersOrdersPerMonth",$max);
 		$this->info_box_head = array(


### PR DESCRIPTION
Instanciation on Facture objects created errors on the index page because the Facture class is never included. These objects were never uses so I just deleted them.
