### PR TITLE
Work on extrafields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -65,6 +65,7 @@ For users:
 - New: Add feature to order to invoice on supplier part
 - Upgrade phpexcel lib to 1.7.8
 - New : Use of MAIN_USE_FILECACHE_EXPORT_EXCEL_DIR to use disk cache for big excel export
+- New : Option on extrafields to have them always editable regardless of the document status
 - Fix: [ bug #1487 ] PAYMENT_DELETE trigger does not intercept trigger action
 - Fix: [ bug #1470, #1472, #1473] User trigger problem
 - Fix: [ bug #1489, #1491 ] Intervention trigger problem

--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -2032,9 +2032,16 @@ if ($action == 'create')
 			}
 			else
 			{
-				print '<tr><td';
+				print '<tr><td>';
+				print '<table width="100%" class="nobordernopadding"><tr><td';
 				if (! empty($extrafields->attribute_required [$key])) print ' class="fieldrequired"';
-				print '>' . $label . '</td><td colspan="5">';
+				print '>' . $label . '</td>';
+				if (($object->statut == 0 || $extrafields->attribute_alwayseditable[$key]) && $user->rights->propal->creer && ($action != 'edit_extras' || GETPOST('attribute') != $key))
+					print '<td align="right"><a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_edit().'</a></td>';
+				
+				print '</tr></table>';
+				print '<td colspan="5">';
+				
 				// Convert date into timestamp format
 				if (in_array($extrafields->attribute_type [$key], array('date','datetime'))) {
 					$value = isset($_POST ["options_" . $key]) ? dol_mktime($_POST ["options_" . $key . "hour"], $_POST ["options_" . $key . "min"], 0, $_POST ["options_" . $key . "month"], $_POST ["options_" . $key . "day"], $_POST ["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);
@@ -2057,8 +2064,6 @@ if ($action == 'create')
 				else
 				{
 					print $extrafields->showOutputField($key, $value);
-					if ($object->statut == 0 && $user->rights->propal->creer)
-						print '<a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_picto('', 'edit') . ' ' . $langs->trans('Modify') . '</a>';
 				}
 				print '</td></tr>' . "\n";
 			}

--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -2008,67 +2008,9 @@ if ($action == 'create')
 	    print '</tr>';
 	}
 
-	// Other attributes (TODO Move this into an include)
-	$res = $object->fetch_optionals($object->id, $extralabels);
-	$parameters = array('colspan' => ' colspan="3"');
-	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified
-	                                                                                           // by
-	                                                                                           // hook
-	if (empty($reshook) && ! empty($extrafields->attribute_label))
-	{
-		foreach ($extrafields->attribute_label as $key => $label)
-		{
-			if ($action == 'edit_extras')
-			{
-				$value = (isset($_POST ["options_" . $key]) ? $_POST ["options_" . $key] : $object->array_options ["options_" . $key]);
-			}
-			else
-			{
-				$value = $object->array_options ["options_" . $key];
-			}
-			if ($extrafields->attribute_type [$key] == 'separate')
-			{
-				print $extrafields->showSeparator($key);
-			}
-			else
-			{
-				print '<tr><td>';
-				print '<table width="100%" class="nobordernopadding"><tr><td';
-				if (! empty($extrafields->attribute_required [$key])) print ' class="fieldrequired"';
-				print '>' . $label . '</td>';
-				if (($object->statut == 0 || $extrafields->attribute_alwayseditable[$key]) && $user->rights->propal->creer && ($action != 'edit_extras' || GETPOST('attribute') != $key))
-					print '<td align="right"><a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_edit().'</a></td>';
-				
-				print '</tr></table>';
-				print '<td colspan="5">';
-				
-				// Convert date into timestamp format
-				if (in_array($extrafields->attribute_type [$key], array('date','datetime'))) {
-					$value = isset($_POST ["options_" . $key]) ? dol_mktime($_POST ["options_" . $key . "hour"], $_POST ["options_" . $key . "min"], 0, $_POST ["options_" . $key . "month"], $_POST ["options_" . $key . "day"], $_POST ["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);
-				}
-
-				if ($action == 'edit_extras' && $user->rights->propal->creer && GETPOST('attribute') == $key)
-				{
-					print '<form enctype="multipart/form-data" action="' . $_SERVER["PHP_SELF"] . '" method="post" name="formsoc">';
-					print '<input type="hidden" name="action" value="update_extras">';
-					print '<input type="hidden" name="attribute" value="' . $key . '">';
-					print '<input type="hidden" name="token" value="' . $_SESSION ['newtoken'] . '">';
-					print '<input type="hidden" name="id" value="' . $object->id . '">';
-
-					print $extrafields->showInputField($key, $value);
-
-					print '<input type="submit" class="button" value="' . $langs->trans('Modify') . '">';
-
-					print '</form>';
-				}
-				else
-				{
-					print $extrafields->showOutputField($key, $value);
-				}
-				print '</td></tr>' . "\n";
-			}
-		}
-	}
+	// Other attributes
+	$cols = 3;
+	include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
 	// Amount HT
 	print '<tr><td height="10" width="25%">' . $langs->trans('AmountHT') . '</td>';

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -618,7 +618,7 @@ else if ($action == 'addline' && $user->rights->commande->creer) {
 					$filter = array('t.fk_product' => $prod->id,'t.fk_soc' => $object->thirdparty->id);
 
 					$result = $prodcustprice->fetch_all('', '', 0, 0, $filter);
-					if ($result >= 0) 
+					if ($result >= 0)
 					{
 						if (count($prodcustprice->lines) > 0)
 						{
@@ -628,7 +628,7 @@ else if ($action == 'addline' && $user->rights->commande->creer) {
 							$prod->tva_tx = $prodcustprice->lines [0]->tva_tx;
 						}
 					}
-					else 
+					else
 					{
 						setEventMessage($prodcustprice->error,'errors');
 					}
@@ -2152,9 +2152,16 @@ if ($action == 'create' && $user->rights->commande->creer) {
 				}
 				else
 				{
-					print '<tr><td';
+					print '<tr><td>';
+					print '<table width="100%" class="nobordernopadding"><tr><td';
 					if (! empty($extrafields->attribute_required [$key])) print ' class="fieldrequired"';
-					print '>' . $label . '</td><td colspan="5">';
+					print '>' . $label . '</td>';
+					if (($object->statut == 0 || $extrafields->attribute_alwayseditable[$key]) && $user->rights->propal->creer && ($action != 'edit_extras' || GETPOST('attribute') != $key))
+						print '<td align="right"><a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_edit().'</a></td>';
+					
+					print '</tr></table>';
+					print '<td colspan="5">';
+					
 					// Convert date into timestamp format
 					if (in_array($extrafields->attribute_type [$key], array('date','datetime')))
 					{

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -2130,67 +2130,9 @@ if ($action == 'create' && $user->rights->commande->creer) {
 			print '</tr>';
 		}
 
-		// Other attributes (TODO Move this into an include)
-		$parameters = array('colspan' => ' colspan="3"');
-		$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
-		if (empty($reshook) && ! empty($extrafields->attribute_label))
-		{
-			foreach ($extrafields->attribute_label as $key => $label)
-			{
-				if ($action == 'edit_extras')
-				{
-					$value = (isset($_POST["options_".$key])?$_POST["options_".$key]:$object->array_options["options_".$key]);
-				}
-				else
-				{
-					$value = $object->array_options["options_" . $key];
-				}
-
-				if ($extrafields->attribute_type[$key] == 'separate')
-				{
-					print $extrafields->showSeparator($key);
-				}
-				else
-				{
-					print '<tr><td>';
-					print '<table width="100%" class="nobordernopadding"><tr><td';
-					if (! empty($extrafields->attribute_required [$key])) print ' class="fieldrequired"';
-					print '>' . $label . '</td>';
-					if (($object->statut == 0 || $extrafields->attribute_alwayseditable[$key]) && $user->rights->propal->creer && ($action != 'edit_extras' || GETPOST('attribute') != $key))
-						print '<td align="right"><a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_edit().'</a></td>';
-					
-					print '</tr></table>';
-					print '<td colspan="5">';
-					
-					// Convert date into timestamp format
-					if (in_array($extrafields->attribute_type [$key], array('date','datetime')))
-					{
-						$value = isset($_POST["options_" . $key]) ? dol_mktime($_POST["options_" . $key . "hour"], $_POST["options_" . $key . "min"], 0, $_POST["options_" . $key . "month"], $_POST["options_" . $key . "day"], $_POST["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);
-					}
-
-					if ($action == 'edit_extras' && $user->rights->commande->creer && GETPOST('attribute') == $key)
-					{
-						print '<form enctype="multipart/form-data" action="' . $_SERVER["PHP_SELF"] . '" method="post" name="formsoc">';
-						print '<input type="hidden" name="action" value="update_extras">';
-						print '<input type="hidden" name="attribute" value="' . $key . '">';
-						print '<input type="hidden" name="token" value="' . $_SESSION ['newtoken'] . '">';
-						print '<input type="hidden" name="id" value="' . $object->id . '">';
-
-						print $extrafields->showInputField($key, $value);
-
-						print '<input type="submit" class="button" value="' . $langs->trans('Modify') . '">';
-						print '</form>';
-					}
-					else
-					{
-						print $extrafields->showOutputField($key, $value);
-						if ($object->statut == 0 && $user->rights->commande->creer)
-							print '<a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_picto('', 'edit') . ' ' . $langs->trans('Modify') . '</a>';
-					}
-					print '</td></tr>' . "\n";
-				}
-			}
-		}
+		// Other attributes
+		$cols = 3;
+		include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
 		$rowspan = 4;
 		if ($mysoc->localtax1_assuj == "1" || $object->total_localtax1 != 0)

--- a/htdocs/compta/facture.php
+++ b/htdocs/compta/facture.php
@@ -3341,10 +3341,16 @@ if ($action == 'create')
 			if ($extrafields->attribute_type [$key] == 'separate') {
 				print $extrafields->showSeparator($key);
 			} else {
-				print '<tr><td';
-				if (! empty($extrafields->attribute_required [$key]))
-					print ' class="fieldrequired"';
-				print '>' . $label . '</td><td colspan="5">';
+				print '<tr><td>';
+				print '<table width="100%" class="nobordernopadding"><tr><td';
+				if (! empty($extrafields->attribute_required [$key])) print ' class="fieldrequired"';
+				print '>' . $label . '</td>';
+				if (($object->statut == 0 || $extrafields->attribute_alwayseditable[$key]) && $user->rights->propal->creer && ($action != 'edit_extras' || GETPOST('attribute') != $key))
+					print '<td align="right"><a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_edit().'</a></td>';
+				
+				print '</tr></table>';
+				print '<td colspan="5">';
+				
 				// Convert date into timestamp format
 				if (in_array($extrafields->attribute_type [$key], array('date','datetime'))) {
 					$value = isset($_POST["options_" . $key]) ? dol_mktime($_POST["options_" . $key . "hour"], $_POST["options_" . $key . "min"], 0, $_POST["options_" . $key . "month"], $_POST["options_" . $key . "day"], $_POST["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);

--- a/htdocs/compta/facture.php
+++ b/htdocs/compta/facture.php
@@ -3324,58 +3324,9 @@ if ($action == 'create')
 		print '</tr>';
 	}
 
-	// Other attributes (TODO Move this into an include)
-	$res = $object->fetch_optionals($object->id, $extralabels);
-	$parameters = array('colspan' => ' colspan="5"', "cols" => 5);
-	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by
-	                                                                                      // hook
-	if (empty($reshook) && ! empty($extrafields->attribute_label))
-	{
-		foreach ($extrafields->attribute_label as $key => $label)
-		{
-			if ($action == 'edit_extras') {
-				$value = (isset($_POST["options_" . $key]) ? $_POST["options_" . $key] : $object->array_options ["options_" . $key]);
-			} else {
-				$value = $object->array_options ["options_" . $key];
-			}
-			if ($extrafields->attribute_type [$key] == 'separate') {
-				print $extrafields->showSeparator($key);
-			} else {
-				print '<tr><td>';
-				print '<table width="100%" class="nobordernopadding"><tr><td';
-				if (! empty($extrafields->attribute_required [$key])) print ' class="fieldrequired"';
-				print '>' . $label . '</td>';
-				if (($object->statut == 0 || $extrafields->attribute_alwayseditable[$key]) && $user->rights->propal->creer && ($action != 'edit_extras' || GETPOST('attribute') != $key))
-					print '<td align="right"><a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_edit().'</a></td>';
-				
-				print '</tr></table>';
-				print '<td colspan="5">';
-				
-				// Convert date into timestamp format
-				if (in_array($extrafields->attribute_type [$key], array('date','datetime'))) {
-					$value = isset($_POST["options_" . $key]) ? dol_mktime($_POST["options_" . $key . "hour"], $_POST["options_" . $key . "min"], 0, $_POST["options_" . $key . "month"], $_POST["options_" . $key . "day"], $_POST["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);
-				}
-
-				if ($action == 'edit_extras' && $user->rights->facture->creer && GETPOST('attribute') == $key) {
-					print '<form enctype="multipart/form-data" action="' . $_SERVER["PHP_SELF"] . '" method="post" name="formsoc">';
-					print '<input type="hidden" name="action" value="update_extras">';
-					print '<input type="hidden" name="attribute" value="' . $key . '">';
-					print '<input type="hidden" name="token" value="' . $_SESSION ['newtoken'] . '">';
-					print '<input type="hidden" name="id" value="' . $object->id . '">';
-
-					print $extrafields->showInputField($key, $value);
-
-					print '<input type="submit" class="button" value="' . $langs->trans('Modify') . '">';
-					print '</form>';
-				} else {
-					print $extrafields->showOutputField($key, $value);
-					if ($object->statut == 0 && $user->rights->facture->creer)
-						print '<a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_picto('', 'edit') . ' ' . $langs->trans('Modify') . '</a>';
-				}
-				print '</td></tr>' . "\n";
-			}
-		}
-	}
+	// Other attributes
+	$cols = 5;
+	include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
 	print '</table><br>';
 

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1189,52 +1189,8 @@ else
         }
 
         // Other attributes
-        $parameters=array('colspan' => ' colspan="3"');
-        $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
-
-        $res = $object->fetch_optionals($object->id, $extralabels);
-        if (empty($reshook) && ! empty($extrafields->attribute_label)) {
-        	foreach ($extrafields->attribute_label as $key => $label) {
-        		if ($action == 'edit_extras') {
-        			$value = (isset($_POST ["options_" . $key]) ? $_POST ["options_" . $key] : $object->array_options ["options_" . $key]);
-        		} else {
-        			$value = $object->array_options ["options_" . $key];
-        		}
-        		if ($extrafields->attribute_type [$key] == 'separate') {
-        			print $extrafields->showSeparator($key);
-        		} else {
-        			print '<tr><td';
-        			if (! empty($extrafields->attribute_required [$key]))
-        				print ' class="fieldrequired"';
-        			print '>' . $label . '</td><td colspan="5">';
-        			// Convert date into timestamp format
-        			if (in_array($extrafields->attribute_type [$key], array('date','datetime'))) {
-        				$value = isset($_POST ["options_" . $key]) ? dol_mktime($_POST ["options_" . $key . "hour"], $_POST ["options_" . $key . "min"], 0, $_POST ["options_" . $key . "month"], $_POST ["options_" . $key . "day"], $_POST ["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);
-        			}
-
-        			if ($action == 'edit_extras' && $user->rights->commande->creer && GETPOST('attribute') == $key) {
-        				print '<form enctype="multipart/form-data" action="' . $_SERVER["PHP_SELF"] . '" method="post" name="formcontract">';
-        				print '<input type="hidden" name="action" value="update_extras">';
-        				print '<input type="hidden" name="attribute" value="' . $key . '">';
-        				print '<input type="hidden" name="token" value="' . $_SESSION ['newtoken'] . '">';
-        				print '<input type="hidden" name="id" value="' . $object->id . '">';
-
-        				print $extrafields->showInputField($key, $value);
-
-        				print '<input type="submit" class="button" value="' . $langs->trans('Modify') . '">';
-        				print '</form>';
-        			} else {
-        				print $extrafields->showOutputField($key, $value);
-        				if ($object->statut == 0 && $user->rights->commande->creer)
-        					print '<a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_picto('', 'edit') . ' ' . $langs->trans('Modify') . '</a>';
-        			}
-        			print '</td></tr>' . "\n";
-        		}
-        	}
-        }
-
-
-
+        $cols = 3;
+        include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
         print "</table>";
 

--- a/htdocs/core/actions_extrafields.inc.php
+++ b/htdocs/core/actions_extrafields.inc.php
@@ -141,7 +141,7 @@ if ($action == 'add')
     				}
     			}
 
-                $result=$extrafields->addExtraField($_POST['attrname'],$_POST['label'],$_POST['type'],$_POST['pos'],$extrasize,$elementtype,(GETPOST('unique')?1:0),(GETPOST('required')?1:0),$default_value,$params);
+                $result=$extrafields->addExtraField($_POST['attrname'],$_POST['label'],$_POST['type'],$_POST['pos'],$extrasize,$elementtype,(GETPOST('unique')?1:0),(GETPOST('required')?1:0),$default_value,$params,(GETPOST('alwayseditable')?1:0));
     			if ($result > 0)
     			{
     				setEventMessage($langs->trans('SetupSaved'));
@@ -278,7 +278,7 @@ if ($action == 'update')
     					$params['options'][$key] = $value;
     				}
     			}
-    			$result=$extrafields->update($_POST['attrname'],$_POST['label'],$_POST['type'],$extrasize,$elementtype,(GETPOST('unique')?1:0),(GETPOST('required')?1:0),$pos,$params);
+    			$result=$extrafields->update($_POST['attrname'],$_POST['label'],$_POST['type'],$extrasize,$elementtype,(GETPOST('unique')?1:0),(GETPOST('required')?1:0),$pos,$params,(GETPOST('alwayseditable')?1:0));
     			if ($result > 0)
     			{
     				setEventMessage($langs->trans('SetupSaved'));

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -105,6 +105,7 @@ class ExtraFields
 	 *  @param	int		$required			Is field required or not
 	 *  @param	string	$default_value		Defaulted value
 	 *  @param  array	$param				Params for field
+	 *  @param  int		$alwayseditable		Is attribute always editable regardless of the document status
 	 *  @return int      					<=0 if KO, >0 if OK
 	 */
 	function addExtraField($attrname, $label, $type, $pos, $size, $elementtype, $unique=0, $required=0, $default_value='', $param=0, $alwayseditable=0)
@@ -219,6 +220,7 @@ class ExtraFields
 	 *  @param	int				$unique			Is field unique or not
 	 *  @param	int				$required		Is field required or not
 	 *  @param  array||string	$param			Params for field  (ex for select list : array('options' => array(value'=>'label of option')) )
+	 *  @param  int				$alwayseditable	Is attribute always editable regardless of the document status
 	 *  @return	int								<=0 if KO, >0 if OK
 	 */
 	private function create_label($attrname, $label='', $type='', $pos=0, $size=0, $elementtype='member', $unique=0, $required=0, $param='', $alwayseditable=0)
@@ -350,6 +352,7 @@ class ExtraFields
 	 *  @param	int		$required			Is field required or not
 	 *  @param	int		$pos				Position of attribute
 	 *  @param  array	$param				Params for field  (ex for select list : array('options' => array(value'=>'label of option')) )
+	 *  @param  int		$alwayseditable		Is attribute always editable regardless of the document status
 	 * 	@return	int							>0 if OK, <=0 if KO
 	 */
 	function update($attrname,$label,$type,$length,$elementtype,$unique=0,$required=0,$pos=0,$param='',$alwayseditable=0)
@@ -435,6 +438,7 @@ class ExtraFields
 	 *  @param	int		$required			Is field required or not
 	 *  @param	int		$pos				Position of attribute
 	 *  @param  array	$param				Params for field  (ex for select list : array('options' => array(value'=>'label of option')) )
+	 *  @param  int		$alwayseditable		Is attribute always editable regardless of the document status
 	 *  @return	int							<=0 if KO, >0 if OK
 	 */
 	private function update_label($attrname,$label,$type,$size,$elementtype,$unique=0,$required=0,$pos=0,$param='',$alwayseditable=0)

--- a/htdocs/core/tpl/admin_extrafields_add.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_add.tpl.php
@@ -101,6 +101,8 @@
 <tr><td><?php echo $langs->trans("Unique"); ?></td><td class="valeur"><input id="unique" type="checkbox" name="unique" <?php echo (GETPOST('unique')?' checked="true"':''); ?>></td></tr>
 <!-- Required -->
 <tr><td><?php echo $langs->trans("Required"); ?></td><td class="valeur"><input id="required" type="checkbox" name="required" <?php echo (GETPOST('required')?' checked="true"':''); ?>></td></tr>
+<!-- Always editable -->
+<tr><td><?php echo $langs->trans("AlwaysEditable"); ?></td><td class="valeur"><input id="alwayseditable" type="checkbox" name="alwayseditable" <?php echo (GETPOST('alwayseditable')?' checked="true"':''); ?>></td></tr>
 </table>
 
 <div align="center"><br><input type="submit" name="button" class="button" value="<?php echo $langs->trans("Save"); ?>"> &nbsp;

--- a/htdocs/core/tpl/admin_extrafields_edit.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_edit.tpl.php
@@ -54,6 +54,7 @@ $size=$extrafields->attribute_size[$attrname];
 $unique=$extrafields->attribute_unique[$attrname];
 $required=$extrafields->attribute_required[$attrname];
 $pos=$extrafields->attribute_pos[$attrname];
+$alwayseditable=$extrafields->attribute_alwayseditable[$attrname];
 $param=$extrafields->attribute_param[$attrname];
 
 if((($type == 'select') || ($type == 'checkbox') ||(($type == 'radio'))) && is_array($param))
@@ -110,6 +111,8 @@ if(($type == 'select') || ($type == 'sellist') || ($type == 'checkbox') ||(($typ
 <tr><td><?php echo $langs->trans("Unique"); ?></td><td class="valeur"><input id="unique" type="checkbox" name="unique" <?php echo ($unique?' checked="true"':''); ?>></td></tr>
 <!-- Required -->
 <tr><td><?php echo $langs->trans("Required"); ?></td><td class="valeur"><input id="required" type="checkbox" name="required" <?php echo ($required?' checked="true"':''); ?>></td></tr>
+<!-- Always editable -->
+<tr><td><?php echo $langs->trans("AlwaysEditable"); ?></td><td class="valeur"><input id="alwayseditable" type="checkbox" name="alwayseditable" <?php echo ($alwayseditable?' checked="true"':''); ?>></td></tr>
 
 </table>
 

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -1,0 +1,83 @@
+<?php
+/* Copyright (C) 2014	Maxime Kohlhaas		<support@atm-consulting.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Need to have following variables defined:
+ * $object (invoice, order, ...)
+ * $conf
+ * $langs
+ *
+ * $cols
+ */
+
+//$res = $object->fetch_optionals($object->id, $extralabels);
+$parameters = array('colspan' => ' colspan="'.$cols.'"', 'cols' => $cols, 'socid' => $object->fk_soc);
+$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action);
+
+if (empty($reshook) && ! empty($extrafields->attribute_label))
+{
+	foreach ($extrafields->attribute_label as $key => $label)
+	{
+		if ($action == 'edit_extras')
+		{
+			$value = (isset($_POST ["options_" . $key]) ? $_POST ["options_" . $key] : $object->array_options ["options_" . $key]);
+		}
+		else
+		{
+			$value = $object->array_options ["options_" . $key];
+		}
+		if ($extrafields->attribute_type [$key] == 'separate')
+		{
+			print $extrafields->showSeparator($key);
+		}
+		else
+		{
+			print '<tr><td>';
+			print '<table width="100%" class="nobordernopadding"><tr><td';
+			if (! empty($extrafields->attribute_required [$key])) print ' class="fieldrequired"';
+			print '>' . $label . '</td>';
+			if (($object->statut == 0 || $extrafields->attribute_alwayseditable[$key]) && $user->rights->propal->creer && ($action != 'edit_extras' || GETPOST('attribute') != $key))
+				print '<td align="right"><a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_edit().'</a></td>';
+			
+			print '</tr></table>';
+			print '<td colspan="5">';
+			
+			// Convert date into timestamp format
+			if (in_array($extrafields->attribute_type [$key], array('date','datetime'))) {
+				$value = isset($_POST ["options_" . $key]) ? dol_mktime($_POST ["options_" . $key . "hour"], $_POST ["options_" . $key . "min"], 0, $_POST ["options_" . $key . "month"], $_POST ["options_" . $key . "day"], $_POST ["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);
+			}
+
+			if ($action == 'edit_extras' && $user->rights->propal->creer && GETPOST('attribute') == $key)
+			{
+				print '<form enctype="multipart/form-data" action="' . $_SERVER["PHP_SELF"] . '" method="post" name="formsoc">';
+				print '<input type="hidden" name="action" value="update_extras">';
+				print '<input type="hidden" name="attribute" value="' . $key . '">';
+				print '<input type="hidden" name="token" value="' . $_SESSION ['newtoken'] . '">';
+				print '<input type="hidden" name="id" value="' . $object->id . '">';
+
+				print $extrafields->showInputField($key, $value);
+
+				print '<input type="submit" class="button" value="' . $langs->trans('Modify') . '">';
+
+				print '</form>';
+			}
+			else
+			{
+				print $extrafields->showOutputField($key, $value);
+			}
+			print '</td></tr>' . "\n";
+		}
+	}
+}

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -1330,49 +1330,9 @@ else if ($id > 0 || ! empty($ref))
 	// Statut
 	print '<tr><td>'.$langs->trans("Status").'</td><td colspan="3">'.$object->getLibStatut(4).'</td></tr>';
 
-    // Other attributes (TODO Move this into an include)
-    $parameters=array('colspan' => ' colspan="3"');
-    $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
-	if (empty($reshook) && ! empty($extrafields->attribute_label))
-	{
-		foreach($extrafields->attribute_label as $key=>$label)
-		{
-			if ($action == 'edit_extras') {
-				$value=(isset($_POST["options_".$key])?$_POST["options_".$key]:$object->array_options["options_".$key]);
-			} else {
-				$value=$object->array_options["options_".$key];
-			}
-			if ($extrafields->attribute_type[$key] == 'separate')
-			{
-				print $extrafields->showSeparator($key);
-			}
-			else
-			{
-				print '<tr><td';
-				if (! empty($extrafields->attribute_required[$key])) print ' class="fieldrequired"';
-				print '>'.$label.'</td><td colspan="3">';
-				// Convert date into timestamp format
-				if (in_array($extrafields->attribute_type[$key],array('date','datetime')))
-				{
-					$value = isset($_POST["options_".$key])?dol_mktime($_POST["options_".$key."hour"], $_POST["options_".$key."min"], 0, $_POST["options_".$key."month"], $_POST["options_".$key."day"], $_POST["options_".$key."year"]):$db->jdate($object->array_options['options_'.$key]);
-				}
-				if ($action == 'edit_extras' && $user->rights->ficheinter->creer && GETPOST('attribute') == $key)
-				{
-					print '<input type="hidden" name="attribute" value="'.$key.'">';
-
-					print $extrafields->showInputField($key,$value);
-
-					print ' &nbsp; <input type="submit" class="button" value="'.$langs->trans('Modify').'">';
-				}
-				else
-				{
-					print $extrafields->showOutputField($key,$value);
-					if (($object->statut == 0 || $object->statut == 1) && $user->rights->ficheinter->creer) print ' &nbsp; <a href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=edit_extras&attribute='.$key.'">'.img_picto('','edit').' '.$langs->trans('Modify').'</a>';
-				}
-				print '</td></tr>'."\n";
-			}
-		}
-	}
+    // Other attributes
+    $cols = 3;
+    include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
 	print "</table>";
 

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -413,6 +413,15 @@ class FactureFournisseur extends CommonInvoice
 
                 $this->socid  = $obj->socid;
                 $this->socnom = $obj->socnom;
+				
+                // Retreive all extrafield
+                // fetch optionals attributes and labels
+                require_once(DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php');
+                $extrafields=new ExtraFields($this->db);
+                $extralabels=$extrafields->fetch_name_optionals_label($this->table_element,true);
+                $this->fetch_optionals($this->id,$extralabels);
+
+                if ($this->statut == 0) $this->brouillon = 1;
 
                 $result=$this->fetch_lines();
                 if ($result < 0)

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1484,78 +1484,9 @@ elseif (! empty($object->id))
 		print '</tr>';
 	}
 
-	// Other attributes (TODO Move this into an include)
-	$parameters=array('socid'=>$socid, 'colspan' => ' colspan="3"');
-	$reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
-	if (empty($reshook) && ! empty($extrafields->attribute_label))
-	{
-		foreach($extrafields->attribute_label as $key=>$label)
-		{
-			if ($action == 'edit_extras')
-			{
-				$value=(isset($_POST["options_".$key])?$_POST["options_".$key]:$object->array_options["options_".$key]);
-			}
-			else
-			{
-				$value=$object->array_options["options_".$key];
-			}
-
-			if ($extrafields->attribute_type[$key] == 'separate')
-			{
-				print $extrafields->showSeparator($key);
-			}
-			else
-			{
-				print '<tr><td';
-				if (! empty($extrafields->attribute_required[$key])) print ' class="fieldrequired"';
-				print '>'.$label.'</td><td colspan="5">';
-				// Convert date into timestamp format
-				if (in_array($extrafields->attribute_type[$key],array('date','datetime')))
-				{
-					$value = isset($_POST["options_".$key])?dol_mktime($_POST["options_".$key."hour"], $_POST["options_".$key."min"], 0, $_POST["options_".$key."month"], $_POST["options_".$key."day"], $_POST["options_".$key."year"]):$db->jdate($object->array_options['options_'.$key]);
-				}
-
-				if ($action == 'edit_extras' && $user->rights->commande->creer && GETPOST('attribute') == $key)
-				{
-					print '<form enctype="multipart/form-data" action="' . $_SERVER["PHP_SELF"] . '" method="post" name="formsoc">';
-					print '<input type="hidden" name="action" value="update_extras">';
-					print '<input type="hidden" name="attribute" value="' . $key . '">';
-					print '<input type="hidden" name="token" value="' . $_SESSION ['newtoken'] . '">';
-					print '<input type="hidden" name="id" value="' . $object->id . '">';
-
-					print $extrafields->showInputField($key, $value);
-
-					print '<input type="submit" class="button" value="' . $langs->trans('Modify') . '">';
-					print '</form>';
-				}
-				else
-				{
-					print $extrafields->showOutputField($key, $value);
-					if ($object->statut == 0 && $user->rights->commande->creer)
-						print '<a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_picto('', 'edit') . ' ' . $langs->trans('Modify') . '</a>';
-				}
-				print '</td></tr>'."\n";
-		  	}
-		}
-
-		if(count($extrafields->attribute_label) > 0)
-		{
-			if ($action == 'edit_extras' && $user->rights->fournisseur->commande->creer)
-			{
-				print '<tr><td></td><td colspan="5">';
-				print '<input type="submit" class="button" value="'.$langs->trans('Modify').'">';
-				print '</form>';
-				print '</td></tr>';
-			}
-			else
-			{
-				if ($object->statut == 0 && $user->rights->fournisseur->commande->creer)
-				{
-					print '<tr><td></td><td><a href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=edit_extras">'.img_picto('','edit').' '.$langs->trans('Modify').'</a></td></tr>';
-				}
-			}
-		}
-	}
+	// Other attributes
+	$cols = 3;
+	include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
 	// Ligne de	3 colonnes
 	print '<tr><td>'.$langs->trans("AmountHT").'</td>';

--- a/htdocs/install/mysql/migration/3.6.0-3.7.0.sql
+++ b/htdocs/install/mysql/migration/3.6.0-3.7.0.sql
@@ -1096,3 +1096,5 @@ DELETE FROM llx_const WHERE name = 'MAIN_MODULE_BOUTIQUE';
 DELETE FROM llx_const WHERE name = 'OSC_DB_HOST';
 DELETE FROM llx_menu WHERE module = 'boutique';
 
+-- Add option always editable on extrafield
+ALTER TABLE llx_extrafields ADD alwayseditable INT(11) NOT NULL AFTER pos;

--- a/htdocs/install/mysql/tables/llx_extrafields.sql
+++ b/htdocs/install/mysql/tables/llx_extrafields.sql
@@ -22,7 +22,7 @@ create table llx_extrafields
 	rowid           integer AUTO_INCREMENT PRIMARY KEY,
 	name            varchar(64) NOT NULL,       -- nom de l'attribut
 	entity          integer DEFAULT 1 NOT NULL,	-- multi company id
-    	elementtype     varchar(64) NOT NULL DEFAULT 'member',
+    elementtype     varchar(64) NOT NULL DEFAULT 'member',
 	tms             timestamp,
 	label           varchar(255) NOT NULL,      -- label correspondant a l'attribut
 	type            varchar(8),
@@ -30,5 +30,6 @@ create table llx_extrafields
 	fieldunique     integer DEFAULT 0,
 	fieldrequired   integer DEFAULT 0,
 	pos             integer DEFAULT 0,
+	alwayseditable  integer DEFAULT 0,
 	param		text
 )ENGINE=innodb;


### PR DESCRIPTION
New : can define that an extrafield is always editable (regardless of the document status)
Qual : display of extrafields on objects is now in a single tpl file (proposal, order, invoice, fichinter, contrat, supplier order, supplier invoice)
Fix : extrafields were not working on supplier invoices
Cosmetic : the icon displayed is now the same for extrafields as the standard fields (icon on the left of the value and no "Modify" work next to ir)
