### PR TITLE
FIX: vat management for credit notes (and negative quantities)

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2215,10 +2215,10 @@ class Facture extends CommonInvoice
 			$this->line->rang=$rangtouse;
 			$this->line->info_bits=$info_bits;
 			$this->line->fk_remise_except=$fk_remise_except;
-			$this->line->total_ht=       (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_ht):$total_ht);  // For credit note and if qty is negative, total is negative
-			$this->line->total_tva=      $total_tva;
-			$this->line->total_localtax1=$total_localtax1;
-			$this->line->total_localtax2=$total_localtax2;
+			$this->line->total_ht=(($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_ht):$total_ht);  // For credit note and if qty is negative, total is negative
+			$this->line->total_tva=(($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_tva):$total_tva);  // For credit note and if qty is negative, total is negative
+			$this->line->total_localtax1=(($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_localtax1):$total_localtax1);  // For credit note and if qty is negative, total is negative
+			$this->line->total_localtax2=(($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_localtax2):$total_localtax2);  // For credit note and if qty is negative, total is negative
 			$this->line->localtax1_type = $localtaxes_type[0];
 			$this->line->localtax2_type = $localtaxes_type[2];
 			$this->line->total_ttc=      (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_ttc):$total_ttc);

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2386,9 +2386,9 @@ class Facture extends CommonInvoice
 			$this->line->date_start			= $date_start;
 			$this->line->date_end			= $date_end;
 			$this->line->total_ht			= (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_ht):$total_ht);  // For credit note and if qty is negative, total is negative
-			$this->line->total_tva			= $total_tva;
-			$this->line->total_localtax1	= $total_localtax1;
-			$this->line->total_localtax2	= $total_localtax2;
+			$this->line->total_tva			= (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_tva):$total_tva);  // For credit note and if qty is negative, total is negative
+			$this->line->total_localtax1	= (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_localtax1):$total_localtax1);  // For credit note and if qty is negative, total is negative
+			$this->line->total_localtax2	= (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_localtax2):$total_localtax2);  // For credit note and if qty is negative, total is negative
 			$this->line->total_ttc			= (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_ttc):$total_ttc);
 			$this->line->info_bits			= $info_bits;
 			$this->line->special_code		= $special_code;

--- a/htdocs/core/lib/tax.lib.php
+++ b/htdocs/core/lib/tax.lib.php
@@ -329,7 +329,7 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                 {
                     $oldrowid=$assoc['rowid'];
                     $list[$assoc['rate']]['totalht']  += $assoc['total_ht'];
-                    $list[$assoc['rate']]['vat']      += $assoc['total_vat'];
+                    $list[$assoc['rate']]['vat']      += ($assoc['total_ht'] < 0 ? -1 * $assoc['total_vat']:$assoc['total_vat']);
                     $list[$assoc['rate']]['localtax1']      += $assoc['total_localtax1'];
                     $list[$assoc['rate']]['localtax2']      += $assoc['total_localtax2'];
                 }
@@ -348,7 +348,7 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                 $list[$assoc['rate']]['descr'][] = $assoc['descr'];
 
                 $list[$assoc['rate']]['totalht_list'][] = $assoc['total_ht'];
-                $list[$assoc['rate']]['vat_list'][] = $assoc['total_vat'];
+                $list[$assoc['rate']]['vat_list'][] = ($assoc['total_ht'] < 0 ? -1 * $assoc['total_vat']:$assoc['total_vat']);
                 $list[$assoc['rate']]['localtax1_list'][] = $assoc['total_localtax1'];
                 $list[$assoc['rate']]['localtax2_list'][]  = $assoc['total_localtax2'];
 
@@ -474,7 +474,7 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                 {
                     $oldrowid=$assoc['rowid'];
                     $list[$assoc['rate']]['totalht']  += $assoc['total_ht'];
-                    $list[$assoc['rate']]['vat']      += $assoc['total_vat'];
+                    $list[$assoc['rate']]['vat']      += ($assoc['total_ht'] < 0 ? -1 * $assoc['total_vat']:$assoc['total_vat']);
                     $list[$assoc['rate']]['localtax1']	 += $assoc['total_localtax1'];
                     $list[$assoc['rate']]['localtax2']	 += $assoc['total_localtax2'];
                 }
@@ -493,7 +493,7 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                 $list[$assoc['rate']]['descr'][] = $assoc['descr'];
 
                 $list[$assoc['rate']]['totalht_list'][] = $assoc['total_ht'];
