### PR TITLE
fix: unable to remove salaries, plus correct default rights management

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -242,17 +242,17 @@ function restrictedArea($user, $features, $objectid=0, $tableandshare='', $featu
             {
             	foreach($feature2 as $subfeature)
             	{
-            		if (empty($user->rights->$feature->$subfeature->creer)
-            		&& empty($user->rights->$feature->$subfeature->write)
-            		&& empty($user->rights->$feature->$subfeature->create)) { $createok=0; $nbko++; }
+                        if (empty($user->rights->{$feature}->{$subfeature}->creer)
+                        && empty($user->rights->{$feature}->{$subfeature}->write)
+                        && empty($user->rights->{$feature}->{$subfeature}->create)) { $createok=0; $nbko++; }
             		else { $createok=1; break; } // Break to bypass second test if the first is ok
             	}
             }
             else if (! empty($feature))		// This is for old permissions ('creer' or 'write')
             {
                 //print '<br>feature='.$feature.' creer='.$user->rights->$feature->creer.' write='.$user->rights->$feature->write;
-                if (empty($user->rights->$feature->creer)
-                && empty($user->rights->$feature->write)) { $createok=0; $nbko++; }
+                if (empty($user->rights->{$feature}->creer)
+                && empty($user->rights->{$feature}->write)) { $createok=0; $nbko++; }
             }
         }
 
@@ -306,21 +306,24 @@ function restrictedArea($user, $features, $objectid=0, $tableandshare='', $featu
             else if ($feature == 'ftp')
             {
                 if (! $user->rights->ftp->write) $deleteok=0;
+            }else if ($feature == 'salaries')
+            {
+                if (! $user->rights->salaries->delete) $deleteok=0;
             }
             else if (! empty($feature2))	// This should be used for future changes
             {
             	foreach($feature2 as $subfeature)
             	{
-            		if (empty($user->rights->$feature->$subfeature->supprimer) && empty($user->rights->$feature->$subfeature->delete)) $deleteok=0;
+            		if (empty($user->rights->{$feature}->{$subfeature}->supprimer) && empty($user->rights->$feature->$subfeature->delete)) $deleteok=0;
             		else { $deleteok=1; break; } // For bypass the second test if the first is ok
             	}
             }
             else if (! empty($feature))		// This is for old permissions
             {
                 //print '<br>feature='.$feature.' creer='.$user->rights->$feature->supprimer.' write='.$user->rights->$feature->delete;
-                if (empty($user->rights->$feature->supprimer)
-                && empty($user->rights->$feature->delete)
-                && empty($user->rights->$feature->run)) $deleteok=0;
+                if (empty($user->rights->{$feature}->supprimer)
+                && empty($user->rights->{$feature}->delete)
+                && empty($user->rights->{$feature}->run)) $deleteok=0;
             }
         }
 

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -242,17 +242,17 @@ function restrictedArea($user, $features, $objectid=0, $tableandshare='', $featu
             {
             	foreach($feature2 as $subfeature)
             	{
-                        if (empty($user->rights->{$feature}->{$subfeature}->creer)
-                        && empty($user->rights->{$feature}->{$subfeature}->write)
-                        && empty($user->rights->{$feature}->{$subfeature}->create)) { $createok=0; $nbko++; }
+                        if (empty($user->rights->$feature->$subfeature->creer)
+                        && empty($user->rights->$feature->$subfeature->write)
+                        && empty($user->rights->$feature->$subfeature->create)) { $createok=0; $nbko++; }
             		else { $createok=1; break; } // Break to bypass second test if the first is ok
             	}
             }
             else if (! empty($feature))		// This is for old permissions ('creer' or 'write')
             {
                 //print '<br>feature='.$feature.' creer='.$user->rights->$feature->creer.' write='.$user->rights->$feature->write;
-                if (empty($user->rights->{$feature}->creer)
-                && empty($user->rights->{$feature}->write)) { $createok=0; $nbko++; }
+                if (empty($user->rights->$feature->creer)
+                && empty($user->rights->$feature->write)) { $createok=0; $nbko++; }
             }
         }
 
@@ -314,16 +314,16 @@ function restrictedArea($user, $features, $objectid=0, $tableandshare='', $featu
             {
             	foreach($feature2 as $subfeature)
             	{
-            		if (empty($user->rights->{$feature}->{$subfeature}->supprimer) && empty($user->rights->$feature->$subfeature->delete)) $deleteok=0;
+            		if (empty($user->rights->$feature->$subfeature->supprimer) && empty($user->rights->$feature->$subfeature->delete)) $deleteok=0;
             		else { $deleteok=1; break; } // For bypass the second test if the first is ok
             	}
             }
             else if (! empty($feature))		// This is for old permissions
             {
                 //print '<br>feature='.$feature.' creer='.$user->rights->$feature->supprimer.' write='.$user->rights->$feature->delete;
-                if (empty($user->rights->{$feature}->supprimer)
-                && empty($user->rights->{$feature}->delete)
-                && empty($user->rights->{$feature}->run)) $deleteok=0;
+                if (empty($user->rights->$feature->supprimer)
+                && empty($user->rights->$feature->delete)
+                && empty($user->rights->$feature->run)) $deleteok=0;
             }
         }
 


### PR DESCRIPTION
# Fix unable to remove salaries
Access denied showed whenever one try to delete a Salary
root cause: system was checking $user->rights->salaries->payements->delete (from feature2 if) iso $user->rights->salaries->delete. because the current right doesn't seem to be aligned with the future way of working I have added an exeption

Also I have doubt that the generic code was working because the code was checking rights like this:
$user->rights->$feature->$subfeature->creer
but to be able to process the value of $feature and $subfeature I trust it should be like 
$user->rights->{$feature}->{$subfeature}->creer
(first post I found to SO: https://stackoverflow.com/questions/3515861/how-can-i-access-an-object-property-named-as-a-variable-in-php)


