### PR TITLE
Close/CLOSE #17390 Products API, GET /products without variants

### DIFF
--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -166,10 +166,10 @@ class Products extends DolibarrApi
 	 * @param  int    $category   			Use this param to filter list by category
 	 * @param  string $sqlfilters 			Other criteria to filter answers separated by a comma. Syntax example "(t.tobuy:=:0) and (t.tosell:=:1)"
 	 * @param  bool   $ids_only   			Return only IDs of product instead of all properties (faster, above all if list is long)
-	 * @param  bool   $without_variants   	Return only parent products, not variants
+	 * @param  int    $variant_filter   	Use this param to filter list (0 = all, 1=products without variants, 2=parent of variants, 3=variants only)
 	 * @return array                		Array of product objects
 	 */
-	public function index($sortfield = "t.ref", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $ids_only = false, $without_variants = false)
+	public function index($sortfield = "t.ref", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $ids_only = false, $variant_filter = 0)
 	{
 		global $db, $conf;
 
@@ -188,8 +188,15 @@ class Products extends DolibarrApi
 		}
 		$sql .= ' WHERE t.entity IN ('.getEntity('product').')';
 
-		if ($without_variants) {
+		if ($variant_filter == 1) {
+			$sql .= ' AND t.rowid not in (select distinct fk_product_parent from '.MAIN_DB_PREFIX.'product_attribute_combination)';
+			$sql .= ' AND t.rowid not in (select distinct fk_product_child from '.MAIN_DB_PREFIX.'product_attribute_combination)';
+		}
+		if ($variant_filter == 2) {
 			$sql .= ' AND t.rowid in (select distinct fk_product_parent from '.MAIN_DB_PREFIX.'product_attribute_combination)';
+		}
+		if ($variant_filter == 3) {
+			$sql .= ' AND t.rowid in (select distinct fk_product_child from '.MAIN_DB_PREFIX.'product_attribute_combination)';
 		}
 
 		// Select products of given category

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -188,7 +188,7 @@ class Products extends DolibarrApi
 		}
 		$sql .= ' WHERE t.entity IN ('.getEntity('product').')';
 
-      	if($without_variants){
+		if ($without_variants) {
 			$sql .= ' AND t.rowid in (select distinct fk_product_parent from '.MAIN_DB_PREFIX.'product_attribute_combination)';
 		}
 

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -166,9 +166,10 @@ class Products extends DolibarrApi
 	 * @param  int    $category   Use this param to filter list by category
 	 * @param  string $sqlfilters Other criteria to filter answers separated by a comma. Syntax example "(t.tobuy:=:0) and (t.tosell:=:1)"
 	 * @param  bool   $ids_only   Return only IDs of product instead of all properties (faster, above all if list is long)
+	 * @param  bool   $without_variants   Return only products, not variants
 	 * @return array                Array of product objects
 	 */
-	public function index($sortfield = "t.ref", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $ids_only = false)
+	public function index($sortfield = "t.ref", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $ids_only = false, $without_variants = false)
 	{
 		global $db, $conf;
 
@@ -186,6 +187,11 @@ class Products extends DolibarrApi
 			$sql .= ", ".MAIN_DB_PREFIX."categorie_product as c";
 		}
 		$sql .= ' WHERE t.entity IN ('.getEntity('product').')';
+
+      	if($without_variants){
+			$sql .= ' AND t.rowid in (select distinct fk_product_parent from '.MAIN_DB_PREFIX.'product_attribute_combination)';
+		}
+
 		// Select products of given category
 		if ($category > 0) {
 			$sql .= " AND c.fk_categorie = ".$this->db->escape($category);

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -158,16 +158,16 @@ class Products extends DolibarrApi
 	 *
 	 * Get a list of products
 	 *
-	 * @param  string $sortfield  Sort field
-	 * @param  string $sortorder  Sort order
-	 * @param  int    $limit      Limit for list
-	 * @param  int    $page       Page number
-	 * @param  int    $mode       Use this param to filter list (0 for all, 1 for only product, 2 for only service)
-	 * @param  int    $category   Use this param to filter list by category
-	 * @param  string $sqlfilters Other criteria to filter answers separated by a comma. Syntax example "(t.tobuy:=:0) and (t.tosell:=:1)"
-	 * @param  bool   $ids_only   Return only IDs of product instead of all properties (faster, above all if list is long)
-	 * @param  bool   $without_variants   Return only products, not variants
-	 * @return array                Array of product objects
+	 * @param  string $sortfield  			Sort field
+	 * @param  string $sortorder  			Sort order
+	 * @param  int    $limit      			Limit for list
+	 * @param  int    $page       			Page number
+	 * @param  int    $mode       			Use this param to filter list (0 for all, 1 for only product, 2 for only service)
+	 * @param  int    $category   			Use this param to filter list by category
+	 * @param  string $sqlfilters 			Other criteria to filter answers separated by a comma. Syntax example "(t.tobuy:=:0) and (t.tosell:=:1)"
+	 * @param  bool   $ids_only   			Return only IDs of product instead of all properties (faster, above all if list is long)
+	 * @param  bool   $without_variants   	Return only parent products, not variants
+	 * @return array                		Array of product objects
 	 */
 	public function index($sortfield = "t.ref", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $ids_only = false, $without_variants = false)
 	{


### PR DESCRIPTION
When accessing get /products, using $without_variants parameter to true (the deafult value is false), the api return only products and no variants.

# Close #17390
When calling Rest API get products, I am getting all products & variants

# New, Get only Products without variants
I added one new parameter $without_variants when calling GET /products. When this parameter is true I added a new SQL statment ($sql .= ' AND t.rowid in (SELECT distinct fk_product_parent FROM '.MAIN_DB_PREFIX.'product_attribute_combination')
Using this sql condition, the inner select query will gather all product IDs that act as a parrent product for variant products.
Finaly using t.rowid IN in the above IDs the api returns only products and not variants.
