### PR TITLE
FIX 11.0 - multicurrency_amount not fetched with payments

### DIFF
--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -68,9 +68,10 @@ class Paiement extends CommonObject
 	 */
 	public $montant;
 
-	public $amount;            // Total amount of payment
-	public $amounts=array();   // Array of amounts
-	public $multicurrency_amounts=array();   // Array of amounts
+	public $amount;                        // Total amount of payment (in the main currency)
+	public $multicurrency_amount;          // Total amount of payment (in the currency of the bank account)
+	public $amounts=array();               // array: invoice ID => amount for that invoice (in the main currency)>
+	public $multicurrency_amounts=array(); // array: invoice ID => amount for that invoice (in the invoice's currency)>
 	public $author;
 	public $paiementid;			// Type of payment. Id saved into fields fk_paiement on llx_paiement
 	public $paiementcode;		// Code of payment.
@@ -159,7 +160,7 @@ class Paiement extends CommonObject
 	 */
 	public function fetch($id, $ref = '', $fk_bank = '')
 	{
-		$sql = 'SELECT p.rowid, p.ref, p.datep as dp, p.amount, p.statut, p.ext_payment_id, p.ext_payment_site, p.fk_bank,';
+		$sql = 'SELECT p.rowid, p.ref, p.datep as dp, p.amount, p.statut, p.ext_payment_id, p.ext_payment_site, p.fk_bank, p.multicurrency_amount,';
 		$sql.= ' c.code as type_code, c.libelle as type_label,';
 		$sql.= ' p.num_paiement as num_payment, p.note,';
 		$sql.= ' b.fk_account';
@@ -179,20 +180,21 @@ class Paiement extends CommonObject
 			if ($this->db->num_rows($resql))
 			{
 				$obj = $this->db->fetch_object($resql);
-				$this->id             = $obj->rowid;
-				$this->ref            = $obj->ref?$obj->ref:$obj->rowid;
-				$this->date           = $this->db->jdate($obj->dp);
-				$this->datepaye       = $this->db->jdate($obj->dp);
-				$this->num_paiement   = $obj->num_payment;	// deprecated
-				$this->num_payment    = $obj->num_payment;
-				$this->montant        = $obj->amount;   // deprecated
-				$this->amount         = $obj->amount;
-				$this->note           = $obj->note;
-				$this->type_label   = $obj->type_label;
-				$this->type_code      = $obj->type_code;
-				$this->statut         = $obj->statut;
-                $this->ext_payment_id = $obj->ext_payment_id;
-                $this->ext_payment_site = $obj->ext_payment_site;
+				$this->id                   = $obj->rowid;
+				$this->ref                  = $obj->ref?$obj->ref:$obj->rowid;
+				$this->date                 = $this->db->jdate($obj->dp);
+				$this->datepaye             = $this->db->jdate($obj->dp);
+				$this->num_paiement         = $obj->num_payment;	// deprecated
+				$this->num_payment          = $obj->num_payment;
+				$this->montant              = $obj->amount;   // deprecated
+				$this->amount               = $obj->amount;
+				$this->multicurrency_amount = $obj->multicurrency_amount;
+				$this->note                 = $obj->note;
+				$this->type_label           = $obj->type_label;
+				$this->type_code            = $obj->type_code;
+				$this->statut               = $obj->statut;
+                $this->ext_payment_id       = $obj->ext_payment_id;
+                $this->ext_payment_site     = $obj->ext_payment_site;
 
 				$this->bank_account   = $obj->fk_account; // deprecated
 				$this->fk_account     = $obj->fk_account;

--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -89,7 +89,7 @@ class PaiementFourn extends Paiement
 	{
 		$error=0;
 
-		$sql = 'SELECT p.rowid, p.ref, p.entity, p.datep as dp, p.amount, p.statut, p.fk_bank,';
+		$sql = 'SELECT p.rowid, p.ref, p.entity, p.datep as dp, p.amount, p.statut, p.fk_bank, p.multicurrency_amount,';
 		$sql.= ' c.code as paiement_code, c.libelle as paiement_type,';
 		$sql.= ' p.num_paiement as num_payment, p.note, b.fk_account';
 		$sql.= ' FROM '.MAIN_DB_PREFIX.'paiementfourn as p';
@@ -111,23 +111,24 @@ class PaiementFourn extends Paiement
 			if ($num > 0)
 			{
 				$obj = $this->db->fetch_object($resql);
-				$this->id             = $obj->rowid;
-				$this->ref            = $obj->ref;
-				$this->entity         = $obj->entity;
-				$this->date           = $this->db->jdate($obj->dp);
-				$this->datepaye       = $this->db->jdate($obj->dp);
-				$this->num_paiement   = $obj->num_payment;
-				$this->num_payment    = $obj->num_payment;
-				$this->bank_account   = $obj->fk_account;
-				$this->fk_account     = $obj->fk_account;
-				$this->bank_line      = $obj->fk_bank;
-				$this->montant        = $obj->amount;
-				$this->amount         = $obj->amount;
-				$this->note           = $obj->note;
-				$this->note_private   = $obj->note;
-				$this->type_code      = $obj->paiement_code;
-				$this->type_label   = $obj->paiement_type;
-				$this->statut         = $obj->statut;
+				$this->id                   = $obj->rowid;
+				$this->ref                  = $obj->ref;
+				$this->entity               = $obj->entity;
+				$this->date                 = $this->db->jdate($obj->dp);
+				$this->datepaye             = $this->db->jdate($obj->dp);
+				$this->num_paiement         = $obj->num_payment;
+				$this->num_payment          = $obj->num_payment;
+				$this->bank_account         = $obj->fk_account;
+				$this->fk_account           = $obj->fk_account;
+				$this->bank_line            = $obj->fk_bank;
+				$this->montant              = $obj->amount;
+				$this->amount               = $obj->amount;
+				$this->multicurrency_amount = $obj->multicurrency_amount;
+				$this->note                 = $obj->note;
+				$this->note_private         = $obj->note;
+				$this->type_code            = $obj->paiement_code;
+				$this->type_label           = $obj->paiement_type;
+				$this->statut               = $obj->statut;
 				$error = 1;
 			}
 			else


### PR DESCRIPTION
# Fix: multicurrency_amount not fetched
Both `llx_paiement` and `llx_paiementfourn` have a `multicurrency_amount` column, but as it stands, the `fetch()` method of both paiement.class.php and paiementfourn.class.php don’t fetch that amount.