### PR TITLE
FIX positive values IN supplier credit notes creating diff on addline rounding

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1665,9 +1665,9 @@ class FactureFournisseur extends CommonInvoice
 			$this->line->rang=$rang;
 			$this->line->info_bits=$info_bits;
 			$this->line->total_ht=       (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_ht):$total_ht);  // For credit note and if qty is negative, total is negative
-			$this->line->total_tva=      $total_tva;
-			$this->line->total_localtax1=$total_localtax1;
-			$this->line->total_localtax2=$total_localtax2;
+			$this->line->total_tva=      (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_tva):$total_tva);
+			$this->line->total_localtax1=(($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_localtax1):$total_localtax1);
+			$this->line->total_localtax2=(($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_localtax2):$total_localtax2);
 			$this->line->total_ttc=      (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_ttc):$total_ttc);
 			$this->line->special_code=$this->special_code;
 			$this->line->fk_parent_line=$this->fk_parent_line;
@@ -1837,11 +1837,11 @@ class FactureFournisseur extends CommonInvoice
 	    $line->localtax2_tx = $txlocaltax2;
 		$line->localtax1_type = $localtaxes_type[0];
 		$line->localtax2_type = $localtaxes_type[2];
-	    $line->total_ht = $total_ht;
-	    $line->total_tva = $total_tva;
+		$line->total_ht = (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_ht):$total_ht);
+		$line->total_tva = (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_tva):$total_tva);
 	    $line->total_localtax1 = $total_localtax1;
 	    $line->total_localtax2 = $total_localtax2;
-	    $line->total_ttc = $total_ttc;
+	    $line->total_ttc = (($this->type==self::TYPE_CREDIT_NOTE||$qty<0)?-abs($total_ttc):$total_ttc);
 	    $line->fk_product = $idproduct;
 	    $line->product_type = $product_type;
 	    $line->info_bits = $info_bits;


### PR DESCRIPTION
# Fix Must have same behaviour as customer side
The supplier credit notes lines were inserted with a positive total_vat.
It create a diff in the update_price rounding so lines weren't inserted (if price not 0) and generated a white screen

