### PR TITLE
Copy extrafields of lines from a draft invoice to an invoice template

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -251,6 +251,23 @@ class FactureRec extends CommonInvoice
 					{
 						$error++;
 					}
+					else {
+					    $objectline = new FactureLigneRec($this->db);
+					    if ($objectline->fetch($result_insert))
+					    {
+					        // Extrafields
+					        if (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED) && method_exists($facsrc->lines[$i], 'fetch_optionals')) {
+					            $facsrc->lines[$i]->fetch_optionals($facsrc->lines[$i]->rowid);
+					            $objectline->array_options = $facsrc->lines[$i]->array_options;
+					        }
+					        
+					        $result = $objectline->insertExtraFields();
+					        if ($result < 0)
+					        {
+					            $error++;
+					        }
+					    }
+					}
 				}
 
 				if (!empty($this->linkedObjectsIds) && empty($this->linked_objects))	// To use new linkedObjectsIds instead of old linked_objects

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -260,7 +260,7 @@ class FactureRec extends CommonInvoice
 					            $facsrc->lines[$i]->fetch_optionals($facsrc->lines[$i]->rowid);
 					            $objectline->array_options = $facsrc->lines[$i]->array_options;
 					        }
-					        
+
 					        $result = $objectline->insertExtraFields();
 					        if ($result < 0)
 					        {


### PR DESCRIPTION
This is a PR to fix explained here: https://github.com/Dolibarr/dolibarr/issues/13474

Extra fields of lines are not copied from a draft invoice to an invoice template.

I created extra fields on lines with the **same key** in :

- contract / subscription line
- invoice line
- template line

When I want to create a recurring invoice from a contract / subscription, extra fields :

- are copied from the contract to the draft invoice
- are missing from the template invoice
- and so are missing in the invoice generated from the template

_NB: this is not the same bug than this one #12361 - which concerns the template itself - here I am talking about extrafields in lines._