### PR TITLE
FIX filter by supplier on replenish

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -327,7 +327,7 @@ $sql .= ' FROM '.MAIN_DB_PREFIX.'product as p';
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_stock as s ON p.rowid = s.fk_product';
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'entrepot AS ent ON s.fk_entrepot = ent.rowid AND ent.entity IN('.getEntity('stock').')';
 if ($fk_supplier > 0) {
-	$sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'product_fournisseur_price pfp ON (pfp.fk_product = p.rowid AND pfp.fk_soc = '.$fk_supplier.')';
+	$sql .= ' INNER JOIN '. MAIN_DB_PREFIX . 'product_fournisseur_price pfp ON pfp.rowid = (SELECT pfp1.rowid FROM llx_product_fournisseur_price pfp1 WHERE pfp1.fk_product = p.rowid AND pfp1.fk_soc = ' . $fk_supplier . ' ORDER BY pfp1.rowid LIMIT 1)';
 }
 if (!empty($conf->global->STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE) && $fk_entrepot > 0) {
 	$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_warehouse_properties AS pse ON (p.rowid = pse.fk_product AND pse.fk_entrepot = '.$fk_entrepot.')';


### PR DESCRIPTION
FIX filter by supplier on replenish
- when you want to replenish, and you filter by supplier, the stock of product can be computed several times if the product has several buying prices (same supplier)
- so when you filter on "alerts only" this product can disappear of theses results whereas the same product has a stock alert (in stock tab of product card)

**In replenish with no filter**
![image](https://user-images.githubusercontent.com/45359511/118619871-4476aa80-b7c5-11eb-81ba-025065c0dfaa.png)

**In replenish filter by supplier (no result)**
![image](https://user-images.githubusercontent.com/45359511/118619456-e649c780-b7c4-11eb-96ca-806e6cfa34fe.png)

**In stock tab of product card**
![image](https://user-images.githubusercontent.com/45359511/118619659-17c29300-b7c5-11eb-8fbd-75964ecd8600.png)

