### PR TITLE
If user has not used change control in TakePOS, add total invoice payment

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -175,6 +175,9 @@ if ($action == 'valid' && $user->rights->facture->creer)
 	$payment->datepaye = $now;
 	$payment->fk_account = $bankaccount;
 	$payment->amounts[$invoice->id] = $amountofpayment;
+	
+	// If user has not used change control, add total invoice payment
+	if ($amountofpayment == 0) $payment->amounts[$invoice->id] = $invoice->total_ttc;
 
 	$payment->paiementid=$paiementid;
 	$payment->num_payment=$invoice->ref;


### PR DESCRIPTION
When the cashier does not use the change control and pressed on the payment method does not mean this sale is not payed, it means that he has not needed to control the change. Therefore the sale should be marked as paid.