### PR TITLE
fix entity filter in fetchCommon

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7641,7 +7641,7 @@ abstract class CommonObject
 		if (!empty($id))  $sql .= ' WHERE rowid = '.$id;
 		elseif (!empty($ref)) $sql .= " WHERE ref = ".$this->quote($ref, $this->fields['ref']);
 		else $sql .= ' WHERE 1 = 1'; // usage with empty id and empty ref is very rare
-		if (empty($id) && isset($this->ismultientitymanaged) && $this->ismultientitymanaged == 1) $sql .= ' AND entity IN ('.getEntity($this->table_element).')';
+		if (isset($this->ismultientitymanaged) && $this->ismultientitymanaged == 1) $sql .= ' AND entity IN ('.getEntity($this->table_element).')';
 		if ($morewhere)   $sql .= $morewhere;
 		$sql .= ' LIMIT 1'; // This is a fetch, to be sure to get only one record
 


### PR DESCRIPTION
# Fix entity filter in fetchCommon
If we have the id of an object that manage entities, we can fetch it even if it is not shared because entity is not tested in SQL request.

The entity is tested only if $id is empty