### PR TITLE
fix: payment ok should trigger PAYMENTONLINE_PAYMENT_OK even on custom object

### DIFF
--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -746,6 +746,12 @@ if ($ispaymentok)
 		$result = $object->call_trigger('PAYMENTONLINE_PAYMENT_OK', $user);
 		if ($result < 0) $error++;
 		// End call triggers
+	} elseif (get_class($object)=='stdClass') {
+		//In some case $object is not instanciate (for paiement on custom object) We need to deal with payment
+		include_once DOL_DOCUMENT_ROOT.'/compta/paiement/class/paiement.class.php';
+		$paiement = new Paiement($db);
+		$result = $paiement->call_trigger('PAYMENTONLINE_PAYMENT_OK', $user);
+		if ($result < 0) $error++;
 	}
 
 	print $langs->trans("YourPaymentHasBeenRecorded")."<br>\n";


### PR DESCRIPTION
With custom object (other than invoice, etc...), $object is never set, so trigger is not called (stdClass do not implement call_triggers).
But we need for custom object to register payment and this is the only way to catch it