### PR TITLE
Fix issue #9434 : no array_options available when calling api on order line and invoice line

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1677,10 +1677,11 @@ class Commande extends CommonOrder
 
                 // Retrieve all extrafields for invoice
                 // fetch optionals attributes and labels
-                require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
-                $extrafields=new ExtraFields($this->db);
-                $extralabels=$extrafields->fetch_name_optionals_label($this->table_element,true);
-               	$this->fetch_optionals($this->id,$extralabels);
+//                require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+//                $extrafields=new ExtraFields($this->db);
+//                $extralabels=$extrafields->fetch_name_optionals_label($this->table_element,true);
+//               	$this->fetch_optionals($this->id,$extralabels);
+           	$this->fetch_optionals();
 
                 $this->db->free($result);
 
@@ -1881,6 +1882,9 @@ class Commande extends CommonOrder
 				$line->multicurrency_total_ht 	= $objp->multicurrency_total_ht;
 				$line->multicurrency_total_tva 	= $objp->multicurrency_total_tva;
 				$line->multicurrency_total_ttc 	= $objp->multicurrency_total_ttc;
+
+           	$line->fetch_optionals();
+
 
                 $this->lines[$i] = $line;
 

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1353,10 +1353,12 @@ class Facture extends CommonInvoice
 
 				// Retrieve all extrafield for invoice
 				// fetch optionals attributes and labels
-				require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
-				$extrafields=new ExtraFields($this->db);
-				$extralabels=$extrafields->fetch_name_optionals_label($this->table_element,true);
-				$this->fetch_optionals($this->id,$extralabels);
+//				require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+//				$extrafields=new ExtraFields($this->db);
+//				$extralabels=$extrafields->fetch_name_optionals_label($this->table_element,true);
+//				$this->fetch_optionals($this->id,$extralabels);
+				$this->fetch_optionals();
+                                
 
 				/*
 				 * Lines
@@ -1477,7 +1479,7 @@ class Facture extends CommonInvoice
 				$line->multicurrency_total_tva 	= $objp->multicurrency_total_tva;
 				$line->multicurrency_total_ttc 	= $objp->multicurrency_total_ttc;
 
-				// TODO Fetch optional like done in fetch line of facture_rec ?
+                                $line->fetch_optionals();
 
 				$this->lines[$i] = $line;
 


### PR DESCRIPTION

# Fix #9434 no array_options available when calling api on order line and invoice line
I replace the deprecated code by the fetch_optionnals() recommanded call.

