### PR TITLE
Fix: [ bug #1397 ] Filter by supplier orders with status Draft does not filter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ Fix: [ bug #1381 ] PHP Warning when listing stock transactions page.
 Fix: [ bug #1367 ] "Show invoice" link after a POS sell throws an error.
 Fix: TCPDF error file not found in member card generation.
 Fix: [ bug #1380 ] Customer invoices are not grouped in company results report.
+Fix: [ bug #1397 ] Filter by supplier orders with status Draft does not filter
 
 ***** ChangeLog for 3.5.2 compared to 3.5.1 *****
 Fix: Can't add user for a task.

--- a/htdocs/fourn/commande/liste.php
+++ b/htdocs/fourn/commande/liste.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2004-2010 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@capnetworks.com>
  * Copyright (C) 2013      Cédric Salvador      <csalvador@gpcsolutions.fr>
+ * Copyright (C) 2014      Marcos García        <marcosgdf@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -113,7 +114,8 @@ if ($sall)
 }
 if ($socid) $sql.= " AND s.rowid = ".$socid;
 
-if (GETPOST('statut'))
+//Required triple check because statut=0 means draft filter
+if (GETPOST('statut', 'int') !== '')
 {
 	$sql .= " AND fk_statut =".GETPOST('statut','int');
 }


### PR DESCRIPTION
[ bug #1397 ] Filter by supplier orders with status Draft does not filter
