### PR TITLE
Fix error on creating company with external module in 'custom' folder…

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -2511,7 +2511,7 @@ class Societe extends CommonObject
 
         if (! empty($conf->global->SOCIETE_CODECOMPTA_ADDON))
         {
-        	$file='';
+		$res=false;
             $dirsociete=array_merge(array('/core/modules/societe/'), $conf->modules_parts['societe']);
             foreach ($dirsociete as $dirroot)
             {

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -2515,17 +2515,12 @@ class Societe extends CommonObject
             $dirsociete=array_merge(array('/core/modules/societe/'), $conf->modules_parts['societe']);
             foreach ($dirsociete as $dirroot)
             {
-            	if (file_exists(DOL_DOCUMENT_ROOT.'/'.$dirroot.$conf->global->SOCIETE_CODECOMPTA_ADDON.".php"))
-            	{
-            		$file=$dirroot.$conf->global->SOCIETE_CODECOMPTA_ADDON.".php";
-            		break;
-            	}
+				$res=dol_include_once($dirroot.$conf->global->SOCIETE_CODECOMPTA_ADDON.'.php');
+				if ($res) break;
             }
 
-            if (! empty($file))
+            if ($res)
             {
-            	dol_include_once($file);
-
             	$classname = $conf->global->SOCIETE_CODECOMPTA_ADDON;
             	$mod = new $classname;
 


### PR DESCRIPTION
# Fix create company
If I have an external module with file to generate the accountancy code, I get an error message
We can reproduce it if the module is in 'custom' folder