### PR TITLE
Add  hook printFieldListFrom to reception/list.php to allow add joins

### DIFF
--- a/htdocs/reception/list.php
+++ b/htdocs/reception/list.php
@@ -448,6 +448,12 @@ $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."delivery as l ON l.rowid = ee.fk_target";
 if (!$user->rights->societe->client->voir && !$socid) {	// Internal user with no permission to see all
 	$sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 }
+
+// Add joins from hooks
+$parameters = array();
+$reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters); // Note that $action and $object may have been modified by hook
+$sql .= $hookmanager->resPrint;
+
 $sql .= " WHERE e.entity IN (".getEntity('reception').")";
 if (!$user->rights->societe->client->voir && !$socid) {	// Internal user with no permission to see all
 	$sql .= " AND e.fk_soc = sc.fk_soc";


### PR DESCRIPTION
# New hook `printFieldListFrom` in reception/list.php
The hook `printFieldListFrom` allows to add more joins in the reception/list.php.
With that change, it is now possible to add columns that are references to the receptions (e.g. an "order" column by joining the `element_element` and the `commande_fournisseur` tables).