### PR TITLE
Removed @ operator from dol_include_once

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -243,9 +243,9 @@ function dol_include_once($relpath, $classname='')
 	global $conf,$langs,$user,$mysoc;   // Other global var must be retreived with $GLOBALS['var']
 
 	if (! empty($classname) && ! class_exists($classname)) {
-		return @include dol_buildpath($relpath);			// Remove @ to find error into php log file if you have problems
+		return include dol_buildpath($relpath);
 	} else {
-		return @include_once dol_buildpath($relpath);		// Remove @ to find error into php log file if you have problems
+		return include_once dol_buildpath($relpath);
 	}
 }
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -236,11 +236,15 @@ function dol_getprefix()
  *
  * 	@param	string	$relpath	Relative path to file (Ie: mydir/myfile, ../myfile, ...)
  * 	@param	string	$classname	Class name
- *  @return int					false if include fails.
+ *  @return bool
  */
 function dol_include_once($relpath, $classname='')
 {
-	global $conf,$langs,$user,$mysoc;   // Other global var must be retreived with $GLOBALS['var']
+
+	if (!file_exists($relpath)) {
+		dol_syslog('functions::dol_include_once Tried to load unexisting file: '.$relpath, LOG_ERR);
+		return false;
+	}
 
 	if (! empty($classname) && ! class_exists($classname)) {
 		return include dol_buildpath($relpath);

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -240,16 +240,17 @@ function dol_getprefix()
  */
 function dol_include_once($relpath, $classname='')
 {
+	$fullpath = dol_buildpath($relpath);
 
-	if (!file_exists($relpath)) {
+	if (!file_exists($fullpath)) {
 		dol_syslog('functions::dol_include_once Tried to load unexisting file: '.$relpath, LOG_ERR);
 		return false;
 	}
 
 	if (! empty($classname) && ! class_exists($classname)) {
-		return include dol_buildpath($relpath);
+		return include $fullpath;
 	} else {
-		return include_once dol_buildpath($relpath);
+		return include_once $fullpath;
 	}
 }
 


### PR DESCRIPTION
Adding @ operator to include_once makes include errors untraceable, it shouldn't be there. Errors must be thrown so that we notice them. It is PHP configuration's choice to decide wether to log them or print them.
