### PR TITLE
FIX : Display invalid message when save payment in invoice currency

### DIFF
--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -138,7 +138,7 @@ if (empty($reshook))
 	            if (! empty($multicurrency_amounts[$cursorfacid])) $atleastonepaymentnotnull++;
 	            $result=$tmpinvoice->fetch($cursorfacid);
 	            if ($result <= 0) dol_print_error($db);
-	            $multicurrency_amountsresttopay[$cursorfacid]=price2num($tmpinvoice->total_ttc - $tmpinvoice->getSommePaiement(1));
+	            $multicurrency_amountsresttopay[$cursorfacid]=price2num($tmpinvoice->multicurrency_total_ttc - $tmpinvoice->getSommePaiement(1));
 	            if ($multicurrency_amounts[$cursorfacid])
 	            {
 		            // Check amount


### PR DESCRIPTION
Display "Payment higher than to pay" even if the amount payed is egal to the amount to pay