### PR TITLE
[FM] Fix 12.0 - duplicate label, probably mistaken for ref

### DIFF
--- a/htdocs/core/modules/contract/doc/pdf_strato.modules.php
+++ b/htdocs/core/modules/contract/doc/pdf_strato.modules.php
@@ -343,7 +343,7 @@ class pdf_strato extends ModelePDFContract
 						}
 
 						$txtpredefinedservice = '';
-                        $txtpredefinedservice = $objectligne->product_label;
+                        $txtpredefinedservice = $objectligne->product_ref;
                         if ($objectligne->product_label)
                         {
                         	$txtpredefinedservice .= ' - ';


### PR DESCRIPTION
# FIX
In the strato PDF template, the service label (for contract lines based on a product/service) is printed twice, like this:
![ksnip_20210120-153623](https://user-images.githubusercontent.com/50440633/105189542-5c029700-5b35-11eb-923a-aab44a886db0.png)

I think the first occurrence was supposed to be the service's ref instead.