### PR TITLE
FIX : wrong dol_get_fiche_end()

### DIFF
--- a/htdocs/salaries/paiement_salary.php
+++ b/htdocs/salaries/paiement_salary.php
@@ -174,7 +174,7 @@ if ($action == 'create') {
 	print '<input type="hidden" name="chid" value="'.$chid.'">';
 	print '<input type="hidden" name="action" value="add_payment">';
 
-	print dol_get_fiche_end();
+	print dol_get_fiche_head();
 
 	print '<table class="border centpercent">';
 


### PR DESCRIPTION
Hi @eldy, i did here a little correction with a duplicated dol_get_fiche_end

I also have a question about VAT payments and salary payments :

I saw that for salary, we can use an arrow to fill remain amount to pay (like invoices for example), and for vat remain amount to pay is automatically filled.
Wouldn't it be better to uniformize that ?
Do you prefer use this arrow as well as all payment screens of dolibarr or not ?

![image](https://user-images.githubusercontent.com/5585819/112330484-5e5daa80-8cb8-11eb-8703-b5790f2f29f0.png)

![image](https://user-images.githubusercontent.com/5585819/112330523-66b5e580-8cb8-11eb-9b75-a0d588cdb1a3.png)
