### PR TITLE
FIX label of line is set in description field if empty

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -324,7 +324,7 @@ if (empty($reshook))
 							for($i = 0; $i < $num; $i ++)
 							{
 								$label = (! empty($lines[$i]->label) ? $lines[$i]->label : '');
-								$desc = (! empty($lines[$i]->desc) ? $lines[$i]->desc : $lines[$i]->libelle);
+								$desc = (! empty($lines[$i]->desc) ? $lines[$i]->desc : '');
 								$product_type = (! empty($lines[$i]->product_type) ? $lines[$i]->product_type : 0);
 
 								// Dates


### PR DESCRIPTION
When we create order from propal, the labels of lines are set in description field in the new lines of order if the desc is empty.
