### PR TITLE
Fix bank submenu error

### DIFF
--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -1324,6 +1324,8 @@ function print_left_eldy_menu($db,$menu_array_before,$menu_array_after,&$tabMenu
 		// We update newmenu for special dynamic menus
 		if (!empty($user->rights->banque->lire) && $mainmenu == 'bank')	// Entry for each bank account
 		{
+			require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
+
 			$sql = "SELECT rowid, label, courant, rappro";
 			$sql.= " FROM ".MAIN_DB_PREFIX."bank_account";
 			$sql.= " WHERE entity = ".$conf->entity;


### PR DESCRIPTION
Because of the "Account::TYPE_CASH" used on line 1347, the Account class must be included.

There's a real issue with menu when you open a link from the main menu in another tab, the previous tab displays the new menu even if we are on a page not related to this menu. I guess the question has been asked many times, but I think the menus displayed must always be related to the page we are on don't you think ?
