### PR TITLE
FIX extrafields copy situation invoice, shipment and receipt

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1356,6 +1356,7 @@ if (empty($reshook))
 					{
 						$line->origin = $object->origin;
 						$line->origin_id = $line->id;
+						$line->fetch_optionals($line->id);
 					}
 				}
 
@@ -1377,7 +1378,21 @@ if (empty($reshook))
 
 				$object->situation_counter = $object->situation_counter + 1;
 				$id = $object->createFromCurrent($user);
-				if ($id <= 0) $mesg = $object->error;
+				if ($id <= 0) 
+				{
+					$mesg = $object->error;
+				}
+				else
+				{
+					$nextSituationInvoice = new Facture($db);
+					$nextSituationInvoice->fetch($id);
+					// create extrafields with data from create form
+					$extralabels = $extrafields->fetch_name_optionals_label($nextSituationInvoice->table_element);
+					$ret = $extrafields->setOptionalsFromPost($extralabels, $nextSituationInvoice);
+					if ($ret > 0) {
+						$nextSituationInvoice->insertExtraFields();
+					}
+				}
 			}
 		}
 

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1317,7 +1317,7 @@ if ($action == 'create')
 					$line = new ExpeditionLigne($db);
 					$line->fetch_optionals($object->id,$extralabelslines);
 					$line->array_options = array_merge($line->array_options, $srcLine->array_options);
-					print '<tr '.$bc[$var].'>';
+					print '<tr class="oddeven">';
 					print $line->showOptionals($extrafieldsline, 'edit', array('style'=>$bc[$var], 'colspan'=>$colspan),$indiceAsked);
 					print '</tr>';
 				}

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -780,9 +780,15 @@ if ($action == 'create')
             $reshook=$hookmanager->executeHooks('formObjectOptions',$parameters,$object,$action);    // Note that $action and $object may have been modified by hook
             print $hookmanager->resPrint;
 
-            if (empty($reshook) && ! empty($extrafields->attribute_label)) {
-            	print $object->showOptionals($extrafields, 'edit');
-            }
+			if (empty($reshook) && ! empty($extrafields->attribute_label)) {
+				// copy from order
+				$orderExtrafields = new Extrafields($db);
+				$orderExtrafieldLabels = $orderExtrafields->fetch_name_optionals_label($object->table_element);
+				if ($object->fetch_optionals($object->id, $orderExtrafieldLabels) > 0) {
+					$expe->array_options = array_merge($expe->array_options, $object->array_options);
+				}
+				print $object->showOptionals($extrafields, 'edit');
+			}
 
 
             // Incoterms
@@ -1304,9 +1310,14 @@ if ($action == 'create')
 				if (is_array($extralabelslines) && count($extralabelslines)>0)
 				{
 					$colspan=5;
+					$orderLineExtrafields = new Extrafields($db);
+					$orderLineExtrafieldLabels = $orderLineExtrafields->fetch_name_optionals_label($object->table_element_line);
+					$srcLine = new OrderLine($db);
+					$srcLine->fetch_optionals($line->id,$orderLineExtrafieldLabels); // fetch extrafields also available in orderline
 					$line = new ExpeditionLigne($db);
 					$line->fetch_optionals($object->id,$extralabelslines);
-					print '<tr class="oddeven">';
+					$line->array_options = array_merge($line->array_options, $srcLine->array_options);
+					print '<tr '.$bc[$var].'>';
 					print $line->showOptionals($extrafieldsline, 'edit', array('style'=>$bc[$var], 'colspan'=>$colspan),$indiceAsked);
 					print '</tr>';
 				}

--- a/htdocs/livraison/card.php
+++ b/htdocs/livraison/card.php
@@ -565,6 +565,14 @@ else
 			}
 			
 			// Other attributes
+			if ($action = 'create_delivery') {
+				// copy from expedition
+				$expeditionExtrafields = new Extrafields($db);
+				$expeditionExtrafieldLabels = $expeditionExtrafields->fetch_name_optionals_label($expedition->table_element);
+				if ($expedition->fetch_optionals($object->origin_id, $expeditionExtrafieldLabels) > 0) {
+					$object->array_options = array_merge($object->array_options, $expedition->array_options);
+				}
+			}
 			$cols = 2;
 			include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
@@ -665,6 +673,13 @@ else
 					$mode = ($object->statut == 0) ? 'edit' : 'view';
 					$line = new LivraisonLigne($db);
 					$line->fetch_optionals($object->lines[$i]->id,$extralabelslines);
+					if ($action = 'create_delivery') {
+						$srcLine = new ExpeditionLigne($db);
+						$expeditionLineExtrafields = new Extrafields($db);
+						$expeditionLineExtrafieldLabels = $expeditionLineExtrafields->fetch_name_optionals_label($srcLine->table_element);
+						$srcLine->fetch_optionals($expedition->lines[$i]->id,$expeditionLineExtrafieldLabels);
+						$line->array_options = array_merge($line->array_options, $srcLine->array_options);
+					}
 					print '<tr class="oddeven">';
 					print $line->showOptionals($extrafieldsline, $mode, array('style'=>$bc[$var], 'colspan'=>$colspan),$i);
 					print '</tr>';


### PR DESCRIPTION
Fix extrafield copy:

- From first situation invoice to next situation invoice.
- From customer order to shipment.
- From shipment to receipt.
