### PR TITLE
Fix: Update VAT rates + label of intermediary VAT rate for Luxembourg

### DIFF
--- a/htdocs/install/mysql/data/llx_c_tva.sql
+++ b/htdocs/install/mysql/data/llx_c_tva.sql
@@ -150,7 +150,7 @@ insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (12
 -- LUXEMBOURG (id country=140)
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1401, 140, '17','0','VAT standard rate',1);
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1402, 140, '14','0','VAT reduced rate',1);
-insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1403, 140,  '8','0','VAT reduced rate', 1);
+insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1403, 140,  '8','0','VAT intermediary rate', 1);
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1404, 140,  '3','0','VAT super-reduced rate', 1);
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1405, 140,  '0','0','VAT Rate 0', 1);
 

--- a/htdocs/install/mysql/data/llx_c_tva.sql
+++ b/htdocs/install/mysql/data/llx_c_tva.sql
@@ -148,9 +148,9 @@ insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (12
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1232, 123, '5','0','VAT Rate 5',1);
 
 -- LUXEMBOURG (id country=140)
-insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1401, 140, '15','0','VAT standard rate',1);
-insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1402, 140, '12','0','VAT reduced rate',1);
-insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1403, 140,  '6','0','VAT reduced rate', 1);
+insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1401, 140, '17','0','VAT standard rate',1);
+insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1402, 140, '14','0','VAT reduced rate',1);
+insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1403, 140,  '8','0','VAT reduced rate', 1);
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1404, 140,  '3','0','VAT super-reduced rate', 1);
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (1405, 140,  '0','0','VAT Rate 0', 1);
 

--- a/htdocs/install/mysql/migration/3.8.0-3.9.0.sql
+++ b/htdocs/install/mysql/migration/3.8.0-3.9.0.sql
@@ -583,3 +583,8 @@ ALTER TABLE llx_accounting_bookkeeping MODIFY COLUMN doc_ref varchar(300) NOT NU
 
 ALTER TABLE llx_holiday ADD COLUMN tms timestamp;
 ALTER TABLE llx_holiday ADD COLUMN entity integer DEFAULT 1 NOT NULL;
+
+-- VAT rates Luxembourg
+UPDATE llx_c_tva SET taux='17' WHERE rowid=1401 AND fk_pays=140;
+UPDATE llx_c_tva SET taux='14' WHERE rowid=1402 AND fk_pays=140;
+UPDATE llx_c_tva SET taux='8'  WHERE rowid=1403 AND fk_pays=140;

--- a/htdocs/install/mysql/migration/3.8.0-3.9.0.sql
+++ b/htdocs/install/mysql/migration/3.8.0-3.9.0.sql
@@ -588,3 +588,5 @@ ALTER TABLE llx_holiday ADD COLUMN entity integer DEFAULT 1 NOT NULL;
 UPDATE llx_c_tva SET taux='17' WHERE rowid=1401 AND fk_pays=140;
 UPDATE llx_c_tva SET taux='14' WHERE rowid=1402 AND fk_pays=140;
 UPDATE llx_c_tva SET taux='8'  WHERE rowid=1403 AND fk_pays=140;
+UPDATE llx_c_tva SET note='VAT intermediary rate'  WHERE rowid=1403 AND fk_pays=140;
+

--- a/htdocs/install/mysql/migration/3.8.0-3.9.0.sql
+++ b/htdocs/install/mysql/migration/3.8.0-3.9.0.sql
@@ -588,5 +588,4 @@ ALTER TABLE llx_holiday ADD COLUMN entity integer DEFAULT 1 NOT NULL;
 UPDATE llx_c_tva SET taux='17' WHERE rowid=1401 AND fk_pays=140;
 UPDATE llx_c_tva SET taux='14' WHERE rowid=1402 AND fk_pays=140;
 UPDATE llx_c_tva SET taux='8'  WHERE rowid=1403 AND fk_pays=140;
-UPDATE llx_c_tva SET note='VAT intermediary rate'  WHERE rowid=1403 AND fk_pays=140;
-
+UPDATE llx_c_tva SET note='VAT intermediary rate' WHERE rowid=1403 AND fk_pays=140;


### PR DESCRIPTION
Fix provided for llx_c_tva.sql

Fix provided also for migration 3.8.0-3.9.0.sql but here I wonder: knowing this VAT rates have changed on January 1st 2015, shouldn't Dolibarr releases released after January 1st 2015 be updated as well ? 
