### PR TITLE
Update facture.class.php

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1184,7 +1184,7 @@ class Facture extends CommonInvoice
 				// Get the dates
 				$start = dol_getdate($line->date_start);
 				$end = dol_getdate($line->date_end);
-				
+
 				// Get the first and last day of the month
 				$first = dol_get_first_day($start['year'], $start['mon']);
 				$last = dol_get_first_day($end['year'], $end['mon']);
@@ -1196,8 +1196,8 @@ class Facture extends CommonInvoice
 				// If there is <= 1d (or 2?) of start/or/end of month
 				if ($diffFirst <= 2 && $diffLast <= 2) {
 					$nextMonth = dol_get_next_month($end['mon'], $end['year']);
-					$newFirst = dol_get_first_day($nextMonth['year'],$nextMonth['month']);
-					$newLast = dol_get_last_day($nextMonth['year'],$nextMonth['month']);
+					$newFirst = dol_get_first_day($nextMonth['year'], $nextMonth['month']);
+					$newLast = dol_get_last_day($nextMonth['year'], $nextMonth['month']);
 					$object->lines[$i]->date_start = $newFirst;
 					$object->lines[$i]->date_end = $newLast;
 				}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1178,6 +1178,30 @@ class Facture extends CommonInvoice
 			    unset($object->lines[$i]);
 			    unset($object->products[$i]); // Tant que products encore utilise
 			}
+						// Bloc to update dates of service (month by month only if previously filled at 1d near start or end of month)
+			// If it's a service with start and end dates
+			if ($line->product_type == 1 && !empty($line->date_start) && !empty($line->date_end) ) {
+				// Get the dates
+				$start = dol_getdate($line->date_start);
+				$end = dol_getdate($line->date_end);
+				
+				// Get the first and last day of the month
+				$first = dol_get_first_day($start['year'], $start['mon']);
+				$last = dol_get_first_day($end['year'], $end['mon']);
+
+				// Get diff betweend start/end of month and previously filled
+				$diffFirst = num_between_day($first, dol_mktime($start['hours'], $start['minutes'], $start['seconds'], $start['mon'], $start['mday'], $start['year'], 'user'));
+				$diffLast = num_between_day(dol_mktime($end['hours'], $end['minutes'], $end['seconds'], $end['mon'], $end['mday'], $end['year'], 'user'), $last);
+
+				// If there is <= 1d (or 2?) of start/or/end of month
+				if ($diffFirst <= 2 && $diffLast <= 2) {
+					$nextMonth = dol_get_next_month($end['mon'], $end['year']);
+					$newFirst = dol_get_first_day($nextMonth['year'],$nextMonth['month']);
+					$newLast = dol_get_last_day($nextMonth['year'],$nextMonth['month']);
+					$object->lines[$i]->date_start = $newFirst;
+					$object->lines[$i]->date_end = $newLast;
+				}
+			}
 		}
 
 		// Create clone

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1180,7 +1180,7 @@ class Facture extends CommonInvoice
 			}
 						// Bloc to update dates of service (month by month only if previously filled at 1d near start or end of month)
 			// If it's a service with start and end dates
-			if ($line->product_type == 1 && !empty($line->date_start) && !empty($line->date_end) ) {
+			if (!empty($line->date_start) && !empty($line->date_end) ) {
 				// Get the dates
 				$start = dol_getdate($line->date_start);
 				$end = dol_getdate($line->date_end);


### PR DESCRIPTION
Auto-update dates (if not empty) of services when cloning facture.

Actual code is only for month by month.

If empty (start or end) => do nothing

If set, update for next month if there is only 1d between what had been set and the start (or end) of the month.
If there is more than one day from start or end of the month => do nothing, because we're not sure the service is by month

Worst case scenario : the facture is cloned, the service is updated with new unwanted dates
User need to manually updates date : he would have done that either way
