### PR TITLE
Fix : multi module hook incompatibility

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -7752,13 +7752,14 @@ function complete_head_from_modules($conf, $langs, $object, &$head, &$h, $type, 
 	// No need to make a return $head. Var is modified as a reference
 	if (!empty($hookmanager))
 	{
-		$parameters = array('object' => $object, 'mode' => $mode, 'head' => $head);
+		$parameters = array('object' => $object, 'mode' => $mode, 'head' =>& $head);
 		$reshook = $hookmanager->executeHooks('completeTabsHead', $parameters);
 		if ($reshook > 0)
 		{
 			$head = $hookmanager->resArray;
-			$h = count($head);
 		}
+
+		$h = count($head);
 	}
 }
 


### PR DESCRIPTION
If this hook is used by  2 or more modules and returns 1 for both, then $head will contain data twice  because HookManager makes an array_merge