### PR TITLE
Fix SPEC #7013 : use database type "numeric" to store monetary values

### DIFF
--- a/htdocs/install/mysql/migration/6.0.0-7.0.0.sql
+++ b/htdocs/install/mysql/migration/6.0.0-7.0.0.sql
@@ -1,0 +1,64 @@
+--
+-- Be carefull to requests order.
+-- This file must be loaded by calling /install/index.php page
+-- when current version is 6.0.0 or higher.
+--
+-- To rename a table:       ALTER TABLE llx_table RENAME TO llx_table_new;
+-- To add a column:         ALTER TABLE llx_table ADD COLUMN newcol varchar(60) NOT NULL DEFAULT '0' AFTER existingcol;
+-- To rename a column:      ALTER TABLE llx_table CHANGE COLUMN oldname newname varchar(60);
+-- To drop a column:        ALTER TABLE llx_table DROP COLUMN oldname;
+-- To change type of field: ALTER TABLE llx_table MODIFY COLUMN name varchar(60);
+-- To drop a foreign key:   ALTER TABLE llx_table DROP FOREIGN KEY fk_name;
+-- To drop an index:        -- VMYSQL4.0 DROP INDEX nomindex on llx_table
+-- To drop an index:        -- VPGSQL8.0 DROP INDEX nomindex
+-- To restrict request to Mysql version x.y minimum use -- VMYSQLx.y
+-- To restrict request to Pgsql version x.y minimum use -- VPGSQLx.y
+-- To make pk to be auto increment (mysql):    -- VMYSQL4.3 ALTER TABLE llx_c_shipment_mode CHANGE COLUMN rowid rowid INTEGER NOT NULL AUTO_INCREMENT;
+-- To make pk to be auto increment (postgres): -- VPGSQL8.2 NOT POSSIBLE. MUST DELETE/CREATE TABLE
+-- To set a field as NULL:                     -- VMYSQL4.3 ALTER TABLE llx_table MODIFY COLUMN name varchar(60) NULL;
+-- To set a field as NULL:                     -- VPGSQL8.2 ALTER TABLE llx_table ALTER COLUMN name DROP NOT NULL;
+-- To set a field as NOT NULL:                 -- VMYSQL4.3 ALTER TABLE llx_table MODIFY COLUMN name varchar(60) NOT NULL;
+-- To set a field as NOT NULL:                 -- VPGSQL8.2 ALTER TABLE llx_table ALTER COLUMN name SET NOT NULL;
+-- To set a field as default NULL:             -- VPGSQL8.2 ALTER TABLE llx_table ALTER COLUMN name SET DEFAULT NULL;
+-- Note: fields with type BLOB/TEXT can't have default value.
+-- -- VPGSQL8.2 DELETE FROM llx_usergroup_user      WHERE fk_user      NOT IN (SELECT rowid from llx_user);
+-- -- VMYSQL4.1 DELETE FROM llx_usergroup_user      WHERE fk_usergroup NOT IN (SELECT rowid from llx_usergroup);
+
+
+-- Clean corrupted values for tms
+-- VMYSQL4.1 SET sql_mode = 'ALLOW_INVALID_DATES';
+-- VMYSQL4.1 update llx_opensurvey_sondage set tms = date_fin where DATE(STR_TO_DATE(tms, '%Y-%m-%d')) IS NULL;
+-- VMYSQL4.1 SET sql_mode = 'NO_ZERO_DATE';
+-- VMYSQL4.1 update llx_opensurvey_sondage set tms = date_fin where DATE(STR_TO_DATE(tms, '%Y-%m-%d')) IS NULL;
+-- Remove default not null on date_fin
+-- VMYSQL4.3 ALTER TABLE llx_opensurvey_sondage MODIFY COLUMN date_fin DATETIME NULL DEFAULT NULL;
+-- VPGSQL8.2 ALTER TABLE llx_opensurvey_sondage ALTER COLUMN date_fin DROP NOT NULL;
+
+-- Move real to numeric for more precision for storing monetary amounts (no rouding)
+-- https://wiki.dolibarr.org/index.php/Langages_et_normes#Structure_des_tables_et_champs
+ALTER TABLE llx_accounting_bookkeeping MODIFY COLUMN debit numeric(24,8);
+ALTER TABLE llx_accounting_bookkeeping MODIFY COLUMN credit numeric(24,8);
+ALTER TABLE llx_accounting_bookkeeping MODIFY COLUMN montant numeric(24,8);
+ALTER TABLE llx_accounting_bookkeeping MODIFY COLUMN multicurrency_amount numeric(24,8);
+ALTER TABLE llx_blockedlog MODIFY COLUMN amounts numeric(24,8);
+ALTER TABLE llx_chargessociales MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_commande MODIFY COLUMN amount_ht numeric(24,8);
+ALTER TABLE llx_commande_fournisseur MODIFY COLUMN amount_ht numeric(24,8);
+ALTER TABLE llx_don MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_loan_schedule MODIFY COLUMN amount_capital numeric(24,8);
+ALTER TABLE llx_loan_schedule MODIFY COLUMN amount_insurance numeric(24,8);
+ALTER TABLE llx_loan_schedule MODIFY COLUMN amount_interest numeric(24,8);
+ALTER TABLE llx_paiementcharge MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_paiementfourn MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_payment_donation MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_payment_expensereport MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_payment_loan MODIFY COLUMN amount_capital numeric(24,8);
+ALTER TABLE llx_payment_loan MODIFY COLUMN amount_insurance numeric(24,8);
+ALTER TABLE llx_payment_loan MODIFY COLUMN amount_interest numeric(24,8);
+ALTER TABLE llx_payment_salary MODIFY COLUMN salary numeric(24,8);
+ALTER TABLE llx_payment_salary MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_prelevement_bons MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_prelevement_facture_demande MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_prelevement_lignes MODIFY COLUMN amount numeric(24,8);
+ALTER TABLE llx_societe MODIFY COLUMN capital numeric(24,8);
+ALTER TABLE llx_tva MODIFY COLUMN amount numeric(24,8);

