### PR TITLE
Clean line extrafields when deleting invoice

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -664,9 +664,13 @@ class FactureRec extends CommonInvoice
         $error = 0;
 		$this->db->begin();
 
+		$main = MAIN_DB_PREFIX . 'facturedet_rec';
+        $ef = $main . "_extrafields";
+        $sqlef = "DELETE FROM $ef WHERE fk_object IN (SELECT rowid FROM $main WHERE fk_facture = $rowid)";
+        dol_syslog($sqlef);
 		$sql = "DELETE FROM ".MAIN_DB_PREFIX."facturedet_rec WHERE fk_facture = ".$rowid;
 		dol_syslog($sql);
-		if ($this->db->query($sql))
+		if ($this->db->query($sqlef) && $this->db->query($sql))
 		{
 			$sql = "DELETE FROM ".MAIN_DB_PREFIX."facture_rec WHERE rowid = ".$rowid;
 			dol_syslog($sql);
@@ -675,6 +679,9 @@ class FactureRec extends CommonInvoice
 				// Delete linked object
 				$res = $this->deleteObjectLinked();
 				if ($res < 0) $error = -3;
+				// Delete extrafields
+                $res = $this->deleteExtraFields();
+                if ($res < 0) $error = -4;
 			}
 			else
 			{
@@ -1881,6 +1888,14 @@ class FactureLigneRec extends CommonInvoiceLine
 	            // End call triggers
 	        }
 	    }
+		
+		if (!$error)
+        {
+            $result = $this->deleteExtraFields();
+            if ($result < 0) {
+                $error++;
+            }
+        }
 
 	    if (!$error)
 	    {

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -1888,7 +1888,7 @@ class FactureLigneRec extends CommonInvoiceLine
 	            // End call triggers
 	        }
 	    }
-		
+
 		if (!$error)
         {
             $result = $this->deleteExtraFields();

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2166,13 +2166,16 @@ class Facture extends CommonInvoice
 				}
 			}
 
-
+            // Invoice line extrafileds
+			$main = MAIN_DB_PREFIX . 'facturedet';
+			$ef = $main . "_extrafields";
+			$sqlef = "DELETE FROM $ef WHERE fk_object IN (SELECT rowid FROM $main WHERE fk_facture = $rowid)";
 			// Delete invoice line
 			$sql = 'DELETE FROM '.MAIN_DB_PREFIX.'facturedet WHERE fk_facture = '.$rowid;
 
 			dol_syslog(get_class($this)."::delete", LOG_DEBUG);
 
-			if ($this->db->query($sql) && $this->delete_linked_contact())
+			if ($this->db->query($sqlef) && $this->db->query($sql) && $this->delete_linked_contact())
 			{
 				$sql = 'DELETE FROM '.MAIN_DB_PREFIX.'facture WHERE rowid = '.$rowid;
 
@@ -5312,7 +5315,14 @@ class FactureLigne extends CommonInvoiceLine
 		}
 		// End call triggers
 
-
+        // extrafields
+        $result = $this->deleteExtraFields();
+        if ($result < 0)
+        {
+            $this->db->rollback();
+            return -1;
+        }
+		
 		$sql = "DELETE FROM ".MAIN_DB_PREFIX."facturedet WHERE rowid = ".$this->rowid;
 		dol_syslog(get_class($this)."::delete", LOG_DEBUG);
 		if ($this->db->query($sql))

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5322,7 +5322,7 @@ class FactureLigne extends CommonInvoiceLine
             $this->db->rollback();
             return -1;
         }
-		
+
 		$sql = "DELETE FROM ".MAIN_DB_PREFIX."facturedet WHERE rowid = ".$this->rowid;
 		dol_syslog(get_class($this)."::delete", LOG_DEBUG);
 		if ($this->db->query($sql))


### PR DESCRIPTION
Delete extrafields invoice lines when deleting parent object (sql syntax ok for mariadb & pgsql, hopefully)
Delete extrafields when deleting an invoice line
