### PR TITLE
Fix: Trusty become default linux the July 18th 2017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # from Dolibarr GitHub repository.
 # For syntax, see http://about.travis-ci.org/docs/user/languages/php/
 
+dist: precise
 sudo: required
 
 language: php


### PR DESCRIPTION
https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming