### PR TITLE
Fix the rounding issue in case of multi-currency

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3844,6 +3844,15 @@ if ($action == 'create') {
 	// $resteapayer=bcadd($object->total_ttc,$totalpaye,$conf->global->MAIN_MAX_DECIMALS_TOT);
 	// $resteapayer=bcadd($resteapayer,$totalavoir,$conf->global->MAIN_MAX_DECIMALS_TOT);
 	$resteapayer = price2num($object->total_ttc - $totalpaye - $totalcreditnotes - $totaldeposits, 'MT');
+	
+	// Multicurrency
+	if (!empty($conf->multicurrency->enabled)) {
+		$multicurrency_totalpaye = $object->getSommePaiement(1);
+		$multicurrency_totalcreditnotes = $object->getSumCreditNotesUsed(1);
+		$multicurrency_totaldeposits = $object->getSumDepositsUsed(1);
+		$multicurrency_resteapayer = price2num($object->multicurrency_total_ttc - $multicurrency_totalpaye - $multicurrency_totalcreditnotes - $multicurrency_totaldeposits, 'MT');
+		$resteapayer = price2num($multicurrency_resteapayer / $object->multicurrency_tx, 'MT');
+	}
 
 	if ($object->paye) {
 		$resteapayer = 0;

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3844,7 +3844,7 @@ if ($action == 'create') {
 	// $resteapayer=bcadd($object->total_ttc,$totalpaye,$conf->global->MAIN_MAX_DECIMALS_TOT);
 	// $resteapayer=bcadd($resteapayer,$totalavoir,$conf->global->MAIN_MAX_DECIMALS_TOT);
 	$resteapayer = price2num($object->total_ttc - $totalpaye - $totalcreditnotes - $totaldeposits, 'MT');
-	
+
 	// Multicurrency
 	if (!empty($conf->multicurrency->enabled)) {
 		$multicurrency_totalpaye = $object->getSommePaiement(1);

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2414,7 +2414,7 @@ if ($action == 'create') {
 			$multicurrency_resteapayer = price2num($object->multicurrency_total_ttc - $multicurrency_totalpaye - $multicurrency_totalcreditnotes - $multicurrency_totaldeposits, 'MT');
 			$resteapayer = price2num($multicurrency_resteapayer / $object->multicurrency_tx, 'MT');
 		}
-		
+
 		if ($object->paye) {
 			$resteapayer = 0;
 		}

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2406,6 +2406,15 @@ if ($action == 'create') {
 		// $resteapayer=bcadd($resteapayer,$totalavoir,$conf->global->MAIN_MAX_DECIMALS_TOT);
 		$resteapayer = price2num($object->total_ttc - $totalpaye - $totalcreditnotes - $totaldeposits, 'MT');
 
+		// Multicurrency
+		if (!empty($conf->multicurrency->enabled)) {
+			$multicurrency_totalpaye = $object->getSommePaiement(1);
+			$multicurrency_totalcreditnotes = $object->getSumCreditNotesUsed(1);
+			$multicurrency_totaldeposits = $object->getSumDepositsUsed(1);
+			$multicurrency_resteapayer = price2num($object->multicurrency_total_ttc - $multicurrency_totalpaye - $multicurrency_totalcreditnotes - $multicurrency_totaldeposits, 'MT');
+			$resteapayer = price2num($multicurrency_resteapayer / $object->multicurrency_tx, 'MT');
+		}
+		
 		if ($object->paye) {
 			$resteapayer = 0;
 		}


### PR DESCRIPTION
In case of multicurrency enabled, our invoice and payments are all counted in original currency (in stead of main currency).

Due to the precision of conversion and rounding, our invoice remainder to pay / pay back / refund etc. may result in +/-0.01 in main currency. This may be due to a +/- 0.01 in the invoice amount, deposit amount, credit note amount or payment amount etc. 

Therefore, from time to time, despite the fact that the invoices are correctly paid off, the system does not recognise it due to this +/-0.01 and we have to manually classify the inoivce as paid and have to specify / choose a reason for it. 

An example of supplier invoice is shown below:
![image](https://user-images.githubusercontent.com/3304600/137447503-a0899f39-e64b-4d05-a7b9-3203f388c569.png)

This PR takes into account the original currency values to calculate the remainder either in original currency or main currency. The screenshot below shows the correct remainders.
![image](https://user-images.githubusercontent.com/3304600/137447677-1f654d75-7fe4-4c70-8f7f-065e89251cce.png)
