### PR TITLE
Fix 11.0 -  undef func measuringUnitString() in From::select_produits_fournis…

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2802,6 +2802,7 @@ class Form
 		if ($result)
 		{
 			require_once DOL_DOCUMENT_ROOT.'/product/dynamic_price/class/price_parser.class.php';
+            require_once DOL_DOCUMENT_ROOT.'/core/lib/product.lib.php';
 
 			$num = $this->db->num_rows($result);
 


### PR DESCRIPTION
In the `Form::select_produits_fournisseurs_list()` the function measuringUnitString() is called but the `/core/lib/product.lib.php' is not loaded which causes php to crash.

This fix it by including `product.lib.php`.

