### PR TITLE
FIX php error

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2523,6 +2523,8 @@ class Form
 		$outdurationvalue = $outtype == Product::TYPE_SERVICE ?substr($objp->duration, 0, dol_strlen($objp->duration) - 1) : '';
 		$outdurationunit = $outtype == Product::TYPE_SERVICE ?substr($objp->duration, -1) : '';
 
+		if ($outorigin && !empty($conf->global->PRODUCT_SHOW_ORIGIN_IN_COMBO))  require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
+
         // Units
         $outvalUnits = '';
         if (!empty($conf->global->PRODUCT_USE_UNITS)) {


### PR DESCRIPTION
cf following error in admin of member module (with displaying  origin of product/service)

Fatal error: Uncaught Error: Call to undefined function getCountry() in /volume2/web/dolibarr/htdocs/core/class/html.form.class.php on line 2583 Error: Call to undefined function getCountry() in /volume2/web/dolibarr/htdocs/core/class/html.form.class.php on line 2583 Call Stack: 0.0001 409544 1. {main}() /volume2/web/dolibarr/htdocs/adherents/admin/adherent.php:0 0.1935 3017200 2. Form->select_produits() /volume2/web/dolibarr/htdocs/adherents/admin/adherent.php:215 0.1935 3017200 3. Form->select_produits_list() /volume2/web/dolibarr/htdocs/core/class/html.form.class.php:2134 0.1983 3439880 4. Form->constructProductListOption() /volume2/web/dolibarr/htdocs/core/class/html.form.class.php:2451
