### PR TITLE
12.0 fix display field on page load & admin conf

### DIFF
--- a/htdocs/admin/facture_situation.php
+++ b/htdocs/admin/facture_situation.php
@@ -104,7 +104,7 @@ $arrayAvailableType = array(
 	Facture::TYPE_SITUATION => $langs->trans("InvoiceSituation"),
 	Facture::TYPE_STANDARD.'+'.Facture::TYPE_SITUATION => $langs->trans("InvoiceSituation").' + '.$langs->trans("InvoiceStandard"),
 );
-$selected = $conf->global->{$confkey};
+$selected = $conf->global->$confkey;
 $curentInput = (empty($inputCount) ? 1 : ($inputCount + 1));
 $formSelectInvoiceType = $form->selectarray('value'.$curentInput, $arrayAvailableType, $selected, 1);
 _printInputFormPart($confkey, $langs->trans('AllowedInvoiceForRetainedWarranty'), '', array(), $formSelectInvoiceType);

--- a/htdocs/admin/facture_situation.php
+++ b/htdocs/admin/facture_situation.php
@@ -104,12 +104,7 @@ $arrayAvailableType = array(
 	Facture::TYPE_SITUATION => $langs->trans("InvoiceSituation"),
 	Facture::TYPE_STANDARD.'+'.Facture::TYPE_SITUATION => $langs->trans("InvoiceSituation").' + '.$langs->trans("InvoiceStandard"),
 );
-$selected = array();
-$implodeglue = '+';
-if (!empty($conf->global->{$confkey}) && !is_array($conf->global->{$confkey})) {
-	$selected = explode('+', $conf->global->{$confkey});
-}
-
+$selected = $conf->global->{$confkey};
 $curentInput = (empty($inputCount) ? 1 : ($inputCount + 1));
 $formSelectInvoiceType = $form->selectarray('value'.$curentInput, $arrayAvailableType, $selected, 1);
 _printInputFormPart($confkey, $langs->trans('AllowedInvoiceForRetainedWarranty'), '', array(), $formSelectInvoiceType);

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3497,7 +3497,7 @@ if ($action == 'create')
 				}
 			});
 
-			$("[name=\'type\']").trigger("change");
+			$("[name=\'type\']:checked").trigger("change");
 		});
 		</script>';
 	}


### PR DESCRIPTION
# FIX

- Fix : On invoice creation page, retained warranty fields weren't displayed when user comme from a situation invoice.
- Fix : On situation invoice page, the select form for "allowed invoice for retained warranty" is no longer a multi select so dont use an array