### PR TITLE
Fix: [ bug #1405 ] Rouget PDF expedition incorrect when two expeditions under the same commande

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ Fix: [ bug #1381 ] PHP Warning when listing stock transactions page.
 Fix: [ bug #1367 ] "Show invoice" link after a POS sell throws an error.
 Fix: TCPDF error file not found in member card generation.
 Fix: [ bug #1380 ] Customer invoices are not grouped in company results report.
+Fix: [ bug #1405 ] Rouget PDF expedition incorrect when two expeditions under the same commande
 
 ***** ChangeLog for 3.5.2 compared to 3.5.1 *****
 Fix: Can't add user for a task.

--- a/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
@@ -179,7 +179,7 @@ class pdf_rouget extends ModelePdfExpedition
 				$tab_height = 130;
 				$tab_height_newpage = 150;
 
-				if (! empty($object->note_public) || ! empty($object->tracking_number))
+				if (! empty($object->note_public) || (! empty($object->tracking_number) && ! empty($object->shipping_method_id)))
 				{
 					$tab_top = 88;
 


### PR DESCRIPTION
Fix: [ bug #1405 ] Rouget PDF expedition incorrect when two expeditions under the same commande
