### PR TITLE
Fix/12.0 min php version in composer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"vendor-dir" : "htdocs/includes"
 	},
 	"require" : {
-		"php" : ">=5.5.0",
+		"php" : ">=5.6.0",
 		"ext-curl" : "*",
 		"ckeditor/ckeditor" : "4.12.1",
 		"mike42/escpos-php" : "2.2",


### PR DESCRIPTION
# Minor fix 
The [wiki](https://wiki.dolibarr.org/index.php?title=Prerequisite#PHP) indicates that the oldest supported PHP version is 5.6, but `composer.json` still lists 5.5 as supported.

Many features introduced with PHP 5.6 (such as arbitrary expression arguments inside `empty()` and variadic functions) are already in use but code quality tools report them as "errors" because they use `composer.json` to determine which PHP version the code is supposed to be compatible with.

While not really a bug, this fix would help improve the relevance of code inspections, which in turn will help us improve code quality.