### PR TITLE
Enable Imports with third-party references using customer/supplier code in addition to rowid and name in v13

### DIFF
--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -403,18 +403,18 @@ class ImportCsv extends ModeleImports
 							// We convert field if required
 							if (!empty($objimport->array_import_convertvalue[0][$val]))
 							{
-								//print 'Must convert '.$newval.' with rule '.join(',',$objimport->array_import_convertvalue[0][$val]).'. ';
+								//print 'Must convert '.$newval.' with rule '.join(',',$objimport->array_import_convertvalue[0][$val]).".<br>\n";
 								if ($objimport->array_import_convertvalue[0][$val]['rule'] == 'fetchidfromcodeid'
 									|| $objimport->array_import_convertvalue[0][$val]['rule'] == 'fetchidfromref'
+									|| $objimport->array_import_convertvalue[0][$val]['rule'] == 'fetchidfromreforcode'
 									|| $objimport->array_import_convertvalue[0][$val]['rule'] == 'fetchidfromcodeorlabel'
 									)
 								{
 									// New val can be an id or ref. If it start with id: it is forced to id, if it start with ref: it is forced to ref. It not, we try to guess.
 									$isidorref = 'id';
 									if (!is_numeric($newval) && $newval != '' && !preg_match('/^id:/i', $newval)) $isidorref = 'ref';
-
 									$newval = preg_replace('/^(id|ref):/i', '', $newval); // Remove id: or ref: that was used to force if field is id or ref
-									//print 'Val is now '.$newval.' and is type '.$isidorref."<br>\n";
+									//print 'newval is now '.$newval.' and is type '.$isidorref."<br>\n";
 
 									if ($isidorref == 'ref') {    // If value into input import file is a ref, we apply the function defined into descriptor
 										$file = (empty($objimport->array_import_convertvalue[0][$val]['classfile']) ? $objimport->array_import_convertvalue[0][$val]['file'] : $objimport->array_import_convertvalue[0][$val]['classfile']);
@@ -423,6 +423,7 @@ class ImportCsv extends ModeleImports
 										if ($this->cacheconvert[$file.'_'.$class.'_'.$method.'_'][$newval] != '')
 										{
 											$newval = $this->cacheconvert[$file.'_'.$class.'_'.$method.'_'][$newval];
+											//print 'Cache hit: newval is now '.$newval."<br>\n";
 										} else {
 											$resultload = dol_include_once($file);
 											if (empty($resultload))
@@ -430,6 +431,7 @@ class ImportCsv extends ModeleImports
 												dol_print_error('', 'Error trying to call file='.$file.', class='.$class.', method='.$method);
 												break;
 											}
+											//print 'Instanciate class '.$class."<br>\n";
 											$classinstance = new $class($this->db);
 											// Try the fetch from code or ref
 											$param_array = array('', $newval);
@@ -450,17 +452,21 @@ class ImportCsv extends ModeleImports
 											}
 
 											call_user_func_array(array($classinstance, $method), $param_array);
+											//print "Get id by calling ".$class."->".$method."('','".$newval."')<br>\n";
 											// If not found, try the fetch from label
-											if (!($classinstance->id != '') && $objimport->array_import_convertvalue[0][$val]['rule'] == 'fetchidfromcodeorlabel')
+											if (!($classinstance->id != '')
+												&& (($objimport->array_import_convertvalue[0][$val]['rule'] == 'fetchidfromreforcode')
+												|| $objimport->array_import_convertvalue[0][$val]['rule'] == 'fetchidfromcodeorlabel'))
 											{
 												$param_array = array('', '', $newval);
 												call_user_func_array(array($classinstance, $method), $param_array);
+												//print "Get id by calling ".$class."->".$method."('','','".$newval."')<br>\n";
 											}
 											$this->cacheconvert[$file.'_'.$class.'_'.$method.'_'][$newval] = $classinstance->id;
-											//print 'We have made a '.$class.'->'.$method.' to get id from code '.$newval.'. ';
 											if ($classinstance->id != '')	// id may be 0, it is a found value
 											{
 												$newval = $classinstance->id;
+												//print 'newval is now '.$newval."<br>\n";
 											} else {
 												if (!empty($objimport->array_import_convertvalue[0][$val]['dict'])) $this->errors[$error]['lib'] = $langs->trans('ErrorFieldValueNotIn', $key, $newval, 'code', $langs->transnoentitiesnoconv($objimport->array_import_convertvalue[0][$val]['dict']));
 												elseif (!empty($objimport->array_import_convertvalue[0][$val]['element'])) $this->errors[$error]['lib'] = $langs->trans('ErrorFieldRefNotIn', $key, $newval, $langs->transnoentitiesnoconv($objimport->array_import_convertvalue[0][$val]['element']));
@@ -474,7 +480,7 @@ class ImportCsv extends ModeleImports
 								} elseif ($objimport->array_import_convertvalue[0][$val]['rule'] == 'fetchidfromcodeandlabel') {
 									$isidorref = 'id';
 									if (!is_numeric($newval) && $newval != '' && !preg_match('/^id:/i', $newval)) $isidorref = 'ref';
-									$newval = preg_replace('/^(id|ref):/i', '', $newval);
+									$newval = preg_replace('/^(id|ref):/i', '', $newval); // Remove id: or ref: that was used to force if field is id or ref
 
 									if ($isidorref == 'ref') {
 										$file = (empty($objimport->array_import_convertvalue[0][$val]['classfile']) ? $objimport->array_import_convertvalue[0][$val]['file'] : $objimport->array_import_convertvalue[0][$val]['classfile']);

--- a/htdocs/core/modules/modCategorie.class.php
+++ b/htdocs/core/modules/modCategorie.class.php
@@ -385,6 +385,7 @@ class modCategorie extends DolibarrModules
 				'codefromfield' => 'ca.type'
 			)
 		);
+
 		$typeexample = "";
 		if (!empty($conf->product->enabled)) { $typeexample .= ($typeexample ? "/" : "")."0=Product"; }
 		if (!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD) || !empty($conf->supplier_order->enabled) || !empty($conf->supplier_invoice->enabled)) { $typeexample .= ($typeexample ? "/" : "")."1=Supplier"; }
@@ -431,7 +432,7 @@ class modCategorie extends DolibarrModules
 
 			$this->import_convertvalue_array[$r] = array(
 					'cs.fk_categorie'=>array('rule'=>'fetchidfromref', 'classfile'=>'/categories/class/categorie.class.php', 'class'=>'Categorie', 'method'=>'fetch', 'element'=>'category'),
-					'cs.fk_soc'=>array('rule'=>'fetchidfromref', 'classfile'=>'/societe/class/societe.class.php', 'class'=>'Societe', 'method'=>'fetch', 'element'=>'ThirdParty')
+					'cs.fk_soc'=>array('rule'=>'fetchidfromreforcode', 'classfile'=>'/societe/class/societe.class.php', 'class'=>'Societe', 'method'=>'fetchbycustomercode', 'element'=>'ThirdParty')
 			);
 			$this->import_examplevalues_array[$r] = array('cs.fk_categorie'=>"Imported category", 'cs.fk_soc'=>"MyBigCompany");
 
@@ -472,7 +473,7 @@ class modCategorie extends DolibarrModules
 
 			$this->import_convertvalue_array[$r] = array(
 					'cs.fk_categorie'=>array('rule'=>'fetchidfromref', 'classfile'=>'/categories/class/categorie.class.php', 'class'=>'Categorie', 'method'=>'fetch', 'element'=>'category'),
-					'cs.fk_soc'=>array('rule'=>'fetchidfromref', 'classfile'=>'/societe/class/societe.class.php', 'class'=>'Societe', 'method'=>'fetch', 'element'=>'ThirdParty')
+					'cs.fk_soc'=>array('rule'=>'fetchidfromreforcode', 'classfile'=>'/societe/class/societe.class.php', 'class'=>'Societe', 'method'=>'fetchbysuppliercode', 'element'=>'ThirdParty')
 			);
 			$this->import_examplevalues_array[$r] = array('cs.fk_categorie'=>"Imported category", 'cs.fk_soc'=>"MyBigCompany");
 		}

