### PR TITLE
NEW/FIX : Allow auto picking for child warehouse and taking into account of the quantities already affected in list

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1021,10 +1021,9 @@ if ($action == 'create') {
 			$object->loadExpeditions();
 
 
-            $alreadyQtyBatchSetted = $alreadyQtySetted = array();
+			$alreadyQtyBatchSetted = $alreadyQtySetted = array();
 
-            if ($numAsked)
-            {
+			if ($numAsked) {
 				print '<tr class="liste_titre">';
 				print '<td>'.$langs->trans("Description").'</td>';
 				print '<td class="center">'.$langs->trans("QtyOrdered").'</td>';
@@ -1049,12 +1048,12 @@ if ($action == 'create') {
 			}
 
 			$warehouse_id = GETPOST('entrepot_id', 'int');
-            $warehousePicking = array();
-            // get all warehouse children for picking
-			if($warehouse_id > 0){
+			$warehousePicking = array();
+			// get all warehouse children for picking
+			if ($warehouse_id > 0) {
 				$warehousePicking[] = $warehouse_id;
 				$warehouseObj = new Entrepot($db);
-				$warehouseObj->get_children_warehouses($warehouse_id,$warehousePicking);
+				$warehouseObj->get_children_warehouses($warehouse_id, $warehousePicking);
 			}
 
 			$indiceAsked = 0;
@@ -1306,7 +1305,7 @@ if ($action == 'create') {
 							// Define nb of lines suggested for this order line
 							$nbofsuggested = 0;
 
-							uasort ( $product->stock_warehouse , function ($a, $b){
+							uasort( $product->stock_warehouse, function ($a, $b) {
 								if ($a->real == $b->real) { return 0; }
 								return ($a->real < $b->real) ? -1 : 1;
 							});
@@ -1318,8 +1317,7 @@ if ($action == 'create') {
 							}
 							$tmpwarehouseObject = new Entrepot($db);
 							foreach ($product->stock_warehouse as $warehouse_id => $stock_warehouse) {    // $stock_warehouse is product_stock
-
-								if(!empty($warehousePicking) && !in_array($warehouse_id, $warehousePicking)){
+								if (!empty($warehousePicking) && !in_array($warehouse_id, $warehousePicking)) {
 									// if a warehouse was selected by user, picking is limited to this warehouse and his children
 									continue;
 								}
@@ -1333,11 +1331,10 @@ if ($action == 'create') {
 									print '<!-- subj='.$subj.'/'.$nbofsuggested.' --><tr '.((($subj + 1) == $nbofsuggested) ? $bc[$var] : '').'>';
 									print '<td colspan="3" ></td><td class="center"><!-- qty to ship (no lot management for product line indiceAsked='.$indiceAsked.') -->';
 									if ($line->product_type == Product::TYPE_PRODUCT || !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
-										if(isset($alreadyQtySetted[$line->fk_product][intval($warehouse_id)])){
+										if (isset($alreadyQtySetted[$line->fk_product][intval($warehouse_id)])) {
 											$deliverableQty = min($quantityToBeDelivered, $stock - $alreadyQtySetted[$line->fk_product][intval($warehouse_id)]);
-										}
-										else{
-											if(!isset($alreadyQtySetted[$line->fk_product])){
+										} else {
+											if (!isset($alreadyQtySetted[$line->fk_product])) {
 												$alreadyQtySetted[$line->fk_product] = array();
 											}
 
@@ -1347,14 +1344,14 @@ if ($action == 'create') {
 										if ($deliverableQty < 0) $deliverableQty = 0;
 
 										$tooltip = '';
-										if(!empty($alreadyQtySetted[$line->fk_product][intval($warehouse_id)])){
+										if (!empty($alreadyQtySetted[$line->fk_product][intval($warehouse_id)])) {
 											$tooltip = ' class="classfortooltip" title="'.$langs->trans('StockQuantitiesAlreadyAllocatedOnPreviousLines').' : '.$alreadyQtySetted[$line->fk_product][intval($warehouse_id)].'" ';
 										}
 
 										$alreadyQtySetted[$line->fk_product][intval($warehouse_id)] = $deliverableQty + $alreadyQtySetted[$line->fk_product][intval($warehouse_id)];
 
 										$inputName = 'qtyl'.$indiceAsked.'_'.$subj;
-										if(GETPOSTISSET($inputName)){
+										if (GETPOSTISSET($inputName)) {
 											$deliverableQty = GETPOST($inputName, 'int');
 										}
 
@@ -1416,7 +1413,7 @@ if ($action == 'create') {
 							$tmpwarehouseObject = new Entrepot($db);
 							$productlotObject = new Productlot($db);
 
-							uasort ( $product->stock_warehouse , function ($a, $b){
+							uasort( $product->stock_warehouse, function ($a, $b) {
 								if ($a->real == $b->real) { return 0; }
 								return ($a->real < $b->real) ? -1 : 1;
 							});
@@ -1459,17 +1456,15 @@ if ($action == 'create') {
 								$tmpwarehouseObject->fetch($warehouse_id);
 								if (($stock_warehouse->real > 0) && (count($stock_warehouse->detail_batch))) {
 									foreach ($stock_warehouse->detail_batch as $dbatch) {
-
 										$batchStock = + $dbatch->qty; // To get a numeric
-										if(isset($alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)])){
+										if (isset($alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)])) {
 											$deliverableQty = min($quantityToBeDelivered, $batchStock - $alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)]);
-										}
-										else{
-											if(!isset($alreadyQtyBatchSetted[$line->fk_product])){
+										} else {
+											if (!isset($alreadyQtyBatchSetted[$line->fk_product])) {
 												$alreadyQtyBatchSetted[$line->fk_product] = array();
 											}
 
-											if(!isset($alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch])){
+											if (!isset($alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch])) {
 												$alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch] = array();
 											}
 
@@ -1479,12 +1474,12 @@ if ($action == 'create') {
 										if ($deliverableQty < 0) $deliverableQty = 0;
 
 										$inputName = 'qtyl'.$indiceAsked.'_'.$subj;
-										if(GETPOSTISSET($inputName)){
+										if (GETPOSTISSET($inputName)) {
 											$deliverableQty = GETPOST($inputName, 'int');
 										}
 
 										$tooltip = '';
-										if(!empty($alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)])){
+										if (!empty($alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)])) {
 											$tooltip = ' class="classfortooltip" title="'.$langs->trans('StockQuantitiesAlreadyAllocatedOnPreviousLines').' : '.$alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)].'" ';
 										}
 

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1305,11 +1305,6 @@ if ($action == 'create') {
 							// Define nb of lines suggested for this order line
 							$nbofsuggested = 0;
 
-							uasort( $product->stock_warehouse, function ($a, $b) {
-								if ($a->real == $b->real) { return 0; }
-								return ($a->real < $b->real) ? -1 : 1;
-							});
-
 							foreach ($product->stock_warehouse as $warehouse_id => $stock_warehouse) {
 								if ($stock_warehouse->real > 0) {
 									$nbofsuggested++;
@@ -1413,42 +1408,11 @@ if ($action == 'create') {
 							$tmpwarehouseObject = new Entrepot($db);
 							$productlotObject = new Productlot($db);
 
-							uasort( $product->stock_warehouse, function ($a, $b) {
-								if ($a->real == $b->real) { return 0; }
-								return ($a->real < $b->real) ? -1 : 1;
-							});
-
 							// Define nb of lines suggested for this order line
 							$nbofsuggested = 0;
 							foreach ($product->stock_warehouse as $warehouse_id => $stock_warehouse) {
 								if (($stock_warehouse->real > 0) && (count($stock_warehouse->detail_batch))) {
-									foreach ($stock_warehouse->detail_batch as $dbatch) {
-										$nbofsuggested++;
-									}
-
-									// Sort Batch priority
-									uasort($stock_warehouse->detail_batch, function ($a, $b) {
-										$compare = 0;
-										$multiplePow = 0;
-										// The comparison function must return an integer less than, equal to, or greater than zero if the first argument is considered to be respectively less than, equal to, or greater than the second.
-
-										// PRIORITY FOR QTY : Eliminate place with small qty first
-										$multiplePow++;
-										$multiple = pow(10, $multiplePow);
-										$compare += (($a->qty < $b->qty) ? -1 : 1) * $multiple;
-
-										// PRIORITY FOR SELL EXPIRATION DATE
-										$multiplePow++;
-										$multiple = pow(10, $multiplePow);
-										$compare += (($a->sellby < $b->sellby) ? -1 : 1) * $multiple;
-
-										// PRIORITY FOR CONSUMPTION EXPIRATION DATE
-										$multiplePow++;
-										$multiple = pow(10, $multiplePow);
-										$compare += (($a->eatby < $b->eatby) ? -1 : 1) * $multiple;
-
-										return $compare;
-									});
+									$nbofsuggested+=count($stock_warehouse->detail_batch);
 								}
 							}
 
@@ -1478,15 +1442,15 @@ if ($action == 'create') {
 											$deliverableQty = GETPOST($inputName, 'int');
 										}
 
-										$tooltip = '';
+										$tooltipClass = $tooltipTitle = '';
 										if (!empty($alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)])) {
-											$tooltip = ' class="classfortooltip" title="'.$langs->trans('StockQuantitiesAlreadyAllocatedOnPreviousLines').' : '.$alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)].'" ';
+											$tooltipClass = ' classfortooltip';
+											$tooltipTitle = $langs->trans('StockQuantitiesAlreadyAllocatedOnPreviousLines').' : '.$alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)];
 										}
-
 										$alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)] = $deliverableQty + $alreadyQtyBatchSetted[$line->fk_product][$dbatch->batch][intval($warehouse_id)];
 
 										print '<!-- subj='.$subj.'/'.$nbofsuggested.' --><tr '.((($subj + 1) == $nbofsuggested) ? $bc[$var] : '').'><td colspan="3"></td><td class="center">';
-										print '<input class="qtyl" name="qtyl'.$indiceAsked.'_'.$subj.'" id="qtyl'.$indiceAsked.'_'.$subj.'" type="text" size="4" value="'.$deliverableQty.'">';
+										print '<input class="qtyl '.$tooltipClass.'" title="'.$tooltipTitle.'" name="'.$inputName.'" id="'.$inputName.'" type="text" size="4" value="'.$deliverableQty.'">';
 										print '</td>';
 
 										print '<td class="left">';

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1155,10 +1155,9 @@ if ($action == 'create') {
 					} else {
 						$quantityToBeDelivered = $quantityAsked - $quantityDelivered;
 					}
-					$warehouse_id = GETPOST('entrepot_id', 'int');
 
 					$warehouseObject = null;
-					if ($warehouse_id > 0 || !($line->fk_product > 0) || empty($conf->stock->enabled)) {     // If warehouse was already selected or if product is not a predefined, we go into this part with no multiwarehouse selection
+					if (count($warehousePicking) == 1 || !($line->fk_product > 0) || empty($conf->stock->enabled)) {     // If warehouse was already selected or if product is not a predefined, we go into this part with no multiwarehouse selection
 						print '<!-- Case warehouse already known or product not a predefined product -->';
 						//ship from preselected location
 						$stock = + $product->stock_warehouse[$warehouse_id]->real; // Convert to number

--- a/htdocs/langs/en_US/deliveries.lang
+++ b/htdocs/langs/en_US/deliveries.lang
@@ -30,3 +30,4 @@ NonShippable=Not Shippable
 ShowShippableStatus=Show shippable status
 ShowReceiving=Show delivery receipt
 NonExistentOrder=Nonexistent order
+StockQuantitiesAlreadyAllocatedOnPreviousLines = Stock quantities already allocated on previous lines

--- a/htdocs/langs/fr_FR/deliveries.lang
+++ b/htdocs/langs/fr_FR/deliveries.lang
@@ -30,3 +30,4 @@ NonShippable=Non expédiable
 ShowShippableStatus=Afficher le statut Expédiable
 ShowReceiving=Afficher le bon de réception
 NonExistentOrder=Commande inexistante
+StockQuantitiesAlreadyAllocatedOnPreviousLines = Qtés de stock déja attribuées sur une ou des lignes précédentes

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5147,6 +5147,8 @@ class Product extends CommonObject
 			$sql .= " AND w.statut IN (".$this->db->sanitize(implode(',', $warehouseStatus)).")";
 		}
 
+		$sql .= " ORDER BY ps.reel ".(!empty($conf->global->DO_NOT_TRY_TO_DEFRAGMENT_STOCKS_WAREHOUSE)?'DESC':'ASC'); // Note : qty ASC is important for expedition card, to avoid stock fragmentation;
+
 		dol_syslog(get_class($this)."::load_stock", LOG_DEBUG);
 		$result = $this->db->query($sql);
 		if ($result) {

--- a/htdocs/product/class/productbatch.class.php
+++ b/htdocs/product/class/productbatch.class.php
@@ -436,7 +436,7 @@ class Productbatch extends CommonObject
 	 */
 	public static function findAll($db, $fk_product_stock, $with_qty = 0, $fk_product = 0)
 	{
-		global $langs;
+		global $langs, $conf;
 		$ret = array();
 
 		$sql = "SELECT";
@@ -461,6 +461,12 @@ class Productbatch extends CommonObject
 		if ($with_qty) {
 			$sql .= " AND t.qty <> 0";
 		}
+
+		$sql .= " ORDER BY ";
+		// TODO : use product lifo and fifo when product will implement it
+		if ($fk_product > 0) { $sql .= "pl.eatby ASC, pl.sellby ASC, "; }
+		$sql .= "t.eatby ASC, t.sellby ASC ";
+		$sql .= ", t.qty ".(!empty($conf->global->DO_NOT_TRY_TO_DEFRAGMENT_STOCKS_WAREHOUSE)?'DESC':'ASC'); // Note : qty ASC is important for expedition card, to avoid stock fragmentation
 
 		dol_syslog("productbatch::findAll", LOG_DEBUG);
 		$resql = $db->query($sql);


### PR DESCRIPTION
This is new feature that fixes Dolibarr behavior when creating a shipment.
When a shipment contains the same product several times (on several lines) then the quantities displayed on the next lines do not take into account the quantities already assigned (batch number included)

When a warehouse is selected, also take into account children warehouses.

----------------------------------------------------------

Voici une nouvelle fonctionnalité qui corrige un comportement de Dolibarr sur le formulaire lors de la création d'une expédition.
En effet lors de la création d'une expédition contenant plusieurs fois un même produits (sur plusieurs lignes) alors les quantities affichées sur les lignes d'après ne prennent pas en compte les quantités déjà affectées (n° de lot inclus)

Lorsqu'un entrepôt est sélectionné, prendre en compte aussi les entrepôts enfants.