### PR TITLE
continue is ambiguous in outer loop for php 7.3

### DIFF
--- a/htdocs/includes/phpoffice/phpexcel/Classes/PHPExcel/Shared/OLE.php
+++ b/htdocs/includes/phpoffice/phpexcel/Classes/PHPExcel/Shared/OLE.php
@@ -287,7 +287,7 @@ class PHPExcel_Shared_OLE
 				$pps = new PHPExcel_Shared_OLE_PPS_File($name);
 				break;
 			default:
-				continue;
+				continue 2;
 			}
 			fseek($fh, 1, SEEK_CUR);
 			$pps->Type    = $type;


### PR DESCRIPTION
From php.net
Note: Note that unlike some other languages, the continue statement applies to switch and acts similar to break. If you have a switch inside a loop and wish to continue to the next iteration of the outer loop, use continue 2. 