### PR TITLE
NEW add hidden option MAIN_DOC_UPLOAD_NOT_RENAME_BY_DEFAULT

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -72,7 +72,7 @@ class FormFile
 	 *  @param	string		$options		Add an option column
 	 *  @param	integer		$useajax		Use fileupload ajax (0=never, 1=if enabled, 2=always whatever is option).
      *                                      Deprecated 2 should never be used and if 1 is used, option should no be enabled.
-	 *  @param	string		$dodocmask	Mask to use to define output filename. For example 'XXXXX-__YYYYMMDD__-__file__'
+	 *  @param	string		$savingdocmask	Mask to use to define output filename. For example 'XXXXX-__YYYYMMDD__-__file__'
 	 *  @param	integer		$linkfiles		1=Also add form to link files, 0=Do not show form to link files
 	 *  @param	string		$htmlname		Name and id of HTML form ('formuserfile' by default, 'formuserfileecm' when used to upload a file in ECM)
 	 *  @param	string		$accept			Specifies the types of files accepted (This is not a security check but an user interface facility. eg '.pdf,image/*' or '.png,.jpg' or 'video/*')

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -176,7 +176,13 @@ class FormFile
 			if ($savingdocmask)
             {
             	//add a global variable for disable the auto renaming on upload
-                if($conf->global->MAIN_DOC_UPLOAD_NOT_RENAME_BY_DEFAULT==1){$rename='';}else{$rename='checked';}
+                if (! empty($conf->global->MAIN_DOC_UPLOAD_NOT_RENAME_BY_DEFAULT))
+                {
+                    $rename='';
+                }
+                else {
+                    $rename='checked';
+                }
                 
                 $out .= '<tr>';
    	            if (! empty($options)) $out .= '<td>'.$options.'</td>';

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -72,7 +72,7 @@ class FormFile
 	 *  @param	string		$options		Add an option column
 	 *  @param	integer		$useajax		Use fileupload ajax (0=never, 1=if enabled, 2=always whatever is option).
      *                                      Deprecated 2 should never be used and if 1 is used, option should no be enabled.
-	 *  @param	string		$savingdocmask	Mask to use to define output filename. For example 'XXXXX-__YYYYMMDD__-__file__'
+	 *  @param	string		$dodocmask	Mask to use to define output filename. For example 'XXXXX-__YYYYMMDD__-__file__'
 	 *  @param	integer		$linkfiles		1=Also add form to link files, 0=Do not show form to link files
 	 *  @param	string		$htmlname		Name and id of HTML form ('formuserfile' by default, 'formuserfileecm' when used to upload a file in ECM)
 	 *  @param	string		$accept			Specifies the types of files accepted (This is not a security check but an user interface facility. eg '.pdf,image/*' or '.png,.jpg' or 'video/*')
@@ -174,14 +174,17 @@ class FormFile
 			$out .= "</td></tr>";
 
 			if ($savingdocmask)
-			{
-				$out .= '<tr>';
-   				if (! empty($options)) $out .= '<td>'.$options.'</td>';
-				$out .= '<td class="nowrap valignmiddle">';
-				$out .= '<input type="checkbox" checked class="savingdocmask" name="savingdocmask" value="'.dol_escape_js($savingdocmask).'"> '.$langs->trans("SaveUploadedFileWithMask", preg_replace('/__file__/', $langs->transnoentitiesnoconv("OriginFileName"), $savingdocmask), $langs->transnoentitiesnoconv("OriginFileName"));
-				$out .= '</td>';
-				$out .= '</tr>';
-			}
+            {
+            	//add a global variable for disable the auto renaming on upload
+                if($conf->global->MAIN_DOC_UPLOAD_NOT_RENAME_BY_DEFAULT==1){$rename='';}else{$rename='checked';}
+                
+                $out .= '<tr>';
+   	            if (! empty($options)) $out .= '<td>'.$options.'</td>';
+	            $out .= '<td valign="middle" class="nowrap">';
+				$out .= '<input type="checkbox" '.$rename.' class="savingdocmask" name="savingdocmask" value="'.dol_escape_js($savingdocmask).'"> '.$langs->trans("SaveUploadedFileWithMask", preg_replace('/__file__/',$langs->transnoentitiesnoconv("OriginFileName"),$savingdocmask), $langs->transnoentitiesnoconv("OriginFileName"));
+            	$out .= '</td>';
+            	$out .= '</tr>';
+            }
 
 			$out .= "</table>";
 


### PR DESCRIPTION
# New add MAIN_DOC_UPLOAD_NOT_RENAME_BY_DEFAULT
add a global variable for disable the auto renaming on upload file
corresponds to the request of this post : https://www.dolibarr.fr/forum/12-howto--aide/55094-fichiers-joints-decocher-la-case-sauver-sous#107392
