### PR TITLE
FIX #2976: "Report" tab is the current tab but it is not marked as selected by the UI

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Fix: [ bug #2577 ] Incorrect invoice status in "Linked objects" page of a projec
 Fix: [ bug #2576 ] Unable to edit a dictionary entry that has # in its ref
 Fix: [ bug #2758 ] Product::update sets product note to "null" when $prod->note is null
 Fix: [ bug #2757 ] Deleting product category photo gives "Forbidden access" error
+Fix: [ bug #2976 ] "Report" tab is the current tab but it is not marked as selected by the UI
 
 ***** ChangeLog for 3.5.6 compared to 3.5.5 *****
 Fix: Avoid missing class error for fetch_thirdparty method #1973

--- a/htdocs/core/lib/report.lib.php
+++ b/htdocs/core/lib/report.lib.php
@@ -39,7 +39,7 @@
 */
 function report_header($nom,$variante,$period,$periodlink,$description,$builddate,$exportlink='',$moreparam=array(),$calcmode='')
 {
-	global $langs, $hselected;
+	global $langs;
 
 	print "\n\n<!-- debut cartouche rapport -->\n";
 
@@ -48,7 +48,7 @@ function report_header($nom,$variante,$period,$periodlink,$description,$builddat
 	$head[$h][1] = $langs->trans("Report");
 	$head[$h][2] = 'report';
 
-	dol_fiche_head($head, $hselected);
+	dol_fiche_head($head, 'report');
 
 	print '<form method="POST" action="'.$_SERVER["PHP_SELF"].'">';
 	foreach($moreparam as $key => $value)


### PR DESCRIPTION
FIX #2976: "Report" tab is the current tab but it is not marked as selected by the UI

:warning: Travis CI build fail has nothing to do with this PR
