### PR TITLE
Fix: User id correction on holiday request

### DIFF
--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -39,7 +39,6 @@ require_once DOL_DOCUMENT_ROOT.'/holiday/common.inc.php';
 $myparam = GETPOST("myparam");
 $action=GETPOST('action', 'alpha');
 $id=GETPOST('id', 'int');
-$userID = GETPOST('userID')?GETPOST('userID'):$user->id;
 
 // Protection if external user
 if ($user->societe_id > 0) accessforbidden();
@@ -57,8 +56,8 @@ if ($action == 'create')
 	$cp = new Holiday($db);
 
     // If no right to create a request
-    $userid = GETPOST('userid');
-    if (($userid == $user->id && empty($user->rights->holiday->write)) || ($userid != $user->id && empty($user->rights->holiday->write_all)))
+    $fuserid = GETPOST('fuserid');
+    if (($fuserid == $user->id && empty($user->rights->holiday->write)) || ($fuserid != $user->id && empty($user->rights->holiday->write_all)))
     {
     	$error++;
     	setEventMessages($langs->trans('CantCreateCP'), null, 'errors');
@@ -112,7 +111,7 @@ if ($action == 'create')
 	    }
 
 	    // Check if there is already holiday for this period
-	    $verifCP = $cp->verifDateHolidayCP($userid, $date_debut, $date_fin, $halfday);
+	    $verifCP = $cp->verifDateHolidayCP($fuserid, $date_debut, $date_fin, $halfday);
 	    if (! $verifCP)
 	    {
 	        header('Location: '.$_SERVER["PHP_SELF"].'?action=request&error=alreadyCP');
@@ -140,7 +139,7 @@ if ($action == 'create')
 
 	    if (! $error)
 	    {
-    	    $cp->fk_user = $userid;
+    	    $cp->fk_user = $fuserid;
     	    $cp->description = $description;
     	    $cp->date_debut = $date_debut;
     	    $cp->date_fin = $date_fin;
@@ -682,7 +681,7 @@ llxHeader(array(),$langs->trans('CPTitreMenu'));
 if (empty($id) || $action == 'add' || $action == 'request' || $action == 'create')
 {
     // Si l'utilisateur n'a pas le droit de faire une demande
-    if (($userid == $user->id && empty($user->rights->holiday->write)) || ($userid != $user->id && empty($user->rights->holiday->write_all)))
+    if (($fuserid == $user->id && empty($user->rights->holiday->write)) || ($fuserid != $user->id && empty($user->rights->holiday->write_all)))
     {
         $errors[]=$langs->trans('CantCreateCP');
     }
@@ -762,7 +761,6 @@ if (empty($id) || $action == 'add' || $action == 'request' || $action == 'create
         // Formulaire de demande
         print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'" onsubmit="return valider()" name="demandeCP">'."\n";
         print '<input type="hidden" name="action" value="create" />'."\n";
-        print '<input type="hidden" name="userID" value="'.$userID.'" />'."\n";
 
         dol_fiche_head();
 
@@ -793,10 +791,10 @@ if (empty($id) || $action == 'add' || $action == 'request' || $action == 'create
         print '<td>';
         if (empty($user->rights->holiday->write_all))
         {
-        	print $form->select_dolusers($userid, 'useridbis', 0, '', 1, '', '', 0, 0, 0, '', 0, '', 'maxwidth300');
-        	print '<input type="hidden" name="userid" value="'.$userid.'">';
+        	print $form->select_dolusers($fuserid, 'useridbis', 0, '', 1, '', '', 0, 0, 0, '', 0, '', 'maxwidth300');
+        	print '<input type="hidden" name="fuserid" value="'.$fuserid.'">';
         }
-        else print $form->select_dolusers(GETPOST('userid')?GETPOST('userid'):$user->id,'userid',0,'',0);
+        else print $form->select_dolusers(GETPOST('fuserid')?GETPOST('fuserid'):$user->id,'fuserid',0,'',0);
         print '</td>';
         print '</tr>';
 

--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2012-2015	Laurent Destailleur	<eldy@users.sourceforge.net>
  * Copyright (C) 2012-2016	Regis Houssin		<regis.houssin@capnetworks.com>
  * Copyright (C) 2013		Juanjo Menent		<jmenent@2byte.es>
- * Copyright (C) 2014		Ferran Marcet		<fmarcet@2byte.es>
+ * Copyright (C) 2014-2017	Ferran Marcet		<fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,7 +39,7 @@ require_once DOL_DOCUMENT_ROOT.'/holiday/common.inc.php';
 $myparam = GETPOST("myparam");
 $action=GETPOST('action', 'alpha');
 $id=GETPOST('id', 'int');
-$userid = GETPOST('userid')?GETPOST('userid'):$user->id;
+$userID = GETPOST('userID')?GETPOST('userID'):$user->id;
 
 // Protection if external user
 if ($user->societe_id > 0) accessforbidden();
@@ -57,6 +57,7 @@ if ($action == 'create')
 	$cp = new Holiday($db);
 
     // If no right to create a request
+    $userid = GETPOST('userid');
     if (($userid == $user->id && empty($user->rights->holiday->write)) || ($userid != $user->id && empty($user->rights->holiday->write_all)))
     {
     	$error++;
@@ -82,7 +83,6 @@ if ($action == 'create')
 
 	    $valideur = GETPOST('valideur');
 	    $description = trim(GETPOST('description'));
-	    $userID = GETPOST('userID');
 
     	// If no type
 	    if ($type <= 0)
@@ -112,7 +112,7 @@ if ($action == 'create')
 	    }
 
 	    // Check if there is already holiday for this period
-	    $verifCP = $cp->verifDateHolidayCP($userID, $date_debut, $date_fin, $halfday);
+	    $verifCP = $cp->verifDateHolidayCP($userid, $date_debut, $date_fin, $halfday);
 	    if (! $verifCP)
 	    {
 	        header('Location: '.$_SERVER["PHP_SELF"].'?action=request&error=alreadyCP');
@@ -762,7 +762,7 @@ if (empty($id) || $action == 'add' || $action == 'request' || $action == 'create
         // Formulaire de demande
         print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'" onsubmit="return valider()" name="demandeCP">'."\n";
         print '<input type="hidden" name="action" value="create" />'."\n";
-        print '<input type="hidden" name="userID" value="'.$userid.'" />'."\n";
+        print '<input type="hidden" name="userID" value="'.$userID.'" />'."\n";
 
         dol_fiche_head();
 


### PR DESCRIPTION
Fix: The user who manages the request and the user requesting the vacation was not done correctly. When comparing if a user had already requested vacation in a period, it checks the vacation of the user who was doing the management instead of the user who asked for the vacation.

