### PR TITLE
FIX 11.0 - default filtering for 'select' extrafields should use "=", not "LIKE"

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -40,7 +40,10 @@ if (! empty($extrafieldsobjectkey) && ! empty($search_array_options) && is_array
 			if (in_array($typ, array('sellist','link')) && $crit != '0' && $crit != '-1') $mode_search=2;	// Search on a foreign key int
 			if (in_array($typ, array('chkbxlst','checkbox'))) $mode_search=4;	                            // Search on a multiselect field with sql type = text
 			if (is_array($crit)) $crit = implode(' ', $crit); // natural_search() expects a string
-
+			elseif ($typ === 'select' and is_string($crit) and strpos($crit, ' ') === false) {
+				$sql .= ' AND (' . $extrafieldsobjectprefix.$tmpkey . ' = "' . $db->escape($crit) . '")';
+				continue;
+			}
 			$sql .= natural_search($extrafieldsobjectprefix.$tmpkey, $crit, $mode_search);
 		}
 	}


### PR DESCRIPTION
Cf. discussion of PR https://github.com/Dolibarr/dolibarr/pull/13016
The PR was not valid for v10.0 because the filtering field is a free-text input, but in v11.0, the field is a HTML `<select>`.