### PR TITLE
Fix dates in commande and remisecheque for PostgreSQL

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2234,7 +2234,7 @@ class Commande extends CommonOrder
         	$this->db->begin();
 
             $sql = "UPDATE ".MAIN_DB_PREFIX."commande";
-            $sql.= " SET date_commande = ".($date ? $this->db->idate($date) : 'null');
+            $sql.= " SET date_commande = ".($date ? "'".$this->db->idate($date)."'" : 'null');
             $sql.= " WHERE rowid = ".$this->id." AND fk_statut = ".self::STATUS_DRAFT;
 
             dol_syslog(__METHOD__, LOG_DEBUG);

--- a/htdocs/compta/paiement/cheque/class/remisecheque.class.php
+++ b/htdocs/compta/paiement/cheque/class/remisecheque.class.php
@@ -861,8 +861,8 @@ class RemiseCheque extends CommonObject
         if ($user->rights->banque->cheque)
         {
             $sql = "UPDATE ".MAIN_DB_PREFIX."bordereau_cheque";
-            $sql.= " SET date_bordereau = ".($date ? $this->db->idate($date) : 'null');
-            $sql.= " WHERE rowid = ".$this->id;
+            $sql.= " SET date_bordereau = '".($date ? $this->db->idate($date) : 'null');
+            $sql.= "' WHERE rowid = ".$this->id;
 
             dol_syslog("RemiseCheque::set_date", LOG_DEBUG);
             $resql=$this->db->query($sql);

--- a/htdocs/compta/paiement/cheque/class/remisecheque.class.php
+++ b/htdocs/compta/paiement/cheque/class/remisecheque.class.php
@@ -861,8 +861,8 @@ class RemiseCheque extends CommonObject
         if ($user->rights->banque->cheque)
         {
             $sql = "UPDATE ".MAIN_DB_PREFIX."bordereau_cheque";
-            $sql.= " SET date_bordereau = '".($date ? $this->db->idate($date) : 'null');
-            $sql.= "' WHERE rowid = ".$this->id;
+            $sql.= " SET date_bordereau = ".($date ? "'".$this->db->idate($date)."'" : 'null');
+            $sql.= " WHERE rowid = ".$this->id;
 
             dol_syslog("RemiseCheque::set_date", LOG_DEBUG);
             $resql=$this->db->query($sql);


### PR DESCRIPTION
# New fix for dates in commande and remisecheque on PostgreSQL (string-like syntax)
The syntax for dates in commande and remisecheque classes in invalid for PostgreSQL (more strict SQL standard compliant escaping)
They should be escaped like strings (using single quotes) or better with named parameters (? syntax or :parameter in PDO)

Tested on dolibarr 3.8.3 up to 6.0.0