### PR TITLE
FIX: Impossible to add multiple localtax2

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -9,7 +9,7 @@
  * Copyright (C) 2012-2015	Marcos García			<marcosgdf@gmail.com>
  * Copyright (C) 2012		Christophe Battarel		<christophe.battarel@ltairis.fr>
  * Copyright (C) 2011-2016	Alexandre Spangaro		<aspangaro@open-dsi.fr>
- * Copyright (C) 2015		Ferran Marcet			<fmarcet@2byte.es>
+ * Copyright (C) 2015-2021	Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2016		Raphaël Doursenaud		<rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2019       Frédéric France         <frederic.france@netlogic.fr>
  *
@@ -777,6 +777,9 @@ if (GETPOST('actionadd') || GETPOST('actionmodify'))
             elseif (in_array($keycode, array('joinfile', 'private', 'position', 'scale'))) {
             	$sql .= (int) GETPOST($keycode, 'int');
             }
+			elseif ($keycode == 'localtax2') {
+				$sql .= "'".GETPOST($keycode, 'alpha')."'";
+			}
             else {
             	$sql .= "'".$db->escape(GETPOST($keycode, 'nohtml'))."'";
             }
@@ -843,6 +846,9 @@ if (GETPOST('actionadd') || GETPOST('actionmodify'))
             elseif (in_array($keycode, array('private', 'position', 'scale'))) {
             	$sql .= (int) GETPOST($keycode, 'int');
             }
+			elseif ($keycode == 'localtax2') {
+				$sql .= "'".GETPOST($keycode, 'alpha')."'";
+			}
             else {
             	$sql .= "'".$db->escape(GETPOST($keycode, 'nohtml'))."'";
             }


### PR DESCRIPTION
In Spain we handle various localtax2 rates. The nomenclature used is to separate them by the symbol ':'. With the parameter 'nohtml' in the GETPOST it did not work correctly since only the first rate was saved. So I have added a specific case for the localtax2.