### PR TITLE
FIX : Use table_element instead of element

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -1748,7 +1748,7 @@ function addFileIntoDatabaseIndex($dir, $file, $fullpathorig = '', $mode = 'uplo
 
         if (is_object($object) && $object->id > 0) {
             $ecmfile->src_object_id = $object->id;
-            $ecmfile->src_object_type = $object->element;
+            $ecmfile->src_object_type = $object->table_element;
         }
 
 		if ($setsharekey)


### PR DESCRIPTION
# Fix use table_element instead of element
I made a little mistake in my previous PR.
Indeed in the commonGenerateDocument function, it's the "table_element" property which is used to fill the "src_object_type" ecm field, so i remplace "element" by "table_element" where i used it.
https://github.com/Dolibarr/dolibarr/blob/f33688bd0cd5265b16efe99723149b4cb17503e2/htdocs/core/class/commonobject.class.php#L4689
