### PR TITLE
FIX 10.0: add URL param "restore_last_search_values=1" to all backlinks pointing to lists

### DIFF
--- a/htdocs/adherents/document.php
+++ b/htdocs/adherents/document.php
@@ -115,7 +115,7 @@ if ($id > 0)
         print '<div class="underbanner clearboth"></div>';
 		print '<table class="border tableforfield centpercent">';
 
-		$linkback = '<a href="'.DOL_URL_ROOT.'/adherents/list.php">'.$langs->trans("BackToList").'</a>';
+		$linkback = '<a href="'.DOL_URL_ROOT.'/adherents/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
         // Login
         if (empty($conf->global->ADHERENT_LOGIN_NOT_REQUIRED))

--- a/htdocs/adherents/subscription/info.php
+++ b/htdocs/adherents/subscription/info.php
@@ -53,7 +53,7 @@ $head = subscription_prepare_head($object);
 
 dol_fiche_head($head, 'info', $langs->trans("Subscription"), -1, 'payment');
 
-$linkback = '<a href="'.DOL_URL_ROOT.'/adherents/subscription/list.php">'.$langs->trans("BackToList").'</a>';
+$linkback = '<a href="'.DOL_URL_ROOT.'/adherents/subscription/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 dol_banner_tab($object, 'rowid', $linkback, 1);
 

--- a/htdocs/bookmarks/card.php
+++ b/htdocs/bookmarks/card.php
@@ -223,7 +223,7 @@ if ($id > 0 && ! preg_match('/^add/i', $action))
 
 	dol_fiche_head($head, $hselected, $langs->trans("Bookmark"), -1, 'bookmark');
 
-	$linkback = '<a href="'.DOL_URL_ROOT.'/bookmarks/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/bookmarks/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
     dol_banner_tab($object, 'id', $linkback, 1, 'rowid', 'ref', '', '', 0, '', '', 0);
 

--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -238,7 +238,7 @@ if ($object->id > 0)
 
 	dol_fiche_head($head, 'customer', $langs->trans("ThirdParty"), -1, 'company');
 
-	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
     dol_banner_tab($object, 'socid', $linkback, ($user->societe_id?0:1), 'rowid', 'nom');
 

--- a/htdocs/comm/mailing/card.php
+++ b/htdocs/comm/mailing/card.php
@@ -1174,7 +1174,7 @@ else
 
 			dol_fiche_head($head, 'card', $langs->trans("Mailing"), -1, 'email');
 
-			$linkback = '<a href="'.DOL_URL_ROOT.'/comm/mailing/list.php">'.$langs->trans("BackToList").'</a>';
+			$linkback = '<a href="'.DOL_URL_ROOT.'/comm/mailing/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 			$morehtmlright='';
 			if ($object->statut == 2) $morehtmlright.=' ('.$object->countNbOfTargets('alreadysent').'/'.$object->nbemail.') ';

--- a/htdocs/comm/mailing/cibles.php
+++ b/htdocs/comm/mailing/cibles.php
@@ -176,7 +176,7 @@ if ($object->fetch($id) >= 0)
 
 	dol_fiche_head($head, 'targets', $langs->trans("Mailing"), -1, 'email');
 
-	$linkback = '<a href="'.DOL_URL_ROOT.'/comm/mailing/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/comm/mailing/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 	$morehtmlright='';
 	$nbtry = $nbok = 0;

--- a/htdocs/comm/mailing/info.php
+++ b/htdocs/comm/mailing/info.php
@@ -54,7 +54,7 @@ if ($object->fetch($id) >= 0)
 
 	dol_fiche_head($head, 'info', $langs->trans("Mailing"), -1, 'email');
 
-	$linkback = '<a href="'.DOL_URL_ROOT.'/comm/mailing/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/comm/mailing/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 	$morehtmlright='';
 	if ($object->statut == 2) $morehtmlright.=' ('.$object->countNbOfTargets('alreadysent').'/'.$object->nbemail.') ';

