### PR TITLE
11.0 FIX postgreSQL error on landing page when "members" module is on

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -2282,7 +2282,7 @@ class Adherent extends CommonObject
 		$sql.= " WHERE a.fk_adherent_type = t.rowid";
 		$sql.= " AND a.statut = 1";
 		$sql.= " AND a.entity IN (".getEntity('adherent').")";
-		$sql.= " AND ((a.datefin IS NULL or a.datefin < '".$this->db->idate($now)."') AND t.subscription = 1)";
+		$sql.= " AND ((a.datefin IS NULL or a.datefin < '".$this->db->idate($now)."') AND t.subscription = '1')";
 
 		$resql=$this->db->query($sql);
 		if ($resql)


### PR DESCRIPTION
# Fix postgreSQL error on the main page with "members" (adherents) module on
The field llx_adherent_type.subscription is defined as a VARCHAR, so postgresql requires it to be compared to a string ('1'), not a number (1).