### PR TITLE
FIX: floating point precision errors in the triggers of the workflow module

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -316,7 +316,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
      *                                      invoices linked to $object
      * @param float $object_total_ht        The total amount (excl VAT) of the object
      *                                      (an order, a proposal, a bill, etc.)
-     * @return bool  True if the amounts are equal (arithmetic errors within tolerance margin)
+     * @return bool  True if the amounts are equal (rounded on total amount)
      *               True if the module is configured to skip the amount equality check
      *               False otherwise.
      */
@@ -326,10 +326,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
         if (!empty($conf->global->WORKFLOW_CLASSIFY_IF_AMOUNTS_ARE_DIFFERENTS)) {
             return true;
         }
-        // if the rounded amount difference is zero, allow classification, else deny
-        return 0 == round(
-            $totalonlinkedelements - $object_total_ht,
-            $conf->global->MAIN_MAX_DECIMALS_UNIT
-        );
+        // if the amount are same, allow classification, else deny
+        return (price2num($totalonlinkedelements, 'MT') == price2num($object_total_ht, 'MT'));
     }
 }


### PR DESCRIPTION
Some of the orders were not automatically set as 'billed' because of a very small floating point precision error causing the comparison of the sum of the invoices’ amounts with the order’s amount to fail. I expect that the same problem could happen with other types of documents, so I relocated the amount equality and settings checks to a new `shouldClassify()` method to make it easier to change the classification conditions if required.