### PR TITLE
FIX : Categories Bank vs categories transactions

### DIFF
--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -1071,10 +1071,11 @@ function print_left_eldy_menu($db,$menu_array_before,$menu_array_after,&$tabMenu
 
             if (! empty($conf->categorie->enabled)) {
                 $langs->load("categories");
-                //$newmenu->add("/compta/bank/categ.php",$langs->trans("Rubriques"),1,$user->rights->banque->configurer);
                 $newmenu->add("/categories/index.php?type=5",$langs->trans("Rubriques"),0,$user->rights->categorie->creer, '', $mainmenu, 'tags');
                 $newmenu->add("/categories/card.php?action=create&amp;type=5",$langs->trans("NewCategory"),1,$user->rights->categorie->creer);
-            }
+                $newmenu->add("/compta/bank/categ.php",$langs->trans("RubriquesTransactions"),1,$user->rights->banque->configurer);
+
+	    }
 
 			// Prelevements
 			if (! empty($conf->prelevement->enabled))


### PR DESCRIPTION
PB since 4.0, present in 5.0 and develop version
There is a confusion between the categorization function of bank accounts and the categorization function of the records. The categorization of the entries has been removed or it is not replaced by the categorization of the bank accounts.
I propose for the moment to restore the old category of writings but to envisage the creation of a new type of category "bank records" (or if it is not necessary with the new account) to leave so