### PR TITLE
FIX missing hook completeTabsHead in margins module

### DIFF
--- a/htdocs/margin/lib/margins.lib.php
+++ b/htdocs/margin/lib/margins.lib.php
@@ -96,6 +96,9 @@ function marges_prepare_head()
 		$head[$h][2] = 'checkMargins';
 	}
 
+	complete_head_from_modules($conf,$langs,null,$head,$h,'margins','remove');
+	complete_head_from_modules($conf,$langs,null,$head,$h,'margins');
+
 	return $head;
 }
 


### PR DESCRIPTION
# Fix missing hook completeTabsHead
Added "complete_head_from_modules" function to be able to add custom tabs