### PR TITLE
Adding require_once files.lib to fourn/paiement.

### DIFF
--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -37,6 +37,7 @@ require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
 require_once DOL_DOCUMENT_ROOT.'/fourn/class/paiementfourn.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array('companies', 'bills', 'banks', 'compta'));


### PR DESCRIPTION
Bug when there is a calculated extrafield using "dol_dir_list" for calculating the amount of files attached to a invoice

With bonus: the integer calculated extrafield configuration: 
`count(dol_dir_list($conf->fournisseur->facture->dir_output.'/'.get_exdir($object->id,2,0,0,$object,'invoice_supplier').dol_sanitizeFileName($object->ref),'files',0,'','(\.meta|_preview.*\.png)$'));`