### PR TITLE
View all user by default if we have rights in agenda

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -49,7 +49,7 @@ $usergroup = GETPOST("usergroup","int",3);
 $showbirthday = empty($conf->use_javascript_ajax)?GETPOST("showbirthday","int"):1;
 
 // If not choice done on calendar owner (like on left menu link "Agenda"), we filter on user.
-if (empty($filtert) && empty($conf->global->AGENDA_ALL_CALENDARS))
+if (empty($filtert) && empty($conf->global->AGENDA_ALL_CALENDARS) && ! $user->rights->agenda->allactions->create)
 {
 	$filtert=$user->id;
 }


### PR DESCRIPTION
I think it's better for a user that can 'allactions->create' to see by default all the users.
Because he manage a team and want's to see directly what are doing his crew.