### PR TITLE
NEW Extrafields support in product supplier prices

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -598,7 +598,7 @@ abstract class CommonDocGenerator
                 $columns .= "$key, ";
             }
             $columns = substr($columns, 0, strlen($columns) - 2);
-            $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = '" . $line->ref_fourn . "'");
+            $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = '" . $line->ref_supplier . "'");
             if ($this->db->num_rows($resql) > 0) {
                 $resql = $this->db->fetch_object($resql);
                 foreach ($extralabels as $key => $value) {

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -590,19 +590,24 @@ abstract class CommonDocGenerator
         $resarray = $this->fill_substitutionarray_with_extrafields($line, $resarray, $extrafields, $array_key, $outputlangs);
         
         // Check if the current line belongs to a supplier order
-        if (get_class($line) == 'CommandeFournisseurLigne') {
+        if (get_class($line) == 'CommandeFournisseurLigne')
+        {
             // Add the product supplier extrafields to the substitutions
-            $extralabels=$extrafields->fetch_name_optionals_label("product_fournisseur_price");
+            $extrafields->fetch_name_optionals_label("product_fournisseur_price");
+            $extralabels=$extrafields->attributes["product_fournisseur_price"]['label'];
             $columns = "";
-            foreach ($extralabels as $key => $value) {
+            foreach ($extralabels as $key => $value)
                 $columns .= "$key, ";
-            }
-            $columns = substr($columns, 0, strlen($columns) - 2);
-            $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = '" . $line->ref_fourn . "'");
-            if ($this->db->num_rows($resql) > 0) {
-                $resql = $this->db->fetch_object($resql);
-                foreach ($extralabels as $key => $value) {
-                    $resarray['line_product_supplier_'.$key] = $resql->{$key};
+            
+            if ($columns != "")
+            {
+                $columns = substr($columns, 0, strlen($columns) - 2);
+                $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = '" . $line->ref_fourn . "'");
+                if ($this->db->num_rows($resql) > 0) {
+                    $resql = $this->db->fetch_object($resql);
+
+                    foreach ($extralabels as $key => $value)
+                        $resarray['line_product_supplier_'.$key] = $resql->{$key};
                 }
             }
         }

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -587,21 +587,25 @@ abstract class CommonDocGenerator
 		$extralabels = $extrafields->fetch_name_optionals_label($extrafieldkey, true);
 		$line->fetch_optionals();
 
-		$resarray = $this->fill_substitutionarray_with_extrafields($line, $resarray, $extrafields, $array_key, $outputlangs);
+        $resarray = $this->fill_substitutionarray_with_extrafields($line, $resarray, $extrafields, $array_key, $outputlangs);
         
-        // Add the product supplier extrafields to the substitutions
-        $extralabels=$extrafields->fetch_name_optionals_label("product_fournisseur_price");
-        $columns = "";
-        foreach ($extralabels as $key => $value) {
-            $columns .= "$key, ";
-        }
-        $columns = substr($columns, 0, strlen($columns) - 2);
-        $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = '" . $line->ref_fourn . "'");
-        if ($this->db->num_rows($resql) > 0) {
-            $resql = $this->db->fetch_object($resql);
+        // Check if the current line belongs to a supplier order
+        if (get_class($line) == 'CommandeFournisseurLigne') {
+            // Add the product supplier extrafields to the substitutions
+            $extralabels=$extrafields->fetch_name_optionals_label("product_fournisseur_price");
+            $columns = "";
             foreach ($extralabels as $key => $value) {
-                $resarray['line_product_supplier_'.$key] = $resql->{$key};
+                $columns .= "$key, ";
             }
+            $columns = substr($columns, 0, strlen($columns) - 2);
+            $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = '" . $line->ref_fourn . "'");
+            if ($this->db->num_rows($resql) > 0) {
+                $resql = $this->db->fetch_object($resql);
+                foreach ($extralabels as $key => $value) {
+                    $resarray['line_product_supplier_'.$key] = $resql->{$key};
+                }
+            }
+
         }
 
 		// Load product data optional fields to the line -> enables to use "line_options_{extrafield}"

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -596,7 +596,7 @@ abstract class CommonDocGenerator
             $columns .= "$key, ";
         }
         $columns = substr($columns, 0, strlen($columns) - 2);
-        $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = " . $line->ref_fourn);
+        $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = '" . $line->ref_fourn . "'");
         if ($this->db->num_rows($resql) > 0) {
             $resql = $this->db->fetch_object($resql);
             foreach ($extralabels as $key => $value) {

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -595,7 +595,7 @@ abstract class CommonDocGenerator
         foreach ($extralabels as $key => $value) {
             $columns .= "$key, ";
         }
-        substr($columns, 0, strlen($columns) - 2);
+        $columns = substr($columns, 0, strlen($columns) - 2);
         $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = " . $line->ref_fourn);
         if ($this->db->num_rows($resql) > 0) {
             $resql = $this->db->fetch_object($resql);

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -577,7 +577,7 @@ abstract class CommonDocGenerator
 		{
 		      $resarray['line_unit']=$outputlangs->trans($line->getLabelOfUnit('long'));
 		      $resarray['line_unit_short']=$outputlangs->trans($line->getLabelOfUnit('short'));
-		}
+        }
 
 		// Retrieve extrafields
 		$extrafieldkey=$line->element;
@@ -588,6 +588,16 @@ abstract class CommonDocGenerator
 		$line->fetch_optionals();
 
 		$resarray = $this->fill_substitutionarray_with_extrafields($line, $resarray, $extrafields, $array_key, $outputlangs);
+        
+        // Add the product supplier extrafields to the substitutions
+        $resql = $this->db->query("SELECT * FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = " . $line->ref_fourn);
+        if ($this->db->num_rows($resql) > 0) {
+            $resql = $this->db->fetch_object($resql);
+            $extralabels=$extrafields->fetch_name_optionals_label("product_fournisseur_price");
+            foreach ($extralabels as $key => $value) {
+                $resarray['line_product_supplier_'.$key] = $resql->{$key};
+            }
+        }
 
 		// Load product data optional fields to the line -> enables to use "line_options_{extrafield}"
 		if (isset($line->fk_product) && $line->fk_product > 0)

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -605,7 +605,6 @@ abstract class CommonDocGenerator
                     $resarray['line_product_supplier_'.$key] = $resql->{$key};
                 }
             }
-
         }
 
 		// Load product data optional fields to the line -> enables to use "line_options_{extrafield}"

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -590,10 +590,15 @@ abstract class CommonDocGenerator
 		$resarray = $this->fill_substitutionarray_with_extrafields($line, $resarray, $extrafields, $array_key, $outputlangs);
         
         // Add the product supplier extrafields to the substitutions
-        $resql = $this->db->query("SELECT * FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = " . $line->ref_fourn);
+        $extralabels=$extrafields->fetch_name_optionals_label("product_fournisseur_price");
+        $columns = "";
+        foreach ($extralabels as $key => $value) {
+            $columns .= "$key, ";
+        }
+        substr($columns, 0, strlen($columns) - 2);
+        $resql = $this->db->query("SELECT $columns FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields AS ex INNER JOIN " . MAIN_DB_PREFIX . "product_fournisseur_price AS f ON ex.fk_object = f.rowid WHERE f.ref_fourn = " . $line->ref_fourn);
         if ($this->db->num_rows($resql) > 0) {
             $resql = $this->db->fetch_object($resql);
-            $extralabels=$extrafields->fetch_name_optionals_label("product_fournisseur_price");
             foreach ($extralabels as $key => $value) {
                 $resarray['line_product_supplier_'.$key] = $resql->{$key};
             }

--- a/htdocs/core/lib/product.lib.php
+++ b/htdocs/core/lib/product.lib.php
@@ -292,6 +292,11 @@ function product_admin_prepare_head()
 	$head[$h][2] = 'attributes';
 	$h++;
 
+	$head[$h][0] = DOL_URL_ROOT.'/product/admin/product_supplier_extrafields.php';
+	$head[$h][1] = $langs->trans("ProductSupplierExtraFields");
+	$head[$h][2] = 'supplierAttributes';
+	$h++;
+
 	complete_head_from_modules($conf, $langs, null, $head, $h, 'product_admin', 'remove');
 
 	return $head;

--- a/htdocs/install/mysql/tables/llx_product_fournisseur_price_extrafields.key.sql
+++ b/htdocs/install/mysql/tables/llx_product_fournisseur_price_extrafields.key.sql
@@ -1,0 +1,20 @@
+-- ===================================================================
+-- Copyright (C) 2011 Laurent Destailleur       <eldy@users.sourceforge.net>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+--
+-- ===================================================================
+
+
+ALTER TABLE llx_product_fournisseur_price_extrafields ADD INDEX idx_product_fournisseur_price_extrafields (fk_object);

--- a/htdocs/install/mysql/tables/llx_product_fournisseur_price_extrafields.sql
+++ b/htdocs/install/mysql/tables/llx_product_fournisseur_price_extrafields.sql
@@ -1,0 +1,24 @@
+-- ============================================================================
+-- Copyright (C) 2011 Laurent Destailleur  <eldy@users.sourceforge.net>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+--
+-- ============================================================================
+
+Create Table llx_product_fournisseur_price_extrafields (
+	rowid               integer AUTO_INCREMENT PRIMARY KEY,
+	tms                 timestamp,
+	fk_object           integer NOT NULL,
+	import_key          varchar(14) -- import key
+) ENGINE=innodb;

--- a/htdocs/langs/de_DE/products.lang
+++ b/htdocs/langs/de_DE/products.lang
@@ -341,3 +341,4 @@ ErrorDestinationProductNotFound=Zielprodukt nicht gefunden
 ErrorProductCombinationNotFound=Produktvariante nicht gefunden
 ActionAvailableOnVariantProductOnly=Action only available on the variant of product
 ProductsPricePerCustomer=Product prices per customers
+ProductSupplierExtraFields=Ergänzende Attribute (Lieferantenpreise)

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -341,3 +341,4 @@ ErrorDestinationProductNotFound=Destination product not found
 ErrorProductCombinationNotFound=Product variant not found
 ActionAvailableOnVariantProductOnly=Action only available on the variant of product
 ProductsPricePerCustomer=Product prices per customers
+ProductSupplierExtraFields=Additional Attributes (Supplier Prices)

--- a/htdocs/product/admin/product_supplier_extrafields.php
+++ b/htdocs/product/admin/product_supplier_extrafields.php
@@ -1,0 +1,132 @@
+<?php
+/* Copyright (C) 2001-2002	Rodolphe Quiedeville	<rodolphe@quiedeville.org>
+ * Copyright (C) 2003		Jean-Louis Bergamo		<jlb@j1b.org>
+ * Copyright (C) 2004-2011	Laurent Destailleur		<eldy@users.sourceforge.net>
+ * Copyright (C) 2012		Marcos García			<marcosgdf@gmail.com>
+ * Copyright (C) 2012		Regis Houssin			<regis.houssin@inodbox.com>
+ * Copyright (C) 2019		Tim Otte    			<otte@meuser.it>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *      \file       htdocs/product/admin/product_supplier_extrafields.php
+ *		\ingroup    product
+ *		\brief      Page to setup extra fields of products
+ */
+
+require '../../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/product.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+
+// Load translation files required by the page
+$langs->loadLangs(array('companies', 'admin', 'products'));
+
+$extrafields = new ExtraFields($db);
+$form = new Form($db);
+
+// List of supported format
+$tmptype2label=ExtraFields::$type2label;
+$type2label=array('');
+foreach ($tmptype2label as $key => $val) $type2label[$key]=$langs->transnoentitiesnoconv($val);
+
+$action=GETPOST('action', 'alpha');
+$attrname=GETPOST('attrname', 'alpha');
+$elementtype='product_fournisseur_price'; //Must be the $element of the class that manage extrafield
+
+if (!$user->admin) accessforbidden();
+
+
+/*
+ * Actions
+ */
+
+require DOL_DOCUMENT_ROOT.'/core/actions_extrafields.inc.php';
+
+
+
+/*
+ * View
+ */
+
+$title = $langs->trans('ProductServiceSetup');
+$textobject = $langs->trans("ProductsAndServices");
+if (empty($conf->product->enabled))
+{
+	$title = $langs->trans('ServiceSetup');
+	$textobject = $langs->trans('Services');
+}
+elseif (empty($conf->service->enabled))
+{
+	$title = $langs->trans('ProductSetup');
+	$textobject = $langs->trans('Products');
+}
+
+//$help_url='EN:Module Third Parties setup|FR:Paramétrage_du_module_Tiers';
+$help_url='';
+llxHeader('', $title, $help_url);
+
+
+$linkback='<a href="'.DOL_URL_ROOT.'/admin/modules.php?restore_lastsearch_values=1">'.$langs->trans("BackToModuleList").'</a>';
+print load_fiche_titre($title, $linkback, 'title_setup');
+
+
+$head = product_admin_prepare_head();
+
+dol_fiche_head($head, 'supplierAttributes', $textobject, -1, 'product');
+
+require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_view.tpl.php';
+
+dol_fiche_end();
+
+
+// Buttons
+if ($action != 'create' && $action != 'edit')
+{
+    print '<div class="tabsAction">';
+    print "<a class=\"butAction\" href=\"".$_SERVER["PHP_SELF"]."?action=create#newattrib\">".$langs->trans("NewAttribute")."</a>";
+    print "</div>";
+}
+
+
+/* ************************************************************************** */
+/*                                                                            */
+/* Creation of an optional field											  */
+/*                                                                            */
+/* ************************************************************************** */
+
+if ($action == 'create')
+{
+	print '<br><div id="newattrib"></div>';
+	print load_fiche_titre($langs->trans('NewAttribute'));
+
+    require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_add.tpl.php';
+}
+
+/* ************************************************************************** */
+/*                                                                            */
+/* Edition of an optional field                                               */
+/*                                                                            */
+/* ************************************************************************** */
+if ($action == 'edit' && ! empty($attrname))
+{
+    print "<br>";
+    print load_fiche_titre($langs->trans("FieldEdition", $attrname));
+
+    require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_edit.tpl.php';
+}
+
+// End of page
+llxFooter();
+$db->close();

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -758,7 +758,8 @@ SCRIPT;
     				print '</tr>';
 				}
 
-				$extralabels=$extrafields->fetch_name_optionals_label("product_fournisseur_price");
+				$extrafields->fetch_name_optionals_label("product_fournisseur_price");
+				$extralabels=$extrafields->attributes["product_fournisseur_price"]['label'];
 				// Extrafields
 				$resql = $db->query("SELECT * FROM " . MAIN_DB_PREFIX . "product_fournisseur_price_extrafields WHERE fk_object = " . $rowid);
 				if ($db->num_rows($resql) != 1) {
@@ -865,7 +866,8 @@ SCRIPT;
 				print_liste_field_titre("DateModification", $_SERVER["PHP_SELF"], "pfp.tms", "", $param, '', $sortfield, $sortorder, 'right ');
 
 				// fetch optionals attributes and labels
-				$extralabels=$extrafields->fetch_name_optionals_label("product_fournisseur_price");
+				$extrafields->fetch_name_optionals_label("product_fournisseur_price");
+				$extralabels=$extrafields->attributes["product_fournisseur_price"]['label'];
 				foreach ($extralabels as $key => $value) {
 					// Show field if not hidden
 					if (! empty($extrafields->attributes["product_fournisseur_price"]['list'][$key]) && $extrafields->attributes["product_fournisseur_price"]['list'][$key] != 3) {

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -8,7 +8,8 @@
  * Copyright (C) 2014      Ion Agorria          <ion@agorria.com>
  * Copyright (C) 2015      Alexandre Spangaro   <aspangaro@open-dsi.fr>
  * Copyright (C) 2016      Ferran Marcet		<fmarcet@2byte.es>
- * Copyright (C) 2019       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2019      Frédéric France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2019      Tim Otte			    <otte@meuser.it>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -863,7 +863,7 @@ SCRIPT;
 				// fetch optionals attributes and labels
 				$extralabels=$extrafields->fetch_name_optionals_label("product_fournisseur_price");
 				foreach ($extralabels as $extrafield) {
-					print_liste_field_titre($langs->trans($extrafield), $_SERVER["PHP_SELF"], '', '', $param, '', $sortfield, $sortorder, 'right ');
+					print_liste_field_titre($extrafield, $_SERVER["PHP_SELF"], '', '', $param, '', $sortfield, $sortorder, 'right ');
 				}
 
 				if (is_object($hookmanager))


### PR DESCRIPTION
# New: Extrafields in product supplier prices
I added the extrafield functionality to the product supplier prices (*product_fournisseur_price*). The extrafields can be managed in the admin area of the product module. The extrafields can be used in odt templates like this: {line_product_supplier_*name_of_extrafield*}
