### PR TITLE
Fix: Option MAIN_DIRECT_STATUS_UPDATE broken. Ajax on/off not saving value in DB after updating to version >=12

### DIFF
--- a/htdocs/core/ajax/objectonoff.php
+++ b/htdocs/core/ajax/objectonoff.php
@@ -77,10 +77,10 @@ if (($action == 'set') && !empty($id)) {
 	if ($tablename == 'websitepage') $tablename = 'website_page';
 
 	$format = 'int';
-	
+
 	$object->table_element = $tablename;
 	$object->id = $id;
 	$object->fields[$field] = array('type' => $format, 'enabled' => 1);
-	
+
 	$object->setValueFrom($field, $value, $tablename, $id, $format, '', $user, $triggerkey);
 }

--- a/htdocs/core/ajax/objectonoff.php
+++ b/htdocs/core/ajax/objectonoff.php
@@ -77,6 +77,10 @@ if (($action == 'set') && !empty($id)) {
 	if ($tablename == 'websitepage') $tablename = 'website_page';
 
 	$format = 'int';
-
+	
+	$object->table_element = $tablename;
+	$object->id = $id;
+	$object->fields[$field] = array('type' => $format, 'enabled' => 1);
+	
 	$object->setValueFrom($field, $value, $tablename, $id, $format, '', $user, $triggerkey);
 }


### PR DESCRIPTION
The issue seams to be that starting in version 12 the "[element]_UPDATE" trigger is called in file core/ajax/objectonoff.php but some properties that are required on $object are not set.

Those are (at least for product that is what I use):

$object->id
$object->table_element
$object->fields[$field]

The error occurs on the setValueFrom function in core/class/commonobject.class.php file

# Fix #14201 BUG: ajax_object_onoff not functionnal v12