### PR TITLE
Bug Query llx_categorie_knowledgemanagement.sql

### DIFF
--- a/htdocs/install/mysql/tables/llx_categorie_knowledgemanagement.sql
+++ b/htdocs/install/mysql/tables/llx_categorie_knowledgemanagement.sql
@@ -13,7 +13,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see https://www.gnu.org/licenses/.
 
-create table llx_categorie_knowledgemanagement
+create table llx_categorie_knowledgemanagement(
   fk_categorie  integer NOT NULL,
   fk_knowledgemanagement   integer NOT NULL,
   import_key    varchar(14)


### PR DESCRIPTION
# Fix
Fix Error Fresh install
```
SQL Error DB_ERROR_SYNTAX You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'integer NOT NULL, fk_knowledgemanagement integer NOT NULL, import_key ...' at line 2
```