### PR TITLE
Calendar : add a title on the event in order to display the full title

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1336,7 +1336,7 @@ class ActionComm extends CommonObject
 			if ($add_save_lastsearch_values) $url.='&save_lastsearch_values=1';
 		}
 
-		$linkstart = '<a href="'.$url.'"';
+		$linkstart = '<a href="'.$url.'" title="'.$label.'"';
 		$linkstart.=$linkclose.'>';
 		$linkend='</a>';
 


### PR DESCRIPTION
# New : Calendar : add a title on the event in order to display the full title
When the mouse cursor is over the event label the full title of the event is dispplayed, even when the column is too small.
