### PR TITLE
NEW Compatibility with new Paybox HMAC requirement

### DIFF
--- a/htdocs/paybox/admin/paybox.php
+++ b/htdocs/paybox/admin/paybox.php
@@ -71,6 +71,9 @@ if ($action == 'setvalue' && $user->admin)
 	if (! $result > 0) $error++;
 	$result=dolibarr_set_const($db, "PAYMENT_SECURITY_TOKEN_UNIQUE",GETPOST('PAYMENT_SECURITY_TOKEN_UNIQUE','alpha'),'chaine',0,'',$conf->entity);
 	if (! $result > 0) $error++;
+        $result=dolibarr_set_const($db, "PAYBOX_HMAC_KEY", dol_encode(GETPOST('PAYBOX_HMAC_KEY','alpha')),'chaine',0,'',$conf->entity);
+	if (! $result > 0) $error++;
+        
 
     if (! $error)
   	{
@@ -142,6 +145,12 @@ print '</td></tr>';
 print '<tr class="oddeven"><td>';
 print '<span class="fieldrequired">'.$langs->trans("PAYBOX_PBX_IDENTIFIANT").'</span></td><td>';
 print '<input size="32" type="text" name="PAYBOX_PBX_IDENTIFIANT" value="'.$conf->global->PAYBOX_PBX_IDENTIFIANT.'">';
+print '<br>'.$langs->trans("Example").': 2 ('.$langs->trans("Test").')';
+print '</td></tr>';
+
+print '<tr class="oddeven"><td>';
+print '<span class="fieldrequired">'.$langs->trans("PAYBOX_HMAC_KEY").'</span></td><td>';
+print '<input size="100" type="text" name="PAYBOX_HMAC_KEY" value="'.dol_decode($conf->global->PAYBOX_HMAC_KEY).'">';
 print '<br>'.$langs->trans("Example").': 2 ('.$langs->trans("Test").')';
 print '</td></tr>';
 

--- a/htdocs/paybox/lib/paybox.lib.php
+++ b/htdocs/paybox/lib/paybox.lib.php
@@ -92,16 +92,41 @@ function print_paybox_redirect($PRICE,$CURRENCY,$EMAIL,$urlok,$urlko,$TAG)
     $IBS_REFUSE=$urlko;
     $IBS_BKGD="#FFFFFF";
     $IBS_WAIT="2000";
-	$IBS_LANG="GBR"; 	// By default GBR=english (FRA, GBR, ESP, ITA et DEU...)
-	if (preg_match('/^FR/i',$langs->defaultlang)) $IBS_LANG="FRA";
-	if (preg_match('/^ES/i',$langs->defaultlang)) $IBS_LANG="ESP";
-	if (preg_match('/^IT/i',$langs->defaultlang)) $IBS_LANG="ITA";
-	if (preg_match('/^DE/i',$langs->defaultlang)) $IBS_LANG="DEU";
-	if (preg_match('/^NL/i',$langs->defaultlang)) $IBS_LANG="NLD";
-	if (preg_match('/^SE/i',$langs->defaultlang)) $IBS_LANG="SWE";
-	$IBS_OUTPUT='E';
-	$PBX_SOURCE='HTML';
-	$PBX_TYPEPAIEMENT='CARTE';
+    $IBS_LANG="GBR"; 	// By default GBR=english (FRA, GBR, ESP, ITA et DEU...)
+    if (preg_match('/^FR/i',$langs->defaultlang)) $IBS_LANG="FRA";
+    if (preg_match('/^ES/i',$langs->defaultlang)) $IBS_LANG="ESP";
+    if (preg_match('/^IT/i',$langs->defaultlang)) $IBS_LANG="ITA";
+    if (preg_match('/^DE/i',$langs->defaultlang)) $IBS_LANG="DEU";
+    if (preg_match('/^NL/i',$langs->defaultlang)) $IBS_LANG="NLD";
+    if (preg_match('/^SE/i',$langs->defaultlang)) $IBS_LANG="SWE";
+    $IBS_OUTPUT='E';
+    $PBX_SOURCE='HTML';
+    $PBX_TYPEPAIEMENT='CARTE';
+    
+    $msg = "PBX_IDENTIFIANT=".$PBX_IDENTIFIANT.
+           "&PBX_MODE=".$IBS_MODE.
+           "&PBX_SITE=".$IBS_SITE.
+           "&PBX_RANG=".$IBS_RANG.
+           "&PBX_TOTAL=".$IBS_TOTAL.
+           "&PBX_DEVISE=".$IBS_DEVISE.
+           "&PBX_CMD=".$IBS_CMD.
+           "&PBX_PORTEUR=".$IBS_PORTEUR.
+           "&PBX_RETOUR=".$IBS_RETOUR.
+           "&PBX_EFFECTUE=".$IBS_EFFECTUE.
+           "&PBX_ANNULE=".$IBS_ANNULE.
+           "&PBX_REFUSE=".$IBS_REFUSE.
+           "&PBX_TXT=".$IBS_TXT.
+           "&PBX_BKGD=".$IBS_BKGD.
+           "&PBX_WAIT=".$IBS_WAIT.
+           "&PBX_LANGUE=".$IBS_LANG.
+           "&PBX_OUTPUT=".$IBS_OUTPUT.
+           "&PBX_SOURCE=".$PBX_SOURCE.
+           "&PBX_TYPEPAIEMENT=".$PBX_TYPEPAIEMENT;
+    
+    $binKey = pack("H*", dol_decode($conf->global->PAYBOX_HMAC_KEY));
+            
+    $hmac = strtoupper(hash_hmac('sha512', $msg, $binKey));
+           
 
     dol_syslog("Soumission Paybox", LOG_DEBUG);
     dol_syslog("IBS_MODE: $IBS_MODE", LOG_DEBUG);
@@ -157,7 +182,7 @@ function print_paybox_redirect($PRICE,$CURRENCY,$EMAIL,$urlok,$urlko,$TAG)
     print '<input type="hidden" name="PBX_OUTPUT" value="'.$IBS_OUTPUT.'">'."\n";
     print '<input type="hidden" name="PBX_SOURCE" value="'.$PBX_SOURCE.'">'."\n";
     print '<input type="hidden" name="PBX_TYPEPAIEMENT" value="'.$PBX_TYPEPAIEMENT.'">'."\n";
-
+    print '<input type="hidden" name="PBX_HMAC" value="'.$hmac.'">'."\n";
     print '</form>'."\n";
 
 


### PR DESCRIPTION
# Fix #No issue Number : Paybox module fix
In order to work, the paybox module must use HMAC key wich is mandatory. Dolibarr paybox module miss this key. We add it in module config view and use it to encrypt message sent to paybox account such as E-Transaction (Credit Agricole). Only tested with CA.


