### PR TITLE
FIX: printFieldListValue Hook, $obj never set.

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -956,7 +956,7 @@ if (($id > 0 || ! empty($ref)) || $projectidforalltimes > 0)
             }
 
 			// Fields from hook
-			$parameters=array('arrayfields'=>$arrayfields, 'obj'=>$obj);
+			$parameters=array('arrayfields'=>$arrayfields, 'obj'=>$task_time);
 			$reshook=$hookmanager->executeHooks('printFieldListValue',$parameters);    // Note that $action and $object may have been modified by hook
 			print $hookmanager->resPrint;
 


### PR DESCRIPTION
Replaced $obj by $task_time, that should be the useful object.