-                $list[$assoc['rate']]['vat_list'][] = $assoc['total_vat'];
+                $list[$assoc['rate']]['vat_list'][] = ($assoc['total_ht'] < 0 ? -1 * $assoc['total_vat']:$assoc['total_vat']);
                 $list[$assoc['rate']]['localtax1_list'][] = $assoc['total_localtax1'];
                 $list[$assoc['rate']]['localtax2_list'][] = $assoc['total_localtax2'];
 

--- a/htdocs/core/lib/tax.lib.php
+++ b/htdocs/core/lib/tax.lib.php
@@ -329,7 +329,7 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                 {
                     $oldrowid=$assoc['rowid'];
                     $list[$assoc['rate']]['totalht']  += $assoc['total_ht'];
-                    $list[$assoc['rate']]['vat']      += ($assoc['total_ht'] < 0 ? -1 * $assoc['total_vat']:$assoc['total_vat']);
+                    $list[$assoc['rate']]['vat']      += ($assoc['total_ht'] < 0 && $assoc['total_vat'] > 0) ? -1 * $assoc['total_vat']:$assoc['total_vat'];
                     $list[$assoc['rate']]['localtax1']      += $assoc['total_localtax1'];
                     $list[$assoc['rate']]['localtax2']      += $assoc['total_localtax2'];
                 }
@@ -348,7 +348,7 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                 $list[$assoc['rate']]['descr'][] = $assoc['descr'];
 
                 $list[$assoc['rate']]['totalht_list'][] = $assoc['total_ht'];
-                $list[$assoc['rate']]['vat_list'][] = ($assoc['total_ht'] < 0 ? -1 * $assoc['total_vat']:$assoc['total_vat']);
+                $list[$assoc['rate']]['vat_list'][] = ($assoc['total_ht'] < 0 && $assoc['total_vat'] > 0) ? -1 * $assoc['total_vat']:$assoc['total_vat'];
                 $list[$assoc['rate']]['localtax1_list'][] = $assoc['total_localtax1'];
                 $list[$assoc['rate']]['localtax2_list'][]  = $assoc['total_localtax2'];
 
@@ -474,7 +474,7 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                 {
                     $oldrowid=$assoc['rowid'];
                     $list[$assoc['rate']]['totalht']  += $assoc['total_ht'];
-                    $list[$assoc['rate']]['vat']      += ($assoc['total_ht'] < 0 ? -1 * $assoc['total_vat']:$assoc['total_vat']);
+                    $list[$assoc['rate']]['vat']      += ($assoc['total_ht'] < 0 && $assoc['total_vat'] > 0) ? -1 * $assoc['total_vat']:$assoc['total_vat'];
                     $list[$assoc['rate']]['localtax1']	 += $assoc['total_localtax1'];
                     $list[$assoc['rate']]['localtax2']	 += $assoc['total_localtax2'];
                 }
@@ -493,7 +493,7 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                 $list[$assoc['rate']]['descr'][] = $assoc['descr'];
 
                 $list[$assoc['rate']]['totalht_list'][] = $assoc['total_ht'];
-                $list[$assoc['rate']]['vat_list'][] = ($assoc['total_ht'] < 0 ? -1 * $assoc['total_vat']:$assoc['total_vat']);
+                $list[$assoc['rate']]['vat_list'][] = ($assoc['total_ht'] < 0 && $assoc['total_vat'] > 0) ? -1 * $assoc['total_vat']:$assoc['total_vat'];
                 $list[$assoc['rate']]['localtax1_list'][] = $assoc['total_localtax1'];
                 $list[$assoc['rate']]['localtax2_list'][] = $assoc['total_localtax2'];
 

--- a/htdocs/core/lib/tax.lib.php
+++ b/htdocs/core/lib/tax.lib.php
@@ -330,8 +330,8 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                     $oldrowid=$assoc['rowid'];
                     $list[$assoc['rate']]['totalht']  += $assoc['total_ht'];
                     $list[$assoc['rate']]['vat']      += ($assoc['total_ht'] < 0 && $assoc['total_vat'] > 0) ? -1 * $assoc['total_vat']:$assoc['total_vat'];
