### PR TITLE
Fix for PHP7.1: PHP Warning:  A non-numeric value in product.class.php

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1677,7 +1677,7 @@ class Product extends CommonObject
 			return -1;
 		}
 
-		if ($newprice!='' || $newprice==0)
+		if ($newprice !== '' || $newprice === 0)
 		{
 			if ($newpricebase == 'TTC')
 			{
@@ -1703,8 +1703,8 @@ class Product extends CommonObject
 				$price_ttc = ( $newnpr != 1 ) ? price2num($newprice) * (1 + ($newvat / 100)) : $price;
 				$price_ttc = price2num($price_ttc,'MU');
 
-				if ($newminprice!='' || $newminprice==0)
-				{
+				if ( $newminprice !== '' || $newminprice === 0)
+				{                                    
 					$price_min = price2num($newminprice,'MU');
 					$price_min_ttc = price2num($newminprice) * (1 + ($newvat / 100));
 					$price_min_ttc = price2num($price_min_ttc,'MU');


### PR DESCRIPTION
Since PHP7.1

PHP Warning:  A non-numeric value encountered in /Dolibarr/htdocs/product/class/product.class.php on line 1709