### PR TITLE
FIX #3349 Checking a VAT number with spaces

### DIFF
--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -410,6 +410,7 @@ class DoliDBPgsql extends DoliDB
 			$this->database_name = $name;
 			pg_set_error_verbosity($this->db, PGSQL_ERRORS_VERBOSE);	// Set verbosity to max
 		}
+		pg_query($this->db, "set datestyle = 'ISO, YMD';");
 
 		return $this->db;
 	}

--- a/htdocs/societe/checkvat/checkVatPopup.php
+++ b/htdocs/societe/checkvat/checkVatPopup.php
@@ -49,8 +49,10 @@ if (! $_REQUEST["vatNumber"])
 }
 else
 {
+	$_REQUEST["vatNumber"] = preg_replace('/\^\w/', '', $_REQUEST["vatNumber"]);
 	$countryCode=substr($_REQUEST["vatNumber"],0,2);
 	$vatNumber=substr($_REQUEST["vatNumber"],2);
+	
 	print '<b>'.$langs->trans("Country").'</b>: '.$countryCode.'<br>';
 	print '<b>'.$langs->trans("VATIntraShort").'</b>: '.$vatNumber.'<br>';
 	print '<br>';


### PR DESCRIPTION
This will allow VAT check to work properly even if VAT has been typed with spaces in.
