### PR TITLE
Fix entity was set to 0 on group creation (HOT FIX)

### DIFF
--- a/htdocs/user/group/card.php
+++ b/htdocs/user/group/card.php
@@ -138,7 +138,7 @@ if (empty($reshook)) {
 				if (!empty($conf->multicompany->enabled) && !empty($conf->global->MULTICOMPANY_TRANSVERSE_MODE)) {
 					$object->entity = 0;
 				} else {
-					$object->entity = GETPOST("entity");
+					$object->entity = GETPOSTISSET("entity") ? GETPOST("entity") : $conf->entity;
 				}
 
 				$db->begin();

--- a/htdocs/user/group/card.php
+++ b/htdocs/user/group/card.php
@@ -138,7 +138,11 @@ if (empty($reshook)) {
 				if (!empty($conf->multicompany->enabled) && !empty($conf->global->MULTICOMPANY_TRANSVERSE_MODE)) {
 					$object->entity = 0;
 				} else {
-					$object->entity = GETPOSTISSET("entity") ? GETPOST("entity") : $conf->entity;
+					if ($conf->entity == 1 && $user->admin && !$user->entity) {		// Same permissions test than the one used to show the combo of entities into the form
+						$object->entity = GETPOSTISSET("entity") ? GETPOST("entity") : $conf->entity;
+					} else {
+						$object->entity = $conf->entity;
+					}
 				}
 
 				$db->begin();


### PR DESCRIPTION
HOT FIX : user group creation was getting entity = 0.
In v13 $_POST['entity'] was giving null value and later replaced by $conf->entity. Now GETPOST('entity') gives '' instead of null