### PR TITLE
FIX: postgresql: rebuild sequences at install/upgrade/repair 

### DIFF
--- a/htdocs/install/mysql/data/llx_zzz_install_end.sql
+++ b/htdocs/install/mysql/data/llx_zzz_install_end.sql
@@ -1,0 +1,21 @@
+-- Copyright (C) 2021      Marc de Lima Lucio   <68746600+marc-dll@users.noreply.github.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- Do not add comment at end of line. This file is parsed by install and -- are removed
+
+
+-- PostgreSQL only: recalculate sequences for data INSERTed with forced auto_increment/serial primary key
+-- POSTGRESQL V8.2 SELECT dol_util_rebuild_sequences();
+

--- a/htdocs/install/mysql/migration/10.0.0-11.0.0.sql
+++ b/htdocs/install/mysql/migration/10.0.0-11.0.0.sql
@@ -572,9 +572,3 @@ ALTER TABLE llx_emailcollector_emailcollector ADD UNIQUE INDEX uk_emailcollector
 ALTER TABLE llx_website ADD COLUMN use_manifest integer;
 
 ALTER TABLE llx_facture_rec MODIFY COLUMN fk_cond_reglement integer NOT NULL DEFAULT 1;
-
-
--- DO NOT ADD ANYTHING BELOW THIS LINE
-
--- PostgreSQL only: recalculate sequences for data INSERTed with forced auto_increment/serial primary key
--- VPGSQL8.2 SELECT dol_util_rebuild_sequences();

--- a/htdocs/install/mysql/migration/10.0.0-11.0.0.sql
+++ b/htdocs/install/mysql/migration/10.0.0-11.0.0.sql
@@ -572,3 +572,9 @@ ALTER TABLE llx_emailcollector_emailcollector ADD UNIQUE INDEX uk_emailcollector
 ALTER TABLE llx_website ADD COLUMN use_manifest integer;
 
 ALTER TABLE llx_facture_rec MODIFY COLUMN fk_cond_reglement integer NOT NULL DEFAULT 1;
+
+
+-- DO NOT ADD ANYTHING BELOW THIS LINE
+
+-- PostgreSQL only: recalculate sequences for data INSERTed with forced auto_increment/serial primary key
+-- VPGSQL8.2 SELECT dol_util_rebuild_sequences();

--- a/htdocs/install/mysql/migration/repair.sql
+++ b/htdocs/install/mysql/migration/repair.sql
@@ -524,3 +524,7 @@ UPDATE llx_facturedet SET situation_percent = 100 WHERE situation_percent IS NUL
 --ALTER TABLE llx_tablename ROW_FORMAT=DYNAMIC;
 
 
+-- DO NOT ADD ANYTHING BELOW THIS LINE
+
+-- PostgreSQL only: recalculate sequences for data INSERTed with forced auto_increment/serial primary key
+-- VPGSQL8.2 SELECT dol_util_rebuild_sequences();

--- a/htdocs/install/step2.php
+++ b/htdocs/install/step2.php
@@ -555,6 +555,33 @@ if ($action == "set")
                     $buffer = trim($buffer);
                     if ($buffer)
                     {
+                        // Special case of lines allowed for some version only
+                        if ($choix == 1 && preg_match('/^--\sV([0-9\.]+)/i', $buffer, $reg))
+                        {
+                            $versioncommande=explode('.', $reg[1]);
+                            //print var_dump($versioncommande);
+                            //print var_dump($versionarray);
+                            if (count($versioncommande) && count($versionarray)
+                            && versioncompare($versioncommande, $versionarray) <= 0)
+                            {
+                                // Version qualified, delete SQL comments
+                                $buffer=preg_replace('/^--\sV([0-9\.]+)/i', '', $buffer);
+                                //print "Ligne $i qualifiee par version: ".$buf.'<br>';
+                            }
+                        }
+                        if ($choix == 2 && preg_match('/^--\sPOSTGRESQL\sV([0-9\.]+)/i', $buffer, $reg))
+                        {
+                            $versioncommande=explode('.', $reg[1]);
+                            //print var_dump($versioncommande);
+                            //print var_dump($versionarray);
+                            if (count($versioncommande) && count($versionarray)
+                            && versioncompare($versioncommande, $versionarray) <= 0)
+                            {
+                                // Version qualified, delete SQL comments
+                                $buffer=preg_replace('/^--\sPOSTGRESQL\sV([0-9\.]+)/i', '', $buffer);
+                                //print "Ligne $i qualifiee par version: ".$buf.'<br>';
+                            }
+                        }
                         if (substr($buffer, 0, 2) == '--') continue;
 
                         if ($linefound && ($linefound % $sizeofgroup) == 0)


### PR DESCRIPTION
Contrary to MySQL, PostgreSQL doesn't recompute a `SERIAL` sequence (equivalent to `AUTO_INCREMENT`) when an `INSERT` query declares it explicitly. This happens for example in some dictionary tables, like in the script `htdocs/install/mysql/data/llx_c_chargesociales.sql`.

As a consequence causes multiple `DB_ERROR_RECORD_ALREADY_EXISTS` (as many as the first available unused value) when `INSERT`ing in such tables after the offset (the sequence advances even when the record already exists).

The necessary function to correctly "reboot" the sequence was created but never called (except in v14). It should be, at least at install, upgrade and repair.

If this is validated, I will propose subsequent PRs for the migration script in version 12 and later.