### PR TITLE
Close: #18801 Jan-30 + 1m IS NOT Mar-2

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -181,9 +181,9 @@ function dol_time_plus_duree($time, $duration_value, $duration_unit)
 		$newtimetotalmonths = (($newtimeyear * 12) + $newtimemonth);
 
 		if ($monthsexpected < $newtimetotalmonths) {
-			$newtimehours = dol_print_date($newtime, '%m');
-			$newtimemins = dol_print_date($newtime, '%m');
-			$newtimesecs = dol_print_date($newtime, '%m');
+			$newtimehours = dol_print_date($newtime, '%h');
+			$newtimemins = dol_print_date($newtime, '%i');
+			$newtimesecs = dol_print_date($newtime, '%s');
 
 			$datelim = dol_mktime($newtimehours, $newtimemins, $newtimesecs, $newtimemonth, 1, $newtimeyear);
 			$datelim -= (3600 * 24);

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -166,7 +166,33 @@ function dol_time_plus_duree($time, $duration_value, $duration_unit)
 	} else {
 		$date->add($interval);
 	}
-
+	//Change the behavior of PHP over data-interval when the result of this function is Feb 29 (non-leap years), 30 or Feb 31 (php returns March 1, 2 or 3 respectively)
+	if ($conf->global->MAIN_DATE_CHANGE_PHP_DATEINTERVAL_RESULT_FEBRUARY && $duration_unit == 'm') {
+	
+    	$timeyear = dol_print_date($time, '%Y');
+    	$timemonth = dol_print_date($time, '%m');
+    	$timetotalmonths = (($timeyear * 12) + $timemonth);
+    	
+    	$monthsexpected = ($timetotalmonths + $duration_value);
+    	
+    	$newtime = $date->getTimestamp();
+    	
+    	$newtimeyear = dol_print_date($newtime, '%Y');
+    	$newtimemonth = dol_print_date($newtime, '%m');
+    	$newtimetotalmonths = (($newtimeyear * 12) + $newtimemonth);
+		
+    	if ($monthsexpected < $newtimetotalmonths) { 
+        
+    	    $newtimehours = dol_print_date($newtime, '%m');
+    	    $newtimemins = dol_print_date($newtime, '%m');
+    	    $newtimesecs = dol_print_date($newtime, '%m');
+    	    
+    	    $datelim = dol_mktime($newtimehours, $newtimemins, $newtimesecs, $newtimemonth, 1, $newtimeyear);
+    	    $datelim -= (3600 * 24);
+    	    
+    	    $date->setTimestamp($datelim);    	    
+	    }
+	}
 	return $date->getTimestamp();
 }
 

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -117,7 +117,7 @@ function getServerTimeZoneInt($refgmtdate = 'now')
  *  @param      int			$duration_unit      Unit of added delay (d, m, y, w, h, i)
  *  @return     int      			        	New timestamp
  */
-function dol_time_plus_duree($time, $duration_value, $duration_unit)
+function dol_time_plus_duree($time, $duration_value, $duration_unit, $ruleforendofmonth = 0)
 {
 	global $conf;
 
@@ -167,7 +167,7 @@ function dol_time_plus_duree($time, $duration_value, $duration_unit)
 		$date->add($interval);
 	}
 	//Change the behavior of PHP over data-interval when the result of this function is Feb 29 (non-leap years), 30 or Feb 31 (php returns March 1, 2 or 3 respectively)
-	if ($conf->global->MAIN_DATE_CHANGE_PHP_DATEINTERVAL_RESULT_FEBRUARY && $duration_unit == 'm') {
+	if ($ruleforendofmonth == 1 && $duration_unit == 'm') {
 		$timeyear = dol_print_date($time, '%Y');
 		$timemonth = dol_print_date($time, '%m');
 		$timetotalmonths = (($timeyear * 12) + $timemonth);

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -168,30 +168,28 @@ function dol_time_plus_duree($time, $duration_value, $duration_unit)
 	}
 	//Change the behavior of PHP over data-interval when the result of this function is Feb 29 (non-leap years), 30 or Feb 31 (php returns March 1, 2 or 3 respectively)
 	if ($conf->global->MAIN_DATE_CHANGE_PHP_DATEINTERVAL_RESULT_FEBRUARY && $duration_unit == 'm') {
-	
-    	$timeyear = dol_print_date($time, '%Y');
-    	$timemonth = dol_print_date($time, '%m');
-    	$timetotalmonths = (($timeyear * 12) + $timemonth);
-    	
-    	$monthsexpected = ($timetotalmonths + $duration_value);
-    	
-    	$newtime = $date->getTimestamp();
-    	
-    	$newtimeyear = dol_print_date($newtime, '%Y');
-    	$newtimemonth = dol_print_date($newtime, '%m');
-    	$newtimetotalmonths = (($newtimeyear * 12) + $newtimemonth);
-		
-    	if ($monthsexpected < $newtimetotalmonths) { 
-        
-    	    $newtimehours = dol_print_date($newtime, '%m');
-    	    $newtimemins = dol_print_date($newtime, '%m');
-    	    $newtimesecs = dol_print_date($newtime, '%m');
-    	    
-    	    $datelim = dol_mktime($newtimehours, $newtimemins, $newtimesecs, $newtimemonth, 1, $newtimeyear);
-    	    $datelim -= (3600 * 24);
-    	    
-    	    $date->setTimestamp($datelim);    	    
-	    }
+		$timeyear = dol_print_date($time, '%Y');
+		$timemonth = dol_print_date($time, '%m');
+		$timetotalmonths = (($timeyear * 12) + $timemonth);
+
+		$monthsexpected = ($timetotalmonths + $duration_value);
+
+		$newtime = $date->getTimestamp();
+
+		$newtimeyear = dol_print_date($newtime, '%Y');
+		$newtimemonth = dol_print_date($newtime, '%m');
+		$newtimetotalmonths = (($newtimeyear * 12) + $newtimemonth);
+
+		if ($monthsexpected < $newtimetotalmonths) {
+			$newtimehours = dol_print_date($newtime, '%m');
+			$newtimemins = dol_print_date($newtime, '%m');
+			$newtimesecs = dol_print_date($newtime, '%m');
+
+			$datelim = dol_mktime($newtimehours, $newtimemins, $newtimesecs, $newtimemonth, 1, $newtimeyear);
+			$datelim -= (3600 * 24);
+
+			$date->setTimestamp($datelim);
+		}
 	}
 	return $date->getTimestamp();
 }

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -181,9 +181,9 @@ function dol_time_plus_duree($time, $duration_value, $duration_unit)
 		$newtimetotalmonths = (($newtimeyear * 12) + $newtimemonth);
 
 		if ($monthsexpected < $newtimetotalmonths) {
-			$newtimehours = dol_print_date($newtime, '%h');
-			$newtimemins = dol_print_date($newtime, '%i');
-			$newtimesecs = dol_print_date($newtime, '%s');
+			$newtimehours = dol_print_date($newtime, '%H');
+			$newtimemins = dol_print_date($newtime, '%M');
+			$newtimesecs = dol_print_date($newtime, '%S');
 
 			$datelim = dol_mktime($newtimehours, $newtimemins, $newtimesecs, $newtimemonth, 1, $newtimeyear);
 			$datelim -= (3600 * 24);


### PR DESCRIPTION
Close: #18801 related to avoid this behaviour https://bugs.php.net/bug.php?id=74013


# Close #18801 related to avoid this behaviour https://bugs.php.net/bug.php?id=74013

I think we need the option that dol_time_plus_duree (+ 1m) returns 2021-02-28 instead of 2021-03-02 (example with 2021-01-30)