### PR TITLE
Close #12006 - adds the country in the address of the PDF's footer

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -935,6 +935,11 @@ function pdf_pagefoot(&$pdf, $outputlangs, $paramfreetext, $fromcompany, $marge_
 		{
 			$line1.=($line1?" ":"").$fromcompany->town;
 		}
+		// Country
+		if ($fromcompany->country)
+		{
+			$line1.=($line1?", ":"").$fromcompany->country;
+		}
 		// Phone
 		if ($fromcompany->phone)
 		{


### PR DESCRIPTION
# Instructions
This PR adds the country in the address in the footer of the PDF's as suggested in the ticket #12006 

# Fix #12006 
# Close #12006 

To be able to test it just generate one PDF. The address should be visible after the town.