### PR TITLE
Fix : GETPOST for update keys in import module

### DIFF
--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -77,7 +77,7 @@ $hexa				= GETPOST('hexa');
 $importmodelid		= GETPOST('importmodelid');
 $excludefirstline	= (GETPOST('excludefirstline') ? GETPOST('excludefirstline') : 1);
 $endatlinenb		= (GETPOST('endatlinenb') ? GETPOST('endatlinenb') : '');
-$updatekeys			= (GETPOST('updatekeys') ? GETPOST('updatekeys') : array());
+$updatekeys			= (GETPOST('updatekeys', 'array') ? GETPOST('updatekeys', 'array') : array());
 $separator			= (GETPOST('separator') ? GETPOST('separator') : (! empty($conf->global->IMPORT_CSV_SEPARATOR_TO_USE)?$conf->global->IMPORT_CSV_SEPARATOR_TO_USE:','));
 $enclosure			= (GETPOST('enclosure') ? GETPOST('enclosure') : '"');
 


### PR DESCRIPTION
Warning, GETPOST is now defaulted to 'alpha' so every array variable retrieved with GETPOST will not work anymore (because of trim on alpha check)