### PR TITLE
Revert "FIX missing drop old postgresql unique key"

### DIFF
--- a/htdocs/install/mysql/migration/7.0.0-8.0.0.sql
+++ b/htdocs/install/mysql/migration/7.0.0-8.0.0.sql
@@ -60,7 +60,7 @@ DROP TABLE llx_c_accountancy_category;
 DROP TABLE llx_c_accountingaccount;
 
 -- drop old postgresql unique key
--- VPGSQL8.2 DROP INDEX llx_usergroup_rights_fk_usergroup_fk_id_key;
+-- VPGSQL8.2 ALTER TABLE llx_usergroup_rights DROP CONSTRAINT llx_usergroup_rights_fk_usergroup_fk_id_key;
 
 update llx_propal set fk_statut = 1 where fk_statut = -1;
 


### PR DESCRIPTION
This reverts commit 25c93de80149135fe995c59b02f283c9cfde2e93.

I have trouble upgrading a PostgreSQL instance from 7.0.2 to 8.0.0. I don't get why this index was trying to be deleted since it is still used by table `llx_usergroup_rights` : 
```
dolibarr=> \d llx_usergroup_rights
                               Table « public.llx_usergroup_rights »
   Colonne    |  Type   |                              Modificateurs                               
--------------+---------+--------------------------------------------------------------------------
 rowid        | integer | non NULL Par défaut, nextval('llx_usergroup_rights_rowid_seq'::regclass)
 fk_usergroup | integer | non NULL
 fk_id        | integer | non NULL
 entity       | integer | non NULL Par défaut, 1
Index :
    "llx_usergroup_rights_pkey" PRIMARY KEY, btree (rowid)
    "llx_usergroup_rights_fk_usergroup_fk_id_key" UNIQUE CONSTRAINT, btree (fk_usergroup, fk_id)
    "uk_usergroup_rights" UNIQUE, btree (entity, fk_usergroup, fk_id)
Contraintes de clés étrangères :
    "fk_usergroup_rights_fk_usergroup" FOREIGN KEY (fk_usergroup) REFERENCES llx_usergroup(rowid) DEFERRABLE
```
(no difference spotted in this `\d` between 7.0 and 8.0)

I will try with MySQL soon to see if there are differences, thus the WIP flag.