### PR TITLE
Fix: [ bug #3074 ] Accruals accounting use payment date instead of commitment date in turnover reports for salaries

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,7 @@ English Dolibarr ChangeLog
 - Fix: Bad permission assignments for stock movements actions
 - Fix: [ bug #2891 ] Category hooks do not work
 - Fix: [ bug #2696 ] Adding complementary attribute fails if code is numerics
+- Fix: [ bug #3074 ] Accruals accounting use payment date instead of commitment date in turnover reports for salaries
 
 ***** ChangeLog for 3.6.2 compared to 3.6.1 *****
 - Fix: fix ErrorBadValueForParamNotAString error message in price customer multiprice.

--- a/htdocs/compta/resultat/clientfourn.php
+++ b/htdocs/compta/resultat/clientfourn.php
@@ -543,17 +543,23 @@ if ($mysoc->tva_assuj == 'franchise')	// Non assujeti
  * Salaries
  */
 
+if ($modecompta == 'CREANCES-DETTES') {
+    $column = 'p.datev';
+} else {
+    $column = 'p.datep';
+}
+
 print '<tr><td colspan="4">'.$langs->trans("Salaries").'</td></tr>';    
-$sql = "SELECT p.label as nom, date_format(p.datep,'%Y-%m') as dm, sum(p.amount) as amount, u.firstname, u.lastname, p.fk_user";
+$sql = "SELECT p.label as nom, date_format($column,'%Y-%m') as dm, sum(p.amount) as amount, u.firstname, u.lastname, p.fk_user";
 $sql.= " FROM ".MAIN_DB_PREFIX."payment_salary as p";
 $sql.= " INNER JOIN ".MAIN_DB_PREFIX."user as u ON u.rowid=p.fk_user";
 $sql.= " WHERE p.entity = ".$conf->entity;
 if (! empty($date_start) && ! empty($date_end))
-	$sql.= " AND p.datep >= '".$db->idate($date_start)."' AND p.datep <= '".$db->idate($date_end)."'";
+	$sql.= " AND $column >= '".$db->idate($date_start)."' AND $column <= '".$db->idate($date_end)."'";
 	
 $sql.= " GROUP BY u.rowid, p.label, p.datep, p.fk_user";
 $sql.= " ORDER BY u.firstname";
-    
+
 dol_syslog("get payment salaries sql=".$sql);
 $result=$db->query($sql);
 $subtotal_ht = 0;

--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -473,9 +473,16 @@ $reshook=$hookmanager->executeHooks('addStatisticLine',$parameters,$object,$acti
 /*
  * Salaries
  */
+
+if ($modecompta == 'CREANCES-DETTES') {
+	$column = 'p.datev';
+} else {
+	$column = 'p.datep';
+}
+
 $subtotal_ht = 0;
 $subtotal_ttc = 0;
-$sql = "SELECT p.label as nom, date_format(p.datep,'%Y-%m') as dm, sum(p.amount) as amount";
+$sql = "SELECT p.label as nom, date_format($column,'%Y-%m') as dm, sum(p.amount) as amount";
 $sql.= " FROM ".MAIN_DB_PREFIX."payment_salary as p";
 $sql.= " WHERE p.entity = ".$conf->entity;
 $sql.= " GROUP BY p.label, dm";


### PR DESCRIPTION
Fix: [ bug #3074 ] Accruals accounting use payment date instead of commitment date in turnover reports for salaries

Close #3074
