### PR TITLE
FIX: price impact of new combination is always a percentage even if the checkbox was unchecked

### DIFF
--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -137,9 +137,10 @@ if (($action == 'add' || $action == 'create') && empty($massaction) && !GETPOST(
 		// for conf PRODUIT_MULTIPRICES
 		if ($conf->global->PRODUIT_MULTIPRICES) {
 			$level_price_impact = array_map('price2num', $level_price_impact);
+			$level_price_impact_percent = array(1 => $price_impact_percent);
 		} else {
 			$level_price_impact = array(1 => $price_impact);
-			$level_price_impact_percent = array(1 => $price_impact_percent);
+			$level_price_impact_percent = $price_impact_percent;
 		}
 
 		$sanit_features = array();


### PR DESCRIPTION
# FIX cf. [forum thread](https://www.dolibarr.fr/forum/t/bug-sur-le-variants/37455/2)
When you create a new product combination, even if you leave the "Percentage variation" checkbox empty, the price impact is considered a percentage.

This is caused by the attribute `variation_price_percentage` of `ProductCombination` being either an array or a boolean depending on whether `PRODUIT_MULTIPRICES` is used: it seems to me that in the lines I changed, it was set as an array when it should have been a boolean and vice versa.

My changes fix the problem as it was described, however, I am not very familiar with the multiprice feature, so I’d gladly wait for someone more experienced to take a second look.