### PR TITLE
FIX #8782 : SQL error into accountancy admin journal page

### DIFF
--- a/htdocs/accountancy/admin/journals_list.php
+++ b/htdocs/accountancy/admin/journals_list.php
@@ -86,7 +86,7 @@ $tablib[35]= "DictionaryAccountancyJournal";
 
 // Requests to extract data
 $tabsql=array();
-$tabsql[35]= "SELECT a.rowid as rowid, a.code as code, a.label, a.nature, a.active FROM ".MAIN_DB_PREFIX."accounting_journal as a WHERE a.entity=".$conf->entity;
+$tabsql[35]= "SELECT a.rowid as rowid, a.code as code, a.label, a.nature, a.active FROM ".MAIN_DB_PREFIX."accounting_journal as a";
 
 // Criteria to sort dictionaries
 $tabsqlsort=array();


### PR DESCRIPTION

# Fix #8782 mysql error on accountancy admin journal list page 
SQL instruction filter 'WHERE entity…' was defined twice into page.
