### PR TITLE
Update modulehelp.php

### DIFF
--- a/htdocs/admin/modulehelp.php
+++ b/htdocs/admin/modulehelp.php
@@ -129,7 +129,7 @@ foreach ($modulesdir as $dir)
 								if (preg_match('/deprecated/', $objMod->version) && (empty($conf->global->$const_name) && ($conf->global->MAIN_FEATURES_LEVEL >= 0))) $modulequalified=0;
 
 		    					// We discard modules according to property disabled
-		    					if (! empty($objMod->hidden)) $modulequalified=0;
+		    					//if (! empty($objMod->hidden)) $modulequalified=0;
 
 		    					if ($modulequalified > 0)
 		    					{


### PR DESCRIPTION
how not loaded module hidden. If module is hidden, it is not link to display in modulehelp.
except in a specific context defined by the developer. In this case, this ligen blocks the information display capability of the module.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #[*issue_number Short description*]
[*Long description*]


# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
