### PR TITLE
FIX $conf->task used but it does not exist, use $conf->projet instead

### DIFF
--- a/htdocs/core/modules/project/task/doc/doc_generic_task_odt.modules.php
+++ b/htdocs/core/modules/project/task/doc/doc_generic_task_odt.modules.php
@@ -524,8 +524,8 @@ class doc_generic_task_odt extends ModelePDFTask
 				//print "conf->societe->dir_temp=".$conf->societe->dir_temp;
 
 				dol_mkdir($conf->projet->dir_temp);
-				if (!is_writable($conf->task->dir_temp)) {
-					$this->error = "Failed to write in temp directory ".$conf->task->dir_temp;
+				if (!is_writable($conf->projet->dir_temp)) {
+					$this->error = "Failed to write in temp directory ".$conf->projet->dir_temp;
 					dol_syslog('Error in write_file: '.$this->error, LOG_ERR);
 					return -1;
 				}


### PR DESCRIPTION
# Fix document generation issue
When generating odt document for a task in v14, there is an error because it looks for `$conf->task->dir_temp` instead of `$conf->projet->dir_temp`.

cf. [forum post](https://www.dolibarr.fr/forum/t/probleme-creation-rapport-de-tache-v14/37369)