### PR TITLE
Fix: In list of bank accounts, display the balance in formatted price

### DIFF
--- a/htdocs/compta/bank/list.php
+++ b/htdocs/compta/bank/list.php
@@ -554,7 +554,7 @@ foreach ($accounts as $key=>$type)
     if (! empty($arrayfields['balance']['checked']))
     {
 		print '<td align="right">';
-		print '<a href="'.DOL_URL_ROOT.'/compta/bank/bankentries_list.php?id='.$obj->id.'">'.price($solde, 0, $langs, 0, 0, -1, $obj->currency_code).'</a>';
+		print '<a href="'.DOL_URL_ROOT.'/compta/bank/bankentries_list.php?id='.$obj->id.'">'.price($solde, 0, $langs, 0, -1, -1, $obj->currency_code).'</a>';
 		print '</td>';
 		if (! $i) $totalarray['nbfield']++;
 		if (! $i) $totalarray['totalbalancefield']=$totalarray['nbfield'];


### PR DESCRIPTION
# Problem to solve
in compta/bank/list.php, the balance can be displayed witht decimal or not. This is not fine.
# Fix
Change a parameter in the price function to format the balance with the required number of decimals.
