### PR TITLE
Move to Warning an alert on hook when method return a string than a int

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -275,7 +275,7 @@ class HookManager
                     	// TODO dead code to remove (do not enable this, but fix hook instead): result must not be a string but an int. you must use $actionclassinstance->resprints to return a string
                     	if (! is_array($resaction) && ! is_numeric($resaction))
                     	{
-                    		dol_syslog('Error: Bug into hook '.$method.' of module class '.get_class($actionclassinstance).'. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints', LOG_ERR);
+                    		dol_syslog('Warning: Bug into hook '.$method.' of module class '.get_class($actionclassinstance).'. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints', LOG_WARNING);
                     		if (empty($actionclassinstance->resprints)) { $this->resPrint.=$resaction; $resaction=0; }
                     	}
                     }


### PR DESCRIPTION
For most modules there is a forgotten return in the module and it necessarily wants an integer.

Example : 

2019-04-12 15:40:03 ERR     xxx.xxx.xxx.xxx->xxx.xxx.xxx.xxx Error: Bug into hook beforePDFCreation of module class ActionsFactor. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints