### PR TITLE
FIX undefined function measuringUnitString in product list

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -36,6 +36,7 @@ require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/product.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
 if (!empty($conf->categorie->enabled))
 	require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';


### PR DESCRIPTION
FIX undefined function measuringUnitString in product list : 
- it occurs when you remove "ref" and "label" columns in product list (getNomUrl is not called and lib product is not included)