### PR TITLE
Fix 7470

### DIFF
--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -287,15 +287,18 @@ class Conf
 		{
 			foreach($this->modules_parts['dir'] as $module => $dirs)
 			{
-				foreach($dirs as $type => $name)
+				if (! empty($this->$module->enabled))
 				{
-					$subdir=($type=='temp'?'/temp':'');
-					// For multicompany sharings
-					$varname = 'multidir_'.$type;
-					$this->$module->$varname = array($this->entity => $rootfordata."/".$name.$subdir);
-					// For backward compatibility
-					$varname = 'dir_'.$type;
-					$this->$module->$varname = $rootfordata."/".$name.$subdir;
+					foreach($dirs as $type => $name)
+					{
+						$subdir=($type=='temp'?'/temp':'');
+						// For multicompany sharings
+						$varname = 'multidir_'.$type;
+						$this->$module->$varname = array($this->entity => $rootfordata."/".$name.$subdir);
+						// For backward compatibility
+						$varname = 'dir_'.$type;
+						$this->$module->$varname = $rootfordata."/".$name.$subdir;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
php warning when  MAIN_MODULE_xxxxx_DIR exists but the module does not have a directory.