### PR TITLE
Change to $listofcurrenciesbefore for GBP + AUD

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -2948,7 +2948,7 @@ function price($amount, $form=0, $outlangs='', $trunc=1, $rounding=-1, $forcerou
 	{
 		if ($currency_code == 'auto') $currency_code=$conf->currency;
 
-		$listofcurrenciesbefore=array('USD');
+		$listofcurrenciesbefore=array('USD','GBP','AUD');
 		if (in_array($currency_code,$listofcurrenciesbefore)) $cursymbolbefore.=$outlangs->getCurrencySymbol($currency_code);
 		else
 		{


### PR DESCRIPTION
Update of functions.lib.php - function price()
$listofcurrenciesbefore to include USD, GBP, and AUD to support $ and £ appearing before amounts on invoices not after the amount
