### PR TITLE
FIX - Accountancy balance Error SQL on entity

### DIFF
--- a/htdocs/accountancy/bookkeeping/balance.php
+++ b/htdocs/accountancy/bookkeeping/balance.php
@@ -267,8 +267,12 @@ if ($action != 'export_csv')
 	$sous_total_credit = 0;
 	$displayed_account = "";
 
-	$sql = "select t.numero_compte, (SUM(t.debit) - SUM(t.credit)) as opening_balance from ".MAIN_DB_PREFIX."accounting_bookkeeping as t where entity in ".$conf->entity;
-	$sql .= " AND t.doc_date < '".$db->idate($search_date_start)."' GROUP BY t.numero_compte";
+	$sql = "SELECT t.numero_compte, (SUM(t.debit) - SUM(t.credit)) as opening_balance";
+	$sql .= " FROM ".MAIN_DB_PREFIX."accounting_bookkeeping as t";
+	$sql .= " WHERE t.entity IN (".getEntity('accountancy').")";
+	$sql .= " AND t.doc_date < '".$db->idate($search_date_start)."'";
+	$sql .= " GROUP BY t.numero_compte";
+
 	$resql = $db->query($sql);
 	$nrows = $resql->num_rows;
 	$opening_balances = array();
@@ -289,10 +293,10 @@ if ($action != 'export_csv')
 		}
 		print '<tr class="oddeven">';
 
-		// Permet d'afficher le compte comptable
+		// Display the accounting account
 		if (empty($displayed_account) || $root_account_description != $displayed_account)
 		{
-			// Affiche un Sous-Total par compte comptable
+			// Display a sub-total per account
 			if ($displayed_account != "") {
 				print '<tr class="liste_total"><td class="right" colspan="3">'.$langs->trans("SubTotal").':</td><td class="nowrap right">'.price($sous_total_debit).'</td><td class="nowrap right">'.price($sous_total_credit).'</td><td class="nowrap right">'.price(price2num($sous_total_credit - $sous_total_debit)).'</td>';
 				print "<td>&nbsp;</td>\n";
@@ -321,7 +325,7 @@ if ($action != 'export_csv')
 		print '</td>';
 		print "</tr>\n";
 
-		// Comptabilise le sous-total
+		// Records the sub-total
 		$sous_total_debit += $line->debit;
 		$sous_total_credit += $line->credit;
 	}

--- a/htdocs/accountancy/bookkeeping/balance.php
+++ b/htdocs/accountancy/bookkeeping/balance.php
@@ -269,7 +269,7 @@ if ($action != 'export_csv')
 
 	$sql = "SELECT t.numero_compte, (SUM(t.debit) - SUM(t.credit)) as opening_balance";
 	$sql .= " FROM ".MAIN_DB_PREFIX."accounting_bookkeeping as t";
-	$sql .= " WHERE t.entity IN (".getEntity('accountancy').")";
+	$sql .= " WHERE t.entity = ".$conf->entity;		// Never do sharing into accounting features
 	$sql .= " AND t.doc_date < '".$db->idate($search_date_start)."'";
 	$sql .= " GROUP BY t.numero_compte";
 


### PR DESCRIPTION
Before : 
`sql=select t.numero_compte, (SUM(t.debit) - SUM(t.credit)) as opening_balance from llx_accounting_bookkeeping as t where entity in 1 AND t.doc_date < '2020-06-27 00:00:00' GROUP BY t.numero_compte`

> ERROR DoliDBMysqli::query SQL Error message: DB_ERROR_SYNTAX Erreur de syntaxe près de '1 AND t.doc_date < '2020-06-27 00:00:00' GROUP BY t.numero_compte' à la ligne 1