### PR TITLE
Fix #18289 : fix an error in emptyexample.php

### DIFF
--- a/htdocs/imports/emptyexample.php
+++ b/htdocs/imports/emptyexample.php
@@ -79,7 +79,7 @@ $entity = $objimport->array_import_entities[0][$code];
 $entityicon = $entitytoicon[$entity] ? $entitytoicon[$entity] : $entity;
 $entitylang = $entitytolang[$entity] ? $entitytolang[$entity] : $entity;
 $fieldstarget = $objimport->array_import_fields[0];
-$valuestarget = $objimport->array_import_examplevalues[0];
+$valuestarget = $objimport->array_import_examplevalues;
 
 $attachment = true;
 if (isset($_GET["attachment"])) {


### PR DESCRIPTION
Fix an error in emptyexample.php which create a fatal error in php 8 and an offset error on a string in php 7