### PR TITLE
NEW Quantity calculation on lines containing services with duration and date ranges

### DIFF
--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -41,6 +41,7 @@ require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/modules/propale/modules_propale.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/propal.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/doleditor.class.php';
 if (! empty($conf->projet->enabled)) {
@@ -725,6 +726,35 @@ if (empty($reshook))
 			$error ++;
 		}
 
+		$date_start = dol_mktime(GETPOST('date_start' . $predef . 'hour'), GETPOST('date_start' . $predef . 'min'), GETPOST('date_start' . $predef . 'sec'), GETPOST('date_start' . $predef . 'month'), GETPOST('date_start' . $predef . 'day'), GETPOST('date_start' . $predef . 'year'));
+		$date_end = dol_mktime(GETPOST('date_end' . $predef . 'hour'), GETPOST('date_end' . $predef . 'min'), GETPOST('date_end' . $predef . 'sec'), GETPOST('date_end' . $predef . 'month'), GETPOST('date_end' . $predef . 'day'), GETPOST('date_end' . $predef . 'year'));
+
+		if ($date_start && $date_end)
+		{
+			if ($date_start > $date_end)
+			{
+				setEventMessage($langs->trans('ErrorStartDateGreaterEnd'), 'errors');
+				$error++;
+			}
+			else if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+			{
+				$duration = GETPOST('durationvalue', 'int');
+				if (is_numeric($duration) && $duration > 0) {
+					$durationqty=calculateDurationQuantity($date_start, $date_end, $duration, GETPOST('durationunit', 'alpha'));
+					if ($durationqty < 1)
+					{
+						setEventMessage($langs->trans('DateRangeShortForDuration', 'errors'));
+						$error++;
+					}
+				}
+			}
+		}
+		if (empty($qty))
+		{
+		    setEventMessage($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Qty')), 'errors');
+		    $error++;
+		}
+
 		if (! $error && ($qty >= 0) && (! empty($product_desc) || ! empty($idprod))) {
 			$pu_ht = 0;
 			$pu_ttc = 0;
@@ -1005,10 +1035,37 @@ if (empty($reshook))
 			}
 		}
 
