### PR TITLE
Revert "FIX : close supplier makes no sense. we just need to know if it is ac…"

### DIFF
--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -441,6 +441,14 @@ if (empty($reshook))
 		}
 	}
 
+	// Close proposal
+	else if ($action == 'close' && $user->rights->supplier_proposal->cloturer && ! GETPOST('cancel')) {
+		// prevent browser refresh from reopening proposal several times
+		if ($object->statut == 2) {
+			$object->setStatut(4);
+		}
+	}
+
 	// Set accepted/refused
 	else if ($action == 'setstatut' && $user->rights->supplier_proposal->cloturer && ! GETPOST('cancel')) {
 		if (! GETPOST('statut')) {
@@ -1766,6 +1774,12 @@ if ($action == 'create')
 				if ($object->statut == 1 && $user->rights->supplier_proposal->cloturer) {
 					print '<div class="inline-block divButAction"><a class="butAction" href="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&amp;action=statut' . (empty($conf->global->MAIN_JUMP_TAG) ? '' : '#acceptedrefused') . '"';
 					print '>' . $langs->trans('SetAcceptedRefused') . '</a></div>';
+				}
+
+				// Close
+				if ($object->statut == 2 && $user->rights->supplier_proposal->cloturer) {
+				    print '<div class="inline-block divButAction"><a class="butAction" href="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&amp;action=close' . (empty($conf->global->MAIN_JUMP_TAG) ? '' : '#close') . '"';
+				    print '>' . $langs->trans('Close') . '</a></div>';
 				}
 
 				// Clone


### PR DESCRIPTION
Reverts Dolibarr/dolibarr#6773

When a proposal was set to accepted, someone must convert it into order. As long as it is not done, status is still opened. And when supplier order is created, we can close it.