### PR TITLE
New/14.0 workflow close project automatically when its tasks are all done

### DIFF
--- a/htdocs/admin/workflow.php
+++ b/htdocs/admin/workflow.php
@@ -31,7 +31,18 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 if (!$user->admin) accessforbidden();
 
 // Load translation files required by the page
-$langs->loadLangs(array("admin", "workflow", "propal", "workflow", "orders", "supplier_proposal", "receptions", "errors", 'sendings'));
+$langs->loadLangs(array(
+	"admin",
+	"workflow",
+	"propal",
+	"workflow",
+	"orders",
+	"supplier_proposal",
+	"receptions",
+	"projects",
+	"errors",
+	'sendings'
+));
 
 $action = GETPOST('action', 'aZ09');
 
@@ -137,7 +148,15 @@ $workflowcodes = array(
 		'position' => 66,
 		'enabled' => ! empty($conf->expedition->enabled) && ! empty($conf->facture->enabled),
 		'picto' => 'shipment'
-	)
+	),
+
+	// Automatic classification of projects
+	'WORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE' => array(
+		'family' => 'classify_project',
+		'position' => 68,
+		'enabled' => !empty($conf->projet->enabled),
+		'picto' => 'projet'
+	),
 );
 
 if (!empty($conf->modules_parts['workflow']) && is_array($conf->modules_parts['workflow'])) {
@@ -199,6 +218,7 @@ foreach ($workflowcodes as $key => $params) {
 			if ($reg[1] == 'supplier_order')	$header .= ' - '.$langs->trans('SupplierOrder');
 			if ($reg[1] == 'reception')			$header .= ' - '.$langs->trans('Reception');
 			if ($reg[1] == 'shipping')			$header .= ' - '.$langs->trans('Shipment');
+			if ($reg[1] == 'project')			$header .= ' - '.$langs->trans('Project');
 		} else {
 			$header = $langs->trans("Description");
 		}

--- a/htdocs/admin/workflow.php
+++ b/htdocs/admin/workflow.php
@@ -28,7 +28,7 @@ require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 
 // Load translation files required by the page
-$langs->loadLangs(array("admin", "workflow", "propal", "workflow", "orders", "supplier_proposals", "receptions"));
+$langs->loadLangs(array("admin", "workflow", "propal", "workflow", "orders", "supplier_proposals", "receptions", 'projects'));
 
 if (!$user->admin) accessforbidden();
 
@@ -90,6 +90,13 @@ $workflowcodes = array(
 	'WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER'=>array('family'=>'classify_supplier_order', 'position'=>62, 'enabled'=>'!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD) || !empty($conf->supplier_order->enabled) || !empty($conf->supplier_invoice->enabled)', 'picto'=>'order', 'warning'=>''),
 	//Automatic classification reception
 	'WORKFLOW_BILL_ON_RECEPTION'=>array('family'=>'classify_reception', 'position'=>64, 'enabled'=>'! empty($conf->reception->enabled) && (!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD) || !empty($conf->supplier_order->enabled) || !empty($conf->supplier_invoice->enabled))', 'picto'=>'bill'),
+	// Automatic classification of projects
+	'WORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE' => array(
+		'family' => 'classify_project',
+		'position' => 68,
+		'enabled' => !empty($conf->projet->enabled),
+		'picto' => 'projet'
+	),
 );
 
 if (!empty($conf->modules_parts['workflow']) && is_array($conf->modules_parts['workflow']))
@@ -143,6 +150,7 @@ foreach ($workflowcodes as $key => $params)
 			if ($reg[1] == 'supplier_proposal') print ' - '.$langs->trans('SupplierProposal');
 			if ($reg[1] == 'supplier_order') print ' - '.$langs->trans('SupplierOrder');
 			if ($reg[1] == 'reception') print ' - '.$langs->trans('Reception');
+			if ($reg[1] == 'project') print ' - ' . $langs->trans('Project');
 		}
 		else
 		{

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -330,7 +330,9 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 					// if all tasks are 100% completed, close the project
 					$projectCompleted = array_reduce(
 						$project->lines,
-						function ($allTasksCompleted, $task) { return $allTasksCompleted && $task->progress >= 100; },
+						function ($allTasksCompleted, $task) {
+							return $allTasksCompleted && $task->progress >= 100;
+						},
 						1
 					);
 					if ($projectCompleted) {

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -317,6 +317,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
         		}
         	}
         }
+
 		 // classify billed reception
         if ($action == 'BILL_SUPPLIER_VALIDATE')
         {
@@ -343,6 +344,38 @@ class InterfaceWorkflowManager extends DolibarrTriggers
         		}
         		return $ret;
         	}
+		}
+
+        // classify project as closed when progress of all tasks is 100%
+		if ($action == 'TASK_MODIFY') {
+			//
+			if (!empty($conf->projet->enabled) && !empty($conf->global->WORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE))
+			{
+				/** @var Task $object */
+				require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+				$errors = 0;
+				$project = new Project($this->db);
+				if ($project->fetch($object->fk_project) > 0) {
+					$project->getLinesArray(null); // this method does not return <= 0 if fails
+					// if all tasks are 100% completed, close the project
+					$projectCompleted = array_reduce(
+						$project->lines,
+						function ($allTasksCompleted, $task) { return $allTasksCompleted && $task->progress >= 100; },
+						1
+					);
+					if ($projectCompleted) {
+						if ($project->setClose($user) <= 0) {
+							$errors++;
+						}
+					}
+				} else {
+					$errors++;
+				}
+				if ($errors) {
+					$this->errors[] = $project->error;
+				}
+			}
+
 		}
 
         return 0;

