### PR TITLE
FIX API variable error code return

### DIFF
--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -1413,7 +1413,7 @@ class Setup extends DolibarrApi
      * @url     GET conf/{constantname}
      *
      * @throws RestException 403 Forbidden
-     * @throws RestException 500 Error Bad or unknown value for constantname
+     * @throws RestException 404 Error Bad or unknown value for constantname
      */
     public function getConf($constantname)
     {
@@ -1425,7 +1425,7 @@ class Setup extends DolibarrApi
     	}
 
     	if (!preg_match('/^[a-zA-Z0-9_]+$/', $constantname) || !isset($conf->global->$constantname)) {
-    		throw new RestException(500, 'Error Bad or unknown value for constantname');
+    		throw new RestException(404, 'Error Bad or unknown value for constantname');
     	}
     	if (preg_match('/(_pass|_pw|password|secret|_key|key$)/i', $constantname)) {
     		throw new RestException(403, 'Forbidden');


### PR DESCRIPTION
Some modules, when there is no value, delete the variables so don't find variable can be normal.

Error 404 is better than 500 with error servor (same as other object when not found)
ie thirdparties, contacts invoices...)