### PR TITLE
FIX Accountancy - Display good amount for situation line

### DIFF
--- a/htdocs/accountancy/customer/index.php
+++ b/htdocs/accountancy/customer/index.php
@@ -250,18 +250,19 @@ $sql .= "  ".$db->ifsql('aa.label IS NULL', "'tobind'", 'aa.label')." AS intitul
 for ($i = 1; $i <= 12; $i++) {
 	$j = $i + ($conf->global->SOCIETE_FISCAL_MONTH_START ? $conf->global->SOCIETE_FISCAL_MONTH_START : 1) - 1;
 	if ($j > 12) $j -= 12;
-	$sql .= "  SUM(".$db->ifsql('MONTH(f.datef)='.$j, 'fd.total_ht', '0').") AS month".str_pad($j, 2, '0', STR_PAD_LEFT).",";
+	$sql .= "  SUM(".$db->ifsql('MONTH(f.datef)='.$j, $db->ifsql('fd.fk_prev_id IS NOT NULL', 'fd.total_ht-fd2.total_ht', 'fd.total_ht'), '0').") AS month".str_pad($j, 2, '0', STR_PAD_LEFT).",";
 }
-$sql .= "  SUM(fd.total_ht) as total";
+$sql .= "  SUM(".$db->ifsql('fd.fk_prev_id IS NOT NULL', 'fd.total_ht-fd2.total_ht', 'fd.total_ht').") as total";
 $sql .= " FROM ".MAIN_DB_PREFIX."facturedet as fd";
 $sql .= "  LEFT JOIN ".MAIN_DB_PREFIX."facture as f ON f.rowid = fd.fk_facture";
 $sql .= "  LEFT JOIN ".MAIN_DB_PREFIX."accounting_account as aa ON aa.rowid = fd.fk_code_ventilation";
+$sql .= "  LEFT JOIN ".MAIN_DB_PREFIX."facturedet as fd2 ON fd2.rowid = fd.fk_prev_id";
 $sql .= " WHERE f.datef >= '".$db->idate($search_date_start)."'";
 $sql .= "  AND f.datef <= '".$db->idate($search_date_end)."'";
