### PR TITLE
FIX #14746 Historical list of subscription shows empty member type

### DIFF
--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -628,7 +628,7 @@ if ($rowid > 0) {
                 $subscriptionstatic->ref = $objp->crowid;
                 $subscriptionstatic->id = $objp->crowid;
 
-                $typeid = ($objp->cfk_type > 0 ? $objp->cfk_type : $adh->typeid);
+                $typeid = $objp->cfk_type;
                 if ($typeid > 0) {
                     $adht->fetch($typeid);
                 }


### PR DESCRIPTION
Historical list of subscription shows empty member type if not recorded

# Fix #14746 Historical subscrition type may not be the real one #14746 
Currently, the subscription view displays by default the adherent's current subscription type if no type has been registered in the past. If an update was made from an earlier version of Dolibarr (up to v10), the subscription type was not recorded in the table llx_subscritipion. There should therefore nothing to be displayed.

Indeed, the list gives the type of subscription recorded when it was registered if the type of subscription was recorded otherwise it displays the current type. There is no way to tell if this is the era type being displayed or if it is today.

In certain circumstances, for legal and insurance matters, the history is particularly important. You should know if the adherents were covered several years back. If the information is missing on the platform, the user will know that he will have to retrieve this information otherwise, but if he sees information...

This procedure is risky because it misleads the user into believing that the information is confirmed. It is better not to display anything as a type of subscription when the information does not exist. Only the types of subscription recorded in the past should be displayed in the history. The current type is in the member's profile, there is no need to display it in the list of old membership fees.
