### PR TITLE
V12 Update html.form.class.php to complete Fix #15565 Enhanced behaviour to select product on customer/supplier order to be able to use barcode reader efficiently

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2040,7 +2040,7 @@ class Form
 			if (!empty($conf->global->PRODUIT_CUSTOMER_PRICES) && !empty($socid)) {
 				$urloption .= '&socid='.$socid;
 			}
-			print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 0, $ajaxoptions);
+			print ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/product/ajax/products.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 1, $ajaxoptions);
 
 			if (!empty($conf->variants->enabled)) {
 				?>


### PR DESCRIPTION
From PR #15565 on V12 branch
[Answer to eldy](https://github.com/Dolibarr/dolibarr/pull/15694#issuecomment-741019633) about its partial commit for fixing PR #15565
In fact change in htdocs/core/lib/ajax.lib.php is necessary but not sufficient.
If $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 0, combo remains even the product selected is alone. So an action is necessary to choose it by mouse or down arrow, it's slower.
So I recommend to have $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 1, for customer order filling where the probability is higher to use a barcode scanner.
For supplier order, considering that the barcode reader is less useful and that it's convenient to see the complete product information (description, price) on the combo before to confirm, I would maintain the value $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 0,
Particularly because also that the supplier price box is not currently automatically filled.
[See also screen shots in my previous answer](https://github.com/Dolibarr/dolibarr/pull/15694#issuecomment-741146869).
Thank you for your attention and patience. I don't really know if it's the good way to proceed.