### PR TITLE
FIX: warning when adding a line if $remise_percent is an empty string

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -672,6 +672,7 @@ if (empty($reshook))
 
 		$qty = price2num(GETPOST('qty'.$predef, 'alpha'));
 		$remise_percent = (GETPOSTISSET('remise_percent'.$predef) ? price2num(GETPOST('remise_percent'.$predef, 'alpha')) : 0);
+		if ($remise_percent === '') $remise_percent = 0;
 
 		// Extrafields
 		$extralabelsline = $extrafields->fetch_name_optionals_label($object->table_element_line);


### PR DESCRIPTION
# Issue
When a line is added to an order, if `$remise_percent` is an empty string, the tests for the minimum price (the "CantBeLessThanMinPrice" message around line 947 of `commande/card.php`) cause a PHP warning.