### PR TITLE
FIX: Supplier is not the project customer

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -308,7 +308,7 @@ $listofreferent=array(
 	'margin'=>'minus',
 	'table'=>'facture_fourn',
 	'datefieldname'=>'datef',
-    'urlnew'=>DOL_URL_ROOT.'/fourn/facture/card.php?action=create&projectid='.$id.'&socid='.$socid,
+    'urlnew'=>DOL_URL_ROOT.'/fourn/facture/card.php?action=create&projectid='.$id,
     'lang'=>'suppliers',
     'buttonnew'=>'AddSupplierInvoice',
     'testnew'=>$user->rights->fournisseur->facture->creer,


### PR DESCRIPTION
FIX: Supplier is not the project customer
The code enforce to use the project customer as the provider which is not correct, by removing socid the user can freely chose the supplier

https://www.dolibarr.fr/forum/527-bugs-sur-la-version-stable-courante/58371-module-projet#82869