### PR TITLE
Fix #17930 : input boxes can be empty as previously on survey

### DIFF
--- a/htdocs/opensurvey/wizard/choix_date.php
+++ b/htdocs/opensurvey/wizard/choix_date.php
@@ -55,7 +55,7 @@ if (GETPOST('confirmation')) {
 
 				$tmphorairesi = GETPOST('horaires'.$i, 'array');
 
-				if (!is_array($tmphorairesi) || empty($tmphorairesi[$j])) {
+				if (!is_array($tmphorairesi)) {
 					$errheure[$i][$j] = true;
 					$erreur = true;
 					continue;
@@ -155,7 +155,7 @@ if (GETPOST('confirmation')) {
 			}
 		}
 
-		if (isset($errheure)) {
+		if (!empty($errheure)) {
 			setEventMessages($langs->trans("ErrorBadFormat"), null, 'errors');
 		}
 	}


### PR DESCRIPTION
Survey on date can have his input boxes empty as previously