### PR TITLE
remove useless check on invoice line content when generating pdf

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1272,9 +1272,7 @@ function pdf_getlinedesc($object, $i, $outputlangs, $hideref = 0, $hidedesc = 0,
 			if (!empty($prodser->multilangs[$outputlangs->defaultlang]["note"]) && ($textwasmodified || $translatealsoifmodified))  $note = $prodser->multilangs[$outputlangs->defaultlang]["note"];
 		}
 	} elseif ($object->element == 'facture' || $object->element == 'facturefourn') {
-		if ($object->type == $object::TYPE_DEPOSIT) {
-			$desc = str_replace('(DEPOSIT)', $outputlangs->trans('Deposit'), $desc);
-		}
+		$desc = str_replace('(DEPOSIT)', $outputlangs->trans('Deposit'), $desc);
 	}
 
 	// Description short of product line


### PR DESCRIPTION
remove useless check on invoice line content when generating pdf

it does not translate properly (DEPOSIT) key when you are not in a deposit invoice. Ex : when you do a credit note of a deposit invoice