### PR TITLE
Insert option to use old system storage photos only if the first installation was done with a version < 3.7.0

### DIFF
--- a/htdocs/install/mysql/migration/3.6.0-3.7.0.sql
+++ b/htdocs/install/mysql/migration/3.6.0-3.7.0.sql
@@ -1181,4 +1181,4 @@ insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,localtax1,localtax1_typ
 
 ALTER TABLE llx_livraison MODIFY COLUMN date_delivery DATETIME NULL DEFAULT NULL;
 
-INSERT INTO llx_const (name, value, type, note, visible, entity) values ('PRODUCT_USE_OLD_PATH_FOR_PHOTO','1','chaine','Use old path for products images',1,1);
+INSERT INTO llx_const (name, value, type, note, visible, entity) SELECT 'PRODUCT_USE_OLD_PATH_FOR_PHOTO','1','chaine','Use old path for products images',0,1 FROM llx_const WHERE name='MAIN_VERSION_LAST_INSTALL' AND value < '3.7.0';


### PR DESCRIPTION
Conflicts:
    htdocs/install/mysql/migration/3.6.0-3.7.0.sql
