### PR TITLE
FIX: consistent UX when calling a tab from the invoice card with empty ref/id

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2763,7 +2763,6 @@ if (empty($object->id)) {
 	echo dol_get_fiche_head($head, 'compta', $langs->trans("InvoiceCustomer"), -1, 'bill'),
 		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
 	llxFooter();
-	dol_shutdown();
 	exit;
 }
 

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2756,6 +2756,17 @@ if (empty($reshook))
  * View
  */
 
+if (empty($object->id)) {
+	llxHeader();
+	$head = facture_prepare_head($object);
+	$langs->load('errors');
+	echo dol_get_fiche_head($head, 'compta', $langs->trans("InvoiceCustomer"), -1, 'bill'),
+		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
+	llxFooter();
+	dol_shutdown();
+	exit;
+}
+
 $form = new Form($db);
 $formother = new FormOther($db);
 $formfile = new FormFile($db);

--- a/htdocs/compta/facture/contact.php
+++ b/htdocs/compta/facture/contact.php
@@ -125,7 +125,6 @@ if (empty($object->id)) {
 	echo dol_get_fiche_head($head, 'contact', $langs->trans("InvoiceCustomer"), -1, 'bill'),
 		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
 	llxFooter();
-	dol_shutdown();
 	exit;
 }
 

--- a/htdocs/compta/facture/contact.php
+++ b/htdocs/compta/facture/contact.php
@@ -118,6 +118,17 @@ elseif ($action == 'deletecontact' && $user->rights->facture->creer)
  * View
  */
 
+if (empty($object->id)) {
+	llxHeader();
+	$head = facture_prepare_head($object);
+	$langs->load('errors');
+	echo dol_get_fiche_head($head, 'contact', $langs->trans("InvoiceCustomer"), -1, 'bill'),
+		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
+	llxFooter();
+	dol_shutdown();
+	exit;
+}
+
 $title = $langs->trans('InvoiceCustomer')." - ".$langs->trans('ContactsAddresses');
 $helpurl = "EN:Customers_Invoices|FR:Factures_Clients|ES:Facturas_a_clientes";
 llxHeader('', $title, $helpurl);

--- a/htdocs/compta/facture/document.php
+++ b/htdocs/compta/facture/document.php
@@ -92,7 +92,6 @@ if (empty($object->id)) {
 	echo dol_get_fiche_head($head, 'documents', $langs->trans("InvoiceCustomer"), -1, 'bill'),
 		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
 	llxFooter();
-	dol_shutdown();
 	exit;
 }
 

--- a/htdocs/compta/facture/document.php
+++ b/htdocs/compta/facture/document.php
@@ -85,6 +85,17 @@ require_once DOL_DOCUMENT_ROOT.'/core/actions_linkedfiles.inc.php';
  * View
  */
 
+if (empty($object->id)) {
+	llxHeader();
+	$head = facture_prepare_head($object);
+	$langs->load('errors');
+	echo dol_get_fiche_head($head, 'documents', $langs->trans("InvoiceCustomer"), -1, 'bill'),
+		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
+	llxFooter();
+	dol_shutdown();
+	exit;
+}
+
 $title = $langs->trans('InvoiceCustomer')." - ".$langs->trans('Documents');
 $helpurl = "EN:Customers_Invoices|FR:Factures_Clients|ES:Facturas_a_clientes";
 llxHeader('', $title, $helpurl);

--- a/htdocs/compta/facture/info.php
+++ b/htdocs/compta/facture/info.php
@@ -43,6 +43,17 @@ $ref = GETPOST("ref", 'alpha');
  * View
  */
 
+if (empty($object->id)) {
+	llxHeader();
+	$head = facture_prepare_head($object);
+	$langs->load('errors');
+	echo dol_get_fiche_head($head, 'info', $langs->trans("InvoiceCustomer"), -1, 'bill'),
+		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
+	llxFooter();
+	dol_shutdown();
+	exit;
+}
+
 $form = new Form($db);
 
 $title = $langs->trans('InvoiceCustomer')." - ".$langs->trans('Info');

--- a/htdocs/compta/facture/info.php
+++ b/htdocs/compta/facture/info.php
@@ -50,7 +50,6 @@ if (empty($object->id)) {
 	echo dol_get_fiche_head($head, 'info', $langs->trans("InvoiceCustomer"), -1, 'bill'),
 		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
 	llxFooter();
-	dol_shutdown();
 	exit;
 }
 

--- a/htdocs/compta/facture/note.php
+++ b/htdocs/compta/facture/note.php
@@ -71,7 +71,6 @@ if (empty($object->id)) {
 	echo dol_get_fiche_head($head, 'note', $langs->trans("InvoiceCustomer"), -1, 'bill'),
 		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
 	llxFooter();
-	dol_shutdown();
 	exit;
 }
 

--- a/htdocs/compta/facture/note.php
+++ b/htdocs/compta/facture/note.php
@@ -64,6 +64,17 @@ include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php';	// Must be include, 
  * View
  */
 
+if (empty($object->id)) {
+	llxHeader();
+	$head = facture_prepare_head($object);
+	$langs->load('errors');
+	echo dol_get_fiche_head($head, 'note', $langs->trans("InvoiceCustomer"), -1, 'bill'),
+		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
+	llxFooter();
+	dol_shutdown();
+	exit;
+}
+
 $title = $langs->trans('InvoiceCustomer')." - ".$langs->trans('Notes');
 $helpurl = "EN:Customers_Invoices|FR:Factures_Clients|ES:Facturas_a_clientes";
 llxHeader('', $title, $helpurl);


### PR DESCRIPTION
# Fix
Currently, if you call a tab from the invoice card without providing an invoice ID or ref, the user experience is inconsistent: for most pages the user will get a blank page, for documents, an error message, and for pages with modules implementing hooks, it might even lead to fatals.

Example: https://demo.dolibarr.org/compta/facture/card.php?facid=

This PR tries to make it more consistent. For future Dolibarr versions, it might be a good idea to create functions to handle this, but I thought it was out of scope for a fix.