### PR TITLE
New product supplier description

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -363,7 +363,7 @@ if (empty($reshook))
 
 	    		$label = $productsupplier->label;
 
-	    		$desc = $productsupplier->description;
+	    		$desc = $productsupplier->description_supplier;
 	    		if (trim($product_desc) != trim($desc)) $desc = dol_concatdesc($desc, $product_desc);
 
 	    		$type = $productsupplier->type;

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -740,7 +740,7 @@ if (empty($reshook))
 
 	            $label = $productsupplier->label;
 
-	            $desc = $productsupplier->description;
+	            $desc = $productsupplier->description_supplier;
 	            if (trim($product_desc) != trim($desc)) $desc = dol_concatdesc($desc, $product_desc);
 
 	            $tva_tx=get_default_tva($object->thirdparty, $mysoc, $productsupplier->id, $_POST['idprodfournprice']);

--- a/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
+++ b/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
@@ -454,3 +454,6 @@ CREATE TABLE llx_advtargetemailing
 )ENGINE=InnoDB;
 
 ALTER TABLE llx_advtargetemailing ADD UNIQUE INDEX uk_advtargetemailing_name (name);
+
+ALTER TABLE llx_product ADD COLUMN description_supplier text AFTER description;
+ALTER TABLE llx_product_lang ADD COLUMN description_supplier text AFTER description;

--- a/htdocs/install/mysql/tables/llx_product.sql
+++ b/htdocs/install/mysql/tables/llx_product.sql
@@ -35,6 +35,7 @@ create table llx_product
 
   label						varchar(255) NOT NULL,
   description				text,
+    description				text,
   note_public				text,
   note						text,
   customcode                varchar(32),                    -- Optionnal custom code

--- a/htdocs/install/mysql/tables/llx_product_lang.sql
+++ b/htdocs/install/mysql/tables/llx_product_lang.sql
@@ -25,6 +25,7 @@ create table llx_product_lang
   lang           varchar(5)   DEFAULT 0 NOT NULL,
   label          varchar(255) NOT NULL,
   description    text,
+  description_supplier    text,
   note           text,
   import_key varchar(14) DEFAULT NULL
 )ENGINE=innodb;

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -284,6 +284,7 @@ if (empty($reshook))
             $object->barcode_type_label     = $stdobject->barcode_type_label;
 
             $object->description        	 = dol_htmlcleanlastbr(GETPOST('desc'));
+            $object->description_supplier	 = dol_htmlcleanlastbr(GETPOST('desc_supplier'));
             $object->url					 = GETPOST('url');
             $object->note               	 = dol_htmlcleanlastbr(GETPOST('note'));
             $object->customcode              = GETPOST('customcode');
@@ -370,6 +371,7 @@ if (empty($reshook))
                 $object->ref                    = $ref;
                 $object->label                  = GETPOST('label');
                 $object->description            = dol_htmlcleanlastbr(GETPOST('desc'));
+				$object->description_supplier   = dol_htmlcleanlastbr(GETPOST('desc_supplier'));
             	$object->url					= GETPOST('url');
                 $object->note                   = dol_htmlcleanlastbr(GETPOST('note'));
                 $object->customcode             = GETPOST('customcode');
@@ -924,6 +926,16 @@ else
         $doleditor->Create();
 
         print "</td></tr>";
+		
+		if(!empty($conf->fournisseur->enabled)) {
+	        // Supplier description (used in supplier order, supplier invoice...)
+	        print '<tr><td class="tdtop">'.$langs->trans("SupplierDescription").'</td><td colspan="3">';
+	
+	        $doleditor = new DolEditor('desc_supplier', GETPOST('desc_supplier'), '', 160, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, 4, '80%');
+	        $doleditor->Create();
+	
+	        print "</td></tr>";
+		}
 
         // Public URL
         print '<tr><td>'.$langs->trans("PublicUrl").'</td><td colspan="3">';
@@ -1225,6 +1237,19 @@ else
 
             print "</td></tr>";
             print "\n";
+			
+						
+			if(!empty($conf->fournisseur->enabled)) {
+				// Supplier description (used in supplier order, supplier invoice...)
+				print '<tr><td class="tdtop">'.$langs->trans("SupplierDescription").'</td><td colspan="3">';
+				
+				// We use dolibarr_details as type of DolEditor here, because we must not accept images as description is included into PDF and not accepted by TCPDF.
+				$doleditor = new DolEditor('desc_supplier', $object->description_supplier, '', 160, 'dolibarr_details', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, 4, 80);
+				$doleditor->Create();
+	
+				print "</td></tr>";
+				print "\n";
+			}
 
             // Public Url
             print '<tr><td>'.$langs->trans("PublicUrl").'</td><td colspan="3">';
