### PR TITLE
Fix extrafield contact typed as date isn't show in the list from 'con…

### DIFF
--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -21,7 +21,7 @@ if (! empty($extrafieldsobjectkey))	// New method: $extrafieldsobject can be 'so
 				if ($align) print ' align="'.$align.'"';
 				print '>';
 				$tmpkey='options_'.$key;
-				if (in_array($extrafields->attributes[$extrafieldsobjectkey]['type'][$key], array('date', 'datetime', 'timestamp')))
+				if (in_array($extrafields->attributes[$extrafieldsobjectkey]['type'][$key], array('date', 'datetime', 'timestamp')) && !preg_match('/^[0-9]{10}$/', $obj->$tmpkey))
 				{
 					$value = $db->jdate($obj->$tmpkey);
 				}

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -21,7 +21,7 @@ if (! empty($extrafieldsobjectkey))	// New method: $extrafieldsobject can be 'so
 				if ($align) print ' align="'.$align.'"';
 				print '>';
 				$tmpkey='options_'.$key;
-				if (in_array($extrafields->attributes[$extrafieldsobjectkey]['type'][$key], array('date', 'datetime', 'timestamp')) && !preg_match('/^[0-9]{10}$/', $obj->$tmpkey))
+				if (in_array($extrafields->attributes[$extrafieldsobjectkey]['type'][$key], array('date', 'datetime', 'timestamp')) && !is_numeric($obj->$tmpkey))
 				{
 					$value = $db->jdate($obj->$tmpkey);
 				}


### PR DESCRIPTION
# Fix 
I have create a new extrafield on contact typed as date
After set value in this extrafield on a contact we can see it in the list of contact but from the tab ' contact/address' of company the date is empty

In this case we come from `show_contacts` method in `company.lib.php`  (https://github.com/Dolibarr/dolibarr/blob/b8eaeb7c6263d3fd5be5b51e6b2ddeb7cd6a8ed4/htdocs/core/lib/company.lib.php#L1074)
You can see from the link that the `fetch_optionals`method is call to init values and `jdate` is already apply

So, I add the `preg_match` to don't apply again a `jdate` on the value