### PR TITLE
FIX invoice fetch not found syslog debug level instead of error

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1735,12 +1735,11 @@ class Facture extends CommonInvoice
 
 				return 1;
 			} else {
-				dol_syslog(__METHOD__ . ' Invoice with id=' . $rowid . ' or ref=' . $ref . ' or ref_ext=' . $ref_ext . ' not found', LOG_DEBUG);
+				dol_syslog(__METHOD__ . ' Invoice with id=' . $rowid . ' or ref=' . $ref . ' or ref_ext=' . $ref_ext . ' not found', LOG_WARNING);
 				return 0;
 			}
 		} else {
 			$this->error = $this->db->lasterror();
-			dol_syslog(__METHOD__ . ' Error : ' . $this->error, LOG_ERR);
 			return -1;
 		}
 	}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1625,10 +1625,10 @@ class Facture extends CommonInvoice
 		}
 
 		dol_syslog(get_class($this)."::fetch", LOG_DEBUG);
-		$result = $this->db->query($sql);
-		if ($result) {
-			if ($this->db->num_rows($result)) {
-				$obj = $this->db->fetch_object($result);
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			if ($this->db->num_rows($resql)) {
+				$obj = $this->db->fetch_object($resql);
 
 				$this->id = $obj->rowid;
 				$this->entity = $obj->entity;
@@ -1730,14 +1730,17 @@ class Facture extends CommonInvoice
 					$this->error = $this->db->error();
 					return -3;
 				}
+
+				$this->db->free($resql);
+
 				return 1;
 			} else {
-				$this->error = 'Invoice with id='.$rowid.' or ref='.$ref.' or ref_ext='.$ref_ext.' not found';
-				dol_syslog(get_class($this)."::fetch Error ".$this->error, LOG_ERR);
+				dol_syslog(__METHOD__ . ' Invoice with id=' . $rowid . ' or ref=' . $ref . ' or ref_ext=' . $ref_ext . ' not found', LOG_DEBUG);
 				return 0;
 			}
 		} else {
-			$this->error = $this->db->error();
+			$this->error = $this->db->lasterror();
+			dol_syslog(__METHOD__ . ' Error : ' . $this->error, LOG_ERR);
 			return -1;
 		}
 	}


### PR DESCRIPTION
FIX invoice fetch not found syslog debug level instead of error

In invoice "fetch" method when a record was not found we had an error in syslog.
This not an error but a debug information.
And a free "SQL" resource was added .
And a syslog with "SQL" error was added.