### PR TITLE
Default VAT report date 1 year before current

### DIFF
--- a/htdocs/compta/tva/clients.php
+++ b/htdocs/compta/tva/clients.php
@@ -45,10 +45,10 @@ $langs->loadLangs(array("other", "compta", "banks", "bills", "companies", "produ
 
 // Date range
 $year = GETPOST("year", "int");
-if (empty($year))
-{
+if (empty($year)){
+
     $year_current = strftime("%Y", dol_now());
-    $year_start = $year_current;
+    $year_start = $year_current - 1;
 } else {
     $year_current = $year;
     $year_start = $year;

--- a/htdocs/compta/tva/clients.php
+++ b/htdocs/compta/tva/clients.php
@@ -46,7 +46,6 @@ $langs->loadLangs(array("other", "compta", "banks", "bills", "companies", "produ
 // Date range
 $year = GETPOST("year", "int");
 if (empty($year)){
-
     $year_current = strftime("%Y", dol_now());
     $year_start = $year_current - 1;
 } else {

--- a/htdocs/compta/tva/index.php
+++ b/htdocs/compta/tva/index.php
@@ -37,11 +37,10 @@ $langs->loadLangs(array("other", "compta", "banks", "bills", "companies", "produ
 
 // Date range
 $year = GETPOST("year", "int");
-if (empty($year))
-{
+if (empty($year)) {
 	$year_current = strftime("%Y", dol_now());
 	if ($conf->global->SOCIETE_FISCAL_MONTH_START > date('m')) $year_current--;
-	$year_start = $year_current;
+	$year_start = $year_current - 1;
 } else {
 	$year_current = $year;
 	$year_start = $year;

--- a/htdocs/compta/tva/quadri_detail.php
+++ b/htdocs/compta/tva/quadri_detail.php
@@ -46,10 +46,9 @@ $langs->loadLangs(array("other", "compta", "banks", "bills", "companies", "produ
 
 // Date range
 $year = GETPOST("year", "int");
-if (empty($year))
-{
+if (empty($year)) {
 	$year_current = strftime("%Y", dol_now());
-	$year_start = $year_current;
+	$year_start = $year_current - 1;
 } else {
 	$year_current = $year;
 	$year_start = $year;


### PR DESCRIPTION
# New [*Fix default VAT report start date*]
[*Long description*]
Using current year as default start makes the report meaningless, we want historical data for the last year.
The fix makes default start 1 year before the current.