### PR TITLE
FIX #3987 Undefined variable $newref in CommandeFournisseur::approve

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -765,7 +765,6 @@ class CommandeFournisseur extends CommonOrder
 
                 if (! $error)
                 {
-                	$this->ref=$newref;
                 	if ($movetoapprovestatus) $this->statut = 2;
 					else $this->statut = 1;
            			if (empty($secondlevel))	// standard or first level approval

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -765,6 +765,8 @@ class CommandeFournisseur extends CommonOrder
 
                 if (! $error)
                 {
+                	$this->ref = $this->newref;
+                	
                 	if ($movetoapprovestatus) $this->statut = 2;
 					else $this->statut = 1;
            			if (empty($secondlevel))	// standard or first level approval


### PR DESCRIPTION
FIX #3987 Undefined variable $newref in CommandeFournisseur::approve
