### PR TITLE
MAIN_NO_CONCAT_DESCRIPTION in contrat/card.php

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -523,7 +523,7 @@ if (empty($reshook))
 			   	$desc = $prod->description;
 			   	if (!empty($product_desc) && !empty($conf->global->MAIN_NO_CONCAT_DESCRIPTION)) $desc = $product_desc;
 				else $desc = dol_concatdesc($desc, $product_desc, '', !empty($conf->global->MAIN_CHANGE_ORDER_CONCAT_DESCRIPTION));
-				
+
 				$fk_unit = $prod->fk_unit;
 			}
 			else

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -523,6 +523,7 @@ if (empty($reshook))
 			   	$desc = $prod->description;
 			   	if (!empty($product_desc) && !empty($conf->global->MAIN_NO_CONCAT_DESCRIPTION)) $desc = $product_desc;
 				else $desc = dol_concatdesc($desc, $product_desc, '', !empty($conf->global->MAIN_CHANGE_ORDER_CONCAT_DESCRIPTION));
+				
 				$fk_unit = $prod->fk_unit;
 			}
 			else

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -521,7 +521,8 @@ if (empty($reshook))
 				}
 
 			   	$desc = $prod->description;
-			   	$desc = dol_concatdesc($desc, $product_desc, '', !empty($conf->global->MAIN_CHANGE_ORDER_CONCAT_DESCRIPTION));
+			   	if (!empty($product_desc) && !empty($conf->global->MAIN_NO_CONCAT_DESCRIPTION)) $desc = $product_desc;
+				else $desc = dol_concatdesc($desc, $product_desc, '', !empty($conf->global->MAIN_CHANGE_ORDER_CONCAT_DESCRIPTION));
 				$fk_unit = $prod->fk_unit;
 			}
 			else


### PR DESCRIPTION
Use MAIN_NO_CONCAT_DESCRIPTION  to permit to not concat filled description line with product description.
See comm/propal/card.php lines 1042

