### PR TITLE
NEW add free text on each terminal of cash desk

### DIFF
--- a/htdocs/takepos/admin/terminal.php
+++ b/htdocs/takepos/admin/terminal.php
@@ -94,6 +94,10 @@ if (GETPOST('action', 'alpha') == 'set')
 
 	$res = dolibarr_set_const($db, "TAKEPOS_ADDON".$terminaltouse, GETPOST('TAKEPOS_ADDON'.$terminaltouse, 'alpha'), 'chaine', 0, '', $conf->entity);
 
+	// add free text on each terminal of cash desk
+	$res = dolibarr_set_const($db, 'TAKEPOS_HEADER'.$terminaltouse, GETPOST('TAKEPOS_HEADER'.$terminaltouse, 'none'), 'chaine', 0, '', $conf->entity);
+	$res = dolibarr_set_const($db, 'TAKEPOS_FOOTER'.$terminaltouse, GETPOST('TAKEPOS_FOOTER'.$terminaltouse, 'none'), 'chaine', 0, '', $conf->entity);
+
 	dol_syslog("admin/cashdesk: level ".GETPOST('level', 'alpha'));
 
 	if (!$res > 0) $error++;
@@ -322,6 +326,58 @@ if ($conf->global->TAKEPOS_ADDON == "terminal") {
 }
 
 print '</table>';
+
+// add free text on each terminal of cash desk
+$substitutionarray = pdf_getSubstitutionArray($langs, null, null, 2);
+$substitutionarray['__(AnyTranslationKey)__'] = $langs->trans('Translation');
+$htmltext = '<i>' . $langs->trans('AvailableVariables') . ':<br>';
+foreach ($substitutionarray as $key => $val)	$htmltext .= $key . '<br>';
+$htmltext .= '</i>';
+
+print '<br>';
+print load_fiche_titre($langs->trans('FreeLegalTextOnInvoices'), '', '');
+
+print '<div class="div-table-responsive">';
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>' . $langs->trans("Parameters") . '</td><td>' . $langs->trans('Value') . '</td>';
+print '</tr>';
+
+// free text on header
+print '<tr class="oddeven">';
+print '<td>';
+print $form->textwithpicto($langs->trans('Header'), $htmltext, 1, 'help', '', 0, 2, 'freetexttooltip').'<br>';
+print '</td>';
+print '<td>';
+$variablename = 'TAKEPOS_HEADER' . $terminaltouse;
+if (empty($conf->global->PDF_ALLOW_HTML_FOR_FREE_TEXT)) {
+	print '<textarea name="' . $variablename . '" class="flat" cols="120">' . $conf->global->{$variablename} . '</textarea>';
+} else {
+	include_once DOL_DOCUMENT_ROOT . '/core/class/doleditor.class.php';
+	$doleditor = new DolEditor($variablename, $conf->global->{$variablename}, '', 80, 'dolibarr_notes');
+	print $doleditor->Create();
+}
+print '</td></tr>';
+
+// free text on footer
+print '<tr class="oddeven">';
+print '<td>';
+print $form->textwithpicto($langs->trans('Footer'), $htmltext, 1, 'help', '', 0, 2, 'freetexttooltip').'<br>';
+print '</td>';
+print '<td>';
+$variablename = 'TAKEPOS_FOOTER' . $terminaltouse;
+if (empty($conf->global->PDF_ALLOW_HTML_FOR_FREE_TEXT)) {
+	print '<textarea name="' . $variablename . '" class="flat" cols="120">' . $conf->global->{$variablename} . '</textarea>';
+} else {
+	include_once DOL_DOCUMENT_ROOT . '/core/class/doleditor.class.php';
+	$doleditor = new DolEditor($variablename, $conf->global->{$variablename}, '', 80, 'dolibarr_notes');
+	print $doleditor->Create();
+}
+print '</td></tr>';
+
+print '</table>';
+print '</div>';
+
 print '</div>';
 
 if ($atleastonefound == 0 && !empty($conf->banque->enabled))

--- a/htdocs/takepos/admin/terminal.php
+++ b/htdocs/takepos/admin/terminal.php
@@ -326,6 +326,7 @@ if ($conf->global->TAKEPOS_ADDON == "terminal") {
 }
 
 print '</table>';
+print '</div>';
 
 // add free text on each terminal of cash desk
 $substitutionarray = pdf_getSubstitutionArray($langs, null, null, 2);
@@ -376,8 +377,6 @@ if (empty($conf->global->PDF_ALLOW_HTML_FOR_FREE_TEXT)) {
 print '</td></tr>';
 
 print '</table>';
-print '</div>';
-
 print '</div>';
 
 if ($atleastonefound == 0 && !empty($conf->banque->enabled))

--- a/htdocs/takepos/receipt.php
+++ b/htdocs/takepos/receipt.php
@@ -89,12 +89,14 @@ if (!empty($hookmanager->resPrint)) {
 <br>
 <p class="left">
 <?php
-if (!empty($conf->global->TAKEPOS_HEADER))
+$constFreeText = 'TAKEPOS_HEADER' . $_SESSION['takeposterminal'];
+if (!empty($conf->global->TAKEPOS_HEADER) || !empty($conf->global->{$constFreeText}))
 {
+	$newfreetext = '';
 	$substitutionarray = getCommonSubstitutionArray($langs);
-	if (!empty($conf->global->TAKEPOS_HEADER))
-	$newfreetext = make_substitutions($conf->global->TAKEPOS_HEADER, $substitutionarray);
-	echo $newfreetext;
+	if (!empty($conf->global->TAKEPOS_HEADER))      $newfreetext .= make_substitutions($conf->global->TAKEPOS_HEADER, $substitutionarray);
+	if (!empty($conf->global->{$constFreeText}))    $newfreetext .= make_substitutions($conf->global->{$constFreeText}, $substitutionarray);
+	print $newfreetext;
 }
 ?>
 </p>
@@ -183,11 +185,14 @@ if ($conf->global->TAKEPOS_SHOW_CUSTOMER)
 <br>
 <br>
 <?php
-if (!empty($conf->global->TAKEPOS_FOOTER))
+$constFreeText = 'TAKEPOS_FOOTER' . $_SESSION['takeposterminal'];
+if (!empty($conf->global->TAKEPOS_FOOTER) || !empty($conf->global->{$constFreeText}))
 {
+	$newfreetext = '';
 	$substitutionarray = getCommonSubstitutionArray($langs);
-	$newfreetext = make_substitutions($conf->global->TAKEPOS_FOOTER, $substitutionarray);
-	echo $newfreetext;
+	if (!empty($conf->global->{$constFreeText}))    $newfreetext .= make_substitutions($conf->global->{$constFreeText}, $substitutionarray);
+	if (!empty($conf->global->TAKEPOS_FOOTER))      $newfreetext .= make_substitutions($conf->global->TAKEPOS_FOOTER, $substitutionarray);
+	print $newfreetext;
 }
 ?>
 


### PR DESCRIPTION
NEW add free text on each terminal of cash desk
- create const "TAKEPOS_HEADER1", "TAKEPOS_HEADER2", ... (for each terminal)
- create const "TAKEPOS_FOOTER1", "TAKEPOS_FOOTER2", ... (for each terminal)
- you can cutomize free text on tickets for each terminal of cash desk
- add free text after global free text (in receipt setup) on the header of the ticket
- add free text before global free text (in receipt setup) on footer of the ticket
