### PR TITLE
NEW Add bank data of user into the expense report exports

### DIFF
--- a/htdocs/core/modules/modExpenseReport.class.php
+++ b/htdocs/core/modules/modExpenseReport.class.php
@@ -184,18 +184,25 @@ class modExpenseReport extends DolibarrModules
 			'd.rowid'=>"TripId",'d.ref'=>'Ref','d.date_debut'=>'DateStart','d.date_fin'=>'DateEnd','d.date_create'=>'DateCreation','d.date_approve'=>'DateApprove',
 			'd.total_ht'=>"TotalHT",'d.total_tva'=>'TotalVAT','d.total_ttc'=>'TotalTTC','d.note_private'=>'NotePrivate','d.note_public'=>'NotePublic',
 			'u.lastname'=>'Lastname','u.firstname'=>'Firstname','u.login'=>"Login",'ed.rowid'=>'LineId','tf.code'=>'Type','ed.date'=>'Date','ed.tva_tx'=>'VATRate',
-			'ed.total_ht'=>'TotalHT','ed.total_tva'=>'TotalVAT','ed.total_ttc'=>'TotalTTC','ed.comments'=>'Comment','p.rowid'=>'ProjectId','p.ref'=>'Ref'
+			'ed.total_ht'=>'TotalHT','ed.total_tva'=>'TotalVAT','ed.total_ttc'=>'TotalTTC','ed.comments'=>'Comment','p.rowid'=>'ProjectId','p.ref'=>'Ref',
+            'user_rib.iban_prefix' => 'IBAN', 'user_rib.bic' => 'BIC', 'user_rib.code_banque' => 'BankCode', 'user_rib.bank' => 'BankName', 'user_rib.proprio' => 'BankAccountOwner',
+            'user_rib.owner_address' => 'BankAccountOwnerAddress'
 		);
         $this->export_TypeFields_array[$r]=array(
         	'd.rowid'=>"Numeric",'d.ref'=>'Text','d.date_debut'=>'Date','d.date_fin'=>'Date','d.date_create'=>'Date','d.date_approve'=>'Date',
         	'd.total_ht'=>"Numeric",'d.total_tva'=>'Numeric','d.total_ttc'=>'Numeric','d.note_private'=>'Text','d.note_public'=>'Text',
         	'u.lastname'=>'Text','u.firstname'=>'Text','u.login'=>"Text",'ed.rowid'=>'Numeric','tf.code'=>'Code','ed.date'=>'Date','ed.tva_tx'=>'Numeric',
-        	'ed.total_ht'=>'Numeric','ed.total_tva'=>'Numeric','ed.total_ttc'=>'Numeric','ed.comments'=>'Text','p.rowid'=>'Numeric','p.ref'=>'Text'
+        	'ed.total_ht'=>'Numeric','ed.total_tva'=>'Numeric','ed.total_ttc'=>'Numeric','ed.comments'=>'Text','p.rowid'=>'Numeric','p.ref'=>'Text',
+            'user_rib.iban_prefix' => 'Text', 'user_rib.bic' => 'Text', 'user_rib.code_banque' => 'Text', 'user_rib.bank' => 'Text', 'user_rib.proprio' => 'Text',
+            'user_rib.owner_address' => 'Text'
         );
         $this->export_entities_array[$r]=array(
 			'u.lastname'=>'user','u.firstname'=>'user','u.login'=>'user','ed.rowid'=>'expensereport_line','ed.date'=>'expensereport_line',
 			'ed.tva_tx'=>'expensereport_line','ed.total_ht'=>'expensereport_line','ed.total_tva'=>'expensereport_line','ed.total_ttc'=>'expensereport_line',
-			'ed.comments'=>'expensereport_line','tf.code'=>'expensereport_line','p.project_ref'=>'expensereport_line','p.rowid'=>'project','p.ref'=>'project'
+			'ed.comments'=>'expensereport_line','tf.code'=>'expensereport_line','p.project_ref'=>'expensereport_line','p.rowid'=>'project','p.ref'=>'project',
+            'user_rib.iban_prefix' => 'user', 'user_rib.bic' => 'user', 'user_rib.code_banque' => 'user', 'user_rib.bank' => 'user', 'user_rib.proprio' => 'user',
+            'user_rib.owner_address' => 'user'
+
 		);
         $this->export_alias_array[$r]=array('d.rowid'=>"idtrip",'d.type'=>"type",'d.note_private'=>'note_private','d.note_public'=>'note_public','u.lastname'=>'name','u.firstname'=>'firstname','u.login'=>'login');
 		$this->export_dependencies_array[$r]=array('expensereport_line'=>'ed.rowid','type_fees'=>'tf.rowid'); // To add unique key if we ask a field of a child to avoid the DISTINCT to discard them
@@ -205,7 +212,8 @@ class modExpenseReport extends DolibarrModules
 
 		$this->export_sql_start[$r]='SELECT DISTINCT ';
 		$this->export_sql_end[$r]  =' FROM '.MAIN_DB_PREFIX.'expensereport as d';
-		$this->export_sql_end[$r] .=' LEFT JOIN '.MAIN_DB_PREFIX.'expensereport_extrafields as extra on d.rowid = extra.fk_object,';
+		$this->export_sql_end[$r] .=' LEFT JOIN '.MAIN_DB_PREFIX.'expensereport_extrafields as extra on d.rowid = extra.fk_object';
+		$this->export_sql_end[$r] .=' LEFT JOIN '.MAIN_DB_PREFIX.'user_rib as user_rib ON user_rib.fk_user = d.fk_user_author,';
 		$this->export_sql_end[$r] .=' '.MAIN_DB_PREFIX.'user as u,';
 		$this->export_sql_end[$r] .=' '.MAIN_DB_PREFIX.'expensereport_det as ed LEFT JOIN '.MAIN_DB_PREFIX.'c_type_fees as tf ON ed.fk_c_type_fees = tf.id';
 		$this->export_sql_end[$r] .=' LEFT JOIN '.MAIN_DB_PREFIX.'projet as p ON ed.fk_projet = p.rowid';

--- a/htdocs/exports/export.php
+++ b/htdocs/exports/export.php
@@ -33,7 +33,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/modules/export/modules_export.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 
 // Load translation files required by the page
-$langs->loadlangs(array('exports', 'other', 'users', 'companies', 'projects'));
+$langs->loadlangs(array('exports', 'other', 'users', 'companies', 'projects', 'BankAccounts'));
 
 // Everybody should be able to go on this page
 //if (! $user->admin)

--- a/htdocs/exports/export.php
+++ b/htdocs/exports/export.php
@@ -33,7 +33,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/modules/export/modules_export.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 
 // Load translation files required by the page
-$langs->loadlangs(array('exports', 'other', 'users', 'companies', 'projects', 'BankAccounts'));
+$langs->loadlangs(array('exports', 'other', 'users', 'companies', 'projects', 'banks'));
 
 // Everybody should be able to go on this page
 //if (! $user->admin)


### PR DESCRIPTION
When the user requests the export of the expense reports, some fields
were missing such as the bank account information of the user.

This PR adds the support of all those fields on the expense report
export. Now when you export the expense report you have :
* The bank name
* The bank code
* The IBAN
* The BIC
* The owner
* The owner address

To be able to test it:
* Create a bank number to one user
* Create at least one expense report for that user
* Export all the expense reports
