### PR TITLE
FIX 13.0 - wrong error message for mail sending failure

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -559,8 +559,10 @@ if (!$error && $massaction == 'confirm_presend')
 							{
 								$resaction .= $langs->trans('ErrorFailedToSendMail', $from, $sendto);
 								$resaction .= '<br><div class="error">'.$mailfile->error.'</div>';
-							} else {
+							} elseif (!empty($conf->global->MAIN_DISABLE_ALL_MAILS)) {
 								$resaction .= '<div class="warning">No mail sent. Feature is disabled by option MAIN_DISABLE_ALL_MAILS</div>';
+							} else {
+								$resaction .= $langs->trans('ErrorFailedToSendMail', $from, $sendto) . '<br><div class="error">(unhandled error)</div>';
 							}
 						}
 					}

--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -894,7 +894,7 @@ class CMailFile
 				}
 				// send mail
 				try {
-					$result = $this->mailer->send($this->message);
+					$result = $this->mailer->send($this->message, $failedRecipients);
 				} catch (Exception $e) {
 					$this->error = $e->getMessage();
 				}
@@ -902,6 +902,9 @@ class CMailFile
 
 				$res = true;
 				if (!empty($this->error) || !$result) {
+					if (!empty($failedRecipients)) {
+						$this->error = 'Transport failed for the following addresses: "' . join('", "', $failedRecipients) . '".';
+					}
 					dol_syslog("CMailFile::sendfile: mail end error=".$this->error, LOG_ERR);
 					$res = false;
 				} else {


### PR DESCRIPTION
# Fix wrong error message for mail sending failure
When you send an e-mail using a mass action with swiftmailer, there is at least one case when you may get “No mail sent. Feature is disabled by option MAIN_DISABLE_ALL_MAILS” whereas, in fact, the option is not set.

In swiftmailer's `send` method, there is a try/catch block for the `Swift_RfcComplianceException` exception; when the exception is caught, an optional array argument (passed by reference) is filled.

Using this can be useful to know which e-mail addresses were rejected as non-compliant.

This PR tries to address this.