### PR TITLE
NEW packaging on fournprice (enabled with hidden option PRODUIT_FOURN_PACKAGING)

### DIFF
--- a/htdocs/core/modules/supplier_order/pdf/pdf_muscadet.modules.php
+++ b/htdocs/core/modules/supplier_order/pdf/pdf_muscadet.modules.php
@@ -525,6 +525,14 @@ class pdf_muscadet extends ModelePDFSuppliersOrders
 
 					// Quantity
 					$qty = pdf_getlineqty($object, $i, $outputlangs, $hidedetails);
+					if (!empty($conf->global->PRODUIT_FOURN_PACKAGING) && !empty($qty))
+					{
+					    if (!empty($object->lines[$i]->packaging))
+					    {
+					        $qty = intval($qty/$object->lines[$i]->packaging) . 'x'.intval($object->lines[$i]->packaging);
+					    }
+					}
+					
 					$pdf->SetXY($this->posxqty, $curY);
 					// Enough for 6 chars
 					if($conf->global->PRODUCT_USE_UNITS)

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -397,7 +397,7 @@ class CommandeFournisseur extends CommonOrder
     	$sql.= " l.date_start, l.date_end,";
     	$sql.= ' l.fk_multicurrency, l.multicurrency_code, l.multicurrency_subprice, l.multicurrency_total_ht, l.multicurrency_total_tva, l.multicurrency_total_ttc';
     	if (!empty($conf->global->PRODUIT_FOURN_PACKAGING))
-    	    $sql.= ", pfp.rowid as fk_pfp";
+    	    $sql.= ", pfp.rowid as fk_pfp, pfp.packaging";
     	$sql.= " FROM ".MAIN_DB_PREFIX."commande_fournisseurdet	as l";
     	$sql.= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON l.fk_product = p.rowid';
     	if (!empty($conf->global->PRODUIT_FOURN_PACKAGING))
@@ -452,7 +452,10 @@ class CommandeFournisseur extends CommonOrder
     			$line->ref_fourn           = $objp->ref_supplier;   // The supplier ref of price when product was added. May have change since
     			$line->ref_supplier        = $objp->ref_supplier;   // The supplier ref of price when product was added. May have change since
     			if (!empty($conf->global->PRODUIT_FOURN_PACKAGING))
+    			{
     			    $line->fk_fournprice = $objp->fk_pfp;
+    			    $line->packaging     = $objp->packaging;
+    			}
     			
     			$line->date_start          = $this->db->jdate($objp->date_start);
     			$line->date_end            = $this->db->jdate($objp->date_end);

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1622,6 +1622,7 @@ class CommandeFournisseur extends CommonOrder
                         {
                             $coeff = intval($qty/$prod->packaging) + 1;
                             $qty = $prod->packaging * $coeff;
+                            setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
                         }
                     }
                 }
@@ -2489,7 +2490,7 @@ class CommandeFournisseur extends CommonOrder
      */
     public function updateline($rowid, $desc, $pu, $qty, $remise_percent, $txtva, $txlocaltax1=0, $txlocaltax2=0, $price_base_type='HT', $info_bits=0, $type=0, $notrigger=0, $date_start='', $date_end='', $array_options=0, $fk_unit=null, $pu_ht_devise=0, $ref_supplier='')
     {
-    	global $mysoc, $conf;
+    	global $mysoc, $conf, $langs;
         dol_syslog(get_class($this)."::updateline $rowid, $desc, $pu, $qty, $remise_percent, $txtva, $price_base_type, $info_bits, $type, $fk_unit");
         include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
 
@@ -2556,6 +2557,7 @@ class CommandeFournisseur extends CommonOrder
                     {
                         $coeff = intval($qty/$prod->packaging) + 1;
                         $qty = $prod->packaging * $coeff;
+                        setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
                     }
                 }
             }

--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -321,6 +321,7 @@ class ProductFournisseur extends Product
 			$sql.= " charges = ".$charges.",";           // deprecated
 			$sql.= " delivery_time_days = ".($delivery_time_days != '' ? $delivery_time_days : 'null').",";
 			$sql.= " supplier_reputation = ".(empty($supplier_reputation) ? 'NULL' : "'".$this->db->escape($supplier_reputation)."'");
