### PR TITLE
NEW Add include various payments and loans in accounting report with simplfified accountancy

### DIFF
--- a/htdocs/admin/compta.php
+++ b/htdocs/admin/compta.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2011-2013 Juanjo Menent	    <jmenent@2byte.es>
  * Copyright (C) 2013-2017 Philippe Grand	    <philippe.grand@atoo-net.com>
  * Copyright (C) 2014      Marcos García        <marcosgdf@gmail.com>
+ * Copyright (C) 2020      Maxime DEMAREST      <maxime@indelog.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -83,6 +84,20 @@ if ($action == 'update')
         }
     }
 
+    $report_include_varpay = GETPOST('ACCOUNTING_REPORTS_INCLUDE_VARPAY', 'alpha');
+    if (!empty($report_include_varpay))
+        if ($report_include_varpay == 'yes')
+            if (!dolibarr_set_const($db, 'ACCOUNTING_REPORTS_INCLUDE_VARPAY', 1, 'chaine', 0, '', $conf->entity)) $error++;
+        if ($report_include_varpay == 'no')
+            if (!dolibarr_del_const($db, 'ACCOUNTING_REPORTS_INCLUDE_VARPAY', $conf->entity)) $error++;
+
+    $report_include_loan = GETPOST('ACCOUNTING_REPORTS_INCLUDE_LOAN', 'alpha');
+    if (!empty($report_include_loan))
+        if ($report_include_loan == 'yes')
+            if (!dolibarr_set_const($db, 'ACCOUNTING_REPORTS_INCLUDE_LOAN', 1, 'chaine', 0, '', $conf->entity)) $error++;
+        if ($report_include_loan == 'no')
+            if (!dolibarr_del_const($db, 'ACCOUNTING_REPORTS_INCLUDE_LOAN', $conf->entity)) $error++;
+
     if (!$error)
     {
         setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
@@ -157,6 +172,26 @@ foreach ($list as $key)
 	print '<input type="text" size="20" id="'.$key.'" name="'.$key.'" value="'.$conf->global->$key.'">';
 	print '</td></tr>';
 }
+
+// Option to include various payment in results
+print '<tr class="oddeven value">'."\n";
+print '<td><label for="ACCOUNTING_REPORTS_INCLUDE_VARPAY">'.$langs->trans('IncludeVarpaysInResults').'</label></td>'."\n";
+print '<td class="center">'."\n";
+print '<select id="ACCOUNTING_REPORTS_INCLUDE_VARPAY" name="ACCOUNTING_REPORTS_INCLUDE_VARPAY">'."\n";
+print '<option value="no" '.(empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_VARPAY)?'selected':'').'>'.$langs->trans('No').'</option>'."\n";
+print '<option value="yes" '.(!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_VARPAY)?'selected':'').'>'.$langs->trans('Yes').'</option>'."\n";
+print '</select>'."\n";
+print '</td></tr>';
+
+// Option to include loan in results
+print '<tr class="oddeven value">'."\n";
+print '<td><label for="ACCOUNTING_REPORTS_INCLUDE_LOAN">'.$langs->trans('IncludeLoansInResults').'</label></td>'."\n";
+print '<td class="center">'."\n";
+print '<select id="ACCOUNTING_REPORTS_INCLUDE_LOAN" name="ACCOUNTING_REPORTS_INCLUDE_LOAN">'."\n";
+print '<option value="no" '.(empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_LOAN)?'selected':'').'>'.$langs->trans('No').'</option>'."\n";
+print '<option value="yes" '.(!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_LOAN)?'selected':'').'>'.$langs->trans('Yes').'</option>'."\n";
+print '</select>'."\n";
+print '</td></tr>';
 
 print "</table>\n";
 

--- a/htdocs/admin/compta.php
+++ b/htdocs/admin/compta.php
@@ -177,20 +177,14 @@ foreach ($list as $key)
 print '<tr class="oddeven value">'."\n";
 print '<td><label for="ACCOUNTING_REPORTS_INCLUDE_VARPAY">'.$langs->trans('IncludeVarpaysInResults').'</label></td>'."\n";
 print '<td class="center">'."\n";
