### PR TITLE
NEW: Cash Control in TakePOS

### DIFF
--- a/htdocs/compta/cashcontrol/cashcontrol_card.php
+++ b/htdocs/compta/cashcontrol/cashcontrol_card.php
@@ -54,6 +54,12 @@ $pageprev = $page - 1;
 $pagenext = $page + 1;
 if (!$sortfield) $sortfield = 'rowid';
 if (!$sortorder) $sortorder = 'ASC';
+$contextpage = GETPOST('contextpage', 'aZ') ?GETPOST('contextpage', 'aZ') : 'thirdpartylist';
+
+if ($contextpage == 'takepos')
+{
+    $_GET['optioncss'] = 'print';
+}
 
 // Security check
 if (!$user->rights->cashdesk->run && !$user->rights->takepos->run)
@@ -178,6 +184,13 @@ elseif ($action == "add")
 			$action = "view";
 		}
 	}
+	if ($contextpage == 'takepos'){
+		print "
+		<script>
+		parent.location.href='../../takepos/index.php?place='+parent.place;
+		</script>";
+		exit;
+	}
 }
 
 if ($action == "valid")	// validate = close
@@ -211,6 +224,13 @@ if ($action == "valid")	// validate = close
 		$db->commit();
 	}
 
+	if ($contextpage == 'takepos'){
+		print "
+		<script>
+		parent.location.href='../../takepos/index.php?place='+parent.place;
+		</script>";
+		exit;
+	}
     $action = "view";
 }
 
@@ -364,6 +384,7 @@ if ($action == "create" || $action == "start" || $action == 'close')
 
 		print '<form method="POST" action="'.$_SERVER["PHP_SELF"].'">';
 	    print '<input type="hidden" name="token" value="' . newToken() . '">';
