### PR TITLE
Fix #17836 : order delay warning in list was wrong

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4054,7 +4054,7 @@ class Commande extends CommonOrder
 
 		$now = dol_now();
 
-		return max($this->date_commande, $this->date_livraison) < ($now - $conf->commande->client->warning_delay);
+		return max($this->date, $this->date_livraison) < ($now - $conf->commande->client->warning_delay);
 	}
 
 	/**


### PR DESCRIPTION
date_commande is deprecated