### PR TITLE
FIX [ bug 1925 ] "Link to order" option in supplier invoices is not working properly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ FIX [ bug #2855 ] Wrong translation key in localtax report page
 FIX [ bug #1852 ] JS error when editing a customer order line
 FIX [ bug #2900 ] Courtesy title is not stored in create thirdparty form
 FIX [ bug #3055 ] Product image thumbnails were not deleted after deleting the image
+FIX [ bug 1925 ] "Link to order" option in supplier invoices is not working properly
 
 ***** ChangeLog for 3.7.1 compared to 3.7.* *****
 FIX Bug in the new photo system

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -824,7 +824,7 @@ elseif ($action == 'reopen' && $user->rights->fournisseur->facture->creer)
 if (GETPOST('linkedOrder')) {
 	$object->fetch($id);
 	$object->fetch_thirdparty();
-	$result = $object->add_object_linked('commande', GETPOST('linkedOrder'));
+	$result = $object->add_object_linked('order_supplier', GETPOST('linkedOrder'));
 }
 
 // Add file in email form


### PR DESCRIPTION
FIX [ bug 1925 ] "Link to order" option in supplier invoices is not working properly

Patch submitted by Philippe (pheno) at https://doliforge.org/tracker/?func=detail&aid=1925&group_id=144
