### PR TITLE
Add some enhancements to TravisCI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,7 @@ addons:
   apt:
     sources:
     # To use the last version of pgloader, we add repo of postgresql
-    - postgresql
-    - sourceline: 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main'
-    - key_url: 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+    - pgdg
     packages:
     # We need a webserver to test the webservices
     # Let's install Apache with.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
   apt:
     sources:
     # To use the last version of pgloader, we add repo of postgresql
-    - pgdg
+    - pgdg-trusty
     packages:
     # We need a webserver to test the webservices
     # Let's install Apache with.

--- a/.travis.yml
+++ b/.travis.yml
@@ -293,7 +293,7 @@ script:
   set -e
   # Exclusions are defined in the ruleset.xml file
   #phpcs -s -n -p -d memory_limit=-1 --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 .
-  if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then phpcs -s -p -d memory_limit=-1 --parallel=5 --extensions=php --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 --runtime-set ignore_warnings_on_exit true .; fi
+  if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then phpcs -s -p -d memory_limit=-1 --extensions=php --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 --runtime-set ignore_warnings_on_exit true .; fi
   set +e
   echo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -293,7 +293,7 @@ script:
   set -e
   # Exclusions are defined in the ruleset.xml file
   #phpcs -s -n -p -d memory_limit=-1 --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 .
-  if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then phpcs -s -p -d memory_limit=-1 --parallel=16 --extensions=php --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 --runtime-set ignore_warnings_on_exit true .; fi
+  if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then phpcs -s -p -d memory_limit=-1 --parallel=5 --extensions=php --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 --runtime-set ignore_warnings_on_exit true .; fi
   set +e
   echo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -293,7 +293,7 @@ script:
   set -e
   # Exclusions are defined in the ruleset.xml file
   #phpcs -s -n -p -d memory_limit=-1 --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 .
-  if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then phpcs -s -p -d memory_limit=-1 --extensions=php --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 --runtime-set ignore_warnings_on_exit true .; fi
+  if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then phpcs -s -p -d memory_limit=-1 --parallel=16 --extensions=php --colors --tab-width=4 --standard=dev/setup/codesniffer/ruleset.xml --encoding=utf-8 --runtime-set ignore_warnings_on_exit true .; fi
   set +e
   echo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,32 +110,31 @@ install:
   rm $TRAVIS_BUILD_DIR/composer.json
   rm $TRAVIS_BUILD_DIR/composer.lock
   composer self-update
+  composer global require hirak/prestissimo
   composer -n init
   composer -n config vendor-dir htdocs/includes
   echo
 
 - |
-  echo "Installing Parallel Lint"
-  composer -n require jakub-onderka/php-parallel-lint ^0
-  composer -n require jakub-onderka/php-console-highlighter ^0
-  echo
-
-- |
-  echo "Installing PHP Unit"
+  echo "Installing Composer dependencies (PHP Unit, Parallel Lint & PHP CodeSniffer"
   if [ "$TRAVIS_PHP_VERSION" = '5.4' ] || [ "$TRAVIS_PHP_VERSION" = '5.5' ]; then
-    composer -n require phpunit/phpunit ^4
+    composer -n require phpunit/phpunit ^4 \
+                        jakub-onderka/php-parallel-lint ^0 \
+                        jakub-onderka/php-console-highlighter ^0 \
+                        squizlabs/php_codesniffer ^3
   fi
   if [ "$TRAVIS_PHP_VERSION" = '5.6' ] || [ "$TRAVIS_PHP_VERSION" = '7.0' ] || [ "$TRAVIS_PHP_VERSION" = '7.1' ]; then
-    composer -n require phpunit/phpunit ^5
+    composer -n require phpunit/phpunit ^5 \
+                        jakub-onderka/php-parallel-lint ^0 \
+                        jakub-onderka/php-console-highlighter ^0 \
+                        squizlabs/php_codesniffer ^3
   fi
   if [ "$TRAVIS_PHP_VERSION" = '7.2' ] || [ "$TRAVIS_PHP_VERSION" = '7.3' ] || [ "$TRAVIS_PHP_VERSION" = 'nightly' ]; then
