### PR TITLE
Fix: [ bug #1649 ] Cancel button of several thirdparty actions, does the same thing as modify

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ English Dolibarr ChangeLog
 - Fix: Show sender Country on PDF docs when sender Country <> receiver Country
 - Fix: [ bug #1624 ] Use lowest buying price for margin when selling with POS
 - Fix: [ bug #1749 ] Undefined $mailchimp
+- Fix: [ bug #1649 ] Cancel button of several thirdparty actions, does the same thing as modify
 
 ***** ChangeLog for 3.6.1 compared to 3.6.* *****
 For users:

--- a/htdocs/comm/fiche.php
+++ b/htdocs/comm/fiche.php
@@ -79,17 +79,21 @@ $object = new Societe($db);
 $parameters = array('socid' => $id);
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some
 
+//Some actions show a "cancel" input submit button with name="cancel"
+$cancelbutton = GETPOST('cancel');
 
 if ($action == 'setcustomeraccountancycode')
 {
-	$result=$object->fetch($id);
-	$object->code_compta=$_POST["customeraccountancycode"];
-	$result=$object->update($object->id,$user,1,1,0);
-	if ($result < 0)
-	{
-		$mesgs[]=join(',',$object->errors);
+	if (!$cancelbutton) {
+		$result=$object->fetch($id);
+		$object->code_compta=$_POST["customeraccountancycode"];
+		$result=$object->update($object->id,$user,1,1,0);
+		if ($result < 0)
+		{
+			$mesgs[]=join(',',$object->errors);
+		}
+		$action="";
 	}
-	$action="";
 }
 
 // conditions de reglement
@@ -139,10 +143,14 @@ if ($action == 'cstc')
 // Update communication level
 if ($action == 'setOutstandingBill')
 {
-	$object->fetch($id);
-	$object->outstanding_limit=GETPOST('OutstandingBill');
-	$result=$object->set_OutstandingBill($user);
-	if ($result < 0) setEventMessage($object->error,'errors');
+	if (!$cancelbutton) {
+		$object->fetch($id);
+		$object->outstanding_limit = GETPOST('OutstandingBill');
+		$result = $object->set_OutstandingBill($user);
+		if ($result < 0) {
+			setEventMessage($object->error, 'errors');
+		}
+	}
 }
 
 

--- a/htdocs/fourn/fiche.php
+++ b/htdocs/fourn/fiche.php
@@ -60,14 +60,18 @@ $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action
 
 if ($action == 'setsupplieraccountancycode')
 {
-    $result=$object->fetch($id);
-    $object->code_compta_fournisseur=$_POST["supplieraccountancycode"];
-    $result=$object->update($object->id,$user,1,0,1);
-    if ($result < 0)
-    {
-        $mesg=join(',',$object->errors);
-    }
-    $action="";
+	$cancelbutton = GETPOST('cancel');
+
+	if (!$cancelbutton) {
+
+		$result = $object->fetch($id);
+		$object->code_compta_fournisseur = $_POST["supplieraccountancycode"];
+		$result = $object->update($object->id, $user, 1, 0, 1);
+		if ($result < 0) {
+			$mesg = join(',', $object->errors);
+		}
+		$action = "";
+	}
 }
 // conditions de reglement
 if ($action == 'setconditions' && $user->rights->societe->creer)


### PR DESCRIPTION
Fix: [ bug #1649 ] Cancel button of several thirdparty actions, does the same thing as modify
