### PR TITLE
FIX #2856 : Wrong table design

### DIFF
--- a/htdocs/product/stock/massstockmove.php
+++ b/htdocs/product/stock/massstockmove.php
@@ -301,13 +301,7 @@ foreach($listofdata as $key => $val)
 	$warehousestatict->fetch($val['id_tw']);
 
 	print '<tr '.$bc[$var].'>';
-	print '<td>'.$productstatic->getNomUrl(1).'</td>';
-	print '<td>';
-	$oldref=$productstatic->ref;
-	$productstatic->ref=$productstatic->label;
-	print $productstatic->getNomUrl(1);
-	$productstatic->ref=$oldref;
-	print '</td>';
+	print '<td>'.$productstatic->getNomUrl(1).' - ' . $productstatic->label . '</td>';
 	print '<td>';
 	print $warehousestatics->getNomUrl(1);
 	print '</td>';


### PR DESCRIPTION
Closed bug #2856 "Wrong table design". Product was displayed in two columns (ref and label).
