### PR TITLE
FIX supplier order line creation with rang = 0

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1372,10 +1372,13 @@ class CommandeFournisseur extends CommonOrder
 			$localtax2_type=$localtaxes_type[2];
 
             $subprice = price2num($pu,'MU');
+            
+            $rangmax = $this->line_max();
+            $rang = $rangmax + 1;
 
             $sql = "INSERT INTO ".MAIN_DB_PREFIX."commande_fournisseurdet";
             $sql.= " (fk_commande, label, description, date_start, date_end,";
-            $sql.= " fk_product, product_type,";
+            $sql.= " fk_product, product_type, rang,";
             $sql.= " qty, tva_tx, localtax1_tx, localtax2_tx, localtax1_type, localtax2_type, remise_percent, subprice, ref,";
             $sql.= " total_ht, total_tva, total_localtax1, total_localtax2, total_ttc, fk_unit";
             $sql.= ")";
@@ -1384,7 +1387,7 @@ class CommandeFournisseur extends CommonOrder
             $sql.= " ".($date_end?"'".$this->db->idate($date_end)."'":"null").",";
             if ($fk_product) { $sql.= $fk_product.","; }
             else { $sql.= "null,"; }
-            $sql.= "'".$product_type."',";
+            $sql.= "'".$product_type."', ".$rang.",";
             $sql.= "'".$qty."', ".$txtva.", ".$txlocaltax1.", ".$txlocaltax2;
 
            	$sql.= ", '".$localtax1_type."',";


### PR DESCRIPTION
# FIX supplier order line creation with rang = 0

In 3.9 and above, when adding a new line to a supplier order, the `rang` is never set explicitely and becomes 0 in database. However, the lines stay in the order they are added... until their order is changed with drag/drop. So, from there, new lines are added before the others instead of being in last position.

