### PR TITLE
New : allow new type of document template

### DIFF
--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1539,10 +1539,11 @@ function getListOfModels($db,$type,$maxfilenamelength=0)
                 {
                     $tmpdir=trim($tmpdir);
                     $tmpdir=preg_replace('/DOL_DATA_ROOT/',DOL_DATA_ROOT,$tmpdir);
+		    $tmpdir=preg_replace('/DOL_DOCUMENT_ROOT/',DOL_DOCUMENT_ROOT,$tmpdir);
                     if (! $tmpdir) { unset($listofdir[$key]); continue; }
                     if (is_dir($tmpdir))
                     {
-                        $tmpfiles=dol_dir_list($tmpdir,'files',0,'\.od(s|t)$','','name',SORT_ASC,0);
+                        $tmpfiles=dol_dir_list($tmpdir,'files',0,'','','name',SORT_ASC,0);
                         if (count($tmpfiles)) $listoffiles=array_merge($listoffiles,$tmpfiles);
                     }
                 }

--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1539,7 +1539,6 @@ function getListOfModels($db,$type,$maxfilenamelength=0)
                 {
                     $tmpdir=trim($tmpdir);
                     $tmpdir=preg_replace('/DOL_DATA_ROOT/',DOL_DATA_ROOT,$tmpdir);
-		    $tmpdir=preg_replace('/DOL_DOCUMENT_ROOT/',DOL_DOCUMENT_ROOT,$tmpdir);
                     if (! $tmpdir) { unset($listofdir[$key]); continue; }
                     if (is_dir($tmpdir))
                     {


### PR DESCRIPTION
actually we limit template document are only odt or ods and present only in DOL_DATA_ROOT folder, 
propose that document template must be in DOL_DOCUMENT_ROOT too (installed in folder of a module)
and not limited of odt and ods
this feature may allow to indroduce a new type of template document based of some other format than odt ans ods