### PR TITLE
Fix dynamic prices bug caused by arg displacement

### DIFF
--- a/htdocs/product/dynamic_price/class/price_parser.class.php
+++ b/htdocs/product/dynamic_price/class/price_parser.class.php
@@ -300,7 +300,7 @@ class PriceParser
         }
 
         //Get the product data (use ignore_expression to avoid possible recursion)
-        $product_supplier->fetch($product_supplier->id, '', '', 1);
+        $product_supplier->fetch($product_supplier->id, '', '', '', 1);
 
         //Accessible values by expressions
         $extra_values = array_merge($extra_values, array(


### PR DESCRIPTION
The 4th argument for fetch was used to prevent recursion, this fixes the call to properly set the arg.