### PR TITLE
Fix missing import/export for warehouses and icon/label system

### DIFF
--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -478,7 +478,7 @@ class modSociete extends DolibarrModules
 				'classfile' => '/core/class/cstate.class.php',
 				'class' => 'Cstate',
 				'method' => 'fetch',
-				'dict' => 'DictionaryState'
+				'dict' => 'DictionaryStateCode'
 			),
 			's.fk_pays' => array(
 				'rule' => 'fetchidfromcodeid',
@@ -630,7 +630,7 @@ class modSociete extends DolibarrModules
 				'classfile' => '/core/class/cstate.class.php',
 				'class' => 'Cstate',
 				'method' => 'fetch',
-				'dict' => 'DictionaryState'
+				'dict' => 'DictionaryStateCode'
 			),
 			's.fk_pays' => array(
 				'rule' => 'fetchidfromcodeid',

--- a/htdocs/core/modules/modStock.class.php
+++ b/htdocs/core/modules/modStock.class.php
@@ -188,28 +188,60 @@ class modStock extends DolibarrModules
 		//--------
 		$r = 0;
 
+		// Export warehouses
 		$r++;
-		$this->export_code[$r] = $this->rights_class;
-		$this->export_label[$r] = "WarehousesAndProducts"; // Translation key (used only if key ExportDataset_xxx_z not found)
+		$this->export_code[$r] = $this->rights_class.'_warehouses';
+		$this->export_label[$r] = "Warehouses"; // Translation key (used only if key ExportDataset_xxx_z not found)
+		$this->export_icon[$r] = "warehouse";
 		$this->export_permission[$r] = array(array("stock", "lire"));
 		$this->export_fields_array[$r] = array(
-			'e.rowid'=>'IdWarehouse', 'e.ref'=>'LocationSummary', 'e.description'=>'DescWareHouse', 'e.lieu'=>'LieuWareHouse', 'e.address'=>'Address',
-			'e.zip'=>'Zip', 'e.town'=>'Town', 'p.rowid'=>"ProductId", 'p.ref'=>"Ref", 'p.fk_product_type'=>"Type", 'p.label'=>"Label", 'p.description'=>"Description",
-			'p.note'=>"Note", 'p.price'=>"Price", 'p.tva_tx'=>'VAT', 'p.tosell'=>"OnSell", 'p.tobuy'=>'OnBuy', 'p.duration'=>"Duration", 'p.datec'=>'DateCreation',
-			'p.tms'=>'DateModification', 'p.pmp'=>'PMPValue', 'p.cost_price'=>'CostPrice'
+			'e.rowid'=>'IdWarehouse', 'e.ref'=>'LocationSummary', 'e.description'=>'DescWareHouse', 'e.lieu'=>'LieuWareHouse', 'e.address'=>'Address', 'e.zip'=>'Zip', 'e.town'=>'Town',
+			'd.code_departement'=>'Departement', 'c.code'=>'CountryCode',
+			'e.phone'=>'Phone', 'e.fax'=>'Fax', 'e.statut'=>'Status', 'pe.rowid'=>'ParentWarehouse', 'pe.ref'=>'LocationSummary'
 		);
 		$this->export_TypeFields_array[$r] = array(
-			'e.rowid'=>'List:entrepot:ref::stock', 'e.ref'=>'Text', 'e.lieu'=>'Text', 'e.address'=>'Text', 'e.zip'=>'Text', 'e.town'=>'Text', 'p.rowid'=>"List:product:label::product",
-			'p.ref'=>"Text", 'p.fk_product_type'=>"Text", 'p.label'=>"Text", 'p.description'=>"Text", 'p.note'=>"Text", 'p.price'=>"Numeric", 'p.tva_tx'=>'Numeric',
-			'p.tosell'=>"Boolean", 'p.tobuy'=>"Boolean", 'p.duration'=>"Duree", 'p.datec'=>'Date', 'p.tms'=>'Date', 'p.pmp'=>'Numeric', 'p.cost_price'=>'Numeric',
+			'e.ref'=>'Text', 'e.description'=>'Text', 'e.lieu'=>'Text', 'e.address'=>'Text', 'e.zip'=>'Text', 'e.town'=>'Text',
+			'd.code_departement'=>'List:c_departements:code_departement:code_departement:', 'c.code'=>'List:c_country:code:code:',
+			'e.phone'=>'Text', 'e.fax'=>'Text', 'e.statut'=>'Text', 'pe.rowid'=>'List:entrepot:ref:rowid:stock', 'pe.ref'=>'Text'
+		);
+		$this->export_entities_array[$r] = array();	// We define here only fields that use another icon that the one defined into export_icon
+		$this->export_aggregate_array[$r] = array();
+		$keyforselect = 'warehouse'; $keyforelement = 'warehouse'; $keyforaliasextra = 'extra';
+		include DOL_DOCUMENT_ROOT.'/core/extrafieldsinexport.inc.php';
+
+		$this->export_sql_start[$r] = 'SELECT DISTINCT ';
+		$this->export_sql_end[$r]  = ' FROM '.MAIN_DB_PREFIX.'entrepot as e';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_departements as d ON d.rowid = e.fk_departement';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_country as c ON c.rowid = e.fk_pays';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'entrepot as pe ON pe.rowid = e.fk_parent';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'entrepot_extrafields as extra ON extra.fk_object = e.rowid';
+		$this->export_sql_end[$r] .= ' WHERE e.entity IN ('.getEntity('stock').')';
+
+		// Export stock (without batch number)
+		$r++;
+		$this->export_code[$r] = $this->rights_class;
+		$this->export_label[$r] = "Stocks"; // Translation key (used only if key ExportDataset_xxx_z not found)
+		$this->export_icon[$r] = "warehouse";
+		$this->export_permission[$r] = array(array("stock", "lire"));
+		$this->export_fields_array[$r] = array(
+			'e.rowid'=>'IdWarehouse', 'e.ref'=>'LocationSummary', 'e.description'=>'DescWareHouse', 'e.lieu'=>'LieuWareHouse', 'e.address'=>'Address', 'e.zip'=>'Zip', 'e.town'=>'Town',
+			'p.rowid'=>"ProductId", 'p.ref'=>"Ref", 'p.fk_product_type'=>"Type", 'p.label'=>"Label", 'p.description'=>"Description", 'p.note'=>"Note",
+			'p.price'=>"Price", 'p.tva_tx'=>'VAT', 'p.tosell'=>"OnSell", 'p.tobuy'=>'OnBuy', 'p.duration'=>"Duration",
+			'p.datec'=>'DateCreation', 'p.tms'=>'DateModification', 'p.pmp'=>'PMPValue', 'p.cost_price'=>'CostPrice',
+		);
+		$this->export_TypeFields_array[$r] = array(
+			'e.rowid'=>'List:entrepot:ref::stock', 'e.ref'=>'Text', 'e.lieu'=>'Text', 'e.address'=>'Text', 'e.zip'=>'Text', 'e.town'=>'Text',
+			'p.rowid'=>"List:product:label::product", 'p.ref'=>"Text", 'p.fk_product_type'=>"Text", 'p.label'=>"Text", 'p.description'=>"Text", 'p.note'=>"Text",
+			'p.price'=>"Numeric", 'p.tva_tx'=>'Numeric', 'p.tosell'=>"Boolean", 'p.tobuy'=>"Boolean", 'p.duration'=>"Duree",
+			'p.datec'=>'Date', 'p.tms'=>'Date', 'p.pmp'=>'Numeric', 'p.cost_price'=>'Numeric',
 			'ps.reel'=>'Numeric'
 		);
 		$this->export_entities_array[$r] = array(
-			'e.rowid'=>'warehouse', 'e.ref'=>'warehouse', 'e.description'=>'warehouse', 'e.lieu'=>'warehouse', 'e.address'=>'warehouse', 'e.zip'=>'warehouse',
-			'e.town'=>'warehouse', 'p.rowid'=>"product", 'p.ref'=>"product", 'p.fk_product_type'=>"product", 'p.label'=>"product", 'p.description'=>"product",
-			'p.note'=>"product", 'p.price'=>"product", 'p.tva_tx'=>'product', 'p.tosell'=>"product", 'p.tobuy'=>"product", 'p.duration'=>"product",
-			'p.datec'=>'product', 'p.tms'=>'product', 'p.pmp'=>'product', 'p.cost_price'=>'product', 'ps.reel'=>'stock'
-		);
+			'p.rowid'=>"product", 'p.ref'=>"product", 'p.fk_product_type'=>"product", 'p.label'=>"product", 'p.description'=>"product", 'p.note'=>"product",
+			'p.price'=>"product", 'p.tva_tx'=>'product', 'p.tosell'=>"product", 'p.tobuy'=>"product", 'p.duration'=>"product",
+			'p.datec'=>'product', 'p.tms'=>'product', 'p.pmp'=>'product', 'p.cost_price'=>'product',
+			'ps.reel'=>'stock'
+		);	// We define here only fields that use another icon that the one defined into export_icon
 		$this->export_aggregate_array[$r] = array('ps.reel'=>'SUM'); // TODO Not used yet
 		$this->export_dependencies_array[$r] = array('stock'=>array('p.rowid', 'e.rowid')); // We must keep this until the aggregate_array is used. To have a unique key, if we ask a field of a child, to avoid the DISTINCT to discard them.
 		$keyforselect = 'product'; $keyforelement = 'product'; $keyforaliasextra = 'extra';
