### PR TITLE
NEW possibilty to group payments by mode and show their subtotal

### DIFF
--- a/htdocs/admin/payment.php
+++ b/htdocs/admin/payment.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2015  Juanjo Menent				<jmenent@2byte.es>
+ * Copyright (C) 2020  Maxime DEMAREST              <maxime@indelog.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -70,10 +71,11 @@ if ($action == 'setmod')
 if ($action == 'setparams')
 {
 	$freetext = GETPOST('FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS', 'none'); // No alpha here, we want exact string
-
 	$res = dolibarr_set_const($db, "FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS", $freetext, 'chaine', 0, '', $conf->entity);
-
 	if (!$res > 0) $error++;
+
+    $res = dolibarr_set_const($db, "PAYMENTS_REPORT_GROUP_BY_MOD", GETPOST('PAYMENTS_REPORT_GROUP_BY_MOD', 'int'), 'chaine', 0, '', $conf->entity);
+    if (!$res > 0) $error++;
 
 	if ($error)
 	{
@@ -250,6 +252,14 @@ print '<tr class="oddeven"><td>';
 print $langs->trans("PaymentOnDifferentThirdBills");
 print '</td><td width="60" align="center">';
 print $form->selectyesno("FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS", $conf->global->FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS, 1);
+print '</td><td class="right">';
+print "</td></tr>\n";
+
+// Allow to group payments by mod in rapports
+print '<tr class="oddeven"><td>';
+print $langs->trans("GroupPaymentsByModOnReports");
+print '</td><td width="60" align="center">';
+print $form->selectyesno("PAYMENTS_REPORT_GROUP_BY_MOD", $conf->global->PAYMENTS_REPORT_GROUP_BY_MOD, 1);
 print '</td><td class="right">';
 print "</td></tr>\n";
 

--- a/htdocs/admin/supplier_payment.php
+++ b/htdocs/admin/supplier_payment.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2015  Juanjo Menent				<jmenent@2byte.es>
  * Copyright (C) 2016  Laurent Destailleur          <eldy@users.sourceforge.net>
+ * Copyright (C) 2020  Maxime DEMAREST              <maxime@indelog.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -142,6 +143,23 @@ elseif ($action == 'specimen')
     	setEventMessages($langs->trans("ErrorModuleNotFound"), null, 'errors');
     	dol_syslog($langs->trans("ErrorModuleNotFound"), LOG_ERR);
     }
+}
+
+
+
+elseif ($action == 'setparams')
+{
+       $res = dolibarr_set_const($db, "PAYMENTS_FOURN_REPORT_GROUP_BY_MOD", GETPOST('PAYMENTS_FOURN_REPORT_GROUP_BY_MOD', 'int'), 'chaine', 0, '', $conf->entity);
+       if (!$res > 0) $error++;
+
+       if ($error)
+       {
+               setEventMessages($langs->trans("Error"), null, 'errors');
+       }
+       if (!$error)
+       {
+           setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
+       }
 }
 
 /*
@@ -428,7 +446,45 @@ foreach ($dirmodels as $reldir)
 
 print '</table>';
 
+/*
+ *  Other Options
+ */
+
+print "<br>";
+
+print load_fiche_titre($langs->trans("OtherOptions"), '', '');
+
+print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
+print '<input type="hidden" name="token" value="'.newToken().'" />';
+print '<input type="hidden" name="action" value="setparams" />';
+
+print '<div class="div-table-responsive-no-min">';
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>'.$langs->trans("Parameter").'</td>';
+print '<td align="center" width="60">'.$langs->trans("Value").'</td>';
+print '<td width="80">&nbsp;</td>';
+print "</tr>\n";
+
+// Allow to group payments by mod in rapports
+print '<tr class="oddeven"><td>';
+print $langs->trans("GroupPaymentsByModOnReports");
+print '</td><td width="60" align="center">';
+print $form->selectyesno("PAYMENTS_FOURN_REPORT_GROUP_BY_MOD", $conf->global->PAYMENTS_FOURN_REPORT_GROUP_BY_MOD, 1);
+print '</td><td class="right">';
+print "</td></tr>\n";
+
+print '</table>';
+
 dol_fiche_end();
