### PR TITLE
fix the filters on the restock

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4844,7 +4844,7 @@ class Product extends CommonObject
         $sql .= ", ".MAIN_DB_PREFIX."entrepot as w";
         $sql .= " WHERE w.entity IN (".getEntity('stock').")";
         $sql .= " AND w.rowid = ps.fk_entrepot";
-        if($warehouseId > 0){
+        if ($warehouseId > 0) {
             $sql .= " AND w.rowid = ".$warehouseId;
         }
         $sql .= " AND ps.fk_product = ".$this->id;

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4812,10 +4812,13 @@ class Product extends CommonObject
      *
      * @param  	string 	$option 					'' = Load all stock info, also from closed and internal warehouses, 'nobatch', 'novirtual'
      * @param	int		$includedraftpoforvirtual	Include draft status of PO for virtual stock calculation
+     * @param	int		$warehouseId    filter on the warehouse ID
+     *
      * @return 	int                  				< 0 if KO, > 0 if OK
+     * s
      * @see    	load_virtual_stock(), loadBatchInfo()
      */
-    public function load_stock($option = '', $includedraftpoforvirtual = null)
+    public function load_stock($option = '', $includedraftpoforvirtual = null, $warehouseId = 0)
     {
         // phpcs:enable
         global $conf;
@@ -4841,6 +4844,9 @@ class Product extends CommonObject
         $sql .= ", ".MAIN_DB_PREFIX."entrepot as w";
         $sql .= " WHERE w.entity IN (".getEntity('stock').")";
         $sql .= " AND w.rowid = ps.fk_entrepot";
+        if($warehouseId > 0){
+            $sql .= " AND w.rowid = ".$warehouseId;
+        }
         $sql .= " AND ps.fk_product = ".$this->id;
         if ($conf->global->ENTREPOT_EXTRA_STATUS && count($warehouseStatus)) {
 			$sql .= " AND w.statut IN (".$this->db->escape(implode(',', $warehouseStatus)).")";

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4812,10 +4812,8 @@ class Product extends CommonObject
      *
      * @param  	string 	$option 					'' = Load all stock info, also from closed and internal warehouses, 'nobatch', 'novirtual'
      * @param	int		$includedraftpoforvirtual	Include draft status of PO for virtual stock calculation
-     * @param	int		$warehouseId    filter on the warehouse ID
-     *
+     * @param	int		$warehouseId    			filter on the warehouse ID
      * @return 	int                  				< 0 if KO, > 0 if OK
-     * s
      * @see    	load_virtual_stock(), loadBatchInfo()
      */
     public function load_stock($option = '', $includedraftpoforvirtual = null, $warehouseId = 0)

--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -322,7 +322,7 @@ $reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters); // N
 $sql .= $hookmanager->resPrint;
 
 $sql .= ' FROM '.MAIN_DB_PREFIX.'product as p';
-$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_stock as s ON p.rowid = s.fk_product';
+$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_stock as s ON p.rowid = s.fk_product '.((!empty($conf->global->STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE) && $fk_entrepot > 0) ? ' AND s.fk_entrepot = '.$fk_entrepot : '');
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'entrepot AS ent ON s.fk_entrepot = ent.rowid AND ent.entity IN('.getEntity('stock').')';
 if ($fk_supplier > 0) {
 	$sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'product_fournisseur_price pfp ON (pfp.fk_product = p.rowid AND pfp.fk_soc = '.$fk_supplier.')';
@@ -655,7 +655,7 @@ while ($i < ($limit ? min($num, $limit) : $num))
 	if (!empty($conf->global->STOCK_SUPPORTS_SERVICES) || $objp->fk_product_type == 0)
 	{
 		$prod->fetch($objp->rowid);
-		$prod->load_stock('warehouseopen, warehouseinternal', $draftchecked);
+		$prod->load_stock('warehouseopen, warehouseinternal', $draftchecked, $fk_entrepot);
 
 		// Multilangs
 		if (!empty($conf->global->MAIN_MULTILANGS))


### PR DESCRIPTION
# Bug
The physical stock doesn't take into account the filter of the warehouse when we do a restock order. (product/stock/replenish.php).

# Fix
Ticket : #15002 

To fix this issue I had to add the usage of the "fk_entrepot" two more times:
* One in the query because there too, the row won't be visible if the number of the items is lower than the alert
* The second time is in the computation of the stock.

## Special test case
I think the ticket is explicit enough, to reproduce the issue. The only issue that is not listed in the ticket is this one.
Imagine:
* Stock 1
    * Product 1
        * Qty : 2
        * Alert : 8
* Stock 2
    * Product 1
        * Qty : 4
        * Alert: 6

By the old code, the row won't be visible for the filter: _stock2_ because 4+2 < 6 is false. But since we filtered on the second stock so the real stock is not 4 +2 but only 4. 4 is lower than 6.


