### PR TITLE
Better stats and search in adherent module

### DIFF
--- a/htdocs/adherents/class/adherentstats.class.php
+++ b/htdocs/adherents/class/adherentstats.class.php
@@ -180,7 +180,7 @@ class AdherentStats extends Stats
 		$sql .= " WHERE ".$this->where;
 		$sql .= " GROUP BY year";
         $sql .= $this->db->order('year', 'DESC');
-		
+
 		return $this->_getAllByYear($sql);
 	}
 }

--- a/htdocs/adherents/class/adherentstats.class.php
+++ b/htdocs/adherents/class/adherentstats.class.php
@@ -180,7 +180,7 @@ class AdherentStats extends Stats
 		$sql .= " WHERE ".$this->where;
 		$sql .= " GROUP BY year";
         $sql .= $this->db->order('year', 'DESC');
-
-	  return $this->_getAllByYear($sql);
+		
+		return $this->_getAllByYear($sql);
 	}
 }

--- a/htdocs/adherents/class/adherentstats.class.php
+++ b/htdocs/adherents/class/adherentstats.class.php
@@ -172,13 +172,15 @@ class AdherentStats extends Stats
 	{
 		global $user;
 
-		$sql = "SELECT date_format(p.dateadh,'%Y') as year, count(*) as nb, sum(".$this->field.") as total, avg(".$this->field.") as avg";
+		$sql = "SELECT date_format(p.dateadh,'%Y') as year, date_format(p.dateadh,'%M') as month";
+        $sql .= ", sum(case when m.statut = 1 then 1 else 0 end) as valid, sum(case when m.statut = 0 then 1 else 0 end) as resiliated, count(*) as nb";
+        $sql .= ", sum(".$this->field.") as total, avg(".$this->field.") as avg";
 		$sql .= " FROM ".$this->from;
 		//if (!$user->rights->societe->client->voir && !$this->socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 		$sql .= " WHERE ".$this->where;
 		$sql .= " GROUP BY year";
         $sql .= $this->db->order('year', 'DESC');
 
-		return $this->_getAllByYear($sql);
+	  return $this->_getAllByYear($sql);
 	}
 }

--- a/htdocs/adherents/class/adherentstats.class.php
+++ b/htdocs/adherents/class/adherentstats.class.php
@@ -68,8 +68,7 @@ class AdherentStats extends Stats
 
 		$this->field = 'subscription';
 
