### PR TITLE
Fix #16015 regression in V13: if VAT code is written in non latin characters or begins by numerical characters, unable to edit the pricing correctly in Sales Order

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4864,19 +4864,19 @@ function price2num($amount, $rounding = '', $option = 0)
 		//print 'PP'.$amount.' - '.$dec.' - '.$thousand.' - '.intval($amount).'<br>';
 		if (!is_numeric($amount)) {
 			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters 
-			$amount = substr( $amount, 0, strpos( $amount, ' (' ) );//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
+			$amount = substr($amount, 0, strpos( $amount, ' ('));//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
 			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?]/', '', $amount);//Eliminate alphabetics and special characters, keep only 0-9 . , - + and spaces (eliminated after)
-			$lastpos=strrpos ( $amount,'+',0);//+ if exists, must be alone at first place, eliminate others
+			$lastpos=strrpos($amount,'+',0);//+ if exists, must be alone at first place, eliminate others
 			while (($lastpos<>false) and ($lastpos>0))
 			{
 				$amount=substr_replace($amount, '', $lastpos, 1);
-				$lastpos=strrpos ( $amount,'+',0);
+				$lastpos=strrpos($amount,'+',0);
 			}
-			$lastpos=strrpos ( $amount,'-',0);//- if exists, must be alone at first place, eliminate others
+			$lastpos=strrpos($amount,'-',0);//- if exists, must be alone at first place, eliminate others
 			while (($lastpos<>false) and ($lastpos>0))
 			{
 				$amount=substr_replace($amount, '', $lastpos, 1);
-				$lastpos=strrpos ( $amount,'-',0);
+				$lastpos=strrpos($amount,'-',0);
 			}
 		}
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4863,7 +4863,21 @@ function price2num($amount, $rounding = '', $option = 0)
 	if ($option != 1) {	// If not a PHP number or unknown, we change or clean format
 		//print 'PP'.$amount.' - '.$dec.' - '.$thousand.' - '.intval($amount).'<br>';
 		if (!is_numeric($amount)) {
-			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_]/', '', $amount);
+			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters 
+			$amount = substr( $amount, 0, strpos( $amount, ' (' ) );//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
+			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?]/', '', $amount);//Eliminate alphabetics and special characters, keep only 0-9 . , - + and spaces (eliminated after)
+			$lastpos=strrpos ( $amount,'+',0);//+ if exists, must be alone at first place, eliminate others
+			while (($lastpos<>false) and ($lastpos>0))
+			{
+				$amount=substr_replace($amount, '', $lastpos, 1);
+				$lastpos=strrpos ( $amount,'+',0);
+			}
+			$lastpos=strrpos ( $amount,'-',0);//- if exists, must be alone at first place, eliminate others
+			while (($lastpos<>false) and ($lastpos>0))
+			{
+				$amount=substr_replace($amount, '', $lastpos, 1);
+				$lastpos=strrpos ( $amount,'-',0);
+			}
 		}
 
 		if ($option == 2 && $thousand == '.' && preg_match('/\.(\d\d\d)$/', (string) $amount)) {	// It means the . is used as a thousand separator and string come frominput data, so 1.123 is 1123

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4863,7 +4863,7 @@ function price2num($amount, $rounding = '', $option = 0)
 	if ($option != 1) {	// If not a PHP number or unknown, we change or clean format
 		//print 'PP'.$amount.' - '.$dec.' - '.$thousand.' - '.intval($amount).'<br>';
 		if (!is_numeric($amount)) {
-			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters 
+			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters
 			$amount = substr($amount, 0, strpos($amount, ' ('));//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
 			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?]/', '', $amount);//Eliminate alphabetics and special characters, keep only 0-9 . , - + and spaces (eliminated after)
 			$lastpos=strrpos($amount, '+', 0);//+ if exists, must be alone at first place, eliminate others

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4864,19 +4864,19 @@ function price2num($amount, $rounding = '', $option = 0)
 		//print 'PP'.$amount.' - '.$dec.' - '.$thousand.' - '.intval($amount).'<br>';
 		if (!is_numeric($amount)) {
 			$amount = iconv('UTF-8', 'ASCII//IGNORE', $amount);//Eliminate non ascii characters 
-			$amount = substr($amount, 0, strpos( $amount, ' ('));//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
+			$amount = substr($amount, 0, strpos($amount, ' ('));//if the string contains " (" it contains a code name, so eliminate the end of string including parenthesis, so 85NPR VAT code will work
 			$amount = preg_replace('/[a-zA-Z\/\\\*\(\)\<\>\_\!\"\#\$\%\&\:\;\=\@\[\]\`\{\|\}\'\?]/', '', $amount);//Eliminate alphabetics and special characters, keep only 0-9 . , - + and spaces (eliminated after)
-			$lastpos=strrpos($amount,'+',0);//+ if exists, must be alone at first place, eliminate others
+			$lastpos=strrpos($amount, '+', 0);//+ if exists, must be alone at first place, eliminate others
 			while (($lastpos<>false) and ($lastpos>0))
 			{
 				$amount=substr_replace($amount, '', $lastpos, 1);
-				$lastpos=strrpos($amount,'+',0);
+				$lastpos=strrpos($amount, '+', 0);
 			}
-			$lastpos=strrpos($amount,'-',0);//- if exists, must be alone at first place, eliminate others
+			$lastpos=strrpos($amount, '-', 0);//- if exists, must be alone at first place, eliminate others
 			while (($lastpos<>false) and ($lastpos>0))
 			{
 				$amount=substr_replace($amount, '', $lastpos, 1);
-				$lastpos=strrpos($amount,'-',0);
+				$lastpos=strrpos($amount, '-', 0);
 			}
 		}
 


### PR DESCRIPTION
#Fix #16015 regression in V13 development branch
if VAT code is written in non latin characters or begins by numerical characters, unable to edit the pricing in Sales Order 
code enhancement if $amount is not numeric (about remaining + and -)
The consequence of this code is that all characters are allowed  as VAT codes in dictionnary.