### PR TITLE
Fix dropdown menu in pages with several lists

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6346,7 +6346,7 @@ class Form
 
         <dl class="dropdown">
             <dt>
-            <a href="#">
+            <a href="#'.$htmlname.'">
               '.img_picto('', 'list').'
             </a>
             <input type="hidden" class="'.$htmlname.'" name="'.$htmlname.'" value="'.$listcheckedstring.'">


### PR DESCRIPTION
Fix dropdown menu in pages with several lists
- if you have several lists in your page and the right scrollbar : when you click on the filter button, you go at the top of the first table and you lose the focus on the last table