--- a/htdocs/core/modules/modCommande.class.php
+++ b/htdocs/core/modules/modCommande.class.php
@@ -263,14 +263,15 @@ class modCommande extends DolibarrModules
 		$this->export_sql_end[$r] .= ' WHERE c.fk_soc = s.rowid AND c.rowid = cd.fk_commande';
 		$this->export_sql_end[$r] .= ' AND c.entity IN ('.getEntity('commande').')';
 		if (empty($user->rights->societe->client->voir)) $this->export_sql_end[$r] .= ' AND sc.fk_user = '.(empty($user) ? 0 : $user->id);
+
 		// Imports
 		//--------
 		$r = 0;
-		//Import Order Header
 
+		//Import Order Header
 		$r++;
 		$this->import_code[$r] = 'commande_'.$r;
-		$this->import_label[$r] = 'Sales Orders';
+		$this->import_label[$r] = 'CustomerOrder';
 		$this->import_icon[$r] = $this->picto;
 		$this->import_entities_array[$r] = [];
 		$this->import_tables_array[$r] = ['c' => MAIN_DB_PREFIX.'commande', 'extra' => MAIN_DB_PREFIX.'commande_extrafields'];
@@ -294,8 +295,8 @@ class modCommande extends DolibarrModules
 			'c.note_public'       => 'Note',
 			'c.facture'           => 'Invoice(1/0)',
 			'c.date_livraison'    => 'DeliveryDate',
-			'c.fk_cond_reglement' => 'Payment Condition',
-			'c.fk_mode_reglement' => 'Payment Mode',
+			'c.fk_cond_reglement' => 'PaymentTermsCustomer',
+			'c.fk_mode_reglement' => 'PaymentTypeCustomer',
 			'c.model_pdf'         => 'Model'
 		];
 
