### PR TITLE
FIX #4049 PHP warning when trying to access a non-existing product/service

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1569,7 +1569,6 @@ else
     }
     else if ($action != 'create')
     {
-        header("Location: index.php");
         exit;
     }
 }


### PR DESCRIPTION
FIX #4049 PHP warning when trying to access a non-existing product/service
