### PR TITLE
Fix: [ bug #1393 ] PHP Warning when creating a supplier invoice.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ Fix: [ bug #1381 ] PHP Warning when listing stock transactions page.
 Fix: [ bug #1367 ] "Show invoice" link after a POS sell throws an error.
 Fix: TCPDF error file not found in member card generation.
 Fix: [ bug #1380 ] Customer invoices are not grouped in company results report.
+Fix: [ bug #1393 ] PHP Warning when creating a supplier invoice.
 
 ***** ChangeLog for 3.5.2 compared to 3.5.1 *****
 Fix: Can't add user for a task.

--- a/htdocs/fourn/facture/fiche.php
+++ b/htdocs/fourn/facture/fiche.php
@@ -461,6 +461,7 @@ elseif ($action == 'add' && $user->rights->fournisseur->facture->creer)
             $db->commit();
 
             if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) {
+	            $outputlangs = $langs;
             	$result=supplier_invoice_pdf_create($db, $object, $object->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
             	if ($result	<= 0)
             	{


### PR DESCRIPTION
Fix: [ bug #1393 ] PHP Warning when creating a supplier invoice.
