### PR TITLE
fix #7359 Amount calculation

### DIFF
--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -571,11 +571,7 @@ class Fichinter extends CommonObject
 
 		$thm = $this->author->thm;
 
-		foreach($this->lines as &$line) {
-
-			$amount+=$line->qty * $thm;
-
-		}
+		$amount = $this->duration / 60 / 60 * $thm;
 
 		return $amount;
 	}


### PR DESCRIPTION
# Fix #7359
Instead of getting the duration line by line I changed the function to use the intervention total duration.
The value is than divided by 60 twice to get the value in hours and multiplied by the users thm.
