### PR TITLE
FIX: Product::get_arbo_each_prod() changes the state of $this.

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -3374,6 +3374,7 @@ class Product extends CommonObject
 	 */
 	function get_arbo_each_prod($multiply=1)
 	{
+		$product_id_backup = $this->id;
 		$this->res = array();
 		if (isset($this->sousprods) && is_array($this->sousprods))
 		{
@@ -3381,6 +3382,9 @@ class Product extends CommonObject
 			{
 				if (is_array($desc_product)) $this->fetch_prod_arbo($desc_product,"",$multiply,1,$this->id);
 			}
+		}
+		if ($product_id_backup) {
+			$this->fetch($product_id_backup);
 		}
 		//var_dump($this->res);
 		return $this->res;


### PR DESCRIPTION
Methods prefixed with _get__ usually have no side-effects, but the methods called in _get_arbo_each_prod()_ do (they fetch every product, sequentially, into $this). This behavior isn’t what one would expect based on the method name.

## Example
```php
$myProduct = new Product($db);
$myProduct->fetch(12);
$id_before = $myProduct->id;
$subproducts = $myProduct->get_arbo_each_prod();
$id_after = $myProduct->id;
var_dump($id_before == $id_after);
// before fixing: false
// after fixing: true
```