### PR TITLE
FIX: Unable to edit extrafields in expense report

### DIFF
--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2015 		Alexandre Spangaro  	<aspangaro@open-dsi.fr>
  * Copyright (C) 2018       Nicolas ZABOURI         <info@inovea-conseil.com>
  * Copyright (c) 2018       Frédéric France         <frederic.france@netlogic.fr>
- * Copyright (C) 2016-2018 	Ferran Marcet       	<fmarcet@2byte.es>
+ * Copyright (C) 2016-2020 	Ferran Marcet       	<fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -537,6 +537,8 @@ class ExpenseReport extends CommonObject
                 $this->libelle_paiement = $obj->libelle_paiement;
                 $this->code_statut      = $obj->code_statut;
                 $this->code_paiement    = $obj->code_paiement;
+
+				$this->fetch_optionals();
 
                 $this->lines = array();
 


### PR DESCRIPTION
Extrafields were not loaded in the fetch function and could not be edited (editing one would lose the rest)
