### PR TITLE
FIX 10.0 - make formConfirm an addreplace-type hook

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -160,6 +160,7 @@ class HookManager
 				'doActions',
 				'doMassActions',
 				'formatEvent',
+				'formConfirm',
 				'formCreateThirdpartyOptions',
 				'formObjectOptions',
 				'formattachOptions',


### PR DESCRIPTION
# Issue
Currenly, in all cards I've looked in, `formConfirm` behaves like an _addreplace_ hook (the variable `$formconfirm` is either replaced with `$hookmanager->resPrint` or completed with its contents depending on the return value of `executeHooks`), but it is not registered as an __addreplace__ hook, which creates problems when several modules implement it.

If your module returns 1 but is not the last one whose `formConfirm()` is called, then `executeHooks` will return the value returned by the last one called (presumably 0).