### PR TITLE
Fix email spoofing - with hidden conf

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -401,14 +401,10 @@ class CMailFile
 						$regexp = '/([a-z0-9_\.\-\+])+\@(([a-z0-9\-])+\.)+([a-z0-9]{2,4})+/i'; // This regular expression extracts all emails from a string
 						$emailMatchs = preg_match_all($regexp, $from, $adressEmailFrom);
 						$adressEmailFrom = reset($adressEmailFrom);
-						if($emailMatchs !== false
-							&& filter_var($conf->global->MAIN_MAIL_SMTPS_ID, FILTER_VALIDATE_EMAIL)
-							&& $conf->global->MAIN_MAIL_SMTPS_ID !== $adressEmailFrom)
+						if ($emailMatchs !== false && filter_var($conf->global->MAIN_MAIL_SMTPS_ID, FILTER_VALIDATE_EMAIL) && $conf->global->MAIN_MAIL_SMTPS_ID !== $adressEmailFrom)
 						{
 							$result = $this->message->setFrom($conf->global->MAIN_MAIL_SMTPS_ID);
-						}
-						else
-						{
+						} else {
 							$result = $this->message->setFrom($this->getArrayAddress($from));
 						}
 					} else {

--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -412,7 +412,6 @@ class CMailFile
 					{
 						$result = $this->message->setFrom($this->getArrayAddress($from));
 					}
-
                 } catch (Exception $e) {
                     $this->errors[] = $e->getMessage();
                 }

--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -396,20 +396,22 @@ class CMailFile
             //$this->message->setFrom(array('john@doe.com' => 'John Doe'));
             if (! empty($from)) {
                 try {
-
-					// Prevent email spoofing for smtp server with a strict configuration
-					$regexp = '/([a-z0-9_\.\-\+])+\@(([a-z0-9\-])+\.)+([a-z0-9]{2,4})+/i'; // This regular expression extracts all emails from a string
-					$emailMatchs = preg_match_all($regexp, $from, $adressEmailFrom);
-					$adressEmailFrom = reset($adressEmailFrom);
-					if($emailMatchs !== false
-						&& $conf->global->MAIN_FORCE_DISABLE_MAIL_SPOOFING
-						&& filter_var($conf->global->MAIN_MAIL_SMTPS_ID, FILTER_VALIDATE_EMAIL)
-						&& $conf->global->MAIN_MAIL_SMTPS_ID !== $adressEmailFrom)
-					{
-						$result = $this->message->setFrom($conf->global->MAIN_MAIL_SMTPS_ID);
-					}
-					else
-					{
+					if (! empty($conf->global->MAIN_FORCE_DISABLE_MAIL_SPOOFING)) {
+						// Prevent email spoofing for smtp server with a strict configuration
+						$regexp = '/([a-z0-9_\.\-\+])+\@(([a-z0-9\-])+\.)+([a-z0-9]{2,4})+/i'; // This regular expression extracts all emails from a string
+						$emailMatchs = preg_match_all($regexp, $from, $adressEmailFrom);
+						$adressEmailFrom = reset($adressEmailFrom);
+						if($emailMatchs !== false
+							&& filter_var($conf->global->MAIN_MAIL_SMTPS_ID, FILTER_VALIDATE_EMAIL)
+							&& $conf->global->MAIN_MAIL_SMTPS_ID !== $adressEmailFrom)
+						{
+							$result = $this->message->setFrom($conf->global->MAIN_MAIL_SMTPS_ID);
+						}
+						else
+						{
+							$result = $this->message->setFrom($this->getArrayAddress($from));
+						}
+					} else {
 						$result = $this->message->setFrom($this->getArrayAddress($from));
 					}
                 } catch (Exception $e) {


### PR DESCRIPTION
Some smtp servers like office365 from Microsoft, block  mail sending from userexemple@socdomain.tld account when use an other email as sender like contact@socdomain.tld for exemple

So I add a hidden conf MAIN_FORCE_DISABLE_MAIL_SPOOFING to force using userexemple@socdomain.tld as sender address