### PR TITLE
NEW Add support for Friday as a holiday

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -687,8 +687,8 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 		$country_code = $mysoc->country_code;
 	}
 	if ($includefriday < 0) {
-                $includefriday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY : 1);
-        }
+				$includefriday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY : 1);
+	}
 	if ($includesaturday < 0) {
 		$includesaturday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY : 1);
 	}
@@ -845,10 +845,10 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 				$jour_julien = unixtojd($timestampStart);
 				$jour_semaine = jddayofweek($jour_julien, 0);
 				if ($includefriday) {					//Friday (5), Saturday (6) and Sunday (0)
-                                        if ($jour_semaine == 5) {
-                                                $ferie = true;
-                                        }
-                                }
+					if ($jour_semaine == 5) {
+							$ferie = true;
+					}
+				}
 				if ($includesaturday) {					//Friday (5), Saturday (6) and Sunday (0)
 					if ($jour_semaine == 6) {
 						$ferie = true;

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -658,20 +658,21 @@ function getGMTEasterDatetime($year)
 }
 
 /**
- *	Return the number of non working days including saturday and sunday (or not) between 2 dates in timestamp.
+ *  Return the number of non working days including saturday and sunday (or not) between 2 dates in timestamp.
  *  Dates must be UTC with hour, min, sec to 0.
- *	Called by function num_open_day()
+ *  Called by function num_open_day()
  *
- *	@param	    int			$timestampStart     Timestamp start (UTC with hour, min, sec = 0)
- *	@param	    int			$timestampEnd       Timestamp end (UTC with hour, min, sec = 0)
- *  @param      string		$country_code       Country code
- *	@param      int			$lastday            Last day is included, 0: no, 1:yes
- *  @param		int			$includesaturday	Include saturday as non working day (-1=use setup, 0=no, 1=yes)
- *  @param		int			$includesunday		Include sunday as non working day (-1=use setup, 0=no, 1=yes)
- *	@return   	int|string						Number of non working days or error message string if error
+ *  @param	int			$timestampStart		Timestamp start (UTC with hour, min, sec = 0)
+ *  @param	int			$timestampEnd		Timestamp end (UTC with hour, min, sec = 0)
+ *  @param	string			$country_code		Country code
+ *  @param	int			$lastday		Last day is included, 0: no, 1:yes
+ *  @param	int                     $includefriday		Include friday as non working day (-1=use setup, 0=no, 1=yes)
+ *  @param	int			$includesaturday	Include saturday as non working day (-1=use setup, 0=no, 1=yes)
+ *  @param	int			$includesunday		Include sunday as non working day (-1=use setup, 0=no, 1=yes)
+ *  @return   	int|string					Number of non working days or error message string if error
  *  @see num_between_day(), num_open_day()
  */
-function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', $lastday = 0, $includesaturday = -1, $includesunday = -1)
+function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', $lastday = 0, $includefriday = -1, $includesaturday = -1, $includesunday = -1)
 {
 	global $db, $conf, $mysoc;
 
@@ -685,7 +686,9 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 	if (empty($country_code)) {
 		$country_code = $mysoc->country_code;
 	}
-
+	if ($includefriday < 0) {
+                $includefriday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY : 1);
+        }
 	if ($includesaturday < 0) {
 		$includesaturday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY : 1);
 	}
