### PR TITLE
FIX missing "enabled" value of extrafield after update

### DIFF
--- a/htdocs/core/actions_extrafields.inc.php
+++ b/htdocs/core/actions_extrafields.inc.php
@@ -338,7 +338,7 @@ if ($action == 'update')
 					GETPOST('computed_value', 'alpha'),
 					(GETPOST('entitycurrentorall', 'alpha') ? 0 : ''),
 					GETPOST('langfile'),
-					1,
+				    GETPOST('enabled', 'alpha'),
 					(GETPOST('totalizable', 'alpha') ? 1 : 0),
 					GETPOST('printable', 'alpha')
 				);

--- a/htdocs/core/tpl/admin_extrafields_edit.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_edit.tpl.php
@@ -145,6 +145,7 @@ $listofexamplesforlink = 'Societe:societe/class/societe.class.php<br>Contact:con
 <input type="hidden" name="attrname" value="<?php echo $attrname; ?>">
 <input type="hidden" name="action" value="update">
 <input type="hidden" name="rowid" value="<?php echo $rowid ?>">
+<input type="hidden" name="enabled" value="<?php echo $extrafields->attributes[$elementtype]['enabled'][$attrname]; ?>">
 
 <?php print dol_get_fiche_head(); ?>
 


### PR DESCRIPTION
@eldy 
If an external module gives the "enabled" field a type of value "$conf->mymodule->enabled", this value will be replaced by the value "1" after an update of the field