### PR TITLE
Fix input search is not working for extrafields typed as 'list'

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_input.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_input.tpl.php
@@ -16,12 +16,12 @@ if (is_array($extrafields->attribute_label) && count($extrafields->attribute_lab
 			$align=$extrafields->getAlignFlag($key);
 			$typeofextrafield=$extrafields->attribute_type[$key];
 			print '<td class="liste_titre'.($align?' '.$align:'').'">';
-			if (in_array($typeofextrafield, array('varchar', 'int', 'double', 'select')) && empty($extrafields->attribute_computed[$key]))
+			if (in_array($typeofextrafield, array('varchar', 'int', 'double')) && empty($extrafields->attribute_computed[$key]))
 			{
 				$crit=$val;
 				$tmpkey=preg_replace('/search_options_/','',$key);
 				$searchclass='';
-				if (in_array($typeofextrafield, array('varchar', 'select'))) $searchclass='searchstring';
+				if (in_array($typeofextrafield, array('varchar'))) $searchclass='searchstring';
 				if (in_array($typeofextrafield, array('int', 'double'))) $searchclass='searchnum';
 				print '<input class="flat'.($searchclass?' '.$searchclass:'').'" size="4" type="text" name="search_options_'.$tmpkey.'" value="'.dol_escape_htmltag($search_array_options['search_options_'.$tmpkey]).'">';
 			}


### PR DESCRIPTION
# Fix 
The `showInputField` should be called to display the right content for extrafields typed as 'list' and print an html select instead of input text