### PR TITLE
FIX missing recalculate Costs of bom issue #15388

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -350,6 +350,7 @@ class BOM extends CommonObject
 		$this->lines = array();
 
 		$result = $this->fetchLinesCommon();
+		$this->calculateCosts();
 		return $result;
 	}
 


### PR DESCRIPTION


# Fix #15388
missing recalculate Costs of bom in fetch lines

