### PR TITLE
Close #18527 - Email collector link emails received to more objects

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -30,6 +30,38 @@ require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 require_once DOL_DOCUMENT_ROOT.'/ticket/class/ticket.class.php';
 require_once DOL_DOCUMENT_ROOT.'/recruitment/class/recruitmentcandidature.class.php';
 
+require_once DOL_DOCUMENT_ROOT.'/comm/propal/class/propal.class.php'; // customer proposal
+require_once DOL_DOCUMENT_ROOT.'/commande/class/commande.class.php'; // customer order
+require_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php'; // Shipment
+require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php'; // supplier invoice
+require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.commande.class.php'; // supplier order
+include_once DOL_DOCUMENT_ROOT.'/supplier_proposal/class/supplier_proposal.class.php'; // supplier proposal
+require_once DOL_DOCUMENT_ROOT."/reception/class/reception.class.php"; // reception
+//require_once DOL_DOCUMENT_ROOT.'/holiday/class/holiday.class.php'; // Holidays (leave request)
+//require_once DOL_DOCUMENT_ROOT.'/expensereport/class/expensereport.class.php'; // expernse report
+/*
+if (!empty($conf->propal->enabled)) {
+}
+if (!empty($conf->commande->enabled)) {
+}
+if (!empty($conf->expedition->enabled)) {
+}
+if (!empty($conf->facture->enabled)) {
+	require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
+}
+if (!empty($conf->facture->enabled)) {
+	require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture-rec.class.php';
+}
+if (!empty($conf->contrat->enabled)) {
+	require_once DOL_DOCUMENT_ROOT.'/contrat/class/contrat.class.php';
+}
+if (!empty($conf->adherent->enabled)) {
+	require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
+}
+if (!empty($conf->ficheinter->enabled)) { //files
+	require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
+}*/
+
 
 /**
  * Class for EmailCollector
@@ -1415,8 +1447,8 @@ class EmailCollector extends CommonObject
 				$reg = array();
 				if (!empty($headers['References'])) {
 					$arrayofreferences = preg_split('/(,|\s+)/', $headers['References']);
-					//var_dump($headers['References']);
-					//var_dump($arrayofreferences);
+					// var_dump($headers['References']);
+					// var_dump($arrayofreferences);
 
 					foreach ($arrayofreferences as $reference) {
 						//print "Process mail ".$iforemailloop." email_msgid ".$msgid.", date ".dol_print_date($date, 'dayhour').", subject ".$subject.", reference ".dol_escape_htmltag($reference)."<br>\n";
@@ -1432,8 +1464,29 @@ class EmailCollector extends CommonObject
 							if ($reg[1] == 'ctc') {
 								$objectemail = new Contact($this->db);
 							}
-							if ($reg[1] == 'inv') {
+							if ($reg[1] == 'inv') { // customer invoices
 								$objectemail = new Facture($this->db);
+							} 
+							if ($reg[1] == 'sinv') { // supplier invoices
+								$objectemail = new FactureFournisseur($this->db);
+							}
+							if ($reg[1] == 'pro') { // customer proposals
+								$objectemail = new Propal($this->db);
+							}
+							if ($reg[1] == 'ord') { // customer orders
+								$objectemail = new Commande($this->db);
+							}
+							if ($reg[1] == 'shi') { // shipments
+								$objectemail = new Expedition($this->db);
+							}
+							if ($reg[1] == 'spro') { // supplier proposal
+								$objectemail = new SupplierProposal($this->db);
+							}
+							if ($reg[1] == 'sord') { // supplier order
+								$objectemail = new CommandeFournisseur($this->db);
+							}
+							if ($reg[1] == 'rec') { // Reception
+								$objectemail = new Reception($this->db);
 							}
 							if ($reg[1] == 'proj') {
 								$objectemail = new Project($this->db);
@@ -1456,6 +1509,12 @@ class EmailCollector extends CommonObject
 							if ($reg[1] == 'mem') {
 								$objectemail = new Adherent($this->db);
 							}
+							/*if ($reg[1] == 'leav') {
+								$objectemail = new Holiday($db);
+							}
+							if ($reg[1] == 'exp') {
+								$objectemail = new ExpenseReport($db);
+							}*/
 						} elseif (preg_match('/<(.*@.*)>/', $reference, $reg)) {
 							// This is an external reference, we check if we have it in our database
 							if (!is_object($objectemail)) {

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -35,32 +35,10 @@ require_once DOL_DOCUMENT_ROOT.'/commande/class/commande.class.php'; // customer
 require_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php'; // Shipment
 require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php'; // supplier invoice
 require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.commande.class.php'; // supplier order
-include_once DOL_DOCUMENT_ROOT.'/supplier_proposal/class/supplier_proposal.class.php'; // supplier proposal
+require_once DOL_DOCUMENT_ROOT.'/supplier_proposal/class/supplier_proposal.class.php'; // supplier proposal
 require_once DOL_DOCUMENT_ROOT."/reception/class/reception.class.php"; // reception
 //require_once DOL_DOCUMENT_ROOT.'/holiday/class/holiday.class.php'; // Holidays (leave request)
 //require_once DOL_DOCUMENT_ROOT.'/expensereport/class/expensereport.class.php'; // expernse report
-/*
-if (!empty($conf->propal->enabled)) {
-}
-if (!empty($conf->commande->enabled)) {
-}
-if (!empty($conf->expedition->enabled)) {
-}
-if (!empty($conf->facture->enabled)) {
-	require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
-}
-if (!empty($conf->facture->enabled)) {
-	require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture-rec.class.php';
-}
-if (!empty($conf->contrat->enabled)) {
-	require_once DOL_DOCUMENT_ROOT.'/contrat/class/contrat.class.php';
-}
-if (!empty($conf->adherent->enabled)) {
-	require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
-}
-if (!empty($conf->ficheinter->enabled)) { //files
-	require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
-}*/
 
 
 /**

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1466,7 +1466,7 @@ class EmailCollector extends CommonObject
 							}
 							if ($reg[1] == 'inv') { // customer invoices
 								$objectemail = new Facture($this->db);
-							} 
+							}
 							if ($reg[1] == 'sinv') { // supplier invoices
 								$objectemail = new FactureFournisseur($this->db);
 							}


### PR DESCRIPTION
# Feature Request
Enhance Record event action of email collector to be able to link the received emails in the following object based on the trackID
 - Customer proposal
 - customer order
 - shipment
 - supplier proposal
 - supplier order
 - supplier invoice
 - reception
 - leave request
 - expense report

## Use case
Email collector link received email that are relevant to a dolibarr object to the object
