### PR TITLE
FIX issue #8037

### DIFF
--- a/htdocs/product/traduction.php
+++ b/htdocs/product/traduction.php
@@ -251,7 +251,7 @@ if ($action == 'edit')
 
 			print '<div class="underbanner clearboth"></div>';
 			print '<table class="border" width="100%">';
-			print '<tr><td class="tdtop titlefieldcreate fieldrequired">'.$langs->trans('Label').'</td><td><input name="libelle-'.$key.'" size="40" value="'.$object->multilangs[$key]["label"].'"></td></tr>';
+			print '<tr><td class="tdtop titlefieldcreate fieldrequired">'.$langs->trans('Label').'</td><td><input name="libelle-'.$key.'" size="40" value="'.dol_htmlentities($object->multilangs[$key]["label"], ENT_COMPAT).'"></td></tr>';
 			print '<tr><td class="tdtop">'.$langs->trans('Description').'</td><td>';
 			$doleditor = new DolEditor("desc-$key", $object->multilangs[$key]["description"], '', 160, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, ROWS_3, '90%');
 			$doleditor->Create();

--- a/htdocs/product/traduction.php
+++ b/htdocs/product/traduction.php
@@ -251,7 +251,7 @@ if ($action == 'edit')
 
 			print '<div class="underbanner clearboth"></div>';
 			print '<table class="border" width="100%">';
-			print '<tr><td class="tdtop titlefieldcreate fieldrequired">'.$langs->trans('Label').'</td><td><input name="libelle-'.$key.'" size="40" value="'.dol_htmlentities($object->multilangs[$key]["label"], ENT_COMPAT).'"></td></tr>';
+			print '<tr><td class="tdtop titlefieldcreate fieldrequired">'.$langs->trans('Label').'</td><td><input name="libelle-'.$key.'" size="40" value="'.dol_escape_htmltag($object->multilangs[$key]["label"]).'"></td></tr>';
 			print '<tr><td class="tdtop">'.$langs->trans('Description').'</td><td>';
 			$doleditor = new DolEditor("desc-$key", $object->multilangs[$key]["description"], '', 160, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, ROWS_3, '90%');
 			$doleditor->Create();


### PR DESCRIPTION
# Fix #8037
Updating a product translation that includes a double-quote (") character in the product label causes the product label to be truncated before the ".
