### PR TITLE
remove useless || which deselect permanently costprice pmp

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -694,7 +694,7 @@ jQuery(document).ready(function() {
     	      			{
     	      				// If margin is calculated on PMP, we set it by defaut (but only if value is not 0)
     			      		//console.log("id="+this.id+"-price="+this.price);
-    			      		if ('pmp' == defaultbuyprice || 'costprice' == defaultbuyprice)
+    			      		if ('pmp' == defaultbuyprice)
     			      		{
     			      			if (this.price > 0) {
     				      			defaultkey = this.id; defaultprice = this.price; pmppriceid = this.id; pmppricevalue = this.price;


### PR DESCRIPTION
# Fix costprice selection
When, in margin we set the MARGIN_TYPE to costprice, dolibarr select the pmp
it's because of the "||" in the "pmp" case and the fact that pmpprice is always return at last by getSupplierPrices.php