### PR TITLE
FIX: '0' is a valid search value in object list filters

### DIFF
--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -122,7 +122,7 @@ $search_all=trim(GETPOST("search_all", 'alpha'));
 $search=array();
 foreach($object->fields as $key => $val)
 {
-	if (GETPOST('search_'.$key, 'alpha')) $search[$key]=GETPOST('search_'.$key, 'alpha');
+	if (GETPOST('search_'.$key, 'alpha') !== '') $search[$key]=GETPOST('search_'.$key, 'alpha');
 }
 
 // List of fields to search into when doing a "search in all"


### PR DESCRIPTION
In the loop that fills the `$search` array with the filtering values entered by the user on an object list view, `$search[$key]` is set only if `GETPOST('search_'.$key, 'alpha')` is `true`. 

The problem is that the string `'0'` evaluates to `false`.

Explicitly testing for empty string ensures that the user can still filter columns on the `'0'` value (for instance filtering on the _Draft_ status, whose value is zero on most Dolibarr objects).