### PR TITLE
Fix: price not properly rounded, VAT inconsistencies

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -980,10 +980,8 @@ if (empty($reshook))
 		        setEventMessages($langs->trans("ErrorQtyTooLowForThisSupplier"), null, 'errors');
 	        }
 	    }
-	    else if (GETPOST('price_ht')!=='' || GETPOST('price_ttc')!=='')
+		else if ($price_ht !== '' || GETPOST('price_ttc') !== '') // $price_ht is already set
 		{
-			$pu_ht = price2num($price_ht, 'MU');
-			$pu_ttc = price2num(GETPOST('price_ttc'), 'MU');
 			$tva_npr = (preg_match('/\*/', $tva_tx) ? 1 : 0);
 			$tva_tx = str_replace('*', '', $tva_tx);
 			$label = (GETPOST('product_label') ? GETPOST('product_label') : '');
@@ -998,19 +996,18 @@ if (empty($reshook))
 	    	$localtax1_tx= get_localtax($tva_tx, 1,$mysoc,$object->thirdparty);
 	    	$localtax2_tx= get_localtax($tva_tx, 2,$mysoc,$object->thirdparty);
 
-	    	if (!empty($_POST['price_ht']))
-	    	{
-	    		$ht = price2num($_POST['price_ht']);
-	            $price_base_type = 'HT';
-	        }
-	        else
+			if ($price_ht !== '')
 			{
-	    		$ttc = price2num($_POST['price_ttc']);
-	            $ht = $ttc / (1 + ($tva_tx / 100));
-	            $price_base_type = 'HT';
-	        }
-
-			$result=$object->addline($product_desc, $ht, $tva_tx, $localtax1_tx, $localtax2_tx, $qty, 0, $remise_percent, $date_start, $date_end, 0, $tva_npr, $price_base_type, $type, -1, 0, $array_options, $fk_unit);
+				$pu_ht = price2num($price_ht, 'MU'); // $pu_ht must be rounded according to settings
+			}
+			else
+			{
+				$pu_ttc = price2num(GETPOST('price_ttc'), 'MU');
+				$pu_ht = price2num($pu_ttc / (1 + ($tva_tx / 100)), 'MU'); // $pu_ht must be rounded according to settings
+			}
+			$price_base_type = 'HT';
+			
+			$result=$object->addline($product_desc, $pu_ht, $tva_tx, $localtax1_tx, $localtax2_tx, $qty, 0, $remise_percent, $date_start, $date_end, 0, $tva_npr, $price_base_type, $type, -1, 0, $array_options, $fk_unit);
 	    }
 
 	    //print "xx".$tva_tx; exit;


### PR DESCRIPTION
When adding a 'free line' product or service in a supplier invoice, the amount  excluding tax (HT) is not properly rounded, in particular when calculated from full tax price. This leads to inconsistencies in results when using large quantities or small precision in settings. Test case :
with default settings
MAIN_MAX_DECIMALS_UNIT = 5
MAIN_MAX_DECIMALS_TOT = 2
MAIN_MAX_DECIMALS_SHOWN = 8

Add in a new invoice a free product with 13.33 TTC (full tax), quantity 1, save, then edit the line with quantity 10111
Now in another invoice, add a free product with 13.33 TTC (full tax), quantity 10111, save.
Exact same data in the two invoices, but Tax and grand total are different, and false in second case because computed before rounding.
