### PR TITLE
FIX: Some errors from html.form.class.php not translated on fourn/commande/card.php

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4519,6 +4519,8 @@ class Form
 	{
 		global $langs,$conf,$mysoc;
 
+		$langs->load('errors');
+
 		$return='';
 
 		// Define defaultnpr, defaultttx and defaultcode


### PR DESCRIPTION
# Error

![error](https://image.ibb.co/jnOdd6/ERROR_Translation_fourn_commande_card.png)

# Solution
`$lang->load('errors')` is needed to load the traductions of the lines below, that are called in html.form.class.php:

`$return.= '<font class="error">'.$langs->trans("ErrorYourCountryIsNotDefined").'</div>';`
`$return.= '<font class="error">'.$langs->trans("ErrorSupplierCountryIsNotDefined").'</div>';`

I added `$lang->load('errors')` on html.form.class.php because in this way is not needed to call the statement on other files, like fourn/commande/card.php


