### PR TITLE
Fix PR #18845 and #18843 (error on src_objet_type from emc files)

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5297,7 +5297,7 @@ abstract class CommonObject
 								$ecmfile->gen_or_uploaded = 'generated';
 								$ecmfile->description = ''; // indexed content
 								$ecmfile->keywords = ''; // keyword content
-								$ecmfile->src_object_type = $this->table_element.(empty($this->module) ? '' : '@'.$this->module);
+								$ecmfile->src_object_type = (empty($this->module) ? '' : $this->module.'_').$this->element;
 								$ecmfile->src_object_id   = $this->id;
 
 								$result = $ecmfile->create($user);

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1815,7 +1815,6 @@ class FormFile
 
 				// File
 				// Check if document source has external module part, if it the case use it for module part on document.php
-				var_dump($modulepart);
 				preg_match('/^[^_]*_([^_]*)$/', $modulepart, $modulesuffix);
 				print '<td>';
 				//print "XX".$file['name']; //$file['name'] must be utf8

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1815,7 +1815,7 @@ class FormFile
 
 				// File
 				// Check if document source has external module part, if it the case use it for module part on document.php
-                var_dump($modulepart);
+				var_dump($modulepart);
 				preg_match('/^[^_]*_([^_]*)$/', $modulepart, $modulesuffix);
 				print '<td>';
 				//print "XX".$file['name']; //$file['name'] must be utf8

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1815,7 +1815,8 @@ class FormFile
 
 				// File
 				// Check if document source has external module part, if it the case use it for module part on document.php
-				preg_match('/^[^@]*@([^@]*)$/', $modulepart.'@expertisemedical', $modulesuffix);
+                var_dump($modulepart);
+				preg_match('/^[^_]*_([^_]*)$/', $modulepart, $modulesuffix);
 				print '<td>';
 				//print "XX".$file['name']; //$file['name'] must be utf8
 				print '<a href="'.DOL_URL_ROOT.'/document.php?modulepart='.(empty($modulesuffix) ? $modulepart : $modulesuffix[1]);


### PR DESCRIPTION
The PR #18845 and #18843 modify `CommonObject::commonGenerateDocument()`
and emc auto index page to use a `'@'.$object->module` suffix appened to `
`@object->table_element` when object has `$object->module` property. It's a
mistake (when originating object is referenced in stock movement table,
the module part is indicated after a `@` suffix and i thought it was a convention for
specify module part but in here `_` must be used).

Before the PR #18445 and #18443, `$object->table_element` was used to
set `src_object_type` in `llx_ecm_file`, normally the tables are named
like `$object->module.'_'.$object->element` but for random reason it
possible to name them otherwise (objects has specific `table_element`
property for that). So in CommonObject::commonGenerateDocument(), if the
object has a property `$this->module` use
`$this->module.'_'.$this->element` seem more reliable than use
`$this->table_element`.
