### PR TITLE
Fix links to go back on supplier invoice list

### DIFF
--- a/htdocs/fourn/facture/contact.php
+++ b/htdocs/fourn/facture/contact.php
@@ -142,7 +142,7 @@ if ($id > 0 || !empty($ref))
 
 		dol_fiche_head($head, 'contact', $langs->trans('SupplierInvoice'), -1, 'bill');
 
-		$linkback = '<a href="'.DOL_URL_ROOT.'/compta/facture/list.php?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
+		$linkback = '<a href="'.DOL_URL_ROOT.'/fourn/facture/list.php?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
 
 		$morehtmlref = '<div class="refidno">';
     	// Ref supplier

--- a/htdocs/fourn/facture/info.php
+++ b/htdocs/fourn/facture/info.php
@@ -67,7 +67,7 @@ $head = facturefourn_prepare_head($object);
 $titre = $langs->trans('SupplierInvoice');
 dol_fiche_head($head, 'info', $langs->trans('SupplierInvoice'), -1, 'bill');
 
-$linkback = '<a href="'.DOL_URL_ROOT.'/compta/facture/list.php?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
+$linkback = '<a href="'.DOL_URL_ROOT.'/fourn/facture/list.php?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
 
 $morehtmlref = '<div class="refidno">';
 // Ref supplier


### PR DESCRIPTION
Links to go back on supplier invoice list were wrong on the contact and info tabs