@@ -838,15 +841,20 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 
 		// If we have to include saturday and sunday
 		if (!$ferie) {
-			if ($includesaturday || $includesunday) {
+			if ($includefriday || $includesaturday || $includesunday) {
 				$jour_julien = unixtojd($timestampStart);
 				$jour_semaine = jddayofweek($jour_julien, 0);
-				if ($includesaturday) {					//Saturday (6) and Sunday (0)
+				if ($includefriday) {					//Friday (5), Saturday (6) and Sunday (0)
+                                        if ($jour_semaine == 5) {
+                                                $ferie = true;
+                                        }
+                                }
+				if ($includesaturday) {					//Friday (5), Saturday (6) and Sunday (0)
 					if ($jour_semaine == 6) {
 						$ferie = true;
 					}
 				}
-				if ($includesunday) {						//Saturday (6) and Sunday (0)
+				if ($includesunday) {					//Friday (5), Saturday (6) and Sunday (0)
 					if ($jour_semaine == 0) {
 						$ferie = true;
 					}

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -658,7 +658,7 @@ function getGMTEasterDatetime($year)
 }
 
 /**
- *  Return the number of non working days including saturday and sunday (or not) between 2 dates in timestamp.
+ *  Return the number of non working days including Friday, Saturday and Sunday (or not) between 2 dates in timestamp.
  *  Dates must be UTC with hour, min, sec to 0.
  *  Called by function num_open_day()
  *
@@ -687,7 +687,7 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 		$country_code = $mysoc->country_code;
 	}
 	if ($includefriday < 0) {
-				$includefriday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY : 1);
+				$includefriday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY : 0);
 	}
 	if ($includesaturday < 0) {
 		$includesaturday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY : 1);
@@ -839,7 +839,7 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 		}
 		//print "ferie=".$ferie."\n";
 
-		// If we have to include saturday and sunday
+		// If we have to include Friday, Saturday and Sunday
 		if (!$ferie) {
 			if ($includefriday || $includesaturday || $includesunday) {
 				$jour_julien = unixtojd($timestampStart);

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -672,7 +672,7 @@ function getGMTEasterDatetime($year)
  *  @return   	int|string					Number of non working days or error message string if error
  *  @see num_between_day(), num_open_day()
  */
-function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', $lastday = 0, $includefriday = -1, $includesaturday = -1, $includesunday = -1)
+function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', $lastday = 0, $includesaturday = -1, $includesunday = -1, $includefriday = -1)
 {
 	global $db, $conf, $mysoc;
 
@@ -687,7 +687,7 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 		$country_code = $mysoc->country_code;
 	}
 	if ($includefriday < 0) {
-				$includefriday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY : 0);
+		$includefriday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY : 0);
 	}
 	if ($includesaturday < 0) {
 		$includesaturday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY : 1);

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -666,9 +666,9 @@ function getGMTEasterDatetime($year)
  *  @param	int			$timestampEnd		Timestamp end (UTC with hour, min, sec = 0)
  *  @param	string			$country_code		Country code
  *  @param	int			$lastday		Last day is included, 0: no, 1:yes
- *  @param	int			$includefriday		Include friday as non working day (-1=use setup, 0=no, 1=yes)
  *  @param	int			$includesaturday	Include saturday as non working day (-1=use setup, 0=no, 1=yes)
  *  @param	int			$includesunday		Include sunday as non working day (-1=use setup, 0=no, 1=yes)
+ *  @param	int			$includefriday		Include friday as non working day (-1=use setup, 0=no, 1=yes)
  *  @return	int|string					Number of non working days or error message string if error
  *  @see num_between_day(), num_open_day()
  */

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -666,10 +666,10 @@ function getGMTEasterDatetime($year)
  *  @param	int			$timestampEnd		Timestamp end (UTC with hour, min, sec = 0)
  *  @param	string			$country_code		Country code
  *  @param	int			$lastday		Last day is included, 0: no, 1:yes
- *  @param	int                     $includefriday		Include friday as non working day (-1=use setup, 0=no, 1=yes)
+ *  @param	int			$includefriday		Include friday as non working day (-1=use setup, 0=no, 1=yes)
  *  @param	int			$includesaturday	Include saturday as non working day (-1=use setup, 0=no, 1=yes)
  *  @param	int			$includesunday		Include sunday as non working day (-1=use setup, 0=no, 1=yes)
- *  @return   	int|string					Number of non working days or error message string if error
+ *  @return	int|string					Number of non working days or error message string if error
  *  @see num_between_day(), num_open_day()
  */
 function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', $lastday = 0, $includesaturday = -1, $includesunday = -1, $includefriday = -1)
@@ -693,7 +693,7 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 		$includesaturday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY : 1);
 	}
 	if ($includesunday < 0) {
-		$includesunday   = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SUNDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SUNDAY : 1);
+		$includesunday = (isset($conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SUNDAY) ? $conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SUNDAY : 1);
 	}
 
 	$country_id = dol_getIdFromCode($db, $country_code, 'c_country', 'code', 'rowid');


### PR DESCRIPTION
# New [Add Support for Friday as a Holiday]
[Currently only Saturday and Sunday are supported for holiday calculation, this adds Friday as an option as well. The variables have to be added in Setup -> Other Setup "MAIN_NON_WORKING_DAYS_INCLUDE_FRIDAY", "MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY", "MAIN_NON_WORKING_DAYS_INCLUDE_SUNDAY" with 1 for yes and 0 for no. Currently Saturday and Sunday seems to be considered holidays by default.]
