### PR TITLE
FIX #3989 Undefined variable $conf in CommandeFournisseur::getNomUrl

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -574,7 +574,7 @@ class CommandeFournisseur extends CommonOrder
      */
     function getNomUrl($withpicto=0,$option='')
     {
-        global $langs;
+        global $langs, $conf;
 
         $result='';
         $label = '<u>' . $langs->trans("ShowOrder") . '</u>';


### PR DESCRIPTION
FIX #3989 Undefined variable $conf in CommandeFournisseur::getNomUrl
