### PR TITLE
Fix example comment typo

### DIFF
--- a/dev/examples/code/create_user.php
+++ b/dev/examples/code/create_user.php
@@ -60,14 +60,14 @@ $db->begin();
 
 require_once(DOL_DOCUMENT_ROOT."/user/class/user.class.php");
 
-// Create invoice object
+// Create user object
 $obj = new User($db);
 //$obj->initAsSpecimen();
 
 $obj->login = 'ABCDEF';
 $obj->nom   = 'ABCDEF';
 
-// Create invoice
+// Create user
 $idobject=$obj->create($user);
 if ($idobject > 0)
 {

--- a/dev/examples/code/get_contracts.php
+++ b/dev/examples/code/get_contracts.php
@@ -67,7 +67,7 @@ $db->begin();
 
 require_once(DOL_DOCUMENT_ROOT."/contrat/class/contrat.class.php");
 
-// Create invoice object
+// Create contract object
 $obj = new Contrat($db);
 $obj->socid=$argv[1];
 


### PR DESCRIPTION
Fixed the following example comment typos while reading the code.