### PR TITLE
NEW Improve public member subscription form with member type

### DIFF
--- a/htdocs/adherents/admin/public.php
+++ b/htdocs/adherents/admin/public.php
@@ -29,6 +29,7 @@ require '../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/member.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent_type.class.php';
 
 $langs->load("members");
 $langs->load("admin");
@@ -49,12 +50,15 @@ if ($action == 'update')
 	$editamount=GETPOST('MEMBER_NEWFORM_EDITAMOUNT');
 	$payonline=GETPOST('MEMBER_NEWFORM_PAYONLINE');
 	$email=GETPOST('MEMBER_PAYONLINE_SENDEMAIL');
+        $forcetype=GETPOST('MEMBER_NEWFORM_FORCETYPE');
 
     $res=dolibarr_set_const($db, "MEMBER_ENABLE_PUBLIC",$public,'chaine',0,'',$conf->entity);
     $res=dolibarr_set_const($db, "MEMBER_NEWFORM_AMOUNT",$amount,'chaine',0,'',$conf->entity);
     $res=dolibarr_set_const($db, "MEMBER_NEWFORM_EDITAMOUNT",$editamount,'chaine',0,'',$conf->entity);
     $res=dolibarr_set_const($db, "MEMBER_NEWFORM_PAYONLINE",$payonline,'chaine',0,'',$conf->entity);
     $res=dolibarr_set_const($db, "MEMBER_PAYONLINE_SENDEMAIL",$email,'chaine',0,'',$conf->entity);
+    if ($forcetype < 0) $res=dolibarr_del_const($db, "MEMBER_NEWFORM_FORCETYPE",$conf->entity);
+    else                $res=dolibarr_set_const($db, "MEMBER_NEWFORM_FORCETYPE",$forcetype,'chaine',0,'',$conf->entity);
 
     if (! $res > 0) $error++;
 
@@ -152,14 +156,18 @@ print '</td><td align="right">';
 print $form->selectyesno("MEMBER_ENABLE_PUBLIC",(! empty($conf->global->MEMBER_ENABLE_PUBLIC)?$conf->global->MEMBER_ENABLE_PUBLIC:0),1);
 print "</td></tr>\n";
 
-// Type
-/*$var=! $var;
+// Force Type
+$var=! $var;
+$adht = new AdherentType($db);
 print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
 print '<tr '.$bc[$var].' class="drag"><td>';
-print $langs->trans("EnablePublicSubscriptionForm");
+print $langs->trans("ForceMemberType");
 print '</td><td width="60" align="center">';
-print $form->selectyesno("forcedate",$conf->global->MEMBER_NEWFORM_FORCETYPE,1);
-print "</td></tr>\n"; */
+$listofval = array(-1 => $langs->trans("Undefined"));
+$listofval += $adht->liste_array();
+$forcetype = $conf->global->MEMBER_NEWFORM_FORCETYPE ?: -1;
+print $form->selectarray("MEMBER_NEWFORM_FORCETYPE", $listofval, $forcetype, count($listetype)>1?1:0);
+print "</td></tr>\n";
 
 // Amount
 $var=! $var;

--- a/htdocs/langs/en_US/members.lang
+++ b/htdocs/langs/en_US/members.lang
@@ -90,6 +90,7 @@ PublicMemberList=Public member list
 BlankSubscriptionForm=Public auto-subscription form
 BlankSubscriptionFormDesc=Dolibarr can provide you a public URL to allow external visitors to ask to subscribe to the foundation. If an online payment module is enabled, a payment form will also be automatically provided.
 EnablePublicSubscriptionForm=Enable the public auto-subscription form
+ForceMemberType=Force the member type
 ExportDataset_member_1=Members and subscriptions
 ImportDataset_member_1=Members
 LastMembersModified=Latest %s modified members

--- a/htdocs/langs/fr_FR/members.lang
+++ b/htdocs/langs/fr_FR/members.lang
@@ -90,6 +90,7 @@ PublicMemberList=Liste des membres publics
 BlankSubscriptionForm=Formulaire d'auto-inscription public
 BlankSubscriptionFormDesc=Dolibarr peut offrir une URL de page publique permettant de postuler à une adhésion pour les visiteurs externes. S'il existe un module de paiement en ligne, un formulaire de paiement sera également automatiquement proposé.
 EnablePublicSubscriptionForm=Activer le formulaire d'auto-inscription public
+ForceMemberType=Forcer le type de membre
 ExportDataset_member_1=Adhérents et adhésions
 ImportDataset_member_1=Adhérents
 LastMembersModified=Les %s derniers adhérents modifiés

--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -223,7 +223,7 @@ if ($action == 'add')
         // email a peu pres correct et le login n'existe pas
         $adh = new Adherent($db);
         $adh->statut      = -1;
-        $adh->public      = $_POST["public"];
+        $adh->public      = $public;
         $adh->firstname   = $_POST["firstname"];
         $adh->lastname    = $_POST["lastname"];
         $adh->civility_id = $_POST["civility_id"];
@@ -508,7 +508,7 @@ print '</td></tr>'."\n";
 // Photo
 print '<tr><td>'.$langs->trans("URLPhoto").'</td><td><input type="text" name="photo" size="40" value="'.dol_escape_htmltag(GETPOST('photo')).'"></td></tr>'."\n";
 // Public
-print '<tr><td>'.$langs->trans("Public").'</td><td><input type="checkbox" name="public" value="1" checked></td></tr>'."\n";
+print '<tr><td>'.$langs->trans("Public").'</td><td><input type="checkbox" name="public"></td></tr>'."\n";
 // Extrafields
 foreach($extrafields->attribute_label as $key=>$value)
 {


### PR DESCRIPTION
# New Improve public member subscription form
* In the form, make the details public = false by default, to match the default value in class Adherent
* Expose the existing option MEMBER_NEWFORM_FORCETYPE in the configuration UI, to force the member type in the form
