### PR TITLE
FIX: Not showing task extrafields when creating from left menu

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ FIX [ bug 1634 ] Error deleting a project when it had many linked objects
 FIX [ bug 1925 ] "Link to order" option in supplier invoices is not working properly
 FIX [ bug #3198 ] Trigger LINECONTRACT_INSERT passes Contrat as $object instead of ContratLigne
 FIX: Not showing delivery date on rouget pdf
+FIX: Not showing task extrafields when creating from left menu
 
 NEW: Created new ContratLigne::insert function
 

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -55,8 +55,8 @@ if ($id > 0 || ! empty($ref))
 
 	// fetch optionals attributes and labels
 	$extralabels_projet=$extrafields_project->fetch_name_optionals_label($object->table_element);
-	$extralabels_task=$extrafields_task->fetch_name_optionals_label($taskstatic->table_element);
 }
+$extralabels_task=$extrafields_task->fetch_name_optionals_label($taskstatic->table_element);
 
 // Security check
 $socid=0;


### PR DESCRIPTION
Not showing task extrafields when creating the task from the left menu 'New Task'
