### PR TITLE
FIX #18767 : Adherent delete

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -513,8 +513,8 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 				if (!$user->rights->salaries->delete) {
 					$deleteok = 0;
 				}
-			} elseif ($feature == 'salaries') {
-				if (!$user->rights->salaries->delete) {
+			} elseif ($feature == 'adherent') {
+				if (!$user->rights->adherent->supprimer) {
 					$deleteok = 0;
 				}
 			} elseif (!empty($feature2)) {							// This is for permissions on 2 levels


### PR DESCRIPTION
Adherent Delete was not working due to the fact that 
$features = 'adherent';
$feature2 = 'cotisation';
And $user->rights->$feature->$subfeature->supprimer does not exist

Also I used the double declaration of salaries, one time is enough.
