### PR TITLE
FIX #9497

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4711,6 +4711,10 @@ class Form
 				$tmpthirdparty=new Societe($this->db);
 				$defaulttx=get_default_tva($societe_vendeuse, (is_object($societe_acheteuse)?$societe_acheteuse:$tmpthirdparty), $idprod);
 				$defaultnpr=get_default_npr($societe_vendeuse, (is_object($societe_acheteuse)?$societe_acheteuse:$tmpthirdparty), $idprod);
+		        if (preg_match('/\((.*)\)/', $defaulttx, $reg)) {
+			        $defaultcode=$reg[1];
+			        $defaulttx=preg_replace('/\s*\(.*\)/','',$defaulttx);
+		        }
 				if (empty($defaulttx)) $defaultnpr=0;
 			}
 


### PR DESCRIPTION
This PR extracts the `$defaultcode` and `$defaulttxt` from the value returned by
`get_default_tva` function.

It applies the same regex extraction from: https://github.com/Dolibarr/dolibarr/blob/8.0/htdocs/core/class/html.form.class.php#L4639

```
if (preg_match('/\((.*)\)/', $defaulttx, $reg)) {
  $defaultcode=$reg[1];
  $defaulttx=preg_replace('/\s*\(.*\)/','',$defaulttx);
}
``` 
