### PR TITLE
FIX Have same date formatting to all odt document

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -444,9 +444,9 @@ abstract class CommonDocGenerator
 			'line_price_ht_locale'=>price($line->total_ht, 0, $outputlangs),
 			'line_price_ttc_locale'=>price($line->total_ttc, 0, $outputlangs),
 			'line_price_vat_locale'=>price($line->total_tva, 0, $outputlangs),
-			'line_date_start'=>$line->date_start,
+			'line_date_start'=>dol_print_date($line->date_start,'day','tzuser'),
 			'line_date_start_rfc'=>dol_print_date($line->date_start,'dayrfc'),
-			'line_date_end'=>$line->date_end,
+			'line_date_end'=>dol_print_date($line->date_end,'day','tzuser'),
 			'line_date_end_rfc'=>dol_print_date($line->date_end,'dayrfc')
 		);
 


### PR DESCRIPTION
In line object by default we have choice between unixtime or rfc format (as sql format). In both case, is not an user readable format.
Then we follow same formating about date displayed.