### PR TITLE
FIX: Typo $parameters instead of $parameyers

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -1225,7 +1225,7 @@ else
 
     	// Other attributes
     	$cols = 3;
-    	$parameyers=array('socid'=>$socid);
+    	$parameters=array('socid'=>$socid);
     	include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
         $object->load_ref_elements();

--- a/htdocs/projet/tasks/comment.php
+++ b/htdocs/projet/tasks/comment.php
@@ -263,7 +263,7 @@ if ($id > 0 || ! empty($ref))
 
 		// Other attributes
 		$cols = 3;
-		$parameyers=array('socid'=>$socid);
+		$parameters=array('socid'=>$socid);
 		include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
 		print '</table>';

--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -545,7 +545,7 @@ if ($id > 0 || ! empty($ref))
 
 			// Other attributes
 			$cols = 3;
-			$parameyers=array('socid'=>$socid);
+			$parameters=array('socid'=>$socid);
 			include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 
 			print '</table>';


### PR DESCRIPTION
# Fix # Typo
Fixed Correct name of variable in multiple files : **$parameters** instead of _$parameyers_
