### PR TITLE
FIX: action 'set_thirdparty' on order card has no effect

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1326,7 +1326,7 @@ if (empty($reshook))
 	if ($action == 'set_thirdparty' && $usercancreate)
 	{
 		$object->fetch($id);
-		$object->setValueFrom('fk_soc', $socid, '', '', 'date', '', $user, 'ORDER_MODIFY');
+		$object->setValueFrom('fk_soc', $socid, '', '', 'text', '', $user, 'ORDER_MODIFY');
 
 		header('Location: '.$_SERVER["PHP_SELF"].'?id='.$id);
 		exit();


### PR DESCRIPTION
# FIX third party ID formatted as a date results in SQL error
When you set `action=set_thirdparty&socid=1234` on an order card, there is an action handler meant to change the third party of the order, but it does not work because it formats the ID (1234 in my example) as a date (`1970-01-01 01:20:34`).

**Note**: this feature, which was only available when `COMMANDE_CHANGE_THIRDPARTY` was set, was removed¹ from Dolibarr UI v5.0 (revision [af28a67](https://github.com/Dolibarr/dolibarr/commit/af28a6780380b87a075c18c13255c6f00a5597b6#diff-96a519e1f858c3fdb8f2c7501bbc7d5e250fd5045679ed6736d2c9d7320cfe56R2022)) but the [release notes](https://wiki.dolibarr.org/index.php?title=Roadmap_and_Release_5.0.0) of v5.0 don't mention it.

I created the PR because if the processing of this action is intended to remain there in 12.0, it should work, but maybe it simply needs to be removed from Dolibarr altogether (if so, we should advertise the regression in the release notes).


¹) The processing of the action was not removed, but the form that enables regular users to change the thirdparty was.