### PR TITLE
Control errors before validate invoice in TakePOS

### DIFF
--- a/htdocs/langs/en_US/cashdesk.lang
+++ b/htdocs/langs/en_US/cashdesk.lang
@@ -72,3 +72,5 @@ BasicPhoneLayout=Use basic layout for phones
 SetupOfTerminalNotComplete=Setup of terminal %s is not complete
 DirectPayment=Direct payment
 DirectPaymentButton=Direct cash payment button
+InvoiceIsAlreadyValidated=Invoice is already validated
+NoLinesToBill=No lines to bill

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -166,12 +166,12 @@ if ($action == 'valid' && $user->rights->facture->creer)
 		dol_syslog("Sale already validated");
 		dol_htmloutput_errors($langs->trans("InvoiceIsAlreadyValidated", "TakePos"), null, 1);
 	}
-	else if (count($invoice->lines)==0)
+	elseif (count($invoice->lines)==0)
 	{
 		dol_syslog("Sale without lines");
 		dol_htmloutput_errors($langs->trans("NoLinesToBill", "TakePos"), null, 1);
 	}
-	else if (! empty($conf->stock->enabled) && $conf->global->{'CASHDESK_NO_DECREASE_STOCK'.$_SESSION["takeposterminal"]} != "1")
+	elseif (! empty($conf->stock->enabled) && $conf->global->{'CASHDESK_NO_DECREASE_STOCK'.$_SESSION["takeposterminal"]} != "1")
 	{
 	    $invoice->validate($user, '', $conf->global->{'CASHDESK_ID_WAREHOUSE'.$_SESSION["takeposterminal"]});
 	}

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -161,7 +161,17 @@ if ($action == 'valid' && $user->rights->facture->creer)
 		$invoice->update($user);
 	}
 
-	if (! empty($conf->stock->enabled) && $conf->global->{'CASHDESK_NO_DECREASE_STOCK'.$_SESSION["takeposterminal"]} != "1")
+	if ($invoice->statut != Facture::STATUS_DRAFT)
+	{
+		dol_syslog("Sale already validated");
+		dol_htmloutput_errors($langs->trans("InvoiceIsAlreadyValidated", "TakePos"), null, 1);
+	}
+	else if (count($invoice->lines)==0)
+	{
+		dol_syslog("Sale without lines");
+		dol_htmloutput_errors($langs->trans("NoLinesToBill", "TakePos"), null, 1);
+	}
+	else if (! empty($conf->stock->enabled) && $conf->global->{'CASHDESK_NO_DECREASE_STOCK'.$_SESSION["takeposterminal"]} != "1")
 	{
 	    $invoice->validate($user, '', $conf->global->{'CASHDESK_ID_WAREHOUSE'.$_SESSION["takeposterminal"]});
 	}


### PR DESCRIPTION
Avoid validate invoice if is already validated or is the invoice is empty.
Avoid also revalidate if it have been validated from another terminal.