### PR TITLE
 Fixed[ bug #1661 ] Bookmarks list "Target" translation missing

### DIFF
--- a/htdocs/bookmarks/list.php
+++ b/htdocs/bookmarks/list.php
@@ -25,6 +25,7 @@ require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/bookmarks/class/bookmark.class.php';
 
 $langs->load("bookmarks");
+$langs->load("admin");
 
 // Security check
 if (! $user->rights->bookmark->lire) {


### PR DESCRIPTION
Fixed[ bug #1661 ] Bookmarks list "Target" translation missing
