### PR TITLE
Fix $heightforframes value to fit menu height on dolibarr 8

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -937,7 +937,7 @@ else
 	define('ROWS_9',8);
 }
 
-$heightforframes=48;
+$heightforframes=50;
 
 // Init menu manager
 if (! defined('NOREQUIREMENU'))


### PR DESCRIPTION
Fit $heightforframes value to menu height on dolibarr 8, to display frames properly.