### PR TITLE
FIX #12834 - E-Mails marked as read if scanned with eMail-Collector

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -679,7 +679,7 @@ class EmailCollector extends CommonObject
         $flags = '/service=imap'; // IMAP
         if ($ssl) $flags .= '/ssl'; // '/tls'
         $flags .= '/novalidate-cert';
-        //$flags.='/readonly';
+        $flags.='/readonly';
         //$flags.='/debug';
         if ($norsh || !empty($conf->global->IMPA_FORCE_NORSH)) $flags .= '/norsh';
 


### PR DESCRIPTION
uncomment $flags.='/readonly'; in line 682 to not touch e-mail status (read/unread) after scan with eMail-Collector.