### PR TITLE
NEW: no more default rights defined by default

### DIFF
--- a/htdocs/admin/modules.php
+++ b/htdocs/admin/modules.php
@@ -79,6 +79,11 @@ if ($action == 'set' && $user->admin)
 {
     $result=activateModule($value);
     if ($result) setEventMessages($result, null, 'errors');
+	else
+	{
+		$msg = $langs->trans('ModuleEnabledAdminMustCheckRights');
+		setEventMessages($msg, null, 'warnings');
+	}
     header("Location: modules.php?mode=".$mode.$param.($page_y?'&page_y='.$page_y:''));
 	exit;
 }

--- a/htdocs/core/lib/usergroups.lib.php
+++ b/htdocs/core/lib/usergroups.lib.php
@@ -62,7 +62,7 @@ function user_prepare_head($object)
 	if ($canreadperms)
 	{
 		$head[$h][0] = DOL_URL_ROOT.'/user/perms.php?id='.$object->id;
-		$head[$h][1] = $langs->trans("UserRights");
+		$head[$h][1] = $langs->trans("UserRights"). ' <span class="badge">'.($object->nb_rights).'</span>';
 		$head[$h][2] = 'rights';
 		$h++;
 	}

--- a/htdocs/core/modules/modAdherent.class.php
+++ b/htdocs/core/modules/modAdherent.class.php
@@ -209,7 +209,7 @@ class modAdherent extends DolibarrModules
         $this->rights[$r][0] = 71;
         $this->rights[$r][1] = 'Read members\' card';
         $this->rights[$r][2] = 'r';
-        $this->rights[$r][3] = 1;
+        $this->rights[$r][3] = 0;
         $this->rights[$r][4] = 'lire';
 
         $r++;
@@ -244,7 +244,7 @@ class modAdherent extends DolibarrModules
         $this->rights[$r][0] = 78;
         $this->rights[$r][1] = 'Read subscriptions';
         $this->rights[$r][2] = 'r';
-        $this->rights[$r][3] = 1;
+        $this->rights[$r][3] = 0;
         $this->rights[$r][4] = 'cotisation';
         $this->rights[$r][5] = 'lire';
 

--- a/htdocs/core/modules/modAgenda.class.php
+++ b/htdocs/core/modules/modAgenda.class.php
@@ -118,7 +118,7 @@ class modAgenda extends DolibarrModules
 		$this->rights[$r][0] = 2401;
 		$this->rights[$r][1] = 'Read actions/tasks linked to his account';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'myactions';
 		$this->rights[$r][5] = 'read';
 		$r++;

--- a/htdocs/core/modules/modApi.class.php
+++ b/htdocs/core/modules/modApi.class.php
@@ -155,7 +155,7 @@ class modApi extends DolibarrModules
 		// Example:
 		// $this->rights[$r][0] = $this->numero + $r;	// Permission id (must not be already used)
 		// $this->rights[$r][1] = 'Permision label';	// Permission label
-		// $this->rights[$r][3] = 1; 					// Permission by default for new user (0/1)
+		// $this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		// $this->rights[$r][4] = 'level1';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		// $this->rights[$r][5] = 'level2';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		// $r++;

--- a/htdocs/core/modules/modBanque.class.php
+++ b/htdocs/core/modules/modBanque.class.php
@@ -89,7 +89,7 @@ class modBanque extends DolibarrModules
 		$this->rights[$r][0] = 111; // id de la permission
 		$this->rights[$r][1] = 'Lire les comptes bancaires'; // libelle de la permission
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modBookmark.class.php
+++ b/htdocs/core/modules/modBookmark.class.php
@@ -81,21 +81,21 @@ class modBookmark extends DolibarrModules
 		$this->rights[$r][0] = 331; // id de la permission
 		$this->rights[$r][1] = 'Lire les bookmarks'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = 332; // id de la permission
 		$this->rights[$r][1] = 'Creer/modifier les bookmarks'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = 333; // id de la permission
 		$this->rights[$r][1] = 'Supprimer les bookmarks'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (d�pr�ci� � ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par d�faut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par d�faut
 		$this->rights[$r][4] = 'supprimer';
 
 	}

