### PR TITLE
Fix migration with pgsql do not work correctly

### DIFF
--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -252,7 +252,7 @@ class DoliDBPgsql extends DoliDB
                     $line.= "ALTER TABLE ".$reg[1]." RENAME COLUMN ".$reg[2]." TO ".$reg[3];
                 }
 
-				if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+ADD COLUMN ([a-z0-9_]+)\s+([a-z0-9\(\)]+)\s*(NULL|NOT NULL)?\s*(DEFAULT [a-z0-9\(\)]+)?\s*;$/i',$line,$reg))
+				if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+ADD COLUMN ([a-z0-9_]+)\s+([a-z0-9\(\),]+)\s*(NULL|NOT NULL)?\s*(DEFAULT [a-z0-9\(\)]+)?\s*;$/i',$line,$reg))
 				{
 					$tablename = $reg[1];
 					$column = $reg[2];

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -282,7 +282,7 @@ class DoliDBPgsql extends DoliDB
 				}
 				
 				
-                if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+MODIFY(?: COLUMN)? ([a-z0-9_]+) ([a-zA-Z0-9\(\)]+)\s*(.*)?$/i',$line,$reg))
+                if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+MODIFY(?: COLUMN)? ([a-z0-9_]+) ([a-zA-Z0-9\(\),]+)\s*(.*)?$/i',$line,$reg))
                 {
                     $line = "-- ".$line." replaced by --\n";
 					

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -252,7 +252,7 @@ class DoliDBPgsql extends DoliDB
                     $line.= "ALTER TABLE ".$reg[1]." RENAME COLUMN ".$reg[2]." TO ".$reg[3];
                 }
 
-                if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+MODIFY(?: COLUMN)? ([a-z0-9_]+) ([a-zA-Z0-9\(\)]+) (.*)$/i',$line,$reg))
+                if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+MODIFY(?: COLUMN)? ([a-z0-9_]+) ([a-zA-Z0-9\(\)]+)\s*(.*)?$/i',$line,$reg))
                 {
                     $line = "-- ".$line." replaced by --\n";
 					

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -252,7 +252,10 @@ class DoliDBPgsql extends DoliDB
                     $line.= "ALTER TABLE ".$reg[1]." RENAME COLUMN ".$reg[2]." TO ".$reg[3];
                 }
 
-				if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+ADD COLUMN ([a-z0-9_]+)\s+([a-z0-9\(\),]+)\s*(NULL|NOT NULL)?\s*(DEFAULT [a-z0-9\(\)]+)?\s*;$/i',$line,$reg))
+				if (
+					preg_match('/ALTER TABLE ([a-z0-9_]+)\s+ADD COLUMN ([a-z0-9_]+)\s+([a-z0-9\(\),]+)\s*(NULL|NOT NULL)?\s*(DEFAULT [a-z0-9\(\)\']+)?\s*;$/i',$line,$reg)
+					|| preg_match('/ALTER TABLE ([a-z0-9_]+)\s+ADD COLUMN ([a-z0-9_]+)\s+([a-z0-9\(\),]+)\s*(DEFAULT [a-z0-9\(\)\'\']+)?\s*(NULL|NOT NULL)?\s*;$/i',$line,$reg)
+				)
 				{
 					$tablename = $reg[1];
 					$column = $reg[2];

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -252,7 +252,7 @@ class DoliDBPgsql extends DoliDB
                     $line.= "ALTER TABLE ".$reg[1]." RENAME COLUMN ".$reg[2]." TO ".$reg[3];
                 }
 
-				if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+ADD COLUMN ([a-z0-9_]+) ([a-z0-9\(\)]+)\s*(NULL|NOT NULL)?\s*(DEFAULT [a-z0-9\(\)]+)?\s*;$/i',$line,$reg))
+				if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+ADD COLUMN ([a-z0-9_]+)\s+([a-z0-9\(\)]+)\s*(NULL|NOT NULL)?\s*(DEFAULT [a-z0-9\(\)]+)?\s*;$/i',$line,$reg))
 				{
 					$tablename = $reg[1];
 					$column = $reg[2];

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -252,6 +252,33 @@ class DoliDBPgsql extends DoliDB
                     $line.= "ALTER TABLE ".$reg[1]." RENAME COLUMN ".$reg[2]." TO ".$reg[3];
                 }
 
+				if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+ADD COLUMN ([a-z0-9_]+) ([a-z0-9\(\)]+)\s*(NULL|NOT NULL)?\s*(DEFAULT [a-z0-9\(\)]+)?\s*;$/i',$line,$reg))
+				{
+					$tablename = $reg[1];
+					$column = $reg[2];
+					$column_type = $reg[3];
+					$constraint = $reg[4];
+					$default_value = $reg[5];
+					
+					if (empty($default_value) && preg_match('/DEFAULT [a-z0-9\(\)]+/i', $constraint))
+					{
+						$default_value = $constraint;
+						$constraint = null;
+					}
+					
+					$line = "-- ".$line." replaced by --\n";
+					$line.= "ALTER TABLE ".$tablename." ADD COLUMN ".$column." ".$column_type;
+					if (!empty($constraint)) $line.= " ".$constraint;
+					$line.= ";";
+					
+					if (!empty($default_value))
+					{
+						$line.= "\n";
+						$line.= "ALTER TABLE ".$tablename." ALTER COLUMN ".$column." SET ".$default_value.";";
+					}
+				}
+				
+				
                 if (preg_match('/ALTER TABLE ([a-z0-9_]+)\s+MODIFY(?: COLUMN)? ([a-z0-9_]+) ([a-zA-Z0-9\(\)]+)\s*(.*)?$/i',$line,$reg))
                 {
                     $line = "-- ".$line." replaced by --\n";


### PR DESCRIPTION
# Fix
Meet probleme with `llx_cronjob` and the column `params`
In Dolibarr 3.7 the structure was declare as : https://github.com/Dolibarr/dolibarr/blob/e61bcd03ed86879044e4631e15242602d7501128/htdocs/install/mysql/tables/llx_cronjob.sql#L32
In the next version (3.8) we had this : https://github.com/Dolibarr/dolibarr/blob/71818da6a5b076e4f7c6d71acf0793ecdbf0e05c/htdocs/install/mysql/migration/3.7.0-3.8.0.sql#L37

But the conversion give us a bad request : `ALTER TABLE llx_cronjob ALTER COLUMN params TYPE text DROP NOT NULL;`

Here examples of conversion : 

> -- ALTER TABLE llx_cronjob MODIFY COLUMN params text NULL; replaced by --
> ALTER TABLE llx_cronjob ALTER COLUMN params TYPE text;
> ALTER TABLE llx_cronjob ALTER COLUMN params DROP NOT NULL;

> -- ALTER TABLE llx_cronjob MODIFY COLUMN params VARCHAR(200) DEFAULT NULL; replaced by --
> ALTER TABLE llx_cronjob ALTER COLUMN params TYPE VARCHAR(200);
> ALTER TABLE llx_cronjob ALTER COLUMN params SET DEFAULT NULL;

> -- ALTER TABLE llx_cronjob MODIFY COLUMN params VARCHAR(200) DEFAULT 'test'; replaced by --
> ALTER TABLE llx_cronjob ALTER COLUMN params TYPE VARCHAR(200);
> ALTER TABLE llx_cronjob ALTER COLUMN params SET DEFAULT 'test';
