### PR TITLE
FIX display of extrafields on shipping lines

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7492,6 +7492,9 @@ abstract class CommonObject
 
 						if ($display_type == 'card') {
 							$out .= '<tr '.($html_id ? 'id="'.$html_id.'" ' : '').$csstyle.' class="valuefieldcreate '.$class.$this->element.'_extras_'.$key.' trextrafields_collapse'.$extrafields_collapse_num.(!empty($this->id)?'_'.$this->id:'').'" '.$domData.' >';
+							if ( ! empty($conf->global->MAIN_VIEW_LINE_NUMBER) ) {
+								$out .= '<td></td>';
+							}
 							$out .= '<td class="wordbreak';
 						} elseif ($display_type == 'line') {
 							$out .= '<div '.($html_id ? 'id="'.$html_id.'" ' : '').$csstyle.' class="valuefieldlinecreate '.$class.$this->element.'_extras_'.$key.' trextrafields_collapse'.$extrafields_collapse_num.(!empty($this->id)?'_'.$this->id:'').'" '.$domData.' >';


### PR DESCRIPTION
if MAIN_VIEW_LINE_NUMBER constant is activated the extrafields label goes in the Position column with wordbreak class on td, so it looks like this :  
![image](https://user-images.githubusercontent.com/396322/124727053-a4104d00-df0e-11eb-85e5-2f6aa47141a5.png)

same screenshot after fix : 
![image](https://user-images.githubusercontent.com/396322/124727181-c5713900-df0e-11eb-8d8f-84a19769cae8.png)
