### PR TITLE
contract clone blocked => contact already created

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -656,7 +656,7 @@ abstract class CommonObject
             if ($this->add_contact($contact['id'], $contact['fk_c_type_contact'], $contact['source']) < 0)
             {
                 $this->error=$this->db->lasterror();
-                return -1;
+                //return -1;
             }
         }
         return 1;


### PR DESCRIPTION
contract create function used on clone feature create 2 contacts
contract.class.php => line 920
if we use after copy_linked_contact we have duplicate key error, and clone function goes wrong
propose to considere error has not locked or add a param function to disable the error for contract.class.php

actualy copy_linked_contact are used on contract.class.php, facture.class.php and propal.class.php