### PR TITLE
11.0

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -817,7 +817,7 @@ class CMailFile
 				// Switch content encoding to base64 - avoid the doubledot issue with quoted-printable
                 $contentEncoderBase64 = new Swift_Mime_ContentEncoder_Base64ContentEncoder();
                 $this->message->setEncoder($contentEncoderBase64);
-				
+
 				// Create the Mailer using your created Transport
 				$this->mailer = new Swift_Mailer($this->transport);
 

--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -814,6 +814,10 @@ class CMailFile
 				if (!empty($conf->global->$keyforsmtppw)) $this->transport->setPassword($conf->global->$keyforsmtppw);
 				//$smtps->_msgReplyTo  = 'reply@web.com';
 
+				// Switch content encoding to base64 - avoid the doubledot issue with quoted-printable
+                $contentEncoderBase64 = new Swift_Mime_ContentEncoder_Base64ContentEncoder();
+                $this->message->setEncoder($contentEncoderBase64);
+				
 				// Create the Mailer using your created Transport
 				$this->mailer = new Swift_Mailer($this->transport);
 


### PR DESCRIPTION
When sending HTML mail using swiftmailer, the content will be encoded using quoted-printable. We may then encounter the "double dot" issue (doubled dot at the beginning of the line). This can be problematic with broken links to pictures for example.
This PR switches the encoding to base64.