### PR TITLE
FIX user date timezone offset

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -2284,8 +2284,17 @@ function dol_print_date($time, $format = '', $tzoutput = 'auto', $outputlangs = 
 			} elseif ($tzoutput == 'tzuser' || $tzoutput == 'tzuserrel') {
 				$to_gmt = true;
 				$offsettzstring = (empty($_SESSION['dol_tz_string']) ? 'UTC' : $_SESSION['dol_tz_string']); // Example 'Europe/Berlin' or 'Indian/Reunion'
-				$offsettz = (empty($_SESSION['dol_tz']) ? 0 : $_SESSION['dol_tz']) * 60 * 60; // Will not be used anymore
-				$offsetdst = (empty($_SESSION['dol_dst']) ? 0 : $_SESSION['dol_dst']) * 60 * 60; // Will not be used anymore
+
+				if (class_exists('DateTimeZone')) {
+					$user_date_tz = new DateTimeZone($offsettzstring);
+					$user_dt = new DateTime();
+					$user_dt->setTimezone($user_date_tz);
+					$user_dt->setTimestamp($time);
+					$offsettz = $user_dt->getOffset();
+				} else {
+					$offsettz = (empty($_SESSION['dol_tz']) ? 0 : $_SESSION['dol_tz']) * 60 * 60; // Will not be used anymore
+					$offsetdst = (empty($_SESSION['dol_dst']) ? 0 : $_SESSION['dol_dst']) * 60 * 60; // Will not be used anymore
+				}
 			}
 		}
 	}


### PR DESCRIPTION
FIX user date timezone offset

- if you want to print a date, you can have an offset between summer and winter dates

You can reproduce it, when you create an event on november.
You will see the date with an offset of 1 hour.

For example, you add this event : 
![SaveEvent1](https://user-images.githubusercontent.com/45359511/137335418-8dc35470-7c65-4551-9f05-59baf05ab608.png)

And when you want to show this event , you got this screen (offset of 1 hour) : 
![ShowEnvent1](https://user-images.githubusercontent.com/45359511/137335517-ae62c694-dc78-426d-8068-dfb15ca45d40.png)

So if you want to modify this event, you keep this offset of 1 hour : 
![ModifyEnvent1](https://user-images.githubusercontent.com/45359511/137335770-c828f771-3eb3-409c-9fb2-61fe4065fbe3.png)



