### PR TITLE
FIX send mail card - display receiver select2

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -600,7 +600,7 @@ class FormMail extends Form
 				{
 					if (! empty($this->withtofree))
 					{
-						$out.= '<input class="minwidth200" id="sendto" name="sendto" value="'.(! is_array($this->withto) && ! is_numeric($this->withto)? (isset($_REQUEST["sendto"])?$_REQUEST["sendto"]:$this->withto) :"").'" />';
+						$out.= '<input class="minwidth200" id="sendto" name="sendto" value="'.((! is_array($this->withto) && ! is_numeric($this->withto))? (isset($_POST["sendto"])?$_POST["sendto"]:$this->withto) : (isset($_POST["sendto"])?$_POST["sendto"]:"") ).'" />';
 					}
 					if (! empty($this->withto) && is_array($this->withto))
 					{

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -148,7 +148,7 @@ if ($action == 'presend')
 		}
 	}
 
-	$formmail->withto = GETPOST('sendto') ? GETPOST('sendto') : $liste;
+	$formmail->withto = $liste;
 	$formmail->withtocc = $liste;
 	$formmail->withtoccc = $conf->global->MAIN_EMAIL_USECCC;
 	$formmail->withtopic = $topicmail;


### PR DESCRIPTION
If input of receiver was not empty, select2 was disappearing.