### PR TITLE
FIX #3996 Dictionnary hooks are not working in 3.8

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -148,7 +148,9 @@ class HookManager
 				'printAddress',
 				'printSearchForm',
 				'formatEvent',
-				'addCalendarChoice'
+				'addCalendarChoice',
+				'createDictionaryFieldList',
+				'editDictionaryFieldlist'
 				)
 			)) $hooktype='addreplace';
         // Deprecated hook types ('returnvalue')


### PR DESCRIPTION
FIX #3996 Dictionnary hooks are not working in 3.8
