### PR TITLE
[ bug #1856 ] ODT Templates - Templating keys are not always recognized

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@ English Dolibarr ChangeLog
 - Fix: [ bug #1825 ] External agenda: hide/show checkbox doesn't work
 - Fix: [ bug #1790 ] Email form behaves in an unexpected way when pressing Enter key
 - Fix: Bad SEPA xml file creation
+- Fix: [ bug #1856 ] ODT Templates - Templating keys are not always recognized
 
 ***** ChangeLog for 3.6.2 compared to 3.6.1 *****
 - Fix: fix ErrorBadValueForParamNotAString error message in price customer multiprice.

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -297,9 +297,9 @@ class doc_generic_order_odt extends ModelePDFCommandes
 				}
 
 				// Open and load template
-				require_once ODTPHP_PATH.'odf.php';
+				require_once DOL_DOCUMENT_ROOT.'/core/odtphp/DolibarrOdf.php';
 				try {
-					$odfHandler = new odf(
+					$odfHandler = new DolibarrOdf(
 						$srctemplatepath,
 						array(
 						'PATH_TO_TMP'	  => $conf->commande->dir_temp,

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -297,9 +297,9 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 				}
 
 				// Open and load template
-				require_once ODTPHP_PATH.'odf.php';
+				require_once DOL_DOCUMENT_ROOT.'/core/odtphp/DolibarrOdf.php';
 				try {
-					$odfHandler = new odf(
+					$odfHandler = new DolibarrOdf(
 						$srctemplatepath,
 						array(
 						'PATH_TO_TMP'	  => $conf->expedition->dir_temp,

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -305,9 +305,9 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				}
 
 				// Open and load template
-				require_once ODTPHP_PATH.'odf.php';
+				require_once DOL_DOCUMENT_ROOT.'/core/odtphp/DolibarrOdf.php';
 				try {
-					$odfHandler = new odf(
+					$odfHandler = new DolibarrOdf(
 						$srctemplatepath,
 						array(
 						'PATH_TO_TMP'	  => $conf->facture->dir_temp,

--- a/htdocs/core/modules/project/pdf/doc_generic_project_odt.modules.php
+++ b/htdocs/core/modules/project/pdf/doc_generic_project_odt.modules.php
@@ -458,9 +458,9 @@ class doc_generic_project_odt extends ModelePDFProjects
 				complete_substitutions_array($substitutionarray, $langs, $object);
 
 				// Open and load template
-				require_once ODTPHP_PATH.'odf.php';
+				require_once DOL_DOCUMENT_ROOT.'/core/odtphp/DolibarrOdf.php';
 				try {
-					$odfHandler = new odf(
+					$odfHandler = new DolibarrOdf(
 						$srctemplatepath,
 						array(
 						'PATH_TO_TMP'	  => $conf->projet->dir_temp,

--- a/htdocs/core/modules/project/task/pdf/doc_generic_task_odt.modules.php
+++ b/htdocs/core/modules/project/task/pdf/doc_generic_task_odt.modules.php
@@ -444,9 +444,9 @@ class doc_generic_task_odt extends ModelePDFTask
 				complete_substitutions_array($substitutionarray, $langs, $object);
 
 				// Open and load template
-				require_once ODTPHP_PATH.'odf.php';
+				require_once DOL_DOCUMENT_ROOT.'/core/odtphp/DolibarrOdf.php';
 				try {
-					$odfHandler = new odf(
+					$odfHandler = new DolibarrOdf(
 						$srctemplatepath,
 						array(
 						'PATH_TO_TMP'	  => $conf->projet->dir_temp,

--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -331,9 +331,9 @@ class doc_generic_proposal_odt extends ModelePDFPropales
 				}
 
 				// Open and load template
-				require_once ODTPHP_PATH.'odf.php';
+				require_once DOL_DOCUMENT_ROOT.'/core/odtphp/DolibarrOdf.php';
 				try {
-					$odfHandler = new odf(
+					$odfHandler = new DolibarrOdf(
 						$srctemplatepath,
 						array(
 						'PATH_TO_TMP'	  => $conf->propal->dir_temp,

--- a/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
+++ b/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
@@ -229,9 +229,9 @@ class doc_generic_odt extends ModeleThirdPartyDoc
 				dol_mkdir($conf->societe->multidir_temp[$object->entity]);
 
 				// Open and load template
-				require_once ODTPHP_PATH.'odf.php';
+				require_once DOL_DOCUMENT_ROOT.'/core/odtphp/DolibarrOdf.php';
 				try {
-					$odfHandler = new odf(
+					$odfHandler = new DolibarrOdf(
 					    $srctemplatepath,
 					    array(
 	    					'PATH_TO_TMP'	  => $conf->societe->multidir_temp[$object->entity],

--- a/htdocs/core/odtphp/DolibarrOdf.php
+++ b/htdocs/core/odtphp/DolibarrOdf.php
@@ -1,0 +1,140 @@
+<?php
+
+/* Copyright (C) 2015	Marcos García   <marcosgdf@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * or see http://www.gnu.org/
+ */
+
+/**
+ * Templating class for odt file
+ * You need PHP 5.2 at least
+ * You need Zip Extension or PclZip library
+ * Encoding : ISO-8859-1
+ *
+ * @copyright  GPL License 2008 - Julien Pauli - Cyril PIERRE de GEYER - Anaska (http://www.anaska.com)
+ * @copyright  GPL License 2010 - Laurent Destailleur - eldy@users.sourceforge.net
+ * @copyright  GPL License 2010 -  Vikas Mahajan - http://vikasmahajan.wordpress.com
+ * @copyright  GPL License 2012 - Stephen Larroque - lrq3000@gmail.com
+ * @license    http://www.gnu.org/copyleft/gpl.html  GPL License
+ * @version 1.4.6 (last update 2013-04-07)
+ */
+
+require_once ODTPHP_PATH.'odf.php';
+require_once 'DolibarrSegment.php';
+
+class DolibarrOdf extends Odf {
+
+	/**
+	 * Declare a segment in order to use it in a loop
+	 *
+	 * @param string $segment
+	 * @throws OdfException
+	 * @return Segment
+	 */
+	public function setSegment($segment)
+	{
+		if (array_key_exists($segment, $this->segments)) {
+			return $this->segments[$segment];
+		}
+		// $reg = "#\[!--\sBEGIN\s$segment\s--\]<\/text:p>(.*)<text:p\s.*>\[!--\sEND\s$segment\s--\]#sm";
+		$reg = "#\[!--\sBEGIN\s$segment\s--\](.*)\[!--\sEND\s$segment\s--\]#sm";
+		if (preg_match($reg, html_entity_decode($this->contentXml), $m) == 0) {
+			throw new OdfException("'$segment' segment not found in the document");
+		}
+		$this->segments[$segment] = new DolibarrSegment($segment, $m[1], $this);
+		return $this->segments[$segment];
+	}
+
+	/**
+	 * Assing a template variable
+	 *
+	 * @param string $key name of the variable within the template
+	 * @param string $value replacement value
+	 * @param bool $encode if true, special XML characters are encoded
+	 * @throws OdfException
+	 * @return odf
+	 */
+	public function setVars($key, $value, $encode = true, $charset = 'ISO-8859')
+	{
+		$regex_search = '/'.$this->getConfig('DELIMITER_LEFT').'(<\/text:(.*)>)?'.preg_quote($key, '/').'(<text:(.*)>)?'.$this->getConfig('DELIMITER_RIGHT').'/';
+
+		if (!preg_match($regex_search, $this->contentXml) && !preg_match($regex_search, $this->stylesXml)) {
+			throw new OdfException("var $key not found in the document");
+		}
+
+		$value=$this->htmlToUTFAndPreOdf($value);
+
+		$value = $encode ? htmlspecialchars($value) : $value;
+		$value = ($charset == 'ISO-8859') ? utf8_encode($value) : $value;
+
+		$value=$this->preOdfToOdf($value);
+
+		$this->vars[$key] = $value;
+		return $this;
+	}
+
+	/**
+	 * Merge template variables
+	 * Called automatically for a save
+	 *
+	 * @param  string	$type		'content' or 'styles'
+	 * @return void
+	 */
+	protected function _parse($type='content')
+	{
+		// Conditionals substitution
+		// Note: must be done before content substitution, else the variable will be replaced by its value and the conditional won't work anymore
+		foreach($this->vars as $key => $value)
+		{
+			// If value is true (not 0 nor false nor null nor empty string)
+			if($value)
+			{
+				// Remove the IF tag
+				$this->contentXml = str_replace('[!-- IF '.$key.' --]', '', $this->contentXml);
+				// Remove everything between the ELSE tag (if it exists) and the ENDIF tag
+				$reg = '@(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+				$this->contentXml = preg_replace($reg, '', $this->contentXml);
+			}
+			// Else the value is false, then two cases: no ELSE and we're done, or there is at least one place where there is an ELSE clause, then we replace it
+			else
+			{
+				// Find all conditional blocks for this variable: from IF to ELSE and to ENDIF
+				$reg = '@\[!--\sIF\s' . $key . '\s--\](.*)(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+				preg_match_all($reg, $this->contentXml, $matches, PREG_SET_ORDER);
+				foreach($matches as $match) { // For each match, if there is an ELSE clause, we replace the whole block by the value in the ELSE clause
+					if (!empty($match[3])) $this->contentXml = str_replace($match[0], $match[3], $this->contentXml);
+				}
+				// Cleanup the other conditional blocks (all the others where there were no ELSE clause, we can just remove them altogether)
+				$this->contentXml = preg_replace($reg, '', $this->contentXml);
+			}
+		}
+
+		foreach ($this->vars as $key => $val) {
+			$regex_search = '/'.$this->getConfig('DELIMITER_LEFT').'(<\/text:(.*)>)?'.preg_quote($key).'(<text:(.*)>)?'.$this->getConfig('DELIMITER_RIGHT').'/';
+			$regex_substitution = '${1}'.$val.'${3}';
+
+			if ($type == 'content') {
+				// Content (variable) substitution
+				$this->contentXml = preg_replace($regex_search, $regex_substitution, $this->contentXml);
+			} elseif ($type == 'styles') {
+				// Styles substitution
+				$this->stylesXml = preg_replace($regex_search, $regex_substitution, $this->stylesXml);
+			}
+
+		}
+
+	}
+
+}

--- a/htdocs/core/odtphp/DolibarrSegment.php
+++ b/htdocs/core/odtphp/DolibarrSegment.php
@@ -1,0 +1,109 @@
+<?php
+
+/* Copyright (C) 2015	Marcos García   <marcosgdf@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * or see http://www.gnu.org/
+ */
+
+/**
+ * Class for handling templating segments with odt files
+ * You need PHP 5.2 at least
+ * You need Zip Extension or PclZip library
+ * Encoding : ISO-8859-1
+ *
+ * @copyright  GPL License 2008 - Julien Pauli - Cyril PIERRE de GEYER - Anaska (http://www.anaska.com)
+ * @copyright  GPL License 2012 - Stephen Larroque - lrq3000@gmail.com
+ * @license    http://www.gnu.org/copyleft/gpl.html  GPL License
+ * @version 1.4.5 (last update 2013-04-07)
+ */
+
+class DolibarrSegment extends Segment
+{
+	/**
+	 * @var DolibarrOdf
+	 */
+	protected $odf;
+
+	/**
+	 * @var ZipInterface
+	 */
+	protected $file;
+
+	/**
+	 * Replace variables of the template in the XML code
+	 * All the children are also called
+	 *
+	 * @return string
+	 */
+	public function merge()
+	{
+		$this->xmlParsed = $this->xml;
+
+		foreach ($this->vars as $key => $val) {
+			$regex_search = '/'.$this->odf->getConfig('DELIMITER_LEFT').'(<\/text:(.*)>)?'.preg_quote($key).'(<text:(.*)>)?'.$this->odf->getConfig('DELIMITER_RIGHT').'/';
+			$regex_substitution = '${1}'.$val.'${3}';
+
+			$this->xmlParsed = preg_replace($regex_search, $regex_substitution, $this->xmlParsed);
+		}
+
+		if ($this->hasChildren()) {
+			foreach ($this->children as $child) {
+				$this->xmlParsed = str_replace($child->xml, ($child->xmlParsed=="")?$child->merge():$child->xmlParsed, $this->xmlParsed);
+				$child->xmlParsed = '';
+			}
+		}
+		$reg = "/\[!--\sBEGIN\s$this->name\s--\](.*)\[!--\sEND\s$this->name\s--\]/sm";
+		$this->xmlParsed = preg_replace($reg, '$1', $this->xmlParsed);
+		$this->file->open($this->odf->getTmpfile());
+		foreach ($this->images as $imageKey => $imageValue) {
+			if ($this->file->getFromName('Pictures/' . $imageValue) === false) {
+				// Add the image inside the ODT document
+				$this->file->addFile($imageKey, 'Pictures/' . $imageValue);
+				// Add the image to the Manifest (which maintains a list of images, necessary to avoid "Corrupt ODT file. Repair?" when opening the file with LibreOffice)
+				$this->odf->addImageToManifest($imageValue);
+			}
+		}
+		$this->file->close();
+		return $this->xmlParsed;
+	}
+
+	/**
+	 * Assign a template variable to replace
+	 *
+	 * @param string $key
+	 * @param string $value
+	 * @throws OdfException
+	 * @return Segment
+	 */
+	public function setVars($key, $value, $encode = true, $charset = 'ISO-8859')
+	{
+		$regex_search = '/'.$this->odf->getConfig('DELIMITER_LEFT').'(<\/text:(.*)>)?'.preg_quote($key, '/').'(<text:(.*)>)?'.$this->odf->getConfig('DELIMITER_RIGHT').'/';
+
+		if (!preg_match($regex_search, $this->xml)) {
+			throw new OdfException("var $key not found in the document");
+		}
+
+		$value=$this->odf->htmlToUTFAndPreOdf($value);
+
+		$value = $encode ? htmlspecialchars($value) : $value;
+		$value = ($charset == 'ISO-8859') ? utf8_encode($value) : $value;
+
+		$value=$this->odf->preOdfToOdf($value);
+
+		$this->vars[$key] = $value;
+		return $this;
+	}
+
+}

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -12,6 +12,7 @@ class OdfException extends Exception
  * @copyright  GPL License 2010 - Laurent Destailleur - eldy@users.sourceforge.net
  * @copyright  GPL License 2010 -  Vikas Mahajan - http://vikasmahajan.wordpress.com
  * @copyright  GPL License 2012 - Stephen Larroque - lrq3000@gmail.com
+ * @copyright  GPL License 2015 - Marcos García - marcosgdf@gmail.com
  * @license    http://www.gnu.org/copyleft/gpl.html  GPL License
  * @version 1.4.6 (last update 2013-04-07)
  */
@@ -113,14 +114,8 @@ class Odf
 	public function setVars($key, $value, $encode = true, $charset = 'ISO-8859')
 	{
 		$tag = $this->config['DELIMITER_LEFT'] . $key . $this->config['DELIMITER_RIGHT'];
-		// TODO Warning string may be:
-		// <text:span text:style-name="T13">{</text:span><text:span text:style-name="T12">aaa</text:span><text:span text:style-name="T13">}</text:span>
-		// instead of {aaa} so we should enhance this function.
-		//print $key.'-'.$value.'-'.strpos($this->contentXml, $this->config['DELIMITER_LEFT'] . $key . $this->config['DELIMITER_RIGHT']).'<br>';
 		if (strpos($this->contentXml, $tag) === false && strpos($this->stylesXml , $tag) === false) {
-			//if (strpos($this->contentXml, '">'. $key . '</text;span>') === false) {
 			throw new OdfException("var $key not found in the document");
-			//}
 		}
 
 		$value=$this->htmlToUTFAndPreOdf($value);
@@ -271,7 +266,7 @@ IMG;
 	 * @param  string	$type		'content' or 'styles'
 	 * @return void
 	 */
-	private function _parse($type='content')
+	protected function _parse($type='content')
 	{
 		// Conditionals substitution
 		// Note: must be done before content substitution, else the variable will be replaced by its value and the conditional won't work anymore


### PR DESCRIPTION
Moved changes to own classes DolibarrOdf and DolibarrSegment to not alter the external library.

Now we can handle detection of templating keys with mixed styles
