### PR TITLE
clean code on the common object

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -118,7 +118,7 @@ class Categorie extends CommonObject
 	 *
 	 * @note Move to const array when PHP 5.6 will be our minimum target
 	 */
-	protected $MAP_CAT_TABLE = array(
+	public $MAP_CAT_TABLE = array(
 		'product'  => 'product',
 		'customer' => 'societe',
 		'supplier' => 'fournisseur',

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7567,12 +7567,10 @@ abstract class CommonObject
 				return 0;
 			}
 		}
-		else
-		{
-			$this->error = $this->db->lasterror();
-			$this->errors[] = $this->error;
-			return -1;
-		}
+
+        $this->error = $this->db->lasterror();
+        $this->errors[] = $this->error;
+        return -1;
 	}
 
 	/**
@@ -7617,12 +7615,10 @@ abstract class CommonObject
 
 			return 1;
 		}
-		else
-		{
-			$this->error = $this->db->lasterror();
-			$this->errors[] = $this->error;
-			return -1;
-		}
+
+        $this->error = $this->db->lasterror();
+        $this->errors[] = $this->error;
+        return -1;
 	}
 
 	/**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2029,7 +2029,7 @@ abstract class CommonObject
 	 */
 	public function setMulticurrencyRate($rate, $mode = 1)
 	{
-		dol_syslog(get_class($this).'::setMulticurrencyRate('.$id.')');
+		dol_syslog(get_class($this).'::setMulticurrencyRate('.$this->id.')');
 		if ($this->statut >= 0 || $this->element == 'societe')
 		{
 			$fieldname = 'multicurrency_tx';

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -426,11 +426,40 @@ abstract class CommonObject
 
 	public $next_prev_filter;
 
+    /**
+     * @var string
+     */
+    public $skype;
 
+    /**
+     * @var string
+     */
+    public $jabberid;
 
-	// No constructor as it is an abstract class
+    /**
+     * @var string
+     */
+    public $twitter;
 
-	/**
+    /**
+     * @var string
+     */
+    public $facebook;
+
+    /**
+     * @var string
+     */
+    public $linkedin;
+
+    /**
+     * @param DoliDB $db
+     */
+    public function __construct($db = null)
+    {
+        $this->db = $db;
+    }
+
+    /**
 	 * Check an object id/ref exists
 	 * If you don't need/want to instantiate object and just need to know if object exists, use this method instead of fetch
 	 *
@@ -1958,7 +1987,7 @@ abstract class CommonObject
 	 */
 	public function setMulticurrencyCode($code)
 	{
-		dol_syslog(get_class($this).'::setMulticurrencyCode('.$id.')');
+		dol_syslog(get_class($this).'::setMulticurrencyCode('.$this->id.')');
 		if ($this->statut >= 0 || $this->element == 'societe')
 		{
 			$fieldname = 'multicurrency_code';
@@ -7802,7 +7831,7 @@ abstract class CommonObject
 	 *	@param  User	$user       User that delete
 	 *  @param	int		$idline		Id of line to delete
 	 *  @param 	bool 	$notrigger  false=launch triggers after, true=disable triggers
-     * 
+     *
 	 *  @return int         		>0 if OK, <0 if KO
 	 */
 	public function deleteLineCommon(User $user, $idline, $notrigger = false)

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7705,10 +7705,10 @@ abstract class CommonObject
 		if ($error) {
 			$this->db->rollback();
 			return -1;
-		} else {
-			$this->db->commit();
-			return $this->id;
 		}
+
+        $this->db->commit();
+        return $this->id;
 	}
 
 	/**
@@ -7806,10 +7806,10 @@ abstract class CommonObject
 		if ($error) {
 			$this->db->rollback();
 			return -1;
-		} else {
-			$this->db->commit();
-			return 1;
 		}
+
+        $this->db->commit();
+        return 1;
 	}
 
 	/**
@@ -7866,11 +7866,11 @@ abstract class CommonObject
 		if (empty($error)) {
 			$this->db->commit();
 			return 1;
-		} else {
-			dol_syslog(get_class($this)."::deleteLineCommon ERROR:".$this->error, LOG_ERR);
-			$this->db->rollback();
-			return -1;
 		}
+
+        dol_syslog(get_class($this)."::deleteLineCommon ERROR:".$this->error, LOG_ERR);
+        $this->db->rollback();
+        return -1;
 	}
 
 	/**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7634,7 +7634,7 @@ abstract class CommonObject
 	 */
 	public function updateCommon(User $user, $notrigger = false)
 	{
-		global $conf, $langs;
+		global $conf;
 
 		$error = 0;
 
@@ -7659,14 +7659,6 @@ abstract class CommonObject
 		{
 			if (preg_match('/^integer:/i', $this->fields[$key]['type']) && $values[$key] == '-1') $values[$key]='';		// This is an implicit foreign key field
 			if (! empty($this->fields[$key]['foreignkey']) && $values[$key] == '-1') $values[$key]='';					// This is an explicit foreign key field
-
-			//var_dump($key.'-'.$values[$key].'-'.($this->fields[$key]['notnull'] == 1));
-			/*
-			if ($this->fields[$key]['notnull'] == 1 && empty($values[$key]))
-			{
-				$error++;
-				$this->errors[]=$langs->trans("ErrorFieldRequired", $this->fields[$key]['label']);
-			}*/
 		}
 
 		$sql = 'UPDATE '.MAIN_DB_PREFIX.$this->table_element.' SET '.implode(',', $tmp).' WHERE rowid='.$this->id ;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2414,12 +2414,10 @@ abstract class CommonObject
 			$this->db->rollback();
 			return -1;
 		}
-		else
-		{
-			$this->fk_account = ($fk_account=='NULL')?null:$fk_account;
-			$this->db->commit();
-			return 1;
-		}
+
+        $this->fk_account = ($fk_account=='NULL')?null:$fk_account;
+        $this->db->commit();
+        return 1;
 	}
 
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3937,11 +3937,9 @@ abstract class CommonObject
 				return '';
 			}
 		}
