### PR TITLE
FIX: Hotfix for "Call to a member function getNomUrl() on null in comm/propal/card.php"

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -253,6 +253,9 @@ if (empty($reshook))
 				}
 				$model = $object->modelpdf;
 				$ret = $object->fetch($id); // Reload to get new records
+				if ($ret > 0) {
+					$object->fetch_thirdparty();
+				}
 
 				$object->generateDocument($model, $outputlangs, $hidedetails, $hidedesc, $hideref);
 			}


### PR DESCRIPTION
Same as #14156, but when validating a proposal