### PR TITLE
Fix: payment form & user first/last name position

### DIFF
--- a/htdocs/compta/salaries/card.php
+++ b/htdocs/compta/salaries/card.php
@@ -214,6 +214,12 @@ if ($action == 'create')
 		$pastmonthyear--;
 	}
 
+	$datespmonth = GETPOST('datespmonth', 'int');
+	$datespday = GETPOST('datespday', 'int');
+	$datespyear = GETPOST('datespyear', 'int');
+	$dateepmonth = GETPOST('dateepmonth', 'int');
+	$dateepday = GETPOST('dateepday', 'int');
+	$dateepyear = GETPOST('dateepyear', 'int');
 	$datesp=dol_mktime(0, 0, 0, $datespmonth, $datespday, $datespyear);
 	$dateep=dol_mktime(23, 59, 59, $dateepmonth, $dateepday, $dateepyear);
 

--- a/htdocs/compta/salaries/card.php
+++ b/htdocs/compta/salaries/card.php
@@ -253,7 +253,7 @@ if ($action == 'create')
 	// Label
 	print '<tr><td>';
 	print fieldLabel('Label','label',1).'</td><td>';
-	print '<input name="label" id="label" class="minwidth300" value="'.($_POST["label"]?GETPOST("label",'',2):$langs->trans("SalaryPayment")).'">';
+	print '<input name="label" id="label" class="minwidth300" value="'.(GETPOST("label")?GETPOST("label"):$langs->trans("SalaryPayment")).'">';
 	print '</td></tr>';
 
 	// Date start period

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -2058,7 +2058,7 @@ class User extends CommonObject
 
 		$label.= '<div class="centpercent">';
 		$label.= '<u>' . $langs->trans("User") . '</u><br>';
-		$label.= '<b>' . $langs->trans('Name') . ':</b> ' . $this->getFullName($langs,'','');
+		$label.= '<b>' . $langs->trans('Name') . ':</b> ' . $this->getFullName($langs,'');
 		if (! empty($this->login))
 			$label.= '<br><b>' . $langs->trans('Login') . ':</b> ' . $this->login;
 		$label.= '<br><b>' . $langs->trans("EMail").':</b> '.$this->email;


### PR DESCRIPTION
FIX: in payment form, label does not fill with GET method
FIX: wrong user first name/last name position in user tooltip
FIX: missing variables in payment form