### PR TITLE
Fix #8722 useless sql ORDER BY

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -720,7 +720,6 @@ if (empty($reshook))
 				$sql.= ' WHERE pf.fk_facture = '.$object->id;
 				$sql.= ' AND pf.fk_paiement = p.rowid';
 				$sql.= ' AND p.entity IN (' . getEntity('facture').')';
-				$sql.= ' ORDER BY p.datep, p.tms';
 
 				$resql = $db->query($sql);
 				if (! $resql) dol_print_error($db);

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -508,7 +508,6 @@ if (empty($reshook))
 				$sql.= ' WHERE pf.fk_facturefourn = '.$object->id;
 				$sql.= ' AND pf.fk_paiementfourn = p.rowid';
 				$sql.= ' AND p.entity IN (' . getEntity('facture').')';
-				$sql.= ' ORDER BY p.datep, p.tms';
 
 				$resql = $db->query($sql);
 				if (! $resql) dol_print_error($db);


### PR DESCRIPTION
# Fix #8722 Incorrect SQL query on converttoreduc
This glitch is detected by PostgreSQL.

The fourn/facture on the 7.0 branch doesn't seem to be concerned. Just remove appropriate hunk to apply only to compta/facture on the 7.0 branch.

5 and 6 branch doesn't seem to be concerned at all.