### PR TITLE
Add turnover homepage box

### DIFF
--- a/htdocs/compta/facture/class/facturestats.class.php
+++ b/htdocs/compta/facture/class/facturestats.class.php
@@ -281,8 +281,7 @@ class FactureStats extends Stats
 		$startYear = $endYear - $numberYears;
 		$sql = "SELECT date_format(datef,'%Y') as dm, SUM(f.".$this->field.")";
 		$sql .= " FROM ".$this->from;
-		if (!$user->rights->societe->client->voir && !$this->socid)
-		{
+		if (!$user->rights->societe->client->voir && !$this->socid) {
 			$sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 		}
 		$sql .= $this->join;

--- a/htdocs/compta/facture/class/facturestats.class.php
+++ b/htdocs/compta/facture/class/facturestats.class.php
@@ -266,4 +266,32 @@ class FactureStats extends Stats
 
 		return $this->_getAllByProduct($sql, $limit);
 	}
+	/**
+	 *      Return the invoices amount by year for a number of past years
+	 *
+	 *      @param  int             $numberYears    Years to scan
+	 *      @param  int             $format         0=Label of abscissa is a translated text, 1=Label of abscissa is year, 2=Label of abscissa is last number of year
+	 *      @return array                           Array with amount by year
+	 */
+	public function getAmountByYear($numberYears, $format = 0)
+	{
+		global $user;
+
+		$endYear = date('Y');
+		$startYear = $endYear - $numberYears;
+		$sql = "SELECT date_format(datef,'%Y') as dm, SUM(f.".$this->field.")";
+		$sql .= " FROM ".$this->from;
+		if (!$user->rights->societe->client->voir && !$this->socid)
+		{
+			$sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
+		}
+		$sql .= $this->join;
+		$sql .= " WHERE f.datef BETWEEN '".$this->db->idate(dol_get_first_day($startYear))."' AND '".$this->db->idate(dol_get_last_day($endYear))."'";
+		$sql .= " AND ".$this->where;
+		$sql .= " GROUP BY dm";
+		$sql .= $this->db->order('dm', 'ASC');
+
+		$res = $this->_getAmountByYear($sql);
+		return $res;
+	}
 }

--- a/htdocs/core/boxes/box_graph_invoices_peryear.php
+++ b/htdocs/core/boxes/box_graph_invoices_peryear.php
@@ -117,7 +117,6 @@ class box_graph_invoices_peryear extends ModeleBoxes
 			if (empty($endyear)) $endyear = $nowarray['year'];
 			$numberyears = (empty($conf->global->MAIN_NB_OF_YEAR_IN_WIDGET_GRAPH) ? 5 : $conf->global->MAIN_NB_OF_YEAR_IN_WIDGET_GRAPH);
 			$startyear = $endyear - $numberyears;
-			$endyear =
 
 			$mode = 'customer';
 			$WIDTH = (($showtot) || !empty($conf->dol_optimize_smallscreen)) ? '256' : '320';

