### PR TITLE
hide default model select if only 1 or less models are active

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1712,12 +1712,14 @@ if ($action == 'create' && $usercancreate)
 	}
 
 	// Template to use by default
-	print '<tr><td>'.$langs->trans('DefaultModel').'</td>';
-	print '<td>';
-	include_once DOL_DOCUMENT_ROOT.'/core/modules/commande/modules_commande.php';
 	$liste = ModelePDFCommandes::liste_modeles($db);
-	print $form->selectarray('model', $liste, $conf->global->COMMANDE_ADDON_PDF);
-	print "</td></tr>";
+	if ( count($liste) > 1 )  {
+		print '<tr><td>'.$langs->trans('DefaultModel').'</td>';
+		print '<td>';
+		include_once DOL_DOCUMENT_ROOT.'/core/modules/commande/modules_commande.php';
+		print $form->selectarray('model', $liste, $conf->global->COMMANDE_ADDON_PDF);
+		print "</td></tr>";
+	}
 
 	// Multicurrency
 	if (!empty($conf->multicurrency->enabled))

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3475,19 +3475,21 @@ if ($action == 'create')
 	}
 
 	// Template to use by default
-	print '<tr><td>'.$langs->trans('Model').'</td>';
-	print '<td colspan="2">';
-	include_once DOL_DOCUMENT_ROOT.'/core/modules/facture/modules_facture.php';
 	$liste = ModelePDFFactures::liste_modeles($db);
-	if (!empty($conf->global->INVOICE_USE_DEFAULT_DOCUMENT)) {
-		// Hidden conf
-		$paramkey = 'FACTURE_ADDON_PDF_'.$object->type;
-		$curent = !empty($conf->global->$paramkey) ? $conf->global->$paramkey : $conf->global->FACTURE_ADDON_PDF;
-	} else {
-		$curent = $conf->global->FACTURE_ADDON_PDF;
+	if ( count($liste) > 1 ) {
+		print '<tr><td>' . $langs->trans( 'Model' ) . '</td>';
+		print '<td colspan="2">';
+		include_once DOL_DOCUMENT_ROOT . '/core/modules/facture/modules_facture.php';
+		if ( ! empty( $conf->global->INVOICE_USE_DEFAULT_DOCUMENT ) ) {
+			// Hidden conf
+			$paramkey = 'FACTURE_ADDON_PDF_' . $object->type;
+			$curent   = ! empty( $conf->global->$paramkey ) ? $conf->global->$paramkey : $conf->global->FACTURE_ADDON_PDF;
+		} else {
+			$curent = $conf->global->FACTURE_ADDON_PDF;
+		}
+		print $form->selectarray( 'model', $liste, $curent );
+		print "</td></tr>";
 	}
-	print $form->selectarray('model', $liste, $curent);
-	print "</td></tr>";
 
 	// Multicurrency
 	if (!empty($conf->multicurrency->enabled))

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3477,17 +3477,17 @@ if ($action == 'create')
 	// Template to use by default
 	$liste = ModelePDFFactures::liste_modeles($db);
 	if ( count($liste) > 1 ) {
-		print '<tr><td>' . $langs->trans( 'Model' ) . '</td>';
+		print '<tr><td>' . $langs->trans('Model') . '</td>';
 		print '<td colspan="2">';
 		include_once DOL_DOCUMENT_ROOT . '/core/modules/facture/modules_facture.php';
-		if ( ! empty( $conf->global->INVOICE_USE_DEFAULT_DOCUMENT ) ) {
+		if ( ! empty($conf->global->INVOICE_USE_DEFAULT_DOCUMENT) ) {
 			// Hidden conf
 			$paramkey = 'FACTURE_ADDON_PDF_' . $object->type;
-			$curent   = ! empty( $conf->global->$paramkey ) ? $conf->global->$paramkey : $conf->global->FACTURE_ADDON_PDF;
+			$curent   = ! empty($conf->global->$paramkey) ? $conf->global->$paramkey : $conf->global->FACTURE_ADDON_PDF;
 		} else {
 			$curent = $conf->global->FACTURE_ADDON_PDF;
 		}
-		print $form->selectarray( 'model', $liste, $curent );
+		print $form->selectarray('model', $liste, $curent);
 		print "</td></tr>";
 	}
 

--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -1214,13 +1214,14 @@ if ($action == 'create')
 
 
 	// Model
-	print '<tr>';
-	print '<td>'.$langs->trans("DefaultModel").'</td>';
-	print '<td colspan="2">';
 	$liste = ModelePDFSupplierProposal::liste_modeles($db);
-	print $form->selectarray('model', $liste, ($conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT ? $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT : $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF));
-	print "</td></tr>";
-
+	if ( count($liste) > 1 ) {
+		print '<tr>';
+		print '<td>' . $langs->trans( "DefaultModel" ) . '</td>';
+		print '<td colspan="2">';
+		print $form->selectarray( 'model', $liste, ( $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT ? $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT : $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF ) );
+		print "</td></tr>";
+	}
 	// Project
 	if (!empty($conf->projet->enabled))
 	{

--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -1217,9 +1217,9 @@ if ($action == 'create')
 	$liste = ModelePDFSupplierProposal::liste_modeles($db);
 	if ( count($liste) > 1 ) {
 		print '<tr>';
-		print '<td>' . $langs->trans( "DefaultModel" ) . '</td>';
+		print '<td>' . $langs->trans("DefaultModel") . '</td>';
 		print '<td colspan="2">';
-		print $form->selectarray( 'model', $liste, ( $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT ? $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT : $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF ) );
+		print $form->selectarray('model', $liste, ( $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT ? $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT : $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF ));
 		print "</td></tr>";
 	}
 	// Project


### PR DESCRIPTION
If only (1) model is active for a module it makes no sense to show the default-model select

The changes hide the field if count if the models is (1) or less.