### PR TITLE
Fix creating next situation invoice if a discount was allready apply

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1362,11 +1362,26 @@ if (empty($reshook))
 					$object->origin = $origin;
 					$object->origin_id = $originid;
 
-					foreach ($object->lines as &$line)
+					foreach ($object->lines as $i => &$line)
 					{
 						$line->origin = $object->origin;
 						$line->origin_id = $line->id;
 						$line->fetch_optionals($line->id);
+						
+						// Si fk_remise_except defini on vérifie si la réduction à déjà été appliquée
+						if ($line->fk_remise_except)
+						{
+						    $discount=new DiscountAbsolute($line->db);
+						    $result=$discount->fetch($line->fk_remise_except);
+						    if ($result > 0)
+						    {
+						        // Check if discount not already affected to another invoice
+						        if ($discount->fk_facture_line > 0)
+						        {
+						            unset($object->lines[$i]);
+						        }
+						    }
+						}
 					}
 				}
 

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1378,7 +1378,7 @@ if (empty($reshook))
 						        // Check if discount not already affected to another invoice
 						        if ($discount->fk_facture_line > 0)
 						        {
-						            unset($object->lines[$i]);
+						            $line->fk_remise_except = 0;
 						        }
 						    }
 						}


### PR DESCRIPTION
Fix weird behavior on creating next situation invoice if a dicount was allready apply to one or more lines.


"Erreur, la remise a déjà été attribuée"