### PR TITLE
Upgrade Phpcs to v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -293,7 +293,6 @@ script:
   # Ensure we catch errors
   set -e
   # Exclusions are defined in the ruleset.xml file
-  phpcs --version
   #phpcs -s -n -p -d memory_limit=-1 --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 .
   phpcs -s -p -d memory_limit=-1 --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 --runtime-set ignore_warnings_on_exit true .
   set +e

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # from Dolibarr GitHub repository.
 # For syntax, see http://about.travis-ci.org/docs/user/languages/php/
 
-# We use dist: precise to have php 5.3 available 
+# We use dist: precise to have php 5.3 available
 dist: trusty
 sudo: required
 
@@ -20,7 +20,7 @@ addons:
     # To use the last version of pgloader, we add repo of postgresql
     - postgresql
     - sourceline: 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main'
-    - key_url: 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'  
+    - key_url: 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
     packages:
     # We need a webserver to test the webservices
     # Let's install Apache with.
@@ -101,7 +101,7 @@ before_install:
     pgloader --version
     echo
   fi
- 
+
 install:
 - |
   echo "Updating Composer"
@@ -133,7 +133,7 @@ install:
 
 - |
   echo "Installing PHP CodeSniffer"
-  composer -n require squizlabs/php_codesniffer ^2
+  composer -n require squizlabs/php_codesniffer ^3
   echo
 
 - |
@@ -195,7 +195,7 @@ before_script:
     mysql --version | head -
     mysql -e "SELECT VERSION();"  | head -
     echo
-  
+
   - |
     echo "Setting up database"
     if [ "$DB" = 'mysql' ] || [ "$DB" = 'mariadb' ] || [ "$DB" = 'postgresql' ]; then
@@ -203,7 +203,7 @@ before_script:
       mysql -e 'DROP DATABASE IF EXISTS travis;'
       mysql -e 'CREATE DATABASE IF NOT EXISTS travis;'
       mysql -e 'GRANT ALL PRIVILEGES ON travis.* TO travis@127.0.0.1;'
-      mysql -e 'FLUSH PRIVILEGES;'    
+      mysql -e 'FLUSH PRIVILEGES;'
       mysql -D travis < dev/initdemo/mysqldump_dolibarr_3.5.0.sql
     fi
     if [ "$DB" = 'postgresql' ]; then
@@ -293,6 +293,7 @@ script:
   # Ensure we catch errors
   set -e
   # Exclusions are defined in the ruleset.xml file
+  phpcs --version
   #phpcs -s -n -p -d memory_limit=-1 --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 .
   phpcs -s -p -d memory_limit=-1 --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 --runtime-set ignore_warnings_on_exit true .
   set +e
@@ -384,4 +385,3 @@ after_failure:
     # TODO: PostgreSQL log file
     echo
   fi
-

--- a/dev/setup/codesniffer/ruleset.xml
+++ b/dev/setup/codesniffer/ruleset.xml
@@ -4,6 +4,7 @@
 	<description>Dolibarr coding standard.</description>
 
 	<exclude-pattern type="relative">build/html</exclude-pattern>
+	<exclude-pattern type="relative">build/aps</exclude-pattern>
 	<exclude-pattern type="relative">documents</exclude-pattern>
 	<exclude-pattern type="relative">htdocs/custom</exclude-pattern>
 	<exclude-pattern type="relative">htdocs/includes</exclude-pattern>
@@ -14,40 +15,25 @@
 
 		<!-- List of all tests -->
 
-	
+
 	<!-- Rules from Internal Standard -->
-	
+
 	<rule ref="Internal.NoCodeFound">
 		<severity>0</severity>
 	</rule>
 
-	
-	<!-- Rules from Generic Standard -->
-		
-	<rule ref="Generic.CodeAnalysis.EmptyStatement" />
 
-	<rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH">
-		<severity>0</severity>
-	</rule>
-	<rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedFOREACH">
-		<severity>0</severity>
-	</rule>
-	<rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedIF">
-		<severity>0</severity>
-	</rule>
-	<rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedELSE">
-		<severity>0</severity>
-	</rule>
-	<rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedELSEIF">
-		<severity>0</severity>
-	</rule>
-	
-	<rule ref="Generic.CodeAnalysis.EmptyStatement.NotAllowed">
-		<severity>0</severity>
-	</rule>
-	<rule ref="Generic.CodeAnalysis.EmptyStatement.NotAllowedWarning">
-		<severity>0</severity>
-	</rule>
+	<!-- Rules from Generic Standard -->
+
+	<rule ref="Generic.CodeAnalysis.EmptyStatement">
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedIf"/>
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedElse"/>
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedElseif"/>
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedForeach"/>
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.NotAllowed"/>
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.NotAllowedWarning"/>
+    </rule>
 
     <!-- <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop" /> -->
 
@@ -147,7 +133,7 @@
     <rule ref="Generic.PHP.DeprecatedFunctions.Deprecated">
         <severity>0</severity>
     </rule>
-	
+
 	<rule ref="Generic.PHP.DisallowShortOpenTag" />
 
     <rule ref="Generic.PHP.ForbiddenFunctions" />
@@ -163,7 +149,7 @@
 	<rule ref="Generic.Strings.UnnecessaryStringConcat.Found">
         <severity>0</severity>
 	</rule>
-    
+
 	<!-- Disallow usage of tab -->
 	<!--  <rule ref="Generic.WhiteSpace.DisallowTabIndent" /> -->
 
@@ -186,7 +172,7 @@
     <rule ref="PEAR.Commenting.ClassComment.Missing">
         <severity>0</severity>
     </rule>
-    
+
     <rule ref="PEAR.Commenting.ClassComment.MissingTag">
 		<severity>0</severity>
     </rule>
@@ -206,14 +192,14 @@
     <rule ref="PEAR.Commenting.ClassComment.MissingLinkTag">
         <severity>0</severity>
     </rule>
-        
+
     <rule ref="PEAR.Commenting.ClassComment.MissingPackageTag">
         <severity>0</severity>
     </rule>
-        
 
-   
-    <!-- 
+
+
+    <!--
     <rule ref="PEAR.Commenting.FileComment" />
     <rule ref="PEAR.Commenting.FileComment.WrongStyle">
         <severity>0</severity>
@@ -225,20 +211,20 @@
         <severity>0</severity>
     </rule>
     -->
-    
+
     <rule ref="PEAR.Commenting.FunctionComment" />
 
     <rule ref="PEAR.Commenting.FunctionComment.Empty">
         <severity>5</severity>
     </rule>
-    
+
 	<rule ref="PEAR.Commenting.FunctionComment.MissingReturn">
         <severity>0</severity>
     </rule>
     <rule ref="PEAR.Commenting.FunctionComment.Missing">
         <severity>0</severity>
     </rule>
-    
+
     <rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParamType" />
 
     <rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParamName">
@@ -254,11 +240,11 @@
     <rule ref="PEAR.Commenting.FunctionComment.ReturnNotRequired">
         <severity>0</severity>
     </rule>
-    
+
     <rule ref="PEAR.Commenting.FunctionComment.WrongStyle">
         <severity>0</severity>
     </rule>
-    
+
     <rule ref="PEAR.Commenting.FunctionComment.SpacingBeforeParamType">
         <severity>0</severity>
     </rule>
@@ -328,14 +314,14 @@
     <rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterCloseBracket">
         <severity>0</severity>
     </rule>
-	
+
 	<rule ref="PEAR.Functions.ValidDefaultValue" />
 
 	<rule ref="PEAR.NamingConventions.ValidClassName" />
 	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
         <severity>0</severity>
 	</rule>
-	
+
 	<rule ref="PEAR.NamingConventions.ValidClassName.StartWithCapital">
         <severity>0</severity>
 	</rule>
