### PR TITLE
Update "submitted only" module options

### DIFF
--- a/htdocs/core/actions_setmoduleoptions.inc.php
+++ b/htdocs/core/actions_setmoduleoptions.inc.php
@@ -34,11 +34,15 @@ if ($action == 'update' && is_array($arrayofparameters))
 	$ok=true;
 	foreach($arrayofparameters as $key => $val)
 	{
-		$result=dolibarr_set_const($db, $key, GETPOST($key, 'alpha'), 'chaine', 0, '', $conf->entity);
-		if ($result < 0)
+		// Modify constant only if key was posted (avoid resetting key to the null value)
+		if (GETPOSTISSET($key))
 		{
-			$ok=false;
-			break;
+			$result=dolibarr_set_const($db, $key, GETPOST($key, 'alpha'), 'chaine', 0, '', $conf->entity);
+		    if ($result < 0)
+		    {
+			    $ok=false;
+			    break;
+		    }
 		}
 	}
 


### PR DESCRIPTION
Don't update to the null value options absent from the posted parameters.