### PR TITLE
FIX warning in supplier order list (status filter is multiselect)

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -555,6 +555,7 @@ function GETPOST($paramname, $check = 'alphanohtml', $method = 0, $filter = null
 			if (!is_numeric($out)) { $out = ''; }
 			break;
 		case 'intcomma':
+			if (is_array($out)) break;
 			if (preg_match('/[^0-9,-]+/i', $out)) $out = '';
 			break;
 		case 'alpha':


### PR DESCRIPTION
# FIX
If you use the status filter in the supplier order list, you get a warning
> `preg_match()` expects parameter 2 to be string, array given in `/path/to/dolibarr/htdocs/core/lib/functions.lib.php` on line 559

This is because the status filter is a multiselect, which causes the post value to be an array. Since the `GETPOST` check parameter is `intcomma`, the check implies passing the value (the array) to a `preg_match()`.

This fix only avoids running `preg_match` on the array for the `intcomma` check. Maybe there could be a better fix, but it seems that other type checks do the very same.