@@ -331,10 +332,10 @@ class modCommande extends DolibarrModules
 		$this->import_updatekeys_array[$r] = ['c.ref' => 'Ref'];
 		$this->import_convertvalue_array[$r] = [
 			'c.fk_soc' => [
-				'rule'    => 'fetchidfromref',
+				'rule'    => 'fetchidfromreforcode',
 				'file'    => '/societe/class/societe.class.php',
 				'class'   => 'Societe',
-				'method'  => 'fetch',
+				'method'  => 'fetchbycustomercode',
 				'element' => 'ThirdParty'
 			],
 			'c.fk_user_valid' => [
@@ -344,8 +345,17 @@ class modCommande extends DolibarrModules
 				'method'  => 'fetch',
 				'element' => 'user'
 			],
+			/* TODO
+			'c.fk_cond_reglement' => [
+				'rule' => 'fetchidfromcodeid',
+				'file' => '/core/class/cpaymentterm.class.php',
+				'class' => 'Cpaymentterm',
+				'method' => 'fetch',
+				'element' => 'cpaymentterm'
+			],
+			*/
 			'c.fk_mode_reglement' => [
-				'rule' => 'fetchidfromcodeorlabel',
+				'rule' => 'fetchidfromcodeid',
 				'file' => '/compta/paiement/class/cpaiement.class.php',
 				'class' => 'Cpaiement',
 				'method' => 'fetch',
@@ -356,7 +366,7 @@ class modCommande extends DolibarrModules
 		//Import CPV Lines
 		$r++;
 		$this->import_code[$r] = 'commande_lines_'.$r;
-		$this->import_label[$r] = 'Order Details';
+		$this->import_label[$r] = 'OrderLine';
 		$this->import_icon[$r] = $this->picto;
 		$this->import_entities_array[$r] = [];
 		$this->import_tables_array[$r] = ['cd' => MAIN_DB_PREFIX.'commandedet', 'extra' => MAIN_DB_PREFIX.'commandedet_extrafields'];

--- a/htdocs/core/modules/modFournisseur.class.php
+++ b/htdocs/core/modules/modFournisseur.class.php
@@ -658,7 +658,7 @@ class modFournisseur extends DolibarrModules
 
 		$r++;
 		$this->import_code[$r] = $this->rights_class.'_'.$r;
-		$this->import_label[$r] = "Supplier Invoice"; // Translation key
+		$this->import_label[$r] = "SuppliersInvoice"; // Translation key
 		$this->import_icon[$r] = $this->picto;
 		$this->import_entities_array[$r] = []; // We define here only fields that use another icon that the one defined into import_icon
 		$this->import_tables_array[$r] = ['f' => MAIN_DB_PREFIX.'facture_fourn', 'extra' => MAIN_DB_PREFIX.'facture_fourn_extrafields'];
@@ -683,8 +683,8 @@ class modFournisseur extends DolibarrModules
 			'f.fk_account' => 'Bank Account*',
 			'f.note_public' => 'InvoiceNote',
 			'f.note_private' => 'NotePrivate',
-			'f.fk_cond_reglement' => 'Payment Condition',
-			'f.fk_mode_reglement' => 'Payment Mode',
+			'f.fk_cond_reglement' => 'PaymentTermsSupplier',
+			'f.fk_mode_reglement' => 'PaymentTypeSupplier',
 			'f.model_pdf' => 'Model',
 			'f.date_valid' => 'Validation Date'
 		];
@@ -712,9 +712,9 @@ class modFournisseur extends DolibarrModules
 		$this->import_regex_array[$r] = ['f.ref' => '(SI\d{4}-\d{4}|PROV.{1,32}$)', 'f.multicurrency_code' => 'code@'.MAIN_DB_PREFIX.'multicurrency'];
 		$import_sample = [
 			'f.ref' => '(PROV001)',
-			'f.ref_supplier' => 'Supplier1',
+			'f.ref_supplier' => 'RefSupplier',
 			'f.type' => '0',
-			'f.fk_soc' => 'Vendor1',
+			'f.fk_soc' => 'Supplier/Vendor name or code',
 			'f.datec' => '2021-01-01',
 			'f.datef' => '',
 			'f.date_lim_reglement' => '2021-01-30',
@@ -730,8 +730,8 @@ class modFournisseur extends DolibarrModules
 			'f.fk_account' => 'BANK1',
 			'f.note_public' => 'Note: ',
 			'f.note_private' => '',
-			'f.fk_cond_reglement' => '1',
-			'f.fk_mode_reglement' => '2',
+			'f.fk_cond_reglement' => '1/2/3...matches field "rowid" in table "'.MAIN_DB_PREFIX.'c_payment_term"',
+			'f.fk_mode_reglement' => 'id or code in table "'.MAIN_DB_PREFIX.'c_paiement"',
 			'f.model_pdf' => 'crab',
 			'f.date_valid' => '',
 			'f.multicurrency_code' => 'USD',
@@ -744,14 +744,25 @@ class modFournisseur extends DolibarrModules
 		$this->import_updatekeys_array[$r] = ['f.ref' => 'Ref'];
 		$this->import_convertvalue_array[$r] = [
 			//'c.ref'=>array('rule'=>'getrefifauto'),
-			'f.fk_soc' => ['rule' => 'fetchidfromref', 'file' => '/societe/class/societe.class.php', 'class' => 'Societe', 'method' => 'fetch', 'element' => 'ThirdParty'],
-			'f.fk_account' => ['rule' => 'fetchidfromref', 'file' => '/compta/bank/class/account.class.php', 'class' => 'Account', 'method' => 'fetch', 'element' => 'bank_account'],
+			'f.fk_soc' => [
+				'rule'    => 'fetchidfromreforcode',
+				'file'    => '/societe/class/societe.class.php',
+				'class'   => 'Societe',
+				'method'  => 'fetchbysuppliercode',
+				'element' => 'ThirdParty'
+			],
+			'f.fk_account' => [
+				'rule' => 'fetchidfromref',
+				'file' => '/compta/bank/class/account.class.php',
+				'class' => 'Account',
+				'method' => 'fetch',
+				'element' => 'bank_account'],
 		];
 
 		//Import Supplier Invoice Lines
 		$r++;
 		$this->import_code[$r] = $this->rights_class.'_'.$r;
-		$this->import_label[$r] = "Supplier Invoice Lines"; // Translation key
+		$this->import_label[$r] = "InvoiceLine"; // Translation key
 		$this->import_icon[$r] = $this->picto;
 		$this->import_entities_array[$r] = []; // We define here only fields that use another icon that the one defined into import_icon
 		$this->import_tables_array[$r] = ['fd' => MAIN_DB_PREFIX.'facture_fourn_det', 'extra' => MAIN_DB_PREFIX.'facture_fourn_det_extrafields'];
@@ -831,7 +842,7 @@ class modFournisseur extends DolibarrModules
 		//Import Purchase Orders
 		$r++;
 		$this->import_code[$r] = 'commande_fournisseur_'.$r;
-		$this->import_label[$r] = 'Purchase Orders';
+		$this->import_label[$r] = 'SupplierOrder';
 		$this->import_icon[$r] = $this->picto;
 		$this->import_entities_array[$r] = [];
 		$this->import_tables_array[$r] = ['c' => MAIN_DB_PREFIX.'commande_fournisseur', 'extra' => MAIN_DB_PREFIX.'commande_fournisseur_extrafields'];
@@ -839,7 +850,7 @@ class modFournisseur extends DolibarrModules
 		$this->import_fields_array[$r] = [
 			'c.ref'               => 'Document Ref*',
 			'c.ref_supplier'      => 'RefSupplier',
-			'c.fk_soc'            => 'ThirdPartyName*',
+			'c.fk_soc'            => 'Supplier/Vendor*',
 			'c.fk_projet'         => 'ProjectId',
 			'c.date_creation'     => 'DateCreation',
 			'c.date_valid'        => 'DateValid',
@@ -858,8 +869,8 @@ class modFournisseur extends DolibarrModules
 			'c.note_private'      => 'NotePrivate',
 			'c.note_public'       => 'Note',
 			'c.date_livraison'    => 'DeliveryDate',
-			'c.fk_cond_reglement' => 'Payment Condition',
-			'c.fk_mode_reglement' => 'Payment Mode',
+			'c.fk_cond_reglement' => 'PaymentTypeSupplier',
+			'c.fk_mode_reglement' => 'PaymentTermsSupplier',
 			'c.model_pdf'         => 'Model'
 		];
 
@@ -870,7 +881,6 @@ class modFournisseur extends DolibarrModules
 			$this->import_fields_array[$r]['c.multicurrency_total_tva'] = 'MulticurrencyAmountVAT';
 			$this->import_fields_array[$r]['c.multicurrency_total_ttc'] = 'MulticurrencyAmountTTC';
 		}
-
 		// Add extra fields
 		$import_extrafield_sample = [];
 		$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE elementtype = 'commande_fournisseur' AND entity IN (0, ".$conf->entity.")";
@@ -885,24 +895,45 @@ class modFournisseur extends DolibarrModules
 			}
 		}
 		// End add extra fields
