### PR TITLE
NEW Set invoices as draft using the REST API

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -383,7 +383,7 @@ class Invoices extends DolibarrApi
      * @param   int $id             Order ID
      * @param   int $idwarehouse    Warehouse ID
      *
-     * @url POST    {id}/draft
+     * @url POST    {id}/settodraft
      *
      * @return  array
      * 
@@ -394,7 +394,7 @@ class Invoices extends DolibarrApi
      * @throws 500
      * 
      */
-    function draft($id, $idwarehouse=-1)
+    function settodraft($id, $idwarehouse=-1)
     {
         if(! DolibarrApiAccess::$user->rights->facture->creer) {
                 throw new RestException(401);
@@ -491,7 +491,7 @@ class Invoices extends DolibarrApi
      * @param   string 	$close_code    Code renseigne si on classe a payee completement alors que paiement incomplet (cas escompte par exemple)
      * @param   string 	$close_note    Commentaire renseigne si on classe a payee alors que paiement incomplet (cas escompte par exemple)
      *
-     * @url POST    {id}/paid
+     * @url POST    {id}/settopaid
      *
      * @return  array 	An invoice object
      *
@@ -501,7 +501,7 @@ class Invoices extends DolibarrApi
      * @throws 404
      * @throws 500
      */
-    function set_paid($id, $close_code='', $close_note='')
+    function settopaid($id, $close_code='', $close_note='')
     {
         if(! DolibarrApiAccess::$user->rights->facture->creer) {
                 throw new RestException(401);

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -378,7 +378,7 @@ class Invoices extends DolibarrApi
     }
 
     /**
-     * Set invoice status as draft
+     * Sets an invoice as draft
      *
      * @param   int $id             Order ID
      * @param   int $idwarehouse    Warehouse ID
@@ -483,6 +483,61 @@ class Invoices extends DolibarrApi
 
 
     }
+
+    /**
+     * Sets an invoice as paid
+     *
+     * @param   int 	$id            Order ID
+     * @param   string 	$close_code    Code renseigne si on classe a payee completement alors que paiement incomplet (cas escompte par exemple)
+     * @param   string 	$close_note    Commentaire renseigne si on classe a payee alors que paiement incomplet (cas escompte par exemple)
+     *
+     * @url POST    {id}/paid
+     *
+     * @return  array 	An invoice object
+     *
+     * @throws 200
+     * @throws 304
+     * @throws 401
+     * @throws 404
+     * @throws 500
+     */
+    function set_paid($id, $close_code='', $close_note='')
+    {
+        if(! DolibarrApiAccess::$user->rights->facture->creer) {
+                throw new RestException(401);
+        }
+        $result = $this->invoice->fetch($id);
+        if( ! $result ) {
+                throw new RestException(404, 'Invoice not found');
+        }
+
+        if( ! DolibarrApi::_checkAccessToResource('facture',$this->invoice->id)) {
+                throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        }
+
+        $result = $this->invoice->set_paid(DolibarrApiAccess::$user, $close_code, $close_note);
+        if ($result == 0) {
+                throw new RestException(304, 'Error nothing done. May be object is already validated');
+        }
+        if ($result < 0) {
+                throw new RestException(500, 'Error : '.$this->invoice->error);
+        }
+
+
+        $result = $this->invoice->fetch($id);
+        if( ! $result ) {
+            throw new RestException(404, 'Invoice not found');
+        }
+
+        if( ! DolibarrApi::_checkAccessToResource('facture',$this->invoice->id)) {
+            throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        }
+
+        return $this->_cleanObjectDatas($this->invoice);
+
+
+    }
+
 
     /**
      * Clean sensible object datas


### PR DESCRIPTION
Adds the ability to set an invoice status as draft using the REST API
Change of response content when validating an invoice : before status = 200 + text message, now the API returns an invoice object
Change of response code when nothing has been modified : before 500 (Internal Server Error), now 304 (Not Modified)