### PR TITLE
Fix : contract service list context was mixing up with service list from product/service module

### DIFF
--- a/htdocs/contrat/services.php
+++ b/htdocs/contrat/services.php
@@ -75,7 +75,7 @@ $opclotureyear=GETPOST('opclotureyear');
 $filter_opcloture=GETPOST('filter_opcloture');
 
 // Initialize context for list
-$contextpage=GETPOST('contextpage','aZ')?GETPOST('contextpage','aZ'):'servicelist'.$mode;
+$contextpage=GETPOST('contextpage','aZ')?GETPOST('contextpage','aZ'):'contractservicelist'.$mode;
 
 // Initialize technical object to manage hooks of thirdparties. Note that conf->hooks_modules contains array array
 $hookmanager->initHooks(array($contextpage));


### PR DESCRIPTION
When user was choosing columns to display on service list and on contract service list, the customization were crashing with each other