### PR TITLE
14.0 fix takepos payment methods

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -978,36 +978,39 @@ if (empty($conf->global->TAKEPOS_HIDE_HEAD_BAR)) {
 <?php
 
 // TakePOS setup check
-$sql = "SELECT code, libelle FROM ".MAIN_DB_PREFIX."c_paiement";
-$sql .= " WHERE entity IN (".getEntity('c_paiement').")";
-$sql .= " AND active = 1";
-$sql .= " ORDER BY libelle";
+if ( isset( $_SESSION["takeposterminal"] ) && $_SESSION["takeposterminal"] ) {
+	$sql = "SELECT code, libelle FROM " . MAIN_DB_PREFIX . "c_paiement";
+	$sql .= " WHERE entity IN (" . getEntity( 'c_paiement' ) . ")";
+	$sql .= " AND active = 1";
+	$sql .= " ORDER BY libelle";
 
-$resql = $db->query($sql);
-$paiementsModes = array();
-if ($resql) {
-	while ($obj = $db->fetch_object($resql)) {
-		$paycode = $obj->code;
-		if ($paycode == 'LIQ') {
-			$paycode = 'CASH';
-		}
-		if ($paycode == 'CHQ') {
-			$paycode = 'CHEQUE';
-		}
+	$resql          = $db->query( $sql );
+	$paiementsModes = array();
+	if ( $resql ) {
+		while ( $obj = $db->fetch_object( $resql ) ) {
+			$paycode = $obj->code;
+			if ( $paycode == 'LIQ' ) {
+				$paycode = 'CASH';
+			}
+			if ( $paycode == 'CHQ' ) {
+				$paycode = 'CHEQUE';
+			}
 
-		$constantforkey = "CASHDESK_ID_BANKACCOUNT_".$paycode.$_SESSION["takeposterminal"];
-		//var_dump($constantforkey.' '.$conf->global->$constantforkey);
-		if (!empty($conf->global->$constantforkey) && $conf->global->$constantforkey > 0) {
-			array_push($paiementsModes, $obj);
+			$constantforkey = "CASHDESK_ID_BANKACCOUNT_" . $paycode . $_SESSION["takeposterminal"];
+			//var_dump($constantforkey.' '.$conf->global->$constantforkey);
+			if ( ! empty( $conf->global->$constantforkey ) && $conf->global->$constantforkey > 0 ) {
+				array_push( $paiementsModes, $obj );
+			}
 		}
+	}
+
+	if ( empty( $paiementsModes ) ) {
+		$langs->load( 'errors' );
+		setEventMessages( $langs->trans( "ErrorModuleSetupNotComplete", $langs->transnoentitiesnoconv( "TakePOS" ) ), null, 'errors' );
+		setEventMessages( $langs->trans( "ProblemIsInSetupOfTerminal", $_SESSION["takeposterminal"] ), null, 'errors' );
 	}
 }
 
-if (empty($paiementsModes)) {
-	$langs->load('errors');
-	setEventMessages($langs->trans("ErrorModuleSetupNotComplete", $langs->transnoentitiesnoconv("TakePOS")), null, 'errors');
-	setEventMessages($langs->trans("ProblemIsInSetupOfTerminal", $_SESSION["takeposterminal"]), null, 'errors');
-}
 if (count($maincategories) == 0) {
 	if ($conf->global->TAKEPOS_ROOT_CATEGORY_ID > 0) {
 		$tmpcategory = new Categorie($db);

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -978,36 +978,36 @@ if (empty($conf->global->TAKEPOS_HIDE_HEAD_BAR)) {
 <?php
 
 // TakePOS setup check
-if ( isset( $_SESSION["takeposterminal"] ) && $_SESSION["takeposterminal"] ) {
+if (isset($_SESSION["takeposterminal"]) && $_SESSION["takeposterminal"]) {
 	$sql = "SELECT code, libelle FROM " . MAIN_DB_PREFIX . "c_paiement";
-	$sql .= " WHERE entity IN (" . getEntity( 'c_paiement' ) . ")";
+	$sql .= " WHERE entity IN (" . getEntity('c_paiement') . ")";
 	$sql .= " AND active = 1";
 	$sql .= " ORDER BY libelle";
 
-	$resql          = $db->query( $sql );
+	$resql          = $db->query($sql);
 	$paiementsModes = array();
-	if ( $resql ) {
-		while ( $obj = $db->fetch_object( $resql ) ) {
+	if ($resql) {
+		while ( $obj = $db->fetch_object($resql) ) {
 			$paycode = $obj->code;
-			if ( $paycode == 'LIQ' ) {
+			if ($paycode == 'LIQ') {
 				$paycode = 'CASH';
 			}
-			if ( $paycode == 'CHQ' ) {
+			if ($paycode == 'CHQ') {
 				$paycode = 'CHEQUE';
 			}
 
 			$constantforkey = "CASHDESK_ID_BANKACCOUNT_" . $paycode . $_SESSION["takeposterminal"];
 			//var_dump($constantforkey.' '.$conf->global->$constantforkey);
-			if ( ! empty( $conf->global->$constantforkey ) && $conf->global->$constantforkey > 0 ) {
-				array_push( $paiementsModes, $obj );
+			if ( ! empty($conf->global->$constantforkey) && $conf->global->$constantforkey > 0) {
+				array_push($paiementsModes, $obj);
 			}
 		}
 	}
 
-	if ( empty( $paiementsModes ) ) {
-		$langs->load( 'errors' );
-		setEventMessages( $langs->trans( "ErrorModuleSetupNotComplete", $langs->transnoentitiesnoconv( "TakePOS" ) ), null, 'errors' );
-		setEventMessages( $langs->trans( "ProblemIsInSetupOfTerminal", $_SESSION["takeposterminal"] ), null, 'errors' );
+	if (empty($paiementsModes)) {
+		$langs->load('errors');
+		setEventMessages($langs->trans("ErrorModuleSetupNotComplete", $langs->transnoentitiesnoconv("TakePOS")), null, 'errors');
+		setEventMessages($langs->trans("ProblemIsInSetupOfTerminal", $_SESSION["takeposterminal"]), null, 'errors');
 	}
 }
 

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -188,11 +188,9 @@ if ($action == 'valid' && $user->rights->facture->creer) {
 	if (!empty($conf->global->TAKEPOS_CAN_FORCE_BANK_ACCOUNT_DURING_PAYMENT)) {
 		$bankaccount = GETPOST('accountid', 'int');
 	} else {
-		if ($pay == "cash") {
+		if ($pay == 'LIQ') {
 			$bankaccount = $conf->global->{'CASHDESK_ID_BANKACCOUNT_CASH'.$_SESSION["takeposterminal"]};            // For backward compatibility
-		} elseif ($pay == "card") {
-			$bankaccount = $conf->global->{'CASHDESK_ID_BANKACCOUNT_CB'.$_SESSION["takeposterminal"]};          // For backward compatibility
-		} elseif ($pay == "cheque") {
+		} elseif ($pay == "CHQ") {
 			$bankaccount = $conf->global->{'CASHDESK_ID_BANKACCOUNT_CHEQUE'.$_SESSION["takeposterminal"]};    // For backward compatibility
 		} else {
 			$accountname = "CASHDESK_ID_BANKACCOUNT_".$pay.$_SESSION["takeposterminal"];

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -316,23 +316,20 @@ print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad 
 	$paycode = $arrayOfValidPaymentModes[0]->code;
 	$payIcon = '';
 	if ($paycode == 'LIQ') {
-		$paycode = 'cash';
 		if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON)) {
 			$payIcon = 'coins';
 		}
 	} elseif ($paycode == 'CB') {
-		$paycode = 'card';
 		if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON)) {
 			$payIcon = 'credit-card';
 		}
 	} elseif ($paycode == 'CHQ') {
-		$paycode = 'cheque';
 		if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON)) {
 			$payIcon = 'money-check';
 		}
 	}
 
-	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">'.(!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.' iconwithlabel"></span><span class="hideonsmartphone"><br>'. $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[0]->code) : $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[0]->code)).'</span></button>';
+	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$paycode.'\');">'.(!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.' iconwithlabel"></span><span class="hideonsmartphone"><br>'. $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[0]->code) : $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[0]->code)).'</span></button>';
 } else {
 	print '<button type="button" class="calcbutton2">'.$langs->trans("NoPaimementModesDefined").'</button>';
 }
@@ -345,23 +342,20 @@ print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad 
 	$paycode = $arrayOfValidPaymentModes[1]->code;
 	$payIcon = '';
 	if ($paycode == 'LIQ') {
-		$paycode = 'cash';
 		if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON)) {
 			$payIcon = 'coins';
 		}
 	} elseif ($paycode == 'CB') {
-		$paycode = 'card';
 		if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON)) {
 			$payIcon = 'credit-card';
 		}
 	} elseif ($paycode == 'CHQ') {
-		$paycode = 'cheque';
 		if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON)) {
 			$payIcon = 'money-check';
 		}
 	}
 
-	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">'.(!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.' iconwithlabel"></span><br> '. $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[1]->code) : $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[1]->code)).'</button>';
+	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$paycode.'\');">'.(!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.' iconwithlabel"></span><br> '. $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[1]->code) : $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[1]->code)).'</button>';
 } else {
 	$button = array_pop($action_buttons);
 	print '<button type="button" class="calcbutton2" onclick="'.$button["function"].'"><span '.$button["span"].'>'.$button["text"].'</span></button>';
@@ -375,23 +369,20 @@ print '<button type="button" class="calcbutton" onclick="addreceived('.($numpad 
 	$paycode = $arrayOfValidPaymentModes[2]->code;
 	$payIcon = '';
 	if ($paycode == 'LIQ') {
-		$paycode = 'cash';
 		if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON)) {
 			$payIcon = 'coins';
 		}
 	} elseif ($paycode == 'CB') {
-		$paycode = 'card';
 		if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON)) {
 			$payIcon = 'credit-card';
 		}
 	} elseif ($paycode == 'CHQ') {
-		$paycode = 'cheque';
 		if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON)) {
 			$payIcon = 'money-check';
 		}
 	}
 
-	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$langs->trans($paycode).'\');">'.(!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.' iconwithlabel"></span>'.(!empty($conf->global->TAKEPOS_NUMPAD_FORCE_PAYMENT_ICONS_LABELS) ? '<br> '. $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[2]->code) : '') : $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[2]->code)).'</button>';
+	print '<button type="button" class="calcbutton2" onclick="Validate(\''.$paycode.'\');">'.(!empty($payIcon) ? '<span class="fa fa-2x fa-'.$payIcon.' iconwithlabel"></span>'.(!empty($conf->global->TAKEPOS_NUMPAD_FORCE_PAYMENT_ICONS_LABELS) ? '<br> '. $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[2]->code) : '') : $langs->trans("PaymentTypeShort".$arrayOfValidPaymentModes[2]->code)).'</button>';
 } else {
 	$button = array_pop($action_buttons);
 	print '<button type="button" class="calcbutton2" onclick="'.$button["function"].'"><span '.$button["span"].'>'.$button["text"].'</span></button>';


### PR DESCRIPTION
# Fix #18635

- Only check takepos configuration if a terminal is chosen, to prevent error
- Fix cash payment in some cases. Make pay requests language independent and rely on payment method code.

 Has to be backported to 13.0

