### PR TITLE
New : refactor UserGroup module with new common way

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,7 @@ For Developers or integrators:
   - replace $page = GETPOST('page', 'int') with $page = GETPOSTISSET('pageplusone') ? (GETPOST('pageplusone') - 1) : GETPOST("page", 'int'); 
   - remove input field in form '<input type="hidden" name="page" value="'.$page.'">';'
   - add parameter $pagenavastextinput to value 1 when calling print_barre_liste   
-
+* UserGroup class has been refactored with new architecture. Triggers of class UserGroup are now USERGROUP_CREATE, USERGROUP_MODIFY, USERGROUP_DELETE
 
 WARNING:
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7876,6 +7876,7 @@ abstract class CommonObject
 	public function createCommon(User $user, $notrigger = false)
 	{
 		global $langs;
+		dol_syslog(get_class($this)."::createCommon create", LOG_DEBUG);
 
 		$error = 0;
 
@@ -8114,6 +8115,7 @@ abstract class CommonObject
 	public function updateCommon(User $user, $notrigger = false)
 	{
 		global $conf, $langs;
+		dol_syslog(get_class($this)."::updateCommon update", LOG_DEBUG);
 
 		$error = 0;
 
@@ -8203,6 +8205,8 @@ abstract class CommonObject
 	 */
 	public function deleteCommon(User $user, $notrigger = false, $forcechilddeletion = 0)
 	{
+		dol_syslog(get_class($this)."::deleteCommon delete", LOG_DEBUG);
+
 		$error = 0;
 
 		$this->db->begin();
@@ -8260,17 +8264,10 @@ abstract class CommonObject
 			}
 		}
 
-		if (!$error && !empty($this->isextrafieldmanaged))
+		if (!$error)
 		{
-			$sql = "DELETE FROM ".MAIN_DB_PREFIX.$this->table_element."_extrafields";
-			$sql .= " WHERE fk_object=".$this->id;
-
-			$resql = $this->db->query($sql);
-			if (!$resql)
-			{
-				$this->errors[] = $this->db->lasterror();
-				$error++;
-			}
+			$result = $this->deleteExtraFields();
+			if ($result < 0) { $error++; }
 		}
 
 		if (!$error)

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8264,7 +8264,7 @@ abstract class CommonObject
 			}
 		}
 
-		if (!$error)
+		if (!$error && !empty($this->isextrafieldmanaged))
 		{
 			$result = $this->deleteExtraFields();
 			if ($result < 0) { $error++; }

--- a/htdocs/core/class/events.class.php
+++ b/htdocs/core/class/events.class.php
@@ -100,9 +100,9 @@ class Events // extends CommonObject
 		array('id'=>'USER_NEW_PASSWORD', 'test'=>1),
 		array('id'=>'USER_ENABLEDISABLE', 'test'=>1),
 		array('id'=>'USER_DELETE', 'test'=>1),
-		array('id'=>'GROUP_CREATE', 'test'=>1),
-		array('id'=>'GROUP_MODIFY', 'test'=>1),
-		array('id'=>'GROUP_DELETE', 'test'=>1),
+		array('id'=>'USERGROUP_CREATE', 'test'=>1),
+		array('id'=>'USERGROUP_MODIFY', 'test'=>1),
+		array('id'=>'USERGROUP_DELETE', 'test'=>1),
 	);
 
 

--- a/htdocs/core/triggers/interface_20_all_Logevents.class.php
+++ b/htdocs/core/triggers/interface_20_all_Logevents.class.php
@@ -151,7 +151,7 @@ class InterfaceLogevents extends DolibarrTriggers
         }
 
 		// Groupes
-        elseif ($action == 'GROUP_CREATE')
+        elseif ($action == 'USERGROUP_CREATE')
         {
             dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
             $langs->load("users");
@@ -159,7 +159,7 @@ class InterfaceLogevents extends DolibarrTriggers
             $text = $langs->transnoentities("NewGroupCreated", $object->name);
             $desc = $langs->transnoentities("NewGroupCreated", $object->name);
 		}
-        elseif ($action == 'GROUP_MODIFY')
+        elseif ($action == 'USERGROUP_MODIFY')
         {
             dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
             $langs->load("users");
@@ -167,7 +167,7 @@ class InterfaceLogevents extends DolibarrTriggers
             $text = $langs->transnoentities("GroupModified", $object->name);
             $desc = $langs->transnoentities("GroupModified", $object->name);
 		}
