### PR TITLE
Fix : unable to create a direct debit if ics_transfer is empty

### DIFF
--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -96,8 +96,8 @@ if (empty($reshook)) {
 		$bank = new Account($db);
 		$bank->fetch($conf->global->{$default_account});
 		if ((empty($bank->ics) && $type !== 'bank-transfer')
-            || (empty($bank->ics_transfer) && $type === 'bank-transfer')
-        ) {
+			|| (empty($bank->ics_transfer) && $type === 'bank-transfer')
+		) {
 			$errormessage = str_replace('{url}', $bank->getNomUrl(1, '', '', -1, 1), $langs->trans("ErrorICSmissing", '{url}'));
 			setEventMessages($errormessage, null, 'errors');
 			header("Location: ".DOL_URL_ROOT.'/compta/prelevement/create.php');

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -95,7 +95,9 @@ if (empty($reshook)) {
 		require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 		$bank = new Account($db);
 		$bank->fetch($conf->global->{$default_account});
-		if (empty($bank->ics) || empty($bank->ics_transfer)) {
+		if ((empty($bank->ics) && $type !== 'bank-transfer')
+            || (empty($bank->ics_transfer) && $type === 'bank-transfer')
+        ) {
 			$errormessage = str_replace('{url}', $bank->getNomUrl(1, '', '', -1, 1), $langs->trans("ErrorICSmissing", '{url}'));
 			setEventMessages($errormessage, null, 'errors');
 			header("Location: ".DOL_URL_ROOT.'/compta/prelevement/create.php');


### PR DESCRIPTION
Fix : unable to create a direct debit if ics and ics_transfer are empty even though ics_transfer is only used for bank transfer.