### PR TITLE
FIX: To add more thirdparties pdf models in custom modules

### DIFF
--- a/htdocs/societe/admin/societe.php
+++ b/htdocs/societe/admin/societe.php
@@ -327,6 +327,7 @@ $head = societe_admin_prepare_head();
 dol_fiche_head($head, 'general', $langs->trans("ThirdParties"), -1, 'company');
 
 $dirsociete=array_merge(array('/core/modules/societe/'),$conf->modules_parts['societe']);
+foreach ($conf->modules_parts['models'] as $mo)		$dirsociete[]=$mo.'core/modules/societe/';	//Add more models
 
 // Module to manage customer/supplier code
 


### PR DESCRIPTION
The new model should stay as usual in : _module_folder_/core/modules/societe/doc