### PR TITLE
NEW #9236 Allow to import expedtion lines via API

### DIFF
--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -192,13 +192,13 @@ class Shipments extends DolibarrApi
         foreach($request_data as $field => $value) {
             $this->shipment->$field = $value;
         }
-        /*if (isset($request_data["lines"])) {
+        if (isset($request_data["lines"])) {
           $lines = array();
           foreach ($request_data["lines"] as $line) {
             array_push($lines, (object) $line);
           }
           $this->shipment->lines = $lines;
-        }*/
+        }
 
         if ($this->shipment->create(DolibarrApiAccess::$user) < 0) {
             throw new RestException(500, "Error creating shipment", array_merge(array($this->shipment->error), $this->shipment->errors));


### PR DESCRIPTION
# Fix #9236 
Allow to import expedition lines via API to attach expedition to his order.
Code was existing but commented, so i removed the comments, tested it and it works :)