-        elseif ($action == 'GROUP_DELETE')
+        elseif ($action == 'USERGROUP_DELETE')
         {
             dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
             $langs->load("users");

--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -269,7 +269,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 		}
 
 		// Groupes
-		elseif ($action == 'GROUP_CREATE')
+		elseif ($action == 'USERGROUP_CREATE')
 		{
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && $conf->global->LDAP_SYNCHRO_ACTIVE === 'dolibarr2ldap')
@@ -293,7 +293,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				if ($result < 0) $this->error = "ErrorLDAP ".$ldap->error;
 			}
 		}
-		elseif ($action == 'GROUP_MODIFY')
+		elseif ($action == 'USERGROUP_MODIFY')
 		{
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && $conf->global->LDAP_SYNCHRO_ACTIVE === 'dolibarr2ldap')
@@ -330,7 +330,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				if ($result < 0) $this->error = "ErrorLDAP ".$ldap->error;
 			}
 		}
-		elseif ($action == 'GROUP_DELETE')
+		elseif ($action == 'USERGROUP_DELETE')
 		{
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && $conf->global->LDAP_SYNCHRO_ACTIVE === 'dolibarr2ldap')

--- a/htdocs/core/triggers/interface_99_modZapier_ZapierTriggers.class.php
+++ b/htdocs/core/triggers/interface_99_modZapier_ZapierTriggers.class.php
@@ -147,9 +147,9 @@ class InterfaceZapierTriggers extends DolibarrTriggers
                 break;
 
             // Groups
-            //case 'GROUP_CREATE':
-            //case 'GROUP_MODIFY':
-            //case 'GROUP_DELETE':
+            //case 'USERGROUP_CREATE':
+            //case 'USERGROUP_MODIFY':
+            //case 'USERGROUP_DELETE':
 
             // Companies
             case 'COMPANY_CREATE':

--- a/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
+++ b/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
@@ -118,9 +118,9 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
             //case 'ACTION_DELETE':
 
             // Groups
-            //case 'GROUP_CREATE':
-            //case 'GROUP_MODIFY':
-            //case 'GROUP_DELETE':
+            //case 'USERGROUP_CREATE':
+            //case 'USERGROUP_MODIFY':
+            //case 'USERGROUP_DELETE':
 
             // Companies
             //case 'COMPANY_CREATE':

--- a/htdocs/user/class/usergroup.class.php
+++ b/htdocs/user/class/usergroup.class.php
@@ -404,7 +404,7 @@ class UserGroup extends CommonObject
 				$this->context = array('audit'=>$langs->trans("PermissionsAdd").($rid ? ' (id='.$rid.')' : ''));
 
 			    // Call trigger
-			    $result = $this->call_trigger('GROUP_MODIFY', $user);
+			    $result = $this->call_trigger('USERGROUP_MODIFY', $user);
 			    if ($result < 0) { $error++; }
 			    // End call triggers
 			}
@@ -528,7 +528,7 @@ class UserGroup extends CommonObject
 				$this->context = array('audit'=>$langs->trans("PermissionsDelete").($rid ? ' (id='.$rid.')' : ''));
 
 			    // Call trigger
-			    $result = $this->call_trigger('GROUP_MODIFY', $user);
+			    $result = $this->call_trigger('USERGROUP_MODIFY', $user);
 			    if ($result < 0) { $error++; }
 			    // End call triggers
 			}

--- a/htdocs/user/class/usergroup.class.php
+++ b/htdocs/user/class/usergroup.class.php
@@ -100,6 +100,16 @@ class UserGroup extends CommonObject
 
 	public $oldcopy; // To contains a clone of this when we need to save old properties of object
 