--- a/htdocs/core/modules/modCashDesk.class.php
+++ b/htdocs/core/modules/modCashDesk.class.php
@@ -86,7 +86,7 @@ class modCashDesk extends DolibarrModules
 		$this->rights[$r][0] = 50101;
 		$this->rights[$r][1] = 'Use point of sale';
 		$this->rights[$r][2] = 'a';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'use';
 
 		// Main menu entries

--- a/htdocs/core/modules/modCategorie.class.php
+++ b/htdocs/core/modules/modCategorie.class.php
@@ -89,7 +89,7 @@ class modCategorie extends DolibarrModules
 		$this->rights[$r][0] = 241; // id de la permission
 		$this->rights[$r][1] = 'Lire les categories'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'lire';
 		$r++;
 

--- a/htdocs/core/modules/modCommande.class.php
+++ b/htdocs/core/modules/modCommande.class.php
@@ -114,7 +114,7 @@ class modCommande extends DolibarrModules
 		$this->rights[$r][0] = 81;
 		$this->rights[$r][1] = 'Lire les commandes clients';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modComptabilite.class.php
+++ b/htdocs/core/modules/modComptabilite.class.php
@@ -91,7 +91,7 @@ class modComptabilite extends DolibarrModules
 		$this->rights[$r][0] = 95;
 		$this->rights[$r][1] = 'Lire CA, bilans, resultats';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'resultat';
 		$this->rights[$r][5] = 'lire';
 	}

--- a/htdocs/core/modules/modContrat.class.php
+++ b/htdocs/core/modules/modContrat.class.php
@@ -91,7 +91,7 @@ class modContrat extends DolibarrModules
 		$this->rights[$r][0] = 161;
 		$this->rights[$r][1] = 'Lire les contrats';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modCron.class.php
+++ b/htdocs/core/modules/modCron.class.php
@@ -108,7 +108,7 @@ class modCron extends DolibarrModules
 		
 		$this->rights[$r][0] = 23001;
 		$this->rights[$r][1] = 'Read cron jobs';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'read';
 		$r++;
 

--- a/htdocs/core/modules/modDocumentGeneration.class.php
+++ b/htdocs/core/modules/modDocumentGeneration.class.php
@@ -84,7 +84,7 @@ class modDocumentGeneration extends DolibarrModules
 		$this->rights[$r][0] = 1521;
 		$this->rights[$r][1] = 'Lire les documents';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modECM.class.php
+++ b/htdocs/core/modules/modECM.class.php
@@ -101,21 +101,21 @@ class modECM extends DolibarrModules
 		$this->rights[$r][0] = 2501;
 		$this->rights[$r][1] = 'Consulter/Télécharger les documents';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'read';
 
 		$r++;
 		$this->rights[$r][0] = 2503;
 		$this->rights[$r][1] = 'Soumettre ou supprimer des documents';
 		$this->rights[$r][2] = 'w';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'upload';
 
 		$r++;
 		$this->rights[$r][0] = 2515;
 		$this->rights[$r][1] = 'Administrer les rubriques de documents';
 		$this->rights[$r][2] = 'w';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'setup';
 
 

--- a/htdocs/core/modules/modExpedition.class.php
+++ b/htdocs/core/modules/modExpedition.class.php
@@ -145,7 +145,7 @@ class modExpedition extends DolibarrModules
 		$this->rights[$r][0] = 101;
 		$this->rights[$r][1] = 'Lire les expeditions';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
@@ -190,7 +190,7 @@ class modExpedition extends DolibarrModules
 		$this->rights[$r][0] = 1101;
 		$this->rights[$r][1] = 'Lire les bons de livraison';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'livraison';
 		$this->rights[$r][5] = 'lire';
 

--- a/htdocs/core/modules/modExport.class.php
+++ b/htdocs/core/modules/modExport.class.php
@@ -81,7 +81,7 @@ class modExport extends DolibarrModules
 		$this->rights[$r][0] = 1201;
 		$this->rights[$r][1] = 'Lire les exports';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modFTP.class.php
+++ b/htdocs/core/modules/modFTP.class.php
@@ -97,7 +97,7 @@ class modFTP extends DolibarrModules
 		$this->rights[$r][0] = 2801;
 		$this->rights[$r][1] = 'Use FTP client in read mode (browse and download only)';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'read';
 
 		$r++;

