### PR TITLE
FIX 12.0 - error when displaying lines on order after adding a new line

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -953,7 +953,8 @@ if (empty($reshook))
 
 				if ($result > 0) {
 					$ret = $object->fetch($object->id); // Reload to get new records
-
+					$object->fetch_thirdparty();
+					
 					if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) {
 						// Define output language
 						$outputlangs = $langs;
@@ -966,8 +967,6 @@ if (empty($reshook))
 						}
 
 						$object->generateDocument($object->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
-					} else {
-						$object->fetch_thirdparty();
 					}
 
 					unset($_POST['prod_entry_mode']);

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -966,6 +966,8 @@ if (empty($reshook))
 						}
 
 						$object->generateDocument($object->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
+					} else {
+						$object->fetch_thirdparty();
 					}
 
 					unset($_POST['prod_entry_mode']);


### PR DESCRIPTION
## Issue
When you add a new line on an order, after the call to `$object->addline()`, the `$object` is fetched anew (so that it will have the new line + updated totals).

If you have both `MAIN_DISABLE_PDF_AUTOUPDATE` and `MAIN_MULTILANGS` on, when you add a line to an order, an error occurs during the call to `$object->printObjectLine()` because the object's third party is not loaded.

- If `MAIN_DISABLE_PDF_AUTOUPDATE` is off → no error because `$object->generateDocument` reloads the third party
- If `MAIN_MULTILANGS` is off → no error because then `printObjectLine()` doesn’t need the third party
- If both options are on → error (the third party is not loaded but it is needed by `printObjectLine`).

## Fix
The fix simply adds `$object->fetch_thirdparty()` after the object is fetched.

## Note
The bug apparently affects only orders (not proposals / invoices), though I have only run basic tests.