### PR TITLE
FIX wrong user right's name to top menu "commercial"

### DIFF
--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -234,7 +234,7 @@ function print_eldy_menu($db, $atarget, $type_user, &$tabMenu, &$menu, $noout = 
 	        ) ? 1 : 0,
 		'perms'=>(!empty($user->rights->propal->lire) ||
 				  !empty($user->rights->commande->lire) ||
-				  !empty($user->rights->supplier_order->lire) ||
+				  !empty($user->rights->fournisseur->lire) ||
 				  !empty($user->rights->supplier_proposal->lire) ||
 				  !empty($user->rights->contrat->lire) ||
 				  !empty($user->rights->ficheinter->lire)


### PR DESCRIPTION
# Fix #
Menu "Commercial" in top menu doesn't display when user has rights : wrong name of a user's right in eldy's lib.