### PR TITLE
Fix: webservices productorservice not updating the price.

### DIFF
--- a/htdocs/webservices/server_productorservice.php
+++ b/htdocs/webservices/server_productorservice.php
@@ -668,6 +668,25 @@ function updateProductOrService($authentication,$product)
         {
             $error++;
         }
+        if (! $error)
+        {
+            if ($newobject->price_base_type == 'HT')
+            {
+                $result=$newobject->updatePrice($newobject->price, $newobject->price_base_type,$fuser);
+                if ($result <= 0)
+                {
+                    $error++;
+                }
+            }
+            elseif ($newobject->price_base_type == 'TTC')
+            {
+                $result=$newobject->updatePrice($newobject->price_ttc, $newobject->price_base_type);
+                if ($result <= 0)
+                {
+                    $error++;
+                }
+            }
+        }
 
         if (! $error)
         {


### PR DESCRIPTION
The product.class.php provides another method updatePrice() to update the
price of products or services. We should call updatePrice() when we found the
SOAP client changes the price or price_net.

Signed-off-by: Ying-Chun Liu (PaulLiu) paulliu@debian.org
