### PR TITLE
Fix REST API post calls which were returning empty body #12761

### DIFF
--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -160,8 +160,8 @@ class Members extends DolibarrApi
     /**
      * Create member object
      *
-     * @param array $request_data   Request data
-     * @return int  ID of member
+     * @param array     $request_data   Request data
+     * @return array                    Array of created object
      */
     public function post($request_data = null)
     {
@@ -178,7 +178,7 @@ class Members extends DolibarrApi
         if ($member->create(DolibarrApiAccess::$user) < 0) {
             throw new RestException(500, 'Error creating member', array_merge(array($member->error), $member->errors));
         }
-        return $member->id;
+        return $this->get($member->id);
     }
 
     /**

--- a/htdocs/adherents/class/api_memberstypes.class.php
+++ b/htdocs/adherents/class/api_memberstypes.class.php
@@ -151,8 +151,8 @@ class MembersTypes extends DolibarrApi
     /**
      * Create member type object
      *
-     * @param array $request_data   Request data
-     * @return int  ID of member type
+     * @param array     $request_data   Request data
+     * @return array                    Array of created object
      */
     public function post($request_data = null)
     {
@@ -169,7 +169,7 @@ class MembersTypes extends DolibarrApi
         if ($membertype->create(DolibarrApiAccess::$user) < 0) {
             throw new RestException(500, 'Error creating member type', array_merge(array($membertype->error), $membertype->errors));
         }
-        return $membertype->id;
+        return $this->get($membertype->id);
     }
 
     /**

--- a/htdocs/adherents/class/api_subscriptions.class.php
+++ b/htdocs/adherents/class/api_subscriptions.class.php
@@ -148,8 +148,8 @@ class Subscriptions extends DolibarrApi
     /**
      * Create subscription object
      *
-     * @param array $request_data   Request data
-     * @return int  ID of subscription
+     * @param array     $request_data   Request data
+     * @return array                    Array of created object
      */
     public function post($request_data = null)
     {
@@ -166,7 +166,7 @@ class Subscriptions extends DolibarrApi
         if ($subscription->create(DolibarrApiAccess::$user) < 0) {
             throw new RestException(500, 'Error when creating subscription', array_merge(array($subscription->error), $subscription->errors));
         }
-        return $subscription->id;
+        return $this->get($subscription->id);
     }
 
     /**

--- a/htdocs/bom/class/api_boms.class.php
+++ b/htdocs/bom/class/api_boms.class.php
@@ -177,8 +177,8 @@ class Boms extends DolibarrApi
     /**
      * Create bom object
      *
-     * @param array $request_data   Request datas
-     * @return int  ID of bom
+     * @param array     $request_data   Request datas
+     * @return array                    Array of created object
      */
     public function post($request_data = null)
     {
@@ -194,7 +194,7 @@ class Boms extends DolibarrApi
         if( ! $this->bom->create(DolibarrApiAccess::$user)) {
             throw new RestException(500, "Error creating BOM", array_merge(array($this->bom->error), $this->bom->errors));
         }
-        return $this->bom->id;
+        return $this->get($this->bom->id);
     }
 
     /**

--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -175,8 +175,8 @@ class Categories extends DolibarrApi
     /**
      * Create category object
      *
-     * @param array $request_data   Request data
-     * @return int  ID of category
+     * @param array     $request_data   Request data
+     * @return array                    Array of created object
      */
     public function post($request_data = null)
     {
@@ -193,7 +193,7 @@ class Categories extends DolibarrApi
         if ($this->category->create(DolibarrApiAccess::$user) < 0) {
             throw new RestException(500, 'Error when creating category', array_merge(array($this->category->error), $this->category->errors));
         }
-        return $this->category->id;
+        return $this->get($this->category->id);
     }
 
     /**

--- a/htdocs/comm/action/class/api_agendaevents.class.php
+++ b/htdocs/comm/action/class/api_agendaevents.class.php
@@ -186,7 +186,7 @@ class AgendaEvents extends DolibarrApi
      * Create Agenda Event object
      *
      * @param   array   $request_data   Request data
-     * @return  int                     ID of Agenda Event
+     * @return  array                   Array of created object
      */
     public function post($request_data = null)
     {
@@ -214,7 +214,7 @@ class AgendaEvents extends DolibarrApi
             throw new RestException(500, "Error creating event", array_merge(array($this->actioncomm->error), $this->actioncomm->errors));
         }
 
-        return $this->actioncomm->id;
+        return $this->get($this->actioncomm->id);
     }
 
 

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -179,7 +179,7 @@ class Proposals extends DolibarrApi
 	 * Create commercial proposal object
 	 *
 	 * @param   array   $request_data   Request data
