### PR TITLE
FIX empty cache when we want to load specific warehouses in select

### DIFF
--- a/htdocs/product/class/html.formproduct.class.php
+++ b/htdocs/product/class/html.formproduct.class.php
@@ -243,6 +243,7 @@ class FormProduct
 
 		$out='';
 		if (empty($conf->global->ENTREPOT_EXTRA_STATUS)) $filterstatus = '';
+        if (!empty($fk_product))  $this->cache_warehouses = array();
 		$this->loadWarehouses($fk_product, '', $filterstatus, true, $exclude, $stockMin, $orderBy);
 		$nbofwarehouses=count($this->cache_warehouses);
 


### PR DESCRIPTION
FIX empty cache when we want to load specific warehouses in select :
- if you have several select warehouses in the same card (such as shipment card in create mode), warehouse cache is added for each shipment line (insted of empty cache)