### PR TITLE
enable tooltip for calendar event

### DIFF
--- a/output/0001-Enable-tooltip-for-calendar-events.patch
+++ b/output/0001-Enable-tooltip-for-calendar-events.patch
@@ -1,0 +1,26 @@
+From b2453a2eab4b01fbe2de89b9fd0228416c0f784f Mon Sep 17 00:00:00 2001
+Message-Id: <b2453a2eab4b01fbe2de89b9fd0228416c0f784f.1570469779.git.tbenita@atreal.fr>
+From: Thierry BENITA <tbenita@atreal.fr>
+Date: Mon, 7 Oct 2019 19:31:32 +0200
+Subject: [PATCH] Enable tooltip for calendar events
+
+---
+ htdocs/comm/action/index.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/htdocs/comm/action/index.php b/htdocs/comm/action/index.php
+index bd6b88d51f..d503c1bc71 100644
+--- a/htdocs/comm/action/index.php
++++ b/htdocs/comm/action/index.php
+@@ -1562,7 +1562,7 @@ function show_day_events($db, $day, $month, $year, $monthshown, $style, &$eventa
+                         	$savlabel=$event->label?$event->label:$event->libelle;
+                         	$event->label=$titletoshow;
+                         	$event->libelle=$titletoshow;
+-                        	print $event->getNomUrl(0, $maxnbofchar, 'cal_event', '', 0, 1);
++                        	print $event->getNomUrl(0, $maxnbofchar, 'cal_event', '', 0, 0);
+                         	$event->label=$savlabel;
+                         	$event->libelle=$savlabel;
+                         }
+-- 
+2.20.1
+


### PR DESCRIPTION
# Enable tooltip for calendar events
When calendar events have a too long description the content can't be displayed, especially in the month view. This modification enables tooltips in order to be able to display the content by putting the mouse cursor over the event's title.