### PR TITLE
remove useless param

### DIFF
--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -1128,7 +1128,7 @@ if ($resql)
 		// Status
 		if (! empty($arrayfields['cf.fk_statut']['checked']))
 		{
-			print '<td align="right" class="nowrap">'.$objectstatic->LibStatut($obj->fk_statut, 5, $obj->billed, 1).'</td>';
+			print '<td align="right" class="nowrap">'.$objectstatic->LibStatut($obj->fk_statut, 5, $obj->billed).'</td>';
 			if (! $i) $totalarray['nbfield']++;
 		}
 		// Billed


### PR DESCRIPTION
    /**
     *  Return label of a status
     *
     *  @param  int $statut		Id statut
     *  @param  int $mode       0=Long label, 1=Short label, 2=Picto + Short label, 3=Picto, 4=Picto + Long label, 5=Short label + Picto
     *  @param  int $billed     1=Billed
     *  @return string				Label of status
     */
    function LibStatut($statut,$mode=0,$billed=0)
    {

