### PR TITLE
Fixed invoices webservice

### DIFF
--- a/htdocs/webservices/server_invoice.php
+++ b/htdocs/webservices/server_invoice.php
@@ -136,7 +136,9 @@ $server->wsdl->addComplexType(
             'minOccurs' => '0',
             'maxOccurs' => 'unbounded'
         )
-    )
+    ),
+    null,
+    'tns:line'
 );
 
 
@@ -197,7 +199,9 @@ $server->wsdl->addComplexType(
             'minOccurs' => '0',
             'maxOccurs' => 'unbounded'
         )
-    )
+    ),
+    null,
+    'tns:invoice'
 );
 
 


### PR DESCRIPTION
Lines and invoices were missing their type making the webservice unusable from standard compliant clients.
