### PR TITLE
HTML 5 doctype always

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1003,12 +1003,8 @@ function top_htmlhead($head, $title='', $disablejs=0, $disablehead=0, $arrayofjs
 
     if (empty($conf->css)) $conf->css = '/theme/eldy/style.css.php';	// If not defined, eldy by default
 
-    if (empty($conf->global->MAIN_ACTIVATE_HTML5)) {
-        $doctype = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">';
-    }else {
-        $doctype = '<!doctype html>'; // Html5 - Developement - Only available on Eldy template
-    }
-    print $doctype."\n";
+    // Html5 - Developement - Only available on Eldy template
+    print '<!doctype html>'."\n";
     if (! empty($conf->global->MAIN_USE_CACHE_MANIFEST)) print '<html lang="'.substr($langs->defaultlang,0,2).'" manifest="'.DOL_URL_ROOT.'/cache.manifest">'."\n";
     else print '<html lang="'.substr($langs->defaultlang,0,2).'">'."\n";
     //print '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">'."\n";


### PR DESCRIPTION
Don't bring support for older browsers like IE 6/7/8
Move on, implement HTML 5, improve user experience
