### PR TITLE
Migrate unit type in the product's table from scale to id

### DIFF
--- a/htdocs/install/mysql/migration/9.0.0-10.0.0.sql
+++ b/htdocs/install/mysql/migration/9.0.0-10.0.0.sql
@@ -404,3 +404,98 @@ ALTER TABLE llx_ticket_extrafields ADD INDEX idx_ticket_extrafields (fk_object);
 
 UPDATE llx_website_page set fk_user_creat = fk_user_modif WHERE fk_user_creat IS NULL and fk_user_modif IS NOT NULL;
 
+-- FIX the units in the product table
+-- UPDATE unit : weight
+UPDATE llx_product
+  SET weight_units = (
+    SELECT
+      rowid
+    FROM
+      llx_c_units
+    WHERE
+      llx_c_units.active = 1
+      AND (llx_c_units.scale = llx_product.weight_units
+        OR (
+          llx_product.weight_units = 0
+          AND
+          llx_c_units.scale IS NULL
+        )
+      )
+      AND llx_c_units.unit_type = 'weight'
+    LIMIT 1
+  )
+
+  WHERE
+    llx_product.weight_units <= 0;
+
+-- UPDATE unit : length
+UPDATE llx_product
+  SET length_units = (
+    SELECT
+      rowid
+    FROM
+      llx_c_units
+    WHERE
+      llx_c_units.active = 1
+      AND (llx_c_units.scale = llx_product.length_units
+        OR (
+          llx_product.length_units = 0
+          AND
+          llx_c_units.scale IS NULL
+        )
+      )
+      AND llx_c_units.unit_type = 'size'
+    LIMIT 1
+  )
+
+  WHERE
+    llx_product.length_units <= 0;
+
+
+-- UPDATE unit : surface
+UPDATE llx_product
+  SET surface_units = (
+    SELECT
+      rowid
+    FROM
+      llx_c_units
+    WHERE
+      llx_c_units.active = 1
+      AND (llx_c_units.scale = llx_product.surface_units
+        OR (
+          llx_product.surface_units = 0
+          AND
+          llx_c_units.scale IS NULL
+        )
+      )
+      AND llx_c_units.unit_type = 'surface'
+    LIMIT 1
+  )
+
+  WHERE
+    llx_product.surface_units <= 0;
+
+
+-- UPDATE unit : volume
+UPDATE llx_product
+  SET volume_units = (
+    SELECT
+      rowid
+    FROM
+      llx_c_units
+    WHERE
+      llx_c_units.active = 1
+      AND (llx_c_units.scale = llx_product.volume_units
+        OR (
+          llx_product.volume_units = 0
+          AND
+          llx_c_units.scale IS NULL
+        )
+      )
+      AND llx_c_units.unit_type = 'volume'
+    LIMIT 1
+  )
+
+  WHERE
+    llx_product.volume_units <= 0;
+


### PR DESCRIPTION
**Fix the ticket #11979 **
In version 9.0 the units of the products were managed by the scale
value. In version 10.0, the units were replaced by one table
llx_c_units and thus the links are based on the rowid of the table
llx_c_units.

The fix is easy as creating an update script to get the rowid based on the scale. The scale may be null so I also take that into account.

**Notes**
* I never wrote any update scripts in Dolibarr. I want to apply this script only once, is it the right way?

Cheers
L.