### PR TITLE
FIX : handling $heightforinfotot when he's superior to a page height

### DIFF
--- a/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
@@ -328,6 +328,7 @@ class pdf_crabe extends ModelePDFFactures
                 $pdf->SetAutoPageBreak(1, 0);
 
                 $heightforinfotot = 50 + (4 * $nbpayments); // Height reserved to output the info and total part and payment part
+				if($heightforinfotot > 220) $heightforinfotot = 220;
 		        $heightforfreetext = (isset($conf->global->MAIN_PDF_FREETEXT_HEIGHT) ? $conf->global->MAIN_PDF_FREETEXT_HEIGHT : 5); // Height reserved to output the free text on last page
 	            $heightforfooter = $this->marge_basse + 8; // Height reserved to output the footer (value include bottom margin)
 	            if ($conf->global->MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS > 0) $heightforfooter += 6;


### PR DESCRIPTION
# Fix : When there are too many payments, $heightforinfotot is superior to a page height and make an infinity loop
