### PR TITLE
FIX pdf supplier invoice is empty if created from supplier order

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1322,6 +1322,7 @@ class FactureFournisseur extends CommonInvoice
 	    } else {
 		    // Update total price into invoice record
 		    $res = $this->update_price('','auto');
+			$this->lines[] = $line;
 	    }
 
 	    return $res;


### PR DESCRIPTION
If we create a supplier invoice from supplier order, the current object->lines is empty
