### PR TITLE
Fix: select products in BOM, when adding new item the $conf->product-…

### DIFF
--- a/htdocs/bom/tpl/objectline_create.tpl.php
+++ b/htdocs/bom/tpl/objectline_create.tpl.php
@@ -100,9 +100,9 @@ if (!empty($conf->product->enabled) || !empty($conf->service->enabled)) {
 	$statustoshow = -1;
 	if (!empty($conf->global->ENTREPOT_EXTRA_STATUS)) {
 		// hide products in closed warehouse, but show products for internal transfer
-		$form->select_produits(GETPOST('idprod', 'int'), 'idprod', $filtertype, $conf->product->limit_size, $buyer->price_level, $statustoshow, 2, '', 1, array(), $buyer->id, '1', 0, 'maxwidth500', 0, 'warehouseopen,warehouseinternal', GETPOST('combinations', 'array'));
+		$form->select_produits(GETPOST('idprod', 'int'), 'idprod', $filtertype, 0, $buyer->price_level, $statustoshow, 2, '', 1, array(), $buyer->id, '1', 0, 'maxwidth500', 0, 'warehouseopen,warehouseinternal', GETPOST('combinations', 'array'));
 	} else {
-		$form->select_produits(GETPOST('idprod', 'int'), 'idprod', $filtertype, $conf->product->limit_size, $buyer->price_level, $statustoshow, 2, '', 1, array(), $buyer->id, '1', 0, 'maxwidth500', 0, '', GETPOST('combinations', 'array'));
+		$form->select_produits(GETPOST('idprod', 'int'), 'idprod', $filtertype, 0, $buyer->price_level, $statustoshow, 2, '', 1, array(), $buyer->id, '1', 0, 'maxwidth500', 0, '', GETPOST('combinations', 'array'));
 	}
 
 	echo '</span>';


### PR DESCRIPTION
Currently, when you want to add a new item to a BOM, not all items are loaded as `$conf->product->limit_size `is blocking to load all products.  This PR removes the limitation. #18155