### PR TITLE
Fix link credit note

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -983,15 +983,13 @@ if (empty($reshook))
 				// Add link between credit note and origin
 				if(! empty($object->fk_facture_source)) {
 					$facture_source->fetch($object->fk_facture_source);
-				}
-				$facture_source->fetchObjectLinked();
+					$facture_source->fetchObjectLinked();
 
-				if(! empty($facture_source->linkedObjectsIds)) {
-					$linkedObjectIds = $facture_source->linkedObjectsIds;
-					$sourcetype = key($linkedObjectIds);
-					$fk_origin = current($facture_source->linkedObjectsIds[$sourcetype]);
-
-					$object->add_object_linked($sourcetype, $fk_origin);
+					if(! empty($facture_source->linkedObjectsIds)) {
+						foreach($facture_source->linkedObjectsIds as $sourcetype => $TIds) {
+							$object->add_object_linked($sourcetype, current($TIds));
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# Fix #8504
It will now set credit note linked objects from all of source invoice linked objects, instead of the first one before