### PR TITLE
FIX unique ref check before save

### DIFF
--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -206,10 +206,28 @@ if ($action == 'createtask' && $user->rights->projet->creer)
 		    $checkTaskExistObj = new Task($db);
 		    if($checkTaskExistObj->fetch(0,$taskref) > 0)
 		    {
-		        // TODO : create new trans key in develop like ErrorDuplicateRef using $taskref as parameter
-		        setEventMessages($langs->trans("ErrorDuplicateField"), null, 'errors');
-		        $action='create';
-		        $error++;
+		        if(!empty($conf->global->PROJECT_TASK_FORCE_NEW_TASKREF_ON_EXIST))
+		        {
+		            $obj = empty($conf->global->PROJECT_TASK_ADDON)?'mod_task_simple':$conf->global->PROJECT_TASK_ADDON;
+		            if (! empty($conf->global->PROJECT_TASK_ADDON) && is_readable(DOL_DOCUMENT_ROOT ."/core/modules/project/task/".$conf->global->PROJECT_TASK_ADDON.".php"))
+		            {
+		                require_once DOL_DOCUMENT_ROOT ."/core/modules/project/task/".$conf->global->PROJECT_TASK_ADDON.'.php';
+		                $modTask = new $obj;
+		                $taskref = $modTask->getNextValue($object->thirdparty,null);
+		                setEventMessages($langs->trans("RefChangedAutomatically"), null, 'errors');
+		            }
+		            else{
+		                $error++;
+		            }
+		        }
+		        
+		        if($error || empty($conf->global->PROJECT_TASK_FORCE_NEW_TASKREF_ON_EXIST))
+		        {
+		            // TODO : create new trans key in develop like ErrorDuplicateRef using $taskref as parameter
+		            setEventMessages($langs->trans("ErrorDuplicateField"), null, 'errors');
+		            $action='create';
+		            $error++;
+		        }
 		    }  
 		}
 		

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -200,6 +200,19 @@ if ($action == 'createtask' && $user->rights->projet->creer)
 			$action='create';
 			$error++;
 		}
+		
+		if (!empty($taskref))
+		{
+		    $checkTaskExistObj = new Task($db);
+		    if($checkTaskExistObj->fetch(0,$taskref) > 0)
+		    {
+		        // TODO : create new trans key in develop like ErrorDuplicateRef using $taskref as parameter
+		        setEventMessages($langs->trans("ErrorDuplicateField"), null, 'errors');
+		        $action='create';
+		        $error++;
+		    }  
+		}
+		
 	    if (empty($label))
 		{
 			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("Label")), null, 'errors');


### PR DESCRIPTION
# Fix
Prevent the loss of the form if another user creates a task at the same time with the same ref.
SQL error -> Duplicate entry 'TKxxxx-xxxx-x' for key 'uk_projet_task_ref'
