### PR TITLE
Fix : when using several field for label into sellist extrafields

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -753,6 +753,7 @@ class ExtraFields
 						$fields_label = explode('|',$InfoFieldList[1]);
 						if(is_array($fields_label))
 						{
+							$notrans = true;
 							foreach ($fields_label as $field_toshow)
 							{
 								$labeltoshow.= $obj->$field_toshow.' ';
@@ -778,12 +779,15 @@ class ExtraFields
 						}
 						else
 						{
-							$translabel=$langs->trans($obj->$InfoFieldList[1]);
-							if ($translabel!=$obj->$InfoFieldList[1]) {
-								$labeltoshow=dol_trunc($translabel,18);
-							}
-							else {
-								$labeltoshow=dol_trunc($obj->$InfoFieldList[1],18);
+							if(!$notrans)
+							{
+								$translabel=$langs->trans($obj->$InfoFieldList[1]);
+								if ($translabel!=$obj->$InfoFieldList[1]) {
+									$labeltoshow=dol_trunc($translabel,18);
+								}
+								else {
+									$labeltoshow=dol_trunc($obj->$InfoFieldList[1],18);
+								}
 							}
 							if (empty($labeltoshow)) $labeltoshow='(not defined)';
 							if ($value==$obj->rowid)

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -958,11 +958,11 @@ class ExtraFields
 				{
 					foreach ($fields_label as $field_toshow)
 					{
-						$translabel=$langs->trans($obj->$InfoFieldList[1]);
-						if ($translabel!=$obj->$InfoFieldList[1]) {
-							$value=dol_trunc($translabel,18).' ';
+						$translabel=$langs->trans($field_toshow);
+						if ($translabel!=$field_toshow) {
+							$value.=dol_trunc($translabel,18).' ';
 						}else {
-							$value=$obj->$InfoFieldList[1].' ';
+							$value.=$obj->$field_toshow.' ';
 						}
 					}
 				}


### PR DESCRIPTION
Without this commit, the list displays "not defined". The translate key can't exists because displayed label is built from several fields so we show raw data, not using translation.
