### PR TITLE
FIX opp status required even if PROJECT_USE_OPPORTUNITIES off

### DIFF
--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -132,9 +132,12 @@ if (empty($reshook)) {
 			$error++;
 		}
 
-		if (GETPOST('opp_amount') != '' && !(GETPOST('opp_status') > 0)) {
-			$error++;
-			setEventMessages($langs->trans("ErrorOppStatusRequiredIfAmount"), null, 'errors');
+		if (! empty($conf->global->PROJECT_USE_OPPORTUNITIES))
+		{
+			if (GETPOST('opp_amount') != '' && !(GETPOST('opp_status') > 0)) {
+				$error++;
+				setEventMessages($langs->trans("ErrorOppStatusRequiredIfAmount"), null, 'errors');
+			}
 		}
 
 		// Create with status validated immediatly
@@ -270,9 +273,12 @@ if (empty($reshook)) {
 			}
 		}
 
-		if ($object->opp_amount && ($object->opp_status <= 0)) {
-			$error++;
-			setEventMessages($langs->trans("ErrorOppStatusRequiredIfAmount"), null, 'errors');
+		if (! empty($conf->global->PROJECT_USE_OPPORTUNITIES))
+		{
+			if ($object->opp_amount && ($object->opp_status <= 0)) {
+				$error++;
+				setEventMessages($langs->trans("ErrorOppStatusRequiredIfAmount"), null, 'errors');
+			}
 		}
 
 		if (!$error) {

--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -132,8 +132,7 @@ if (empty($reshook)) {
 			$error++;
 		}
 
-		if (! empty($conf->global->PROJECT_USE_OPPORTUNITIES))
-		{
+		if (! empty($conf->global->PROJECT_USE_OPPORTUNITIES)) {
 			if (GETPOST('opp_amount') != '' && !(GETPOST('opp_status') > 0)) {
 				$error++;
 				setEventMessages($langs->trans("ErrorOppStatusRequiredIfAmount"), null, 'errors');
@@ -273,8 +272,7 @@ if (empty($reshook)) {
 			}
 		}
 
-		if (! empty($conf->global->PROJECT_USE_OPPORTUNITIES))
-		{
+		if (! empty($conf->global->PROJECT_USE_OPPORTUNITIES)) {
 			if ($object->opp_amount && ($object->opp_status <= 0)) {
 				$error++;
 				setEventMessages($langs->trans("ErrorOppStatusRequiredIfAmount"), null, 'errors');


### PR DESCRIPTION
If I modify a project and do not have PROJECT_USE_OPPORTUNITIES enabled, I cannot change the project budget. I get the error message that ErrorOppStatusRequiredIfAmount. However, I do not have the opportunities enabled and it does not make sense for that message to appear when I have not added any opportunities.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #[*issue_number Short description*]
[*Long description*]


# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
