### PR TITLE
product card typo

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -894,7 +894,7 @@ if (empty($reshook)) {
 				$result = $facture->addline(
 					$desc,
 					$pu_ht,
-					price2nm(GETPOST('qty'), 'MS'),
+					price2num(GETPOST('qty'), 'MS'),
 					$tva_tx,
 					$localtax1_tx,
 					$localtax2_tx,


### PR DESCRIPTION
Hello,
I think I spotted a typo in product/card.php (or my IDE did, claiming the function price2nm() did not exist).