### PR TITLE
FIX #7581 Import INSERT foreign key

### DIFF
--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -628,6 +628,9 @@ class ImportCsv extends ModeleImports
 								}
 							} else {
 								// We have a last INSERT ID. Check if we have a row referencing this foreign key.
+								// This is required when updating table with some extrafields. When inserting a record in parent table, we can make 
+								// a direct insert into subtable extrafields, but when me wake an update, the insertid is defined and the child record 
+								// may already exists. So we rescan the extrafield table to be know if record exists or not for the rowid.
 								$sqlSelect = 'SELECT rowid FROM '.$tablename;
 
 								if(empty($keyfield)) $keyfield = 'rowid';

--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -649,6 +649,31 @@ class ImportXlsx extends ModeleImports
 									$this->errors[$error]['type']='SQL';
 									$error++;
 								}
+							} else {
+								// We have a last INSERT ID. Check if we have a row referencing this foreign key.
+								$sqlSelect = 'SELECT rowid FROM '.$tablename;
+
+								if(empty($keyfield)) $keyfield = 'rowid';
+								$sqlSelect .= ' WHERE '.$keyfield.' = '.$lastinsertid;
+
+								$resql=$this->db->query($sqlSelect);
+								if($resql) {
+									$res = $this->db->fetch_object($resql);
+									if($resql->num_rows == 1) {
+										// We have a row referencing this last foreign key, continue with UPDATE.
+									} else {
+										// No record found referencing this last foreign key,
+										// force $lastinsertid to 0 so we INSERT below.
+										$lastinsertid = 0;
+									}
+								}
+								else
+								{
+									//print 'E';
+									$this->errors[$error]['lib']=$this->db->lasterror();
+									$this->errors[$error]['type']='SQL';
+									$error++;
+								}
 							}
 
 							if (!empty($lastinsertid)) {

--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -651,6 +651,9 @@ class ImportXlsx extends ModeleImports
 								}
 							} else {
 								// We have a last INSERT ID. Check if we have a row referencing this foreign key.
+								// This is required when updating table with some extrafields. When inserting a record in parent table, we can make 
+								// a direct insert into subtable extrafields, but when me wake an update, the insertid is defined and the child record 
+								// may already exists. So we rescan the extrafield table to be know if record exists or not for the rowid.
 								$sqlSelect = 'SELECT rowid FROM '.$tablename;
 
 								if(empty($keyfield)) $keyfield = 'rowid';


### PR DESCRIPTION
Hello,

Here is a fix for an **Import** module bug we have experienced affecting Dolibarr since 6.0.

Check the row referencing this foreign key exists first
instead of always trying to perform an UPDATE.

This seems to be a regression introduced by commit 1dcecf487306546e22f8ea1921d6b923fcff70f4

# Fix #7581 Extra fields not importing for products

> i have 2 extra fields in the products when importing with excel . its not importing . the value is empty in the database
> 
> Version 6.0.1

> same issue
> both for products and third parties
> 
> Version 6.0.3
> 
> No error message during import


# Tests

Some tests have been performed on Product extra fields (see "Famille": `extra.family`), with a simple CSV file containing 2 products:

1. Without fix:
![screenshot from 2018-03-26 15-00-41](https://user-images.githubusercontent.com/32769270/37918429-4ca86492-3121-11e8-99d9-5a76dfe04357.png)


![screenshot from 2018-03-26 15-01-42](https://user-images.githubusercontent.com/32769270/37918183-8df04aba-3120-11e8-97e8-7d573dfe661c.png)

![screenshot from 2018-03-26 15-01-22](https://user-images.githubusercontent.com/32769270/37918148-7b332244-3120-11e8-84d0-f43d71e5656b.png)


2. With fix:

![screenshot from 2018-03-26 15-03-06](https://user-images.githubusercontent.com/32769270/37918387-2df5ebf0-3121-11e8-895c-7553a6f442eb.png)


![screenshot from 2018-03-26 15-03-32](https://user-images.githubusercontent.com/32769270/37918220-a9a6a24a-3120-11e8-84a7-39f8154db1a6.png)

