### PR TITLE
add security.lib.php for dol_hash

### DIFF
--- a/htdocs/blockedlog/class/blockedlog.class.php
+++ b/htdocs/blockedlog/class/blockedlog.class.php
@@ -1048,6 +1048,7 @@ class BlockedLog
 		if (empty($conf->global->BLOCKEDLOG_ENTITY_FINGERPRINT)) { // creation of a unique fingerprint
 
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/security2.lib.php';
 
 			$fingerprint = dol_hash(print_r($mysoc, true).getRandomPassword(1), '5');


### PR DESCRIPTION
# Fix missing lib
I was performing a migration from 6.0 to 10.0 when blockedLog module thrown a fatal error.

In fact, the function dol_hash() called in the method blockedLog::getSignature() is in security.lib.php that wasn't included...