### PR TITLE
Fix for #14239 / Method printObjectLine was called on an object and object->fetch_thirdparty was not done before

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1863,6 +1863,7 @@ if ($action == 'create' && $usercancreate)
 		$author = new User($db);
 		$author->fetch($object->user_author_id);
 
+		$object->fetch_thirdparty();
 		$res = $object->fetch_optionals();
 
 		$head = commande_prepare_head($object);


### PR DESCRIPTION
# Fix #14239 
Make a call to $object->fetch_thirdparty() before any call to printObjectLine in view mode
