### PR TITLE
FIX reading MAIN_USE_COMPANY_NAME_OF_CONTACT

### DIFF
--- a/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
+++ b/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
@@ -296,7 +296,7 @@ class doc_generic_bom_odt extends ModelePDFBom
 				$contactobject = null;
 				if (!empty($usecontact)) {
 					// On peut utiliser le nom de la societe du contact
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -307,7 +307,7 @@ class doc_generic_order_odt extends ModelePDFCommandes
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/commande/doc/pdf_einstein.modules.php
+++ b/htdocs/core/modules/commande/doc/pdf_einstein.modules.php
@@ -1438,7 +1438,7 @@ class pdf_einstein extends ModelePDFCommandes
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
+++ b/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
@@ -1623,7 +1623,7 @@ class pdf_eratosthene extends ModelePDFCommandes
 			}
 
 			//Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
+++ b/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
@@ -295,7 +295,7 @@ class doc_generic_contract_odt extends ModelePDFContract
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/contract/doc/pdf_strato.modules.php
+++ b/htdocs/core/modules/contract/doc/pdf_strato.modules.php
@@ -716,7 +716,7 @@ class pdf_strato extends ModelePDFContract
 			$this->recipient = $object->thirdparty;
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/delivery/doc/pdf_storm.modules.php
+++ b/htdocs/core/modules/delivery/doc/pdf_storm.modules.php
@@ -860,7 +860,7 @@ class pdf_storm extends ModelePDFDeliveryOrder
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/delivery/doc/pdf_typhon.modules.php
+++ b/htdocs/core/modules/delivery/doc/pdf_typhon.modules.php
@@ -859,7 +859,7 @@ class pdf_typhon extends ModelePDFDeliveryOrder
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -307,7 +307,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
@@ -1117,7 +1117,7 @@ class pdf_espadon extends ModelePdfExpedition
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/expedition/doc/pdf_merou.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_merou.modules.php
@@ -676,7 +676,7 @@ class pdf_merou extends ModelePdfExpedition
 		}
 
 		// Recipient name
-		if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+		if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 			$thirdparty = $object->contact;
 		} else {
 			$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_rouget.modules.php
@@ -1067,7 +1067,7 @@ class pdf_rouget extends ModelePdfExpedition
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -308,7 +308,7 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
@@ -1880,7 +1880,7 @@ class pdf_crabe extends ModelePDFFactures
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -2117,7 +2117,7 @@ class pdf_sponge extends ModelePDFFactures
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
+++ b/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
@@ -670,7 +670,7 @@ class pdf_soleil extends ModelePDFFicheinter
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
+++ b/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
@@ -295,7 +295,7 @@ class doc_generic_member_odt extends ModelePDFMember
 
 				// Recipient name
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
+++ b/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
@@ -302,7 +302,7 @@ class doc_generic_mo_odt extends ModelePDFMo
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
+++ b/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
@@ -319,7 +319,7 @@ class doc_generic_product_odt extends ModelePDFProduct
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -335,7 +335,7 @@ class doc_generic_proposal_odt extends ModelePDFPropales
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/propale/doc/pdf_azur.modules.php
+++ b/htdocs/core/modules/propale/doc/pdf_azur.modules.php
@@ -1605,7 +1605,7 @@ class pdf_azur extends ModelePDFPropales
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/propale/doc/pdf_cyan.modules.php
+++ b/htdocs/core/modules/propale/doc/pdf_cyan.modules.php
@@ -1719,7 +1719,7 @@ class pdf_cyan extends ModelePDFPropales
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
+++ b/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
@@ -298,7 +298,7 @@ class doc_generic_reception_odt extends ModelePdfReception
 
 				// Recipient name
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/reception/doc/pdf_squille.modules.php
+++ b/htdocs/core/modules/reception/doc/pdf_squille.modules.php
@@ -972,7 +972,7 @@ class pdf_squille extends ModelePdfReception
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/stock/doc/doc_generic_stock_odt.modules.php
+++ b/htdocs/core/modules/stock/doc/doc_generic_stock_odt.modules.php
@@ -308,7 +308,7 @@ class doc_generic_stock_odt extends ModelePDFStock
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/supplier_invoice/doc/pdf_canelle.modules.php
+++ b/htdocs/core/modules/supplier_invoice/doc/pdf_canelle.modules.php
@@ -1239,7 +1239,7 @@ class pdf_canelle extends ModelePDFSuppliersInvoices
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $mysoc;

--- a/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
@@ -298,7 +298,7 @@ class doc_generic_supplier_order_odt extends ModelePDFSuppliersOrders
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
@@ -1407,7 +1407,7 @@ class pdf_cornas extends ModelePDFSuppliersOrders
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/supplier_order/doc/pdf_muscadet.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/pdf_muscadet.modules.php
@@ -1314,7 +1314,7 @@ class pdf_muscadet extends ModelePDFSuppliersOrders
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
@@ -332,7 +332,7 @@ class doc_generic_supplier_proposal_odt extends ModelePDFSupplierProposal
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/supplier_proposal/doc/pdf_aurore.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/pdf_aurore.modules.php
@@ -1418,7 +1418,7 @@ class pdf_aurore extends ModelePDFSupplierProposal
 
 			// Recipient name
 			if (!empty($usecontact)) {
-				if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+				if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 					$socname = $object->contact;
 				} else {
 					$socname = $object->thirdparty;

--- a/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
+++ b/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
@@ -293,7 +293,7 @@ class doc_generic_ticket_odt extends ModelePDFTicket
 
 				// Recipient name
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
+++ b/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
@@ -325,7 +325,7 @@ class doc_generic_user_odt extends ModelePDFUser
 
 				// Recipient name
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
+++ b/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
@@ -315,7 +315,7 @@ class doc_generic_usergroup_odt extends ModelePDFUserGroup
 
 				// Recipient name
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
@@ -301,7 +301,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/modulebuilder/template/core/modules/mymodule/doc/pdf_standard_myobject.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/doc/pdf_standard_myobject.modules.php
@@ -1110,7 +1110,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 			}
 
 			// Recipient name
-			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;

--- a/htdocs/recruitment/core/modules/recruitment/doc/doc_generic_recruitmentjobposition_odt.modules.php
+++ b/htdocs/recruitment/core/modules/recruitment/doc/doc_generic_recruitmentjobposition_odt.modules.php
@@ -294,7 +294,7 @@ class doc_generic_recruitmentjobposition_odt extends ModelePDFRecruitmentJobPosi
 				// Recipient name
 				$contactobject = null;
 				if (!empty($usecontact)) {
-					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+					if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$socobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;

--- a/htdocs/recruitment/core/modules/recruitment/doc/pdf_standard_recruitmentjobposition.modules.php
+++ b/htdocs/recruitment/core/modules/recruitment/doc/pdf_standard_recruitmentjobposition.modules.php
@@ -1026,7 +1026,7 @@ class pdf_standard_recruitmentjobposition extends ModelePDFRecruitmentJobPositio
 			}
 
 			// Recipient name
-			/*if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT)))) {
+			/*if ($usecontact && ($object->contact->fk_soc != $object->thirdparty->id && !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;


### PR DESCRIPTION
The logic to evaluate MAIN_USE_COMPANY_NAME_OF_CONTACT was mostly
broken. The option became active when the variable was unset or not
empty, however, checking for non-emptyness should be enough.