### PR TITLE
Fix: Strict standards: Only variables should be passed by reference

### DIFF
--- a/htdocs/core/modules/modFacture.class.php
+++ b/htdocs/core/modules/modFacture.class.php
@@ -211,7 +211,10 @@ class modFacture extends DolibarrModules
         			case 'sellist':
 						$tmp='';
 						$tmpparam=unserialize($obj->param);	// $tmp ay be array 'options' => array 'c_currencies:code_iso:code_iso' => null
-						if ($tmpparam['options'] && is_array($tmpparam['options'])) $tmp=array_shift(array_keys($tmpparam['options']));
+						if ($tmpparam['options'] && is_array($tmpparam['options'])) {
+							$tmpkeys=array_keys($tmpparam['options']);
+							$tmp=array_shift($tmpkeys);
+						}
 						if (preg_match('/[a-z0-9_]+:[a-z0-9_]+:[a-z0-9_]+/', $tmp)) $typeFilter="List:".$tmp;
 						break;
         			}
@@ -270,7 +273,10 @@ class modFacture extends DolibarrModules
 					case 'sellist':
 						$tmp='';
 						$tmpparam=unserialize($obj->param);	// $tmp ay be array 'options' => array 'c_currencies:code_iso:code_iso' => null
-						if ($tmpparam['options'] && is_array($tmpparam['options'])) $tmp=array_shift(array_keys($tmpparam['options']));
+						if ($tmpparam['options'] && is_array($tmpparam['options'])) {
+							$tmpkeys=array_keys($tmpparam['options']);
+							$tmp=array_shift($tmpkeys);
+						}
 						if (preg_match('/[a-z0-9_]+:[a-z0-9_]+:[a-z0-9_]+/', $tmp)) $typeFilter="List:".$tmp;
 						break;
 				}


### PR DESCRIPTION
http://geoffray.be/blog/php/only-variables-should-be-passed-by-reference
