### PR TITLE
FIX Add some missing attributes in Adherent:makeSubstitution (type, phone…

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -198,6 +198,9 @@ class Adherent extends CommonObject
 		$infos.= $langs->transnoentities("Town").": ".$this->town."\n";
 		$infos.= $langs->transnoentities("Country").": ".$this->country."\n";
 		$infos.= $langs->transnoentities("EMail").": ".$this->email."\n";
+        $infos.= $langs->transnoentities("PhonePro").": ".$this->phone."\n";
+        $infos.= $langs->transnoentities("PhonePerso").": ".$this->phone_perso."\n";
+        $infos.= $langs->transnoentities("PhoneMobile").": ".$this->phone_mobile."\n";
 		if (empty($conf->global->ADHERENT_LOGIN_NOT_REQUIRED))
 		{
 		    $infos.= $langs->transnoentities("Login").": ".$this->login."\n";
@@ -225,6 +228,10 @@ class Adherent extends CommonObject
 				'%PHOTO%'=>$msgishtml?dol_htmlentitiesbr($this->photo):$this->photo,
 				'%LOGIN%'=>$msgishtml?dol_htmlentitiesbr($this->login):$this->login,
 				'%PASSWORD%'=>$msgishtml?dol_htmlentitiesbr($this->pass):$this->pass,
+                '%TYPE%'=>$msgishtml?dol_htmlentitiesbr($this->type):$this->type,
+                '%PHONE_PRO%'=>$msgishtml?dol_htmlentitiesbr($this->phone):$this->phone,
+                '%PHONE_PERSO%'=>$msgishtml?dol_htmlentitiesbr($this->phone_perso):$this->phone_perso,
+                '%PHONE_MOBILE%'=>$msgishtml?dol_htmlentitiesbr($this->phone_mobile):$this->phone_mobile,
 				// For backward compatibility
 				'%INFOS%'=>$msgishtml?dol_htmlentitiesbr($infos):$infos,
 				'%SOCIETE%'=>$msgishtml?dol_htmlentitiesbr($this->societe):$this->societe,


### PR DESCRIPTION
… numbers) for use in substitution of tags


# New [Some attributes of the Adherent class are not accessible for substitution]
Some attributes are not available for substitution when, for example, sending an automatic email after auto-subscription of a member.
My use required the member type and the phone numbers. I added these data in the substitution function.
To avoid redoing the job after each Dolibarr release, it should be fine to integrate these changes in the next delivery.