### PR TITLE
WIP FIX pdf page break with photo

### DIFF
--- a/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
@@ -530,7 +530,7 @@ class pdf_cornas extends ModelePDFSuppliersOrders
 						if (isset($imglinesize['width']) && isset($imglinesize['height'])
 							&& ($curY + $imglinesize['height']) > ($this->page_hauteur-($heightforfooter+$heightforfreetext)))	// If photo too high, we moved completely on new page
 						{
-							$pdf->AddPage('','',true);
+							$pdf->AddPage('', '', true);
 							if (! empty($tplidx)) $pdf->useTemplate($tplidx);
 							$pdf->setPage($pageposbefore+1);
 

--- a/htdocs/core/modules/supplier_proposal/doc/pdf_aurore.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/pdf_aurore.modules.php
@@ -412,7 +412,7 @@ class pdf_aurore extends ModelePDFSupplierProposal
 					if (!empty($realpatharray[$i])) $imglinesize = pdf_getSizeForImage($realpatharray[$i]);
 
 					$pdf->setTopMargin($tab_top_newpage);
-					$pdf->setPageOrientation('', 1, $heightforfooter + $heightforfreetext + $heightforinfotot); // The only function to edit the bottom margin of current page to set it.
+					$pdf->setPageOrientation('', 1, $heightforfooter + $heightforfreetext); // The only function to edit the bottom margin of current page to set it.
 					$pageposbefore = $pdf->getPage();
 
 					$showpricebeforepagebreak = 1;
@@ -420,7 +420,7 @@ class pdf_aurore extends ModelePDFSupplierProposal
 					$posYAfterDescription = 0;
 
 					// We start with Photo of product line
-					if (!empty($imglinesize['width']) && !empty($imglinesize['height']) && ($curY + $imglinesize['height']) > ($this->page_hauteur - ($heightforfooter + $heightforfreetext + $heightforinfotot)))	// If photo too high, we moved completely on new page
+					if (!empty($imglinesize['width']) && !empty($imglinesize['height']) && ($curY + $imglinesize['height']) > ($this->page_hauteur - ($heightforfooter + $heightforfreetext)))	// If photo too high, we moved completely on new page
 					{
 						$pdf->AddPage('', '', true);
 						if (!empty($tplidx)) $pdf->useTemplate($tplidx);


### PR DESCRIPTION
# Fix

Fix : Missing the "new column management "for column photo on PDF cornas

Fix : When use product photo on PDF documents, page break leave a huge blank space

**Blanc space fixed for PDF :**
- [x] cornas
- [x] aurore

**To do for all others PDF**



# Do not merge yet