### PR TITLE
FIX Button Classify abandonned for donation not displaying

### DIFF
--- a/htdocs/don/card.php
+++ b/htdocs/don/card.php
@@ -730,7 +730,7 @@ if (! empty($id) && $action != 'edit')
 		print '<div class="inline-block divButAction"><a class="butAction" href="' . $_SERVER["PHP_SELF"] . '?rowid='.$object->id.'&action=valid_promesse">'.$langs->trans("ValidPromess").'</a></div>';
 	}
 
-    if (($object->statut == 0 || $object->statut == 1) && $remaintopay == 0 && $object->paid == 0)
+    if (($object->statut == 0 || $object->statut == 1) && $totalpaid == 0 && $object->paid == 0)
     {
         print '<div class="inline-block divButAction"><a class="butAction" href="' . $_SERVER["PHP_SELF"] . '?rowid='.$object->id.'&action=set_cancel">'.$langs->trans("ClassifyCanceled")."</a></div>";
     }


### PR DESCRIPTION
# Fix #5606 Cancel a donation

We could abandon a donation only if it was full paid, which wasn't meaningful at all. With this fix, we can now classify a donation as abandoned only if there weren't any payments on it.