### PR TITLE
Custom input method in supplier orders not showing

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2040,7 +2040,7 @@ class CommandeFournisseur extends CommonOrder
 
                 if ($string == $result->code)
                 {
-                    $string = $obj->libelle != '-' ? $obj->libelle : '';
+                    $string = $result->libelle != '-' ? $result->libelle : '';
                 }
 
                 return $string;


### PR DESCRIPTION
Seems that $obj is a undefined variable, the correct one is $result, with this the label displays correctly in custom input method's

develop branch also has this typo, seems that code in 3.5 is ok, as obj is not renamed to result
