### PR TITLE
Sync rfc2307 group membership from LDAP

### DIFF
--- a/scripts/user/sync_groups_ldap2dolibarr.php
+++ b/scripts/user/sync_groups_ldap2dolibarr.php
@@ -186,8 +186,13 @@ if ($result >= 0)
 			foreach($ldapgroup[$conf->global->LDAP_GROUP_FIELD_GROUPMEMBERS] as $key => $userdn) {
 				if($key === 'count') continue;
 				if(empty($userList[$userdn])) { // Récupération de l'utilisateur
-					$userFilter = explode(',', $userdn);
-					$userKey = $ldap->getAttributeValues('('.$userFilter[0].')', $conf->global->LDAP_KEY_USERS);
+					// Schéma rfc2307: les membres sont listés dans l'attribut memberUid sous form de login uniquement
+					if ($conf->global->LDAP_GROUP_FIELD_GROUPMEMBERS === 'memberUid'){
+						$userKey = array($userdn);
+					} else { // Pour les autres schémas, les membres sont listés sous forme de DN complets
+						$userFilter = explode(',', $userdn);
+						$userKey = $ldap->getAttributeValues('('.$userFilter[0].')', $conf->global->LDAP_KEY_USERS);
+					}
 					if(!is_array($userKey)) continue;
 
 					$fuser = new User($db);


### PR DESCRIPTION
# New Sync rfc2307 LDAP group membership
With rfc2307 LDAP scheme, group members are listed in the memberUid attribute, as simple uid, not as full DN like rfc2307bis, or AD-style groups. With this PR, group memberships are synced from LDAP if your LDAP tree is using the rfc2307 scheme
