### PR TITLE
FIX : when mailing is deleted, the targets list was kept in database

### DIFF
--- a/htdocs/comm/mailing/class/mailing.class.php
+++ b/htdocs/comm/mailing/class/mailing.class.php
@@ -421,12 +421,35 @@ class Mailing extends CommonObject
 		$resql=$this->db->query($sql);
 		if ($resql)
 		{
-			return 1;
+			return $this->delete_targets();
 		}
 		else
 		{
 			$this->error=$this->db->lasterror();
 			return -1;
+		}
+	}
+	
+	/**
+	 *  Delete targets emailing
+	 *
+	 *  @return int       1 if OK, 0 if error
+	 */
+	function delete_targets()
+	{
+		$sql = "DELETE FROM ".MAIN_DB_PREFIX."mailing_cibles";
+		$sql.= " WHERE fk_mailing = ".$this->id;
+
+		dol_syslog("Mailing::delete_targets", LOG_DEBUG);
+		$resql=$this->db->query($sql);
+		if ($resql)
+		{
+			return 1;
+		}
+		else
+		{
+			$this->error=$this->db->lasterror();
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
This commit allow to keep the table 'llx_mailing_cibles' clear if we delete a mailing.
