### PR TITLE
FIX #2857, #4291 & #4341 Escape GETPOST alpha data by default

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1,16 +1,17 @@
 <?php
-/* Copyright (C) 2000-2007 Rodolphe Quiedeville <rodolphe@quiedeville.org>
- * Copyright (C) 2003      Jean-Louis Bergamo   <jlb@j1b.org>
- * Copyright (C) 2004-2013 Laurent Destailleur  <eldy@users.sourceforge.net>
- * Copyright (C) 2004      Sebastien Di Cintio  <sdicintio@ressource-toi.org>
- * Copyright (C) 2004      Benoit Mortier       <benoit.mortier@opensides.be>
- * Copyright (C) 2004      Christophe Combelles <ccomb@free.fr>
- * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@capnetworks.com>
- * Copyright (C) 2008      Raphael Bertrand (Resultic)       <raphael.bertrand@resultic.fr>
- * Copyright (C) 2010-2011 Juanjo Menent        <jmenent@2byte.es>
- * Copyright (C) 2013      Cédric Salvador      <csalvador@gpcsolutions.fr>
- * Copyright (C) 2013      Alexandre Spangaro   <alexandre.spangaro@gmail.com>
- * Copyright (C) 2014-2015 Marcos García        <marcosgdf@gmail.com>
+/* Copyright (C) 2000-2007  Rodolphe Quiedeville        <rodolphe@quiedeville.org>
+ * Copyright (C) 2003       Jean-Louis Bergamo          <jlb@j1b.org>
+ * Copyright (C) 2004-2013  Laurent Destailleur         <eldy@users.sourceforge.net>
+ * Copyright (C) 2004       Sebastien Di Cintio         <sdicintio@ressource-toi.org>
+ * Copyright (C) 2004       Benoit Mortier              <benoit.mortier@opensides.be>
+ * Copyright (C) 2004       Christophe Combelles        <ccomb@free.fr>
+ * Copyright (C) 2005-2012  Regis Houssin               <regis.houssin@capnetworks.com>
+ * Copyright (C) 2008       Raphael Bertrand (Resultic) <raphael.bertrand@resultic.fr>
+ * Copyright (C) 2010-2011  Juanjo Menent               <jmenent@2byte.es>
+ * Copyright (C) 2013       Cédric Salvador             <csalvador@gpcsolutions.fr>
+ * Copyright (C) 2013       Alexandre Spangaro          <alexandre.spangaro@gmail.com>
+ * Copyright (C) 2014-2015  Marcos García               <marcosgdf@gmail.com>
+ * Copyright (C) 2016       Raphaël Doursenaud          <rdoursenaud@gpcsolutions.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -194,10 +195,10 @@ function GETPOST($paramname,$check='',$method=0)
 		elseif ($check == 'alpha')
 		{
 			$out=trim($out);
-			// '"' is dangerous because param in url can close the href= or src= and add javascript functions.
 			// '../' is dangerous because it allows dir transversals
-			if (preg_match('/"/',$out)) $out='';
-			else if (preg_match('/\.\.\//',$out)) $out='';
+			if (preg_match('/\.\.\//',$out)) $out='';
+			// Quotes are dangerous because param in url can close the href= or src= and add javascript functions.
+			$out = htmlspecialchars($out, ENT_QUOTES);
 		}
 		elseif ($check == 'aZ')
 		{

--- a/test/phpunit/SecurityTest.php
+++ b/test/phpunit/SecurityTest.php
@@ -145,6 +145,7 @@ class SecurityTest extends PHPUnit_Framework_TestCase
 		$_GET["param2"]='a/b#e(pr)qq-rr\cc';
         $_GET["param3"]='"a/b#e(pr)qq-rr\cc';    // Same than param2 + "
         $_GET["param4"]='../dir';
+		$_GET["param5"] = '<h1>This is HTML</h1>';
 
         $result=GETPOST('id','int');              // Must return nothing
         print __METHOD__." result=".$result."\n";
@@ -162,13 +163,17 @@ class SecurityTest extends PHPUnit_Framework_TestCase
         print __METHOD__." result=".$result."\n";
         $this->assertEquals($result,$_GET["param2"]);
 
-        $result=GETPOST("param3",'alpha');  // Must return '' as there is a forbidden char "
+        $result=GETPOST("param3",'alpha');  // Must be escaped as there is a forbidden char "
         print __METHOD__." result=".$result."\n";
-        $this->assertEquals($result,'');
+        $this->assertEquals($result,'&quot;a/b#e(pr)qq-rr\cc');
 
         $result=GETPOST("param4",'alpha');  // Must return '' as there is a forbidden char ../
         print __METHOD__." result=".$result."\n";
         $this->assertEquals($result,'');
+
+		$result = GETPOST("param5", 'alpha');  // Must be escaped as it contains HTML characters
+		print __METHOD__ . " result=" . $result . "\n";
+		$this->assertEquals($result, '&lt;h1&gt;This is HTML&lt;/h1&gt;');
 
         return $result;
     }


### PR DESCRIPTION
This should mitigate most HTML injections allowing XSS.
