### PR TITLE
FIX #3992 CommandeFournisseur::ref is marked as deprecated and it shouldn't be

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -54,7 +54,7 @@ class CommandeFournisseur extends CommonOrder
 
 	/**
 	 * Supplier invoice reference
-     * @var string
+	 * @var string
 	 */
     var $ref;
     var $ref_supplier;

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -53,12 +53,10 @@ class CommandeFournisseur extends CommonOrder
     var $id;
 
 	/**
-	 * TODO: Remove
-	 * @deprecated
-	 * @see product_ref
+	 * Supplier invoice reference
+     * @var string
 	 */
     var $ref;
-    var $product_ref;
     var $ref_supplier;
     var $brouillon;
     var $statut;			// 0=Draft -> 1=Validated -> 2=Approved -> 3=Process runing -> 4=Received partially -> 5=Received totally -> (reopen) 4=Received partially


### PR DESCRIPTION
FIX #3992 CommandeFournisseur::ref is marked as deprecated and it shouldn't be
