### PR TITLE
Fix invoice list filter on withdrawal card

### DIFF
--- a/htdocs/compta/prelevement/factures.php
+++ b/htdocs/compta/prelevement/factures.php
@@ -160,7 +160,7 @@ $sql.= " AND pl.fk_prelevement_bons = p.rowid";
 $sql.= " AND f.fk_soc = s.rowid";
 $sql.= " AND pf.fk_facture = f.rowid";
 $sql.= " AND f.entity = ".$conf->entity;
-if ($prev_id) $sql.= " AND p.rowid=".$prev_id;
+if ($object->id) $sql.= " AND p.rowid=".$object->id;
 if ($socid) $sql.= " AND s.rowid = ".$socid;
 $sql.= $db->order($sortfield,$sortorder);
 


### PR DESCRIPTION
When navigating between withdrawals cards on the invoice tab, the invoice list was containing all invoices from all withdrawals.