### PR TITLE
fix new company in contacts template file

### DIFF
--- a/htdocs/core/tpl/contacts.tpl.php
+++ b/htdocs/core/tpl/contacts.tpl.php
@@ -145,7 +145,7 @@ if ($permission)
 			$newcardbutton = '';
 			if (!empty($object->socid) && $object->socid > 1 && $user->rights->societe->creer)
 			{
-				$newcardbutton .= '<a href="'.DOL_URL_ROOT.'/contact/card.php?socid='.$object->socid.'&action=create&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id).'" title="'.$langs->trans('NewContact').'"><span class="fa fa-plus-circle valignmiddle paddingleft"></span></a>';
+				$newcardbutton .= '<a href="'.DOL_URL_ROOT.'/contact/card.php?socid='.$selectedCompany.'&action=create&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id).'" title="'.$langs->trans('NewContact').'"><span class="fa fa-plus-circle valignmiddle paddingleft"></span></a>';
 			}
 			print $newcardbutton;
 			?>


### PR DESCRIPTION
IF you switch the third company in a contacts list (eg project) the add new contact +button will not change the id connected to the thirdparty