### PR TITLE
NEW Add a parameter to specify char used as separator for variant product label

### DIFF
--- a/htdocs/variants/admin/admin.php
+++ b/htdocs/variants/admin/admin.php
@@ -37,6 +37,12 @@ if ($_POST) {
 		setEventMessage($langs->trans('CoreErrorMessage'), 'errors');
 	}
 
+       if (dolibarr_set_const($db, 'PRODUIT_ATTRIBUTES_SEPARATOR', GETPOST('PRODUIT_ATTRIBUTES_SEPARATOR'), 'chaine', 0, '', $conf->entity)) {
+               setEventMessage($langs->trans('RecordSaved'));
+       } else {
+               setEventMessage($langs->trans('CoreErrorMessage'), 'errors');
+       }
+
 }
 
 $title = $langs->trans('ModuleSetup').' '.$langs->trans('ProductAttributes');
@@ -55,6 +61,13 @@ print '<td align="right" width="60">'.$langs->trans("Value").'</td>'."\n";
 print '<td width="80">&nbsp;</td></tr>'."\n";
 print '<tr><td>'.$langs->trans('HideProductCombinations').'</td><td>';
 print $form->selectyesno("PRODUIT_ATTRIBUTES_HIDECHILD",$conf->global->PRODUIT_ATTRIBUTES_HIDECHILD,1).'</td></tr>';
+print '<tr><td>'.$langs->trans('CombinationsSeparator').'</td><td>';
+if(isset($conf->global->PRODUIT_ATTRIBUTES_SEPARATOR)) {
+       $separator = $conf->global->PRODUIT_ATTRIBUTES_SEPARATOR;
+} else {
+       $separator = "_";
+}
+print '<td align="right"><input size="3" type="text" class="flat" name="PRODUIT_ATTRIBUTES_SEPARATOR" value="'.$separator.'"></td></tr>';
 print '</table>';
 print '<br><div style="text-align: center"><input type="submit" value="'.$langs->trans('Save').'" class="button"></div>';
 print '</form>';

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -476,7 +476,7 @@ WHERE c.fk_product_parent = ".(int) $productid." AND p.tosell = 1";
 	 */
 	public function createProductCombination(Product $product, array $combinations, array $variations, $price_var_percent = false, $forced_pricevar = false, $forced_weightvar = false)
 	{
-		global $db, $user;
+		global $db, $user, $conf;
 
 		require_once DOL_DOCUMENT_ROOT.'/variants/class/ProductAttribute.class.php';
 		require_once DOL_DOCUMENT_ROOT.'/variants/class/ProductAttributeValue.class.php';
@@ -542,7 +542,11 @@ WHERE c.fk_product_parent = ".(int) $productid." AND p.tosell = 1";
 				$price_impact += (float) price2num($variations[$currcombattr][$currcombval]['price']);
 			}
 
-			$newproduct->ref .= '_'.$prodattrval->ref;
+			if (isset($conf->global->PRODUIT_ATTRIBUTES_SEPARATOR)) {
+			  $newproduct->ref .= $conf->global->PRODUIT_ATTRIBUTES_SEPARATOR . $prodattrval->ref;
+			} else {
+			  $newproduct->ref .= '_'.$prodattrval->ref;
+			}
 
 			//The first one should not contain a linebreak
 			if ($newproduct->description) {


### PR DESCRIPTION
# New Permit any variant separator for reference
Currently references of variants are created using the underscore character as a separator.
With this patch we can replace it with any configured value.
