### PR TITLE
Fix : contract lines from origin were containing all lines desc

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -327,7 +327,7 @@ if (empty($reshook))
 										$label = $lines[$i]->product_label;
 									}
 	
-									$desc .= ($lines[$i]->desc && $lines[$i]->desc!=$lines[$i]->libelle)?dol_htmlentitiesbr($lines[$i]->desc):'';
+									$desc = ($lines[$i]->desc && $lines[$i]->desc!=$lines[$i]->libelle)?dol_htmlentitiesbr($lines[$i]->desc):'';
 								}
 								else {
 								    $desc = dol_htmlentitiesbr($lines[$i]->desc);


### PR DESCRIPTION
When creating contract from proposal for example, line 2 of contract was containing desc of line 1 and line 2 of propal, and so on ...