### PR TITLE
New + Fix : handle supplier orders from customer orders with id variable name correction

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -941,9 +941,17 @@ if (empty($reshook))
        			// If creation from another object of another module (Example: origin=propal, originid=1)
 				if (! empty($origin) && ! empty($originid))
 				{
-					$element = 'supplier_proposal';
-					$subelement = 'supplier_proposal';
-
+					if ($origin == 'order' || $origin == 'commande') {
+                        $element = $subelement = 'commande';
+                    }
+                    elseif ($origin =='supplier_proposal'){
+						$element = 'supplier_proposal';
+						$subelement = 'supplier_proposal';
+					}  
+					else { 
+                        $element = 'comm/askpricesupplier';
+                        $subelement = 'askpricesupplier';
+                    }    
 					$object->origin = $origin;
 					$object->origin_id = $originid;
 
@@ -1003,18 +1011,17 @@ if (empty($reshook))
 									$lines[$i]->fetch_optionals($lines[$i]->rowid);
 									$array_option = $lines[$i]->array_options;
 								}
-								
-								$res = $productsupplier->find_min_price_product_fournisseur($lines[$i]->fk_product, $lines[$i]->qty);
-								/*if ($productsupplier->id > 0)
-								{
-								    $res = $productsupplier->fetch($productsupplier->id);
-								}*/
-								
+
+								$idprod = $productsupplier->find_min_price_product_fournisseur($lines[$i]->fk_product, $lines[$i]->qty);
+								$res = $productsupplier->fetch($idprod);
+                                $soc=new societe($db);
+                                $soc->fetch($socid);
+                                $tva_tx=($origin=="commande")?get_default_tva($soc,$mysoc,$lines[$i]->fk_product,$idprod):$lines[$i]->tva_tx;
 								$result = $object->addline(
 									$desc,
 									$lines[$i]->subprice,
 									$lines[$i]->qty,
-									$lines[$i]->tva_tx,
+									$tva_tx,
 									$lines[$i]->localtax1_tx,
 									$lines[$i]->localtax2_tx,
 									$lines[$i]->fk_product,

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1012,33 +1012,34 @@ if (empty($reshook))
 									$array_option = $lines[$i]->array_options;
 								}
 
-								$idprod = $productsupplier->find_min_price_product_fournisseur($lines[$i]->fk_product, $lines[$i]->qty);
-								$res = $productsupplier->fetch($idprod);
-                                $soc=new societe($db);
-                                $soc->fetch($socid);
-                                $tva_tx=($origin=="commande")?get_default_tva($soc,$mysoc,$lines[$i]->fk_product,$idprod):$lines[$i]->tva_tx;
-								$result = $object->addline(
-									$desc,
-									$lines[$i]->subprice,
-									$lines[$i]->qty,
-									$tva_tx,
-									$lines[$i]->localtax1_tx,
-									$lines[$i]->localtax2_tx,
-									$lines[$i]->fk_product,
-									$productsupplier->product_fourn_price_id,
-									$productsupplier->ref_fourn,
-									$lines[$i]->remise_percent,
-									'HT',
-									0,
-									$lines[$i]->product_type,
-									'',
-									'',
-									null,
-									null,
-									array(),
-									$lines[$i]->fk_unit
-								);
-
+								$result = $productsupplier->find_min_price_product_fournisseur($lines[$i]->fk_product, $lines[$i]->qty);
+								if ($result>0) {
+									$productsupplier->fetch($productsupplier->id);
+					                                $soc=new societe($db);
+					                                $soc->fetch($socid);
+					                                $tva_tx=($origin=="commande")?get_default_tva($soc,$mysoc,$lines[$i]->fk_product,$idprod):$lines[$i]->tva_tx;
+									$result = $object->addline(
+										$desc,
+										$lines[$i]->subprice,
+										$lines[$i]->qty,
+										$tva_tx,
+										$lines[$i]->localtax1_tx,
+										$lines[$i]->localtax2_tx,
+										$lines[$i]->fk_product,
+										$productsupplier->product_fourn_price_id,
+										$productsupplier->ref_fourn,
+										$lines[$i]->remise_percent,
+										'HT',
+										0,
+										$lines[$i]->product_type,
+										'',
+										'',
+										null,
+										null,
+										array(),
+										$lines[$i]->fk_unit
+									);
+								}
 								if ($result < 0) {
 									$error++;
 									break;


### PR DESCRIPTION
NEW Allow creation of a supplier order from a customer order. Presently, the button to do so may only be coded thanks to the hook "addMoreActionsButtons"
