### PR TITLE
Missing include contrat.class.php

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -29,6 +29,7 @@
  */
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
 require_once(DOL_DOCUMENT_ROOT ."/margin/lib/margins.lib.php");
 
 /**


### PR DESCRIPTION
Missing include for function calcul_price_total.
