### PR TITLE
FIX [ bug #3460 ] Bank account is not saved when creating a customer invoice and facing an error message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@ FIX [ bug #3288 ] Tasks box is not properly drawn
 FIX [ bug #3211 ] Outstading bill amount of a client showed wrong amounts
 FIX [ bug #3321 ] Users with certain permissions were shown a "forbidden access" page even if they had the rights
 FIX [ bug #3426 ] Unable to create an invoice from a contract with extrafields
+FIX [ bug #3460 ] Bank account is not saved when creating a customer invoice and facing an error message
 
 NEW: Created new ContratLigne::insert function
 

--- a/htdocs/compta/facture.php
+++ b/htdocs/compta/facture.php
@@ -2121,6 +2121,10 @@ if ($action == 'create')
 	print '</td></tr>';
 
     // Bank Account
+	if (isset($_POST['fk_account'])) {
+		$fk_account = $_POST['fk_account'];
+	}
+
     print '<tr><td>' . $langs->trans('BankAccount') . '</td><td colspan="2">';
     $form->select_comptes($fk_account, 'fk_account', 0, '', 1);
     print '</td></tr>';


### PR DESCRIPTION
FIX [ #3460 ] Selected bank account was not saved when an error happened when trying to create a customer invoice

Close #3460
