### PR TITLE
Fix a previous commit that causes TakePOS not work

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -87,11 +87,12 @@ if (($action=="addline" || $action=="freezone") && $placeid == 0)
 {
 	$invoice->socid = $conf->global->CASHDESK_ID_THIRDPARTY;
 	$invoice->date = dol_now();
-	$invoice->ref = "(PROV-POS-".$place.")";
 	$invoice->module_source = 'takepos';
 	$invoice->pos_source = (string) $place;
 
 	$placeid = $invoice->create($user);
+	$sql="UPDATE ".MAIN_DB_PREFIX."facture set ref='(PROV-POS-".$place.")' where rowid=".$placeid;
+	$db->query($sql);
 }
 
 if ($action == "addline") {


### PR DESCRIPTION
@hregis 
In a previous commit the command to change 'ref' has been changed. And now TakePOS don't work.

In Dolibarr the next command not update ref on draft invoice:
$invoice->ref = "(PROV-POS-".$place.")";
So I return to the previous command:
$sql="UPDATE ".MAIN_DB_PREFIX."facture set ref='(PROV-POS-".$place.")' where rowid=".$placeid;
