### PR TITLE
FIX length, width and height units coherence in product table

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -819,9 +819,9 @@ class Product extends CommonObject
         $this->height = price2num($this->height);
         $this->height_units = trim($this->height_units);
         // set unit not defined
-        if ($this->length_units) { $this->width_units = $this->length_units;    // Not used yet
+        if (is_numeric($this->length_units)) { $this->width_units = $this->length_units;    // Not used yet
         }
-        if ($this->length_units) { $this->height_units = $this->length_units;    // Not used yet
+        if (is_numeric($this->length_units)) { $this->height_units = $this->length_units;    // Not used yet
         }
         // Automated compute surface and volume if not filled
         if (empty($this->surface) && !empty($this->length) && !empty($this->width) && $this->length_units == $this->width_units) {


### PR DESCRIPTION
FIX length, width and height units coherence in product table : 
- when you update length_unit in a product card you can have "0" in "length_unit" and "width_unit" and "height_unit" keep their last values (ex : "-2" for cm) and you have a difference between "length_unit" and "width_unit" (the same difference occurs with "length_unit" and "height_unit")