### PR TITLE
FIX 10.0 - before crediting a withdrawal receipt, check whether it has been credited already

### DIFF
--- a/htdocs/compta/prelevement/card.php
+++ b/htdocs/compta/prelevement/card.php
@@ -85,16 +85,21 @@ if (empty($reshook))
         }
     }
 
-    // Seems to no be used and replaced with $action == 'infocredit'
-    if ( $action == 'confirm_credite' && GETPOST('confirm', 'alpha') == 'yes')
-    {
-        $res=$object->set_credite();
-        if ($res >= 0)
-        {
-            header("Location: card.php?id=".$id);
-            exit;
-        }
-    }
+	// Seems to no be used and replaced with $action == 'infocredit'
+	if ( $action == 'confirm_credite' && GETPOST('confirm', 'alpha') == 'yes')
+	{
+		if ($object->statut == 2) {
+			$res = -1;
+			setEventMessages('WithdrawalCantBeCreditedTwice', array(), 'errors');
+		} else {
+			$res=$object->set_credite();
+		}
+		if ($res >= 0)
+		{
+			header("Location: card.php?id=".$id);
+			exit;
+		}
+	}
 
     if ($action == 'infotrans' && $user->rights->prelevement->bons->send)
     {
@@ -135,14 +140,19 @@ if (empty($reshook))
 	{
 		$dt = dol_mktime(12, 0, 0, GETPOST('remonth', 'int'), GETPOST('reday', 'int'), GETPOST('reyear', 'int'));
 
-        $error = $object->set_infocredit($user, $dt);
+		if ($object->statut == 2) {
+			$error = 1;
+			setEventMessages('WithdrawalCantBeCreditedTwice', array(), 'errors');
+		} else {
+			$error = $object->set_infocredit($user, $dt);
+		}
 
-        if ($error)
-        {
-            header("Location: card.php?id=".$id."&error=$error");
-            exit;
-        }
-    }
+		if ($error)
+		{
+			header("Location: card.php?id=".$id."&error=$error");
+			exit;
+		}
+	}
 }
 
 

--- a/htdocs/langs/en_US/withdrawals.lang
+++ b/htdocs/langs/en_US/withdrawals.lang
@@ -27,6 +27,7 @@ MakeWithdrawRequest=Make a direct debit payment request
 WithdrawRequestsDone=%s direct debit payment requests recorded
 ThirdPartyBankCode=Third-party bank code
 NoInvoiceCouldBeWithdrawed=No invoice debited successfully. Check that invoices are on companies with a valid IBAN and that IBAN has a UMR (Unique Mandate Reference) with mode <strong>%s</strong>.
+WithdrawalCantBeCreditedTwice=This withdrawal receipt is already marked as credited; this can't be done twice, as this would potentially create duplicate payments and bank entries.
 ClassCredited=Classify credited
 ClassCreditedConfirm=Are you sure you want to classify this withdrawal receipt as credited on your bank account?
 TransData=Transmission date

--- a/htdocs/langs/fr_FR/withdrawals.lang
+++ b/htdocs/langs/fr_FR/withdrawals.lang
@@ -27,6 +27,7 @@ MakeWithdrawRequest=Faire une demande de prélèvement
 WithdrawRequestsDone=%s demandes de prélèvements enregistrées
 ThirdPartyBankCode=Code banque du tiers
 NoInvoiceCouldBeWithdrawed=Aucune facture traitée avec succès. Vérifiez que les factures sont sur les sociétés avec un BAN par défaut valide et que le BAN a un RUM avec le mode <strong> %s </strong>.
+WithdrawalCantBeCreditedTwice=Ce bon de prélèvement est déjà classé crédité ; cette opération ne peut pas être réalisée deux fois, car cela pourrait engendrer des doublons dans les paiements et les écritures bancaires.
 ClassCredited=Classer crédité
 ClassCreditedConfirm=Êtes-vous sûr de vouloir classer ce bon de prélèvement comme crédité sur votre compte bancaire ?
 TransData=Date de transmission


### PR DESCRIPTION
# Issue
Currently it is possible to mistakenly credit a withdrawal receipt twice (for instance by reloading the page or by having two users do the action separately, one having displayed the confirm form before the other confirmed the action).

This creates duplicate bank entries and invoice payments, which are not easy to clean-up.

# Fix
This tries to ensure that this doesn't happen by checking the status of the withdrawal receipt before crediting it.