### PR TITLE
FIX : #3530

### DIFF
--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -5,11 +5,8 @@
  * Copyright (C) 2004		Christophe Combelles	<ccomb@free.fr>
  * Copyright (C) 2005		Marc Barilley / Ocebo	<marc@ocebo.com>
  * Copyright (C) 2005-2012	Regis Houssin			<regis.houssin@capnetworks.com>
-<<<<<<< HEAD
  * Copyright (C) 2014		Teddy Andreotti			<125155@supinfo.com>
-=======
  * Copyright (C) 2015       Marcos García           <marcosgdf@gmail.com>
->>>>>>> refs/remotes/origin/3.6
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,6 +43,7 @@ $confirm	= GETPOST('confirm');
 
 $facid=GETPOST('facid','int');
 $socid=GETPOST('socid','int');
+$accountid	= GETPOST('accountid');
 
 $sortfield = GETPOST("sortfield",'alpha');
 $sortorder = GETPOST("sortorder",'alpha');
@@ -200,7 +198,7 @@ if (empty($reshook))
 
 	        if (! $error)
 	        {
-	            $result=$paiement->addPaymentToBank($user,'payment_supplier','(SupplierInvoicePayment)',$_POST['accountid'],'','');
+	            $result=$paiement->addPaymentToBank($user,'payment_supplier','(SupplierInvoicePayment)',$accountid,'','');
 	            if ($result < 0)
 	            {
 	            	setEventMessage($paiement->error, 'errors');
@@ -304,7 +302,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
             if (! empty($conf->banque->enabled))
             {
                 print '<tr><td class="fieldrequired">'.$langs->trans('Account').'</td><td>';
-                $form->select_comptes(empty($_POST['accountid'])?'':$_POST['accountid'],'accountid',0,'',2);
+                $form->select_comptes(empty($accountid)?'':$accountid,'accountid',0,'',2);
                 print '</td></tr>';
             }
             else


### PR DESCRIPTION
Just do the same as on customer paiement (and do the same as already done in 3.8). I consider this as a FIX because URL parameters accountid is already send in URL by supplier invoice card, so it is a not finish feature, and it is already implement into 3.8. To my mind there is no regression risk  
