### PR TITLE
Fix #11683 Correct links to create a new product or service from search results

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -450,6 +450,10 @@ if ($resql)
 	if($type == Product::TYPE_SERVICE) $rightskey='service';
 	if($user->rights->{$rightskey}->creer)
 	{
+		if ($type === "") {
+			$newcardbutton.= dolGetButtonTitle($langs->trans('NewProduct'), '', 'fa fa-plus-circle', DOL_URL_ROOT.'/product/card.php?action=create&amp;type=0');
+			$type = Product::TYPE_SERVICE;
+		}
 		$label='NewProduct';
 		if($type == Product::TYPE_SERVICE) $label='NewService';
         $newcardbutton.= dolGetButtonTitle($langs->trans($label), '', 'fa fa-plus-circle', DOL_URL_ROOT.'/product/card.php?action=create&amp;type='.$type);


### PR DESCRIPTION
Backported #11695 for 10.0 branch
-----

# Fix #11683 
Correct links to create a new product or service from search results

On the results page coming from a search using the search box in the left menu, the type parameter is not defined and this caused an SQL error when trying to create a product after clicking the **New product** button.

Because the results page is for products as well as services, this PR add both buttons **New product** and **New service** with the appropriate **type** query string parameter in the buttons links if the **type** parameter is omitted in the query string of the page.

![fix-links](https://user-images.githubusercontent.com/613615/63124607-f8715300-bfab-11e9-816d-7b9a230fc6f9.png)
