### PR TITLE
 fix: restore autofill lost functionality on expeditions

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1042,6 +1042,7 @@ if ($action == 'create')
     	    while ($i < $numAsked)
     	    {
     	    	print 'jQuery("#qtyl'.$i.'").val(jQuery("#qtyasked'.$i.'").val() - jQuery("#qtydelivered'.$i.'").val());'."\n";
+                if (!empty($conf->productbatch->enabled)) print 'jQuery("#qtyl'.$i.'_'.$i.'").val(jQuery("#qtyasked'.$i.'").val() - jQuery("#qtydelivered'.$i.'").val());'."\n";
     	    	$i++;
     	    }
         	print '});
@@ -1050,6 +1051,7 @@ if ($action == 'create')
     	    while ($i < $numAsked)
     	    {
     	    	print 'jQuery("#qtyl'.$i.'").val(0);'."\n";
+                if (!empty($conf->productbatch->enabled)) print 'jQuery("#qtyl'.$i.'_'.$i.'").val(0);'."\n";
     	    	$i++;
     	    }
         	print '});
@@ -1070,11 +1072,8 @@ if ($action == 'create')
                 print '<td class="center">'.$langs->trans("QtyOrdered").'</td>';
                 print '<td class="center">'.$langs->trans("QtyShipped").'</td>';
                 print '<td class="center">'.$langs->trans("QtyToShip");
-				if (empty($conf->productbatch->enabled))
-				{
-	                print ' <br>(<a href="#" id="autofill">'.$langs->trans("Fill").'</a>';
-	                print ' / <a href="#" id="autoreset">'.$langs->trans("Reset").'</a>)';
-				}
+                print ' <br>(<a href="#" id="autofill">'.$langs->trans("Fill").'</a>';
+                print ' / <a href="#" id="autoreset">'.$langs->trans("Reset").'</a>)';
                 print '</td>';
                 if (!empty($conf->stock->enabled))
                 {

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1072,8 +1072,14 @@ if ($action == 'create')
                 print '<td class="center">'.$langs->trans("QtyOrdered").'</td>';
                 print '<td class="center">'.$langs->trans("QtyShipped").'</td>';
                 print '<td class="center">'.$langs->trans("QtyToShip");
-                print ' <br>(<a href="#" id="autofill">'.$langs->trans("Fill").'</a>';
-                print ' / <a href="#" id="autoreset">'.$langs->trans("Reset").'</a>)';
+				if (empty($conf->productbatch->enabled))
+				{
+	                print '<br><a href="#" id="autofill">'.$langs->trans("Fill").'</a>';	
+	                print ' / ';	
+				} else {
+					print '<br>';
+				}
+				print '<a href="#" id="autoreset">'.$langs->trans("Reset").'</a>';
                 print '</td>';
                 if (!empty($conf->stock->enabled))
                 {


### PR DESCRIPTION
Restore autofill on expeditions lost functionality even if batch module is enabled.
A more complete solution may be given, but this solution is yet better than to deactivate autofill when dispatch module is disabled.
