### PR TITLE
New : Option INVOICE_CAN_REMOVE_DRAFT_ONLY to delete draft invoices with precedence over INVOICE_CAN_ALWAYS_BE_REMOVED

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -585,24 +585,22 @@ if ($resql)
 		'presend'=>$langs->trans("SendByMail"),
 		'builddoc'=>$langs->trans("PDFMerge"),
 	);
-	if ($conf->prelevement->enabled)
-	{
-	   $langs->load("withdrawals");
-	   $arrayofmassactions['withdrawrequest']=$langs->trans("MakeWithdrawRequest");
-	}
-	if ($user->rights->facture->supprimer)
-	{
-		//if (! empty($conf->global->STOCK_CALCULATE_ON_BILL) || empty($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED))
-		if (empty($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED))
-		{
-			// mass deletion never possible on invoices on such situation
-		}
-		else
-		{
-		   $arrayofmassactions['predelete']=$langs->trans("Delete");
-		}
-	}
-	if (in_array($massaction, array('presend','predelete'))) $arrayofmassactions=array();
+    if ($conf->prelevement->enabled) {
+        $langs->load("withdrawals");
+        $arrayofmassactions['withdrawrequest'] = $langs->trans("MakeWithdrawRequest");
+    }
+    if ($user->rights->facture->supprimer) {
+        //if (! empty($conf->global->STOCK_CALCULATE_ON_BILL) || empty($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED))
+        if (!empty($conf->global->INVOICE_CAN_REMOVE_DRAFT_ONLY)) {
+            $arrayofmassactions['predeletedraft'] = $langs->trans("Deletedraft");
+
+        }
+        elseif (!empty($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED)) {
+            // mass deletion never possible on invoices on such situation
+            $arrayofmassactions['predelete'] = $langs->trans("Delete");
+        }
+    }
+    if (in_array($massaction, array('presend', 'predelete'))) $arrayofmassactions = array();
 	$massactionbutton=$form->selectMassAction('', $arrayofmassactions);
 
 	$newcardbutton='';

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -585,22 +585,19 @@ if ($resql)
 		'presend'=>$langs->trans("SendByMail"),
 		'builddoc'=>$langs->trans("PDFMerge"),
 	);
