### PR TITLE
FIX #15604 TakePOS category filter is undefined

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -140,7 +140,7 @@ if ($conf->global->TAKEPOS_ROOT_CATEGORY_ID > 0)
 		}
 	}
 }
-$levelofmaincategories = $levelofrootcategory + 1;
+$levelofmaincategories = $levelofrootcategory ? $levelofrootcategory : 1;
 
 $maincategories = array();
 $subcategories = array();


### PR DESCRIPTION
# Fix #15604 TakePOS category filter is undefine

The level of main categories ($levelofmaincategories) should be set to 1 if the rootcategory is undefined or set to 0 but it should be equal to the levelofrootcategory in the other situation.