### PR TITLE
FIX: Load translate file when 'mymodule' is considered loaded but is not found and the 'mymodule@mymodule' is not loaded but exist

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -205,7 +205,7 @@ class Translate
 		}
 
         // Check cache
-		if (! empty($this->_tab_loaded[$newdomain]))	// File already loaded for this domain
+		if (! empty($this->_tab_loaded[$newdomain]) && $this->_tab_loaded[$newdomain] != 2)	// File already loaded for this domain
 		{
 			//dol_syslog("Translate::Load already loaded for newdomain=".$newdomain);
 			return 0;


### PR DESCRIPTION
FIX: Load translate file when 'mymodule' is considered loaded but is not found and the 'mymodule@mymodule' is not loaded but exist