### PR TITLE
Fix barcode reader on POS

### DIFF
--- a/htdocs/cashdesk/tpl/facturation1.tpl.php
+++ b/htdocs/cashdesk/tpl/facturation1.tpl.php
@@ -42,9 +42,9 @@ $langs->load("cashdesk");
 			<tr><th class="label1"><?php echo $langs->trans("FilterRefOrLabelOrBC"); ?></th><th class="label1"><?php echo $langs->trans("Designation"); ?></th></tr>
 			<tr>
 			<!-- Affichage de la reference et de la designation -->
+			<!-- Suppression de l'attribut onkeyup qui causait un probleme d'emulation avec les douchettes -->
 			<td><input class="texte_ref" type="text" id ="txtRef" name="txtRef" value="<?php echo $obj_facturation->ref() ?>"
 				onchange="javascript: setSource('REF');"
-				onkeyup="javascript: verifResultat('resultats_dhtml', this.value, <?php echo (isset($conf->global->BARCODE_USE_SEARCH_TO_SELECT) ? (int) $conf->global->BARCODE_USE_SEARCH_TO_SELECT : 1) ?>);"
 				onfocus="javascript: this.select(); verifResultat('resultats_dhtml', this.value, <?php echo (isset($conf->global->BARCODE_USE_SEARCH_TO_SELECT) ? (int) $conf->global->BARCODE_USE_SEARCH_TO_SELECT : 1) ?>);"
 				onBlur="javascript: document.getElementById('resultats_dhtml').innerHTML = '';"/>
 			</td>


### PR DESCRIPTION
# Bug

Thanks to a post on the french dolibarr forum (https://www.dolibarr.fr/forum/12-howto--aide/59602-module-pdv-comportement-de-la-douchette), i observe a problem of emulation with barcode reader in the research (Ref/Lib) area. It don't write the good barcode but instead a sort of random short number.

## Suggested implementation

I try to find what this issue is due to. I try to correct the /htdocs/cashdesk/tpl/facturation1.tpl.php.
I observe that the suppression of onkeyup attribute of txtRef mark solve the problem