### PR TITLE
Fix: [ bug #3198 ] Trigger LINECONTRACT_INSERT passes Contrat as $object instead of ContratLigne

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,9 @@ FIX [ bug #2900 ] Courtesy title is not stored in create thirdparty form
 FIX [ bug #3055 ] Product image thumbnails were not deleted after deleting the image
 FIX [ bug 1634 ] Error deleting a project when it had many linked objects
 FIX [ bug 1925 ] "Link to order" option in supplier invoices is not working properly
+FIX [ bug #3198 ] Trigger LINECONTRACT_INSERT passes Contrat as $object instead of ContratLigne
+
+NEW: Created new ContratLigne::insert function
 
 ***** ChangeLog for 3.7.1 compared to 3.7.* *****
 FIX Bug in the new photo system


### PR DESCRIPTION
Fix: [ bug #3198 ] Trigger LINECONTRACT_INSERT passes Contrat as $object instead of ContratLigne

Created new ContratLigne::insert function

I don't know if this should be introduced to 3.8 instead of 3.7... 

Close #3198
