### PR TITLE
Fix - Supplier deposit invoice - auto convert to discount (error)

### DIFF
--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -223,10 +223,10 @@ class PaiementFourn extends Paiement
 							// If we want to closed paid invoices
 							if ($closepaidinvoices) {
 								$paiement = $invoice->getSommePaiement();
-								//$creditnotes=$invoice->getSumCreditNotesUsed();
-								$creditnotes = 0;
-								//$deposits=$invoice->getSumDepositsUsed();
-								$deposits = 0;
+								$creditnotes=$invoice->getSumCreditNotesUsed();
+								//$creditnotes = 0;
+								$deposits=$invoice->getSumDepositsUsed();
+								//$deposits = 0;
 								$alreadypayed = price2num($paiement + $creditnotes + $deposits, 'MT');
 								$remaintopay = price2num($invoice->total_ttc - $paiement - $creditnotes - $deposits, 'MT');
 								if ($remaintopay == 0) {
@@ -238,7 +238,7 @@ class PaiementFourn extends Paiement
 										// Insert one discount by VAT rate category
 										require_once DOL_DOCUMENT_ROOT . '/core/class/discount.class.php';
 										$discount = new DiscountAbsolute($this->db);
-										$discount->fetch('', $invoice->id);
+										$discount->fetch('', 0, $invoice->id);
 										if (empty($discount->id)) {    // If the invoice was not yet converted into a discount (this may have been done manually before we come here)
 											$discount->discount_type = 1; // Supplier discount
 											$discount->description = '(DEPOSIT)';


### PR DESCRIPTION
Upon full payment to Supplier Invoice(s), the deposit invoice is supposed to auto convert into discount. However, this is not always the case.

This fix is to correct the incorrect $discount->fetch function for supplier invoice.

The functions to get the total of credit notes and other deposits are also updated. 