### PR TITLE
Deprecated code

### DIFF
--- a/htdocs/core/filemanagerdol/connectors/php/util.php
+++ b/htdocs/core/filemanagerdol/connectors/php/util.php
@@ -208,27 +208,25 @@ function IsImageValid( $filePath, $extension )
 		return -1;
 	}
 
-	$imageCheckExtensions = array('gif', 'jpeg', 'jpg', 'png', 'swf', 'psd', 'bmp', 'iff');
-
-	// version_compare is available since PHP4 >= 4.0.7
-	if ( function_exists('version_compare') ) {
-		$sCurrentVersion = phpversion();
-		if ( version_compare($sCurrentVersion, "4.2.0") >= 0 ) {
-			$imageCheckExtensions[] = "tiff";
-			$imageCheckExtensions[] = "tif";
-		}
-		if ( version_compare($sCurrentVersion, "4.3.0") >= 0 ) {
-			$imageCheckExtensions[] = "swc";
-		}
-		if ( version_compare($sCurrentVersion, "4.3.2") >= 0 ) {
-			$imageCheckExtensions[] = "jpc";
-			$imageCheckExtensions[] = "jp2";
-			$imageCheckExtensions[] = "jpx";
-			$imageCheckExtensions[] = "jb2";
-			$imageCheckExtensions[] = "xbm";
-			$imageCheckExtensions[] = "wbmp";
-		}
-	}
+	$imageCheckExtensions = array(
+        'gif',
+        'jpeg',
+        'jpg',
+        'png',
+        'swf',
+        'psd',
+        'bmp',
+        'iff',
+        'tiff',
+        'tif',
+        'swc',
+        'jpc',
+        'jp2',
+        'jpx',
+        'jb2',
+        'xbm',
+        'wbmp'
+    );
 
 	if (!in_array($extension, $imageCheckExtensions) ) {
 		return true;

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -314,6 +314,7 @@ function dol_buildpath($path, $type=0)
  *	Create a clone of instance of object (new instance with same properties)
  * 	This function works for both PHP4 and PHP5
  *
+ *  @deprecated Dolibarr no longer supports PHP4, you can now use native function
  * 	@param	object	$object		Object to clone
  *	@return object				Object clone
  */
@@ -321,11 +322,6 @@ function dol_clone($object)
 {
 	dol_syslog("Functions.lib::dol_clone Clone object");
 
-	// We create dynamically a clone function, making a =
-	if (version_compare(phpversion(), '5.0') < 0 && ! function_exists('clone'))
-	{
-		eval('function clone($object){return($object);}');
-	}
 	$myclone=clone($object);
 	return $myclone;
 }

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -314,9 +314,9 @@ function dol_buildpath($path, $type=0)
  *	Create a clone of instance of object (new instance with same properties)
  * 	This function works for both PHP4 and PHP5
  *
- *  @deprecated Dolibarr no longer supports PHP4, you can now use native function
  * 	@param	object	$object		Object to clone
  *	@return object				Object clone
+ *  @deprecated Dolibarr no longer supports PHP4, you can now use native function
  */
 function dol_clone($object)
 {


### PR DESCRIPTION
Since Dolibarr now only supports PHP higher than 5.2.1, there is no need to maintain PHP4 code.
