### PR TITLE
FIX #2758 Product::update sets product note to "null" when $prod->note is null

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ Fix: [ bug #1905 ] Custom deplacement types do not get translated in deplacement
 Fix: [ bug #2583 ] Unable to create a bank transfer with localized numbers
 Fix: [ bug #2577 ] Incorrect invoice status in "Linked objects" page of a project
 Fix: [ bug #2576 ] Unable to edit a dictionary entry that has # in its ref
+Fix: [ bug #2758 ] Product::update sets product note to "null" when $prod->note is null
 
 ***** ChangeLog for 3.5.6 compared to 3.5.5 *****
 Fix: Avoid missing class error for fetch_thirdparty method #1973

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -442,7 +442,7 @@ class Product extends CommonObject
 		$this->ref = dol_string_nospecial(trim($this->ref));
 		$this->libelle = trim($this->libelle);
 		$this->description = trim($this->description);
-		$this->note = (isset($this->note)? trim($this->note):"null");
+		$this->note = (isset($this->note)? trim($this->note):null);
 		$this->weight = price2num($this->weight);
 		$this->weight_units = trim($this->weight_units);
 		$this->length = price2num($this->length);
@@ -493,7 +493,7 @@ class Product extends CommonObject
 		$sql.= ", accountancy_code_sell= '" . $this->accountancy_code_sell."'";
 		$sql.= ", desiredstock = " . ((isset($this->desiredstock) && $this->desiredstock != '') ? $this->desiredstock : "null");
 		$sql.= " WHERE rowid = " . $id;
-
+var_dump($sql);die;
 		dol_syslog(get_class($this)."update sql=".$sql);
 		$resql=$this->db->query($sql);
 		if ($resql)

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -493,7 +493,7 @@ class Product extends CommonObject
 		$sql.= ", accountancy_code_sell= '" . $this->accountancy_code_sell."'";
 		$sql.= ", desiredstock = " . ((isset($this->desiredstock) && $this->desiredstock != '') ? $this->desiredstock : "null");
 		$sql.= " WHERE rowid = " . $id;
-var_dump($sql);die;
+
 		dol_syslog(get_class($this)."update sql=".$sql);
 		$resql=$this->db->query($sql);
 		if ($resql)


### PR DESCRIPTION
FIX #2758 Product::update sets product note to "null" when $prod->note is null

Build failure has nothing to do with this PR
