### PR TITLE
Tentative fixes for #6074

### DIFF
--- a/htdocs/core/class/menu.class.php
+++ b/htdocs/core/class/menu.class.php
@@ -56,8 +56,8 @@ class Menu
      * @param   integer	$level      Level of menu to add
      * @param   int		$enabled    Menu active or not (0=Not active, 1=Active, 2=Active but grey)
      * @param   string	$target		Target lien
-     * @param	string	$mainmenu	Main menu ('home', 'companies', 'products', ...)
-     * @param	string	$leftmenu	Left menu ('setup', 'system', 'admintools', ...)
+     * @param	string	$mainmenu	This main menu name ('home', 'companies', 'products', ...)
+     * @param	string	$leftmenu	This left menu name ('setup', 'system', 'admintools', ...)
      * @param	int		$position	Position (not used yet)
      * @return	void
      */
@@ -75,8 +75,8 @@ class Menu
      * @param   integer	$level      Level of menu to add
      * @param   int		$enabled    Menu active or not
      * @param   string	$target		Target lien
-     * @param	string	$mainmenu	Main menu ('home', 'companies', 'products', ...)
-     * @param	string	$leftmenu	Left menu ('setup', 'system', 'admintools', ...)
+     * @param	string	$mainmenu	This main menu name ('home', 'companies', 'products', ...)
+     * @param	string	$leftmenu	This left menu name ('setup', 'system', 'admintools', ...)
      * @param	int		$position	Position (not used yet)
      * @return	void
      */

--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -785,12 +785,12 @@ function print_left_eldy_menu($db,$menu_array_before,$menu_array_after,&$tabMenu
 				$langs->load("bills");
 				$newmenu->add("/fourn/facture/list.php?leftmenu=suppliers_bills", $langs->trans("BillsSuppliers"),0,$user->rights->fournisseur->facture->lire, '', $mainmenu, 'suppliers_bills');
 				$newmenu->add("/fourn/facture/card.php?action=create",$langs->trans("NewBill"),1,$user->rights->fournisseur->facture->creer);
-				$newmenu->add("/fourn/facture/list.php?leftmenu=suppliers_bills", $langs->trans("List"),1,$user->rights->fournisseur->facture->lire, '', $mainmenu, 'suppliers_bills');
+				$newmenu->add("/fourn/facture/list.php?leftmenu=suppliers_bills", $langs->trans("List"),1,$user->rights->fournisseur->facture->lire);
 
 				if (empty($leftmenu) || ($leftmenu == 'suppliers_bills')) {
-					$newmenu->add("/fourn/facture/list.php?leftmenu=suppliers_bills&amp;search_status=0", $langs->trans("BillShortStatusDraft"),2,$user->rights->fournisseur->facture->lire, '', $mainmenu, 'suppliers_bills');
-					$newmenu->add("/fourn/facture/list.php?leftmenu=suppliers_bills&amp;search_status=1", $langs->trans("BillShortStatusNotPaid"),2,$user->rights->fournisseur->facture->lire, '', $mainmenu, 'suppliers_bills');
-					$newmenu->add("/fourn/facture/list.php?leftmenu=suppliers_bills&amp;search_status=2", $langs->trans("BillShortStatusPaid"),2,$user->rights->fournisseur->facture->lire, '', $mainmenu, 'suppliers_bills');
+					$newmenu->add("/fourn/facture/list.php?leftmenu=suppliers_bills&amp;search_status=0", $langs->trans("BillShortStatusDraft"),2,$user->rights->fournisseur->facture->lire);
+					$newmenu->add("/fourn/facture/list.php?leftmenu=suppliers_bills&amp;search_status=1", $langs->trans("BillShortStatusNotPaid"),2,$user->rights->fournisseur->facture->lire);
+					$newmenu->add("/fourn/facture/list.php?leftmenu=suppliers_bills&amp;search_status=2", $langs->trans("BillShortStatusPaid"),2,$user->rights->fournisseur->facture->lire);
 				}
 
 				$newmenu->add("/fourn/facture/paiement.php", $langs->trans("Payments"),1,$user->rights->fournisseur->facture->lire);

--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -643,7 +643,7 @@ function print_left_eldy_menu($db,$menu_array_before,$menu_array_after,&$tabMenu
 					$newmenu->add("/categories/card.php?action=create&amp;type=2", $langs->trans("NewCategory"), 1, $user->rights->categorie->creer);
 				}
 				// Categories Contact
-				$newmenu->add("/categories/index.php?leftmenu=cat&amp;type=4", $langs->trans("ContactCategoriesShort"), 0, $user->rights->categorie->lire, '', $mainmenu, 'cat');
+				$newmenu->add("/categories/index.php?leftmenu=cat&amp;type=4", $langs->trans("ContactCategoriesShort"), 0, $user->rights->categorie->lire, '', $mainmenu, 'cat'); // FIXME: duplicated leftmenu key
 				$newmenu->add("/categories/card.php?action=create&amp;type=4", $langs->trans("NewCategory"), 1, $user->rights->categorie->creer);
 				// Categories suppliers
 				if (! empty($conf->fournisseur->enabled))
@@ -812,7 +812,7 @@ function print_left_eldy_menu($db,$menu_array_before,$menu_array_after,&$tabMenu
 				if (! empty($conf->global->SUPPLIER_MENU_ORDER_RECEIVED_INTO_INVOICE))
 				{
 					$langs->load("supplier");
-					$newmenu->add("/fourn/commande/list.php?leftmenu=orders&amp;search_status=5", $langs->trans("MenuOrdersSupplierToBill"), 0, $user->rights->commande->lire, '', $mainmenu, 'orders');
+					$newmenu->add("/fourn/commande/list.php?leftmenu=orders&amp;search_status=5", $langs->trans("MenuOrdersSupplierToBill"), 0, $user->rights->commande->lire, '', $mainmenu, 'orders'); // FIXME: duplicate leftmenu key
 					//                  if (empty($leftmenu) || $leftmenu=="orders") $newmenu->add("/commande/", $langs->trans("StatusOrderToBill"), 1, $user->rights->commande->lire);
 				}
 			}


### PR DESCRIPTION
These fixes the #6074 issue but similar issues are remaining.
I don't quite know how these remaining entries should be treated since this can cause regressions in existing module code and they can be hard to discriminate. eg. the three entries referenced ```cat```.
Please see my commit messages for more insights and particularly the one that adds fixmes.

Other branches (3.9, 4.0…) may have introduced the same problems and needs further investigations once this is merged up the tree.