### PR TITLE
NEW: Add edit/delete action icons on categories list pages

### DIFF
--- a/htdocs/categories/edit.php
+++ b/htdocs/categories/edit.php
@@ -39,6 +39,7 @@ $type = GETPOST('type', 'aZ09');		// Can be int or string
 $action = (GETPOST('action', 'aZ09') ?GETPOST('action', 'aZ09') : 'edit');
 $confirm = GETPOST('confirm');
 $cancel = GETPOST('cancel', 'alpha');
+$backtopage = GETPOST('backtopage', 'alpha');
 
 $socid = (int) GETPOST('socid', 'int');
 $label = (string) GETPOST('label', 'alphanohtml');
@@ -74,8 +75,13 @@ $error = 0;
  */
 
 if ($cancel) {
-	header('Location: '.DOL_URL_ROOT.'/categories/viewcat.php?id='.$object->id.'&type='.$type);
-	exit;
+	if ($backtopage) {
+		header("Location: ".$backtopage);
+		exit;
+	} else {
+		header('Location: '.DOL_URL_ROOT.'/categories/viewcat.php?id='.$object->id.'&type='.$type);
+		exit;
+	}
 }
 
 // Action mise a jour d'une categorie
@@ -98,9 +104,15 @@ if ($action == 'update' && $user->rights->categorie->creer) {
 		$ret = $extrafields->setOptionalsFromPost(null, $object);
 		if ($ret < 0) $error++;
 
-		if (!$error && $object->update($user) > 0) {
-			header('Location: '.DOL_URL_ROOT.'/categories/viewcat.php?id='.$object->id.'&type='.$type);
-			exit;
+		if (!$error && $object->update($user) > 0)
+		{
+			if ($backtopage) {
+				header("Location: ".$backtopage);
+				exit;
+			} else {
+				header('Location: '.DOL_URL_ROOT.'/categories/viewcat.php?id='.$object->id.'&type='.$type);
+				exit;
+			}
 		} else {
 			setEventMessages($object->error, $object->errors, 'errors');
 		}
@@ -131,6 +143,7 @@ print '<input type="hidden" name="token" value="'.newToken().'">';
 print '<input type="hidden" name="action" value="update">';
 print '<input type="hidden" name="id" value="'.$object->id.'">';
 print '<input type="hidden" name="type" value="'.$type.'">';
+print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
 
 print dol_get_fiche_head('');
 

--- a/htdocs/categories/index.php
+++ b/htdocs/categories/index.php
@@ -109,7 +109,7 @@ if (empty($nosearch)) {
 
 		foreach ($cats as $cat)
 		{
-			$color = $categstatic->color ? ' style="background: #'.$categstatic->color.';"' : ' style="background: #bbb"';
+			$color = $categstatic->color ? ' style="background: #'.sprintf("%06s", $categstatic->color).';"' : ' style="background: #bbb"';
 
 			print "\t".'<tr class="oddeven">'."\n";
 			print "\t\t<td>";
@@ -160,26 +160,45 @@ foreach ($fulltree as $key => $val)
 	$categstatic->ref = $val['label'];
 	$categstatic->color = $val['color'];
 	$categstatic->type = $type;
-	$li = $categstatic->getNomUrl(1, '', 60, $moreparam.'&backtolist='.urlencode($_SERVER["PHP_SELF"].'?type='.$type.$moreparam));
 	$desc = dol_htmlcleanlastbr($val['description']);
 
 	$counter = '';
-
 	if ($conf->global->CATEGORY_SHOW_COUNTS)
 	{
 		// we need only a count of the elements, so it is enough to consume only the id's from the database
-		$elements = $categstatic->getObjectsInCateg($type, 1);
+		$elements = $type == Categorie::TYPE_ACCOUNT
+			? $categstatic->getObjectsInCateg("account", 1)			// Categorie::TYPE_ACCOUNT is "bank_account" instead of "account"
+			: $categstatic->getObjectsInCateg($type, 1);
+
 		$counter = "<td class='left' width='40px;'>".(is_countable($elements) ? count($elements) : '0')."</td>";
 	}
 
 	$color = $categstatic->color ? ' style="background: #'.sprintf("%06s", $categstatic->color).';"' : ' style="background: #bbb"';
+	$li = $categstatic->getNomUrl(1, '', 60, '&backtolist='.urlencode($_SERVER["PHP_SELF"].'?type='.$type.$moreparam));
 
-	$data[] = array(
-	'rowid'=>$val['rowid'],
-	'fk_menu'=>$val['fk_parent'],
-	'entry'=>'<table class="nobordernopadding centpercent"><tr><td><span class="noborderoncategories"'.$color.'>'.$li.'</span></td>'.$counter.
-		'<td class="right" width="20px;"><a href="'.DOL_URL_ROOT.'/categories/viewcat.php?id='.$val['id'].'&type='.$type.$moreparam.'&backtolist='.urlencode($_SERVER["PHP_SELF"].'?type='.$type.$moreparam).'">'.img_view().'</a></td></tr></table>'
-	);
+	$entry = '<table class="nobordernopadding centpercent">';
+	$entry .= '<tr>';
+
+	$entry .= '<td>';
+	$entry .= '<span class="noborderoncategories" '.$color.'>'.$li.'</span>';
+	$entry .= '</td>';
+
+	$entry .= $counter;
+
+	$entry .= '<td class="right" width="20px;">';
+	$entry .= '<a href="'.DOL_URL_ROOT.'/categories/viewcat.php?id='.$val['id'].'&type='.$type.$moreparam.'&backtolist='.urlencode($_SERVER["PHP_SELF"].'?type='.$type).'">'.img_view().'</a>';
+	$entry .= '</td>';
+	$entry .= '<td class="right" width="20px;">';
+	$entry .= '<a class="editfielda" href="'.DOL_URL_ROOT.'/categories/edit.php?id='.$val['id'].'&type='.$type.$moreparam.'&backtopage='.urlencode($_SERVER["PHP_SELF"].'?type='.$type).'">'.img_edit().'</a>';
+	$entry .= '</td>';
+	$entry .= '<td class="right" width="20px;">';
+	$entry .= '<a class="deletefilelink" href="'.DOL_URL_ROOT.'/categories/viewcat.php?action=delete&token='.newToken().'&id='.$val['id'].'&type='.$type.$moreparam.'&backtopage='.urlencode($_SERVER["PHP_SELF"].'?type='.$type.$moreparam).'&backtolist='.urlencode($_SERVER["PHP_SELF"].'?type='.$type.$moreparam).'">'.img_delete().'</a>';
+	$entry .= '</td>';
+
+	$entry .= '</tr>';
+	$entry .= '</table>';
+
+	$data[] = array('rowid' => $val['rowid'], 'fk_menu' => $val['fk_parent'], 'entry' => $entry);
 }
 
 
@@ -194,7 +213,6 @@ if (!empty($conf->use_javascript_ajax))
 print '</td></tr>';
 
 $nbofentries = (count($data) - 1);
-
 if ($nbofentries > 0)
 {
 	print '<tr class="pair"><td colspan="3">';

--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -104,6 +104,14 @@ if ($objecttype != $type) {
  *	Actions
  */
 
+if ($confirm == 'no')
+{
+	if ($backtopage) {
+		header("Location: ".$backtopage);
+		exit;
+	}
+}
+
 $parameters = array();
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 // Remove element from category
@@ -164,8 +172,13 @@ if ($user->rights->categorie->supprimer && $action == 'confirm_delete' && $confi
 {
 	if ($object->delete($user) >= 0)
 	{
-		header("Location: ".DOL_URL_ROOT.'/categories/index.php?type='.$type);
-		exit;
+		if ($backtopage) {
+			header("Location: ".$backtopage);
+			exit;
+		} else {
+			header("Location: ".DOL_URL_ROOT.'/categories/index.php?type='.$type);
+			exit;
+		}
 	} else {
 		setEventMessages($object->error, $object->errors, 'errors');
 	}
@@ -250,7 +263,11 @@ dol_banner_tab($object, 'label', $linkback, ($user->socid ? 0 : 1), 'label', 'la
 
 if ($action == 'delete')
 {
-	print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;type='.$type, $langs->trans('DeleteCategory'), $langs->trans('ConfirmDeleteCategory'), 'confirm_delete', '', '', 1);
+	if ($backtopage) {
+		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id.'&type='.$type.'&backtopage='.urlencode($backtopage), $langs->trans('DeleteCategory'), $langs->trans('ConfirmDeleteCategory'), 'confirm_delete', '', '', 2);
+	} else {
+		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id.'&type='.$type, $langs->trans('DeleteCategory'), $langs->trans('ConfirmDeleteCategory'), 'confirm_delete', '', '', 1);
+	}
 }
 
 print '<br>';
@@ -294,7 +311,7 @@ if ($user->rights->categorie->creer)
 
 if ($user->rights->categorie->supprimer)
 {
-	print '<a class="butActionDelete" href="'.$_SERVER["PHP_SELF"].'?action=delete&token='.newToken().'&id='.$object->id.'&type='.$type.'">'.$langs->trans("Delete").'</a>';
+	print '<a class="butActionDelete" href="'.$_SERVER["PHP_SELF"].'?action=delete&token='.newToken().'&id='.$object->id.'&type='.$type.'&backtolist='.urlencode($backtolist).'">'.$langs->trans("Delete").'</a>';
 }
 
 print "</div>";
@@ -376,8 +393,7 @@ if ($cats < 0)
 		$categstatic->type = $type;
 		$desc = dol_htmlcleanlastbr($val['description']);
 
-		$counter = 0;
-
+		$counter = '';
 		if ($conf->global->CATEGORY_SHOW_COUNTS)
 		{
 			// we need only a count of the elements, so it is enough to consume only the id's from the database
@@ -385,22 +401,29 @@ if ($cats < 0)
 				? $categstatic->getObjectsInCateg("account", 1)			// Categorie::TYPE_ACCOUNT is "bank_account" instead of "account"
 				: $categstatic->getObjectsInCateg($type, 1);
 
-			$counter = is_countable($elements) ? count($elements) : 0;
+			$counter = "<td class='left' width='40px;'>".(is_countable($elements) ? count($elements) : '0')."</td>";
 		}
 
-		$color = $categstatic->color ? ' style="background: #'.$categstatic->color.';"' : ' style="background: #aaa"';
+		$color = $categstatic->color ? ' style="background: #'.sprintf("%06s", $categstatic->color).';"' : ' style="background: #bbb"';
+		$li = $categstatic->getNomUrl(1, '', 60, '&backtolist='.urlencode($_SERVER["PHP_SELF"].'?id='.$id.'&type='.$type));
 
 		$entry = '<table class="nobordernopadding centpercent">';
 		$entry .= '<tr>';
 
 		$entry .= '<td>';
-		$entry .= '<span class="noborderoncategories" '.$color.'>'.$categstatic->getNomUrl(1, '', 60).'</span>';
+		$entry .= '<span class="noborderoncategories" '.$color.'>'.$li.'</span>';
 		$entry .= '</td>';
 
-		$entry .= '<td class="left" width="40px;">'.$counter.'</td>';
+		$entry .= $counter;
 
 		$entry .= '<td class="right" width="20px;">';
-		$entry .= '<a href="'.DOL_URL_ROOT.'/categories/viewcat.php?id='.$val['id'].'&type='.$type.'">'.img_view().'</a>';
+		$entry .= '<a href="'.DOL_URL_ROOT.'/categories/viewcat.php?id='.$val['id'].'&type='.$type.'&backtolist='.urlencode($_SERVER["PHP_SELF"].'?id='.$id.'&type='.$type).'">'.img_view().'</a>';
+		$entry .= '</td>';
+		$entry .= '<td class="right" width="20px;">';
+		$entry .= '<a class="editfielda" href="'.DOL_URL_ROOT.'/categories/edit.php?id='.$val['id'].'&type='.$type.'&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$id.'&type='.$type).'">'.img_edit().'</a>';
+		$entry .= '</td>';
+		$entry .= '<td class="right" width="20px;">';
+		$entry .= '<a class="deletefilelink" href="'.DOL_URL_ROOT.'/categories/viewcat.php?action=delete&token='.newToken().'&id='.$val['id'].'&type='.$type.'&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$id.'&type='.$type).'&backtolist='.urlencode($_SERVER["PHP_SELF"].'?id='.$id.'&type='.$type).'">'.img_delete().'</a>';
 		$entry .= '</td>';
 
 		$entry .= '</tr>';
@@ -409,7 +432,8 @@ if ($cats < 0)
 		$data[] = array('rowid' => $val['rowid'], 'fk_menu' => $val['fk_parent'], 'entry' => $entry);
 	}
 
-	if ((count($data) - 1))
+	$nbofentries = (count($data) - 1);
+	if ($nbofentries > 0)
 	{
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/treeview.lib.php';
 		print '<tr class="pair">';


### PR DESCRIPTION
# Add edit/delete action icons on categories list pages

In index.php and viewcat.php, we can view the list of all / sub categories.
There's only one icon at the end of the line: it's a link to view the category, exactly like clicking on the category on the left, so it's useless. Then editing or delete a category from here is really annoying, we have to do many clicks:
- go to view
- click on modify or delete
- then come back to the parent category

This PR adds 2 new icons "Edit" and "Delete" for fast direct action and also easy navigation comes back automatically to the parent category :
![image](https://user-images.githubusercontent.com/69054301/99888978-377f6100-2c51-11eb-9db2-c2c2ee34f83c.png)

There are also 2 minor bug fixes : display counter & bank_account category

