### PR TITLE
Fix #6504: CVE-2017-7886

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -439,7 +439,7 @@ class Translate
 		if (! $found)
 		{
     		// Overwrite translation with database read
-            $sql="SELECT transkey, transvalue FROM ".MAIN_DB_PREFIX."overwrite_trans where lang='".$this->defaultlang."'";            
+            $sql="SELECT transkey, transvalue FROM ".MAIN_DB_PREFIX."overwrite_trans where lang='".$db->escape($this->defaultlang)."'";            
 		    $resql=$db->query($sql);
 		    
 		    if ($resql)


### PR DESCRIPTION
'defaultlang' attribute was not filtered before database request which cause an SQL injection.



*Please:*
Quickly merge into 4.0 / 5.0 and develop branch.

# Fix #6504  (partially)

See FOXMOLE - Security Advisory 2017-02-23 : http://seclists.org/oss-sec/2017/q2/243 

This commit fix CVE-2017-7886.


