### PR TITLE
Resolve Error if dolibarr is running in docker container

### DIFF
--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -584,7 +584,7 @@ IMG;
 			// using windows libreoffice that must be in path
 			// using linux/mac libreoffice that must be in path
 			// Note PHP Config "fastcgi.impersonate=0" must set to 0 - Default is 1
-			$command ='soffice --headless --convert-to pdf --outdir '. escapeshellarg(dirname($name)). " ".escapeshellarg($name);
+			$command ='soffice --headless -env:UserInstallation=file:///tmp/nobody --convert-to pdf --outdir '. escapeshellarg(dirname($name)). " ".escapeshellarg($name);
 		}
 		elseif (preg_match('/unoconv/', $conf->global->MAIN_ODT_AS_PDF))
 		{


### PR DESCRIPTION
# Fix #[*issue_number Short description*]
If dolibarr is running in docker containers with alpine-linux it will fail because it has wrong environment variables. This pull request resolve the issue. It was found by dolichicken in the german user forum: https://www.dolibarr.de/forum/howto-hilfe/52509-anleitung-odt-nach-pdf-konvertieren#57583
