### PR TITLE
fix case objecttmp is an invoice in selectForFormsList

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5558,7 +5558,7 @@ class Form
 		if ($prefixforautocompletemode == 'societe') $prefixforautocompletemode='company';
 		$confkeyforautocompletemode=strtoupper($prefixforautocompletemode).'_USE_SEARCH_TO_SELECT';	// For example COMPANY_USE_SEARCH_TO_SELECT
 
-		if (DOL_VERSION < 10 && $objecttmp->element == 'facture') $fieldstoshow = 't.facnumber';
+		if (((float) DOL_VERSION) < 10 && $objecttmp->element == 'facture') $fieldstoshow = 't.facnumber';
 		else $fieldstoshow='t.ref';
 		if (! empty($objecttmp->fields))	// For object that declare it, it is better to use declared fields ( like societe, contact, ...)
 		{

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5558,7 +5558,8 @@ class Form
 		if ($prefixforautocompletemode == 'societe') $prefixforautocompletemode='company';
 		$confkeyforautocompletemode=strtoupper($prefixforautocompletemode).'_USE_SEARCH_TO_SELECT';	// For example COMPANY_USE_SEARCH_TO_SELECT
 
-		$fieldstoshow='t.ref';
+		if (DOL_VERSION < 10 && $objecttmp->element == 'facture') $fieldstoshow = 't.facnumber';
+		else $fieldstoshow='t.ref';
 		if (! empty($objecttmp->fields))	// For object that declare it, it is better to use declared fields ( like societe, contact, ...)
 		{
 			$tmpfieldstoshow='';


### PR DESCRIPTION
# Fix behaviour for invoices
I've got an object with a field "fk_facture" which type is "integer:Facture:compta/facture/class/facture.class.php"
problem : in edit mode Form::the selectForFormsList build an sql query with fields rowid and **ref**.
On Facture objects, the ref is available only in 10.0