### PR TITLE
Fix FormFile::list_of_autoecmfiles object_instance classname after hook

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1672,7 +1672,8 @@ class FormFile
 					dol_include_once($hookmanager->resArray['classpath']);
 					if (array_key_exists('classname', $hookmanager->resArray) && !empty($hookmanager->resArray['classname'])) {
 						if (class_exists($hookmanager->resArray['classname'])) {
-							$object_instance = new $hookmanager->resArray['classname']($this->db);
+							$tmpclassname = $hookmanager->resArray['classname'];
+							$object_instance = new $tmpclassname($this->db);
 						}
 					}
 				}

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1672,7 +1672,7 @@ class FormFile
 					dol_include_once($hookmanager->resArray['classpath']);
 					if (array_key_exists('classname', $hookmanager->resArray) && !empty($hookmanager->resArray['classname'])) {
 						if (class_exists($hookmanager->resArray['classname'])) {
-							$object_instance = new ${$hookmanager->resArray['classname']}($this->db);
+							$object_instance = new $hookmanager->resArray['classname']($this->db);
 						}
 					}
 				}


### PR DESCRIPTION
FormFile::list_of_autoecmfiles() can instantiate object with parameters
resulting of hook `addSectionECMAuto` but for do this,
it use `${$hookmanager->resArray['classname']}` which return a
`null`. Instead we should do this
`$hookmanager->resArray['classname']`.
