### PR TITLE
Description text is not translated

### DIFF
--- a/htdocs/core/modules/mailings/contacts1.modules.php
+++ b/htdocs/core/modules/mailings/contacts1.modules.php
@@ -50,7 +50,9 @@ class mailing_contacts1 extends MailingTargets
 	 */
 	function __construct($db)
 	{
+		global $langs;
 		$this->db=$db;
+		$this->desc = $langs->trans($this->name);
 	}
 
 


### PR DESCRIPTION
Propose to use name of class as translation terms
@eldy : If solution is ok for you I do the job for the other terms