### PR TITLE
Update list.php wrong number presentation in stock

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -1644,7 +1644,7 @@ if ($resql) {
 					print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
 				}
 				$decimals = !isset($conf->global->MAIN_MAX_DECIMALS_STOCK) ? 5 : $conf->global->MAIN_MAX_DECIMALS_STOCK;
-				print price($product_static->stock_reel, 0, $langs->defaultlang,1,-1,$decimals);
+				print price($product_static->stock_reel, 0, $langs->defaultlang, 1, -1, $decimals);
 				//print price2num($product_static->stock_reel, 'MS');
 			}
 			print '</td>';
@@ -1660,7 +1660,7 @@ if ($resql) {
 					print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
 				}
 				$decimals = !isset($conf->global->MAIN_MAX_DECIMALS_STOCK) ? 5 : $conf->global->MAIN_MAX_DECIMALS_STOCK;
-				print price($product_static->stock_theorique, 0, $langs->defaultlang,1,-1,$decimals);
+				print price($product_static->stock_theorique, 0, $langs->defaultlang, 1, -1, $decimals);
 				//print price2num($product_static->stock_theorique, 'MS');
 			}
 			print '</td>';

--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -1643,7 +1643,9 @@ if ($resql) {
 				if ($obj->seuil_stock_alerte != '' && $product_static->stock_reel < (float) $obj->seuil_stock_alerte) {
 					print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
 				}
-				print price2num($product_static->stock_reel, 'MS');
+				$decimals = !isset($conf->global->MAIN_MAX_DECIMALS_STOCK) ? 5 : $conf->global->MAIN_MAX_DECIMALS_STOCK;
+				print price($product_static->stock_reel, 0, $langs->defaultlang,1,-1,$decimals);
+				//print price2num($product_static->stock_reel, 'MS');
 			}
 			print '</td>';
 			if (!$i) {
@@ -1657,7 +1659,9 @@ if ($resql) {
 				if ($obj->seuil_stock_alerte != '' && $product_static->stock_theorique < (float) $obj->seuil_stock_alerte) {
 					print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
 				}
-				print price2num($product_static->stock_theorique, 'MS');
+				$decimals = !isset($conf->global->MAIN_MAX_DECIMALS_STOCK) ? 5 : $conf->global->MAIN_MAX_DECIMALS_STOCK;
+				print price($product_static->stock_theorique, 0, $langs->defaultlang,1,-1,$decimals);
+				//print price2num($product_static->stock_theorique, 'MS');
 			}
 			print '</td>';
 			if (!$i) {

--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -1643,9 +1643,7 @@ if ($resql) {
 				if ($obj->seuil_stock_alerte != '' && $product_static->stock_reel < (float) $obj->seuil_stock_alerte) {
 					print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
 				}
-				$decimals = !isset($conf->global->MAIN_MAX_DECIMALS_STOCK) ? 5 : $conf->global->MAIN_MAX_DECIMALS_STOCK;
-				print price($product_static->stock_reel, 0, $langs->defaultlang, 1, -1, $decimals);
-				//print price2num($product_static->stock_reel, 'MS');
+				print price(price2num($product_static->stock_reel, 'MS'));
 			}
 			print '</td>';
 			if (!$i) {
@@ -1659,9 +1657,7 @@ if ($resql) {
 				if ($obj->seuil_stock_alerte != '' && $product_static->stock_theorique < (float) $obj->seuil_stock_alerte) {
 					print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
 				}
-				$decimals = !isset($conf->global->MAIN_MAX_DECIMALS_STOCK) ? 5 : $conf->global->MAIN_MAX_DECIMALS_STOCK;
-				print price($product_static->stock_theorique, 0, $langs->defaultlang, 1, -1, $decimals);
-				//print price2num($product_static->stock_theorique, 'MS');
+				print price(price2num($product_static->stock_theorique, 'MS'));
 			}
 			print '</td>';
 			if (!$i) {


### PR DESCRIPTION
Changed the presentation of the stock to show decimals and thousands separator. changes price2num to price and use MAIN_MAX_DECIMALS_STOCK

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #[*issue_number Short description*]
[*Long description*]


# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
