### PR TITLE
Fix error on module builder delete of a property

### DIFF
--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -1296,6 +1296,9 @@ if ($dirins && $action == 'addproperty' && !empty($module) && !empty($tabobj)) {
 if ($dirins && $action == 'confirm_deleteproperty' && $propertykey) {
 	$objectname = $tabobj;
 
+	$dirins = $dirread = $listofmodules[strtolower($module)]['moduledescriptorrootpath'];
+	$moduletype = $listofmodules[strtolower($module)]['moduletype'];
+
 	$srcdir = $dirread.'/'.strtolower($module);
 	$destdir = $dirins.'/'.strtolower($module);
 	dol_mkdir($destdir);


### PR DESCRIPTION
Fix of an error with modules we couldn't delete an object property in module builder
