### PR TITLE
FIX: missing trigger on contact delete

### DIFF
--- a/htdocs/societe/class/api_contacts.class.php
+++ b/htdocs/societe/class/api_contacts.class.php
@@ -293,7 +293,7 @@ class Contacts extends DolibarrApi
 			throw new RestException(401, 'Access not allowed for login ' . DolibarrApiAccess::$user->login);
 		}
         $this->contact->oldcopy = clone $this->contact;
-		return $this->contact->delete($id);
+		return $this->contact->delete();
 	}
 
 	/**


### PR DESCRIPTION
# Fix
Current behaviour is when a contact get's deleted through the REST API no trigger gets executed. This is due to wrong arguments.