-	 * @return  int     ID of proposal
+     * @return  array                   Array of created object
 	 */
     public function post($request_data = null)
     {
@@ -203,7 +203,7 @@ class Proposals extends DolibarrApi
 			throw new RestException(500, "Error creating order", array_merge(array($this->propal->error), $this->propal->errors));
 		}
 
-		return $this->propal->id;
+		return $this->get($this->propal->id);
     }
 
 	/**

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -183,7 +183,7 @@ class Orders extends DolibarrApi
      * Create order object
      *
      * @param   array   $request_data   Request data
-     * @return  int     ID of order
+     * @return  array                   Array of created object
      */
     public function post($request_data = null)
     {
@@ -208,7 +208,7 @@ class Orders extends DolibarrApi
             throw new RestException(500, "Error creating order", array_merge(array($this->commande->error), $this->commande->errors));
         }
 
-        return $this->commande->id;
+        return $this->get($this->commande->id);
     }
 
     /**

--- a/htdocs/compta/bank/class/api_bankaccounts.class.php
+++ b/htdocs/compta/bank/class/api_bankaccounts.class.php
@@ -139,8 +139,8 @@ class BankAccounts extends DolibarrApi
     /**
      * Create account object
      *
-     * @param array $request_data    Request data
-     * @return int ID of account
+     * @param array $request_data   Request data
+     * @return array                Array of created object
      */
     public function post($request_data = null)
     {
@@ -163,7 +163,7 @@ class BankAccounts extends DolibarrApi
         if ($account->create(DolibarrApiAccess::$user) < 0) {
             throw new RestException(500, 'Error creating bank account', array_merge(array($account->error), $account->errors));
         }
-        return $account->id;
+        return $this->get($account->id);
     }
 
     /**

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -202,7 +202,7 @@ class Invoices extends DolibarrApi
      * Create invoice object
      *
      * @param array $request_data   Request datas
-     * @return int                  ID of invoice
+     * @return array                Array of created object
      */
     public function post($request_data = null)
     {
@@ -230,7 +230,7 @@ class Invoices extends DolibarrApi
         if ($this->invoice->create(DolibarrApiAccess::$user, 0, (empty($request_data["date_lim_reglement"]) ? 0 : $request_data["date_lim_reglement"])) < 0) {
             throw new RestException(500, "Error creating invoice", array_merge(array($this->invoice->error), $this->invoice->errors));
         }
-        return $this->invoice->id;
+        return $this->get($this->invoice->id);
     }
 
      /**

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -182,7 +182,7 @@ class Contracts extends DolibarrApi
      * Create contract object
      *
      * @param   array   $request_data   Request data
-     * @return  int     ID of contrat
+     * @return  array                   Array of created object
      */
     public function post($request_data = null)
     {
@@ -206,7 +206,7 @@ class Contracts extends DolibarrApi
             throw new RestException(500, "Error creating contract", array_merge(array($this->contract->error), $this->contract->errors));
         }
 
-        return $this->contract->id;
+        return $this->get($this->contract->id);
     }
 
     /**

--- a/htdocs/don/class/api_donations.class.php
+++ b/htdocs/don/class/api_donations.class.php
@@ -172,7 +172,7 @@ class Donations extends DolibarrApi
      * Create donation object
      *
      * @param   array   $request_data   Request data
-     * @return  int     ID of order
+     * @return  array                   Array of created object
      */
     public function post($request_data = null)
     {
@@ -197,7 +197,7 @@ class Donations extends DolibarrApi
             throw new RestException(500, "Error creating order", array_merge(array($this->don->error), $this->don->errors));
         }
 
-        return $this->don->id;
+        return $this->get($this->don->id);
     }
 
     /**

--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -180,7 +180,7 @@ class Shipments extends DolibarrApi
      * Create shipment object
      *
      * @param   array   $request_data   Request data
-     * @return  int     ID of shipment
+     * @return  array                   Array of created object
      */
     public function post($request_data = null)
     {
@@ -205,7 +205,7 @@ class Shipments extends DolibarrApi
             throw new RestException(500, "Error creating shipment", array_merge(array($this->shipment->error), $this->shipment->errors));
         }
 
-        return $this->shipment->id;
+        return $this->get($this->shipment->id);
     }
 
     /**

--- a/htdocs/expensereport/class/api_expensereports.class.php
+++ b/htdocs/expensereport/class/api_expensereports.class.php
@@ -159,7 +159,7 @@ class ExpenseReports extends DolibarrApi
      * Create Expense Report object
      *
      * @param   array   $request_data   Request data
-     * @return  int                     ID of Expense Report
+     * @return  array                   Array of created object
      */
     public function post($request_data = null)
     {
@@ -183,7 +183,7 @@ class ExpenseReports extends DolibarrApi
             throw new RestException(500, "Error creating expensereport", array_merge(array($this->expensereport->error), $this->expensereport->errors));
         }
 
