### PR TITLE
FIX #3233 [Barcode] Setup page engine lists should only show generators supporting the format

### DIFF
--- a/htdocs/admin/barcode.php
+++ b/htdocs/admin/barcode.php
@@ -274,7 +274,7 @@ if ($resql)
 		print '</td>';
 
 		print '<td align="center">';
-		print $formbarcode->setBarcodeEncoder($obj->coder,$barcodelist,$obj->rowid,'form'.$i);
+		print $formbarcode->setBarcodeEncoder($obj->coder,$barcodelist,$obj->rowid,'form'.$i, $obj->encoding);
 		print "</td></tr>\n";
 		$var=!$var;
 		$i++;

--- a/htdocs/core/class/html.formbarcode.class.php
+++ b/htdocs/core/class/html.formbarcode.class.php
@@ -94,6 +94,9 @@ class FormBarCode
         foreach($barcodelist as $key => $value)
         {
             if ($encoding) {
+                $res = 0;
+                $result = false;
+
                 foreach ($dirbarcode as $reldir) {
                     $dir = dol_buildpath($reldir, 0);
                     $newdir = dol_osencode($dir);


### PR DESCRIPTION
FIX #3233 [Barcode] Setup page engine lists should only show generators supporting the format

I don't really like the solution but I am limited by the rules of fixing bugs in older releases
