### PR TITLE
NEW: additional html tags allowed by dol_string_onlythesehtmltags()

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5694,8 +5694,7 @@ function dol_string_onlythesehtmltags($stringtoclean, $cleanalsosomestyles = 1)
 {
 	$allowed_tags = array(
 		"html", "head", "meta", "body", "article", "a", "abbr", "b", "blockquote", "br", "cite", "div", "dl", "dd", "dt", "em", "font", "img", "ins", "hr", "i", "li", "link",
-		"ol", "p", "q", "s", "section", "span", "strike", "strong", "title",
-		"table", "tr", "th", "td", "u", "ul"
+		"ol", "p", "q", "s", "section", "span", "strike", "strong", "title", "table", "tr", "th", "td", "u", "ul", "sup", "sub", "blockquote", "pre", "h1", "h2", "h3", "h4", "h5", "h6"
 	);
 	$allowed_tags_string = join("><", $allowed_tags);
 	$allowed_tags_string = preg_replace('/^>/', '', $allowed_tags_string);


### PR DESCRIPTION
# Issue
Currently, some tags like `<sup>` and `<sub>` are removed by this function, although they don't appear to be harmful.
Same goes for `<blockquote>`, `<pre>`, and maybe some others.

Titles (`<h1>` through `<h6>`) are arguably more sensitive, but I still don't see why they should not be included either.

## Use case
Typically, we should be able to filter text returned by the WYSIWYG editor and (for a typical, non-malignant user), it should be left unaltered by `dol_string_onlythesehtmltags()`. As it stands, superscript (for example, footnotes<sup>1</sup>) and subscript (for instance gas names like O<sub>2</sub>) would be flattened out. I am sure they are not more dangerous than others already included.

I am a little less confident about titles ; if you want them removed from this PR I’ll be happy to oblige.