### PR TITLE
Correct pattern to match all odt var tags

### DIFF
--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -284,7 +284,7 @@ IMG;
 	private function _parse($type='content')
 	{
 	    // Search all tags fou into condition to complete $this->vars, so we will proceed all tests even if not defined
-	    $reg='@\[!--\sIF\s([{}a-zA-Z_]+)\s--\]@smU';
+	    $reg='@\[!--\sIF\s([{}a-zA-Z0-9\.\,_]+)\s--\]@smU';
 	    preg_match_all($reg, $this->contentXml, $matches, PREG_SET_ORDER);
 	    //var_dump($this->vars);exit;
 	    foreach($matches as $match)   // For each match, if there is no entry into this->vars, we add it


### PR DESCRIPTION
some vars like {object_total_vat_local_x.y} or {object_total_vat_local_x,y} could not be tested to know if they were existing with [!-- IF {xxx} --] syntax
