### PR TITLE
FIX: Error FactureFournisseurTest::testFactureFournisseurCreate

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1482,8 +1482,16 @@ class FactureFournisseur extends CommonInvoice
 	    $line->pu_ttc = $pu_ttc;
 	    $line->qty = $qty;
 	    $line->remise_percent = $remise_percent;
-        
-	    $this->line->vat_src_code=$vat_src_code;
+
+        // Clean vat code
+        $vat_src_code='';
+        if (preg_match('/\((.*)\)/', $vatrate, $reg))
+        {
+            $vat_src_code = $reg[1];
+            $vatrate = preg_replace('/\s*\(.*\)/', '', $vatrate);    // Remove code into vatrate.
+        }
+
+        $this->vat_src_code=$vat_src_code;
 	    $line->tva_tx = $vatrate;
 	    $line->localtax1_tx = $txlocaltax1;
 	    $line->localtax2_tx = $txlocaltax2;


### PR DESCRIPTION
Error Travis:
1) FactureFournisseurTest::testFactureFournisseurCreate
Creating default object from empty value
/home/travis/build/Dolibarr/dolibarr/htdocs/fourn/class/fournisseur.facture.class.php:1493
/home/travis/build/Dolibarr/dolibarr/htdocs/fourn/class/fournisseur.facture.class.php:339
/home/travis/build/Dolibarr/dolibarr/test/phpunit/FactureFournisseurTest.php:133