@@ -217,76 +249,85 @@ class modStock extends DolibarrModules
 		$this->export_fields_array[$r] = array_merge($this->export_fields_array[$r], array('ps.reel'=>'Stock'));
 
 		$this->export_sql_start[$r] = 'SELECT DISTINCT ';
-		$this->export_sql_end[$r]  = ' FROM '.MAIN_DB_PREFIX.'product as p LEFT JOIN '.MAIN_DB_PREFIX.'product_extrafields as extra ON extra.fk_object = p.rowid, '.MAIN_DB_PREFIX.'product_stock as ps, '.MAIN_DB_PREFIX.'entrepot as e';
-		$this->export_sql_end[$r] .= ' WHERE p.rowid = ps.fk_product AND ps.fk_entrepot = e.rowid';
-		$this->export_sql_end[$r] .= ' AND e.entity IN ('.getEntity('stock').')';
+		$this->export_sql_end[$r] = ' FROM '.MAIN_DB_PREFIX.'product_stock as ps';	// Primary table is stock, but product must exist
+		$this->export_sql_end[$r] .= ' INNER JOIN '.MAIN_DB_PREFIX.'product as p ON p.rowid = ps.fk_product';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_extrafields as extra ON extra.fk_object = p.rowid';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'entrepot as e ON e.rowid = ps.fk_entrepot';
+		$this->export_sql_end[$r] .= ' WHERE e.entity IN ('.getEntity('stock').')';
+
+		// Export stock including batch number
 		if ($conf->productbatch->enabled)
 		{
-			// Export of stock including lot number
 			$langs->load("productbatch");
 
 			// This request is same than previous but without field ps.stock (real stock in warehouse) and with link to subtable productbatch
 			$r++;
 
 			$this->export_code[$r] = $this->rights_class.'_lot';
-			$this->export_label[$r] = "WarehousesAndProductsBatchDetail"; // Translation key (used only if key ExportDataset_xxx_z not found)
+			$this->export_label[$r] = "StocksWithBatch"; // Translation key (used only if key ExportDataset_xxx_z not found)
+			$this->export_icon[$r] = "warehouse";
 			$this->export_permission[$r] = array(array("stock", "lire"));
 			$this->export_fields_array[$r] = array(
-				'e.rowid'=>'IdWarehouse', 'e.ref'=>'LocationSummary', 'e.description'=>'DescWareHouse', 'e.lieu'=>'LieuWareHouse', 'e.address'=>'Address',
-				'e.zip'=>'Zip', 'e.town'=>'Town', 'p.rowid'=>"ProductId", 'p.ref'=>"Ref", 'p.fk_product_type'=>"Type", 'p.label'=>"Label", 'p.description'=>"Description",
-				'p.note'=>"Note", 'p.price'=>"Price", 'p.tva_tx'=>'VAT', 'p.tosell'=>"OnSell", 'p.tobuy'=>'OnBuy', 'p.duration'=>"Duration", 'p.datec'=>'DateCreation',
-				'p.tms'=>'DateModification', 'pb.rowid'=>'Id', 'pb.batch'=>'Batch', 'pb.qty'=>'Qty', 'pl.eatby'=>'EatByDate', 'pl.sellby'=>'SellByDate'
+				'e.rowid'=>'IdWarehouse', 'e.ref'=>'LocationSummary', 'e.description'=>'DescWareHouse', 'e.lieu'=>'LieuWareHouse', 'e.address'=>'Address', 'e.zip'=>'Zip', 'e.town'=>'Town',
+				'p.rowid'=>"ProductId", 'p.ref'=>"Ref", 'p.fk_product_type'=>"Type", 'p.label'=>"Label", 'p.description'=>"Description", 'p.note'=>"Note",
+				'p.price'=>"Price", 'p.tva_tx'=>'VAT', 'p.tosell'=>"OnSell", 'p.tobuy'=>'OnBuy', 'p.duration'=>"Duration",
+				'p.datec'=>'DateCreation', 'p.tms'=>'DateModification', 'p.pmp'=>'PMPValue', 'p.cost_price'=>'CostPrice',
+				'pb.rowid'=>'Id', 'pb.batch'=>'Batch', 'pb.qty'=>'Qty',
+				'pl.eatby'=>'EatByDate', 'pl.sellby'=>'SellByDate'
 			);
 			$this->export_TypeFields_array[$r] = array(
 				'e.rowid'=>'List:entrepot:ref::stock', 'e.ref'=>'Text', 'e.lieu'=>'Text', 'e.description'=>'Text', 'e.address'=>'Text', 'e.zip'=>'Text', 'e.town'=>'Text',
 				'p.rowid'=>"List:product:label::product", 'p.ref'=>"Text", 'p.fk_product_type'=>"Text", 'p.label'=>"Text", 'p.description'=>"Text", 'p.note'=>"Text",
-				'p.price'=>"Numeric", 'p.tva_tx'=>'Numeric', 'p.tosell'=>"Boolean", 'p.tobuy'=>"Boolean", 'p.duration'=>"Duree", 'p.datec'=>'Date', 'p.tms'=>'Date',
-				'pb.batch'=>'Text', 'pb.qty'=>'Numeric', 'pl.eatby'=>'Date', 'pl.sellby'=>'Date'
+				'p.price'=>"Numeric", 'p.tva_tx'=>'Numeric', 'p.tosell'=>"Boolean", 'p.tobuy'=>"Boolean", 'p.duration'=>"Duree",
+				'p.datec'=>'DateCreation', 'p.tms'=>'DateModification', 'p.pmp'=>'PMPValue', 'p.cost_price'=>'CostPrice',
+				'pb.batch'=>'Text', 'pb.qty'=>'Numeric',
+				'pl.eatby'=>'Date', 'pl.sellby'=>'Date'
 			);
 			$this->export_entities_array[$r] = array(
-				'e.rowid'=>'warehouse', 'e.ref'=>'warehouse', 'e.description'=>'warehouse', 'e.lieu'=>'warehouse', 'e.address'=>'warehouse', 'e.zip'=>'warehouse',
-				'e.town'=>'warehouse', 'p.rowid'=>"product", 'p.ref'=>"product", 'p.fk_product_type'=>"product", 'p.label'=>"product", 'p.description'=>"product",
-				'p.note'=>"product", 'p.price'=>"product", 'p.tva_tx'=>'product', 'p.tosell'=>"product", 'p.tobuy'=>"product", 'p.duration'=>"product",
-				'p.datec'=>'product', 'p.tms'=>'product', 'pb.rowid'=>'stockbatch', 'pb.batch'=>'stockbatch', 'pb.qty'=>'stockbatch', 'pl.eatby'=>'batch',
-				'pl.sellby'=>'batch'
-			);
+				'p.rowid'=>"product", 'p.ref'=>"product", 'p.fk_product_type'=>"product", 'p.label'=>"product", 'p.description'=>"product", 'p.note'=>"product",
+				'p.price'=>"product", 'p.tva_tx'=>'product', 'p.tosell'=>"product", 'p.tobuy'=>"product", 'p.duration'=>"product",
+				'p.datec'=>'product', 'p.tms'=>'product', 'p.pmp'=>'product', 'p.cost_price'=>'product',
+				'pb.rowid'=>'batch', 'pb.batch'=>'batch', 'pb.qty'=>'batch',
+				'pl.eatby'=>'batch', 'pl.sellby'=>'batch'
+			);	// We define here only fields that use another icon that the one defined into export_icon
 			$this->export_aggregate_array[$r] = array('ps.reel'=>'SUM'); // TODO Not used yet
 			$this->export_dependencies_array[$r] = array('stockbatch'=>array('pb.rowid'), 'batch'=>array('pb.rowid')); // We must keep this until the aggregate_array is used. To add unique key if we ask a field of a child to avoid the DISTINCT to discard them.
 			$keyforselect = 'product_lot'; $keyforelement = 'batch'; $keyforaliasextra = 'extra';
 			include DOL_DOCUMENT_ROOT.'/core/extrafieldsinexport.inc.php';
