### PR TITLE
fix path for include of reception admin screen

### DIFF
--- a/htdocs/admin/reception_setup.php
+++ b/htdocs/admin/reception_setup.php
@@ -221,7 +221,7 @@ clearstatcache();
 
 foreach ($dirmodels as $reldir)
 {
-	$dir = dol_buildpath($reldir."core/modules/reception");
+	$dir = dol_buildpath($reldir."core/modules/reception/");
 
 	if (is_dir($dir))
 	{


### PR DESCRIPTION
The options screen for the new reception modules was broken.

Cause is a missing slash in the path to the core folder.