### PR TITLE
Specify window size for tests run

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -20,7 +20,7 @@ module.exports = {
 				chromeOptions : {
 					args : ['disable-gpu', 'window-size=1280,1024'],
 					w3c : false
-				},
+				}
 			}
 		}
 	}

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -18,9 +18,9 @@ module.exports = {
 				browserName : 'chrome',
 				javascriptEnabled : true,
 				chromeOptions : {
-					args : ['disable-gpu'],
+					args : ['disable-gpu', 'window-size=1280,1024'],
 					w3c : false
-				}
+				},
 			}
 		}
 	}

--- a/test/acceptance/pageObjects/loginPage.js
+++ b/test/acceptance/pageObjects/loginPage.js
@@ -26,7 +26,8 @@ module.exports = {
 			},
 
 			userIsLoggedIn: async function (login) {
-				await this.useXpath()
+				await this.waitForElementNotPresent('@loginTable')
+					.useXpath()
 					.waitForElementVisible('@userLogin')
 					.expect.element('@userLogin')
 					.text.to.equal(login);

--- a/test/acceptance/setup.js
+++ b/test/acceptance/setup.js
@@ -30,7 +30,7 @@ Before(async function getDolApiKey() {
 	const params = new URLSearchParams()
 	params.set('login', adminUsername)
 	params.set('password', adminPassword)
-	const apiKey = `http://localhost/dolibarr/htdocs/api/index.php/login?${params.toString()}`;
+	const apiKey = client.globals.backend_url + `api/index.php/login?${params.toString()}`;
 	header['Accept'] = 'application/json'
 	await fetch(apiKey, {
 		method: 'GET',

--- a/test/acceptance/stepDefinitions/addUsersContext.js
+++ b/test/acceptance/stepDefinitions/addUsersContext.js
@@ -5,12 +5,6 @@ const assert = require('assert');
 let response;
 let Login = {};
 
-Given('the administrator has logged in using the webUI', async function () {
-    await client.page.loginPage().navigate().waitForLoginPage();
-    await client.page.loginPage().userLogsInWithUsernameAndPassword(client.globals.adminUsername, client.globals.adminPassword);
-    return client.page.loginPage().userIsLoggedIn(client.globals.adminUsername);
-});
-
 Given('the administrator has browsed to the new users page', function () {
     return client.page.homePage().browsedToNewUserPage();
 });

--- a/test/acceptance/stepDefinitions/loginContext.js
+++ b/test/acceptance/stepDefinitions/loginContext.js
@@ -1,6 +1,12 @@
 const { Given, When, Then } = require('cucumber')
 const { client } = require('nightwatch-api')
 
+Given('the administrator has logged in using the webUI', async function () {
+	await client.page.loginPage().navigate().waitForLoginPage();
+	await client.page.loginPage().userLogsInWithUsernameAndPassword(client.globals.adminUsername, client.globals.adminPassword);
+	return client.page.loginPage().userIsLoggedIn(client.globals.adminUsername);
+});
+
 Given('the user has browsed to the login page', function () {
 	return client.page.loginPage().navigate();
 });


### PR DESCRIPTION
## Description:
In this PR, the default window-size for tests run is specified in the nighwatch configuration file.

Additionally, the admin login step definition which was placed in the addUsersContext file is moved to the loginContext file to make the tests uniform and maintainable.

## Related Issue:
The window-size is specified as a response to the comment: https://github.com/Dolibarr/dolibarr/pull/15024#issuecomment-709000664
