### PR TITLE
NEW Allow to enter a timespent with a numeric value

### DIFF
--- a/htdocs/core/js/timesheet.js
+++ b/htdocs/core/js/timesheet.js
@@ -45,11 +45,16 @@ function regexEvent(objet,evt,type)
           case 'hours':
               var regex= /^[0-9]{1,2}:[0-9]{2}$/;
               var regex2=/^[0-9]{1,2}$/;
+              var regex3= /^[0-9]{1}([.,]{1}[0-9]{1,2})?$/;
               if(!regex.test(objet.value))
               { 
                   if(regex2.test(objet.value))
                     objet.value=objet.value+':00';
-                  else
+                  else if(regex3.test(objet.value)) {
+                    var tmp=parseFloat(objet.value.replace(',','.'));
+                    var rnd=Math.trunc(tmp);
+                    objet.value=rnd+':'+ Math.round(60*(tmp-rnd));
+                  } else
                     objet.value='';
               }
               /* alert(jQuery("#"+id).val()); */


### PR DESCRIPTION
This allows to entre time spent in the project time form with a simple numeric format (e.g "3.5" or "2,5"). Until now, only this format was allowed : 3:30