### PR TITLE
Corrected syncRates parameter

### DIFF
--- a/htdocs/multicurrency/class/multicurrency.class.php
+++ b/htdocs/multicurrency/class/multicurrency.class.php
@@ -626,7 +626,7 @@ class MultiCurrency extends CommonObject
 	/**
 	 * Sync rates from api
 	 *
-	 * @param 	array 	$response 	array of reponse from api to sync dolibarr rates
+	 * @param 	string  $key    Key to use. Come from $conf->global->MULTICURRENCY_APP_ID.
      * @return  void
 	 */
 	public static function syncRates($key)

--- a/htdocs/multicurrency/class/multicurrency.class.php
+++ b/htdocs/multicurrency/class/multicurrency.class.php
@@ -629,7 +629,7 @@ class MultiCurrency extends CommonObject
 	 * @param 	array 	$response 	array of reponse from api to sync dolibarr rates
      * @return  void
 	 */
-	public static function syncRates($response)
+	public static function syncRates($key)
 	{
 		global $conf, $db, $langs;
 


### PR DESCRIPTION
# New syncRates was not getting the API key
Function syncRates was sending 500 error when executing because $key wasn't defined. 