-
 		$this->import_fieldshidden_array[$r] = ['extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'commande_fournisseur'];
 		$this->import_regex_array[$r] = [
 			'c.ref' => '(PO\d{4}-\d{4}|PORDER.{1,32}$|PROV.{1,32}$)',
 			'c.multicurrency_code' => 'code@'.MAIN_DB_PREFIX.'multicurrency'
 		];
+		$import_sample = [
+			'c.ref'	              => '(PROV001)',
+			'c.ref_supplier'	  => 'RefSupplier',
+			'c.fk_soc'	          => 'Supplier/Vendor name or code',
+			'c.date_creation'	  => '2021-01-01',
+			'c.date_valid'		  => '2021-01-01',
+			'c.date_approve'      => '2021-01-01',
+			'c.date_commande'     => '2021-01-01',
+			'c.date_livraison'	  => '2021-01-01',
+			'c.fk_cond_reglement' => '1/2/3...matches field "rowid" in table "'.MAIN_DB_PREFIX.'c_payment_term"',
+			'c.fk_mode_reglement' => 'id or code in table "'.MAIN_DB_PREFIX.'c_paiement"',
+		];
 
+		$this->import_examplevalues_array[$r] = array_merge($import_sample, $import_extrafield_sample);
 		$this->import_updatekeys_array[$r] = ['c.ref' => 'Ref'];
 		$this->import_convertvalue_array[$r] = [
 			'c.fk_soc' => [
-				'rule'    => 'fetchidfromref',
+				'rule'    => 'fetchidfromreforcode',
 				'file'    => '/societe/class/societe.class.php',
 				'class'   => 'Societe',
-				'method'  => 'fetch',
+				'method'  => 'fetchbysuppliercode',
 				'element' => 'ThirdParty'
 			],
+			/* TODO
+			'c.fk_cond_reglement' => [
+				'rule' => 'fetchidfromcodeid',
+				'file' => '/core/class/cpaymentterm.class.php',
+				'class' => 'Cpaymentterm',
+				'method' => 'fetch',
+				'element' => 'cpaymentterm'
+			],
+			*/
 			'c.fk_mode_reglement' => [
-				'rule' => 'fetchidfromcodeorlabel',
+				'rule' => 'fetchidfromcodeid',
 				'file' => '/compta/paiement/class/cpaiement.class.php',
 				'class' => 'Cpaiement',
 				'method' => 'fetch',
@@ -914,7 +945,7 @@ class modFournisseur extends DolibarrModules
 		//Import PO Lines
 		$r++;
 		$this->import_code[$r] = 'commande_fournisseurdet_'.$r;
-		$this->import_label[$r] = 'PO Lines';
+		$this->import_label[$r] = 'OrderLine';
 		$this->import_icon[$r] = $this->picto;
 		$this->import_entities_array[$r] = [];
 		$this->import_tables_array[$r] = ['cd' => MAIN_DB_PREFIX.'commande_fournisseurdet', 'extra' => MAIN_DB_PREFIX.'commande_fournisseurdet_extrafields'];
@@ -948,7 +979,6 @@ class modFournisseur extends DolibarrModules
 			$this->import_fields_array[$r]['cd.multicurrency_total_tva'] = 'MulticurrencyAmountVAT';
 			$this->import_fields_array[$r]['cd.multicurrency_total_ttc'] = 'MulticurrencyAmountTTC';
 		}
-
 		// Add extra fields
 		$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE elementtype = 'commande_fournisseurdet' AND entity IN (0, ".$conf->entity.")";
 		$resql = $this->db->query($sql);
@@ -960,7 +990,6 @@ class modFournisseur extends DolibarrModules
 			}
 		}
 		// End add extra fields
