### PR TITLE
FIX compatibility postgre sql

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -41,7 +41,7 @@ if (! empty($extrafieldsobjectkey) && ! empty($search_array_options) && is_array
 			if (in_array($typ, array('chkbxlst', 'checkbox'))) $mode_search=4;	                            // Search on a multiselect field with sql type = text
 			if (is_array($crit)) $crit = implode(' ', $crit); // natural_search() expects a string
 			elseif ($typ === 'select' and is_string($crit) and strpos($crit, ' ') === false) {
-				$sql .= ' AND (' . $extrafieldsobjectprefix.$tmpkey . ' = \'' . $db->escape($crit) . '\')';
+				$sql .= " AND (" . $extrafieldsobjectprefix.$tmpkey . " = '" . $db->escape($crit) . "')";
 				continue;
 			}
 			$sql .= natural_search($extrafieldsobjectprefix.$tmpkey, $crit, $mode_search);

--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -41,7 +41,7 @@ if (! empty($extrafieldsobjectkey) && ! empty($search_array_options) && is_array
 			if (in_array($typ, array('chkbxlst', 'checkbox'))) $mode_search=4;	                            // Search on a multiselect field with sql type = text
 			if (is_array($crit)) $crit = implode(' ', $crit); // natural_search() expects a string
 			elseif ($typ === 'select' and is_string($crit) and strpos($crit, ' ') === false) {
-				$sql .= ' AND (' . $extrafieldsobjectprefix.$tmpkey . ' = "' . $db->escape($crit) . '")';
+				$sql .= ' AND (' . $extrafieldsobjectprefix.$tmpkey . ' = \'' . $db->escape($crit) . '\')';
 				continue;
 			}
 			$sql .= natural_search($extrafieldsobjectprefix.$tmpkey, $crit, $mode_search);


### PR DESCRIPTION


# Fix compatibility postgre sql

When you filter on a select, an error occurs because two quotes are used, but for varchar search you have to use simple quote