--- a/htdocs/install/mysql/tables/llx_accounting_bookkeeping.sql
+++ b/htdocs/install/mysql/tables/llx_accounting_bookkeeping.sql
@@ -26,17 +26,17 @@ CREATE TABLE llx_accounting_bookkeeping
   doc_ref               varchar(300) NOT NULL,		-- 					| facture_client/reglement_client/... reference number
   fk_doc                integer NOT NULL,			-- 					| facture_client/reglement_client/... rowid
   fk_docdet             integer NOT NULL,			-- 					| facture_client/reglement_client/... line rowid
-  thirdparty_code       varchar(32),                -- Third party code (customer or supplier) when record is saved (may help debug) 
+  thirdparty_code       varchar(32),				-- Third party code (customer or supplier) when record is saved (may help debug) 
   subledger_account     varchar(32),				-- FEC:CompAuxNum	| account number of subledger account
   subledger_label       varchar(255),				-- FEC:CompAuxLib	| label of subledger account
   numero_compte         varchar(32) NOT NULL,		-- FEC:CompteNum	| account number
   label_compte          varchar(255) NOT NULL,		-- FEC:CompteLib	| label of account
   label_operation       varchar(255),				-- FEC:EcritureLib	| label of the operation
-  debit                 double NOT NULL,			-- FEC:Debit
-  credit                double NOT NULL,			-- FEC:Credit
-  montant               double NOT NULL,			-- FEC:Montant (Not necessary)
+  debit                 numeric(24,8) NOT NULL,		-- FEC:Debit
+  credit                numeric(24,8) NOT NULL,		-- FEC:Credit
+  montant               numeric(24,8) NOT NULL,		-- FEC:Montant (Not necessary)
   sens                  varchar(1) DEFAULT NULL,	-- FEC:Sens (Not necessary)
-  multicurrency_amount  double,						-- FEC:Montantdevise
+  multicurrency_amount  numeric(24,8),				-- FEC:Montantdevise
   multicurrency_code    varchar(255),				-- FEC:Idevise
   lettering_code        varchar(255),				-- FEC:EcritureLet
   date_lettering        datetime,					-- FEC:DateLet

--- a/htdocs/install/mysql/tables/llx_blockedlog.sql
+++ b/htdocs/install/mysql/tables/llx_blockedlog.sql
@@ -4,7 +4,7 @@ CREATE TABLE llx_blockedlog
 	rowid integer AUTO_INCREMENT PRIMARY KEY, 
 	tms	timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	action varchar(50), 
-	amounts real NOT NULL, 
+	amounts numeric(24,8) NOT NULL, 
 	signature varchar(100) NOT NULL, 
 	signature_line varchar(100) NOT NULL, 
 	element varchar(50), 

--- a/htdocs/install/mysql/tables/llx_chargesociales.sql
+++ b/htdocs/install/mysql/tables/llx_chargesociales.sql
@@ -34,7 +34,7 @@ create table llx_chargesociales
   fk_type			integer NOT NULL,
   fk_account		integer,                       -- bank account
   fk_mode_reglement	integer,                -- mode de reglement
-  amount			real     default 0 NOT NULL,
+  amount			numeric(24,8) default 0 NOT NULL,
   paye				smallint default 0 NOT NULL,
   periode			date,
   fk_projet			integer DEFAULT NULL,

--- a/htdocs/install/mysql/tables/llx_commande.sql
+++ b/htdocs/install/mysql/tables/llx_commande.sql
@@ -42,7 +42,7 @@ create table llx_commande
   fk_user_cloture		integer,						-- user closing
   source				smallint,						-- not used, except by setting this to 42 for orders coming for replenishment and 0 in other case ?
   fk_statut				smallint  default 0,
