### PR TITLE
FIX 10.0 - undefined $langs if template file copy fails during activation of modContrat

### DIFF
--- a/htdocs/core/modules/modContrat.class.php
+++ b/htdocs/core/modules/modContrat.class.php
@@ -214,7 +214,7 @@ class modContrat extends DolibarrModules
 	 */
 	public function init($options = '')
 	{
-		global $conf;
+		global $conf, $langs;
 
 		// Nettoyage avant activation
 		$this->remove($options);


### PR DESCRIPTION
# Fix: fatal when enabling modContrat
If you enable the "Contract" module and your directory permissions are somehow messed up, instead of getting an error message saying that the copying of ODT template failed, you get a fatal error because `$langs` is undefined.