### PR TITLE
Fix ldap passw bug with activedirectory

### DIFF
--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -486,10 +486,10 @@ class Ldap
 		// For better compatibility with Samba4 AD
 		if ($this->serverType == "activedirectory") {
 			unset($info['cn']); // To avoid error : Operation not allowed on RDN (Code 67)
-						
+
 			// To avoid error : LDAP Error: 53 (Unwilling to perform)
-			if(isset($info['unicodePwd'])){
-				$info['unicodePwd'] = mb_convert_encoding("\"".$info['unicodePwd']."\"", "UTF-16LE", "UTF-8"); 
+			if (isset($info['unicodePwd'])) {
+				$info['unicodePwd'] = mb_convert_encoding("\"".$info['unicodePwd']."\"", "UTF-16LE", "UTF-8");
 			}
 		}
 		$result = @ldap_modify($this->connection, $dn, $info);

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -486,7 +486,11 @@ class Ldap
 		// For better compatibility with Samba4 AD
 		if ($this->serverType == "activedirectory") {
 			unset($info['cn']); // To avoid error : Operation not allowed on RDN (Code 67)
-			$info['unicodePwd'] = mb_convert_encoding("\"".$info['unicodePwd']."\"", "UTF-16LE", "UTF-8"); // To avoid error : LDAP Error: 53 (Unwilling to perform)
+						
+			// To avoid error : LDAP Error: 53 (Unwilling to perform)
+			if(isset($info['unicodePwd'])){
+				$info['unicodePwd'] = mb_convert_encoding("\"".$info['unicodePwd']."\"", "UTF-16LE", "UTF-8"); 
+			}
 		}
 		$result = @ldap_modify($this->connection, $dn, $info);
 

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -486,6 +486,7 @@ class Ldap
 		// For better compatibility with Samba4 AD
 		if ($this->serverType == "activedirectory") {
 			unset($info['cn']); // To avoid error : Operation not allowed on RDN (Code 67)
+			$info['unicodePwd'] = mb_convert_encoding("\"".$info['unicodePwd']."\"", "UTF-16LE", "UTF-8"); // To avoid error : LDAP Error: 53 (Unwilling to perform)
 		}
 		$result = @ldap_modify($this->connection, $dn, $info);
 


### PR DESCRIPTION
Fix to avoid LDAP Error: 53 (Unwilling to perform) on Samba4 AD

# Fix Bug on LDAP Samba4 AD when creating or updating password
Format was wrong creating LDAP Error: 53 (Unwilling to perform)

