### PR TITLE
Passes the list of third parties and the list of objects ref to the complete_substitutions_array function as parameters.

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -356,6 +356,14 @@ if (! $error && $massaction == 'confirm_presend')
 					$substitutionarray['__CHECK_READ__'] = '<img src="'.DOL_MAIN_URL_ROOT.'/public/emailing/mailing-read.php?tag='.$thirdparty->tag.'&securitykey='.urlencode($conf->global->MAILING_EMAIL_UNSUBSCRIBE_KEY).'" width="1" height="1" style="width:1px;height:1px" border="0"/>';
 
 					$parameters=array('mode'=>'formemail');
+
+					if ( ! empty( $listofobjectthirdparties ) ) {
+						$parameters['listofobjectthirdparties'] = $listofobjectthirdparties;
+					}
+					if ( ! empty( $listofobjectref ) ) {
+						$parameters['listofobjectref'] = $listofobjectref;
+					}
+
 					complete_substitutions_array($substitutionarray, $langs, $objecttmp, $parameters);
 
 					$subject=make_substitutions($subject, $substitutionarray);


### PR DESCRIPTION
# New Passes the list of third parties and the list of objects ref to the complete_substitutions_array function as parameters. 

When sending an email using "mass action", and when using a custom substitution function in a module, there is no access to the user selected third parties and/or objects (eg: selected invoices).

Access to those is required in order to create substitutions that for example can:
- show to the total amount
- show a summary table

This pull request allows just that.