### PR TITLE
FIX Avoid (DEPOSIT) (1) & (2) descriptions

### DIFF
--- a/htdocs/comm/remx.php
+++ b/htdocs/comm/remx.php
@@ -92,7 +92,7 @@ if ($action == 'confirm_split' && GETPOST("confirm") == 'yes')
 		$newdiscount2->fk_facture=$discount->fk_facture;
 		$newdiscount1->fk_facture_line=$discount->fk_facture_line;
 		$newdiscount2->fk_facture_line=$discount->fk_facture_line;
-		if ($discount->description == '(CREDIT_NOTE)')
+		if ($discount->description == '(CREDIT_NOTE)' || $discount->description == '(DEPOSIT)')
 		{
 			$newdiscount1->description=$discount->description;
 			$newdiscount2->description=$discount->description;


### PR DESCRIPTION
When splitting a rebate into two parts, the word "DEPOSIT" is no longer translated on the invoices.
