### PR TITLE
Fix include class WorkboardResponse

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -383,7 +383,7 @@ if ($showweather) $boxwork.='<th class="liste_titre hideonsmartphone" width="80"
 $boxwork.='</tr>'."\n";
 
 // Do not include sections without management permission
-require DOL_DOCUMENT_ROOT.'/core/class/workboardresponse.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/workboardresponse.class.php';
 
 // Number of actions to do (late)
 if (! empty($conf->agenda->enabled) && $user->rights->agenda->myactions->read)


### PR DESCRIPTION
# Fix
I'm developping a new module to duplication the "Working board" (Open items dashboard) as a box
I need to include the class WorkboardResponse but I can't do it because the require come to late with the key word 'require' and produce a fatal error

This should be apply for upper versions