### PR TITLE
FIX Accountancy - If deposit invoice is used, force binding in deposit accounting account to solve transaction

### DIFF
--- a/htdocs/accountancy/customer/index.php
+++ b/htdocs/accountancy/customer/index.php
@@ -170,6 +170,8 @@ if ($action == 'validatehistory') {
 	} else {
 		$num_lines = $db->num_rows($result);
 
+		$facture_static = new Facture($db);
+
 		$isSellerInEEC = isInEEC($mysoc);
 
 		$i = 0;
@@ -210,6 +212,18 @@ if ($action == 'validatehistory') {
 					$objp->code_sell_t = $objp->company_code_sell;
 					$objp->aarowid_suggest = $objp->aarowid_thirdparty;
 					$suggestedaccountingaccountfor = '';
+				}
+			}
+
+			// Manage Deposit
+			if (!empty($conf->global->ACCOUNTING_ACCOUNT_CUSTOMER_DEPOSIT)) {
+				if ($objp->description == "(DEPOSIT)" || $objp->ftype == $facture_static::TYPE_DEPOSIT) {
+					$accountdeposittoventilated = new AccountingAccount($db);
+					$accountdeposittoventilated->fetch('', $conf->global->ACCOUNTING_ACCOUNT_CUSTOMER_DEPOSIT, 1);
+					$objp->code_sell_l = $accountdeposittoventilated->ref;
+					$objp->code_sell_p = '';
+					$objp->code_sell_t = '';
+					$objp->aarowid_suggest = $accountdeposittoventilated->rowid;
 				}
 			}
 

--- a/htdocs/accountancy/customer/list.php
+++ b/htdocs/accountancy/customer/list.php
@@ -637,11 +637,15 @@ if ($result) {
 		}
 
 		// Manage Deposit
-		if ($objp->description == "(DEPOSIT)") {
-			$accountdeposittoventilated = new AccountingAccount($db);
-			$accountdeposittoventilated->fetch('', $conf->global->ACCOUNTING_ACCOUNT_CUSTOMER_DEPOSIT, 1);
-			$objp->code_sell_l = $accountdeposittoventilated->ref;
-			$objp->aarowid_suggest = $accountdeposittoventilated->rowid;
+		if (!empty($conf->global->ACCOUNTING_ACCOUNT_CUSTOMER_DEPOSIT)) {
+			if ($objp->description == "(DEPOSIT)" || $objp->ftype == $facture_static::TYPE_DEPOSIT) {
+				$accountdeposittoventilated = new AccountingAccount($db);
+				$accountdeposittoventilated->fetch('', $conf->global->ACCOUNTING_ACCOUNT_CUSTOMER_DEPOSIT, 1);
+				$objp->code_sell_l = $accountdeposittoventilated->ref;
+				$objp->code_sell_p = '';
+				$objp->code_sell_t = '';
+				$objp->aarowid_suggest = $accountdeposittoventilated->rowid;
+			}
 		}
 
 		if (!empty($objp->code_sell_p)) {


### PR DESCRIPTION
Before, only deposit line from final invoice are put to accounting deposit account. 

Also alls lines from original deposit invoice must be binded into accounting deposit account. 

![image](https://user-images.githubusercontent.com/2341395/137200044-ab451396-8223-49b1-b5af-35314e2175a4.png)
