### PR TITLE
FIX complex export model loading

### DIFF
--- a/htdocs/exports/export.php
+++ b/htdocs/exports/export.php
@@ -373,7 +373,7 @@ if ($step == 2 && $action == 'select_model')
     $result = $objexport->fetch($exportmodelid);
     if ($result > 0)
     {
-		$fieldsarray=explode(',', $objexport->hexa);
+		$fieldsarray=preg_split("/,(?! [^(]*\))/", $objexport->hexa);
 		$i=1;
 		foreach($fieldsarray as $val)
 		{


### PR DESCRIPTION
An error page was shown up when we did the extract for complex export model

Usage of "explode" with a comma separator disable usage of a complex sql select including "IF" or "CONCAT" instruction because contains commas

I use preg_split instead 