-		else
-		{
-			$this->errors[] = $this->db->lasterror();
-			return false;
-		}
+
+        $this->errors[] = $this->db->lasterror();
+        return false;
 	}
 
 	/**
@@ -3975,13 +3973,12 @@ abstract class CommonObject
 				}
 				return 1;
 			}
-			else
-			{
-				$this->errors[] = $this->db->lasterror();
-				return -1;
-			}
+
+            $this->errors[] = $this->db->lasterror();
+            return -1;
 		}
-		else return -1;
+
+		return -1;
 	}
 
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7802,6 +7802,7 @@ abstract class CommonObject
 	 *	@param  User	$user       User that delete
 	 *  @param	int		$idline		Id of line to delete
 	 *  @param 	bool 	$notrigger  false=launch triggers after, true=disable triggers
+     * 
 	 *  @return int         		>0 if OK, <0 if KO
 	 */
 	public function deleteLineCommon(User $user, $idline, $notrigger = false)
@@ -7857,7 +7858,7 @@ abstract class CommonObject
 	}
 
 	/**
-	 * Initialise object with example values
+	 * Initialise object with example values.
 	 * Id must be 0 if object instance is a specimen
 	 *
 	 * @return void
@@ -7867,6 +7868,7 @@ abstract class CommonObject
 	    global $user;
 
 		$this->id = 0;
+
 		if (array_key_exists('label', $this->fields)) $this->label='This is label';
 		if (array_key_exists('note_public', $this->fields)) $this->note_public='Public note';
 		if (array_key_exists('note_private', $this->fields)) $this->note_private='Private note';
@@ -7875,15 +7877,15 @@ abstract class CommonObject
 		if (array_key_exists('fk_user_creat', $this->fields)) $this->fk_user_creat=$user->id;
 		if (array_key_exists('fk_user_modif', $this->fields)) $this->fk_user_modif=$user->id;
 		if (array_key_exists('date', $this->fields)) $this->date=dol_now();
-		// ...
 	}
 
 
 	/* Part for comments */
 
 	/**
-	 * Load comments linked with current task
-	 *	@return boolean	1 if ok
+	 * Load comments linked with current task and return the number of comments.
+     *
+	 *	@return int -1 if error
 	 */
 	public function fetchComments()
 	{
@@ -7894,10 +7896,10 @@ abstract class CommonObject
 		if ($result<0) {
 			$this->errors=array_merge($this->errors, $comment->errors);
 			return -1;
-		} else {
-			$this->comments = $comment->comments;
 		}
-		return count($this->comments);
+
+		$this->comments = $comment->comments;
+		return $this->getNbComments();
 	}
 
     /**
@@ -7911,7 +7913,8 @@ abstract class CommonObject
     }
 
     /**
-     * Trim object parameters
+     * Trim object parameters.
+     *
      * @param string[] $parameters array of parameters to trim
      *
      * @return void

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7216,12 +7216,7 @@ abstract class CommonObject
 	 */
 	protected function isIndex($info)
 	{
-		if(is_array($info))
-		{
-			if(isset($info['index']) && $info['index']==true) return true;
-			else return false;
-		}
-		return false;
+	    return is_array($info) && isset($info['index']) && $info['index']==true;
 	}
 
 	/**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7129,16 +7129,7 @@ abstract class CommonObject
 	 */
 	protected function isNull($info)
 	{
-		if(is_array($info))
-		{
-			if(isset($info['type']) && $info['type']=='null'){
-			    return true;
-            }
-
-			return false;
-		}
-
-		return false;
+        return is_array($info) && isset($info['type']) && $info['type']=='null';
 	}
 
 	/**
@@ -7149,8 +7140,7 @@ abstract class CommonObject
 	 */
 	public function isDate($info)
 	{
-		if(isset($info['type']) && ($info['type']=='date' || $info['type']=='datetime' || $info['type']=='timestamp')) return true;
-		return false;
+		return isset($info['type']) && ($info['type']=='date' || $info['type']=='datetime' || $info['type']=='timestamp');
 	}
 
 	/**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7391,7 +7391,7 @@ abstract class CommonObject
 		unset($fieldvalues['rowid']);	// The field 'rowid' is reserved field name for autoincrement field so we don't need it into insert.
 		if (array_key_exists('ref', $fieldvalues)) $fieldvalues['ref']=dol_string_nospecial($fieldvalues['ref']);					// If field is a ref,we sanitize data
 
-		$keys=array();
+		$keys = array();
 		$values = array();
 		foreach ($fieldvalues as $k => $v) {
 			$keys[$k] = $k;
@@ -7406,7 +7406,6 @@ abstract class CommonObject
 			if (preg_match('/^integer:/i', $this->fields[$key]['type']) && $values[$key] == '-1') $values[$key]='';
 			if (! empty($this->fields[$key]['foreignkey']) && $values[$key] == '-1') $values[$key]='';
 
-			//var_dump($key.'-'.$values[$key].'-'.($this->fields[$key]['notnull'] == 1));
 			if (isset($this->fields[$key]['notnull']) && $this->fields[$key]['notnull'] == 1 && ! isset($values[$key]) && is_null($val['default']))
 			{
 				$error++;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -108,7 +108,6 @@ abstract class CommonObject
 	protected $table_ref_field = '';
 
 
-
 	// Following vars are used by some objects only. We keep this property here in CommonObject to be able to provide common method using them.
 
 	/**
@@ -7926,35 +7925,4 @@ abstract class CommonObject
             }
         }
     }
-
-    /**
-     *  copy related categories to another object
-     *
-     * @param  int		$fromId	Id object source
-     * @param  int		$toId	Id object cible
-     * @param  string	$type	Type of category ('product', ...)
-     * @return int      < 0 si erreur, > 0 si ok
-     */
-	public function cloneCategories($fromId, $toId, $type = '')
-	{
-		$this->db->begin();
-
-		if (empty($type)) $type = $this->table_element;
-
-		require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
-		$categorystatic = new Categorie($this->db);
-
-		$sql = "INSERT INTO ".MAIN_DB_PREFIX."categorie_" . $categorystatic->MAP_CAT_TABLE[$type] . " (fk_categorie, fk_product)";
-		$sql.= " SELECT fk_categorie, $toId FROM ".MAIN_DB_PREFIX."categorie_" . $categorystatic->MAP_CAT_TABLE[$type];
-		$sql.= " WHERE fk_product = '".$fromId."'";
-
-		if (! $this->db->query($sql))
-		{
-			$this->db->rollback();die($sql);
-			return -1;
-		}
-
-		$this->db->commit();
-		return 1;
-	}
 }

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7151,12 +7151,7 @@ abstract class CommonObject
 	 */
 	public function isInt($info)
 	{
-		if(is_array($info))
-		{
-			if(isset($info['type']) && ($info['type']=='int' || preg_match('/^integer/i', $info['type']) ) ) return true;
-			else return false;
-		}
-		else return false;
+	    return is_array($info) && isset($info['type']) && ($info['type']=='int' || preg_match('/^integer/i', $info['type']) );
 	}
 
 	/**
@@ -7167,12 +7162,7 @@ abstract class CommonObject
 	 */
 	public function isFloat($info)
 	{
-		if(is_array($info))
-		{
-			if (isset($info['type']) && (preg_match('/^(double|real|price)/i', $info['type']))) return true;
-			else return false;
-		}
-		return false;
+	    return is_array($info) && isset($info['type']) && (preg_match('/^(double|real|price)/i', $info['type']));
 	}
 
 	/**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -457,7 +457,7 @@ abstract class CommonObject
     public $fields;
 
     /**
-     * @param DoliDB $db
+     * @param DoliDB|null $db the connection to the DB.
      */
     public function __construct($db = null)
     {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2350,16 +2350,15 @@ abstract class CommonObject
 
 		dol_syslog(get_class($this)."::setDocModel", LOG_DEBUG);
 		$resql=$this->db->query($sql);
+
 		if ($resql)
 		{
 			$this->modelpdf=$modelpdf;
 			return 1;
 		}
-		else
-		{
-			dol_print_error($this->db);
-			return 0;
-		}
+
+        dol_print_error($this->db);
+        return 0;
 	}
 
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7173,12 +7173,7 @@ abstract class CommonObject
 	 */
 	public function isText($info)
 	{
-		if(is_array($info))
-		{
-			if(isset($info['type']) && $info['type']=='text') return true;
-			else return false;
-		}
-		return false;
+        return is_array($info) && isset($info['type']) && $info['type']=='text';
 	}
 
 	/**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2806,11 +2806,9 @@ abstract class CommonObject
 			$this->ref_ext = $ref_ext;
 			return 1;
 		}
-		else
-		{
-			$this->error=$this->db->error();
-			return -1;
-		}
+
+        $this->error=$this->db->error();
+        return -1;
 	}
 
     // phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7120,8 +7120,11 @@ abstract class CommonObject
 	{
 		if(is_array($info))
 		{
-			if(isset($info['type']) && $info['type']=='array') return true;
-			else return false;
+			if(isset($info['type']) && $info['type']=='array'){
+			    return true;
+            }
+
+			return false;
 		}
 		return false;
 	}
@@ -7405,7 +7408,7 @@ abstract class CommonObject
 		if (array_key_exists('fk_user_creat', $fieldvalues) && ! ($fieldvalues['fk_user_creat'] > 0)) $fieldvalues['fk_user_creat']=$user->id;
 		unset($fieldvalues['rowid']);	// The field 'rowid' is reserved field name for autoincrement field so we don't need it into insert.
 		if (array_key_exists('ref', $fieldvalues)) $fieldvalues['ref']=dol_string_nospecial($fieldvalues['ref']);					// If field is a ref,we sanitize data
-		
+
 		$keys=array();
 		$values = array();
 		foreach ($fieldvalues as $k => $v) {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7118,14 +7118,26 @@ abstract class CommonObject
 	 */
 	protected function isArray($info)
 	{
+	    return is_array($info) && isset($info['type']) && $info['type']=='array';
+	}
+
+	/**
+	 * Function test if type is null
+	 *
+	 * @param   array   $info   content informations of field
+	 * @return                  bool
+	 */
+	protected function isNull($info)
+	{
 		if(is_array($info))
 		{
-			if(isset($info['type']) && $info['type']=='array'){
+			if(isset($info['type']) && $info['type']=='null'){
 			    return true;
             }
 
 			return false;
 		}
+
 		return false;
 	}
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2857,11 +2857,9 @@ abstract class CommonObject
 			}
 			return 1;
 		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			return -1;
