### PR TITLE
FIX Fix PHP warning "count(): Parameter must be an array..."

### DIFF
--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -251,7 +251,7 @@ class DolibarrApi
 	    //$tmp=preg_replace_all('/'.$regexstring.'/', '', $sqlfilters);
 	    $tmp=$sqlfilters;
 	    $ok=0;
-	    $i=0; $nb=count($tmp);
+	    $i=0; $nb=strlen($tmp);
 	    $counter=0;
 	    while ($i < $nb)
 	    {


### PR DESCRIPTION
Use strlen() instead of count() to remove the warning "count(): Parameter must be an array..." with PHP 7.2. This warning is included in the response sent by the REST API and this breaks the parsing of the JSON data contained in the response.