### PR TITLE
Enable getSumDepositsUsed for Supplier Deposit Invoice

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -159,11 +159,6 @@ abstract class CommonInvoice extends CommonObject
 	 */
 	public function getSumDepositsUsed($multicurrency = 0)
 	{
-		if ($this->element == 'facture_fourn' || $this->element == 'invoice_supplier') {
-			// TODO
-			return 0.0;
-		}
-
 		require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
 
 		$discountstatic = new DiscountAbsolute($this->db);


### PR DESCRIPTION
When FACTURE_DEPOSITS_ARE_JUST_PAYMENTS is enabled, getSumDepositsUsed shall be enabled for Supplier Deposit Invoice in order to fetch the correct amount of deposit amount applied as payment of Supplier Invoice.