### PR TITLE
Fixes for bug 1449, 1450 and 1451

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,7 +30,7 @@ Fix: [ bug #1353 ] Email notifications, wrong URL.
 Fix: [ bug #1362 ] Note is not saved.
 Fix: tr/td balance.
 Fix: [ bug #1360 ] note indicator for member tab.
-Fix: Nb of notes and doc not visible onto task
+Fix: Nb of notes and doc not visible onto tasks.
 Fix: [ bug #1372 ] Margin calculation does not work in proposals.
 Fix: [ bug #1381 ] PHP Warning when listing stock transactions page.
 Fix: [ bug #1367 ] "Show invoice" link after a POS sell throws an error.

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Fix: [ bug #1416 ] Supplier order does not list document models in the select bo
      supplier order card
 Fix: [ bug #1443 ] Payment conditions is erased after editing supplier invoice label or 
      limit date for payment
+Fix: [ bug #1449 ] Trigger ORDER_CREATE ignores interception on error
 
 ***** ChangeLog for 3.5.3 compared to 3.5.2 *****
 Fix: Error on field accountancy code for export profile of invoices.

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Fix: [ bug #1416 ] Supplier order does not list document models in the select bo
 Fix: [ bug #1443 ] Payment conditions is erased after editing supplier invoice label or 
      limit date for payment
 Fix: [ bug #1449 ] Trigger ORDER_CREATE, LINEORDER_DELETE, LINEORDER_UPDATE and LINEORDER_INSERT ignore interception on error
+Fix: [ bug #1450 ] Several Customer order's triggers do not report the error from the trigger handler
 
 ***** ChangeLog for 3.5.3 compared to 3.5.2 *****
 Fix: Error on field accountancy code for export profile of invoices.

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Fix: [ bug #1416 ] Supplier order does not list document models in the select bo
      supplier order card
 Fix: [ bug #1443 ] Payment conditions is erased after editing supplier invoice label or 
      limit date for payment
-Fix: [ bug #1449 ] Trigger ORDER_CREATE ignores interception on error
+Fix: [ bug #1449 ] Trigger ORDER_CREATE, LINEORDER_DELETE, LINEORDER_UPDATE and LINEORDER_INSERT ignore interception on error
 
 ***** ChangeLog for 3.5.3 compared to 3.5.2 *****
 Fix: Error on field accountancy code for export profile of invoices.
@@ -29,7 +29,7 @@ Fix: [ bug #1353 ] Email notifications, wrong URL.
 Fix: [ bug #1362 ] Note is not saved.
 Fix: tr/td balance.
 Fix: [ bug #1360 ] note indicator for member tab.
-Fix: Nb of notes and doc not visible onto tasks.
+Fix: Nb of notes and doc not visible onto task
 Fix: [ bug #1372 ] Margin calculation does not work in proposals.
 Fix: [ bug #1381 ] PHP Warning when listing stock transactions page.
 Fix: [ bug #1367 ] "Show invoice" link after a POS sell throws an error.

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Fix: [ bug #1443 ] Payment conditions is erased after editing supplier invoice l
      limit date for payment
 Fix: [ bug #1449 ] Trigger ORDER_CREATE, LINEORDER_DELETE, LINEORDER_UPDATE and LINEORDER_INSERT ignore interception on error
 Fix: [ bug #1450 ] Several Customer order's triggers do not report the error from the trigger handler
+Fix: [ bug #1451 ] Interrupted order clone through trigger, loads nonexistent order
 
 ***** ChangeLog for 3.5.3 compared to 3.5.2 *****
 Fix: Error on field accountancy code for export profile of invoices.

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1792,7 +1792,7 @@ class Commande extends CommonOrder
                     else
                     {
                         $this->db->rollback();
-                        $this->error=$this->db->lasterror();
+                        $this->error=$line->error;
                         return -1;
                     }
                 }
@@ -2399,11 +2399,10 @@ class Commande extends CommonOrder
             }
             else
             {
-                $this->error=$this->db->lasterror();
-        		$this->errors=array($this->db->lasterror());
-                $this->db->rollback();
-                dol_syslog(get_class($this)."::updateline Error=".$this->error, LOG_ERR);
-                return -1;
+	            $this->error=$this->line->error;
+
+	            $this->db->rollback();
+	            return -1;
             }
         }
         else

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2521,9 +2521,13 @@ class Commande extends CommonOrder
         else
         {
             $this->error=$this->db->lasterror();
-            dol_syslog(get_class($this)."::delete ".$this->error, LOG_ERR);
-            $this->db->rollback();
-            return -1;
+	        foreach($this->errors as $errmsg)
+	        {
+		        dol_syslog(get_class($this)."::delete ".$errmsg, LOG_ERR);
+		        $this->error.=($this->error?', '.$errmsg:$errmsg);
+	        }
+	        $this->db->rollback();
+	        return -1*$error;
         }
     }
 

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3294,8 +3294,18 @@ class OrderLine extends CommonOrderLine
                 // Fin appel triggers
             }
 
-            $this->db->commit();
-            return 1;
+	        if (!$error) {
+		        $this->db->commit();
+		        return 1;
+	        }
+
+	        foreach($this->errors as $errmsg)
+	        {
+		        dol_syslog(get_class($this)."::delete ".$errmsg, LOG_ERR);
+		        $this->error.=($this->error?', '.$errmsg:$errmsg);
+	        }
+	        $this->db->rollback();
+	        return -1*$error;
         }
         else
         {

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -452,8 +452,13 @@ class Commande extends CommonOrder
         }
         else
         {
-            $this->db->rollback();
-            return -1;
+	        foreach($this->errors as $errmsg)
+	        {
+		        dol_syslog(get_class($this)."::set_reopen ".$errmsg, LOG_ERR);
+		        $this->error.=($this->error?', '.$errmsg:$errmsg);
+	        }
+	        $this->db->rollback();
+	        return -1*$error;
         }
     }
 

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2226,9 +2226,14 @@ class Commande extends CommonOrder
 			else
 			{
 				$this->error=$this->db->error();
-				dol_syslog(get_class($this)."::classifyBilled ".$this->error, LOG_ERR);
+
+				foreach($this->errors as $errmsg)
+				{
+					dol_syslog(get_class($this)."::classifyBilled ".$errmsg, LOG_ERR);
+					$this->error.=($this->error?', '.$errmsg:$errmsg);
+				}
 				$this->db->rollback();
-				return -2;
+				return -1*$error;
 			}
 		}
 		else

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3402,8 +3402,18 @@ class OrderLine extends CommonOrderLine
 				// Fin appel triggers
 			}
 
-			$this->db->commit();
-			return 1;
+			if (!$error) {
+				$this->db->commit();
+				return 1;
+			}
+
+			foreach($this->errors as $errmsg)
+			{
+				dol_syslog(get_class($this)."::update ".$errmsg, LOG_ERR);
+				$this->error.=($this->error?', '.$errmsg:$errmsg);
+			}
+			$this->db->rollback();
+			return -1*$error;
 		}
 		else
 		{

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -584,8 +584,14 @@ class Commande extends CommonOrder
 			else
 			{
 				$this->error=$mouvP->error;
+
+				foreach($this->errors as $errmsg)
+				{
+					dol_syslog(get_class($this)."::cancel ".$errmsg, LOG_ERR);
+					$this->error.=($this->error?', '.$errmsg:$errmsg);
+				}
 				$this->db->rollback();
-				return -1;
+				return -1*$error;
 			}
 		}
 		else

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3140,6 +3140,8 @@ class OrderLine extends CommonOrderLine
 
 		$error=0;
 
+	    $this->db->begin();
+
         $sql = 'DELETE FROM '.MAIN_DB_PREFIX."commandedet WHERE rowid='".$this->rowid."';";
 
         dol_syslog("OrderLine::delete sql=".$sql);
@@ -3165,7 +3167,18 @@ class OrderLine extends CommonOrderLine
             if ($result < 0) { $error++; $this->errors=$interface->errors; }
             // Fin appel triggers
 
-            return 1;
+	        if (!$error) {
+		        $this->db->commit();
+		        return 1;
+	        }
+
+	        foreach($this->errors as $errmsg)
+	        {
+		        dol_syslog(get_class($this)."::delete ".$errmsg, LOG_ERR);
+		        $this->error.=($this->error?', '.$errmsg:$errmsg);
+	        }
+	        $this->db->rollback();
+	        return -1*$error;
         }
         else
         {

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -795,8 +795,19 @@ class Commande extends CommonOrder
                         // Fin appel triggers
                     }
 
-                    $this->db->commit();
-                    return $this->id;
+	                if (!$error) {
+		                $this->db->commit();
+		                return $this->id;
+	                }
+
+	                foreach($this->errors as $errmsg)
+	                {
+		                dol_syslog(get_class($this)."::create ".$errmsg, LOG_ERR);
+		                $this->error.=($this->error?', '.$errmsg:$errmsg);
+	                }
+	                $this->db->rollback();
+	                return -1*$error;
+
                 }
                 else
                 {

--- a/htdocs/commande/fiche.php
+++ b/htdocs/commande/fiche.php
@@ -112,6 +112,9 @@ if ($action == 'confirm_clone' && $confirm == 'yes' && $user->rights->commande->
 	{
 		if ($object->id > 0)
 		{
+			//Because createFromClone modifies the object, we must clone it so that we can restore it later
+			$orig = clone $object;
+
 			$result=$object->createFromClone($socid);
 			if ($result > 0)
 			{
@@ -121,6 +124,7 @@ if ($action == 'confirm_clone' && $confirm == 'yes' && $user->rights->commande->
 			else
 			{
 				setEventMessage($object->error, 'errors');
+				$object = $orig;
 				$action='';
 			}
 		}

--- a/htdocs/commande/fiche.php
+++ b/htdocs/commande/fiche.php
@@ -120,7 +120,7 @@ if ($action == 'confirm_clone' && $confirm == 'yes' && $user->rights->commande->
 			}
 			else
 			{
-				$mesg='<div class="error">'.$object->error.'</div>';
+				setEventMessage($object->error, 'errors');
 				$action='';
 			}
 		}

--- a/htdocs/commande/fiche.php
+++ b/htdocs/commande/fiche.php
@@ -140,7 +140,7 @@ else if ($action == 'reopen' && $user->rights->commande->creer)
 		}
 		else
 		{
-			$mesg='<div class="error">'.$object->error.'</div>';
+			setEventMessage($object->error, 'errors');
 		}
 	}
 }
@@ -154,9 +154,8 @@ else if ($action == 'confirm_delete' && $confirm == 'yes' && $user->rights->comm
 		header('Location: index.php');
 		exit;
 	}
-	else
-	{
-		$mesg='<div class="error">'.$object->error.'</div>';
+	else {
+		setEventMessage($object->error, 'errors');
 	}
 }
 
@@ -187,7 +186,7 @@ else if ($action == 'confirm_deleteline' && $confirm == 'yes' && $user->rights->
 	}
 	else
 	{
-		$mesg='<div class="error">'.$object->error.'</div>';
+		setEventMessage($object->error, 'errors');
 	}
 }
 
@@ -445,6 +444,10 @@ else if ($action == 'add' && $user->rights->commande->creer)
 else if ($action == 'classifybilled' && $user->rights->commande->creer)
 {
 	$ret=$object->classifyBilled();
+
+	if ($ret < 0) {
+		setEventMessage($object->error, 'errors');
+	}
 }
 
 // Positionne ref commande client
@@ -1076,7 +1079,9 @@ else if ($action == 'confirm_modif' && $user->rights->commande->creer)
 else if ($action == 'confirm_shipped' && $confirm == 'yes' && $user->rights->commande->cloturer)
 {
 	$result = $object->cloture($user);
-	if ($result < 0) $mesgs=$object->errors;
+	if ($result < 0) {
+		setEventMessage($object->error, 'errors');
+	}
 }
 
 else if ($action == 'confirm_cancel' && $confirm == 'yes' && $user->rights->commande->valider)
@@ -1097,6 +1102,10 @@ else if ($action == 'confirm_cancel' && $confirm == 'yes' && $user->rights->comm
 	if (! $error)
 	{
 		$result = $object->cancel($idwarehouse);
+
+		if ($result < 0) {
+			setEventMessage($object->error, 'errors');
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes:

[ bug #1449 ] Trigger ORDER_CREATE, LINEORDER_DELETE, LINEORDER_UPDATE and LINEORDER_INSERT ignore interception on error
[ bug #1450 ] Several Customer order's triggers do not report the error from the trigger handler
[ bug #1451 ] Interrupted order clone through trigger, loads nonexistent order
