### PR TITLE
new:handle new type reference in add and update actions

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -76,7 +76,8 @@ if ($action == 'add' && !empty($permissiontoadd))
 		} elseif ($object->fields[$key]['type'] == 'boolean') {
 			$value = (GETPOST($key) == '1' ? 1 : 0);
 		} elseif ($object->fields[$key]['type'] == 'reference') {
-			$value = array_keys($object->param_list)[GETPOST($key)].','.GETPOST($key.'2');
+			$tmparraykey = array_keys($object->param_list);
+			$value = $tmparraykey[GETPOST($key)].','.GETPOST($key.'2');
 		} else {
 			$value = GETPOST($key, 'alphanohtml');
 		}

--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -74,7 +74,9 @@ if ($action == 'add' && !empty($permissiontoadd))
 		} elseif (preg_match('/^(integer|price|real|double)/', $object->fields[$key]['type'])) {
 			$value = price2num(GETPOST($key, 'alphanohtml')); // To fix decimal separator according to lang setup
 		} elseif ($object->fields[$key]['type'] == 'boolean') {
-			$value = ((GETPOST($key) == '1' || GETPOST($key) == 'on') ? 1 : 0);
+			$value = (GETPOST($key) == '1' ? 1 : 0);
+		} elseif ($object->fields[$key]['type'] == 'reference') {
+			$value = array_keys($object->param_list)[GETPOST($key)].','.GETPOST($key.'2');
 		} else {
 			$value = GETPOST($key, 'alphanohtml');
 		}
@@ -161,7 +163,9 @@ if ($action == 'update' && !empty($permissiontoadd))
 		} elseif (preg_match('/^(integer|price|real|double)/', $object->fields[$key]['type'])) {
 			$value = price2num(GETPOST($key, 'alphanohtml')); // To fix decimal separator according to lang setup
 		} elseif ($object->fields[$key]['type'] == 'boolean') {
-			$value = ((GETPOST($key, 'aZ09') == 'on' || GETPOST($key, 'aZ09') == '1') ? 1 : 0);
+			$value = (GETPOST($key) == '1' ? 1 : 0);
+		} elseif ($object->fields[$key]['type'] == 'reference') {
+			$value = array_keys($object->param_list)[GETPOST($key)].','.GETPOST($key.'2');
 		} else {
 			$value = GETPOST($key, 'alpha');
 		}

--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -164,7 +164,7 @@ if ($action == 'update' && !empty($permissiontoadd))
 		} elseif (preg_match('/^(integer|price|real|double)/', $object->fields[$key]['type'])) {
 			$value = price2num(GETPOST($key, 'alphanohtml')); // To fix decimal separator according to lang setup
 		} elseif ($object->fields[$key]['type'] == 'boolean') {
-			$value = (GETPOST($key) == '1' ? 1 : 0);
+			$value = ((GETPOST($key, 'aZ09') == 'on' || GETPOST($key, 'aZ09') == '1') ? 1 : 0);
 		} elseif ($object->fields[$key]['type'] == 'reference') {
 			$value = array_keys($object->param_list)[GETPOST($key)].','.GETPOST($key.'2');
 		} else {

--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -74,7 +74,7 @@ if ($action == 'add' && !empty($permissiontoadd))
 		} elseif (preg_match('/^(integer|price|real|double)/', $object->fields[$key]['type'])) {
 			$value = price2num(GETPOST($key, 'alphanohtml')); // To fix decimal separator according to lang setup
 		} elseif ($object->fields[$key]['type'] == 'boolean') {
-			$value = (GETPOST($key) == '1' ? 1 : 0);
+			$value = ((GETPOST($key) == '1' || GETPOST($key) == 'on') ? 1 : 0);
 		} elseif ($object->fields[$key]['type'] == 'reference') {
 			$tmparraykey = array_keys($object->param_list);
 			$value = $tmparraykey[GETPOST($key)].','.GETPOST($key.'2');


### PR DESCRIPTION
The type reference ( standard odoo object type) is a compostion of an object name and an id separated by a comma. Examples are :"user,1" or "product,20". This code needs to be included in this core file. Other code handling this object type is inserted in the modulebuilder generated files. It should be inserted in modulebuilder prototype files in the future.