### PR TITLE
Fix: Missing Translation String Expense Report

### DIFF
--- a/htdocs/langs/en_US/agenda.lang
+++ b/htdocs/langs/en_US/agenda.lang
@@ -54,6 +54,7 @@ ShipmentValidatedInDolibarr=Shipment %s validated
 ShipmentClassifyClosedInDolibarr=Shipment %s classify billed
 ShipmentUnClassifyCloseddInDolibarr=Shipment %s classify reopened
 ShipmentDeletedInDolibarr=Shipment %s deleted
+OrderCreatedInDolibarr=Order created
 OrderValidatedInDolibarr=Order %s validated
 OrderDeliveredInDolibarr=Order %s classified delivered
 OrderCanceledInDolibarr=Order %s canceled

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -75,6 +75,7 @@ PaymentsAlreadyDone=Payments already done
 PaymentsBackAlreadyDone=Payments back already done
 PaymentRule=Payment rule
 PaymentMode=Payment type
+PaymentTypeDC=Debit/Credit Card
 IdPaymentMode=Payment type (id)
 LabelPaymentMode=Payment type (label)
 PaymentModeShort=Payment type

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -331,6 +331,7 @@ GeneratedFromRecurringInvoice=Generated from template recurring invoice %s
 DateIsNotEnough=Date not reached yet
 InvoiceGeneratedFromTemplate=Invoice %s generated from recurring template invoice %s
 # PaymentConditions
+Statut=Status
 PaymentConditionShortRECEP=Immediate
 PaymentConditionRECEP=Immediate
 PaymentConditionShort30D=30 days


### PR DESCRIPTION
# Fix #Missing Translation String
In Expense Reports, add 'Debit/Credit Card' type.