### PR TITLE
FIX keep dates filters parameters on order list

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -59,10 +59,10 @@ $search_datecloture_start = GETPOST('search_datecloture_start', 'int');
 if (empty($search_datecloture_start)) $search_datecloture_start = dol_mktime(0, 0, 0, GETPOST('search_datecloture_startmonth', 'int'), GETPOST('search_datecloture_startday', 'int'), GETPOST('search_datecloture_startyear', 'int'));
 $search_datecloture_end = GETPOST('search_datecloture_end', 'int');
 if (empty($search_datecloture_end)) $search_datecloture_end = dol_mktime(23, 59, 59, GETPOST('search_datecloture_endmonth', 'int'), GETPOST('search_datecloture_endday', 'int'), GETPOST('search_datecloture_endyear', 'int'));
-$search_dateorder_start = dol_mktime(0, 0, 0, GETPOST('search_dateorder_startmonth', 'int'), GETPOST('search_dateorder_startday', 'int'), GETPOST('search_dateorder_startyear', 'int'));
-$search_dateorder_end = dol_mktime(23, 59, 59, GETPOST('search_dateorder_endmonth', 'int'), GETPOST('search_dateorder_endday', 'int'), GETPOST('search_dateorder_endyear', 'int'));
-$search_datedelivery_start = dol_mktime(0, 0, 0, GETPOST('search_datedelivery_startmonth', 'int'), GETPOST('search_datedelivery_startday', 'int'), GETPOST('search_datedelivery_startyear', 'int'));
-$search_datedelivery_end = dol_mktime(23, 59, 59, GETPOST('search_datedelivery_endmonth', 'int'), GETPOST('search_datedelivery_endday', 'int'), GETPOST('search_datedelivery_endyear', 'int'));
+$search_dateorder_start = dol_mktime(0, 0, 0, GETPOST('search_dateorder_start_month', 'int'), GETPOST('search_dateorder_start_day', 'int'), GETPOST('search_dateorder_start_year', 'int'));
+$search_dateorder_end = dol_mktime(23, 59, 59, GETPOST('search_dateorder_end_month', 'int'), GETPOST('search_dateorder_end_day', 'int'), GETPOST('search_dateorder_end_year', 'int'));
+$search_datedelivery_start = dol_mktime(0, 0, 0, GETPOST('search_datedelivery_start_month', 'int'), GETPOST('search_datedelivery_start_day', 'int'), GETPOST('search_datedelivery_start_year', 'int'));
+$search_datedelivery_end = dol_mktime(23, 59, 59, GETPOST('search_datedelivery_end_month', 'int'), GETPOST('search_datedelivery_end_day', 'int'), GETPOST('search_datedelivery_end_year', 'int'));
 $search_product_category = GETPOST('search_product_category', 'int');
 $search_ref = GETPOST('search_ref', 'alpha') != '' ?GETPOST('search_ref', 'alpha') : GETPOST('sref', 'alpha');
 $search_ref_customer = GETPOST('search_ref_customer', 'alpha');
@@ -448,10 +448,10 @@ if ($resql)
 	if ($search_status != '')		$param .= '&search_status='.urlencode($search_status);
 	if ($search_datecloture_start)  $param .= '&search_datecloture_start='.urlencode($search_datecloture_start);
 	if ($search_datecloture_end)    $param .= '&search_datecloture_end='.urlencode($search_datecloture_end);
-	if ($search_dateorder_start)    $param .= '&search_dateorder_start='.urlencode($search_dateorder_start);
-	if ($search_dateorder_end)      $param .= '&search_dateorder_end='.urlencode($search_dateorder_end);
-	if ($search_datedelivery_start) $param .= '&search_datedelivery_start='.urlencode($search_datedelivery_start);
-	if ($search_datedelivery_end)   $param .= '&search_datedelivery_end='.urlencode($search_datedelivery_end);
+	if ($search_datedelivery_start) $param .= '&search_dateorder_start_day=' . dol_print_date($search_dateorder_start, '%d') . '&search_dateorder_start_month=' . dol_print_date($search_dateorder_start, '%m') . '&search_dateorder_start_year=' . dol_print_date($search_dateorder_start, '%Y');
+	if ($search_datedelivery_end) 	$param .= '&search_dateorder_end_day=' . dol_print_date($search_dateorder_end, '%d') . '&search_dateorder_end_month=' . dol_print_date($search_dateorder_end, '%m') . '&search_dateorder_end_year=' . dol_print_date($search_dateorder_end, '%Y');
+	if ($search_datedelivery_start) $param .= '&search_datedelivery_start_day=' . dol_print_date($search_datedelivery_start, '%d') . '&search_datedelivery_start_month=' . dol_print_date($search_datedelivery_start, '%m') . '&search_datedelivery_start_year=' . dol_print_date($search_datedelivery_start, '%Y');
+	if ($search_datedelivery_end) 	$param .= '&search_datedelivery_end_day=' . dol_print_date($search_datedelivery_end, '%d') . '&search_datedelivery_end_month=' . dol_print_date($search_datedelivery_end, '%m') . '&search_datedelivery_end_year=' . dol_print_date($search_datedelivery_end, '%Y');
 	if ($search_ref)      			$param .= '&search_ref='.urlencode($search_ref);
 	if ($search_company)  			$param .= '&search_company='.urlencode($search_company);
 	if ($search_ref_customer)		$param .= '&search_ref_customer='.urlencode($search_ref_customer);
