### PR TITLE
Fix Warehouse PDF Generation Error

### DIFF
--- a/htdocs/core/modules/stock/doc/pdf_standard.modules.php
+++ b/htdocs/core/modules/stock/doc/pdf_standard.modules.php
@@ -208,8 +208,6 @@ class pdf_standard extends ModelePDFStock
 		// Load traductions files required by page
 		$outputlangs->loadLangs(array("main", "dict", "companies", "bills", "stocks", "orders", "deliveries"));
 
-		$nblines = count($object->lines);
-
 		if ($conf->stock->dir_output) {
 			// Definition of $dir and $file
 			if ($object->specimen) {


### PR DESCRIPTION
Fixes the following warning received when attempting to generate a warehouse stock document using the default template:
`count(): Parameter must be an array or an object that implements Countable in /var/www/html/core/modules/stock/doc/pdf_standard.modules.php on line 211`.

$nblines is subsequently assigned on line 326, after which it is used.