### PR TITLE
Fix  #18604 : fix percentage on variant product

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -715,6 +715,10 @@ class ProductCombination
 			$price_impact = $forced_pricevar;
 		}
 
+		if (!array($price_var_percent)) {
+			$price_var_percent[1] = (float) $price_var_percent;
+		}
+
 		$newcomb = new ProductCombination($this->db);
 		$existingCombination = $newcomb->fetchByProductCombination2ValuePairs($product->id, $combinations);
 
@@ -787,7 +791,7 @@ class ProductCombination
 			$newproduct->description .= '<strong>'.$prodattr->label.':</strong> '.$prodattrval->value;
 		}
 
-		$newcomb->variation_price_percentage = $price_var_percent;
+		$newcomb->variation_price_percentage = $price_var_percent[1];
 		$newcomb->variation_price = $price_impact[1];
 		$newcomb->variation_weight = $weight_impact;
 		$newcomb->variation_ref_ext = $this->db->escape($ref_ext);


### PR DESCRIPTION
fix error "when assigning the price to a product combination, even if the percentage check is not marked, the impact on the price is assigned as a percentage."