### PR TITLE
Fix: update supplier orderline + rm deprecated prop

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2066,7 +2066,7 @@ class CommandeFournisseur extends CommonOrder
             $sql.= ",total_localtax2='".price2num($total_localtax2)."'";
             $sql.= ",total_ttc='".price2num($total_ttc)."'";
             $sql.= ",product_type=".$type;
-	        $sql.= ($fk_unit ? "'".$this->db->escape($fk_unit)."'":"null");
+			$sql.= ($fk_unit ? ",fk_unit='".$this->db->escape($fk_unit)."'":", fk_unit=null");
             $sql.= " WHERE rowid = ".$rowid;
 
             dol_syslog(get_class($this)."::updateline", LOG_DEBUG);

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -170,6 +170,7 @@ ErrorGlobalVariableUpdater4=SOAP client failed with error '%s'
 ErrorGlobalVariableUpdater5=No global variable selected
 ErrorFieldMustBeANumeric=Field <b>%s</b> must be a numeric value
 ErrorFieldMustBeAnInteger=Field <b>%s</b> must be an integer
+ErrorMandatoryParametersNotProvided=Mandatory parameter(s) not provided
 
 # Warnings
 WarningMandatorySetupNotComplete=Mandatory setup parameters are not yet defined

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -62,12 +62,6 @@ class Product extends CommonObject
     /**
      * Product label
      * @var string
-     * @deprecated use $label
-     */
-	var $libelle;
-    /**
-     * Product label
-     * @var string
      */
 	var $label;
     /**


### PR DESCRIPTION
- Fix SQL error in update supplier orderline
- Remove deprecated $libelle from product class, $libelle is removed
  from code and can not be used anymore, no sense to mark deprecated.
- Add missing translation key
