### PR TITLE
New function count_all_categories

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -2011,27 +2011,24 @@ class Categorie extends CommonObject
 		}
 	}
 
-	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *      Count all categories
 	 *
 	 *      @return int                             Number of categories, -1 on error
 	 */
-	public function count_all_categories()
+	public function countNbOfCategories()
 	{
 		dol_syslog(get_class($this)."::count_all_categories", LOG_DEBUG);
-			$sql = "SELECT COUNT(rowid) FROM ".MAIN_DB_PREFIX."categorie";
-			$sql .= " WHERE entity IN (".getEntity('category').")";
+		$sql = "SELECT COUNT(rowid) FROM ".MAIN_DB_PREFIX."categorie";
+		$sql .= " WHERE entity IN (".getEntity('category').")";
 
-			$res = $this->db->query($sql);
-		if ($res)
-			{
+		$res = $this->db->query($sql);
+		if ($res) {
 			$obj = $this->db->fetch_object($res);
-				return $obj->count;
-		}
-		else {
-				dol_print_error($this->db);
-				return -1;
+			return $obj->count;
+		} else {
+			dol_print_error($this->db);
+			return -1;
 		}
 	}
 }

--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -2010,4 +2010,29 @@ class Categorie extends CommonObject
 			return "";
 		}
 	}
+	
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *      Count all categories
+	 *
+	 *      @return int                             Number of categories, -1 on error
+	 */
+	public function count_all_categories()
+	{
+	dol_syslog(get_class($this)."::count_all_categories", LOG_DEBUG);
+			$sql = "SELECT COUNT(rowid) FROM ".MAIN_DB_PREFIX."categorie";
+			$sql .= " WHERE entity IN (".getEntity('category').")";
+
+			$res = $this->db->query($sql);
+			if ($res)
+			{
+		$obj = $this->db->fetch_object($res);
+					return $obj->count;
+			}
+			else
+			{
+					dol_print_error($this->db);
+					return -1;
+			}
+	}
 }

--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -2010,7 +2010,7 @@ class Categorie extends CommonObject
 			return "";
 		}
 	}
-	
+
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *      Count all categories
@@ -2019,20 +2019,19 @@ class Categorie extends CommonObject
 	 */
 	public function count_all_categories()
 	{
-	dol_syslog(get_class($this)."::count_all_categories", LOG_DEBUG);
+		dol_syslog(get_class($this)."::count_all_categories", LOG_DEBUG);
 			$sql = "SELECT COUNT(rowid) FROM ".MAIN_DB_PREFIX."categorie";
 			$sql .= " WHERE entity IN (".getEntity('category').")";
 
 			$res = $this->db->query($sql);
-			if ($res)
+		if ($res)
 			{
-		$obj = $this->db->fetch_object($res);
-					return $obj->count;
-			}
-			else
-			{
-					dol_print_error($this->db);
-					return -1;
-			}
+			$obj = $this->db->fetch_object($res);
+				return $obj->count;
+		}
+		else {
+				dol_print_error($this->db);
+				return -1;
+		}
 	}
 }


### PR DESCRIPTION
This is useful to count the total number of categories e.g. to decide whether to load the full tree or not. It might make most sense to wait with merging until there is code in viewcat.php or index.php using it.