### PR TITLE
Add hidden conf to display supplier in object lines

### DIFF
--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -166,7 +166,7 @@ else
 	}
 }
 
-if ($user->rights->fournisseur->lire && $line->fk_fournprice > 0)
+if ($user->rights->fournisseur->lire && $line->fk_fournprice > 0 && !empty($conf->global->DISPLAY_SUPPLIER_OBJECTLINES))
 {
     require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
 	$productfourn = new ProductFournisseur($this->db);

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -166,7 +166,7 @@ else
 	}
 }
 
-if ($user->rights->fournisseur->lire && $line->fk_fournprice > 0 && !empty($conf->global->DISPLAY_SUPPLIER_OBJECTLINES))
+if ($user->rights->fournisseur->lire && $line->fk_fournprice > 0 && empty($conf->global->SUPPLIER_HIDE_SUPPLIER_OBJECTLINES))
 {
     require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
 	$productfourn = new ProductFournisseur($this->db);


### PR DESCRIPTION
# Fix # Add hidden conf to display supplier in object lines

Commit [https://github.com/Dolibarr/dolibarr/commit/b06bfef6320286b1c4294f13d0ce054698c25209](url)

Several customers complain about this new information. I think it's better to add a hidden conf to display or not object line's supplier. What do you think about it ? 