### PR TITLE
FIX: Supplier order statut is not reverted if RECEIVE trigger fails

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1961,6 +1961,7 @@ class CommandeFournisseur extends CommonOrder
                 if ($resql)
                 {
                     $result = 0;
+                    $old_statut = $this->statut;
                     $this->statut = $statut;
 
                     // Call trigger
@@ -1974,6 +1975,7 @@ class CommandeFournisseur extends CommonOrder
                     }
                     else
                     {
+                        $this->statut = $old_statut;
                         $this->db->rollback();
                         $this->error=$this->db->lasterror();
                         $result = -1;


### PR DESCRIPTION
This reverts the statut variable if trigger fails on SUPPLIER_ORDER_RECEIVE