### PR TITLE
FIX 17965 - Keep enter key only to submit expense lines form

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -159,7 +159,7 @@ if (empty($reshook)) {
 
 	include DOL_DOCUMENT_ROOT.'/core/actions_linkedfiles.inc.php';
 
-	if (GETPOSTISSET('sendit')) {    // If we just submit a file
+	if (!empty(GETPOST('sendit', 'alpha'))) {   // If we just submit a file
 		if ($action == 'updateline') {
 			$action = 'editline'; // To avoid to make the updateline now
 		} else {
@@ -2191,33 +2191,23 @@ if ($action == 'create') {
         				        $( ".auploadnewfilenow" ).click(function() {
         				            jQuery(".truploadnewfilenow").toggle();
                                     jQuery(".trattachnewfilenow").hide();
-                                    if (jQuery(".truploadnewfilenow").is(":hidden")) {
-                                        jQuery("input[name=\"sendit\"]").prop("disabled", true);
-                                    } else {
-                                        jQuery("input[name=\"sendit\"]").prop("disabled", false);
-                                    }
                                     return false;
                                 });
         				        $( ".aattachtodoc" ).click(function() {
         				            jQuery(".trattachnewfilenow").toggle();
                                     jQuery(".truploadnewfilenow").hide();
-                                    if (jQuery(".truploadnewfilenow").is(":hidden")) {
-                                        jQuery("input[name=\"sendit\"]").prop("disabled", true);
-                                    } else {
-                                        jQuery("input[name=\"sendit\"]").prop("disabled", false);
-                                    }
                                     return false;
                                 });';
 							if (is_array(GETPOST('attachfile', 'array')) && count(GETPOST('attachfile', 'array'))) {
 								print 'jQuery(".trattachnewfilenow").toggle();'."\n";
 							}
 							print '
-                                if (jQuery(".truploadnewfilenow").is(":hidden")) {
-                                    jQuery("input[name=\"sendit\"]").prop("disabled", true);
-                                } else {
-                                    jQuery("input[name=\"sendit\"]").prop("disabled", false);
-                                }
-                            ';
+                        		jQuery("form[name=\"expensereport\"]").submit(function() {
+                            		if (jQuery(".truploadnewfilenow").is(":hidden")) {
+                                		jQuery("input[name=\"sendit\"]").val("");
+                            		}
+                        		});
+                    		';
 							print '
                             });
         				    ';
@@ -2354,33 +2344,23 @@ if ($action == 'create') {
 				        $( ".auploadnewfilenow" ).click(function() {
 				            jQuery(".truploadnewfilenow").toggle();
                             jQuery(".trattachnewfilenow").hide();
-                            if (jQuery(".truploadnewfilenow").is(":hidden")) {
-                                jQuery("input[name=\"sendit\"]").prop("disabled", true);
-                            } else {
-                                jQuery("input[name=\"sendit\"]").prop("disabled", false);
-                            }
                             return false;
                         });
 				        $( ".aattachtodoc" ).click(function() {
 				            jQuery(".trattachnewfilenow").toggle();
                             jQuery(".truploadnewfilenow").hide();
-                            if (jQuery(".truploadnewfilenow").is(":hidden")) {
-                                jQuery("input[name=\"sendit\"]").prop("disabled", true);
-                            } else {
-                                jQuery("input[name=\"sendit\"]").prop("disabled", false);
-                            }
                             return false;
                         });'."\n";
 					if (is_array(GETPOST('attachfile', 'array')) && count(GETPOST('attachfile', 'array')) && $action != 'updateline') {
 						print 'jQuery(".trattachnewfilenow").show();'."\n";
 					}
 					print '
-                        if (jQuery(".truploadnewfilenow").is(":hidden")) {
-                            jQuery("input[name=\"sendit\"]").prop("disabled", true);
-                        } else {
-                            jQuery("input[name=\"sendit\"]").prop("disabled", false);
-                        }
-                    ';
+						jQuery("form[name=\"expensereport\"]").submit(function() {
+							if (jQuery(".truploadnewfilenow").is(":hidden")) {
+								jQuery("input[name=\"sendit\"]").val("");
+							}
+						});
+					';
 					print '
                     });
 				    ';


### PR DESCRIPTION
FIX 17965 - Keep enter key only to submit expense lines form
- otherwise you can't submit form on add or update expense lines
- it's faster to use "enter" key for users than to use "add / save" button