+
+print '<br>';
+print '<div class="center">';
+print '<input type="submit" class="button" value="'.$langs->trans("Modify").'" />';
+print '</div>';
+print '<br>';
+
+print '</form>';
 
 // End of page
 llxFooter();

--- a/htdocs/admin/supplier_payment.php
+++ b/htdocs/admin/supplier_payment.php
@@ -152,14 +152,14 @@ elseif ($action == 'setparams')
        $res = dolibarr_set_const($db, "PAYMENTS_FOURN_REPORT_GROUP_BY_MOD", GETPOST('PAYMENTS_FOURN_REPORT_GROUP_BY_MOD', 'int'), 'chaine', 0, '', $conf->entity);
        if (!$res > 0) $error++;
 
-       if ($error)
+	if ($error)
        {
-               setEventMessages($langs->trans("Error"), null, 'errors');
-       }
-       if (!$error)
+			setEventMessages($langs->trans("Error"), null, 'errors');
+	}
+	if (!$error)
        {
-           setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
-       }
+		setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
+	}
 }
 
 /*

--- a/htdocs/compta/paiement/rapport.php
+++ b/htdocs/compta/paiement/rapport.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2003-2006 Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (C) 2004-2014 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2015      Jean-François Ferry	<jfefe@aternatik.fr>
+ * Copyright (C) 2020      Maxime DEMAREST      <maxime@indelog.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +27,7 @@
 require '../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/modules/rapport/pdf_paiement.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
 
 // Security check
@@ -84,6 +86,7 @@ if ($action == 'builddoc')
  */
 
 $formother = new FormOther($db);
+$formfile = new FormFile($db);
 
 llxHeader();
 
@@ -155,7 +158,7 @@ if ($year)
                     $tfile = $dir.'/'.$year.'/'.$file;
                     $relativepath = $year.'/'.$file;
                     print '<tr class="oddeven">';
-                    print '<td><a data-ajax="false" href="'.DOL_URL_ROOT.'/document.php?modulepart=facture_paiement&amp;file='.urlencode($relativepath).'">'.img_pdf().' '.$file.'</a></td>';
+                    print '<td><a data-ajax="false" href="'.DOL_URL_ROOT.'/document.php?modulepart=facture_paiement&amp;file='.urlencode($relativepath).'">'.img_pdf().' '.$file.'</a>'.$formfile->showPreview($file, 'facture_paiement', $relativepath, 0).'</td>';
                     print '<td class="right">'.dol_print_size(dol_filesize($tfile)).'</td>';
                     print '<td class="right">'.dol_print_date(dol_filemtime($tfile), "dayhour").'</td>';
                     print '</tr>';

--- a/htdocs/core/modules/rapport/pdf_paiement.class.php
+++ b/htdocs/core/modules/rapport/pdf_paiement.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2003-2006 Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (C) 2006-2014 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2015-2018 Charlene BENKE  	<charlie@patas-monkey.com>
+ * Copyright (C) 2020      Maxime DEMAREST <maxime@indelog.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -207,7 +208,11 @@ class pdf_paiement
 					$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".$user->id;
 				}
 				if (!empty($socid)) $sql .= " AND s.rowid = ".$socid;
-				$sql .= " ORDER BY p.datep ASC, pf.fk_paiement ASC";
+				// If global param PAYMENTS_REPORT_GROUP_BY_MOD is set, payement are ordered by paiement_code
+				if (!empty($conf->global->PAYMENTS_REPORT_GROUP_BY_MOD))
+					$sql .= " ORDER BY paiement_code ASC, p.datep ASC, pf.fk_paiement ASC";
+				else
+					$sql .= " ORDER BY p.datep ASC, pf.fk_paiement ASC";
 				break;
 			case "fourn":
 				$sql = "SELECT p.datep as dp, f.ref as ref";
@@ -237,7 +242,11 @@ class pdf_paiement
 					$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".$user->id;
 				}
 				if (!empty($socid)) $sql .= " AND s.rowid = ".$socid;
