### PR TITLE
Missing argument 1 for CommonDocGenerator::__construct()

### DIFF
--- a/htdocs/exports/index.php
+++ b/htdocs/exports/index.php
@@ -123,7 +123,7 @@ print '<td align="right">'.$langs->trans("LibraryVersion").'</td>';
 print '</tr>';
 
 include_once DOL_DOCUMENT_ROOT.'/core/modules/export/modules_export.php';
-$model=new ModeleExports();
+$model=new ModeleExports($db);
 $liste=$model->liste_modeles($db);    // This is not a static method for exports because method load non static properties
 
 $var=true;


### PR DESCRIPTION
add _construct on htdocs/core/class/commondocgenerator.class.php class need to send $db as parameters
