### PR TITLE
FIX: e-mail of applicant is not transferred to the new user when creating a user from an applicant card

### DIFF
--- a/htdocs/recruitment/recruitmentcandidature_card.php
+++ b/htdocs/recruitment/recruitmentcandidature_card.php
@@ -264,6 +264,7 @@ if (empty($reshook)) {
 			$nuser->birth = $object->date_birth;
 			$nuser->salary = $object->remuneration_proposed;
 			$nuser->fk_user = $jobposition->fk_user_supervisor; // Supervisor
+			$nuser->email = $object->email;
 
 			$result = $nuser->create($user);
 


### PR DESCRIPTION
# FIX

cf. [forum thread](https://www.dolibarr.fr/forum/t/module-recrutement-pb-creation-compte-depuis-fiche-candidat/37535/4)

When you create a new Dolibarr user from an applicant card, the creation fails with the message "Email …@… already exists."
Transferring the e-mail field from the applicant object to the user object fixes it.