-				$sql .= " ORDER BY p.datep ASC, pf.fk_paiementfourn ASC";
+                // If global param PAYMENTS_FOURN_REPORT_GROUP_BY_MOD is set, payement fourn are ordered by paiement_code
+				if (!empty($conf->global->PAYMENTS_FOURN_REPORT_GROUP_BY_MOD))
+					$sql .= " ORDER BY paiement_code ASC, p.datep ASC, pf.fk_paiementfourn ASC";
+				else
+					$sql .= " ORDER BY p.datep ASC, pf.fk_paiementfourn ASC";
 				break;
 		}
 
@@ -425,7 +434,7 @@ class pdf_paiement
 	public function Body(&$pdf, $page, $lines, $outputlangs)
 	{
         // phpcs:enable
-		global $langs;
+		global $langs, $conf;
 		$default_font_size = pdf_getPDFFontSize($outputlangs);
 
 		$pdf->SetFont('', '', $default_font_size - 1);
@@ -435,6 +444,11 @@ class pdf_paiement
 		$pdf->SetFillColor(220, 220, 220);
 		$yp = 0;
 		$numlines = count($lines);
+		if (($this->doc_type == 'client' && !empty($conf->global->PAYMENTS_REPORT_GROUP_BY_MOD)) || ($this->doc_type == 'fourn' && !empty($conf->global->PAYMENTS_FOURN_REPORT_GROUP_BY_MOD)))
+		{
+			$mod = $lines[0][2];
+			$total_mod = 0;
+		}
 		for ($j = 0; $j < $numlines; $j++)
 		{
 			$i = $j;
@@ -450,8 +464,17 @@ class pdf_paiement
 			{
 				if ($yp > $this->tab_height - 15)
 				{
-					$pdf->SetXY($this->posxpaymentamount, $this->tab_top + 10 + $yp);
-					$pdf->MultiCell($this->page_largeur - $this->marge_droite - $this->posxpaymentamount, $this->line_height, $langs->transnoentities('SubTotal')." : ".price($total_page), 0, 'R', 0);
+                    $pdf->SetFillColor(255, 255, 255);
+                    $pdf->Rect($this->marge_gauche +1, $this->tab_top + 10 + $yp, $this->posxpaymentamount - $this->marge_droite -3, $this->line_height, 'F', array(), array());
+                    $pdf->line($this->marge_gauche, $this->tab_top + 10 + $yp, $this->page_largeur - $this->marge_droite, $this->tab_top + 10 + $yp, array('dash'=>1));
+                    $pdf->line($this->marge_gauche, $this->tab_top + 15 + $yp, $this->page_largeur - $this->marge_droite, $this->tab_top + 15 + $yp);
+                    $pdf->SetFont('', 'B', $default_font_size - 1);
+                    $pdf->SetXY($this->posxdate -1, $this->tab_top + 10 + $yp);
+                    $pdf->MultiCell($this->posxpaymentamount - 2 - $this->marge_droite, $this->line_height, $langs->transnoentities('SubTotal')." : ", 0, 'R', 1);
+                    $pdf->SetXY($this->posxpaymentamount -1, $this->tab_top + 10 + $yp);
+                    $pdf->MultiCell($this->page_largeur - $this->marge_droite - $this->posxpaymentamount +1, $this->line_height, price($total_page), 0, 'R', 1);
+                    $pdf->SetFont('', '', $default_font_size - 1);
+                    $pdf->SetFillColor(220, 220, 220);
 					$page++;
 					$pdf->AddPage();
 					$this->_pagehead($pdf, $page, 0, $outputlangs);
@@ -474,6 +497,7 @@ class pdf_paiement
 				$pdf->MultiCell($this->page_largeur - $this->marge_droite - $this->posxpaymentamount, $this->line_height, $lines[$j][4], 0, 'R', 1);
 				$yp = $yp + 5;
 				$total_page += $lines[$j][9];
+				if (($this->doc_type == 'client' && !empty($conf->global->PAYMENTS_REPORT_GROUP_BY_MOD)) || ($this->doc_type == 'fourn' && !empty($conf->global->PAYMENTS_FOURN_REPORT_GROUP_BY_MOD))) $total_mod += $lines[$j][9];
 			}
 
 			// Invoice number
@@ -497,9 +521,45 @@ class pdf_paiement
 			{
 				$oldprowid = $lines[$j][7];
 			}
+
+            // Add line to add total by payment mode if mode reglement for nex line change
+            if ((($this->doc_type == 'client' && !empty($conf->global->PAYMENTS_REPORT_GROUP_BY_MOD)) || ($this->doc_type == 'fourn' && !empty($conf->global->PAYMENTS_FOURN_REPORT_GROUP_BY_MOD))) && ($mod != $lines[$j+1][2]))
+            {
+                $pdf->SetFillColor(245, 245, 245);
+                $pdf->Rect($this->marge_gauche +1, $this->tab_top + 10 + $yp, $this->posxpaymentamount - $this->marge_droite -3, $this->line_height, 'F', array(), array());
+                $pdf->line($this->marge_gauche, $this->tab_top + 10 + $yp, $this->page_largeur - $this->marge_droite, $this->tab_top + 10 + $yp, array('dash'=>1));
+                $pdf->line($this->marge_gauche, $this->tab_top + 15 + $yp, $this->page_largeur - $this->marge_droite, $this->tab_top + 15 + $yp);
+                $pdf->SetXY($this->posxdate -1, $this->tab_top + 10 + $yp);
+				$pdf->SetFont('', 'I', $default_font_size - 1);
+                $pdf->MultiCell($this->posxpaymentamount - 2 - $this->marge_droite, $this->line_height, $langs->transnoentities('Total').' '.$mod." : ", 0, 'R', 1);
+                $pdf->SetXY($this->posxpaymentamount -1, $this->tab_top + 10 + $yp);
+                $pdf->MultiCell($this->page_largeur - $this->marge_droite - $this->posxpaymentamount +1, $this->line_height, price($total_mod), 0, 'R', 1);
+				$pdf->SetFont('', '', $default_font_size - 1);
+                $mod = $lines[$j+1][2];
+                $total_mod = 0;
+				$yp = $yp + 5;
+                if ($yp > $this->tab_height - 5)
+                {
+                    $page++;
+                    $pdf->AddPage();
+                    $this->_pagehead($pdf, $page, 0, $outputlangs);
+                    $pdf->SetFont('', '', $default_font_size - 1);
+                    $yp = 0;
+                }
+                $pdf->SetFillColor(220, 220, 220);
+            }
+
 		}
 		$total += $total_page;
-		$pdf->SetXY($this->posxpaymentamount, $this->tab_top + 10 + $yp);
-		$pdf->MultiCell($this->page_largeur - $this->marge_droite - $this->posxpaymentamount, $this->line_height, $langs->transnoentities('Total')." : ".price($total), 0, 'R', 0);
+        $pdf->SetFillColor(255, 255, 255);
+        $pdf->Rect($this->marge_gauche +1, $this->tab_top + 10 + $yp, $this->posxpaymentamount - $this->marge_droite -3, $this->line_height, 'F', array(), array());
+        $pdf->line($this->marge_gauche, $this->tab_top + 10 + $yp, $this->page_largeur - $this->marge_droite, $this->tab_top + 10 + $yp, array('dash'=>1));
+        $pdf->line($this->marge_gauche, $this->tab_top + 15 + $yp, $this->page_largeur - $this->marge_droite, $this->tab_top + 15 + $yp);
+        $pdf->SetXY($this->posxdate -1, $this->tab_top + 10 + $yp);
+        $pdf->SetFont('', 'B');
+        $pdf->MultiCell($this->posxpaymentamount - 2 - $this->marge_droite, $this->line_height, $langs->transnoentities('Total')." : ", 0, 'R', 1);
+        $pdf->SetXY($this->posxpaymentamount -1, $this->tab_top + 10 + $yp);
+        $pdf->MultiCell($this->page_largeur - $this->marge_droite - $this->posxpaymentamount +1, $this->line_height, price($total), 0, 'R', 1);
+        $pdf->SetFillColor(220, 220, 220);
 	}
 }

