### PR TITLE
Fix undefined method getProjectsAuthorizedForUser.

### DIFF
--- a/htdocs/projet/tasks/contact.php
+++ b/htdocs/projet/tasks/contact.php
@@ -208,7 +208,7 @@ if ($id > 0 || ! empty($ref))
             // Define a complementary filter for search of next/prev ref.
             if (! $user->rights->projet->all->lire)
             {
-                $objectsListId = $object->getProjectsAuthorizedForUser($user,0,0);
+                $objectsListId = $projectstatic->getProjectsAuthorizedForUser($user,0,0);
                 $projectstatic->next_prev_filter=" rowid in (".(count($objectsListId)?join(',',array_keys($objectsListId)):'0').")";
             }
             

--- a/htdocs/projet/tasks/document.php
+++ b/htdocs/projet/tasks/document.php
@@ -151,7 +151,7 @@ if ($object->id > 0)
         // Define a complementary filter for search of next/prev ref.
         if (! $user->rights->projet->all->lire)
         {
-            $objectsListId = $object->getProjectsAuthorizedForUser($user,0,0);
+            $objectsListId = $projectstatic->getProjectsAuthorizedForUser($user,0,0);
             $projectstatic->next_prev_filter=" rowid in (".(count($objectsListId)?join(',',array_keys($objectsListId)):'0').")";
         }
         

--- a/htdocs/projet/tasks/note.php
+++ b/htdocs/projet/tasks/note.php
@@ -130,7 +130,7 @@ if ($object->id > 0)
 		// Define a complementary filter for search of next/prev ref.
 		if (! $user->rights->projet->all->lire)
 		{
-		    $objectsListId = $object->getProjectsAuthorizedForUser($user,0,0);
+		    $objectsListId = $projectstatic->getProjectsAuthorizedForUser($user,0,0);
 		    $projectstatic->next_prev_filter=" rowid in (".(count($objectsListId)?join(',',array_keys($objectsListId)):'0').")";
 		}
 		

--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -242,7 +242,7 @@ if ($id > 0 || ! empty($ref))
             // Define a complementary filter for search of next/prev ref.
             if (! $user->rights->projet->all->lire)
             {
-                $objectsListId = $object->getProjectsAuthorizedForUser($user,0,0);
+                $objectsListId = $projectstatic->getProjectsAuthorizedForUser($user,0,0);
                 $projectstatic->next_prev_filter=" rowid in (".(count($objectsListId)?join(',',array_keys($objectsListId)):'0').")";
             }
             

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -318,7 +318,7 @@ if (($id > 0 || ! empty($ref)) || $projectidforalltimes > 0)
             // Define a complementary filter for search of next/prev ref.
             if (! $user->rights->projet->all->lire)
             {
-                $objectsListId = $object->getProjectsAuthorizedForUser($user,0,0);
+                $objectsListId = $projectstatic->getProjectsAuthorizedForUser($user,0,0);
                 $projectstatic->next_prev_filter=" rowid in (".(count($objectsListId)?join(',',array_keys($objectsListId)):'0').")";
             }
             


### PR DESCRIPTION
When a user don't have the permission
`$user->rights->projet->all->lire`, viewing some tasks related entities
(like `tasks/contact.php?id=1&withproject=1`) cause `Call to undefined
method Task::getProjectsAuthorizedForUser()` fatal error.

The problem is caused by calling getProjectsAuthorizedForUser on `$object`
insted of `$projectstatic`.