### PR TITLE
Update translate.class.php

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -282,7 +282,7 @@ class Translate
 						 * and split the rest until a line feed.
 						 * This is more efficient than fgets + explode + trim by a factor of ~2.
 						 */
-						while ($line = fscanf($fp, "%[^= ]%*[ =]%[^\n]"))
+						while ($line = fscanf($fp, "%[^= ]%*[ =]%[^\n\r]"))
 						{
 							if (isset($line[1]))
 							{


### PR DESCRIPTION
# Fix #9105
When load() function loads translation file from an external modules, adds a \r simbol at the end of each line.
Translation file ends each line with \r\n (0x0D, 0x0A) when it comes from DOS or Windows. If is saved as Unix this issue dissapear.
