### PR TITLE
FIX 6962 Can't create shipment if no write permission on order

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -73,7 +73,12 @@ $ref=GETPOST('ref','alpha');
 // Security check
 $socid='';
 if ($user->societe_id) $socid=$user->societe_id;
-$result=restrictedArea($user, $origin, $origin_id);
+
+if ($origin == 'expedition') $result=restrictedArea($user, $origin, $id);
+else {
+	$result=restrictedArea($user, 'expedition');
+	if (empty($user->rights->{$origin}->lire) && empty($user->rights->{$origin}->read)) accessforbidden();
+}
 
 $action		= GETPOST('action','alpha');
 $confirm	= GETPOST('confirm','alpha');


### PR DESCRIPTION
# Fix #6962 
If the user has only read permission on order and read/write for shipment, he can click on the button from order to create shipment but he can't pass the first step of the form to create the shipment 
