### PR TITLE
Fix Contact Agenda events filter when no Third Party

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1517,7 +1517,8 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon='', $noprint=
         $contactstatic = new Contact($db);
 
         $out.='<form name="listactionsfilter" class="listactionsfilter" action="' . $_SERVER["PHP_SELF"] . '" method="POST">';
-        if ($objcon && get_class($objcon) == 'Contact' && $filterobj && get_class($filterobj) == 'Societe')
+        if ($objcon && get_class($objcon) == 'Contact' &&
+            (is_null($filterobj) || get_class($filterobj) == 'Societe'))
         {
             $out.='<input type="hidden" name="id" value="'.$objcon->id.'" />';
         }


### PR DESCRIPTION
# Fix Contact Agenda events filter when no Third Party
Handle case where the contact is not linked to any third party (`Societe`).

The list filter form will now function again as the current contact ID is correctly set in the hidden input.

Note: No [issues](https://github.com/Dolibarr/dolibarr/issues) were found reporting this same problem.

Before the fix:
![image](https://user-images.githubusercontent.com/32769270/48612245-ba95be80-e988-11e8-87b5-992d4233ecc0.png)

(after clicking on the filter icon:)
![image](https://user-images.githubusercontent.com/32769270/48612270-d13c1580-e988-11e8-8496-8693787ed854.png)



After the fix:
![image](https://user-images.githubusercontent.com/32769270/48612317-f597f200-e988-11e8-94a9-9e0f4554a8fa.png)

![image](https://user-images.githubusercontent.com/32769270/48612376-26782700-e989-11e8-9355-ea4dd0f60cc0.png)
