### PR TITLE
FIX #6227 Document models table header "Unit" is shown in 2 lines in Spanish

### DIFF
--- a/htdocs/core/modules/commande/doc/pdf_einstein.modules.php
+++ b/htdocs/core/modules/commande/doc/pdf_einstein.modules.php
@@ -110,8 +110,8 @@ class pdf_einstein extends ModelePDFCommandes
 		{
 			$this->posxtva=99;
 			$this->posxup=114;
-			$this->posxqty=133;
-			$this->posxunit=150;
+			$this->posxqty=130;
+			$this->posxunit=147;
 		}
 		else
 		{

--- a/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
@@ -120,8 +120,8 @@ class pdf_crabe extends ModelePDFFactures
 		{
 			$this->posxtva=99;
 			$this->posxup=114;
-			$this->posxqty=133;
-			$this->posxunit=150;
+			$this->posxqty=130;
+			$this->posxunit=147;
 		}
 		else
 		{

--- a/htdocs/core/modules/propale/doc/pdf_azur.modules.php
+++ b/htdocs/core/modules/propale/doc/pdf_azur.modules.php
@@ -108,8 +108,8 @@ class pdf_azur extends ModelePDFPropales
 		{
 			$this->posxtva=99;
 			$this->posxup=114;
-			$this->posxqty=133;
-			$this->posxunit=150;
+			$this->posxqty=130;
+			$this->posxunit=147;
 		}
 		else
 		{

--- a/htdocs/core/modules/supplier_invoice/pdf/pdf_canelle.modules.php
+++ b/htdocs/core/modules/supplier_invoice/pdf/pdf_canelle.modules.php
@@ -102,8 +102,8 @@ class pdf_canelle extends ModelePDFSuppliersInvoices
 		if($conf->global->PRODUCT_USE_UNITS) {
 			$this->posxtva=99;
 			$this->posxup=114;
-			$this->posxqty=133;
-			$this->posxunit=150;
+			$this->posxqty=130;
+			$this->posxunit=147;
 		}
 		//if (! empty($conf->global->MAIN_GENERATE_DOCUMENTS_WITHOUT_VAT)) $this->posxtva=$this->posxup;
 		$this->posxpicture=$this->posxtva - (empty($conf->global->MAIN_DOCUMENTS_WITH_PICTURE_WIDTH)?20:$conf->global->MAIN_DOCUMENTS_WITH_PICTURE_WIDTH);	// width of images

--- a/htdocs/core/modules/supplier_order/pdf/pdf_muscadet.modules.php
+++ b/htdocs/core/modules/supplier_order/pdf/pdf_muscadet.modules.php
@@ -111,8 +111,8 @@ class pdf_muscadet extends ModelePDFSuppliersOrders
 		{
 			$this->posxtva=99;
 			$this->posxup=114;
-			$this->posxqty=133;
-			$this->posxunit=150;
+			$this->posxqty=130;
+			$this->posxunit=147;
 		} else {
 			$this->posxtva=112;
 			$this->posxup=126;


### PR DESCRIPTION
FIX #6227 Document models table header "Unit" is shown in 2 lines in Spanish