### PR TITLE
FIX 2 bugfix for PDF generated by Templates/Cron: DueDate and translation

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -984,6 +984,7 @@ class FactureRec extends CommonInvoice
 		$error=0;
 
 		$langs->load("bills");
+		$langs->load('main');
 
 		$nb_create=0;
 
@@ -1060,6 +1061,8 @@ class FactureRec extends CommonInvoice
 				    }
 	                if (! $error && $facturerec->generate_pdf)
 	                {
+	                    // We refresh the object in order to have all necessary data (like date_lim_reglement)
+	                    $facture->fetch($facture->id);
 	                    $result = $facture->generateDocument($facturerec->modelpdf, $langs);
 	                    if ($result <= 0)
 	                    {


### PR DESCRIPTION
When launching Cron on a facturerec with auto_validate at 1, the
generated PDF doesn't contain the DueDate, and some tokens like
__INVOICE_PREVIOUS_MONTH_TEXT__ in the public notes are not
translated (tested with fr_FR).