### PR TITLE
Fix for #14957 and probably a lot of other issues

### DIFF
--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -141,6 +141,7 @@ class Odf
 			//}
 		}
 
+		$value = $encode ? htmlspecialchars($value) : $value;
 		$value = ($charset == 'ISO-8859') ? utf8_encode($value) : $value;
 
 		// Check if the value includes html tags


### PR DESCRIPTION
# Fix #14957 
Some special characters have to be converted before creating an xml document. Otherwise the document will become invalid and the resulting odt will not be usable.
