### PR TITLE
NEW : info of number of product still to dispatched in a supplier order

### DIFF
--- a/htdocs/core/lib/fourn.lib.php
+++ b/htdocs/core/lib/fourn.lib.php
@@ -162,14 +162,17 @@ function ordersupplier_prepare_head($object)
 
 		//If dispach process running we add the number of item to dispatch into the head
 		if ($object->statut == '3' OR $object->statut == '4' OR $object->statut == '5') {
-			$lines = $object->fetch_lines();
+			$object->fetch_lines();
+			$nbLinesOrdered = count($object->lines);
 			$dispachedLines = $object->getDispachedLines(1);
+			$nbDispachedLines = count($dispachedLines);
+
 			$sumQtyAllreadyDispatched = 0;
-			for ($line = 0 ; $line < count($dispachedLines); $line++) {
+			for ($line = 0 ; $line < $nbDispachedLines; $line++) {
 				$sumQtyAllreadyDispatched = $sumQtyAllreadyDispatched + $dispachedLines[$line]['qty'];
 			}
 			$sumQtyOrdered = 0;
-			for ($line = 0 ; $line < count($object->lines); $line++) {
+			for ($line = 0 ; $line < $nbLinesOrdered; $line++) {
 				$sumQtyOrdered = $sumQtyOrdered + $object->lines[$line]->qty;
 			}
 			$head[$h][1] .= '<span class="badge marginleftonlyshort">'.$sumQtyAllreadyDispatched.' / '.$sumQtyOrdered.'</span>';

--- a/htdocs/core/lib/fourn.lib.php
+++ b/htdocs/core/lib/fourn.lib.php
@@ -157,8 +157,12 @@ function ordersupplier_prepare_head($object)
 
 	if (!empty($conf->stock->enabled) && (!empty($conf->global->STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER) || !empty($conf->global->STOCK_CALCULATE_ON_RECEPTION) || !empty($conf->global->STOCK_CALCULATE_ON_RECEPTION_CLOSE))) {
 		$langs->load("stocks");
+		$nbLineToDispatch = count($object->getNotCompletlyDispatchedLines());
 		$head[$h][0] = DOL_URL_ROOT.'/fourn/commande/dispatch.php?id='.$object->id;
 		$head[$h][1] = $langs->trans("OrderDispatch");
+		if ($nbLineToDispatch > 0) {
+			$head[$h][1] .= '<span class="badge marginleftonlyshort">'.$nbLineToDispatch.'</span>';
+		}
 		$head[$h][2] = 'dispatch';
 		$h++;
 	}

--- a/htdocs/core/lib/fourn.lib.php
+++ b/htdocs/core/lib/fourn.lib.php
@@ -159,22 +159,22 @@ function ordersupplier_prepare_head($object)
 		$langs->load("stocks");
 		$head[$h][0] = DOL_URL_ROOT.'/fourn/commande/dispatch.php?id='.$object->id;
 		$head[$h][1] = $langs->trans("OrderDispatch");
-		
+
 		//If dispach process running we add the number of item to dispatch into the head
 		if ($object->statut == '3' OR $object->statut == '4' OR $object->statut == '5') {
 			$lines = $object->fetch_lines();
 			$dispachedLines = $object->getDispachedLines(1);
 			$sumQtyAllreadyDispatched = 0;
-			for ($line = 0 ; $line < count($dispachedLines) ; $line++) {
+			for ($line = 0 ; $line < count($dispachedLines); $line++) {
 				$sumQtyAllreadyDispatched = $sumQtyAllreadyDispatched + $dispachedLines[$line]['qty'];
 			}
 			$sumQtyOrdered = 0;
-			for ($line = 0 ; $line < count($object->lines) ; $line++) {
+			for ($line = 0 ; $line < count($object->lines); $line++) {
 				$sumQtyOrdered = $sumQtyOrdered + $object->lines[$line]->qty;
-			}		
+			}
 			$head[$h][1] .= '<span class="badge marginleftonlyshort">'.$sumQtyAllreadyDispatched.' / '.$sumQtyOrdered.'</span>';
 		}
-		
+
 		$head[$h][2] = 'dispatch';
 		$h++;
 	}

--- a/htdocs/core/lib/fourn.lib.php
+++ b/htdocs/core/lib/fourn.lib.php
@@ -157,12 +157,24 @@ function ordersupplier_prepare_head($object)
 
 	if (!empty($conf->stock->enabled) && (!empty($conf->global->STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER) || !empty($conf->global->STOCK_CALCULATE_ON_RECEPTION) || !empty($conf->global->STOCK_CALCULATE_ON_RECEPTION_CLOSE))) {
 		$langs->load("stocks");
-		$nbLineToDispatch = count($object->getNotCompletlyDispatchedLines());
 		$head[$h][0] = DOL_URL_ROOT.'/fourn/commande/dispatch.php?id='.$object->id;
 		$head[$h][1] = $langs->trans("OrderDispatch");
-		if ($nbLineToDispatch > 0) {
-			$head[$h][1] .= '<span class="badge marginleftonlyshort">'.$nbLineToDispatch.'</span>';
+		
+		//If dispach process running we add the number of item to dispatch into the head
+		if ($object->statut == '3' OR $object->statut == '4' OR $object->statut == '5') {
+			$lines = $object->fetch_lines();
+			$dispachedLines = $object->getDispachedLines(1);
+			$sumQtyAllreadyDispatched = 0;
+			for ($line = 0 ; $line < count($dispachedLines) ; $line++) {
+				$sumQtyAllreadyDispatched = $sumQtyAllreadyDispatched + $dispachedLines[$line]['qty'];
+			}
+			$sumQtyOrdered = 0;
+			for ($line = 0 ; $line < count($object->lines) ; $line++) {
+				$sumQtyOrdered = $sumQtyOrdered + $object->lines[$line]->qty;
+			}		
+			$head[$h][1] .= '<span class="badge marginleftonlyshort">'.$sumQtyAllreadyDispatched.' / '.$sumQtyOrdered.'</span>';
 		}
+		
 		$head[$h][2] = 'dispatch';
 		$h++;
 	}

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2287,7 +2287,7 @@ class CommandeFournisseur extends CommonOrder
 		$sql .= " dispatch.rowid as dispatchedlineid, sum(dispatch.qty) as qty_dispatched";
 		$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as supplierOrderDet";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as dispatch ON supplierOrderDet.rowid = dispatch.fk_commandefourndet";
-		$sql .= " WHERE supplierOrderDet.fk_commande = ".$this->id;
+		$sql .= " WHERE supplierOrderDet.fk_commande = ".((int) $this->id);
 		$sql .= " GROUP BY supplierOrderDet.fk_product";
 
 		$resql = $this->db->query($sql);

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2274,50 +2274,6 @@ class CommandeFournisseur extends CommonOrder
 		return $ret;
 	}
 
-	/**
-	 * Return array of the lines that are waiting to be dispatched
-	 *
-	 * @return	array				Array of lines
-	 */
-	public function getNotCompletlyDispatchedLines()
-	{
-		$ret = array();
-
-		$sql = "SELECT supplierOrderDet.fk_product as product_id, supplierOrderDet.qty as qty_ordered, supplierOrderDet.fk_commande,";
-		$sql .= " dispatch.rowid as dispatchedlineid, sum(dispatch.qty) as qty_dispatched";
-		$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as supplierOrderDet";
-		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as dispatch ON supplierOrderDet.rowid = dispatch.fk_commandefourndet";
-		$sql .= " WHERE supplierOrderDet.fk_commande = ".((int) $this->id);
-		$sql .= " GROUP BY supplierOrderDet.fk_product";
-
-		$resql = $this->db->query($sql);
-
-		if ($resql) {
-			$num = $this->db->num_rows($resql);
-			$i = 0;
-
-			while ($i < $num) {
-				$objp = $this->db->fetch_object($resql);
-
-				if ($objp) {
-					// If product not completly dispatched
-					if (is_null($objp->qty_dispatched) OR ($objp->qty_dispatched < $objp->qty_ordered)) {
-						$ret[] = array(
-							'product_id' => $objp->product_id,
-							'qty_ordered' => $objp->qty_ordered,
-							'qty_dispatched' => $objp->qty_dispatched,
-						);
-					}
-				}
-				$i++;
-			}
-		} else {
-			dol_print_error($this->db, 'Failed to execute request to get not completly dispatched lines');
-		}
-
-		return $ret;
-	}
-
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 * 	Set a delivery in database for this supplier order

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2289,7 +2289,7 @@ class CommandeFournisseur extends CommonOrder
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as dispatch ON supplierOrderDet.rowid = dispatch.fk_commandefourndet";
 		$sql .= " WHERE supplierOrderDet.fk_commande = ".$this->id;
 		$sql .= " GROUP BY supplierOrderDet.fk_product";
-		
+
 		$resql = $this->db->query($sql);
 
 		if ($resql) {
@@ -2301,7 +2301,7 @@ class CommandeFournisseur extends CommonOrder
 
 				if ($objp) {
 					// If product not completly dispatched
-					if (is_null($objp->qty_dispatched) OR ($objp->qty_dispatched < $objp->qty_ordered)){
+					if (is_null($objp->qty_dispatched) OR ($objp->qty_dispatched < $objp->qty_ordered)) {
 						$ret[] = array(
 							'product_id' => $objp->product_id,
 							'qty_ordered' => $objp->qty_ordered,


### PR DESCRIPTION
When you are in the tab "Commande fournisseur" you can now see if you have some product to receive and dispatch.
With this it's more user friendly to see if there is still an action to do in the dispatch product of the supplier order.

For example here you have still 2 product to receive and dispatch from your supplier order.
![image](https://user-images.githubusercontent.com/74144396/137109579-a8befec7-7248-4f19-857c-10b663fedcff.png)


Then, you have 1.
![image](https://user-images.githubusercontent.com/74144396/137109530-3466da92-23e1-4bf5-a76d-237b72ca1651.png)

