### PR TITLE
FIX optional visibility on create card

### DIFF
--- a/htdocs/asset/type.php
+++ b/htdocs/asset/type.php
@@ -389,7 +389,7 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit', $parameters);
+		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 	print '<tbody>';
 	print "</table>\n";

--- a/htdocs/categories/card.php
+++ b/htdocs/categories/card.php
@@ -266,7 +266,7 @@ if ($user->rights->categorie->creer) {
 		$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 		print $hookmanager->resPrint;
 		if (empty($reshook)) {
-			print $object->showOptionals($extrafields, 'edit', $parameters);
+			print $object->showOptionals($extrafields, 'create', $parameters);
 		}
 
 		print '</table>';

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -1262,7 +1262,7 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit', $parameters);
+		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 
 	print '</table>';

--- a/htdocs/comm/mailing/card.php
+++ b/htdocs/comm/mailing/card.php
@@ -726,7 +726,7 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit');
+		print $object->showOptionals($extrafields, 'create');
 	}
 
 	print '</table>';

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1721,7 +1721,7 @@ if ($action == 'create' && $usercancreate) {
 			}
 		};
 
-		print $object->showOptionals($extrafields, 'edit', $parameters);
+		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 
 	// Template to use by default

--- a/htdocs/compta/bank/card.php
+++ b/htdocs/compta/bank/card.php
@@ -444,7 +444,7 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit', $parameters);
+		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 
 	print '</table>';

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3636,7 +3636,7 @@ if ($action == 'create') {
 			}
 		};
 
-		print $object->showOptionals($extrafields, 'edit', $parameters);
+		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 
 	// Template to use by default

--- a/htdocs/don/card.php
+++ b/htdocs/don/card.php
@@ -492,7 +492,7 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit', $parameters);
+		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 
 	print '</tbody>';

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1421,7 +1421,7 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit', $parameters);
+		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 
 	print '<tbody>';

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -930,7 +930,7 @@ if ($action == 'create') {
 		$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 		print $hookmanager->resPrint;
 		if (empty($reshook)) {
-			print $object->showOptionals($extrafields, 'edit');
+			print $object->showOptionals($extrafields, 'create');
 		}
 
 		// Show link to origin object

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1760,7 +1760,7 @@ if ($action == 'create') {
 	print $hookmanager->resPrint;
 
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit');
+		print $object->showOptionals($extrafields, 'create');
 	}
 
 	// Bouton "Create Draft"

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2270,7 +2270,7 @@ if ($action == 'create') {
 	}
 
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit');
+		print $object->showOptionals($extrafields, 'create');
 	}
 
 	// Public note

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1334,7 +1334,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 		$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 		print $hookmanager->resPrint;
 		if (empty($reshook)) {
-			print $object->showOptionals($extrafields, 'edit', $parameters);
+			print $object->showOptionals($extrafields, 'create', $parameters);
 		}
 
 		// Note (private, no output on invoices, propales...)

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -869,7 +869,7 @@ if ($action == 'create') {
 				if ($objectsrc->fetch_optionals() > 0) {
 					$recept->array_options = array_merge($recept->array_options, $objectsrc->array_options);
 				}
-				print $object->showOptionals($extrafields, 'edit', $parameters);
+				print $object->showOptionals($extrafields, 'create', $parameters);
 			}
 
 			// Incoterms

--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -576,7 +576,7 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit');
+		print $object->showOptionals($extrafields, 'create');
 	}
 
 	print '</table>';

--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -1233,7 +1233,7 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	if (empty($reshook)) {
-		print $object->showOptionals($extrafields, 'edit', $parameters);
+		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 
 


### PR DESCRIPTION
FIX optional visibility on create card

- on "create" action you had "edit" mode in several cards
- so if you add an extrafield with visibility level 4 (hidden on create form), this field still remains on create form

Exemple : 

- add this extra field on customer invoices

![image](https://user-images.githubusercontent.com/45359511/136570949-49eb7ac2-78c7-4c4b-bb9d-c7b8ea532fa2.png)

-  and on create invoice form this field is here

![image](https://user-images.githubusercontent.com/45359511/136571231-d61192b0-bba4-4cda-a9f8-76cb85eadb24.png)


