### PR TITLE
fix lang for other payment mode available

### DIFF
--- a/htdocs/stripe/charge.php
+++ b/htdocs/stripe/charge.php
@@ -139,6 +139,10 @@ if (!$rowid)
 			$type = $langs->trans("card");
 	    } elseif ($charge->payment_method_details->type=='three_d_secure'){
 			$type = $langs->trans("card3DS");
+	    } elseif ($charge->payment_method_details->type=='sepa_debit'){
+			$type = $langs->trans("sepadebit");
+	    } elseif ($charge->payment_method_details->type=='ideal'){
+			$type = $langs->trans("iDEAL");
 	    }
 
         if (! empty($charge->payment_intent)) {


### PR DESCRIPTION
payment intent have other payment method available so we need more translation for type (not use for the moment in public payment page but can be used by external plugin as sellyousaas or doliconnect)