### PR TITLE
Update Stripe Version API

### DIFF
--- a/htdocs/stripe/config.php
+++ b/htdocs/stripe/config.php
@@ -55,4 +55,4 @@ else
 
 \Stripe\Stripe::setApiKey($stripearrayofkeys['secret_key']);
 \Stripe\Stripe::setAppInfo("Dolibarr Stripe", DOL_VERSION, "https://www.dolibarr.org"); // add dolibarr version
-\Stripe\Stripe::setApiVersion("2018-10-31"); // force version API
+\Stripe\Stripe::setApiVersion("2018-11-08"); // force version API

--- a/htdocs/stripe/config.php
+++ b/htdocs/stripe/config.php
@@ -55,4 +55,4 @@ else
 
 \Stripe\Stripe::setApiKey($stripearrayofkeys['secret_key']);
 \Stripe\Stripe::setAppInfo("Dolibarr Stripe", DOL_VERSION, "https://www.dolibarr.org"); // add dolibarr version
-\Stripe\Stripe::setApiVersion("2018-09-24"); // force version API
+\Stripe\Stripe::setApiVersion("2018-10-31"); // force version API


### PR DESCRIPTION
The description field on customer endpoints has a maximum character length limit of 350 now. The name field on product endpoints has a maximum character length limit of 250 now. The description field on invoice line items has a maximum character length limit of 500 now.
The billing_reason attribute of the invoice object now can take the value of subscription_create, indicating that it is the first invoice of a subscription. For older API versions, billing_reason=subscription_create is represented as subscription_update.