### PR TITLE
Fixed Check if $mc is a valid global

### DIFF
--- a/htdocs/core/login/functions_dolibarr.php
+++ b/htdocs/core/login/functions_dolibarr.php
@@ -111,15 +111,22 @@ function check_user_password_dolibarr($usertotest,$passwordtotest,$entitytotest=
 					$_SESSION["dol_loginmesg"]=$langs->trans("ErrorBadLoginPassword");
 				}
 
-				if ($passok && ! empty($conf->multicompany->enabled))	// We must check entity
+				// We must check entity
+				if ($passok)
 				{
 					global $mc;
 
-					$ret=$mc->checkRight($obj->rowid, $entitytotest);
-					if ($ret < 0)
-					{
-						dol_syslog("functions_dolibarr::check_user_password_dolibarr Authentification ko entity '".$entitytotest."' not allowed for user '".$obj->rowid."'");
-						$login=''; // force authentication failure
+					if (!isset($mc)) {
+						//Global not available, disable $conf->multicompany->enabled for safety
+						$conf->multicompany->enabled = false;
+					}
+
+					if (! empty($conf->multicompany->enabled)) {
+						$ret = $mc->checkRight($obj->rowid, $entitytotest);
+						if ($ret < 0) {
+							dol_syslog("functions_dolibarr::check_user_password_dolibarr Authentification ko entity '" . $entitytotest . "' not allowed for user '" . $obj->rowid . "'");
+							$login = ''; // force authentication failure
+						}
 					}
 				}
 			}


### PR DESCRIPTION
If you enable multicompany module and then delete the module folder the $conf->multicompany->enabled is still valid, login will be blocked because of calling $mc->checkRight() from a null $mc global
