### PR TITLE
Fix/FIX: Show missing notification in Event in user dashboard if assigned by others

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1201,14 +1201,21 @@ class ActionComm extends CommonObject
     	}
     	$sql .= " FROM ".MAIN_DB_PREFIX."actioncomm as a";
     	if (!$user->rights->societe->client->voir && !$user->socid) $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON a.fk_soc = sc.fk_soc";
+    	if (!$user->rights->agenda->allactions->read) { // If bloack Added by PV
+    	    $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."actioncomm_resources AS ar ON a.id = ar.fk_actioncomm";
+    	}
     	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON a.fk_soc = s.rowid";
     	$sql .= " WHERE 1 = 1";
     	if (empty($load_state_board)) $sql .= " AND a.percent >= 0 AND a.percent < 100";
     	$sql .= " AND a.entity IN (".getEntity('agenda').")";
     	if (!$user->rights->societe->client->voir && !$user->socid) $sql .= " AND (a.fk_soc IS NULL OR sc.fk_user = ".$user->id.")";
     	if ($user->socid) $sql .= " AND a.fk_soc = ".$user->socid;
-    	if (!$user->rights->agenda->allactions->read) $sql .= " AND (a.fk_user_author = ".$user->id." OR a.fk_user_action = ".$user->id." OR a.fk_user_done = ".$user->id.")";
-
+    	if (!$user->rights->agenda->allactions->read) {
+    	    $sql .= " AND (a.fk_user_author = ".$user->id." OR a.fk_user_action = ".$user->id." OR a.fk_user_done = ".$user->id;
+    	    $sql .= " OR ar.fk_element = ".$user->id; // Added by PV
+    	    $sql .= ")";
+    	}
+    	
     	$resql = $this->db->query($sql);
     	if ($resql)
     	{

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1201,8 +1201,8 @@ class ActionComm extends CommonObject
     	}
     	$sql .= " FROM ".MAIN_DB_PREFIX."actioncomm as a";
     	if (!$user->rights->societe->client->voir && !$user->socid) $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON a.fk_soc = sc.fk_soc";
-    	if (!$user->rights->agenda->allactions->read) { // If bloack Added by PV
-    	    $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."actioncomm_resources AS ar ON a.id = ar.fk_actioncomm";
+    	if (!$user->rights->agenda->allactions->read) {
+    	    $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."actioncomm_resources AS ar ON a.id = ar.fk_actioncomm AND ar.element_type ='user' AND ar.fk_element = ".$user->id;
     	}
     	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON a.fk_soc = s.rowid";
     	$sql .= " WHERE 1 = 1";

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1215,7 +1215,7 @@ class ActionComm extends CommonObject
     	    $sql .= " OR ar.fk_element = ".$user->id; // Added by PV
     	    $sql .= ")";
     	}
-    	
+
     	$resql = $this->db->query($sql);
     	if ($resql)
     	{


### PR DESCRIPTION
# Fix #16108
If a user was assigned by an event by another user, the notification do not show in this:
![image](https://user-images.githubusercontent.com/38374663/106378384-4fa4f680-63df-11eb-9146-99ec8e38897e.png)

User can still see notifications from Events Tab, fix above is to immediately make the user aware of assigned events by others