### PR TITLE
FIX #17476 releve.php: Fix SQL statement

### DIFF
--- a/htdocs/compta/bank/releve.php
+++ b/htdocs/compta/bank/releve.php
@@ -177,7 +177,7 @@ $sqlrequestforbankline = $sql;
 if ($action == 'confirm_editbankreceipt' && !empty($oldbankreceipt) && !empty($newbankreceipt))
 {
 	// TODO Add a test to check newbankreceipt does not exists yet
-	$sqlupdate = 'UPDATE '.MAIN_DB_PREFIX.'bank SET num_releve = "'.$db->escape($newbankreceipt).'" WHERE num_releve = "'.$db->escape($oldbankreceipt).'" AND fk_account = '.$id;
+	$sqlupdate = 'UPDATE '.MAIN_DB_PREFIX.'bank SET num_releve = \''.$db->escape($newbankreceipt).'\' WHERE num_releve = \''.$db->escape($oldbankreceipt).'\' AND fk_account = '.$id;
 	$result = $db->query($sqlupdate);
 	if ($result < 0) dol_print_error($db);
 

--- a/htdocs/compta/bank/releve.php
+++ b/htdocs/compta/bank/releve.php
@@ -177,7 +177,7 @@ $sqlrequestforbankline = $sql;
 if ($action == 'confirm_editbankreceipt' && !empty($oldbankreceipt) && !empty($newbankreceipt))
 {
 	// TODO Add a test to check newbankreceipt does not exists yet
-	$sqlupdate = 'UPDATE '.MAIN_DB_PREFIX.'bank SET num_releve = \''.$db->escape($newbankreceipt).'\' WHERE num_releve = \''.$db->escape($oldbankreceipt).'\' AND fk_account = '.$id;
+	$sqlupdate = "UPDATE ".MAIN_DB_PREFIX."bank SET num_releve = '".$db->escape($newbankreceipt)."' WHERE num_releve = '".$db->escape($oldbankreceipt)."' AND fk_account = ".((int) $id);
 	$result = $db->query($sqlupdate);
 	if ($result < 0) dol_print_error($db);
 


### PR DESCRIPTION
# Fix #17476
Single quotes `'` should be uses instead of double quotes `"` for string values in SQL statements.