### PR TITLE
Fix: Correction in the calculation of the next week

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2004-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2011 Regis Houssin        <regis.houssin@capnetworks.com>
  * Copyright (C) 2011-2015 Juanjo Menent        <jmenent@2byte.es>
+ * Copyright (C) 2017      Ferran Marcet        <fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -407,7 +408,7 @@ function dol_get_next_week($day, $week, $month, $year)
 {
 	$tmparray = dol_get_first_day_week($day, $month, $year);
 
-	$time=dol_mktime(12,0,0,$month,$tmparray['first_day'],$year,1,0);
+	$time=dol_mktime(12,0,0,$tmparray['first_month'],$tmparray['first_day'],$tmparray['first_year'],1,0);
 	$time+=24*60*60*7;
 	$tmparray=dol_getdate($time,true);
 


### PR DESCRIPTION
The date of next week is not being calculated correctly. For today's case, call the function dol_get_first_day_week () which returns 07/31/2017, but then at the time of making the calculation uses the current month calculating from 08/31/2017 with what the final result is 09/09/2017