### PR TITLE
Fix Stock movement user's right (Fixes #11967)

### DIFF
--- a/htdocs/core/lib/stock.lib.php
+++ b/htdocs/core/lib/stock.lib.php
@@ -29,7 +29,7 @@
  */
 function stock_prepare_head($object)
 {
-	global $langs, $conf;
+	global $langs, $conf, $user;
 
 	$h = 0;
 	$head = array();
@@ -39,10 +39,13 @@ function stock_prepare_head($object)
 	$head[$h][2] = 'card';
 	$h++;
 
-	$head[$h][0] = DOL_URL_ROOT.'/product/stock/movement_list.php?id='.$object->id;
-	$head[$h][1] = $langs->trans("StockMovements");
-	$head[$h][2] = 'movements';
-	$h++;
+	if (!empty($user->rights->stock->mouvement->lire))
+	{
+		$head[$h][0] = DOL_URL_ROOT.'/product/stock/movement_list.php?id='.$object->id;
+		$head[$h][1] = $langs->trans("StockMovements");
+		$head[$h][2] = 'movements';
+		$h++;
+	}
 
 	/*
 	$head[$h][0] = DOL_URL_ROOT.'/product/stock/fiche-valo.php?id='.$object->id;

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -429,30 +429,26 @@ else
 			print "</td></tr>";
 
 			// Last movement
-			$sql = "SELECT max(m.datem) as datem";
-			$sql .= " FROM ".MAIN_DB_PREFIX."stock_mouvement as m";
-			$sql .= " WHERE m.fk_entrepot = '".$object->id."'";
-			$resqlbis = $db->query($sql);
-			if ($resqlbis)
-			{
-			    $obj = $db->fetch_object($resqlbis);
-			    $lastmovementdate=$db->jdate($obj->datem);
+			if (!empty($user->rights->stock->mouvement->lire)) {
+				$sql = "SELECT max(m.datem) as datem";
+				$sql .= " FROM " . MAIN_DB_PREFIX . "stock_mouvement as m";
+				$sql .= " WHERE m.fk_entrepot = '" . $object->id . "'";
+				$resqlbis = $db->query($sql);
+				if ($resqlbis) {
+					$obj = $db->fetch_object($resqlbis);
+					$lastmovementdate = $db->jdate($obj->datem);
+				} else {
+					dol_print_error($db);
+				}
+				print '<tr><td>' . $langs->trans("LastMovement") . '</td><td>';
+				if ($lastmovementdate) {
+					print dol_print_date($lastmovementdate, 'dayhour') . ' ';
+					print '(<a href="' . DOL_URL_ROOT . '/product/stock/movement_list.php?id=' . $object->id . '">' . $langs->trans("FullList") . '</a>)';
+				} else {
+					print $langs->trans("None");
+				}
+				print "</td></tr>";
 			}
-			else
-			{
-			    dol_print_error($db);
-			}
-			print '<tr><td>'.$langs->trans("LastMovement").'</td><td>';
-			if ($lastmovementdate)
-			{
-			    print dol_print_date($lastmovementdate, 'dayhour').' ';
-			    print '(<a href="'.DOL_URL_ROOT.'/product/stock/movement_list.php?id='.$object->id.'">'.$langs->trans("FullList").'</a>)';
-			}
-			else
-			{
-			    print $langs->trans("None");
-			}
-			print "</td></tr>";
 
             // Other attributes
             include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -118,6 +118,10 @@ $arrayfields=array(
     //'m.tms'=>array('label'=>$langs->trans("DateModificationShort"), 'checked'=>0, 'position'=>500)
 );
 
+// Security check
+if (!$user->rights->stock->mouvement->lire) {
+	accessforbidden();
+}
 
 
 /*

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -699,24 +699,27 @@ if ($id > 0 || $ref)
 			print '</tr>';
 
 			// Last movement
-			$sql = "SELECT max(m.datem) as datem";
-			$sql .= " FROM " . MAIN_DB_PREFIX . "stock_mouvement as m";
-			$sql .= " WHERE m.fk_product = '" . $object->id . "'";
-			$resqlbis = $db->query($sql);
-			if ($resqlbis) {
-				$obj = $db->fetch_object($resqlbis);
-				$lastmovementdate = $db->jdate($obj->datem);
-			} else {
-				dol_print_error($db);
+			if (!empty($user->rights->stock->mouvement->lire))
+			{
+				$sql = "SELECT max(m.datem) as datem";
+				$sql .= " FROM " . MAIN_DB_PREFIX . "stock_mouvement as m";
+				$sql .= " WHERE m.fk_product = '" . $object->id . "'";
+				$resqlbis = $db->query($sql);
+				if ($resqlbis) {
+					$obj = $db->fetch_object($resqlbis);
+					$lastmovementdate = $db->jdate($obj->datem);
+				} else {
+					dol_print_error($db);
+				}
+				print '<tr><td class="tdtop">' . $langs->trans("LastMovement") . '</td><td>';
+				if ($lastmovementdate) {
+					print dol_print_date($lastmovementdate, 'dayhour') . ' ';
+					print '(<a href="' . DOL_URL_ROOT . '/product/stock/movement_list.php?idproduct=' . $object->id . '">' . $langs->trans("FullList") . '</a>)';
+				} else {
+					print '<a href="' . DOL_URL_ROOT . '/product/stock/movement_list.php?idproduct=' . $object->id . '">' . $langs->trans("None") . '</a>';
+				}
+				print "</td></tr>";
 			}
-			print '<tr><td class="tdtop">' . $langs->trans("LastMovement") . '</td><td>';
-			if ($lastmovementdate) {
-				print dol_print_date($lastmovementdate, 'dayhour') . ' ';
-				print '(<a href="' . DOL_URL_ROOT . '/product/stock/movement_list.php?idproduct=' . $object->id . '">' . $langs->trans("FullList") . '</a>)';
-			} else {
-				print '<a href="' . DOL_URL_ROOT . '/product/stock/movement_list.php?idproduct=' . $object->id . '">' . $langs->trans("None") . '</a>';
-			}
-			print "</td></tr>";
 		}
 		print "</table>";
 


### PR DESCRIPTION
# Fix #11967 
User can see stock movements without "Read stock movements" right

- Added security check on the file: `htdocs/product/stock/movement_list.php`
- Hide **Stock movements** tab for users who don't have the right in warehouse card
- Hide **Last movement** date for users who don't have the right in `htdocs/product/stock/card.php` and `htdocs/product/stock/product.php`