### PR TITLE
Fix shipment ref is empty

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -212,7 +212,7 @@ if (empty($reshook))
 	    $objectsrc->fetch($object->origin_id);
 
 	    $object->socid					= $objectsrc->socid;
-	    $object->ref_customer			= '';                   // We don't use $objectsrc->ref_client, this is ref or order not shipment
+	    $object->ref_customer			= GETPOST('ref_customer');                   // We don't use $objectsrc->ref_client, this is ref or order not shipment
 	    $object->model_pdf				= GETPOST('model');
 	    $object->date_delivery			= $date_delivery;	    // Date delivery planed
 	    $object->fk_delivery_address	= $objectsrc->fk_delivery_address;
@@ -692,7 +692,7 @@ if ($action == 'create')
             else if ($origin == 'propal') print $langs->trans('RefCustomerOrder');
             else print $langs->trans('RefCustomer');
             print '</td><td colspan="3">';
-            print $object->ref_client;
+            print '<input type="text" name="ref_customer" value="'.$object->ref_client.'" />';
             print '</td>';
             print '</tr>';
 


### PR DESCRIPTION
# Fix 
https://github.com/Dolibarr/dolibarr/commit/a3607fff776b5f29af9790e42d061996d6bdcf3b#diff-2ef8d572314ed032648eefae11a6a92cR205
@eldy you did that but I don't understand why, so I suggest to add an input text to let the choice to avoid the field before creating shipment by the user

