### PR TITLE
Fix #3442 Remove useless syslog

### DIFF
--- a/htdocs/core/boxes/box_prospect.php
+++ b/htdocs/core/boxes/box_prospect.php
@@ -119,7 +119,6 @@ class box_prospect extends ModeleBoxes
 			}
 		}
 		else {
-			dol_syslog("box_prospect::loadBox not allowed de read this box content",LOG_ERR);
 			$this->info_box_contents[0][0] = array('td' => 'align="left"',
         'text' => $langs->trans("ReadPermissionNotAllowed"));
 		}


### PR DESCRIPTION
Not having the permission to read the box is not an error.
Furthermore, no other boxes have this behavior.
