### PR TITLE
Adding Default version for the BOM

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -105,6 +105,7 @@ class BOM extends CommonObject
 		'date_creation' => array('type'=>'datetime', 'label'=>'DateCreation', 'enabled'=>1, 'visible'=>-2, 'position'=>300, 'notnull'=>1,),
 		'tms' => array('type'=>'timestamp', 'label'=>'DateModification', 'enabled'=>1, 'visible'=>-2, 'position'=>501, 'notnull'=>1,),
 		'date_valid' => array('type'=>'datetime', 'label'=>'DateValidation', 'enabled'=>1, 'visible'=>-2, 'position'=>502, 'notnull'=>0,),
+		'default_version' => array('type'=>'integer', 'label'=>'DefaultVersion', 'enabled'=>1, 'visible'=>1, 'position'=>504, 'notnull'=>0, 'default'=>0,  'arrayofkeyval'=>array(0=>'Other', 1=>'Default')),
 		'fk_user_creat' => array('type'=>'integer:User:user/class/user.class.php', 'label'=>'UserCreation', 'enabled'=>1, 'visible'=>-2, 'position'=>510, 'notnull'=>1, 'foreignkey'=>'user.rowid',),
 		'fk_user_modif' => array('type'=>'integer:User:user/class/user.class.php', 'label'=>'UserModif', 'enabled'=>1, 'visible'=>-2, 'position'=>511, 'notnull'=>-1,),
 		'fk_user_valid' => array('type'=>'integer:User:user/class/user.class.php', 'label'=>'UserValidation', 'enabled'=>1, 'visible'=>-2, 'position'=>512, 'notnull'=>0,),

--- a/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
+++ b/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
@@ -56,8 +56,8 @@ ALTER TABLE llx_mrp_mo_extrafields DROP INDEX idx_fk_object;
 
 ALTER TABLE llx_mrp_mo_extrafields ADD INDEX idx_mrp_mo_fk_object(fk_object);
 
-
 -- For v13
+ALTER TABLE llx_bom_bom ADD COLUMN default_version integer DEFAULT 0 after fk_user_valid ;
 
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (111,11,     '0','0','No Sales Tax',1);
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (112,11,     '4','0','Sales Tax 4%',1);

--- a/htdocs/install/mysql/tables/llx_bom_bom.sql
+++ b/htdocs/install/mysql/tables/llx_bom_bom.sql
@@ -35,6 +35,7 @@ CREATE TABLE llx_bom_bom(
 	fk_user_creat integer NOT NULL,
 	fk_user_modif integer, 
 	fk_user_valid integer, 
+	default_version integer,			-- 1 for default BOM, 0 for other version 
 	import_key varchar(14),
 	model_pdf varchar(255), 
 	status integer NOT NULL 


### PR DESCRIPTION
It is necessary to have a default BOM for the automation of replenishment or the creation of a default OF