@@ -1530,6 +1555,11 @@ else
 
             // Description
             print '<tr><td class="tdtop">'.$langs->trans("Description").'</td><td colspan="2">'.(dol_textishtml($object->description)?$object->description:dol_nl2br($object->description,1,true)).'</td></tr>';
+			
+			if(!empty($conf->fournisseur->enabled)) {
+				// Supplier description
+				print '<tr><td class="tdtop">'.$langs->trans("SupplierDescription").'</td><td colspan="2">'.(dol_textishtml($object->description_supplier)?$object->description_supplier:dol_nl2br($object->description_supplier,1,true)).'</td></tr>';
+			}
 
             // Public URL
             print '<tr><td>'.$langs->trans("PublicUrl").'</td><td colspan="2">';

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -66,11 +66,16 @@ class Product extends CommonObject
 	 * @var string
 	 */
 	var $label;
-    /**
-     * Product descripion
-     * @var string
-     */
+	/**
+	 * Product descripion
+	 * @var string
+	 */
 	var $description;
+	/**
+	 * Product supplier descripion
+	 * @var string
+	 */
+	var $description_supplier;
 
 	/**
 	 * Check TYPE constants
@@ -628,6 +633,7 @@ class Product extends CommonObject
 		$this->ref = dol_string_nospecial(trim($this->ref));
 		$this->label = trim($this->label);
 		$this->description = trim($this->description);
+		$this->description_supplier = trim($this->description_supplier);
 		$this->note = (isset($this->note) ? trim($this->note) : null);
 		$this->weight = price2num($this->weight);
 		$this->weight_units = trim($this->weight_units);
@@ -731,6 +737,7 @@ class Product extends CommonObject
 			$sql.= ", volume_units = " . ($this->volume_units!='' ? "'".$this->volume_units."'" : 'null');
 			$sql.= ", seuil_stock_alerte = " . ((isset($this->seuil_stock_alerte) && $this->seuil_stock_alerte != '') ? "'".$this->seuil_stock_alerte."'" : "null");
 			$sql.= ", description = '" . $this->db->escape($this->description) ."'";
+			$sql.= ", description_supplier = '" . $this->db->escape($this->description_supplier) ."'";
 			$sql.= ", url = " . ($this->url?"'".$this->db->escape($this->url)."'":'null');
 			$sql.= ", customcode = '" .        $this->db->escape($this->customcode) ."'";
 	        $sql.= ", fk_country = " . ($this->country_id > 0 ? $this->country_id : 'null');
@@ -1015,14 +1022,16 @@ class Product extends CommonObject
 					$sql2 = "UPDATE ".MAIN_DB_PREFIX."product_lang";
 					$sql2.= " SET label='".$this->db->escape($this->label)."',";
 					$sql2.= " description='".$this->db->escape($this->description)."',";
+					$sql2.= " description_supplier='".$this->db->escape($this->description_supplier)."',";
 					$sql2.= " note='".$this->db->escape($this->note)."'";
 					$sql2.= " WHERE fk_product=".$this->id." AND lang='".$key."'";
 				}
 				else
 				{
-					$sql2 = "INSERT INTO ".MAIN_DB_PREFIX."product_lang (fk_product, lang, label, description, note)";
+					$sql2 = "INSERT INTO ".MAIN_DB_PREFIX."product_lang (fk_product, lang, label, description, description_supplier, note)";
 					$sql2.= " VALUES(".$this->id.",'".$key."','". $this->db->escape($this->label);
 					$sql2.= "','".$this->db->escape($this->description);
+					$sql2.= "','".$this->db->escape($this->description_supplier);
 					$sql2.= "','".$this->db->escape($this->note)."')";
 				}
 				dol_syslog(get_class($this).'::setMultiLangs key = current_lang = '.$key);
@@ -1046,19 +1055,21 @@ class Product extends CommonObject
 					$sql2 = "UPDATE ".MAIN_DB_PREFIX."product_lang";
 					$sql2.= " SET label='".$this->db->escape($this->multilangs["$key"]["label"])."',";
 					$sql2.= " description='".$this->db->escape($this->multilangs["$key"]["description"])."',";
+					$sql2.= " description_supplier='".$this->db->escape($this->multilangs["$key"]["description_supplier"])."',";
 					$sql2.= " note='".$this->db->escape($this->multilangs["$key"]["note"])."'";
 					$sql2.= " WHERE fk_product=".$this->id." AND lang='".$key."'";
 				}
 				else
 				{
-					$sql2 = "INSERT INTO ".MAIN_DB_PREFIX."product_lang (fk_product, lang, label, description, note)";
+					$sql2 = "INSERT INTO ".MAIN_DB_PREFIX."product_lang (fk_product, lang, label, description, description_supplier, note)";
 					$sql2.= " VALUES(".$this->id.",'".$key."','". $this->db->escape($this->multilangs["$key"]["label"]);
 					$sql2.= "','".$this->db->escape($this->multilangs["$key"]["description"]);
+					$sql2.= "','".$this->db->escape($this->multilangs["$key"]["description_supplier"]);
 					$sql2.= "','".$this->db->escape($this->multilangs["$key"]["note"])."')";
 				}
 
 				// on ne sauvegarde pas des champs vides
-				if ( $this->multilangs["$key"]["label"] || $this->multilangs["$key"]["description"] || $this->multilangs["$key"]["note"] )
+				if ( $this->multilangs["$key"]["label"] || $this->multilangs["$key"]["description"] || $this->multilangs["$key"]["description_supplier"] || $this->multilangs["$key"]["note"] )
 				dol_syslog(get_class($this).'::setMultiLangs key = '.$key);
 				if (! $this->db->query($sql2))
 				{
@@ -1185,7 +1196,7 @@ class Product extends CommonObject
 
 		$current_lang = $langs->getDefaultLang();
 
-		$sql = "SELECT lang, label, description, note";
+		$sql = "SELECT lang, label, description, description_supplier, note";
 		$sql.= " FROM ".MAIN_DB_PREFIX."product_lang";
 		$sql.= " WHERE fk_product=".$this->id;
 
@@ -1199,11 +1210,13 @@ class Product extends CommonObject
 				{
 					$this->label		= $obj->label;
 					$this->description	= $obj->description;
+					$this->description_supplier	= $obj->description_supplier;
 					$this->note			= $obj->note;
 
 				}
 				$this->multilangs["$obj->lang"]["label"]		= $obj->label;
 				$this->multilangs["$obj->lang"]["description"]	= $obj->description;
+				$this->multilangs["$obj->lang"]["description_supplier"]	= $obj->description_supplier;
 				$this->multilangs["$obj->lang"]["note"]			= $obj->note;
 			}
 			return 1;
@@ -1613,7 +1626,7 @@ class Product extends CommonObject
 			return -1;
 		}
 
-		$sql = "SELECT rowid, ref, ref_ext, label, description, url, note, customcode, fk_country, price, price_ttc,";
+		$sql = "SELECT rowid, ref, ref_ext, label, description, description_supplier, url, note, customcode, fk_country, price, price_ttc,";
 		$sql.= " price_min, price_min_ttc, price_base_type, cost_price, default_vat_code, tva_tx, recuperableonly as tva_npr, localtax1_tx, localtax2_tx, localtax1_type, localtax2_type, tosell,";
 		$sql.= " tobuy, fk_product_type, duration, seuil_stock_alerte, canvas,";
 		$sql.= " weight, weight_units, length, length_units, surface, surface_units, volume, volume_units, barcode, fk_barcode_type, finished,";
@@ -1641,6 +1654,7 @@ class Product extends CommonObject
 				$this->ref_ext					= $obj->ref_ext;
 				$this->label					= $obj->label;
 				$this->description				= $obj->description;
+				$this->description_supplier		= $obj->description_supplier;
 				$this->url						= $obj->url;
 				$this->note						= $obj->note;
 
@@ -3931,6 +3945,7 @@ class Product extends CommonObject
         $this->ref = 'PRODUCT_SPEC';
         $this->label = 'PRODUCT SPECIMEN';
         $this->description = 'PRODUCT SPECIMEN '.dol_print_date($now,'dayhourlog');
+		$this->description_supplier = 'PRODUCT SPECIMEN SUPPLIER '.dol_print_date($now,'dayhourlog');
         $this->specimen=1;
         $this->country_id=1;
         $this->tosell=1;


### PR DESCRIPTION
This new field will allow to define a product description for suppliers different from the standard product description. The use case is that the standard description can be used to have a commercial description of the product (sale side), but when ordering the product to a supplier, we might want another description.

I wonder if I must initialize this new column with the standard description for backward compatibility. Like this, someone making a Dolibarr migration will have to fill all product supplier description to work as before. Adding an "UPDATE description_supplier = description" in the migration script seems to me a good idea. Any thoughts ?
