### PR TITLE
Fix access to project task time spent creation #5249

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -359,7 +359,7 @@ if ($id > 0 || ! empty($ref))
 		/*
 		 * Form to add time spent
 		 */
-		if ($user->rights->projet->creer)
+		if ($user->rights->projet->lire)
 		{
 			print '<br>';
 


### PR DESCRIPTION
As described in the right management, user who can read project can also create a time spent
