### PR TITLE
FIX #3726 Not showing images on product card

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3764,7 +3764,7 @@ function get_exdir($num,$level,$alpha,$withoutslash,$object,$modulepart)
 	// TODO if object is null, load it from id and modulepart.
 
 
-	if (! empty($level) && in_array($modulepart, array('cheque','user','category','holiday','shipment', 'member','don','donation','supplier_invoice','invoice_supplier')))
+	if (! empty($level) && in_array($modulepart, array('cheque','user','category','holiday','shipment', 'member','don','donation','supplier_invoice','invoice_supplier','product')))
 	{
 		// This part should be removed once all code is using "get_exdir" to forge path, with all parameters provided
 		if (empty($alpha)) $num = preg_replace('/([^0-9])/i','',$num);

--- a/htdocs/product/document.php
+++ b/htdocs/product/document.php
@@ -70,8 +70,10 @@ if ($id > 0 || ! empty($ref))
 {
     $result = $object->fetch($id, $ref);
 
-    if (! empty($conf->product->enabled)) $upload_dir = $conf->product->multidir_output[$object->entity].'/'.dol_sanitizeFileName($object->ref);
-    elseif (! empty($conf->service->enabled)) $upload_dir = $conf->service->multidir_output[$object->entity].'/'.dol_sanitizeFileName($object->ref);
+    if (! empty($conf->product->enabled)) $upload_dir = $conf->product->multidir_output[$object->entity].'/';
+    elseif (! empty($conf->service->enabled)) $upload_dir = $conf->service->multidir_output[$object->entity].'/';
+	if($conf->global->PRODUCT_USE_OLD_PATH_FOR_PHOTO)$upload_dir.= get_exdir($object->id,2,0,0,$object,'product').$object->id."/photos";
+	else $upload_dir.= dol_sanitizeFileName($object->ref);
 }
 $modulepart='produit';
 

--- a/htdocs/product/document.php
+++ b/htdocs/product/document.php
@@ -72,7 +72,7 @@ if ($id > 0 || ! empty($ref))
 
     if (! empty($conf->product->enabled)) $upload_dir = $conf->product->multidir_output[$object->entity].'/';
     elseif (! empty($conf->service->enabled)) $upload_dir = $conf->service->multidir_output[$object->entity].'/';
-	if($conf->global->PRODUCT_USE_OLD_PATH_FOR_PHOTO)$upload_dir.= get_exdir($object->id,2,0,0,$object,'product').$object->id."/photos";
+	if (! empty($conf->global->PRODUCT_USE_OLD_PATH_FOR_PHOTO)) $upload_dir.= get_exdir($object->id,2,0,0,$object,'product').$object->id."/photos";
 	else $upload_dir.= dol_sanitizeFileName($object->ref);
 }
 $modulepart='produit';


### PR DESCRIPTION
The get_exdir function did't consider products.

On the other hand, when upload documents to the products didn't consider whether the global variable PRODUCT_USE_OLD_PATH_FOR_PHOTO is active or not.
