### PR TITLE
Fix: properly set gid for Group LDAP synchro

### DIFF
--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -282,8 +282,8 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					$info=$object->_load_ldap_info();
 					$dn=$object->_load_ldap_dn($info);
 
-					// Get a gid number for objectclass PosixGroup
-					if (in_array('posixGroup', $info['objectclass'])) {
+					// Get a gid number for objectclass PosixGroup if none was provided
+					if (empty($info[$conf->global->LDAP_GROUP_FIELD_GROUPID]) && in_array('posixGroup', $info['objectclass'])) {
 						$info['gidNumber'] = $ldap->getNextGroupGid('LDAP_KEY_GROUPS');
 					}
 

--- a/htdocs/user/class/usergroup.class.php
+++ b/htdocs/user/class/usergroup.class.php
@@ -983,7 +983,7 @@ class UserGroup extends CommonObject
 			}
 			$info[$conf->global->LDAP_GROUP_FIELD_GROUPMEMBERS] = (!empty($valueofldapfield)?$valueofldapfield:'');
         }
-        if(!empty($info[$conf->global->LDAP_GROUP_FIELD_GROUPID])){
+        if(!empty($conf->global->LDAP_GROUP_FIELD_GROUPID)){
             $info[$conf->global->LDAP_GROUP_FIELD_GROUPID]=$this->id;
         }
 		return $info;

--- a/htdocs/user/group/ldap.php
+++ b/htdocs/user/group/ldap.php
@@ -69,8 +69,8 @@ if ($action == 'dolibarr2ldap')
 	{
 		$info=$object->_load_ldap_info();
 
-		// Get a gid number for objectclass PosixGroup
-		if (in_array('posixGroup', $info['objectclass'])) {
+		// Get a gid number for objectclass PosixGroup if none was provided
+		if (empty($info[$conf->global->LDAP_GROUP_FIELD_GROUPID]) && in_array('posixGroup', $info['objectclass'])) {
 			$info['gidNumber'] = $ldap->getNextGroupGid('LDAP_KEY_GROUPS');
 		}
 


### PR DESCRIPTION
Bugs present in 11.0, 12.0, 13.0 and develop since the introduction of the feature in #11868 .
**PR based off the 11.0 branch but will have to be merged in newer branches as well.**

#  Fix: properly set gid for Group LDAP synchro 

Even if the gidNumber field was set in the configuration, a gid different from the Dolibarr's one was generated and stored into LDAP.
Now the gidNumber is properly set to Dolibarr's gid if gidNumber field is set in the LDAP module configuration.