### PR TITLE
Added function - using list of location_incoterms

### DIFF
--- a/htdocs/core/ajax/locationincoterms.php
+++ b/htdocs/core/ajax/locationincoterms.php
@@ -65,7 +65,7 @@ dol_syslog('location_incoterms call with MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY
 // Generation of list of zip-town
 if (GETPOST('location_incoterms')) {
 	$return_arr = array();
-	
+
 	// Define filter on text typed
 	$location_incoterms = GETPOST('location_incoterms');
 
@@ -79,13 +79,13 @@ if (GETPOST('location_incoterms')) {
 	{
 		$sql = "SELECT DISTINCT s.location_incoterms FROM ".MAIN_DB_PREFIX.'commande as s';
 		$sql .= " WHERE UPPER(s.location_incoterms) LIKE UPPER('%".$db->escape($location_incoterms)."%')";
-	
-	//Todo: merge with data from table of supplier order
-	/*	$sql .=" UNION";
+
+		//Todo: merge with data from table of supplier order
+		/*	$sql .=" UNION";
 		$sql .= " SELECT DISTINCT p.location_incoterms FROM ".MAIN_DB_PREFIX.'commande_fournisseur as p';
 		$sql .= " WHERE UPPER(p.location_incoterms) LIKE UPPER('%".$db->escape($location_incoterms)."%')";
-	*/
-	    $sql .= " ORDER BY s.location_incoterms";
+		*/
+		$sql .= " ORDER BY s.location_incoterms";
 		$sql .= $db->plimit(100); // Avoid pb with bad criteria
 	}
 
@@ -94,7 +94,7 @@ if (GETPOST('location_incoterms')) {
 	//var_dump($db);
 	if ($resql) {
 		while ($row = $db->fetch_array($resql)) {
-		    $row_array['label'] = $row['location_incoterms'].($row['label']?' - '.$row['label'] : '');
+			$row_array['label'] = $row['location_incoterms'].($row['label']?' - '.$row['label'] : '');
 			if ($location_incoterms) {
 				$row_array['value'] = $row['location_incoterms'];
 			}

--- a/htdocs/core/ajax/locationincoterms.php
+++ b/htdocs/core/ajax/locationincoterms.php
@@ -1,0 +1,110 @@
+<?php
+/* Copyright (C) 2010      Regis Houssin       <regis.houssin@inodbox.com>
+ * Copyright (C) 2011-2014 Laurent Destailleur <eldy@users.sourceforge.net>
+ * Copyright (C) 2021 	   Henry Guo <henrynopo@homtail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *       \file      htdocs/core/ajax/locationincoterms.php
+ *       \ingroup	core
+ *       \brief     File to return Ajax response on location_incoterms request
+ */
+
+if (!defined('NOTOKENRENEWAL')) {
+	define('NOTOKENRENEWAL', 1); // Disables token renewal
+}
+if (!defined('NOREQUIREMENU')) {
+	define('NOREQUIREMENU', '1');
+}
+if (!defined('NOREQUIREHTML')) {
+	define('NOREQUIREHTML', '1');
+}
+if (!defined('NOREQUIREAJAX')) {
+	define('NOREQUIREAJAX', '1');
+}
+if (!defined('NOREQUIRESOC')) {
+	define('NOREQUIRESOC', '1');
+}
+if (!defined('NOCSRFCHECK')) {
+	define('NOCSRFCHECK', '1');
+}
+
+require '../../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
+
+
+/*
+ * View
+ */
+
+// Ajout directives pour resoudre bug IE
+//header('Cache-Control: Public, must-revalidate');
+//header('Pragma: public');
+
+//top_htmlhead("", "", 1);  // Replaced with top_httphead. An ajax page does not need html header.
+top_httphead();
+
+//print '<!-- Ajax page called with url '.dol_escape_htmltag($_SERVER["PHP_SELF"]).'?'.dol_escape_htmltag($_SERVER["QUERY_STRING"]).' -->'."\n";
+
+dol_syslog('location_incoterms call with MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY='.(empty($conf->global->MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY) ? '' : $conf->global->MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY));
+//var_dump($_GET);
+
+// Generation of list of zip-town
+if (GETPOST('location_incoterms')) {
+	$return_arr = array();
+	
+	// Define filter on text typed
+	$location_incoterms = GETPOST('location_incoterms');
+
+	if (!empty($conf->global->MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY)) {   // Use location_incoterms
+		$sql = "SELECT z.location as location_incoterms, z.label as label";
+		$sql .= " FROM ".MAIN_DB_PREFIX."c_location_incoterms as z";
+		$sql .= " WHERE z.active = 1  AND UPPER(z.location) LIKE UPPER('%".$db->escape($location_incoterms)."%')";
+		$sql .= " ORDER BY z.location";
+		$sql .= $db->plimit(100); // Avoid pb with bad criteria
+	} else // Use table of commande
+	{
+		$sql = "SELECT DISTINCT s.location_incoterms FROM ".MAIN_DB_PREFIX.'commande as s';
+		$sql .= " WHERE UPPER(s.location_incoterms) LIKE UPPER('%".$db->escape($location_incoterms)."%')";
+	
+	//Todo: merge with data from table of supplier order
+	/*	$sql .=" UNION";
+		$sql .= " SELECT DISTINCT p.location_incoterms FROM ".MAIN_DB_PREFIX.'commande_fournisseur as p';
+		$sql .= " WHERE UPPER(p.location_incoterms) LIKE UPPER('%".$db->escape($location_incoterms)."%')";
+	*/
+	    $sql .= " ORDER BY s.location_incoterms";
+		$sql .= $db->plimit(100); // Avoid pb with bad criteria
+	}
+
+	//print $sql;
+	$resql = $db->query($sql);
+	//var_dump($db);
+	if ($resql) {
+		while ($row = $db->fetch_array($resql)) {
+		    $row_array['label'] = $row['location_incoterms'].($row['label']?' - '.$row['label'] : '');
+			if ($location_incoterms) {
+				$row_array['value'] = $row['location_incoterms'];
+			}
+			// TODO Use a cache here to avoid to make select_state in each pass (this make a SQL and lot of logs)
+
+			array_push($return_arr, $row_array);
+		}
+	}
+
+	echo json_encode($return_arr);
+}
+
+$db->close();

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1056,7 +1056,7 @@ class Form
 			}
 			$out .= '</select>';
 			
-			if ($conf->use_javascript_ajax && empty($disableautocomplete = 0)) {
+			if ($conf->use_javascript_ajax && empty($disableautocomplete)) {
 		    	$out .= ajax_multiautocompleter('location_incoterms', '', DOL_URL_ROOT.'/core/ajax/locationincoterms.php')."\n";
 		    	$moreattrib .= ' autocomplete="off"';
 	    	}			

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1055,8 +1055,12 @@ class Form
 				}
 			}
 			$out .= '</select>';
-
-			$out .= '<input id="location_incoterms" class="maxwidth100onsmartphone nomargintop nomarginbottom" name="location_incoterms" value="'.$location_incoterms.'">';
+			
+			if ($conf->use_javascript_ajax && empty($disableautocomplete = 0)) {
+		    	$out .= ajax_multiautocompleter('location_incoterms', '', DOL_URL_ROOT.'/core/ajax/locationincoterms.php')."\n";
+		    	$moreattrib .= ' autocomplete="off"';
+	    	}			
+	    	$out .= '<input id="location_incoterms" class="maxwidthonsmartphone type="text" name="location_incoterms" value="'.$location_incoterms.'">'."\n";
 
 			if (!empty($page)) {
 				$out .= '<input type="submit" class="button valignmiddle smallpaddingimp nomargintop nomarginbottom" value="'.$langs->trans("Modify").'"></form>';


### PR DESCRIPTION
Added function to call for list of location_incoterms from the existing order records or table of location_incoterms.

Accordingly, an dditional ajex file namely "locationincoterms.php" (https://github.com/henrynopo/dolibarr/commit/5f8f9ccac541ae067aa0bfc45ddfe55d252a26ff) and a database table namely c_location_incoterms are required. 

The function in "locationincoterms.php" is based on that of ziptown.php. It will allow a general setup MAIN_USE_LOCATION_INCOTERMS_DICTIONNARY.

For the table namely c_location_incoterms, the following columns are proposed: rowid, location, label, fk_country (optional, for future development if necessary), active.
