### PR TITLE
Fix: when sending a mail the default template used should be the first positioned template

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -828,7 +828,7 @@ class FormMail extends Form
 		if ($active >= 0) $sql.=" AND active = ".$active;
 		if (is_object($outputlangs)) $sql.= " AND (lang = '".$outputlangs->defaultlang."' OR lang IS NULL OR lang = '')";
 		if (!empty($id)) $sql.= " AND rowid=".$id;
-		$sql.= $db->order("lang,label","ASC");
+		$sql.= $db->order("position,lang,label","ASC");
 		//print $sql;
 
 		$resql = $db->query($sql);


### PR DESCRIPTION
# Fix: when sending a mail the default template used should be the first positioned template

Email templates have mandatory position index. This fix makes use of it for ordering the templates and thus correctly selecting the default template.