### PR TITLE
FIX shipping default warehouse if only one warehouse

### DIFF
--- a/htdocs/expedition/shipment.php
+++ b/htdocs/expedition/shipment.php
@@ -894,7 +894,7 @@ if ($id > 0 || ! empty($ref))
 					print $langs->trans("WarehouseSource");
 					//print '</td>';
 					//print '<td>';
-					print $formproduct->selectWarehouses(! empty($object->warehouse_id)?$object->warehouse_id:-1, 'entrepot_id', '', 1, 0, 0, '', 0, 0, array(), 'minwidth200');
+					print $formproduct->selectWarehouses(! empty($object->warehouse_id)?$object->warehouse_id:'ifone', 'entrepot_id', '', 1, 0, 0, '', 0, 0, array(), 'minwidth200');
 					if (count($formproduct->cache_warehouses) <= 0)
 					{
 						print ' &nbsp; '.$langs->trans("WarehouseSourceNotDefined").' <a href="'.DOL_URL_ROOT.'/product/stock/card.php?action=create">'.$langs->trans("AddOne").'</a>';


### PR DESCRIPTION
# Fix
Thanks to this fix, if only one warehouse is created, dolibarr will auto select the good warehouse on shipping view.
This fix is really important for products without stock and negativ_stock_allowed configuration.
In the other case, users will not be able to choose a warehouse on the next screen.