### PR TITLE
Made test pessimistic by default

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -832,7 +832,7 @@ function dol_delete_file($file,$disableglob=0,$nophperrors=0,$nohook=0,$object=n
 		$error=0;
 
 		//print "x".$file." ".$disableglob;exit;
-		$ok=true;
+		$ok=false;
 		$file_osencoded=dol_osencode($file);    // New filename encoded in OS filesystem encoding charset
 		if (empty($disableglob) && ! empty($file_osencoded))
 		{

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -802,7 +802,7 @@ function dol_move_uploaded_file($src_file, $dest_file, $allowoverwrite, $disable
  */
 function dol_delete_file($file,$disableglob=0,$nophperrors=0,$nohook=0,$object=null)
 {
-	global $db, $conf, $user, $langs;
+	global $langs;
 	global $hookmanager;
 
 	$langs->load("other");
@@ -829,8 +829,6 @@ function dol_delete_file($file,$disableglob=0,$nophperrors=0,$nohook=0,$object=n
 	}
 	else
 	{
-		$error=0;
-
 		//print "x".$file." ".$disableglob;exit;
 		$ok=false;
 		$file_osencoded=dol_osencode($file);    // New filename encoded in OS filesystem encoding charset

--- a/test/phpunit/FilesLibTest.php
+++ b/test/phpunit/FilesLibTest.php
@@ -339,10 +339,9 @@ class FilesLibTest extends PHPUnit_Framework_TestCase
         print __METHOD__." result=".$result."\n";
         $this->assertTrue($result,'delete file');
 
-        // Again to test no error when deleteing a non existing file
         $result=dol_delete_file($conf->admin->dir_temp.'/file2.csv');
         print __METHOD__." result=".$result."\n";
-        $this->assertTrue($result,'delete file that does not exists');
+        $this->assertFalse($result,'delete file that does not exists');
 
         // Test copy with special char / delete with blob
         $result=dol_copy($file, $conf->admin->dir_temp.'/file with [x] and é.csv',0,1);


### PR DESCRIPTION
The test result was wrong if, for example, the path was wrong.
The unlink() function being never called, it returned the default true value even if it didn't
remove a file.
