### PR TITLE
FIX: Cannot set property '_renderItem of undefined 

### DIFF
--- a/htdocs/core/js/lib_head.js
+++ b/htdocs/core/js/lib_head.js
@@ -864,8 +864,8 @@ function confirmConstantAction(action, url, code, input, box, entity, yesButton,
                 .addClass( "ui-widget ui-widget-content ui-corner-left dolibarrcombobox" );
 
             input.data("ui-autocomplete")._renderItem = function( ul, item ) {
-                return $("<li></li>")
-                    .data( "item.autocomplete", item )
+                return $("<li>")
+                    .data( "ui-autocomplete-item", item ) // jQuery UI > 1.10.0
                     .append( "<a>" + item.label + "</a>" )
                     .appendTo( ul );
             };

--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -170,8 +170,8 @@ function ajax_autocompleter($selected, $htmlname, $url, $urloption='', $minLengt
     					}
     					,delay: 500
 					}).data("ui-autocomplete")._renderItem = function( ul, item ) {
-						return $("<li></li>")
-						.data( "item.autocomplete", item )
+						return $("<li>")
+						.data( "ui-autocomplete-item", item ) // jQuery UI > 1.10.0
 						.append( \'<a><span class="tag">\' + item.label + "</span></a>" )
 						.appendTo(ul);
 					};


### PR DESCRIPTION
Since Dolibarr use jQuery 1.11+, this function should use the new syntax.
http://jqueryui.com/upgrade-guide/1.10/#autocomplete
