### PR TITLE
FIX Work with new table actioncomm_resources and multiple contact affectation

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1359,8 +1359,14 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon='', $noprint=
         	$sql.= " AND a.fk_element = o.rowid AND a.elementtype = 'product'";
         	if ($filterobj->id) $sql.= " AND a.fk_element = ".$filterobj->id;
         }
-        //TODO check how ot work with new table actioncomm_resources and multiple contact affectation
-        if (is_object($objcon) && $objcon->id) $sql.= " AND a.fk_contact = ".$objcon->id;
+
+	    // Work with new table actioncomm_resources and multiple contact affectation.
+	    if (is_object($objcon) && $objcon->id)
+	    {
+		    $sql.= " AND r.element_type = '" . $objcon->table_element . "'" .
+			    " AND r.fk_element = " . $objcon->id;
+	    }
+
         // Condition on actioncode
         if (! empty($actioncode))
         {

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1315,7 +1315,8 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon='', $noprint=
     if (! empty($conf->agenda->enabled))
     {
         // Recherche histo sur actioncomm
-        $sql = "SELECT a.id, a.label,";
+	    // @since PR #9972, add DISTINCT.
+        $sql = "SELECT DISTINCT a.id, a.label,";
         $sql.= " a.datep as dp,";
         $sql.= " a.datep2 as dp2,";
         $sql.= " a.note, a.percent,";

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1330,6 +1330,7 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon='', $noprint=
         $sql.= " FROM ".MAIN_DB_PREFIX."actioncomm as a";
         $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."user as u on u.rowid = a.fk_user_action";
         $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."c_actioncomm as c ON a.fk_action = c.id";
+        $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."actioncomm_resources as r ON a.id = r.fk_actioncomm";
         if (is_object($filterobj) && get_class($filterobj) == 'Societe')  $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."socpeople as sp ON a.fk_contact = sp.rowid";
         elseif (is_object($filterobj) && get_class($filterobj) == 'Dolresource') {
         	$sql.= " INNER JOIN ".MAIN_DB_PREFIX."element_resources as er";

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1330,8 +1330,12 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon='', $noprint=
         $sql.= " FROM ".MAIN_DB_PREFIX."actioncomm as a";
         $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."user as u on u.rowid = a.fk_user_action";
         $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."c_actioncomm as c ON a.fk_action = c.id";
-        $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."actioncomm_resources as r ON a.id = r.fk_actioncomm";
-        if (is_object($filterobj) && get_class($filterobj) == 'Societe')  $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."socpeople as sp ON a.fk_contact = sp.rowid";
+
+        if (is_object($objcon) && $objcon->id) {
+		    $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."actioncomm_resources as r ON a.id = r.fk_actioncomm";
+	    }
+
+	    if (is_object($filterobj) && get_class($filterobj) == 'Societe')  $sql.= " LEFT JOIN ".MAIN_DB_PREFIX."socpeople as sp ON a.fk_contact = sp.rowid";
         elseif (is_object($filterobj) && get_class($filterobj) == 'Dolresource') {
         	$sql.= " INNER JOIN ".MAIN_DB_PREFIX."element_resources as er";
         	$sql.= " ON er.resource_type = 'dolresource'";

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1315,9 +1315,14 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon='', $noprint=
     if (! empty($conf->agenda->enabled))
     {
         // Recherche histo sur actioncomm
-	    // @since PR #9972, add DISTINCT.
-        $sql = "SELECT DISTINCT a.id, a.label,";
-        $sql.= " a.datep as dp,";
+ 	if (is_object($objcon) && $objcon->id) {
+		$sql = "SELECT DISTINCT a.id, a.label,";
+	}
+	else
+	{
+		$sql = "SELECT a.id, a.label,";
+	}
+	$sql.= " a.datep as dp,";
         $sql.= " a.datep2 as dp2,";
         $sql.= " a.note, a.percent,";
         $sql.= " a.fk_element, a.elementtype,";


### PR DESCRIPTION
# NEW Work with new `actioncomm_resources` table and multiple contact affectation

An Agenda event set to concern _multiple_ Contacts will now be displayed in the Agenda tab's list of _every_ concerned Contact.

This modifies the [`show_actions_done()` function](https://github.com/Dolibarr/dolibarr/blob/develop/htdocs/core/lib/company.lib.php#L1298) by joining the new `actioncomm_resources` SQL  table to find any (can be multiple now) contact (or other) referenced as resources for this `actioncomm` / event.

### Screenshots

Before (only the first contact referenced in the Event has an the event displayed on his Agenda tab):
Contact 1:
![image](https://user-images.githubusercontent.com/32769270/48144420-20ab8300-e2b1-11e8-9bd6-aeecb917e986.png)

Contact2:
![image](https://user-images.githubusercontent.com/32769270/48144330-f8238900-e2b0-11e8-858f-ed32e4c2762d.png)

After:
Contact 1:
![image](https://user-images.githubusercontent.com/32769270/48144593-7718c180-e2b1-11e8-8181-5d82f7637ea6.png)

Contact 2:
![image](https://user-images.githubusercontent.com/32769270/48144493-505a8b00-e2b1-11e8-8ba2-821c765a7efa.png)
