### PR TITLE
Search PDF document templates in all needed additional modules directories

### DIFF
--- a/htdocs/admin/agenda_other.php
+++ b/htdocs/admin/agenda_other.php
@@ -95,17 +95,26 @@ else if ($action == 'specimen')  // For orders
     $commande->thirdparty=$specimenthirdparty;
 
     // Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
     $file=''; $classname=''; $filefound=0;
     $dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
     foreach($dirmodels as $reldir)
     {
-    	$file=dol_buildpath($reldir."core/modules/action/doc/pdf_".$modele.".modules.php",0);
-    	if (file_exists($file))
-    	{
-    		$filefound=1;
-    		$classname = "pdf_".$modele;
-    		break;
-    	}
+		$files = array(dol_buildpath($reldir."core/modules/action/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/action/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
+		{
+			dol_syslog("admin/agenda_other.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
+		}
+		if ($filefound == 1) break;
     }
 
     if ($filefound)

--- a/htdocs/admin/agenda_reminder.php
+++ b/htdocs/admin/agenda_reminder.php
@@ -90,17 +90,26 @@ else if ($action == 'specimen')  // For orders
     $commande->thirdparty=$specimenthirdparty;
 
     // Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
     $file=''; $classname=''; $filefound=0;
     $dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
     foreach($dirmodels as $reldir)
     {
-    	$file=dol_buildpath($reldir."core/modules/action/doc/pdf_".$modele.".modules.php",0);
-    	if (file_exists($file))
-    	{
-    		$filefound=1;
-    		$classname = "pdf_".$modele;
-    		break;
-    	}
+		$files = array(dol_buildpath($reldir."core/modules/action/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/action/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
+		{
+			dol_syslog("admin/agenda_reminder.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
+		}
+		if ($filefound == 1) break;
     }
 
     if ($filefound)

--- a/htdocs/admin/bank.php
+++ b/htdocs/admin/bank.php
@@ -95,18 +95,27 @@ if ($action == 'specimen') {
     $object->initAsSpecimen();
 
     // Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
     $file = '';
     $classname = '';
     $filefound = 0;
     $dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
     foreach ($dirmodels as $reldir) {
-        $file = dol_buildpath($reldir . "core/modules/bank/doc/pdf_" . $modele . ".modules.php",
-                0);
-        if (file_exists($file)) {
-            $filefound = 1;
-            $classname = "pdf_" . $modele;
-            break;
-        }
+		$files = array(dol_buildpath($reldir."core/modules/bank/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/bank/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
+		{
+			dol_syslog("admin/bank.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
+		}
+		if ($filefound == 1) break;
     }
 
     if ($filefound) {

--- a/htdocs/admin/commande.php
+++ b/htdocs/admin/commande.php
@@ -81,17 +81,26 @@ else if ($action == 'specimen')
 	$commande->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/commande/doc/pdf_".$modele.".modules.php",0);
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/commande/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/commande/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/commande.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
 		}
+		if ($filefound == 1) break;
 	}
 
 	if ($filefound)

--- a/htdocs/admin/contract.php
+++ b/htdocs/admin/contract.php
@@ -77,17 +77,26 @@ else if ($action == 'specimen') // For contract
 	$contract->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/contract/doc/pdf_".$modele.".modules.php",0);
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/contract/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/contract/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/contract.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
 		}
+		if ($filefound == 1) break;
 	}
 
 	if ($filefound)

--- a/htdocs/admin/expedition.php
+++ b/htdocs/admin/expedition.php
@@ -126,7 +126,6 @@ else if ($action == 'specimen')
 			}
 		}
 		if ($filefound == 1) break;
-		}
 	}
 
 	if ($filefound)

--- a/htdocs/admin/expedition.php
+++ b/htdocs/admin/expedition.php
@@ -106,16 +106,26 @@ else if ($action == 'specimen')
 	$exp->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/expedition/doc/pdf_".$modele.".modules.php",0);
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/expedition/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/expedition/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/expedition.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
+		}
+		if ($filefound == 1) break;
 		}
 	}
 

