### PR TITLE
Fix #16899 New stuff related to excluded members forgotten during transfer to box graph

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -2280,7 +2280,7 @@ class Adherent extends CommonObject
 			$labelStatus = $langs->trans("MemberStatusResiliated");
 			$labelStatusShort = $langs->trans("MemberStatusResiliatedShort");
 		} elseif ($status == -2) {
-			$statusType = 'status8';
+			$statusType = 'status10';
 			$labelStatus = $langs->trans("MemberStatusExcluded");
 			$labelStatusShort = $langs->trans("MemberStatusExcludedShort");
 		}

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -2279,7 +2279,7 @@ class Adherent extends CommonObject
 			$labelStatus = $langs->trans("MemberStatusResiliated");
 			$labelStatusShort = $langs->trans("MemberStatusResiliatedShort");
 		} elseif ($status == -2) {
-			$statusType = 'status10';
+			$statusType = 'status8';
 			$labelStatus = $langs->trans("MemberStatusExcluded");
 			$labelStatusShort = $langs->trans("MemberStatusExcludedShort");
 		}

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -13,6 +13,7 @@
  * Copyright (C) 2018-2019	Thibault FOUCART		<support@ptibogxiv.net>
  * Copyright (C) 2019		Nicolas ZABOURI 		<info@inovea-conseil.com>
  * Copyright (C) 2020		Josep Lluís Amador 		<joseplluis@lliuretic.cat>
+ * Copyright (C) 2021           Waël Almoman                    <wael@almoman.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -13,7 +13,7 @@
  * Copyright (C) 2018-2019	Thibault FOUCART		<support@ptibogxiv.net>
  * Copyright (C) 2019		Nicolas ZABOURI 		<info@inovea-conseil.com>
  * Copyright (C) 2020		Josep Lluís Amador 		<joseplluis@lliuretic.cat>
- * Copyright (C) 2021           Waël Almoman                    <wael@almoman.com>
+ * Copyright (C) 2021           Waël Almoman                    <info@almoman.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/adherents/class/adherent_type.class.php
+++ b/htdocs/adherents/class/adherent_type.class.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2009-2017	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2016		Charlie Benke			<charlie@patas-monkey.com>
  * Copyright (C) 2018-2019  Thibault Foucart		<support@ptibogxiv.net>
- * Copyright (C) 2021           Waël Almoman            <wael@almoman.com>
+ * Copyright (C) 2021           Waël Almoman            <info@almoman.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/adherents/class/adherent_type.class.php
+++ b/htdocs/adherents/class/adherent_type.class.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2009-2017	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2016		Charlie Benke			<charlie@patas-monkey.com>
  * Copyright (C) 2018-2019  Thibault Foucart		<support@ptibogxiv.net>
