### PR TITLE
Added missing translation of categories' "Translation" tab

### DIFF
--- a/htdocs/core/lib/categories.lib.php
+++ b/htdocs/core/lib/categories.lib.php
@@ -34,6 +34,7 @@ function categories_prepare_head($object,$type)
 	global $langs, $conf, $user;
 
 	$langs->load("categories");
+	$langs->load("products");
 
 	$h = 0;
 	$head = array();


### PR DESCRIPTION
Fix #2769
