### PR TITLE
fix sql error duplicate entry key on admin/boxes

### DIFF
--- a/htdocs/admin/boxes.php
+++ b/htdocs/admin/boxes.php
@@ -112,20 +112,35 @@ if ($action == 'add') {
                         }
                         else dol_print_error($db);
 
-                        $sql = "INSERT IGNORE INTO ".MAIN_DB_PREFIX."boxes (";
-                        $sql.= "box_id, position, box_order, fk_user, entity";
-                        $sql.= ") values (";
-                        $sql.= $boxid['value'].", ".$pos.", '".(($nbboxonleft > $nbboxonright) ? 'B01' : 'A01')."', ".$fk_user.", ".$conf->entity;
-                        $sql.= ")";
+						$sql = "SELECT COUNT(rowid) as nb FROM ".MAIN_DB_PREFIX."boxes";
+						$sql.= " WHERE box_id = ".$boxid['value'];
+						$sql.= " AND position = ".$pos;
+						$sql.= " AND fk_user = ".$fk_user;
+						$sql.= " AND entity = ".$conf->entity;
+						$resql = $db->query($sql);
+						if ($resql)
+						{
+							$obj = $db->fetch_object($resql);
+							if (empty($obj->nb))
+							{
+								$sql = "INSERT INTO ".MAIN_DB_PREFIX."boxes (";
+								$sql.= "box_id, position, box_order, fk_user, entity";
+								$sql.= ") values (";
+								$sql.= $boxid['value'].", ".$pos.", '".(($nbboxonleft > $nbboxonright) ? 'B01' : 'A01')."', ".$fk_user.", ".$conf->entity;
+								$sql.= ")";
 
-                        dol_syslog("boxes.php activate box", LOG_DEBUG);
-                        $resql = $db->query($sql);
-                        if (! $resql)
-                        {
-                            setEventMessages($db->lasterror(), null, 'errors');
-                            $error++;
-                        }
-                    }
+								dol_syslog("boxes.php activate box", LOG_DEBUG);
+								$resql = $db->query($sql);
+								if (! $resql)
+								{
+									setEventMessages($db->lasterror(), null, 'errors');
+									$error++;
+								}
+
+							}
+						}
+
+					}
                 }
             }
         }

--- a/htdocs/admin/boxes.php
+++ b/htdocs/admin/boxes.php
@@ -112,7 +112,7 @@ if ($action == 'add') {
                         }
                         else dol_print_error($db);
 
-                        $sql = "INSERT INTO ".MAIN_DB_PREFIX."boxes (";
+                        $sql = "INSERT IGNORE INTO ".MAIN_DB_PREFIX."boxes (";
                         $sql.= "box_id, position, box_order, fk_user, entity";
                         $sql.= ") values (";
                         $sql.= $boxid['value'].", ".$pos.", '".(($nbboxonleft > $nbboxonright) ? 'B01' : 'A01')."', ".$fk_user.", ".$conf->entity;

--- a/htdocs/admin/boxes.php
+++ b/htdocs/admin/boxes.php
@@ -136,10 +136,8 @@ if ($action == 'add') {
 									setEventMessages($db->lasterror(), null, 'errors');
 									$error++;
 								}
-
 							}
 						}
-
 					}
                 }
             }


### PR DESCRIPTION
# Fix duplicate entry error on boxe add
The user want to add boxes in home page from the admin/boxes.php screen.
If one user already had one of the added boxes it results with a duplicate entry error the prevent from adding the boxe.

Adding "IGNORE" to the insert request skip the insertion for already existing entries
