### PR TITLE
fix Call to undefined method Form::formTransportMode()

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2665,10 +2665,10 @@ if ($action == 'create')
         print '</td><td colspan="2">';
         if ($action == 'editmode')
         {
-            $form->formTransportMode($_SERVER['PHP_SELF'].'?id='.$object->id, $object->transport_mode_id, 'transport_mode_id', 1, 1);
+            $form->formSelectTransportMode($_SERVER['PHP_SELF'].'?id='.$object->id, $object->transport_mode_id, 'transport_mode_id', 1, 1);
         }
         else {
-            $form->formTransportMode($_SERVER['PHP_SELF'].'?id='.$object->id, $object->transport_mode_id, 'none');
+            $form->formSelectTransportMode($_SERVER['PHP_SELF'].'?id='.$object->id, $object->transport_mode_id, 'none');
         }
         print '</td></tr>';
 


### PR DESCRIPTION

# Fix #[Call to undefined method Form::formTransportMode()]
[Fatal error: Uncaught Error: Call to undefined method Form::formTransportMode() in /home/httpd/vhosts/atoo-net.com/domains/../httpdocs/fourn/facture/card.php on line 2671]


