### PR TITLE
Fixed all resources displaying on add in projects, events...

### DIFF
--- a/htdocs/core/tpl/resource_add.tpl.php
+++ b/htdocs/core/tpl/resource_add.tpl.php
@@ -28,7 +28,7 @@ $out .= '<input type="hidden" name="resource_type" value="'.(empty($resource_typ
 $out .= '<div class="tagtd">'.$langs->trans("SelectResource").'</div>';
 $out .= '<div class="tagtd">';
 $events=array();
-$out .= $formresources->select_resource_list('','fk_resource','',1,1,0,$events,'',2);
+$out .= $formresources->select_resource_list('','fk_resource','',1,1,0,$events,'',2,null);
 $out .= '</div>';
 
 $out .= '<div class="tagtd"><label>'.$langs->trans('Busy').'</label> '.$form->selectyesno('busy',(isset($_POST['busy'])?$_POST['busy']:1),1).'</div>';


### PR DESCRIPTION
# New Fixed all resources displaying in add dropdown
With the modification of select_resource_list inducing a default maximum of resources, the dropdown was displaying not the full list of resources. This small patch adds a null argument making all the resources displaying in the add resource dropdown.