### PR TITLE
FIX : search accented words in product description (consumption page)

### DIFF
--- a/htdocs/societe/consumption.php
+++ b/htdocs/societe/consumption.php
@@ -309,7 +309,7 @@ if (!empty($sql_select))
 	if ($sref) $sql.= " AND ".$doc_number." LIKE '%".$db->escape($sref)."%'";
 	if ($sprod_fulldescr)
 	{
-	    $sql.= " AND (d.description LIKE '%".$db->escape($sprod_fulldescr)."%'";
+	    $sql.= " AND (d.description LIKE '%".$db->escape($sprod_fulldescr)."%' OR d.description LIKE '%".$db->escape(dol_htmlentities($sprod_fulldescr))."%'";
 	    if (GETPOST('type_element') != 'fichinter') $sql.= " OR p.ref LIKE '%".$db->escape($sprod_fulldescr)."%'";
 	    if (GETPOST('type_element') != 'fichinter') $sql.= " OR p.label LIKE '%".$db->escape($sprod_fulldescr)."%'";
 	    $sql.=")";


### PR DESCRIPTION
If you search orders for a customer with product containing European  accents in description no result is found because accents are html encoded in database (if wysiwyg html editor is ON)

Ex : Boîte is stored as ```Bo&icirc;te``` in BDD so searching Boîte will not find results

Next step is to allow finding ```Bo&icirc;te```  when user type "Boite" without accent, but I havent find how i can do this  without edges effects yet...

