### PR TITLE
Fix: #18760 bad rights admin if advanced perms

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1041,14 +1041,16 @@ if (!defined('NOLOGIN')) {
 		$user->rights->user->self->password = 1;
 
 		//Required if advanced permissions are used with MAIN_USE_ADVANCED_PERMS
-		$user->rights->user->user_advance->readperms = 1;
-		$user->rights->user->user_advance->write = 1;
-		$user->rights->user->self_advance->readperms = 1;
-		$user->rights->user->self_advance->writeperms = 1;
-		$user->rights->user->group_advance->read = 1;
-		$user->rights->user->group_advance->readperms = 1;
-		$user->rights->user->group_advance->write = 1;
-		$user->rights->user->group_advance->delete = 1;
+		if (!empty($conf->global->MAIN_USE_ADVANCED_PERMS)) {
+			$user->rights->user->user_advance->readperms = 1;
+			$user->rights->user->user_advance->write = 1;
+			$user->rights->user->self_advance->readperms = 1;
+			$user->rights->user->self_advance->writeperms = 1;
+			$user->rights->user->group_advance->read = 1;
+			$user->rights->user->group_advance->readperms = 1;
+			$user->rights->user->group_advance->write = 1;
+			$user->rights->user->group_advance->delete = 1;
+		}
 	}
 
 	/*

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1039,6 +1039,16 @@ if (!defined('NOLOGIN')) {
 		$user->rights->user->user->supprimer = 1;
 		$user->rights->user->self->creer = 1;
 		$user->rights->user->self->password = 1;
+		
+		//Required if advanced permissions are used with MAIN_USE_ADVANCED_PERMS
+		$user->rights->user->user_advance->readperms = 1;
+		$user->rights->user->user_advance->write = 1;
+		$user->rights->user->self_advance->readperms = 1;
+		$user->rights->user->self_advance->writeperms = 1;
+		$user->rights->user->group_advance->read = 1;
+		$user->rights->user->group_advance->readperms = 1;
+		$user->rights->user->group_advance->write = 1;
+		$user->rights->user->group_advance->delete = 1;
 	}
 
 	/*

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1039,7 +1039,7 @@ if (!defined('NOLOGIN')) {
 		$user->rights->user->user->supprimer = 1;
 		$user->rights->user->self->creer = 1;
 		$user->rights->user->self->password = 1;
-		
+
 		//Required if advanced permissions are used with MAIN_USE_ADVANCED_PERMS
 		$user->rights->user->user_advance->readperms = 1;
 		$user->rights->user->user_advance->write = 1;


### PR DESCRIPTION
Insufficient rights to view a group's card for admin users if advanced permissions are used

# Fix #18760 bad rights admin if advanced perms
Insufficient rights to view a group's card for admin users if advanced permissions are used
