### PR TITLE
Fix create bills on mass action does not retrieve the original currency

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -510,7 +510,7 @@ if ($massaction == 'confirm_createbills')
 			$objecttmp->cond_reglement_id	= $cmd->cond_reglement_id;
 			$objecttmp->mode_reglement_id	= $cmd->mode_reglement_id;
 			$objecttmp->fk_project			= $cmd->fk_project;
-
+            $objecttmp->multicurrency_code  = $cmd->multicurrency_code;
 			$datefacture = dol_mktime(12, 0, 0, $_POST['remonth'], $_POST['reday'], $_POST['reyear']);
 			if (empty($datefacture))
 			{


### PR DESCRIPTION
# Fix
From orders list, the mass action to bills does not retrieve the original currency code 