+			if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $sql.= ", packaging = ".(empty($this->packaging) ? 1 : $this->packaging);
 			$sql.= " WHERE rowid = ".$this->product_fourn_price_id;
 			// TODO Add price_base_type and price_ttc
 
@@ -364,8 +365,9 @@ class ProductFournisseur extends Product
                 // Add price for this quantity to supplier
                 $sql = "INSERT INTO " . MAIN_DB_PREFIX . "product_fournisseur_price(";
                 $sql.= " multicurrency_price, multicurrency_unitprice, multicurrency_tx, fk_multicurrency, multicurrency_code,";
-                $sql .= "datec, fk_product, fk_soc, ref_fourn, desc_fourn, fk_user, price, quantity, remise_percent, remise, unitprice, tva_tx, charges, fk_availability, default_vat_code, info_bits, entity, delivery_time_days, supplier_reputation)";
-                $sql .= " values(";
+                $sql.= "datec, fk_product, fk_soc, ref_fourn, desc_fourn, fk_user, price, quantity, remise_percent, remise, unitprice, tva_tx, charges, fk_availability, default_vat_code, info_bits, entity, delivery_time_days, supplier_reputation";
+                if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $sql.= ", packaging";
+                $sql .= ") values(";
                 $sql.= (isset($multicurrency_buyprice)?"'".$this->db->escape(price2num($multicurrency_buyprice))."'":'null').",";
                 $sql.= (isset($multicurrency_unitBuyPrice)?"'".$this->db->escape(price2num($multicurrency_unitBuyPrice))."'":'null').",";
                 $sql.= (isset($multicurrency_tx)?"'".$this->db->escape($multicurrency_tx)."'":'1').",";
@@ -390,6 +392,7 @@ class ProductFournisseur extends Product
                 $sql .= $conf->entity . ",";
                 $sql .= $delivery_time_days . ",";
                 $sql .= (empty($supplier_reputation) ? 'NULL' : "'" . $this->db->escape($supplier_reputation) . "'");
+                if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $sql.= ", ".(empty($this->packaging) ? 1 : $this->db->escape($this->packaging)) ;
                 $sql .= ")";
 
                 $idinserted = 0;
@@ -469,6 +472,7 @@ class ProductFournisseur extends Product
         $sql = "SELECT pfp.rowid, pfp.price, pfp.quantity, pfp.unitprice, pfp.remise_percent, pfp.remise, pfp.tva_tx, pfp.default_vat_code, pfp.info_bits as fourn_tva_npr, pfp.fk_availability,";
         $sql.= " pfp.fk_soc, pfp.ref_fourn, pfp.desc_fourn, pfp.fk_product, pfp.charges, pfp.fk_supplier_price_expression, pfp.delivery_time_days,";
         $sql.= " pfp.supplier_reputation";
+        if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $sql.= ", pfp.packaging";
         $sql.= " ,pfp.multicurrency_price, pfp.multicurrency_unitprice, pfp.multicurrency_tx, pfp.fk_multicurrency, pfp.multicurrency_code";
         $sql.= " FROM ".MAIN_DB_PREFIX."product_fournisseur_price as pfp";
         $sql.= " WHERE pfp.rowid = ".$rowid;
@@ -502,6 +506,7 @@ class ProductFournisseur extends Product
                 $this->fk_supplier_price_expression      = $obj->fk_supplier_price_expression;
                 $this->supplier_reputation      = $obj->supplier_reputation;
                 $this->default_vat_code         = $obj->default_vat_code;
+                if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $this->packaging                = $obj->packaging;
 
                 $this->fourn_multicurrency_price       = $obj->multicurrency_price;
                 $this->fourn_multicurrency_unitprice   = $obj->multicurrency_unitprice;
