### PR TITLE
Remove processing by htmlentities()

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -620,15 +620,6 @@ class Translate
 
 			if ($maxsize) $str=dol_trunc($str,$maxsize);
 
-			// We replace some HTML tags by __xx__ to avoid having them encoded by htmlentities
-            $str=str_replace(array('<','>','"',),array('__lt__','__gt__','__quot__'),$str);
-
-			// Crypt string into HTML
-			$str=htmlentities($str,ENT_QUOTES,$this->charset_output);
-
-			// Restore HTML tags
-            $str=str_replace(array('__lt__','__gt__','__quot__'),array('<','>','"',),$str);
-
 			return $str;
 		}
 		else								// Translation is not available


### PR DESCRIPTION
When translated texts contain international characters they are unintentionally changed by htmlentities().

You can see the problem at the admin/index.php page (language set to French):

`  Les paramètres dans le menu Configuration -> Soci&eacute;t&eacute;/Organisation sont requis car les données définies sont utilisées dans l'affichage Dolibarr et pour personnaliser le comportement par défaut du logiciel (pour les fonctionnalités liées à un pays par exemple).
`