### PR TITLE
 Fix: [ bug #1434 ] Muscadet supplier order document model linked objects overlap the text

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,7 @@ Fix: [ bug #1388 ] Wrong date when invoicing several orders.
 Fix: [ bug #1411 ] Unable to set an expedition note if invoices module is not enabled.
 Fix: [ bug #1407 ] Rouget pdf overlapped when using tracking number and public notes.
 Fix: [ bug #1405 ] Rouget PDF expedition incorrect when two expeditions under the same commande
+Fix: [ bug #1434 ] Muscadet supplier order document model linked objects overlap the text
 
 ***** ChangeLog for 3.5.2 compared to 3.5.1 *****
 Fix: Can't add user for a task.

--- a/htdocs/core/modules/supplier_order/pdf/pdf_muscadet.modules.php
+++ b/htdocs/core/modules/supplier_order/pdf/pdf_muscadet.modules.php
@@ -991,7 +991,7 @@ class pdf_muscadet extends ModelePDFSuppliersOrders
 			$pdf->MultiCell(100, 3, $outputlangs->transnoentities("OrderToProcess"), '', 'R');
 		}
 
-		$posy+=2;
+		$posy+=5;
 		$pdf->SetTextColor(0,0,60);
 
 		// Show list of linked objects


### PR DESCRIPTION
Fix: [ bug #1434 ] Muscadet supplier order document model linked objects overlap the text
