### PR TITLE
FIX 10.0 - missing translations for "orders" homepage "orders" box

### DIFF
--- a/htdocs/core/boxes/box_commandes.php
+++ b/htdocs/core/boxes/box_commandes.php
@@ -72,6 +72,7 @@ class box_commandes extends ModeleBoxes
     public function loadBox($max = 5)
     {
         global $user, $langs, $db, $conf;
+        $langs->load('orders');
 
         $this->max = $max;
 


### PR DESCRIPTION
# Issue description
In the "Last 10 customer orders" widget, the status tooltip shows "StatusOrderDraft" / "StatusOrderProcessed" instead of the translation.

# Fix
The fix simply loads the translations when the widget is loaded.