### PR TITLE
FIX Use current chart of accounts to get accountancy labels in journals

### DIFF
--- a/htdocs/accountancy/journal/expensereportsjournal.php
+++ b/htdocs/accountancy/journal/expensereportsjournal.php
@@ -187,11 +187,11 @@ if ($action == 'writebookkeeping') {
 		// Fees
 		foreach ( $tabht[$key] as $k => $mt ) {
 			$accountingaccount = new AccountingAccount($db);
-			$accountingaccount->fetch(null, $k);
+			$accountingaccount->fetch(null, $k, true);
 			if ($mt) {
 				// get compte id and label
 				$accountingaccount = new AccountingAccount($db);
-				if ($accountingaccount->fetch(null, $k)) {
+				if ($accountingaccount->fetch(null, $k, true)) {
 					$bookkeeping = new BookKeeping($db);
 					$bookkeeping->doc_date = $val["date"];
 					$bookkeeping->doc_ref = $val["ref"];
@@ -355,7 +355,7 @@ if ($action == 'export_csv') {
 			// Fees
 			foreach ( $tabht[$key] as $k => $mt ) {
 				$accountingaccount = new AccountingAccount($db);
-				$accountingaccount->fetch(null, $k);
+				$accountingaccount->fetch(null, $k, true);
 				if ($mt) {
 					print '"' . $date . '"' . $sep;
 					print '"' . $val["ref"] . '"' . $sep;
@@ -464,7 +464,7 @@ if (empty($action) || $action == 'view') {
 		// Fees
 		foreach ( $tabht[$key] as $k => $mt ) {
 			$accountingaccount = new AccountingAccount($db);
-			$accountingaccount->fetch(null, $k);
+			$accountingaccount->fetch(null, $k, true);
 
 			if ($mt) {
 				print "<tr " . $bc[$var] . " >";

--- a/htdocs/accountancy/journal/purchasesjournal.php
+++ b/htdocs/accountancy/journal/purchasesjournal.php
@@ -219,11 +219,11 @@ if ($action == 'writebookkeeping') {
 		// Product / Service
 		foreach ( $tabht[$key] as $k => $mt ) {
 			$accountingaccount = new AccountingAccount($db);
-			$accountingaccount->fetch(null, $k);
+			$accountingaccount->fetch(null, $k, true);
 			if ($mt) {
 				// get compte id and label
 				$accountingaccount = new AccountingAccount($db);
-				if ($accountingaccount->fetch(null, $k)) {
+				if ($accountingaccount->fetch(null, $k, true)) {
 					$bookkeeping = new BookKeeping($db);
 					$bookkeeping->doc_date = $val["date"];
 					$bookkeeping->doc_ref = $val["ref"];
@@ -398,7 +398,7 @@ if ($action == 'export_csv') {
 			// Product / Service
 			foreach ( $tabht[$key] as $k => $mt ) {
 				$accountingaccount = new AccountingAccount($db);
-				$accountingaccount->fetch(null, $k);
+				$accountingaccount->fetch(null, $k, true);
 				if ($mt) {
 					print '"' . $date . '"' . $sep;
 					print '"' . $val["ref"] . '"' . $sep;
@@ -518,7 +518,7 @@ if (empty($action) || $action == 'view') {
 		// Product / Service
 		foreach ( $tabht[$key] as $k => $mt ) {
 			$accountingaccount = new AccountingAccount($db);
-			$accountingaccount->fetch(null, $k);
+			$accountingaccount->fetch(null, $k, true);
 
 			if ($mt) {
 				print "<tr " . $bc[$var] . " >";

--- a/htdocs/accountancy/journal/sellsjournal.php
+++ b/htdocs/accountancy/journal/sellsjournal.php
@@ -243,7 +243,7 @@ if ($action == 'writebookkeeping') {
             if ($mt) {
                 // get compte id and label
                 $accountingaccount = new AccountingAccount($db);
-                if ($accountingaccount->fetch(null, $k)) {
+                if ($accountingaccount->fetch(null, $k, true)) {
                     $bookkeeping = new BookKeeping($db);
                     $bookkeeping->doc_date = $val["date"];
                     $bookkeeping->doc_ref = $val["ref"];
@@ -375,7 +375,7 @@ if ($action == 'export_csv') {
             // Product / Service
             foreach ( $tabht[$key] as $k => $mt ) {
                 $accountingaccount_static = new AccountingAccount($db);
-                if ($accountingaccount_static->fetch(null, $k)) {
+                if ($accountingaccount_static->fetch(null, $k, true)) {
                     print $date . $sep;
                     print $sell_journal . $sep;
                     print length_accountg(html_entity_decode($k)) . $sep;
@@ -429,7 +429,7 @@ if ($action == 'export_csv') {
             // Product / Service
             foreach ( $tabht[$key] as $k => $mt ) {
                 $accountingaccount = new AccountingAccount($db);
-                $accountingaccount->fetch(null, $k);
+                $accountingaccount->fetch(null, $k, true);
 
                 if ($mt) {
                     print '"' . $date . '"' . $sep;
@@ -559,7 +559,7 @@ if (empty($action) || $action == 'view') {
 		// Product / Service
 		foreach ( $tabht[$key] as $k => $mt ) {
 			$accountingaccount = new AccountingAccount($db);
-			$accountingaccount->fetch(null, $k);
+			$accountingaccount->fetch(null, $k, true);
 
 			if ($mt) {
 				print "<tr " . $bc[$var] . ">";


### PR DESCRIPTION
# Fix #5945 

Use current chart of accounts to get accountancy labels in journals view and export

