### PR TITLE
FIX [ bug #3426 ] Unable to create an invoice from a contract with extrafields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@ FIX: Not showing task extrafields when creating from left menu
 FIX [ bug #3288 ] Tasks box is not properly drawn
 FIX [ bug #3211 ] Outstading bill amount of a client showed wrong amounts
 FIX [ bug #3321 ] Users with certain permissions were shown a "forbidden access" page even if they had the rights
+FIX [ bug #3426 ] Unable to create an invoice from a contract with extrafields
 
 NEW: Created new ContratLigne::insert function
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3375,6 +3375,11 @@ abstract class CommonObject
     {
     	if (empty($rowid)) $rowid=$this->id;
 
+        //To avoid SQL errors. Probably not the better solution though
+        if (!$this->table_element) {
+            return 0;
+        }
+
         if (! is_array($optionsArray))
         {
             // optionsArray not already loaded, so we load it


### PR DESCRIPTION
FIX [ bug #3426 ] Unable to create an invoice from a contract with extrafields

Close #3426
