### PR TITLE
FIX : specify text color for input fields

### DIFF
--- a/htdocs/theme/eldy/style.css.php
+++ b/htdocs/theme/eldy/style.css.php
@@ -263,7 +263,7 @@ input, input.flat, textarea, textarea.flat, form.flat select, select, select.fla
     font-size: <?php print $fontsize ?>px;
     font-family: <?php print $fontlist ?>;
     background: #FFF;
-    /* color: #111; */
+    color: #111;
     border: 1px solid #C0C0C0;
     margin: 0px 0px 0px 0px;
 }


### PR DESCRIPTION
With some (GTK) themes, text is not visible into browser if no color specified into CSS on forms input fields. 

This is not present into 3.8 version.
