### PR TITLE
FIX deposit can create credit note in payment conf

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5260,7 +5260,7 @@ elseif ($id > 0 || !empty($ref))
 			}
 
 			// Create a credit note
-			if (($object->type == Facture::TYPE_STANDARD || $object->type == Facture::TYPE_DEPOSIT || $object->type == Facture::TYPE_PROFORMA) && $object->statut > 0 && $usercancreate)
+			if (($object->type == Facture::TYPE_STANDARD || ($object->type == Facture::TYPE_DEPOSIT && empty($conf->global->FACTURE_DEPOSITS_ARE_JUST_PAYMENTS) ) || $object->type == Facture::TYPE_PROFORMA) && $object->statut > 0 && $usercancreate)
 			{
 				if (!$objectidnext)
 				{


### PR DESCRIPTION
# Fix
The problem comes from FACTURE_DEPOSITS_ARE_JUST_PAYMENTS conf. In this case we can't allowed an user to create a credit note on a deposit. This is not good because Dolibarr will decrease our sales revenue stats.

AC 5000€ not count in sales revenue
AV -5000 count in sales revenue

This is not a good method and we have to delete the credit note button in this case