### PR TITLE
Delete extrafieds when delete an intervention

### DIFF
--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -906,6 +906,13 @@ class Fichinter extends CommonObject
 					// End call triggers
 				}
 
+				// Remove extrafields
+				if ((! $error) && (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED))) // For avoid conflicts if trigger used
+				{
+					$result=$this->deleteExtraFields();
+					if ($result < 0) { $error++; $this->db->rollback(); return -1; }
+				}
+				
 				$this->db->commit();
 				return 1;
 			}


### PR DESCRIPTION
When user delete an intervention, we should delete the extrafields too.