### PR TITLE
FIX the access of the bank account of one user

### DIFF
--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -54,6 +54,7 @@ $ok=false;
 if ($user->id == $id) $ok=true; // A user can always read its own card
 if (! empty($user->rights->salaries->read)) $ok=true;
 if (! empty($user->rights->hrm->read)) $ok=true;
+if (! empty($user->rights->expensereport->lire) && ($user->id == $object->id || $user->rights->expensereport->readall)) $ok=true;
 if (! $ok)
 {
 	accessforbidden();


### PR DESCRIPTION
There are 3 ways to access this tab :
    1. If the module holiday is enabled
    2. If the module holidays is enabled
    3. If the module expense report is enabled

More over that, the application checks if the user can access the bank
account of the selected user. The application does that twice (logical
^^), first to know if the tab has to be displayed or not. Second time,
when you arrive on the page /user/bank.php to know if you have access
(eg. if you type the url directly).

In this second check, the check of the expense report module was missing
(added by this PR). This caused the following issue: the tab was visible
but when the user clicked on itn, he received an error as he cannot
access the page.