### PR TITLE
fix `tomail` param in mail form usage

### DIFF
--- a/htdocs/core/actions_sendmails.inc.php
+++ b/htdocs/core/actions_sendmails.inc.php
@@ -186,6 +186,11 @@ if (($action == 'send' || $action == 'relance') && !$_POST['addfile'] && !$_POST
 			$tmparray[] = trim($_POST['sendto']);
 		}
 
+		if (trim($_POST['tomail'])) {
+			// Recipients are provided as free text
+			$tmparray[] = trim($_POST['tomail']);
+		}
+
 		if (count($receiver) > 0) {
 			// Recipient was provided from combo list
 			foreach ($receiver as $key => $val) {


### PR DESCRIPTION
the field 'tomail' in the mailing (presend) form is broken.
this fixes that