### PR TITLE
NEW : add MAIN_LANGUAGES_ALLOWED constant to limit languages displayed

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -782,7 +782,7 @@ class Translate
 			{
 				$this->load("languages");
 				
-				if (! empty($conf->global->MAIN_LANGUAGES_ALLOWED) && ! in_array($dir, explode(',' , $conf->global->MAIN_LANGUAGES_ALLOWED)) ) continue;
+				if (! empty($conf->global->MAIN_LANGUAGES_ALLOWED) && ! in_array($dir, explode(',', $conf->global->MAIN_LANGUAGES_ALLOWED)) ) continue;
 
 				if ($usecode == 2)
 				{

--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -781,6 +781,8 @@ class Translate
 			if (preg_match('/^[a-z]+_[A-Z]+/i', $dir))
 			{
 				$this->load("languages");
+				
+				if (! empty($conf->global->MAIN_LANGUAGES_ALLOWED) && ! in_array($dir, explode(',' , $conf->global->MAIN_LANGUAGES_ALLOWED)) ) continue;
 
 				if ($usecode == 2)
 				{


### PR DESCRIPTION
MAIN_LANGUAGES_ALLOWED is a list of languages without spaces, ie : fr_FR,en_US,de_DE,it_IT
if defined, oly those languages will appear in combos.