### PR TITLE
FIX: Global on $user parameter reset the variable

### DIFF
--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -140,7 +140,7 @@ class Fichinter extends CommonObject
 	 */
 	function create($user, $notrigger=0)
 	{
-		global $conf, $user, $langs;
+		global $conf, $langs;
 
 		dol_syslog(get_class($this)."::create ref=".$this->ref);
 


### PR DESCRIPTION
FIX: Global on $user parameter reset the variable

When we use the fichinter API with global, the $user object is reset
If global is not applied on $user we can retrieve the informations from it

I didn't create the issue yet because maybe I did an error for the API file
Related to https://github.com/Dolibarr/dolibarr/pull/8104

Cheers