### PR TITLE
Fix #13911 set weight to 0 for new product created with no weight

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -303,7 +303,7 @@ if (empty($reshook))
             $object->canvas             	 = GETPOST('canvas');
             $object->net_measure           = GETPOST('net_measure');
             $object->net_measure_units     = GETPOST('net_measure_units'); // This is not the fk_unit but the power of unit
-            $object->weight             	 = GETPOST('weight');
+            $object->weight             	 = GETPOST('weight')?GETPOST('weight') : 0;
             $object->weight_units       	 = GETPOST('weight_units'); // This is not the fk_unit but the power of unit
             $object->length             	 = GETPOST('size');
             $object->length_units       	 = GETPOST('size_units'); // This is not the fk_unit but the power of unit

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -328,7 +328,7 @@ class ProductCombination
 		$child->fetch($this->fk_product_child);
 
 		// Get the label of the child from the DB to preserve user changes
-        $childDataSqlQuery = 'SELECT label FROM ' . MAIN_DB_PREFIX . "product "
+        $childDataSqlQuery = 'SELECT label FROM ' . MAIN_DB_PREFIX . 'product '
                             .'WHERE rowid = ' . $this->fk_product_child;
         $childQuery = $this->db->query($childDataSqlQuery);
         $childLabel = $this->db->fetch_row($childQuery);

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -326,11 +326,18 @@ class ProductCombination
 
 		$child = new Product($this->db);
 		$child->fetch($this->fk_product_child);
-		$child->price_autogen = $parent->price_autogen;
-		$child->weight = $parent->weight + $this->variation_weight;
-		$child->weight_units = $parent->weight_units;
-		$varlabel = $this->getCombinationLabel($this->fk_product_child);
-		$child->label = $parent->label.$varlabel;
+
+		// Get the label of the child from the DB to preserve user changes
+        $childDataSqlQuery = 'SELECT label FROM ' . MAIN_DB_PREFIX . "product "
+                            .'WHERE rowid = ' . $this->fk_product_child;
+        $childQuery = $this->db->query($childDataSqlQuery);
+        $childLabel = $this->db->fetch_row($childQuery);
+
+        $child->price_autogen   = $parent->price_autogen;
+        $child->weight          = $parent->weight + $this->variation_weight;
+        $child->weight_units    = $parent->weight_units;
+        $varlabel               = $this->getCombinationLabel($this->fk_product_child);
+        $child->label           = $childLabel[0];
 
 		if ($child->update($child->id, $user) > 0) {
 			$new_vat = $parent->tva_tx;

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -328,8 +328,7 @@ class ProductCombination
 		$child->fetch($this->fk_product_child);
 
 		// Get the label of the child from the DB to preserve user changes
-        $childDataSqlQuery = 'SELECT label FROM ' . MAIN_DB_PREFIX . 'product '
-                            .'WHERE rowid = ' . $this->fk_product_child;
+        $childDataSqlQuery = 'SELECT label FROM ' . MAIN_DB_PREFIX . 'product WHERE rowid = ' . $this->fk_product_child;
         $childQuery = $this->db->query($childDataSqlQuery);
         $childLabel = $this->db->fetch_row($childQuery);
 


### PR DESCRIPTION
# Fix #13911 
Set the weight to "0" instead of "NULL" for newly created product.
This will prevent warning when the weight is used for calculation.
Ex:
When the weight of the product is added to the weight of a variant.

> htdocs/variants/class/ProductCombination.class.php - Line 330


