### PR TITLE
Fix #18895 Fix negative stock correction

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5129,6 +5129,13 @@ class Product extends CommonObject
 
 			include_once DOL_DOCUMENT_ROOT.'/product/stock/class/mouvementstock.class.php';
 
+			if ($nbpiece < 0) {
+				if (!$movement) {
+					$movement = 1;
+				}
+				$nbpiece *= -1;
+			}
+
 			$op[0] = "+".trim($nbpiece);
 			$op[1] = "-".trim($nbpiece);
 
@@ -5175,6 +5182,13 @@ class Product extends CommonObject
 			$this->db->begin();
 
 			include_once DOL_DOCUMENT_ROOT.'/product/stock/class/mouvementstock.class.php';
+
+			if ($nbpiece < 0) {
+				if (!$movement) {
+					$movement = 1;
+				}
+				$nbpiece *= -1;
+			}
 
 			$op[0] = "+".trim($nbpiece);
 			$op[1] = "-".trim($nbpiece);

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5111,7 +5111,7 @@ class Product extends CommonObject
 	 *
 	 * @param  User   $user           user asking change
 	 * @param  int    $id_entrepot    id of warehouse
-	 * @param  double $nbpiece        nb of units
+	 * @param  double $nbpiece        nb of units (should be always positive, use $movement to decide if we add or remove)
 	 * @param  int    $movement       0 = add, 1 = remove
 	 * @param  string $label          Label of stock movement
 	 * @param  double $price          Unit price HT of product, used to calculate average weighted price (PMP in french). If 0, average weighted price is not changed.
@@ -5133,7 +5133,7 @@ class Product extends CommonObject
 				if (!$movement) {
 					$movement = 1;
 				}
-				$nbpiece *= -1;
+				$nbpiece = abs($nbpiece);
 			}
 
 			$op[0] = "+".trim($nbpiece);
@@ -5162,7 +5162,7 @@ class Product extends CommonObject
 	 *
 	 * @param  User     $user           user asking change
 	 * @param  int      $id_entrepot    id of warehouse
-	 * @param  double   $nbpiece        nb of units
+	 * @param  double   $nbpiece        nb of units (should be always positive, use $movement to decide if we add or remove)
 	 * @param  int      $movement       0 = add, 1 = remove
 	 * @param  string   $label          Label of stock movement
 	 * @param  double   $price          Price to use for stock eval
@@ -5187,7 +5187,7 @@ class Product extends CommonObject
 				if (!$movement) {
 					$movement = 1;
 				}
-				$nbpiece *= -1;
+				$nbpiece = abs($nbpiece);
 			}
 
 			$op[0] = "+".trim($nbpiece);


### PR DESCRIPTION
# Fix #18895 Fix negative stock correction
If people use a negative number as input, I think we can assume they want to delete units. It will now set the movement to 1 (remove) if the number is negative and 'add' was selected.

For each negative number we now multiply this number by -1, to make it a positive number again.
