### PR TITLE
FIX #18542 REST API: set global $user variable to DolibarrApiAccess::user

### DIFF
--- a/htdocs/api/class/api_access.class.php
+++ b/htdocs/api/class/api_access.class.php
@@ -149,6 +149,8 @@ class DolibarrApiAccess implements iAuthenticate
 			}
 			$fuser->getrights();
 			static::$user = $fuser;
+			
+			// Set the global variable $user to the $user of API
 			$user = $fuser;
 
 			if ($fuser->socid) {

--- a/htdocs/api/class/api_access.class.php
+++ b/htdocs/api/class/api_access.class.php
@@ -80,7 +80,7 @@ class DolibarrApiAccess implements iAuthenticate
 	public function __isAllowed()
 	{
 		// phpcs:enable
-		global $conf, $db;
+		global $conf, $db, $user;
 
 		$login = '';
 		$stored_key = '';
@@ -149,6 +149,7 @@ class DolibarrApiAccess implements iAuthenticate
 			}
 			$fuser->getrights();
 			static::$user = $fuser;
+			$user = $fuser;
 
 			if ($fuser->socid) {
 				static::$role = 'external';


### PR DESCRIPTION
# Fix #18542
Some functions needs global $user variable to be set to current user. In the specific case of REST API, this should be set to DolibarrApiAccess::$user, unfortunately this is not the case and some functions doesn't work as expected (from example getCommonSubstitutionArray from core/lib/functions.lib.php).