### PR TITLE
fix the init of the barcode

### DIFF
--- a/htdocs/barcode/codeinit.php
+++ b/htdocs/barcode/codeinit.php
@@ -202,6 +202,7 @@ print '<br>';
 print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 print '<input type="hidden" name="mode" value="label">';
 print '<input type="hidden" name="action" value="initbarcodeproducts">';
+print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
 
 print '<br>';
 

--- a/htdocs/barcode/codeinit.php
+++ b/htdocs/barcode/codeinit.php
@@ -202,7 +202,7 @@ print '<br>';
 print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 print '<input type="hidden" name="mode" value="label">';
 print '<input type="hidden" name="action" value="initbarcodeproducts">';
-print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+print '<input type="hidden" name="token" value="'.newToken().'">';
 
 print '<br>';
 


### PR DESCRIPTION
When you try to initiate all the barcode, you were logged out. Due to
the missing session parameter.

# Test
Try to generate the barcode for all the products with and without this fix.