### PR TITLE
FIX : when we create deposit with multi tva, we mustn't add line if a…

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1218,8 +1218,7 @@ if (empty($reshook))
 
 							foreach ($amountdeposit as $tva => $amount)
 							{
-
-								if(empty($amount)) continue;
+								if (empty($amount)) continue;
 
 								$arraylist = array('amount' => 'FixAmount','variable' => 'VarAmount');
 								$descline = $langs->trans('Deposit');

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1218,6 +1218,9 @@ if (empty($reshook))
 
 							foreach ($amountdeposit as $tva => $amount)
 							{
+
+								if(empty($amount)) continue;
+
 								$arraylist = array('amount' => 'FixAmount','variable' => 'VarAmount');
 								$descline = $langs->trans('Deposit');
 								$descline.= ' - '.$langs->trans($arraylist[$typeamount]);


### PR DESCRIPTION
…mount = 0 (example when we have a 100% reduc on one of origin invoice line)