### PR TITLE
Fix lost value if use double quote

### DIFF
--- a/htdocs/societe/soc.php
+++ b/htdocs/societe/soc.php
@@ -252,7 +252,7 @@ if (empty($reshook))
 	        $object->name_alias   = GETPOST('name_alias');
         }
 
-        $object->address               = GETPOST('address', 'alpha');
+        $object->address               = GETPOST('address');
         $object->zip                   = GETPOST('zipcode', 'alpha');
         $object->town                  = GETPOST('town', 'alpha');
         $object->country_id            = GETPOST('country_id', 'int');


### PR DESCRIPTION
I have thirdparty card with an address already registered.
If I modify his address value for exemple like that  : 
- 12 street Orchard Hill

by
- 12 street "Orchard Hill"
  I'll lost my data after save
