### PR TITLE
FIX wrong value for module part and return access denied

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -1611,7 +1611,7 @@ if ($id > 0)
 
             $var=true;
 
-            print $formfile->showdocuments('agenda',$object->id,$filedir,$urlsource,$genallowed,$delallowed,'',0,0,0,0,0,'','','',$object->default_lang);
+            print $formfile->showdocuments('actions',$object->id,$filedir,$urlsource,$genallowed,$delallowed,'',0,0,0,0,0,'','','',$object->default_lang);
 
 			print '</div><div class="fichehalfright"><div class="ficheaddleft">';
 


### PR DESCRIPTION
# Fix
Wrong value passed, the function `dol_check_secure_access_document` test with `actions` instead `agenda` value to check the agenda rights

From the card I got access denied : 
![image](https://user-images.githubusercontent.com/10596597/46483083-223be400-c7f7-11e8-98ca-299a171266b4.png)

But no error from linked files