### PR TITLE
fix mulitple module using completeTabsHead

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8385,12 +8385,12 @@ function complete_head_from_modules($conf, $langs, $object, &$head, &$h, $type, 
 
 	// No need to make a return $head. Var is modified as a reference
 	if (!empty($hookmanager)) {
-		$parameters = array('object' => $object, 'mode' => $mode, 'head' => $head);
+		$parameters = array('object' => $object, 'mode' => $mode, 'head' => &$head);
 		$reshook = $hookmanager->executeHooks('completeTabsHead', $parameters);
 		if ($reshook > 0) {
 			$head = $hookmanager->resArray;
-			$h = count($head);
 		}
+		$h = count($head);
 	}
 }
 


### PR DESCRIPTION
complete $template['head'] in module and return 0 to not replace instead return $head and replace