### PR TITLE
Locale line ODT tags

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@ For users:
 - New: Add filter on text and status into survey list. Can also sorter on id, text and date end.
 - New: Add option MAIN_FAVICON_URL
 - Fix: Project Task numbering rule customs rule works
+- New: Created {line_price_ht_locale}, {line_price_vat_locale} and {line_price_ttc_locale} ODT tags
 
 TODO
 - New: Predefined product and free product use same form.

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010-2012 	Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2012		Juanjo Menent		<jmenent@2byte.es>
+ * Copyright (C) 2014		Marcos García		<marcosgdf@gmail.com>
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -93,7 +93,7 @@ class doc_generic_order_odt extends ModelePDFCommandes
 	 * @param   Translate		$outputlangs        Lang object to use for output
 	 * @return	array								Array of substitution
 	 */
-	function get_substitutionarray_object($object,$outputlangs)
+	function get_substitutionarray_object($object, Translate $outputlangs)
 	{
 		global $conf;
 
@@ -176,6 +176,9 @@ class doc_generic_order_odt extends ModelePDFCommandes
 		'line_price_ht'=>price($line->total_ht, 0, $outputlangs),
 		'line_price_ttc'=>price($line->total_ttc, 0, $outputlangs),
 		'line_price_vat'=>price($line->total_tva, 0, $outputlangs),
+			'line_price_ht_locale'=>price($line->total_ht, 0, $outputlangs),
+			'line_price_ttc_locale'=>price($line->total_ttc, 0, $outputlangs),
+			'line_price_vat_locale'=>price($line->total_tva, 0, $outputlangs),
 		'line_date_start'=>$line->date_start,
 		'line_date_end'=>$line->date_end
 		);

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -165,22 +165,22 @@ class doc_generic_order_odt extends ModelePDFCommandes
 		global $conf;
 
 		return array(
-		'line_fulldesc'=>doc_getlinedesc($line,$outputlangs),
-		'line_product_ref'=>$line->product_ref,
-		'line_product_label'=>$line->product_label,
-		'line_desc'=>$line->desc,
-		'line_vatrate'=>vatrate($line->tva_tx,true,$line->info_bits),
-		'line_up'=>price($line->subprice, 0, $outputlangs),
-		'line_qty'=>$line->qty,
-		'line_discount_percent'=>($line->remise_percent?$line->remise_percent.'%':''),
-		'line_price_ht'=>price($line->total_ht, 0, $outputlangs),
-		'line_price_ttc'=>price($line->total_ttc, 0, $outputlangs),
-		'line_price_vat'=>price($line->total_tva, 0, $outputlangs),
+			'line_fulldesc'=>doc_getlinedesc($line,$outputlangs),
+			'line_product_ref'=>$line->product_ref,
+			'line_product_label'=>$line->product_label,
+			'line_desc'=>$line->desc,
+			'line_vatrate'=>vatrate($line->tva_tx,true,$line->info_bits),
+			'line_up'=>price($line->subprice, 0, $outputlangs),
+			'line_qty'=>$line->qty,
+			'line_discount_percent'=>($line->remise_percent?$line->remise_percent.'%':''),
+			'line_price_ht'=>price($line->total_ht, 0, $outputlangs),
+			'line_price_ttc'=>price($line->total_ttc, 0, $outputlangs),
+			'line_price_vat'=>price($line->total_tva, 0, $outputlangs),
 			'line_price_ht_locale'=>price($line->total_ht, 0, $outputlangs),
 			'line_price_ttc_locale'=>price($line->total_ttc, 0, $outputlangs),
 			'line_price_vat_locale'=>price($line->total_tva, 0, $outputlangs),
-		'line_date_start'=>$line->date_start,
-		'line_date_end'=>$line->date_end
+			'line_date_start'=>$line->date_start,
+			'line_date_end'=>$line->date_end
 		);
 	}
 

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010-2012 	Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2012		Juanjo Menent		<jmenent@2byte.es>
+ * Copyright (C) 2014		Marcos García		<marcosgdf@gmail.com>
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -150,7 +150,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 	 *	@param  Translate		$outputlangs        Lang object to use for output
 	 *  @return	array								Return a substitution array
 	 */
