### PR TITLE
do not dispay ok message if const input are not name with same name a…

### DIFF
--- a/htdocs/core/actions_setmoduleoptions.inc.php
+++ b/htdocs/core/actions_setmoduleoptions.inc.php
@@ -31,12 +31,12 @@ if ($action == 'update' && is_array($arrayofparameters))
 {
 	$db->begin();
 
-	$ok = true;
 	foreach ($arrayofparameters as $key => $val)
 	{
 		// Modify constant only if key was posted (avoid resetting key to the null value)
 		if (GETPOSTISSET($key))
 		{
+			$ok = true;
 			$result = dolibarr_set_const($db, $key, GETPOST($key, 'alpha'), 'chaine', 0, '', $conf->entity);
 			if ($result < 0)
 			{


### PR DESCRIPTION
if my CONST come from extrafield input (like setting default value for an extrafields into module configuration), the input name is not same as CONST. The is no need to display "Saved" because no data were saved