### PR TITLE
Fix: [ bug #1449 ] Trigger ORDER_CREATE, LINEORDER_DELETE, LINEORDER_UPDATE and LINEORDER_INSERT ignore interception on error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,7 +29,7 @@ Fix: [ bug #1353 ] Email notifications, wrong URL.
 Fix: [ bug #1362 ] Note is not saved.
 Fix: tr/td balance.
 Fix: [ bug #1360 ] note indicator for member tab.
-Fix: Nb of notes and doc not visible onto task
+Fix: Nb of notes and doc not visible onto tasks.
 Fix: [ bug #1372 ] Margin calculation does not work in proposals.
 Fix: [ bug #1381 ] PHP Warning when listing stock transactions page.
 Fix: [ bug #1367 ] "Show invoice" link after a POS sell throws an error.

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Fix: [ bug #1416 ] Supplier order does not list document models in the select bo
      supplier order card
 Fix: [ bug #1443 ] Payment conditions is erased after editing supplier invoice label or 
      limit date for payment
+Fix: [ bug #1449 ] Trigger ORDER_CREATE ignores interception on error
 
 ***** ChangeLog for 3.5.3 compared to 3.5.2 *****
 Fix: Error on field accountancy code for export profile of invoices.

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Fix: [ bug #1416 ] Supplier order does not list document models in the select bo
      supplier order card
 Fix: [ bug #1443 ] Payment conditions is erased after editing supplier invoice label or 
      limit date for payment
-Fix: [ bug #1449 ] Trigger ORDER_CREATE ignores interception on error
+Fix: [ bug #1449 ] Trigger ORDER_CREATE, LINEORDER_DELETE, LINEORDER_UPDATE and LINEORDER_INSERT ignore interception on error
 
 ***** ChangeLog for 3.5.3 compared to 3.5.2 *****
 Fix: Error on field accountancy code for export profile of invoices.
@@ -29,7 +29,7 @@ Fix: [ bug #1353 ] Email notifications, wrong URL.
 Fix: [ bug #1362 ] Note is not saved.
 Fix: tr/td balance.
 Fix: [ bug #1360 ] note indicator for member tab.
-Fix: Nb of notes and doc not visible onto tasks.
+Fix: Nb of notes and doc not visible onto task
 Fix: [ bug #1372 ] Margin calculation does not work in proposals.
 Fix: [ bug #1381 ] PHP Warning when listing stock transactions page.
 Fix: [ bug #1367 ] "Show invoice" link after a POS sell throws an error.

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3294,8 +3294,18 @@ class OrderLine extends CommonOrderLine
                 // Fin appel triggers
             }
 
-            $this->db->commit();
-            return 1;
+	        if (!$error) {
+		        $this->db->commit();
+		        return 1;
+	        }
+
+	        foreach($this->errors as $errmsg)
+	        {
+		        dol_syslog(get_class($this)."::delete ".$errmsg, LOG_ERR);
+		        $this->error.=($this->error?', '.$errmsg:$errmsg);
+	        }
+	        $this->db->rollback();
+	        return -1*$error;
         }
         else
         {

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3402,8 +3402,18 @@ class OrderLine extends CommonOrderLine
 				// Fin appel triggers
 			}
 
-			$this->db->commit();
-			return 1;
+			if (!$error) {
+				$this->db->commit();
+				return 1;
+			}
+
+			foreach($this->errors as $errmsg)
+			{
+				dol_syslog(get_class($this)."::update ".$errmsg, LOG_ERR);
+				$this->error.=($this->error?', '.$errmsg:$errmsg);
+			}
+			$this->db->rollback();
+			return -1*$error;
 		}
 		else
 		{

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3140,6 +3140,8 @@ class OrderLine extends CommonOrderLine
 
 		$error=0;
 
+	    $this->db->begin();
+
         $sql = 'DELETE FROM '.MAIN_DB_PREFIX."commandedet WHERE rowid='".$this->rowid."';";
 
         dol_syslog("OrderLine::delete sql=".$sql);
@@ -3165,7 +3167,18 @@ class OrderLine extends CommonOrderLine
             if ($result < 0) { $error++; $this->errors=$interface->errors; }
             // Fin appel triggers
 
-            return 1;
+	        if (!$error) {
+		        $this->db->commit();
+		        return 1;
+	        }
+
+	        foreach($this->errors as $errmsg)
+	        {
+		        dol_syslog(get_class($this)."::delete ".$errmsg, LOG_ERR);
+		        $this->error.=($this->error?', '.$errmsg:$errmsg);
+	        }
+	        $this->db->rollback();
+	        return -1*$error;
         }
         else
         {

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -795,8 +795,19 @@ class Commande extends CommonOrder
                         // Fin appel triggers
                     }
 
-                    $this->db->commit();
-                    return $this->id;
+	                if (!$error) {
+		                $this->db->commit();
+		                return $this->id;
+	                }
+
+	                foreach($this->errors as $errmsg)
+	                {
+		                dol_syslog(get_class($this)."::create ".$errmsg, LOG_ERR);
+		                $this->error.=($this->error?', '.$errmsg:$errmsg);
+	                }
+	                $this->db->rollback();
+	                return -1*$error;
+
                 }
                 else
                 {


### PR DESCRIPTION
Fix: [ bug #1449 ] Trigger ORDER_CREATE ignores interception on error
