### PR TITLE
FIX jquery select of project generate js error on change event

### DIFF
--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -148,7 +148,7 @@ class FormProjets
 			if (! empty($conf->use_javascript_ajax))
 			{
 				include_once DOL_DOCUMENT_ROOT . '/core/lib/ajax.lib.php';
-	           	$comboenhancement = ajax_combobox($htmlname, '', 0, $forcefocus);
+	           	$comboenhancement = ajax_combobox($htmlname, array(), 0, $forcefocus);
             	$out.=$comboenhancement;
             	$nodatarole=($comboenhancement?' data-role="none"':'');
             	$minmax='minwidth100 maxwidth300';


### PR DESCRIPTION
When we use the jquery select of projects we got every time "TypeError: invalid 'in' operand a".
