### PR TITLE
FIX resource hooks

### DIFF
--- a/htdocs/resource/add.php
+++ b/htdocs/resource/add.php
@@ -66,63 +66,71 @@ $extrafields = new ExtraFields($db);
 // fetch optionals attributes and labels
 $extralabels=$extrafields->fetch_name_optionals_label($object->table_element);
 
-if ($action == 'confirm_add_resource')
+$hookmanager->initHooks(array('resource_card_add','globalcard'));
+$parameters=array();
+$reshook=$hookmanager->executeHooks('doActions',$parameters,$object,$action);    // Note that $action and $object may have been modified by some hooks
+if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+
+if (empty($reshook))
 {
-        if (! $cancel)
-        {
-                $error='';
 
-                $ref=GETPOST('ref','alpha');
-                $description=GETPOST('description','alpha');
-                $fk_code_type_resource=GETPOST('fk_code_type_resource','alpha');
-
-                if (empty($ref))
-                {
-                        $mesg=$langs->trans("ErrorFieldRequired",$langs->transnoentities("Ref"));
-                        setEventMessages($mesg, null, 'errors');
-                        $error++;
-                }
-
-                if (! $error)
-                {
-                        $object=new Dolresource($db);
-                        $object->ref=$ref;
-                        $object->description=$description;
-                        $object->fk_code_type_resource=$fk_code_type_resource;
-
-                        // Fill array 'array_options' with data from add form
-                        $ret = $extrafields->setOptionalsFromPost($extralabels, $object);
-                        if ($ret < 0) {
-                        	$error ++;
-                        }
-
-                        $result=$object->create($user);
-                        if ($result > 0)
-                        {
-                                // Creation OK
-                                $db->commit();
-                                setEventMessages($langs->trans('ResourceCreatedWithSuccess'), null, 'mesgs');
-                                Header("Location: card.php?id=" . $object->id);
-                                return;
-                        }
-                        else
-                        {
-                                // Creation KO
-                                setEventMessages($object->error, $object->errors, 'errors');
-                                $action = '';
-                        }
-                }
-                else
-                {
-                        $action = '';
-                }
-        }
-        else
-        {
-                Header("Location: list.php");
-        }
+	if ($action == 'confirm_add_resource')
+	{
+	        if (! $cancel)
+	        {
+	                $error='';
+	
+	                $ref=GETPOST('ref','alpha');
+	                $description=GETPOST('description','alpha');
+	                $fk_code_type_resource=GETPOST('fk_code_type_resource','alpha');
+	
+	                if (empty($ref))
+	                {
+	                        $mesg=$langs->trans("ErrorFieldRequired",$langs->transnoentities("Ref"));
+	                        setEventMessages($mesg, null, 'errors');
+	                        $error++;
+	                }
+	
+	                if (! $error)
+	                {
+	                        $object=new Dolresource($db);
+	                        $object->ref=$ref;
+	                        $object->description=$description;
+	                        $object->fk_code_type_resource=$fk_code_type_resource;
+	
+	                        // Fill array 'array_options' with data from add form
+	                        $ret = $extrafields->setOptionalsFromPost($extralabels, $object);
+	                        if ($ret < 0) {
+	                        	$error ++;
+	                        }
+	
+	                        $result=$object->create($user);
+	                        if ($result > 0)
+	                        {
+	                                // Creation OK
+	                                $db->commit();
+	                                setEventMessages($langs->trans('ResourceCreatedWithSuccess'), null, 'mesgs');
+	                                Header("Location: card.php?id=" . $object->id);
+	                                return;
+	                        }
+	                        else
+	                        {
+	                                // Creation KO
+	                                setEventMessages($object->error, $object->errors, 'errors');
+	                                $action = '';
+	                        }
+	                }
+	                else
+	                {
+	                        $action = '';
+	                }
+	        }
+	        else
+	        {
+	                Header("Location: list.php");
+	        }
+	}
 }
-
 
 /*
  * View

--- a/htdocs/resource/card.php
+++ b/htdocs/resource/card.php
@@ -54,12 +54,12 @@ if ($user->societe_id > 0)
 	accessforbidden();
 }
 
-if( ! $user->rights->resource->read)
+if (! $user->rights->resource->read)
 	accessforbidden();
 
 $object = new Dolresource($db);
 $objectFetchRes = $object->fetch($id);
-if ( !$objectFetchRes> 0 ) dol_print_error();
+if (! ($objectFetchRes > 0)) dol_print_error($db, $object->error);
 
 
 $extrafields = new ExtraFields($db);

--- a/htdocs/resource/card.php
+++ b/htdocs/resource/card.php
@@ -58,6 +58,9 @@ if( ! $user->rights->resource->read)
 	accessforbidden();
 
 $object = new Dolresource($db);
+$objectFetchRes = $object->fetch($id);
+if ( !$objectFetchRes> 0 ) dol_print_error();
+
 
 $extrafields = new ExtraFields($db);
 
@@ -162,7 +165,7 @@ llxHeader('',$pagetitle,'');
 $form = new Form($db);
 $formresource = new FormResource($db);
 
-if ( $object->fetch($id) > 0 )
+if ( $objectFetchRes > 0 )
 {
 	$head=resource_prepare_head($object);
 


### PR DESCRIPTION
[EN]
For resource card and add : 
- Resource hook "doAction" is call before resource fetch, so it's difficult to correctly override card object comportment. FIXED BY FECTING OBJECT BEFORE HOOK CALL 
- Resource hook "doAction"  is absent from resource add.php script but present on card. FIXED BY ADDING MISSING HOOK

[FR]
Sur la fiche resource et ajout de resource :
- Le hook "doAction"  est appelé après le "fetch" de la resource, il est alors difficile de surcharger le comportement de la fiche et/ou de l'objet. L'objet est maintenant fetch avant l'appel du hook doAction
- Le hook doAction est absent de la fiche d'ajout de resource alors qu'il est présent sur la card.
