### PR TITLE
FIX : Compare array_options with oldcopy

### DIFF
--- a/htdocs/contact/class/contact.class.php
+++ b/htdocs/contact/class/contact.class.php
@@ -628,6 +628,13 @@ class Contact extends CommonObject
 					}
 				}
 
+				// Retreive all extrafield for contact
+                // fetch optionals attributes and labels
+                require_once(DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php');
+                $extrafields=new ExtraFields($this->db);
+                $extralabels=$extrafields->fetch_name_optionals_label($this->table_element,true);
+               	$this->fetch_optionals($this->id,$extralabels);
+
 				return 1;
 			}
 			else


### PR DESCRIPTION
Add fetch extrafields in contact class as societe class for more flexibility with the object for other modules. Because we can't compare old values between array_options.
