### PR TITLE
Fix wrong attribute name for loop

### DIFF
--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -825,7 +825,7 @@ function activateModule($value,$withdeps=1)
             {
                 // Activation of modules this module depends on
                 // this->depends may be array('modModule1', 'mmodModule2') or array('always'=>"modModule1", 'FR'=>'modModule2')
-                foreach ($objMod->depend as $key => $modulestring)
+                foreach ($objMod->depends as $key => $modulestring)
                 {
                     if ((! is_numeric($key)) && $key != 'always' && $key != $mysoc->country_code)
                     {


### PR DESCRIPTION
# Fix wrong attribute name for loop
I got this message with PHP 5.6 :
`Warning: Invalid argument supplied for foreach()`
