### PR TITLE
New: Make more efficient data loading on replenishment

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2016		Juanjo Menent		<jmenent@2byte.es>
  * Copyright (C) 2016		ATM Consulting		<support@atm-consulting.fr>
  * Copyright (C) 2019       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2021		Ferran Marcet		<fmarcet@2byte.es>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -750,7 +751,7 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 
 	if (!empty($conf->global->STOCK_SUPPORTS_SERVICES) || $objp->fk_product_type == 0) {
 		$prod->fetch($objp->rowid);
-		$prod->load_stock('warehouseopen, warehouseinternal', $draftchecked);
+		$prod->load_stock('warehouseopen, warehouseinternal'.(!$usevirtualstock?', novirtual':''), $draftchecked);
 
 		// Multilangs
 		if (!empty($conf->global->MAIN_MULTILANGS)) {
@@ -785,11 +786,13 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 		// Force call prod->load_stats_xxx to choose status to count (otherwise it is loaded by load_stock function)
 		if (isset($draftchecked)) {
 			$result = $prod->load_stats_commande_fournisseur(0, '0,1,2,3,4');
-		} else {
+		} else if (!$usevirtualstock){
 			$result = $prod->load_stats_commande_fournisseur(0, '1,2,3,4');
 		}
 
-		$result = $prod->load_stats_reception(0, '4');
+		if (!$usevirtualstock) {
+			$result = $prod->load_stats_reception(0, '4');
+		}
 
 		//print $prod->stats_commande_fournisseur['qty'].'<br>'."\n";
 		//print $prod->stats_reception['qty'];

--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -786,7 +786,7 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 		// Force call prod->load_stats_xxx to choose status to count (otherwise it is loaded by load_stock function)
 		if (isset($draftchecked)) {
 			$result = $prod->load_stats_commande_fournisseur(0, '0,1,2,3,4');
-		} else if (!$usevirtualstock){
+		} elseif (!$usevirtualstock) {
 			$result = $prod->load_stats_commande_fournisseur(0, '1,2,3,4');
 		}
 


### PR DESCRIPTION
The first change is to only load the virtual stock in case the option to view virtual stock is selected. In cases where you have a large number of orders and lines, it slows down the data load a lot.

The second change, if we have previously loaded the virtual stock because the option is selected, it does not make sense to call the load_stats_XXX functions again to load the same data.