### PR TITLE
Fix show for external module in ecm index auto page

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1811,9 +1811,11 @@ class FormFile
 				print '</td>';
 
 				// File
+				// Check if document source has external module part, if it the case use it for module part on document.php
+				preg_match('/^[^@]*@([^@]*)$/', $modulepart.'@expertisemedical', $modulesuffix);
 				print '<td>';
 				//print "XX".$file['name']; //$file['name'] must be utf8
-				print '<a href="'.DOL_URL_ROOT.'/document.php?modulepart='.$modulepart;
+				print '<a href="'.DOL_URL_ROOT.'/document.php?modulepart='.(empty($modulesuffix) ? $modulepart : $modulesuffix[1]);
 				if ($forcedownload) {
 					print '&attachment=1';
 				}
@@ -1824,7 +1826,7 @@ class FormFile
 
 				//print $this->getDocumentsLink($modulepart, $modulesubdir, $filedir, '^'.preg_quote($file['name'],'/').'$');
 
-				print $this->showPreview($file, $modulepart, $file['relativename']);
+				print $this->showPreview($file, (empty($modulesuffix) ? $modulepart : $modulesuffix[1]), $file['relativename']);
 
 				print "</td>\n";
 


### PR DESCRIPTION
This set the correct `modulepart` parameter for link generated to
`document.php` of ecm auto index page if `src_object_type` for
ecm document has a module suffix (`@modulename`).