### PR TITLE
FIX call trigger LINEBILL_SUPPLIER_CREATE

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -447,7 +447,7 @@ if (empty($reshook))
 	                            'HT',
 	                            $product_type,
 	                        	$lines[$i]->rang,
-	                        	1,
+	                        	0,
 	                        	$lines[$i]->array_options,
 	                        	$lines[$i]->fk_unit
 	                        );


### PR DESCRIPTION
When we create supplier invoice from supplier order, the trigger call was disabled on add line.
