### PR TITLE
Fix link to create event had no socid if from thirdparty card

### DIFF
--- a/htdocs/core/class/html.formactions.class.php
+++ b/htdocs/core/class/html.formactions.class.php
@@ -196,7 +196,7 @@ class FormActions
 
 			if (! empty($conf->agenda->enabled))
 			{
-				$buttontoaddnewevent = '<a href="'.DOL_URL_ROOT.'/comm/action/card.php?action=create&datep='.dol_print_date(dol_now(),'dayhourlog').'&origin='.$typeelement.'&originid='.$object->id.($object->socid>0?'&socid='.$object->socid:'').($projectid>0?'&projectid='.$projectid:'').($socid>0?'&socid='.$socid:'').'&backtopage='.urlencode($urlbacktopage).'">';
+				$buttontoaddnewevent = '<a href="'.DOL_URL_ROOT.'/comm/action/card.php?action=create&datep='.dol_print_date(dol_now(),'dayhourlog').'&origin='.$typeelement.'&originid='.$object->id.($object->socid>0?'&socid='.$object->socid:($socid>0?'&socid='.$socid:'')).($projectid>0?'&projectid='.$projectid:'').'&backtopage='.urlencode($urlbacktopage).'">';
 				$buttontoaddnewevent.= $langs->trans("AddEvent");
 				$buttontoaddnewevent.= '</a>';
 			}

--- a/htdocs/core/class/html.formactions.class.php
+++ b/htdocs/core/class/html.formactions.class.php
@@ -196,7 +196,7 @@ class FormActions
 
 			if (! empty($conf->agenda->enabled))
 			{
-				$buttontoaddnewevent = '<a href="'.DOL_URL_ROOT.'/comm/action/card.php?action=create&datep='.dol_print_date(dol_now(),'dayhourlog').'&origin='.$typeelement.'&originid='.$object->id.($object->socid>0?'&socid='.$object->socid:'').($projectid>0?'&projectid='.$projectid:'').'&backtopage='.urlencode($urlbacktopage).'">';
+				$buttontoaddnewevent = '<a href="'.DOL_URL_ROOT.'/comm/action/card.php?action=create&datep='.dol_print_date(dol_now(),'dayhourlog').'&origin='.$typeelement.'&originid='.$object->id.($object->socid>0?'&socid='.$object->socid:'').($projectid>0?'&projectid='.$projectid:'').($socid>0?'&socid='.$socid:'').'&backtopage='.urlencode($urlbacktopage).'">';
 				$buttontoaddnewevent.= $langs->trans("AddEvent");
 				$buttontoaddnewevent.= '</a>';
 			}


### PR DESCRIPTION
Not sure this is the best way, but when creating an event from a thirdpartycard, socid was not given.
Should we pass an elementtype instead an deal with the specific case of element 'societe' ?