### PR TITLE
FIX remove all contact default types on contact card

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -429,7 +429,7 @@ if (empty($reshook))
 			$object->note_public = (string) GETPOST("note_public", 'restricthtml');
 			$object->note_private = (string) GETPOST("note_private", 'restricthtml');
 
-			if (GETPOSTISSET("roles")) {
+			if (!empty($object->socid)) {
 				$object->roles = GETPOST("roles", 'array');
 			}
 

--- a/htdocs/contact/class/contact.class.php
+++ b/htdocs/contact/class/contact.class.php
@@ -1763,14 +1763,14 @@ class Contact extends CommonObject
 			if (count($this->roles) > 0) {
 				foreach ($this->roles as $keyRoles => $valRoles) {
 					$idrole = 0;
-					if (is_array($idrole)) {
+					if (is_array($valRoles)) {
 						$idrole = $valRoles['id'];
 					} else {
 						$idrole = $valRoles;
 					}
 
 					$socid = 0;
-					if (is_array($idrole)) {
+					if (is_array($valRoles)) {
 						$socid = $valRoles['socid'];
 					} else {
 						$socid = $this->socid;


### PR DESCRIPTION
FIX remove all contact default types on contact card
- you can't remove all contact default types
- fix insert Array SQL error if you update a card that already have some default contacts

