### PR TITLE
FIX useless tracking number displayed on pdf if empty issue #14501

### DIFF
--- a/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
@@ -381,7 +381,7 @@ class pdf_rouget extends ModelePdfExpedition
 					{
 						$pdf->writeHTMLCell(60, 4, $this->posxdesc - 1, $tab_top - 1, $outputlangs->transnoentities("TrackingNumber")." : ".$object->tracking_number, 0, 1, false, true, 'L');
 						$tab_top_alt = $pdf->GetY();
-						
+
 						$object->getUrlTrackingStatus($object->tracking_number);
 						if (!empty($object->tracking_url))
 						{

--- a/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
@@ -373,14 +373,15 @@ class pdf_rouget extends ModelePdfExpedition
 					$tab_top_alt = $tab_top;
 
 					$pdf->SetFont('', 'B', $default_font_size - 2);
-					$pdf->writeHTMLCell(60, 4, $this->posxdesc - 1, $tab_top - 1, $outputlangs->transnoentities("TrackingNumber")." : ".$object->tracking_number, 0, 1, false, true, 'L');
 
-					$tab_top_alt = $pdf->GetY();
 					//$tab_top_alt += 1;
 
 					// Tracking number
 					if (!empty($object->tracking_number))
 					{
+						$pdf->writeHTMLCell(60, 4, $this->posxdesc - 1, $tab_top - 1, $outputlangs->transnoentities("TrackingNumber")." : ".$object->tracking_number, 0, 1, false, true, 'L');
+						$tab_top_alt = $pdf->GetY();
+						
 						$object->getUrlTrackingStatus($object->tracking_number);
 						if (!empty($object->tracking_url))
 						{


### PR DESCRIPTION
# Fix #14501 
useless tracking number displayed on pdf if empty

