### PR TITLE
New takepos search on keycode

### DIFF
--- a/htdocs/takepos/takepos.php
+++ b/htdocs/takepos/takepos.php
@@ -473,7 +473,7 @@ function Search2(keyCodeForEnter) {
 				$("#prodiv" + i).data("iscat", 0);
 			}
 		}).always(function (data) {
-			if (data.length == 1) ClickProduct(0);
+			if ($('#search').val().length > 0 && data.length == 1) ClickProduct(0);
 		});
 	}
 }

--- a/htdocs/takepos/takepos.php
+++ b/htdocs/takepos/takepos.php
@@ -446,28 +446,36 @@ function New() {
  */
 function Search2(keyCodeForEnter) {
 	console.log("Search2 Call ajax search to replace products");
-	if(window.event.keyCode == keyCodeForEnter) var key=13;
-	pageproducts=0;
-	jQuery(".wrapper2 .catwatermark").hide();
-	$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=search&term='+$('#search').val(), function(data) {
-		for (i = 0; i < <?php echo $MAXPRODUCT ?>; i++) {
-			if (typeof (data[i]) == "undefined"){
-				$("#prodesc"+i).text("");
-				$("#proimg"+i).attr("src","genimg/empty.png");
-                $("#prodiv"+i).data("rowid","");
-				continue;
+
+	var search = false;
+	var eventKeyCode = window.event.keyCode;
+	if (typeof keyCodeForEnter === 'undefined' || eventKeyCode == keyCodeForEnter) {
+		search = true;
+	}
+
+	if (search === true) {
+		pageproducts = 0;
+		jQuery(".wrapper2 .catwatermark").hide();
+		$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=search&term=' + $('#search').val(), function (data) {
+			for (i = 0; i < <?php echo $MAXPRODUCT ?>; i++) {
+				if (typeof (data[i]) == "undefined") {
+					$("#prodesc" + i).text("");
+					$("#proimg" + i).attr("src", "genimg/empty.png");
+					$("#prodiv" + i).data("rowid", "");
+					continue;
+				}
+				var titlestring = '<?php echo dol_escape_js($langs->transnoentities('Ref') . ': '); ?>' + data[i]['ref'];
+				$("#prodesc" + i).text(data[i]['label']);
+				$("#prodivdesc" + i).show();
+				$("#proimg" + i).attr("title", titlestring);
+				$("#proimg" + i).attr("src", "genimg/index.php?query=pro&id=" + data[i]['rowid']);
+				$("#prodiv" + i).data("rowid", data[i]['rowid']);
+				$("#prodiv" + i).data("iscat", 0);
 			}
-			var titlestring = '<?php echo dol_escape_js($langs->transnoentities('Ref').': '); ?>'+data[i]['ref'];
-			$("#prodesc"+i).text(data[i]['label']);
-			$("#prodivdesc"+i).show();
-			$("#proimg"+i).attr("title", titlestring);
-			$("#proimg"+i).attr("src", "genimg/index.php?query=pro&id="+data[i]['rowid']);
-			$("#prodiv"+i).data("rowid", data[i]['rowid']);
-			$("#prodiv"+i).data("iscat", 0);
-		}
-	}).always(function(data) {
-		if(key==13 && data.length==1) ClickProduct(0);
-  });
+		}).always(function (data) {
+			if (eventKeyCode == keyCodeForEnter && data.length == 1) ClickProduct(0);
+		});
+	}
 }
 
 function Edit(number) {
@@ -655,7 +663,7 @@ $( document ).ready(function() {
 <body class="bodytakepos" style="overflow: hidden;">
 <?php
 print '<div class="hidden" id="dialog-info" title="TakePOS">'.$langs->trans('TerminalSelect').'</div>';
-$keyCodeForEnter = $conf->global->{'CASHDESK_READER_KEYCODE_FOR_ENTER'.$_SESSION['takeposterminal']} > 0 ? $conf->global->{'CASHDESK_READER_KEYCODE_FOR_ENTER'.$_SESSION['takeposterminal']} : 13;
+$keyCodeForEnter = $conf->global->{'CASHDESK_READER_KEYCODE_FOR_ENTER'.$_SESSION['takeposterminal']} > 0 ? $conf->global->{'CASHDESK_READER_KEYCODE_FOR_ENTER'.$_SESSION['takeposterminal']} : '';
 ?>
 <div class="container">
 

--- a/htdocs/takepos/takepos.php
+++ b/htdocs/takepos/takepos.php
@@ -473,7 +473,7 @@ function Search2(keyCodeForEnter) {
 				$("#prodiv" + i).data("iscat", 0);
 			}
 		}).always(function (data) {
-			if (eventKeyCode == keyCodeForEnter && data.length == 1) ClickProduct(0);
+			if (data.length == 1) ClickProduct(0);
 		});
 	}
 }


### PR DESCRIPTION
NEW search on key code "enter" if defined in cash desk
- if not defined it will searh on each key pressed
- if defined it will search only on key code (ex : 13 for key "enter")

It avoids to have several searches at the same time when you scan a product with a barcode reader (it spends a long time to load products with pictures).