### PR TITLE
 FIX Accountancy - Format Quadra export - Missing line type C to create automaticly a subledger account with label

### DIFF
--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -543,7 +543,7 @@ class AccountancyExport
 
 			$Tab = array();
 
-			if (!empty($data->subledger_account)){
+			if (!empty($data->subledger_account)) {
 				$Tab['type_ligne'] = 'C';
 				$Tab['num_compte'] = str_pad(self::trunc($data->subledger_account, 8), 8);
 				$Tab['lib_compte'] = str_pad(self::trunc($data->subledger_label, 30), 30);

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -547,18 +547,22 @@ class AccountancyExport
 				$Tab['type_ligne'] = 'C';
 				$Tab['num_compte'] = str_pad(self::trunc($data->subledger_account, 8), 8);
 				$Tab['lib_compte'] = str_pad(self::trunc($data->subledger_label, 30), 30);
-				$Tab['filler'] = str_repeat(' ', 59);
 
 				if ($data->doc_type == 'customer_invoice') {
+					$Tab['lib_alpha'] = strtoupper(str_pad('C'.self::trunc($data->subledger_label, 6), 6));
+					$Tab['filler'] = str_repeat(' ', 52);
 					$Tab['coll_compte'] = str_pad(self::trunc($conf->global->ACCOUNTING_ACCOUNT_CUSTOMER, 8), 8);
 				} elseif ($data->doc_type == 'supplier_invoice') {
+					$Tab['lib_alpha'] = strtoupper(str_pad('F'.self::trunc($data->subledger_label, 6), 6));
+					$Tab['filler'] = str_repeat(' ', 52);
 					$Tab['coll_compte'] = str_pad(self::trunc($conf->global->ACCOUNTING_ACCOUNT_SUPPLIER, 8), 8);
 				} else {
+					$Tab['filler'] = str_repeat(' ', 59);
 					$Tab['coll_compte'] = str_pad(' ', 8);
 				}
 
 				$Tab['filler2'] = str_repeat(' ', 110);
-				$Tab['Maj'] = 2; // Maj partielle (clé alpha, intitulé, adresse, collectif, RIB)
+				$Tab['Maj'] = 2; // Partial update (alpha key, label, address, collectif, RIB)
 
 				if ($data->doc_type == 'customer_invoice') {
 					$Tab['type_compte'] = 'C';

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -516,14 +516,19 @@ class AccountancyExport
 	}
 
 	/**
-	 * Export format : Quadratus
+	 * Export format : Quadratus (Format ASCII)
+	 * Format since 2015 compatible QuadraCOMPTA
+	 * Last review for this format : 2021/09/13 Alexandre Spangaro (aspangaro@open-dsi.fr)
+	 *
+	 * Help : https://docplayer.fr/20769649-Fichier-d-entree-ascii-dans-quadracompta.html
+	 * In QuadraCompta | Use menu : "Outils" > "Suivi des dossiers" > "Import ASCII(Compta)"
 	 *
 	 * @param array $TData data
 	 * @return void
 	 */
 	public function exportQuadratus(&$TData)
 	{
-		global $conf;
+		global $conf, $db;
 
 		$end_line = "\r\n";
 
@@ -534,6 +539,40 @@ class AccountancyExport
 			$code_compta = $data->numero_compte;
 			if (!empty($data->subledger_account)) {
 				$code_compta = $data->subledger_account;
+			}
+
+			$Tab = array();
+
+			if (!empty($data->subledger_account)){
+				$Tab['type_ligne'] = 'C';
+				$Tab['num_compte'] = str_pad(self::trunc($data->subledger_account, 8), 8);
+				$Tab['lib_compte'] = str_pad(self::trunc($data->subledger_label, 30), 30);
+				$Tab['filler'] = str_repeat(' ', 59);
+
+				if ($data->doc_type == 'customer_invoice') {
+					$Tab['coll_compte'] = str_pad(self::trunc($conf->global->ACCOUNTING_ACCOUNT_CUSTOMER, 8), 8);
+				} elseif ($data->doc_type == 'supplier_invoice') {
+					$Tab['coll_compte'] = str_pad(self::trunc($conf->global->ACCOUNTING_ACCOUNT_SUPPLIER, 8), 8);
+				} else {
+					$Tab['coll_compte'] = str_pad(' ', 8);
+				}
+
+				$Tab['filler2'] = str_repeat(' ', 110);
+				$Tab['Maj'] = 2; // Maj partielle (clé alpha, intitulé, adresse, collectif, RIB)
+
+				if ($data->doc_type == 'customer_invoice') {
+					$Tab['type_compte'] = 'C';
+				} elseif ($data->doc_type == 'supplier_invoice') {
+					$Tab['coll_compte'] = 'F';
+				} else {
+					$Tab['coll_compte'] = 'G';
+				}
+
+				$Tab['filler3'] = str_repeat(' ', 235);
+
+				$Tab['end_line'] = $end_line;
+
+				print implode($Tab);
 			}
 
 			$Tab = array();


### PR DESCRIPTION
Rendering of the import in the chart of accounts of the subledger accounts in the QuadraCOMPTA software without line type C:

![image](https://user-images.githubusercontent.com/2341395/133143440-d487ba08-bc67-4149-9478-e57b38f85224.png)