+	public $fields = array(
+		'rowid'=>array('type'=>'integer', 'label'=>'TechnicalID', 'enabled'=>1, 'visible'=>-2, 'notnull'=>1, 'index'=>1, 'position'=>1, 'comment'=>'Id'),
+		'entity' => array('type'=>'integer', 'label'=>'Entity', 'enabled'=>1, 'visible'=>0, 'notnull'=> 1, 'default'=>1, 'index'=>1, 'position'=>5),
+		'nom'=>array('type'=>'varchar(180)', 'label'=>'Name', 'enabled'=>1, 'visible'=>1, 'notnull'=>1, 'showoncombobox'=>1, 'index'=>1, 'position'=>10, 'searchall'=>1, 'comment'=>'Group name'),
+		'note' => array('type'=>'html', 'label'=>'Description', 'enabled'=>1, 'visible'=>1, 'position'=>20, 'notnull'=>-1,),
+		'datec' => array('type'=>'datetime', 'label'=>'DateCreation', 'enabled'=>1, 'visible'=>-2, 'position'=>50, 'notnull'=>1,),
+		'tms' => array('type'=>'timestamp', 'label'=>'DateModification', 'enabled'=>1, 'visible'=>-2, 'position'=>60, 'notnull'=>1,),
+		'model_pdf' =>array('type'=>'varchar(255)', 'label'=>'ModelPDF', 'enabled'=>1, 'visible'=>0, 'position'=>100),
+	);
+
 
 	/**
      *    Constructor de la classe

--- a/htdocs/user/class/usergroup.class.php
+++ b/htdocs/user/class/usergroup.class.php
@@ -110,6 +110,21 @@ class UserGroup extends CommonObject
 		'model_pdf' =>array('type'=>'varchar(255)', 'label'=>'ModelPDF', 'enabled'=>1, 'visible'=>0, 'position'=>100),
 	);
 
+	/**
+	 * @var int    Field with ID of parent key if this field has a parent
+	 */
+	public $fk_element = 'fk_usergroup';
+
+	/**
+	 * @var array	List of child tables. To test if we can delete object.
+	 */
+	protected $childtables=array();
+
+	/**
+	 * @var array	List of child tables. To know object to delete on cascade.
+	 */
+	protected $childtablesoncascade = array('usergroup_rights','usergroup_user');
+
 
 	/**
      *    Constructor de la classe
@@ -135,47 +150,23 @@ class UserGroup extends CommonObject
 	{
 		global $conf;
 
-		$sql = "SELECT g.rowid, g.entity, g.nom as name, g.note, g.datec, g.tms as datem";
-		$sql .= " FROM ".MAIN_DB_PREFIX."usergroup as g";
-		if ($groupname)
+		dol_syslog(get_class($this)."::fetch", LOG_DEBUG);
+		if (!empty($groupname))
 		{
-			$sql .= " WHERE g.nom = '".$this->db->escape($groupname)."'";
+			$result = $this->fetchCommon(0, '', ' AND nom = \''.$this->db->escape($groupname).'\'');
 		}
 		else
 		{
-			$sql .= " WHERE g.rowid = ".$id;
+			$result = $this->fetchCommon($id);
 		}
 
-		dol_syslog(get_class($this)."::fetch", LOG_DEBUG);
-		$result = $this->db->query($sql);
-		if ($result)
+		if($result)
 		{
-			if ($this->db->num_rows($result))
+			if ($load_members)
 			{
-				$obj = $this->db->fetch_object($result);
-
-				$this->id = $obj->rowid;
-				$this->ref = $obj->rowid;
-				$this->entity = $obj->entity;
-				$this->name = $obj->name;
-				$this->nom = $obj->name; // Deprecated
-				$this->note = $obj->note;
-				$this->datec = $obj->datec;
-				$this->datem = $obj->datem;
-
-				if ($load_members)
-					$this->members = $this->listUsersForGroup();
-
-
-				// Retreive all extrafield
-				// fetch optionals attributes and labels
-				$this->fetch_optionals();
-
-
-				// Sav current LDAP Current DN
-				//$this->ldap_dn = $this->_load_ldap_dn($this->_load_ldap_info(),0);
+				$this->members = $this->listUsersForGroup();
 			}
-			$this->db->free($result);
+
 			return 1;
 		}
 		else
@@ -647,50 +638,7 @@ class UserGroup extends CommonObject
 	 */
 	public function delete(User $user)
 	{
-		global $conf, $langs;
-
-		$error = 0;
-
-		$this->db->begin();
-
-		$sql = "DELETE FROM ".MAIN_DB_PREFIX."usergroup_rights";
-		$sql .= " WHERE fk_usergroup = ".$this->id;
-		$this->db->query($sql);
-
-		$sql = "DELETE FROM ".MAIN_DB_PREFIX."usergroup_user";
-		$sql .= " WHERE fk_usergroup = ".$this->id;
-		$this->db->query($sql);
-
-        // Remove extrafields
-        if ((!$error) && (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED))) // For avoid conflicts if trigger used
-        {
-            $result = $this->deleteExtraFields();
-            if ($result < 0)
-            {
-                $error++;
-                dol_syslog(get_class($this)."::delete error -4 ".$this->error, LOG_ERR);
-            }
-        }
-
-		$sql = "DELETE FROM ".MAIN_DB_PREFIX."usergroup";
-		$sql .= " WHERE rowid = ".$this->id;
-		$result = $this->db->query($sql);
-		if ($result)
-		{
-            // Call trigger
-            $result = $this->call_trigger('GROUP_DELETE', $user);
-            if ($result < 0) { $error++; $this->db->rollback(); return -1; }
-            // End call triggers
-
-			$this->db->commit();
-			return 1;
-		}
-		else
-		{
-			$this->db->rollback();
-			dol_print_error($this->db);
-			return -1;
-		}
+		return $this->deleteCommon($user);
 	}
 
 	/**
@@ -701,67 +649,15 @@ class UserGroup extends CommonObject
 	 */
 	public function create($notrigger = 0)
 	{
-		global $user, $conf, $langs, $hookmanager;
+		global $user, $conf;
 
-		$error = 0;
-		$now = dol_now();
+		$this->datec = dol_now();
 
 		if (!isset($this->entity)) $this->entity = $conf->entity; // If not defined, we use default value
-
 		$entity = $this->entity;
 		if (!empty($conf->multicompany->enabled) && $conf->entity == 1) $entity = $this->entity;
 
-		$this->db->begin();
-
-		$sql = "INSERT INTO ".MAIN_DB_PREFIX."usergroup (";
-		$sql .= "datec";
-		$sql .= ", nom";
-		$sql .= ", entity";
-		$sql .= ") VALUES (";
-		$sql .= "'".$this->db->idate($now)."'";
-		$sql .= ",'".$this->db->escape($this->nom)."'";
-		$sql .= ",".$this->db->escape($entity);
-		$sql .= ")";
-
-		dol_syslog(get_class($this)."::create", LOG_DEBUG);
-		$result = $this->db->query($sql);
-		if ($result)
-		{
-			$this->id = $this->db->last_insert_id(MAIN_DB_PREFIX."usergroup");
-
-			if ($this->update(1) < 0) return -2;
-
-			$action = 'create';
-
-			// Actions on extra fields (by external module or standard code)
-			if (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED)) // For avoid conflicts if trigger used
-			{
-				$result = $this->insertExtraFields();
-				if ($result < 0)
-				{
-					$error++;
-				}
-			}
-
-			if (!$error && !$notrigger)
-			{
-                // Call trigger
-                $result = $this->call_trigger('GROUP_CREATE', $user);
-                if ($result < 0) { $error++; $this->db->rollback(); return -1; }
-                // End call triggers
-			}
-
-			if ($error > 0) { $error++; $this->db->rollback(); return -1; }
-			else $this->db->commit();
-
-			return $this->id;
-		}
-		else
-		{
-		    $this->db->rollback();
-			$this->error = $this->db->lasterror();
-			return -1;
-		}
+		return $this->createCommon($user, $notrigger);
 	}
 
 	/**
@@ -772,9 +668,7 @@ class UserGroup extends CommonObject
 	 */
 	public function update($notrigger = 0)
 	{
-		global $user, $conf, $langs, $hookmanager;
-
-		$error = 0;
+		global $user, $conf;
 
 		$entity = $conf->entity;
 		if (!empty($conf->multicompany->enabled) && $conf->entity == 1)
@@ -782,55 +676,7 @@ class UserGroup extends CommonObject
 			$entity = $this->entity;
 		}
 
