### PR TITLE
Prevent space separator in module definition

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -580,7 +580,7 @@ if ($id == 10)
 // Actions add or modify an entry into a dictionary
 if (GETPOST('actionadd') || GETPOST('actionmodify'))
 {
-    $listfield=explode(',',$tabfield[$id]);
+    $listfield=explode(',', str_replace(' ', '',$tabfield[$id]));
     $listfieldinsert=explode(',',$tabfieldinsert[$id]);
     $listfieldmodify=explode(',',$tabfieldinsert[$id]);
     $listfieldvalue=explode(',',$tabfieldvalue[$id]);


### PR DESCRIPTION
If we type in definition of dictionnary "code,libelle, color" we can't insert/update value because dictionnary feature create a field named " color"
propose to allow typing space bettween field (better lisibility) and remove space after
