### PR TITLE
FIX #15016 File name with two spaces throws ErrorFileDoesNotExist

### DIFF
--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -74,7 +74,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 
 $encoding = '';
 $action=GETPOST('action', 'alpha');
-$original_file=GETPOST('file', 'alphanohtml');  // Do not use urldecode here ($_GET are already decoded by PHP).
+$original_file = GETPOST('file', 'alpha'); // Do not use urldecode here ($_GET are already decoded by PHP).
 $hashp=GETPOST('hashp', 'aZ09');
 $modulepart=GETPOST('modulepart', 'alpha');
 $urlsource=GETPOST('urlsource', 'alpha');


### PR DESCRIPTION
GETPOST applied to file names should not need an alphanohtml check