### PR TITLE
New extrafields replicated on contract creation

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1090,6 +1090,10 @@ if ($action == 'create')
 			$objectsrc->fetch(GETPOST('originid'));
 			if (empty($objectsrc->lines) && method_exists($objectsrc,'fetch_lines'))  $objectsrc->fetch_lines();
 			$objectsrc->fetch_thirdparty();
+			
+			// Replicate extrafields
+			$objectsrc->fetch_optionals($originid);
+			$object->array_options = $objectsrc->array_options;
 
 			$projectid          = (!empty($objectsrc->fk_project)?$objectsrc->fk_project:'');
 


### PR DESCRIPTION
When creating a contract from another document (ie a proposal), now extrafields are retrieved too