### PR TITLE
NEW [Allow constants values to be overridden by environment variables]

### DIFF
--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -177,7 +177,7 @@ class Conf
 					} elseif (isset($_ENV['DOLIBARR_' . $key])) {
 						$value=$_ENV['DOLIBARR_' . $key];
 					}
-					
+
 					//if (! defined("$key")) define("$key", $value);	// In some cases, the constant might be already forced (Example: SYSLOG_HANDLERS during install)
 					$this->global->$key = $value;
 

--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -171,6 +171,13 @@ class Conf
 				$value = $objp->value;
 				if ($key)
 				{
+					// Allow constants values to be overridden by environment variables
+					if (isset($_SERVER['DOLIBARR_' . $key])) {
+						$value=$_SERVER['DOLIBARR_' . $key];
+					} elseif (isset($_ENV['DOLIBARR_' . $key])) {
+						$value=$_ENV['DOLIBARR_' . $key];
+					}
+					
 					//if (! defined("$key")) define("$key", $value);	// In some cases, the constant might be already forced (Example: SYSLOG_HANDLERS during install)
 					$this->global->$key = $value;
 


### PR DESCRIPTION
# New [Allow constants values to be overridden by environment variables]

Following [Twelve-Factor App methodology](https://en.wikipedia.org/wiki/Twelve-Factor_App_methodology), configuration that may vary between environments (dev, staging, production, ...) should be stored in environment itself, aka. in environment variables.

This is the less worst implementation i found :)

We may also consider:
- backporting this feature on still maintained versions
- adding this in official constants documentation
- unit testing it

Thx :)