### PR TITLE
FIX  Dol print error : conf usage thirdparty propagate extrafields to

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1772,7 +1772,7 @@ if ($action == 'create' && $usercancreate)
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action);
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		if (!empty($conf->global->THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_ORDER)) {
+		if (!empty($conf->global->THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_ORDER) && !empty($soc->id)) {
 			// copy from thirdparty
 			$tpExtrafields = new Extrafields($db);
 			$tpExtrafieldLabels = $tpExtrafields->fetch_name_optionals_label($soc->table_element);

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3571,7 +3571,7 @@ if ($action == 'create')
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		if (!empty($conf->global->THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_INVOICE)) {
+		if (!empty($conf->global->THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_INVOICE) && !empty($soc->id)) {
 			// copy from thirdparty
 			$tpExtrafields = new Extrafields($db);
 			$tpExtrafieldLabels = $tpExtrafields->fetch_name_optionals_label($soc->table_element);


### PR DESCRIPTION
# Fix

If conf THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_ORDER or THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_INVOICE are used :  

$soc->fetch_optionals() will get an error if $soc->id is empty