### PR TITLE
Fix vulnerability - Wrong permission in adherent card

### DIFF
--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -1891,7 +1891,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 				}*/
 
 				// Modify
-				if (!$user->rights->adherent->creer) {
+				if ($user->rights->adherent->creer) {
 					print '<a class="butAction" href="card.php?rowid='.$id.'&action=edit">'.$langs->trans("Modify").'</a>'."\n";
 				} else {
 					print '<span class="butActionRefused classfortooltip" title="'.dol_escape_htmltag($langs->trans("NotEnoughPermissions")).'">'.$langs->trans("Modify").'</span>'."\n";

--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -1891,7 +1891,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 				}*/
 
 				// Modify
-				if ($user->rights->adherent->creer) {
+				if (!empty($user->rights->adherent->creer)) {
 					print '<a class="butAction" href="card.php?rowid='.$id.'&action=edit">'.$langs->trans("Modify").'</a>'."\n";
 				} else {
 					print '<span class="butActionRefused classfortooltip" title="'.dol_escape_htmltag($langs->trans("NotEnoughPermissions")).'">'.$langs->trans("Modify").'</span>'."\n";


### PR DESCRIPTION
if a user can create a member, he's able to modify, but if he cannot, he shouldn't be able to modify.
But user without permission are able to modify...