--- a/htdocs/compta/paiement/card.php
+++ b/htdocs/compta/paiement/card.php
@@ -204,7 +204,7 @@ if ($action == 'valide')
 	print $form->formconfirm($_SERVER['PHP_SELF'].'?id='.$object->id.'&amp;facid='.$facid, $langs->trans("ValidatePayment"), $langs->trans("ConfirmValidatePayment"), 'confirm_valide', '', 0, 2);
 }
 
-$linkback = '<a href="' . DOL_URL_ROOT . '/compta/paiement/list.php">' . $langs->trans("BackToList") . '</a>';
+$linkback = '<a href="' . DOL_URL_ROOT . '/compta/paiement/list.php?restore_lastsearch_values=1">' . $langs->trans("BackToList") . '</a>';
 
 dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref', '');
 

--- a/htdocs/compta/paiement/info.php
+++ b/htdocs/compta/paiement/info.php
@@ -58,7 +58,7 @@ $head = payment_prepare_head($object);
 dol_fiche_head($head, 'info', $langs->trans("PaymentCustomerInvoice"), -1, 'payment');
 
 
-$linkback = '<a href="' . DOL_URL_ROOT . '/compta/paiement/list.php">' . $langs->trans("BackToList") . '</a>';
+$linkback = '<a href="' . DOL_URL_ROOT . '/compta/paiement/list.php?restore_lastsearch_values=1">' . $langs->trans("BackToList") . '</a>';
 
 dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref', '');
 

