### PR TITLE
NEW allow display extrafields on pdf

### DIFF
--- a/htdocs/core/actions_extrafields.inc.php
+++ b/htdocs/core/actions_extrafields.inc.php
@@ -183,7 +183,8 @@ if ($action == 'add')
                 	(GETPOST('entitycurrentorall', 'alpha')?0:''),
                     GETPOST('langfile', 'alpha'),
                     1,
-                    (GETPOST('totalizable', 'alpha')?1:0)
+                    (GETPOST('totalizable', 'alpha')?1:0),
+                    (GETPOST('documentpdf', 'alpha')?1:0)
                 );
     			if ($result > 0)
     			{
@@ -352,7 +353,8 @@ if ($action == 'update')
     				(GETPOST('entitycurrentorall', 'alpha')?0:''),
                     GETPOST('langfile'),
                     1,
-                    (GETPOST('totalizable', 'alpha')?1:0)
+                    (GETPOST('totalizable', 'alpha')?1:0),
+                    (GETPOST('documentpdf', 'alpha')?1:0)
     			);
     			if ($result > 0)
     			{

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1278,7 +1278,6 @@ abstract class CommonDocGenerator
 
                     // for some type we need line break
                     if (in_array($field->type, $params['table']['arrayOfLineBreakType'])) {
-
                         if ($itemsInRow > 0) {
                             // close table row and empty cols
                             for ($i = $itemsInRow; $i <= $maxItemsInRow; $i++) {
@@ -1295,7 +1294,6 @@ abstract class CommonDocGenerator
                         $html .= '<strong>' . $field->label . ' :</strong> ';
                         $html .= $field->content;
                         $html .= "</td>";
-
                     } else {
                         $itemsInRow++;
                         $html .= '<td width="'.$params['table']['labelcolwidth'].'" class="extrafield-label">';

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1328,7 +1328,6 @@ abstract class CommonDocGenerator
 
 
         if (!empty($extrafields->attributes[$object->table_element]) && is_array($extrafields->attributes[$object->table_element]['label'])) {
-
             foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $label)
             {
                 // Dont display separator yet even is set to be displayed (not compatible yet)

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1187,16 +1187,7 @@ abstract class CommonDocGenerator
             foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $label)
             {
                 // Enable extrafield ?
-                $enabled = 1;
-                if ($enabled && isset($extrafields->attributes[$object->table_element]['enabled'][$key])){
-                    $enabled = dol_eval($extrafields->attributes[$object->table_element]['enabled'][$key], 1);
-                }
-
-                if ($enabled && isset($extrafields->attributes[$object->table_element]['list'][$key])){
-                    $enabled = dol_eval($extrafields->attributes[$object->table_element]['list'][$key], 1);
-                }
-
-                // TODO : add extrafields enabled for display from extrafield config panel
+                $enabled = !empty($extrafields->attributes[$object->table_element]['documentpdf'][$key]);
 
                 if(empty($enabled)){
                     continue;
@@ -1338,16 +1329,8 @@ abstract class CommonDocGenerator
                 }
 
                 // Enable extrafield ?
-                $enabled = 1;
-                if ($enabled && isset($extrafields->attributes[$object->table_element]['enabled'][$key])){
-                    $enabled = dol_eval($extrafields->attributes[$object->table_element]['enabled'][$key], 1);
-                }
+                $enabled = !empty($extrafields->attributes[$object->table_element]['documentpdf'][$key]);
 
-                if ($enabled && isset($extrafields->attributes[$object->table_element]['list'][$key])){
-                    $enabled = dol_eval($extrafields->attributes[$object->table_element]['list'][$key], 1);
-                }
-
-                // TODO : add extrafields $enabled from extrafield config panel
 
                 // Load language if required
                 if (!empty($extrafields->attributes[$object->table_element]['langfile'][$key])) $outputlangs->load($extrafields->attributes[$object->table_element]['langfile'][$key]);

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1219,9 +1219,9 @@ abstract class CommonDocGenerator
 
         if(!empty($fields))
         {
-            uasort($fields, function($a, $b){
+            uasort($fields, function ($a, $b) {
                 return  ($a->rank > $b->rank) ? -1 : 1;
-                }
+			}
             );
 
             foreach ($fields as $field){

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1115,7 +1115,7 @@ abstract class CommonDocGenerator
         // Cleanup extrafield key to remove prefix if present
         $pos = strpos($extrafieldKey, $extrafieldsKeyPrefix);
         if($pos===0){
-            $extrafieldKey = substr($extrafieldKey, strlen ( $extrafieldsKeyPrefix));
+            $extrafieldKey = substr($extrafieldKey, strlen($extrafieldsKeyPrefix));
         }
 
         $extrafieldOptionsKey = $extrafieldsKeyPrefix.$extrafieldKey;
@@ -1300,7 +1300,6 @@ abstract class CommonDocGenerator
 
 
         if (is_array($extrafields->attributes[$object->table_element]['label'])) {
-
             // For cache on lines loop
             if(!isset($this->extrafieldsCache)){ $this->extrafieldsCache = array(); }
             $this->extrafieldsCache[$object->table_element] = $extrafields;

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1074,7 +1074,7 @@ abstract class CommonDocGenerator
      *  @param	float		$curY    	curent Y position
      *  @param	string		$colKey    	the column key
      *  @param	string		$columnText   column text
-     *  @return	int         new rank on success and -1 on error
+     *  @return	null
      */
     public function printStdColumnContent($pdf, &$curY, $colKey, $columnText = '')
     {
@@ -1094,6 +1094,111 @@ abstract class CommonDocGenerator
             $colDef = $this->cols[$colKey];
             $pdf->writeHTMLCell($this->getColumnContentWidth($colKey) + 2, 2, $this->getColumnContentXStart($colKey) - 1, $curY, $columnText, 0, 0, 0, true, $colDef['content']['align']);
         }
+    }
+
+    /**
+     *  get extrafield content for pdf writeHtmlCell compatibility
+     *  usage for PDF line columns and object note block
+     *
+     *  @param	object		$object     common object
+     *  @param	string		$extrafieldKey    	the extrafield key
+     *  @return	null
+     */
+    public function getExtrafieldContent($object, $extrafieldKey)
+    {
+        global $hookmanager;
+
+        if(empty($object->table_element)){ return; }
+
+        $extrafieldsKeyPrefix = "options_";
+
+        // Cleanup extrafield key to remove prefix if present
+        $pos = strpos($extrafieldKey, $extrafieldsKeyPrefix);
+        if($pos===0){
+            $extrafieldKey = substr($extrafieldKey, strlen ( $extrafieldsKeyPrefix));
+        }
+
+        $extrafieldOptionsKey = $extrafieldsKeyPrefix.$extrafieldKey;
+
+
+        // Load extrafiels if not allready does
+        if(!isset($this->extrafieldsCache)){ $this->extrafieldsCache = array(); }
+        if(!isset($this->extrafieldsCache[$object->table_element])){
+            $extrafields = new ExtraFields($this->db);
+            $extrafields->fetch_name_optionals_label($object->table_element);
+        }
+        else{
+            $extrafields = $this->extrafieldsCache[$object->table_element];
+        }
+
+        $extrafieldOutputContent = $extrafields->showOutputField($extrafieldKey, $object->array_options[$extrafieldOptionsKey], '', $object->table_element);
+
+        // TODO : allow showOutputField to be pdf public friendly, ex: in a link to object, clean getNomUrl to remove link and images... like a getName methode ...
+        if($extrafields->attributes[$object->table_element]['type'][$extrafieldKey] == 'link'){
+            // for lack of anything better we cleanup all html tags
+            $extrafieldOutputContent = dol_string_nohtmltag($extrafieldOutputContent);
+        }
+
+        $parameters = array(
+            'object' => $object,
+            'extrafields' => $extrafields,
+            'extrafieldKey' => $extrafieldKey,
+            'extrafieldOutputContent' =>& $extrafieldOutputContent
+        );
+        $reshook = $hookmanager->executeHooks('getPDFExtrafieldContent', $parameters, $this); // Note that $action and $object may have been modified by hook
+        if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+        if ($reshook)
+        {
+            $extrafieldOutputContent = $hookmanager->resPrint;
+        }
+
+        return $extrafieldOutputContent;
+    }
+
+
+    /**
+     *  print extrafields columns content
+     *
+     *  @param	Tcpdf		    $pdf    	pdf object
+     *  @param	float		$curY    	curent Y position
+     *  @param	object		$object    	line of common object
+     *  @return	double  max y value
+     */
+    public function printLineExtrafieldsColumnsContent($pdf, &$curY, $object)
+    {
+        global $hookmanager;
+
+        if(empty($object->table_element) || !isset($this->extrafieldsCache[$object->table_element])){
+            return;
+        }
+
+        $nextY = $curY;
+
+        // get extrafield config from cache
+        $extrafields =& $this->extrafieldsCache[$object->table_element];
+
+        /**
+         * @var $extrafields ExtraFields
+         */
+
+        if (is_array($extrafields->attributes[$object->table_element]['label'])) {
+            foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $label)
+            {
+                $extrafieldColKey = "options_".$key;
+
+                if ($this->getColumnStatus($extrafieldColKey) && isset($object->array_options[$extrafieldColKey]))
+                {
+                    // TODO : allow showOutputField to be pdf public friendly, ex: in a link to object, clean getNomUrl to remove link and images...
+                    $columnText = $extrafields->showOutputField($key, $object->array_options[$extrafieldColKey], '', $object->table_element);
+
+
+                    $this->printStdColumnContent($pdf, $curY, $extrafieldColKey, $columnText);
+                    $nextY = max($pdf->GetY(), $nextY);
+                }
+            }
+        }
+
+        return $nextY;
     }
 
 
@@ -1166,5 +1271,92 @@ abstract class CommonDocGenerator
             }
         }
         return $this->tabTitleHeight;
+    }
+
+
+
+    /**
+     *  Define Array Column Field for extrafields
+     *
+     *  @param	object			$object    		common object det
+     *  @param	Translate		$outputlangs    langs
+     *  @param	int			   $hidedetails		Do not show line details
+     *  @return	null
+     */
+    public function defineColumnExtrafield($object, $outputlangs, $hidedetails = 0)
+    {
+        global $conf;
+
+        if(!empty($hidedetails)){
+            return;
+        }
+
+        if(empty($object->table_element)){
+            return;
+        }
+
+        $extrafields = new ExtraFields($this->db);
+        $extralabels = $extrafields->fetch_name_optionals_label($object->table_element);
+
+
+        if (is_array($extrafields->attributes[$object->table_element]['label'])) {
+
+            // For cache on lines loop
+            if(!isset($this->extrafieldsCache)){ $this->extrafieldsCache = array(); }
+            $this->extrafieldsCache[$object->table_element] = $extrafields;
+
+            foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $label)
+            {
+                // Dont display separator yet even is set to be displayed (not compatible yet)
+                if ($extrafields->attributes[$object->table_element]['type'][$key] == 'separate')
+                {
+                    continue;
+                }
+
+                // Enable extrafield ?
+                $enabled = 1;
+                if ($enabled && isset($extrafields->attributes[$object->table_element]['enabled'][$key]))
+                {
+                    $enabled = dol_eval($extrafields->attributes[$object->table_element]['enabled'][$key], 1);
+                }
+                if ($enabled && isset($extrafields->attributes[$object->table_element]['list'][$key]))
+                {
+                    $enabled = dol_eval($extrafields->attributes[$object->table_element]['list'][$key], 1);
+                }
+
+                // Load language if required
+                if (!empty($extrafields->attributes[$object->table_element]['langfile'][$key])) $outputlangs->load($extrafields->attributes[$object->table_element]['langfile'][$key]);
+
+                // TODO : add more extrafield customisation capacities for PDF like width, rank...
+
+                // set column definition
+                $def = array(
+                    'rank' => intval($extrafields->attributes[$object->table_element]['pos'][$key]),
+                    'width' => 25, // in mm
+                    'status' => boolval($enabled),
+                    'title' => array(
+                        'label' => $outputlangs->transnoentities($label)
+                    ),
+                    'content' => array(
+                        'align' => 'C'
+                    ),
+                    'border-left' => true, // add left line separator
+                );
+
+                $alignTypeRight = array('double', 'int', 'price');
+                if(in_array($extrafields->attributes[$object->table_element]['type'][$key], $alignTypeRight)){
+                    $def['content']['align'] = 'R';
+                }
+
+                $alignTypeLeft  = array('text', 'html');
+                if(in_array($extrafields->attributes[$object->table_element]['type'][$key], $alignTypeLeft)){
+                    $def['content']['align'] = 'L';
+                }
+
+
+                // for extrafields we use rank of extrafield to place it on PDF
+                $this->insertNewColumnDef("options_".$key, $def);
+            }
+        }
     }
 }

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -49,6 +49,10 @@ abstract class CommonDocGenerator
      */
 	protected $db;
 
+    /**
+     * @var Extrafields object
+     */
+	public $extrafieldsCache;
 
 	/**
 	 *	Constructor
@@ -1122,14 +1126,9 @@ abstract class CommonDocGenerator
 
 
         // Load extrafiels if not allready does
-        if(!isset($this->extrafieldsCache)){ $this->extrafieldsCache = array(); }
-        if(!isset($this->extrafieldsCache[$object->table_element])){
-            $extrafields = new ExtraFields($this->db);
-            $extrafields->fetch_name_optionals_label($object->table_element);
-        }
-        else{
-            $extrafields = $this->extrafieldsCache[$object->table_element];
-        }
+        if(empty($this->extrafieldsCache)){ $this->extrafieldsCache = new ExtraFields($this->db); }
+        if(empty($this->extrafieldsCache->attributes[$object->table_element])){ $this->extrafieldsCache->fetch_name_optionals_label($object->table_element); }
+        $extrafields = $this->extrafieldsCache;
 
         $extrafieldOutputContent = $extrafields->showOutputField($extrafieldKey, $object->array_options[$extrafieldOptionsKey], '', $object->table_element);
 
@@ -1172,14 +1171,9 @@ abstract class CommonDocGenerator
         }
 
         // Load extrafiels if not allready does
-        if(!isset($this->extrafieldsCache)){ $this->extrafieldsCache = array(); }
-        if(!isset($this->extrafieldsCache[$object->table_element])){
-            $extrafields = new ExtraFields($this->db);
-            $extrafields->fetch_name_optionals_label($object->table_element);
-        }
-        else{
-            $extrafields = $this->extrafieldsCache[$object->table_element];
-        }
+        if(empty($this->extrafieldsCache)){ $this->extrafieldsCache = new ExtraFields($this->db); }
+        if(empty($this->extrafieldsCache->attributes[$object->table_element])){ $this->extrafieldsCache->fetch_name_optionals_label($object->table_element); }
+        $extrafields = $this->extrafieldsCache;
 
 
         /**
@@ -1327,14 +1321,13 @@ abstract class CommonDocGenerator
             return;
         }
 
-        $extrafields = new ExtraFields($this->db);
-        $extralabels = $extrafields->fetch_name_optionals_label($object->table_element);
+        // Load extrafiels if not allready does
+        if(empty($this->extrafieldsCache)){ $this->extrafieldsCache = new ExtraFields($this->db); }
+        if(empty($this->extrafieldsCache->attributes[$object->table_element])){ $this->extrafieldsCache->fetch_name_optionals_label($object->table_element); }
+        $extrafields = $this->extrafieldsCache;
 
 
-        if (is_array($extrafields->attributes[$object->table_element]['label'])) {
-            // For cache on lines loop
-            if(!isset($this->extrafieldsCache)){ $this->extrafieldsCache = array(); }
-            $this->extrafieldsCache[$object->table_element] = $extrafields;
+        if (!empty($extrafields->attributes[$object->table_element]) && is_array($extrafields->attributes[$object->table_element]['label'])) {
 
             foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $label)
             {

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -374,9 +374,11 @@ class ExtraFields
 	 *  @param	string			$langfile		Language file
 	 *  @param  string  		$enabled  		Condition to have the field enabled or not
 	 *  @param	int				$totalizable	Is a measure. Must show a total on lists
+     *  @param  int             $documentpdf        Is extrafield displayed on PDF
 	 *  @return	int								<=0 if KO, >0 if OK
+     *  @throws Exception
 	 */
-	private function create_label($attrname, $label = '', $type = '', $pos = 0, $size = 0, $elementtype = 'member', $unique = 0, $required = 0, $param = '', $alwayseditable = 0, $perms = '', $list = '-1', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0)
+	private function create_label($attrname, $label = '', $type = '', $pos = 0, $size = 0, $elementtype = 'member', $unique = 0, $required = 0, $param = '', $alwayseditable = 0, $perms = '', $list = '-1', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $documentpdf = 0)
 	{
         // phpcs:enable
 		global $conf, $user;
@@ -421,6 +423,7 @@ class ExtraFields
 			$sql .= " perms,";
 			$sql .= " langs,";
 			$sql .= " list,";
+			$sql .= " documentpdf,";
 			$sql .= " fielddefault,";
 			$sql .= " fieldcomputed,";
 			$sql .= " fk_user_author,";
@@ -444,6 +447,7 @@ class ExtraFields
 			$sql .= " ".($perms ? "'".$this->db->escape($perms)."'" : "null").",";
 			$sql .= " ".($langfile ? "'".$this->db->escape($langfile)."'" : "null").",";
 			$sql .= " '".$this->db->escape($list)."',";
+			$sql .= " '".$this->db->escape($documentpdf)."',";
 			$sql .= " ".($default ? "'".$this->db->escape($default)."'" : "null").",";
 			$sql .= " ".($computed ? "'".$this->db->escape($computed)."'" : "null").",";
 			$sql .= " ".(is_object($user) ? $user->id : 0).",";
@@ -590,9 +594,11 @@ class ExtraFields
 	 *  @param	string	$langfile			Language file
 	 *  @param  string  $enabled  			Condition to have the field enabled or not
      *  @param  int     $totalizable        Is extrafield totalizable on list
+     *  @param  int     $documentpdf        Is extrafield displayed on PDF
 	 * 	@return	int							>0 if OK, <=0 if KO
+     *  @throws Exception
 	 */
-	public function update($attrname, $label, $type, $length, $elementtype, $unique = 0, $required = 0, $pos = 0, $param = '', $alwayseditable = 0, $perms = '', $list = '', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0)
+	public function update($attrname, $label, $type, $length, $elementtype, $unique = 0, $required = 0, $pos = 0, $param = '', $alwayseditable = 0, $perms = '', $list = '', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $documentpdf = 0)
 	{
 		if ($elementtype == 'thirdparty') $elementtype = 'societe';
 		if ($elementtype == 'contact') $elementtype = 'socpeople';
@@ -642,7 +648,7 @@ class ExtraFields
 			{
 				if ($label)
 				{
-					$result = $this->update_label($attrname, $label, $type, $length, $elementtype, $unique, $required, $pos, $param, $alwayseditable, $perms, $list, $help, $default, $computed, $entity, $langfile, $enabled, $totalizable);
+					$result = $this->update_label($attrname, $label, $type, $length, $elementtype, $unique, $required, $pos, $param, $alwayseditable, $perms, $list, $help, $default, $computed, $entity, $langfile, $enabled, $totalizable, $documentpdf);
 				}
 				if ($result > 0)
 				{
@@ -700,13 +706,15 @@ class ExtraFields
 	 *  @param	string	$langfile			Language file
 	 *  @param  string  $enabled  			Condition to have the field enabled or not
      *  @param  int     $totalizable        Is extrafield totalizable on list
+     *  @param  int     $documentpdf        Is extrafield displayed on PDF
      *  @return	int							<=0 if KO, >0 if OK
+     *  @throws Exception
 	 */
-	private function update_label($attrname, $label, $type, $size, $elementtype, $unique = 0, $required = 0, $pos = 0, $param = '', $alwayseditable = 0, $perms = '', $list = '0', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0)
+	private function update_label($attrname, $label, $type, $size, $elementtype, $unique = 0, $required = 0, $pos = 0, $param = '', $alwayseditable = 0, $perms = '', $list = '0', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $documentpdf = 0)
 	{
         // phpcs:enable
 		global $conf, $user;
-		dol_syslog(get_class($this)."::update_label ".$attrname.", ".$label.", ".$type.", ".$size.", ".$elementtype.", ".$unique.", ".$required.", ".$pos.", ".$alwayseditable.", ".$perms.", ".$list.", ".$default.", ".$computed.", ".$entity.", ".$langfile.", ".$enabled.", ".$totalizable);
+		dol_syslog(get_class($this)."::update_label ".$attrname.", ".$label.", ".$type.", ".$size.", ".$elementtype.", ".$unique.", ".$required.", ".$pos.", ".$alwayseditable.", ".$perms.", ".$list.", ".$default.", ".$computed.", ".$entity.", ".$langfile.", ".$enabled.", ".$totalizable.", ".$documentpdf);
 
 		// Clean parameters
 		if ($elementtype == 'thirdparty') $elementtype = 'societe';
@@ -771,6 +779,7 @@ class ExtraFields
 			$sql .= " alwayseditable,";
 			$sql .= " param,";
 			$sql .= " list,";
+			$sql .= " documentpdf,";
             $sql .= " totalizable,";
 			$sql .= " fielddefault,";
 			$sql .= " fieldcomputed,";
@@ -794,6 +803,7 @@ class ExtraFields
 			$sql .= " '".$this->db->escape($alwayseditable)."',";
 			$sql .= " '".$this->db->escape($params)."',";
 			$sql .= " '".$this->db->escape($list)."', ";
+			$sql .= " '".$this->db->escape($documentpdf)."', ";
             $sql .= " ".$totalizable.",";
 			$sql .= " ".(($default != '') ? "'".$this->db->escape($default)."'" : "null").",";
 			$sql .= " ".($computed ? "'".$this->db->escape($computed)."'" : "null").",";
@@ -871,7 +881,7 @@ class ExtraFields
 		}*/
 
 		// We should not have several time this request. If we have, there is some optimization to do by calling a simple $extrafields->fetch_optionals() in top of code and not into subcode
-		$sql = "SELECT rowid,name,label,type,size,elementtype,fieldunique,fieldrequired,param,pos,alwayseditable,perms,langs,list,totalizable,fielddefault,fieldcomputed,entity,enabled,help";
+		$sql = "SELECT rowid,name,label,type,size,elementtype,fieldunique,fieldrequired,param,pos,alwayseditable,perms,langs,list,documentpdf,totalizable,fielddefault,fieldcomputed,entity,enabled,help";
 		$sql .= " FROM ".MAIN_DB_PREFIX."extrafields";
 		//$sql.= " WHERE entity IN (0,".$conf->entity.")";    // Filter is done later
 		if ($elementtype) $sql .= " WHERE elementtype = '".$elementtype."'"; // Filed with object->table_element
@@ -933,6 +943,7 @@ class ExtraFields
 					$this->attributes[$tab->elementtype]['perms'][$tab->name] = (strlen($tab->perms) == 0 ? 1 : $tab->perms);
 					$this->attributes[$tab->elementtype]['langfile'][$tab->name] = $tab->langs;
 					$this->attributes[$tab->elementtype]['list'][$tab->name] = $tab->list;
+					$this->attributes[$tab->elementtype]['documentpdf'][$tab->name] = $tab->documentpdf;
                     $this->attributes[$tab->elementtype]['totalizable'][$tab->name] = $tab->totalizable;
 					$this->attributes[$tab->elementtype]['entityid'][$tab->name] = $tab->entity;
 					$this->attributes[$tab->elementtype]['enabled'][$tab->name] = $tab->enabled;

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -225,9 +225,10 @@ class ExtraFields
 	 *  @param  string  		$langfile  		 	Language file
 	 *  @param  string  		$enabled  		 	Condition to have the field enabled or not
 	 *  @param	int				$totalizable		Is a measure. Must show a total on lists
+     *  @param  int             $documentpdf        Is extrafield displayed on PDF
 	 *  @return int      							<=0 if KO, >0 if OK
 	 */
-	public function addExtraField($attrname, $label, $type, $pos, $size, $elementtype, $unique = 0, $required = 0, $default_value = '', $param = '', $alwayseditable = 0, $perms = '', $list = '-1', $help = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0)
+	public function addExtraField($attrname, $label, $type, $pos, $size, $elementtype, $unique = 0, $required = 0, $default_value = '', $param = '', $alwayseditable = 0, $perms = '', $list = '-1', $help = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $documentpdf = 0)
 	{
 		if (empty($attrname)) return -1;
 		if (empty($label)) return -1;
@@ -245,7 +246,7 @@ class ExtraFields
 		if ($result > 0 || $err1 == 'DB_ERROR_COLUMN_ALREADY_EXISTS' || $type == 'separate')
 		{
 			// Add declaration of field into table
-			$result2 = $this->create_label($attrname, $label, $type, $pos, $size, $elementtype, $unique, $required, $param, $alwayseditable, $perms, $list, $help, $default_value, $computed, $entity, $langfile, $enabled, $totalizable);
+			$result2 = $this->create_label($attrname, $label, $type, $pos, $size, $elementtype, $unique, $required, $param, $alwayseditable, $perms, $list, $help, $default_value, $computed, $entity, $langfile, $enabled, $totalizable, $documentpdf);
 			$err2 = $this->errno;
 			if ($result2 > 0 || ($err1 == 'DB_ERROR_COLUMN_ALREADY_EXISTS' && $err2 == 'DB_ERROR_RECORD_ALREADY_EXISTS'))
 			{

--- a/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
+++ b/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
@@ -410,6 +410,13 @@ class pdf_eratosthene extends ModelePDFCommandes
 					}
 				}
 
+                // Extrafields in note
+                $extranote = $this->getExtrafieldsInHtml($object, $outputlangs);
+                if (!empty($extranote))
+                {
+                    $notetoshow = dol_concatdesc($notetoshow, $extranote);
+                }
+
 				$pagenb = $pdf->getPage();
 				if ($notetoshow)
 				{

--- a/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
+++ b/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
@@ -702,6 +702,17 @@ class pdf_eratosthene extends ModelePDFCommandes
 					    $nexY = max($pdf->GetY(), $nexY);
 					}
 
+                    // Extrafields
+                    if(!empty($object->lines[$i]->array_options)){
+                        foreach ($object->lines[$i]->array_options as $extrafieldColKey => $extrafieldValue){
+                            if ($this->getColumnStatus($extrafieldColKey))
+                            {
+                                $extrafieldValue = $this->getExtrafieldContent($object->lines[$i], $extrafieldColKey);
+                                $this->printStdColumnContent($pdf, $curY, $extrafieldColKey, $extrafieldValue);
+                                $nexY = max($pdf->GetY(), $nexY);
+                            }
+                        }
+                    }
 
 					$parameters = array(
 					    'object' => $object,
@@ -1804,7 +1815,7 @@ class pdf_eratosthene extends ModelePDFCommandes
 	        $this->cols['discount']['status'] = true;
 	    }
 
-	    $rank = $rank + 10;
+	    $rank = $rank + 1000; // add a big offset to be sure is the last col because default extrafield rank is 100
 	    $this->cols['totalexcltax'] = array(
 	        'rank' => $rank,
 	        'width' => 26, // in mm
@@ -1815,6 +1826,11 @@ class pdf_eratosthene extends ModelePDFCommandes
 	        'border-left' => true, // add left line separator
 	    );
 
+        // Add extrafields cols
+        if(!empty($object->lines)) {
+            $line = reset($object->lines);
+            $this->defineColumnExtrafield($line, $outputlangs, $hidedetails);
+        }
 
 	    $parameters = array(
 	        'object' => $object,

--- a/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
@@ -313,6 +313,8 @@ class pdf_espadon extends ModelePdfExpedition
 				$tab_height = 130;
 				$tab_height_newpage = 150;
 
+                $this->posxdesc = $this->marge_gauche + 1;
+
 				// Incoterm
 				$height_incoterms = 0;
 				if ($conf->incoterm->enabled)

--- a/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
@@ -336,7 +336,17 @@ class pdf_espadon extends ModelePdfExpedition
 					}
 				}
 
-				if (!empty($object->note_public) || !empty($object->tracking_number))
+                // display note
+                $notetoshow = empty($object->note_public) ? '' : $object->note_public;
+
+                // Extrafields in note
+                $extranote = $this->getExtrafieldsInHtml($object, $outputlangs);
+                if (!empty($extranote))
+                {
+                    $notetoshow = dol_concatdesc($notetoshow, $extranote);
+                }
+
+				if (!empty($notetoshow) || !empty($object->tracking_number))
 				{
 					$tab_top = 88 + $height_incoterms;
 					$tab_top_alt = $tab_top;
@@ -375,10 +385,10 @@ class pdf_espadon extends ModelePdfExpedition
 					}
 
 					// Notes
-					if (!empty($object->note_public))
+					if (!empty($notetoshow))
 					{
 					    $pdf->SetFont('', '', $default_font_size - 1); // In loop to manage multi-page
-						$pdf->writeHTMLCell(190, 3, $this->posxdesc - 1, $tab_top_alt, dol_htmlentitiesbr($object->note_public), 0, 1);
+						$pdf->writeHTMLCell(190, 3, $this->posxdesc - 1, $tab_top_alt, dol_htmlentitiesbr($notetoshow), 0, 1);
 					}
 
 					$nexY = $pdf->GetY();

--- a/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
@@ -558,7 +558,17 @@ class pdf_espadon extends ModelePdfExpedition
 					    $nexY = max($pdf->GetY(), $nexY);
 					}
 
-
+                    // Extrafields
+                    if(!empty($object->lines[$i]->array_options)){
+                        foreach ($object->lines[$i]->array_options as $extrafieldColKey => $extrafieldValue){
+                            if ($this->getColumnStatus($extrafieldColKey))
+                            {
+                                $extrafieldValue = $this->getExtrafieldContent($object->lines[$i], $extrafieldColKey);
+                                $this->printStdColumnContent($pdf, $curY, $extrafieldColKey, $extrafieldValue);
+                                $nexY = max($pdf->GetY(), $nexY);
+                            }
+                        }
+                    }
 
 					$nexY += 3;
 					if ($weighttxt && $voltxt) $nexY += 2;
@@ -1225,6 +1235,11 @@ class pdf_espadon extends ModelePdfExpedition
 	        ),
 	    );
 
+        // Add extrafields cols
+        if(!empty($object->lines)) {
+            $line = reset($object->lines);
+            $this->defineColumnExtrafield($line, $outputlangs, $hidedetails);
+        }
 
 	    $parameters = array(
 	        'object' => $object,

--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -126,10 +126,11 @@ class pdf_sponge extends ModelePDFFactures
 	 */
 	public $situationinvoice;
 
+
 	/**
-	 * @var float X position for the situation progress column
+	 * @var array of document table collumns
 	 */
-	public $posxprogress;
+	public $cols;
 
 
 	/**
@@ -407,6 +408,8 @@ class pdf_sponge extends ModelePDFFactures
 	            $tab_height_newpage = 150;
 	            if (empty($conf->global->MAIN_PDF_DONOTREPEAT_HEAD)) $tab_height_newpage -= $top_shift;
 
+                $nexY = $tab_top - 1;
+
 	            // Incoterm
 	            $height_incoterms = 0;
 	            if ($conf->incoterm->enabled)
@@ -632,8 +635,6 @@ class pdf_sponge extends ModelePDFFactures
     	                if ($pageposafter > $pageposbefore)	// There is a pagebreak
     	                {
     	                    $pdf->rollbackTransaction(true);
-    	                    $pageposafter = $pageposbefore;
-    	                    //print $pageposafter.'-'.$pageposbefore;exit;
     	                    $pdf->setPageOrientation('', 1, $heightforfooter); // The only function to edit the bottom margin of current page to set it.
     	                    pdf_writelinedesc($pdf, $object, $i, $outputlangs, $this->getColumnContentWidth('desc'), 3, $this->getColumnContentXStart('desc'), $curY, $hideref, $hidedesc);
     	                    $pageposafter = $pdf->getPage();
@@ -1052,7 +1053,7 @@ class pdf_sponge extends ModelePDFFactures
 	/**
 	 *   Show miscellaneous information (payment mode, payment term, ...)
 	 *
-	 *   @param		PDF			$pdf     		Object PDF
+	 *   @param		tcpdf			$pdf     		Object PDF
 	 *   @param		Object		$object			Object to show
 	 *   @param		int			$posy			Y
 	 *   @param		Translate	$outputlangs	Langs object
@@ -1223,7 +1224,7 @@ class pdf_sponge extends ModelePDFFactures
 	/**
 	 *  Show total to pay
 	 *
-	 *  @param	PDF			$pdf            Object PDF
+	 *  @param	TCPDI			$pdf            Object PDF
 	 *	@param  Facture		$object         Object invoice
 	 *	@param  int			$deja_regle     Amount already paid (in the currency of invoice)
 	 *	@param	int			$posy			Position depart
@@ -1789,7 +1790,7 @@ class pdf_sponge extends ModelePDFFactures
 	/**
 	 *   Show table for lines
 	 *
-	 *   @param		PDF			$pdf     		Object PDF
+	 *   @param		tcpdf			$pdf     		Object PDF
 	 *   @param		string		$tab_top		Top position of table
 	 *   @param		string		$tab_height		Height of table (rectangle)
 	 *   @param		int			$nexY			Y (not used)
@@ -1849,7 +1850,7 @@ class pdf_sponge extends ModelePDFFactures
 	/**
 	 *  Show top header of page.
 	 *
-	 *  @param	PDF			$pdf     		Object PDF
+	 *  @param	Tcpdf			$pdf     		Object PDF
 	 *  @param  Object		$object     	Object to show
 	 *  @param  int	    	$showaddress    0=no, 1=yes
 	 *  @param  Translate	$outputlangs	Object lang for output

--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -447,6 +447,13 @@ class pdf_sponge extends ModelePDFFactures
 	                }
 	            }
 
+	            // Extrafields in note
+                $extranote = $this->getExtrafieldsInHtml($object, $outputlangs);
+                if (!empty($extranote))
+                {
+                    $notetoshow = dol_concatdesc($notetoshow, $extranote);
+                }
+
 	            $pagenb = $pdf->getPage();
 	            if ($notetoshow)
 	            {

--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -736,6 +736,18 @@ class pdf_sponge extends ModelePDFFactures
 	                    $nexY = max($pdf->GetY(), $nexY);
 	                }
 
+                    // Extrafields
+	                if(!empty($object->lines[$i]->array_options)){
+	                    foreach ($object->lines[$i]->array_options as $extrafieldColKey => $extrafieldValue){
+                            if ($this->getColumnStatus($extrafieldColKey))
+                            {
+                                $extrafieldValue = $this->getExtrafieldContent($object->lines[$i], $extrafieldColKey);
+                                $this->printStdColumnContent($pdf, $curY, $extrafieldColKey, $extrafieldValue);
+                                $nexY = max($pdf->GetY(), $nexY);
+                            }
+                        }
+                    }
+
 
 	                $parameters = array(
 	                    'object' => $object,
@@ -2346,7 +2358,7 @@ class pdf_sponge extends ModelePDFFactures
 	        $this->cols['discount']['status'] = true;
 	    }
 
-	    $rank = $rank + 10;
+	    $rank = $rank + 1000; // add a big offset to be sure is the last col because default extrafield rank is 100
 	    $this->cols['totalexcltax'] = array(
 	        'rank' => $rank,
 	        'width' => 26, // in mm
@@ -2357,6 +2369,11 @@ class pdf_sponge extends ModelePDFFactures
 	        'border-left' => true, // add left line separator
 	    );
 
+	    // Add extrafields cols
+        if(!empty($object->lines)) {
+            $line = reset($object->lines);
+            $this->defineColumnExtrafield($line, $outputlangs, $hidedetails);
+        }
 
 	    $parameters = array(
 	        'object' => $object,

--- a/htdocs/core/modules/propale/doc/pdf_cyan.modules.php
+++ b/htdocs/core/modules/propale/doc/pdf_cyan.modules.php
@@ -717,6 +717,17 @@ class pdf_cyan extends ModelePDFPropales
 					    $nexY = max($pdf->GetY(), $nexY);
 					}
 
+                    // Extrafields
+                    if(!empty($object->lines[$i]->array_options)){
+                        foreach ($object->lines[$i]->array_options as $extrafieldColKey => $extrafieldValue){
+                            if ($this->getColumnStatus($extrafieldColKey))
+                            {
+                                $extrafieldValue = $this->getExtrafieldContent($object->lines[$i], $extrafieldColKey);
+                                $this->printStdColumnContent($pdf, $curY, $extrafieldColKey, $extrafieldValue);
+                                $nexY = max($pdf->GetY(), $nexY);
+                            }
+                        }
+                    }
 
 					$parameters = array(
 					    'object' => $object,
@@ -1952,7 +1963,7 @@ class pdf_cyan extends ModelePDFPropales
 	        $this->cols['discount']['status'] = true;
 	    }
 
-	    $rank = $rank + 10;
+	    $rank = $rank + 1000; // add a big offset to be sure is the last col because default extrafield rank is 100
 	    $this->cols['totalexcltax'] = array(
 	        'rank' => $rank,
 	        'width' => 26, // in mm
@@ -1963,6 +1974,11 @@ class pdf_cyan extends ModelePDFPropales
 	        'border-left' => true, // add left line separator
 	    );
 
+        // Add extrafields cols
+        if(!empty($object->lines)) {
+            $line = reset($object->lines);
+            $this->defineColumnExtrafield($line, $outputlangs, $hidedetails);
+        }
 
 	    $parameters = array(
 	        'object' => $object,

--- a/htdocs/core/modules/propale/doc/pdf_cyan.modules.php
+++ b/htdocs/core/modules/propale/doc/pdf_cyan.modules.php
@@ -418,6 +418,14 @@ class pdf_cyan extends ModelePDFPropales
 						if (!empty($salerepobj->signature)) $notetoshow = dol_concatdesc($notetoshow, $salerepobj->signature);
 					}
 				}
+
+                // Extrafields in note
+                $extranote = $this->getExtrafieldsInHtml($object, $outputlangs);
+                if (!empty($extranote))
+                {
+                    $notetoshow = dol_concatdesc($notetoshow, $extranote);
+                }
+
 				if (!empty($conf->global->MAIN_ADD_CREATOR_IN_NOTE) && $object->user_author_id > 0)
 				{
 				    $tmpuser = new User($this->db);

--- a/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
@@ -369,6 +369,13 @@ class pdf_cornas extends ModelePDFSuppliersOrders
 				// Affiche notes
 				$notetoshow = empty($object->note_public) ? '' : $object->note_public;
 
+                // Extrafields in note
+                $extranote = $this->getExtrafieldsInHtml($object, $outputlangs);
+                if (!empty($extranote))
+                {
+                    $notetoshow = dol_concatdesc($notetoshow, $extranote);
+                }
+
 				$pagenb = $pdf->getPage();
 				if ($notetoshow)
 				{

--- a/htdocs/core/tpl/admin_extrafields_add.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_add.tpl.php
@@ -196,6 +196,9 @@ $langs->load("modulebuilder");
 <!-- Visibility -->
 <tr><td class="extra_list"><?php echo $form->textwithpicto($langs->trans("Visibility"), $langs->trans("VisibleDesc")); ?>
 </td><td class="valeur"><input id="list" class="minwidth100" type="text" name="list" value="<?php echo GETPOST('list', 'int')!='' ? GETPOST('list', 'int') : '1'; ?>"></td></tr>
+<!-- Visibility for PDF-->
+<tr><td class="extra_pdf"><?php echo $form->textwithpicto($langs->trans("DisplayOnPdf"), $langs->trans("DisplayOnPdfDesc")); ?>
+</td><td class="valeur"><input id="documentpdf" type="checkbox" name="documentpdf"<?php echo GETPOST('documentpdf', 'alpha')?' checked':''; ?>></td></tr>
 <!-- Totalizable -->
 <tr class="extra_totalizable"><td><?php echo $langs->trans("Totalizable"); ?></td><td class="valeur"><input id="totalizable" type="checkbox" name="totalizable"<?php echo ((GETPOST('totalizable', 'alpha') || GETPOST('button', 'alpha'))?' checked':''); ?>></td></tr>
 <!-- Help tooltip -->

--- a/htdocs/core/tpl/admin_extrafields_edit.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_edit.tpl.php
@@ -165,6 +165,7 @@ $list=$extrafields->attributes[$elementtype]['list'][$attrname];
 $totalizable = $extrafields->attributes[$elementtype]['totalizable'][$attrname];
 $help=$extrafields->attributes[$elementtype]['help'][$attrname];
 $entitycurrentorall=$extrafields->attributes[$elementtype]['entityid'][$attrname];
+$documentpdf=$extrafields->attributes[$elementtype]['documentpdf'][$attrname];
 
 if((($type == 'select') || ($type == 'checkbox') || ($type == 'radio')) && is_array($param))
 {
@@ -261,8 +262,12 @@ else
 <tr class="extra_required"><td><?php echo $langs->trans("Required"); ?></td><td class="valeur"><input id="required" type="checkbox" name="required"<?php echo ($required?' checked':''); ?>></td></tr>
 <!-- Always editable -->
 <tr class="extra_alwayseditable"><td><?php echo $langs->trans("AlwaysEditable"); ?></td><td class="valeur"><input id="alwayseditable" type="checkbox" name="alwayseditable"<?php echo ($alwayseditable?' checked':''); ?>></td></tr>
+<!-- Visibility -->
 <tr><td class="extra_list"><?php echo $form->textwithpicto($langs->trans("Visibility"), $langs->trans("VisibleDesc")); ?>
 </td><td class="valeur"><input id="list" class="minwidth100" type="text" name="list" value="<?php echo ($list!=''?$list:'1'); ?>"></td></tr>
+<!-- Visibility for PDF-->
+<tr><td class="extra_pdf"><?php echo $form->textwithpicto($langs->trans("DisplayOnPdf"), $langs->trans("DisplayOnPdfDesc")); ?>
+</td><td class="valeur"><input id="documentpdf" type="checkbox" name="documentpdf"<?php echo !empty($documentpdf)?' checked':''; ?>></td></tr>
 <tr class="extra_totalizable"><td><?php echo $form->textwithpicto($langs->trans("Totalizable"), $langs->trans("TotalizableDesc")); ?></td><td class="valeur"><input id="totalizable" type="checkbox" name="totalizable"<?php echo ($totalizable?' checked':''); ?>></td></tr>
 <!-- Help tooltip -->
 <tr class="help"><td><?php echo $form->textwithpicto($langs->trans("HelpOnTooltip"), $langs->trans("HelpOnTooltipDesc")); ?></td><td class="valeur"><input id="help" class="quatrevingtpercent" type="text" name="help" value="<?php echo dol_escape_htmltag($help); ?>"></td></tr>
@@ -270,7 +275,6 @@ else
 	<!-- Multicompany entity -->
     <tr><td><?php echo $langs->trans("AllEntities"); ?></td><td class="valeur"><input id="entitycurrentorall" type="checkbox" name="entitycurrentorall"<?php echo (empty($entitycurrentorall) ?' checked':''); ?>></td></tr>
 <?php } ?>
-<!-- Visibility -->
 </table>
 
 <?php dol_fiche_end(); ?>

--- a/htdocs/core/tpl/admin_extrafields_view.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_view.tpl.php
@@ -64,8 +64,9 @@ print '<td class="center">'.$langs->trans("Unique").'</td>';
 print '<td class="center">'.$langs->trans("Required").'</td>';
 print '<td class="center">'.$langs->trans("AlwaysEditable").'</td>';
 print '<td class="center">'.$form->textwithpicto($langs->trans("Visible"), $langs->trans("VisibleDesc")).'</td>';
+print '<td class="center">'.$form->textwithpicto($langs->trans("DisplayOnPdf"), $langs->trans("DisplayOnPdfDesc")).'</td>';
 print '<td class="center">'.$form->textwithpicto($langs->trans("Totalizable"), $langs->trans("TotalizableDesc")).'</td>';
-if ($conf->multicompany->enabled)  {
+if ($conf->multicompany->enabled){
 	print '<td class="center">'.$langs->trans("Entities").'</td>';
 }
 print '<td width="80">&nbsp;</td>';
@@ -92,6 +93,7 @@ if (is_array($extrafields->attributes[$elementtype]['type']) && count($extrafiel
 		print '<td class="center">'.yn($extrafields->attributes[$elementtype]['required'][$key])."</td>\n";
 		print '<td class="center">'.yn($extrafields->attributes[$elementtype]['alwayseditable'][$key])."</td>\n";
 		print '<td class="center">'.$extrafields->attributes[$elementtype]['list'][$key]."</td>\n";
+		print '<td class="center">'.yn($extrafields->attributes[$elementtype]['documentpdf'][$key])."</td>\n";
 		print '<td class="center">'.yn($extrafields->attributes[$elementtype]['totalizable'][$key])."</td>\n";
 		if (! empty($conf->multicompany->enabled))  {
 			print '<td class="center">';

--- a/htdocs/install/mysql/migration/11.0.0-12.0.0.sql
+++ b/htdocs/install/mysql/migration/11.0.0-12.0.0.sql
@@ -180,3 +180,5 @@ INSERT INTO llx_c_ticket_resolution (code, pos, label, active, use_default, desc
 INSERT INTO llx_c_ticket_resolution (code, pos, label, active, use_default, description) VALUES('OTHER',    '90', 'Other',     1, 0, NULL);
 
 DELETE FROM llx_const WHERE name = __ENCRYPT('DONATION_ART885')__;
+
+ALTER TABLE llx_extrafields ADD COLUMN documentpdf integer DEFAULT 0;

--- a/htdocs/langs/en_US/modulebuilder.lang
+++ b/htdocs/langs/en_US/modulebuilder.lang
@@ -84,6 +84,8 @@ ListOfPermissionsDefined=List of defined permissions
 SeeExamples=See examples here
 EnabledDesc=Condition to have this field active (Examples: 1 or $conf->global->MYMODULE_MYOPTION)
 VisibleDesc=Is the field visible ? (Examples: 0=Never visible, 1=Visible on list and create/update/view forms, 2=Visible on list only, 3=Visible on create/update/view form only (not list), 4=Visible on list and update/view form only (not create), 5=Visible on list end view form only (not create, not update). Using a negative value means field is not shown by default on list but can be selected for viewing). It can be an expression, for example:<br>preg_match('/public/', $_SERVER['PHP_SELF'])?0:1<br>($user->rights->holiday->define_holiday ? 1 : 0)
+DisplayOnPdfDesc=Display this field on compatible PDF documents, you can manage position with "Position" field.<br/>Currently, known compatibles PDF models are : eratostene (order), espadon (ship), sponge (invoices), cyan (propal/quotation), cornas (supplier order)
+DisplayOnPdf=Display on PDF
 IsAMeasureDesc=Can the value of field be cumulated to get a total into list? (Examples: 1 or 0)
 SearchAllDesc=Is the field used to make a search from the quick search tool? (Examples: 1 or 0)
 SpecDefDesc=Enter here all documentation you want to provide with your module that is not already defined by other tabs. You can use .md or better, the rich .asciidoc syntax.


### PR DESCRIPTION
# Fix comments and PHP doc

# WIP : allow extrafields on pdf
Allow display extrafields on PDF lines cols and notes

- [x] Add methods to define extrafields cols on documents lines  in commondocgenerator class
- [x] Add line cols extrafields display tools
- [x] Add document extrafields display tools for documents notes
- [x] Add new params to extrafields forms to allow extrafields to be displayed on pdf documents
- [x] improve extrafields display in notes
- [x] Add for invoices lines
- [x] Add for invoices notes
- [x] Add for orders lines
- [x] Add for orders notes
- [x] Add for propals lines
- [x] Add for propals notes
- [x] Add for expedition lines
- [x] Add for expedition notes
- [x] Add for supplier order lines
- [x] Add for supplier order notes
- [x] Perform tests

**To fix**
- [x] Expedition notes html offset 
- [x] On admin page add extrafields form,  display on pdf option doesn't saved

**To improuve** (not necessary in this pull request)
- [ ] allow in extrafield conf to choose to add extrafield in a new col or append it to description, it could be useful for html or long text extrafields