### PR TITLE
NEW : add constant ORDER_DONT_KEEP_INTERNAL_CONTACTS_ON_CLONING

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1229,7 +1229,7 @@ class Commande extends CommonOrder
 			$error++;
 		}
 
-		if (!$error) {
+		if (!$error && empty($conf->global->ORDER_DONT_KEEP_INTERNAL_CONTACTS_ON_CLONING)) {
 			// copy internal contacts
 			if ($this->copy_linked_contact($objFrom, 'internal') < 0) {
 				$error++;


### PR DESCRIPTION
allow to not copy internal contacts when cloning an order for a whole company workflow strict process