### PR TITLE
Add path formation at form::showdocuments to handle custom module

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -628,10 +628,18 @@ class FormFile
 				// For normalized external modules.
 				else {
 				    $file = dol_buildpath('/'.$modulepart.'/core/modules/'.$modulepart.'/modules_'.$submodulepart.'.php', 0);
-					$res = include_once $file;
+					if (file_exists($file))
+						$res = include_once $file;
+					if (!$res)
+					{
+						$file = './'.$modulepart.'/core/modules/'.$submodulepart.'/doc/pdf_'.$modelselected.'.modules.php';
+						dol_include_once($file);
+					}
 				}
 				$class = 'ModelePDF'.ucfirst($submodulepart);
-
+				if (!class_exists($class))
+					$class = 'pdf_'.$modelselected;
+				
 				if (class_exists($class))
 				{
 					$modellist = call_user_func($class.'::liste_modeles', $this->db);

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -639,7 +639,7 @@ class FormFile
 				$class = 'ModelePDF'.ucfirst($submodulepart);
 				if (!class_exists($class))
 					$class = 'pdf_'.$modelselected;
-				
+
 				if (class_exists($class))
 				{
 					$modellist = call_user_func($class.'::liste_modeles', $this->db);


### PR DESCRIPTION
# New [*Method Form::showdocuments fails with custom module*]
[*Following the various instructions and the code generated from modul builder, it is neccessary to modify _showdocuments_ so it works with a custom module.*]
