### PR TITLE
FIX : infinite fetch object linked loop

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2132,7 +2132,7 @@ function pdf_getLinkedObjects($object,$outputlangs)
 						include_once DOL_DOCUMENT_ROOT.'/commande/commande.class.php';
 						$order = new Commande($object->db);
 						$ret = $order->fetch(reset($elementobject->linkedObjectsIds['commande']));
-						if ($ret < 1){ $order=null; }
+						if ($ret < 1) { $order=null; }
 					}
 			    }
 			    if (! is_object($order))

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2127,8 +2127,13 @@ function pdf_getLinkedObjects($object,$outputlangs)
 			    // We concat this record info into fields xxx_value. title is overwrote.
 			    if (empty($object->linkedObjects['commande']) && $object->element != 'commande')	// There is not already a link to order and object is not the order, so we show also info with order
 			    {
-			        $elementobject->fetchObjectLinked();
-			        if (! empty($elementobject->linkedObjects['commande'])) $order = reset($elementobject->linkedObjects['commande']);
+			        $elementobject->fetchObjectLinked(null, '', null, '', 'OR', 1, 'sourcetype', 0);
+			        if (! empty($elementobject->linkedObjectsIds['commande'])){
+						dol_include_once('/commande/commande.class.php');
+						$order = new Commande($object->db);
+						$ret = $order->fetch(reset($elementobject->linkedObjectsIds['commande']));
+						if ($ret < 1){ $order=null; }
+					}
 			    }
 			    if (! is_object($order))
 			    {

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2129,7 +2129,7 @@ function pdf_getLinkedObjects($object,$outputlangs)
 			    {
 			        $elementobject->fetchObjectLinked(null, '', null, '', 'OR', 1, 'sourcetype', 0);
 			        if (! empty($elementobject->linkedObjectsIds['commande'])){
-						dol_include_once('/commande/commande.class.php');
+						include_once DOL_DOCUMENT_ROOT.'/commande/commande.class.php';
 						$order = new Commande($object->db);
 						$ret = $order->fetch(reset($elementobject->linkedObjectsIds['commande']));
 						if ($ret < 1){ $order=null; }

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2071,7 +2071,7 @@ function pdf_getTotalQty($object,$type,$outputlangs)
  */
 function pdf_getLinkedObjects($object,$outputlangs)
 {
-	global $hookmanager;
+	global $db, $hookmanager;
 
 	$linkedobjects=array();
 
@@ -2130,7 +2130,7 @@ function pdf_getLinkedObjects($object,$outputlangs)
 			        $elementobject->fetchObjectLinked(null, '', null, '', 'OR', 1, 'sourcetype', 0);
 			        if (! empty($elementobject->linkedObjectsIds['commande'])){
 						include_once DOL_DOCUMENT_ROOT.'/commande/commande.class.php';
-						$order = new Commande($object->db);
+						$order = new Commande($db);
 						$ret = $order->fetch(reset($elementobject->linkedObjectsIds['commande']));
 						if ($ret < 1) { $order=null; }
 					}


### PR DESCRIPTION
# Fix infinite fetch object linked loop
On generating an invoice with a lot a shipments linked, but no order, it create an very long loop.

it's because param $loadalsoobjects of fetchObjectLinked is true so it load object linked be fetching them... so fetching linked object... etc...

with this patch, in my case generate PDF time fall down from more than 2 mins (memory exceed 512Mo and time execution exceed 120sec ) to 3sec