-	function get_substitutionarray_lines($line,$outputlangs)
+	function get_substitutionarray_lines($line, Translate $outputlangs)
 	{
 		global $conf;
 
@@ -163,9 +163,12 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 		'line_up'=>price($line->subprice, 0, $outputlangs),
 		'line_qty'=>$line->qty,
 		'line_discount_percent'=>($line->remise_percent?$line->remise_percent.'%':''),
-		'line_price_ht'=>price($line->total_ht, 0, $outputlangs),
-		'line_price_ttc'=>price($line->total_ttc, 0, $outputlangs),
-		'line_price_vat'=>price($line->total_tva, 0, $outputlangs),
+			'line_price_ht'=>price2num($line->total_ht), 
+			'line_price_ttc'=>price2num($line->total_ttc),
+			'line_price_vat'=>price2num($line->total_tva),
+			'line_price_ht_locale'=>price($line->total_ht, 0, $outputlangs), 
+			'line_price_ttc_locale'=>price($line->total_ttc, 0, $outputlangs),
+			'line_price_vat_locale'=>price($line->total_tva, 0, $outputlangs),
 		'line_date_start'=>$line->date_start,
 		'line_date_end'=>$line->date_end
 		);

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -155,22 +155,22 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 		global $conf;
 
 		return array(
-		'line_fulldesc'=>doc_getlinedesc($line,$outputlangs),
-		'line_product_ref'=>$line->product_ref,
-		'line_product_label'=>$line->product_label,
-		'line_desc'=>$line->desc,
-		'line_vatrate'=>vatrate($line->tva_tx,true,$line->info_bits),
-		'line_up'=>price($line->subprice, 0, $outputlangs),
-		'line_qty'=>$line->qty,
-		'line_discount_percent'=>($line->remise_percent?$line->remise_percent.'%':''),
+			'line_fulldesc'=>doc_getlinedesc($line,$outputlangs),
+			'line_product_ref'=>$line->product_ref,
+			'line_product_label'=>$line->product_label,
+			'line_desc'=>$line->desc,
+			'line_vatrate'=>vatrate($line->tva_tx,true,$line->info_bits),
+			'line_up'=>price($line->subprice, 0, $outputlangs),
+			'line_qty'=>$line->qty,
+			'line_discount_percent'=>($line->remise_percent?$line->remise_percent.'%':''),
 			'line_price_ht'=>price2num($line->total_ht), 
 			'line_price_ttc'=>price2num($line->total_ttc),
 			'line_price_vat'=>price2num($line->total_tva),
 			'line_price_ht_locale'=>price($line->total_ht, 0, $outputlangs), 
 			'line_price_ttc_locale'=>price($line->total_ttc, 0, $outputlangs),
 			'line_price_vat_locale'=>price($line->total_tva, 0, $outputlangs),
-		'line_date_start'=>$line->date_start,
-		'line_date_end'=>$line->date_end
+			'line_date_start'=>$line->date_start,
+			'line_date_end'=>$line->date_end
 		);
 	}
 

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -180,22 +180,22 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 		global $conf;
 
 		return array(
-		'line_fulldesc'=>doc_getlinedesc($line,$outputlangs),
-		'line_product_ref'=>$line->product_ref,
-		'line_product_label'=>$line->product_label,
-		'line_desc'=>$line->desc,
-		'line_vatrate'=>vatrate($line->tva_tx,true,$line->info_bits),
-		'line_up'=>price($line->subprice, 0, $outputlangs),
-		'line_qty'=>$line->qty,
-		'line_discount_percent'=>($line->remise_percent?$line->remise_percent.'%':''),
-		'line_price_ht'=>price2num($line->total_ht),
-		'line_price_ttc'=>price2num($line->total_ttc),
-		'line_price_vat'=>price2num($line->total_tva),
+			'line_fulldesc'=>doc_getlinedesc($line,$outputlangs),
+			'line_product_ref'=>$line->product_ref,
+			'line_product_label'=>$line->product_label,
+			'line_desc'=>$line->desc,
+			'line_vatrate'=>vatrate($line->tva_tx,true,$line->info_bits),
+			'line_up'=>price($line->subprice, 0, $outputlangs),
+			'line_qty'=>$line->qty,
+			'line_discount_percent'=>($line->remise_percent?$line->remise_percent.'%':''),
+			'line_price_ht'=>price2num($line->total_ht),
+			'line_price_ttc'=>price2num($line->total_ttc),
+			'line_price_vat'=>price2num($line->total_tva),
 			'line_price_ht_locale'=>price($line->total_ht, 0, $outputlangs),
 			'line_price_ttc_locale'=>price($line->total_ttc, 0, $outputlangs),
 			'line_price_vat_locale'=>price($line->total_tva, 0, $outputlangs),
-		'line_date_start'=>dol_print_date($line->date_start, 'day', false, $outputlangs),
-		'line_date_end'=>dol_print_date($line->date_end, 'day', false, $outputlangs),
+			'line_date_start'=>dol_print_date($line->date_start, 'day', false, $outputlangs),
+			'line_date_end'=>dol_print_date($line->date_end, 'day', false, $outputlangs),
 		);
 	}
 

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -1,7 +1,8 @@
 <?php
 /* Copyright (C) 2010-2012	Laurent Destailleur	<ely@users.sourceforge.net>
  * Copyright (C) 2012		Regis Houssin		<regis.houssin@capnetworks.com>
-
+* Copyright (C) 2014		Marcos García		<marcosgdf@gmail.com>
+* 
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 3 of the License, or

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -175,7 +175,7 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 	 * @param   Translate	$outputlangs    Lang object to use for output
 	 * @return	array						Return substitution array
 	 */
-	function get_substitutionarray_lines($line,$outputlangs)
+	function get_substitutionarray_lines($line, Translate $outputlangs)
 	{
 		global $conf;
 
@@ -191,6 +191,9 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 		'line_price_ht'=>price2num($line->total_ht),
 		'line_price_ttc'=>price2num($line->total_ttc),
 		'line_price_vat'=>price2num($line->total_tva),
+			'line_price_ht_locale'=>price($line->total_ht, 0, $outputlangs),
+			'line_price_ttc_locale'=>price($line->total_ttc, 0, $outputlangs),
+			'line_price_vat_locale'=>price($line->total_tva, 0, $outputlangs),
 		'line_date_start'=>dol_print_date($line->date_start, 'day', false, $outputlangs),
 		'line_date_end'=>dol_print_date($line->date_end, 'day', false, $outputlangs),
 		);


### PR DESCRIPTION
The purpose of this PR is to create the following tags:
- {line_price_ht_locale}
- {line_price_vat_locale}
- {line_price_ttc_locale}

Because order and shipment modules were assigning locale number format to non-locale tag and this behaviour was not correct, I've changed it.

Also, I've corrected array indentation, that's why you may see many changes (i've separated it into 2 commits so that PR check is easier)
