### PR TITLE
Fix insert error logged as a delete error

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4409,7 +4409,7 @@ class OrderLine extends CommonOrderLine
 
 			foreach ($this->errors as $errmsg)
 			{
-				dol_syslog(get_class($this)."::delete ".$errmsg, LOG_ERR);
+				dol_syslog(get_class($this)."::insert ".$errmsg, LOG_ERR);
 				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
 			}
 			$this->db->rollback();


### PR DESCRIPTION
# Fix insert error logged as a delete error
Since OrderLine::delete has exactly the same block, I think this comes from a copy-paste that wasn’t edited.
