### PR TITLE
FIX : Accountancy - BANK_DISABLE_DIRECT_INPUT Add an option

### DIFF
--- a/htdocs/accountancy/admin/index.php
+++ b/htdocs/accountancy/admin/index.php
@@ -168,6 +168,18 @@ if ($action == 'setmanagezero') {
 	}
 }
 
+if ($action == 'setdisabledirectinput') {
+	$setdisabledirectinput = GETPOST('value', 'int');
+	$res = dolibarr_set_const($db, "BANK_DISABLE_DIRECT_INPUT", $setdisabledirectinput, 'yesno', 0, '', $conf->entity);
+	if (! $res > 0)
+		$error ++;
+	if (! $error) {
+		setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
+	} else {
+		setEventMessages($langs->trans("Error"), null, 'mesgs');
+	}
+}
+
 /*
  * View
  */
@@ -337,6 +349,20 @@ if (! empty($conf->global->ACCOUNTING_MANAGE_ZERO)) {
 	print '</a></td>';
 } else {
 	print '<td align="center" colspan="2"><a href="' . $_SERVER['PHP_SELF'] . '?action=setmanagezero&value=1">';
+	print img_picto($langs->trans("Disabled"), 'switch_off');
+	print '</a></td>';
+}
+print '</tr>';
+
+$var = ! $var;
+print "<tr " . $bc[$var] . ">";
+print '<td width="80%">' . $langs->trans("BANK_DISABLE_DIRECT_INPUT") . '</td>';
+if (! empty($conf->global->BANK_DISABLE_DIRECT_INPUT)) {
+	print '<td align="center" colspan="2"><a href="' . $_SERVER['PHP_SELF'] . '?action=setdisabledirectinput&value=0">';
+	print img_picto($langs->trans("Activated"), 'switch_on');
+	print '</a></td>';
+} else {
+	print '<td align="center" colspan="2"><a href="' . $_SERVER['PHP_SELF'] . '?action=setdisabledirectinput&value=1">';
 	print img_picto($langs->trans("Disabled"), 'switch_off');
 	print '</a></td>';
 }

--- a/htdocs/compta/bank/account.php
+++ b/htdocs/compta/bank/account.php
@@ -366,16 +366,11 @@ if ($id > 0 || ! empty($ref))
 		{
 			if (empty($conf->global->BANK_DISABLE_DIRECT_INPUT)) 
 			{
-                if (empty($conf->accounting->enabled))
-                {
-                    if ($user->rights->banque->modifier) {
-                        print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?action=addline&amp;id='.$object->id.'&amp;page='.$page.($vline?'&amp;vline='.$vline:'').'">'.$langs->trans("AddBankRecord").'</a>';
-                    } else {
-                        print '<a class="butActionRefused" title="'.$langs->trans("NotEnoughPermissions").'" href="#">'.$langs->trans("AddBankRecord").'</a>';
-                    }
-                } else {
-                    print '<a class="butActionRefused" title="'.$langs->trans("FeatureDisabled").'" href="#">'.$langs->trans("AddBankRecord").'</a>';
-                }
+				if ($user->rights->banque->modifier) {
+					print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?action=addline&amp;id='.$object->id.'&amp;page='.$page.($vline?'&amp;vline='.$vline:'').'">'.$langs->trans("AddBankRecord").'</a>';
+				} else {
+					print '<a class="butActionRefused" title="'.$langs->trans("NotEnoughPermissions").'" href="#">'.$langs->trans("AddBankRecord").'</a>';
+				}
 			} else {
                 print '<a class="butActionRefused" title="'.$langs->trans("FeatureDisabled").'" href="#">'.$langs->trans("AddBankRecord").'</a>';
             }

--- a/htdocs/core/modules/modAccounting.class.php
+++ b/htdocs/core/modules/modAccounting.class.php
@@ -207,6 +207,11 @@ class modAccounting extends DolibarrModules
 				"chaine",
 				"csv"
 		);
+		$this->const[24] = array(
+				"BANK_DISABLE_DIRECT_INPUT",
+				"yesno",
+				"1"
+		);
 
 		// Tabs
 		$this->tabs = array();

--- a/htdocs/langs/en_US/accountancy.lang
+++ b/htdocs/langs/en_US/accountancy.lang
@@ -56,7 +56,8 @@ ACCOUNTING_LENGTH_DESCRIPTION=Length for displaying product & services descripti
 ACCOUNTING_LENGTH_DESCRIPTION_ACCOUNT=Length for displaying product & services account description form in listings (Best = 50)
 ACCOUNTING_LENGTH_GACCOUNT=Length of the general accounts
 ACCOUNTING_LENGTH_AACCOUNT=Length of the third party accounts
-ACCOUNTING_MANAGE_ZERO=Manage the zero at the end of an accounting account. Needed by some countries. Disable by default. Be careful with the function of length of the accounts.
+ACCOUNTING_MANAGE_ZERO=Manage the zero at the end of an accounting account. Needed by some countries. Disable by default. Be careful with the function "length of the accounts".
+BANK_DISABLE_DIRECT_INPUT=Disable free input of bank transactions. Enable by default with this module.
 
 ACCOUNTING_SELL_JOURNAL=Sell journal
 ACCOUNTING_PURCHASE_JOURNAL=Purchase journal


### PR DESCRIPTION
For user comprehension, add an option in accountancy configuration module to enable free input of bank transactions. By default, with this module, the free input is disable.

![image](https://cloud.githubusercontent.com/assets/2341395/17543639/51c9eb4e-5ed2-11e6-89de-6ccfa3f30124.png)
