### PR TITLE
FIX problem with multicompany transverse mode

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -484,9 +484,9 @@ function checkUserAccessToObject($user, $featuresarray, $objectid=0, $tableandsh
 					{
 						$sql.= ",".MAIN_DB_PREFIX."usergroup_user as ug";
 						$sql.= " WHERE dbt.".$dbt_select." IN (".$objectid.")";
-						$sql.= " AND (ug.fk_user = dbt.rowid";
-						$sql.= " AND ug.entity IN (".getEntity('user')."))";
-						$sql.= " OR dbt.entity = 0"; // Show always superadmin
+						$sql.= " AND ((ug.fk_user = dbt.rowid";
+						$sql.= " AND ug.entity IN (".getEntity('usergroup')."))";
+						$sql.= " OR dbt.entity = 0)"; // Show always superadmin
 					}
 				}
 				else {

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -85,7 +85,9 @@ if ($user->societe_id > 0) $socid = $user->societe_id;
 $feature2='user';
 if ($user->id == $id) { $feature2=''; $canreaduser=1; } // A user can always read its own card
 
-$result = restrictedArea($user, 'user', $id, 'user&user', $feature2);
+if (! $canreaduser) {
+	$result = restrictedArea($user, 'user', $id, 'user&user', $feature2);
+}
 
 if ($user->id <> $id && ! $canreaduser) accessforbidden();
 

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -84,9 +84,9 @@ $socid=0;
 if ($user->societe_id > 0) $socid = $user->societe_id;
 $feature2='user';
 if ($user->id == $id) { $feature2=''; $canreaduser=1; } // A user can always read its own card
-if (!$canreaduser) {
-	$result = restrictedArea($user, 'user', $id, 'user&user', $feature2);
-}
+
+$result = restrictedArea($user, 'user', $id, 'user&user', $feature2);
+
 if ($user->id <> $id && ! $canreaduser) accessforbidden();
 
 // Load translation files required by page


### PR DESCRIPTION
@eldy désolé je le fait en français, un utilisateur ayant le droit de voir la fiche des autres users et faisant parti d'une seule entité pouvait voir la fiche des utilisateurs ne faisant pas parti de cette entité (lorsque la gestion des utilisateurs est centralisée dans l'entité principale.

Signed-off-by: Regis Houssin <regis.houssin@inodbox.com>