--- a/htdocs/core/boxes/box_graph_invoices_peryear.php
+++ b/htdocs/core/boxes/box_graph_invoices_peryear.php
@@ -1,0 +1,223 @@
+<?php
+/* Copyright (C) 2013 Laurent Destailleur  <eldy@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *	\file       htdocs/core/boxes/box_graph_invoices_peryear.php
+ *	\ingroup    factures
+ *	\brief      Box to show graph of invoices per year
+ */
+include_once DOL_DOCUMENT_ROOT.'/core/boxes/modules_boxes.php';
+
+
+/**
+ * Class to manage the box to show last invoices
+ */
+class box_graph_invoices_peryear extends ModeleBoxes
+{
+	public $boxcode = "invoicesperyear";
+	public $boximg = "object_bill";
+	public $boxlabel = "BoxCustomersInvoicesPerYear";
+	public $depends = array("facture");
+
+	/**
+	 * @var DoliDB Database handler.
+	 */
+	public $db;
+
+	public $info_box_head = array();
+	public $info_box_contents = array();
+
+
+	/**
+	 *  Constructor
+	 *
+	 * 	@param	DoliDB	$db			Database handler
+	 *  @param	string	$param		More parameters
+	 */
+	public function __construct($db, $param)
+	{
+		global $user;
+
+		$this->db = $db;
+
+		$this->hidden = !($user->rights->facture->lire);
+	}
+
+	/**
+	 *  Load data into info_box_contents array to show array later.
+	 *
+	 *  @param	int		$max        Maximum number of records to load
+	 *  @return	void
+	 */
+	public function loadBox($max = 5)
+	{
+		global $conf, $user, $langs;
+
+		$this->max = $max;
+
+		$refreshaction = 'refresh_'.$this->boxcode;
+
+		//include_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
+		//$facturestatic=new Facture($this->db);
+
+		$startmonth = $conf->global->SOCIETE_FISCAL_MONTH_START ? ($conf->global->SOCIETE_FISCAL_MONTH_START) : 1;
+		if (empty($conf->global->GRAPH_USE_FISCAL_YEAR)) $startmonth = 1;
+
+		$text = $langs->trans("Turnover", $max);
+		$this->info_box_head = array(
+			'text' => $text,
+			'limit'=> dol_strlen($text),
+			'graph'=> 1,
+			'sublink'=>'',
+			'subtext'=>$langs->trans("Filter"),
+			'subpicto'=>'filter.png',
+			'subclass'=>'linkobject boxfilter',
+			'target'=>'none'	// Set '' to get target="_blank"
+		);
+
+		$dir = ''; // We don't need a path because image file will not be saved into disk
+		$prefix = '';
+		$socid = 0;
+		if ($user->socid) $socid = $user->socid;
+		if (!$user->rights->societe->client->voir || $socid) $prefix .= 'private-'.$user->id.'-'; // If user has no permission to see all, output dir is specific to user
+
+		if ($user->rights->facture->lire)
+		{
+			$mesg = '';
+
+			$param_year = 'DOLUSERCOOKIE_box_'.$this->boxcode.'_year';
+			$param_showtot = 'DOLUSERCOOKIE_box_'.$this->boxcode.'_showtot';
+
+			include_once DOL_DOCUMENT_ROOT.'/core/class/dolgraph.class.php';
+			include_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facturestats.class.php';
+			$autosetarray = preg_split("/[,;:]+/", GETPOST('DOL_AUTOSET_COOKIE'));
+			if (in_array('DOLUSERCOOKIE_box_'.$this->boxcode, $autosetarray))
+			{
+				$endyear = GETPOST($param_year, 'int');
+				$showtot = GETPOST($param_showtot, 'alpha');
+			} else {
+				$tmparray = json_decode($_COOKIE['DOLUSERCOOKIE_box_'.$this->boxcode], true);
+				$endyear = $tmparray['year'];
+				$showtot = $tmparray['showtot'];
+			}
+			if (empty($showtot)) { $showtot = 1; }
+			$nowarray = dol_getdate(dol_now(), true);
+			if (empty($endyear)) $endyear = $nowarray['year'];
+			$numberyears = (empty($conf->global->MAIN_NB_OF_YEAR_IN_WIDGET_GRAPH) ? 5 : $conf->global->MAIN_NB_OF_YEAR_IN_WIDGET_GRAPH);
+			$startyear = $endyear - $numberyears;
+			$endyear = 
+
+			$mode = 'customer';
+			$WIDTH = (($showtot) || !empty($conf->dol_optimize_smallscreen)) ? '256' : '320';
+			$HEIGHT = '192';
+
+			$stats = new FactureStats($this->db, $socid, $mode, 0);
+
+			// Build graphic amount of object. $data = array(array('Lib',val1,val2,val3),...)
+			$data2 = $stats->getAmountByYear($numberyears);
+
+			$filenamenb = $dir."/".$prefix."invoicesamountyears-".$endyear.".png";
+			// default value for customer mode
+			$fileurlnb = DOL_URL_ROOT.'/viewimage.php?modulepart=billstats&amp;file=invoicesamountyears-'.$endyear.'.png';
+			if ($mode == 'supplier') $fileurlnb = DOL_URL_ROOT.'/viewimage.php?modulepart=billstatssupplier&amp;file=invoicessupplieramountyears-'.$endyear.'.png';
+
+			$px2 = new DolGraph();
+			$mesg = $px2->isGraphKo();
+			if (!$mesg)
+			{
+				$langs->load("bills");
+
+				$px2->SetData($data2);
+				unset($data2);
+				$i = $startyear;
+				$legend = array();
+				while ($i <= $endyear)
+				{
+					if ($startmonth != 1)
+					{
+						$legend[] = sprintf("%d/%d", $i - 2001, $i - 2000);
+					} else {
+						$legend[] = $i;
+					}
+					$i++;
+				}
+				$px2->SetLegend([$langs->trans("AmountOfBillsHT")]);
+				$px2->SetMaxValue($px2->GetCeilMaxValue());
+				$px2->SetWidth($WIDTH);
+				$px2->SetHeight($HEIGHT);
+				$px2->SetYLabel($langs->trans("AmountOfBillsHT"));
+				$px2->SetShading(3);
+				$px2->SetHorizTickIncrement(1);
+				$px2->SetCssPrefix("cssboxes");
+				$px2->mode = 'depth';
+				$px2->SetTitle($langs->trans("Turnover"));
+
+				$px2->draw($filenamenb, $fileurlnb);
+			}
+
+			if (empty($conf->use_javascript_ajax))
+			{
+				$langs->load("errors");
+				$mesg = $langs->trans("WarningFeatureDisabledWithDisplayOptimizedForBlindNoJs");
+			}
+
+			if (!$mesg)
+			{
+				$stringtoshow = '';
+				$stringtoshow .= '<script type="text/javascript" language="javascript">
+					jQuery(document).ready(function() {
+						jQuery("#idsubimg'.$this->boxcode.'").click(function() {
+							jQuery("#idfilter'.$this->boxcode.'").toggle();
+						});
+					});
+					</script>';
+				$stringtoshow .= '<div class="center hideobject" id="idfilter'.$this->boxcode.'">'; // hideobject is to start hidden
+				$stringtoshow .= '<form class="flat formboxfilter" method="POST" action="'.$_SERVER["PHP_SELF"].'">';
+				$stringtoshow .= '<input type="hidden" name="token" value="'.newToken().'">';
+				$stringtoshow .= '<input type="hidden" name="action" value="'.$refreshaction.'">';
+				$stringtoshow .= '<input type="hidden" name="page_y" value="">';
+				$stringtoshow .= '<input type="hidden" name="DOL_AUTOSET_COOKIE" value="DOLUSERCOOKIE_box_'.$this->boxcode.':year,showtot">';
+				$stringtoshow .= $langs->trans("Year").' <input class="flat" size="4" type="text" name="'.$param_year.'" value="'.$endyear.'">';
+				$stringtoshow .= '<input class="reposition inline-block valigntextbottom" type="image" alt="'.$langs->trans("Refresh").'" src="'.img_picto($langs->trans("Refresh"), 'refresh.png', '', '', 1).'">';
+				$stringtoshow .= '</form>';
+				$stringtoshow .= '</div>';
+				$stringtoshow .= $px2->show();
+				$this->info_box_contents[0][0] = array('tr'=>'class="oddeven nohover"', 'td' => 'class="nohover center"', 'textnoformat'=>$stringtoshow);
+			} else {
+				$this->info_box_contents[0][0] = array('tr'=>'class="oddeven nohover"', 'td' => 'class="nohover left"', 'maxlength'=>500, 'text' => $mesg);
+			}
+		} else {
+			$this->info_box_contents[0][0] = array(
+				'td' => 'class="nohover left"',
+				'text' => '<span class="opacitymedium">'.$langs->trans("ReadPermissionNotAllowed").'</span>'
+			);
+		}
+	}
+
+	/**
+	 *	Method to show box
+	 *
+	 *	@param	array	$head       Array with properties of box title
+	 *	@param  array	$contents   Array with properties of box lines
+	 *  @param	int		$nooutput	No print, only return string
+	 *	@return	string
+	 */
+	public function showBox($head = null, $contents = null, $nooutput = 0)
+	{
+		return parent::showBox($this->info_box_head, $this->info_box_contents, $nooutput);
+	}
+}

