### PR TITLE
Mailing for supplier orders

### DIFF
--- a/htdocs/comm/mailing/card.php
+++ b/htdocs/comm/mailing/card.php
@@ -679,7 +679,7 @@ if ($action == 'create')
 		print '<td>';
 
 		// Mail line
-		$doleditor = new DolEditor('line', $_POST['line'], '', 320, 'dolibarr_mailings', '', true, true, $conf->global->FCKEDITOR_ENABLE_MAILING, 3, 70);
+		$doleditor = new DolEditor('line', $_POST['line'], '', 320, 'dolibarr_mailings', '', true, true, $conf->global->FCKEDITOR_ENABLE_MAILING, 20, 70);
 		$doleditor->Create();
 		print '</td></tr>';
 	}
@@ -1003,7 +1003,7 @@ else
             //Mail line substitutions
             $line_substitutions = $object->getSubstitutionsLang(1);
             if (!empty($line_substitutions)) {
-                print '<tr><td width="25%" valign="top">' . $langs->trans("MailMessage") . '<br>';
+                print '<tr><td width="25%" valign="top">' . $langs->trans("MailLine") . '<br>';
                 print '<br><i>' . $langs->trans("CommonSubstitutions") . ':<br>';
                 foreach ($line_substitutions as $key => $val) {
                     print $key . ' = ' . $langs->trans($val) . '<br>';
@@ -1150,7 +1150,7 @@ else
 				print '<td>';
 
 				// Mail line
-				$doleditor = new DolEditor('line', $object->line, '', 320, 'dolibarr_mailings', '', true, true, $conf->global->FCKEDITOR_ENABLE_MAILING, 3, 120);
+				$doleditor = new DolEditor('line', $object->line, '', 320, 'dolibarr_mailings', '', true, true, $conf->global->FCKEDITOR_ENABLE_MAILING, 20, 120);
 				$doleditor->Create();
 				print '</td></tr>';
 			}

--- a/htdocs/comm/mailing/cibles.php
+++ b/htdocs/comm/mailing/cibles.php
@@ -185,7 +185,7 @@ if ($object->fetch($id) >= 0)
 	print $form->showrefnav($object,'id', $linkback);
 	print '</td></tr>';
 
-	print '<tr><td width="25%">'.$langs->trans("MailTitle").'</td><td colspan="3">'.$object->titre.'</td></tr>';
+	print '<tr><td width="25%">'.$langs->trans("MailTitle").'</td><td colspan="3">'.$object->description.'</td></tr>';
 
 	print '<tr><td width="25%">'.$langs->trans("MailFrom").'</td><td colspan="3">'.dol_print_email($object->email_from,0,0,0,0,1).'</td></tr>';
 

--- a/htdocs/comm/mailing/class/mailing.class.php
+++ b/htdocs/comm/mailing/class/mailing.class.php
@@ -833,7 +833,7 @@ class Mailing extends CommonObject
      */
     function listMailings($mail_type = null)
     {
-        $sql = "SELECT rowid, titre, mail_type";
+        $sql = "SELECT rowid, statut, titre, mail_type";
         $sql.= " FROM ".MAIN_DB_PREFIX."mailing";
         if ($mail_type != null) {
             $sql.= " WHERE mail_type = ".$mail_type;
@@ -849,7 +849,9 @@ class Mailing extends CommonObject
             {
                 $mail = array();
                 $mail["id"]             = $record["rowid"];
+                $mail["statut"]         = $record["statut"];
                 $mail["description"]    = $record["titre"];
+                $mail["mail_type"]      = $record["mail_type"];
                 $retarray[]=$mail;
             }
 

--- a/htdocs/comm/mailing/class/mailing.class.php
+++ b/htdocs/comm/mailing/class/mailing.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2005      Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (C) 2005-2012 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@capnetworks.com>
+ * Copyright (C) 2015      Ion Agorria          <ion@agorria.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,543 +32,836 @@ require_once DOL_DOCUMENT_ROOT .'/core/class/commonobject.class.php';
  */
 class Mailing extends CommonObject
 {
-	public $element='mailing';
-	public $table_element='mailing';
+    public $element='mailing';
+    public $table_element='mailing';
 
-	var $id;
-	var $statut;
-	var $titre;
-	var $sujet;
-	var $body;
-	var $nbemail;
-	var $bgcolor;
-	var $bgimage;
+    var $id;
+    var $statut;
+    var $titre; //TODO Deprecated
+    var $description;
+    var $sujet; //TODO Deprecated
+    var $subject;
+    var $body;
+    var $line;
+    var $nbemail;
+    var $bgcolor;
+    var $bgimage;
+    var $mail_type;
 
-	var $email_from;
-	var $email_replyto;
-	var $email_errorsto;
+    var $email_from;
+    var $email_replyto;
+    var $email_errorsto;
 
-	var $joined_file1;
-	var $joined_file2;
-	var $joined_file3;
-	var $joined_file4;
+    var $joined_file1;
+    var $joined_file2;
+    var $joined_file3;
+    var $joined_file4;
 
-	var $user_creat;
-	var $user_valid;
+    var $user_creat;
+    var $user_valid;
 
-	var $date_creat;
-	var $date_valid;
-	
-	var $extraparams=array();
+    var $date_creat;
+    var $date_valid;
 
-	public $statut_dest=array();
-	public $statuts=array();
+    var $extraparams=array();
 
+    // List of language codes for status
+    public $statuts=array(
+        0 => 'MailingStatusDraft',
+        1 => 'MailingStatusValidated',
+        2 => 'MailingStatusSentPartialy',
+        3 => 'MailingStatusSentCompletely',
+    );
+    public static $statut_dest=array(
+        -1 => 'MailingStatusError',
+        1  => 'MailingStatusSent',
+        2  => 'MailingStatusRead',
+        3  => 'MailingStatusNotContact',
+    );
 
-	/**
+    /**
      *  Constructor
      *
      *  @param      DoliDb		$db      Database handler
-	 */
-	function __construct($db)
-	{
-		$this->db = $db;
+     */
+    function __construct($db)
+    {
+        $this->db = $db;
+    }
 
-		// List of language codes for status
-		$this->statuts[0] = 'MailingStatusDraft';
-		$this->statuts[1] = 'MailingStatusValidated';
-		$this->statuts[2] = 'MailingStatusSentPartialy';
-		$this->statuts[3] = 'MailingStatusSentCompletely';
-		
-		$this->statut_dest[-1] = 'MailingStatusError';
-		$this->statut_dest[1] = 'MailingStatusSent';
-		$this->statut_dest[2] = 'MailingStatusRead';
-		$this->statut_dest[3] = 'MailingStatusNotContact';
-				
-	}
+    /**
+     *  Create an EMailing
+     *
+     *  @param	User	$user 		Object of user making creation
+     *  @return int	   				-1 if error, Id of created object if OK
+     */
+    function create($user)
+    {
+        global $conf, $langs;
 
-	/**
-	 *  Create an EMailing
-	 *
-	 *  @param	User	$user 		Object of user making creation
-	 *  @return int	   				-1 if error, Id of created object if OK
-	 */
-	function create($user)
-	{
-		global $conf, $langs;
+        $this->db->begin();
 
-		$this->db->begin();
+        $this->description=trim($this->description);
+        $this->email_from=trim($this->email_from);
 
-		$this->titre=trim($this->titre);
-		$this->email_from=trim($this->email_from);
+        if (! $this->email_from)
+        {
+            $this->error = $langs->trans("ErrorMailFromRequired");
+            $this->errors[] = $langs->trans("ErrorMailFromRequired");
+            return -1;
+        }
 
-		if (! $this->email_from)
-		{
-			$this->error = $langs->trans("ErrorMailFromRequired");
-			return -1;
-		}
+        $now=dol_now();
 
-		$now=dol_now();
+        $sql = "INSERT INTO ".MAIN_DB_PREFIX."mailing";
+        $sql .= " (date_creat, fk_user_creat, entity, mail_type)";
+        $sql .= " VALUES ('".$this->db->idate($now)."', ".$user->id.", ".$conf->entity.", ".$this->mail_type.")";
 
-		$sql = "INSERT INTO ".MAIN_DB_PREFIX."mailing";
-		$sql .= " (date_creat, fk_user_creat, entity)";
-		$sql .= " VALUES ('".$this->db->idate($now)."', ".$user->id.", ".$conf->entity.")";
+        if (! $this->description)
+        {
+            $this->description = $langs->trans("NoTitle");
+        }
 
-		if (! $this->titre)
-		{
-			$this->titre = $langs->trans("NoTitle");
-		}
+        dol_syslog("Mailing::Create", LOG_DEBUG);
+        $result=$this->db->query($sql);
+        if ($result)
+        {
+            $this->id = $this->db->last_insert_id(MAIN_DB_PREFIX."mailing");
 
-		dol_syslog("Mailing::Create", LOG_DEBUG);
-		$result=$this->db->query($sql);
-		if ($result)
-		{
-			$this->id = $this->db->last_insert_id(MAIN_DB_PREFIX."mailing");
+            if ($this->update($user) > 0)
+            {
+                $this->db->commit();
+            }
+            else
+            {
+                $this->error=$this->db->lasterror();
+                $this->errors[]=$this->db->lasterror();
+                $this->db->rollback();
+                return -1;
+            }
 
-			if ($this->update($user) > 0)
-			{
-				$this->db->commit();
-			}
-			else
-			{
-				$this->error=$this->db->lasterror();
-				$this->db->rollback();
-				return -1;
-			}
+            return $this->id;
+        }
+        else
+        {
+            $this->error=$this->db->lasterror();
+            $this->errors[]=$this->db->lasterror();
+            $this->db->rollback();
+            return -1;
+        }
+    }
 
-			return $this->id;
-		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			$this->db->rollback();
-			return -1;
-		}
-	}
+    /**
+     *  Update emailing record
+     *
+     *  @param	User	$user 		Object of user making change
+     *  @return int				    < 0 if KO, > 0 if OK
+     */
+    function update($user)
+    {
+        $sql = "UPDATE ".MAIN_DB_PREFIX."mailing ";
+        $sql .= " SET titre = '".$this->db->escape($this->description)."'";
+        $sql .= ", sujet = '".$this->db->escape($this->subject)."'";
+        $sql .= ", body = '".$this->db->escape($this->body)."'";
+        $sql .= ", line = '".$this->db->escape($this->line)."'";
+        $sql .= ", email_from = '".$this->email_from."'";
+        $sql .= ", email_replyto = '".$this->email_replyto."'";
+        $sql .= ", email_errorsto = '".$this->email_errorsto."'";
+        $sql .= ", bgcolor = '".($this->bgcolor?$this->bgcolor:null)."'";
+        $sql .= ", bgimage = '".($this->bgimage?$this->bgimage:null)."'";
+        $sql .= " WHERE rowid = ".$this->id;
 
-	/**
-	 *  Update emailing record
-	 *
-	 *  @param	User	$user 		Object of user making change
-	 *  @return int				    < 0 if KO, > 0 if OK
-	 */
-	function update($user)
-	{
-		$sql = "UPDATE ".MAIN_DB_PREFIX."mailing ";
-		$sql .= " SET titre = '".$this->db->escape($this->titre)."'";
-		$sql .= ", sujet = '".$this->db->escape($this->sujet)."'";
-		$sql .= ", body = '".$this->db->escape($this->body)."'";
-		$sql .= ", email_from = '".$this->email_from."'";
-		$sql .= ", email_replyto = '".$this->email_replyto."'";
-		$sql .= ", email_errorsto = '".$this->email_errorsto."'";
-		$sql .= ", bgcolor = '".($this->bgcolor?$this->bgcolor:null)."'";
-		$sql .= ", bgimage = '".($this->bgimage?$this->bgimage:null)."'";
-		$sql .= " WHERE rowid = ".$this->id;
+        dol_syslog("Mailing::Update", LOG_DEBUG);
+        $result=$this->db->query($sql);
+        if ($result)
+        {
+            return 1;
+        }
+        else
+        {
+            $this->error=$this->db->lasterror();
+            $this->errors[]=$this->db->lasterror();
+            return -1;
+        }
+    }
 
-		dol_syslog("Mailing::Update", LOG_DEBUG);
-		$result=$this->db->query($sql);
-		if ($result)
-		{
-			return 1;
-		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			return -1;
-		}
-	}
+    /**
+     *	Get object from database
+     *
+     *	@param	int		$rowid      Id of emailing
+     *	@return	int					<0 if KO, >0 if OK
+     */
+    function fetch($rowid)
+    {
+        global $conf;
 
-	/**
-	 *	Get object from database
-	 *
-	 *	@param	int		$rowid      Id of emailing
-	 *	@return	int					<0 if KO, >0 if OK
-	 */
-	function fetch($rowid)
-	{
-		global $conf;
-		
-		$sql = "SELECT m.rowid, m.titre, m.sujet, m.body, m.bgcolor, m.bgimage";
-		$sql.= ", m.email_from, m.email_replyto, m.email_errorsto";
-		$sql.= ", m.statut, m.nbemail";
-		$sql.= ", m.fk_user_creat, m.fk_user_valid";
-		$sql.= ", m.date_creat";
-		$sql.= ", m.date_valid";
-		$sql.= ", m.date_envoi";
-		$sql.= ", m.extraparams";
-		$sql.= " FROM ".MAIN_DB_PREFIX."mailing as m";
-		$sql.= " WHERE m.rowid = ".$rowid;
+        $sql = "SELECT m.rowid, m.titre, m.sujet, m.body, m.line, m.bgcolor, m.bgimage";
+        $sql.= ", m.email_from, m.email_replyto, m.email_errorsto";
+        $sql.= ", m.mail_type, m.statut, m.nbemail";
+        $sql.= ", m.fk_user_creat, m.fk_user_valid";
+        $sql.= ", m.date_creat";
+        $sql.= ", m.date_valid";
+        $sql.= ", m.date_envoi";
+        $sql.= ", m.extraparams";
+        $sql.= " FROM ".MAIN_DB_PREFIX."mailing as m";
+        $sql.= " WHERE m.rowid = ".$rowid;
 
-		dol_syslog(get_class($this)."::fetch", LOG_DEBUG);
-		$result=$this->db->query($sql);
-		if ($result)
-		{
-			if ($this->db->num_rows($result))
-			{
-				$obj = $this->db->fetch_object($result);
+        dol_syslog(get_class($this)."::fetch", LOG_DEBUG);
+        $result=$this->db->query($sql);
+        if ($result)
+        {
+            if ($this->db->num_rows($result))
+            {
+                $obj = $this->db->fetch_object($result);
 
-				$this->id				= $obj->rowid;
-				$this->ref				= $obj->rowid;
-				$this->statut			= $obj->statut;
-				$this->nbemail			= $obj->nbemail;
-				$this->titre			= $obj->titre;
-				
-				$this->sujet			= $obj->sujet;				
-				if (!empty($conf->global->FCKEDITOR_ENABLE_MAILING) && dol_textishtml(dol_html_entity_decode($obj->body, ENT_COMPAT | ENT_HTML401))) {
-					$this->body				= dol_html_entity_decode($obj->body, ENT_COMPAT | ENT_HTML401);
-				}else {
-					$this->body				= $obj->body;
-				}
-				
-				$this->bgcolor			= $obj->bgcolor;
-				$this->bgimage			= $obj->bgimage;
+                $this->id				= $obj->rowid;
+                $this->ref				= $obj->rowid;
+                $this->statut			= $obj->statut;
+                $this->nbemail			= $obj->nbemail;
+                $this->titre			= $obj->titre; //TODO Deprecated
+                $this->description		= $obj->titre;
+                $this->mail_type		= $obj->mail_type;
 
-				$this->email_from		= $obj->email_from;
-				$this->email_replyto	= $obj->email_replyto;
-				$this->email_errorsto	= $obj->email_errorsto;
+                $this->sujet			= $obj->sujet; //TODO Deprecated
+                $this->subject			= $obj->sujet;
+                if (!empty($conf->global->FCKEDITOR_ENABLE_MAILING) && dol_textishtml(dol_html_entity_decode($obj->body, ENT_COMPAT | ENT_HTML401))) {
+                    $this->body				= dol_html_entity_decode($obj->body, ENT_COMPAT | ENT_HTML401);
+                }else {
+                    $this->body				= $obj->body;
+                }
+                if (!empty($conf->global->FCKEDITOR_ENABLE_MAILING) && dol_textishtml(dol_html_entity_decode($obj->line, ENT_COMPAT | ENT_HTML401))) {
+                    $this->line				= dol_html_entity_decode($obj->line, ENT_COMPAT | ENT_HTML401);
+                }else {
+                    $this->line				= $obj->line;
+                }
 
-				$this->user_creat		= $obj->fk_user_creat;
-				$this->user_valid		= $obj->fk_user_valid;
+                $this->bgcolor			= $obj->bgcolor;
+                $this->bgimage			= $obj->bgimage;
 
-				$this->date_creat		= $this->db->jdate($obj->date_creat);
-				$this->date_valid		= $this->db->jdate($obj->date_valid);
-				$this->date_envoi		= $this->db->jdate($obj->date_envoi);
-				
-				$this->extraparams		= (array) json_decode($obj->extraparams, true);
+                $this->email_from		= $obj->email_from;
+                $this->email_replyto	= $obj->email_replyto;
+                $this->email_errorsto	= $obj->email_errorsto;
 
-				return 1;
-			}
-			else
-			{
-				dol_syslog(get_class($this)."::fetch Erreur -1");
-				return -1;
-			}
-		}
-		else
-		{
-			dol_syslog(get_class($this)."::fetch Erreur -2");
-			return -2;
-		}
-	}
+                $this->user_creat		= $obj->fk_user_creat;
+                $this->user_valid		= $obj->fk_user_valid;
 
+                $this->date_creat		= $this->db->jdate($obj->date_creat);
+                $this->date_valid		= $this->db->jdate($obj->date_valid);
+                $this->date_envoi		= $this->db->jdate($obj->date_envoi);
 
-	/**
-	 *	Load an object from its id and create a new one in database
-	 *
-	 *	@param  int		$fromid     	Id of object to clone
-	 *	@param	int		$option1		1=Copy content, 0=Forget content
-	 *	@param	int		$option2		Not used
-	 *	@return	int						New id of clone
-	 */
-	function createFromClone($fromid,$option1,$option2)
-	{
-		global $user,$langs;
+                $this->extraparams		= (array) json_decode($obj->extraparams, true);
 
-		$error=0;
-
-		$object=new Mailing($this->db);
-
-		$this->db->begin();
-
-		// Load source object
-		$object->fetch($fromid);
-		$object->id=0;
-		$object->statut=0;
-
-		// Clear fields
-		$object->titre=$langs->trans("CopyOf").' '.$object->titre.' '.dol_print_date(dol_now());
-
-		// If no option copy content
-		if (empty($option1))
-		{
-			// Clear values
-			$object->nbemail            = 0;
-			$object->sujet              = '';
-			$object->body               = '';
-			$object->bgcolor            = '';
-			$object->bgimage            = '';
-
-			$object->email_from         = '';
-			$object->email_replyto      = '';
-			$object->email_errorsto     = '';
-
-			$object->user_creat         = $user->id;
-			$object->user_valid         = '';
-
-			$object->date_creat         = '';
-			$object->date_valid         = '';
-			$object->date_envoi         = '';
-		}
-
-		// Create clone
-		$result=$object->create($user);
-
-		// Other options
-		if ($result < 0)
-		{
-			$this->error=$object->error;
-			$error++;
-		}
-
-		if (! $error)
-		{
-			//Clone target
-			if (!empty($option2)) {
-				
-				require_once DOL_DOCUMENT_ROOT .'/core/modules/mailings/modules_mailings.php';
-				
-				$mailing_target = new MailingTargets($this->db);
-				
-				$target_array=array();
-				
-				$sql = "SELECT fk_contact, ";
-				$sql.=" lastname,   ";
-				$sql.=" firstname,";
-				$sql.=" email,";
-				$sql.=" other,";
-				$sql.=" source_url,";
-				$sql.=" source_id ,";
-				$sql.=" source_type ";
-				$sql.= " FROM ".MAIN_DB_PREFIX."mailing_cibles ";
-				$sql.= " WHERE fk_mailing = ".$fromid;
-				
-				dol_syslog(get_class($this)."::createFromClone", LOG_DEBUG);
-				$result=$this->db->query($sql);
-				if ($result)
-				{
-					if ($this->db->num_rows($result))
-					{
-						while ($obj = $this->db->fetch_object($result)) {
-						
-							$target_array[]=array('fk_contact'=>$obj->fk_contact,
-							'lastname'=>$obj->lastname,
-							'firstname'=>$obj->firstname,
-							'email'=>$obj->email, 
-							'other'=>$obj->other,
-							'source_url'=>$obj->source_url,
-							'source_id'=>$obj->source_id,
-							'source_type'=>$obj->source_type);
-						}
-						
-					}
-				}
-				else
-				{
-					$this->error=$this->db->lasterror();
-					return -1;
-				}
-				
-				$mailing_target->add_to_target($object->id, $target_array);
-			}
-
-		}
-
-		// End
-		if (! $error)
-		{
-			$this->db->commit();
-			return $object->id;
-		}
-		else
-		{
-			$this->db->rollback();
-			return -1;
-		}
-	}
-
-	/**
-	 *  Validate emailing
-	 *
-	 *  @param	User	$user      	Objet user qui valide
-	 * 	@return	int					<0 if KO, >0 if OK
-	 */
-	function valid($user)
-	{
-		$now=dol_now();
-
-		$sql = "UPDATE ".MAIN_DB_PREFIX."mailing ";
-		$sql .= " SET statut = 1, date_valid = '".$this->db->idate($now)."', fk_user_valid=".$user->id;
-		$sql .= " WHERE rowid = ".$this->id;
-
-		dol_syslog("Mailing::valid", LOG_DEBUG);
-		if ($this->db->query($sql))
-		{
-			return 1;
-		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			return -1;
-		}
-	}
+                return 1;
+            }
+            else
+            {
+                dol_syslog(get_class($this)."::fetch Error -1");
+                return -1;
+            }
+        }
+        else
+        {
+            dol_syslog(get_class($this)."::fetch Error -2");
+            return -2;
+        }
+    }
 
 
-	/**
-	 *  Delete emailing
-	 *
-	 *  @param	int		$rowid      id du mailing a supprimer
-	 *  @return int         		1 en cas de succes
-	 */
-	function delete($rowid)
-	{
-		$sql = "DELETE FROM ".MAIN_DB_PREFIX."mailing";
-		$sql.= " WHERE rowid = ".$rowid;
+    /**
+     *	Load an object from its id and create a new one in database
+     *
+     *	@param  int		$fromid     	Id of object to clone
+     *	@param	int		$option1		1=Copy content, 0=Forget content
+     *	@param	int		$option2		Not used
+     *	@return	int						New id of clone
+     */
+    function createFromClone($fromid,$option1,$option2)
+    {
+        global $user,$langs;
 
-		dol_syslog("Mailing::delete", LOG_DEBUG);
-		$resql=$this->db->query($sql);
-		if ($resql)
-		{
-			return 1;
-		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			return -1;
-		}
-	}
+        $error=0;
+
+        $object=new Mailing($this->db);
+
+        $this->db->begin();
+
+        // Load source object
+        $object->fetch($fromid);
+        $object->id=0;
+        $object->statut=0;
+
+        // Clear fields
+        $object->description=$langs->trans("CopyOf").' '.$object->description.' '.dol_print_date(dol_now());
+
+        // If no option copy content
+        if (empty($option1))
+        {
+            // Clear values
+            $object->nbemail            = 0;
+            $object->subject              = '';
+            $object->body               = '';
+            $object->line               = '';
+            $object->bgcolor            = '';
+            $object->bgimage            = '';
+
+            $object->email_from         = '';
+            $object->email_replyto      = '';
+            $object->email_errorsto     = '';
+
+            $object->user_creat         = $user->id;
+            $object->user_valid         = '';
+
+            $object->date_creat         = '';
+            $object->date_valid         = '';
+            $object->date_envoi         = '';
+        }
+
+        // Create clone
+        $result=$object->create($user);
+
+        // Other options
+        if ($result < 0)
+        {
+            $this->error=$object->error;
+            $error++;
+        }
+
+        if (! $error)
+        {
+            //Clone target
+            if (!empty($option2)) {
+
+                require_once DOL_DOCUMENT_ROOT .'/core/modules/mailings/modules_mailings.php';
+
+                $mailing_target = new MailingTargets($this->db);
+
+                $target_array=array();
+
+                $sql = "SELECT fk_contact, ";
+                $sql.=" lastname,   ";
+                $sql.=" firstname,";
+                $sql.=" email,";
+                $sql.=" other,";
+                $sql.=" source_url,";
+                $sql.=" source_id ,";
+                $sql.=" source_type ";
+                $sql.= " FROM ".MAIN_DB_PREFIX."mailing_cibles ";
+                $sql.= " WHERE fk_mailing = ".$fromid;
+
+                dol_syslog(get_class($this)."::createFromClone", LOG_DEBUG);
+                $result=$this->db->query($sql);
+                if ($result)
+                {
+                    if ($this->db->num_rows($result))
+                    {
+                        while ($obj = $this->db->fetch_object($result)) {
+
+                            $target_array[]=array('fk_contact'=>$obj->fk_contact,
+                            'lastname'=>$obj->lastname,
+                            'firstname'=>$obj->firstname,
+                            'email'=>$obj->email,
+                            'other'=>$obj->other,
+                            'source_url'=>$obj->source_url,
+                            'source_id'=>$obj->source_id,
+                            'source_type'=>$obj->source_type);
+                        }
+
+                    }
+                }
+                else
+                {
+                    $this->error=$this->db->lasterror();
+                    $this->errors[]=$this->db->lasterror();
+                    return -1;
+                }
+
+                $mailing_target->add_to_target($object->id, $target_array);
+            }
+
+        }
+
+        // End
+        if (! $error)
+        {
+            $this->db->commit();
+            return $object->id;
+        }
+        else
+        {
+            $this->db->rollback();
+            return -1;
+        }
+    }
+
+    /**
+     *  Validate emailing
+     *
+     *  @param	User	$user      	Objet user qui valide
+     * 	@return	int					<0 if KO, >0 if OK
+     */
+    function valid($user)
+    {
+        $now=dol_now();
+
+        $sql = "UPDATE ".MAIN_DB_PREFIX."mailing ";
+        $sql .= " SET statut = 1, date_valid = '".$this->db->idate($now)."', fk_user_valid=".$user->id;
+        $sql .= " WHERE rowid = ".$this->id;
+
+        dol_syslog("Mailing::valid", LOG_DEBUG);
+        if ($this->db->query($sql))
+        {
+            return 1;
+        }
+        else
+        {
+            $this->error=$this->db->lasterror();
+            $this->errors[]=$this->db->lasterror();
+            return -1;
+        }
+    }
 
 
-	/**
-	 *  Change status of each recipient
-	 *
-	 *	@param	User	$user      	Objet user qui valide
-	 *  @return int         		<0 if KO, >0 if OK
-	 */
-	function reset_targets_status($user)
-	{
-		$sql = "UPDATE ".MAIN_DB_PREFIX."mailing_cibles";
-		$sql.= " SET statut = 0";
-		$sql.= " WHERE fk_mailing = ".$this->id;
+    /**
+     *  Delete emailing
+     *
+     *  @param	int		$rowid      id du mailing a supprimer
+     *  @return int         		1 en cas de succes
+     */
+    function delete($rowid)
+    {
+        $sql = "DELETE FROM ".MAIN_DB_PREFIX."mailing";
+        $sql.= " WHERE rowid = ".$rowid;
 
-		dol_syslog("Mailing::reset_targets_status", LOG_DEBUG);
-		$resql=$this->db->query($sql);
-		if ($resql)
-		{
-			return 1;
-		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			return -1;
-		}
-	}
+        dol_syslog("Mailing::delete", LOG_DEBUG);
+        $resql=$this->db->query($sql);
+        if ($resql)
+        {
+            return 1;
+        }
+        else
+        {
+            $this->error=$this->db->lasterror();
+            $this->errors[]=$this->db->lasterror();
+            return -1;
+        }
+    }
 
 
-	/**
-	 *  Retourne le libelle du statut d'un mailing (brouillon, validee, ...
-	 *
-	 *  @param	int		$mode          	0=libelle long, 1=libelle court, 2=Picto + Libelle court, 3=Picto, 4=Picto + Libelle long
-	 *  @return string        			Label
-	 */
-	function getLibStatut($mode=0)
-	{
-		return $this->LibStatut($this->statut,$mode);
-	}
+    /**
+     *  Change status of each recipient
+     *
+     *	@param	User	$user      	Objet user qui valide
+     *  @return int         		<0 if KO, >0 if OK
+     */
+    function reset_targets_status($user)
+    {
+        $sql = "UPDATE ".MAIN_DB_PREFIX."mailing_cibles";
+        $sql.= " SET statut = 0";
+        $sql.= " WHERE fk_mailing = ".$this->id;
 
-	/**
-	 *  Renvoi le libelle d'un statut donne
-	 *
-	 *  @param	int		$statut        	Id statut
-	 *  @param  int		$mode          	0=libelle long, 1=libelle court, 2=Picto + Libelle court, 3=Picto, 4=Picto + Libelle long, 5=Libelle court + Picto
-	 *  @return string        			Label
-	 */
-	function LibStatut($statut,$mode=0)
-	{
-		global $langs;
-		$langs->load('mails');
+        dol_syslog("Mailing::reset_targets_status", LOG_DEBUG);
+        $resql=$this->db->query($sql);
+        if ($resql)
+        {
+            return 1;
+        }
+        else
+        {
+            $this->error=$this->db->lasterror();
+            $this->errors[]=$this->db->lasterror();
+            return -1;
+        }
+    }
 
-		if ($mode == 0)
-		{
-			return $langs->trans($this->statuts[$statut]);
-		}
-		if ($mode == 1)
-		{
-			return $langs->trans($this->statuts[$statut]);
-		}
-		if ($mode == 2)
-		{
-			if ($statut == 0) return img_picto($langs->trans($this->statuts[$statut]),'statut0').' '.$langs->trans($this->statuts[$statut]);
-			if ($statut == 1) return img_picto($langs->trans($this->statuts[$statut]),'statut1').' '.$langs->trans($this->statuts[$statut]);
-			if ($statut == 2) return img_picto($langs->trans($this->statuts[$statut]),'statut3').' '.$langs->trans($this->statuts[$statut]);
-			if ($statut == 3) return img_picto($langs->trans($this->statuts[$statut]),'statut6').' '.$langs->trans($this->statuts[$statut]);
-		}
-		if ($mode == 3)
-		{
-			if ($statut == 0) return img_picto($langs->trans($this->statuts[$statut]),'statut0');
-			if ($statut == 1) return img_picto($langs->trans($this->statuts[$statut]),'statut1');
-			if ($statut == 2) return img_picto($langs->trans($this->statuts[$statut]),'statut3');
-			if ($statut == 3) return img_picto($langs->trans($this->statuts[$statut]),'statut6');
-		}
-		if ($mode == 4)
-		{
-			if ($statut == 0) return img_picto($langs->trans($this->statuts[$statut]),'statut0').' '.$langs->trans($this->statuts[$statut]);
-			if ($statut == 1) return img_picto($langs->trans($this->statuts[$statut]),'statut1').' '.$langs->trans($this->statuts[$statut]);
-			if ($statut == 2) return img_picto($langs->trans($this->statuts[$statut]),'statut3').' '.$langs->trans($this->statuts[$statut]);
-			if ($statut == 3) return img_picto($langs->trans($this->statuts[$statut]),'statut6').' '.$langs->trans($this->statuts[$statut]);
-		}
-		if ($mode == 5)
-		{
-			if ($statut == 0)  return $langs->trans($this->statuts[$statut]).' '.img_picto($langs->trans($this->statuts[$statut]),'statut0');
-			if ($statut == 1)  return $langs->trans($this->statuts[$statut]).' '.img_picto($langs->trans($this->statuts[$statut]),'statut1');
-			if ($statut == 2)  return $langs->trans($this->statuts[$statut]).' '.img_picto($langs->trans($this->statuts[$statut]),'statut3');
-			if ($statut == 3)  return $langs->trans($this->statuts[$statut]).' '.img_picto($langs->trans($this->statuts[$statut]),'statut6');
-		}
-	}
 
-	
-	/**
-	 *  Renvoi le libelle d'un statut donne
-	 *
-	 *  @param	int		$statut        	Id statut
-	 *  @param  int		$mode          	0=libelle long, 1=libelle court, 2=Picto + Libelle court, 3=Picto, 4=Picto + Libelle long, 5=Libelle court + Picto
-	 *  @return string        			Label
-	 */
-	static public function libStatutDest($statut,$mode=0)
-	{
-		global $langs;
-		$langs->load('mails');
-	
-		if ($mode == 0)
-		{
-			return $langs->trans($this->statut_dest[$statut]);
-		}
-		if ($mode == 1)
-		{
-			return $langs->trans($this->statut_dest[$statut]);
-		}
-		if ($mode == 2)
-		{
-			if ($statut==-1) return $langs->trans("MailingStatusError").' '.img_error();
-			if ($statut==1) return $langs->trans("MailingStatusSent").' '.img_picto($langs->trans("MailingStatusSent"),'statut4');
-			if ($statut==2) return $langs->trans("MailingStatusRead").' '.img_picto($langs->trans("MailingStatusRead"),'statut6');
-			if ($statut==3) return $langs->trans("MailingStatusNotContact").' '.img_picto($langs->trans("MailingStatusNotContact"),'statut8');
-		}
-		if ($mode == 3)
-		{
-			if ($statut==-1) return $langs->trans("MailingStatusError").' '.img_error();
-			if ($statut==1) return $langs->trans("MailingStatusSent").' '.img_picto($langs->trans("MailingStatusSent"),'statut4');
-			if ($statut==2) return $langs->trans("MailingStatusRead").' '.img_picto($langs->trans("MailingStatusRead"),'statut6');
-			if ($statut==3) return $langs->trans("MailingStatusNotContact").' '.img_picto($langs->trans("MailingStatusNotContact"),'statut8');
-		}
-		if ($mode == 4)
-		{
-			if ($statut==-1) return $langs->trans("MailingStatusError").' '.img_error();
-			if ($statut==1) return $langs->trans("MailingStatusSent").' '.img_picto($langs->trans("MailingStatusSent"),'statut4');
-			if ($statut==2) return $langs->trans("MailingStatusRead").' '.img_picto($langs->trans("MailingStatusRead"),'statut6');
-			if ($statut==3) return $langs->trans("MailingStatusNotContact").' '.img_picto($langs->trans("MailingStatusNotContact"),'statut8');
-		}
-		if ($mode == 5)
-		{
-			if ($statut==-1) return $langs->trans("MailingStatusError").' '.img_error();
-			if ($statut==1) return $langs->trans("MailingStatusSent").' '.img_picto($langs->trans("MailingStatusSent"),'statut4');
-			if ($statut==2) return $langs->trans("MailingStatusRead").' '.img_picto($langs->trans("MailingStatusRead"),'statut6');
-			if ($statut==3) return $langs->trans("MailingStatusNotContact").' '.img_picto($langs->trans("MailingStatusNotContact"),'statut8');
-		}
-		
-		
-		
-		
-	}
+    /**
+     *  Retourne le libelle du statut d'un mailing (brouillon, validee, ...
+     *
+     *  @param	int		$mode          	0=libelle long, 1=libelle court, 2=Picto + Libelle court, 3=Picto, 4=Picto + Libelle long
+     *  @return string        			Label
+     */
+    function getLibStatut($mode=0)
+    {
+        return $this->LibStatut($this->statut,$mode);
+    }
 
+    /**
+     *  Renvoi le libelle d'un statut donne
+     *
+     *  @param	int		$statut        	Id statut
+     *  @param  int		$mode          	0=libelle long, 1=libelle court, 2=Picto + Libelle court, 3=Picto, 4=Picto + Libelle long, 5=Libelle court + Picto
+     *  @return string        			Label
+     */
+    function LibStatut($statut,$mode=0)
+    {
+        global $langs;
+        $langs->load('mails');
+
+        if ($mode == 0)
+        {
+            return $langs->trans($this->statuts[$statut]);
+        }
+        if ($mode == 1)
+        {
+            return $langs->trans($this->statuts[$statut]);
+        }
+        if ($mode == 2)
+        {
+            if ($statut == 0) return img_picto($langs->trans($this->statuts[$statut]),'statut0').' '.$langs->trans($this->statuts[$statut]);
+            if ($statut == 1) return img_picto($langs->trans($this->statuts[$statut]),'statut1').' '.$langs->trans($this->statuts[$statut]);
+            if ($statut == 2) return img_picto($langs->trans($this->statuts[$statut]),'statut3').' '.$langs->trans($this->statuts[$statut]);
+            if ($statut == 3) return img_picto($langs->trans($this->statuts[$statut]),'statut6').' '.$langs->trans($this->statuts[$statut]);
+        }
+        if ($mode == 3)
+        {
+            if ($statut == 0) return img_picto($langs->trans($this->statuts[$statut]),'statut0');
+            if ($statut == 1) return img_picto($langs->trans($this->statuts[$statut]),'statut1');
+            if ($statut == 2) return img_picto($langs->trans($this->statuts[$statut]),'statut3');
+            if ($statut == 3) return img_picto($langs->trans($this->statuts[$statut]),'statut6');
+        }
+        if ($mode == 4)
+        {
+            if ($statut == 0) return img_picto($langs->trans($this->statuts[$statut]),'statut0').' '.$langs->trans($this->statuts[$statut]);
+            if ($statut == 1) return img_picto($langs->trans($this->statuts[$statut]),'statut1').' '.$langs->trans($this->statuts[$statut]);
+            if ($statut == 2) return img_picto($langs->trans($this->statuts[$statut]),'statut3').' '.$langs->trans($this->statuts[$statut]);
+            if ($statut == 3) return img_picto($langs->trans($this->statuts[$statut]),'statut6').' '.$langs->trans($this->statuts[$statut]);
+        }
+        if ($mode == 5)
+        {
+            if ($statut == 0)  return $langs->trans($this->statuts[$statut]).' '.img_picto($langs->trans($this->statuts[$statut]),'statut0');
+            if ($statut == 1)  return $langs->trans($this->statuts[$statut]).' '.img_picto($langs->trans($this->statuts[$statut]),'statut1');
+            if ($statut == 2)  return $langs->trans($this->statuts[$statut]).' '.img_picto($langs->trans($this->statuts[$statut]),'statut3');
+            if ($statut == 3)  return $langs->trans($this->statuts[$statut]).' '.img_picto($langs->trans($this->statuts[$statut]),'statut6');
+        }
+        return "";
+    }
+
+
+    /**
+     *  Renvoi le libelle d'un statut donne
+     *
+     *  @param	int		$statut        	Id statut
+     *  @param  int		$mode          	0=libelle long, 1=libelle court, 2=Picto + Libelle court, 3=Picto, 4=Picto + Libelle long, 5=Libelle court + Picto
+     *  @return string        			Label
+     */
+    static public function libStatutDest($statut,$mode=0)
+    {
+        global $langs;
+        $langs->load('mails');
+
+        if ($mode == 0)
+        {
+            return $langs->trans(Mailing::$statut_dest[$statut]);
+        }
+        if ($mode == 1)
+        {
+            return $langs->trans(Mailing::$statut_dest[$statut]);
+        }
+        if ($mode == 2)
+        {
+            if ($statut ==-1) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_error();
+            if ($statut == 1) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusSent"),'statut4');
+            if ($statut == 2) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusRead"),'statut6');
+            if ($statut == 3) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusNotContact"),'statut8');
+        }
+        if ($mode == 3)
+        {
+            if ($statut ==-1) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_error();
+            if ($statut == 1) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusSent"),'statut4');
+            if ($statut == 2) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusRead"),'statut6');
+            if ($statut == 3) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusNotContact"),'statut8');
+        }
+        if ($mode == 4)
+        {
+            if ($statut ==-1) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_error();
+            if ($statut == 1) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusSent"),'statut4');
+            if ($statut == 2) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusRead"),'statut6');
+            if ($statut == 3) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusNotContact"),'statut8');
+        }
+        if ($mode == 5)
+        {
+            if ($statut ==-1) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_error();
+            if ($statut == 1) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusSent"),'statut4');
+            if ($statut == 2) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusRead"),'statut6');
+            if ($statut == 3) return $langs->trans(Mailing::$statut_dest[$statut]).' '.img_picto($langs->trans("MailingStatusNotContact"),'statut8');
+        }
+        return "";
+    }
+
+    /**
+     *  Handles mail substitutions
+     *
+     *  @param	int		$mode 			0 = Title, 1 = Body, 2 = Line
+     *  @param	Object	$obj			Object to get data
+     *  @return string					-1 if error, Id of created object if OK
+     */
+    function handleSubstitutions($mode, $obj)
+    {
+        global $conf, $langs;
+        $text = "";
+
+        // Fill substitution array with data from $obj depending of mail type
+        if ($mode == 0 || $mode == 1) {
+            $text = $mode == 0 ? $this->subject: $this->body;
+            if ($this->mail_type == 0) {
+                $substitutions = array(
+                    //Common
+                    '__ID__' => $obj->source_id,
+                    '__EMAIL__' => $obj->email,
+                    '__MAILTOEMAIL__' => '<a href="mailto:'.$obj->email.'">'.$obj->email.'</a>',
+                    //Specific
+                    '__LASTNAME__' => $obj->lastname,
+                    '__FIRSTNAME__' => $obj->firstname,
+                    '__CHECK_READ__' => '<img src="'.DOL_MAIN_URL_ROOT.'/public/emailing/mailing-read.php?tag='.$obj->tag.'&securitykey='.urlencode($conf->global->MAILING_EMAIL_UNSUBSCRIBE_KEY).'" width="1" height="1" style="width:1px;height:1px" border="0"/>',
+                    '__UNSUBSCRIBE__' => '<a href="'.DOL_MAIN_URL_ROOT.'/public/emailing/mailing-unsubscribe.php?tag='.$obj->tag.'&unsuscrib=1&securitykey='.urlencode($conf->global->MAILING_EMAIL_UNSUBSCRIBE_KEY).'" target="_blank">'.$langs->trans("MailUnsubcribe") . '</a>',
+                    //'__OTHER_FIELD__' Done dinamically
+                );
+
+                // create dinamic tags for __OTHER_FIELD__
+                $other = explode(';', $obj->other);
+                foreach ($other as $pair) {
+                    $pair = explode('=', $pair);
+                    $substitutions['__OTHER_' . strtoupper($pair[0]) . '__'] = $pair[1];
+                }
+            } else if ($this->mail_type == 1) {
+                //$obj should be a CommandeFournisseur
+                $soc = new Societe($this->db);
+                $soc->fetch($obj->socid);
+                $lines = "";
+                if ($mode == 1) { //Only show lines in body
+                    foreach ($obj->lines as $index=>$line) {
+                        $line_obj = array($index, $line);
+                        $lines = $lines . $this->handleSubstitutions(2, $line_obj) . '\n';
+                    }
+                }
+                $substitutions = array(
+                    //Common
+                    '__ID__' => $obj->id,
+                    '__EMAIL__' => $soc->email,
+                    '__MAILTOEMAIL__' => '<a href="mailto:'.$soc->email.'">'.$soc->email.'</a>',
+                    //Specific
+                    '__REF__' => $obj->ref,
+                    '__REF_SUPPLIER__' => $obj->ref_supplier,
+                    '__THIRDPARTY_NAME__' => $soc->name,
+                    '__LINES__' => $lines,
+                    //'__EXTRAFIELD_ORDER_FIELD__' Done dinamically
+                );
+                // Create dinamic tags for __EXTRAFIELD_ORDER_FIELD__
+                $extrafields = new ExtraFields($this->db);
+                $extralabels=$extrafields->fetch_name_optionals_label($obj->table_element,true);
+                $obj->fetch_optionals($obj->id, $extralabels);
+                foreach ($extrafields->attribute_label as $key=>$label)
+                {
+                    $substitutions['__EXTRAFIELD_ORDER_' . strtoupper($key) . '__'] = $obj->array_options['options_'.$key];
+                }
+            }
+        } else if ($mode == 2) {
+            $text = $this -> line;
+            if ($this->mail_type == 1) {
+                //$obj should be a array(index, line)
+                $format = "";
+                $line = $obj[1];
+                $product = new Product($this->db);
+                $product->fetch($line->fk_product, '', '', 1);
+                $substitutions = array(
+                    '__NUM__' => $obj[0],
+                    '__REF__' => $line->product_ref,
+                    '__REF_SUPPLIER__' => $line->ref_supplier,
+                    '__LABEL__' => $line->product_label,
+                    '__DESCRIPTION__' => $line->product_desc,
+                    '__DATE_START__' => dol_print_date($line->date_start, $format),
+                    '__DATE_END__' => dol_print_date($line->date_end, $format),
+                    '__QUANTITY__' => $line->qty,
+                    '__TOTAL__' => $line->total_ttc,
+                    //'__EXTRAFIELD_PRODUCT_FIELD__' Done dinamically
+                );
+
+                // Create dinamic tags for __EXTRAFIELD_PRODUCT_FIELD__
+                $extrafields = new ExtraFields($this->db);
+                $extralabels = $extrafields->fetch_name_optionals_label('product', true);
+                $product->fetch_optionals($product->id, $extralabels);
+                foreach ($extrafields->attribute_label as $key => $label) {
+                    $substitutions['__EXTRAFIELD_PRODUCT_' . strtoupper($key) . '__'] = $product->array_options['options_' . $key];
+                }
+            }
+        }
+
+        //Paypal substitutions
+        if (! empty($conf->paypal->enabled) && ! empty($conf->global->PAYPAL_SECURITY_TOKEN))
+        {
+            $substitutions['__SECUREKEYPAYPAL__']=dol_hash($conf->global->PAYPAL_SECURITY_TOKEN, 2);
+            if (empty($conf->global->PAYPAL_SECURITY_TOKEN_UNIQUE)) $substitutions['__SECUREKEYPAYPAL_MEMBER__']=dol_hash($conf->global->PAYPAL_SECURITY_TOKEN, 2);
+            else $substitutions['__SECUREKEYPAYPAL_MEMBER__']=dol_hash($conf->global->PAYPAL_SECURITY_TOKEN . 'membersubscription' . $obj->source_id, 2);
+        }
+
+        // Complete the substitutions with external substitutions
+        complete_substitutions_array($substitutions, $langs);
+        // Do substitutions and return result
+        return make_substitutions($text, $substitutions);
+    }
+
+    /**
+     *  Returns the correct substitutions for language depending of mail type and requested $mode
+     *
+     *  @param	int         $mode 			0 = language substitutions, 1 = line language substitutions
+     *  @return array       Substitution
+     */
+    public function getSubstitutionsLang($mode)
+    {
+        global $conf;
+
+        if ($mode == 0) {
+            // Array of language codes for substitutions (See also file comm/mailing/card.php that should manage same substitutions)
+            $substitution_common = array(
+                '__ID__' => 'IdRecord',
+                '__EMAIL__' => 'EMail',
+                '__MAILTOEMAIL__' => 'TagMailtoEmail',
+                '__SIGNATURE__' => 'TagSignature',
+                //,'__PERSONALIZED__' => 'Personalized'	// Hidden because not used yet
+            );
+
+            //Paypal stuff
+            if (!empty($conf->paypal->enabled) && !empty($conf->global->PAYPAL_SECURITY_TOKEN)) {
+                $substitution_common['__SECUREKEYPAYPAL__'] = 'SecureKeyPaypal';
+                if (!empty($conf->global->PAYPAL_SECURITY_TOKEN_UNIQUE)) {
+                    $substitution_common['__SECUREKEYPAYPAL_MEMBER__'] = 'SecureKeyPaypalUniquePerMember';
+                }
+            }
+
+            if ($this->mail_type == 0) { //Mail type 0 extra substitutions + commons
+                return array_merge($substitution_common, array(
+                    '__LASTNAME__' => 'Lastname',
+                    '__FIRSTNAME__' => 'Firstname',
+                    '__CHECK_READ__' => 'TagCheckMail',
+                    '__UNSUBSCRIBE__' => 'TagUnsubscribe',
+                    '__OTHER_FIELD__' => 'OtherField',
+                ));
+            } else if ($this->mail_type == 1) { //Mail type 1 extra substitutions + commons
+                return array_merge($substitution_common, array(
+                    '__REF__' => 'Ref',
+                    '__REF_SUPPLIER__' => 'RefSupplier',
+                    '__THIRDPARTY_NAME__' => 'ThirdPartyName',
+                    '__LINES__' => 'MailLines',
+                    '__EXTRAFIELD_ORDER_FIELD__' => 'ExtraFieldOrder'
+                ));
+            }
+        } else if ($mode == 1) {
+            if ($this->mail_type == 1) {
+                return array(
+                    '__NUM__' => 'Number',
+                    '__REF__' => 'Ref',
+                    '__REF_SUPPLIER__' => 'RefSupplier',
+                    '__LABEL__' => 'Label',
+                    '__DESCRIPTION__' => 'Description',
+                    '__DATE_START__' => 'DateStart',
+                    '__DATE_END__' => 'DateEnd',
+                    '__QUANTITY__' => 'Quantity',
+                    '__TOTAL__' => 'AmountTTC',
+                    '__EXTRAFIELD_PRODUCT_FIELD__' => 'ExtraFieldProduct'
+                );
+            }
+        }
+        return array();
+    }
+
+    /**
+     *  Returns the correct substitutions for test depending of mail type
+     *
+     *  @return array       Substitution
+     */
+    public function getSubstitutionsTest()
+    {
+        global $conf, $user;
+
+        // Array of common test
+        $substitution_common = array(
+            '__ID__' => 'TESTIdRecord',
+            '__EMAIL__' => 'TESTEMail',
+            '__MAILTOEMAIL__' => 'TESTMailtoEmail',
+            '__SIGNATURE__' => (($user->signature && empty($conf->global->MAIN_MAIL_DO_NOT_USE_SIGN))?$user->signature:''),
+            '__CHECK_READ__' => 'TagCheckMail',
+            '__UNSUBSCRIBE__' => 'TagUnsubscribe'
+            //,'__PERSONALIZED__' => 'TESTPersonalized'	// Not used yet
+        );
+
+        //Paypal stuff
+        if (!empty($conf->paypal->enabled) && !empty($conf->global->PAYPAL_SECURITY_TOKEN)) {
+            $substitution_common['__SECUREKEYPAYPAL__'] = 'TESTSecureKeyPaypal';
+            if (!empty($conf->global->PAYPAL_SECURITY_TOKEN_UNIQUE)) {
+                $substitution_common['__SECUREKEYPAYPAL_MEMBER__'] = 'TESTSecureKeyPaypalUniquePerMember';
+            }
+        }
+
+        //Lines stuff
+        $substitution_line = array(
+            '__NUM__' => 'TESTNumber',
+            '__REF__' => 'TESTRef',
+            '__REF_SUPPLIER__' => 'TESTRefSupplier',
+            '__LABEL__' => 'TESTLabel',
+            '__DESCRIPTION__' => 'TESTDescription',
+            '__DATE_START__' => 'TESTDateStart',
+            '__DATE_END__' => 'TESTDateEnd',
+            '__QUANTITY__' => 'TESTQuantity',
+            '__TOTAL__' => 'TESTTotal',
+            //'__EXTRAFIELD_PRODUCT_FIELD__' => 'ExtraFieldProduct'
+        );
+        $lines = make_substitutions($this->line, $substitution_line);
+
+        if ($this->mail_type == 0) { //Mail type 0 extra substitutions + commons
+            return array_merge($substitution_common, array(
+                '__LASTNAME__' => 'TESTLastname',
+                '__FIRSTNAME__' => 'TESTFirstname',
+                //'__OTHER_FIELD__' => 'OtherField',
+            ));
+        } else if ($this->mail_type == 1) { //Mail type 1 extra substitutions + commons
+            return array_merge($substitution_common, array(
+                '__REF__' => 'TESTRef',
+                '__REF_SUPPLIER__' => 'TESTRefSupplier',
+                '__THIRDPARTY_NAME__' => 'TESTThirdPartyName',
+                '__LINES__' => !empty($lines) ? $lines : 'TESTLines',
+                //'__EXTRAFIELD_ORDER_FIELD__' => 'ExtraFieldOrder'
+            ));
+        }
+        return array();
+    }
+
+    /**
+     * List all mailings with selected mail_type
+     *
+     *  @param	int		$mail_type 	Mail Type, if null no filter will be used
+     *  @return	array				Array of mailings
+     */
+    function listMailings($mail_type = null)
+    {
+        $sql = "SELECT rowid, titre, mail_type";
+        $sql.= " FROM ".MAIN_DB_PREFIX."mailing";
+        if ($mail_type != null) {
+            $sql.= " WHERE mail_type = ".$mail_type;
+        }
+
+    	dol_syslog(get_class($this)."::listMailings", LOG_DEBUG);
+        $resql=$this->db->query($sql);
+        if ($resql)
+        {
+            $retarray = array();
+
+            while ($record = $this->db->fetch_array($resql))
+            {
+                $mail = array();
+                $mail["id"]             = $record["rowid"];
+                $mail["description"]    = $record["titre"];
+                $retarray[]=$mail;
+            }
+
+            $this->db->free($resql);
+            return $retarray;
+        }
+        else
+        {
+            $this->error=$this->db->error();
+            $this->errors[]=$this->db->error();
+            return -1;
+        }
+    }
 }
 

--- a/htdocs/comm/mailing/list.php
+++ b/htdocs/comm/mailing/list.php
@@ -57,7 +57,7 @@ $form = new Form($db);
 
 if ($filteremail)
 {
-	$sql = "SELECT m.rowid, m.titre, m.nbemail, m.statut, m.date_creat as datec, m.date_envoi as date_envoi,";
+	$sql = "SELECT m.rowid, m.titre, m.mail_type, m.nbemail, m.statut, m.date_creat as datec, m.date_envoi as date_envoi,";
 	$sql.= " mc.statut as sendstatut";
 	$sql.= " FROM ".MAIN_DB_PREFIX."mailing as m, ".MAIN_DB_PREFIX."mailing_cibles as mc";
 	$sql.= " WHERE m.rowid = mc.fk_mailing AND m.entity = ".$conf->entity;
@@ -71,7 +71,7 @@ if ($filteremail)
 }
 else
 {
-	$sql = "SELECT m.rowid, m.titre, m.nbemail, m.statut, m.date_creat as datec, m.date_envoi as date_envoi";
+	$sql = "SELECT m.rowid, m.titre, m.mail_type, m.nbemail, m.statut, m.date_creat as datec, m.date_envoi as date_envoi";
 	$sql.= " FROM ".MAIN_DB_PREFIX."mailing as m";
 	$sql.= " WHERE m.entity = ".$conf->entity;
 	if ($sref) $sql.= " AND m.rowid = '".$sref."'";
@@ -101,6 +101,7 @@ if ($result)
 	print '<tr class="liste_titre">';
 	print_liste_field_titre($langs->trans("Ref"),$_SERVER["PHP_SELF"],"m.rowid",$param,"","",$sortfield,$sortorder);
 	print_liste_field_titre($langs->trans("Title"),$_SERVER["PHP_SELF"],"m.titre",$param,"","",$sortfield,$sortorder);
+	print_liste_field_titre($langs->trans("MailType"),$_SERVER["PHP_SELF"],"m.mail_type",$param,"","",$sortfield,$sortorder);
 	print_liste_field_titre($langs->trans("DateCreation"),$_SERVER["PHP_SELF"],"m.date_creat",$param,"",'align="center"',$sortfield,$sortorder);
 	if (! $filteremail) print_liste_field_titre($langs->trans("NbOfEMails"),$_SERVER["PHP_SELF"],"m.nbemail",$param,"",'align="center"',$sortfield,$sortorder);
 	if (! $filteremail) print_liste_field_titre($langs->trans("DateLastSend"),$_SERVER["PHP_SELF"],"m.date_envoi",$param,"",'align="center"',$sortfield,$sortorder);
@@ -119,6 +120,7 @@ if ($result)
 	print '</td>';
 	print '<td class="liste_titre">&nbsp;</td>';
 	if (! $filteremail) print '<td class="liste_titre">&nbsp;</td>';
+	print '<td class="liste_titre">&nbsp;</td>';
 	print '<td class="liste_titre">&nbsp;</td>';
 	print '<td class="liste_titre" align="right"><input class="liste_titre" type="image" src="'.img_picto($langs->trans("Search"),'search.png','','',1).'" value="'.dol_escape_htmltag($langs->trans("Search")).'" title="'.dol_escape_htmltag($langs->trans("Search")).'">';
 	print "</td>";
@@ -139,6 +141,7 @@ if ($result)
 		print '<td><a href="'.DOL_URL_ROOT.'/comm/mailing/card.php?id='.$obj->rowid.'">';
 		print img_object($langs->trans("ShowEMail"),"email").' '.stripslashes($obj->rowid).'</a></td>';
 		print '<td>'.$obj->titre.'</td>';
+		print '<td>'.$langs->trans("MailType".$obj->mail_type).'</td>';
 		// Date creation
 		print '<td align="center">';
 		print dol_print_date($db->jdate($obj->datec),'day');

--- a/htdocs/core/class/html.formmailing.class.php
+++ b/htdocs/core/class/html.formmailing.class.php
@@ -59,8 +59,6 @@ class FormMailing  extends Form
 		require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
 		$mailing = new Mailing($this->db);
 
-
-		$array = $mailing->statut_dest;
 		//Cannot use form->selectarray because empty value is defaulted to -1 in this method and we use here status -1...
 
 		$out = '<select name="'.$htmlname.'" class="flat">';
@@ -69,7 +67,7 @@ class FormMailing  extends Form
 			$out .= '<option value=""></option>';
 		}
 
-		foreach($mailing->statut_dest as $id=>$status) {
+		foreach(Mailing::$statut_dest as $id=>$status) {
 			if ($selectedid==$id)  {
 				$selected=" selected=selected ";
 			}else {

--- a/htdocs/core/lib/emailing.lib.php
+++ b/htdocs/core/lib/emailing.lib.php
@@ -43,10 +43,12 @@ function emailing_prepare_head(Mailing $object)
 		return $head;
 	}
 
-	$head[$h][0] = DOL_URL_ROOT."/comm/mailing/cibles.php?id=".$object->id;
-	$head[$h][1] = $langs->trans("MailRecipients");
-	$head[$h][2] = 'targets';
-	$h++;
+	if ($object->mail_type == 0) {
+		$head[$h][0] = DOL_URL_ROOT . "/comm/mailing/cibles.php?id=" . $object->id;
+		$head[$h][1] = $langs->trans("MailRecipients");
+		$head[$h][2] = 'targets';
+		$h++;
+	}
 
 	$head[$h][0] = DOL_URL_ROOT."/comm/mailing/info.php?id=".$object->id;
 	$head[$h][1] = $langs->trans("Info");

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1950,31 +1950,33 @@ elseif (! empty($object->id))
 
 		print_titre($langs->trans('SendOrderByMail'));
 
-        require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
-        $mailing = new Mailing($db);
-        $mail_template = GETPOST('mailtemplate', 'int');
-        $mail_template = $mail_template > 0 ? $mail_template : null;
+		require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
+		$mailing = new Mailing($db);
+		$mail_template = GETPOST('mailtemplate', 'int');
+		$mail_template = $mail_template > 0 ? $mail_template : null;
 
-        // Manual or premade template selector
+		// Manual or premade template selector
 		print '<table>';
-        print '<tr><td width="180">'.$langs->trans("Template").'</td><td>';
-        $mail_templates = array(0 => $langs->trans("None"));
-        foreach ($mailing->listMailings(1) as $entry) {
-            $mail_templates[$entry["id"]] = $entry["description"];
-        }
-        print $form->selectarray('mailtemplate', $mail_templates, $mail_template);
-        print '</td></tr>';
+		print '<tr><td width="180">'.$langs->trans("Template").'</td><td>';
+		$mail_templates = array(0 => $langs->trans("None"));
+		foreach ($mailing->listMailings(1) as $entry) {
+			if ($entry["statut"] > 0) {
+				$mail_templates[$entry["id"]] = $entry["description"];
+			}
+		}
+		print $form->selectarray('mailtemplate', $mail_templates, $mail_template);
+		print '</td></tr>';
 
-        // This code reloads page when mail template is changed
-        print '<script type="text/javascript">
-            jQuery(document).ready(run);
-            function run() {
-                jQuery("#mailtemplate").change(on_change);
-            }
-            function on_change() {
-                window.location = "'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=presend&mode=init&mailtemplate=" + $("#mailtemplate").attr("value");
-            }
-        </script>';
+		// This code reloads page when mail template is changed
+		print '<script type="text/javascript">
+			jQuery(document).ready(run);
+			function run() {
+				jQuery("#mailtemplate").change(on_change);
+			}
+			function on_change() {
+				window.location = "'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=presend&mode=init&mailtemplate=" + $("#mailtemplate").attr("value");
+			}
+		</script>';
 		print '</table>';
 
 		// Cree l'objet formulaire mail
@@ -1992,14 +1994,16 @@ elseif (! empty($object->id))
 		$formmail->withtocc=$liste;
 		$formmail->withtoccc=(! empty($conf->global->MAIN_EMAIL_USECCC)?$conf->global->MAIN_EMAIL_USECCC:false);
 		$formmail->withfile=2;
-        if (empty($mail_template)) {
-            $formmail->withtopic = $outputlangs->trans('SendOrderRef', '__ORDERREF__');
-            $formmail->withbody = 1;
-        } else {
-            $mailing->fetch($mail_template);
-            $formmail->withtopic = $mailing->handleSubstitutions(0, $object);
-            $formmail->withbody = $mailing->handleSubstitutions(1, $object);
-        }
+		if (empty($mail_template)) {
+			$formmail->withtopic = $outputlangs->trans('SendOrderRef', '__ORDERREF__');
+			$formmail->withbody = 1;
+		} else {
+			$mailing->fetch($mail_template);
+			if ($mailing->mail_type == 1 && $mailing->statut > 0) {
+				$formmail->withtopic = $mailing->handleSubstitutions(0, $object);
+				$formmail->withbody = $mailing->handleSubstitutions(1, $object);
+			}
+		}
 		$formmail->withdeliveryreceipt=1;
 		$formmail->withcancel=1;
 		// Tableau des substitutions

--- a/htdocs/install/mysql/migration/3.7.0-3.8.0.sql
+++ b/htdocs/install/mysql/migration/3.7.0-3.8.0.sql
@@ -195,5 +195,7 @@ CREATE TABLE llx_expensereport_det
 
 
 ALTER TABLE llx_projet ADD COLUMN budget_amount double(24,8);
-
+-- Add mail type column
+ALTER TABLE llx_mailing ADD COLUMN mail_type smallint DEFAULT 0;
+ALTER TABLE llx_mailing ADD COLUMN line varchar(255) NULL;
 

--- a/htdocs/install/mysql/tables/llx_mailing.sql
+++ b/htdocs/install/mysql/tables/llx_mailing.sql
@@ -50,5 +50,7 @@ create table llx_mailing
   joined_file1		varchar(255),
   joined_file2		varchar(255),
   joined_file3		varchar(255),
-  joined_file4		varchar(255)
+  joined_file4		varchar(255),
+  mail_type		smallint	DEFAULT 0,           -- Type of mail
+  line			varchar(255)	NULL                 -- Format for some mail types which require line formatting
 )ENGINE=innodb;

--- a/htdocs/langs/en_US/mails.lang
+++ b/htdocs/langs/en_US/mails.lang
@@ -139,3 +139,11 @@ ListOfNotificationsDone=List all email notifications sent
 MailSendSetupIs=Configuration of email sending has been setup to '%s'. This mode can't be used to send mass emailing.
 MailSendSetupIs2=You must first go, with an admin account, into menu %sHome - Setup - EMails%s to change parameter <strong>'%s'</strong> to use mode '%s'. With this mode, you can enter setup of the SMTP server provided by your Internet Service Provider and use Mass emailing feature.
 MailSendSetupIs3=If you have any questions on how to setup your SMTP server, you can ask to %s.
+MailType=Mail Type
+MailType0=Normal mail
+MailType1=Supplier order mail
+OtherField=Use for getting a Other field, where FIELD is a Other field name, for example 'Login' or 'yyy' in Login=xxxx;yyy=zzzz would be __OTHER_LOGIN__
+ExtraFieldOrder=Use for getting a order field, where FIELD is a order extrafield name
+ExtraFieldProduct=Use for getting a product field, where FIELD is a product extrafield name
+MailLine=Each line format
+MailLines=Location for all lines

--- a/htdocs/langs/en_US/main.lang
+++ b/htdocs/langs/en_US/main.lang
@@ -719,3 +719,4 @@ ShortThursday=T
 ShortFriday=F
 ShortSaturday=S
 ShortSunday=S
+Template=Template


### PR DESCRIPTION
This pull adds mailings for creating diferent supplier order mail templates which are seleccionable when sending mail in supplier order page

You can put order information in mail, per line format etc
__ LINES __ will be filled with all lines of order, the line format is specified in mailing editor

I have cleaned some old code by the way, renamed titre to description and sujet to subject, moved substitution arrays from card.php to separate methods in mailing.class.php, fixed using $this-> in static method libStatutDest
