### PR TITLE
NEW add alert before change thirdparty in takepos

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -610,6 +610,10 @@ if (!empty($type))
 	if ($type == 'f') $label = 'NewSupplier';
 }
 
+if ($contextpage = 'poslist' && ( !empty($conf->global->PRODUIT_MULTIPRICES) || !empty($conf->global->PRODUIT_CUSTOMER_PRICES) || !empty($conf->global->PRODUIT_CUSTOMER_PRICES_BY_QTY_MULTIPRICES))) {
+print get_htmloutput_mesg(img_warning('default') . ' ' . $langs->trans("BecarefullChangeThirdpartyBeforeAddProductToInvoice"), '', 'warning', 1);
+}
+
 // Show the new button only when this page is not opend from the Extended POS (pop-up window)
 // but allow it too, when a user has the rights to create a new customer
 if ($contextpage != 'poslist')

--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -611,7 +611,7 @@ if (!empty($type))
 }
 
 if ($contextpage = 'poslist' && ( !empty($conf->global->PRODUIT_MULTIPRICES) || !empty($conf->global->PRODUIT_CUSTOMER_PRICES) || !empty($conf->global->PRODUIT_CUSTOMER_PRICES_BY_QTY_MULTIPRICES))) {
-print get_htmloutput_mesg(img_warning('default') . ' ' . $langs->trans("BecarefullChangeThirdpartyBeforeAddProductToInvoice"), '', 'warning', 1);
+	print get_htmloutput_mesg(img_warning('default') . ' ' . $langs->trans("BecarefullChangeThirdpartyBeforeAddProductToInvoice"), '', 'warning', 1);
 }
 
 // Show the new button only when this page is not opend from the Extended POS (pop-up window)


### PR DESCRIPTION
With some prices rules, change thirdparty should only done before add products to draft invoice.
We can't block it but display an alert can be done for users