### PR TITLE
FIX: Expense Report Ref Not Showing in PDF File Properties

### DIFF
--- a/htdocs/core/modules/expensereport/doc/pdf_standard.modules.php
+++ b/htdocs/core/modules/expensereport/doc/pdf_standard.modules.php
@@ -278,7 +278,7 @@ class pdf_standard extends ModeleExpenseReport
 				$pagenb=0;
 				$pdf->SetDrawColor(128,128,128);
 
-				$pdf->SetTitle($outputlangs->convToOutputCharset($object->ref_number));
+				$pdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 				$pdf->SetSubject($outputlangs->transnoentities("Trips"));
 				$pdf->SetCreator("Dolibarr ".DOL_VERSION);
 				$pdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));


### PR DESCRIPTION
The generated pdf title field in the pdf file document properties was blank.  This fixes that.