-print '<select id="ACCOUNTING_REPORTS_INCLUDE_VARPAY" name="ACCOUNTING_REPORTS_INCLUDE_VARPAY">'."\n";
-print '<option value="no" '.(empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_VARPAY)?'selected':'').'>'.$langs->trans('No').'</option>'."\n";
-print '<option value="yes" '.(!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_VARPAY)?'selected':'').'>'.$langs->trans('Yes').'</option>'."\n";
-print '</select>'."\n";
+print $form->selectyesno('ACCOUNTING_REPORTS_INCLUDE_VARPAY', (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_VARPAY)));
 print '</td></tr>';
 
 // Option to include loan in results
 print '<tr class="oddeven value">'."\n";
 print '<td><label for="ACCOUNTING_REPORTS_INCLUDE_LOAN">'.$langs->trans('IncludeLoansInResults').'</label></td>'."\n";
 print '<td class="center">'."\n";
-print '<select id="ACCOUNTING_REPORTS_INCLUDE_LOAN" name="ACCOUNTING_REPORTS_INCLUDE_LOAN">'."\n";
-print '<option value="no" '.(empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_LOAN)?'selected':'').'>'.$langs->trans('No').'</option>'."\n";
-print '<option value="yes" '.(!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_LOAN)?'selected':'').'>'.$langs->trans('Yes').'</option>'."\n";
-print '</select>'."\n";
+print $form->selectyesno('ACCOUNTING_REPORTS_INCLUDE_LOAN', (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_LOAN)));
 print '</td></tr>';
 
 print "</table>\n";

--- a/htdocs/compta/resultat/clientfourn.php
+++ b/htdocs/compta/resultat/clientfourn.php
@@ -977,7 +977,6 @@ else
         $result = $db->query($sql);
         if ($result)
         {
-
             // Debit
             $obj = $db->fetch_object($result);
             if (isset($obj->amount))
@@ -987,7 +986,7 @@ else
             }
             print '<tr class="oddeven"><td>&nbsp;</td>';
             print "<td>".$langs->trans("Debit")."</td>\n";
-	        if ($modecompta == 'CREANCES-DETTES') print '<td class="right">'.price(-$obj->amount).'</td>';
+            if ($modecompta == 'CREANCES-DETTES') print '<td class="right">'.price(-$obj->amount).'</td>';
             print '<td class="right">'.price(-$obj->amount)."</td>\n";
             print "</tr>\n";
 
@@ -1000,7 +999,7 @@ else
             }
             print '<tr class="oddeven"><td>&nbsp;</td>';
             print "<td>".$langs->trans("Credit")."</td>\n";
-	        if ($modecompta == 'CREANCES-DETTES') print '<td class="right">'.price($obj->amount).'</td>';
+            if ($modecompta == 'CREANCES-DETTES') print '<td class="right">'.price($obj->amount).'</td>';
             print '<td class="right">'.price($obj->amount)."</td>\n";
             print "</tr>\n";
 
@@ -1012,7 +1011,6 @@ else
                 print '<td colspan="3" class="right">'.price($subtotal_ht).'</td>';
             print '<td colspan="3" class="right">'.price($subtotal_ttc).'</td>';
             print '</tr>';
-
         }
         else dol_print_error($db);
     }
@@ -1055,7 +1053,6 @@ else
                 $subtotal_ht -= $obj->amount;
                 $subtotal_ttc -= $obj->amount;
             }
-
             $total_ht += $subtotal_ht;
             $total_ttc += $subtotal_ttc;
             print '<tr class="liste_total">';
@@ -1066,7 +1063,6 @@ else
         }
         else dol_print_error($db);
     }
