### PR TITLE
public holiday in austria

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -706,6 +706,93 @@ function num_public_holiday($timestampStart, $timestampEnd, $countrycode='FR', $
 			if($jour_semaine == 0 || $jour_semaine == 6) $ferie=true;
 			//Samedi (6) et dimanche (0)
 		}
+		
+		if ($countrycode == 'AT')
+		{
+		    $countryfound=1;
+		    
+		    // Definition des dates feriees fixes
+		    if($jour == 1 && $mois == 1)   $ferie=true; // Neujahr
+		    if($jour == 6 && $mois == 1)   $ferie=true; // Hl. 3 Koenige
+		    if($jour == 1 && $mois == 5)   $ferie=true; // 1. Mai
+		    if($jour == 15 && $mois == 8)  $ferie=true; // Mariae Himmelfahrt
+		    if($jour == 26 && $mois == 10) $ferie=true; // 26. Oktober
+		    if($jour == 1 && $mois == 11)  $ferie=true; // Allerheiligen
+		    if($jour == 8 && $mois == 12)  $ferie=true; // Mariae Empfaengnis
+		    if($jour == 24 && $mois == 12) $ferie=true; // Heilig abend
+		    if($jour == 25 && $mois == 12) $ferie=true; // Christtag
+		    if($jour == 26 && $mois == 12) $ferie=true; // Stefanietag
+		    if($jour == 31 && $mois == 12) $ferie=true; // Silvester
+		    
+		    // Easter calculation
+		    $date_paques = easter_date($annee);
+		    $jour_paques = date("d", $date_paques);
+		    $mois_paques = date("m", $date_paques);
+		    if($jour_paques == $jour && $mois_paques == $mois) $ferie=true;
+		    // Easter sunday
+		    
+		    // Monday after easter
+		    $date_eastermonday = mktime(
+		        date("H", $date_paques),
+		        date("i", $date_paques),
+		        date("s", $date_paques),
+		        date("m", $date_paques),
+		        date("d", $date_paques) + 1,
+		        date("Y", $date_paques)
+		        );
+		    $jour_eastermonday = date("d", $date_eastermonday);
+		    $mois_eastermonday = date("m", $date_eastermonday);
+		    if($jour_eastermonday == $jour && $mois_eastermonday == $mois) $ferie=true;
+		    // Easter monday
+		    
+		    // Christi Himmelfahrt (39 days after easter sunday)
+		    $date_ch = mktime(
+		        date("H", $date_paques),
+		        date("i", $date_paques),
+		        date("s", $date_paques),
+		        date("m", $date_paques),
+		        date("d", $date_paques) + 39,
+		        date("Y", $date_paques)
+		        );
+		    $jour_ch = date("d", $date_ch);
+		    $mois_ch = date("m", $date_ch);
+		    if($jour_ch == $jour && $mois_ch == $mois) $ferie=true;
+		    // Christi Himmelfahrt
+		    
+		    // Pfingsten (50 days after easter sunday)
+		    $date_pentecote = mktime(
+		        date("H", $date_paques),
+		        date("i", $date_paques),
+		        date("s", $date_paques),
+		        date("m", $date_paques),
+		        date("d", $date_paques) + 50,
+		        date("Y", $date_paques)
+		        );
+		    $jour_pentecote = date("d", $date_pentecote);
+		    $mois_pentecote = date("m", $date_pentecote);
+		    if($jour_pentecote == $jour && $mois_pentecote == $mois) $ferie=true;
+		    // Pfingsten
+		    
+		    // Fronleichnam (60 days after easter sunday)
+		    $date_fronleichnam = mktime(
+		        date("H", $date_paques),
+		        date("i", $date_paques),
+		        date("s", $date_paques),
+		        date("m", $date_paques),
+		        date("d", $date_paques) + 60,
+		        date("Y", $date_paques)
+		        );
+		    $jour_fronleichnam = date("d", $date_fronleichnam);
+		    $mois_fronleichnam = date("m", $date_fronleichnam);
+		    if($jour_fronleichnam == $jour && $mois_fronleichnam == $mois) $ferie=true;
+		    // Fronleichnam
+
+		    // Calul des samedis et dimanches
+		    $jour_julien = unixtojd($timestampStart);
+		    $jour_semaine = jddayofweek($jour_julien, 0);
+		    if($jour_semaine == 0 || $jour_semaine == 6) $ferie=true;
+		    //Samedi (6) et dimanche (0)
+		}
 
 		// Cas pays non defini
 		if (! $countryfound)


### PR DESCRIPTION
# New public holidays in austria
All common public holidays in austria. Not included: federal state related holidays (e.g. "Leopold" only in Vienna and Lower Austria,...)
