### PR TITLE
FIX : filter language is an array

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -741,7 +741,7 @@ class FormFile
 				$defaultlang=$codelang?$codelang:$langs->getDefaultLang();
 				$morecss='maxwidth150';
 				if ($conf->browser->layout == 'phone') $morecss='maxwidth100';
-				$out.= $formadmin->select_language($defaultlang, 'lang_id', 0, 0, 0, 0, 0, $morecss);
+				$out.= $formadmin->select_language($defaultlang, 'lang_id', 0, null, 0, 0, 0, $morecss);
 			}
 			else
 			{


### PR DESCRIPTION
there was a warning when using filter because it is an array and the value sent was scalar type.