### PR TITLE
[REGRESSION] Fix #14181. Limits and accuracy form not saving modified values.

### DIFF
--- a/htdocs/admin/limits.php
+++ b/htdocs/admin/limits.php
@@ -34,6 +34,10 @@ if (!$user->admin) accessforbidden();
 $action = GETPOST('action', 'alpha');
 $currencycode = GETPOST('currencycode', 'alpha');
 
+if (!empty($conf->multicurrency->enabled) && !empty($conf->global->MULTICURRENCY_USE_LIMIT_BY_CURRENCY)) {
+	$currencycode = (!empty($currencycode) ? $currencycode : $conf->currency);
+}
+
 $mainmaxdecimalsunit = 'MAIN_MAX_DECIMALS_UNIT'.(!empty($currencycode) ? '_'.$currencycode : '');
 $mainmaxdecimalstot = 'MAIN_MAX_DECIMALS_TOT'.(!empty($currencycode) ? '_'.$currencycode : '');
 $mainmaxdecimalsshown = 'MAIN_MAX_DECIMALS_SHOWN'.(!empty($currencycode) ? '_'.$currencycode : '');
@@ -94,7 +98,6 @@ llxHeader();
 
 print load_fiche_titre($langs->trans("LimitsSetup"), '', 'title_setup');
 
-$currencycode = (!empty($currencycode) ? $currencycode : $conf->currency);
 $aCurrencies = array($conf->currency); // Default currency always first position
 
 if (!empty($conf->multicurrency->enabled) && !empty($conf->global->MULTICURRENCY_USE_LIMIT_BY_CURRENCY))


### PR DESCRIPTION
# Fix #14181. Limits and accuracy form not saving modified values.

Limits and accuracy form is not saving modified values. The support for "per currency limits and accuracy" wasn't properly implemented. 

By the way when activating the MultiCurrencies module and adding the constant MULTICURRENCY_USE_LIMIT_BY_CURRENCY, with my change the values are still correctly saved with the currency suffix added to the constants, but it is not used for PDF generation, only the global constant without the currency suffix is used. The feature is half-baked.
