### PR TITLE
FIX #3980 Search field in "product by supplier" list sends empty result 3.8 and 3.7

### DIFF
--- a/htdocs/fourn/product/list.php
+++ b/htdocs/fourn/product/list.php
@@ -108,7 +108,7 @@ if ($sref)
 }
 if ($snom)
 {
-	$sql .= natural_search('s.nom', $snom);
+	$sql .= natural_search('p.label', $snom);
 }
 if($catid)
 {


### PR DESCRIPTION
FIX #3980 Search field in "product by supplier" list sends empty result 3.8 and 3.7
