### PR TITLE
FIX: Error show list invoice when sql_mode=only_full_group_by

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -767,6 +767,11 @@ if (! $sall)
     $sql.= ' f.datec, f.tms,';
     $sql.= ' s.rowid, s.nom, s.town, s.zip, s.fk_pays, s.code_client, s.client, typent.code';
     $sql.= ' ,state.code_departement, state.nom';
+
+    foreach ($extrafields->attribute_label as $key => $val) //prevent error with sql_mode=only_full_group_by
+    {
+        $sql.=($extrafields->attribute_type[$key] != 'separate' ? ",ef.".$key : '');
+    }
 }
 else
 {


### PR DESCRIPTION
When sql_mode = only_full_group_by and add extrafields show error if show list invoice
## Environment
- **Version**: 4.0.2
- **OS**: Linux
- **Web server**: Apache/2.4.20 (Debian)
- **PHP**: apache2handler 7.0.11-1~dotdeb+8.1
- **Database**: MySQL or MariaDB 5.7.16
- **URL**: dolibarr/htdocs/compta/facture/list.php

**Database type manager:** mysqli
**Latest database access request error:** 

> `SELECT f.rowid as facid, f.facnumber, f.ref_client, f.type, f.note_private, f.note_public, f.increment, f.fk_mode_reglement, f.total as total_ht, f.tva as total_vat, f.total_ttc, f.datef as df, f.date_lim_reglement as datelimite, f.paye as paye, f.fk_statut, f.datec as date_creation, f.tms as date_update, s.rowid as socid, s.nom as name, s.town, s.zip, s.fk_pays, s.client, s.code_client, typent.code as typent_code, state.code_departement as state_code, state.nom as state_name, SUM(pf.amount) as am,ef.serie as options_serie FROM llx_societe as s LEFT JOIN llx_c_country as country on (country.rowid = s.fk_pays) LEFT JOIN llx_c_typent as typent on (typent.id = s.fk_typent) LEFT JOIN llx_c_departements as state on (state.rowid = s.fk_departement), llx_facture as f LEFT JOIN llx_facture_extrafields as ef on (f.rowid = ef.fk_object) LEFT JOIN llx_paiement_facture as pf ON pf.fk_facture = f.rowid WHERE f.fk_soc = s.rowid AND f.entity = 1 GROUP BY f.rowid, f.facnumber, ref_client, f.type, f.note_private, f.note_public, f.increment, fk_mode_reglement, f.total, f.tva, f.total_ttc, f.datef, f.date_lim_reglement, f.paye, f.fk_statut, f.datec, f.tms, s.rowid, s.nom, s.town, s.zip, s.fk_pays, s.code_client, s.client, typent.code ,state.code_departement, state.nom ORDER BY f.datef DESC, f.rowid DESC LIMIT 26`

**Return code for latest database access request error:** DB_ERROR_1055
**Information for latest database access request error:** 

> Expression `#29` of SELECT list is not in GROUP BY clause and contains nonaggregated column 'dolibarr_40_check.ef.serie' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
