### PR TITLE
Fix: On payment list, not filter by company when it is an external user

### DIFF
--- a/htdocs/compta/paiement/list.php
+++ b/htdocs/compta/paiement/list.php
@@ -6,7 +6,7 @@
  * Copyright (C) 2015		Jean-François Ferry		<jfefe@aternatik.fr>
  * Copyright (C) 2015		Juanjo Menent			<jmenent@2byte.es>
  * Copyright (C) 2017		Alexandre Spangaro		<aspangaro@open-dsi.fr>
- * Copyright (C) 2018		Ferran Marcet			<fmarcet@2byte.es>
+ * Copyright (C) 2018-2021	Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2018		Charlene Benke			<charlie@patas-monkey.com>
  * Copyright (C) 2020		Tobias Sekan			<tobias.sekan@startmail.com>
  *
@@ -31,11 +31,6 @@
  */
 
 require '../../main.inc.php';
-
-// Security check
-if ($user->socid) $socid = $user->socid;
-$result = restrictedArea($user, 'facture', $facid, '');
-
 require_once DOL_DOCUMENT_ROOT.'/compta/paiement/class/paiement.class.php';
 require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
@@ -57,6 +52,10 @@ $userid = GETPOST('userid', 'int');
 $day = GETPOST('day', 'int');
 $month				= GETPOST('month', 'int');
 $year = GETPOST('year', 'int');
+
+// Security check
+if ($user->socid) $socid = $user->socid;
+$result = restrictedArea($user, 'facture', $facid, '');
 
 $search_ref = GETPOST("search_ref", "alpha");
 $search_company		= GETPOST("search_company", 'alpha');

--- a/htdocs/fourn/paiement/list.php
+++ b/htdocs/fourn/paiement/list.php
@@ -35,8 +35,7 @@
 
 require '../../main.inc.php';
 
-// Security check
-if ($user->socid) $socid = $user->socid;
+
 
 // doesn't work :-(
 // restrictedArea($user, 'fournisseur');
@@ -63,6 +62,9 @@ $optioncss = GETPOST('optioncss', 'alpha');
 $contextpage			= GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'vendorpaymentlist';
 
 $socid = GETPOST('socid', 'int');
+
+// Security check
+if ($user->socid) $socid = $user->socid;
 
 $search_ref				= GETPOST('search_ref', 'alpha');
 $search_day				= GETPOST('search_day', 'int');


### PR DESCRIPTION
You can see all payments because the variable $socid does not keep the value of the external user's company