### PR TITLE
Fix function to create a task

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -158,7 +158,6 @@ class Task extends CommonObject
 		$sql .= "entity";
 		$sql .= ", fk_projet";
 		$sql .= ", ref";
-		$sql .= ", entity";
 		$sql .= ", fk_task_parent";
 		$sql .= ", label";
 		$sql .= ", description";
@@ -172,7 +171,6 @@ class Task extends CommonObject
 		$sql .= $conf->entity;
 		$sql .= ", ".$this->fk_project;
 		$sql .= ", ".(!empty($this->ref) ? "'".$this->db->escape($this->ref)."'" : 'null');
-		$sql .= ", ".$conf->entity;
 		$sql .= ", ".$this->fk_task_parent;
 		$sql .= ", '".$this->db->escape($this->label)."'";
 		$sql .= ", '".$this->db->escape($this->description)."'";


### PR DESCRIPTION
Fixes the function to create a task.

The change introduced in https://github.com/Dolibarr/dolibarr/pull/13416 results in sending the `entity` twice in the sql statement.