### PR TITLE
FIX #2835 Customer prices of a product shows incorrect history order

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Fix: [ bug #2577 ] Incorrect invoice status in "Linked objects" page of a projec
 Fix: [ bug #2576 ] Unable to edit a dictionary entry that has # in its ref
 Fix: [ bug #2758 ] Product::update sets product note to "null" when $prod->note is null
 Fix: [ bug #2757 ] Deleting product category photo gives "Forbidden access" error
+Fix: [ bug #2835 ] Customer prices of a product shows incorrect history order
 
 ***** ChangeLog for 3.5.6 compared to 3.5.5 *****
 Fix: Avoid missing class error for fetch_thirdparty method #1973

--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -670,7 +670,7 @@ $sql.= " WHERE fk_product = ".$object->id;
 $sql.= " AND p.entity IN (".getEntity('productprice', 1).")";
 $sql.= " AND p.fk_user_author = u.rowid";
 if (! empty($socid) && ! empty($conf->global->PRODUIT_MULTIPRICES)) $sql.= " AND p.price_level = ".$soc->price_level;
-$sql.= " ORDER BY p.date_price DESC, p.price_level ASC";
+$sql.= " ORDER BY p.date_price DESC, p.price_level ASC, p.rowid DESC";
 
 dol_syslog("sql=".$sql);
 $result = $db->query($sql);


### PR DESCRIPTION
FIX Close #2835 Customer prices of a product shows incorrect history order

:warning: Travis CI build fail has nothing to do with this PR
