### PR TITLE
FIX : wrong hook context

### DIFF
--- a/htdocs/product/stock/stockatdate.php
+++ b/htdocs/product/stock/stockatdate.php
@@ -45,7 +45,7 @@ if ($user->socid) {
 $result = restrictedArea($user, 'produit|service');
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
-$hookmanager->initHooks(array('stockreplenishlist'));
+$hookmanager->initHooks(array('stockatdate'));
 
 //checks if a product has been ordered
 


### PR DESCRIPTION
stockreplenishlist is also used for another page so external module could use wrong context on this page, stockatdate context will remove errors