### PR TITLE
V13 Fix #16241 Date filter resets on Miscellaneous Payments

### DIFF
--- a/htdocs/compta/bank/various_payment/list.php
+++ b/htdocs/compta/bank/various_payment/list.php
@@ -58,6 +58,10 @@ $search_accountancy_account = GETPOST("search_accountancy_account");
 if ($search_accountancy_account == - 1) $search_accountancy_account = '';
 $search_accountancy_subledger = GETPOST("search_accountancy_subledger");
 if ($search_accountancy_subledger == - 1) $search_accountancy_subledger = '';
+if (empty($search_datep_start))  $search_datep_start = GETPOST("search_datep_start", 'int');
+if (empty($search_datep_end)) $search_datep_end = GETPOST("search_datep_end", 'int');
+if (empty($search_datev_start)) $search_datev_start = GETPOST("search_datev_start", 'int');
+if (empty($search_datev_end)) $search_datev_end = GETPOST("search_datev_end", 'int');
 
 $sortfield = GETPOST("sortfield", 'alpha');
 $sortorder = GETPOST("sortorder", 'alpha');


### PR DESCRIPTION
Changed $search_datep_start, $search_datep_end, $search_datev_start and $search_datev_end variables to get values from search_datep_start, search_datep_end, search_datev_start and search_datev_end GET parameters if their value is empty after checking POST parameters

# Fix #16241 Date filter resets on Miscellaneous Payments on V13
Date filter resets on Miscellaneous Payments when changing pages on V13