### PR TITLE
Prevent sentry logging error with 3.9 update

### DIFF
--- a/htdocs/core/modules/syslog/mod_syslog_sentry.php
+++ b/htdocs/core/modules/syslog/mod_syslog_sentry.php
@@ -145,6 +145,10 @@ class mod_syslog_sentry extends LogHandler implements LogHandlerInterface
 	 */
 	public function export($content)
 	{
+		if (! $this->isActive()) {
+			return;
+		}
+
 		global $conf;
 		$dsn = $conf->global->SYSLOG_SENTRY_DSN;
 		$client = new Raven_Client(


### PR DESCRIPTION
Since we don't ship the required libraries anymore,
if the module had been enabled before upgrade,
the code was failing making Dolibarr totally unusable.

Mitigated the issue by disabling sentry logging
if the required libraries are unavailable.
