### PR TITLE
NEW [REST API] Add the possibility to remove a category from a thirdparty

### DIFF
--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -552,7 +552,45 @@ class Thirdparties extends DolibarrApi
       return $this->company;
     }
 
+    /**
+     * Delete category to a thirdparty
+     *
+     * @param int		$id	Id of thirdparty
+     * @param array     $request_data   Request datas
+     *
+     * @return mixed
+     *
+     * @url POST {id}/deleteCategory
+     */
+    function deleteCategory($id, $request_data = NULL) {
+        if (!isset($request_data["category_id"]))
+            throw new RestException(400, "category_id field missing");
+        $category_id = $request_data["category_id"];
 
+      if(! DolibarrApiAccess::$user->rights->societe->creer) {
+			  throw new RestException(401);
+      }
+
+      $result = $this->company->fetch($id);
+      if( ! $result ) {
+          throw new RestException(404, 'Thirdparty not found');
+      }
+      $category = new Categorie($this->db);
+      $result = $category->fetch($category_id);
+      if( ! $result ) {
+          throw new RestException(404, 'category not found');
+      }
+
+      if( ! DolibarrApi::_checkAccessToResource('societe',$this->company->id)) {
+        throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+      }
+      if( ! DolibarrApi::_checkAccessToResource('category',$category->id)) {
+        throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+      }
+
+      $category->del_type($this->company,'customer');
+      return $this->company;
+    }
 
     /**
      * Get outstanding proposals of thirdparty


### PR DESCRIPTION
I added one function to the thirdparty rest api class.

One thing I am still wondering is if there is a good reason for not proposing to unlink a category from a thirdparty but if it is not the case here is a piece of code allowing to remove a category.

I don't have much to say about it, it's pretty straightforward.

That works for me and seems general enough to be useful to other people.
The new function is inspired from the addCategory function.
