### PR TITLE
FIX: Accountancy - FEC - With a manual entry, need subaccount label in data

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -956,8 +956,12 @@ class BookKeeping extends CommonObject
 		$sql .= " t.date_creation,";
 		$sql .= " t.date_lim_reglement,";
 		$sql .= " t.tms as date_modification,";
-		$sql .= " t.date_export";
+		$sql .= " t.date_export,";
+		$sql .= " c.nom as customer_name,";
+		$sql .= " s.nom as supplier_name";
 		$sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element.' as t';
+		$sql .= " LEFT JOIN llx_societe as c ON t.subledger_account = c.code_compta";
+		$sql .= " LEFT JOIN llx_societe as s ON t.subledger_account = s.code_compta_fournisseur";
 		// Manage filter
 		$sqlwhere = array();
 		if (count($filter) > 0) {
@@ -1018,7 +1022,10 @@ class BookKeeping extends CommonObject
 				$line->fk_docdet = $obj->fk_docdet;
 				$line->thirdparty_code = $obj->thirdparty_code;
 				$line->subledger_account = $obj->subledger_account;
-				$line->subledger_label = $obj->subledger_label;
+
+				if (!empty($obj->customer_name)) $line->subledger_label = $obj->customer_name;
+				if (!empty($obj->supplier_name)) $line->subledger_label = $obj->supplier_name;
+
 				$line->numero_compte = $obj->numero_compte;
 				$line->label_compte = $obj->label_compte;
 				$line->label_operation = $obj->label_operation;


### PR DESCRIPTION
Hello,

/!\ I'm not satisfied by this fix. Maybe add societe & user id, type in select subaccount for a better detection of the thirdparty/employee.

In fact, when with add a manuel transaction in ledger : 

![image](https://user-images.githubusercontent.com/2341395/104544896-381cee00-5629-11eb-906d-520a1ff6bf58.png)

A data is missing in database (subledger_label is empty) and it's necessary for the FEC export :

![image](https://user-images.githubusercontent.com/2341395/104545107-98139480-5629-11eb-982a-fcd8a19fbe38.png)

With the function select_auxaccount(), we have subaccount number from thirdparty & employee but not the rowid & type of the element to launch a more precise fetch after.

Subaccount number is not accurate enough and with this correction, it is possible to have several results...
Maybe register in field thirdparty_code or add a field thirdparty_rowid & type in table accounting_bookkeeping & modified function select_axuaccount() to have it


