### PR TITLE
Visible receipt printer settings without stock module in TakePOS

### DIFF
--- a/htdocs/takepos/admin/terminal.php
+++ b/htdocs/takepos/admin/terminal.php
@@ -207,33 +207,34 @@ if (!empty($conf->stock->enabled))
 		print '<span class="opacitymedium">'.$langs->trans("StockDecreaseForPointOfSaleDisabled").'</span>';
 	}
 	print '</td></tr>';
-	if ($conf->receiptprinter->enabled) {
-		// Select printer to use with terminal
-		require_once DOL_DOCUMENT_ROOT.'/core/class/dolreceiptprinter.class.php';
-		$printer = new dolReceiptPrinter($db);
-		$printer->listprinters();
-		$printers = array();
-		foreach ($printer->listprinters as $key => $value) {
-			$printers[$value['rowid']] = $value['name'];
-		}
-		print '<tr class="oddeven"><td>'.$langs->trans("TakeposTerminalPrinterToUse").'</td>';
-		print '<td>';
-		print $form->selectarray('TAKEPOS_PRINTER_TO_USE'.$terminal, $printers, (empty($conf->global->{'TAKEPOS_PRINTER_TO_USE'.$terminal}) ? '0' : $conf->global->{'TAKEPOS_PRINTER_TO_USE'.$terminal}), 1);
-		print '</td></tr>';
-		$printer->listPrintersTemplates();
-		$templates = array();
-		foreach ($printer->listprinterstemplates as $key => $value) {
-			$templates[$value['rowid']] = $value['name'];
-		}
-		print '<tr class="oddeven"><td>'.$langs->trans("TakeposTerminalTemplateToUseForInvoicesTicket").'</td>';
-		print '<td>';
-		print $form->selectarray('TAKEPOS_TEMPLATE_TO_USE_FOR_INVOICES'.$terminal, $templates, (empty($conf->global->{'TAKEPOS_TEMPLATE_TO_USE_FOR_INVOICES'.$terminal}) ? '0' : $conf->global->{'TAKEPOS_TEMPLATE_TO_USE_FOR_INVOICES'.$terminal}), 1);
-		print '</td></tr>';
-		print '<tr class="oddeven"><td>'.$langs->trans("TakeposTerminalTemplateToUseForOrdersTicket").'</td>';
-		print '<td>';
-		print $form->selectarray('TAKEPOS_TEMPLATE_TO_USE_FOR_ORDERS'.$terminal, $templates, (empty($conf->global->{'TAKEPOS_TEMPLATE_TO_USE_FOR_ORDERS'.$terminal}) ? '0' : $conf->global->{'TAKEPOS_TEMPLATE_TO_USE_FOR_ORDERS'.$terminal}), 1);
-		print '</td></tr>';
+}
+
+if ($conf->receiptprinter->enabled) {
+	// Select printer to use with terminal
+	require_once DOL_DOCUMENT_ROOT.'/core/class/dolreceiptprinter.class.php';
+	$printer = new dolReceiptPrinter($db);
+	$printer->listprinters();
+	$printers = array();
+	foreach ($printer->listprinters as $key => $value) {
+		$printers[$value['rowid']] = $value['name'];
 	}
+	print '<tr class="oddeven"><td>'.$langs->trans("TakeposTerminalPrinterToUse").'</td>';
+	print '<td>';
+	print $form->selectarray('TAKEPOS_PRINTER_TO_USE'.$terminal, $printers, (empty($conf->global->{'TAKEPOS_PRINTER_TO_USE'.$terminal}) ? '0' : $conf->global->{'TAKEPOS_PRINTER_TO_USE'.$terminal}), 1);
+	print '</td></tr>';
+	$printer->listPrintersTemplates();
+	$templates = array();
+	foreach ($printer->listprinterstemplates as $key => $value) {
+		$templates[$value['rowid']] = $value['name'];
+	}
+	print '<tr class="oddeven"><td>'.$langs->trans("TakeposTerminalTemplateToUseForInvoicesTicket").'</td>';
+	print '<td>';
+	print $form->selectarray('TAKEPOS_TEMPLATE_TO_USE_FOR_INVOICES'.$terminal, $templates, (empty($conf->global->{'TAKEPOS_TEMPLATE_TO_USE_FOR_INVOICES'.$terminal}) ? '0' : $conf->global->{'TAKEPOS_TEMPLATE_TO_USE_FOR_INVOICES'.$terminal}), 1);
+	print '</td></tr>';
+	print '<tr class="oddeven"><td>'.$langs->trans("TakeposTerminalTemplateToUseForOrdersTicket").'</td>';
+	print '<td>';
+	print $form->selectarray('TAKEPOS_TEMPLATE_TO_USE_FOR_ORDERS'.$terminal, $templates, (empty($conf->global->{'TAKEPOS_TEMPLATE_TO_USE_FOR_ORDERS'.$terminal}) ? '0' : $conf->global->{'TAKEPOS_TEMPLATE_TO_USE_FOR_ORDERS'.$terminal}), 1);
+	print '</td></tr>';
 }
 
 print '</table>';


### PR DESCRIPTION
Stock module is not necesary to view receipt printer settings, so I move this receipt printer code out stock conditional block
