### PR TITLE
FIX #16143

### DIFF
--- a/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
+++ b/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
@@ -574,3 +574,5 @@ insert into llx_c_action_trigger (code,label,description,elementtype,rang) value
 insert into llx_c_action_trigger (code,label,description,elementtype,rang) values ('EXPENSE_REPORT_PAID','Expense report billed','Executed when an expense report is set as billed','expensereport',204);
 insert into llx_c_action_trigger (code,label,description,elementtype,rang) values ('EXPENSE_REPORT_DELETE','Expense report deleted','Executed when an expense report is deleted','expensereport',205);
 
+-- Unsed function
+DROP FUNCTION IF EXISTS update_modified_column_date_m CASCADE;


### PR DESCRIPTION
Remove the function update_modified_column_date_m is required because old triggers can throw errors during PDF generation
