### PR TITLE
FIX - Backtick not work with postgresql

### DIFF
--- a/htdocs/install/mysql/migration/10.0.0-11.0.0.sql
+++ b/htdocs/install/mysql/migration/10.0.0-11.0.0.sql
@@ -98,7 +98,8 @@ ALTER TABLE llx_bom_bomline ADD COLUMN position integer NOT NULL DEFAULT 0;
 ALTER TABLE llx_bom_bomline ADD COLUMN qty_frozen smallint DEFAULT 0;
 ALTER TABLE llx_bom_bomline ADD COLUMN disable_stock_change smallint DEFAULT 0;
 
-ALTER TABLE llx_bom_bomline DROP COLUMN `rank`;
+-- VMYSQL4.1 ALTER TABLE llx_bom_bomline DROP COLUMN `rank`;
+-- VPGSQL8.2 ALTER TABLE llx_bom_bomline DROP COLUMN rank;
 
 create table llx_categorie_warehouse
 (


### PR DESCRIPTION
# Fix #Backtick not work with postgresql

Column "rank" is reserved. In mysql we need to use backtick. In postgresql backtick does'nt work. 
Thus we need two versions of "drop rank" line. 

**Note** : where is this column rank created ? 
