### PR TITLE
fix php warning : count parameters must be countable

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -1124,7 +1124,7 @@ if ($resql)
 		if (!empty($arrayfields['typent.code']['checked']))
 		{
 			print '<td class="center">';
-			if (count($typenArray) == 0) $typenArray = $formcompany->typent_array(1);
+			if (empty($typenArray)) $typenArray = $formcompany->typent_array(1);
 			print $typenArray[$obj->typent_code];
 			print '</td>';
 			if (!$i) $totalarray['nbfield']++;


### PR DESCRIPTION
fix php warning : count parameters must be countable