### PR TITLE
NEW Initialising hook system for FactureRec creation

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -1008,6 +1008,7 @@ class FactureRec extends CommonInvoice
 
 		$error=0;
 		$nb_create=0;
+		$hookmanager->initHooks(array('creationOfRecurringInvoices'));
 
 		// Load translation files required by the page
 		$langs->loadLangs(array("main","bills"));


### PR DESCRIPTION
Quick pull-request to add an `initHooks()` call to recurring invoice creation. Without it, the hooks list of the hookmanager is empty when calling `beforeCreationOfRecurringInvoices` and `afterCreationOfRecurringInvoice` hooks (probably overlooked while doing #10154).