### PR TITLE
fix actioncomm module for long trigger names

### DIFF
--- a/htdocs/fourn/commande/orderstoinvoice.php
+++ b/htdocs/fourn/commande/orderstoinvoice.php
@@ -216,7 +216,7 @@ if (($action == 'create' || $action == 'add') && ! $error) {
 									$fk_parent_line = 0;
 								}
 								// FIXME Missing $lines[$i]->ref_supplier and $lines[$i]->label into addline and updateline methods. They are filled when coming from order for example.
-								$result = $object->addline($desc, $lines[$i]->subprice, $lines[$i]->tva_tx, $lines[$i]->localtax1_tx, $lines[$i]->localtax2_tx, $lines[$i]->qty, $lines[$i]->fk_product, $lines[$i]->remise_percent, $date_start, $date_end, 0, $lines[$i]->info_bits, 'HT', $product_type, -1, false, 0, $lines[$i]->fk_unit);
+								$result = $object->addline($desc, $lines[$i]->subprice, $lines[$i]->tva_tx, $lines[$i]->localtax1_tx, $lines[$i]->localtax2_tx, $lines[$i]->qty, $lines[$i]->fk_product, $lines[$i]->remise_percent, $date_start, $date_end, 0, $lines[$i]->info_bits, 'HT', $product_type, -1, false, 0, $lines[$i]->fk_unit, $line[$i]->id);
 
 								if ($result > 0) {
 									$lineid = $result;

--- a/htdocs/install/mysql/migration/7.0.0-8.0.0.sql
+++ b/htdocs/install/mysql/migration/7.0.0-8.0.0.sql
@@ -560,3 +560,5 @@ UPDATE llx_advtargetemailing SET fk_element = fk_mailing, type_element='mailing'
 ALTER TABLE llx_advtargetemailing DROP COLUMN fk_mailing;
 
 DROP TABLE llx_ticket_logs;
+
+ALTER TABLE llx_actioncomm MODIFY COLUMN code varchar(50);

--- a/htdocs/install/mysql/tables/llx_actioncomm.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm.sql
@@ -29,7 +29,7 @@ create table llx_actioncomm
   datep2			datetime,						-- date end
 
   fk_action			integer,						-- type of action (optional link with id in llx_c_actioncomm or null)
-  code				varchar(32) NULL,				-- code of action for automatic action ('AC_OTH_AUTO' for automatic actions, 'AC_EMAILIN_AUTO' for email input, 'AC_xxx' for manual action...) 
+  code				varchar(50) NULL,				-- code of action for automatic action ('AC_OTH_AUTO' for automatic actions, 'AC_EMAILIN_AUTO' for email input, 'AC_xxx' for manual action...) 
   
   datec				datetime,						-- date creation
   tms				timestamp,						-- date modification


### PR DESCRIPTION
# Fix event's code for long trigger names
If we have the supplier module and the actioncomm activated, we aren't able to classify a supplier_order billed because the trigger name is too long. It tries to create an event with code "AC_ORDER_SUPPLIER_CLASSIFY_BILLED" (length = 33 for code fied that is a varchar 32)...