### PR TITLE
FIX project link for stock correction

### DIFF
--- a/htdocs/product/stock/tpl/stockcorrection.tpl.php
+++ b/htdocs/product/stock/tpl/stockcorrection.tpl.php
@@ -100,7 +100,7 @@ if (empty($conf) || ! is_object($conf))
 		{
 			print '<td>'.$langs->trans('Project').'</td>';
 			print '<td>';
-			$formproject->select_projects(0, '', 'projectid', 0, 0, 1, 0, 0, 0, 0, '', 0, 0, 'maxwidth300');
+			$formproject->select_projects(-1, '', 'projectid', 0, 0, 1, 0, 0, 0, 0, '', 0, 0, 'maxwidth300');
 			print '</td>';
 		}
 		print '</tr>';


### PR DESCRIPTION
# Fix link to project on stock correction
The select_project didn't work because $socid param was set to "0".
This was searching only searching for projects which fk_soc was 0 or NULL...
with "-1", all projects are returned.