### PR TITLE
Fix numbering was disaplying technical error instead of error message

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -239,7 +239,8 @@ class Commande extends CommonOrder
             }
             else
 			{
-            	dol_print_error($this->db,get_class($this)."::getNextNumRef ".$obj->error);
+				$this->error=$obj->error;
+            	//dol_print_error($this->db,get_class($this)."::getNextNumRef ".$obj->error);
             	return "";
             }
         }

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -3003,7 +3003,8 @@ class Facture extends CommonInvoice
 			 * set up mask.
 			 */
 			if ($mode != 'last' && !$numref) {
-				dol_print_error($this->db,"Facture::getNextNumRef ".$obj->error);
+				$this->error=$obj->error;
+				//dol_print_error($this->db,"Facture::getNextNumRef ".$obj->error);
 				return "";
 			}
 

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1627,6 +1627,7 @@ class FactureFournisseur extends CommonInvoice
         }
         else
        {
+       		$this->error=$obj->error;
         	//dol_print_error($db,get_class($this)."::getNextNumRef ".$obj->error);
         	return false;
         }


### PR DESCRIPTION
When using an external numbering module, if the numbering returns an error message, this is the tehcnical error that was displayed instead of proper error message. Was right in propal.class and fournisseur.commande.class though.