### PR TITLE
Fix: using strlen() instead of count() to measure a message length on CSMSFile

### DIFF
--- a/htdocs/core/class/CSMSFile.class.php
+++ b/htdocs/core/class/CSMSFile.class.php
@@ -75,7 +75,7 @@ class CSMSFile
 		    return -1;
 		}
 
-		dol_syslog("CSMSFile::CSMSFile: MAIN_SMS_SENDMODE=".$conf->global->MAIN_SMS_SENDMODE." charset=".$conf->file->character_set_client." from=".$from.", to=".$to.", msg length=".count($msg), LOG_DEBUG);
+		dol_syslog("CSMSFile::CSMSFile: MAIN_SMS_SENDMODE=".$conf->global->MAIN_SMS_SENDMODE." charset=".$conf->file->character_set_client." from=".$from.", to=".$to.", msg length=".strlen($msg), LOG_DEBUG);
 		dol_syslog("CSMSFile::CSMSFile: deferred=".$deferred." priority=".$priority." class=".$class, LOG_DEBUG);
 
 		// Action according to choosed sending method


### PR DESCRIPTION
The message is not an array, thus we should use strlen() to avoid any error.

Currently it triggers an error on PHP 7+.