-    if ($conf->prelevement->enabled) {
-        $langs->load("withdrawals");
-        $arrayofmassactions['withdrawrequest'] = $langs->trans("MakeWithdrawRequest");
-    }
-    if ($user->rights->facture->supprimer) {
-        //if (! empty($conf->global->STOCK_CALCULATE_ON_BILL) || empty($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED))
-        if (!empty($conf->global->INVOICE_CAN_REMOVE_DRAFT_ONLY)) {
-            $arrayofmassactions['predeletedraft'] = $langs->trans("Deletedraft");
-
-        }
-        elseif (!empty($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED)) {
-            // mass deletion never possible on invoices on such situation
-            $arrayofmassactions['predelete'] = $langs->trans("Delete");
-        }
-    }
-    if (in_array($massaction, array('presend', 'predelete'))) $arrayofmassactions = array();
+	if ($conf->prelevement->enabled) {
+        	$langs->load("withdrawals");
+        	$arrayofmassactions['withdrawrequest'] = $langs->trans("MakeWithdrawRequest");
+	}
+	if ($user->rights->facture->supprimer) {
+		if (!empty($conf->global->INVOICE_CAN_REMOVE_DRAFT_ONLY)) {
+        		$arrayofmassactions['predeletedraft'] = $langs->trans("Deletedraft");
+		}
+        	elseif (!empty($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED)) {	// mass deletion never possible on invoices on such situation
+            		$arrayofmassactions['predelete'] = $langs->trans("Delete");
+        	}
+    	}
+	if (in_array($massaction, array('presend', 'predelete'))) $arrayofmassactions = array();
 	$massactionbutton=$form->selectMassAction('', $arrayofmassactions);
 
 	$newcardbutton='';

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1079,26 +1079,16 @@ if (! $error && ($massaction == 'delete' || ($action == 'delete' && $confirm == 
 		$result=$objecttmp->fetch($toselectid);
 		if ($result > 0)
 		{
-			// Refuse deletion for some status ?
-			/*
-       		if ($objectclass == 'Facture' && $objecttmp->status == Facture::STATUS_DRAFT)
-       		{
-       			$langs->load("errors");
-       			$nbignored++;
-       			$resaction.='<div class="error">'.$langs->trans('ErrorOnlyDraftStatusCanBeDeletedInMassAction',$objecttmp->ref).'</div><br>';
-       			continue;
-       		}*/
+       		if ($objectclass != 'Facture' || empty($conf->global->INVOICE_CAN_REMOVE_DRAFT_ONLY) || (!empty($conf->global->INVOICE_CAN_REMOVE_DRAFT_ONLY) && $objecttmp->statut == Facture::STATUS_DRAFT) ) {
+                if (in_array($objecttmp->element, array('societe', 'member'))) $result = $objecttmp->delete($objecttmp->id, $user, 1);
+                else $result = $objecttmp->delete($user);
 
-			if (in_array($objecttmp->element, array('societe','member'))) $result = $objecttmp->delete($objecttmp->id, $user, 1);
-			else $result = $objecttmp->delete($user);
-
-			if ($result <= 0)
-			{
-				setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
-				$error++;
-				break;
-			}
-			else $nbok++;
+                if ($result <= 0) {
+                    setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
+                    $error++;
+                    break;
+                } else $nbok++;
+            }
 		}
 		else
 		{

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1091,12 +1091,13 @@ if (! $error && ($massaction == 'delete' || ($action == 'delete' && $confirm == 
 			if (in_array($objecttmp->element, array('societe', 'member'))) $result = $objecttmp->delete($objecttmp->id, $user, 1);
 			else $result = $objecttmp->delete($user);
 
-			if ($result <= 0) {
+			if ($result <= 0) 
+			{
 			    setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
 			    $error++;
 			    break;
-			} else $nbok++;
-
+			}
+			else $nbok++;
 		}
 		else
 		{

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1079,16 +1079,24 @@ if (! $error && ($massaction == 'delete' || ($action == 'delete' && $confirm == 
 		$result=$objecttmp->fetch($toselectid);
 		if ($result > 0)
 		{
-       		if ($objectclass != 'Facture' || empty($conf->global->INVOICE_CAN_REMOVE_DRAFT_ONLY) || (!empty($conf->global->INVOICE_CAN_REMOVE_DRAFT_ONLY) && $objecttmp->statut == Facture::STATUS_DRAFT) ) {
-                if (in_array($objecttmp->element, array('societe', 'member'))) $result = $objecttmp->delete($objecttmp->id, $user, 1);
-                else $result = $objecttmp->delete($user);
+			// Refuse deletion for some objects/status
+	       		if ($objectclass == 'Facture' && empty($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED) && $objecttmp->status != Facture::STATUS_DRAFT))
+       			{
+       				$langs->load("errors");
+       				$nbignored++;
+       				$resaction.='<div class="error">'.$langs->trans('ErrorOnlyDraftStatusCanBeDeletedInMassAction',$objecttmp->ref).'</div><br>';
+       				continue;
+       			}
+	
+			if (in_array($objecttmp->element, array('societe', 'member'))) $result = $objecttmp->delete($objecttmp->id, $user, 1);
+			else $result = $objecttmp->delete($user);
 
-                if ($result <= 0) {
-                    setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
-                    $error++;
-                    break;
-                } else $nbok++;
-            }
+			if ($result <= 0) {
+			    setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
+			    $error++;
+			    break;
+			} else $nbok++;
+
 		}
 		else
 		{

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -27,6 +27,11 @@
 // $trackid='ord'.$object->id;
 
 
+if ($massaction == 'predeletedraft')
+{
+	print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans("ConfirmMassDraftDeletion"), $langs->trans("ConfirmMassDeletionQuestion", count($toselect)), "delete", null, '', 0, 200, 500, 1);
+}
+
 if ($massaction == 'predelete')
 {
 	print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans("ConfirmMassDeletion"), $langs->trans("ConfirmMassDeletionQuestion", count($toselect)), "delete", null, '', 0, 200, 500, 1);

--- a/htdocs/langs/en_US/main.lang
+++ b/htdocs/langs/en_US/main.lang
@@ -942,3 +942,5 @@ Remote=Remote
 LocalAndRemote=Local and Remote
 KeyboardShortcut=Keyboard shortcut
 AssignedTo=Assigned to
+Deletedraft=Delete draft
+ConfirmMassDraftDeletion=Draft Bulk delete confirmation

--- a/htdocs/langs/fr_FR/main.lang
+++ b/htdocs/langs/fr_FR/main.lang
@@ -941,3 +941,5 @@ Remote=Distant
 LocalAndRemote=Local et distant
 KeyboardShortcut=Raccourci clavier
 AssignedTo=Assigné à
+Deletedraft=Supprimer brouillon
+ConfirmMassDraftDeletion=Confirmation de suppression brouillons en masse


### PR DESCRIPTION
New : Option INVOICE_CAN_REMOVE_DRAFT_ONLY to delete draft invoices with precedence over INVOICE_CAN_ALWAYS_BE_REMOVED