### PR TITLE
FIX #4302 Undefined variable $conf in Commande::LibStatut

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2917,7 +2917,7 @@ class Commande extends CommonOrder
      */
     function LibStatut($statut,$billed,$mode)
     {
-        global $langs;
+        global $langs, $conf;
         //print 'x'.$statut.'-'.$billed;
         if ($mode == 0)
         {


### PR DESCRIPTION
FIX #4302 Undefined variable $conf in Commande::LibStatut
