### PR TITLE
FIX email sent was not in HTML

### DIFF
--- a/htdocs/compta/prelevement/class/rejetprelevement.class.php
+++ b/htdocs/compta/prelevement/class/rejetprelevement.class.php
@@ -236,7 +236,7 @@ class RejetPrelevement
 
 			require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
 
-			$subject = $langs->trans("InfoRejectSubject");
+			$subject = $langs->transnoentities("InfoRejectSubject");
 			$sendto = $emuser->getFullName($langs)." <".$emuser->email.">";
 			$from = $this->user->getFullName($langs)." <".$this->user->email.">";
 			$msgishtml=1;

--- a/htdocs/compta/prelevement/class/rejetprelevement.class.php
+++ b/htdocs/compta/prelevement/class/rejetprelevement.class.php
@@ -239,7 +239,7 @@ class RejetPrelevement
 			$subject = $langs->trans("InfoRejectSubject");
 			$sendto = $emuser->getFullName($langs)." <".$emuser->email.">";
 			$from = $this->user->getFullName($langs)." <".$this->user->email.">";
-			$msgishtml=0;
+			$msgishtml=1;
 
 			$arr_file = array();
 			$arr_mime = array();


### PR DESCRIPTION
The mail was sent plain/text. So customers could seen many &eacute; &egrav ...
The RejectMessage traduction contains html code like br. SO i just changed mimeType for this mail