### PR TITLE
NEW Add hidden option THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_ORDER to copy extrafields from third party to order

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1758,12 +1758,14 @@ if ($action == 'create' && $usercancreate)
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action);
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
+		if (! empty($conf->global->THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_ORDER))
 		// copy from thirdparty
 				$tpExtrafields = new Extrafields($db);
 				$tpExtrafieldLabels = $tpExtrafields->fetch_name_optionals_label($soc->table_element);
 				if ($soc->fetch_optionals() > 0) {
 					$object->array_options = array_merge($object->array_options, $soc->array_options);
 				}
+		};
 				print $object->showOptionals($extrafields, 'edit');
 	}
 

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1765,7 +1765,6 @@ if ($action == 'create' && $usercancreate)
 					$object->array_options = array_merge($object->array_options, $soc->array_options);
 				}
 				print $object->showOptionals($extrafields, 'edit');
-
 	}
 
 	// Template to use by default

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1758,7 +1758,14 @@ if ($action == 'create' && $usercancreate)
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action);
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit');
+		// copy from thirdparty
+				$tpExtrafields = new Extrafields($db);
+				$tpExtrafieldLabels = $tpExtrafields->fetch_name_optionals_label($soc->table_element);
+				if ($soc->fetch_optionals() > 0) {
+					$object->array_options = array_merge($object->array_options, $soc->array_options);
+				}
+				print $object->showOptionals($extrafields, 'edit');
+
 	}
 
 	// Template to use by default


### PR DESCRIPTION


# Fix copy of extra fields from third party to order
Extra fields of third party were not transferred to the order from that third party
