### PR TITLE
Use login from LDAP attribute

### DIFF
--- a/htdocs/core/login/functions_ldap.php
+++ b/htdocs/core/login/functions_ldap.php
@@ -148,8 +148,11 @@ function check_user_password_ldap($usertotest, $passwordtotest, $entitytotest)
 		{
 			if ($result == 2)	// Connection is ok for user/pass into LDAP
 			{
-				dol_syslog("functions_ldap::check_user_password_ldap Authentification ok");
 				$login = $usertotest;
+				if (!empty($conf->global->LDAP_FIELD_LOGIN)) {
+					$login = $ldap->login;
+				}
+				dol_syslog("functions_ldap::check_user_password_ldap $login authentication ok");
 
 				require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 


### PR DESCRIPTION
The LDAP authentication function (check_user_password_ldap) returns the login
sting when authentication is successful.

The current implementation always return the provided login to the check function,
instead of LDAP entry login field (as defined in the LDAP_FIELD_LOGIN).

This is problematic when you expect user to log with several login, like mail,
or the LDAP login doesn't match the dolibarr database.

For example, the following filter allows users auth with mail and cn ldap fields:
$dolibarr_main_auth_ldap_filter = '(&(objectClass=person)(|(cn=%1%)(mail=%1%)))';
but, dolibarr will not find the user when mail is provided.

This patch returns the $ldap->login when LDAP_FIELD_LOGIN is configured.