### PR TITLE
Update facture.class.php

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -526,6 +526,7 @@ class Facture extends CommonInvoice
 			$this->cond_reglement_id = GETPOST('cond_reglement_id', 'int') > 0 ? ((int) GETPOST('cond_reglement_id', 'int')) : $_facrec->cond_reglement_id;
 			$this->mode_reglement_id = GETPOST('mode_reglement_id', 'int') > 0 ? ((int) GETPOST('mode_reglement_id', 'int')) : $_facrec->mode_reglement_id;
 			$this->fk_account        = GETPOST('fk_account') > 0 ? ((int) GETPOST('fk_account')) : $_facrec->fk_account;
+			
 
 			// Set here to have this defined for substitution into notes, should be recalculated after adding lines to get same result
 			$this->total_ht          = $_facrec->total_ht;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -526,7 +526,11 @@ class Facture extends CommonInvoice
 			$this->cond_reglement_id = GETPOST('cond_reglement_id', 'int') > 0 ? ((int) GETPOST('cond_reglement_id', 'int')) : $_facrec->cond_reglement_id;
 			$this->mode_reglement_id = GETPOST('mode_reglement_id', 'int') > 0 ? ((int) GETPOST('mode_reglement_id', 'int')) : $_facrec->mode_reglement_id;
 			$this->fk_account        = GETPOST('fk_account') > 0 ? ((int) GETPOST('fk_account')) : $_facrec->fk_account;
-
+			
+			// if ref_client was not set by caller, use the facref title
+			if (empty($this->ref_client)) {
+				$this->ref_client =  trim($_facrec->title);
+			}
 
 			// Set here to have this defined for substitution into notes, should be recalculated after adding lines to get same result
 			$this->total_ht          = $_facrec->total_ht;
@@ -614,6 +618,7 @@ class Facture extends CommonInvoice
 
 			$this->note_public = make_substitutions($this->note_public, $substitutionarray);
 			$this->note_private = make_substitutions($this->note_private, $substitutionarray);
+			$this->ref_client = make_substitutions($this->ref_client, $substitutionarray);
 		}
 
 		// Define due date if not already defined

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -526,7 +526,7 @@ class Facture extends CommonInvoice
 			$this->cond_reglement_id = GETPOST('cond_reglement_id', 'int') > 0 ? ((int) GETPOST('cond_reglement_id', 'int')) : $_facrec->cond_reglement_id;
 			$this->mode_reglement_id = GETPOST('mode_reglement_id', 'int') > 0 ? ((int) GETPOST('mode_reglement_id', 'int')) : $_facrec->mode_reglement_id;
 			$this->fk_account        = GETPOST('fk_account') > 0 ? ((int) GETPOST('fk_account')) : $_facrec->fk_account;
-			
+
 			// if ref_client was not set by caller, use the facref title
 			if (empty($this->ref_client)) {
 				$this->ref_client =  trim($_facrec->title);

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -526,7 +526,7 @@ class Facture extends CommonInvoice
 			$this->cond_reglement_id = GETPOST('cond_reglement_id', 'int') > 0 ? ((int) GETPOST('cond_reglement_id', 'int')) : $_facrec->cond_reglement_id;
 			$this->mode_reglement_id = GETPOST('mode_reglement_id', 'int') > 0 ? ((int) GETPOST('mode_reglement_id', 'int')) : $_facrec->mode_reglement_id;
 			$this->fk_account        = GETPOST('fk_account') > 0 ? ((int) GETPOST('fk_account')) : $_facrec->fk_account;
-			
+
 
 			// Set here to have this defined for substitution into notes, should be recalculated after adding lines to get same result
 			$this->total_ht          = $_facrec->total_ht;


### PR DESCRIPTION
copy ref_client from facrec
substitute keys into ref_client. (eg: __INVOICE_YEAR__ etc...)

# New ref_client is not copied from facture_rec
When creating invoices from recurring invoices, original ref_client field is left blank on new invoice.
This fix allow ref_client to be copied, dans substituted to create date aware ref_client field values.
This allow recurring invoices like:
 [Company] Invoice __INVOICE_YEAR__-__INVOICE_MONTH__ 

to be instantiated for each month like:
 [Company] Invoice 2021-09
