### PR TITLE
FIX add and modify category translate form with posted values on errors

### DIFF
--- a/htdocs/categories/traduction.php
+++ b/htdocs/categories/traduction.php
@@ -62,6 +62,7 @@ $object = new Categorie($db);
 /*
  * Actions
  */
+$error = 0;
 
 // retour a l'affichage des traduction si annulation
 if ($cancel == $langs->trans("Cancel"))
@@ -78,28 +79,44 @@ $cancel != $langs->trans("Cancel") &&
 	$object->fetch($id);
 	$current_lang = $langs->getDefaultLang();
 
-	// update de l'objet
-	if ( $_POST["forcelangprod"] == $current_lang )
-	{
-		$object->label			= $_POST["libelle"];
-		$object->description	= dol_htmlcleanlastbr($_POST["desc"]);
-	}
-	else
-	{
-		$object->multilangs[$_POST["forcelangprod"]]["label"]			= $_POST["libelle"];
-		$object->multilangs[$_POST["forcelangprod"]]["description"]   	= dol_htmlcleanlastbr($_POST["desc"]);
-	}
+	// check parameters
+    $forcelangprod = GETPOST('forcelangprod', 'alpha');
+    $libelle = GETPOST('libelle', 'alpha');
+    $desc = GETPOST('desc');
 
-	// sauvegarde en base
-	if ( $object->setMultiLangs($user) > 0 )
-	{
-		$action = '';
-	}
-	else
-	{
-		$action = 'add';
-		setEventMessages($object->error, $object->errors, 'errors');
-	}
+    if (empty($forcelangprod)) {
+        $error++;
+        $object->errors[] = $langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Translation'));
+    }
+
+    if (!$error) {
+        if (empty($libelle)) {
+            $error++;
+            $object->errors[] = $langs->trans('Language_' . $forcelangprod)  . ' : ' . $langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Label'));
+        }
+
+        if (!$error) {
+            // update de l'objet
+            if ($forcelangprod == $current_lang) {
+                $object->label = $libelle;
+                $object->description = dol_htmlcleanlastbr($desc);
+            } else {
+                $object->multilangs[$forcelangprod]["label"] = $libelle;
+                $object->multilangs[$forcelangprod]["description"] = dol_htmlcleanlastbr($desc);
+            }
+
+            // sauvegarde en base
+            $res = $object->setMultiLangs($user);
+            if ($res < 0) $error++;
+        }
+    }
+
+    if ($error) {
+        $action = 'add';
+        setEventMessages($object->error, $object->errors, 'errors');
+    } else {
+        $action = '';
+    }
 }
 
 // Validation de l'edition
@@ -112,27 +129,34 @@ $cancel != $langs->trans("Cancel") &&
 
 	foreach ($object->multilangs as $key => $value) // enregistrement des nouvelles valeurs dans l'objet
 	{
-		if ( $key == $current_lang )
-		{
-			$object->label			= $_POST["libelle-".$key];
-			$object->description	= dol_htmlcleanlastbr($_POST["desc-".$key]);
-		}
-		else
-		{
-			$object->multilangs[$key]["label"]			= $_POST["libelle-".$key];
-			$object->multilangs[$key]["description"]	= dol_htmlcleanlastbr($_POST["desc-".$key]);
+        $libelle = GETPOST('libelle-'. $key, 'alpha');
+        $desc = GETPOST('desc-' . $key);
+
+        if (empty($libelle)) {
+            $error++;
+            $object->errors[] = $langs->trans('Language_' . $key) . ' : ' . $langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Label'));
+        }
+
+		if ( $key == $current_lang ) {
+			$object->label       = $libelle;
+			$object->description = dol_htmlcleanlastbr($desc);
+		} else {
+			$object->multilangs[$key]["label"]       = $libelle;
+			$object->multilangs[$key]["description"] = dol_htmlcleanlastbr($desc);
 		}
 	}
 
-	if ( $object->setMultiLangs($user) > 0 )
-	{
-		$action = '';
-	}
-	else
-	{
-		$action = 'edit';
-		setEventMessages($object->error, $object->errors, 'errors');
-	}
+    if (!$error) {
+        $res = $object->setMultiLangs($user);
+        if ($res < 0)   $error++;
+    }
+
+    if ($error) {
+        $action = 'edit';
+        setEventMessages($object->error, $object->errors, 'errors');
+    } else {
+        $action = '';
+    }
 }
 
 $result = $object->fetch($id, $ref);
@@ -224,8 +248,8 @@ if ($action == '')
 {
     if ($user->rights->produit->creer || $user->rights->service->creer)
     {
-        print '<a class="butAction" href="'.$_SERVER['PHP_SELF'].'?action=add&id='.$object->id.'">'.$langs->trans("Add").'</a>';
-        if ($cnt_trans > 0) print '<a class="butAction" href="'.$_SERVER['PHP_SELF'].'?action=edit&id='.$object->id.'">'.$langs->trans("Update").'</a>';
+        print '<a class="butAction" href="'.$_SERVER['PHP_SELF'].'?action=add&id='.$object->id.'&type='.$type.'">'.$langs->trans('Add').'</a>';
+        if ($cnt_trans > 0) print '<a class="butAction" href="'.$_SERVER['PHP_SELF'].'?action=edit&id='.$object->id.'&type='.$type.'">'.$langs->trans('Update').'</a>';
     }
 }
 
