### PR TITLE
FIX : Static property called as non static

### DIFF
--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -32,7 +32,7 @@ class DolibarrApi
     /**
      * @var DoliDb        $db Database object
      */
-    protected static $db;
+    protected $db;
 
     /**
      * @var Restler     $r	Restler object


### PR DESCRIPTION
# Fix static property called as non static

The $db property was initialized as a static property but used as a non-static property

https://github.com/Dolibarr/dolibarr/blob/b0a15f958f355713ec5408df51021a4cbdfc4d3f/htdocs/api/class/api.class.php#L35
https://github.com/Dolibarr/dolibarr/blob/b0a15f958f355713ec5408df51021a4cbdfc4d3f/htdocs/api/class/api.class.php#L56