### PR TITLE
remove useless line of code

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1382,7 +1382,6 @@ function top_htmlhead($head, $title='', $disablejs=0, $disablehead=0, $arrayofjs
                     }
                     else
                     {
-                        if (! preg_match('/^\//',$jsfile)) $jsfile='/'.$jsfile;	// For backward compatibility
                         print '<script type="text/javascript" src="'.dol_buildpath($jsfile,1).'"></script>'."\n";
                     }
                 }


### PR DESCRIPTION
This line of code seems useless
https://github.com/Dolibarr/dolibarr/blob/193b153fbf0a36dcf4345585e2aa6ccfbffff352/htdocs/main.inc.php#L1385

Because once dol_buildpath(...) function is called after, the slash is automatically removed at the begining of the function @see
https://github.com/Dolibarr/dolibarr/blob/193b153fbf0a36dcf4345585e2aa6ccfbffff352/htdocs/core/lib/functions.lib.php#L684

So i guess this is just a loss of performance. Correct me if i'm wrong x).