### PR TITLE
FIX the member e-mail on resign and validation.

### DIFF
--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -634,25 +634,27 @@ if (empty($reshook))
 					$msg     = $arraydefaultmessage->content;
 				}
 
-                if (empty($labeltouse)) {
+                if (empty($labeltouse) || (int)$labeltouse === -1) {
                     //fallback on the old configuration.
-                    $subject = $conf->global->ADHERENT_MAIL_VALID_SUBJECT;
-                    $msg = $conf->global->ADHERENT_MAIL_VALID;
+                    setEventMessages('WarningMandatorySetupNotComplete', [], 'errors');
+                    $error++;
+                }else{
+                    $substitutionarray=getCommonSubstitutionArray($outputlangs, 0, null, $object);
+                    complete_substitutions_array($substitutionarray, $outputlangs, $object);
+                    $subjecttosend = make_substitutions($subject, $substitutionarray, $outputlangs);
+                    $texttosend = make_substitutions(dol_concatdesc($msg, $adht->getMailOnValid()), $substitutionarray, $outputlangs);
+
+                    $moreinheader='X-Dolibarr-Info: send_an_email by adherents/card.php'."\r\n";
+
+                    $result=$object->send_an_email($texttosend, $subjecttosend, array(), array(), array(), "", "", 0, -1, '', $moreinheader);
+                    if ($result < 0)
+                    {
+                        $error++;
+                        setEventMessages($object->error, $object->errors, 'errors');
+                    }
                 }
 
-				$substitutionarray=getCommonSubstitutionArray($outputlangs, 0, null, $object);
-				complete_substitutions_array($substitutionarray, $outputlangs, $object);
-				$subjecttosend = make_substitutions($subject, $substitutionarray, $outputlangs);
-				$texttosend = make_substitutions(dol_concatdesc($msg, $adht->getMailOnValid()), $substitutionarray, $outputlangs);
 
-				$moreinheader='X-Dolibarr-Info: send_an_email by adherents/card.php'."\r\n";
-
-				$result=$object->send_an_email($texttosend, $subjecttosend, array(), array(), array(), "", "", 0, -1, '', $moreinheader);
-				if ($result < 0)
-				{
-					$error++;
-					setEventMessages($object->error, $object->errors, 'errors');
-				}
 			}
 		}
 		else
@@ -713,26 +715,28 @@ if (empty($reshook))
 						$msg     = $arraydefaultmessage->content;
 					}
 
-                    if (empty($labeltouse)) {
+                    if (empty($labeltouse) || (int)$labeltouse === -1) {
                         //fallback on the old configuration.
-                        $subject = $conf->global->ADHERENT_MAIL_RESIL_SUBJECT;
-                        $msg = $conf->global->ADHERENT_MAIL_RESIL;
+                        setEventMessages('WarningMandatorySetupNotComplete', [], 'errors');
+                        $error++;
+                    }else{
+                        $substitutionarray=getCommonSubstitutionArray($outputlangs, 0, null, $object);
+                        complete_substitutions_array($substitutionarray, $outputlangs, $object);
+                        $subjecttosend = make_substitutions($subject, $substitutionarray, $outputlangs);
+                        $texttosend = make_substitutions(dol_concatdesc($msg, $adht->getMailOnResiliate()), $substitutionarray, $outputlangs);
+
+                        $moreinheader='X-Dolibarr-Info: send_an_email by adherents/card.php'."\r\n";
+
+                        $result=$object->send_an_email($texttosend, $subjecttosend, array(), array(), array(), "", "", 0, -1, '', $moreinheader);
+                        if ($result < 0)
+                        {
+                            $error++;
+                            setEventMessages($object->error, $object->errors, 'errors');
+                        }
                     }
+                }
 
-					$substitutionarray=getCommonSubstitutionArray($outputlangs, 0, null, $object);
-					complete_substitutions_array($substitutionarray, $outputlangs, $object);
-					$subjecttosend = make_substitutions($subject, $substitutionarray, $outputlangs);
-					$texttosend = make_substitutions(dol_concatdesc($msg, $adht->getMailOnResiliate()), $substitutionarray, $outputlangs);
 
-					$moreinheader='X-Dolibarr-Info: send_an_email by adherents/card.php'."\r\n";
-
-					$result=$object->send_an_email($texttosend, $subjecttosend, array(), array(), array(), "", "", 0, -1, '', $moreinheader);
-				}
-				if ($result < 0)
-				{
-					$error++;
-					setEventMessages($object->error, $object->errors, 'errors');
-				}
 			}
 			else
 			{

--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -634,6 +634,12 @@ if (empty($reshook))
 					$msg     = $arraydefaultmessage->content;
 				}
 
+                if (empty($labeltouse)) {
+                    //fallback on the old configuration.
+                    $subject = $conf->global->ADHERENT_MAIL_VALID_SUBJECT;
+                    $msg = $conf->global->ADHERENT_MAIL_VALID;
+                }
+
 				$substitutionarray=getCommonSubstitutionArray($outputlangs, 0, null, $object);
 				complete_substitutions_array($substitutionarray, $outputlangs, $object);
 				$subjecttosend = make_substitutions($subject, $substitutionarray, $outputlangs);
