### PR TITLE
FIX compatibility with all type of stripeconnect account

### DIFF
--- a/htdocs/stripe/class/stripe.class.php
+++ b/htdocs/stripe/class/stripe.class.php
@@ -61,8 +61,8 @@ class Stripe extends CommonObject
 	{
 		global $conf;
 
-		$sql = "SELECT tokenstring";
-		$sql.= " FROM ".MAIN_DB_PREFIX."oauth_token";
+		$sql = "SELECT key_account, type";
+		$sql.= " FROM ".MAIN_DB_PREFIX."stripeconnect ";
 		$sql.= " WHERE entity = ".$conf->entity;
 		$sql.= " AND service = '".$mode."'";
 
@@ -73,13 +73,10 @@ class Stripe extends CommonObject
 			if ($this->db->num_rows($result))
 			{
 				$obj = $this->db->fetch_object($result);
-    			$tokenstring=$obj->tokenstring;
-
-    			$tmparray = dol_json_decode($tokenstring);
-    			$key = $tmparray->stripe_user_id;
+    			$key = $obj->key_account;
     		}
     		else {
-    			$tokenstring='';
+    			$key='';
     		}
     	}
     	else {
@@ -89,7 +86,7 @@ class Stripe extends CommonObject
     	dol_syslog("No dedicated Stipe Connect account available for entity".$conf->entity);
 		return $key;
 	}
-
+	
 	/**
 	 * getStripeCustomerAccount
 	 *


### PR DESCRIPTION
TODO transform it in class for recall key, type or other information without REST API Call for better and quick response
-> need type of account for select display or not some informations as link to stripe dashboard (not support in custom & express), standard must be default account for display
-> custom or express don't support Oauth just API connexion
-> LIVE & TEST account should be different 
 functional with standard and not stripeconnect mode (database create by addon module)