### PR TITLE
Fix: User can see events that are not assigned to it

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -564,7 +564,7 @@ function checkUserAccessToObject($user, $featuresarray, $objectid = 0, $tableand
 					require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 					$action = new ActionComm($db);
 					$action->fetch($objectid);
-					if ($action->authorid != $user->id && $action->userownerid != $user->id && !(array_key_exists($user->id,$action->userassigned))) {
+					if ($action->authorid != $user->id && $action->userownerid != $user->id && !(array_key_exists($user->id, $action->userassigned))) {
 						return false;
 					}
 				}

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -248,25 +248,6 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 		{
 			if (! $user->rights->projet->lire && ! $user->rights->projet->all->lire) { $readok=0; $nbko++; }
 		}
-		elseif ($feature == 'agenda')
-		{
-			if ($objectid > 0) {
-				require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
-				$action = new ActionComm($db);
-				$action->fetch($objectid);
-				if (empty($user->rights->agenda->allactions->read) && (($action->authorid != $user->id && $action->userownerid != $user->id && !(array_key_exists($user->id,
-								$action->userassigned))) || empty($user->rights->agenda->myactions->read))) {
-					$readok = 0;
-					$nbko++;
-				}
-			}
-			else{
-				if (empty($user->rights->agenda->myactions->read) && empty($user->rights->agenda->allactions->read)) {
-					$readok = 0;
-					$nbko++;
-				}
-			}
-		}
 		elseif (! empty($feature2))														// This is for permissions on 2 levels
 		{
 			$tmpreadok=1;

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -266,7 +266,6 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 					$nbko++;
 				}
 			}
-
 		}
 		elseif (! empty($feature2))														// This is for permissions on 2 levels
 		{

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -576,6 +576,18 @@ function checkUserAccessToObject($user, $featuresarray, $objectid = 0, $tableand
 				$sql.= " WHERE dbt.".$dbt_select." IN (".$objectid.")";
 				$sql.= " AND dbt.entity IN (".getEntity($sharedelement, 1).")";
 			}
+
+			if ($feature == 'agenda')// Also check myactions rights
+			{
+				if ($objectid > 0 && empty($user->rights->agenda->allactions->read)) {
+					require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
+					$action = new ActionComm($db);
+					$action->fetch($objectid);
+					if ($action->authorid != $user->id && $action->userownerid != $user->id && !(array_key_exists($user->id,$action->userassigned))) {
+						return false;
+					}
+				}
+			}
 		}
 		elseif (in_array($feature, $checkproject))
 		{

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2008-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2008-2017 Regis Houssin        <regis.houssin@inodbox.com>
+ * Copyright (C) 2020	   Ferran Marcet        <fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -246,6 +247,26 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 		elseif ($feature == 'projet')
 		{
 			if (! $user->rights->projet->lire && ! $user->rights->projet->all->lire) { $readok=0; $nbko++; }
+		}
+		elseif ($feature == 'agenda')
+		{
+			if ($objectid > 0) {
+				require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
+				$action = new ActionComm($db);
+				$action->fetch($objectid);
+				if (empty($user->rights->agenda->allactions->read) && (($action->authorid != $user->id && $action->userownerid != $user->id && !(array_key_exists($user->id,
+								$action->userassigned))) || empty($user->rights->agenda->myactions->read))) {
+					$readok = 0;
+					$nbko++;
+				}
+			}
+			else{
+				if (empty($user->rights->agenda->myactions->read) && empty($user->rights->agenda->allactions->read)) {
+					$readok = 0;
+					$nbko++;
+				}
+			}
+
 		}
 		elseif (! empty($feature2))														// This is for permissions on 2 levels
 		{


### PR DESCRIPTION
A user can see events that are not assigned if he accesses directly through the url. The function only checks that the user has permission to view their events, but not if the user is assigned to that event.