### PR TITLE
bug resolution: exception

### DIFF
--- a/htdocs/core/actions_sendmails.inc.php
+++ b/htdocs/core/actions_sendmails.inc.php
@@ -345,7 +345,7 @@ if (($action == 'send' || $action == 'relance') && !$_POST['addfile'] && !$_POST
 			$subject = make_substitutions($subject, $substitutionarray);
 			$message = make_substitutions($message, $substitutionarray);
 
-			if (method_exists($object, 'makeSubstitution')) {
+			if (is_object($object) && method_exists($object, 'makeSubstitution')) {
 				$subject = $object->makeSubstitution($subject);
 				$message = $object->makeSubstitution($message);
 			}


### PR DESCRIPTION
when a user test the send mail functionality, an exception is thrown: $object is null in the method_exists's function. and thus not allowed. 
Adding is_object resolve the problem

