### PR TITLE
Re-add set_date_livraison as a deprecated function.

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -287,7 +287,7 @@ if (empty($reshook))
 			dol_print_error($db, $object->error);
 	} elseif ($action == 'setdate_livraison' && $usercancreate)
 	{
-		$result = $object->set_delivery_date($user, dol_mktime(12, 0, 0, $_POST['date_livraisonmonth'], $_POST['date_livraisonday'], $_POST['date_livraisonyear']));
+		$result = $object->setDeliveryDate($user, dol_mktime(12, 0, 0, $_POST['date_livraisonmonth'], $_POST['date_livraisonday'], $_POST['date_livraisonyear']));
 		if ($result < 0)
 			dol_print_error($db, $object->error);
 	} // Positionne ref client

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -2060,8 +2060,22 @@ class Propal extends CommonObject
 		}
 	}
 
-    // phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
+	 *	Set delivery date
+	 *
+	 *	@param      User 	$user        		Object user that modify
+	 *	@param      int		$delivery_date		Delivery date
+	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers
+	 *	@return     int         				<0 if ko, >0 if ok
+	 *	@deprecated Use  setDeliveryDate
+	 */
+    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+	{
+		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
+	}
+
+    /**
 	 *	Set delivery date
 	 *
 	 *	@param      User 	$user        		Object user that modify
@@ -2069,7 +2083,7 @@ class Propal extends CommonObject
 	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers
 	 *	@return     int         				<0 if ko, >0 if ok
 	 */
