### PR TITLE
Translation: adding 'Enable' term in main

### DIFF
--- a/htdocs/langs/en_US/main.lang
+++ b/htdocs/langs/en_US/main.lang
@@ -142,6 +142,7 @@ Closed=Closed
 Closed2=Closed
 NotClosed=Not closed
 Enabled=Enabled
+Enable=Enable
 Deprecated=Deprecated
 Disable=Disable
 Disabled=Disabled


### PR DESCRIPTION
compta/facture/fiche-rec.php uses 'Enable' / 'Disable' in a button text but no translation is available for 'Enable'.

Another option would be to change 'Enable' to 'Activate' in
fiche-rec.php but I guess this word will probably be useful in other
places.