### PR TITLE
Fix : GET extrafields on API "get events list" requests

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -763,6 +763,7 @@ class ActionComm extends CommonObject
                 $this->elementid = $obj->elementid;
                 $this->elementtype = $obj->elementtype;
 
+                $this->fetch_optionals();
                 $this->fetchResources();
             }
             $this->db->free($resql);

--- a/htdocs/comm/action/class/api_agendaevents.class.php
+++ b/htdocs/comm/action/class/api_agendaevents.class.php
@@ -171,6 +171,7 @@ class AgendaEvents extends DolibarrApi
                 $obj = $db->fetch_object($result);
                 $actioncomm_static = new ActionComm($db);
                 if ($actioncomm_static->fetch($obj->rowid)) {
+                    $actioncomm_static->fetch_optionals();
                     $obj_ret[] = $this->_cleanObjectDatas($actioncomm_static);
                 }
                 $i++;

--- a/htdocs/comm/action/class/api_agendaevents.class.php
+++ b/htdocs/comm/action/class/api_agendaevents.class.php
@@ -171,7 +171,6 @@ class AgendaEvents extends DolibarrApi
                 $obj = $db->fetch_object($result);
                 $actioncomm_static = new ActionComm($db);
                 if ($actioncomm_static->fetch($obj->rowid)) {
-                    $actioncomm_static->fetch_optionals();
                     $obj_ret[] = $this->_cleanObjectDatas($actioncomm_static);
                 }
                 $i++;


### PR DESCRIPTION

# Fix # API allow to get agendaevents list with extrafields

Add $actioncomm_static->fetch_optionals() helps to get extrafielsd when getting agendaevents list from api.


