### PR TITLE
Fix contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Administrator, user, developer and translator's documentations are available alo
 
 ## CONTRIBUTING
 
-See file [CONTRIBUTING](https://github.com/Dolibarr/dolibarr/blob/develop/CONTRIBUTING.md)
+See file [CONTRIBUTING](https://github.com/Dolibarr/dolibarr/blob/develop/.github/CONTRIBUTING.md)
 
 ## CREDITS
 


### PR DESCRIPTION
The contributing link of the readme pointed to a inexistent location.
