### PR TITLE
Fix: MO status selector draft showing all values instead of showing o…

### DIFF
--- a/htdocs/mrp/mo_list.php
+++ b/htdocs/mrp/mo_list.php
@@ -235,7 +235,7 @@ foreach ($search as $key => $val) {
 		}
 		$mode_search = (($object->isInt($object->fields[$key]) || $object->isFloat($object->fields[$key])) ? 1 : 0);
 		if ((strpos($object->fields[$key]['type'], 'integer:') === 0) || (strpos($object->fields[$key]['type'], 'sellist:') === 0) || !empty($object->fields[$key]['arrayofkeyval'])) {
-			if ($search[$key] == '-1' || $search[$key] === '0') {
+			if ($search[$key] == '-1') {
 				$search[$key] = '';
 			}
 			$mode_search = 2;


### PR DESCRIPTION
Currently, when status selector draft is selected in Manufacturing Orders, all values are listed (Draft, Validated, In Progress, Produced and Canceled). The pull request fixes this issue by only showing the Draft MO's.

This bug is also present in bom_list.php and workstation_list.php when this pull request is accepted, I will create a pull request for both bom_list and workstation_list. 

This issue was referenced @cfoellmann in https://github.com/Dolibarr/dolibarr/pull/18347#issue-705190299
