### PR TITLE
Fix search by statut in list of holiday module

### DIFF
--- a/htdocs/holiday/list.php
+++ b/htdocs/holiday/list.php
@@ -106,7 +106,7 @@ $search_month_end    = GETPOST('search_month_end', 'int');
 $search_year_end     = GETPOST('search_year_end', 'int');
 $search_employee     = GETPOST('search_employee', 'int');
 $search_valideur     = GETPOST('search_valideur', 'int');
-$search_status       = GETPOST('search_status', 'int');
+$search_status       = GETPOST('search_statut', 'int');
 $search_type         = GETPOST('search_type', 'int');
 
 // Initialize technical objects


### PR DESCRIPTION
There was an error on search by statut in list of holiday module, the GETPOST was on search_status but in url it was search_statut so it wasn't working.