### PR TITLE
bugfix/supplierBankTransfertWrongCodeCheckMassAction

### DIFF
--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -323,7 +323,7 @@ if (empty($reshook))
 					if ($numprlv > 0) {
 						$error++;
 						setEventMessages($objecttmp->ref.' '.$langs->trans("RequestAlreadyDone"), $objecttmp->errors, 'warnings');
-					} elseif (!empty($objecttmp->mode_reglement_code) && $objecttmp->mode_reglement_code != 'PRE') {
+					} elseif (!empty($objecttmp->mode_reglement_code) && $objecttmp->mode_reglement_code != 'VIR') {
 						$error++;
 						setEventMessages($objecttmp->ref.' '.$langs->trans("BadPaymentMethod"), $objecttmp->errors, 'errors');
 					} else {


### PR DESCRIPTION
# On supplier invoice list and bank transfer request, wrong code seems to be check for the payment method on the invoice when doing a mass bank transfer request.