--- a/htdocs/core/modules/rapport/pdf_paiement.class.php
+++ b/htdocs/core/modules/rapport/pdf_paiement.class.php
@@ -548,7 +548,6 @@ class pdf_paiement
                 }
                 $pdf->SetFillColor(220, 220, 220);
             }
-
 		}
 		$total += $total_page;
         $pdf->SetFillColor(255, 255, 255);

--- a/htdocs/fourn/facture/rapport.php
+++ b/htdocs/fourn/facture/rapport.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2017		ATM-Consulting  	 <support@atm-consulting.fr>
+ * Copyright (C) 2020		Maxime DEMAREST  	 <maxime@indelog.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +25,7 @@
 require '../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/modules/rapport/pdf_paiement_fourn.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
 
 $langs->loadLangs(array('bills'));
@@ -86,6 +88,7 @@ if ($action == 'builddoc')
  */
 
 $formother = new FormOther($db);
+$formfile = new FormFile($db);
 
 $titre = ($year ? $langs->trans("PaymentsReportsForYear", $year) : $langs->trans("PaymentsReports"));
 
@@ -157,7 +160,7 @@ if ($year)
                 {
                     $tfile = $dir.'/'.$year.'/'.$file;
                     $relativepath = $year.'/'.$file;
-                    print '<tr class="oddeven"><td><a data-ajax="false" href="'.DOL_URL_ROOT.'/document.php?modulepart=facture_fournisseur&amp;file=payments/'.urlencode($relativepath).'">'.img_pdf().' '.$file.'</a></td>';
+                    print '<tr class="oddeven"><td><a data-ajax="false" href="'.DOL_URL_ROOT.'/document.php?modulepart=facture_fournisseur&amp;file=payments/'.urlencode($relativepath).'">'.img_pdf().' '.$file.'</a>'.$formfile->showPreview($file, 'facture_fournisseur', 'payments/'.$relativepath, 0).'</td>';
                     print '<td class="right">'.dol_print_size(dol_filesize($tfile)).'</td>';
                     print '<td class="right">'.dol_print_date(dol_filemtime($tfile), "dayhour").'</td></tr>';
                 }

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -385,6 +385,7 @@ GeneratedFromTemplate=Generated from template invoice %s
 WarningInvoiceDateInFuture=Warning, the invoice date is higher than current date
 WarningInvoiceDateTooFarInFuture=Warning, the invoice date is too far from current date
 ViewAvailableGlobalDiscounts=View available discounts
