### PR TITLE
update ->nom field if different from ->name

### DIFF
--- a/htdocs/user/class/usergroup.class.php
+++ b/htdocs/user/class/usergroup.class.php
@@ -675,7 +675,7 @@ class UserGroup extends CommonObject
 	{
 		global $user, $conf;
 
-		if (empty($this->nom) && !empty($this->name)) {
+		if ((empty($this->nom) || $this->nom != $this->name) && !empty($this->name)) {
 			$this->nom = $this->name;
 		}
 


### PR DESCRIPTION
# Fix Impossible update for group label
On usergroup card, we can modify label and description of a group.

When the update is launched, the value of the label input populate the "name" field
The object calls on update_common, which is based on "fields" array field.
There is no "name" field in this array. Just "nom", so it won't update with the user entry...