### PR TITLE
Fix button Add (a product) on customer order disappearing on right for <1400px width screens

### DIFF
--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -1104,7 +1104,7 @@ table[summary="list_of_modules"] .fa-cog {
 	.titlefield { /* width: 30% !important; */ }
 	.titlefieldcreate { width: 30% !important; }
 	.minwidth50imp  { min-width: 50px !important; }
-    .minwidth75imp  { min-width: 75px !important; }
+    .minwidth75imp  { min-width: 75px !important; max-width: 150px !important; }
     .minwidth100imp { min-width: 100px !important; }
     .minwidth150imp { min-width: 150px !important; }
     .minwidth200imp { min-width: 200px !important; }

--- a/htdocs/theme/md/style.css.php
+++ b/htdocs/theme/md/style.css.php
@@ -1189,7 +1189,7 @@ table[summary="list_of_modules"] .fa-cog {
 	.titlefield { /* width: 30% !important; */ }
 	.titlefieldcreate { width: 30% !important; }
 	.minwidth50imp  { min-width: 50px !important; }
-    .minwidth75imp  { min-width: 75px !important; }
+    .minwidth75imp  { min-width: 75px !important; max-width: 150px !important; }
     .minwidth100imp { min-width: 100px !important; }
     .minwidth150imp { min-width: 150px !important; }
     .minwidth200imp { min-width: 200px !important; }


### PR DESCRIPTION
# New [*button Add (a product) on customer order is disappearing on right for <1400px screens*]
On V12.0.4
When there are too much characters prefilled on the select, the button to add the line on the order disappears on right for screens <1400px width.
![image](https://user-images.githubusercontent.com/1511011/103408943-dbb7ca00-4b64-11eb-9912-778787d9bc71.png)
The correction limits the width of the select to 150px for screens <1400px width.
![image](https://user-images.githubusercontent.com/1511011/103409008-1d487500-4b65-11eb-9285-b2689a3438c7.png)
the correction is proposed for the 2 themes eldy and md
The correction will have to be reported on development branch if you agree...