### PR TITLE
FIX search with '0'

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -7587,7 +7587,7 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 				$i3 = 0;
 				foreach($tmpcrits as $tmpcrit)
 				{
-					if(empty($tmpcrit)) continue;
+					if(!isset($tmpcrit)) continue;
 
 					$newres .= (($i2 > 0 || $i3 > 0) ? ' OR ' : '');
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -7587,7 +7587,7 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 				$i3 = 0;
 				foreach($tmpcrits as $tmpcrit)
 				{
-					if(!isset($tmpcrit)) continue;
+                    if($tmpcrit !== '0' && empty($tmpcrit)) continue;
 
 					$newres .= (($i2 > 0 || $i3 > 0) ? ' OR ' : '');
 


### PR DESCRIPTION
# Fix search with '0'
When we search ,for example, on thirdarpty list all phone number containing 0 or all zip code containing 0, or etc... We have an error cause of empty test (in sql request "AND ()" is added)

