### PR TITLE
[docker image] Add ldap php module, declares useful volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM php:5.6-apache
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libldap2-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd
-
-RUN docker-php-ext-install mysqli
+	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+        && docker-php-ext-install ldap \
+        && docker-php-ext-install mysqli \
+        && apt-get purge -y libpng12-dev libjpeg-dev libldap2-dev
 
 COPY htdocs/ /var/www/html/
 
 RUN chown -hR www-data:www-data /var/www/html
+
+VOLUME /var/www/html/conf
+VOLUME /var/www/html/documents
 
 EXPOSE 80


### PR DESCRIPTION
This patch adds ldap support to the Docker image.

It also declares 2 volumes :
/var/www/html/conf : so the configuration is kept between updates
/var/www/html/documents : so the documents are kept between updates
