### PR TITLE
avoid generating PDF files for the supplier

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1919,13 +1919,14 @@ class FactureFournisseur extends CommonInvoice
 		// Set the model on the model name to use
 		if (! dol_strlen($modele))
 		{
+			
 			if (! empty($conf->global->INVOICE_SUPPLIER_ADDON_PDF))
 			{
 				$modele = $conf->global->INVOICE_SUPPLIER_ADDON_PDF;
 			}
 			else
 			{
-				$modele = 'canelle';
+				return false; // won't generate the pdf is nothing is set
 			}
 		}
 


### PR DESCRIPTION
# Fix  impossible to block generation of pdf for supplier (canelle always by default)

When someone upload the scan of the supplier invoice he doesn't need a file generated by Dolibarr ( make a mess in the document section)
