### PR TITLE
fix import of product desc without wrong linebreaks

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3385,7 +3385,7 @@ class Form
 				if (!empty($objp->idprodfournprice) && $objp->idprodfournprice > 0) {
 					$opt .= ' data-qty="'.$objp->quantity.'" data-up="'.$objp->unitprice.'" data-discount="'.$outdiscount.'"';
 				}
-				$opt .= ' data-description="'.dol_escape_htmltag($objp->description).'"';
+				$opt .= ' data-description="'.dol_escape_htmltag($objp->description, 0, 1).'"';
 				$opt .= ' data-html="'.dol_escape_htmltag($optlabel).'"';
 				$opt .= '>';
 


### PR DESCRIPTION
When using predefined products and `PRODUIT_AUTOFILL_DESC = 1` you get the desc set into the textarea to be modified.
Without this fix you get nasty `\n\r` for all line breaks from the DB data