-		$this->db->begin();
-
-		$sql = "UPDATE ".MAIN_DB_PREFIX."usergroup SET ";
-		$sql .= " nom = '".$this->db->escape($this->name)."'";
-		$sql .= ", entity = ".$this->db->escape($entity);
-		$sql .= ", note = '".$this->db->escape($this->note)."'";
-		$sql .= " WHERE rowid = ".$this->id;
-
-		dol_syslog(get_class($this)."::update", LOG_DEBUG);
-		$resql = $this->db->query($sql);
-		if ($resql)
-		{
-			$action = 'update';
-
-			// Actions on extra fields (by external module or standard code)
-			if (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED)) // For avoid conflicts if trigger used
-			{
-				$result = $this->insertExtraFields();
-				if ($result < 0)
-				{
-					$error++;
-				}
-			}
-
-			if (!$error && !$notrigger)
-			{
-                // Call trigger
-                $result = $this->call_trigger('GROUP_MODIFY', $user);
-                if ($result < 0) { $error++; }
-                // End call triggers
-			}
-
-			if (!$error)
-			{
-			    $this->db->commit();
-			    return 1;
-			}
-			else
-			{
-			    $this->db->rollback();
-			    return -$error;
-			}
-		}
-		else
-		{
-		    $this->db->rollback();
-			dol_print_error($this->db);
-			return -1;
-		}
+		return $this->updateCommon($user, $notrigger);
 	}
 
 

