### PR TITLE
Don't delete link between order and shipment

### DIFF
--- a/htdocs/commande/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/commande/tpl/linkedobjectblock.tpl.php
@@ -46,7 +46,16 @@ foreach($linkedObjectBlock as $key => $objectlink)
 			echo price($objectlink->total_ht);
 		} ?></td>
 	<td align="right"><?php echo $objectlink->getLibStatut(3); ?></td>
-	<td align="right"><a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=dellink&dellinkid='.$key; ?>"><?php echo img_delete($langs->transnoentitiesnoconv("RemoveLink")); ?></a></td>
+	<td align="right">
+		<?php
+		// For now, shipments must stay linked to order, so link is not deletable
+		if($object->element != 'shipping') {
+			?>
+			<a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=dellink&dellinkid='.$key; ?>"><?php echo img_delete($langs->transnoentitiesnoconv("RemoveLink")); ?></a>
+			<?php
+		}
+		?>
+	</td>
 </tr>
 <?php
 }

--- a/htdocs/expedition/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/expedition/tpl/linkedobjectblock.tpl.php
@@ -41,12 +41,20 @@ foreach($linkedObjectBlock as $key => $objectlink)
     <td></td>
 	<td align="center"><?php echo dol_print_date($objectlink->date_delivery,'day'); ?></td>
 	<td align="right"><?php
-		/*if ($user->rights->expedition->lire) {
+		if ($user->rights->expedition->lire) {
 			$total = $total + $objectlink->total_ht;
 			echo price($objectlink->total_ht);
-		}*/ ?></td>
+		} ?></td>
 	<td align="right"><?php echo $objectlink->getLibStatut(3); ?></td>
-	<td align="right"><a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=dellink&dellinkid='.$key; ?>"><?php echo img_delete($langs->transnoentitiesnoconv("RemoveLink")); ?></a></td>
+	<td align="right">
+		<?php
+		// For now, shipments must stay linked to order, so link is not deletable
+		if($object->element != 'commande') {
+			?>
+			<a href="<?php echo $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=dellink&dellinkid='.$key; ?>"><?php echo img_delete($langs->transnoentitiesnoconv("RemoveLink")); ?></a></td>
+			<?php
+		}
+		?>
 </tr>
 <?php
 }


### PR DESCRIPTION
For now, shipment can't exist correctly in the system if it's not related to an order. So I remove the possibility to delete the link between the 2 objects.
