### PR TITLE
fix add french translation for label 'Payed'

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -197,7 +197,7 @@ $arrayfields = array(
 	'f.total_localtax2'=>array('label'=>$langs->transcountry("AmountLT2", $mysoc->country_code), 'checked'=>0, 'enabled'=>($mysoc->localtax2_assuj == "1"), 'position'=>120),
 	'f.total_ttc'=>array('label'=>"AmountTTC", 'checked'=>0, 'position'=>130),
 	'u.login'=>array('label'=>"Author", 'checked'=>1, 'position'=>135),
-	'dynamount_payed'=>array('label'=>"Received", 'checked'=>0, 'position'=>140),
+	'dynamount_payed'=>array('label'=>"Payed", 'checked'=>0, 'position'=>140),
 	'rtp'=>array('label'=>"Rest", 'checked'=>0, 'position'=>150), // Not enabled by default because slow
 	'f.multicurrency_code'=>array('label'=>'Currency', 'checked'=>0, 'enabled'=>(empty($conf->multicurrency->enabled) ? 0 : 1), 'position'=>160),
 	'f.multicurrency_tx'=>array('label'=>'CurrencyRate', 'checked'=>0, 'enabled'=>(empty($conf->multicurrency->enabled) ? 0 : 1), 'position'=>170),

--- a/htdocs/langs/fr_FR/bills.lang
+++ b/htdocs/langs/fr_FR/bills.lang
@@ -384,6 +384,7 @@ WarningInvoiceDateInFuture=Attention, la date de facturation est antérieur à l
 WarningInvoiceDateTooFarInFuture=Attention, la date de facturation est trop éloignée de la date actuelle
 ViewAvailableGlobalDiscounts=Voir les remises disponibles
 GroupPaymentsByModOnReports=Paiements groupés par mode sur les rapports
+Payed=Règlement reçu
 # PaymentConditions
 Statut=État
 PaymentConditionShortRECEP=A réception


### PR DESCRIPTION
# Fix # Add french translation for label 'Payed', and update label for dynamount_payed option in invoice list
Fix add french translation for label 'Payed', and change label from 'Received' to 'Payed' for dynamount_payed option in compta/facture/list.php.
This update allows to have the same label on the fourn/facture/list.php and on the compta/facture/list.php for dynamount_payed option.