### PR TITLE
FIX project pie chart status selection

### DIFF
--- a/htdocs/projet/index.php
+++ b/htdocs/projet/index.php
@@ -94,6 +94,7 @@ else
 $listofoppstatus=array(); $listofopplabel=array(); $listofoppcode=array();
 $sql = "SELECT cls.rowid, cls.code, cls.percent, cls.label";
 $sql.= " FROM ".MAIN_DB_PREFIX."c_lead_status as cls";
+$sql.= " WHERE active=1";
 $resql = $db->query($sql);
 if ( $resql )
 {


### PR DESCRIPTION
I propose to the maintainer a variation to code at line number 97 to show only the statuses enabled in the pie chart.

![progetti](https://user-images.githubusercontent.com/33025815/31887620-4c2a8df2-b7f9-11e7-9d24-f9c1bf97d2d5.png)

