### PR TITLE
FIX : multiple creation of same event

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -837,6 +837,8 @@ if (empty($reshook))
 				$object->generateDocument($object->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
 			}
 			$action = '';
+			header("Location: ".$_SERVER["PHP_SELF"]."?id=".$object->id);
+			exit;
 		}
 		else
 		{


### PR DESCRIPTION
# Fix #8512 
This will check if there is already an event in actioncomm with the same label, if there is at least one record, this will not create event