### PR TITLE
NEW: add constant MAIN_IBAN_IS_NEVER_MANDATORY

### DIFF
--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -1519,6 +1519,10 @@ class Account extends CommonObject
 	 */
 	public function needIBAN()
 	{
+		global $conf;
+
+		if ( ! empty($conf->global->MAIN_IBAN_NOT_MANDATORY) ) return 0;
+
 		$country_code = $this->getCountryCode();
 
 		$country_code_in_EEC = array(


### PR DESCRIPTION
let IBAN and BIC informations not mandatory.
very useful if the company don't use SEPA direct debit , but LCR external module for instance.
With this constant, they dont have to input IBAN informations for thousands of thirdparties for no use.