### PR TITLE
Fix missing insert bill_time in project.class on create

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -196,6 +196,7 @@ class Project extends CommonObject
         $sql.= ", " . ($this->date_end != '' ? "'".$this->db->idate($this->date_end)."'" : 'null');
         $sql.= ", " . (strcmp($this->opp_amount,'') ? price2num($this->opp_amount) : 'null');
         $sql.= ", " . (strcmp($this->budget_amount,'') ? price2num($this->budget_amount) : 'null');
+        $sql.= ", " . ($this->bill_time ? 1 : 0);
         $sql.= ", ".$conf->entity;
         $sql.= ")";
 


### PR DESCRIPTION
# Fix commit https://github.com/Dolibarr/dolibarr/commit/82475e2e5f17667bc7517baf5a46ac2c5327d7ff
Missing insert bill_time in project.class on create throws "Column count doesn't match value count at row 1"