### PR TITLE
FIX bad entity for login user on multicompany

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -443,6 +443,7 @@ if (! defined('NOLOGIN'))
         	$login = checkLoginPassEntity($usertotest,$passwordtotest,$entitytotest,$authmode);
         	if ($login)
             {
+            	$user->entity = $entitytotest;
                 $dol_authmode=$conf->authmode;	// This properties is defined only when logged, to say what mode was successfully used
                 $dol_tz=$_POST["tz"];
                 $dol_tz_string=$_POST["tz_string"];


### PR DESCRIPTION
The check for password is right but the fetched user is the first with right login, not login and entity
