### PR TITLE
FIX: Warning: implode(): Invalid arguments passed

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1551,7 +1551,7 @@ class ExtraFields
 				else if (in_array($key_type,array('checkbox')))
 				{
 					$value_arr=GETPOST($keysuffix."options_".$key.$keyprefix);
-					$value_key=implode(',', $value_arr);
+					$value_key=implode(',', (array)$value_arr);
 				}
 				else if (in_array($key_type,array('price','double')))
 				{

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1551,7 +1551,9 @@ class ExtraFields
 				else if (in_array($key_type,array('checkbox')))
 				{
 					$value_arr=GETPOST($keysuffix."options_".$key.$keyprefix);
-					$value_key=implode(',', (array)$value_arr);
+					// Make sure we get an array even if there's only one checkbox
+					$value_arr=(array)$value_arr
+					$value_key=implode(',', $value_arr);
 				}
 				else if (in_array($key_type,array('price','double')))
 				{


### PR DESCRIPTION
 Declare array type before implode to avoid warning
