### PR TITLE
Remove useless filter for "text" parameter of boxes content

### DIFF
--- a/htdocs/core/boxes/modules_boxes.php
+++ b/htdocs/core/boxes/modules_boxes.php
@@ -273,7 +273,6 @@ class ModeleBoxes    // Can't be abtract as it is instantiated to build "empty" 
                             $tdparam='';
                             if (isset($contents[$i][$j]['td'])) $tdparam.=' '.$contents[$i][$j]['td'];
 
-                            if (empty($contents[$i][$j]['text'])) $contents[$i][$j]['text']="";
                             $text=isset($contents[$i][$j]['text'])?$contents[$i][$j]['text']:'';
                             $textwithnotags=preg_replace('/<([^>]+)>/i','',$text);
                             $text2=isset($contents[$i][$j]['text2'])?$contents[$i][$j]['text2']:'';


### PR DESCRIPTION
This filter doesn't allow to display "0" value and is not applied to the similar "text2" parameter.
