### PR TITLE
Fix installation script link to Task 1074 (missing new field)

### DIFF
--- a/htdocs/install/mysql/tables/llx_stock_mouvement.sql
+++ b/htdocs/install/mysql/tables/llx_stock_mouvement.sql
@@ -29,4 +29,6 @@ create table llx_stock_mouvement
   type_mouvement  smallint,
   fk_user_author  integer,
   label           varchar(128)
+  fk_origin       integer,
+  origintype      varchar(32)
 )ENGINE=innodb;


### PR DESCRIPTION
New fields are include in migration script but not in build database script
