### PR TITLE
FIX: Remove link between categories and project when deleting

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -688,6 +688,18 @@ class Project extends CommonObject
 	        }
         }
 
+        // Remove linked categories.
+        if (! $error) {
+            $sql = "DELETE FROM ".MAIN_DB_PREFIX. "categorie_project";
+            $sql.= " WHERE fk_project = ". $this->id;
+
+            $result = $this->db->query($sql);
+            if (! $result) {
+                $error++;
+                $this->errors[] = $this->db->lasterror();
+            }
+        }
+
 		// Fetch tasks
 		$this->getLinesArray($user);
 


### PR DESCRIPTION
When a project is linked to a category, removing the project was impossible as the Project object doesn't remove the entries in `categorie_project` in the `delete()` method. This PR removes the entries in the same way as a Product object when `delete()` is called.