### PR TITLE
Bank module is not accessible (error 500) since 7.0.0

### DIFF
--- a/htdocs/compta/tva/class/tva.class.php
+++ b/htdocs/compta/tva/class/tva.class.php
@@ -655,7 +655,7 @@ class Tva extends CommonObject
      *  @param	string	$morecss		More CSS
 	 *	@return	string					Chaine with URL
 	 */
-	function getNomUrl($withpicto=0, $option='', $notooltip=0, morecss='')
+	function getNomUrl($withpicto=0, $option='', $notooltip=0, $morecss='')
 	{
 		global $langs, $conf;
 
@@ -669,6 +669,9 @@ class Tva extends CommonObject
         $linkclose='';
         if (empty($notooltip))
         {
+
+
+            
         	if (! empty($conf->global->MAIN_OPTIMIZEFORTEXTBROWSER))
         	{
         		$label=$langs->trans("ShowMyObject");


### PR DESCRIPTION
Since the latest version of 7.0.0 the bank module is not accessible. => Error 500.

This PR fixes the error 500.