### PR TITLE
FIX extrafield template for list and resource list with extrafields

### DIFF
--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -25,7 +25,12 @@ if (! empty($extrafieldsobjectkey))	// $extrafieldsobject is the $object->table_
 				$tmpkey='options_'.$key;
 				if (in_array($extrafields->attributes[$extrafieldsobjectkey]['type'][$key], array('date', 'datetime', 'timestamp')))
 				{
-					$value = $db->jdate($obj->$tmpkey);
+					$datenotinstring = $obj->$tmpkey;
+					if (! is_numeric($obj->$tmpkey))	// For backward compatibility
+					{
+						$datenotinstring = $db->jdate($datenotinstring);
+					}
+					$value = $datenotinstring;
 				}
 				else
 				{

--- a/htdocs/resource/list.php
+++ b/htdocs/resource/list.php
@@ -265,7 +265,7 @@ if ($ret)
 	        if (! $i) $totalarray['nbfield']++;
         }
         // Extra fields
-        $obj = (object) $resource->array_options;
+        $obj = (Object) $resource->array_options;
         include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_print_fields.tpl.php';
 
         print '<td align="center">';

--- a/htdocs/resource/list.php
+++ b/htdocs/resource/list.php
@@ -265,6 +265,7 @@ if ($ret)
 	        if (! $i) $totalarray['nbfield']++;
         }
         // Extra fields
+        $obj = (object) $resource->array_options;
         include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_print_fields.tpl.php';
 
         print '<td align="center">';


### PR DESCRIPTION
Fixed extrafield template for list which was not consistent with the template for view causing issue with date display.

Fixed display of extrafield in resource list. The $obj object was not filled before calling the template for list.


