### PR TITLE
Date selector for service missing in add line / edit line form on propal/order/invoice

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -31,7 +31,7 @@
 $usemargins=0;
 if (! empty($conf->margin->enabled) && ! empty($object->element) && in_array($object->element,array('facture','propal','commande'))) $usemargins=1;
 
-global $dateSelector, $forceall, $senderissupplier, $inputalsopricewithtax;
+global $forceall, $senderissupplier, $inputalsopricewithtax;
 if (empty($dateSelector)) $dateSelector=0;
 if (empty($forceall)) $forceall=0;
 if (empty($senderissupplier)) $senderissupplier=0;

--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -31,7 +31,7 @@
 $usemargins=0;
 if (! empty($conf->margin->enabled) && ! empty($object->element) && in_array($object->element,array('facture','propal','commande'))) $usemargins=1;
 
-global $dateSelector, $forceall, $senderissupplier, $inputalsopricewithtax;
+global $forceall, $senderissupplier, $inputalsopricewithtax;
 if (empty($dateSelector)) $dateSelector=0;
 if (empty($forceall)) $forceall=0;
 if (empty($senderissupplier)) $senderissupplier=0;


### PR DESCRIPTION
$dateSelector is a paramters of formAddObjectLine, if use "global $dateSelector" it is reset to 0 because not declare in outer context but already exists in the same context.
