### PR TITLE
TakePos - fast product search

### DIFF
--- a/htdocs/takepos/ajax/ajax.php
+++ b/htdocs/takepos/ajax/ajax.php
@@ -133,7 +133,6 @@ if ($action == 'getProducts') {
 			} else {
 				if (!defined('INCLUDE_PHONEPAGE_FROM_PUBLIC_PAGE')) {
 					$ig = $file.'&cache=1';
-
 				} else {
 					$ig = $file.'&cache=1&publictakepos=1&modulepart=product';
 				}

--- a/htdocs/takepos/ajax/ajax.php
+++ b/htdocs/takepos/ajax/ajax.php
@@ -42,6 +42,7 @@ if (!defined('NOBROWSERNOTIF')) {
 
 require '../../main.inc.php'; // Load $user and permissions
 require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
+require_once DOL_DOCUMENT_ROOT."/product/class/product.class.php";
 
 $category = GETPOST('category', 'alphanohtml');	// Can be id of category or 'supplements'
 $action = GETPOST('action', 'aZ09');
@@ -119,6 +120,25 @@ if ($action == 'getProducts') {
 	if ($resql) {
 		$rows = array();
 		while ($obj = $db->fetch_object($resql)) {
+
+			$objProd = new Product($db);
+			$objProd->fetch($obj->rowid);
+			$image = $objProd->show_photos('product', $conf->product->multidir_output[$objProd->entity], 'small', 1);
+
+			preg_match('@src="([^"]+)"@', $image, $match);
+			$file = array_pop($match);
+
+			if ($file == "") {
+				$ig = '../public/theme/common/nophoto.png';
+			} else {
+				if (!defined('INCLUDE_PHONEPAGE_FROM_PUBLIC_PAGE')) {
+					$ig = $file.'&cache=1';
+
+				} else {
+					$ig = $file.'&cache=1&publictakepos=1&modulepart=product';
+				}
+			}
+
 			$rows[] = array(
 				'rowid' => $obj->rowid,
 				'ref' => $obj->ref,
@@ -127,7 +147,8 @@ if ($action == 'getProducts') {
 				'tobuy' => $obj->tobuy,
 				'barcode' => $obj->barcode,
 				'price' => $obj->price,
-			'object' => 'product'
+				'object' => 'product',
+				'img' => $ig,
 				//'price_formated' => price(price2num($obj->price, 'MU'), 1, $langs, 1, -1, -1, $conf->currency)
 			);
 		}

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -549,7 +549,6 @@ function Search2(keyCodeForEnter) {
 
 		// temporization time to give time to type
 		if (search2_timer) {
-			console.log(search2_timer);
 			clearTimeout(search2_timer);
 		}
 
@@ -583,7 +582,12 @@ function Search2(keyCodeForEnter) {
 						$("#proprice" + i).html(data[i]['price_formated']);
 					}
 					$("#proimg" + i).attr("title", titlestring);
-					$("#proimg" + i).attr("src", "genimg/index.php?query=pro&id=" + data[i]['rowid']);
+					if( undefined !== data[i]['img']) {
+						$("#proimg" + i).attr("src", data[i]['img']);
+					}
+					else {
+						$("#proimg" + i).attr("src", "genimg/index.php?query=pro&id=" + data[i]['rowid']);
+					}
 					$("#prodiv" + i).data("rowid", data[i]['rowid']);
 					$("#prodiv" + i).data("iscat", 0);
 				}

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -178,6 +178,7 @@ var place="<?php echo $place; ?>";
 var editaction="qty";
 var editnumber="";
 var invoiceid=0;
+var search2_timer=null;
 
 /*
 var app = this;
@@ -545,62 +546,72 @@ function Search2(keyCodeForEnter) {
 	}
 
 	if (search === true) {
-		pageproducts = 0;
-		jQuery(".wrapper2 .catwatermark").hide();
-		$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=search&term=' + $('#search').val(), function (data) {
-			for (i = 0; i < <?php echo $MAXPRODUCT ?>; i++) {
-				if (typeof (data[i]) == "undefined") {
-					$("#prodesc" + i).text("");
-					$("#probutton" + i).text("");
-					$("#probutton" + i).hide();
-					$("#proprice" + i).attr("class", "hidden");
-					$("#proprice" + i).html("");
-					$("#proimg" + i).attr("src", "genimg/empty.png");
-					$("#prodiv" + i).data("rowid", "");
-					continue;
+
+		// temporization time to give time to type
+		if (search2_timer) {
+			console.log(search2_timer);
+			clearTimeout(search2_timer);
+		}
+
+		search2_timer = setTimeout(function(){
+
+			pageproducts = 0;
+			jQuery(".wrapper2 .catwatermark").hide();
+			$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=search&term=' + $('#search').val(), function (data) {
+				for (i = 0; i < <?php echo $MAXPRODUCT ?>; i++) {
+					if (typeof (data[i]) == "undefined") {
+						$("#prodesc" + i).text("");
+						$("#probutton" + i).text("");
+						$("#probutton" + i).hide();
+						$("#proprice" + i).attr("class", "hidden");
+						$("#proprice" + i).html("");
+						$("#proimg" + i).attr("src", "genimg/empty.png");
+						$("#prodiv" + i).data("rowid", "");
+						continue;
+					}
+					<?php
+					$titlestring = "'".dol_escape_js($langs->transnoentities('Ref').': ')."' + data[i]['ref']";
+					$titlestring .= " + ' - ".dol_escape_js($langs->trans("Barcode").': ')."' + data[i]['barcode']";
+					?>
+					var titlestring = <?php echo $titlestring; ?>;
+					$("#prodesc" + i).text(data[i]['label']);
+					$("#prodivdesc" + i).show();
+					$("#probutton" + i).text(data[i]['label']);
+					$("#probutton" + i).show();
+					if (data[i]['price_formated']) {
+						$("#proprice" + i).attr("class", "productprice");
+						$("#proprice" + i).html(data[i]['price_formated']);
+					}
+					$("#proimg" + i).attr("title", titlestring);
+					$("#proimg" + i).attr("src", "genimg/index.php?query=pro&id=" + data[i]['rowid']);
+					$("#prodiv" + i).data("rowid", data[i]['rowid']);
+					$("#prodiv" + i).data("iscat", 0);
 				}
-				<?php
-				$titlestring = "'".dol_escape_js($langs->transnoentities('Ref').': ')."' + data[i]['ref']";
-				$titlestring .= " + ' - ".dol_escape_js($langs->trans("Barcode").': ')."' + data[i]['barcode']";
-				?>
-				var titlestring = <?php echo $titlestring; ?>;
-				$("#prodesc" + i).text(data[i]['label']);
-				$("#prodivdesc" + i).show();
-				$("#probutton" + i).text(data[i]['label']);
-				$("#probutton" + i).show();
-				if (data[i]['price_formated']) {
-					$("#proprice" + i).attr("class", "productprice");
-					$("#proprice" + i).html(data[i]['price_formated']);
+			}).always(function (data) {
+				// If there is only 1 answer
+				if ($('#search').val().length > 0 && data.length == 1) {
+					console.log($('#search').val()+' - '+data[0]['barcode']);
+					if ($('#search').val() == data[0]['barcode'] && 'thirdparty' == data[0]['object']) {
+						console.log("There is only 1 answer with barcode matching the search, so we change the thirdparty "+data[0]['rowid']);
+						ChangeThirdparty(data[0]['rowid']);
+					}
+					else if ($('#search').val() == data[0]['barcode'] && 'product' == data[0]['object']) {
+						console.log("There is only 1 answer with barcode matching the search, so we add the product in basket");
+						ClickProduct(0);
+					}
 				}
-				$("#proimg" + i).attr("title", titlestring);
-				$("#proimg" + i).attr("src", "genimg/index.php?query=pro&id=" + data[i]['rowid']);
-				$("#prodiv" + i).data("rowid", data[i]['rowid']);
-				$("#prodiv" + i).data("iscat", 0);
-			}
-		}).always(function (data) {
-			// If there is only 1 answer
-			if ($('#search').val().length > 0 && data.length == 1) {
-				console.log($('#search').val()+' - '+data[0]['barcode']);
-				if ($('#search').val() == data[0]['barcode'] && 'thirdparty' == data[0]['object']) {
-					console.log("There is only 1 answer with barcode matching the search, so we change the thirdparty "+data[0]['rowid']);
-					ChangeThirdparty(data[0]['rowid']);
+				if (eventKeyCode == keyCodeForEnter){
+					if (data.length == 0) {
+						$('#search').val('<?php
+						$langs->load('errors');
+						echo dol_escape_js($langs->trans("ErrorRecordNotFound"));
+						?>');
+						$('#search').select();
+					}
+					else ClearSearch();
 				}
-				else if ($('#search').val() == data[0]['barcode'] && 'product' == data[0]['object']) {
-					console.log("There is only 1 answer with barcode matching the search, so we add the product in basket");
-					ClickProduct(0);
-				}
-			}
-			if (eventKeyCode == keyCodeForEnter){
-				if (data.length == 0) {
-					$('#search').val('<?php
-					$langs->load('errors');
-					echo dol_escape_js($langs->trans("ErrorRecordNotFound"));
-					?>');
-					$('#search').select();
-				}
-				else ClearSearch();
-			}
-		});
+			});
+		}, 700); // 700ms delay
 	}
 
 }


### PR DESCRIPTION
# New Greatly enhances product search

- Add temporization when searching products: Adds a temporization after each typed letter, giving the user 700ms to type next letter before sending the search request. It prevents hammering the server for each typed letter and "results jumping" effect, which is error-prone.

- Set proper image directly when searching products, Bypasses genimg/index.php that either redirects to viewimage.php or to nophoto.png. That was making lots of request to the server and excessive load on the database server, that queues them slowing down the UI.

On my test environment, it gives nearly instantaneous search results.