### PR TITLE
FIX #16143 Old PG requires "()" on DROP FUNCTION

### DIFF
--- a/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
+++ b/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
@@ -579,7 +579,7 @@ insert into llx_c_action_trigger (code,label,description,elementtype,rang) value
 insert into llx_c_action_trigger (code,label,description,elementtype,rang) values ('EXPENSE_REPORT_DELETE','Expense report deleted','Executed when an expense report is deleted','expensereport',205);
 
 -- Removed no more used function
--- VPGSQL8.2 DROP FUNCTION IF EXISTS update_modified_column_date_m CASCADE;
+-- VPGSQL8.2 DROP FUNCTION IF EXISTS update_modified_column_date_m() CASCADE;
 
 insert into llx_c_actioncomm (id, code, type, libelle, module, active, position) values ( 6,'AC_EMAIL_IN','system','reception Email',NULL, 1, 4);
 


### PR DESCRIPTION
On PostgreSQL 9.6 and previous, the upgrade script fails with a syntax
error if the dropped function's name is not followed by parentheses.

Patch tested on PG 9.6 and 13.2.

This patch should probably be backported to the 13.0 branch.