### PR TITLE
FIx error 500 on restler api PHP 8.0

### DIFF
--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -17,7 +17,7 @@
 
  use Luracast\Restler\RestException;
 
-require 'ticket.class.php';
+require_once DOL_DOCUMENT_ROOT.'/ticket/class/ticket.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/ticket.lib.php';
 
 


### PR DESCRIPTION
Fix error 500 when importing ticket.class.php when starting rest api on php 8.0