### PR TITLE
FIX: stock increase on shipment deletion if STOCK_CALCULATE_ON_SHIPMENT_CLOSE is set 

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1179,7 +1179,9 @@ class Expedition extends CommonObject
 		}
 
 		// Stock control
-		if (! $error && $conf->stock->enabled && $conf->global->STOCK_CALCULATE_ON_SHIPMENT && $this->statut > self::STATUS_DRAFT)
+		if (! $error && $conf->stock->enabled &&
+			(($conf->global->STOCK_CALCULATE_ON_SHIPMENT && $this->statut > self::STATUS_DRAFT) ||
+			 ($conf->global->STOCK_CALCULATE_ON_SHIPMENT_CLOSE && $this->statut == 2)))
 		{
 			require_once DOL_DOCUMENT_ROOT."/product/stock/class/mouvementstock.class.php";
 


### PR DESCRIPTION
When STOCK_CALCULATE_ON_SHIPMENT_CLOSE is set, a closed shipment means that the stock is decreased by the shipped quantity. However, if you delete that closed shipment with this configuration, the stock should be increased back accordingly.