### PR TITLE
handle fk_origin for stock movement for users the core way

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -1002,6 +1002,10 @@ class MouvementStock extends CommonObject
 				require_once DOL_DOCUMENT_ROOT.'/mrp/class/mo.class.php';
 				$origin = new Mo($this->db);
 				break;
+			case 'user':
+				require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
+				$origin = new User($this->db);
+				break;
 
 			default:
 				if ($origintype)


### PR DESCRIPTION
when you create a stock movement connected to a user. The fk_origin will be `user` but core expects `user@user` like for a custom module.
This changes it and allows to show origins for users automatically