### PR TITLE
Fix id of expense report must be before object fetch (HOT FIX)

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -55,6 +55,7 @@ $action = GETPOST('action', 'aZ09');
 $cancel = GETPOST('cancel', 'alpha');
 $confirm = GETPOST('confirm', 'alpha');
 
+$id = GETPOST('id', 'int');
 $date_start = dol_mktime(0, 0, 0, GETPOST('date_debutmonth', 'int'), GETPOST('date_debutday', 'int'), GETPOST('date_debutyear', 'int'));
 $date_end = dol_mktime(0, 0, 0, GETPOST('date_finmonth', 'int'), GETPOST('date_finday', 'int'), GETPOST('date_finyear', 'int'));
 $date = dol_mktime(0, 0, 0, GETPOST('datemonth', 'int'), GETPOST('dateday', 'int'), GETPOST('dateyear', 'int'));
@@ -120,7 +121,6 @@ if ($object->id > 0) {
 }
 
 // Security check
-$id = GETPOST("id", 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }


### PR DESCRIPTION
Introduced by 1d87f060dc75ec3779fa64ffa876ae0ae70c84e2
id must be retrieved before the object fetch