### PR TITLE
Fix unable to delete order line

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1379,6 +1379,7 @@ class CommandeFournisseur extends CommonOrder
      */
     function deleteline($idline, $notrigger=0)
     {
+        global $user,$langs,$conf;
         if ($this->statut == 0)
         {
         	$this->db->begin();


### PR DESCRIPTION
Calling trigger without having globalized $conf causes error and cancels delete operation, this commit adds the missing

2014-08-23 16:52:05 ERR     127.0.0.1        Interfaces::run_triggers was called with wrong parameters action=LINEORDER_SUPPLIER_DELETE object=1 user= langs= conf=
