### PR TITLE
Fix #15565 Enhanced behaviour to select product on customer/supplier order to be able to use barcode reader efficiently

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1995,7 +1995,7 @@ class Form
 			if (!empty($conf->global->PRODUIT_CUSTOMER_PRICES) && !empty($socid)) {
 				$urloption .= '&socid='.$socid;
 			}
-			$out .= ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 0, $ajaxoptions);
+			$out .= ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 1, $ajaxoptions);
 
 			if (!empty($conf->variants->enabled)) {
 				$out .= '
@@ -2725,7 +2725,7 @@ class Form
 
 			// mode=2 means suppliers products
 			$urloption = ($socid > 0 ? 'socid='.$socid.'&' : '').'htmlname='.$htmlname.'&outjson=1&price_level='.$price_level.'&type='.$filtertype.'&mode=2&status='.$status.'&finished='.$finished.'&alsoproductwithnosupplierprice='.$alsoproductwithnosupplierprice;
-			print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 0, $ajaxoptions);
+			print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 1, $ajaxoptions);
 			print ($hidelabel ? '' : $langs->trans("RefOrLabel").' : ').'<input type="text" size="20" name="search_'.$htmlname.'" id="search_'.$htmlname.'" value="'.$selected_input_value.'">';
 		} else {
 			print $this->select_produits_fournisseurs_list($socid, $selected, $htmlname, $filtertype, $filtre, '', -1, 0, 0, $alsoproductwithnosupplierprice, $morecss);

--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -68,6 +68,7 @@ function ajax_autocompleter($selected, $htmlname, $url, $urloption = '', $minLen
 					$("input#search_'.$htmlname.'").keydown(function(e) {
 						if (e.keyCode != 9)		/* If not "Tab" key */
 						{
+							if (e.keyCode == 13) {return false;} /*disable "ENTER" key useful for barcode readers*/
 							console.log("Clear id previously selected for field '.$htmlname.'");
 							$("#'.$htmlname.'").val("");
 						}


### PR DESCRIPTION
# Fix #15565 Enhanced behaviour to select product on customer/supplier order to be able to use barcode reader efficiently
This pull request  is a transfer from a PR first issued on V12.0.3 under the reference #15694

When using a barcode reader in ajax list on customer/supplier order 2 conditions are necessary:

1. The unique product found (it is allways unique, when exists, with a barcode reader) must be automatically selected,

2. The ENTER (CR/LF) key must be ignored if sent by the barcode reader (it's very often the case), because this ENTER key comes too early and erase the previous automatic typing before the ajax selection could be done.

If the data (from the Products module):
**Wait until you have pressed a key before loading the contents of the product drop-down list**.
is set to YES (1 to 3 characters), 
the performance will be excellent (instantaneous for a test with more than 10K products).
The performance will be not worst if this data would be set to NO.

I did not see any inconvenience and interferences with manual typing after these changes.

For the point
1. in file  /core/class/html.form.class.php the change consists on setting 1 instead of 0
$out .= ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 1, $ajaxoptions);

print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 1, $ajaxoptions);

For the 2 instances customer order and supplier order.

2. in file /core/lib/ajax.lib.php in function ajax_autocompleter the change consists on
if (e.keyCode == 13) {return false;} /*disable "ENTER" key */
on characters reading for this task.

I don't know if there is interference with other functions by deactivating the ENTER key in this treatment. 
If this is the case, a parameter setting might be necessary...
or a new parameter passed by ajax_autocompleter function to limit disabling the ENTER key only for product selection in customer or supplier order function.
These precautions should be taken and validated by developers having a deeper knowledge than me about Dolibarr.
