### PR TITLE
FIX Site ec.europa.eu has moved to https://

### DIFF
--- a/htdocs/societe/checkvat/checkVatPopup.php
+++ b/htdocs/societe/checkvat/checkVatPopup.php
@@ -28,9 +28,9 @@ require_once NUSOAP_PATH.'/nusoap.php';
 $langs->load("companies");
 
 //http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl
-$WS_DOL_URL='http://ec.europa.eu/taxation_customs/vies/services/checkVatService';
+$WS_DOL_URL='https://ec.europa.eu/taxation_customs/vies/services/checkVatService';
 //$WS_DOL_URL_WSDL=$WS_DOL_URL.'?wsdl';
-$WS_DOL_URL_WSDL='http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
+$WS_DOL_URL_WSDL='https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
 $WS_METHOD ='checkVat';
 
 


### PR DESCRIPTION
Refer to this post on french forum : 

https://www.dolibarr.fr/forum/t/resolu-la-verification-du-numero-de-tva-ne-fonctionne-plus/32924/4

Service is not out. Service has moved to https. Fix for all version of Dolibarr from v9.

Thanks to Anwar Guerch !