### PR TITLE
Fix Do not always append htdocs to include path

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -164,7 +164,10 @@ if (! defined('NOSCANPOSTFORINJECTION'))
 }
 
 // This is to make Dolibarr working with Plesk
-if (! empty($_SERVER['DOCUMENT_ROOT'])) set_include_path($_SERVER['DOCUMENT_ROOT'].'/htdocs');
+if (! empty($_SERVER['DOCUMENT_ROOT']) && substr($_SERVER['DOCUMENT_ROOT'], -6) !== 'htdocs') {
+		set_include_path($_SERVER['DOCUMENT_ROOT'] . '/htdocs');
+	}
+}
 
 // Include the conf.php and functions.lib.php
 require_once 'filefunc.inc.php';


### PR DESCRIPTION
Serving the htdocs directly is a best practice. The old code generates
a bogus include path in that case.
This code tries to mitigate the issue by setting a correct include path
in both cases.
