### PR TITLE
Fix : shipment model selection

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -164,8 +164,6 @@ class Expedition extends CommonObject
 
 		$now=dol_now();
 
-		if (empty($this->model_pdf)) $this->model_pdf=$conf->global->EXPEDITION_ADDON_PDF;
-
 		require_once DOL_DOCUMENT_ROOT .'/product/stock/class/mouvementstock.class.php';
 		$error = 0;
 

--- a/htdocs/expedition/fiche.php
+++ b/htdocs/expedition/fiche.php
@@ -113,6 +113,7 @@ if ($action == 'add')
 
     $object->socid					= $objectsrc->socid;
     $object->ref_customer			= $objectsrc->ref_client;
+	$object->model_pdf				= GETPOST('model');
     $object->date_delivery			= $date_delivery;	// Date delivery planed
     $object->fk_delivery_address	= $objectsrc->fk_delivery_address;
     $object->shipping_method_id		= GETPOST('shipping_method_id','int');
@@ -661,6 +662,14 @@ if ($action == 'create')
             print "<tr><td>".$langs->trans("TrackingNumber")."</td>";
             print '<td colspan="3">';
             print '<input name="tracking_number" size="20" value="'.GETPOST('tracking_number','alpha').'">';
+            print "</td></tr>\n";
+            
+            // Document model
+            print "<tr><td>".$langs->trans("Model")."</td>";
+            print '<td colspan="3">';
+			include_once DOL_DOCUMENT_ROOT . '/core/modules/expedition/modules_expedition.php';
+			$liste = ModelePdfExpedition::liste_modeles($db);
+			print $form->selectarray('model', $liste, $conf->global->EXPEDITION_ADDON_PDF);
             print "</td></tr>\n";
 
             // Other attributes


### PR DESCRIPTION
If ODT template was selected as default document, shipment validation produces an error because wrong model name was used to generate document. Now model is selected directly while creating the shipment