-$sql .= " AND f.fk_statut > 0";
-$sql .= " AND fd.product_type <= 2";
-$sql .= " AND f.entity IN (".getEntity('invoice', 0).")"; // We don't share object for accountancy
-$sql .= " AND aa.account_number IS NULL";
+$sql .= "  AND f.fk_statut > 0";
+$sql .= "  AND fd.product_type <= 2";
+$sql .= "  AND f.entity IN (".getEntity('invoice', 0).")"; // We don't share object for accountancy
+$sql .= "  AND aa.account_number IS NULL";
 if (!empty($conf->global->FACTURE_DEPOSITS_ARE_JUST_PAYMENTS)) {
 	$sql .= " AND f.type IN (".Facture::TYPE_STANDARD.",".Facture::TYPE_REPLACEMENT.",".Facture::TYPE_CREDIT_NOTE.",".Facture::TYPE_SITUATION.")";
 } else {
@@ -326,12 +327,13 @@ $sql .= "  ".$db->ifsql('aa.label IS NULL', "'tobind'", 'aa.label')." AS intitul
 for ($i = 1; $i <= 12; $i++) {
 	$j = $i + ($conf->global->SOCIETE_FISCAL_MONTH_START ? $conf->global->SOCIETE_FISCAL_MONTH_START : 1) - 1;
 	if ($j > 12) $j -= 12;
-	$sql .= "  SUM(".$db->ifsql('MONTH(f.datef)='.$j, 'fd.total_ht', '0').") AS month".str_pad($j, 2, '0', STR_PAD_LEFT).",";
+	$sql .= "  SUM(".$db->ifsql('MONTH(f.datef)='.$j, $db->ifsql('fd.fk_prev_id IS NOT NULL', 'fd.total_ht-fd2.total_ht', 'fd.total_ht'), '0').") AS month".str_pad($j, 2, '0', STR_PAD_LEFT).",";
 }
-$sql .= "  SUM(fd.total_ht) as total";
+$sql .= "  SUM(".$db->ifsql('fd.fk_prev_id IS NOT NULL', 'fd.total_ht-fd2.total_ht', 'fd.total_ht').") as total";
 $sql .= " FROM ".MAIN_DB_PREFIX."facturedet as fd";
 $sql .= "  LEFT JOIN ".MAIN_DB_PREFIX."facture as f ON f.rowid = fd.fk_facture";
 $sql .= "  LEFT JOIN ".MAIN_DB_PREFIX."accounting_account as aa ON aa.rowid = fd.fk_code_ventilation";
+$sql .= "  LEFT JOIN ".MAIN_DB_PREFIX."facturedet as fd2 ON fd2.rowid = fd.fk_prev_id";
 $sql .= " WHERE f.datef >= '".$db->idate($search_date_start)."'";
 $sql .= "  AND f.datef <= '".$db->idate($search_date_end)."'";
 $sql .= " AND f.entity IN (".getEntity('invoice', 0).")"; // We don't share object for accountancy
@@ -404,11 +406,12 @@ if ($conf->global->MAIN_FEATURES_LEVEL > 0) // This part of code looks strange. 
 	for ($i = 1; $i <= 12; $i++) {
 		$j = $i + ($conf->global->SOCIETE_FISCAL_MONTH_START ? $conf->global->SOCIETE_FISCAL_MONTH_START : 1) - 1;
 		if ($j > 12) $j -= 12;
-		$sql .= "  SUM(".$db->ifsql('MONTH(f.datef)='.$j, 'fd.total_ht', '0').") AS month".str_pad($j, 2, '0', STR_PAD_LEFT).",";
+		$sql .= "  SUM(".$db->ifsql('MONTH(f.datef)='.$j, $db->ifsql('fd.fk_prev_id IS NOT NULL', 'fd.total_ht-fd2.total_ht', 'fd.total_ht'), '0').") AS month".str_pad($j, 2, '0', STR_PAD_LEFT).",";
 	}
-	$sql .= "  SUM(fd.total_ht) as total";
+	$sql .= "  SUM(".$db->ifsql('fd.fk_prev_id IS NOT NULL', 'fd.total_ht-fd2.total_ht', 'fd.total_ht').") as total";
 	$sql .= " FROM ".MAIN_DB_PREFIX."facturedet as fd";
 	$sql .= "  LEFT JOIN ".MAIN_DB_PREFIX."facture as f ON f.rowid = fd.fk_facture";
+	$sql .= "  LEFT JOIN ".MAIN_DB_PREFIX."facturedet as fd2 ON fd2.rowid = fd.fk_prev_id";
 	$sql .= " WHERE f.datef >= '".$db->idate($search_date_start)."'";
 	$sql .= "  AND f.datef <= '".$db->idate($search_date_end)."'";
 	$sql .= " AND f.entity IN (".getEntity('invoice', 0).")"; // We don't share object for accountancy
@@ -457,7 +460,7 @@ if ($conf->global->MAIN_FEATURES_LEVEL > 0) // This part of code looks strange. 
 		for ($i = 1; $i <= 12; $i++) {
 			$j = $i + ($conf->global->SOCIETE_FISCAL_MONTH_START ? $conf->global->SOCIETE_FISCAL_MONTH_START : 1) - 1;
 			if ($j > 12) $j -= 12;
-			$sql .= "  SUM(".$db->ifsql('MONTH(f.datef)='.$j, '(fd.total_ht-(fd.qty * fd.buy_price_ht))', '0').") AS month".str_pad($j, 2, '0', STR_PAD_LEFT).",";
+			$sql .= "  SUM(".$db->ifsql('MONTH(f.datef)='.$j, $db->ifsql('fd.fk_prev_id IS NOT NULL', '(fd.total_ht-fd2.total_ht-(fd.qty * fd.buy_price_ht))', '(fd.total_ht-(fd.qty * fd.buy_price_ht))'), '0').") AS month".str_pad($j, 2, '0', STR_PAD_LEFT).",";
 		}
 		$sql .= "  SUM((fd.total_ht-(fd.qty * fd.buy_price_ht))) as total";
 		$sql .= " FROM ".MAIN_DB_PREFIX."facturedet as fd";

--- a/htdocs/accountancy/customer/list.php
+++ b/htdocs/accountancy/customer/list.php
@@ -208,7 +208,7 @@ if (empty($chartaccountcode))
 
 // Customer Invoice lines
 $sql = "SELECT f.rowid as facid, f.ref as ref, f.datef, f.type as ftype,";
-$sql .= " l.rowid, l.fk_product, l.description, l.total_ht, l.fk_code_ventilation, l.product_type as type_l, l.tva_tx as tva_tx_line, l.vat_src_code,";
+$sql .= " l.rowid, l.fk_product, l.description, l.total_ht, l.fk_code_ventilation, l.product_type as type_l, l.tva_tx as tva_tx_line, l.vat_src_code, l.fk_prev_id,";
 $sql .= " p.rowid as product_id, p.ref as product_ref, p.label as product_label, p.fk_product_type as type, p.tva_tx as tva_tx_prod,";
 $sql .= " p.accountancy_code_sell as code_sell, p.accountancy_code_sell_intra as code_sell_intra, p.accountancy_code_sell_export as code_sell_export,";
 $sql .= " p.accountancy_code_buy as code_buy, p.accountancy_code_buy_intra as code_buy_intra, p.accountancy_code_buy_export as code_buy_export,";
@@ -567,6 +567,14 @@ if ($result) {
 		$trunclength = empty($conf->global->ACCOUNTING_LENGTH_DESCRIPTION) ? 32 : $conf->global->ACCOUNTING_LENGTH_DESCRIPTION;
 		print $form->textwithtooltip(dol_trunc($text, $trunclength), $objp->description);
 		print '</td>';
+
+		// Recalculation of the line amount in relation to the progress rate of the situation invoice
+		if (!empty($objp->fk_prev_id)) {
+			$prevLine = new FactureLigne($db);
+			$prevLine->fetch($objp->fk_prev_id);
+
+			$objp->total_ht = $objp->total_ht - $prevLine->total_ht;
+		}
 
 		print '<td class="nowrap right">';
 		print price($objp->total_ht);


### PR DESCRIPTION
Hello,

When we have a situation line from a S2 to bind, amount displayed is the total amount of the situation line without advancement.

### Exemple : 
Advancement : S1 (30% * 50000 €) = **15000 €**    |      S2 (50% * 50000 €) = **25000 €**

Reported sales displayed = 40 000 € (**15000 €** + **25000 €**)

Reported sales real = 25 000 € (**15000 €** + (**25000 €** - **15000 €**))

No problem when you register in accountancy, we work with the total fields of the invoice, not the lines. It's just a display problem on the binding pages

Before : 
![image](https://user-images.githubusercontent.com/2341395/132518888-9be81182-5309-4075-afba-f05dcfb0217f.png)

With this invoice :
![image](https://user-images.githubusercontent.com/2341395/132518984-02ff5657-b63a-40ff-a63c-a97ed3676b26.png)

After : 
![image](https://user-images.githubusercontent.com/2341395/132519130-0ff1699f-8ec1-4704-b289-c1bf78aa8302.png)

-----------------------------------------------
Strictly the same problem on customer index :

Before : 
![image](https://user-images.githubusercontent.com/2341395/132609714-e8a04031-6b95-4207-98dd-55bab771659f.png)


After : 
![image](https://user-images.githubusercontent.com/2341395/132609489-b31dfee0-5835-449f-84c0-054b9034f0c5.png)




