### PR TITLE
FIX : filepath of generated documents doesn't handle products with sp…

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -764,7 +764,7 @@ class FormFile
 
 					// Show file name with link to download
 					$out.= '<td class="minwidth200">';
-					$out.= '<a class="documentdownload paddingright" href="'.$documenturl.'?modulepart='.$modulepart.'&amp;file='.urlencode(dol_sanitizePathName($relativepath)).($param?'&'.$param:'').'"';
+					$out.= '<a class="documentdownload paddingright" href="'.$documenturl.'?modulepart='.$modulepart.'&amp;file='.urlencode($relativepath).($param?'&'.$param:'').'"';
 					$mime=dol_mimetype($relativepath,'',0);
 					if (preg_match('/text/',$mime)) $out.= ' target="_blank"';
 					$out.= '>';

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -764,7 +764,7 @@ class FormFile
 
 					// Show file name with link to download
 					$out.= '<td class="minwidth200">';
-					$out.= '<a class="documentdownload paddingright" href="'.$documenturl.'?modulepart='.$modulepart.'&amp;file='.urlencode($relativepath).($param?'&'.$param:'').'"';
+					$out.= '<a class="documentdownload paddingright" href="'.$documenturl.'?modulepart='.$modulepart.'&amp;file='.urlencode(dol_sanitizePathName($relativepath)).($param?'&'.$param:'').'"';
 					$mime=dol_mimetype($relativepath,'',0);
 					if (preg_match('/text/',$mime)) $out.= ' target="_blank"';
 					$out.= '>';

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -429,7 +429,7 @@ class Product extends CommonObject
             $error=0;
 
         // Clean parameters
-        $this->ref = dol_string_nospecial(trim($this->ref));
+        $this->ref = dol_sanitizeFileName(dol_string_nospecial(trim($this->ref)));
         $this->label = trim($this->label);
         $this->price_ttc=price2num($this->price_ttc);
         $this->price=price2num($this->price);


### PR DESCRIPTION
Fix : filepath of generated documents doesn't handle products with special characters

Generated documents filepath doesn't handle references and names with special characters (such as 'é').
The path related to the generated document is wrong
