### PR TITLE
Fix:  [ bug #1797 ] Tulip Supplier invoice module takes creation date instead of invoice date

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Fix: Paypal link were broken dur to SSL v3 closed.
 Fix: [ bug #1769 ] Error when installing to a PostgreSQL DB that contains numbers
 Fix: [ bug #1752 ] Date filter of margins module, filters since 12H instead of 00H
 Fix: [ bug #1757 ] Sorting breaks product/service statistics
+Fix: [ bug #1797 ] Tulip supplier invoice module takes creation date instead of invoice date
 
 ***** ChangeLog for 3.5.6 compared to 3.5.5 *****
 Fix: Avoid missing class error for fetch_thirdparty method #1973

--- a/htdocs/core/modules/supplier_invoice/mod_facture_fournisseur_tulip.php
+++ b/htdocs/core/modules/supplier_invoice/mod_facture_fournisseur_tulip.php
@@ -125,7 +125,8 @@ class mod_facture_fournisseur_tulip extends ModeleNumRefSuppliersInvoices
 			return 0;
 		}
 
-		$numFinal=get_next_value($db,$mask,'facture_fourn','ref','',$objsoc->code_fournisseur,$object->datef);
+	    //Supplier invoices take invoice date instead of creation date for the mask
+		$numFinal=get_next_value($db,$mask,'facture_fourn','ref','',$objsoc->code_fournisseur,$object->date);
 
 		return  $numFinal;
 	}


### PR DESCRIPTION
Fix:  [ bug #1797 ] Tulip Supplier invoice module takes creation date instead of invoice date