-		}
+
+        $this->error=$this->db->lasterror();
+        return -1;
 	}
 
     // phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -3158,12 +3156,10 @@ abstract class CommonObject
 			$this->db->commit();
 			return 1;
 		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			$this->db->rollback();
-			return 0;
-		}
+
+        $this->error=$this->db->lasterror();
+        $this->db->rollback();
+        return 0;
 	}
 
 	/**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3371,11 +3371,9 @@ abstract class CommonObject
 			}
 			return 1;
 		}
-		else
-		{
-			dol_print_error($this->db);
-			return -1;
-		}
+
+        dol_print_error($this->db);
+        return -1;
 	}
 
 	/**
@@ -3417,11 +3415,9 @@ abstract class CommonObject
 		{
 			return 1;
 		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			return -1;
-		}
+
+        $this->error=$this->db->lasterror();
+        return -1;
 	}
 
 	/**
@@ -3479,12 +3475,10 @@ abstract class CommonObject
 		{
 			return 1;
 		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			$this->errors[]=$this->error;
-			return -1;
-		}
+
+        $this->error=$this->db->lasterror();
+        $this->errors[]=$this->error;
+        return -1;
 	}
 
 	/**
@@ -3568,12 +3562,10 @@ abstract class CommonObject
 				return -1;
 			}
 		}
-		else
-		{
-			$this->error=$this->db->lasterror();
-			$this->db->rollback();
-			return -1;
-		}
+
+        $this->error=$this->db->lasterror();
+        $this->db->rollback();
+        return -1;
 	}
 
 
@@ -3611,11 +3603,9 @@ abstract class CommonObject
 			}
 			else return 0;
 		}
-		else
-		{
-			dol_print_error($this->db);
-			return -1;
-		}
+
+        dol_print_error($this->db);
+        return -1;
 	}
 
 
@@ -3635,6 +3625,8 @@ abstract class CommonObject
 			$row = $this->db->fetch_row($resql);
 			return $row[0];
 		}
+
+		//TODO add a return here
 	}
 
 	/**
@@ -3704,7 +3696,8 @@ abstract class CommonObject
 			$this->errors[]="ErrorRecordHasChildren";
 			return $haschild;
 		}
-		else return 0;
+
+		return 0;
 	}
 
 	/**
@@ -3765,7 +3758,6 @@ abstract class CommonObject
 			}
 		}
 
-		//print $total_discount; exit;
 		return price2num($total_discount);
 	}
 
@@ -3889,11 +3881,9 @@ abstract class CommonObject
 			$this->db->rollback();
 			return -1;
 		}
-		else
-		{
-			$this->db->commit();
-			return 1;
-		}
+
+        $this->db->commit();
+        return 1;
 	}
 
 

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5289,4 +5289,35 @@ class Product extends CommonObject
             dol_print_error($this->db);
         }
     }
+
+    /**
+     *  copy related categories to another product.
+     *
+     * @param  int		$fromId	Id object source
+     * @param  int		$toId	Id object cible
+     * @param  string	$type	Type of category ('product', ...)
+     * @return int      < 0 si erreur, > 0 si ok
+     */
+    public function cloneCategories($fromId, $toId, $type = '')
+    {
+        $this->db->begin();
+
+        if (empty($type)) $type = $this->table_element;
+
+        require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
+        $categorystatic = new Categorie($this->db);
+
+        $sql = "INSERT INTO ".MAIN_DB_PREFIX."categorie_" . $categorystatic->MAP_CAT_TABLE[$type] . " (fk_categorie, fk_product)";
+        $sql.= " SELECT fk_categorie, $toId FROM ".MAIN_DB_PREFIX."categorie_" . $categorystatic->MAP_CAT_TABLE[$type];
+        $sql.= " WHERE fk_product = '".$fromId."'";
+
+        if (! $this->db->query($sql))
+        {
+            $this->db->rollback();die($sql);
+            return -1;
+        }
+
+        $this->db->commit();
+        return 1;
+    }
 }

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -404,7 +404,7 @@ class Product extends CommonObject
      */
     public function __construct($db)
     {
-        $this->db = $db;
+        parent::__construct($db);
         $this->canvas = '';
     }
 


### PR DESCRIPTION
Hello @eldy ;

The only objective of this PR is to optimize the code base of Dolibarr by cleaning the code of the common class.

* I simplified a lot of if ... else. When there is a return in the 'if' condition you don't need the else (cf the code)
* I tried to remove unused variables
* I tried to check why this class is red (and still red) on PHPStorm 
![image](https://user-images.githubusercontent.com/3658458/66458392-f212cb00-ea72-11e9-95e7-507f1f1c953e.png)


If you have any concerns about this refactoring please share it. But, I think important to improve our codebase. I can explain each change I made.

### Why PHPStorm is red ?
For those who don't develop with PHPStorm. There is a flag which informs the developer about the stability of his class. If it's red it means the class has (probably) a running error. 

In our case, it's because there is some JS on the page so the PHP interpreter cannot interpret that code (that's a non issue). But it was also red because the usage of some variables that don't exist! 

So I cleaned that also.

Cheers
L.
