### PR TITLE
Fix double display of create credit note button

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -4829,6 +4829,7 @@ elseif ($id > 0 || ! empty($ref))
 
 			// For situation invoice with excess received
 			if ($object->statut > Facture::STATUS_DRAFT
+				&& $object->type == Facture::TYPE_SITUATION
 			    && ($object->total_ttc - $totalpaye - $totalcreditnotes - $totaldeposits) > 0
 			    && $usercancreate
 			    && !$objectidnext


### PR DESCRIPTION
# Fix 
Before: Display of the "Create credit note" button twice for standard invoices when situation invoices are activated.
After: Displays a single button "Create a credit note"