### PR TITLE
NEW add icon on payment buttons in cash desk

### DIFF
--- a/htdocs/langs/en_US/cashdesk.lang
+++ b/htdocs/langs/en_US/cashdesk.lang
@@ -91,3 +91,4 @@ TakeposConnectorMethodDescription=External module with extra features. Posibilit
 PrintMethod=Print method
 ReceiptPrinterMethodDescription=Powerful method with a lot of parameters. Full customizable with templates. Cannot print from the cloud.
 ByTerminal=By terminal
+TakeposNumpadUsePaymentIcon=Use payment icon on numpad

--- a/htdocs/langs/fr_FR/cashdesk.lang
+++ b/htdocs/langs/fr_FR/cashdesk.lang
@@ -82,3 +82,4 @@ ReceiptName=Nom du reçu
 ProductSupplements=Suppléments de produit
 SupplementCategory=Catégorie des suppléments
 SortProductField=Champ pour le tri des produits
+TakeposNumpadUsePaymentIcon=Utilisation d'icônes sur les touches des modes de règlement du pavé numérique

--- a/htdocs/takepos/admin/setup.php
+++ b/htdocs/takepos/admin/setup.php
@@ -201,6 +201,13 @@ $array = array(0=>$langs->trans("Numberspad"), 1=>$langs->trans("BillsCoinsPad")
 print $form->selectarray('TAKEPOS_NUMPAD', $array, (empty($conf->global->TAKEPOS_NUMPAD) ? '0' : $conf->global->TAKEPOS_NUMPAD), 0);
 print "</td></tr>\n";
 
+// Numpad use payment icons
+print '<tr class="oddeven"><td>';
+print $langs->trans('TakeposNumpadUsePaymentIcon');
+print '<td colspan="2">';
+print ajax_constantonoff("TAKEPOS_NUMPAD_USE_PAYMENT_ICON", array(), $conf->entity, 0, 0, 1, 0);
+print "</td></tr>\n";
+
 // Direct Payment
 print '<tr class="oddeven"><td>';
 print $langs->trans('DirectPaymentButton');

--- a/htdocs/takepos/css/pos.css.php
+++ b/htdocs/takepos/css/pos.css.php
@@ -101,6 +101,7 @@ button.calcbutton {
     /* border-color: unset; */
     border-width: 0;
     margin: 1px;
+	font-size: 14pt;
 }
 
 button.calcbutton2 {
@@ -118,6 +119,8 @@ button.calcbutton2 {
 	width: calc(25% - 2px);
 	height: calc(25% - 2px);
 	font-weight: bold;
+	font-size: 8pt;
+	margin: 1px;
 }
 
 button.calcbutton3 {
@@ -128,10 +131,11 @@ button.calcbutton3 {
 	cursor: pointer;
 	vertical-align: middle;
 	text-align: center;
-	font-size:120%;
 	overflow: visible; /* removes extra width in IE */
 	width: calc(25% - 2px);
 	height: calc(25% - 2px);
+	font-size: 14pt;
+	margin: 1px;
 }
 
 button.actionbutton {
@@ -468,12 +472,6 @@ div.description_content {
 }
 
 @media screen and (min-width: 892px) {
-	.calcbutton{
-		font-size: 18px;
-	}
-	.calcbutton2{
-		font-size: 14px;
-	}
 	.actionbutton{
 		font-size: 13px;
 	}
@@ -486,12 +484,6 @@ div.description_content {
 }
 
 @media (max-width: 891px) and (min-width: 386px) {
-	.calcbutton{
-		font-size: 12px;
-	}
-	.calcbutton2{
-		font-size: 9px;
-	}
 	.actionbutton{
 		font-size: 12px;
 	}
@@ -504,12 +496,6 @@ div.description_content {
 }
 
 @media screen and (max-width: 385px){
-	.calcbutton{
-		font-size: 8px;
-	}
-	.calcbutton2{
-		font-size: 7px;
-	}
 	.actionbutton{
 		font-size: 10px;
 	}

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -233,7 +233,7 @@ else print "var received=0;";
 </center>
 </div>
 
-<div style="position:absolute; top:33%; left:5%; height:55%; width:91%; display: inline-table;">
+<div style="position:absolute; top:33%; left:5%; height:52%; width:92%;">
 <?php
 $action_buttons = array(
 	array(
@@ -244,65 +244,92 @@ $action_buttons = array(
 	),
 	array(
 		"function" => "parent.$.colorbox.close();",
-		"span" => "id='printtext'",
-		"text" => $langs->trans("Cancel"),
+		"span" => "id='printtext' style='font-weight: bold; font-size: 18pt;'",
+		"text" => "X",
 	    "class" => "poscolordelete"
 	),
 );
 $numpad = $conf->global->TAKEPOS_NUMPAD;
+
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '7' : '10').');">' . ($numpad == 0 ? '7' : '10') . '</button>';
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '8' : '20').');">' . ($numpad == 0 ? '8' : '20') . '</button>';
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '9' : '50').');">' . ($numpad == 0 ? '9' : '50') . '</button>';
 ?>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "7"; else print "10"; ?>);"><?php if ($numpad == 0) print "7"; else print "10"; ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "8"; else print "20"; ?>);"><?php if ($numpad == 0) print "8"; else print "20"; ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "9"; else print "50"; ?>);"><?php if ($numpad == 0) print "9"; else print "50"; ?></button>
 <?php if (count($paiements) > 0) {
     $paycode = $paiements[0]->code;
-    if ($paycode == 'LIQ') $paycode = 'cash';
-    if ($paycode == 'CB')  $paycode = 'card';
-    if ($paycode == 'CHQ') $paycode = 'cheque';
-    ?>
-<button type="button" class="calcbutton2" onclick="Validate('<?php echo $langs->trans($paycode); ?>');"><?php echo $langs->trans("PaymentTypeShort".$paiements[0]->code); ?></button>
-<?php } else { ?>
-<button type="button" class="calcbutton2"><?php echo $langs->trans("NoPaimementModesDefined"); ?></button>
-<?php } ?>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "4"; else print "1"; ?>);"><?php if ($numpad == 0) print "4"; else print "1"; ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "5"; else print "2"; ?>);"><?php if ($numpad == 0) print "5"; else print "2"; ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "6"; else print "5"; ?>);"><?php if ($numpad == 0) print "6"; else print "5"; ?></button>
+	$payIcon = '';
+	if ($paycode == 'LIQ') {
+		$paycode = 'cash';
+		$payIcon = 'coins';
+	} elseif ($paycode == 'CB') {
+		$paycode = 'card';
+		$payIcon = 'credit-card';
+	} elseif ($paycode == 'CHQ') {
+		$paycode = 'cheque';
+		$payIcon = 'money-check';
+	}
+
+	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">' . (!empty($payIcon) ? '<span class="fa fa-2x fa-' . $payIcon . '"></span>' : $langs->trans("PaymentTypeShort".$paiements[0]->code)) . '</button>';
+
+} else {
+	print '<button type="button" class="calcbutton2">' . $langs->trans("NoPaimementModesDefined") . '</button>';
+}
+
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '4' : '1').');">' . ($numpad == 0 ? '4' : '1') . '</button>';
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '5' : '2').');">' . ($numpad == 0 ? '5' : '2') . '</button>';
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '6' : '5').');">' . ($numpad == 0 ? '6' : '5') . '</button>';
+?>
 <?php if (count($paiements) > 1) {
     $paycode = $paiements[1]->code;
-    if ($paycode == 'LIQ') $paycode = 'cash';
-    if ($paycode == 'CB')  $paycode = 'card';
-    if ($paycode == 'CHQ') $paycode = 'cheque';
-    ?>
-<button type="button" class="calcbutton2" onclick="Validate('<?php echo $langs->trans($paycode); ?>');"><?php echo $langs->trans("PaymentTypeShort".$paiements[1]->code); ?></button>
-<?php } else {
-    $button = array_pop($action_buttons);
-    ?>
-	<button type="button" class="calcbutton2" onclick="<?php echo $button["function"]; ?>"><span <?php echo $button["span"]; ?>><?php echo $button["text"]; ?></span></button>
-<?php } ?>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "1"; else print "0.10"; ?>);"><?php if ($numpad == 0) print "1"; else print "0.10"; ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "2"; else print "0.20"; ?>);"><?php if ($numpad == 0) print "2"; else print "0.20"; ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "3"; else print "0.50"; ?>);"><?php if ($numpad == 0) print "3"; else print "0.50"; ?></button>
+	$payIcon = '';
+	if ($paycode == 'LIQ') {
+		$paycode = 'cash';
+		$payIcon = 'coins';
+	} elseif ($paycode == 'CB') {
+		$paycode = 'card';
+		$payIcon = 'credit-card';
+	} elseif ($paycode == 'CHQ') {
+		$paycode = 'cheque';
+		$payIcon = 'money-check';
+	}
+
+	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">'. (!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.'"></span>' : $langs->trans("PaymentTypeShort".$paiements[1]->code)) . '</button>';
+} else {
+	$button = array_pop($action_buttons);
+	print '<button type="button" class="calcbutton2" onclick="' . $button["function"] . '"><span ' . $button["span"] . '>' . $button["text"] . '</span></button>';
+}
+
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '1' : '0.10').');">' . ($numpad == 0 ? '1' : '0.10') . '</button>';
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '2' : '0.20').');">' . ($numpad == 0 ? '2' : '0.20') . '</button>';
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '3' : '0.50').');">' . ($numpad == 0 ? '3' : '0.50') . '</button>';
+?>
 <?php if (count($paiements) > 2) {
     $paycode = $paiements[2]->code;
-    if ($paycode == 'LIQ') $paycode = 'cash';
-    if ($paycode == 'CB')  $paycode = 'card';
-    if ($paycode == 'CHQ') $paycode = 'cheque';
-    ?>
-<button type="button" class="calcbutton2" onclick="Validate('<?php echo $langs->trans($paycode); ?>');"><?php echo $langs->trans("PaymentTypeShort".$paiements[2]->code); ?></button>
-<?php } else {
+	$payIcon = '';
+	if ($paycode == 'LIQ') {
+		$paycode = 'cash';
+		$payIcon = 'coins';
+	} elseif ($paycode == 'CB') {
+		$paycode = 'card';
+		$payIcon = 'credit-card';
+	} elseif ($paycode == 'CHQ') {
+		$paycode = 'cheque';
+		$payIcon = 'money-check';
+	}
+
+	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">' . (!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.'"></span>' : $langs->trans("PaymentTypeShort".$paiements[2]->code)) . '</button>';
+} else {
     $button = array_pop($action_buttons);
-    ?>
-	<button type="button" class="calcbutton2" onclick="<?php echo $button["function"]; ?>"><span <?php echo $button["span"]; ?>><?php echo $button["text"]; ?></span></button>
-<?php } ?>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "0"; else print "0.01"; ?>);"><?php if ($numpad == 0) print "0"; else print "0.01"; ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "'000'"; else print "0.02"; ?>);"><?php if ($numpad == 0) print "000"; else print "0.02"; ?></button>
-<button type="button" class="calcbutton" onclick="addreceived(<?php if ($numpad == 0) print "'.'"; else print "0.05"; ?>);"><?php if ($numpad == 0) print "."; else print "0.05"; ?></button>
-<?php
+	print '<button type="button" class="calcbutton2" onclick="'.$button["function"].'"><span '.$button["span"].'>' . $button["text"] . '</span></button>';
+}
+
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '0' : '0.01').');">' . ($numpad == 0 ? '0' : '0.01') . '</button>';
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '\'000\'' : '0.02').');">' . ($numpad == 0 ? '000' : '0.02') . '</button>';
+print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad == 0 ? '\'.\'' : '0.05').');">' . ($numpad == 0 ? '.' : '0.05') . '</button>';
+
 $i = 3;
 while ($i < count($paiements)) {
-    ?>
-<button type="button" class="calcbutton2" onclick="Validate('<?php echo $langs->trans($paiements[$i]->code); ?>');"><?php echo $langs->trans("PaymentTypeShort".$paiements[$i]->code); ?></button>
-    <?php
+	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paiements[$i]->code).'\');">' . $langs->trans("PaymentTypeShort".$paiements[$i]->code) . '</button>';
 	$i = $i + 1;
 }
 
