### PR TITLE
FIX: It's not possible to remove a contact which is assigned to an event #8852

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -417,6 +417,7 @@ if ($action == 'update')
 		$object->location    = GETPOST('location');
 		$object->socid       = GETPOST("socid");
 		$socpeopleassigned   = GETPOST("socpeopleassigned",'array');
+		$object->socpeopleassigned = [];
 		foreach ($socpeopleassigned as $cid) $object->socpeopleassigned[$cid] = array('id' => $cid);
 		$object->contactid   = GETPOST("contactid",'int');
 		$object->fk_project  = GETPOST("projectid",'int');


### PR DESCRIPTION
# Fix #8852 
For for bug #8852.
Initialize array before line 420
foreach ($socpeopleassigned as $cid) $object->socpeopleassigned[$cid] = array('id' => $cid);

