### PR TITLE
NEW hook on ics generation to add more events in eventarray

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1721,6 +1721,13 @@ class ActionComm extends CommonObject
                     }
                     $diff++;
                 }
+
+				$parameters=array('filters' => $filters, 'eventarray' => &$eventarray);
+				$reshook=$hookmanager->executeHooks('addMoreEventsExport', $parameters);    // Note that $action and $object may have been modified by hook
+				if ($reshook > 0)
+				{
+					$eventarray = $hookmanager->resArray;
+				}
             }
             else
             {


### PR DESCRIPTION
# New hook to add more events in actioncomm::build_exportfile process
This hook gives the ability to add more events by overwriting the eventArray before ICS generation.