### PR TITLE
Conflict with external module lead in project

### DIFF
--- a/htdocs/install/mysql/migration/3.7.0-3.8.0.sql
+++ b/htdocs/install/mysql/migration/3.7.0-3.8.0.sql
@@ -720,6 +720,16 @@ create table llx_c_lead_status
   active      tinyint DEFAULT 1 NOT NULL
 )ENGINE=innodb;
 
+ALTER TABLE llx_c_lead_status ADD COLUMN position integer AFTER label;
+ALTER TABLE llx_c_lead_status ADD COLUMN percent double(5,2) AFTER position;
+UPDATE llx_c_lead_status SET position='10' , percent='0' WHERE code='PROSP';
+UPDATE llx_c_lead_status SET position='20' , percent='20' WHERE code='QUAL';
+UPDATE llx_c_lead_status SET position='30' , percent='40' WHERE code='PROPO';
+UPDATE llx_c_lead_status SET position='40' , percent='60' WHERE code='NEGO';
+UPDATE llx_c_lead_status SET position='50' , percent='50' WHERE code='PENDING';
+UPDATE llx_c_lead_status SET position='60' , percent='100' WHERE code='WIN';
+UPDATE llx_c_lead_status SET position='70' , percent='0' WHERE code='LOST';
+
 -- Opportunities status
 INSERT INTO llx_c_lead_status(rowid,code,label,position,percent,active) VALUES (1,'PROSP'  ,'Prospection',  10, 0,1);
 INSERT INTO llx_c_lead_status(rowid,code,label,position,percent,active) VALUES (2,'QUAL'   ,'Qualification',20, 20,1);


### PR DESCRIPTION
Dolibarr has detected a technical error.
This is information that can help diagnostic:
Date: 20151012001611
Dolibarr: 3.8.1
Level of features: 0
PHP: 5.5.9-1ubuntu4.13
Server: Apache/2.4.7 (Ubuntu)
OS: Linux 3.13.0-65-generic #106-Ubuntu SMP Fri Oct 2 22:08:27 UTC 2015 x86_64
UserAgent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:41.0) Gecko/20100101 Firefox/41.0

Requested Url: /ALL/erp/projet/index.php?mainmenu=project&leftmenu=
Referer: http://localhost/ALL/erp/admin/ihm.php?mainmenu=home&leftmenu=setup
Menu manager: eldy_menu.php

Database type manager: mysql
Request for last database access in error: SELECT cls.rowid, cls.code, cls.percent, cls.label FROM llx_c_lead_status as cls
Return code for last database access in error: DB_ERROR_NOSUCHFIELD
Information for last database access in error: Unknown column 'cls.percent' in 'field list'
