### PR TITLE
NEW Can hide eatby, sellby dates with option PRODUCT_DISABLE_SELLBY and PRODUCT_DISABLE_EATBY

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -2307,8 +2307,12 @@ if ($action == 'create')
 								foreach ($lines[$i]->detail_batch as $dbatch)	// $dbatch is instance of ExpeditionLineBatch
 								{
 									$detail .= $langs->trans("Batch").': '.$dbatch->batch;
-									$detail .= ' - '.$langs->trans("SellByDate").': '.dol_print_date($dbatch->sellby, "day");
-									$detail .= ' - '.$langs->trans("EatByDate").': '.dol_print_date($dbatch->eatby, "day");
+									if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+										$detail .= ' - '.$langs->trans("SellByDate").': '.dol_print_date($dbatch->sellby, "day");
+									}
+									if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+										$detail .= ' - '.$langs->trans("EatByDate").': '.dol_print_date($dbatch->eatby, "day");
+									}
 									$detail .= ' - '.$langs->trans("Qty").': '.$dbatch->qty;
 									$detail .= '<br>';
 								}

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1300,8 +1300,12 @@ if ($action == 'create')
 
 									$detail = '';
 									$detail .= $langs->trans("Batch").': '.$dbatch->batch;
-									$detail .= ' - '.$langs->trans("SellByDate").': '.dol_print_date($dbatch->sellby, "day");
-									$detail .= ' - '.$langs->trans("EatByDate").': '.dol_print_date($dbatch->eatby, "day");
+									if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+										$detail .= ' - '.$langs->trans("SellByDate").': '.dol_print_date($dbatch->sellby, "day");
+									}
+									if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+										$detail .= ' - '.$langs->trans("EatByDate").': '.dol_print_date($dbatch->eatby, "day");
+									}
 									$detail .= ' - '.$langs->trans("Qty").': '.$dbatch->qty;
 									$detail .= '<br>';
 									print $detail;

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -910,8 +910,8 @@ if ($id > 0 || !empty($ref)) {
 							print '</td>';
 							if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
 								print '<td class="nowraponall">';
-								$dlcdatesuffix = dol_mktime( 0, 0, 0, GETPOST( 'dlc' . $suffix . 'month' ), GETPOST( 'dlc' . $suffix . 'day' ), GETPOST( 'dlc' . $suffix . 'year' ) );
-								print $form->selectDate( $dlcdatesuffix, 'dlc' . $suffix, '', '', 1, '' );
+								$dlcdatesuffix = dol_mktime(0, 0, 0, GETPOST('dlc' . $suffix . 'month'), GETPOST('dlc' . $suffix . 'day'), GETPOST('dlc' . $suffix . 'year'));
+								print $form->selectDate($dlcdatesuffix, 'dlc' . $suffix, '', '', 1, '');
 								print '</td>';
 							}
 							if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
@@ -1135,10 +1135,10 @@ if ($id > 0 || !empty($ref)) {
 			if (!empty($conf->productbatch->enabled)) {
 				print '<td class="dispatch_batch_number_title">'.$langs->trans("batch_number").'</td>';
 				if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
-					print '<td class="dispatch_dluo_title">' . $langs->trans( "EatByDate" ) . '</td>';
+					print '<td class="dispatch_dluo_title">' . $langs->trans("EatByDate") . '</td>';
 				}
 				if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
-					print '<td class="dispatch_dlc_title">' . $langs->trans( "SellByDate" ) . '</td>';
+					print '<td class="dispatch_dlc_title">' . $langs->trans("SellByDate") . '</td>';
 				}
 			}
 			print '<td class="right">'.$langs->trans("QtyDispatched").'</td>';
@@ -1195,10 +1195,10 @@ if ($id > 0 || !empty($ref)) {
 						$lot->fetch(0, $objp->pid, $objp->batch);
 						print '<td class="dispatch_batch_number">'.$lot->getNomUrl(1).'</td>';
 						if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
-							print '<td class="dispatch_dluo">' . dol_print_date( $lot->eatby, 'day' ) . '</td>';
+							print '<td class="dispatch_dluo">' . dol_print_date($lot->eatby, 'day') . '</td>';
 						}
 						if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
