### PR TITLE
FIX 13.0: end date required to edit a ticket message

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -503,7 +503,7 @@ if (empty($reshook) && $action == 'update')
 		$object->note_private = trim(GETPOST("note", "restricthtml"));
 		$object->fk_element	 = GETPOST("fk_element", "int");
 		$object->elementtype = GETPOST("elementtype", "alphanohtml");
-		if (!$datef && $percentage == 100 && !preg_match('/^TICKET_MSG/', $object->code))
+		if (!$datef && $percentage == 100)
 		{
 			$error++; $donotclearsession = 1;
 			setEventMessages($langs->transnoentitiesnoconv("ErrorFieldRequired", $langs->transnoentitiesnoconv("DateEnd")), $object->errors, 'errors');

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -503,7 +503,7 @@ if (empty($reshook) && $action == 'update')
 		$object->note_private = trim(GETPOST("note", "restricthtml"));
 		$object->fk_element	 = GETPOST("fk_element", "int");
 		$object->elementtype = GETPOST("elementtype", "alphanohtml");
-		if (!$datef && $percentage == 100)
+		if (!$datef && $percentage == 100 && !preg_match('/^TICKET_MSG/', $object->code))
 		{
 			$error++; $donotclearsession = 1;
 			setEventMessages($langs->transnoentitiesnoconv("ErrorFieldRequired", $langs->transnoentitiesnoconv("DateEnd")), $object->errors, 'errors');

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1657,7 +1657,7 @@ class Ticket extends CommonObject
 		$actioncomm->userassigned = array($user->id);
 		$actioncomm->userownerid = $user->id;
 		$actioncomm->datep = $now;
-		$actioncomm->percentage = -1;
+		$actioncomm->percentage = -1; // percentage is not relevant for punctual events
 		$actioncomm->elementtype = 'ticket';
 		$actioncomm->fk_element = $this->id;
 

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1657,7 +1657,7 @@ class Ticket extends CommonObject
 		$actioncomm->userassigned = array($user->id);
 		$actioncomm->userownerid = $user->id;
 		$actioncomm->datep = $now;
-		$actioncomm->percentage = 100;
+		$actioncomm->percentage = -1;
 		$actioncomm->elementtype = 'ticket';
 		$actioncomm->fk_element = $this->id;
 


### PR DESCRIPTION
# FIX module ticket: editing message requires end date

When ticket messages are created, they do not have an end date. However, when you save after editing a ticket message, you get an error saying that the end date is required.

This PR adds an exception for tickets. If an event is a private or public message for a ticket, an end date will not be requested.

Another way to fix it could be to add an end date (identical to the creation date) when the message is created; if the alternative is better, I’ll be happy to change it.