-
 
 	/*
 	 * VAT

--- a/htdocs/compta/resultat/clientfourn.php
+++ b/htdocs/compta/resultat/clientfourn.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2014       Juanjo Menent           <jmenent@2byte.es>
  * Copyright (C) 2014       Florian Henry           <florian.henry@open-concept.pro>
  * Copyright (C) 2018       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2020       Maxime DEMAREST         <maxime@indelog.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,7 +39,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/accountancy/class/accountancycategory.class.php';
 
 // Load translation files required by the page
-$langs->loadLangs(array('compta', 'bills', 'donation', 'salaries', 'accountancy'));
+$langs->loadLangs(array('compta', 'bills', 'donation', 'salaries', 'accountancy', 'loan'));
 
 $date_startmonth = GETPOST('date_startmonth', 'int');
 $date_startday = GETPOST('date_startday', 'int');
@@ -952,6 +953,119 @@ else
 		print '<td colspan="3" class="right">'.price($subtotal_ttc).'</td>';
 		print '</tr>';
 	}
+
+    /*
+     * Various Payments
+     */
+
+    if (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_VARPAY) && !empty($conf->banque->enabled) && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES"))
+    {
+        $subtotal_ht = 0;
+        $subtotal_ttc = 0;
+
+        print '<tr class="trforbreak"><td colspan="4">'.$langs->trans("VariousPayment").'</td></tr>';
+
+        // Debit
+        $sql = "SELECT SUM(p.amount) AS amount FROM ".MAIN_DB_PREFIX."payment_various as p";
+        $sql .= ' WHERE 1 = 1';
+        if (!empty($date_start) && !empty($date_end))
+            $sql .= " AND p.datep >= '".$db->idate($date_start)."' AND p.datep <= '".$db->idate($date_end)."'";
+        $sql .= ' GROUP BY p.sens';
+        $sql .= ' ORDER BY p.sens';
+
+        dol_syslog('get various payments', LOG_DEBUG);
+        $result = $db->query($sql);
+        if ($result)
+        {
+
+            // Debit
+            $obj = $db->fetch_object($result);
+            if (isset($obj->amount))
+            {
+                $subtotal_ht += -$obj->amount;
+                $subtotal_ttc += -$obj->amount;
+            }
+            print '<tr class="oddeven"><td>&nbsp;</td>';
+            print "<td>".$langs->trans("Debit")."</td>\n";
+	        if ($modecompta == 'CREANCES-DETTES') print '<td class="right">'.price(-$obj->amount).'</td>';
+            print '<td class="right">'.price(-$obj->amount)."</td>\n";
+            print "</tr>\n";
+
+            // Credit
+            $obj = $db->fetch_object($result);
+            if (isset($obj->amount))
+            {
+                $subtotal_ht += $obj->amount;
+                $subtotal_ttc += $obj->amount;
+            }
+            print '<tr class="oddeven"><td>&nbsp;</td>';
+            print "<td>".$langs->trans("Credit")."</td>\n";
+	        if ($modecompta == 'CREANCES-DETTES') print '<td class="right">'.price($obj->amount).'</td>';
+            print '<td class="right">'.price($obj->amount)."</td>\n";
+            print "</tr>\n";
+
+            // Total
+            $total_ht += $subtotal_ht;
+            $total_ttc += $subtotal_ttc;
+            print '<tr class="liste_total">';
+            if ($modecompta == 'CREANCES-DETTES')
+                print '<td colspan="3" class="right">'.price($subtotal_ht).'</td>';
+            print '<td colspan="3" class="right">'.price($subtotal_ttc).'</td>';
+            print '</tr>';
+
+        }
+        else dol_print_error($db);
+    }
+
+    /*
+     * Payement Loan
+     */
+
+    if (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_LOAN) && !empty($conf->loan->enabled) && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES"))
+    {
+        $subtotal_ht = 0;
+        $subtotal_ttc = 0;
+
+        print '<tr class="trforbreak"><td colspan="4">'.$langs->trans("PaymentLoan").'</td></tr>';
+
+        $sql = 'SELECT l.rowid as id, l.label AS label, SUM(p.amount_capital + p.amount_insurance + p.amount_interest) as amount FROM '.MAIN_DB_PREFIX.'payment_loan as p';
+        $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'loan AS l ON l.rowid = p.fk_loan';
+        $sql .= ' WHERE 1 = 1';
+        if (!empty($date_start) && !empty($date_end))
+            $sql .= " AND p.datep >= '".$db->idate($date_start)."' AND p.datep <= '".$db->idate($date_end)."'";
+        $sql .= ' GROUP BY p.fk_loan';
+        $sql .= ' ORDER BY p.fk_loan';
+
+        dol_syslog('get loan payments', LOG_DEBUG);
+        $result = $db->query($sql);
+        if ($result)
+        {
+            require_once DOL_DOCUMENT_ROOT.'/loan/class/loan.class.php';
+            $loan_static = new Loan($db);
+            while ($obj = $db->fetch_object($result))
+            {
+                $loan_static->id = $obj->id;
+                $loan_static->ref = $obj->id;
+                $loan_static->label = $obj->label;
+                print '<tr class="oddeven"><td>&nbsp;</td>';
+                print "<td>".$loan_static->getNomUrl(1).' - '.$obj->label."</td>\n";
+                if ($modecompta == 'CREANCES-DETTES') print '<td class="right">'.price(-$obj->amount).'</td>';
+                print '<td class="right">'.price(-$obj->amount)."</td>\n";
+                print "</tr>\n";
+                $subtotal_ht -= $obj->amount;
+                $subtotal_ttc -= $obj->amount;
+            }
+
+            $total_ht += $subtotal_ht;
+            $total_ttc += $subtotal_ttc;
+            print '<tr class="liste_total">';
+            if ($modecompta == 'CREANCES-DETTES')
+                print '<td colspan="3" class="right">'.price($subtotal_ht).'</td>';
+            print '<td colspan="3" class="right">'.price($subtotal_ttc).'</td>';
+            print '</tr>';
+        }
+        else dol_print_error($db);
+    }
 
 
 	/*

--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -801,7 +801,6 @@ elseif ($modecompta == 'BOOKKEEPING') {
 
 if (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_VARPAY) && !empty($conf->banque->enabled) && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES"))
 {
-
     // decaiss
 
     $sql = "SELECT date_format(p.datep, '%Y-%m') AS dm, SUM(p.amount) AS amount FROM ".MAIN_DB_PREFIX."payment_various as p";
@@ -863,9 +862,9 @@ if (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_VARPAY) && !empty($conf->ba
     }
 
 }
-elseif ($modecompta == 'BOOKKEEPING') {
-	// Useless with BOOKKEEPING
-}
+// Useless with BOOKKEEPING
+//elseif ($modecompta == 'BOOKKEEPING') {
+//}
 
 /*
  * Payement Loan
@@ -873,7 +872,6 @@ elseif ($modecompta == 'BOOKKEEPING') {
 
 if (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_LOAN) && !empty($conf->loan->enabled) && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES"))
 {
-
     $sql = "SELECT date_format(p.datep, '%Y-%m') AS dm, SUM(p.amount_capital + p.amount_insurance + p.amount_interest) AS amount FROM ".MAIN_DB_PREFIX."payment_loan AS p";
     $sql .= ' WHERE 1 = 1';
     if (!empty($date_start) && !empty($date_end))
@@ -903,9 +901,9 @@ if (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_LOAN) && !empty($conf->loan
     }
 
 }
-elseif ($modecompta == 'BOOKKEEPING') {
-	// Not use with BOOKKEEPING
-}
+// Useless with BOOKKEEPING
+//elseif ($modecompta == 'BOOKKEEPING') {
+//}
 
 
 /*

--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -860,7 +860,6 @@ if (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_VARPAY) && !empty($conf->ba
     {
     	dol_print_error($db);
     }
-
 }
 // Useless with BOOKKEEPING
 //elseif ($modecompta == 'BOOKKEEPING') {
@@ -899,7 +898,6 @@ if (!empty($conf->global->ACCOUNTING_REPORTS_INCLUDE_LOAN) && !empty($conf->loan
     {
     	dol_print_error($db);
     }
-
 }
 // Useless with BOOKKEEPING
 //elseif ($modecompta == 'BOOKKEEPING') {

--- a/htdocs/langs/en_US/compta.lang
+++ b/htdocs/langs/en_US/compta.lang
@@ -262,3 +262,5 @@ RulesPurchaseTurnoverIn=- It includes all the effective payments of invoices don
 RulesPurchaseTurnoverTotalPurchaseJournal=It includes all debit lines from the purchase journal.
 ReportPurchaseTurnover=Purchase turnover invoiced
 ReportPurchaseTurnoverCollected=Purchase turnover collected
+IncludeVarpaysInResults = Include various payments in reports
+IncludeLoansInResults = Include loans in reports

--- a/htdocs/langs/fr_FR/compta.lang
+++ b/htdocs/langs/fr_FR/compta.lang
@@ -262,3 +262,5 @@ RulesPurchaseTurnoverIn=- It includes all the effective payments of invoices don
 RulesPurchaseTurnoverTotalPurchaseJournal=It includes all debit lines from the purchase journal.
 ReportPurchaseTurnover=Purchase turnover invoiced
 ReportPurchaseTurnoverCollected=Purchase turnover collected
+IncludeVarpaysInResults = Inclure les payments divers dans les rapports
+IncludeLoansInResults = Inclure les emprunts dans les rapports


### PR DESCRIPTION

When use simplified accounting accounting module, the payments various and the loans payments are not included in reports.

This add the possibility to optionaly include them by this global settings :

* `ACCOUNTING_REPORTS_INCLUDE_VARPAY` for payments various.
* `ACCOUNTING_REPORTS_INCLUDE_LOAN` for loans payments.

This settings can also be enabled in admin page for simplified accounting module.