### PR TITLE
FIX calculate correct remain to pay for planned bank transactions

### DIFF
--- a/htdocs/compta/bank/treso.php
+++ b/htdocs/compta/bank/treso.php
@@ -282,6 +282,8 @@ if ($_REQUEST["account"] || $_REQUEST["ref"])
 				$refcomp=$societestatic->getNomUrl(1,'',24);
 
 				$paiement = $facturestatic->getSommePaiement();	// Payment already done
+				$paiement+= $facturestatic->getSumDepositsUsed();
+				$paiement+= $facturestatic->getSumCreditNotesUsed();
 			}
 			if ($obj->family == 'social_contribution')
 			{


### PR DESCRIPTION
Deposits and credit notes associated to an invoice (instead of being included as a discount line, like when hidden conf FACTURE_DEPOSITS_ARE_JUST_PAYMENTS is activated) were not included in the calculation.