### PR TITLE
FIX : tool export extrafields

### DIFF
--- a/htdocs/core/modules/export/export_csv.modules.php
+++ b/htdocs/core/modules/export/export_csv.modules.php
@@ -252,6 +252,13 @@ class ExportCsv extends ModeleExports
 
 			$newvalue=$this->csv_clean($newvalue,$outputlangs->charset_output);
 
+			if (preg_match('/^Select:/i', $typefield, $reg) && $typefield = substr($typefield, 7))
+			{
+				$array = unserialize($typefield);
+				$array = $array['options'];
+				$newvalue = $array[$newvalue];
+			}
+			
 			fwrite($this->handle,$newvalue.$this->separator);
 			$this->col++;
 		}

--- a/htdocs/core/modules/export/export_excel.modules.php
+++ b/htdocs/core/modules/export/export_excel.modules.php
@@ -305,7 +305,14 @@ class ExportExcel extends ModeleExports
 
 			$newvalue=$this->excel_clean($newvalue);
 			$typefield=isset($array_types[$code])?$array_types[$code]:'';
-
+			
+			if (preg_match('/^Select:/i', $typefield, $reg) && $typefield = substr($typefield, 7))
+			{
+				$array = unserialize($typefield);
+				$array = $array['options'];
+				$newvalue = $array[$newvalue];
+			}
+			
 			// Traduction newvalue
 			if (preg_match('/^\((.*)\)$/i',$newvalue,$reg))
 			{

--- a/htdocs/core/modules/export/export_tsv.modules.php
+++ b/htdocs/core/modules/export/export_tsv.modules.php
@@ -226,7 +226,14 @@ class ExportTsv extends ModeleExports
 			if (preg_match('/^\((.*)\)$/i',$newvalue,$reg)) $newvalue=$outputlangs->transnoentities($reg[1]);
 
 			$newvalue=$this->tsv_clean($newvalue,$outputlangs->charset_output);
-
+			
+			if (preg_match('/^Select:/i', $typefield, $reg) && $typefield = substr($typefield, 7))
+			{
+				$array = unserialize($typefield);
+				$array = $array['options'];
+				$newvalue = $array[$newvalue];
+			}
+			
 			fwrite($this->handle,$newvalue.$this->separator);
             $this->col++;
 		}

--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -355,6 +355,9 @@ class modSociete extends DolibarrModules
         			case 'sellist':
         				$typeFilter="List:".$obj->param;
         				break;
+					case 'select':
+						$typeFilter="Select:".$obj->param;
+						break;
         		}
         		$this->export_fields_array[$r][$fieldname]=$fieldlabel;
         		$this->export_TypeFields_array[$r][$fieldname]=$typeFilter;


### PR DESCRIPTION
The tool export can handle the extrafield with "select" type. Now we get the value instead of "id" in the file.
