### PR TITLE
On _checkAccessToResource: category -> categorie

### DIFF
--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -231,7 +231,7 @@ class Categories extends DolibarrApi
             throw new RestException(404, 'category not found');
         }
 
-        if (!DolibarrApi::_checkAccessToResource('category', $this->category->id)) {
+        if (!DolibarrApi::_checkAccessToResource('categorie', $this->category->id)) {
             throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
         }
 
@@ -266,7 +266,7 @@ class Categories extends DolibarrApi
             throw new RestException(404, 'category not found');
         }
 
-        if (!DolibarrApi::_checkAccessToResource('category', $this->category->id)) {
+        if (!DolibarrApi::_checkAccessToResource('categorie', $this->category->id)) {
             throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
         }
 
@@ -755,7 +755,7 @@ class Categories extends DolibarrApi
             throw new RestException(404, 'category not found');
         }
 
-		if (!DolibarrApi::_checkAccessToResource('category', $this->category->id)) {
+		if (!DolibarrApi::_checkAccessToResource('categorie', $this->category->id)) {
 			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 


### PR DESCRIPTION
Hi, I found the categories api to be not functioning properly for a regular user with correct rights.
Admins users have no problem to use the api.
Change category tag to categorie fixes the problem.