### PR TITLE
NEW: minimum php version is now 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"vendor-dir" : "htdocs/includes"
 	},
 	"require" : {
-		"php" : ">=5.6.0",
+		"php" : ">=7.3.0",
 		"ext-curl" : "*",
 		"ckeditor/ckeditor" : "4.12.1",
 		"mike42/escpos-php" : "2.2",

--- a/htdocs/install/check.php
+++ b/htdocs/install/check.php
@@ -81,8 +81,8 @@ if (!empty($useragent)) {
 
 
 // Check PHP version
-$arrayphpminversionerror = array(5, 5, 0);
-$arrayphpminversionwarning = array(5, 6, 0);
+$arrayphpminversionerror = array(7, 3, 0);
+$arrayphpminversionwarning = array(7, 3, 0);
 if (versioncompare(versionphparray(), $arrayphpminversionerror) < 0) {        // Minimum to use (error if lower)
 	print '<img src="../theme/eldy/img/error.png" alt="Error" class="valignmiddle"> '.$langs->trans("ErrorPHPVersionTooLow", versiontostring($arrayphpminversionerror));
 	$checksok = 0; // 0=error, 1=warning


### PR DESCRIPTION
As preview version of PHP is not supported anymore https://www.php.net/supported-versions.php we need to set minimum php version to 7.3