### PR TITLE
NEW Hook to allow external modules to add their own shortlist of recent objects

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -1266,6 +1266,12 @@ if ($object->id > 0)
 		}
 	}
 
+	// Allow external modules to add their own shortlist of recent objects
+	$parameters = array();
+	$reshook = $hookmanager->executeHooks('addMoreRecentObjects', $parameters, $object, $action);
+	if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	else print $hookmanager->resPrint;
+
 	print '</div></div></div>';
 	print '<div style="clear:both"></div>';
 


### PR DESCRIPTION
# New

Add a hook on customer tab of thirdparty to allow external modules to add their own shortlist of recent objects.
