### PR TITLE
[ bug #1577 ] When creating new Private individual third, selected third type is ignored

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ Fix: [ bug #1544 ] Can remove date from invoice.
 Fix: list event view lost type event filter.
 Fix: Add code save on create event.
 Fix: SQL injection.
+Fix: [ bug #1577 ] When creating new Private individual third, selected third type is ignored
 
 ***** ChangeLog for 3.5.4 compared to 3.5.3 *****
 Fix: Hide title of event when agenda module disabled.

--- a/htdocs/societe/soc.php
+++ b/htdocs/societe/soc.php
@@ -159,14 +159,7 @@ if (empty($reshook))
 
         $object->forme_juridique_code  = GETPOST('forme_juridique_code');
         $object->effectif_id           = GETPOST('effectif_id');
-        if (GETPOST("private") == 1)
-        {
-            $object->typent_id         = dol_getIdFromCode($db,'TE_PRIVATE','c_typent');
-        }
-        else
-        {
-            $object->typent_id         = GETPOST('typent_id');
-        }
+        $object->typent_id         = GETPOST('typent_id');
 
         $object->client                = GETPOST('client');
         $object->fournisseur           = GETPOST('fournisseur');


### PR DESCRIPTION
Since third types can be modified in the dictionary, there is no reason to force typent to be always TE_PRIVATE
