### PR TITLE
FIX feature INVOICE_CREDIT_NOTE_STANDALONE doesn't work

### DIFF
--- a/htdocs/compta/facture.php
+++ b/htdocs/compta/facture.php
@@ -2349,7 +2349,8 @@ if ($action == 'create')
 		else
 		{
 			print '<div class="tagtr listofinvoicetype"><div class="tagtd listofinvoicetype">';
-			$tmp='<input type="radio" name="type" id="radio_creditnote" value="0" disabled> ';
+			if (empty($conf->global->INVOICE_CREDIT_NOTE_STANDALONE)) $tmp='<input type="radio" name="type" id="radio_creditnote" value="0" disabled> ';
+			else $tmp='<input type="radio" name="type" id="radio_creditnote" value="2" > ';
 			$text = $tmp.$langs->trans("InvoiceAvoir") . ' ';
 			$text.= '('.$langs->trans("YouMustCreateInvoiceFromThird").') ';
 			$desc = $form->textwithpicto($text, $langs->transnoentities("InvoiceAvoirDesc"), 1, 'help', '', 0, 3);


### PR DESCRIPTION
# Fix
The conf INVOICE_CREDIT_NOTE_STANDALONE don't allow us to create a credit note without origin
