### PR TITLE
NEW convert all subscription in datetime

### DIFF
--- a/htdocs/adherents/class/subscription.class.php
+++ b/htdocs/adherents/class/subscription.class.php
@@ -99,7 +99,7 @@ class Subscription extends CommonObject
     	'datec' =>array('type'=>'datetime', 'label'=>'DateCreation', 'enabled'=>1, 'visible'=>-1, 'position'=>20),
     	'fk_adherent' =>array('type'=>'integer', 'label'=>'Member', 'enabled'=>1, 'visible'=>-1, 'position'=>25),
     	'dateadh' =>array('type'=>'datetime', 'label'=>'DateSubscription', 'enabled'=>1, 'visible'=>-1, 'position'=>30),
-    	'datef' =>array('type'=>'date', 'label'=>'DateEndSubscription', 'enabled'=>1, 'visible'=>-1, 'position'=>35),
+    	'datef' =>array('type'=>'datetime', 'label'=>'DateEndSubscription', 'enabled'=>1, 'visible'=>-1, 'position'=>35),
     	'subscription' =>array('type'=>'double(24,8)', 'label'=>'Amount', 'enabled'=>1, 'visible'=>-1, 'position'=>40, 'isameasure'=>1),
     	'fk_bank' =>array('type'=>'integer', 'label'=>'BankId', 'enabled'=>1, 'visible'=>-1, 'position'=>45),
     	'note' =>array('type'=>'text', 'label'=>'Note', 'enabled'=>1, 'visible'=>-1, 'position'=>50),

--- a/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
+++ b/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
@@ -43,3 +43,4 @@ UPDATE llx_establishment SET ref = rowid WHERE ref IS NULL;
 ALTER TABLE llx_establishment MODIFY COLUMN ref varchar(30) NOT NULL;
 ALTER TABLE llx_establishment MODIFY COLUMN name varchar(128);
 
+ALTER TABLE llx_subscription MODIFY COLUMN datef DATETIME;

--- a/htdocs/install/mysql/tables/llx_subscription.sql
+++ b/htdocs/install/mysql/tables/llx_subscription.sql
@@ -24,7 +24,7 @@ create table llx_subscription
   fk_adherent     integer,
   fk_type         integer,
   dateadh         datetime,
-  datef           date,
+  datef           datetime,
   subscription    double(24,8),
   fk_bank         integer DEFAULT NULL,
   fk_user_creat   integer DEFAULT NULL,


### PR DESCRIPTION
convert all field  in datetime for better compliances (date begin et datefin of member already in datetime)

-> use in adherentsplus then in adherent, better for renew subscription without break (daily, weekly, monthly, yearly) or delete subscription and return to old 'datefin'
