### PR TITLE
Fix append module suffix on src_object_type when create ecm file

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5297,7 +5297,7 @@ abstract class CommonObject
 								$ecmfile->gen_or_uploaded = 'generated';
 								$ecmfile->description = ''; // indexed content
 								$ecmfile->keywords = ''; // keyword content
-								$ecmfile->src_object_type = $this->table_element;
+								$ecmfile->src_object_type = $this->table_element.(empty($this->module) ? '' : '@'.$this->module);
 								$ecmfile->src_object_id   = $this->id;
 
 								$result = $ecmfile->create($user);


### PR DESCRIPTION
Files added to `llx_ecm_files` for externals modules never be removed on
object deletion.

When `CommonObject::deleteEcmFiles()` is called with `mode=1`, it  use
this sql filter to find the file related to the object which is removed
:

```
$sql .= " WHERE fk_object IN (SELECT rowid FROM ".MAIN_DB_PREFIX."ecm_files WHERE src_object_type = '".$this->db->escape($this->table_element.(empty($this->module) ? '' : '@'.$this->module))."' AND src_object_id = ".((int) $this->id).")";
```

We see it append `'@'.$this->module` to `$this->table_element` but when
file is add to the `llx_ecm_files` by
`CommonObject::commonGenerateDocument()` , it added whiteout the
`'@'.$this->module` suffix. So the file is never remove from
`llx_ecm_files` when object is deleted.

This fix it by appending module suffix on `src_object_type` if object
has `module` property when add document to the `llx_ecm_files`.
