### PR TITLE
NEW log sale without lines as error in cash desk

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -207,7 +207,8 @@ if ($action == 'valid' && $user->rights->facture->creer)
 			dol_htmloutput_errors($langs->trans("InvoiceIsAlreadyValidated", "TakePos"), null, 1);
 		}
 	} elseif (count($invoice->lines) == 0) {
-		dol_syslog("Sale without lines");
+		$error++;
+		dol_syslog('Sale without lines', LOG_ERR);
 		dol_htmloutput_errors($langs->trans("NoLinesToBill", "TakePos"), null, 1);
 	} elseif (!empty($conf->stock->enabled) && $conf->global->$constantforkey != "1") {
 		$savconst = $conf->global->STOCK_CALCULATE_ON_BILL;

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -208,7 +208,7 @@ if ($action == 'valid' && $user->rights->facture->creer)
 		}
 	} elseif (count($invoice->lines) == 0) {
 		$error++;
-		dol_syslog('Sale without lines', LOG_ERR);
+		dol_syslog('Sale without lines');
 		dol_htmloutput_errors($langs->trans("NoLinesToBill", "TakePos"), null, 1);
 	} elseif (!empty($conf->stock->enabled) && $conf->global->$constantforkey != "1") {
 		$savconst = $conf->global->STOCK_CALCULATE_ON_BILL;


### PR DESCRIPTION
NEW log sale without lines as error in cash desk
- so it avoids having payment on invoices without lines
- you can click on payment button and valid this payment even if you have no product in this ticket (no lines) and after the terminal is blocked (you can't add products and can't do any other action)