@@ -343,7 +329,7 @@
 	<rule ref="PEAR.NamingConventions.ValidClassName.StartWithCaptial">
         <severity>0</severity>
 	</rule>
-	
+
 	<rule ref="PEAR.NamingConventions.ValidFunctionName" />
 
 	<rule ref="PEAR.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore">
@@ -363,6 +349,9 @@
 	<rule ref="PEAR.NamingConventions.ValidFunctionName.NotCamelCaps">
         <severity>0</severity>
 	</rule>
+	<rule ref="PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
+        <severity>0</severity>
+	</rule>
 	<rule ref="PEAR.NamingConventions.ValidFunctionName.PrivateNoUnderscore">
         <severity>0</severity>
 	</rule>
@@ -372,19 +361,19 @@
 	<rule ref="PEAR.NamingConventions.ValidVariableName.PrivateNoUnderscore">
         <severity>0</severity>
     </rule>
-	
+
 	<rule ref="PEAR.WhiteSpace.ObjectOperatorIndent" />
 
 	<!-- Need to be commented to be disabled
 	<rule ref="PEAR.WhiteSpace.ScopeClosingBrace">
         <severity>0</severity>
     </rule>
-	
+
     <rule ref="PEAR.WhiteSpace.ScopeClosingBrace.Line">
         <severity>0</severity>
     </rule>
 	-->
