### PR TITLE
NEW add hook `beforeBodyClose`

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -3081,7 +3081,7 @@ if (!function_exists("llxFooter")) {
 	 */
 	function llxFooter($comment = '', $zone = 'private', $disabledoutputofmessages = 0)
 	{
-		global $conf, $db, $langs, $user, $mysoc, $object;
+		global $conf, $db, $langs, $user, $mysoc, $object, $hookmanager;
 		global $delayedhtmlcontent;
 		global $contextpage, $page, $limit;
 		global $dolibarr_distrib;
@@ -3302,6 +3302,11 @@ if (!function_exists("llxFooter")) {
 					dolibarr_set_const($db, 'MAIN_FIRST_PING_OK_ID', 'disabled', 'chaine', 0, '', $conf->entity);
 				}
 			}
+		}
+
+		$reshook = $hookmanager->executeHooks('beforeBodyClose'); // Note that $action and $object may have been modified by some hooks
+		if ($reshook > 0) {
+			print $hookmanager->resPrint;
 		}
 
 		print "</body>\n";


### PR DESCRIPTION
This adds a hook just before the close tag </body>

Usage:
```php
	public function beforeBodyClose( $parameters, &$object, &$action, $hookmanager ) {
		
			$hookmanager->resPrint = '
<div style="width: 250px; background: white; text-align: center; padding: 10px; margin: 0 auto; border: 8px solid red;">
	BODY ENding
</div>';
			
		return 1;

	}
```