### PR TITLE
FIX : correct error in files with multiple spaces

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -1540,6 +1540,11 @@ function dol_add_file_process($upload_dir, $allowoverwrite=0, $donotupdatesessio
 				$info = pathinfo($destfile);
 				$destfile = dol_sanitizeFileName($info['filename'].'.'.strtolower($info['extension']));
 
+                // We apply dol_string_nohtmltag also to clean file names (this remove duplicate spaces) because
+                // this function is also applied when we make try to download file (by the GETPOST(filename, 'alphanohtml') call).
+                $destfile = dol_string_nohtmltag($destfile);
+                $destfull = dol_string_nohtmltag($destfull);
+
 				$resupload = dol_move_uploaded_file($TFile['tmp_name'][$i], $destfull, $allowoverwrite, 0, $TFile['error'][$i], 0, $varfiles);
 
 				if (is_numeric($resupload) && $resupload > 0)   // $resupload can be 'ErrorFileAlreadyExists'


### PR DESCRIPTION
Fix : Correct filenames with multiple spaces

Avoid to get error when try to download a file originally uploaded with multiple spaces in its name