### PR TITLE
Add contextpage hidden input to preserve contexpage in customer search form

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -596,6 +596,7 @@ print '<input type="hidden" name="formfilteraction" id="formfilteraction" value=
 print '<input type="hidden" name="sortfield" value="'.$sortfield.'">';
 print '<input type="hidden" name="sortorder" value="'.$sortorder.'">';
 print '<input type="hidden" name="page" value="'.$page.'">';
+print '<input type="hidden" name="contextpage" value="'.$contextpage.'">';
 
 print_barre_liste($title, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, 'title_companies', 0, $newcardbutton, '', $limit);
 


### PR DESCRIPTION
Adding a contextpage hidden input we preserve contextpage variable in customer search in TakePOS and fix this issue:
[https://github.com/Dolibarr/dolibarr/issues/11626#issue-476460212](https://github.com/Dolibarr/dolibarr/issues/11626#issue-476460212)

Thank you @ptibogxiv 
