### PR TITLE
FIX: TakePOS is not loading some specific customer taxes

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -348,6 +348,7 @@ if ($action == "addline")
 		}
 	}
 	if ($idoflineadded <= 0) {
+		$invoice->fetch_thirdparty();
 		$idoflineadded = $invoice->addline($prod->description, $price, 1, $tva_tx, $localtax1_tx, $localtax2_tx, $idproduct, $customer->remise_percent, '', 0, 0, 0, '', $price_base_type, $price_ttc, $prod->type, -1, 0, '', 0, $parent_line, null, '', '', 0, 100, '', null, 0);
 	}
 


### PR DESCRIPTION
TakePOS is not adding some taxes.
For example in Spain, the RE (Recargo de equivalencia), a very unusual tax in the point of sale.
To solve the problem we need add the line in this commit, if not in facture.class.php line 3037 the following instruction does not load some specific customer taxes:
`$localtaxes_type = getLocalTaxesFromRate($txtva, 0, $this->thirdparty, $mysoc);`


