### PR TITLE
FIX: round stock value on product list

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -1290,7 +1290,7 @@ if ($resql)
 			if ($obj->fk_product_type != 1)
 			{
 				if ($obj->seuil_stock_alerte != '' && $product_static->stock_reel < (float) $obj->seuil_stock_alerte) print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
-				print $product_static->stock_reel;
+				print price2num($product_static->stock_reel, 'MS');
 			}
 			print '</td>';
 			if (!$i) $totalarray['nbfield']++;
@@ -1302,7 +1302,7 @@ if ($resql)
 			if ($obj->fk_product_type != 1)
 			{
 				if ($obj->seuil_stock_alerte != '' && $product_static->stock_theorique < (float) $obj->seuil_stock_alerte) print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
-				print $product_static->stock_theorique;
+				print price2num($product_static->stock_theorique, 'MS');
 			}
 			print '</td>';
 			if (!$i) $totalarray['nbfield']++;


### PR DESCRIPTION
# Context
When you are on the “Stock” tab of a product card, the physical and virtual stock values are rounded to `MAIN_MAX_DECIMALS_STOCK`, but it is not the case on the product list.

# Fix
I used the rounding method used in `product/stock/product.php` to improve consistency.