### PR TITLE
Fixed translation of product units in documents

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -927,6 +927,7 @@ class BOM extends CommonObject
 		global $conf, $langs;
 
 		$langs->load("mrp");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
 			$modele = 'standard';

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -3662,6 +3662,7 @@ class Propal extends CommonObject
 		global $conf, $langs;
 
 		$langs->load("propale");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
 			$modele = 'azur';

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3859,6 +3859,7 @@ class Commande extends CommonOrder
 		global $conf, $langs;
 
 		$langs->load("orders");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
 			$modele = 'einstein';

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4296,6 +4296,7 @@ class Facture extends CommonInvoice
 		global $conf, $langs;
 
 		$langs->load("bills");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele))
 		{

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -2393,6 +2393,7 @@ class Contrat extends CommonObject
 		global $conf, $langs;
 
 		$langs->load("contracts");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
 			$modele = 'strato';

--- a/htdocs/core/class/commonobjectline.class.php
+++ b/htdocs/core/class/commonobjectline.class.php
@@ -74,12 +74,12 @@ abstract class CommonObjectLine extends CommonObject
 			$label_type = 'short_label';
 		}
 
-		$sql = 'select '.$label_type.' from '.MAIN_DB_PREFIX.'c_units where rowid='.$this->fk_unit;
+		$sql = 'select '.$label_type.',code from '.MAIN_DB_PREFIX.'c_units where rowid='.$this->fk_unit;
 		$resql = $this->db->query($sql);
 		if ($resql && $this->db->num_rows($resql) > 0)
 		{
 			$res = $this->db->fetch_array($resql);
-			$label = $res[$label_type];
+			$label = ($label_type == 'short' ? $res[$label_type] : 'unit'.$res['code']);
 			$this->db->free($resql);
 			return $label;
 		} else {

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2462,6 +2462,7 @@ class Expedition extends CommonObject
 		global $conf, $langs;
 
 		$langs->load("sendings");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
 			$modele = 'rouget';

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2959,6 +2959,7 @@ class CommandeFournisseur extends CommonOrder
 		global $conf, $langs;
 
 		$langs->load("suppliers");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
 			$modele = 'muscadet';

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2637,6 +2637,7 @@ class FactureFournisseur extends CommonInvoice
 		global $conf, $user, $langs;
 
 		$langs->load("suppliers");
+		$outputlangs->load("products");
 
 		// Set the model on the model name to use
 		if (empty($modele))

--- a/htdocs/livraison/class/livraison.class.php
+++ b/htdocs/livraison/class/livraison.class.php
@@ -1035,6 +1035,7 @@ class Livraison extends CommonObject
 		global $conf, $user, $langs;
 
 		$langs->load("deliveries");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
 			$modele = 'typhon';

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4426,6 +4426,7 @@ class Product extends CommonObject
         global $conf, $user, $langs;
 
         $langs->load("products");
+		$outputlangs->load("products");
 
         // Positionne le modele sur le nom du modele a utiliser
         if (!dol_strlen($modele)) {

--- a/htdocs/product/stock/class/entrepot.class.php
+++ b/htdocs/product/stock/class/entrepot.class.php
@@ -856,6 +856,7 @@ class Entrepot extends CommonObject
 		global $conf, $user, $langs;
 
 		$langs->load("stocks");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
 			$modele = 'standard';

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -1167,6 +1167,7 @@ class MouvementStock extends CommonObject
 		global $conf, $user, $langs;
 
 		$langs->load("stocks");
+		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
 			$modele = 'stdmovement';

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -2630,6 +2630,7 @@ class SupplierProposal extends CommonObject
         global $conf, $langs;
 
         $langs->load("supplier_proposal");
+		$outputlangs->load("products");
 
         if (!dol_strlen($modele)) {
             $modele = 'aurore';


### PR DESCRIPTION
- Fixed the translation of product units in odt documents
- Fixed the product unit translation key in `commonobjectline` for consistency with #13866