### PR TITLE
Fix: [ bug #1736 ] Failing supplier Elephant numeration module with some masks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,7 @@ Fix: Paypal link were broken dur to SSL v3 closed.
 - Fix: Show sender Country on PDF docs when sender Country <> receiver Country
 - Fix: [ bug #1624 ] Use lowest buying price for margin when selling with POS
 - Fix: [ bug #1749 ] Undefined $mailchimp
+- Fix: [ bug #1736 ] Failing supplier Elephant numeration module with some masks
 
 ***** ChangeLog for 3.6.1 compared to 3.6.* *****
 For users:

--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -738,7 +738,7 @@ function get_next_value($db,$mask,$table,$field,$where='',$objsoc='',$date='',$m
     $sql = "SELECT MAX(".$sqlstring.") as val";
     $sql.= " FROM ".MAIN_DB_PREFIX.$table;
     $sql.= " WHERE ".$field." LIKE '".$maskLike."'";
-    $sql.= " AND ".$field." NOT LIKE '%PROV%'";
+    $sql.= " AND ".$field." NOT LIKE '(PROV%)'";
     $sql.= " AND entity IN (".getEntity($table, 1).")";
     if ($where) $sql.=$where;
     if ($sqlwhere) $sql.=' AND '.$sqlwhere;


### PR DESCRIPTION
The problem was that it was filtering itself off. Because PROV masks are (PROVXX), I refined the SQL query
