### PR TITLE
FIX 7.0: addresses not displayed in e-mail sending error messages

### DIFF
--- a/htdocs/core/actions_sendmails.inc.php
+++ b/htdocs/core/actions_sendmails.inc.php
@@ -460,7 +460,7 @@ if (($action == 'send' || $action == 'relance') && ! $_POST['addfile'] && ! $_PO
 					$mesg='<div class="error">';
 					if ($mailfile->error)
 					{
-						$mesg.=$langs->trans('ErrorFailedToSendMail',$from,$sendto);
+						$mesg.=$langs->transnoentities('ErrorFailedToSendMail',dol_escape_htmltag($from),dol_escape_htmltag($sendto));
 						$mesg.='<br>'.$mailfile->error;
 					}
 					else


### PR DESCRIPTION
# Fix
If the address is in the form `Tom <tom@examp.le>` or `Ana <ana@beispi.el>`, the sending error message will read:

> Failed to send mail (sender=Tom , receiver=Ana )

The issue is caused by the variables `$from` and `$sendto`, which may contain unescaped angle brackets.