### PR TITLE
Default type missing for add links from module builder

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -70,7 +70,7 @@ $refalreadyexists = 0;
 
 $id = GETPOST('id', 'int');
 $ref = GETPOST('ref', 'alpha');
-$type = GETPOST('type', 'int');
+$type = (GETPOST('type', 'int') !== '')? GETPOST('type', 'int'):Product::TYPE_PRODUCT;
 $action = (GETPOST('action', 'alpha') ? GETPOST('action', 'alpha') : 'view');
 $cancel = GETPOST('cancel', 'alpha');
 $backtopage = GETPOST('backtopage', 'alpha');


### PR DESCRIPTION
BOM links to add product don't precise the type (from common object)
