### PR TITLE
Fix lost search value in list if come from thirdparty card

### DIFF
--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -353,6 +353,7 @@ if ($resql)
 		$soc = new Societe($db);
 		$soc->fetch($socid);
 		$title = $langs->trans('ListOfProposals') . ' - '.$soc->name;
+		if (empty($search_societe)) $search_societe = $soc->name;
 	}
 	else
 	{

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -578,6 +578,7 @@ if ($resql)
 		$soc = new Societe($db);
 		$soc->fetch($socid);
 		$title = $langs->trans('ListOfOrders') . ' - '.$soc->name;
+		if (empty($search_company)) $search_company = $soc->name;
 	}
 	else
 	{

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -423,6 +423,7 @@ if ($resql)
     {
         $soc = new Societe($db);
         $soc->fetch($socid);
+		if (empty($search_societe)) $search_societe = $soc->name;
     }
 
     $param='&socid='.$socid;

--- a/htdocs/contrat/list.php
+++ b/htdocs/contrat/list.php
@@ -306,6 +306,13 @@ if ($resql)
 
     $arrayofselected=is_array($toselect)?$toselect:array();
     
+	if ($socid)
+	{
+		$soc = new Societe($db);
+		$soc->fetch($socid);
+		if (empty($search_name)) $search_name = $soc->name;
+	}
+	
     $param='';
     if (! empty($contextpage) && $contextpage != $_SERVER["PHP_SELF"]) $param.='&contextpage='.$contextpage;
     if ($limit > 0 && $limit != $conf->liste_limit) $param.='&limit='.$limit;

--- a/htdocs/contrat/list.php
+++ b/htdocs/contrat/list.php
@@ -306,7 +306,7 @@ if ($resql)
 
     $arrayofselected=is_array($toselect)?$toselect:array();
     
-	if ($socid)
+	if ($socid > 0)
 	{
 		$soc = new Societe($db);
 		$soc->fetch($socid);

--- a/htdocs/fichinter/list.php
+++ b/htdocs/fichinter/list.php
@@ -212,7 +212,7 @@ if ($result)
 {
 	$num = $db->num_rows($result);
 	
-	if ($socid)
+	if ($socid > 0)
 	{
 		$soc = new Societe($db);
 		$soc->fetch($socid);

--- a/htdocs/fichinter/list.php
+++ b/htdocs/fichinter/list.php
@@ -211,7 +211,14 @@ $result=$db->query($sql);
 if ($result)
 {
 	$num = $db->num_rows($result);
-
+	
+	if ($socid)
+	{
+		$soc = new Societe($db);
+		$soc->fetch($socid);
+		if (empty($search_company)) $search_company = $soc->name;
+	}
+	
 	$param='';
     if (! empty($contextpage) && $contextpage != $_SERVER["PHP_SELF"]) $param.='&contextpage='.$contextpage;
 	if ($limit > 0 && $limit != $conf->liste_limit) $param.='&limit='.$limit;

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -394,6 +394,7 @@ if ($resql)
 	{
 		$soc = new Societe($db);
 		$soc->fetch($socid);
+		if (empty($search_societe)) $search_societe = $soc->name;
 	}
 
 	$param='&socid='.$socid;


### PR DESCRIPTION
# Fix
If we go to the list of proposal/order/invoice ... from thirdparty card to show the linked documents we loose the associate company if we add new filter

