### PR TITLE
Update V13 fournisseurs.php to Fix #15755 Product: purchase price tab, supplier price table with list of products not "responsive"

### DIFF
--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -915,7 +915,7 @@ END;
 
 				// Suppliers list title
 				print '<div class="div-table-responsive">';
-				print '<table class="liste centpercent">';
+				print '<table class="noborder centpercent">';
 
 				$param = "&id=".$object->id;
 


### PR DESCRIPTION
# Fix  *#15755 Product: purchase price tab, supplier price table with list of products not "responsive"* 
Product: purchase price tab, the supplier price table with its list of products is not "responsive", as a result, the right-clickable areas, including the "Add purchase price" button, disappear to the right of the screens that are not full HD which forces the user to drag his window with the mouse.
The solution is to change the CSS class of the table to adopt the CSS class of the equivalent table of the selling price tab, which is "responsive", to it.
**This is a transfer of the correction originally created for version V12.0.3**
in htdocs/product/fournisseurs.php
We therefore replace :
`print '<table class="liste centpercent">';`
by :
`print '<table class="noborder centpercent">';`

Knowing that the class is used in 24 files, there might be other places where this class poses the same ergonomic problem. I don't know enough Dolibarr to generalize the correction ...
See also [discussion on the french forum](https://www.dolibarr.fr/forum/t/produit-prix-dachat-fenetre-non-responsive-et-ca-agace-mes-utilisateurs/35064).
