### PR TITLE
New/currency rate editor

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5117,7 +5117,7 @@ class Form
 	 * @param bool $excludeConfCurrency false  = If company current currency not in table, we add it into list. Should always be available.  true = we are in currency_rate update , we don't want to see conf->currency in select
 	 * @return    string
 	 */
-	public function selectMultiCurrency($selected = '', $htmlname = 'multicurrency_code', $useempty = 0, $filter = '',$excludeConfCurrency = false)
+	public function selectMultiCurrency($selected = '', $htmlname = 'multicurrency_code', $useempty = 0, $filter = '', $excludeConfCurrency = false)
 	{
 		global $db, $conf, $langs, $user;
 
@@ -5137,8 +5137,8 @@ class Form
 		$out = '';
 		$out .= '<select class="flat" name="'.$htmlname.'" id="'.$htmlname.'">';
 		if ($useempty) $out .= '<option value="">&nbsp;</option>';
-		// If company current currency not in table, we add it into list. Should always be available.
-		if (!in_array($conf->currency, $TCurrency))
+		// If company current currency not in table, we add it into list. Should always be available. except if we are in currency_rate update
+		if (!in_array($conf->currency, $TCurrency) && !$excludeConfCurrency)
 		{
 			$TCurrency[$conf->currency] = $conf->currency;
 		}

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5108,14 +5108,16 @@ class Form
 	}
 
 	/**
-	 *	Return array of currencies in user language
+	 *    Return array of currencies in user language
 	 *
-	 *  @param	string	$selected    preselected currency code
-	 *  @param  string	$htmlname    name of HTML select list
-	 *  @param  integer	$useempty    1=Add empty line
-	 * 	@return	string
+	 * @param string $selected preselected currency code
+	 * @param string $htmlname name of HTML select list
+	 * @param integer $useempty 1=Add empty line
+	 * @param string $filter Optional filters criteras (example: 'code <> x', ' in (1,3)')
+	 * @param bool $excludeConfCurrency false  = If company current currency not in table, we add it into list. Should always be available.  true = we are in currency_rate update , we don't want to see conf->currency in select
+	 * @return    string
 	 */
