### PR TITLE
Fix folder rename behavior

### DIFF
--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -168,11 +168,14 @@ if ($_POST) {
 		$bulkaction = $massaction;
 		$error = 0;
 
-		$prodstatic = new Product($db);
+
 
 		$db->begin();
 
 		foreach ($toselect as $prodid) {
+
+			// need create new of Product to prevent rename dir behavior
+			$prodstatic = new Product($db);
 
 			if ($prodstatic->fetch($prodid) < 0) {
 				continue;


### PR DESCRIPTION

remove weird behavior on variant massaction : Failed to rename directory

the script use a $prodstatic = new Product($db); and fetch all product variant without erase or clear $prodstatic so $prodstatic->oldcopy contain the previous fetched product and on update action product class try to rename previous fetched product folder to the curent fetched product ref... 