### PR TITLE
Fix creataing invoice originating for custom module object

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3731,7 +3731,7 @@ if ($action == 'create') {
 		print '<input type="hidden" name="total"    value="'.$objectsrc->total_ttc.'">'."\n";
 		print '<input type="hidden" name="tva"      value="'.$objectsrc->total_tva.'">'."\n";
 		// The lines below override the parameters set by GET or POST for origin value and also be present in $origin and $originid variables (it make creation of invoice originating from an external module object impossible because for get an external module class we also need to know the name of the module in addition of the name of the element).
-        // This input fields already printed above at the <form> begin.
+		// This input fields already printed above at the <form> begin.
 		//print '<input type="hidden" name="origin"   value="'.$objectsrc->element.'">';
 		//print '<input type="hidden" name="originid" value="'.$objectsrc->id.'">';
 

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3730,8 +3730,10 @@ if ($action == 'create') {
 		print '<input type="hidden" name="amount"   value="'.$objectsrc->total_ht.'">'."\n";
 		print '<input type="hidden" name="total"    value="'.$objectsrc->total_ttc.'">'."\n";
 		print '<input type="hidden" name="tva"      value="'.$objectsrc->total_tva.'">'."\n";
-		print '<input type="hidden" name="origin"   value="'.$objectsrc->element.'">';
-		print '<input type="hidden" name="originid" value="'.$objectsrc->id.'">';
+		// The lines below override the parameters set by GET or POST for origin value and also be present in $origin and $originid variables (it make creation of invoice originating from an external module object impossible because for get an external module class we also need to know the name of the module in addition of the name of the element).
+        // This input fields already printed above at the <form> begin.
+		//print '<input type="hidden" name="origin"   value="'.$objectsrc->element.'">';
+		//print '<input type="hidden" name="originid" value="'.$objectsrc->id.'">';
 
 		switch (get_class($objectsrc)) {
 			case 'Propal':

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3730,8 +3730,7 @@ if ($action == 'create') {
 		print '<input type="hidden" name="amount"   value="'.$objectsrc->total_ht.'">'."\n";
 		print '<input type="hidden" name="total"    value="'.$objectsrc->total_ttc.'">'."\n";
 		print '<input type="hidden" name="tva"      value="'.$objectsrc->total_tva.'">'."\n";
-		// The lines below override the parameters set by GET or POST for origin value and also be present in $origin and $originid variables (it make creation of invoice originating from an external module object impossible because for get an external module class we also need to know the name of the module in addition of the name of the element).
-		// This input fields already printed above at the <form> begin.
+		// The commented lines below are fields already added as hidden parameters before
 		//print '<input type="hidden" name="origin"   value="'.$objectsrc->element.'">';
 		//print '<input type="hidden" name="originid" value="'.$objectsrc->id.'">';
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3712,18 +3712,33 @@ abstract class CommonObject
 		$withtargettype = false;
 		$withsourcetype = false;
 
-		$sourceid = (!empty($sourceid) ? $sourceid : $this->id);
-		$targetid = (!empty($targetid) ? $targetid : $this->id);
-		$sourcetype = (!empty($sourcetype) ? $sourcetype : $this->element);
-		$targettype = (!empty($targettype) ? $targettype : $this->element);
-
 		$parameters = array('sourcetype'=>$sourcetype, 'sourceid'=>$sourceid, 'targettype'=>$targettype, 'targetid'=>$targetid);
 		// Hook for explicitly set the targettype if it must be differtent than $this->element
 		$reshook = $hookmanager->executeHooks('setLinkedObjectSourceTargetType', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 		if ($reshook > 0) {
 			if (!empty($hookmanager->resArray['sourcetype'])) $sourcetype = $hookmanager->resArray['sourcetype'];
+			if (!empty($hookmanager->resArray['sourceid'])) $sourceid = $hookmanager->resArray['sourceid'];
 			if (!empty($hookmanager->resArray['targettype'])) $targettype = $hookmanager->resArray['targettype'];
+			if (!empty($hookmanager->resArray['targetid'])) $targetid = $hookmanager->resArray['targetid'];
 		}
+
+		if (!empty($sourceid) && !empty($sourcetype) && empty($targetid)) {
+			$justsource = true; // the source (id and type) is a search criteria
+			if (!empty($targettype)) {
+				$withtargettype = true;
+			}
+		}
+		if (!empty($targetid) && !empty($targettype) && empty($sourceid)) {
+			$justtarget = true; // the target (id and type) is a search criteria
+			if (!empty($sourcetype)) {
+				$withsourcetype = true;
+			}
+		}
+
+		$sourceid = (!empty($sourceid) ? $sourceid : $this->id);
+		$targetid = (!empty($targetid) ? $targetid : $this->id);
+		$sourcetype = (!empty($sourcetype) ? $sourcetype : $this->element);
+		$targettype = (!empty($targettype) ? $targettype : $this->element);
 
 		/*if (empty($sourceid) && empty($targetid))
 		 {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3623,6 +3623,12 @@ abstract class CommonObject
 		$this->db->begin();
 		$error = 0;
 
+		// Elements of the core modules which have `$module` property but may to which we don't want to prefix module part to the element name for finding the linked object in llx_element_element.
+		// It's because an entry for this element may be exist in llx_element_element before this modification (version <=14.2) and ave named only with their element name in fk_source or fk_target.
+		$coremodule = array('knowledgemanagement', 'partnership', 'workstation', 'ticket', 'recruitment', 'eventorganization');
+        // Add module part to target type if object has $module property and isn't in core modules.
+        $targettype = ((!empty($this->module) && ! in_array($this->module, $coremodule)) ? $this->module.'_' : '').$this->element;
+
 		$sql = "INSERT INTO " . MAIN_DB_PREFIX . "element_element (";
 		$sql .= "fk_source";
 		$sql .= ", sourcetype";
@@ -3632,7 +3638,7 @@ abstract class CommonObject
 		$sql .= ((int) $origin_id);
 		$sql .= ", '" . $this->db->escape($origin) . "'";
 		$sql .= ", " . ((int) $this->id);
-		$sql .= ", '" . $this->db->escape($this->element) . "'";
+		$sql .= ", '" . $this->db->escape($targettype) . "'";
 		$sql .= ")";
 
 		dol_syslog(get_class($this) . "::add_object_linked", LOG_DEBUG);
@@ -3714,7 +3720,6 @@ abstract class CommonObject
 
 		$sourceid = (!empty($sourceid) ? $sourceid : $this->id);
 		$targetid = (!empty($targetid) ? $targetid : $this->id);
-		// For module whit
 		if (empty($sourcetype)) {
 			// If empty $sourcetype and no core module, add module part for searching element in llx_element_element (needed for external module).
 			if (!empty($this->module) && ! in_array($this->module, $coremodule)) $sourcetype = $this->module.'_'.$this->element;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3708,10 +3708,23 @@ abstract class CommonObject
 			}
 		}
 
+		// Elements of the core modules which have `$module` property but may to which we don't want to prefix module part to the element name for finding the linked object in llx_element_element.
+		// It's because an entry for this element may be exist in llx_element_element before this modification (version <=14.2) and ave named only with their element name in fk_source or fk_target.
+		$coremodule = array('knowledgemanagement', 'partnership', 'workstation', 'ticket', 'recruitment', 'eventorganization');
+
 		$sourceid = (!empty($sourceid) ? $sourceid : $this->id);
 		$targetid = (!empty($targetid) ? $targetid : $this->id);
-		$sourcetype = (!empty($sourcetype) ? $sourcetype : $this->element);
-		$targettype = (!empty($targettype) ? $targettype : $this->element);
+		// For module whit
+		if (empty($sourcetype)) {
+			// If empty $sourcetype and no core module, add module part for searching element in llx_element_element (needed for external module).
+			if (!empty($this->module) && ! in_array($this->module, $coremodule)) $sourcetype = $this->module.'_'.$this->element;
+			else $sourcetype = $this->element;
+		}
+		if (empty($targettype)) {
+			// If empty $targettype and no core module, add module part for searching element in llx_element_element (needed for external module).
+			if (!empty($this->module) && ! in_array($this->module, $coremodule)) $targettype = $this->module.'_'.$this->element;
+			else $targettype = $this->element;
+		}
 
 		/*if (empty($sourceid) && empty($targetid))
 		 {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3626,8 +3626,8 @@ abstract class CommonObject
 		// Elements of the core modules which have `$module` property but may to which we don't want to prefix module part to the element name for finding the linked object in llx_element_element.
 		// It's because an entry for this element may be exist in llx_element_element before this modification (version <=14.2) and ave named only with their element name in fk_source or fk_target.
 		$coremodule = array('knowledgemanagement', 'partnership', 'workstation', 'ticket', 'recruitment', 'eventorganization');
-        // Add module part to target type if object has $module property and isn't in core modules.
-        $targettype = ((!empty($this->module) && ! in_array($this->module, $coremodule)) ? $this->module.'_' : '').$this->element;
+		// Add module part to target type if object has $module property and isn't in core modules.
+		$targettype = ((!empty($this->module) && ! in_array($this->module, $coremodule)) ? $this->module.'_' : '').$this->element;
 
 		$sql = "INSERT INTO " . MAIN_DB_PREFIX . "element_element (";
 		$sql .= "fk_source";


### PR DESCRIPTION
This fix the invoice create form when we provide `origin` element in
url. The actual create form overide the value for origin field with
`$objectsrc->element`. This make creation of invoice originating from a custom
module module impossible because we need the module part to instantiate
the class for the custom module object.

This also modify Common Object::fetch Object Linked() to append the
module part for `$sourcetype` and `$targettype` if it not set and object
have module property and it not in core module and 
`CommonObject::add_object_linked()` to append the module part if
object has `$module` property and is not in core modules.
