### PR TITLE
FIX Require Discount class on markAsCreditAvailable API method

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -997,7 +997,7 @@ class Invoices extends DolibarrApi
     public function markAsCreditAvailable($id)
     {
 		require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
-		
+
         if (!DolibarrApiAccess::$user->rights->facture->creer) {
             throw new RestException(401);
         }

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -996,6 +996,8 @@ class Invoices extends DolibarrApi
      */
     public function markAsCreditAvailable($id)
     {
+		require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
+		
         if (!DolibarrApiAccess::$user->rights->facture->creer) {
             throw new RestException(401);
         }


### PR DESCRIPTION
Hi!

Quick fix of a problem I encountered earlier when using `markAsCreditAvailable` API method for invoice routes.
The method was using the `DiscountAbsolute` class without importing it resulting in a 500 HTTP error.

I added a `require_once` of the `DiscountAbsolute` class within the `markAsCreditAvailable` method content.

Thanks!