### PR TITLE
Fix prevent double action on shipment close

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1902,6 +1902,12 @@ class Expedition extends CommonObject
 
 		$error=0;
 
+		// Protection. This avoid to move stock later when we should not
+                if ($this->statut == self::STATUS_CLOSED)
+                {
+                        return 0;
+                }
+
 		$this->db->begin();
 
 		$sql = 'UPDATE '.MAIN_DB_PREFIX.'expedition SET fk_statut='.self::STATUS_CLOSED;


### PR DESCRIPTION
If stock is moved on shipment closed and if we click twice on the close button, the movement were done twice...