### PR TITLE
FIX #4043 Incorrect translation in error mesage in menu creation admin page

### DIFF
--- a/htdocs/admin/menus/edit.php
+++ b/htdocs/admin/menus/edit.php
@@ -147,7 +147,7 @@ if ($action == 'add')
     }
     if (! $error && ! $_POST['url'])
     {
-	    setEventMessage($langs->trans("ErrorFieldRequired",$langs->trans("Url")), 'errors');
+	    setEventMessage($langs->trans("ErrorFieldRequired",$langs->trans("URL")), 'errors');
         $action = 'create';
         $error++;
     }


### PR DESCRIPTION
FIX #4043 Incorrect translation in error mesage in menu creation admin page
