### PR TITLE
FIX - API - DLC/DLUO date for stock movement

### DIFF
--- a/htdocs/product/stock/class/api_stockmovements.class.php
+++ b/htdocs/product/stock/class/api_stockmovements.class.php
@@ -186,10 +186,15 @@ class StockMovements extends DolibarrApi
         }
 
         // Type increase or decrease
-        if ($qty >= 0) $type = 3;
-        else $type = 2;
+        $type = 2;
+        if ($qty >= 0){
+            $type = 3;
+        }
 
-        if($this->stockmovement->_create(DolibarrApiAccess::$user, $product_id, $warehouse_id, $qty, $type, $price, $movementlabel, $movementcode, '', $dlc, $dluo, $lot) <= 0) {
+        $eatBy = empty($dluo) ? '' : (new DateTime($dluo))->getTimestamp();
+        $sellBy = empty($dlc) ? '' : (new DateTime($dlc))->getTimestamp();;
+
+        if($this->stockmovement->_create(DolibarrApiAccess::$user, $product_id, $warehouse_id, $qty, $type, $price, $movementlabel, $movementcode, '', $eatBy, $sellBy, $lot) <= 0) {
             throw new RestException(503, 'Error when create stock movement : '.$this->stockmovement->error);
         }
 


### PR DESCRIPTION
Instead of giving a string to the creation of a stock movement, we have
to give an integer.

This PR fixes that.

**Do you want to test that PR ?**
* Enable batch on one product
* Give the DLC and DLUO for a stock movement
* Retest with the same previous call, now it should pass ... before the system was failing on finding another stock with the same date ...