### PR TITLE
V12 Urgent workaround to  fix #15770 following a migration by import, the products selling prices move by themselves.

### DIFF
--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -1466,7 +1466,7 @@ if ((empty($conf->global->PRODUIT_CUSTOMER_PRICES) || $action == 'showlog_defaul
 
     		$result = $db->query($sql);
     		$num = $db->num_rows($result);
-     */}
+			*/}
 
     	if ($num > 0)
     	{

--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -1452,7 +1452,7 @@ if ((empty($conf->global->PRODUIT_CUSTOMER_PRICES) || $action == 'showlog_defaul
         $num = $db->num_rows($result);
 
     	if (!$num)
-    	{
+    	{/*
     		$db->free($result);
 
     		// Il doit au moins y avoir la ligne de prix initial.
@@ -1466,7 +1466,7 @@ if ((empty($conf->global->PRODUIT_CUSTOMER_PRICES) || $action == 'showlog_defaul
 
     		$result = $db->query($sql);
     		$num = $db->num_rows($result);
-    	}
+     */}
 
     	if ($num > 0)
     	{


### PR DESCRIPTION
# Fix #15770 **workaround**
Urgent workaround to  fix #15770 the Bug : Very annoying, following a migration by import, the selling prices of the products move by themselves.
Product, selling price, avoid to create automatically an history erroneous line the first time seeing an imported product. Because this erroneous history line breaks the true selling price (imported at first).


