### PR TITLE
FIX: Contact type translation

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1297,6 +1297,8 @@ abstract class CommonObject
 		// phpcs:enable
 		global $langs, $conf;
 
+		$langs->loadLangs(array('bills', 'contracts', 'interventions', 'orders', 'projects', 'propal', 'ticket'));
+
 		$tab = array();
 
 		$sql = "SELECT DISTINCT tc.rowid, tc.code, tc.libelle, tc.position, tc.element";

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1297,7 +1297,7 @@ abstract class CommonObject
 		// phpcs:enable
 		global $langs, $conf;
 
-		$langs->loadLangs(array('bills', 'contracts', 'interventions', 'orders', 'projects', 'propal', 'ticket'));
+		$langs->loadLangs(array('bills', 'contracts', 'interventions', 'orders', 'projects', 'propal', 'ticket', 'agenda'));
 
 		$tab = array();
 


### PR DESCRIPTION
In the current version of dolibarr the labels of the contact types are fetched from the database. This fix allows dolibarr to use the already existing translations for the contact type labels.

**Caution:** The translations for the agenda module are missing in the translation files. Override the translations in dolibarr to translate the missing labels as well. The keys are: `TypeContact_agenda_external_ACTOR`, `TypeContact_agenda_external_GUEST`, `TypeContact_agenda_internal_ACTOR`, `TypeContact_agenda_internal_GUEST`
