### PR TITLE
NEW permit multiple file upload in linked documents tab

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -126,7 +126,9 @@ class FormFile
             {
                 $out .= '<input type="hidden" name="max_file_size" value="'.($max*1024).'">';
             }
-            $out .= '<input class="flat minwidth400" type="file" name="userfile"';
+
+            $out .= '<input class="flat minwidth400" type="file"';
+            $out .= (empty($conf->global->MAIN_USE_MULTIPLE_FILEUPLOAD)?' name="userfile"':' name="userfile[]" multiple');
             $out .= (empty($conf->global->MAIN_UPLOAD_DOC) || empty($perm)?' disabled':'');
             $out .= '>';
             $out .= ' ';

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -128,7 +128,7 @@ class FormFile
             }
 
             $out .= '<input class="flat minwidth400" type="file"';
-            $out .= (empty($conf->global->MAIN_USE_MULTIPLE_FILEUPLOAD)?' name="userfile"':' name="userfile[]" multiple');
+            $out .= ((empty($conf->global->MAIN_USE_MULTIPLE_FILEUPLOAD) || $conf->browser->layout == 'phone')?' name="userfile"':' name="userfile[]" multiple');
             $out .= (empty($conf->global->MAIN_UPLOAD_DOC) || empty($perm)?' disabled':'');
             $out .= '>';
             $out .= ' ';


### PR DESCRIPTION
In linked documents tab, `<input type="file" />` has been modified to permit multiple file uploads. For now, it is enabled via the hidden conf `MAIN_USE_MULTIPLE_FILEUPLOAD`. Dolibarr's file upload backend is already designed to handle multiple files at once. For reference, here is a recap of browser compatibility for this feature : https://caniuse.com/#feat=input-file-multiple