### PR TITLE
Fix massaction create bills from orders

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -1377,48 +1377,49 @@ class Adherent extends CommonObject
 
 		require_once DOL_DOCUMENT_ROOT.'/adherents/class/subscription.class.php';
 
-		$sql = "SELECT c.rowid, c.fk_adherent, c.subscription, c.note, c.fk_bank,";
-		$sql.= " c.tms as datem,";
-		$sql.= " c.datec as datec,";
-		$sql.= " c.dateadh as dateh,";
-		$sql.= " c.datef as datef";
-		$sql.= " FROM ".MAIN_DB_PREFIX."subscription as c";
-		$sql.= " WHERE c.fk_adherent = ".$this->id;
-		$sql.= " ORDER BY c.dateadh";
+		$sql = "SELECT c.rowid, c.fk_adherent, c.fk_type, c.subscription, c.note, c.fk_bank,";
+		$sql .= " c.tms as datem,";
+		$sql .= " c.datec as datec,";
+		$sql .= " c.dateadh as dateh,";
+		$sql .= " c.datef as datef";
+		$sql .= " FROM ".MAIN_DB_PREFIX."subscription as c";
+		$sql .= " WHERE c.fk_adherent = ".$this->id;
+		$sql .= " ORDER BY c.dateadh";
 		dol_syslog(get_class($this)."::fetch_subscriptions", LOG_DEBUG);
 
-		$resql=$this->db->query($sql);
+		$resql = $this->db->query($sql);
 		if ($resql)
 		{
-			$this->subscriptions=array();
+			$this->subscriptions = array();
 
-			$i=0;
+			$i = 0;
 			while ($obj = $this->db->fetch_object($resql))
 			{
-				if ($i==0)
+				if ($i == 0)
 				{
-					$this->first_subscription_date=$this->db->jdate($obj->datec);
-					$this->first_subscription_date_start=$this->db->jdate($obj->dateh);
-					$this->first_subscription_date_end=$this->db->jdate($obj->datef);
-					$this->first_subscription_amount=$obj->subscription;
+					$this->first_subscription_date = $this->db->jdate($obj->datec);
+					$this->first_subscription_date_start = $this->db->jdate($obj->dateh);
+					$this->first_subscription_date_end = $this->db->jdate($obj->datef);
+					$this->first_subscription_amount = $obj->subscription;
 				}
-				$this->last_subscription_date=$this->db->jdate($obj->datec);
-				$this->last_subscription_date_start=$this->db->jdate($obj->datef);
-				$this->last_subscription_date_end=$this->db->jdate($obj->datef);
-				$this->last_subscription_amount=$obj->subscription;
+				$this->last_subscription_date = $this->db->jdate($obj->datec);
+				$this->last_subscription_date_start = $this->db->jdate($obj->datef);
+				$this->last_subscription_date_end = $this->db->jdate($obj->datef);
+				$this->last_subscription_amount = $obj->subscription;
 
-				$subscription=new Subscription($this->db);
-				$subscription->id=$obj->rowid;
-				$subscription->fk_adherent=$obj->fk_adherent;
-				$subscription->amount=$obj->subscription;
-				$subscription->note=$obj->note;
-				$subscription->fk_bank=$obj->fk_bank;
-				$subscription->datem=$this->db->jdate($obj->datem);
-				$subscription->datec=$this->db->jdate($obj->datec);
-				$subscription->dateh=$this->db->jdate($obj->dateh);
-				$subscription->datef=$this->db->jdate($obj->datef);
+				$subscription = new Subscription($this->db);
+				$subscription->id = $obj->rowid;
+				$subscription->fk_adherent = $obj->fk_adherent;
+				$subscription->fk_type = $obj->fk_type;
+				$subscription->amount = $obj->subscription;
+				$subscription->note = $obj->note;
+				$subscription->fk_bank = $obj->fk_bank;
+				$subscription->datem = $this->db->jdate($obj->datem);
+				$subscription->datec = $this->db->jdate($obj->datec);
+				$subscription->dateh = $this->db->jdate($obj->dateh);
+				$subscription->datef = $this->db->jdate($obj->datef);
 
-				$this->subscriptions[]=$subscription;
+				$this->subscriptions[] = $subscription;
 
 				$i++;
 			}
@@ -1426,7 +1427,7 @@ class Adherent extends CommonObject
 		}
 		else
 		{
-			$this->error=$this->db->error().' sql='.$sql;
+			$this->error = $this->db->error().' sql='.$sql;
 			return -1;
 		}
 	}

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -658,11 +658,11 @@ if ($massaction == 'confirm_createbills')   // Create bills from orders
 
 				for ($i=0;$i<$num;$i++)
 				{
-					$desc=($lines[$i]->desc?$lines[$i]->desc:$lines[$i]->libelle);
+					$desc=($lines[$i]->desc?$lines[$i]->desc:'');
 					// If we build one invoice for several order, we must put the invoice of order on the line
 					if (! empty($createbills_onebythird))
 					{
-					    $desc=dol_concatdesc($desc, $langs->trans("Order").' '.$cmd->ref.' - '.dol_print_date($cmd->date, 'day', $langs));
+					    $desc=dol_concatdesc($desc, $langs->trans("Order").' '.$cmd->ref.' - '.dol_print_date($cmd->date, 'day'));
 					}
 
 					if ($lines[$i]->subprice < 0)

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1788,6 +1788,7 @@ function dol_print_date($time, $format = '', $tzoutput = 'tzserver', $outputlang
 		$format=str_replace('%A', '__A__', $format);
 	}
 
+	
 	// Analyze date
 	$reg=array();
 	if (preg_match('/^([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])$/i', $time, $reg))	// Deprecated. Ex: 1970-01-01, 1970-01-01 01:00:00, 19700101010000
@@ -1821,6 +1822,8 @@ function dol_print_date($time, $format = '', $tzoutput = 'tzserver', $outputlang
 			$ret=adodb_strftime($format, $timetouse, $to_gmt);
 		}
 		else $ret='Bad value '.$time.' for date';
+		
+		
 	}
 
 	if (preg_match('/__b__/i', $format))

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -969,6 +969,8 @@ class ExpenseReport extends CommonObject
     public function fetch_lines()
     {
         // phpcs:enable
+		global $conf;
+		
         $this->lines=array();
 
         $sql = ' SELECT de.rowid, de.comments, de.qty, de.value_unit, de.date, de.rang,';


### PR DESCRIPTION
# Instructions
2 problems in this FIX was solved.

- Orders billed form massactions. If description was empty, The code was using the label into desc. That's no sense for me. All Invoices was repeting Label 2 times per line
- Date (dol_print_date) writted bad date. Order in 02/03/2020 was writting 01/03/2020 in invoice line ... The problem comes from $langs param. I'm not able to improve the code to fix this. But if we delete $langs param there is no more bug. I deleted $langs param because in order card or invoice card, it wasn't used. So now dol_print_date call is same.

@eldy  hope this Fix will enjoy the feature ;)