### PR TITLE
BugFix on Delete Trigger : Loading Payment amounts

### DIFF
--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -119,7 +119,7 @@ class Paiement extends CommonObject
 				$this->bank_line      = $obj->fk_bank;
 
 				$this->db->free($resql);
-				return 1;
+				return $this->fetch_amounts();
 			}
 			else
 			{
@@ -133,6 +133,40 @@ class Paiement extends CommonObject
 			return -1;
 		}
 	}
+
+	/**
+	 *  @abstract Fetch List of Invoices Payments Amounts
+	 *
+	 *  @return   int		>0 if OK
+	 */
+	function fetch_amounts()
+	{
+            //====================================================================//
+            // SELECT SQL Request 
+            $sql = 'SELECT fk_facture, amount';
+            $sql.= ' FROM '.MAIN_DB_PREFIX.'paiement_facture';
+            $sql.= ' WHERE fk_paiement = '.$this->id;
+            $resql = $this->db->query($sql);
+            //====================================================================//
+            // SQL Error 
+            if (!$resql)
+            {
+                $this->error=$this->db->error();
+                dol_syslog(get_class($this).'::fetch_amounts Error '.$this->error.' -', LOG_DEBUG);
+                return -1;
+            }
+            $this->amounts=array();
+            //====================================================================//
+            // Populate Object
+            for ($i=0; $i < $this->db->num_rows($resql); $i++)
+            {
+                $obj = $this->db->fetch_object($resql);
+                $this->amounts[$obj->fk_facture]    =   $obj->amount;
+            }
+            $this->db->free($resql);                    
+            return 1;
+	}             
+
 
 	/**
 	 *    Create payment of invoices into database.


### PR DESCRIPTION
When using PAYMENT_CUSTOMER_DELETE trigger, it isn't possible to load invoice amounts informations as database changes have already been commited. 

Database transactionnal mode isn't working here due to COMMITs inside $accline->delete_urls or $accline->delete actions. This means on Payment delete, it is impossible for a module to retrieve list of invoices impacted by this change.

New function is quite similar to getBillsArray() but keep same array format as used in create function.
Tested on my side and it works fine!
