### PR TITLE
FIX - hide Dolibarr version number in main banner on features level 0

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1693,7 +1693,7 @@ function top_menu($head, $title = '', $target = '', $disablejs = 0, $disablehead
 			}
 		}
 
-		$text = '<span href="#" class="aversion"><span class="hideonsmartphone small">'.DOL_VERSION.'</span></span>';
+		if ($conf->global->MAIN_FEATURES_LEVEL > 0) $text = '<span href="#" class="aversion"><span class="hideonsmartphone small">'.DOL_VERSION.'</span></span>';
 		$toprightmenu .= @Form::textwithtooltip('', $appli, 2, 1, $text, 'login_block_elem', 2);
 
 


### PR DESCRIPTION
The version number is available in the User dropdown; while it is useful to have it constantly visible for debugging, it is not necessary in typical production environments and it breaks the color pattern of the banner.