### PR TITLE
Display the intervention button only in develop mode

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -1648,11 +1648,10 @@ else if ($id > 0 || ! empty($ref))
 				}
 
 		    	// create intervention model
-				if ($object->statut == Fichinter::STATUS_DRAFT && $user->rights->ficheinter->creer && (count($object->lines) > 0)) {
+				if ($conf->global->MAIN_FEATURE_LEVEL >=2 && $object->statut == Fichinter::STATUS_DRAFT && $user->rights->ficheinter->creer && (count($object->lines) > 0)) {
 					print '<div class="inline-block divButAction">';
 					// This feature is not yet implemented
-					//print '<a class="butAction" href="'.DOL_URL_ROOT.'/fichinter/card-rec.php?id='.$object->id.'&action=create">'.$langs->trans("ChangeIntoRepeatableIntervention").'</a>';
-					print '<a class="butAction" title="'.$langs->trans("ChangeIntoRepeatableIntervention").'" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'">'.$langs->trans("not yet implemented").'</a>';
+					print '<a class="butAction" href="'.DOL_URL_ROOT.'/fichinter/card-rec.php?id='.$object->id.'&action=create">'.$langs->trans("ChangeIntoRepeatableIntervention").'</a>';
 					print '</div>';
 				}
 


### PR DESCRIPTION
# Fix Display the intervention button only in develop mode
Fix : button of a non implemented feature is displayed.
Feature : Create intervention model from existing intervention.