@@ -708,10 +708,10 @@ if ($resql)
 	{
 		print '<td class="liste_titre center">';
 		print '<div class="nowrap">';
-		print $form->selectDate($search_dateorder_start ? $search_dateorder_start : -1, 'search_dateorder_start', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
+		print $form->selectDate($search_dateorder_start ? $search_dateorder_start : -1, 'search_dateorder_start_', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
 		print '</div>';
 		print '<div class="nowrap">';
-		print $form->selectDate($search_dateorder_end ? $search_dateorder_end : -1, 'search_dateorder_end', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('to'));
+		print $form->selectDate($search_dateorder_end ? $search_dateorder_end : -1, 'search_dateorder_end_', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('to'));
 		print '</div>';
 		print '</td>';
 	}
@@ -719,10 +719,10 @@ if ($resql)
 	{
 		print '<td class="liste_titre center">';
 		print '<div class="nowrap">';
-		print $form->selectDate($search_datedelivery_start ? $search_datedelivery_start : -1, 'search_datedelivery_start', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
+		print $form->selectDate($search_datedelivery_start ? $search_datedelivery_start : -1, 'search_datedelivery_start_', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
 		print '</div>';
 		print '<div class="nowrap">';
-		print $form->selectDate($search_datedelivery_end ? $search_datedelivery_end : -1, 'search_datedelivery_end', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('to'));
+		print $form->selectDate($search_datedelivery_end ? $search_datedelivery_end : -1, 'search_datedelivery_end_', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('to'));
 		print '</div>';
 		print '</td>';
 	}

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -448,8 +448,8 @@ if ($resql)
 	if ($search_status != '')		$param .= '&search_status='.urlencode($search_status);
 	if ($search_datecloture_start)  $param .= '&search_datecloture_start='.urlencode($search_datecloture_start);
 	if ($search_datecloture_end)    $param .= '&search_datecloture_end='.urlencode($search_datecloture_end);
-	if ($search_datedelivery_start) $param .= '&search_dateorder_start_day=' . dol_print_date($search_dateorder_start, '%d') . '&search_dateorder_start_month=' . dol_print_date($search_dateorder_start, '%m') . '&search_dateorder_start_year=' . dol_print_date($search_dateorder_start, '%Y');
-	if ($search_datedelivery_end) 	$param .= '&search_dateorder_end_day=' . dol_print_date($search_dateorder_end, '%d') . '&search_dateorder_end_month=' . dol_print_date($search_dateorder_end, '%m') . '&search_dateorder_end_year=' . dol_print_date($search_dateorder_end, '%Y');
+	if ($search_dateorder_start) 	$param .= '&search_dateorder_start_day=' . dol_print_date($search_dateorder_start, '%d') . '&search_dateorder_start_month=' . dol_print_date($search_dateorder_start, '%m') . '&search_dateorder_start_year=' . dol_print_date($search_dateorder_start, '%Y');
+	if ($search_dateorder_end) 		$param .= '&search_dateorder_end_day=' . dol_print_date($search_dateorder_end, '%d') . '&search_dateorder_end_month=' . dol_print_date($search_dateorder_end, '%m') . '&search_dateorder_end_year=' . dol_print_date($search_dateorder_end, '%Y');
 	if ($search_datedelivery_start) $param .= '&search_datedelivery_start_day=' . dol_print_date($search_datedelivery_start, '%d') . '&search_datedelivery_start_month=' . dol_print_date($search_datedelivery_start, '%m') . '&search_datedelivery_start_year=' . dol_print_date($search_datedelivery_start, '%Y');
 	if ($search_datedelivery_end) 	$param .= '&search_datedelivery_end_day=' . dol_print_date($search_datedelivery_end, '%d') . '&search_datedelivery_end_month=' . dol_print_date($search_datedelivery_end, '%m') . '&search_datedelivery_end_year=' . dol_print_date($search_datedelivery_end, '%Y');
 	if ($search_ref)      			$param .= '&search_ref='.urlencode($search_ref);


### PR DESCRIPTION
FIX keep dates filters parameters on order list
- when you select a page or order by a field you loose order and delivery dates filters