### PR TITLE
FIX can not have access to the new ids or propal lines on PROPAL_CLONE

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1162,7 +1162,7 @@ class Propal extends CommonObject
             }
 
             // Call trigger
-            $result=$this->call_trigger('PROPAL_CLONE',$user);
+            $result=$clonedObj->call_trigger('PROPAL_CLONE',$user);
             if ($result < 0) { $error++; }
             // End call triggers
         }


### PR DESCRIPTION
With module we can't have the ids of propal lines cloned with the trigger PROPAL_CLONE.
I tried to fetch the object but still old propal lines ids.
