### PR TITLE
FIX #4018 SQL error if trying to access the mailing/card.php page without an ID defined

### DIFF
--- a/htdocs/comm/mailing/class/mailing.class.php
+++ b/htdocs/comm/mailing/class/mailing.class.php
@@ -196,7 +196,7 @@ class Mailing extends CommonObject
 		$sql.= ", m.date_envoi";
 		$sql.= ", m.extraparams";
 		$sql.= " FROM ".MAIN_DB_PREFIX."mailing as m";
-		$sql.= " WHERE m.rowid = ".$rowid;
+		$sql.= " WHERE m.rowid = ".(int) $rowid;
 
 		dol_syslog(get_class($this)."::fetch", LOG_DEBUG);
 		$result=$this->db->query($sql);


### PR DESCRIPTION
FIX #4018 SQL error if trying to access the mailing/card.php page without an ID defined