--- a/htdocs/livraison/card.php
+++ b/htdocs/livraison/card.php
@@ -440,7 +440,7 @@ else
 			/*
 			if (($object->origin == 'shipment' || $object->origin == 'expedition') && $object->origin_id > 0)
 			{
-				$linkback = '<a href="'.DOL_URL_ROOT.'/expedition/list.php">'.$langs->trans("BackToList").'</a>';
+				$linkback = '<a href="'.DOL_URL_ROOT.'/expedition/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 				// Ref
 				print '<tr><td width="20%">'.$langs->trans("RefSending").'</td>';

--- a/htdocs/loan/card.php
+++ b/htdocs/loan/card.php
@@ -439,7 +439,7 @@ if ($id > 0)
 
 		// Loan card
 
-		$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php">' . $langs->trans("BackToList") . '</a>';
+		$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php?restore_lastsearch_values=1">' . $langs->trans("BackToList") . '</a>';
 
 		$morehtmlref='<div class="refidno">';
 		// Ref loan

--- a/htdocs/loan/document.php
+++ b/htdocs/loan/document.php
@@ -124,7 +124,7 @@ if ($object->id)
 	}
 	$morehtmlref.='</div>';
 
-	$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php">' . $langs->trans("BackToList") . '</a>';
+	$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php?restore_lastsearch_values=1">' . $langs->trans("BackToList") . '</a>';
 
 	$object->totalpaid = $totalpaid;   // To give a chance to dol_banner_tab to use already paid amount to show correct status
 

--- a/htdocs/loan/info.php
+++ b/htdocs/loan/info.php
@@ -96,7 +96,7 @@ if (! empty($conf->projet->enabled)) {
 }
 $morehtmlref.='</div>';
 
-$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php">' . $langs->trans("BackToList") . '</a>';
+$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php?restore_lastsearch_values=1">' . $langs->trans("BackToList") . '</a>';
 
 $object->totalpaid = $totalpaid;   // To give a chance to dol_banner_tab to use already paid amount to show correct status
 

--- a/htdocs/loan/note.php
+++ b/htdocs/loan/note.php
@@ -113,7 +113,7 @@ if ($id > 0)
 	}
 	$morehtmlref.='</div>';
 
-	$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php">' . $langs->trans("BackToList") . '</a>';
+	$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php?restore_lastsearch_values=1">' . $langs->trans("BackToList") . '</a>';
 
 	$object->totalpaid = $totalpaid;   // To give a chance to dol_banner_tab to use already paid amount to show correct status
 

--- a/htdocs/loan/schedule.php
+++ b/htdocs/loan/schedule.php
@@ -44,7 +44,7 @@ llxHeader("", $title, $help_url);
 $head=loan_prepare_head($object);
 dol_fiche_head($head, 'FinancialCommitment', $langs->trans("Loan"), -1, 'bill');
 
-$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php">' . $langs->trans("BackToList") . '</a>';
+$linkback = '<a href="' . DOL_URL_ROOT . '/loan/list.php?restore_lastsearch_values=1">' . $langs->trans("BackToList") . '</a>';
 
 $morehtmlref='<div class="refidno">';
 // Ref loan

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -309,7 +309,7 @@ else
 			print $formconfirm;
 
 			// Warehouse card
-			$linkback = '<a href="'.DOL_URL_ROOT.'/product/stock/list.php">'.$langs->trans("BackToList").'</a>';
+			$linkback = '<a href="'.DOL_URL_ROOT.'/product/stock/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 			$morehtmlref='<div class="refidno">';
 			$morehtmlref.=$langs->trans("LocationSummary").' : '.$object->lieu;

--- a/htdocs/product/stock/info.php
+++ b/htdocs/product/stock/info.php
@@ -53,7 +53,7 @@ $head = stock_prepare_head($object);
 dol_fiche_head($head, 'info', $langs->trans("Warehouse"), -1, 'stock');
 
 
-$linkback = '<a href="'.DOL_URL_ROOT.'/product/stock/list.php">'.$langs->trans("BackToList").'</a>';
+$linkback = '<a href="'.DOL_URL_ROOT.'/product/stock/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 $morehtmlref='<div class="refidno">';
 $morehtmlref.=$langs->trans("LocationSummary").' : '.$object->lieu;

--- a/htdocs/product/stock/movement_card.php
+++ b/htdocs/product/stock/movement_card.php
@@ -567,7 +567,7 @@ if ($resql)
         dol_fiche_head($head, 'movements', $langs->trans("Warehouse"), -1, 'stock');
 
 
-        $linkback = '<a href="'.DOL_URL_ROOT.'/product/stock/list.php">'.$langs->trans("BackToList").'</a>';
+        $linkback = '<a href="'.DOL_URL_ROOT.'/product/stock/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
         $morehtmlref='<div class="refidno">';
         $morehtmlref.=$langs->trans("LocationSummary").' : '.$object->lieu;

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -543,7 +543,7 @@ if ($resql)
         dol_fiche_head($head, 'movements', $langs->trans("Warehouse"), -1, 'stock');
 
 
-        $linkback = '<a href="'.DOL_URL_ROOT.'/product/stock/list.php">'.$langs->trans("BackToList").'</a>';
+        $linkback = '<a href="'.DOL_URL_ROOT.'/product/stock/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
         $morehtmlref='<div class="refidno">';
         $morehtmlref.=$langs->trans("LocationSummary").' : '.$object->lieu;

--- a/htdocs/reception/contact.php
+++ b/htdocs/reception/contact.php
@@ -162,7 +162,7 @@ if ($id > 0 || ! empty($ref))
 
 
 	// Reception card
-	$linkback = '<a href="'.DOL_URL_ROOT.'/reception/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/reception/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 	$morehtmlref='<div class="refidno">';
 	// Ref customer reception

--- a/htdocs/reception/note.php
+++ b/htdocs/reception/note.php
@@ -103,7 +103,7 @@ if ($id > 0 || ! empty($ref))
 
 
 	// Reception card
-	$linkback = '<a href="'.DOL_URL_ROOT.'/reception/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/reception/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 	$morehtmlref='<div class="refidno">';
 	// Ref customer reception

--- a/htdocs/societe/paymentmodes.php
+++ b/htdocs/societe/paymentmodes.php
@@ -1451,7 +1451,7 @@ if ($socid && $action == 'edit' && $user->rights->societe->creer)
 {
 	dol_fiche_head($head, 'rib', $langs->trans("ThirdParty"), 0, 'company');
 
-	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 	dol_banner_tab($object, 'socid', $linkback, ($user->societe_id?0:1), 'rowid', 'nom');
 
@@ -1555,7 +1555,7 @@ if ($socid && $action == 'editcard' && $user->rights->societe->creer)
 {
 	dol_fiche_head($head, 'rib', $langs->trans("ThirdParty"), 0, 'company');
 
-	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 	dol_banner_tab($object, 'socid', $linkback, ($user->societe_id?0:1), 'rowid', 'nom');
 
@@ -1603,7 +1603,7 @@ if ($socid && $action == 'create' && $user->rights->societe->creer)
 {
 	dol_fiche_head($head, 'rib', $langs->trans("ThirdParty"), 0, 'company');
 
-	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 	dol_banner_tab($object, 'socid', $linkback, ($user->societe_id?0:1), 'rowid', 'nom');
 
@@ -1701,7 +1701,7 @@ if ($socid && $action == 'createcard' && $user->rights->societe->creer)
 {
 	dol_fiche_head($head, 'rib', $langs->trans("ThirdParty"), 0, 'company');
 
-	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 	dol_banner_tab($object, 'socid', $linkback, ($user->societe_id?0:1), 'rowid', 'nom');
 

--- a/htdocs/societe/price.php
+++ b/htdocs/societe/price.php
@@ -187,7 +187,7 @@ $head = societe_prepare_head($object);
 
 dol_fiche_head($head, 'price', $langs->trans("ThirdParty"), -1, 'company');
 
-$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php">'.$langs->trans("BackToList").'</a>';
+$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
 dol_banner_tab($object, 'socid', $linkback, ($user->societe_id?0:1), 'rowid', 'nom');
 

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -693,7 +693,7 @@ if (empty($action) || $action == 'view' || $action == 'addlink' || $action == 'd
                  */
                 print '<table class="border" width="100%">';
 
