### PR TITLE
Fix empty $sublang dolSavePageAlias

### DIFF
--- a/htdocs/core/lib/website2.lib.php
+++ b/htdocs/core/lib/website2.lib.php
@@ -104,7 +104,7 @@ function dolSavePageAlias($filealias, $object, $objectpage)
 	}
 	// Save also alias into all language subdirectories if it is a main language
 	elseif (empty($objectpage->lang) || !in_array($objectpage->lang, explode(',', $object->otherlang))) {
-		if (empty($conf->global->WEBSITE_DISABLE_MAIN_LANGUAGE_INTO_LANGSUBDIR)) {
+		if (empty($conf->global->WEBSITE_DISABLE_MAIN_LANGUAGE_INTO_LANGSUBDIR) && !empty($object->otherlang)) {
 			$dirname = dirname($filealias);
 			$filename = basename($filealias);
 			foreach (explode(',', $object->otherlang) as $sublang) {


### PR DESCRIPTION
Dolibarr version : 13.2
Php version : 7.3

When call dolSavePageAlias(), avoid to loop on `explode(',', $object->otherlang)` if
`$object->otherlang` is empty. Else we loop once on empty string which
is set in `$sublang` and the path defined in `$filealiassub` point to the main alias file in the root of the web site reather the alias page in a sub lang dir. The generated page expects to be in a sub lang directory and the php code that putted in it require the real template page in parrent directory (`if (empty($dolibarr_main_data_root)) require \'../page'.$objectpage->id.'.tpl.php\';`), but since the page is in the root of web site directory the `require` can't found the page template in parent dir and it raise a php error.

