### PR TITLE
Fix #17491 : date extrafield filter works well now

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -23,9 +23,9 @@ if (!empty($extrafieldsobjectkey) && !empty($search_array_options) && is_array($
 
 		if ($crit != '' && in_array($typ, array('date', 'datetime', 'timestamp')))
 		{
-			if($typ == 'date'){
+			if ($typ == 'date'){
 				$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = DATE('".$db->idate($crit)."')";
-			}else{
+			}else {
 				$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = '".$db->idate($crit)."'";
 			}
 		} elseif (in_array($typ, array('boolean')))

--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -23,7 +23,11 @@ if (!empty($extrafieldsobjectkey) && !empty($search_array_options) && is_array($
 
 		if ($crit != '' && in_array($typ, array('date', 'datetime', 'timestamp')))
 		{
-			$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = '".$db->idate($crit)."'";
+			if($typ == 'date'){
+				$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = DATE('".$db->idate($crit)."')";
+			}else{
+				$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = '".$db->idate($crit)."'";
+			}
 		} elseif (in_array($typ, array('boolean')))
 		{
 			if ($crit !== '-1' && $crit !== '') {

--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -23,11 +23,11 @@ if (!empty($extrafieldsobjectkey) && !empty($search_array_options) && is_array($
 
 		if ($crit != '' && in_array($typ, array('date', 'datetime', 'timestamp')))
 		{
-			if($typ == 'date'){
+			if ($typ == 'date'){
 				include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 				$crit = dol_get_first_hour($crit);
 				$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = '".$db->idate($crit)."'";
-			}else{
+			}else {
 				$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = '".$db->idate($crit)."'";
 			}
 		} elseif (in_array($typ, array('boolean')))

--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -23,9 +23,11 @@ if (!empty($extrafieldsobjectkey) && !empty($search_array_options) && is_array($
 
 		if ($crit != '' && in_array($typ, array('date', 'datetime', 'timestamp')))
 		{
-			if ($typ == 'date'){
-				$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = DATE('".$db->idate($crit)."')";
-			}else {
+			if($typ == 'date'){
+				include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
+				$crit = dol_get_first_hour($crit);
+				$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = '".$db->idate($crit)."'";
+			}else{
 				$sql .= " AND ".$extrafieldsobjectprefix.$tmpkey." = '".$db->idate($crit)."'";
 			}
 		} elseif (in_array($typ, array('boolean')))


### PR DESCRIPTION
Edit of core/tpl/extrafields_list_search_sql.tpl.php to use only Date (and not time) when extrafield of type  date is used