### PR TITLE
Show extrafields only when enabled

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6624,7 +6624,12 @@ abstract class CommonObject
 				if (is_array($params) && array_key_exists('onlykey', $params) && $key != $params['onlykey']) continue;
 
 				// @todo Add test also on 'enabled' (different than 'list' that is 'visibility')
-				//$enabled = 1;
+				$enabled = 1;
+				if ($enabled && isset($extrafields->attributes[$this->table_element]['enabled'][$key]))
+				{
+                    $enabled = dol_eval($extrafields->attributes[$this->table_element]['enabled'][$key], 1);
+                }
+				if (empty($enabled)) continue;
 
 				$visibility = 1;
 				if ($visibility && isset($extrafields->attributes[$this->table_element]['list'][$key]))


### PR DESCRIPTION
Show extrafields only in context where they are enabled (especially in edit mode that uses the showOptionals function).