### PR TITLE
NEW: add week number for month view in agenda

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -1210,6 +1210,8 @@ if (empty($action) || $action == 'show_month')      // View by month
     print '<div class="div-table-responsive-no-min">';
     print '<table width="100%" class="noborder nocellnopadd cal_pannel cal_month">';
     print ' <tr class="liste_titre">';
+	// Column title of weeks numbers
+	echo '  <td align="center">#</td>';
     $i = 0;
     while ($i < 7)
     {
@@ -1232,6 +1234,24 @@ if (empty($action) || $action == 'show_month')      // View by month
     //var_dump($eventarray);
     for ($iter_week = 0; $iter_week < 6; $iter_week++) {
         echo " <tr>\n";
+		// Get date of the current day, format 'yyyy-mm-dd'
+		if ($tmpday <= 0) // If number of the current day is in previous month
+		{
+			$currdate0 = sprintf("%04d", $prev_year).sprintf("%02d", $prev_month).sprintf("%02d", $max_day_in_prev_month + $tmpday);
+		}
+		elseif ($tmpday <= $max_day_in_month) // If number of the current day is in current month
+		{
+			$currdate0 = sprintf("%04d", $year).sprintf("%02d", $month).sprintf("%02d", $tmpday);
+		}
+		else // If number of the current day is in next month
+		{
+			$currdate0 = sprintf("%04d", $next_year).sprintf("%02d", $next_month).sprintf("%02d", $tmpday - $max_day_in_month);
+		}
+		// Get week number for the targeted date '$currdate0'
+		$numweek0 = date("W", strtotime(date($currdate0)));
+		// Show the week number, and define column width
+		echo ' <td align="center" width="2.0%">'.$numweek0.'</td>';
+		
         for ($iter_day = 0; $iter_day < 7; $iter_day++) {
             if ($tmpday <= 0) {
                 /* Show days before the beginning of the current month (previous month)  */


### PR DESCRIPTION
# New: add week number for month view in agenda

Agenda, view by month : add a column on left side of agenda, which containt the week number for each line, so for each week. Column width at 2%, no change for width of others columns, because with 14% by defalut, so 14*7=98, the 2% for new column is available. For get date and week number, use fonctions and variables already define in file.

![Agenda vue mois avec numéros semaines](https://user-images.githubusercontent.com/69631660/92113029-ff554880-edee-11ea-84ef-b4f991331bed.jpg)
