### PR TITLE
TCPDF: Replaced missing courier monotype font by provided freemono

### DIFF
--- a/dev/dolibarr_changes.txt
+++ b/dev/dolibarr_changes.txt
@@ -39,6 +39,11 @@ into
 	// initialize subsetchars
 	$subsetchars = array_fill(0, 256, true);
 
+* Made freemono the default monotype font because we removed courier
+In htdocs/includes/tcpdf/tcpdf.php
+-       protected $default_monospaced_font = 'courier';
++       protected $default_monospaced_font = 'freemono';
+
 
 JSGANTT:
 --------

--- a/htdocs/includes/tcpdf/tcpdf.php
+++ b/htdocs/includes/tcpdf/tcpdf.php
@@ -1258,7 +1258,7 @@ class TCPDF {
 	 * @protected
 	 * @since 4.5.025 (2009-03-10)
 	 */
-	protected $default_monospaced_font = 'courier';
+	protected $default_monospaced_font = 'freemono';
 
 	/**
 	 * Cloned copy of the current class object.


### PR DESCRIPTION
The courier font is missing from TCPDF's directory.
This leads to "TCPDF ERROR: Could not include font definition file: courier" being outputed by PHP
when the library attempts to render an element with a monotyped font.
Use freemono instead since it's a better alternative (e.g. supports more glyphs) and is already
shipped with Dolibarr.
