### PR TITLE
FIX 12.0 - dol_string_onlythesehtmltags(): remove class attribute by default

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5685,12 +5685,13 @@ function dol_string_nohtmltag($stringtoclean, $removelinefeed = 1, $pagecodeto =
  *	Clean a string to keep only desirable HTML tags.
  *
  *	@param	string	$stringtoclean			String to clean
- *  @param	string	$cleanalsosomestyles	Clean also some tags
+ *  @param	boolean	$cleanalsosomestyles	Remove absolute/fixed positioning from inline styles
+ *  @param	boolean	$removeclassattribute	Remove the class attribute from tags
  *	@return string	    					String cleaned
  *
  * 	@see	dol_escape_htmltag() strip_tags() dol_string_nohtmltag() dol_string_neverthesehtmltags()
  */
-function dol_string_onlythesehtmltags($stringtoclean, $cleanalsosomestyles = 1)
+function dol_string_onlythesehtmltags($stringtoclean, $cleanalsosomestyles = 1, $removeclassattribute = 1)
 {
 	$allowed_tags = array(
 		"html", "head", "meta", "body", "article", "a", "abbr", "b", "blockquote", "br", "cite", "div", "dl", "dd", "dt", "em", "font", "img", "ins", "hr", "i", "li", "link",
@@ -5702,7 +5703,10 @@ function dol_string_onlythesehtmltags($stringtoclean, $cleanalsosomestyles = 1)
 	$allowed_tags_string = '<'.$allowed_tags_string.'>';
 
 	if ($cleanalsosomestyles) {
-		$stringtoclean = preg_replace('/position\s*:\s*(absolute|fixed)\s*!\s*important/', '', $stringtoclean); // Note: If hacker try to introduce css comment into string to bypass this regex, the string must also be encoded by the dol_htmlentitiesbr during output so it become harmless
+		$stringtoclean = preg_replace('/position\s*:\s*(absolute|fixed)\s*!\s*important/i', '', $stringtoclean); // Note: If hacker try to introduce css comment into string to bypass this regex, the string must also be encoded by the dol_htmlentitiesbr during output so it become harmless
+	}
+	if ($removeclassattribute) {
+		$stringtoclean = preg_replace('/(<[^>]+)\s+class=((["\']).*?\\3|\\w*)/i', '\\1', $stringtoclean);
 	}
 
 	$temp = strip_tags($stringtoclean, $allowed_tags_string);


### PR DESCRIPTION
## Rationale
When this new parameter is enabled, the HTML elements will be stripped of their class attribute, which could be misused.

It tries not to remove `class=xyz` if it is outside a tag's attribute. It is not 100% bullet-proof (this is only a regex, not a true XML parser).

Example:
```HTML
<!-- before -->
<a class="ext-link" style="font-size: 9pt" href="https://url.tld/rep/index.html?id=12&class=compact">example</a>

<!-- after calling dol_string_onlythesehtmltags() with $removeclassattribute set to true -->
<a style="font-size: 9pt" href="https://url.tld/rep/index.html?id=12&class=compact">example</a>
```

## Concerns
I am not sure about the default value for `$removeclassattribute`. I set it to `1` (more secure in itself) but I am concerned that it might incentivize module developers to call GETPOST with no check.