### PR TITLE
New categories options in sellist and chbxlist extrafields

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -984,11 +984,11 @@ class Categorie extends CommonObject
 	 *                fullpath = chemin complet compose des id
 	 *
 	 * @param   string                  $type                   Type of categories ('customer', 'supplier', 'contact', 'product', 'member') or (0, 1, 2, ...).
-	 * @param   int|string|array    	$markafterid            Removed all categories including the leaf $markafterid in category tree (exclude) or Keep only of category is inside the leaf starting with this id.
+	 * @param   int|string|array    	$markafterid            Keep only or removed all categories including the leaf $markafterid in category tree (exclude) or Keep only of category is inside the leaf starting with this id.
      *                                                          $markafterid can be an :    int (id of category)
      *                                                                                      string (categories ids seprated by comma)
      *                                                                                      array (list of categories ids)
-     * @param   int                     $include                [=0] Exlude or 1=Include
+     * @param   int                     $include                [=0] Removed or 1=Keep only
 	 * @return  array|int               Array of categories. this->cats and this->motherof are set, -1 on error
 	 */
 	public function get_full_arbo($type, $markafterid = 0, $include = 0)

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1180,6 +1180,8 @@ class ExtraFields
 				// 2 : key fields name (if differ of rowid)
 				// 3 : key field parent (for dependent lists)
 				// 4 : where clause filter on column or table extrafield, syntax field='value' or extra.field=value
+                // 5 : id category type
+                // 6 : ids categories list separated by comma for category root
 				$keyList=(empty($InfoFieldList[2])?'rowid':$InfoFieldList[2].' as rowid');
 
 
@@ -1198,136 +1200,130 @@ class ExtraFields
 					$keyList.= ', '.$parentField;
 				}
 
-				$fields_label = explode('|', $InfoFieldList[1]);
-				if (is_array($fields_label))
-				{
-					$keyList .=', ';
-					$keyList .= implode(', ', $fields_label);
-				}
+                $filter_categorie = false;
+                if (count($InfoFieldList) > 5) {
+                    if ($InfoFieldList[0] == 'categorie') {
+                        $filter_categorie = true;
+                    }
+                }
 
