### PR TITLE
FIX : Clone product's status and status_buy too

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -412,8 +412,6 @@ if (empty($reshook))
             if ($object->id > 0)
             {
                 $object->ref = GETPOST('clone_ref');
-                $object->status = 0;
-                $object->status_buy = 0;
                 $object->id = null;
                 $object->barcode = -1;
 


### PR DESCRIPTION
While cloning a product, buying and selling status were not send to the clone.
