### PR TITLE
FIX : missing class declaration

### DIFF
--- a/htdocs/core/boxes/box_shipments.php
+++ b/htdocs/core/boxes/box_shipments.php
@@ -77,6 +77,7 @@ class box_shipments extends ModeleBoxes
         $this->max = $max;
 
         include_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php';
+        include_once DOL_DOCUMENT_ROOT.'/commande/class/commande.class.php';
         include_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
 
         $shipmentstatic = new Expedition($this->db);


### PR DESCRIPTION
was leading to error on index page (or blank screen if $dolibarr_main_prod = 1)