### PR TITLE
Fix #17317 use default label for online subscription

### DIFF
--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -417,7 +417,7 @@ if ($ispaymentok) {
 
 				$paymentdate = $now;
 				$amount = $FinalPaymentAmt;
-				$label = 'Online subscription '.dol_print_date($now, 'standard').' using '.$paymentmethod.' from '.$ipaddress.' - Transaction ID = '.$TRANSACTIONID;
+				$label = (empty($conf->global->MEMBER_NO_DEFAULT_LABEL)) ? $langs->trans("Subscription").' '.dol_print_date(($datefrom ? $datefrom : time()), "%Y") : 'Online subscription '.dol_print_date($now, 'standard').' using '.$paymentmethod.' from '.$ipaddress.' - Transaction ID = '.$TRANSACTIONID;
 
 				// Payment informations
 				$accountid = 0;


### PR DESCRIPTION
#Fix #17317 Subscription label is wrong when member pay online on renew and new form

