### PR TITLE
fix ErrorBadValueForParamNotAString error message in price customer multiprice

### DIFF
--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -368,7 +368,10 @@ if (! empty($conf->global->PRODUIT_MULTIPRICES)) {
 			if ($object->multiprices_base_type ["$i"] == 'TTC') {
 				print price($object->multiprices_min_ttc ["$i"]) . ' ' . $langs->trans($object->multiprices_base_type ["$i"]);
 			} else {
-				print price($object->multiprices_min ["$i"]) . ' ' . $langs->trans($object->multiprices_base_type ["$i"]);
+				print price($object->multiprices_min ["$i"]) ;
+				if (!empty($object->multiprices_base_type ["$i"])) {
+					print ' ' . $langs->trans($object->multiprices_base_type ["$i"]);
+				}
 			}
 			print '</td></tr>';
 


### PR DESCRIPTION
avoid ErrorBadValueForParamNotAString message when base price type does not exist
