### PR TITLE
FIX: Docker-compose file and Dockerfile

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -57,7 +57,6 @@ RUN echo "host mail" >> /etc/msmtprc
 RUN echo "from local@localdomain.com" >> /etc/msmtprc
 RUN echo "domain localhost.localdomain" >> /etc/msmtprc
 RUN echo "sendmail_path=/usr/bin/msmtp -t" >> /usr/local/etc/php/conf.d/php-sendmail.ini
-RUN echo "localhost localhost.localdomain" >> /etc/hosts
 
 EXPOSE 80
 

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -46,6 +46,8 @@ services:
         networks:
             - internal-pod
             - external-pod
+        extra_hosts:
+            - "localhost.localdomain:127.0.0.1"
 
     mail:
         image: maildev/maildev


### PR DESCRIPTION
Fix #18816 : During the build of the docker-compose `web` service, in
the `Dockerfile` There is a command which attemps to modify
`/etc/hosts`. On my system This file is Read-only. Using the
`extra_hosts` parameter in `docker-compose.yml` instead fix the
problem.