-							print '<td class="dispatch_dlc">' . dol_print_date( $lot->sellby, 'day' ) . '</td>';
+							print '<td class="dispatch_dlc">' . dol_print_date($lot->sellby, 'day') . '</td>';
 						}
 					} else {
 						print '<td class="dispatch_batch_number"></td>';

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -733,8 +733,12 @@ if ($id > 0 || !empty($ref)) {
 				print '<td>'.$langs->trans("Description").'</td>';
 				if (!empty($conf->productbatch->enabled)) {
 					print '<td class="dispatch_batch_number_title">'.$langs->trans("batch_number").'</td>';
-					print '<td class="dispatch_dluo_title">'.$langs->trans("EatByDate").'</td>';
-					print '<td class="dispatch_dlc_title">'.$langs->trans("SellByDate").'</td>';
+					if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+						print '<td class="dispatch_dluo_title">'.$langs->trans("EatByDate").'</td>';
+					}
+					if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+						print '<td class="dispatch_dlc_title">'.$langs->trans("SellByDate").'</td>';
+					}
 				} else {
 					print '<td></td>';
 					print '<td></td>';
@@ -819,8 +823,12 @@ if ($id > 0 || !empty($ref)) {
 								print $linktoprod;
 								print "</td>";
 								print '<td class="dispatch_batch_number"></td>';
-								print '<td class="dispatch_dluo"></td>';
-								print '<td class="dispatch_dlc"></td>';
+								if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+									print '<td class="dispatch_dluo"></td>';
+								}
+								if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+									print '<td class="dispatch_dlc"></td>';
+								}
 							} else {
 								print '<td>';
 								print $linktoprod;
@@ -828,8 +836,12 @@ if ($id > 0 || !empty($ref)) {
 								print '<td class="dispatch_batch_number">';
 								print $langs->trans("ProductDoesNotUseBatchSerial");
 								print '</td>';
-								print '<td class="dispatch_dluo"></td>';
-								print '<td class="dispatch_dlc"></td>';
+								if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+									print '<td class="dispatch_dluo"></td>';
+								}
+								if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+									print '<td class="dispatch_dlc"></td>';
+								}
 							}
 						} else {
 							print '<td colspan="4">';
@@ -896,14 +908,18 @@ if ($id > 0 || !empty($ref)) {
 							print '<td>';
 							print '<input type="text" class="inputlotnumber quatrevingtquinzepercent" id="lot_number'.$suffix.'" name="lot_number'.$suffix.'" value="'.GETPOST('lot_number'.$suffix).'">';
 							print '</td>';
-							print '<td class="nowraponall">';
-							$dlcdatesuffix = dol_mktime(0, 0, 0, GETPOST('dlc'.$suffix.'month'), GETPOST('dlc'.$suffix.'day'), GETPOST('dlc'.$suffix.'year'));
-							print $form->selectDate($dlcdatesuffix, 'dlc'.$suffix, '', '', 1, '');
-							print '</td>';
-							print '<td class="nowraponall">';
-							$dluodatesuffix = dol_mktime(0, 0, 0, GETPOST('dluo'.$suffix.'month'), GETPOST('dluo'.$suffix.'day'), GETPOST('dluo'.$suffix.'year'));
-							print $form->selectDate($dluodatesuffix, 'dluo'.$suffix, '', '', 1, '');
-							print '</td>';
+							if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+								print '<td class="nowraponall">';
+								$dlcdatesuffix = dol_mktime( 0, 0, 0, GETPOST( 'dlc' . $suffix . 'month' ), GETPOST( 'dlc' . $suffix . 'day' ), GETPOST( 'dlc' . $suffix . 'year' ) );
+								print $form->selectDate( $dlcdatesuffix, 'dlc' . $suffix, '', '', 1, '' );
+								print '</td>';
+							}
+							if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+								print '<td class="nowraponall">';
+								$dluodatesuffix = dol_mktime(0, 0, 0, GETPOST('dluo'.$suffix.'month'), GETPOST('dluo'.$suffix.'day'), GETPOST('dluo'.$suffix.'year'));
+								print $form->selectDate($dluodatesuffix, 'dluo'.$suffix, '', '', 1, '');
+								print '</td>';
+							}
 							print '<td colspan="3">&nbsp</td>'; // Supplier ref + Qty ordered + qty already dispatched
 						} else {
 							$type = 'dispatch';
@@ -1118,8 +1134,12 @@ if ($id > 0 || !empty($ref)) {
 			print '<td>'.$langs->trans("DateDeliveryPlanned").'</td>';
 			if (!empty($conf->productbatch->enabled)) {
 				print '<td class="dispatch_batch_number_title">'.$langs->trans("batch_number").'</td>';
-				print '<td class="dispatch_dluo_title">'.$langs->trans("EatByDate").'</td>';
-				print '<td class="dispatch_dlc_title">'.$langs->trans("SellByDate").'</td>';
+				if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+					print '<td class="dispatch_dluo_title">' . $langs->trans( "EatByDate" ) . '</td>';
+				}
+				if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+					print '<td class="dispatch_dlc_title">' . $langs->trans( "SellByDate" ) . '</td>';
+				}
 			}
 			print '<td class="right">'.$langs->trans("QtyDispatched").'</td>';
 			print '<td>'.$langs->trans("Warehouse").'</td>';
@@ -1174,8 +1194,12 @@ if ($id > 0 || !empty($ref)) {
 						$lot=new Productlot($db);
 						$lot->fetch(0, $objp->pid, $objp->batch);
 						print '<td class="dispatch_batch_number">'.$lot->getNomUrl(1).'</td>';
-						print '<td class="dispatch_dluo">'.dol_print_date($lot->eatby, 'day').'</td>';
-						print '<td class="dispatch_dlc">'.dol_print_date($lot->sellby, 'day').'</td>';
+						if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+							print '<td class="dispatch_dluo">' . dol_print_date( $lot->eatby, 'day' ) . '</td>';
+						}
+						if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+							print '<td class="dispatch_dlc">' . dol_print_date( $lot->sellby, 'day' ) . '</td>';
+						}
 					} else {
 						print '<td class="dispatch_batch_number"></td>';
 						print '<td class="dispatch_dluo"></td>';

--- a/htdocs/mrp/mo_movements.php
+++ b/htdocs/mrp/mo_movements.php
@@ -143,6 +143,12 @@ $arrayfields = array(
 	//'m.datec'=>array('label'=>$langs->trans("DateCreation"), 'checked'=>0, 'position'=>500),
 	//'m.tms'=>array('label'=>$langs->trans("DateModificationShort"), 'checked'=>0, 'position'=>500)
 );
+if (!empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+	unset($arrayfields['pl.eatby']);
+}
+if (!empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+	unset($arrayfields['pl.sellby']);
+}
 $objectlist->fields = dol_sort_array($objectlist->fields, 'position');
 $arrayfields = dol_sort_array($arrayfields, 'position');
 

--- a/htdocs/product/reassortlot.php
+++ b/htdocs/product/reassortlot.php
@@ -284,8 +284,12 @@ if ($resql)
 	print '<td class="liste_titre center"><input class="flat" type="text" name="search_batch" size="6" value="'.$search_batch.'"></td>';
 	print '<td class="liste_titre right">&nbsp;</td>';
 	print '<td class="liste_titre">&nbsp;</td>';
-	print '<td class="liste_titre">&nbsp;</td>';
-	print '<td class="liste_titre">&nbsp;</td>';
+	if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+		print '<td class="liste_titre">&nbsp;</td>';
+	}
+	if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+		print '<td class="liste_titre">&nbsp;</td>';
+	}
 	print '<td class="liste_titre">&nbsp;</td>';
     print '<td class="liste_titre">&nbsp;</td>';
     print '<td class="liste_titre maxwidthsearch">';
