### PR TITLE
Fix for #14957 and probably a lot of other issues

### DIFF
--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -156,6 +156,7 @@ class Odf
      */
 	public function convertVarToOdf($value, $encode = true, $charset = 'ISO-8859')
 	{
+		$value = $encode ? htmlspecialchars($value) : $value;
 		$value = ($charset == 'ISO-8859') ? utf8_encode($value) : $value;
 		$convertedValue = $value;
 


### PR DESCRIPTION
Convert special characters for a valid use in xml documents

# Fix #14957 
Some special characters have to be converted before creating an xml document. Otherwise the document will become invalid and the resulting odt will not be usable.

