### PR TITLE
FIX 9.0 - fatal during migration from 3.1 using PHP 7

### DIFF
--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -3605,10 +3605,9 @@ function migrate_mode_reglement($db,$langs,$conf)
  * @param	DoliDB		$db			Database handler
  * @param	Translate	$langs		Object langs
  * @param	Conf		$conf		Object conf
- * @param	string		$versionto	Version target
  * @return	void
  */
-function migrate_clean_association($db,$langs,$conf,$versionto)
+function migrate_clean_association($db, $langs, $conf)
 {
     $result = $db->DDLDescTable(MAIN_DB_PREFIX."categorie_association");
     if ($result)	// result defined for version 3.2 or -


### PR DESCRIPTION
# Fix: fatal error during migration from 3.1 when using PHP 7
## Context
The function `migrate_clean_association` (used only once) takes 4 mandatory arguments, but it is called with 3. The fourth argument (`$versionto`) is not used within the function.

Before PHP 7, a lower than required argument count in a function call triggered a warning; now it is an error.

## Fix
I removed the unused argument from the function declaration and PHPdoc.