### PR TITLE
fix the export (in CSV) of the book accounting

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -991,7 +991,7 @@ class BookKeeping extends CommonObject
 			$num = $this->db->num_rows($resql);
 
 			$i = 0;
-			while (($obj = $this->db->fetch_object($resql)) && ($i < min($limit, $num)))
+			while (($obj = $this->db->fetch_object($resql)))
 			{
 				$line = new BookKeepingLine();
 


### PR DESCRIPTION
# Fix #9836 
Problem, on the export of the accounting, an empty CSV was generated.

Cause, this issue is due to a limit which shouldn't occur.

Solution, since the limit is already present in the SQL query, the application doesn't have to apply it once again => removed.