### PR TITLE
[docker image] Optimize the image size by getting the tarball from github releases a…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:5.6-apache
 
+ENV DOLIBARR_RELEASE 3.9.3
+
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
@@ -7,8 +9,10 @@ RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev \
 
 RUN docker-php-ext-install mysqli
 
-COPY htdocs/ /var/www/html/
-
-RUN chown -hR www-data:www-data /var/www/html
+RUN curl -L https://github.com/Dolibarr/dolibarr/archive/${DOLIBARR_RELEASE}.tar.gz \
+        > /tmp/${DOLIBARR_RELEASE}.tar.gz \
+        && tar xzf /tmp/${DOLIBARR_RELEASE}.tar.gz -C /tmp \
+        && cp -ar /tmp/dolibarr-${DOLIBARR_RELEASE}/htdocs/* /var/www/html/ \
+        && rm -rf /tmp/dolibarr-${DOLIBARR_RELEASE} /tmp/${DOLIBARR_RELEASE}.tar.gz
 
 EXPOSE 80


### PR DESCRIPTION
This path get the dolibarr code from github releases.

This allow the addition of the code in the docker image in only one step, reducing the image size by about 100MB (COPY + chmod => 2 copies of the files in 2 different layers in the image).

The env variable allow to choose the release version to use.
