### PR TITLE
FIX : Drag and drop lines with extrafields

### DIFF
--- a/htdocs/core/tpl/ajaxrow.tpl.php
+++ b/htdocs/core/tpl/ajaxrow.tpl.php
@@ -55,6 +55,7 @@ $(document).ready(function(){
 			var reloadpage = "<?php echo $forcereloadpage; ?>";
 			console.log("tableDND onDrop");
 			console.log(decodeURI($("#<?php echo $tagidfortablednd; ?>").tableDnDSerialize()));
+			$('#<?php echo $tagidfortablednd; ?> tr[data-element=extrafield]').attr('id', '');	// Set extrafields id to empty value in order to ignore them in tableDnDSerialize function
 			var roworder = cleanSerialize(decodeURI($("#<?php echo $tagidfortablednd; ?>").tableDnDSerialize()));
 			var table_element_line = "<?php echo $table_element_line; ?>";
 			var fk_element = "<?php echo $fk_element; ?>";


### PR DESCRIPTION
# Fix drag and drop lines with extrafields
Drag and drop lines with some line extrafields didn't work as expected : the variable "roworder" was set with ids of extrafield lines
This will temporarily remove the id attribute of all extrafield lines in order to ignore them in tableDnDSerialize function, which allow it to output the correct order to the object lines
