### PR TITLE
ADD note to supplier order refusal

### DIFF
--- a/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
+++ b/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
@@ -552,7 +552,7 @@ class InterfaceActionsAuto extends DolibarrTriggers
 			$object->actionmsg = $langs->transnoentities("OrderRefusedInDolibarr", $object->ref);
 
 			if (!empty($object->refuse_note)) {
-				$object->actionmsg .= '<br />';
+				$object->actionmsg .= '<br>';
 				$object->actionmsg .= $langs->trans("Reason") . ': '.$object->refuse_note;
 			}
 

--- a/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
+++ b/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
@@ -544,12 +544,17 @@ class InterfaceActionsAuto extends DolibarrTriggers
 			$object->sendtoid = 0;
 		} elseif ($action == 'ORDER_SUPPLIER_REFUSE') {
 			// Load translation files required by the page
-			$langs->loadLangs(array("agenda", "other", "orders"));
+			$langs->loadLangs(array("agenda", "other", "orders", "main"));
 
 			if (empty($object->actionmsg2)) {
 				$object->actionmsg2 = $langs->transnoentities("OrderRefusedInDolibarr", $object->ref);
 			}
 			$object->actionmsg = $langs->transnoentities("OrderRefusedInDolibarr", $object->ref);
+
+			if (!empty($object->refuse_note)) {
+				$object->actionmsg .= '<br />';
+				$object->actionmsg .= $langs->trans("Reason") . ': '.$object->refuse_note;
+			}
 
 			$object->sendtoid = 0;
 		} elseif ($action == 'ORDER_SUPPLIER_SUBMIT') {

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -960,6 +960,9 @@ if (empty($reshook)) {
 	}
 
 	if ($action == 'confirm_refuse' && $confirm == 'yes' && $usercanapprove) {
+		if (GETPOST('refuse_note')) {
+			$object->refuse_note = GETPOST('refuse_note');
+		}
 		$result = $object->refuse($user);
 		if ($result > 0) {
 			header("Location: ".$_SERVER["PHP_SELF"]."?id=".$object->id);
@@ -1875,7 +1878,16 @@ if ($action == 'create') {
 
 	// Confirmation de la desapprobation
 	if ($action == 'refuse') {
-		$formconfirm = $form->formconfirm($_SERVER['PHP_SELF']."?id=$object->id", $langs->trans("DenyingThisOrder"), $langs->trans("ConfirmDenyingThisOrder", $object->ref), "confirm_refuse", '', 0, 1);
+		$formquestion = array(
+			array(
+				'type' => 'text',
+				'name' => 'refuse_note',
+				'label' => $langs->trans("MotifCP"),
+				'value' => '',
+				'morecss' => 'minwidth300'
+			)
+		);
+		$formconfirm  = $form->formconfirm($_SERVER['PHP_SELF']."?id=$object->id", $langs->trans("DenyingThisOrder"), $langs->trans("ConfirmDenyingThisOrder", $object->ref), "confirm_refuse", $formquestion, 0, 1);
 	}
 
 	// Confirmation de l'annulation


### PR DESCRIPTION
This adds a textfield to the refusal dialog box.
If text is set it is saved to the agenda item and is accessible to the trigger