### PR TITLE
Delete empty row in select list of vats in expenses

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1829,7 +1829,6 @@ else
 						$defaultvat=-1;
 						if (! empty($conf->global->EXPENSEREPORT_NO_DEFAULT_VAT)) $conf->global->MAIN_VAT_DEFAULT_IF_AUTODETECT_FAILS = 'none';
 						print '<select class="flat" name="vatrate">';
-						print '<option name="none" value="" selected>';
 						print $form->load_tva('vatrate', ($vatrate!=''?$vatrate:$defaultvat), $mysoc, '', 0, 0, '', true);
 						print '</select>';
 						print '</td>';


### PR DESCRIPTION
Delete empty row in select list of vats in expenses as this value is not accepted and is handled as an input error.
