### PR TITLE
Fix #10313 BUG: Invoice Put fails (mismatched parameters)

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -454,7 +454,7 @@ class Invoices extends DolibarrApi
              }
         }
 
-        if($this->invoice->update($id, DolibarrApiAccess::$user))
+        if($this->invoice->update(DolibarrApiAccess::$user))
             return $this->get($id);
 
         return false;


### PR DESCRIPTION
The first parameter is expected to be the user.
The $id of the invoice is already contained in $this

See facture.class.php 1610:
function update(User $user, $notrigger=0)