--- a/htdocs/user/group/card.php
+++ b/htdocs/user/group/card.php
@@ -68,15 +68,13 @@ if (!empty($conf->multicompany->enabled) && $conf->entity > 1 && $conf->global->
 }
 
 $object = new Usergroup($db);
-if ($id > 0)
-{
-	$object->fetch($id);
-	$object->getrights();
-}
-
 $extrafields = new ExtraFields($db);
 // fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
+
+// Load object
+include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be include, not include_once.
+$object->getrights();
 
 // Initialize technical object to manage hooks. Note that conf->hooks_modules contains array
 $hookmanager->initHooks(array('groupcard', 'globalcard'));
@@ -325,6 +323,8 @@ else
 {
     if ($id)
     {
+		$res = $object->fetch_optionals();
+
         $head = group_prepare_head($object);
         $title = $langs->trans("Group");
 
@@ -374,6 +374,8 @@ else
 				print '<td class="valeur">'.dol_escape_htmltag($mc->label);
 				print "</td></tr>\n";
 			}
+
+			unset($object->fields['nom']); // Name already displayed in banner
 
 			// Common attributes
 			$keyforbreak = '';

--- a/htdocs/user/group/card.php
+++ b/htdocs/user/group/card.php
@@ -90,7 +90,6 @@ $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action
 if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 
 if (empty($reshook)) {
-
 	$backurlforlist = DOL_URL_ROOT.'/user/group/list.php';
 
 	if (empty($backtopage) || ($cancel && empty($id))) {

--- a/htdocs/user/group/card.php
+++ b/htdocs/user/group/card.php
@@ -54,6 +54,7 @@ $action = GETPOST('action', 'alpha');
 $cancel = GETPOST('cancel', 'aZ09');
 $confirm = GETPOST('confirm', 'alpha');
 $contextpage = GETPOST('contextpage', 'aZ') ?GETPOST('contextpage', 'aZ') : 'groupcard'; // To manage different context of search
+$backtopage = GETPOST('backtopage', 'alpha');
 
 $userid = GETPOST('user', 'int');
 
@@ -91,19 +92,20 @@ $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action
 if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 
 if (empty($reshook)) {
+
+	$backurlforlist = DOL_URL_ROOT.'/user/group/list.php';
+
+	if (empty($backtopage) || ($cancel && empty($id))) {
+		if (empty($backtopage) || ($cancel && strpos($backtopage, '__ID__'))) {
+			if (empty($id) && (($action != 'add' && $action != 'create') || $cancel)) $backtopage = $backurlforlist;
+			else $backtopage = dol_buildpath('/user/group/card.php', 1).'?id='.($id > 0 ? $id : '__ID__');
+		}
+	}
+
 	if ($cancel)
 	{
-		if (!empty($backtopage))
-		{
-			header("Location: ".$backtopage);
-			exit;
-		}
-		else
-		{
-			header("Location: ".DOL_URL_ROOT.'/user/group/list.php');
-			exit;
-		}
-		$action = '';
+		header("Location: ".$backtopage);
+		exit;
 	}
 
 	// Action remove group
@@ -215,7 +217,7 @@ if (empty($reshook)) {
 
 			$object->oldcopy = clone $object;
 
-			$object->name	= trim(GETPOST("group", 'nohtml'));
+			$object->name	= trim(GETPOST("nom", 'nohtml'));
 			$object->nom = $object->name; // For backward compatibility
 			$object->note	= dol_htmlcleanlastbr(trim(GETPOST("note", 'none')));
 
@@ -273,14 +275,11 @@ if ($action == 'create')
     print '<form action="'.$_SERVER["PHP_SELF"].'" method="post">';
     print '<input type="hidden" name="token" value="'.newToken().'">';
     print '<input type="hidden" name="action" value="add">';
+	print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
 
     dol_fiche_head('', '', '', 0, '');
 
-    print '<table class="border centpercent">';
-
-	print "<tr>";
-	print '<td class="fieldrequired titlefield">'.$langs->trans("Name").'</td>';
-	print '<td><input type="text" id="nom" name="nom" value="'.dol_escape_htmltag(GETPOST('nom', 'nohtml')).'"></td></tr>';
+    print '<table class="border centpercent tableforfieldcreate">';
 
 	// Multicompany
 	if (!empty($conf->multicompany->enabled) && is_object($mc))
@@ -297,27 +296,18 @@ if ($action == 'create')
 		}
 	}
 
-    print "<tr>".'<td class="tdtop">'.$langs->trans("Description").'</td><td>';
-    require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
-    $doleditor = new DolEditor('note', '', '', 240, 'dolibarr_notes', '', false, true, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_8, '90%');
-    $doleditor->Create();
-    print "</td></tr>\n";
+	// Common attributes
+	include DOL_DOCUMENT_ROOT.'/core/tpl/commonfields_add.tpl.php';
 
 	// Other attributes
-    $parameters = array('object' => $object);
-    $reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
-    print $hookmanager->resPrint;
-    if (empty($reshook))
-    {
-		print $object->showOptionals($extrafields, 'edit');
-    }
+	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_add.tpl.php';
 
-    print "</table>\n";
+	print "</table>\n";
 
     dol_fiche_end();
 
     print '<div class="center">';
-    print '<input class="button" value="'.$langs->trans("CreateGroup").'" type="submit">';
+    print '<input class="button" name="add" value="'.$langs->trans("CreateGroup").'" type="submit">';
     print ' &nbsp; ';
     print '<input class="button" value="'.$langs->trans("Cancel").'" name="cancel" type="submit">';
     print '</div>';
@@ -359,6 +349,7 @@ else
 			dol_banner_tab($object, 'id', $linkback, $user->rights->user->user->lire || $user->admin);
 
 			print '<div class="fichecenter">';
+			print '<div class="fichehalfleft">';
 			print '<div class="underbanner clearboth"></div>';
 
 			print '<table class="border centpercent tableforfield">';
@@ -384,19 +375,18 @@ else
 				print "</td></tr>\n";
 			}
 
-			// Note
-			print '<tr><td class="titlefield tdtop">'.$langs->trans("Description").'</td>';
-			print '<td class="valeur sensiblehtmlcontent"">';
-			print dol_string_onlythesehtmltags(dol_htmlentitiesbr($object->note));
-			print '</td>';
-			print "</tr>\n";
+			// Common attributes
+			$keyforbreak = '';
+			include DOL_DOCUMENT_ROOT.'/core/tpl/commonfields_view.tpl.php';
 
 			// Other attributes
-            $parameters = array('colspan' => ' colspan="2"');
 			include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_view.tpl.php';
 
-			print "</table>\n";
-            print '</div>';
+			print '</table>';
+			print '</div>';
+			print '</div>';
+
+			print '<div class="clearboth"></div>';
 
 			dol_fiche_end();
 
@@ -406,6 +396,10 @@ else
 			 */
 
 			print '<div class="tabsAction">';
+
+			$parameters = array();
+			$reshook = $hookmanager->executeHooks('addMoreActionsButtons', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+			if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 
 			if ($caneditperms)
 			{
@@ -421,7 +415,7 @@ else
 
             // List users in group
 
-            print load_fiche_titre($langs->trans("ListOfUsersInGroup"), '', '');
+            print load_fiche_titre($langs->trans("ListOfUsersInGroup"), '', 'user');
 
             // On selectionne les users qui ne sont pas deja dans le groupe
             $exclude = array();
@@ -485,7 +479,7 @@ else
 						print '</td>';
 						print '<td>'.$useringroup->lastname.'</td>';
 						print '<td>'.$useringroup->firstname.'</td>';
-						print '<td class="center">'.$useringroup->getLibStatut(3).'</td>';
+						print '<td class="center">'.$useringroup->getLibStatut(5).'</td>';
 						print '<td class="right">';
 						if (!empty($user->admin)) {
 							print '<a href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&amp;action=removeuser&amp;user='.$useringroup->id.'">';
@@ -542,53 +536,44 @@ else
 
         if ($action == 'edit' && $caneditperms)
         {
-            print '<form action="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'" method="post" name="updategroup" enctype="multipart/form-data">';
+            print '<form action="'.$_SERVER['PHP_SELF'].'" method="post" name="updategroup" enctype="multipart/form-data">';
             print '<input type="hidden" name="token" value="'.newToken().'">';
             print '<input type="hidden" name="action" value="update">';
+			print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
+			print '<input type="hidden" name="id" value="'.$object->id.'">';
 
             dol_fiche_head($head, 'group', $title, 0, 'group');
 
-            print '<table class="border centpercent">';
-            print '<tr><td class="titlefield fieldrequired">'.$langs->trans("Name").'</td>';
-            print '<td class="valeur"><input class="minwidth300" type="text" name="group" value="'.dol_escape_htmltag($object->name).'">';
-            print "</td></tr>\n";
+			print '<table class="border centpercent tableforfieldedit">'."\n";
 
-            // Multicompany
-            if (!empty($conf->multicompany->enabled) && is_object($mc))
-            {
-                if (empty($conf->global->MULTICOMPANY_TRANSVERSE_MODE) && $conf->entity == 1 && $user->admin && !$user->entity)
-                {
-                    print "<tr>".'<td class="tdtop">'.$langs->trans("Entity").'</td>';
-                    print "<td>".$mc->select_entities($object->entity);
-                    print "</td></tr>\n";
-                }
-                else
-                {
+			// Multicompany
+			if (!empty($conf->multicompany->enabled) && is_object($mc))
+			{
+				if (empty($conf->global->MULTICOMPANY_TRANSVERSE_MODE) && $conf->entity == 1 && $user->admin && !$user->entity)
+				{
+					print "<tr>".'<td class="tdtop">'.$langs->trans("Entity").'</td>';
+					print "<td>".$mc->select_entities($object->entity);
+					print "</td></tr>\n";
+				}
+				else
+				{
 					print '<input type="hidden" name="entity" value="'.$conf->entity.'" />';
 				}
-            }
+			}
 
-            print '<tr><td class="tdtop">'.$langs->trans("Description").'</td>';
-            print '<td class="valeur">';
-            require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
-            $doleditor = new DolEditor('note', $object->note, '', 240, 'dolibarr_notes', '', true, false, $conf->global->FCKEDITOR_ENABLE_SOCIETE, ROWS_8, '90%');
-            $doleditor->Create();
-            print '</td>';
-            print "</tr>\n";
+			// Common attributes
+			include DOL_DOCUMENT_ROOT.'/core/tpl/commonfields_edit.tpl.php';
+
 			// Other attributes
-            $parameters = array();
-            $reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
-            print $hookmanager->resPrint;
-            if (empty($reshook))
-            {
-				print $object->showOptionals($extrafields, 'edit');
-            }
+			include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_edit.tpl.php';
 
-            print "</table>\n";
+			print '</table>';
 
             dol_fiche_end();
 
-            print '<div class="center"><input class="button" value="'.$langs->trans("Save").'" type="submit"></div>';
+			print '<div class="center"><input type="submit" class="button" name="save" value="'.$langs->trans("Save").'">';
+			print ' &nbsp; <input type="submit" class="button" name="cancel" value="'.$langs->trans("Cancel").'">';
+			print '</div>';
 
             print '</form>';
         }


### PR DESCRIPTION
Hi !
I wanted to see what work must be done to refactor a standard module with the new structure used in modulebuilder (based on $fields object member).
So to start simple I did it on the usergroup module. Here's what I've done :

- Add $fields on the UserGroup object
- Use commonFunctions from commonObject
- Change card to use common tpl (still some multicompany specific code)
- Add hook addMoreActionsButtons
- Look and feel v12

The only thing I see is problematic is that the trigger name is changed. Now it's USERGROUP_XXX, before it was GROUP_XXX.

Tell me what you think about it, and I'll try the same on the user class :wink: 