### PR TITLE
Update categorie.php

### DIFF
--- a/htdocs/categories/categorie.php
+++ b/htdocs/categories/categorie.php
@@ -419,7 +419,7 @@ else if ($id || $ref)
 		// Ref
 		print '<tr><td width="20%">'.$langs->trans("Ref").'</td>';
 		print '<td class="valeur">';
-		print $form->showrefnav($member,'id');
+		print $form->showrefnav($member,'id','','1','rowid','ref','','&type=3');
 		print '</td></tr>';
 
         // Login


### PR DESCRIPTION
la navigation entre membres depuis la vue catégorie du membre (adhérent) ne fonctionne pas sans ajouter "&type=3" à l'URL

J'ai ajouté les autres paramètres ('1', 'rowid' et 'ref'), car ils m'apparaissent indispensables. Je n'ai pas fait de tests exhaustifs, j'ai seulement testé pour que la navigation entre membres depuis la vue catégorie fonctionne.
