### PR TITLE
Fix: getLabelOfUnit() for Product, CommonObjectline to print long label

### DIFF
--- a/htdocs/core/class/commonobjectline.class.php
+++ b/htdocs/core/class/commonobjectline.class.php
@@ -51,7 +51,7 @@ abstract class CommonObjectLine extends CommonObject
 
 
 	/**
-	 *	Returns the translation key from units dictionary.
+	 *	Returns the label, shot_label or code found in units dictionary from ->fk_unit.
 	 *  A langs->trans() must be called on result to get translated value.
 	 *
 	 * 	@param	string $type 	Label type (long, short or code). This can be a translation key.

--- a/htdocs/core/class/commonobjectline.class.php
+++ b/htdocs/core/class/commonobjectline.class.php
@@ -54,7 +54,7 @@ abstract class CommonObjectLine extends CommonObject
 	 *	Returns the translation key from units dictionary.
 	 *  A langs->trans() must be called on result to get translated value.
 	 *
-	 * 	@param	string $type 	Label type (long or short). This can be a translation key.
+	 * 	@param	string $type 	Label type (long, short or code). This can be a translation key.
 	 *	@return	string|int 		<0 if ko, label if ok
 	 */
 	public function getLabelOfUnit($type = 'long')
@@ -69,17 +69,16 @@ abstract class CommonObjectLine extends CommonObject
 
 		$label_type = 'label';
 
-		if ($type == 'short')
-		{
-			$label_type = 'short_label';
-		}
+		$label_type = 'label';
+		if ($type == 'short') $label_type = 'short_label';
+		elseif ($type == 'code') $label_type = 'code';
 
-		$sql = 'select '.$label_type.',code from '.MAIN_DB_PREFIX.'c_units where rowid='.$this->fk_unit;
+		$sql = 'select '.$label_type.', code from '.MAIN_DB_PREFIX.'c_units where rowid='.$this->fk_unit;
 		$resql = $this->db->query($sql);
-		if ($resql && $this->db->num_rows($resql) > 0)
-		{
+		if ($resql && $this->db->num_rows($resql) > 0) {
 			$res = $this->db->fetch_array($resql);
-			$label = ($label_type == 'short' ? $res[$label_type] : 'unit'.$res['code']);
+			if ($label_type == 'code') $label = 'unit'.$res['code'];
+			else $label = $res[$label_type];
 			$this->db->free($resql);
 			return $label;
 		}

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5368,8 +5368,9 @@ class Product extends CommonObject
 
     /**
      *    Returns the text label from units dictionary
+	 *    A langs->trans() must be called on result to get translated value.
      *
-     * @param  string $type Label type (long or short)
+     * @param  string $type Label type (long, short or code)
      * @return string|int <0 if ko, label if ok
      */
     public function getLabelOfUnit($type = 'long')
@@ -5383,16 +5384,15 @@ class Product extends CommonObject
         $langs->load('products');
 
         $label_type = 'label';
-
-        if ($type == 'short') {
-            $label_type = 'short_label';
-        }
+        if ($type == 'short') $label_type = 'short_label';
+        elseif ($type == 'code') $label_type = 'code';
 
         $sql = 'select '.$label_type.', code from '.MAIN_DB_PREFIX.'c_units where rowid='.$this->fk_unit;
         $resql = $this->db->query($sql);
         if ($resql && $this->db->num_rows($resql) > 0) {
             $res = $this->db->fetch_array($resql);
-            $label = ($label_type == 'short_label' ? $res[$label_type] : 'unit'.$res['code']);
+            if ($label_type == 'code') $label = 'unit'.$res['code'];
+            else $label = $res[$label_type];
             $this->db->free($resql);
             return $label;
         }

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5367,11 +5367,12 @@ class Product extends CommonObject
     }
 
     /**
-     *    Returns the text label from units dictionary
-	 *    A langs->trans() must be called on result to get translated value.
+     * Returns the label, shot_label or code found in units dictionary from ->fk_unit.
+	 * A langs->trans() must be called on result to get translated value.
      *
      * @param  string $type Label type (long, short or code)
      * @return string|int <0 if ko, label if ok
+	 * @see getLabelOfUnit() in CommonObjectLine
      */
     public function getLabelOfUnit($type = 'long')
     {


### PR DESCRIPTION
The method getLabelOfUnit() for Product and CommonObjectline do not return *short* or *long* label (only 'unitXX' where XX is code of unit). I've already provided a fix for short label for Product::getLabelOfUnit() (#14712) which do not functional for long label and do not correct CommonObjectline::getLabelOfUnit(). 

Something seems strange to me, in langs trans files, the translation for *short*, *long* and *unitXX* are provided, so maybe the reason for which the getLabelOfUnit() only return *codeXX* from is because the *long* form *short* form are deprecied but i've no élement to be sure. So i've added new type of unit for theses method (`code`) for explicitly return unit code in form *unitXX*.

