### PR TITLE
FIX : [ bug #1317 ] Removing a category does not remove all child categories

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -292,6 +292,20 @@ class Categorie
 
 		$this->db->begin();
 
+		/* FIX #1317 : Check for child cat and move up 1 level*/
+		if (! $error)
+		{
+			$sql = "UPDATE ".MAIN_DB_PREFIX."categorie";
+			$sql.= " SET fk_parent = ".$this->fk_parent; 
+			$sql.= " WHERE fk_parent = ".$this->id;
+
+			if (!$this->db->query($sql))
+			{
+				$this->error=$this->db->lasterror();
+				dol_syslog("Error sql=".$sql." ".$this->error, LOG_ERR);
+				$error++;
+			}
+		}
 		if (! $error)
 		{
 			$sql  = "DELETE FROM ".MAIN_DB_PREFIX."categorie_societe";


### PR DESCRIPTION
Orphaned child are move up by one level when deleting parent categories
