### PR TITLE
FIX 10.0 - when the mime file name is different from the filesystem n…

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -463,6 +463,9 @@ class CMailFile
 				{
 					//$this->message->attach(Swift_Attachment::fromPath($filename_list[$i],$mimetype_list[$i]));
 					$attachment = Swift_Attachment::fromPath($filename_list[$i], $mimetype_list[$i]);
+					if (!empty($mimefilename_list[$i])) {
+						$attachment->setFilename($mimefilename_list[$i]);
+					}
 					$this->message->attach($attachment);
 				}
 			}


### PR DESCRIPTION
# Description of issue
When an e-mail is sent with an attachment, it is possible to provide a file name for that attachment and it doesn't have to match the name of the file on the server's filesystem. For instance, the attached file source may be `/tmp/RaNdOmFiLeNaMe` but you may want the attachment to be named `my-well-named-file.odt`.

It works with some e-mail sending methods, but not with SwiftMailer.

# Analysis
In the constructor of `CMailFile`, there are 3 tables for attachments:
* `$filename_list` : filesystem path to the file
* `$mimetype_list` : mime type
* `$mimefilename_list` : desired name for the attachment

But the SwiftMailer part doesn't use `$mimefilename_list`.

# Fix
My proposal is to call `Swift_Attachment::setFilename()` with the right name after the attachment has been instantiated. 