### PR TITLE
Add feature to inform error is deprecated

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -103,6 +103,7 @@ removed. You must now use the 6 parameters way. See file modMyModule.class.php f
   So check that return value is 0 to keep default standard behaviour after hook or 1 to disable
   default standard behaviour.
 - Properties "civilite_id" were renamed into "civility_id".
+- CommonObject's property error is marked as deprecated, lot's of warning could be show.
 
 
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -35,8 +35,8 @@
 abstract class CommonObject
 {
     protected $db;
-    public $error;
-    public $errors;
+    //public $error;                //Just one error, deprecated
+    public $errors;                 //Stack of error
     public $canvas;                // Contains canvas name if it is
 
     public $name;
@@ -52,7 +52,84 @@ abstract class CommonObject
 
     // No constructor as it is an abstract class
 
+    /**
+     * Magic function for managing deprecated property and setting others
+     * 
+     * @param   string    $name   name of the property
+     * @param   mixed     $value  value assigned to property
+     * @return  void
+     */
+    public function __set($name,$value)
+    {
+        if ($name == 'error') 
+        {
+            trigger_error('property error is deprecated, prefer usage of errors',E_USER_DEPRECATED);
+            $this->errors[]=$value;
+        } 
+        else
+        {
+            $this->$name = $value;
+            return;
+        } 
+    }
 
+    /**
+     * Magic function for managing deprecated property and getting others
+     * 
+     * @param   string  $name   name of the property
+     * @return  mixed           value of the property
+     */
+    public function __get($name)
+    {
+        if ($name == 'error') 
+        {
+            trigger_error('property error is deprecated, prefer usage of errors',E_USER_DEPRECATED);
+            return end($this->errors);
+        } 
+        else
+        {
+            return $this->$name;
+        } 
+    }
+    
+    /**
+     * Magic function for managing deprecated property and testing others
+     * 
+     * @param   string  $name   name of the property
+     * @return  boolean         result of empty on the property
+     */
+    public function __isset($name)
+    {
+        if ($name == 'error') 
+        {
+            trigger_error('property error is deprecated, prefer usage of errors',E_USER_DEPRECATED);
+            return empty($this->errors);
+        } 
+        else
+        {
+            return empty($this->$name);
+        }
+    }
+
+    /**
+     * Magic function for managing deprecated property and unsetting others
+     * 
+     * @param   string  $name   name of the property
+     * @return  void
+     */
+    public function __unset($name)
+    {
+        if ($name == 'error') 
+        {
+            trigger_error('property error is deprecated, prefer usage of errors',E_USER_DEPRECATED);
+            return array_pop($this->errors);
+        } 
+        else
+        {
+            unset($this->$name);
+        }
+    }
+    
     /**
      * Check an object id/ref exists
      * If you don't need/want to instantiate object and just need to know if object exists, use this method instead of fetch


### PR DESCRIPTION
Could be usefull for chasing down usage of error or other property.
You could use this to test undeclared property also by changing else part of __set to : 
if (property_exists($this, $name)) {
            $this->$name = $value;
            return;
} else {
            trigger_error("Undefined property in __set(): {$name}");
}

and else part of __get to :
if (property_exists($this, $name)) {
            return $this->$name;
        }
        else {
            trigger_error("Undefined property in __get(): $name");
            return NULL;
}
