### PR TITLE
NEW Show total number of records by category

### DIFF
--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -353,7 +353,7 @@ if ($type == Categorie::TYPE_PRODUCT)
 
 		print "<br>";
 		print "<table class='noborder' width='100%'>\n";
-		print '<tr class="liste_titre"><td colspan="3">'.$langs->trans("ProductsAndServices")."</td></tr>\n";
+		print '<tr class="liste_titre"><td colspan="3">'.$langs->trans("ProductsAndServices")." (".count($prods).")</td></tr>\n";
 
 		if (count($prods) > 0)
 		{
@@ -402,7 +402,7 @@ if ($type == Categorie::TYPE_SUPPLIER)
 	{
 		print "<br>";
 		print '<table class="noborder" width="100%">'."\n";
-		print '<tr class="liste_titre"><td colspan="2">'.$langs->trans("Suppliers")."</td></tr>\n";
+		print '<tr class="liste_titre"><td colspan="2">'.$langs->trans("Suppliers")." (".count($socs).")</td></tr>\n";
 
 		if (count($socs) > 0)
 		{
@@ -451,7 +451,7 @@ if($type == Categorie::TYPE_CUSTOMER)
 	{
 		print "<br>";
 		print '<table class="noborder" width="100%">'."\n";
-		print '<tr class="liste_titre"><td colspan="2">'.$langs->trans("Customers")."</td></tr>\n";
+		print '<tr class="liste_titre"><td colspan="2">'.$langs->trans("Customers")." (".count($socs).")</td></tr>\n";
 
 		if (count($socs) > 0)
 		{
@@ -507,7 +507,7 @@ if ($type == Categorie::TYPE_MEMBER)
 	{
 		print "<br>";
 		print "<table class='noborder' width='100%'>\n";
-		print '<tr class="liste_titre"><td colspan="4">'.$langs->trans("Member")."</td></tr>\n";
+		print '<tr class="liste_titre"><td colspan="4">'.$langs->trans("Member")." (".count($prods).")</td></tr>\n";
 
 		if (count($prods) > 0)
 		{
@@ -558,7 +558,7 @@ if ($type == Categorie::TYPE_CONTACT)
 	{
 		print "<br>";
 		print '<table class="noborder" width="100%">'."\n";
-		print '<tr class="liste_titre"><td colspan="2">'.$langs->trans("Contact")."</td></tr>\n";
+		print '<tr class="liste_titre"><td colspan="2">'.$langs->trans("Contact")." (".count($contacts).")</td></tr>\n";
 
 		if (count($contacts) > 0)
 		{
@@ -613,7 +613,7 @@ if ($type == Categorie::TYPE_ACCOUNT)
     {
         print "<br>";
         print "<table class='noborder' width='100%'>\n";
-        print '<tr class="liste_titre"><td colspan="4">'.$langs->trans("Account")."</td></tr>\n";
+        print '<tr class="liste_titre"><td colspan="4">'.$langs->trans("Account")." (".count($accounts).")</td></tr>\n";
 
         if (count($accounts) > 0)
         {
@@ -666,7 +666,7 @@ if ($type == Categorie::TYPE_PROJECT)
 	{
 		print "<br>";
 		print "<table class='noborder' width='100%'>\n";
-		print '<tr class="liste_titre"><td colspan="4">'.$langs->trans("Project")."</td></tr>\n";
+		print '<tr class="liste_titre"><td colspan="4">'.$langs->trans("Project")." (".count($projects).")</td></tr>\n";
 
 		if (count($projects) > 0)
 		{


### PR DESCRIPTION
# New Here is a small hack to display the total number of record(s) in the list header of each category.

There is so much information missing in these categories and it is also not possible to sort or display other information than currently displayed.

Developed for a client, here is a small hack to display the total number of record (s) in the list header of each category.

I do not currently know how to sort, eg Thirds by name. But that would be a next step ... ;-)