### PR TITLE
Bills and coins pad, or Num pad in TakePOS

### DIFF
--- a/htdocs/langs/en_US/cashdesk.lang
+++ b/htdocs/langs/en_US/cashdesk.lang
@@ -50,3 +50,6 @@ TheoricalAmount=Theorical amount
 RealAmount=Real amount
 CashFenceDone=Cash fence done for the period
 NbOfInvoices=Nb of invoices
+Paymentnumpad=Payment Num Pad
+Numberspad=Numbers Pad
+BillsCoinsPad=Bills and Coins Pad

--- a/htdocs/takepos/admin/setup.php
+++ b/htdocs/takepos/admin/setup.php
@@ -62,6 +62,7 @@ if (GETPOST('action','alpha') == 'set')
 	$res = dolibarr_set_const($db,"TAKEPOS_ORDER_PRINTERS", GETPOST('TAKEPOS_ORDER_PRINTERS','alpha'),'chaine',0,'',$conf->entity);
 	$res = dolibarr_set_const($db,"TAKEPOS_HEADER", GETPOST('TAKEPOS_HEADER','alpha'),'chaine',0,'',$conf->entity);
 	$res = dolibarr_set_const($db,"TAKEPOS_FOOTER", GETPOST('TAKEPOS_FOOTER','alpha'),'chaine',0,'',$conf->entity);
+	$res = dolibarr_set_const($db,"TAKEPOS_NUMPAD", GETPOST('TAKEPOS_NUMPAD','alpha'),'chaine',0,'',$conf->entity);
 
 	dol_syslog("admin/cashdesk: level ".GETPOST('level','alpha'));
 
@@ -142,6 +143,14 @@ if ($conf->global->TAKEPOS_BAR_RESTAURANT && $conf->global->TAKEPOSCONNECTOR){
 	print $form->selectyesno("TAKEPOS_ORDER_PRINTERS",$conf->global->TAKEPOS_ORDER_PRINTERS,1);
 	print '</td></tr>';
 }
+
+// Payment numpad
+print '<tr class="oddeven"><td>';
+print $langs->trans("Paymentnumpad");
+print '<td colspan="2">';
+$array=array(0=>$langs->trans("Numberspad"), 1=>$langs->trans("BillsCoinsPad"));
+print $form->selectarray('TAKEPOS_NUMPAD', $array, (empty($conf->global->TAKEPOS_NUMPAD)?'0':$conf->global->TAKEPOS_NUMPAD), 0);
+print "</td></tr>\n";
 
 $substitutionarray=pdf_getSubstitutionArray($langs, null, null, 2);
 $substitutionarray['__(AnyTranslationKey)__']=$langs->trans("Translation");

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -53,14 +53,20 @@ $langs->loadLangs(array("main", "bills", "cashdesk"));
 ?>
 <link rel="stylesheet" href="css/pos.css">
 	<script>
-	var received=0;
+	<?php
+	if ($conf->global->TAKEPOS_NUMPAD==0) print "var received='';";
+	else print "var received=0;";
+	?>
 	function addreceived(price)
 	{
-	received+=parseFloat(price);
-	$('#change1').html(received.toFixed(2));
-	if (received><?php echo $invoice->total_ttc;?>)
+	<?php
+	if ($conf->global->TAKEPOS_NUMPAD==0) print 'received+=String(price);';
+	else print 'received+=parseFloat(price);';
+	?>
+	$('#change1').html(parseFloat(received).toFixed(2));
+	if (parseFloat(received)><?php echo $invoice->total_ttc;?>)
 		{
-		var change=parseFloat(received-<?php echo $invoice->total_ttc;?>);
+		var change=parseFloat(parseFloat(received)-<?php echo $invoice->total_ttc;?>);
 		$('#change2').html(change.toFixed(2));
 		}
 	}
@@ -98,21 +104,24 @@ $langs->loadLangs(array("main", "bills", "cashdesk"));
 </div>
 
 <div style="position:absolute; top:40%; left:5%; height:55%; width:91%;">
