### PR TITLE
FIX: Wrong line insert trigger in supplier order

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3089,7 +3089,7 @@ class CommandeFournisseurLigne extends CommonOrderLine
             if (! $error && ! $notrigger)
             {
                 // Call trigger
-                $result=$this->call_trigger('LINEORDER_INSERT',$user);
+                $result=$this->call_trigger('LINEORDER_SUPPLIER_CREATE',$user);
                 if ($result < 0) $error++;
                 // End call triggers
             }


### PR DESCRIPTION
# Fix Wrong line insert trigger in supplier order

This restores the LINEORDER_SUPPLIER_CREATE trigger
