### PR TITLE
Fix: #16452 Dates in perweek.ph are shifted by one

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -680,7 +680,7 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 	/**
 	 * This bit checks that the date we received is actually a GMT date. It doesn't
 	 * matter what date we're checking against, since the UTC clock does not have
-	 * daylight savings, but it's important that the timestamp represents a UTC 
+	 * daylight savings, but it's important that the timestamp represents a UTC
 	 * midnight time.
 	 */
 	if (((dol_mktime(0, 0, 0, 10, 10, 2020, true) - $timestampStart) % 86400) != 0) {

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -677,6 +677,16 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 
 	$nbFerie = 0;
 
+	/**
+	 * This bit checks that the date we received is actually a GMT date. It doesn't
+	 * matter what date we're checking against, since the UTC clock does not have
+	 * daylight savings, but it's important that the timestamp represents a UTC 
+	 * midnight time.
+	 */
+	if (((dol_mktime(0, 0, 0, 10, 10, 2020, true) - $timestampStart) % 86400) != 0) {
+		die('Error: Dates must be GMT dates');
+	}
+
 	// Check to ensure we use correct parameters
 	if ((($timestampEnd - $timestampStart) % 86400) != 0) {
 		return 'Error Dates must use same hours and must be GMT dates';

--- a/htdocs/projet/activity/perweek.php
+++ b/htdocs/projet/activity/perweek.php
@@ -98,7 +98,8 @@ $next_month = $next['month'];
 $next_day   = $next['day'];
 
 // Define firstdaytoshow and lastdaytoshow (warning: lastdaytoshow is last second to show + 1)
-$firstdaytoshow = dol_mktime(0, 0, 0, $first_month, $first_day, $first_year, true);
+$firstdaytoshow = dol_mktime(0, 0, 0, $first_month, $first_day, $first_year);
+$utcOffset = $firstdaytoshow - dol_mktime(0, 0, 0, $first_month, $first_day, $first_year, true);
 $lastdaytoshow = dol_time_plus_duree($firstdaytoshow, 7, 'd');
 
 if (empty($search_usertoprocessid) || $search_usertoprocessid == $user->id) {
@@ -530,7 +531,7 @@ for ($idw = 0; $idw < 7; $idw++) {
 	$isavailablefordayanduser = $holiday->verifDateHolidayForTimestamp($usertoprocess->id, $dayinloopfromfirstdaytoshow, $statusofholidaytocheck);
 	$isavailable[$dayinloopfromfirstdaytoshow] = $isavailablefordayanduser; // in projectLinesPerWeek later, we are using $firstdaytoshow and dol_time_plus_duree to loop on each day
 
-	$test = num_public_holiday($dayinloopfromfirstdaytoshow, $dayinloopfromfirstdaytoshow + 86400, $mysoc->country_code);
+	$test = num_public_holiday($dayinloopfromfirstdaytoshow - $utcOffset, $dayinloopfromfirstdaytoshow - $utcOffset + 86400, $mysoc->country_code);
 	if ($test) {
 		$isavailable[$dayinloopfromfirstdaytoshow] = array('morning'=>false, 'afternoon'=>false, 'morning_reason'=>'public_holiday', 'afternoon_reason'=>'public_holiday');
 	}

--- a/htdocs/projet/activity/perweek.php
+++ b/htdocs/projet/activity/perweek.php
@@ -98,7 +98,7 @@ $next_month = $next['month'];
 $next_day   = $next['day'];
 
 // Define firstdaytoshow and lastdaytoshow (warning: lastdaytoshow is last second to show + 1)
-$firstdaytoshow = dol_mktime(0, 0, 0, $first_month, $first_day, $first_year);
+$firstdaytoshow = dol_mktime(0, 0, 0, $first_month, $first_day, $first_year, true);
 $lastdaytoshow = dol_time_plus_duree($firstdaytoshow, 7, 'd');
 
 if (empty($search_usertoprocessid) || $search_usertoprocessid == $user->id) {


### PR DESCRIPTION
# Fix https://github.com/Dolibarr/dolibarr/issues/16452

When opening `projet/activity/perweek.php?leftmenu=tasks` dates
are shifted by 1 day to the future / past depending on the timezone of
the machine hosting the code.

When changing the calculation to UTC times, the issue goes away.