### PR TITLE
Fix: [ bug #1416 ] Supplier order does not list document models in the select box of the supplier order card

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
 English Dolibarr ChangeLog
 --------------------------------------------------------------
 
+***** ChangeLog for 3.5.4 compared to 3.5.3 *****
+Fix: [ bug #1416 ] Supplier order does not list document models in the select box of the supplier order card
+
 ***** ChangeLog for 3.5.3 compared to 3.5.2 *****
 Fix: Error on field accountancy code for export profile of invoices.
 Fix: [ bug #1351 ] VIES verification link broken.

--- a/htdocs/admin/supplier_order.php
+++ b/htdocs/admin/supplier_order.php
@@ -42,6 +42,7 @@ accessforbidden();
 
 $type=GETPOST('type', 'alpha');
 $value=GETPOST('value', 'alpha');
+$label = GETPOST('label','alpha');
 $action=GETPOST('action', 'alpha');
 
 $specimenthirdparty=new Societe($db);


### PR DESCRIPTION
Fix: [ bug #1416 ] Supplier order does not list document models in the select box of the supplier order card
