### PR TITLE
use access right to validate expense report created for someone else

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -2092,7 +2092,7 @@ if ($action != 'create' && $action != 'edit')
 	*/
 	if ($user->rights->expensereport->creer && $object->fk_statut==0)
 	{
-		if (in_array($object->fk_user_author, $user->getAllChildIds(1)))
+		if (in_array($object->fk_user_author, $user->getAllChildIds(1)) || !empty($user->rights->expensereport->writeall_advance))
 		{
 			// Modify
 			print '<div class="inline-block divButAction"><a class="butAction" href="'.$_SERVER["PHP_SELF"].'?action=edit&id='.$object->id.'">'.$langs->trans('Modify').'</a></div>';


### PR DESCRIPTION
When we create an expense report for someone else, the check to validate and edit it is only on the fk_user_author, but we are not the author so I check also the access right