### PR TITLE
FIX ecm_files didnt match cause document ref contained "/"

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -549,7 +549,7 @@ class BOM extends CommonObject
 	    {
 	        $num = $this->ref;
 	    }
-	    $this->newref = $num;
+	    $this->newref = dol_sanitizeFileName($num);
 
 	    // Validate
 	    $sql = "UPDATE ".MAIN_DB_PREFIX."bom_bom";

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1777,7 +1777,7 @@ class Propal extends CommonObject
 		{
 			$num = $this->ref;
 		}
-		$this->newref = $num;
+		$this->newref = dol_sanitizeFileName($num);
 
 		$sql = "UPDATE ".MAIN_DB_PREFIX."propal";
 		$sql.= " SET ref = '".$num."',";

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -361,7 +361,7 @@ class Commande extends CommonOrder
 		{
 			$num = $this->ref;
 		}
-		$this->newref = $num;
+		$this->newref = dol_sanitizeFileName($num);
 
 		// Validate
 		$sql = "UPDATE ".MAIN_DB_PREFIX."commande";

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2350,7 +2350,7 @@ class Facture extends CommonInvoice
 		{
 			$num = $this->ref;
 		}
-		$this->newref = $num;
+		$this->newref = dol_sanitizeFileName($num);
 
 		if ($num)
 		{

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -453,7 +453,7 @@ class Contrat extends CommonObject
 		{
 			$num = $this->ref;
 		}
-        $this->newref = $num;
+        $this->newref = dol_sanitizeFileName($num);
 
 		if ($num)
 		{

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -693,7 +693,7 @@ class Expedition extends CommonObject
 		{
 			$numref = "EXP".$this->id;
 		}
-		$this->newref = $numref;
+		$this->newref = dol_sanitizeFileName($numref);
 
 		$now=dol_now();
 

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -1117,7 +1117,7 @@ class ExpenseReport extends CommonObject
         }
         if (empty($num) || $num < 0) return -1;
 
-        $this->newref = $num;
+        $this->newref = dol_sanitizeFileName($num);
 
 		$this->db->begin();
 

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -540,7 +540,7 @@ class Fichinter extends CommonObject
 			{
 				$num = $this->ref;
 			}
-			$this->newref = $num;
+			$this->newref = dol_sanitizeFileName($num);
 
 			$sql = "UPDATE ".MAIN_DB_PREFIX."fichinter";
 			$sql.= " SET fk_statut = 1";

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -519,7 +519,7 @@ class CommandeFournisseur extends CommonOrder
 			{
                 $num = $this->ref;
             }
-            $this->newref = $num;
+            $this->newref = dol_sanitizeFileName($num);
 
             $sql = 'UPDATE '.MAIN_DB_PREFIX."commande_fournisseur";
             $sql.= " SET ref='".$this->db->escape($num)."',";
@@ -912,7 +912,7 @@ class CommandeFournisseur extends CommonOrder
 			{
                 $num = $this->ref;
             }
-            $this->newref = $num;
+            $this->newref = dol_sanitizeFileName($num);
 
             // Do we have to change status now ? (If double approval is required and first approval, we keep status to 1 = validated)
 			$movetoapprovestatus=true;

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1369,7 +1369,7 @@ class FactureFournisseur extends CommonInvoice
 		{
             $num = $this->ref;
         }
-        $this->newref = $num;
+        $this->newref = dol_sanitizeFileName($num);
 
         $sql = "UPDATE ".MAIN_DB_PREFIX."facture_fourn";
         $sql.= " SET ref='".$num."', fk_statut = 1, fk_user_valid = ".$user->id.", date_valid = '".$this->db->idate($now)."'";

--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -688,7 +688,7 @@ class Holiday extends CommonObject
 		{
 			$num = $this->ref;
 		}
-		$this->newref = $num;
+		$this->newref = dol_sanitizeFileName($num);
 
 		// Update status
 		$sql = "UPDATE ".MAIN_DB_PREFIX."holiday SET";

--- a/htdocs/livraison/class/livraison.class.php
+++ b/htdocs/livraison/class/livraison.class.php
@@ -391,7 +391,7 @@ class Livraison extends CommonObject
 					{
 		                $numref = $this->ref;
 		            }
-            		$this->newref = $numref;
+            		$this->newref = dol_sanitizeFileName($numref);
 
 					// Test if is not already in valid status. If so, we stop to avoid decrementing the stock twice.
 					$sql = "SELECT ref";

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -529,7 +529,7 @@ class Reception extends CommonObject
 			$numref = $this->ref;
 		}
 
-        $this->newref = $numref;
+        $this->newref = dol_sanitizeFileName($numref);
 
 		$now=dol_now();
 

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -1453,7 +1453,7 @@ class SupplierProposal extends CommonObject
             {
                 $num = $this->ref;
             }
-            $this->newref = $num;
+            $this->newref = dol_sanitizeFileName($num);
 
             $sql = "UPDATE ".MAIN_DB_PREFIX."supplier_proposal";
             $sql.= " SET ref = '".$this->db->escape($num)."',";


### PR DESCRIPTION
# Fix ecm_files didnt match cause document ref contained "/"
(dol_sanitize will replace "/" by "_")
For example : 
- We create a shipment, we generate a pdf on draft status.
- We validate it 
- We delete it
- We create an other new shipment,  we generate a pdf on draft status
- We validate it then an error tell us that there is already an existing line in ecm_files for this entity
The problem only append if we delete the last document validated.

The problem is when we generate a draft pdf and then validate, on every document, ecm_files will add 2 lines : the 1st one is the prov filename converted into ref.pdf (ref with "/") but the 2nd one is added by generateDocument function because the filename is sanitize in this function, so it adds a ref with '/' replaced by '_'