-    public function selectMultiCurrency($selected = '', $htmlname = 'multicurrency_code', $useempty = 0)
+	public function selectMultiCurrency($selected = '', $htmlname = 'multicurrency_code', $useempty = 0, $filter= '',$excludeConfCurrency = false)
 	{
 		global $db, $conf, $langs, $user;
 
@@ -5125,6 +5127,7 @@ class Form
 
 		$sql = 'SELECT code FROM '.MAIN_DB_PREFIX.'multicurrency';
 		$sql .= " WHERE entity IN ('".getEntity('mutlicurrency')."')";
+		if ($filter) $sql .= " AND ".$filter;
 		$resql = $db->query($sql);
 		if ($resql)
 		{

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5117,7 +5117,7 @@ class Form
 	 * @param bool $excludeConfCurrency false  = If company current currency not in table, we add it into list. Should always be available.  true = we are in currency_rate update , we don't want to see conf->currency in select
 	 * @return    string
 	 */
-	public function selectMultiCurrency($selected = '', $htmlname = 'multicurrency_code', $useempty = 0, $filter= '',$excludeConfCurrency = false)
+	public function selectMultiCurrency($selected = '', $htmlname = 'multicurrency_code', $useempty = 0, $filter = '',$excludeConfCurrency = false)
 	{
 		global $db, $conf, $langs, $user;
 

--- a/htdocs/core/lib/multicurrency.lib.php
+++ b/htdocs/core/lib/multicurrency.lib.php
@@ -40,6 +40,11 @@ function multicurrencyAdminPrepareHead()
     $head[$h][2] = 'settings';
     $h++;
 
+	$head[$h][0] = dol_buildpath("/multicurrency/multicurrency_rate.php", 1);
+	$head[$h][1] = $langs->trans("TabTitleMulticurrencyRate");
+	$head[$h][2] = 'ratelist';
+	$h++;
+
     complete_head_from_modules($conf, $langs, null, $head, $h, 'multicurrency');
 
     return $head;

--- a/htdocs/langs/fr_FR/multicurrency.lang
+++ b/htdocs/langs/fr_FR/multicurrency.lang
@@ -18,3 +18,21 @@ MulticurrencyReceived=Reçu, devise originale
 MulticurrencyRemainderToTake=Montant restant, devise d'origine
 MulticurrencyPaymentAmount=Montant du règlement (devise d'origine)
 AmountToOthercurrency=Montant destination (en devise du compte de réception)
+TabTitleMulticurrencyRate = liste des Taux
+No_record_on_multicurrency_rate=Pas d'enregistrement dans la table multicurrency_rate
+ListCurrencyRate=liste des taux de change pour la devise
+CreateRate=créer un taux
+FormCreateRate=formulaire de création de taux
+FormUpdateRate=Modification de taux
+successRateCreate=Taux pour la devise %s a été ajouté à la base de donnée
+ConfirmDeleteLineRate=Êtes-vous sûr de vouloir supprimer le taux %s pour la devise %s à la date du %s ?
+DeleteLineRate=Effacer Taux
+successRateDelete= Taux supprimé
+errorRateDelete= Erreur lors de la suppression du taux
+successUpdateRate=Modification effectuée
+ErrorUpdateRate=Erreur lors de la modification du taux
+Codemulticurrency=code devise
+UpdateRate=modifier le taux
+CancelUpdate=annuler
+
+

--- a/htdocs/multicurrency/class/multicurrency.class.php
+++ b/htdocs/multicurrency/class/multicurrency.class.php
@@ -763,7 +763,7 @@ class CurrencyRate extends CommonObjectLine
 		$error = 0;
 		$this->rate = price2num($this->rate);
 		if (empty($this->entity) || $this->entity <= 0) $this->entity = $conf->entity;
-		$now = date('Y-m-d H:i:s');
+		$now = !empty($this->date_sync) ? $this->date_sync : date('Y-m-d H:i:s');
 
 		// Insert request
 		$sql = 'INSERT INTO '.MAIN_DB_PREFIX.$this->table_element.'(';

--- a/htdocs/multicurrency/multicurrency_rate.php
+++ b/htdocs/multicurrency/multicurrency_rate.php
@@ -1,0 +1,552 @@
+<?php
+/* Copyright (C) 2001-2006  Rodolphe Quiedeville    <rodolphe@quiedeville.org>
+ * Copyright (C) 2004-2018  Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2005-2012  Regis Houssin           <regis.houssin@capnetworks.com>
+ * Copyright (C) 2012-2016  Marcos García           <marcosgdf@gmail.com>
+ * Copyright (C) 2013-2019	Juanjo Menent           <jmenent@2byte.es>
+ * Copyright (C) 2013-2015  Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
+ * Copyright (C) 2013       Jean Heimburger         <jean@tiaris.info>
+ * Copyright (C) 2013       Cédric Salvador         <csalvador@gpcsolutions.fr>
+ * Copyright (C) 2013       Florian Henry           <florian.henry@open-concept.pro>
+ * Copyright (C) 2013       Adolfo segura           <adolfo.segura@gmail.com>
+ * Copyright (C) 2015       Jean-François Ferry     <jfefe@aternatik.fr>
+ * Copyright (C) 2016       Ferran Marcet		    <fmarcet@2byte.es>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *  \file       htdocs/multicurrency/multicurrency_rate.php
+ *  \ingroup    multicurrency
+ *  \brief      Page to list multicurrency rate
+ */
+
+require '../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/multicurrency.lib.php';
+
+// Load translation files required by the page
+$langs->loadLangs(array('multicurrency'));
+
+$action				= GETPOST('action','alpha');
+$massaction			= GETPOST('massaction','alpha');
+$show_files			= GETPOST('show_files','int');
+$confirm			= GETPOST('confirm','alpha');
+$toselect 			= GETPOST('toselect', 'array');
+$id_rate_selected 	= GETPOST('id_rate');
+$sall				= trim((GETPOST('search_all', 'alphanohtml')!='')?GETPOST('search_all', 'alphanohtml'):GETPOST('sall', 'alphanohtml'));
+$search_date_sync	= GETPOST("search_date_sync",'alpha');
+$search_rate		= GETPOST("search_rate",'alpha');
+$search_code		= GETPOST("search_code",'alpha');
+$multicurrency_code = GETPOST('multicurrency_code');
+$dateinput 			= GETPOST('dateinput','alpha');
+$rateinput 			= GETPOST('rateinput','int');
+$search_tobatch 	= GETPOST("search_tobatch",'int');
+$optioncss 			= GETPOST('optioncss','alpha');
+$limit 				= GETPOST('limit','int')?GETPOST('limit','int'):$conf->liste_limit;
+$sortfield 			= GETPOST("sortfield",'alpha');
+$sortorder 			= GETPOST("sortorder",'alpha');
+$page 				= (GETPOST("page",'int')?GETPOST("page", 'int'):0);
+
+if (empty($page) || $page == -1) { $page = 0; }     // If $page is not defined, or '' or -1
+$offset = $limit * $page;
+$pageprev = $page - 1;
+$pagenext = $page + 1;
+if (! $sortfield) $sortfield="cr.date_sync";
+if (! $sortorder) $sortorder="ASC";
+
+
+// Initialize technical object to manage hooks. Note that conf->hooks_modules contains array of hooks
+$object=new CurrencyRate($db);
+
+$extrafields = new ExtraFields($db);
+$form=new Form($db);
+
+if (empty($action)) $action='list';
+
+// List of fields to search into when doing a "search in all"
+$fieldstosearchall = array(
+	'cr.date_sync'=>"date_sync",
+	'cr.rate'=>"rate",
+	'm.code'=>"code",
+);
+
+// Definition of fields for lists
+$arrayfields=array(
+	'cr.date_sync'=>array('label'=>$langs->trans("date_sync"), 'checked'=>1),
+	'cr.rate'=>array('label'=>$langs->trans("rate"), 'checked'=>1),
+	'm.code'=>array('label'=>$langs->trans("code"), 'checked'=>1),
+);
+
+
+$object->fields = dol_sort_array($object->fields, 'position');
+$arrayfields = dol_sort_array($arrayfields, 'position');
+
+
+
+/*
+ * Actions
+ */
+if ($action == "create"){
+	$currencyRate_static = new CurrencyRate($db);
+	$currency_static  = new MultiCurrency($db);
+	$fk_currency = $currency_static->getIdFromCode($db,$multicurrency_code);
+
+	$currencyRate_static->fk_multicurrency = $fk_currency;
+	$currencyRate_static->entity = $conf->entity;
+	$currencyRate_static->date_sync = $dateinput;
+	$currencyRate_static->rate = $rateinput;
+
+	$result = $currencyRate_static->create(intval($fk_currency));
+	if ($result){
+		setEventMessage($langs->trans('successRateCreate',$multicurrency_code));
+	}else{
+		dol_syslog("currencyRate:createRate",LOG_WARNING);
+		setEventMessage($langs->trans('successRateCreate'));
+	}
+}
+
+if ($action == 'update'){
+	$currencyRate = new CurrencyRate($db);
+	$result = $currencyRate->fetch($id_rate_selected);
+	if ( $result > 0){
+		$currency_static  = new MultiCurrency($db);
+		$fk_currency = $currency_static->getIdFromCode($db,$multicurrency_code);
+		$currencyRate->date_sync = GETPOST('dateinput');
+		$currencyRate->fk_multicurrency = $fk_currency;
+		$currencyRate->rate = GETPOST('rateinput');
+		$res = $currencyRate->update();
+		if ($res){
+			setEventMessage($langs->trans('successUpdateRate'));
+		}else{
+			setEventMessage($langs->trans('errorUpdateRate'),"errors");
+		}
+	}else{
+		setEventMessage($langs->trans(''),"warnings");
+	}
+}
+
+if ($action == "deleteRate"){
+
+	$current_rate = new CurrencyRate($db);
+	$current_rate->fetch(intval($id_rate_selected));
+
+	if ($current_rate){
+		$current_currency = new MultiCurrency($db);
+		$current_currency->fetch($current_rate->fk_multicurrency);
+		if ($current_currency){
+			$delayedhtmlcontent .= $form->formconfirm(
+				$_SERVER["PHP_SELF"].'?id_rate='.$id_rate_selected,
+				$langs->trans('DeleteLineRate'),
+				$langs->trans('ConfirmDeleteLineRate',$current_rate->rate, $current_currency->name,$current_rate->date_sync),
+				'confirm_delete',
+				'',
+				0,
+				1
+			);
+		}else{
+			dol_syslog("Multicurrency::fetch",LOG_WARNING);
+		}
+	}else{
+		setEventMessage($langs->trans('NoCurrencyRateSelected'),"warnings");
+	}
+
+}
+
+if ($action == "confirm_delete"){
+	$current_rate = new CurrencyRate($db);
+	$current_rate->fetch(intval($id_rate_selected));
+	if ($current_rate){
+		$result  = $current_rate->delete();
+		if ($result){
+			setEventMessage($langs->trans('successRateDelete'));
+		}else{
+			setEventMessage($langs->trans('errorRateDelete'));
+
+		}
+	}else{
+		setEventMessage($langs->trans('NoCurrencyRateSelected'),"warnings");
+		dol_syslog($langs->trans('NoCurrencyRateSelected'),LOG_WARNING);
+	}
+
+}
+
+
+if (GETPOST('cancel','alpha')) { $action='list'; $massaction=''; }
+if (! GETPOST('confirmmassaction','alpha') && $massaction != 'presend' && $massaction != 'confirm_presend') { $massaction=''; }
+
+$parameters=array();
+$reshook=$hookmanager->executeHooks('doActions',$parameters, $object, $action);    // Note that $action and $object may have been modified by some hooks
+if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+if (empty($reshook))
+{
+	// Selection of new fields
+	include DOL_DOCUMENT_ROOT.'/core/actions_changeselectedfields.inc.php';
+
+	// Purge search criteria
+	if (GETPOST('button_removefilter_x','alpha') || GETPOST('button_removefilter.x','alpha') || GETPOST('button_removefilter','alpha')) // All tests are required to be compatible with all browsers
+	{
+		$sall="";
+		$search_date_sync="";
+		$search_rate="";
+		$search_code="";
+		$search_array_options=array();
+	}
+
+	// Mass actions
+	$objectclass="CurrencyRate";
+	$uploaddir = $conf->multicurrency->multidir_output; // define only because core/actions_massactions.inc.php want it
+	$permtoread = $user->admin;
+	$permtodelete = $user->admin;
+	include DOL_DOCUMENT_ROOT.'/core/actions_massactions.inc.php';
+}
+
+/*
+ * View
+ */
+
+$htmlother=new FormOther($db);
+
+$title=$langs->trans("CurrencyRate");
+$page_name = "ListCurrencyRate";
+
+llxHeader('',$title,$helpurl,'');
+// Subheader
+$linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php?restore_lastsearch_values=1">'.$langs->trans("BackToModuleList").'</a>';
+print load_fiche_titre($langs->trans($page_name), $linkback);
+
+// Configuration header
+$head = multicurrencyAdminPrepareHead();
+dol_fiche_head($head, 'ratelist', $langs->trans("ModuleSetup"), -1, "multicurrency");
+
+// ACTION
+
+if ($action!= "updateRate" && $action!= "deleteRate" ) {
+	print '<table class="noborder centpercent">';
+	print '<tr class="liste_titre">';
+	print '<td>'.$langs->trans("FormCreateRate").'</td>'."\n";
+	print '</tr></table>';
+
+	$form = new Form($db);
+	print '<form action="' . $_SERVER["PHP_SELF"] . '" method="post" name="formulaire">';
+	print '<table><tr>';
+
+	print ' <td>' . $langs->trans('date') . '</td>';
+	print ' <td><input class="minwidth200" name="dateinput" value="' . dol_escape_htmltag($dateinput) . '" type="date"></td>';
+
+	print ' <td>' . $langs->trans('Codemulticurrency') . '</td>';
+	print '<td>' . $form->selectMultiCurrency((GETPOSTISSET('multicurrency_code') ? GETPOST('multicurrency_code', 'alpha') : $multicurrency_code), 'multicurrency_code',0," code != '".$conf->currency."'",true) . '</td>';
+
+	print ' <td>' . $langs->trans('rate') . '</td>';
+	print ' <td><input class="minwidth200" name="rateinput" value="' . dol_escape_htmltag($rateinput) . '" type="text"></td>';
+
+	print '<td>';
+	print '<input type="hidden" name="action" value="create">';
+	print '<input type="submit" class="button" name="btnCreateCurrencyRate" value="' . $langs->trans('CreateRate') . '">';
+	print '</td>';
+
+	print '</tr></table>';
+	print '</form>';
+
+}
+
+if ($action == "updateRate"){
+
+	$current_rate = new CurrencyRate($db);
+	$current_rate->fetch(intval($id_rate_selected));
+
+	if ($current_rate) {
+		$curr = new MultiCurrency($db);
+		$resultcurrentCurrency =  $curr->fetch($current_rate->fk_multicurrency);
+
+		if ($resultcurrentCurrency){
+			$currency_code = $curr->code;
+		}else{
+			$currency_code = '';
+		}
+
+		print '<table class="noborder centpercent">';
+		print '<tr class="liste_titre">';
+		print '<td>' . $langs->trans("FormUpdateRate") . '</td>' . "\n";
+		print '</tr></table>';
+
+		$form = new Form($db);
+		print '<form action="' . $_SERVER["PHP_SELF"] . '" method="post" name="formulaire">';
+		print '<table><tr>';
+		print ' <td>' . $langs->trans('date') . '</td>';
+		print '<td><input class="minwidth200" name="dateinput" value="'. date('Y-m-d', dol_stringtotime($current_rate->date_sync)) .'" type="date"></td>';
+
+		print '<td>' . $langs->trans('Codemulticurrency') . '</td>';
+		print '<td>' . $form->selectMultiCurrency($currency_code,'multicurrency_code',0," code != '".$conf->currency."'",true) . '</td>';
+
+		print '<td>' . $langs->trans('rate') . '</td>';
+		print '<td><input class="minwidth200" name="rateinput" value="' . dol_escape_htmltag($current_rate->rate) . '" type="text"></td>';
+
+		print '<td>';
+		print '<input type="hidden" name="action" value="update">';
+		print '<input type="hidden" name="id_rate" value="'.$current_rate->id.'">';
+		print '<input type="submit" class="button" name="btnupdateCurrencyRate" value="' . $langs->trans('UpdateRate') . '">';
+		print '<a href="'.$_SERVER["PHP_SELF"].'" class="butAction">' .$langs->trans('CancelUpdate') . '</a>';
+
+		print '</td>';
+		print '</tr></table>';
+		print '</form>';
+
+	}else{
+		dol_syslog("currency_rate:list:update",LOG_WARNING);
+	}
+}
+
+
+$sql = 'SELECT cr.rowid, cr.date_sync, cr.rate, cr.entity, m.code, m.name ';
+
+// Add fields from hooks
+$parameters=array();
+$reshook=$hookmanager->executeHooks('printFieldListSelect',$parameters);    // Note that $action and $object may have been modified by hook
+$sql.=$hookmanager->resPrint;
+$sql.= ' FROM '.MAIN_DB_PREFIX.'multicurrency_rate as cr ';
+$sql .=" INNER JOIN ".MAIN_DB_PREFIX."multicurrency AS m ON cr.fk_multicurrency = m.rowid";
+
+
+if ($sall) $sql .= natural_search(array_keys($fieldstosearchall), $sall);
+
+if ($search_date_sync)     $sql .= natural_search('cr.date_sync', $search_date_sync);
+if ($search_rate)   $sql .= natural_search('cr.rate', $search_rate);
+if ($search_code) $sql .= natural_search('m.code', $search_code);
+
+$sql.= ' WHERE m.code != '. '\''.$conf->currency. '\'';
+
+// Add where from hooks
+$parameters=array();
+$reshook=$hookmanager->executeHooks('printFieldListWhere',$parameters);    // Note that $action and $object may have been modified by hook
+$sql.=$hookmanager->resPrint;
+$sql.= " GROUP BY cr.rowid, cr.date_sync, cr.rate, m.code, cr.entity ";
+
+// Add fields from hooks
+$parameters=array();
+$reshook=$hookmanager->executeHooks('printFieldSelect',$parameters);    // Note that $action and $object may have been modified by hook
+$sql.=$hookmanager->resPrint;
+
+$sql.= $db->order($sortfield,$sortorder);
+
+
+$nbtotalofrecords = '';
+if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST))
+{
+	$result = $db->query($sql);
+
+	if ($result){
+		$nbtotalofrecords = $db->num_rows($result);
+		if (($page * $limit) > $nbtotalofrecords)	// if total resultset is smaller then paging size (filtering), goto and load page 0
+		{
+			$page = 0;
+			$offset = 0;
+		}
+	}else{
+		setEventMessage($langs->trans('No_record_on_multicurrency_rate'),'warnings');
+	}
+
+}
+
+$sql.= $db->plimit($limit + 1, $offset);
+
+$resql = $db->query($sql);
+if ($resql)
+{
+	$num = $db->num_rows($resql);
+	$arrayofselected=is_array($toselect)?$toselect:array();
+
+	$param='';
+	if (! empty($contextpage) && $contextpage != $_SERVER["PHP_SELF"]) $param.='&contextpage='.urlencode($contextpage);
+	if ($limit > 0 && $limit != $conf->liste_limit) $param.='&limit='.urlencode($limit);
+	if ($sall) $param.="&sall=".urlencode($sall);
+
+	if ($search_date_sync) $param="&search_date_sync=".urlencode($search_date_sync);
+	if ($search_rate) $param="&search_rate=".urlencode($search_rate);
+	if ($search_code != '') $param.="&search_code=".urlencode($search_code);
+
+	// Add $param from extra fields
+	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_param.tpl.php';
+
+
+	if ($user->admin) $arrayofmassactions['predelete']=$langs->trans("Delete");
+	if (in_array($massaction, array('presend','predelete'))) $arrayofmassactions=array();
+	$massactionbutton=$form->selectMassAction('', $arrayofmassactions);
+
+	print '<form action="'.$_SERVER["PHP_SELF"].'" method="post" name="formulaire">';
+	if ($optioncss != '') print '<input type="hidden" name="optioncss" value="'.$optioncss.'">';
+	print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+	print '<input type="hidden" name="formfilteraction" id="formfilteraction" value="list">';
+	print '<input type="hidden" name="action" value="list">';
+	print '<input type="hidden" name="sortfield" value="'.$sortfield.'">';
+	print '<input type="hidden" name="sortorder" value="'.$sortorder.'">';
+	print '<input type="hidden" name="page" value="'.$page.'">';
+	print '<input type="hidden" name="type" value="'.$type.'">';
+
+	print_barre_liste($texte, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, 'title_currency.png', 0, $newcardbutton, '', $limit);
+
+	include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
+
+	if ($sall)
+	{
+		foreach($fieldstosearchall as $key => $val) $fieldstosearchall[$key]=$langs->trans($val);
+		print '<div class="divsearchfieldfilter">'.$langs->trans("FilterOnInto", $sall) . join(', ',$fieldstosearchall).'</div>';
+	}
+
+	// Filter on categories
+	$moreforfilter='';
+
+
+	$parameters=array();
+	$reshook=$hookmanager->executeHooks('printFieldPreListTitle',$parameters);    // Note that $action and $object may have been modified by hook
+	if (empty($reshook)) $moreforfilter.=$hookmanager->resPrint;
+	else $moreforfilter=$hookmanager->resPrint;
+
+	if ($moreforfilter)
+	{
+		print '<div class="liste_titre liste_titre_bydiv centpercent">';
+		print $moreforfilter;
+		print '</div>';
+	}
+
+	$varpage=empty($contextpage)?$_SERVER["PHP_SELF"]:$contextpage;
+	$selectedfields=$form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage);	// This also change content of $arrayfields
+	if ($massactionbutton) $selectedfields.=$form->showCheckAddButtons('checkforselect', 1);
+
+	print '<div class="div-table-responsive">';
+	print '<table class="tagtable liste'.($moreforfilter?" listwithfilterbefore":"").'">'."\n";
+
+	// Lines with input filters
+	print '<tr class="liste_titre_filter">';
+
+	// date
+	if (! empty($arrayfields['cr.date_sync']['checked']))
+	{
+		print '<td class="liste_titre" align="left">';
+		print '<input class="flat" type="text" name="search_date_sync" size="8" value="'.dol_escape_htmltag($search_date_sync).'">';
+		print '</td>';
+	}
+	// code
+	if (! empty($arrayfields['m.code']['checked']))
+	{
+		print '<td class="liste_titre" align="left">';
+		print '<input class="flat" type="text" name="search_code" size="12" value="'.dol_escape_htmltag($search_code).'">';
+		print '</td>';
+	}
+	// rate
+	if (! empty($arrayfields['cr.rate']['checked']))
+	{
+		print '<td class="liste_titre" align="left">';
+		print '<input class="flat" type="text" name="search_rate" size="8" value="'.dol_escape_htmltag($search_rate).'">';
+		print '</td>';
+	}
+
+	// Fields from hook
+	$parameters=array('arrayfields'=>$arrayfields);
+	$reshook=$hookmanager->executeHooks('printFieldListOption',$parameters);    // Note that $action and $object may have been modified by hook
+	print $hookmanager->resPrint;
+
+	print '<td class="liste_titre" align="middle">';
+	$searchpicto=$form->showFilterButtons();
+	print $searchpicto;
+	print '</td>';
+
+	print '</tr>';
+
+	print '<tr class="liste_titre">';
+	if (! empty($arrayfields['cr.date_sync']['checked']))  print_liste_field_titre($arrayfields['cr.date_sync']['label'], $_SERVER["PHP_SELF"],"cr.date_sync","",$param,"",$sortfield,$sortorder);
+	if (! empty($arrayfields['m.code']['checked']))  print_liste_field_titre($arrayfields['m.code']['label'], $_SERVER["PHP_SELF"],"m.code","",$param,"",$sortfield,$sortorder);
+	if (! empty($arrayfields['cr.rate']['checked']))  print_liste_field_titre($arrayfields['cr.rate']['label'], $_SERVER["PHP_SELF"],"cr.rate","",$param,"",$sortfield,$sortorder);
+
+	// Hook fields
+	$parameters=array('arrayfields'=>$arrayfields,'param'=>$param,'sortfield'=>$sortfield,'sortorder'=>$sortorder);
+	$reshook=$hookmanager->executeHooks('printFieldListTitle',$parameters);    // Note that $action and $object may have been modified by hook
+	print $hookmanager->resPrint;
+
+	print_liste_field_titre($selectedfields, $_SERVER["PHP_SELF"],"",'','','align="center"',$sortfield,$sortorder,'maxwidthsearch ');
+	print "</tr>\n";
+
+	$i = 0;
+	$totalarray=array();
+	while ($i < min($num,$limit))
+	{
+		$obj = $db->fetch_object($resql);
+
+		print '<tr class="oddeven">';
+
+		// date_sync
+		if (! empty($arrayfields['cr.date_sync']['checked']))
+		{
+			print '<td class="tdoverflowmax200">';
+			print $obj->date_sync;
+			print "</td>\n";
+			if (! $i) $totalarray['nbfield']++;
+		}
+
+		// code
+		if (! empty($arrayfields['m.code']['checked']))
+		{
+			print '<td class="tdoverflowmax200">';
+			print $obj->code ." ". $obj->name;
+			print "</td>\n";
+
+			if (! $i) $totalarray['nbfield']++;
+		}
+
+		// rate
+		if (! empty($arrayfields['cr.rate']['checked']))
+		{
+			print '<td class="tdoverflowmax200">';
+			print $obj->rate;
+			print "</td>\n";
+			if (! $i) $totalarray['nbfield']++;
+		}
+
+		// Fields from hook
+		$parameters=array('arrayfields'=>$arrayfields, 'obj'=>$obj);
+		$reshook=$hookmanager->executeHooks('printFieldListValue',$parameters);    // Note that $action and $object may have been modified by hook
+		print $hookmanager->resPrint;
+
+		// Action
+		print '<td class="nowrap" align="center">';
+		if ($massactionbutton || $massaction)   // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
+		{
+			$selected=0;
+			if (in_array($obj->rowid, $arrayofselected)) $selected=1;
+			print '<a href="'.$_SERVER["PHP_SELF"].'?action=updateRate&amp;id_rate='.$obj->rowid.'" class="like-link " style="margin-right:15px;important">' . img_picto('edit', 'edit') . '</a>';
+			print '<a href="'.$_SERVER["PHP_SELF"].'?action=deleteRate&amp;id_rate='.$obj->rowid.'" class="like-link" style="margin-right:45px;important">' . img_picto('delete', 'delete') . '</a>';
+			print '<input id="cb'.$obj->rowid.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->rowid.'"'.($selected?' checked="checked"':'').'>';
+		}
+		print '</td>';
+		if (! $i) $totalarray['nbfield']++;
+
+		print "</tr>\n";
+		$i++;
+	}
+
+	$db->free($resql);
+
+	print "</table>";
+	print "</div>";
+
+	print '</form>';
+}
+else
+{
+	dol_print_error($db);
+}
+
+
+llxFooter();
+$db->close();

--- a/htdocs/multicurrency/multicurrency_rate.php
+++ b/htdocs/multicurrency/multicurrency_rate.php
@@ -39,25 +39,25 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/multicurrency.lib.php';
 // Load translation files required by the page
 $langs->loadLangs(array('multicurrency'));
 
-$action				= GETPOST('action','alpha');
-$massaction			= GETPOST('massaction','alpha');
-$show_files			= GETPOST('show_files','int');
-$confirm			= GETPOST('confirm','alpha');
+$action				= GETPOST('action', 'alpha');
+$massaction			= GETPOST('massaction', 'alpha');
+$show_files			= GETPOST('show_files', 'int');
+$confirm			= GETPOST('confirm', 'alpha');
 $toselect 			= GETPOST('toselect', 'array');
-$id_rate_selected 	= GETPOST('id_rate');
+$id_rate_selected 	= GETPOST('id_rate','int');
 $sall				= trim((GETPOST('search_all', 'alphanohtml')!='')?GETPOST('search_all', 'alphanohtml'):GETPOST('sall', 'alphanohtml'));
-$search_date_sync	= GETPOST("search_date_sync",'alpha');
-$search_rate		= GETPOST("search_rate",'alpha');
-$search_code		= GETPOST("search_code",'alpha');
-$multicurrency_code = GETPOST('multicurrency_code');
-$dateinput 			= GETPOST('dateinput','alpha');
-$rateinput 			= GETPOST('rateinput','int');
-$search_tobatch 	= GETPOST("search_tobatch",'int');
-$optioncss 			= GETPOST('optioncss','alpha');
-$limit 				= GETPOST('limit','int')?GETPOST('limit','int'):$conf->liste_limit;
-$sortfield 			= GETPOST("sortfield",'alpha');
-$sortorder 			= GETPOST("sortorder",'alpha');
-$page 				= (GETPOST("page",'int')?GETPOST("page", 'int'):0);
+$search_date_sync	= GETPOST('search_date_sync', 'alpha');
+$search_rate		= GETPOST('search_rate', 'alpha');
+$search_code		= GETPOST('search_code', 'alpha');
+$multicurrency_code = GETPOST('multicurrency_code', 'alpha');
+$dateinput 			= GETPOST('dateinput', 'alpha');
+$rateinput 			= GETPOST('rateinput', 'int');
+$search_tobatch 	= GETPOST('search_tobatch', 'int');
+$optioncss 			= GETPOST('optioncss', 'alpha');
+$limit 				= GETPOST('limit', 'int')?GETPOST('limit', 'int') : $conf->liste_limit;
+$sortfield 			= GETPOST("sortfield", 'alpha');
+$sortorder 			= GETPOST("sortorder", 'alpha');
+$page 				= (GETPOST("page", 'int')?GETPOST("page", 'int'):0);
 
 if (empty($page) || $page == -1) { $page = 0; }     // If $page is not defined, or '' or -1
 $offset = $limit * $page;
@@ -101,7 +101,7 @@ $arrayfields = dol_sort_array($arrayfields, 'position');
 if ($action == "create"){
 	$currencyRate_static = new CurrencyRate($db);
 	$currency_static  = new MultiCurrency($db);
-	$fk_currency = $currency_static->getIdFromCode($db,$multicurrency_code);
+	$fk_currency = $currency_static->getIdFromCode($db, $multicurrency_code);
 
 	$currencyRate_static->fk_multicurrency = $fk_currency;
 	$currencyRate_static->entity = $conf->entity;
@@ -110,9 +110,9 @@ if ($action == "create"){
 
 	$result = $currencyRate_static->create(intval($fk_currency));
 	if ($result){
-		setEventMessage($langs->trans('successRateCreate',$multicurrency_code));
+		setEventMessage($langs->trans('successRateCreate', $multicurrency_code));
 	}else{
-		dol_syslog("currencyRate:createRate",LOG_WARNING);
+		dol_syslog("currencyRate:createRate", LOG_WARNING);
 		setEventMessage($langs->trans('successRateCreate'));
 	}
 }
@@ -122,7 +122,7 @@ if ($action == 'update'){
 	$result = $currencyRate->fetch($id_rate_selected);
 	if ( $result > 0){
 		$currency_static  = new MultiCurrency($db);
-		$fk_currency = $currency_static->getIdFromCode($db,$multicurrency_code);
+		$fk_currency = $currency_static->getIdFromCode($db, $multicurrency_code);
 		$currencyRate->date_sync = $db->escape(GETPOST('dateinput'));
 		$currencyRate->fk_multicurrency = $fk_currency;
 		$currencyRate->rate = $db->escape(GETPOST('rateinput'));
@@ -130,10 +130,10 @@ if ($action == 'update'){
 		if ($res){
 			setEventMessage($langs->trans('successUpdateRate'));
 		}else{
-			setEventMessage($langs->trans('errorUpdateRate'),"errors");
+			setEventMessage($langs->trans('errorUpdateRate'), "errors");
 		}
 	}else{
-		setEventMessage($langs->trans(''),"warnings");
+		setEventMessage($langs->trans(''), "warnings");
 	}
 }
 
@@ -149,19 +149,18 @@ if ($action == "deleteRate"){
 			$delayedhtmlcontent .= $form->formconfirm(
 				$_SERVER["PHP_SELF"].'?id_rate='.$id_rate_selected,
 				$langs->trans('DeleteLineRate'),
-				$langs->trans('ConfirmDeleteLineRate',$current_rate->rate, $current_currency->name,$current_rate->date_sync),
+				$langs->trans('ConfirmDeleteLineRate', $current_rate->rate, $current_currency->name, $current_rate->date_sync),
 				'confirm_delete',
 				'',
 				0,
 				1
 			);
 		}else{
-			dol_syslog("Multicurrency::fetch",LOG_WARNING);
+			dol_syslog("Multicurrency::fetch", LOG_WARNING);
 		}
 	}else{
-		setEventMessage($langs->trans('NoCurrencyRateSelected'),"warnings");
+		setEventMessage($langs->trans('NoCurrencyRateSelected'), "warnings");
 	}
-
 }
 
 if ($action == "confirm_delete"){
@@ -177,14 +176,13 @@ if ($action == "confirm_delete"){
 		}
 	}else{
 		setEventMessage($langs->trans('NoCurrencyRateSelected'),"warnings");
-		dol_syslog($langs->trans('NoCurrencyRateSelected'),LOG_WARNING);
+		dol_syslog($langs->trans('NoCurrencyRateSelected'), LOG_WARNING);
 	}
-
 }
 
 
