### PR TITLE
Passing $totalarray as parameter to printFieldListFooter Hook's

### DIFF
--- a/htdocs/expedition/list.php
+++ b/htdocs/expedition/list.php
@@ -800,7 +800,7 @@ if ($resql)
 	}
 	$db->free($resql);
 
-	$parameters = array('arrayfields'=>$arrayfields, 'sql'=>$sql);
+	$parameters = array('arrayfields'=>$arrayfields, 'totalarray' => $totalarray, 'sql'=>$sql);
 	$reshook = $hookmanager->executeHooks('printFieldListFooter', $parameters); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 


### PR DESCRIPTION
#New [*Pass $totalarray as hook's parameter to Expeditions List*]
[*Long description*]
Sometimes, we need $totalarray to know 'nbfield' or to display some vars in the footer of list.