### PR TITLE
Force user to enter a valid VAT number

### DIFF
--- a/htdocs/societe/soc.php
+++ b/htdocs/societe/soc.php
@@ -1755,7 +1755,7 @@ else
             // VAT Code
             print '<tr><td>'.fieldLabel('VATIntra','intra_vat').'</td>';
             print '<td colspan="3">';
-            $s ='<input type="text" class="flat maxwidthonsmartphone" name="tva_intra" id="intra_vat" maxlength="20" value="'.$object->tva_intra.'">';
+           $s ='<input type="text" name="tva_intra" class="flat maxwidthonsmartphone" id="intra_vat" value="'.$object->tva_intra.'" pattern="^((AT)?U[0-9]{8}|(BE)?0[0-9]{9}|(BG)?[0-9]{9,10}|(CY)?[0-9]{8}L|(CZ)?[0-9]{8,10}|(DE)?[0-9]{9}|(DK)?[0-9]{8}|(EE)?[0-9]{9}|(EL|GR)?[0-9]{9}|(ES)?[0-9A-Z][0-9]{7}[0-9A-Z]|(FI)?[0-9]{8}|(FR)?[0-9A-Z]{2}[0-9]{9}|(GB)?([0-9]{9}([0-9]{3})?|[A-Z]{2}[0-9]{3})|(HU)?[0-9]{8}|(IE)?[0-9]S[0-9]{5}L|(IT)?[0-9]{11}|(LT)?([0-9]{9}|[0-9]{12})|(LU)?[0-9]{8}|(LV)?[0-9]{11}|(MT)?[0-9]{8}|(NL)?[0-9]{9}B[0-9]{2}|(PL)?[0-9]{10}|(PT)?[0-9]{9}|(RO)?[0-9]{2,10}|(SE)?[0-9]{12}|(SI)?[0-9]{8}|(SK)?[0-9]{10})$" title="European VAT">';
 
             if (empty($conf->global->MAIN_DISABLEVATCHECK))
             {


### PR DESCRIPTION
# New
Force user to enter a valid VAT number by checking with a regex in the input attribute pattern.
The regex is from here : https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s21.html