### PR TITLE
FIX When buy price not explicetly defined, it is return by defineBuyPrice function that return total price instead of unit price

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4560,7 +4560,7 @@ abstract class CommonObject
 					$productFournisseur = new ProductFournisseur($this->db);
 					if (($result = $productFournisseur->find_min_price_product_fournisseur($fk_product)) > 0)
 					{
-						$buyPrice = $productFournisseur->fourn_price;
+						$buyPrice = $productFournisseur->fourn_unitprice;
 					}
 					else if ($result < 0)
 					{


### PR DESCRIPTION
# Fix

To fix a bug encountered at customer shop about margin calculation. In some case, returned buy price is total buy price from provider and not unit buy price.
Case opened on forum: http://www.dolibarr.fr/forum/527-bugs-sur-la-version-stable-courante/55467-calcul-des-marges
