### PR TITLE
Fix: [ bug #1411 ] Unable to set an expedition note if invoices module is not enabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -113,6 +113,7 @@ Fix: [ bug #1306 ] Fatal error when adding an external calendar.
 New: Added es_CL language
 Fix: Margin tabs bad data show
 Fix: [ bug #1318 ] Problem with enter key when adding an existing product to a customer invoice.
+Fix: [ bug #1411 ] Unable to set an expedition note if invoices module is not enabled
 
 ***** ChangeLog for 3.5 compared to 3.4.* *****
 For users:

--- a/htdocs/expedition/note.php
+++ b/htdocs/expedition/note.php
@@ -77,14 +77,14 @@ if ($id > 0 || ! empty($ref))
 /*                     Actions                                                */
 /******************************************************************************/
 
-if ($action == 'setnote_public' && $user->rights->facture->creer)
+if ($action == 'setnote_public')
 {
 	$object->fetch($id);
 	$result=$object->update_note(dol_html_entity_decode(GETPOST('note_public'), ENT_QUOTES),'_public');
 	if ($result < 0) dol_print_error($db,$object->error);
 }
 
-else if ($action == 'setnote_private' && $user->rights->facture->creer)
+else if ($action == 'setnote_private')
 {
 	$object->fetch($id);
 	$result=$object->update_note(dol_html_entity_decode(GETPOST('note_private'), ENT_QUOTES),'_private');


### PR DESCRIPTION
Fix: [ bug #1411 ] Unable to set an expedition note if invoices module is not enabled
