### PR TITLE
fix (pmp)

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -484,7 +484,7 @@ class MouvementStock extends CommonObject
 			{
 				// Note: PMP is calculated on stock input only (type of movement = 0 or 3). If type == 0 or 3, qty should be > 0.
 				// Note: Price should always be >0 or 0. PMP should be always >0 (calculated on input)
-				if (($type == 0 || $type == 3) && $price > 0)
+				if (($type == 0 || $type == 3) && $price >= 0)
 				{
 					$oldqtytouse = ($oldqty >= 0 ? $oldqty : 0);
 					// We make a test on oldpmp>0 to avoid to use normal rule on old data with no pmp field defined


### PR DESCRIPTION
Added the possibility of price == 0 (as said in the commentary just above) to take consideration of the free products.

# Fix #14092 Bug PMP calculation
The price can be equal to 0 and the free products will be integrated in the formula changing the PMP.