### PR TITLE
FIX the SELECT examine more than MAX_JOIN_SIZE rows #12305

### DIFF
--- a/htdocs/accountancy/customer/list.php
+++ b/htdocs/accountancy/customer/list.php
@@ -313,7 +313,9 @@ $sql .= $db->plimit($limit + 1, $offset);
 dol_syslog("accountancy/customer/list.php", LOG_DEBUG);
 // MAX_JOIN_SIZE can be very low (ex: 300000) on some limited configurations (ex: https://www.online.net/fr/hosting/online-perso)
 // This big SELECT command may exceed the MAX_JOIN_SIZE limit => Therefore we use SQL_BIG_SELECTS=1 to disable the MAX_JOIN_SIZE security
-$db->query("SET SQL_BIG_SELECTS=1");
+if ($db->type == 'mysqli') {
+	$db->query("SET SQL_BIG_SELECTS=1");
+}
 $result = $db->query($sql);
 if ($result) {
 	$num_lines = $db->num_rows($result);
@@ -590,7 +592,9 @@ if ($result) {
 } else {
 	print $db->error();
 }
-$db->query("SET SQL_BIG_SELECTS=0");  // Enable MAX_JOIN_SIZE limitation
+if ($db->type == 'mysqli') {
+	$db->query("SET SQL_BIG_SELECTS=0");  // Enable MAX_JOIN_SIZE limitation
+}
 
 // Add code to auto check the box when we select an account
 print '<script type="text/javascript" language="javascript">

--- a/htdocs/accountancy/customer/list.php
+++ b/htdocs/accountancy/customer/list.php
@@ -311,6 +311,9 @@ if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST))
 $sql .= $db->plimit($limit + 1, $offset);
 
 dol_syslog("accountancy/customer/list.php", LOG_DEBUG);
+// MAX_JOIN_SIZE can be very low (ex: 300000) on some limited configurations (ex: https://www.online.net/fr/hosting/online-perso)
+// This big SELECT command may exceed the MAX_JOIN_SIZE limit => Therefore we use SQL_BIG_SELECTS=1 to disable the MAX_JOIN_SIZE security
+$db->query("SET SQL_BIG_SELECTS=1");
 $result = $db->query($sql);
 if ($result) {
 	$num_lines = $db->num_rows($result);
@@ -418,7 +421,7 @@ if ($result) {
 	$facture_static = new Facture($db);
 	$product_static = new Product($db);
 
-    $isSellerInEEC = isInEEC($mysoc);
+	$isSellerInEEC = isInEEC($mysoc);
 
 	while ($i < min($num_lines, $limit)) {
 		$objp = $db->fetch_object($result);
@@ -587,6 +590,7 @@ if ($result) {
 } else {
 	print $db->error();
 }
+$db->query("SET SQL_BIG_SELECTS=0");  // Enable MAX_JOIN_SIZE limitation
 
 // Add code to auto check the box when we select an account
 print '<script type="text/javascript" language="javascript">


### PR DESCRIPTION
# Fix #12305 the SELECT examine more than MAX_JOIN_SIZE rows

Mon [hébergement mutualisé](https://www.online.net/fr/hosting/online-perso) limite `MAX_JOIN_SIZE` :

```sql
SELECT @@MAX_JOIN_SIZE
300000
```

Sur mon ordinateur personnel, j'ai une valeur immense :

```sql
SELECT @@MAX_JOIN_SIZE
18446744073709551615
```

La correction consiste à prévenir MySQL que c'est un gros `SELECT` avec les commandes suivantes :

```php
$db->query("SET SQL_BIG_SELECTS=1");

[... le code du gros SELECT ...]

$db->query("SET SQL_BIG_SELECTS=0");
```

Je n'ai pas testé avec PostgreSQL.