### PR TITLE
Fix can't use search on all extrafields on list

### DIFF
--- a/htdocs/product/inventory/listview.class.php
+++ b/htdocs/product/inventory/listview.class.php
@@ -41,6 +41,11 @@ class Listview
 		$this->totalRow=0;
 		
 		$this->TField=array();
+		
+		require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+		$this->extrafields = new ExtraFields($this->db);
+		$this->extralabels = $this->extrafields->fetch_name_optionals_label('product');
+		$this->search_array_options=$this->extrafields->getOptionalsFromPost($this->extralabels,'','search_');
 	}
 
     /**
@@ -808,6 +813,9 @@ class Listview
 				  	}
 					else
 					{
+						// Overrive search from extrafields
+						// for the type as 'checkbox', 'chkbxlst', 'sellist' we should use code instead of id (example: I declare a 'chkbxlst' to have a link with dictionnairy, I have to extend it with the 'code' instead 'rowid')
+						if (isset($this->extralabels[$field])) $TParam['search'][$field] = $this->extrafields->showInputField($field, $this->search_array_options['search_options_'.$field], '', '', 'search_');
 						$visible = 1;
 					}
 		            

--- a/htdocs/product/list-with-listview.php
+++ b/htdocs/product/list-with-listview.php
@@ -611,7 +611,7 @@ else
     }
     
     //var_dump($arraytitle,$arrayhide);
-    $list=new Listview($db, 'products');
+    $list=new Listview($db, 'product');
     $listHTML = $list->render($sql,array(
     		'list'=>array(
     				'title'=>$texte

--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -840,6 +840,11 @@ if (is_array($extrafields->attribute_label) && count($extrafields->attribute_lab
 				if (in_array($typeofextrafield, array('int', 'double'))) $searchclass='searchnum';
 				print '<input class="flat'.($searchclass?' '.$searchclass:'').'" size="4" type="text" name="search_options_'.$tmpkey.'" value="'.dol_escape_htmltag($search_array_options['search_options_'.$tmpkey]).'">';
 			}
+			else
+			{
+				// for the type as 'checkbox', 'chkbxlst', 'sellist' we should use code instead of id (example: I declare a 'chkbxlst' to have a link with dictionnairy, I have to extend it with the 'code' instead 'rowid')
+				echo $extrafields->showInputField($key, $search_array_options['search_options_'.$key], '', '', 'search_');
+			}
 			print '</td>';
 		}
    }


### PR DESCRIPTION
# Fix search input for all types of extrafields

I think this is the most appropriate if we declare our extrafields correctly

Actually we can search by complexe type as 'chkbxlst' or 'sellist' because the values in database is save like '2,27' (multiple id separate with coma)
But if we declare our extrafields to save a code instead an id like 'CODEA,CODEB' the 'natural_search' function work properly