### PR TITLE
FIX bad result on fetch ProductStockEntrepot

### DIFF
--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -85,6 +85,9 @@ if ($id > 0 || ! empty($ref))
     $result = $object->fetch($id, $ref);
 
 }
+
+if(empty($id) && !empty($object->id)) $id = $object->id; 
+
 $modulepart='product';
 
 // Get object canvas (By default, this is not defined, so standard usage of dolibarr)
@@ -130,7 +133,7 @@ if ($action == 'addlimitstockwarehouse' && !empty($user->rights->produit->creer)
 	if($maj_ok) {
 
 		$pse = new ProductStockEntrepot($db);
-		if($pse->fetch('', GETPOST('id'), GETPOST('fk_entrepot')) > 0) {
+		if($pse->fetch('', $id, GETPOST('fk_entrepot')) > 0) {
 
 			// Update
 			$pse->seuil_stock_alerte = $seuil_stock_alerte;
@@ -141,7 +144,7 @@ if ($action == 'addlimitstockwarehouse' && !empty($user->rights->produit->creer)
 
 			// Create
 			$pse->fk_entrepot 		 = GETPOST('fk_entrepot');
-			$pse->fk_product  	 	 = GETPOST('id');
+			$pse->fk_product  	 	 = $id;
 			$pse->seuil_stock_alerte = GETPOST('seuil_stock_alerte');
 			$pse->desiredstock  	 = GETPOST('desiredstock');
 			if($pse->create($user) > 0) setEventMessage($langs->trans('ProductStockWarehouseCreated'));
@@ -150,7 +153,7 @@ if ($action == 'addlimitstockwarehouse' && !empty($user->rights->produit->creer)
 
 	}
 
-	header("Location: ".$_SERVER["PHP_SELF"]."?id=".GETPOST('id'));
+	header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
 	exit;
 
 }
@@ -951,7 +954,7 @@ if (!empty($conf->global->STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE))
 	if (!empty($user->rights->produit->creer)){
 		print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 		print '<input type="hidden" name="action" value="addlimitstockwarehouse">';
-		print '<input type="hidden" name="id" value="'.GETPOST('id').'">';
+		print '<input type="hidden" name="id" value="'.$id.'">';
 	}
 	print '<table class="noborder" width="100%">';
 	if (!empty($user->rights->produit->creer)){
@@ -968,7 +971,7 @@ if (!empty($conf->global->STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE))
 	}
 
 	$pse = new ProductStockEntrepot($db);
-	$lines = $pse->fetchAll(GETPOST('id'));
+	$lines = $pse->fetchAll($id);
 
 	if (!empty($lines))
 	{
@@ -981,7 +984,7 @@ if (!empty($conf->global->STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE))
 			print '<td align="right">'.$line['seuil_stock_alerte'].'</td>';
 			print '<td align="right">'.$line['desiredstock'].'</td>';
 			if (!empty($user->rights->produit->creer)){
-				print '<td align="right"><a href="?id='.GETPOST('id').'&fk_productstockwarehouse='.$line['id'].'&action=delete_productstockwarehouse">'.img_delete().'</a></td>';
+			    print '<td align="right"><a href="?id='.$id.'&fk_productstockwarehouse='.$line['id'].'&action=delete_productstockwarehouse">'.img_delete().'</a></td>';
 			}
 			print '</tr>';
 		}


### PR DESCRIPTION
# Fix the desired stock show bad values
the ProductStockEntrepot for a product is always fetched with GETPOST('id').
When we browse the products with the nav tool in the dol_banner, ref is defined but not the id of the product.
So it displays bad values...