### PR TITLE
Adding translation of extrafield attribute if defined

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1341,7 +1341,7 @@ abstract class CommonDocGenerator
 
 				$field = new stdClass();
 				$field->rank = intval($extrafields->attributes[$object->table_element]['pos'][$key]);
-				$field->content = $this->getExtrafieldContent($object, $key);
+				$field->content = $outputlangs->transnoentities($this->getExtrafieldContent($object, $key));
 				$field->label = $outputlangs->transnoentities($label);
 				$field->type = $extrafields->attributes[$object->table_element]['type'][$key];
 


### PR DESCRIPTION
In case of multilingual production, it is necessary to allow translation of the extrafield, both the lable and attribute, especially for pdf generation. If the extrafield attribute is predefined in the translation, this update will allow it be shown in different languages in the pdf file.
