### PR TITLE
Upgrade php min version to 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ sudo: required
 language: php
 
 php:
-- '5.4'
-- '5.5'
 - '5.6'
 - '7.0'
 #- '7.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ sudo: required
 language: php
 
 php:
-- '5.3'
 - '5.4'
 - '5.5'
 - '5.6'
 - '7.0'
+#- '7.1'
 - nightly
 
 addons:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "vendor-dir": "htdocs/includes"
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6.0",
         "ext-curl": "*",
         "ccampbell/chromephp": "4.1.0",
         "ckeditor/ckeditor": "4.5.9",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "vendor-dir": "htdocs/includes"
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "ext-curl": "*",
         "ccampbell/chromephp": "4.1.0",
         "ckeditor/ckeditor": "4.5.9",


### PR DESCRIPTION
PHP dropped the support of version 5.3 5.3 in 14 Aug 2014,  2 years, 4 months ago
http://php.net/eol.php