@@ -320,9 +347,7 @@ if ($conf->global->TAKEPOS_ENABLE_SUMUP) {
 $class = ($i == 3) ? "calcbutton3" : "calcbutton2";
 foreach ($action_buttons as $button) {
     $newclass = $class.($button["class"] ? " ".$button["class"] : "");
-    ?>
-	<button type="button" class="<?php echo $newclass; ?>" onclick="<?php echo $button["function"]; ?>"><span <?php echo $button["span"]; ?>><?php echo $button["text"]; ?></span></button>
-    <?php
+	print '<button type="button" class="'.$newclass.'" onclick="'.$button["function"].'"><span '.$button["span"].'>'.$button["text"].'</span></button>';
 }
 ?>
 </div>

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -260,13 +260,13 @@ print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad 
 	$payIcon = '';
 	if ($paycode == 'LIQ') {
 		$paycode = 'cash';
-		$payIcon = 'coins';
+		if (!empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON))	$payIcon = 'coins';
 	} elseif ($paycode == 'CB') {
 		$paycode = 'card';
-		$payIcon = 'credit-card';
+		if (!empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON))	$payIcon = 'credit-card';
 	} elseif ($paycode == 'CHQ') {
 		$paycode = 'cheque';
-		$payIcon = 'money-check';
+		if (!empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON))	$payIcon = 'money-check';
 	}
 
 	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">' . (!empty($payIcon) ? '<span class="fa fa-2x fa-' . $payIcon . '"></span>' : $langs->trans("PaymentTypeShort".$paiements[0]->code)) . '</button>';