--- a/htdocs/core/boxes/box_graph_invoices_peryear.php
+++ b/htdocs/core/boxes/box_graph_invoices_peryear.php
@@ -95,8 +95,7 @@ class box_graph_invoices_peryear extends ModeleBoxes
 		if ($user->socid) $socid = $user->socid;
 		if (!$user->rights->societe->client->voir || $socid) $prefix .= 'private-'.$user->id.'-'; // If user has no permission to see all, output dir is specific to user
 
-		if ($user->rights->facture->lire)
-		{
+		if ($user->rights->facture->lire) {
 			$mesg = '';
 
 			$param_year = 'DOLUSERCOOKIE_box_'.$this->boxcode.'_year';
@@ -105,8 +104,7 @@ class box_graph_invoices_peryear extends ModeleBoxes
 			include_once DOL_DOCUMENT_ROOT.'/core/class/dolgraph.class.php';
 			include_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facturestats.class.php';
 			$autosetarray = preg_split("/[,;:]+/", GETPOST('DOL_AUTOSET_COOKIE'));
-			if (in_array('DOLUSERCOOKIE_box_'.$this->boxcode, $autosetarray))
-			{
+			if (in_array('DOLUSERCOOKIE_box_'.$this->boxcode, $autosetarray)) {
 				$endyear = GETPOST($param_year, 'int');
 				$showtot = GETPOST($param_showtot, 'alpha');
 			} else {
@@ -119,7 +117,7 @@ class box_graph_invoices_peryear extends ModeleBoxes
 			if (empty($endyear)) $endyear = $nowarray['year'];
 			$numberyears = (empty($conf->global->MAIN_NB_OF_YEAR_IN_WIDGET_GRAPH) ? 5 : $conf->global->MAIN_NB_OF_YEAR_IN_WIDGET_GRAPH);
 			$startyear = $endyear - $numberyears;
-			$endyear = 
+			$endyear =
 
 			$mode = 'customer';
 			$WIDTH = (($showtot) || !empty($conf->dol_optimize_smallscreen)) ? '256' : '320';
@@ -137,18 +135,15 @@ class box_graph_invoices_peryear extends ModeleBoxes
 
 			$px2 = new DolGraph();
 			$mesg = $px2->isGraphKo();
-			if (!$mesg)
-			{
+			if (!$mesg) {
 				$langs->load("bills");
 
 				$px2->SetData($data2);
 				unset($data2);
 				$i = $startyear;
 				$legend = array();
-				while ($i <= $endyear)
-				{
-					if ($startmonth != 1)
-					{
+				while ($i <= $endyear) {
+					if ($startmonth != 1) {
 						$legend[] = sprintf("%d/%d", $i - 2001, $i - 2000);
 					} else {
 						$legend[] = $i;
@@ -169,14 +164,12 @@ class box_graph_invoices_peryear extends ModeleBoxes
 				$px2->draw($filenamenb, $fileurlnb);
 			}
 
-			if (empty($conf->use_javascript_ajax))
-			{
+			if (empty($conf->use_javascript_ajax)) {
 				$langs->load("errors");
 				$mesg = $langs->trans("WarningFeatureDisabledWithDisplayOptimizedForBlindNoJs");
 			}
 
-			if (!$mesg)
-			{
+			if (!$mesg) {
 				$stringtoshow = '';
 				$stringtoshow .= '<script type="text/javascript" language="javascript">
 					jQuery(document).ready(function() {

--- a/htdocs/core/class/stats.class.php
+++ b/htdocs/core/class/stats.class.php
@@ -617,4 +617,34 @@ abstract class Stats
 
 		return $result;
 	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
+    /**
+	 *  Returns the summed amounts per year for a given number of past years ending now
+	 *  @param  string  $sql    SQL
+	 *  @return array
+	 */
+	function _getAmountByYear($sql)
+	{
+		$result = array();
+		$resql = $this->db->query($sql);
+		if ($resql)
+		{
+			$num = $this->db->num_rows($resql);
+			$i = 0;
+			while ($i < $num)
+			{
+				$row = $this->db->fetch_row($resql);
+				$j = (int) $row[0];
+				$result[] = [
+					0 => (int) $row[0],
+					1 => (int) $row[1],
+				];
+				$i++;
+			}
+			$this->db->free($resql);
+		}
+		return $result;
+	}
+
 }

--- a/htdocs/core/class/stats.class.php
+++ b/htdocs/core/class/stats.class.php
@@ -619,7 +619,7 @@ abstract class Stats
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
-    /**
+	/**
 	 *  Returns the summed amounts per year for a given number of past years ending now
 	 *  @param  string  $sql    SQL
 	 *  @return array
@@ -628,12 +628,10 @@ abstract class Stats
 	{
 		$result = array();
 		$resql = $this->db->query($sql);
-		if ($resql)
-		{
+		if ($resql) {
 			$num = $this->db->num_rows($resql);
 			$i = 0;
-			while ($i < $num)
-			{
+			while ($i < $num) {
 				$row = $this->db->fetch_row($resql);
 				$j = (int) $row[0];
 				$result[] = [
@@ -646,5 +644,4 @@ abstract class Stats
 		}
 		return $result;
 	}
-
 }

--- a/htdocs/core/class/stats.class.php
+++ b/htdocs/core/class/stats.class.php
@@ -624,7 +624,7 @@ abstract class Stats
 	 *  @param  string  $sql    SQL
 	 *  @return array
 	 */
-	function _getAmountByYear($sql)
+	protected function _getAmountByYear($sql)
 	{
 		$result = array();
 		$resql = $this->db->query($sql);


### PR DESCRIPTION
# New Turnover widget
This widget, largely inspired by the "customer invoices per month" widget, adds a chart of the company's turnover for the last `x` years (`x` defined by `MAIN_NB_OF_YEAR_IN_WIDGET_GRAPH`).

It is missing an addition to the `boxes_def` table, which I don't know how to do properly (I guess this is part of an upgrade script somewhere), but adding it without this doesn't break anything.
I inserted it manually using `box_graph_invoices_peryear.php` in the `file` field.