### PR TITLE
FIX date order was -1D and desc with label repetition

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -658,11 +658,11 @@ if ($massaction == 'confirm_createbills')   // Create bills from orders
 
 				for ($i=0;$i<$num;$i++)
 				{
-					$desc=($lines[$i]->desc?$lines[$i]->desc:$lines[$i]->libelle);
+					$desc=($lines[$i]->desc?$lines[$i]->desc:'');
 					// If we build one invoice for several order, we must put the invoice of order on the line
 					if (! empty($createbills_onebythird))
 					{
-					    $desc=dol_concatdesc($desc, $langs->trans("Order").' '.$cmd->ref.' - '.dol_print_date($cmd->date, 'day', $langs));
+					    $desc=dol_concatdesc($desc, $langs->trans("Order").' '.$cmd->ref.' - '.dol_print_date($cmd->date, 'day'));
 					}
 
 					if ($lines[$i]->subprice < 0)

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1788,6 +1788,7 @@ function dol_print_date($time, $format = '', $tzoutput = 'tzserver', $outputlang
 		$format=str_replace('%A', '__A__', $format);
 	}
 
+	
 	// Analyze date
 	$reg=array();
 	if (preg_match('/^([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])$/i', $time, $reg))	// Deprecated. Ex: 1970-01-01, 1970-01-01 01:00:00, 19700101010000
@@ -1821,6 +1822,8 @@ function dol_print_date($time, $format = '', $tzoutput = 'tzserver', $outputlang
 			$ret=adodb_strftime($format, $timetouse, $to_gmt);
 		}
 		else $ret='Bad value '.$time.' for date';
+		
+		
 	}
 
 	if (preg_match('/__b__/i', $format))


### PR DESCRIPTION
# Instructions
2 problems in this FIX was solved.

- Orders billed form massactions. If description was empty, The code was using the label into desc. That's no sense for me. All Invoices was repeting Label 2 times per line
- Date (dol_print_date) writted bad date. Order in 02/03/2020 was writting 01/03/2020 in invoice line ... The problem comes from $langs param. I'm not able to improve the code to fix this. But if we delete $langs param there is no more bug. I deleted $langs param because in order card or invoice card, it wasn't used. So now dol_print_date call is same.

@eldy  hope this Fix will enjoy the feature ;)