### PR TITLE
Include local constants files and fetch their values to the correspon…

### DIFF
--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -205,6 +205,16 @@ class Conf
 
 		    $db->free($resql);
 		}
+	        // Include local constants files and fetch their values to the corresponding database constants
+	        if(! empty($this->global->LOCAL_CONSTS_FILES)) {
+	            $filesList = explode(":", $this->global->LOCAL_CONSTS_FILES);
+	            foreach ($filesList as $file) {
+	                include_once DOL_DOCUMENT_ROOT . "/$file/{$file}_consts.php";
+	                foreach ($file2bddconsts as $key=>$value) {
+	                    $conf->global->$key=constant($value);
+	                }
+	            }
+	        }
 		//var_dump($this->modules);
 		//var_dump($this->modules_parts['theme']);
 

--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -209,6 +209,7 @@ class Conf
 	        if(! empty($this->global->LOCAL_CONSTS_FILES)) {
 	            $filesList = explode(":", $this->global->LOCAL_CONSTS_FILES);
 	            foreach ($filesList as $file) {
+	                $file=dol_sanitizeFileName($file);
 	                include_once DOL_DOCUMENT_ROOT . "/$file/{$file}_consts.php";
 	                foreach ($file2bddconsts as $key=>$value) {
 	                    $conf->global->$key=constant($value);


### PR DESCRIPTION
…ding database constants

Modules may declare their file constants in a file named as : "module name"_consts.php and located in the module root folder.
They may also assign a correspondence between file constants they define and their equivalent database constants in a table named $file2bddconsts defined in their constants file.
To get this two functions the module need to add its name to the list of modules in LOCAL_CONSTS_FILES.
