### PR TITLE
FIX: printOriginLinesList: backport PR #13863 to v12

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4459,7 +4459,6 @@ abstract class CommonObject
 		$i = 0;
 
 		if (!empty($this->lines)) {
-
 			foreach ($this->lines as $line) {
 				$reshook = null;
 


### PR DESCRIPTION
I worked on nearly the same change proposed in PR #13863 before seeing. However, I would like to propose to backport it in v12.

The behaviour changed had been modified way back (6 years ago, commit https://github.com/Dolibarr/dolibarr/commit/990fbf3ef45a06577264f7ce6630964acdc9269c for version 3.9) for the equivalent `printObjectLine` hook, which is great as it enabled us to completely change the structure of the documents.

Not being able to do the same in the origin line list seems incoherent to me, it should have been made the same way from the beginning, that is why i'm proposing in this PR for version 12.0 instead of develop.

More over, I did some more modifications than in the PR#13863

The changes in detail :
- Initialize `$hookmanager` if it is not the case (should not happen anyway)
- expose hook `printOriginObjectLineTitle` to modify the origin lines table header

