### PR TITLE
FIX 13.0 warning - missing quotes around 'label'

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -7207,7 +7207,7 @@ class Form
 						print '<td class="center">'.$objp->ref.'</td>';
 						print '<td>'.(!empty($objp->ref_client) ? $objp->ref_client : $objp->ref_supplier).'</td>';
 						print '<td class="right">';
-						if ($possiblelink[label] == 'LinkToContract') {
+						if ($possiblelink['label'] == 'LinkToContract') {
 							$form = new Form($db);
 							print $form->textwithpicto('', $langs->trans("InformationOnLinkToContract")).' ';
 						}


### PR DESCRIPTION
# FIX 13.0 warning - missing quotes around `label`
`label` is not a constant, it is a string used as an array key. This is a minor fix.