### PR TITLE
fix lost name_alias on country selection

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -950,6 +950,7 @@ else
         if (! empty($conf->fournisseur->enabled) && (GETPOST("type")=='f' || (GETPOST("type")=='' && ! empty($conf->global->THIRDPARTY_SUPPLIER_BY_DEFAULT))))  { $object->fournisseur=1; }
 
         $object->name				= GETPOST('name', 'alpha');
+        $object->name_alias			= GETPOST('name_alias', 'alpha');
         $object->firstname			= GETPOST('firstname', 'alpha');
         $object->particulier		= $private;
         $object->prefix_comm		= GETPOST('prefix_comm', 'alpha');


### PR DESCRIPTION
# Fix lost name_alias on country selection
On thirdparty card, in "create" action, the value in the name_alias field isn't reloaded in the object when the selection of the country trigger a form.submit().
So we lose the information