@@ -302,8 +306,12 @@ if ($resql)
 	print_liste_field_titre("Warehouse", $_SERVER["PHP_SELF"], "e.ref", $param, "", '', $sortfield, $sortorder);
 	//print_liste_field_titre("DesiredStock", $_SERVER["PHP_SELF"], "p.desiredstock",$param,"",'',$sortfield,$sortorder, 'right );
 	print_liste_field_titre("Batch", $_SERVER["PHP_SELF"], "pb.batch", $param, "", '', $sortfield, $sortorder, 'center ');
-	print_liste_field_titre("EatByDate", $_SERVER["PHP_SELF"], "pb.eatby", $param, "", '', $sortfield, $sortorder, 'center ');
-	print_liste_field_titre("SellByDate", $_SERVER["PHP_SELF"], "pb.sellby", $param, "", '', $sortfield, $sortorder, 'center ');
+	if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+		print_liste_field_titre("EatByDate", $_SERVER["PHP_SELF"], "pb.eatby", $param, "", '', $sortfield, $sortorder, 'center ');
+	}
+	if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+		print_liste_field_titre("SellByDate", $_SERVER["PHP_SELF"], "pb.sellby", $param, "", '', $sortfield, $sortorder, 'center ');
+	}
 	print_liste_field_titre("PhysicalStock", $_SERVER["PHP_SELF"], "stock_physique", $param, "", '', $sortfield, $sortorder, 'right ');
 	// TODO Add info of running suppliers/customers orders
 	//print_liste_field_titre("TheoreticalStock",$_SERVER["PHP_SELF"], "stock_theorique",$param,"",'',$sortfield,$sortorder, 'right ');
@@ -400,8 +408,12 @@ if ($resql)
 		}
 		print '</td>';
 
-		print '<td class="center">'.dol_print_date($db->jdate($objp->eatby), 'day').'</td>';
-		print '<td class="center">'.dol_print_date($db->jdate($objp->sellby), 'day').'</td>';
+		if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+			print '<td class="center">'.dol_print_date($db->jdate($objp->eatby), 'day').'</td>';
+		}
+		if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+			print '<td class="center">'.dol_print_date($db->jdate($objp->sellby), 'day').'</td>';
+		}
 		print '<td class="right">';
         //if ($objp->seuil_stock_alerte && ($objp->stock_physique < $objp->seuil_stock_alerte)) print img_warning($langs->trans("StockTooLow")).' ';
 		print $objp->stock_physique;

--- a/htdocs/product/stock/index.php
+++ b/htdocs/product/stock/index.php
@@ -159,8 +159,12 @@ if ($resql)
 	if (!empty($conf->productbatch->enabled))
 	{
 		print '<th>'.$langs->trans("Batch").'</th>';
-		print '<th>'.$langs->trans("SellByDate").'</th>';
-		print '<th>'.$langs->trans("EatByDate").'</th>';
+		if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+			print '<th>'.$langs->trans("SellByDate").'</th>';
+		}
+		if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+			print '<th>'.$langs->trans("EatByDate").'</th>';
+		}
 	}
 	print '<th>'.$langs->trans("Warehouse").'</th>';
 	print '<th class="right"><a class="notasortlink" href="'.DOL_URL_ROOT.'/product/stock/movement_list.php">'.$langs->trans("FullList").'</a></th>';
@@ -191,8 +195,12 @@ if ($resql)
 		if (!empty($conf->productbatch->enabled))
 		{
 			print '<td>'.$objp->batch.'</td>';
-			print '<td>'.dol_print_date($db->jdate($objp->sellby), 'day').'</td>';
-			print '<td>'.dol_print_date($db->jdate($objp->eatby), 'day').'</td>';
+			if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+				print '<td>'.dol_print_date($db->jdate($objp->sellby), 'day').'</td>';
+			}
+			if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+				print '<td>'.dol_print_date($db->jdate($objp->eatby), 'day').'</td>';
+			}
 		}
 		print '<td class="tdoverflowmax200">';
 		print $warehouse->getNomUrl(1);

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -121,6 +121,12 @@ $arrayfields = array(
 		//'m.datec'=>array('label'=>$langs->trans("DateCreation"), 'checked'=>0, 'position'=>500),
     //'m.tms'=>array('label'=>$langs->trans("DateModificationShort"), 'checked'=>0, 'position'=>500)
 );
