### PR TITLE
New : Add native spellcheck to CKEditor

### DIFF
--- a/htdocs/core/class/doleditor.class.php
+++ b/htdocs/core/class/doleditor.class.php
@@ -226,7 +226,7 @@ class DolEditor
                                                         });
                                                 }
                                             },
-									disableNativeSpellChecker: false';
+											disableNativeSpellChecker: '.(empty($conf->global->CKEDITOR_NATIVE_SPELLCHECKER)?'false':'true');
 
             	if ($this->uselocalbrowser)
             	{

--- a/htdocs/core/class/doleditor.class.php
+++ b/htdocs/core/class/doleditor.class.php
@@ -225,7 +225,8 @@ class DolEditor
                                                             breakAfterClose : true
                                                         });
                                                 }
-                                            }';
+                                            },
+									disableNativeSpellChecker: false';
 
             	if ($this->uselocalbrowser)
             	{


### PR DESCRIPTION
# New : Add native spellcheck to CKEditor 
As the native spell checker is disabled by default, this PR removes the default behaviour and restore it to check for spelling and grammar in wysiwyg editor.

See [CKEditor doc](https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#native-browser-spell-checker) for more information
