### PR TITLE
Stay in Salary Create form after submission. Reuse previous info to h…

### DIFF
--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -146,14 +146,12 @@ if ($action == 'add' && empty($cancel))
 		if ($ret > 0)
 		{
 			$db->commit();
-			header("Location: list.php");
-			exit;
+			unset($_POST['fk_user']);
 		}
 		else
 		{
 			$db->rollback();
 			setEventMessages($object->error, $object->errors, 'errors');
-			$action = "create";
 		}
 	}
 


### PR DESCRIPTION
#12066 New [*Create Salary form to stay in the same form and re-use previous data.*]
Processing even a short payroll is painful as it requires repetitive clicks and same payment information.
This patch optimises payroll processing. Form submission stays on the same form and maintains the same dates, bank account, payment type, period, salary information. Only Employee field is cleared in preparation for the next submission.
This makes entering multiple salaries much easier.