### PR TITLE
Fix: Agenda and Banks module were not working with multicompany module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Fix: Warning into bank conciliation feature.
 Fix: Bad get of localtaxes into contracts add lines.
 Fix: Add a limit into list to avoid browser to hang when database is too large.
 Fix: [ bug #1212 ] 'jqueryFileTree.php' directory traversal vulnerability
+Fix: Agenda and Banks module were not working with multicompany module
 
 ***** ChangeLog for 3.4.2 compared to 3.4.1 *****
 Fix: field's problem into company's page (RIB).

--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -311,7 +311,7 @@ $sql.= " ".MAIN_DB_PREFIX."actioncomm as a)";
 if (! $user->rights->societe->client->voir && ! $socid) $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON a.fk_soc = sc.fk_soc";
 $sql.= ' WHERE a.fk_action = ca.id';
 $sql.= ' AND a.fk_user_author = u.rowid';
-$sql.= ' AND a.entity IN ('.getEntity().')';
+$sql.= ' AND a.entity IN ('.getEntity('agenda', 1).')';
 if ($actioncode) $sql.=" AND ca.code='".$db->escape($actioncode)."'";
 if ($pid) $sql.=" AND a.fk_project=".$db->escape($pid);
 if (! $user->rights->societe->client->voir && ! $socid) $sql.= " AND (a.fk_soc IS NULL OR sc.fk_user = " .$user->id . ")";

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -125,6 +125,7 @@ function restrictedArea($user, $features, $objectid=0, $dbtablename='', $feature
     $params = explode('&', $dbtablename);
     $dbtablename=(! empty($params[0]) ? $params[0] : '');
     $sharedelement=(! empty($params[1]) ? $params[1] : '');
+    $sharedelement=(! empty($params[1]) ? $params[1] : $params[0]);
 
 	$listofmodules=explode(',',$conf->global->MAIN_MODULES_FOR_EXTERNAL);
 

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -124,7 +124,6 @@ function restrictedArea($user, $features, $objectid=0, $dbtablename='', $feature
     // More parameters
     $params = explode('&', $dbtablename);
     $dbtablename=(! empty($params[0]) ? $params[0] : '');
-    $sharedelement=(! empty($params[1]) ? $params[1] : '');
     $sharedelement=(! empty($params[1]) ? $params[1] : $params[0]);
 
 	$listofmodules=explode(',',$conf->global->MAIN_MODULES_FOR_EXTERNAL);

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -124,7 +124,7 @@ function restrictedArea($user, $features, $objectid=0, $dbtablename='', $feature
     // More parameters
     $params = explode('&', $dbtablename);
     $dbtablename=(! empty($params[0]) ? $params[0] : '');
-    $sharedelement=(! empty($params[1]) ? $params[1] : $params[0]);
+    $sharedelement=(! empty($params[1]) ? $params[1] : $dbtablename);
 
 	$listofmodules=explode(',',$conf->global->MAIN_MODULES_FOR_EXTERNAL);
 


### PR DESCRIPTION
Multicompany module has a feature that allows information sharing across diferent entities. Because agenda module does not set the element and share variables, the information was not shared event if it was configured to do it.

Also, the banks module was not getting the element name if it was not set. But the module itself looks for the table name, so this could be the fix.
