### PR TITLE
NEW prevent default submit form on enter key in expense card

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -2191,16 +2191,33 @@ if ($action == 'create') {
         				        $( ".auploadnewfilenow" ).click(function() {
         				            jQuery(".truploadnewfilenow").toggle();
                                     jQuery(".trattachnewfilenow").hide();
+                                    if (jQuery(".truploadnewfilenow").is(":hidden")) {
+                                        jQuery("input[name=\"sendit\"]").prop("disabled", true);
+                                    } else {
+                                        jQuery("input[name=\"sendit\"]").prop("disabled", false);
+                                    }
                                     return false;
                                 });
         				        $( ".aattachtodoc" ).click(function() {
         				            jQuery(".trattachnewfilenow").toggle();
                                     jQuery(".truploadnewfilenow").hide();
+                                    if (jQuery(".truploadnewfilenow").is(":hidden")) {
+                                        jQuery("input[name=\"sendit\"]").prop("disabled", true);
+                                    } else {
+                                        jQuery("input[name=\"sendit\"]").prop("disabled", false);
+                                    }
                                     return false;
                                 });';
 							if (is_array(GETPOST('attachfile', 'array')) && count(GETPOST('attachfile', 'array'))) {
 								print 'jQuery(".trattachnewfilenow").toggle();'."\n";
 							}
+							print '
+                                if (jQuery(".truploadnewfilenow").is(":hidden")) {
+                                    jQuery("input[name=\"sendit\"]").prop("disabled", true);
+                                } else {
+                                    jQuery("input[name=\"sendit\"]").prop("disabled", false);
+                                }
+                            ';
 							print '
                             });
         				    ';
@@ -2337,16 +2354,33 @@ if ($action == 'create') {
 				        $( ".auploadnewfilenow" ).click(function() {
 				            jQuery(".truploadnewfilenow").toggle();
                             jQuery(".trattachnewfilenow").hide();
+                            if (jQuery(".truploadnewfilenow").is(":hidden")) {
+                                jQuery("input[name=\"sendit\"]").prop("disabled", true);
+                            } else {
+                                jQuery("input[name=\"sendit\"]").prop("disabled", false);
+                            }
                             return false;
                         });
 				        $( ".aattachtodoc" ).click(function() {
 				            jQuery(".trattachnewfilenow").toggle();
                             jQuery(".truploadnewfilenow").hide();
+                            if (jQuery(".truploadnewfilenow").is(":hidden")) {
+                                jQuery("input[name=\"sendit\"]").prop("disabled", true);
+                            } else {
+                                jQuery("input[name=\"sendit\"]").prop("disabled", false);
+                            }
                             return false;
                         });'."\n";
 					if (is_array(GETPOST('attachfile', 'array')) && count(GETPOST('attachfile', 'array')) && $action != 'updateline') {
 						print 'jQuery(".trattachnewfilenow").show();'."\n";
 					}
+					print '
+                        if (jQuery(".truploadnewfilenow").is(":hidden")) {
+                            jQuery("input[name=\"sendit\"]").prop("disabled", true);
+                        } else {
+                            jQuery("input[name=\"sendit\"]").prop("disabled", false);
+                        }
+                    ';
 					print '
                     });
 				    ';


### PR DESCRIPTION
NEW prevent default submit form on enter key in expense card
- in expense card and when you use enter key in a field of an expense line, you got an error "The field File is required" whereas you don't want to send file

![image](https://user-images.githubusercontent.com/45359511/122406907-80965a00-cf81-11eb-90cd-092eeabb3cb5.png)

I disabled the file submit button when the file form is hidden and I enable this button only when you want to send a file.