### PR TITLE
Fix displaying of the warning image.

### DIFF
--- a/htdocs/commande/liste.php
+++ b/htdocs/commande/liste.php
@@ -341,7 +341,7 @@ if ($resql)
 		print '</td>';
 
 		print '<td style="min-width: 20px" class="nobordernopadding nowrap">';
-		if (($objp->fk_statut > 0) && ($objp->fk_statut < 3) && max($db->jdate($objp->date_commande),$db->jdate($objp->date_livraison)) < ($now - $conf->commande->client->warning_delay))
+		if (($objp->fk_statut > 0) && ($objp->fk_statut < 3) && max($db->jdate($objp->date_commande),$db->jdate($objp->date_delivery)) < ($now - $conf->commande->client->warning_delay))
 			print img_picto($langs->trans("Late"),"warning");
 		if(!empty($objp->note_private))
 		{


### PR DESCRIPTION
Since last commit, $objp->date_livraison returns nothing ; max() will
then returns wrong result, and the warning image will be displayed when it
should not.
