### PR TITLE
Fix: Add Missing Translation String

### DIFF
--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -142,3 +142,4 @@ ProductStockWarehouseCreated=Stock limit for alert and desired optimal stock cor
 ProductStockWarehouseUpdated=Stock limit for alert and desired optimal stock correctly updated
 ProductStockWarehouseDeleted=Stock limit for alert and desired optimal stock correctly deleted
 AddNewProductStockWarehouse=Set new limit for alert and desired optimal stock
+AddStockLocationLine=Decrease quantity then click to add another warehouse for this product


### PR DESCRIPTION
When product batch module is disabled, the translation string is missing for dispatch line.