### PR TITLE
Fix warning caused by price2num() returning an empty string in some cases

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4450,6 +4450,8 @@ function price2num($amount, $rounding = '', $alreadysqlnb = 0)
 {
 	global $langs,$conf;
 
+	if( !$amount) $amount = 0.0;
+
 	// Round PHP function does not allow number like '1,234.56' nor '1.234,56' nor '1 234,56'
 	// Numbers must be '1234.56'
 	// Decimal delimiter for PHP and database SQL requests must be '.'

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1263,8 +1263,10 @@ function pdf_getlinedesc($object, $i, $outputlangs, $hideref = 0, $hidedesc = 0,
 			if (! empty($prodser->multilangs[$outputlangs->defaultlang]["note"]) && ($textwasmodified || $translatealsoifmodified))  $note=$prodser->multilangs[$outputlangs->defaultlang]["note"];
 		}
 	}
-	elseif ($object->type == Facture::TYPE_DEPOSIT && $object->element == 'facture') {
-		$desc = str_replace('(DEPOSIT)', $outputlangs->trans('Deposit'), $desc);
+	elseif ($object->element == 'facture' || $object->element == 'facturefourn') {
+		if ($object->type == $object::TYPE_DEPOSIT) {
+			$desc = str_replace('(DEPOSIT)', $outputlangs->trans('Deposit'), $desc);
+		}
 	}
 
 	// Description short of product line

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -587,7 +587,7 @@ class modProduct extends DolibarrModules
 			$this->import_fields_array[$r]=array(//field order as per structure of table llx_product_fournisseur_price, without optional fields
 			    'sp.fk_product'=>"ProductOrService*",
                 'sp.fk_soc' => "Supplier*",
-                'sp.ref_fourn' => 'SupplierRef',
+                'sp.ref_fourn' => 'SupplierRef*',
                 'sp.quantity' => "QtyMin*",
                 'sp.tva_tx' => 'VATRate',
                 'sp.default_vat_code' => 'VATCode',

--- a/htdocs/core/modules/modService.class.php
+++ b/htdocs/core/modules/modService.class.php
@@ -563,7 +563,7 @@ class modService extends DolibarrModules
 				$this->import_fields_array[$r]=array(//field order as per structure of table llx_product_fournisseur_price, without optional fields
 				    'sp.fk_product'=>"ProductOrService*",
 				    'sp.fk_soc' => "Supplier*",
-				    'sp.ref_fourn' => 'SupplierRef',
+				    'sp.ref_fourn' => 'SupplierRef*',
 				    'sp.quantity' => "QtyMin*",
 				    'sp.tva_tx' => 'VATRate',
 				    'sp.default_vat_code' => 'VATCode',

--- a/htdocs/core/modules/propale/doc/pdf_azur.modules.php
+++ b/htdocs/core/modules/propale/doc/pdf_azur.modules.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2015      Marcos García        <marcosgdf@gmail.com>
  * Copyright (C) 2017-2018 Ferran Marcet        <fmarcet@2byte.es>
  * Copyright (C) 2018      Frédéric France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2019      Pierre Ardoin      	<mapiolca@me.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -257,7 +258,13 @@ class pdf_azur extends ModelePDFPropales
 				{
 					if (! $arephoto)
 					{
-						$dir = $conf->product->dir_output.'/'.$midir;
+						if ($conf->product->entity != $objphoto->entity) {
+							
+							$dir = $conf->product->multidir_output[$objphoto->entity].'/'.$midir; //Check repertories of current entities
+						}else{
+
+							$dir = $conf->product->dir_output.'/'.$midir; //Check repertory of the current product
+						}
 
 						foreach ($objphoto->liste_photos($dir, 1) as $key => $obj)
 						{

--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -4463,13 +4463,15 @@ function migrate_delete_old_files($db, $langs, $conf)
         '/core/modules/facture/pdf_crabe.modules.php',
         '/core/modules/facture/pdf_oursin.modules.php',
 
-        '/compta/facture/class/api_invoice.class.php',
+    	'/categories/class/api_category.class.php',
+    	'/categories/class/api_deprecated_category.class.php',
+    	'/compta/facture/class/api_invoice.class.php',
         '/commande/class/api_commande.class.php',
         '/user/class/api_user.class.php',
         '/product/class/api_product.class.php',
         '/societe/class/api_contact.class.php',
         '/societe/class/api_thirdparty.class.php',
-        '/support/online.php',
+    	'/support/online.php',
         '/takepos/class/actions_takepos.class.php'
     );
 

--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -4463,6 +4463,7 @@ function migrate_delete_old_files($db, $langs, $conf)
         '/core/modules/facture/pdf_crabe.modules.php',
         '/core/modules/facture/pdf_oursin.modules.php',
 
+    	'/api/class/api_generic.class.php',
     	'/categories/class/api_category.class.php',
     	'/categories/class/api_deprecated_category.class.php',
     	'/compta/facture/class/api_invoice.class.php',

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -879,6 +879,7 @@ class User extends CommonObject
 		else
 		{
 			$sql.= " AND gr.entity = ".$conf->entity;
+			$sql.= " AND gu.entity = ".$conf->entity;
 			$sql.= " AND r.entity = ".$conf->entity;
 		}
 		$sql.= " AND gr.fk_usergroup = gu.fk_usergroup";


### PR DESCRIPTION
I noticed that warning working on branch 10.0:

```
[07-Dec-2019 03:51:40 UTC] PHP Stack trace:
[07-Dec-2019 03:51:40 UTC] PHP   1. {main}() /home/lox/public_html/Dev/Dolibarr/dolidemo/htdocs/compta/facture/card.php:0
[07-Dec-2019 03:51:58 UTC] PHP Warning:  A non-numeric value encountered in /home/lox/public_html/Dev/Dolibarr/dolidemo/htdocs/compta/facture/card.php on line 1942
```

The fix aims at preventing the price2num() function from returning an empty string.