### PR TITLE
Fix: [ bug 1791 ] Margin menu not available if any Finance module is not enabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ Fix: [ bug #2837 ] Product list table column header does not match column body
 Fix: [ bug #2835 ] Customer prices of a product shows incorrect history order
 Fix: [ bug #2814 ] JPEG photos are not displayed in Product photos page
 Fix: [ bug #2715 ] Statistics page has broken layout with long thirdparty names
+Fix: [ bug #1791 ] Margin menu not available if any Finance module is not enabled
 
 ***** ChangeLog for 3.5.6 compared to 3.5.5 *****
 Fix: Avoid missing class error for fetch_thirdparty method #1973

--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -134,9 +134,11 @@ function print_eldy_menu($db,$atarget,$type_user,&$tabMenu,&$menu,$noout=0)
 	}
 
 	// Financial
-	$tmpentry=array('enabled'=>(! empty($conf->comptabilite->enabled) || ! empty($conf->accounting->enabled) || ! empty($conf->facture->enabled) || ! empty($conf->deplacement->enabled) || ! empty($conf->don->enabled) || ! empty($conf->tax->enabled)),
-	'perms'=>(! empty($user->rights->compta->resultat->lire) || ! empty($user->rights->accounting->plancompte->lire) || ! empty($user->rights->facture->lire) || ! empty($user->rights->deplacement->lire) || ! empty($user->rights->don->lire) || ! empty($user->rights->tax->charges->lire)),
-	'module'=>'comptabilite|accounting|facture|deplacement|don|tax');
+	$tmpentry = array(
+		'enabled' => (!empty($conf->comptabilite->enabled) || !empty($conf->accounting->enabled) || !empty($conf->facture->enabled) || !empty($conf->deplacement->enabled) || !empty($conf->don->enabled) || !empty($conf->tax->enabled) || !empty($conf->margin->enabled)),
+		'perms' => (!empty($user->rights->compta->resultat->lire) || !empty($user->rights->accounting->plancompte->lire) || !empty($user->rights->facture->lire) || !empty($user->rights->deplacement->lire) || !empty($user->rights->don->lire) || !empty($user->rights->tax->charges->lire) || !empty($user->rights->margins->liretous)),
+		'module' => 'comptabilite|accounting|facture|deplacement|don|tax'
+	);
 	$showmode=dol_eldy_showmenu($type_user, $tmpentry, $listofmodulesforexternal);
 	if ($showmode)
 	{


### PR DESCRIPTION
Fix: [ bug 1791 ] Margin menu not available if any Finance module is not enabled
