### PR TITLE
Fix Syntax error, unrecognized expression: input.remain]

### DIFF
--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -394,7 +394,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							json["invoice_type"] = $("#invoice_type").val();
 							json["amountPayment"] = $("#amountpayment").attr("value");
 							json["amounts"] = _elemToJson(form.find("input.amount"));
-							json["remains"] = _elemToJson(form.find("input.remain]"));
+							json["remains"] = _elemToJson(form.find("input.remain"));
 
 							if (imgId != null) {
 								json["imgClicked"] = imgId;


### PR DESCRIPTION
Fix

```
 jquery.min.js?version=4.0.0:2 Uncaught Error: Syntax error, unrecognized expression: input.remain]
```
