### PR TITLE
Fix: [ bug #1775 ] New lines can be entered after contract validation

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1672,7 +1672,7 @@ else
         }
 
 		// Form to add new line
-        if ($user->rights->contrat->creer && ($object->statut >= 0))
+        if ($user->rights->contrat->creer && ($object->statut == 0))
         {
         	$dateSelector=1;
 


### PR DESCRIPTION
Fix: [ bug #1775 ] New lines can be entered after contract validation
