### PR TITLE
Update sync_members_types_dolibarr2ldap.php

### DIFF
--- a/scripts/members/sync_members_types_dolibarr2ldap.php
+++ b/scripts/members/sync_members_types_dolibarr2ldap.php
@@ -89,7 +89,7 @@ if ($resql) {
 			$membertype->id = $obj->rowid;
 			$membertype->fetch($membertype->id);
 
-			print $langs->trans("UpdateMemberType")." rowid=".$membertype->id." ".$membertype - label;
+			print $langs->trans("UpdateMemberType")." rowid=".$membertype->id." ".$membertype->label;
 
 			$oldobject = $membertype;
 


### PR DESCRIPTION
# Fix #[*issue_number Short description*]
[*Long description*]
Solve following error : "Object of class AdherentType could not be converted to string in /var/www/html/dolibarr/scripts/members/sync_members_types_dolibarr2ldap.php on line 88"

# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