-				$sqlwhere='';
-				$sql = 'SELECT '.$keyList;
-				$sql.= ' FROM '.MAIN_DB_PREFIX .$InfoFieldList[0];
-				if (!empty($InfoFieldList[4]))
-				{
-				    // can use curent entity filter
-				    if (strpos($InfoFieldList[4], '$ENTITY$')!==false) {
-				        $InfoFieldList[4]=str_replace('$ENTITY$', $conf->entity, $InfoFieldList[4]);
-				    }
-					// can use SELECT request
-					if (strpos($InfoFieldList[4], '$SEL$')!==false) {
-						$InfoFieldList[4]=str_replace('$SEL$', 'SELECT', $InfoFieldList[4]);
-					}
+                if ($filter_categorie === false) {
+                    $fields_label = explode('|', $InfoFieldList[1]);
+                    if (is_array($fields_label)) {
+                        $keyList .= ', ';
+                        $keyList .= implode(', ', $fields_label);
+                    }
 
-					// current object id can be use into filter
-					if (strpos($InfoFieldList[4], '$ID$')!==false && !empty($objectid)) {
-						$InfoFieldList[4]=str_replace('$ID$', $objectid, $InfoFieldList[4]);
-					} else {
-						$InfoFieldList[4]=str_replace('$ID$', '0', $InfoFieldList[4]);
-					}
-					//We have to join on extrafield table
-					if (strpos($InfoFieldList[4], 'extra')!==false)
-					{
-						$sql.= ' as main, '.MAIN_DB_PREFIX .$InfoFieldList[0].'_extrafields as extra';
-						$sqlwhere.= ' WHERE extra.fk_object=main.'.$InfoFieldList[2]. ' AND '.$InfoFieldList[4];
-					}
-					else
-					{
-						$sqlwhere.= ' WHERE '.$InfoFieldList[4];
-					}
-				}
-				else
-				{
-					$sqlwhere.= ' WHERE 1=1';
-				}
-				// Some tables may have field, some other not. For the moment we disable it.
-				if (in_array($InfoFieldList[0], array('tablewithentity')))
-				{
-					$sqlwhere.= ' AND entity = '.$conf->entity;
-				}
-				$sql.=$sqlwhere;
-				//print $sql;
+                    $sqlwhere = '';
+                    $sql = 'SELECT ' . $keyList;
+                    $sql .= ' FROM ' . MAIN_DB_PREFIX . $InfoFieldList[0];
+                    if (!empty($InfoFieldList[4])) {
+                        // can use curent entity filter
+                        if (strpos($InfoFieldList[4], '$ENTITY$') !== false) {
+                            $InfoFieldList[4] = str_replace('$ENTITY$', $conf->entity, $InfoFieldList[4]);
+                        }
+                        // can use SELECT request
+                        if (strpos($InfoFieldList[4], '$SEL$') !== false) {
+                            $InfoFieldList[4] = str_replace('$SEL$', 'SELECT', $InfoFieldList[4]);
+                        }
 
-				$sql .= ' ORDER BY ' . implode(', ', $fields_label);
+                        // current object id can be use into filter
+                        if (strpos($InfoFieldList[4], '$ID$') !== false && !empty($objectid)) {
+                            $InfoFieldList[4] = str_replace('$ID$', $objectid, $InfoFieldList[4]);
+                        } else {
+                            $InfoFieldList[4] = str_replace('$ID$', '0', $InfoFieldList[4]);
+                        }
+                        //We have to join on extrafield table
+                        if (strpos($InfoFieldList[4], 'extra') !== false) {
+                            $sql .= ' as main, ' . MAIN_DB_PREFIX . $InfoFieldList[0] . '_extrafields as extra';
+                            $sqlwhere .= ' WHERE extra.fk_object=main.' . $InfoFieldList[2] . ' AND ' . $InfoFieldList[4];
+                        } else {
+                            $sqlwhere .= ' WHERE ' . $InfoFieldList[4];
+                        }
+                    } else {
+                        $sqlwhere .= ' WHERE 1=1';
+                    }
+                    // Some tables may have field, some other not. For the moment we disable it.
+                    if (in_array($InfoFieldList[0], array('tablewithentity'))) {
+                        $sqlwhere .= ' AND entity = ' . $conf->entity;
+                    }
+                    $sql .= $sqlwhere;
+                    //print $sql;
 
-				dol_syslog(get_class($this).'::showInputField type=sellist', LOG_DEBUG);
-				$resql = $this->db->query($sql);
-				if ($resql)
-				{
-					$out.='<option value="0">&nbsp;</option>';
-					$num = $this->db->num_rows($resql);
-					$i = 0;
-					while ($i < $num)
-					{
-						$labeltoshow='';
-						$obj = $this->db->fetch_object($resql);
+                    $sql .= ' ORDER BY ' . implode(', ', $fields_label);
 
-						// Several field into label (eq table:code|libelle:rowid)
-						$notrans = false;
-						$fields_label = explode('|', $InfoFieldList[1]);
-						if (is_array($fields_label))
-						{
-							$notrans = true;
-							foreach ($fields_label as $field_toshow)
-							{
-								$labeltoshow.= $obj->$field_toshow.' ';
-							}
-						}
-						else
-						{
-							$labeltoshow=$obj->{$InfoFieldList[1]};
-						}
-						$labeltoshow=dol_trunc($labeltoshow, 45);
+                    dol_syslog(get_class($this) . '::showInputField type=sellist', LOG_DEBUG);
+                    $resql = $this->db->query($sql);
+                    if ($resql) {
+                        $out .= '<option value="0">&nbsp;</option>';
+                        $num = $this->db->num_rows($resql);
+                        $i = 0;
+                        while ($i < $num) {
+                            $labeltoshow = '';
+                            $obj = $this->db->fetch_object($resql);
 
-						if ($value == $obj->rowid)
-						{
-							foreach ($fields_label as $field_toshow)
-							{
-								$translabel=$langs->trans($obj->$field_toshow);
-								if ($translabel!=$obj->$field_toshow) {
-									$labeltoshow=dol_trunc($translabel, 18).' ';
-								}else {
-									$labeltoshow=dol_trunc($obj->$field_toshow, 18).' ';
-								}
-							}
-							$out.='<option value="'.$obj->rowid.'" selected>'.$labeltoshow.'</option>';
-						}
-						else
-						{
-							if (! $notrans)
-							{
-								$translabel=$langs->trans($obj->{$InfoFieldList[1]});
-								if ($translabel!=$obj->{$InfoFieldList[1]}) {
-									$labeltoshow=dol_trunc($translabel, 18);
-								}
-								else {
-									$labeltoshow=dol_trunc($obj->{$InfoFieldList[1]}, 18);
-								}
-							}
-							if (empty($labeltoshow)) $labeltoshow='(not defined)';
-							if ($value==$obj->rowid)
-							{
-								$out.='<option value="'.$obj->rowid.'" selected>'.$labeltoshow.'</option>';
-							}
+                            // Several field into label (eq table:code|libelle:rowid)
+                            $notrans = false;
+                            $fields_label = explode('|', $InfoFieldList[1]);
+                            if (is_array($fields_label)) {
+                                $notrans = true;
+                                foreach ($fields_label as $field_toshow) {
+                                    $labeltoshow .= $obj->$field_toshow . ' ';
+                                }
+                            } else {
+                                $labeltoshow = $obj->{$InfoFieldList[1]};
+                            }
+                            $labeltoshow = dol_trunc($labeltoshow, 45);
 
-							if (!empty($InfoFieldList[3]) && $parentField)
-							{
-								$parent = $parentName.':'.$obj->{$parentField};
-							}
+                            if ($value == $obj->rowid) {
+                                foreach ($fields_label as $field_toshow) {
+                                    $translabel = $langs->trans($obj->$field_toshow);
+                                    if ($translabel != $obj->$field_toshow) {
+                                        $labeltoshow = dol_trunc($translabel, 18) . ' ';
+                                    } else {
+                                        $labeltoshow = dol_trunc($obj->$field_toshow, 18) . ' ';
+                                    }
+                                }
+                                $out .= '<option value="' . $obj->rowid . '" selected>' . $labeltoshow . '</option>';
+                            } else {
+                                if (!$notrans) {
+                                    $translabel = $langs->trans($obj->{$InfoFieldList[1]});
+                                    if ($translabel != $obj->{$InfoFieldList[1]}) {
+                                        $labeltoshow = dol_trunc($translabel, 18);
+                                    } else {
+                                        $labeltoshow = dol_trunc($obj->{$InfoFieldList[1]}, 18);
+                                    }
+                                }
+                                if (empty($labeltoshow)) $labeltoshow = '(not defined)';
+                                if ($value == $obj->rowid) {
+                                    $out .= '<option value="' . $obj->rowid . '" selected>' . $labeltoshow . '</option>';
+                                }
 
-							$out.='<option value="'.$obj->rowid.'"';
-							$out.= ($value==$obj->rowid?' selected':'');
-							$out.= (!empty($parent)?' parent="'.$parent.'"':'');
-							$out.='>'.$labeltoshow.'</option>';
-						}
+                                if (!empty($InfoFieldList[3]) && $parentField) {
+                                    $parent = $parentName . ':' . $obj->{$parentField};
+                                }
 
-						$i++;
-					}
-					$this->db->free($resql);
-				}
-				else {
-					print 'Error in request '.$sql.' '.$this->db->lasterror().'. Check setup of extra parameters.<br>';
-				}
+                                $out .= '<option value="' . $obj->rowid . '"';
+                                $out .= ($value == $obj->rowid ? ' selected' : '');
+                                $out .= (!empty($parent) ? ' parent="' . $parent . '"' : '');
+                                $out .= '>' . $labeltoshow . '</option>';
+                            }
+
+                            $i++;
+                        }
+                        $this->db->free($resql);
+                    } else {
+                        print 'Error in request ' . $sql . ' ' . $this->db->lasterror() . '. Check setup of extra parameters.<br>';
+                    }
+                } else {
+                    $data = $form->select_all_categories(Categorie::$MAP_ID_TO_CODE[$InfoFieldList[5]], '', 'parent', 64, $InfoFieldList[6], 1, 1);
+                    $out .= '<option value="0">&nbsp;</option>';
+                    foreach ($data as $data_key => $data_value) {
+                        $out .= '<option value="' . $data_key . '"';
+                        $out .= ($value == $data_key ? ' selected' : '');
+                        $out .= '>' . $data_value . '</option>';
+                    }
+                }
 			}
 			$out.='</select>';
 		}
