### PR TITLE
Improved emailconfirmation of ticket module when you create a new ticket

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -170,8 +170,12 @@ if (empty($reshook)) {
 			$object->message = GETPOST("message", 'restricthtml');
 
 			$object->type_code = GETPOST("type_code", 'alpha');
+			$object->type_label = $langs->trans($langs->getLabelFromKey($db, $object->type_code, 'c_ticket_type', 'code', 'label'));
 			$object->category_code = GETPOST("category_code", 'alpha');
+			$object->category_label = $langs->trans($langs->getLabelFromKey($db, $object->category_code, 'c_ticket_category', 'code', 'label'));
 			$object->severity_code = GETPOST("severity_code", 'alpha');
+			$object->severity_label = $langs->trans($langs->getLabelFromKey($db, $object->severity_code, 'c_ticket_severity', 'code', 'label'));
+			$object->email_from = $user->email;
 			$notifyTiers = GETPOST("notify_tiers_at_create", 'alpha');
 			$object->notify_tiers_at_create = empty($notifyTiers) ? 0 : 1;
 

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -142,6 +142,26 @@ class Ticket extends CommonObject
 	 */
 	public $severity_code;
 
+    /**
+     * Type label
+     */
+    public $type_label;
+
+    /**
+     * Category label
+     */
+    public $category_label;
+
+    /**
+     * Severity label
+     */
+    public $severity_label;
+
+        /**
+     * Email from user
+     */
+    public $email_from;
+
 	/**
 	 * @var int Création date
 	 */


### PR DESCRIPTION
# Fix email fields when creating new ticket

**Userstory**
As a user I want to send a correct email when I create a new ticket.

**Details**
These fields in the email are fixed by adding label values of fields in card.php and ticket.class.php:
•	Type : _Change or enhancement request_
•	Category : _Other_
•	Priority: _High_
•	From: _user@domain.com_

Please consider to merge these code or suggest how to improve to fix this issue.

kind regeards,
Hans
Dolisupport.nl