### PR TITLE
Update json.lib.php

### DIFF
--- a/htdocs/core/lib/json.lib.php
+++ b/htdocs/core/lib/json.lib.php
@@ -242,8 +242,11 @@ function dol_json_decode($json, $assoc=false)
 	$out=_unval($out);
 
 	// Return an array
-	if ($out != '') eval('$array = '.$out.';');
-	else $array=array();
+	if ($out != '') {
+		$out = str_replace('\"', '"', $out);
+		eval('$array = '.$out.';');
+	}
+        else $array=array();
 
 	// Return an object
 	if (! $assoc)


### PR DESCRIPTION
http://www.dolibarr.fr/forum/3-installation/51023-erreur-sur-page-d-accueil-dans-les-boite-graphique

If we have \" in $out like array(\"year\" => \"2014\",\"showtot\" => \"on\") we have : Parse error: syntax error, unexpected '"', expecting T_STRING in /dolibarr/htdocs/core/lib/json.lib.php(248) : eval()'d code on line 1
