### PR TITLE
Provide NotFound and Error return values

### DIFF
--- a/htdocs/asterisk/cidlookup.php
+++ b/htdocs/asterisk/cidlookup.php
@@ -32,7 +32,8 @@
 include '../master.inc.php';
 
 $phone = GETPOST('phone');
-
+$notfound = "Not found";
+$error = "Error"
 
 // Security check
 if (empty($conf->clicktodial->enabled)) {
@@ -64,13 +65,15 @@ if ($resql)
 	if ($obj)
 	{
 		$found = $obj->name;
+	} else {
+		$found = $notfound;
 	}
 	$db->free($resql);
 }
 else
 {
 	dol_print_error($db,'Error');
+	$found = $error;
 }
 
 echo $found;
-


### PR DESCRIPTION
Providing a Not Found Message when a Third Party entity is not found to match with details provided, and providing an Error Message when the SQL Lookup fails.

This will help Asterisk Users determine whether the CallerID would be usable from Dolibarr or to reject and continue with existing CID from Asterisk
