### PR TITLE
ODT generation : No segment defined in odt file is not an error

### DIFF
--- a/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
+++ b/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
@@ -698,9 +698,14 @@ class doc_generic_project_odt extends ModelePDFProjects
 				}
 				catch(OdfException $e)
 				{
-					$this->error=$e->getMessage();
-					dol_syslog($this->error, LOG_WARNING);
-					return -1;
+					$ExceptionTrace=$e->getTrace();
+					// no segment defined on ODT is not an error
+					if($ExceptionTrace[0]['function'] != 'setSegment')
+					{
+						$this->error=$e->getMessage();
+						dol_syslog($this->error, LOG_WARNING);
+						return -1;
+					}
 				}
 
 				// Replace tags of project files


### PR DESCRIPTION
This is a proposition of correction on all ODT file
If we don't define table of segment on odt we have an error on generation
But in some case (ex simple : summary of document) we don't want an table on ODT