--- a/htdocs/core/modules/modFacture.class.php
+++ b/htdocs/core/modules/modFacture.class.php
@@ -126,7 +126,7 @@ class modFacture extends DolibarrModules
 		$this->rights[$r][0] = 11;
 		$this->rights[$r][1] = 'Lire les factures';
 		$this->rights[$r][2] = 'a';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modFicheinter.class.php
+++ b/htdocs/core/modules/modFicheinter.class.php
@@ -99,7 +99,7 @@ class modFicheinter extends DolibarrModules
         $this->rights[$r][0] = 61;
         $this->rights[$r][1] = 'Lire les fiches d\'intervention';
         $this->rights[$r][2] = 'r';
-        $this->rights[$r][3] = 1;
+        $this->rights[$r][3] = 0;
         $this->rights[$r][4] = 'lire';
 
         $r++;

--- a/htdocs/core/modules/modFournisseur.class.php
+++ b/htdocs/core/modules/modFournisseur.class.php
@@ -129,14 +129,14 @@ class modFournisseur extends DolibarrModules
 		$this->rights[$r][0] = 1181;
 		$this->rights[$r][1] = 'Consulter les fournisseurs';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = 1182;
 		$this->rights[$r][1] = 'Consulter les commandes fournisseur';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'commande';
 		$this->rights[$r][5] = 'lire';
 
@@ -209,7 +209,7 @@ class modFournisseur extends DolibarrModules
 		$this->rights[$r][0] = 1231;
 		$this->rights[$r][1] = 'Consulter les factures fournisseur';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'facture';
 		$this->rights[$r][5] = 'lire';
 

--- a/htdocs/core/modules/modGravatar.class.php
+++ b/htdocs/core/modules/modGravatar.class.php
@@ -114,7 +114,7 @@ class modGravatar extends DolibarrModules
 		// Example:
 		// $this->rights[$r][0] = 2000; 				// Permission id (must not be already used)
 		// $this->rights[$r][1] = 'Permision label';	// Permission label
-		// $this->rights[$r][3] = 1; 					// Permission by default for new user (0/1)
+		// $this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		// $this->rights[$r][4] = 'level1';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		// $this->rights[$r][5] = 'level2';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		// $r++;

--- a/htdocs/core/modules/modHRM.class.php
+++ b/htdocs/core/modules/modHRM.class.php
@@ -99,21 +99,21 @@ class modHRM extends DolibarrModules
 
 		$this->rights[$r][0] = 4001;
 		$this->rights[$r][1] = 'See employees';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'employee';
 		$this->rights[$r][5] = 'read';
 		$r ++;
 		
 		$this->rights[$r][0] = 4002;
 		$this->rights[$r][1] = 'Create employees';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'employee';
 		$this->rights[$r][5] = 'write';
 		$r ++;
 		
 		$this->rights[$r][0] = 4003;
 		$this->rights[$r][1] = 'Delete employees';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'employee';
 		$this->rights[$r][5] = 'delete';
 		$r ++;

--- a/htdocs/core/modules/modHoliday.class.php
+++ b/htdocs/core/modules/modHoliday.class.php
@@ -133,14 +133,14 @@ class modHoliday extends DolibarrModules
 
 		$this->rights[$r][0] = 20001; 				// Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read your own holidays';	// Permission label
-		$this->rights[$r][3] = 1; 					// Permission by default for new user (0/1)
+		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = '';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$r++;
 
 		$this->rights[$r][0] = 20002; 				// Permission id (must not be already used)
 		$this->rights[$r][1] = 'Create/modify your own holidays';	// Permission label
-		$this->rights[$r][3] = 1; 					// Permission by default for new user (0/1)
+		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'write';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = '';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$r++;

--- a/htdocs/core/modules/modLoan.class.php
+++ b/htdocs/core/modules/modLoan.class.php
@@ -99,7 +99,7 @@ class modLoan extends DolibarrModules
 		$this->rights[$r][0] = 520;
 		$this->rights[$r][1] = 'Read loans';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'read';
 		$this->rights[$r][5] = '';
 