--- a/htdocs/admin/expensereport.php
+++ b/htdocs/admin/expensereport.php
@@ -80,17 +80,26 @@ else if ($action == 'specimen') // For fiche inter
 	$inter->fk_statut = 0;     // Force statut draft to show watermark
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/expensereport/doc/pdf_".$modele.".modules.php",0);
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/expensereport/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/expensereport/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/expensereport.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
 		}
+		if ($filefound == 1) break;
 	}
 
 	if ($filefound)

--- a/htdocs/admin/facture.php
+++ b/htdocs/admin/facture.php
@@ -86,17 +86,26 @@ if ($action == 'specimen')
     $facture->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/facture/doc/pdf_".$modele.".modules.php",0);
-    	if (file_exists($file))
-    	{
-    		$filefound=1;
-    		$classname = "pdf_".$modele;
-    		break;
-    	}
+		$files = array(dol_buildpath($reldir."core/modules/facture/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/facture/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
+		{
+			dol_syslog("admin/facture.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
+		}
+		if ($filefound == 1) break;
     }
 
     if ($filefound)

--- a/htdocs/admin/fichinter.php
+++ b/htdocs/admin/fichinter.php
@@ -78,17 +78,26 @@ else if ($action == 'specimen') // For fiche inter
 	$inter->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/fichinter/doc/pdf_".$modele.".modules.php",0);
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/fichinter/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/fichinter/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/fichinter.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
 		}
+		if ($filefound == 1) break;
 	}
 
 	if ($filefound)

--- a/htdocs/admin/livraison.php
+++ b/htdocs/admin/livraison.php
@@ -95,17 +95,26 @@ if ($action == 'specimen')
     $sending->initAsSpecimen();
 
     // Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
     $file=''; $classname=''; $filefound=0;
     $dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
     foreach($dirmodels as $reldir)
     {
-        $file=dol_buildpath($reldir."core/modules/livraison/doc/pdf_".$modele.".modules.php",0);
-        if (file_exists($file))
-        {
-            $filefound=1;
-            $classname = "pdf_".$modele;
-            break;
-        }
+		$files = array(dol_buildpath($reldir."core/modules/livraison/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/livraison/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
+		{
+			dol_syslog("admin/livraison.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
+		}
+		if ($filefound == 1) break;
     }
 
     if ($filefound)

--- a/htdocs/admin/prelevement.php
+++ b/htdocs/admin/prelevement.php
@@ -120,17 +120,26 @@ if ($action == 'specimen')
     $commande->initAsSpecimen();
 
     // Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
     $file=''; $classname=''; $filefound=0;
     $dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
     foreach($dirmodels as $reldir)
     {
-        $file=dol_buildpath($reldir."core/modules/paymentorders/doc/pdf_".$modele.".modules.php",0);
-        if (file_exists($file))
-        {
-            $filefound=1;
-            $classname = "pdf_".$modele;
-            break;
-        }
+		$files = array(dol_buildpath($reldir."core/modules/paymentorders/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/paymentorders/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
+		{
+			dol_syslog("admin/prelevement.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
+		}
+		if ($filefound == 1) break;
     }
 
     if ($filefound)

--- a/htdocs/admin/propal.php
+++ b/htdocs/admin/propal.php
@@ -78,17 +78,26 @@ if ($action == 'specimen')
 	$propal->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/propale/doc/pdf_".$modele.".modules.php");
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/propal/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/propal/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/propal.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
 		}
+		if ($filefound == 1) break;
 	}
 
 	if ($filefound)

--- a/htdocs/admin/supplier_payment.php
+++ b/htdocs/admin/supplier_payment.php
@@ -107,17 +107,26 @@ else if ($action == 'specimen')
     $paiementFourn->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/supplier_payment/doc/pdf_".$modele.".modules.php",0);
-    	if (file_exists($file))
-    	{
-    		$filefound=1;
-    		$classname = "pdf_".$modele;
-    		break;
-    	}
+		$files = array(dol_buildpath($reldir."core/modules/supplier_payment/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/supplier_payment/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
+		{
+			dol_syslog("admin/supplier_payment.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
+		}
+		if ($filefound == 1) break;
     }
 
     if ($filefound)

--- a/htdocs/admin/supplier_proposal.php
+++ b/htdocs/admin/supplier_proposal.php
@@ -75,17 +75,26 @@ if ($action == 'specimen')
 	$supplier_proposal->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/supplier_proposal/doc/pdf_".$modele.".modules.php");
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/supplier_proposal/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/supplier_proposal/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/supplier_proposal.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
 		}
+		if ($filefound == 1) break;
 	}
 
 	if ($filefound)

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4344,14 +4344,21 @@ abstract class CommonObject
 				if (in_array(get_class($this), array('Adherent'))) $file = $prefix."_".$modele.".class.php";     // Member module use prefix_module.class.php
 				else $file = $prefix."_".$modele.".modules.php";
 
-				// On verifie l'emplacement du modele
-				$file=dol_buildpath($reldir.$modelspath.$file,0);
-				if (file_exists($file))
+				// NB an additional module (mymodule) may be located in :
+				// - dolibarr/htdocs/mymodule
+				// - dolibarr/htdocs/custom/mymodule
+				// so we must check the two locations
+				$files=array(dol_buildpath($reldir.$modelspath.$file,0),dol_buildpath('/custom'.$reldir.preg_replace('/doc/','',$modelspath).$file,0));
+				foreach($files as $file)
 				{
-					$filefound=1;
-					$classname=$prefix.'_'.$modele;
-					break;
+					if (file_exists($file))
+					{
+						$filefound=1;
+						$classname=$prefix.'_'.$modele;
+						break;
+					}
 				}
+				if ($filefound) break;
 			}
 			if ($filefound) break;
 		}

--- a/htdocs/product/admin/product.php
+++ b/htdocs/product/admin/product.php
@@ -154,17 +154,26 @@ if ($action == 'specimen') // For products
 	$product->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-	    $file=dol_buildpath($reldir."core/modules/product/doc/pdf_".$modele.".modules.php",0);
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/product/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/product/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/product.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
 		}
+		if ($filefound == 1) break;
 	}
 
 	if ($filefound)

