### PR TITLE
Fix dict contact type element list

### DIFF
--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -1380,14 +1380,12 @@ function complete_elementList_with_modules(&$elementList)
                             $dirmod[$i] = $dir;
                             //print "x".$modName." ".$orders[$i]."\n<br>";
 
-                            if (!empty($objMod->module_parts['contactelement']))
-                            {
-                            	if(is_array($objMod->module_parts['contactelement'])) {
+                            if (!empty($objMod->module_parts['contactelement'])) {
+                            	if (is_array($objMod->module_parts['contactelement'])) {
 									foreach ($objMod->module_parts['contactelement'] as $elem => $title) {
 										$elementList[$elem] = $langs->trans($title);
 									}
-								}
-                            	else {
+								} else {
 									$elementList[$objMod->name] = $langs->trans($objMod->name);
 								}
                             }

--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -1382,7 +1382,14 @@ function complete_elementList_with_modules(&$elementList)
 
                             if (!empty($objMod->module_parts['contactelement']))
                             {
-                            	$elementList[$objMod->name] = $langs->trans($objMod->name);
+                            	if(is_array($objMod->module_parts['contactelement'])) {
+									foreach ($objMod->module_parts['contactelement'] as $elem => $title) {
+										$elementList[$elem] = $langs->trans($title);
+									}
+								}
+                            	else {
+									$elementList[$objMod->name] = $langs->trans($objMod->name);
+								}
                             }
 
                             $j++;


### PR DESCRIPTION
There was an inconsistency between the contact type list which is based on the object->element and the contact type dictionary which was based on mod->name. I propose to allow module part "contactelement" to contain an array to specify which object can have contact roles.
Without this, it's impossible to add/change a specific contact role for an object coming from an external module.