### PR TITLE
Fix for issue #10333 branch 7.0

### DIFF
--- a/htdocs/compta/facture/class/paymentterm.class.php
+++ b/htdocs/compta/facture/class/paymentterm.class.php
@@ -167,7 +167,7 @@ class PaymentTerm // extends CommonObject
     	global $langs;
         $sql = "SELECT";
 		$sql.= " t.rowid,";
-		$sql.= " t.entity";
+		$sql.= " t.entity,";
 
 		$sql.= " t.code,";
 		$sql.= " t.sortorder,";


### PR DESCRIPTION
paymentterm.class.php invalid SQL in fetch
In branch 7.0, where it did occur the first time