-
 		$this->import_fieldshidden_array[$r] = ['extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'commande_fournisseurdet'];
 		$this->import_regex_array[$r] = [
 			'cd.product_type'       => '[0|1]$',

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -682,13 +682,13 @@ class modProduct extends DolibarrModules
 			$this->import_fieldshidden_array[$r] = array('extra.fk_object'=>'lastrowid-'.MAIN_DB_PREFIX.'product_fournisseur_price'); // aliastable.field => ('user->id' or 'lastrowid-'.tableparent)
 
 			$this->import_convertvalue_array[$r] = array(
-					'sp.fk_soc'=>array('rule'=>'fetchidfromref', 'classfile'=>'/societe/class/societe.class.php', 'class'=>'Societe', 'method'=>'fetch', 'element'=>'ThirdParty'),
+					'sp.fk_soc'=>array('rule'=>'fetchidfromreforcode', 'classfile'=>'/societe/class/societe.class.php', 'class'=>'Societe', 'method'=>'fetchbysuppliercode', 'element'=>'ThirdParty'),
 					'sp.fk_product'=>array('rule'=>'fetchidfromref', 'classfile'=>'/product/class/product.class.php', 'class'=>'Product', 'method'=>'fetch', 'element'=>'Product')
 			);
 
 			$this->import_examplevalues_array[$r] = array(
 				'sp.fk_product' => "PRODUCT_REF or id:123456",
-				'sp.fk_soc' => "My Supplier",
+				'sp.fk_soc' => "Supplier name or code",
 				'sp.ref_fourn' => "XYZ-F123456",
 				'sp.quantity' => "5",
 				'sp.tva_tx' => '10',

--- a/htdocs/core/modules/modPropale.class.php
+++ b/htdocs/core/modules/modPropale.class.php
@@ -306,8 +306,8 @@ class modPropale extends DolibarrModules
 		$this->import_regex_array[$r] = ['c.ref' => '[^ ]'];
 		$import_sample = [
 			'c.ref' => 'PROV0077',
-			'c.ref_client' => 'Client1',
-			'c.fk_soc' => 'MyBigCompany',
+			'c.ref_client' => 'RefClient',
+			'c.fk_soc' => 'Customer name or code',
 			'c.datec' => '2020-01-01',
 			'c.datep' => '2020-01-01',
 			'c.fin_validite' => '2020-01-01',
@@ -328,10 +328,10 @@ class modPropale extends DolibarrModules
 		$this->import_updatekeys_array[$r] = ['c.ref'=>'Ref'];
 		$this->import_convertvalue_array[$r] = [
 			'c.fk_soc' => [
-				'rule' => 'fetchidfromref',
+				'rule' => 'fetchidfromreforcode',
 				'file' => '/societe/class/societe.class.php',
 				'class' => 'Societe',
-				'method' => 'fetch',
+				'method' => 'fetchbycustomercode',
 				'element' => 'ThirdParty'
 			]
 		];

--- a/htdocs/core/modules/modService.class.php
+++ b/htdocs/core/modules/modService.class.php
@@ -604,12 +604,12 @@ class modService extends DolibarrModules
 				}
 
 				$this->import_convertvalue_array[$r] = array(
-						'sp.fk_soc'=>array('rule'=>'fetchidfromref', 'classfile'=>'/societe/class/societe.class.php', 'class'=>'Societe', 'method'=>'fetch', 'element'=>'ThirdParty'),
+						'sp.fk_soc'=>array('rule'=>'fetchidfromreforcode', 'classfile'=>'/societe/class/societe.class.php', 'class'=>'Societe', 'method'=>'fetchbysuppliercode', 'element'=>'ThirdParty'),
 						'sp.fk_product'=>array('rule'=>'fetchidfromref', 'classfile'=>'/product/class/product.class.php', 'class'=>'Product', 'method'=>'fetch', 'element'=>'Product')
 				);
 				$this->import_examplevalues_array[$r] = array(
 					'sp.fk_product' => "PRODUCT_REF or id:123456",
-					'sp.fk_soc' => "My Supplier",
+					'sp.fk_soc' => "Supplier name or code",
 					'sp.ref_fourn' => "XYZ-F123456",
 					'sp.quantity' => "5",
 					'sp.tva_tx' => '10',

--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -516,22 +516,56 @@ class modSociete extends DolibarrModules
 				'element' => 'ThirdParty'
 			),
 			's.outstanding_limit' => array('rule' => 'numeric'),
+			/* TODO
+			'c.cond_reglement' => [
+				'rule' => 'fetchidfromcodeid',
+				'file' => '/core/class/cpaymentterm.class.php',
+				'class' => 'Cpaymentterm',
+				'method' => 'fetch',
+				'element' => 'cpaymentterm'
+			],
+			*/
+			'c.mode_reglement' => array(
+				'rule' => 'fetchidfromcodeid',
+				'file' => '/compta/paiement/class/cpaiement.class.php',
+				'class' => 'Cpaiement',
+				'method' => 'fetch',
+				'element' => 'cpayment'
+			),
+			/* TODO
+			'c.cond_reglement_supplier' => [
+				'rule' => 'fetchidfromcodeid',
+				'file' => '/core/class/cpaymentterm.class.php',
+				'class' => 'Cpaymentterm',
+				'method' => 'fetch',
+				'element' => 'cpaymentterm'
+			],
+			*/
+			'c.mode_reglement_supplier' => array(
+				'rule' => 'fetchidfromcodeid',
+				'file' => '/compta/paiement/class/cpaiement.class.php',
+				'class' => 'Cpaiement',
+				'method' => 'fetch',
+				'element' => 'cpayment'
+			),
 			's.fk_account' => array(
 				'rule' => 'fetchidfromcodeid',
 				'classfile' => '/compta/bank/class/account.class.php',
 				'class' => 'Account',
 				'method' => 'fetch',
 				'element' => 'BankAccount'
-		//          ),
-		//          TODO
-		//          's.fk_incoterms' => array(
-		//              'rule' => 'fetchidfromcodeid',
-		//              'classfile' => '/core/class/cincoterm.class.php',
-		//              'class' => 'Cincoterm',
-		//              'method' => 'fetch',
-		//              'dict' => 'IncotermLabel'
-			)
+			),
+			/* TODO
+			's.fk_incoterms' => array(
+				'rule' => 'fetchidfromcodeid',
+		        'file' => '/core/class/cincoterm.class.php',
+		        'class' => 'Cincoterm',
+		        'method' => 'fetch',
+		        'dict' => 'IncotermLabel'
+			),
+			*/
 		);
+
 		//$this->import_convertvalue_array[$r]=array('s.fk_soc'=>array('rule'=>'lastrowid',table='t');
 		$this->import_regex_array[$r] = array(//field order as per structure of table llx_societe
 			's.status' => '^[0|1]',
@@ -585,9 +619,9 @@ class modSociete extends DolibarrModules
 			's.client' => '0 (no customer no prospect) / 1 (customer) / 2 (prospect)/ 3 (customer and prospect)',
 			's.fournisseur' => '0 (not supplier) / 1 (supplier)',
 			's.fk_prospectlevel' => 'eg. "PL_MEDIUM" matches field "code" in table "'.MAIN_DB_PREFIX.'c_prospectlevel"',
-			's.mode_reglement' => '1/2/3...matches field "id" in table "'.MAIN_DB_PREFIX.'c_paiement"',
+			's.mode_reglement' => 'id or code in table "'.MAIN_DB_PREFIX.'c_paiement"',
 			's.cond_reglement' => '1/2/3...matches field "rowid" in table "'.MAIN_DB_PREFIX.'c_payment_term"',
-			's.mode_reglement_supplier' => '1/2/3...matches field "id" in table "'.MAIN_DB_PREFIX.'c_paiement"',
+			's.mode_reglement_supplier' => 'id or code in table "'.MAIN_DB_PREFIX.'c_paiement"',
 			's.cond_reglement_supplier' => '1/2/3...matches field "rowid" in table "'.MAIN_DB_PREFIX.'c_payment_term"',
 			's.outstanding_limit' => "5000",
 			's.fk_account' => "rowid or ref",

--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -507,12 +507,12 @@ class modSociete extends DolibarrModules
 				'dict' => 'DictionaryCompanyType'
 			),
 			's.capital' => array('rule' => 'numeric'),
-			's.fk_stcomm' => array('rule' => 'zeroifnull'),
+			's.fk_stcomm' => array('rule' => 'zeroifnull'),	// TODO fetchidfromcodeid
 			's.parent' => array(
-				'rule' => 'fetchidfromref',
-				'file' => '/societe/class/societe.class.php',
+				'rule' => 'fetchidfromreforcode',
+				'classfile' => '/societe/class/societe.class.php',
 				'class' => 'Societe',
-				'method' => 'fetch',
+				'method' => 'fetchbycode',
 				'element' => 'ThirdParty'
 			),
 			's.outstanding_limit' => array('rule' => 'numeric'),
@@ -552,7 +552,7 @@ class modSociete extends DolibarrModules
 		$this->import_examplevalues_array[$r] = array(//field order as per structure of table llx_societe
 			's.nom' => "TPBigCompany",
 			's.name_alias' => "Alias for TPBigCompany",
-			's.parent' => "TPMotherCompany",
+			's.parent' => "TPMotherCompany, name or customer/supplier code",
 			's.status' => "0 (closed) / 1 (active)",
 			's.code_client' => 'eg. CU01-0001 / empty / "auto"',
 			's.code_fournisseur' => 'eg. SU01-0001 / empty / "auto"',
@@ -659,10 +659,10 @@ class modSociete extends DolibarrModules
 		); // aliastable.field => ('user->id' or 'lastrowid-'.tableparent)
 		$this->import_convertvalue_array[$r] = array(
 			's.fk_soc' => array(
-				'rule' => 'fetchidfromref',
-				'file' => '/societe/class/societe.class.php',
+				'rule' => 'fetchidfromreforcode',
+				'classfile' => '/societe/class/societe.class.php',
 				'class' => 'Societe',
-				'method' => 'fetch',
+				'method' => 'fetchbycode',
 				'element' => 'ThirdParty'
 			),
 			's.fk_departement' => array(
@@ -688,7 +688,7 @@ class modSociete extends DolibarrModules
 		$this->import_examplevalues_array[$r] = array(//field order as per structure of table llx_socpeople
 			's.rowid' => '1',
 			's.datec' => 'formatted as '.dol_print_date(dol_now(), '%Y-%m-%d'),
-			's.fk_soc' => 'Third Party name eg. TPBigCompany',
+			's.fk_soc' => 'Third Party name or customer/supplier code',
 			's.civility' => 'Title of civility eg: MR...matches field "code" in table "'.MAIN_DB_PREFIX.'c_civility"',
 			's.lastname' => "lastname or label",
 			's.firstname' => 'John',
@@ -740,18 +740,17 @@ class modSociete extends DolibarrModules
 
 		$this->import_convertvalue_array[$r] = array(
 			'sr.fk_soc' => array(
-				'rule' => 'fetchidfromref',
+				'rule' => 'fetchidfromreforcode',
 				'classfile' => '/societe/class/societe.class.php',
 				'class' => 'Societe',
-				'method' => 'fetch',
+				'method' => 'fetchbycode',
 				'element' => 'ThirdParty'
-			)
+			),
 		);
 		$this->import_examplevalues_array[$r] = array(//field order as per structure of table llx_societe_rib
 			'sr.label' => 'eg. "account1"',
-			'sr.fk_soc' => 'eg. "TPBigCompany"',
-			'sr.datec' => 'date used for creating direct debit UMR formatted as '.dol_print_date(dol_now(),
-					'%Y-%m-%d'),
+			'sr.fk_soc' => 'Third Party name or customer/supplier code',
+			'sr.datec' => 'date used for creating direct debit UMR formatted as '.dol_print_date(dol_now(), '%Y-%m-%d'),
 			'sr.bank' => 'bank name eg: "ING-Direct"',
 			'sr.code_banque' => 'account sort code (GB)/Routing number (US) eg. "8456"',
 			'sr.code_guichet' => "bank code for office/branch",
@@ -777,10 +776,26 @@ class modSociete extends DolibarrModules
 		$this->import_fields_array[$r] = array('sr.fk_soc'=>"ThirdPartyName*", 'sr.fk_user'=>"User*");
 
 		$this->import_convertvalue_array[$r] = array(
-				'sr.fk_soc'=>array('rule'=>'fetchidfromref', 'classfile'=>'/societe/class/societe.class.php', 'class'=>'Societe', 'method'=>'fetch', 'element'=>'ThirdParty'),
-				'sr.fk_user'=>array('rule'=>'fetchidfromref', 'classfile'=>'/user/class/user.class.php', 'class'=>'User', 'method'=>'fetch', 'element'=>'User')
+			'sr.fk_soc' => array(
+				'rule' => 'fetchidfromreforcode',
+				'classfile' => '/societe/class/societe.class.php',
+				'class' => 'Societe',
+				'method' => 'fetchbycode',
+				'element' => 'ThirdParty'
+			),
+			'sr.fk_user' => array(
+				'rule' => 'fetchidfromref',
+				'classfile' => '/user/class/user.class.php',
+				'class' => 'User',
+				'method' => 'fetch',
+				'element' => 'User'
+			),
 		);
-		$this->import_examplevalues_array[$r] = array('sr.fk_soc'=>"MyBigCompany", 'sr.fk_user'=>"login");
+
+		$this->import_examplevalues_array[$r] = array(
+			'sr.fk_soc' => 'Third Party name or customer/supplier code',
+			'sr.fk_user'=>"login"
+		);
 	}
 
 

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1483,14 +1483,15 @@ class Societe extends CommonObject
 	 *    @param    string	$idprof6		Prof id 6 of third party (Warning, this can return several records)
 	 *    @param    string	$email   		Email of third party (Warning, this can return several records)
 	 *    @param    string	$ref_alias 		Name_alias of third party (Warning, this can return several records)
+	 *    @param    string	$ref_code      	Customer or Supplier code (Should be unique)
 	 *    @return   int						>0 if OK, <0 if KO or if two records found for same ref or idprof, 0 if not found.
 	 */
-	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '')
+	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $ref_code = '')
 	{
 		global $langs;
 		global $conf;
 
-		if (empty($rowid) && empty($ref) && empty($ref_ext) && empty($barcode) && empty($idprof1) && empty($idprof2) && empty($idprof3) && empty($idprof4) && empty($idprof5) && empty($idprof6) && empty($email)) return -1;
+		if (empty($rowid) && empty($ref) && empty($ref_ext) && empty($barcode) && empty($idprof1) && empty($idprof2) && empty($idprof3) && empty($idprof4) && empty($idprof5) && empty($idprof6) && empty($email) && empty($ref_alias) && empty($ref_code)) return -1;
 
 		$sql = 'SELECT s.rowid, s.nom as name, s.name_alias, s.entity, s.ref_ext, s.address, s.datec as date_creation, s.prefix_comm';
 		$sql .= ', s.status';
@@ -1537,6 +1538,7 @@ class Societe extends CommonObject
 		if ($ref)       $sql .= " AND s.nom = '".$this->db->escape($ref)."'";
 		if ($ref_alias) $sql .= " AND s.name_alias = '".$this->db->escape($ref_alias)."'";
 		if ($ref_ext)   $sql .= " AND s.ref_ext = '".$this->db->escape($ref_ext)."'";
+		if ($ref_code)  $sql .= " AND (s.code_client = '".$this->db->escape($ref_code)."' OR s.code_fournisseur = '".$this->db->escape($ref_code)."')";
 		if ($barcode)   $sql .= " AND s.barcode = '".$this->db->escape($barcode)."'";
 		if ($idprof1)   $sql .= " AND s.siren = '".$this->db->escape($idprof1)."'";
 		if ($idprof2)   $sql .= " AND s.siret = '".$this->db->escape($idprof2)."'";
@@ -1704,6 +1706,20 @@ class Societe extends CommonObject
 		// Use first price level if level not defined for third party
 		if ((!empty($conf->global->PRODUIT_MULTIPRICES) || !empty($conf->global->PRODUIT_CUSTOMER_PRICES_BY_QTY_MULTIPRICES)) && empty($this->price_level)) $this->price_level = 1;
 
+		return $result;
+	}
+
+	/**
+	 *    Load a third party from database into memory from name or code (for imports)
+	 *
+	 *    @param	int		$rowid			Id of third party to load
+	 *    @param    string	$ref			Reference of third party, name (Warning, this can return several records)
+	 *    @param    string	$ref_code      	Customer or Supplier code (Should be unique)
+	 *    @return   int						>0 if OK, <0 if KO or if two records found for same ref or idprof, 0 if not found.
+	 */
+	public function fetchbycode($rowid, $ref = '', $ref_code = '')
+	{
+		$result = $this->fetch($rowid, $ref, '', '', '', '', '', '', '', '', '', '', $ref_code);
 		return $result;
 	}
 

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1483,15 +1483,16 @@ class Societe extends CommonObject
 	 *    @param    string	$idprof6		Prof id 6 of third party (Warning, this can return several records)
 	 *    @param    string	$email   		Email of third party (Warning, this can return several records)
 	 *    @param    string	$ref_alias 		Name_alias of third party (Warning, this can return several records)
-	 *    @param    string	$ref_code      	Customer or Supplier code (Should be unique)
+	 *    @param    string	$customer_code	Customer code (Should be unique)
+	 *    @param    string	$supplier_code	Supplier code (Should be unique)
 	 *    @return   int						>0 if OK, <0 if KO or if two records found for same ref or idprof, 0 if not found.
 	 */
-	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $ref_code = '')
+	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $customer_code = '', $supplier_code = '')
 	{
 		global $langs;
 		global $conf;
 
-		if (empty($rowid) && empty($ref) && empty($ref_ext) && empty($barcode) && empty($idprof1) && empty($idprof2) && empty($idprof3) && empty($idprof4) && empty($idprof5) && empty($idprof6) && empty($email) && empty($ref_alias) && empty($ref_code)) return -1;
+		if (empty($rowid) && empty($ref) && empty($ref_ext) && empty($barcode) && empty($idprof1) && empty($idprof2) && empty($idprof3) && empty($idprof4) && empty($idprof5) && empty($idprof6) && empty($email) && empty($ref_alias) && empty($customer_code) && empty($supplier_code)) return -1;
 
 		$sql = 'SELECT s.rowid, s.nom as name, s.name_alias, s.entity, s.ref_ext, s.address, s.datec as date_creation, s.prefix_comm';
 		$sql .= ', s.status';
@@ -1538,7 +1539,6 @@ class Societe extends CommonObject
 		if ($ref)       $sql .= " AND s.nom = '".$this->db->escape($ref)."'";
 		if ($ref_alias) $sql .= " AND s.name_alias = '".$this->db->escape($ref_alias)."'";
 		if ($ref_ext)   $sql .= " AND s.ref_ext = '".$this->db->escape($ref_ext)."'";
-		if ($ref_code)  $sql .= " AND (s.code_client = '".$this->db->escape($ref_code)."' OR s.code_fournisseur = '".$this->db->escape($ref_code)."')";
 		if ($barcode)   $sql .= " AND s.barcode = '".$this->db->escape($barcode)."'";
 		if ($idprof1)   $sql .= " AND s.siren = '".$this->db->escape($idprof1)."'";
 		if ($idprof2)   $sql .= " AND s.siret = '".$this->db->escape($idprof2)."'";
@@ -1547,6 +1547,15 @@ class Societe extends CommonObject
 		if ($idprof5)   $sql .= " AND s.idprof5 = '".$this->db->escape($idprof5)."'";
 		if ($idprof6)   $sql .= " AND s.idprof6 = '".$this->db->escape($idprof6)."'";
 		if ($email)     $sql .= " AND s.email = '".$this->db->escape($email)."'";
+		if ($customer_code)
+		{
+			if ($supplier_code)		$sql .= " AND (s.code_client = '".$this->db->escape($customer_code)."' OR s.code_fournisseur = '".$this->db->escape($supplier_code)."')";
+			else $sql .= " AND s.code_client = '".$this->db->escape($customer_code)."'";
+		}
+		elseif ($supplier_code)
+		{
+			$sql .= " AND s.code_fournisseur = '".$this->db->escape($supplier_code)."'";
+		}
 
 		$resql = $this->db->query($sql);
 		if ($resql)
@@ -1719,7 +1728,35 @@ class Societe extends CommonObject
 	 */
 	public function fetchbycode($rowid, $ref = '', $ref_code = '')
 	{
-		$result = $this->fetch($rowid, $ref, '', '', '', '', '', '', '', '', '', '', $ref_code);
+		$result = $this->fetch($rowid, $ref, '', '', '', '', '', '', '', '', '', '', $ref_code, $ref_code);
+		return $result;
+	}
+
+	/**
+	 *    Load a third party from database into memory from name or customer code (for imports)
+	 *
+	 *    @param	int		$rowid			Id of third party to load
+	 *    @param    string	$ref			Reference of third party, name (Warning, this can return several records)
+	 *    @param    string	$customer_code	Customer code (Should be unique)
+	 *    @return   int						>0 if OK, <0 if KO or if two records found for same ref or idprof, 0 if not found.
+	 */
+	public function fetchbycustomercode($rowid, $ref = '', $customer_code = '')
+	{
+		$result = $this->fetch($rowid, $ref, '', '', '', '', '', '', '', '', '', '', $customer_code, '');
+		return $result;
+	}
+
+	/**
+	 *    Load a third party from database into memory from name or supplier code (for imports)
+	 *
+	 *    @param	int		$rowid			Id of third party to load
+	 *    @param    string	$ref			Reference of third party, name (Warning, this can return several records)
+	 *    @param    string	$supplier_code	Supplier code (Should be unique)
+	 *    @return   int						>0 if OK, <0 if KO or if two records found for same ref or idprof, 0 if not found.
+	 */
+	public function fetchbysuppliercode($rowid, $ref = '', $supplier_code = '')
+	{
+		$result = $this->fetch($rowid, $ref, '', '', '', '', '', '', '', '', '', '', '', $supplier_code);
 		return $result;
 	}
 


### PR DESCRIPTION
# New
Modify all imports related to third parties to be able to reference them by customer/supplier code in addition of name which may not be unique:
- third party: mother company
- third party contacts, bank accounts and sale representatives
- categories
- customer propal/orders
- supplier orders/invoices
- product/service supplier prices