### PR TITLE
Add default values to extrafields

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7117,16 +7117,9 @@ abstract class CommonObject
 					{
 						$value = GETPOSTISSET($keyprefix.'options_'.$key.$keysuffix) ?price2num(GETPOST($keyprefix.'options_'.$key.$keysuffix, 'alpha', 3)) : $this->array_options['options_'.$key];
 					}
-
-					// HTML and text add default value
-					if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('html', 'text')))
-					{
-						if($action=='create') $value = $extrafields->attributes[$this->table_element]['default'][$key];
-						else $value = $this->array_options['options_'.$key];
-					}
-
-					// select fields use default value
-					if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('select')))
+					
+					// HTML, select, integer and text add default value
+					if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('html', 'text', 'select', 'int')))
 					{
 						if($action=='create') $value = $extrafields->attributes[$this->table_element]['default'][$key];
 						else $value = $this->array_options['options_'.$key];

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7124,7 +7124,14 @@ abstract class CommonObject
 						if($action=='create') $value = $extrafields->attributes[$this->table_element]['default'][$key];
 						else $value = $this->array_options['options_'.$key];
 					}
-					
+
+					// select fields use default value
+					if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('select')))
+					{
+						if($action=='create') $value = $extrafields->attributes[$this->table_element]['default'][$key];
+						else $value = $this->array_options['options_'.$key];
+					}
+
 					$labeltoshow = $langs->trans($label);
 					$helptoshow = $langs->trans($extrafields->attributes[$this->table_element]['help'][$key]);
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7117,6 +7117,14 @@ abstract class CommonObject
 					{
 						$value = GETPOSTISSET($keyprefix.'options_'.$key.$keysuffix) ?price2num(GETPOST($keyprefix.'options_'.$key.$keysuffix, 'alpha', 3)) : $this->array_options['options_'.$key];
 					}
+
+					// HTML and text add default value
+					if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('html', 'text')))
+					{
+						if($action=='create') $value = $extrafields->attributes[$this->table_element]['default'][$key];
+						else $value = $this->array_options['options_'.$key];
+					}
+					
 					$labeltoshow = $langs->trans($label);
 					$helptoshow = $langs->trans($extrafields->attributes[$this->table_element]['help'][$key]);
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7117,7 +7117,6 @@ abstract class CommonObject
 					{
 						$value = GETPOSTISSET($keyprefix.'options_'.$key.$keysuffix) ?price2num(GETPOST($keyprefix.'options_'.$key.$keysuffix, 'alpha', 3)) : $this->array_options['options_'.$key];
 					}
-					
 					// HTML, select, integer and text add default value
 					if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('html', 'text', 'select', 'int')))
 					{


### PR DESCRIPTION
# Fix #10387 Default value for Extrafield of type SELECT is not working
Extrafields for an object now shows the default value (if there is one) on creation for html, text and standard select fields.