-                $linkback = '<a href="' . DOL_URL_ROOT . '/projet/list.php">' . $langs->trans("BackToList") . '</a>';
+                $linkback = '<a href="' . DOL_URL_ROOT . '/projet/list.php?restore_lastsearch_values=1">' . $langs->trans("BackToList") . '</a>';
 
                 // Ref
                 print '<tr><td width="30%">' . $langs->trans('Ref') . '</td><td colspan="3">';
@@ -821,7 +821,7 @@ if (empty($action) || $action == 'view' || $action == 'addlink' || $action == 'd
 
         $morehtmlref.='</div>';
 
-        $linkback = '<a href="' . DOL_URL_ROOT. '/ticket/list.php"><strong>' . $langs->trans("BackToList") . '</strong></a> ';
+        $linkback = '<a href="' . DOL_URL_ROOT. '/ticket/list.php?restore_lastsearch_values=1"><strong>' . $langs->trans("BackToList") . '</strong></a> ';
 
         dol_banner_tab($object, 'ref', $linkback, ($user->societe_id ? 0 : 1), 'ref', 'ref', $morehtmlref);
 

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -477,7 +477,7 @@ if ($id && ($action == 'edit' || $action == 'create' ) && $user->rights->user->u
 	$title = $langs->trans("User");
 	dol_fiche_head($head, 'bank', $title, 0, 'user');
 
-	$linkback = '<a href="'.DOL_URL_ROOT.'/user/list.php">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.DOL_URL_ROOT.'/user/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
     dol_banner_tab($object, 'id', $linkback, $user->rights->user->user->lire || $user->admin);
 

--- a/htdocs/user/param_ihm.php
+++ b/htdocs/user/param_ihm.php
@@ -323,7 +323,7 @@ else
 {
     dol_fiche_head($head, 'guisetup', $title, -1, 'user');
 
-    $linkback = '<a href="'.DOL_URL_ROOT.'/user/list.php">'.$langs->trans("BackToList").'</a>';
+    $linkback = '<a href="'.DOL_URL_ROOT.'/user/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
     dol_banner_tab($object, 'id', $linkback, $user->rights->user->user->lire || $user->admin);
 


### PR DESCRIPTION
# Fix: filter values lost
Filter values are kept when getting back to lists from some cards (or card tabs) but not when getting back from some others.

**Note**: I added the missing URL parameter to all non-commented occurrences matching `(\$linkback = '<a .*DOL_URL_ROOT.*list\.php)([^?]>)`. 
* some replacement might not have been necessary (e.g. the bookmarks list doesn't allow filtering in 10.0)
* some cards may build the backlink differently and may have been left out
* some lists may have a different name and may have been left out
However I think this will fix most occurrences of the problem.