### PR TITLE
FIX Syntax error in Debian Apache configuration

### DIFF
--- a/build/debian/apache/dolibarr.conf
+++ b/build/debian/apache/dolibarr.conf
@@ -15,7 +15,7 @@ Alias /dolibarr /usr/share/dolibarr/htdocs
 #	Require all granted
 #	</IfVersion>
 #	<IfVersion < 2.3>
-#	Order allow, deny
+#	Order allow,deny
 #	Allow from all
 #	</IfVersion>
 #
@@ -27,7 +27,7 @@ Alias /dolibarr /usr/share/dolibarr/htdocs
 	Require all granted
 	</IfVersion>
 	<IfVersion < 2.3>
-	Order allow, deny
+	Order allow,deny
 	Allow from all
 	</IfVersion>
 


### PR DESCRIPTION
This issue prevented Apache from starting after dolibarr deb package
installation with the following error:
Syntax error on line 30 of /etc/apache2/conf.d/dolibarr.conf:
order takes one argument, 'allow,deny', 'deny,allow', or 'mutual-failure'
