### PR TITLE
FIX when trans file is not found do it again

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -205,7 +205,7 @@ class Translate
 		}
 
         // Check cache
-		if (! empty($this->_tab_loaded[$newdomain]))	// File already loaded for this domain
+		if (! empty($this->_tab_loaded[$newdomain]) && $this->_tab_loaded[$newdomain] != 2 )	// File already loaded for this domain
 		{
 			//dol_syslog("Translate::Load already loaded for newdomain=".$newdomain);
 			return 0;
@@ -270,7 +270,6 @@ class Translate
 						$found=true;						// Found in dolibarr PHP cache
 					}
 				}
-
 				if (! $found)
 				{
 					if ($fp = @fopen($file_lang, "rt"))


### PR DESCRIPTION
# Fix Translate load function

if a file is not found, _tab_loaded value is 2, or in some pages (like cron list with run_jobs function), we load first langs->load(module_name) then langs->load(module_name@module_name).
Actually if value is not empty, you dont try to load by the second method.
So for exemple i make cron in a custom module, my langs file is never load when i run it because of this test.

So this fix allow to try again if file is not found.

https://github.com/Dolibarr/dolibarr/blob/b4eb14ee4440e00288dc2b5a26f2b5a5add188c2/htdocs/cron/class/cronjob.class.php#L1059
https://github.com/Dolibarr/dolibarr/blob/b4eb14ee4440e00288dc2b5a26f2b5a5add188c2/htdocs/cron/class/cronjob.class.php#L1060