-    composer -n require phpunit/phpunit ^5
+    composer -n require phpunit/phpunit ^5 \
+                        jakub-onderka/php-parallel-lint ^0 \
+                        jakub-onderka/php-console-highlighter ^0 \
+                        squizlabs/php_codesniffer ^3
   fi
-  echo
-
-- |
-  echo "Installing PHP CodeSniffer"
-  composer -n require squizlabs/php_codesniffer ^3
   echo
 
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -246,8 +246,8 @@ before_script:
 
 
   - echo "Setting up Apache + FPM"
-  - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -244,8 +244,6 @@ before_script:
 
 
   - echo "Setting up Apache + FPM"
-  - travis_retry sudo apt-get update
-  - travis_retry sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,7 @@ install:
   rm $TRAVIS_BUILD_DIR/composer.json
   rm $TRAVIS_BUILD_DIR/composer.lock
   composer self-update
+  # To have composer making parallel downloads
   composer global require hirak/prestissimo
   composer -n init
   composer -n config vendor-dir htdocs/includes

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,18 +123,19 @@ install:
                         jakub-onderka/php-console-highlighter ^0 \
                         squizlabs/php_codesniffer ^3
   fi
-  if [ "$TRAVIS_PHP_VERSION" = '5.6' ] || [ "$TRAVIS_PHP_VERSION" = '7.0' ] || [ "$TRAVIS_PHP_VERSION" = '7.1' ]; then
+  if [ "$TRAVIS_PHP_VERSION" = '5.6' ] || [ "$TRAVIS_PHP_VERSION" = '7.0' ] || [ "$TRAVIS_PHP_VERSION" = '7.1' ] \
+     [ "$TRAVIS_PHP_VERSION" = '7.2' ] || [ "$TRAVIS_PHP_VERSION" = '7.3' ]; then
     composer -n require phpunit/phpunit ^5 \
                         jakub-onderka/php-parallel-lint ^0 \
                         jakub-onderka/php-console-highlighter ^0 \
                         squizlabs/php_codesniffer ^3
   fi
-  if [ "$TRAVIS_PHP_VERSION" = '7.2' ] || [ "$TRAVIS_PHP_VERSION" = '7.3' ] || [ "$TRAVIS_PHP_VERSION" = 'nightly' ]; then
-    composer -n require phpunit/phpunit ^5 \
-                        jakub-onderka/php-parallel-lint ^0 \
-                        jakub-onderka/php-console-highlighter ^0 \
-                        squizlabs/php_codesniffer ^3
-  fi
+  if [ "$TRAVIS_PHP_VERSION" = 'nightly' ]; then
+      composer -n require --ignore-platform-reqs phpunit/phpunit ^5 \
+                                                 jakub-onderka/php-parallel-lint ^0 \
+                                                 jakub-onderka/php-console-highlighter ^0 \
+                                                 squizlabs/php_codesniffer ^3
+    fi
   echo
 
 - |


### PR DESCRIPTION
- Using **`pgdg-trusty`** from `travis-ci/apt-source-safelist` for initializing PostgreSQL repository for pgloader.
- Installing `composer` dependencies using `hirak/prestissimo` (parallel downloads from GitHub archives) and requiring the dependencies in only one command.
- Adding `--ignore-platform-reqs`option to `composer` requirements **for PHP nightly** to not stop the build even if the PHP requirements are not met (some packages requires explicitly nothing greater than PHP 7.x).
- Removing the `apt-get update && apt-get install apache2 libapache2-mod-fastcgi` as both packages are already installed 

https://github.com/jtraulle/dolibarr/blob/0939ea18bc2946e3e779afc4fd96d1447e86afee/.travis.yml#L23-L27