### PR TITLE
FIX: Default language overwritten on thirdparty edit/update

### DIFF
--- a/htdocs/core/class/html.formadmin.class.php
+++ b/htdocs/core/class/html.formadmin.class.php
@@ -125,6 +125,7 @@ class FormAdmin
 		{
 			include_once DOL_DOCUMENT_ROOT.'/core/lib/ajax.lib.php';
 			$out .= ajax_combobox($htmlname);
+			$out .= '<script>$(document).ready(function () { $("select#'.$htmlname.'").val($("select#'.$htmlname.'").children("[selected]").val()).trigger("change"); });</script>';
 		}
 
 		return $out;


### PR DESCRIPTION
Fixed an error where the selected default language would be ignored in the UI and overwritten on an update