### PR TITLE
Fix Bug: delivery date value is not hide with global ORDER_DISABLE_DELIVE…

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -587,10 +587,13 @@ if ($resql)
 		print dol_print_date($db->jdate($objp->date_commande), 'day');
 		print '</td>';
 
-		// Delivery date
-		print '<td align="center">';
-		print dol_print_date($db->jdate($objp->date_delivery), 'day');
-		print '</td>';
+		if (empty($conf->global->ORDER_DISABLE_DELIVERY_DATE)) 
+		{
+			// Delivery date
+			print '<td align="center">';
+			print dol_print_date($db->jdate($objp->date_delivery), 'day');
+			print '</td>';
+		}
 
 		// Amount HT
 		print '<td align="right" class="nowrap">'.price($objp->total_ht).'</td>';


### PR DESCRIPTION
# Fix delivery date value is not hide with global

In title and in filter the delivery date column is well hidden. 
The error is only in column value,
