### PR TITLE
FIX: holiday: balances not updated correctly with pgsql because of case sensitivity

### DIFF
--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -2112,7 +2112,7 @@ class Holiday extends CommonObject
 	{
 		global $mysoc;
 
-		$sql = "SELECT rowid, code, label, affect, delay, newByMonth";
+		$sql = "SELECT rowid, code, label, affect, delay, newbymonth";
 		$sql .= " FROM ".MAIN_DB_PREFIX."c_holiday_types";
 		$sql .= " WHERE (fk_country IS NULL OR fk_country = ".$mysoc->country_id.')';
 		if ($active >= 0) $sql .= " AND active = ".((int) $active);
@@ -2126,7 +2126,7 @@ class Holiday extends CommonObject
 			{
 				while ($obj = $this->db->fetch_object($result))
 				{
-					$types[$obj->rowid] = array('rowid'=> $obj->rowid, 'code'=> $obj->code, 'label'=>$obj->label, 'affect'=>$obj->affect, 'delay'=>$obj->delay, 'newByMonth'=>$obj->newByMonth);
+					$types[$obj->rowid] = array('rowid'=> $obj->rowid, 'code'=> $obj->code, 'label'=>$obj->label, 'affect'=>$obj->affect, 'delay'=>$obj->delay, 'newByMonth'=>$obj->newbymonth);
 				}
 
 				return $types;


### PR DESCRIPTION
Field names are case-insensitive both in MariaDB and PostgreSQL, but pg_fetch_*() lowercases them.

Tested with MariaDB and PostgreSQL.