### PR TITLE
Cashcontrol TakePOS fixes

### DIFF
--- a/htdocs/compta/cashcontrol/cashcontrol_card.php
+++ b/htdocs/compta/cashcontrol/cashcontrol_card.php
@@ -88,7 +88,7 @@ if (empty($backtopage)) $backtopage = dol_buildpath('/compta/cashcontrol/cashcon
 $backurlforlist = dol_buildpath('/compta/cashcontrol/cashcontrol_list.php', 1);
 $triggermodname = 'CACHCONTROL_MODIFY';	// Name of trigger action code to execute when we modify record
 
-if (empty($conf->global->CASHDESK_ID_BANKACCOUNT_CASH))
+if (empty($conf->global->CASHDESK_ID_BANKACCOUNT_CASH) && empty($conf->global->CASHDESK_ID_BANKACCOUNT_CASH1))
 {
 	setEventMessages($langs->trans("CashDesk")." - ".$langs->trans("NotConfigured"), null, 'errors');
 }
@@ -132,16 +132,7 @@ elseif ($action=="add")
 	$error=0;
 	foreach($arrayofpaymentmode as $key=>$val)
 	{
-		if (GETPOST($key.'_amount', 'alpha') == '')
-		{
-			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv($val)), null, 'errors');
-			$action='start';
-			$error++;
-		}
-		else
-		{
-			$object->$key = price2num(GETPOST($key.'_amount', 'alpha'));
-		}
+		$object->$key = price2num(GETPOST($key.'_amount', 'alpha'));
 	}
 
 	if (! $error)
@@ -235,7 +226,7 @@ if ($action=="create" || $action=="start")
 		$posmodule = GETPOST('posmodule', 'alpha');
 		$terminalid = GETPOST('posnumber', 'alpha');
 		$terminaltouse = $terminalid;
-		if ($terminaltouse == '1') $terminaltouse = '';
+		if ($terminaltouse == '1' && $posmodule=='cashdesk') $terminaltouse = '';
 
 		// Calculate $initialbalanceforterminal for terminal 0
 		foreach($arrayofpaymentmode as $key => $val)

--- a/htdocs/compta/cashcontrol/report.php
+++ b/htdocs/compta/cashcontrol/report.php
@@ -196,10 +196,18 @@ if ($resql)
     	// Bank account
         print '<td class="nowrap right">';
 		print $bankaccount->getNomUrl(1);
-		if ($conf->global->CASHDESK_ID_BANKACCOUNT_CASH==$bankaccount->id) $cash+=$objp->amount;
-		elseif ($conf->global->CASHDESK_ID_BANKACCOUNT_CB==$bankaccount->id) $bank+=$objp->amount;
-		elseif ($conf->global->CASHDESK_ID_BANKACCOUNT_CHEQUE==$bankaccount->id) $cheque+=$objp->amount;
-		else $other+=$objp->amount;
+		if ($cashcontrol->posmodule=="takepos"){
+			if ($conf->global->{'CASHDESK_ID_BANKACCOUNT_CASH'.$cashcontrol->posnumber}==$bankaccount->id) $cash+=$objp->amount;
+			elseif ($conf->global->{'CASHDESK_ID_BANKACCOUNT_CB'.$cashcontrol->posnumber}==$bankaccount->id) $bank+=$objp->amount;
+			elseif ($conf->global->{'CASHDESK_ID_BANKACCOUNT_CHEQUE'.$cashcontrol->posnumber}==$bankaccount->id) $cheque+=$objp->amount;
+			else $other+=$objp->amount;
+		}
+		else{
+			if ($conf->global->CASHDESK_ID_BANKACCOUNT_CASH==$bankaccount->id) $cash+=$objp->amount;
+			elseif ($conf->global->CASHDESK_ID_BANKACCOUNT_CB==$bankaccount->id) $bank+=$objp->amount;
+			elseif ($conf->global->CASHDESK_ID_BANKACCOUNT_CHEQUE==$bankaccount->id) $cheque+=$objp->amount;
+			else $other+=$objp->amount;
+		}
 		print "</td>\n";
         if (! $i) $totalarray['nbfield']++;
 


### PR DESCRIPTION
This commit fix this:
1. First terminal in TakePOS use CASHDESK_ID_BANKACCOUNT_CASH**1**
2. When starts a new cash fence the final amounts are unknown, so are not required fields
