### PR TITLE
Translation support for workflow and extrafields from external modules

### DIFF
--- a/htdocs/admin/workflow.php
+++ b/htdocs/admin/workflow.php
@@ -88,8 +88,11 @@ $workflowcodes=array(
 
 if (! empty($conf->modules_parts['workflow']) && is_array($conf->modules_parts['workflow']))
 {
-	foreach($conf->modules_parts['workflow'] as $workflow)
+	foreach($conf->modules_parts['workflow'] as $modulename => $workflow)
 	{
+		// Load language file for external modules
+		$langs->load('workflow@' . $modulename);
+
 		$workflowcodes = array_merge($workflowcodes, $workflow);
 	}
 }

--- a/htdocs/comm/admin/propal_extrafields.php
+++ b/htdocs/comm/admin/propal_extrafields.php
@@ -96,10 +96,14 @@ print "</tr>\n";
 $var=True;
 foreach($extrafields->attribute_type as $key => $value)
 {
+	// Load language file for external modules
+	$label = explode('@', $extrafields->attribute_label[$key]);
+	$langs->load('extrafields@' . $label[1]);
+
     $var=!$var;
     print "<tr ".$bc[$var].">";
     print "<td>".$extrafields->attribute_pos[$key]."</td>\n";
-    print "<td>".$extrafields->attribute_label[$key]."</td>\n";
+    print "<td>".$langs->trans($label[0])."</td>\n";
     print "<td>".$key."</td>\n";
     print "<td>".$type2label[$extrafields->attribute_type[$key]]."</td>\n";
     print '<td align="right">'.$extrafields->attribute_size[$key]."</td>\n";

--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -1999,7 +1999,7 @@ if ($action == 'create') {
 		foreach ($extrafields->attribute_label as $key => $label) {
 
 			// Load language file for external modules
-			$label = explode('@', $label)[1];
+			$label = explode('@', $label);
 			$langs->load('extrafields@' . $label[1]);
 
 			if ($action == 'edit_extras') {
@@ -2013,7 +2013,7 @@ if ($action == 'create') {
 				print '<tr><td';
 				if (! empty($extrafields->attribute_required [$key]))
 					print ' class="fieldrequired"';
-				print '>' . $langs->trans($label) . '</td><td colspan="5">';
+				print '>' . $langs->trans($label[0]) . '</td><td colspan="5">';
 				// Convert date into timestamp format
 				if (in_array($extrafields->attribute_type [$key], array('date','datetime'))) {
 					$value = isset($_POST ["options_" . $key]) ? dol_mktime($_POST ["options_" . $key . "hour"], $_POST ["options_" . $key . "min"], 0, $_POST ["options_" . $key . "month"], $_POST ["options_" . $key . "day"], $_POST ["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);

--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -1997,6 +1997,11 @@ if ($action == 'create') {
 	                                                                                           // hook
 	if (empty($reshook) && ! empty($extrafields->attribute_label)) {
 		foreach ($extrafields->attribute_label as $key => $label) {
+
+			// Load language file for external modules
+			$label = explode('@', $label)[1];
+			$langs->load('extrafields@' . $label[1]);
+
 			if ($action == 'edit_extras') {
 				$value = (isset($_POST ["options_" . $key]) ? $_POST ["options_" . $key] : $object->array_options ["options_" . $key]);
 			} else {
@@ -2008,7 +2013,7 @@ if ($action == 'create') {
 				print '<tr><td';
 				if (! empty($extrafields->attribute_required [$key]))
 					print ' class="fieldrequired"';
-				print '>' . $label . '</td><td colspan="5">';
+				print '>' . $langs->trans($label) . '</td><td colspan="5">';
 				// Convert date into timestamp format
 				if (in_array($extrafields->attribute_type [$key], array('date','datetime'))) {
 					$value = isset($_POST ["options_" . $key]) ? dol_mktime($_POST ["options_" . $key . "hour"], $_POST ["options_" . $key . "min"], 0, $_POST ["options_" . $key . "month"], $_POST ["options_" . $key . "day"], $_POST ["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);

--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -183,10 +183,10 @@ class Translate
 			$modulename = $regs[2];
 		}
 
-        // Check cache
-		if (! empty($this->_tab_loaded[$newdomain]))	// File already loaded for this domain
+        // Check cache for native files only
+		if (! empty($this->_tab_loaded[$newdomain]) && empty($modulename))	// File already loaded for this domain
 		{
-			//dol_syslog("Translate::Load already loaded for newdomain=".$newdomain);
+			dol_syslog("Translate::Load already loaded for newdomain=".$newdomain, LOG_DEBUG);
 			return 0;
 		}
 


### PR DESCRIPTION
This is a first step to see if upstream is OK to go that route.

The idea here is to provide a simple way for external modules to provide translations for workflow entries and extrafields.

For workflow, the approach is fairly simple since we know from which module it comes.

For extrafields, I structured the translation token just like pictos and other module parts in the form of "TranslationKey@modulename" to provide that information.

The module developer has then to just provide respectively workflow.lang or extrafields.lang to have the translation automagically loaded.

Please let me know if this strategy is OK or if you have a better one.
