### PR TITLE
Fix #18890 Fix disabled button if sum real qty is 0

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -801,7 +801,7 @@ if ($object->id > 0) {
 	print '</div>';
 
 	// Call method to disable the button if no qty entered yet for inventory
-	if (!$hasinput) {
+	if ($object->status != $object::STATUS_VALIDATED || !$hasinput) {
 		print '<script type="text/javascript" language="javascript">
 					jQuery(document).ready(function() {
 						disablebuttonmakemovementandclose();

--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -716,7 +716,7 @@ if ($object->id > 0) {
 		$num = $db->num_rows($resql);
 
 		$i = 0;
-		$totalfound = 0;
+		$hasinput = false;
 		$totalarray = array();
 		while ($i < $num) {
 			$obj = $db->fetch_object($resql);
@@ -766,7 +766,10 @@ if ($object->id > 0) {
 			print '<td class="center">';
 			if ($object->status == $object::STATUS_VALIDATED) {
 				$qty_view = GETPOST("id_".$obj->rowid) && price2num(GETPOST("id_".$obj->rowid), 'MS') >= 0 ? GETPOST("id_".$obj->rowid) : $obj->qty_view;
-				$totalfound += price2num($qty_view, 'MS');
+				if (!$hasinput && $qty_view !== null && $obj->qty_stock != $qty_view) {
+					$hasinput = true;
+				}
+
 				print '<input type="text" class="maxwidth75 right realqty" name="id_'.$obj->rowid.'" id="id_'.$obj->rowid.'_input" value="'.$qty_view.'">';
 				print '</td>';
 				print '<td class="right">';
@@ -777,7 +780,6 @@ if ($object->id > 0) {
 				print '<input type="hidden" class="maxwidth75 right realqty" name="id_'.$obj->rowid.'_input_tmp" id="id_'.$obj->rowid.'_input_tmp" value="'.$qty_tmp.'">';
 			} else {
 				print $obj->qty_view;
-				$totalfound += $obj->qty_view;
 				print '</td>';
 			}
 			print '</tr>';
@@ -799,7 +801,7 @@ if ($object->id > 0) {
 	print '</div>';
 
 	// Call method to disable the button if no qty entered yet for inventory
-	if ($object->status != $object::STATUS_VALIDATED || $totalfound == 0) {
+	if (!$hasinput) {
 		print '<script type="text/javascript" language="javascript">
 					jQuery(document).ready(function() {
 						disablebuttonmakemovementandclose();


### PR DESCRIPTION
# Fix #18890 Fix disabled button if sum real qty is 0
Instead of counting the sum of the 'real qty' input, only disable the button if no input has been given, or if all input is the same as the expected qty.

'$object->status' check seems unnecessary here since the button is only there when the status is 'STATUS_VALIDATED'.
