### PR TITLE
FIX: Missing Supplier Order Translation String

### DIFF
--- a/htdocs/langs/en_US/agenda.lang
+++ b/htdocs/langs/en_US/agenda.lang
@@ -54,6 +54,7 @@ ShipmentValidatedInDolibarr=Shipment %s validated
 ShipmentClassifyClosedInDolibarr=Shipment %s classify billed
 ShipmentUnClassifyCloseddInDolibarr=Shipment %s classify reopened
 ShipmentDeletedInDolibarr=Shipment %s deleted
+OrderCreatedInDolibarr=Order created
 OrderValidatedInDolibarr=Order %s validated
 OrderDeliveredInDolibarr=Order %s classified delivered
 OrderCanceledInDolibarr=Order %s canceled


### PR DESCRIPTION
# Fix

When supplier order is created, the agenda event shows as 'OrderCreatedInDolibarr' which is an untranslated string.

This is my first pull request so apologies if I have done it wrong.
