### PR TITLE
fix: on Event tabs, if no evt type use in filter, filter on label and state not apply

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1548,7 +1548,7 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon = '', $noprin
 					$sql .= "OR (";
 				}
 				if (!empty($code)) {
-					addEventTypeSQL($sql, $code, $donetodo, $now, $filters, "");
+					addEventTypeSQL($sql, $code);
 				}
 				if ($key != 0) {
 					$sql .= ")";
@@ -1556,8 +1556,10 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon = '', $noprin
 			}
 			$sql .= ')';
 		} elseif (!empty($actioncode)) {
-			addEventTypeSQL($sql, $actioncode, $donetodo, $now, $filters);
+			addEventTypeSQL($sql, $actioncode);
 		}
+
+		addOtherFilterSQL($sql, $donetodo, $now, $filters);
 
 		if (is_array($actioncode)) {
 			foreach ($actioncode as $code) {
@@ -2021,13 +2023,10 @@ function show_subsidiaries($conf, $langs, $db, $object)
  *
  *		@param	string		$sql		    $sql modified
  * 		@param	string	    $actioncode		Action code
- * 		@param	string		$donetodo		donetodo
- * 		@param	string		$now		    now
- * 		@param	string		$filters		array
  * 		@param	string		$sqlANDOR		"AND", "OR" or "" sql condition
  * 		@return	string      sql request
  */
-function addEventTypeSQL(&$sql, $actioncode, $donetodo, $now, $filters, $sqlANDOR = "AND")
+function addEventTypeSQL(&$sql, $actioncode, $sqlANDOR = "AND")
 {
 	global $conf, $db;
 	// Condition on actioncode
@@ -2053,6 +2052,23 @@ function addEventTypeSQL(&$sql, $actioncode, $donetodo, $now, $filters, $sqlANDO
 			$sql .= " $sqlANDOR c.code = '".$db->escape($actioncode)."'";
 		}
 	}
+
+	return $sql;
+}
+
+/**
+ * 		Add Event Type SQL
+ *
+ *		@param	string		$sql		    $sql modified
+ * 		@param	string		$donetodo		donetodo
+ * 		@param	string		$now		    now
+ * 		@param	string		$filters		array
+ * 		@return	string      sql request
+ */
+function addOtherFilterSQL(&$sql, $donetodo, $now, $filters)
+{
+	global $conf, $db;
+	// Condition on actioncode
 
 	if ($donetodo == 'todo') {
 		$sql .= " AND ((a.percent >= 0 AND a.percent < 100) OR (a.percent = -1 AND a.datep > '".$db->idate($now)."'))";


### PR DESCRIPTION
fix: on Event tabs, if no evt type use in filter, filter on label and state not apply

For exemple on projet/info.php 
filter on label do not apply if no type evt filter is selected