### PR TITLE
Fix wrong placement to print title and missing hook to print value

### DIFF
--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -593,6 +593,10 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
                 print '<td align="right">'.$alreadypayedlabel.'</td>';
                 print '<td align="right">'.$remaindertopay.'</td>';
                 print '<td align="right">'.$langs->trans('PaymentAmount').'</td>';
+
+                $parameters=array();
+                $reshook=$hookmanager->executeHooks('printFieldListTitle', $parameters, $facture, $action); // Note that $action and $object may have been modified by hook
+
                 print '<td align="right">&nbsp;</td>';
                 print "</tr>\n";
 
@@ -737,7 +741,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
                     print "</td>";
 
                     $parameters=array();
-                    $reshook=$hookmanager->executeHooks('printFieldListTitle', $parameters, $objp, $action); // Note that $action and $object may have been modified by hook
+                    $reshook=$hookmanager->executeHooks('printFieldListValue', $parameters, $objp, $action); // Note that $action and $object may have been modified by hook
 
                     // Warning
                     print '<td align="center" width="16">';


### PR DESCRIPTION
# Fix

On payment card from customer side :  
Before 
![image](https://user-images.githubusercontent.com/10596597/63573986-06643c80-c587-11e9-8ce2-fda2ddde729d.png)

After
![image](https://user-images.githubusercontent.com/10596597/63574003-111ed180-c587-11e9-98d1-0f74b8505220.png)

In #11710, @atm-lena use wrong name for hook and you @eldy your commit a35f010e55e76518bf don't fix the original subject
So I did again this pull request to allow developers to interact properly on this view