### PR TITLE
Fixed typo

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -685,7 +685,7 @@ class FormMail
 	 * 		@param	DoliDB		$db				Database handler
 	 * 		@param	string		$type_template	Get message for key module
 	 *      @param	string		$user			Use template public or limited to this user
-	 *      @para	Translate	$outputlangs	Output lang object
+	 *      @param	Translate	$outputlangs	Output lang object
 	 *      @return array						array('topic'=>,'content'=>,..)
 	 */
 	private function getEMailTemplate($db, $type_template, $user, $outputlangs)


### PR DESCRIPTION
Sorry, I'm going for another rant and this trivial fix is just a pretense!

I'm really tired to find these kind of errors in Travis CI completely unrelated to the PR contents.

Maintainers and people who have direct write access to the repo _shouldn't_ use it.
GIT is not SVN.
Get your own fork and pull request from it. _Please_.

This way everyone will benefit from continuous integration.
We'll also be able to review your changes and make comments or fixes even before the code hits the main repo.

Thanks!

ping @eldy @simnandez @hregis 
