### PR TITLE
Change low level access verification to a better high level one

### DIFF
--- a/htdocs/public/test/test_arrays.php
+++ b/htdocs/public/test/test_arrays.php
@@ -2,15 +2,11 @@
 //define("NOLOGIN",1);		// This means this output page does not require to be logged.
 define("NOCSRFCHECK",1);	// We accept to go on this page from external web site.
 
-
 require '../../main.inc.php';
 
-if ($_SERVER['REMOTE_ADDR'] != '127.0.0.1')
-{
-	print "Page available only from remote address 127.0.0.1";
-	exit;
+if ($dolibarr_main_prod) {
+	accessforbidden();
 }
-
 
 $usedolheader=1;	// 1 = Test inside a dolibarr page, 0 = Use hard coded header
 

--- a/htdocs/public/test/test_forms.php
+++ b/htdocs/public/test/test_forms.php
@@ -6,12 +6,9 @@ define('REQUIRE_JQUERY_MULTISELECT','select2');
 require '../../main.inc.php';
 include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 
-if ($_SERVER['REMOTE_ADDR'] != '127.0.0.1')
-{
-	print "Page available only from remote address 127.0.0.1";
-	exit;
+if ($dolibarr_main_prod) {
+	accessforbidden();
 }
-
 
 llxHeader();
 


### PR DESCRIPTION
I found the test to be silly: not everyone uses local IPv4 for development.
Better rely on the production setting and refuse access on production systems.
