### PR TITLE
Fix: MEMBER_MODIFY trigger not called if i change only extrafields

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -599,14 +599,14 @@ class Adherent extends CommonObject
 						$error++;
 					}
 				}
+			}
 
-				if (! $error && ! $notrigger)
-				{
-					// Call trigger
-					$result=$this->call_trigger('MEMBER_MODIFY',$user);
-					if ($result < 0) { $error++; }
-					// End call triggers
-				}
+			if (! $error && ! $notrigger)
+			{
+				// Call trigger
+				$result=$this->call_trigger('MEMBER_MODIFY',$user);
+				if ($result < 0) { $error++; }
+				// End call triggers
 			}
 
 			if (! $error)


### PR DESCRIPTION
@eldy 
trigger is inside : 

`if (! $error && $nbrowsaffected)`

but if i change only an extrafield the value of "$nbrowsaffected" is 0 and the trigger MEMBER_MODIFY is not executed !