### PR TITLE
FIX Duplicate product_type asignement on order addline

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1405,7 +1405,6 @@ class Commande extends CommonOrder
             $this->line->total_localtax1=$total_localtax1;
             $this->line->total_localtax2=$total_localtax2;
             $this->line->total_ttc=$total_ttc;
-            $this->line->product_type=$type;
             $this->line->special_code=$special_code;
             $this->line->origin=$origin;
             $this->line->origin_id=$origin_id;


### PR DESCRIPTION
On addline order method, ther is a duplicate assignation on
line->product_type before call to "insert" method.
The second assignement always make product_type to "0" while it was
fetched from product himsel like it was made on first asignement few
lines above

