### PR TITLE
Fix : bad name of field

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -2422,7 +2422,7 @@ class ContratLigne extends CommonObjectLine
 		$sql.= " p.ref as product_ref,";
 		$sql.= " p.label as product_label,";
 		$sql.= " p.description as product_desc,";
-		$sql.= " p.type as product_type,";
+		$sql.= " p.product_type as product_type,";
 		$sql.= " t.description,";
 		$sql.= " t.date_commande,";
 		$sql.= " t.date_ouverture_prevue as date_ouverture_prevue,";


### PR DESCRIPTION
# Fix : bad name of field

DoliDBMysqli::query SQL Error message: DB_ERROR_NOSUCHFIELD Champ 'p.type' inconnu dans field list
