### PR TITLE
FIX Rounding Total TVA in "crabe" model pdf

### DIFF
--- a/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
@@ -1275,7 +1275,7 @@ class pdf_crabe extends ModelePDFFactures
 						$pdf->MultiCell($col2x - $col1x, $tab2_hl, $totalvat, 0, 'L', 1);
 
 						$pdf->SetXY($col2x, $tab2_top + $tab2_hl * $index);
-						$pdf->MultiCell($largcol2, $tab2_hl, price($tvaval, 0, $outputlangs, '', '', ($conf->global->MAIN_MAX_DECIMALS_TOT ? $conf->global->MAIN_MAX_DECIMALS_TOT : 0)), 0, 'R', 1);
+						$pdf->MultiCell($largcol2, $tab2_hl, price(price2num($tvaval, 'MT'), 0', $outputlangs), 0, 'R', 1);
 					}
 				}
 

--- a/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
@@ -1275,7 +1275,7 @@ class pdf_crabe extends ModelePDFFactures
 						$pdf->MultiCell($col2x - $col1x, $tab2_hl, $totalvat, 0, 'L', 1);
 
 						$pdf->SetXY($col2x, $tab2_top + $tab2_hl * $index);
-						$pdf->MultiCell($largcol2, $tab2_hl, price(price2num($tvaval, 'MT'), 0', $outputlangs), 0, 'R', 1);
+						$pdf->MultiCell($largcol2, $tab2_hl, price(price2num($tvaval, 'MT'), 0, $outputlangs), 0, 'R', 1);
 					}
 				}
 

--- a/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
@@ -1275,7 +1275,7 @@ class pdf_crabe extends ModelePDFFactures
 						$pdf->MultiCell($col2x - $col1x, $tab2_hl, $totalvat, 0, 'L', 1);
 
 						$pdf->SetXY($col2x, $tab2_top + $tab2_hl * $index);
-						$pdf->MultiCell($largcol2, $tab2_hl, price($tvaval, 0, $outputlangs), 0, 'R', 1);
+						$pdf->MultiCell($largcol2, $tab2_hl, price($tvaval, 0, $outputlangs, '', '', ($conf->global->MAIN_MAX_DECIMALS_TOT ? $conf->global->MAIN_MAX_DECIMALS_TOT : 0)), 0, 'R', 1);
 					}
 				}
 


### PR DESCRIPTION
# Fix # 
TVA Total in crabe model PDF isn't rounding in function price() because of these lines : 

        // We increase nbdecimal if there is more decimal than asked (to not loose information)
	if (dol_strlen($decpart) > $nbdecimal) $nbdecimal = dol_strlen($decpart);

I give the conf " MAIN_MAX_DECIMALS_TOT" to "forcerounding" parameter.

