### PR TITLE
Fix Category is lost on sorting member list

### DIFF
--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -370,6 +370,7 @@ if ($search_lastname)  $param .= "&search_lastname=".urlencode($search_lastname)
 if ($search_gender)  $param .= "&search_gender=".urlencode($search_gender);
 if ($search_login)   $param .= "&search_login=".urlencode($search_login);
 if ($search_email)   $param .= "&search_email=".urlencode($search_email);
+if ($search_categ)   $param .= "&search_categ=".urlencode($search_categ);
 if ($search_company) $param .= "&search_company=".urlencode($search_company);
 if ($search_address != '') $param .= "&search_address=".urlencode($search_address);
 if ($search_town != '') $param .= "&search_town=".urlencode($search_town);
@@ -545,7 +546,7 @@ if (!empty($arrayfields['d.email']['checked'])) {
 	print '<td class="liste_titre left">';
 	print '<input class="flat maxwidth75imp" type="text" name="search_email" value="'.dol_escape_htmltag($search_email).'"></td>';
 }
-
+// End of subscription date
 if (!empty($arrayfields['d.datefin']['checked'])) {
 	print '<td class="liste_titre left">';
 	print '</td>';


### PR DESCRIPTION
When sorting member list filter by tag/category the criteria is lost because of one missing GET parameter

* Just adding a GET parameter to keep the category/tag parameter when sorting the list
* Adding a missing comment, just for the readability