### PR TITLE
Fix deposit line was not translated in deposit invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1314,7 +1314,7 @@ if (empty($reshook))
 								if (empty($amount)) continue;
 
 								$arraylist = array('amount' => 'FixAmount','variable' => 'VarAmount');
-								$descline = $langs->trans('Deposit');
+								$descline = '(DEPOSIT)';
 								//$descline.= ' - '.$langs->trans($arraylist[$typeamount]);
 								if ($typeamount=='amount') {
 									$descline.= ' ('. price($valuedeposit, '', $langs, 0, - 1, - 1, (!empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency)).')';

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1264,9 +1264,10 @@ function pdf_getlinedesc($object,$i,$outputlangs,$hideref=0,$hidedesc=0,$issuppl
 			$sourceref=!empty($discount->discount_type)?$discount->ref_invoive_supplier_source:$discount->ref_facture_source;
 			$libelleproduitservice=$outputlangs->transnoentitiesnoconv("DiscountFromDeposit",$sourceref);
 			// Add date of deposit
-			if (! empty($conf->global->INVOICE_ADD_DEPOSIT_DATE)) echo ' ('.dol_print_date($discount->datec,'day','',$outputlangs).')';
+			if (! empty($conf->global->INVOICE_ADD_DEPOSIT_DATE)) $libelleproduitservice.= ' ('.dol_print_date($discount->datec,'day','',$outputlangs).')';
+
 		}
-		if ($desc == '(EXCESS RECEIVED)' && $object->lines[$i]->fk_remise_except)
+		elseif ($desc == '(EXCESS RECEIVED)' && $object->lines[$i]->fk_remise_except)
 		{
 			$discount=new DiscountAbsolute($db);
 			$discount->fetch($object->lines[$i]->fk_remise_except);

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1238,6 +1238,9 @@ function pdf_getlinedesc($object,$i,$outputlangs,$hideref=0,$hidedesc=0,$issuppl
 			if (! empty($prodser->multilangs[$outputlangs->defaultlang]["note"]) && ($textwasmodified || $translatealsoifmodified))  $note=$prodser->multilangs[$outputlangs->defaultlang]["note"];
 		}
 	}
+	elseif ($object->type == Facture::TYPE_DEPOSIT && $object->element == 'facture') {
+		$desc = str_replace('(DEPOSIT)', $outputlangs->trans('Deposit'), $desc);
+	}
 
 	// Description short of product line
 	$libelleproduitservice=$label;

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -137,6 +137,8 @@ $domData .= ' data-product_type="'.$line->product_type.'"';
 			if (! empty($line->label)) {
 				$text.= ' <strong>'.$line->label.'</strong>';
 				echo $form->textwithtooltip($text,dol_htmlentitiesbr($line->description),3,'','',$i,0,(!empty($line->fk_parent_line)?img_picto('', 'rightarrow'):''));
+			} elseif (strpos($line->description, '(DEPOSIT)') === 0) {
+				echo $text.' '.str_replace('(DEPOSIT)', $langs->trans("Deposit"), $line->description);;
 			} else {
 				if (! empty($line->fk_parent_line)) echo img_picto('', 'rightarrow');
 				echo $text.' '.dol_htmlentitiesbr($line->description);


### PR DESCRIPTION
After this, the (DEPOSIT) key is add in the line and can be translated.
Also fixed "(DEPOSIT)" that was displayed after the label and fixed the display date hidden option