@@ -283,13 +283,13 @@ print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad 
 	$payIcon = '';
 	if ($paycode == 'LIQ') {
 		$paycode = 'cash';
-		$payIcon = 'coins';
+		if (!empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON))	$payIcon = 'coins';
 	} elseif ($paycode == 'CB') {
 		$paycode = 'card';
-		$payIcon = 'credit-card';
+		if (!empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON))	$payIcon = 'credit-card';
 	} elseif ($paycode == 'CHQ') {
 		$paycode = 'cheque';
-		$payIcon = 'money-check';
+		if (!empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON))	$payIcon = 'money-check';
 	}
 
 	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">'. (!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.'"></span>' : $langs->trans("PaymentTypeShort".$paiements[1]->code)) . '</button>';
@@ -307,13 +307,13 @@ print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad 
 	$payIcon = '';
 	if ($paycode == 'LIQ') {
 		$paycode = 'cash';
-		$payIcon = 'coins';
+		if (!empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON))	$payIcon = 'coins';
 	} elseif ($paycode == 'CB') {
 		$paycode = 'card';
-		$payIcon = 'credit-card';
+		if (!empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON))	$payIcon = 'credit-card';
 	} elseif ($paycode == 'CHQ') {
 		$paycode = 'cheque';
-		$payIcon = 'money-check';
+		if (!empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON))	$payIcon = 'money-check';
 	}
 
 	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">' . (!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.'"></span>' : $langs->trans("PaymentTypeShort".$paiements[2]->code)) . '</button>';

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -270,7 +270,6 @@ print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad 
 	}
 
 	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">' . (!empty($payIcon) ? '<span class="fa fa-2x fa-' . $payIcon . '"></span>' : $langs->trans("PaymentTypeShort".$paiements[0]->code)) . '</button>';
-
 } else {
 	print '<button type="button" class="calcbutton2">' . $langs->trans("NoPaimementModesDefined") . '</button>';
 }


### PR DESCRIPTION
NEW add icon on payment buttons in cash desk
- replace payment label by icon (some payment labels are out of the button)
- replace "cancel" translation (too large for button) by "X" letter
- fix CSS on payment buttons (more responsive)

![image](https://user-images.githubusercontent.com/45359511/76303913-c49ca880-62c2-11ea-878b-0edf07e3e380.png)

