### PR TITLE
Fix old resource type compat

### DIFF
--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1918,6 +1918,9 @@ function getElementProperties($element_type)
         $subelement = 'Actioncomm';
         $module = 'agenda';
     }
+    if ($element_type == 'resource') {
+        $subelement='dolresource';
+    }
 
     // To work with non standard path
     if ($element_type == 'facture' || $element_type == 'invoice') {


### PR DESCRIPTION
This adds compatibility for old element resources that are already stored with "resources" element type, as with #4473 the linked elements are stored with "dolresource" element type at the DB

Im not sure if current type "dolresource" is correct considering that Dolresources class still has $element var as "resources"...
