### PR TITLE
Fix 12.0 cron methods cant be called without params

### DIFF
--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -1052,7 +1052,10 @@ class Cronjob extends CommonObject
 				$object = new $this->objectname($this->db);
 				if ($this->entity > 0) $object->entity = $this->entity; // We work on a dedicated entity
 
-				$params_arr = array_map('trim', explode(",", $this->params));
+				$params_arr = array();
+				if (!empty($this->params) || $this->params === '0'){
+					$params_arr = array_map('trim', explode(",", $this->params));
+				}
 
 				if (!is_array($params_arr))
 				{
@@ -1113,7 +1116,7 @@ class Cronjob extends CommonObject
 			}
 
 			dol_syslog(get_class($this)."::run_jobs ".$this->libname."::".$this->methodename."(".$this->params.");", LOG_DEBUG);
-			$params_arr = explode(", ", $this->params);
+				$params_arr = explode(", ", $this->params);
 			if (!is_array($params_arr))
 			{
 				$result = call_user_func($this->methodename, $this->params);

--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -1116,7 +1116,7 @@ class Cronjob extends CommonObject
 			}
 
 			dol_syslog(get_class($this)."::run_jobs ".$this->libname."::".$this->methodename."(".$this->params.");", LOG_DEBUG);
-				$params_arr = explode(", ", $this->params);
+			$params_arr = explode(", ", $this->params);
 			if (!is_array($params_arr))
 			{
 				$result = call_user_func($this->methodename, $this->params);


### PR DESCRIPTION
# Problem
Le's say you want to call this class method as a scheduled task:
```php
class CRONTEST {
	var $output = '';
	function testMonCron($param1 = true) {
		$this->output = '$param1: ' . json_encode($param1);
	}
}
```

You want to call it with no params (to use the default values).

Currently, if you create your job and leave the "Parameters" field empty, the method will still be called with one param (an empty string) because `explode(',', '')` returns `array('')`

# Fix
If `$this->params` is truly empty, then don't call the method with any params.