### PR TITLE
FIX Close bug #2861 Undefined variable $res when migrating from 3.6.2 to 3.7.0

### DIFF
--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -3661,8 +3661,8 @@ function migrate_reload_modules($db,$langs,$conf)
     if (! empty($conf->global->MAIN_MODULE_SERVICE))    // Permission has changed into 2.7
     {
         dolibarr_install_syslog("upgrade2::migrate_reload_modules Reactivate module Service");
-        if ($res) {
-            $res=@include_once DOL_DOCUMENT_ROOT.'/core/modules/modService.class.php';
+	    $res=@include_once DOL_DOCUMENT_ROOT.'/core/modules/modService.class.php';
+	    if ($res) {
             $mod=new modService($db);
             //$mod->remove('noboxes');
             $mod->init('newboxdefonly');
@@ -3671,8 +3671,8 @@ function migrate_reload_modules($db,$langs,$conf)
     if (! empty($conf->global->MAIN_MODULE_COMMANDE))   // Permission has changed into 2.9
     {
         dolibarr_install_syslog("upgrade2::migrate_reload_modules Reactivate module Commande");
-        if ($res) {
-            $res=@include_once DOL_DOCUMENT_ROOT.'/core/modules/modCommande.class.php';
+	    $res=@include_once DOL_DOCUMENT_ROOT.'/core/modules/modCommande.class.php';
+	    if ($res) {
             $mod=new modCommande($db);
             //$mod->remove('noboxes');
             $mod->init('newboxdefonly');
@@ -3681,8 +3681,8 @@ function migrate_reload_modules($db,$langs,$conf)
     if (! empty($conf->global->MAIN_MODULE_FACTURE))    // Permission has changed into 2.9
     {
         dolibarr_install_syslog("upgrade2::migrate_reload_modules Reactivate module Facture");
-        if ($res) {
-            $res=@include_once DOL_DOCUMENT_ROOT.'/core/modules/modFacture.class.php';
+	    $res=@include_once DOL_DOCUMENT_ROOT.'/core/modules/modFacture.class.php';
+	    if ($res) {
             $mod=new modFacture($db);
             //$mod->remove('noboxes');
             $mod->init('newboxdefonly');
@@ -3732,8 +3732,8 @@ function migrate_reload_modules($db,$langs,$conf)
     if (! empty($conf->global->MAIN_MODULE_ECM))    // Permission has changed into 3.0 and 3.1
     {
         dolibarr_install_syslog("upgrade2::migrate_reload_modules Reactivate module ECM");
-        if ($res) {
-            $res=@include_once DOL_DOCUMENT_ROOT.'/core/modules/modECM.class.php';
+	    $res=@include_once DOL_DOCUMENT_ROOT.'/core/modules/modECM.class.php';
+	    if ($res) {
             $mod=new modECM($db);
             $mod->remove('noboxes');	// We need to remove because a permission id has been removed
             $mod->init('newboxdefonly');


### PR DESCRIPTION
FIX Close bug #2861 Undefined variable $res when migrating from 3.6.2 to 3.7.0
