### PR TITLE
[FIX] Dictionaries without rowid

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -1537,7 +1537,8 @@ if ($id)
                     $canbemodified=$iserasable;
                     if ($obj->code == 'RECEP') $canbemodified=1;
 
-                    $url = $_SERVER["PHP_SELF"].'?'.($page?'page='.$page.'&':'').'sortfield='.$sortfield.'&sortorder='.$sortorder.'&rowid='.(! empty($obj->rowid)?$obj->rowid:(! empty($obj->code)?$obj->code:'')).'&code='.(! empty($obj->code)?urlencode($obj->code):'');
+                    $rowidcol=$tabrowid[$id];
+                    $url = $_SERVER["PHP_SELF"].'?'.($page?'page='.$page.'&':'').'sortfield='.$sortfield.'&sortorder='.$sortorder.'&rowid='.(! empty($obj->{$rowidcol})?$obj->{$rowidcol}:(! empty($obj->code)?$obj->code:'')).'&code='.(! empty($obj->code)?urlencode($obj->code):'');
                     if ($param) $url .= '&'.$param;
                     $url.='&';
 


### PR DESCRIPTION
It's possible to create a dictionary without the key rowid.
But in that case it's impossible to enable/disable the value because the dictionary functionality uses always rowid even another primary key is defined.

By this fix, the id property uses is the primary key defined on the dictionary creation.