### PR TITLE
Fix #4227: Change FactureRec superclass to CommonInvoice

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -36,7 +36,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 /**
  *	Classe de gestion des factures recurrentes/Modeles
  */
-class FactureRec extends Facture
+class FactureRec extends CommonInvoice
 {
 	public $element='facturerec';
 	public $table_element='facture_rec';


### PR DESCRIPTION
Instead of extending Facture which have it's own method parameter's we extend CommonInvoice, which avoids the warnings about different method signatures.

Im not sure if this change would cause any problem, seems that everything is fine after some basic tests creating facture templates.