-		$this->where .= " m.statut != 0";
-		$this->where .= " AND p.fk_adherent = m.rowid AND m.entity IN (".getEntity('adherent').")";
+		$this->where .= " p.fk_adherent = m.rowid AND m.entity IN (".getEntity('adherent').")";
 		//if (!$user->rights->societe->client->voir && !$user->socid) $this->where .= " AND p.fk_soc = sc.fk_soc AND sc.fk_user = " .$user->id;
 		if ($this->memberid) {
 			$this->where .= " AND m.rowid = ".$this->memberid;

--- a/htdocs/adherents/class/adherentstats.class.php
+++ b/htdocs/adherents/class/adherentstats.class.php
@@ -68,7 +68,8 @@ class AdherentStats extends Stats
 
 		$this->field = 'subscription';
 
-		$this->where .= " p.fk_adherent = m.rowid AND m.entity IN (".getEntity('adherent').")";
+		$this->where .= " m.statut != -1";
+		$this->where .= " AND p.fk_adherent = m.rowid AND m.entity IN (".getEntity('adherent').")";
 		//if (!$user->rights->societe->client->voir && !$user->socid) $this->where .= " AND p.fk_soc = sc.fk_soc AND sc.fk_user = " .$user->id;
 		if ($this->memberid) {
 			$this->where .= " AND m.rowid = ".$this->memberid;

--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -544,7 +544,9 @@ if (!empty($arrayfields['d.email']['checked'])) {
 	print '<td class="liste_titre left">';
 	print '<input class="flat maxwidth75imp" type="text" name="search_email" value="'.$search_email.'"></td>';
 }
-
+// Filter UptoDate
+print '<input type="hidden" name="filter" value="'.$filter.'">';
+// Date end membership
 if (!empty($arrayfields['d.datefin']['checked'])) {
 	print '<td class="liste_titre left">';
 	print '</td>';

--- a/htdocs/adherents/stats/byproperties.php
+++ b/htdocs/adherents/stats/byproperties.php
@@ -68,7 +68,8 @@ $sql .= "SELECT COUNT(DISTINCT d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX
 $sql .= " FROM ".MAIN_DB_PREFIX."adherent as d";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
 $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-$sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
+$sql .= " AND ( ( d.statut = 1 AND s.datef = NULL )";
+$sql .= " OR ( '".dol_print_date(dol_now(), '%Y%m%d%H%M%S')."' BETWEEN s.dateadh AND s.datef ) )";
 $sql .= " GROUP BY d.morphy";
 
 $foundphy = $foundmor = 0;

--- a/htdocs/adherents/stats/byproperties.php
+++ b/htdocs/adherents/stats/byproperties.php
@@ -64,11 +64,11 @@ dol_mkdir($dir);
 $tab = 'byproperties';
 
 $data = array();
-$sql .= "SELECT COUNT(d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, d.morphy as code";
+$sql .= "SELECT COUNT(DISTINCT d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, d.morphy as code";
 $sql .= " FROM ".MAIN_DB_PREFIX."adherent as d";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
 $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-$sql .= " AND d.statut = 1";
+$sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
 $sql .= " GROUP BY d.morphy";
 
 $foundphy = $foundmor = 0;

--- a/htdocs/adherents/stats/geo.php
+++ b/htdocs/adherents/stats/geo.php
@@ -79,7 +79,8 @@ if ($mode) {
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as c on d.country = c.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
         $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-        $sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
+        $sql .= " AND ( ( d.statut = 1 AND s.datef = NULL )";
+        $sql .= " OR ( '".dol_print_date(dol_now(), '%Y%m%d%H%M%S')."' BETWEEN s.dateadh AND s.datef ) )";
         $sql .= " GROUP BY c.label, c.code";
         //print $sql;
     }
@@ -97,7 +98,8 @@ if ($mode) {
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as co on d.country = co.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
         $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-        $sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
+        $sql .= " AND ( ( d.statut = 1 AND s.datef = NULL )";
+        $sql .= " OR ( '".dol_print_date(dol_now(), '%Y%m%d%H%M%S')."' BETWEEN s.dateadh AND s.datef ) )";
         $sql .= " GROUP BY co.label, co.code, c.nom";
         //print $sql;
     }
@@ -114,7 +116,8 @@ if ($mode) {
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as co on d.country = co.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
         $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-        $sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
+        $sql .= " AND ( ( d.statut = 1 AND s.datef = NULL )";
+        $sql .= " OR ( '".dol_print_date(dol_now(), '%Y%m%d%H%M%S')."' BETWEEN s.dateadh AND s.datef ) )";
         $sql .= " GROUP BY co.label, co.code, r.nom"; //+
         //print $sql;
     }
@@ -129,7 +132,8 @@ if ($mode) {
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as c on d.country = c.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
         $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-        $sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
+        $sql .= " AND ( ( d.statut = 1 AND s.datef = NULL )";
+        $sql .= " OR ( '".dol_print_date(dol_now(), '%Y%m%d%H%M%S')."' BETWEEN s.dateadh AND s.datef ) )";
         $sql .= " GROUP BY c.label, c.code, d.town";
         //print $sql;
     }

--- a/htdocs/adherents/stats/geo.php
+++ b/htdocs/adherents/stats/geo.php
@@ -74,12 +74,12 @@ if ($mode) {
         $tab = 'statscountry';
 
         $data = array();
-        $sql .= "SELECT COUNT(d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, c.code, c.label";
+        $sql .= "SELECT COUNT(DISTINCT d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, c.code, c.label";
         $sql .= " FROM ".MAIN_DB_PREFIX."adherent as d";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as c on d.country = c.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
         $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-        $sql .= " AND d.statut = 1";
+        $sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
         $sql .= " GROUP BY c.label, c.code";
         //print $sql;
     }
@@ -90,14 +90,14 @@ if ($mode) {
         $tab = 'statsstate';
 
         $data = array();
-        $sql .= "SELECT COUNT(d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, co.code, co.label, c.nom as label2"; //
+        $sql .= "SELECT COUNT(DISTINCT d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, co.code, co.label, c.nom as label2"; //
         $sql .= " FROM ".MAIN_DB_PREFIX."adherent as d";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_departements as c on d.state_id = c.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_regions as r on c.fk_region = r.code_region";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as co on d.country = co.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
         $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-        $sql .= " AND d.statut = 1";
+        $sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
         $sql .= " GROUP BY co.label, co.code, c.nom";
         //print $sql;
     }
@@ -107,14 +107,14 @@ if ($mode) {
         $tab = 'statsregion'; //onglet
 
         $data = array(); //tableau de donnée
-        $sql .= "SELECT COUNT(d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, co.code, co.label, r.nom as label2";
+        $sql .= "SELECT COUNT(DISTINCT d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, co.code, co.label, r.nom as label2";
         $sql .= " FROM ".MAIN_DB_PREFIX."adherent as d";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_departements as c on d.state_id = c.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_regions as r on c.fk_region = r.code_region";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as co on d.country = co.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
         $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-        $sql .= " AND d.statut = 1";
+        $sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
         $sql .= " GROUP BY co.label, co.code, r.nom"; //+
         //print $sql;
     }
@@ -124,12 +124,12 @@ if ($mode) {
         $tab = 'statstown';
 
         $data = array();
-        $sql .= "SELECT COUNT(d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, c.code, c.label, d.town as label2";
+        $sql .= "SELECT COUNT(DISTINCT d.rowid) as nb, MAX(d.datevalid) as lastdate, MAX(s.dateadh) as lastsubscriptiondate, c.code, c.label, d.town as label2";
         $sql .= " FROM ".MAIN_DB_PREFIX."adherent as d";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as c on d.country = c.rowid";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."subscription as s ON s.fk_adherent = d.rowid";
         $sql .= " WHERE d.entity IN (".getEntity('adherent').")";
-        $sql .= " AND d.statut = 1";
+        $sql .= " AND CURDATE() BETWEEN s.dateadh AND s.datef";
         $sql .= " GROUP BY c.label, c.code, d.town";
         //print $sql;
     }

--- a/htdocs/adherents/stats/index.php
+++ b/htdocs/adherents/stats/index.php
@@ -158,13 +158,16 @@ print '<br><br>';
 
 // Show array
 $data = $stats->getAllByYear();
-
+//var_dump($data);
 
 print '<div class="div-table-responsive-no-min">';
 print '<table class="noborder">';
 print '<tr class="liste_titre" height="24">';
 print '<td class="center">'.$langs->trans("Year").'</td>';
+print '<td class="right">'.$langs->trans("MenuMembersValidated").'</td>';
+print '<td class="right">'.$langs->trans("MenuMembersResiliated").'</td>';
 print '<td class="right">'.$langs->trans("NbOfSubscriptions").'</td>';
+//print '<td class="right">'.$langs->trans("Total").'</td>';
 print '<td class="right">'.$langs->trans("AmountTotal").'</td>';
 print '<td class="right">'.$langs->trans("AmountAverage").'</td>';
 print '</tr>';
@@ -191,6 +194,8 @@ foreach ($data as $val) {
     print $year;
     //print '</a>';
     print '</td>';
+    print '<td class="right">'.$val['resiliated'].'</td>';
+    print '<td class="right">'.$val['valid'].'</td>';
     print '<td class="right">'.$val['nb'].'</td>';
     print '<td class="right">'.price(price2num($val['total'], 'MT'), 1).'</td>';
     print '<td class="right">'.price(price2num($val['avg'], 'MT'), 1).'</td>';

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -580,7 +580,7 @@ if ($rowid > 0) {
      * List of subscriptions
      */
     if ($action != 'addsubscription' && $action != 'create_thirdparty') {
-        $sql = "SELECT d.rowid, d.firstname, d.lastname, d.societe, c.fk_type as type,";
+        $sql = "SELECT d.rowid, d.firstname, d.lastname, d.societe, d.fk_adherent_type as type,";
         $sql .= " c.rowid as crowid, c.subscription,";
         $sql .= " c.datec, c.fk_type as cfk_type,";
         $sql .= " c.dateadh as dateh,";
@@ -628,11 +628,8 @@ if ($rowid > 0) {
                 $subscriptionstatic->ref = $objp->crowid;
                 $subscriptionstatic->id = $objp->crowid;
 
-                $typeid = ($objp->cfk_type > 0 ? $objp->cfk_type : $adh->typeid);
-                if ($typeid > 0) {
-                    $adht->fetch($typeid);
-                }
-
+                $typeid = $objp->cfk_type;
+                
                 print '<tr class="oddeven">';
                 print '<td>'.$subscriptionstatic->getNomUrl(1).'</td>';
                 print '<td class="center">'.dol_print_date($db->jdate($objp->datec), 'dayhour')."</td>\n";

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -580,7 +580,7 @@ if ($rowid > 0) {
      * List of subscriptions
      */
     if ($action != 'addsubscription' && $action != 'create_thirdparty') {
-        $sql = "SELECT d.rowid, d.firstname, d.lastname, d.societe, d.fk_adherent_type as type,";
+        $sql = "SELECT d.rowid, d.firstname, d.lastname, d.societe, c.fk_adherent_type as type,";
         $sql .= " c.rowid as crowid, c.subscription,";
         $sql .= " c.datec, c.fk_type as cfk_type,";
         $sql .= " c.dateadh as dateh,";

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -629,7 +629,7 @@ if ($rowid > 0) {
                 $subscriptionstatic->id = $objp->crowid;
 
                 $typeid = $objp->cfk_type;
-                
+
                 print '<tr class="oddeven">';
                 print '<td>'.$subscriptionstatic->getNomUrl(1).'</td>';
                 print '<td class="center">'.dol_print_date($db->jdate($objp->datec), 'dayhour')."</td>\n";

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -580,7 +580,7 @@ if ($rowid > 0) {
      * List of subscriptions
      */
     if ($action != 'addsubscription' && $action != 'create_thirdparty') {
-        $sql = "SELECT d.rowid, d.firstname, d.lastname, d.societe, c.fk_adherent_type as type,";
+        $sql = "SELECT d.rowid, d.firstname, d.lastname, d.societe, c.fk_type as type,";
         $sql .= " c.rowid as crowid, c.subscription,";
         $sql .= " c.datec, c.fk_type as cfk_type,";
         $sql .= " c.dateadh as dateh,";

--- a/htdocs/core/class/stats.class.php
+++ b/htdocs/core/class/stats.class.php
@@ -381,6 +381,8 @@ abstract class Stats
 			{
 				$row = $this->db->fetch_object($resql);
 				$result[$i]['year'] = $row->year;
+				$result[$i]['resiliated'] = $row->resiliated;
+				$result[$i]['valid'] = $row->valid;
 				$result[$i]['nb'] = $row->nb;
 				if ($i > 0 && $row->nb > 0) $result[$i - 1]['nb_diff'] = ($result[$i - 1]['nb'] - $row->nb) / $row->nb * 100;
 				$result[$i]['total'] = $row->total;


### PR DESCRIPTION
#Fix #13757 count too much entities or location and wrong history
Properties stats should count each adherent only once, not each subscription.
The status of the adherent isn't so important as the validation date. So it should be counted when, and only when, a subscription is up to date (paid). Historical stats should count each adherent who has subscribed in the past years even if the status of the adherent is retired.

#Fix BUG - Subscrition type may not be confirmed
Currently, the subscription view displays by default the adherent's current subscription type if no type has been registered in the past. If an update was made from an earlier version of Dolibarr (up to v10), the subscription type was not recorded in the tablellx_subscritipion. There is therefore nothing to display. This procedure is risky because it misleads the user into believing that the information is confirmed. In my opinion, it is better not to display anything as a type of subscription when the information does not exist. In certain circumstances, for legal and insurance matters, the history is particularly important. You should know if the adherents were covered several years back. If the information is missing on the platform, the user will know that he will have to retrieve this information otherwise, but if he sees information, he risks saying that it is true. It was far too risky.

#Fix Filter up/out-todate disappear when searching in adherent list
I just added an hidden field to keep the membership type (uptodate or outofdate) even in search mode. Particulary usefull when using tags/categories

