### PR TITLE
FIX : same logic for setting fieldvalue and fieldtype

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -90,7 +90,7 @@ if (! empty($canvas))
 
 // Security check
 $fieldvalue = (! empty($id) ? $id : (! empty($ref) ? $ref : ''));
-$fieldtype = (! empty($ref) ? 'ref' : 'rowid');
+$fieldtype = (! empty($id) ? 'rowid' : 'ref');
 $result=restrictedArea($user,'produit|service',$fieldvalue,'product&product','','',$fieldtype,$objcanvas);
 
 // Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array


### PR DESCRIPTION
if _POST was filled with id and ref, the fieldvalue passed to restrictedarea function was the object id but the fieldtype was "ref" !
Happens when you edit a product card and click on Cancel button.

Note that i have only fix the problem in product card but it appears on every other card tab in dolibarr !