### PR TITLE
Fix add new line for bank records

### DIFF
--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -471,9 +471,9 @@ class Account extends CommonObject
 
 		if ($accline->insert() > 0) {
 
-			if ($categorie) {
-				$sql = "INSERT INTO ".MAIN_DB_PREFIX."categorie_account (";
-				$sql .= "fk_account, fk_categorie";
+			if ($categorie>0) {
+				$sql = "INSERT INTO ".MAIN_DB_PREFIX."bank_class (";
+				$sql .= "lineid, fk_categ;
 				$sql .= ") VALUES (";
 				$sql .= " ".$accline->id.", ".$categorie;
 				$sql .= ")";


### PR DESCRIPTION

In version 5.0.1, add new record in bank page (compta/bank/bankentries.php?action=addline&page=&contextpage=banktransactionlist-2&id=2&account=XX) does not works.
There where problem in request who creates category and nothing works because the request for add bank record category in not correct.
This patch fix-it.

