### PR TITLE
NEW: API Proposal, Orders, Invoices: Add contact details

### DIFF
--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -58,7 +58,7 @@ class Proposals extends DolibarrApi
 	 * Return an array with commercial proposal informations
 	 *
 	 * @param       int         $id           ID of commercial proposal
-	 * @param       int         $contact_list 0:Return array contains all properties, 1:Return array contains just id
+	 * @param       int         $contact_list 0: Returned array of contacts/addresses contains all properties, 1: Return array contains just id
 	 * @return 	array|mixed data without useless information
 	 *
 	 * @throws 	RestException

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -57,7 +57,7 @@ class Orders extends DolibarrApi
      * Return an array with order informations
      *
      * @param       int         $id            ID of order
-     * @param       int         $contact_list  0:Return array contains all properties, 1:Return array contains just id
+     * @param       int         $contact_list  0: Returned array of contacts/addresses contains all properties, 1: Return array contains just id
      * @return 	array|mixed data without useless information
 	 *
      * @throws 	RestException

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -56,12 +56,13 @@ class Orders extends DolibarrApi
      *
      * Return an array with order informations
      *
-     * @param       int         $id         ID of order
+     * @param       int         $id            ID of order
+     * @param       int         $contact_list  0:Return array contains all properties, 1:Return array contains just id
      * @return 	array|mixed data without useless information
 	 *
      * @throws 	RestException
      */
-    function get($id)
+    function get($id, $contact_list = 1)
     {
 		if(! DolibarrApiAccess::$user->rights->commande->lire) {
 			throw new RestException(401);
@@ -77,7 +78,7 @@ class Orders extends DolibarrApi
 		}
 
 		// Add external contacts ids
-		$this->commande->contacts_ids = $this->commande->liste_contact(-1, 'external', 1);
+		$this->commande->contacts_ids = $this->commande->liste_contact(-1, 'external', $contact_list);
 		$this->commande->fetchObjectLinked();
 		return $this->_cleanObjectDatas($this->commande);
 	}

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -55,12 +55,13 @@ class Invoices extends DolibarrApi
      *
      * Return an array with invoice informations
      *
-     * @param 	int 	$id ID of invoice
+     * @param 	int 	$id           ID of invoice
+     * @param   int     $contact_list 0:Return array contains all properties, 1:Return array contains just id
      * @return 	array|mixed data without useless information
      *
      * @throws 	RestException
      */
-	function get($id)
+	function get($id, $contact_list = 1)
 	{
 		if(! DolibarrApiAccess::$user->rights->facture->lire) {
 			throw new RestException(401);
@@ -82,7 +83,7 @@ class Invoices extends DolibarrApi
 		}
 
 		// Add external contacts ids
-		$this->invoice->contacts_ids = $this->invoice->liste_contact(-1, 'external', 1);
+		$this->invoice->contacts_ids = $this->invoice->liste_contact(-1, 'external', $contact_list);
 
 		$this->invoice->fetchObjectLinked();
 		return $this->_cleanObjectDatas($this->invoice);


### PR DESCRIPTION
# New Rest API Proposal, Orders, Invoices contact details

For object: Proposal, Orders and Invoices, i added a parameter contact_list for liste_contact function to their get function.
By default this parameter is 1, same value passing before this update.

Like this, we can know the type of contacts associated with these objects.

Also, i added add_contact and delete_contact route in the rest API for the Proposal object.

In my external app, i need to add contact in proposal from the rest API.

