### PR TITLE
[ bug #1589 ] Menu type in "Edit menu" page is not translated

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ Fix: [ bug #1544 ] Can remove date from invoice.
 Fix: list event view lost type event filter.
 Fix: Add code save on create event.
 Fix: SQL injection.
+Fix: [ bug #1589 ] Menu type in "Edit menu" page is not translated
 
 ***** ChangeLog for 3.5.4 compared to 3.5.3 *****
 Fix: Hide title of event when agenda module disabled.

--- a/htdocs/admin/menus/edit.php
+++ b/htdocs/admin/menus/edit.php
@@ -317,7 +317,7 @@ if ($action == 'create')
     print '<tr><td class="fieldrequired">'.$langs->trans('Type').'</td><td>';
     if ($parent_rowid)
     {
-        print 'Left';
+        print $langs->trans('Left');
         print '<input type="hidden" name="type" value="left">';
     }
     else


### PR DESCRIPTION
[ bug #1589 ] Menu type in "Edit menu" page is not translated
