### PR TITLE
Fix  disabled sync tax_id for avoid error

### DIFF
--- a/htdocs/core/triggers/interface_80_modStripe_Stripe.class.php
+++ b/htdocs/core/triggers/interface_80_modStripe_Stripe.class.php
@@ -190,8 +190,8 @@ class InterfaceStripe
 						$customer->description = $desccleaned;
 						$customer->preferred_locales = $langcleaned;
 						$customer->tax_exempt = $taxexemptcleaned;
-						if (! empty($vatcleaned)) $customer->tax_ids = array('object'=>'list', 'data'=>array('value'=>$vatcleaned));
-						else $customer->tax_ids = null;
+						//if (! empty($vatcleaned)) $customer->tax_ids = array('object'=>'list', 'data'=>array('value'=>$vatcleaned));
+						//else $customer->tax_ids = null;
 
 						$customer->save();
 					}


### PR DESCRIPTION
tempory fix for avoid  error in stripe dashboard

TO DO LATER: integration of new stripe tax id with auto check validity
https://stripe.com/docs/api/customer_tax_ids
https://stripe.com/docs/billing/migration/taxes#moving-from-taxinfo-to-customer-tax-ids