-        return $this->expensereport->id;
+        return $this->get($this->expensereport->id);
     }
 
     /**

--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -186,7 +186,7 @@ class Interventions extends DolibarrApi
      * Create intervention object
      *
      * @param   array   $request_data   Request data
-     * @return  int     ID of intervention
+     * @return  array                   Array of created object
      */
     public function post($request_data = null)
     {
@@ -203,7 +203,7 @@ class Interventions extends DolibarrApi
             throw new RestException(500, "Error creating intervention", array_merge(array($this->fichinter->error), $this->fichinter->errors));
         }
 
-        return $this->fichinter->id;
+        return $this->get($this->fichinter->id);
     }
 
 

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -187,7 +187,7 @@ class SupplierInvoices extends DolibarrApi
      * Create supplier invoice object
      *
      * @param array $request_data   Request datas
-     * @return int  ID of supplier invoice
+     * @return array                Array of created object
      */
     public function post($request_data = null)
     {
@@ -215,7 +215,7 @@ class SupplierInvoices extends DolibarrApi
         if ($this->invoice->create(DolibarrApiAccess::$user) < 0) {
             throw new RestException(500, "Error creating order", array_merge(array($this->invoice->error), $this->invoice->errors));
         }
-        return $this->invoice->id;
+        return $this->get($this->invoice->id);
     }
 
     /**

--- a/htdocs/fourn/class/api_supplier_orders.class.php
+++ b/htdocs/fourn/class/api_supplier_orders.class.php
@@ -185,7 +185,7 @@ class SupplierOrders extends DolibarrApi
      * Create supplier order object
      *
      * @param array $request_data   Request datas
-     * @return int  ID of supplier order
+     * @return array                Array of created object
      */
     public function post($request_data = null)
     {
@@ -213,7 +213,7 @@ class SupplierOrders extends DolibarrApi
         if ($this->order->create(DolibarrApiAccess::$user) < 0) {
             throw new RestException(500, "Error creating order", array_merge(array($this->order->error), $this->order->errors));
         }
-        return $this->order->id;
+        return $this->get($this->order->id);
     }
 
     /**

--- a/htdocs/modulebuilder/template/class/api_mymodule.class.php
+++ b/htdocs/modulebuilder/template/class/api_mymodule.class.php
@@ -184,7 +184,7 @@ class MyModuleApi extends DolibarrApi
      * Create myobject object
      *
      * @param array $request_data   Request datas
-     * @return int  ID of myobject
+     * @return array                Array of created object
      *
      * @url	POST myobjects/
      */
@@ -202,7 +202,7 @@ class MyModuleApi extends DolibarrApi
         if( ! $this->myobject->create(DolibarrApiAccess::$user)) {
             throw new RestException(500, "Error creating MyObject", array_merge(array($this->myobject->error), $this->myobject->errors));
         }
-        return $this->myobject->id;
+        return $this->get($this->myobject->id);
     }
 
     /**

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -182,8 +182,8 @@ class Products extends DolibarrApi
     /**
      * Create product object
      *
-     * @param  array $request_data Request data
-     * @return int     ID of product
+     * @param  array $request_data  Request data
+     * @return array                Array of created object
      */
     public function post($request_data = null)
     {
@@ -200,7 +200,7 @@ class Products extends DolibarrApi
             throw new RestException(500, "Error creating product", array_merge(array($this->product->error), $this->product->errors));
         }
 
-        return $this->product->id;
+        return $this->get($this->product->id);
     }
 
     /**

--- a/htdocs/product/stock/class/api_stockmovements.class.php
+++ b/htdocs/product/stock/class/api_stockmovements.class.php
@@ -171,7 +171,7 @@ class StockMovements extends DolibarrApi
      * { "product_id": 1, "warehouse_id": 1, "qty": 1, "lot": "", "movementcode": "INV123", "movementlabel": "Inventory 123", "price": 0 }
      *
      * @param array $request_data   Request data
-     * @return  int                         ID of stock movement
+     * @return array                Array of created object
      */
     //function post($product_id, $warehouse_id, $qty, $lot='', $movementcode='', $movementlabel='', $price=0)
     public function post($request_data = null)
@@ -202,7 +202,7 @@ class StockMovements extends DolibarrApi
             throw new RestException(503, 'Error when create stock movement : '.$this->stockmovement->error);
         }
 
