### PR TITLE
NEW Add afterSelectContactOptions hook

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1389,7 +1389,7 @@ class Form
 	 *	Return HTML code of the SELECT of list of all contacts (for a third party or all).
 	 *  This also set the number of contacts found into $this->num
 	 *
-	 * @since 8.0 Add afterSelectOptions hook & selectcontacts context.
+	 * @since 9.0 Add afterSelectOptions hook & selectcontacts context.
 	 *
 	 *	@param	int			$socid      	Id ot third party or 0 for all or -1 for empty list
 	 *	@param  array|int	$selected   	Array of ID of pre-selected contact id

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1389,7 +1389,7 @@ class Form
 	 *	Return HTML code of the SELECT of list of all contacts (for a third party or all).
 	 *  This also set the number of contacts found into $this->num
 	 *
-	 * @since 9.0 Add afterSelectOptions hook & selectcontacts context.
+	 * @since 9.0 Add afterSelectContactOptions hook
 	 *
 	 *	@param	int			$socid      	Id ot third party or 0 for all or -1 for empty list
 	 *	@param  array|int	$selected   	Array of ID of pre-selected contact id
@@ -1418,17 +1418,15 @@ class Form
 
 		if ($selected === '') $selected = array();
 		else if (!is_array($selected)) $selected = array($selected);
-        $out='';
+		$out='';
 
-		// Add selectcontacts hook
 		if (! is_object($hookmanager))
 		{
 			include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
 			$hookmanager=new HookManager($this->db);
 		}
-		$hookmanager->initHooks(array('selectcontacts'));
 
-		// On recherche les societes
+		// We search third parties
 		$sql = "SELECT sp.rowid, sp.lastname, sp.statut, sp.firstname, sp.poste";
 		if ($showsoc > 0) $sql.= " , s.nom as company";
 		$sql.= " FROM ".MAIN_DB_PREFIX ."socpeople as sp";
@@ -1523,7 +1521,7 @@ class Form
 				'showsoc'=>$showsoc,
 			);
 
-			$reshook = $hookmanager->executeHooks( 'afterSelectOptions', $parameters, $this, $action );    // Note that $action and $object may have been modified by some hooks
+			$reshook = $hookmanager->executeHooks( 'afterSelectContactOptions', $parameters, $this, $action );    // Note that $action and $object may have been modified by some hooks
 
 			if ($htmlname != 'none' || $options_only)
 			{

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1389,6 +1389,8 @@ class Form
 	 *	Return HTML code of the SELECT of list of all contacts (for a third party or all).
 	 *  This also set the number of contacts found into $this->num
 	 *
+	 * @since 8.0 Add afterSelectOptions hook & selectcontacts context.
+	 *
 	 *	@param	int			$socid      	Id ot third party or 0 for all or -1 for empty list
 	 *	@param  array|int	$selected   	Array of ID of pre-selected contact id
 	 *	@param  string		$htmlname  	    Name of HTML field ('none' for a not editable field)
@@ -1408,7 +1410,7 @@ class Form
 	 */
 	function selectcontacts($socid, $selected='', $htmlname='contactid', $showempty=0, $exclude='', $limitto='', $showfunction=0, $moreclass='', $options_only=false, $showsoc=0, $forcecombo=0, $events=array(), $moreparam='', $htmlid='', $multiple=false)
 	{
-		global $conf,$langs;
+		global $conf,$langs,$hookmanager,$action;
 
 		$langs->load('companies');
 
@@ -1417,6 +1419,14 @@ class Form
 		if ($selected === '') $selected = array();
 		else if (!is_array($selected)) $selected = array($selected);
         $out='';
+
+		// Add selectcontacts hook
+		if (! is_object($hookmanager))
+		{
+			include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
+			$hookmanager=new HookManager($this->db);
+		}
+		$hookmanager->initHooks(array('selectcontacts'));
 
 		// On recherche les societes
 		$sql = "SELECT sp.rowid, sp.lastname, sp.statut, sp.firstname, sp.poste";
@@ -1503,6 +1513,18 @@ class Form
 				$out.= ($socid != -1) ? ($langs->trans($socid?"NoContactDefinedForThirdParty":"NoContactDefined")) : $langs->trans('SelectAThirdPartyFirst');
 				$out.= '</option>';
 			}
+
+			$parameters = array(
+				'socid'=>$socid,
+				'htmlname'=>$htmlname,
+				'resql'=>$resql,
+				'out'=>&$out,
+				'showfunction'=>$showfunction,
+				'showsoc'=>$showsoc,
+			);
+
+			$reshook = $hookmanager->executeHooks( 'afterSelectOptions', $parameters, $this, $action );    // Note that $action and $object may have been modified by some hooks
+
 			if ($htmlname != 'none' || $options_only)
 			{
 				$out.= '</select>';


### PR DESCRIPTION
# New Add afterSelectOptions hook & selectcontacts context

Add the `afterSelectOptions` hook and `selectcontacts` context to the [`Form::selectcontacts` method](https://github.com/Dolibarr/dolibarr/blob/develop/htdocs/core/class/html.form.class.php#L1409).

Was successfully used to add contacts to the list when on the new Event form.

Lots of parameters are sent to the hook so you can easily build new options and save them to the `$parameters['out']` variable.