+ * Copyright (C) 2021           Waël Almoman            <wael@almoman.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/adherents/index.php
+++ b/htdocs/adherents/index.php
@@ -234,7 +234,7 @@ if ($conf->use_javascript_ajax) {
 	include_once DOL_DOCUMENT_ROOT.'/core/class/dolgraph.class.php';
 	$dolgraph = new DolGraph();
 	$dolgraph->SetData($dataseries);
-	$dolgraph->SetDataColor(array($badgeStatus1, $badgeStatus4, $badgeStatus8, $badgeStatus6, '-'.$badgeStatus0));
+	$dolgraph->SetDataColor(array($badgeStatus1, $badgeStatus4, '-'.$badgeStatus8, $badgeStatus6, '-'.$badgeStatus0));
 	$dolgraph->setShowLegend(2);
 	$dolgraph->setShowPercent(1);
 	$dolgraph->SetType(array('pie'));

--- a/htdocs/adherents/index.php
+++ b/htdocs/adherents/index.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2005-2012	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2019       Nicolas ZABOURI         <info@inovea-conseil.com>
  * Copyright (C) 2021		Frédéric France			<frederic.france@netlgic.fr>
+ * Copyright (C) 2021       Waël Almoman            <wael@almoman.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/adherents/index.php
+++ b/htdocs/adherents/index.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2005-2012	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2019       Nicolas ZABOURI         <info@inovea-conseil.com>
  * Copyright (C) 2021		Frédéric France			<frederic.france@netlgic.fr>
- * Copyright (C) 2021       Waël Almoman            <wael@almoman.com>
+ * Copyright (C) 2021       Waël Almoman            <info@almoman.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/adherents/index.php
+++ b/htdocs/adherents/index.php
@@ -233,7 +233,7 @@ if ($conf->use_javascript_ajax) {
 	include_once DOL_DOCUMENT_ROOT.'/core/class/dolgraph.class.php';
 	$dolgraph = new DolGraph();
 	$dolgraph->SetData($dataseries);
-	$dolgraph->SetDataColor(array($badgeStatus1, $badgeStatus4, '-'.$badgeStatus8, $badgeStatus6, '-'.$badgeStatus0));
+	$dolgraph->SetDataColor(array($badgeStatus1, $badgeStatus4, $badgeStatus8, $badgeStatus6, '-'.$badgeStatus0));
 	$dolgraph->setShowLegend(2);
 	$dolgraph->setShowPercent(1);
 	$dolgraph->SetType(array('pie'));

--- a/htdocs/core/boxes/box_members_by_type.php
+++ b/htdocs/core/boxes/box_members_by_type.php
@@ -135,7 +135,7 @@ class box_members_by_type extends ModeleBoxes
 						$MembersValidated[$objp->rowid] = $objp->somme;
 					}
 					if ($objp->statut == -2) {
-					    $MembersExcluded[$objp->rowid] = $objp->somme;
+						$MembersExcluded[$objp->rowid] = $objp->somme;
 					}
 					if ($objp->statut == 0) {
 						$MembersResiliated[$objp->rowid] = $objp->somme;
@@ -187,8 +187,8 @@ class box_members_by_type extends ModeleBoxes
 					'text' => $langs->trans("UpToDate"),
 				);
 				$this->info_box_contents[$line][] = array(
-				    'td' => 'class="right"',
-				    'text' => $langs->trans("MembersStatusExcluded"),
+					'td' => 'class="right"',
+					'text' => $langs->trans("MembersStatusExcluded"),
 				);
 				$this->info_box_contents[$line][] = array(
 					'td' => 'class="right"',
@@ -196,13 +196,12 @@ class box_members_by_type extends ModeleBoxes
 				);
 				$line++;
 				foreach ($AdherentType as $key => $adhtype) {
-				    
-				    $SumToValidate += isset($MembersToValidate[$key]) ? $MembersToValidate[$key] : 0;
-				    $SumValidated += isset($MembersValidated[$key]) ? $MembersValidated[$key] - (isset($MembersUpToDate[$key]) ? $MembersUpToDate[$key] : 0) : 0;
-				    $SumUpToDate += isset($MembersUpToDate[$key]) ? $MembersUpToDate[$key] : 0;
-				    $SumExcluded += isset($MembersExcluded[$key]) ? $MembersExcluded [$key] : 0;
-				    $SumResiliated += isset($MembersResiliated[$key]) ? $MembersResiliated[$key] : 0;
-				    
+					$SumToValidate += isset($MembersToValidate[$key]) ? $MembersToValidate[$key] : 0;
+					$SumValidated += isset($MembersValidated[$key]) ? $MembersValidated[$key] - (isset($MembersUpToDate[$key]) ? $MembersUpToDate[$key] : 0) : 0;
+					$SumUpToDate += isset($MembersUpToDate[$key]) ? $MembersUpToDate[$key] : 0;
+					$SumExcluded += isset($MembersExcluded[$key]) ? $MembersExcluded [$key] : 0;
+					$SumResiliated += isset($MembersResiliated[$key]) ? $MembersResiliated[$key] : 0;
+
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="tdoverflowmax150 maxwidth150onsmartphone"',
 						'text' => $adhtype->getNomUrl(1, dol_size(32)),
@@ -224,9 +223,9 @@ class box_members_by_type extends ModeleBoxes
 						'asis' => 1,
 					);
 					$this->info_box_contents[$line][] = array(
-					    'td' => 'class="right"',
-					    'text' => (isset($MembersExcluded[$key]) && $MembersExcluded[$key] > 0 ? $MembersExcluded[$key] : '') . ' ' . $staticmember->LibStatut(-2, 1, $now, 3),
-					    'asis' => 1,
+						'td' => 'class="right"',
+						'text' => (isset($MembersExcluded[$key]) && $MembersExcluded[$key] > 0 ? $MembersExcluded[$key] : '') . ' ' . $staticmember->LibStatut(-2, 1, $now, 3),
+						'asis' => 1,
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="right"',
@@ -236,7 +235,7 @@ class box_members_by_type extends ModeleBoxes
 
 					$line++;
 				}
-				
+
 				if ($num == 0) {
 					$this->info_box_contents[$line][0] = array(
 						'td' => 'class="center"',
@@ -249,27 +248,27 @@ class box_members_by_type extends ModeleBoxes
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="liste_total right"',
-					    'text' => $SumToValidate.' '.$staticmember->LibStatut(-1, 1, 0, 3),
+						'text' => $SumToValidate.' '.$staticmember->LibStatut(-1, 1, 0, 3),
 						'asis' => 1
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="liste_total right"',
-					    'text' => $SumValidated.' '.$staticmember->LibStatut(1, 1, 0, 3),
+						'text' => $SumValidated.' '.$staticmember->LibStatut(1, 1, 0, 3),
 						'asis' => 1
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="liste_total right"',
-					    'text' => $SumUpToDate.' '.$staticmember->LibStatut(1, 1, $now, 3),
+						'text' => $SumUpToDate.' '.$staticmember->LibStatut(1, 1, $now, 3),
 						'asis' => 1
 					);
 					$this->info_box_contents[$line][] = array(
-					    'td' => 'class="liste_total right"',
-					    'text' => $SumExcluded.' '.$staticmember->LibStatut(-2, 1, 0, 3),
-					    'asis' => 1
+						'td' => 'class="liste_total right"',
+						'text' => $SumExcluded.' '.$staticmember->LibStatut(-2, 1, 0, 3),
+						'asis' => 1
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="liste_total right"',
-					    'text' => $SumResiliated.' '.$staticmember->LibStatut(0, 1, 0, 3),
+						'text' => $SumResiliated.' '.$staticmember->LibStatut(0, 1, 0, 3),
 						'asis' => 1
 					);
 				}

--- a/htdocs/core/boxes/box_members_by_type.php
+++ b/htdocs/core/boxes/box_members_by_type.php
@@ -236,7 +236,7 @@ class box_members_by_type extends ModeleBoxes
 
 					$line++;
 				}
