### PR TITLE
FIX misspelled restore_lastsearch_values

### DIFF
--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -117,7 +117,7 @@ if ($action == 'confirm_delete' && $confirm == 'yes' && $user->rights->stock->su
 	if ($result > 0)
 	{
 	    setEventMessages($langs->trans("RecordDeleted"), null, 'mesgs');
-		header("Location: ".DOL_URL_ROOT.'/product/stock/list.php?resotre_lastsearch_values=1');
+		header("Location: ".DOL_URL_ROOT.'/product/stock/list.php?restore_lastsearch_values=1');
 		exit;
 	}
 	else


### PR DESCRIPTION
# Fix misspelling in commit https://github.com/Dolibarr/dolibarr/commit/3c552cec15e48cb7a33cadfb4488f488150e3c2f
Fix misspelled restore_lastsearch_values