+if (!empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+	unset($arrayfields['pl.eatby']);
+}
+if (!empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+	unset($arrayfields['pl.sellby']);
+}
 
 // Security check
 if (!$user->rights->stock->mouvement->lire) {

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -894,7 +894,7 @@ if (!$variants) {
 						print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 						print '<input type="hidden" name="token" value="'.newToken().'">';
 						print '<input type="hidden" name="pdluoid" value="'.$pdluo->id.'"><input type="hidden" name="action" value="updateline"><input type="hidden" name="id" value="'.$id.'"><table class="noborder centpercent"><tr><td width="10%"></td>';
-						//                      print '<td class="right" width="10%"><input type="text" name="batch_number" value="'.$pdluo->batch.'"></td>';
+						print '<td class="right" width="10%"><input type="text" name="batch_number" value="'.$pdluo->batch.'"></td>';
 						if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
 							print '<td class="center" width="10%">';
 							print $form->selectDate($pdluo->eatby, 'eatby', '', '', 1, '', 1, 0);

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -805,11 +805,18 @@ if (!$variants) {
 	print '<td class="right">'.$langs->trans("EstimatedStockValueSellShort").'</td>';
 	print '</tr>';
 	if ((!empty($conf->productbatch->enabled)) && $object->hasbatch()) {
+		$colspan = 3;
 		print '<tr class="liste_titre"><td width="10%"></td>';
 		print '<td class="right" width="10%">'.$langs->trans("batch_number").'</td>';
-		print '<td class="center" width="10%">'.$langs->trans("EatByDate").'</td>';
-		print '<td class="center" width="10%">'.$langs->trans("SellByDate").'</td>';
-		print '<td></td>';
+		if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+			$colspan--;
+			print '<td class="center" width="10%">'.$langs->trans("EatByDate").'</td>';
+		}
+		if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+			$colspan--;
+			print '<td class="center" width="10%">'.$langs->trans("SellByDate").'</td>';
+		}
+		print '<td colspan="'.$colspan.'"></td>';
 		print '<td></td>';
 		print '<td></td>';
 		print '<td></td>';
@@ -887,14 +894,18 @@ if (!$variants) {
 						print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 						print '<input type="hidden" name="token" value="'.newToken().'">';
 						print '<input type="hidden" name="pdluoid" value="'.$pdluo->id.'"><input type="hidden" name="action" value="updateline"><input type="hidden" name="id" value="'.$id.'"><table class="noborder centpercent"><tr><td width="10%"></td>';
-						print '<td class="right" width="10%"><input type="text" name="batch_number" value="'.$pdluo->batch.'"></td>';
-						print '<td class="center" width="10%">';
-						print $form->selectDate($pdluo->eatby, 'eatby', '', '', 1, '', 1, 0);
-						print '</td>';
-						print '<td class="center" width="10%">';
-						print $form->selectDate($pdluo->sellby, 'sellby', '', '', 1, '', 1, 0);
-						print '</td>';
-						print '<td class="right" width="10%">'.$pdluo->qty.($pdluo->qty < 0 ? ' '.img_warning() : '').'</td>';
+//						print '<td class="right" width="10%"><input type="text" name="batch_number" value="'.$pdluo->batch.'"></td>';
+						if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+							print '<td class="center" width="10%">';
+							print $form->selectDate($pdluo->eatby, 'eatby', '', '', 1, '', 1, 0);
+							print '</td>';
+						}
+						if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+							print '<td class="center" width="10%">';
+							print $form->selectDate($pdluo->sellby, 'sellby', '', '', 1, '', 1, 0);
+							print '</td>';
+						}
+						print '<td class="right" colspan="3">'.$pdluo->qty.($pdluo->qty < 0 ? ' '.img_warning() : '').'</td>';
 						print '<td colspan="4"><input type="submit" class="button" id="savelinebutton marginbottomonly" name="save" value="'.$langs->trans("Save").'">';
 						print '<input type="submit" class="button" id="cancellinebutton" name="Cancel" value="'.$langs->trans("Cancel").'"></td></tr>';
 						print '</table>';
@@ -911,9 +922,16 @@ if (!$variants) {
 						print '<td class="right">';
 						print $product_lot_static->getNomUrl(1);
 						print '</td>';
-						print '<td class="center">'.dol_print_date($pdluo->eatby, 'day').'</td>';
-						print '<td class="center">'.dol_print_date($pdluo->sellby, 'day').'</td>';
-						print '<td class="right">'.$pdluo->qty.($pdluo->qty < 0 ? ' '.img_warning() : '').'</td>';
+						$colspan = 3;
+						if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+							$colspan--;
+							print '<td class="center">'.dol_print_date($pdluo->eatby, 'day').'</td>';
+						}
+						if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+							$colspan--;
+							print '<td class="center">'.dol_print_date($pdluo->sellby, 'day').'</td>';
+						}
+						print '<td class="right" colspan="'.$colspan.'">'.$pdluo->qty.($pdluo->qty < 0 ? ' '.img_warning() : '').'</td>';
 						print '<td colspan="4"></td>';
 						print '</tr>';
 					}

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -894,7 +894,7 @@ if (!$variants) {
 						print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 						print '<input type="hidden" name="token" value="'.newToken().'">';
 						print '<input type="hidden" name="pdluoid" value="'.$pdluo->id.'"><input type="hidden" name="action" value="updateline"><input type="hidden" name="id" value="'.$id.'"><table class="noborder centpercent"><tr><td width="10%"></td>';
-//						print '<td class="right" width="10%"><input type="text" name="batch_number" value="'.$pdluo->batch.'"></td>';
+						//                      print '<td class="right" width="10%"><input type="text" name="batch_number" value="'.$pdluo->batch.'"></td>';
 						if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
 							print '<td class="center" width="10%">';
 							print $form->selectDate($pdluo->eatby, 'eatby', '', '', 1, '', 1, 0);

--- a/htdocs/product/stock/productlot_card.php
+++ b/htdocs/product/stock/productlot_card.php
@@ -329,9 +329,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     // Eat by
 	if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
 		print '<tr><td>';
-		print $form->editfieldkey( $langs->trans( 'EatByDate' ), 'eatby', $object->eatby, $object, $user->rights->stock->creer, 'datepicker' );
+		print $form->editfieldkey($langs->trans('EatByDate'), 'eatby', $object->eatby, $object, $user->rights->stock->creer, 'datepicker');
 		print '</td><td>';
-		print $form->editfieldval( $langs->trans( 'EatByDate' ), 'eatby', $object->eatby, $object, $user->rights->stock->creer, 'datepicker' );
+		print $form->editfieldval($langs->trans('EatByDate'), 'eatby', $object->eatby, $object, $user->rights->stock->creer, 'datepicker');
 		print '</td>';
 		print '</tr>';
 	}
