### PR TITLE
Add PayPal Missing Translation String

### DIFF
--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -76,6 +76,7 @@ PaymentsBackAlreadyDone=Payments back already done
 PaymentRule=Payment rule
 PaymentMode=Payment type
 PaymentTypeDC=Debit/Credit Card
+PaymentTypePP=PayPal
 IdPaymentMode=Payment type (id)
 LabelPaymentMode=Payment type (label)
 PaymentModeShort=Payment type


### PR DESCRIPTION
Add PayPal missing translation string to expense report payment type