### PR TITLE
Fix Infinite Loop in trigger

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1556,9 +1556,10 @@ class CommandeFournisseur extends CommonOrder
 	 *
 	 *  @param	    User	$user		User making the clone
 	 *	@param		int		$socid		Id of thirdparty
+ 	 *  @param 		int		$notrigger  Disable all triggers
 	 *	@return		int					New id of clone
 	 */
-	public function createFromClone(User $user, $socid = 0)
+	public function createFromClone(User $user, $socid = 0, $notrigger = 0)
 	{
 		global $conf, $user, $hookmanager;
 
@@ -1605,7 +1606,7 @@ class CommandeFournisseur extends CommonOrder
 
 		// Create clone
 		$this->context['createfromclone'] = 'createfromclone';
-		$result = $this->create($user);
+		$result = $this->create($user, $notrigger);
 		if ($result < 0) {
 			$error++;
 		}

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1556,7 +1556,7 @@ class CommandeFournisseur extends CommonOrder
 	 *
 	 *  @param	    User	$user		User making the clone
 	 *	@param		int		$socid		Id of thirdparty
- 	 *  @param 		int		$notrigger  Disable all triggers
+	 *  @param 		int		$notrigger  Disable all triggers
 	 *	@return		int					New id of clone
 	 */
 	public function createFromClone(User $user, $socid = 0, $notrigger = 0)


### PR DESCRIPTION
# Fix #[Loop in trigger]
Calling CommandeFournisseur::createFromClone in a trigger cause an infinite loop because this method calls CommandeFournisseur::create
param added $notrigger to avoid an infinite loop when createFromClone calls create

