### PR TITLE
FIX 10.0: do not display single-letter duration values in product list

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -900,7 +900,7 @@ if ($resql)
 				print $duration_value;
 				print (! empty($duration_unit) && isset($dur[$duration_unit]) ? ' '.$langs->trans($dur[$duration_unit]) : '');
 			}
-			else
+			elseif (! preg_match('/^[a-z]$/i', $obj->duration))		// If duration is a simple char (like 's' of 'm'), we do not show value
 			{
 				print $obj->duration;
 			}


### PR DESCRIPTION
This fix already exists in develop, cf. commit 0cd451ef1ad11751d5b935271054c0bb9ce6e75a.