### PR TITLE
Fix miss entity column in llx_multicurrency_rate

### DIFF
--- a/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
+++ b/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
@@ -541,3 +541,4 @@ INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (178, 
 -- VMYSQL4.1 ALTER TABLE llx_establishment CHANGE COLUMN fk_user_mod fk_user_mod integer NULL;
 -- VPGSQL8.2 ALTER TABLE llx_establishment ALTER COLUMN fk_user_mod DROP NOT NULL;
 
+ALTER TABLE llx_multicurrency_rate ADD COLUMN entity integer;

--- a/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
+++ b/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
@@ -541,4 +541,4 @@ INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (178, 
 -- VMYSQL4.1 ALTER TABLE llx_establishment CHANGE COLUMN fk_user_mod fk_user_mod integer NULL;
 -- VPGSQL8.2 ALTER TABLE llx_establishment ALTER COLUMN fk_user_mod DROP NOT NULL;
 
-ALTER TABLE llx_multicurrency_rate ADD COLUMN entity integer;
+ALTER TABLE llx_multicurrency_rate ADD COLUMN entity integer DEFAULT 1;

--- a/htdocs/install/mysql/tables/llx_multicurrency_rate.sql
+++ b/htdocs/install/mysql/tables/llx_multicurrency_rate.sql
@@ -22,5 +22,6 @@ CREATE TABLE llx_multicurrency_rate
 	rowid integer AUTO_INCREMENT PRIMARY KEY, 
 	date_sync datetime DEFAULT NULL,  
 	rate double NOT NULL DEFAULT 0, 
-	fk_multicurrency integer NOT NULL
+	fk_multicurrency integer NOT NULL,
+	entity integer DEFAULT 1,
 ) ENGINE=innodb;


### PR DESCRIPTION
Currently we can't add or modify a rate
Each currency have an empty value
