### PR TITLE
Add a trigger for product translation deletion

### DIFF
--- a/htdocs/core/triggers/interface_90_all_Demo.class.php-NORUN
+++ b/htdocs/core/triggers/interface_90_all_Demo.class.php-NORUN
@@ -101,6 +101,7 @@ class InterfaceDemo extends DolibarrTriggers
 		    case 'PRODUCT_DELETE':
 		    case 'PRODUCT_PRICE_MODIFY':
 		    case 'PRODUCT_SET_MULTILANGS':
+		    case 'PRODUCT_DEL_MULTILANGS':
 
 			//Stock mouvement
 		    case 'STOCK_MOVEMENT':

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1067,9 +1067,11 @@ class Product extends CommonObject
 	 *	Delete a language for this product
 	 *
 	 *  @param		string	$langtodelete		Language code to delete
+	 *	@param		User	$user       Object user making delete
+	 *
 	 *	@return		int							<0 if KO, >0 if OK
 	 */
-	function delMultiLangs($langtodelete)
+	function delMultiLangs($langtodelete, $user)
 	{
 		$sql = "DELETE FROM ".MAIN_DB_PREFIX."product_lang";
 		$sql.= " WHERE fk_product=".$this->id." AND lang='".$this->db->escape($langtodelete)."'";
@@ -1078,6 +1080,14 @@ class Product extends CommonObject
 		$result = $this->db->query($sql);
 		if ($result)
 		{
+			// Call trigger
+			$result = $this->call_trigger('PRODUCT_DEL_MULTILANGS',$user);
+			if ($result < 0) {
+				$this->error = $this->db->lasterror();
+				dol_syslog(get_class($this).'::delMultiLangs error='.$this->error, LOG_ERR);
+				return -1;
+			}
+			// End call triggers
 			return 1;
 		}
 		else

--- a/htdocs/product/traduction.php
+++ b/htdocs/product/traduction.php
@@ -60,7 +60,7 @@ if ($action == 'delete' && GETPOST('langtodelete','alpha'))
 {
 	$object = new Product($db);
 	$object->fetch($id);
-	$object->delMultiLangs(GETPOST('langtodelete','alpha'));
+	$object->delMultiLangs(GETPOST('langtodelete','alpha'), $user);
 }
 
 // Add translation
@@ -144,7 +144,7 @@ $cancel != $langs->trans("Cancel") &&
 	$langtodelete=GETPOST('langdel','alpha');
 
 
-	if ( $object->delMultiLangs($langtodelete) > 0 )
+	if ( $object->delMultiLangs($langtodelete, $user) > 0 )
 	{
 		$action = '';
 	}


### PR DESCRIPTION
In my previous pull request, i missed that product translations could be deleted.
So lets add a trigger for that. Category translations dont have a deletion for now.
