### PR TITLE
NEW : Add password_hash as hash algorithm

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -82,7 +82,8 @@ function dol_hash($chain, $type='0')
 	global $conf;
 
 	// No need to add salt for password_hash
-	if ($type == '0' && ! empty($conf->global->MAIN_SECURITY_HASH_ALGO) && $conf->global->MAIN_SECURITY_HASH_ALGO == 'password_hash') return password_hash($chain, PASSWORD_DEFAULT);
+	if ($type == '0' && ! empty($conf->global->MAIN_SECURITY_HASH_ALGO) && $conf->global->MAIN_SECURITY_HASH_ALGO == 'password_hash' && function_exists('password_hash'))
+        return password_hash($chain, PASSWORD_DEFAULT);
 
 	// Salt value
 	if (! empty($conf->global->MAIN_SECURITY_SALT)) $chain=$conf->global->MAIN_SECURITY_SALT.$chain;
@@ -114,7 +115,7 @@ function dol_verifyHash($chain, $hash, $type='0')
 {
 	global $conf;
 
-	if ($type == '0' && ! empty($conf->global->MAIN_SECURITY_HASH_ALGO) && $conf->global->MAIN_SECURITY_HASH_ALGO == 'password_hash') {
+	if ($type == '0' && ! empty($conf->global->MAIN_SECURITY_HASH_ALGO) && $conf->global->MAIN_SECURITY_HASH_ALGO == 'password_hash' && function_exists('password_verify')) {
 		if ($hash[0] == '$') return password_verify($chain, $hash);
 		else if(strlen($hash) == 32) return dol_verifyHash($chain, $hash, '3'); // md5
 		else if(strlen($hash) == 40) return dol_verifyHash($chain, $hash, '2'); // sha1md5

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -81,6 +81,9 @@ function dol_hash($chain, $type='0')
 {
 	global $conf;
 
+	// No need to add salt for password_hash
+	if ($type == '0' && ! empty($conf->global->MAIN_SECURITY_HASH_ALGO) && $conf->global->MAIN_SECURITY_HASH_ALGO == 'password_hash') return password_hash($chain, PASSWORD_DEFAULT);
+
 	// Salt value
 	if (! empty($conf->global->MAIN_SECURITY_SALT)) $chain=$conf->global->MAIN_SECURITY_SALT.$chain;
 
@@ -94,6 +97,32 @@ function dol_hash($chain, $type='0')
 
 	// No particular encoding defined, use default
 	return md5($chain);
+}
+
+/**
+ * 	Compute a hash and compare it to the given one
+ *  For backward compatibility reasons, if the hash is not in the password_hash format, we will try to match against md5 and sha1md5
+ *  If constant MAIN_SECURITY_HASH_ALGO is defined, we use this function as hashing function.
+ *  If constant MAIN_SECURITY_SALT is defined, we use it as a salt.
+ *
+ * 	@param 		string		$chain		String to hash
+ * 	@param 		string		$hash		hash to compare
+ * 	@param		string		$type		Type of hash ('0':auto, '1':sha1, '2':sha1+md5, '3':md5, '4':md5 for OpenLdap, '5':sha256). Use '3' here, if hash is not needed for security purpose, for security need, prefer '0'.
+ * 	@return		bool					True if the computed hash is the same as the given one
+ */
+function dol_verifyHash($chain, $hash, $type='0')
+{
+	global $conf;
+
+	if ($type == '0' && ! empty($conf->global->MAIN_SECURITY_HASH_ALGO) && $conf->global->MAIN_SECURITY_HASH_ALGO == 'password_hash') {
+		if ($hash[0] == '$') return password_verify($chain, $hash);
+		else if(strlen($hash) == 32) return dol_verifyHash($chain, $hash, '3'); // md5
+		else if(strlen($hash) == 40) return dol_verifyHash($chain, $hash, '2'); // sha1md5
+
+		return false;
+	}
+
+	return dol_hash($chain, $type) == $hash;
 }
 
 
@@ -606,4 +635,3 @@ function accessforbidden($message='',$printheader=1,$printfooter=1,$showonlymess
     if ($printfooter && function_exists("llxFooter")) llxFooter();
     exit(0);
 }
-

--- a/htdocs/core/login/functions_dolibarr.php
+++ b/htdocs/core/login/functions_dolibarr.php
@@ -84,7 +84,7 @@ function check_user_password_dolibarr($usertotest,$passwordtotest,$entitytotest=
 				// Check crypted password according to crypt algorithm
 				if ($cryptType == 'md5')
 				{
-					if (dol_hash($passtyped) == $passcrypted)
+					if (dol_verifyHash($passtyped, $passcrypted))
 					{
 						$passok=true;
 						dol_syslog("functions_dolibarr::check_user_password_dolibarr Authentification ok - ".$cryptType." of pass is ok");
@@ -152,5 +152,3 @@ function check_user_password_dolibarr($usertotest,$passwordtotest,$entitytotest=
 
 	return $login;
 }
-
-

--- a/htdocs/install/step5.php
+++ b/htdocs/install/step5.php
@@ -181,7 +181,7 @@ if ($action == "set" || empty($action) || preg_match('/upgrade/i',$action))
     			    // Define default setup for password encryption
     			    dolibarr_set_const($db, "DATABASE_PWD_ENCRYPTED", "1", 'chaine', 0, '', $conf->entity);
     			    dolibarr_set_const($db, "MAIN_SECURITY_SALT", dol_print_date(dol_now(), 'dayhourlog'), 'chaine', 0, '', 0);      // All entities
-    			    dolibarr_set_const($db, "MAIN_SECURITY_HASH_ALGO", 'sha1md5', 'chaine', 0, '', 0);                               // All entities
+    			    dolibarr_set_const($db, "MAIN_SECURITY_HASH_ALGO", 'password_hash', 'chaine', 0, '', 0);                         // All entities
     			}
 		    }
 

--- a/htdocs/install/step5.php
+++ b/htdocs/install/step5.php
@@ -181,7 +181,10 @@ if ($action == "set" || empty($action) || preg_match('/upgrade/i',$action))
     			    // Define default setup for password encryption
     			    dolibarr_set_const($db, "DATABASE_PWD_ENCRYPTED", "1", 'chaine', 0, '', $conf->entity);
     			    dolibarr_set_const($db, "MAIN_SECURITY_SALT", dol_print_date(dol_now(), 'dayhourlog'), 'chaine', 0, '', 0);      // All entities
-    			    dolibarr_set_const($db, "MAIN_SECURITY_HASH_ALGO", 'password_hash', 'chaine', 0, '', 0);                         // All entities
+                    if (function_exists('password_hash'))
+                        dolibarr_set_const($db, "MAIN_SECURITY_HASH_ALGO", 'password_hash', 'chaine', 0, '', 0);                     // All entities
+                    else
+                        dolibarr_set_const($db, "MAIN_SECURITY_HASH_ALGO", 'sha1md5', 'chaine', 0, '', 0);                           // All entities
     			}
 		    }
 

--- a/htdocs/user/passwordforgotten.php
+++ b/htdocs/user/passwordforgotten.php
@@ -78,7 +78,7 @@ if ($action == 'validatenewpassword' && $username && $passwordhash)
     }
     else
     {
-        if (dol_hash($edituser->pass_temp) == $passwordhash)
+        if (dol_verifyHash($edituser->pass_temp, $passwordhash))
         {
             $newpassword=$edituser->setPassword($user,$edituser->pass_temp,0);
             dol_syslog("passwordforgotten.php new password for user->id=".$edituser->id." validated in database");
@@ -238,4 +238,3 @@ $reshook = $hookmanager->executeHooks('getPasswordForgottenPageExtraOptions',$pa
 $moreloginextracontent = $hookmanager->resPrint;
 
 include $template_dir.'passwordforgotten.tpl.php';	// To use native PHP
-


### PR DESCRIPTION
As pointed out by #5950, md5 (or sha1md5) hash of passwords is much better than clear text but this is still not the recommanded way to do it. It doens't really matter which algo we use, it will allways be outdated in few years.

That's why `password_hash` and `password_verify` exist in PHP, they will use the current recommanded (bcrypt) hashing algorithm and take care about the salt. Every hash generated by `password_hash` has a prefix that indicate the type of the hash to keep backward compatibilty and accept multiple types of hashes.

This PR add `password_hash` as a hash algorithm to replace `md5`, `sha1md5` and `sha1`. To encourage the upgrade, I made it backward-compatible, `md5` and `sha1md5` will still work to authenticate, but new password will be generated with `password_hash`.