### PR TITLE
Fix cron globals reload, missing mysoc and langs

### DIFF
--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -223,7 +223,7 @@ if (is_array($qualifiedjobs) && (count($qualifiedjobs)>0))
 		    // Reload langs
 		    $langcode = (empty($conf->global->MAIN_LANG_DEFAULT)?'auto':$conf->global->MAIN_LANG_DEFAULT);
 		    if (! empty($user->conf->MAIN_LANG_DEFAULT)) $langcode = $user->conf->MAIN_LANG_DEFAULT;
-		    if($langs->getDefaultLang() != $langcode) $langs->setDefaultLang($langcode);
+		    if ($langs->getDefaultLang() != $langcode) $langs->setDefaultLang($langcode);
 		}
 
 		//If date_next_jobs is less of current date, execute the program, and store the execution time of the next execution in database

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -191,11 +191,12 @@ if (is_array($qualifiedjobs) && (count($qualifiedjobs)>0))
 		// Force reload of setup for the current entity
 		if ($line->entity != $conf->entity)
 		{
-		    dol_syslog("cron_run_jobs.php we work on another entity so we reload user and conf", LOG_DEBUG);
-		    echo " -> we change entity so we reload user and conf";
+		    dol_syslog("cron_run_jobs.php we work on another entity so we reload mysoc, langs, user and conf", LOG_DEBUG);
+		    echo " -> we change entity so we reload mysoc, langs, user and conf";
 
 		    $conf->entity = (empty($line->entity)?1:$line->entity);
 		    $conf->setValues($db);        // This make also the $mc->setValues($conf); that reload $mc->sharings
+		    $mysoc->setMysoc($conf);
 
 		    // Force recheck that user is ok for the entity to process and reload permission for entity
 		    if ($conf->entity != $user->entity && $user->entity != 0)
@@ -218,6 +219,11 @@ if (is_array($qualifiedjobs) && (count($qualifiedjobs)>0))
     		    }
     		    $user->getrights();
 		    }
+
+		    // Reload langs
+		    $langcode = (empty($conf->global->MAIN_LANG_DEFAULT)?'auto':$conf->global->MAIN_LANG_DEFAULT);
+		    if (! empty($user->conf->MAIN_LANG_DEFAULT)) $langcode = $user->conf->MAIN_LANG_DEFAULT;
+		    if($langs->getDefaultLang() != $langcode) $langs->setDefaultLang($langcode);
 		}
 
 		//If date_next_jobs is less of current date, execute the program, and store the execution time of the next execution in database


### PR DESCRIPTION
The cron job was not reloading mysoc and langs, so with multicompany module, the invoice model job was generating invoices with mysoc infos from entity 1, and in the language of entity 1, for all entities.