### PR TITLE
[FIX] ORDER BY before custom filters for where

### DIFF
--- a/htdocs/core/modules/modAgenda.class.php
+++ b/htdocs/core/modules/modAgenda.class.php
@@ -418,6 +418,6 @@ class modAgenda extends DolibarrModules
 		$this->export_sql_end[$r] .=' WHERE ac.entity IN ('.getEntity('agenda').')';
 		if (empty($user->rights->societe->client->voir)) $this->export_sql_end[$r] .=' AND (sc.fk_user = '.(empty($user)?0:$user->id).' OR ac.fk_soc IS NULL)';
 		if (empty($user->rights->agenda->allactions->read)) $this->export_sql_end[$r] .=' AND acr.fk_element = '.(empty($user)?0:$user->id);
-		$this->export_sql_end[$r] .=' ORDER BY ac.datep';
+		$this->export_sql_order[$r] .=' ORDER BY ac.datep';
 	}
 }


### PR DESCRIPTION
When filtering data " and cac.libelle='<id>'" would be appended after ORDER BY