### PR TITLE
Fix extrafieldsline insert

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4156,6 +4156,10 @@ abstract class CommonObject
             foreach($this->array_options as $key => $value)
             {
                	$attributeKey = substr($key,8);   // Remove 'options_' prefix
+               	
+               	// array_option may contain extrafields from an origin object that doesn't exist in current object, we should not try to insert them
+               	if(empty($extrafields->attribute_type[$attributeKey])) continue;
+				
                	$attributeType  = $extrafields->attribute_type[$attributeKey];
                	$attributeLabel = $extrafields->attribute_label[$attributeKey];
                	$attributeParam = $extrafields->attribute_param[$attributeKey];

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4156,9 +4156,12 @@ abstract class CommonObject
             foreach($this->array_options as $key => $value)
             {
                	$attributeKey = substr($key,8);   // Remove 'options_' prefix
-               	
-               	// array_option may contain extrafields from an origin object that doesn't exist in current object, we should not try to insert them
-               	if(empty($extrafields->attribute_type[$attributeKey])) continue;
+
+				// array_option may contain extrafields from an origin object that doesn't exist in current object, we should not try to insert them
+				if(empty($extrafields->attribute_type[$attributeKey])) {
+					unset($this->array_options[$key]);
+					continue;
+				}
 				
                	$attributeType  = $extrafields->attribute_type[$attributeKey];
                	$attributeLabel = $extrafields->attribute_label[$attributeKey];


### PR DESCRIPTION
When creating an object from another, there was an SQL error if origin object had extrafield that new object hasn't.