-if (GETPOST('cancel','alpha')) { $action='list'; $massaction=''; }
-if (! GETPOST('confirmmassaction','alpha') && $massaction != 'presend' && $massaction != 'confirm_presend') { $massaction=''; }
+if (GETPOST('cancel', 'alpha')) { $action='list'; $massaction=''; }
+if (! GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend') { $massaction = ''; }
 
 $parameters=array();
 $reshook=$hookmanager->executeHooks('doActions',$parameters, $object, $action);    // Note that $action and $object may have been modified by some hooks
@@ -195,7 +193,7 @@ if (empty($reshook))
 	include DOL_DOCUMENT_ROOT.'/core/actions_changeselectedfields.inc.php';
 
 	// Purge search criteria
-	if (GETPOST('button_removefilter_x','alpha') || GETPOST('button_removefilter.x','alpha') || GETPOST('button_removefilter','alpha')) // All tests are required to be compatible with all browsers
+	if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter.x', 'alpha') || GETPOST('button_removefilter', 'alpha')) // All tests are required to be compatible with all browsers
 	{
 		$sall="";
 		$search_date_sync="";
@@ -221,7 +219,7 @@ $htmlother=new FormOther($db);
 $title=$langs->trans("CurrencyRate");
 $page_name = "ListCurrencyRate";
 
-llxHeader('',$title,$helpurl,'');
+llxHeader('', $title, $helpurl, '');
 // Subheader
 $linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php?restore_lastsearch_values=1">'.$langs->trans("BackToModuleList").'</a>';
 print load_fiche_titre($langs->trans($page_name), $linkback);
@@ -246,7 +244,7 @@ if ($action!= "updateRate" && $action!= "deleteRate" ) {
 	print ' <td><input class="minwidth200" name="dateinput" value="' . dol_escape_htmltag($dateinput) . '" type="date"></td>';
 
 	print ' <td>' . $langs->trans('Codemulticurrency') . '</td>';
-	print '<td>' . $form->selectMultiCurrency((GETPOSTISSET('multicurrency_code') ? GETPOST('multicurrency_code', 'alpha') : $multicurrency_code), 'multicurrency_code',0," code != '".$conf->currency."'",true) . '</td>';
+	print '<td>' . $form->selectMultiCurrency((GETPOSTISSET('multicurrency_code') ? GETPOST('multicurrency_code', 'alpha') : $multicurrency_code), 'multicurrency_code', 0, " code != '".$conf->currency."'", true) . '</td>';
 
 	print ' <td>' . $langs->trans('rate') . '</td>';
 	print ' <td><input class="minwidth200" name="rateinput" value="' . dol_escape_htmltag($rateinput) . '" type="text"></td>';
@@ -258,11 +256,9 @@ if ($action!= "updateRate" && $action!= "deleteRate" ) {
 
 	print '</tr></table>';
 	print '</form>';
-
 }
 
 if ($action == "updateRate"){
-
 	$current_rate = new CurrencyRate($db);
 	$current_rate->fetch(intval($id_rate_selected));
 
@@ -288,7 +284,7 @@ if ($action == "updateRate"){
 		print '<td><input class="minwidth200" name="dateinput" value="'. date('Y-m-d', dol_stringtotime($current_rate->date_sync)) .'" type="date"></td>';
 
 		print '<td>' . $langs->trans('Codemulticurrency') . '</td>';
-		print '<td>' . $form->selectMultiCurrency($currency_code,'multicurrency_code',0," code != '".$conf->currency."'",true) . '</td>';
+		print '<td>' . $form->selectMultiCurrency($currency_code, 'multicurrency_code', 0, " code != '".$conf->currency."'", true) . '</td>';
 
 		print '<td>' . $langs->trans('rate') . '</td>';
 		print '<td><input class="minwidth200" name="rateinput" value="' . dol_escape_htmltag($current_rate->rate) . '" type="text"></td>';
@@ -304,7 +300,7 @@ if ($action == "updateRate"){
 		print '</form>';
 
 	}else{
-		dol_syslog("currency_rate:list:update",LOG_WARNING);
+		dol_syslog("currency_rate:list:update", LOG_WARNING);
 	}
 }
 
@@ -313,7 +309,7 @@ $sql = 'SELECT cr.rowid, cr.date_sync, cr.rate, cr.entity, m.code, m.name ';
 
 // Add fields from hooks
 $parameters=array();
-$reshook=$hookmanager->executeHooks('printFieldListSelect',$parameters);    // Note that $action and $object may have been modified by hook
+$reshook=$hookmanager->executeHooks('printFieldListSelect', $parameters);    // Note that $action and $object may have been modified by hook
 $sql.=$hookmanager->resPrint;
 $sql.= ' FROM '.MAIN_DB_PREFIX.'multicurrency_rate as cr ';
 $sql .=" INNER JOIN ".MAIN_DB_PREFIX."multicurrency AS m ON cr.fk_multicurrency = m.rowid";
@@ -325,20 +321,20 @@ if ($search_date_sync)     $sql .= natural_search('cr.date_sync', $search_date_s
 if ($search_rate)   $sql .= natural_search('cr.rate', $search_rate);
 if ($search_code) $sql .= natural_search('m.code', $search_code);
 
-$sql.= ' WHERE m.code != '. '\''.$conf->currency. '\'';
+$sql.= ' WHERE m.code != \''.$conf->currency. '\'';
 
 // Add where from hooks
 $parameters=array();
-$reshook=$hookmanager->executeHooks('printFieldListWhere',$parameters);    // Note that $action and $object may have been modified by hook
+$reshook=$hookmanager->executeHooks('printFieldListWhere', $parameters);    // Note that $action and $object may have been modified by hook
 $sql.=$hookmanager->resPrint;
 $sql.= " GROUP BY cr.rowid, cr.date_sync, cr.rate, m.code, cr.entity ";
 
 // Add fields from hooks
 $parameters=array();
-$reshook=$hookmanager->executeHooks('printFieldSelect',$parameters);    // Note that $action and $object may have been modified by hook
+$reshook=$hookmanager->executeHooks('printFieldSelect', $parameters);    // Note that $action and $object may have been modified by hook
 $sql.=$hookmanager->resPrint;
 
-$sql.= $db->order($sortfield,$sortorder);
+$sql.= $db->order($sortfield, $sortorder);
 
 
 $nbtotalofrecords = '';
@@ -354,7 +350,7 @@ if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST))
 			$offset = 0;
 		}
 	}else{
-		setEventMessage($langs->trans('No_record_on_multicurrency_rate'),'warnings');
+		setEventMessage($langs->trans('No_record_on_multicurrency_rate'), 'warnings');
 	}
 
 }
