### PR TITLE
FIX : extrafields required on thirdparty

### DIFF
--- a/htdocs/societe/soc.php
+++ b/htdocs/societe/soc.php
@@ -197,7 +197,7 @@ if (empty($reshook))
         $ret = $extrafields->setOptionalsFromPost($extralabels,$object);
 		if ($ret < 0)
 		{
-			 $error++; // This increment output "1" as text error
+			 $error++;
 			 $action = ($action=='add'?'create':'edit'); 
 		}
 

--- a/htdocs/societe/soc.php
+++ b/htdocs/societe/soc.php
@@ -195,7 +195,11 @@ if (empty($reshook))
 
         // Fill array 'array_options' with data from add form
         $ret = $extrafields->setOptionalsFromPost($extralabels,$object);
-		if ($ret < 0) $error++;
+		if ($ret < 0)
+		{
+			 $error++; // This increment output "1" as text error
+			 $action = ($action=='add'?'create':'edit'); 
+		}
 
         if (GETPOST('deletephoto')) $object->logo = '';
         else if (! empty($_FILES['photo']['name'])) $object->logo = dol_sanitizeFileName($_FILES['photo']['name']);


### PR DESCRIPTION
Create or update thirdparty output an error php if we set null value in require extrafield.
But care about "$error++" because I got 2 errors messages, this first with "1" as text and then the correct error is display.
