### PR TITLE
NEW : Group intervention list by rowid

### DIFF
--- a/htdocs/fichinter/list.php
+++ b/htdocs/fichinter/list.php
@@ -221,6 +221,10 @@ include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 $parameters=array();
 $reshook=$hookmanager->executeHooks('printFieldListWhere',$parameters);    // Note that $action and $object may have been modified by hook
 $sql.=$hookmanager->resPrint;
+
+if(!empty($conf->global->FICHINTER_GROUP_LIST))
+	$sql.=" GROUP BY f.rowid";
+
 $sql.= $db->order($sortfield,$sortorder);
 
 // Count total nb of records


### PR DESCRIPTION
Hi!

Group intervention by rowid only in list.php (keep details in card.php)


_This constant is different than FICHINTER_DISABLE_DETAILS_

- FICHINTER_DISABLE_DETAILS : disable details in the interventions
- FICHINTER_GROUP_LIST : group intervention by ref in the intervention list

see #7951

Tks

