### PR TITLE
FIX time.php crashed without project id in param if project isn't linked to a company

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -442,7 +442,7 @@ if (($id > 0 || ! empty($ref)) || $projectidforalltimes > 0)
 		else $object->next_prev_filter=" fk_projet = ".$projectstatic->id;
 
 		$morehtmlref='';
-
+		
 		// Project
 		if (empty($withproject))
 		{
@@ -450,10 +450,12 @@ if (($id > 0 || ! empty($ref)) || $projectidforalltimes > 0)
 		    $morehtmlref.=$langs->trans("Project").': ';
 		    $morehtmlref.=$projectstatic->getNomUrl(1);
 		    $morehtmlref.='<br>';
-
+			
 		    // Third party
-		    $morehtmlref.=$langs->trans("ThirdParty").': ';
-		    $morehtmlref.=$projectstatic->thirdparty->getNomUrl(1);
+	    	$morehtmlref.=$langs->trans("ThirdParty").': ';
+	    	if (!empty($projectstatic->thirdparty)) {
+	    		$morehtmlref.=$projectstatic->thirdparty->getNomUrl(1);
+	    	}
 		    $morehtmlref.='</div>';
 		}
 

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -453,7 +453,7 @@ if (($id > 0 || ! empty($ref)) || $projectidforalltimes > 0)
 			
 		    // Third party
 	    	$morehtmlref.=$langs->trans("ThirdParty").': ';
-	    	if (!empty($projectstatic->thirdparty)) {
+	    	if (is_object($projectstatic->thirdparty)) {
 	    		$morehtmlref.=$projectstatic->thirdparty->getNomUrl(1);
 	    	}
 		    $morehtmlref.='</div>';
@@ -464,7 +464,7 @@ if (($id > 0 || ! empty($ref)) || $projectidforalltimes > 0)
 		print '<div class="fichecenter">';
 		print '<div class="fichehalfleft">';
 
-        print '<div class="underbanner clearboth"></div>';
+        	print '<div class="underbanner clearboth"></div>';
 		print '<table class="border" width="100%">';
 
 		// Date start - Date end


### PR DESCRIPTION
if project isn't linked to a company this page will generate a fatal error. I fixed it with an If (added in others files in v6 commit by Laurent).