### PR TITLE
Fix: [ bug #1415 ] Intervention document model name and suppliers model names is not shown properly in module configuration

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
 English Dolibarr ChangeLog
 --------------------------------------------------------------
 
+***** ChangeLog for 3.5.4 compared to 3.5.2 *****
+Fix: [ bug #1415 ] Intervention document model name and suppliers model names is not shown properly in module configuration
+
 ***** ChangeLog for 3.5.3 compared to 3.5.2 *****
 Fix: Error on field accountancy code for export profile of invoices.
 Fix: [ bug #1351 ] VIES verification link broken.

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 English Dolibarr ChangeLog
 --------------------------------------------------------------
 
-***** ChangeLog for 3.5.4 compared to 3.5.2 *****
+***** ChangeLog for 3.5.4 compared to 3.5.3 *****
 Fix: [ bug #1415 ] Intervention document model name and suppliers model names is not shown properly in module configuration
 
 ***** ChangeLog for 3.5.3 compared to 3.5.2 *****

--- a/htdocs/admin/fichinter.php
+++ b/htdocs/admin/fichinter.php
@@ -376,13 +376,16 @@ foreach ($dirmodels as $reldir)
 		    {
 		    	if (substr($file, dol_strlen($file) -12) == '.modules.php' && substr($file,0,4) == 'pdf_')
 		    	{
+				    $var=!$var;
+
 		    		$name = substr($file, 4, dol_strlen($file) -16);
 		    		$classname = substr($file, 0, dol_strlen($file) -12);
 
-		    		$var=!$var;
+				    require_once $dir.'/'.$file;
+				    $module = new $classname($db);
 
 		    		print '<tr '.$bc[$var].'><td>';
-		    		echo "$name";
+				    print (empty($module->name)?$name:$module->name);
 		    		print "</td><td>\n";
 		    		require_once $dir.$file;
 		    		$module = new $classname($db);

--- a/htdocs/admin/supplier_invoice.php
+++ b/htdocs/admin/supplier_invoice.php
@@ -372,9 +372,14 @@ foreach ($dirmodels as $reldir)
                     $name = substr($file, 4, dol_strlen($file) -16);
                     $classname = substr($file, 0, dol_strlen($file) -12);
 
+	                require_once $dir.'/'.$file;
+	                $module = new $classname($db, new FactureFournisseur($db));
+
                     $var=!$var;
                     print "<tr ".$bc[$var].">\n";
-                    print "<td>".$name."</td>\n";
+                    print "<td>";
+	                print (empty($module->name)?$name:$module->name);
+	                print "</td>\n";
                     print "<td>\n";
                     require_once $dir.$file;
                     $module = new $classname($db,$specimenthirdparty);

--- a/htdocs/admin/supplier_order.php
+++ b/htdocs/admin/supplier_order.php
@@ -367,9 +367,14 @@ foreach ($dirmodels as $reldir)
                     $name = substr($file, 4, dol_strlen($file) -16);
                     $classname = substr($file, 0, dol_strlen($file) -12);
 
+	                require_once $dir.'/'.$file;
+	                $module = new $classname($db, new CommandeFournisseur($db));
+
                     $var=!$var;
                     print "<tr ".$bc[$var].">\n";
-                    print "<td>".$name."</td>\n";
+                    print "<td>";
+	                print (empty($module->name)?$name:$module->name);
+	                print "</td>\n";
                     print "<td>\n";
                     require_once $dir.$file;
                     $module = new $classname($db,$specimenthirdparty);


### PR DESCRIPTION
Fix: [ bug #1415 ] Intervention document model name and suppliers model names is not shown properly in module configuration
