### PR TITLE
FIX no projet_task_time id from trigger TASK_TIMESPENT_CREATE

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -770,7 +770,8 @@ class Task extends CommonObject
         {
             $tasktime_id = $this->db->last_insert_id(MAIN_DB_PREFIX."projet_task_time");
             $ret = $tasktime_id;
-
+			$this->timespent_id = $ret;
+			
             if (! $notrigger)
             {
                 // Call triggers


### PR DESCRIPTION
When we add time on task, we cant access to the id of the line added in llx_projet_task_time.
