### PR TITLE
Fix problem on task creation with chrome for french browser.

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1053,7 +1053,11 @@ function dol_mktime($hour,$minute,$second,$month,$day,$year,$gm=false,$check=1)
 				$default_timezone=@date_default_timezone_get();
 			}
 		}
-		else $localtz = new DateTimeZone('UTC');
+		
+		if (empty($localtz)) {
+			$localtz = new DateTimeZone('UTC');
+		}
+		
 		$dt = new DateTime(null,$localtz);
 		$dt->setDate($year,$month,$day);
 		$dt->setTime((int) $hour, (int) $minute, (int) $second);

--- a/htdocs/user/fiche.php
+++ b/htdocs/user/fiche.php
@@ -1208,7 +1208,11 @@ else
 
             // Signature
             print '<tr><td valign="top">'.$langs->trans('Signature').'</td><td>';
-            print dol_htmlentitiesbr($object->signature);
+            if (empty($conf->global->FCKEDITOR_ENABLE_USERSIGN)) {
+            	print dol_htmlentitiesbr($object->signature);
+            } else {
+            	print $object->signature;
+            }
             print "</td></tr>\n";
 
             // Hierarchy


### PR DESCRIPTION
With Chrome on windows 8 french $_SESSION["dol_tz_string"] is "Paris/_Madrid", that is not a valid parameters for $localtz = new DateTimeZone($default_timezone);

In all case, if  $localtz is empty we should initialze with something, else new DateTime(null,$localtz); will trhow an execption with second paramters cannot be NULL.
