### PR TITLE
CLOSE #4366 Add hook for use custom ticket template

### DIFF
--- a/htdocs/cashdesk/validation_ticket.php
+++ b/htdocs/cashdesk/validation_ticket.php
@@ -24,12 +24,19 @@
 require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/cashdesk/include/environnement.php';
 require_once DOL_DOCUMENT_ROOT.'/cashdesk/class/Facturation.class.php';
+include_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
 
 $obj_facturation = unserialize($_SESSION['serObjFacturation']);
 unset($_SESSION['serObjFacturation']);
 
+$hookmanager->initHooks(array('cashdeskTplTicket'));
 
-require ('tpl/ticket.tpl.php');
+$parameters=array();
+$reshook=$hookmanager->executeHooks('doActions',$parameters,$obj_facturation);
+if (empty($reshook))
+{
+    require ('tpl/ticket.tpl.php');
+}
 
 
 $_SESSION['serObjFacturation'] = serialize($obj_facturation);


### PR DESCRIPTION
I have an ticket printer and I must generate a PDF whith good siez for print my ticket correctly.
I would have add a hook in cashdesk for no change dolibar codes after updates.
