### PR TITLE
FIX #3928 Creating a Customer order and a Customer invoice from a project, does not inherit payment conditions and method of payment of customer card

### DIFF
--- a/htdocs/commande/fiche.php
+++ b/htdocs/commande/fiche.php
@@ -1366,6 +1366,9 @@ if ($action == 'create' && $user->rights->commande->creer) {
 	if ($socid > 0)
 		$res = $soc->fetch($socid);
 
+	$projectid = 0;
+	$remise_absolue = 0;
+
 	if (! empty($origin) && ! empty($originid)) {
 		// Parse element/subelement (ex: project_task)
 		$element = $subelement = $origin;
@@ -1423,17 +1426,26 @@ if ($action == 'create' && $user->rights->commande->creer) {
 			$srccontactslist = $objectsrc->liste_contact(- 1, 'external', 1);
 		}
 	}
-	else
-	{
-		$cond_reglement_id  = $soc->cond_reglement_id;
-		$mode_reglement_id  = $soc->mode_reglement_id;
-		$availability_id    = $soc->availability_id;
-		$demand_reason_id   = $soc->demand_reason_id;
-		$remise_percent     = $soc->remise_percent;
-		$remise_absolue     = 0;
-		$dateinvoice        = empty($conf->global->MAIN_AUTOFILL_DATE)?-1:'';
-		$projectid          = 0;
+
+	if (!$cond_reglement_id) {
+		$cond_reglement_id = $soc->cond_reglement_id;
 	}
+	if (!$mode_reglement_id) {
+		$mode_reglement_id = $soc->mode_reglement_id;
+	}
+	if (!$availability_id) {
+		$availability_id = $soc->availability_id;
+	}
+	if (!$demand_reason_id) {
+		$demand_reason_id = $soc->demand_reason_id;
+	}
+	if (!$remise_percent) {
+		$remise_percent = $soc->remise_percent;
+	}
+	if (!$dateinvoice) {
+		$dateinvoice = empty($conf->global->MAIN_AUTOFILL_DATE) ? - 1 : '';
+	}
+
 	$absolute_discount=$soc->getAvailableDiscounts();
 
 	$nbrow = 10;

--- a/htdocs/compta/facture.php
+++ b/htdocs/compta/facture.php
@@ -1860,6 +1860,8 @@ if ($action == 'create')
 	if ($socid > 0)
 		$res = $soc->fetch($socid);
 
+	$remise_absolue = 0;
+
 	if (! empty($origin) && ! empty($originid))
 	{
 		// Parse element/subelement (ex: project_task)
@@ -1916,14 +1918,21 @@ if ($action == 'create')
 		}
 		$dateinvoice = empty($conf->global->MAIN_AUTOFILL_DATE) ? -1 : '';	// Dot not set 0 here (0 for a date is 1970)
 	}
-	else
-	{
-		$cond_reglement_id 	= $soc->cond_reglement_id;
-		$mode_reglement_id 	= $soc->mode_reglement_id;
-		$remise_percent 	= $soc->remise_percent;
-		$remise_absolue 	= 0;
-		$dateinvoice		= (empty($dateinvoice)?(empty($conf->global->MAIN_AUTOFILL_DATE)?-1:''):$dateinvoice);		// Do not set 0 here (0 for a date is 1970)
+
+	if (!$cond_reglement_id) {
+		$cond_reglement_id = $soc->cond_reglement_id;
 	}
+	if (!$mode_reglement_id) {
+		$mode_reglement_id = $soc->mode_reglement_id;
+	}
+	if (!$remise_percent) {
+		$remise_percent = $soc->remise_percent;
+	}
+	if (!$dateinvoice) {
+		// Do not set 0 here (0 for a date is 1970)
+		$dateinvoice = (empty($dateinvoice)?(empty($conf->global->MAIN_AUTOFILL_DATE)?-1:''):$dateinvoice);
+	}
+
 	$absolute_discount = $soc->getAvailableDiscounts();
 
 	if (! empty($conf->use_javascript_ajax))


### PR DESCRIPTION
FIX #3928 Creating a Customer order and a Customer invoice from a project, does not inherit payment conditions and method of payment of customer card

Close #3928
