### PR TITLE
Fix label of subaccount

### DIFF
--- a/htdocs/accountancy/bookkeeping/listbysubaccount.php
+++ b/htdocs/accountancy/bookkeeping/listbysubaccount.php
@@ -682,7 +682,7 @@ while ($i < min($num, $limit)) {
 		print "<tr>";
 		print '<td colspan="'.($totalarray['nbfield'] ? $totalarray['nbfield'] : 10).'" style="font-weight:bold; border-bottom: 1pt solid black;">';
 		if ($line->subledger_account != "" && $line->subledger_account != '-1') {
-			print $object->get_compte_desc($line->numero_compte).' : '.length_accounta($line->subledger_account);
+			print $line->subledger_label.' : '.length_accounta($line->subledger_account);
 		} else {
 			// Should not happen: subledger account must be null or a non empty value
 			print '<span class="error">'.$langs->trans("Unknown");


### PR DESCRIPTION
Showing label of each subledger_account  as headline in the View by accounting account (Subledger), not the description of the ledger from the first item.


