### PR TITLE
FIX #4272 Error when trying to print the page "Linked objects" of a Thirdparty

### DIFF
--- a/htdocs/societe/consumption.php
+++ b/htdocs/societe/consumption.php
@@ -177,10 +177,8 @@ dol_fiche_end();
 print '<br>';
 
 
-print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
+print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'?socid='.$socid.'">';
 print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
-print '<input type="hidden" name="socid" value="'.$socid.'">'."\n";
-
 
 $sql_select='';
 /*if ($type_element == 'action')


### PR DESCRIPTION
FIX #4272 Error when trying to print the page "Linked objects" of a Thirdparty
