### PR TITLE
Fix wrong amount for situation invoice in sellsjournal

### DIFF
--- a/htdocs/accountancy/journal/sellsjournal.php
+++ b/htdocs/accountancy/journal/sellsjournal.php
@@ -164,7 +164,7 @@ if ($result) {
 		// Situation invoices handling
 		$line = new FactureLigne($db);
 		$line->fetch($obj->fdid);
-		$prev_progress = $line->get_prev_progress($obj->fdid);
+		$prev_progress = $line->get_prev_progress($obj->rowid);
 		if ($obj->type == Facture::TYPE_SITUATION) {
 			// Avoid divide by 0
 			if ($obj->situation_percent == 0) {


### PR DESCRIPTION
# Fix
Wrong parameter for the `get_prev_progress()` method, need the invoice id instead of invoice line id

