### PR TITLE
fix error 500 on pdf_generation

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -438,7 +438,7 @@ function pdf_build_address($outputlangs,$sourcecompany,$targetcompany='',$target
 				// Contact on a thirdparty that is a different thirdparty than the thirdparty of object
     				if ($targetcontact->socid > 0 && $targetcontact->socid != $targetcompany->id)
 				{
-    					$targetcontact->fetch_thirparty();
+    					$targetcontact->fetch_thirdparty();
     					$companytouseforaddress = $targetcontact->thirdparty;
     				}
 


### PR DESCRIPTION
# Fix pdf generation blocked error 500
a "d" is missing in $targetcontact->fetch_thirdparty() so it causes an error