### PR TITLE
FIX : update wrong datetime extrafield

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4609,8 +4609,8 @@ abstract class CommonObject
 						$new_array_options[$key] = $this->db->idate($this->array_options[$key]);
 						break;
 					case 'datetime':
-						// This will convert date to timestamp
-						if(!is_int($this->array_options[$key])) {
+						// If data is a string instead of a timestamp, we convert it
+						if (! is_int($this->array_options[$key])) {
 							$this->array_options[$key] = strtotime($this->array_options[$key]);
 						}
 						$new_array_options[$key] = $this->db->idate($this->array_options[$key]);

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4609,6 +4609,10 @@ abstract class CommonObject
 						$new_array_options[$key] = $this->db->idate($this->array_options[$key]);
 						break;
 					case 'datetime':
+						// This will convert date to timestamp
+						if(!is_int($this->array_options[$key])) {
+							$this->array_options[$key] = strtotime($this->array_options[$key]);
+						}
 						$new_array_options[$key] = $this->db->idate($this->array_options[$key]);
 						break;
 		   			case 'link':


### PR DESCRIPTION
# Fix #8240 
The given parameter could be a string instead of an integer (timestamp)
This will convert string date to timestamp before update