### PR TITLE
FIX on first activate module it must create if needed the first curre…

### DIFF
--- a/htdocs/core/modules/modMultiCurrency.class.php
+++ b/htdocs/core/modules/modMultiCurrency.class.php
@@ -265,8 +265,14 @@ class modMultiCurrency extends DolibarrModules
 		$sql = array();
 
 		//$this->_load_tables('/multicurrency/sql/');
-
-		return $this->_init($sql, $options);
+		$res = $this->_init($sql, $options);
+		
+		if ($res)
+		{
+			$this->createFirstCurrency();
+		}
+		
+		return $res;
 	}
 
 	/**
@@ -284,5 +290,27 @@ class modMultiCurrency extends DolibarrModules
 		return $this->_remove($sql, $options);
 	}
 
+	/**
+	 * Function called when module is enabled
+	 * Create the currency from general setting
+	 * 
+	 * @return 	int		1 if OK, 0 if KO
+	 */
+	private function createFirstCurrency()
+	{
+		global $conf,$user,$langs;
+		
+		if (!MultiCurrency::checkCodeAlreadyExists($conf->currency))
+		{
+			$langs->loadCacheCurrencies('');
+			
+			$multicurrency = new MultiCurrency($this->db);
+			$multicurrency->code = $conf->currency;
+			$multicurrency->name = $langs->cache_currencies[$conf->currency]['label'].' ('.$langs->getCurrencySymbol($conf->currency).')';
+			$r = $multicurrency->create($user);
+			
+			if ($r > 0)	$multicurrency->addRate(1);
+		}
+	}
 }
 


### PR DESCRIPTION
On enabling multicurrency module no rate is create 
Now on the first activate the currency setting up in general configuration is use to create the first currency rate to 1