@@ -401,7 +397,7 @@ if ($resql)
 	if ($sall)
 	{
 		foreach($fieldstosearchall as $key => $val) $fieldstosearchall[$key]=$langs->trans($val);
-		print '<div class="divsearchfieldfilter">'.$langs->trans("FilterOnInto", $sall) . join(', ',$fieldstosearchall).'</div>';
+		print '<div class="divsearchfieldfilter">'.$langs->trans("FilterOnInto", $sall) . join(', ', $fieldstosearchall).'</div>';
 	}
 
 	// Filter on categories
@@ -409,7 +405,7 @@ if ($resql)
 
 
 	$parameters=array();
-	$reshook=$hookmanager->executeHooks('printFieldPreListTitle',$parameters);    // Note that $action and $object may have been modified by hook
+	$reshook=$hookmanager->executeHooks('printFieldPreListTitle', $parameters);    // Note that $action and $object may have been modified by hook
 	if (empty($reshook)) $moreforfilter.=$hookmanager->resPrint;
 	else $moreforfilter=$hookmanager->resPrint;
 
@@ -454,7 +450,7 @@ if ($resql)
 
 	// Fields from hook
 	$parameters=array('arrayfields'=>$arrayfields);
-	$reshook=$hookmanager->executeHooks('printFieldListOption',$parameters);    // Note that $action and $object may have been modified by hook
+	$reshook=$hookmanager->executeHooks('printFieldListOption', $parameters);    // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 
 	print '<td class="liste_titre" align="middle">';
