### PR TITLE
New :  Add js confirm modal option to BTN created with dolGetButtonAction

### DIFF
--- a/htdocs/core/js/lib_foot.js.php
+++ b/htdocs/core/js/lib_foot.js.php
@@ -247,7 +247,7 @@ print 'jQuery(\'.clipboardCPButton, .clipboardCPValueToPrint\').click(function()
 	})'."\n";
 
 
-print "\n/* JS CODE TO ENABLE ClipBoard copy paste*/\n";
+print "\n/* JS CODE TO ENABLE DIALOG CONFIRM POPUP ON ACTION BUTTON */\n";
 print '$( document ).ready(function() {
 	$(document).on("click", \'.butActionConfirm\', function(event) {
 		event.preventDefault();

--- a/htdocs/core/js/lib_foot.js.php
+++ b/htdocs/core/js/lib_foot.js.php
@@ -245,3 +245,59 @@ print 'jQuery(\'.clipboardCPButton, .clipboardCPValueToPrint\').click(function()
 		lastchild.innerHTML = \''.dol_escape_js($langs->trans('CopiedToClipboard')).'\';
 		setTimeout(() => { lastchild.innerHTML = tmp; }, 1000);
 	})'."\n";
+
+
+print "\n/* JS CODE TO ENABLE ClipBoard copy paste*/\n";
+print '$( document ).ready(function() {
+	$(document).on("click", \'.butActionConfirm\', function(event) {
+		event.preventDefault();
+
+		// I don\'t use jquery $(this).data(\'confirm-url\'); to get $(this).attr(\'data-confirm-url\'); because .data() can doesn\'t work with ajax
+		var confirmUrl  			= $(this).attr(\'data-confirm-url\');
+		var confirmTitle 			= $(this).attr(\'data-confirm-title\');
+		var confirmContent 			= $(this).attr(\'data-confirm-content\');
+		var confirmActionBtnLabel 	= $(this).attr(\'data-confirm-action-btn-label\');
+		var confirmCancelBtnLabel 	= $(this).attr(\'data-confirm-cancel-btn-label\');
+
+		var confirmId = \'confirm-dialog-box\';
+		if($(this).attr(\'id\') != undefined){ var confirmId = confirmId + "-" + $(this).attr(\'id\'); }
+		if($("#" + confirmId)  != undefined) { $(\'#\' + confirmId).remove(); }
+
+		// Create modal box
+
+		var $confirmBox = $(\'<div/>\', {
+			id: confirmId,
+			title: confirmTitle
+		}).appendTo(\'body\');
+
+		$confirmBox.dialog({
+			autoOpen: true,
+			modal: false,
+			//width: Math.min($( window ).width() - 50, 1700),
+			dialogClass: \'confirm-dialog-box\',
+			buttons: [
+				{
+					text: confirmActionBtnLabel,
+					"class": \'ui-state-information\',
+					click: function () {
+					window.location.replace(confirmUrl);
+				}
+				},
+				{
+					text: confirmCancelBtnLabel,
+					"class": \'ui-state-information\',
+					click: function () {
+					$(this).dialog("close");
+				}
+				}
+			],
+			close: function( event, ui ) {
+	$(\'#\'+confirmBox).remove();
+},
+			open: function( event, ui ) {
+	$confirmBox.html(confirmContent);
+}
+		});
+	});
+});
+'."\n";

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9777,7 +9777,13 @@ function dolGetButtonAction($label, $html = '', $actionType = 'default', $url = 
 	}
 
 	// Js Confirm button
-	if (!empty($params['confirm']) && is_array($params['confirm']) && !empty($params['confirm']['url'])) {
+	if (!empty($params['confirm'])) {
+		if (!is_array($params['confirm'])) {
+			$params['confirm'] = array(
+				'url' => $url . (strpos($url, '?') > 0 ? '&' : '?') . 'confirm=yes'
+			);
+		}
+
 		// for js desabled compatibility set $url as call to confirm action and $params['confirm']['url'] to confirmed action
 		$attr['data-confirm-url'] = $params['confirm']['url'];
 		$attr['data-confirm-title'] = !empty($params['confirm']['title']) ? $params['confirm']['title'] : $langs->trans('ConfirmBtnCommonTitle', $label);

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9734,6 +9734,8 @@ function dolGetStatus($statusLabel = '', $statusLabelShort = '', $html = '', $st
  */
 function dolGetButtonAction($label, $html = '', $actionType = 'default', $url = '', $id = '', $userRight = 1, $params = array())
 {
+	global $hookmanager, $action, $object, $langs;
+
 	$class = 'butAction';
 	if ($actionType == 'danger' || $actionType == 'delete') {
 		$class = 'butActionDelete';
@@ -9774,11 +9776,20 @@ function dolGetButtonAction($label, $html = '', $actionType = 'default', $url = 
 		}
 	}
 
+	// Js Confirm button
+	if (!empty($params['confirm']) && is_array($params['confirm']) && !empty($params['confirm']['url'])) {
+		// for js desabled compatibility set $url as call to confirm action and $params['confirm']['url'] to confirmed action
+		$attr['data-confirm-url'] = $params['confirm']['url'];
+		$attr['data-confirm-title'] = !empty($params['confirm']['title']) ? $params['confirm']['title'] : $langs->trans('ConfirmBtnCommonTitle', $label);
+		$attr['data-confirm-content'] = !empty($params['confirm']['content']) ? $params['confirm']['content'] : $langs->trans('ConfirmBtnCommonContent', $label);
+		$attr['data-confirm-action-btn-label'] = !empty($params['confirm']['action-btn-label']) ? $params['confirm']['action-btn-label'] : $langs->trans('Confirm');
+		$attr['data-confirm-cancel-btn-label'] = !empty($params['confirm']['cancel-btn-label']) ? $params['confirm']['cancel-btn-label'] : $langs->trans('CloseDialog');
+		$attr['class'].= ' butActionConfirm';
+	}
+
 	if (isset($attr['href']) && empty($attr['href'])) {
 		unset($attr['href']);
 	}
-
-	// TODO : add a hook
 
 	// escape all attribute
 	$attr = array_map('dol_escape_htmltag', $attr);
@@ -9792,7 +9803,29 @@ function dolGetButtonAction($label, $html = '', $actionType = 'default', $url = 
 
 	$tag = !empty($attr['href']) ? 'a' : 'span';
 
-	return '<'.$tag.' '.$compiledAttributes.'>'.$html.'</'.$tag.'>';
+
+	$parameters = array(
+		'TCompiledAttr' => $TCompiledAttr,
+		'compiledAttributes' => $compiledAttributes,
+		'attr' => $attr,
+		'tag' => $tag,
+		'label' => $label,
+		'html' => $html,
+		'actionType' => $actionType,
+		'url' => $url,
+		'id' => $id,
+		'userRight' => $userRight,
+		'params' => $params
+	);
+
+	$reshook = $hookmanager->executeHooks('dolGetButtonAction', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+	if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+
+	if (empty($reshook)) {
+		return '<' . $tag . ' ' . $compiledAttributes . '>' . $html . '</' . $tag . '>';
+	} else {
+		return $hookmanager->resPrint;
+	}
 }
 
 /**

--- a/htdocs/langs/en_US/other.lang
+++ b/htdocs/langs/en_US/other.lang
@@ -291,3 +291,7 @@ PopuCom=Products/Services by popularity in Orders
 ProductStatistics=Products/Services Statistics
 NbOfQtyInOrders=Qty in orders
 SelectTheTypeOfObjectToAnalyze=Select an object to view its statistics...
+
+ConfirmBtnCommonContent = Are you sure you want to "%s" ?
+ConfirmBtnCommonTitle = Confirm your action
+CloseDialog = Close

--- a/htdocs/langs/fr_FR/other.lang
+++ b/htdocs/langs/fr_FR/other.lang
@@ -291,3 +291,7 @@ PopuCom=Produits/services par popularité dans les commandes
 ProductStatistics=Statistiques sur les produits / services
 NbOfQtyInOrders=Qté en commandes
 SelectTheTypeOfObjectToAnalyze=Sélectionner un objet pour en voir les statistiques
+
+ConfirmBtnCommonContent = Êtes-vous sûr de vouloir : "%s" ?
+ConfirmBtnCommonTitle = Confirmez votre action
+CloseDialog = Fermer


### PR DESCRIPTION
# New :  Add js confirm modal option to BTN created with dolGetButtonAction

Exemple of button used to activate modal : 
```php
	$params = array( 'confirm' => true);
	print dolGetButtonAction('Test button modal', '', 'default', $_SERVER['PHP_SELF'].'?id='.$object->id.'&amp;action=youraction', 'btn-action-test', $usercancreate, $params);
```

you can also customise the modal :
```php
	$params = array( 
		'confirm' => array( 
			'url' => 'your confirm action url',
			'title' => 'Your title to display',
			'action-btn-label' => 'Your confirm button label',
			'cancel-btn-label' => 'Your cancel button label',
			'content' => 'Content to display'
		);
	);
	print dolGetButtonAction('Test button modal', '', 'default', $_SERVER['PHP_SELF'].'?id='.$object->id.'&amp;action=youraction', 'btn-action-test', $usercancreate, $params);
```

![image](https://user-images.githubusercontent.com/29435477/124399500-2dabf900-dd1c-11eb-82c6-b73652f4d2b6.png)