--- a/htdocs/projet/admin/project.php
+++ b/htdocs/projet/admin/project.php
@@ -107,17 +107,26 @@ else if ($action == 'specimen')
 	$project->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-		$file=dol_buildpath($reldir."core/modules/project/doc/pdf_".$modele.".modules.php",0);
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/project/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/project/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/project.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
 		}
+		if ($filefound == 1) break;
 	}
 
 	if ($filefound)
@@ -152,17 +161,26 @@ else if ($action == 'specimentask')
 	$project->initAsSpecimen();
 
 	// Search template files
+	// NB an additional module (mymodule) may be located in :
+	// - dolibarr/htdocs/mymodule
+	// - dolibarr/htdocs/custom/mymodule
+	// so we must check the two locations
 	$file=''; $classname=''; $filefound=0;
 	$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
 	foreach($dirmodels as $reldir)
 	{
-		$file=dol_buildpath($reldir."core/modules/project/task/doc/pdf_".$modele.".modules.php",0);
-		if (file_exists($file))
+		$files = array(dol_buildpath($reldir."core/modules/task/doc/pdf_".$modele.".modules.php",0),dol_buildpath("/custom".$reldir."core/modules/task/pdf_".$modele.".modules.php",0));
+		foreach($files as $file)
 		{
-			$filefound=1;
-			$classname = "pdf_".$modele;
-			break;
+			dol_syslog("admin/project.php PDF model : ".$file, LOG_DEBUG);
+			if (file_exists($file))
+			{
+				$filefound=1;
+				$classname = "pdf_".$modele;
+				break;
+			}
 		}
+		if ($filefound == 1) break;
 	}
 
 	if ($filefound)


### PR DESCRIPTION
# Instructions
# New 
[*correct "PDF document template not found" error*]
Since additional modules (eg. mymodule) may be located in dolibarr root directory (dolibarr/htdocs/mymodule) or in custom directory (dolibarr/htdocs/custom/mymodule) we have to search document templates (pdf_xxxx.modules.php) in directories
- dolibarr/htdocs/mymodule/core/modules/<doctype>
- dolibarr/htdocs/custom/mymodule/core/modules/<doctype>
Files "admin/xxx.php" changes are about PDF specimen generation
File "core/class/commonobject.class.php" changes are about "normal" PDF document generation
