### PR TITLE
FIX 7109 - class name already exist for customer payment

### DIFF
--- a/htdocs/core/modules/supplier_payment/mod_supplier_payment_brodator.php
+++ b/htdocs/core/modules/supplier_payment/mod_supplier_payment_brodator.php
@@ -28,7 +28,7 @@ require_once DOL_DOCUMENT_ROOT .'/core/modules/supplier_payment/modules_supplier
 /**
  *	Class to manage customer payment numbering rules Ant
  */
-class mod_supplier_payment_brodator extends ModeleNumRefPayments
+class mod_supplier_payment_brodator extends ModeleNumRefSupplierPayments
 {
 	var $version='dolibarr';		// 'development', 'experimental', 'dolibarr'
 	var $error = '';

--- a/htdocs/core/modules/supplier_payment/mod_supplier_payment_bronan.php
+++ b/htdocs/core/modules/supplier_payment/mod_supplier_payment_bronan.php
@@ -27,7 +27,7 @@ require_once DOL_DOCUMENT_ROOT .'/core/modules/supplier_payment/modules_supplier
 /**
  *	Class to manage customer payment numbering rules Cicada
  */
-class mod_supplier_payment_bronan extends ModeleNumRefPayments
+class mod_supplier_payment_bronan extends ModeleNumRefSupplierPayments
 {
 	var $version='dolibarr';		// 'development', 'experimental', 'dolibarr'
 	var $prefix='SPAY';

--- a/htdocs/core/modules/supplier_payment/modules_supplier_payment.php
+++ b/htdocs/core/modules/supplier_payment/modules_supplier_payment.php
@@ -17,11 +17,11 @@
  */
 
 /**
- *  \class      ModeleNumRefPayments
+ *  \class      ModeleNumRefSupplierPayments
  *  \brief      Payment numbering references mother class
  */
 
-abstract class ModeleNumRefPayments
+abstract class ModeleNumRefSupplierPayments
 {
 	var $error='';
 


### PR DESCRIPTION
# Fix #7109 
I forgot to rename the class name when integrating
