### PR TITLE
fix the collate of the  numero_compte field in book keeping

### DIFF
--- a/htdocs/install/mysql/migration/repair.sql
+++ b/htdocs/install/mysql/migration/repair.sql
@@ -445,6 +445,7 @@ update llx_facture_fourn_det set product_type = 1 where product_type = 0 AND fk_
  
 UPDATE llx_accounting_bookkeeping set date_creation = tms where date_creation IS NULL;
 
+ALTER TABLE `llx_accounting_bookkeeping` CHANGE `numero_compte` `numero_compte` VARCHAR(20) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;
  
 -- UPDATE llx_contratdet set label = NULL WHERE label IS NOT NULL;
 -- UPDATE llx_facturedet_rec set label = NULL WHERE label IS NOT NULL;


### PR DESCRIPTION
# Problem 

In the accountancy detail: ***/compta/resultat/index.php?year_start=2016&modecompta=BOOKKEEPING

there is an issue with a query since the collate is not correct.

>Dolibarr a détecté une erreur technique.
You use an experimental or develop level of features, so please do NOT report any bugs, except if problem is confirmed moving option MAIN_FEATURES_LEVEL back to 0.
Voici les informations qui pourront aider au diagnostic (Vous pouvez fixer l'option $dolibarr_main_prod sur '1' pour supprimer quelques notifications):
Date: 20190212141723
Dolibarr: 9.0.1
Niveau de fonctionnalités: 1
PHP: 7.3.1
Server: Apache
OS: Linux webm274.media.ha.ovh.net 4.14.66-ovh-vps-grsec-zfs-classid #1 SMP Thu Aug 23 15:15:40 CEST 2018 x86_64
UserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36

Url sollicitée: /compta/resultat/index.php?year_start=2016&modecompta=BOOKKEEPING
Referer: https://membres.belgianballoonclub.be/compta/resultat/index.php?year_start=2016&modecompta=CREANCES-DETTES
Gestionnaire de menu: eldy_menu.php

Type gestionnaire de base de données: mysqli
Requête dernier accès en base en erreur: SELECT b.doc_ref, b.numero_compte, b.subledger_account, b.subledger_label, pcg_type, date_format(b.doc_date,'%Y-%m') as dm, sum(b.debit) as debit, sum(b.credit) as credit, sum(b.montant) as amount FROM llx_accounting_bookkeeping as b, llx_accounting_account as aa WHERE b.numero_compte = aa.account_number AND b.entity = 1 AND ( (pcg_type = 'EXPENSE') OR (pcg_type = 'INCOME')) AND fk_pcg_version = 'PCMN-BASE' AND b.doc_date >= '2016-01-01 00:00:00' AND b.doc_date <= '2019-12-31 23:59:59' GROUP BY b.doc_ref, b.numero_compte, b.subledger_account, b.subledger_label, pcg_type, dm
Code retour dernier accès en base en erreur: DB_ERROR_1267
Information sur le dernier accès en base en erreur: Illegal mix of collations (utf8_unicode_ci,IMPLICIT) and (utf8_general_ci,IMPLICIT) for operation '='

# Fix
fix the collate of the  numero_compte field in book keeping

    Some queries are failing since the collate is not the same everuwhere. I
    changed that one from unicode_ci to general_ci.

# Comment
I don't know if it's how you execute an update script so please let me know if it's not the correct place.