### PR TITLE
FIX 11.0 - fatal with postgres on contact/agenda.php

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1448,7 +1448,7 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon = '', $noprin
         $langs->load("mails");
 
         $sql2 = "SELECT m.rowid as id, m.titre as label, mc.date_envoi as dp, mc.date_envoi as dp2, '100' as percent, 'mailing' as type";
-        $sql2 .= ", '' as fk_element, '' as elementtype, '' as contact_id";
+        $sql2 .= ", null as fk_element, '' as elementtype, null as contact_id";
         $sql2 .= ", 'AC_EMAILING' as acode, '' as alabel, '' as apicto";
         $sql2 .= ", u.rowid as user_id, u.login as user_login, u.photo as user_photo, u.firstname as user_firstname, u.lastname as user_lastname"; // User that valid action
         if (is_object($filterobj) && get_class($filterobj) == 'Societe')      $sql2 .= ", '' as lastname, '' as firstname";

--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -427,7 +427,7 @@ function show_ticket_messaging($conf, $langs, $db, $filterobj, $objcon = '', $no
         $langs->load("mails");
 
         $sql2 = "SELECT m.rowid as id, m.titre as label, mc.date_envoi as dp, mc.date_envoi as dp2, '100' as percent, 'mailing' as type";
-        $sql2 .= ", '' as fk_element, '' as elementtype, '' as contact_id";
+        $sql2 .= ", null as fk_element, '' as elementtype, null as contact_id";
         $sql2 .= ", 'AC_EMAILING' as acode, '' as alabel, '' as apicto";
         $sql2 .= ", u.rowid as user_id, u.login as user_login, u.photo as user_photo, u.firstname as user_firstname, u.lastname as user_lastname"; // User that valid action
         if (is_object($filterobj) && get_class($filterobj) == 'Societe')      $sql2 .= ", '' as lastname, '' as firstname";


### PR DESCRIPTION
# Fix fatal with PostgreSQL
The function `show_actions_done()` in `company.lib.php` performs an SQL query with a union that requires an integer for the fields `fk_element` and `contact_id`, but they are assigned literal empty string values (`''`) in the first part of the `UNION`.

MariaDB and MySQL accept this but PostgreSQL doesn't.

Since the actual query is pretty long, here is a more basic example of a query with the same problem (this is just an example, not an actual query used in Dolibarr) :
```sql
SELECT '' as fk_user_ UNION SELECT fk_user FROM llx_usergroup_user AS ug;
```

Solution: using `null` or `0` instead of `''`.


