### PR TITLE
Fix non existing "supplier invoice setting to draft" trigger

### DIFF
--- a/htdocs/core/modules/modAgenda.class.php
+++ b/htdocs/core/modules/modAgenda.class.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2004      Benoit Mortier       <benoit.mortier@opensides.be>
  * Copyright (C) 2009-2011 Regis Houssin        <regis.houssin@capnetworks.com>
  * Copyright (C) 2013      Cedric Gross          <c.gross@kreiz-it.fr>
+ * Copyright (C) 2015       Bahfir Abbes        <bafbes@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -90,6 +91,7 @@ class modAgenda extends DolibarrModules
         $this->const[12] = array("MAIN_AGENDA_ACTIONAUTO_SHIPPING_VALIDATE","chaine","1");
         $this->const[13] = array("MAIN_AGENDA_ACTIONAUTO_SHIPPING_SENTBYMAIL","chaine","1");
         $this->const[14] = array("MAIN_AGENDA_ACTIONAUTO_BILL_UNVALIDATE","chaine","1");
+        $this->const[15] = array("MAIN_AGENDA_ACTIONAUTO_BILL_SUPPLIER_UNVALIDATE","chaine","1");
 
 		// New pages on tabs
 		// -----------------

--- a/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
+++ b/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2011-2014 Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2013	   Cedric GROSS         <c.gross@kreiz-it.fr>
  * Copyright (C) 2014       Marcos García       <marcosgdf@gmail.com>
+ * Copyright (C) 2015       Bahfir Abbes        <bafbes@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -491,6 +492,18 @@ class InterfaceActionsAuto extends DolibarrTriggers
 			$object->actiontypecode='AC_OTH_AUTO';
             if (empty($object->actionmsg2)) $object->actionmsg2=$langs->transnoentities("InvoiceValidatedInDolibarr",($object->newref?$object->newref:$object->ref));
             $object->actionmsg=$langs->transnoentities("InvoiceValidatedInDolibarr",($object->newref?$object->newref:$object->ref));
+            $object->actionmsg.="\n".$langs->transnoentities("Author").': '.$user->login;
+
+            $object->sendtoid=0;
+		}
+		elseif ($action == 'BILL_SUPPLIER_UNVALIDATE')
+        {
+            $langs->load("other");
+            $langs->load("bills");
+
+			$object->actiontypecode='AC_OTH_AUTO';
+            if (empty($object->actionmsg2)) $object->actionmsg2=$langs->transnoentities("InvoiceBackToDraftInDolibarr",$object->ref);
+            $object->actionmsg=$langs->transnoentities("InvoiceBackToDraftInDolibarr",$object->ref);
             $object->actionmsg.="\n".$langs->transnoentities("Author").': '.$user->login;
 
             $object->sendtoid=0;

--- a/htdocs/core/triggers/interface_90_all_Demo.class.php-NORUN
+++ b/htdocs/core/triggers/interface_90_all_Demo.class.php-NORUN
@@ -2,6 +2,7 @@
 /* Copyright (C) 2005-2014 Laurent Destailleur	<eldy@users.sourceforge.net>
  * Copyright (C) 2005-2014 Regis Houssin		<regis.houssin@capnetworks.com>
  * Copyright (C) 2014      Marcos García		<marcosgdf@gmail.com>
+ * Copyright (C) 2015      Bahfir Abbes        <bafbes@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -197,6 +198,7 @@ class InterfaceDemo extends DolibarrTriggers
 		    case 'BILL_SUPPLIER_PAYED':
 		    case 'BILL_SUPPLIER_UNPAYED':
 		    case 'BILL_SUPPLIER_VALIDATE':
+		    case 'BILL_SUPPLIER_UNVALIDATE':
 		    case 'LINEBILL_SUPPLIER_CREATE':
 		    case 'LINEBILL_SUPPLIER_UPDATE':
 		    case 'LINEBILL_SUPPLIER_DELETE':

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2013		Philippe Grand			<philippe.grand@atoo-net.com>
  * Copyright (C) 2013       Florian Henry		  	<florian.henry@open-concept.pro>
  * Copyright (C) 2014-2015  Marcos García           <marcosgdf@gmail.com>
+ *	Copyright (C) 2015      Bahfir Abbes			<bafbes@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1073,7 +1074,14 @@ class FactureFournisseur extends CommonInvoice
                     }
                 }
             }
-
+            // Triggers call
+            if (! $error && empty($notrigger))
+            {
+                // Call trigger
+                $result=$this->call_trigger('BILL_SUPPLIER_VALIDATE',$user);
+                if ($result < 0) $error++;
+                // End call triggers
+            }
             if ($error == 0)
             {
                 $this->db->commit();

--- a/htdocs/install/mysql/data/llx_c_action_trigger.sql
+++ b/htdocs/install/mysql/data/llx_c_action_trigger.sql
@@ -8,6 +8,7 @@
 -- Copyright (C) 2010-2013  Juanjo Menent           <jmenent@2byte.es>
 -- Copyright (C) 2013       Cedric Gross            <c.gross@kreiz-it.fr>
 -- Copyright (C) 2014       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
+-- Copyright (C) 2015       Bahfir Abbes            <bafbes@gmail.com>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -74,3 +75,4 @@ insert into llx_c_action_trigger (code,label,description,elementtype,rang) value
 insert into llx_c_action_trigger (code,label,description,elementtype,rang) values ('TASK_CREATE','Task created','Executed when a project task is created','project',35);
 insert into llx_c_action_trigger (code,label,description,elementtype,rang) values ('TASK_MODIFY','Task modified','Executed when a project task is modified','project',36);
 insert into llx_c_action_trigger (code,label,description,elementtype,rang) values ('TASK_DELETE','Task deleted','Executed when a project task is deleted','project',37);
+insert into llx_c_action_trigger (code,label,description,elementtype,rang) values ('BILL_SUPPLIER_UNVALIDATE',	'Supplier invoice unvalidated',	'Executed when a supplier invoice status is set back to draft',	'invoice_supplier',15);

--- a/htdocs/install/mysql/migration/3.7.0-3.8.0.sql
+++ b/htdocs/install/mysql/migration/3.7.0-3.8.0.sql
@@ -644,4 +644,5 @@ ALTER TABLE llx_actioncomm ADD COLUMN recurdateend datetime;
 
 ALTER TABLE llx_stcomm ADD COLUMN picto varchar(128);
 
-
+-- New trigger for Supplier invoice unvalidation
+INSERT INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('BILL_SUPPLIER_UNVALIDATE','Supplier invoice unvalidated','Executed when a supplier invoice status is set back to draft','invoice_supplier',15);


### PR DESCRIPTION
Till now, no trigger was fired when supplier bills were set to Draft.  Fixing the issue by creating the BILL_SUPPLIER_UNVALIDATE trigger.
