### PR TITLE
round progress percentage

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2055,9 +2055,9 @@ function pdf_getlineprogress($object, $i, $outputlangs, $hidedetails = 0, $hookm
 				if (method_exists($object, 'get_prev_progress')) {
 					$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
 				}
-				$result = ($object->lines[$i]->situation_percent - $prev_progress).'%';
+				$result = round($object->lines[$i]->situation_percent - $prev_progress).'%';
 			} else {
-				$result = $object->lines[$i]->situation_percent.'%';
+				$result = round($object->lines[$i]->situation_percent).'%';
 			}
 		}
 	}


### PR DESCRIPTION
At the moment, progress percentage is not rounded and leads to ugly result on pdf crabe. (50.3945678 % printed on about 1cm !)