### PR TITLE
Fix can not update extrafields values

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -175,6 +175,21 @@ if (empty($reshook))
 		$result=$object->update($object->id, $user);
 		if ($result < 0) setEventMessages($object->error, $object->errors, 'errors');
 	}
+	
+	if ($action == 'update_extras') {
+        $object->fetch($id);
+
+        // Fill array 'array_options' with data from update form
+        $extralabels = $extrafields->fetch_name_optionals_label($object->table_element);
+        $ret = $extrafields->setOptionalsFromPost($extralabels, $object, GETPOST('attribute'));
+        if ($ret < 0) $error++;
+        if (! $error)
+        {
+            $result = $object->insertExtraFields();
+            if ($result < 0) $error++;
+        }
+        if ($error) $action = 'edit_extras';
+    }
 }
 
 


### PR DESCRIPTION
# Fix can not update extrafields values
For example I would like update a value of an extrafields from 'customer' tab of customer card (htdocs/comm/card.php)
I can edit the value but the new value is ignored