### PR TITLE
Fix supplier order clone was keeping objectlinked

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -321,8 +321,6 @@ class CommandeFournisseur extends CommonOrder
 
             if ($this->statut == 0) $this->brouillon = 1;
 
-			$this->fetchObjectLinked();
-
 			//$result=$this->fetch_lines();
             $this->lines=array();
 


### PR DESCRIPTION
No need to fetch object linked in the object fetch, it's done after.
And here on supplier orders it's linking all object linked to the cloned object