### PR TITLE
Fix can't add an attribute simply

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -2010,7 +2010,7 @@ class Societe extends CommonObject
 				$hookmanager=new HookManager($this->db);
 			}
 			$hookmanager->initHooks(array('societedao'));
-			$parameters=array('id'=>$this->id);
+			$parameters=array('id'=>$this->id, 'linkclose'=>$linkclose);
 			$reshook=$hookmanager->executeHooks('getnomurltooltip',$parameters,$this,$action);    // Note that $action and $object may have been modified by some hooks
 			if ($reshook > 0) $linkclose = $hookmanager->resPrint;
 		}


### PR DESCRIPTION
# Fix
I have an external module pluged on the `getnomurltooltip` and I want add new attribute without lost the content of `$linkclose`
Without passing `$linkclose` as parameter I should copy and past all tests previously did

