### PR TITLE
FIX getrights() request

### DIFF
--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -879,6 +879,7 @@ class User extends CommonObject
 		else
 		{
 			$sql.= " AND gr.entity = ".$conf->entity;
+			$sql.= " AND gu.entity = ".$conf->entity;
 			$sql.= " AND r.entity = ".$conf->entity;
 		}
 		$sql.= " AND gr.fk_usergroup = gu.fk_usergroup";


### PR DESCRIPTION
The request that loads permissions of groups takes into account entities group rights but not entities group users.
The user has group rights even if  he is in an other entity.