### PR TITLE
fix useless calculation

### DIFF
--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -91,7 +91,7 @@ class FormMargin
 				$line->pa_ht = $line->subprice * (1 - ($line->remise_percent / 100));
 			}
 
-			$pv = $line->qty * $line->subprice * (1 - $line->remise_percent / 100);
+			$pv = $line->total_ht;
 			$pa_ht = ($pv < 0 ? - $line->pa_ht : $line->pa_ht);      // We choosed to have line->pa_ht always positive in database, so we guess the correct sign
 			$pa = $line->qty * $pa_ht;
 


### PR DESCRIPTION
# Fix useless calculation
the $pv calculation is useless because line total is already calculated on the line.
It can display a different total of the document because of the difference between sum of rounding (of the document's lines) and rounding of the sum in the method getMarginInfosArray