### PR TITLE
avoid an infinite loop between a parent company and a branch when updating customer rates

### DIFF
--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -349,7 +349,7 @@ $help_url = 'EN:Commercial_Proposals|FR:Proposition_commerciale|ES:Presupuestos'
 
 $sql = 'SELECT';
 if ($sall || $search_product_category > 0 || $search_user > 0) $sql = 'SELECT DISTINCT';
-$sql .= ' s.rowid as socid, s.nom as name, s.email, s.town, s.zip, s.fk_pays, s.client, s.code_client, ';
+$sql .= ' s.rowid as socid, s.nom as name, s.name_alias, s.email, s.town, s.zip, s.fk_pays, s.client, s.code_client, ';	// InfraS change
 $sql .= " typent.code as typent_code,";
 $sql .= " ava.rowid as availability,";
 $sql .= " state.code_departement as state_code, state.nom as state_name,";
@@ -949,6 +949,7 @@ if ($resql)
 
 		$companystatic->id = $obj->socid;
 		$companystatic->name = $obj->name;
+		$companystatic->name_alias = $obj->name_alias;	// InfraS add
 		$companystatic->client = $obj->client;
 		$companystatic->code_client = $obj->code_client;
 		$companystatic->email = $obj->email;

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -270,7 +270,7 @@ $help_url = "EN:Module_Customers_Orders|FR:Module_Commandes_Clients|ES:Módulo_P
 
 $sql = 'SELECT';
 if ($sall || $search_product_category > 0 || $search_user > 0) $sql = 'SELECT DISTINCT';
-$sql .= ' s.rowid as socid, s.nom as name, s.email, s.town, s.zip, s.fk_pays, s.client, s.code_client,';
+$sql .= ' s.rowid as socid, s.nom as name, s.name_alias, s.email, s.town, s.zip, s.fk_pays, s.client, s.code_client,';	// InfraS change
 $sql .= " typent.code as typent_code,";
 $sql .= " state.code_departement as state_code, state.nom as state_name,";
 $sql .= ' c.rowid, c.ref, c.total_ht, c.tva as total_tva, c.total_ttc, c.ref_client, c.fk_user_author,';
@@ -937,6 +937,7 @@ if ($resql)
 		$companystatic->id = $obj->socid;
 		$companystatic->code_client = $obj->code_client;
 		$companystatic->name = $obj->name;
+		$companystatic->name_alias = $obj->name_alias;	// InfraS add
 		$companystatic->client = $obj->client;
 		$companystatic->email = $obj->email;
 		if (!isset($getNomUrl_cache[$obj->socid])) {

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -422,7 +422,7 @@ $sql .= ' f.datef as df, f.date_valid, f.date_lim_reglement as datelimite, f.mod
 $sql .= ' f.paye as paye, f.fk_statut, f.close_code,';
 $sql .= ' f.datec as date_creation, f.tms as date_update, f.date_closing as date_closing,';
 $sql .= ' f.retained_warranty, f.retained_warranty_date_limit, f.situation_final, f.situation_cycle_ref, f.situation_counter,';
-$sql .= ' s.rowid as socid, s.nom as name, s.email, s.town, s.zip, s.fk_pays, s.client, s.fournisseur, s.code_client, s.code_fournisseur, s.code_compta as code_compta_client, s.code_compta_fournisseur,';
+$sql .= ' s.rowid as socid, s.nom as name, s.name_alias, s.email, s.town, s.zip, s.fk_pays, s.client, s.fournisseur, s.code_client, s.code_fournisseur, s.code_compta as code_compta_client, s.code_compta_fournisseur,';	// InfraS change
 $sql .= " typent.code as typent_code,";
 $sql .= " state.code_departement as state_code, state.nom as state_name,";
 $sql .= " country.code as country_code,";
@@ -1193,6 +1193,7 @@ if ($resql)
 			}
 			$thirdpartystatic->id = $obj->socid;
 			$thirdpartystatic->name = $obj->name;
+			$thirdpartystatic->name_alias = $obj->name_alias;	// InfraS add
 			$thirdpartystatic->client = $obj->client;
 			$thirdpartystatic->fournisseur = $obj->fournisseur;
 			$thirdpartystatic->code_client = $obj->code_client;

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -3113,26 +3113,26 @@ class Societe extends CommonObject
 		// phpcs:enable
 		if ($this->id) {
 			// InfraS change (to avoid infinite loop)
-			$sameparent				= $this->get_parents($id, $this->id);
-			if ($sameparent < 0)	return -1;
-			elseif ($sameparent == 1)
-			{
-				setEventMessages('la maison mère choisie est déjà filiale de ce tiers', null, 'warnings');
+			$sameparent	= $this->get_parents($id, $this->id);
+			if ($sameparent < 0) {
 				return -1;
-			}	// elseif ($sameparent == 1)
-			else {
+			} elseif ($sameparent == 1) {
+				setEventMessages('ParentCompanyIsAlreadyAChild', null, 'warnings');
+				return -1;
+			} else {
 				$sql	= 'UPDATE '.MAIN_DB_PREFIX.'societe SET parent = '.($id > 0 ? $id : 'null').' WHERE rowid = '.$this->id;
 				dol_syslog(get_class($this).'::set_parent', LOG_DEBUG);
 				$resql	= $this->db->query($sql);
-				if ($resql)
-				{
+				if ($resql) {
 					$this->parent	= $id;
 					return 1;
-				}	// if ($resql)
-				else return -1;
-			}	// else	// elseif ($sameparent == 1)
-		}	// if ($this->id)
-		else return -1;
+				} else {
+					return -1;
+				}
+			}
+		} else {
+			return -1;
+		}
 	}
 
     // phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -3150,16 +3150,20 @@ class Societe extends CommonObject
 		$sql	.= ' FROM '.MAIN_DB_PREFIX.'societe as s';
 		$sql	.= ' WHERE rowid = '.$idparent;
 		$resql	= $this->db->query($sql);
