### PR TITLE
FIX #4608 [Debian] Don't hard depend on mysql-server

### DIFF
--- a/build/debian/control
+++ b/build/debian/control
@@ -26,11 +26,11 @@ Depends: libapache2-mod-php5 | libapache2-mod-php5filter | php5-cgi | php5-fpm |
 # Misc dependencies
 #    fonts-dejavu-core | ttf-dejavu-core,
     xdg-utils,
-    mysql-server,
-    mysql-client,
+    virtual-mysql-client,
     ${misc:Depends},
     ${perl:Depends}
-Recommends: apache2 | lighttpd | httpd
+Recommends: apache2 | lighttpd | httpd,
+    virtual-mysql-server
 Suggests: www-browser, php5-geoip
 Description: Web based software to manage a company or foundation
  Dolibarr ERP & CRM is an easy to use open source/free software package for 


### PR DESCRIPTION
Allows using a separate MySQL server and switching to MariaDB.

Rebased against develop. See #5573.
