### PR TITLE
NEW bank account tags for invoice ODT template

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2015       Marcos García           <marcosgdf@gmail.com>
  * Copyright (C) 2016       Charlie Benke           <charlie@patas-monkey.com>
  * Copyright (C) 2018       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2020       Josep Lluís Amador      <joseplluis@lliuretic.cat>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -386,6 +387,12 @@ abstract class CommonDocGenerator
 			$sumcreditnote = $object->getSumCreditNotesUsed();
 			$already_payed_all = $sumpayed + $sumdeposit + $sumcreditnote;
 			$remain_to_pay = $sumpayed - $sumdeposit - $sumcreditnote;
+			
+			if ($object->fk_account > 0) {
+				require_once DOL_DOCUMENT_ROOT .'/compta/bank/class/account.class.php';
+				$bank_account = new Account($this->db);
+				$bank_account->fetch($object->fk_account);
+			}
 		}
 
 		$date = ($object->element == 'contrat' ? $object->date_contrat : $object->date);
@@ -413,6 +420,9 @@ abstract class CommonDocGenerator
 		$array_key.'_payment_mode'=>($outputlangs->transnoentitiesnoconv('PaymentType'.$object->mode_reglement_code) != 'PaymentType'.$object->mode_reglement_code ? $outputlangs->transnoentitiesnoconv('PaymentType'.$object->mode_reglement_code) : $object->mode_reglement),
 		$array_key.'_payment_term_code'=>$object->cond_reglement_code,
 		$array_key.'_payment_term'=>($outputlangs->transnoentitiesnoconv('PaymentCondition'.$object->cond_reglement_code) != 'PaymentCondition'.$object->cond_reglement_code ? $outputlangs->transnoentitiesnoconv('PaymentCondition'.$object->cond_reglement_code) : ($object->cond_reglement_doc ? $object->cond_reglement_doc : $object->cond_reglement)),
+
+		$array_key.'_bank_iban'=>$bank_account->iban,
+		$array_key.'_bank_bic'=>$bank_account->bic,
 
 		$array_key.'_total_ht_locale'=>price($object->total_ht, 0, $outputlangs),
 		$array_key.'_total_vat_locale'=>(!empty($object->total_vat) ?price($object->total_vat, 0, $outputlangs) : price($object->total_tva, 0, $outputlangs)),

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -387,7 +387,7 @@ abstract class CommonDocGenerator
 			$sumcreditnote = $object->getSumCreditNotesUsed();
 			$already_payed_all = $sumpayed + $sumdeposit + $sumcreditnote;
 			$remain_to_pay = $sumpayed - $sumdeposit - $sumcreditnote;
-			
+
 			if ($object->fk_account > 0) {
 				require_once DOL_DOCUMENT_ROOT .'/compta/bank/class/account.class.php';
 				$bank_account = new Account($this->db);


### PR DESCRIPTION
# New: bank account tags for invoice ODT template
added tags object_bank_iban and object_bank_bic, useful for ODT invoices when a bank account is assigned, also suggested in #8419

