### PR TITLE
Update api_supplier_invoices.class.php

### DIFF
--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -200,7 +200,7 @@ class SupplierInvoices extends DolibarrApi
         foreach($request_data as $field => $value) {
             $this->invoice->$field = $value;
         }
-        if(! array_keys($request_data, 'date')) {
+        if(! array_key_exists('date', $request_data)) {
             $this->invoice->date = dol_now();
         }
         /* We keep lines as an array


### PR DESCRIPTION
# New [*no custom date when creating supplier invoice via REST API *]
Correction test data 'date'  lors de la création d'une facture fournisseur. `array_keys` remplacé par `array_key_exists` dans la clause `if`. Cette clause est correcte dans api_invoices.class.php.
