### PR TITLE
Fix multicurrency $total_ht in pdf_muscadet

### DIFF
--- a/htdocs/core/modules/supplier_order/pdf/pdf_muscadet.modules.php
+++ b/htdocs/core/modules/supplier_order/pdf/pdf_muscadet.modules.php
@@ -822,7 +822,7 @@ class pdf_muscadet extends ModelePDFSuppliersOrders
 		$pdf->SetXY($col1x, $tab2_top + 0);
 		$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("TotalHT"), 0, 'L', 1);
 
-		$total_ht = (($conf->multicurrency->enabled && isset($object->multicurrency_tx) && $object->multicurrency_tx != 1) ? $object->multicurrency_total_ht : $object->total_ht);
+		$total_ht = ($conf->multicurrency->enabled && $object->multicurrency_tx != 1) ? $object->multicurrency_total_ht : $object->total_ht;
 		$pdf->SetXY($col2x, $tab2_top + 0);
 		$pdf->MultiCell($largcol2, $tab2_hl, price($total_ht + (! empty($object->remise)?$object->remise:0)), 0, 'R', 1);
 


### PR DESCRIPTION
The "Total HT" is displayed in local currency instead of the currency
displayed in the pdf.
Other total lines (tax and inc. taxes) are correctly displayed.

See: ![screenshot 2](https://user-images.githubusercontent.com/615816/47161096-972c1500-d2f1-11e8-80c8-6a28344eb5d4.png)

Switch to the same ternary used by $total_tcc.

This issue is mentioned in #7700.