### PR TITLE
13.0-fix16323

### DIFF
--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -305,8 +305,10 @@ class doc_generic_order_odt extends ModelePDFCommandes
 				$contactobject = null;
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a CUSTOMER contact and we dont use as recipient we store the contact object for later use

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -305,7 +305,7 @@ class doc_generic_order_odt extends ModelePDFCommandes
 				$contactobject = null;
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
+++ b/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
@@ -291,8 +291,7 @@ class doc_generic_contract_odt extends ModelePDFContract
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$object->contact->fetch_thirdparty();
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;
 					} else {

--- a/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
+++ b/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
@@ -291,8 +291,10 @@ class doc_generic_contract_odt extends ModelePDFContract
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a CUSTOMER contact and we dont use as recipient we store the contact object for later use

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -304,8 +304,10 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a SHIPPING contact and we dont use as recipient we store the contact object for later use

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -304,7 +304,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -305,8 +305,10 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a BILLING contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -305,7 +305,7 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
+++ b/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
@@ -282,8 +282,10 @@ class doc_generic_member_odt extends ModelePDFMember
 
 				// Recipient name
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a CUSTOMER contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
+++ b/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
@@ -282,7 +282,7 @@ class doc_generic_member_odt extends ModelePDFMember
 
 				// Recipient name
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
+++ b/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
@@ -299,7 +299,7 @@ class doc_generic_mo_odt extends ModelePDFMo
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
+++ b/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
@@ -299,8 +299,10 @@ class doc_generic_mo_odt extends ModelePDFMo
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 			   			// if we have a CUSTOMER contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
+++ b/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
@@ -316,7 +316,7 @@ class doc_generic_product_odt extends ModelePDFProduct
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
+++ b/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
@@ -316,8 +316,10 @@ class doc_generic_product_odt extends ModelePDFProduct
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a CUSTOMER contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -335,8 +335,10 @@ class doc_generic_proposal_odt extends ModelePDFPropales
 				$contactobject = null;
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a CUSTOMER contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -335,7 +335,7 @@ class doc_generic_proposal_odt extends ModelePDFPropales
 				$contactobject = null;
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
+++ b/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
@@ -295,8 +295,10 @@ class doc_generic_reception_odt extends ModelePdfReception
 
 				// Recipient name
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a BILLING contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
+++ b/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
@@ -295,7 +295,7 @@ class doc_generic_reception_odt extends ModelePdfReception
 
 				// Recipient name
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
@@ -295,8 +295,10 @@ class doc_generic_supplier_order_odt extends ModelePDFSuppliersOrders
 				$contactobject = null;
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 			   			// if we have a CUSTOMER contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
@@ -295,7 +295,7 @@ class doc_generic_supplier_order_odt extends ModelePDFSuppliersOrders
 				$contactobject = null;
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
@@ -331,8 +331,10 @@ class doc_generic_supplier_proposal_odt extends ModelePDFSupplierProposal
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a BILLING contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
@@ -331,7 +331,7 @@ class doc_generic_supplier_proposal_odt extends ModelePDFSupplierProposal
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
+++ b/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
@@ -290,8 +290,10 @@ class doc_generic_ticket_odt extends ModelePDFTicket
 				// Recipient name
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a CUSTOMER contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
+++ b/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
@@ -290,7 +290,7 @@ class doc_generic_ticket_odt extends ModelePDFTicket
 				// Recipient name
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
+++ b/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
@@ -324,8 +324,10 @@ class doc_generic_user_odt extends ModelePDFUser
 				// Recipient name
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a CUSTOMER contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
+++ b/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
@@ -324,7 +324,7 @@ class doc_generic_user_odt extends ModelePDFUser
 				// Recipient name
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;

--- a/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
+++ b/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
@@ -314,8 +314,10 @@ class doc_generic_usergroup_odt extends ModelePDFUserGroup
 				// Recipient name
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
-						$socobject = $object->contact;
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+						$object->contact->fetch_thirdparty();
+						$socobject = $object->contact->thirdparty;
+						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
 						// if we have a CUSTOMER contact and we dont use it as recipient we store the contact object for later use

--- a/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
+++ b/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
@@ -314,7 +314,7 @@ class doc_generic_usergroup_odt extends ModelePDFUserGroup
 				// Recipient name
 				if (!empty($usecontact))
 				{
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
 						$contactobject = $object->contact;


### PR DESCRIPTION
# Fix #16323
[*Long description*]

This is a new bug in V13 in php-scripts htdocs/core/modules/xxx/doc/doc_generic_xxx_odt.modules.php

The following line makes no sense, because !isset OR !empty is always true:

if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))))

Also the following line makes no sense

$socobject = $object->contact;

because $socobject should be a Societe object and not contact
