### PR TITLE
FIX : Change status values taken for load_stats_commande_fournisseur()

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4479,7 +4479,11 @@ class Product extends CommonObject
 		}
 		if (! empty($conf->fournisseur->enabled))
 		{
-			$result=$this->load_stats_commande_fournisseur(0, '3,4', 1);
+			if (!empty($conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK)){
+				$result=$this->load_stats_commande_fournisseur(0, $conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK, 1);
+			} else {
+				$result=$this->load_stats_commande_fournisseur(0, '1,2,3,4', 1);
+			}
 			if ($result < 0) dol_print_error($this->db, $this->error);
 			$stock_commande_fournisseur=$this->stats_commande_fournisseur['qty'];
 

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4479,7 +4479,7 @@ class Product extends CommonObject
 		}
 		if (! empty($conf->fournisseur->enabled))
 		{
-			$result=$this->load_stats_commande_fournisseur(0, '1,2,3,4', 1);
+			$result=$this->load_stats_commande_fournisseur(0, '3,4', 1);
 			if ($result < 0) dol_print_error($this->db, $this->error);
 			$stock_commande_fournisseur=$this->stats_commande_fournisseur['qty'];
 


### PR DESCRIPTION
# FIX : Change status value taken in load_stats_commande_fournisseur() function

The status validated and approved is taken in the function, but at this status, the order is not placed so it should not be part of the supplier ordered virtual stock