### PR TITLE
PSR-2 Noncompliance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,6 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 
-# PHP PSR-2 Coding Standards
-# http://www.php-fig.org/psr/psr-2/
 [*.php]
 indent_style = tab
 indent_size = 4

--- a/htdocs/modulebuilder/template/.editorconfig
+++ b/htdocs/modulebuilder/template/.editorconfig
@@ -9,8 +9,6 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 
-# PHP PSR-2 Coding Standards
-# http://www.php-fig.org/psr/psr-2/
 [*.php]
 indent_style = tab
 indent_size = 4


### PR DESCRIPTION
Dolibarr is not PSR-2 compliant, as seen on https://www.php-fig.org/psr/psr-2/

> Code MUST use 4 spaces for indenting, not tabs.
