### PR TITLE
FIX cancelling order line modification returned to list instead of card

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -111,7 +111,7 @@ if (empty($reshook))
 {
 	if ($cancel) 
 	{
-		if ($action != 'addlink')
+		if ($action != 'addlink' && $action != 'updateline')
 		{
 			$urltogo=$backtopage?$backtopage:dol_buildpath('/commande/list.php',1);
 			header("Location: ".$urltogo);


### PR DESCRIPTION
Now, user stays on order card