### PR TITLE
Bill supplier validate

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -209,7 +209,6 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 						}
 					}
 				}
-				return $ret;
 			}
 
 			// Second classify billed the proposal.


### PR DESCRIPTION
# Fix - *Regroup all actions of the `BILL_SUPPLIER_VALIDATE` action/event* 

All the actions for the `BILL_SUPPLIER_VALIDATE` where separated so that they couldn't be all excuted if needed.
There was a `return $ret` at the end of the body of the first `if ($action == 'BILL_SUPPLIER_VALIDATE')` so the second was never executed