+
 			$this->export_sql_start[$r] = 'SELECT DISTINCT ';
-			$this->export_sql_end[$r]  = ' FROM ('.MAIN_DB_PREFIX.'product as p, '.MAIN_DB_PREFIX.'product_stock as ps, '.MAIN_DB_PREFIX.'product_batch as pb)';
+			$this->export_sql_end[$r] = ' FROM '.MAIN_DB_PREFIX.'product_stock as ps';	// Primary table is stock, but product and batch must exist
+			$this->export_sql_end[$r] .= ' INNER JOIN '.MAIN_DB_PREFIX.'product as p ON p.rowid = ps.fk_product';
+			$this->export_sql_end[$r] .= ' INNER JOIN '.MAIN_DB_PREFIX.'product_batch as pb ON pb.fk_product_stock = ps.rowid';
 			$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_lot as pl ON pl.fk_product = p.rowid AND pl.batch = pb.batch';
-			$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_lot_extrafields as extra ON extra.fk_object = pl.rowid,';
-			$this->export_sql_end[$r] .= ' '.MAIN_DB_PREFIX.'entrepot as e';
-			$this->export_sql_end[$r] .= ' WHERE p.rowid = ps.fk_product AND ps.fk_entrepot = e.rowid AND ps.rowid = pb.fk_product_stock';
-			$this->export_sql_end[$r] .= ' AND e.entity IN ('.getEntity('stock').')';
+			$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_lot_extrafields as extra ON extra.fk_object = pl.rowid';
+			$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'entrepot as e ON e.rowid = ps.fk_entrepot';
+			$this->export_sql_end[$r] .= ' WHERE e.entity IN ('.getEntity('stock').')';
 		}
 
