### PR TITLE
Fix ExtraFields::setOptionalsFromPost() check enabled

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2079,8 +2079,8 @@ class ExtraFields
 				}
 
 				$enabled = 1;
-				if (isset($this->attributes[$object->table_element]['list'][$key])) {
-					$enabled = dol_eval($this->attributes[$object->table_element]['list'][$key], 1);
+				if (isset($this->attributes[$object->table_element]['enabled'][$key])) {
+					$enabled = dol_eval($this->attributes[$object->table_element]['enabled'][$key], 1);
 				}
 				$perms = 1;
 				if (isset($this->attributes[$object->table_element]['perms'][$key])) {


### PR DESCRIPTION
`ExtraFields::setOptionalsFromPost()` check if extrafield is enabled or
not with `list` property. Shouldn't that be the property `enabled` instead ?
