### PR TITLE
object must be reloaded before creating pdf on confirmation and ordering

### DIFF
--- a/htdocs/fourn/commande/fiche.php
+++ b/htdocs/fourn/commande/fiche.php
@@ -523,7 +523,8 @@ else if ($action == 'confirm_approve' && $confirm == 'yes' && $user->rights->fou
         if ($result > 0)
         {
             if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) {
-                supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
+            	$ret=$object->fetch($object->id);    // Reload to get new records
+            	supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
             }
             header("Location: ".$_SERVER["PHP_SELF"]."?id=".$object->id);
             exit;
@@ -555,7 +556,8 @@ else if ($action == 'confirm_commande' && $confirm	== 'yes' &&	$user->rights->fo
     if ($result > 0)
     {
         if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) {
-            supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
+        	$ret=$object->fetch($object->id);    // Reload to get new records
+        	supplier_order_pdf_create($db, $object, $object->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
         }
         header("Location: ".$_SERVER["PHP_SELF"]."?id=".$object->id);
         exit;


### PR DESCRIPTION
in suppplier order, when confirming or ordering the cretaed pdf file is false because object is not reloaded
