### PR TITLE
Fix: [ bug #1785 ] Start date is lost in Project > Linked objects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ English Dolibarr ChangeLog
 ***** ChangeLog for 3.6.3 compared to 3.6.2 *****
 - Fix: ref_ext was not saved when recording a customer order from web service
 - Fix: amarok is a bugged theme making dolidroid failed. We swith to eldy automatically with dolidroid.
+- Fix: [ bug #1785 ] Start date is lost in Project > Linked objects
 
 ***** ChangeLog for 3.6.2 compared to 3.6.1 *****
 - Fix: fix ErrorBadValueForParamNotAString error message in price customer multiprice.

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -130,12 +130,12 @@ print '<tr><td>'.$langs->trans("Status").'</td><td>'.$project->getLibStatut(4).'
 
 // Date start
 print '<tr><td>'.$langs->trans("DateStart").'</td><td>';
-print dol_print_date($object->date_start,'day');
+print dol_print_date($project->date_start,'day');
 print '</td></tr>';
 
 // Date end
 print '<tr><td>'.$langs->trans("DateEnd").'</td><td>';
-print dol_print_date($object->date_end,'day');
+print dol_print_date($project->date_end,'day');
 print '</td></tr>';
 
 print '</table>';


### PR DESCRIPTION
Fix: [ bug #1785 ] Start date is lost in Project > Linked objects
