### PR TITLE
NEW Add confirmation button at bottom of reconciliation page

### DIFF
--- a/htdocs/compta/bank/bankentries_list.php
+++ b/htdocs/compta/bank/bankentries_list.php
@@ -1442,6 +1442,14 @@ if ($resql)
 	print "</table>";
 	print "</div>";
 
+    if ($user->rights->banque->consolidate && $action == 'reconcile') {
+        print '<div class="tabsAction">';
+        print '<div class="inline-block divButAction">';
+        print '<input class="button" name="confirm_reconcile" type="submit" value="' . $langs->trans("Conciliate") . '">';
+        print "</div>";
+        print "</div>";
+    }
+
     print '</form>';
 	$db->free($resql);
 }


### PR DESCRIPTION
Small ergonomic improvement of the reconciliation page.

Confirming at the bottom of the page after ticking the lines is easier!