### PR TITLE
Fix Translation

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -427,10 +427,10 @@ abstract class CommonDocGenerator
 
 		$resarray= array(
 			'line_fulldesc'=>doc_getlinedesc($line,$outputlangs),
-			'line_product_ref'=>$line->product_ref,
-			'line_product_label'=>$line->product_label,
-                        'line_product_type'=>$line->product_type,
-			'line_desc'=>$line->desc,
+			'line_product_ref'=>doc_gettranslatedfield($line,'product_ref',$outputlangs),
+			'line_product_label'=>doc_gettranslatedfield($line,'product_label',$outputlangs),
+                        'line_product_type'=>doc_gettranslatedfield($line,'product_type',$outputlangs),
+			'line_desc'=>doc_gettranslatedfield($line,'desc',$outputlangs),
 			'line_vatrate'=>vatrate($line->tva_tx,true,$line->info_bits),
 			'line_up'=>price2num($line->subprice),
 			'line_up_locale'=>price($line->subprice, 0, $outputlangs),

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -535,9 +535,9 @@ abstract class CommonDocGenerator
 
     	return array(
 	    	'line_fulldesc'=>doc_getlinedesc($line,$outputlangs),
-	    	'line_product_ref'=>$line->product_ref,
-	    	'line_product_label'=>$line->product_label,
-	    	'line_desc'=>$line->desc,
+	    	'line_product_ref'=>doc_gettranslatedfield($line,'product_ref',$outputlangs),
+	    	'line_product_label'=>doc_gettranslatedfield($line,'product_label',$outputlangs),
+	    	'line_desc'=>doc_gettranslatedfield($line,'desc',$outputlangs),
 	    	'line_vatrate'=>vatrate($line->tva_tx,true,$line->info_bits),
 	    	'line_up'=>price($line->subprice),
 	    	'line_qty'=>$line->qty,

--- a/htdocs/core/lib/doc.lib.php
+++ b/htdocs/core/lib/doc.lib.php
@@ -152,3 +152,26 @@ function doc_getlinedesc($line,$outputlangs,$hideref=0,$hidedesc=0,$issupplierli
 	return $libelleproduitservice;
 }
 
+/**
+ *  Return line field translated in outputlangs
+ *
+ *  @param  Line        $line                Current line object
+ *  @param  string      $field               Field to translate (product_ref, product_label...)
+ *  @param  Translate   $outputlangs         Object langs for output
+ *  @return string                           Translated field
+ */
+function doc_gettranslatedfield($line, $field, $outputlangs){
+    global $conf;
+
+    // use the current field value
+    $value = empty($line->$field)?'':$line->$field;
+
+    // and try to translate it
+    if (! empty($conf->global->MAIN_MULTILANGS))
+    {
+        if (! empty($line->multilangs[$outputlangs->defaultlang][$field])){
+            $value=$line->multilangs[$outputlangs->defaultlang][$field];
+        }
+    }
+    return $value;
+}

--- a/htdocs/core/lib/doc.lib.php
+++ b/htdocs/core/lib/doc.lib.php
@@ -161,7 +161,7 @@ function doc_getlinedesc($line,$outputlangs,$hideref=0,$hidedesc=0,$issupplierli
  *  @return string                           Translated field
  */
 function doc_gettranslatedfield($line, $field, $outputlangs){
-    global $conf;
+    global $db, $conf;
 
     // use the current field value
     $value = empty($line->$field)?'':$line->$field;
@@ -169,9 +169,17 @@ function doc_gettranslatedfield($line, $field, $outputlangs){
     // and try to translate it
     if (! empty($conf->global->MAIN_MULTILANGS))
     {
-        if (! empty($line->multilangs[$outputlangs->defaultlang][$field])){
-            $value=$line->multilangs[$outputlangs->defaultlang][$field];
-        }
+    	$idprod=$line->fk_product;
+    	$prodser = new Product($db);
+
+	if ($idprod)
+	{
+		$prodser->fetch($idprod);
+	        if (! empty($prodser->multilangs[$outputlangs->defaultlang][$field]))
+	        {
+	            $value=$prodser->multilangs[$outputlangs->defaultlang][$field];
+	        }
+	}
     }
     return $value;
 }


### PR DESCRIPTION
# Fix [Odt-product  translations not supported](https://www.dolibarr.org/forum/12-howto-help/25594-odt-product-service-translations-not-supported)

_In French: http://www.dolibarr.fr/forum/12-howto--aide/55504-description-multilingue-produits-bug-propal-odt_
Some fields are not translated when the ODT is generated. For instance:
- {line_product_label}
- {company_country}

This PR adds a new function to easily translate the fields and uses it for some fields (I might have miss some of them: feel free to edit my work)
