### PR TITLE
Fix list from 'Contacts/Addresses' on company may show duplicate valu…

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4459,6 +4459,7 @@ abstract class CommonObject
 			$resql=$this->db->query($sql);
 			if ($resql)
 			{
+				$this->array_options = array();
 				$numrows=$this->db->num_rows($resql);
 				if ($numrows)
 				{


### PR DESCRIPTION
# Fix
For example : 
- I have a company with 2 contacts and the tab 'Contacts/Addresses' list my 2 contact : 'c1' and 'c2'
- I create my first extrafield for contact
- Update values on 'c1' and set value for my new extrafield
- Refresh tab 'Contacts/Addresses'
The list show 'c1' with the value and 'c2' have same value then I never updated him and contain nothing for this extrafield

I come from here
https://github.com/Dolibarr/dolibarr/blob/aedc6fadf4ab3288a50646d9c552f8c07686c91c/htdocs/core/lib/company.lib.php#L986
`fetch_optionals` is call twice in my case but the second time `$numrows=$this->db->num_rows($resql);` return 0
