### PR TITLE
FIX #2837 Product list table column header does not match column body

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Fix: [ bug #2577 ] Incorrect invoice status in "Linked objects" page of a projec
 Fix: [ bug #2576 ] Unable to edit a dictionary entry that has # in its ref
 Fix: [ bug #2758 ] Product::update sets product note to "null" when $prod->note is null
 Fix: [ bug #2757 ] Deleting product category photo gives "Forbidden access" error
+Fix: [ bug #2837 ] Product list table column header does not match column body
 
 ***** ChangeLog for 3.5.6 compared to 3.5.5 *****
 Fix: Avoid missing class error for fetch_thirdparty method #1973

--- a/htdocs/product/liste.php
+++ b/htdocs/product/liste.php
@@ -459,7 +459,7 @@ else
     			}
 
     			// Better buy price
-    			if ($user->rights->produit->creer) {
+    			if ($user->rights->fournisseur->lire) {
         			print  '<td align="right">';
         			if ($objp->minsellprice != '')
         			{


### PR DESCRIPTION
FIX Close #2837 Product list table column header does not match column body

:warning: Travis CI build fail has nothing to do with this PR
