### PR TITLE
FIX: wrong margin calculation if sell price is negative

### DIFF
--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -97,7 +97,7 @@ class FormMargin
 			}
 
 			$pv = $line->total_ht;
-			$pa_ht = ($pv < 0 ? - $line->pa_ht : $line->pa_ht);      // We choosed to have line->pa_ht always positive in database, so we guess the correct sign
+			$pa_ht = $line->pa_ht;
 			if ($object->element == 'facture' && $object->type == $object::TYPE_SITUATION) {
 				$pa = $line->qty * $pa_ht * ($line->situation_percent / 100);
 			} else {


### PR DESCRIPTION
# Issue description
If you have an order and create a line with a sell price of -50 and a buy price of -50, instead of being 0, your margin is -100 because in the margin calulation, Dolibarr flips the sign of the buy price if the sell price is negative. So -50 - (- (-50)) = -100.

The line that changes the sign has a comment suggesting that, at the time it was introduced, negative buy prices were never stored in the database. Now this is no longer true (negative buy prices can be stored).

# Fix
This PR simply removes the sign guessing line and it seems to do the job well (the margin is my example is 0 as expected). As always I am open to suggestions, since there might be implications that I haven't foreseen.