### PR TITLE
Fix #2814 JPEG photos are not displayed in Product photos page

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Fix: [ bug #2577 ] Incorrect invoice status in "Linked objects" page of a projec
 Fix: [ bug #2576 ] Unable to edit a dictionary entry that has # in its ref
 Fix: [ bug #2758 ] Product::update sets product note to "null" when $prod->note is null
 Fix: [ bug #2757 ] Deleting product category photo gives "Forbidden access" error
+Fix: [ bug #2814 ] JPEG photos are not displayed in Product photos page
 
 ***** ChangeLog for 3.5.6 compared to 3.5.5 *****
 Fix: Avoid missing class error for fetch_thirdparty method #1973

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2856,7 +2856,7 @@ class Product extends CommonObject
 
     				if (! utf8_check($file)) $file=utf8_encode($file);	// To be sure file is stored in UTF8 in memory
 
-    				if (dol_is_file($dir.$file) && preg_match('/(\.jpg|\.bmp|\.gif|\.png|\.tiff)$/i', $dir.$file))
+    				if (dol_is_file($dir.$file) && preg_match('/(\.jp(e?)g|\.bmp|\.gif|\.png|\.tiff)$/i', $dir.$file))
     				{
     					$nbphoto++;
     					$photo = $file;


### PR DESCRIPTION
Fix Close bug #2814 JPEG photos are not displayed in Product photos page

:warning: Travis CI build fail has nothing to do with this PR
