### PR TITLE
FIX importing extrafields does nothing

### DIFF
--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -647,8 +647,14 @@ class ImportCsv extends ModeleImports
 								// Run update request
 								$resql=$this->db->query($sql);
 								if($resql) {
-									// No error, update has been done. $this->db->db->affected_rows can be 0 if data hasn't changed
-									$updatedone = true;
+									// No error, $this->db->db->affected_rows can be 0 if data hasn't changed
+									// Update was done if there is an entry, nothing was done otherwise
+									$sql = "SELECT count(*) AS count FROM $tablename WHERE $keyfield = $lastinsertid";
+									$resql = $this->db->query($sql);
+									if($resql) {
+										$res = $this->db->fetch_object($resql);
+										$updatedone = $res->count > 0;
+									}
 								}
 								else
 								{

--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -672,8 +672,14 @@ class ImportXlsx extends ModeleImports
 								// Run update request
 								$resql=$this->db->query($sql);
 								if($resql) {
-									// No error, update has been done. $this->db->db->affected_rows can be 0 if data hasn't changed
-									$updatedone = true;
+									// No error, $this->db->db->affected_rows can be 0 if data hasn't changed
+									// Update was done if there is an entry, nothing was done otherwise
+									$sql = "SELECT count(*) AS count FROM $tablename WHERE $keyfield = $lastinsertid";
+									$resql = $this->db->query($sql);
+									if($resql) {
+										$res = $this->db->fetch_object($resql);
+										$updatedone = $res->count > 0;
+									}
 								}
 								else
 								{


### PR DESCRIPTION
Currently if I add an extrafield to a product, existing product don't have the extrafield line in the database.
It is properly added when i edit the product and save via the form.
However if i want to update the product via import, the import says everything is ok but does not update the extra field.
