### PR TITLE
FIX top menu right padding

### DIFF
--- a/htdocs/theme/eldy/style.css.php
+++ b/htdocs/theme/eldy/style.css.php
@@ -199,7 +199,7 @@ $minwidthtmenu=66;		/* minimum width for one top menu entry */
 $heightmenu=48;			/* height of top menu, part with image */
 $heightmenu2=49;        /* height of top menu, part with login  */
 $disableimages = 0;
-$maxwidthloginblock = 130;
+$maxwidthloginblock = 180;
 if (! empty($conf->global->THEME_TOPMENU_DISABLE_IMAGE)) { $disableimages = 1; $maxwidthloginblock = 180; $minwidthtmenu=0; }
 
 


### PR DESCRIPTION
bug can be reproduce when top menu need more than 100% of screen to display all items.