### PR TITLE
FIX : translation for 1 word do not work

### DIFF
--- a/htdocs/langs/fr_FR/categories.lang
+++ b/htdocs/langs/fr_FR/categories.lang
@@ -108,3 +108,4 @@ CategorieRecursiv=Lier automatiquement avec le(a) tag/catégorie parent(e)
 CategorieRecursivHelp=Si activé : quand un élément est ajouté dans une catégorie, l'ajouter aussi dans toutes les catégories parentes
 AddProductServiceIntoCategory=Ajouter le produit/service suivant
 ShowCategory=Afficher tag/catégorie
+Translation=Traduction


### PR DESCRIPTION
If we create new tag/category without product/service module enabled we have 1 word without translation if we look tabs on view mode.
