### PR TITLE
NEW compute column value from others columns in import module

### DIFF
--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -581,8 +581,27 @@ class ImportCsv extends ModeleImports
                                     if (is_numeric($defaultref) && $defaultref <= 0) $defaultref='';
                                     $newval=$defaultref;
                                 }
-
-
+                                elseif ($objimport->array_import_convertvalue[0][$val]['rule']=='compute')
+                                {
+                                    $file=(empty($objimport->array_import_convertvalue[0][$val]['classfile'])?$objimport->array_import_convertvalue[0][$val]['file']:$objimport->array_import_convertvalue[0][$val]['classfile']);
+                                    $class=$objimport->array_import_convertvalue[0][$val]['class'];
+                                    $method=$objimport->array_import_convertvalue[0][$val]['method'];
+                                    $resultload = dol_include_once($file);
+                                    if (empty($resultload))
+                                    {
+                                        dol_print_error('', 'Error trying to call file='.$file.', class='.$class.', method='.$method);
+                                        break;
+                                    }
+                                    $classinstance=new $class($this->db);
+                                    $res = call_user_func_array(array($classinstance, $method), array(&$arrayrecord));
+                                    if ($res<0) {
+                                        if (!empty($objimport->array_import_convertvalue[0][$val]['dict'])) $this->errors[$error]['lib']=$langs->trans('ErrorFieldValueNotIn', $key, $newval, 'code', $langs->transnoentitiesnoconv($objimport->array_import_convertvalue[0][$val]['dict']));
+                                        else $this->errors[$error]['lib']='ErrorFieldValueNotIn';
+                                        $this->errors[$error]['type']='FOREIGNKEY';
+                                        $errorforthistable++;
+                                        $error++;
+                                    }
+                                }
                                 elseif ($objimport->array_import_convertvalue[0][$val]['rule']=='numeric')
                                 {
                                     $newval = price2num($newval);

--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -608,8 +608,27 @@ class ImportXlsx extends ModeleImports
                                     if (is_numeric($defaultref) && $defaultref <= 0) $defaultref='';
                                     $newval=$defaultref;
                                 }
-
-
+                                elseif ($objimport->array_import_convertvalue[0][$val]['rule']=='compute')
+                                {
+                                    $file=(empty($objimport->array_import_convertvalue[0][$val]['classfile'])?$objimport->array_import_convertvalue[0][$val]['file']:$objimport->array_import_convertvalue[0][$val]['classfile']);
+                                    $class=$objimport->array_import_convertvalue[0][$val]['class'];
+                                    $method=$objimport->array_import_convertvalue[0][$val]['method'];
+                                    $resultload = dol_include_once($file);
+                                    if (empty($resultload))
+                                    {
+                                        dol_print_error('', 'Error trying to call file='.$file.', class='.$class.', method='.$method);
+                                        break;
+                                    }
+                                    $classinstance=new $class($this->db);
+                                    $res = call_user_func_array(array($classinstance, $method), array(&$arrayrecord));
+                                    if ($res<0) {
+                                        if (!empty($objimport->array_import_convertvalue[0][$val]['dict'])) $this->errors[$error]['lib']=$langs->trans('ErrorFieldValueNotIn', $key, $newval, 'code', $langs->transnoentitiesnoconv($objimport->array_import_convertvalue[0][$val]['dict']));
+                                        else $this->errors[$error]['lib']='ErrorFieldValueNotIn';
+                                        $this->errors[$error]['type']='FOREIGNKEY';
+                                        $errorforthistable++;
+                                        $error++;
+                                    }
+                                }
                                 elseif ($objimport->array_import_convertvalue[0][$val]['rule']=='numeric')
                                 {
                                     $newval = price2num($newval);


### PR DESCRIPTION
# New compute column value from others columns in import module
In CSV and XLS import module it will be useful to had a method to compute a value.
The new value is computed from other columns values (from current line in import file).

Example : If you have in a first column the tax value and in a second column the price without taxes and an empty column for the price with taxes. You can automatically compute the price with taxes. 
In import model you put :
- $this->import_convertvalue_array[$r]  = array( 'cp.price' => array('rule' => 'compute', 'classfile' => '/monmodule/class/myclass.class.php', 'class' => 'MyClass', 'method' => 'compute_price', 'element' => 'MyModule'));

So, you add a class "MyClass" in "MyModule" with a method "compute_price" and you can automatically compute the price with taxes (and this column can be empty in CSV or XLS import file).