@@ -562,6 +567,7 @@ class ProductFournisseur extends Product
         $sql.= " pfp.rowid as product_fourn_pri_id, pfp.ref_fourn, pfp.desc_fourn, pfp.fk_product as product_fourn_id, pfp.fk_supplier_price_expression,";
         $sql.= " pfp.price, pfp.quantity, pfp.unitprice, pfp.remise_percent, pfp.remise, pfp.tva_tx, pfp.fk_availability, pfp.charges, pfp.info_bits, pfp.delivery_time_days, pfp.supplier_reputation";
         $sql.= " ,pfp.multicurrency_price, pfp.multicurrency_unitprice, pfp.multicurrency_tx, pfp.fk_multicurrency, pfp.multicurrency_code";
+        if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $sql.= ", pfp.packaging";
         $sql.= " FROM ".MAIN_DB_PREFIX."product_fournisseur_price as pfp";
         $sql.= ", ".MAIN_DB_PREFIX."societe as s";
         $sql.= " WHERE pfp.entity IN (".getEntity('productsupplierprice').")";
@@ -602,7 +608,9 @@ class ProductFournisseur extends Product
                 $prodfourn->id						= $prodid;
                 $prodfourn->fourn_tva_npr					= $record["info_bits"];
                 $prodfourn->fk_supplier_price_expression    = $record["fk_supplier_price_expression"];
-				$prodfourn->supplier_reputation    = $record["supplier_reputation"];
+				$prodfourn->supplier_reputation     = $record["supplier_reputation"];
+				if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) 
+				    $prodfourn->packaging               = $record["packaging"];
 
                 $prodfourn->fourn_multicurrency_price       = $record["multicurrency_price"];
                 $prodfourn->fourn_multicurrency_unitprice   = $record["multicurrency_unitprice"];

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -295,6 +295,9 @@ PossibleValues=Possible values
 GoOnMenuToCreateVairants=Go on menu %s - %s to prepare attribute variants (like colors, size, ...)
 UseProductFournDesc=Use supplier descriptions of products in supplier documents
 ProductSupplierDescription=Supplier description for the product
+UseProductFournPackaging=Use packaging on supplier prices (recalculate quantities according to packaging set on supplier price when adding/updating an order supplier line)
+PackagingForThisProduct=Packaging
+QtyRecalculatedWithPackaging=The quantity of the line were recalculated according to supplier packaging
 #Attributes
 VariantAttributes=Variant attributes
 ProductAttributes=Variant attributes for products

--- a/htdocs/product/admin/product.php
+++ b/htdocs/product/admin/product.php
@@ -156,6 +156,18 @@ if ($action == 'other')
 	        $resql_new = $db->query($sql_new);
 	    }
 	}
+	
+	$value = GETPOST('activate_useProdFournPackaging', 'alpha');
+	$res = dolibarr_set_const($db, "PRODUIT_FOURN_PACKAGING", $value,'chaine',0,'',$conf->entity);
+	if ($value) {
+	    $sql_test = "SELECT count(packaging) as cpt FROM ".MAIN_DB_PREFIX."product_fournisseur_price WHERE 1";
+	    $resql = $db->query($sql_test);
+	    if (!$resql && $db->lasterrno == 'DB_ERROR_NOSUCHFIELD') // if the field does not exist, we create it
+	    {
+	        $sql_new = "ALTER TABLE ".MAIN_DB_PREFIX."product_fournisseur_price ADD COLUMN pakaging double(24,8) DEFAULT 1";
+	        $resql_new = $db->query($sql_new);
+	    }
+	}
 }
 
 if ($action == 'specimen') // For products
@@ -672,6 +684,13 @@ if (! empty($conf->fournisseur->enabled))
     print '<td>'.$langs->trans("UseProductFournDesc").'</td>';
     print '<td width="60" align="right">';
     print $form->selectyesno("activate_useProdFournDesc", (! empty($conf->global->PRODUIT_FOURN_TEXTS)?$conf->global->PRODUIT_FOURN_TEXTS:0), 1);
+    print '</td>';
+    print '</tr>';
+    
+    print '<tr class="oddeven">';
+    print '<td>'.$langs->trans("UseProductFournPackaging").'</td>';
+    print '<td width="60" align="right">';
+    print $form->selectyesno("activate_useProdFournPackaging", (! empty($conf->global->PRODUIT_FOURN_PACKAGING)?$conf->global->PRODUIT_FOURN_PACKAGING:0), 1);
     print '</td>';
     print '</tr>';
 }

