### PR TITLE
Fix #17743 - token was hashed with membersubscription

### DIFF
--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -292,7 +292,7 @@ if (!empty($conf->global->PAYMENT_SECURITY_TOKEN)) {
 	} else {
 		$token = $conf->global->PAYMENT_SECURITY_TOKEN;
 	}
-	if ($SECUREKEY != $token && $SECUREKEY != $tokenoldcompat) {
+	if ($SECUREKEY != $token && (empty($tokenoldcompat) || $SECUREKEY != $tokenoldcompat)) {
 		if (empty($conf->global->PAYMENT_SECURITY_ACCEPT_ANY_TOKEN)) {
 			$valid = false; // PAYMENT_SECURITY_ACCEPT_ANY_TOKEN is for backward compatibility
 		} else {

--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -281,6 +281,9 @@ if (!empty($conf->global->PAYMENT_SECURITY_TOKEN)) {
 	if (!empty($conf->global->PAYMENT_SECURITY_TOKEN_UNIQUE)) {
 		if ($tmpsource && $REF) {
 			$token = dol_hash($conf->global->PAYMENT_SECURITY_TOKEN.$tmpsource.$REF, 2); // Use the source in the hash to avoid duplicates if the references are identical
+			if ($SECUREKEY != $token) {
+				$token = dol_hash($conf->global->PAYMENT_SECURITY_TOKEN.$source.$REF, 2); // for retro-compatibility (token may have been hashed with membersubscription in external module)
+			}
 		} else {
 			$token = dol_hash($conf->global->PAYMENT_SECURITY_TOKEN, 2);
 		}

--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -278,11 +278,13 @@ if ($tmpsource == 'membersubscription') {
 }
 $valid = true;
 if (!empty($conf->global->PAYMENT_SECURITY_TOKEN)) {
+	$token = '';
+	$tokenoldcompat = '';
 	if (!empty($conf->global->PAYMENT_SECURITY_TOKEN_UNIQUE)) {
 		if ($tmpsource && $REF) {
 			$token = dol_hash($conf->global->PAYMENT_SECURITY_TOKEN.$tmpsource.$REF, 2); // Use the source in the hash to avoid duplicates if the references are identical
-			if ($SECUREKEY != $token) {
-				$token = dol_hash($conf->global->PAYMENT_SECURITY_TOKEN.$source.$REF, 2); // for retro-compatibility (token may have been hashed with membersubscription in external module)
+			if ($tmpsource != $source) {
+				$tokenoldcompat = dol_hash($conf->global->PAYMENT_SECURITY_TOKEN.$source.$REF, 2); // for retro-compatibility (token may have been hashed with membersubscription in external module)
 			}
 		} else {
 			$token = dol_hash($conf->global->PAYMENT_SECURITY_TOKEN, 2);
@@ -290,7 +292,7 @@ if (!empty($conf->global->PAYMENT_SECURITY_TOKEN)) {
 	} else {
 		$token = $conf->global->PAYMENT_SECURITY_TOKEN;
 	}
-	if ($SECUREKEY != $token) {
+	if ($SECUREKEY != $token && $SECUREKEY != $tokenoldcompat) {
 		if (empty($conf->global->PAYMENT_SECURITY_ACCEPT_ANY_TOKEN)) {
 			$valid = false; // PAYMENT_SECURITY_ACCEPT_ANY_TOKEN is for backward compatibility
 		} else {


### PR DESCRIPTION
#Fix #17743 - token was hashed with membersubscription

for retro-compatibility we must try to hash token wth both "membre" ans "membersubscription" to verify unique secure key d'or member