### PR TITLE
FIX: tk9877 - PDF rouget requires product.lib.php

### DIFF
--- a/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
@@ -29,6 +29,7 @@
 require_once DOL_DOCUMENT_ROOT.'/core/modules/expedition/modules_expedition.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/pdf.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/product.lib.php';
 
 
 /**


### PR DESCRIPTION
The PDF model calls `measuring_units_string()` which is defined in `product.lib.php`. If it has not been included before, this can result in a fatal error.