### PR TITLE
FIX PropalStatusValidatedShort missing in langs/es_ES/propal.lang

### DIFF
--- a/htdocs/langs/es_ES/propal.lang
+++ b/htdocs/langs/es_ES/propal.lang
@@ -33,6 +33,7 @@ PropalStatusSigned=Firmado (a facturar)
 PropalStatusNotSigned=No firmado (cerrado)
 PropalStatusBilled=Facturado
 PropalStatusDraftShort=Borrador
+PropalStatusValidatedShort=Activo
 PropalStatusClosedShort=Cerrado
 PropalStatusSignedShort=Firmado
 PropalStatusNotSignedShort=No firmado


### PR DESCRIPTION
Added PropalStatusValidatedShort value, missing in lang/es_ES/propal.lang file.