### PR TITLE
FIX missing hook

### DIFF
--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -593,7 +593,8 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
                 print '<td align="right">'.$alreadypayedlabel.'</td>';
                 print '<td align="right">'.$remaindertopay.'</td>';
                 print '<td align="right">'.$langs->trans('PaymentAmount').'</td>';
-                print '<td align="right">&nbsp;</td>';
+				$reshook=$hookmanager->executeHooks('printObjectLineTitle',$parameters,$objp,$action);
+				print '<td align="right">&nbsp;</td>';
                 print "</tr>\n";
 
                 $total=0;


### PR DESCRIPTION
# Fix # *9.0 Missing Hook*
*Hook "printObjectLine" ok but Hook "printObjectLineTitle" missing*
