### PR TITLE
allow proper filters for listUsersForGroup

### DIFF
--- a/htdocs/user/class/usergroup.class.php
+++ b/htdocs/user/class/usergroup.class.php
@@ -237,7 +237,7 @@ class UserGroup extends CommonObject
 
 		$ret = array();
 
-		$sql = "SELECT u.rowid";
+		$sql = "SELECT u.*";
 		if (!empty($this->id)) {
 			$sql .= ", ug.entity as usergroup_entity";
 		}


### PR DESCRIPTION
when you use the `function listUsersForGroup($excludefilter = '', $mode = 0)` there is no access to the users data to be used in the parameter `$excludefilter`
this change loads the complete user row to exclude users via the parameter