### PR TITLE
[FIX][#11881] -  remove referent from the project

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -1691,7 +1691,8 @@ class Project extends CommonObject
 			$sql.= " WHERE id=".$elementSelectId;
 		}else
 		{
-			$sql.= sprintf(" SET %s=NULL WHERE rowid=%s", $projectfield, $elementSelectId);
+			$sql.= " SET ".$projectfield."=NULL";
+			$sql.= " WHERE rowid=".$elementSelectId;
 		}
 
 		dol_syslog(get_class($this)."::remove_element", LOG_DEBUG);

--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -1676,9 +1676,11 @@ class Project extends CommonObject
 	 *
 	 *    @param	string	$tableName			Table of the element to update
 	 *    @param	int		$elementSelectId	Key-rowid of the line of the element to update
+	 *    @param	string	$projectfield	    The column name that stores the link with the project
+     *
 	 *    @return	int							1 if OK or < 0 if KO
 	 */
-	public function remove_element($tableName, $elementSelectId)
+	public function remove_element($tableName, $elementSelectId, $projectfield = 'fk_projet')
 	{
         // phpcs:enable
 		$sql="UPDATE ".MAIN_DB_PREFIX.$tableName;
@@ -1687,11 +1689,9 @@ class Project extends CommonObject
 		{
 			$sql.= " SET fk_project=NULL";
 			$sql.= " WHERE id=".$elementSelectId;
-		}
-		else
+		}else
 		{
-			$sql.= " SET fk_projet=NULL";
-			$sql.= " WHERE rowid=".$elementSelectId;
+			$sql.= sprintf(" SET %s=NULL WHERE rowid=%s", $projectfield, $elementSelectId);
 		}
 
 		dol_syslog(get_class($this)."::remove_element", LOG_DEBUG);

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -512,9 +512,9 @@ if ($action=="addelement")
 elseif ($action == "unlink")
 {
 
-	$tablename = GETPOST("tablename");
-    $projectField = GETPOST("projectfield");
-	$elementselectid = GETPOST("elementselect");
+	$tablename = GETPOST("tablename", "aZ09");
+    $projectField = GETPOST("projectfield", "aZ09");
+	$elementselectid = GETPOST("elementselect", "int");
 
 	$result = $object->remove_element($tablename, $elementselectid, $projectField);
 	if ($result < 0)
@@ -890,7 +890,7 @@ foreach ($listofreferent as $key => $value)
 				{
 					if (empty($conf->global->PROJECT_DISABLE_UNLINK_FROM_OVERVIEW) || $user->admin)		// PROJECT_DISABLE_UNLINK_FROM_OVERVIEW is empty by defaut, so this test true
 					{
-						print sprintf('<a href="%s?id=%s&action=unlink&tablename=%s&elementselect=%s&projectfield=%s" class="reposition">', $_SERVER["PHP_SELF"], $projectid, $tablename, $element->id, $project_field?: 'fk_projet');
+						print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $projectid . '&action=unlink&tablename=' . $tablename . '&elementselect=' . $element->id . ($project_field ? '&projectfield=' . $project_field : '') . " class="reposition">';
 						print img_picto($langs->trans('Unlink'), 'unlink');
 						print '</a>';
 					}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -513,9 +513,10 @@ elseif ($action == "unlink")
 {
 
 	$tablename = GETPOST("tablename");
+    $projectField = GETPOST("projectfield");
 	$elementselectid = GETPOST("elementselect");
 
-	$result = $object->remove_element($tablename, $elementselectid);
+	$result = $object->remove_element($tablename, $elementselectid, $projectField);
 	if ($result < 0)
 	{
 		setEventMessages($object->error, $object->errors, 'errors');
@@ -889,7 +890,7 @@ foreach ($listofreferent as $key => $value)
 				{
 					if (empty($conf->global->PROJECT_DISABLE_UNLINK_FROM_OVERVIEW) || $user->admin)		// PROJECT_DISABLE_UNLINK_FROM_OVERVIEW is empty by defaut, so this test true
 					{
-						print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $projectid . '&action=unlink&tablename=' . $tablename . '&elementselect=' . $element->id . '" class="reposition">';
+						print sprintf('<a href="%s?id=%s&action=unlink&tablename=%s&elementselect=%s&projectfield=%s" class="reposition">', $_SERVER["PHP_SELF"], $projectid, $tablename, $element->id, $project_field?: 'fk_projet');
 						print img_picto($langs->trans('Unlink'), 'unlink');
 						print '</a>';
 					}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -890,7 +890,7 @@ foreach ($listofreferent as $key => $value)
 				{
 					if (empty($conf->global->PROJECT_DISABLE_UNLINK_FROM_OVERVIEW) || $user->admin)		// PROJECT_DISABLE_UNLINK_FROM_OVERVIEW is empty by defaut, so this test true
 					{
-						print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $projectid . '&action=unlink&tablename=' . $tablename . '&elementselect=' . $element->id . ($project_field ? '&projectfield=' . $project_field : '') . " class="reposition">';
+						print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $projectid . '&action=unlink&tablename=' . $tablename . '&elementselect=' . $element->id . ($project_field ? '&projectfield=' . $project_field : '') . '" class="reposition">';
 						print img_picto($langs->trans('Unlink'), 'unlink');
 						print '</a>';
 					}


### PR DESCRIPTION
# Instructions
When one custom module adds some elements in one project. We cannot remove those elements due to the fact that the remove doesn't support another name than "fk_projet". This PR support the field _project field_ configurable in the project itself.


# Fix #11881