### PR TITLE
FIX: #5907 No translation string for PDF Proposal

### DIFF
--- a/htdocs/langs/en_US/main.lang
+++ b/htdocs/langs/en_US/main.lang
@@ -576,6 +576,7 @@ MailSentBy=Email sent by
 TextUsedInTheMessageBody=Email body
 SendAcknowledgementByMail=Send Ack. by email
 NoEMail=No email
+Email=Email
 NoMobilePhone=No mobile phone
 Owner=Owner
 DetectedVersion=Detected version


### PR DESCRIPTION
FIX: #5907 No translation string for PDF Proposal