-    public function set_delivery_date($user, $delivery_date, $notrigger = 0)
+    public function setDeliveryDate($user, $delivery_date, $notrigger = 0)
 	{
         // phpcs:enable
 		if (!empty($user->rights->propal->creer))

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -2070,7 +2070,7 @@ class Propal extends CommonObject
 	 *	@return     int         				<0 if ko, >0 if ok
 	 *	@deprecated Use  setDeliveryDate
 	 */
-    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+	public function set_date_livraison($user, $delivery_date, $notrigger = 0)
 	{
 		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date, $notrigger);

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -2072,6 +2072,7 @@ class Propal extends CommonObject
 	 */
     public function set_date_livraison($user, $delivery_date, $notrigger = 0)
 	{
+		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
 	}
 
@@ -2085,7 +2086,6 @@ class Propal extends CommonObject
 	 */
     public function setDeliveryDate($user, $delivery_date, $notrigger = 0)
 	{
-        // phpcs:enable
 		if (!empty($user->rights->propal->creer))
 		{
 			$error = 0;

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -541,7 +541,7 @@ if (empty($reshook))
 	    $datedelivery = dol_mktime(GETPOST('liv_hour', 'int'), GETPOST('liv_min', 'int'), 0, GETPOST('liv_month', 'int'), GETPOST('liv_day', 'int'), GETPOST('liv_year', 'int'));
 
 	    $object->fetch($id);
-	    $result = $object->set_delivery_date($user, $datedelivery);
+	    $result = $object->setDeliveryDate($user, $datedelivery);
 	    if ($result < 0) {
 	        setEventMessages($object->error, $object->errors, 'errors');
 	    }

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2559,6 +2559,7 @@ class Commande extends CommonOrder
 	 */
     public function set_date_livraison($user, $delivery_date, $notrigger = 0)
 	{
+		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
 	}
 
@@ -2572,7 +2573,6 @@ class Commande extends CommonOrder
 	 */
 	public function setDeliveryDate($user, $delivery_date, $notrigger = 0)
 	{
-		// phpcs:enable
 		if ($user->rights->commande->creer)
 		{
 			$error = 0;

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2550,7 +2550,7 @@ class Commande extends CommonOrder
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *	Set delivery date
-	 *  
+	 *
 	 *	@param      User 	$user        		Object user that modify
 	 *	@param      int		$delivery_date		Delivery date
 	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2549,6 +2549,20 @@ class Commande extends CommonOrder
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
+	 *	Set delivery date
+	 *  
+	 *	@param      User 	$user        		Object user that modify
+	 *	@param      int		$delivery_date		Delivery date
+	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers
+	 *	@return     int         				<0 if ko, >0 if ok
+	 *	@deprecated Use  setDeliveryDate
+	 */
+    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+	{
+		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
+	}
+
+	/**
 	 *	Set the planned delivery date
 	 *
 	 *	@param      User	$user        		Objet utilisateur qui modifie
@@ -2556,7 +2570,7 @@ class Commande extends CommonOrder
 	 *  @param     	int		$notrigger			1=Does not execute triggers, 0= execute triggers
 	 *	@return     int         				<0 si ko, >0 si ok
 	 */
-	public function set_delivery_date($user, $delivery_date, $notrigger = 0)
+	public function setDeliveryDate($user, $delivery_date, $notrigger = 0)
 	{
 		// phpcs:enable
 		if ($user->rights->commande->creer)

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2557,7 +2557,7 @@ class Commande extends CommonOrder
 	 *	@return     int         				<0 if ko, >0 if ok
 	 *	@deprecated Use  setDeliveryDate
 	 */
-    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+	public function set_date_livraison($user, $delivery_date, $notrigger = 0)
 	{
 		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date, $notrigger);

--- a/htdocs/delivery/card.php
+++ b/htdocs/delivery/card.php
@@ -171,7 +171,7 @@ if ($action == 'confirm_delete' && $confirm == 'yes' && $user->rights->expeditio
 if ($action == 'setdate_livraison' && $user->rights->expedition->delivery->creer)
 {
     $datedelivery = dol_mktime(GETPOST('liv_hour', 'int'), GETPOST('liv_min', 'int'), 0, GETPOST('liv_month', 'int'), GETPOST('liv_day', 'int'), GETPOST('liv_year', 'int'));
-    $result = $object->set_delivery_date($user, $datedelivery);
+    $result = $object->setDeliveryDate($user, $datedelivery);
     if ($result < 0)
     {
         $mesg = '<div class="error">'.$object->error.'</div>';

--- a/htdocs/delivery/class/delivery.class.php
+++ b/htdocs/delivery/class/delivery.class.php
@@ -1007,7 +1007,7 @@ class Delivery extends CommonObject
 	 *	@param      integer 		$delivery_date     Delivery date
 	 *	@return     int         						<0 if KO, >0 if OK
 	 */
-    public function set_delivery_date($user, $delivery_date)
+    public function setDeliveryDate($user, $delivery_date)
 	{
         // phpcs:enable
 		if ($user->rights->expedition->creer)
@@ -1016,7 +1016,7 @@ class Delivery extends CommonObject
 			$sql .= " SET date_delivery = ".($delivery_date ? "'".$this->db->idate($delivery_date)."'" : 'null');
 			$sql .= " WHERE rowid = ".$this->id;
 
-			dol_syslog(get_class($this)."::set_delivery_date", LOG_DEBUG);
+			dol_syslog(get_class($this)."::setDeliveryDate", LOG_DEBUG);
 			$resql = $this->db->query($sql);
 			if ($resql)
 			{

--- a/htdocs/delivery/class/delivery.class.php
+++ b/htdocs/delivery/class/delivery.class.php
@@ -999,8 +999,7 @@ class Delivery extends CommonObject
 		}
 	}
 
-    // phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
-	/**
+    /**
 	 *	Set the planned delivery date
 	 *
 	 *	@param      User			$user        		Objet utilisateur qui modifie
@@ -1009,7 +1008,6 @@ class Delivery extends CommonObject
 	 */
     public function setDeliveryDate($user, $delivery_date)
 	{
-        // phpcs:enable
 		if ($user->rights->expedition->creer)
 		{
 			$sql = "UPDATE ".MAIN_DB_PREFIX."delivery";

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -479,7 +479,7 @@ if (empty($reshook))
 		$datedelivery = dol_mktime(GETPOST('liv_hour', 'int'), GETPOST('liv_min', 'int'), 0, GETPOST('liv_month', 'int'), GETPOST('liv_day', 'int'), GETPOST('liv_year', 'int'));
 
 		$object->fetch($id);
-		$result = $object->set_delivery_date($user, $datedelivery);
+		$result = $object->setDeliveryDate($user, $datedelivery);
 		if ($result < 0)
 		{
 			setEventMessages($object->error, $object->errors, 'errors');

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1966,7 +1966,7 @@ class Expedition extends CommonObject
 	 *	@return     int         				<0 if ko, >0 if ok
 	 *	@deprecated Use  setDeliveryDate
 	 */
-    public function set_date_livraison($user, $delivery_date)
+	public function set_date_livraison($user, $delivery_date)
 	{
 		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date);

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1957,15 +1957,29 @@ class Expedition extends CommonObject
 		}
 	}
 
-    // phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
+	 *	Set delivery date
+	 *
+	 *	@param      User 	$user        		Object user that modify
+	 *	@param      int		$delivery_date		Delivery date
+	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers
+	 *	@return     int         				<0 if ko, >0 if ok
+	 *	@deprecated Use  setDeliveryDate
+	 */
+    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+	{
+		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
+	}
+
+    /**
 	 *	Set the planned delivery date
 	 *
 	 *	@param      User			$user        		Objet user that modify
 	 *	@param      integer 		$delivery_date     Date of delivery
 	 *	@return     int         						<0 if KO, >0 if OK
 	 */
-	public function set_delivery_date($user, $delivery_date)
+	public function setDeliveryDate($user, $delivery_date)
 	{
         // phpcs:enable
 		if ($user->rights->expedition->creer)
@@ -1974,7 +1988,7 @@ class Expedition extends CommonObject
 			$sql .= " SET date_delivery = ".($delivery_date ? "'".$this->db->idate($delivery_date)."'" : 'null');
 			$sql .= " WHERE rowid = ".$this->id;
 
-			dol_syslog(get_class($this)."::set_delivery_date", LOG_DEBUG);
+			dol_syslog(get_class($this)."::setDeliveryDate", LOG_DEBUG);
 			$resql = $this->db->query($sql);
 			if ($resql)
 			{

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1963,13 +1963,12 @@ class Expedition extends CommonObject
 	 *
 	 *	@param      User 	$user        		Object user that modify
 	 *	@param      int		$delivery_date		Delivery date
-	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers
 	 *	@return     int         				<0 if ko, >0 if ok
 	 *	@deprecated Use  setDeliveryDate
 	 */
-    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+    public function set_date_livraison($user, $delivery_date)
 	{
-		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
+		return $this->setDeliveryDate($user, $delivery_date);
 	}
 
     /**

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1968,6 +1968,7 @@ class Expedition extends CommonObject
 	 */
     public function set_date_livraison($user, $delivery_date)
 	{
+		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date);
 	}
 
@@ -1980,7 +1981,6 @@ class Expedition extends CommonObject
 	 */
 	public function setDeliveryDate($user, $delivery_date)
 	{
-        // phpcs:enable
 		if ($user->rights->expedition->creer)
 		{
 			$sql = "UPDATE ".MAIN_DB_PREFIX."expedition";

--- a/htdocs/expedition/shipment.php
+++ b/htdocs/expedition/shipment.php
@@ -108,7 +108,7 @@ if (empty($reshook))
 	    $datedelivery = dol_mktime(GETPOST('liv_hour', 'int'), GETPOST('liv_min', 'int'), 0, GETPOST('liv_month', 'int'), GETPOST('liv_day', 'int'), GETPOST('liv_year', 'int'));
 
 	    $object->fetch($id);
-	    $result = $object->set_delivery_date($user, $datedelivery);
+	    $result = $object->setDeliveryDate($user, $datedelivery);
 	    if ($result < 0)
 	    {
 	        setEventMessages($object->error, $object->errors, 'errors');

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2260,7 +2260,7 @@ class CommandeFournisseur extends CommonOrder
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *	Set delivery date
-	 *  
+	 *
 	 *	@param      User 	$user        		Object user that modify
 	 *	@param      int		$delivery_date		Delivery date
 	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2269,6 +2269,7 @@ class CommandeFournisseur extends CommonOrder
 	 */
     public function set_date_livraison($user, $delivery_date, $notrigger = 0)
 	{
+		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
 	}
 
@@ -2282,7 +2283,6 @@ class CommandeFournisseur extends CommonOrder
 	 */
 	public function setDeliveryDate($user, $delivery_date, $notrigger = 0)
 	{
-		// phpcs:enable
 		if ($user->rights->fournisseur->commande->creer)
 		{
 			$error = 0;

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2259,6 +2259,20 @@ class CommandeFournisseur extends CommonOrder
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
+	 *	Set delivery date
+	 *  
+	 *	@param      User 	$user        		Object user that modify
+	 *	@param      int		$delivery_date		Delivery date
+	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers
+	 *	@return     int         				<0 if ko, >0 if ok
+	 *	@deprecated Use  setDeliveryDate
+	 */
+    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+	{
+		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
+	}
+
+	/**
 	 *	Set the planned delivery date
 	 *
 	 *	@param      User			$user        		Objet user making change
@@ -2266,7 +2280,7 @@ class CommandeFournisseur extends CommonOrder
 	 *  @param     	int				$notrigger			1=Does not execute triggers, 0= execute triggers
 	 *	@return     int         						<0 if KO, >0 if OK
 	 */
-	public function set_delivery_date($user, $delivery_date, $notrigger = 0)
+	public function setDeliveryDate($user, $delivery_date, $notrigger = 0)
 	{
 		// phpcs:enable
 		if ($user->rights->fournisseur->commande->creer)

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2267,7 +2267,7 @@ class CommandeFournisseur extends CommonOrder
 	 *	@return     int         				<0 if ko, >0 if ok
 	 *	@deprecated Use  setDeliveryDate
 	 */
-    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+	public function set_date_livraison($user, $delivery_date, $notrigger = 0)
 	{
 		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date, $notrigger);

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -203,7 +203,7 @@ if (empty($reshook))
 	// date of delivery
 	if ($action == 'setdate_livraison' && $usercancreate)
 	{
-		$result = $object->set_delivery_date($user, $datelivraison);
+		$result = $object->setDeliveryDate($user, $datelivraison);
 		if ($result < 0) setEventMessages($object->error, $object->errors, 'errors');
 	}
 
@@ -1199,7 +1199,7 @@ if (empty($reshook))
 						$result = $srcobject->fetch($object->origin_id);
 						if ($result > 0)
 						{
-							$object->set_delivery_date($user, $srcobject->date_livraison);
+							$object->setDeliveryDate($user, $srcobject->date_livraison);
 							$object->set_id_projet($user, $srcobject->fk_project);
 
 							$lines = $srcobject->lines;

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -425,7 +425,7 @@ if (empty($reshook))
 	    $datedelivery = dol_mktime(GETPOST('liv_hour', 'int'), GETPOST('liv_min', 'int'), 0, GETPOST('liv_month', 'int'), GETPOST('liv_day', 'int'), GETPOST('liv_year', 'int'));
 
 	    $object->fetch($id);
-	    $result = $object->set_delivery_date($user, $datedelivery);
+	    $result = $object->setDeliveryDate($user, $datedelivery);
 	    if ($result < 0)
 	    {
 	        setEventMessages($object->error, $object->errors, 'errors');

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1219,15 +1219,14 @@ class Reception extends CommonObject
 		}
 	}
 
-    // phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
-	/**
+    /**
 	 *	Set the planned delivery date
 	 *
 	 *	@param      User			$user        		Objet utilisateur qui modifie
 	 *	@param      integer 		$delivery_date     Delivery date
 	 *	@return     int         						<0 if KO, >0 if OK
 	 */
-    public function set_delivery_date($user, $delivery_date)
+    public function setDeliveryDate($user, $delivery_date)
 	{
 		// phpcs:enable
 		if ($user->rights->reception->creer)
@@ -1236,7 +1235,7 @@ class Reception extends CommonObject
 			$sql .= " SET date_delivery = ".($delivery_date ? "'".$this->db->idate($delivery_date)."'" : 'null');
 			$sql .= " WHERE rowid = ".$this->id;
 
-			dol_syslog(get_class($this)."::set_delivery_date", LOG_DEBUG);
+			dol_syslog(get_class($this)."::setDeliveryDate", LOG_DEBUG);
 			$resql = $this->db->query($sql);
 			if ($resql)
 			{

--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -229,7 +229,7 @@ if (empty($reshook))
 			else setEventMessages($langs->trans($object->error), null, 'errors');
 		}
 	} elseif ($action == 'setdate_livraison' && $usercancreate) {
-		$result = $object->set_delivery_date($user, dol_mktime(12, 0, 0, $_POST['liv_month'], $_POST['liv_day'], $_POST['liv_year']));
+		$result = $object->setDeliveryDate($user, dol_mktime(12, 0, 0, $_POST['liv_month'], $_POST['liv_day'], $_POST['liv_year']));
 		if ($result < 0)
 			dol_print_error($db, $object->error);
 	}

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -1510,11 +1510,25 @@ class SupplierProposal extends CommonObject
 	/**
 	 *	Set delivery date
 	 *
+	 *	@param      User 	$user        		Object user that modify
+	 *	@param      int		$delivery_date		Delivery date
+	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers
+	 *	@return     int         				<0 if ko, >0 if ok
+	 *	@deprecated Use  setDeliveryDate
+	 */
+    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+	{
+		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
+	}
+
+	/**
+	 *	Set delivery date
+	 *
 	 *	@param      User 		$user        		Object user that modify
 	 *	@param      int			$delivery_date     Delivery date
 	 *	@return     int         					<0 if ko, >0 if ok
 	 */
-	public function set_delivery_date($user, $delivery_date)
+	public function setDeliveryDate($user, $delivery_date)
 	{
 		// phpcs:enable
 		if (!empty($user->rights->supplier_proposal->creer))
@@ -1529,7 +1543,7 @@ class SupplierProposal extends CommonObject
 				return 1;
 			} else {
 				$this->error = $this->db->error();
-				dol_syslog(get_class($this)."::set_delivery_date Erreur SQL");
+				dol_syslog(get_class($this)."::setDeliveryDate Erreur SQL");
 				return -1;
 			}
 		}

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -1512,13 +1512,12 @@ class SupplierProposal extends CommonObject
 	 *
 	 *	@param      User 	$user        		Object user that modify
 	 *	@param      int		$delivery_date		Delivery date
-	 *  @param  	int		$notrigger			1=Does not execute triggers, 0= execute triggers
 	 *	@return     int         				<0 if ko, >0 if ok
 	 *	@deprecated Use  setDeliveryDate
 	 */
-    public function set_date_livraison($user, $delivery_date, $notrigger = 0)
+    public function set_date_livraison($user, $delivery_date)
 	{
-		return $this->setDeliveryDate($user, $delivery_date, $notrigger);
+		return $this->setDeliveryDate($user, $delivery_date);
 	}
 
 	/**

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -1515,7 +1515,7 @@ class SupplierProposal extends CommonObject
 	 *	@return     int         				<0 if ko, >0 if ok
 	 *	@deprecated Use  setDeliveryDate
 	 */
-    public function set_date_livraison($user, $delivery_date)
+	public function set_date_livraison($user, $delivery_date)
 	{
 		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date);

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -1517,6 +1517,7 @@ class SupplierProposal extends CommonObject
 	 */
     public function set_date_livraison($user, $delivery_date)
 	{
+		// phpcs:enable
 		return $this->setDeliveryDate($user, $delivery_date);
 	}
 
@@ -1529,7 +1530,6 @@ class SupplierProposal extends CommonObject
 	 */
 	public function setDeliveryDate($user, $delivery_date)
 	{
-		// phpcs:enable
 		if (!empty($user->rights->supplier_proposal->creer))
 		{
 			$sql = "UPDATE ".MAIN_DB_PREFIX."supplier_proposal ";


### PR DESCRIPTION
Add deprecation phase, think used in quite some external or custom modules.

Also use correct naming convention for new method naming.
