### PR TITLE
Move error on function dol_include_once() to LOG_WARNING

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -622,7 +622,7 @@ function dol_include_once($relpath, $classname = '')
 	$fullpath = dol_buildpath($relpath);
 
 	if (!file_exists($fullpath)) {
-		dol_syslog('functions::dol_include_once Tried to load unexisting file: '.$relpath, LOG_ERR);
+		dol_syslog('functions::dol_include_once Tried to load unexisting file: '.$relpath, LOG_WARNING);
 		return false;
 	}
 


### PR DESCRIPTION
We use LOG_ERR to count errors but Dolibarr still works with this error.

I propose to go to LOG_WARNING instead (Idea of Tanguy ;) )

Thanks