### PR TITLE
FIX missing hook 'formConfirm' in 'addreplace' $hooktype

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -171,6 +171,7 @@ class HookManager
 				'formattachOptions',
 				'formBuilddocLineOptions',
 				'formatNotificationMessage',
+			    'formConfirm',
 				'getAccessForbiddenMessage',
 				'getDirList',
 				'getFormMail',


### PR DESCRIPTION
If several external modules use the "formConfirm" hook and the first module return 1 and the last return 0, the return code will be 0 which will create a side effect on the operation of the first module.
the $resprints of the first module will be concatenated with the global $formconfirm instead of replacing it