### PR TITLE
FIX : do not include tpl from disabled modules

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3715,16 +3715,25 @@ abstract class CommonObject
 
 		// Output template part (modules that overwrite templates must declare this into descriptor)
 		// Use global variables + $dateSelector + $seller and $buyer
-		$dirtpls=array_merge($conf->modules_parts['tpl'],array('/core/tpl'));
-		foreach($dirtpls as $reldir)
+		$dirtpls=array_merge($conf->modules_parts['tpl'], array('/core/tpl'));
+		foreach($dirtpls as $module => $reldir)
 		{
-			$tpl = dol_buildpath($reldir.'/objectline_create.tpl.php');
+			if (!empty($module) && empty($conf->$module->enabled)) continue;
+
+			if (!empty($module))
+			{
+				$tpl = dol_buildpath($reldir.'/objectline_create.tpl.php');
+			}
+			else
+			{
+				$tpl = DOL_DOCUMENT_ROOT.$reldir.'/objectline_create.tpl.php';
+			}
 			if (empty($conf->file->strict_mode)) {
 				$res=@include $tpl;
 			} else {
 				$res=include $tpl; // for debug
 			}
-			if ($res) break;
+			if ($res > 0) break;
 		}
 	}
 
@@ -3967,16 +3976,25 @@ abstract class CommonObject
 
 			// Output template part (modules that overwrite templates must declare this into descriptor)
 			// Use global variables + $dateSelector + $seller and $buyer
-			$dirtpls=array_merge($conf->modules_parts['tpl'],array('/core/tpl'));
-			foreach($dirtpls as $reldir)
+			$dirtpls=array_merge($conf->modules_parts['tpl'], array('/core/tpl'));
+			foreach($dirtpls as $module => $reldir)
 			{
-				$tpl = dol_buildpath($reldir.'/objectline_view.tpl.php');
+				if (!empty($module) && empty($conf->$module->enabled)) continue;
+
+				if (!empty($module))
+				{
+					$tpl = dol_buildpath($reldir.'/objectline_view.tpl.php');
+				}
+				else
+				{
+					$tpl = DOL_DOCUMENT_ROOT.$reldir.'/objectline_view.tpl.php';
+				}
 				if (empty($conf->file->strict_mode)) {
 					$res=@include $tpl;
 				} else {
 					$res=include $tpl; // for debug
 				}
-				if ($res) break;
+				if ($res > 0) break;
 			}
 		}
 
@@ -3990,16 +4008,25 @@ abstract class CommonObject
 
 			// Output template part (modules that overwrite templates must declare this into descriptor)
 			// Use global variables + $dateSelector + $seller and $buyer
-			$dirtpls=array_merge($conf->modules_parts['tpl'],array('/core/tpl'));
-			foreach($dirtpls as $reldir)
+			$dirtpls=array_merge($conf->modules_parts['tpl'], array('/core/tpl'));
+			foreach($dirtpls as $module => $reldir)
 			{
-				$tpl = dol_buildpath($reldir.'/objectline_edit.tpl.php');
+				if (!empty($module) && empty($conf->$module->enabled)) continue;
+
+				if (!empty($module))
+				{
+					$tpl = dol_buildpath($reldir.'/objectline_edit.tpl.php');
+				}
+				else
+				{
+					$tpl = DOL_DOCUMENT_ROOT.$reldir.'/objectline_edit.tpl.php';
+				}
 				if (empty($conf->file->strict_mode)) {
 					$res=@include $tpl;
 				} else {
 					$res=include $tpl; // for debug
 				}
-				if ($res) break;
+				if ($res > 0) break;
 			}
 		}
 	}
@@ -4186,16 +4213,25 @@ abstract class CommonObject
 
 		// Output template part (modules that overwrite templates must declare this into descriptor)
 		// Use global variables + $dateSelector + $seller and $buyer
-		$dirtpls=array_merge($conf->modules_parts['tpl'],array('/core/tpl'));
-		foreach($dirtpls as $reldir)
+		$dirtpls=array_merge($conf->modules_parts['tpl'], array('/core/tpl'));
+		foreach($dirtpls as $module => $reldir)
 		{
-			$tpl = dol_buildpath($reldir.'/originproductline.tpl.php');
+			if (!empty($module) && empty($conf->$module->enabled)) continue;
+
+			if (!empty($module))
+			{
+				$tpl = dol_buildpath($reldir.'/originproductline.tpl.php');
+			}
+			else
+			{
+				$tpl = DOL_DOCUMENT_ROOT.$reldir.'/originproductline.tpl.php';
+			}
 			if (empty($conf->file->strict_mode)) {
 				$res=@include $tpl;
 			} else {
 				$res=include $tpl; // for debug
 			}
-			if ($res) break;
+			if ($res > 0) break;
 		}
 	}
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3733,7 +3733,7 @@ abstract class CommonObject
 			} else {
 				$res=include $tpl; // for debug
 			}
-			if ($res !== FALSE) break;
+			if ($res) break;
 		}
 	}
 
@@ -3994,7 +3994,7 @@ abstract class CommonObject
 				} else {
 					$res=include $tpl; // for debug
 				}
-				if ($res !== FALSE) break;
+				if ($res) break;
 			}
 		}
 
@@ -4026,7 +4026,7 @@ abstract class CommonObject
 				} else {
 					$res=include $tpl; // for debug
 				}
-				if ($res !== FALSE) break;
+				if ($res) break;
 			}
 		}
 	}
@@ -4231,7 +4231,7 @@ abstract class CommonObject
 			} else {
 				$res=include $tpl; // for debug
 			}
-			if ($res !== FALSE) break;
+			if ($res) break;
 		}
 	}
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3733,7 +3733,7 @@ abstract class CommonObject
 			} else {
 				$res=include $tpl; // for debug
 			}
-			if ($res > 0) break;
+			if ($res === TRUE) break;
 		}
 	}
 
@@ -3994,7 +3994,7 @@ abstract class CommonObject
 				} else {
 					$res=include $tpl; // for debug
 				}
-				if ($res > 0) break;
+				if ($res === TRUE) break;
 			}
 		}
 
@@ -4026,7 +4026,7 @@ abstract class CommonObject
 				} else {
 					$res=include $tpl; // for debug
 				}
-				if ($res > 0) break;
+				if ($res === TRUE) break;
 			}
 		}
 	}
@@ -4231,7 +4231,7 @@ abstract class CommonObject
 			} else {
 				$res=include $tpl; // for debug
 			}
-			if ($res > 0) break;
+			if ($res === TRUE) break;
 		}
 	}
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3733,7 +3733,7 @@ abstract class CommonObject
 			} else {
 				$res=include $tpl; // for debug
 			}
-			if ($res === TRUE) break;
+			if ($res !== FALSE) break;
 		}
 	}
 
@@ -3994,7 +3994,7 @@ abstract class CommonObject
 				} else {
 					$res=include $tpl; // for debug
 				}
-				if ($res === TRUE) break;
+				if ($res !== FALSE) break;
 			}
 		}
 
@@ -4026,7 +4026,7 @@ abstract class CommonObject
 				} else {
 					$res=include $tpl; // for debug
 				}
-				if ($res === TRUE) break;
+				if ($res !== FALSE) break;
 			}
 		}
 	}
@@ -4231,7 +4231,7 @@ abstract class CommonObject
 			} else {
 				$res=include $tpl; // for debug
 			}
-			if ($res === TRUE) break;
+			if ($res !== FALSE) break;
 		}
 	}
 


### PR DESCRIPTION
With the old way, the tpl were included even if the external module was disabled !
Now we check if module is enabled before including tpl.