### PR TITLE
differentiate serial numbers from lot management

### DIFF
--- a/htdocs/langs/en_US/productbatch.lang
+++ b/htdocs/langs/en_US/productbatch.lang
@@ -1,7 +1,7 @@
 # ProductBATCH language file - en_US - ProductBATCH
 ManageLotSerial=Use lot/serial number
 ProductStatusOnBatch=Lot (required)
-ProductStatusOnSerial=Serial number (required)
+ProductStatusOnSerial=Serial number (must be unique for each equipment)
 ProductStatusNotOnBatch=No (lot/serial not used)
 ProductStatusOnBatchShort=Lot
 ProductStatusOnSerialShort=Serial

--- a/htdocs/langs/en_US/productbatch.lang
+++ b/htdocs/langs/en_US/productbatch.lang
@@ -1,8 +1,10 @@
 # ProductBATCH language file - en_US - ProductBATCH
 ManageLotSerial=Use lot/serial number
-ProductStatusOnBatch=Yes (lot/serial required)
+ProductStatusOnBatch=Lot (required)
+ProductStatusOnSerial=Serial number (required)
 ProductStatusNotOnBatch=No (lot/serial not used)
-ProductStatusOnBatchShort=Yes
+ProductStatusOnBatchShort=Lot
+ProductStatusOnSerialShort=Serial
 ProductStatusNotOnBatchShort=No
 Batch=Lot/Serial
 atleast1batchfield=Eat-by date or Sell-by date or Lot/Serial number

--- a/htdocs/langs/fr_FR/productbatch.lang
+++ b/htdocs/langs/fr_FR/productbatch.lang
@@ -1,7 +1,7 @@
 # ProductBATCH language file - en_US - ProductBATCH
 ManageLotSerial=Utiliser les numéros de lots/série
 ProductStatusOnBatch=Lot (requis)
-ProductStatusOnSerial=Numéro de série (requis)
+ProductStatusOnSerial=Numéro de série (doit être unique pour chaque équipement)
 ProductStatusNotOnBatch=Non (Lot/Série non utilisé)
 ProductStatusOnBatchShort=Lot
 ProductStatusOnSerialShort=N°série

--- a/htdocs/langs/fr_FR/productbatch.lang
+++ b/htdocs/langs/fr_FR/productbatch.lang
@@ -1,8 +1,10 @@
 # ProductBATCH language file - en_US - ProductBATCH
 ManageLotSerial=Utiliser les numéros de lots/série
-ProductStatusOnBatch=Oui (Lot/Série requis)
+ProductStatusOnBatch=Lot (requis)
+ProductStatusOnSerial=Numéro de série (requis)
 ProductStatusNotOnBatch=Non (Lot/Série non utilisé)
-ProductStatusOnBatchShort=Oui
+ProductStatusOnBatchShort=Lot
+ProductStatusOnSerialShort=N°série
 ProductStatusNotOnBatchShort=Non
 Batch=Lot/Série
 atleast1batchfield=Date limite utilisation optimale, de consommation ou numéro de lot/série

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1029,7 +1029,14 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action))
 		if (!empty($conf->productbatch->enabled))
 		{
 			print '<tr><td>'.$langs->trans("ManageLotSerial").'</td><td colspan="3">';
-			$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"));
+			if ( empty($conf->global ->MAIN_ADVANCE_NUMLOT) )
+			{
+				$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"));
+			}
+			else
+			{
+				$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"), '2' => $langs->trans("ProductStatusOnSerial"));
+			}
 			print $form->selectarray('status_batch', $statutarray, GETPOST('status_batch'));
 			print '</td></tr>';
 		}
@@ -1488,7 +1495,14 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action))
 				if ($object->isProduct() || !empty($conf->global->STOCK_SUPPORTS_SERVICES))
 				{
 					print '<tr><td>'.$langs->trans("ManageLotSerial").'</td><td colspan="3">';
-					$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"));
+					if ( empty($conf->global ->MAIN_ADVANCE_NUMLOT) )
+					{
+						$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"));
+					}
+					else
+					{
+						$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"), '2' => $langs->trans("ProductStatusOnSerial"));
+					}
 					print $form->selectarray('status_batch', $statutarray, $object->status_batch);
 					print '</td></tr>';
 				}
@@ -1996,7 +2010,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action))
 				if ($object->isProduct() || !empty($conf->global->STOCK_SUPPORTS_SERVICES))
 				{
 					print '<tr><td>'.$langs->trans("ManageLotSerial").'</td><td colspan="2">';
-					if (!empty($conf->use_javascript_ajax) && $usercancreate && !empty($conf->global->MAIN_DIRECT_STATUS_UPDATE)) {
+					if (!empty($conf->use_javascript_ajax) && $usercancreate && !empty($conf->global->MAIN_DIRECT_STATUS_UPDATE) && empty($conf->global->MAIN_ADVANCE_NUMLOT)) {
 						print ajax_object_onoff($object, 'status_batch', 'tobatch', 'ProductStatusOnBatch', 'ProductStatusNotOnBatch');
 					} else {
 						print $object->getLibStatut(0, 2);

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1033,8 +1033,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action))
 			{
 				$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"));
 			}
-			else
-			{
+			else {
 				$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"), '2' => $langs->trans("ProductStatusOnSerial"));
 			}
 			print $form->selectarray('status_batch', $statutarray, GETPOST('status_batch'));
@@ -1499,8 +1498,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action))
 					{
 						$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"));
 					}
