### PR TITLE
Fix default contact id for update and clone actions in event card

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -160,6 +160,10 @@ if ($action == 'confirm_clone' && $confirm == 'yes')
 	{
 		if ($id > 0) {
 			$object->fetch($id);
+            if (!empty($object->socpeopleassigned)) {
+                reset($object->socpeopleassigned);
+                $object->contactid = key($object->socpeopleassigned);
+            }
 			$result = $object->createFromClone(GETPOST('fk_userowner'), GETPOST('socid'));
 			if ($result > 0) {
 				header("Location: " . $_SERVER['PHP_SELF'] . '?id=' . $result);
@@ -431,6 +435,10 @@ if ($action == 'update')
 		$object->socpeopleassigned = array();
 		foreach ($socpeopleassigned as $cid) $object->socpeopleassigned[$cid] = array('id' => $cid);
 		$object->contactid   = GETPOST("contactid", 'int');
+        if (empty($object->contactid) && !empty($object->socpeopleassigned)) {
+            reset($object->socpeopleassigned);
+            $object->contactid = key($object->socpeopleassigned);
+        }
 		$object->fk_project  = GETPOST("projectid", 'int');
 		$object->note        = GETPOST("note", "none");	// deprecated
 		$object->note_private= GETPOST("note", "none");

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -270,7 +270,7 @@ class ActionComm extends CommonObject
         	$this->userassigned[$tmpid]=array('id'=>$tmpid, 'transparency'=>$this->transparency);
         }
 
-        if (is_object($this->contact) && isset($this->contact->id) && $this->contact->id > 0 && ! ($this->contactid > 0)) $this->contactid = $this->contact->id;		// For backward compatibility. Using this->contact->xx is deprecated
+        //if (is_object($this->contact) && isset($this->contact->id) && $this->contact->id > 0 && ! ($this->contactid > 0)) $this->contactid = $this->contact->id;		// For backward compatibility. Using this->contact->xx is deprecated
 
 
         $userownerid=$this->userownerid;
@@ -656,7 +656,7 @@ class ActionComm extends CommonObject
                 $this->fk_project			= $obj->fk_project;		// To have fetch_project method working
 
                 $this->societe->id			= $obj->fk_soc;			// deprecated
-                $this->contact->id			= $obj->fk_contact;		// deprecated
+                //$this->contact->id			= $obj->fk_contact;		// deprecated
 
                 $this->fk_element			= $obj->elementid;
                 $this->elementid			= $obj->elementid;
@@ -867,7 +867,7 @@ class ActionComm extends CommonObject
         }
 
         $socid=($this->socid?$this->socid:((isset($this->societe->id) && $this->societe->id > 0) ? $this->societe->id : 0));
-        $contactid=($this->contactid?$this->contactid:((isset($this->contact->id) && $this->contact->id > 0) ? $this->contact->id : 0));
+        $contactid=($this->contactid?$this->contactid:0);
 		$userownerid=($this->userownerid?$this->userownerid:0);
 		$userdoneid=($this->userdoneid?$this->userdoneid:0);
 


### PR DESCRIPTION
Fix default contact id for update and clone actions in event card (take only first person assigned by default)
- remove deprecated contact object in fetch, create and update methods to avoid from having old values when we want to update or clone an event