### PR TITLE
FIX Stripe not working on live mode

### DIFF
--- a/htdocs/stripe/config.php
+++ b/htdocs/stripe/config.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2017		Alexandre Spangaro		<aspangaro@zendsi.com>
  * Copyright (C) 2017		Saasprov				<saasprov@gmail.com>
+ * Copyright (C) 2017		Ferran Marcet			<fmarcet@2byte.es.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +33,7 @@ global $conf;
 //use \includes\stripe as stripe;
 $stripe = array();
 
-if (empty($conf->global->SKYPE_LIVE))
+if (empty($conf->global->STRIPE_LIVE))
 {
 	$stripe = array(
 		"secret_key"      => $conf->global->STRIPE_TEST_SECRET_KEY,


### PR DESCRIPTION
The name of the variable was wrong, so it always ran in test mode
