### PR TITLE
Fix getFullName() on a non-object in notify.class.php

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -143,7 +143,7 @@ class Notify
      */
     function send($action, $object)
     {
-        global $conf,$langs,$mysoc,$dolibarr_main_url_root;
+        global $user,$conf,$langs,$mysoc,$dolibarr_main_url_root;
 
 	    include_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 


### PR DESCRIPTION
http://www.dolibarr.fr/forum/12-howto--aide/54061-probleme-sur-la-validation-des-commande-fournisseu
Fatal error: Call to a member function getFullName() on a non-object in /home/xxxx/public_html/xxxxx/htdocs/core/class/notify.class.php on line 374
