### PR TITLE
FIX Can't create shipping if have shipping line's extrafields

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1576,7 +1576,7 @@ if ($action == 'create')
 					$srcLine = new OrderLine($db);
 					$srcLine->fetch_optionals($line->id); // fetch extrafields also available in orderline
 					$line = new ExpeditionLigne($db);
-					$line->fetch_optionals($line->id);
+					//$line->fetch_optionals($line->id);
 					$line->array_options = array_merge($line->array_options, $srcLine->array_options);
 					print '<tr class="oddeven">';
 					print $line->showOptionals($extrafieldsline, 'edit', array('style'=>$bc[$var], 'colspan'=>$colspan),$indiceAsked);


### PR DESCRIPTION
If you have shpping line's extrafields, can't create shippings. You can't fetch an object that hasn't yet been created.
