### PR TITLE
Added order status =1 or =2 for overview of orders

### DIFF
--- a/htdocs/comm/index.php
+++ b/htdocs/comm/index.php
@@ -768,7 +768,7 @@ if (! empty($conf->commande->enabled) && $user->rights->commande->lire)
 	if (! $user->rights->societe->client->voir && ! $socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 	$sql.= " WHERE c.fk_soc = s.rowid";
 	$sql.= " AND c.entity IN (".getEntity('commande').")";
-	$sql.= " AND c.fk_statut = 1";
+	$sql.= " AND (c.fk_statut = 1 or c.fk_statut = 2)";
 	if (! $user->rights->societe->client->voir && ! $socid) $sql.= " AND s.rowid = sc.fk_soc AND sc.fk_user = " .$user->id;
 	if ($socid) $sql.= " AND s.rowid = ".$socid;
 	$sql.= " ORDER BY c.rowid DESC";

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -316,7 +316,7 @@ if (empty($reshook))
 										$label = (! empty($prod->multilangs[$outputlangs->defaultlang]["libelle"])) ? $prod->multilangs[$outputlangs->defaultlang]["libelle"] : $lines[$i]->product_label;
 									} else {
 										$prod->fetch($lines[$i]->fk_product);
-										$label .= $lines[$i]->product_label;
+										$label = $lines[$i]->product_label;
 									}
 
 									if ($prod->duration_value && $conf->global->FICHINTER_USE_SERVICE_DURATION) {


### PR DESCRIPTION
# New Added order status =1 or =2 for overview of orders
At the overview of orders there are only status '3' visibl. Added status '2' to see open and ongoing orders which are otherwise be invisible and easily missed.
