### PR TITLE
Fix #11331 Bug: extrafields type double wrong length

### DIFF
--- a/htdocs/core/actions_extrafields.inc.php
+++ b/htdocs/core/actions_extrafields.inc.php
@@ -27,7 +27,7 @@ $maxsizestring=255;
 $maxsizeint=10;
 $mesg=array();
 
-$extrasize=GETPOST('size', 'int');
+$extrasize=GETPOST('size','intcomma');
 $type=GETPOST('type', 'alpha');
 $param=GETPOST('param', 'alpha');
 

--- a/htdocs/core/actions_extrafields.inc.php
+++ b/htdocs/core/actions_extrafields.inc.php
@@ -27,7 +27,7 @@ $maxsizestring=255;
 $maxsizeint=10;
 $mesg=array();
 
-$extrasize=GETPOST('size','intcomma');
+$extrasize=GETPOST('size', 'intcomma');
 $type=GETPOST('type', 'alpha');
 $param=GETPOST('param', 'alpha');
 

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1645,7 +1645,10 @@ class ExtraFields
 		elseif ($type == 'double')
 		{
 			if (!empty($value)) {
-				$value=price($value);
+			//	$value=price($value);
+				$sizeparts = explode(",",$size);
+				$number_decimals = $sizeparts[1];
+				$value=price($value, 0, $langs, 0, 0, $number_decimals, '');
 			}
 		}
 		elseif ($type == 'boolean')

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1645,8 +1645,8 @@ class ExtraFields
 		elseif ($type == 'double')
 		{
 			if (!empty($value)) {
-			//	$value=price($value);
-				$sizeparts = explode(",",$size);
+				//$value=price($value);
+				$sizeparts = explode(",", $size);
 				$number_decimals = $sizeparts[1];
 				$value=price($value, 0, $langs, 0, 0, $number_decimals, '');
 			}


### PR DESCRIPTION

# Fix #11331 Bug: extrafields type double wrong length
Extrafields with type float need specific number of decimals. The system now always imposes 24,8 as length and always shows 2 decimals.

