### PR TITLE
CLOSE #15065 Put the product label in bold in the PDF templates if co…

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1278,8 +1278,12 @@ function pdf_getlinedesc($object, $i, $outputlangs, $hideref = 0, $hidedesc = 0,
 
 	// Description short of product line
 	$libelleproduitservice = $label;
+        if (!empty($libelleproduitservice) && !empty($conf->global->PDF_BOLD_PRODUCT_LABEL))
+        {
+            $libelleproduitservice = '<b>'.$libelleproduitservice.'</b>';
+        }
 
-	// Description long of product line
+        // Description long of product line
 	if (!empty($desc) && ($desc != $label))
 	{
 		if ($libelleproduitservice && empty($hidedesc))

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1278,12 +1278,11 @@ function pdf_getlinedesc($object, $i, $outputlangs, $hideref = 0, $hidedesc = 0,
 
 	// Description short of product line
 	$libelleproduitservice = $label;
-        if (!empty($libelleproduitservice) && !empty($conf->global->PDF_BOLD_PRODUCT_LABEL))
-        {
-            $libelleproduitservice = '<b>'.$libelleproduitservice.'</b>';
-        }
+	if (!empty($libelleproduitservice) && !empty($conf->global->PDF_BOLD_PRODUCT_LABEL)) {
+		$libelleproduitservice = '<b>' . $libelleproduitservice . '</b>';
+	}
 
-        // Description long of product line
+	// Description long of product line
 	if (!empty($desc) && ($desc != $label))
 	{
 		if ($libelleproduitservice && empty($hidedesc))


### PR DESCRIPTION
# Close #15065 Put the product label in bold in the PDF templates if configured
The global configuration variable PDF_BOLD_PRODUCT_LABEL is checked to put the product label in bold in the PDF
templates.
This modification is based on the same behaviour for the product reference, found at line 1373 of the same file.

The products table of the invoices / commercial propositions is produced in the PDF library, hence we have to modify
this library to style the invoices.
Producing a new template would mean duplicating code from the library with the maintenace implications.
