### PR TITLE
FIX #11427 require product class (fixes POST /supplierinvoices REST API endpoint)

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -36,6 +36,7 @@
 
 include_once DOL_DOCUMENT_ROOT.'/core/class/commoninvoice.class.php';
 require_once DOL_DOCUMENT_ROOT.'/multicurrency/class/multicurrency.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 
 /**
  *	Class to manage suppliers invoices


### PR DESCRIPTION
Backported #11684 for 10.0 branch
----

When passing a `fk_product` field into a supplier invoice line on the `POST /supplierinvoices` REST API endpoint, we need to require the product class first in `fournisseur.facture.class.php` to be able to create the `Product` object from the passed id otherwise, it dies with a HTTP 500 error.