### PR TITLE
Fix :  multiprices log spam

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1534,6 +1534,38 @@ class Product extends CommonObject
 		}
 	}
 
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *  check if price have really change to avoid log pollution
+	 *
+	 * @param  int  $level price level to change
+	 * @return int                    <0 if KO, >0 if OK
+	 */
+	private function getArrayForPriceCompare($level = 0)
+	{
+		// phpcs:enable
+
+		$testExit = array('multiprices','multiprices_ttc','multiprices_base_type','multiprices_min','multiprices_min_ttc','multiprices_tva_tx','multiprices_recuperableonly');
+
+		foreach ($testExit as $field){
+			if (!isset($this->$field[$level])) {
+				return array();
+			}
+		}
+
+		$lastPrice = array(
+			'level' => $level ? $level : 1,
+			'multiprices' => doubleval($this->multiprices[$level]),
+			'multiprices_ttc' => doubleval($this->multiprices_ttc[$level]),
+			'multiprices_base_type' => $this->multiprices_base_type[$level],
+			'multiprices_min' => doubleval($this->multiprices_min[$level]),
+			'multiprices_min_ttc' => doubleval($this->multiprices_min_ttc[$level]),
+			'multiprices_tva_tx' => doubleval($this->multiprices_tva_tx[$level]),
+			'multiprices_recuperableonly' => doubleval($this->multiprices_recuperableonly[$level]),
+		);
+
+		return $lastPrice;
+	}
 
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -1862,6 +1894,8 @@ class Product extends CommonObject
 	{
 		global $conf, $langs;
 
+		$lastPriceData = $this->getArrayForPriceCompare($level); // temporary store current price before update
+
 		$id = $this->id;
 
 		dol_syslog(get_class($this)."::update_price id=".$id." newprice=".$newprice." newpricebase=".$newpricebase." newminprice=".$newminprice." level=".$level." npr=".$newnpr." newdefaultvatcode=".$newdefaultvatcode);
@@ -1994,7 +2028,11 @@ class Product extends CommonObject
 				// Price by quantity
 				$this->price_by_qty = $newpbq;
 
-				$this->_log_price($user, $level); // Save price for level into table product_price
+				// check if price have really change before log
+				$newPriceData = $this->getArrayForPriceCompare($level);
+				if (!empty(array_diff_assoc($newPriceData, $lastPriceData)) || empty($conf->global->PRODUIT_MULTIPRICES)) {
+					$this->_log_price($user, $level); // Save price for level into table product_price
+				}
 
 				$this->level = $level; // Store level of price edited for trigger
 

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1534,7 +1534,6 @@ class Product extends CommonObject
 		}
 	}
 
-	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *  check if price have really change to avoid log pollution
 	 *
@@ -1543,7 +1542,6 @@ class Product extends CommonObject
 	 */
 	private function getArrayForPriceCompare($level = 0)
 	{
-		// phpcs:enable
 
 		$testExit = array('multiprices','multiprices_ttc','multiprices_base_type','multiprices_min','multiprices_min_ttc','multiprices_tva_tx','multiprices_recuperableonly');
 

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1535,10 +1535,10 @@ class Product extends CommonObject
 	}
 
 	/**
-	 *  check if price have really change to avoid log pollution
+	 *  used to check if price have really change to avoid log pollution
 	 *
 	 * @param  int  $level price level to change
-	 * @return int                    <0 if KO, >0 if OK
+	 * @return array
 	 */
 	private function getArrayForPriceCompare($level = 0)
 	{


### PR DESCRIPTION
if PRODUIT_MULTIPRICES conf is activated, when user change just one price level data, all price levels are logs in history. This behavior can spam database with a lots of useless insert specially if there is a lot of level and updates  from an API or external modules or if product use variants