### PR TITLE
Allow removal of tabs

### DIFF
--- a/htdocs/mrp/lib/mrp_mo.lib.php
+++ b/htdocs/mrp/lib/mrp_mo.lib.php
@@ -103,6 +103,8 @@ function moPrepareHead($object)
 	//	'entity:-tabname:Title:@mrp:/mrp/mypage.php?id=__ID__'
 	//); // to remove a tab
 	complete_head_from_modules($conf, $langs, $object, $head, $h, 'mo@mrp');
+	
+	complete_head_from_modules($conf, $langs, $object, $head, $h, 'mo@mrp', 'remove');
 
 	return $head;
 }

--- a/htdocs/mrp/lib/mrp_mo.lib.php
+++ b/htdocs/mrp/lib/mrp_mo.lib.php
@@ -103,7 +103,7 @@ function moPrepareHead($object)
 	//	'entity:-tabname:Title:@mrp:/mrp/mypage.php?id=__ID__'
 	//); // to remove a tab
 	complete_head_from_modules($conf, $langs, $object, $head, $h, 'mo@mrp');
-	
+
 	complete_head_from_modules($conf, $langs, $object, $head, $h, 'mo@mrp', 'remove');
 
 	return $head;


### PR DESCRIPTION
# Fix: Removal of tabs from custom modules doesn't  work
For being able to remove or replace tabs, it is also necessary to call complete_head_from_modules with 'remove' mode.


