### PR TITLE
FIX: set fk_user_modif when note is updated

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2106,6 +2106,8 @@ abstract class CommonObject
      */
     function update_note($note,$suffix='')
     {
+    	global $user;
+    	
     	if (! $this->table_element)
     	{
     		dol_syslog(get_class($this)."::update_note was called on objet with property table_element not defined", LOG_ERR);
@@ -2119,6 +2121,7 @@ abstract class CommonObject
 
     	$sql = 'UPDATE '.MAIN_DB_PREFIX.$this->table_element;
     	$sql.= " SET note".$suffix." = ".(!empty($note)?("'".$this->db->escape($note)."'"):"NULL");
+    	$sql.= " ,fk_user_modif=".$user->id;
     	$sql.= " WHERE rowid =". $this->id;
 
     	dol_syslog(get_class($this)."::update_note", LOG_DEBUG);

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2121,7 +2121,7 @@ abstract class CommonObject
 
     	$sql = 'UPDATE '.MAIN_DB_PREFIX.$this->table_element;
     	$sql.= " SET note".$suffix." = ".(!empty($note)?("'".$this->db->escape($note)."'"):"NULL");
-    	$sql.= " ,fk_user_modif=".$user->id;
+    	$sql.= " ,".($this->table_element == 'adherent'?"fk_user_mod":"fk_user_modif")."=".$user->id;
     	$sql.= " WHERE rowid =". $this->id;
 
     	dol_syslog(get_class($this)."::update_note", LOG_DEBUG);


### PR DESCRIPTION
when a user updates a note, update date was set (by database tms field definition) but user was not updated; this was not good for the Log tab