### PR TITLE
Fix link "refresh" on turnover report

### DIFF
--- a/htdocs/compta/stats/index.php
+++ b/htdocs/compta/stats/index.php
@@ -84,6 +84,12 @@ if (empty($date_start) || empty($date_end)) // We define date_start and date_end
 $userid=GETPOST('userid','int');
 $socid = GETPOST('socid','int');
 
+$tmps=dol_getdate($date_start);
+$year_start = $tmps['year'];
+$tmpe=dol_getdate($date_end);
+$year_end = $tmpe['year'];
+$nbofyear = ($year_end - $year_start) + 1;
+
 // Define modecompta ('CREANCES-DETTES' or 'RECETTES-DEPENSES' or 'BOOKKEEPING')
 $modecompta = $conf->global->ACCOUNTING_MODE;
 if (! empty($conf->accounting->enabled)) $modecompta='BOOKKEEPING';


### PR DESCRIPTION
On page "htdocs/compta/stats/index.php" when cliking on link "refresh" then the page is reloaded without data.

Bug reproduced in each mode :
-"CREANCES-DETTES"
-"RECETTES-DEPENSES"
-"BOOKKEEPING"