### PR TITLE
Fix : creating user from member was failing due to column size difference

### DIFF
--- a/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
+++ b/htdocs/install/mysql/migration/3.9.0-4.0.0.sql
@@ -545,3 +545,5 @@ INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (178, 
 -- VPGSQL8.2 ALTER TABLE llx_establishment ALTER COLUMN fk_user_mod DROP NOT NULL;
 
 ALTER TABLE llx_multicurrency_rate ADD COLUMN entity integer DEFAULT 1;
+
+ALTER TABLE llx_user MODIFY COLUMN login varchar(50);

--- a/htdocs/install/mysql/tables/llx_user.sql
+++ b/htdocs/install/mysql/tables/llx_user.sql
@@ -33,7 +33,7 @@ create table llx_user
   tms               timestamp,
   fk_user_creat     integer,
   fk_user_modif     integer,
-  login             varchar(24) NOT NULL,
+  login             varchar(50) NOT NULL,
   pass              varchar(128),
   pass_crypted      varchar(128),
   pass_temp         varchar(128),			    -- temporary password when asked for forget password


### PR DESCRIPTION
login in member table was varchar 50
login in user table was varchar 24
so when creating a user from a member card with a login longer than 24, sql was failing