### PR TITLE
FIX Approved users only shown in the filter of GRH plugin

### DIFF
--- a/htdocs/holiday/list.php
+++ b/htdocs/holiday/list.php
@@ -517,11 +517,19 @@ if ($resql)
 		if ($user->rights->holiday->read_all)
 		{
 		    print '<td class="liste_titre maxwidthonsmartphone left">';
-		    $validator = new UserGroup($db);
-		    $excludefilter = $user->admin ? '' : 'u.rowid <> '.$user->id;
-		    $valideurobjects = $validator->listUsersForGroup($excludefilter);
+
+                    $users = new User($db);
+                    $valideurobjects = $users->get_full_tree();
+
 		    $valideurarray = array();
-		    foreach ($valideurobjects as $val) $valideurarray[$val->id] = $val->id;
+                    foreach ($valideurobjects as $val) {
+                        // Check the right for each returned users if valid we add it to the approver
+                        $valideur_user  = new User($db);
+                        $valideur_user->fetch($val['id']);
+                        $valideur_user->getrights('holiday');
+                        if($valideur_user->rights->holiday->approve) $valideurarray[$valideur_user->id] = $valideur_user->id;
+                    }
+
 		    print $form->select_dolusers($search_valideur, "search_valideur", 1, "", 0, $valideurarray, '', 0, 0, 0, $morefilter, 0, '', 'maxwidth200');
 		    print '</td>';
 		}

--- a/htdocs/holiday/list.php
+++ b/htdocs/holiday/list.php
@@ -522,13 +522,13 @@ if ($resql)
                     $valideurobjects = $users->get_full_tree();
 
 		    $valideurarray = array();
-                    foreach ($valideurobjects as $val) {
-                        // Check the right for each returned users if valid we add it to the approver
-                        $valideur_user  = new User($db);
-                        $valideur_user->fetch($val['id']);
-                        $valideur_user->getrights('holiday');
-                        if($valideur_user->rights->holiday->approve) $valideurarray[$valideur_user->id] = $valideur_user->id;
-                    }
+			foreach ($valideurobjects as $val) {
+				// Check the right for each returned users if valid we add it to the approver
+				$valideur_user  = new User($db);
+				$valideur_user->fetch($val['id']);
+				$valideur_user->getrights('holiday');
+				if($valideur_user->rights->holiday->approve) $valideurarray[$valideur_user->id] = $valideur_user->id;
+			}
 
 		    print $form->select_dolusers($search_valideur, "search_valideur", 1, "", 0, $valideurarray, '', 0, 0, 0, $morefilter, 0, '', 'maxwidth200');
 		    print '</td>';


### PR DESCRIPTION
# FIX Approved users only shown in the filter of GRH plugin

Hello,

In the GRH plugin the users shown in the "approve" filter were everyone  instead of only the users with the "approved" right.

I used the get_full_tree method to obtain all the users and from that I grab the rights for each users.
If they have the right to approved holidays I add them in $valideurarray

If there is a better way to do it, don't hesitate to modify this PR.

Cheers.