+		if ($contextpage == 'takepos') print '<input type="hidden" name="contextpage" value="takepos">';
 	    if ($action == 'start' && GETPOST('posnumber', 'int') != '' && GETPOST('posnumber', 'int') != '' && GETPOST('posnumber', 'int') != '-1')
 	    {
 		    print '<input type="hidden" name="action" value="add">';
@@ -668,7 +689,7 @@ if (empty($action) || $action == "view" || $action == "close")
 
 			if ($object->status == CashControl::STATUS_DRAFT)
 			{
-				print '<div class="inline-block divButAction"><a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$id.'&amp;action=close">'.$langs->trans('Close').'</a></div>';
+				print '<div class="inline-block divButAction"><a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$id.'&amp;action=close&amp;contextpage='.$contextpage.'">'.$langs->trans('Close').'</a></div>';
 
 				print '<div class="inline-block divButAction"><a class="butActionDelete" href="'.$_SERVER["PHP_SELF"].'?id='.$id.'&amp;action=confirm_delete">'.$langs->trans('Delete').'</a></div>';
 			} else {
@@ -677,10 +698,11 @@ if (empty($action) || $action == "view" || $action == "close")
 
 			print '</div>';
 
-			print '<center><iframe src="report.php?id='.$id.'" width="60%" height="800"></iframe></center>';
+			if ($contextpage != 'takepos') print '<center><iframe src="report.php?id='.$id.'" width="60%" height="800"></iframe></center>';
 	    } else {
 	    	print '<form method="POST" action="'.$_SERVER["PHP_SELF"].'" name="formclose">';
 	    	print '<input type="hidden" name="token" value="' . newToken() . '">';
+			if ($contextpage == 'takepos') print '<input type="hidden" name="contextpage" value="takepos">';
 	    	if ($action == 'start' && GETPOST('posnumber', 'int') != '' && GETPOST('posnumber', 'int') != '' && GETPOST('posnumber', 'int') != '-1')
 	    	{
 	    		print '<input type="hidden" name="action" value="add">';

--- a/htdocs/langs/en_US/cashdesk.lang
+++ b/htdocs/langs/en_US/cashdesk.lang
@@ -98,3 +98,6 @@ CashDeskRefNumberingModules=Numbering module for cash desk
 CashDeskGenericMaskCodes6 = <br><b>{TN}</b> tag is used to add the terminal number
 TakeposGroupSameProduct=Group same products lines
 StartAParallelSale=Start a new parallel sale
+ControlCashOpening=Control cash box at opening pos
+CloseCashFence=Close cash fence
+CashReport=Cash report

--- a/htdocs/takepos/admin/setup.php
+++ b/htdocs/takepos/admin/setup.php
@@ -370,6 +370,13 @@ if (is_array($formmail->lines_model)) {
 print $form->selectarray('TAKEPOS_EMAIL_TEMPLATE_INVOICE', $arrayofmessagename, $conf->global->TAKEPOS_EMAIL_TEMPLATE_INVOICE, 'None', 1, 0, '', 0, 0, 0, '', '', 1);
 print "</td></tr>\n";
 
+// Control cash box at opening pos
+print '<tr class="oddeven"><td>';
+print $langs->trans('ControlCashOpening');
+print '<td colspan="2">';
+print ajax_constantonoff("TAKEPOS_CONTROL_CASH_OPENING", array(), $conf->entity, 0, 0, 1, 0);
+print "</td></tr>\n";
+
 // Numbering module
 //print '<tr class="oddeven"><td>';
 //print $langs->trans("BillsNumberingModule");

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -50,7 +50,7 @@ if ($setterminal > 0)
 
 $_SESSION["urlfrom"] = '/takepos/index.php';
 
-$langs->loadLangs(array("bills", "orders", "commercial", "cashdesk", "receiptprinter"));
+$langs->loadLangs(array("bills", "orders", "commercial", "cashdesk", "receiptprinter", "banks"));
 
 $categorie = new Categorie($db);
 
@@ -661,6 +661,21 @@ function MoreActions(totalactions){
 	}
 }
 
+function ControlCashOpening()
+{
+    $.colorbox({href:"../compta/cashcontrol/cashcontrol_card.php?action=create&contextpage=takepos", width:"90%", height:"60%", transition:"none", iframe:"true", title:"<?php echo $langs->trans("NewCashFence"); ?>"});
+}
+
+function CloseCashFence(rowid)
+{
+    $.colorbox({href:"../compta/cashcontrol/cashcontrol_card.php?id="+rowid+"&contextpage=takepos", width:"90%", height:"90%", transition:"none", iframe:"true", title:"<?php echo $langs->trans("NewCashFence"); ?>"});
+}
+
+function CashReport(rowid)
+{
+    $.colorbox({href:"../compta/cashcontrol/report.php?id="+rowid+"&contextpage=takepos", width:"60%", height:"90%", transition:"none", iframe:"true", title:"<?php echo $langs->trans("CashReport"); ?>"});
+}
+
 // Popup to select the terminal to use
 function TerminalsDialog()
 {
@@ -707,6 +722,18 @@ $( document ).ready(function() {
 	{
 		if ($conf->global->TAKEPOS_NUM_TERMINALS == "1") $_SESSION["takeposterminal"] = 1;
 		else print "TerminalsDialog();";
+	}
+	if ($conf->global->TAKEPOS_CONTROL_CASH_OPENING)
+	{
+		$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."pos_cash_fence WHERE ";
+		$sql .= "date(date_creation) = CURDATE() ";
+		$sql .= "";
+		$resql = $db->query($sql);
+		if ($resql) {
+			$obj = $db->fetch_object($resql);
+			// If there is no cash control from today open it
+			if ($obj->rowid == null) print "ControlCashOpening();";
+		}
 	}
 	?>
 });
@@ -870,6 +897,20 @@ if ($conf->global->TAKEPOS_PRINT_METHOD == "receiptprinter") {
 		'title' => '<span class="fa fa-receipt paddingrightonly"></span><div class="trunc">'.$langs->trans("DOL_OPEN_DRAWER").'</div>',
 		'action' => 'DolibarrOpenDrawer();',
 	);
+}
+
+$sql = "SELECT rowid, status FROM ".MAIN_DB_PREFIX."pos_cash_fence WHERE ";
+$sql .= "date(date_creation) = CURDATE() ";
+$resql = $db->query($sql);
+if ($resql)
+{
+	$num = $db->num_rows($resql);
+	if ($num)
+	{
+		$obj = $db->fetch_object($resql);
+		$menus[$r++] = array('title'=>'<span class="fas fa-file-invoice-dollar paddingrightonly"></span><div class="trunc">'.$langs->trans("CashReport").'</div>', 'action'=>'CashReport('.$obj->rowid.');');
+		if ($obj->status == 0) $menus[$r++] = array('title'=>'<span class="fas fa-cash-register paddingrightonly"></span><div class="trunc">'.$langs->trans("CloseCashFence").'</div>', 'action'=>'CloseCashFence('.$obj->rowid.');');
+	}
 }
 
 $hookmanager->initHooks(array('takeposfrontend'));


### PR DESCRIPTION
Integrating the cash control in TakePOS in 3 ways:
1. From TakePOS setup can activate to open the cash control box on load TakePOS to open cash
2. If there is an open cash control add a button to print the report.
3. If this cash is in draft mode add a button to close this cash.