### PR TITLE
FIX css in the case of not showing topmenu images.

### DIFF
--- a/htdocs/theme/eldy/style.css.php
+++ b/htdocs/theme/eldy/style.css.php
@@ -1542,7 +1542,7 @@ div#tmenu_tooltip {
 <?php } ?>
 }
 
-div.tmenusep {
+div.topmenuimage {
 <?php if ($disableimages) { ?>
 	display: none;
 <?php } ?>


### PR DESCRIPTION
This PR fixes the class name when disabling `topmenu` images.