@@ -465,21 +461,21 @@ if ($resql)
 	print '</tr>';
 
 	print '<tr class="liste_titre">';
-	if (! empty($arrayfields['cr.date_sync']['checked']))  print_liste_field_titre($arrayfields['cr.date_sync']['label'], $_SERVER["PHP_SELF"],"cr.date_sync","",$param,"",$sortfield,$sortorder);
-	if (! empty($arrayfields['m.code']['checked']))  print_liste_field_titre($arrayfields['m.code']['label'], $_SERVER["PHP_SELF"],"m.code","",$param,"",$sortfield,$sortorder);
-	if (! empty($arrayfields['cr.rate']['checked']))  print_liste_field_titre($arrayfields['cr.rate']['label'], $_SERVER["PHP_SELF"],"cr.rate","",$param,"",$sortfield,$sortorder);
+	if (! empty($arrayfields['cr.date_sync']['checked']))  print_liste_field_titre($arrayfields['cr.date_sync']['label'], $_SERVER["PHP_SELF"], "cr.date_sync", "", $param, "", $sortfield, $sortorder);
+	if (! empty($arrayfields['m.code']['checked']))  print_liste_field_titre($arrayfields['m.code']['label'], $_SERVER["PHP_SELF"], "m.code", "", $param, "", $sortfield, $sortorder);
+	if (! empty($arrayfields['cr.rate']['checked']))  print_liste_field_titre($arrayfields['cr.rate']['label'], $_SERVER["PHP_SELF"], "cr.rate", "", $param, "", $sortfield, $sortorder);
 
 	// Hook fields