-		// Export of stock movement
+		// Export of stock movements
 		$r++;
 		$this->export_code[$r] = $this->rights_class.'_movement';
 		$this->export_label[$r] = "StockMovements"; // Translation key (used only if key ExportDataset_xxx_z not found)
+		$this->export_icon[$r] = "movement";
 		$this->export_permission[$r] = array(array("stock", "lire"));
 		$this->export_fields_array[$r] = array(
-			'e.rowid'=>'IdWarehouse', 'e.ref'=>'LocationSummary', 'e.description'=>'DescWareHouse', 'e.lieu'=>'LieuWareHouse', 'e.address'=>'Address', 'e.zip'=>'Zip',
-			'e.town'=>'Town', 'p.rowid'=>"ProductId", 'p.ref'=>"Ref", 'p.fk_product_type'=>"Type", 'p.label'=>"Label", 'p.description'=>"Description", 'p.note'=>"Note",
-			'p.price'=>"Price", 'p.tva_tx'=>'VAT', 'p.tosell'=>"OnSell", 'p.tobuy'=>'OnBuy', 'p.duration'=>"Duration", 'p.datec'=>'DateCreation',
-			'p.tms'=>'DateModification', 'sm.rowid'=>'MovementId', 'sm.value'=>'Qty', 'sm.datem'=>'DateMovement', 'sm.label'=>'MovementLabel',
-			'sm.inventorycode'=>'InventoryCode'
+			'sm.rowid'=>'MovementId', 'sm.value'=>'Qty', 'sm.datem'=>'DateMovement', 'sm.label'=>'MovementLabel', 'sm.inventorycode'=>'InventoryCode',
+			'e.rowid'=>'IdWarehouse', 'e.ref'=>'LocationSummary', 'e.description'=>'DescWareHouse', 'e.lieu'=>'LieuWareHouse', 'e.address'=>'Address', 'e.zip'=>'Zip', 'e.town'=>'Town',
+			'p.rowid'=>"ProductId", 'p.ref'=>"Ref", 'p.fk_product_type'=>"Type", 'p.label'=>"Label", 'p.description'=>"Description", 'p.note'=>"Note",
+			'p.price'=>"Price", 'p.tva_tx'=>'VAT', 'p.tosell'=>"OnSell", 'p.tobuy'=>'OnBuy', 'p.duration'=>"Duration", 'p.datec'=>'DateCreation', 'p.tms'=>'DateModification'
 		);
 		$this->export_TypeFields_array[$r] = array(
+			'sm.rowid'=>'Numeric', 'sm.value'=>'Numeric', 'sm.datem'=>'Date', 'sm.batch'=>'Text', 'sm.label'=>'Text', 'sm.inventorycode'=>'Text',
 			'e.rowid'=>'List:entrepot:ref::stock', 'e.ref'=>'Text', 'e.description'=>'Text', 'e.lieu'=>'Text', 'e.address'=>'Text', 'e.zip'=>'Text', 'e.town'=>'Text',
 			'p.rowid'=>"List:product:label::product", 'p.ref'=>"Text", 'p.fk_product_type'=>"Text", 'p.label'=>"Text", 'p.description'=>"Text", 'p.note'=>"Text",
-			'p.price'=>"Numeric", 'p.tva_tx'=>'Numeric', 'p.tosell'=>"Boolean", 'p.tobuy'=>"Boolean", 'p.duration'=>"Duree", 'p.datec'=>'Date', 'p.tms'=>'Date',
-			'sm.rowid'=>'Numeric', 'sm.value'=>'Numeric', 'sm.datem'=>'Date', 'sm.batch'=>'Text', 'sm.label'=>'Text', 'sm.inventorycode'=>'Text'
+			'p.price'=>"Numeric", 'p.tva_tx'=>'Numeric', 'p.tosell'=>"Boolean", 'p.tobuy'=>"Boolean", 'p.duration'=>"Duree", 'p.datec'=>'Date', 'p.tms'=>'Date'
 		);
 		$this->export_entities_array[$r] = array(
-			'e.rowid'=>'warehouse', 'e.ref'=>'warehouse', 'e.description'=>'warehouse', 'e.lieu'=>'warehouse', 'e.address'=>'warehouse', 'e.zip'=>'warehouse',
-			'e.town'=>'warehouse', 'p.rowid'=>"product", 'p.ref'=>"product", 'p.fk_product_type'=>"product", 'p.label'=>"product", 'p.description'=>"product",
-			'p.note'=>"product", 'p.price'=>"product", 'p.tva_tx'=>'product', 'p.tosell'=>"product", 'p.tobuy'=>"product", 'p.duration'=>"product", 'p.datec'=>'product',
-			'p.tms'=>'product', 'sm.rowid'=>'movement', 'sm.value'=>'movement', 'sm.datem'=>'movement', 'sm.label'=>'movement', 'sm.inventorycode'=>'movement'
-		);
+			'e.rowid'=>'warehouse', 'e.ref'=>'warehouse', 'e.description'=>'warehouse', 'e.lieu'=>'warehouse', 'e.address'=>'warehouse', 'e.zip'=>'warehouse', 'e.town'=>'warehouse',
+			'p.rowid'=>"product", 'p.ref'=>"product", 'p.fk_product_type'=>"product", 'p.label'=>"product", 'p.description'=>"product", 'p.note'=>"product",
+			'p.price'=>"product", 'p.tva_tx'=>'product', 'p.tosell'=>"product", 'p.tobuy'=>"product", 'p.duration'=>"product", 'p.datec'=>'product', 'p.tms'=>'product'
+		);	// We define here only fields that use another icon that the one defined into export_icon
 		if ($conf->productbatch->enabled)
 		{
 			$this->export_fields_array[$r]['sm.batch'] = 'Batch';
@@ -295,10 +336,12 @@ class modStock extends DolibarrModules
 		}
 		$this->export_aggregate_array[$r] = array('sm.value'=>'SUM'); // TODO Not used yet
 		$this->export_dependencies_array[$r] = array('movement'=>array('sm.rowid')); // We must keep this until the aggregate_array is used. To add unique key if we ask a field of a child to avoid the DISTINCT to discard them.
