### PR TITLE
NEW add VAT rates on free zone in cash desk

### DIFF
--- a/htdocs/takepos/css/pos.css.php
+++ b/htdocs/takepos/css/pos.css.php
@@ -50,7 +50,6 @@ top_httphead('text/css');
 // Important: Following code is to avoid page request by browser and PHP CPU at each Dolibarr page access.
 if (empty($dolibarr_nocache)) header('Cache-Control: max-age=10800, public, must-revalidate');
 else header('Cache-Control: no-cache');
-header('Cache-Control: no-cache');
 
 
 require DOL_DOCUMENT_ROOT.'/theme/'.$conf->theme.'/theme_vars.inc.php';
@@ -120,7 +119,7 @@ button.calcbutton2 {
 	width: calc(25% - 2px);
 	height: calc(25% - 2px);
 	font-weight: bold;
-	font-size: 10pt;
+	font-size: 8pt;
 	margin: 1px;
 }
 

--- a/htdocs/takepos/css/pos.css.php
+++ b/htdocs/takepos/css/pos.css.php
@@ -50,6 +50,7 @@ top_httphead('text/css');
 // Important: Following code is to avoid page request by browser and PHP CPU at each Dolibarr page access.
 if (empty($dolibarr_nocache)) header('Cache-Control: max-age=10800, public, must-revalidate');
 else header('Cache-Control: no-cache');
+header('Cache-Control: no-cache');
 
 
 require DOL_DOCUMENT_ROOT.'/theme/'.$conf->theme.'/theme_vars.inc.php';
@@ -119,7 +120,7 @@ button.calcbutton2 {
 	width: calc(25% - 2px);
 	height: calc(25% - 2px);
 	font-weight: bold;
-	font-size: 8pt;
+	font-size: 10pt;
 	margin: 1px;
 }
 
