### PR TITLE
V13 FIX #16241 Bank Account filter resets on Miscellaneous Payments

### DIFF
--- a/htdocs/compta/bank/various_payment/list.php
+++ b/htdocs/compta/bank/various_payment/list.php
@@ -251,7 +251,7 @@ if ($result)
 	if ($typeid > 0)						$param .= '&typeid='.urlencode($typeid);
 	if ($search_amount_deb)					$param .= '&search_amount_deb='.urlencode($search_amount_deb);
 	if ($search_amount_cred)				$param .= '&search_amount_cred='.urlencode($search_amount_cred);
-	if ($search_bank_account > 0)			$param .= '&search_amount='.urlencode($search_bank_account);
+	if ($search_bank_account > 0)			$param .= '&search_account='.urlencode($search_bank_account);
 	if ($search_accountancy_account > 0)	$param .= '&search_accountancy_account='.urlencode($search_accountancy_account);
 	if ($search_accountancy_subledger > 0)	$param .= '&search_accountancy_subledger='.urlencode($search_accountancy_subledger);
 


### PR DESCRIPTION
Changed GET search bank account GET parameter from search_amount to search_account


# V13 Fix #16241 Bank Account filter resets on Miscellaneous Payments
Bank Account filter resets on Miscellaneous Payments when changing pages