### PR TITLE
Bug: ActionComm::ref_ext is not saved properly

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -495,7 +495,7 @@ class ActionComm extends CommonObject
 		$sql .= ((isset($this->durationp) && $this->durationp >= 0 && $this->durationp != '') ? "'".$this->db->escape($this->durationp)."'" : "null").", "; // deprecated
 		$sql .= (isset($this->type_id) ? $this->type_id : "null").",";
 		$sql .= ($code ? ("'".$this->db->escape($code)."'") : "null").", ";
-		$sql .= ($this->ref_ext ? ("'".$this->db->idate($this->ref_ext)."'") : "null").", ";
+		$sql .= (!empty($this->ref_ext) ? "'".$this->db->escape($this->ref_ext)."'" : "null").", ";
 		$sql .= ((isset($this->socid) && $this->socid > 0) ? $this->socid : "null").", ";
 		$sql .= ((isset($this->fk_project) && $this->fk_project > 0) ? $this->fk_project : "null").", ";
 		$sql .= " '".$this->db->escape($this->note_private)."', ";


### PR DESCRIPTION
ActionComm::ref_ext is considered to be a timestamp in ActionComm::create(), (but not in ActionComm::create()).
Correction to consider it a string.