@@ -157,6 +158,19 @@ button.actionbutton {
 	height: calc(25% - 2px);
 	margin: 1px;
    	border-width: 0;
+}
+
+button.item_value {
+	background: #bbbbbb;
+	border: #000000 1px solid;
+	border-radius: 4px;
+	padding: 8px;
+}
+
+button.item_value.selected {
+	background: #ffffff;
+	color: #000000;
+	font-weight: bold;
 }
 
 div[aria-describedby="dialog-info"] button:before {

--- a/htdocs/takepos/freezone.php
+++ b/htdocs/takepos/freezone.php
@@ -16,7 +16,7 @@
  */
 
 /**
- *	\file       htdocs/takepos/floors.php
+ *	\file       htdocs/takepos/freezone.php
  *	\ingroup    takepos
  *	\brief      Popup to enter a free line
  */
@@ -32,6 +32,11 @@ if (!defined('NOREQUIREHTML'))		define('NOREQUIREHTML', '1');
 if (!defined('NOREQUIREAJAX'))		define('NOREQUIREAJAX', '1');
 
 require '../main.inc.php'; // Load $user and permissions
+require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+
+global $mysoc;
 
 $langs->loadLangs(array("bills", "cashdesk"));
 
@@ -40,6 +45,20 @@ $place = (GETPOST('place', 'int') > 0 ? GETPOST('place', 'int') : 0); // $place 
 $idline = GETPOST('idline', 'int');
 $action = GETPOST('action', 'alpha');
 
+// get invoice
+$invoice = new Facture($db);
+if ($place > 0) {
+	$invoice->fetch($place);
+} else {
+	$invoice->fetch('', '(PROV-POS'.$_SESSION['takeposterminal'].'-'.$place.')');
+}
+
+// get default vat rate
+$constforcompanyid = 'CASHDESK_ID_THIRDPARTY'.$_SESSION['takeposterminal'];
+$soc = new Societe($db);
+if ($invoice->socid > 0) $soc->fetch($invoice->socid);
+else $soc->fetch($conf->global->$constforcompanyid);
+$vatRateDefault = get_default_tva($mysoc, $soc);
 
 /*
  * View
@@ -48,18 +67,34 @@ $action = GETPOST('action', 'alpha');
 $arrayofcss = array('/takepos/css/pos.css.php');
 $arrayofjs = array();
 
-top_htmlhead($head, $title, $disablejs, $disablehead, $arrayofjs, $arrayofcss);
-
+top_htmlhead($head, '', 0, 0, $arrayofjs, $arrayofcss);
 ?>
 <script>
-function Save(){
-	$.get( "invoice.php", { action: "<?php echo $action; ?>", place: "<?php echo $place; ?>", desc:$('#desc').val(), number:$('#number').val()} );
-	parent.$.colorbox.close();
-}
+	var vatRate = '<?php echo dol_escape_js($vatRateDefault); ?>';
 
-$( document ).ready(function() {
-    $('#desc').focus()
-});
+	/**
+	 * Apply new VAT rate
+	 *
+	 * @param   {string}    id          VAT id
+	 * @param   {string}    rate        VAT rate
+	 */
+	function ApplyVATRate(id, rate) {
+		vatRate = rate;
+		jQuery('button.vat_rate').removeClass('selected');
+		jQuery('#vat_rate_' + id).addClass('selected');
+	}
+
+	/**
+	 * Save (validate)
+	 */
+	function Save() {
+		$.get( "invoice.php", { action: "<?php echo $action; ?>", place: "<?php echo $place; ?>", desc:$('#desc').val(), number:$('#number').val(), tva_tx: vatRate} );
+		parent.$.colorbox.close();
+	}
+
+	$( document ).ready(function() {
+		$('#desc').focus()
+	});
 </script>
 </head>
 <body>
@@ -72,6 +107,21 @@ if ($action == "addnote") echo '<input type="hidden" id="number" name="number" v
 ?>
 <input type="hidden" name="place" class="takepospay" value="<?php echo $place; ?>">
 <input type="button" class="button takepospay clearboth" value="OK" onclick="Save();">
+<?php
+if ($action == 'freezone') {
+	require_once DOL_DOCUMENT_ROOT . '/core/class/html.form.class.php';
+
+	$form = new Form($db);
+	$num = $form->load_cache_vatrates("'" . $mysoc->country_code . "'");
+	if ($num > 0) {
+		print '<br><br>';
+		print $langs->trans('VAT') . ' : ';
+		foreach ($form->cache_vatrates as $rate) {
+			print '<button type="button" class="button item_value vat_rate' . ($rate['txtva'] == $vatRateDefault ? ' selected' : '') . '" id="vat_rate_' . $rate['rowid'] . '" onclick="ApplyVATRate(\'' . $rate['rowid'] . '\', \'' . $rate['txtva'] .'\');">' . $rate['txtva'] . ' %</button>';
+		}
+	}
+}
+?>
 </center>
 
 </body>

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -37,6 +37,8 @@ require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 require_once DOL_DOCUMENT_ROOT.'/compta/paiement/class/paiement.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 
+global $mysoc;
+
 $langs->loadLangs(array("companies", "commercial", "bills", "cashdesk", "stocks"));
 
 $id = GETPOST('id', 'int');
@@ -327,7 +329,12 @@ if ($action == "freezone") {
     $customer = new Societe($db);
     $customer->fetch($invoice->socid);
 
-    $tva_tx = get_default_tva($mysoc, $customer);
+	$tva_tx = GETPOST('tva_tx', 'alpha');
+	if ($tva_tx != '') {
+		$tva_tx = price2num($tva_tx);
+	} else {
+		$tva_tx = get_default_tva($mysoc, $customer);
+	}
 
     // Local Taxes
     $localtax1_tx = get_localtax($tva_tx, 1, $customer, $mysoc, $tva_npr);


### PR DESCRIPTION
NEW add VAT rates on free zone in cash desk : 
- add all VAT rates (determined by coutry code of configured company) on free zone for products/services
- you can choice VAT rate if needed (the default VAT rate is selected by default)

![image](https://user-images.githubusercontent.com/45359511/76839926-ab51aa00-6836-11ea-943b-2c003d4a7f98.png)
