### PR TITLE
FIX|Fix #6318 Inconsistent handling in list view of third parties

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -224,7 +224,7 @@ if (GETPOST("button_removefilter_x") || GETPOST("button_removefilter.x") || GETP
 	$search_idprof6='';
 	$search_type='';
 	$search_type_thirdparty='';
-	$search_status='';
+	$search_status=-1;
 	$search_stcomm='';
  	$search_level_from='';
  	$search_level_to='';
@@ -396,7 +396,7 @@ if ($search_idprof6)  $sql.= natural_search("s.idprof6",$search_idprof6);
 if ($search_type > 0 && in_array($search_type,array('1,3','2,3'))) $sql .= " AND s.client IN (".$db->escape($search_type).")";
 if ($search_type > 0 && in_array($search_type,array('4')))         $sql .= " AND s.fournisseur = 1";
 if ($search_type == '0') $sql .= " AND s.client = 0 AND s.fournisseur = 0";
-if ($search_status!='') $sql .= " AND s.status = ".$db->escape($search_status);
+if ($search_status != '' && $search_status >= 0) $sql .= " AND s.status = ".$db->escape($search_status);
 if (!empty($conf->barcode->enabled) && $search_barcode) $sql.= " AND s.barcode LIKE '%".$db->escape($search_barcode)."%'";
 if ($search_type_thirdparty) $sql .= " AND s.fk_typent IN (".$search_type_thirdparty.')';
 if ($search_levels)  $sql .= " AND s.fk_prospectlevel IN (".$search_levels.')';
@@ -836,7 +836,7 @@ if (! empty($arrayfields['s.tms']['checked']))
 if (! empty($arrayfields['s.status']['checked']))
 {
     print '<td class="liste_titre maxwidthonsmartphone" align="center">';
-    print $form->selectarray('search_status', array('0'=>$langs->trans('ActivityCeased'),'1'=>$langs->trans('InActivity')),$search_status);
+    print $form->selectarray('search_status', array('-1'=>'', '0'=>$langs->trans('ActivityCeased'),'1'=>$langs->trans('InActivity')),$search_status);
     print '</td>';
 }
 // Action column


### PR DESCRIPTION
The "Status" field in the list-view has a different behavior for third-parties and contacts. For contacts it's possible to select both (active and inactive) in the search bar, for third parties only active or inactive can be selected.

Only relevant for branch 4.0.