### PR TITLE
FIX: unit price divided by quantity when accepting supplier price pro…

### DIFF
--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -1810,7 +1810,7 @@ class SupplierProposal extends CommonObject
             if(!empty($conf->multicurrency->enabled) && !empty($product->multicurrency_code)) list($fk_multicurrency, $multicurrency_tx) = MultiCurrency::getIdAndTxFromCode($this->db, $product->multicurrency_code);
             $productsupplier->id = $product->fk_product;
 
-            $productsupplier->update_buyprice($product->qty, $product->subprice, $user, 'HT', $this->thirdparty, '', $ref_fourn, $product->tva_tx, 0, 0, 0, $product->info_bits,  '',  '',  array(),  '', $product->multicurrency_subprice,  'HT', $multicurrency_tx, $product->multicurrency_code,  '',  '',  '');
+            $productsupplier->update_buyprice($product->qty, $product->total_ht, $user, 'HT', $this->thirdparty, '', $ref_fourn, $product->tva_tx, 0, 0, 0, $product->info_bits,  '',  '',  array(),  '', $product->multicurrency_total_ht,  'HT', $multicurrency_tx, $product->multicurrency_code,  '',  '',  '' );
         }
 
         return 1;
@@ -1849,7 +1849,7 @@ class SupplierProposal extends CommonObject
     public function createPriceFournisseur($product, $user)
     {
         global $conf;
-        
+
 		$price=price2num($product->subprice*$product->qty, 'MU');
         $qty=price2num($product->qty);
         $unitPrice = price2num($product->subprice, 'MU');


### PR DESCRIPTION
## Issue description
When you create a price request line, you can add a product, a quantity (qty) and a unit price (p). However, when this price request is accepted, the unit price of the new supplier product price is set to `qty / p` instead of just `p`.

For instance, let’s say, you're requesting the price of a box of 10 screws. In your price request, the line with the product "screw" will have qty=10 and p=0.1 (so the box's price will be the total price of the line = 1).

But when the request is accepted, your supplier product price for a screw will be 0.01 (=0.1 / 10) instead of 0.1 (1/10), which is not what I think is intended.

## Analysis
In SupplierProposal > updateOrCreatePriceFournisseur, `ProductFournisseur::update_buyprice()` is called with the `$buyprice` parameter set to `$product->subprice`, but, `$buyprice` is supposed to be the "purchase price for the quantity min", whereas `$product->subprice` is the unit purchase price.

## Fix
Call `update_buyprice()` with `$product->total_ht` instead of `$product->subprice`.