### PR TITLE
Update facture.php foreach wrong argument

### DIFF
--- a/htdocs/admin/facture.php
+++ b/htdocs/admin/facture.php
@@ -500,7 +500,7 @@ print "</tr>\n";
 clearstatcache();
 
 $var=true;
-foreach ($dirmodels as $reldir)
+foreach ($def as $reldir)
 {
     foreach (array('','/doc') as $valdir)
     {


### PR DESCRIPTION
Wrong array in foreach line 503.
With previous version, cutom option doesn't show in invoice module configuration.
