### PR TITLE
NEW Added SumUp payment to TakePOS

### DIFF
--- a/htdocs/takepos/admin/setup.php
+++ b/htdocs/takepos/admin/setup.php
@@ -81,6 +81,8 @@ if (GETPOST('action', 'alpha') == 'set')
 	$res = dolibarr_set_const($db, "TAKEPOS_DIRECT_PAYMENT", GETPOST('TAKEPOS_DIRECT_PAYMENT', 'int'), 'int', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "TAKEPOS_CUSTOM_RECEIPT", GETPOST('TAKEPOS_CUSTOM_RECEIPT', 'int'), 'int', 0, '', $conf->entity);
     $res = dolibarr_set_const($db, "TAKEPOS_EMAIL_TEMPLATE_INVOICE", GETPOST('TAKEPOS_EMAIL_TEMPLATE_INVOICE', 'alpha'), 'chaine', 0, '', $conf->entity);
+	$res = dolibarr_set_const($db, "TAKEPOS_SUMUP_AFFILIATE", GETPOST('TAKEPOS_SUMUP_AFFILIATE', 'alpha'), 'chaine', 0, '', $conf->entity);
+	$res = dolibarr_set_const($db, "TAKEPOS_SUMUP_APPID", GETPOST('TAKEPOS_SUMUP_APPID', 'alpha'), 'chaine', 0, '', $conf->entity);
 
 	if ($conf->global->TAKEPOS_ORDER_NOTES == 1)
 	{
@@ -240,6 +242,20 @@ print $langs->trans('DirectPaymentButton');
 print '<td colspan="2">';
 print $form->selectyesno("TAKEPOS_DIRECT_PAYMENT", $conf->global->TAKEPOS_DIRECT_PAYMENT, 1);
 print "</td></tr>\n";
+
+// Sumup options
+if ($conf->global->TAKEPOS_ENABLE_SUMUP) {
+	print '<tr class="oddeven"><td>';
+	print $langs->trans("SumupAffiliate");
+	print '<td colspan="2">';
+	print '<input type="text" name="TAKEPOS_SUMUP_AFFILIATE" value="' . $conf->global->TAKEPOS_SUMUP_AFFILIATE . '"></input>';
+	print "</td></tr>\n";
+	print '<tr class="oddeven"><td>';
+	print $langs->trans("SumupAppId");
+	print '<td colspan="2">';
+	print '<input type="text" name="TAKEPOS_SUMUP_APPID" value="' . $conf->global->TAKEPOS_SUMUP_APPID . '"></input>';
+	print "</td></tr>\n";
+}
 
 // Custom Receipt
 print '<tr class="oddeven"><td>';

--- a/htdocs/takepos/admin/setup.php
+++ b/htdocs/takepos/admin/setup.php
@@ -81,9 +81,10 @@ if (GETPOST('action', 'alpha') == 'set')
 	$res = dolibarr_set_const($db, "TAKEPOS_DIRECT_PAYMENT", GETPOST('TAKEPOS_DIRECT_PAYMENT', 'int'), 'int', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "TAKEPOS_CUSTOM_RECEIPT", GETPOST('TAKEPOS_CUSTOM_RECEIPT', 'int'), 'int', 0, '', $conf->entity);
     $res = dolibarr_set_const($db, "TAKEPOS_EMAIL_TEMPLATE_INVOICE", GETPOST('TAKEPOS_EMAIL_TEMPLATE_INVOICE', 'alpha'), 'chaine', 0, '', $conf->entity);
-	$res = dolibarr_set_const($db, "TAKEPOS_SUMUP_AFFILIATE", GETPOST('TAKEPOS_SUMUP_AFFILIATE', 'alpha'), 'chaine', 0, '', $conf->entity);
-	$res = dolibarr_set_const($db, "TAKEPOS_SUMUP_APPID", GETPOST('TAKEPOS_SUMUP_APPID', 'alpha'), 'chaine', 0, '', $conf->entity);
-
+	if (! empty($conf->global->TAKEPOS_ENABLE_SUMUP)) {
+		$res = dolibarr_set_const($db, "TAKEPOS_SUMUP_AFFILIATE", GETPOST('TAKEPOS_SUMUP_AFFILIATE', 'alpha'), 'chaine', 0, '', $conf->entity);
+		$res = dolibarr_set_const($db, "TAKEPOS_SUMUP_APPID", GETPOST('TAKEPOS_SUMUP_APPID', 'alpha'), 'chaine', 0, '', $conf->entity);
+	}
 	if ($conf->global->TAKEPOS_ORDER_NOTES == 1)
 	{
 		$extrafields = new ExtraFields($db);

--- a/htdocs/takepos/admin/terminal.php
+++ b/htdocs/takepos/admin/terminal.php
@@ -74,6 +74,7 @@ if (GETPOST('action', 'alpha') == 'set')
 	$res = dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CASH".$terminaltouse, (GETPOST('CASHDESK_ID_BANKACCOUNT_CASH'.$terminaltouse, 'alpha') > 0 ? GETPOST('CASHDESK_ID_BANKACCOUNT_CASH'.$terminaltouse, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CHEQUE".$terminaltouse, (GETPOST('CASHDESK_ID_BANKACCOUNT_CHEQUE'.$terminaltouse, 'alpha') > 0 ? GETPOST('CASHDESK_ID_BANKACCOUNT_CHEQUE'.$terminaltouse, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CB".$terminaltouse, (GETPOST('CASHDESK_ID_BANKACCOUNT_CB'.$terminaltouse, 'alpha') > 0 ? GETPOST('CASHDESK_ID_BANKACCOUNT_CB'.$terminaltouse, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
+	$res = dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_SUMUP".$terminaltouse, (GETPOST('CASHDESK_ID_BANKACCOUNT_SUMUP'.$terminaltouse, 'alpha') > 0 ? GETPOST('CASHDESK_ID_BANKACCOUNT_SUMUP'.$terminaltouse, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
     foreach($paiements as $modep) {
         if (in_array($modep->code, array('LIQ', 'CB', 'CHQ'))) continue;
         $name="CASHDESK_ID_BANKACCOUNT_".$modep->code.$terminaltouse;
@@ -151,6 +152,13 @@ if (! empty($conf->banque->enabled))
 	$form->select_comptes($conf->global->{'CASHDESK_ID_BANKACCOUNT_CB'.$terminaltouse}, 'CASHDESK_ID_BANKACCOUNT_CB'.$terminaltouse, 0, "courant=1", 1);
 	if (! empty($conf->global->{'CASHDESK_ID_BANKACCOUNT_CB'.$terminaltouse})) $atleastonefound++;
 	print '</td></tr>';
+	if ($conf->global->TAKEPOS_ENABLE_SUMUP) {
+		print '<tr class="oddeven"><td>' . $langs->trans("CashDeskBankAccountForSumup") . '</td>';
+		print '<td>';
+		$form->select_comptes($conf->global->{'CASHDESK_ID_BANKACCOUNT_SUMUP' . $terminaltouse}, 'CASHDESK_ID_BANKACCOUNT_SUMUP' . $terminaltouse, 0, "courant=1", 1);
+		if (!empty($conf->global->{'CASHDESK_ID_BANKACCOUNT_SUMUP' . $terminaltouse})) $atleastonefound++;
+		print '</td></tr>';
+	}
 
 	foreach($paiements as $modep) {
         if (in_array($modep->code, array('LIQ', 'CB', 'CHQ'))) continue;	// Already managed before

--- a/htdocs/takepos/admin/terminal.php
+++ b/htdocs/takepos/admin/terminal.php
@@ -74,8 +74,10 @@ if (GETPOST('action', 'alpha') == 'set')
 	$res = dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CASH".$terminaltouse, (GETPOST('CASHDESK_ID_BANKACCOUNT_CASH'.$terminaltouse, 'alpha') > 0 ? GETPOST('CASHDESK_ID_BANKACCOUNT_CASH'.$terminaltouse, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CHEQUE".$terminaltouse, (GETPOST('CASHDESK_ID_BANKACCOUNT_CHEQUE'.$terminaltouse, 'alpha') > 0 ? GETPOST('CASHDESK_ID_BANKACCOUNT_CHEQUE'.$terminaltouse, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CB".$terminaltouse, (GETPOST('CASHDESK_ID_BANKACCOUNT_CB'.$terminaltouse, 'alpha') > 0 ? GETPOST('CASHDESK_ID_BANKACCOUNT_CB'.$terminaltouse, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
-	$res = dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_SUMUP".$terminaltouse, (GETPOST('CASHDESK_ID_BANKACCOUNT_SUMUP'.$terminaltouse, 'alpha') > 0 ? GETPOST('CASHDESK_ID_BANKACCOUNT_SUMUP'.$terminaltouse, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
-    foreach($paiements as $modep) {
+	if (! empty($conf->global->TAKEPOS_ENABLE_SUMUP)) {
+		$res = dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_SUMUP".$terminaltouse, (GETPOST('CASHDESK_ID_BANKACCOUNT_SUMUP'.$terminaltouse, 'alpha') > 0 ? GETPOST('CASHDESK_ID_BANKACCOUNT_SUMUP'.$terminaltouse, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
+	}
+	foreach($paiements as $modep) {
         if (in_array($modep->code, array('LIQ', 'CB', 'CHQ'))) continue;
         $name="CASHDESK_ID_BANKACCOUNT_".$modep->code.$terminaltouse;
 		$res = dolibarr_set_const($db, $name, (GETPOST($name, 'alpha') > 0 ? GETPOST($name, 'alpha') : ''), 'chaine', 0, '', $conf->entity);

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -299,7 +299,7 @@ while($i < count($paiements)){
 	$i=$i+1;
 }
 
-if($conf->global->TAKEPOS_ENABLE_SUMUP && !empty(dolibarr_get_const($db,"CASHDESK_ID_BANKACCOUNT_SUMUP".$_SESSION["takeposterminal"]))) {
+if($conf->global->TAKEPOS_ENABLE_SUMUP && !empty(dolibarr_get_const($db, "CASHDESK_ID_BANKACCOUNT_SUMUP".$_SESSION["takeposterminal"]))) {
 	?>
 	<button type="button" class="calcbutton2" onclick="ValidateSumup();">Sumup</button>
 	<?php

--- a/htdocs/takepos/smpcb.php
+++ b/htdocs/takepos/smpcb.php
@@ -1,0 +1,36 @@
+<?php
+    require '../main.inc.php';
+
+    if(isset($_GET['status'])) {
+        die(strtoupper($_SESSION['SMP_CURRENT_PAYMENT']));
+    }
+
+    if($_GET['smp-status']) {
+        print '<html lang="en">
+<head>
+    <meta charset="utf-8">
+
+    <title>The HTML5 Herald</title>
+    <meta name="description" content="The HTML5 Herald">
+    <meta name="author" content="SitePoint">
+
+    <link rel="stylesheet" href="css/styles.css?v=1.0">
+
+</head>
+
+<body>';
+        $_SESSION['SMP_CURRENT_PAYMENT'] = $_GET['smp-status'];
+
+        print '<script type="application/javascript">
+                window.onload = function() {
+                    window.close();
+                };
+            </script>';
+
+        print "Transaction status registered, you can close this";
+
+        die('</body></html>');
+    }
+
+    print 'NOOP';
+?>

--- a/htdocs/takepos/smpcb.php
+++ b/htdocs/takepos/smpcb.php
@@ -1,12 +1,12 @@
 <?php
     require '../main.inc.php';
 
-    if(isset($_GET['status'])) {
-        die(strtoupper($_SESSION['SMP_CURRENT_PAYMENT']));
-    }
+if(isset($_GET['status'])) {
+	die(strtoupper($_SESSION['SMP_CURRENT_PAYMENT']));
+}
 
-    if($_GET['smp-status']) {
-        print '<html lang="en">
+if($_GET['smp-status']) {
+	print '<html lang="en">
 <head>
     <meta charset="utf-8">
 
@@ -19,18 +19,17 @@
 </head>
 
 <body>';
-        $_SESSION['SMP_CURRENT_PAYMENT'] = $_GET['smp-status'];
+	$_SESSION['SMP_CURRENT_PAYMENT'] = $_GET['smp-status'];
 
-        print '<script type="application/javascript">
+	print '<script type="application/javascript">
                 window.onload = function() {
                     window.close();
                 };
             </script>';
 
-        print "Transaction status registered, you can close this";
+	print "Transaction status registered, you can close this";
 
-        die('</body></html>');
-    }
+	die('</body></html>');
+}
 
     print 'NOOP';
-?>


### PR DESCRIPTION
This PR is the correction of the PR #11941 :

It's now possible to configure Sumup application in TakePoS. It permits to trigger the Credit Card Terminal directly from the PoS, and continue the usual workflow if the transaction is successful.

_Note: We may have to adapt mobile.php to enable sumup for mobile devices._