### PR TITLE
Show accounting code under supplier invoice line

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -38,6 +38,8 @@ include_once DOL_DOCUMENT_ROOT.'/core/class/commoninvoice.class.php';
 require_once DOL_DOCUMENT_ROOT.'/multicurrency/class/multicurrency.class.php';
 require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 
+if (!empty($conf->accounting->enabled)) require_once DOL_DOCUMENT_ROOT.'/accountancy/class/accountingaccount.class.php';
+
 /**
  *	Class to manage suppliers invoices
  */
@@ -733,7 +735,7 @@ class FactureFournisseur extends CommonInvoice
         $sql = 'SELECT f.rowid, f.ref as ref_supplier, f.description, f.date_start, f.date_end, f.pu_ht, f.pu_ttc, f.qty, f.remise_percent, f.vat_src_code, f.tva_tx';
         $sql.= ', f.localtax1_tx, f.localtax2_tx, f.localtax1_type, f.localtax2_type, f.total_localtax1, f.total_localtax2, f.fk_facture_fourn ';
         $sql.= ', f.total_ht, f.tva as total_tva, f.total_ttc, f.fk_product, f.product_type, f.info_bits, f.rang, f.special_code, f.fk_parent_line, f.fk_unit';
-        $sql.= ', p.rowid as product_id, p.ref as product_ref, p.label as label, p.description as product_desc';
+        $sql.= ', f.fk_code_ventilation, p.rowid as product_id, p.ref as product_ref, p.label as label, p.description as product_desc';
         $sql.= ', f.fk_multicurrency, f.multicurrency_code, f.multicurrency_subprice, f.multicurrency_total_ht, f.multicurrency_total_tva, f.multicurrency_total_ttc';
         $sql.= ' FROM '.MAIN_DB_PREFIX.'facture_fourn_det as f';
         $sql.= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON f.fk_product = p.rowid';
@@ -794,6 +796,10 @@ class FactureFournisseur extends CommonInvoice
                     $line->rang       		= $obj->rang;
                     $line->fk_unit          = $obj->fk_unit;
 
+					// Accountancy
+					$line->code_ventilation = $obj->fk_code_ventilation;
+					$line->fk_accounting_account	= $obj->fk_code_ventilation;
+					
 					// Multicurrency
 					$line->fk_multicurrency = $obj->fk_multicurrency;
 					$line->multicurrency_code = $obj->multicurrency_code;


### PR DESCRIPTION
Add accountancy informations in supplier invoice line like customer invoice

# New : Add accountancy informations in supplier invoice line

On the display page of a supplier invoice, the patch adds the affected accounting account under the description line of each product. This behavior is already applied on customer invoices.

Sur la page d'affichage d'une facture fournisseur, le patch ajoute sous la ligne de description de chaque produit le compte compta affecté. Ce comportement est déjà appliqué sur les factures clients.

![image](https://user-images.githubusercontent.com/429449/94790010-be992100-03e6-11eb-958e-202401e1cf59.png)
