### PR TITLE
FIX : missing GETPOST parameters on card_presend.tpl.php

### DIFF
--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -209,7 +209,7 @@ if ($action == 'presend')
 	}
 
 	$formmail->withto = $liste;
-	$formmail->withtofree = (GETPOSTISSET('sendto') ? (GETPOST('sendto') ? GETPOST('sendto') : '1') : '1');
+	$formmail->withtofree = (GETPOSTISSET('sendto') ? (GETPOST('sendto', 'alpha') ? GETPOST('sendto', 'alpha') : '1') : '1');
 	$formmail->withtocc = $liste;
 	$formmail->withtoccc = $conf->global->MAIN_EMAIL_USECCC;
 	$formmail->withtopic = $topicmail;


### PR DESCRIPTION
# Fix

In the case of an email presend, the email addresses of the recipients are in the "< aaaa@aaaa.fr >" format.
The default 'alphanohtml' parameter of the GETPOST deletes the chevrons as well as the contents inside the chevrons.