-        return $this->stockmovement->id;
+        return $this->get($this->stockmovement->id);
     }
 
     /**

--- a/htdocs/product/stock/class/api_warehouses.class.php
+++ b/htdocs/product/stock/class/api_warehouses.class.php
@@ -157,7 +157,7 @@ class Warehouses extends DolibarrApi
      * Create warehouse object
      *
      * @param array $request_data   Request data
-     * @return int  ID of warehouse
+     * @return array                Array of created object
      */
     public function post($request_data = null)
     {
@@ -174,7 +174,7 @@ class Warehouses extends DolibarrApi
         if ($this->warehouse->create(DolibarrApiAccess::$user) < 0) {
             throw new RestException(500, "Error creating warehouse", array_merge(array($this->warehouse->error), $this->warehouse->errors));
         }
-        return $this->warehouse->id;
+        return $this->get($this->warehouse->id);
     }
 
     /**

--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -178,7 +178,7 @@ class Projects extends DolibarrApi
      * Create project object
      *
      * @param   array   $request_data   Request data
-     * @return  int     ID of project
+     * @return  array                   Array of created object
      */
     public function post($request_data = null)
     {
@@ -202,7 +202,7 @@ class Projects extends DolibarrApi
             throw new RestException(500, "Error creating project", array_merge(array($this->project->error), $this->project->errors));
         }
 
-        return $this->project->id;
+        return $this->get($this->project->id);
     }
 
     /**

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -186,7 +186,7 @@ class Tasks extends DolibarrApi
      * Create task object
      *
      * @param   array   $request_data   Request data
-     * @return  int     ID of project
+     * @return  array                   Array of created object
      */
     public function post($request_data = null)
     {
@@ -210,7 +210,7 @@ class Tasks extends DolibarrApi
             throw new RestException(500, "Error creating task", array_merge(array($this->task->error), $this->task->errors));
         }
 
-        return $this->task->id;
+        return $this->get($this->task->id);
     }
 
     /**

--- a/htdocs/societe/class/api_contacts.class.php
+++ b/htdocs/societe/class/api_contacts.class.php
@@ -208,8 +208,8 @@ class Contacts extends DolibarrApi
 	/**
 	 * Create contact object
 	 *
-	 * @param   array   $request_data   Request datas
-	 * @return  int     ID of contact
+	 * @param   array   $request_data  Request datas
+	 * @return  array                  Array of created object
 	 */
     public function post($request_data = null)
     {
@@ -227,7 +227,7 @@ class Contacts extends DolibarrApi
 		if ($this->contact->create(DolibarrApiAccess::$user) < 0) {
 		    throw new RestException(500, "Error creating contact", array_merge(array($this->contact->error), $this->contact->errors));
 		}
-		return $this->contact->id;
+		return $this->get($this->contact->id);
 	}
 
 	/**

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -200,8 +200,8 @@ class Thirdparties extends DolibarrApi
 	/**
 	 * Create thirdparty object
 	 *
-	 * @param array $request_data   Request datas
-	 * @return int  ID of thirdparty
+	 * @param array $request_data  Request datas
+	 * @return array               Array of created object
 	 */
     public function post($request_data = null)
 	{
@@ -217,7 +217,7 @@ class Thirdparties extends DolibarrApi
 		if ($this->company->create(DolibarrApiAccess::$user) < 0)
 			throw new RestException(500, 'Error creating thirdparty', array_merge(array($this->company->error), $this->company->errors));
 
-		return $this->company->id;
+		return $this->get($this->company->id);
 	}
 
 	/**

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -316,8 +316,8 @@ class Tickets extends DolibarrApi
     /**
      * Create ticket object
      *
-     * @param array $request_data   Request datas
-     * @return int  ID of ticket
+     * @param array  $request_data  Request datas
+     * @return array                Array of created object
      */
     public function post($request_data = null)
     {
@@ -342,7 +342,7 @@ class Tickets extends DolibarrApi
         	throw new RestException(500, "Error creating ticket", array_merge(array($this->ticket->error), $this->ticket->errors));
         }
 
-        return $this->ticket->id;
+        return $this->get($this->ticket->id);
     }
 
     /**

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -163,8 +163,8 @@ class Users extends DolibarrApi
 	/**
 	 * Create user account
 	 *
-	 * @param array $request_data New user data
-	 * @return int
+	 * @param array $request_data  New user data
+	 * @return array               Array of created object
 	 */
     public function post($request_data = null)
     {
@@ -188,7 +188,7 @@ class Users extends DolibarrApi
 	    if ($this->useraccount->create(DolibarrApiAccess::$user) < 0) {
              throw new RestException(500, 'Error creating', array_merge(array($this->useraccount->error), $this->useraccount->errors));
 	    }
-	    return $this->useraccount->id;
+	    return $this->get($this->useraccount->id);
     }
 
 


### PR DESCRIPTION
Hi,

This pull request is to fix all API "POST" requests that were returning empty body,

As reported here : https://github.com/Dolibarr/dolibarr/issues/12761

I used what it is used for the PUT requests : returning the $this->get(id)

And then all POST API request return the newly created object.