### PR TITLE
Fix changing currency in a doc was recalculating amounts in company currency #9801

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1778,7 +1778,7 @@ abstract class CommonObject
 				$this->multicurrency_code = $code;
 
 				list($fk_multicurrency, $rate) = MultiCurrency::getIdAndTxFromCode($this->db, $code);
-				if ($rate) $this->setMulticurrencyRate($rate);
+				if ($rate) $this->setMulticurrencyRate($rate,2);
 
 				return 1;
 			}


### PR DESCRIPTION
Fixes #9801 
When you change the currency of a document, amounts that must be recalculated are the ones in the new selected currency.