### PR TITLE
FIX: objectline_create.tpl.php

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -721,7 +721,7 @@ jQuery(document).ready(function() {
     	      			{
     	      				// If margin is calculated on PMP, we set it by defaut (but only if value is not 0)
     			      		//console.log("id="+this.id+"-price="+this.price);
-    			      		if ('pmp' == defaultbuyprice || 'costprice' == defaultbuyprice)
+    			      		if ('pmp' == defaultbuyprice)
     			      		{
     			      			if (this.price > 0) {
     				      			defaultkey = this.id; defaultprice = this.price; pmppriceid = this.id; pmppricevalue = this.price;


### PR DESCRIPTION
If we set by default cost price to calculate margin, it show PMP.
# Steps to reproduce the behavior
In setup Margin Module we can set 3 modes to calculate margin:
- Best provider price
- PMP
- Cost price

Inserting a new product **_automatically_** we see by default the price that will be used to calculate the margin as we have defined in the module before. 

So, in  Cost Price mode it shows PMP (in rest of cases are right). 

This PR try to make default Cost Price if we set this mode.




