### PR TITLE
Fix: broken feature

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -570,7 +570,7 @@ if (! defined('NOLOGIN'))
 			exit;
 		}
 
-		$resultFetchUser=$user->fetch('', $login, '', 1, ($entitytotest > 0 ? $entitytotest : -1));
+		$resultFetchUser=$user->fetch('', $login, '', 1, (!empty($conf->entity) ? $conf->entity : ($entitytotest > 0 ? $entitytotest : -1)));
 		if ($resultFetchUser <= 0)
 		{
 			dol_syslog('User not found, connexion refused');


### PR DESCRIPTION
@eldy 
User not found when you hide the entity drop-down list on the login page with multicompany and "mc" authentication