-		if ($resql)
-		{
+		if ($resql) {
 			$obj	= $this->db->fetch_object($resql);
 
-			if ($obj->parent == '')				return 0;
-			elseif ($obj->parent == $idchild)	return 1;
-			else $sameparent	= $this->get_parents($obj->parent, $idchild);
+			if ($obj->parent == '')	{
+				return 0;
+			} elseif ($obj->parent == $idchild)	{
+				return 1;
+			} else {
+				$sameparent	= $this->get_parents($obj->parent, $idchild);
+			}
 			return $sameparent;
-		}	// if ($resql)
-		else return -1;
+		} else {
+			return -1;
+		}
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -3112,15 +3112,15 @@ class Societe extends CommonObject
 	{
 		// phpcs:enable
 		if ($this->id) {
-			// InfraS change (to avoid infinite loop)
+			// Check if the id we want to add as parent has not already one parent that is the current id we try to update
 			$sameparent	= $this->validateFamilyTree($id, $this->id, 0);
 			if ($sameparent < 0) {
 				return -1;
 			} elseif ($sameparent == 1) {
-				setEventMessages('ParentCompanyIsAlreadyAChild', null, 'warnings');
+				setEventMessages('ParentCompanyToAddIsAlreadyAChildOfModifiedCompany', null, 'warnings');
 				return -1;
 			} else {
-				$sql	= 'UPDATE '.MAIN_DB_PREFIX.'societe SET parent = '.($id > 0 ? $id : 'null').' WHERE rowid = '.$this->id;
+				$sql = 'UPDATE '.MAIN_DB_PREFIX.'societe SET parent = '.($id > 0 ? $id : 'null').' WHERE rowid = '.((int) $this->id);
 				dol_syslog(get_class($this).'::set_parent', LOG_DEBUG);
 				$resql	= $this->db->query($sql);
 				if ($resql) {
@@ -3148,7 +3148,7 @@ class Societe extends CommonObject
 		if ($counter > 100) {
 			dol_syslog("Too high level of parent - child for company. May be an infinite loop ?", LOG_WARNING);
 		}
-
+		
 		$sql	= 'SELECT s.parent';
 		$sql	.= ' FROM '.MAIN_DB_PREFIX.'societe as s';
 		$sql	.= ' WHERE rowid = '.$idparent;

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -3148,7 +3148,7 @@ class Societe extends CommonObject
 		if ($counter > 100) {
 			dol_syslog("Too high level of parent - child for company. May be an infinite loop ?", LOG_WARNING);
 		}
-		
+
 		$sql	= 'SELECT s.parent';
 		$sql	.= ' FROM '.MAIN_DB_PREFIX.'societe as s';
 		$sql	.= ' WHERE rowid = '.$idparent;

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -3120,8 +3120,7 @@ class Societe extends CommonObject
 				setEventMessages('la maison mère choisie est déjà filiale de ce tiers', null, 'warnings');
 				return -1;
 			}	// elseif ($sameparent == 1)
-			else
-			{
+			else {
 				$sql	= 'UPDATE '.MAIN_DB_PREFIX.'societe SET parent = '.($id > 0 ? $id : 'null').' WHERE rowid = '.$this->id;
 				dol_syslog(get_class($this).'::set_parent', LOG_DEBUG);
 				$resql	= $this->db->query($sql);
@@ -3130,7 +3129,7 @@ class Societe extends CommonObject
 					$this->parent	= $id;
 					return 1;
 				}	// if ($resql)
-				else	return -1;
+				else return -1;
 			}	// else	// elseif ($sameparent == 1)
 		}	// if ($this->id)
 		else return -1;
@@ -3157,10 +3156,10 @@ class Societe extends CommonObject
 
 			if ($obj->parent == '')				return 0;
 			elseif ($obj->parent == $idchild)	return 1;
-			else								$sameparent	= $this->get_parents($obj->parent, $idchild);
+			else $sameparent	= $this->get_parents($obj->parent, $idchild);
 			return $sameparent;
 		}	// if ($resql)
-		else	return -1;
+		else return -1;
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps


### PR DESCRIPTION
# Fix #14119
If you select a parent company for a third party, you are able to define it as the parent company of its parent company.
Then, by updating the customer price of the branch from the price of the parent company, you create an infinite loop!