### PR TITLE
Fix : Migration 7.0.0 don't contains all new chart of accounts.

### DIFF
--- a/htdocs/install/mysql/data/llx_accounting_abc.sql
+++ b/htdocs/install/mysql/data/llx_accounting_abc.sql
@@ -44,7 +44,7 @@ INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUE
 -- Description of chart of account FR PCG99-BASE
 INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUES (  1, 'PCG99-BASE', 'The base accountancy french plan', 1);
 
--- Description of chart of account FR PCG14-BASE
+-- Description of chart of account FR PCG14-DEV
 INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUES (  1, 'PCG14-DEV', 'The developed accountancy french plan 2014', 1);
 
 -- Description of chart of account BE PCMN-BASE

--- a/htdocs/install/mysql/migration/7.0.0-8.0.0.sql
+++ b/htdocs/install/mysql/migration/7.0.0-8.0.0.sql
@@ -46,6 +46,13 @@ ALTER TABLE llx_inventory ADD COLUMN fk_user_modif integer;
 ALTER TABLE llx_inventory ADD COLUMN fk_user_valid integer;
 ALTER TABLE llx_inventory ADD COLUMN import_key varchar(14);
 
+-- Missing Chart of accounts in migration 7.0.0
+INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUES (  1, 'PCG14-DEV', 'The developed accountancy french plan 2014', 1);
+INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUES (  6, 'PCG_SUISSE', 'Switzerland plan', 1);
+INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUES (140, 'PCN-LUXEMBURG', 'Plan comptable normalisé Luxembourgeois', 1);
+INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUES ( 80, 'DK-STD', 'Standardkontoplan fra SKAT', 1);
+INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUES ( 10, 'PCT', 'The Tunisia plan', 1);
+INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUES ( 12, 'PCG', 'The Moroccan chart of accounts', 1);
 
 -- For 8.0
 


### PR DESCRIPTION
Clean install ok. View all chart of accounts in accountancy module but with a migration, some charts are missing.