### PR TITLE
FIX : Update field "billed" on reopening expedition

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2448,7 +2448,7 @@ class Expedition extends CommonObject
 
 		$oldbilled = $this->billed;
 
-		$sql = 'UPDATE '.MAIN_DB_PREFIX.'expedition SET fk_statut=1';
+		$sql = 'UPDATE '.MAIN_DB_PREFIX.'expedition SET fk_statut=1, billed=0';
 		$sql .= ' WHERE rowid = '.$this->id.' AND fk_statut > 0';
 
 		$resql = $this->db->query($sql);


### PR DESCRIPTION
### FIX : Update field "billed" on reopening expedition

When we reopen an expedition, the button "Cloturer" disapppear because of the condition on the "billed" field. So when it happen we can't close this expédition.

- Update the "billed" field at the same time as the "statut" field.
