### PR TITLE
NEW ticket classification on create from email collector

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1879,9 +1879,9 @@ class EmailCollector extends CommonObject
 
 							$tickettocreate->subject = $subject;
 							$tickettocreate->message = $description;
-							$tickettocreate->type_code = 0;
-							$tickettocreate->category_code = null;
-							$tickettocreate->severity_code = null;
+							$tickettocreate->type_code = (!empty($conf->global->MAIN_EMAILCOLLECTOR_TICKET_TYPE_CODE) ? $conf->global->MAIN_EMAILCOLLECTOR_TICKET_TYPE_CODE : dol_getIdFromCode($this->db, 1, 'c_ticket_type', 'use_default', 'code', 1));
+							$tickettocreate->category_code = (!empty($conf->global->MAIN_EMAILCOLLECTOR_TICKET_CATEGORY_CODE) ? $conf->global->MAIN_EMAILCOLLECTOR_TICKET_CATEGORY_CODE : dol_getIdFromCode($this->db, 1, 'c_ticket_category', 'use_default', 'code', 1));
+							$tickettocreate->severity_code = (!empty($conf->global->MAIN_EMAILCOLLECTOR_TICKET_SEVERITY_CODE) ? $conf->global->MAIN_EMAILCOLLECTOR_TICKET_SEVERITY_CODE : dol_getIdFromCode($this->db, 1, 'c_ticket_severity', 'use_default', 'code', 1));
 							$tickettocreate->origin_email = $from;
 							$tickettocreate->fk_user_create = $user->id;
 							$tickettocreate->datec = $date;


### PR DESCRIPTION
NEW ticket classification on create from email collector
- uses constant or default value defined in dictionary to create a ticket for classification (when a ticket was created from "email collector") 