-
+				
 				if ($num == 0) {
 					$this->info_box_contents[$line][0] = array(
 						'td' => 'class="center"',
@@ -249,27 +249,27 @@ class box_members_by_type extends ModeleBoxes
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="liste_total right"',
-						'text' => $SommeA.' '.$staticmember->LibStatut(-1, 1, 0, 3),
+					    'text' => $SumToValidate.' '.$staticmember->LibStatut(-1, 1, 0, 3),
 						'asis' => 1
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="liste_total right"',
-						'text' => $SommeB.' '.$staticmember->LibStatut(1, 1, 0, 3),
+					    'text' => $SumValidated.' '.$staticmember->LibStatut(1, 1, 0, 3),
 						'asis' => 1
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="liste_total right"',
-						'text' => $SommeC.' '.$staticmember->LibStatut(1, 1, $now, 3),
+					    'text' => $SumUpToDate.' '.$staticmember->LibStatut(1, 1, $now, 3),
 						'asis' => 1
 					);
 					$this->info_box_contents[$line][] = array(
 					    'td' => 'class="liste_total right"',
-					    'text' => $SommeD.' '.$staticmember->LibStatut(-2, 1, 0, 3),
+					    'text' => $SumExcluded.' '.$staticmember->LibStatut(-2, 1, 0, 3),
 					    'asis' => 1
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="liste_total right"',
-						'text' => $SommeD.' '.$staticmember->LibStatut(0, 1, 0, 3),
+					    'text' => $SumResiliated.' '.$staticmember->LibStatut(0, 1, 0, 3),
 						'asis' => 1
 					);
 				}

--- a/htdocs/core/boxes/box_members_by_type.php
+++ b/htdocs/core/boxes/box_members_by_type.php
@@ -93,12 +93,14 @@ class box_members_by_type extends ModeleBoxes
 			$MembersToValidate = array();
 			$MembersValidated = array();
 			$MemberUpToDate = array();
+			$MembersExcluded = array();
 			$MembersResiliated = array();
 
-			$SommeA = 0;
-			$SommeB = 0;
-			$SommeC = 0;
-			$SommeD = 0;
+			$SumToValidate = 0;
+			$SumValidated = 0;
+			$SumUpToDate = 0;
+			$SumResiliated = 0;
+			$SumExcluded = 0;
 
 			$AdherentType = array();
 
