### PR TITLE
NEW print without details

### DIFF
--- a/htdocs/langs/en_US/cashdesk.lang
+++ b/htdocs/langs/en_US/cashdesk.lang
@@ -130,3 +130,6 @@ ShowPriceHT = Display the column with the price excluding tax (on screen)
 ShowPriceHTOnReceipt = Display the column with the price excluding tax (on the receipt)
 CustomerDisplay=Customer display
 SplitSale=Split sale
+PrintWithoutDetailsButton=Add "Print without details" button
+PrintWithoutDetailsLabelDefault=Line label by default on printing without details
+PrintWithoutDetails=Print without details

--- a/htdocs/langs/fr_FR/cashdesk.lang
+++ b/htdocs/langs/fr_FR/cashdesk.lang
@@ -129,3 +129,6 @@ WeighingScale=échelle de poids
 ShowPriceHT = Afficher la colonne du prix HT (à l'écran)
 ShowPriceHTOnReceipt = Afficher la colonne avec le prix hors taxes (sur le ticket de caisse)
 CustomerDisplay=Customer display
+PrintWithoutDetailsButton=Ajouter un bouton "Imprimer sans détail"
+PrintWithoutDetailsLabelDefault=Libellé de la ligne par défaut sur l'impression sans détail
+PrintWithoutDetails=Imprimer sans détail

--- a/htdocs/takepos/admin/receipt.php
+++ b/htdocs/takepos/admin/receipt.php
@@ -51,6 +51,7 @@ if (GETPOST('action', 'alpha') == 'set') {
 	$res = dolibarr_set_const($db, "TAKEPOS_AUTO_PRINT_TICKETS", GETPOST('TAKEPOS_AUTO_PRINT_TICKETS', 'int'), 'int', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "TAKEPOS_PRINT_SERVER", GETPOST('TAKEPOS_PRINT_SERVER', 'alpha'), 'chaine', 0, '', $conf->entity);
 	$res = dolibarr_set_const($db, "TAKEPOS_PRINT_PAYMENT_METHOD", GETPOST('TAKEPOS_PRINT_PAYMENT_METHOD', 'alpha'), 'chaine', 0, '', $conf->entity);
+	$res = dolibarr_set_const($db, 'TAKEPOS_PRINT_WITHOUT_DETAILS_LABEL_DEFAULT', GETPOST('TAKEPOS_PRINT_WITHOUT_DETAILS_LABEL_DEFAULT', 'alphanohtml'), 'chaine', 0, '', $conf->entity);
 
 	dol_syslog("admin/cashdesk: level ".GETPOST('level', 'alpha'));
 
@@ -259,6 +260,20 @@ if ($conf->global->TAKEPOS_PRINT_METHOD == "takeposconnector" && filter_var($con
 	print $langs->trans('CustomerDisplay');
 	print '<td colspan="2">';
 	print ajax_constantonoff("TAKEPOS_CUSTOMER_DISPLAY", array(), $conf->entity, 0, 0, 1, 0);
+	print "</td></tr>\n";
+}
+
+// Print without details
+print '<tr class="oddeven"><td>';
+print $langs->trans('PrintWithoutDetailsButton');
+print '<td colspan="2">';
+print ajax_constantonoff('TAKEPOS_PRINT_WITHOUT_DETAILS', array(), $conf->entity, 0, 0, 1, 0);
+print "</td></tr>\n";
+if (!empty($conf->global->TAKEPOS_PRINT_WITHOUT_DETAILS)) {
+	print '<tr class="oddeven"><td>';
+	print $langs->trans('PrintWithoutDetailsLabelDefault');
+	print '<td colspan="2">';
+	print '<input type="text" name="TAKEPOS_PRINT_WITHOUT_DETAILS_LABEL_DEFAULT" value="' . getDolGlobalString('TAKEPOS_PRINT_WITHOUT_DETAILS_LABEL_DEFAULT') . '" />';
 	print "</td></tr>\n";
 }
 

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -158,7 +158,7 @@ if ($ret > 0) {
 	$placeid = $invoice->id;
 }
 
-$constforcompanyid = 'CASHDESK_ID_THIRDPARTY'. isset($_SESSION["takeposterminal"]) ? $_SESSION["takeposterminal"] : '' ;
+$constforcompanyid = 'CASHDESK_ID_THIRDPARTY'. (isset($_SESSION["takeposterminal"]) ? $_SESSION["takeposterminal"] : '');
 
 $soc = new Societe($db);
 if ($invoice->socid > 0) {
@@ -877,6 +877,9 @@ if ($action == "valid" || $action == "history" || $action == 'creditnote') {
 		$sectionwithinvoicelink .= ' <button id="buttonprint" type="button" onclick="DolibarrTakeposPrinting('.$placeid.');">'.$langs->trans('PrintTicket').'</button>';
 	} else {
 		$sectionwithinvoicelink .= ' <button id="buttonprint" type="button" onclick="Print('.$placeid.');">'.$langs->trans('PrintTicket').'</button>';
+		if (getDolGlobalString('TAKEPOS_PRINT_WITHOUT_DETAILS')) {
+			$sectionwithinvoicelink .= ' <button id="buttonprint" type="button" onclick="PrintBox('.$placeid.', \'without_details\');">'.$langs->trans('PrintWithoutDetails').'</button>';
+		}
 		if (getDolGlobalString('TAKEPOS_GIFT_RECEIPT')) {
 			$sectionwithinvoicelink .= ' <button id="buttonprint" type="button" onclick="Print('.$placeid.', 1);">'.$langs->trans('GiftReceipt').'</button>';
 		}
@@ -1015,6 +1018,11 @@ function SendTicket(id)
 {
 	console.log("Open box to select the Print/Send form");
 	$.colorbox({href:"send.php?facid="+id, width:"70%", height:"30%", transition:"none", iframe:"true", title:'<?php echo dol_escape_js($langs->trans("SendTicket")); ?>'});
+}
+
+function PrintBox(id, action) {
+	console.log("Open box before printing");
+	$.colorbox({href:"printbox.php?facid="+id+"&action="+action, width:"80%", height:"200px", transition:"none", iframe:"true", title:"<?php echo $langs->trans("PrintWithoutDetails"); ?>"});
 }
 
 function Print(id, gift){

--- a/htdocs/takepos/printbox.php
+++ b/htdocs/takepos/printbox.php
@@ -1,0 +1,102 @@
+<?php
+/* Copyright (C) 2018 Andreu Bisquerra	<jove@bisquerra.com>
+ * Copyright (C) 2020 Laurent Destailleur  <eldy@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *	\file       htdocs/takepos/printbox.php
+ *	\ingroup    takepos
+ *	\brief      Popup to enter details before printing
+ */
+
+//if (! defined('NOREQUIREUSER'))	define('NOREQUIREUSER','1');	// Not disabled cause need to load personalized language
+//if (! defined('NOREQUIREDB'))		define('NOREQUIREDB','1');		// Not disabled cause need to load personalized language
+//if (! defined('NOREQUIRESOC'))	define('NOREQUIRESOC','1');
+//if (! defined('NOREQUIRETRAN'))	define('NOREQUIRETRAN','1');
+if (!defined('NOCSRFCHECK')) {
+	define('NOCSRFCHECK', '1');
+}
+if (!defined('NOTOKENRENEWAL')) {
+	define('NOTOKENRENEWAL', '1');
+}
+if (!defined('NOREQUIREMENU')) {
+	define('NOREQUIREMENU', '1');
+}
+if (!defined('NOREQUIREHTML')) {
+	define('NOREQUIREHTML', '1');
+}
+if (!defined('NOREQUIREAJAX')) {
+	define('NOREQUIREAJAX', '1');
+}
+
+require '../main.inc.php'; // Load $user and permissions
+require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
+
+global $langs, $db;
+
+$langs->loadLangs(array("bills", "cashdesk"));
+
+$facid = GETPOST('facid', 'int');
+
+$action = GETPOST('action', 'aZ09');
+
+if (empty($user->rights->takepos->run)) {
+	accessforbidden();
+}
+
+
+/*
+ * View
+ */
+
+$arrayofcss = array('/takepos/css/pos.css.php');
+$arrayofjs = array('/takepos/js/jquery.colorbox-min.js');
+
+$head = '';
+top_htmlhead($head, '', 0, 0, $arrayofjs, $arrayofcss);
+?>
+<script>
+	/**
+	 * Save (validate)
+	 */
+	function Save() {
+		console.log("We click so we call page receipt.php with facid=<?php echo $facid; ?>");
+		parent.$.colorbox.close();
+		$.colorbox({href:"receipt.php?facid=<?php echo $facid; ?>&action=<?php echo $action; ?>&label="+$('#label').val()+"&qty="+$('#qty').val(), width:"40%", height:"90%", transition:"none", iframe:"true", title:'<?php echo dol_escape_js($langs->trans("PrintTicket")); ?>'});
+	}
+
+	jQuery(document).ready(function(){
+		$('#label').focus()
+	});
+</script>
+</head>
+<body>
+<br>
+<center>
+<?php
+	if ($action == "without_details") {
+		$label_default = getDolGlobalString('TAKEPOS_PRINT_WITHOUT_DETAILS_LABEL_DEFAULT');
+		$qty_default = 1;
+
+		print '<input type="text" id="label" name="label" class="takepospay" value="' . $label_default . '" style="width:40%;" placeholder="' . $langs->trans('Label') . '">';
+		print '<input type="text" id="qty" name="qty" class="takepospay" value="' . $qty_default . '" style="width:10%;" placeholder="' . $langs->trans('Qty') . '">';
+	}
+?>
+<input type="button" class="button takepospay clearboth" value="OK" onclick="Save();">
+</center>
+
+</body>
+</html>

--- a/htdocs/takepos/printbox.php
+++ b/htdocs/takepos/printbox.php
@@ -87,13 +87,13 @@ top_htmlhead($head, '', 0, 0, $arrayofjs, $arrayofcss);
 <br>
 <center>
 <?php
-	if ($action == "without_details") {
-		$label_default = getDolGlobalString('TAKEPOS_PRINT_WITHOUT_DETAILS_LABEL_DEFAULT');
-		$qty_default = 1;
+if ($action == "without_details") {
+	$label_default = getDolGlobalString('TAKEPOS_PRINT_WITHOUT_DETAILS_LABEL_DEFAULT');
+	$qty_default = 1;
 
-		print '<input type="text" id="label" name="label" class="takepospay" value="' . $label_default . '" style="width:40%;" placeholder="' . $langs->trans('Label') . '">';
-		print '<input type="text" id="qty" name="qty" class="takepospay" value="' . $qty_default . '" style="width:10%;" placeholder="' . $langs->trans('Qty') . '">';
-	}
+	print '<input type="text" id="label" name="label" class="takepospay" value="' . $label_default . '" style="width:40%;" placeholder="' . $langs->trans('Label') . '">';
+	print '<input type="text" id="qty" name="qty" class="takepospay" value="' . $qty_default . '" style="width:10%;" placeholder="' . $langs->trans('Qty') . '">';
+}
 ?>
 <input type="button" class="button takepospay clearboth" value="OK" onclick="Save();">
 </center>

--- a/htdocs/takepos/receipt.php
+++ b/htdocs/takepos/receipt.php
@@ -54,6 +54,7 @@ $place = (GETPOST('place', 'aZ09') ? GETPOST('place', 'aZ09') : 0); // $place is
 
 $facid = GETPOST('facid', 'int');
 
+$action = GETPOST('action', 'aZ09');
 $gift = GETPOST('gift', 'int');
 
 if (empty($user->rights->takepos->run)) {
@@ -169,33 +170,46 @@ if ($conf->global->TAKEPOS_SHOW_CUSTOMER) {
 	</thead>
 	<tbody>
 	<?php
-	foreach ($object->lines as $line) {
-		?>
-	<tr>
-		<td>
-		<?php if (!empty($line->product_label)) {
-			echo $line->product_label;
-		} else {
-			echo $line->description;
-		} ?>
-		</td>
-		<td class="right"><?php echo $line->qty; ?></td>
-		<td class="right"><?php if ($gift != 1) {
-			echo price(price2num($line->total_ttc / $line->qty, 'MT'), 1);
-						  } ?></td>
-		<?php
-		if (!empty($conf->global->TAKEPOS_SHOW_HT_RECEIPT)) { ?>
-					<td class="right"><?php if ($gift != 1) {
-						echo price($line->total_ht, 1);
-									  } ?></td>
+	if ($action == 'without_details') {
+		$qty = GETPOST('qty', 'int') > 0 ? GETPOST('qty', 'int') : 1;
+		print '<tr>';
+		print '<td>' . GETPOST('label', 'alphanohtml') . '</td>';
+		print '<td class="right">' . $qty . '</td>';
+		print '<td class="right">' . price(price2num($object->total_ttc / $qty, 'MU'), 1) . '</td>';
+		if (!empty($conf->global->TAKEPOS_SHOW_HT_RECEIPT)) {
+			print '<td class="right">' . price($object->total_ht, 1) . '</td>';
+		}
+		print '<td class="right">' . price($object->total_ttc, 1) . '</td>';
+		print '</tr>';
+	} else {
+		foreach ($object->lines as $line) {
+			?>
+		<tr>
+			<td>
+			<?php if (!empty($line->product_label)) {
+				echo $line->product_label;
+			} else {
+				echo $line->description;
+			} ?>
+			</td>
+			<td class="right"><?php echo $line->qty; ?></td>
+			<td class="right"><?php if ($gift != 1) {
+				echo price(price2num($line->total_ttc / $line->qty, 'MT'), 1);
+							  } ?></td>
+			<?php
+			if (!empty($conf->global->TAKEPOS_SHOW_HT_RECEIPT)) { ?>
+						<td class="right"><?php if ($gift != 1) {
+							echo price($line->total_ht, 1);
+										  } ?></td>
+				<?php
+			}
+			?>
+			<td class="right"><?php if ($gift != 1) {
+				echo price($line->total_ttc, 1);
+							  } ?></td>
+		</tr>
 			<?php
 		}
-		?>
-		<td class="right"><?php if ($gift != 1) {
-			echo price($line->total_ttc, 1);
-						  } ?></td>
-	</tr>
-		<?php
 	}
 	?>
 	</tbody>


### PR DESCRIPTION
NEW print without details

You can print a ticket in cashdesk without all lines.
You can put your own label with the quantity and the price and total price with taxes are automatically computed.

- add a "Print without details" button and a default label in "takepos" setup (receipt tab)

![image](https://user-images.githubusercontent.com/45359511/136343788-54a07eb0-61ba-4cf7-ae11-e5b7bd8d1b8b.png)

-  in the cashdesk you have a new "print without details" button (closed to the "print" button)

![image](https://user-images.githubusercontent.com/45359511/136344111-40b284c6-8459-462e-a266-364952c3ecc3.png)

- after you can put the label and quantity before printing

![image](https://user-images.githubusercontent.com/45359511/136344526-446c5a5f-ecf2-4fe4-8999-8757567930d2.png)

- and you launch print with "OK" button

![image](https://user-images.githubusercontent.com/45359511/136344672-02b37f60-56ff-4315-a4e7-ec84fc330ddd.png)