--- a/htdocs/langs/en_US/workflow.lang
+++ b/htdocs/langs/en_US/workflow.lang
@@ -16,5 +16,7 @@ descWORKFLOW_ORDER_CLASSIFY_SHIPPED_SHIPPING=Classify linked source sales order 
 # Autoclassify purchase order
 descWORKFLOW_ORDER_CLASSIFY_BILLED_SUPPLIER_PROPOSAL=Classify linked source vendor proposal as billed when vendor invoice is validated (and if the amount of the invoice is the same as the total amount of the linked proposal)
 descWORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER=Classify linked source purchase order as billed when vendor invoice is validated (and if the amount of the invoice is the same as the total amount of the linked order)
+# Autoclassify project
+descWORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classify project as closed when all its tasks are completed (100%% progress).
 AutomaticCreation=Automatic creation
 AutomaticClassification=Automatic classification

--- a/htdocs/langs/en_US/workflow.lang
+++ b/htdocs/langs/en_US/workflow.lang
@@ -23,3 +23,5 @@ AutomaticCreation=Automatic creation
 AutomaticClassification=Automatic classification
 # Autoclassify shipment
 descWORKFLOW_SHIPPING_CLASSIFY_CLOSED_INVOICE=Classify linked source shipment as closed when customer invoice is validated
+# Autoclassify project
+descWORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classify project as closed when all its tasks are completed (100%% progress).

--- a/htdocs/langs/en_US/workflow.lang
+++ b/htdocs/langs/en_US/workflow.lang
@@ -17,6 +17,6 @@ descWORKFLOW_ORDER_CLASSIFY_SHIPPED_SHIPPING=Classify linked source sales order 
 descWORKFLOW_ORDER_CLASSIFY_BILLED_SUPPLIER_PROPOSAL=Classify linked source vendor proposal as billed when vendor invoice is validated (and if the amount of the invoice is the same as the total amount of the linked proposal)
 descWORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER=Classify linked source purchase order as billed when vendor invoice is validated (and if the amount of the invoice is the same as the total amount of the linked order)
 # Autoclassify project
-descWORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classify project as closed when all its tasks are completed (100%% progress).
+descWORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classify project as closed when all its tasks are completed (100%% progress)<br/> <small>Note: existing projects with all tasks at 100 %% progress won't be affected: you will have to close them manually.</small> 
 AutomaticCreation=Automatic creation
 AutomaticClassification=Automatic classification

--- a/htdocs/langs/fr_FR/workflow.lang
+++ b/htdocs/langs/fr_FR/workflow.lang
@@ -16,6 +16,8 @@ descWORKFLOW_ORDER_CLASSIFY_SHIPPED_SHIPPING=Classer la commande source à expé
 # Autoclassify supplier order
 descWORKFLOW_ORDER_CLASSIFY_BILLED_SUPPLIER_PROPOSAL=Classer la ou les proposition(s) commerciale(s) fournisseur sources facturées quand une facture fournisseur est validée (et si le montant de la facture est le même que le total des propositions sources liées)
 descWORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER=Classer la ou les commande(s) fournisseur(s) de source(s) à facturée(s) lorsque la facture fournisseur est validée (et si le montant de la facture est le même que le montant total des commandes liées)
-descWORKFLOW_BILL_ON_RECEPTION=Classer la/les réception(s) facturée(s) à la validation d'une facture fournisseur 
+descWORKFLOW_BILL_ON_RECEPTION=Classer la/les réception(s) facturée(s) à la validation d'une facture fournisseur
+# Autoclassify project
+descWORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classer le projet à clôturé lorsque toutes les tâches de ce projet sont à 100 %% de progression.
 AutomaticCreation=Création automatique
 AutomaticClassification=Classification automatique

--- a/htdocs/langs/fr_FR/workflow.lang
+++ b/htdocs/langs/fr_FR/workflow.lang
@@ -18,6 +18,6 @@ descWORKFLOW_ORDER_CLASSIFY_BILLED_SUPPLIER_PROPOSAL=Classer la ou les propositi
 descWORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER=Classer la ou les commande(s) fournisseur(s) de source(s) à facturée(s) lorsque la facture fournisseur est validée (et si le montant de la facture est le même que le montant total des commandes liées)
 descWORKFLOW_BILL_ON_RECEPTION=Classer la/les réception(s) facturée(s) à la validation d'une facture fournisseur
 # Autoclassify project
-descWORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classer le projet à clôturé lorsque toutes les tâches de ce projet sont à 100 %% de progression.
+descWORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classer le projet à clôturé lorsque toutes les tâches de ce projet sont à 100 %% de progression<br/> <small>Non rétroactif : l’activation de cette option ne clôturera pas les projets dont les tâches sont déjà à 100 %%.</small>
 AutomaticCreation=Création automatique
 AutomaticClassification=Classification automatique

--- a/htdocs/langs/fr_FR/workflow.lang
+++ b/htdocs/langs/fr_FR/workflow.lang
@@ -23,3 +23,5 @@ AutomaticCreation=Création automatique
 AutomaticClassification=Classification automatique
 # Autoclassify shipment
 descWORKFLOW_SHIPPING_CLASSIFY_CLOSED_INVOICE=Classify linked source shipment as closed when customer invoice is validated
+# Autoclassify project
+descWORKFLOW_PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classer le projet à clôturé lorsque toutes les tâches de ce projet sont à 100 %% de progression.


### PR DESCRIPTION
# NEW
New workflow option: whenever the progress of all tasks in a project reach 100%, close the project automatically. Note: as it stands, even a draft project can be closed that way; this option is non-retroactive (when enabled, it won't loop over all existing projects and close those meeting the criterion: it will only check a project when one of its tasks is modified).