### PR TITLE
FIX 12.0 - "openall" filter on ticket list does not include read tickets

### DIFF
--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -346,11 +346,12 @@ foreach ($search as $key => $val)
 			$newarrayofstatus[] = $val2;
 		}
 	    if ($search['fk_statut'] == 'openall' || in_array('openall', $search['fk_statut'])) {
-	    	$newarrayofstatus[] = Ticket::STATUS_NOT_READ;
-	    	$newarrayofstatus[] = Ticket::STATUS_ASSIGNED;
-	    	$newarrayofstatus[] = Ticket::STATUS_IN_PROGRESS;
-	    	$newarrayofstatus[] = Ticket::STATUS_NEED_MORE_INFO;
-	    	$newarrayofstatus[] = Ticket::STATUS_WAITING;
+			$newarrayofstatus[] = Ticket::STATUS_NOT_READ;
+			$newarrayofstatus[] = Ticket::STATUS_READ;
+			$newarrayofstatus[] = Ticket::STATUS_ASSIGNED;
+			$newarrayofstatus[] = Ticket::STATUS_IN_PROGRESS;
+			$newarrayofstatus[] = Ticket::STATUS_NEED_MORE_INFO;
+			$newarrayofstatus[] = Ticket::STATUS_WAITING;
 	    }
 	    if ($search['fk_statut'] == 'closeall' || in_array('closeall', $search['fk_statut'])) {
 	    	$newarrayofstatus[] = Ticket::STATUS_CLOSED;


### PR DESCRIPTION
# Fix
The ticket list provides a global filter for open tickets, but it does not include read tickets (tickets with status `STATUS_READ`). I think that filter should include read tickets since they are not closed or canceled.