### PR TITLE
fix wrong buy price update (confusion between entity and npr !)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,7 @@ English Dolibarr ChangeLog
 Fix: Bad rounding on margin calculations and display.
 Fix: Option drpo table into backup was broken.
 Fix: [ bug #1105 ] Searching Boxes other search option
-
+Fix: wrong buy price update
 
 ***** ChangeLog for 3.4.1 compared to 3.4.0 *****
 Fix: Display buying price on line edit when no supplier price is defined

--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -222,7 +222,7 @@ class ProductFournisseur extends Product
 		  		{
 		            // Add price for this quantity to supplier
 		            $sql = "INSERT INTO ".MAIN_DB_PREFIX."product_fournisseur_price(";
-		            $sql.= "datec, fk_product, fk_soc, ref_fourn, fk_user, price, quantity, remise_percent, remise, unitprice, tva_tx, charges, unitcharges, fk_availability, entity, info_bits)";
+		            $sql.= "datec, fk_product, fk_soc, ref_fourn, fk_user, price, quantity, remise_percent, remise, unitprice, tva_tx, charges, unitcharges, fk_availability, info_bits, entity)";
 		            $sql.= " values('".$this->db->idate($now)."',";
 		            $sql.= " ".$this->id.",";
 		            $sql.= " ".$fourn->id.",";


### PR DESCRIPTION
and i hope a lot there is not the same problem elsewhere because entity is kind of important in dolibarr foreign keys... (yes my supplier prices database is very corrupted and i'm as well irritated)
