### PR TITLE
13.0

### DIFF
--- a/htdocs/comm/mailing/cibles.php
+++ b/htdocs/comm/mailing/cibles.php
@@ -689,6 +689,7 @@ if ($object->fetch($id) >= 0)
 
 				// Search Icon
 				print '<td class="right">';
+				print '<!-- ID mailing_cibles = '.$obj->rowid.' -->';
 				if ($obj->statut == 0)	// Not sent yet
 				{
 					if ($user->rights->mailing->creer && $allowaddtarget) {

--- a/htdocs/core/extrafieldsinexport.inc.php
+++ b/htdocs/core/extrafieldsinexport.inc.php
@@ -1,5 +1,9 @@
 <?php
 
+// $keyforselect = name of main table
+// keyforelement = name of picto
+// $keyforaliasextra = a key to avoid conflict with extrafields of other objects
+
 if (empty($keyforselect) || empty($keyforelement) || empty($keyforaliasextra))
 {
 	//print $keyforselet.' - '.$keyforelement.' - '.$keyforaliasextra;

--- a/htdocs/core/modules/modAgenda.class.php
+++ b/htdocs/core/modules/modAgenda.class.php
@@ -454,8 +454,12 @@ class modAgenda extends DolibarrModules
 			'p.ref' => 'project',
 		);
 
+		$keyforselect = 'actioncomm'; $keyforelement = 'action'; $keyforaliasextra = 'extra';
+		include DOL_DOCUMENT_ROOT.'/core/extrafieldsinexport.inc.php';
+
 		$this->export_sql_start[$r] = 'SELECT DISTINCT ';
 		$this->export_sql_end[$r]  = ' FROM  '.MAIN_DB_PREFIX.'actioncomm as ac';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'actioncomm_extrafields as extra ON ac.id = extra.fk_object';
 		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_actioncomm as cac on ac.fk_action = cac.id';
 		if (!empty($user) && empty($user->rights->agenda->allactions->read)) $this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'actioncomm_resources acr on ac.id = acr.fk_actioncomm';
 		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'socpeople as sp on ac.fk_contact = sp.rowid';

--- a/htdocs/core/modules/modAgenda.class.php
+++ b/htdocs/core/modules/modAgenda.class.php
@@ -413,7 +413,7 @@ class modAgenda extends DolibarrModules
 			'langs' => 'agenda',
 			'position' => 170,
 			'perms' => '$user->rights->agenda->allactions->read',
-			'enabled' => '$conf->categorie->enabled&&$conf->categorie->enabled',
+			'enabled' => '$conf->categorie->enabled',
 			'target' => '',
 			'user' => 2
 		);

--- a/htdocs/fichinter/list.php
+++ b/htdocs/fichinter/list.php
@@ -259,6 +259,10 @@ include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
+// Add GroupBy from hooks
+$parameters = array('all' => $all, 'fieldstosearchall' => $fieldstosearchall);
+$reshook = $hookmanager->executeHooks('printFieldListGroupBy', $parameters, $object); // Note that $action and $object may have been modified by hook
+$sql .= $hookmanager->resPrint;
 $sql .= $db->order($sortfield, $sortorder);
 
 // Count total nb of records


### PR DESCRIPTION
# New [*Product and services on interventions documents*]

It is possible to have the possibility of adding products (equipment) and predefined service directly to the intervention sheet. Because when you create a ticket you can directly create an intervention document, but to have the goods you have to create an estimate or order associated with the intervention and it is too much manipulation. Or be able to create a quote / order from a ticket directly ?

Thank you for your work