### PR TITLE
Don't discard previously collected data

### DIFF
--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -449,7 +449,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 				}
 
 				// Replace tags of object + external modules
-				$tmparray = $this->get_substitutionarray_shipment($object, $outputlangs);
+				$tmparray = array_merge($tmparray, $this->get_substitutionarray_shipment($object, $outputlangs));
 
 				complete_substitutions_array($tmparray, $outputlangs, $object);
 				// Call the ODTSubstitution hook


### PR DESCRIPTION
For keeping all previously collected data (i.e. company_... values), one has to merge the array but not to assign a new one.

# Fix #16559
Use merge function to append to the previously built array instead of replacing it.