--- a/htdocs/product/admin/product.php
+++ b/htdocs/product/admin/product.php
@@ -164,7 +164,7 @@ if ($action == 'other')
 	    $resql = $db->query($sql_test);
 	    if (!$resql && $db->lasterrno == 'DB_ERROR_NOSUCHFIELD') // if the field does not exist, we create it
 	    {
-	        $sql_new = "ALTER TABLE ".MAIN_DB_PREFIX."product_fournisseur_price ADD COLUMN pakaging double(24,8) DEFAULT 1";
+	        $sql_new = "ALTER TABLE ".MAIN_DB_PREFIX."product_fournisseur_price ADD COLUMN packaging double(24,8) DEFAULT 1";
 	        $resql_new = $db->query($sql_new);
 	    }
 	}

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1564,6 +1564,7 @@ class Product extends CommonObject
 		$sql.= " pfp.fk_product, pfp.ref_fourn, pfp.desc_fourn, pfp.fk_soc, pfp.tva_tx, pfp.fk_supplier_price_expression";
 		$sql.= " ,pfp.default_vat_code";
         $sql.= " ,pfp.multicurrency_price, pfp.multicurrency_unitprice, pfp.multicurrency_tx, pfp.fk_multicurrency, pfp.multicurrency_code";
+        if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $sql.= ", pfp.packaging";
 		$sql.= " FROM ".MAIN_DB_PREFIX."product_fournisseur_price as pfp";
 		$sql.= " WHERE pfp.rowid = ".$prodfournprice;
 		if ($qty > 0) $sql.= " AND pfp.quantity <= ".$qty;
@@ -1602,6 +1603,7 @@ class Product extends CommonObject
 				$this->remise_percent = $obj->remise_percent;       // remise percent if present and not typed
 				$this->vatrate_supplier = $obj->tva_tx;             // Vat ref supplier
 				$this->default_vat_code = $obj->default_vat_code;   // Vat code supplier
+				if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $this->packaging = $obj->packaging;
                 $this->fourn_multicurrency_price       = $obj->multicurrency_price;
                 $this->fourn_multicurrency_unitprice   = $obj->multicurrency_unitprice;
                 $this->fourn_multicurrency_tx          = $obj->multicurrency_tx;
@@ -1617,6 +1619,7 @@ class Product extends CommonObject
 				$sql.= " pfp.fk_product, pfp.ref_fourn as ref_supplier, pfp.desc_fourn as desc_supplier, pfp.tva_tx, pfp.fk_supplier_price_expression";
 				$sql.= " ,pfp.default_vat_code";
                 $sql.= " ,pfp.multicurrency_price, pfp.multicurrency_unitprice, pfp.multicurrency_tx, pfp.fk_multicurrency, pfp.multicurrency_code";
+                if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $sql.= ", pfp.packaging";
 				$sql.= " FROM ".MAIN_DB_PREFIX."product_fournisseur_price as pfp";
 				$sql.= " WHERE pfp.fk_product = ".$product_id;
 				if ($fourn_ref != 'none') $sql.= " AND pfp.ref_fourn = '".$fourn_ref."'";
@@ -1659,6 +1662,7 @@ class Product extends CommonObject
 						$this->remise_percent = $obj->remise_percent;       // remise percent if present and not typed
 						$this->vatrate_supplier = $obj->tva_tx;             // Vat ref supplier
 						$this->default_vat_code = $obj->default_vat_code;   // Vat code supplier
+						if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $this->packaging = $obj->packaging;
                         $this->fourn_multicurrency_price       = $obj->multicurrency_price;
                         $this->fourn_multicurrency_unitprice   = $obj->multicurrency_unitprice;
                         $this->fourn_multicurrency_tx          = $obj->multicurrency_tx;
@@ -3221,6 +3225,7 @@ class Product extends CommonObject
 				$sql.= ", quantity";
 				$sql.= ", fk_user";
 				$sql.= ", tva_tx";
