### PR TITLE
FIX : Buyprice was updated only if min price for this qty had same qty

### DIFF
--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -428,7 +428,7 @@ class ProductFournisseur extends Product
                 $sql .= " ".($newdefaultvatcode?"'".$this->db->escape($newdefaultvatcode)."'":"null").",";
                 $sql .= " " . $newnpr . ",";
                 $sql .= $conf->entity . ",";
-                $sql .= $delivery_time_days . ",";
+                $sql .= ($delivery_time_days != '' ? $delivery_time_days : 'null') . ",";
                 $sql .= (empty($supplier_reputation) ? 'NULL' : "'" . $this->db->escape($supplier_reputation) . "'") . ",";
                 $sql .= (empty($barcode) ? 'NULL' : "'" . $this->db->escape($barcode) . "'") . ",";
                 $sql .= (empty($fk_barcode_type) ? 'NULL' : "'" . $this->db->escape($fk_barcode_type) . "'");
@@ -447,7 +447,7 @@ class ProductFournisseur extends Product
                 if (! $error && empty($conf->global->PRODUCT_PRICE_SUPPLIER_NO_LOG)) {
                     // Add record into log table
 					// $this->product_fourn_price_id must be set
-                    $result = $this->logPrice($user, $now, $buyprice, $qty, $multicurrency_buyprice, $multicurrency_unitBuyPrice, $multicurrency_tx, $fk_multicurrenc, $multicurrency_code);
+                    $result = $this->logPrice($user, $now, $buyprice, $qty, $multicurrency_buyprice, $multicurrency_unitBuyPrice, $multicurrency_tx, $fk_multicurrency, $multicurrency_code);
                     if ($result < 0) {
                         $error++;
                     }

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -1810,7 +1810,7 @@ class SupplierProposal extends CommonObject
             if(!empty($conf->multicurrency->enabled) && !empty($product->multicurrency_code)) list($fk_multicurrency, $multicurrency_tx) = MultiCurrency::getIdAndTxFromCode($this->db, $product->multicurrency_code);
             $productsupplier->id = $product->fk_product;
 
-            $productsupplier->update_buyprice($product->qty, $product->subprice, $user, 'HT', $this->thirdparty, '', $ref_fourn, $product->tva_tx, 0, 0, 0, $product->info_bits,  '',  '',  array(),  '', $product->multicurrency_subprice,  'HT', $multicurrency_tx, $product->multicurrency_code,  '',  '',  '' );
+            $productsupplier->update_buyprice($product->qty, $product->subprice, $user, 'HT', $this->thirdparty, '', $ref_fourn, $product->tva_tx, 0, 0, 0, $product->info_bits,  '',  '',  array(),  '', $product->multicurrency_subprice,  'HT', $multicurrency_tx, $product->multicurrency_code,  '',  '',  '');
         }
 
         return 1;


### PR DESCRIPTION
# Fix Buyprice was updated only if min price for this qty had same qty
I replaced by update_buyprice funciton to verify well before updating or inserting price.
I fixed missing 'y' on fk_multicurrency
I fixed sql request with ($delivery_time_days != '' ? $delivery_time_days : 'null')

This function is only call if we use hidden conf :  SUPPLIER_PROPOSAL_UPDATE_PRICE_ON_SUPPlIER_PROPOSAL (maybe a conf to show in a nearby future ?)

To explain more : 
_When we make a supplier proposal a buyprice can be create. But if a price exists with same qty, then it was updating the price even if there was different supplier ref or supplier.
So, to uniformize i used product_buyprice function_
