### PR TITLE
FIX : don't display custom masks if they are not used

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1636,14 +1636,14 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 						$tooltip .= '<br>'.$langs->trans("GenericMaskCodes4a", $langs->transnoentities("Batch"), $langs->transnoentities("Batch"));
 						$tooltip .= '<br>'.$langs->trans("GenericMaskCodes5");
 						print '<tr><td id="mask_option">'.$langs->trans("ManageLotMask").'</td>';
-						if ($object->status_batch == '1' && $conf->global->PRODUCTBATCH_LOT_USE_PRODUCT_MASKS && $conf->global->PRODUCTBATCH_LOT_ADDON == 'mod_lot_advanced') {
-							$mask = !empty($object->batch_mask) ? $object->batch_mask : $conf->global->LOT_ADVANCED_MASK;
+						if ($object->status_batch == '1' && getDolGlobalString('PRODUCTBATCH_LOT_USE_PRODUCT_MASKS') && getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_advanced') {
+							$mask = !empty($object->batch_mask) ? $object->batch_mask : getDolGlobalString('LOT_ADVANCED_MASK');
 						}
-						if ($object->status_batch == '2' && $conf->global->PRODUCTBATCH_SN_USE_PRODUCT_MASKS && $conf->global->PRODUCTBATCH_SN_ADDON == 'mod_sn_advanced') {
+						if ($object->status_batch == '2' && getDolGlobalString('PRODUCTBATCH_SN_USE_PRODUCT_MASKS') && $conf->global->PRODUCTBATCH_SN_ADDON == 'mod_sn_advanced') {
 							$mask = !empty($object->batch_mask) ? $object->batch_mask : $conf->global->SN_ADVANCED_MASK;
 						}
-						$inherited_mask_lot = $conf->global->LOT_ADVANCED_MASK;
-						$inherited_mask_sn = $conf->global->SN_ADVANCED_MASK;
+						$inherited_mask_lot = getDolGlobalString('LOT_ADVANCED_MASK');
+						$inherited_mask_sn = getDolGlobalString('SN_ADVANCED_MASK');
 						print '<td id="field_mask">';
 						print $form->textwithpicto('<input type="text" class="flat minwidth175" name="batch_mask" id="batch_mask_input" value="'.$mask.'">', $tooltip, 1, 1);
 
@@ -1651,12 +1651,12 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 						$(document).ready(function() {
 							$("#field_mask").parent().addClass("hideobject");
 							var preselect = document.getElementById("status_batch");';
-						if ($conf->global->PRODUCTBATCH_SN_USE_PRODUCT_MASKS) {
+						if (getDolGlobalString('PRODUCTBATCH_SN_USE_PRODUCT_MASKS')) {
 							print 'if (preselect.value == "2") {
 									$("#field_mask").parent().removeClass("hideobject");
 								}';
 						}
-						if ($conf->global->PRODUCTBATCH_LOT_USE_PRODUCT_MASKS) {
+						if (getDolGlobalString('PRODUCTBATCH_LOT_USE_PRODUCT_MASKS')) {
 							print 'if (preselect.value == "1") {
 									$("#field_mask").parent().removeClass("hideobject");
 								}';
@@ -1666,7 +1666,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 								var valueSelected = this.value;
 								$("#field_mask").parent().addClass("hideobject");
 						';
-						if ($conf->global->PRODUCTBATCH_LOT_USE_PRODUCT_MASKS && $conf->global->PRODUCTBATCH_LOT_ADDON == 'mod_lot_advanced') {
+						if (getDolGlobalString('PRODUCTBATCH_LOT_USE_PRODUCT_MASKS') && getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_advanced') {
 							print '
 								if (this.value == 1) {
 									$("#field_mask").parent().removeClass("hideobject");
@@ -1674,7 +1674,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 								}
 							';
 						}
-						if ($conf->global->PRODUCTBATCH_SN_USE_PRODUCT_MASKS && $conf->global->PRODUCTBATCH_SN_ADDON == 'mod_sn_advanced') {
+						if (getDolGlobalString('PRODUCTBATCH_SN_USE_PRODUCT_MASKS') && getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_advanced') {
 							print '
 								if (this.value == 2) {
 									$("#field_mask").parent().removeClass("hideobject");

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1650,21 +1650,20 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 						print '<script type="text/javascript">
 						$(document).ready(function() {
 							$("#field_mask").parent().addClass("hideobject");
-							var preselect = $("#status_batch option:selected");';
+							var preselect = document.getElementById("status_batch");';
 						if ($conf->global->PRODUCTBATCH_SN_USE_PRODUCT_MASKS)
 						{
-						print 'if (preselect == "2") {
-								$("#field_mask").parent().toggleClass("hideobject");
+						print 'if (preselect.value == "2") {
+								$("#field_mask").parent().removeClass("hideobject");
 							}';
 						}
 						if ($conf->global->PRODUCTBATCH_LOT_USE_PRODUCT_MASKS)
 						{
-						print 'if (preselect == "1") {
-								$("#field_mask").parent().toggleClass("hideobject");
+						print 'if (preselect.value == "1") {
+								$("#field_mask").parent().removeClass("hideobject");
 							}';
 						}
 						print '$("#status_batch").on("change", function () {
-								console.log("We change batch status");
 								var optionSelected = $("option:selected", this);
 								var valueSelected = this.value;
 								$("#field_mask").parent().addClass("hideobject");
@@ -1672,7 +1671,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 						if ($conf->global->PRODUCTBATCH_LOT_USE_PRODUCT_MASKS && $conf->global->PRODUCTBATCH_LOT_ADDON == 'mod_lot_advanced') {
 							print '
 								if (this.value == 1) {
-									$("#field_mask").parent().toggleClass("hideobject");
+									$("#field_mask").parent().removeClass("hideobject");
 									$("#batch_mask_input").val("'.$inherited_mask_lot.'");
 								}
 							';
@@ -1680,7 +1679,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 						if ($conf->global->PRODUCTBATCH_SN_USE_PRODUCT_MASKS && $conf->global->PRODUCTBATCH_SN_ADDON == 'mod_sn_advanced') {
 							print '
 								if (this.value == 2) {
-									$("#field_mask").parent().toggleClass("hideobject");
+									$("#field_mask").parent().removeClass("hideobject");
 									$("#batch_mask_input").val("'.$inherited_mask_sn.'");
 								}
 							';

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1639,8 +1639,8 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 						if ($object->status_batch == '1' && getDolGlobalString('PRODUCTBATCH_LOT_USE_PRODUCT_MASKS') && getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_advanced') {
 							$mask = !empty($object->batch_mask) ? $object->batch_mask : getDolGlobalString('LOT_ADVANCED_MASK');
 						}
-						if ($object->status_batch == '2' && getDolGlobalString('PRODUCTBATCH_SN_USE_PRODUCT_MASKS') && $conf->global->PRODUCTBATCH_SN_ADDON == 'mod_sn_advanced') {
-							$mask = !empty($object->batch_mask) ? $object->batch_mask : $conf->global->SN_ADVANCED_MASK;
+						if ($object->status_batch == '2' && getDolGlobalString('PRODUCTBATCH_SN_USE_PRODUCT_MASKS') && getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_advanced') {
+							$mask = !empty($object->batch_mask) ? $object->batch_mask : getDolGlobalString('SN_ADVANCED_MASK');
 						}
 						$inherited_mask_lot = getDolGlobalString('LOT_ADVANCED_MASK');
 						$inherited_mask_sn = getDolGlobalString('SN_ADVANCED_MASK');

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1649,21 +1649,30 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 
 						print '<script type="text/javascript">
 						$(document).ready(function() {
-							$("#field_mask, #mask_option").addClass("hideobject");
-							var preselect = $("#status_batch option:selected");
-							if (preselect !== "0") {
-								$("#field_mask, #mask_option").toggleClass("hideobject");
-							}
-							$("#status_batch").on("change", function () {
+							$("#field_mask").parent().addClass("hideobject");
+							var preselect = $("#status_batch option:selected");';
+						if ($conf->global->PRODUCTBATCH_SN_USE_PRODUCT_MASKS)
+						{
+						print 'if (preselect == "2") {
+								$("#field_mask").parent().toggleClass("hideobject");
+							}';
+						}
+						if ($conf->global->PRODUCTBATCH_LOT_USE_PRODUCT_MASKS)
+						{
+						print 'if (preselect == "1") {
+								$("#field_mask").parent().toggleClass("hideobject");
+							}';
+						}
+						print '$("#status_batch").on("change", function () {
 								console.log("We change batch status");
 								var optionSelected = $("option:selected", this);
 								var valueSelected = this.value;
-								$("#field_mask, #mask_option").addClass("hideobject");
+								$("#field_mask").parent().addClass("hideobject");
 						';
 						if ($conf->global->PRODUCTBATCH_LOT_USE_PRODUCT_MASKS && $conf->global->PRODUCTBATCH_LOT_ADDON == 'mod_lot_advanced') {
 							print '
 								if (this.value == 1) {
-									$("#field_mask, #mask_option").toggleClass("hideobject");
+									$("#field_mask").parent().toggleClass("hideobject");
 									$("#batch_mask_input").val("'.$inherited_mask_lot.'");
 								}
 							';
@@ -1671,7 +1680,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 						if ($conf->global->PRODUCTBATCH_SN_USE_PRODUCT_MASKS && $conf->global->PRODUCTBATCH_SN_ADDON == 'mod_sn_advanced') {
 							print '
 								if (this.value == 2) {
-									$("#field_mask, #mask_option").toggleClass("hideobject");
+									$("#field_mask").parent().toggleClass("hideobject");
 									$("#batch_mask_input").val("'.$inherited_mask_sn.'");
 								}
 							';

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1651,17 +1651,15 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 						$(document).ready(function() {
 							$("#field_mask").parent().addClass("hideobject");
 							var preselect = document.getElementById("status_batch");';
-						if ($conf->global->PRODUCTBATCH_SN_USE_PRODUCT_MASKS)
-						{
-						print 'if (preselect.value == "2") {
-								$("#field_mask").parent().removeClass("hideobject");
-							}';
+						if ($conf->global->PRODUCTBATCH_SN_USE_PRODUCT_MASKS) {
+							print 'if (preselect.value == "2") {
+									$("#field_mask").parent().removeClass("hideobject");
+								}';
 						}
-						if ($conf->global->PRODUCTBATCH_LOT_USE_PRODUCT_MASKS)
-						{
-						print 'if (preselect.value == "1") {
-								$("#field_mask").parent().removeClass("hideobject");
-							}';
+						if ($conf->global->PRODUCTBATCH_LOT_USE_PRODUCT_MASKS) {
+							print 'if (preselect.value == "1") {
+									$("#field_mask").parent().removeClass("hideobject");
+								}';
 						}
 						print '$("#status_batch").on("change", function () {
 								var optionSelected = $("option:selected", this);


### PR DESCRIPTION
While testing v14, it occurred to us that the custom mask field was not properly hidden in product card edit.

Here when the lot product mask is inactive
![hiddenField](https://user-images.githubusercontent.com/81741011/124935402-eb2d3980-e005-11eb-8ce8-fdf825521762.png)
Here when the serial number product mask is activated
![visibleField](https://user-images.githubusercontent.com/81741011/124935746-3b0c0080-e006-11eb-949e-8815fc8edc22.png)

