### PR TITLE
NEW deposits can be converted even if unpaid

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -677,7 +677,7 @@ if (empty($reshook))
 		$result=$discountcheck->fetch(0,$object->id);
 
 		$canconvert=0;
-		if ($object->type == Facture::TYPE_DEPOSIT && $object->paye == 1 && empty($discountcheck->id)) $canconvert=1;	// we can convert deposit into discount if deposit is payed completely and not already converted (see real condition into condition used to show button converttoreduc)
+		if ($object->type == Facture::TYPE_DEPOSIT && empty($discountcheck->id)) $canconvert=1;	// we can convert deposit into discount if deposit is payed completely and not already converted (see real condition into condition used to show button converttoreduc)
 		if (($object->type == Facture::TYPE_CREDIT_NOTE || $object->type == Facture::TYPE_STANDARD) && $object->paye == 0 && empty($discountcheck->id)) $canconvert=1;	// we can convert credit note into discount if credit note is not payed back and not already converted and amount of payment is 0 (see real condition into condition used to show button converttoreduc)
 		if ($canconvert)
 		{
@@ -763,16 +763,20 @@ if (empty($reshook))
 
 			if (empty($error))
 			{
-				// Classe facture
-				$result = $object->set_paid($user);
-				if ($result >= 0)
-				{
+				if($object->type != Facture::TYPE_DEPOSIT) {
+					// Classe facture
+					$result = $object->set_paid($user);
+					if ($result >= 0)
+					{
+						$db->commit();
+					}
+					else
+					{
+						setEventMessages($object->error, $object->errors, 'errors');
+						$db->rollback();
+					}
+				} else {
 					$db->commit();
-				}
-				else
-				{
-					setEventMessages($object->error, $object->errors, 'errors');
-					$db->rollback();
 				}
 			}
 			else
@@ -4258,7 +4262,7 @@ else if ($id > 0 || ! empty($ref))
 					print '<div class="inline-block divButAction"><a class="butAction" href="' . $_SERVER["PHP_SELF"] . '?facid=' . $object->id . '&amp;action=converttoreduc">' . $langs->trans('ConvertToReduc') . '</a></div>';
 				}
 				// For deposit invoice
-				if ($object->type == Facture::TYPE_DEPOSIT && $object->paye == 1 && $resteapayer == 0 && $user->rights->facture->creer && empty($discount->id))
+				if ($object->type == Facture::TYPE_DEPOSIT && $user->rights->facture->creer && empty($discount->id))
 				{
 					print '<div class="inline-block divButAction"><a class="butAction" href="'.$_SERVER["PHP_SELF"].'?facid='.$object->id.'&amp;action=converttoreduc">'.$langs->trans('ConvertToReduc').'</a></div>';
 				}


### PR DESCRIPTION
If my deposit invoice is unpaid and I have to create my final invoice, I can't deduce my deposit. Now a deposit can be converted to future deduction even if unpaid. This allows to create the final invoice and when the customer pays the deposit and the final invoice, I can record the payment on the 2 invoices.

What do you think ? 