### PR TITLE
NEW : Adds PDF_HIDE_PRODUCT_LABEL_IN_SUPPLIER_LINES to hide product label in supplier order lines

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1275,11 +1275,14 @@ function pdf_getlinedesc($object, $i, $outputlangs, $hideref = 0, $hidedesc = 0,
 		$desc = str_replace('(DEPOSIT)', $outputlangs->trans('Deposit'), $desc);
 	}
 
-	// Description short of product line
-	$libelleproduitservice = $label;
-	if (!empty($libelleproduitservice) && !empty($conf->global->PDF_BOLD_PRODUCT_LABEL)) {
-		$libelleproduitservice = '<b>'.$libelleproduitservice.'</b>';
+	if (empty($conf->global->PDF_HIDE_PRODUCT_LABEL_IN_SUPPLIER_LINES)) {
+		// Description short of product line
+		$libelleproduitservice = $label;
+		if (!empty($libelleproduitservice) && !empty($conf->global->PDF_BOLD_PRODUCT_LABEL)) {
+			$libelleproduitservice = '<b>'.$libelleproduitservice.'</b>';
+		}
 	}
+
 
 	// Add ref of subproducts
 	if (!empty($conf->global->SHOW_SUBPRODUCT_REF_IN_PDF)) {


### PR DESCRIPTION
Adds a Global variable 'PDF_HIDE_PRODUCT_LABEL_IN_SUPPLIER_LINES' to have the possibility to hide product label in supplier order lines.

# New : *Adds possibility to hide the product label in the supplier order lines*
This PR allows to hide the product label in the supplier order lines by setting the global variable `PDF_HIDE_PRODUCT_LABEL_IN_SUPPLIER_LINES`. Combined with the already existing variable `PRODUIT_FOURN_TEXTS`, only the supplier description (in product supplier price) will be shown instead of the two descriptions.