### PR TITLE
Increase the width of column for General Set-ups - Update dolibarr.php

### DIFF
--- a/htdocs/admin/system/dolibarr.php
+++ b/htdocs/admin/system/dolibarr.php
@@ -505,7 +505,7 @@ if ($resql) {
 		$obj = $db->fetch_object($resql);
 
 		print '<tr class="oddeven">';
-		print '<td class="tdoverflowmax300">'.$obj->name.'</td>'."\n";
+		print '<td class="tdoverflowmax600">'.$obj->name.'</td>'."\n";
 		print '<td class="tdoverflowmax300">';
 		if (isASecretKey($obj->name)) {
 			if (empty($dolibarr_main_prod)) {

--- a/htdocs/admin/system/dolibarr.php
+++ b/htdocs/admin/system/dolibarr.php
@@ -505,7 +505,7 @@ if ($resql) {
 		$obj = $db->fetch_object($resql);
 
 		print '<tr class="oddeven">';
-		print '<td class="tdoverflowmax600" title="'dol_escape_htmltag($obj->name).'">'.dol_escape_htmltag($obj->name).'</td>'."\n";
+		print '<td class="tdoverflowmax600" title="'.dol_escape_htmltag($obj->name).'">'.dol_escape_htmltag($obj->name).'</td>'."\n";
 		print '<td class="tdoverflowmax300">';
 		if (isASecretKey($obj->name)) {
 			if (empty($dolibarr_main_prod)) {

--- a/htdocs/admin/system/dolibarr.php
+++ b/htdocs/admin/system/dolibarr.php
@@ -505,7 +505,7 @@ if ($resql) {
 		$obj = $db->fetch_object($resql);
 
 		print '<tr class="oddeven">';
-		print '<td class="tdoverflowmax600">'.$obj->name.'</td>'."\n";
+		print '<td class="tdoverflowmax600" title="'dol_escape_htmltag($obj->name).'">'.dol_escape_htmltag($obj->name).'</td>'."\n";
 		print '<td class="tdoverflowmax300">';
 		if (isASecretKey($obj->name)) {
 			if (empty($dolibarr_main_prod)) {


### PR DESCRIPTION
Some names of the general set-ups are too long and are cut off by the limited width 300px.

Suggest to double it (here updated). Or it would be considerable to take out the limit of width.