### PR TITLE
NEW Load product data optional fields to the line -> enables to use "line_options_{extrafield}"

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -529,10 +529,13 @@ abstract class CommonDocGenerator
 		$resarray = $this->fill_substitutionarray_with_extrafields($line,$resarray,$extrafields,$array_key=$array_key,$outputlangs);
 	
 		// Load product data optional fields to the line -> enables to use "line_options_{extrafield}"
-		$product = new Product($this->db);
-		$result = $product->fetch(null, $line->product_ref);
-		foreach($product->array_options as $key=>$label)
-			$resarray["line_".$key] = $label;
+		if (isset($line->product_ref))
+		{
+			$product = new Product($this->db);
+			$result = $product->fetch(null, $line->product_ref);
+			foreach($product->array_options as $key=>$label)
+				$resarray["line_".$key] = $label;
+		}		
 		
 		return $resarray;
 	}

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -527,7 +527,13 @@ abstract class CommonDocGenerator
 		$line->fetch_optionals($line->rowid,$extralabels);
 
 		$resarray = $this->fill_substitutionarray_with_extrafields($line,$resarray,$extrafields,$array_key=$array_key,$outputlangs);
-
+	
+		// Load product data optional fields to the line -> enables to use "line_options_{extrafield}"
+		$product = new Product($this->db);
+		$result = $product->fetch(null, $line->product_ref);
+		foreach($product->array_options as $key=>$label)
+			$resarray["line_".$key] = $label;
+		
 		return $resarray;
 	}
 


### PR DESCRIPTION
Load product optional fields to the line -> enables to use "line_options_{extrafield}"

This fixes the issue #3185
https://github.com/Dolibarr/dolibarr/issues/3185

