### PR TITLE
Fix: Search on supplier payment list doesn't work

### DIFF
--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -797,7 +797,6 @@ if (empty($action))
         if ($optioncss != '') print '<input type="hidden" name="optioncss" value="'.$optioncss.'">';
         print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
         print '<input type="hidden" name="formfilteraction" id="formfilteraction" value="list">';
-        print '<input type="hidden" name="action" value="list">';
         print '<input type="hidden" name="sortfield" value="'.$sortfield.'">';
         print '<input type="hidden" name="sortorder" value="'.$sortorder.'">';
         print '<input type="hidden" name="page" value="'.$page.'">';


### PR DESCRIPTION
Search on supplier payment list return a white page. For list by default, $action must be empty.