### PR TITLE
FIX attached files list with link file was broked

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -833,7 +833,7 @@ class FormFile
 				{
 					$out.='<tr class="oddeven">';
 					$out.='<td colspan="'.$colspan.'" class="maxwidhtonsmartphone">';
-					$out.='<a data-ajax="false" href="' . $link->url . '" target="_blank">';
+					$out.='<a data-ajax="false" href="' . $file->url . '" target="_blank">';
 					$out.=$file->label;
 					$out.='</a>';
 					$out.='</td>';


### PR DESCRIPTION
Bad var was called in code that's why href was empty.
Litle fix but usefull

![image](https://user-images.githubusercontent.com/14542208/57446033-03517480-7254-11e9-8689-217eec2a46c0.png)
