### PR TITLE
Add Extrafields for Supplier invoice lines

### DIFF
--- a/htdocs/admin/supplierinvoicedet_extrafields.php
+++ b/htdocs/admin/supplierinvoicedet_extrafields.php
@@ -1,0 +1,160 @@
+<?php
+/* Copyright (C) 2001-2002 Rodolphe Quiedeville <rodolphe@quiedeville.org>
+* Copyright (C) 2003 Jean-Louis Bergamo <jlb@j1b.org>
+* Copyright (C) 2004-2011 Laurent Destailleur <eldy@users.sourceforge.net>
+* Copyright (C) 2012 Regis Houssin <regis.houssin@capnetworks.com>
+* Copyright (C) 2013 Jean-Francois FERRY <jfefe@aternatik.fr>
+* Copyright (C) 2013 Florian Henry	<florian.henry@open-concept.pro>
+* Copyright (C) 2015 Claudio Aschieri <c.aschieri@19.coop>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ *      \file     htdocs/admin/supplierinvoicedet_extrafields.php
+ *		\ingroup    fourn
+ *		\brief      Page to setup extra fields of supplierinvoice line
+*/
+
+require '../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/fourn.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+
+$langs->load("companies");
+$langs->load("admin");
+$langs->load("bills");
+$langs->load("suppliers");
+
+$extrafields = new ExtraFields($db);
+$form = new Form($db);
+
+// List of supported format
+$tmptype2label=getStaticMember(get_class($extrafields),'type2label');
+$type2label=array('');
+foreach ($tmptype2label as $key => $val) $type2label[$key]=$langs->trans($val);
+
+$action=GETPOST('action', 'alpha');
+$attrname=GETPOST('attrname', 'alpha');
+$elementtype='facturefourn_det'; //Must be the $table_element of the class that manage extrafield
+
+if (!$user->admin) accessforbidden();
+
+
+/*
+* Actions
+*/
+
+require DOL_DOCUMENT_ROOT.'/core/actions_extrafields.inc.php';
+
+
+
+/*
+* View
+*/
+
+$textobject=strtolower($langs->transnoentitiesnoconv("BillsSuppliers"));
+
+
+llxHeader('',$langs->trans("SuppliersSetup"));
+
+
+$linkback='<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans("BackToModuleList").'</a>';
+print_fiche_titre($langs->trans("SuppliersSetup"),$linkback,'setup');
+print '<br>';
+
+$head = supplierorder_admin_prepare_head(null);
+
+dol_fiche_head($head, 'supplierinvoice', $langs->trans("Suppliers"), 0, 'company');
+
+
+print $langs->trans("DefineHereComplementaryAttributes",$textobject).'<br><br>'."\n";
+
+// Load attribute_label
+$extrafields->fetch_name_optionals_label($elementtype);
+
+print "<table summary=\"listofattributes\" class=\"noborder\" width=\"100%\">";
+
+print '<tr class="liste_titre">';
+print '<td align="center">'.$langs->trans("Position").'</td>';
+print '<td>'.$langs->trans("Label").'</td>';
+print '<td>'.$langs->trans("AttributeCode").'</td>';
+print '<td>'.$langs->trans("Type").'</td>';
+print '<td align="right">'.$langs->trans("Size").'</td>';
+print '<td align="center">'.$langs->trans("Unique").'</td>';
+print '<td align="center">'.$langs->trans("Required").'</td>';
+print '<td width="80">&nbsp;</td>';
+print "</tr>\n";
+
+$var=True;
+foreach($extrafields->attribute_type as $key => $value)
+{
+    $var=!$var;
+    print "<tr ".$bc[$var].">";
+    print "<td>".$extrafields->attribute_pos[$key]."</td>\n";
+    print "<td>".$extrafields->attribute_label[$key]."</td>\n";
+    print "<td>".$key."</td>\n";
+    print "<td>".$type2label[$extrafields->attribute_type[$key]]."</td>\n";
+    print '<td align="right">'.$extrafields->attribute_size[$key]."</td>\n";
+    print '<td align="center">'.yn($extrafields->attribute_unique[$key])."</td>\n";
+    print '<td align="center">'.yn($extrafields->attribute_required[$key])."</td>\n";
+    print '<td align="right"><a href="'.$_SERVER["PHP_SELF"].'?action=edit&attrname='.$key.'">'.img_edit().'</a>';
+    print "&nbsp; <a href=\"".$_SERVER["PHP_SELF"]."?action=delete&attrname=$key\">".img_delete()."</a></td>\n";
+    print "</tr>";
+    // $i++;
+}
+
+print "</table>";
+
+dol_fiche_end();
+
+
+// Buttons
+if ($action != 'create' && $action != 'edit')
+{
+    print '<div class="tabsAction">';
+    print "<a class=\"butAction\" href=\"".$_SERVER["PHP_SELF"]."?action=create\">".$langs->trans("NewAttribute")."</a>";
+    print "</div>";
+}
+
+
+/* ************************************************************************** */
+/* */
+/* Creation d'un champ optionnel
+/* */
+/* ************************************************************************** */
+
+if ($action == 'create')
+{
+    print "<br>";
+    print_titre($langs->trans('NewAttribute'));
+
+    require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_add.tpl.php';
+}
+
+/* ************************************************************************** */
+/* */
+/* Edition d'un champ optionnel */
+/* */
+/* ************************************************************************** */
+if ($action == 'edit' && ! empty($attrname))
+{
+    print "<br>";
+    print_titre($langs->trans("FieldEdition", $attrname));
+
+    require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_edit.tpl.php';
+}
+
+llxFooter();
+
+$db->close();

