### PR TITLE
Fix bank amount rounding

### DIFF
--- a/htdocs/compta/bank/list.php
+++ b/htdocs/compta/bank/list.php
@@ -551,7 +551,7 @@ foreach ($accounts as $key=>$type)
     if (! empty($arrayfields['balance']['checked']))
     {
 		print '<td align="right">';
-		print '<a href="'.DOL_URL_ROOT.'/compta/bank/bankentries_list.php?id='.$obj->id.'">'.price($solde, 0, $langs, 0, 0, -1, $obj->currency_code).'</a>';
+		print '<a href="'.DOL_URL_ROOT.'/compta/bank/bankentries_list.php?id='.$obj->id.'">'.price($solde, 0, $langs, 0, $conf->global->MAIN_MAX_DECIMALS_TOT, -1, $obj->currency_code).'</a>';
 		print '</td>';
 		if (! $i) $totalarray['nbfield']++;
 		if (! $i) $totalarray['totalbalancefield']=$totalarray['nbfield'];


### PR DESCRIPTION
# Fix 
![image](https://user-images.githubusercontent.com/10596597/47221548-f43ccf00-d3b4-11e8-912a-da2029b128bf.png)

https://github.com/Dolibarr/dolibarr/blob/57ad200ae50f28f95cf9e615543e6ada7e20c570/htdocs/compta/bank/list.php#L413
The method `solde()` return an SQL SUM and return 8 decimals but I haven't payment with more than 2 decimals