### PR TITLE
FIX: Salary - link 'salary' of bank_url  isn't managed in module bank & accountancy

### DIFF
--- a/htdocs/compta/bank/bankentries_list.php
+++ b/htdocs/compta/bank/bankentries_list.php
@@ -1423,7 +1423,6 @@ if ($resql) {
 				} elseif ($links[$key]['type'] == 'member') {
 				} elseif ($links[$key]['type'] == 'sc') {
 				} elseif ($links[$key]['type'] == 'vat') {
-				} elseif ($links[$key]['type'] == 'salary') {
 				} else {
 					// Show link with label $links[$key]['label']
 					if (!empty($objp->label) && !empty($links[$key]['label'])) {
@@ -1510,9 +1509,9 @@ if ($resql) {
 			print '<td class="tdoverflowmax150">';
 
 			$companylinked_id = 0;
-				$userlinked_id = 0;
+			$userlinked_id = 0;
 
-				//payment line type to define user display and user or company linked
+			//payment line type to define user display and user or company linked
 			foreach ($links as $key => $value) {
 				if ($links[$key]['type'] == 'payment_sc') {
 					$type_link = 'payment_sc';
@@ -1520,7 +1519,6 @@ if ($resql) {
 				if ($links[$key]['type'] == 'payment_salary') {
 					$type_link = 'payment_salary';
 				}
-
 				if ($links[$key]['type'] == 'company') {
 					$companylinked_id = $links[$key]['url_id'];
 				}

--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -226,7 +226,8 @@ if ($action == 'add' && empty($cancel)) {
 			$paiement->amounts      = array($object->id=>$amount); // Tableau de montant
 			$paiement->paiementtype = $type_payment;
 			$paiement->num_payment  = GETPOST("num_payment", 'alphanohtml');
-			$paiement->note = GETPOST("note", 'none');
+			$paiement->note			= GETPOST("note", 'none');
+			$paiement->fk_user		= GETPOST("fk_user", 'int') > 0 ? GETPOST("fk_user", "int") : 0;
 
 			if (!$error) {
 				$paymentid = $paiement->create($user, (int) GETPOST('closepaidsalary'));

--- a/htdocs/salaries/class/paymentsalary.class.php
+++ b/htdocs/salaries/class/paymentsalary.class.php
@@ -572,8 +572,6 @@ class PaymentSalary extends CommonObject
 				// Add link 'user' in bank_url between user and bank transaction
 				if (!$error) {
 					foreach ($this->amounts as $key => $value) {
-						dol_syslog(get_class($this) . '::Insertuser ' . $key);
-
 						if ($mode == 'payment_salary') {
 							$fuser = new User($this->db);
 							$fuser->fetch($this->fk_user);

--- a/htdocs/salaries/class/paymentsalary.class.php
+++ b/htdocs/salaries/class/paymentsalary.class.php
@@ -572,7 +572,6 @@ class PaymentSalary extends CommonObject
 				// Add link 'user' in bank_url between user and bank transaction
 				if (!$error) {
 					foreach ($this->amounts as $key => $value) {
-
 						dol_syslog(get_class($this) . '::Insertuser ' . $key);
 
 						if ($mode == 'payment_salary') {


### PR DESCRIPTION
Return to type 'user' in bank_url to resolve some problems.

In bank entries :
![image](https://user-images.githubusercontent.com/2341395/126889777-4d545198-1668-43e5-92d7-189a815b784e.png)

In accountancy before transaction inscription :
![image](https://user-images.githubusercontent.com/2341395/126889817-b1c6d0e5-7876-48ef-8eac-a9a94d94e413.png)


