### PR TITLE
Avoid empty sales and orders when all lines are removed.

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -398,6 +398,7 @@ if ($action == "deleteline") {
         $invoice->deleteline($deletelineid);
         $invoice->fetch($placeid);
     }
+	if (count($invoice->lines)==0) $invoice->delete($user);
 }
 
 if ($action == "delete") {


### PR DESCRIPTION
When all lines are deleted in a sale or order the sale remains I think it is better delete the sale. If it is not deleted and a sale is made on the same place within a few days, the old date remains. Also, if concurrent sales are created, it cannot be deleted until a sale is made with the old date and time.