### PR TITLE
Show buttons on products when 'Hide Product Images' is enabled

### DIFF
--- a/htdocs/takepos/css/pos.css.php
+++ b/htdocs/takepos/css/pos.css.php
@@ -141,6 +141,27 @@ button.calcbutton3 {
     border-radius: 3px;
 }
 
+button.productbutton {
+	display: inline-block;
+	position: relative;
+	padding: 0;
+	line-height: normal;
+	cursor: pointer;
+	vertical-align: middle;
+	text-align: center;
+	overflow: visible; /* removes extra width in IE */
+	width: calc(100% - 2px);
+	height: calc(100% - 2px);
+	font-weight: bold;
+    background-color: #a3a6a3;
+    color: #fff;
+    /* border-color: unset; */
+    border-width: 0;
+    margin: 1px;
+	font-size: 14pt;
+    border-radius: 3px;
+}
+
 button.actionbutton {
     background: #EABCA6;
     border: 2px solid #EEE;

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -297,8 +297,7 @@ function LoadProducts(position, issubcat) {
 					echo '$("#prodesc"+ishow).text("");';
 					echo '$("#proimg"+ishow).attr("title","");';
 					echo '$("#proimg"+ishow).attr("src","genimg/empty.png");';
-				} else
-				{
+				} else {
 					echo '$("#probutton"+ishow).hide();';
 					echo '$("#probutton"+ishow).text("");';
 				}?>

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -297,8 +297,7 @@ function LoadProducts(position, issubcat) {
 					echo '$("#prodesc"+ishow).text("");';
 					echo '$("#proimg"+ishow).attr("title","");';
 					echo '$("#proimg"+ishow).attr("src","genimg/empty.png");';
-				}
-				else
+				} else
 				{
 					echo '$("#probutton"+ishow).hide();';
 					echo '$("#probutton"+ishow).text("");';
@@ -323,8 +322,7 @@ function LoadProducts(position, issubcat) {
 					echo '$("#proimg"+ishow).attr("title", titlestring);';
 					echo '$("#proimg"+ishow).attr("src", "genimg/index.php?query=pro&id="+data[idata][\'id\']);';
 				}
-				else
-				{
+				else {
 					echo '$("#probutton"+ishow).show();';
 					echo '$("#probutton"+ishow).text(data[parseInt(idata)][\'label\']);';
 				}
@@ -1088,8 +1086,7 @@ if ($conf->global->TAKEPOS_WEIGHING_SCALE)
     					print '<span class="fa fa-chevron-right centerinmiddle" style="font-size: 5em;"></span>';
     				} else {
 						if ($conf->global->TAKEPOS_HIDE_PRODUCT_IMAGES) echo '<button type="button" id="probutton'.$count.'" class="productbutton" style="display: none;"></button>';
-    					else
-						{
+    					else {
 							print '<div class="" id="proprice'.$count.'"></div>';
 							print '<img class="imgwrapper" height="100%" title="" id="proimg'.$count.'">';
 						}

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -291,12 +291,20 @@ function LoadProducts(position, issubcat) {
 			//console.log("ishow"+ishow+" idata="+idata);
 			console.log(data[idata]);
 			if (typeof (data[idata]) == "undefined") {
-				$("#prodivdesc"+ishow).hide();
-				$("#prodesc"+ishow).text("");
+				<?php if (!$conf->global->TAKEPOS_HIDE_PRODUCT_IMAGES)
+				{
+					echo '$("#prodivdesc"+ishow).hide();';
+					echo '$("#prodesc"+ishow).text("");';
+					echo '$("#proimg"+ishow).attr("title","");';
+					echo '$("#proimg"+ishow).attr("src","genimg/empty.png");';
+				}
+				else
+				{
+					echo '$("#probutton"+ishow).hide();';
+					echo '$("#probutton"+ishow).text("");';
+				}?>
 				$("#proprice"+ishow).attr("class", "hidden");
 				$("#proprice"+ishow).html("");
-				$("#proimg"+ishow).attr("title","");
-				$("#proimg"+ishow).attr("src","genimg/empty.png");
 				$("#prodiv"+ishow).data("rowid","");
 				$("#prodiv"+ishow).attr("class","wrapper2 divempty");
 				$("#prowatermark"+ishow).hide();
@@ -308,14 +316,23 @@ function LoadProducts(position, issubcat) {
 					$titlestring .= " + ' - ".dol_escape_js($langs->trans("Barcode").': ')."' + data[idata]['barcode']";
 				?>
 				var titlestring = <?php echo $titlestring; ?>;
-				$("#prodivdesc"+ishow).show();
-				$("#prodesc"+ishow).text(data[parseInt(idata)]['label']);
+				<?php if (!$conf->global->TAKEPOS_HIDE_PRODUCT_IMAGES)
+				{
+					echo '$("#prodivdesc"+ishow).show();';
+					echo '$("#prodesc"+ishow).text(data[parseInt(idata)][\'label\']);';
+					echo '$("#proimg"+ishow).attr("title", titlestring);';
+					echo '$("#proimg"+ishow).attr("src", "genimg/index.php?query=pro&id="+data[idata][\'id\']);';
+				}
+				else
+				{
+					echo '$("#probutton"+ishow).show();';
+					echo '$("#probutton"+ishow).text(data[parseInt(idata)][\'label\']);';
+				}
+				?>
 				if (data[parseInt(idata)]['price_formated']) {
 					$("#proprice"+ishow).attr("class", "productprice");
 					$("#proprice"+ishow).html(data[parseInt(idata)]['price_formated']);
 				}
-				$("#proimg"+ishow).attr("title", titlestring);
-				$("#proimg"+ishow).attr("src", "genimg/index.php?query=pro&id="+data[idata]['id']);
 				$("#prodiv"+ishow).data("rowid", data[idata]['id']);
 				$("#prodiv"+ishow).data("iscat", 0);
 				$("#prodiv"+ishow).attr("class","wrapper2");
@@ -1070,11 +1087,15 @@ if ($conf->global->TAKEPOS_WEIGHING_SCALE)
     				    //echo '<img class="imgwrapper" src="img/arrow-next-top.png" height="100%" id="proimg'.$count.'" />';
     					print '<span class="fa fa-chevron-right centerinmiddle" style="font-size: 5em;"></span>';
     				} else {
-    					print '<div class="" id="proprice'.$count.'"></div>';
-    					if (!$conf->global->TAKEPOS_HIDE_PRODUCT_IMAGES) print '<img class="imgwrapper" height="100%" title="" id="proimg'.$count.'">';
+						if ($conf->global->TAKEPOS_HIDE_PRODUCT_IMAGES) echo '<button type="button" id="probutton'.$count.'" class="productbutton" style="display: none;"></button>';
+    					else
+						{
+							print '<div class="" id="proprice'.$count.'"></div>';
+							print '<img class="imgwrapper" height="100%" title="" id="proimg'.$count.'">';
+						}
     				}
     				?>
-					<?php if ($count != ($MAXPRODUCT - 2) && $count != ($MAXPRODUCT - 1)) { ?>
+					<?php if ($count != ($MAXPRODUCT - 2) && $count != ($MAXPRODUCT - 1) && !$conf->global->TAKEPOS_HIDE_PRODUCT_IMAGES) { ?>
     				<div class="description" id="prodivdesc<?php echo $count; ?>">
     					<div class="description_content" id="prodesc<?php echo $count; ?>"></div>
     				</div>


### PR DESCRIPTION
In TakePOS is better show buttons instead of an unknown icon on products when 'Hide Product Images' is enabled, and looks like:
![buttons](https://user-images.githubusercontent.com/28452516/93299714-cad18b80-f7f5-11ea-91ac-e9824540c467.JPG)

Until now it looked like this:
![current](https://user-images.githubusercontent.com/28452516/93299976-44697980-f7f6-11ea-9c5a-6111bc26ee64.JPG)