--- a/htdocs/core/modules/modMailing.class.php
+++ b/htdocs/core/modules/modMailing.class.php
@@ -79,7 +79,7 @@ class modMailing extends DolibarrModules
 		$this->rights[$r][0] = 221; // id de la permission
 		$this->rights[$r][1] = 'Consulter les mailings'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modMargin.class.php
+++ b/htdocs/core/modules/modMargin.class.php
@@ -126,7 +126,7 @@ class modMargin extends DolibarrModules
 		$this->rights[$r][0] = 59001; // id de la permission
 		$this->rights[$r][1] = 'Visualiser les marges'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'liretous';
 
 		$r++;

--- a/htdocs/core/modules/modMultiCurrency.class.php
+++ b/htdocs/core/modules/modMultiCurrency.class.php
@@ -189,7 +189,7 @@ class modMultiCurrency extends DolibarrModules
 		// Example:
 		// $this->rights[$r][0] = $this->numero + $r;	// Permission id (must not be already used)
 		// $this->rights[$r][1] = 'Permision label';	// Permission label
-		// $this->rights[$r][3] = 1; 					// Permission by default for new user (0/1)
+		// $this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		// $this->rights[$r][4] = 'level1';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		// $this->rights[$r][5] = 'level2';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		// $r++;

--- a/htdocs/core/modules/modOauth.class.php
+++ b/htdocs/core/modules/modOauth.class.php
@@ -97,7 +97,7 @@ class modOauth extends DolibarrModules
         $this->rights[$r][0] = 66000;
         $this->rights[$r][1] = 'OauthAccess';
         $this->rights[$r][2] = 'r';
-        $this->rights[$r][3] = 1;
+        $this->rights[$r][3] = 0;
         $this->rights[$r][4] = 'read';*/
 
         // Main menu entries

--- a/htdocs/core/modules/modPaybox.class.php
+++ b/htdocs/core/modules/modPaybox.class.php
@@ -106,7 +106,7 @@ class modPayBox extends DolibarrModules
         // Example:
         // $this->rights[$r][0] = 2000; 				// Permission id (must not be already used)
         // $this->rights[$r][1] = 'Permision label';	// Permission label
-        // $this->rights[$r][3] = 1; 					// Permission by default for new user (0/1)
+        // $this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
         // $this->rights[$r][4] = 'level1';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
         // $this->rights[$r][5] = 'level2';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
         // $r++;

--- a/htdocs/core/modules/modPrelevement.class.php
+++ b/htdocs/core/modules/modPrelevement.class.php
@@ -85,7 +85,7 @@ class modPrelevement extends DolibarrModules
 		$this->rights[$r][0] = 151;
 		$this->rights[$r][1] = 'Read withdrawals';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'bons';
 		$this->rights[$r][5] = 'lire';
 

--- a/htdocs/core/modules/modPrinting.class.php
+++ b/htdocs/core/modules/modPrinting.class.php
@@ -97,7 +97,7 @@ class modPrinting extends DolibarrModules
         $this->rights[$r][0] = 64001;
         $this->rights[$r][1] = 'DirectPrint';
         $this->rights[$r][2] = 'r';
-        $this->rights[$r][3] = 1;
+        $this->rights[$r][3] = 0;
         $this->rights[$r][4] = 'read';
 
         // Main menu entries

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -99,7 +99,7 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][0] = 31; // id de la permission
 		$this->rights[$r][1] = 'Lire les produits'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'lire';
 		$r++;
 

--- a/htdocs/core/modules/modProjet.class.php
+++ b/htdocs/core/modules/modProjet.class.php
@@ -149,7 +149,7 @@ class modProjet extends DolibarrModules
 		$this->rights[$r][0] = 41; // id de la permission
 		$this->rights[$r][1] = "Read projects and tasks (shared projects or projects I am contact for). Can also enter time consumed on assigned tasks (timesheet)"; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modPropale.class.php
+++ b/htdocs/core/modules/modPropale.class.php
@@ -116,7 +116,7 @@ class modPropale extends DolibarrModules
 		$this->rights[$r][0] = 21; // id de la permission
 		$this->rights[$r][1] = 'Lire les propositions commerciales'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modReceiptPrinter.class.php
