### PR TITLE
FIX payment style and html5 tags

### DIFF
--- a/htdocs/takepos/css/pos.css.php
+++ b/htdocs/takepos/css/pos.css.php
@@ -320,12 +320,11 @@ table.postablelines tr td {
 
 div.paymentbordline
 {
-	width:calc(50% - 16px);
-	background-color:#888;
+	background-color: #888;
 	border-radius: 8px;
-	margin-bottom: 4px;
-	display: inline-block;
+	margin: 4px auto;
 	padding: 5px;
+	width: calc(50% - 10px);
 }
 
 @media only screen and (max-aspect-ratio: 6/4) {

--- a/htdocs/takepos/css/pos.css.php
+++ b/htdocs/takepos/css/pos.css.php
@@ -320,11 +320,12 @@ table.postablelines tr td {
 
 div.paymentbordline
 {
-	background-color: #888;
+	width:calc(50% - 16px);
+	background-color:#888;
 	border-radius: 8px;
-	margin: 4px auto;
+	margin-bottom: 4px;
+	display: inline-block;
 	padding: 5px;
-	width: calc(50% - 10px);
 }
 
 @media only screen and (max-aspect-ratio: 6/4) {

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -37,9 +37,9 @@ if (!defined('NOREQUIREMENU')) {
 if (!defined('NOREQUIREHTML')) {
 	define('NOREQUIREHTML', '1');
 }
-if (!defined('NOREQUIREAJAX')) {
-	define('NOREQUIREAJAX', '1');
-}
+//if (!defined('NOREQUIREAJAX')) {
+//	define('NOREQUIREAJAX', '1');
+//}
 
 require '../main.inc.php'; // Load $user and permissions
 require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
@@ -257,38 +257,36 @@ if ($conf->global->TAKEPOS_NUMPAD == 0) {
 	}
 </script>
 
-<div style="position:relative; padding-top: 20px; left:5%; height:150px; width:90%;">
-
-<div class="paymentbordline paymentbordlinetotal">
-	<center><span class="takepospay"><font color="white"><?php echo $langs->trans('TotalTTC'); ?>: </font><span id="totaldisplay" class="colorwhite"><?php echo price($invoice->total_ttc, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span></span></center>
+<div style="position:relative; padding-top: 16px; left:5%; min-height: 150px; width:90%;">
+	<div class="center">
+		<div class="paymentbordline paymentbordlinetotal">
+			<span class="takepospay colorwhite"><?php echo $langs->trans('TotalTTC'); ?>: <span id="totaldisplay"><?php echo price($invoice->total_ttc, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span></span>
+		</div>
+		<?php if ($remaintopay != $invoice->total_ttc) { ?>
+		<div class="paymentbordline paymentbordlineremain">
+			<span class="takepospay colorwhite"><?php echo $langs->trans('RemainToPay'); ?>: <span id="remaintopaydisplay"><?php echo price($remaintopay, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span></span>
+		</div>
+		<?php } ?>
+		<div class="paymentbordline paymentbordlinereceived">
+			<span class="takepospay colorwhite"><?php echo $langs->trans("Received"); ?>: <span class="change1 colorred"><?php echo price(0, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span><input type="hidden" id="change1" class="change1" value="0"></span>
+		</div>
+		<div class="paymentbordline paymentbordlinechange">
+			<span class="takepospay colorwhite"><?php echo $langs->trans("Change"); ?>: <span class="change2"><?php echo price(0, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span><input type="hidden" id="change2" class="change2" value="0"></span>
+		</div>
+		<?php
+		if (!empty($conf->global->TAKEPOS_CAN_FORCE_BANK_ACCOUNT_DURING_PAYMENT)) {
+			require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
+			print '<div class="paymentbordline paddingtop paddingbottom">';
+			$filter = '';
+			$form = new Form($db);
+			print '<span class="takepospay"><font color="white">'.$langs->trans("BankAccount").': </font></span>';
+			$form->select_comptes(0, 'accountid', 0, $filter, 1, '');
+			print ajax_combobox('selectaccountid');
+			print '</div>';
+		}
+		?>
+	</div>
 </div>
-<?php if ($remaintopay != $invoice->total_ttc) { ?>
-<div class="paymentbordline paymentbordlineremain">
-	<center><span class="takepospay"><font color="white"><?php echo $langs->trans('RemainToPay'); ?>: </font><span id="remaintopaydisplay" class="colorwhite"><?php echo price($remaintopay, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span></span></center>
-</div>
-<?php } ?>
-<div class="paymentbordline paymentbordlinereceived">
-	<center><span class="takepospay"><font color="white"><?php echo $langs->trans("Received"); ?>: </font><span class="change1 colorred"><?php echo price(0, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span><input type="hidden" id="change1" class="change1" value="0"></span></center>
-</div>
-<div class="paymentbordline paymentbordlinechange">
-	<center><span class="takepospay"><font color="white"><?php echo $langs->trans("Change"); ?>: </font><span class="change2 colorwhite"><?php echo price(0, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span><input type="hidden" id="change2" class="change2" value="0"></span></center>
-</div>
-<?php
-if (!empty($conf->global->TAKEPOS_CAN_FORCE_BANK_ACCOUNT_DURING_PAYMENT)) {
-	print '<div class="paymentbordline paddingtop paddingbottom">
-	<center>';
-	$filter = '';
-	$form = new Form($db);
-	print '<span class="takepospay"><font color="white">'.$langs->trans("BankAccount").': </font></span>';
-	$form->select_comptes(0, 'accountid', 0, $filter, 1, '');
-	print ajax_combobox('selectaccountid');
-	print '</center>
-	</div>';
-}
-?>
-
-</div>
-
 
 <div style="position:absolute; left:5%; height:52%; width:90%;">
 <?php

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -257,35 +257,33 @@ if ($conf->global->TAKEPOS_NUMPAD == 0) {
 	}
 </script>
 
-<div style="position:relative; padding-top: 16px; left:5%; min-height: 150px; width:90%;">
-	<div class="center">
-		<div class="paymentbordline paymentbordlinetotal">
-			<span class="takepospay colorwhite"><?php echo $langs->trans('TotalTTC'); ?>: <span id="totaldisplay"><?php echo price($invoice->total_ttc, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span></span>
-		</div>
-		<?php if ($remaintopay != $invoice->total_ttc) { ?>
-		<div class="paymentbordline paymentbordlineremain">
-			<span class="takepospay colorwhite"><?php echo $langs->trans('RemainToPay'); ?>: <span id="remaintopaydisplay"><?php echo price($remaintopay, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span></span>
-		</div>
-		<?php } ?>
-		<div class="paymentbordline paymentbordlinereceived">
-			<span class="takepospay colorwhite"><?php echo $langs->trans("Received"); ?>: <span class="change1 colorred"><?php echo price(0, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span><input type="hidden" id="change1" class="change1" value="0"></span>
-		</div>
-		<div class="paymentbordline paymentbordlinechange">
-			<span class="takepospay colorwhite"><?php echo $langs->trans("Change"); ?>: <span class="change2"><?php echo price(0, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span><input type="hidden" id="change2" class="change2" value="0"></span>
-		</div>
-		<?php
-		if (!empty($conf->global->TAKEPOS_CAN_FORCE_BANK_ACCOUNT_DURING_PAYMENT)) {
-			require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
-			print '<div class="paymentbordline paddingtop paddingbottom">';
-			$filter = '';
-			$form = new Form($db);
-			print '<span class="takepospay"><font color="white">'.$langs->trans("BankAccount").': </font></span>';
-			$form->select_comptes(0, 'accountid', 0, $filter, 1, '');
-			print ajax_combobox('selectaccountid');
-			print '</div>';
-		}
-		?>
+<div style="position:relative; padding-top: 20px; left:5%; height:150px; width:90%;">
+	<div class="paymentbordline paymentbordlinetotal center">
+		<span class="takepospay colorwhite"><?php echo $langs->trans('TotalTTC'); ?>: <span id="totaldisplay" class="colorwhite"><?php echo price($invoice->total_ttc, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span></span>
 	</div>
+	<?php if ($remaintopay != $invoice->total_ttc) { ?>
+		<div class="paymentbordline paymentbordlineremain center">
+			<span class="takepospay colorwhite"><?php echo $langs->trans('RemainToPay'); ?>: <span id="remaintopaydisplay" class="colorwhite"><?php echo price($remaintopay, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span></span>
+		</div>
+	<?php } ?>
+	<div class="paymentbordline paymentbordlinereceived center">
+		<span class="takepospay colorwhite"><?php echo $langs->trans("Received"); ?>: <span class="change1 colorred"><?php echo price(0, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span><input type="hidden" id="change1" class="change1" value="0"></span>
+	</div>
+	<div class="paymentbordline paymentbordlinechange center">
+		<span class="takepospay colorwhite"><?php echo $langs->trans("Change"); ?>: <span class="change2 colorwhite"><?php echo price(0, 1, '', 1, -1, -1, $invoice->multicurrency_code); ?></span><input type="hidden" id="change2" class="change2" value="0"></span>
+	</div>
+	<?php
+	if (!empty($conf->global->TAKEPOS_CAN_FORCE_BANK_ACCOUNT_DURING_PAYMENT)) {
+		require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
+		print '<div class="paymentbordline paddingtop paddingbottom center">';
+		$filter = '';
+		$form = new Form($db);
+		print '<span class="takepospay colorwhite">'.$langs->trans("BankAccount").': </span>';
+		$form->select_comptes(0, 'accountid', 0, $filter, 1, '');
+		print ajax_combobox('selectaccountid');
+		print '</div>';
+	}
+	?>
 </div>
 
 <div style="position:absolute; left:5%; height:52%; width:90%;">


### PR DESCRIPTION
FIX payment style and html5 tags

- in terminal view, when you enter in payment page, you had :

![TerminalReglement](https://user-images.githubusercontent.com/45359511/136954511-d45471b7-8c60-4193-9b62-5fa2dfd4382c.png)

- display "total" labels and values in center of the terminal :

![image](https://user-images.githubusercontent.com/45359511/136954971-5acef3a3-5ef2-49d4-b5c7-c4c0080bec45.png)

And I removed "center" and "font" tag that are not supported in HTML5.
And I fixed account select when "TAKEPOS_CAN_FORCE_BANK_ACCOUNT_DURING_PAYMENT" was enabled.


