### PR TITLE
Fix Duplicate Id & Anchor link for quick access.

### DIFF
--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -52,7 +52,7 @@ if (empty($usemargins)) $usemargins=0;
 	<?php if (! empty($conf->global->MAIN_VIEW_LINE_NUMBER)) { ?>
 	<td align="center"><?php $coldisplay++; ?><?php echo ($i+1); ?></td>
 	<?php } ?>
-	<td><?php $coldisplay++; ?><div id="row-<?php echo $line->id; ?>"></div>
+	<td><?php $coldisplay++; ?><div id="line_<?php echo $line->id; ?>"></div>
 	<?php if (($line->info_bits & 2) == 2) { ?>
 		<a href="<?php echo DOL_URL_ROOT.'/comm/remx.php?id='.$this->socid; ?>">
 		<?php
@@ -183,7 +183,7 @@ if (empty($usemargins)) $usemargins=0;
 	<td align="center"><?php $coldisplay++; ?>
 		<?php if (($line->info_bits & 2) == 2) { ?>
 		<?php } else { ?>
-		<a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=editline&amp;lineid='.$line->id.'#'.$line->id; ?>">
+		<a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=editline&amp;lineid='.$line->id.'#line_'.$line->id; ?>">
 		<?php echo img_edit(); ?>
 		</a>
 		<?php } ?>


### PR DESCRIPTION
As per my other modification, i add my quick fix to this branch.

New small bug on this branch : Duplicate id between line 51 & L55.

L.55 : I change id by line_ as it is linked in /htdocs/core/tpl/objectline_edit.tpl.php. 
// That fix a a bug from old time and solve the duplicate id thing.

L.186 : I change the link to match with div id from /htdocs/core/tpl/objectline_edit.tpl.php

Best regards,
