### PR TITLE
Fix: Do a strict comparison when check if stock is enough

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -355,7 +355,7 @@ class MouvementStock extends CommonObject
 				$qtyisnotenough = 0;
 				foreach ($product->stock_warehouse[$entrepot_id]->detail_batch as $batchcursor => $prodbatch)
 				{
-					if ($batch != $batchcursor) continue;
+					if ($batch !== $batchcursor) continue; // Do a strict comparison because $batchcursar can be an integer
 					$foundforbatch = 1;
 					if ($prodbatch->qty < abs($qty)) $qtyisnotenough = $prodbatch->qty;
 					break;

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -355,7 +355,9 @@ class MouvementStock extends CommonObject
 				$qtyisnotenough = 0;
 				foreach ($product->stock_warehouse[$entrepot_id]->detail_batch as $batchcursor => $prodbatch)
 				{
-					if ($batch !== $batchcursor) continue; // Do a strict comparison because $batchcursar can be an integer
+					if ((string) $batch != (string) $batchcursor) {		// Lot '59' must be different than lot '59c'
+						continue;
+					}
 					$foundforbatch = 1;
 					if ($prodbatch->qty < abs($qty)) $qtyisnotenough = $prodbatch->qty;
 					break;


### PR DESCRIPTION
# Fix bug

If a product with 2 batchs like 59 and 59c, ship the product with batch 59c will fail if the stock is not enough for 59.