@@ -339,9 +339,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     // Sell by
 	if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
 		print '<tr><td>';
-		print $form->editfieldkey( $langs->trans( 'SellByDate' ), 'sellby', $object->sellby, $object, $user->rights->stock->creer, 'datepicker' );
+		print $form->editfieldkey($langs->trans('SellByDate'), 'sellby', $object->sellby, $object, $user->rights->stock->creer, 'datepicker');
 		print '</td><td>';
-		print $form->editfieldval( $langs->trans( 'SellByDate' ), 'sellby', $object->sellby, $object, $user->rights->stock->creer, 'datepicker' );
+		print $form->editfieldval($langs->trans('SellByDate'), 'sellby', $object->sellby, $object, $user->rights->stock->creer, 'datepicker');
 		print '</td>';
 		print '</tr>';
 	}

--- a/htdocs/product/stock/productlot_card.php
+++ b/htdocs/product/stock/productlot_card.php
@@ -327,21 +327,24 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     print '</td></tr>';
 
     // Eat by
-    print '<tr><td>';
-    print $form->editfieldkey($langs->trans('EatByDate'), 'eatby', $object->eatby, $object, $user->rights->stock->creer, 'datepicker');
-    print '</td><td>';
-    print $form->editfieldval($langs->trans('EatByDate'), 'eatby', $object->eatby, $object, $user->rights->stock->creer, 'datepicker');
-    print '</td>';
-    print '</tr>';
+	if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+		print '<tr><td>';
+		print $form->editfieldkey( $langs->trans( 'EatByDate' ), 'eatby', $object->eatby, $object, $user->rights->stock->creer, 'datepicker' );
+		print '</td><td>';
+		print $form->editfieldval( $langs->trans( 'EatByDate' ), 'eatby', $object->eatby, $object, $user->rights->stock->creer, 'datepicker' );
+		print '</td>';
+		print '</tr>';
+	}
 
     // Sell by
-    print '<tr><td>';
-    print $form->editfieldkey($langs->trans('SellByDate'), 'sellby', $object->sellby, $object, $user->rights->stock->creer, 'datepicker');
-    print '</td><td>';
-    print $form->editfieldval($langs->trans('SellByDate'), 'sellby', $object->sellby, $object, $user->rights->stock->creer, 'datepicker');
-    print '</td>';
-    print '</tr>';
-
+	if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+		print '<tr><td>';
+		print $form->editfieldkey( $langs->trans( 'SellByDate' ), 'sellby', $object->sellby, $object, $user->rights->stock->creer, 'datepicker' );
+		print '</td><td>';
+		print $form->editfieldval( $langs->trans( 'SellByDate' ), 'sellby', $object->sellby, $object, $user->rights->stock->creer, 'datepicker' );
+		print '</td>';
+		print '</tr>';
+	}
     // Other attributes
     $cols = 2;
     include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_view.tpl.php';

