### PR TITLE
Fix Error Column 'date_m' cannot be null

### DIFF
--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -141,6 +141,7 @@ class EcmFiles //extends CommonObject
 			 $this->acl = trim($this->acl);
 		}
 		if (empty($this->date_c)) $this->date_c = dol_now();
+		if (empty($this->date_m)) $this->date_m = dol_now();
 
 		// If ref not defined
 		$ref = dol_hash($this->filepath.'/'.$this->filename, 3);


### PR DESCRIPTION
Dans un document (facture, devis, ...), dans l'onglet document, si on s'y rend alors que le document n'existe pas encore, il est créé en base. 
Pour une raison que je ne comprends pas bien, date_m est inseré en base s'il est défini et différent de 0, or il est initialisé à '' (vide). Il est donc inseré et non conforme au MCD. 

Faut d'avoir l'historique sur l'évolution de ce module, j'ai trouvé plus simple d'initialiser date_m à la date actuelle lors de sa création. A voir si c'est ou non la meilleure solution.

(désolé si je m'y prends mal, n'hésitez pas à me contacter pour me le dire et je ferai mieux la prochaine fois !). 