### PR TITLE
Fix Use dynamically exif image information with conf MAIN_USE_EXIF_ROTATION

### DIFF
--- a/htdocs/core/lib/images.lib.php
+++ b/htdocs/core/lib/images.lib.php
@@ -313,10 +313,10 @@ function dolRotateImage($file_path)
 /**
  * Add exif orientation correction for image
  *
- * @param $fileSource string
- * @param $fileDest string | false | null  :  on false return gd img on null , on NULL the raw image stream will be outputted directly
- * @param $quality int
- * @return bool true on success or false on failure or gd img if $fileDest is false.
+ * @param string $fileSource Full path to source image to rotate
+ * @param string $fileDest string : Full path to image to rotate | false return gd img  | null  the raw image stream will be outputted directly
+ * @param int $quality
+ * @return bool : true on success or false on failure or gd img if $fileDest is false.
  */
 function correctExifImageOrientation($fileSource, $fileDest, $quality = 95)
 {

--- a/htdocs/core/lib/images.lib.php
+++ b/htdocs/core/lib/images.lib.php
@@ -279,7 +279,7 @@ function dol_imageResizeOrCrop($file, $mode, $newWidth, $newHeight, $src_x = 0, 
 			imagepng($imgThumb, $imgThumbName, $newquality);
 			break;
 		case 4:	// Bmp
-			image2wbmp($imgThumb, $imgThumbName);
+			imagewbmp($imgThumb, $imgThumbName);
 			break;
 	}
 
@@ -379,7 +379,7 @@ function correctExifImageOrientation($fileSource, $fileDest, $quality = 95)
 							// Not supported by PHP GD
 							break;
 						case IMAGETYPE_WBMP:    // 15
-							$image = image2wbmp($img, $fileDest);
+							$image = imagewbmp($img, $fileDest);
 							break;
 					}
 
@@ -696,7 +696,7 @@ function vignette($file, $maxWidth = 160, $maxHeight = 120, $extName = '_small',
             // Not supported by PHP GD
 			break;
 		case IMAGETYPE_WBMP:    // 15
-			image2wbmp($imgThumb, $imgThumbName);
+			imagewbmp($imgThumb, $imgThumbName);
 			break;
 	}
 

--- a/htdocs/core/lib/images.lib.php
+++ b/htdocs/core/lib/images.lib.php
@@ -315,7 +315,7 @@ function dolRotateImage($file_path)
  *
  * @param string $fileSource Full path to source image to rotate
  * @param string $fileDest string : Full path to image to rotate | false return gd img  | null  the raw image stream will be outputted directly
- * @param int $quality
+ * @param int $quality output image quality
  * @return bool : true on success or false on failure or gd img if $fileDest is false.
  */
 function correctExifImageOrientation($fileSource, $fileDest, $quality = 95)

--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -71,6 +71,7 @@ function llxFooter()
 
 require 'main.inc.php';	// Load $user and permissions
 require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/images.lib.php';
 
 $encoding = '';
 $action=GETPOST('action', 'alpha');
@@ -250,11 +251,20 @@ if ($encoding)   header('Content-Encoding: '.$encoding);
 // Add MIME Content-Disposition from RFC 2183 (inline=automatically displayed, attachment=need user action to open)
 if ($attachment) header('Content-Disposition: attachment; filename="'.$filename.'"');
 else header('Content-Disposition: inline; filename="'.$filename.'"');
-header('Content-Length: ' . dol_filesize($fullpath_original_file));
 // Ajout directives pour resoudre bug IE
 header('Cache-Control: Public, must-revalidate');
 header('Pragma: public');
+$readfile = true;
 
-readfile($fullpath_original_file_osencoded);
+// on view document, can output images with good orientation according to exif infos
+if (!$attachment && !empty($conf->global->MAIN_USE_EXIF_ROTATION) && image_format_supported($fullpath_original_file_osencoded) == 1) {
+	$imgres = correctExifImageOrientation($fullpath_original_file_osencoded, null);
+	$readfile = !$imgres;
+}
+
+if($readfile){
+	header('Content-Length: ' . dol_filesize($fullpath_original_file));
+	readfile($fullpath_original_file_osencoded);
+}
 
 if (is_object($db)) $db->close();


### PR DESCRIPTION
The conf MAIN_USE_EXIF_ROTATION is hidden.
This fixed allows to correct the orientation of images according to the exif file.
This fix correct file display on browser, it does not destroy the file send in the documents and keep exif data. So when the image is download (force download) the file contains the exif data.

-----------------------------
La conf MAIN_USE_EXIF_ROTATION est cachée.
Ce fixe permet de corriger l'orientation des images en fonction du fichier exif.
Ce fix corrige l'affichage du fichier sur le navigateur, il ne détruit pas le fichier envoyé dans les document permettant ainsi de conserver les données exifs. Ainsi lorsque l'image est téléchargée (force download) le fichier contient bien les données exifs

 le fix est applicable sur une V10 de dolibarr (au cas où)
