### PR TITLE
Fix #5931 Shipment closed correctly

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -10,6 +10,7 @@
  * Copyright (C) 2014-2015	Francis Appels			<francis.appels@yahoo.com>
  * Copyright (C) 2015		Claudio Aschieri		<c.aschieri@19.coop>
  * Copyright (C) 2016		Ferran Marcet			<fmarcet@2byte.es>
+ * Copyright (C) 2016		Yasser Carreón			<yacasia@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -534,13 +535,21 @@ if (empty($reshook))
 	elseif ($action == 'classifybilled')
 	{
 	    $object->fetch($id);
-	    $object->set_billed();
+	    $result = $object->set_billed();
+	    if($result >= 0) {
+	    	header('Location: ' . $_SERVER["PHP_SELF"] . '?id=' . $object->id);
+	    	exit();
+	    }
 	}
 
 	elseif ($action == 'classifyclosed')
 	{
 	    $object->fetch($id);
-	    $object->setClosed();
+	    $result = $object->setClosed();
+	    if($result >= 0) {
+	    	header('Location: ' . $_SERVER["PHP_SELF"] . '?id=' . $object->id);
+	    	exit();
+	    }
 	}
 
 	include DOL_DOCUMENT_ROOT.'/core/actions_printing.inc.php';


### PR DESCRIPTION
I would like to contribute to Dolibarr and this is my first pull request here, so any advise is accepted.
# Fix #5931 Refresh issue when closing a shipment

The problem was when a shipment was closed the page didn't refresh, this allowed to user to click the 'close' button again, decreasing another time the stock if the decrease rule was there.

I think that the same happens to 'classifybilled' action although it doesn't cause a problem like 'classifyclosed' but I fix it anyway.

Now the page refreshes when shipment is closed or billed to avoid a second action call.
