### PR TITLE
DRAFT: Fix 13.0 EATBY/SELLBY hidden conf names mixed up

### DIFF
--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -828,10 +828,10 @@ if ($id > 0 || !empty($ref)) {
 								print $linktoprod;
 								print "</td>";
 								print '<td class="dispatch_batch_number"></td>';
-								if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+								if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
 									print '<td class="dispatch_dluo"></td>';
 								}
-								if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+								if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
 									print '<td class="dispatch_dlc"></td>';
 								}
 							} else {
@@ -841,10 +841,10 @@ if ($id > 0 || !empty($ref)) {
 								print '<td class="dispatch_batch_number">';
 								print $langs->trans("ProductDoesNotUseBatchSerial");
 								print '</td>';
-								if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+								if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
 									print '<td class="dispatch_dluo"></td>';
 								}
-								if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
+								if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
 									print '<td class="dispatch_dlc"></td>';
 								}
 							}
@@ -919,7 +919,7 @@ if ($id > 0 || !empty($ref)) {
 								print $form->selectDate($dlcdatesuffix, 'dlc'.$suffix, '', '', 1, '');
 								print '</td>';
 							}
-							if (empty($conf->global->PRODUCT_DISABLE_EATBY)) {
+							if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
 								print '<td class="nowraponall">';
 								$dluodatesuffix = dol_mktime(0, 0, 0, GETPOST('dluo'.$suffix.'month'), GETPOST('dluo'.$suffix.'day'), GETPOST('dluo'.$suffix.'year'));
 								print $form->selectDate($dluodatesuffix, 'dluo'.$suffix, '', '', 1, '');


### PR DESCRIPTION
# [do not merge] Fix
Checks for hidden options `PRODUCT_DISABLE_EATBY` and `PRODUCT_DISABLE_SELLBY` are sometimes mixed up. This causes (among other problems) some colspan / col count bugs if you activate one of those options and not the other.

[edit]
I am reworking this fix, apparently there are still some misaligned columns in a few cases.