### PR TITLE
Agenda events visibility

### DIFF
--- a/htdocs/core/lib/agenda.lib.php
+++ b/htdocs/core/lib/agenda.lib.php
@@ -69,7 +69,7 @@ function print_actions_filter($form, $canedit, $status, $year, $month, $day, $sh
 	}
 	print '<input type="hidden" name="search_showbirthday" value="'.((int) $showbirthday).'">';
 
-	if ($canedit) {
+	//if ($canedit) {
 		print '<div class="divsearchfield">';
 
 		// Type
@@ -103,7 +103,7 @@ function print_actions_filter($form, $canedit, $status, $year, $month, $day, $sh
 			print $formresource->select_resource_list($resourceid, "search_resourceid", '', 1, 0, 0, null, '', 2, 0, 'maxwidth500');
 			print '</div>';
 		}
-	}
+	//}
 
 	if (!empty($conf->societe->enabled) && $user->rights->societe->lire) {
 		print '<div class="divsearchfield">';


### PR DESCRIPTION
# Fix
All users should be able to filter event types and to see auto events in agenda views. Currently read-only agenda events users can't filter, and don't see auto events.
