### PR TITLE
Fix #17361 : change of llx_export_model type to varchar(64)

### DIFF
--- a/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
+++ b/htdocs/install/mysql/migration/12.0.0-13.0.0.sql
@@ -583,4 +583,5 @@ insert into llx_c_actioncomm (id, code, type, libelle, module, active, position)
 -- VMYSQL4.3 ALTER TABLE llx_accounting_bookkeeping MODIFY COLUMN montant double(24,8) NULL;
 -- VPGSQL8.2 ALTER TABLE llx_accounting_bookkeeping ALTER COLUMN montant DROP NOT NULL;
 
+ALTER TABLE llx_export_model MODIFY COLUMN type varchar(64);
 

--- a/htdocs/install/mysql/tables/llx_export_model.sql
+++ b/htdocs/install/mysql/tables/llx_export_model.sql
@@ -24,7 +24,7 @@ create table llx_export_model
   	rowid		integer AUTO_INCREMENT PRIMARY KEY,
 	fk_user		integer DEFAULT 0 NOT NULL,
   	label		varchar(50) NOT NULL,
-  	type		varchar(20) NOT NULL,
+  	type		varchar(64) NOT NULL,
   	field		text NOT NULL,
   	filter		text
   	


### PR DESCRIPTION
Update of migration 12.0 to 13.0 to change llx_export_model to type = varchar(64)