### PR TITLE
Update 6.0.0-7.0.0.sql

### DIFF
--- a/htdocs/install/mysql/migration/6.0.0-7.0.0.sql
+++ b/htdocs/install/mysql/migration/6.0.0-7.0.0.sql
@@ -285,7 +285,7 @@ CREATE TABLE llx_website_account(
     date_last_login     datetime,
     date_previous_login datetime,
 	date_creation       datetime NOT NULL, 
-	tms                 timestamp NOT NULL, 
+	tms                 timestamp, 
 	fk_user_creat       integer NOT NULL, 
 	fk_user_modif       integer, 
 	import_key          varchar(14), 


### PR DESCRIPTION
timestamp NOT NULL can cause DDL SQL error.