### PR TITLE
Fix: An empty variable is used to update multiprice

### DIFF
--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -10,6 +10,7 @@
  * Copyright (C) 2014		Ion agorria				<ion@agorria.com>
  * Copyright (C) 2015		Alexandre Spangaro		<aspangaro.dolibarr@gmail.com>
  * Copyright (C) 2015		Marcos García			<marcosgdf@gmail.com>
+ * Copyright (C) 2016		Ferran Marcet			<fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -213,7 +214,7 @@ if (empty($reshook))
 					'price' => $newprice[$i],
 					'price_min' => $newprice_min[$i],
 					'price_base_type' => $newpricebase[$i],
-					'vat_tx' => $tva_tx,
+					'vat_tx' => $tva_tx_txt,
 					'npr' => $npr,
 				    'localtaxes_array' => array('0'=>$localtax1_type, '1'=>$localtax1, '2'=>$localtax2_type, '3'=>$localtax2)
 				);


### PR DESCRIPTION
An uninitialized variable($tva_tx) is used to update VAT when use multiprice. It has been found that on some servers uses the value of $ _POST['tva_tx] with the same name that contains an array. This causes a Fatal Error when trying to do arithmetic operations on an array.
