### PR TITLE
FIX #14243 Failed opening master.inc in cron_run_job

### DIFF
--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -47,7 +47,7 @@ $masterpath = ( false !== file_exists($path."../../htdocs/master.inc.php") ) ? $
 
 // if master.inc.php is not in htdocs or root, try to find it in root subfolder (incase of renaming htdocs)
 if ( false === file_exists($masterpath."/master.inc.php") ){
-	foreach (scandir ($path."../../") as $key => $value) {
+	foreach (scandir($path."../../") as $key => $value) {
 		// test only dorectories but not project default folders
 		if ( is_dir($path."../../".$value) && !in_array($value, array( ".", "..", ".github", ".tx", "build", "dev", "doc", "documents", "scripts", "test" )) && file_exists($path."../../".$value."/master.inc.php") ){
 			$masterpath = $path."../../".$value;

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -56,7 +56,7 @@ if ( false === file_exists($masterpath."/master.inc.php") ){
 	}
 }
 
-require_once $$masterpath."/master.inc.php";
+require_once $masterpath."/master.inc.php";
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -42,7 +42,21 @@ if (substr($sapi_type, 0, 3) == 'cgi') {
 	exit(-1);
 }
 
-require_once $path."../../htdocs/master.inc.php";
+// master.inc.php should be in htdocs or in root folder in most cases
+$masterpath = ( false !== file_exists($path."../../htdocs/master.inc.php") ) ? $path."../../htdocs" : $path."../.." ;
+
+// if master.inc.php is not in htdocs or root, try to find it in root subfolder (incase of renaming htdocs)
+if ( false === file_exists($masterpath."/master.inc.php") ){
+	foreach (scandir ($path."../../") as $key => $value) {
+		// test only dorectories but not project default folders
+		if ( is_dir($path."../../".$value) && !in_array($value, array( ".", "..", ".github", ".tx", "build", "dev", "doc", "documents", "scripts", "test" )) && file_exists($path."../../".$value."/master.inc.php") ){
+			$masterpath = $path."../../".$value;
+			break;
+		}
+	}
+}
+
+require_once $$masterpath."/master.inc.php";
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 


### PR DESCRIPTION
# Fix #14243 Fatal error failed opening master.inc in cron_run_job

If the htdocs is missing the cron_run_job.php can not find the main.inc.php cause path was hard coded with htdocs.

Here is a version wich try to locate the master.inc.php