### PR TITLE
FIX top links menu have target attribute with wrong value

### DIFF
--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -190,7 +190,7 @@ if ($resql)
 	$texte.=' ('.$langs->trans("Stocks").')';
 
 
-	llxHeader("",$title,$helpurl,$texte);
+	llxHeader("",$texte,$helpurl);
 
 	if ($sref || $snom || $sall || GETPOST('search'))
 	{


### PR DESCRIPTION
When we are on reassort.php page in "Products > Stocks" each top links menu have target attribute with wrong value and simulate _blank.
