### PR TITLE
Fix : Security Vulnerability, delete third party without delete right

### DIFF
--- a/htdocs/societe/soc.php
+++ b/htdocs/societe/soc.php
@@ -109,7 +109,7 @@ if (empty($reshook))
         }
     }
 
-	if ($action == 'confirm_merge' && $confirm == 'yes')
+	if ($action == 'confirm_merge' && $confirm == 'yes' && $user->rights->societe->supprimer)
 	{
 		$object->fetch($socid);
 


### PR DESCRIPTION
It's possible to delete third party without delete right.
Only create right it's necessary with merge function.