-                    $list[$assoc['rate']]['localtax1']      += $assoc['total_localtax1'];
-                    $list[$assoc['rate']]['localtax2']      += $assoc['total_localtax2'];
+                    $list[$assoc['rate']]['localtax1']      += ($assoc['total_ht'] < 0 && $assoc['total_localtax1'] > 0) ? -1 * $assoc['total_localtax1']:$assoc['total_localtax1'];
+                    $list[$assoc['rate']]['localtax2']      += ($assoc['total_ht'] < 0 && $assoc['total_localtax2'] > 0) ? -1 * $assoc['total_localtax2']:$assoc['total_localtax2'];
                 }
                 $list[$assoc['rate']]['dtotal_ttc'][] = $assoc['total_ttc'];
                 $list[$assoc['rate']]['dtype'][] = $assoc['dtype'];
@@ -349,8 +349,8 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
 
                 $list[$assoc['rate']]['totalht_list'][] = $assoc['total_ht'];
                 $list[$assoc['rate']]['vat_list'][] = ($assoc['total_ht'] < 0 && $assoc['total_vat'] > 0) ? -1 * $assoc['total_vat']:$assoc['total_vat'];
-                $list[$assoc['rate']]['localtax1_list'][] = $assoc['total_localtax1'];
-                $list[$assoc['rate']]['localtax2_list'][]  = $assoc['total_localtax2'];
+                $list[$assoc['rate']]['localtax1_list'][] = ($assoc['total_ht'] < 0 && $assoc['total_localtax1'] > 0) ? -1 * $assoc['total_localtax1']:$assoc['total_localtax1'];
+                $list[$assoc['rate']]['localtax2_list'][]  = ($assoc['total_ht'] < 0 && $assoc['total_localtax2'] > 0) ? -1 * $assoc['total_localtax2']:$assoc['total_localtax2'];
 
                 $list[$assoc['rate']]['pid'][] = $assoc['pid'];
                 $list[$assoc['rate']]['pref'][] = $assoc['pref'];
@@ -475,8 +475,8 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
                     $oldrowid=$assoc['rowid'];
                     $list[$assoc['rate']]['totalht']  += $assoc['total_ht'];
                     $list[$assoc['rate']]['vat']      += ($assoc['total_ht'] < 0 && $assoc['total_vat'] > 0) ? -1 * $assoc['total_vat']:$assoc['total_vat'];
-                    $list[$assoc['rate']]['localtax1']	 += $assoc['total_localtax1'];
-                    $list[$assoc['rate']]['localtax2']	 += $assoc['total_localtax2'];
+                    $list[$assoc['rate']]['localtax1']	 += ($assoc['total_ht'] < 0 && $assoc['total_localtax1'] > 0) ? -1 * $assoc['total_localtax1']:$assoc['total_localtax1'];
+                    $list[$assoc['rate']]['localtax2']	 += ($assoc['total_ht'] < 0 && $assoc['total_localtax2'] > 0) ? -1 * $assoc['total_localtax2']:$assoc['total_localtax2'];
                 }
                 $list[$assoc['rate']]['dtotal_ttc'][] = $assoc['total_ttc'];
                 $list[$assoc['rate']]['dtype'][] = $assoc['dtype'];
@@ -494,8 +494,8 @@ function vat_by_date($db, $y, $q, $date_start, $date_end, $modetax, $direction, 
 
                 $list[$assoc['rate']]['totalht_list'][] = $assoc['total_ht'];
                 $list[$assoc['rate']]['vat_list'][] = ($assoc['total_ht'] < 0 && $assoc['total_vat'] > 0) ? -1 * $assoc['total_vat']:$assoc['total_vat'];
-                $list[$assoc['rate']]['localtax1_list'][] = $assoc['total_localtax1'];
-                $list[$assoc['rate']]['localtax2_list'][] = $assoc['total_localtax2'];
+                $list[$assoc['rate']]['localtax1_list'][] = ($assoc['total_ht'] < 0 && $assoc['total_localtax1'] > 0) ? -1 * $assoc['total_localtax1']:$assoc['total_localtax1'];
+                $list[$assoc['rate']]['localtax2_list'][] = ($assoc['total_ht'] < 0 && $assoc['total_localtax2'] > 0) ? -1 * $assoc['total_localtax2']:$assoc['total_localtax2'];
 
                 $list[$assoc['rate']]['pid'][] = $assoc['pid'];
                 $list[$assoc['rate']]['pref'][] = $assoc['pref'];


### PR DESCRIPTION
in vat reports, vat was positive even if total_ht was negative, so vat reports were false (case of credit notes)
