### PR TITLE
FIX run_sql function: support for numbers in database prefix

### DIFF
--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -235,7 +235,7 @@ function run_sql($sqlfile, $silent=1, $entity='', $usesavepoint=1, $handler='', 
         $newsql=$sql;
 
         // Replace __+MAX_table__ with max of table
-        while (preg_match('/__\+MAX_([A-Za-z_]+)__/i',$newsql,$reg))
+        while (preg_match('/__\+MAX_([A-Za-z0-9_]+)__/i',$newsql,$reg))
         {
             $table=$reg[1];
             if (! isset($listofmaxrowid[$table]))


### PR DESCRIPTION
# Issue
when database prefix contains numbers, for example: `db7x_`, run_sql function fail to replace `__+MAX_table__` instructions with their values which causes sql errors.

# Fix
add support for numbers in `__+MAX_table__` regex pattern.