### PR TITLE
NEW option to automatically close an open project when all its tasks …

### DIFF
--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -269,3 +269,5 @@ OneLinePerPeriod=One line per period
 RefTaskParent=Ref. Parent Task
 ProfitIsCalculatedWith=Profit is calculated using
 AddPersonToTask=Add also to tasks
+PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classify project as closed when all its tasks are completed (100%% progress)
+PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE_help=Note: existing projects with all tasks at 100 %% progress won't be affected: you will have to close them manually. This option only affects open projects.

--- a/htdocs/langs/fr_FR/projects.lang
+++ b/htdocs/langs/fr_FR/projects.lang
@@ -268,3 +268,5 @@ OneLinePerTask=Une ligne par tâche
 OneLinePerPeriod=Une ligne par période
 RefTaskParent=Réf. Tâche parent
 ProfitIsCalculatedWith=Le bénéfice est calculé sur la base de
+PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE=Classer le projet à clôturé lorsque toutes les tâches de ce projet sont à 100 %% de progression
+PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE_help=Non rétroactif : l’activation de cette option ne clôturera pas les projets dont les tâches sont déjà à 100 %%. Cette option ne classe que les projets ouverts.

--- a/htdocs/projet/admin/project.php
+++ b/htdocs/projet/admin/project.php
@@ -244,6 +244,12 @@ elseif ($action == 'setdoc')
 	}
 }
 
+// Set boolean (on/off) constants
+elseif (preg_match('/^(set|del)_?([A-Z_]+)$/', $action, $reg)) {
+	if (!dolibarr_set_const($db, $reg[2], ($reg[1] === 'set' ? '1' : '0'), 'chaine', 0, '', $conf->entity) > 0) {
+		dol_print_error($db);
+	}
+}
 
 /*
  * View
@@ -839,6 +845,16 @@ print '<input type="text" id="projectToSelect" name="projectToSelect" value="'.$
 print $form->textwithpicto('', $langs->trans('AllowToLinkFromOtherCompany'));
 print '<input type="submit" class="button" name="PROJECT_ALLOW_TO_LINK_FROM_OTHER_COMPANY" value="'.$langs->trans("Modify").'">';
 print '</td>';
+
+$key = 'PROJECT_CLASSIFY_CLOSED_WHEN_ALL_TASKS_DONE';
+echo '<tr class="oddeven">',
+		'<td class="left">',
+			$form->textwithpicto($langs->transnoentities($key), $langs->transnoentities($key . '_help')),
+		'</td>',
+		'<td class="right" colspan="2">',
+			ajax_constantonoff($key),
+		'</td>',
+	'</tr>';
 
 print '</table>';
 


### PR DESCRIPTION
# NEW
cf. https://github.com/Dolibarr/dolibarr/pull/16299

New project option: whenever the progress of all tasks in a validated project reach 100%, close the project automatically.

The option is non-retroactive (when enabled, it won't loop over all existing projects and close those meeting the criterion: it will only check a project when one of its tasks is modified).