### PR TITLE
Fix fields too long for database

### DIFF
--- a/htdocs/societe/class/companybankaccount.class.php
+++ b/htdocs/societe/class/companybankaccount.class.php
@@ -110,6 +110,9 @@ class CompanyBankAccount extends Account
         {
             $this->create();
         }
+		
+		if (dol_strlen($this->domiciliation) > 255) $this->domiciliation = dol_trunc($this->domiciliation, 254, 'right', 'UTF-8', 1);
+		if (dol_strlen($this->owner_address) > 255) $this->owner_address = dol_trunc($this->owner_address, 254, 'right', 'UTF-8', 1);
 
         $sql = "UPDATE ".MAIN_DB_PREFIX."societe_rib SET";
         $sql.= " bank = '" .$this->db->escape($this->bank)."'";

--- a/htdocs/societe/rib.php
+++ b/htdocs/societe/rib.php
@@ -467,7 +467,7 @@ if ($socid && $action == 'edit' && $user->rights->societe->creer)
     print '<td colspan="4"><input size="12" type="text" name="bic" value="'.$account->bic.'"></td></tr>';
 
     print '<tr><td>'.$langs->trans("BankAccountDomiciliation").'</td><td colspan="4">';
-    print '<textarea name="domiciliation" rows="4" cols="40">';
+    print '<textarea name="domiciliation" rows="4" cols="40" maxlength="255">';
     print $account->domiciliation;
     print "</textarea></td></tr>";
 
@@ -476,7 +476,7 @@ if ($socid && $action == 'edit' && $user->rights->societe->creer)
     print "</td></tr>\n";
 
     print '<tr><td>'.$langs->trans("BankAccountOwnerAddress").'</td><td colspan="4">';
-    print "<textarea name=\"owner_address\" rows=\"4\" cols=\"40\">";
+    print "<textarea name=\"owner_address\" rows=\"4\" cols=\"40\" maxlength=\"255\">";
     print $account->owner_address;
     print "</textarea></td></tr>";
 
@@ -570,7 +570,7 @@ if ($socid && $action == 'create' && $user->rights->societe->creer)
     print '<td colspan="4"><input size="12" type="text" name="bic" value="'.GETPOST('bic').'"></td></tr>';
 
     print '<tr><td>'.$langs->trans("BankAccountDomiciliation").'</td><td colspan="4">';
-    print '<textarea name="domiciliation" rows="4" cols="40">';
+    print '<textarea name="domiciliation" rows="4" cols="40" maxlength="255">';
     print GETPOST('domiciliation');
     print "</textarea></td></tr>";
 
@@ -579,7 +579,7 @@ if ($socid && $action == 'create' && $user->rights->societe->creer)
     print "</td></tr>\n";
 
     print '<tr><td>'.$langs->trans("BankAccountOwnerAddress").'</td><td colspan="4">';
-    print '<textarea name="owner_address" rows="4" cols="40">';
+    print '<textarea name="owner_address" rows="4" cols="40" maxlength="255">';
     print GETPOST('owner_address');
     print "</textarea></td></tr>";
 


### PR DESCRIPTION
From fresh install the fields "domiciliation" and "owner_address" from llx_societe_rib are defined as varchar(255) 

When we add or modify bank account from third party card the fields are not checked and postgres do not permit this
