### PR TITLE
Fix add/del user to group modifies LDAP group

### DIFF
--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -126,6 +126,52 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					$newparent = $object->_load_ldap_dn($info, 1);
 
 					$result = $ldap->update($dn, $info, $user, $olddn, $newrdn, $newparent);
+
+					if ($result > 0 && !empty($object->context['newgroupid'])) {      // We are in context of adding a new group to user
+						$usergroup = new Usergroup($this->db);
+
+						$usergroup->fetch($object->context['newgroupid']);
+
+						$oldinfo = $usergroup->_load_ldap_info();
+						$olddn = $usergroup->_load_ldap_dn($oldinfo);
+
+						// Verify if entry exist
+						$container = $usergroup->_load_ldap_dn($oldinfo, 1);
+						$search = "(".$usergroup->_load_ldap_dn($oldinfo, 2).")";
+						$records = $ldap->search($container, $search);
+						if (count($records) && $records['count'] == 0)
+						{
+							$olddn = '';
+						}
+
+						$info = $usergroup->_load_ldap_info(); // Contains all members, included the new one (insert already done before trigger call)
+						$dn = $usergroup->_load_ldap_dn($info);
+
+						$result = $ldap->update($dn, $info, $user, $olddn);
+					}
+
+					if ($result > 0 && !empty($object->context['oldgroupid'])) {      // We are in context of removing a group from user
+						$usergroup = new Usergroup($this->db);
+
+						$usergroup->fetch($object->context['oldgroupid']);
+
+						$oldinfo = $usergroup->_load_ldap_info();
+						$olddn = $usergroup->_load_ldap_dn($oldinfo);
+
+						// Verify if entry exist
+						$container = $usergroup->_load_ldap_dn($oldinfo, 1);
+						$search = "(".$usergroup->_load_ldap_dn($oldinfo, 2).")";
+						$records = $ldap->search($container, $search);
+						if (count($records) && $records['count'] == 0)
+						{
+							$olddn = '';
+						}
+
+						$info = $usergroup->_load_ldap_info(); // Contains all members, except the old one (remove already done before trigger call)
+						$dn = $usergroup->_load_ldap_dn($info);
+
+						$result = $ldap->update($dn, $info, $user, $olddn);
+					}
 				}
 
 				if ($result < 0) $this->error = "ErrorLDAP ".$ldap->error;


### PR DESCRIPTION
Bug present at least in 12.0, 13.0 and develop but it has probably been there for longer.

_**v2:**_
**PR based off the 12.0 branch but will have to be merged in newer branches as well.**

# Fix add/del user to group modifies LDAP group 

Adding or removing a user from a group modifies the user object on Dolibarr's side.
In LDAP however, members of a group are stored in the group itself.
Therefore group must be updated after adding/removing a user from it.
Update group in LDAP with new list of users at the end of USER_MODIFY trigger.

~~_**v1:**_~~
~~**PR based off the 12.0 branch (to at least have the correct `USERGROUP_MODIFY` trigger) but will have to be merged in newer branches as well.**~~

# ~~Fix add/del user to group trigger USERGROUP_MODIFY~~

~~Adding or removing a user from a group modifies the user object on Dolibarr's side.~~
~~In LDAP however, members of a group are stored in the group itself.~~
~~Therefore group must be updated after adding/removing a user from it.~~
~~Trigger the USERGROUP_MODIFY event from SetInGroup/RemoveFromGroup to that effect.~~

~~**Warning**: I don't know if there are side effects to calling the trigger here. I also don't know if it is the proper way to solve this problem.~~