### PR TITLE
fix:use of function updateExtrafield instead of insertExtrafields in interventions

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -882,8 +882,7 @@ if (empty($reshook))
 			$parameters=array('id'=>$object->id);
 			$reshook=$hookmanager->executeHooks('insertExtraFields',$parameters,$object,$action);    // Note that $action and $object may have been modified by some hooks
 			if (empty($reshook))
-			{
-				$result=$object->insertExtraFields();
+			{   $result=$object->updateExtraField($_POST["attribute"]);
 				if ($result < 0)
 				{
 					$error++;


### PR DESCRIPTION
# Fix #[use of function updateExtrafield instead of insertExtrafields in interventions]

[First use of function updateExtrafield instead of insertExtrafields in interventions which should be extended to all other common object. This merge needs prevous merge of branch abb-14 which defines the function  updateExtrafield]
