### PR TITLE
[BUGFIX] Allow update of extra fields

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -976,7 +976,7 @@ class FactureFournisseur extends CommonInvoice
                 $this->errors[] = "Error ".$this->db->lasterror();
             }
         }
-		
+
 		if (! $error && empty($conf->global->MAIN_EXTRAFIELDS_DISABLED) && is_array($this->array_options) && count($this->array_options)>0)
 		{
 			$result=$this->insertExtraFields();

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -976,6 +976,15 @@ class FactureFournisseur extends CommonInvoice
                 $this->errors[] = "Error ".$this->db->lasterror();
             }
         }
+		
+		if (! $error && empty($conf->global->MAIN_EXTRAFIELDS_DISABLED) && is_array($this->array_options) && count($this->array_options)>0)
+		{
+			$result=$this->insertExtraFields();
+			if ($result < 0)
+			{
+				$error++;
+			}
+		}
 
         if (!$error)
         {


### PR DESCRIPTION
# New allow upate of extra fields
Currently the REST API doesn't allow to update extra fields for supplier invoices, because the update function of the supplier invoice class misses these few lines. This will make it consistent with other similar classes (regular invoices etc).
