### PR TITLE
FIX get categories linked to another object type

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -1497,7 +1497,7 @@ class Categorie extends CommonObject
 		} else {
 			$sql = "SELECT ct.fk_categorie, c.label, c.rowid";
 			$sql .= " FROM ".MAIN_DB_PREFIX."categorie_".(empty($this->MAP_CAT_TABLE[$type]) ? $type : $this->MAP_CAT_TABLE[$type])." as ct, ".MAIN_DB_PREFIX."categorie as c";
-			$sql .= " WHERE ct.fk_categorie = c.rowid AND ct.fk_".(empty($this->MAP_CAT_FK[$type]) ? $type : $this->MAP_CAT_FK[$type])." = ".(int) $id." AND c.type = ".$this->MAP_ID[$type];
+			$sql .= " WHERE ct.fk_categorie = c.rowid AND ct.fk_".(empty($this->MAP_CAT_FK[$type]) ? $type : $this->MAP_CAT_FK[$type])." = ".(int) $id;
 			$sql .= " AND c.entity IN (".getEntity('category').")";
 
 			$res = $this->db->query($sql);


### PR DESCRIPTION
FIX get categories linked to another object type (and this test is also not necessary)

Example: when link product categories to a ticket object and add a new map categorie by hook
 array(
	'id' => 500,
	'code' => 'ticket',
	'cat_fk' => 'ticket',
	'cat_table' => 'ticket',
	'obj_class' => 'Ticket',
	'obj_table' => 'ticket',
)
