### PR TITLE
FIX : Call to price function for prices substitution keys

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5544,9 +5544,9 @@ function getCommonSubstitutionArray($outputlangs, $onlykey=0, $exclude=null, $ob
 	{
 		$substitutionarray['__DATE_YMD__']        = is_object($object)?(isset($object->date) ? dol_print_date($object->date, 'day', 0, $outputlangs) : '') : '';
 		$substitutionarray['__DATE_DUE_YMD__']    = is_object($object)?(isset($object->date_lim_reglement)? dol_print_date($object->date_lim_reglement, 'day', 0, $outputlangs) : '') : '';
-		$substitutionarray['__AMOUNT__']          = is_object($object)?$object->total_ttc:'';
-		$substitutionarray['__AMOUNT_EXCL_TAX__'] = is_object($object)?$object->total_ht:'';
-		$substitutionarray['__AMOUNT_VAT__']      = is_object($object)?($object->total_vat?$object->total_vat:$object->total_tva):'';
+		$substitutionarray['__AMOUNT__']          = is_object($object)?price($object->total_ttc):'';
+		$substitutionarray['__AMOUNT_EXCL_TAX__'] = is_object($object)?price($object->total_ht):'';
+		$substitutionarray['__AMOUNT_VAT__']      = is_object($object)?($object->total_vat?price($object->total_vat):price($object->total_tva)):'';
  		if ($onlykey != 2 || $mysoc->useLocalTax(1)) $substitutionarray['__AMOUNT_TAX2__']     = is_object($object)?($object->total_localtax1?$object->total_localtax1:$object->total_localtax1):'';
 		if ($onlykey != 2 || $mysoc->useLocalTax(2)) $substitutionarray['__AMOUNT_TAX3__']     = is_object($object)?($object->total_localtax2?$object->total_localtax2:$object->total_localtax2):'';
 
@@ -5558,9 +5558,9 @@ function getCommonSubstitutionArray($outputlangs, $onlykey=0, $exclude=null, $ob
 		// For backward compatibility
 		if ($onlykey != 2)
 		{
-			$substitutionarray['__TOTAL_TTC__']    = is_object($object)?$object->total_ttc:'';
-			$substitutionarray['__TOTAL_HT__']     = is_object($object)?$object->total_ht:'';
-			$substitutionarray['__TOTAL_VAT__']    = is_object($object)?($object->total_vat?$object->total_vat:$object->total_tva):'';
+			$substitutionarray['__TOTAL_TTC__']    = is_object($object)?price($object->total_ttc):'';
+			$substitutionarray['__TOTAL_HT__']     = is_object($object)?price($object->total_ht):'';
+			$substitutionarray['__TOTAL_VAT__']    = is_object($object)?($object->total_vat?price($object->total_vat):price($object->total_tva)):'';
 		}
 	}
 


### PR DESCRIPTION
# Fix call to price function for prices substitution keys
This will, for exemple, print 17.00 instead of 17.00000000 for amount, amount_excl_tax and amount_vat substitution keys
