### PR TITLE
Fixed some XSS vulnerabilites

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -272,7 +272,7 @@ function GETPOST($paramname,$check='',$method=0,$filter=NULL,$options=NULL)
 	    }
 	}
 
-	return $out;
+	return htmlspecialchars($out);
 }
 
 

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -95,8 +95,8 @@ function test_sql_and_script_inject($val, $type)
     // This is all cases a browser consider text is javascript:
     // When it found '<script', 'javascript:', '<style', 'onload\s=' on body tag, '="&' on a tag size with old browsers
     // All examples on page: http://ha.ckers.org/xss.html#XSScalc
-//    $sql_inj += preg_match('/<img/i', $val);
-//    $sql_inj += preg_match('/<iframe/i', $val);
+    $sql_inj += preg_match('/<img/i', $val);
+    $sql_inj += preg_match('/<iframe/i', $val);
 
     $sql_inj += preg_match('/<script/i', $val);
     if (! defined('NOSTYLECHECK')) $sql_inj += preg_match('/<style/i', $val);

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -95,6 +95,9 @@ function test_sql_and_script_inject($val, $type)
     // This is all cases a browser consider text is javascript:
     // When it found '<script', 'javascript:', '<style', 'onload\s=' on body tag, '="&' on a tag size with old browsers
     // All examples on page: http://ha.ckers.org/xss.html#XSScalc
+//    $sql_inj += preg_match('/<img/i', $val);
+//    $sql_inj += preg_match('/<iframe/i', $val);
+
     $sql_inj += preg_match('/<script/i', $val);
     if (! defined('NOSTYLECHECK')) $sql_inj += preg_match('/<style/i', $val);
     $sql_inj += preg_match('/base[\s]+href/i', $val);


### PR DESCRIPTION
Hello, 

some of the search and "new"-anything fields could be still be injected with XSS, e.g. by using a <img src=d onerror=alert(123)/> tag despite being filtered. I tried to mitigate the problem by adding more filter to the function test_sql_and_script_inject. Also, in the GETPOST function I only return htmlspecialchars-filtered output. This should make simpler XSS-Injections more difficult. But there still could be problems with SQL-Injections, I have not yet looked into that. 

Regards
mft1
