### PR TITLE
bug fix : replacing orders by donations and setting required field to…

### DIFF
--- a/htdocs/don/class/api_donations.class.php
+++ b/htdocs/don/class/api_donations.class.php
@@ -33,7 +33,7 @@ class Donations extends DolibarrApi
 	 * @var array   $FIELDS     Mandatory fields, checked when create and update object
 	 */
 	static $FIELDS = array(
-		'socid'
+		'amount'
 	);
 
 	/**
@@ -193,7 +193,7 @@ class Donations extends DolibarrApi
         }*/
 
 		if ($this->don->create(DolibarrApiAccess::$user) < 0) {
-			throw new RestException(500, "Error creating order", array_merge(array($this->don->error), $this->don->errors));
+			throw new RestException(500, "Error creating donation", array_merge(array($this->don->error), $this->don->errors));
 		}
 
 		return $this->don->id;
@@ -355,7 +355,7 @@ class Donations extends DolibarrApi
 	private function _validate($data)
 	{
 		$don = array();
-		foreach (Orders::$FIELDS as $field) {
+		foreach (Donations::$FIELDS as $field) {
 			if (!isset($data[$field]))
 				throw new RestException(400, $field." field missing");
 			$don[$field] = $data[$field];

--- a/htdocs/don/class/api_donations.class.php
+++ b/htdocs/don/class/api_donations.class.php
@@ -302,7 +302,7 @@ class Donations extends DolibarrApi
 			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
-		$result = $this->don->valid(DolibarrApiAccess::$user, $idwarehouse, $notrigger);
+		$result = $this->don->valid_promesse($id, DolibarrApiAccess::$user->id, $notrigger);
 		if ($result == 0) {
 			throw new RestException(304, 'Error nothing done. May be object is already validated');
 		}

--- a/htdocs/don/class/don.class.php
+++ b/htdocs/don/class/don.class.php
@@ -390,7 +390,7 @@ class Don extends CommonObject
 		$sql .= ", phone";
 		$sql .= ", phone_mobile";
 		$sql .= ") VALUES (";
-		$sql .= "'".$this->db->idate($now)."'";
+		$sql .= "'".$this->db->idate($this->date)."'";
 		$sql .= ", ".$conf->entity;
 		$sql .= ", ".price2num($this->amount);
 		$sql .= ", ".($this->modepaymentid ? $this->modepaymentid : "null");

--- a/htdocs/don/class/don.class.php
+++ b/htdocs/don/class/don.class.php
@@ -390,7 +390,7 @@ class Don extends CommonObject
 		$sql .= ", phone";
 		$sql .= ", phone_mobile";
 		$sql .= ") VALUES (";
-		$sql .= "'".$this->db->idate($this->date)."'";
+		$sql .= "'".$this->db->idate($this->date ? $this->date : $now)."'";
 		$sql .= ", ".$conf->entity;
 		$sql .= ", ".price2num($this->amount);
 		$sql .= ", ".($this->modepaymentid ? $this->modepaymentid : "null");


### PR DESCRIPTION
… allow post action in rest API for url donations. See issue #17700

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #17700
The REST API is not working for POST /donations which throw an exception in apache error.logs.
The  htdocs/don/class/api_donations.class.php is refering to Orders class and not to Donations which is probably due to a wrong copy/past.

