### PR TITLE
Fix unittests regression

### DIFF
--- a/htdocs/core/modules/modWebServicesClient.class.php
+++ b/htdocs/core/modules/modWebServicesClient.class.php
@@ -18,7 +18,7 @@
 /**
  *      \defgroup   webservices     Module webservices
  *      \brief      Module to enable client for supplier WebServices
- *       \file       htdocs/core/modules/modSyncSupplierWebServices.class.php
+ *       \file       htdocs/core/modules/modWebServicesClient.class.php
  *       \ingroup    webservices
  *       \brief      File to describe client for supplier webservices module
  */

--- a/htdocs/install/filelist.xml
+++ b/htdocs/install/filelist.xml
@@ -6873,7 +6873,7 @@
 <md5file name="modCashDesk.class.php">69982f8171837cd8669bfe9c2f08dc8f</md5file>
 <md5file name="modLdap.class.php">ddf6dfeb77c98411b4d5434f20c24483</md5file>
 <md5file name="modFacture.class.php">c23010fa68c5996cb5977f84a6bb7ceb</md5file>
-<md5file name="modSyncSupplierWebServices.class.php">90a300e9bd857966226c68dca8660456</md5file>
+<md5file name="modWebServicesClient.class.php">822961d86ae558588632b3b08c085b89</md5file>
 <md5file name="index.html">d41d8cd98f00b204e9800998ecf8427e</md5file>
 <md5file name="modIncoterm.class.php">b4e9f07aa5268af49d3bb9429719b201</md5file>
 <md5file name="modFTP.class.php">8293bd60fe13ac64c22f8500b346821c</md5file>

--- a/test/phpunit/ModulesTest.php
+++ b/test/phpunit/ModulesTest.php
@@ -133,7 +133,7 @@ class ModulesTest extends PHPUnit_Framework_TestCase
 		'Facture','Fckeditor','Ficheinter','Fournisseur','FTP','GeoIPMaxmind','Gravatar','Holiday','Import','Label','Ldap',
 		'Mailing','MailmanSpip','Margin',
 		'Notification','OpenSurvey','Paybox','Paypal','Prelevement','Product','ProductBatch','Projet','Propale',
-		'Salaries','Service','Skype','Societe','Stock','SyncSupplierWebServices','Syslog','Tax','User','WebServices','Workflow');
+		'Salaries','Service','Skype','Societe','Stock','WebServicesClient','Syslog','Tax','User','WebServices','Workflow');
 		foreach($modulelist as $modlabel)
 		{
     		require_once(DOL_DOCUMENT_ROOT.'/core/modules/mod'.$modlabel.'.class.php');


### PR DESCRIPTION
Introduced by incomplete renaming
of modSyncSupplierWebServices to modWebServicesClient
in 4b103ba8ce6c2da955ab8ecb17258b5ba0f52b40
