### PR TITLE
Docker corrections

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,31 +1,37 @@
-FROM php:7.0-apache
+FROM php:7.2-apache
 
 ENV HOST_USER_ID 33
 ENV PHP_INI_DATE_TIMEZONE 'UTC'
 
-RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libldap2-dev \
+RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libldap2-dev zlib1g-dev libicu-dev g++\
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd \
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
         && docker-php-ext-install ldap \
         && docker-php-ext-install mysqli \
-        && apt-get purge -y libjpeg-dev libldap2-dev
+        && docker-php-ext-install calendar \
+        && docker-php-ext-configure intl \
+        && docker-php-ext-install intl \
+        && apt-get autoremove --purge -y libjpeg-dev libldap2-dev zlib1g-dev libicu-dev g++
+
+RUN mkdir /var/documents
+RUN chown www-data /var/documents
 
 COPY docker-run.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-run.sh
 
-RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
+RUN pecl install xdebug && docker-php-ext-enable xdebug
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_autostart=0' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.default_enable=0' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_host=docker.for.mac.host.internal' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_host=docker.host' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_port=9000' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.profiler_enable=0' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_log="/tmp/xdebug.log"' >> /usr/local/etc/php/php.ini
-
+RUN echo '172.17.0.1 docker.host' >> /etc/hosts
 
 EXPOSE 80
 

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 mariadb:
-    image: mariadb:latest
+    build: mariadb
     environment:
         MYSQL_ROOT_PASSWORD: root
         MYSQL_DATABASE: dolibarr

--- a/build/docker/docker-run.sh
+++ b/build/docker/docker-run.sh
@@ -3,7 +3,8 @@
 usermod -u $HOST_USER_ID www-data
 groupmod -g $HOST_USER_ID www-data
 
-chown -hR www-data:www-data /var/www
+chgrp -hR www-data /var/www/html
+chmod g+rwx /var/www/html/conf
 
 if [ ! -f /usr/local/etc/php/php.ini ]; then
   cat <<EOF > /usr/local/etc/php/php.ini

--- a/build/docker/mariadb/Dockerfile
+++ b/build/docker/mariadb/Dockerfile
@@ -1,0 +1,3 @@
+FROM mariadb:latest
+# Enable comented out UTF8 charset/collation options
+RUN sed '/utf8/ s/^#//' /etc/mysql/mariadb.cnf >/tmp/t && mv /tmp/t /etc/mysql/mariadb.cnf


### PR DESCRIPTION
# New [*Fix docker build. Upgrade Docker PHP to 7.2*]
[*Long description*]
Several Docker issues fixed.
- MySQL seed fails to load because seed SQL contains international UTF8, but mysql server has UTF8 disabled by default. Changed MySQL image build so that utf8 options are enabled.
- php 7.2 upgrade fails to build due to absent dependencies. Added build dependencies, alsp fixed debug options for Linux.
- dolibarr-run changes all files owner to www-data, which makes them non-writeable in host IDE. Fixed to only change group ownership, and make htdocs/conf writable by Apache.