### PR TITLE
FournisseurCommandDispatch extends CommonObjectLine instead of CommonObject

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.dispatch.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.dispatch.class.php
@@ -31,7 +31,7 @@ require_once DOL_DOCUMENT_ROOT."/reception/class/reception.class.php";
 /**
  *  Class to manage table commandefournisseurdispatch
  */
-class CommandeFournisseurDispatch extends CommonObject
+class CommandeFournisseurDispatch extends CommonObjectLine
 {
 	/**
 	 * @var DoliDB Database handler.


### PR DESCRIPTION
# Fix #18516 
If the `CommandeFournisseurDispatch` extends `CommonObjectLine`, everything is working as expected.
As `CommonObjectLine` is extending `CommonObject`, it should not create any bugs.
