### PR TITLE
FIX 11.0: DebugBar hides content at page bottom

### DIFF
--- a/htdocs/includes/DebugBar/Resources/debugbar.js
+++ b/htdocs/includes/DebugBar/Resources/debugbar.js
@@ -409,12 +409,11 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
         className: "phpdebugbar " + csscls('minimized'),
 
-        options: {
-            bodyMarginBottom: true,
-            bodyMarginBottomHeight: parseInt($('body').css('margin-bottom'))
-        },
-
         initialize: function() {
+            this.options = {
+                bodyMarginBottom: true,
+                bodyMarginBottomHeight: parseInt($('body').css('margin-bottom')),
+            };
             this.controls = {};
             this.dataMap = {};
             this.datasets = {};


### PR DESCRIPTION
# Rationale
When the DebugBar is displayed, you can't scroll down enough to see the bottommost elements of the page.

DebugBar has a built-in mechanism for that, but it is broken because body bottom margin calculation occurs before `<body>` has loaded (and thus returns `NaN`).

# This PR
This PR proposes that we set the options (including `bodyMarginBottomHeight`) inside the `initialize()` metod (instead of during the prototype's creation).

Since I am not familiar with the inner workings of DebugBar, there may be a better option, but I’ve tested this one and it does the job.

BTW, DebugBar is a fantastic tool :-)