### PR TITLE
FIX add product in supplier order dont get default discount

### DIFF
--- a/htdocs/fourn/commande/fiche.php
+++ b/htdocs/fourn/commande/fiche.php
@@ -250,7 +250,9 @@ else if ($action == 'addline' && $user->rights->fournisseur->commande->creer)
 
     		$tva_tx	= get_default_tva($object->thirdparty, $mysoc, $productsupplier->id, GETPOST('idprodfournprice'));
     		$type = $productsupplier->type;
-
+			
+			if (!empty($productsupplier->remise_percent)) $remise_percent = $productsupplier->remise_percent;
+			
     		// Local Taxes
     		$localtax1_tx= get_localtax($tva_tx, 1,$mysoc,$object->thirdparty);
     		$localtax2_tx= get_localtax($tva_tx, 2,$mysoc,$object->thirdparty);

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1171,7 +1171,7 @@ class Product extends CommonObject
 
 		// We do select by searching with qty and prodfournprice
 		$sql = "SELECT pfp.rowid, pfp.price as price, pfp.quantity as quantity,";
-		$sql.= " pfp.fk_product, pfp.ref_fourn, pfp.fk_soc, pfp.tva_tx";
+		$sql.= " pfp.fk_product, pfp.ref_fourn, pfp.fk_soc, pfp.tva_tx, pfp.remise_percent";
 		$sql.= " FROM ".MAIN_DB_PREFIX."product_fournisseur_price as pfp";
 		$sql.= " WHERE pfp.rowid = ".$prodfournprice;
 		if ($qty) $sql.= " AND pfp.quantity <= ".$qty;
@@ -1187,6 +1187,7 @@ class Product extends CommonObject
 				$this->fourn_pu = $obj->price / $obj->quantity;     // Prix unitaire du produit pour le fournisseur $fourn_id
 				$this->ref_fourn = $obj->ref_fourn;                 // Ref supplier
 				$this->vatrate_supplier = $obj->tva_tx;             // Vat ref supplier
+				$this->remise_percent = $obj->remise_percent;
 				$result=$obj->fk_product;
 				return $result;
 			}
@@ -1194,7 +1195,7 @@ class Product extends CommonObject
 			{
 				// We do same select again but searching with qty, ref and id product
 				$sql = "SELECT pfp.rowid, pfp.price as price, pfp.quantity as quantity, pfp.fk_soc,";
-				$sql.= " pfp.fk_product, pfp.ref_fourn as ref_supplier, pfp.tva_tx";
+				$sql.= " pfp.fk_product, pfp.ref_fourn as ref_supplier, pfp.tva_tx, pfp.remise_percent";
 				$sql.= " FROM ".MAIN_DB_PREFIX."product_fournisseur_price as pfp";
 				$sql.= " WHERE pfp.ref_fourn = '".$fourn_ref."'";
 				$sql.= " AND pfp.fk_product = ".$product_id;
@@ -1215,6 +1216,7 @@ class Product extends CommonObject
 						$this->ref_fourn = $obj->ref_supplier;              // deprecated
 						$this->ref_supplier = $obj->ref_supplier;           // Ref supplier
 						$this->vatrate_supplier = $obj->tva_tx;             // Vat ref supplier
+						$this->remise_percent = $obj->remise_percent;
 						$result=$obj->fk_product;
 						return $result;
 					}


### PR DESCRIPTION
When we have default discount percent on supplier price and we add the product to supplier order, the default discount is not used.
