### PR TITLE
bug #1179

### DIFF
--- a/htdocs/commande/liste.php
+++ b/htdocs/commande/liste.php
@@ -325,7 +325,8 @@ if ($resql)
 		print '</td>';
 
 		print '<td style="min-width: 20px" class="nobordernopadding nowrap">';
-		if (($objp->fk_statut > 0) && ($objp->fk_statut < 3) && $db->jdate($objp->date_valid) < ($now - $conf->commande->client->warning_delay)) print img_picto($langs->trans("Late"),"warning");
+		if (($objp->fk_statut > 0) && ($objp->fk_statut < 3) && max($db->jdate($objp->date_valid),$db->jdate($objp->date_livrais
+on)) < ($now - $conf->commande->client->warning_delay)) print img_picto($langs->trans("Late"),"warning");
 		if(!empty($objp->note_private))
 		{
 			print ' <span class="note">';


### PR DESCRIPTION
if there's a delivery date (date_livraison) then use it instead of the validation date (date_valid) to check if we need to display a warning or not...

For example, if we are in Septembre and there's an order that was validated in june but its delivery date is set to november then a warning is not necessary, since there's nothing to do but wait for the order to be delivered.

see https://doliforge.org/tracker/?func=detail&aid=1179&group_id=144
