### PR TITLE
Remove auto activate cron recuring invoice

### DIFF
--- a/htdocs/core/modules/modFacture.class.php
+++ b/htdocs/core/modules/modFacture.class.php
@@ -117,7 +117,7 @@ class modFacture extends DolibarrModules
 
         // Cronjobs
         $this->cronjobs = array(
-            0=>array('label'=>'RecurringInvoices', 'jobtype'=>'method', 'class'=>'compta/facture/class/facture-rec.class.php', 'objectname'=>'FactureRec', 'method'=>'createRecurringInvoices', 'parameters'=>'', 'comment'=>'Generate recurring invoices', 'frequency'=>1, 'unitfrequency'=>3600*24),
+            0=>array('label'=>'RecurringInvoices', 'jobtype'=>'method', 'class'=>'compta/facture/class/facture-rec.class.php', 'objectname'=>'FactureRec', 'method'=>'createRecurringInvoices', 'parameters'=>'', 'comment'=>'Generate recurring invoices', 'frequency'=>1, 'unitfrequency'=>3600*24, 'status'=>0),
             // 1=>array('label'=>'My label', 'jobtype'=>'command', 'command'=>'', 'parameters'=>'', 'comment'=>'Comment', 'frequency'=>3600, 'unitfrequency'=>3600)
         );
         // List of cron jobs entries to add


### PR DESCRIPTION
Currently, during an update or activation / deactivation of the "Invoices" module, the cron task "RecurringInvoices" is automatically recreated and activated without taking care of last settings. That can pose very big problems of generations of unsolicited documents !!!

Actuellement, lors d'un mise à jour ou l'activation/désactivation du module "Factures", la tâche cron "RecurringInvoices" est automatiquement recrée et activée sans prendre en compte les derniers réglages. Cela peu poser de très gros problèmes de générations de documents non sollicités !!! 