### PR TITLE
#9480 Password link broken if login contains space

### DIFF
--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -1975,7 +1975,7 @@ class User extends CommonObject
 		}
 		else
 		{
-			$url = $urlwithroot.'/user/passwordforgotten.php?action=validatenewpassword&username='.$this->login."&passwordhash=".dol_hash($password);
+			$url = $urlwithroot.'/user/passwordforgotten.php?action=validatenewpassword&username='.urlencode($this->login)."&passwordhash=".dol_hash($password);
 
 			$mesg.= $outputlangs->transnoentitiesnoconv("RequestToResetPasswordReceived")."\n";
 			$mesg.= $outputlangs->transnoentitiesnoconv("NewKeyWillBe")." :\n\n";


### PR DESCRIPTION
# Bug

When an user login contains spaces, the password reset link is broken.

## Environment
- **Version**: 8.0.1

## Expected and actual behavior

The "reset password" link should escape the extraneous characters.

## Steps to reproduce the behavior

 * Create a user with its login containing a space, for instance "test space".
 * Ask a password reset on the "password forgotten ?" form
 * The link is diplayed as https://SITE:443/user/passwordforgotten.php?action=validatenewpassword&username=test space&passwordhash=xxxx
instead of https://SITE:443/user/passwordforgotten.php?action=validatenewpassword&username=test+space&passwordhash=xxxx
