### PR TITLE
[Qual] OOP constructor

### DIFF
--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -1590,7 +1590,7 @@ class ExpenseReportLine
      *
      * @param DoliDB    $db     Handlet database
      */
-    function ExpenseReportLine($db)
+    function __construct($db)
     {
         $this->db= $db;
     }


### PR DESCRIPTION
Using class name as constructor method is deprecated in PHP 7
