### PR TITLE
FIX 12.0 - on survey creation, entity is always set to 1 ⇒ set it to $conf->entity

### DIFF
--- a/htdocs/opensurvey/class/opensurveysondage.class.php
+++ b/htdocs/opensurvey/class/opensurveysondage.class.php
@@ -168,7 +168,7 @@ class Opensurveysondage extends CommonObject
         $sql .= " ".$this->db->escape($this->allow_comments).",";
         $sql .= " ".$this->db->escape($this->allow_spy).",";
         $sql .= " '".$this->db->escape($this->sujet)."',";
-        $sql .= " '".$conf->entity."',";
+        $sql .= " ".$conf->entity;
         $sql .= ")";
 
         $this->db->begin();

--- a/htdocs/opensurvey/class/opensurveysondage.class.php
+++ b/htdocs/opensurvey/class/opensurveysondage.class.php
@@ -128,6 +128,7 @@ class Opensurveysondage extends CommonObject
      */
     public function create(User $user, $notrigger = 0)
     {
+        global $conf;
         $error = 0;
 
         // Clean parameters
@@ -153,7 +154,8 @@ class Opensurveysondage extends CommonObject
         $sql .= "mailsonde,";
         $sql .= "allow_comments,";
         $sql .= "allow_spy,";
-        $sql .= "sujet";
+        $sql .= "sujet,";
+        $sql .= "entity";
         $sql .= ") VALUES (";
         $sql .= "'".$this->db->escape($this->id_sondage)."',";
         $sql .= " ".(empty($this->commentaires) ? 'NULL' : "'".$this->db->escape($this->commentaires)."'").",";
@@ -165,7 +167,8 @@ class Opensurveysondage extends CommonObject
         $sql .= " ".$this->db->escape($this->mailsonde).",";
         $sql .= " ".$this->db->escape($this->allow_comments).",";
         $sql .= " ".$this->db->escape($this->allow_spy).",";
-        $sql .= " '".$this->db->escape($this->sujet)."'";
+        $sql .= " '".$this->db->escape($this->sujet)."',";
+        $sql .= " '".$conf->entity."',";
         $sql .= ")";
 
         $this->db->begin();


### PR DESCRIPTION
# Issue
If you have multiples entities, when you create a survey from any entity other than entity 1, you can't find the survey in the list on your entity.

This is because the `list.php` filters by entity while surveys are always created on entity 1 (cf. `3.5.0-3.6.0.sql`).

# Fix
This fix changes `Opensurveysondage::create()` so that the entity is set to `$conf->entity`.
