### PR TITLE
FIX : wrong display with contact country

### DIFF
--- a/htdocs/contact/class/contact.class.php
+++ b/htdocs/contact/class/contact.class.php
@@ -555,7 +555,7 @@ class Contact extends CommonObject
 
 				$this->country_id 		= $obj->country_id;
 				$this->country_code		= $obj->country_id?$obj->country_code:'';
-				$this->country			= ($obj->country_id > 0)?$langs->transnoentitiesnoconv("Country".$obj->country_code):'';
+				$this->country			= $obj->country_id?($langs->trans('Country'.$obj->country_code)!='Country'.$obj->country_code?$langs->transnoentities('Country'.$obj->country_code):$obj->country):'';
 
 				$this->socid			= $obj->fk_soc;
 				$this->socname			= $obj->socname;


### PR DESCRIPTION
If we create a new country in the dictionary and this country not have a translate, we got this "CountryXX" (XX = country code given).