@@ -242,6 +266,7 @@ if ($action == 'edit')
 	print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
 	print '<input type="hidden" name="action" value="vedit">';
 	print '<input type="hidden" name="id" value="'.$object->id.'">';
+    print '<input type="hidden" name="type" value="' . $type . '">';
 
 	if (! empty($object->multilangs))
 	{
@@ -249,9 +274,14 @@ if ($action == 'edit')
 		{
 		    print "<br><b><u>".$langs->trans('Language_'.$key)." :</u></b><br>";
 			print '<table class="border" width="100%">';
-			print '<tr><td class="titlefield fieldrequired">'.$langs->trans('Label').'</td><td><input name="libelle-'.$key.'" size="40" value="'.$object->multilangs[$key]["label"].'"></td></tr>';
+
+			// Label
+            $libelle = (GETPOST('libelle-'.$key, 'alpha') ? GETPOST('libelle-'.$key, 'alpha') : $object->multilangs[$key]['label']);
+			print '<tr><td class="titlefield fieldrequired">'.$langs->trans('Label').'</td><td><input name="libelle-'.$key.'" size="40" value="'.$libelle.'"></td></tr>';
+			// Desc
+            $desc = (GETPOST('desc-'.$key) ? GETPOST('desc-'.$key) : $object->multilangs[$key]['description']);
 			print '<tr><td class="tdtop">'.$langs->trans('Description').'</td><td>';
-			$doleditor = new DolEditor("desc-$key", $object->multilangs[$key]["description"], '', 160, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, ROWS_3, '90%');
+			$doleditor = new DolEditor("desc-$key", $desc, '', 160, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, ROWS_3, '90%');
 			$doleditor->Create();
 			print '</td></tr>';
 
@@ -280,7 +310,7 @@ elseif ($action != 'add')
 		{
 		    $s=picto_from_langcode($key);
 			print '<table class="border" width="100%">';
-			print '<tr class="liste_titre"><td colspan="2">'.($s?$s.' ':'')." <b>".$langs->trans('Language_'.$key).":</b> ".'<a href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=delete&langtodelete='.$key.'">'.img_delete('', '').'</a></td></tr>';
+			print '<tr class="liste_titre"><td colspan="2">'.($s?$s.' ':'')." <b>".$langs->trans('Language_'.$key).":</b> ".'<a href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=delete&langtodelete='.$key.'&type='.$type.'">'.img_delete('', '').'</a></td></tr>';
 			print '<tr><td class="titlefield">'.$langs->trans('Label').'</td><td>'.$object->multilangs[$key]["label"].'</td></tr>';
 			print '<tr><td>'.$langs->trans('Description').'</td><td>'.$object->multilangs[$key]["description"].'</td></tr>';
 			if (! empty($conf->global->CATEGORY_USE_OTHER_FIELD_IN_TRANSLATION))
@@ -308,14 +338,16 @@ if ($action == 'add' && ($user->rights->produit->creer || $user->rights->service
 	print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
 	print '<input type="hidden" name="action" value="vadd">';
 	print '<input type="hidden" name="id" value="'.$id.'">';
+    print '<input type="hidden" name="type" value="' . $type . '">';
 
 	print '<table class="border" width="100%">';
 	print '<tr><td class="titlefield fieldrequired">'.$langs->trans('Translation').'</td><td>';
-    print $formadmin->select_language('', 'forcelangprod', 0, $object->multilangs);
+    print $formadmin->select_language(GETPOST('forcelangprod', 'alpha'), 'forcelangprod', 0, $object->multilangs);
 	print '</td></tr>';
-	print '<tr><td class="fieldrequired">'.$langs->trans('Label').'</td><td><input name="libelle" size="40"></td></tr>';
+	print '<tr><td class="fieldrequired">' . $langs->trans('Label') . '</td>';
+	print '<td><input name="libelle" size="40" value="' . GETPOST('libelle', 'alpha'). '"></td></tr>';
 	print '<tr><td>'.$langs->trans('Description').'</td><td>';
-	$doleditor = new DolEditor('desc', '', '', 160, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, ROWS_3, '90%');
+	$doleditor = new DolEditor('desc', GETPOST('desc'), '', 160, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, ROWS_3, '90%');
 	$doleditor->Create();
 	print '</td></tr>';
 

--- a/htdocs/categories/traduction.php
+++ b/htdocs/categories/traduction.php
@@ -347,7 +347,7 @@ if ($action == 'add' && ($user->rights->produit->creer || $user->rights->service
 	print '<tr><td class="fieldrequired">' . $langs->trans('Label') . '</td>';
 	print '<td><input name="libelle" size="40" value="' . GETPOST('libelle', 'alpha'). '"></td></tr>';
 	print '<tr><td>'.$langs->trans('Description').'</td><td>';
-	$doleditor = new DolEditor('desc', GETPOST('desc'), '', 160, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, ROWS_3, '90%');
+	$doleditor = new DolEditor('desc', GETPOST('desc', 'none'), '', 160, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_PRODUCTDESC, ROWS_3, '90%');
 	$doleditor->Create();
 	print '</td></tr>';
 


### PR DESCRIPTION
FIX add and modify category translate form with posted values on errors
- keep posted values on errors
- add type in form and url links to stay in the same category
- check parameters required in add and modify form
