### PR TITLE
Fix extrafields transmition from supplier order to supplier invoice : lines part

### DIFF
--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -414,7 +414,7 @@ function ajax_combobox($htmlname, $events=array(), $minLengthToAutocomplete=0, $
 	if ($forcefocus) $msg.= '.select2(\'focus\')';
 	$msg.= ';'."\n";
 
-	if (count($events))    // If an array of js events to do were provided.
+	if (is_array($events) && count($events))    // If an array of js events to do were provided.
 	{
 		$msg.= '
 			jQuery("#'.$htmlname.'").change(function () {

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -679,6 +679,11 @@ if (empty($reshook))
 								$desc=($lines[$i]->desc?$lines[$i]->desc:$lines[$i]->libelle);
 								$product_type=($lines[$i]->product_type?$lines[$i]->product_type:0);
 
+								// Extrafields
+								if (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED) && method_exists($lines[$i], 'fetch_optionals')) {
+									$lines[$i]->fetch_optionals($lines[$i]->rowid);
+								}
+								
 								// Dates
 								// TODO mutualiser
 								$date_start=$lines[$i]->date_debut_prevue;


### PR DESCRIPTION
This is following of fix #7608

When an user create a supplier's invoice from a supplier order, **lines** extrafields are not copied.

Lorsqu'un utilisateur crée la facture d'un fournisseur à partir d'une commande fournisseur, les champs supplémentaires **des lignes**  ne sont pas copiés.