### PR TITLE
FIX: Set invoice paid to 1 if partially paid but closed in case of discount

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1995,7 +1995,16 @@ class Facture extends CommonInvoice
 
 			$sql = 'UPDATE '.MAIN_DB_PREFIX.'facture SET';
 			$sql.= ' fk_statut='.self::STATUS_CLOSED;
-			if (! $close_code) $sql.= ', paye=1';
+			if (! $close_code)
+			{
+				$sql.= ', paye=1';
+			}
+			elseif ( $close_code === 'discount_vat' )
+			{
+				// Set invoice paid to 1 if partially paid but closed in case of discount.
+				$sql.= ', paye=1';
+			}
+
 			if ($close_code) $sql.= ", close_code='".$this->db->escape($close_code)."'";
 			if ($close_note) $sql.= ", close_note='".$this->db->escape($close_note)."'";
 			$sql.= ' WHERE rowid = '.$this->id;


### PR DESCRIPTION

# Fix (no reported issue found)
Set invoice `paid` SQL column to `1` if _partially paid_ but closed in case of _discount_.

Applies to the `Facture::set_paid` function.

# Environment
- Version: 6 and above
- OS: Gnu/Linux
- Web server: Apache 2 & PHP 7
- Database: MariaDB 5
- URL: `/compta/facture/card.php?facid=4&action=paid`


# Reproduce behavior
1. Create a new Customer Invoice
2. Validate it.
3. Add a partial payment
4. Click the "Classify 'Partially Paid'" button.
5. Select the Discount radio button and validate.

![image](https://user-images.githubusercontent.com/32769270/40552349-afeb2c2c-603f-11e8-904c-12869ea74dbc.png)

![image](https://user-images.githubusercontent.com/32769270/40552442-f43f969c-603f-11e8-9dc0-3760d0b368a1.png)

![image](https://user-images.githubusercontent.com/32769270/40552587-75fed1c0-6040-11e8-9961-7de42d467de3.png)

Note the Invoice status is _**Partially Paid**_ but the _Due left_ amount is **0**.

## After the fix
![image](https://user-images.githubusercontent.com/32769270/40552515-2a37073a-6040-11e8-9c87-9862f2ca3ab0.png)
Note the Invoice status is now _**Paid**_.



