### PR TITLE
Improve printStdColumnContent by passing the $pdf object

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1083,7 +1083,7 @@ abstract class CommonDocGenerator
             'curY' => &$curY,
             'columnText' => $columnText,
             'colKey' => $colKey,
-            'pdf' => $pdf,
+            'pdf' => &$pdf,
         );
         $reshook = $hookmanager->executeHooks('printStdColumnContent', $parameters, $this); // Note that $action and $object may have been modified by hook
         if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1082,7 +1082,8 @@ abstract class CommonDocGenerator
         $parameters = array(
             'curY' => &$curY,
             'columnText' => $columnText,
-            'colKey' => $colKey
+            'colKey' => $colKey,
+            'pdf' => $pdf,
         );
         $reshook = $hookmanager->executeHooks('printStdColumnContent', $parameters, $this); // Note that $action and $object may have been modified by hook
         if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');


### PR DESCRIPTION
# New Improve printStdColumnContent by passing the $pdf object

It isn't possible to replace the pdf edition done by this method without the $pdf object, so, passing it as a parameter.