-	$parameters=array('arrayfields'=>$arrayfields,'param'=>$param,'sortfield'=>$sortfield,'sortorder'=>$sortorder);
-	$reshook=$hookmanager->executeHooks('printFieldListTitle',$parameters);    // Note that $action and $object may have been modified by hook
+	$parameters=array('arrayfields'=>$arrayfields, 'param'=>$param, 'sortfield'=>$sortfield, 'sortorder'=>$sortorder);
+	$reshook=$hookmanager->executeHooks('printFieldListTitle', $parameters);    // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 
-	print_liste_field_titre($selectedfields, $_SERVER["PHP_SELF"],"",'','','align="center"',$sortfield,$sortorder,'maxwidthsearch ');
+	print_liste_field_titre($selectedfields, $_SERVER["PHP_SELF"], "", '', '', 'align="center"', $sortfield, $sortorder, 'maxwidthsearch ');
 	print "</tr>\n";
 
 	$i = 0;
 	$totalarray=array();
-	while ($i < min($num,$limit))
+	while ($i < min($num, $limit))
 	{
 		$obj = $db->fetch_object($resql);
 
@@ -515,7 +511,7 @@ if ($resql)
 
 		// Fields from hook
 		$parameters=array('arrayfields'=>$arrayfields, 'obj'=>$obj);
-		$reshook=$hookmanager->executeHooks('printFieldListValue',$parameters);    // Note that $action and $object may have been modified by hook
+		$reshook=$hookmanager->executeHooks('printFieldListValue', $parameters);    // Note that $action and $object may have been modified by hook
 		print $hookmanager->resPrint;
 
 		// Action

--- a/htdocs/multicurrency/multicurrency_rate.php
+++ b/htdocs/multicurrency/multicurrency_rate.php
@@ -99,21 +99,25 @@ $arrayfields = dol_sort_array($arrayfields, 'position');
  * Actions
  */
 if ($action == "create"){
-	$currencyRate_static = new CurrencyRate($db);
-	$currency_static  = new MultiCurrency($db);
-	$fk_currency = $currency_static->getIdFromCode($db, $multicurrency_code);
+	if (!empty($rateinput)) {
+		$currencyRate_static = new CurrencyRate($db);
+		$currency_static = new MultiCurrency($db);
+		$fk_currency = $currency_static->getIdFromCode($db, $multicurrency_code);
 
-	$currencyRate_static->fk_multicurrency = $fk_currency;
-	$currencyRate_static->entity = $conf->entity;
-	$currencyRate_static->date_sync = $dateinput;
-	$currencyRate_static->rate = $rateinput;
+		$currencyRate_static->fk_multicurrency = $fk_currency;
+		$currencyRate_static->entity = $conf->entity;
+		$currencyRate_static->date_sync = $dateinput;
+		$currencyRate_static->rate = $rateinput;
 
-	$result = $currencyRate_static->create(intval($fk_currency));
-	if ($result){
-		setEventMessage($langs->trans('successRateCreate', $multicurrency_code));
+		$result = $currencyRate_static->create(intval($fk_currency));
+		if ($result) {
+			setEventMessage($langs->trans('successRateCreate', $multicurrency_code));
+		} else {
+			dol_syslog("currencyRate:createRate", LOG_WARNING);
+			setEventMessage($langs->trans('successRateCreate'));
+		}
 	}else{
-		dol_syslog("currencyRate:createRate", LOG_WARNING);
-		setEventMessage($langs->trans('successRateCreate'));
+		setEventMessage($langs->trans('NoEmptyRate'), "errors");
 	}
 }
 

--- a/htdocs/multicurrency/multicurrency_rate.php
+++ b/htdocs/multicurrency/multicurrency_rate.php
@@ -44,7 +44,7 @@ $massaction			= GETPOST('massaction', 'alpha');
 $show_files			= GETPOST('show_files', 'int');
 $confirm			= GETPOST('confirm', 'alpha');
 $toselect 			= GETPOST('toselect', 'array');
-$id_rate_selected 	= GETPOST('id_rate','int');
+$id_rate_selected 	= GETPOST('id_rate', 'int');
 $sall				= trim((GETPOST('search_all', 'alphanohtml')!='')?GETPOST('search_all', 'alphanohtml'):GETPOST('sall', 'alphanohtml'));
 $search_date_sync	= GETPOST('search_date_sync', 'alpha');
 $search_rate		= GETPOST('search_rate', 'alpha');
@@ -138,7 +138,6 @@ if ($action == 'update'){
 }
 
 if ($action == "deleteRate"){
-
 	$current_rate = new CurrencyRate($db);
 	$current_rate->fetch(intval($id_rate_selected));
 
@@ -172,10 +171,9 @@ if ($action == "confirm_delete"){
 			setEventMessage($langs->trans('successRateDelete'));
 		}else{
 			setEventMessage($langs->trans('errorRateDelete'));
-
 		}
 	}else{
-		setEventMessage($langs->trans('NoCurrencyRateSelected'),"warnings");
+		setEventMessage($langs->trans('NoCurrencyRateSelected'), "warnings");
 		dol_syslog($langs->trans('NoCurrencyRateSelected'), LOG_WARNING);
 	}
 }
@@ -185,7 +183,7 @@ if (GETPOST('cancel', 'alpha')) { $action='list'; $massaction=''; }
 if (! GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend') { $massaction = ''; }
 
 $parameters=array();
-$reshook=$hookmanager->executeHooks('doActions',$parameters, $object, $action);    // Note that $action and $object may have been modified by some hooks
+$reshook=$hookmanager->executeHooks('doActions', $parameters, $object, $action);    // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 if (empty($reshook))
 {
@@ -298,7 +296,6 @@ if ($action == "updateRate"){
 		print '</td>';
 		print '</tr></table>';
 		print '</form>';
-
 	}else{
 		dol_syslog("currency_rate:list:update", LOG_WARNING);
 	}
@@ -352,7 +349,6 @@ if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST))
 	}else{
 		setEventMessage($langs->trans('No_record_on_multicurrency_rate'), 'warnings');
 	}
