### PR TITLE
Bad chmod for directory when changing product ref

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -765,8 +765,10 @@ class Product extends CommonObject
 						$newdir = $conf->product->dir_output . "/" . dol_sanitizeFileName($this->ref);
 						if (file_exists($olddir))
 						{
-							include_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
-							$res = dol_move($olddir, $newdir, '0775');
+							//include_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+							//$res = dol_move($olddir, $newdir);
+							// do not use dol_move with directory
+							$res = @rename($olddir, $newdir);
 							if (! $res)
 							{
 								$this->error='ErrorFailToMoveDir';

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -766,7 +766,7 @@ class Product extends CommonObject
 						if (file_exists($olddir))
 						{
 							include_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
-							$res=dol_move($olddir, $newdir);
+							$res = dol_move($olddir, $newdir, '0775');
 							if (! $res)
 							{
 								$this->error='ErrorFailToMoveDir';


### PR DESCRIPTION
When changing product ref, the old document directory is renamed and chmod 0664 in place of 0775
