### PR TITLE
FIX: When filter with empty status, by default get canceled status (-1)

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -338,7 +338,7 @@ if ($resql)
 	print '</td>';
 	print '<td align="right">';
 	$liststatus=array('0'=>$langs->trans("StatusOrderDraftShort"), '1'=>$langs->trans("StatusOrderValidated"), '2'=>$langs->trans("StatusOrderSentShort"), '3'=>$langs->trans("StatusOrderToBill"), '4'=>$langs->trans("StatusOrderProcessed"), '-1'=>$langs->trans("StatusOrderCanceledShort"));
-	print $form->selectarray('viewstatut', $liststatus, $viewstatut, 1);
+	print $form->selectarray('viewstatut', $liststatus, $viewstatut, -4);
 	print '</td>';
 	print '<td class="liste_titre" align="right"><input type="image" class="liste_titre" name="button_search" src="'.img_picto($langs->trans("Search"),'search.png','','',1).'" value="'.dol_escape_htmltag($langs->trans("Search")).'" title="'.dol_escape_htmltag($langs->trans("Search")).'">';
 	print '<input type="image" class="liste_titre" name="button_removefilter" src="'.img_picto($langs->trans("Search"),'searchclear.png','','',1).'" value="'.dol_escape_htmltag($langs->trans("RemoveFilter")).'" title="'.dol_escape_htmltag($langs->trans("RemoveFilter")).'">';

--- a/htdocs/product/class/productcustomerprice.class.php
+++ b/htdocs/product/class/productcustomerprice.class.php
@@ -307,8 +307,8 @@ class Productcustomerprice extends CommonObject
 	{
 		global $langs;
 
-		if (! empty($sortfield)) $sortfield = "t.rowid";
-		if (! empty($sortorder)) $sortorder = "DESC";
+		if ( empty($sortfield)) $sortfield = "t.rowid";
+		if ( empty($sortorder)) $sortorder = "DESC";
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";


### PR DESCRIPTION
Now, the empty status return -4 to avoid conflicts