@@ -1367,6 +1363,8 @@ class ExtraFields
 				// 2 : key fields name (if differ of rowid)
 				// 3 : key field parent (for dependent lists)
 				// 4 : where clause filter on column or table extrafield, syntax field='value' or extra.field=value
+                // 5 : id category type
+                // 6 : ids categories list separated by comma for category root
 				$keyList = (empty($InfoFieldList[2]) ? 'rowid' : $InfoFieldList[2] . ' as rowid');
 
 				if (count($InfoFieldList) > 3 && ! empty($InfoFieldList[3])) {
@@ -1381,166 +1379,173 @@ class ExtraFields
 					}
 				}
 
-				$fields_label = explode('|', $InfoFieldList[1]);
-				if (is_array($fields_label)) {
-					$keyList .= ', ';
-					$keyList .= implode(', ', $fields_label);
-				}
+                $filter_categorie = false;
+                if (count($InfoFieldList) > 5) {
+                    if ($InfoFieldList[0] == 'categorie') {
+                        $filter_categorie = true;
+                    }
+                }
 
-				$sqlwhere = '';
-				$sql = 'SELECT ' . $keyList;
-				$sql .= ' FROM ' . MAIN_DB_PREFIX . $InfoFieldList[0];
-				if (! empty($InfoFieldList[4])) {
+                if ($filter_categorie === false) {
+                    $fields_label = explode('|', $InfoFieldList[1]);
+                    if (is_array($fields_label)) {
+                        $keyList .= ', ';
+                        $keyList .= implode(', ', $fields_label);
+                    }
 
-					// can use SELECT request
-					if (strpos($InfoFieldList[4], '$SEL$')!==false) {
-						$InfoFieldList[4]=str_replace('$SEL$', 'SELECT', $InfoFieldList[4]);
-					}
+                    $sqlwhere = '';
+                    $sql = 'SELECT ' . $keyList;
+                    $sql .= ' FROM ' . MAIN_DB_PREFIX . $InfoFieldList[0];
+                    if (!empty($InfoFieldList[4])) {
 
-					// current object id can be use into filter
-					if (strpos($InfoFieldList[4], '$ID$')!==false && !empty($objectid)) {
-						$InfoFieldList[4]=str_replace('$ID$', $objectid, $InfoFieldList[4]);
-					} elseif (preg_match("#^.*list.php$#", $_SERVER["DOCUMENT_URI"])) {
-						// Pattern for word=$ID$
-						$word = '\b[a-zA-Z0-9-\.-_]+\b=\$ID\$';
+                        // can use SELECT request
+                        if (strpos($InfoFieldList[4], '$SEL$') !== false) {
+                            $InfoFieldList[4] = str_replace('$SEL$', 'SELECT', $InfoFieldList[4]);
+                        }
 
-						// Removing space arount =, ( and )
-						$InfoFieldList[4]=preg_replace('# *(=|\(|\)) *#', '$1', $InfoFieldList[4]);
+                        // current object id can be use into filter
+                        if (strpos($InfoFieldList[4], '$ID$') !== false && !empty($objectid)) {
+                            $InfoFieldList[4] = str_replace('$ID$', $objectid, $InfoFieldList[4]);
+                        } elseif (preg_match("#^.*list.php$#", $_SERVER["DOCUMENT_URI"])) {
+                            // Pattern for word=$ID$
+                            $word = '\b[a-zA-Z0-9-\.-_]+\b=\$ID\$';
 
-						$nbPreg = 1;
-						// While we have parenthesis
-						while ($nbPreg!=0) {
-							// Init des compteurs
-							$nbPregRepl = $nbPregSel = 0;
-							// On retire toutes les parenthèses sans = avant
-							$InfoFieldList[4]=preg_replace('#([^=])(\([^)^(]*(' . $word .   ')[^)^(]*\))#', '$1 $3 ', $InfoFieldList[4], -1, $nbPregRepl);
-							// On retire les espaces autour des = et parenthèses
-							$InfoFieldList[4]=preg_replace('# *(=|\(|\)) *#', '$1', $InfoFieldList[4]);
-							// On retire toutes les parenthèses avec = avant
-							$InfoFieldList[4]=preg_replace('#\b[a-zA-Z0-9-\.-_]+\b=\([^)^(]*(' . $word .   ')[^)^(]*\)#', '$1 ', $InfoFieldList[4], -1, $nbPregSel);
-							// On retire les espaces autour des = et parenthèses
-							$InfoFieldList[4]=preg_replace('# *(=|\(|\)) *#', '$1', $InfoFieldList[4]);
+                            // Removing space arount =, ( and )
+                            $InfoFieldList[4] = preg_replace('# *(=|\(|\)) *#', '$1', $InfoFieldList[4]);
 
-							// Calcul du compteur général pour la boucle
-							$nbPreg = $nbPregRepl + $nbPregSel;
-						}
+                            $nbPreg = 1;
+                            // While we have parenthesis
+                            while ($nbPreg != 0) {
+                                // Init des compteurs
+                                $nbPregRepl = $nbPregSel = 0;
+                                // On retire toutes les parenthèses sans = avant
+                                $InfoFieldList[4] = preg_replace('#([^=])(\([^)^(]*(' . $word . ')[^)^(]*\))#', '$1 $3 ', $InfoFieldList[4], -1, $nbPregRepl);
+                                // On retire les espaces autour des = et parenthèses
+                                $InfoFieldList[4] = preg_replace('# *(=|\(|\)) *#', '$1', $InfoFieldList[4]);
+                                // On retire toutes les parenthèses avec = avant
+                                $InfoFieldList[4] = preg_replace('#\b[a-zA-Z0-9-\.-_]+\b=\([^)^(]*(' . $word . ')[^)^(]*\)#', '$1 ', $InfoFieldList[4], -1, $nbPregSel);
+                                // On retire les espaces autour des = et parenthèses
+                                $InfoFieldList[4] = preg_replace('# *(=|\(|\)) *#', '$1', $InfoFieldList[4]);
 
-						// Si l'on a un AND ou un OR, avant ou après
-						preg_match('#(AND|OR|) *('.$word.') *(AND|OR|)#', $InfoFieldList[4], $matchCondition);
-						while(!empty($matchCondition[0])) {
-							// If the two sides differ but are not empty
-							if (! empty($matchCondition[1]) && ! empty($matchCondition[3]) && $matchCondition[1] != $matchCondition[3] ) {
-								// Nobody sain would do that without parentheses
-								$InfoFieldList[4]=str_replace('$ID$', '0', $InfoFieldList[4]);
-							}
-							else {
-								if (! empty($matchCondition[1])) {
-									$boolCond =(( $matchCondition[1] == "AND" )?' AND 1 ':' OR 0 ');
-									$InfoFieldList[4]=str_replace($matchCondition[0], $boolCond.$matchCondition[3], $InfoFieldList[4]);
-								}
-								elseif (! empty($matchCondition[3])) {
-									$boolCond =(( $matchCondition[3] == "AND" )?' 1 AND ':' 0 OR');
-									$InfoFieldList[4]=str_replace($matchCondition[0], $boolCond, $InfoFieldList[4]);
-								}
-								else {
-									$InfoFieldList[4] = 1;
-								}
-							}
+                                // Calcul du compteur général pour la boucle
+                                $nbPreg = $nbPregRepl + $nbPregSel;
+                            }
 
-							// Si l'on a un AND ou un OR, avant ou après
-							preg_match('#(AND|OR|) *('.$word.') *(AND|OR|)#', $InfoFieldList[4], $matchCondition);
-						}
-					}
-					else {
-						$InfoFieldList[4]=str_replace('$ID$', '0', $InfoFieldList[4]);
-					}
+                            // Si l'on a un AND ou un OR, avant ou après
+                            preg_match('#(AND|OR|) *(' . $word . ') *(AND|OR|)#', $InfoFieldList[4], $matchCondition);
+                            while (!empty($matchCondition[0])) {
+                                // If the two sides differ but are not empty
+                                if (!empty($matchCondition[1]) && !empty($matchCondition[3]) && $matchCondition[1] != $matchCondition[3]) {
+                                    // Nobody sain would do that without parentheses
+                                    $InfoFieldList[4] = str_replace('$ID$', '0', $InfoFieldList[4]);
+                                } else {
+                                    if (!empty($matchCondition[1])) {
+                                        $boolCond = (($matchCondition[1] == "AND") ? ' AND 1 ' : ' OR 0 ');
+                                        $InfoFieldList[4] = str_replace($matchCondition[0], $boolCond . $matchCondition[3], $InfoFieldList[4]);
+                                    } elseif (!empty($matchCondition[3])) {
+                                        $boolCond = (($matchCondition[3] == "AND") ? ' 1 AND ' : ' 0 OR');
+                                        $InfoFieldList[4] = str_replace($matchCondition[0], $boolCond, $InfoFieldList[4]);
+                                    } else {
+                                        $InfoFieldList[4] = 1;
+                                    }
+                                }
 
-					// We have to join on extrafield table
-					if (strpos($InfoFieldList[4], 'extra') !== false) {
-						$sql .= ' as main, ' . MAIN_DB_PREFIX . $InfoFieldList[0] . '_extrafields as extra';
-						$sqlwhere .= ' WHERE extra.fk_object=main.' . $InfoFieldList[2] . ' AND ' . $InfoFieldList[4];
-					} else {
-						$sqlwhere .= ' WHERE ' . $InfoFieldList[4];
-					}
-				} else {
-					$sqlwhere .= ' WHERE 1=1';
-				}
-				// Some tables may have field, some other not. For the moment we disable it.
-				if (in_array($InfoFieldList[0], array ('tablewithentity')))
-				{
-					$sqlwhere .= ' AND entity = ' . $conf->entity;
-				}
-				// $sql.=preg_replace('/^ AND /','',$sqlwhere);
-				// print $sql;
+                                // Si l'on a un AND ou un OR, avant ou après
+                                preg_match('#(AND|OR|) *(' . $word . ') *(AND|OR|)#', $InfoFieldList[4], $matchCondition);
+                            }
+                        } else {
+                            $InfoFieldList[4] = str_replace('$ID$', '0', $InfoFieldList[4]);
+                        }
 
-				$sql .= $sqlwhere;
-				dol_syslog(get_class($this) . '::showInputField type=chkbxlst', LOG_DEBUG);
-				$resql = $this->db->query($sql);
-				if ($resql) {
-					$num = $this->db->num_rows($resql);
-					$i = 0;
+                        // We have to join on extrafield table
+                        if (strpos($InfoFieldList[4], 'extra') !== false) {
+                            $sql .= ' as main, ' . MAIN_DB_PREFIX . $InfoFieldList[0] . '_extrafields as extra';
+                            $sqlwhere .= ' WHERE extra.fk_object=main.' . $InfoFieldList[2] . ' AND ' . $InfoFieldList[4];
+                        } else {
+                            $sqlwhere .= ' WHERE ' . $InfoFieldList[4];
+                        }
+                    } else {
+                        $sqlwhere .= ' WHERE 1=1';
+                    }
+                    // Some tables may have field, some other not. For the moment we disable it.
+                    if (in_array($InfoFieldList[0], array('tablewithentity'))) {
+                        $sqlwhere .= ' AND entity = ' . $conf->entity;
+                    }
+                    // $sql.=preg_replace('/^ AND /','',$sqlwhere);
+                    // print $sql;
 
-					$data=array();
+                    $sql .= $sqlwhere;
+                    dol_syslog(get_class($this) . '::showInputField type=chkbxlst', LOG_DEBUG);
+                    $resql = $this->db->query($sql);
+                    if ($resql) {
+                        $num = $this->db->num_rows($resql);
+                        $i = 0;
 
-					while ( $i < $num ) {
-						$labeltoshow = '';
-						$obj = $this->db->fetch_object($resql);
+                        $data = array();
 
-						$notrans = false;
-						// Several field into label (eq table:code|libelle:rowid)
-						$fields_label = explode('|', $InfoFieldList[1]);
-						if (is_array($fields_label)) {
-							$notrans = true;
-							foreach ($fields_label as $field_toshow) {
-								$labeltoshow .= $obj->$field_toshow . ' ';
-							}
-						} else {
-							$labeltoshow = $obj->{$InfoFieldList[1]};
-						}
-						$labeltoshow = dol_trunc($labeltoshow, 45);
+                        while ($i < $num) {
+                            $labeltoshow = '';
+                            $obj = $this->db->fetch_object($resql);
 
-						if (is_array($value_arr) && in_array($obj->rowid, $value_arr)) {
-							foreach ($fields_label as $field_toshow) {
-								$translabel = $langs->trans($obj->$field_toshow);
-								if ($translabel != $obj->$field_toshow) {
-									$labeltoshow = dol_trunc($translabel, 18) . ' ';
-								} else {
-									$labeltoshow = dol_trunc($obj->$field_toshow, 18) . ' ';
-								}
-							}
+                            $notrans = false;
+                            // Several field into label (eq table:code|libelle:rowid)
+                            $fields_label = explode('|', $InfoFieldList[1]);
+                            if (is_array($fields_label)) {
+                                $notrans = true;
+                                foreach ($fields_label as $field_toshow) {
+                                    $labeltoshow .= $obj->$field_toshow . ' ';
+                                }
+                            } else {
+                                $labeltoshow = $obj->{$InfoFieldList[1]};
+                            }
+                            $labeltoshow = dol_trunc($labeltoshow, 45);
 
-							$data[$obj->rowid]=$labeltoshow;
-						} else {
-							if (! $notrans) {
-								$translabel = $langs->trans($obj->{$InfoFieldList[1]});
-								if ($translabel != $obj->{$InfoFieldList[1]}) {
-									$labeltoshow = dol_trunc($translabel, 18);
-								} else {
-									$labeltoshow = dol_trunc($obj->{$InfoFieldList[1]}, 18);
-								}
-							}
-							if (empty($labeltoshow))
-								$labeltoshow = '(not defined)';
+                            if (is_array($value_arr) && in_array($obj->rowid, $value_arr)) {
+                                foreach ($fields_label as $field_toshow) {
+                                    $translabel = $langs->trans($obj->$field_toshow);
+                                    if ($translabel != $obj->$field_toshow) {
+                                        $labeltoshow = dol_trunc($translabel, 18) . ' ';
+                                    } else {
+                                        $labeltoshow = dol_trunc($obj->$field_toshow, 18) . ' ';
+                                    }
+                                }
 
-								if (is_array($value_arr) && in_array($obj->rowid, $value_arr)) {
-									$data[$obj->rowid]=$labeltoshow;
-								}
+                                $data[$obj->rowid] = $labeltoshow;
+                            } else {
+                                if (!$notrans) {
+                                    $translabel = $langs->trans($obj->{$InfoFieldList[1]});
+                                    if ($translabel != $obj->{$InfoFieldList[1]}) {
+                                        $labeltoshow = dol_trunc($translabel, 18);
+                                    } else {
+                                        $labeltoshow = dol_trunc($obj->{$InfoFieldList[1]}, 18);
+                                    }
+                                }
+                                if (empty($labeltoshow))
+                                    $labeltoshow = '(not defined)';
 
-								if (! empty($InfoFieldList[3]) && $parentField) {
-									$parent = $parentName . ':' . $obj->{$parentField};
-								}
+                                if (is_array($value_arr) && in_array($obj->rowid, $value_arr)) {
+                                    $data[$obj->rowid] = $labeltoshow;
+                                }
 
-								$data[$obj->rowid]=$labeltoshow;
-						}
+                                if (!empty($InfoFieldList[3]) && $parentField) {
+                                    $parent = $parentName . ':' . $obj->{$parentField};
+                                }
 
-						$i ++;
-					}
-					$this->db->free($resql);
+                                $data[$obj->rowid] = $labeltoshow;
+                            }
 
-					$out=$form->multiselectarray($keyprefix.$key.$keysuffix, $data, $value_arr, '', 0, '', 0, '100%');
-				} else {
-					print 'Error in request ' . $sql . ' ' . $this->db->lasterror() . '. Check setup of extra parameters.<br>';
-				}
+                            $i++;
+                        }
+                        $this->db->free($resql);
+
+                        $out = $form->multiselectarray($keyprefix . $key . $keysuffix, $data, $value_arr, '', 0, '', 0, '100%');
+                    } else {
+                        print 'Error in request ' . $sql . ' ' . $this->db->lasterror() . '. Check setup of extra parameters.<br>';
+                    }
+                } else {
+                    $data = $form->select_all_categories(Categorie::$MAP_ID_TO_CODE[$InfoFieldList[5]], '', 'parent', 64, $InfoFieldList[6], 1, 1);
+                    $out = $form->multiselectarray($keyprefix . $key . $keysuffix, $data, $value_arr, '', 0, '', 0, '100%');
+                }
 			}
 		}
 		elseif ($type == 'link')

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3801,16 +3801,20 @@ class Form
 	/**
 	 *    Return list of categories having choosed type
 	 *
-	 *    @param	string|int	$type				Type of category ('customer', 'supplier', 'contact', 'product', 'member'). Old mode (0, 1, 2, ...) is deprecated.
-	 *    @param    string		$selected    		Id of category preselected or 'auto' (autoselect category if there is only one element)
-	 *    @param    string		$htmlname			HTML field name
-	 *    @param    int			$maxlength      	Maximum length for labels
-	 *    @param    int			$excludeafterid 	Exclude all categories after this leaf in category tree.
-	 *    @param	int			$outputmode			0=HTML select string, 1=Array
+	 *    @param	string|int	            $type				Type of category ('customer', 'supplier', 'contact', 'product', 'member'). Old mode (0, 1, 2, ...) is deprecated.
+	 *    @param    string		            $selected    		Id of category preselected or 'auto' (autoselect category if there is only one element)
+	 *    @param    string		            $htmlname			HTML field name
+	 *    @param    int			            $maxlength      	Maximum length for labels
+     *    @param    int|string|array    	$markafterid        Removed all categories including the leaf $markafterid in category tree (exclude) or Keep only of category is inside the leaf starting with this id.
+     *                                                          $markafterid can be an :    int (id of category)
+     *                                                                                      string (categories ids seprated by comma)
+     *                                                                                      array (list of categories ids)
+	 *    @param	int			            $outputmode			0=HTML select string, 1=Array
+     *    @param	int			            $include			[=0] Exlude or 1=Include
 	 *    @return	string
 	 *    @see select_categories()
 	 */
