### PR TITLE
remove useless db begin

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4456,8 +4456,6 @@ class Product extends CommonObject
 
 		$langs->load('products');
 
-		$this->db->begin();
-
 		$label_type = 'label';
 
 		if ($type == 'short')


### PR DESCRIPTION
# Fix db transaction
the method starts a dbg transaction but never close it.
The $db->begin() is useless because there's no modification of the database to commit
