### PR TITLE
Fix Typo for traduction

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2622,7 +2622,7 @@ class Form
                     $i++;
                 }
                 print "</select>";
-                if ($user->admin) print info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionnarySetup"),1);
+                if ($user->admin) print info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"),1);
             } else {
                 print $langs->trans("NoShippingMethodDefined");
             }


### PR DESCRIPTION
line 2625 I removed a 'n' from "YouCanChangeValuesForThisListFromDictionnarySetup" to have correct translation
