### PR TITLE
Fix Supplier Invoice - add product line - always fail to input multicurrency price

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -800,6 +800,11 @@ if (empty($reshook)) {
 				if (!empty($price_ht) || $price_ht === '0') {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
+					//added test to record multicurrency price while the default price is 0.
+					if($price_ht === '0' && $price_ht_devise != '') {
+						$pu_ht_devise = price2num($price_ht_devise, 'MU');
+						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
+					}
 				} elseif ($tmpvat != $tmpprodvat) {
 					// On reevalue prix selon taux tva car taux tva transaction peut etre different
 					// de ceux du produit par defaut (par exemple si pays different entre vendeur et acheteur).

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -800,11 +800,6 @@ if (empty($reshook)) {
 				if (!empty($price_ht) || $price_ht === '0') {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
-					//added test to record multicurrency price while the default price is 0.
-					if ($price_ht === '0' && $price_ht_devise != '') {
-						$pu_ht_devise = price2num($price_ht_devise, 'MU');
-						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
-					}
 				} elseif ($tmpvat != $tmpprodvat) {
 					// On reevalue prix selon taux tva car taux tva transaction peut etre different
 					// de ceux du produit par defaut (par exemple si pays different entre vendeur et acheteur).

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -801,7 +801,7 @@ if (empty($reshook)) {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
 					//added test to record multicurrency price while the default price is 0.
-					if($price_ht === '0' && $price_ht_devise != '') {
+					if ($price_ht === '0' && $price_ht_devise != '') {
 						$pu_ht_devise = price2num($price_ht_devise, 'MU');
 						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
 					}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2105,7 +2105,7 @@ if (empty($reshook)) {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
 					//added test to record multicurrency price while the default price is 0.
-					if($price_ht === '0' && $price_ht_devise != '') {
+					if ($price_ht === '0' && $price_ht_devise != '') {
 						$pu_ht_devise = price2num($price_ht_devise, 'MU');
 						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
 					}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2104,6 +2104,11 @@ if (empty($reshook)) {
 				if (!empty($price_ht) || $price_ht === '0') {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
+					//added test to record multicurrency price while the default price is 0.
+					if($price_ht === '0' && $price_ht_devise != '') {
+						$pu_ht_devise = price2num($price_ht_devise, 'MU');
+						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
+					}
 				} elseif ($tmpvat != $tmpprodvat) {
 					// On reevalue prix selon taux tva car taux tva transaction peut etre different
 					// de ceux du produit par defaut (par exemple si pays different entre vendeur et acheteur).

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -1440,10 +1440,10 @@ if (empty($reshook)) {
 				}
 
 				$type = $productsupplier->type;
-				if (GETPOST('price_ht') != '' || GETPOST('price_ht_devise') != '') {
+				if ($price_ht != '' || $price_ht_devise != '') {
 					$price_base_type = 'HT';
 					$pu = price2num($price_ht, 'MU');
-					$pu_ht_devise = price2num($price_ht_devise, 'CU');
+					$pu_ht_devise = price2num($price_ht_devise, 'MU');
 				} else {
 					$price_base_type = ($productsupplier->fourn_price_base_type ? $productsupplier->fourn_price_base_type : 'HT');
 					if (empty($object->multicurrency_code) || ($productsupplier->fourn_multicurrency_code != $object->multicurrency_code)) {	// If object is in a different currency and price not in this currency


### PR DESCRIPTION
While adding product line in Supplier Invoice, the price of invoice currency (multicurrency mode enabled and no purchase price is predefined) cannot be recorded, while there is no issue to record the price in the main currency.

Reference to the latest Supplier Order card (/four/commande/card.php) file, this update can fix the issue.

However, I am not sure which rounding ('MU' or 'CU') is better $pu_ht_devise. I replaced the 'CU' by 'MU' taking reference to the coding of supplier order card.