### PR TITLE
New change default agenda event creation

### DIFF
--- a/htdocs/core/modules/modAgenda.class.php
+++ b/htdocs/core/modules/modAgenda.class.php
@@ -80,17 +80,16 @@ class modAgenda extends DolibarrModules
 		$resql = $this->db->query($sqlreadactions);
 		if ($resql)
 		{
-		    while ($obj = $this->db->fetch_object($sqlreadactions))
-		    {
-		        if (preg_match('/_CREATE$/',$obj->code)) continue;    // We don't track such events (*_CREATE) by default. 
-		        if (preg_match('/^PROJECT_/',$obj->code)) continue;   // We don't track such events by default.
-		        if (preg_match('/^TASK_/',$obj->code)) continue;      // We don't track such events by default.
-		        $this->const[] = array('MAIN_AGENDA_ACTIONAUTO_'.$obj->code, "chaine", "1");
-		    }
+			while ($obj = $this->db->fetch_object($sqlreadactions))
+			{
+				if (preg_match('/_SENTBYMAIL$/',$obj->code)) {
+					$this->const[] = array('MAIN_AGENDA_ACTIONAUTO_'.$obj->code, "chaine", "1");
+				}
+			}
 		}
 		else 
 		{
-		    dol_print_error($this->db->lasterror());
+			dol_print_error($this->db->lasterror());
 		}
 		
 		// New pages on tabs


### PR DESCRIPTION
I think that by default, only "SENTBYMAIL" actions should be automatically created as calendar events. Sending an e-mail is for me a real external interaction that needs to be in the third calendar to have a follow up. IMHO  other actions (create, validate, reopen...) should be in the "log" tab, just as it was in supplier order (before 4.0, see https://github.com/Dolibarr/dolibarr/commit/b9ffc18c27c89554be436ef9ea3bf77257687677)

Really open to discussion here.
