### PR TITLE
FIX 9.0 - when users create an event from a supplier proposal, the "linked objects" section says "Deleted"

### DIFF
--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1872,6 +1872,12 @@ function dolGetElementUrl($objectid,$objecttype,$withpicto=0,$option='')
 		$classpath = 'fourn/class';
 		$module='fournisseur';
 	}
+	elseif ($objecttype == 'supplier_proposal') {
+		$classfile = 'supplier_proposal';
+		$classname = 'SupplierProposal';
+		$classpath = 'supplier_proposal/class';
+		$module = 'supplier_proposal';
+	}
 	elseif ($objecttype == 'stock')   {
 		$classpath = 'product/stock/class';
 		$classfile='entrepot';


### PR DESCRIPTION
# Issue
When a user creates a new event from a supplier proposal, the event should be linked with the supplier proposal automatically. Instead, the user sees "Deleted" because the supplier proposal is incorrectly fetched.

# Fix
This fix adds a name mapping to `dolGetElementUrl()` in `functions2.lib.php` so that it fetches supplier proposals correctly.

# Note
This bug is still there in v12.0.