### PR TITLE
FIX status in linkedobject block for order, propal etc.

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -223,7 +223,8 @@ abstract class CommonInvoice extends CommonObject
 	 */
 	function getLibStatut($mode=0,$alreadypaid=-1)
 	{
-		return $this->LibStatut($this->paye,$this->statut,$mode,$alreadypaid,$this->type);
+		$paiement = $this->getSommePaiement();
+		return $this->LibStatut($this->paye,$this->statut,$mode,$paiement,$this->type);
 	}
 
 	/**


### PR DESCRIPTION
The problem come from partial paid status. This status need a payment value to choose the right status else it will appear like an abandoned invoice.