### PR TITLE
Fix value cond_reglement_id & mode_reglement_id

### DIFF
--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -838,8 +838,8 @@ class SupplierProposal extends CommonObject
         $sql.= ", '".$this->db->escape($this->note_private)."'";
         $sql.= ", '".$this->db->escape($this->note_public)."'";
         $sql.= ", '".$this->db->escape($this->modelpdf)."'";
-        $sql.= ", ".($this->cond_reglement_id?$this->cond_reglement_id:'NULL');
-        $sql.= ", ".($this->mode_reglement_id?$this->mode_reglement_id:'NULL');
+        $sql.= ", ".($this->cond_reglement_id > 0 ? $this->cond_reglement_id : 'NULL');
+        $sql.= ", ".($this->mode_reglement_id > 0 ? $this->mode_reglement_id : 'NULL');
         $sql.= ", ".($this->fk_account>0?$this->fk_account:'NULL');
         $sql.= ", ".($this->date_livraison!=''?"'".$this->db->idate($this->date_livraison)."'":"null");
         $sql.= ", ".($this->shipping_method_id>0?$this->shipping_method_id:'NULL');

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -838,8 +838,8 @@ class SupplierProposal extends CommonObject
         $sql.= ", '".$this->db->escape($this->note_private)."'";
         $sql.= ", '".$this->db->escape($this->note_public)."'";
         $sql.= ", '".$this->db->escape($this->modelpdf)."'";
-        $sql.= ", ".$this->cond_reglement_id;
-        $sql.= ", ".$this->mode_reglement_id;
+        $sql.= ", ".($this->cond_reglement_id?$this->cond_reglement_id:'NULL');
+        $sql.= ", ".($this->mode_reglement_id?$this->mode_reglement_id:'NULL');
         $sql.= ", ".($this->fk_account>0?$this->fk_account:'NULL');
         $sql.= ", ".($this->date_livraison!=''?"'".$this->db->idate($this->date_livraison)."'":"null");
         $sql.= ", ".($this->shipping_method_id>0?$this->shipping_method_id:'NULL');


### PR DESCRIPTION
# Fix #
I had a bug when trying to create a supplier proposal by this way : 

```
$fournisseur = new Societe($db);
$fournisseur->fetch(1);

$supplierproposal = new SupplierProposal($db, $fournisseur->id);
if ($supplierproposal->create($user) < 1) {
    echo $supplierproposal->error . '<br/><br/>';
    echo $db->lastquery;
}
```

This would generate an insert query with some empty values (fk_cond_reglement & fk_mode_reglement) : 

`INSERT INTO llx_supplier_proposal (fk_soc, price, remise, remise_percent, remise_absolue, tva, total, datec, ref, fk_user_author, note_private, note_public, model_pdf, fk_cond_reglement, fk_mode_reglement, fk_account, date_livraison, fk_shipping_method, fk_projet, entity, fk_multicurrency, multicurrency_code, multicurrency_tx) VALUES (1, 0, 0, null, null, 0, 0, '2018-04-10 23:01:52', '(PROV)', '1', '', '', '', , , NULL, null, NULL, null, 1, 0, 'EUR', 1)`