--- a/htdocs/admin/supplierinvoicedet_extrafields.php
+++ b/htdocs/admin/supplierinvoicedet_extrafields.php
@@ -75,7 +75,7 @@ print '<br>';
 
 $head = supplierorder_admin_prepare_head(null);
 
-dol_fiche_head($head, 'supplierinvoice', $langs->trans("Suppliers"), 0, 'company');
+dol_fiche_head($head, 'supplierinvoicedet', $langs->trans("Suppliers"), 0, 'company');
 
 
 print $langs->trans("DefineHereComplementaryAttributes",$textobject).'<br><br>'."\n";

--- a/htdocs/core/lib/fourn.lib.php
+++ b/htdocs/core/lib/fourn.lib.php
@@ -191,6 +191,11 @@ function supplierorder_admin_prepare_head($object)
 	$head[$h][1] = $langs->trans("ExtraFieldsSupplierInvoices");
 	$head[$h][2] = 'supplierinvoice';
 	$h++;
+	
+	$head[$h][0] = DOL_URL_ROOT.'/admin/supplierinvoicedet_extrafields.php';
+	$head[$h][1] = $langs->trans("ExtraFieldsLines");
+	$head[$h][2] = 'supplierinvoicedet';
+	$h++;
 
 	complete_head_from_modules($conf,$langs,$object,$head,$h,'supplierorder_admin','remove');
 

--- a/htdocs/fourn/facture/fiche.php
+++ b/htdocs/fourn/facture/fiche.php
@@ -1804,6 +1804,52 @@ else
         // Other options
         $parameters=array('colspan' => ' colspan="4"');
         $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
+        
+        // Extrafields
+        $extrafields = new ExtraFields($db);
+        $extralabels = $extrafields->fetch_name_optionals_label($object->table_element);
+        $ret = $extrafields->setOptionalsFromPost($extralabels, $object);
+        
+        if (empty($reshook) && ! empty($extrafields->attribute_label)) {
+        
+        	foreach ($extrafields->attribute_label as $key => $label) {
+        		if ($action == 'edit_extras') {
+        			$value = (isset($_POST["options_" . $key]) ? $_POST["options_" . $key] : $object->array_options ["options_" . $key]);
+        		} else {
+        			$value = $object->array_options ["options_" . $key];
+        		}
+        		if ($extrafields->attribute_type [$key] == 'separate') {
+        			print $extrafields->showSeparator($key);
+        		} else {
+        			print '<tr><td';
+        			if (! empty($extrafields->attribute_required [$key]))
+        				print ' class="fieldrequired"';
+        			print '>' . $label . '</td><td colspan="5">';
+        			// Convert date into timestamp format
+        			if (in_array($extrafields->attribute_type [$key], array('date','datetime'))) {
+        				$value = isset($_POST["options_" . $key]) ? dol_mktime($_POST["options_" . $key . "hour"], $_POST["options_" . $key . "min"], 0, $_POST["options_" . $key . "month"], $_POST["options_" . $key . "day"], $_POST["options_" . $key . "year"]) : $db->jdate($object->array_options ['options_' . $key]);
+        			}
+        
+        			if ($action == 'edit_extras' && $user->rights->fournisseur->facture->creer && GETPOST('attribute') == $key) {
+        				print '<form enctype="multipart/form-data" action="' . $_SERVER["PHP_SELF"] . '" method="post" name="formsoc">';
+        				print '<input type="hidden" name="action" value="update_extras">';
+        				print '<input type="hidden" name="attribute" value="' . $key . '">';
+        				print '<input type="hidden" name="token" value="' . $_SESSION ['newtoken'] . '">';
+        				print '<input type="hidden" name="id" value="' . $object->id . '">';
+        
+        				print $extrafields->showInputField($key, $value);
+        
+        				print '<input type="submit" class="button" value="' . $langs->trans('Modify') . '">';
+        				print '</form>';
+        			} else {
+        				print $extrafields->showOutputField($key, $value);
+        				if ($object->statut == 0 && $user->rights->fournisseur->facture->creer)
+        					print '<a href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit_extras&attribute=' . $key . '">' . img_picto('', 'edit') . ' ' . $langs->trans('Modify') . '</a>';
+        			}
+        			print '</td></tr>' . "\n";
+        		}
+        	}
+        }
 
         print '</table>';
 

--- a/htdocs/install/mysql/tables/llx_facture_fourn_det_extrafields.key.sql
+++ b/htdocs/install/mysql/tables/llx_facture_fourn_det_extrafields.key.sql
@@ -1,0 +1,20 @@
+-- ===================================================================
+-- Copyright (C) 2015      Claudio Aschieri	<c.aschieri@19.coop>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+--
+-- ===================================================================
+
+
+ALTER TABLE llx_facturefourn_det_extrafields ADD INDEX idx_facturefourndet_extrafields (fk_object);

--- a/htdocs/install/mysql/tables/llx_facture_fourn_det_extrafields.sql
+++ b/htdocs/install/mysql/tables/llx_facture_fourn_det_extrafields.sql
@@ -1,0 +1,25 @@
+-- ===================================================================
+-- Copyright (C) 2015      Claudio Aschieri	<c.aschieri@19.coop>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+--
+-- ===================================================================
+
+create table llx_facturefourn_det_extrafields
+(
+  rowid            integer AUTO_INCREMENT PRIMARY KEY,
+  tms              timestamp,
+  fk_object        integer NOT NULL,    -- object id
+  import_key       varchar(14)      	-- import key
+)ENGINE=innodb;


### PR DESCRIPTION
I added extrafields features for supplier invoice lines. I created 2 new files in install directory with sql code. I didn't create file sql to migrate from 3.6.0 because i think that file will be updated by developer  that will merge this code. 
Third commit add extrafields on supplier invoice head.
It's my first Dolibarr pull request, so let me know what I wrong 
