### PR TITLE
NEW Add product unit fields for ODT substitution

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -509,6 +509,10 @@ abstract class CommonDocGenerator
 		    'line_multicurrency_total_ht_locale' => price($line->multicurrency_total_ht, 0, $outputlangs),
 		    'line_multicurrency_total_tva_locale' => price($line->multicurrency_total_tva, 0, $outputlangs),
 		    'line_multicurrency_total_ttc_locale' => price($line->multicurrency_total_ttc, 0, $outputlangs),
+
+		    // Units
+		    'line_unit'=>$line->getLabelOfUnit('long'),
+		    'line_unit_short'=>$line->getLabelOfUnit('short'),
 		);
 
 		// Retrieve extrafields

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -509,11 +509,14 @@ abstract class CommonDocGenerator
 		    'line_multicurrency_total_ht_locale' => price($line->multicurrency_total_ht, 0, $outputlangs),
 		    'line_multicurrency_total_tva_locale' => price($line->multicurrency_total_tva, 0, $outputlangs),
 		    'line_multicurrency_total_ttc_locale' => price($line->multicurrency_total_ttc, 0, $outputlangs),
-
-		    // Units
-		    'line_unit'=>$outputlangs->trans($line->getLabelOfUnit('long')),
-		    'line_unit_short'=>$outputlangs->trans($line->getLabelOfUnit('short')),
 		);
+		
+		    // Units
+		if ($conf->global->PRODUCT_USE_UNITS)
+		{
+		      $resarray['line_unit']=$outputlangs->trans($line->getLabelOfUnit('long')),
+		      $resarray['line_unit_short']=$outputlangs->trans($line->getLabelOfUnit('short'))
+		}
 
 		// Retrieve extrafields
 		$extrafieldkey=$line->element;

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -511,8 +511,8 @@ abstract class CommonDocGenerator
 		    'line_multicurrency_total_ttc_locale' => price($line->multicurrency_total_ttc, 0, $outputlangs),
 
 		    // Units
-		    'line_unit'=>$line->getLabelOfUnit('long'),
-		    'line_unit_short'=>$line->getLabelOfUnit('short'),
+		    'line_unit'=>$outputlangs->trans($line->getLabelOfUnit('long')),
+		    'line_unit_short'=>$outputlangs->trans($line->getLabelOfUnit('short')),
 		);
 
 		// Retrieve extrafields

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -514,8 +514,8 @@ abstract class CommonDocGenerator
 		    // Units
 		if ($conf->global->PRODUCT_USE_UNITS)
 		{
-		      $resarray['line_unit']=$outputlangs->trans($line->getLabelOfUnit('long')),
-		      $resarray['line_unit_short']=$outputlangs->trans($line->getLabelOfUnit('short'))
+		      $resarray['line_unit']=$outputlangs->trans($line->getLabelOfUnit('long'));
+		      $resarray['line_unit_short']=$outputlangs->trans($line->getLabelOfUnit('short'));
 		}
 
 		// Retrieve extrafields


### PR DESCRIPTION
# New Add product unit fields for ODT substitution
There was no substitution fields for product/service units when generating odt-files
