### PR TITLE
Fix: Bug when delete payment when already deleted in account

### DIFF
--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -532,9 +532,8 @@ class Paiement extends CommonObject
 			$accline = new AccountLine($this->db);
 
 			$result=$accline->fetch($bank_line_id);
-			if ($result == 0)
-			{
-				$accline->id=$accline->rowid=$bank_line_id;    // If not found, we set artificially rowid to allow delete of llx_bank_url
+			if ($result == 0) {
+				$accline->id = $accline->rowid = $bank_line_id;    // If not found, we set artificially rowid to allow delete of llx_bank_url
 			}
 
             // Delete bank account url lines linked to payment

--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -532,7 +532,10 @@ class Paiement extends CommonObject
 			$accline = new AccountLine($this->db);
 
 			$result=$accline->fetch($bank_line_id);
-			if ($result == 0) $accline->rowid=$bank_line_id;    // If not found, we set artificially rowid to allow delete of llx_bank_url
+			if ($result == 0)
+			{
+				$accline->id=$accline->rowid=$bank_line_id;    // If not found, we set artificially rowid to allow delete of llx_bank_url
+			}
 
             // Delete bank account url lines linked to payment
 			$result=$accline->delete_urls($user);


### PR DESCRIPTION
Related to : 
https://github.com/Dolibarr/dolibarr/blame/11.0/htdocs/compta/bank/class/account.class.php#L1976

Mistake between id / rowid. I prefere add the fix here (but a fix in account class can be also a good fix). 
And best fix may use setter to do it (but to complicated : maybe latter ? i may check it in september if you want in all CommonObject properties)

# Instructions
# Fix SQL error when delete payment line