### PR TITLE
Fix dynamic prices not updating

### DIFF
--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -846,7 +846,7 @@ class ProductFournisseur extends Product
 						$this->fourn_qty                = $record["quantity"];
 						$this->fourn_remise_percent     = $record["remise_percent"];
 						$this->fourn_remise             = $record["remise"];
-						$this->fourn_unitprice          = $record["unitprice"];
+						$this->fourn_unitprice          = $fourn_unitprice;
 						$this->fourn_charges            = $record["charges"]; // deprecated
 						$this->fourn_tva_tx             = $record["tva_tx"];
 						$this->fourn_id                 = $record["fourn_id"];


### PR DESCRIPTION
# New [*Fix dynamic prices not updating*]
[*When Dynamic price module active and an a math expression is used to compute buy price on supplier product card, the calculated price does not update on the card when saved.
Changing line 849 appears to solve this without any ill effect.*]
