### PR TITLE
Add Order Notes to TakePOS

### DIFF
--- a/htdocs/langs/en_US/cashdesk.lang
+++ b/htdocs/langs/en_US/cashdesk.lang
@@ -55,3 +55,4 @@ Numberspad=Numbers Pad
 BillsCoinsPad=Bills and Coins Pad
 DolistorePosCategory=TakePOS modules and other POS solutions for Dolibarr
 TakeposNeedsCategories=TakePOS needs product categories to work
+OrderNotes=Order Notes

--- a/htdocs/takepos/admin/setup.php
+++ b/htdocs/takepos/admin/setup.php
@@ -60,9 +60,16 @@ if (GETPOST('action', 'alpha') == 'set')
 	$res = dolibarr_set_const($db, "TAKEPOS_BAR_RESTAURANT", GETPOST('TAKEPOS_BAR_RESTAURANT', 'alpha'), 'chaine', 0, '', $conf->entity);
     $res = dolibarr_set_const($db, "TAKEPOS_PRINT_SERVER", GETPOST('TAKEPOS_PRINT_SERVER', 'alpha'), 'chaine', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "TAKEPOS_ORDER_PRINTERS", GETPOST('TAKEPOS_ORDER_PRINTERS', 'alpha'), 'chaine', 0, '', $conf->entity);
+	$res = dolibarr_set_const($db, "TAKEPOS_ORDER_NOTES", GETPOST('TAKEPOS_ORDER_NOTES', 'alpha'), 'chaine', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "TAKEPOS_HEADER", GETPOST('TAKEPOS_HEADER', 'alpha'), 'chaine', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "TAKEPOS_FOOTER", GETPOST('TAKEPOS_FOOTER', 'alpha'), 'chaine', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "TAKEPOS_NUMPAD", GETPOST('TAKEPOS_NUMPAD', 'alpha'), 'chaine', 0, '', $conf->entity);
+	
+	if ($conf->global->TAKEPOS_ORDER_NOTES==1)
+	{
+		$extrafields = new ExtraFields($db);
+		$extrafields->addExtraField('order_notes', 'Order notes', 'varchar', 0, 255, 'facturedet', 0, 0, '', '', 0, '', 0, 1);
+	}
 
 	dol_syslog("admin/cashdesk: level ".GETPOST('level', 'alpha'));
 
@@ -141,6 +148,12 @@ if ($conf->global->TAKEPOS_BAR_RESTAURANT && $conf->global->TAKEPOSCONNECTOR){
 	print $langs->trans("OrderPrinters").' (<a href="orderprinters.php?leftmenu=setup">'.$langs->trans("Setup").'</a>)';
 	print '<td colspan="2">';
 	print $form->selectyesno("TAKEPOS_ORDER_PRINTERS", $conf->global->TAKEPOS_ORDER_PRINTERS, 1);
+	print '</td></tr>';
+	
+	print '<tr class="oddeven value"><td>';
+	print $langs->trans("OrderNotes");
+	print '<td colspan="2">';
+	print $form->selectyesno("TAKEPOS_ORDER_NOTES", $conf->global->TAKEPOS_ORDER_NOTES, 1);
 	print '</td></tr>';
 }
 

--- a/htdocs/takepos/freezone.php
+++ b/htdocs/takepos/freezone.php
@@ -30,7 +30,8 @@ require '../main.inc.php';	// Load $user and permissions
 $langs->loadLangs(array("bills", "cashdesk"));
 
 $place = GETPOST('place', 'int');
-
+$idline = GETPOST('idline', 'int');
+$action = GETPOST('action');
 
 /*
  * View
@@ -41,16 +42,23 @@ top_htmlhead($head, $title, $disablejs, $disablehead, $arrayofjs, $arrayofcss);
 ?>
 <script>
 function Save(){
-	$.get( "invoice.php", { action: "freezone", place: "<?php echo $place;?>", desc:$('#desc').val(), number:$('#price').val()} );
+	$.get( "invoice.php", { action: "<?php echo $action;?>", place: "<?php echo $place;?>", desc:$('#desc').val(), number:$('#number').val()} );
 	parent.$.colorbox.close();
 }
+
+$( document ).ready(function() {
+    $('#desc').focus()
+});
 </script>
 </head>
 <body>
 <br>
 <center>
 <input type="text" id="desc" name="desc" style="width:40%;font-size: 200%;" placeholder="<?php echo $langs->trans('Description');?>">
-<input type="text" id="price" name="price" style="width:15%;font-size: 200%;" placeholder="<?php echo $langs->trans('Price');?>">
+<?php
+if ($action=="freezone") echo '<input type="text" id="number" name="number" style="width:15%;font-size: 200%;" placeholder="'.$langs->trans('Price').'">';
+if ($action=="addnote") echo '<input type="hidden" id="number" name="number" value="'.$idline.'">';
+?>
 <input type="hidden" name="place" value="<?php echo $place;?>">
 <input type="button" style="width:15%;font-size: 200%;" value="OK" onclick="Save();">
 </center>

--- a/htdocs/takepos/genimg/index.php
+++ b/htdocs/takepos/genimg/index.php
@@ -38,9 +38,6 @@ $query= GETPOST('query', 'alpha');
  * View
  */
 
