### PR TITLE
Remove useless variables for common object

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -91,11 +91,10 @@ abstract class CommonObject
      */
     public $canvas;
 
-
-    public $name;
-    public $lastname;
-    public $firstname;
-    public $civility_id;
+    /**
+     *
+     * @var object      Thirdparty associated with object
+     */
     public $thirdparty;
 
     // No constructor as it is an abstract class


### PR DESCRIPTION
Fields name / civility / ... are nonsense for a lot of objects into Dolibarr.
They could be defined for each object instead of into the common object class.
This for the API which exposes a property civility for a category :\
