### PR TITLE
Removed 'page_y' parameter that used JS to move the scroll to a particular page Y when it is not necessary in Dolibarr admin page

### DIFF
--- a/htdocs/admin/modules.php
+++ b/htdocs/admin/modules.php
@@ -37,7 +37,6 @@ $langs->load("admin");
 $mode=GETPOST('mode', 'alpha')?GETPOST('mode', 'alpha'):0;
 $action=GETPOST('action','alpha');
 $value=GETPOST('value', 'alpha');
-$page_y=GETPOST('page_y','int');
 $search_keyword=GETPOST('search_keyword','alpha');
 $search_status=GETPOST('search_status','alpha');
 $search_nature=GETPOST('search_nature','alpha');
@@ -97,7 +96,7 @@ if ($action == 'set' && $user->admin)
     		setEventMessages($msg, null, 'warnings');
 	    }
 	}
-    header("Location: modules.php?mode=".$mode.$param.($page_y?'&page_y='.$page_y:''));
+    header("Location: modules.php?mode=".$mode.$param.'#'.$value);
 	exit;
 }
 
@@ -105,7 +104,7 @@ if ($action == 'reset' && $user->admin)
 {
     $result=unActivateModule($value);
     if ($result) setEventMessages($result, null, 'errors');
-    header("Location: modules.php?mode=".$mode.$param.($page_y?'&page_y='.$page_y:''));
+    header("Location: modules.php?mode=".$mode.$param.'#'.$value);
 	exit;
 }
 
@@ -685,7 +684,7 @@ if ($mode != 'marketplace')
         	}
         	else
         	{
-        		print '<a class="reposition" href="modules.php?id='.$objMod->numero.'&amp;module_position='.$module_position.'&amp;action=reset&amp;value=' . $modName . '&amp;mode=' . $mode . $param . '">';
+        		print '<a name="'.$modName.'" href="modules.php?id='.$objMod->numero.'&amp;module_position='.$module_position.'&amp;action=reset&amp;value=' . $modName . '&amp;mode=' . $mode . $param . '">';
         		print img_picto($langs->trans("Activated"),'switch_on');
         		print '</a>';
         	}
@@ -749,7 +748,7 @@ if ($mode != 'marketplace')
         	else
         	{
 	        	// Module non actif
-	        	print '<a class="reposition" href="modules.php?id='.$objMod->numero.'&amp;module_position='.$module_position.'&amp;action=set&amp;value=' . $modName . '&amp;mode=' . $mode . $param . '">';
+	        	print '<a name="'.$modName.'" href="modules.php?id='.$objMod->numero.'&amp;module_position='.$module_position.'&amp;action=set&amp;value=' . $modName . '&amp;mode=' . $mode . $param . '">';
 	        	print img_picto($langs->trans("Disabled"),'switch_off');
 	        	print "</a>\n";
         	}

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5513,6 +5513,18 @@ function printCommonFooter($zone='private')
 		print '<!-- Reposition management (does not work if a redirect is done after action of submission) -->'."\n";
     	print '<script type="text/javascript" language="javascript">jQuery(document).ready(function() {'."\n";
 
+    	print '<!-- If page_y set, we set scollbar with it -->'."\n";
+    	print "page_y=getParameterByName('page_y', 0);";
+    	print "if (page_y > 0) $('html, body').scrollTop(page_y);\n";
+
+    	print '<!-- Set handler to add page_y param on some a href links -->'."\n";
+    	print 'jQuery(".reposition").click(function() {
+    	           var page_y = $(document).scrollTop();
+    	           /*alert(page_y);*/
+    	           this.href=this.href+\'&page_y=\'+page_y;
+    	           });'."\n";
+    	print '});'."\n";
+    	
     	if (empty($conf->dol_use_jmobile))
     	{
         	print '<!-- Set handler to switch left menu page -->'."\n";

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5513,18 +5513,6 @@ function printCommonFooter($zone='private')
 		print '<!-- Reposition management (does not work if a redirect is done after action of submission) -->'."\n";
     	print '<script type="text/javascript" language="javascript">jQuery(document).ready(function() {'."\n";
 
-    	print '<!-- If page_y set, we set scollbar with it -->'."\n";
-    	print "page_y=getParameterByName('page_y', 0);";
-    	print "if (page_y > 0) $('html, body').scrollTop(page_y);\n";
-
-    	print '<!-- Set handler to add page_y param on some a href links -->'."\n";
-    	print 'jQuery(".reposition").click(function() {
-    	           var page_y = $(document).scrollTop();
-    	           /*alert(page_y);*/
-    	           this.href=this.href+\'&page_y=\'+page_y;
-    	           });'."\n";
-    	print '});'."\n";
-    	
     	if (empty($conf->dol_use_jmobile))
     	{
         	print '<!-- Set handler to switch left menu page -->'."\n";


### PR DESCRIPTION
Removed 'page_y' parameter that used JS to move the scroll to a particular page Y when it is not necessary in Dolibarr admin page