### PR TITLE
Module builder: Don't delete hidden .tx-folder

### DIFF
--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -230,7 +230,7 @@ if ($dirins && $action == 'initmodule' && $modulename)
 		dol_delete_dir_recursive($destdir.'/core/tpl');
 		dol_delete_dir_recursive($destdir.'/core/triggers');
 		dol_delete_dir_recursive($destdir.'/doc');
-		dol_delete_dir_recursive($destdir.'/.tx');
+		//dol_delete_dir_recursive($destdir.'/.tx');
 		dol_delete_dir_recursive($destdir.'/core/boxes');
 
 		dol_delete_file($destdir.'/admin/myobject_extrafields.php');


### PR DESCRIPTION
# New ModuleBuilder Transifex Setup
Currently with creating a new module using module builder the hidden .tx folder gets deleted.
Maybe this is a desired action. As far as I can see the folder DOES NOT get added at a later point.