### PR TITLE
FIX class Facture undefined in displaying margin information

### DIFF
--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -63,6 +63,8 @@ class FormMargin
 	{
 		global $conf, $db;
 
+        require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
+
 		// Default returned array
 		$marginInfos = array(
 				'pa_products' => 0,


### PR DESCRIPTION
FIX class Facture undefined in displaying margin information :
- it can be reproduce when you want show an order card (Error : Class "Facture" not found)

Branch : 
- v10 and develop