### PR TITLE
Improve logo printing compatibility with TakePOS connector

### DIFF
--- a/htdocs/core/class/dolreceiptprinter.class.php
+++ b/htdocs/core/class/dolreceiptprinter.class.php
@@ -825,7 +825,7 @@ class dolReceiptPrinter extends Printer
 			if ($this->printer->connector instanceof DummyPrintConnector || $conf->global->TAKEPOS_PRINT_METHOD == "takeposconnector")
 			{
 				$data = $this->printer->connector->getData();
-				if ($conf->global->TAKEPOS_PRINT_METHOD == "takeposconnector") echo base64_encode($data);
+				if ($conf->global->TAKEPOS_PRINT_METHOD == "takeposconnector") echo rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
 				dol_syslog($data);
 			}
 			// Close and print


### PR DESCRIPTION
To avoid decode errors in received post data we control the special characters with a commented command on the php website:
https://www.php.net/manual/es/function.base64-encode.php