### PR TITLE
Fix #17906 : fix access denied

### DIFF
--- a/htdocs/user/notify/card.php
+++ b/htdocs/user/notify/card.php
@@ -72,7 +72,7 @@ $permissiontoadd = (($object->id == $user->id) || (!empty($user->rights->user->u
 if ($user->socid) {
 	$id = $user->socid;
 }
-$result = restrictedArea($user, 'user', '', '');
+$result = restrictedArea($user, 'user', '', '', 'user');
 
 
 /*


### PR DESCRIPTION
Fix access denied on creation of notification where creation is not supposed to be denied