### PR TITLE
fix badge status bgcolor

### DIFF
--- a/htdocs/theme/eldy/badges.inc.php
+++ b/htdocs/theme/eldy/badges.inc.php
@@ -258,9 +258,9 @@ function _createStatusBadgeCss($statusName, $statusVarNamePrefix = '', $commentL
 		print $cssPrefix.".badge-status".$statusName." {\n";
 		print "        color: ".$thisBadgeTextColor." !important;\n";
 		if (in_array((string) $statusName, $TBadgeBorderOnly)) {
-			print "        border-color: ".$thisBadgeBorderColor.";\n";
+			print "        border-color: ".$thisBadgeBorderColor." !important;\n";
 		}
-		print "        background-color: ".$thisBadgeBackgroundColor.";\n";
+		print "        background-color: ".$thisBadgeBackgroundColor." !important;\n";
 		print "}\n";
 
 		print $cssPrefix.".font-status".$statusName." {\n";
@@ -269,14 +269,14 @@ function _createStatusBadgeCss($statusName, $statusVarNamePrefix = '', $commentL
 
 		print $cssPrefix.".badge-status".$statusName.".focus, ".$cssPrefix.".badge-status".$statusName.":focus {\n";
 		print "    outline: 0;\n";
-		print "    box-shadow: 0 0 0 0.2rem ".colorHexToRgb($thisBadgeBackgroundColor, 0.5).";\n";
+		print "    box-shadow: 0 0 0 0.2rem ".colorHexToRgb($thisBadgeBackgroundColor, 0.5)." !important;\n";
 		print "}\n";
 
 		print $cssPrefix.".badge-status".$statusName.":focus, ".$cssPrefix.".badge-status".$statusName.":hover {\n";
 		print "    color: ".$thisBadgeTextColor." !important;\n";
 		//print "    background-color: " . colorDarker($thisBadgeBackgroundColor, 10) . ";\n";
 		if (in_array((string) $statusName, $TBadgeBorderOnly)) {
-			print "        border-color: ".colorDarker($thisBadgeBorderColor, 10).";\n";
+			print "        border-color: ".colorDarker($thisBadgeBorderColor, 10)." !important;\n";
 		}
 		print "}\n";
 	}

--- a/htdocs/theme/md/badges.inc.php
+++ b/htdocs/theme/md/badges.inc.php
@@ -261,9 +261,9 @@ function _createStatusBadgeCss($statusName, $statusVarNamePrefix = '', $commentL
 		print $cssPrefix.".badge-status".$statusName." {\n";
 		print "        color: ".$thisBadgeTextColor." !important;\n";
 		if (in_array((string) $statusName, $TBadgeBorderOnly)) {
-			print "        border-color: ".$thisBadgeBorderColor.";\n";
+			print "        border-color: ".$thisBadgeBorderColor." !important;\n";
 		}
-		print "        background-color: ".$thisBadgeBackgroundColor.";\n";
+		print "        background-color: ".$thisBadgeBackgroundColor." !important;\n";
 		print "}\n";
 
 		print $cssPrefix.".font-status".$statusName." {\n";
@@ -272,14 +272,14 @@ function _createStatusBadgeCss($statusName, $statusVarNamePrefix = '', $commentL
 
 		print $cssPrefix.".badge-status".$statusName.".focus, ".$cssPrefix.".badge-status".$statusName.":focus {\n";
 		print "    outline: 0;\n";
-		print "    box-shadow: 0 0 0 0.2rem ".colorHexToRgb($thisBadgeBackgroundColor, 0.5).";\n";
+		print "    box-shadow: 0 0 0 0.2rem ".colorHexToRgb($thisBadgeBackgroundColor, 0.5)." !important;\n";
 		print "}\n";
 
 		print $cssPrefix.".badge-status".$statusName.":focus, ".$cssPrefix.".badge-status".$statusName.":hover {\n";
 		print "    color: ".$thisBadgeTextColor." !important;\n";
 		//print "    background-color: ".colorDarker($thisBadgeBackgroundColor, 10).";\n";
 		if (in_array((string) $statusName, $TBadgeBorderOnly)) {
-			print "        border-color: ".colorDarker($thisBadgeBorderColor, 10).";\n";
+			print "        border-color: ".colorDarker($thisBadgeBorderColor, 10)." !important;\n";
 		}
 		print "}\n";
 	}


### PR DESCRIPTION
added !important to background and border colors rules in badge.inc.php because of external modules using bootstrap css (ie : tiaris logistique module). The badge bgcolor was dark for all statuses with this module !
![image](https://user-images.githubusercontent.com/396322/125285841-5daa5c00-e31b-11eb-8678-78c91c8db90a.png)
