### PR TITLE
doxygen

### DIFF
--- a/htdocs/admin/eventorganization_confboothattendee_extrafields.php
+++ b/htdocs/admin/eventorganization_confboothattendee_extrafields.php
@@ -21,7 +21,7 @@
  */
 
 /**
- *      \file       admin/conferenceorboothattendee_extrafields.php
+ *      \file       htdocs/admin/eventorganization_confboothattendee_extrafields.php
  *		\ingroup    eventorganization
  *		\brief      Page to setup extra fields of conferenceorboothattendee
  */


### PR DESCRIPTION
/home/dolibarr/htdocs/admin/eventorganization_confboothattendee_extrafields.php:23: warning: the name 'admin/conferenceorboothattendee_extrafields.php' supplied as the argument in the \file statement is not an input file