### PR TITLE
FIX 10.0 - status missing from last customer invoices box when using MAIN_STATUS_USES_CSS

### DIFF
--- a/htdocs/core/boxes/modules_boxes.php
+++ b/htdocs/core/boxes/modules_boxes.php
@@ -332,13 +332,13 @@ class ModeleBoxes // Can't be abtract as it is instantiated to build "empty" box
                             if (! empty($contents[$i][$j]['maxlength'])) $maxlength=$contents[$i][$j]['maxlength'];
 
                             if ($maxlength) $textwithnotags=dol_trunc($textwithnotags, $maxlength);
-                            if (preg_match('/^<img/i', $text) || preg_match('/^<div/i', $text) || ! empty($contents[$i][$j]['asis'])) $out.= $text;   // show text with no html cleaning
+                            if (preg_match('/^<(img|div|span)/i', $text) || ! empty($contents[$i][$j]['asis'])) $out.= $text;   // show text with no html cleaning
                             else $out.= $textwithnotags;                // show text with html cleaning
 
                             // End Url
                             if (! empty($contents[$i][$j]['url'])) $out.= '</a>';
 
-                            if (preg_match('/^<img/i', $text2) || preg_match('/^<div/i', $text2) || ! empty($contents[$i][$j]['asis2'])) $out.= $text2; // show text with no html cleaning
+                            if (preg_match('/^<(img|div|span)/i', $text2) || ! empty($contents[$i][$j]['asis2'])) $out.= $text2; // show text with no html cleaning
                             else $out.= $text2withnotags;               // show text with html cleaning
 
                             if (! empty($textnoformat)) $out.= "\n".$textnoformat."\n";


### PR DESCRIPTION
# Bug description
With the hidden conf `MAIN_STATUS_USES_CSS` enabled, the status of invoices is not shown in the box on the home page. The status column appears to be empty.

# Cause
The option causes the picto to be displayed as a `<span class="badge…">` tag (using Font Awesome) instead of an `<img>` tag. There is a mechanism that strips all markup from box cell text (and truncates it at `$maxlength`), unless it is an `<img>` or `<div>` tag.

Since in this case, the cell text is only markup, it ends up printing an empty cell.

# Fix
This commit simply adds `<span>` to the "whitelisted" tags. This way, the whole cell text is printed including markup. The fix is based on commit db651a607d07c856e65ef9906828c97b0cc13e85 (present in v11.0).