### PR TITLE
FIX [ bug #1913 ] [EXPORT] [PGSQL] Bug when filtering export on a specific year

### DIFF
--- a/htdocs/exports/class/export.class.php
+++ b/htdocs/exports/class/export.class.php
@@ -328,7 +328,7 @@ class Export
 	function conditionDate($Field, $Value, $Sens)
 	{
 		// TODO date_format is forbidden, not performant and not portable. Use instead BETWEEN
-		if (strlen($Value)==4) $Condition=" date_format(".$Field.",'%Y') ".$Sens." ".$Value;
+		if (strlen($Value)==4) $Condition=" date_format(".$Field.",'%Y') ".$Sens." '".$Value."'";
 		elseif (strlen($Value)==6) $Condition=" date_format(".$Field.",'%Y%m') ".$Sens." '".$Value."'";
 		else  $Condition=" date_format(".$Field.",'%Y%m%d') ".$Sens." ".$Value;
 		return $Condition;


### PR DESCRIPTION
PgSql date_format function (created by dolibarr) get text as return format. PgSql is type sensive, Compare text with text, not text with int. Without quote $Value is understand as interger and date_format cannot do compare function. MySql is more permisive on this feature. 
