### PR TITLE
Fix propal updateline oldcopy extrafields

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -651,6 +651,7 @@ class Propal extends CommonObject
             //Fetch current line from the database and then clone the object and set it in $oldline property
             $line = new PropaleLigne($this->db);
             $line->fetch($rowid);
+			$line->fetch_optionals(); // Fetch extrafields for oldcopy
 
 			$staticline = clone $line;
 


### PR DESCRIPTION
This fix will complete the oldline / newline compare. Fetching extrafields before clone to add them on oldline. If not used like this, we can't recover olds extrafields in triggers (AIM of oldline attribute)