### PR TITLE
doxygen

### DIFF
--- a/htdocs/admin/eventorganization_confbooth_extrafields.php
+++ b/htdocs/admin/eventorganization_confbooth_extrafields.php
@@ -16,7 +16,7 @@
  */
 
 /**
- *      \file       htdocs/admin/eventorganization_extrafields.php
+ *      \file       htdocs/admin/eventorganization_confbooth_extrafields.php
  *		\ingroup    bom
  *		\brief      Page to setup extra fields of EventOrganization
  */


### PR DESCRIPTION
/home/dolibarr/htdocs/admin/eventorganization_confbooth_extrafields.php:18: warning: the name 'htdocs/admin/eventorganization_extrafields.php' supplied as the argument in the \file statement is not an input file