### PR TITLE
FIX #4758 PHP warning when installing to PostgreSQL with incorrect credentials

### DIFF
--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -412,8 +412,8 @@ class DoliDBPgsql extends DoliDB
 		{
 			$this->database_name = $name;
 			pg_set_error_verbosity($this->db, PGSQL_ERRORS_VERBOSE);	// Set verbosity to max
+			pg_query($this->db, "set datestyle = 'ISO, YMD';");
 		}
-		pg_query($this->db, "set datestyle = 'ISO, YMD';");
 
 		return $this->db;
 	}


### PR DESCRIPTION
FIX #4758 PHP warning when installing to PostgreSQL with incorrect credentials

Introduced in 9267fe367eecdff0385f6cfd102468579601b33d

Closes #4758