### PR TITLE
FIX: Contacts of expedition

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -569,7 +569,8 @@ if ($id == 11)
 			'commande'          => $langs->trans('Order'),
 			'facture'           => $langs->trans('Bill'),
 			'fichinter'         => $langs->trans('InterventionCard'),
-			'contrat'           => $langs->trans('Contract')
+			'contrat'           => $langs->trans('Contract'),
+			'shipping'			=> $langs->trans('Expedition')
 	);
 	if (! empty($conf->global->MAIN_SUPPORT_SHARED_CONTACT_BETWEEN_THIRDPARTIES)) $elementList["societe"] = $langs->trans('ThirdParty');
 

--- a/htdocs/core/lib/sendings.lib.php
+++ b/htdocs/core/lib/sendings.lib.php
@@ -66,11 +66,13 @@ function shipping_prepare_head($object)
 	if (empty($conf->global->MAIN_DISABLE_CONTACTS_TAB))
 	{
 	    $objectsrc = $object;
+	    /*
 	    if ($object->origin == 'commande' && $object->origin_id > 0)
 	    {
 	        $objectsrc = new Commande($db);
 	        $objectsrc->fetch($object->origin_id);
 	    }
+	    */
 	    $nbContact = count($objectsrc->liste_contact(-1, 'internal')) + count($objectsrc->liste_contact(-1, 'external'));
 	    $head[$h][0] = DOL_URL_ROOT."/expedition/contact.php?id=".$object->id;
     	$head[$h][1] = $langs->trans("ContactsAddresses");

--- a/htdocs/core/tpl/contacts.tpl.php
+++ b/htdocs/core/tpl/contacts.tpl.php
@@ -95,7 +95,7 @@ if ($permission) {
 		<div class="tagtd maxwidthonsmartphone">
 		<?php
 		$tmpobject=$object;
-		if (($object->element == 'shipping' || $object->element == 'reception') && is_object($objectsrc)) $tmpobject=$objectsrc;
+		//if (($object->element == 'shipping' || $object->element == 'reception') && is_object($objectsrc)) $tmpobject=$objectsrc;
 		echo $formcompany->selectTypeContact($tmpobject, '', 'type', 'internal');
 		?></div>
 		<div class="tagtd">&nbsp;</div>
@@ -134,7 +134,7 @@ if ($permission) {
 		<div class="tagtd maxwidthonsmartphone noborderbottom">
 			<?php
 			$tmpobject=$object;
-			if (($object->element == 'shipping'|| $object->element == 'reception') && is_object($objectsrc)) $tmpobject=$objectsrc;
+			//if (($object->element == 'shipping'|| $object->element == 'reception') && is_object($objectsrc)) $tmpobject=$objectsrc;
 			$formcompany->selectTypeContact($tmpobject, '', 'type', 'external', 'position', 0, 'minwidth100imp'); ?>
 		</div>
 		<div class="tagtd noborderbottom">&nbsp;</div>
@@ -164,7 +164,7 @@ if ($permission) {
 	foreach($arrayofsource as $source) {
 
 		$tmpobject=$object;
-		if (($object->element == 'shipping'|| $object->element == 'reception') && is_object($objectsrc)) $tmpobject=$objectsrc;
+		//if (($object->element == 'shipping'|| $object->element == 'reception') && is_object($objectsrc)) $tmpobject=$objectsrc;
 
 		$tab = $tmpobject->liste_contact(-1, $source);
 		$num=count($tab);

--- a/htdocs/expedition/contact.php
+++ b/htdocs/expedition/contact.php
@@ -59,6 +59,7 @@ if ($id > 0 || ! empty($ref))
     }
 
     // Linked documents
+    /*
     if ($typeobject == 'commande' && $object->$typeobject->id && ! empty($conf->commande->enabled))
     {
         $objectsrc=new Commande($db);
@@ -69,13 +70,14 @@ if ($id > 0 || ! empty($ref))
         $objectsrc=new Propal($db);
         $objectsrc->fetch($object->$typeobject->id);
     }
+    */
 }
 
 
 /*
  * Actions
  */
-
+$objectsrc=$object;
 if ($action == 'addcontact' && $user->rights->expedition->creer)
 {
     if ($result > 0 && $id > 0)
@@ -257,7 +259,7 @@ if ($id > 0 || ! empty($ref))
 
 	// Lignes de contacts
 	echo '<br>';
-
+$objectsrc=$object;
 	// Contacts lines (modules that overwrite templates must declare this into descriptor)
 	$dirtpls=array_merge($conf->modules_parts['tpl'], array('/core/tpl'));
 	foreach($dirtpls as $reldir)


### PR DESCRIPTION
Currently the expeditions do not register their own contacts, they use those defined in the order. If there are several shipments in the same order, everyone uses the same contact.

With this simple patch you can indicate a single contact for each shipment.
I think it's related to issue #11636