### PR TITLE
Add filter on sortfield and sortorder to avoid bad sql request

### DIFF
--- a/htdocs/bookmarks/liste.php
+++ b/htdocs/bookmarks/liste.php
@@ -38,6 +38,7 @@ if ($page == -1) { $page = 0 ; }
 $offset = $conf->liste_limit * $page ;
 $pageprev = $page - 1;
 $pagenext = $page + 1;
+if (! in_array($sortorder, array('asc', 'desc'))) $sortorder='desc';
 if (! $sortorder) $sortorder="ASC";
 if (! $sortfield) $sortfield="position";
 $limit=$conf->liste_limit;

--- a/htdocs/commande/document.php
+++ b/htdocs/commande/document.php
@@ -57,6 +57,7 @@ if ($page == -1) { $page = 0; }
 $offset = $conf->liste_limit * $page;
 $pageprev = $page - 1;
 $pagenext = $page + 1;
+if (! in_array($sortorder, array('asc', 'desc'))) $sortorder='desc';
 if (! $sortorder) $sortorder="ASC";
 if (! $sortfield) $sortfield="name";
 

--- a/htdocs/commande/liste.php
+++ b/htdocs/commande/liste.php
@@ -62,11 +62,13 @@ if ($page == -1) { $page = 0; }
 $offset = $conf->liste_limit * $page;
 $pageprev = $page - 1;
 $pagenext = $page + 1;
+if (! in_array($sortfield, array('c.ref', 'c.ref_client', 's.nom', 'c.date_commande', 'c.date_livraison', 'c.total_ht', 'c.fk_statut'))) $sortfield='c.rowid';
 if (! $sortfield) $sortfield='c.rowid';
+if (! in_array($sortorder, array('asc', 'desc'))) $sortorder='desc';
 if (! $sortorder) $sortorder='DESC';
 $limit = $conf->liste_limit;
 
-$viewstatut=GETPOST('viewstatut');
+$viewstatut=GETPOST('viewstatut', 'int');
 
 
 // Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array

--- a/htdocs/commande/orderstoinvoice.php
+++ b/htdocs/commande/orderstoinvoice.php
@@ -61,6 +61,7 @@ $viewstatut		= GETPOST('viewstatut');
 $error = 0;
 
 if (! $sortfield) $sortfield='c.rowid';
+if (! in_array($sortorder, array('asc', 'desc'))) $sortorder='desc';
 if (! $sortorder) $sortorder='DESC';
 
 $now = dol_now();

--- a/htdocs/holiday/index.php
+++ b/htdocs/holiday/index.php
@@ -46,6 +46,7 @@ $page = is_numeric($page) ? $page : 0;
 $page = $page == -1 ? 0 : $page;
 
 if (! $sortfield) $sortfield="cp.rowid";
+if (! in_array($sortorder, array('asc', 'desc'))) $sortorder='desc';
 if (! $sortorder) $sortorder="DESC";
 $offset = $conf->liste_limit * $page ;
 $pageprev = $page - 1;


### PR DESCRIPTION
Example : dolibarr/commande/liste.php?sortfield=c.ref_client&sortorder=asc&begin=&socid=&viewstatut=
replace c.ref_client or asc with bad sql and you get an error
