### PR TITLE
Fix link the expense report in the accountancy

### DIFF
--- a/htdocs/accountancy/expensereport/list.php
+++ b/htdocs/accountancy/expensereport/list.php
@@ -217,6 +217,8 @@ if (strlen(trim($search_vat))) {
 $sql .= dolSqlDateFilter('erd.date', $search_day, $search_month, $search_year);
 $sql .= " AND er.entity IN (".getEntity('expensereport', 0).")"; // We don't share object for accountancy
 
+$sql .= ' GROUP BY erd.rowid ';
+
 $sql .= $db->order($sortfield, $sortorder);
 
 // Count total nb of records


### PR DESCRIPTION
For the bug ...
Cf ticket #14948 

Fix:
* I group on the expense report detail id
** If there is only one account it doesn't change for them (most of the cases)
** If there are multiple accounts for the same fee it will preselect the second account.