-  amount_ht				real      default 0,
+  amount_ht				numeric(24,8)  default 0,
   remise_percent		real      default 0,
   remise_absolue		real      default 0,
   remise				real      default 0,

--- a/htdocs/install/mysql/tables/llx_commande_fournisseur.sql
+++ b/htdocs/install/mysql/tables/llx_commande_fournisseur.sql
@@ -46,7 +46,7 @@ create table llx_commande_fournisseur
   source				smallint NOT NULL,			-- not used, except by setting this to 42 for orders coming for replenishment and 0 in other case ?
   fk_statut				smallint  default 0,
   billed				smallint  default 0,
-  amount_ht				real      default 0,
+  amount_ht				numeric(24,8)  default 0,
   remise_percent		real      default 0,
   remise				real      default 0,
   tva					double(24,8)      default 0,

--- a/htdocs/install/mysql/tables/llx_don.sql
+++ b/htdocs/install/mysql/tables/llx_don.sql
@@ -28,7 +28,7 @@ create table llx_don
   tms             timestamp,
   fk_statut       smallint NOT NULL DEFAULT 0,  -- Status of donation promise or validate
   datedon         datetime,                     -- Date of the donation/promise
-  amount          real DEFAULT 0,
+  amount          numeric(24,8) DEFAULT 0,
   fk_payment      integer,
   paid            smallint default 0 NOT NULL,
   firstname       varchar(50),

--- a/htdocs/install/mysql/tables/llx_loan_schedule.sql
+++ b/htdocs/install/mysql/tables/llx_loan_schedule.sql
@@ -24,9 +24,9 @@ create table llx_loan_schedule
   datec				datetime,         -- creation date
   tms				timestamp,
   datep				datetime,         -- payment date
-  amount_capital	real DEFAULT 0,
-  amount_insurance	real DEFAULT 0,
-  amount_interest	real DEFAULT 0,
+  amount_capital	numeric(24,8) DEFAULT 0,
+  amount_insurance	numeric(24,8) DEFAULT 0,
+  amount_interest	numeric(24,8) DEFAULT 0,
   fk_typepayment	integer NOT NULL,
   num_payment		varchar(50),
   note_private      text,

--- a/htdocs/install/mysql/tables/llx_paiementcharge.sql
+++ b/htdocs/install/mysql/tables/llx_paiementcharge.sql
@@ -23,7 +23,7 @@ create table llx_paiementcharge
   datec           datetime,           -- date de creation
   tms             timestamp,
   datep           datetime,           -- payment date
-  amount          real DEFAULT 0,
+  amount          numeric(24,8) DEFAULT 0,
   fk_typepaiement integer NOT NULL,
   num_paiement    varchar(50),
   note            text,

--- a/htdocs/install/mysql/tables/llx_paiementfourn.sql
+++ b/htdocs/install/mysql/tables/llx_paiementfourn.sql
@@ -25,7 +25,7 @@ create table llx_paiementfourn
   tms               timestamp,
   datec             datetime,          -- date de creation de l'enregistrement
   datep             datetime,          -- date de paiement
-  amount            real DEFAULT 0,    -- montant
+  amount            numeric(24,8) DEFAULT 0,      -- montant
   multicurrency_amount double(24,8) DEFAULT 0,    -- multicurrency amount
   fk_user_author    integer,           -- auteur
   fk_paiement       integer NOT NULL,  -- moyen de paiement

--- a/htdocs/install/mysql/tables/llx_payment_donation.sql
+++ b/htdocs/install/mysql/tables/llx_payment_donation.sql
@@ -23,7 +23,7 @@ create table llx_payment_donation
   datec           datetime,           -- date de creation
   tms             timestamp,
   datep           datetime,           -- payment date
-  amount          real DEFAULT 0,
+  amount          numeric(24,8) DEFAULT 0,
   fk_typepayment  integer NOT NULL,
   num_payment     varchar(50),
   note            text,

--- a/htdocs/install/mysql/tables/llx_payment_expensereport.sql
+++ b/htdocs/install/mysql/tables/llx_payment_expensereport.sql
@@ -23,7 +23,7 @@ create table llx_payment_expensereport
   datec                   datetime,           -- date de creation
   tms                     timestamp,
   datep                   datetime,           -- payment date
-  amount                  real DEFAULT 0,
+  amount                  numeric(24,8) DEFAULT 0,
   fk_typepayment          integer NOT NULL,
   num_payment             varchar(50),
   note                    text,

--- a/htdocs/install/mysql/tables/llx_payment_loan.sql
+++ b/htdocs/install/mysql/tables/llx_payment_loan.sql
@@ -24,9 +24,9 @@ create table llx_payment_loan
   datec				datetime,         -- creation date
   tms				timestamp,
   datep				datetime,         -- payment date
