### PR TITLE
Fix sort order in birthday box

### DIFF
--- a/htdocs/core/boxes/box_birthdays.php
+++ b/htdocs/core/boxes/box_birthdays.php
@@ -91,7 +91,7 @@ class box_birthdays extends ModeleBoxes
 			$sql .= " WHERE u.entity IN (".getEntity('user').")";
 			$sql .= " AND u.statut = 1";
 			$sql .= dolSqlDateFilter('u.birth', 0, $tmparray['mon'], 0);
-			$sql .= " ORDER BY u.birth ASC";
+			$sql .= " ORDER BY DAYOFMONTH(u.birth) ASC";
 			$sql .= $this->db->plimit($max, 0);
 
 			dol_syslog(get_class($this)."::loadBox", LOG_DEBUG);

--- a/htdocs/core/boxes/box_birthdays.php
+++ b/htdocs/core/boxes/box_birthdays.php
@@ -91,7 +91,7 @@ class box_birthdays extends ModeleBoxes
 			$sql .= " WHERE u.entity IN (".getEntity('user').")";
 			$sql .= " AND u.statut = 1";
 			$sql .= dolSqlDateFilter('u.birth', 0, $tmparray['mon'], 0);
-			$sql .= " ORDER BY DAYOFMONTH(u.birth) ASC";
+			$sql .= " ORDER BY DAY(u.birth) ASC";
 			$sql .= $this->db->plimit($max, 0);
 
 			dol_syslog(get_class($this)."::loadBox", LOG_DEBUG);


### PR DESCRIPTION
# Fix sort order in birthday box
The current sort order is by date and not by day of month. This yields
the following unexpected results:

Given

* Person A, born on 1980-01-10
* Person B, born on 1970-01-30

I expect Person A to be listed first because their birthday is before
that of Person B _in January_. But without this fix, Person B would show
up first because 1970 is before 1980.
