### PR TITLE
Add possibility to add lines in the dashboard without changing index.php

### DIFF
--- a/htdocs/core/lib/dashboardlines.lib.php
+++ b/htdocs/core/lib/dashboardlines.lib.php
@@ -16,63 +16,60 @@
  */
 
 /**
- *	\file       core/lib/dashboardlines.lib.php
- *	\brief      Functions for dashboard
- *	\ingroup    dashboardlines
+ *    \file       core/lib/dashboardlines.lib.php
+ *    \brief      Functions for dashboard
+ *    \ingroup    dashboardlines
  */
 
-require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
 
-function dbl_get_dashboardlines(&$dashboardlines)
+function dbl_get_dashboardlines ( &$dashboardlines )
 {
-    global $user, $db;
+    global $user , $db;
 
     $dbl = dbl_get_lines_from_db();
 
-    if (! empty($dbl))
-            {
-                foreach ($dbl as $line)
-                    {
-                        if (! $line['right']) $evalright = 1;
+    if ( !empty($dbl) ) {
+        foreach ( $dbl as $line ) {
+            if ( !$line['right'] ) $evalright = 1;
             else $evalright = verifCond($line['right']);
-            if ($evalright && ($line['allow_external'] || !$user->socid ))
-                            {
-                                include_once DOL_DOCUMENT_ROOT.$line['class_file'];
-                                $board = new $line['class_name']($db);
-                                if (! $line['extra_param']) $dashboardlines[] = $board->$line['class_func']($user);
-                else $dashboardlines[] = $board->$line['class_func']($user, $line['extra_param']);
+            if ( $evalright && ($line['allow_external'] || !$user->socid) ) {
+                include_once DOL_DOCUMENT_ROOT . $line['class_file'];
+                $board = new $line['class_name']($db);
+                if ( !$line['extra_param'] ) $dashboardlines[] = $board->$line['class_func']($user);
+                else $dashboardlines[] = $board->$line['class_func']($user , $line['extra_param']);
             }
         }
     }
 }
 
-function dbl_get_lines_from_db()
+function dbl_get_lines_from_db ()
 {
-        global $conf, $db;
+    global $conf , $db;
 
     $entity = $conf->entity;
 
-    $sql = "SELECT * FROM ".MAIN_DB_PREFIX."dashboardlines ";
-    $sql.= "WHERE entity = ".$entity;
+    $sql = "SELECT * FROM " . MAIN_DB_PREFIX . "dashboardlines ";
+    $sql .= "WHERE entity = " . $entity;
 
-    dol_syslog("Get modules dashboard lines", LOG_DEBUG);
+    dol_syslog("Get modules dashboard lines" , LOG_DEBUG);
     $resql = $db->query($sql);
 
     $dbl = array();
 
-    if ($resql) {
-               while ( $obj = $db->fetch_object($resql) ) {
-                        $line = array(
-                                'class_file'     => $obj->class_file ,
-                                'class_name'     => $obj->class_name ,
-                                'class_func'     => $obj->class_func ,
-                                'extra_param'    => $obj->extra_param ,
-                                'allow_external' => $obj->allow_external ,
-                                'right'          => $obj->perm
-                                );
+    if ( $resql ) {
+        while ( $obj = $db->fetch_object($resql) ) {
+            $line = array(
+                'class_file'     => $obj->class_file ,
+                'class_name'     => $obj->class_name ,
+                'class_func'     => $obj->class_func ,
+                'extra_param'    => $obj->extra_param ,
+                'allow_external' => $obj->allow_external ,
+                'right'          => $obj->perm
+            );
 
-                        $dbl[] = $line;
-                    }
+            $dbl[] = $line;
+        }
     }
 
     return $dbl;

--- a/htdocs/core/lib/dashboardlines.lib.php
+++ b/htdocs/core/lib/dashboardlines.lib.php
@@ -37,7 +37,7 @@ function dbl_get_dashboardlines ( &$dashboardlines )
                 include_once DOL_DOCUMENT_ROOT . $line['class_file'];
                 $board = new $line['class_name']($db);
                 if ( !$line['extra_param'] ) $dashboardlines[] = $board->$line['class_func']($user);
-                else $dashboardlines[] = $board->$line['class_func']($user , $line['extra_param']);
+                else $dashboardlines[] = $board->$line['class_func']($user, $line['extra_param']);
             }
         }
     }
@@ -52,7 +52,7 @@ function dbl_get_lines_from_db ()
     $sql = "SELECT * FROM " . MAIN_DB_PREFIX . "dashboardlines ";
     $sql .= "WHERE entity = " . $entity;
 
-    dol_syslog("Get modules dashboard lines" , LOG_DEBUG);
+    dol_syslog("Get modules dashboard lines", LOG_DEBUG);
     $resql = $db->query($sql);
 
     $dbl = array();

--- a/htdocs/core/lib/dashboardlines.lib.php
+++ b/htdocs/core/lib/dashboardlines.lib.php
@@ -1,0 +1,79 @@
+<?php
+/* Copyright (C) 2015   Peter Fontaine      <contact@peterfontaine.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *	\file       core/lib/dashboardlines.lib.php
+ *	\brief      Functions for dashboard
+ *	\ingroup    dashboardlines
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
+
+function dbl_get_dashboardlines(&$dashboardlines)
+{
+    global $user, $db;
+
+    $dbl = dbl_get_lines_from_db();
+
+    if (! empty($dbl))
+            {
+                foreach ($dbl as $line)
+                    {
+                        if (! $line['right']) $evalright = 1;
+            else $evalright = verifCond($line['right']);
+            if ($evalright && ($line['allow_external'] || !$user->socid ))
+                            {
+                                include_once DOL_DOCUMENT_ROOT.$line['class_file'];
+                                $board = new $line['class_name']($db);
+                                if (! $line['extra_param']) $dashboardlines[] = $board->$line['class_func']($user);
+                else $dashboardlines[] = $board->$line['class_func']($user, $line['extra_param']);
+            }
+        }
+    }
+}
+
+function dbl_get_lines_from_db()
+{
+        global $conf, $db;
+
+    $entity = $conf->entity;
+
+    $sql = "SELECT * FROM ".MAIN_DB_PREFIX."dashboardlines ";
+    $sql.= "WHERE entity = ".$entity;
+
+    dol_syslog("Get modules dashboard lines", LOG_DEBUG);
+    $resql = $db->query($sql);
+
+    $dbl = array();
+
+    if ($resql) {
+               while ( $obj = $db->fetch_object($resql) ) {
+                        $line = array(
+                                'class_file'     => $obj->class_file ,
+                                'class_name'     => $obj->class_name ,
+                                'class_func'     => $obj->class_func ,
+                                'extra_param'    => $obj->extra_param ,
+                                'allow_external' => $obj->allow_external ,
+                                'right'          => $obj->perm
+                                );
+
+                        $dbl[] = $line;
+                    }
+    }
+
+    return $dbl;
+}

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -194,7 +194,7 @@ class DolibarrModules           // Can not be abstract, because we need to insta
      * @var bool Module is enabled globally (Multicompany support)
      */
     public $core_enabled;
-    
+
     /**
      * @var array Module dashboard entries
      *

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2005-2015 Regis Houssin	<regis.houssin@capnetworks.com>
  * Copyright (C) 2011-2012 Juanjo Menent	<jmenent@2byte.es>
  * Copyright (C) 2015      Marcos García        <marcosgdf@gmail.com>
+ * Copyright (C) 2015      Peter Fontaine		<contact@peterfontaine.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,6 +29,7 @@ define('NOCSRFCHECK',1);	// This is login page. We must be able to go on it from
 
 require 'main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/dashboardlines.lib.php';
 
 // If not defined, we select menu "home"
 $_GET['mainmenu']=GETPOST('mainmenu', 'alpha')?GETPOST('mainmenu', 'alpha'):'home';
@@ -418,6 +420,9 @@ if (! empty($conf->expensereport->enabled) && $user->rights->expensereport->lire
 
 	$dashboardlines[] = $board->load_board($user);
 }
+
+// Adding lines from modules
+dbl_get_dashboardlines($dashboardlines);
 
 // Calculate total nb of late
 $totallate=0;

--- a/htdocs/install/mysql/migration/3.8.0-3.9.0.sql
+++ b/htdocs/install/mysql/migration/3.8.0-3.9.0.sql
@@ -42,3 +42,14 @@ create table llx_overwrite_trans
   transvalue      text
 )ENGINE=innodb;
 
+CREATE TABLE llx_dashboardlines (
+  rowid          integer      AUTO_INCREMENT PRIMARY KEY,
+  module         varchar(255) NOT NULL,
+  class_file     varchar(255) NOT NULL,
+  class_name     varchar(255) NOT NULL,
+  class_func     varchar(255) NOT NULL,
+  extra_param    varchar(255) DEFAULT NULL,
+  allow_external smallint     DEFAULT 0 NOT NULL,
+  perm           varchar(255) DEFAULT NULL,
+  entity         integer      DEFAULT 1 NOT NULL
+)ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_dashboardlines.sql
+++ b/htdocs/install/mysql/tables/llx_dashboardlines.sql
@@ -1,0 +1,29 @@
+-- ========================================================================
+-- Copyright (C) 2015   Peter Fontaine    <contact@peterfontaine.fr>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+--
+-- ========================================================================
+
+CREATE TABLE llx_dashboardlines (
+  rowid          integer      AUTO_INCREMENT PRIMARY KEY,
+  module         varchar(255) NOT NULL,
+  class_file     varchar(255) NOT NULL,
+  class_name     varchar(255) NOT NULL,
+  class_func     varchar(255) NOT NULL,
+  extra_param    varchar(255) DEFAULT NULL,
+  allow_external smallint     DEFAULT 0 NOT NULL,
+  perm           varchar(255) DEFAULT NULL,
+  entity         integer      DEFAULT 1 NOT NULL
+)ENGINE=innodb;


### PR DESCRIPTION
This addition to the code allows external modules to easily add lines in the dashboard without changing the file htdocs/index.php

To use this feature simply add a few lines in the module declaration file.
