### PR TITLE
Fix boxes third-parties information

### DIFF
--- a/htdocs/comm/index.php
+++ b/htdocs/comm/index.php
@@ -137,8 +137,12 @@ if (!empty($conf->global->MAIN_SEARCH_FORM_ON_HOME_AREAS)) {
  * Draft customer proposals
  */
 if (!empty($conf->propal->enabled) && $user->rights->propal->lire) {
-	$sql = "SELECT p.rowid, p.ref, p.ref_client, p.total_ht, p.tva as total_tva, p.total as total_ttc, p.fk_statut as status,";
-	$sql .= " s.rowid as socid, s.nom as name, s.client, s.canvas, s.code_client, s.email, s.entity, s.code_compta";
+	$sql = "SELECT p.rowid, p.ref, p.ref_client, p.total_ht, p.tva as total_tva, p.total as total_ttc, p.fk_statut as status";
+	$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+	$sql .= ", s.logo, s.email, s.entity";
+	$sql .= ", s.canvas";
 	$sql .= " FROM ".MAIN_DB_PREFIX."propal as p,";
 	$sql .= " ".MAIN_DB_PREFIX."societe as s";
 	if (!$user->rights->societe->client->voir && !$socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -171,13 +175,17 @@ if (!empty($conf->propal->enabled) && $user->rights->propal->lire) {
 
 				$companystatic->id = $obj->socid;
 				$companystatic->name = $obj->name;
-				$companystatic->client = $obj->client;
+				$companystatic->name_alias = $obj->name_alias;
 				$companystatic->code_client = $obj->code_client;
-				$companystatic->code_fournisseur = $obj->code_fournisseur;
-				$companystatic->canvas = $obj->canvas;
-				$companystatic->entity = $obj->entity;
-				$companystatic->email = $obj->email;
 				$companystatic->code_compta = $obj->code_compta;
+				$companystatic->client = $obj->client;
+				$companystatic->code_fournisseur = $obj->code_fournisseur;
+				$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
+				$companystatic->fournisseur = $obj->fournisseur;
+				$companystatic->logo = $obj->logo;
+				$companystatic->email = $obj->email;
+				$companystatic->entity = $obj->entity;
+				$companystatic->canvas = $obj->canvas;
 
 				print '<tr class="oddeven">';
 				print '<td class="nowrap tdoverflowmax100">'.$propalstatic->getNomUrl(1).'</td>';
@@ -204,8 +212,12 @@ if (!empty($conf->propal->enabled) && $user->rights->propal->lire) {
  * Draft supplier proposals
  */
 if (!empty($conf->supplier_proposal->enabled) && $user->rights->supplier_proposal->lire) {
-	$sql = "SELECT p.rowid, p.ref, p.total_ht, p.tva as total_tva, p.total as total_ttc, p.fk_statut as status,";
-	$sql .= " s.rowid as socid, s.nom as name, s.client, s.canvas, s.code_client, s.code_fournisseur, s.entity, s.email";
+	$sql = "SELECT p.rowid, p.ref, p.total_ht, p.tva as total_tva, p.total as total_ttc, p.fk_statut as status";
+	$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+	$sql .= ", s.logo, s.email, s.entity";
+	$sql .= ", s.canvas";
 	$sql .= " FROM ".MAIN_DB_PREFIX."supplier_proposal as p,";
 	$sql .= " ".MAIN_DB_PREFIX."societe as s";
 	if (!$user->rights->societe->client->voir && !$socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -237,12 +249,17 @@ if (!empty($conf->supplier_proposal->enabled) && $user->rights->supplier_proposa
 
 				$companystatic->id = $obj->socid;
 				$companystatic->name = $obj->name;
-				$companystatic->client = $obj->client;
+				$companystatic->name_alias = $obj->name_alias;
 				$companystatic->code_client = $obj->code_client;
+				$companystatic->code_compta = $obj->code_compta;
+				$companystatic->client = $obj->client;
 				$companystatic->code_fournisseur = $obj->code_fournisseur;
-				$companystatic->canvas = $obj->canvas;
-				$companystatic->entity = $obj->entity;
+				$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
+				$companystatic->fournisseur = $obj->fournisseur;
+				$companystatic->logo = $obj->logo;
 				$companystatic->email = $obj->email;
+				$companystatic->entity = $obj->entity;
+				$companystatic->canvas = $obj->canvas;
 
 				print '<tr class="oddeven">';
 				print '<td class="nowrap tdoverflowmax100">'.$supplierproposalstatic->getNomUrl(1).'</td>';
@@ -269,8 +286,12 @@ if (!empty($conf->supplier_proposal->enabled) && $user->rights->supplier_proposa
  * Draft customer orders
  */
 if (!empty($conf->commande->enabled) && $user->rights->commande->lire) {
-	$sql = "SELECT c.rowid, c.ref, c.ref_client, c.total_ht, c.tva as total_tva, c.total_ttc, c.fk_statut as status,";
-	$sql .= " s.rowid as socid, s.nom as name, s.client, s.canvas, s.code_client, s.email, s.entity, s.code_compta";
+	$sql = "SELECT c.rowid, c.ref, c.ref_client, c.total_ht, c.tva as total_tva, c.total_ttc, c.fk_statut as status";
+	$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+	$sql .= ", s.logo, s.email, s.entity";
+	$sql .= ", s.canvas";
 	$sql .= " FROM ".MAIN_DB_PREFIX."commande as c,";
 	$sql .= " ".MAIN_DB_PREFIX."societe as s";
 	if (!$user->rights->societe->client->voir && !$socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -303,12 +324,17 @@ if (!empty($conf->commande->enabled) && $user->rights->commande->lire) {
 
 				$companystatic->id = $obj->socid;
 				$companystatic->name = $obj->name;
-				$companystatic->client = $obj->client;
+				$companystatic->name_alias = $obj->name_alias;
 				$companystatic->code_client = $obj->code_client;
+				$companystatic->code_compta = $obj->code_compta;
+				$companystatic->client = $obj->client;
 				$companystatic->code_fournisseur = $obj->code_fournisseur;
-				$companystatic->canvas = $obj->canvas;
+				$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
+				$companystatic->fournisseur = $obj->fournisseur;
+				$companystatic->logo = $obj->logo;
 				$companystatic->email = $obj->email;
 				$companystatic->entity = $obj->entity;
+				$companystatic->canvas = $obj->canvas;
 
 				print '<tr class="oddeven">';
 				print '<td class="nowrap tdoverflowmax100">'.$orderstatic->getNomUrl(1).'</td>';
@@ -335,8 +361,12 @@ if (!empty($conf->commande->enabled) && $user->rights->commande->lire) {
  * Draft purchase orders
  */
 if ((!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD) || !empty($conf->supplier_order->enabled)) && $user->rights->fournisseur->commande->lire) {
-	$sql = "SELECT cf.rowid, cf.ref, cf.ref_supplier, cf.total_ttc, cf.fk_statut as status,";
-	$sql .= " s.rowid as socid, s.nom as name, s.client, s.canvas, s.code_client, s.code_fournisseur, s.entity, s.email";
+	$sql = "SELECT cf.rowid, cf.ref, cf.ref_supplier, cf.total_ttc, cf.fk_statut as status";
+	$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+	$sql .= ", s.logo, s.email, s.entity";
+	$sql .= ", s.canvas";
 	$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseur as cf,";
 	$sql .= " ".MAIN_DB_PREFIX."societe as s";
 	if (!$user->rights->societe->client->voir && !$socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -369,12 +399,17 @@ if ((!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SU
 
 				$companystatic->id = $obj->socid;
 				$companystatic->name = $obj->name;
-				$companystatic->client = $obj->client;
+				$companystatic->name_alias = $obj->name_alias;
 				$companystatic->code_client = $obj->code_client;
+				$companystatic->code_compta = $obj->code_compta;
+				$companystatic->client = $obj->client;
 				$companystatic->code_fournisseur = $obj->code_fournisseur;
-				$companystatic->canvas = $obj->canvas;
-				$companystatic->entity = $obj->entity;
+				$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
+				$companystatic->fournisseur = $obj->fournisseur;
+				$companystatic->logo = $obj->logo;
 				$companystatic->email = $obj->email;
+				$companystatic->entity = $obj->entity;
+				$companystatic->canvas = $obj->canvas;
 
 				print '<tr class="oddeven">';
 				print '<td class="nowrap tdoverflowmax100">'.$supplierorderstatic->getNomUrl(1).'</td>';
@@ -403,7 +438,12 @@ print '<div class="ficheaddleft">';
  * Last modified customers or prospects
  */
 if (!empty($conf->societe->enabled) && $user->rights->societe->lire) {
-	$sql = "SELECT s.rowid, s.nom as name, s.client, s.datec, s.tms, s.canvas, s.code_client, s.code_compta, s.entity, s.email";
+	$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+	$sql .= ", s.logo, s.email, s.entity";
+	$sql .= ", s.canvas";
+	$sql .= ", s.datec, s.tms";
 	$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 	if (!$user->rights->societe->client->voir && !$socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 	$sql .= " WHERE s.entity IN (".getEntity($companystatic->element).")";
@@ -434,15 +474,19 @@ if (!empty($conf->societe->enabled) && $user->rights->societe->lire) {
 			while ($i < $num && $i < $max) {
 				$objp = $db->fetch_object($resql);
 
-				$companystatic->id = $objp->rowid;
+				$companystatic->id = $objp->socid;
 				$companystatic->name = $objp->name;
-				$companystatic->client = $objp->client;
+				$companystatic->name_alias = $objp->name_alias;
 				$companystatic->code_client = $objp->code_client;
-				$companystatic->code_fournisseur = $objp->code_fournisseur;
-				$companystatic->canvas = $objp->canvas;
 				$companystatic->code_compta = $objp->code_compta;
-				$companystatic->entity = $objp->entity;
+				$companystatic->client = $objp->client;
+				$companystatic->code_fournisseur = $objp->code_fournisseur;
+				$companystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
+				$companystatic->fournisseur = $objp->fournisseur;
+				$companystatic->logo = $objp->logo;
 				$companystatic->email = $objp->email;
+				$companystatic->entity = $objp->entity;
+				$companystatic->canvas = $objp->canvas;
 
 				print '<tr class="oddeven">';
 				print '<td class="nowrap tdoverflowmax100">'.$companystatic->getNomUrl(1, 'customer').'</td>';
@@ -488,7 +532,12 @@ if (!empty($conf->societe->enabled) && $user->rights->societe->lire) {
  * Last suppliers
  */
 if ((!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD) || !empty($conf->supplier_order->enabled) || !empty($conf->supplier_invoice->enabled)) && $user->rights->societe->lire) {
-	$sql = "SELECT s.nom as name, s.rowid, s.datec as dc, s.canvas, s.tms as dm, s.code_fournisseur, s.entity, s.email, s.fournisseur";
+	$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+	$sql .= ", s.logo, s.email, s.entity";
+	$sql .= ", s.canvas";
+	$sql .= ", s.datec as dc, s.tms as dm";
 	$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 	if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 	$sql .= " WHERE s.entity IN (".getEntity($companystatic->element).")";
@@ -508,14 +557,19 @@ if ((!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SU
 			while ($i < $num && $i < $max) {
 				$objp = $db->fetch_object($resql);
 
-				$companystatic->id = $objp->rowid;
+				$companystatic->id = $objp->socid;
 				$companystatic->name = $objp->name;
+				$companystatic->name_alias = $objp->name_alias;
 				$companystatic->code_client = $objp->code_client;
+				$companystatic->code_compta = $objp->code_compta;
+				$companystatic->client = $objp->client;
 				$companystatic->code_fournisseur = $objp->code_fournisseur;
-				$companystatic->canvas = $objp->canvas;
-				$companystatic->entity = $objp->entity;
-				$companystatic->email = $objp->email;
+				$companystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
 				$companystatic->fournisseur = $objp->fournisseur;
+				$companystatic->logo = $objp->logo;
+				$companystatic->email = $objp->email;
+				$companystatic->entity = $objp->entity;
+				$companystatic->canvas = $objp->canvas;
 
 				print '<tr class="oddeven">';
 				print '<td class="nowrap tdoverflowmax100">'.$companystatic->getNomUrl(1, 'supplier').'</td>';
@@ -577,7 +631,11 @@ if ($user->rights->agenda->myactions->read) {
 if (!empty($conf->contrat->enabled) && $user->rights->contrat->lire && 0) { // TODO A REFAIRE DEPUIS NOUVEAU CONTRAT
 	$staticcontrat = new Contrat($db);
 
-	$sql = "SELECT s.nom as name, s.rowid, s.canvas, s.code_client, s.entity, s.email";
+	$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+	$sql .= ", s.logo, s.email, s.entity";
+	$sql .= ", s.canvas";
 	$sql .= ", c.statut, c.rowid as contratid, p.ref, c.fin_validite as datefin, c.date_cloture as dateclo";
 	$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 	$sql .= ", ".MAIN_DB_PREFIX."contrat as c";
@@ -602,13 +660,19 @@ if (!empty($conf->contrat->enabled) && $user->rights->contrat->lire && 0) { // T
 			while ($i < $num) {
 				$obj = $db->fetch_object($resql);
 
-				$companystatic->id = $objp->rowid;
-				$companystatic->name = $objp->name;
-				$companystatic->code_client = $objp->code_client;
-				$companystatic->code_fournisseur = $objp->code_fournisseur;
-				$companystatic->canvas = $objp->canvas;
-				$companystatic->entity = $objp->entity;
-				$companystatic->email = $objp->email;
+				$companystatic->id = $obj->socid;
+				$companystatic->name = $obj->name;
+				$companystatic->name_alias = $obj->name_alias;
+				$companystatic->code_client = $obj->code_client;
+				$companystatic->code_compta = $obj->code_compta;
+				$companystatic->client = $obj->client;
+				$companystatic->code_fournisseur = $obj->code_fournisseur;
+				$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
+				$companystatic->fournisseur = $obj->fournisseur;
+				$companystatic->logo = $obj->logo;
+				$companystatic->email = $obj->email;
+				$companystatic->entity = $obj->entity;
+				$companystatic->canvas = $obj->canvas;
 
 				$staticcontrat->id = $obj->contratid;
 				$staticcontrat->ref = $obj->ref;
@@ -638,7 +702,11 @@ if (!empty($conf->contrat->enabled) && $user->rights->contrat->lire && 0) { // T
  */
 if (!empty($conf->propal->enabled) && $user->rights->propal->lire) {
 	$sql = "SELECT p.rowid as propalid, p.entity, p.total as total_ttc, p.total_ht, p.tva as total_tva, p.ref, p.ref_client, p.fk_statut, p.datep as dp, p.fin_validite as dfv";
-	$sql .= ", s.nom as name, s.rowid, s.code_client, s.entity, s.email";
+	$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+	$sql .= ", s.logo, s.email, s.entity";
+	$sql .= ", s.canvas";
 	$sql .= " FROM ".MAIN_DB_PREFIX."propal as p";
 	$sql .= ", ".MAIN_DB_PREFIX."societe as s";
 	if (!$user->rights->societe->client->voir && !$socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -678,14 +746,19 @@ if (!empty($conf->propal->enabled) && $user->rights->propal->lire) {
 				$propalstatic->total_tva = $obj->total_tva;
 				$propalstatic->total_ttc = $obj->total_ttc;
 
-				$companystatic->id = $obj->rowid;
+				$companystatic->id = $obj->socid;
 				$companystatic->name = $obj->name;
-				$companystatic->client = $obj->client;
+				$companystatic->name_alias = $obj->name_alias;
 				$companystatic->code_client = $obj->code_client;
+				$companystatic->code_compta = $obj->code_compta;
+				$companystatic->client = $obj->client;
 				$companystatic->code_fournisseur = $obj->code_fournisseur;
-				$companystatic->canvas = $obj->canvas;
-				$companystatic->entity = $obj->entity;
+				$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
+				$companystatic->fournisseur = $obj->fournisseur;
+				$companystatic->logo = $obj->logo;
 				$companystatic->email = $obj->email;
+				$companystatic->entity = $obj->entity;
+				$companystatic->canvas = $obj->canvas;
 
 				$filename = dol_sanitizeFileName($obj->ref);
 				$filedir = $conf->propal->multidir_output[$obj->entity].'/'.dol_sanitizeFileName($obj->ref);
@@ -739,7 +812,11 @@ if (!empty($conf->propal->enabled) && $user->rights->propal->lire) {
  */
 if (!empty($conf->commande->enabled) && $user->rights->commande->lire) {
 	$sql = "SELECT c.rowid as commandeid, c.total_ttc, c.total_ht, c.tva as total_tva, c.ref, c.ref_client, c.fk_statut, c.date_valid as dv, c.facture as billed";
-	$sql .= ", s.nom as name, s.rowid, s.code_client, s.entity, s.email";
+	$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+	$sql .= ", s.logo, s.email, s.entity";
+	$sql .= ", s.canvas";
 	$sql .= " FROM ".MAIN_DB_PREFIX."commande as c";
 	$sql .= ", ".MAIN_DB_PREFIX."societe as s";
 	if (!$user->rights->societe->client->voir && !$socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -779,14 +856,19 @@ if (!empty($conf->commande->enabled) && $user->rights->commande->lire) {
 				$orderstatic->total_tva = $obj->total_tva;
 				$orderstatic->total_ttc = $obj->total_ttc;
 
-				$companystatic->id = $obj->rowid;
+				$companystatic->id = $obj->socid;
 				$companystatic->name = $obj->name;
-				$companystatic->client = $obj->client;
+				$companystatic->name_alias = $obj->name_alias;
 				$companystatic->code_client = $obj->code_client;
+				$companystatic->code_compta = $obj->code_compta;
+				$companystatic->client = $obj->client;
 				$companystatic->code_fournisseur = $obj->code_fournisseur;
-				$companystatic->canvas = $obj->canvas;
-				$companystatic->entity = $obj->entity;
+				$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
+				$companystatic->fournisseur = $obj->fournisseur;
+				$companystatic->logo = $obj->logo;
 				$companystatic->email = $obj->email;
+				$companystatic->entity = $obj->entity;
+				$companystatic->canvas = $obj->canvas;
 
 				$filename = dol_sanitizeFileName($obj->ref);
 				$filedir = $conf->commande->dir_output.'/'.dol_sanitizeFileName($obj->ref);

--- a/htdocs/core/boxes/box_actions.php
+++ b/htdocs/core/boxes/box_actions.php
@@ -88,9 +88,9 @@ class box_actions extends ModeleBoxes
 			$sql = "SELECT a.id, a.label, a.datep as dp, a.percent as percentage";
 			$sql .= ", ta.code";
 			$sql .= ", ta.libelle as type_label";
-			$sql .= ", s.nom as name";
-			$sql .= ", s.rowid as socid";
-			$sql .= ", s.code_client";
+			$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
 			$sql .= " FROM ".MAIN_DB_PREFIX."c_actioncomm AS ta, ".MAIN_DB_PREFIX."actioncomm AS a";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON a.fk_soc = sc.fk_soc";
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON a.fk_soc = s.rowid";
@@ -116,13 +116,21 @@ class box_actions extends ModeleBoxes
 					$late = '';
 					$objp = $this->db->fetch_object($result);
 					$datelimite = $this->db->jdate($objp->dp);
+
 					$actionstatic->id = $objp->id;
 					$actionstatic->label = $objp->label;
 					$actionstatic->type_label = $objp->type_label;
 					$actionstatic->code = $objp->code;
+
 					$societestatic->id = $objp->socid;
 					$societestatic->name = $objp->name;
+					//$societestatic->name_alias = $objp->name_alias;
 					$societestatic->code_client = $objp->code_client;
+					$societestatic->code_compta = $objp->code_compta;
+					$societestatic->client = $objp->client;
+					$societestatic->logo = $objp->logo;
+					$societestatic->email = $objp->email;
+					$societestatic->entity = $objp->entity;
 
 					if ($objp->percentage >= 0 && $objp->percentage < 100 && $datelimite < ($now - $delay_warning))
 						$late = img_warning($langs->trans("Late"));

--- a/htdocs/core/boxes/box_clients.php
+++ b/htdocs/core/boxes/box_clients.php
@@ -80,28 +80,22 @@ class box_clients extends ModeleBoxes
 		$this->max = $max;
 
 		include_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
-		$thirdpartystatic = new Societe($this->db);
+		$thirdpartystatic = new Client($this->db);
 
 		$this->info_box_head = array('text' => $langs->trans("BoxTitleLastModifiedCustomers", $max));
 
 		if ($user->rights->societe->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid";
-			$sql .= ", s.code_client";
-			$sql .= ", s.client";
-			$sql .= ", s.code_fournisseur";
-			$sql .= ", s.fournisseur";
-			$sql .= ", s.code_compta";
-			$sql .= ", s.code_compta_fournisseur";
-			$sql .= ", s.logo";
-			$sql .= ", s.email";
-			$sql .= ", s.datec, s.tms, s.status, s.entity";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", s.datec, s.tms, s.status";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 			$sql .= " WHERE s.client IN (1, 3)";
 			$sql .= " AND s.entity IN (".getEntity('societe').")";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".$user->id;
-			if ($user->socid) $sql .= " AND s.rowid = $user->socid";
+			if ($user->socid) $sql .= " AND s.rowid = ".$user->socid;
 			$sql .= " ORDER BY s.tms DESC";
 			$sql .= $this->db->plimit($max, 0);
 
@@ -117,14 +111,13 @@ class box_clients extends ModeleBoxes
 					$objp = $this->db->fetch_object($result);
 					$datec = $this->db->jdate($objp->datec);
 					$datem = $this->db->jdate($objp->tms);
+
 					$thirdpartystatic->id = $objp->socid;
 					$thirdpartystatic->name = $objp->name;
+					$thirdpartystatic->name_alias = $objp->name_alias;
 					$thirdpartystatic->code_client = $objp->code_client;
-					$thirdpartystatic->code_fournisseur = $objp->code_fournisseur;
 					$thirdpartystatic->code_compta = $objp->code_compta;
-					$thirdpartystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
 					$thirdpartystatic->client = $objp->client;
-					$thirdpartystatic->fournisseur = $objp->fournisseur;
 					$thirdpartystatic->logo = $objp->logo;
 					$thirdpartystatic->email = $objp->email;
 					$thirdpartystatic->entity = $objp->entity;

--- a/htdocs/core/boxes/box_commandes.php
+++ b/htdocs/core/boxes/box_commandes.php
@@ -87,10 +87,9 @@ class box_commandes extends ModeleBoxes
 
 		if ($user->rights->commande->lire)
 		{
-			$sql = "SELECT s.nom as name";
-			$sql .= ", s.rowid as socid";
-			$sql .= ", s.code_client";
-			$sql .= ", s.logo, s.email";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
 			$sql .= ", c.ref, c.tms";
 			$sql .= ", c.rowid";
 			$sql .= ", c.date_commande";
@@ -123,17 +122,23 @@ class box_commandes extends ModeleBoxes
 					$objp = $this->db->fetch_object($result);
 					$date = $this->db->jdate($objp->date_commande);
 					$datem = $this->db->jdate($objp->tms);
+
 					$commandestatic->id = $objp->rowid;
 					$commandestatic->ref = $objp->ref;
 					$commandestatic->ref_client = $objp->ref_client;
 					$commandestatic->total_ht = $objp->total_ht;
 					$commandestatic->total_tva = $objp->total_tva;
 					$commandestatic->total_ttc = $objp->total_ttc;
+
 					$societestatic->id = $objp->socid;
 					$societestatic->name = $objp->name;
-					$societestatic->email = $objp->email;
+					//$societestatic->name_alias = $objp->name_alias;
 					$societestatic->code_client = $objp->code_client;
+					$societestatic->code_compta = $objp->code_compta;
+					$societestatic->client = $objp->client;
 					$societestatic->logo = $objp->logo;
+					$societestatic->email = $objp->email;
+					$societestatic->entity = $objp->entity;
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="nowraponall"',

--- a/htdocs/core/boxes/box_contacts.php
+++ b/htdocs/core/boxes/box_contacts.php
@@ -86,8 +86,10 @@ class box_contacts extends ModeleBoxes
 			$sql = "SELECT sp.rowid as id, sp.lastname, sp.firstname, sp.civility as civility_id, sp.datec, sp.tms, sp.fk_soc, sp.statut as status";
 
 			$sql .= ", sp.address, sp.zip, sp.town, sp.phone, sp.phone_perso, sp.phone_mobile, sp.email as spemail";
-			$sql .= ", s.nom as socname, s.name_alias, s.email as semail";
-			$sql .= ", s.client, s.fournisseur, s.code_client, s.code_fournisseur";
+			$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+			$sql .= ", s.logo, s.email, s.entity";
 			$sql .= ", co.label as country, co.code as country_code";
 			$sql .= " FROM ".MAIN_DB_PREFIX."socpeople as sp";
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as co ON sp.fk_pays = co.rowid";
@@ -128,14 +130,18 @@ class box_contacts extends ModeleBoxes
 					$contactstatic->country = $objp->country;
 					$contactstatic->country_code = $objp->country_code;
 
-					$societestatic->id = $objp->fk_soc;
-					$societestatic->name = $objp->socname;
-					$societestatic->email = $objp->semail;
-					$societestatic->name_alias = $objp->name_alias;
+					$societestatic->id = $objp->socid;
+					$societestatic->name = $objp->name;
+					//$societestatic->name_alias = $objp->name_alias;
 					$societestatic->code_client = $objp->code_client;
-					$societestatic->code_fournisseur = $objp->code_fournisseur;
+					$societestatic->code_compta = $objp->code_compta;
 					$societestatic->client = $objp->client;
+					$societestatic->code_fournisseur = $objp->code_fournisseur;
+					$societestatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
 					$societestatic->fournisseur = $objp->fournisseur;
+					$societestatic->logo = $objp->logo;
+					$societestatic->email = $objp->email;
+					$societestatic->entity = $objp->entity;
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="tdoverflowmax150 maxwidth150onsmartphone"',
@@ -145,7 +151,7 @@ class box_contacts extends ModeleBoxes
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="tdoverflowmax150 maxwidth150onsmartphone"',
-						'text' => ($objp->fk_soc > 0 ? $societestatic->getNomUrl(1) : ''),
+						'text' => ($societestatic->id > 0 ? $societestatic->getNomUrl(1) : ''),
 						'asis' => 1,
 					);
 

--- a/htdocs/core/boxes/box_customers_outstanding_bill_reached.php
+++ b/htdocs/core/boxes/box_customers_outstanding_bill_reached.php
@@ -86,17 +86,11 @@ class box_customers_outstanding_bill_reached extends ModeleBoxes
 
 		if ($user->rights->societe->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid";
-			$sql .= ", s.code_client";
-			$sql .= ", s.client";
-			$sql .= ", s.code_fournisseur";
-			$sql .= ", s.fournisseur";
-			$sql .= ", s.code_compta";
-			$sql .= ", s.code_compta_fournisseur";
-			$sql .= ", s.logo";
-			$sql .= ", s.email";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
 			$sql .= ", s.outstanding_limit";
-			$sql .= ", s.datec, s.tms, s.status, s.entity";
+			$sql .= ", s.datec, s.tms, s.status";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 			$sql .= " WHERE s.client IN (1, 3)";
@@ -120,17 +114,15 @@ class box_customers_outstanding_bill_reached extends ModeleBoxes
 				while ($line < $num)
 				{
 					$objp = $this->db->fetch_object($result);
-
 					$datec = $this->db->jdate($objp->datec);
 					$datem = $this->db->jdate($objp->tms);
+
 					$thirdpartystatic->id = $objp->socid;
 					$thirdpartystatic->name = $objp->name;
+					//$thirdpartystatic->name_alias = $objp->name_alias;
 					$thirdpartystatic->code_client = $objp->code_client;
-					$thirdpartystatic->code_fournisseur = $objp->code_fournisseur;
 					$thirdpartystatic->code_compta = $objp->code_compta;
-					$thirdpartystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
 					$thirdpartystatic->client = $objp->client;
-					$thirdpartystatic->fournisseur = $objp->fournisseur;
 					$thirdpartystatic->logo = $objp->logo;
 					$thirdpartystatic->email = $objp->email;
 					$thirdpartystatic->entity = $objp->entity;

--- a/htdocs/core/boxes/box_factures.php
+++ b/htdocs/core/boxes/box_factures.php
@@ -94,8 +94,11 @@ class box_factures extends ModeleBoxes
 			$sql .= ", f.total_ttc";
 			$sql .= ", f.datef as df";
 			$sql .= ", f.paye, f.fk_statut, f.datec, f.tms";
-			$sql .= ", s.rowid as socid, s.nom as name, s.code_client, s.email, s.tva_intra, s.code_compta, s.siren as idprof1, s.siret as idprof2, s.ape as idprof3, s.idprof4, s.idprof5, s.idprof6";
 			$sql .= ", f.date_lim_reglement as datelimite";
+			$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", s.tva_intra, s.siren as idprof1, s.siret as idprof2, s.ape as idprof3, s.idprof4, s.idprof5, s.idprof6";
 			$sql .= " FROM (".MAIN_DB_PREFIX."societe as s,".MAIN_DB_PREFIX."facture as f";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 			$sql .= ")";
@@ -133,9 +136,14 @@ class box_factures extends ModeleBoxes
 
 					$societestatic->id = $objp->socid;
 					$societestatic->name = $objp->name;
+					//$societestatic->name_alias = $objp->name_alias;
 					$societestatic->code_client = $objp->code_client;
-					$societestatic->tva_intra = $objp->tva_intra;
+					$societestatic->code_compta = $objp->code_compta;
+					$societestatic->client = $objp->client;
+					$societestatic->logo = $objp->logo;
 					$societestatic->email = $objp->email;
+					$societestatic->entity = $objp->entity;
+					$societestatic->tva_intra = $objp->tva_intra;
 					$societestatic->idprof1 = $objp->idprof1;
 					$societestatic->idprof2 = $objp->idprof2;
 					$societestatic->idprof3 = $objp->idprof3;

--- a/htdocs/core/boxes/box_factures_fourn.php
+++ b/htdocs/core/boxes/box_factures_fourn.php
@@ -78,7 +78,7 @@ class box_factures_fourn extends ModeleBoxes
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.class.php';
 
 		$facturestatic = new FactureFournisseur($this->db);
-		$thirdpartytmp = new Fournisseur($this->db);
+		$thirdpartystatic = new Fournisseur($this->db);
 
 		$this->info_box_head = array(
 			'text' => $langs->trans("BoxTitleLast".($conf->global->MAIN_LASTBOX_ON_OBJECT_DATE ? "" : "Modified")."SupplierBills", $max)
@@ -86,17 +86,17 @@ class box_factures_fourn extends ModeleBoxes
 
 		if ($user->rights->fournisseur->facture->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid,";
-			$sql .= " s.code_fournisseur, s.email,";
-			$sql .= " s.logo,";
-			$sql .= " f.rowid as facid, f.ref, f.ref_supplier,";
-			$sql .= " f.total_ht,";
-			$sql .= " f.total_tva,";
-			$sql .= " f.total_ttc,";
-			$sql .= " f.paye, f.fk_statut,";
-			$sql .= ' f.datef as df,';
-			$sql .= ' f.datec as datec,';
-			$sql .= ' f.date_lim_reglement as datelimite, f.tms, f.type';
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", f.rowid as facid, f.ref, f.ref_supplier";
+			$sql .= ", f.total_ht";
+			$sql .= ", f.total_tva";
+			$sql .= ", f.total_ttc";
+			$sql .= ", f.paye, f.fk_statut";
+			$sql .= ', f.datef as df';
+			$sql .= ', f.datec as datec';
+			$sql .= ', f.date_lim_reglement as datelimite, f.tms, f.type';
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			$sql .= ", ".MAIN_DB_PREFIX."facture_fourn as f";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -131,12 +131,15 @@ class box_factures_fourn extends ModeleBoxes
 					$facturestatic->statut = $objp->fk_statut;
 					$facturestatic->ref_supplier = $objp->ref_supplier;
 
-					$thirdpartytmp->id = $objp->socid;
-					$thirdpartytmp->name = $objp->name;
-					$thirdpartytmp->email = $objp->email;
-					$thirdpartytmp->fournisseur = 1;
-					$thirdpartytmp->code_fournisseur = $objp->code_fournisseur;
-					$thirdpartytmp->logo = $objp->logo;
+					$thirdpartystatic->id = $objp->socid;
+					$thirdpartystatic->name = $objp->name;
+					//$thirdpartystatic->name_alias = $objp->name_alias;
+					$thirdpartystatic->code_fournisseur = $objp->code_fournisseur;
+					$thirdpartystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
+					$thirdpartystatic->fournisseur = $objp->fournisseur;
+					$thirdpartystatic->logo = $objp->logo;
+					$thirdpartystatic->email = $objp->email;
+					$thirdpartystatic->entity = $objp->entity;
 
 					$late = '';
 
@@ -160,7 +163,7 @@ class box_factures_fourn extends ModeleBoxes
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="tdoverflowmax150"',
-						'text' => $thirdpartytmp->getNomUrl(1, 'supplier'),
+						'text' => $thirdpartystatic->getNomUrl(1, 'supplier'),
 						'asis' => 1,
 					);
 

--- a/htdocs/core/boxes/box_factures_fourn_imp.php
+++ b/htdocs/core/boxes/box_factures_fourn_imp.php
@@ -76,19 +76,21 @@ class box_factures_fourn_imp extends ModeleBoxes
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
 		$facturestatic = new FactureFournisseur($this->db);
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.class.php';
-		$thirdpartytmp = new Fournisseur($this->db);
+		$thirdpartystatic = new Fournisseur($this->db);
 
 		$this->info_box_head = array('text' => $langs->trans("BoxTitleOldestUnpaidSupplierBills", $max));
 
 		if ($user->rights->fournisseur->facture->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid,";
-			$sql .= " f.rowid as facid, f.ref, f.ref_supplier, f.date_lim_reglement as datelimite,";
-			$sql .= " f.datef as df,";
-			$sql .= " f.total_ht as total_ht,";
-			$sql .= " f.tva as total_tva,";
-			$sql .= " f.total_ttc,";
-			$sql .= " f.paye, f.fk_statut, f.type";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", f.rowid as facid, f.ref, f.ref_supplier, f.date_lim_reglement as datelimite";
+			$sql .= ", f.datef as df";
+			$sql .= ", f.total_ht as total_ht";
+			$sql .= ", f.tva as total_tva";
+			$sql .= ", f.total_ttc";
+			$sql .= ", f.paye, f.fk_statut, f.type";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			$sql .= ",".MAIN_DB_PREFIX."facture_fourn as f";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -117,6 +119,7 @@ class box_factures_fourn_imp extends ModeleBoxes
 					$datelimite = $this->db->jdate($objp->datelimite);
 					$date = $this->db->jdate($objp->df);
 					$datem = $this->db->jdate($objp->tms);
+
 					$facturestatic->id = $objp->facid;
 					$facturestatic->ref = $objp->ref;
 					$facturestatic->total_ht = $objp->total_ht;
@@ -124,11 +127,16 @@ class box_factures_fourn_imp extends ModeleBoxes
 					$facturestatic->total_ttc = $objp->total_ttc;
 					$facturestatic->date_echeance = $datelimite;
 					$facturestatic->statut = $objp->fk_statut;
-					$thirdpartytmp->id = $objp->socid;
-					$thirdpartytmp->name = $objp->name;
-					$thirdpartytmp->fournisseur = 1;
-					$thirdpartytmp->code_fournisseur = $objp->code_fournisseur;
-					$thirdpartytmp->logo = $objp->logo;
+
+					$thirdpartystatic->id = $objp->socid;
+					$thirdpartystatic->name = $objp->name;
+					//$thirdpartystatic->name_alias = $objp->name_alias;
+					$thirdpartystatic->code_fournisseur = $objp->code_fournisseur;
+					$thirdpartystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
+					$thirdpartystatic->fournisseur = $objp->fournisseur;
+					$thirdpartystatic->logo = $objp->logo;
+					$thirdpartystatic->email = $objp->email;
+					$thirdpartystatic->entity = $objp->entity;
 
 					$late = '';
 					if ($facturestatic->hasDelay()) {
@@ -146,7 +154,7 @@ class box_factures_fourn_imp extends ModeleBoxes
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="tdoverflowmax150 maxwidth150onsmartphone"',
-						'text' => $thirdpartytmp->getNomUrl(1, '', 40),
+						'text' => $thirdpartystatic->getNomUrl(1, '', 40),
 						'asis' => 1,
 					);
 

--- a/htdocs/core/boxes/box_factures_imp.php
+++ b/htdocs/core/boxes/box_factures_imp.php
@@ -88,16 +88,17 @@ class box_factures_imp extends ModeleBoxes
 
 		if ($user->rights->facture->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid, s.email,";
-			$sql .= " s.code_client,";
-			$sql .= " s.logo,";
-			$sql .= " f.ref, f.date_lim_reglement as datelimite,";
-			$sql .= " f.type,";
-			$sql .= " f.datef as df,";
-			$sql .= " f.total as total_ht,";
-			$sql .= " f.tva as total_tva,";
-			$sql .= " f.total_ttc,";
-			$sql .= " f.paye, f.fk_statut, f.rowid as facid";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", s.tva_intra, s.siren as idprof1, s.siret as idprof2, s.ape as idprof3, s.idprof4, s.idprof5, s.idprof6";
+			$sql .= ", f.ref, f.date_lim_reglement as datelimite";
+			$sql .= ", f.type";
+			$sql .= ", f.datef as df";
+			$sql .= ", f.total as total_ht";
+			$sql .= ", f.tva as total_tva";
+			$sql .= ", f.total_ttc";
+			$sql .= ", f.paye, f.fk_statut, f.rowid as facid";
 			$sql .= ", sum(pf.amount) as am";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -139,10 +140,20 @@ class box_factures_imp extends ModeleBoxes
 
 					$societestatic->id = $objp->socid;
 					$societestatic->name = $objp->name;
-					$societestatic->client = 1;
-					$societestatic->email = $objp->email;
+					//$societestatic->name_alias = $objp->name_alias;
 					$societestatic->code_client = $objp->code_client;
+					$societestatic->code_compta = $objp->code_compta;
+					$societestatic->client = $objp->client;
 					$societestatic->logo = $objp->logo;
+					$societestatic->email = $objp->email;
+					$societestatic->entity = $objp->entity;
+					$societestatic->tva_intra = $objp->tva_intra;
+					$societestatic->idprof1 = $objp->idprof1;
+					$societestatic->idprof2 = $objp->idprof2;
+					$societestatic->idprof3 = $objp->idprof3;
+					$societestatic->idprof4 = $objp->idprof4;
+					$societestatic->idprof5 = $objp->idprof5;
+					$societestatic->idprof6 = $objp->idprof6;
 
 					$late = '';
 					if ($facturestatic->hasDelay()) {

--- a/htdocs/core/boxes/box_ficheinter.php
+++ b/htdocs/core/boxes/box_ficheinter.php
@@ -76,17 +76,19 @@ class box_ficheinter extends ModeleBoxes
 
 		include_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
 		$ficheinterstatic = new Fichinter($this->db);
-		$companystatic = new Societe($this->db);
+		$thirdpartystatic = new Societe($this->db);
 
 		$this->info_box_head = array('text' => $langs->trans("BoxTitleLastFicheInter", $max));
 
 		if (!empty($user->rights->ficheinter->lire))
 		{
-			$sql = "SELECT f.rowid, f.ref, f.fk_soc, f.fk_statut,";
-			$sql .= " f.datec,";
-			$sql .= " f.date_valid as datev,";
-			$sql .= " f.tms as datem,";
-			$sql .= " s.nom as name, s.rowid as socid, s.client, s.email as semail";
+			$sql = "SELECT f.rowid, f.ref, f.fk_soc, f.fk_statut";
+			$sql .= ", f.datec";
+			$sql .= ", f.date_valid as datev";
+			$sql .= ", f.tms as datem";
+			$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			if (!$user->rights->societe->client->voir) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 			$sql .= ", ".MAIN_DB_PREFIX."fichinter as f";
@@ -115,9 +117,15 @@ class box_ficheinter extends ModeleBoxes
 					$ficheinterstatic->id = $objp->rowid;
 					$ficheinterstatic->ref = $objp->ref;
 
-					$companystatic->id = $objp->socid;
-					$companystatic->name = $objp->name;
-					$companystatic->email = $objp->semail;
+					$thirdpartystatic->id = $objp->socid;
+					$thirdpartystatic->name = $objp->name;
+					//$thirdpartystatic->name_alias = $objp->name_alias;
+					$thirdpartystatic->code_client = $objp->code_client;
+					$thirdpartystatic->code_compta = $objp->code_compta;
+					$thirdpartystatic->client = $objp->client;
+					$thirdpartystatic->logo = $objp->logo;
+					$thirdpartystatic->email = $objp->email;
+					$thirdpartystatic->entity = $objp->entity;
 
 					$this->info_box_contents[$i][] = array(
 						'td' => 'class="nowraponall"',
@@ -127,7 +135,7 @@ class box_ficheinter extends ModeleBoxes
 
 					$this->info_box_contents[$i][] = array(
 						'td' => 'class="tdoverflowmax150 maxwidth150onsmartphone"',
-						'text' => $companystatic->getNomUrl(1),
+						'text' => $thirdpartystatic->getNomUrl(1),
 						'asis' => 1,
 					);
 

--- a/htdocs/core/boxes/box_fournisseurs.php
+++ b/htdocs/core/boxes/box_fournisseurs.php
@@ -76,18 +76,17 @@ class box_fournisseurs extends ModeleBoxes
 
 		$this->max = $max;
 
-		include_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
-		$thirdpartystatic = new Societe($this->db);
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.class.php';
-		$thirdpartytmp = new Fournisseur($this->db);
+		$thirdpartystatic = new Fournisseur($this->db);
 
 		$this->info_box_head = array('text' => $langs->trans("BoxTitleLastModifiedSuppliers", $max));
 
 		if ($user->rights->societe->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid, s.datec, s.tms, s.status,";
-			$sql .= " s.code_fournisseur, s.email as semail,";
-			$sql .= " s.logo, s.code_compta_fournisseur, s.entity";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", s.datec, s.tms, s.status";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 			$sql .= " WHERE s.fournisseur = 1";
@@ -108,17 +107,20 @@ class box_fournisseurs extends ModeleBoxes
 					$objp = $this->db->fetch_object($result);
 					$datec = $this->db->jdate($objp->datec);
 					$datem = $this->db->jdate($objp->tms);
-					$thirdpartytmp->id = $objp->socid;
-					$thirdpartytmp->name = $objp->name;
-					$thirdpartytmp->email = $objp->semail;
-					$thirdpartytmp->code_client = $objp->code_client;
-					$thirdpartytmp->logo = $objp->logo;
-					$thirdpartytmp->code_compta_fournisseur = $objp->code_compta_fournisseur;
-					$thirdpartytmp->entity = $objp->entity;
+
+					$thirdpartystatic->id = $objp->socid;
+					$thirdpartystatic->name = $objp->name;
+					$thirdpartystatic->name_alias = $objp->name_alias;
+					$thirdpartystatic->code_fournisseur = $objp->code_fournisseur;
+					$thirdpartystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
+					$thirdpartystatic->fournisseur = $objp->fournisseur;
+					$thirdpartystatic->logo = $objp->logo;
+					$thirdpartystatic->email = $objp->email;
+					$thirdpartystatic->entity = $objp->entity;
 
 				   	$this->info_box_contents[$line][] = array(
 						'td' => '',
-						'text' => $thirdpartytmp->getNomUrl(1, '', 40),
+						'text' => $thirdpartystatic->getNomUrl(1, '', 40),
 						'asis' => 1,
 					);
 

--- a/htdocs/core/boxes/box_propales.php
+++ b/htdocs/core/boxes/box_propales.php
@@ -85,8 +85,10 @@ class box_propales extends ModeleBoxes
 
 		if ($user->rights->propale->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid, s.code_client, s.logo, s.entity, s.email,";
-			$sql .= " p.rowid, p.ref, p.fk_statut, p.datep as dp, p.datec, p.fin_validite, p.date_cloture, p.total_ht, p.tva as total_tva, p.total as total_ttc, p.tms";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", p.rowid, p.ref, p.fk_statut, p.datep as dp, p.datec, p.fin_validite, p.date_cloture, p.total_ht, p.tva as total_tva, p.total as total_ttc, p.tms";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			$sql .= ", ".MAIN_DB_PREFIX."propal as p";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -113,14 +115,19 @@ class box_propales extends ModeleBoxes
 					$datem = $this->db->jdate($objp->tms);
 					$dateterm = $this->db->jdate($objp->fin_validite);
 					$dateclose = $this->db->jdate($objp->date_cloture);
+
 					$propalstatic->id = $objp->rowid;
 					$propalstatic->ref = $objp->ref;
 					$propalstatic->total_ht = $objp->total_ht;
 					$propalstatic->total_tva = $objp->total_tva;
 					$propalstatic->total_ttc = $objp->total_ttc;
+
 					$societestatic->id = $objp->socid;
 					$societestatic->name = $objp->name;
+					//$societestatic->name_alias = $objp->name_alias;
 					$societestatic->code_client = $objp->code_client;
+					$societestatic->code_compta = $objp->code_compta;
+					$societestatic->client = $objp->client;
 					$societestatic->logo = $objp->logo;
 					$societestatic->email = $objp->email;
 					$societestatic->entity = $objp->entity;

--- a/htdocs/core/boxes/box_prospect.php
+++ b/htdocs/core/boxes/box_prospect.php
@@ -86,13 +86,11 @@ class box_prospect extends ModeleBoxes
 
 		if ($user->rights->societe->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid";
-			$sql .= ", s.code_client";
-			$sql .= ", s.client, s.email";
-			$sql .= ", s.code_fournisseur";
-			$sql .= ", s.fournisseur";
-			$sql .= ", s.logo";
-			$sql .= ", s.fk_stcomm, s.datec, s.tms, s.status";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", s.fk_stcomm";
+			$sql .= ", s.datec, s.tms, s.status";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 			$sql .= " WHERE s.client IN (2, 3)";
@@ -114,14 +112,16 @@ class box_prospect extends ModeleBoxes
 					$objp = $this->db->fetch_object($resql);
 					$datec = $this->db->jdate($objp->datec);
 					$datem = $this->db->jdate($objp->tms);
+
 					$thirdpartystatic->id = $objp->socid;
 					$thirdpartystatic->name = $objp->name;
-					$thirdpartystatic->email = $objp->email;
+					$thirdpartystatic->name_alias = $objp->name_alias;
 					$thirdpartystatic->code_client = $objp->code_client;
-					$thirdpartystatic->code_fournisseur = $objp->code_fournisseur;
+					$thirdpartystatic->code_compta = $objp->code_compta;
 					$thirdpartystatic->client = $objp->client;
-					$thirdpartystatic->fournisseur = $objp->fournisseur;
 					$thirdpartystatic->logo = $objp->logo;
+					$thirdpartystatic->email = $objp->email;
+					$thirdpartystatic->entity = $objp->entity;
 
 					$this->info_box_contents[$line][] = array(
 						'td' => '',

--- a/htdocs/core/boxes/box_shipments.php
+++ b/htdocs/core/boxes/box_shipments.php
@@ -88,10 +88,9 @@ class box_shipments extends ModeleBoxes
 
 		if ($user->rights->expedition->lire)
 		{
-			$sql = "SELECT s.nom as name";
-			$sql .= ", s.rowid as socid";
-			$sql .= ", s.code_client";
-			$sql .= ", s.logo, s.email";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_client, s.code_compta, s.client";
+			$sql .= ", s.logo, s.email, s.entity";
 			$sql .= ", e.ref, e.tms";
 			$sql .= ", e.rowid";
 			$sql .= ", e.ref_customer";
@@ -128,9 +127,13 @@ class box_shipments extends ModeleBoxes
 
 					$societestatic->id = $objp->socid;
 					$societestatic->name = $objp->name;
-					$societestatic->email = $objp->email;
+					//$societestatic->name_alias = $objp->name_alias;
 					$societestatic->code_client = $objp->code_client;
+					$societestatic->code_compta = $objp->code_compta;
+					$societestatic->client = $objp->client;
 					$societestatic->logo = $objp->logo;
+					$societestatic->email = $objp->email;
+					$societestatic->entity = $objp->entity;
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="nowraponall"',

--- a/htdocs/core/boxes/box_supplier_orders.php
+++ b/htdocs/core/boxes/box_supplier_orders.php
@@ -77,20 +77,20 @@ class box_supplier_orders extends ModeleBoxes
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.commande.class.php';
 		$supplierorderstatic = new CommandeFournisseur($this->db);
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.class.php';
-		$thirdpartytmp = new Fournisseur($this->db);
+		$thirdpartystatic = new Fournisseur($this->db);
 
 		$this->info_box_head = array('text' => $langs->trans("BoxTitleLatest".($conf->global->MAIN_LASTBOX_ON_OBJECT_DATE ? "" : "Modified")."SupplierOrders", $max));
 
 		if ($user->rights->fournisseur->commande->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid,";
-			$sql .= " s.code_client, s.code_fournisseur,";
-			$sql .= " s.logo, s.email,";
-			$sql .= " c.rowid, c.ref, c.tms, c.date_commande,";
-			$sql .= " c.total_ht,";
-			$sql .= " c.tva as total_tva,";
-			$sql .= " c.total_ttc,";
-			$sql .= " c.fk_statut";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", c.rowid, c.ref, c.tms, c.date_commande";
+			$sql .= ", c.total_ht";
+			$sql .= ", c.tva as total_tva";
+			$sql .= ", c.total_ttc";
+			$sql .= ", c.fk_statut";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			$sql .= ", ".MAIN_DB_PREFIX."commande_fournisseur as c";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -116,12 +116,15 @@ class box_supplier_orders extends ModeleBoxes
 					$supplierorderstatic->id = $objp->rowid;
 					$supplierorderstatic->ref = $objp->ref;
 
-					$thirdpartytmp->id = $objp->socid;
-					$thirdpartytmp->name = $objp->name;
-					$thirdpartytmp->email = $objp->email;
-					$thirdpartytmp->fournisseur = 1;
-					$thirdpartytmp->code_fournisseur = $objp->code_fournisseur;
-					$thirdpartytmp->logo = $objp->logo;
+					$thirdpartystatic->id = $objp->socid;
+					$thirdpartystatic->name = $objp->name;
+					//$thirdpartystatic->name_alias = $objp->name_alias;
+					$thirdpartystatic->code_fournisseur = $objp->code_fournisseur;
+					$thirdpartystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
+					$thirdpartystatic->fournisseur = $objp->fournisseur;
+					$thirdpartystatic->logo = $objp->logo;
+					$thirdpartystatic->email = $objp->email;
+					$thirdpartystatic->entity = $objp->entity;
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="nowraponall"',
@@ -131,7 +134,7 @@ class box_supplier_orders extends ModeleBoxes
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="tdoverflowmax150 maxwidth150onsmartphone"',
-						'text' => $thirdpartytmp->getNomUrl(1, 'supplier'),
+						'text' => $thirdpartystatic->getNomUrl(1, 'supplier'),
 						'asis' => 1,
 					);
 

--- a/htdocs/core/boxes/box_supplier_orders_awaiting_reception.php
+++ b/htdocs/core/boxes/box_supplier_orders_awaiting_reception.php
@@ -77,20 +77,20 @@ class box_supplier_orders_awaiting_reception extends ModeleBoxes
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.commande.class.php';
 		$supplierorderstatic = new CommandeFournisseur($this->db);
 		include_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.class.php';
-		$thirdpartytmp = new Fournisseur($this->db);
+		$thirdpartystatic = new Fournisseur($this->db);
 
 		$this->info_box_head = array('text' => $langs->trans("BoxTitleSupplierOrdersAwaitingReception", $max));
 
 		if ($user->rights->fournisseur->commande->lire)
 		{
-			$sql = "SELECT s.nom as name, s.rowid as socid,";
-			$sql .= " s.code_client, s.code_fournisseur, s.email,";
-			$sql .= " s.logo,";
-			$sql .= " c.rowid, c.ref, c.tms, c.date_commande, c.date_livraison as delivery_date, ";
-			$sql .= " c.total_ht,";
-			$sql .= " c.tva as total_tva,";
-			$sql .= " c.total_ttc,";
-			$sql .= " c.fk_statut";
+			$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias";
+			$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+			$sql .= ", s.logo, s.email, s.entity";
+			$sql .= ", c.rowid, c.ref, c.tms, c.date_commande, c.date_livraison as delivery_date";
+			$sql .= ", c.total_ht";
+			$sql .= ", c.tva as total_tva";
+			$sql .= ", c.total_ttc";
+			$sql .= ", c.fk_statut";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			$sql .= ", ".MAIN_DB_PREFIX."commande_fournisseur as c";
 			if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -121,12 +121,15 @@ class box_supplier_orders_awaiting_reception extends ModeleBoxes
 					$supplierorderstatic->id = $objp->rowid;
 					$supplierorderstatic->ref = $objp->ref;
 
-					$thirdpartytmp->id = $objp->socid;
-					$thirdpartytmp->name = $objp->name;
-					$thirdpartytmp->email = $objp->email;
-					$thirdpartytmp->fournisseur = 1;
-					$thirdpartytmp->code_fournisseur = $objp->code_fournisseur;
-					$thirdpartytmp->logo = $objp->logo;
+					$thirdpartystatic->id = $objp->socid;
+					$thirdpartystatic->name = $objp->name;
+					//$thirdpartystatic->name_alias = $objp->name_alias;
+					$thirdpartystatic->code_fournisseur = $objp->code_fournisseur;
+					$thirdpartystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
+					$thirdpartystatic->fournisseur = $objp->fournisseur;
+					$thirdpartystatic->logo = $objp->logo;
+					$thirdpartystatic->email = $objp->email;
+					$thirdpartystatic->entity = $objp->entity;
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="nowraponall"',
@@ -136,7 +139,7 @@ class box_supplier_orders_awaiting_reception extends ModeleBoxes
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="tdoverflowmax150 maxwidth150onsmartphone"',
-						'text' => $thirdpartytmp->getNomUrl(1, 'supplier'),
+						'text' => $thirdpartystatic->getNomUrl(1, 'supplier'),
 						'asis' => 1,
 					);
 

--- a/htdocs/core/lib/agenda.lib.php
+++ b/htdocs/core/lib/agenda.lib.php
@@ -164,9 +164,11 @@ function show_array_actions_to_do($max = 5)
 	include_once DOL_DOCUMENT_ROOT.'/comm/action/class/actioncomm.class.php';
 	include_once DOL_DOCUMENT_ROOT.'/societe/class/client.class.php';
 
-	$sql = "SELECT a.id, a.label, a.datep as dp, a.datep2 as dp2, a.fk_user_author, a.percent,";
-	$sql .= " c.code, c.libelle as type_label,";
-	$sql .= " s.nom as sname, s.rowid, s.client";
+	$sql = "SELECT a.id, a.label, a.datep as dp, a.datep2 as dp2, a.fk_user_author, a.percent";
+	$sql .= ", c.code, c.libelle as type_label";
+	$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.logo, s.email, s.entity";
 	$sql .= " FROM ".MAIN_DB_PREFIX."actioncomm as a LEFT JOIN ";
 	$sql .= " ".MAIN_DB_PREFIX."c_actioncomm as c ON c.id = a.fk_action";
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON a.fk_soc = s.rowid";
@@ -210,12 +212,18 @@ function show_array_actions_to_do($max = 5)
 			// print '<td>'.dol_trunc($obj->label,22).'</td>';
 
 			print '<td>';
-			if ($obj->rowid > 0)
+			if ($obj->socid > 0)
 			{
-				$customerstatic->id = $obj->rowid;
-				$customerstatic->name = $obj->sname;
+				$customerstatic->id = $obj->socid;
+				$customerstatic->name = $obj->name;
+				//$customerstatic->name_alias = $obj->name_alias;
+				$customerstatic->code_client = $obj->code_client;
+				$customerstatic->code_compta = $obj->code_compta;
 				$customerstatic->client = $obj->client;
-				print $customerstatic->getNomUrl(1, '', 16);
+				$customerstatic->logo = $obj->logo;
+				$customerstatic->email = $obj->email;
+				$customerstatic->entity = $obj->entity;
+				print $customerstatic->getNomUrl(1, '', 40);
 			}
 			print '</td>';
 
@@ -260,9 +268,11 @@ function show_array_last_actions_done($max = 5)
 
 	$now = dol_now();
 
-	$sql = "SELECT a.id, a.percent, a.datep as da, a.datep2 as da2, a.fk_user_author, a.label,";
-	$sql .= " c.code, c.libelle,";
-	$sql .= " s.rowid, s.nom as sname, s.client";
+	$sql = "SELECT a.id, a.percent, a.datep as da, a.datep2 as da2, a.fk_user_author, a.label";
+	$sql .= ", c.code, c.libelle";
+	$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+	$sql .= ", s.code_client, s.code_compta, s.client";
+	$sql .= ", s.logo, s.email, s.entity";
 	$sql .= " FROM ".MAIN_DB_PREFIX."actioncomm as a LEFT JOIN ";
 	$sql .= " ".MAIN_DB_PREFIX."c_actioncomm as c ON c.id = a.fk_action ";
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON a.fk_soc = s.rowid";
@@ -305,12 +315,18 @@ function show_array_last_actions_done($max = 5)
 			//print '<td>'.dol_trunc($obj->label,24).'</td>';
 
 			print '<td>';
-			if ($obj->rowid > 0)
+			if ($obj->socid > 0)
 			{
-				$customerstatic->id = $obj->rowid;
-				$customerstatic->name = $obj->sname;
+				$customerstatic->id = $obj->socid;
+				$customerstatic->name = $obj->name;
+				//$customerstatic->name_alias = $obj->name_alias;
+				$customerstatic->code_client = $obj->code_client;
+				$customerstatic->code_compta = $obj->code_compta;
 				$customerstatic->client = $obj->client;
-				print $customerstatic->getNomUrl(1, '', 24);
+				$customerstatic->logo = $obj->logo;
+				$customerstatic->email = $obj->email;
+				$customerstatic->entity = $obj->entity;
+				print $customerstatic->getNomUrl(1, '', 30);
 			}
 			print '</td>';
 

--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -2168,7 +2168,11 @@ function print_projecttasks_array($db, $form, $socid, $projectsListId, $mytasks 
 	if (empty($arrayidofprojects)) $arrayidofprojects[0] = -1;
 
 	// Get list of project with calculation on tasks
-	$sql2 = "SELECT p.rowid as projectid, p.ref, p.title, p.fk_soc, s.nom as socname, s.email, s.client, s.fournisseur,";
+	$sql2 = "SELECT p.rowid as projectid, p.ref, p.title, p.fk_soc,";
+	$sql2 .= " s.rowid as socid, s.nom as socname, s.name_alias,";
+	$sql2 .= " s.code_client, s.code_compta, s.client,";
+	$sql2 .= " s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur,";
+	$sql2 .= " s.logo, s.email, s.entity,";
 	$sql2 .= " p.fk_user_creat, p.public, p.fk_statut as status, p.fk_opp_status as opp_status, p.opp_percent, p.opp_amount,";
 	$sql2 .= " p.dateo, p.datee,";
 	$sql2 .= " COUNT(t.rowid) as nb, SUM(t.planned_workload) as planned_workload, SUM(t.planned_workload * t.progress / 100) as declared_progess_workload";
@@ -2237,12 +2241,18 @@ function print_projecttasks_array($db, $form, $socid, $projectsListId, $mytasks 
 				print '<td class="nowraponall tdoverflowmax100">';
 				if ($objp->fk_soc > 0)
 				{
-					$thirdpartystatic->id = $objp->fk_soc;
-					$thirdpartystatic->ref = $objp->socname;
+					$thirdpartystatic->id = $objp->socid;
 					$thirdpartystatic->name = $objp->socname;
+					//$thirdpartystatic->name_alias = $objp->name_alias;
+					//$thirdpartystatic->code_client = $objp->code_client;
+					$thirdpartystatic->code_compta = $objp->code_compta;
 					$thirdpartystatic->client = $objp->client;
+					//$thirdpartystatic->code_fournisseur = $objp->code_fournisseur;
+					$thirdpartystatic->code_compta_fournisseur = $objp->code_compta_fournisseur;
 					$thirdpartystatic->fournisseur = $objp->fournisseur;
+					$thirdpartystatic->logo = $objp->logo;
 					$thirdpartystatic->email = $objp->email;
+					$thirdpartystatic->entity = $objp->entity;
 					print $thirdpartystatic->getNomUrl(1);
 				}
 				print '</td>';

--- a/htdocs/projet/index.php
+++ b/htdocs/projet/index.php
@@ -213,8 +213,12 @@ print_projecttasks_array($db, $form, $socid, $projectsListId, 0, 0, $listofoppst
 print '</div><div class="fichetwothirdright"><div class="ficheaddleft">';
 
 // Latest modified projects
-$sql = "SELECT p.rowid, p.ref, p.title, p.fk_statut as status, p.tms as datem,";
-$sql .= " s.rowid as socid, s.nom as name, s.email, s.client, s.fournisseur, s.code_client, s.code_fournisseur, s.canvas, s.status as thirdpartystatus";
+$sql = "SELECT p.rowid, p.ref, p.title, p.fk_statut as status, p.tms as datem";
+$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+$sql .= ", s.code_client, s.code_compta, s.client";
+$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+$sql .= ", s.logo, s.email, s.entity";
+$sql .= ", s.canvas, s.status as thirdpartystatus";
 $sql .= " FROM ".MAIN_DB_PREFIX."projet as p";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s on p.fk_soc = s.rowid";
 $sql .= " WHERE p.entity IN (".getEntity('project').")";
@@ -253,11 +257,16 @@ if ($resql)
 
 			$companystatic->id = $obj->socid;
 			$companystatic->name = $obj->name;
-			$companystatic->email = $obj->email;
+			//$companystatic->name_alias = $obj->name_alias;
+			//$companystatic->code_client = $obj->code_client;
+			$companystatic->code_compta = $obj->code_compta;
 			$companystatic->client = $obj->client;
+			//$companystatic->code_fournisseur = $obj->code_fournisseur;
+			$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
 			$companystatic->fournisseur = $obj->fournisseur;
-			$companystatic->code_client = $obj->code_client;
-			$companystatic->code_fournisseur = $obj->code_fournisseur;
+			$companystatic->logo = $obj->logo;
+			$companystatic->email = $obj->email;
+			$companystatic->entity = $obj->entity;
 			$companystatic->canvas = $obj->canvas;
 			$companystatic->status = $obj->thirdpartystatus;
 
@@ -307,7 +316,11 @@ print_liste_field_titre("NbOfProjects", $_SERVER["PHP_SELF"], "nb", "", "", '', 
 print "</tr>\n";
 
 $sql = "SELECT COUNT(p.rowid) as nb, SUM(p.opp_amount)";
-$sql .= ", s.rowid as socid, s.nom as name, s.email, s.client, s.fournisseur, s.code_client, s.code_fournisseur, s.canvas, s.status";
+$sql .= ", s.rowid as socid, s.nom as name, s.name_alias";
+$sql .= ", s.code_client, s.code_compta, s.client";
+$sql .= ", s.code_fournisseur, s.code_compta_fournisseur, s.fournisseur";
+$sql .= ", s.logo, s.email, s.entity";
+$sql .= ", s.canvas, s.status";
 $sql .= " FROM ".MAIN_DB_PREFIX."projet as p";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s on p.fk_soc = s.rowid";
 $sql .= " WHERE p.entity IN (".getEntity('project').")";
@@ -341,9 +354,17 @@ if ($resql)
 		{
 			$companystatic->id = $obj->socid;
 			$companystatic->name = $obj->name;
-			$companystatic->email = $obj->email;
+			$companystatic->name_alias = $obj->name_alias;
+			$companystatic->code_client = $obj->code_client;
+			$companystatic->code_compta = $obj->code_compta;
 			$companystatic->client = $obj->client;
+			$companystatic->code_fournisseur = $obj->code_fournisseur;
+			$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
 			$companystatic->fournisseur = $obj->fournisseur;
+			$companystatic->logo = $obj->logo;
+			$companystatic->email = $obj->email;
+			$companystatic->entity = $obj->entity;
+			$companystatic->canvas = $obj->canvas;
 			$companystatic->status = $obj->status;
 
 			print $companystatic->getNomUrl(1);


### PR DESCRIPTION
# Fix #14405

On some boxes, the customer or supplier code is not displayed  with option "Show customer/supplier reference in lists, labels and links". In addition, all tool tips don't show the same information.
The library function to display a third party is OK.
The problem is that the code of the boxes don't always fetch all fields.
Sometimes code is not fetched.
Sometimes supplier code is fetched instead of customer.
Sometimes accountancy code is fetched, sometimes not.
.....

=> use the same SQL request and code for all boxes
