### PR TITLE
FIX param entity in html form file

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -352,7 +352,9 @@ class FormFile
 
 		// Add entity in $param if not already exists
 		if (!preg_match('/entity\=[0-9]+/', $param)) {
-			$param.= 'entity='.(!empty($object->entity)?$object->entity:$conf->entity);
+			$paramEntity = 'entity='.(!empty($object->entity)?$object->entity:$conf->entity);
+			if (!empty($param))	$paramEntity = '&' .$paramEntity;
+			$param .= $paramEntity;
 		}
 
 		$printer=0;


### PR DESCRIPTION
FIX param entity in html form file
- the character "&" is missing before entity parameter in url (if entity parameter is not set before)
- you can have this problem in lists after generating files in mass action