### PR TITLE
 Add missing pmp valorisation to MO production. (Issue #16072)

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -1479,7 +1479,7 @@ class MoLine extends CommonObjectLine
 	public function fetch($id, $ref = null)
 	{
 		$result = $this->fetchCommon($id, $ref);
-		if ($result > 0 && !empty($this->table_element_line)) $this->fetchLines();
+
 		return $result;
 	}
 

--- a/htdocs/mrp/mo_movements.php
+++ b/htdocs/mrp/mo_movements.php
@@ -153,9 +153,9 @@ $permissiontodelete = $user->rights->mrp->delete || ($permissiontoadd && isset($
 $upload_dir = $conf->mrp->multidir_output[isset($object->entity) ? $object->entity : 1];
 
 $permissiontoproduce = $permissiontoadd;
-$permissiontodeupdatecost = $user->rights->bom->write; // User who can define cost must have knowledge of pricing
+$permissiontoupdatecost = $user->rights->bom->write; // User who can define cost must have knowledge of pricing
 
-if ($permissiontodeupdatecost) {
+if ($permissiontoupdatecost) {
 	$arrayfields['m.price']['enabled'] = 1;
 }
 

--- a/htdocs/mrp/mo_movements.php
+++ b/htdocs/mrp/mo_movements.php
@@ -139,7 +139,7 @@ $arrayfields = array(
 	'm.type_mouvement'=>array('label'=>$langs->trans("TypeMovement"), 'checked'=>1),
 	'origin'=>array('label'=>$langs->trans("Origin"), 'enabled'=>0, 'checked'=>0),
 	'm.value'=>array('label'=>$langs->trans("Qty"), 'checked'=>1),
-	'm.price'=>array('label'=>$langs->trans("UnitPurchaseValue"), 'checked'=>0),
+	'm.price'=>array('label'=>$langs->trans("PMPValue"), 'enabled'=>0, 'checked'=>0),
 	//'m.datec'=>array('label'=>$langs->trans("DateCreation"), 'checked'=>0, 'position'=>500),
 	//'m.tms'=>array('label'=>$langs->trans("DateModificationShort"), 'checked'=>0, 'position'=>500)
 );
@@ -153,7 +153,11 @@ $permissiontodelete = $user->rights->mrp->delete || ($permissiontoadd && isset($
 $upload_dir = $conf->mrp->multidir_output[isset($object->entity) ? $object->entity : 1];
 
 $permissiontoproduce = $permissiontoadd;
+$permissiontodeupdatecost = $user->rights->bom->write; // User who can define cost must have knowledge of pricing
 
+if ($permissiontodeupdatecost) {
+	$arrayfields['m.price']['enabled'] = 1;
+}
 
 /*
  * Actions

--- a/htdocs/mrp/mo_movements.php
+++ b/htdocs/mrp/mo_movements.php
@@ -139,7 +139,7 @@ $arrayfields = array(
 	'm.type_mouvement'=>array('label'=>$langs->trans("TypeMovement"), 'checked'=>1),
 	'origin'=>array('label'=>$langs->trans("Origin"), 'enabled'=>0, 'checked'=>0),
 	'm.value'=>array('label'=>$langs->trans("Qty"), 'checked'=>1),
-	'm.price'=>array('label'=>$langs->trans("UnitPurchaseValue"), 'enabled'=>0, 'checked'=>0),
+	'm.price'=>array('label'=>$langs->trans("UnitPurchaseValue"), 'checked'=>0),
 	//'m.datec'=>array('label'=>$langs->trans("DateCreation"), 'checked'=>0, 'position'=>500),
 	//'m.tms'=>array('label'=>$langs->trans("DateModificationShort"), 'checked'=>0, 'position'=>500)
 );

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -776,7 +776,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						print '<td></td>';
 					} else {
 						print '<td class="right nowraponall">';
-						print $tmpproduct->pmp;
+						print price($tmpproduct->pmp);
 						print '</td>';
 					}
     	    		print '<td class="right">';
@@ -842,7 +842,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     	    			$preselected = (GETPOSTISSET('qty-'.$line->id.'-'.$i) ? GETPOST('qty-'.$line->id.'-'.$i) : max(0, $line->qty - $alreadyconsumed));
     	    			if ($action == 'consumeorproduce' && !GETPOSTISSET('qty-'.$line->id.'-'.$i)) $preselected = 0;
     	    			print '<td class="right"><input type="text" class="width50 right" name="qty-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
-						$preselected = (GETPOSTISSET('price-'.$line->id.'-'.$i) ? GETPOST('price-'.$line->id.'-'.$i) : $tmpproduct->pmp);
+						$preselected = (GETPOSTISSET('price-'.$line->id.'-'.$i) ? GETPOST('price-'.$line->id.'-'.$i) : price($tmpproduct->pmp));
     	    			print '<td class="right"><input type="text" class="width50 right" name="price-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
     	    			print '<td></td>';
     	    			print '<td>';
@@ -938,7 +938,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						print '<td></td>';
 					} else {
 						print '<td class="right nowraponall">';
-						print $tmpproduct->pmp;
+						print price($tmpproduct->pmp);
 						print '</td>';
 					}
     				print '<td class="right nowraponall">';
@@ -1001,7 +1001,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     					$preselected = (GETPOSTISSET('qtytoproduce-'.$line->id.'-'.$i) ? GETPOST('qtytoproduce-'.$line->id.'-'.$i) : max(0, $line->qty - $alreadyproduced));
     					if ($action == 'consumeorproduce' && !GETPOSTISSET('qtytoproduce-'.$line->id.'-'.$i)) $preselected = 0;
 						print '<td class="right"><input type="text" class="width50 right" id="qtytoproduce-'.$line->id.'-'.$i.'" name="qtytoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
-						$preselected = (GETPOSTISSET('pricetoproduce-'.$line->id.'-'.$i) ? GETPOST('pricetoproduce-'.$line->id.'-'.$i) : $tmpproduct->pmp);
+						$preselected = (GETPOSTISSET('pricetoproduce-'.$line->id.'-'.$i) ? GETPOST('pricetoproduce-'.$line->id.'-'.$i) : price($tmpproduct->pmp));
     	    			print '<td class="right"><input type="text" class="width50 right" name="pricetoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
     					print '<td></td>';
     					print '<td>';

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -108,7 +108,7 @@ $permissiontodelete = $user->rights->mrp->delete || ($permissiontoadd && isset($
 $upload_dir = $conf->mrp->multidir_output[isset($object->entity) ? $object->entity : 1];
 
 $permissiontoproduce = $permissiontoadd;
-$permissiontodeupdatecost = $user->rights->bom->write; // User who can define cost must have knowledge of pricing
+$permissiontoupdatecost = $user->rights->bom->write; // User who can define cost must have knowledge of pricing
 
 
 /*
@@ -708,7 +708,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     	print '<tr class="liste_titre">';
     	print '<td>'.$langs->trans("Product").'</td>';
 		print '<td class="right">'.$langs->trans("Qty").'</td>';
-		if ($permissiontodeupdatecost) print '<td class="right">'.$langs->trans("PMPValue").'</td>';
+		if ($permissiontoupdatecost) print '<td class="right">'.$langs->trans("PMPValue").'</td>';
     	print '<td class="right">'.$langs->trans("QtyAlreadyConsumed").'</td>';
     	print '<td>';
     	if ($collapse || in_array($action, array('consumeorproduce', 'consumeandproduceall'))) print $langs->trans("Warehouse");
@@ -772,7 +772,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     	    			print $line->qty;
     	    		}
 					print '</td>';
-					if ($permissiontodeupdatecost) {
+					if ($permissiontoupdatecost) {
 						if ($action == 'addconsumeline') {
 							print '<td></td>';
 						} else {
@@ -844,7 +844,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     	    			$preselected = (GETPOSTISSET('qty-'.$line->id.'-'.$i) ? GETPOST('qty-'.$line->id.'-'.$i) : max(0, $line->qty - $alreadyconsumed));
     	    			if ($action == 'consumeorproduce' && !GETPOSTISSET('qty-'.$line->id.'-'.$i)) $preselected = 0;
 						print '<td class="right"><input type="text" class="width50 right" name="qty-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
-						if ($permissiontodeupdatecost) print '<td></td>';
+						if ($permissiontoupdatecost) print '<td></td>';
     	    			print '<td></td>';
     	    			print '<td>';
     	    			if ($tmpproduct->type == Product::TYPE_PRODUCT || !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
@@ -888,7 +888,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     	print '<tr class="liste_titre">';
     	print '<td>'.$langs->trans("Product").'</td>';
 		print '<td class="right">'.$langs->trans("Qty").'</td>';
-		if ($permissiontodeupdatecost) print '<td class="right">'.$langs->trans("PMPValue").'</td>';
+		if ($permissiontoupdatecost) print '<td class="right">'.$langs->trans("PMPValue").'</td>';
     	print '<td class="right">'.$langs->trans("QtyAlreadyProduced").'</td>';
     	print '<td>';
     	if ($collapse || in_array($action, array('consumeorproduce', 'consumeandproduceall'))) print $langs->trans("Warehouse");
@@ -935,7 +935,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     				print '<tr>';
     				print '<td>'.$tmpproduct->getNomUrl(1).'</td>';
 					print '<td class="right">'.$line->qty.'</td>';
-					if ($permissiontodeupdatecost) {
+					if ($permissiontoupdatecost) {
 						if ($action == 'addconsumeline') {
 							print '<td></td>';
 						} else {
@@ -1004,7 +1004,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     					$preselected = (GETPOSTISSET('qtytoproduce-'.$line->id.'-'.$i) ? GETPOST('qtytoproduce-'.$line->id.'-'.$i) : max(0, $line->qty - $alreadyproduced));
     					if ($action == 'consumeorproduce' && !GETPOSTISSET('qtytoproduce-'.$line->id.'-'.$i)) $preselected = 0;
 						print '<td class="right"><input type="text" class="width50 right" id="qtytoproduce-'.$line->id.'-'.$i.'" name="qtytoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
-						if ($permissiontodeupdatecost) {
+						if ($permissiontoupdatecost) {
 							$preselected = (GETPOSTISSET('pricetoproduce-'.$line->id.'-'.$i) ? GETPOST('pricetoproduce-'.$line->id.'-'.$i) : price($tmpproduct->pmp));
 							print '<td class="right"><input type="text" class="width50 right" name="pricetoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
 						}

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -197,7 +197,8 @@ if (empty($reshook))
 
     			$i = 1;
     			while (GETPOSTISSET('qty-'.$line->id.'-'.$i)) {
-    				$qtytoprocess = price2num(GETPOST('qty-'.$line->id.'-'.$i));
+					$qtytoprocess = price2num(GETPOST('qty-'.$line->id.'-'.$i));
+					$pricetoprocess = GETPOST('price-'.$line->id.'-'.$i) ? price2num(GETPOST('price-'.$line->id.'-'.$i)) : 0;
 
     				if ($qtytoprocess != 0) {
 						// Check warehouse is set if we should have to
@@ -219,7 +220,7 @@ if (empty($reshook))
 	    					// Record stock movement
 	    					$id_product_batch = 0;
 	    					$stockmove->origin = $object;
-	    					$idstockmove = $stockmove->livraison($user, $line->fk_product, GETPOST('idwarehouse-'.$line->id.'-'.$i), $qtytoprocess, 0, $labelmovement, dol_now(), '', '', GETPOST('batch-'.$line->id.'-'.$i), $id_product_batch, $codemovement);
+	    					$idstockmove = $stockmove->livraison($user, $line->fk_product, GETPOST('idwarehouse-'.$line->id.'-'.$i), $qtytoprocess, $pricetoprocess, $labelmovement, dol_now(), '', '', GETPOST('batch-'.$line->id.'-'.$i), $id_product_batch, $codemovement);
 	    					if ($idstockmove < 0) {
 	    						$error++;
 	    						setEventMessages($stockmove->error, $stockmove->errors, 'errors');
@@ -264,7 +265,8 @@ if (empty($reshook))
 
     			$i = 1;
     			while (GETPOSTISSET('qtytoproduce-'.$line->id.'-'.$i)) {
-    				$qtytoprocess = price2num(GETPOST('qtytoproduce-'.$line->id.'-'.$i));
+					$qtytoprocess = price2num(GETPOST('qtytoproduce-'.$line->id.'-'.$i));
+					$pricetoprocess = GETPOST('pricetoproduce-'.$line->id.'-'.$i) ? price2num(GETPOST('pricetoproduce-'.$line->id.'-'.$i)) : 0;
 
     				if ($qtytoprocess != 0) {
 	    				// Check warehouse is set if we should have to
@@ -286,7 +288,7 @@ if (empty($reshook))
 	    					// Record stock movement
 	    					$id_product_batch = 0;
 	    					$stockmove->origin = $object;
-	    					$idstockmove = $stockmove->reception($user, $line->fk_product, GETPOST('idwarehousetoproduce-'.$line->id.'-'.$i), $qtytoprocess, 0, $labelmovement, '', '', GETPOST('batchtoproduce-'.$line->id.'-'.$i), dol_now(), $id_product_batch, $codemovement);
+	    					$idstockmove = $stockmove->reception($user, $line->fk_product, GETPOST('idwarehousetoproduce-'.$line->id.'-'.$i), $qtytoprocess, $pricetoprocess, $labelmovement, '', '', GETPOST('batchtoproduce-'.$line->id.'-'.$i), dol_now(), $id_product_batch, $codemovement);
 	    					if ($idstockmove < 0) {
 	    						$error++;
 	    						setEventMessages($stockmove->error, $stockmove->errors, 'errors');
@@ -705,7 +707,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
     	print '<tr class="liste_titre">';
     	print '<td>'.$langs->trans("Product").'</td>';
-    	print '<td class="right">'.$langs->trans("Qty").'</td>';
+		print '<td class="right">'.$langs->trans("Qty").'</td>';
+		print '<td class="right">'.$langs->trans("PMPValue").'</td>';
     	print '<td class="right">'.$langs->trans("QtyAlreadyConsumed").'</td>';
     	print '<td>';
     	if ($collapse || in_array($action, array('consumeorproduce', 'consumeandproduceall'))) print $langs->trans("Warehouse");
@@ -768,7 +771,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     	    		} else {
     	    			print $line->qty;
     	    		}
-    	    		print '</td>';
+					print '</td>';
+					if ($action == 'addconsumeline') {
+						print '<td></td>';
+					} else {
+						print '<td class="right nowraponall">';
+						print $tmpproduct->pmp;
+						print '</td>';
+					}
     	    		print '<td class="right">';
     	    		if ($alreadyconsumed) {
     	    			print '<script>';
@@ -832,6 +842,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     	    			$preselected = (GETPOSTISSET('qty-'.$line->id.'-'.$i) ? GETPOST('qty-'.$line->id.'-'.$i) : max(0, $line->qty - $alreadyconsumed));
     	    			if ($action == 'consumeorproduce' && !GETPOSTISSET('qty-'.$line->id.'-'.$i)) $preselected = 0;
     	    			print '<td class="right"><input type="text" class="width50 right" name="qty-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
+						$preselected = (GETPOSTISSET('price-'.$line->id.'-'.$i) ? GETPOST('price-'.$line->id.'-'.$i) : $tmpproduct->pmp);
+    	    			print '<td class="right"><input type="text" class="width50 right" name="price-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
     	    			print '<td></td>';
     	    			print '<td>';
     	    			if ($tmpproduct->type == Product::TYPE_PRODUCT || !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
@@ -874,7 +886,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
     	print '<tr class="liste_titre">';
     	print '<td>'.$langs->trans("Product").'</td>';
-    	print '<td class="right">'.$langs->trans("Qty").'</td>';
+		print '<td class="right">'.$langs->trans("Qty").'</td>';
+		print '<td class="right">'.$langs->trans("PMPValue").'</td>';
     	print '<td class="right">'.$langs->trans("QtyAlreadyProduced").'</td>';
     	print '<td>';
     	if ($collapse || in_array($action, array('consumeorproduce', 'consumeandproduceall'))) print $langs->trans("Warehouse");
@@ -920,7 +933,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
     				print '<tr>';
     				print '<td>'.$tmpproduct->getNomUrl(1).'</td>';
-    				print '<td class="right">'.$line->qty.'</td>';
+					print '<td class="right">'.$line->qty.'</td>';
+					if ($action == 'addconsumeline') {
+						print '<td></td>';
+					} else {
+						print '<td class="right nowraponall">';
+						print $tmpproduct->pmp;
+						print '</td>';
+					}
     				print '<td class="right nowraponall">';
     				if ($alreadyproduced) {
     					print '<script>';
@@ -980,7 +1000,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     					print '<td>'.$langs->trans("ToProduce").'</td>';
     					$preselected = (GETPOSTISSET('qtytoproduce-'.$line->id.'-'.$i) ? GETPOST('qtytoproduce-'.$line->id.'-'.$i) : max(0, $line->qty - $alreadyproduced));
     					if ($action == 'consumeorproduce' && !GETPOSTISSET('qtytoproduce-'.$line->id.'-'.$i)) $preselected = 0;
-    					print '<td class="right"><input type="text" class="width50 right" id="qtytoproduce-'.$line->id.'-'.$i.'" name="qtytoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
+						print '<td class="right"><input type="text" class="width50 right" id="qtytoproduce-'.$line->id.'-'.$i.'" name="qtytoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
+						$preselected = (GETPOSTISSET('pricetoproduce-'.$line->id.'-'.$i) ? GETPOST('pricetoproduce-'.$line->id.'-'.$i) : $tmpproduct->pmp);
+    	    			print '<td class="right"><input type="text" class="width50 right" name="pricetoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
     					print '<td></td>';
     					print '<td>';
     					if ($tmpproduct->type == Product::TYPE_PRODUCT || !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {


### PR DESCRIPTION
Add pmp valorisation to MO production. (Issue #16072)
Add visualization of product pmp and unit cost update for produced product.
Only when user has pricing knowledge (if he has rights to create bom's)
Add production unitcost calculation for free consumption line 
Hide add free consumptionline if production started.
Other bug: mo line is line so no fetchLines