@@ -131,6 +133,9 @@ class box_members_by_type extends ModeleBoxes
 					}
 					if ($objp->statut == 1) {
 						$MembersValidated[$objp->rowid] = $objp->somme;
+					}
+					if ($objp->statut == -2) {
+					    $MembersExcluded[$objp->rowid] = $objp->somme;
 					}
 					if ($objp->statut == 0) {
 						$MembersResiliated[$objp->rowid] = $objp->somme;
@@ -182,15 +187,22 @@ class box_members_by_type extends ModeleBoxes
 					'text' => $langs->trans("UpToDate"),
 				);
 				$this->info_box_contents[$line][] = array(
+				    'td' => 'class="right"',
+				    'text' => $langs->trans("MembersStatusExcluded"),
+				);
+				$this->info_box_contents[$line][] = array(
 					'td' => 'class="right"',
 					'text' => $langs->trans("MembersStatusResiliated"),
 				);
 				$line++;
 				foreach ($AdherentType as $key => $adhtype) {
-					$SommeA += isset($MembersToValidate[$key]) ? $MembersToValidate[$key] : 0;
-					$SommeB += isset($MembersValidated[$key]) ? $MembersValidated[$key] - (isset($MemberUpToDate[$key]) ? $MemberUpToDate[$key] : 0) : 0;
-					$SommeC += isset($MemberUpToDate[$key]) ? $MemberUpToDate[$key] : 0;
-					$SommeD += isset($MembersResiliated[$key]) ? $MembersResiliated[$key] : 0;
+				    
+				    $SumToValidate += isset($MembersToValidate[$key]) ? $MembersToValidate[$key] : 0;
+				    $SumValidated += isset($MembersValidated[$key]) ? $MembersValidated[$key] - (isset($MembersUpToDate[$key]) ? $MembersUpToDate[$key] : 0) : 0;
+				    $SumUpToDate += isset($MembersUpToDate[$key]) ? $MembersUpToDate[$key] : 0;
+				    $SumExcluded += isset($MembersExcluded[$key]) ? $MembersExcluded [$key] : 0;
+				    $SumResiliated += isset($MembersResiliated[$key]) ? $MembersResiliated[$key] : 0;
+				    
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="tdoverflowmax150 maxwidth150onsmartphone"',
 						'text' => $adhtype->getNomUrl(1, dol_size(32)),
@@ -210,6 +222,11 @@ class box_members_by_type extends ModeleBoxes
 						'td' => 'class="right"',
 						'text' => (isset($MemberUpToDate[$key]) && $MemberUpToDate[$key] > 0 ? $MemberUpToDate[$key] : '') . ' ' . $staticmember->LibStatut(1, 1, $now, 3),
 						'asis' => 1,
+					);
+					$this->info_box_contents[$line][] = array(
+					    'td' => 'class="right"',
+					    'text' => (isset($MembersExcluded[$key]) && $MembersExcluded[$key] > 0 ? $MembersExcluded[$key] : '') . ' ' . $staticmember->LibStatut(-2, 1, $now, 3),
+					    'asis' => 1,
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="right"',
@@ -244,6 +261,11 @@ class box_members_by_type extends ModeleBoxes
 						'td' => 'class="liste_total right"',
 						'text' => $SommeC.' '.$staticmember->LibStatut(1, 1, $now, 3),
 						'asis' => 1
+					);
+					$this->info_box_contents[$line][] = array(
+					    'td' => 'class="liste_total right"',
+					    'text' => $SommeD.' '.$staticmember->LibStatut(-2, 1, 0, 3),
+					    'asis' => 1
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="liste_total right"',

--- a/htdocs/core/boxes/box_members_by_type.php
+++ b/htdocs/core/boxes/box_members_by_type.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2004-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2015-2020 Frederic France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2021      Waël Almoman         <info@almoman.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
# Fix missing new excluded member in box_members_by_type
when migrating from adherents/index.php, it seems that the new status was forgotten
# Fix use English for coding in box_members_by_type
Translation Somme A to SumToValidate, etc.
# Fix use a plain red disc instead of a read circle to list excluded member
It's more logical to use the plain disc in the graph (as we do for the out-of-date witch should be an orange circle but we use a plain orange disc)
### ACTUALLY
![image](https://user-images.githubusercontent.com/8067223/112722504-44b3a180-8f0a-11eb-92fd-90e2b06f81ed.png)
### WITH PR 
![image](https://user-images.githubusercontent.com/8067223/112720779-d7e7d980-8f00-11eb-80e5-361326aa2df2.png)
