### PR TITLE
call to createCommon() return int and not bool

### DIFF
--- a/htdocs/modulebuilder/template/class/api_mymodule.class.php
+++ b/htdocs/modulebuilder/template/class/api_mymodule.class.php
@@ -203,7 +203,7 @@ class MyModuleApi extends DolibarrApi
 		foreach ($request_data as $field => $value) {
 			$this->myobject->$field = $value;
 		}
-		if (!$this->myobject->create(DolibarrApiAccess::$user)) {
+		if ($this->myobject->create(DolibarrApiAccess::$user)<0) {
 			throw new RestException(500, "Error creating MyObject", array_merge(array($this->myobject->error), $this->myobject->errors));
 		}
 		return $this->myobject->id;


### PR DESCRIPTION
# Fix # POST request always code 200 but no insert was successfull
with generated Object, the post request call to createCommon() in it and taht function return a int (id or -1 if error).
but the test on the returned value is a '!', that don't return false on "-1".
a post request with an sql error for example(foreign key error for my test), will always return 200 instead of 500 with the error

