### PR TITLE
FIX Solve bug with alias name shown on wrong thirdparty in list

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -1024,6 +1024,7 @@ while ($i < min($num, $limit))
 
 	$companystatic->id=$obj->rowid;
 	$companystatic->name=$obj->name;
+	$companystatic->name_alias=$obj->name_alias;
 	$companystatic->canvas=$obj->canvas;
 	$companystatic->client=$obj->client;
 	$companystatic->status=$obj->status;
@@ -1053,7 +1054,6 @@ while ($i < min($num, $limit))
 	}
 	if (! empty($arrayfields['s.name_alias']['checked']))
 	{
-	    $companystatic->name_alias=$obj->name_alias;   // Added after the getNomUrl
 	    print '<td class="tdoverflowmax200">';
 	    print $companystatic->name_alias;
 	    print "</td>\n";


### PR DESCRIPTION
The bug display the alias name on the following name between brackets after name into name column.
![image](https://user-images.githubusercontent.com/4528670/30826384-bd287420-a236-11e7-97d9-35d8feb664bb.png)