### PR TITLE
FIX #3953 Don't round supplier price

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -554,7 +554,7 @@ jQuery(document).ready(function() {
 
 	      		/* Define default price at loading */
 	      		var defaultprice = $("#fournprice_predef").find('option:selected').attr("price");
-	      		$("#buying_price").val(parseFloat(defaultprice).toFixed(<?php print ($conf->global->MAIN_MAX_DECIMALS_UNIT ? $conf->global->MAIN_MAX_DECIMALS_UNIT : 5); ?>));
+			    $("#buying_price").val(defaultprice);
 
 	      		$("#fournprice_predef").change(function() {
 		      		console.log("change on fournprice_predef");


### PR DESCRIPTION
The price is already rounded when inserted on the product page.
It's also rounded at display.
There's no need to round it here.
Rounding it leads to serious calculation errors.
