### PR TITLE
FIX Allow to reach ALL levels of subcategories in accountancy export

### DIFF
--- a/htdocs/compta/stats/cabyprodserv.php
+++ b/htdocs/compta/stats/cabyprodserv.php
@@ -476,19 +476,20 @@ print_liste_field_titre(
 llxFooter();
 $db->close();
 
-function getNestedChildrenCats($rootCatID, $db) {
+function getNestedChildrenCats($rootCatID, $db)
+{
     $childrenCategoriesSQL =  'SELECT * FROM llx_categorie c WHERE c.fk_parent = '.$rootCatID;
     $childrenCategories = $db->query($childrenCategoriesSQL)->fetch_all(MYSQLI_ASSOC);
     $idsArray = array();
 
     foreach ($childrenCategories as $childrenCategory) {
         $childrenIDs = getNestedChildrenCats(
-            (int)$childrenCategory['rowid'],
+            (int) $childrenCategory['rowid'],
             $db
         );
         $idsArray = array_merge(
             $idsArray,
-            array((int)$childrenCategory['rowid']),
+            array((int) $childrenCategory['rowid']),
             $childrenIDs
         );
     }

--- a/htdocs/compta/stats/cabyprodserv.php
+++ b/htdocs/compta/stats/cabyprodserv.php
@@ -476,6 +476,13 @@ print_liste_field_titre(
 llxFooter();
 $db->close();
 
+/**
+ *  Retourne un tableau d'ID des sous-categories de l'ID catégorie donnée
+ *
+ *  @param	int		$rootCatID	(ID catégorie racine)
+ *  @param	mysqli	$db	(SQL DB object)
+ *  @return array	IDs sous-catégories de $rootCatID
+ */
 function getNestedChildrenCats($rootCatID, $db)
 {
     $childrenCategoriesSQL =  'SELECT * FROM llx_categorie c WHERE c.fk_parent = '.$rootCatID;


### PR DESCRIPTION
When checking "Subcategories" checkbox in accountancy export, you were not able to reach a sub category deeper than n+1.
This fix enable to reach all subcategories of the given one.

That may not be written in the most elegant way, but the idea is here :)

Best regards,
