### PR TITLE
Fix : situation percent should be 100 by default

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -3897,7 +3897,7 @@ class FactureLigne extends CommonInvoiceLine
 		if (empty($this->special_code)) $this->special_code=0;
 		if (empty($this->fk_parent_line)) $this->fk_parent_line=0;
 		if (empty($this->fk_prev_id)) $this->fk_prev_id = 'null';
-		if (empty($this->situation_percent)) $this->situation_percent = 0;
+		if (empty($this->situation_percent)) $this->situation_percent = 100;
 
 		if (empty($this->pa_ht)) $this->pa_ht=0;
 


### PR DESCRIPTION
I noticed big calculation errors due to this new column, for example when a deposit is added to an invoice, this column contains 0 so the total_ttc of the deposit is recalculated to 0.
