### PR TITLE
Fix #15676 Hide Password when importing from LDAP

### DIFF
--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -740,7 +740,7 @@ if ($action == 'create' || $action == 'adduserldap')
 						if ($value === $conf->global->LDAP_FIELD_PASSWORD || $value === $conf->global->LDAP_FIELD_PASSWORD_CRYPTED)
  						{
  							$label .= $value."=******* ";
- 						} else if ($value) {
+ 						} elseif ($value) {
  							$label .= $value."=".$ldapuser[$value]." ";
  						}
 					}

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -737,10 +737,12 @@ if ($action == 'create' || $action == 'adduserldap')
 					$label = '';
 					foreach ($required_fields as $value)
 					{
-						if ($value)
-						{
-							$label .= $value."=".$ldapuser[$value]." ";
-						}
+						if ($value === $conf->global->LDAP_FIELD_PASSWORD || $value === $conf->global->LDAP_FIELD_PASSWORD_CRYPTED)
+ 						{
+ 							$label .= $value."=******* ";
+ 						} else if ($value) {
+ 							$label .= $value."=".$ldapuser[$value]." ";
+ 						}
 					}
 					$liste[$key] = $label;
 				}


### PR DESCRIPTION
Refers to Issue #15676


# Fix #15676 "Passwords are being showed clear when admin is importing LDAP user"
Admins should not be able to read plain password values according to good practices and security.

Proposition is following:
We can check if field showed is a password field according to LDAP Module configuration (global conf variables) and then display some stars if it is a password.

An other way to fix this would just be to not display password fields, but there would be no way to check if password exists in LDAP.