### PR TITLE
FIX complete function ordersupplier_prepare_head() so a module can remove tabs

### DIFF
--- a/htdocs/core/lib/fourn.lib.php
+++ b/htdocs/core/lib/fourn.lib.php
@@ -153,7 +153,7 @@ function ordersupplier_prepare_head($object)
 	$head[$h][1] = $langs->trans("OrderFollow");
 	$head[$h][2] = 'info';
 	$h++;
-
+	complete_head_from_modules($conf,$langs,$object,$head,$h,'supplier_order', 'remove');
 	return $head;
 }
 


### PR DESCRIPTION
Ajout de la fonction complete_head_from_modules() pour supprimer les onglets si besoin.