+		if ($date_start && $date_end)
+		{
+			if ($date_start > $date_end)
+			{
+				setEventMessage($langs->trans('ErrorStartDateGreaterEnd'), 'errors');
+				$error++;
+			}
+			else if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+			{
+				$duration = GETPOST('durationvalue', 'int');
+				if (is_numeric($duration) && $duration > 0) {
+					$durationqty=calculateDurationQuantity($date_start, $date_end, $duration, GETPOST('durationunit', 'alpha'));
+					if ($durationqty < 1)
+					{
+						setEventMessage($langs->trans('DateRangeShortForDuration', 'errors'));
+						$error++;
+					}
+				}
+			}
+		}
+		$qty = GETPOST('qty');
+		if (empty($qty))
+		{
+		    setEventMessage($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Qty')), 'errors');
+		    $error++;
+		}
+
 		if (! $error) {
 			$db->begin();
 
-			$result = $object->updateline(GETPOST('lineid'), $pu_ht, GETPOST('qty'), GETPOST('remise_percent'), $vat_rate, $localtax1_rate, $localtax2_rate, $description, 'HT', $info_bits, $special_code, GETPOST('fk_parent_line'), 0, $fournprice, $buyingprice, $label, $type, $date_start, $date_end, $array_options, $_POST["units"]);
+			$result = $object->updateline(GETPOST('lineid'), $pu_ht, $qty, GETPOST('remise_percent'), $vat_rate, $localtax1_rate, $localtax2_rate, $description, 'HT', $info_bits, $special_code, GETPOST('fk_parent_line'), 0, $fournprice, $buyingprice, $label, $type, $date_start, $date_end, $array_options, $_POST["units"]);
 
 			if ($result >= 0) {
 				$db->commit();

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -430,6 +430,7 @@ class Propal extends CommonObject
 					$product_type = $product->type;
 
 					if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+					{
 						if ($product_type == Product::TYPE_SERVICE && $date_start && $date_end && $product->duration_value && $product->duration_unit)
 						{
 							require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -419,17 +419,33 @@ class Propal extends CommonObject
         {
             $this->db->begin();
 
-        	$product_type=$type;
+			$durationqty = 1;
+			$product_type=$type;
 			if (!empty($fk_product))
 			{
 				$product=new Product($this->db);
 				$result=$product->fetch($fk_product);
-				$product_type=$product->type;
+				if ($result > 0)
+				{
+					$product_type = $product->type;
 
-				if (! empty($conf->global->STOCK_MUST_BE_ENOUGH_FOR_PROPOSAL) && $product_type == 0 && $product->stock_reel < $qty) {
-					$this->error=$langs->trans('ErrorStockIsNotEnough');
-					$this->db->rollback();
-					return -3;
+					if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+						if ($product_type == Product::TYPE_SERVICE && $date_start && $date_end && $product->duration_value && $product->duration_unit)
+						{
+							require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
+							$durationqty = calculateDurationQuantity($date_start, $date_end, $product->duration_value, $product->duration_unit);
+							if ($durationqty <= 0) {
+								$this->error = $langs->trans('DateRangeShortForDuration');
+								return -4;
+							}
+						}
+					}
+
+					if (! empty($conf->global->STOCK_MUST_BE_ENOUGH_FOR_PROPOSAL) && $product_type == 0 && $product->stock_reel < $qty * $durationqty) {
+						$this->error=$langs->trans('ErrorStockIsNotEnough');
+						$this->db->rollback();
+						return -3;
+					}
 				}
 			}
 			
@@ -441,7 +457,7 @@ class Propal extends CommonObject
             $localtaxes_type=getLocalTaxesFromRate($txtva,0,$this->thirdparty,$mysoc);
             $txtva = preg_replace('/\s*\(.*\)/','',$txtva);  // Remove code into vatrate.
             
-            $tabprice=calcul_price_total($qty, $pu, $remise_percent, $txtva, $txlocaltax1, $txlocaltax2, 0, $price_base_type, $info_bits, $product_type, $mysoc, $localtaxes_type);
+            $tabprice=calcul_price_total($qty * $durationqty, $pu, $remise_percent, $txtva, $txlocaltax1, $txlocaltax2, 0, $price_base_type, $info_bits, $product_type, $mysoc, $localtaxes_type);
 
             $total_ht  = $tabprice[0];
             $total_tva = $tabprice[1];
@@ -574,7 +590,7 @@ class Propal extends CommonObject
      */
 	function updateline($rowid, $pu, $qty, $remise_percent, $txtva, $txlocaltax1=0.0, $txlocaltax2=0.0, $desc='', $price_base_type='HT', $info_bits=0, $special_code=0, $fk_parent_line=0, $skip_update_total=0, $fk_fournprice=0, $pa_ht=0, $label='', $type=0, $date_start='', $date_end='', $array_options=0, $fk_unit=null)
     {
-        global $mysoc;
+        global $mysoc, $langs, $conf;
 
         dol_syslog(get_class($this)."::updateLine rowid=$rowid, pu=$pu, qty=$qty, remise_percent=$remise_percent,
         txtva=$txtva, desc=$desc, price_base_type=$price_base_type, info_bits=$info_bits, special_code=$special_code, fk_parent_line=$fk_parent_line, pa_ht=$pa_ht, type=$type, date_start=$date_start, date_end=$date_end");
@@ -595,6 +611,36 @@ class Propal extends CommonObject
         {
             $this->db->begin();
 
+            //Fetch current line from the database and then clone the object and set it in $oldline property
+            $line = new PropaleLigne($this->db);
+            $line->fetch($rowid);
+
+			$staticline = clone $line;
+
+            $line->oldline = $staticline;
+            $this->line = $line;
+            $this->line->context = $this->context;
+
+			//Calculate duration qty
+			$durationqty = 1;
+			if (!empty($this->line->fk_product))
+			{
+				$product=new Product($this->db);
+				$result=$product->fetch($this->line->fk_product);
+				if ($result > 0 && !empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+				{
+					if ($product->type == Product::TYPE_SERVICE && $date_start && $date_end && $product->duration_value && $product->duration_unit)
+					{
+						require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
+						$durationqty = calculateDurationQuantity($date_start, $date_end, $product->duration_value, $product->duration_unit);
+						if ($durationqty <= 0) {
+							$this->error = $langs->trans('DateRangeShortForDuration');
+							return -4 ;
+						}
+					}
+				}
+			}
+
             // Calcul du total TTC et de la TVA pour la ligne a partir de
             // qty, pu, remise_percent et txtva
             // TRES IMPORTANT: C'est au moment de l'insertion ligne qu'on doit stocker
@@ -603,7 +649,7 @@ class Propal extends CommonObject
             $localtaxes_type=getLocalTaxesFromRate($txtva,0,$this->thirdparty,$mysoc);
             $txtva = preg_replace('/\s*\(.*\)/','',$txtva);  // Remove code into vatrate.
             
-            $tabprice=calcul_price_total($qty, $pu, $remise_percent, $txtva, $txlocaltax1, $txlocaltax2, 0, $price_base_type, $info_bits, $type, $mysoc, $localtaxes_type);
+            $tabprice=calcul_price_total($qty * $durationqty, $pu, $remise_percent, $txtva, $txlocaltax1, $txlocaltax2, 0, $price_base_type, $info_bits, $type, $mysoc, $localtaxes_type);
             $total_ht  = $tabprice[0];
             $total_tva = $tabprice[1];
             $total_ttc = $tabprice[2];
@@ -617,16 +663,6 @@ class Propal extends CommonObject
                 $remise = round(($pu * $remise_percent / 100), 2);
                 $price = $pu - $remise;
             }
-
-            //Fetch current line from the database and then clone the object and set it in $oldline property
-            $line = new PropaleLigne($this->db);
-            $line->fetch($rowid);
-
-			$staticline = clone $line;
-
-            $line->oldline = $staticline;
-            $this->line = $line;
-            $this->line->context = $this->context;
 
             // Reorder if fk_parent_line change
             if (! empty($fk_parent_line) && ! empty($staticline->fk_parent_line) && $fk_parent_line != $staticline->fk_parent_line)
@@ -911,7 +947,7 @@ class Propal extends CommonObject
                         {
                             $error++;
                             $this->error=$this->db->error;
-                            dol_print_error($this->db);
+                            dol_print_error($this->db, "Error addline: ".$result);
                             break;
                         }
                         // Defined the new fk_parent_line

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -42,6 +42,7 @@ require_once DOL_DOCUMENT_ROOT . '/commande/class/commande.class.php';
 require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/order.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
 if (! empty($conf->propal->enabled))
 	require DOL_DOCUMENT_ROOT . '/comm/propal/class/propal.class.php';
@@ -624,6 +625,32 @@ if (empty($reshook))
 			$error++;
 		}
 
+		if ($date_start && $date_end)
+		{
+			if ($date_start > $date_end)
+			{
+				setEventMessage($langs->trans('ErrorStartDateGreaterEnd'), 'errors');
+				$error++;
+			}
+			else if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+			{
+				$duration = GETPOST('durationvalue', 'int');
+				if (is_numeric($duration) && $duration > 0) {
+					$durationqty=calculateDurationQuantity($date_start, $date_end, $duration, GETPOST('durationunit', 'alpha'));
+					if ($durationqty < 1)
+					{
+						setEventMessage($langs->trans('DateRangeShortForDuration', 'errors'));
+						$error++;
+					}
+				}
+			}
+		}
+		if (empty($qty))
+		{
+		    setEventMessage($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Qty')), 'errors');
+		    $error++;
+		}
+
 		if (! $error && ($qty >= 0) && (! empty($product_desc) || ! empty($idprod))) {
 			// Clean parameters
 			$date_start=dol_mktime(GETPOST('date_start'.$predef.'hour'), GETPOST('date_start'.$predef.'min'), GETPOST('date_start'.$predef.'sec'), GETPOST('date_start'.$predef.'month'), GETPOST('date_start'.$predef.'day'), GETPOST('date_start'.$predef.'year'));
@@ -830,14 +857,15 @@ if (empty($reshook))
 	 */
 	else if ($action == 'updateline' && $user->rights->commande->creer && GETPOST('save'))
 	{
+		$error = 0;
+
 		// Clean parameters
-		$date_start='';
-		$date_end='';
 		$date_start=dol_mktime(GETPOST('date_starthour'), GETPOST('date_startmin'), GETPOST('date_startsec'), GETPOST('date_startmonth'), GETPOST('date_startday'), GETPOST('date_startyear'));
 		$date_end=dol_mktime(GETPOST('date_endhour'), GETPOST('date_endmin'), GETPOST('date_endsec'), GETPOST('date_endmonth'), GETPOST('date_endday'), GETPOST('date_endyear'));
 		$description=dol_htmlcleanlastbr(GETPOST('product_desc'));
 		$pu_ht=GETPOST('price_ht');
 		$vat_rate=(GETPOST('tva_tx')?GETPOST('tva_tx'):0);
+		$qty=GETPOST('qty');
 
 		// Define info_bits
 		$info_bits = 0;
@@ -866,7 +894,7 @@ if (empty($reshook))
 
 		// Define special_code for special lines
 		$special_code=GETPOST('special_code');
-		if (! GETPOST('qty')) $special_code=3;
+		if (!$qty) $special_code=3;
 
 		// Check minimum price
 		$productid = GETPOST('productid', 'int');
@@ -897,8 +925,34 @@ if (empty($reshook))
 			}
 		}
 
+		if ($date_start && $date_end)
+		{
+			if ($date_start > $date_end)
+			{
+				setEventMessage($langs->trans('ErrorStartDateGreaterEnd'), 'errors');
+				$error++;
+			}
+			else if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+			{
+				$duration = GETPOST('durationvalue', 'int');
+				if (is_numeric($duration) && $duration > 0) {
+					$durationqty=calculateDurationQuantity($date_start, $date_end, $duration, GETPOST('durationunit', 'alpha'));
+					if ($durationqty < 1)
+					{
+						setEventMessage($langs->trans('DateRangeShortForDuration', 'errors'));
+						$error++;
+					}
+				}
+			}
+		}
+		if (empty($qty))
+		{
+		    setEventMessage($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Qty')), 'errors');
+		    $error++;
+		}
+
 		if (! $error) {
-			$result = $object->updateline(GETPOST('lineid'), $description, $pu_ht, GETPOST('qty'), GETPOST('remise_percent'), $vat_rate, $localtax1_rate, $localtax2_rate, 'HT', $info_bits, $date_start, $date_end, $type, GETPOST('fk_parent_line'), 0, $fournprice, $buyingprice, $label, $special_code, $array_options, GETPOST('units'));
+			$result = $object->updateline(GETPOST('lineid'), $description, $pu_ht, $qty, GETPOST('remise_percent'), $vat_rate, $localtax1_rate, $localtax2_rate, 'HT', $info_bits, $date_start, $date_end, $type, GETPOST('fk_parent_line'), 0, $fournprice, $buyingprice, $label, $special_code, $array_options, GETPOST('units'));
 
 			if ($result >= 0) {
 				if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) {

--- a/htdocs/compta/facture.php
+++ b/htdocs/compta/facture.php
@@ -1236,6 +1236,8 @@ if (empty($reshook))
 
 		$qty = GETPOST('qty' . $predef);
 		$remise_percent = GETPOST('remise_percent' . $predef);
+		$date_start = dol_mktime(GETPOST('date_start' . $predef . 'hour'), GETPOST('date_start' . $predef . 'min'), GETPOST('date_start' . $predef . 'sec'), GETPOST('date_start' . $predef . 'month'), GETPOST('date_start' . $predef . 'day'), GETPOST('date_start' . $predef . 'year'));
+		$date_end = dol_mktime(GETPOST('date_end' . $predef . 'hour'), GETPOST('date_end' . $predef . 'min'), GETPOST('date_end' . $predef . 'sec'), GETPOST('date_end' . $predef . 'month'), GETPOST('date_end' . $predef . 'day'), GETPOST('date_end' . $predef . 'year'));
 
 		// Extrafields
 		$extrafieldsline = new ExtraFields($db);
@@ -1270,11 +1272,28 @@ if (empty($reshook))
 			setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Description')), null, 'errors');
 			$error ++;
 		}
-		if ($qty < 0) {
-			$langs->load("errors");
-			setEventMessages($langs->trans('ErrorQtyForCustomerInvoiceCantBeNegative'), null, 'errors');
-			$error ++;
+
+		if ($date_start && $date_end)
+		{
+			if ($date_start > $date_end)
+			{
+				setEventMessage($langs->trans('ErrorStartDateGreaterEnd'), 'errors');
+				$error++;
+			}
+			else if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+			{
+				$duration = GETPOST('durationvalue', 'int');
+				if (is_numeric($duration) && $duration > 0) {
+					$durationqty=calculateDurationQuantity($date_start, $date_end, $duration, GETPOST('durationunit', 'alpha'));
+					if ($durationqty < 1)
+					{
+						setEventMessage($langs->trans('DateRangeShortForDuration', 'errors'));
+						$error++;
+					}
+				}
+			}
 		}
+
 		if (! $error && ($qty >= 0) && (! empty($product_desc) || ! empty($idprod))) {
 			$ret = $object->fetch($id);
 			if ($ret < 0) {
@@ -1284,8 +1303,6 @@ if (empty($reshook))
 			$ret = $object->fetch_thirdparty();
 
 			// Clean parameters
-			$date_start = dol_mktime(GETPOST('date_start' . $predef . 'hour'), GETPOST('date_start' . $predef . 'min'), GETPOST('date_start' . $predef . 'sec'), GETPOST('date_start' . $predef . 'month'), GETPOST('date_start' . $predef . 'day'), GETPOST('date_start' . $predef . 'year'));
-			$date_end = dol_mktime(GETPOST('date_end' . $predef . 'hour'), GETPOST('date_end' . $predef . 'min'), GETPOST('date_end' . $predef . 'sec'), GETPOST('date_end' . $predef . 'month'), GETPOST('date_end' . $predef . 'day'), GETPOST('date_end' . $predef . 'year'));
 			$price_base_type = (GETPOST('price_base_type', 'alpha') ? GETPOST('price_base_type', 'alpha') : 'HT');
 
 			// Define special_code for special lines
@@ -1500,8 +1517,6 @@ if (empty($reshook))
 		$object->fetch_thirdparty();
 
 		// Clean parameters
-		$date_start = '';
-		$date_end = '';
 		$date_start = dol_mktime(GETPOST('date_starthour'), GETPOST('date_startmin'), GETPOST('date_startsec'), GETPOST('date_startmonth'), GETPOST('date_startday'), GETPOST('date_startyear'));
 		$date_end = dol_mktime(GETPOST('date_endhour'), GETPOST('date_endmin'), GETPOST('date_endsec'), GETPOST('date_endmonth'), GETPOST('date_endday'), GETPOST('date_endyear'));
 		$description = dol_htmlcleanlastbr(GETPOST('product_desc') ? GETPOST('product_desc') : GETPOST('desc'));
@@ -1585,6 +1600,27 @@ if (empty($reshook))
 			$langs->load("errors");
 			setEventMessages($langs->trans('ErrorQtyForCustomerInvoiceCantBeNegative'), null, 'errors');
 			$error ++;
+		}
+
+		if ($date_start && $date_end)
+		{
+			if ($date_start > $date_end)
+			{
+				setEventMessage($langs->trans('ErrorStartDateGreaterEnd'), 'errors');
+				$error++;
+			}
+			else if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+			{
+				$duration = GETPOST('durationvalue', 'int');
+				if (is_numeric($duration) && $duration > 0) {
+					$durationqty=calculateDurationQuantity($date_start, $date_end, $duration, GETPOST('durationunit', 'alpha'));
+					if ($durationqty < 1)
+					{
+						setEventMessage($langs->trans('DateRangeShortForDuration', 'errors'));
+						$error++;
+					}
+				}
+			}
 		}
 
 		// Update line

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1864,6 +1864,8 @@ class Form
         $outlabel=$objp->label;
         $outdesc=$objp->description;
         $outtype=$objp->fk_product_type;
+        $outdurationvalue=$outtype == Product::TYPE_SERVICE?substr($objp->duration,0,dol_strlen($objp->duration)-1):'';
+        $outdurationunit=$outtype == Product::TYPE_SERVICE?substr($objp->duration,-1):'';
 
         $opt = '<option value="'.$objp->rowid.'"';
         $opt.= ($objp->rowid == $selected)?' selected':'';
@@ -2008,24 +2010,19 @@ class Form
             $outval.=' - '.$langs->transnoentities("Stock").':'.$objp->stock;
         }
 
-        if ($objp->duration)
+        if ($outdurationvalue && $outdurationunit)
         {
-            $duration_value = substr($objp->duration,0,dol_strlen($objp->duration)-1);
-            $duration_unit = substr($objp->duration,-1);
-            if ($duration_value > 1)
+            $da=array("h"=>$langs->trans("Hour"),"d"=>$langs->trans("Day"),"w"=>$langs->trans("Week"),"m"=>$langs->trans("Month"),"y"=>$langs->trans("Year"));
+            if (isset($da[$outdurationunit]))
             {
-                $dur=array("h"=>$langs->trans("Hours"),"d"=>$langs->trans("Days"),"w"=>$langs->trans("Weeks"),"m"=>$langs->trans("Months"),"y"=>$langs->trans("Years"));
+                $key = $da[$outdurationunit].($outdurationvalue > 1?'s':'');
+                $opt.= ' - '.$outdurationvalue.' '.$langs->trans($key);
+                $outval.=' - '.$outdurationvalue.' '.$langs->transnoentities($key);
             }
-            else
-            {
-                $dur=array("h"=>$langs->trans("Hour"),"d"=>$langs->trans("Day"),"w"=>$langs->trans("Week"),"m"=>$langs->trans("Month"),"y"=>$langs->trans("Year"));
-            }
-            $opt.= ' - '.$duration_value.' '.($dur[$duration_unit]?$langs->trans($dur[$duration_unit]):'');
-            $outval.=' - '.$duration_value.' '.($dur[$duration_unit]?$langs->transnoentities($dur[$duration_unit]):'');
         }
 
         $opt.= "</option>\n";
-		$optJson = array('key'=>$outkey, 'value'=>$outref, 'label'=>$outval, 'label2'=>$outlabel, 'desc'=>$outdesc, 'type'=>$outtype, 'price_ht'=>$outprice_ht, 'price_ttc'=>$outprice_ttc, 'pricebasetype'=>$outpricebasetype, 'tva_tx'=>$outtva_tx, 'qty'=>$outqty, 'discount'=>$outdiscount);
+		$optJson = array('key'=>$outkey, 'value'=>$outref, 'label'=>$outval, 'label2'=>$outlabel, 'desc'=>$outdesc, 'type'=>$outtype, 'price_ht'=>$outprice_ht, 'price_ttc'=>$outprice_ttc, 'pricebasetype'=>$outpricebasetype, 'tva_tx'=>$outtva_tx, 'qty'=>$outqty, 'discount'=>$outdiscount, 'durationvalue'=>$outdurationvalue, 'durationunit'=>$outdurationunit);
 	}
 
     /**
@@ -2081,7 +2078,7 @@ class Form
 
         $langs->load('stocks');
 
-        $sql = "SELECT p.rowid, p.label, p.ref, p.price, p.duration,";
+        $sql = "SELECT p.rowid, p.label, p.ref, p.price, p.duration, p.fk_product_type,";
         $sql.= " pfp.ref_fourn, pfp.rowid as idprodfournprice, pfp.price as fprice, pfp.quantity, pfp.remise_percent, pfp.remise, pfp.unitprice,";
         $sql.= " pfp.fk_supplier_price_expression, pfp.fk_product, pfp.tva_tx, s.nom as name";
         $sql.= " FROM ".MAIN_DB_PREFIX."product as p";
@@ -2139,6 +2136,9 @@ class Form
                 $outval='';
                 $outqty=1;
 				$outdiscount=0;
+                $outtype=$objp->fk_product_type;
+                $outdurationvalue=$outtype == Product::TYPE_SERVICE?substr($objp->duration,0,dol_strlen($objp->duration)-1):'';
+                $outdurationunit=$outtype == Product::TYPE_SERVICE?substr($objp->duration,-1):'';
 
                 $opt = '<option value="'.$objp->idprodfournprice.'"';
                 if ($selected && $selected == $objp->idprodfournprice) $opt.= ' selected';
@@ -2226,7 +2226,7 @@ class Form
                 // "key" value of json key array is used by jQuery automatically as selected value
                 // "label" value of json key array is used by jQuery automatically as text for combo box
                 $out.=$opt;
-                array_push($outarray, array('key'=>$outkey, 'value'=>$outref, 'label'=>$outval, 'qty'=>$outqty, 'discount'=>$outdiscount, 'disabled'=>(empty($objp->idprodfournprice)?true:false)));
+                array_push($outarray, array('key'=>$outkey, 'value'=>$outref, 'label'=>$outval, 'qty'=>$outqty, 'discount'=>$outdiscount, 'type'=>$outtype, 'durationvalue'=>$outdurationvalue, 'durationunit'=>$outdurationunit, 'disabled'=>(empty($objp->idprodfournprice)?true:false)));
 				// Exemple of var_dump $outarray
 				// array(1) {[0]=>array(6) {[key"]=>string(1) "2" ["value"]=>string(3) "ppp"
 				//           ["label"]=>string(76) "ppp (<strong>f</strong>ff2) - ppp - 20,00 Euros/1unité (20,00 Euros/unité)"

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -837,3 +837,21 @@ function monthArray($outputlangs,$short=0)
 	return $montharray;
 }
 
+
+/**
+ * Function to calculate proper quantity based on date range and duration
+ *
+ * @param  int		$start_date		Start date
+ * @param  int		$end_date		End date
+ * @param  int		$duration		Duration
+ * @param  int		$duration_unit	Duration unit, empty for seconds
+ * @return int		Quantity as result
+ */
+function calculateDurationQuantity($start_date, $end_date, $duration, $duration_unit)
+{
+	if (!empty($duration_unit)) {
+		$duration = dol_time_plus_duree(0, $duration, $duration_unit);
+	}
+	$qty = floor(($end_date - $start_date) / $duration);
+	return ($qty<0) ? 0 : $qty;
+}

--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -65,7 +65,7 @@ $coldisplay=-1; // We remove first td
 
 		<a href="<?php echo DOL_URL_ROOT.'/product/card.php?id='.$line->fk_product; ?>">
 		<?php
-		if ($line->product_type==1) echo img_object($langs->trans('ShowService'),'service');
+		if ($line->product_type==Product::TYPE_SERVICE) echo img_object($langs->trans('ShowService'),'service');
 		else print img_object($langs->trans('ShowProduct'),'product');
 		echo ' '.$line->ref;
 		?>
@@ -217,14 +217,31 @@ $coldisplay=-1; // We remove first td
 	?>
 </tr>
 
-<?php if (! empty($conf->service->enabled) && $line->product_type == 1 && $dateSelector)	 { ?>
+<?php if (! empty($conf->service->enabled) && $line->product_type == Product::TYPE_SERVICE && $dateSelector)	 { ?>
 <tr id="service_duration_area" <?php echo $bc[$var]; ?>>
 	<td colspan="11"><?php echo $langs->trans('ServiceLimitedDuration').' '.$langs->trans('From').' '; ?>
 	<?php
 	$hourmin=(isset($conf->global->MAIN_USE_HOURMIN_IN_DATE_RANGE)?$conf->global->MAIN_USE_HOURMIN_IN_DATE_RANGE:'');
-	echo $form->select_date($line->date_start,'date_start',$hourmin,$hourmin,$line->date_start?0:1,"updateligne",1,0,1);
+	echo $form->select_date($line->date_start,'date_start',$hourmin,$hourmin,1,"updateligne",1,0,1);
 	echo ' '.$langs->trans('to').' ';
-	echo $form->select_date($line->date_end,'date_end',$hourmin,$hourmin,$line->date_end?0:1,"updateligne",1,0,1);
+	$h = 1; $m = 1;
+	if ($line->fk_product > 0)
+	{
+		global $db;
+		$lineproduct = new Product($db);
+		$ret = $lineproduct->fetch($line->fk_product);
+		if ($ret > 0)
+		{
+			$duration_value = $lineproduct->duration_value;
+			$duration_unit = $lineproduct->duration_unit;
+			$h = $hourmin && ($duration_unit=='h' || $duration_unit=='d');
+			$m = $hourmin &&  $duration_unit=='h';
+			echo '<input type="hidden" id="durationvalue" name="durationvalue" value="'.$duration_value.'">';
+			echo '<input type="hidden" id="durationunit" name="durationunit" value="'.$duration_unit.'">';
+		}
+		unset($lineproduct);
+	}
+	echo $form->select_date($line->date_end,'date_end',$h,$m,1,"updateligne",1,0,1);
 	?>
 	</td>
 </tr>

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -90,12 +90,13 @@ if (empty($usemargins)) $usemargins=0;
 	}
 	else
 	{
+		$format = $conf->global->MAIN_USE_HOURMIN_IN_DATE_RANGE?'dayhourtextshort':'daytextshort';
 		if ($line->fk_product > 0)
 		{
 			echo $form->textwithtooltip($text,$description,3,'','',$i,0,(!empty($line->fk_parent_line)?img_picto('', 'rightarrow'):''));
 			
 			// Show range
-			echo get_date_range($line->date_start, $line->date_end);
+			echo get_date_range($line->date_start,$line->date_end, $format);
 
 			// Add description in form
 			if (! empty($conf->global->PRODUIT_DESC_IN_FORM))
@@ -119,7 +120,7 @@ if (empty($usemargins)) $usemargins=0;
 			}
 
 			// Show range
-			echo get_date_range($line->date_start,$line->date_end);
+			echo get_date_range($line->date_start,$line->date_end, $format);
 		}
 	}
 	?>

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -493,7 +493,7 @@ class FactureFournisseur extends CommonInvoice
     function fetch_lines()
     {
         $sql = 'SELECT f.rowid, f.ref as ref_supplier, f.description, f.pu_ht, f.pu_ttc, f.qty, f.remise_percent, f.tva_tx';
-        $sql.= ', f.localtax1_tx, f.localtax2_tx, f.total_localtax1, f.total_localtax2 ';
+        $sql.= ', f.localtax1_tx, f.localtax2_tx, f.total_localtax1, f.total_localtax2, f.date_start, f.date_end';
         $sql.= ', f.total_ht, f.tva as total_tva, f.total_ttc, f.fk_product, f.product_type, f.info_bits, f.rang, f.special_code, f.fk_parent_line, f.fk_unit';
         $sql.= ', p.rowid as product_id, p.ref as product_ref, p.label as label, p.description as product_desc';
         $sql.= ' FROM '.MAIN_DB_PREFIX.'facture_fourn_det as f';
@@ -545,6 +545,8 @@ class FactureFournisseur extends CommonInvoice
                     $line->fk_parent_line    = $obj->fk_parent_line;
                     $line->special_code		= $obj->special_code;
                     $line->rang       		= $obj->rang;
+                    $line->date_start       = $this->db->jdate($obj->date_start);
+                    $line->date_end         = $this->db->jdate($obj->date_end);
                     $line->fk_unit           = $obj->fk_unit;
 
 	                $this->lines[$i] = $line;
@@ -1183,7 +1185,7 @@ class FactureFournisseur extends CommonInvoice
         {
             $idligne = $this->db->last_insert_id(MAIN_DB_PREFIX.'facture_fourn_det');
 
-            $result=$this->updateline($idligne, $desc, $pu, $txtva, $txlocaltax1, $txlocaltax2, $qty, $fk_product, $price_base_type, $info_bits, $type, $remise_percent, true, '', '', $array_options, $fk_unit);
+            $result=$this->updateline($idligne, $desc, $pu, $txtva, $txlocaltax1, $txlocaltax2, $qty, $fk_product, $price_base_type, $info_bits, $type, $remise_percent, true, $date_start, $date_end, $array_options, $fk_unit);
             if ($result > 0)
             {
                 $this->rowid = $idligne;
@@ -1243,7 +1245,7 @@ class FactureFournisseur extends CommonInvoice
      */
     function updateline($id, $desc, $pu, $vatrate, $txlocaltax1=0, $txlocaltax2=0, $qty=1, $idproduct=0, $price_base_type='HT', $info_bits=0, $type=0, $remise_percent=0, $notrigger=false, $date_start='', $date_end='', $array_options=0, $fk_unit = null)
     {
-    	global $mysoc;
+    	global $mysoc, $langs, $conf;
         dol_syslog(get_class($this)."::updateline $id,$desc,$pu,$vatrate,$qty,$idproduct,$price_base_type,$info_bits,$type,$remise_percent,$fk_unit", LOG_DEBUG);
         include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
 
@@ -1270,8 +1272,31 @@ class FactureFournisseur extends CommonInvoice
 
         $localtaxes_type=getLocalTaxesFromRate($vatrate,0,$mysoc, $this->thirdparty);
         $txtva = preg_replace('/\s*\(.*\)/','',$txtva);  // Remove code into vatrate.
+
+        $durationqty = 1;
+        $product_type = $type;
+        if ($idproduct)
+        {
+            $product=new Product($this->db);
+            $result=$product->fetch($idproduct);
+            if ($result > 0)
+            {
+                $product_type = $product->type;
+                if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE)) {
+                    if ($product_type == Product::TYPE_SERVICE && $date_start && $date_end && $product->duration_value && $product->duration_unit)
+                    {
+                        require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
+                        $durationqty = calculateDurationQuantity($date_start, $date_end, $product->duration_value, $product->duration_unit);
+                        if ($durationqty <= 0) {
+                            $this->error = $langs->trans('DateRangeShortForDuration');
+                            return -2;
+                        }
+                    }
+                }
+            }
+        }
         
-        $tabprice = calcul_price_total($qty, $pu, $remise_percent, $vatrate, $txlocaltax1, $txlocaltax2, 0, $price_base_type, $info_bits, $type, $this->thirdparty, $localtaxes_type);
+        $tabprice = calcul_price_total($qty * $durationqty, $pu, $remise_percent, $vatrate, $txlocaltax1, $txlocaltax2, 0, $price_base_type, $info_bits, $type, $this->thirdparty, $localtaxes_type);
         $total_ht  = $tabprice[0];
         $total_tva = $tabprice[1];
         $total_ttc = $tabprice[2];
@@ -1281,17 +1306,6 @@ class FactureFournisseur extends CommonInvoice
         $total_localtax1 = $tabprice[9];
         $total_localtax2 = $tabprice[10];
         if (empty($info_bits)) $info_bits=0;
-
-        if ($idproduct)
-        {
-            $product=new Product($this->db);
-            $result=$product->fetch($idproduct);
-            $product_type = $product->type;
-        }
-        else
-        {
-            $product_type = $type;
-        }
 
 	    $line = new SupplierInvoiceLine($this->db);
 
@@ -1318,6 +1332,8 @@ class FactureFournisseur extends CommonInvoice
 	    $line->fk_product = $idproduct;
 	    $line->product_type = $product_type;
 	    $line->info_bits = $info_bits;
+	    $line->date_start = $date_start;
+	    $line->date_end = $date_end;
 	    $line->fk_unit = $fk_unit;
 	    $line->array_options = $array_options;
 
@@ -1970,6 +1986,8 @@ class SupplierInvoiceLine extends CommonObjectLine
 	public $rang;
 	public $localtax1_type;
 	public $localtax2_type;
+	public $date_start;
+	public $date_end;
 
 
 	/**
@@ -1990,7 +2008,7 @@ class SupplierInvoiceLine extends CommonObjectLine
 	 */
 	public function fetch($rowid)
 	{
-		$sql = 'SELECT f.rowid, f.ref as ref_supplier, f.description, f.pu_ht, f.pu_ttc, f.qty, f.remise_percent, f.tva_tx';
+		$sql = 'SELECT f.rowid, f.ref as ref_supplier, f.description, f.pu_ht, f.pu_ttc, f.qty, f.remise_percent, f.tva_tx, f.date_start, f.date_end';
 		$sql.= ', f.localtax1_type, f.localtax2_type, f.localtax1_tx, f.localtax2_tx, f.total_localtax1, f.total_localtax2 ';
 		$sql.= ', f.total_ht, f.tva as total_tva, f.total_ttc, f.fk_product, f.product_type, f.info_bits, f.rang, f.special_code, f.fk_parent_line, f.fk_unit';
 		$sql.= ', p.rowid as product_id, p.ref as product_ref, p.label as label, p.description as product_desc';
@@ -2044,6 +2062,8 @@ class SupplierInvoiceLine extends CommonObjectLine
 		$this->fk_parent_line    = $obj->fk_parent_line;
 		$this->special_code		= $obj->special_code;
 		$this->rang       		= $obj->rang;
+		$this->date_start       = $this->db->jdate($obj->date_start);
+		$this->date_end         = $this->db->jdate($obj->date_end);
 		$this->fk_unit           = $obj->fk_unit;
 
 		return 1;
@@ -2162,6 +2182,8 @@ class SupplierInvoiceLine extends CommonObjectLine
 		$sql.= ", fk_product = ".$fk_product;
 		$sql.= ", product_type = ".$this->product_type;
 		$sql.= ", info_bits = ".$this->info_bits;
+		$sql.= ", date_start = ".(! empty($this->date_start)?"'".$this->db->idate($this->date_start)."'":"null");
+		$sql.= ", date_end = ".(! empty($this->date_end)?"'".$this->db->idate($this->date_end)."'":"null");
 		$sql.= ", fk_unit = ".$fk_unit;
 		$sql.= " WHERE rowid = ".$this->id;
 

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -39,6 +39,7 @@ require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/fourn.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
 if (! empty($conf->supplier_proposal->enabled))
 	require DOL_DOCUMENT_ROOT . '/supplier_proposal/class/supplier_proposal.class.php';
@@ -316,6 +317,33 @@ if (empty($reshook))
 	        $error++;
 	    }
 
+		$durationqty = 1;
+		if ($date_start && $date_end)
+		{
+			if ($date_start > $date_end)
+			{
+				setEventMessage($langs->trans('ErrorStartDateGreaterEnd'), 'errors');
+				$error++;
+			}
+			else if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+			{
+				$duration = GETPOST('durationvalue', 'int');
+				if (is_numeric($duration) && $duration > 0) {
+					$durationqty=calculateDurationQuantity($date_start, $date_end, $duration, GETPOST('durationunit', 'alpha'));
+					if ($durationqty < 1)
+					{
+						setEventMessage($langs->trans('DateRangeShortForDuration', 'errors'));
+						$error++;
+					}
+				}
+			}
+		}
+		if (empty($qty))
+		{
+		    setEventMessage($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Qty')), 'errors');
+		    $error++;
+		}
+
 	    // Ecrase $pu par celui	du produit
 	    // Ecrase $desc	par	celui du produit
 	    // Ecrase $txtva  par celui du produit
@@ -328,7 +356,7 @@ if (empty($reshook))
 
 	    	if (GETPOST('idprodfournprice') > 0)
 	    	{
-	    		$idprod=$productsupplier->get_buyprice(GETPOST('idprodfournprice'), $qty);    // Just to see if a price exists for the quantity. Not used to found vat.
+	    		$idprod=$productsupplier->get_buyprice(GETPOST('idprodfournprice'), $qty * $durationqty);    // Just to see if a price exists for the quantity. Not used to found vat.
 	    	}
 
 	    	if ($idprod > 0)

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -37,6 +37,7 @@ require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
 require_once DOL_DOCUMENT_ROOT.'/fourn/class/paiementfourn.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/fourn.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
 if (!empty($conf->produit->enabled))
 	require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
@@ -675,7 +676,29 @@ if (empty($reshook))
 	        setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Description')), null, 'errors');
 	        $error++;
 	    }
-	    if (! GETPOST('qty'))
+
+		$durationqty=1;
+		if ($date_start && $date_end)
+		{
+			if ($date_start > $date_end)
+			{
+				setEventMessage($langs->trans('ErrorStartDateGreaterEnd'), 'errors');
+				$error++;
+			}
+			else if (!empty($conf->global->MAIN_USE_DURATION_DATERANGE))
+			{
+				$duration = GETPOST('durationvalue', 'int');
+				if (is_numeric($duration) && $duration > 0) {
+					$durationqty=calculateDurationQuantity($date_start, $date_end, $duration, GETPOST('durationunit', 'alpha'));
+					if ($durationqty < 1)
+					{
+						setEventMessage($langs->trans('DateRangeShortForDuration', 'errors'));
+						$error++;
+					}
+				}
+			}
+		}
+	    if (empty($qty))
 	    {
 	        setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Qty')), null, 'errors');
 	        $error++;
@@ -690,7 +713,7 @@ if (empty($reshook))
 
 	    	if (GETPOST('idprodfournprice') > 0)
 	    	{
-	    		$idprod=$productsupplier->get_buyprice(GETPOST('idprodfournprice'), $qty);    // Just to see if a price exists for the quantity. Not used to found vat.
+	    		$idprod=$productsupplier->get_buyprice(GETPOST('idprodfournprice'), $durationqty*$qty);    // Just to see if a price exists for the quantity. Not used to found vat.
 	    	}
 
 		    //Replaces $fk_unit with the product's

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1495,17 +1495,12 @@ else
             {
                 // Duration
                 print '<tr><td class="titlefield">'.$langs->trans("Duration").'</td><td colspan="2">'.$object->duration_value.'&nbsp;';
-                if ($object->duration_value > 1)
+                $da=array("h"=>$langs->trans("Hour"),"d"=>$langs->trans("Day"),"w"=>$langs->trans("Week"),"m"=>$langs->trans("Month"),"y"=>$langs->trans("Year"));
+                if ($object->duration_value != '' && ! empty($object->duration_unit) && isset($da[$object->duration_unit]))
                 {
-                    $dur=array("h"=>$langs->trans("Hours"),"d"=>$langs->trans("Days"),"w"=>$langs->trans("Weeks"),"m"=>$langs->trans("Months"),"y"=>$langs->trans("Years"));
+                    print $langs->trans($da[$object->duration_unit].($object->duration_value > 1?'s':''));
                 }
-                else if ($object->duration_value > 0)
-                {
-                    $dur=array("h"=>$langs->trans("Hour"),"d"=>$langs->trans("Day"),"w"=>$langs->trans("Week"),"m"=>$langs->trans("Month"),"y"=>$langs->trans("Year"));
-                }
-                print (! empty($object->duration_unit) && isset($dur[$object->duration_unit]) ? $langs->trans($dur[$object->duration_unit]) : '')."&nbsp;";
-
-                print '</td></tr>';
+                print '&nbsp;</td></tr>';
             }
             else
             {

--- a/htdocs/webservices/demo_wsclient_resource.php
+++ b/htdocs/webservices/demo_wsclient_resource.php
@@ -1,0 +1,182 @@
+<?php
+/* Copyright (C) 2006-2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *       \file       htdocs/webservices/demo_wsclient_resource.php
+ *       \brief      Demo page to make a client call to Dolibarr WebServices "server_resource"
+ */
+
+// This is to make Dolibarr working with Plesk
+set_include_path($_SERVER['DOCUMENT_ROOT'].'/htdocs');
+
+require_once '../master.inc.php';
+require_once NUSOAP_PATH.'/nusoap.php';		// Include SOAP
+
+$WS_DOL_URL = DOL_MAIN_URL_ROOT.'/webservices/server_resource.php';
+//$WS_DOL_URL = 'http://localhost:8080/';	// To test with Soapui mock. If not a page, should end with /
+$WS_METHOD1 = 'getResource';
+$WS_METHOD2 = 'getStatus';
+$WS_METHOD3 = 'createResourcePlacement';
+$ns='http://www.dolibarr.org/ns/';
+
+
+// Set the WebService URL
+dol_syslog("Create nusoap_client for URL=".$WS_DOL_URL);
+$soapclient1 = new nusoap_client($WS_DOL_URL);
+if ($soapclient1)
+{
+	$soapclient1->soap_defencoding='UTF-8';
+	$soapclient1->decodeUTF8(false);
+}
+$soapclient2 = new nusoap_client($WS_DOL_URL);
+if ($soapclient2)
+{
+    $soapclient2->soap_defencoding='UTF-8';
+	$soapclient2->decodeUTF8(false);
+}
+$soapclient3 = new nusoap_client($WS_DOL_URL);
+if ($soapclient3)
+{
+    $soapclient3->soap_defencoding='UTF-8';
+	$soapclient3->decodeUTF8(false);
+}
+
+
+// Call the WebService method and store its result in $result.
+$authentication=array(
+    'dolibarrkey'=>$conf->global->WEBSERVICES_KEY,
+    'sourceapplication'=>'DEMO',
+    'login'=>'admin',
+    'password'=>'changeme',
+    'entity'=>'');
+
+
+// Test url 1
+if ($WS_METHOD1)
+{
+    $parameters = array('authentication'=>$authentication,'id'=>7,'ref'=>'');
+    dol_syslog("Call method ".$WS_METHOD1);
+    $result1 = $soapclient1->call($WS_METHOD1,$parameters,$ns,'');
+    if (! $result1)
+    {
+    	print $soapclient1->error_str;
+    	print "<br>\n\n";
+    	print $soapclient1->request;
+    	print "<br>\n\n";
+    	print $soapclient1->response;
+    	exit;
+    }
+}
+
+// Test url 2
+if ($WS_METHOD2)
+{
+    $parameters = array('authentication'=>$authentication,'id'=>7,'date_start'=>'2016-01-18 01:00','date_end'=>'2016-01-18 04:00');
+    dol_syslog("Call method ".$WS_METHOD2);
+    $result2 = $soapclient2->call($WS_METHOD2,$parameters,$ns,'');
+    if (! $result2)
+    {
+    	print $soapclient2->error_str;
+    	print "<br>\n\n";
+    	print $soapclient2->request;
+    	print "<br>\n\n";
+    	print $soapclient2->response;
+    	exit;
+    }
+}
+
+// Test url 3
+if ($WS_METHOD3 && false)
+{
+    $parameters = array('authentication'=>$authentication,'filterproduct'=>array('type'=>-1));
+    dol_syslog("Call method ".$WS_METHOD3);
+    $result3 = $soapclient3->call($WS_METHOD3,$parameters,$ns,'');
+    if (! $result3)
+    {
+    	print $soapclient3->error_str;
+    	print "<br>\n\n";
+    	print $soapclient3->request;
+    	print "<br>\n\n";
+    	print $soapclient3->response;
+    	exit;
+    }
+}
+
+
+/*
+ * View
+ */
+
+header("Content-type: text/html; charset=utf8");
+print '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">'."\n";
+echo '<html>'."\n";
+echo '<head>';
+echo '<title>WebService Test: '.$WS_METHOD1.'</title>';
+echo '</head>'."\n";
+
+echo '<body>'."\n";
+echo 'NUSOAP_PATH='.NUSOAP_PATH.'<br>';
+
+echo "<h2>Request:</h2>";
+echo '<h4>Function</h4>';
+echo $WS_METHOD1;
+echo '<h4>SOAP Message</h4>';
+echo '<pre>' . htmlspecialchars($soapclient1->request, ENT_QUOTES) . '</pre>';
+//echo '<hr>';
+echo "<h2>Response:</h2>";
+echo '<h4>Result</h4>';
+echo '<pre>';
+print_r($result1);
+echo '</pre>';
+echo '<h4>SOAP Message</h4>';
+echo '<pre>' . htmlspecialchars($soapclient1->response, ENT_QUOTES) . '</pre>';
+
+print '<hr>';
+
+echo "<h2>Request:</h2>";
+echo '<h4>Function</h4>';
+echo $WS_METHOD2;
+echo '<h4>SOAP Message</h4>';
+echo '<pre>' . htmlspecialchars($soapclient2->request, ENT_QUOTES) . '</pre>';
+//echo '<hr>';
+echo "<h2>Response:</h2>";
+echo '<h4>Result</h4>';
+echo '<pre>';
+print_r($result2);
+echo '</pre>';
+echo '<h4>SOAP Message</h4>';
+echo '<pre>' . htmlspecialchars($soapclient2->response, ENT_QUOTES) . '</pre>';
+
+print '<hr>';
+
+echo "<h2>Request:</h2>";
+echo '<h4>Function</h4>';
+echo $WS_METHOD3;
+echo '<h4>SOAP Message</h4>';
+echo '<pre>' . htmlspecialchars($soapclient3->request, ENT_QUOTES) . '</pre>';
+//echo '<hr>';
+echo "<h2>Response:</h2>";
+echo '<h4>Result</h4>';
+echo '<pre>';
+print_r($result3);
+echo '</pre>';
+echo '<h4>SOAP Message</h4>';
+echo '<pre>' . htmlspecialchars($soapclient3->response, ENT_QUOTES) . '</pre>';
+
+echo '</body>'."\n";
+echo '</html>'."\n";
+?>


### PR DESCRIPTION
This makes the lines which have services (with a specified duration) and date range do calculation of amounts of services that would allocate in such date range, for example:
- Service with 4 hours of duration
- Line with start day 1 and end day 3 and quantity of 2 would allocate 24 qty -> (48h/4h) \* 2

This doesn't modify the qty value directly so the stored value is still the manual asigned one, only the price calculation is affected.

(old branch pull was #4208)
