### PR TITLE
[ bug #1555 ] Update accountancy code of products does not throw PRODUCT_MODIFY trigger

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ Fix: [ bug #1544 ] Can remove date from invoice.
 Fix: list event view lost type event filter.
 Fix: Add code save on create event.
 Fix: SQL injection.
+Fix: [ bug #1555 ] Update accountancy code of products does not throw PRODUCT_MODIFY trigger
 
 ***** ChangeLog for 3.5.4 compared to 3.5.3 *****
 Fix: Hide title of event when agenda module disabled.

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1053,7 +1053,6 @@ abstract class CommonObject
         }
     }
 
-
     /**
      *  Save a new position (field rang) for details lines.
      *  You can choose to set position for lines with already a position or lines without any position defined.

--- a/htdocs/product/fiche.php
+++ b/htdocs/product/fiche.php
@@ -6,7 +6,7 @@
  * Copyright (C) 2006      Andre Cianfarani     <acianfa@free.fr>
  * Copyright (C) 2006      Auguria SARL         <info@auguria.org>
  * Copyright (C) 2010-2011 Juanjo Menent        <jmenent@2byte.es>
- * Copyright (C) 2013      Marcos García        <marcosgdf@gmail.com>
+ * Copyright (C) 2013-2014 Marcos García        <marcosgdf@gmail.com>
  * Copyright (C) 2013      Cédric Salvador      <csalvador@gpcsolutions.fr>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -122,20 +122,18 @@ if (empty($reshook))
     	exit;
     }
 
-    if ($action == 'setaccountancy_code_buy')
-    {
-        $result = $object->setValueFrom('accountancy_code_buy', GETPOST('accountancy_code_buy'));
+    if ($action == 'setaccountancy_code_buy') {
+
+	    $result = $object->setAccountancyCode('buy', GETPOST('accountancy_code_buy'));
         if ($result < 0) setEventMessage(join(',',$object->errors), 'errors');
-        else $object->accountancy_code_buy=GETPOST('accountancy_code_buy');
         $action="";
     }
 
     if ($action == 'setaccountancy_code_sell')
     {
-        $result = $object->setValueFrom('accountancy_code_sell', GETPOST('accountancy_code_sell'));
-        if ($result < 0) setEventMessage(join(',',$object->errors), 'errors');
-        else $object->accountancy_code_sell=GETPOST('accountancy_code_sell');
-        $action="";
+	    $result = $object->setAccountancyCode('sell', GETPOST('accountancy_code_sell'));
+	    if ($result < 0) setEventMessage(join(',',$object->errors), 'errors');
+	    $action="";
     }
 
     // Add a product or service


### PR DESCRIPTION
I'm not sure if I should have modified CommonObject::setValueFrom but I didn't because it is used in a lot of places. If you think that would be a better solution I won't have problem in changing it.
