### PR TITLE
Fix contract line creation

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -320,7 +320,7 @@ if ($action == 'add' && $user->rights->contrat->creer)
 								}
 
 								if ($conf->global->PRODUIT_DESC_IN_FORM)
-									$desc .= ($lines[$i]->desc && $lines[$i]->desc!=$lines[$i]->libelle)?dol_htmlentitiesbr($lines[$i]->desc):'';
+									$desc = ($lines[$i]->desc && $lines[$i]->desc!=$lines[$i]->libelle)?dol_htmlentitiesbr($lines[$i]->desc):'';
 							}
 							else {
 							    $desc = dol_htmlentitiesbr($lines[$i]->desc);

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -319,8 +319,7 @@ if ($action == 'add' && $user->rights->contrat->creer)
 									$label = $lines[$i]->product_label;
 								}
 
-								if ($conf->global->PRODUIT_DESC_IN_FORM)
-									$desc = ($lines[$i]->desc && $lines[$i]->desc!=$lines[$i]->libelle)?dol_htmlentitiesbr($lines[$i]->desc):'';
+								$desc = ($lines[$i]->desc && $lines[$i]->desc!=$lines[$i]->libelle)?dol_htmlentitiesbr($lines[$i]->desc):'';
 							}
 							else {
 							    $desc = dol_htmlentitiesbr($lines[$i]->desc);


### PR DESCRIPTION
When creating a contract from a proposal for example, the contract line desc was mixing all line desc from proposal.

Beside, there was a condition to have desc from proposal line added in contract line that is not right. A variable to setup how lines are displayed in card should not be used in fonctionnal line creation.
