### PR TITLE
FIX #16285 warning undefine array key in cron_run_job.php

### DIFF
--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -125,7 +125,7 @@ if ($result < 0) {
 }
 $user->getrights();
 
-if (isset($argv[3]) || $argv[3]) {
+if (isset($argv[3]) && $argv[3]) {
 	$id = $argv[3];
 }
 


### PR DESCRIPTION
# Close #16285 warning undefine array key in cron_run_job.php