### PR TITLE
Added China into the list of country using State / province in address

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -2130,7 +2130,7 @@ function dol_format_address($object, $withcountry = 0, $sep = "\n", $outputlangs
 	global $conf, $langs;
 
 	$ret = '';
-	$countriesusingstate = array('AU', 'CA', 'US', 'IN', 'GB', 'ES', 'UK', 'TR'); // See also MAIN_FORCE_STATE_INTO_ADDRESS
+	$countriesusingstate = array('AU', 'CA', 'US', 'IN', 'GB', 'ES', 'UK', 'TR', 'CN'); // See also MAIN_FORCE_STATE_INTO_ADDRESS
 
 	// See format of addresses on https://en.wikipedia.org/wiki/Address
 	// Address
@@ -2138,7 +2138,7 @@ function dol_format_address($object, $withcountry = 0, $sep = "\n", $outputlangs
 		$ret .= ($extralangcode ? $object->array_languages['address'][$extralangcode] : (empty($object->address) ? '' : $object->address));
 	}
 	// Zip/Town/State
-	if (isset($object->country_code) && in_array($object->country_code, array('AU', 'CA', 'US')) || !empty($conf->global->MAIN_FORCE_STATE_INTO_ADDRESS)) {
+	if (isset($object->country_code) && in_array($object->country_code, array('AU', 'CA', 'US', 'CN')) || !empty($conf->global->MAIN_FORCE_STATE_INTO_ADDRESS)) {
 		// US: title firstname name \n address lines \n town, state, zip \n country
 		$town = ($extralangcode ? $object->array_languages['town'][$extralangcode] : (empty($object->town) ? '' : $object->town));
 		$ret .= ($ret ? $sep : '').$town;


### PR DESCRIPTION
Amended as subject.

In addition, I noticed that the coding seems to allow bi-lingual records of Towns: array_languages['town'][$extralangcode]. Where should this language-specific Town list be saved? in the corresponding language folder or in the database?

If the Town can be saved in bilingual, it would be perfect to allow State/Province also be shown in bi-lingual. Something similiar might be:
$state = ($extralangcode ? $object->array_languages['state'][$extralangcode] : (empty($object->state) ? '' : $object->state));

Same question is: where to save this language-specific list of states?

In addition, the function pdf_build_address does not specify any $extralangcode when calling the function in discussion here (dol_format_address). Is this $extralangcode useful or shall it be further replaced by $outputlangs?

An example of application for the above cases: in Dolibarr basic database, the list of states for Greece is all in Grecque language. How should I know its Latin state names both in card (for example Third-Party / Contact) and in pdf (for example order / invoice / shipment etc)?