### PR TITLE
FIX : Check for old picture name if the new one was not found

### DIFF
--- a/htdocs/theme/eldy/style.css.php
+++ b/htdocs/theme/eldy/style.css.php
@@ -1783,6 +1783,12 @@ foreach($mainmenuusedarray as $val)
 			$found=1;
 			break;
 		}
+		else if (file_exists($dirroot."/".$val."/img/".$val.".png"))    // Retro compatibilité
+		{
+			$url=dol_buildpath('/'.$val.'/img/'.$val.'.png', 1);
+			$found=1;
+			break;
+		}
 	}
 	// Img file not found
 	if (! $found)


### PR DESCRIPTION
# Fix check for old top menu picture name
If picture with "_over.png" suffix is not found, this will check for old name (without the "_over" suffix)