### PR TITLE
FIX get remain to pay with rounding decimals

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -103,7 +103,7 @@ abstract class CommonInvoice extends CommonObject
 	    $alreadypaid+=$this->getSommePaiement($multicurrency);
 	    $alreadypaid+=$this->getSumDepositsUsed($multicurrency);
 	    $alreadypaid+=$this->getSumCreditNotesUsed($multicurrency);
-    	return $this->total_ttc - $alreadypaid;
+		return price2num($this->total_ttc, 'MT') - price2num($alreadypaid, 'MT');
 	}
 
 	/**


### PR DESCRIPTION
FIX get remain to pay with rounding decimals
- it compares two decimal numbers with the same rounding (to avoid to have a little difference between two same amounts using float and double values)
- see "https://www.php.net/manual/fr/language.types.float.php"

You can reproduce in the cash desk with these products lines :
- "Product A" costs "5,90 €" TTC (TVA = 0%)
- "Product B" costs "6,90 €" TTC (TVA = 0%)
- "Product B" costs "6,90 €" TTC (TVA = 0%)

![image](https://user-images.githubusercontent.com/45359511/77530069-0d428d00-6e91-11ea-94a7-644f9f3b9ba3.png)

And then you enter all totoal amount "19,70 €" paid by credit card for example and you will obtain a message "Remain to pay : 0.0000 €" even if all amount was paid.