### PR TITLE
FIX: #5640 Bad price for predefine product

### DIFF
--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -65,7 +65,6 @@ $id = GETPOST('id', 'int');
 $ref = GETPOST('ref', 'alpha');
 $socid = GETPOST('socid', 'int');
 $action = GETPOST('action', 'alpha');
-$cancel = GETPOST('cancel', 'alpha');
 $origin = GETPOST('origin', 'alpha');
 $originid = GETPOST('originid', 'int');
 $confirm = GETPOST('confirm', 'alpha');
@@ -117,7 +116,6 @@ if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'e
 
 if (empty($reshook))
 {
-	if ($cancel) $action = '';
 
 	include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php'; // Must be include, not includ_once
 

--- a/htdocs/comm/propal.php
+++ b/htdocs/comm/propal.php
@@ -65,6 +65,7 @@ $id = GETPOST('id', 'int');
 $ref = GETPOST('ref', 'alpha');
 $socid = GETPOST('socid', 'int');
 $action = GETPOST('action', 'alpha');
+$cancel = GETPOST('cancel', 'alpha');
 $origin = GETPOST('origin', 'alpha');
 $originid = GETPOST('originid', 'int');
 $confirm = GETPOST('confirm', 'alpha');
@@ -116,6 +117,25 @@ if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'e
 
 if (empty($reshook))
 {
+	if ($cancel){
+        if ($action == 'updateligne' && $user->rights->propal->creer)
+        {
+            unset($_POST['qty']);
+            unset($_POST['type']);
+            unset($_POST['productid']);
+            unset($_POST['remise_percent']);
+            unset($_POST['price_ht']);
+            unset($_POST['price_ttc']);
+            unset($_POST['tva_tx']);
+            unset($_POST['product_ref']);
+            unset($_POST['product_label']);
+            unset($_POST['product_desc']);
+            unset($_POST['fournprice']);
+            unset($_POST['buying_price']);
+        }
+
+        $action = '';
+    }
 
 	include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php'; // Must be include, not includ_once
 
@@ -1007,13 +1027,6 @@ if (empty($reshook))
 			}
 		}
 	}
-
-	else if ($action == 'updateligne' && $user->rights->propal->creer && GETPOST('cancel'))
-	{
-		header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id); // Pour reaffichage de la fiche en cours d'edition
-		exit();
-	}
-
 	// Generation doc (depuis lien ou depuis cartouche doc)
 	else if ($action == 'builddoc' && $user->rights->propal->creer) {
 		if (GETPOST('model')) {

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -90,6 +90,9 @@ $extralabels = $extrafields->fetch_name_optionals_label($object->table_element);
 // Load object
 include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php';  // Must be include, not include_once
 
+//if $cancel before include, when cancel no load object and not show anything
+$cancel = GETPOST('cancel', 'alpha');
+
 // Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
 $hookmanager->initHooks(array('ordercard','globalcard'));
 
@@ -109,6 +112,23 @@ if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'e
 
 if (empty($reshook))
 {
+	if ($cancel){
+        if ($action == 'updateline' && $user->rights->commande->creer) {
+            unset($_POST['qty']);
+            unset($_POST['type']);
+            unset($_POST['productid']);
+            unset($_POST['remise_percent']);
+            unset($_POST['price_ht']);
+            unset($_POST['price_ttc']);
+            unset($_POST['tva_tx']);
+            unset($_POST['product_ref']);
+            unset($_POST['product_label']);
+            unset($_POST['product_desc']);
+            unset($_POST['fournprice']);
+            unset($_POST['buying_price']);
+        }
+        $action='';
+    }
 
 	include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php'; 	// Must be include, not include_once
 
@@ -915,11 +935,6 @@ if (empty($reshook))
 				setEventMessage($object->error, 'errors');
 			}
 		}
-	}
-
-	else if ($action == 'updateline' && $user->rights->commande->creer && GETPOST('cancel') == $langs->trans('Cancel')) {
-		header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id); // Pour reaffichage de la fiche en cours d'edition
-		exit();
 	}
 
 	else if ($action == 'confirm_validate' && $confirm == 'yes' &&

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -109,7 +109,6 @@ if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'e
 
 if (empty($reshook))
 {
-	if ($cancel) $action='';
 
 	include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php'; 	// Must be include, not include_once
 

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -622,6 +622,11 @@ if (empty($reshook))
 		header('Location: '.$_SERVER["PHP_SELF"].'?id='.$object->id);
 		exit;
 	}
+    else if ($action == 'updateline' && $user->rights->ficheinter->creer && GETPOST('cancel'))
+    {
+        header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id); // Pour reaffichage de la fiche en cours d'edition
+        exit();
+    }
 
 	/*
 	 *  Supprime une ligne d'intervention AVEC confirmation

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -101,6 +101,8 @@ if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'e
 
 if (empty($reshook))
 {
+    if ($cancel) $action='';
+
 	include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php';	// Must be include, not include_once
 
 	include DOL_DOCUMENT_ROOT.'/core/actions_dellink.inc.php';		// Must be include, not include_once

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -58,7 +58,6 @@ $id			= (GETPOST('facid','int') ? GETPOST('facid','int') : GETPOST('id','int'));
 $action		= GETPOST("action");
 $confirm	= GETPOST("confirm");
 $ref		= GETPOST('ref','alpha');
-$cancel     = GETPOST('cancel','alpha');
 $lineid     = GETPOST('lineid', 'int');
 
 //PDF
@@ -102,8 +101,6 @@ if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'e
 
 if (empty($reshook))
 {
-	if ($cancel) $action='';
-
 	include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php';	// Must be include, not include_once
 
 	include DOL_DOCUMENT_ROOT.'/core/actions_dellink.inc.php';		// Must be include, not include_once
@@ -546,7 +543,7 @@ if (empty($reshook))
 	}
 
 	// Edit line
-	elseif ($action == 'updateline' && $user->rights->fournisseur->facture->creer)
+	elseif ($action == 'updateline' && $user->rights->fournisseur->facture->creer && GETPOST('save'))
 	{
 		$db->begin();
 
@@ -611,6 +608,11 @@ if (empty($reshook))
 	            setEventMessage($object->error,'errors');
 	        }
 	}
+
+    elseif ($action == 'updateline' && $user->rights->fournisseur->facture->creer && GETPOST('cancel')){
+        header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id); // Pour reaffichage de la fiche en cours d'edition
+        exit();
+    }
 
 	elseif ($action == 'addline' && $user->rights->fournisseur->facture->creer)
 	{


### PR DESCRIPTION
This error persists in Dolibarr 4.0.

I edit files that are in different directory in Dolibarr 4.0.
If I have to create another pull request to that let me know and I think other with editions for that version

Delete 

> $cancel     = GETPOST('cancel','alpha');

It hasn't any funcion really, because in loop if else use for example:

> else if ($action == 'updateline' && $user->rights->ficheinter->creer && **GETPOST('cancel')**)
