### PR TITLE
Fix #9464 issue: convert localized 'numeric' value to SQL value

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4851,6 +4851,9 @@ abstract class CommonObject
 			   		}
 			   	}
 
+				dol_syslog("attributeLabel=".$attributeLabel, LOG_DEBUG);
+				dol_syslog("attributeType=".$attributeType, LOG_DEBUG);
+
 			   	switch ($attributeType)
 			   	{
 			   		case 'int':
@@ -4864,6 +4867,21 @@ abstract class CommonObject
 			   				$new_array_options[$key] = null;
 			   			}
 			 			break;
+					case 'double':
+						$value = localeNumericStringToSqlNumericString($value);
+						if (!is_numeric($value) && $value!='')
+						{
+							dol_syslog($langs->trans("ExtraFieldHasWrongValue")." sur ".$attributeLabel."(".$value."is not '".$attributeType."')", LOG_DEBUG);
+							$this->errors[]=$langs->trans("ExtraFieldHasWrongValue", $attributeLabel);
+							return -1;
+						}
+						elseif ($value=='')
+						{
+							$new_array_options[$key] = null;
+						}
+						dol_syslog("double value"." sur ".$attributeLabel."(".$value." is '".$attributeType."')", LOG_DEBUG);
+						$new_array_options[$key] = $value;
+						break;
 			 		/*case 'select':	// Not required, we chosed value='0' for undefined values
              			if ($value=='-1')
              			{
@@ -5070,6 +5088,21 @@ abstract class CommonObject
 					{
 						$this->array_options["options_".$key] = null;
 					}
+					break;
+				case 'double':
+					$value = localeNumericStringToSqlNumericString($value);
+					if (!is_numeric($value) && $value!='')
+					{
+						dol_syslog($langs->trans("ExtraFieldHasWrongValue")." sur ".$attributeLabel."(".$value."is not '".$attributeType."')", LOG_DEBUG);
+						$this->errors[]=$langs->trans("ExtraFieldHasWrongValue", $attributeLabel);
+						return -1;
+					}
+					elseif ($value=='')
+					{
+						$new_array_options[$key] = null;
+					}
+					dol_syslog("double value"." sur ".$attributeLabel."(".$value." is '".$attributeType."')", LOG_DEBUG);
+					$this->array_options["options_".$key] = $value;
 					break;
 			 	/*case 'select':	// Not required, we chosed value='0' for undefined values
              		if ($value=='-1')

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -7651,3 +7651,33 @@ function roundUpToNextMultiple($n, $x=5)
 {
 	return (ceil($n)%$x === 0) ? ceil($n) : round(($n+$x/2)/$x)*$x;
 }
+
+/**
+ * Convert localized numeric string to sql numeric string.
+ *
+ * @param 	string	$value		Numeric string
+ * @return 	string				Sql numeric string.
+ */
+function localeNumericStringToSqlNumericString($value)
+{
+	global $langs,$conf;
+
+	// SQL does not allow number like '1,234.56' nor '1.234,56' nor '1 234,56'
+	// Numbers must be '1234.56'
+	// Decimal delimiter for PHP and database SQL requests must be '.'
+	$dec=','; $thousand=' ';
+	if ($langs->transnoentitiesnoconv("SeparatorDecimal") != "SeparatorDecimal")  $dec=$langs->transnoentitiesnoconv("SeparatorDecimal");
+	if ($langs->transnoentitiesnoconv("SeparatorThousand")!= "SeparatorThousand") $thousand=$langs->transnoentitiesnoconv("SeparatorThousand");
+	if ($thousand == 'None') $thousand='';
+	elseif ($thousand == 'Space') $thousand=' ';
+	//print "value=".$value." dec='".$dec."' thousand='".$thousand."'<br>";
+
+	//print 'PP'.$value.' - '.$dec.' - '.$thousand.'<br>';
+	// Make replace
+	if ($thousand != ',' && $thousand != '.') $value=str_replace(',','.',$value);	// To accept 2 notations for french users
+	$value=str_replace(' ','',$value);		// To avoid spaces
+	$value=str_replace($thousand,'',$value);	// Replace of thousand before replace of dec to avoid pb if thousand is .
+	$value=str_replace($dec,'.',$value);
+
+	return $value;
+}


### PR DESCRIPTION
# Fix *Issue 9464*
*Long description*
Process numeric extrafield value to convert it from localized value (fr) to SQL value :

- add function localeNumericStringToSqlNumericString($value) to convert value (functions.lib.php)
- add 'double' case in value processing for functions insertExtraFields and updatetExtraFields (commonobject.class.php)

1 234,45 => 1234.45
