### PR TITLE
FIX #18389 Accountancy - Bug on LDcompta10 export for supplier invoice

### DIFF
--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1462,13 +1462,13 @@ class AccountancyExport
 			print $date_lim_reglement.$separator;
 			// CNPI
 			if ($line->doc_type == 'supplier_invoice') {
-				if (($line->debit - $line->credit) < 0) {
+				if (($line->amount) < 0) {
 					$nature_piece = 'AF';
 				} else {
 					$nature_piece = 'FF';
 				}
 			} elseif ($line->doc_type == 'customer_invoice') {
-				if (($line->debit - $line->credit) < 0) {
+				if (($line->amount) < 0) {
 					$nature_piece = 'AC';
 				} else {
 					$nature_piece = 'FC';

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1296,7 +1296,9 @@ class AccountancyExport
 
 	/**
 	 * Export format : LD Compta version 10 & higher
-	 * http://www.ldsysteme.fr/fileadmin/telechargement/np/ldcompta/Documentation/IntCptW10.pdf
+	 * Last review for this format : 08-15-2021 Alexandre Spangaro (aspangaro@open-dsi.fr)
+	 *
+	 * Help : http://www.ldsysteme.fr/fileadmin/telechargement/np/ldcompta/Documentation/IntCptW10.pdf
 	 *
 	 * @param array $objectLines data
 	 *
@@ -1460,7 +1462,7 @@ class AccountancyExport
 			print $date_lim_reglement.$separator;
 			// CNPI
 			if ($line->doc_type == 'supplier_invoice') {
-				if (($line->debit - $line->credit) > 0) {
+				if (($line->debit - $line->credit) < 0) {
 					$nature_piece = 'AF';
 				} else {
 					$nature_piece = 'FF';

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1462,14 +1462,14 @@ class AccountancyExport
 			print $date_lim_reglement.$separator;
 			// CNPI
 			if ($line->doc_type == 'supplier_invoice') {
-				if (($line->amount) < 0) {		// Currently, only the sign of amount allows to know the type of invoice (standard or credit note). Other solution is to analyse debit/credit/role of account. TODO Add column doc_type_long
+				if (($line->amount) < 0) {		// Currently, only the sign of amount allows to know the type of invoice (standard or credit note). Other solution is to analyse debit/credit/role of account. TODO Add column doc_type_long or make amount mandatory with rule on sign.
 					$nature_piece = 'AF';
 				} else {
 					$nature_piece = 'FF';
 				}
 			} elseif ($line->doc_type == 'customer_invoice') {
 				if (($line->amount) < 0) {
-					$nature_piece = 'AC';		// Currently, only the sign of amount allows to know the type of invoice (standard or credit note). Other solution is to analyse debit/credit/role of account. TODO Add column doc_type_long
+					$nature_piece = 'AC';		// Currently, only the sign of amount allows to know the type of invoice (standard or credit note). Other solution is to analyse debit/credit/role of account. TODO Add column doc_type_long or make amount mandatory with rule on sign.
 				} else {
 					$nature_piece = 'FC';
 				}

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1462,14 +1462,14 @@ class AccountancyExport
 			print $date_lim_reglement.$separator;
 			// CNPI
 			if ($line->doc_type == 'supplier_invoice') {
-				if (($line->amount) < 0) {
+				if (($line->amount) < 0) {		// Currently, only the sign of amount allows to know the type of invoice (warning: not reliable). TODO Add column doc_type_long
 					$nature_piece = 'AF';
 				} else {
 					$nature_piece = 'FF';
 				}
 			} elseif ($line->doc_type == 'customer_invoice') {
 				if (($line->amount) < 0) {
-					$nature_piece = 'AC';
+					$nature_piece = 'AC';		// Currently, only the sign of amount allows to know the type of invoice (warning: not reliable). TODO Add column doc_type_long
 				} else {
 					$nature_piece = 'FC';
 				}

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1462,14 +1462,14 @@ class AccountancyExport
 			print $date_lim_reglement.$separator;
 			// CNPI
 			if ($line->doc_type == 'supplier_invoice') {
-				if (($line->amount) < 0) {		// Currently, only the sign of amount allows to know the type of invoice (warning: not reliable). TODO Add column doc_type_long
+				if (($line->amount) < 0) {		// Currently, only the sign of amount allows to know the type of invoice (standard or credit note). Other solution is to analyse debit/credit/role of account. TODO Add column doc_type_long
 					$nature_piece = 'AF';
 				} else {
 					$nature_piece = 'FF';
 				}
 			} elseif ($line->doc_type == 'customer_invoice') {
 				if (($line->amount) < 0) {
-					$nature_piece = 'AC';		// Currently, only the sign of amount allows to know the type of invoice (warning: not reliable). TODO Add column doc_type_long
+					$nature_piece = 'AC';		// Currently, only the sign of amount allows to know the type of invoice (standard or credit note). Other solution is to analyse debit/credit/role of account. TODO Add column doc_type_long
 				} else {
 					$nature_piece = 'FC';
 				}


### PR DESCRIPTION
Even if the amount field is depreciated, we still need it to detect a credit easily. A simple calculation (debit - credit) is not enough to know the type of situation.

Example : 

Supplier invoice
![image](https://user-images.githubusercontent.com/2341395/129509657-426d6a17-b36c-4a57-b663-a8d52c82d797.png)

Credit supplier invoice
![image](https://user-images.githubusercontent.com/2341395/129509525-fe66a241-c720-443c-bbec-c22d27b77be5.png)

Only information in amount field define the sens of the operation... Please, it is necessary to keep the amount field