### PR TITLE
NEW assign sale representative in thirdparty create card

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1508,7 +1508,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action))
 		print '<td colspan="3" class="maxwidthonsmartphone">';
 		$userlist = $form->select_dolusers('', '', 0, null, 0, '', '', 0, 0, 0, '', 0, '', '', 0, 1);
 		// Note: If user has no right to "see all thirdparties", we force selection of sale representative to him, so after creation he can see the record.
-		$selected = (count(GETPOST('commercial', 'array')) > 0 ? GETPOST('commercial', 'array') : (GETPOST('commercial', 'int') > 0 ? array(GETPOST('commercial', 'int')) : (empty($user->rights->societe->client->voir) ? array($user->id) : array())));
+		$selected = (count(GETPOST('commercial', 'array')) > 0 ? GETPOST('commercial', 'array') : (GETPOST('commercial', 'int') > 0 ? array(GETPOST('commercial', 'int')) : (!empty($conf->global->THIRDPARTY_DEFAULT_CREATE_ASSIGN_USER_IN_SALE_REPRESENTATIVE) || empty($user->rights->societe->client->voir)?array($user->id):array())));
 		print $form->multiselectarray('commercial', $userlist, $selected, null, null, null, null, "90%");
 		print '</td></tr>';
 


### PR DESCRIPTION
NEW assign sale representative in thirdparty create card
- add const "THIRDPARTY_DEFAULT_CREATE_ASSIGN_USER_IN_SALE_REPRESENTATIVE" to assign user by default in sale representative field
- keep the same behaivour if this const is not defined