### PR TITLE
FIX : "disabled" field missing on definition

### DIFF
--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -267,6 +267,11 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	public $always_enabled;
 
 	/**
+	 * @var bool Module is disabled
+	 */
+	public $disabled;
+
+	/**
 	 * @var int Module is enabled globally (Multicompany support)
 	 */
 	public $core_enabled;


### PR DESCRIPTION
leave a warning message instead