### PR TITLE
Fix: Keep status filter when using pager

### DIFF
--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -93,7 +93,6 @@ $search_btn = GETPOST('button_search', 'alpha');
 $search_remove_btn = GETPOST('button_removefilter', 'alpha');
 
 $status = GETPOST('statut', 'alpha');
-$search_status = GETPOST('search_status');
 
 // Security check
 $orderid = GETPOST('orderid', 'int');


### PR DESCRIPTION
# New `$search_status` was already set before

`$search_status` has correctly been set before a few lines above. In some cirumstances it will be cleared with this line.