+GroupPaymentsByModOnReports=Group payments by mode on reports
 # PaymentConditions
 Statut=Status
 PaymentConditionShortRECEP=Due Upon Receipt

--- a/htdocs/langs/fr_FR/bills.lang
+++ b/htdocs/langs/fr_FR/bills.lang
@@ -393,6 +393,7 @@ GeneratedFromTemplate=Généré à partir du modèle de facture %s
 WarningInvoiceDateInFuture=Attention, la date de facturation est antérieur à la date actuelle
 WarningInvoiceDateTooFarInFuture=Attention, la date de facturation est trop éloignée de la date actuelle
 ViewAvailableGlobalDiscounts=Voir les remises disponibles
+GroupPaymentsByModOnReports=Grouper les paiements par mode sur les rapports
 # PaymentConditions
 Statut=État
 PaymentConditionShortRECEP=A réception


### PR DESCRIPTION
This add two params (PAYMENTS_REPORT_GROUP_BY_MOD and
PAYMENTS_FOURN_REPORT_GROUP_BY_MOD) for payments and supplier payments
to group them by mode and get subtotals for each mode. Add the
corresponding configuration options on admin page fore each payments and
supplier payments.

I also improve pdf payments report genération by merging cells at begin of a line for total and sub totals and separating them by dashed line. Now we can preview reglement on page to generate it.
