### PR TITLE
FIXED Removed deprecated forcing SSLv3 for CURL

### DIFF
--- a/htdocs/core/lib/geturl.lib.php
+++ b/htdocs/core/lib/geturl.lib.php
@@ -52,7 +52,6 @@ function getURLContent($url,$postorget='GET',$param='',$followlocation=1,$addhea
      exit;*/
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_VERBOSE, 1);
-    curl_setopt($ch, CURLOPT_SSLVERSION, 3); // Force SSLv3
 	curl_setopt($ch, CURLOPT_USERAGENT, 'Dolibarr geturl function');
 
 	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, ($followlocation?true:false));


### PR DESCRIPTION
Since the Poodle vulnerability, SSLv3 has been supersedded by TLS.
Many services do not offer SSLv3 anymore.
CURL has also been patched in PHP so it now auto-negociates the most appropriate protocol.
This prevented most API calls from working.