+				if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $sql.= ", packaging";
 				$sql.= ") VALUES (";
 				$sql.= "'".$this->db->idate($now)."'";
 				$sql.= ", ".$conf->entity;
@@ -3230,6 +3235,7 @@ class Product extends CommonObject
 				$sql.= ", ".$quantity;
 				$sql.= ", ".$user->id;
 				$sql.= ", 0";
+				if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) $sql.= ", ".(!empty($this->packaging) ? $this->packaging : 1);
 				$sql.= ")";
 
 				if ($this->db->query($sql))

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -678,6 +678,15 @@ SCRIPT;
 						print '</tr>';
 					}
 				}
+				
+				// Product packaging
+				if (!empty($conf->global->PRODUIT_FOURN_PACKAGING))
+				{
+				    print '<tr>';
+				    print '<td>'.$langs->trans('FournProductPackaging').'</td>';
+				    print '<td><input class="flat" name="packaging" size="4" value="'.($rowid ? $object->packaging : 1).'"></td>';
+				    print '</tr>';
+				}
 
 				// Product description of the supplier
 				if (! empty($conf->global->PRODUIT_FOURN_TEXTS))

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -157,6 +157,7 @@ if (empty($reshook))
 		$delivery_time_days = GETPOST('delivery_time_days', 'int') ? GETPOST('delivery_time_days', 'int') : '';
 		$supplier_reputation = GETPOST('supplier_reputation');
 		$supplier_description = GETPOST('supplier_description', 'alpha');
+		$packaging = GETPOST('packaging', 'int');
 
 		if ($tva_tx == '')
 		{
@@ -219,6 +220,9 @@ if (empty($reshook))
             }
         }
 
+        if (empty($packaging)) $packaging = 1;
+        $object->packaging = $packaging;
+
 		if (! $error)
 		{
 			$db->begin();
@@ -248,9 +252,10 @@ if (empty($reshook))
 				$result=$supplier->fetch($id_fourn);
 				if (isset($_POST['ref_fourn_price_id']))
 					$object->fetch_product_fournisseur_price($_POST['ref_fourn_price_id']);
-
+					$object->packaging = $packaging;
+					
 				$newprice = price2num(GETPOST("price","alpha"));
-
+				
                 if ($conf->multicurrency->enabled)
                 {
                 	$multicurrency_tx = price2num(GETPOST("multicurrency_tx",'alpha'));
@@ -787,6 +792,7 @@ SCRIPT;
 				print_liste_field_titre("DiscountQtyMin",$_SERVER["PHP_SELF"],'','',$param,'align="right"',$sortfield,$sortorder);
 				print_liste_field_titre("NbDaysToDelivery",$_SERVER["PHP_SELF"],"pfp.delivery_time_days","",$param,'align="right"',$sortfield,$sortorder);
 				print_liste_field_titre("ReputationForThisProduct",$_SERVER["PHP_SELF"],"pfp.supplier_reputation","",$param,'align="center"',$sortfield,$sortorder);
+				if (!empty($conf->global->PRODUIT_FOURN_PACKAGING)) print_liste_field_titre("PackagingForThisProduct",$_SERVER["PHP_SELF"],"pfp.packaging","",$param,'align="center"',$sortfield,$sortorder);
 				print_liste_field_titre('');
 				print "</tr>\n";
 
@@ -866,7 +872,15 @@ SCRIPT;
 						if (!empty($productfourn->supplier_reputation) && !empty($object->reputations[$productfourn->supplier_reputation])) {
 							print $object->reputations[$productfourn->supplier_reputation];
 						}
-						print'</td>';
+						print '</td>';
+
+						// Packaging
+						if (!empty($conf->global->PRODUIT_FOURN_PACKAGING))
+						{
+    						print '<td align="center">';
+    						print price($productfourn->packaging);
+    						print '</td>';
+						}
 
 						if (is_object($hookmanager))
 						{


### PR DESCRIPTION
# New manage packaging on fourn product price
allow to set a packaging value on supplier price.
Use the packaging to recalculate qty of supplier_order lines according to it.

ex. : your supplier sales pen by 10. You need 3 pens to sale to your customers. You will order a pack of 10 pens to your supplier.
