### PR TITLE
Bug fix last_gen should be date_last_gen

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -155,7 +155,7 @@ class FactureRec extends CommonInvoice
 		'note_private' =>array('type'=>'text', 'label'=>'NotePublic', 'enabled'=>1, 'visible'=>0, 'position'=>105),
 		'note_public' =>array('type'=>'text', 'label'=>'NotePrivate', 'enabled'=>1, 'visible'=>0, 'position'=>110),
 		'modelpdf' =>array('type'=>'varchar(255)', 'label'=>'Modelpdf', 'enabled'=>1, 'visible'=>-1, 'position'=>115),
-		'last_gen' =>array('type'=>'varchar(7)', 'label'=>'Last gen', 'enabled'=>1, 'visible'=>-1, 'position'=>120),
+		'date_last_gen' =>array('type'=>'varchar(7)', 'label'=>'Last gen', 'enabled'=>1, 'visible'=>-1, 'position'=>120),
 		'unit_frequency' =>array('type'=>'varchar(2)', 'label'=>'Unit frequency', 'enabled'=>1, 'visible'=>-1, 'position'=>125),
 		'date_when' =>array('type'=>'datetime', 'label'=>'Date when', 'enabled'=>1, 'visible'=>-1, 'position'=>130),
 		'date_last_gen' =>array('type'=>'datetime', 'label'=>'Date last gen', 'enabled'=>1, 'visible'=>-1, 'position'=>135),

--- a/htdocs/fichinter/class/fichinterrec.class.php
+++ b/htdocs/fichinter/class/fichinterrec.class.php
@@ -567,14 +567,14 @@ class FichinterRec extends Fichinter
         if ($user->rights->fichinter->creer) {
             $sql = "UPDATE ".MAIN_DB_PREFIX."fichinter_rec ";
             $sql .= " SET frequency='".$this->db->escape($freq)."'";
-            $sql .= ", last_gen='".$this->db->escape($courant)."'";
+            $sql .= ", date_last_gen='".$this->db->escape($courant)."'";
             $sql .= " WHERE rowid = ".$this->id;
 
             $resql = $this->db->query($sql);
 
             if ($resql) {
                 $this->frequency = $freq;
-                $this->last_gen = $courant;
+                $this->date_last_gen = $courant;
                 return 0;
             } else {
                 dol_print_error($this->db);


### PR DESCRIPTION
Buf fix 

"last_gen" should be "date_last_gen"  in these files:

/compta/facture/class/facture-rec.class.php:158: 'last_gen' =>array('type'=>'varchar(7)', 'label'=>'Last gen', 'enabled'=>1, 'visible'=>-1, 'position'=>120),
./fichinter/class/fichinterrec.class.php:570: $sql .= ", last_gen='".$this->db->escape($courant)."'";
./fichinter/class/fichinterrec.class.php:577: $this->last_gen = $courant;


See this thread:  https://www.dolibarr.es/foro/viewtopic.php?f=18&t=13302