### PR TITLE
Bug - Shipment, unable to edit / save product lines

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -725,11 +725,11 @@ if (empty($reshook)) {
 						$line->id = $line_id;
 						$line->qty = GETPOST($qty, 'int');
 						$line->entrepot_id = 0;
-						if ($line->update($user) < 0) {
-							setEventMessages($line->error, $line->errors, 'errors');
-							$error++;
-						}
-						unset($_POST[$qty]);					
+					if ($line->update($user) < 0) {
+						setEventMessages($line->error, $line->errors, 'errors');
+						$error++;
+					}
+						unset($_POST[$qty]);
 				}
 			}
 		}

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -718,8 +718,9 @@ if (empty($reshook)) {
 								}
 							}
 						}
-					} else {
-						// Product no predefined
+					}
+				} else {
+						// Product Qty no predefined
 						$qty = "qtyl".$line_id;
 						$line->id = $line_id;
 						$line->qty = GETPOST($qty, 'int');
@@ -728,8 +729,7 @@ if (empty($reshook)) {
 							setEventMessages($line->error, $line->errors, 'errors');
 							$error++;
 						}
-						unset($_POST[$qty]);
-					}
+						unset($_POST[$qty]);					
 				}
 			}
 		}
@@ -2330,7 +2330,7 @@ if ($action == 'create') {
 				// Size
 				//print '<td class="center">'.$lines[$i]->volume*$lines[$i]->qty_shipped.' '.measuringUnitString(0, "volume", $lines[$i]->volume_units).'</td>';
 
-				if ($action == 'editline' && $lines[$i]->id == $line_id) {
+				if ($action == 'editline' && $lines[$i]->id == $line_id) { //The two action buttons do not work. There is a defition of $action editline at code line 1948 - 1954 and the action updateline between lines 568 - 761. The save buttons looks not calling any action.
 					print '<td class="center" colspan="2" valign="middle">';
 					print '<input type="submit" class="button button-save" id="savelinebutton marginbottomonly" name="save" value="'.$langs->trans("Save").'"><br>';
 					print '<input type="submit" class="button button-cancel" id="cancellinebutton" name="cancel" value="'.$langs->trans("Cancel").'"><br>';


### PR DESCRIPTION
This bug exists since the first day I use the module Shipment from v13.0.0.

I have no batch or warehouse defined. Therefore, whenever the shipment is created, editing the product line always fails even though the shipment is in draft status.
There are two bugs:
1. the current coding does not show the Qty to ship in the edit form. Therefore, I updated the last Else to a higher level.
2. The save / cancel buttons do not work, resulting in any mofications of the Qty-to-ship or extrafield (product line) cannot be saved. Very new to coding, I suspect this is due to the Save button does not call the correct Action Updateline, or there may still be other bugs in the section of $action == 'updateline'.

Fig 1 shows the editing function of product line
![image](https://user-images.githubusercontent.com/3304600/130413029-b4c69e81-de3f-49d1-987f-9991f01d716a.png)

Fig 1 show the Qty-to-ship is not edittable after Fix-1 above.
![image](https://user-images.githubusercontent.com/3304600/130412151-052ec1cb-1ada-49b3-8528-a27662b4cef2.png)