### PR TITLE
select_date: in memory timestamp should be UTC

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3322,7 +3322,7 @@ class Form
         if($m == '') $m=0;
         if($empty == '') $empty=0;
 
-        if (! $set_time && $empty == 0) $set_time = dol_now('tzuser');
+        if (! $set_time && $empty == 0) $set_time = dol_now();
 
         // Analysis of the pre-selection date
         if (preg_match('/^([0-9]+)\-([0-9]+)\-([0-9]+)\s?([0-9]+)?:?([0-9]+)?/',$set_time,$reg))


### PR DESCRIPTION
This induced a subtle hour bug because the `dol_print_date()` on the following lines were expecting an UTC timestamp.

Please also merge to 3.4, 3.5 and develop (do **not** cherry_pick).
