### PR TITLE
restore MAIN_SHOWDATABASENAMEINHELPPAGESLINK option to show database name in help pages link

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1641,11 +1641,7 @@ function top_menu($head, $title = '', $target = '', $disablejs = 0, $disablehead
 				$text = '';
 				$title = $langs->trans($mode == 'wiki' ? 'GoToWikiHelpPage' : 'GoToHelpPage');
 				if ($mode == 'wiki') $title .= ' - '.$langs->trans("PageWiki").' &quot;'.dol_escape_htmltag(strtr($helppage, '_', ' ')).'&quot;'."";
-	            if (!empty($conf->global->MAIN_SHOWDATABASENAMEINHELPPAGESLINK)) {
-                    $langs->load('admin');
-                    $title .= '<br>'.$langs->trans("Database").': '.(!empty($db->database_name)?$db->database_name:$db->db->database_name);
-                }
-				$text .= '<a class="help" target="_blank" rel="noopener" href="';
+	            $text .= '<a class="help" target="_blank" rel="noopener" href="';
 				if ($mode == 'wiki') $text .= sprintf($helpbaseurl, urlencode(html_entity_decode($helppage)));
 				else $text .= sprintf($helpbaseurl, $helppage);
 				$text .= '">';
@@ -1657,7 +1653,7 @@ function top_menu($head, $title = '', $target = '', $disablejs = 0, $disablehead
 			// Version
 			if (!empty($conf->global->MAIN_SHOWDATABASENAMEINHELPPAGESLINK)) {
 				$langs->load('admin');
-				$appli .= '<br>'.$langs->trans("Database").': '.$db->database_name;
+                $title .= '<br>'.$langs->trans("Database").': '.(!empty($db->database_name)?$db->database_name:$db->db->database_name);
 			}
 			$text = '<span href="#" class="aversion"><span class="hideonsmartphone small">'.DOL_VERSION.'</span></span>';
 			$toprightmenu .= @Form::textwithtooltip('', $appli, 2, 1, $text, 'login_block_elem', 2);

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1641,6 +1641,10 @@ function top_menu($head, $title = '', $target = '', $disablejs = 0, $disablehead
 				$text = '';
 				$title = $langs->trans($mode == 'wiki' ? 'GoToWikiHelpPage' : 'GoToHelpPage');
 				if ($mode == 'wiki') $title .= ' - '.$langs->trans("PageWiki").' &quot;'.dol_escape_htmltag(strtr($helppage, '_', ' ')).'&quot;'."";
+	            if (!empty($conf->global->MAIN_SHOWDATABASENAMEINHELPPAGESLINK)) {
+                    $langs->load('admin');
+                    $title .= '<br>'.$langs->trans("Database").': '.(!empty($db->database_name)?$db->database_name:$db->db->database_name);
+                }
 				$text .= '<a class="help" target="_blank" rel="noopener" href="';
 				if ($mode == 'wiki') $text .= sprintf($helpbaseurl, urlencode(html_entity_decode($helppage)));
 				else $text .= sprintf($helpbaseurl, $helppage);


### PR DESCRIPTION
# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #[*issue_number Short description*]
[*Long description*]


# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
