### PR TITLE
Translation of event title for incoming email

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -966,7 +966,7 @@ class EmailCollector extends CommonObject
 
 		dol_syslog("EmailCollector::doCollectOneCollector start for id=".$this->id, LOG_DEBUG);
 
-		$langs->loadLangs(array("project", "companies", "mails", "errors", "ticket", "agenda"));
+		$langs->loadLangs(array("project", "companies", "mails", "errors", "ticket", "agenda", "commercial"));
 
 		$error = 0;
 		$this->output = '';


### PR DESCRIPTION
Event title for incoming email is not translated while collected by cronjob. 
i.e : ActionAC_EMAIL_IN