+++ b/htdocs/core/modules/modReceiptPrinter.class.php
@@ -97,7 +97,7 @@ class modReceiptPrinter extends DolibarrModules
         $this->rights[$r][0] = 67000;
         $this->rights[$r][1] = 'ReceiptPrinter';
         $this->rights[$r][2] = 'r';
-        $this->rights[$r][3] = 1;
+        $this->rights[$r][3] = 0;
         $this->rights[$r][4] = 'read';
 
         // Main menu entries

--- a/htdocs/core/modules/modResource.class.php
+++ b/htdocs/core/modules/modResource.class.php
@@ -204,7 +204,7 @@ class modResource extends DolibarrModules
 		//// Permission label
 		//$this->rights[$r][1] = 'Permision label';
 		//// Permission by default for new user (0/1)
-		//$this->rights[$r][3] = 1;
+		//$this->rights[$r][3] = 0;
 		//// In php code, permission will be checked by test
 		//// if ($user->rights->permkey->level1->level2)
 		//$this->rights[$r][4] = 'level1';

--- a/htdocs/core/modules/modService.class.php
+++ b/htdocs/core/modules/modService.class.php
@@ -88,7 +88,7 @@ class modService extends DolibarrModules
 		$this->rights[$r][0] = 531; // id de la permission
 		$this->rights[$r][1] = 'Lire les services'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'lire';
         $r++;
 

--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -143,7 +143,7 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 121; // id de la permission
 		$this->rights[$r][1] = 'Lire les societes'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'lire';
 
 /*		$r++;
@@ -206,7 +206,7 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 262;
 		$this->rights[$r][1] = 'Consulter tous les tiers par utilisateurs internes (sinon uniquement si contact commercial). Non effectif pour utilisateurs externes (tjs limités à eux-meme).';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'client';
 		$this->rights[$r][5] = 'voir';
 
@@ -214,7 +214,7 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 281; // id de la permission
 		$this->rights[$r][1] = 'Lire les contacts'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'contact';
 		$this->rights[$r][5] = 'lire';
 

--- a/htdocs/core/modules/modSupplierProposal.class.php
+++ b/htdocs/core/modules/modSupplierProposal.class.php
@@ -102,13 +102,13 @@ class modSupplierProposal extends DolibarrModules
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
 		$this->rights[$r][1] = 'Read supplier proposals'; // libelle de la permission
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
 		$this->rights[$r][1] = 'Create/modify supplier proposals'; // libelle de la permission
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
 		$this->rights[$r][4] = 'creer';
 
 		$r++;

--- a/htdocs/core/modules/modTax.class.php
+++ b/htdocs/core/modules/modTax.class.php
@@ -88,7 +88,7 @@ class modTax extends DolibarrModules
 		$this->rights[$r][0] = 91;
 		$this->rights[$r][1] = 'Lire les charges';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'charges';
 		$this->rights[$r][5] = 'lire';
 

--- a/htdocs/core/modules/modUser.class.php
+++ b/htdocs/core/modules/modUser.class.php
@@ -134,7 +134,7 @@ class modUser extends DolibarrModules
 		$this->rights[$r][0] = 341;
 		$this->rights[$r][1] = 'Consulter ses propres permissions';
 		$this->rights[$r][2] = 'r';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'self_advance';        // Visible if option MAIN_USE_ADVANCED_PERMS is on
 		$this->rights[$r][5] = 'readperms';
 
@@ -142,7 +142,7 @@ class modUser extends DolibarrModules
 		$this->rights[$r][0] = 342;
 		$this->rights[$r][1] = 'Creer/modifier ses propres infos utilisateur';
 		$this->rights[$r][2] = 'w';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'self';
 		$this->rights[$r][5] = 'creer';
 
@@ -150,7 +150,7 @@ class modUser extends DolibarrModules
 		$this->rights[$r][0] = 343;
 		$this->rights[$r][1] = 'Modifier son propre mot de passe';
 		$this->rights[$r][2] = 'w';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'self';
 		$this->rights[$r][5] = 'password';
 
@@ -158,7 +158,7 @@ class modUser extends DolibarrModules
 		$this->rights[$r][0] = 344;
 		$this->rights[$r][1] = 'Modifier ses propres permissions';
 		$this->rights[$r][2] = 'w';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'self_advance';          // Visible if option MAIN_USE_ADVANCED_PERMS is on
 		$this->rights[$r][5] = 'writeperms';
 

--- a/htdocs/core/modules/modWebsites.class.php
+++ b/htdocs/core/modules/modWebsites.class.php
@@ -92,7 +92,7 @@ class modWebsites extends DolibarrModules
 
 		$this->rights[$r][0] = 10001;
 		$this->rights[$r][1] = 'Read website content';
-		$this->rights[$r][3] = 1;
+		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'read';
 		$r++;
 

--- a/htdocs/core/modules/modWorkflow.class.php
+++ b/htdocs/core/modules/modWorkflow.class.php
@@ -94,7 +94,7 @@ class modWorkflow extends DolibarrModules
         $this->rights[$r][0] = 6001; // id de la permission
         $this->rights[$r][1] = "Lire les workflow"; // libelle de la permission
         $this->rights[$r][2] = 'r'; // type de la permission (deprecie a ce jour)
-        $this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
+        $this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
         $this->rights[$r][4] = 'read';
         */
 

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -1752,3 +1752,5 @@ AddSubstitutions=Add keys substitutions
 DetectionNotPossible=Detection not possible
 UrlToGetKeyToUseAPIs=Url to get token to use API (once token has been received it is saved on database user table and will be checked on each future access) 
 ListOfAvailableAPIs=List of available APIs
