### PR TITLE
FIX translatable field name in stock movement table

### DIFF
--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -45,6 +45,7 @@ MassStockTransferShort=Mass stock transfer
 StockMovement=Stock movement
 StockMovements=Stock movements
 LabelMovement=Movement label
+TypeMovement=Movement type
 NumberOfUnit=Number of units
 UnitPurchaseValue=Unit purchase price
 StockTooLow=Stock too low

--- a/htdocs/product/stock/mouvement.php
+++ b/htdocs/product/stock/mouvement.php
@@ -104,7 +104,7 @@ $arrayfields=array(
     'm.fk_user_author'=>array('label'=>$langs->trans("Author"), 'checked'=>0),
     'm.inventorycode'=>array('label'=>$langs->trans("InventoryCodeShort"), 'checked'=>1),
     'm.label'=>array('label'=>$langs->trans("LabelMovement"), 'checked'=>1),
-    'm.type_mouvement'=>array('label'=>$langs->trans("Type Mouvement"), 'checked'=>1),
+    'm.type_mouvement'=>array('label'=>$langs->trans("TypeMovement"), 'checked'=>1),
     'origin'=>array('label'=>$langs->trans("Origin"), 'checked'=>1),
 	'm.value'=>array('label'=>$langs->trans("Qty"), 'checked'=>1),
 	'm.price'=>array('label'=>$langs->trans("UnitPurchaseValue"), 'checked'=>0),


### PR DESCRIPTION
# Fix translatable field name in stock movement table
The table shows "Type mouvement" in one of its fields because the related code it's not using a translation key. This commit fixes this and adds a translation key to support the previous change.