### PR TITLE
FIX only keep pmp price if set in margin setup

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -698,7 +698,7 @@ if (!empty($usemargins) && $user->rights->margins->creer)
 						{
 							// If margin is calculated on PMP, we set it by defaut (but only if value is not 0)
 							console.log("id="+this.id+"-price="+this.price);
-							if ('pmp' == defaultbuyprice || 'costprice' == defaultbuyprice)
+							if ('pmp' == defaultbuyprice)
 							{
 								if (this.price > 0) {
 									defaultkey = this.id; defaultprice = this.price; pmppriceid = this.id; pmppricevalue = this.price;


### PR DESCRIPTION
FIX only keep pmp price if set in margin setup
- pmp price was selected by default even if it was'nt set in margin setup
