### PR TITLE
#12883 -  DLC and  DLUO in the stock movement api

### DIFF
--- a/htdocs/product/stock/class/api_stockmovements.class.php
+++ b/htdocs/product/stock/class/api_stockmovements.class.php
@@ -192,13 +192,15 @@ class StockMovements extends DolibarrApi
             if ($field == 'movementcode') $movementcode = $value;
             if ($field == 'movementlabel') $movementlabel = $value;
             if ($field == 'price') $price = $value;
+            if ($field == 'dlc') $dlc = $value;
+            if ($field == 'dluo') $dluo = $value;
         }
 
         // Type increase or decrease
         if ($qty >= 0) $type = 3;
         else $type = 2;
 
-        if($this->stockmovement->_create(DolibarrApiAccess::$user, $product_id, $warehouse_id, $qty, $type, $price, $movementlabel, $movementcode, '', '', '', $lot) <= 0) {
+        if($this->stockmovement->_create(DolibarrApiAccess::$user, $product_id, $warehouse_id, $qty, $type, $price, $movementlabel, $movementcode, '', $dlc, $dluo, $lot) <= 0) {
             throw new RestException(503, 'Error when create stock movement : '.$this->stockmovement->error);
         }
 

--- a/htdocs/product/stock/class/api_stockmovements.class.php
+++ b/htdocs/product/stock/class/api_stockmovements.class.php
@@ -154,46 +154,25 @@ class StockMovements extends DolibarrApi
         return $obj_ret;
     }
 
-    /*
-     * @param   int     $product_id         Id product id {@min 1}
-     * @param   int     $warehouse_id       Id warehouse {@min 1}
-     * @param   float   $qty                Qty to add (Use negative value for a stock decrease) {@min 0} {@message qty must be higher than 0}
-     * @param   string  $lot                Lot
-     * @param   string  $movementcode       Movement code {@example INV123}
-     * @param   string  $movementlabel      Movement label {@example Inventory number 123}
-     * @param   string  $price              To update AWP (Average Weighted Price) when you make a stock increase (qty must be higher then 0).
-     */
-
-
     /**
      * Create stock movement object.
-     * You can use the following message to test this RES API:
-     * { "product_id": 1, "warehouse_id": 1, "qty": 1, "lot": "", "movementcode": "INV123", "movementlabel": "Inventory 123", "price": 0 }
+     * @param int $product_id Id product id {@min 1} {@from body} {@required true}
+     * @param int $warehouse_id Id warehouse {@min 1} {@from body} {@required true}
+     * @param float $qty Qty to add (Use negative value for a stock decrease) {@min 0} {@message qty must be higher than 0} {@from body} {@required true}
+     * @param string $lot Lot {@from body}
+     * @param string $movementcode Movement code {@example INV123} {@from body}
+     * @param string $movementlabel Movement label {@example Inventory number 123} {@from body}
+     * @param string $price To update AWP (Average Weighted Price) when you make a stock increase (qty must be higher then 0). {@from body}
+     * @param string $dlc {@from body} {@type date}
+     * @param string $dluo {@from body} {@type date}
      *
-     * @param array $request_data   Request data
      * @return  int                         ID of stock movement
+     * @throws RestException
      */
-    //function post($product_id, $warehouse_id, $qty, $lot='', $movementcode='', $movementlabel='', $price=0)
-    public function post($request_data = null)
+    public function post($product_id, $warehouse_id, $qty, $lot = '', $movementcode = '', $movementlabel = '', $price = '', $dlc = '', $dluo = '')
     {
         if(! DolibarrApiAccess::$user->rights->stock->creer) {
             throw new RestException(401);
-        }
-
-        // Check mandatory fields
-        //$result = $this->_validate($request_data);
-
-        foreach($request_data as $field => $value) {
-            //$this->stockmovement->$field = $value;
-            if ($field == 'product_id') $product_id = $value;
-            if ($field == 'warehouse_id') $warehouse_id = $value;
-            if ($field == 'qty') $qty = $value;
-            if ($field == 'lot') $lot = $value;
-            if ($field == 'movementcode') $movementcode = $value;
-            if ($field == 'movementlabel') $movementlabel = $value;
-            if ($field == 'price') $price = $value;
-            if ($field == 'dlc') $dlc = $value;
-            if ($field == 'dluo') $dluo = $value;
         }
 
         // Type increase or decrease
@@ -344,7 +323,7 @@ class StockMovements extends DolibarrApi
     private function _validate($data)
     {
         $stockmovement = array();
-        foreach (Warehouses::$FIELDS as $field) {
+        foreach (self::$FIELDS as $field) {
             if (!isset($data[$field]))
                 throw new RestException(400, "$field field missing");
             $stockmovement[$field] = $data[$field];


### PR DESCRIPTION
This fixes the not supported DLUO and DLC on the stock movement in the API.

It also improves a lot the documentation without introducing any BC break
![image](https://user-images.githubusercontent.com/3658458/72630713-33a8f100-3953-11ea-9f05-3dd106176fc7.png)
