### PR TITLE
Add missing end tag `form` into fichinter setup

### DIFF
--- a/htdocs/admin/fichinter.php
+++ b/htdocs/admin/fichinter.php
@@ -559,6 +559,7 @@ print '/>';
 print '</td><td align="right">';
 print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 print "</td></tr>\n";
+print '</form>';
 // Use services duration
 print '<form action="' . $_SERVER["PHP_SELF"] . '" method="post">';
 print '<input type="hidden" name="token" value="' . $_SESSION['newtoken'] . '">';


### PR DESCRIPTION


# Fix #7058 

The setup for option `FICHINTER_PRINT_PRODUCTS` was broken.