### PR TITLE
New/14.0 new payments on vat default checkbox value

### DIFF
--- a/htdocs/admin/taxes.php
+++ b/htdocs/admin/taxes.php
@@ -110,7 +110,12 @@ if ($action == 'update') {
 		setEventMessages($langs->trans("Error"), null, 'errors');
 	}
 }
-
+// Set boolean (on/off) constants
+elseif (preg_match('/^(set|del)_?([A-Z_]+)$/', $action, $reg)) {
+	if (!dolibarr_set_const($db, $reg[2], ($reg[1] === 'set' ? '1' : '0'), 'chaine', 0, '', $conf->entity) > 0) {
+		dol_print_error($db);
+	}
+}
 
 
 /*
@@ -257,7 +262,17 @@ else
 
 print "<br>\n";
 
+
+print '<div class="center">';
+print '<input type="submit" class="button" value="'.$langs->trans("Modify").'" name="button">';
+print '<br/><br/>';
+print '</div>';
+
+print '</form>';
+
 // Options
+
+echo '<div>';
 echo '<table class="noborder centpercent">';
 echo '<thead>';
 echo '<tr class="liste_titre"><th>' . $langs->trans('Parameter') . '</th><th>' . $langs->trans('Value') . '</th></tr>';
@@ -269,14 +284,7 @@ echo '<tr><td>', $langs->trans($key), '</td><td>', ajax_constantonoff($key), '</
 
 echo '</tbody>';
 echo '</table>';
-
-print '<div class="center">';
-print '<input type="submit" class="button" value="'.$langs->trans("Modify").'" name="button">';
-print '</div>';
-
-print '</form>';
-
-
+echo '</div>';
 
 
 if (!empty($conf->accounting->enabled))

--- a/htdocs/admin/taxes.php
+++ b/htdocs/admin/taxes.php
@@ -257,6 +257,18 @@ else
 
 print "<br>\n";
 
+// Options
+echo '<table class="noborder centpercent">';
+echo '<thead>';
+echo '<tr class="liste_titre"><th>' . $langs->trans('Parameter') . '</th><th>' . $langs->trans('Value') . '</th></tr>';
+echo '</thead>';
+echo '<tbody>';
+
+$key = 'CREATE_NEW_VAT_WITHOUT_AUTO_PAYMENT';
+echo '<tr><td>', $langs->trans($key), '</td><td>', ajax_constantonoff($key), '</td></tr>';
+
+echo '</tbody>';
+echo '</table>';
 
 print '<div class="center">';
 print '<input type="submit" class="button" value="'.$langs->trans("Modify").'" name="button">';

--- a/htdocs/compta/tva/card.php
+++ b/htdocs/compta/tva/card.php
@@ -43,7 +43,11 @@ $id = GETPOST("id", 'int');
 $action = GETPOST("action", "alpha");
 $confirm = GETPOST('confirm');
 $refund = GETPOST("refund", "int");
-$auto_create_payment = GETPOST("auto_create_paiement", "int");
+if (GETPOSTISSET('auto_create_paiement')) {
+	$auto_create_payment = GETPOST("auto_create_paiement", "int");
+} else {
+	$auto_create_payment = empty($conf->global->CREATE_NEW_VAT_WITHOUT_AUTO_PAYMENT);
+}
 
 if (empty($refund)) $refund = 0;
 
@@ -384,17 +388,10 @@ if ($action == 'create')
 	if (!empty($conf->use_javascript_ajax))
     {
         print "\n".'<script type="text/javascript" language="javascript">';
-        print '$(document).ready(function () {
-                $("#radiopayment").click(function() {
-                    $("#label").val($(this).data("label"));
-
-                });
-                $("#radiorefund").click(function() {
-                    $("#label").val($(this).data("label"));
-
-                });
-				$("#auto_create_paiement").click(function() {
-					if($(this).is(":checked")) {
+		print /** @lang JavaScript */'
+			$(document).ready(function () {
+				let onAutoCreatePaiementChange = function () {
+					if($("#auto_create_paiement").is(":checked")) {
 						$("#label_fk_account").addClass("fieldrequired");
 						$("#label_type_payment").addClass("fieldrequired");
 						$(".hide_if_no_auto_create_payment").show();
@@ -403,21 +400,21 @@ if ($action == 'create')
 						$("#label_type_payment").removeClass("fieldrequired");
 						$(".hide_if_no_auto_create_payment").hide();
 					}
-				});';
+				};
+				$("#radiopayment").click(function() {
+					$("#label").val($(this).data("label"));
+				});
+				$("#radiorefund").click(function() {
+					$("#label").val($(this).data("label"));
 
-		if($_REQUEST['action'] === 'add') { // form has been send but there is at least one error
-			if(empty($auto_create_payment)) {
-				print '$("#label_fk_account").removeClass("fieldrequired");
-					   $("#label_type_payment").removeClass("fieldrequired");
-					   $(".hide_if_no_auto_create_payment").hide();';
-			} else {
-				print '$("#label_fk_account").addClass("fieldrequired");
-					   $("#label_type_payment").addClass("fieldrequired");
-					   $(".hide_if_no_auto_create_payment").show();';
-			}
-		}
+				});
+				$("#auto_create_paiement").click(function () {
+					onAutoCreatePaiementChange();
+				});
+				onAutoCreatePaiementChange();
+			});
+			';
 
-        print '});';
 		print '</script>'."\n";
 	}
 
@@ -482,7 +479,7 @@ if ($action == 'create')
 
 	// Auto create payment
 	print '<tr><td>'.$langs->trans('AutomaticCreationPayment').'</td>';
-	print '<td><input id="auto_create_paiement" name="auto_create_paiement" type="checkbox" '.($_REQUEST['action'] === 'add' ? (empty($auto_create_payment) ? '' : 'checked="checked"') : 'checked="checked"').' value="1"></td></tr>'."\n";
+	print '<td><input id="auto_create_paiement" name="auto_create_paiement" type="checkbox" ' . (empty($auto_create_payment) ? '' : 'checked="checked"') . ' value="1"></td></tr>'."\n";
 
 	// Number
 	print '<tr class="hide_if_no_auto_create_payment"><td>'.$langs->trans('Numero');

--- a/htdocs/compta/tva/card.php
+++ b/htdocs/compta/tva/card.php
@@ -43,7 +43,7 @@ $id = GETPOST("id", 'int');
 $action = GETPOST("action", "alpha");
 $confirm = GETPOST('confirm');
 $refund = GETPOST("refund", "int");
-if (GETPOSTISSET('auto_create_paiement')) {
+if (GETPOSTISSET('auto_create_paiement') || $action === 'add') {
 	$auto_create_payment = GETPOST("auto_create_paiement", "int");
 } else {
 	$auto_create_payment = empty($conf->global->CREATE_NEW_VAT_WITHOUT_AUTO_PAYMENT);

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -1683,6 +1683,7 @@ YourCompanyDoesNotUseVAT=Your company has been defined to not use VAT (Home - Se
 AccountancyCode=Accounting Code
 AccountancyCodeSell=Sale account. code
 AccountancyCodeBuy=Purchase account. code
+CREATE_NEW_VAT_WITHOUT_AUTO_PAYMENT=By default, leave the checkbox “Automatically create a total payment” empty when creating a new tax object
 ##### Agenda #####
 AgendaSetup=Events and agenda module setup
 PasswordTogetVCalExport=Key to authorize export link


### PR DESCRIPTION
# NEW
New option to leave the checkbox "Automatically create a total payment" empty by default on the the "new Sales tax" form.