### PR TITLE
FIX [ bug #3321 ] Users with certain permissions were shown a "forbidden access" page even if they had the rights

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ FIX: Not showing delivery date on rouget pdf
 FIX: Not showing task extrafields when creating from left menu
 FIX [ bug #3288 ] Tasks box is not properly drawn
 FIX [ bug #3211 ] Outstading bill amount of a client showed wrong amounts
+FIX [ bug #3321 ] Users with certain permissions were shown a "forbidden access" page even if they had the rights
 
 NEW: Created new ContratLigne::insert function
 

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -451,7 +451,7 @@ function restrictedArea($user, $features, $objectid=0, $dbtablename='', $feature
                 	if (empty($dbt_keyfield)) dol_print_error('','Param dbt_keyfield is required but not defined');
                    
 
-				    $sql = "SELECT dbt.id";
+				    $sql = "SELECT dbt.$dbt_select";
                     $sql.= " FROM ".MAIN_DB_PREFIX.$dbtablename." as dbt";
                     $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON (dbt.".$dbt_keyfield." = s.rowid)";
                     $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON (sc.fk_soc = dbt.".$dbt_keyfield.")";


### PR DESCRIPTION
FIX [ bug #3321 ] Users with certain permissions were shown a "forbidden access" page even if they had the rights

Close #3321
