### PR TITLE
FIX 11.0: when a new intervention is created from an object, a new $e…

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -258,7 +258,13 @@ if (empty($reshook))
 				}
 
 				// Extrafields
-				$extrafields = new ExtraFields($db);
+
+				// Fill array 'array_options' with data from add form
+				$ret = $extrafields->setOptionalsFromPost(null, $object);
+				if ($ret < 0) {
+					$error++;
+					$action = 'create';
+				}
 				$array_options = $extrafields->getOptionalsFromPost($object->table_element);
 
 		        $object->array_options = $array_options;


### PR DESCRIPTION
# Reproducing the issue
* Enable module "interventions" and, for instance, "proposals"
* Setup some extrafields on interventions (make sure they are **mandatory**)
* From a proposal, create a new intervention
* Don't fill anything in the form, just validate

Expected behavior : Dolibarr should not create the intervention card because the mandatory extrafields were not filled.

Actual behavior : the intervention card is created with no extrafields.