### PR TITLE
Fix #16015 regression in V12: if VAT code is written in non latin characters or begins by numerical characters, unable to edit the pricing correctly in Sales Order

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4730,8 +4730,13 @@ function price2num($amount, $rounding = '', $option = 0)
 		if (!is_numeric($amount)) {
 			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters
 			$amount = preg_replace('/[a-df-zA-DF-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?\+\~\^]/', '', $amount);//Eliminate remaining no numerical characters, keep only 0-9 . , - e E
-			//
-			$amount = preg_replace('/[\,\.]/', '%', $amount);//Treat , and . (as % to work)
+			if ($dec == ','){
+				$amount = preg_replace('/\./', '', $amount);//Remove all useless dots
+			}
+			if ($dec == '.'){
+				$amount = preg_replace('/\,/', '', $amount);//Remove all useless commas
+			}
+			$amount = preg_replace('/[\,\.]/', '%', $amount);//Treat , or . (as % to work)
 			$pos = strpos($amount, '%');
 			if ($pos !== false) {
 				$amount = substr_replace($amount, '.', $pos, 1);

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4730,21 +4730,21 @@ function price2num($amount, $rounding = '', $option = 0)
 		if (!is_numeric($amount)) {
 			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters
 			$amount = preg_replace('/[a-df-zA-DF-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?\+\~\^]/', '', $amount);//Eliminate remaining no numerical characters, keep only 0-9 . , - e E
-//
+			//
 			$amount = preg_replace('/[\,\.]/', '%', $amount);//Treat , and . (as % to work)
 			$pos = strpos($amount, '%');
 			if ($pos !== false) {
 				$amount = substr_replace($amount, '.', $pos, 1);
 			}
 			$amount = preg_replace('/%/', '', $amount);//Keep only one dot
-//
+			//
 			$amount = preg_replace('/[eE]/', '%', $amount);//Treat e and E (as % to work)
 			$pos = strpos($amount, '%');
 			if ($pos !== false) {
 				$amount = substr_replace($amount, 'E', $pos, 1);
 			}
 			$amount = preg_replace('/%/', '', $amount);//Keep only the first e or E as E
-//
+			//
 			$amount = preg_replace('/[-]/', '%', $amount);//Treat - (as % to work)
 			$pos = strpos($amount, '%');
 			if ($pos !== false) {
@@ -4755,7 +4755,7 @@ function price2num($amount, $rounding = '', $option = 0)
 				$amount = substr_replace($amount, '-', $pos, 1);
 			}
 			$amount = preg_replace('/%/', '', $amount);//Keep at max two -
-//
+			//
 			if (!is_numeric($amount)) {
 				dol_syslog("functions.lib::price2num: amount in=".$amountin." No numeric result=".$amount, LOG_ERR);
 				$amount='';//Clear amount, not numeric, nothing possible to do

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4726,19 +4726,19 @@ function price2num($amount, $rounding = '', $option = 0)
 		//print 'PP'.$amount.' - '.$dec.' - '.$thousand.' - '.intval($amount).'<br>';
 		if (!is_numeric($amount)) {
 			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters 
-			$amount = substr($amount, 0, strpos($amount,' ('));//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
+			$amount = substr($amount, 0, strpos($amount, ' ('));//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
 			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?]/', '', $amount);//Eliminate alphabetics and special characters, keep only 0-9 . , - + and spaces (eliminated after)
-			$lastpos=strrpos($amount,'+',0);//+ if exists, must be alone at first place, eliminate others
-			while(($lastpos<>false)and($lastpos>0))
+			$lastpos=strrpos($amount, '+', 0);//+ if exists, must be alone at first place, eliminate others
+			while (($lastpos<>false) and ($lastpos>0))
 			{
 				$amount=substr_replace($amount, '', $lastpos, 1);
-				$lastpos=strrpos ($amount,'+',0);
+				$lastpos=strrpos($amount, '+', 0);
 			}
-			$lastpos=strrpos ($amount,'-',0);//- if exists, must be alone at first place, eliminate others
-			while(($lastpos<>false)and($lastpos>0))
+			$lastpos=strrpos($amount, '-', 0);//- if exists, must be alone at first place, eliminate others
+			while (($lastpos<>false) and ($lastpos>0))
 			{
 				$amount=substr_replace($amount, '', $lastpos, 1);
-				$lastpos=strrpos($amount,'-',0);
+				$lastpos=strrpos($amount, '-', 0);
 			}
 		}
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4725,7 +4725,21 @@ function price2num($amount, $rounding = '', $option = 0)
 	if ($option != 1) {	// If not a PHP number or unknown, we change or clean format
 		//print 'PP'.$amount.' - '.$dec.' - '.$thousand.' - '.intval($amount).'<br>';
 		if (!is_numeric($amount)) {
-			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_]/', '', $amount);
+			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters 
+			$amount = substr( $amount, 0, strpos( $amount, ' (' ) );//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
+			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?]/', '', $amount);//Eliminate alphabetics and special characters, keep only 0-9 . , - + and spaces (eliminated after)
+			$lastpos=strrpos ( $amount,'+',0);//+ if exists, must be alone at first place, eliminate others
+			while (($lastpos<>false) and ($lastpos>0))
+			{
+				$amount=substr_replace($amount, '', $lastpos, 1);
+				$lastpos=strrpos ( $amount,'+',0);
+			}
+			$lastpos=strrpos ( $amount,'-',0);//- if exists, must be alone at first place, eliminate others
+			while (($lastpos<>false) and ($lastpos>0))
+			{
+				$amount=substr_replace($amount, '', $lastpos, 1);
+				$lastpos=strrpos ( $amount,'-',0);
+			}
 		}
 
 		if ($option == 2 && $thousand == '.' && preg_match('/\.(\d\d\d)$/', (string) $amount)) {	// It means the . is used as a thousand separator and string come frominput data, so 1.123 is 1123

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4725,7 +4725,7 @@ function price2num($amount, $rounding = '', $option = 0)
 	if ($option != 1) {	// If not a PHP number or unknown, we change or clean format
 		//print 'PP'.$amount.' - '.$dec.' - '.$thousand.' - '.intval($amount).'<br>';
 		if (!is_numeric($amount)) {
-			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters 
+			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters
 			$amount = substr($amount, 0, strpos($amount, ' ('));//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
 			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?]/', '', $amount);//Eliminate alphabetics and special characters, keep only 0-9 . , - + and spaces (eliminated after)
 			$lastpos=strrpos($amount, '+', 0);//+ if exists, must be alone at first place, eliminate others

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4726,7 +4726,10 @@ function price2num($amount, $rounding = '', $option = 0)
 		//print 'PP'.$amount.' - '.$dec.' - '.$thousand.' - '.intval($amount).'<br>';
 		if (!is_numeric($amount)) {
 			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters
-			$amount = substr($amount, 0, strpos($amount, ' ('));//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
+			$codepos = strpos($amount, ' (' );//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
+			if ($codepos > 0) {
+				$amount = substr($amount, 0, $codepos);
+			}
 			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?]/', '', $amount);//Eliminate alphabetics and special characters, keep only 0-9 . , - + and spaces (eliminated after)
 			$lastpos=strrpos($amount, '+', 0);//+ if exists, must be alone at first place, eliminate others
 			while (($lastpos<>false) and ($lastpos>0))

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4730,17 +4730,32 @@ function price2num($amount, $rounding = '', $option = 0)
 		if (!is_numeric($amount)) {
 			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters
 			$amount = preg_replace('/[a-df-zA-DF-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?\+\~\^]/', '', $amount);//Eliminate remaining no numerical characters, keep only 0-9 . , - e E
-			$pos = strpos($amount, ',');//Replace 1st place of a comma by dot
+//
+			$amount = preg_replace('/[\,\.]/', '%', $amount);//Treat , and . (as % to work)
+			$pos = strpos($amount, '%');
 			if ($pos !== false) {
 				$amount = substr_replace($amount, '.', $pos, 1);
 			}
-			$amount = preg_replace('/,/', '', $amount);//Eliminate all remaining commas
-			$amount = preg_replace('/[eE]/', '%', $amount);//Treat e and E
+			$amount = preg_replace('/%/', '', $amount);//Keep only one dot
+//
+			$amount = preg_replace('/[eE]/', '%', $amount);//Treat e and E (as % to work)
 			$pos = strpos($amount, '%');
 			if ($pos !== false) {
 				$amount = substr_replace($amount, 'E', $pos, 1);
 			}
 			$amount = preg_replace('/%/', '', $amount);//Keep only the first e or E as E
+//
+			$amount = preg_replace('/[-]/', '%', $amount);//Treat - (as % to work)
+			$pos = strpos($amount, '%');
+			if ($pos !== false) {
+				$amount = substr_replace($amount, '-', $pos, 1);
+			}
+			$pos = strpos($amount, '%');
+			if ($pos !== false) {
+				$amount = substr_replace($amount, '-', $pos, 1);
+			}
+			$amount = preg_replace('/%/', '', $amount);//Keep at max two -
+//
 			if (!is_numeric($amount)) {
 				dol_syslog("functions.lib::price2num: amount in=".$amountin." No numeric result=".$amount, LOG_ERR);
 				$amount='';//Clear amount, not numeric, nothing possible to do

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4726,19 +4726,19 @@ function price2num($amount, $rounding = '', $option = 0)
 		//print 'PP'.$amount.' - '.$dec.' - '.$thousand.' - '.intval($amount).'<br>';
 		if (!is_numeric($amount)) {
 			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters 
-			$amount = substr( $amount, 0, strpos( $amount, ' (' ) );//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
+			$amount = substr($amount, 0, strpos($amount,' ('));//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
 			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?]/', '', $amount);//Eliminate alphabetics and special characters, keep only 0-9 . , - + and spaces (eliminated after)
-			$lastpos=strrpos ( $amount,'+',0);//+ if exists, must be alone at first place, eliminate others
-			while (($lastpos<>false) and ($lastpos>0))
+			$lastpos=strrpos($amount,'+',0);//+ if exists, must be alone at first place, eliminate others
+			while(($lastpos<>false)and($lastpos>0))
 			{
 				$amount=substr_replace($amount, '', $lastpos, 1);
-				$lastpos=strrpos ( $amount,'+',0);
+				$lastpos=strrpos ($amount,'+',0);
 			}
-			$lastpos=strrpos ( $amount,'-',0);//- if exists, must be alone at first place, eliminate others
-			while (($lastpos<>false) and ($lastpos>0))
+			$lastpos=strrpos ($amount,'-',0);//- if exists, must be alone at first place, eliminate others
+			while(($lastpos<>false)and($lastpos>0))
 			{
 				$amount=substr_replace($amount, '', $lastpos, 1);
-				$lastpos=strrpos ( $amount,'-',0);
+				$lastpos=strrpos($amount,'-',0);
 			}
 		}
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4727,7 +4727,7 @@ function price2num($amount, $rounding = '', $option = 0)
 		$amountin = $amount;//Save the given amount in order to log
 		$amount = preg_replace('/\s*\(.*\)/', '', $amount); // Remove forgotten code into vatrate or local taxe.
 		$amount = preg_replace('/\s*/', '', $amount);// Remove remaining spaces if any
-		if (!is_numeric($amount)) {
+		if ((!is_numeric($amount)) and ($amount<>'')) {
 			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters
 			$amount = preg_replace('/[a-df-zA-DF-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?\+\~\^]/', '', $amount);//Eliminate remaining no numerical characters, keep only 0-9 . , - e E
 			if ($dec == ','){
@@ -4763,6 +4763,11 @@ function price2num($amount, $rounding = '', $option = 0)
 			//
 			if (!is_numeric($amount)) {
 				dol_syslog("functions.lib::price2num: amount in=".$amountin." No numeric result=".$amount, LOG_ERR);
+				$message1 = $langs->trans('Typing error =');
+				$message2 = $langs->trans('value set to 0, retype a correct value');
+				echo '<script language="javascript">';
+				echo 'alert("'.$message1.$amountin.'\n'.$message2.'")';
+				echo '</script>';
 				$amount='';//Clear amount, not numeric, nothing possible to do
 			}
 		}


### PR DESCRIPTION
#Fix #16015 regression in V12
if VAT code is written in non latin characters or begins by numerical characters, unable to edit the pricing in Sales Order 
code enhancement if $amount is not numeric (about remaining + and -)
The consequence of this code is that all characters are allowed  as VAT codes in dictionnary.
