### PR TITLE
NEW Update working chkbxlst filter for lists

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1334,7 +1334,55 @@ class ExtraFields
 					if (strpos($InfoFieldList[4], '$ID$')!==false && !empty($objectid)) {
 						$InfoFieldList[4]=str_replace('$ID$',$objectid,$InfoFieldList[4]);
 					} else {
-						$InfoFieldList[4]=str_replace('$ID$','0',$InfoFieldList[4]);
+						// Pattern for word=$ID$
+						$word = '\b[a-zA-Z0-9-\.-_]+\b=\$ID\$';
+						
+						// Removing space arount =, ( and )
+						$InfoFieldList[4]=preg_replace('# *(=|\(|\)) *#','$1', $InfoFieldList[4]);
+						
+						$nbPreg = 1;
+						// While we have parenthesis
+						while ($nbPreg!=0) {
+							// Init des compteurs
+							$nbPregRepl = $nbPregSel = 0;
+							// On retire toutes les parenthèses sans = avant
+							$InfoFieldList[4]=preg_replace( '#([^=])(\([^)^(]*(' . $word .   ')[^)^(]*\))#','$1 $3 ',$InfoFieldList[4],-1,$nbPregRepl);
+							// On retire les espaces autour des = et parenthèses
+							$InfoFieldList[4]=preg_replace('# *(=|\(|\)) *#','$1', $InfoFieldList[4]);
+							// On retire toutes les parenthèses avec = avant
+							$InfoFieldList[4]=preg_replace(  '#\b[a-zA-Z0-9-\.-_]+\b=\([^)^(]*(' . $word .   ')[^)^(]*\)#','$1 ',$InfoFieldList[4], -1, $nbPregSel);
+							// On retire les espaces autour des = et parenthèses
+							$InfoFieldList[4]=preg_replace('# *(=|\(|\)) *#','$1', $InfoFieldList[4]);
+							
+							// Calcul du compteur général pour la boucle
+							$nbPreg = $nbPregRepl + $nbPregSel;
+						}
+						
+						// Si l'on a un AND ou un OR, avant ou après
+						preg_match(  '#(AND|OR|) *(' . $word .   ') *(AND|OR|)#'  ,$InfoFieldList[4],$matchCondition);
+						while(!empty($matchCondition[0])) {
+							// If the two sides differ but are not empty
+							if (! empty($matchCondition[1]) && ! empty($matchCondition[3]) && $matchCondition[1] != $matchCondition[3] ) {
+								// Nobody sain would do that without parentheses
+								$InfoFieldList[4]=str_replace('$ID$','0',$InfoFieldList[4]);
+							}
+							else {
+								if (! empty($matchCondition[1])) {
+									$boolCond =(( $matchCondition[1] == "AND" )?' AND 1 ':' OR 0 ');
+									$InfoFieldList[4]=str_replace($matchCondition[0],$boolCond.$matchCondition[3] ,$InfoFieldList[4]);
+								}
+								else if (! empty($matchCondition[3])) {
+									$boolCond =(( $matchCondition[3] == "AND" )?' 1 AND ':' 0 OR');
+									$InfoFieldList[4]=str_replace($matchCondition[0],$boolCond,$InfoFieldList[4]);
+								}
+								else {
+									$InfoFieldList[4] = 1;
+								}
+							}
+							
+							// Si l'on a un AND ou un OR, avant ou après
+							preg_match(  '#(AND|OR|) *(' . $word .   ') *(AND|OR|)#'  ,$InfoFieldList[4],$matchCondition);
+						}
 					}
 
 					// We have to join on extrafield table

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1333,7 +1333,7 @@ class ExtraFields
 					// current object id can be use into filter
 					if (strpos($InfoFieldList[4], '$ID$')!==false && !empty($objectid)) {
 						$InfoFieldList[4]=str_replace('$ID$',$objectid,$InfoFieldList[4]);
-					} else {
+					} else if (preg_match("#^.*list.php$#",$_SERVER["DOCUMENT_URI"])) {
 						// Pattern for word=$ID$
 						$word = '\b[a-zA-Z0-9-\.-_]+\b=\$ID\$';
 						
@@ -1359,7 +1359,7 @@ class ExtraFields
 						}
 						
 						// Si l'on a un AND ou un OR, avant ou après
-						preg_match(  '#(AND|OR|) *(' . $word .   ') *(AND|OR|)#'  ,$InfoFieldList[4],$matchCondition);
+						preg_match('#(AND|OR|) *('.$word.') *(AND|OR|)#',$InfoFieldList[4],$matchCondition);
 						while(!empty($matchCondition[0])) {
 							// If the two sides differ but are not empty
 							if (! empty($matchCondition[1]) && ! empty($matchCondition[3]) && $matchCondition[1] != $matchCondition[3] ) {
@@ -1369,7 +1369,7 @@ class ExtraFields
 							else {
 								if (! empty($matchCondition[1])) {
 									$boolCond =(( $matchCondition[1] == "AND" )?' AND 1 ':' OR 0 ');
-									$InfoFieldList[4]=str_replace($matchCondition[0],$boolCond.$matchCondition[3] ,$InfoFieldList[4]);
+									$InfoFieldList[4]=str_replace($matchCondition[0],$boolCond.$matchCondition[3],$InfoFieldList[4]);
 								}
 								else if (! empty($matchCondition[3])) {
 									$boolCond =(( $matchCondition[3] == "AND" )?' 1 AND ':' 0 OR');
@@ -1381,8 +1381,11 @@ class ExtraFields
 							}
 							
 							// Si l'on a un AND ou un OR, avant ou après
-							preg_match(  '#(AND|OR|) *(' . $word .   ') *(AND|OR|)#'  ,$InfoFieldList[4],$matchCondition);
+							preg_match('#(AND|OR|) *('.$word.') *(AND|OR|)#',$InfoFieldList[4],$matchCondition);
 						}
+					}
+					else { 
+						$InfoFieldList[4]=str_replace('$ID$','0',$InfoFieldList[4]);
 					}
 
 					// We have to join on extrafield table

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1384,7 +1384,7 @@ class ExtraFields
 							preg_match('#(AND|OR|) *('.$word.') *(AND|OR|)#',$InfoFieldList[4],$matchCondition);
 						}
 					}
-					else { 
+					else {
 						$InfoFieldList[4]=str_replace('$ID$','0',$InfoFieldList[4]);
 					}
 


### PR DESCRIPTION
Sorry, I don't know if it is a already requested feature or if it's know as a bug or else...

I've made working the filters for the "Checkboxes from a list" extrafields.

I believe i've adequatly removed the multiples possibilities of using $ID$ :

In the order :
- using of "table.col=$ID$ inside parenthesis with whatever AND and OR formula" replaced by "table.col=$ID$"
-- ex : "( foo = bar AND table.col=$ID$)"
-- replaced by : "table.col=$ID$"
- using of "table.filter=($SEL$...col=$ID$...)" replaced by "table.col=$ID$"
-- ex : "fk_soc = ($SEL$ fk_soc FROM llx_facture WHERE rowid = $ID$)" 
-- replaced by : rowid = $ID$

These two firsts are iterated until there is no more replacement possible

- using of "table.col=$ID$" replaced by 1 if surrounded by "AND" or nothing, replaced by 0 if surrounded by "OR"
-- ex :  foo = bar AND table.col=$ID$
-- replaced by : foo = bar AND 1

Hopefully, no one would use smth like that without parenthesis :
`foo = bar AND table.col=$ID$ OR foo2 = bar2`

That code permit to factorize every utilisation of AND, OR, (SELECT...), JOIN operators.
I don't think the LIKE and IN operators would work