### PR TITLE
FIX: dont put a mess with date and datetime extrafield value if already in right format

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2178,10 +2178,10 @@ abstract class CommonObject
             			$this->array_options[$key] = price2num($this->array_options[$key]);
             			break;
             		case 'date':
-            			$this->array_options[$key]=$this->db->idate($this->array_options[$key]);
+            			if (is_numeric($this->array_options[$key])) $this->array_options[$key]=$this->db->idate($this->array_options[$key]);
             			break;
             		case 'datetime':
-            			$this->array_options[$key]=$this->db->idate($this->array_options[$key]);
+            			if (is_numeric($this->array_options[$key])) $this->array_options[$key]=$this->db->idate($this->array_options[$key]);
             			break;
                	}
             }


### PR DESCRIPTION
 (the bug was in propale/order/invoice extrafields, mainly visible with 2 datetime extrafields)
