### PR TITLE
Order Supplier Email Sender Extension

### DIFF
--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -137,7 +137,14 @@ if ($action == 'presend') {
 		$formmail->fromname = '';
 		$formmail->fromtype = 'special';
 	}
+    if ($object->element === 'order_supplier' && !empty($conf->global->ORDER_SUPPLIER_EMAIL_SENDER)) {
+        $formmail->frommail = $conf->global->ORDER_SUPPLIER_EMAIL_SENDER;
+        $formmail->fromname = '';
+        $formmail->fromtype = 'special';
+    }
 
+	
+	
 	$formmail->trackid = $trackid;
 	if (!empty($conf->global->MAIN_EMAIL_ADD_TRACK_ID) && ($conf->global->MAIN_EMAIL_ADD_TRACK_ID & 2)) {	// If bit 2 is set
 		include DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -137,14 +137,14 @@ if ($action == 'presend') {
 		$formmail->fromname = '';
 		$formmail->fromtype = 'special';
 	}
-    if ($object->element === 'order_supplier' && !empty($conf->global->ORDER_SUPPLIER_EMAIL_SENDER)) {
-        $formmail->frommail = $conf->global->ORDER_SUPPLIER_EMAIL_SENDER;
-        $formmail->fromname = '';
-        $formmail->fromtype = 'special';
-    }
+	if ($object->element === 'order_supplier' && !empty($conf->global->ORDER_SUPPLIER_EMAIL_SENDER)) {
+		$formmail->frommail = $conf->global->ORDER_SUPPLIER_EMAIL_SENDER;
+		$formmail->fromname = '';
+		$formmail->fromtype = 'special';
+	}
 
-	
-	
+
+
 	$formmail->trackid = $trackid;
 	if (!empty($conf->global->MAIN_EMAIL_ADD_TRACK_ID) && ($conf->global->MAIN_EMAIL_ADD_TRACK_ID & 2)) {	// If bit 2 is set
 		include DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';


### PR DESCRIPTION
# New: Order Supplier Address
Extended the advanced options to specify an email address for the order supplier. Useful if you operate under a brand, but order under a different. It extends the following functionality introduced with the patch https://github.com/Dolibarr/dolibarr/pull/14273/files in Dolibarr 10