### PR TITLE
FIX: refresh of prospecting icon/label after modifying status

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -170,6 +170,7 @@ if (empty($reshook))
 		$object->stcomm_id = dol_getIdFromCode($db, GETPOST('stcomm', 'alpha'), 'c_stcomm');
 		$result = $object->update($object->id, $user);
 		if ($result < 0) setEventMessages($object->error, $object->errors, 'errors');
+		else $result = $object->fetch($object->id);
 	}
 
 	// update outstandng limit


### PR DESCRIPTION
# Fix #15526 

Bug seems to come from commit 9cb90cb which introduces the custom pictures.

fetch() queries cached values for label and picto, used only 1 time and not outside this code, and this is largely useless given the helper functions we have already.
And... of course, the modify action updates only the status id and not these values......

This is a simple & dirty fix by refetching the object after update.
I think it would need a complete rewrite, because:

The prospecting status customisation system is not usable and can completely mess up display and table, so that the user has no other option but to try to restore the standard values with phpmyadmin and abandon.
It's not possible to understand how it works, even by a developer, until you look at the code in depth and realise the assumptions that were made and not documented anywhere.
I won't comment any further, this is a story for another day.