### PR TITLE
Display list related items : height auto

### DIFF
--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -3065,6 +3065,14 @@ table.liste td, table.noborder td, div.noborder form div, table.tableforservicep
 	/* line-height: 22px; This create trouble on cell login on list of last events of a contract*/
 	height: 22px;
 }
+
+@media only screen and (max-width: 1500px)
+{
+	table.liste td, table.noborder td, div.noborder form div, table.tableforservicepart1 td, table.tableforservicepart2 td {
+		height: auto;
+	}
+}
+
 div.liste_titre_bydiv .divsearchfield {
 	padding: 2px 1px 2px 7px;			/* t r b l */
 }


### PR DESCRIPTION
# Fix # Display list ref object : height auto

Related Items list : Under 1500px, long labels are written on top of each other. 
![refobjectlist_soccard](https://user-images.githubusercontent.com/52402938/106755956-04812280-662f-11eb-849c-fbd135ab5340.png)
