### PR TITLE
NEW Close #12098 : allow usage of AUTH LOGIN in smtp

### DIFF
--- a/htdocs/core/class/smtps.class.php
+++ b/htdocs/core/class/smtps.class.php
@@ -498,15 +498,24 @@ class SMTPs
             }
             // Send Authentication to Server
             // Check for errors along the way
-            $this->socket_send_str('AUTH LOGIN', '334');
-
-            // User name will not return any error, server will take anything we give it.
-            $this->socket_send_str(base64_encode($this->_smtpsID), '334');
-
-            // The error here just means the ID/password combo doesn't work.
-            // There is not a method to determine which is the problem, ID or password
-            if ( ! $_retVal = $this->socket_send_str(base64_encode($this->_smtpsPW), '235') )
-            $this->_setErr(130, 'Invalid Authentication Credentials.');
+            switch ($conf->global->MAIL_SMTP_AUTH_TYPE) {
+                case 'PLAIN':
+                    $this->socket_send_str('AUTH PLAIN', '334');
+                    // The error here just means the ID/password combo doesn't work.
+                    $_retVal = $this->socket_send_str(base64_encode("\0" . $this->_smtpsID . "\0" . $this->_smtpsPW), '235');
+                    break;
+                case 'LOGIN':
+                default:
+                    $this->socket_send_str('AUTH LOGIN', '334');
+                    // User name will not return any error, server will take anything we give it.
+                    $this->socket_send_str(base64_encode($this->_smtpsID), '334');
+                    // The error here just means the ID/password combo doesn't work.
+                    // There is not a method to determine which is the problem, ID or password
+                    $_retVal = $this->socket_send_str(base64_encode($this->_smtpsPW), '235');
+                    break;
+            }
+            if(!$_retVal)
+                $this->_setErr(130, 'Invalid Authentication Credentials.');
         }
         else
         {

--- a/htdocs/core/class/smtps.class.php
+++ b/htdocs/core/class/smtps.class.php
@@ -496,6 +496,10 @@ class SMTPs
                     return $_retVal;
                 }
             }
+			
+			// Default authentication method is LOGIN
+			if (empty($conf->global->MAIL_SMTP_AUTH_TYPE)) $conf->global->MAIL_SMTP_AUTH_TYPE = 'LOGIN';
+			
             // Send Authentication to Server
             // Check for errors along the way
             switch ($conf->global->MAIL_SMTP_AUTH_TYPE) {

--- a/htdocs/core/class/smtps.class.php
+++ b/htdocs/core/class/smtps.class.php
@@ -514,8 +514,9 @@ class SMTPs
                     $_retVal = $this->socket_send_str(base64_encode($this->_smtpsPW), '235');
                     break;
             }
-            if(!$_retVal)
+            if (! $_retVal) {
                 $this->_setErr(130, 'Invalid Authentication Credentials.');
+			}
         }
         else
         {


### PR DESCRIPTION
Global variable MAIL_SMTP_AUTH_TYPE can be used to PLAIN to allow AUTH PLAIN authentification. Default still AUTH LOGIN.