### PR TITLE
Fix format error in graph in fourn/commande/index.php

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -736,8 +736,8 @@ class CommandeFournisseur extends CommonOrder
 		}
 		if ($status == 5 && $billed) $statusClass = 'status6';
 
-		$statusLong = $langs->trans($this->statuts[$status]).$billedtext;
-		$statusShort = $langs->trans($this->statutshort[$status]);
+		$statusLong = $langs->transnoentitiesnoconv($this->statuts[$status]).$billedtext;
+		$statusShort = $langs->transnoentitiesnoconv($this->statutshort[$status]);
 
 		return dolGetStatus($statusLong, $statusShort, '', $statusClass, $mode);
 	}


### PR DESCRIPTION
Fix format error in graph in fourn/commande/index.php because of UTF-8 chars converted in html chars