### PR TITLE
FIX parent link was not removed on societe deletion #9106

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1518,6 +1518,19 @@ class Societe extends CommonObject
 					dol_syslog(get_class($this)."::delete error -3 ".$this->error, LOG_ERR);
 				}
 			}
+			
+			// Remove links to subsidiaries companies
+			if (! $error)
+			{
+				$sql = "UPDATE ".MAIN_DB_PREFIX."societe";
+				$sql.= " SET parent = NULL";
+				$sql.= " WHERE parent = " . $id;
+				if (! $this->db->query($sql))
+				{
+					$error++;
+					$this->errors[] = $this->db->lasterror();
+				}
+			}
 
 			// Remove third party
 			if (! $error)


### PR DESCRIPTION
Fixes #9106
On company deletion, link to subsidiaries was not removed.
Should I add something in the SQL migration ? Something like UPDATE societe SET parent = NULL WHERE parent NOT IN (SELECT rowid FROM societe)