### PR TITLE
 FIX If salaries subledger account not defined, put only in the general account

### DIFF
--- a/htdocs/accountancy/admin/defaultaccounts.php
+++ b/htdocs/accountancy/admin/defaultaccounts.php
@@ -101,22 +101,6 @@ if ($conf->societe->enabled) {
 /*
  * Actions
  */
-
-$accounting_mode = empty($conf->global->ACCOUNTING_MODE) ? 'RECETTES-DEPENSES' : $conf->global->ACCOUNTING_MODE;
-
-if (GETPOST('change_chart', 'alpha'))
-{
-    $chartofaccounts = GETPOST('chartofaccounts', 'int');
-
-    if (!empty($chartofaccounts)) {
-        if (!dolibarr_set_const($db, 'CHARTOFACCOUNTS', $chartofaccounts, 'chaine', 0, '', $conf->entity)) {
-            $error++;
-        }
-    } else {
-        $error++;
-    }
-}
-
 if ($action == 'update') {
 	$error = 0;
 

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -180,10 +180,10 @@ if ($result) {
 	$account_supplier			= (($conf->global->ACCOUNTING_ACCOUNT_SUPPLIER != "") ? $conf->global->ACCOUNTING_ACCOUNT_SUPPLIER : 'NotDefined'); // NotDefined is a reserved word
 	$account_customer			= (($conf->global->ACCOUNTING_ACCOUNT_CUSTOMER != "") ? $conf->global->ACCOUNTING_ACCOUNT_CUSTOMER : 'NotDefined'); // NotDefined is a reserved word
 	$account_employee			= (!empty($conf->global->SALARIES_ACCOUNTING_ACCOUNT_PAYMENT) ? $conf->global->SALARIES_ACCOUNTING_ACCOUNT_PAYMENT : 'NotDefined'); // NotDefined is a reserved word
-	$account_pay_vat = (!empty($conf->global->ACCOUNTING_VAT_PAY_ACCOUNT) ? $conf->global->ACCOUNTING_VAT_PAY_ACCOUNT : 'NotDefined'); // NotDefined is a reserved word
-	$account_pay_donation = (!empty($conf->global->DONATION_ACCOUNTINGACCOUNT) ? $conf->global->DONATION_ACCOUNTINGACCOUNT : 'NotDefined'); // NotDefined is a reserved word
-	$account_pay_subscription = (!empty($conf->global->ADHERENT_SUBSCRIPTION_ACCOUNTINGACCOUNT) ? $conf->global->ADHERENT_SUBSCRIPTION_ACCOUNTINGACCOUNT : 'NotDefined'); // NotDefined is a reserved word
-	$account_transfer = (!empty($conf->global->ACCOUNTING_ACCOUNT_TRANSFER_CASH) ? $conf->global->ACCOUNTING_ACCOUNT_TRANSFER_CASH : 'NotDefined'); // NotDefined is a reserved word
+	$account_pay_vat			= (!empty($conf->global->ACCOUNTING_VAT_PAY_ACCOUNT) ? $conf->global->ACCOUNTING_VAT_PAY_ACCOUNT : 'NotDefined'); // NotDefined is a reserved word
+	$account_pay_donation		= (!empty($conf->global->DONATION_ACCOUNTINGACCOUNT) ? $conf->global->DONATION_ACCOUNTINGACCOUNT : 'NotDefined'); // NotDefined is a reserved word
+	$account_pay_subscription	= (!empty($conf->global->ADHERENT_SUBSCRIPTION_ACCOUNTINGACCOUNT) ? $conf->global->ADHERENT_SUBSCRIPTION_ACCOUNTINGACCOUNT : 'NotDefined'); // NotDefined is a reserved word
+	$account_transfer			= (!empty($conf->global->ACCOUNTING_ACCOUNT_TRANSFER_CASH) ? $conf->global->ACCOUNTING_ACCOUNT_TRANSFER_CASH : 'NotDefined'); // NotDefined is a reserved word
 
 	$tabcompany = array();
 	$tabuser = array();
@@ -237,7 +237,7 @@ if ($result) {
 		);
 
 		// Set accountancy code for user
-		$compta_user = (!empty($obj->accountancy_code) ? $obj->accountancy_code : $account_employee);
+		$compta_user = (!empty($obj->accountancy_code) ? $obj->accountancy_code : '');
 
 		$tabuser[$obj->rowid] = array(
 				'id' => $obj->userid,


### PR DESCRIPTION
1rst, just add a payment on salaries module with an employee without subledger account defined.
Result on accounting when prepare transfer in the ledger 
![image](https://user-images.githubusercontent.com/2341395/94644218-fde14800-02e8-11eb-83c6-bfeab0ef4893.png)

2nd, realize transfer in accountancy, we have an unknown subledger account (based on general account)...
![image](https://user-images.githubusercontent.com/2341395/94644380-70522800-02e9-11eb-8424-0de9acb1fafe.png)

This FIX remove unknown subledger account to put operation only in general account. Result : 
![image](https://user-images.githubusercontent.com/2341395/94644449-a0013000-02e9-11eb-8a6c-3fd3fe032db0.png)
