### PR TITLE
Fix 8183 - adherent welcome e-mail edition always put 1 instead of keeping the e-mail

### DIFF
--- a/htdocs/adherents/type.php
+++ b/htdocs/adherents/type.php
@@ -96,7 +96,7 @@ if ($action == 'add' && $user->rights->adherent->configurer)
 		$object->label			= trim($label);
 		$object->subscription	= (int) trim($subscription);
 		$object->note			= trim($comment);
-		$object->mail_valid		= (boolean) trim($mail_valid);
+		$object->mail_valid		= $db->escape(trim($mail_valid));
 		$object->vote			= (boolean) trim($vote);
 
 		// Fill array 'array_options' with data from add form
@@ -134,7 +134,7 @@ if ($action == 'update' && $user->rights->adherent->configurer)
 		$object->label        = trim($label);
 		$object->subscription   = (int) trim($subscription);
 		$object->note           = trim($comment);
-		$object->mail_valid     = (boolean) trim($mail_valid);
+		$object->mail_valid     = $db->escape(trim($mail_valid));
 		$object->vote           = (boolean) trim($vote);
 
 		// Fill array 'array_options' with data from add form

--- a/htdocs/adherents/type.php
+++ b/htdocs/adherents/type.php
@@ -96,7 +96,7 @@ if ($action == 'add' && $user->rights->adherent->configurer)
 		$object->label			= trim($label);
 		$object->subscription	= (int) trim($subscription);
 		$object->note			= trim($comment);
-		$object->mail_valid		= $db->escape(trim($mail_valid));
+		$object->mail_valid		= trim($mail_valid);
 		$object->vote			= (boolean) trim($vote);
 
 		// Fill array 'array_options' with data from add form

--- a/htdocs/adherents/type.php
+++ b/htdocs/adherents/type.php
@@ -134,7 +134,7 @@ if ($action == 'update' && $user->rights->adherent->configurer)
 		$object->label        = trim($label);
 		$object->subscription   = (int) trim($subscription);
 		$object->note           = trim($comment);
-		$object->mail_valid     = $db->escape(trim($mail_valid));
+		$object->mail_valid     = trim($mail_valid);
 		$object->vote           = (boolean) trim($vote);
 
 		// Fill array 'array_options' with data from add form


### PR DESCRIPTION
Fix the adherent welcome e-mail.

Instead of editing and keeping the text, the edit returns 1.

[see: #8183]