### PR TITLE
FIX set sales representatives on create company card

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -539,7 +539,7 @@ if (empty($reshook))
 
 					// Links with users
 					$salesreps = GETPOST('commercial', 'array');
-					$result = $object->setSalesRep($salesreps);
+					$result = $object->setSalesRep($salesreps, true);
 					if ($result < 0)
 					{
 						$error++;

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -4133,9 +4133,10 @@ class Societe extends CommonObject
 	 * Sets sales representatives of the thirdparty
 	 *
 	 * @param 	int[]|int 	$salesrep	 	User ID or array of user IDs
+	 * @param   bool        $onlyAdd        Only add (no delete before)
 	 * @return	int							<0 if KO, >0 if OK
 	 */
-	public function setSalesRep($salesrep)
+	public function setSalesRep($salesrep, $onlyAdd = false)
 	{
 		global $user;
 
@@ -4144,16 +4145,18 @@ class Societe extends CommonObject
 			$salesrep = array($salesrep);
 		}
 
-		// Get current users
-		$existing = $this->getSalesRepresentatives($user, 1);
 
-		// Diff
-		if (is_array($existing)) {
-			$to_del = array_diff($existing, $salesrep);
-			$to_add = array_diff($salesrep, $existing);
-		} else {
-			$to_del = array(); // Nothing to delete
-			$to_add = $salesrep;
+		$to_del = array(); // Nothing to delete
+		$to_add = $salesrep;
+		if ($onlyAdd === false) {
+			// Get current users
+			$existing = $this->getSalesRepresentatives($user, 1);
+
+			// Diff
+			if (is_array($existing)) {
+				$to_del = array_diff($existing, $salesrep);
+				$to_add = array_diff($salesrep, $existing);
+			}
 		}
 
 		$error = 0;


### PR DESCRIPTION
FIX set sales representatives on create company card :

If in external module you automatically add a sale representative (for example you want to add the manager of the sale representative), so you use trigger "COMPANY_CREATE" to add the manager, then this manager is deleted with "setSalesRep()" method.
It keeps only posted values of sales representatives put in the create company card.
