### PR TITLE
FIX wrong variable fk_code_ventilation register for addline

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1830,7 +1830,7 @@ class FactureFournisseur extends CommonInvoice
 			$this->line->remise_percent = $remise_percent;
 			$this->line->date_start = $date_start;
 			$this->line->date_end = $date_end;
-			$this->line->ventil = $ventil;
+			$this->line->fk_code_ventilation = $ventil;
 			$this->line->rang = $rang;
 			$this->line->info_bits = $info_bits;
 


### PR DESCRIPTION
In insert function in fournisseur.facture.class.php, the name is not $ventil

![image](https://user-images.githubusercontent.com/2341395/118757204-ed2c1500-b86c-11eb-801b-68679498399c.png)
