### PR TITLE
Fix : event status was reset after user selection

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -856,7 +856,7 @@ if ($id > 0)
 		$object->label       = GETPOST("label");
 		$object->datep       = $datep;
 		$object->datef       = $datef;
-		$object->percentage  = $percentage;
+		$object->percentage  = $object->percentage;
 		$object->priority    = GETPOST("priority");
         $object->fulldayevent= GETPOST("fullday")?1:0;
 		$object->location    = GETPOST('location');


### PR DESCRIPTION
After selecting a user on an action card, the status was changed to NA