### PR TITLE
Fix UI event badge status

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1899,7 +1899,7 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon = '', $noprin
 			}
 
 			// Status
-			$out .= '<td class="nowrap center">'.$actionstatic->LibStatut($histo[$key]['percent'], 3, 0, $histo[$key]['datestart']).'</td>';
+			$out .= '<td class="nowrap center">'.$actionstatic->LibStatut($histo[$key]['percent'], 2, 0, $histo[$key]['datestart']).'</td>';
 
 			// Actions
 			$out .= '<td></td>';


### PR DESCRIPTION
Change pill badge to standard badges in Events list to be like others lists


![image](https://user-images.githubusercontent.com/29435477/125273321-187f2d80-e30d-11eb-9c60-a45cb1931455.png)


![image](https://user-images.githubusercontent.com/29435477/125273120-e1108100-e30c-11eb-9975-d854be929885.png)
