### PR TITLE
Additional reason for Customer's partial payment - bank charge

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -800,6 +800,11 @@ if (empty($reshook)) {
 				if (!empty($price_ht) || $price_ht === '0') {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
+					//added test to record multicurrency price while the default price is 0.
+					if($price_ht === '0' && $price_ht_devise != '') {
+						$pu_ht_devise = price2num($price_ht_devise, 'MU');
+						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
+					}
 				} elseif ($tmpvat != $tmpprodvat) {
 					// On reevalue prix selon taux tva car taux tva transaction peut etre different
 					// de ceux du produit par defaut (par exemple si pays different entre vendeur et acheteur).

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -801,7 +801,7 @@ if (empty($reshook)) {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
 					//added test to record multicurrency price while the default price is 0.
-					if($price_ht === '0' && $price_ht_devise != '') {
+					if ($price_ht === '0' && $price_ht_devise != '') {
 						$pu_ht_devise = price2num($price_ht_devise, 'MU');
 						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
 					}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2105,7 +2105,7 @@ if (empty($reshook)) {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
 					//added test to record multicurrency price while the default price is 0.
-					if($price_ht === '0' && $price_ht_devise != '') {
+					if ($price_ht === '0' && $price_ht_devise != '') {
 						$pu_ht_devise = price2num($price_ht_devise, 'MU');
 						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
 					}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2104,6 +2104,11 @@ if (empty($reshook)) {
 				if (!empty($price_ht) || $price_ht === '0') {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
+					//added test to record multicurrency price while the default price is 0.
+					if($price_ht === '0' && $price_ht_devise != '') {
+						$pu_ht_devise = price2num($price_ht_devise, 'MU');
+						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
+					}
 				} elseif ($tmpvat != $tmpprodvat) {
 					// On reevalue prix selon taux tva car taux tva transaction peut etre different
 					// de ceux du produit par defaut (par exemple si pays different entre vendeur et acheteur).

--- a/htdocs/core/ajax/locationincoterms.php
+++ b/htdocs/core/ajax/locationincoterms.php
@@ -65,7 +65,7 @@ dol_syslog('location_incoterms call with MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY
 // Generation of list of zip-town
 if (GETPOST('location_incoterms')) {
 	$return_arr = array();
-	
+
 	// Define filter on text typed
 	$location_incoterms = GETPOST('location_incoterms');
 
@@ -79,13 +79,13 @@ if (GETPOST('location_incoterms')) {
 	{
 		$sql = "SELECT DISTINCT s.location_incoterms FROM ".MAIN_DB_PREFIX.'commande as s';
 		$sql .= " WHERE UPPER(s.location_incoterms) LIKE UPPER('".$db->escape($location_incoterms)."%')";
-	
-	//Todo: merge with data from table of supplier order
-	/*	$sql .=" UNION";
+
+		//Todo: merge with data from table of supplier order
+		/*	$sql .=" UNION";
 		$sql .= " SELECT DISTINCT p.location_incoterms FROM ".MAIN_DB_PREFIX.'commande_fournisseur as p';
 		$sql .= " WHERE UPPER(p.location_incoterms) LIKE UPPER('".$db->escape($location_incoterms)."%')";
-	*/
-	    $sql .= " ORDER BY s.location_incoterms";
+		*/
+		$sql .= " ORDER BY s.location_incoterms";
 		$sql .= $db->plimit(100); // Avoid pb with bad criteria
 	}
 
@@ -94,7 +94,7 @@ if (GETPOST('location_incoterms')) {
 	//var_dump($db);
 	if ($resql) {
 		while ($row = $db->fetch_array($resql)) {
-		    $row_array['label'] = $row['location_incoterms'].($row['label']?' - '.$row['label'] : '');
+			$row_array['label'] = $row['location_incoterms'].($row['label']?' - '.$row['label'] : '');
 			if ($location_incoterms) {
 				$row_array['value'] = $row['location_incoterms'];
 			}

--- a/htdocs/core/ajax/locationincoterms.php
+++ b/htdocs/core/ajax/locationincoterms.php
@@ -1,0 +1,110 @@
+<?php
+/* Copyright (C) 2010      Regis Houssin       <regis.houssin@inodbox.com>
+ * Copyright (C) 2011-2014 Laurent Destailleur <eldy@users.sourceforge.net>
+ * Copyright (C) 2021 	   Henry Guo <henrynopo@homtail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *       \file      htdocs/core/ajax/locationincoterms.php
+ *       \ingroup	core
+ *       \brief     File to return Ajax response on location_incoterms request
+ */
+
+if (!defined('NOTOKENRENEWAL')) {
+	define('NOTOKENRENEWAL', 1); // Disables token renewal
+}
+if (!defined('NOREQUIREMENU')) {
+	define('NOREQUIREMENU', '1');
+}
+if (!defined('NOREQUIREHTML')) {
+	define('NOREQUIREHTML', '1');
+}
+if (!defined('NOREQUIREAJAX')) {
+	define('NOREQUIREAJAX', '1');
+}
+if (!defined('NOREQUIRESOC')) {
+	define('NOREQUIRESOC', '1');
+}
+if (!defined('NOCSRFCHECK')) {
+	define('NOCSRFCHECK', '1');
+}
+
+require '../../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
+
+
+/*
+ * View
+ */
+
+// Ajout directives pour resoudre bug IE
+//header('Cache-Control: Public, must-revalidate');
+//header('Pragma: public');
+
+//top_htmlhead("", "", 1);  // Replaced with top_httphead. An ajax page does not need html header.
+top_httphead();
+
+//print '<!-- Ajax page called with url '.dol_escape_htmltag($_SERVER["PHP_SELF"]).'?'.dol_escape_htmltag($_SERVER["QUERY_STRING"]).' -->'."\n";
+
+dol_syslog('location_incoterms call with MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY='.(empty($conf->global->MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY) ? '' : $conf->global->MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY));
+//var_dump($_GET);
+
+// Generation of list of zip-town
+if (GETPOST('location_incoterms')) {
+	$return_arr = array();
+	
+	// Define filter on text typed
+	$location_incoterms = GETPOST('location_incoterms');
+
+	if (!empty($conf->global->MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY)) {   // Use location_incoterms
+		$sql = "SELECT z.location as location_incoterms, z.label as label";
+		$sql .= " FROM ".MAIN_DB_PREFIX."c_location_incoterms as z";
+		$sql .= " WHERE z.active = 1  AND UPPER(z.location) LIKE UPPER('".$db->escape($location_incoterms)."%')";
+		$sql .= " ORDER BY z.location";
+		$sql .= $db->plimit(100); // Avoid pb with bad criteria
+	} else // Use table of commande
+	{
+		$sql = "SELECT DISTINCT s.location_incoterms FROM ".MAIN_DB_PREFIX.'commande as s';
+		$sql .= " WHERE UPPER(s.location_incoterms) LIKE UPPER('".$db->escape($location_incoterms)."%')";
+	
+	//Todo: merge with data from table of supplier order
+	/*	$sql .=" UNION";
+		$sql .= " SELECT DISTINCT p.location_incoterms FROM ".MAIN_DB_PREFIX.'commande_fournisseur as p';
+		$sql .= " WHERE UPPER(p.location_incoterms) LIKE UPPER('".$db->escape($location_incoterms)."%')";
+	*/
+	    $sql .= " ORDER BY s.location_incoterms";
+		$sql .= $db->plimit(100); // Avoid pb with bad criteria
+	}
+
+	//print $sql;
+	$resql = $db->query($sql);
+	//var_dump($db);
+	if ($resql) {
+		while ($row = $db->fetch_array($resql)) {
+		    $row_array['label'] = $row['location_incoterms'].($row['label']?' - '.$row['label'] : '');
+			if ($location_incoterms) {
+				$row_array['value'] = $row['location_incoterms'];
+			}
+			// TODO Use a cache here to avoid to make select_state in each pass (this make a SQL and lot of logs)
+
+			array_push($return_arr, $row_array);
+		}
+	}
+
+	echo json_encode($return_arr);
+}
+
+$db->close();

--- a/htdocs/core/ajax/locationincoterms.php
+++ b/htdocs/core/ajax/locationincoterms.php
@@ -72,18 +72,18 @@ if (GETPOST('location_incoterms')) {
 	if (!empty($conf->global->MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY)) {   // Use location_incoterms
 		$sql = "SELECT z.location as location_incoterms, z.label as label";
 		$sql .= " FROM ".MAIN_DB_PREFIX."c_location_incoterms as z";
-		$sql .= " WHERE z.active = 1  AND UPPER(z.location) LIKE UPPER('".$db->escape($location_incoterms)."%')";
+		$sql .= " WHERE z.active = 1  AND UPPER(z.location) LIKE UPPER('%".$db->escape($location_incoterms)."%')";
 		$sql .= " ORDER BY z.location";
 		$sql .= $db->plimit(100); // Avoid pb with bad criteria
 	} else // Use table of commande
 	{
 		$sql = "SELECT DISTINCT s.location_incoterms FROM ".MAIN_DB_PREFIX.'commande as s';
-		$sql .= " WHERE UPPER(s.location_incoterms) LIKE UPPER('".$db->escape($location_incoterms)."%')";
+		$sql .= " WHERE UPPER(s.location_incoterms) LIKE UPPER('%".$db->escape($location_incoterms)."%')";
 
 		//Todo: merge with data from table of supplier order
 		/*	$sql .=" UNION";
 		$sql .= " SELECT DISTINCT p.location_incoterms FROM ".MAIN_DB_PREFIX.'commande_fournisseur as p';
-		$sql .= " WHERE UPPER(p.location_incoterms) LIKE UPPER('".$db->escape($location_incoterms)."%')";
+		$sql .= " WHERE UPPER(p.location_incoterms) LIKE UPPER('%".$db->escape($location_incoterms)."%')";
 		*/
 		$sql .= " ORDER BY s.location_incoterms";
 		$sql .= $db->plimit(100); // Avoid pb with bad criteria

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1511,8 +1511,8 @@ class Form
 		global $langs, $conf;
 
 		// On recherche les remises
-		$sql = "SELECT re.rowid, re.amount_ht, re.amount_tva, re.amount_ttc,";
-		$sql .= " re.description, re.fk_facture_source";
+		$sql = "SELECT re.rowid, re.amount_ht, re.amount_tva, re.amount_ttc, re.multicurrency_amount_ttc,";
+		$sql .= " re.description, re.fk_facture_sourcere, re.fk_invoice_supplier_source";
 		$sql .= " FROM ".MAIN_DB_PREFIX."societe_remise_except as re";
 		$sql .= " WHERE re.fk_soc = ".(int) $socid;
 		$sql .= " AND re.entity = ".$conf->entity;
@@ -1563,10 +1563,21 @@ class Form
 						$tmpfac = new Facture($this->db);
 						if ($tmpfac->fetch($obj->fk_facture_source) > 0) {
 							$desc = $desc.' - '.$tmpfac->ref;
+							$multicurrency_code = $tmpfac->multicurrency_code;
 						}
 					}
+					// show Source Supplier Invoice Ref
+					else {
+        				if (!empty($conf->global->MAIN_SHOW_FACNUMBER_IN_DISCOUNT_LIST) && !empty($obj->fk_invoice_supplier_source)) {
+							$tmpfac = new FactureFournisseur($this->db);
+    						if ($tmpfac->fetch($obj->fk_invoice_supplier_source) > 0) {
+    							$desc = $desc.' - '.$tmpfac->ref;
+    							$multicurrency_code = $tmpfac->multicurrency_code;
+    						} 
+    					}
+					}
 
-					print '<option value="'.$obj->rowid.'"'.$selectstring.$disabled.'>'.$desc.' ('.price($obj->amount_ht).' '.$langs->trans("HT").' - '.price($obj->amount_ttc).' '.$langs->trans("TTC").')</option>';
+					print '<option value="'.$obj->rowid.'"'.$selectstring.$disabled.'>'.$desc.' ('.$conf->currency.' '.price($obj->amount_ttc).' - '.$multicurrency_code.' '.price($obj->multicurrency_amount_ttc).')</option>'; //Added currency code, and replaced amount_HT by multicurrency_amount_ttc;
 					$i++;
 				}
 			}

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1055,7 +1055,7 @@ class Form
 				}
 			}
 			$out .= '</select>';
-
+			
 			$out .= '<input id="location_incoterms" class="maxwidth100onsmartphone nomargintop nomarginbottom" name="location_incoterms" value="'.$location_incoterms.'">';
 
 			if (!empty($page)) {


### PR DESCRIPTION
For international bank transfer, there is often some charge by the intermediate bank and this amount is deducted directly from the amount received.

I'd like to propose adding an additional reason (namely "bank charge") for classifying partial payment of customer's invoice. To achieve this, it still need to add in the translation as below:
- en_US or en_GB	bankcharge	Bank Charge	   
- en_US or en_GB	ConfirmClassifyPaidPartiallyReasonBankCharge	Bank Charge	   
- en_US or en_GB	ConfirmClassifyPaidPartiallyReasonBankChargeDesc	The difference was charged by bank while Client paid the correct amount.