### PR TITLE
Fix edition of tag/category which used type parameter instead of object's type

### DIFF
--- a/htdocs/categories/edit.php
+++ b/htdocs/categories/edit.php
@@ -35,7 +35,6 @@ $langs->load("categories");
 
 $id = GETPOST('id', 'int');
 $ref = GETPOST('ref', 'alphanohtml');
-$type = GETPOST('type', 'aZ09');		// Can be int or string
 $action = (GETPOST('action', 'aZ09') ?GETPOST('action', 'aZ09') : 'edit');
 $confirm = GETPOST('confirm');
 $cancel = GETPOST('cancel', 'alpha');
@@ -56,9 +55,13 @@ if ($id == "") {
 $result = restrictedArea($user, 'categorie', $id, '&category');
 
 $object = new Categorie($db);
-if ($id > 0) {
-	$result = $object->fetch($id);
+$result = $object->fetch($id, $label);
+if ($result <= 0) {
+	dol_print_error($db, $object->error); exit;
 }
+
+$type = $object->type;
+if (is_numeric($type)) $type = Categorie::$MAP_ID_TO_CODE[$type]; // For backward compatibility
 
 $extrafields = new ExtraFields($db);
 $extrafields->fetch_name_optionals_label($object->table_element);

--- a/htdocs/categories/info.php
+++ b/htdocs/categories/info.php
@@ -43,10 +43,11 @@ if ($user->socid) $socid = $user->socid;
 $result = restrictedArea($user, 'categorie', $id, '&category');
 
 $object = new Categorie($db);
-if (!$object->fetch($id) > 0) {
-	dol_print_error($db);
-	exit;
+$result = $object->fetch($id);
+if ($result <= 0) {
+	dol_print_error($db, $object->error); exit;
 }
+
 $type = $object->type;
 if (is_numeric($type)) $type = Categorie::$MAP_ID_TO_CODE[$type]; // For backward compatibility
 

--- a/htdocs/categories/info.php
+++ b/htdocs/categories/info.php
@@ -37,13 +37,14 @@ $langs->loadLangs(array('categories', 'sendings'));
 
 $socid = 0;
 $id = GETPOST('id', 'int');
+$label = GETPOST('label', 'alpha');
 
 // Security check
 if ($user->socid) $socid = $user->socid;
 $result = restrictedArea($user, 'categorie', $id, '&category');
 
 $object = new Categorie($db);
-$result = $object->fetch($id);
+$result = $object->fetch($id, $label);
 if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
@@ -64,11 +65,11 @@ llxHeader('', $langs->trans('Categories'), '');
 $title = Categorie::$MAP_TYPE_TITLE_AREA[$type];
 
 $head = categories_prepare_head($object, $type);
-
 print dol_get_fiche_head($head, 'info', $langs->trans($title), -1, 'category');
+
 $backtolist = (GETPOST('backtolist') ? GETPOST('backtolist') : DOL_URL_ROOT.'/categories/index.php?leftmenu=cat&type='.$type);
 $linkback = '<a href="'.$backtolist.'">'.$langs->trans("BackToList").'</a>';
-$object->next_prev_filter = ' type = '.$type;
+$object->next_prev_filter = ' type = '.$object->type;
 $object->ref = $object->label;
 $morehtmlref = '<br><div class="refidno"><a href="'.DOL_URL_ROOT.'/categories/index.php?leftmenu=cat&type='.$type.'">'.$langs->trans("Root").'</a> >> ';
 $ways = $object->print_all_ways(" &gt;&gt; ", '', 1);

--- a/htdocs/categories/photos.php
+++ b/htdocs/categories/photos.php
@@ -55,10 +55,6 @@ $result = $object->fetch($id, $label);
 if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
-$object->fetch_optionals();
-if ($result <= 0) {
-	dol_print_error($db, $object->error); exit;
-}
 
 $type = $object->type;
 if (is_numeric($type)) $type = Categorie::$MAP_ID_TO_CODE[$type]; // For backward compatibility
@@ -116,8 +112,6 @@ if ($object->id)
 	$title = Categorie::$MAP_TYPE_TITLE_AREA[$type];
 
 	$head = categories_prepare_head($object, $type);
-
-
 	print dol_get_fiche_head($head, 'photos', $langs->trans($title), -1, 'category');
 
 	$linkback = '<a href="'.DOL_URL_ROOT.'/categories/index.php?leftmenu=cat&type='.$type.'">'.$langs->trans("BackToList").'</a>';

--- a/htdocs/categories/photos.php
+++ b/htdocs/categories/photos.php
@@ -38,7 +38,6 @@ $langs->loadlangs(array('categories', 'bills'));
 
 $id      = GETPOST('id', 'int');
 $label   = GETPOST('label', 'alpha');
-$type    = GETPOST('type');
 $action  = GETPOST('action', 'aZ09');
 $confirm = GETPOST('confirm');
 
@@ -52,7 +51,7 @@ if ($id == '' && $label == '')
 $result = restrictedArea($user, 'categorie', $id, '&category');
 
 $object = new Categorie($db);
-$result = $object->fetch($id, $label, $type);
+$result = $object->fetch($id, $label);
 if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
@@ -60,9 +59,11 @@ $object->fetch_optionals();
 if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
-$upload_dir = $conf->categorie->multidir_output[$object->entity];
 
+$type = $object->type;
 if (is_numeric($type)) $type = Categorie::$MAP_ID_TO_CODE[$type]; // For backward compatibility
+
+$upload_dir = $conf->categorie->multidir_output[$object->entity];
 
 /*
  * Actions

--- a/htdocs/categories/traduction.php
+++ b/htdocs/categories/traduction.php
@@ -39,7 +39,6 @@ $id     = GETPOST('id', 'int');
 $label  = GETPOST('label', 'alpha');
 $action = GETPOST('action', 'aZ09');
 $cancel = GETPOST('cancel', 'alpha');
-$type   = GETPOST('type', 'aZ09');
 
 if ($id == '' && $label == '')
 {
@@ -51,7 +50,7 @@ if ($id == '' && $label == '')
 $result = restrictedArea($user, 'categorie', $id, '&category');
 
 $object = new Categorie($db);
-$result = $object->fetch($id, $label, $type);
+$result = $object->fetch($id, $label);
 if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
@@ -60,6 +59,7 @@ if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
 
+$type = $object->type;
 if (is_numeric($type)) $type = Categorie::$MAP_ID_TO_CODE[$type]; // For backward compatibility
 
 /*

--- a/htdocs/categories/traduction.php
+++ b/htdocs/categories/traduction.php
@@ -54,10 +54,6 @@ $result = $object->fetch($id, $label);
 if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
-$object->fetch_optionals();
-if ($result <= 0) {
-	dol_print_error($db, $object->error); exit;
-}
 
 $type = $object->type;
 if (is_numeric($type)) $type = Categorie::$MAP_ID_TO_CODE[$type]; // For backward compatibility

--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -76,10 +76,6 @@ $result = $object->fetch($id, $label);
 if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
-$object->fetch_optionals();
-if ($result <= 0) {
-	dol_print_error($db, $object->error); exit;
-}
 
 $type = $object->type;
 if (is_numeric($type)) $type = Categorie::$MAP_ID_TO_CODE[$type]; // For backward compatibility
@@ -216,9 +212,8 @@ llxHeader("", $langs->trans("Categories"), $helpurl, '', 0, 0, $arrayofjs, $arra
 $title = Categorie::$MAP_TYPE_TITLE_AREA[$type];
 
 $head = categories_prepare_head($object, $type);
-
-
 print dol_get_fiche_head($head, 'card', $langs->trans($title), -1, 'category');
+
 $backtolist = (GETPOST('backtolist') ? GETPOST('backtolist') : DOL_URL_ROOT.'/categories/index.php?leftmenu=cat&type='.$type);
 $linkback = '<a href="'.$backtolist.'">'.$langs->trans("BackToList").'</a>';
 $object->next_prev_filter = ' type = '.$object->type;

--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -38,7 +38,6 @@ $langs->load("categories");
 
 $id         = GETPOST('id', 'int');
 $label      = GETPOST('label', 'alpha');
-$type       = GETPOST('type', 'aZ09');
 $removeelem = GETPOST('removeelem', 'int');
 $elemid     = GETPOST('elemid', 'int');
 
@@ -73,7 +72,7 @@ if ($id == "" && $label == "")
 $result = restrictedArea($user, 'categorie', $id, '&category');
 
 $object = new Categorie($db);
-$result = $object->fetch($id, $label, $type);
+$result = $object->fetch($id, $label);
 if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
@@ -82,10 +81,7 @@ if ($result <= 0) {
 	dol_print_error($db, $object->error); exit;
 }
 
-$objecttype = $object->type;
-if (is_numeric($objecttype)) $objecttype = Categorie::$MAP_ID_TO_CODE[$objecttype];
-if ($type === '') $type = $objecttype;
-
+$type = $object->type;
 if (is_numeric($type)) $type = Categorie::$MAP_ID_TO_CODE[$type]; // For backward compatibility
 
 $extrafields = new ExtraFields($db);
@@ -93,12 +89,6 @@ $extrafields->fetch_name_optionals_label($object->table_element);
 
 // Initialize technical object to manage hooks. Note that conf->hooks_modules contains array array
 $hookmanager->initHooks(array('categorycard', 'globalcard'));
-
-// Protection when type provided is not similare to type of category
-if ($objecttype != $type) {
-	print 'Error: Value for type parameter does not match value of the type of the category with id='.$id;
-	exit;
-}
 
 /*
  *	Actions

--- a/htdocs/core/lib/categories.lib.php
+++ b/htdocs/core/lib/categories.lib.php
@@ -57,7 +57,7 @@ function categories_prepare_head(Categorie $object, $type)
 		$h++;
 	}
 
-	$head[$h][0] = DOL_URL_ROOT.'/categories/info.php?id='.$object->id;
+	$head[$h][0] = DOL_URL_ROOT.'/categories/info.php?id='.$object->id.'&amp;type='.$type;
 	$head[$h][1] = $langs->trans("Info");
 	$head[$h][2] = 'info';
 	$h++;


### PR DESCRIPTION
# Fix #15475 

Done like info.php page:
- DO NOT read type parameter 
- fetch object by id -> display error and exit
- get type from object
- call Categorie::$MAP_ID_TO_CODE[$type] if numeric

I also updated viewcat.php and photos.php

I don't see why there would have been a regression, I think the bug has always been present since categories are named.
So this fix should be applied to all maintained versions.

Active developers should review the other pages.
