### PR TITLE
FIX: situation invoice miscalculation (#6653)

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2872,7 +2872,7 @@ class Facture extends CommonInvoice
 		// Cap percentages to 100
 		if ($percent > 100) $percent = 100;
 		$line->situation_percent = $percent;
-		$tabprice = calcul_price_total($line->qty, $line->subprice, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, $line->product_type, 'HT', 0, 0, $mysoc, '', $percent);
+		$tabprice = calcul_price_total($line->qty, $line->subprice, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 0, 'HT', 0, $line->product_type, $mysoc, '', $percent);
 		$line->total_ht = $tabprice[0];
 		$line->total_tva = $tabprice[1];
 		$line->total_ttc = $tabprice[2];


### PR DESCRIPTION
# Fix: situation invoice miscalculation (#6653)

In price.lib.php (htdocs\core\lib\price.lib.php), the function calcul_price_total() is defined (line 76). The 7th parameter is **$remise_percent_global**.

However, this function is called on facture.class.php (htdocs\compta\facture\class\facture.class.php) and the 7th parameter used is **$line->product_type**. Consequently, invoice situation is correct when user sells a product (product_type = 0) and is wrong when user sells a service (product_type = 1).
Effectively, in the latter case, the total situation invoice will be wrong by 1%.

In order to correct this, we can add **0** as the **7th parameter** and move **$line->product_type** to the **10th parameter**.