### PR TITLE
Update modulehelp.php

### DIFF
--- a/htdocs/admin/modulehelp.php
+++ b/htdocs/admin/modulehelp.php
@@ -451,10 +451,10 @@ if ($mode == 'feature')
     }
     require_once DOL_DOCUMENT_ROOT.'/core/class/interfaces.class.php';
     $interfaces = new Interfaces($db);
-    $triggers = $interfaces->getTriggersList(array((($objMod->isCoreOrExternalModule() == 'external')?'/'.$objMod->code:'').'/core/triggers'));
+    $triggers = $interfaces->getTriggersList(array((($objMod->isCoreOrExternalModule() == 'external')?'/'.$objMod->name:'').'/core/triggers'));
 	foreach($triggers as $triggercursor)
 	{
-		if ($triggercursor['module'] == $objMod->code)
+		if ($triggercursor['module'] == $objMod->name)
 		{
 			$yesno='Yes';
 			$moreinfoontriggerfile=' ('.$triggercursor['relpath'].')';

--- a/htdocs/admin/modulehelp.php
+++ b/htdocs/admin/modulehelp.php
@@ -241,7 +241,7 @@ $head = modulehelp_prepare_head($objMod);
 $modulename=$objMod->getName();
 $moduledesc=$objMod->getDesc();
 $moduleauthor=$objMod->getPublisher();
-$moduledir=substr($modNameLoaded[get_class($objMod)],0, -13);
+$moduledir=substr($modNameLoaded[get_class($objMod)], 0, -13);
 
 
 print '<div class="centpercent">';

--- a/htdocs/admin/modulehelp.php
+++ b/htdocs/admin/modulehelp.php
@@ -241,7 +241,7 @@ $head = modulehelp_prepare_head($objMod);
 $modulename=$objMod->getName();
 $moduledesc=$objMod->getDesc();
 $moduleauthor=$objMod->getPublisher();
-$moduledir=strtolower(preg_replace('/^mod/i', '', get_class($objMod)));
+$moduledir=substr($modNameLoaded[get_class($objMod)],0, -13);
 
 
 print '<div class="centpercent">';
@@ -348,7 +348,7 @@ if ($mode == 'feature')
     $text.='<br><br>';
 
     $text.='<br><strong>'.$langs->trans("AddDataTables").':</strong> ';
-	$sqlfiles = dol_dir_list(dol_buildpath($moduledir.'/sql/'), 'files', 0, 'llx.*\.sql', array('\.key\.sql'));
+	$sqlfiles = dol_dir_list($moduledir.'/sql/', 'files', 0, 'llx.*\.sql', array('\.key\.sql'));
     if (count($sqlfiles) > 0)
     {
     	$text.=$langs->trans("Yes").' (';
@@ -379,7 +379,7 @@ if ($mode == 'feature')
     $text.='<br>';
 
     $text.='<br><strong>'.$langs->trans("AddData").':</strong> ';
-    $filedata = dol_buildpath($moduledir.'/sql/data.sql');
+    $filedata = $moduledir.'/sql/data.sql';
     if (dol_is_file($filedata))
     {
         $text.=$langs->trans("Yes").' ('.$moduledir.'/sql/data.sql'.')';
@@ -451,10 +451,10 @@ if ($mode == 'feature')
     }
     require_once DOL_DOCUMENT_ROOT.'/core/class/interfaces.class.php';
     $interfaces = new Interfaces($db);
-    $triggers = $interfaces->getTriggersList(array((($objMod->isCoreOrExternalModule() == 'external')?'/'.$moduledir:'').'/core/triggers'));
+    $triggers = $interfaces->getTriggersList(array((($objMod->isCoreOrExternalModule() == 'external')?'/'.$objMod->code:'').'/core/triggers'));
 	foreach($triggers as $triggercursor)
 	{
-		if ($triggercursor['module'] == $moduledir)
+		if ($triggercursor['module'] == $objMod->code)
 		{
 			$yesno='Yes';
 			$moreinfoontriggerfile=' ('.$triggercursor['relpath'].')';


### PR DESCRIPTION
the var $ modNameLoaded online 114 defines the descriptor path.
Also the path of the module can be determined by removing the "/ core / modules /" from the value contained in $ modNameLoaded.
Moreover in the extraction of the triggers, $ moduledir is used whereas it is the $ objMod-> code which is the good one.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #[*issue_number Short description*]
[*Long description*]


# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