+
 		$this->export_sql_start[$r] = 'SELECT DISTINCT ';
-		$this->export_sql_end[$r]  = ' FROM '.MAIN_DB_PREFIX.'product as p, '.MAIN_DB_PREFIX.'stock_mouvement as sm, '.MAIN_DB_PREFIX.'entrepot as e';
-		$this->export_sql_end[$r] .= ' WHERE p.rowid = sm.fk_product AND sm.fk_entrepot = e.rowid';
-		$this->export_sql_end[$r] .= ' AND e.entity IN ('.getEntity('stock').')';
+		$this->export_sql_end[$r]  = ' FROM '.MAIN_DB_PREFIX.'stock_mouvement as sm';	// Primary table is stock movements
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON p.rowid = sm.fk_product';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'entrepot as e ON e.rowid = sm.fk_entrepot';
+		$this->export_sql_end[$r] .= ' WHERE e.entity IN ('.getEntity('stock').')';
 
 		// Imports
 		//--------
@@ -309,34 +352,48 @@ class modStock extends DolibarrModules
 		$r++;
 		$this->import_code[$r] = $this->rights_class.'_'.$r;
 		$this->import_label[$r] = "Warehouses"; // Translation key
-		$this->import_icon[$r] = $this->picto;
+		$this->import_icon[$r] = "warehouse";
 		$this->import_entities_array[$r] = array(); // We define here only fields that use another icon that the one defined into import_icon
 		$this->import_tables_array[$r] = array('e'=>MAIN_DB_PREFIX.'entrepot');
 		$this->import_tables_creator_array[$r] = array('e'=>'fk_user_author');
 		$this->import_fields_array[$r] = array('e.ref'=>"LocationSummary*",
-				'e.description'=>"DescWareHouse", 'e.lieu'=>"LieuWareHouse",
-				'e.address'=>"Address", 'e.zip'=>'Zip', 'e.fk_pays'=>'CountryCode',
+				'e.description'=>"DescWareHouse",
+				'e.lieu'=>"LieuWareHouse",
+				'e.address'=>"Address",
+				'e.zip'=>'Zip',
+				'e.fk_departement'=>'StateCode',
+				'e.fk_pays'=>'CountryCode',
+				'e.phone'=>'Phone',
+				'e.fax'=>'Fax',
 				'e.statut'=>'Status',
                 'e.fk_parent'=>'ParentWarehouse'
 		);
 
 		$this->import_convertvalue_array[$r] = array(
+				'e.fk_departement'=>array('rule'=>'fetchidfromcodeid', 'classfile'=>'/core/class/cstate.class.php', 'class'=>'Cstate', 'method'=>'fetch', 'dict'=>'DictionaryStateCode'),
 				'e.fk_pays'=>array('rule'=>'fetchidfromcodeid', 'classfile'=>'/core/class/ccountry.class.php', 'class'=>'Ccountry', 'method'=>'fetch', 'dict'=>'DictionaryCountry'),
                 'e.fk_parent'=>array('rule'=>'fetchidfromref', 'classfile'=>'/product/stock/class/entrepot.class.php', 'class'=>'Entrepot', 'method'=>'fetch', 'element'=>'ref')
 		);
 		$this->import_regex_array[$r] = array('e.statut'=>'^[0|1]');
 		$this->import_examplevalues_array[$r] = array('e.ref'=>"ALM001",
-				'e.description'=>"Central Warehouse", 'e.lieu'=>"Central",
-				'e.address'=>"Route 66", 'e.zip'=>'28080', 'e.fk_pays'=>'US',
+				'e.description'=>"Central Warehouse",
+				'e.lieu'=>"Central",
+				'e.address'=>"Route 66",
+				'e.zip'=>'28080',
+				'e.fk_departement'=>'matches field "code_departement" in table "'.MAIN_DB_PREFIX.'c_departements"',
+				'e.fk_pays'=>'US/FR/DE etc. matches field "code" in table "'.MAIN_DB_PREFIX.'c_country"',
+				'e.phone'=>'(+33)(0)123456789',
+				'e.fax'=>'(+33)(0)123456790',
 				'e.statut'=>'1',
-                'e.fk_parent'=>''
+                'e.fk_parent'=>'id or ref in this table'
         );
+        $this->import_updatekeys_array[$r] = array('p.ref'=>'Ref');
 
 		// Import stocks
 		$r++;
 		$this->import_code[$r] = $this->rights_class.'_'.$r;
 		$this->import_label[$r] = "Stocks"; // Translation key
-		$this->import_icon[$r] = $this->picto;
+		$this->import_icon[$r] = "stock";
 		$this->import_entities_array[$r] = array(); // We define here only fields that use another icon that the one defined into import_icon
 		$this->import_tables_array[$r] = array('ps'=>MAIN_DB_PREFIX.'product_stock');
 		$this->import_fields_array[$r] = array('ps.fk_product'=>"Product*", 'ps.fk_entrepot'=>"Warehouse*", 'ps.reel'=>"Stock*");
