### PR TITLE
Fix: Missing address information in ODT-Generation

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1574,12 +1574,20 @@ class Facture extends CommonInvoice
 				$this->close_code			= $obj->close_code;
 				$this->close_note			= $obj->close_note;
 
-				$this->socid = $obj->fk_soc;
-				$this->thirdparty = null; // Clear if another value was already set by fetch_thirdparty
-
-				$this->fk_project = $obj->fk_project;
-				$this->project = null; // Clear if another value was already set by fetch_projet
-
+				if ($this->socid != $obj->fk_soc) {
+					$this->socid = $obj->fk_soc;
+					if (isset($this->thirdparty)) {
+						$this->fetch_thirdparty();
+					}
+				}
+				
+				if ($this->fk_project != $obj->fk_project) {
+					$this->fk_project = $obj->fk_project;
+					if (isset($this->project)) {
+						$this->fetch_projet();
+					}
+				}
+				
 				$this->statut = $obj->fk_statut;
 				$this->date_lim_reglement = $this->db->jdate($obj->dlr);
 				$this->mode_reglement_id	= $obj->fk_mode_reglement;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1580,14 +1580,14 @@ class Facture extends CommonInvoice
 						$this->fetch_thirdparty();
 					}
 				}
-				
+
 				if ($this->fk_project != $obj->fk_project) {
 					$this->fk_project = $obj->fk_project;
 					if (isset($this->project)) {
 						$this->fetch_projet();
 					}
 				}
-				
+
 				$this->statut = $obj->fk_statut;
 				$this->date_lim_reglement = $this->db->jdate($obj->dlr);
 				$this->mode_reglement_id	= $obj->fk_mode_reglement;


### PR DESCRIPTION
# Fix #14979 ODT generation not working when validating invoice

At several locations in the code it is expected that if thirdparty has been fetched before it won't "forget" its values if the object is being fetched for another time. Setting members to null results in missing address or project information where it might be needed.
As an example ODT documents created for invoices won't have their needed recipient information.

See #14979 
See https://www.dolibarr.org/forum/t/error-when-creating-documents/19640
Probably there are other bug reports concerning this issue.

This is also problematic with other classes for business transactions like proposals, orders etc.. Actually I would prefer to create setters and getters for this kind of class members. It might even be better to put all this setter/getter-stuff into **one** common parent class to prevent copying code over all these classes. However, it looks like that the only class in question would be _CommonObject_, which is not only for business transactions but also for other objects like societies and so on.

Wouldn't it make sense to have a class hierarchy like the following?

```
CommonObject 
  CommonTransaction 
    CommonInvoice
      Invoice
    CommonProposal
      Proposal
    CommonOrder
      Order
...
```

In this case we just had to create common setters or getters inside CommonTransaction and all child classes would benefit from any changes...

