### PR TITLE
Fix issue with project.class.php elementarray null if num_rows = 0

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -584,10 +584,10 @@ class Project extends CommonObject
                     $i++;
                 }
                 $this->db->free($result);
-
-                /* Return array */
-                return $elements;
             }
+
+            /* Return array even if empty*/
+            return $elements;
         }
         else
         {


### PR DESCRIPTION
# Fix issue with project.class.php elementarray null if num_rows = 0
As is function get_element_list in project.class.php may return NULL if SQL query has no results, which will throw some warnings in project overview page