### PR TITLE
NEW Enable or disable "Reply-to" in the header when we send mail with Dolibarr

### DIFF
--- a/htdocs/admin/dolistore/ajax/image.php
+++ b/htdocs/admin/dolistore/ajax/image.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2017		 Oscss-Shop              <support@oscss-shop.fr>.
  * Copyright (C) 2008-2011   Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2020       Frédéric France         <frederic.france@netlogic.fr>
  *
  * This program is free software; you can redistribute it and/or modifyion 2.0 (the "License");
  * it under the terms of the GNU General Public License as published bypliance with the License.
@@ -17,6 +18,9 @@
  */
 
 if (!defined('REQUIRE_JQUERY_BLOCKUI')) define('REQUIRE_JQUERY_BLOCKUI', 1);
+if (!defined('NOTOKENRENEWAL')) {
+    define('NOTOKENRENEWAL', 1);
+}
 
 
 /**

--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -235,7 +235,7 @@ if ($action == "view_ticketlist")
         if (is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label'])) {
         	foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $val) {
         		if ($extrafields->attributes[$object->table_element]['type'][$key] != 'separate') {
-        			$arrayfields["ef.".$key] = array('label' => $extrafields->attributes[$object->table_element]['label'][$key], 'checked' => $extrafields->attributes[$object->table_element]['list'][$key], 'position' => $extrafields->attributes[$object->table_element]['pos'][$key], 'enabled' => $extrafields->attributes[$object->table_element]['perms'][$key]);
+        			$arrayfields["ef.".$key] = array('label' => $extrafields->attributes[$object->table_element]['label'][$key], 'checked' => ($extrafields->attributes[$object->table_element]['list'][$key] < 0) ? 0 : 1, 'position' => $extrafields->attributes[$object->table_element]['pos'][$key], 'enabled' =>(abs($extrafields->attributes[$object->table_element]['list'][$key]) != 3) && $extrafields->attributes[$object->table_element]['perms'][$key]);
                 }
             }
         }


### PR DESCRIPTION
# New Enable or disable "Reply-to" in the header when we send mail 
Possibility to disable or enable the "reply-to" parameter in the header when we send mail with Dolibarr.

Actually, the "reply-to" parameter is always in the mail header.
When we use automatic signature inserted with SMTP connector (like LetSignIT or Exclaimer), they detect the "reply-to" in the mail header and they push the "reply" signature instead of the first mail send signature.



