### PR TITLE
FIX : when fetch_optionnal_by_label in Extrafields with $this->db cannot

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -32,6 +32,18 @@
 abstract class CommonDocGenerator
 {
 	var $error='';
+	public $db;
+	
+	
+	/**
+	 *	Constructor
+	 *
+	 *  @param		DoliDB		$db      Database handler
+	*/
+	public function __construct($db) {
+		$this->db = $db;
+		return 1;
+	}
 
 
     /**

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -32,7 +32,7 @@
 abstract class CommonDocGenerator
 {
 	var $error='';
-	public $db;
+	protected $db;
 	
 	
 	/**


### PR DESCRIPTION
when fetch_optionnal_by_label in Extrafields with $this->db cannot work because this->db is never instanciated
