### PR TITLE
Fix: [ bug #1391 ] Available "Create invoice" button for supplier-related pages and "last 5 invoices" even if the invoices module is not enabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ Fix: [ bug #1381 ] PHP Warning when listing stock transactions page.
 Fix: [ bug #1367 ] "Show invoice" link after a POS sell throws an error.
 Fix: TCPDF error file not found in member card generation.
 Fix: [ bug #1380 ] Customer invoices are not grouped in company results report.
+Fix: [ bug #1391 ] Available "Create invoice" button for supplier-related pages and "last 5 invoices" even if the invoices module is not enabled
 
 ***** ChangeLog for 3.5.2 compared to 3.5.1 *****
 Fix: Can't add user for a task.

--- a/htdocs/fourn/commande/fiche.php
+++ b/htdocs/fourn/commande/fiche.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@capnetworks.com>
  * Copyright (C) 2010-2013 Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2011      Philippe Grand       <philippe.grand@atoo-net.com>
- * Copyright (C) 2012      Marcos García        <marcosgdf@gmail.com>
+ * Copyright (C) 2012-2014 Marcos García        <marcosgdf@gmail.com>
  * Copyright (C) 2013      Florian Henry        <florian.henry@open-concept.pro>
  *
  * This	program	is free	software; you can redistribute it and/or modify
@@ -1889,7 +1889,7 @@ elseif (! empty($object->id))
 			}
 
 			// Create bill
-			if (! empty($conf->fournisseur->enabled) && $object->statut >= 2)  // 2 means accepted
+			if (! empty($conf->fournisseur->enabled) && $conf->facture->enabled && $conf->$object->statut >= 2)  // 2 means accepted
 			{
 				if ($user->rights->fournisseur->facture->creer)
 				{

--- a/htdocs/fourn/fiche.php
+++ b/htdocs/fourn/fiche.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2004-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2010 Regis Houssin        <regis.houssin@capnetworks.com>
  * Copyright (C) 2010-2013 Juanjo Menent        <jmenent@2byte.es>
+ * Copyright (C) 2014      Marcos García        <marcosgdf@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -369,11 +370,10 @@ if ($object->fetch($id))
 	 */
 	$MAXLIST=5;
 
-	$langs->load('bills');
-	$facturestatic = new FactureFournisseur($db);
-
-	if ($user->rights->fournisseur->facture->lire)
+	if ($user->rights->fournisseur->facture->lire && $conf->facture->enabled)
 	{
+		$facturestatic = new FactureFournisseur($db);
+
 		// TODO move to DAO class
 		$sql = 'SELECT f.rowid,f.libelle,f.ref_supplier,f.fk_statut,f.datef as df,f.total_ttc as amount,f.paye,';
 		$sql.= ' SUM(pf.amount) as am';
@@ -441,7 +441,7 @@ if ($object->fetch($id))
 		print '<a class="butAction" href="'.DOL_URL_ROOT.'/fourn/commande/fiche.php?action=create&socid='.$object->id.'">'.$langs->trans("AddOrder").'</a>';
 	}
 
-	if ($user->rights->fournisseur->facture->creer)
+	if ($user->rights->fournisseur->facture->creer && $conf->facture->enabled)
 	{
 		$langs->load("bills");
 		print '<a class="butAction" href="'.DOL_URL_ROOT.'/fourn/facture/fiche.php?action=create&socid='.$object->id.'">'.$langs->trans("AddBill").'</a>';

--- a/htdocs/fourn/fiche.php
+++ b/htdocs/fourn/fiche.php
@@ -28,7 +28,6 @@
 
 require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.class.php';
-require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
 require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
 if (! empty($conf->adherent->enabled)) require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
@@ -372,6 +371,9 @@ if ($object->fetch($id))
 
 	if ($user->rights->fournisseur->facture->lire && $conf->facture->enabled)
 	{
+
+		require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
+
 		$facturestatic = new FactureFournisseur($db);
 
 		// TODO move to DAO class


### PR DESCRIPTION
Fix: [ bug #1391 ] Available "Create invoice" button for supplier-related pages and "last 5 invoices" even if the invoices module is not enabled
