### PR TITLE
fix php8 warning

### DIFF
--- a/htdocs/core/boxes/box_last_ticket.php
+++ b/htdocs/core/boxes/box_last_ticket.php
@@ -2,7 +2,7 @@
 /* Module descriptor for ticket system
  * Copyright (C) 2013-2016  Jean-François FERRY <hello@librethic.io>
  * Copyright (C) 2016       Christophe Battarel <christophe@altairis.fr>
- * Copyright (C) 2018-2019  Frédéric France     <frederic.france@netlogic.fr>
+ * Copyright (C) 2018-2021  Frédéric France     <frederic.france@netlogic.fr>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -115,9 +115,9 @@ class box_last_ticket extends ModeleBoxes
 				while ($i < $num) {
 					$objp = $this->db->fetch_object($resql);
 					$datec = $this->db->jdate($objp->datec);
-					$dateterm = $this->db->jdate($objp->fin_validite);
-					$dateclose = $this->db->jdate($objp->date_cloture);
-					$late = '';
+					//$dateterm = $this->db->jdate($objp->fin_validite);
+					//$dateclose = $this->db->jdate($objp->date_close);
+					//$late = '';
 
 					$ticket = new Ticket($this->db);
 					$ticket->id = $objp->id;


### PR DESCRIPTION
Undefined property: stdClass::$fin_validite
Undefined property: stdClass::$date_cloture
$dateterm, $dateclose, $late not used