### PR TITLE
FIX: Agenda events are not exported in the ICAL, VCAL if begin exactly with the same $datestart

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -2,8 +2,8 @@
 /* Copyright (C) 2002-2004 Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (C) 2004-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@capnetworks.com>
- * Copyright (C) 2011	   Juanjo Menent        <jmenent@2byte.es>
- * Copyright (C) 2015       Marcos García           <marcosgdf@gmail.com>
+ * Copyright (C) 2011-2017 Juanjo Menent        <jmenent@2byte.es>
+ * Copyright (C) 2015	   Marcos García		<marcosgdf@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1255,6 +1255,7 @@ class ActionComm extends CommonObject
             {
                 // Note: Output of sql request is encoded in $conf->file->character_set_client
                 // This assignment in condition is not a bug. It allows walking the results.
+				$diff = 0;
                 while ($obj=$this->db->fetch_object($resql))
                 {
                     $qualified=true;
@@ -1289,8 +1290,9 @@ class ActionComm extends CommonObject
 
                     if ($qualified && $datestart)
                     {
-                        $eventarray[$datestart]=$event;
+                        $eventarray[$datestart+$diff]=$event;
                     }
+                    $diff++;
                 }
             }
             else


### PR DESCRIPTION
Thanks to Joan Ferre