### PR TITLE
FIX clone invoice with acount line

### DIFF
--- a/htdocs/core/triggers/interface_90_modSociete_ContactRoles.class.php
+++ b/htdocs/core/triggers/interface_90_modSociete_ContactRoles.class.php
@@ -84,11 +84,7 @@ class InterfaceContactRoles extends DolibarrTriggers
 				if (is_array($TContact) && ! empty($TContact)) {
 					$TContactAlreadyLinked = array();
 					if ($object->id > 0) {
-						$cloneFrom = dol_clone($object, 1);
-
-						if (! empty($cloneFrom->id)) {
-							$TContactAlreadyLinked = array_merge($cloneFrom->liste_contact(- 1, 'external'), $cloneFrom->liste_contact(- 1, 'internal'));
-						}
+						$TContactAlreadyLinked = array_merge($object->liste_contact(- 1, 'external'), $object->liste_contact(- 1, 'internal'));
 					}
 
 					foreach ($TContact as $i => $infos) {


### PR DESCRIPTION
FIX clone invoice with acount line
- when you have an invoice with an acount line and you want to clone it : you got a blank page

1) Create an invoice with an acount line like this ;
![image](https://user-images.githubusercontent.com/45359511/121382932-5d4b2980-c947-11eb-83a5-f5ff31a4fe21.png)

2) Click to clone
![image](https://user-images.githubusercontent.com/45359511/121383091-78b63480-c947-11eb-8054-b54df77d8667.png)

3) Then click yes and you got a blank page

- with this "apache" error : "Got error 'PHP message: PHP Fatal error:  Uncaught Error: __clone method called on non-object in ..."


