### PR TITLE
FIX modify parenting before task deletion

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -598,6 +598,17 @@ if (! $error && $massaction == 'delete' && $permtodelete)
         $result=$objecttmp->fetch($toselectid);
         if ($result > 0)
         {
+            if ($objectclass == "Task" && $objecttmp->hasChildren() > 0) {
+                $sql = "UPDATE ".MAIN_DB_PREFIX."projet_task SET fk_task_parent = 0 WHERE fk_task_parent = ".$objecttmp->id;
+                $res = $db->query($sql);
+                
+                if (!$res)
+                {
+                    setEventMessage('ErrorRecordParentingNotModified', 'errors');
+                    $error++;
+                }
+            }
+            
             if (in_array($objecttmp->element, array('societe','member'))) $result = $objecttmp->delete($objecttmp->id, $user, 1);
             else $result = $objecttmp->delete($user);
             if ($result <= 0)


### PR DESCRIPTION
# Fix task delete on massaction
Allow to delete task with massaction.
If the task has children then delete the parenting before deleting the task.