### PR TITLE
Fix: [ bug #1774 ] PHP Fatal error when creating a contract with Product module not enabled

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1229,8 +1229,10 @@ else
         /*
          * Lines of contracts
          */
-        $productstatic=new Product($db);
 
+	    if ($conf->product->enabled) {
+			$productstatic=new Product($db);
+	    }
 
         $usemargins=0;
 		if (! empty($conf->margin->enabled) && ! empty($object->element) && in_array($object->element,array('facture','propal','commande'))) $usemargins=1;


### PR DESCRIPTION
Fix: [ bug #1774 ] PHP Fatal error when creating a contract with Product module not enabled
