### PR TITLE
FIX #12665 Mass invoice validation with stock management (branch 8.0)

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1048,7 +1048,7 @@ if (! $error && $massaction == 'validate' && $permtocreate)
 {
 	$objecttmp=new $objectclass($db);
 
-	if ($objecttmp->element == 'invoice' && ! empty($conf->stock->enabled) && ! empty($conf->global->STOCK_CALCULATE_ON_BILL))
+	if (($objecttmp->element == 'facture' || $objecttmp->element == 'invoice') && ! empty($conf->stock->enabled) && ! empty($conf->global->STOCK_CALCULATE_ON_BILL))
 	{
 		$langs->load("errors");
 		setEventMessages($langs->trans('ErrorMassValidationNotAllowedWhenStockIncreaseOnAction'), null, 'errors');


### PR DESCRIPTION
Retrofit on FIX #12665 (branch 10.0) on branch 8.0

----------------------------
Normally the mass invoice validation is not authorized due to the need to choose the warehouse where to increase
or decrease the stock.
A message ErrorMassValidationNotAllowedWhenStockIncreaseOnAction is displayed to inform the user to do this
validation manually one by one.
The invoices should not be validated.