-    
+
     <!-- Already found as a Generic rule -->
 	<!-- <rule ref="PEAR.WhiteSpace.ScopeIndent" /> -->
 

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -185,9 +185,9 @@ class Orders extends DolibarrApi
      */
     function post($request_data = null)
     {
-      if(! DolibarrApiAccess::$user->rights->commande->creer) {
-			  throw new RestException(401, "Insuffisant rights");
-		  }
+        if(! DolibarrApiAccess::$user->rights->commande->creer) {
+			throw new RestException(401, "Insuffisant rights");
+		}
         // Check mandatory fields
         $result = $this->_validate($request_data);
 
@@ -219,24 +219,24 @@ class Orders extends DolibarrApi
      * @return int
      */
     function getLines($id) {
-      if(! DolibarrApiAccess::$user->rights->commande->lire) {
-		  	throw new RestException(401);
-		  }
+        if(! DolibarrApiAccess::$user->rights->commande->lire) {
+			throw new RestException(401);
+		}
 
-      $result = $this->commande->fetch($id);
-      if( ! $result ) {
-         throw new RestException(404, 'Order not found');
-      }
+        $result = $this->commande->fetch($id);
+        if( ! $result ) {
+            throw new RestException(404, 'Order not found');
+        }
 
-		  if( ! DolibarrApi::_checkAccessToResource('commande',$this->commande->id)) {
-			  throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
-      }
-      $this->commande->getLinesArray();
-      $result = array();
-      foreach ($this->commande->lines as $line) {
-        array_push($result,$this->_cleanObjectDatas($line));
-      }
-      return $result;
+		if( ! DolibarrApi::_checkAccessToResource('commande',$this->commande->id)) {
+			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        }
+        $this->commande->getLinesArray();
+        $result = array();
+        foreach ($this->commande->lines as $line) {
+            array_push($result,$this->_cleanObjectDatas($line));
+        }
+        return $result;
     }
 
     /**
@@ -250,20 +250,20 @@ class Orders extends DolibarrApi
      * @return int
      */
     function postLine($id, $request_data = null) {
-      if(! DolibarrApiAccess::$user->rights->commande->creer) {
-		  	throw new RestException(401);
-		  }
+        if(! DolibarrApiAccess::$user->rights->commande->creer) {
+			throw new RestException(401);
+		}
 
-      $result = $this->commande->fetch($id);
-      if( ! $result ) {
-         throw new RestException(404, 'Order not found');
-      }
+        $result = $this->commande->fetch($id);
+        if( ! $result ) {
+            throw new RestException(404, 'Order not found');
+        }
 
-		  if( ! DolibarrApi::_checkAccessToResource('commande',$this->commande->id)) {
-			  throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
-      }
-			$request_data = (object) $request_data;
-      $updateRes = $this->commande->addline(
+		if( ! DolibarrApi::_checkAccessToResource('commande',$this->commande->id)) {
+			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        }
+		$request_data = (object) $request_data;
+        $updateRes = $this->commande->addline(
                         $request_data->desc,
                         $request_data->subprice,
                         $request_data->qty,
@@ -290,15 +290,14 @@ class Orders extends DolibarrApi
                         $request_data->origin,
                         $request_data->origin_id,
                         $request_data->multicurrency_subprice
-      );
+        );
 
-      if ($updateRes > 0) {
-        return $updateRes;
+        if ($updateRes > 0) {
+            return $updateRes;
 
-      }
-      else {
+        } else {
 			throw new RestException(400, $this->commande->error);
-      }
+        }
     }
 
     /**
@@ -313,50 +312,50 @@ class Orders extends DolibarrApi
      * @return object
      */
     function putLine($id, $lineid, $request_data = null) {
-      if(! DolibarrApiAccess::$user->rights->commande->creer) {
-		  	throw new RestException(401);
-		  }
+        if(! DolibarrApiAccess::$user->rights->commande->creer) {
+			throw new RestException(401);
+		}
 
-      $result = $this->commande->fetch($id);
-      if( ! $result ) {
-         throw new RestException(404, 'Order not found');
-      }
+        $result = $this->commande->fetch($id);
+        if( ! $result ) {
+            throw new RestException(404, 'Order not found');
+        }
 
-		  if( ! DolibarrApi::_checkAccessToResource('commande',$this->commande->id)) {
-			  throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
-      }
-			$request_data = (object) $request_data;
-      $updateRes = $this->commande->updateline(
-                        $lineid,
-                        $request_data->desc,
-                        $request_data->subprice,
-                        $request_data->qty,
-                        $request_data->remise_percent,
-                        $request_data->tva_tx,
-                        $request_data->localtax1_tx,
-                        $request_data->localtax2_tx,
-                        'HT',
-                        $request_data->info_bits,
-                        $request_data->date_start,
-                        $request_data->date_end,
-                        $request_data->product_type,
-                        $request_data->fk_parent_line,
-                        0,
-                        $request_data->fk_fournprice,
-                        $request_data->pa_ht,
-                        $request_data->label,
-                        $request_data->special_code,
-                        $request_data->array_options,
-                        $request_data->fk_unit,
-      					$request_data->multicurrency_subprice
-      );
+		if( ! DolibarrApi::_checkAccessToResource('commande',$this->commande->id)) {
+			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        }
+		$request_data = (object) $request_data;
+        $updateRes = $this->commande->updateline(
+            $lineid,
+            $request_data->desc,
+            $request_data->subprice,
+            $request_data->qty,
+            $request_data->remise_percent,
+            $request_data->tva_tx,
+            $request_data->localtax1_tx,
+            $request_data->localtax2_tx,
+            'HT',
+            $request_data->info_bits,
+            $request_data->date_start,
+            $request_data->date_end,
+            $request_data->product_type,
+            $request_data->fk_parent_line,
+            0,
+            $request_data->fk_fournprice,
+            $request_data->pa_ht,
+            $request_data->label,
+            $request_data->special_code,
+            $request_data->array_options,
+            $request_data->fk_unit,
+      		$request_data->multicurrency_subprice
+        );
 
-      if ($updateRes > 0) {
-        $result = $this->get($id);
-        unset($result->line);
-        return $this->_cleanObjectDatas($result);
-      }
-      return false;
+        if ($updateRes > 0) {
+            $result = $this->get($id);
+            unset($result->line);
+            return $this->_cleanObjectDatas($result);
+        }
+        return false;
     }
 
     /**
@@ -373,29 +372,27 @@ class Orders extends DolibarrApi
      * @throws 404
      */
     function deleteLine($id, $lineid) {
-      if(! DolibarrApiAccess::$user->rights->commande->creer) {
-		  	throw new RestException(401);
-		  }
+        if(! DolibarrApiAccess::$user->rights->commande->creer) {
+			throw new RestException(401);
+		}
 
-      $result = $this->commande->fetch($id);
-      if( ! $result ) {
-         throw new RestException(404, 'Order not found');
-      }
+        $result = $this->commande->fetch($id);
+        if( ! $result ) {
+            throw new RestException(404, 'Order not found');
+        }
 
-		  if( ! DolibarrApi::_checkAccessToResource('commande',$this->commande->id)) {
-			  throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
-      }
+		if( ! DolibarrApi::_checkAccessToResource('commande',$this->commande->id)) {
+			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        }
 
-      // TODO Check the lineid $lineid is a line of ojbect
+        // TODO Check the lineid $lineid is a line of ojbect
 
-      $updateRes = $this->commande->deleteline(DolibarrApiAccess::$user,$lineid);
-      if ($updateRes > 0) {
-        return $this->get($id);
-      }
-      else
-      {
-      	throw new RestException(405, $this->commande->error);
-      }
+        $updateRes = $this->commande->deleteline(DolibarrApiAccess::$user,$lineid);
+        if ($updateRes > 0) {
+            return $this->get($id);
+        } else {
+            throw new RestException(405, $this->commande->error);
+        }
     }
 
     /**
@@ -407,9 +404,9 @@ class Orders extends DolibarrApi
      * @return int
      */
     function put($id, $request_data = null) {
-      if (! DolibarrApiAccess::$user->rights->commande->creer) {
-		  	throw new RestException(401);
-		  }
+        if (! DolibarrApiAccess::$user->rights->commande->creer) {
+			throw new RestException(401);
+		}
 
         $result = $this->commande->fetch($id);
         if (! $result) {
@@ -550,21 +547,21 @@ class Orders extends DolibarrApi
     function reopen($id) {
 
         if(! DolibarrApiAccess::$user->rights->commande->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         if(empty($id)) {
-                throw new RestException(400, 'Order ID is mandatory');
+            throw new RestException(400, 'Order ID is mandatory');
         }
         $result = $this->commande->fetch($id);
         if( ! $result ) {
-                throw new RestException(404, 'Order not found');
+            throw new RestException(404, 'Order not found');
         }
 
         $result = $this->commande->set_reopen(DolibarrApiAccess::$user);
         if( $result < 0) {
-                throw new RestException(405, $this->commande->error);
+            throw new RestException(405, $this->commande->error);
         }else if( $result == 0) {
-                throw new RestException(304);
+            throw new RestException(304);
         }
 
         return $result;
@@ -587,19 +584,19 @@ class Orders extends DolibarrApi
     function setinvoiced($id) {
 
         if(! DolibarrApiAccess::$user->rights->commande->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         if(empty($id)) {
-                throw new RestException(400, 'Order ID is mandatory');
+            throw new RestException(400, 'Order ID is mandatory');
         }
         $result = $this->commande->fetch($id);
         if( ! $result ) {
-                throw new RestException(404, 'Order not found');
+            throw new RestException(404, 'Order not found');
         }
 
         $result = $this->commande->classifyBilled(DolibarrApiAccess::$user);
         if( $result < 0) {
-                throw new RestException(400, $this->commande->error);
+            throw new RestException(400, $this->commande->error);
         }
 
         $result = $this->commande->fetch($id);
@@ -675,23 +672,23 @@ class Orders extends DolibarrApi
     function settodraft($id, $idwarehouse=-1)
     {
         if(! DolibarrApiAccess::$user->rights->commande->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         $result = $this->commande->fetch($id);
         if( ! $result ) {
-                throw new RestException(404, 'Order not found');
+            throw new RestException(404, 'Order not found');
         }
 
         if( ! DolibarrApi::_checkAccessToResource('commande',$this->commande->id)) {
-                throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+            throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
         }
 
         $result = $this->commande->set_draft(DolibarrApiAccess::$user, $idwarehouse);
         if ($result == 0) {
-                throw new RestException(304, 'Nothing done. May be object is already closed');
+            throw new RestException(304, 'Nothing done. May be object is already closed');
         }
         if ($result < 0) {
-                throw new RestException(500, 'Error when closing Order: '.$this->commande->error);
+            throw new RestException(500, 'Error when closing Order: '.$this->commande->error);
         }
 
 		$result = $this->commande->fetch($id);
@@ -728,24 +725,24 @@ class Orders extends DolibarrApi
         require_once DOL_DOCUMENT_ROOT . '/comm/propal/class/propal.class.php';
 
         if(! DolibarrApiAccess::$user->rights->propal->lire) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         if(! DolibarrApiAccess::$user->rights->commande->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         if(empty($proposalid)) {
-                throw new RestException(400, 'Proposal ID is mandatory');
+            throw new RestException(400, 'Proposal ID is mandatory');
         }
 
         $propal = new Propal($this->db);
         $result = $propal->fetch($proposalid);
         if( ! $result ) {
-                throw new RestException(404, 'Proposal not found');
+            throw new RestException(404, 'Proposal not found');
         }
 
         $result = $this->commande->createFromProposal($propal, DolibarrApiAccess::$user);
         if( $result < 0) {
-                throw new RestException(405, $this->commande->error);
+            throw new RestException(405, $this->commande->error);
         }
         $this->commande->fetchObjectLinked();
 
@@ -785,7 +782,7 @@ class Orders extends DolibarrApi
         $commande = array();
         foreach (Orders::$FIELDS as $field) {
             if (!isset($data[$field]))
-                throw new RestException(400, "$field field missing");
+                throw new RestException(400, $field ." field missing");
             $commande[$field] = $data[$field];
 
         }

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -250,24 +250,24 @@ class Invoices extends DolibarrApi
         require_once DOL_DOCUMENT_ROOT . '/commande/class/commande.class.php';
 
         if(! DolibarrApiAccess::$user->rights->commande->lire) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         if(! DolibarrApiAccess::$user->rights->facture->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         if(empty($orderid)) {
-                throw new RestException(400, 'Order ID is mandatory');
+            throw new RestException(400, 'Order ID is mandatory');
         }
 
         $order = new Commande($this->db);
         $result = $order->fetch($orderid);
         if( ! $result ) {
-                throw new RestException(404, 'Order not found');
+            throw new RestException(404, 'Order not found');
         }
 
         $result = $this->invoice->createFromOrder($order, DolibarrApiAccess::$user);
         if( $result < 0) {
-                throw new RestException(405, $this->invoice->error);
+            throw new RestException(405, $this->invoice->error);
         }
         $this->invoice->fetchObjectLinked();
         return $this->_cleanObjectDatas($this->invoice);
@@ -512,66 +512,66 @@ class Invoices extends DolibarrApi
      * @throws 400
      */
     function postLine($id, $request_data = null) {
-      if(! DolibarrApiAccess::$user->rights->facture->creer) {
-                        throw new RestException(401);
-                  }
+        if(! DolibarrApiAccess::$user->rights->facture->creer) {
+            throw new RestException(401);
+        }
 
-      $result = $this->invoice->fetch($id);
-      if( ! $result ) {
-         throw new RestException(404, 'Invoice not found');
-      }
+        $result = $this->invoice->fetch($id);
+        if( ! $result ) {
+            throw new RestException(404, 'Invoice not found');
+        }
 
-      if( ! DolibarrApi::_checkAccessToResource('facture',$this->invoice->id)) {
-                          throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
-      }
+        if( ! DolibarrApi::_checkAccessToResource('facture',$this->invoice->id)) {
+            throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        }
 
-      $request_data = (object) $request_data;
+        $request_data = (object) $request_data;
 
-      // Reset fk_parent_line for no child products and special product
-      if (($request_data->product_type != 9 && empty($request_data->fk_parent_line)) || $request_data->product_type == 9) {
-              $request_data->fk_parent_line = 0;
-      }
+        // Reset fk_parent_line for no child products and special product
+        if (($request_data->product_type != 9 && empty($request_data->fk_parent_line)) || $request_data->product_type == 9) {
+            $request_data->fk_parent_line = 0;
+        }
 
-      // calculate pa_ht
-      $marginInfos = getMarginInfos($request_data->subprice, $request_data->remise_percent, $request_data->tva_tx, $request_data->localtax1_tx, $request_data->localtax2_tx, $request_data->fk_fournprice, $request_data->pa_ht);
-      $pa_ht = $marginInfos[0];
+        // calculate pa_ht
+        $marginInfos = getMarginInfos($request_data->subprice, $request_data->remise_percent, $request_data->tva_tx, $request_data->localtax1_tx, $request_data->localtax2_tx, $request_data->fk_fournprice, $request_data->pa_ht);
+        $pa_ht = $marginInfos[0];
 
-      $updateRes = $this->invoice->addline(
-                              $request_data->desc,
-                              $request_data->subprice,
-                              $request_data->qty,
-                              $request_data->tva_tx,
-                              $request_data->localtax1_tx,
-                              $request_data->localtax2_tx,
-                              $request_data->fk_product,
-                              $request_data->remise_percent,
-                              $request_data->date_start,
-                              $request_data->date_end,
-                              $request_data->fk_code_ventilation,
-                              $request_data->info_bits,
-                              $request_data->fk_remise_except,
-                              'HT',
-                              0,
-                              $request_data->product_type,
-                              $request_data->rang,
-                              $request_data->special_code,
-                              $request_data->origin,
-                              $request_data->origin_id,
-                              $request_data->fk_parent_line,
-                              empty($request_data->fk_fournprice)?null:$request_data->fk_fournprice,
-                              $pa_ht,
-                              $request_data->label,
-                              $request_data->array_options,
-                              $request_data->situation_percent,
-                              $request_data->fk_prev_id,
-                              $request_data->fk_unit
-      );
+        $updateRes = $this->invoice->addline(
+            $request_data->desc,
+            $request_data->subprice,
+            $request_data->qty,
+            $request_data->tva_tx,
+            $request_data->localtax1_tx,
+            $request_data->localtax2_tx,
+            $request_data->fk_product,
+            $request_data->remise_percent,
+            $request_data->date_start,
+            $request_data->date_end,
+            $request_data->fk_code_ventilation,
+            $request_data->info_bits,
+            $request_data->fk_remise_except,
+            'HT',
+            0,
+            $request_data->product_type,
+            $request_data->rang,
+            $request_data->special_code,
+            $request_data->origin,
+            $request_data->origin_id,
+            $request_data->fk_parent_line,
+            empty($request_data->fk_fournprice)?null:$request_data->fk_fournprice,
+            $pa_ht,
+            $request_data->label,
+            $request_data->array_options,
+            $request_data->situation_percent,
+            $request_data->fk_prev_id,
+            $request_data->fk_unit
+        );
 
-      if ($updateRes < 0) {
+        if ($updateRes < 0) {
             throw new RestException(400, 'Unable to insert the new line. Check your inputs. '.$this->invoice->error);
-      }
+        }
 
-      return $updateRes;
+        return $updateRes;
     }
 
     /**
@@ -647,23 +647,23 @@ class Invoices extends DolibarrApi
     function settodraft($id, $idwarehouse=-1)
     {
         if(! DolibarrApiAccess::$user->rights->facture->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         $result = $this->invoice->fetch($id);
         if( ! $result ) {
-                throw new RestException(404, 'Invoice not found');
+            throw new RestException(404, 'Invoice not found');
         }
 
         if( ! DolibarrApi::_checkAccessToResource('facture',$this->invoice->id)) {
-                throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+            throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
         }
 
         $result = $this->invoice->set_draft(DolibarrApiAccess::$user, $idwarehouse);
         if ($result == 0) {
-                throw new RestException(304, 'Nothing done.');
+            throw new RestException(304, 'Nothing done.');
         }
         if ($result < 0) {
-                throw new RestException(500, 'Error : '.$this->invoice->error);
+            throw new RestException(500, 'Error : '.$this->invoice->error);
         }
 
         $result = $this->invoice->fetch($id);
@@ -750,23 +750,23 @@ class Invoices extends DolibarrApi
     function settopaid($id, $close_code='', $close_note='')
     {
         if(! DolibarrApiAccess::$user->rights->facture->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         $result = $this->invoice->fetch($id);
         if( ! $result ) {
-                throw new RestException(404, 'Invoice not found');
+            throw new RestException(404, 'Invoice not found');
         }
 
         if( ! DolibarrApi::_checkAccessToResource('facture',$this->invoice->id)) {
-                throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+            throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
         }
 
         $result = $this->invoice->set_paid(DolibarrApiAccess::$user, $close_code, $close_note);
         if ($result == 0) {
-                throw new RestException(304, 'Error nothing done. May be object is already validated');
+            throw new RestException(304, 'Error nothing done. May be object is already validated');
         }
         if ($result < 0) {
-                throw new RestException(500, 'Error : '.$this->invoice->error);
+            throw new RestException(500, 'Error : '.$this->invoice->error);
         }
 
 
@@ -801,23 +801,23 @@ class Invoices extends DolibarrApi
     function settounpaid($id)
     {
         if(! DolibarrApiAccess::$user->rights->facture->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         $result = $this->invoice->fetch($id);
         if( ! $result ) {
-                throw new RestException(404, 'Invoice not found');
+            throw new RestException(404, 'Invoice not found');
         }
 
         if( ! DolibarrApi::_checkAccessToResource('facture',$this->invoice->id)) {
-                throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+            throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
         }
 
         $result = $this->invoice->set_unpaid(DolibarrApiAccess::$user);
         if ($result == 0) {
-                throw new RestException(304, 'Nothing done');
+            throw new RestException(304, 'Nothing done');
         }
         if ($result < 0) {
-                throw new RestException(500, 'Error : '.$this->invoice->error);
+            throw new RestException(500, 'Error : '.$this->invoice->error);
         }
 
 
@@ -852,27 +852,27 @@ class Invoices extends DolibarrApi
     function useDiscount($id, $discountid) {
 
         if(! DolibarrApiAccess::$user->rights->facture->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         if(empty($id)) {
-                throw new RestException(400, 'Invoice ID is mandatory');
+            throw new RestException(400, 'Invoice ID is mandatory');
         }
         if(empty($discountid)) {
-                throw new RestException(400, 'Discount ID is mandatory');
+            throw new RestException(400, 'Discount ID is mandatory');
         }
 
         if( ! DolibarrApi::_checkAccessToResource('facture',$id)) {
-                throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+            throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
         }
 
         $result = $this->invoice->fetch($id);
         if( ! $result ) {
-                throw new RestException(404, 'Invoice not found');
+            throw new RestException(404, 'Invoice not found');
         }
 
         $result = $this->invoice->insert_discount($discountid);
         if( $result < 0) {
-                throw new RestException(405, $this->invoice->error);
+            throw new RestException(405, $this->invoice->error);
         }
 
         return $result;
@@ -899,27 +899,27 @@ class Invoices extends DolibarrApi
         require_once DOL_DOCUMENT_ROOT . '/core/class/discount.class.php';
 
         if(! DolibarrApiAccess::$user->rights->facture->creer) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         if(empty($id)) {
-                throw new RestException(400, 'Invoice ID is mandatory');
+            throw new RestException(400, 'Invoice ID is mandatory');
         }
         if(empty($discountid)) {
-                throw new RestException(400, 'Credit ID is mandatory');
+            throw new RestException(400, 'Credit ID is mandatory');
         }
 
         if( ! DolibarrApi::_checkAccessToResource('facture',$id)) {
-                throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+            throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
         }
         $discount = new DiscountAbsolute($this->db);
         $result = $discount->fetch($discountid);
         if( ! $result ) {
-                throw new RestException(404, 'Credit not found');
+            throw new RestException(404, 'Credit not found');
         }
 
         $result = $discount->link_to_invoice(0, $id);
         if( $result < 0) {
-                throw new RestException(405, $discount->error);
+            throw new RestException(405, $discount->error);
         }
 
         return $result;
@@ -941,24 +941,24 @@ class Invoices extends DolibarrApi
     function getPayments($id) {
 
         if(! DolibarrApiAccess::$user->rights->facture->lire) {
-                throw new RestException(401);
+            throw new RestException(401);
         }
         if(empty($id)) {
-                throw new RestException(400, 'Invoice ID is mandatory');
+            throw new RestException(400, 'Invoice ID is mandatory');
         }
 
         if( ! DolibarrApi::_checkAccessToResource('facture',$id)) {
-                throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+            throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
         }
 
         $result = $this->invoice->fetch($id);
         if( ! $result ) {
-                throw new RestException(404, 'Invoice not found');
+            throw new RestException(404, 'Invoice not found');
         }
 
         $result = $this->invoice->getListOfPayments();
         if( $result < 0) {
-                throw new RestException(405, $this->invoice->error);
+            throw new RestException(405, $this->invoice->error);
         }
 
         return $result;
@@ -1111,7 +1111,7 @@ class Invoices extends DolibarrApi
         require_once DOL_DOCUMENT_ROOT . '/compta/paiement/class/paiement.class.php';
 
         if(! DolibarrApiAccess::$user->rights->facture->creer) {
-                throw new RestException(403);
+            throw new RestException(403);
         }
         foreach($arrayofamounts as $id => $amount) {
         	if(empty($id)) {

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -248,45 +248,45 @@ class Contracts extends DolibarrApi
      * @return int
      */
     function postLine($id, $request_data = null) {
-      if(! DolibarrApiAccess::$user->rights->contrat->creer) {
-		  	throw new RestException(401);
-		  }
+        if(! DolibarrApiAccess::$user->rights->contrat->creer) {
+			throw new RestException(401);
+		}
 
-      $result = $this->contract->fetch($id);
-      if( ! $result ) {
-         throw new RestException(404, 'Contract not found');
-      }
+        $result = $this->contract->fetch($id);
+        if( ! $result ) {
+            throw new RestException(404, 'Contract not found');
+        }
 
-		  if( ! DolibarrApi::_checkAccessToResource('contrat',$this->contract->id)) {
-			  throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
-      }
-			$request_data = (object) $request_data;
-      $updateRes = $this->contract->addline(
-                        $request_data->desc,
-                        $request_data->subprice,
-                        $request_data->qty,
-                        $request_data->tva_tx,
-                        $request_data->localtax1_tx,
-                        $request_data->localtax2_tx,
-                        $request_data->fk_product,
-                        $request_data->remise_percent,
-                        $request_data->date_start,			// date_start = date planned start, date ouverture = date_start_real
-                        $request_data->date_end,			// date_end = date planned end, date_cloture = date_end_real
-                        $request_data->HT,
-      					$request_data->subprice_excl_tax,
-      					$request_data->info_bits,
-                        $request_data->fk_fournprice,
-				      	$request_data->pa_ht,
-      					$request_data->array_options,
-      					$request_data->fk_unit,
-      					$request_data->rang
-      );
+		if( ! DolibarrApi::_checkAccessToResource('contrat',$this->contract->id)) {
+			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        }
+		$request_data = (object) $request_data;
+        $updateRes = $this->contract->addline(
+            $request_data->desc,
+            $request_data->subprice,
+            $request_data->qty,
+            $request_data->tva_tx,
+            $request_data->localtax1_tx,
+            $request_data->localtax2_tx,
+            $request_data->fk_product,
+            $request_data->remise_percent,
+            $request_data->date_start,			// date_start = date planned start, date ouverture = date_start_real
+            $request_data->date_end,			// date_end = date planned end, date_cloture = date_end_real
+            $request_data->HT,
+      		$request_data->subprice_excl_tax,
+      		$request_data->info_bits,
+            $request_data->fk_fournprice,
+			$request_data->pa_ht,
+      		$request_data->array_options,
+      		$request_data->fk_unit,
+      		$request_data->rang
+        );
 
-      if ($updateRes > 0) {
-        return $updateRes;
+        if ($updateRes > 0) {
+            return $updateRes;
 
-      }
-      return false;
+        }
+        return false;
     }
 
     /**
@@ -301,49 +301,49 @@ class Contracts extends DolibarrApi
      * @return object
      */
     function putLine($id, $lineid, $request_data = null) {
-      if(! DolibarrApiAccess::$user->rights->contrat->creer) {
-		  	throw new RestException(401);
-		  }
-
-      $result = $this->contract->fetch($id);
-      if( ! $result ) {
-         throw new RestException(404, 'Contrat not found');
-      }
-
-		if( ! DolibarrApi::_checkAccessToResource('contrat',$this->contract->id)) {
-			  throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        if(! DolibarrApiAccess::$user->rights->contrat->creer) {
+			throw new RestException(401);
 		}
 
-      $request_data = (object) $request_data;
+        $result = $this->contract->fetch($id);
+        if( ! $result ) {
+            throw new RestException(404, 'Contrat not found');
+        }
 
-      $updateRes = $this->contract->updateline(
-                        $lineid,
-                        $request_data->desc,
-                        $request_data->subprice,
-                        $request_data->qty,
-                        $request_data->remise_percent,
-                        $request_data->date_ouveture_prevue,
-                        $request_data->date_fin_validite,
-      					$request_data->tva_tx,
-                        $request_data->localtax1_tx,
-                        $request_data->localtax2_tx,
-                        $request_data->date_ouverture,
-                        $request_data->date_cloture,
-      					'HT',
-                        $request_data->info_bits,
-                        $request_data->fk_fourn_price,
-                        $request_data->pa_ht,
-                        $request_data->array_options,
-                        $request_data->fk_unit
-      );
+		if( ! DolibarrApi::_checkAccessToResource('contrat',$this->contract->id)) {
+			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+		}
 
-      if ($updateRes > 0) {
-        $result = $this->get($id);
-        unset($result->line);
-        return $this->_cleanObjectDatas($result);
-      }
+        $request_data = (object) $request_data;
 
-      return false;
+        $updateRes = $this->contract->updateline(
+            $lineid,
+            $request_data->desc,
+            $request_data->subprice,
+            $request_data->qty,
+            $request_data->remise_percent,
+            $request_data->date_ouveture_prevue,
+            $request_data->date_fin_validite,
+      		$request_data->tva_tx,
+            $request_data->localtax1_tx,
+            $request_data->localtax2_tx,
+            $request_data->date_ouverture,
+            $request_data->date_cloture,
+      		'HT',
+            $request_data->info_bits,
+            $request_data->fk_fourn_price,
+            $request_data->pa_ht,
+            $request_data->array_options,
+            $request_data->fk_unit
+        );
+
+        if ($updateRes > 0) {
+            $result = $this->get($id);
+            unset($result->line);
+            return $this->_cleanObjectDatas($result);
+        }
+
+        return false;
     }
 
     /**
@@ -437,29 +437,29 @@ class Contracts extends DolibarrApi
      * @throws 404
      */
     function deleteLine($id, $lineid) {
-      if(! DolibarrApiAccess::$user->rights->contrat->creer) {
-		  	throw new RestException(401);
-		  }
+        if(! DolibarrApiAccess::$user->rights->contrat->creer) {
+			throw new RestException(401);
+		}
 
-      $result = $this->contract->fetch($id);
-      if( ! $result ) {
-         throw new RestException(404, 'Contrat not found');
-      }
+        $result = $this->contract->fetch($id);
+        if( ! $result ) {
+            throw new RestException(404, 'Contrat not found');
+        }
 
-		  if( ! DolibarrApi::_checkAccessToResource('contrat',$this->contract->id)) {
-			  throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
-      }
+		if( ! DolibarrApi::_checkAccessToResource('contrat',$this->contract->id)) {
+			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+        }
 
-      // TODO Check the lineid $lineid is a line of ojbect
+        // TODO Check the lineid $lineid is a line of ojbect
 
-      $updateRes = $this->contract->deleteline($lineid, DolibarrApiAccess::$user);
-      if ($updateRes > 0) {
-        return $this->get($id);
-      }
-      else
-      {
-      	throw new RestException(405, $this->contract->error);
-      }
+        $updateRes = $this->contract->deleteline($lineid, DolibarrApiAccess::$user);
+        if ($updateRes > 0) {
+            return $this->get($id);
+        }
+        else
+        {
+      	    throw new RestException(405, $this->contract->error);
+        }
     }
 
     /**
@@ -471,9 +471,9 @@ class Contracts extends DolibarrApi
      * @return int
      */
     function put($id, $request_data = null) {
-      if(! DolibarrApiAccess::$user->rights->contrat->creer) {
-		  	throw new RestException(401);
-		  }
+        if(! DolibarrApiAccess::$user->rights->contrat->creer) {
+			throw new RestException(401);
+		}
 
         $result = $this->contract->fetch($id);
         if( ! $result ) {

--- a/htdocs/core/db/Database.interface.php
+++ b/htdocs/core/db/Database.interface.php
@@ -196,7 +196,7 @@ interface Database
 	 *
 	 * @param   string $query SQL query string
 	 * @param   int $usesavepoint 0=Default mode, 1=Run a savepoint before and a rollback to savepoint if error (this allow to have some request with errors inside global transactions).
-	 *                                    Note that with Mysql, this parameter is not used as Myssql can already commit a transaction even if one request is in error, without using savepoints.
+	 *                            Note that with Mysql, this parameter is not used as Myssql can already commit a transaction even if one request is in error, without using savepoints.
 	 * @param   string $type Type of SQL order ('ddl' for insert, update, select, delete or 'dml' for create, alter...)
 	 * @return  resource                Resultset of answer
 	 */

--- a/htdocs/core/js/lib_photosresize.js
+++ b/htdocs/core/js/lib_photosresize.js
@@ -21,10 +21,10 @@
 
 /* Enable jcrop plugin onto id cropbox */
 jQuery(function() {
-   jQuery('#cropbox').Jcrop({
-      onSelect: updateCoords, 
-      onChange: updateCoords
-   });
+    jQuery('#cropbox').Jcrop({
+        onSelect: updateCoords,
+        onChange: updateCoords
+    });
 });
 
 /* Update fields that store new size */

--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -35,12 +35,12 @@
  *  @param	string	$urloption			More parameters on URL request
  *  @param	int		$minLength			Minimum number of chars to trigger that Ajax search
  *  @param	int		$autoselect			Automatic selection if just one value
- *  @param	array	$ajaxoptions		Multiple options array
- *                                          Ex: array('update'=>array('field1','field2'...)) will reset field1 and field2 once select done
- *                                          Ex: array('disabled'=> )
- *                                          Ex: array('show'=> )
- *                                          Ex: array('update_textarea'=> )
- *                                          Ex: array('option_disabled'=> id to disable and warning to show if we select a disabled value (this is possible when using autocomplete ajax)
+ *  @param	array   $ajaxoptions		Multiple options array
+ *                                      - Ex: array('update'=>array('field1','field2'...)) will reset field1 and field2 once select done
+ *                                      - Ex: array('disabled'=> )
+ *                                      - Ex: array('show'=> )
+ *                                      - Ex: array('update_textarea'=> )
+ *                                      - Ex: array('option_disabled'=> id to disable and warning to show if we select a disabled value (this is possible when using autocomplete ajax)
  *	@return string              		Script
  */
 function ajax_autocompleter($selected, $htmlname, $url, $urloption='', $minLength=2, $autoselect=0, $ajaxoptions=array())
@@ -622,4 +622,3 @@ function ajax_object_onoff($object, $code, $field, $text_on, $text_off, $input=a
 
     return $out;
 }
-

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -162,15 +162,15 @@ function convertTime2Seconds($iHours=0,$iMinutes=0,$iSeconds=0)
  *
  *    	@param      int		$iSecond		Number of seconds
  *    	@param      string	$format		    Output format ('all': total delay days hour:min like "2 days 12:30",
- *                                                         'allwithouthour': total delay days without hour part like "2 days",
- *                                                         'allhourmin': total delay with format hours:min like "60:30",
- *                                                         'allhour': total delay hours without min/sec like "60:30",
- *                                                         'fullhour': total delay hour decimal like "60.5" for 60:30,
- *                                                         'hour': only hours part "12",
- *                                                         'min': only minutes part "30",
- *                                                         'sec': only seconds part,
- *                                                         'month': only month part,
- *                                                         'year': only year part);
+ *                                          - 'allwithouthour': total delay days without hour part like "2 days",
+ *                                          - 'allhourmin': total delay with format hours:min like "60:30",
+ *                                          - 'allhour': total delay hours without min/sec like "60:30",
+ *                                          - 'fullhour': total delay hour decimal like "60.5" for 60:30,
+ *                                          - 'hour': only hours part "12",
+ *                                          - 'min': only minutes part "30",
+ *                                          - 'sec': only seconds part,
+ *                                          - 'month': only month part,
+ *                                          - 'year': only year part);
  *      @param      int		$lengthOfDay    Length of day (default 86400 seconds for 1 day, 28800 for 8 hour)
  *      @param      int		$lengthOfWeek   Length of week (default 7)
  *    	@return     string		 		 	Formated text of duration
@@ -964,4 +964,3 @@ function monthArray($outputlangs,$short=0)
 
 	return $montharray;
 }
-

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -253,19 +253,19 @@ function GETPOSTISSET($paramname)
  *  Use the property $user->default_values[path]['creatform'] and/or $user->default_values[path]['filters'] and/or $user->default_values[path]['sortorder']
  *  Note: The property $user->default_values is loaded by main.php when loading the user.
  *
- *  @param	string	$paramname   Name of parameter to found
- *  @param	string	$check	     Type of check
- *                                  ''=no check (deprecated)
- *                                  'none'=no check (only for param that should have very rich content)
- *                                  'int'=check it's numeric (integer or float)
- *                                  'intcomma'=check it's integer+comma ('1,2,3,4...')
- *                                  'alpha'=check it's text and sign
- *                                  'aZ'=check it's a-z only
- *                                  'aZ09'=check it's simple alpha string (recommended for keys)
- *                                  'array'=check it's array
- *                                  'san_alpha'=Use filter_var with FILTER_SANITIZE_STRING (do not use this for free text string)
- *                                  'nohtml', 'alphanohtml'=check there is no html content
- *                                  'custom'= custom filter specify $filter and $options)
+ *  @param  string  $paramname   Name of parameter to found
+ *  @param  string  $check	     Type of check
+ *                               ''=no check (deprecated)
+ *                               'none'=no check (only for param that should have very rich content)
+ *                               'int'=check it's numeric (integer or float)
+ *                               'intcomma'=check it's integer+comma ('1,2,3,4...')
+ *                               'alpha'=check it's text and sign
+ *                               'aZ'=check it's a-z only
+ *                               'aZ09'=check it's simple alpha string (recommended for keys)
+ *                               'array'=check it's array
+ *                               'san_alpha'=Use filter_var with FILTER_SANITIZE_STRING (do not use this for free text string)
+ *                               'nohtml', 'alphanohtml'=check there is no html content
+ *                               'custom'= custom filter specify $filter and $options)
  *  @param	int		$method	     Type of method (0 = get then post, 1 = only get, 2 = only post, 3 = post then get, 4 = post then get then cookie)
  *  @param  int     $filter      Filter to apply when $check is set to 'custom'. (See http://php.net/manual/en/filter.filters.php for détails)
  *  @param  mixed   $options     Options to pass to filter_var when $check is set to 'custom'
@@ -7174,11 +7174,11 @@ function dol_getmypid()
 /**
  * Generate natural SQL search string for a criteria (this criteria can be tested on one or several fields)
  *
- * @param 	string|string[]	$fields 	String or array of strings, filled with the name of all fields in the SQL query we must check (combined with a OR). Example: array("p.field1","p.field2")
- * @param 	string 			$value 		The value to look for.
+ * @param   string|string[]	$fields 	String or array of strings, filled with the name of all fields in the SQL query we must check (combined with a OR). Example: array("p.field1","p.field2")
+ * @param   string 			$value 		The value to look for.
  *                          		    If param $mode is 0, can contains several keywords separated with a space or |
- *                                         like "keyword1 keyword2" = We want record field like keyword1 AND field like keyword2
- *                                         or like "keyword1|keyword2" = We want record field like keyword1 OR field like keyword2
+ *                                      like "keyword1 keyword2" = We want record field like keyword1 AND field like keyword2
+ *                                      or like "keyword1|keyword2" = We want record field like keyword1 OR field like keyword2
  *                             			If param $mode is 1, can contains an operator <, > or = like "<10" or ">=100.5 < 1000"
  *                             			If param $mode is 2, can contains a list of int id separated by comma like "1,3,4"
  *                             			If param $mode is 3, can contains a list of string separated by comma like "a,b,c"

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -377,8 +377,8 @@ class DolibarrModules           // Can not be abstract, because we need to insta
 	 *
 	 * @param   array  		$array_sql  SQL requests to be executed when enabling module
 	 * @param   string      $options    String with options when disabling module:
-	 *                                    'noboxes' = Do not insert boxes
-	 *                                    'newboxdefonly' = For boxes, insert def of boxes only and not boxes activation
+	 *                                  - 'noboxes' = Do not insert boxes
+	 *                                  - 'newboxdefonly' = For boxes, insert def of boxes only and not boxes activation
 	 *
 	 * @return  int                         1 if OK, 0 if KO
 	 */
@@ -468,7 +468,7 @@ class DolibarrModules           // Can not be abstract, because we need to insta
 	 *
 	 * @param   string[]    $array_sql  SQL requests to be executed when module is disabled
 	 * @param   string      $options	Options when disabling module:
-	 *                                    'newboxdefonly|noboxes' = We don't remove boxes.
+	 *                                  - 'newboxdefonly|noboxes' = We don't remove boxes.
 	 *
 	 * @return  int                     1 if OK, 0 if KO
 	 */

--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -803,7 +803,7 @@ class ProductFournisseur extends Product
      *  @param  int     $showsuptitle     Show "Supplier" into output string
      *  @param  int     $maxlen           Max length of name
      *  @param  integer $notooltip        1=Disable tooltip
-     *  @param  array   $productFournList  list of ProductFournisseur objects
+     *  @param  array   $productFournList list of ProductFournisseur objects
      *                                    to display in table format.
      *  @return string                    String with supplier price
      */
@@ -850,4 +850,3 @@ class ProductFournisseur extends Product
 	}
 
 }
-

--- a/htdocs/install/fileconf.php
+++ b/htdocs/install/fileconf.php
@@ -503,19 +503,19 @@ if (! empty($force_install_message))
 			       name="db_pass_root"
 			       class="needroot"
 			       value="<?php
-			       // If $force_install_databaserootpass is on, we don't want to set password here, we just show '***'. Real value will be extracted from the forced install file at step1.
-			       $autofill = ((!empty($force_install_databaserootpass)) ? str_pad('', strlen($force_install_databaserootpass), '*') : @$db_pass_root);
-			       if (!empty($dolibarr_main_prod)) {
-				       $autofill = '';
-			       }
-				   // Do not autofill password if instance is a production instance
-			       if (!empty($_SERVER["SERVER_NAME"]) && !in_array($_SERVER["SERVER_NAME"],
-					       array('127.0.0.1', 'localhost', 'localhostgit'))
-			       ) {
-				       $autofill = '';
-			       }    // Do not autofill password for remote access
-			       print dol_escape_htmltag($autofill);
-			       ?>"
+			        // If $force_install_databaserootpass is on, we don't want to set password here, we just show '***'. Real value will be extracted from the forced install file at step1.
+			        $autofill = ((!empty($force_install_databaserootpass)) ? str_pad('', strlen($force_install_databaserootpass), '*') : @$db_pass_root);
+			        if (!empty($dolibarr_main_prod)) {
+				        $autofill = '';
+			        }
+				    // Do not autofill password if instance is a production instance
+			        if (!empty($_SERVER["SERVER_NAME"]) && !in_array($_SERVER["SERVER_NAME"],
+					    array('127.0.0.1', 'localhost', 'localhostgit'))
+			        ) {
+				        $autofill = '';
+			        }    // Do not autofill password for remote access
+			        print dol_escape_htmltag($autofill);
+			        ?>"
 				<?php if ($force_install_noedit > 0 && ! empty($force_install_databaserootpass)) {
 					print ' disabled';     // May be removed by javascript
 				} ?>

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1453,7 +1453,7 @@ function top_htmlhead($head, $title='', $disablejs=0, $disablehead=0, $arrayofjs
  *  @param		string	$morequerystring	Query string to add to the link "print" to get same parameters (use only if autodetect fails)
  *  @param      string	$helppagename    	Name of wiki page for help ('' by default).
  * 				     		                Syntax is: For a wiki page: EN:EnglishPage|FR:FrenchPage|ES:SpanishPage
- * 									                   For other external page: http://server/url
+ * 						                    For other external page: http://server/url
  *  @return		void
  */
 function top_menu($head, $title='', $target='', $disablejs=0, $disablehead=0, $arrayofjs='', $arrayofcss='', $morequerystring='', $helppagename='')
@@ -2071,4 +2071,3 @@ if (! function_exists("llxFooter"))
 		print "</html>\n";
 	}
 }
-

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1653,7 +1653,7 @@ function top_menu($head, $title='', $target='', $disablejs=0, $disablehead=0, $a
  *  @param  array	$menu_array_before 	       	Table of menu entries to show before entries of menu handler. This param is deprectaed and must be provided to ''.
  *  @param  string	$helppagename    	       	Name of wiki page for help ('' by default).
  * 				     		                   	Syntax is: For a wiki page: EN:EnglishPage|FR:FrenchPage|ES:SpanishPage
- * 									         		       For other external page: http://server/url
+ * 									         	For other external page: http://server/url
  *  @param  string	$notused             		Deprecated. Used in past to add content into left menu. Hooks can be used now.
  *  @param  array	$menu_array_after           Table of menu entries to show after entries of menu handler
  *  @param  int		$leftmenuwithoutmainarea    Must be set to 1. 0 by default for backward compatibility with old modules.

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -777,8 +777,8 @@ class MouvementStock extends CommonObject
 	 * Create or update batch record (update table llx_product_batch). No check is done here, done by parent.
 	 *
 	 * @param	array|int	$dluo	      Could be either
-	 *                                     - int if row id of product_batch table
-	 *                                     - or complete array('fk_product_stock'=>, 'batchnumber'=>)
+	 *                                    - int if row id of product_batch table
+	 *                                    - or complete array('fk_product_stock'=>, 'batchnumber'=>)
 	 * @param	int			$qty	      Quantity of product with batch number. May be a negative amount.
 	 * @return 	int   				      <0 if KO, else return productbatch id
 	 */
@@ -1059,7 +1059,7 @@ class MouvementStock extends CommonObject
 	public function generateDocument($modele, $outputlangs='',$hidedetails=0,$hidedesc=0,$hideref=0)
 	{
 		global $conf,$user,$langs;
-	
+
 		$langs->load("stocks");
 
 		if (! dol_strlen($modele)) {

--- a/htdocs/product/stock/replenishorders.php
+++ b/htdocs/product/stock/replenishorders.php
@@ -199,72 +199,72 @@ if ($resql)
          '</td>'.
          '<td class="liste_titre" align="right">';
          $searchpicto=$form->showFilterAndCheckAddButtons(0);
-         print $searchpicto;
-         '</td>'.
-         '</tr>';
+    print $searchpicto;
+    print '</td>';
+    print '</tr>';
 
-         print '<tr class="liste_titre">';
-         print_liste_field_titre(
-             'Ref',
-             $_SERVER['PHP_SELF'],
-             'cf.ref',
-             '',
-             $param,
-             '',
-             $sortfield,
-             $sortorder
-             );
-         print_liste_field_titre(
-             'Company',
-             $_SERVER['PHP_SELF'],
-             's.nom',
-             '',
-             $param,
-             '',
-             $sortfield,
-             $sortorder
-             );
-         print_liste_field_titre(
-             'Author',
-             $_SERVER['PHP_SELF'],
-             'u.login',
-             '',
-             '',
-             '',
-             $sortfield,
-             $sortorder
-             );
-         print_liste_field_titre(
-             'AmountTTC',
-             $_SERVER['PHP_SELF'],
-             'cf.total_ttc',
-             '',
-             $param,
-             '',
-             $sortfield,
-             $sortorder
-             );
-         print_liste_field_titre(
-             'OrderCreation',
-             $_SERVER['PHP_SELF'],
-             'cf.date_creation',
-             '',
-             $param,
-             '',
-             $sortfield,
-             $sortorder
-             );
-         print_liste_field_titre(
-             'Status',
-             $_SERVER['PHP_SELF'],
-             'cf.fk_statut',
-             '',
-             $param,
-             'align="right"',
-             $sortfield,
-             $sortorder
-             );
-         print '</tr>';
+    print '<tr class="liste_titre">';
+    print_liste_field_titre(
+        'Ref',
+        $_SERVER['PHP_SELF'],
+        'cf.ref',
+        '',
+        $param,
+        '',
+        $sortfield,
+        $sortorder
+    );
+    print_liste_field_titre(
+        'Company',
+        $_SERVER['PHP_SELF'],
+        's.nom',
+        '',
+        $param,
+        '',
+        $sortfield,
+        $sortorder
+    );
+    print_liste_field_titre(
+        'Author',
+        $_SERVER['PHP_SELF'],
+        'u.login',
+        '',
+        '',
+        '',
+        $sortfield,
+        $sortorder
+    );
+    print_liste_field_titre(
+        'AmountTTC',
+        $_SERVER['PHP_SELF'],
+        'cf.total_ttc',
+        '',
+        $param,
+        '',
+        $sortfield,
+        $sortorder
+    );
+    print_liste_field_titre(
+        'OrderCreation',
+        $_SERVER['PHP_SELF'],
+        'cf.date_creation',
+        '',
+        $param,
+        '',
+        $sortfield,
+        $sortorder
+    );
+    print_liste_field_titre(
+        'Status',
+        $_SERVER['PHP_SELF'],
+        'cf.fk_statut',
+        '',
+        $param,
+        'align="right"',
+        $sortfield,
+        $sortorder
+    );
+    print '</tr>';
 
     $userstatic = new User($db);
 
@@ -324,8 +324,8 @@ if ($resql)
         }
         $i++;
     }
-    print '</table>'.
-         '</form>';
+    print '</table>';
+    print '</form>';
 
     $db->free($resql);
 
@@ -337,5 +337,4 @@ else
 }
 
 llxFooter();
-
 $db->close();

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -555,7 +555,7 @@ class Ticket extends CommonObject
      * @param  int    $offset    Offset for query
      * @param  int    $arch      archive or not (not used)
      * @param  array  $filter    Filter for query
-     *            output
+     *                           output
      * @return int <0 if KO, >0 if OK
      */
     public function fetchAll($user, $sortorder = 'ASC', $sortfield = 't.datec', $limit = '', $offset = 0, $arch = '', $filter = '')
@@ -1614,11 +1614,11 @@ class Ticket extends CommonObject
                 }
                 include_once DOL_DOCUMENT_ROOT . '/core/class/CMailFile.class.php';
                 $mailfile = new CMailFile($subject, $info_sendto['email'], $from, $message, $filepath, $mimetype, $filename, $sendtocc, '', $deliveryreceipt, 0);
-                if ($mailfile->error || $mailfile->errors) 
+                if ($mailfile->error || $mailfile->errors)
                 {
                     setEventMessages($mailfile->error, $mailfile->errors, 'errors');
-                } 
-                else 
+                }
+                else
                 {
                     $result = $mailfile->sendfile();
                     if ($result > 0) {

--- a/htdocs/webservices/server_category.php
+++ b/htdocs/webservices/server_category.php
@@ -92,7 +92,7 @@ $server->wsdl->addComplexType(
 /*
  * Les catégories filles, sous tableau dez la catégorie
  */
- $server->wsdl->addComplexType(
+$server->wsdl->addComplexType(
     'FillesArray',
     'complexType',
     'array',
@@ -108,38 +108,38 @@ $server->wsdl->addComplexType(
  /*
   * Image of product
  */
- $server->wsdl->addComplexType(
- 		'PhotosArray',
- 		'complexType',
- 		'array',
- 		'sequence',
- 		'',
- 		array(
- 				'image' => array(
- 						'name' => 'image',
- 						'type' => 'tns:image',
- 						'minOccurs' => '0',
- 						'maxOccurs' => 'unbounded'
- 				)
- 		)
- );
+$server->wsdl->addComplexType(
+		'PhotosArray',
+		'complexType',
+		'array',
+		'sequence',
+		'',
+		array(
+				'image' => array(
+						'name' => 'image',
+						'type' => 'tns:image',
+						'minOccurs' => '0',
+						'maxOccurs' => 'unbounded'
+				)
+		)
+);
 
  /*
   * An image
  */
- $server->wsdl->addComplexType(
- 		'image',
- 		'complexType',
- 		'struct',
- 		'all',
- 		'',
- 		array(
- 				'photo' => array('name'=>'photo','type'=>'xsd:string'),
- 				'photo_vignette' => array('name'=>'photo_vignette','type'=>'xsd:string'),
- 				'imgWidth' => array('name'=>'imgWidth','type'=>'xsd:string'),
- 				'imgHeight' => array('name'=>'imgHeight','type'=>'xsd:string')
- 		)
- );
+$server->wsdl->addComplexType(
+		'image',
+		'complexType',
+		'struct',
+		'all',
+		'',
+		array(
+				'photo' => array('name'=>'photo','type'=>'xsd:string'),
+				'photo_vignette' => array('name'=>'photo_vignette','type'=>'xsd:string'),
+				'imgWidth' => array('name'=>'imgWidth','type'=>'xsd:string'),
+				'imgHeight' => array('name'=>'imgHeight','type'=>'xsd:string')
+		)
+);
 
 /*
  * Retour


### PR DESCRIPTION
with v3 we can use comment in code like:

     *  @return int          			    <0 if KO, >0 if OK
     */
    // phpcs:ignore PEAR.NamingConventions.ValidFunctionName.NotCamelCaps -- place for comment
    function fetch_all($sortorder='DESC', $sortfield='t.rowid', $limit=0, $offset=0, $status=1, $filter='', $processing=-1)
    {

just to ignore specific rule for one line

https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file