-  amount_capital	real DEFAULT 0,
-  amount_insurance	real DEFAULT 0,
-  amount_interest	real DEFAULT 0,
+  amount_capital	numeric(24,8) DEFAULT 0,
+  amount_insurance	numeric(24,8) DEFAULT 0,
+  amount_interest	numeric(24,8) DEFAULT 0,
   fk_typepayment	integer NOT NULL,
   num_payment		varchar(50),
   note_private      text,

--- a/htdocs/install/mysql/tables/llx_payment_salary.sql
+++ b/htdocs/install/mysql/tables/llx_payment_salary.sql
@@ -24,8 +24,8 @@ create table llx_payment_salary
   fk_user         integer NOT NULL,
   datep           date,                       -- date de paiement
   datev           date,                       -- date de valeur (this field should not be here, only into bank tables)
-  salary          real,						  -- salary of user when payment was done
-  amount          real NOT NULL DEFAULT 0,
+  salary          numeric(24,8),              -- salary of user when payment was done
+  amount          numeric(24,8) NOT NULL DEFAULT 0,
   fk_typepayment  integer NOT NULL,
   num_payment     varchar(50),				  -- ref
   label           varchar(255),

--- a/htdocs/install/mysql/tables/llx_prelevement_bons.sql
+++ b/htdocs/install/mysql/tables/llx_prelevement_bons.sql
@@ -29,7 +29,7 @@ create table llx_prelevement_bons
   ref            varchar(12),        -- reference
   entity         integer DEFAULT 1 NOT NULL, -- multi company id
   datec          datetime,           -- date de creation
-  amount         real DEFAULT 0,     -- montant total du prelevement
+  amount         numeric(24,8) DEFAULT 0,    -- montant total du prelevement
   statut         smallint DEFAULT 0, -- statut
   credite        smallint DEFAULT 0, -- indique si le prelevement a ete credite
   note           text,

--- a/htdocs/install/mysql/tables/llx_prelevement_facture_demande.sql
+++ b/htdocs/install/mysql/tables/llx_prelevement_facture_demande.sql
@@ -21,7 +21,7 @@ create table llx_prelevement_facture_demande
 (
   rowid               integer AUTO_INCREMENT PRIMARY KEY,
   fk_facture          integer NOT NULL,
-  amount              real NOT NULL,
+  amount              numeric(24,8) NOT NULL,
   date_demande        datetime NOT NULL,
   traite              smallint DEFAULT 0,
   date_traite         datetime,

--- a/htdocs/install/mysql/tables/llx_prelevement_lignes.sql
+++ b/htdocs/install/mysql/tables/llx_prelevement_lignes.sql
@@ -24,7 +24,7 @@ create table llx_prelevement_lignes
   statut              smallint DEFAULT 0,
 
   client_nom          varchar(255),
-  amount              real DEFAULT 0,
+  amount              numeric(24,8) DEFAULT 0,
   code_banque         varchar(128),
   code_guichet        varchar(6),
   number              varchar(255),

--- a/htdocs/install/mysql/tables/llx_societe.sql
+++ b/htdocs/install/mysql/tables/llx_societe.sql
@@ -64,7 +64,7 @@ create table llx_societe
   idprof5                  varchar(128),                         		-- IDProf5: nu for france
   idprof6                  varchar(128),                         		-- IDProf6: nu for france
   tva_intra                varchar(20),                         		-- tva
-  capital                  real,                                		-- capital de la societe
+  capital                  numeric(24,8),                       		-- capital de la societe
   fk_stcomm                integer        DEFAULT 0 NOT NULL,      	-- commercial statut
   note_private             text,                                		--
   note_public              text,                                        --

--- a/htdocs/install/mysql/tables/llx_tva.sql
+++ b/htdocs/install/mysql/tables/llx_tva.sql
@@ -24,11 +24,11 @@ create table llx_tva
   datec           datetime,                   -- Create date
   datep           date,                       -- date de paiement
   datev           date,                       -- date de valeur
-  amount          real NOT NULL DEFAULT 0,
+  amount          numeric(24,8) NOT NULL DEFAULT 0,
   fk_typepayment  integer NULL,
   num_payment     varchar(50),
   label           varchar(255),
-  entity          integer DEFAULT 1 NOT NULL,	-- multi company id
+  entity          integer DEFAULT 1 NOT NULL, -- multi company id
   note            text,
   fk_bank         integer,  
   fk_user_creat   integer,                    -- utilisateur who create record


### PR DESCRIPTION
[https://wiki.dolibarr.org/index.php/Langages_et_normes#Structure_des_tables_et_champs](https://wiki.dolibarr.org/index.php/Langages_et_normes#Structure_des_tables_et_champs)