### PR TITLE
add hook 'functionGetEntity' 

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -188,6 +188,7 @@ class HookManager
 				'formConfirm',
 				'getAccessForbiddenMessage',
 				'getDirList',
+				'functionGetEntity',
 				'getFormMail',
 				'getFormatedCustomerRef',
 				'getFormatedSupplierRef',


### PR DESCRIPTION
To manipulate entities for queries on the fly

We are need to filter some lists (selects and list tables) on our multicompany install.
This hook allows us to filter all queries that use the function `getEntity()` to show only items from the entity we want.

Scenario: We share products/services between all entities but want to sell only items from the current entity. propal,commande
example implementation:

```php
public function functionGetEntity( $parameters, &$object, &$action, $hookmanager ) {

	global $conf;

	$elements = array('propal','commande');

	if ( $parameters['element'] == 'product' && in_array( $parameters['object']->element, $elements ) ) {

		$entity = $conf->entity;
		$return = '0,'.$entity;

		$hookmanager->resprints = $return;

		return 1; // 0 = add / 1 = replace
	}
}

```