### PR TITLE
NEW Adding hooks to facturerec

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -32,7 +32,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/notify.class.php';
 require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
-require_once(DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php');
 
 
 /**
@@ -1033,7 +1032,6 @@ class FactureRec extends CommonInvoice
 		$sql.= $db->order('entity', 'ASC');
 		//print $sql;exit;
 		$parameters = array(
-			'entity' => $conf->entity,
 			'restrictioninvoiceid' => $restrictioninvoiceid,
 			'forcevalidation' => $forcevalidation,
 			);
@@ -1083,7 +1081,7 @@ class FactureRec extends CommonInvoice
 					$invoiceidgenerated = $facture->create($user);
 					if ($invoiceidgenerated <= 0)
 					{
-						$this->errors[] = $facture->errors;
+						$this->errors = $facture->errors;
 						$this->error = $facture->error;
 						$error++;
 					}
@@ -1092,7 +1090,7 @@ class FactureRec extends CommonInvoice
 						$result = $facture->validate($user);
 						if ($result <= 0)
 						{
-							$this->errors[] = $facture->errors;
+							$this->errors = $facture->errors;
 							$this->error = $facture->error;
 							$error++;
 						}
@@ -1104,7 +1102,7 @@ class FactureRec extends CommonInvoice
 						$result = $facture->generateDocument($facturerec->modelpdf, $langs);
 						if ($result <= 0)
 						{
-							$this->errors[] = $facture->errors;
+							$this->errors = $facture->errors;
 							$this->error = $facture->error;
 							$error++;
 						}

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -1006,14 +1006,11 @@ class FactureRec extends CommonInvoice
 	{
 		global $conf, $langs, $db, $user, $hookmanager;
 
-
 		$error=0;
 		$nb_create=0;
 
 		// Load translation files required by the page
 		$langs->loadLangs(array("main","bills"));
-
-		$hookmanager->initHooks(array('createrecurringinvoices'));
 
 		$now = dol_now();
 		$tmparray=dol_getdate($now);
@@ -1035,7 +1032,7 @@ class FactureRec extends CommonInvoice
 			'restrictioninvoiceid' => $restrictioninvoiceid,
 			'forcevalidation' => $forcevalidation,
 			);
-		$reshook = $hookmanager->executeHooks('writeSQL', $parameters, $sql); // note that $sql might be modified by hooks
+		$reshook = $hookmanager->executeHooks('beforeCreationOfRecurringInvoices', $parameters, $sql); // note that $sql might be modified by hooks
 
 		$resql = $db->query($sql);
 		if ($resql)
@@ -1136,7 +1133,7 @@ class FactureRec extends CommonInvoice
 					'facturerec' => $facturerec,	// it's an object which PHP passes by "reference", so modifiable by hooks.
 					'this'       => $this,		// it's an object which PHP passes by "reference", so modifiable by hooks.
 					);
-				$reshook = $hookmanager->executeHooks('generatedInvoice', $parameters, $facture);  // note: $facture can be modified by hooks (warning: $facture can be null)
+				$reshook = $hookmanager->executeHooks('afterCreationOfRecurringInvoice', $parameters, $facture);  // note: $facture can be modified by hooks (warning: $facture can be null)
 
 				$i++;
 			}

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -998,11 +998,11 @@ class FactureRec extends CommonInvoice
 	 *
 	 *  WARNING: This method change temporarly context $conf->entity to be in correct context for each recurring invoice found.
 	 *
-	 *  @param	int		$restictoninvoiceid		0=All qualified template invoices found. > 0 = restrict action on invoice ID
+	 *  @param	int		$restrictioninvoiceid		0=All qualified template invoices found. > 0 = restrict action on invoice ID
 	 *  @param	int		$forcevalidation		1=Force validation of invoice whatever is template auto_validate flag.
 	 *  @return	int								0 if OK, < 0 if KO (this function is used also by cron so only 0 is OK)
 	 */
-	function createRecurringInvoices($restictoninvoiceid=0, $forcevalidation=0)
+	function createRecurringInvoices($restrictioninvoiceid=0, $forcevalidation=0)
 	{
 		global $conf, $langs, $db, $user;
 
@@ -1017,7 +1017,7 @@ class FactureRec extends CommonInvoice
 		$tmparray=dol_getdate($now);
 		$today = dol_mktime(23,59,59,$tmparray['mon'],$tmparray['mday'],$tmparray['year']);   // Today is last second of current day
 
-		dol_syslog("createRecurringInvoices restictoninvoiceid=".$restictoninvoiceid." forcevalidation=".$forcevalidation);
+		dol_syslog("createRecurringInvoices restrictioninvoiceid=".$restrictioninvoiceid." forcevalidation=".$forcevalidation);
 
 		$sql = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'facture_rec';
 		$sql.= ' WHERE frequency > 0';      // A recurring invoice is an invoice with a frequency
@@ -1025,8 +1025,8 @@ class FactureRec extends CommonInvoice
 		$sql.= ' AND (nb_gen_done < nb_gen_max OR nb_gen_max = 0)';
 		$sql.= ' AND suspended = 0';
 		$sql.= ' AND entity = '.$conf->entity;	// MUST STAY = $conf->entity here
-		if ($restictoninvoiceid > 0)
-			$sql.=' AND rowid = '.$restictoninvoiceid;
+		if ($restrictioninvoiceid > 0)
+			$sql.=' AND rowid = '.$restrictioninvoiceid;
 		$sql.= $db->order('entity', 'ASC');
 		//print $sql;exit;
 

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -1025,30 +1025,33 @@ class FactureRec extends CommonInvoice
 		$sql.= ' AND (nb_gen_done < nb_gen_max OR nb_gen_max = 0)';
 		$sql.= ' AND suspended = 0';
 		$sql.= ' AND entity = '.$conf->entity;	// MUST STAY = $conf->entity here
-		if ($restictoninvoiceid > 0) $sql.=' AND rowid = '.$restictoninvoiceid;
+		if ($restictoninvoiceid > 0)
+			$sql.=' AND rowid = '.$restictoninvoiceid;
 		$sql.= $db->order('entity', 'ASC');
 		//print $sql;exit;
 
 		$resql = $db->query($sql);
 		if ($resql)
 		{
-		    $i=0;
-		    $num = $db->num_rows($resql);
+			$i=0;
+			$num = $db->num_rows($resql);
 
-		    if ($num) $this->output.=$langs->trans("FoundXQualifiedRecurringInvoiceTemplate", $num)."\n";
-		    else $this->output.=$langs->trans("NoQualifiedRecurringInvoiceTemplateFound");
+			if ($num)
+				$this->output.=$langs->trans("FoundXQualifiedRecurringInvoiceTemplate", $num)."\n";
+			else
+				$this->output.=$langs->trans("NoQualifiedRecurringInvoiceTemplateFound");
 
-		    $saventity = $conf->entity;
+			$saventity = $conf->entity;
 
-		    while ($i < $num)     // Loop on each template invoice. If $num = 0, test is false at first pass.
+			while ($i < $num)     // Loop on each template invoice. If $num = 0, test is false at first pass.
 			{
 				$line = $db->fetch_object($resql);
 
-			    $db->begin();
+				$db->begin();
 
-			    $invoiceidgenerated = 0;
+				$invoiceidgenerated = 0;
 
-			    $facturerec = new FactureRec($db);
+				$facturerec = new FactureRec($db);
 				$facturerec->fetch($line->rowid);
 
 				if ($facturerec->id > 0)
@@ -1058,44 +1061,44 @@ class FactureRec extends CommonInvoice
 
 					dol_syslog("createRecurringInvoices Process invoice template id=".$facturerec->id.", ref=".$facturerec->ref.", entity=".$facturerec->entity);
 
-				    $facture = new Facture($db);
+					$facture = new Facture($db);
 					$facture->fac_rec = $facturerec->id;    // We will create $facture from this recurring invoice
 					$facture->fk_fac_rec_source = $facturerec->id;    // We will create $facture from this recurring invoice
 
-				    $facture->type = self::TYPE_STANDARD;
-				    $facture->brouillon = 1;
-				    $facture->date = (empty($facturerec->date_when)?$now:$facturerec->date_when);	// We could also use dol_now here but we prefer date_when so invoice has real date when we would like even if we generate later.
-				    $facture->socid = $facturerec->socid;
+					$facture->type = self::TYPE_STANDARD;
+					$facture->brouillon = 1;
+					$facture->date = (empty($facturerec->date_when)?$now:$facturerec->date_when);	// We could also use dol_now here but we prefer date_when so invoice has real date when we would like even if we generate later.
+					$facture->socid = $facturerec->socid;
 
-				    $invoiceidgenerated = $facture->create($user);
-				    if ($invoiceidgenerated <= 0)
-				    {
-				        $this->errors = $facture->errors;
-				        $this->error = $facture->error;
-				        $error++;
-				    }
-				    if (! $error && ($facturerec->auto_validate || $forcevalidation))
-				    {
-				        $result = $facture->validate($user);
-				        if ($result <= 0)
-				        {
-	    			        $this->errors = $facture->errors;
-	    			        $this->error = $facture->error;
-				            $error++;
-	                    }
-				    }
-	                if (! $error && $facturerec->generate_pdf)
-	                {
-	                    // We refresh the object in order to have all necessary data (like date_lim_reglement)
-	                    $facture->fetch($facture->id);
-	                    $result = $facture->generateDocument($facturerec->modelpdf, $langs);
-	                    if ($result <= 0)
-	                    {
-	                        $this->errors = $facture->errors;
-	                        $this->error = $facture->error;
-	                        $error++;
-	                    }
-	                }
+					$invoiceidgenerated = $facture->create($user);
+					if ($invoiceidgenerated <= 0)
+					{
+						$this->errors = $facture->errors;
+						$this->error = $facture->error;
+						$error++;
+					}
+					if (! $error && ($facturerec->auto_validate || $forcevalidation))
+					{
+						$result = $facture->validate($user);
+						if ($result <= 0)
+						{
+							$this->errors = $facture->errors;
+							$this->error = $facture->error;
+							$error++;
+						}
+					}
+					if (! $error && $facturerec->generate_pdf)
+					{
+						// We refresh the object in order to have all necessary data (like date_lim_reglement)
+						$facture->fetch($facture->id);
+						$result = $facture->generateDocument($facturerec->modelpdf, $langs);
+						if ($result <= 0)
+						{
+							$this->errors = $facture->errors;
+							$this->error = $facture->error;
+							$error++;
+						}
+					}
 				}
 				else
 				{
@@ -1114,7 +1117,7 @@ class FactureRec extends CommonInvoice
 				}
 				else
 				{
-				    $db->rollback("createRecurringInvoices Process invoice template id=".$facturerec->id.", ref=".$facturerec->ref);
+					$db->rollback("createRecurringInvoices Process invoice template id=".$facturerec->id.", ref=".$facturerec->ref);
 				}
 
 				$i++;


### PR DESCRIPTION
# Adding hooks to facturerec generation
The last of those commits adds two hook points to the facturerec generation process. These hooks aim at:
* allowing modules to modify the SQL query selecting which facturerec gets processed or not,
* allowing modules to react specifically after an invoice is automatically generated (for example, sending the generated PDF by mail, cf. #6852 with a prototype at https://github.com/bugness-chl/sendfacrecmail )

Other commits include a reindent (full tab) and a typo correction.