### PR TITLE
Update ruleset.xml

### DIFF
--- a/dev/codesniffer/ruleset.xml
+++ b/dev/codesniffer/ruleset.xml
@@ -18,6 +18,9 @@
 		<severity>0</severity>
 	</rule>
 
+    <!-- The closing ?> tag MUST be omitted from files containing only PHP. -->
+    <rule ref="Zend.Files.ClosingTag"/>
+
     <!-- <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop" /> -->
 
     <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall" />


### PR DESCRIPTION
The closing ?> tag MUST be omitted from files containing only PHP.

Perhaps we have to run /dev/rmphpclosingtag.sh before 
