### PR TITLE
FIX - Clone Fourn Command, add line's extrafields

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1178,7 +1178,7 @@ class CommandeFournisseur extends CommonOrder
                         false,
 	                    $this->lines[$i]->date_start,
                         $this->lines[$i]->date_end,
-                        0,
+                        $this->lines[$i]->array_options,
                         $this->lines[$i]->fk_unit
 	                );
 	                if ($result < 0)

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1288,6 +1288,10 @@ class CommandeFournisseur extends CommonOrder
 
 		$this->db->begin();
 
+        // get extrafields so they will be clone
+        foreach($this->lines as $line)
+            $line->fetch_optionals($line->rowid);
+
 		// Load source object
 		$objFrom = clone $this;
 


### PR DESCRIPTION
# Fix Clone Fourn Command, add line's extrafields
If we clone a supplier command, we clone line's extrafields too. Like propal, invoice...