### PR TITLE
Fix : IF in SQL request is not standard and don't work with Postgresql

### DIFF
--- a/htdocs/margin/tabs/productMargins.php
+++ b/htdocs/margin/tabs/productMargins.php
@@ -135,9 +135,9 @@ if ($id > 0 || ! empty($ref))
             $sql.= " f.datef, f.paye, f.fk_statut as statut, f.type,";
             if (!$user->rights->societe->client->voir && !$socid) $sql.= " sc.fk_soc, sc.fk_user,";
             $sql.= " sum(d.total_ht) as selling_price,";							// may be negative or positive
-            $sql.= " IF(f.type = 2, -1, 1) * sum(d.qty) as qty,";						// not always positive in case of Credit note
-            $sql.= " IF(f.type = 2, -1, 1) * sum(d.qty * d.buy_price_ht) as buying_price,";			// not always positive in case of Credit note
-            $sql.= " IF(f.type = 2, -1, 1) * sum(abs(d.total_ht) - (d.buy_price_ht * d.qty)) as marge" ;	// not always positive in case of Credit note
+            $sql.= " CASE WHEN f.type = 2 THEN -1 * sum(d.qty) ELSE sum(d.qty) END as qty,";                    // not always positive in case of Credit note
+            $sql.= " CASE WHEN f.type = 2 THEN -1 * sum(d.qty * d.buy_price_ht) ELSE sum(d.qty * d.buy_price_ht) END as buying_price,"; // not always positive in case of Credit note
+            $sql.= " CASE WHEN f.type = 2 THEN -1 * sum(abs(d.total_ht) - (d.buy_price_ht * d.qty)) ELSE sum(abs(d.total_ht) - (d.buy_price_ht * d.qty)) END as marge" ;        // not always positive in case of Credit note
             $sql.= " FROM ".MAIN_DB_PREFIX."societe as s";
             $sql.= ", ".MAIN_DB_PREFIX."facture as f";
             $sql.= ", ".MAIN_DB_PREFIX."facturedet as d";


### PR DESCRIPTION
IF is not a SQL-compliant conditional expressions in a request so IF is not available in PostgreSQL.
But CASE = yes.

https://www.postgresql.org/docs/9.6/functions-conditional.html#FUNCTIONS-CASE
https://mariadb.com/kb/en/library/case-operator/

En français:

Les IF dans une requête fonctionne sur Mysql/mariadb mais pas dans Postgresql car ce n'est pas dans le standard Sql.
CASE oui.