### PR TITLE
FIX Remove Isle of Man of ECC's countries compatible with VAT Rules

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -724,7 +724,7 @@ function getFormeJuridiqueLabel($code)
 function getCountriesInEEC()
 {
 	// List of all country codes that are in europe for european vat rules
-	// List found on https://europa.eu/european-union/about-eu/countries_en
+	// List found on https://ec.europa.eu/taxation_customs/territorial-status-eu-countries-and-certain-territories_en
 	global $conf, $db;
 	$country_code_in_EEC = array();
 

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -724,7 +724,7 @@ function getFormeJuridiqueLabel($code)
 function getCountriesInEEC()
 {
 	// List of all country codes that are in europe for european vat rules
-	// List found on http://ec.europa.eu/taxation_customs/common/faq/faq_1179_en.htm#9
+	// List found on https://europa.eu/european-union/about-eu/countries_en
 	global $conf, $db;
 	$country_code_in_EEC = array();
 

--- a/htdocs/install/mysql/data/llx_00_c_country.sql
+++ b/htdocs/install/mysql/data/llx_00_c_country.sql
@@ -279,5 +279,5 @@ INSERT INTO llx_c_country (rowid,code,code_iso,label,active,favorite) VALUES (24
 
 
 -- Set field eec
-UPDATE llx_c_country SET eec = 1 WHERE code IN ('AT','BE','BG','CY','CZ','DE','DK','EE','ES','FI','FR','GR','HR','NL','HU','IE','IM','IT','LT','LU','LV','MC','MT','PL','PT','RO','SE','SK','SI');
+UPDATE llx_c_country SET eec = 1 WHERE code IN ('AT','BE','BG','CY','CZ','DE','DK','EE','ES','FI','FR','GR','HR','NL','HU','IE','IT','LT','LU','LV','MC','MT','PL','PT','RO','SE','SK','SI');
 


### PR DESCRIPTION
https://ec.europa.eu/taxation_customs/territorial-status-eu-countries-and-certain-territories_en