### PR TITLE
CLOSE #2499 Made third parties country field mandatory

### DIFF
--- a/htdocs/langs/en_US/companies.lang
+++ b/htdocs/langs/en_US/companies.lang
@@ -429,3 +429,4 @@ MergeThirdparties=Merge third parties
 ConfirmMergeThirdparties=Are you sure you want to merge this third party into the current one ? All linked objects (invoices, orders, ...) will be moved to current third party so you will be able to delete the duplicate one.
 ThirdpartiesMergeSuccess=Thirdparties have been merged
 ErrorThirdpartiesMerge=There was an error when deleting the thirdparties. Please check the log. Changes have been reverted.
+ErrorCountryRequired=The country field is required

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -612,6 +612,11 @@ class Societe extends CommonObject
             }
         }
 
+		if (! $this->country_id) {
+			$this->errors[] = 'ErrorCountryRequired';
+			$result = -1;
+		}
+
         return $result;
     }
 

--- a/htdocs/societe/soc.php
+++ b/htdocs/societe/soc.php
@@ -1029,7 +1029,7 @@ else
         print '</td></tr>';
 
         // Country
-        print '<tr><td width="25%">'.fieldLabel('Country','selectcountry_id').'</td><td colspan="3" class="maxwidthonsmartphone">';
+        print '<tr><td width="25%" class="fieldrequired">'.fieldLabel('Country','selectcountry_id').'</td><td colspan="3" class="maxwidthonsmartphone">';
         print $form->select_country((GETPOST('country_id')!=''?GETPOST('country_id'):$object->country_id));
         if ($user->admin) print info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"),1);
         print '</td></tr>';
@@ -1567,7 +1567,7 @@ else
             print '</td></tr>';
 
             // Country
-            print '<tr><td>'.fieldLabel('Country','selectcounty_id').'</td><td colspan="3">';
+            print '<tr><td class="fieldrequired">'.fieldLabel('Country','selectcounty_id').'</td><td colspan="3">';
             print $form->select_country((GETPOST('country_id')!=''?GETPOST('country_id'):$object->country_id),'country_id');
             if ($user->admin) print info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"),1);
             print '</td></tr>';


### PR DESCRIPTION
The thirdparty country is a vital information for Dolibarr processing.
VAT amounts and other taxes depends on its presence.
Making it mandatory mitigates these issues in a simple and efficient way.
