### PR TITLE
FIX - 10.0 - remove 'action' parameter from redirect URL when reordering lines

### DIFF
--- a/htdocs/core/tpl/ajaxrow.tpl.php
+++ b/htdocs/core/tpl/ajaxrow.tpl.php
@@ -80,7 +80,12 @@ $(document).ready(function(){
 						console.log("tableDND end of ajax call");
 						if (reloadpage == 1) {
 							//console.log('<?php echo $urltorefreshaftermove.' - '.$_SERVER['PHP_SELF'].' - '.dol_escape_js($_SERVER['QUERY_STRING']); ?>');
-							location.href = '<?php echo dol_escape_js(empty($urltorefreshaftermove) ? ($_SERVER['PHP_SELF'].'?'.dol_escape_js($_SERVER['QUERY_STRING'])) : $urltorefreshaftermove); ?>';
+							<?php
+							$redirectURL = empty($urltorefreshaftermove) ? ($_SERVER['PHP_SELF'].'?'.dol_escape_js($_SERVER['QUERY_STRING'])) : $urltorefreshaftermove;
+							// remove action parameter from URL
+							$redirectURL = preg_replace('/[&?]action=[^&]*/', '', $redirectURL);
+							?>
+							location.href = '<?php echo dol_escape_js($redirectURL); ?>';
 						} else {
 							$("#<?php echo $tagidfortablednd; ?> .drag").each(
 									function( intIndex ) {

--- a/htdocs/core/tpl/ajaxrow.tpl.php
+++ b/htdocs/core/tpl/ajaxrow.tpl.php
@@ -83,7 +83,7 @@ $(document).ready(function(){
 							<?php
 							$redirectURL = empty($urltorefreshaftermove) ? ($_SERVER['PHP_SELF'].'?'.dol_escape_js($_SERVER['QUERY_STRING'])) : $urltorefreshaftermove;
 							// remove action parameter from URL
-							$redirectURL = preg_replace('/[&?]action=[^&]*/', '', $redirectURL);
+							$redirectURL = preg_replace('/(&|\?)action=[^&#]*/', '', $redirectURL);
 							?>
 							location.href = '<?php echo dol_escape_js($redirectURL); ?>';
 						} else {


### PR DESCRIPTION
# Issue
When you reorder lines on a document by drag and drop, there is a redirection after the drop event to reload the document.

The redirection URL is the current page's URL.

The problem arises if you performed an action using a `GET` form or a link (`POST` data is unaffected by the bug) just before the drag & drop: then the redirect URL will still have the `action=<myaction>` parameter.

For instance, if you are on order N, you click on the little trash can symbol to delete line X but don't confirm the action. The URL parameters are now `id=N&action=ask_deleteline&lineid=X`. Now reorder lines → the formConfirm pop-in will appear again.

# Fix
This PR removes the `action=*` part of the URL before redirecting.