### PR TITLE
FIX : Default sign out icon if not using Font Awesome 5

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3056,6 +3056,7 @@ function img_picto($titlealt, $picto, $moreatt = '', $pictoisfullpath = false, $
 				$marginleftonlyshort = 1;
 			}
 			elseif ($pictowithoutext == 'sign-out')     {
+                $fakey = 'fa-sign-out';
 			    $marginleftonlyshort=0;
 			    if (! empty($conf->global->MAIN_USE_FONT_AWESOME_5)) $fakey = 'fa-sign-out-alt';
 			}


### PR DESCRIPTION
# Fix default sign out icon
If we don't use Font Awesome 5, the sign out icon disappear 