### PR TITLE
NEW MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER const in email collector

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1672,8 +1672,10 @@ class EmailCollector extends CommonObject
 							$description = dol_concatdesc($description, $messagetext);
 
 							$descriptionfull = $description;
-							$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
-							$descriptionfull = dol_concatdesc($descriptionfull, $header);
+							if (empty($conf->global->MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER)) {
+								$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
+								$descriptionfull = dol_concatdesc($descriptionfull, $header);
+							}
 
 							// Insert record of emails sent
 							$actioncomm->type_code   = 'AC_OTH_AUTO'; // Type of event ('AC_OTH', 'AC_OTH_AUTO', 'AC_XXX'...)
@@ -1760,8 +1762,10 @@ class EmailCollector extends CommonObject
 							$description = dol_concatdesc($description, $messagetext);
 
 							$descriptionfull = $description;
-							$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
-							$descriptionfull = dol_concatdesc($descriptionfull, $header);
+							if (empty($conf->global->MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER)) {
+								$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
+								$descriptionfull = dol_concatdesc($descriptionfull, $header);
+							}
 
 							$id_opp_status = dol_getIdFromCode($this->db, 'PROSP', 'c_lead_status', 'code', 'rowid');
 							$percent_opp_status = dol_getIdFromCode($this->db, 'PROSP', 'c_lead_status', 'code', 'percent');
@@ -1874,8 +1878,10 @@ class EmailCollector extends CommonObject
 							$description = dol_concatdesc($description, $messagetext);
 
 							$descriptionfull = $description;
-							$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
-							$descriptionfull = dol_concatdesc($descriptionfull, $header);
+							if (empty($conf->global->MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER)) {
+								$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
+								$descriptionfull = dol_concatdesc($descriptionfull, $header);
+							}
 
 							$tickettocreate->subject = $subject;
 							$tickettocreate->message = $description;

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -482,7 +482,7 @@ class Ticket extends CommonObject
 		global $langs;
 
 		// Check parameters
-		if (!$id && !$track_id && !$ref) {
+		if (!$id && !$track_id && !$ref && !$email_msgid) {
 			$this->error = 'ErrorWrongParameters';
 			dol_print_error(get_class($this)."::fetch ".$this->error);
 			return -1;


### PR DESCRIPTION
NEW MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER const in email collector : 
- add a const to avoid from having mail header in events when collecting email
