### PR TITLE
FIX: copy value date of VariousPayment onto the new AccountLine

### DIFF
--- a/htdocs/compta/bank/class/paymentvarious.class.php
+++ b/htdocs/compta/bank/class/paymentvarious.class.php
@@ -422,7 +422,11 @@ class PaymentVarious extends CommonObject
 						$sign * abs($this->amount),
 						$this->num_payment,
                         ($this->category_transaction > 0 ? $this->category_transaction : 0),
-						$user
+						$user,
+						'',
+						'',
+						'',
+						$this->datev
 					);
 
 					// Update fk_bank into llx_paiement.


### PR DESCRIPTION
# Fix
When you create a new misc payment, a corresponding bank account line is created.

However, the bank account line’s value date is always the payment's payment date (datep) even if you chose a different value date (datev) on your payment.

So in the end it might look like this:
* Payment
    * datep: 12/02/2020
    * datev: 15/02/2020
* AccountLine
    * dateo: 12/02/2020
    * datev: 12/02/2020

This fix ensures the payment's value date is copied onto the account line.