### PR TITLE
FIX #3734 Do not show empty links of deleted source objects in stock movement list

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -508,7 +508,10 @@ class MouvementStock
 				break;
 		}
 		
-		$origin->fetch($fk_origin);
-		return $origin->getNomUrl(1);
+		if ($origin->fetch($fk_origin) > 0) {
+			return $origin->getNomUrl(1);
+		}
+
+		return '';
 	}
 }


### PR DESCRIPTION
FIX #3734 Do not show empty links of deleted source objects in stock movement list
