### PR TITLE
Fix 6910 if conf PROJECT_USE_SEARCH_TO_SELECT is used we got BadFirst…

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -195,6 +195,7 @@ class Expedition extends CommonObject
 		// Clean parameters
 		$this->brouillon = 1;
 		$this->tracking_number = dol_sanitizeFileName($this->tracking_number);
+		if (empty($this->fk_project)) $this->fk_project = 0;
 
 		$this->user = $user;
 

--- a/htdocs/projet/ajax/projects.php
+++ b/htdocs/projet/ajax/projects.php
@@ -61,7 +61,7 @@ $idprod = (! empty($match[0]) ? $match[0] : '');
 if (! GETPOST($htmlname) && ! GETPOST($idprod)) return;
 
 // When used from jQuery, the search term is added as GET param "term".
-$searchkey=(GETPOST($idprod)?GETPOST($idprod):(GETPOST($htmlname)?GETPOST($htmlname):''));
+$searchkey=(!empty($idprod) && GETPOST($idprod)?GETPOST($idprod):(GETPOST($htmlname)?GETPOST($htmlname):''));
 
 $form = new FormProjets($db);
 $arrayresult=$form->select_projects_list($socid, '', $htmlname, 0, 0, 1, $discard_closed, 0, 0, 1, $searchkey);

--- a/htdocs/projet/ajax/projects.php
+++ b/htdocs/projet/ajax/projects.php
@@ -61,7 +61,7 @@ $idprod = (! empty($match[0]) ? $match[0] : '');
 if (! GETPOST($htmlname) && ! GETPOST($idprod)) return;
 
 // When used from jQuery, the search term is added as GET param "term".
-$searchkey=(!empty($idprod) && GETPOST($idprod)?GETPOST($idprod):(GETPOST($htmlname)?GETPOST($htmlname):''));
+$searchkey=((!empty($idprod) && GETPOST($idprod))?GETPOST($idprod):(GETPOST($htmlname)?GETPOST($htmlname):''));
 
 $form = new FormProjets($db);
 $arrayresult=$form->select_projects_list($socid, '', $htmlname, 0, 0, 1, $discard_closed, 0, 0, 1, $searchkey);


### PR DESCRIPTION
# Fix #6910 
The first error with PROJECT_USE_SEARCH_TO_SELECT is the ajax call return BadFirstParameterForGETPOST and we can't select one

Second error is with the select project on create shipment form if we chose project and then remove the value the input hidden of projectid is '' instead '0'
This occure the sql error

