### PR TITLE
Fix #11682 Missing origin object ref and thirdparty ref in future ban…

### DIFF
--- a/htdocs/compta/bank/treso.php
+++ b/htdocs/compta/bank/treso.php
@@ -267,9 +267,9 @@ if ($_REQUEST["account"] || $_REQUEST["ref"])
 			$parameters = array('obj' => $obj);
 			$reshook = $hookmanager->executeHooks('moreFamily', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 			if(empty($reshook)){
-				$ref = isset($hookmanager->resArray['ref']) ? $hookmanager->resArray['ref'] : '';
-				$refcomp = isset($hookmanager->resArray['refcomp']) ? $hookmanager->resArray['refcomp'] : '';
-				$paiement = isset($hookmanager->resArray['paiement']) ? $hookmanager->resArray['paiement'] : 0;
+				$ref = isset($hookmanager->resArray['ref']) ? $hookmanager->resArray['ref'] : $ref;
+				$refcomp = isset($hookmanager->resArray['refcomp']) ? $hookmanager->resArray['refcomp'] : $refcomp;
+				$paiement = isset($hookmanager->resArray['paiement']) ? $hookmanager->resArray['paiement'] : $paiement;
 			}
 
 			$total_ttc = $obj->total_ttc;

--- a/htdocs/compta/bank/treso.php
+++ b/htdocs/compta/bank/treso.php
@@ -269,7 +269,7 @@ if ($_REQUEST["account"] || $_REQUEST["ref"])
 			if(empty($reshook)){
 				$ref = isset($hookmanager->resArray['ref']) ? $hookmanager->resArray['ref'] : $ref;
 				$refcomp = isset($hookmanager->resArray['refcomp']) ? $hookmanager->resArray['refcomp'] : $refcomp;
-				$paiement = isset($hookmanager->resArray['payment']) ? $hookmanager->resArray['payment'] : $paiement;
+				$paiement = isset($hookmanager->resArray['paiement']) ? $hookmanager->resArray['paiement'] : $paiement;
 			}
 
 			$total_ttc = $obj->total_ttc;

--- a/htdocs/compta/bank/treso.php
+++ b/htdocs/compta/bank/treso.php
@@ -264,12 +264,12 @@ if ($_REQUEST["account"] || $_REQUEST["ref"])
 				$paiement = -1*$socialcontribstatic->getSommePaiement();	// Payment already done
 			}
 
-			$parameters = array('obj' => $obj);
+			$parameters = array('obj' => $obj, 'ref' => $ref, 'refcomp' => $refcomp, 'payment' => $paiement);
 			$reshook = $hookmanager->executeHooks('moreFamily', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 			if(empty($reshook)){
 				$ref = isset($hookmanager->resArray['ref']) ? $hookmanager->resArray['ref'] : $ref;
 				$refcomp = isset($hookmanager->resArray['refcomp']) ? $hookmanager->resArray['refcomp'] : $refcomp;
-				$paiement = isset($hookmanager->resArray['paiement']) ? $hookmanager->resArray['paiement'] : $paiement;
+				$paiement = isset($hookmanager->resArray['payment']) ? $hookmanager->resArray['payment'] : $paiement;
 			}
 
 			$total_ttc = $obj->total_ttc;


### PR DESCRIPTION
Backported #11698 
-----

# Fix #11682 
Fix missing origin object ref and third-party ref in future bank entries.

![future-bank](https://user-images.githubusercontent.com/613615/63158672-0fe72500-c01a-11e9-8378-405cc96c290c.png)
