### PR TITLE
Run soffice in background

### DIFF
--- a/scripts/odt2pdf/odt2pdf.sh
+++ b/scripts/odt2pdf/odt2pdf.sh
@@ -17,13 +17,16 @@ then
 	exit
 fi
 
+soffice="/usr/bin/soffice"
+
 
 if [ -f "$1.odt" ]
  then
   nbprocess=$(pgrep -c soffice)
   if [ $nbprocess -ne 1 ]	# If there is some soffice process running
    then
-    soffice --invisible --accept="socket,host=127.0.0.1,port=8100;urp;" --nofirststartwizard --headless &
+    cmd="$soffice --invisible --accept=socket,host=127.0.0.1,port=8100;urp; --nofirststartwizard --headless"
+    $cmd &
     retcode=$?
     if [ $retcode -ne 0 ]
      then

--- a/scripts/odt2pdf/odt2pdf.sh
+++ b/scripts/odt2pdf/odt2pdf.sh
@@ -18,15 +18,15 @@ then
 fi
 
 soffice="/usr/bin/soffice"
-
+home_java="/tmp"
 
 if [ -f "$1.odt" ]
  then
   nbprocess=$(pgrep -c soffice)
   if [ $nbprocess -ne 1 ]	# If there is some soffice process running
    then
-    cmd="$soffice --invisible --accept=socket,host=127.0.0.1,port=8100;urp; --nofirststartwizard --headless"
-    $cmd &
+    cmd="$soffice --invisible --accept=socket,host=127.0.0.1,port=8100;urp; --nofirststartwizard --headless -env:UserInstallation=file:///$home_java/"
+    export HOME=$home_java && cd $home_java && $cmd&
     retcode=$?
     if [ $retcode -ne 0 ]
      then


### PR DESCRIPTION
In some case soffice can't be execute.  
As www-data might be a system user, home directory is not set or without correct user right, then we prevent this to a tmp/ directory.

Inspired from http://stackoverflow.com/questions/22973641/php-libreoffice-shell-exec-not-working
