### PR TITLE
Fix use json when storing array constant

### DIFF
--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -548,7 +548,7 @@ function dolibarr_get_const($db, $name, $entity = 1)
 	global $conf;
 	$value = '';
 
-	$sql = "SELECT ".$db->decrypt('value')." as value";";
+	$sql = "SELECT ".$db->decrypt('value')." as value";
 	$sql .= " , type";
 	$sql .= " FROM ".MAIN_DB_PREFIX."const";
 	$sql .= " WHERE name = ".$db->encrypt($name, 1);

--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -549,7 +549,7 @@ function dolibarr_get_const($db, $name, $entity = 1)
 	$value = '';
 
 	$sql = "SELECT ".$db->decrypt('value')." as value";";
-	$sql .= " , type "
+	$sql .= " , type";
 	$sql .= " FROM ".MAIN_DB_PREFIX."const";
 	$sql .= " WHERE name = ".$db->encrypt($name, 1);
 	$sql .= " AND entity = ".$entity;

--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -587,12 +587,12 @@ function dolibarr_set_const($db, $name, $value, $type = 'string', $visible = 0, 
 	// use string instead of chaine
 	$type = $type == 'chaine' ? 'string' : $type;
 
-	// TODO activate verify type 
+	// TODO activate verify type
 	// $is_type_function = $type == 'yesno' ? 'is_integer' : is_'.$type;
 	// $name = $is_type_function($value) ? $name : '';
-	
+
 	// Encode with JSON if value is an array to store in DB
-	$value = is_array ($value) ? json_encode ($value) : $value;
+	$value = is_array($value) ? json_encode($value) : $value;
 
 	// Clean parameters
 	$name = trim($name);


### PR DESCRIPTION
Fix use json  when storing array constant
When setting an array as a constant, it should store it using JSON encode / decode to be sure.