### PR TITLE
FIX: cannot add time spend when column ref is not displayed

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -1374,7 +1374,7 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0)
         			print '</td>';
         			if (!$i) $totalarray['nbfield']++;
     			}
-            } else {
+            } elseif ($action !== 'createtime') {
             	print '<input type="hidden" name="taskid" value="'.$id.'">';
             }
 


### PR DESCRIPTION
On Time spent Tab on project, if task ref column is not displayed, and already have time send on task, when submit new time you got Error Message with "Task Is Required"
![image](https://user-images.githubusercontent.com/1050053/126957565-1e4a7a52-2bab-4b55-8684-cd86626f8158.png)

![image](https://user-images.githubusercontent.com/1050053/126957623-acd68644-944c-4dce-8c4a-07b2fb4c0fa8.png)

