### PR TITLE
FIX remove backward compatibility projectid and uses object id instead

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -83,16 +83,15 @@ if (! isset($_POST['datesrfc']) && ! isset($_POST['datesday']) && ! empty($conf-
 	//$dates=dol_time_plus_duree($datee, -1, 'y');
 	$dates=dol_get_first_day($tmp['year'], 1);
 }
-if ($id == '' && $projectid == '' && $ref == '')
+if ($id == '' && $ref == '')
 {
-	dol_print_error('', 'Bad parameter');
-	exit;
+	setEventMessage($langs->trans('ErrorBadParameters'), 'errors');
+	header('Location: list.php');
+	exit();
 }
 
 $mine = $_REQUEST['mode']=='mine' ? 1 : 0;
 //if (! $user->rights->projet->all->lire) $mine=1;	// Special for projects
-
-$projectid=$id;	// For backward compatibility
 
 $object = new Project($db);
 
@@ -102,7 +101,7 @@ if(! empty($conf->global->PROJECT_ALLOW_COMMENT_ON_PROJECT) && method_exists($ob
 // Security check
 $socid=$object->socid;
 //if ($user->societe_id > 0) $socid = $user->societe_id;    // For external user, no check is done on company because readability is managed by public status of project and assignement.
-$result = restrictedArea($user, 'projet', $projectid, 'projet&project');
+$result = restrictedArea($user, 'projet',  $object->id, 'projet&project');
 
 $hookmanager->initHooks(array('projectOverview'));
 
@@ -539,7 +538,7 @@ if ($action=="addelement")
 elseif ($action == "unlink")
 {
 	$tablename = GETPOST("tablename", "aZ09");
-    $projectField = GETPOST("projectfield", "aZ09");
+    $projectField = GETPOST('projectfield', 'aZ09') ? GETPOST('projectfield', 'aZ09') : 'fk_projet';
 	$elementselectid = GETPOST("elementselect", "int");
 
 	$result = $object->remove_element($tablename, $elementselectid, $projectField);
@@ -558,7 +557,7 @@ $showdatefilter=0;
 if (! $showdatefilter)
 {
 	print '<div class="center centpercent">';
-    print '<form action="'.$_SERVER["PHP_SELF"].'?id='.$projectid.'" method="post">';
+    print '<form action="'.$_SERVER["PHP_SELF"].'?id=' . $object->id . '" method="post">';
     print '<input type="hidden" name="token" value="'.$_SESSION["newtoken"].'">';
     print '<input type="hidden" name="tablename" value="'.$tablename.'">';
 	print '<input type="hidden" name="action" value="view">';
@@ -781,7 +780,7 @@ foreach ($listofreferent as $key => $value)
        	if (empty($conf->global->PROJECT_LINK_ON_OVERWIEW_DISABLED) && $idtofilterthirdparty && !in_array($tablename, $exclude_select_element))
        	{
 			$selectList=$formproject->select_element($tablename, $idtofilterthirdparty, 'minwidth300', -2, !empty($project_field)?$project_field:'fk_projet');
-			if (! $selectList || ($selectList<0))
+			if ($selectList<0)
 			{
 				setEventMessages($formproject->error, $formproject->errors, 'errors');
 			}
@@ -789,7 +788,7 @@ foreach ($listofreferent as $key => $value)
 			{
 				// Define form with the combo list of elements to link
 			    $addform.='<div class="inline-block valignmiddle">';
-			    $addform.='<form action="'.$_SERVER["PHP_SELF"].'?id='.$projectid.'" method="post">';
+			    $addform.='<form action="'.$_SERVER["PHP_SELF"].'?id=' . $object->id . '" method="post">';
 			    $addform.='<input type="hidden" name="token" value="'.$_SESSION["newtoken"].'">';
 			    $addform.='<input type="hidden" name="tablename" value="'.$tablename.'">';
 				$addform.='<input type="hidden" name="action" value="addelement">';
@@ -916,7 +915,7 @@ foreach ($listofreferent as $key => $value)
 				{
 					if (empty($conf->global->PROJECT_DISABLE_UNLINK_FROM_OVERVIEW) || $user->admin)		// PROJECT_DISABLE_UNLINK_FROM_OVERVIEW is empty by defaut, so this test true
 					{
-						print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $projectid . '&action=unlink&tablename=' . $tablename . '&elementselect=' . $element->id . ($project_field ? '&projectfield=' . $project_field : '') . '" class="reposition">';
+						print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' .  $object->id . '&action=unlink&tablename=' . $tablename . '&elementselect=' . $element->id . ($project_field ? '&projectfield=' . $project_field : '') . '" class="reposition">';
 						print img_picto($langs->trans('Unlink'), 'unlink');
 						print '</a>';
 					}


### PR DESCRIPTION
FIX remove backward compatibility projectid and uses object id instead :
- if you try to access to this page with ref in GET or POST variable it build in forms an url with an empty id (example : element.php?id=) and it occurs an error message "Bad parameter"

FIX unlink element action : 
- uses "fk_projet" by default when you want to unlink an element to a project (otherwise you have a SQL error : "SET =NULL")

FIX Warning message "Try to add a message in stack with empty message" :
- if you have no link with elements (HTML select an element is NULL) and you have a warning message "Try to add a message in stack with empty message" (there aren't errors)