-<button type="button" class="calcbutton" onclick="addreceived(10);">10</button>
-<button type="button" class="calcbutton" onclick="addreceived(20);">20</button>
-<button type="button" class="calcbutton" onclick="addreceived(50);">50</button>
+<?php
+$numpad=$conf->global->TAKEPOS_NUMPAD;
+?>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "7"; else print "10";?>);"><?php if ($numpad==0) print "7"; else print "10";?></button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "8"; else print "20";?>);"><?php if ($numpad==0) print "8"; else print "20";?></button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "9"; else print "50";?>);"><?php if ($numpad==0) print "9"; else print "50";?></button>
 <button type="button" <?php if ($placeid==0) echo "disabled";?> class="calcbutton2" onclick="Validate('cash');"><?php echo $langs->trans("Cash"); ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(1);">1</button>
-<button type="button" class="calcbutton" onclick="addreceived(2);">2</button>
-<button type="button" class="calcbutton" onclick="addreceived(5);">5</button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "4"; else print "1";?>);"><?php if ($numpad==0) print "4"; else print "1";?></button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "5"; else print "2";?>);"><?php if ($numpad==0) print "5"; else print "2";?></button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "6"; else print "5";?>);"><?php if ($numpad==0) print "6"; else print "5";?></button>
 <button type="button" <?php if ($placeid==0) echo "disabled";?> class="calcbutton2" onclick="Validate('card');"><?php echo $langs->trans("PaymentTypeCB"); ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(0.10);">0.10</button>
-<button type="button" class="calcbutton" onclick="addreceived(0.20);">0.20</button>
-<button type="button" class="calcbutton" onclick="addreceived(0.50);">0.50</button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "1"; else print "0.10";?>);"><?php if ($numpad==0) print "1"; else print "0.10";?></button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "2"; else print "0.20";?>);"><?php if ($numpad==0) print "2"; else print "0.20";?></button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "3"; else print "0.50";?>);"><?php if ($numpad==0) print "3"; else print "0.50";?></button>
 <button type="button" <?php if ($placeid==0) echo "disabled";?> class="calcbutton2" onclick="Validate('cheque');"><?php echo $langs->trans("Cheque"); ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(0.01);">0.01</button>
-<button type="button" class="calcbutton" onclick="addreceived(0.02);">0.02</button>
-<button type="button" class="calcbutton" onclick="addreceived(0.05);">0.05</button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "0"; else print "0.01";?>);"><?php if ($numpad==0) print "0"; else print "0.01";?></button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "'000'"; else print "0.02";?>);"><?php if ($numpad==0) print "000"; else print "0.02";?></button>
+<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad==0) print "'.'"; else print "0.05";?>);"><?php if ($numpad==0) print "."; else print "0.05";?></button>
 <button type="button" class="calcbutton3" onclick="reset();"><span style='font-size: 150%;'>C</span></button>
 <button type="button" class="calcbutton3" onclick="parent.$.colorbox.close();"><span id="printtext"><?php echo $langs->trans("GoBack"); ?></span></button>
 </div>

--- a/htdocs/takepos/takepos.php
+++ b/htdocs/takepos/takepos.php
@@ -32,6 +32,7 @@ require '../main.inc.php';	// Load $user and permissions
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
 require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
 require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
 
 $place = GETPOST('place','int');
 if ($place=="") $place="0";
@@ -410,6 +411,14 @@ if ($conf->global->TAKEPOSCONNECTOR){
 	$menus[$r++]=array('title'=>$langs->trans("DOL_OPEN_DRAWER"),
 					'action'=>'OpenDrawer();');
 }
+
+$hookmanager->initHooks(array('takeposfrontend'));
+$reshook=$hookmanager->executeHooks('ActionButtons');
+if (!empty($reshook))
+	{
+		$menus[$r++]=$reshook;
+	}
+
 ?>
 <div style="position:absolute; top:1%; left:65.5%; height:37%; width:32.5%;">
 <?php


### PR DESCRIPTION
@hregis 
I have discussed with Regis about the payment pad for users of countries with large amounts currencies. Now in TakePOS you can choose a payment pad with bills and coins, or a numeric pad.
Additionally some developers have asked me to add a hook so they can develop plugins to add buttons with more features to TakePOS.