### PR TITLE
FIX contact card state address selected after filling addresss

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -972,7 +972,7 @@ else
                     print '<tr><td><label for="state_id">'.$langs->trans('State').'</label></td><td colspan="3" class="maxwidthonsmartphone">';
                 }
 
-                print $formcompany->select_state(GETPOST('state_id', 'alpha')?GETPOST('state_id', 'alpha'):$object->state_id, $object->country_code, 'state_id');
+                print $formcompany->select_state(GETPOSTISSET('state_id')?GETPOST('state_id', 'alpha'):$object->state_id, $object->country_code, 'state_id');
                 print '</td></tr>';
             }
 

--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -972,7 +972,7 @@ else
                     print '<tr><td><label for="state_id">'.$langs->trans('State').'</label></td><td colspan="3" class="maxwidthonsmartphone">';
                 }
 
-                print $formcompany->select_state($object->state_id, isset($_POST["country_id"])?GETPOST("country_id"):$object->country_id, 'state_id');
+                print $formcompany->select_state(GETPOST('state_id', 'alpha')?GETPOST('state_id', 'alpha'):$object->state_id, $object->country_code, 'state_id');
                 print '</td></tr>';
             }
 


### PR DESCRIPTION
FIX contact card state address selected after filling addresss from a thirdparty :
- when you edit a contact card and you want to fill address from the thirdparty address of this contact, the sate of the thirdparty address is selected and then it disappear