### PR TITLE
FIX : When we clone a propal, if it has a project which is not assign…

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -959,8 +959,10 @@ class Propal extends CommonObject
      */
     function createFromClone($socid=0)
     {
-        global $user,$langs,$conf,$hookmanager;
-
+        global $db, $user,$langs,$conf,$hookmanager;
+		
+		dol_include_once('/projet/class.project.class.php');
+				
         $this->context['createfromclone']='createfromclone';
 
         $error=0;
@@ -985,7 +987,16 @@ class Propal extends CommonObject
                 $this->socid 				= $objsoc->id;
                 $this->cond_reglement_id	= (! empty($objsoc->cond_reglement_id) ? $objsoc->cond_reglement_id : 0);
                 $this->mode_reglement_id	= (! empty($objsoc->mode_reglement_id) ? $objsoc->mode_reglement_id : 0);
-                $this->fk_project			= '';
+				
+				$project = new Project($db);
+				
+				if($objFrom->fk_project > 0 && $project->fetch($objFrom->fk_project)) {
+					if($project->socid <= 0) $this->fk_project = $objFrom->fk_project;
+					else $this->fk_project = '';
+				} else {
+					$this->fk_project = '';
+				}
+                
                 $this->fk_delivery_address	= '';
             }
 


### PR DESCRIPTION
…ed to a third, it was not on new propal because fk_project was always set to an empty string if new propal is for another third.
