### PR TITLE
Fix #6142

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -135,6 +135,7 @@ function societe_prepare_head(Societe $object)
     // Bank accounrs
     if (empty($conf->global->SOCIETE_DISABLE_BANKACCOUNT))
     {
+        $langs->load("banks");
         $nbBankAccount=0;
         $head[$h][0] = DOL_URL_ROOT .'/societe/rib.php?socid='.$object->id;
         $head[$h][1] = $langs->trans("BankAccounts");


### PR DESCRIPTION
# Fix #6142 
# New 
load "banks" translation when constructing societe tab head in
`societe_prepare_head`.