### PR TITLE
Fix: [ bug #1849 ] Broken flag image when a contact does not have a country set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@ English Dolibarr ChangeLog
 - Fix: [ bug #1812 ] SQL Error message while sending emailing with PostgreSQL datatabase
 - Fix: [ bug #1819 ] SQL error when searching for an invoice payment
 - Fix: [ bug #1827 ] Tax reports gives incorrect amounts when using external modules that create lines with special codes
+- Fix: [ bug #1849 ] Broken flag image when a contact does not have a country set
 
 ***** ChangeLog for 3.6.2 compared to 3.6.1 *****
 - Fix: fix ErrorBadValueForParamNotAString error message in price customer multiprice.

--- a/htdocs/contact/fiche.php
+++ b/htdocs/contact/fiche.php
@@ -914,9 +914,14 @@ else
 
         // Country
         print '<tr><td>'.$langs->trans("Country").'</td><td colspan="3">';
-        $img=picto_from_langcode($object->country_code);
-        if ($img) print $img.' ';
-        print $object->country;
+	    if ($object->country_code) {
+		    $img = picto_from_langcode($object->country_code);
+		    if ($img) {
+			    print $img.' ';
+		    }
+
+            print $object->country;
+	    }
         print '</td></tr>';
 
         // State


### PR DESCRIPTION
Fix: [ bug #1849 ] Broken flag image when a contact does not have a country set
