### PR TITLE
FIX stock movement does not need virtual stock.

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -163,7 +163,7 @@ class MouvementStock extends CommonObject
 
 		$this->db->begin();
 
-		$product->load_stock();
+		$product->load_stock('novirtual');
 
 		// Test if product require batch data. If yes, and there is not, we throw an error.
 		if (! empty($conf->productbatch->enabled) && $product->hasbatch() && ! $skip_batch)


### PR DESCRIPTION
A stock movement only needs reel stock, so virtual stock does not need to be calculated.

This gives a big performance improvement when stock rule is set for validating orders, shipments or invoices on dolibarr installs with +10000 orders.
