### PR TITLE
FIX saving template email

### DIFF
--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -257,7 +257,7 @@ if (empty($reshook))
             $sql = "INSERT INTO ".$tabname[$id]." (";
             // List of fields
             $sql .= $tabfieldinsert[$id];
-            $sql .= ",active)";
+            $sql .= ",active,enabled)";
             $sql .= " VALUES(";
 
             // List of values
@@ -289,7 +289,7 @@ if (empty($reshook))
 
                 $i++;
             }
-            $sql .= ", 1)";
+            $sql .= ", 1, 1)";
 
             dol_syslog("actionadd", LOG_DEBUG);
             $result = $db->query($sql);


### PR DESCRIPTION
For some unknowns reasons, sometime the column "enabled" of table  llx_c_email_templates is not set as 1, the fix in 6.0.0-7.0.0.sql exists and do the job but...

So I added this fix to be sure... 