### PR TITLE
FIX change selected fields on company card

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -846,6 +846,11 @@ if (empty($reshook))
     $id=$socid;
     $object->fetch($socid);
 
+	// Selection of new fields
+	if (!empty($conf->global->MAIN_DUPLICATE_CONTACTS_TAB_ON_MAIN_CARD) && (empty($conf->global->SOCIETE_DISABLE_CONTACTS) || !empty($conf->global->SOCIETE_ADDRESSES_MANAGEMENT))) {
+		include DOL_DOCUMENT_ROOT . '/core/actions_changeselectedfields.inc.php';
+	}
+
     // Actions to send emails
     $trigger_name='COMPANY_SENTBYMAIL';
     $paramname='socid';


### PR DESCRIPTION
FIX change selected fields for contact list on company card when "MAIN_DUPLICATE_CONTACTS_TAB_ON_MAIN_CARD" is enabled and "SOCIETE_DISABLE_CONTACTS" disabled
