### PR TITLE
NEW right to read thirdparties of subordonates users

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -136,6 +136,20 @@ function getEntity($element, $shared=1, $forceentity=null)
 }
 
 /**
+ * Get list of user ids for current user and its subordonates
+ * 
+ * @return	mixed				User id(s) to use
+ */
+function getUserAndSub()
+{
+	global $user;
+	if(!$user->rights->societe->client->read_sub) return $user->id;
+	
+	$userids = $user->getAllChildIds(1);
+	return implode(',', $userids);
+}
+
+/**
  * Return information about user browser
  *
  * Returns array with the following format:

--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -208,6 +208,14 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'client';
 		$this->rights[$r][5] = 'voir';
+		
+		$r++;
+		$this->rights[$r][0] = 263;
+		$this->rights[$r][1] = 'Read third parties of subordonates.';
+		$this->rights[$r][2] = 'r';
+		$this->rights[$r][3] = 0;
+		$this->rights[$r][4] = 'client';
+		$this->rights[$r][5] = 'read_sub';
 
 		$r++;
 		$this->rights[$r][0] = 281; // id de la permission

--- a/htdocs/societe/index.php
+++ b/htdocs/societe/index.php
@@ -104,11 +104,11 @@ $third = array(
 );
 $total=0;
 
-$sql = "SELECT s.rowid, s.client, s.fournisseur";
+$sql = "SELECT DISTINCT s.rowid, s.client, s.fournisseur";
 $sql.= " FROM ".MAIN_DB_PREFIX."societe as s";
 if (! $user->rights->societe->client->voir && ! $socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 $sql.= ' WHERE s.entity IN ('.getEntity('societe').')';
-if (! $user->rights->societe->client->voir && ! $socid) $sql.= " AND s.rowid = sc.fk_soc AND sc.fk_user = " .$user->id;
+if (! $user->rights->societe->client->voir && ! $socid) $sql.= " AND s.rowid = sc.fk_soc AND sc.fk_user IN (".getUserAndSub().")";
 if ($socid)	$sql.= " AND s.rowid = ".$socid;
 if (! $user->rights->fournisseur->lire) $sql.=" AND (s.fournisseur <> 1 OR s.client <> 0)";    // client=0, fournisseur=0 must be visible
 //print $sql;
@@ -264,7 +264,7 @@ print '</div><div class="fichetwothirdright"><div class="ficheaddleft">';
  * Last third parties modified
  */
 $max=15;
-$sql = "SELECT s.rowid, s.nom as name, s.client, s.fournisseur";
+$sql = "SELECT DISTINCT s.rowid, s.nom as name, s.client, s.fournisseur";
 $sql.= ", s.code_client";
 $sql.= ", s.code_fournisseur";
 $sql.= ", s.logo";
@@ -272,7 +272,7 @@ $sql.= ", s.canvas, s.tms as datem, s.status as status";
 $sql.= " FROM ".MAIN_DB_PREFIX."societe as s";
 if (! $user->rights->societe->client->voir && ! $socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 $sql.= ' WHERE s.entity IN ('.getEntity('societe').')';
-if (! $user->rights->societe->client->voir && ! $socid) $sql.= " AND s.rowid = sc.fk_soc AND sc.fk_user = " .$user->id;
+if (! $user->rights->societe->client->voir && ! $socid) $sql.= " AND s.rowid = sc.fk_soc AND sc.fk_user IN (".getUserAndSub().")";
 if ($socid)	$sql.= " AND s.rowid = ".$socid;
 if (! $user->rights->fournisseur->lire) $sql.=" AND (s.fournisseur != 1 OR s.client != 0)";
 $sql.= $db->order("s.tms","DESC");


### PR DESCRIPTION
A bit like the getEntity function, I added a **getUserAndSub** function which returns the current user id and all of it's subordonates ids.
It comes with a new right on thirdparties "**Read third parties of subordonates**". With this we can have 3 levels of thirdparty access : only my thirds, my thirds and thirds of my subordonates, all thirds.

This means that everywhere the table "societe_commerciaux" is used to test if user is linked to the third, I have to use the new getUserAndSub function. As an example I only changed the index.php file for now.

@eldy If it's ok with you, I'll start changing everywhere it's needed.

Last question : should I change SQL requests that I will modify in order to use LEFT JOIN everywhere ? In the index.php file, I didn't for now.