### PR TITLE
Fix: [ bug #1784 ] « Message page de connexion » n'apparaît pas

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ English Dolibarr ChangeLog
 - Fix: amarok is a bugged theme making dolidroid failed. We swith to eldy automatically with dolidroid.
 - Fix: withdrawal create error if in the same month are deleted previus withdrawals.
 - Fix: [ bug #1801 ] FAC_FORCE_DATE_VALIDATION constant alters supplier invoice date given to numeration modules
+- Fix: [ bug #1784 ] « Message page de connexion » n'apparaît pas
 
 ***** ChangeLog for 3.6.2 compared to 3.6.1 *****
 - Fix: fix ErrorBadValueForParamNotAString error message in price customer multiprice.

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@ English Dolibarr ChangeLog
 - Fix: amarok is a bugged theme making dolidroid failed. We swith to eldy automatically with dolidroid.
 - Fix: withdrawal create error if in the same month are deleted previus withdrawals.
 - Fix: [ bug #1801 ] FAC_FORCE_DATE_VALIDATION constant alters supplier invoice date given to numeration modules
-- Fix: [ bug #1784 ] « Message page de connexion » n'apparaît pas
+- Fix: [ bug #1784 ] MOTD doesn't show up in Amarok theme
 
 ***** ChangeLog for 3.6.2 compared to 3.6.1 *****
 - Fix: fix ErrorBadValueForParamNotAString error message in price customer multiprice.

--- a/htdocs/core/tpl/login.tpl.php
+++ b/htdocs/core/tpl/login.tpl.php
@@ -203,7 +203,7 @@ if (isset($conf->file->main_authentication) && preg_match('/openid/',$conf->file
 <?php if ($main_home)
 {
 ?>
-	<div class="center" class="login_main_home" style="max-width: 80%">
+	<div class="login_main_home" style="max-width: 80%">
 	<?php echo $main_home; ?>
 	</div><br>
 <?php


### PR DESCRIPTION
Fix: [ bug #1784 ] « Message page de connexion » n'apparaît pas
