### PR TITLE
FIX Calling soc.php with an unknown socid display a message

### DIFF
--- a/htdocs/societe/soc.php
+++ b/htdocs/societe/soc.php
@@ -74,9 +74,8 @@ $hookmanager->initHooks(array('thirdpartycard','globalcard'));
 
 if ($action == 'view' && $object->fetch($socid)<=0)
 {
-	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
-	$socid=0;
-	$action='create';
+	$langs->load('errors');
+	print($langs->trans('ErrorRecordNotFound'));
 }
 
 // Get object canvas (By default, this is not defined, so standard usage of dolibarr)

--- a/htdocs/societe/soc.php
+++ b/htdocs/societe/soc.php
@@ -72,6 +72,12 @@ $extralabels=$extrafields->fetch_name_optionals_label($object->table_element);
 // Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
 $hookmanager->initHooks(array('thirdpartycard','globalcard'));
 
+if ($action == 'view' && $object->fetch($socid)<=0)
+{
+	setEventMessages($langs->trans('ErrorRecordNotFound'), null, 'errors');
+	$socid=0;
+	$action='create';
+}
 
 // Get object canvas (By default, this is not defined, so standard usage of dolibarr)
 $object->getCanvas($socid);


### PR DESCRIPTION
# Fix #4632
Calling soc.php with an unknown socid, display an event message and switch to create mode with an empty form
