### PR TITLE
Add missing $mode in BookKeeping::createStd()

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -501,7 +501,7 @@ class BookKeeping extends CommonObject
 		}
 
 		if (! $error) {
-			$this->id = $this->db->last_insert_id(MAIN_DB_PREFIX . $this->table_element);
+			$this->id = $this->db->last_insert_id(MAIN_DB_PREFIX . $this->table_element . $mode);
 
 			if (! $notrigger) {
 				// Uncomment this and change MYOBJECT to your own tag if you


### PR DESCRIPTION
In accountancy ledger, creating new transaction, there is
'ERROR: 55000: currval of sequence "llx_accounting_bookkeeping_rowid_seq"
is not yet defined in this session' occurred.

According to dolibarr.log, this error will show up after
createStd() {...Insert request to llx_accounting_bookkeeping_tmp...}.

It query the "llx_accounting_bookkeeping_rowid_seq" instead of
"llx_accounting_bookkeeping_tmp_rowid_seq",
due to missing $mode at bookkeeping.class.php
line504:last_insert_id().

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #[*issue_number Short description*]
[*Long description*]


# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
