### PR TITLE
NEW : add constant PROPAL_DONT_KEEP_SHIPPING_INFOS_ON_CLONING

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1378,6 +1378,10 @@ class Propal extends CommonObject
 			$object->note_private = '';
 			$object->note_public = '';
 		}
+		if ( ! empty($conf->global->PROPAL_DONT_KEEP_SHIPPING_INFOS_ON_CLONING)) {
+			$object->availability_id = '';
+			$object->date_livraison = '';
+		}
 		// Create clone
 		$object->context['createfromclone'] = 'createfromclone';
 		$result = $object->create($user);


### PR DESCRIPTION
do not copy availability id and planned shippiing date when cloning a proposal