### PR TITLE
Fix the pdf_getlineprogress hook isn't use because hookmanager is null

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1753,6 +1753,8 @@ function pdf_getlineremisepercent($object,$i,$outputlangs,$hidedetails=0)
  */
 function pdf_getlineprogress($object, $i, $outputlangs, $hidedetails = 0, $hookmanager = null)
 {
+	if (empty($hookmanager)) global $hookmanager;
+	
 	$reshook=0;
     $result='';
     //if (is_object($hookmanager) && ( (isset($object->lines[$i]->product_type) && $object->lines[$i]->product_type == 9 && ! empty($object->lines[$i]->special_code)) || ! empty($object->lines[$i]->fk_parent_line) ) )


### PR DESCRIPTION
# Fix
can't override the printed text for the progress value from situation invoice with a hook because the function "pdf_getlineprogress" use a parameter to use hookmanager instead declare with global key word as the others functions like pdf_getlineremisepercent, pdf_getlineqty