### PR TITLE
add credit notes and deposit to getListOfPayments

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -336,7 +336,7 @@ abstract class CommonInvoice extends CommonObject
 				$retarray[]=array('amount'=>$obj->amount,'type'=>$obj->code, 'date'=>$obj->datep, 'num'=>$obj->num, 'ref'=>$obj->ref);
 				$i++;
 			}
-			
+
 			//look for credit notes and discounts and deposits
 			$sql = 0;
 			if ($this->element == 'facture' || $this->element == 'invoice')
@@ -363,11 +363,11 @@ abstract class CommonInvoice extends CommonObject
 					while ($i < $num)
 					{
 						$obj = $this->db->fetch_object($resql);
-						if ($multicurrency) { 
-							$retarray[]=array('amount'=>$obj->multicurrency_amount,'type'=>$obj->type, 'date'=>$obj->date, 'num'=>'0', 'ref'=>$obj->ref); 
+						if ($multicurrency) {
+							$retarray[]=array('amount'=>$obj->multicurrency_amount,'type'=>$obj->type, 'date'=>$obj->date, 'num'=>'0', 'ref'=>$obj->ref);
 						}
-						else { 
-							$retarray[]=array('amount'=>$obj->amount,'type'=>$obj->type, 'date'=>$obj->date, 'num'=>'', 'ref'=>$obj->ref); 
+						else {
+							$retarray[]=array('amount'=>$obj->amount,'type'=>$obj->type, 'date'=>$obj->date, 'num'=>'', 'ref'=>$obj->ref);
 						}
 						$i++;
 					}
@@ -380,7 +380,7 @@ abstract class CommonInvoice extends CommonObject
 				}
 				$this->db->free($resql);
 			}
-			
+
 			return $retarray;
 		}
 		else

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -336,7 +336,8 @@ abstract class CommonInvoice extends CommonObject
 				$retarray[]=array('amount'=>$obj->amount,'type'=>$obj->code, 'date'=>$obj->datep, 'num'=>$obj->num, 'ref'=>$obj->ref);
 				$i++;
 			}
-
+			$this->db->free($resql);
+			
 			//look for credit notes and discounts and deposits
 			$sql = '';
 			if ($this->element == 'facture' || $this->element == 'invoice')

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -337,7 +337,7 @@ abstract class CommonInvoice extends CommonObject
 				$i++;
 			}
 			$this->db->free($resql);
-			
+
 			//look for credit notes and discounts and deposits
 			$sql = '';
 			if ($this->element == 'facture' || $this->element == 'invoice')

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -342,14 +342,14 @@ abstract class CommonInvoice extends CommonObject
 				$sql = 'SELECT rc.amount_ttc as amount, rc.multicurrency_amount_ttc as multicurrency_amount, rc.datec as date, f.ref as ref, rc.description as type';
 				$sql.= ' FROM '.MAIN_DB_PREFIX.'societe_remise_except as rc, '.MAIN_DB_PREFIX.'facture as f';
 				$sql.= ' WHERE rc.fk_facture_source=f.rowid AND rc.fk_facture = '.$this->id;
-				$sql.= ' AND (f.type = 2 OR f.type = 0 OR f.type = 3)';	// Find discount coming from credit note or excess received or credit note
+				$sql.= ' AND (f.type = 2 OR f.type = 0 OR f.type = 3)';	// Find discount coming from credit note or excess received or deposits (payments from deposits are always null except if FACTURE_DEPOSITS_ARE_JUST_PAYMENTS is set)
 			}
 			elseif ($this->element == 'facture_fourn' || $this->element == 'invoice_supplier')
 			{
 				$sql = 'SELECT rc.amount_ttc as amount, rc.multicurrency_amount_ttc as multicurrency_amount, rc.datec as date, f.ref as ref, rc.description as type';
 				$sql.= ' FROM '.MAIN_DB_PREFIX.'societe_remise_except as rc, '.MAIN_DB_PREFIX.'facture_fourn as f';
 				$sql.= ' WHERE rc.fk_invoice_supplier_source=f.rowid AND rc.fk_invoice_supplier = '.$this->id;
-				$sql.= ' AND (f.type = 2 OR f.type = 0 OR f.type = 3)';	// Find discount coming from credit note or excess received or credit note
+				$sql.= ' AND (f.type = 2 OR f.type = 0 OR f.type = 3)';	// Find discount coming from credit note or excess received or deposits (payments from deposits are always null except if FACTURE_DEPOSITS_ARE_JUST_PAYMENTS is set)
 			}
 
 			$resql=$this->db->query($sql);

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -338,7 +338,7 @@ abstract class CommonInvoice extends CommonObject
 			}
 
 			//look for credit notes and discounts and deposits
-			$sql = 0;
+			$sql = '';
 			if ($this->element == 'facture' || $this->element == 'invoice')
 			{
 				$sql = 'SELECT rc.amount_ttc as amount, rc.multicurrency_amount_ttc as multicurrency_amount, rc.datec as date, f.ref as ref, rc.description as type';

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -351,7 +351,7 @@ abstract class CommonInvoice extends CommonObject
 				$sql.= ' WHERE rc.fk_invoice_supplier_source=f.rowid AND rc.fk_invoice_supplier = '.$this->id;
 				$sql.= ' AND (f.type = 2 OR f.type = 0 OR f.type = 3)';	// Find discount coming from credit note or excess received or credit note
 			}
-			
+
 			$resql=$this->db->query($sql);
 			if ($resql)
 			{


### PR DESCRIPTION
# New : add credit notes and discounts to getListOfPayments
[*Now the API returns all payments, including deposits, discounts used and credit notes when option FACTURES_DEPOSITS_ARE_JUST_PAYMENTS is active, so the total amount paid is now correct*]
