### PR TITLE
Fix extrafields ordering on PDFs

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1296,7 +1296,7 @@ abstract class CommonDocGenerator
         {
             // Sort extrafields by rank
             uasort($fields, function ($a, $b) {
-                return  ($a->rank > $b->rank) ? -1 : 1;
+                return  ($a->rank > $b->rank) ? 1 : -1;
 			});
 
             // define some HTML content with style


### PR DESCRIPTION
The extra fields on PDFs are in reverse order. Fixing it.
