### PR TITLE
FIX : Sale representative column didn't increase nbfield variable

### DIFF
--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -968,6 +968,7 @@ if ($resql)
 				print '&nbsp';
 			}
 			print '</td>';
+			if (! $i) $totalarray['nbfield']++;
 		}
 
 		// Extra fields


### PR DESCRIPTION
# Fix sale representative column didn't increase nbfield variable on proposal list
That's why, in total line, one td is missing like in the picture below
![image](https://user-images.githubusercontent.com/31647290/57128081-9b51e880-6d92-11e9-9153-e9b6299d7b32.png)