### PR TITLE
New Hooks to rename Supplier Orders statuses

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -770,7 +770,7 @@ class CommandeFournisseur extends CommonOrder
 	 */
 	public function getNomUrl($withpicto = 0, $option = '', $notooltip = 0, $save_lastsearch_value = -1, $addlinktonotes = 0)
 	{
-		global $langs, $conf, $user, $hookmanager;
+		global $langs, $conf, $user;
 
 		$result = '';
 
@@ -779,7 +779,7 @@ class CommandeFournisseur extends CommonOrder
 		if ($user->rights->fournisseur->commande->lire) {
 			$label = '<u class="paddingrightonly">'.$langs->trans("SupplierOrder").'</u>';
 			if (isset($this->statut)) {
-				$label = ' '.$this->getLibStatut(5);
+				$label .= ' '.$this->getLibStatut(5);
 			}
 			if (!empty($this->ref)) {
 				$label .= '<br><b>'.$langs->trans('Ref').':</b> '.$this->ref;

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -750,7 +750,7 @@ class CommandeFournisseur extends CommonOrder
 		$statusShort = $langs->transnoentitiesnoconv($this->statutshort[$status]);
 
 		$parameters = array('status' => $status, 'mode' => $mode, 'billed' => $billed, 'obj'=>$this);
-		$reshook = $hookmanager->executeHooks('diffHtmlStatus', $parameters, $object); // Note that $action and $object may have been modified by hook
+		$reshook = $hookmanager->executeHooks('LibStatut', $parameters, $object); // Note that $action and $object may have been modified by hook
 		if ($reshook > 0) {
 			return $hookmanager->resPrint;
 		}
@@ -779,15 +779,7 @@ class CommandeFournisseur extends CommonOrder
 		if ($user->rights->fournisseur->commande->lire) {
 			$label = '<u class="paddingrightonly">'.$langs->trans("SupplierOrder").'</u>';
 			if (isset($this->statut)) {
-				$statusText = ' '.$this->getLibStatut(5);
-				$parameters = array('obj' => $this);
-				$reshook = $hookmanager->executeHooks('moreHtmlStatus', $parameters, $object); // Note that $action and $object may have been modified by hook
-				if (empty($reshook)) {
-					$statusText .= $hookmanager->resPrint;
-				} else {
-					$statusText = $hookmanager->resPrint;
-				}
-				$label .= $statusText;
+				$label = ' '.$this->getLibStatut(5);
 			}
 			if (!empty($this->ref)) {
 				$label .= '<br><b>'.$langs->trans('Ref').':</b> '.$this->ref;

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -749,8 +749,8 @@ class CommandeFournisseur extends CommonOrder
 		$statusLong = $langs->transnoentitiesnoconv($this->statuts[$status]).$billedtext;
 		$statusShort = $langs->transnoentitiesnoconv($this->statutshort[$status]);
 
-		$parameters = array('status' => $status, 'mode' => $mode, 'billed' => $billed, 'obj'=>$this);
-		$reshook = $hookmanager->executeHooks('LibStatut', $parameters, $object); // Note that $action and $object may have been modified by hook
+		$parameters = array('status' => $status, 'mode' => $mode, 'billed' => $billed);
+		$reshook = $hookmanager->executeHooks('LibStatut', $parameters, $this); // Note that $action and $object may have been modified by hook
 		if ($reshook > 0) {
 			return $hookmanager->resPrint;
 		}

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -690,7 +690,7 @@ class CommandeFournisseur extends CommonOrder
 	public function LibStatut($status, $mode = 0, $billed = 0)
 	{
 		// phpcs:enable
-		global $conf, $langs;
+		global $conf, $langs, $hookmanager;
 
 		if (empty($this->statuts) || empty($this->statutshort)) {
 			$langs->load('orders');
@@ -749,6 +749,11 @@ class CommandeFournisseur extends CommonOrder
 		$statusLong = $langs->transnoentitiesnoconv($this->statuts[$status]).$billedtext;
 		$statusShort = $langs->transnoentitiesnoconv($this->statutshort[$status]);
 
+		$parameters = array('status' => $status, 'mode' => $mode, 'billed' => $billed, 'obj'=>$this);
+		$reshook = $hookmanager->executeHooks('diffHtmlStatus', $parameters, $object); // Note that $action and $object may have been modified by hook
+		if ($reshook > 0) {
+			return $hookmanager->resPrint;
+		} 
 		return dolGetStatus($statusLong, $statusShort, '', $statusClass, $mode);
 	}
 

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -753,7 +753,7 @@ class CommandeFournisseur extends CommonOrder
 		$reshook = $hookmanager->executeHooks('diffHtmlStatus', $parameters, $object); // Note that $action and $object may have been modified by hook
 		if ($reshook > 0) {
 			return $hookmanager->resPrint;
-		} 
+		}
 		return dolGetStatus($statusLong, $statusShort, '', $statusClass, $mode);
 	}
 

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -765,7 +765,7 @@ class CommandeFournisseur extends CommonOrder
 	 */
 	public function getNomUrl($withpicto = 0, $option = '', $notooltip = 0, $save_lastsearch_value = -1, $addlinktonotes = 0)
 	{
-		global $langs, $conf, $user;
+		global $langs, $conf, $user, $hookmanager;
 
 		$result = '';
 
@@ -774,7 +774,15 @@ class CommandeFournisseur extends CommonOrder
 		if ($user->rights->fournisseur->commande->lire) {
 			$label = '<u class="paddingrightonly">'.$langs->trans("SupplierOrder").'</u>';
 			if (isset($this->statut)) {
-				$label .= ' '.$this->getLibStatut(5);
+				$statusText = ' '.$this->getLibStatut(5);
+				$parameters = array('obj' => $this);
+				$reshook = $hookmanager->executeHooks('moreHtmlStatus', $parameters, $object); // Note that $action and $object may have been modified by hook
+				if (empty($reshook)) {
+					$statusText .= $hookmanager->resPrint;
+				} else {
+					$statusText = $hookmanager->resPrint;
+				}
+				$label .= $statusText;
 			}
 			if (!empty($this->ref)) {
 				$label .= '<br><b>'.$langs->trans('Ref').':</b> '.$this->ref;

--- a/htdocs/fourn/commande/contact.php
+++ b/htdocs/fourn/commande/contact.php
@@ -45,6 +45,7 @@ if ($user->socid) {
 	$socid = $user->socid;
 }
 $result = restrictedArea($user, 'fournisseur', $id, 'commande_fournisseur', 'commande');
+$hookmanager->initHooks(array('ordersuppliercardcontact'));
 
 $object = new CommandeFournisseur($db);
 

--- a/htdocs/fourn/commande/document.php
+++ b/htdocs/fourn/commande/document.php
@@ -70,6 +70,7 @@ if (!$sortfield) {
 	$sortfield = "name";
 }
 
+$hookmanager->initHooks(array('ordersuppliercarddocument'));
 
 $object = new CommandeFournisseur($db);
 if ($object->fetch($id, $ref) < 0) {

--- a/htdocs/fourn/commande/info.php
+++ b/htdocs/fourn/commande/info.php
@@ -78,6 +78,7 @@ if (!$user->rights->fournisseur->commande->lire) {
 	accessforbidden();
 }
 
+$hookmanager->initHooks(array('ordersuppliercardinfo'));
 
 
 

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -1537,15 +1537,7 @@ if ($resql) {
 		}
 		// Status
 		if (!empty($arrayfields['cf.fk_statut']['checked'])) {
-			$parameters = array('obj' => $obj);
-			$morehtmlstatus = $objectstatic->LibStatut($obj->fk_statut, 5, $obj->billed);
-			$reshook = $hookmanager->executeHooks('moreHtmlStatus', $parameters, $object); // Note that $action and $object may have been modified by hook
-			if (empty($reshook)) {
-				$morehtmlstatus .= $hookmanager->resPrint;
-			} else {
-				$morehtmlstatus = $hookmanager->resPrint;
-			}
-			print '<td class="right nowrap">' . $morehtmlstatus . '</td>';
+			print '<td class="right nowrap">'.$objectstatic->LibStatut($obj->fk_statut, 5, $obj->billed).'</td>';
 			if (!$i) {
 				$totalarray['nbfield']++;
 			}

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -1537,7 +1537,15 @@ if ($resql) {
 		}
 		// Status
 		if (!empty($arrayfields['cf.fk_statut']['checked'])) {
-			print '<td class="right nowrap">'.$objectstatic->LibStatut($obj->fk_statut, 5, $obj->billed).'</td>';
+			$parameters = array('obj' => $obj);
+			$morehtmlstatus = $objectstatic->LibStatut($obj->fk_statut, 5, $obj->billed);
+			$reshook = $hookmanager->executeHooks('moreHtmlStatus', $parameters, $object); // Note that $action and $object may have been modified by hook
+			if (empty($reshook)) {
+				$morehtmlstatus .= $hookmanager->resPrint;
+			} else {
+				$morehtmlstatus = $hookmanager->resPrint;
+			}
+			print '<td class="right nowrap">' . $morehtmlstatus . '</td>';
 			if (!$i) {
 				$totalarray['nbfield']++;
 			}

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -1283,6 +1283,7 @@ if ($resql) {
 
 		$objectstatic->id = $obj->rowid;
 		$objectstatic->ref = $obj->ref;
+		$objectstatic->socid = $obj->socid;
 		$objectstatic->ref_supplier = $obj->ref_supplier;
 		$objectstatic->total_ht = $obj->total_ht;
 		$objectstatic->total_tva = $obj->total_tva;

--- a/htdocs/fourn/commande/note.php
+++ b/htdocs/fourn/commande/note.php
@@ -48,6 +48,8 @@ $result = restrictedArea($user, 'fournisseur', $id, 'commande_fournisseur', 'com
 $object = new CommandeFournisseur($db);
 $object->fetch($id, $ref);
 
+$hookmanager->initHooks(array('ordersuppliercardnote'));
+
 $permissionnote = ($user->rights->fournisseur->commande->creer || $user->rights->supplier_order->creer); // Used by the include of actions_setnotes.inc.php
 
 

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2208,7 +2208,7 @@ class Product extends CommonObject
 			$sql .= " p.stock,";
 		}
 		if ($separatedEntityPMP) {
-			$sql .= " pa.pmp, p.datec, p.tms, p.import_key, p.entity, p.desiredstock, p.tobatch, p.batch_mask, p.fk_unit,";
+			$sql .= " ppe.pmp, p.datec, p.tms, p.import_key, p.entity, p.desiredstock, p.tobatch, p.batch_mask, p.fk_unit,";
 		} else {
 			$sql .= " p.pmp, p.datec, p.tms, p.import_key, p.entity, p.desiredstock, p.tobatch, p.batch_mask, p.fk_unit,";
 		}

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2208,7 +2208,7 @@ class Product extends CommonObject
 			$sql .= " p.stock,";
 		}
 		if ($separatedEntityPMP) {
-			$sql .= " ppe.pmp, p.datec, p.tms, p.import_key, p.entity, p.desiredstock, p.tobatch, p.batch_mask, p.fk_unit,";
+			$sql .= " pa.pmp, p.datec, p.tms, p.import_key, p.entity, p.desiredstock, p.tobatch, p.batch_mask, p.fk_unit,";
 		} else {
 			$sql .= " p.pmp, p.datec, p.tms, p.import_key, p.entity, p.desiredstock, p.tobatch, p.batch_mask, p.fk_unit,";
 		}


### PR DESCRIPTION
# New Hooks to rename Supplier Orders statuses
While creating an external module, I wanted to display other variants of statuses if certain conditions. 
These hooks inspired by htdocs\core\class\html.form.class.php line 8020 allow to change the label of the order status on 
fourn/commande/card.php
fourn/commande/list.php (right and on hover)


