### PR TITLE
New: Permit to print TotalTTC price in objectline_view

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3277,7 +3277,7 @@ abstract class CommonObject
 	{
 		global $conf, $hookmanager, $langs, $user;
 		// TODO We should not use global var for this !
-		global $inputalsopricewithtax, $usemargins, $disableedit, $disablemove, $disableremove;
+		global $inputalsopricewithtax, $usemargins, $disableedit, $disablemove, $disableremove, $inputalsopricetotalwithtax;
 
 		// Define usemargins
 		$usemargins=0;
@@ -3339,6 +3339,8 @@ abstract class CommonObject
 
 		// Multicurrency
 		if (!empty($conf->multicurrency->enabled)) print '<td class="linecoltotalht_currency" align="right">'.$langs->trans('TotalHTShortCurrency').'</td>';
+
+        if ($inputalsopricetotalwithtax) print '<td align="right" width="80">'.$langs->trans('TotalTTCShort').'</td>';
 
 		print '<td class="linecoledit"></td>';  // No width to allow autodim
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3277,7 +3277,7 @@ abstract class CommonObject
 	{
 		global $conf, $hookmanager, $langs, $user;
 		// TODO We should not use global var for this !
-		global $inputalsopricewithtax, $usemargins, $disableedit, $disablemove, $disableremove, $inputalsopricetotalwithtax;
+		global $inputalsopricewithtax, $usemargins, $disableedit, $disablemove, $disableremove, $outputalsopricetotalwithtax;
 
 		// Define usemargins
 		$usemargins=0;
@@ -3340,7 +3340,7 @@ abstract class CommonObject
 		// Multicurrency
 		if (!empty($conf->multicurrency->enabled)) print '<td class="linecoltotalht_currency" align="right">'.$langs->trans('TotalHTShortCurrency').'</td>';
 
-        if ($inputalsopricetotalwithtax) print '<td align="right" width="80">'.$langs->trans('TotalTTCShort').'</td>';
+        if ($outputalsopricetotalwithtax) print '<td align="right" width="80">'.$langs->trans('TotalTTCShort').'</td>';
 
 		print '<td class="linecoledit"></td>';  // No width to allow autodim
 

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -36,7 +36,7 @@
  * $type, $text, $description, $line
  */
 
-global $forceall, $senderissupplier, $inputalsopricewithtax, $usemargins, $inputalsopricetotalwithtax;
+global $forceall, $senderissupplier, $inputalsopricewithtax, $usemargins, $outputalsopricetotalwithtax;
 
 $usemargins=0;
 if (! empty($conf->margin->enabled) && ! empty($object->element) && in_array($object->element,array('facture','propal','commande'))) $usemargins=1;
@@ -45,7 +45,7 @@ if (empty($dateSelector)) $dateSelector=0;
 if (empty($forceall)) $forceall=0;
 if (empty($senderissupplier)) $senderissupplier=0;
 if (empty($inputalsopricewithtax)) $inputalsopricewithtax=0;
-if (empty($inputalsopricetotalwithtax)) $inputalsopricetotalwithtax=0;
+if (empty($outputalsopricetotalwithtax)) $outputalsopricetotalwithtax=0;
 if (empty($usemargins)) $usemargins=0;
 ?>
 <?php $coldisplay=0; ?>
@@ -202,7 +202,7 @@ if (empty($usemargins)) $usemargins=0;
 		<td align="right" class="linecolutotalht_currency nowrap"><?php $coldisplay++; ?><?php echo price($line->multicurrency_total_ht); ?></td>
 		<?php } ?>
 	<?php } ?>
-        <?php if ($inputalsopricetotalwithtax) { ?>
+        <?php if ($outputalsopricetotalwithtax) { ?>
         <td align="right" class="liencolht nowrap"><?php $coldisplay++; ?><?php echo price($line->total_ttc); ?></td>
         <?php } ?>
 

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -36,7 +36,7 @@
  * $type, $text, $description, $line
  */
 
-global $forceall, $senderissupplier, $inputalsopricewithtax, $usemargins;
+global $forceall, $senderissupplier, $inputalsopricewithtax, $usemargins, $inputalsopricetotalwithtax;
 
 $usemargins=0;
 if (! empty($conf->margin->enabled) && ! empty($object->element) && in_array($object->element,array('facture','propal','commande'))) $usemargins=1;
@@ -45,6 +45,7 @@ if (empty($dateSelector)) $dateSelector=0;
 if (empty($forceall)) $forceall=0;
 if (empty($senderissupplier)) $senderissupplier=0;
 if (empty($inputalsopricewithtax)) $inputalsopricewithtax=0;
+if (empty($inputalsopricetotalwithtax)) $inputalsopricetotalwithtax=0;
 if (empty($usemargins)) $usemargins=0;
 ?>
 <?php $coldisplay=0; ?>
@@ -201,6 +202,10 @@ if (empty($usemargins)) $usemargins=0;
 		<td align="right" class="linecolutotalht_currency nowrap"><?php $coldisplay++; ?><?php echo price($line->multicurrency_total_ht); ?></td>
 		<?php } ?>
 	<?php } ?>
+        <?php if ($inputalsopricetotalwithtax) { ?>
+        <td align="right" class="liencolht nowrap"><?php $coldisplay++; ?><?php echo price($line->total_ttc); ?></td>
+        <?php } ?>
+
 
 	<?php 
 	if ($this->statut == 0  && ($object_rights->creer)) { ?>


### PR DESCRIPTION
Hello,

When I see propal or invoice, it is possible to print unit TVA (with inputalsopricewithtax=1) per line but no total TVA.
I add possibiliy to print the total_ttc price/line with inputalsopricetotalwithtax option.

Regards,
Ben
