### PR TITLE
FIX - Add function "completeTabsHead" to "addreplace" type hook.

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -207,7 +207,8 @@ class HookManager
 				'sendMailAfter',
 				'showLinkToObjectBlock',
 				'setContentSecurityPolicy',
-				'setHtmlTitle'
+				'setHtmlTitle',
+                'completeTabsHead'
 				)
 			)) $hooktype='addreplace';
 


### PR DESCRIPTION
# Fix #
Add function "completeTabsHead" to "addreplace" type hook because $head is replaced.