### PR TITLE
New filter on product supplier price import update

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -320,7 +320,7 @@ class modProduct extends DolibarrModules
 					'sp.unitprice'=>'50',
 					'sp.remise_percent'=>'0'
 			);
-			$this->import_updatekeys_array[$r]=array('sp.fk_product'=>'ProductOrService','sp.ref_fourn'=>'SupplierRef');
+			$this->import_updatekeys_array[$r]=array('sp.fk_product'=>'ProductOrService','sp.ref_fourn'=>'SupplierRef','sp.fk_soc'=>'Supplier');
 		}
 
 		if (! empty($conf->global->PRODUIT_MULTIPRICES))


### PR DESCRIPTION
If the same product has several suppliers with the same supplier ref, the update is not possible. This filter allows that.