### PR TITLE
FIX wrong approve time in expense report

### DIFF
--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -1246,7 +1246,7 @@ class ExpenseReport extends CommonObject
 		$error = 0;
 
         // date approval
-        $this->date_approve = $this->db->idate($now);
+        $this->date_approve = $now;
         if ($this->fk_statut != 5)
         {
 			$this->db->begin();


### PR DESCRIPTION
The approve time showed was 8 hours more than the real time.
Checking database turned out that it had the wrong data(+8 hours).

After checking every timezone related settings were correct,
I found that it do twice idate() in setApproved().
Since we have idate() in $sql, we don't need the idate()
at the line 1249.