### PR TITLE
FIX fatal error in php 8.0

### DIFF
--- a/htdocs/eventorganization/class/conferenceorbooth.class.php
+++ b/htdocs/eventorganization/class/conferenceorbooth.class.php
@@ -238,9 +238,10 @@ class ConferenceOrBooth extends ActionComm
 	 * @param string $ref  Ref
 	 * @param  string	$ref_ext		Ref ext to get
 	 * @param	string	$email_msgid	Email msgid
+	 * @param int 		$loadresources	1=Load also resources
 	 * @return int         <0 if KO, 0 if not found, >0 if OK
 	 */
-	public function fetch($id, $ref = null, $ref_ext = '', $email_msgid = '')
+	public function fetch($id, $ref = null, $ref_ext = '', $email_msgid = '', $loadresources = 1)
 	{
 		global $dolibarr_main_url_root, $conf, $langs;
 


### PR DESCRIPTION
Fix fatal error in php 8.0 on eventorganization module because fetch was not compatible with ActionComm:fetch 