### PR TITLE
FIX 12.0 - third party of object is not always fetched when initiating an e-mail presend form

### DIFF
--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -180,7 +180,7 @@ if ($action == 'presend')
 	}
 	else
 	{
-		if (!empty($object->socid) && empty($object->thirdparty)) {
+		if (!empty($object->socid) && empty($object->thirdparty) && method_exists($object, 'fetch_thirdparty')) {
 			$object->fetch_thirdparty();
 		}
 		if (is_object($object->thirdparty))

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -180,6 +180,9 @@ if ($action == 'presend')
 	}
 	else
 	{
+		if (!empty($object->socid) && empty($object->thirdparty)) {
+			$object->fetch_thirdparty();
+		}
 		if (is_object($object->thirdparty))
 		{
 			foreach ($object->thirdparty->thirdparty_and_contact_email_array(1) as $key => $value) {


### PR DESCRIPTION
# FIX
In some cases, when you want to send an e-mail from, say, a proposal or an order, the select for third party contacts (as recipients) is not displayed even though there are contacts.

I found this was because `$object->thirdparty` was null (even though `$object->socid` wasn't).

This PR fixes the problem, but maybe there is a better way if we can find exactly where the object's thirdparty should have been fetched and wasn't.