### PR TITLE
FIX : Keep same project when creating shipping from order

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -988,6 +988,7 @@ if ($action == 'create')
             if (! empty($conf->projet->enabled))
             {
                 $projectid = GETPOST('projectid','int')?GETPOST('projectid','int'):0;
+                if(empty($projectid) && ! empty($object->fk_project)) $projectid = $object->fk_project;
                 if ($origin == 'project') $projectid = ($originid ? $originid : 0);
 
                 $langs->load("projects");


### PR DESCRIPTION
# Fix keep same project when creating shipping from order
When creating shipping from an order, this will preselect the order's project in the creation form