### PR TITLE
FIX: If price2num return '' it may produce an error inserting in MYSQL 5.7

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3455,6 +3455,7 @@ function price2num($amount,$rounding='',$alreadysqlnb=0)
 		$amount=str_replace($dec,'.',$amount);
 	}
 
+	if(!is_numeric($amount)) $amount = '0';
 	return $amount;
 }
 

--- a/test/phpunit/FunctionsLibTest.php
+++ b/test/phpunit/FunctionsLibTest.php
@@ -940,8 +940,8 @@ class FunctionsLibTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals(1000.12546, price2num('1 000.125456','MU'),"Test MU");
 
 		// Text can't be converted
-		$this->assertEquals('12.4$',price2num('12.4$'));
-		$this->assertEquals('12r.4$',price2num('12r.4$'));
+		$this->assertEquals('0',price2num('12.4$'));
+		$this->assertEquals('0',price2num('12r.4$'));
 
 		return true;
 	}


### PR DESCRIPTION
If input value is null, the function return ''.
This value, for example when add line in contract, is in sql query and cause error in MYSQL 5.7.
### For check the error:

Need MYSQL 5.7
Use data demo -> mysqldump_dolibarr_4.0.0.sql
Create new contract
Customer -> Spanish Comp

Add service "DOLICLOUD"
