### PR TITLE
how to see draft stats if we exclude them

### DIFF
--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -79,6 +79,7 @@ class PropaleStats extends Stats
     		$this->field = 'total_ht';
     		$this->field_line = 'total_ht';
 
+			// how to see draft stats if we exclude them ???
     		$this->where .= " p.fk_statut > 0";
         }
         if ($mode == 'supplier')


### PR DESCRIPTION
they may be excluded only for total, not for global stats
the same mistake for quotation and orders
