### PR TITLE
image2wbmp() is deprecated as of PHP 7.3.0

### DIFF
--- a/htdocs/core/lib/images.lib.php
+++ b/htdocs/core/lib/images.lib.php
@@ -281,7 +281,7 @@ function dol_imageResizeOrCrop($file, $mode, $newWidth, $newHeight, $src_x = 0, 
 			imagepng($imgThumb, $imgThumbName, $newquality);
 			break;
 		case 4:	// Bmp
-			image2wbmp($imgThumb, $imgThumbName);
+			imagewbmp($imgThumb, $imgThumbName);
 			break;
 	}
 
@@ -584,7 +584,7 @@ function vignette($file, $maxWidth = 160, $maxHeight = 120, $extName = '_small',
             // Not supported by PHP GD
 			break;
 		case IMAGETYPE_WBMP:    // 15
-			image2wbmp($imgThumb, $imgThumbName);
+			imagewbmp($imgThumb, $imgThumbName);
 			break;
 	}
 


### PR DESCRIPTION
https://www.php.net/manual/en/function.image2wbmp.php
image2wbmp() is deprecated as of PHP 7.3.0, and will be removed in the next major version. Use imagewbmp() instead.