### PR TITLE
FIX error creating default object from empty value

### DIFF
--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -110,6 +110,7 @@ class Conf
 		$this->bank				= new stdClass();
 		$this->notification		= new stdClass();
 		$this->mailing			= new stdClass();
+		$this->expensereport	= new stdClass();
 	}
 
 


### PR DESCRIPTION
"Creating default object from empty value" is display on each page of Dolibarr. Missing attribute into __construct function.
