### PR TITLE
Add un specific link to late invoices

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -3902,6 +3902,7 @@ class Facture extends CommonInvoice
 
 				if ($generic_facture->hasDelay()) {
 					$response->nbtodolate++;
+					$response->url_late=DOL_URL_ROOT.'/compta/facture/list.php?search_option=late&mainmenu=billing&leftmenu=customers_bills';
 				}
 			}
 


### PR DESCRIPTION
Before : $response->url_late always == $response->url
After : if $response->nbtodolate >= 1 : $response->url_late redirects to list with only late unpaid costumer invoices.