### PR TITLE
refactor

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -107,6 +107,9 @@ class Propal extends CommonObject
     var $products=array();
     var $extraparams=array();
 
+	/**
+	 * @var PropaleLigne[]
+	 */
     var $lines = array();
     var $line;
 
@@ -2801,9 +2804,6 @@ class Propal extends CommonObject
  */
 class PropaleLigne  extends CommonObject
 {
-    var $db;
-    var $error;
-
     public $element='propaldet';
     public $table_element='propaldet';
 

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3178,7 +3178,6 @@ class Commande extends CommonOrder
 
 				$this->lines[$i]					= new OrderLine($this->db);
                 $this->lines[$i]->id				= $obj->rowid;
-                $this->lines[$i]->rowid				= $obj->rowid;
                 $this->lines[$i]->label 			= $obj->custom_label;
                 $this->lines[$i]->description 		= $obj->description;
                 $this->lines[$i]->fk_product		= $obj->fk_product;

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -104,7 +104,10 @@ class Commande extends CommonOrder
 
     var $user_author_id;
 
-    var $lines = array();
+	/**
+	 * @var OrderLine[]
+	 */
+	var $lines = array();
 
 	//Incorterms
 	var $fk_incoterms;
@@ -1635,12 +1638,12 @@ class Commande extends CommonOrder
 
                 $line = new OrderLine($this->db);
 
-                $line->rowid            = $objp->rowid;				// \deprecated
+                $line->rowid            = $objp->rowid;
                 $line->id               = $objp->rowid;
                 $line->fk_commande      = $objp->fk_commande;
-                $line->commande_id      = $objp->fk_commande;			// \deprecated
+                $line->commande_id      = $objp->fk_commande;
                 $line->label            = $objp->custom_label;
-                $line->desc             = $objp->description;  		// Description ligne
+                $line->desc             = $objp->description;
                 $line->product_type     = $objp->product_type;
                 $line->qty              = $objp->qty;
                 $line->tva_tx           = $objp->tva_tx;
@@ -1666,11 +1669,11 @@ class Commande extends CommonOrder
                 $line->special_code		= $objp->special_code;
                 $line->fk_parent_line	= $objp->fk_parent_line;
 
-                $line->ref				= $objp->product_ref;		// TODO deprecated
+                $line->ref				= $objp->product_ref;
                 $line->product_ref		= $objp->product_ref;
-                $line->libelle			= $objp->product_label;		// TODO deprecated
+                $line->libelle			= $objp->product_label;
                 $line->product_label	= $objp->product_label;
-                $line->product_desc     = $objp->product_desc; 		// Description produit
+                $line->product_desc     = $objp->product_desc;
                 $line->fk_product_type  = $objp->fk_product_type;	// Produit ou service
 
                 $line->date_start       = $this->db->jdate($objp->date_start);
@@ -3175,6 +3178,7 @@ class Commande extends CommonOrder
 
 				$this->lines[$i]					= new OrderLine($this->db);
                 $this->lines[$i]->id				= $obj->rowid;
+                $this->lines[$i]->rowid				= $obj->rowid;
                 $this->lines[$i]->label 			= $obj->custom_label;
                 $this->lines[$i]->description 		= $obj->description;
                 $this->lines[$i]->fk_product		= $obj->fk_product;
@@ -3261,56 +3265,44 @@ class Commande extends CommonOrder
  */
 class OrderLine extends CommonOrderLine
 {
-    var $db;
-    var $error;
-
 	public $element='commandedet';
 	public $table_element='commandedet';
 
     var $oldline;
 
+	/**
+	 * Id of parent order
+	 * @var int
+	 */
+	public $fk_commande;
+
+	/**
+	 * Id of parent order
+	 * @var int
+	 * @deprecated Use fk_commande
+	 */
+	public $commande_id;
+
     // From llx_commandedet
-    var $rowid;
     var $fk_parent_line;
     var $fk_facture;
     var $label;
-    var $desc;          	// Description ligne
-    var $fk_product;		// Id produit predefini
-    var $product_type = 0;	// Type 0 = product, 1 = Service
-
-    var $qty;				// Quantity (example 2)
-    var $tva_tx;			// VAT Rate for product/service (example 19.6)
-    var $localtax1_tx; 		// Local tax 1
-    var $localtax2_tx; 		// Local tax 2
-    var $localtax1_type;	// Local tax 1 type
-	var $localtax2_type;	// Local tax 2 type
-    var $subprice;      	// U.P. HT (example 100)
-    var $remise_percent;	// % for line discount (example 20%)
     var $fk_remise_except;
     var $rang = 0;
 	var $fk_fournprice;
+
+	/**
+	 * Buy price without taxes
+	 * @var float
+	 */
 	var $pa_ht;
     var $marge_tx;
     var $marque_tx;
-    var $info_bits = 0;		// Bit 0: 	0 si TVA normal - 1 si TVA NPR
-						    // Bit 1:	0 ligne normale - 1 si ligne de remise fixe
-    var $special_code = 0;
-    var $total_ht;			// Total HT  de la ligne toute quantite et incluant la remise ligne
-    var $total_tva;			// Total TVA  de la ligne toute quantite et incluant la remise ligne
-    var $total_localtax1;   // Total local tax 1 for the line
-    var $total_localtax2;   // Total local tax 2 for the line
-    var $total_ttc;			// Total TTC de la ligne toute quantite et incluant la remise ligne
 
-    // Ne plus utiliser
-    var $remise;
-    var $price;
-
-    // From llx_product
-    var $ref;				// deprecated
-    var $libelle;			// deprecated
-    var $product_ref;
-    var $product_label; 	// Label produit
-    var $product_desc;  	// Description produit
+	/**
+	 * @deprecated
+	 */
+	var $remise;
 
     // Added by Matelli (See http://matelli.fr/showcases/patchs-dolibarr/add-dates-in-order-lines.html)
     // Start and end date of the line

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -3408,7 +3408,6 @@ class Facture extends CommonInvoice
 
 				$this->lines[$i]					= new FactureLigne($this->db);
 				$this->lines[$i]->id				= $obj->rowid;
-				$this->lines[$i]->rowid				= $obj->rowid;
 				$this->lines[$i]->label 			= $obj->custom_label;	// deprecated
 				$this->lines[$i]->description 		= $obj->description;
 				$this->lines[$i]->fk_product		= $obj->fk_product;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -3408,6 +3408,7 @@ class Facture extends CommonInvoice
 
 				$this->lines[$i]					= new FactureLigne($this->db);
 				$this->lines[$i]->id				= $obj->rowid;
+				$this->lines[$i]->rowid				= $obj->rowid;
 				$this->lines[$i]->label 			= $obj->custom_label;	// deprecated
 				$this->lines[$i]->description 		= $obj->description;
 				$this->lines[$i]->fk_product		= $obj->fk_product;
@@ -3606,16 +3607,12 @@ class Facture extends CommonInvoice
  */
 class FactureLigne extends CommonInvoiceLine
 {
-	var $db;
-	var $error;
-
     public $element='facturedet';
     public $table_element='facturedet';
 
 	var $oldline;
 
 	//! From llx_facturedet
-	var $rowid;
 	//! Id facture
 	var $fk_facture;
 	//! Id parent line
@@ -3623,17 +3620,9 @@ class FactureLigne extends CommonInvoiceLine
 	var $label;				// deprecated
 	//! Description ligne
 	var $desc;
-	var $fk_product;		// Id of predefined product
-	var $product_type = 0;	// Type 0 = product, 1 = Service
 
-	var $qty;				// Quantity (example 2)
-	var $tva_tx;			// Taux tva produit/service (example 19.6)
-	var $localtax1_tx;		// Local tax 1
-	var $localtax2_tx;		// Local tax 2
 	var $localtax1_type;	// Local tax 1 type
 	var $localtax2_type;	// Local tax 2 type
-	var $subprice;      	// P.U. HT (example 100)
-	var $remise_percent;	// % de la remise ligne (example 20%)
 	var $fk_remise_except;	// Link to line into llx_remise_except
 	var $rang = 0;
 
@@ -3642,10 +3631,6 @@ class FactureLigne extends CommonInvoiceLine
 	var $marge_tx;
 	var $marque_tx;
 
-	var $info_bits = 0;		// Liste d'options cumulables:
-	// Bit 0:	0 si TVA normal - 1 si TVA NPR
-	// Bit 1:	0 si ligne normal - 1 si bit discount (link to line into llx_remise_except)
-
 	var $special_code;	// Liste d'options non cumulabels:
 	// 1: frais de port
 	// 2: ecotaxe
@@ -3653,15 +3638,6 @@ class FactureLigne extends CommonInvoiceLine
 
 	var $origin;
 	var $origin_id;
-
-	//! Total HT  de la ligne toute quantite et incluant la remise ligne
-	var $total_ht;
-	//! Total TVA  de la ligne toute quantite et incluant la remise ligne
-	var $total_tva;
-	var $total_localtax1; //Total Local tax 1 de la ligne
-	var $total_localtax2; //Total Local tax 2 de la ligne
-	//! Total TTC de la ligne toute quantite et incluant la remise ligne
-	var $total_ttc;
 
 	var $fk_code_ventilation = 0;
 
@@ -3690,16 +3666,6 @@ class FactureLigne extends CommonInvoiceLine
 	 * @var int Previous situation line id reference
 	 */
 	public $fk_prev_id;
-
-	/**
-	 *  Constructor
-	 *
-	 *  @param	DoliDB		$db		Database handler
-	 */
-	function __construct($db)
-	{
-		$this->db = $db;
-	}
 
 	/**
 	 *	Load invoice line from database

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -400,5 +400,100 @@ require_once DOL_DOCUMENT_ROOT .'/core/class/commonobjectline.class.php';
  */
 abstract class CommonInvoiceLine extends CommonObjectLine
 {
+	/**
+	 * Quantity
+	 * @var int
+	 */
+	public $qty;
+
+	/**
+	 * Unit price before taxes
+	 * @var float
+	 */
+	public $subprice;
+
+	/**
+	 * Type of the product. 0 for product 1 for service
+	 * @var int
+	 */
+	public $product_type = 0;
+
+	/**
+	 * Id of corresponding product
+	 * @var int
+	 */
+	public $fk_product;
+
+	/**
+	 * VAT %
+	 * @var float
+	 */
+	public $tva_tx;
+
+	/**
+	 * Local tax 1 %
+	 * @var float
+	 */
+	public $localtax1_tx;
+
+	/**
+	 * Local tax 2 %
+	 * @var float
+	 */
+	public $localtax2_tx;
+
+	/**
+	 * Percent of discount
+	 * @var float
+	 */
+	public $remise_percent;
+
+	/**
+	 * Total amount before taxes
+	 * @var float
+	 */
+	public $total_ht;
+
+	/**
+	 * Total VAT amount
+	 * @var float
+	 */
+	public $total_tva;
+
+	/**
+	 * Total local tax 1 amount
+	 * @var float
+	 */
+	public $total_localtax1;
+
+	/**
+	 * Total local tax 2 amount
+	 * @var float
+	 */
+	public $total_localtax2;
+
+	/**
+	 * Total amount with taxes
+	 * @var float
+	 */
+	public $total_ttc;
+
+	/**
+	 * Liste d'options cumulables:
+	 * Bit 0:	0 si TVA normal - 1 si TVA NPR
+	 * Bit 1:	0 si ligne normal - 1 si bit discount (link to line into llx_remise_except)
+	 * @var int
+	 */
+	public $info_bits = 0;
+
+	/**
+	 *  Constructor
+	 *
+	 *  @param	DoliDB		$db		Database handler
+	 */
+	public function __construct(DoliDB $db)
+	{
+		$this->db = $db;
+	}
 }
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2821,7 +2821,7 @@ abstract class CommonObject
 		if (! empty($line->date_end)) $type=1; // deprecated
 
 		// Ligne en mode visu
-		if ($action != 'editline' || $selected != $line->rowid)
+		if ($action != 'editline' || $selected != $line->id)
 		{
 			// Product
 			if ($line->fk_product > 0)
@@ -2879,7 +2879,7 @@ abstract class CommonObject
 		}
 
 		// Ligne en mode update
-		if ($this->statut == 0 && $action == 'editline' && $selected == $line->rowid)
+		if ($this->statut == 0 && $action == 'editline' && $selected == $line->id)
 		{
 			$label = (! empty($line->label) ? $line->label : (($line->fk_product > 0) ? $line->product_label : ''));
 			if (! empty($conf->global->MAIN_HTML5_PLACEHOLDER)) $placeholder=' placeholder="'.$langs->trans("Label").'"';

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2685,10 +2685,9 @@ abstract class CommonObject
 	 *	@param  string  	$buyer             	Object of buyer third party
 	 *	@param	string		$selected		   	Object line selected
 	 *	@param  int	    	$dateSelector      	1=Show also date range input fields
-	 *  @param	int			$permtoedit			Permission to edit line
 	 *	@return	void
 	 */
-	function printObjectLines($action, $seller, $buyer, $selected=0, $dateSelector=0, $permtoedit=0)
+	function printObjectLines($action, $seller, $buyer, $selected=0, $dateSelector=0)
 	{
 		global $conf, $hookmanager, $inputalsopricewithtax, $usemargins, $langs, $user;
 
@@ -2781,7 +2780,7 @@ abstract class CommonObject
 			}
 			else
 			{
-				$this->printObjectLine($action,$line,$var,$num,$i,$dateSelector,$seller,$buyer,$selected,$extrafieldsline,$permtoedit);
+				$this->printObjectLine($action,$line,$var,$num,$i,$dateSelector,$seller,$buyer,$selected,$extrafieldsline);
 			}
 
 			$i++;
@@ -2793,7 +2792,7 @@ abstract class CommonObject
 	 *	TODO Move this into an output class file (htmlline.class.php)
 	 *
 	 *	@param	string		$action				GET/POST action
-	 *	@param	array	    $line		       	Selected object line to output
+	 *	@param CommonObjectLine $line		       	Selected object line to output
 	 *	@param  string	    $var               	Is it a an odd line (true)
 	 *	@param  int		    $num               	Number of line (0)
 	 *	@param  int		    $i					I
@@ -2802,13 +2801,14 @@ abstract class CommonObject
 	 *	@param  string	    $buyer             	Object of buyer third party
 	 *	@param	string		$selected		   	Object line selected
 	 *  @param  object		$extrafieldsline	Object of extrafield line attribute
-	 *  @param	int			$permtoedit			Permission to edit
 	 *	@return	void
 	 */
-	function printObjectLine($action,$line,$var,$num,$i,$dateSelector,$seller,$buyer,$selected=0,$extrafieldsline=0,$permtoedit=0)
+	function printObjectLine($action,$line,$var,$num,$i,$dateSelector,$seller,$buyer,$selected=0,$extrafieldsline=0)
 	{
 		global $conf,$langs,$user,$object,$hookmanager;
-		global $form,$bc,$bcdd;
+		global $form,$bc,$bcdd, $object_rights;
+
+		$object_rights = $this->getRights();
 
 		$element=$this->element;
 
@@ -2821,7 +2821,7 @@ abstract class CommonObject
 		if (! empty($line->date_end)) $type=1; // deprecated
 
 		// Ligne en mode visu
-		if ($action != 'editline' || $selected != $line->id)
+		if ($action != 'editline' || $selected != $line->rowid)
 		{
 			// Product
 			if ($line->fk_product > 0)
@@ -2879,7 +2879,7 @@ abstract class CommonObject
 		}
 
 		// Ligne en mode update
-		if ($this->statut == 0 && $action == 'editline' && $selected == $line->id)
+		if ($this->statut == 0 && $action == 'editline' && $selected == $line->rowid)
 		{
 			$label = (! empty($line->label) ? $line->label : (($line->fk_product > 0) ? $line->product_label : ''));
 			if (! empty($conf->global->MAIN_HTML5_PLACEHOLDER)) $placeholder=' placeholder="'.$langs->trans("Label").'"';
@@ -3882,5 +3882,17 @@ abstract class CommonObject
 		}
 		return $out;
 	}
+
+	/**
+	 * Returns the rights used for this class
+	 * @return stdClass
+	 */
+	public function getRights()
+	{
+		global $user;
+
+		return $user->rights->{$this->element};
+	}
+
 
 }

--- a/htdocs/core/class/commonobjectline.class.php
+++ b/htdocs/core/class/commonobjectline.class.php
@@ -28,6 +28,19 @@
  */
 abstract class CommonObjectLine extends CommonObject
 {
+	/**
+	 * Id of the line
+	 * @var int
+	 * @deprecated Use $rowid
+	 */
+	public $id;
+
+	/**
+	 * Id of the line
+	 * @var int
+	 */
+	public $rowid;
+
 	// TODO
 
 	// Currently we need function at end of file CommonObject for all object lines. Should find a way to avoid duplicate code.

--- a/htdocs/core/class/commonobjectline.class.php
+++ b/htdocs/core/class/commonobjectline.class.php
@@ -31,13 +31,13 @@ abstract class CommonObjectLine extends CommonObject
 	/**
 	 * Id of the line
 	 * @var int
-	 * @deprecated Use $rowid
 	 */
 	public $id;
 
 	/**
 	 * Id of the line
 	 * @var int
+	 * @deprecated Try to use id property as possible
 	 */
 	public $rowid;
 

--- a/htdocs/core/class/commonorder.class.php
+++ b/htdocs/core/class/commonorder.class.php
@@ -22,6 +22,7 @@
  */
 
 require_once DOL_DOCUMENT_ROOT .'/core/class/commonobject.class.php';
+require_once DOL_DOCUMENT_ROOT .'/core/class/commonobjectline.class.php';
 
 /**
  *		\class 		CommonOrder
@@ -36,8 +37,141 @@ abstract class CommonOrder extends CommonObject
  *		\class 		CommonOrderLine
  *       \brief 		Superclass for orders classes
  */
-abstract class CommonOrderLine extends CommonObject
+abstract class CommonOrderLine extends CommonObjectLine
 {
+	/**
+	 * Product ref
+	 * @var string
+	 * @deprecated Use product_ref
+	 */
+	public $ref;
+
+	/**
+	 * Product ref
+	 * @var string
+	 */
+	public $product_ref;
+
+	/**
+	 * Product label
+	 * @var string
+	 * @deprecated Use product_label
+	 */
+	public $libelle;
+
+	/**
+	 * Product label
+	 * @var string
+	 */
+	public $product_label;
+
+	/**
+	 * Product description
+	 * @var string
+	 */
+	public $product_desc;
+
+	/**
+	 * Quantity
+	 * @var int
+	 */
+	public $qty;
+
+	/**
+	 * @deprecated
+	 */
+	var $price;
+
+	/**
+	 * Unit price before taxes
+	 * @var float
+	 */
+	public $subprice;
+
+	/**
+	 * Type of the product. 0 for product 1 for service
+	 * @var int
+	 */
+	public $product_type = 0;
+
+	/**
+	 * Description of the line
+	 * @var string
+	 */
+	public $desc;
+
+	/**
+	 * Id of corresponding product
+	 * @var int
+	 */
+	public $fk_product;
+
+	/**
+	 * Percent line discount
+	 * @var float
+	 */
+	public $remise_percent;
+
+	/**
+	 * VAT %
+	 * @var float
+	 */
+	public $tva_tx;
+
+	/**
+	 * Local tax 1 %
+	 * @var float
+	 */
+	public $localtax1_tx;
+
+	/**
+	 * Local tax 2 %
+	 * @var float
+	 */
+	public $localtax2_tx;
+
+	public $localtax1_type;
+	public $localtax2_type;
+
+	/**
+	 * Total amount before taxes
+	 * @var float
+	 */
+	public $total_ht;
+
+	/**
+	 * Total VAT amount
+	 * @var float
+	 */
+	public $total_tva;
+
+	/**
+	 * Total local tax 1 amount
+	 * @var float
+	 */
+	public $total_localtax1;
+
+	/**
+	 * Total local tax 2 amount
+	 * @var float
+	 */
+	public $total_localtax2;
+
+	/**
+	 * Total amount with taxes
+	 * @var float
+	 */
+	public $total_ttc;
+
+	/**
+	 * Liste d'options cumulables:
+	 * Bit 0:	0 si TVA normal - 1 si TVA NPR
+	 * Bit 1:	0 si ligne normal - 1 si bit discount (link to line into llx_remise_except)
+	 * @var int
+	 */
+	public $info_bits = 0;
+
+	public $special_code = 0;
 
 }
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3929,9 +3929,7 @@ function dol_htmlcleanlastbr($stringtodecode)
  */
 function dol_html_entity_decode($a,$b,$c='UTF-8')
 {
-	// We use @ to avoid warning on PHP4 that does not support entity decoding to UTF8;
-	$ret=@html_entity_decode($a,$b,$c);
-	return $ret;
+	return html_entity_decode($a,$b,$c);
 }
 
 /**

--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -286,7 +286,7 @@ else {
 			$newline = new CommandeFournisseurLigne($this->db);
 		}
 		elseif ($this->table_element_line=='facture_fourn_det') {
-			$newline = new FactureFournisseurLigne($this->db);
+			$newline = new SupplierInvoiceLine($this->db);
 		}
 		if (is_object($newline)) {
 			print $newline->showOptionals($extrafieldsline, 'edit', array('style'=>$bcnd[$var], 'colspan'=>$coldisplay+8));

--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -53,9 +53,9 @@ $coldisplay=-1; // We remove first td
 ?>
 <tr <?php echo $bc[$var]; ?>>
 	<td<?php echo (! empty($conf->global->MAIN_VIEW_LINE_NUMBER) ? ' colspan="2"' : ''); ?>><?php $coldisplay+=(! empty($conf->global->MAIN_VIEW_LINE_NUMBER))?2:1; ?>
-	<div id="line_<?php echo $line->id; ?>"></div>
+	<div id="line_<?php echo $line->rowid; ?>"></div>
 
-	<input type="hidden" name="lineid" value="<?php echo $line->id; ?>">
+	<input type="hidden" name="lineid" value="<?php echo $line->rowid; ?>">
 	<input type="hidden" id="product_type" name="type" value="<?php echo $line->product_type; ?>">
 	<input type="hidden" id="product_id" name="productid" value="<?php echo (! empty($line->fk_product)?$line->fk_product:0); ?>" />
 	<input type="hidden" id="special_code" name="special_code" value="<?php echo $line->special_code; ?>">

--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -53,9 +53,9 @@ $coldisplay=-1; // We remove first td
 ?>
 <tr <?php echo $bc[$var]; ?>>
 	<td<?php echo (! empty($conf->global->MAIN_VIEW_LINE_NUMBER) ? ' colspan="2"' : ''); ?>><?php $coldisplay+=(! empty($conf->global->MAIN_VIEW_LINE_NUMBER))?2:1; ?>
-	<div id="line_<?php echo $line->rowid; ?>"></div>
+	<div id="line_<?php echo $line->id; ?>"></div>
 
-	<input type="hidden" name="lineid" value="<?php echo $line->rowid; ?>">
+	<input type="hidden" name="lineid" value="<?php echo $line->id; ?>">
 	<input type="hidden" id="product_type" name="type" value="<?php echo $line->product_type; ?>">
 	<input type="hidden" id="product_id" name="productid" value="<?php echo (! empty($line->fk_product)?$line->fk_product:0); ?>" />
 	<input type="hidden" id="special_code" name="special_code" value="<?php echo $line->special_code; ?>">

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -48,11 +48,11 @@ if (empty($usemargins)) $usemargins=0;
 ?>
 <?php $coldisplay=0; ?>
 <!-- BEGIN PHP TEMPLATE objectline_view.tpl.php -->
-<tr <?php echo 'id="row-'.$line->rowid.'" '.$bcdd[$var]; ?>>
+<tr <?php echo 'id="row-'.$line->id.'" '.$bcdd[$var]; ?>>
 	<?php if (! empty($conf->global->MAIN_VIEW_LINE_NUMBER)) { ?>
 	<td align="center"><?php $coldisplay++; ?><?php echo ($i+1); ?></td>
 	<?php } ?>
-	<td><?php $coldisplay++; ?><div id="line_<?php echo $line->rowid; ?>"></div>
+	<td><?php $coldisplay++; ?><div id="line_<?php echo $line->id; ?>"></div>
 	<?php if (($line->info_bits & 2) == 2) { ?>
 		<a href="<?php echo DOL_URL_ROOT.'/comm/remx.php?id='.$this->socid; ?>">
 		<?php
@@ -183,7 +183,7 @@ if (empty($usemargins)) $usemargins=0;
 	<td align="center"><?php $coldisplay++; ?>
 		<?php if (($line->info_bits & 2) == 2) { ?>
 		<?php } else { ?>
-		<a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=editline&amp;lineid='.$line->rowid.'#line_'.$line->rowid; ?>">
+		<a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=editline&amp;lineid='.$line->id.'#line_'.$line->id; ?>">
 		<?php echo img_edit(); ?>
 		</a>
 		<?php } ?>
@@ -192,7 +192,7 @@ if (empty($usemargins)) $usemargins=0;
 	<td align="center"><?php $coldisplay++; ?>
 		<?php
 		if ($this->situation_counter == 1 || !$this->situation_cycle_ref) {
-			print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $this->id . '&amp;action=ask_deleteline&amp;lineid=' . $line->rowid . '">';
+			print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $this->id . '&amp;action=ask_deleteline&amp;lineid=' . $line->id . '">';
 			print img_delete();
 			print '</a>';
 		}
@@ -202,12 +202,12 @@ if (empty($usemargins)) $usemargins=0;
 	<?php if ($num > 1 && empty($conf->browser->phone) && ($this->situation_counter == 1 || !$this->situation_cycle_ref)) { ?>
 	<td align="center" class="tdlineupdown"><?php $coldisplay++; ?>
 		<?php if ($i > 0) { ?>
-		<a class="lineupdown" href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=up&amp;rowid='.$line->rowid; ?>">
+		<a class="lineupdown" href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=up&amp;rowid='.$line->id; ?>">
 		<?php echo img_up('default',0,'imgupforline'); ?>
 		</a>
 		<?php } ?>
 		<?php if ($i < $num-1) { ?>
-		<a class="lineupdown" href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=down&amp;rowid='.$line->rowid; ?>">
+		<a class="lineupdown" href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=down&amp;rowid='.$line->id; ?>">
 		<?php echo img_down('default',0,'imgdownforline'); ?>
 		</a>
 		<?php } ?>

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -48,11 +48,11 @@ if (empty($usemargins)) $usemargins=0;
 ?>
 <?php $coldisplay=0; ?>
 <!-- BEGIN PHP TEMPLATE objectline_view.tpl.php -->
-<tr <?php echo 'id="row-'.$line->id.'" '.$bcdd[$var]; ?>>
+<tr <?php echo 'id="row-'.$line->rowid.'" '.$bcdd[$var]; ?>>
 	<?php if (! empty($conf->global->MAIN_VIEW_LINE_NUMBER)) { ?>
 	<td align="center"><?php $coldisplay++; ?><?php echo ($i+1); ?></td>
 	<?php } ?>
-	<td><?php $coldisplay++; ?><div id="line_<?php echo $line->id; ?>"></div>
+	<td><?php $coldisplay++; ?><div id="line_<?php echo $line->rowid; ?>"></div>
 	<?php if (($line->info_bits & 2) == 2) { ?>
 		<a href="<?php echo DOL_URL_ROOT.'/comm/remx.php?id='.$this->socid; ?>">
 		<?php
@@ -128,7 +128,7 @@ if (empty($usemargins)) $usemargins=0;
 	<?php } ?>
 	<td align="right" class="nowrap"><?php $coldisplay++; ?><?php echo vatrate($line->tva_tx,'%',$line->info_bits); ?></td>
 
-	<td align="right" class="nowrap"><?php $coldisplay++; ?><?php echo (isset($line->pu_ht)?price($line->pu_ht):price($line->subprice)); ?></td>
+	<td align="right" class="nowrap"><?php $coldisplay++; ?><?php echo price($line->pu_ht); ?></td>
 
 	<?php if ($inputalsopricewithtax) { ?>
 	<td align="right" class="nowrap"><?php $coldisplay++; ?><?php echo (isset($line->pu_ttc)?price($line->pu_ttc):price($line->subprice)); ?></td>
@@ -179,11 +179,11 @@ if (empty($usemargins)) $usemargins=0;
 	<td align="right" class="nowrap"><?php $coldisplay++; ?><?php echo price($line->total_ht); ?></td>
 	<?php } ?>
 
-	<?php if ($this->statut == 0  && ($user->rights->$element->creer || $permtoedit)) { ?>
+	<?php if ($this->statut == 0  && ($object_rights->creer)) { ?>
 	<td align="center"><?php $coldisplay++; ?>
 		<?php if (($line->info_bits & 2) == 2) { ?>
 		<?php } else { ?>
-		<a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=editline&amp;lineid='.$line->id.'#line_'.$line->id; ?>">
+		<a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=editline&amp;lineid='.$line->rowid.'#line_'.$line->rowid; ?>">
 		<?php echo img_edit(); ?>
 		</a>
 		<?php } ?>
@@ -192,7 +192,7 @@ if (empty($usemargins)) $usemargins=0;
 	<td align="center"><?php $coldisplay++; ?>
 		<?php
 		if ($this->situation_counter == 1 || !$this->situation_cycle_ref) {
-			print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $this->id . '&amp;action=ask_deleteline&amp;lineid=' . $line->id . '">';
+			print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $this->id . '&amp;action=ask_deleteline&amp;lineid=' . $line->rowid . '">';
 			print img_delete();
 			print '</a>';
 		}
@@ -202,12 +202,12 @@ if (empty($usemargins)) $usemargins=0;
 	<?php if ($num > 1 && empty($conf->browser->phone) && ($this->situation_counter == 1 || !$this->situation_cycle_ref)) { ?>
 	<td align="center" class="tdlineupdown"><?php $coldisplay++; ?>
 		<?php if ($i > 0) { ?>
-		<a class="lineupdown" href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=up&amp;rowid='.$line->id; ?>">
+		<a class="lineupdown" href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=up&amp;rowid='.$line->rowid; ?>">
 		<?php echo img_up('default',0,'imgupforline'); ?>
 		</a>
 		<?php } ?>
 		<?php if ($i < $num-1) { ?>
-		<a class="lineupdown" href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=down&amp;rowid='.$line->id; ?>">
+		<a class="lineupdown" href="<?php echo $_SERVER["PHP_SELF"].'?id='.$this->id.'&amp;action=down&amp;rowid='.$line->rowid; ?>">
 		<?php echo img_down('default',0,'imgdownforline'); ?>
 		</a>
 		<?php } ?>

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -1022,7 +1022,6 @@ class FichinterLigne extends CommonObjectLine
 	var $error;
 
 	// From llx_fichinterdet
-	var $rowid;
 	var $fk_fichinter;
 	var $desc;          	// Description ligne
 	var $datei;           // Date intervention

--- a/htdocs/filefunc.inc.php
+++ b/htdocs/filefunc.inc.php
@@ -83,7 +83,6 @@ if (! empty($dolibarr_strict_mode))
 }
 else
 {
-	if (! defined('E_DEPRECATED')) define('E_DEPRECATED',0);	// For PHP < 5.3.0 compatibility
 	error_reporting(E_ALL & ~(E_STRICT|E_NOTICE|E_DEPRECATED));
 }
 

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -93,13 +93,16 @@ class CommandeFournisseur extends CommonOrder
 	
     var $extraparams=array();
 
+	/**
+	 * @var CommandeFournisseurLigne[]
+	 */
+	public $lines = array();
 	//Ajout pour askpricesupplier
 	var $origin;
     var $origin_id;
     var $linked_objects=array();
-    var $lines = array();
 
-    /**
+	/**
      * 	Constructor
      *
      *  @param      DoliDB		$db      Database handler
@@ -110,7 +113,6 @@ class CommandeFournisseur extends CommonOrder
     	
         $this->db = $db;
         $this->products = array();
-        $this->lines = array();
 
         // List of language codes for status
         $this->statuts[0] = 'StatusOrderDraft';
@@ -258,14 +260,15 @@ class CommandeFournisseur extends CommonOrder
                     $line                 = new CommandeFournisseurLigne($this->db);
 
                     $line->id                  = $objp->rowid;
-                    $line->desc                = $objp->description;  // Description ligne
-                    $line->description         = $objp->description;  // Description ligne
+                    $line->rowid               = $objp->rowid;
+                    $line->desc                = $objp->description;
+                    $line->description         = $objp->description;
                     $line->qty                 = $objp->qty;
                     $line->tva_tx              = $objp->tva_tx;
                     $line->localtax1_tx		   = $objp->localtax1_tx;
                     $line->localtax2_tx		   = $objp->localtax2_tx;
-                    $line->subprice            = $objp->subprice;	  // deprecated
-                    $line->pu_ht	           = $objp->subprice;	  // Unit price HT
+                    $line->subprice            = $objp->subprice;
+                    $line->pu_ht	           = $objp->subprice;
                     $line->remise_percent      = $objp->remise_percent;
                     $line->total_ht            = $objp->total_ht;
                     $line->total_tva           = $objp->total_tva;
@@ -274,16 +277,16 @@ class CommandeFournisseur extends CommonOrder
                     $line->total_ttc           = $objp->total_ttc;
                     $line->product_type        = $objp->product_type;
 
-                    $line->fk_product          = $objp->fk_product;    // Id du produit
+                    $line->fk_product          = $objp->fk_product;
 
-                    $line->libelle             = $objp->product_label; // TODO deprecated
-                    $line->product_label       = $objp->product_label; // Label produit
-                    $line->product_desc        = $objp->product_desc;  // Description produit
+                    $line->libelle             = $objp->product_label;
+                    $line->product_label       = $objp->product_label;
+                    $line->product_desc        = $objp->product_desc;
 
-                    $line->ref                 = $objp->product_ref;     // TODO deprecated
-                    $line->product_ref         = $objp->product_ref;     // Internal reference
-                    $line->ref_fourn           = $objp->ref_supplier;    // TODO deprecated
-                    $line->ref_supplier        = $objp->ref_supplier;    // Reference supplier
+                    $line->ref                 = $objp->product_ref;
+                    $line->product_ref         = $objp->product_ref;
+                    $line->ref_fourn           = $objp->ref_supplier;
+                    $line->ref_supplier        = $objp->ref_supplier;
 
                     $line->date_start          = $this->db->jdate($objp->date_start);
                     $line->date_end            = $this->db->jdate($objp->date_end);
@@ -1621,7 +1624,6 @@ class CommandeFournisseur extends CommonOrder
         }
     }
 
-    
     /**
 	 * Return array of dispathed lines waiting to be approved for this order
 	 * 
@@ -2326,6 +2328,18 @@ class CommandeFournisseur extends CommonOrder
 		if ($nb === 0) return $langs->trans('Undefined');
 		else return $nb.' '.$langs->trans('Days');
 	}
+
+	/**
+	 * Returns the rights used for this class
+	 * @return stdClass
+	 */
+	public function getRights()
+	{
+		global $user;
+
+		return $user->rights->fournisseur->commande;
+	}
+
 }
 
 
@@ -2335,42 +2349,32 @@ class CommandeFournisseur extends CommonOrder
  */
 class CommandeFournisseurLigne extends CommonOrderLine
 {
-    var $db;
-    var $error;
-
 	public $element='commande_fournisseurdet';
 	public $table_element='commande_fournisseurdet';
+	
+	/**
+	 * Unit price without taxes
+	 * @var float
+	 */
+	public $pu_ht;
 
-    var $oldline;
-
-    // From llx_commandedet
-    var $qty;
-    var $tva_tx;
-    var $localtax1_tx;
-    var $localtax2_tx;
-    var $localtax1_type;
-    var $localtax2_type;
-    var $subprice;
-    var $remise_percent;
-    var $desc;          	// Description ligne
-    var $fk_product;		// Id of predefined product
-    var $product_type = 0;	// Type 0 = product, 1 = Service
-    var $total_ht;
-    var $total_tva;
-    var $total_localtax1;
-    var $total_localtax2;
-    var $total_ttc;
-    var $info_bits;
-    var $special_code;
-    var $date_start;
+	var $date_start;
     var $date_end;
 
-    // From llx_product
-    var $libelle;       // Label produit
-    var $product_desc;  // Description produit
-
     // From llx_product_fournisseur_price
-    var $ref_fourn;     // Ref supplier
+
+	/**
+	 * Supplier ref
+	 * @var string
+	 * @deprecated Use ref_supplier
+	 */
+	public $ref_fourn;
+
+	/**
+	 * Supplier reference
+	 * @var string
+	 */
+	public $ref_supplier;
 
 
     /**
@@ -2430,7 +2434,7 @@ class CommandeFournisseurLigne extends CommonOrderLine
 
             $this->date_start       = $this->db->jdate($objp->date_start);
             $this->date_end         = $this->db->jdate($objp->date_end);
-			
+
             $this->db->free($result);
             return 1;
         }

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -260,7 +260,6 @@ class CommandeFournisseur extends CommonOrder
                     $line                 = new CommandeFournisseurLigne($this->db);
 
                     $line->id                  = $objp->rowid;
-                    $line->rowid               = $objp->rowid;
                     $line->desc                = $objp->description;
                     $line->description         = $objp->description;
                     $line->qty                 = $objp->qty;

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -89,9 +89,12 @@ class FactureFournisseur extends CommonInvoice
     var $mode_reglement_id;
     var $mode_reglement_code;
 
-    var $lines;
+	/**
+	 * Invoice lines
+	 * @var SupplierInvoiceLine[]
+	 */
+    public $lines = array();
     var $fournisseur;	// deprecated
-	var $thirdparty;	// To store thirdparty
 
 	//Incorterms
 	var $fk_incoterms;
@@ -99,31 +102,6 @@ class FactureFournisseur extends CommonInvoice
 	var $libelle_incoterms;  //Used into tooltip
 	
     var $extraparams=array();
-
-    /**
-     * Standard invoice
-     */
-    const TYPE_STANDARD = 0;
-
-    /**
-     * Replacement invoice
-     */
-    const TYPE_REPLACEMENT = 1;
-
-    /**
-     * Credit note invoice
-     */
-    const TYPE_CREDIT_NOTE = 2;
-
-    /**
-     * Deposit invoice
-     */
-    const TYPE_DEPOSIT = 3;
-
-    /**
-     * Proforma invoice
-     */
-    const TYPE_PROFORMA = 4;
 
     /**
 	 *	Constructor
@@ -145,7 +123,6 @@ class FactureFournisseur extends CommonInvoice
         $this->propalid = 0;
 
         $this->products = array();
-        $this->lines = array();
     }
 
     /**
@@ -496,7 +473,7 @@ class FactureFournisseur extends CommonInvoice
      */
     function fetch_lines()
     {
-        $sql = 'SELECT f.rowid, f.ref as ref_supplier, f.description, f.pu_ht, f.pu_ttc, f.qty, f.remise_percent, f.tva_tx, f.tva';
+        $sql = 'SELECT f.rowid, f.ref as ref_supplier, f.description, f.pu_ht, f.pu_ttc, f.qty, f.remise_percent, f.tva_tx';
         $sql.= ', f.localtax1_tx, f.localtax2_tx, f.total_localtax1, f.total_localtax2 ';
         $sql.= ', f.total_ht, f.tva as total_tva, f.total_ttc, f.fk_product, f.product_type, f.info_bits, f.rang, f.special_code, f.fk_parent_line';
         $sql.= ', p.rowid as product_id, p.ref as product_ref, p.label as label, p.description as product_desc';
@@ -517,7 +494,7 @@ class FactureFournisseur extends CommonInvoice
                 {
                     $obj = $this->db->fetch_object($resql_rows);
 
-                    $this->lines[$i]					= new FactureFournisseurLigne($this->db);
+                    $this->lines[$i]					= new SupplierInvoiceLine($this->db);
 
                     $this->lines[$i]->id				= $obj->rowid;
                     $this->lines[$i]->rowid				= $obj->rowid;
@@ -527,6 +504,7 @@ class FactureFournisseur extends CommonInvoice
                     $this->lines[$i]->ref_supplier		= $obj->ref_supplier;      // Reference product supplier TODO Rename field ref to ref_supplier into table llx_facture_fourn_det and llx_commande_fournisseurdet and update fields it into updateline
                     $this->lines[$i]->libelle			= $obj->label;             // This field may contains label of product (when invoice create from order)
                     $this->lines[$i]->product_desc		= $obj->product_desc;      // Description du produit
+                    $this->lines[$i]->subprice			= $obj->pu_ht;
                     $this->lines[$i]->pu_ht				= $obj->pu_ht;
                     $this->lines[$i]->pu_ttc			= $obj->pu_ttc;
                     $this->lines[$i]->tva_tx			= $obj->tva_tx;
@@ -534,7 +512,7 @@ class FactureFournisseur extends CommonInvoice
                     $this->lines[$i]->localtax2_tx		= $obj->localtax2_tx;
                     $this->lines[$i]->qty				= $obj->qty;
                     $this->lines[$i]->remise_percent    = $obj->remise_percent;
-                    $this->lines[$i]->tva				= $obj->tva;
+                    $this->lines[$i]->tva				= $obj->total_tva;
                     $this->lines[$i]->total_ht			= $obj->total_ht;
                     $this->lines[$i]->total_tva			= $obj->total_tva;
                     $this->lines[$i]->total_localtax1	= $obj->total_localtax1;
@@ -1313,7 +1291,7 @@ class FactureFournisseur extends CommonInvoice
 
         	if (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED)) // For avoid conflicts if trigger used
 			{
-				$linetmp = new FactureFournisseurLigne($this->db);
+				$linetmp = new SupplierInvoiceLine($this->db);
 				$linetmp->id=$this->rowid;
 				$linetmp->array_options = $array_options;
 				$result=$linetmp->insertExtraFields();
@@ -1858,6 +1836,18 @@ class FactureFournisseur extends CommonInvoice
 		return $this->commonGenerateDocument($modelpath, $modele, $outputlangs, $hidedetails, $hidedesc, $hideref);
 	}
 
+	/**
+	 * Returns the rights used for this class
+	 * @return stdClass
+	 */
+	public function getRights()
+	{
+		global $user;
+
+		return $user->rights->fournisseur->facture;
+	}
+
+
 }
 
 
@@ -1865,20 +1855,70 @@ class FactureFournisseur extends CommonInvoice
 /**
  *  Class to manage line invoices
  */
-class FactureFournisseurLigne extends CommonInvoice
+class SupplierInvoiceLine extends CommonInvoice
 {
-    var $db;
-    var $error;
-
-    var $pu_ht;
-    var $pu_ttc;
-
 	public $element='facture_fourn_det';
 	public $table_element='facture_fourn_det';
 
-    var $oldline;
+	var $oldline;
 
-    /**
+	public $ref;
+	public $product_ref;
+	public $ref_supplier;
+	public $libelle;
+	public $product_desc;
+
+	/**
+	 * Unit price before taxes
+	 * @var float
+	 * @deprecated Use $subprice
+	 */
+	public $pu_ht;
+
+	/**
+	 * Unit price included taxes
+	 * @var float
+	 */
+	public $pu_ttc;
+
+	/**
+	 * Total VAT amount
+	 * @var float
+	 * @deprecated Use $total_tva instead
+	 */
+	public $tva;
+
+	/**
+	 * Id of the corresponding supplier invoice
+	 * @var int
+	 */
+	var $fk_facture_fourn;
+
+	/**
+	 * Product label
+	 * @var string
+	 */
+	var $label;				// deprecated
+
+	/**
+	 * Description of the line
+	 * @var string
+	 */
+	var $description;
+
+	var $skip_update_total; // Skip update price total for special lines
+
+	/**
+	 * @var int Situation advance percentage
+	 */
+	public $situation_percent;
+
+	/**
+	 * @var int Previous situation line id reference
+	 */
+	public $fk_prev_id;
+
+	/**
      *	Constructor
      *
      *  @param		DoliDB		$db      Database handler

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2015,7 +2015,7 @@ elseif (! empty($object->id))
 	// Show object lines
 	$inputalsopricewithtax=0;
 	if (! empty($object->lines))
-		$ret = $object->printObjectLines($action, $soc, $mysoc, $lineid, 1, $user->rights->fournisseur->commande->creer);
+		$ret = $object->printObjectLines($action, $soc, $mysoc, $lineid, 1);
 
 	$num = count($object->lines);
 

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2092,7 +2092,7 @@ else
 
 		// Show object lines
 		if (! empty($object->lines))
-			$ret = $object->printObjectLines($action, $soc, $mysoc, $lineid, 1, $user->rights->fournisseur->facture->creer);
+			$ret = $object->printObjectLines($action, $soc, $mysoc, $lineid, 1);
 
 		$num=count($object->lines);
 

--- a/htdocs/margin/admin/margin.php
+++ b/htdocs/margin/admin/margin.php
@@ -72,7 +72,6 @@ if ($action == 'remises')
 {
     if (dolibarr_set_const($db, 'MARGIN_METHODE_FOR_DISCOUNT', $_POST['MARGIN_METHODE_FOR_DISCOUNT'], 'chaine', 0, '', $conf->entity) > 0)
     {
-          $conf->global->MARGIN_METHODE_FOR_DISCOUNT = $_POST['MARGIN_METHODE_FOR_DISCOUNT'];
           setEventMessage($langs->trans("RecordModifiedSuccessfully"));
     }
     else
@@ -85,7 +84,6 @@ if ($action == 'typemarges')
 {
     if (dolibarr_set_const($db, 'MARGIN_TYPE', $_POST['MARGIN_TYPE'], 'chaine', 0, '', $conf->entity) > 0)
     {
-          $conf->global->MARGIN_METHODE_FOR_DISCOUNT = $_POST['MARGIN_TYPE'];
           setEventMessage($langs->trans("RecordModifiedSuccessfully"));
     }
     else
@@ -98,7 +96,6 @@ if ($action == 'contact')
 {
     if (dolibarr_set_const($db, 'AGENT_CONTACT_TYPE', $_POST['AGENT_CONTACT_TYPE'], 'chaine', 0, '', $conf->entity) > 0)
     {
-          $conf->global->AGENT_CONTACT_TYPE = $_POST['AGENT_CONTACT_TYPE'];
           setEventMessage($langs->trans("RecordModifiedSuccessfully"));
     }
     else

--- a/htdocs/projet/admin/project.php
+++ b/htdocs/projet/admin/project.php
@@ -237,12 +237,7 @@ if ($action == 'deltask')
 // Set default model
 else if ($action == 'setdoc')
 {
-	if (dolibarr_set_const($db, "PROJECT_ADDON_PDF",$value,'chaine',0,'',$conf->entity))
-	{
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
-		$conf->global->PROJECT_ADDON_PDF = $value;
-	}
+	dolibarr_set_const($db, "PROJECT_ADDON_PDF",$value,'chaine',0,'',$conf->entity);
 
 	// On active le modele
 	$ret = delDocumentModel($value, $type);

--- a/htdocs/societe/admin/societe.php
+++ b/htdocs/societe/admin/societe.php
@@ -165,10 +165,7 @@ if ($action == 'setdoc')
 
 	$db->begin();
 
-	if (dolibarr_set_const($db, "COMPANY_ADDON_PDF",$value,'chaine',0,'',$conf->entity))
-	{
-		$conf->global->COMPANY_ADDON_PDF = $value;
-	}
+	dolibarr_set_const($db, "COMPANY_ADDON_PDF",$value,'chaine',0,'',$conf->entity);
 
 	// On active le modele
 	$type='company';


### PR DESCRIPTION
PR is the same as #2456 but using $id instead of $rowid.
## 

I was initially refactoring supplier invoice and supplier order cards until I realized that @eldy was doing the same... I compared the changes and there are some things that I like more how I implemented them...

Like using CommonObject::getRights() instead of a global variable $permtoedit. This way we are able to change the way common module is called without changing the code. There is a CommonObject function and a FactureFournisseur and CommandeFournisseur one.

I also renamed FactureFournisseurLigne to SupplierInvoiceLine because being a new class it does not make sense to still use French naming.