--- a/htdocs/product/stock/productlot_list.php
+++ b/htdocs/product/stock/productlot_list.php
@@ -344,8 +344,8 @@ if ($resql)
 	if (!empty($arrayfields['t.entity']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_entity" value="'.$search_entity.'" size="8"></td>';
 	if (!empty($arrayfields['t.batch']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_batch" value="'.$search_batch.'" size="8"></td>';
 	if (!empty($arrayfields['t.fk_product']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_product" value="'.$search_product.'" size="8"></td>';
-	if (!empty($arrayfields['t.sellby']['checked']) && empty($conf->global->PRODUCT_DISABLE_SELLBY)) print '<td class="liste_titre"></td>';
-	if (!empty($arrayfields['t.eatby']['checked']) && empty($conf->global->PRODUCT_DISABLE_EATBY)) print '<td class="liste_titre"></td>';
+	if (!empty($arrayfields['t.sellby']['checked'])) print '<td class="liste_titre"></td>';
+	if (!empty($arrayfields['t.eatby']['checked'])) print '<td class="liste_titre"></td>';
 	if (!empty($arrayfields['t.fk_user_creat']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_fk_user_creat" value="'.$search_fk_user_creat.'" size="10"></td>';
 	if (!empty($arrayfields['t.fk_user_modif']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_fk_user_modif" value="'.$search_fk_user_modif.'" size="10"></td>';
 	if (!empty($arrayfields['t.import_key']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_import_key" value="'.$search_import_key.'" size="10"></td>';
@@ -387,8 +387,8 @@ if ($resql)
 	if (!empty($arrayfields['t.entity']['checked']))        print_liste_field_titre($arrayfields['t.entity']['label'], $_SERVER['PHP_SELF'], 't.entity', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.batch']['checked']))         print_liste_field_titre($arrayfields['t.batch']['label'], $_SERVER['PHP_SELF'], 't.batch', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.fk_product']['checked']))    print_liste_field_titre($arrayfields['t.fk_product']['label'], $_SERVER['PHP_SELF'], 't.fk_product', '', $param, '', $sortfield, $sortorder);
-	if (!empty($arrayfields['t.sellby']['checked']) && empty($conf->global->PRODUCT_DISABLE_SELLBY))        print_liste_field_titre($arrayfields['t.sellby']['label'], $_SERVER['PHP_SELF'], 't.sellby', '', $param, '', $sortfield, $sortorder);
-	if (!empty($arrayfields['t.eatby']['checked']) && empty($conf->global->PRODUCT_DISABLE_EATBY))         print_liste_field_titre($arrayfields['t.eatby']['label'], $_SERVER['PHP_SELF'], 't.eatby', '', $param, '', $sortfield, $sortorder);
+	if (!empty($arrayfields['t.sellby']['checked']))        print_liste_field_titre($arrayfields['t.sellby']['label'], $_SERVER['PHP_SELF'], 't.sellby', '', $param, '', $sortfield, $sortorder);
+	if (!empty($arrayfields['t.eatby']['checked']))         print_liste_field_titre($arrayfields['t.eatby']['label'], $_SERVER['PHP_SELF'], 't.eatby', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.fk_user_creat']['checked'])) print_liste_field_titre($arrayfields['t.fk_user_creat']['label'], $_SERVER['PHP_SELF'], 't.fk_user_creat', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.fk_user_modif']['checked'])) print_liste_field_titre($arrayfields['t.fk_user_modif']['label'], $_SERVER['PHP_SELF'], 't.fk_user_modif', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.import_key']['checked']))    print_liste_field_titre($arrayfields['t.import_key']['label'], $_SERVER['PHP_SELF'], 't.import_key', '', $param, '', $sortfield, $sortorder);
@@ -448,12 +448,12 @@ if ($resql)
 				print '<td>'.$productstatic->getNomUrl(1).'</td>';
 				if (!$i) $totalarray['nbfield']++;
 			}
-			if (!empty($arrayfields['t.sellby']['checked']) && empty($conf->global->PRODUCT_DISABLE_SELLBY))
+			if (!empty($arrayfields['t.sellby']['checked']))
 			{
 				print '<td>'.dol_print_date($db->jdate($obj->sellby), 'day').'</td>';
 				if (!$i) $totalarray['nbfield']++;
 			}
-			if (!empty($arrayfields['t.eatby']['checked']) && empty($conf->global->PRODUCT_DISABLE_EATBY))
+			if (!empty($arrayfields['t.eatby']['checked']))
 			{
 				print '<td>'.dol_print_date($db->jdate($obj->eatby), 'day').'</td>';
 				if (!$i) $totalarray['nbfield']++;

--- a/htdocs/product/stock/productlot_list.php
+++ b/htdocs/product/stock/productlot_list.php
@@ -99,6 +99,12 @@ $arrayfields = array(
 	't.tms'=>array('label'=>$langs->trans("DateModificationShort"), 'checked'=>0, 'position'=>500),
 	//'t.statut'=>array('label'=>$langs->trans("Status"), 'checked'=>1, 'position'=>1000),
 );
+if (!empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+	unset($arrayfields['t.sellby']);
+}
+if (!empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+	unset($arrayfields['t.eatby']);
+}
 // Extra fields
 if (is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label']) > 0)
 {
@@ -338,8 +344,8 @@ if ($resql)
 	if (!empty($arrayfields['t.entity']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_entity" value="'.$search_entity.'" size="8"></td>';
 	if (!empty($arrayfields['t.batch']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_batch" value="'.$search_batch.'" size="8"></td>';
 	if (!empty($arrayfields['t.fk_product']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_product" value="'.$search_product.'" size="8"></td>';
-	if (!empty($arrayfields['t.sellby']['checked'])) print '<td class="liste_titre"></td>';
-	if (!empty($arrayfields['t.eatby']['checked'])) print '<td class="liste_titre"></td>';
+	if (!empty($arrayfields['t.sellby']['checked']) && empty($conf->global->PRODUCT_DISABLE_SELLBY)) print '<td class="liste_titre"></td>';
+	if (!empty($arrayfields['t.eatby']['checked']) && empty($conf->global->PRODUCT_DISABLE_EATBY)) print '<td class="liste_titre"></td>';
 	if (!empty($arrayfields['t.fk_user_creat']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_fk_user_creat" value="'.$search_fk_user_creat.'" size="10"></td>';
 	if (!empty($arrayfields['t.fk_user_modif']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_fk_user_modif" value="'.$search_fk_user_modif.'" size="10"></td>';
 	if (!empty($arrayfields['t.import_key']['checked'])) print '<td class="liste_titre"><input type="text" class="flat" name="search_import_key" value="'.$search_import_key.'" size="10"></td>';
@@ -381,8 +387,8 @@ if ($resql)
 	if (!empty($arrayfields['t.entity']['checked']))        print_liste_field_titre($arrayfields['t.entity']['label'], $_SERVER['PHP_SELF'], 't.entity', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.batch']['checked']))         print_liste_field_titre($arrayfields['t.batch']['label'], $_SERVER['PHP_SELF'], 't.batch', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.fk_product']['checked']))    print_liste_field_titre($arrayfields['t.fk_product']['label'], $_SERVER['PHP_SELF'], 't.fk_product', '', $param, '', $sortfield, $sortorder);
-	if (!empty($arrayfields['t.sellby']['checked']))        print_liste_field_titre($arrayfields['t.sellby']['label'], $_SERVER['PHP_SELF'], 't.sellby', '', $param, '', $sortfield, $sortorder);
-	if (!empty($arrayfields['t.eatby']['checked']))         print_liste_field_titre($arrayfields['t.eatby']['label'], $_SERVER['PHP_SELF'], 't.eatby', '', $param, '', $sortfield, $sortorder);
+	if (!empty($arrayfields['t.sellby']['checked']) && empty($conf->global->PRODUCT_DISABLE_SELLBY))        print_liste_field_titre($arrayfields['t.sellby']['label'], $_SERVER['PHP_SELF'], 't.sellby', '', $param, '', $sortfield, $sortorder);
+	if (!empty($arrayfields['t.eatby']['checked']) && empty($conf->global->PRODUCT_DISABLE_EATBY))         print_liste_field_titre($arrayfields['t.eatby']['label'], $_SERVER['PHP_SELF'], 't.eatby', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.fk_user_creat']['checked'])) print_liste_field_titre($arrayfields['t.fk_user_creat']['label'], $_SERVER['PHP_SELF'], 't.fk_user_creat', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.fk_user_modif']['checked'])) print_liste_field_titre($arrayfields['t.fk_user_modif']['label'], $_SERVER['PHP_SELF'], 't.fk_user_modif', '', $param, '', $sortfield, $sortorder);
 	if (!empty($arrayfields['t.import_key']['checked']))    print_liste_field_titre($arrayfields['t.import_key']['label'], $_SERVER['PHP_SELF'], 't.import_key', '', $param, '', $sortfield, $sortorder);
@@ -442,12 +448,12 @@ if ($resql)
 				print '<td>'.$productstatic->getNomUrl(1).'</td>';
 				if (!$i) $totalarray['nbfield']++;
 			}
-			if (!empty($arrayfields['t.sellby']['checked']))
+			if (!empty($arrayfields['t.sellby']['checked']) && empty($conf->global->PRODUCT_DISABLE_SELLBY))
 			{
 				print '<td>'.dol_print_date($db->jdate($obj->sellby), 'day').'</td>';
 				if (!$i) $totalarray['nbfield']++;
 			}
-			if (!empty($arrayfields['t.eatby']['checked']))
+			if (!empty($arrayfields['t.eatby']['checked']) && empty($conf->global->PRODUCT_DISABLE_EATBY))
 			{
 				print '<td>'.dol_print_date($db->jdate($obj->eatby), 'day').'</td>';
 				if (!$i) $totalarray['nbfield']++;

--- a/htdocs/product/stock/tpl/stockcorrection.tpl.php
+++ b/htdocs/product/stock/tpl/stockcorrection.tpl.php
@@ -103,14 +103,18 @@ if (!empty($conf->productbatch->enabled) &&
 	print '</td>';
 	print '</tr>';
 	print '<tr>';
-	print '<td>'.$langs->trans("EatByDate").'</td><td>';
-	$eatbyselected = dol_mktime(0, 0, 0, GETPOST('eatbymonth'), GETPOST('eatbyday'), GETPOST('eatbyyear'));
-	print $form->selectDate($eatbyselected, 'eatby', '', '', 1, "");
-	print '</td>';
-	print '<td>'.$langs->trans("SellByDate").'</td><td>';
-	$sellbyselected = dol_mktime(0, 0, 0, GETPOST('sellbymonth'), GETPOST('sellbyday'), GETPOST('sellbyyear'));
-	print $form->selectDate($sellbyselected, 'sellby', '', '', 1, "");
-	print '</td>';
+	if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+		print '<td>'.$langs->trans("EatByDate").'</td><td>';
+		$eatbyselected = dol_mktime(0, 0, 0, GETPOST('eatbymonth'), GETPOST('eatbyday'), GETPOST('eatbyyear'));
+		print $form->selectDate($eatbyselected, 'eatby', '', '', 1, "");
+		print '</td>';
+	}
+	if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+		print '<td>'.$langs->trans("SellByDate").'</td><td>';
+		$sellbyselected = dol_mktime(0, 0, 0, GETPOST('sellbymonth'), GETPOST('sellbyday'), GETPOST('sellbyyear'));
+		print $form->selectDate($sellbyselected, 'sellby', '', '', 1, "");
+		print '</td>';
+	}
 	print '</tr>';
 }
 

--- a/htdocs/product/stock/tpl/stocktransfer.tpl.php
+++ b/htdocs/product/stock/tpl/stocktransfer.tpl.php
@@ -107,12 +107,16 @@ if (!empty($conf->productbatch->enabled) &&
 	print '</tr>';
 
 	print '<tr>';
-	print '<td>'.$langs->trans("EatByDate").'</td><td>';
-	print $form->selectDate(($d_eatby ? $d_eatby : $pdluo->eatby), 'eatby', '', '', 1, "", 1, 0, ($pdluoid > 0 ? 1 : 0)); // If form was opened for a specific pdluoid, field is disabled
-	print '</td>';
-	print '<td>'.$langs->trans("SellByDate").'</td><td>';
-	print $form->selectDate(($d_sellby ? $d_sellby : $pdluo->sellby), 'sellby', '', '', 1, "", 1, 0, ($pdluoid > 0 ? 1 : 0)); // If form was opened for a specific pdluoid, field is disabled
-	print '</td>';
+	if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+		print '<td>'.$langs->trans("EatByDate").'</td><td>';
+		print $form->selectDate(($d_eatby ? $d_eatby : $pdluo->eatby), 'eatby', '', '', 1, "", 1, 0, ($pdluoid > 0 ? 1 : 0)); // If form was opened for a specific pdluoid, field is disabled
+		print '</td>';
+	}
+	if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+		print '<td>'.$langs->trans("SellByDate").'</td><td>';
+		print $form->selectDate(($d_sellby ? $d_sellby : $pdluo->sellby), 'sellby', '', '', 1, "", 1, 0, ($pdluoid > 0 ? 1 : 0)); // If form was opened for a specific pdluoid, field is disabled
+		print '</td>';
+	}
 	print '</tr>';
 }
 

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -966,8 +966,12 @@ if ($action == 'create')
 				if (!empty($conf->productbatch->enabled))
 				{
 					print '<td class="left">'.$langs->trans("batch_number").'</td>';
-					print '<td class="left">'.$langs->trans("EatByDate").'</td>';
-					print '<td class="left">'.$langs->trans("SellByDate").'</td>';
+					if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+						print '<td class="left">'.$langs->trans("EatByDate").'</td>';
+					}
+					if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+						print '<td class="left">'.$langs->trans("SellByDate").'</td>';
+					}
 				}
                 print "</tr>\n";
             }
@@ -1114,12 +1118,16 @@ if ($action == 'create')
 						if (!empty($product->status_batch))
 						{
 							print '<td><input name="batch'.$indiceAsked.'" value="'.$dispatchLines[$indiceAsked]['lot'].'"></td>';
-							print '<td>';
-							print $form->selectDate($dispatchLines[$indiceAsked]['DLC'], 'dlc'.$indiceAsked, '', '', 1, "");
-							print '</td>';
-							print '<td>';
-							print $form->selectDate($dispatchLines[$indiceAsked]['DLUO'], 'dluo'.$indiceAsked, '', '', 1, "");
-							print '</td>';
+							if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+								print '<td>';
+								print $form->selectDate($dispatchLines[$indiceAsked]['DLC'], 'dlc'.$indiceAsked, '', '', 1, "");
+								print '</td>';
+							}
+							if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+								print '<td>';
+								print $form->selectDate($dispatchLines[$indiceAsked]['DLUO'], 'dluo'.$indiceAsked, '', '', 1, "");
+								print '</td>';
+							}
 						} else {
 							print '<td colspan="3"></td>';
 						}
@@ -1807,10 +1815,14 @@ if ($action == 'create')
 						if ($conf->productbatch->enabled && !empty($lines[$i]->product->status_batch))
 						{
 							print '<td>  <input name="batch'.$line_id.'" id="batch'.$line_id.'" type="text" value="'.$lines[$i]->batch.'"> </br>';
-							print $langs->trans('EatByDate').' : ';
-							print $form->selectDate($lines[$i]->eatby, 'dlc'.$line_id, '', '', 1, "").'</br>';
-							print $langs->trans('SellByDate').' : ';
-							print $form->selectDate($lines[$i]->sellby, 'dluo'.$line_id, '', '', 1, "");
+							if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+								print $langs->trans('EatByDate').' : ';
+								print $form->selectDate($lines[$i]->eatby, 'dlc'.$line_id, '', '', 1, "").'</br>';
+							}
+							if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+								print $langs->trans('SellByDate').' : ';
+								print $form->selectDate($lines[$i]->sellby, 'dluo'.$line_id, '', '', 1, "");
+							}
 							print '</td>';
 						}
 						print '</tr>';
@@ -1856,11 +1868,14 @@ if ($action == 'create')
 						$detail = '';
 						if ($lines[$i]->product->status_batch)
 						{
-								$detail .= $langs->trans("Batch").': '.$lines[$i]->batch;
+							$detail .= $langs->trans("Batch").': '.$lines[$i]->batch;
+							if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
 								$detail .= ' - '.$langs->trans("SellByDate").': '.dol_print_date($lines[$i]->sellby, "day");
+							}
+							if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
 								$detail .= ' - '.$langs->trans("EatByDate").': '.dol_print_date($lines[$i]->eatby, "day");
-
-								$detail .= '<br>';
+							}
+							$detail .= '<br>';
 
 							print $form->textwithtooltip(img_picto('', 'object_barcode').' '.$langs->trans("DetailBatchNumber"), $detail);
 						} else {


### PR DESCRIPTION
# Fix #14200 

By defining the globals

`PRODUCT_DISABLE_EATBY`
and/or
`PRODUCT_DISABLE_SELLBY`

the fields will be hidden from the UI