### PR TITLE
FIX load default linked options for linked sellist extra fields

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6571,6 +6571,7 @@ abstract class CommonObject
 								$("select[name=\""+parent_list+"\"]").change(function() {
 									showOptions(child_list, parent_list);
 								});
+								showOptions(child_list, parent_list);
 					    	});
 						}
 

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -199,6 +199,7 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 								$("select[name=\""+parent_list+"\"]").change(function() {
 									showOptions(child_list, parent_list);
 								});
+								showOptions(child_list, parent_list);
 					    	});
 						}
 						setListDependencies();


### PR DESCRIPTION
FIX load default linked options for linked sellist extra fields
- if you add two extra fields with one linked to the first and you load create card page with a default value, the other linked options are not filtered with the default value of parent linked extra field

For example : you add "CompanyActivityArea" with regions and a linked extra field "CompanyActivityZone" with departments.
If you create a new company with a default activity area, the linked options for "CompanyActivityZone" are not filtered with "CompanyActivityArea" loaded value.