### PR TITLE
Fix extrafield empty value saving

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2157,7 +2157,7 @@ class ExtraFields
 				}
 				elseif (in_array($key_type, array('checkbox', 'chkbxlst')))
 				{
-					if (! GETPOSTISSET($keysuffix."options_".$key.$keyprefix)) continue;	// Value was not provided, we should not set it.
+					// even we receve nothing from this input we need to update it because checkbox send nothing when nothing is selected
 					$value_arr = GETPOST($keysuffix."options_".$key.$keyprefix);
 					// Make sure we get an array even if there's only one checkbox
 					$value_arr = (array) $value_arr;


### PR DESCRIPTION
see @eldy fix  https://github.com/Dolibarr/dolibarr/commit/09f809f347df80160aed14af2ee9362dbb6025e4 for  #12913 

This is an small correction for checkbox.

**how to experiment the bug : (need dolibarr v11)**
1. Add a new extrafield multi checkbox on propal line
2. Add a new line with 2 selected item.
3. Edit the line, remove all selected item and save, the selected items are still here

**Correction :**
Even we receive nothing from this input we need to update it because checkbox send nothing when nothing is selected