### PR TITLE
NEW Add calendar selection for agenda view

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -90,6 +90,15 @@ $status = GETPOST("search_status", 'aZ09') ?GETPOST("search_status", 'aZ09') : G
 $type = GETPOST("search_type", 'aZ09') ?GETPOST("search_type", 'aZ09') : GETPOST("type", 'aZ09');
 $maxprint = (isset($_GET["maxprint"]) ?GETPOST("maxprint") : $conf->global->AGENDA_MAX_EVENTS_DAY_VIEW);
 $optioncss = GETPOST('optioncss', 'aZ'); // Option for the css output (always '' except when 'print')
+
+$dateselect=dol_mktime(0, 0, 0, GETPOST('dateselectmonth', 'int'), GETPOST('dateselectday', 'int'), GETPOST('dateselectyear', 'int'));
+if ($dateselect > 0)
+{
+	$day=GETPOST('dateselectday', 'int');
+	$month=GETPOST('dateselectmonth', 'int');
+	$year=GETPOST('dateselectyear', 'int');
+}
+
 // Set actioncode (this code must be same for setting actioncode into peruser, listacton and index)
 if (GETPOST('search_actioncode', 'array'))
 {
@@ -370,6 +379,9 @@ if ($action == 'show_day')
     $nav .= " &nbsp; (<a href=\"?year=".$nowyear."&amp;month=".$nowmonth."&amp;day=".$nowday.$param."\">".$langs->trans("Today")."</a>)";
     $picto = 'calendarday';
 }
+
+$nav .= $form->selectDate($dateselect, 'dateselect', 0, 0, 1, '', 1, 0);
+$nav .= ' <input type="submit" name="submitdateselect" class="button" value="'.$langs->trans("Refresh").'">';
 
 // Must be after the nav definition
 $param .= '&year='.$year.'&month='.$month.($day ? '&day='.$day : '');


### PR DESCRIPTION
# Add calendar selection for agenda view
Add a calendar picker for date selection in the month, week and day view. It is the same functionality as the peruser view.
![image](https://user-images.githubusercontent.com/1376669/83126104-aa5fb300-a0d8-11ea-939c-5f64f5e98d24.png)


