### PR TITLE
Fixed [ bug #1718 ] Mistakenly searching for text in amount field breaks

### DIFF
--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -123,7 +123,7 @@ if ($search_user)
 }
 if ($search_ttc)
 {
-	$sql .= " AND total_ttc = ".price2num($search_ttc);
+	$sql .= " AND total_ttc = '".$db->escape(price2num($search_ttc))."'";
 }
 if ($sall)
 {


### PR DESCRIPTION
Fixed [ bug #1718 ] Mistakenly searching for text in amount field breaks
