### PR TITLE
Fix #15565 Enhanced behaviour to select product on customer/supplier order to be able to use barcode reader efficiently

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -690,8 +690,14 @@ abstract class CommonDocGenerator
 		    $array_shipment = $this->fill_substitutionarray_with_extrafields($object, $array_shipment, $extrafields, $array_key, $outputlangs);
 	    }
 
-    	return $array_shipment;
-    }
+		// Add infor from $object->xxx where xxx has been loaded by fetch_origin() of shipment
+		if (!empty($object->commande) && is_object($object->commande)) {
+			$array_shipment['order_ref'] = $object->commande->ref;
+			$array_shipment['order_ref_customer'] = $object->commande->ref_customer;
+		}
+
+		return $array_shipment;
+	}
 
 
     // phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2040,7 +2040,7 @@ class Form
 			if (!empty($conf->global->PRODUIT_CUSTOMER_PRICES) && !empty($socid)) {
 				$urloption .= '&socid='.$socid;
 			}
-			print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 0, $ajaxoptions);
+			print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 1, $ajaxoptions);
 
 			if (!empty($conf->variants->enabled)) {
 				?>
@@ -2792,7 +2792,7 @@ class Form
 
 			// mode=2 means suppliers products
 			$urloption = ($socid > 0 ? 'socid='.$socid.'&' : '').'htmlname='.$htmlname.'&outjson=1&price_level='.$price_level.'&type='.$filtertype.'&mode=2&status='.$status.'&finished='.$finished.'&alsoproductwithnosupplierprice='.$alsoproductwithnosupplierprice;
-			print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 0, $ajaxoptions);
+			print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 1, $ajaxoptions);
 			print ($hidelabel ? '' : $langs->trans("RefOrLabel").' : ').'<input type="text" size="20" name="search_'.$htmlname.'" id="search_'.$htmlname.'" value="'.$selected_input_value.'">';
 		}
 		else

--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -68,6 +68,7 @@ function ajax_autocompleter($selected, $htmlname, $url, $urloption = '', $minLen
 					$("input#search_'.$htmlname.'").keydown(function(e) {
 						if (e.keyCode != 9)		/* If not "Tab" key */
 						{
+							if (e.keyCode == 13) {return false;} /*disable "ENTER"*/
 							console.log("Clear id previously selected for field '.$htmlname.'");
 							$("#'.$htmlname.'").val("");
 						}

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -468,6 +468,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 
 				// Replace tags of object + external modules
 				$tmparray = $this->get_substitutionarray_shipment($object, $outputlangs);
+
 				complete_substitutions_array($tmparray, $outputlangs, $object);
 				// Call the ODTSubstitution hook
 				$parameters = array('odfHandler'=>&$odfHandler, 'file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs, 'substitutionarray'=>&$tmparray);


### PR DESCRIPTION
# Fix #15565 Enhanced behaviour to select product on customer/supplier order to be able to use barcode reader efficiently
Correction made and validated on sources V12.0.3.
See also Pull Request #15704 which is the same correction reported on the current branch (with no conflicts).

When using a barcode reader in ajax list on customer/supplier order 2 conditions are necessary:

1. The unique product found (it is allways unique, when exists, with a barcode reader) must be automatically selected,

2. The ENTER (CR/LF) key must be ignored if sent by the barcode reader (it's very often the case), because this ENTER key comes too early and erase the previous automatic typing before the ajax selection could be done.

If the data (from the Products module):
**Wait until you have pressed a key before loading the contents of the product drop-down list**.
is set to YES (1 to 3 characters), 
the performance will be excellent (instantaneous for a test with more than 10K products).
The performance will be not worst if this data would be set to NO.

I did not see any inconvenience and interferences with manual typing after these changes.

For the point
1. in file  /core/class/html.form.class.php the change consists on setting 1 instead of 0
print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.’/product/ajax/products.php’, $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, **1**, $ajaxoptions); 
For the 2 instances customer order and supplier order.

2. in file /core/lib/ajax.lib.php in function ajax_autocompleter the change consists on
if (e.keyCode == 13) {return false;} /*disable "ENTER" key */
on characters reading for this task.

I don't know if there is interference with other functions by deactivating the ENTER key in this treatment. 
If this is the case, a parameter setting might be necessary...
Or a new parameter to ajax_autocompleter function to limit disabling ENTER only for product selection in customer or supplier order.

I ask your indulgence for this first Pull Request in Dolibarr ;-)