### PR TITLE
FIX notrigger ignored on BILL_CREATE

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -694,10 +694,16 @@ class Facture extends CommonInvoice
 					}
 					else if ($reshook < 0) $error++;*/
 
-                    // Call trigger
-                    $result=$this->call_trigger('BILL_CREATE',$user);
-                    if ($result < 0) $error++;
-                    // End call triggers
+          if (! $error)
+          {
+            if (! $notrigger)
+            {
+              // Call trigger
+              $result=$this->call_trigger('BILL_CREATE',$user);
+              if ($result < 0) $error++;
+              // End call triggers
+            }
+          }
 
 					if (! $error)
 					{


### PR DESCRIPTION
# Fix

Trigger BILL_CREATE is always called even if $notrigger is set to 1.

I have seen this bug since Dolibarr 5.