### PR TITLE
Fix [ bug #1786 ] Spanish localtax2 calculation errors with corrective invoices

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Fix: [ bug #1752 ] Date filter of margins module, filters since 12H instead of 0
 Fix: [ bug #1757 ] Sorting breaks product/service statistics
 Fix: [ bug #1797 ] Tulip supplier invoice module takes creation date instead of invoice date
 Fix: [ bug #1792 ] Users are not allowed to see margins module index page when no product view permission is enabled
+Fix: [ bug #1786 ] Spanish localtax2 calculation errors with corrective invoices
 
 ***** ChangeLog for 3.5.6 compared to 3.5.5 *****
 Fix: Avoid missing class error for fetch_thirdparty method #1973

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -9,7 +9,7 @@
  * Copyright (C) 2007      Franky Van Liedekerke <franky.van.liedekerke@telenet.be>
  * Copyright (C) 2010-2013 Juanjo Menent         <jmenent@2byte.es>
  * Copyright (C) 2012-2014 Christophe Battarel   <christophe.battarel@altairis.fr>
- * Copyright (C) 2012      Marcos García         <marcosgdf@gmail.com>
+ * Copyright (C) 2012-2015 Marcos García         <marcosgdf@gmail.com>
  * Copyright (C) 2013      Cedric Gross          <c.gross@kreiz-it.fr>
  * Copyright (C) 2013      Florian Henry		  	<florian.henry@open-concept.pro>
  *
@@ -2095,12 +2095,12 @@ class Facture extends CommonInvoice
 			$this->line->info_bits=$info_bits;
 			$this->line->fk_remise_except=$fk_remise_except;
 			$this->line->total_ht=       (($this->type==2||$qty<0)?-abs($total_ht):$total_ht);  // For credit note and if qty is negative, total is negative
-			$this->line->total_tva=      (($this->type==2||$qty<0)?-abs($total_tva):$total_tva);
-			$this->line->total_localtax1=(($this->type==2||$qty<0)?-abs($total_localtax1):$total_localtax1);
-			$this->line->total_localtax2=(($this->type==2||$qty<0)?-abs($total_localtax2):$total_localtax2);
+			$this->line->total_tva=      $total_tva;
+			$this->line->total_localtax1=$total_localtax1;
+			$this->line->total_localtax2=$total_localtax2;
 			$this->line->localtax1_type = $localtaxes_type[0];
 			$this->line->localtax2_type = $localtaxes_type[2];
-			$this->line->total_ttc=      (($this->type==2||$qty<0)?-abs($total_ttc):$total_ttc);
+			$this->line->total_ttc=      $total_ttc;
 			$this->line->special_code=$special_code;
 			$this->line->fk_parent_line=$fk_parent_line;
 			$this->line->origin=$origin;
@@ -2253,10 +2253,10 @@ class Facture extends CommonInvoice
 			$this->line->date_start			= $date_start;
 			$this->line->date_end			= $date_end;
 			$this->line->total_ht			= (($this->type==2||$qty<0)?-abs($total_ht):$total_ht);  // For credit note and if qty is negative, total is negative
-			$this->line->total_tva			= (($this->type==2||$qty<0)?-abs($total_tva):$total_tva);
-			$this->line->total_localtax1	= (($this->type==2||$qty<0)?-abs($total_localtax1):$total_localtax1);
-			$this->line->total_localtax2	= (($this->type==2||$qty<0)?-abs($total_localtax2):$total_localtax2);
-			$this->line->total_ttc			= (($this->type==2||$qty<0)?-abs($total_ttc):$total_ttc);
+			$this->line->total_tva			= $total_tva;
+			$this->line->total_localtax1	= $total_localtax1;
+			$this->line->total_localtax2	= $total_localtax2;
+			$this->line->total_ttc			= $total_ttc;
 			$this->line->info_bits			= $info_bits;
 			$this->line->special_code		= $special_code;
 			$this->line->product_type		= $type;


### PR DESCRIPTION
_:warning:  Build failure has nothing to do with my PR._

Because this is an important change I'm going to explain why did I do it:

Given a normal invoice:

| U.P. | VAT Rate | Localtax1 Rate | Localtax2 Rate | Total HT | Total VAT | Total Localtax1 | Total Localtax2 | Total TTC |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 3 | 21 % | 0 | 0 | 3 | 3 \* 0,21 = 0,63 | 0 | 0 | 3+0,21 = 3,63 |

Given a corrective invoice:

| U.P. | VAT Rate | Localtax1 Rate | Localtax2 Rate | Total HT | Total VAT | Total Localtax1 | Total Localtax2 | Total TTC |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| -3 | 21 % | 0 | 0 | 3 | -3 \* 0,21 = -0,63 | 0 | 0 | -3+-0,21 = -3,63 |

We don't need to alter total_vat, total_localtax, total_localtax2 or total_ttc because the calculations are correct.

`-abs(-3,63) = -3,63` => There's no need to do abs as the calculations are actually negative because of the negative P.U.

This alterations were forcing localtax2 to be always negative and that is not correct, as it depends on negative or positive P.U.

For example, in Spain we have a Localtax2 with a -21 % rate.

Before the changes:

| U.P. | VAT Rate | Localtax1 Rate | Localtax2 Rate | Total HT | Total VAT | Total Localtax1 | Total Localtax2 | Total TTC |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| -3 | 21 % | 0 | -21 % | 3 | -3 \* 0,21 = -0,63 | 0 | -3 \* -0,21 = 0,63 But -0,63 is shown | -3+0,63-0,63 = -3 <-- See this is incorrect as Dolibarr is showing total_localtax2 as -0,63 |

After my changes:

| U.P. | VAT Rate | Localtax1 Rate | Localtax2 Rate | Total HT | Total VAT | Total Localtax1 | Total Localtax2 | Total TTC |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| -3 | 21 % | 0 | -21 % | 3 | -3 \* 0,21 = -0,63 | 0 | -3 \* -0,21 = 0,63 | -3+-0,63+0,63 = -3 |