-    public function select_all_categories($type, $selected = '', $htmlname = "parent", $maxlength = 64, $excludeafterid = 0, $outputmode = 0)
+    public function select_all_categories($type, $selected = '', $htmlname = "parent", $maxlength = 64, $markafterid = 0, $outputmode = 0, $include = 0)
 	{
         // phpcs:enable
 		global $conf, $langs;
@@ -3850,7 +3854,7 @@ class Form
 		else
 		{
 			$cat = new Categorie($this->db);
-			$cate_arbo = $cat->get_full_arbo($type, $excludeafterid);
+            $cate_arbo = $cat->get_full_arbo($type, $markafterid, $include);
 		}
 
 		$output = '<select class="flat" name="'.$htmlname.'" id="'.$htmlname.'">';

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3805,12 +3805,12 @@ class Form
 	 *    @param    string		            $selected    		Id of category preselected or 'auto' (autoselect category if there is only one element)
 	 *    @param    string		            $htmlname			HTML field name
 	 *    @param    int			            $maxlength      	Maximum length for labels
-     *    @param    int|string|array    	$markafterid        Removed all categories including the leaf $markafterid in category tree (exclude) or Keep only of category is inside the leaf starting with this id.
+     *    @param    int|string|array    	$markafterid        Keep only or removed all categories including the leaf $markafterid in category tree (exclude) or Keep only of category is inside the leaf starting with this id.
      *                                                          $markafterid can be an :    int (id of category)
      *                                                                                      string (categories ids seprated by comma)
      *                                                                                      array (list of categories ids)
 	 *    @param	int			            $outputmode			0=HTML select string, 1=Array
-     *    @param	int			            $include			[=0] Exlude or 1=Include
+     *    @param	int			            $include			[=0] Removed or 1=Keep only
 	 *    @return	string
 	 *    @see select_categories()
 	 */

--- a/htdocs/takepos/takepos.php
+++ b/htdocs/takepos/takepos.php
@@ -77,7 +77,7 @@ top_htmlhead($head, $title, $disablejs, $disablehead, $arrayofjs, $arrayofcss);
 <script type="text/javascript" src="js/jquery.colorbox-min.js"></script>	<!-- TODO It seems we don't need this -->
 <script language="javascript">
 <?php
-$categories = $categorie->get_full_arbo('product', 0, (($conf->global->TAKEPOS_ROOT_CATEGORY_ID > 0)?$conf->global->TAKEPOS_ROOT_CATEGORY_ID:0));
+$categories = $categorie->get_full_arbo('product', (($conf->global->TAKEPOS_ROOT_CATEGORY_ID > 0)?$conf->global->TAKEPOS_ROOT_CATEGORY_ID:0), 1);
 
 
 // Search root category to know its level


### PR DESCRIPTION
New categories options in sellist and chbxlist extrafields
- add category type and categories ids (string of start category id separated by comma)
- show full category path in input extrafield
- extrafield example : "categorie:label:rowid::type=6:6:1,2,3" (for category project extrafield)