### PR TITLE
Fix variants issues: decimal separator not always parsed right + fatal on variant list

### DIFF
--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -56,6 +56,9 @@ $prodstatic = new Product($db);
 $prodattr = new ProductAttribute($db);
 $prodattr_val = new ProductAttributeValue($db);
 
+if (GETPOSTISSET('price_impact')) $price_impact = price2num($price_impact);
+if (GETPOSTISSET('weight_impact')) $weight_impact = price2num($weight_impact);
+
 $object = new Product($db);
 if ($id > 0 || $ref) {
 	$object->fetch($id, $ref);
@@ -128,8 +131,6 @@ if (($action == 'add' || $action == 'create') && empty($massaction) && !GETPOST(
 		if (empty($reference)) {
 			$reference = false;
 		}
-		$weight_impact = price2num($weight_impact);
-		$price_impact = price2num($price_impact);
 
 		// for conf PRODUIT_MULTIPRICES
 		if ($conf->global->PRODUIT_MULTIPRICES) {

--- a/htdocs/variants/list.php
+++ b/htdocs/variants/list.php
@@ -16,8 +16,8 @@
  */
 
 require '../main.inc.php';
-require DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
-require DOL_DOCUMENT_ROOT.'/variants/class/ProductAttribute.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
+require_once DOL_DOCUMENT_ROOT.'/variants/class/ProductAttribute.class.php';
 
 $action = GETPOST('action', 'aZ09');
 $object = new ProductAttribute($db);


### PR DESCRIPTION
# Fix fatal on variant list + decimal sep. parsing
The fatal error occurs on `htdocs/variants/list.php` because class `Product` is redeclared (using `require_once` instead of `require` fixes it).

The other error occurs when you save a variant with a non-percentage variation (box unchecked) using a decimal separator other than ".": the value is not saved properly. Applying `price2num` from the moment the HTTP parameter value is assigned to its variable fixes the problem.