### PR TITLE
Remove full descriptions from the product list in the contract card

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1290,7 +1290,8 @@ else
                         	$productstatic->ref=$objp->label;
                         	print $productstatic->getNomUrl(0,'',16);
                         }
-                        if ($objp->description) print '<br>'.dol_nl2br($objp->description);
+                        if (! empty($conf->global->PRODUIT_DESC_IN_FORM) and $objp->description) 
+                            print '<br>'.dol_nl2br($objp->description);
                         print '</td>';
                     }
                     else


### PR DESCRIPTION
Hi guys !

We've been using the "contract" feature since a few weeks now. It's usefull but the card/fiche pages are too long  because:

a/ we have a lot of product in our contracts 
b/ our product have very long descriptions 

Display the entire description of each prpduct is not usefull at all and it take a lot of rooms on the page.

I'd like to remove it so that the contract card would be more consistent with propal and invoice pages....

Regards,
