### PR TITLE
addLogCP and updateSoledCP methodes throwing warnings when assigning leave for a user

### DIFF
--- a/htdocs/.gitignore
+++ b/htdocs/.gitignore
@@ -20,3 +20,4 @@
 /allscreens*
 /ecommerce/
 /cabinetmed*
+/conf/conf.php

--- a/htdocs/holiday/define_holiday.php
+++ b/htdocs/holiday/define_holiday.php
@@ -130,10 +130,15 @@ elseif($action == 'add_event')
         $add_holiday = $holiday->getValueEventCp($event);
         $new_holiday = $nb_holiday + $add_holiday;
 
-        // On ajoute la modification dans le LOG
-        $holiday->addLogCP($user->id,$userCP, $holiday->getNameEventCp($event),$new_holiday);
+        // add event to existing types of vacation
+        foreach ($typeleaves as $key => $leave) {
+        	$vacationTypeID = $leave['rowid'];
 
-        $holiday->updateSoldeCP($userCP,$new_holiday);
+	        // On ajoute la modification dans le LOG
+	        $holiday->addLogCP($user->id,$userCP, $holiday->getNameEventCp($event),$new_holiday, $vacationTypeID);
+
+	        $holiday->updateSoldeCP($userCP,$new_holiday, $vacationTypeID);
+        }
 
 		setEventMessages('AddEventToUserOkCP', '', 'mesgs');
     }


### PR DESCRIPTION
the two methods in holiday module creates warnings as the fifth parameter in addLogCP method is missing, the same thing for updateSoldeCP method except that for this method the parameter missing is the third one, the parameter is the type of vacation which is required and can not be null in both tables in database.

the second commit is for ignoring the conf.php file as it contains sensitive data.