-header('Cache-Control: max-age=604800, public, must-revalidate');
-header('Pragma: cache');
-
 if ($query=="cat")
 {
 	require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
@@ -63,7 +60,7 @@ if ($query=="cat")
 		{
 			$filename=$obj['photo'];
 		}
-		$file=DOL_URL_ROOT.'/viewimage.php?modulepart=category&entity='.$object->entity.'&file='.urlencode($pdir.$filename);
+		$file=DOL_URL_ROOT.'/viewimage.php?cache=1&modulepart=category&entity='.$object->entity.'&file='.urlencode($pdir.$filename);
 		header('Location: '.$file);
 		exit;
 	}
@@ -80,7 +77,7 @@ elseif ($query=="pro")
 	preg_match('@src="([^"]+)"@', $image, $match);
 	$file = array_pop($match);
 	if ($file=="") header('Location: ../../public/theme/common/nophoto.png');
-	else header('Location: '.$file);
+	else header('Location: '.$file.'&cache=1');
 }
 else
 {

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -120,6 +120,18 @@ if ($action == "freezone") {
     $invoice->fetch($placeid);
 }
 
+if ($action == "addnote") {
+    foreach($invoice->lines as $line)
+    {
+        if ($line->id == $number)
+		{
+			$line->array_options['order_notes'] = $desc;
+			$result = $invoice->updateline($line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit);
+        }
+    }
+    $invoice->fetch($placeid);
+}
+
 if ($action == "deleteline") {
     if ($idline > 0 and $placeid > 0) { //If exist invoice and line, to avoid errors if deleted from other device or no line selected
         $invoice->deleteline($idline);
@@ -185,7 +197,9 @@ if ($action == "order" and $placeid != 0) {
         if ($count > 0) {
             $sql = "UPDATE " . MAIN_DB_PREFIX . "facturedet set special_code='3' where rowid=$line->rowid";
             $db->query($sql);
-            $order_receipt_printer1.= '<tr>' . $line->product_label . '<td align="right">' . $line->qty . '</td></tr>';
+            $order_receipt_printer1.= '<tr>' . $line->product_label . '<td align="right">' . $line->qty;
+			if (!empty($line->array_options['options_order_notes'])) $order_receipt_printer1.="<br>(".$line->array_options['options_order_notes'].")";
+			$order_receipt_printer1.='</td></tr>';
         }
     }
 
@@ -200,7 +214,9 @@ if ($action == "order" and $placeid != 0) {
         if ($count > 0) {
             $sql = "UPDATE " . MAIN_DB_PREFIX . "facturedet set special_code='3' where rowid=$line->rowid";
             $db->query($sql);
-            $order_receipt_printer2.= '<tr>' . $line->product_label . '<td align="right">' . $line->qty . '</td></tr>';
+            $order_receipt_printer2.= '<tr>' . $line->product_label . '<td align="right">' . $line->qty;
+			if (!empty($line->array_options['options_order_notes'])) $order_receipt_printer2.="<br>(".$line->array_options['options_order_notes'].")";
+			$order_receipt_printer2.='</td></tr>';
         }
     }
 
@@ -325,7 +341,9 @@ if ($placeid > 0) {
             print ' order';
         }
         print '" id="' . $line->rowid . '">';
-        print '<td align="left">' . $line->product_label . $line->desc . '</td>';
+        print '<td align="left">' . $line->product_label . $line->desc;
+		if (!empty($line->array_options['options_order_notes'])) echo "<br>(".$line->array_options['options_order_notes'].")";
+		print '</td>';
         print '<td align="right">' . $line->qty . '</td>';
         print '<td align="right">' . price($line->total_ttc) . '</td>';
         print '</tr>';

--- a/htdocs/takepos/takepos.php
+++ b/htdocs/takepos/takepos.php
@@ -246,7 +246,11 @@ function Floors(){
 }
 
 function FreeZone(){
-	$.colorbox({href:"freezone.php?place="+place, onClosed: function () { Refresh(); },width:"80%", height:"30%", transition:"none", iframe:"true", title:"<?php echo $langs->trans("FreeZone");?>"});
+	$.colorbox({href:"freezone.php?action=freezone&place="+place, onClosed: function () { Refresh(); },width:"80%", height:"30%", transition:"none", iframe:"true", title:"<?php echo $langs->trans("FreeZone");?>"});
+}
+
+function TakeposOrderNotes(){
+	$.colorbox({href:"freezone.php?action=addnote&place="+place+"&idline="+selectedline, onClosed: function () { Refresh(); },width:"80%", height:"30%", transition:"none", iframe:"true", title:"<?php echo $langs->trans("OrderNotes");?>"});
 }
 
 function Refresh(){
@@ -456,6 +460,10 @@ if($conf->global->TAKEPOS_BAR_RESTAURANT){
 	if ($conf->global->TAKEPOS_BAR_RESTAURANT){
 		if ($conf->global->TAKEPOSCONNECTOR) $menus[$r++]=array('title'=>$langs->trans("Receipt"),'action'=>'TakeposPrinting(placeid);');
 		else $menus[$r++]=array('title'=>$langs->trans("Receipt"),'action'=>'Print(placeid);');
+	}
+	if ($conf->global->TAKEPOSCONNECTOR && $conf->global->TAKEPOS_ORDER_NOTES==1){
+		$menus[$r++]=array('title'=>$langs->trans("OrderNotes"),
+		'action'=>'TakeposOrderNotes();');
 	}
 }
 


### PR DESCRIPTION
The order notes are essential for restaurants so they can print the notes in the kitchen printer.