### PR TITLE
FIX Hide a non relevant message when PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS is on on project edit view

### DIFF
--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -635,8 +635,12 @@ else
 	    $filteronlist='';
 	    if (! empty($conf->global->PROJECT_FILTER_FOR_THIRDPARTY_LIST)) $filteronlist=$conf->global->PROJECT_FILTER_FOR_THIRDPARTY_LIST;
         $text=$form->select_thirdparty_list($object->thirdparty->id, 'socid', $filteronlist, 1, 1);
-        $texthelp=$langs->trans("IfNeedToUseOhterObjectKeepEmpty");
-        print $form->textwithtooltip($text.' '.img_help(), $texthelp, 1, 0, '', '', 2);
+        if (empty($conf->global->PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS) && empty($conf->dol_use_jmobile))
+	    {
+	    	$texthelp=$langs->trans("IfNeedToUseOhterObjectKeepEmpty");
+	    	print $form->textwithtooltip($text.' '.img_help(),$texthelp,1);
+	    }
+	    else print $text;
         print '</td></tr>';
 
         // Visibility


### PR DESCRIPTION
# Fix PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS on project edit view. Enabled on create view but not deployed on edit view
