### PR TITLE
Fix Shipment Bug for edit product lines and Add button for modification

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -800,6 +800,11 @@ if (empty($reshook)) {
 				if (!empty($price_ht) || $price_ht === '0') {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
+					//added test to record multicurrency price while the default price is 0.
+					if($price_ht === '0' && $price_ht_devise != '') {
+						$pu_ht_devise = price2num($price_ht_devise, 'MU');
+						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
+					}
 				} elseif ($tmpvat != $tmpprodvat) {
 					// On reevalue prix selon taux tva car taux tva transaction peut etre different
 					// de ceux du produit par defaut (par exemple si pays different entre vendeur et acheteur).

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2104,6 +2104,11 @@ if (empty($reshook)) {
 				if (!empty($price_ht) || $price_ht === '0') {
 					$pu_ht = price2num($price_ht, 'MU');
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
+					//added test to record multicurrency price while the default price is 0.
+					if($price_ht === '0' && $price_ht_devise != '') {
+						$pu_ht_devise = price2num($price_ht_devise, 'MU');
+						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
+					}
 				} elseif ($tmpvat != $tmpprodvat) {
 					// On reevalue prix selon taux tva car taux tva transaction peut etre different
 					// de ceux du produit par defaut (par exemple si pays different entre vendeur et acheteur).

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -159,11 +159,6 @@ abstract class CommonInvoice extends CommonObject
 	 */
 	public function getSumDepositsUsed($multicurrency = 0)
 	{
-		if ($this->element == 'facture_fourn' || $this->element == 'invoice_supplier') {
-			// TODO
-			return 0.0;
-		}
-
 		require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
 
 		$discountstatic = new DiscountAbsolute($this->db);

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -1440,10 +1440,10 @@ if (empty($reshook)) {
 				}
 
 				$type = $productsupplier->type;
-				if (GETPOST('price_ht') != '' || GETPOST('price_ht_devise') != '') {
+				if ($price_ht != '' || $price_ht_devise != '') {
 					$price_base_type = 'HT';
 					$pu = price2num($price_ht, 'MU');
-					$pu_ht_devise = price2num($price_ht_devise, 'CU');
+					$pu_ht_devise = price2num($price_ht_devise, 'MU');
 				} else {
 					$price_base_type = ($productsupplier->fourn_price_base_type ? $productsupplier->fourn_price_base_type : 'HT');
 					if (empty($object->multicurrency_code) || ($productsupplier->fourn_multicurrency_code != $object->multicurrency_code)) {	// If object is in a different currency and price not in this currency

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -861,7 +861,7 @@ if (empty($reshook)) {
 			}
 		}
 
-		// Standard invoice or Deposit invoice, created from a Predefined template invoice
+		// Standard invoice or Deposit invoice, created not from a Predefined template invoice
 		if (GETPOST('type') == FactureFournisseur::TYPE_STANDARD || GETPOST('type') == FactureFournisseur::TYPE_DEPOSIT) {
 			if (GETPOST('socid', 'int') < 1) {
 				setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentities('Supplier')), null, 'errors');
@@ -1085,12 +1085,12 @@ if (empty($reshook)) {
 									1,
 									0,
 									0,
-									0,
 									null,
 									$object->origin,
 									0,
 									'',
 									$lines[$i]->special_code,
+									0,
 									0
 									//,$langs->trans('Deposit') //Deprecated
 								);

--- a/htdocs/langs/en_US/sendings.lang
+++ b/htdocs/langs/en_US/sendings.lang
@@ -62,6 +62,8 @@ ProductQtyInSuppliersShipmentAlreadyRecevied=Product quantity from open purchase
 NoProductToShipFoundIntoStock=No product to ship found in warehouse <b>%s</b>. Correct stock or go back to choose another warehouse.
 WeightVolShort=Weight/Vol.
 ValidateOrderFirstBeforeShipment=You must first validate the order before being able to make shipments.
+UnvalidateShipment=Mofidy Shipment
+ConfirmUnvalidateShipment=Are you sure you want to change this shipment to draft status?
 
 # Sending methods
 # ModelDocument


### PR DESCRIPTION
This bug exists since the first day I use the module Shipment from v13.0.0. (Please ignore the other files which should not be in this topic but I don't know how to move it out from here).

1. htdocs//expedition/card.php

In my case, no product batch or stock is pre-defined but the products are predefined (product ref exists). Therefore, whenever the shipment is created, editing the product line(s) and the respective extrafields always fail even though the shipment is in draft status. This fix (expedition/card.php) added the missing case for both editline and updateline.

2. htdocs/langs/en_US/sendings.lang

In addition, I have added a button for Shipment with status Validated. It will allow back to draft status for further editing.

3. Incorrect translation Key

The current translation for ValidateSending (confirm validation) seems incorrect and should be corrected. However, I failed to find its language file. 