### PR TITLE
NEW Add an option to hide by default icon shippable order in order list

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -957,13 +957,13 @@ if ($resql)
 		if (!empty($arrayfields['c.ref']['checked']))
 		{
 			print '<td class="nowraponall">';
-			if(!empty($show_shippable_command)) {
+			if (!empty($show_shippable_command)) {
 				$generic_commande->getLinesArray(); // This set ->lines
 			}
 
 			print $generic_commande->getNomUrl(1, ($search_status != 2 ? 0 : $obj->fk_statut), 0, 0, 0, 1, 1);
 
-			if(!empty($show_shippable_command)) {
+			if (!empty($show_shippable_command)) {
 				// Show shippable Icon (create subloop, so may be slow)
 				if ($conf->stock->enabled) {
 					if (($obj->fk_statut > 0) && ($obj->fk_statut < 3)) {

--- a/htdocs/langs/en_US/deliveries.lang
+++ b/htdocs/langs/en_US/deliveries.lang
@@ -27,5 +27,6 @@ Recipient=Recipient
 ErrorStockIsNotEnough=There's not enough stock
 Shippable=Shippable
 NonShippable=Not Shippable
+ShowShippableCommand=Show shippable command
 ShowReceiving=Show delivery receipt
 NonExistentOrder=Nonexistent order

--- a/htdocs/langs/fr_FR/deliveries.lang
+++ b/htdocs/langs/fr_FR/deliveries.lang
@@ -27,5 +27,6 @@ Recipient=Destinataire
 ErrorStockIsNotEnough=Le stock est insuffisant
 Shippable=Expédiable
 NonShippable=Non expédiable
+ShowShippableCommand=Afficher statut expédiabilité
 ShowReceiving=Afficher le bon de réception
 NonExistentOrder=Commande inexistante


### PR DESCRIPTION
NEW Add an option to hide by default icon shippable order in order list

Problem :
- to show shippable icon takes a long time when we have a lot of orders
- there is a loop on each order lines (do a lot of SQL queries) to determine if there is enough products in stock to deliver the order

So with this option, we reduce the page loading.