### PR TITLE
Erreur dol_trunc sur caractère spécial quand fonction mb_substr n'exi…

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1698,7 +1698,9 @@ function dol_substr($string,$start,$length,$stringencoding='')
 	}
 	else
 	{
+		$string = utf8_decode($string);//Pour coupe sur caractére spéciale
 		$ret=substr($string,$start,$length);
+                $ret = utf8_encode($ret);
 	}
 	return $ret;
 }


### PR DESCRIPTION
…ste pas.

Error when function mb_substr dont exist and trunc stop in special caractere
