### PR TITLE
FIX CommandeFournisseur::getDispachedLines line ID & return quantity

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1959,7 +1959,7 @@ class CommandeFournisseur extends CommonOrder
     	// List of already dispatched lines
 		$sql = "SELECT p.ref, p.label,";
 		$sql.= " e.rowid as warehouse_id, e.ref as entrepot,";
-		$sql.= " cfd.rowid as dispatchlineid, cfd.fk_product, cfd.qty, cfd.eatby, cfd.sellby, cfd.batch, cfd.comment, cfd.status";
+		$sql.= " cfd.rowid as dispatchedlineid, cfd.fk_product, cfd.qty, cfd.eatby, cfd.sellby, cfd.batch, cfd.comment, cfd.status";
 		$sql.= " FROM ".MAIN_DB_PREFIX."product as p,";
 		$sql.= " ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as cfd";
 		$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."entrepot as e ON cfd.fk_entrepot = e.rowid";
@@ -1977,7 +1977,15 @@ class CommandeFournisseur extends CommonOrder
 			while ($i < $num)
 			{
 				$objp = $this->db->fetch_object($resql);
-				if ($objp) $ret[]=array('id'=>$objp->dispatchedlineid, 'productid'=>$objp->fk_product, 'warehouseid'=>$objp->warehouse_id);
+				if ($objp)
+				{
+					$ret[] = array(
+						'id' => $objp->dispatchedlineid,
+						'productid' => $objp->fk_product,
+						'warehouseid' => $objp->warehouse_id,
+						'qty' => $objp->qty,
+					);
+				}
 
 				$i++;
 			}

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1948,6 +1948,8 @@ class CommandeFournisseur extends CommonOrder
 
     /**
 	 * Return array of dispathed lines waiting to be approved for this order
+     *
+     * @since 8.0 Return dispatched quantity (qty).
 	 *
 	 * @param	int		$status		Filter on stats (-1 = no filter, 0 = lines draft to be approved, 1 = approved lines)
 	 * @return	array				Array of lines


### PR DESCRIPTION
Hello,

This bug was found while trying to get dispatched lines in order to compare dispatched quantities with ordered quantities.

# Fix CommandeFournisseur::getDispachedLines line ID & return quantity
Since: Dolibarr v6.

Fix the SQL statement to get dispatched lines: `dispatchedlineid` alias.

And add `qty` field to the returned line array (so now there is no need to individually fetch `CommandeFournisseurDispatch` objects).

# Tests

Before fix:
![screenshot from 2018-04-04 13-59-51](https://user-images.githubusercontent.com/32769270/38306416-c95422b0-3810-11e8-9ff7-332532d2d643.png)

After fix:
![screenshot from 2018-04-04 13-58-49](https://user-images.githubusercontent.com/32769270/38306426-cec49612-3810-11e8-88e4-40f76ed14653.png)