### PR TITLE
Fix bug when click on refresh button

### DIFF
--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -90,7 +90,7 @@ $tmps=dol_getdate($date_start);
 $year_start = $tmps['year'];
 $tmpe=dol_getdate($date_end);
 $year_end = $tmpe['year'];
-$nbofyear = ($year_end - $start_year) + 1;
+$nbofyear = ($year_end - $year_start) + 1;
 //var_dump("year_start=".$year_start." year_end=".$year_end." nbofyear=".$nbofyear." date_start=".dol_print_date($date_start, 'dayhour')." date_end=".dol_print_date($date_end, 'dayhour'));
 
 


### PR DESCRIPTION
On page "htdocs/compta/resultat/index.php" when cliking on link "refresh" then in the reloaded page the link "previous period" and "next period" are broken.
Eg. for year 2018, after clicking on "refresh", next button point to year 4032!

Bug reproduced in each mode :
-"CREANCES-DETTES"
-"RECETTES-DEPENSES"
-"BOOKKEEPING"