### PR TITLE
FIX #3931 [Insight] Logical operators should be avoided - in htdocs/core/class/extrafields.class.php, line 261

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -258,7 +258,7 @@ class ExtraFields
 
 		if (! empty($attrname) && preg_match("/^\w[a-zA-Z0-9-_]*$/",$attrname) && ! is_numeric($attrname))
 		{
-			if(is_array($param) and count($param) > 0)
+			if(is_array($param) && count($param) > 0)
 			{
 				$params = $this->db->escape(serialize($param));
 			}


### PR DESCRIPTION
FIX #3931 [Insight] Logical operators should be avoided - in htdocs/core/class/extrafields.class.php, line 261

Close #3931
