### PR TITLE
add missing translation string "Usage" (projects)

### DIFF
--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -257,6 +257,7 @@ InvoiceGeneratedFromTimeSpent=Invoice %s has been generated from time spent on p
 ProjectBillTimeDescription=Check if you enter timesheet on tasks of project AND you plan to generate invoice(s) from the timesheet to bill the customer of the project (do not check if you plan to create invoice that is not based on entered timesheets). Note: To generate invoice, go on tab 'Time spent' of the project and select lines to include.
 ProjectFollowOpportunity=Follow opportunity
 ProjectFollowTasks=Follow tasks
+Usage=Usage
 UsageOpportunity=Usage: Opportunity
 UsageTasks=Usage: Tasks
 UsageBillTimeShort=Usage: Bill time


### PR DESCRIPTION
# Fix 

Add missing string "Usage" to en_US / Projects