### PR TITLE
NEW check if a resource is in use in an event

### DIFF
--- a/htdocs/admin/resource.php
+++ b/htdocs/admin/resource.php
@@ -127,6 +127,15 @@ print '</td>';
 print '<td></td>';
 print '</tr>';
 
+
+print '<tr class="oddeven">';
+print '<td>'.$langs->trans('EnableResourceUsedInEventCheck').'</td>';
+print '<td>';
+echo ajax_constantonoff('RESOURCE_USED_IN_EVENT_CHECK');
+print '</td>';
+print '<td></td>';
+print '</tr>';
+
 print '</table>';
 
 print '</form>';

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -558,7 +558,7 @@ if ($action == 'update')
                         $error++;
                         $object->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ';
                         while ($obj = $db->fetch_object($resql)) {
-                            $object->error .= '<br /> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
+                            $object->error .= '<br> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
                         }
                         $object->errors[] = $object->error;
                     }

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -512,6 +512,64 @@ if ($action == 'update')
 		$ret = $extrafields->setOptionalsFromPost($extralabels, $object);
 		if ($ret < 0) $error++;
 
+        if (!$error) {
+            // check if an event resource is already in use
+            if (!empty($conf->global->RESOURCE_USED_IN_EVENT_CHECK) && $object->element == 'action') {
+                $eventDateStart = $object->datep;
+                $eventDateEnd = $object->datef;
+
+                $sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
+                $sql .= " FROM " . MAIN_DB_PREFIX . "element_resources as er";
+                $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "resource as r ON r.rowid = er.resource_id AND er.resource_type = 'dolresource'";
+                $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "actioncomm as ac ON ac.id = er.element_id AND er.element_type = '" . $db->escape($object->element) . "'";
+                $sql .= " WHERE ac.id != " . $object->id;
+                $sql .= " AND er.resource_id IN (";
+                $sql .= " SELECT resource_id FROM " . MAIN_DB_PREFIX . "element_resources as er";
+                $sql .= " WHERE er.element_id = " . $object->id;
+                $sql .= " AND er.element_type = '" . $db->escape($object->element) . "'";
+                $sql .= ")";
+                $sql .= " AND er.busy = 1";
+                $sql .= " AND (";
+
+                // event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
+                $sql .= " (ac.datep <= '" . $db->idate($eventDateStart) . "' AND (ac.datep2 IS NULL OR ac.datep2 >= '" . $db->idate($eventDateStart) . "'))";
+                // event date end between ac.datep and ac.datep2
+                if (!empty($eventDateEnd)) {
+                    $sql .= " OR (ac.datep <= '" . $db->idate($eventDateEnd) . "' AND (ac.datep2 >= '" . $db->idate($eventDateEnd) . "'))";
+                }
+                // event date start before ac.datep and event date end after ac.datep2
+                $sql .= " OR (";
+                $sql .= "ac.datep >= '" . $db->idate($eventDateStart) . "'";
+                if (!empty($eventDateEnd)) {
+                    $sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '" . $db->idate($eventDateEnd) . "')";
+                }
+                $sql .= ")";
+
+                $sql .= ")";
+                $resql = $db->query($sql);
+                if (!$resql) {
+                    $error++;
+                    $object->error = $db->lasterror();
+                    $object->errors[] = $object->error;
+                } else {
+                    if ($db->num_rows($resql) > 0) {
+                        // already in use
+                        $error++;
+                        $object->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ';
+                        while ($obj = $db->fetch_object($resql)) {
+                            $object->error .= '<br /> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
+                        }
+                        $object->errors[] = $object->error;
+                    }
+                    $db->free($resql);
+                }
+
+                if ($error) {
+                    setEventMessages($object->error, $object->errors, 'errors');
+                }
+            }
+        }
+
 		if (! $error)
 		{
 			$db->begin();

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -520,7 +520,7 @@ if ($action == 'update')
 
                 $sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
                 $sql .= " FROM " . MAIN_DB_PREFIX . "element_resources as er";
-                $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "resource as r ON r.rowid = er.resource_id AND er.resource_type = 'resource'";
+                $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "resource as r ON r.rowid = er.resource_id AND er.resource_type = 'dolresource'";
                 $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "actioncomm as ac ON ac.id = er.element_id AND er.element_type = '" . $db->escape($object->element) . "'";
                 $sql .= " WHERE ac.id != " . $object->id;
                 $sql .= " AND er.resource_id IN (";

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -520,7 +520,7 @@ if ($action == 'update')
 
                 $sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
                 $sql .= " FROM " . MAIN_DB_PREFIX . "element_resources as er";
-                $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "resource as r ON r.rowid = er.resource_id AND er.resource_type = 'dolresource'";
+                $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "resource as r ON r.rowid = er.resource_id AND er.resource_type = 'resource'";
                 $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "actioncomm as ac ON ac.id = er.element_id AND er.element_type = '" . $db->escape($object->element) . "'";
                 $sql .= " WHERE ac.id != " . $object->id;
                 $sql .= " AND er.resource_id IN (";

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -524,9 +524,10 @@ if ($action == 'update')
                 $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "actioncomm as ac ON ac.id = er.element_id AND er.element_type = '" . $db->escape($object->element) . "'";
                 $sql .= " WHERE ac.id != " . $object->id;
                 $sql .= " AND er.resource_id IN (";
-                $sql .= " SELECT resource_id FROM " . MAIN_DB_PREFIX . "element_resources as er";
-                $sql .= " WHERE er.element_id = " . $object->id;
-                $sql .= " AND er.element_type = '" . $db->escape($object->element) . "'";
+                $sql .= " SELECT resource_id FROM " . MAIN_DB_PREFIX . "element_resources";
+                $sql .= " WHERE element_id = " . $object->id;
+                $sql .= " AND element_type = '" . $db->escape($object->element) . "'";
+                $sql .= " AND busy = 1";
                 $sql .= ")";
                 $sql .= " AND er.busy = 1";
                 $sql .= " AND (";

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -1900,6 +1900,7 @@ ResourceSetup=Configuration of Resource module
 UseSearchToSelectResource=Use a search form to choose a resource (rather than a drop-down list).
 DisabledResourceLinkUser=Disable feature to link a resource to users
 DisabledResourceLinkContact=Disable feature to link a resource to contacts
+EnableResourceUsedInEventCheck=Enable feature to check if a resource is in use in an event
 ConfirmUnactivation=Confirm module reset
 OnMobileOnly=On small screen (smartphone) only
 DisableProspectCustomerType=Disable the "Prospect + Customer" third party type (so third party must be Prospect or Customer but can't be both)

--- a/htdocs/langs/en_US/resource.lang
+++ b/htdocs/langs/en_US/resource.lang
@@ -34,3 +34,6 @@ IdResource=Id resource
 AssetNumber=Serial number
 ResourceTypeCode=Resource type code
 ImportDataset_resource_1=Resources
+
+ErrorResourcesAlreadyInUse=Some resources are in use
+ErrorResourceUseInEvent=%s use in %s event

--- a/htdocs/langs/fr_FR/admin.lang
+++ b/htdocs/langs/fr_FR/admin.lang
@@ -1896,6 +1896,7 @@ ResourceSetup=Configuration du module Ressource
 UseSearchToSelectResource=Utilisez un champ avec auto-complétion pour choisir les ressources (plutôt qu'une liste déroulante).
 DisabledResourceLinkUser=Désactiver la fonctionnalité pour lier une ressource aux utilisateurs
 DisabledResourceLinkContact=Désactiver la fonctionnalité pour lier une ressource aux contacts/adresses
+EnableResourceUsedInEventCheck=Activer la fonctionnalité de vérification d'une ressource déjà réservée lors d'un évènement
 ConfirmUnactivation=Confirmer réinitialisation du module
 OnMobileOnly=Sur petit écran (smartphone) uniquement
 DisableProspectCustomerType=Désactiver le type de tiers "Prospect + Client" (le tiers doit donc être un client potentiel ou un client, mais ne peut pas être les deux)

--- a/htdocs/langs/fr_FR/resource.lang
+++ b/htdocs/langs/fr_FR/resource.lang
@@ -34,3 +34,6 @@ IdResource=id ressource
 AssetNumber=Numéro de série
 ResourceTypeCode=Code de type de ressource
 ImportDataset_resource_1=Ressources
+
+ErrorResourcesAlreadyInUse=Des ressources sont déjà occupées
+ErrorResourceUseInEvent=%s occupée dans l'événement %s

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -202,6 +202,7 @@ if (empty($reshook))
                 $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "resource as r ON r.rowid = er.resource_id AND er.resource_type = '" . $db->escape($object->resource_type) . "'";
                 $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "actioncomm as ac ON ac.id = er.element_id AND er.element_type = '" . $db->escape($object->element_type) . "'";
                 $sql .= " WHERE er.resource_id = " . $object->resource_id;
+                $sql .= " AND ac.id != " . $object->element_id;
                 $sql .= " AND er.busy = 1";
                 $sql .= " AND (";
 

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -105,7 +105,7 @@ if (empty($reshook))
 
             // TODO : add this check at update_linked_resource and when modifying event start or end date
             // check if an event resource is already in use
-            if (!empty($conf->global->RESOURCE_USED_IN_EVENT_CHECK) && $objstat->element=='action' && $resource_type=='resource' && intval($busy)==1) {
+            if (!empty($conf->global->RESOURCE_USED_IN_EVENT_CHECK) && $objstat->element=='action' && $resource_type=='dolresource' && intval($busy)==1) {
                 $eventDateStart = $objstat->datep;
                 $eventDateEnd   = $objstat->datef;
                 $isFullDayEvent = intval($objstat->fulldayevent);
@@ -185,7 +185,7 @@ if (empty($reshook))
 			$object->busy = $busy;
 			$object->mandatory = $mandatory;
 
-            if (!empty($conf->global->RESOURCE_USED_IN_EVENT_CHECK) && $object->element_type=='action' && $object->resource_type=='resource' && intval($object->busy)==1) {
+            if (!empty($conf->global->RESOURCE_USED_IN_EVENT_CHECK) && $object->element_type=='action' && $object->resource_type=='dolresource' && intval($object->busy)==1) {
                 $eventDateStart = $object->objelement->datep;
                 $eventDateEnd   = $object->objelement->datef;
                 $isFullDayEvent = intval($objstat->fulldayevent);

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -105,7 +105,7 @@ if (empty($reshook))
 
             // TODO : add this check at update_linked_resource and when modifying event start or end date
             // check if an event resource is already in use
-            if (!empty($conf->global->RESOURCE_USED_IN_EVENT_CHECK) && $objstat->element=='action' && $resource_type=='dolresource' && intval($busy)==1) {
+            if (!empty($conf->global->RESOURCE_USED_IN_EVENT_CHECK) && $objstat->element=='action' && $resource_type=='resource' && intval($busy)==1) {
                 $eventDateStart = $objstat->datep;
                 $eventDateEnd   = $objstat->datef;
                 $isFullDayEvent = intval($objstat->fulldayevent);
@@ -185,7 +185,7 @@ if (empty($reshook))
 			$object->busy = $busy;
 			$object->mandatory = $mandatory;
 
-            if (!empty($conf->global->RESOURCE_USED_IN_EVENT_CHECK) && $object->element_type=='action' && $object->resource_type=='dolresource' && intval($object->busy)==1) {
+            if (!empty($conf->global->RESOURCE_USED_IN_EVENT_CHECK) && $object->element_type=='action' && $object->resource_type=='resource' && intval($object->busy)==1) {
                 $eventDateStart = $object->objelement->datep;
                 $eventDateEnd   = $object->objelement->datef;
                 $isFullDayEvent = intval($objstat->fulldayevent);

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -151,7 +151,7 @@ if (empty($reshook))
                         $error++;
                         $objstat->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ';
                         while ($obj = $db->fetch_object($resql)) {
-                            $objstat->error .= '<br /> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
+                            $objstat->error .= '<br> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
                         }
                         $objstat->errors[] = $objstat->error;
                     }
@@ -232,7 +232,7 @@ if (empty($reshook))
                         $error++;
                         $object->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ';
                         while ($obj = $db->fetch_object($resql)) {
-                            $object->error .= '<br /> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
+                            $object->error .= '<br> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
                         }
                         $object->errors[] = $objstat->error;
                     }


### PR DESCRIPTION
NEW check if a resource is in use in an event
- add a constant "RESOURCE_USED_IN_EVENT_CHECK" in resource admin
- check if a resource is already in use when we create or update a resource from an event
- check if resources of an event are already in use in others events when we update an event
- add error messages to determine which resource is in use