### PR TITLE
Fix show table of pdf payments repports in file order

### DIFF
--- a/htdocs/compta/paiement/rapport.php
+++ b/htdocs/compta/paiement/rapport.php
@@ -150,7 +150,7 @@ if ($year)
 		foreach ($files as $f) {
 			$tfile = $dir.'/'.$year.'/'.$f;
 			$relativepath = $year.'/'.$f;
-			if (is_file($tfile)) {
+			if (is_file($tfile) && preg_match('/^payment/i', $f)) {
 				print '<tr class="oddeven">';
 				print '<td><a data-ajax="false" href="'.DOL_URL_ROOT.'/document.php?modulepart=facture_paiement&amp;file='.urlencode($relativepath).'">'.img_pdf().' '.$f.'</a>'.$formfile->showPreview($f, 'facture_paiement', $relativepath, 0).'</td>';
 				print '<td class="right">'.dol_print_size(dol_filesize($tfile)).'</td>';

--- a/htdocs/compta/paiement/rapport.php
+++ b/htdocs/compta/paiement/rapport.php
@@ -136,7 +136,6 @@ if ($year)
 {
 	if (is_dir($dir.'/'.$year))
 	{
-		$handle = opendir($dir.'/'.$year);
 
 		if ($found) print '<br>';
 		print '<br>';
@@ -147,22 +146,17 @@ if ($year)
 		print '<td class="right">'.$langs->trans("Date").'</td>';
 		print '</tr>';
 
-		if (is_resource($handle))
-		{
-			while (($file = readdir($handle)) !== false)
-			{
-				if (preg_match('/^payment/i', $file))
-				{
-					$tfile = $dir.'/'.$year.'/'.$file;
-					$relativepath = $year.'/'.$file;
-					print '<tr class="oddeven">';
-					print '<td><a data-ajax="false" href="'.DOL_URL_ROOT.'/document.php?modulepart=facture_paiement&amp;file='.urlencode($relativepath).'">'.img_pdf().' '.$file.'</a>'.$formfile->showPreview($file, 'facture_paiement', $relativepath, 0).'</td>';
-					print '<td class="right">'.dol_print_size(dol_filesize($tfile)).'</td>';
-					print '<td class="right">'.dol_print_date(dol_filemtime($tfile), "dayhour").'</td>';
-					print '</tr>';
-				}
+		$files = (scandir($dir.'/'.$year));
+		foreach ($files as $f) {
+			$tfile = $dir.'/'.$year.'/'.$f;
+			$relativepath = $year.'/'.$f;
+			if (is_file($tfile)) {
+				print '<tr class="oddeven">';
+				print '<td><a data-ajax="false" href="'.DOL_URL_ROOT.'/document.php?modulepart=facture_paiement&amp;file='.urlencode($relativepath).'">'.img_pdf().' '.$f.'</a>'.$formfile->showPreview($f, 'facture_paiement', $relativepath, 0).'</td>';
+				print '<td class="right">'.dol_print_size(dol_filesize($tfile)).'</td>';
+				print '<td class="right">'.dol_print_date(dol_filemtime($tfile), "dayhour").'</td>';
+				print '</tr>';
 			}
-			closedir($handle);
 		}
 		print '</table>';
 	}

--- a/htdocs/compta/paiement/rapport.php
+++ b/htdocs/compta/paiement/rapport.php
@@ -109,35 +109,18 @@ print '<br>';
 clearstatcache();
 
 // Show link on other years
-$linkforyear = array();
-$found = 0;
-if (is_dir($dir))
+$year_dirs = dol_dir_list($dir, 'directories', 0, '^[0-9]{4}$', '', 'DESC');
+foreach ($year_dirs as $d)
 {
-	$handle = opendir($dir);
-	if (is_resource($handle))
-	{
-		while (($file = readdir($handle)) !== false)
-		{
-			if (is_dir($dir.'/'.$file) && !preg_match('/^\./', $file) && is_numeric($file))
-			{
-				$found = 1;
-				$linkforyear[] = $file;
-			}
-		}
-	}
-}
-asort($linkforyear);
-foreach ($linkforyear as $cursoryear)
-{
-	print '<a href="'.$_SERVER["PHP_SELF"].'?year='.$cursoryear.'">'.$cursoryear.'</a> &nbsp;';
+	print '<a href="'.$_SERVER["PHP_SELF"].'?year='.$d['name'].'">'.$d['name'].'</a> &nbsp;';
 }
 
+$found = true;
 if ($year)
 {
 	if (is_dir($dir.'/'.$year))
 	{
-
-		if ($found) print '<br>';
+		if (!empty($year_dirs)) print '<br>';
 		print '<br>';
 		print '<table width="100%" class="noborder">';
 		print '<tr class="liste_titre">';
@@ -146,17 +129,14 @@ if ($year)
 		print '<td class="right">'.$langs->trans("Date").'</td>';
 		print '</tr>';
 
-		$files = (scandir($dir.'/'.$year));
+		$files = (dol_dir_list($dir.'/'.$year, 'files', 0, '^payments-[0-9]{4}-[0-9]{2}\.pdf$', '', 'name', 'DESC', 1));
 		foreach ($files as $f) {
-			$tfile = $dir.'/'.$year.'/'.$f;
-			$relativepath = $year.'/'.$f;
-			if (is_file($tfile) && preg_match('/^payment/i', $f)) {
-				print '<tr class="oddeven">';
-				print '<td><a data-ajax="false" href="'.DOL_URL_ROOT.'/document.php?modulepart=facture_paiement&amp;file='.urlencode($relativepath).'">'.img_pdf().' '.$f.'</a>'.$formfile->showPreview($f, 'facture_paiement', $relativepath, 0).'</td>';
-				print '<td class="right">'.dol_print_size(dol_filesize($tfile)).'</td>';
-				print '<td class="right">'.dol_print_date(dol_filemtime($tfile), "dayhour").'</td>';
-				print '</tr>';
-			}
+			$relativepath = $f['level1name'].'/'.$f['name'];
+			print '<tr class="oddeven">';
+			print '<td><a data-ajax="false" href="'.DOL_URL_ROOT.'/document.php?modulepart=facture_paiement&amp;file='.urlencode($relativepath).'">'.img_pdf().' '.$f['name'].'</a>'.$formfile->showPreview($f['name'], 'facture_paiement', $relativepath, 0).'</td>';
+			print '<td class="right">'.dol_print_size($f['size']).'</td>';
+			print '<td class="right">'.dol_print_date($f['date'], "dayhour").'</td>';
+			print '</tr>';
 		}
 		print '</table>';
 	}


### PR DESCRIPTION
Use scandir() rather opendir() and readdir() to get a sorted list of files.