### PR TITLE
extend the hook `getElementList` to make $ids in the hooked function

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -744,7 +744,8 @@ class Project extends CommonObject
 			'datefieldname'  => $datefieldname,
 			'dates' => $dates,
 			'datee' => $datee,
-			'fk_projet' => $projectkey
+			'fk_projet' => $projectkey,
+			'ids' => $ids,
 		);
 		$reshook = $hookmanager->executeHooks('getElementList', $parameters, $object, $action);
 		if ($reshook > 0) {


### PR DESCRIPTION
allows for other types of costs on the project elements.php

example implementation

```php
	public function completeListOfReferent( $parameters, &$object, &$action, $hookmanager ) {

		global $user;
		global $langs;

		$this->results = array(
			'consumption' => array(
				'name'          => $langs->trans("Verbrauch"),
				'title'         => $langs->trans("Liste der Verbräuche"),
				'class'         => 'MouvementStock',
				'table'         => 'stock_mouvement',
				'datefieldname' => 'datev',
				'margin'        => 'minus',
				'disableamount' => 0,
				'urlnew'        => DOL_URL_ROOT . '/custom/consumption/card.php?id=' . $object->id . '&type=project',
				'lang'          => 'consumption',
				'buttonnew'     => $langs->trans("Neuen Verbrauch erfassen"),
				'testnew'       => $user->rights->consumption->writeproject,
				'test'          => $user->rights->consumption->writeproject,
			),
		);

		return 1;
	}

	public function getElementList( $parameters, &$object, &$action, $hookmanager ) {

		if ( $parameters['tablename'] == 'stock_mouvement' ) {
			$this->resprints = 'SELECT rowid FROM ' . MAIN_DB_PREFIX . "stock_mouvement WHERE origintype IN ('project') AND fk_origin IN (" . $parameters['ids'] . ")";

			return 1;
		}

		return 0;
	}
```