### PR TITLE
FIX: add auto incrementation to llx_c_typent.sql

### DIFF
--- a/htdocs/install/mysql/tables/llx_c_typent.sql
+++ b/htdocs/install/mysql/tables/llx_c_typent.sql
@@ -19,11 +19,11 @@
 
 create table llx_c_typent
 (
-  id         integer      PRIMARY KEY,
-  code       varchar(12)  NOT NULL,
-  libelle    varchar(64),
-  fk_country integer NULL,		-- Defined only to have specific list for countries that can't use generic list (like argentina that need type A or B)
-  active     tinyint DEFAULT 1   NOT NULL,
-  module     varchar(32) NULL,
-  position   integer NOT NULL DEFAULT 0
+  id				integer			AUTO_INCREMENT PRIMARY KEY,
+  code			varchar(12)		NOT NULL,
+  libelle			varchar(64),
+  fk_country	integer			NULL,		-- Defined only to have specific list for countries that can't use generic list (like argentina that need type A or B)
+  active			tinyint				DEFAULT 1 NOT NULL,
+  module		varchar(32)		NULL,
+  position		integer			NOT NULL DEFAULT 0
 )ENGINE=innodb;


### PR DESCRIPTION
The llx_c_typent.sql had no AUTO_INCREMENT on id primary key. Using CTypent::create() without setting an id attribute before fails. We had to find ourselves the max(id) of the table then +1 then set the id then call create(). Think it would be easier to have this feature enabled unless there is a good reason to not have to?