### PR TITLE
Update Stripe API version

### DIFF
--- a/htdocs/stripe/config.php
+++ b/htdocs/stripe/config.php
@@ -55,4 +55,4 @@ else
 
 \Stripe\Stripe::setApiKey($stripearrayofkeys['secret_key']);
 \Stripe\Stripe::setAppInfo("Dolibarr Stripe", DOL_VERSION, "https://www.dolibarr.org"); // add dolibarr version
-\Stripe\Stripe::setApiVersion("2018-07-27"); // force version API
+\Stripe\Stripe::setApiVersion("2018-08-23"); // force version API

--- a/htdocs/stripe/config.php
+++ b/htdocs/stripe/config.php
@@ -55,4 +55,4 @@ else
 
 \Stripe\Stripe::setApiKey($stripearrayofkeys['secret_key']);
 \Stripe\Stripe::setAppInfo("Dolibarr Stripe", DOL_VERSION, "https://www.dolibarr.org"); // add dolibarr version
-\Stripe\Stripe::setApiVersion("2018-09-06"); // force version API
+\Stripe\Stripe::setApiVersion("2018-09-24"); // force version API

--- a/htdocs/stripe/config.php
+++ b/htdocs/stripe/config.php
@@ -55,4 +55,4 @@ else
 
 \Stripe\Stripe::setApiKey($stripearrayofkeys['secret_key']);
 \Stripe\Stripe::setAppInfo("Dolibarr Stripe", DOL_VERSION, "https://www.dolibarr.org"); // add dolibarr version
-\Stripe\Stripe::setApiVersion("2018-08-23"); // force version API
+\Stripe\Stripe::setApiVersion("2018-09-06"); // force version API


### PR DESCRIPTION
We need to downgrade this change to V8 because some breaks occur if Stripe API is updated in dashboard to 2018-08-23

> 2018-08-23
> The business_vat_id field was changed from String to Hash called tax_info, consisting of tax_id and type, in both requests and responses.