-					else
-					{
+					else {
 						$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"), '2' => $langs->trans("ProductStatusOnSerial"));
 					}
 					print $form->selectarray('status_batch', $statutarray, $object->status_batch);

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4688,10 +4688,10 @@ class Product extends CommonObject
 			switch ($mode)
 			{
 				case 0:
-					$label = ($status == 0 ? $langs->trans('ProductStatusNotOnBatch') : $langs->trans('ProductStatusOnBatch'));
+                    $label = ($status == 0 ? $langs->trans('ProductStatusNotOnBatch') : ($status == 1 || empty($conf->global->MAIN_ADVANCE_NUMLOT) ? $langs->trans('ProductStatusOnBatch') : $langs->trans('ProductStatusOnSerial')));
 					return dolGetStatus($label);
 				case 1:
-					$label = ($status == 0 ? $langs->trans('ProductStatusNotOnBatchShort') : $langs->trans('ProductStatusOnBatchShort'));
+					$label = ($status == 0 ? $langs->trans('ProductStatusNotOnBatchShort') : ($status == 1 || empty($conf->global->MAIN_ADVANCE_NUMLOT) ? $langs->trans('ProductStatusOnBatchShort') : $langs->trans('ProductStatusOnSerialShort')));
 					return dolGetStatus($label);
 				case 2:
 					return $this->LibStatut($status, 3, 2).' '.$this->LibStatut($status, 1, 2);
@@ -4729,11 +4729,15 @@ class Product extends CommonObject
 				$labelStatus = $langs->trans('ProductStatusOnBuyShort');
 				$labelStatusShort = $langs->trans('ProductStatusOnBuy');
 			} elseif ($type == 2) {
-				$labelStatus = $langs->trans('ProductStatusOnBatch');
-				$labelStatusShort = $langs->trans('ProductStatusOnBatchShort');
+				$labelStatus = ($status == 1 || empty($conf->global->MAIN_ADVANCE_NUMLOT) ? $langs->trans('ProductStatusOnBatch') : $langs->trans('ProductStatusOnSerial'));
+				$labelStatusShort = ($status == 1 || empty($conf->global->MAIN_ADVANCE_NUMLOT) ? $langs->trans('ProductStatusOnBatchShort') : $langs->trans('ProductStatusOnSerialShort'));
 			}
 		}
-
+		elseif ( ! empty($conf->global->MAIN_ADVANCE_NUMLOT) && $type == 2 && $status == 2)
+        {
+			$labelStatus = $langs->trans('ProductStatusOnSerial');
+			$labelStatusShort = $langs->trans('ProductStatusOnSerialShort');
+		}
 
 		if ($mode > 6) {
 			return dolGetStatus($langs->trans('Unknown'), '', '', 'status0', 0);

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5460,7 +5460,7 @@ class Product extends CommonObject
 	 */
 	public function hasbatch()
 	{
-		return ($this->status_batch == 1 ? true : false);
+		return ($this->status_batch > 0 ? true : false);
 	}
 
 

--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -833,7 +833,22 @@ if ($resql)
 	// Stock
 	if (!empty($arrayfields['stock_virtual']['checked'])) print '<td class="liste_titre">&nbsp;</td>';
 	// To batch
-	if (!empty($arrayfields['p.tobatch']['checked'])) print '<td class="liste_titre center">'.$form->selectyesno('search_tobatch', $search_tobatch, 1, false, 1).'</td>';
+	if (!empty($arrayfields['p.tobatch']['checked']))
+	{
+		print '<td class="liste_titre center">';
+
+		if ( empty($conf->global ->MAIN_ADVANCE_NUMLOT) )
+		{
+			print $form->selectyesno('search_tobatch', $search_tobatch, 1, false, 1);
+		}
+		else
+		{
+			$statutarray = array('-1' => '', '0' => $langs->trans("ProductStatusNotOnBatchShort"), '1' => $langs->trans("ProductStatusOnBatchShort"), '2' => $langs->trans("ProductStatusOnSerialShort"));
+			print $form->selectarray('search_tobatch', $statutarray, $search_tobatch);
+		}
+
+		'</td>';
+	}
 	// Country
 	if (!empty($arrayfields['p.fk_country']['checked'])) print '<td class="liste_titre center">'.$form->select_country($search_country, 'search_country', '', 0).'</td>';
 	// State
@@ -1463,7 +1478,14 @@ if ($resql)
 		if (!empty($arrayfields['p.tobatch']['checked']))
 		{
 			print '<td class="center">';
-			print yn($obj->tobatch);
+			if ( empty($conf->global->MAIN_ADVANCE_NUMLOT) )
+			{
+				print yn($obj->tobatch);
+			}
+			else
+			{
+				print $product_static->getLibStatut(1, 2);
+			}
 			print '</td>';
 			if (!$i) $totalarray['nbfield']++;
 		}

--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -840,8 +840,7 @@ if ($resql)
 		if ( empty($conf->global ->MAIN_ADVANCE_NUMLOT) )
 		{
 			print $form->selectyesno('search_tobatch', $search_tobatch, 1, false, 1);
-		}
-		else
+		} else
 		{
 			$statutarray = array('-1' => '', '0' => $langs->trans("ProductStatusNotOnBatchShort"), '1' => $langs->trans("ProductStatusOnBatchShort"), '2' => $langs->trans("ProductStatusOnSerialShort"));
 			print $form->selectarray('search_tobatch', $statutarray, $search_tobatch);
@@ -1482,8 +1481,7 @@ if ($resql)
 			{
 				print yn($obj->tobatch);
 			}
-			else
-			{
+			else {
 				print $product_static->getLibStatut(1, 2);
 			}
 			print '</td>';


### PR DESCRIPTION
add a value to status_batch for a better serial numbers management in batch products.

This is the first commit of many that will lead to better trace equipments with unique product serial numbers.

It was analysed in conjonction with @FHenry and @lmag :

Now there are 3 status on a product : 
0 : No (lot/serial not used)
1 : Lot (required)
2 : Serial number (required)