### PR TITLE
FIX sql error using no category

### DIFF
--- a/htdocs/compta/bank/bankentries_list.php
+++ b/htdocs/compta/bank/bankentries_list.php
@@ -455,7 +455,7 @@ $parameters=array();
 $reshook=$hookmanager->executeHooks('printFieldListSelect',$parameters);    // Note that $action and $object may have been modified by hook
 $sql.=$hookmanager->resPrint;
 $sql.= " FROM ";
-if ($search_bid) $sql.= MAIN_DB_PREFIX."bank_class as l,";
+if ($search_bid>0) $sql.= MAIN_DB_PREFIX."bank_class as l,";
 $sql.= " ".MAIN_DB_PREFIX."bank_account as ba,";
 $sql.= " ".MAIN_DB_PREFIX."bank as b";
 if (is_array($extrafields->attribute_label) && count($extrafields->attribute_label)) $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."bank_extrafields as ef on (b.rowid = ef.fk_object)";


### PR DESCRIPTION
# Fix error on bankentries_list search
When searching something in this list, if we're using tags/cantegories and no category is defined, the select_category value is -1.

This causes troubles on results list.