### PR TITLE
avoid placeid to be string or string[]

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -226,7 +226,7 @@ if ($action == 'valid' && $user->rights->facture->creer)
 
 if ($action == 'history')
 {
-    $placeid = GETPOST('placeid', 'int');
+    $placeid = (int) GETPOST('placeid', 'int');
     $invoice = new Facture($db);
     $invoice->fetch($placeid);
 }


### PR DESCRIPTION
Are you sure $placeid > 0 ? $placeid : 0 of type integer|string|string[] can be used in echo?