### PR TITLE
FIX: default filtering for extrafield of type 'select' should not use LIKE%%

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -31,6 +31,10 @@ if (! empty($extrafieldsobjectkey) && ! empty($search_array_options) && is_array
 			if (in_array($typ, array('int','double','real'))) $mode_search=1;								// Search on a numeric
 			if (in_array($typ, array('sellist','link')) && $crit != '0' && $crit != '-1') $mode_search=2;	// Search on a foreign key int
 			if (in_array($typ, array('chkbxlst','checkbox'))) $mode_search=4;	                            // Search on a multiselect field with sql type = text
+			if ($typ === 'select' and strpos($crit, ' ') === false) {
+				$sql .= ' AND (' . $extrafieldsobjectprefix.$tmpkey . ' = "' . $db->escape($crit) . '")';
+				continue;
+			}
 			if (is_array($crit)) $crit = implode(' ', $crit); // natural_search() expects a string
 
 			$sql .= natural_search($extrafieldsobjectprefix.$tmpkey, $crit, $mode_search);


### PR DESCRIPTION
If you have a "select" extrafield whose values are defined as:
```JSON
{
   "-1": "No",
   "1":  "Yes"
}
```
When you want to filter a list on "Yes", the query fragment generated by natural_search is:
```SQL
AND (ef.my_extrafield LIKE '%1%')
```
Which matches both "-1" and "1", which defeats the purpose of the filtering.

The extra check (`strpos($crit, ' ') === false`) ensures that multi-select filters will work the same as before.