### PR TITLE
Fix missing column ref on migration for inventory

### DIFF
--- a/htdocs/install/mysql/migration/5.0.0-6.0.0.sql
+++ b/htdocs/install/mysql/migration/5.0.0-6.0.0.sql
@@ -326,3 +326,4 @@ ALTER TABLE llx_facture ADD COLUMN fk_fac_rec_source integer;
 DELETE from llx_c_actioncomm where code in ('AC_PROP','AC_COM','AC_FAC','AC_SHIP','AC_SUP_ORD','AC_SUP_INV') AND id NOT IN (SELECT DISTINCT fk_action FROM llx_actioncomm);
 
 
+ALTER TABLE llx_inventory ADD COLUMN ref varchar(48);


### PR DESCRIPTION
# Fix
missing colum "ref" for inventory table if we use migration
#6818 