@@ -706,6 +712,12 @@ if (empty($reshook))
 						$subject = $arraydefaultmessage->topic;
 						$msg     = $arraydefaultmessage->content;
 					}
+
+                    if (empty($labeltouse)) {
+                        //fallback on the old configuration.
+                        $subject = $conf->global->ADHERENT_MAIL_RESIL_SUBJECT;
+                        $msg = $conf->global->ADHERENT_MAIL_RESIL;
+                    }
 
 					$substitutionarray=getCommonSubstitutionArray($outputlangs, 0, null, $object);
 					complete_substitutions_array($substitutionarray, $outputlangs, $object);

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -6555,7 +6555,7 @@ function get_htmloutput_errors($mesgstring='', $mesgarray='', $keepembedded=0)
  *  @see    dol_htmloutput_errors
  *  @see    setEventMessages
  */
-function dol_htmloutput_mesg($mesgstring='',$mesgarray='', $style='ok', $keepembedded=0)
+function dol_htmloutput_mesg($mesgstring = '',$mesgarray = [], $style = 'ok', $keepembedded=0)
 {
 	if (empty($mesgstring) && (! is_array($mesgarray) || count($mesgarray) == 0)) return;
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -6529,7 +6529,7 @@ function get_htmloutput_mesg($mesgstring='',$mesgarray='', $style='ok', $keepemb
 /**
  *  Get formated error messages to output (Used to show messages on html output).
  *
- *  @param	string	$mesgstring         Error message
+ *  @param  string	$mesgstring         Error message
  *  @param  array	$mesgarray          Error messages array
  *  @param  int		$keepembedded       Set to 1 in error message must be kept embedded into its html place (this disable jnotify)
  *  @return string                		Return html output
@@ -6537,7 +6537,7 @@ function get_htmloutput_mesg($mesgstring='',$mesgarray='', $style='ok', $keepemb
  *  @see    dol_print_error
  *  @see    dol_htmloutput_mesg
  */
-function get_htmloutput_errors($mesgstring='', $mesgarray='', $keepembedded=0)
+function get_htmloutput_errors($mesgstring='', $mesgarray=array(), $keepembedded=0)
 {
 	return get_htmloutput_mesg($mesgstring, $mesgarray,'error',$keepembedded);
 }
@@ -6547,15 +6547,15 @@ function get_htmloutput_errors($mesgstring='', $mesgarray='', $keepembedded=0)
  *
  *	@param	string		$mesgstring		Message string or message key
  *	@param	string[]	$mesgarray      Array of message strings or message keys
- *  @param  string      $style          Which style to use ('ok', 'warning', 'error')
- *  @param  int         $keepembedded   Set to 1 if message must be kept embedded into its html place (this disable jnotify)
- *  @return	void
+ *	@param  string      $style          Which style to use ('ok', 'warning', 'error')
+ *	@param  int         $keepembedded   Set to 1 if message must be kept embedded into its html place (this disable jnotify)
+ *	@return	void
  *
- *  @see    dol_print_error
- *  @see    dol_htmloutput_errors
- *  @see    setEventMessages
+ *	@see    dol_print_error
+ *	@see    dol_htmloutput_errors
+ *	@see    setEventMessages
  */
-function dol_htmloutput_mesg($mesgstring = '',$mesgarray = [], $style = 'ok', $keepembedded=0)
+function dol_htmloutput_mesg($mesgstring = '',$mesgarray = array(), $style = 'ok', $keepembedded=0)
 {
 	if (empty($mesgstring) && (! is_array($mesgarray) || count($mesgarray) == 0)) return;
 
@@ -6609,7 +6609,7 @@ function dol_htmloutput_mesg($mesgstring = '',$mesgarray = [], $style = 'ok', $k
  *  @see    dol_print_error
  *  @see    dol_htmloutput_mesg
  */
-function dol_htmloutput_errors($mesgstring='', $mesgarray='', $keepembedded=0)
+function dol_htmloutput_errors($mesgstring='', $mesgarray=array(), $keepembedded=0)
 {
 	dol_htmloutput_mesg($mesgstring, $mesgarray, 'error', $keepembedded);
 }


### PR DESCRIPTION
# Fix #9640

The problem is due to the new configuration of the module members. Indeed in the previous version the subject and the content of the e-mail were directly written in the module itself and saved in global variables.

In the new version this configuration has been replaced by the usage of e-mail templates (it's a very great idea) but it introduces a  backward compatibility break. Because if you do not change your configuration, the module doesn't send e-mails anymore.

My fix introduces a fallback on the previous configuration.

Of course this fix needs to be removed in a future version, but I'm not yet sure of the best ay to do this, I propose to discuss about that in the ticket #9640.

