### PR TITLE
Update main.lang with StatusInterInvoiced which is only in interventions.lang and isn't translated on Dashboard

### DIFF
--- a/htdocs/langs/fr_FR/main.lang
+++ b/htdocs/langs/fr_FR/main.lang
@@ -433,6 +433,7 @@ Reporting=Rapport
 Reportings=Rapports
 Draft=Brouillon
 Drafts=Brouillons
+StatusInterInvoiced=Facturée
 Validated=Validé
 Opened=Ouvert
 New=Nouveau


### PR DESCRIPTION
On the Dashboard, box "Les 10 dernières interventions modifiées", the key StatusInterInvoiced appears because translation is only in interventions.lang file and not in main.lang.