### PR TITLE
Fix create supplier invoice from supplier order don't keep source object as linked obkect

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -917,6 +917,10 @@ if (empty($reshook))
 							}
 						}
 					}
+					elseif (!empty($object->origin) && !empty($object->origin_id))
+ 					{
+						$object->linkedObjectsIds[$object->origin] = $object->origin_id;
+					}
 
 					$id = $object->create($user);
 


### PR DESCRIPTION
# Fix
We lost a functionality as described in the title 
