### PR TITLE
Fix Delete action for documents backup.

### DIFF
--- a/htdocs/admin/tools/dolibarr_export.php
+++ b/htdocs/admin/tools/dolibarr_export.php
@@ -50,7 +50,7 @@ if (! $user->admin)
 
 if ($action == 'delete')
 {
-	if (preg_match('/backup\//', GETPOST('urlfile', 'alpha')))
+	if (preg_match('/^backup\//', GETPOST('urlfile', 'alpha')))
 	{
 		$file=$conf->admin->dir_output.'/backup/'.basename(GETPOST('urlfile', 'alpha'));
 		$ret=dol_delete_file($file, 1);

--- a/htdocs/admin/tools/dolibarr_export.php
+++ b/htdocs/admin/tools/dolibarr_export.php
@@ -50,7 +50,7 @@ if (! $user->admin)
 
 if ($action == 'delete')
 {
-	if (preg_match('#backup/#', GETPOST('urlfile', 'alpha')))
+	if (preg_match('/backup\//', GETPOST('urlfile', 'alpha')))
 	{
 		$file=$conf->admin->dir_output.'/backup/'.basename(GETPOST('urlfile', 'alpha'));
 		$ret=dol_delete_file($file, 1);

--- a/htdocs/admin/tools/dolibarr_export.php
+++ b/htdocs/admin/tools/dolibarr_export.php
@@ -50,7 +50,7 @@ if (! $user->admin)
 
 if ($action == 'delete')
 {
-	if (preg_match('#backup/#', GETPOST('urlfile', 'alpha'))) 
+	if (preg_match('#backup/#', GETPOST('urlfile', 'alpha')))
 	{
 		$file=$conf->admin->dir_output.'/backup/'.basename(GETPOST('urlfile', 'alpha'));
 		$ret=dol_delete_file($file, 1);

--- a/htdocs/admin/tools/dolibarr_export.php
+++ b/htdocs/admin/tools/dolibarr_export.php
@@ -67,7 +67,6 @@ if ($action == 'delete')
 	$action='';
 }
 
-
 /*
  * View
  */

--- a/htdocs/admin/tools/dolibarr_export.php
+++ b/htdocs/admin/tools/dolibarr_export.php
@@ -50,11 +50,21 @@ if (! $user->admin)
 
 if ($action == 'delete')
 {
-	$file=$conf->admin->dir_output.'/backup/'.basename(GETPOST('urlfile', 'alpha'));
-    $ret=dol_delete_file($file, 1);
-    if ($ret) setEventMessages($langs->trans("FileWasRemoved", GETPOST('urlfile')), null, 'mesgs');
-    else setEventMessages($langs->trans("ErrorFailToDeleteFile", GETPOST('urlfile')), null, 'errors');
-    $action='';
+        if (preg_match('#backup/#', GETPOST('urlfile', 'alpha'))) 
+		{
+            $file=$conf->admin->dir_output.'/backup/'.basename(GETPOST('urlfile', 'alpha'));
+           $ret=dol_delete_file($file, 1);
+           if ($ret) setEventMessages($langs->trans("FileWasRemoved", GETPOST('urlfile')), null, 'mesgs');
+           else setEventMessages($langs->trans("ErrorFailToDeleteFile", GETPOST('urlfile')), null, 'errors');
+        }
+        else 
+		{
+           $file=$conf->admin->dir_output.'/documents/'.basename(GETPOST('urlfile', 'alpha'));
+           $ret=dol_delete_file($file, 1);
+           if ($ret) setEventMessages($langs->trans("FileWasRemoved", GETPOST('urlfile')), null, 'mesgs');
+           else setEventMessages($langs->trans("ErrorFailToDeleteFile", GETPOST('urlfile')), null, 'errors');
+        }
+        $action='';
 }
 
 

--- a/htdocs/admin/tools/dolibarr_export.php
+++ b/htdocs/admin/tools/dolibarr_export.php
@@ -50,21 +50,21 @@ if (! $user->admin)
 
 if ($action == 'delete')
 {
-        if (preg_match('#backup/#', GETPOST('urlfile', 'alpha'))) 
-		{
-            $file=$conf->admin->dir_output.'/backup/'.basename(GETPOST('urlfile', 'alpha'));
-           $ret=dol_delete_file($file, 1);
-           if ($ret) setEventMessages($langs->trans("FileWasRemoved", GETPOST('urlfile')), null, 'mesgs');
-           else setEventMessages($langs->trans("ErrorFailToDeleteFile", GETPOST('urlfile')), null, 'errors');
-        }
-        else 
-		{
-           $file=$conf->admin->dir_output.'/documents/'.basename(GETPOST('urlfile', 'alpha'));
-           $ret=dol_delete_file($file, 1);
-           if ($ret) setEventMessages($langs->trans("FileWasRemoved", GETPOST('urlfile')), null, 'mesgs');
-           else setEventMessages($langs->trans("ErrorFailToDeleteFile", GETPOST('urlfile')), null, 'errors');
-        }
-        $action='';
+	if (preg_match('#backup/#', GETPOST('urlfile', 'alpha'))) 
+	{
+		$file=$conf->admin->dir_output.'/backup/'.basename(GETPOST('urlfile', 'alpha'));
+		$ret=dol_delete_file($file, 1);
+		if ($ret) setEventMessages($langs->trans("FileWasRemoved", GETPOST('urlfile')), null, 'mesgs');
+		else setEventMessages($langs->trans("ErrorFailToDeleteFile", GETPOST('urlfile')), null, 'errors');
+	}
+	else
+	{
+		$file=$conf->admin->dir_output.'/documents/'.basename(GETPOST('urlfile', 'alpha'));
+		$ret=dol_delete_file($file, 1);
+		if ($ret) setEventMessages($langs->trans("FileWasRemoved", GETPOST('urlfile')), null, 'mesgs');
+		else setEventMessages($langs->trans("ErrorFailToDeleteFile", GETPOST('urlfile')), null, 'errors');
+	}
+	$action='';
 }
 
 

--- a/htdocs/stripe/class/stripe.class.php
+++ b/htdocs/stripe/class/stripe.class.php
@@ -92,7 +92,7 @@ class Stripe extends CommonObject
 		if ($fk_soc > 0) {
 			$sql.= " AND fk_soc = ".$fk_soc;
 		}
-		else { 
+		else {
 			$sql.= " AND fk_soc IS NULL";
 		}
 		$sql.= " AND fk_user IS NULL AND fk_adherent IS NULL";


### PR DESCRIPTION
# Fix # [delete action not working on documents backups]
When trying to delete a document backup it never works because the delete action always use documents/admin/backup directory instead of documents/admin/documents directory.(If preg_match is too "heavy" it can be replaced by strpos)


