### PR TITLE
Fix loading api files for external modules

### DIFF
--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -2214,6 +2214,10 @@ function getModuleDirForApiClass($module)
     elseif ($module == 'users') {
         $moduledirforclass = 'user';
     }
+    elseif ( isset(glob('../custom/*/class/api_'.$module.'*.php')[0]) ) {
+        $apifilepath = glob('../custom/*/class/api_'.$module.'*.php')[0];
+        $moduledirforclass = explode('/', $apifilepath)[2];
+    }
 
     return $moduledirforclass;
 }


### PR DESCRIPTION
# Fix #9116 Fix load api for external modules
Actually the API from external modules are not loaded automaticaly
This PR try to find the right path for a module if it's find in the custom directory