@@ -346,7 +403,7 @@ class modStock extends DolibarrModules
 			'ps.fk_entrepot'=>array('rule'=>'fetchidfromref', 'classfile'=>'/product/stock/class/entrepot.class.php', 'class'=>'Entrepot', 'method'=>'fetch', 'element'=>'ref')
 		  );
 		$this->import_examplevalues_array[$r] = array(
-		    'ps.fk_product'=>"PREF123456", 'ps.fk_entrepot'=>"ALM001", 'ps.reel'=>"10"
+		    'ps.fk_product'=>"id or ref", 'ps.fk_entrepot'=>"id or ref", 'ps.reel'=>"10"
 		);
 		$this->import_updatekeys_array[$r] = array('ps.fk_product'=>'Product', 'ps.fk_entrepot'=>"Warehouse");
 		$this->import_run_sql_after_array[$r] = array(    // Because we may change data that are denormalized, we must update dernormalized data after.

--- a/htdocs/exports/export.php
+++ b/htdocs/exports/export.php
@@ -24,7 +24,7 @@
  *       \ingroup    export
  *       \brief      Pages of export Wizard
  */
- 
+
 require_once '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';

--- a/htdocs/exports/export.php
+++ b/htdocs/exports/export.php
@@ -24,7 +24,7 @@
  *       \ingroup    export
  *       \brief      Pages of export Wizard
  */
-
+ 
 require_once '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
@@ -39,6 +39,7 @@ $langs->loadlangs(array('admin', 'exports', 'other', 'users', 'companies', 'proj
 //if (! $user->admin)
 //  accessforbidden();
 
+// Map icons, array duplicated in import.php, was not synchronized, TODO put it somewhere only once
 $entitytoicon = array(
 	'invoice'      => 'bill',
     'invoice_line' => 'bill',
@@ -54,13 +55,13 @@ $entitytoicon = array(
     'payment'      => 'payment',
 	'tax'          => 'generic',
     'tax_type'     => 'generic',
-    'stock'        => 'generic',
     'other'        => 'generic',
 	'account'      => 'account',
 	'product'      => 'product',
     'virtualproduct'=>'product',
 	'subproduct'   => 'product',
 	'product_supplier_ref'      => 'product',
+    'stock'        => 'stock',
 	'warehouse'    => 'stock',
 	'batch'        => 'stock',
 	'stockbatch'   => 'stock',
@@ -78,7 +79,7 @@ $entitytoicon = array(
     'bomline'      => 'bom'
 );
 
-// Translation code
+// Translation code, array duplicated in import.php, was not synchronized, TODO put it somewhere only once
 $entitytolang = array(
 	'user'         => 'User',
 	'company'      => 'Company',
@@ -459,15 +460,14 @@ if ($step == 1 || !$datatoexport)
     	$sortedarrayofmodules = dol_sort_array($objexport->array_export_module, 'module_position', 'asc', 0, 0, 1);
     	foreach ($sortedarrayofmodules as $key => $value)
         {
+			//var_dump($objexport->array_import_code[$key]);
             print '<tr class="oddeven"><td nospan="nospan">';
-	        //print img_object($objexport->array_export_module[$key]->getName(),$export->array_export_module[$key]->picto).' ';
-            print $objexport->array_export_module[$key]->getName();
+			print $objexport->array_export_module[$key]->getName();
             print '</td><td>';
-			$icon = preg_replace('/:.*$/', '', $objexport->array_export_icon[$key]);
-			$label = $objexport->array_export_label[$key];
-            //print $value.'-'.$icon.'-'.$label."<br>";
-			print img_object($objexport->array_export_module[$key]->getName(), $icon).' ';
-            print $label;
+			$entity = preg_replace('/:.*$/', '', $objexport->array_export_icon[$key]);
+			$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+ 			print img_object($objexport->array_export_module[$key]->getName(), $entityicon).' ';
+            print $objexport->array_export_label[$key];
             print '</td><td class="right">';
             if ($objexport->array_export_perms[$key])
             {
@@ -522,11 +522,10 @@ if ($step == 2 && $datatoexport)
     // Lot de donnees a exporter
     print '<tr><td>'.$langs->trans("DatasetToExport").'</td>';
     print '<td>';
-	$icon = preg_replace('/:.*$/', '', $objexport->array_export_icon[0]);
-    $label = $objexport->array_export_label[0];
-    //print $value.'-'.$icon.'-'.$label."<br>";
-    print img_object($objexport->array_export_module[0]->getName(), $icon).' ';
-    print $label;
+	$entity = preg_replace('/:.*$/', '', $objexport->array_export_icon[0]);
+	$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+    print img_object($objexport->array_export_module[0]->getName(), $entityicon).' ';
+    print $objexport->array_export_label[0];
     print '</td></tr>';
 
     print '</table>';
@@ -728,11 +727,10 @@ if ($step == 3 && $datatoexport)
 	// Lot de donnees a exporter
 	print '<tr><td>'.$langs->trans("DatasetToExport").'</td>';
 	print '<td>';
-	$icon = preg_replace('/:.*$/', '', $objexport->array_export_icon[0]);
-	$label = $objexport->array_export_label[0];
-	//print $value.'-'.$icon.'-'.$label."<br>";
-	print img_object($objexport->array_export_module[0]->getName(), $icon).' ';
-	print $label;
+	$entity = preg_replace('/:.*$/', '', $objexport->array_export_icon[0]);
+	$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+	print img_object($objexport->array_export_module[0]->getName(), $entityicon).' ';
+	print $objexport->array_export_label[0];
 	print '</td></tr>';
 
 	// Nbre champs exportes
@@ -920,8 +918,9 @@ if ($step == 4 && $datatoexport)
     // Lot de donnees a exporter
     print '<tr><td>'.$langs->trans("DatasetToExport").'</td>';
     print '<td>';
-	$icon = preg_replace('/:.*$/', '', $objexport->array_export_icon[0]);
-    print img_object($objexport->array_export_module[0]->getName(), $icon).' ';
+	$entity = preg_replace('/:.*$/', '', $objexport->array_export_icon[0]);
+	$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+    print img_object($objexport->array_export_module[0]->getName(), $entityicon).' ';
     print $objexport->array_export_label[0];
     print '</td></tr>';
 
@@ -1190,8 +1189,9 @@ if ($step == 5 && $datatoexport)
     // Dataset to export
     print '<tr><td>'.$langs->trans("DatasetToExport").'</td>';
     print '<td>';
-	$icon = preg_replace('/:.*$/', '', $objexport->array_export_icon[0]);
-    print img_object($objexport->array_export_module[0]->getName(), $icon).' ';
+	$entity = preg_replace('/:.*$/', '', $objexport->array_export_icon[0]);
+	$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+    print img_object($objexport->array_export_module[0]->getName(), $entityicon).' ';
     print $objexport->array_export_label[0];
     print '</td></tr>';
 

--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -38,31 +38,93 @@ $langs->loadLangs(array('exports', 'compta', 'errors'));
 // Security check
 $result = restrictedArea($user, 'import');
 
+// Map icons, array duplicated in export.php, was not synchronized, TODO put it somewhere only once
 $entitytoicon = array(
-	'invoice'=>'bill', 'invoice_line'=>'bill',
-	'order'=>'order', 'order_line'=>'order',
-	'intervention'=>'intervention', 'inter_line'=>'intervention',
-	'member'=>'user', 'member_type'=>'group', 'subscription'=>'payment',
-	'tax'=>'bill', 'tax_type'=>'generic',
-	'account'=>'account',
-	'payment'=>'payment',
-	'product'=>'product', 'stock'=>'generic', 'warehouse'=>'stock',
-	'category'=>'generic',
-	'other'=>'generic'
+	'invoice'      => 'bill',
+    'invoice_line' => 'bill',
+	'order'        => 'order',
+    'order_line'   => 'order',
+	'propal'       => 'propal',
+    'propal_line'  => 'propal',
+	'intervention' => 'intervention',
+    'inter_line'   => 'intervention',
+	'member'       => 'user',
+    'member_type'  => 'group',
+    'subscription' => 'payment',
+    'payment'      => 'payment',
+	'tax'          => 'bill',
+    'tax_type'     => 'generic',
+    'other'        => 'generic',
+	'account'      => 'account',
+	'product'      => 'product',
+    'virtualproduct'=>'product',
+	'subproduct'   => 'product',
+	'product_supplier_ref'      => 'product',
+    'stock'        => 'stock',
+	'warehouse'    => 'stock',
+	'batch'        => 'stock',
+	'stockbatch'   => 'stock',
+	'category'     => 'category',
+	'shipment'     => 'sending',
+    'shipment_line'=> 'sending',
+    'reception'=> 'sending',
+    'reception_line'=> 'sending',
+	'expensereport'=> 'trip',
+    'expensereport_line'=> 'trip',
+	'holiday'      => 'holiday',
+    'contract_line' => 'contract',
+    'translation'  => 'generic',
+    'bomm'         => 'bom',
+    'bomline'      => 'bom'
 );
-$entitytolang = array(		// Translation code
-	'user'=>'User',
-	'company'=>'Company', 'contact'=>'Contact',
-	'invoice'=>'Bill', 'invoice_line'=>'InvoiceLine',
-	'order'=>'Order', 'order_line'=>'OrderLine',
-	'intervention'=>'Intervention', 'inter_line'=>'InterLine',
-	'member'=>'Member', 'member_type'=>'MemberType', 'subscription'=>'Subscription',
-	'tax'=>'SocialContribution', 'tax_type'=>'DictionarySocialContributions',
-	'account'=>'BankTransactions',
-	'payment'=>'Payment',
-	'product'=>'Product', 'stock'=>'Stock', 'warehouse'=>'Warehouse',
-	'category'=>'Category',
-	'other'=>'Other'
+
+// Translation code, array duplicated in export.php, was not synchronized, TODO put it somewhere only once
+$entitytolang = array(
+	'user'         => 'User',
+	'company'      => 'Company',
+    'contact'      => 'Contact',
+	'invoice'      => 'Bill',
+    'invoice_line' => 'InvoiceLine',
+	'order'        => 'Order',
+    'order_line'   => 'OrderLine',
+    'propal'       => 'Proposal',
+    'propal_line'  => 'ProposalLine',
+	'intervention' => 'Intervention',
+    'inter_line'   => 'InterLine',
+	'member'       => 'Member',
+    'member_type'  => 'MemberType',
+    'subscription' => 'Subscription',
+	'tax'          => 'SocialContribution',
+    'tax_type'     => 'DictionarySocialContributions',
+	'account'      => 'BankTransactions',
+	'payment'      => 'Payment',
+	'product'      => 'Product',
+	'virtualproduct'  => 'AssociatedProducts',
+	'subproduct'      => 'SubProduct',
+	'product_supplier_ref'      => 'SupplierPrices',
+	'service'      => 'Service',
+    'stock'        => 'Stock',
+	'movement'	   => 'StockMovement',
+	'batch'        => 'Batch',
+	'stockbatch'   => 'StockDetailPerBatch',
+	'warehouse'    => 'Warehouse',
+	'category'     => 'Category',
+	'other'        => 'Other',
+    'trip'         => 'TripsAndExpenses',
+    'shipment'     => 'Shipments',
+    'shipment_line'=> 'ShipmentLine',
+    'project'      => 'Projects',
+    'projecttask'  => 'Tasks',
+    'task_time'    => 'TaskTimeSpent',
+	'action'       => 'Event',
+	'expensereport'=> 'ExpenseReport',
+	'expensereport_line'=> 'ExpenseReportLine',
+	'holiday'      => 'TitreRequestCP',
+	'contract'     => 'Contract',
+    'contract_line'=> 'ContractLine',
+    'translation'  => 'Translation',
+    'bom'          => 'BOM',
+    'bomline'      => 'BOMLine'
 );
 
 $datatoimport		= GETPOST('datatoimport');
@@ -365,7 +427,9 @@ if ($step == 1 || !$datatoimport)
 			if (in_array($objimport->array_import_code[$key], array('produit_supplierprices', 'produit_multiprice', 'produit_languages'))) $titleofmodule = $langs->trans("ProductOrService");
 			print $titleofmodule;
 			print '</td><td>';
-			print img_object($objimport->array_import_module[$key]->getName(), $objimport->array_import_icon[$key]).' ';
+			$entity = preg_replace('/:.*$/', '', $objimport->array_import_icon[$key]);
+			$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+			print img_object($objimport->array_import_module[$key]->getName(), $entityicon).' ';
 			print $objimport->array_import_label[$key];
             print '</td><td style="text-align: right">';
 			if ($objimport->array_import_perms[$key])
@@ -422,16 +486,16 @@ if ($step == 2 && $datatoimport)
 	// Lot de donnees a importer
 	print '<tr><td>'.$langs->trans("DatasetToImport").'</td>';
 	print '<td>';
-	print img_object($objimport->array_import_module[0]->getName(), $objimport->array_import_icon[0]).' ';
+	$entity = preg_replace('/:.*$/', '', $objimport->array_import_icon[0]);
+	$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+	print img_object($objimport->array_import_module[0]->getName(), $entityicon).' ';
 	print $objimport->array_import_label[0];
 	print '</td></tr>';
 
 	print '</table>';
-
 	print '</div>';
 
 	dol_fiche_end();
-
 
 	print '<form name="userfile" action="'.$_SERVER["PHP_SELF"].'" enctype="multipart/form-data" METHOD="POST">';
 	print '<input type="hidden" name="token" value="'.newToken().'">';
@@ -512,16 +576,16 @@ if ($step == 3 && $datatoimport)
 	// Lot de donnees a importer
 	print '<tr><td>'.$langs->trans("DatasetToImport").'</td>';
 	print '<td>';
-	print img_object($objimport->array_import_module[0]->getName(), $objimport->array_import_icon[0]).' ';
+	$entity = preg_replace('/:.*$/', '', $objimport->array_import_icon[0]);
+	$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+	print img_object($objimport->array_import_module[0]->getName(), $entityicon).' ';
 	print $objimport->array_import_label[0];
 	print '</td></tr>';
 
 	print '</table>';
 	print '</div>';
 
-
 	print load_fiche_titre($langs->trans("InformationOnSourceFile"), '', '');
-
 
 	print '<div class="underbanner clearboth"></div>';
 	print '<div class="fichecenter">';
@@ -797,13 +861,14 @@ if ($step == 4 && $datatoimport)
 	// Lot de donnees a importer
 	print '<tr><td>'.$langs->trans("DatasetToImport").'</td>';
 	print '<td>';
-	print img_object($objimport->array_import_module[0]->getName(), $objimport->array_import_icon[0]).' ';
+	$entity = preg_replace('/:.*$/', '', $objimport->array_import_icon[0]);
+	$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+	print img_object($objimport->array_import_module[0]->getName(), $entityicon).' ';
 	print $objimport->array_import_label[0];
 	print '</td></tr>';
 
 	print '</table>';
 	print '</div>';
-
 
 	print load_fiche_titre($langs->trans("InformationOnSourceFile"), '', '');
 
@@ -1273,13 +1338,14 @@ if ($step == 5 && $datatoimport)
 	// Lot de donnees a importer
 	print '<tr><td>'.$langs->trans("DatasetToImport").'</td>';
 	print '<td>';
-	print img_object($objimport->array_import_module[0]->getName(), $objimport->array_import_icon[0]).' ';
+	$entity = preg_replace('/:.*$/', '', $objimport->array_import_icon[0]);
+	$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+	print img_object($objimport->array_import_module[0]->getName(), $entityicon).' ';
 	print $objimport->array_import_label[0];
 	print '</td></tr>';
 
 	print '</table>';
 	print '</div>';
-
 
 	print load_fiche_titre($langs->trans("InformationOnSourceFile"), '', '');
 
@@ -1716,13 +1782,14 @@ if ($step == 6 && $datatoimport)
 	// Lot de donnees a importer
 	print '<tr><td>'.$langs->trans("DatasetToImport").'</td>';
 	print '<td>';
-	print img_object($objimport->array_import_module[0]->getName(), $objimport->array_import_icon[0]).' ';
+	$entity = preg_replace('/:.*$/', '', $objimport->array_import_icon[0]);
+	$entityicon = strtolower(!empty($entitytoicon[$entity]) ? $entitytoicon[$entity] : $entity);
+	print img_object($objimport->array_import_module[0]->getName(), $entityicon).' ';
 	print $objimport->array_import_label[0];
 	print '</td></tr>';
 
 	print '</table>';
 	print '</div>';
-
 
 	print load_fiche_titre($langs->trans("InformationOnSourceFile"), '', '');
 

--- a/htdocs/langs/en_US/exports.lang
+++ b/htdocs/langs/en_US/exports.lang
@@ -133,3 +133,4 @@ KeysToUseForUpdates=Key (column) to use for <b>updating</b> existing data
 NbInsert=Number of inserted lines: %s
 NbUpdate=Number of updated lines: %s
 MultipleRecordFoundWithTheseFilters=Multiple records have been found with these filters: %s
+StocksWithBatch=Stocks and location (warehouse) of products with batch/serial number

--- a/htdocs/langs/fr_FR/exports.lang
+++ b/htdocs/langs/fr_FR/exports.lang
@@ -133,3 +133,4 @@ KeysToUseForUpdates=Clé à utiliser pour mettre à jour les données
 NbInsert=Nombre de lignes insérées: %s
 NbUpdate=Nombre de lignes mises à jour: %s
 MultipleRecordFoundWithTheseFilters=Plusieurs enregistrements ont été trouvés avec ces filtres: %s
+StocksWithBatch=Stocks et emplacements (entrepôts) des produits avec numéros de lots/séries


### PR DESCRIPTION
# Fix missing export and import fields for warehouses and icon/label system
also a little bit of code cleaning:
- icon/label translation arrays were not synchronized between import and export
- it was not used everywhere in the both codes
- organize fields arrays by table
- replace multiple table select by proper syntax INNER JOIN, but was it really intended ?
