### PR TITLE
FIX 10.0 - pagination in prelevement/bons.php

### DIFF
--- a/htdocs/compta/prelevement/bons.php
+++ b/htdocs/compta/prelevement/bons.php
@@ -36,7 +36,10 @@ $socid = GETPOST('socid', 'int');
 if ($user->societe_id) $socid=$user->societe_id;
 $result = restrictedArea($user, 'prelevement', '', '', 'bons');
 
+$urladd = '';
 $limit = GETPOST('limit', 'int')?GETPOST('limit', 'int'):$conf->liste_limit;
+if ($limit != $conf->liste_limit) $urladd .= '&limit=' . $limit;
+
 $sortfield = GETPOST('sortfield', 'alpha');
 $sortorder = GETPOST('sortorder', 'alpha');
 $page = GETPOST('page', 'int');
@@ -102,7 +105,7 @@ if ($result)
     $num = $db->num_rows($result);
     $i = 0;
 
-    $urladd= "&amp;statut=".$statut;
+    $urladd .= "&amp;statut=" . $statut;
 
     $selectedfields='';
 


### PR DESCRIPTION
# Fix
Links to next pages do not contain the `limit` parameter, so the number of elements per page is reset whenever you switch pages.