### PR TITLE
Added Markdown rule to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,5 @@ indent_style = tab
 indent_style = tab
 [*.xml]
 indent_style = tab
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Markdown uses two spaces to encode a line break.
Editors usually removes them without this configuration which can prove
quite frustrating.
