### PR TITLE
FIX: jdate returning -62169955200 on x64 machine

### DIFF
--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -274,6 +274,8 @@ abstract class DoliDB implements Database
 	 */
 	function jdate($string, $gm=false)
 	{
+		if($string==0 || $string=="0000-00-00 00:00:00")
+			return NULL;
 		$string=preg_replace('/([^0-9])/i','',$string);
 		$tmp=$string.'000000';
 		$date=dol_mktime(substr($tmp,8,2),substr($tmp,10,2),substr($tmp,12,2),substr($tmp,4,2),substr($tmp,6,2),substr($tmp,0,4),$gm);


### PR DESCRIPTION
on x64 machine jdate return -62169955200 instead of 0 when the input is 00-00-00 00:00:00 or equivalent
same issue for mktime https://bugs.php.net/bug.php?id=53662
