### PR TITLE
improve forms - redirect after submission

### DIFF
--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -603,11 +603,14 @@ if (empty($reshook)) {
 					setEventMessages($object->error, $object->errors, 'errors');
 				}
 			}
-			$page = DOL_URL_ROOT.'/adherents/card.php?rowid='.$object->id;
-			header("Location: ".$page);
-			exit;
 		}
-		$action = ($result < 0 || !$error) ?  '' : 'create';
+
+		if ($result > 0 && !$error) {
+			header("Location: ".$_SERVER["PHP_SELF"].'?rowid='.$object->id);
+			exit;
+		} else {
+			$action = 'create';
+		}
 	}
 
 	if ($user->rights->adherent->supprimer && $action == 'confirm_delete' && $confirm == 'yes') {

--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -603,6 +603,9 @@ if (empty($reshook)) {
 					setEventMessages($object->error, $object->errors, 'errors');
 				}
 			}
+			$page = DOL_URL_ROOT.'/adherents/card.php?rowid='.$object->id;
+			header("Location: ".$page);
+			exit;
 		}
 		$action = ($result < 0 || !$error) ?  '' : 'create';
 	}

--- a/htdocs/adherents/type.php
+++ b/htdocs/adherents/type.php
@@ -153,7 +153,7 @@ if ($action == 'add' && $user->rights->adherent->configurer) {
 	if (!$error) {
 		$id = $object->create($user);
 		if ($id > 0) {
-			header("Location: ".$_SERVER["PHP_SELF"]);
+			header("Location: ".$_SERVER["PHP_SELF"]."?rowid=".$object->id);
 			exit;
 		} else {
 			setEventMessages($object->error, $object->errors, 'errors');

--- a/htdocs/compta/bank/card.php
+++ b/htdocs/compta/bank/card.php
@@ -257,9 +257,7 @@ if (empty($reshook)) {
 		if (!$error) {
 			// Fill array 'array_options' with data from add form
 			$ret = $extrafields->setOptionalsFromPost(null, $object);
-		}
 
-		if (!$error) {
 			$result = $object->update($user);
 			if ($result >= 0) {
 				// Category association

--- a/htdocs/compta/bank/card.php
+++ b/htdocs/compta/bank/card.php
@@ -178,6 +178,8 @@ if (empty($reshook)) {
 
 		if (!$error) {
 			$db->commit();
+			header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+			exit;
 		} else {
 			$db->rollback();
 		}
@@ -274,6 +276,8 @@ if (empty($reshook)) {
 
 		if (!$error) {
 			$db->commit();
+			header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+			exit;
 		} else {
 			$db->rollback();
 		}
@@ -287,7 +291,7 @@ if (empty($reshook)) {
 
 		if ($result > 0) {
 			setEventMessages($langs->trans("RecordDeleted"), null, 'mesgs');
-			header("Location: " . DOL_URL_ROOT . "/compta/bank/list.php");
+			header("Location: ".DOL_URL_ROOT."/compta/bank/list.php?leftmenu=bank&mainmenu=bank");
 			exit;
 		} else {
 			setEventMessages($object->error, $object->errors, 'errors');

--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -444,6 +444,9 @@ if (empty($reshook)) {
 					}
 
 					$action = 'view';
+
+					header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+					exit;
 				} else {
 					setEventMessages($object->error, $object->errors, 'errors');
 					$action = 'edit';
@@ -497,6 +500,9 @@ if (empty($reshook)) {
 		if ($result > 0) {
 			setEventMessages($langs->trans('RecordSaved'), null, 'mesgs');
 			$action = 'view';
+
+			header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+			exit;
 		} else {
 			setEventMessages($object->error, $object->errors, 'errors');
 			$action = 'edit_extras';

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1279,8 +1279,8 @@ if (empty($reshook)) {
 
 				$result = $object->recalculer($id);
 
-				//header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
-				//exit;
+				header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+				exit;
 			} else {
 				setEventMessages($object->error, $object->errors, 'errors');
 			}

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -196,16 +196,16 @@ if (empty($reshook)) {
 			}
 
 			if ($error) {
-				$action = 'edit';
 				setEventMessages($object->error, $object->errors, 'errors');
+				$action = 'edit';
 			} else {
 				$categories = GETPOST('categories', 'array');
 				$object->setCategories($categories);
-				$action = '';
-			}
+				$action = 'view';
 
-			header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
-			exit;
+				header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+				exit;
+			}
 		} else {
 			$action = 'edit';
 			setEventMessages($object->error, $object->errors, 'errors');

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -203,6 +203,9 @@ if (empty($reshook)) {
 				$object->setCategories($categories);
 				$action = '';
 			}
+
+			header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+			exit;
 		} else {
 			$action = 'edit';
 			setEventMessages($object->error, $object->errors, 'errors');

--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -334,6 +334,11 @@ if (empty($reshook)) {
 			} else {
 				unset($object->thirdparty);
 			}
+			if (!empty($id)) {
+				$page = DOL_URL_ROOT . '/projet/card.php?id=' . $id;
+				header( "Location: " . $page );
+				exit;
+			}
 		}
 	}
 

--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -335,8 +335,7 @@ if (empty($reshook)) {
 				unset($object->thirdparty);
 			}
 			if (!empty($id)) {
-				$page = DOL_URL_ROOT . '/projet/card.php?id=' . $id;
-				header("Location: " . $page);
+				header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
 				exit;
 			}
 		}

--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -336,7 +336,7 @@ if (empty($reshook)) {
 			}
 			if (!empty($id)) {
 				$page = DOL_URL_ROOT . '/projet/card.php?id=' . $id;
-				header( "Location: " . $page );
+				header("Location: " . $page);
 				exit;
 			}
 		}

--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -114,6 +114,9 @@ if ($action == 'update' && !GETPOST("cancel") && $user->rights->projet->creer) {
 			if ($result < 0) {
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
+			$page = DOL_URL_ROOT.'/projet/tasks/task.php?id='.$id.'&withproject=1';
+			header("Location: ".$page);
+			exit;
 		}
 	} else {
 		$action = 'edit';

--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -113,10 +113,10 @@ if ($action == 'update' && !GETPOST("cancel") && $user->rights->projet->creer) {
 			$result = $object->update($user);
 			if ($result < 0) {
 				setEventMessages($object->error, $object->errors, 'errors');
+
+				header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id."&withproject=1");
+				exit;
 			}
-			$page = DOL_URL_ROOT.'/projet/tasks/task.php?id='.$id.'&withproject=1';
-			header("Location: ".$page);
-			exit;
 		}
 	} else {
 		$action = 'edit';
@@ -129,7 +129,7 @@ if ($action == 'confirm_delete' && $confirm == "yes" && $user->rights->projet->s
 		$projectstatic->fetch_thirdparty();
 
 		if ($object->delete($user) > 0) {
-			header('Location: '.DOL_URL_ROOT.'/projet/tasks.php?restore_lastsearch_values=1&id='.$projectstatic->id.($withproject ? '&withproject=1' : ''));
+			header('Location: '.$_SERVER["PHP_SELF"].'?restore_lastsearch_values=1&id='.$projectstatic->id.($withproject ? '&withproject=1' : ''));
 			exit;
 		} else {
 			setEventMessages($object->error, $object->errors, 'errors');
@@ -145,7 +145,7 @@ if (!empty($project_ref) && !empty($withproject)) {
 		if (count($tasksarray) > 0) {
 			$id = $tasksarray[0]->id;
 		} else {
-			header("Location: ".DOL_URL_ROOT.'/projet/tasks.php?id='.$projectstatic->id.(empty($mode) ? '' : '&mode='.$mode));
+			header("Location: ".$_SERVER["PHP_SELF"].'?id='.$projectstatic->id.(empty($mode) ? '' : '&mode='.$mode));
 		}
 	}
 }

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -208,9 +208,8 @@ if ($action == 'addtimespent' && $user->rights->projet->lire) {
 				}
 			}
 			$page = DOL_URL_ROOT . '/projet/tasks/time.php?withproject=1&projectid='.$projectid;
-			header( "Location: ".$page );
+			header("Location: ".$page);
 			exit;
-
 		}
 	} else {
 		if (empty($id)) {

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -207,6 +207,10 @@ if ($action == 'addtimespent' && $user->rights->projet->lire) {
 					$error++;
 				}
 			}
+			$page = DOL_URL_ROOT . '/projet/tasks/time.php?withproject=1&projectid='.$projectid;
+			header( "Location: ".$page );
+			exit;
+
 		}
 	} else {
 		if (empty($id)) {

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -202,14 +202,14 @@ if ($action == 'addtimespent' && $user->rights->projet->lire) {
 				$result = $object->addTimeSpent($user);
 				if ($result >= 0) {
 					setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
+
+					header("Location: ".$_SERVER["PHP_SELF"]."?withproject=1&projectid=".$projectid);
+					exit;
 				} else {
 					setEventMessages($langs->trans($object->error), null, 'errors');
 					$error++;
 				}
 			}
-			$page = DOL_URL_ROOT . '/projet/tasks/time.php?withproject=1&projectid='.$projectid;
-			header("Location: ".$page);
-			exit;
 		}
 	} else {
 		if (empty($id)) {

--- a/htdocs/variants/card.php
+++ b/htdocs/variants/card.php
@@ -86,14 +86,16 @@ if ($action) {
 			if (!$error) {
 				if ($objectval->update($user) > 0) {
 					setEventMessages($langs->trans('RecordSaved'), null, 'mesgs');
+
+					header("Location: ".$_SERVER["PHP_SELF"]."?id=".$object->id);
+					exit;
 				} else {
 					setEventMessage($langs->trans('CoreErrorMessage'), $objectval->errors, 'errors');
 				}
 			}
 		}
 
-		header('Location: '.dol_buildpath('/variants/card.php?id='.$object->id, 2));
-		exit();
+
 	}
 }
 

--- a/htdocs/variants/create.php
+++ b/htdocs/variants/create.php
@@ -55,7 +55,7 @@ if ($action == 'add') {
 			if ($backtopage) {
 				header('Location: '.$backtopage);
 			} else {
-				header('Location: '.DOL_URL_ROOT.'/variants/card.php?id='.$resid.'&backtopage='.urlencode($backtopage));
+				header('Location: '.DOL_URL_ROOT.'/variants/card.php?id='.$resid);
 			}
 			exit;
 		} else {


### PR DESCRIPTION
redirect forms to appropriate target after submission + clear all POST to prevent resubmission errors

when a form (e.g. new product) is sent
1. redirect to product cardWITH `?id=`
2. cleared all $_POST to allow users to refresh the page without issue