### PR TITLE
FIX #7349 Change Class from Invoices to SupplierInvoices

### DIFF
--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -351,7 +351,7 @@ class SupplierInvoices extends DolibarrApi
     function _validate($data)
     {
         $invoice = array();
-        foreach (Invoices::$FIELDS as $field) {
+        foreach (SupplierInvoices::$FIELDS as $field) {
             if (!isset($data[$field]))
                 throw new RestException(400, "$field field missing");
             $invoice[$field] = $data[$field];


### PR DESCRIPTION
# Fix #7349 Change Class from Invoices to SupplierInvoices
The wrong class was used to process the API function
