### PR TITLE
Supplier Invoice Payment List

### DIFF
--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -642,13 +642,19 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 
 								print '<td class="right">';
 								if ($objp->multicurrency_code && $objp->multicurrency_code != $conf->currency) {
-									print price($objp->multicurrency_am);
+									print price($sign * $multicurrency_payment);
+									if ($multicurrency_creditnotes) {
+										print '+'.price($multicurrency_creditnotes);
+									}
+									if ($multicurrency_deposits) {
+										print '+'.price($multicurrency_deposits);
+									}
 								}
 								print '</td>';
 
 								print '<td class="right">';
 								if ($objp->multicurrency_code && $objp->multicurrency_code != $conf->currency) {
-									print price($objp->multicurrency_total_ttc - $objp->multicurrency_am);
+									print price($sign * $multicurrency_remaintopay);
 								}
 								print '</td>';
 							}


### PR DESCRIPTION
fix the missing multicurrency payments and remainders. The examples below are from different supplier invoices list but you can see the difference that the deposits/credit notes are taken into the list which tally with the system records.


Before coding change.
![image](https://user-images.githubusercontent.com/3304600/137426679-605eeaed-2baa-439e-acaf-bf7a5c64b653.png)

After coding change:
![image](https://user-images.githubusercontent.com/3304600/137426730-d4fc082f-752e-4a78-ab18-bab5d3228337.png)
