### PR TITLE
FIX Lose HTML tags when adding a new product/service into a document 

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -790,7 +790,7 @@ if (empty($reshook))
 	} elseif ($action == 'addline' && $usercancreate) {		// Add line
 		// Set if we used free entry or predefined product
 		$predef = '';
-		$product_desc = (GETPOST('dp_desc') ?GETPOST('dp_desc') : '');
+		$product_desc = (GETPOST('dp_desc', 'none') ?GETPOST('dp_desc', 'none') : '');
 		$price_ht = GETPOST('price_ht');
 		$price_ht_devise = GETPOST('multicurrency_price_ht');
 		$prod_entry_mode = GETPOST('prod_entry_mode');


### PR DESCRIPTION
La description d'un produit/service libre (HTML) est formatée en texte simple, lorsqu'on ajoute une nouvelle ligne d'un devis.
