### PR TITLE
FIX : delete image from card.php page dont remove the thumbs

### DIFF
--- a/htdocs/core/actions_builddoc.inc.php
+++ b/htdocs/core/actions_builddoc.inc.php
@@ -127,8 +127,23 @@ if ($action == 'remove_file' && $permissiontoadd) {
 		$langs->load("other");
 		$filetodelete = GETPOST('file', 'alpha');
 		$file = $upload_dir.'/'.$filetodelete;
+		$dirthumb = dirname($file).'/thumbs/'; // Chemin du dossier contenant la vignette (if file is an image)
 		$ret = dol_delete_file($file, 0, 0, 0, $object);
 		if ($ret) {
+			// If it exists, remove thumb.
+			$regs = array();
+			if (preg_match('/(\.jpg|\.jpeg|\.bmp|\.gif|\.png|\.tiff)$/i', $file, $regs)) {
+				$photo_vignette = basename(preg_replace('/'.$regs[0].'/i', '', $file).'_small'.$regs[0]);
+				if (file_exists(dol_osencode($dirthumb.$photo_vignette))) {
+					dol_delete_file($dirthumb.$photo_vignette);
+				}
+
+				$photo_vignette = basename(preg_replace('/'.$regs[0].'/i', '', $file).'_mini'.$regs[0]);
+				if (file_exists(dol_osencode($dirthumb.$photo_vignette))) {
+					dol_delete_file($dirthumb.$photo_vignette);
+				}
+			}
+
 			setEventMessages($langs->trans("FileWasRemoved", $filetodelete), null, 'mesgs');
 		} else {
 			setEventMessages($langs->trans("ErrorFailToDeleteFile", $filetodelete), null, 'errors');

--- a/htdocs/core/actions_linkedfiles.inc.php
+++ b/htdocs/core/actions_linkedfiles.inc.php
@@ -112,21 +112,20 @@ if ($action == 'confirm_deletefile' && $confirm == 'yes' && (!isset($permissiont
 			dol_delete_file($fileold, 0, 0, 0, (is_object($object) ? $object : null)); // Delete file using old path
 		}
 
-		// If it exists, remove thumb.
-		$regs = array();
-		if (preg_match('/(\.jpg|\.jpeg|\.bmp|\.gif|\.png|\.tiff)$/i', $file, $regs)) {
-			$photo_vignette = basename(preg_replace('/'.$regs[0].'/i', '', $file).'_small'.$regs[0]);
-			if (file_exists(dol_osencode($dirthumb.$photo_vignette))) {
-				dol_delete_file($dirthumb.$photo_vignette);
-			}
-
-			$photo_vignette = basename(preg_replace('/'.$regs[0].'/i', '', $file).'_mini'.$regs[0]);
-			if (file_exists(dol_osencode($dirthumb.$photo_vignette))) {
-				dol_delete_file($dirthumb.$photo_vignette);
-			}
-		}
-
 		if ($ret) {
+			// If it exists, remove thumb.
+			$regs = array();
+			if (preg_match('/(\.jpg|\.jpeg|\.bmp|\.gif|\.png|\.tiff)$/i', $file, $regs)) {
+				$photo_vignette = basename(preg_replace('/'.$regs[0].'/i', '', $file).'_small'.$regs[0]);
+				if (file_exists(dol_osencode($dirthumb.$photo_vignette))) {
+					dol_delete_file($dirthumb.$photo_vignette);
+				}
+
+				$photo_vignette = basename(preg_replace('/'.$regs[0].'/i', '', $file).'_mini'.$regs[0]);
+				if (file_exists(dol_osencode($dirthumb.$photo_vignette))) {
+					dol_delete_file($dirthumb.$photo_vignette);
+				}
+			}
 			setEventMessages($langs->trans("FileWasRemoved", $urlfile), null, 'mesgs');
 		} else {
 			setEventMessages($langs->trans("ErrorFailToDeleteFile", $urlfile), null, 'errors');


### PR DESCRIPTION
1°) When you are on card.php, if you delete a linked file (below builddoc) the thumbs are not deleted

Minor bug because rare situation
2°) When you are on document.php, if you delete a linked file, the thumbs are deleted even if delete main image failed