### PR TITLE
FIX : allow standalone credit note even if no invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3047,7 +3047,7 @@ if ($action == 'create')
 			{
 				print '<div class="tagtr listofinvoicetype"><div class="tagtd listofinvoicetype">';
 				$tmp='<input type="radio" id="radio_creditnote" name="type" value="2"' . (GETPOST('type') == 2 ? ' checked' : '');
-				if ( ! $optionsav && ! empty($conf->global->INVOICE_CREDIT_NOTE_STANDALONE) ) $tmp.=' disabled';
+				if ( ! $optionsav && empty($conf->global->INVOICE_CREDIT_NOTE_STANDALONE) ) $tmp.=' disabled';
 				$tmp.= '> ';
 				// Show credit note options only if we checked credit note
 				print '<script type="text/javascript" language="javascript">

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3047,7 +3047,7 @@ if ($action == 'create')
 			{
 				print '<div class="tagtr listofinvoicetype"><div class="tagtd listofinvoicetype">';
 				$tmp='<input type="radio" id="radio_creditnote" name="type" value="2"' . (GETPOST('type') == 2 ? ' checked' : '');
-				if ( ! $optionsav && empty($conf->global->INVOICE_CREDIT_NOTE_STANDALONE) ) $tmp.=' disabled';
+				if (! $optionsav && empty($conf->global->INVOICE_CREDIT_NOTE_STANDALONE)) $tmp.=' disabled';
 				$tmp.= '> ';
 				// Show credit note options only if we checked credit note
 				print '<script type="text/javascript" language="javascript">

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3047,7 +3047,7 @@ if ($action == 'create')
 			{
 				print '<div class="tagtr listofinvoicetype"><div class="tagtd listofinvoicetype">';
 				$tmp='<input type="radio" id="radio_creditnote" name="type" value="2"' . (GETPOST('type') == 2 ? ' checked' : '');
-				if (! $optionsav) $tmp.=' disabled';
+				if ( ! $optionsav && ! empty($conf->global->INVOICE_CREDIT_NOTE_STANDALONE) ) $tmp.=' disabled';
 				$tmp.= '> ';
 				// Show credit note options only if we checked credit note
 				print '<script type="text/javascript" language="javascript">


### PR DESCRIPTION
if constant INVOICE_CREDIT_NOTE_STANDALONE is activated, one should be able to create credit note even if no invoice exists for the thirdparty