### PR TITLE
FIX product label and desc were never updated when modifying trans

### DIFF
--- a/htdocs/product/traduction.php
+++ b/htdocs/product/traduction.php
@@ -78,6 +78,7 @@ $cancel != $langs->trans("Cancel") &&
 		$object->label			= $_POST["libelle"];
 		$object->description	= dol_htmlcleanlastbr($_POST["desc"]);
 		$object->other			= dol_htmlcleanlastbr($_POST["other"]);
+		$object->update($object->id, $user);
 	}
 	else
 	{


### PR DESCRIPTION
# FIX product label and desc were never updated when modifying trans in multilang 

In database, label, and desc were never modified. In pdf, when we generate doc in same lang as default lang, we dont translate, and we use product/line element, so sometimes we have wrong labels in pdf
