### PR TITLE
Fix #11682 Missing origin object ref and thirdparty ref in future bank entries

### DIFF
--- a/htdocs/admin/pdf.php
+++ b/htdocs/admin/pdf.php
@@ -283,7 +283,7 @@ if ($action == 'edit')	// Edit
 	//Invert sender and recipient
 
 	print '<tr class="oddeven"><td>'.$langs->trans("SwapSenderAndRecipientOnPDF").'</td><td>';
-	print $form->selectyesno('MAIN_INVERT_SENDER_RECIPIENT',(! empty($conf->global->MAIN_INVERT_SENDER_RECIPIENT))?$conf->global->MAIN_INVERT_SENDER_RECIPIENT:0,1);
+	print $form->selectyesno('MAIN_INVERT_SENDER_RECIPIENT', (! empty($conf->global->MAIN_INVERT_SENDER_RECIPIENT))?$conf->global->MAIN_INVERT_SENDER_RECIPIENT:0, 1);
 	print '</td></tr>';
 
  	// Place customer adress to the ISO location

--- a/htdocs/compta/bank/treso.php
+++ b/htdocs/compta/bank/treso.php
@@ -267,9 +267,9 @@ if ($_REQUEST["account"] || $_REQUEST["ref"])
 			$parameters = array('obj' => $obj);
 			$reshook = $hookmanager->executeHooks('moreFamily', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 			if(empty($reshook)){
-				$ref = isset($hookmanager->resArray['ref']) ? $hookmanager->resArray['ref'] : '';
-				$refcomp = isset($hookmanager->resArray['refcomp']) ? $hookmanager->resArray['refcomp'] : '';
-				$paiement = isset($hookmanager->resArray['paiement']) ? $hookmanager->resArray['paiement'] : 0;
+				$ref = isset($hookmanager->resArray['ref']) ? $hookmanager->resArray['ref'] : $ref;
+				$refcomp = isset($hookmanager->resArray['refcomp']) ? $hookmanager->resArray['refcomp'] : $refcomp;
+				$paiement = isset($hookmanager->resArray['paiement']) ? $hookmanager->resArray['paiement'] : $paiement;
 			}
 
 			$total_ttc = $obj->total_ttc;


### PR DESCRIPTION
# Fix #11682 
Fix missing origin object ref and third-party ref in future bank entries.

![future-bank](https://user-images.githubusercontent.com/613615/63158672-0fe72500-c01a-11e9-8378-405cc96c290c.png)

