### PR TITLE
Add orders received partially and delay icons

### DIFF
--- a/htdocs/core/boxes/box_supplier_orders_awaiting_reception.php
+++ b/htdocs/core/boxes/box_supplier_orders_awaiting_reception.php
@@ -96,7 +96,7 @@ class box_supplier_orders_awaiting_reception extends ModeleBoxes
             if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
             $sql .= " WHERE c.fk_soc = s.rowid";
             $sql .= " AND c.entity IN (".getEntity('supplier_order').")";
-            $sql .= " AND c.fk_statut = ".CommandeFournisseur::STATUS_ORDERSENT;
+            $sql .= " AND c.fk_statut IN (".CommandeFournisseur::STATUS_ORDERSENT.", ".CommandeFournisseur::STATUS_RECEIVED_PARTIALLY.")";
             if (!$user->rights->societe->client->voir && !$user->socid) $sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".$user->id;
             if ($user->socid) $sql .= " AND s.rowid = ".$user->socid;
             if ($conf->global->MAIN_LASTBOX_ON_OBJECT_DATE) $sql .= " ORDER BY c.date_commande DESC, c.ref DESC ";

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2987,7 +2987,7 @@ class CommandeFournisseur extends CommonOrder
         }
         $sql .= $clause." c.entity = ".$conf->entity;
         if ($mode === 'awaiting') {
-            $sql .= " AND c.fk_statut = ".self::STATUS_ORDERSENT;
+            $sql .= " AND c.fk_statut IN (".self::STATUS_ORDERSENT.", ".self::STATUS_RECEIVED_PARTIALLY.")";
         }
         else {
             $sql .= " AND c.fk_statut IN (".self::STATUS_VALIDATED.", ".self::STATUS_ACCEPTED.")";
@@ -3009,7 +3009,7 @@ class CommandeFournisseur extends CommonOrder
             if ($mode === 'awaiting') {
                 $response->label = $langs->trans("SuppliersOrdersAwaitingReception");
                 $response->labelShort = $langs->trans("AwaitingReception");
-                $response->url = DOL_URL_ROOT.'/fourn/commande/list.php?statut=3&mainmenu=commercial&leftmenu=orders_suppliers';
+                $response->url = DOL_URL_ROOT.'/fourn/commande/list.php?statut=3,4&mainmenu=commercial&leftmenu=orders_suppliers';
             }
 
             while ($obj = $this->db->fetch_object($resql))
@@ -3175,9 +3175,9 @@ class CommandeFournisseur extends CommonOrder
         if (empty($this->date_delivery) && !empty($this->date_livraison)) $this->date_delivery = $this->date_livraison; // For backward compatibility
 
         $now = dol_now();
-        $date_to_test = empty($this->date_delivery) ? $this->date_commande : $this->date_delivery;
+        $date_to_test = empty($this->date_livraison) ? $this->date_commande : $this->date_livraison;
 
-        return ($this->statut > 0 && $this->statut < 4) && $date_to_test && $date_to_test < ($now - $conf->commande->fournisseur->warning_delay);
+        return ($this->statut > 0 && $this->statut < 5) && $date_to_test && $date_to_test < ($now - $conf->commande->fournisseur->warning_delay);
     }
 
     /**

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2065,9 +2065,9 @@ elseif (!empty($object->id))
 	if ($object->methode_commande_id > 0)
 	{
 		print '<tr><td class="titlefield">'.$langs->trans("Date").'</td><td>';
-		if ($object->date_commande)
-		{
-			print dol_print_date($object->date_commande, "dayhour")."\n";
+		print $object->date_commande ? dol_print_date($object->date_commande, $usehourmin) : '&nbsp;';
+		if ($object->hasDelay() && empty($object->date_livraison) && !empty($object->date_commande)) {
+			print ' '.img_picto($langs->trans("Late").' : '.$object->showDelay(), "warning");
 		}
 		print "</td></tr>";
 

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -1001,6 +1001,7 @@ if ($resql)
 		$objectstatic->total_ht = $obj->total_ht;
 		$objectstatic->total_tva = $obj->total_tva;
 		$objectstatic->total_ttc = $obj->total_ttc;
+		$objectstatic->date_commande = $db->jdate($obj->date_commande);
 		$objectstatic->date_delivery = $db->jdate($obj->date_delivery);
 		$objectstatic->note_public = $obj->note_public;
 		$objectstatic->note_private = $obj->note_private;
@@ -1110,8 +1111,10 @@ if ($resql)
 		if (!empty($arrayfields['cf.date_commande']['checked']))
 		{
 			print '<td class="center">';
-			if ($obj->date_commande) print dol_print_date($db->jdate($obj->date_commande), 'day');
-			else print '';
+			print dol_print_date($db->jdate($obj->date_commande), 'day');
+			if ($objectstatic->hasDelay() && empty($objectstatic->date_delivery)) {
+				print ' '.img_picto($langs->trans("Late").' : '.$objectstatic->showDelay(), "warning");
+			}
 			print '</td>';
 			if (!$i) $totalarray['nbfield']++;
 		}


### PR DESCRIPTION
# Description
This modifications is to allow the following of suppliers orders received partially in addition of simple suppliers orders sent, in the dashboard and with the widget "Latest Supplier Orders Awaiting Reception".
I also edit file to, correct a issues with delay when a supplier order have a delivery date.
And to finish i also edit file to upgrade the lisibilty of delayed orders in order suppliers list and card.