### PR TITLE
Fix: remove the not null violation in payment_various

### DIFF
--- a/htdocs/install/mysql/tables/llx_payment_various.sql
+++ b/htdocs/install/mysql/tables/llx_payment_various.sql
@@ -19,7 +19,6 @@
 create table llx_payment_various
 (
   rowid                 integer AUTO_INCREMENT PRIMARY KEY,
-  ref                   varchar(30) NOT NULL,       -- payment reference number
   num_payment           varchar(50),				-- num cheque or other
   label                 varchar(255),
   tms                   timestamp,


### PR DESCRIPTION
The column `ref` does not seem to have any reason to be in the database. We can see in [paymentvarious.class.php](https://github.com/Dolibarr/dolibarr/blob/fa060f97b183a52901ad75c6107cd8c5ea449c5c/htdocs/compta/bank/class/paymentvarious.class.php#L399) that this attribute takes the value of the column `rowid`.

In addition, [when inserting](https://github.com/Dolibarr/dolibarr/blob/fa060f97b183a52901ad75c6107cd8c5ea449c5c/htdocs/compta/bank/class/paymentvarious.class.php#L359), since the value of this column is not set and is configured with a NOT NULL constraint, it will raise a not null violation.