### PR TITLE
Fix: Changing the status of an opportunity without closing the project automatically

### DIFF
--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -954,8 +954,7 @@ elseif ($object->id > 0)
     // Change probability from status
     if (! empty($conf->use_javascript_ajax) && ! empty($conf->global->PROJECT_USE_OPPORTUNITIES))
     {
-        $defaultcheckedwhenoppclose=1;
-        if (empty($conf->global->PROJECT_HIDE_TASKS)) $defaultcheckedwhenoppclose=0;
+        $defaultcheckedwhenoppclose=0;
         
         print '<!-- Javascript to manage opportunity status change -->';
         print '<script type="text/javascript" language="javascript">


### PR DESCRIPTION
#6880 