### PR TITLE
FIX 11.0 - $this->socid injected in query without checking for empty string

### DIFF
--- a/htdocs/contact/class/contact.class.php
+++ b/htdocs/contact/class/contact.class.php
@@ -1686,7 +1686,7 @@ class Contact extends CommonObject
 
 		$this->db->begin();
 
-		$sql = "DELETE FROM ".MAIN_DB_PREFIX."societe_contacts WHERE fk_soc=".$this->socid." AND fk_socpeople=".$this->id; ;
+		$sql = "DELETE FROM ".MAIN_DB_PREFIX."societe_contacts WHERE fk_soc=".intval($this->socid)." AND fk_socpeople=".$this->id; ;
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
 		$result = $this->db->query($sql);


### PR DESCRIPTION
# Fix SQL syntax error
When `updateRoles()` is called on a contact whose socid is an empty string, it causes a syntax error.

`updateRoles()` doesn't really make sense when there is no third party, but by injecting `intval($this->socid)` instead of `$this->socid` directly, an empty `socid` will just cause the SQL query to return no result and the method will have no effect.
