### PR TITLE
Update 13.0.0-14.0.0.sql

### DIFF
--- a/htdocs/install/mysql/migration/13.0.0-14.0.0.sql
+++ b/htdocs/install/mysql/migration/13.0.0-14.0.0.sql
@@ -57,8 +57,8 @@ ALTER TABLE llx_website ADD COLUMN pageviews_total BIGINT UNSIGNED DEFAULT 0;
 
 
 -- Drop foreign key with bad name or not required
-ALTER TABLE DROP FOREIGN KEY llx_workstation_workstation_fk_user_creat;
-ALTER TABLE DROP FOREIGN KEY llx_propal_fk_warehouse;
+ALTER TABLE llx_workstation_workstation DROP FOREIGN KEY llx_workstation_workstation_fk_user_creat;
+ALTER TABLE llx_propal DROP FOREIGN KEY llx_propal_fk_warehouse;
 
 
 CREATE TABLE llx_workstation_workstation(


### PR DESCRIPTION
# Fix #[*Update 13.0 to 14.0 #16036*]

`Erreur DB_ERROR_SYNTAX: ALTER TABLE DROP FOREIGN KEY llx_workstation_workstation_fk_user_creat;Erreur de syntaxe près de 'DROP FOREIGN KEY llx_workstation_workstation_fk_user_creat' à la ligne 1
--
Request 16 sql='ALTER TABLE DROP FOREIGN KEY llx_propal_fk_warehouse;'
Erreur DB_ERROR_`
