### PR TITLE
FIX order or proposals billed if both workflow conf activated

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -121,7 +121,8 @@ class InterfaceWorkflowManager extends DolibarrTriggers
         if ($action == 'BILL_VALIDATE')
         {
         	dol_syslog( "Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id );
-
+        	$ret = null;
+        	
 			// First classify billed the order to allow the proposal classify process
 			if (! empty($conf->commande->enabled) && ! empty($conf->workflow->enabled) && ! empty($conf->global->WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_ORDER))
         	{
@@ -142,7 +143,6 @@ class InterfaceWorkflowManager extends DolibarrTriggers
         		        }
         		    }
         		}
-        		return $ret;
         	}
 
 			// Second classify billed the proposal.
@@ -165,8 +165,9 @@ class InterfaceWorkflowManager extends DolibarrTriggers
         		        }
         		    }
         		}
-        		return $ret;
         	}
+        	
+        	return $ret;
         }
 
         // classify billed order & billed propososal

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -121,7 +121,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
         if ($action == 'BILL_VALIDATE')
         {
         	dol_syslog( "Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id );
-        	$ret = null;
+        	$ret = 0;
         	
 			// First classify billed the order to allow the proposal classify process
 			if (! empty($conf->commande->enabled) && ! empty($conf->workflow->enabled) && ! empty($conf->global->WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_ORDER))


### PR DESCRIPTION
# FIX workflow
If both configurations (auto proposal and auto order billed clasify) are activated, the previous code only checked order and never proposals. I fixed it by a general return.