+ModuleEnabledAdminMustCheckRights=Module has been activated. All permissions were given to admin users only.
+UserHasNoPermissions=This user has no permission defined

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -1129,6 +1129,10 @@ else
         $object->fetch($id);
         if ($res < 0) { dol_print_error($db,$object->error); exit; }
         $res=$object->fetch_optionals($object->id,$extralabels);
+		
+		// Check if user has rights
+		$object->getrights();
+		if(empty($object->nb_rights)) setEventMessages($langs->trans('UserHasNoPermissions'), null, 'warnings');
 
         // Connexion ldap
         // pour recuperer passDoNotExpire et userChangePassNextLogon

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -107,6 +107,7 @@ class User extends CommonObject
 	var $rights;                        // Array of permissions user->rights->permx
 	var $all_permissions_are_loaded;	/**< \private all_permissions_are_loaded */
 	private $_tab_loaded=array();		// Array of cache of already loaded permissions
+	var $nb_rights;						// Number of rights granted to the user
 
 	var $conf;           			// To store personal config
 	var $oldcopy;                	// To contains a clone of this when we need to save old properties of object
@@ -138,6 +139,7 @@ class User extends CommonObject
 
 		// For cache usage
 		$this->all_permissions_are_loaded = 0;
+		$this->nb_rights = 0;
 
 		// Force some default values
 		$this->admin = 0;
@@ -629,10 +631,12 @@ class User extends CommonObject
 					if ($subperms)
 					{
 						if (! isset($this->rights->$module->$perms) || ! is_object($this->rights->$module->$perms)) $this->rights->$module->$perms = new stdClass();
+						if(empty($this->rights->$module->$perms->$subperms)) $this->nb_rights++;
 						$this->rights->$module->$perms->$subperms = 1;
 					}
 					else
 					{
+						if(empty($this->rights->$module->$perms)) $this->nb_rights++;
 						$this->rights->$module->$perms = 1;
 					}
 
@@ -679,10 +683,12 @@ class User extends CommonObject
 					if ($subperms)
 					{
 						if (! isset($this->rights->$module->$perms) || ! is_object($this->rights->$module->$perms)) $this->rights->$module->$perms = new stdClass();
+						if(empty($this->rights->$module->$perms->$subperms)) $this->nb_rights++;
 						$this->rights->$module->$perms->$subperms = 1;
 					}
 					else
 					{
+						if(empty($this->rights->$module->$perms)) $this->nb_rights++;
 						$this->rights->$module->$perms = 1;
 					}
 


### PR DESCRIPTION
That's a suggestion I'd like to make. From my point of view, having default permission given when a module is activated is a bad practice. It happended many times that a new user is created and has by default rights to read "everything" (bank accounts, invoices, ...).
Rights should be managed by administrator on user or groups cards.

Open to suggestions or opposite points of view :)
