### PR TITLE
NEW Support Italian addresses format. Fixes #7785

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1450,6 +1450,12 @@ function dol_format_address($object,$withcountry=0,$sep="\n",$outputlangs='')
 			$ret.="\n".$object->state;
 		}
 	}
+	else if (in_array($object->country_code,array('IT'))) // IT: tile firstname name\n address lines \n zip (Code Departement) \n country
+	{
+                $ret .= ($ret ? $sep : '' ).$object->zip;
+                $ret .= ($object->town?(($object->zip?' ':'').$object->town):'');
+                $ret .= ($object->departement_id?(' ('.($object->departement_id).')'):'');
+	}
 	else                                        		// Other: title firstname name \n address lines \n zip town \n country
 	{
 		$ret .= $object->zip ? (($ret ? $sep : '' ).$object->zip) : '';

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -390,8 +390,10 @@ function pdf_build_address($outputlangs,$sourcecompany,$targetcompany='',$target
 
 	if (! empty($sourcecompany->state_id) && empty($sourcecompany->departement)) $sourcecompany->departement=getState($sourcecompany->state_id); //TODO deprecated
 	if (! empty($sourcecompany->state_id) && empty($sourcecompany->state))       $sourcecompany->state=getState($sourcecompany->state_id);
+	if (! empty($sourcecompany->state_id) && !isset($sourcecompany->departement_id))   $sourcecompany->departement_id=getState($sourcecompany->state_id,'2');
 	if (! empty($targetcompany->state_id) && empty($targetcompany->departement)) $targetcompany->departement=getState($targetcompany->state_id); //TODO deprecated
 	if (! empty($targetcompany->state_id) && empty($targetcompany->state))       $targetcompany->state=getState($targetcompany->state_id);
+	if (! empty($targetcompany->state_id) && !isset($targetcompany->departement_id))   $targetcompany->departement_id=getState($targetcompany->state_id,'2');
 
 	$reshook=0;
 	$stringaddress = '';


### PR DESCRIPTION
Fixes #7785

This PR adds support for Italian addresses format.

Italian format is
```
Name Surname || Company
Street address
ZIP code City (Province ID)
Optional: Country
```
