### PR TITLE
Fix warning caused by price2num() returning an empty string in some cases

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4450,6 +4450,8 @@ function price2num($amount, $rounding = '', $alreadysqlnb = 0)
 {
 	global $langs,$conf;
 
+	if( !$amount) $amount = 0.0;
+
 	// Round PHP function does not allow number like '1,234.56' nor '1.234,56' nor '1 234,56'
 	// Numbers must be '1234.56'
 	// Decimal delimiter for PHP and database SQL requests must be '.'


### PR DESCRIPTION
I noticed that warning working on branch 10.0:

```
[07-Dec-2019 03:51:40 UTC] PHP Stack trace:
[07-Dec-2019 03:51:40 UTC] PHP   1. {main}() /home/lox/public_html/Dev/Dolibarr/dolidemo/htdocs/compta/facture/card.php:0
[07-Dec-2019 03:51:58 UTC] PHP Warning:  A non-numeric value encountered in /home/lox/public_html/Dev/Dolibarr/dolidemo/htdocs/compta/facture/card.php on line 1942
```

The fix aims at preventing the price2num() function from returning an empty string.