### PR TITLE
Add support to product translation imports

### DIFF
--- a/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
+++ b/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
@@ -250,6 +250,7 @@ ALTER TABLE llx_propaldet ADD COLUMN multicurrency_total_ht double(24,8) DEFAULT
 ALTER TABLE llx_propaldet ADD COLUMN multicurrency_total_tva double(24,8) DEFAULT 0;
 ALTER TABLE llx_propaldet ADD COLUMN multicurrency_total_ttc double(24,8) DEFAULT 0;
 
+<<<<<<< HEAD
  
 -- Add for recurring template invoices
 
@@ -302,3 +303,5 @@ ALTER TABLE llx_supplier_proposaldet ADD COLUMN multicurrency_subprice double(24
 ALTER TABLE llx_supplier_proposaldet ADD COLUMN multicurrency_total_ht double(24,8) DEFAULT 0;
 ALTER TABLE llx_supplier_proposaldet ADD COLUMN multicurrency_total_tva double(24,8) DEFAULT 0;
 ALTER TABLE llx_supplier_proposaldet ADD COLUMN multicurrency_total_ttc double(24,8) DEFAULT 0;
+
+ALTER TABLE llx_product_lang ADD COLUMN import_key varchar(14) DEFAULT NULL;

--- a/htdocs/install/mysql/tables/llx_product_lang.sql
+++ b/htdocs/install/mysql/tables/llx_product_lang.sql
@@ -25,5 +25,6 @@ create table llx_product_lang
   lang           varchar(5)   DEFAULT 0 NOT NULL,
   label          varchar(255) NOT NULL,
   description    text,
-  note           text
+  note           text,
+  import_key varchar(14) DEFAULT NULL
 )ENGINE=innodb;


### PR DESCRIPTION
Currently you can massively import products from a csv file, but you still have to create translations by hand.
This patch enables products imports withs their translation included.
