### PR TITLE
FIX: expedition card: infinite loop for printObjectLine hook if return > 0

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1586,9 +1586,9 @@ if ($action == 'create')
 						print $line->showOptionals($extrafieldsline, 'edit', array('style'=>$bc[$var], 'colspan'=>$colspan),$indiceAsked);
 						print '</tr>';
 					}
-
-                	$indiceAsked++;
                 }
+
+	            $indiceAsked++;
             }
 
             print "</table>";


### PR DESCRIPTION
Introduced in merge commit https://github.com/Dolibarr/dolibarr/commit/a35a2faacb57271c622d158f982770ff419f5b26

