### PR TITLE
Fix: undefined measuring_units_squared() on update

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -35,6 +35,7 @@
  *    \ingroup    produit
  *    \brief      File of class to manage predefined products or services
  */
+require_once DOL_DOCUMENT_ROOT.'/core/lib/product.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
 require_once DOL_DOCUMENT_ROOT.'/product/class/productbatch.class.php';
 require_once DOL_DOCUMENT_ROOT.'/product/stock/class/entrepot.class.php';


### PR DESCRIPTION
On update product, by a third party module, measuring_units_squared() and measuring_units_cubed() was undefined