### PR TITLE
typo fixes in .github/PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 *Please:*
 - *only keep the "Fix", "Close" or "New" section*
 - *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
-- *replace the bracket enclosed textswith meaningful informations*
+- *replace the bracket enclosed texts with meaningful information*
 
 
 # Fix #[*issue_number Short description*]


### PR DESCRIPTION
added a missing space, removed a superfluous plural marker.