### PR TITLE
FIX : Agenda getCalendarEvents hook

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -919,7 +919,14 @@ if (count($listofextcals))
 // Complete $eventarray with events coming from external module
 $parameters=array(); $object=null;
 $reshook=$hookmanager->executeHooks('getCalendarEvents',$parameters,$object,$action);
-if (! empty($hookmanager->resArray['eventarray'])) $eventarray=array_merge($eventarray, $hookmanager->resArray['eventarray']);
+if (! empty($hookmanager->resArray['eventarray'])) {
+    foreach ($hookmanager->resArray['eventarray'] as $keyDate => $events) {
+        if (!isset($eventarray[$keyDate])) {
+            $eventarray[$keyDate]=array();
+        }
+        $eventarray[$keyDate]=array_merge($eventarray[$keyDate], $events);
+    }
+}
 
 
 


### PR DESCRIPTION
# Fix Agenda getCalendarEvents hook
Return of getCalendarEvents on agenda page :
The `array_merge` will reindex the merged array because of numeric key

Ex :
Merging of two array of events : 
```php
array(1) {
  [1488412800]=>
  object(ActionComm) {...}
}
array(1) {
  [1488412800]=>
  object(ActionComm) {...}
}
```
Give :
```php
array(1) {
  [0]=>
  object(ActionComm) {...}
}
```
More informations :
https://softonsofa.com/php-array_merge-vs-array_replace-vs-plus-aka-union/