### PR TITLE
Fix: short label of unit in Product::getLabelOfUnit()

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5392,7 +5392,7 @@ class Product extends CommonObject
         $resql = $this->db->query($sql);
         if ($resql && $this->db->num_rows($resql) > 0) {
             $res = $this->db->fetch_array($resql);
-            $label = ($label_type == 'short' ? $res[$label_type] : 'unit'.$res['code']);
+            $label = ($label_type == 'short_label' ? $res[$label_type] : 'unit'.$res['code']);
             $this->db->free($resql);
             return $label;
         }


### PR DESCRIPTION
In Product::getLabelOfUnit() if use shot label, the label type is identified by `short_label` not by `short` (renamed by the if block at line 5387).