### PR TITLE
problems with additionnal template type

### DIFF
--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1530,8 +1530,10 @@ function getListOfModels($db,$type,$maxfilenamelength=0)
                 include_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 
                 $const=$obj->description;
-                $dirtoscan.=($dirtoscan?',':'').preg_replace('/[\r\n]+/',',',trim($conf->global->$const));
-                $listoffiles=array();
+                //irtoscan.=($dirtoscan?',':'').preg_replace('/[\r\n]+/',',',trim($conf->global->$const));
+                $dirtoscan= preg_replace('/[\r\n]+/',',',trim($conf->global->$const));
+
+		$listoffiles=array();
 
                 // Now we add models found in directories scanned
                 $listofdir=explode(',',$dirtoscan);


### PR DESCRIPTION
If i active my new xml templater, and keep odt, the odt folder is added on folder to scan on my xml path
ex : 
odt folder defined : c:\toto
xml folder defined : c:\tata
then
folder scanned with odt :  c:\toto
folder scanned with odt :  c:\toto,c:\tata
