### PR TITLE
Fix #15829

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -3650,7 +3650,7 @@ class Societe extends CommonObject
     public function create_from_member(Adherent $member, $socname = '', $socalias = '', $customercode = '')
 	{
         // phpcs:enable
-		global $user, $langs;
+		global $conf, $user, $langs;
 
 		dol_syslog(get_class($this)."::create_from_member", LOG_DEBUG);
 
@@ -3683,6 +3683,22 @@ class Societe extends CommonObject
 		$result = $this->create($user);
 		if ($result >= 0)
 		{
+			// Auto-create contact on thirdparty creation
+			if (!empty($conf->global->THIRDPARTY_DEFAULT_CREATE_CONTACT))
+			{
+				// Fill fields needed by contact
+				$this->name_bis = $member->lastname;
+				$this->firstname = $member->firstname;
+				$this->civility_id = $member->civility_id;
+				dol_syslog("We ask to create a contact/address too", LOG_DEBUG);
+				$result = $this->create_individual($user);
+				if ($result < 0)
+				{
+					setEventMessages($this->error, $this->errors, 'errors');
+					return -1;
+				}
+			}
+
 			$sql = "UPDATE ".MAIN_DB_PREFIX."adherent";
 			$sql .= " SET fk_soc=".$this->id;
 			$sql .= " WHERE rowid=".$member->id;


### PR DESCRIPTION
# Fix #15829 

Contact is now created when a third party is created from an adherent (when THIRDPARTY_DEFAULT_CREATE_CONTACT is set to "1" )