-
 }
 
 $sql.= $db->plimit($limit + 1, $offset);

--- a/htdocs/multicurrency/multicurrency_rate.php
+++ b/htdocs/multicurrency/multicurrency_rate.php
@@ -123,9 +123,9 @@ if ($action == 'update'){
 	if ( $result > 0){
 		$currency_static  = new MultiCurrency($db);
 		$fk_currency = $currency_static->getIdFromCode($db,$multicurrency_code);
-		$currencyRate->date_sync = GETPOST('dateinput');
+		$currencyRate->date_sync = $db->escape(GETPOST('dateinput'));
 		$currencyRate->fk_multicurrency = $fk_currency;
-		$currencyRate->rate = GETPOST('rateinput');
+		$currencyRate->rate = $db->escape(GETPOST('rateinput'));
 		$res = $currencyRate->update();
 		if ($res){
 			setEventMessage($langs->trans('successUpdateRate'));


### PR DESCRIPTION
# New multi-currency exchange rate editor
## Context
Currently multicurrency logs past exchange rates when you "update" the exchange rate of a currency, but it doesn't enable you to correct past exchange rates or to date an exchange rate when you add it (the date is automatically set to the current time).

## This PR
This PR introduces a new page that enables you to view, edit or add exchange rates in a way somewhat similar to Dolibarr dictionaries. The page is accessible via the administration module.

![image](https://user-images.githubusercontent.com/68547382/96860257-d3eff100-1462-11eb-81ac-870285d99aa9.png)

## questions 
    you'll  see in multicurrency_rate.php  on  line 205 
 the action_massactions.inc.php need $uploaddir to operate but not really needed in multicurrency context. my question is this one : do i have to create this directory  ?