### PR TITLE
FIX Bug where amount of voters was always 0

### DIFF
--- a/htdocs/opensurvey/list.php
+++ b/htdocs/opensurvey/list.php
@@ -349,7 +349,7 @@ while ($i < min($num, $limit))
 	$obj = $db->fetch_object($resql);
 	if (empty($obj)) break; // Should not happen
 
-	$sql2 = 'select COUNT(*) as nb from '.MAIN_DB_PREFIX."opensurvey_user_studs where id_sondage='".$db->escape($obj->id_sondage)."'";
+	$sql2 = 'select COUNT(*) as nb from '.MAIN_DB_PREFIX."opensurvey_user_studs where id_sondage='".$db->escape($obj->rowid)."'";
 	$resql2 = $db->query($sql2);
 	if ($resql2)
 	{


### PR DESCRIPTION
# Fix Bug where amount of voters was always 0
In the initial query `$sql2 = 'select COUNT(*) as nb from '.MAIN_DB_PREFIX."opensurvey_user_studs where id_sondage='".$db->escape($obj->id_sondage)."'";` The row selected is wrong. It should be `rowid`
