### PR TITLE
fix:missing quote in query in commonobject updatefield function

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4295,7 +4295,7 @@ abstract class CommonObject
             }
             
             $this->db->begin();
-            $sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element."_extrafields SET $key='".$this->array_options["options_$key"]."'";
+            $sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element."_extrafields SET $key='".$this->db->escape($this->array_options["options_$key"])."'";
             $sql .= " WHERE fk_object = ".$this->id;
             $resql = $this->db->query($sql);
             if (! $resql)

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4295,7 +4295,7 @@ abstract class CommonObject
             }
             
             $this->db->begin();
-            $sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element."_extrafields SET $key=".$this->array_options["options_$key"];
+            $sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element."_extrafields SET $key='".$this->array_options["options_$key"]."'";
             $sql .= " WHERE fk_object = ".$this->id;
             $resql = $this->db->query($sql);
             if (! $resql)


### PR DESCRIPTION
# Fix #[urgent fix:missing quote in mysql query in commonobject updatefield function]

This Fix prevents the presence of error in mysql queries related to string extrafields and prevents their update.
