### PR TITLE
#8650 Migration issue for 7.0 on existing crontasks

### DIFF
--- a/htdocs/install/mysql/migration/6.0.0-7.0.0.sql
+++ b/htdocs/install/mysql/migration/6.0.0-7.0.0.sql
@@ -707,3 +707,5 @@ create table llx_facture_rec_extrafields
 
 
 ALTER TABLE llx_facture_rec_extrafields ADD INDEX idx_facture_rec_extrafields (fk_object);
+
+UPDATE llx_cronjob SET entity = 1 WHERE entity = 0 ;

--- a/htdocs/install/mysql/migration/6.0.0-7.0.0.sql
+++ b/htdocs/install/mysql/migration/6.0.0-7.0.0.sql
@@ -707,5 +707,3 @@ create table llx_facture_rec_extrafields
 
 
 ALTER TABLE llx_facture_rec_extrafields ADD INDEX idx_facture_rec_extrafields (fk_object);
-
-UPDATE llx_cronjob SET entity = 1 WHERE entity = 0 ;

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -328,8 +328,7 @@ class User extends CommonObject
 				// fetch optionals attributes and labels
 				require_once(DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php');
 				$extrafields=new ExtraFields($this->db);
-				$extralabels=$extrafields->fetch_name_optionals_label($this->table_element,true);
-				$this->fetch_optionals($this->id,$extralabels);
+				$this->fetch_optionals($this->id);
 
 				$this->db->free($result);
 			}


### PR DESCRIPTION
avoiding warning message Warning: fetch_optionals was called with param
optionsArray defined when you should pass null now when calling
user->fetch

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #[*issue_number Short description*]
[*Long description*]


# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
