### PR TITLE
FIX issue #9300: install error with PostgreSQL using custom table prefix

### DIFF
--- a/htdocs/install/step2.php
+++ b/htdocs/install/step2.php
@@ -451,6 +451,11 @@ if ($action == "set")
                 $buffer=trim($buffer);
                 if ($buffer)
                 {
+                    // Replace the prefix in table names
+                    if ($dolibarr_main_db_prefix != 'llx_')
+                    {
+                        $buffer=preg_replace('/llx_/i',$dolibarr_main_db_prefix,$buffer);
+                    }
                     dolibarr_install_syslog("step2: request: " . $buffer);
                     print "<!-- Insert line : ".$buffer."<br>-->\n";
                     $resql=$db->query($buffer,0,'dml');


### PR DESCRIPTION
The llx_ replacement was missing from this part of `step2.php`.

It doesn’t affect MySQL simply because `mysql/functions/functions.sql` is essentially empty.