### PR TITLE
FIX 11.0 - when using pdftk for pdf concatenation, check if file was created before saying so

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1030,14 +1030,18 @@ if (!$error && $massaction == "builddoc" && $permissiontoread && !GETPOST('butto
 				$input_files .= ' '.escapeshellarg($f);
 			}
 
-			$cmd = 'pdftk '.escapeshellarg($input_files).' cat output '.escapeshellarg($file);
+			$cmd = 'pdftk ' . $input_files . ' cat output '.escapeshellarg($file);
 			exec($cmd);
 
-			if (!empty($conf->global->MAIN_UMASK))
-				@chmod($file, octdec($conf->global->MAIN_UMASK));
-
-			$langs->load("exports");
-			setEventMessages($langs->trans('FileSuccessfullyBuilt', $filename.'_'.dol_print_date($now, 'dayhourlog')), null, 'mesgs');
+			// check if pdftk is installed
+			if (file_exists($file)) {
+				if (!empty($conf->global->MAIN_UMASK))
+					@chmod($file, octdec($conf->global->MAIN_UMASK));
+				$langs->load("exports");
+				setEventMessages($langs->trans('FileSuccessfullyBuilt', $filename.'_'.dol_print_date($now, 'dayhourlog')), null, 'mesgs');
+			} else {
+				setEventMessages($langs->trans('ErrorPDFTkOutputFileNotFound'), null, 'errors');
+			}
 		}
 		else
 		{

--- a/htdocs/langs/en_US/main.lang
+++ b/htdocs/langs/en_US/main.lang
@@ -837,6 +837,7 @@ Sincerely=Sincerely
 ConfirmDeleteObject=Are you sure you want to delete this object?
 DeleteLine=Delete line
 ConfirmDeleteLine=Are you sure you want to delete this line?
+ErrorPDFTkOutputFileNotFound=Error: the file was not generated. Please check that the 'pdftk' command is installed in a directory included in the $PATH environment variable (linux/unix only) or contact your system administrator.
 NoPDFAvailableForDocGenAmongChecked=No PDF were available for the document generation among checked record
 TooManyRecordForMassAction=Too many records selected for mass action. The action is restricted to a list of %s records.
 NoRecordSelected=No record selected


### PR DESCRIPTION
# Context
Currently if you have the hidden conf `USE_PDFTK_FOR_PDF_CONCAT`, Dolibarr calls the shell command `pdftk` to concatenate several PDF documents in the "PDF fusion" mass action.

The problem is that it then shows a success message regardless of whether the output file was really created. In my case, the `pdftk` package wasn’t even installed.

Another problem was that it escaped the input shell arguments of the command twice, resulting in one single input argument instead of one per input file (which caused a pdftk error).

# Fix
This PR simply checks whether the output PDF file exists. If not, it shows an error message.

It also removes the excess call to `escapeshellarg()`.