### PR TITLE
FIX : We must save code instead of value in database…

### DIFF
--- a/htdocs/compta/facture/fiche-rec.php
+++ b/htdocs/compta/facture/fiche-rec.php
@@ -1423,8 +1423,8 @@ else
             include_once DOL_DOCUMENT_ROOT . '/core/modules/facture/modules_facture.php';
             $list = array();
             $models = ModelePDFFactures::liste_modeles($db);
-            foreach ($models as $model) {
-                $list[] = $model . ':' . $model;
+            foreach ($models as $k => $model) {
+                $list[] = $k . ':' . $model;
             }
             $select = 'select;'.implode(',', $list);
             print $form->editfieldval($langs->trans("Model"), 'modelpdf', $object->modelpdf, $object, $user->rights->facture->creer, $select);


### PR DESCRIPTION
# Fix we must save code instead of value in database
When editing the PDF model on a template invoice, this will now save the code instead of value into database