### PR TITLE
Fix #8034 - Surface and volume units are calculated incorrectly

### DIFF
--- a/htdocs/core/lib/product.lib.php
+++ b/htdocs/core/lib/product.lib.php
@@ -477,3 +477,42 @@ function measuring_units_string($unit,$measuring_style='')
 
 	return $measuring_units[$unit];
 }
+
+/**
+ *	Transform a given unit into the square of that unit, if known
+ *
+ *	@param	int		$unit            Unit key (-3,-2,-1,0,98,99...)
+ *	@return	int	   			         Squared unit key (-6,-4,-2,0,98,99...)
+ * 	@see	formproduct->load_measuring_units
+ */
+function measuring_units_squared($unit)
+{
+	$measuring_units=array();
+	$measuring_units[0] = 0;   // m -> m3
+	$measuring_units[-1] = -2; // dm-> dm2
+	$measuring_units[-2] = -4; // cm -> cm2
+	$measuring_units[-3] = -6; // mm -> mm2
+	$measuring_units[98] = 98; // foot -> foot2
+	$measuring_units[99] = 99; // inch -> inch2
+	return $measuring_units[$unit];
+}
+
+
+/**
+ *	Transform a given unit into the cube of that unit, if known
+ *
+ *	@param	int		$unit            Unit key (-3,-2,-1,0,98,99...)
+ *	@return	int	   			         Cubed unit key (-9,-6,-3,0,88,89...)
+ * 	@see	formproduct->load_measuring_units
+ */
+function measuring_units_cubed($unit)
+{
+	$measuring_units=array();
+	$measuring_units[0] = 0;   // m -> m2
+	$measuring_units[-1] = -3; // dm-> dm3
+	$measuring_units[-2] = -6; // cm -> cm3
+	$measuring_units[-3] = -9; // mm -> mm3
+	$measuring_units[98] = 88; // foot -> foot3
+	$measuring_units[99] = 89; // inch -> inch3
+	return $measuring_units[$unit];
+}

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -745,12 +745,12 @@ class Product extends CommonObject
 		if (empty($this->surface) && !empty($this->length) && !empty($this->width) && $this->length_units == $this->width_units)
 		{
 			$this->surface = $this->length * $this->width;
-			$this->surface_units = $this->length_units + $this->width_units;
+			$this->surface_units = measuring_units_squared($this->length_units);
 		}
 		if (empty($this->volume) && !empty($this->surface_units) && !empty($this->height) && $this->length_units == $this->height_units)
 		{
 			$this->volume =  $this->surface * $this->height;
-			$this->volume_units = $this->surface_units + $this->height_units;
+			$this->volume_units = measuring_units_cubed($this->height_units);
 		}
 
 		$this->surface = price2num($this->surface);


### PR DESCRIPTION
# Fix #8034 - Surface and volume units are calculated incorrectly

When you create a new product and specify width and height in inches or feet The volume and area measurement units are updated incorrectly.