### PR TITLE
FIX #4016 User link is not correctly formed in emailing receivers

### DIFF
--- a/htdocs/comm/mailing/cibles.php
+++ b/htdocs/comm/mailing/cibles.php
@@ -485,13 +485,14 @@ if ($object->fetch($id) >= 0)
                     {
                         include_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
                         $m=new Adherent($db);
-                        $m->id=$obj->source_id;
+						$m->fetch($obj->source_id);
                         print $m->getNomUrl(2);
                     }
                     else if ($obj->source_type == 'user')
                     {
                         include_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
                         $m=new User($db);
+						$m->fetch($obj->source_id);
                         $m->id=$obj->source_id;
                         print $m->getNomUrl(2);
                     }
@@ -499,7 +500,7 @@ if ($object->fetch($id) >= 0)
                     {
                         include_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
                         $m=new Societe($db);
-                        $m->id=$obj->source_id;
+						$m->fetch($obj->source_id);
                         print $m->getNomUrl(2);
                     }
                     else


### PR DESCRIPTION
FIX #4016 User link is not correctly formed in emailing receivers
