### PR TITLE
PSR-12 for module builder

### DIFF
--- a/htdocs/modulebuilder/template/admin/about.php
+++ b/htdocs/modulebuilder/template/admin/about.php
@@ -22,41 +22,50 @@
  * \brief   About page of module MyModule.
  */
 
-// Load Dolibarr environment
+declare(strict_types=1);
+
+/// Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
+}
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 // Libraries
-require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/admin.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
 require_once '../lib/mymodule.lib.php';
 
 // Translations
-$langs->loadLangs(array("errors", "admin", "mymodule@mymodule"));
+$langs->loadLangs(['errors', 'admin', 'mymodule@mymodule']);
 
 // Access control
 if (!$user->admin) {
@@ -82,12 +91,13 @@ $backtopage = GETPOST('backtopage', 'alpha');
 $form = new Form($db);
 
 $help_url = '';
-$page_name = "MyModuleAbout";
+$page_name = 'MyModuleAbout';
 
 llxHeader('', $langs->trans($page_name), $help_url);
 
 // Subheader
-$linkback = '<a href="'.($backtopage ? $backtopage : DOL_URL_ROOT.'/admin/modules.php?restore_lastsearch_values=1').'">'.$langs->trans("BackToModuleList").'</a>';
+$linkback = '<a href="' . ($backtopage ?: DOL_URL_ROOT . '/admin/modules.php?restore_lastsearch_values=1') . '">
+			' . $langs->trans('BackToModuleList') . '</a>';
 
 print load_fiche_titre($langs->trans($page_name), $linkback, 'title_setup');
 

--- a/htdocs/modulebuilder/template/admin/myobject_extrafields.php
+++ b/htdocs/modulebuilder/template/admin/myobject_extrafields.php
@@ -23,49 +23,58 @@
 /**
  *      \file       htdocs/modulebuilder/template/admin/myobject_extrafields.php
  *		\ingroup    mymodule
- *		\brief      Page to setup extra fields of myobject
+ *		\brief      Page to set up extra fields of myobject
  */
+
+declare(strict_types=1);
 
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
+}
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 require_once '../lib/mymodule.lib.php';
 
 // Load translation files required by the page
-$langs->loadLangs(array('mymodule@mymodule', 'admin'));
+$langs->loadLangs(['mymodule@mymodule', 'admin']);
 
 $extrafields = new ExtraFields($db);
 $form = new Form($db);
 
 // List of supported format
 $tmptype2label = ExtraFields::$type2label;
-$type2label = array('');
+$type2label = [''];
 foreach ($tmptype2label as $key => $val) {
 	$type2label[$key] = $langs->transnoentitiesnoconv($val);
 }
@@ -92,12 +101,14 @@ require DOL_DOCUMENT_ROOT.'/core/actions_extrafields.inc.php';
  */
 
 $help_url = '';
-$page_name = "MyModuleSetup";
+$page_name = 'MyModuleSetup';
 
-llxHeader('', $langs->trans("MyModuleSetup"), $help_url);
+llxHeader('', $langs->trans('MyModuleSetup'), $help_url);
 
 
-$linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php?restore_lastsearch_values=1">'.$langs->trans("BackToModuleList").'</a>';
+$linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php?restore_lastsearch_values=1">'.$langs->trans(
+		'BackToModuleList'
+	).'</a>';
 print load_fiche_titre($langs->trans($page_name), $linkback, 'title_setup');
 
 
@@ -111,17 +122,19 @@ print dol_get_fiche_end();
 
 
 // Buttons
-if ($action != 'create' && $action != 'edit') {
+if ($action !== 'create' && $action !== 'edit') {
 	print '<div class="tabsAction">';
-	print "<a class=\"butAction\" href=\"".$_SERVER["PHP_SELF"]."?action=create#newattrib\">".$langs->trans("NewAttribute")."</a>";
-	print "</div>";
+	print '<a class="butAction" href="' .$_SERVER['PHP_SELF']. '?action=create#newattrib">' .$langs->trans(
+			'NewAttribute'
+		). '</a>';
+	print '</div>';
 }
 
 
 /*
  * Creation of an optional field
  */
-if ($action == 'create') {
+if ($action === 'create') {
 	print '<br><div id="newattrib"></div>';
 	print load_fiche_titre($langs->trans('NewAttribute'));
 
@@ -131,9 +144,9 @@ if ($action == 'create') {
 /*
  * Edition of an optional field
  */
-if ($action == 'edit' && !empty($attrname)) {
-	print "<br>";
-	print load_fiche_titre($langs->trans("FieldEdition", $attrname));
+if ($action === 'edit' && !empty($attrname)) {
+	print '<br>';
+	print load_fiche_titre($langs->trans('FieldEdition', $attrname));
 
 	require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_edit.tpl.php';
 }

--- a/htdocs/modulebuilder/template/admin/setup.php
+++ b/htdocs/modulebuilder/template/admin/setup.php
@@ -22,43 +22,52 @@
  * \brief   MyModule setup page.
  */
 
+declare(strict_types=1);
+
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
+}
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 global $langs, $user;
 
 // Libraries
-require_once DOL_DOCUMENT_ROOT."/core/lib/admin.lib.php";
+require_once DOL_DOCUMENT_ROOT . '/core/lib/admin.lib.php';
 require_once '../lib/mymodule.lib.php';
 //require_once "../class/myclass.class.php";
 
 // Translations
-$langs->loadLangs(array("admin", "mymodule@mymodule"));
+$langs->loadLangs(['admin', 'mymodule@mymodule']);
 
 // Access control
 if (!$user->admin) {
@@ -74,21 +83,21 @@ $label = GETPOST('label', 'alpha');
 $scandir = GETPOST('scan_dir', 'alpha');
 $type = 'myobject';
 
-$arrayofparameters = array(
-	'MYMODULE_MYPARAM1'=>array('type'=>'string', 'css'=>'minwidth500' ,'enabled'=>1),
-	'MYMODULE_MYPARAM2'=>array('type'=>'textarea','enabled'=>1),
+$arrayofparameters = [
+	'MYMODULE_MYPARAM1' => ['type' => 'string', 'css' => 'minwidth500', 'enabled' => 1],
+	'MYMODULE_MYPARAM2' => ['type' => 'textarea', 'enabled' => 1],
 	//'MYMODULE_MYPARAM3'=>array('type'=>'category:'.Categorie::TYPE_CUSTOMER, 'enabled'=>1),
 	//'MYMODULE_MYPARAM4'=>array('type'=>'emailtemplate:thirdparty', 'enabled'=>1),
 	//'MYMODULE_MYPARAM5'=>array('type'=>'yesno', 'enabled'=>1),
 	//'MYMODULE_MYPARAM5'=>array('type'=>'thirdparty_type', 'enabled'=>1),
 	//'MYMODULE_MYPARAM6'=>array('type'=>'securekey', 'enabled'=>1),
 	//'MYMODULE_MYPARAM7'=>array('type'=>'product', 'enabled'=>1),
-);
+];
 
 $error = 0;
 $setupnotempty = 0;
 
-$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
+$dirmodels = array_merge(['/'], $conf->modules_parts['models']);
 
 
 /*
@@ -99,7 +108,7 @@ if ((float) DOL_VERSION >= 6) {
 	include DOL_DOCUMENT_ROOT.'/core/actions_setmoduleoptions.inc.php';
 }
 
-if ($action == 'updateMask') {
+if ($action === 'updateMask') {
 	$maskconstorder = GETPOST('maskconstorder', 'alpha');
 	$maskorder = GETPOST('maskorder', 'alpha');
 
@@ -110,12 +119,12 @@ if ($action == 'updateMask') {
 		}
 	}
 
-	if (!$error) {
-		setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
+	if ($error) {
+		setEventMessages($langs->trans('Error'), null, 'errors');
 	} else {
-		setEventMessages($langs->trans("Error"), null, 'errors');
+		setEventMessages($langs->trans('SetupSaved'), null);
 	}
-} elseif ($action == 'specimen') {
+} elseif ($action === 'specimen') {
 	$modele = GETPOST('module', 'alpha');
 	$tmpobjectkey = GETPOST('object');
 
@@ -123,13 +132,17 @@ if ($action == 'updateMask') {
 	$tmpobject->initAsSpecimen();
 
 	// Search template files
-	$file = ''; $classname = ''; $filefound = 0;
-	$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
+	$file = '';
+	$classname = '';
+	$filefound = 0;
+	$dirmodels = array_merge(['/'], $conf->modules_parts['models']);
 	foreach ($dirmodels as $reldir) {
-		$file = dol_buildpath($reldir."core/modules/mymodule/doc/pdf_".$modele."_".strtolower($tmpobjectkey).".modules.php", 0);
+		$file = dol_buildpath(
+			$reldir . 'core/modules/mymodule/doc/pdf_' . $modele . '_' . strtolower($tmpobjectkey) . '.modules.php'
+		);
 		if (file_exists($file)) {
 			$filefound = 1;
-			$classname = "pdf_".$modele;
+			$classname = 'pdf_' . $modele;
 			break;
 		}
 	}
@@ -140,42 +153,54 @@ if ($action == 'updateMask') {
 		$module = new $classname($db);
 
 		if ($module->write_file($tmpobject, $langs) > 0) {
-			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=".strtolower($tmpobjectkey)."&file=SPECIMEN.pdf");
+			header(
+				'Location: ' . DOL_URL_ROOT . '/document.php?modulepart=' . strtolower(
+					$tmpobjectkey
+				) . '&file=SPECIMEN.pdf'
+			);
 			return;
-		} else {
-			setEventMessages($module->error, null, 'errors');
+		}
+
+		setEventMessages($module->error, null, 'errors');
+		try {
 			dol_syslog($module->error, LOG_ERR);
+		} catch (Exception $e) {
+			return 'ERROR: ' . $e->getMessage();
 		}
 	} else {
-		setEventMessages($langs->trans("ErrorModuleNotFound"), null, 'errors');
-		dol_syslog($langs->trans("ErrorModuleNotFound"), LOG_ERR);
+		setEventMessages($langs->trans('ErrorModuleNotFound'), null, 'errors');
+		try {
+			dol_syslog($langs->trans('ErrorModuleNotFound'), LOG_ERR);
+		} catch (Exception $e) {
+			return 'ERROR: ' . $e->getMessage();
+		}
 	}
-} elseif ($action == 'setmod') {
+} elseif ($action === 'setmod') {
 	// TODO Check if numbering module chosen can be activated by calling method canBeActivated
 	$tmpobjectkey = GETPOST('object');
 	if (!empty($tmpobjectkey)) {
-		$constforval = 'MYMODULE_'.strtoupper($tmpobjectkey)."_ADDON";
+		$constforval = 'MYMODULE_' . strtoupper($tmpobjectkey) . '_ADDON';
 		dolibarr_set_const($db, $constforval, $value, 'chaine', 0, '', $conf->entity);
 	}
-} elseif ($action == 'set') {
+} elseif ($action === 'set') {
 	// Activate a model
 	$ret = addDocumentModel($value, $type, $label, $scandir);
-} elseif ($action == 'del') {
+} elseif ($action === 'del') {
 	$ret = delDocumentModel($value, $type);
 	if ($ret > 0) {
 		$tmpobjectkey = GETPOST('object');
 		if (!empty($tmpobjectkey)) {
-			$constforval = 'MYMODULE_'.strtoupper($tmpobjectkey).'_ADDON_PDF';
-			if ($conf->global->$constforval == "$value") {
+			$constforval = 'MYMODULE_' . strtoupper($tmpobjectkey) . '_ADDON_PDF';
+			if ($conf->global->$constforval === (string) $value) {
 				dolibarr_del_const($db, $constforval, $conf->entity);
 			}
 		}
 	}
-} elseif ($action == 'setdoc') {
+} elseif ($action === 'setdoc') {
 	// Set or unset default model
 	$tmpobjectkey = GETPOST('object');
 	if (!empty($tmpobjectkey)) {
-		$constforval = 'MYMODULE_'.strtoupper($tmpobjectkey).'_ADDON_PDF';
+		$constforval = 'MYMODULE_' . strtoupper($tmpobjectkey) . '_ADDON_PDF';
 		if (dolibarr_set_const($db, $constforval, $value, 'chaine', 0, '', $conf->entity)) {
 			// The constant that was read before the new set
 			// We therefore requires a variable to have a coherent view
@@ -188,10 +213,10 @@ if ($action == 'updateMask') {
 			$ret = addDocumentModel($value, $type, $label, $scandir);
 		}
 	}
-} elseif ($action == 'unsetdoc') {
+} elseif ($action === 'unsetdoc') {
 	$tmpobjectkey = GETPOST('object');
 	if (!empty($tmpobjectkey)) {
-		$constforval = 'MYMODULE_'.strtoupper($tmpobjectkey).'_ADDON_PDF';
+		$constforval = 'MYMODULE_' . strtoupper($tmpobjectkey) . '_ADDON_PDF';
 		dolibarr_del_const($db, $constforval, $conf->entity);
 	}
 }
@@ -205,108 +230,158 @@ if ($action == 'updateMask') {
 $form = new Form($db);
 
 $help_url = '';
-$page_name = "MyModuleSetup";
+$page_name = 'MyModuleSetup';
 
 llxHeader('', $langs->trans($page_name), $help_url);
 
 // Subheader
-$linkback = '<a href="'.($backtopage ? $backtopage : DOL_URL_ROOT.'/admin/modules.php?restore_lastsearch_values=1').'">'.$langs->trans("BackToModuleList").'</a>';
+$linkback = '<a href="' . ($backtopage ?: DOL_URL_ROOT . '/admin/modules.php?restore_lastsearch_values=1') . '">
+	' . $langs->trans(
+		'BackToModuleList'
+	) . '</a>';
 
 print load_fiche_titre($langs->trans($page_name), $linkback, 'title_setup');
 
 // Configuration header
 $head = mymoduleAdminPrepareHead();
-print dol_get_fiche_head($head, 'settings', $langs->trans($page_name), -1, "mymodule@mymodule");
+print dol_get_fiche_head($head, 'settings', $langs->trans($page_name), -1, 'mymodule@mymodule');
 
 // Setup page goes here
-echo '<span class="opacitymedium">'.$langs->trans("MyModuleSetupPage").'</span><br><br>';
+echo '<span class="opacitymedium">' . $langs->trans('MyModuleSetupPage') . '</span><br><br>';
 
 
-if ($action == 'edit') {
-	print '<form method="POST" action="'.$_SERVER["PHP_SELF"].'">';
-	print '<input type="hidden" name="token" value="'.newToken().'">';
+if ($action === 'edit') {
+	print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '">';
+	print '<input type="hidden" name="token" value="' . newToken() . '">';
 	print '<input type="hidden" name="action" value="update">';
 
 	print '<table class="noborder centpercent">';
-	print '<tr class="liste_titre"><td class="titlefield">'.$langs->trans("Parameter").'</td><td>'.$langs->trans("Value").'</td></tr>';
+	print '<tr class="liste_titre"><td class="titlefield">' . $langs->trans('Parameter') . '</td><td>' . $langs->trans(
+			'Value'
+		) . '</td></tr>';
 
 	foreach ($arrayofparameters as $constname => $val) {
-		if ($val['enabled']==1) {
+		if ($val['enabled'] === 1) {
 			$setupnotempty++;
 			print '<tr class="oddeven"><td>';
-			$tooltiphelp = (($langs->trans($constname . 'Tooltip') != $constname . 'Tooltip') ? $langs->trans($constname . 'Tooltip') : '');
-			print '<span id="helplink'.$constname.'" class="spanforparamtooltip">'.$form->textwithpicto($langs->trans($constname), $tooltiphelp, 1, 'info', '', 0, 3, 'tootips'.$constname).'</span>';
+			$tooltiphelp = (($langs->trans($constname . 'Tooltip') !== $constname . 'Tooltip') ? $langs->trans(
+				$constname . 'Tooltip'
+			) : '');
+			print '<span id="helplink' . $constname . '" class="spanforparamtooltip">' . $form->textwithpicto(
+					$langs->trans($constname),
+					$tooltiphelp,
+					1,
+					'info',
+					'',
+					0,
+					3,
+					'tootips' . $constname
+				) . '</span>';
 			print '</td><td>';
 
-			if ($val['type'] == 'textarea') {
-				print '<textarea class="flat" name="'.$constname.'" id="'.$constname.'" cols="50" rows="5" wrap="soft">' . "\n";
+			if ($val['type'] === 'textarea') {
+				print '<textarea class="flat" name="' . $constname . '"
+						d="' . $constname . '" cols="50" rows="5" wrap="soft">' . "\n";
 				print $conf->global->{$constname};
 				print "</textarea>\n";
-			} elseif ($val['type']== 'html') {
+			} elseif ($val['type'] === 'html') {
 				require_once DOL_DOCUMENT_ROOT . '/core/class/doleditor.class.php';
-				$doleditor = new DolEditor($constname, $conf->global->{$constname}, '', 160, 'dolibarr_notes', '', false, false, $conf->fckeditor->enabled, ROWS_5, '90%');
+				$doleditor = new DolEditor(
+					$constname,
+					$conf->global->{$constname},
+					'',
+					160,
+					'dolibarr_notes',
+					'',
+					false,
+					false,
+					$conf->fckeditor->enabled,
+					ROWS_5,
+					'90%'
+				);
 				$doleditor->Create();
-			} elseif ($val['type'] == 'yesno') {
+			} elseif ($val['type'] === 'yesno') {
 				print $form->selectyesno($constname, $conf->global->{$constname}, 1);
 			} elseif (preg_match('/emailtemplate:/', $val['type'])) {
 				include_once DOL_DOCUMENT_ROOT . '/core/class/html.formmail.class.php';
 				$formmail = new FormMail($db);
 
 				$tmp = explode(':', $val['type']);
-				$nboftemplates = $formmail->fetchAllEMailTemplate($tmp[1], $user, null, 1); // We set lang=null to get in priority record with no lang
+				$nboftemplates = $formmail->fetchAllEMailTemplate(
+					$tmp[1],
+					$user,
+					null
+				); // We set lang=null to get in priority record with no lang
 				//$arraydefaultmessage = $formmail->getEMailTemplate($db, $tmp[1], $user, null, 0, 1, '');
-				$arrayofmessagename = array();
+				$arrayofmessagename = [];
 				if (is_array($formmail->lines_model)) {
 					foreach ($formmail->lines_model as $modelmail) {
 						//var_dump($modelmail);
 						$moreonlabel = '';
 						if (!empty($arrayofmessagename[$modelmail->label])) {
-							$moreonlabel = ' <span class="opacitymedium">(' . $langs->trans("SeveralLangugeVariatFound") . ')</span>';
+							$moreonlabel = ' <span class="opacitymedium">(' . $langs->trans(
+									'SeveralLangugeVariatFound'
+								) . ')</span>';
 						}
 						// The 'label' is the key that is unique if we exclude the language
 						$arrayofmessagename[$modelmail->id] = $langs->trans(preg_replace('/\(|\)/', '', $modelmail->label)) . $moreonlabel;
 					}
 				}
-				print $form->selectarray($constname, $arrayofmessagename, $conf->global->{$constname}, 'None', 0, 0, '', 0, 0, 0, '', '', 1);
+				print $form::selectarray($constname, $arrayofmessagename, $conf->global->{$constname}, 'None');
 			} elseif (preg_match('/category:/', $val['type'])) {
-				require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
-				require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
+				require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+				require_once DOL_DOCUMENT_ROOT . '/core/class/html.formother.class.php';
 				$formother = new FormOther($db);
 
 				$tmp = explode(':', $val['type']);
 				print img_picto('', 'category', 'class="pictofixedwidth"');
-				print $formother->select_categories($tmp[1],  $conf->global->{$constname}, $constname, 0, $langs->trans('CustomersProspectsCategoriesShort'));
-			} elseif (preg_match('/thirdparty_type/', $val['type'])) {
-				require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
+				print $formother->select_categories(
+					$tmp[1],
+					$conf->global->{$constname},
+					$constname,
+					0,
+					$langs->trans('CustomersProspectsCategoriesShort')
+				);
+			} elseif (strpos($val['type'], 'thirdparty_type') !== false) {
+				require_once DOL_DOCUMENT_ROOT . '/core/class/html.formcompany.class.php';
 				$formcompany = new FormCompany($db);
 				print $formcompany->selectProspectCustomerType($conf->global->{$constname}, $constname);
-			} elseif ($val['type'] == 'securekey') {
-				print '<input required="required" type="text" class="flat" id="'.$constname.'" name="'.$constname.'" value="'.(GETPOST($constname, 'alpha') ?GETPOST($constname, 'alpha') : $conf->global->{$constname}).'" size="40">';
+			} elseif ($val['type'] === 'securekey') {
+				print '<input required="required" type="text" class="flat"
+						id="' . $constname . '"
+						name="' . $constname . '"
+						value="' . (GETPOST($constname, 'alpha') ?: $conf->global->{$constname}) . '" size="40">';
 				if (!empty($conf->use_javascript_ajax)) {
-					print '&nbsp;'.img_picto($langs->trans('Generate'), 'refresh', 'id="generate_token'.$constname.'" class="linkobject"');
+					print '&nbsp;' . img_picto(
+							$langs->trans('Generate'),
+							'refresh',
+							'id="generate_token' . $constname . '" class="linkobject"'
+						);
 				}
 				if (!empty($conf->use_javascript_ajax)) {
-					print "\n".'<script type="text/javascript">';
+					print "\n" . '<script type="text/javascript">';
 					print '$(document).ready(function () {
-                        $("#generate_token'.$constname.'").click(function() {
-                	        $.get( "'.DOL_URL_ROOT.'/core/ajax/security.php", {
+                        $("#generate_token' . $constname . '").click(function() {
+                	        $.get( "' . DOL_URL_ROOT . '/core/ajax/security.php", {
                 		      action: \'getrandompassword\',
                 		      generic: true
     				        },
     				        function(token) {
-    					       $("#'.$constname.'").val(token);
+    					       $("#' . $constname . '").val(token);
             				});
                          });
                     });';
 					print '</script>';
 				}
-			} elseif ($val['type'] == 'product') {
+			} elseif ($val['type'] === 'product') {
 				if (!empty($conf->product->enabled) || !empty($conf->service->enabled)) {
 					$selected = (empty($conf->global->$constname) ? '' : $conf->global->$constname);
-					$form->select_produits($selected, $constname, '', 0);
+					$form->select_produits($selected, $constname);
 				}
 			} else {
-				print '<input name="'.$constname.'"  class="flat '.(empty($val['css']) ? 'minwidth200' : $val['css']).'" value="'.$conf->global->{$constname}.'">';
+				print '<input name="' . $constname . '"
+						class="flat ' . (empty($val['css']) ? 'minwidth200' : $val['css']) . '"
+						value="' . $conf->global->{$constname} . '">';
 			}
 			print '</td></tr>';
 		}
@@ -314,96 +389,110 @@ if ($action == 'edit') {
 	print '</table>';
 
 	print '<br><div class="center">';
-	print '<input class="button button-save" type="submit" value="'.$langs->trans("Save").'">';
+	print '<input class="button button-save" type="submit" value="' . $langs->trans('Save') . '">';
 	print '</div>';
 
 	print '</form>';
 	print '<br>';
-} else {
-	if (!empty($arrayofparameters)) {
-		print '<table class="noborder centpercent">';
-		print '<tr class="liste_titre"><td class="titlefield">'.$langs->trans("Parameter").'</td><td>'.$langs->trans("Value").'</td></tr>';
+} elseif (!empty($arrayofparameters)) {
+	print '<table class="noborder centpercent">';
+	print '<tr class="liste_titre"><td class="titlefield">' . $langs->trans('Parameter') . '</td><td>' . $langs->trans(
+			'Value'
+		) . '</td></tr>';
 
-		foreach ($arrayofparameters as $constname => $val) {
-			if ($val['enabled']==1) {
-				$setupnotempty++;
-				print '<tr class="oddeven"><td>';
-				$tooltiphelp = (($langs->trans($constname . 'Tooltip') != $constname . 'Tooltip') ? $langs->trans($constname . 'Tooltip') : '');
-				print $form->textwithpicto($langs->trans($constname), $tooltiphelp);
-				print '</td><td>';
+	foreach ($arrayofparameters as $constname => $val) {
+		if ($val['enabled'] === 1) {
+			$setupnotempty++;
+			print '<tr class="oddeven"><td>';
+			$tooltiphelp = (($langs->trans($constname . 'Tooltip') !== $constname . 'Tooltip') ? $langs->trans(
+				$constname . 'Tooltip'
+			) : '');
+			print $form->textwithpicto($langs->trans($constname), $tooltiphelp);
+			print '</td><td>';
 
-				if ($val['type'] == 'textarea') {
-					print dol_nl2br($conf->global->{$constname});
-				} elseif ($val['type']== 'html') {
-					print  $conf->global->{$constname};
-				} elseif ($val['type'] == 'yesno') {
-					print ajax_constantonoff($constname);
-				} elseif (preg_match('/emailtemplate:/', $val['type'])) {
-					include_once DOL_DOCUMENT_ROOT . '/core/class/html.formmail.class.php';
-					$formmail = new FormMail($db);
+			if ($val['type'] === 'textarea') {
+				print dol_nl2br($conf->global->{$constname});
+			} elseif ($val['type'] === 'html') {
+				print  $conf->global->{$constname};
+			} elseif ($val['type'] === 'yesno') {
+				print ajax_constantonoff($constname);
+			} elseif (preg_match('/emailtemplate:/', $val['type'])) {
+				include_once DOL_DOCUMENT_ROOT . '/core/class/html.formmail.class.php';
+				$formmail = new FormMail($db);
 
-					$tmp = explode(':', $val['type']);
+				$tmp = explode(':', $val['type']);
 
-					$template = $formmail->getEMailTemplate($db, $tmp[1], $user, $langs, $conf->global->{$constname});
-					if ($template<0) {
-						setEventMessages(null, $formmail->errors, 'errors');
-					}
-					print $langs->trans($template->label);
-				} elseif (preg_match('/category:/', $val['type'])) {
-					$c = new Categorie($db);
-					$result = $c->fetch($conf->global->{$constname});
-					if ($result < 0) {
-						setEventMessages(null, $c->errors, 'errors');
-					}
-					$ways = $c->print_all_ways(' &gt;&gt; ', 'none', 0, 1); // $ways[0] = "ccc2 >> ccc2a >> ccc2a1" with html formated text
-					$toprint = array();
-					foreach ($ways as $way) {
-						$toprint[] = '<li class="select2-search-choice-dolibarr noborderoncategories"' . ($c->color ? ' style="background: #' . $c->color . ';"' : ' style="background: #bbb"') . '>' . $way . '</li>';
-					}
-					print '<div class="select2-container-multi-dolibarr" style="width: 90%;"><ul class="select2-choices-dolibarr">' . implode(' ', $toprint) . '</ul></div>';
-				} elseif (preg_match('/thirdparty_type/', $val['type'])) {
-					if ($conf->global->{$constname}==2) {
-						print $langs->trans("Prospect");
-					} elseif ($conf->global->{$constname}==3) {
-						print $langs->trans("ProspectCustomer");
-					} elseif ($conf->global->{$constname}==1) {
-						print $langs->trans("Customer");
-					} elseif ($conf->global->{$constname}==0) {
-						print $langs->trans("NorProspectNorCustomer");
-					}
-				} elseif ($val['type'] == 'product') {
-					$product = new Product($db);
-					$resprod = $product->fetch($conf->global->{$constname});
-					if ($resprod > 0) {
-						print $product->ref;
-					} elseif ($resprod < 0) {
-						setEventMessages(null, $object->errors, "errors");
-					}
-				} else {
-					print $conf->global->{$constname};
+				$template = $formmail->getEMailTemplate($db, $tmp[1], $user, $langs, $conf->global->{$constname});
+				if ($template < 0) {
+					setEventMessages(null, $formmail->errors, 'errors');
 				}
-				print '</td></tr>';
+				print $langs->trans($template->label);
+			} elseif (preg_match('/category:/', $val['type'])) {
+				$c = new Categorie($db);
+				$result = $c->fetch($conf->global->{$constname});
+				if ($result < 0) {
+					setEventMessages(null, $c->errors, 'errors');
+				}
+				$ways = $c->print_all_ways(
+					' &gt;&gt; ',
+					'none',
+					0,
+					1
+				); // $ways[0] = "ccc2 >> ccc2a >> ccc2a1" with html formated text
+				$toprint = [];
+				foreach ($ways as $way) {
+					$toprint[] = '<li class="select2-search-choice-dolibarr
+						noborderoncategories"' . ($c->color ? '
+						style="background: #' . $c->color . ';"' : '
+						style="background: #bbb"') . '>' . $way . '</li>';
+				}
+				print '<div class="select2-container-multi-dolibarr" style="width: 90%;">
+						<ul class="select2-choices-dolibarr">' . implode(' ', $toprint) . '</ul></div>';
+			} elseif (strpos($val['type'], 'thirdparty_type') !== false) {
+				if ($conf->global->{$constname} === 2) {
+					print $langs->trans('Prospect');
+				} elseif ($conf->global->{$constname} === 3) {
+					print $langs->trans('ProspectCustomer');
+				} elseif ($conf->global->{$constname} === 1) {
+					print $langs->trans('Customer');
+				} elseif ($conf->global->{$constname} === 0) {
+					print $langs->trans('NorProspectNorCustomer');
+				}
+			} elseif ($val['type'] === 'product') {
+				$product = new Product($db);
+				$resprod = $product->fetch($conf->global->{$constname});
+				if ($resprod > 0) {
+					print $product->ref;
+				} elseif ($resprod < 0) {
+					setEventMessages(null, $object->errors, 'errors');
+				}
+			} else {
+				print $conf->global->{$constname};
 			}
+			print '</td></tr>';
 		}
-
-		print '</table>';
-
-		print '<div class="tabsAction">';
-		print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?action=edit&token='.newToken().'">'.$langs->trans("Modify").'</a>';
-		print '</div>';
-	} else {
-		print '<br>'.$langs->trans("NothingToSetup");
 	}
+
+	print '</table>';
+
+	print '<div class="tabsAction">';
+	print '<a class="butAction" href="' . $_SERVER['PHP_SELF'] . '?action=edit&token=' . newToken(
+		) . '">' . $langs->trans(
+			'Modify'
+		) . '</a>';
+	print '</div>';
+} else {
+	print '<br>' . $langs->trans('NothingToSetup');
 }
 
 
 $moduledir = 'mymodule';
-$myTmpObjects = array();
-$myTmpObjects['MyObject'] = array('includerefgeneration'=>0, 'includedocgeneration'=>0);
+$myTmpObjects = [];
+$myTmpObjects['MyObject'] = ['includerefgeneration' => 0, 'includedocgeneration' => 0];
 
 
 foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
-	if ($myTmpObjectKey == 'MyObject') {
+	if ($myTmpObjectKey === 'MyObject') {
 		continue;
 	}
 	if ($myTmpObjectArray['includerefgeneration']) {
@@ -412,68 +501,77 @@ foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 		 */
 		$setupnotempty++;
 
-		print load_fiche_titre($langs->trans("NumberingModules", $myTmpObjectKey), '', '');
+		print load_fiche_titre($langs->trans('NumberingModules', $myTmpObjectKey), '', '');
 
 		print '<table class="noborder centpercent">';
 		print '<tr class="liste_titre">';
-		print '<td>'.$langs->trans("Name").'</td>';
-		print '<td>'.$langs->trans("Description").'</td>';
-		print '<td class="nowrap">'.$langs->trans("Example").'</td>';
-		print '<td class="center" width="60">'.$langs->trans("Status").'</td>';
-		print '<td class="center" width="16">'.$langs->trans("ShortInfo").'</td>';
-		print '</tr>'."\n";
+		print '<td>' . $langs->trans('Name') . '</td>';
+		print '<td>' . $langs->trans('Description') . '</td>';
+		print '<td class="nowrap">' . $langs->trans('Example') . '</td>';
+		print '<td class="center">' . $langs->trans('Status') . '</td>';
+		print '<td class="center">' . $langs->trans('ShortInfo') . '</td>';
+		print '</tr>' . "\n";
 
 		clearstatcache();
 
 		foreach ($dirmodels as $reldir) {
-			$dir = dol_buildpath($reldir."core/modules/".$moduledir);
+			$dir = dol_buildpath($reldir . 'core/modules/' . $moduledir);
 
 			if (is_dir($dir)) {
 				$handle = opendir($dir);
 				if (is_resource($handle)) {
 					while (($file = readdir($handle)) !== false) {
-						if (strpos($file, 'mod_'.strtolower($myTmpObjectKey).'_') === 0 && substr($file, dol_strlen($file) - 3, 3) == 'php') {
+						if (strpos($file, 'mod_' . strtolower($myTmpObjectKey) . '_') === 0 && substr(
+								$file,
+								dol_strlen($file) - 3,
+								3
+							) === 'php') {
 							$file = substr($file, 0, dol_strlen($file) - 4);
 
-							require_once $dir.'/'.$file.'.php';
+							require_once $dir . '/' . $file . '.php';
 
 							$module = new $file($db);
 
 							// Show modules according to features level
-							if ($module->version == 'development' && $conf->global->MAIN_FEATURES_LEVEL < 2) {
+							if ($module->version === 'development' && $conf->global->MAIN_FEATURES_LEVEL < 2) {
 								continue;
 							}
-							if ($module->version == 'experimental' && $conf->global->MAIN_FEATURES_LEVEL < 1) {
+							if ($module->version === 'experimental' && $conf->global->MAIN_FEATURES_LEVEL < 1) {
 								continue;
 							}
 
 							if ($module->isEnabled()) {
-								dol_include_once('/'.$moduledir.'/class/'.strtolower($myTmpObjectKey).'.class.php');
+								dol_include_once(
+									'/' . $moduledir . '/class/' . strtolower($myTmpObjectKey) . '.class.php'
+								);
 
-								print '<tr class="oddeven"><td>'.$module->name."</td><td>\n";
+								print '<tr class="oddeven"><td>' . $module->name . "</td><td>\n";
 								print $module->info();
 								print '</td>';
 
 								// Show example of numbering model
 								print '<td class="nowrap">';
 								$tmp = $module->getExample();
-								if (preg_match('/^Error/', $tmp)) {
-									$langs->load("errors");
-									print '<div class="error">'.$langs->trans($tmp).'</div>';
-								} elseif ($tmp == 'NotConfigured') {
+								if (strncmp($tmp, 'Error', 5) === 0) {
+									$langs->load('errors');
+									print '<div class="error">' . $langs->trans($tmp) . '</div>';
+								} elseif ($tmp === 'NotConfigured') {
 									print $langs->trans($tmp);
 								} else {
 									print $tmp;
 								}
-								print '</td>'."\n";
+								print '</td>' . "\n";
 
 								print '<td class="center">';
-								$constforvar = 'MYMODULE_'.strtoupper($myTmpObjectKey).'_ADDON';
-								if ($conf->global->$constforvar == $file) {
-									print img_picto($langs->trans("Activated"), 'switch_on');
+								$constforvar = 'MYMODULE_' . strtoupper($myTmpObjectKey) . '_ADDON';
+								if ($conf->global->$constforvar === $file) {
+									print img_picto($langs->trans('Activated'), 'switch_on');
 								} else {
-									print '<a href="'.$_SERVER["PHP_SELF"].'?action=setmod&token='.newToken().'&object='.strtolower($myTmpObjectKey).'&value='.urlencode($file).'">';
-									print img_picto($langs->trans("Disabled"), 'switch_off');
+									print '<a href="' . $_SERVER['PHP_SELF'] . '?action=setmod&token=' . newToken(
+										) . '&object=' . strtolower($myTmpObjectKey) . '&value=' . urlencode(
+											$file
+										) . '">';
+									print img_picto($langs->trans('Disabled'), 'switch_off');
 									print '</a>';
 								}
 								print '</td>';
@@ -482,19 +580,19 @@ foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 								$mytmpinstance->initAsSpecimen();
 
 								// Info
-								$htmltooltip = '';
-								$htmltooltip .= ''.$langs->trans("Version").': <b>'.$module->getVersion().'</b><br>';
+								$htmltooltip = '' . $langs->trans('Version') . ': <b>' . $module->getVersion(
+									) . '</b><br>';
 
 								$nextval = $module->getNextValue($mytmpinstance);
-								if ("$nextval" != $langs->trans("NotAvailable")) {  // Keep " on nextval
-									$htmltooltip .= ''.$langs->trans("NextValue").': ';
+								if ((string) $nextval !== $langs->trans('NotAvailable')) {  // Keep " on nextval
+									$htmltooltip .= '' . $langs->trans('NextValue') . ': ';
 									if ($nextval) {
-										if (preg_match('/^Error/', $nextval) || $nextval == 'NotConfigured') {
+										if (strncmp($nextval, 'Error', 5) === 0 || $nextval === 'NotConfigured') {
 											$nextval = $langs->trans($nextval);
 										}
-										$htmltooltip .= $nextval.'<br>';
+										$htmltooltip .= $nextval . '<br>';
 									} else {
-										$htmltooltip .= $langs->trans($module->error).'<br>';
+										$htmltooltip .= $langs->trans($module->error) . '<br>';
 									}
 								}
 
@@ -520,42 +618,42 @@ foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 		$setupnotempty++;
 		$type = strtolower($myTmpObjectKey);
 
-		print load_fiche_titre($langs->trans("DocumentModules", $myTmpObjectKey), '', '');
+		print load_fiche_titre($langs->trans('DocumentModules', $myTmpObjectKey), '', '');
 
 		// Load array def with activated templates
-		$def = array();
-		$sql = "SELECT nom";
-		$sql .= " FROM ".MAIN_DB_PREFIX."document_model";
-		$sql .= " WHERE type = '".$db->escape($type)."'";
-		$sql .= " AND entity = ".$conf->entity;
+		$def = [];
+		$sql = 'SELECT nom';
+		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'document_model';
+		$sql .= " WHERE type = '" . $db->escape($type) . "'";
+		$sql .= ' AND entity = ' . $conf->entity;
 		$resql = $db->query($sql);
 		if ($resql) {
 			$i = 0;
 			$num_rows = $db->num_rows($resql);
 			while ($i < $num_rows) {
 				$array = $db->fetch_array($resql);
-				array_push($def, $array[0]);
+				$def[] = $array[0];
 				$i++;
 			}
 		} else {
 			dol_print_error($db);
 		}
 
-		print "<table class=\"noborder\" width=\"100%\">\n";
+		print "<table class=\"noborder\">\n";
 		print "<tr class=\"liste_titre\">\n";
-		print '<td>'.$langs->trans("Name").'</td>';
-		print '<td>'.$langs->trans("Description").'</td>';
-		print '<td class="center" width="60">'.$langs->trans("Status")."</td>\n";
-		print '<td class="center" width="60">'.$langs->trans("Default")."</td>\n";
-		print '<td class="center" width="38">'.$langs->trans("ShortInfo").'</td>';
-		print '<td class="center" width="38">'.$langs->trans("Preview").'</td>';
+		print '<td>' . $langs->trans('Name') . '</td>';
+		print '<td>' . $langs->trans('Description') . '</td>';
+		print '<td class="center">' . $langs->trans('Status') . "</td>\n";
+		print '<td class="center">' . $langs->trans('Default') . "</td>\n";
+		print '<td class="center">' . $langs->trans('ShortInfo') . '</td>';
+		print '<td class="center">' . $langs->trans('Preview') . '</td>';
 		print "</tr>\n";
 
 		clearstatcache();
 
 		foreach ($dirmodels as $reldir) {
-			foreach (array('', '/doc') as $valdir) {
-				$realpath = $reldir."core/modules/".$moduledir.$valdir;
+			foreach (['', '/doc'] as $valdir) {
+				$realpath = $reldir . 'core/modules/' . $moduledir . $valdir;
 				$dir = dol_buildpath($realpath);
 
 				if (is_dir($dir)) {
@@ -568,85 +666,140 @@ foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 						arsort($filelist);
 
 						foreach ($filelist as $file) {
-							if (preg_match('/\.modules\.php$/i', $file) && preg_match('/^(pdf_|doc_)/', $file)) {
-								if (file_exists($dir.'/'.$file)) {
-									$name = substr($file, 4, dol_strlen($file) - 16);
-									$classname = substr($file, 0, dol_strlen($file) - 12);
+							if (preg_match('/\.modules\.php$/i', $file) && preg_match(
+									'/^(pdf_|doc_)/',
+									$file
+								) && file_exists($dir . '/' . $file)) {
+								$name = substr($file, 4, dol_strlen($file) - 16);
+								$classname = substr($file, 0, dol_strlen($file) - 12);
 
-									require_once $dir.'/'.$file;
-									$module = new $classname($db);
+								require_once $dir . '/' . $file;
+								$module = new $classname($db);
 
-									$modulequalified = 1;
-									if ($module->version == 'development' && $conf->global->MAIN_FEATURES_LEVEL < 2) {
-										$modulequalified = 0;
+								$modulequalified = 1;
+								if ($module->version === 'development' && $conf->global->MAIN_FEATURES_LEVEL < 2) {
+									$modulequalified = 0;
+								}
+								if ($module->version === 'experimental' && $conf->global->MAIN_FEATURES_LEVEL < 1) {
+									$modulequalified = 0;
+								}
+
+								if ($modulequalified) {
+									print '<tr class="oddeven"><td>';
+									print (empty($module->name) ? $name : $module->name);
+									print "</td><td>\n";
+									if (method_exists($module, 'info')) {
+										print $module->info($langs);
+									} else {
+										print $module->description;
 									}
-									if ($module->version == 'experimental' && $conf->global->MAIN_FEATURES_LEVEL < 1) {
-										$modulequalified = 0;
+									print '</td>';
+
+									// Active
+									print '<td class="center">' . "\n";
+									if (in_array($name, $def, true)) {
+										print '<a href="' . $_SERVER['PHP_SELF'] . '?action=del&token=' . newToken(
+											) . '&value=' . urlencode($name) . '">';
+										print img_picto($langs->trans('Enabled'), 'switch_on');
+										print '</a>';
+									} else {
+										print '<a href="' . $_SERVER['PHP_SELF'] . '?action=set&token=' . newToken(
+											) . '&value=' . urlencode($name) . '&scan_dir=' . urlencode(
+												$module->scandir
+											) . '&label=' . urlencode($module->name) . '">' . img_picto(
+												$langs->trans(
+													'Disabled'
+												),
+												'switch_off'
+											) . '</a>';
 									}
+									print '</td>';
 
-									if ($modulequalified) {
-										print '<tr class="oddeven"><td width="100">';
-										print (empty($module->name) ? $name : $module->name);
-										print "</td><td>\n";
-										if (method_exists($module, 'info')) {
-											print $module->info($langs);
-										} else {
-											print $module->description;
-										}
-										print '</td>';
-
-										// Active
-										if (in_array($name, $def)) {
-											print '<td class="center">'."\n";
-											print '<a href="'.$_SERVER["PHP_SELF"].'?action=del&token='.newToken().'&value='.urlencode($name).'">';
-											print img_picto($langs->trans("Enabled"), 'switch_on');
-											print '</a>';
-											print '</td>';
-										} else {
-											print '<td class="center">'."\n";
-											print '<a href="'.$_SERVER["PHP_SELF"].'?action=set&token='.newToken().'&value='.urlencode($name).'&scan_dir='.urlencode($module->scandir).'&label='.urlencode($module->name).'">'.img_picto($langs->trans("Disabled"), 'switch_off').'</a>';
-											print "</td>";
-										}
-
-										// Default
-										print '<td class="center">';
-										$constforvar = 'MYMODULE_'.strtoupper($myTmpObjectKey).'_ADDON';
-										if ($conf->global->$constforvar == $name) {
-											//print img_picto($langs->trans("Default"), 'on');
-											// Even if choice is the default value, we allow to disable it. Replace this with previous line if you need to disable unset
-											print '<a href="'.$_SERVER["PHP_SELF"].'?action=unsetdoc&token='.newToken().'&object='.urlencode(strtolower($myTmpObjectKey)).'&value='.urlencode($name).'&scan_dir='.urlencode($module->scandir).'&label='.urlencode($module->name).'&amp;type='.urlencode($type).'" alt="'.$langs->trans("Disable").'">'.img_picto($langs->trans("Enabled"), 'on').'</a>';
-										} else {
-											print '<a href="'.$_SERVER["PHP_SELF"].'?action=setdoc&token='.newToken().'&object='.urlencode(strtolower($myTmpObjectKey)).'&value='.urlencode($name).'&scan_dir='.urlencode($module->scandir).'&label='.urlencode($module->name).'" alt="'.$langs->trans("Default").'">'.img_picto($langs->trans("Disabled"), 'off').'</a>';
-										}
-										print '</td>';
-
-										// Info
-										$htmltooltip = ''.$langs->trans("Name").': '.$module->name;
-										$htmltooltip .= '<br>'.$langs->trans("Type").': '.($module->type ? $module->type : $langs->trans("Unknown"));
-										if ($module->type == 'pdf') {
-											$htmltooltip .= '<br>'.$langs->trans("Width").'/'.$langs->trans("Height").': '.$module->page_largeur.'/'.$module->page_hauteur;
-										}
-										$htmltooltip .= '<br>'.$langs->trans("Path").': '.preg_replace('/^\//', '', $realpath).'/'.$file;
-
-										$htmltooltip .= '<br><br><u>'.$langs->trans("FeaturesSupported").':</u>';
-										$htmltooltip .= '<br>'.$langs->trans("Logo").': '.yn($module->option_logo, 1, 1);
-										$htmltooltip .= '<br>'.$langs->trans("MultiLanguage").': '.yn($module->option_multilang, 1, 1);
-
-										print '<td class="center">';
-										print $form->textwithpicto('', $htmltooltip, 1, 0);
-										print '</td>';
-
-										// Preview
-										print '<td class="center">';
-										if ($module->type == 'pdf') {
-											print '<a href="'.$_SERVER["PHP_SELF"].'?action=specimen&module='.$name.'&object='.$myTmpObjectKey.'">'.img_object($langs->trans("Preview"), 'pdf').'</a>';
-										} else {
-											print img_object($langs->trans("PreviewNotAvailable"), 'generic');
-										}
-										print '</td>';
-
-										print "</tr>\n";
+									// Default
+									print '<td class="center">';
+									$constforvar = 'MYMODULE_' . strtoupper($myTmpObjectKey) . '_ADDON';
+									if ($conf->global->$constforvar === $name) {
+										//print img_picto($langs->trans("Default"), 'on');
+										// Even if choice is the default value, we allow to disable it.
+										// Replace this with previous line if you need to disable unset
+										print '<a href="' . $_SERVER['PHP_SELF'] . '?action=unsetdoc&token=' . newToken(
+											) . '&object=' . urlencode(
+												strtolower($myTmpObjectKey)
+											) . '&value=' . urlencode($name) . '&scan_dir=' . urlencode(
+												$module->scandir
+											) . '&label=' . urlencode($module->name) . '&amp;type=' . urlencode(
+												$type
+											) . '">' . img_picto(
+												$langs->trans(
+													'Enabled'
+												),
+												'on'
+											) . '</a>';
+									} else {
+										print '<a href="' . $_SERVER['PHP_SELF'] . '?action=setdoc&token=' . newToken(
+											) . '&object=' . urlencode(
+												strtolower($myTmpObjectKey)
+											) . '&value=' . urlencode($name) . '&scan_dir=' . urlencode(
+												$module->scandir
+											) . '&label=' . urlencode($module->name) . '" >' . img_picto(
+												$langs->trans(
+													'Disabled'
+												),
+												'off'
+											) . '</a>';
 									}
+									print '</td>';
+
+									// Info
+									$htmltooltip = '' . $langs->trans('Name') . ': ' . $module->name;
+									$htmltooltip .= '<br>' . $langs->trans(
+											'Type'
+										) . ': ' . ($module->type ?: $langs->trans(
+											'Unknown'
+										));
+									if ($module->type === 'pdf') {
+										$htmltooltip .= '<br>' . $langs->trans('Width') . '/' . $langs->trans(
+												'Height'
+											) . ': ' . $module->page_largeur . '/' . $module->page_hauteur;
+									}
+									$htmltooltip .= '<br>' . $langs->trans('Path') . ': ' . preg_replace(
+											'/^\//',
+											'',
+											$realpath
+										) . '/' . $file;
+
+									$htmltooltip .= '<br><br><u>' . $langs->trans('FeaturesSupported') . ':</u>';
+									$htmltooltip .= '<br>' . $langs->trans('Logo') . ': ' . yn(
+											$module->option_logo,
+											1,
+											1
+										);
+									$htmltooltip .= '<br>' . $langs->trans('MultiLanguage') . ': ' . yn(
+											$module->option_multilang,
+											1,
+											1
+										);
+
+									print '<td class="center">';
+									print $form->textwithpicto('', $htmltooltip, 1, 0);
+									print '</td>';
+
+									// Preview
+									print '<td class="center">';
+									if ($module->type === 'pdf') {
+										print '<a href="' . $_SERVER['PHP_SELF'] . '?action=specimen
+													&module=' . $name . '&
+													object=' . $myTmpObjectKey . '">
+													' . img_object(
+												$langs->trans('Preview'),
+												'pdf'
+											) . '</a>';
+									} else {
+										print img_object($langs->trans('PreviewNotAvailable'), 'generic');
+									}
+									print '</td>';
+
+									print "</tr>\n";
 								}
 							}
 						}
@@ -660,7 +813,7 @@ foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 }
 
 if (empty($setupnotempty)) {
-	print '<br>'.$langs->trans("NothingToSetup");
+	print '<br>' . $langs->trans('NothingToSetup');
 }
 
 // Page end

--- a/htdocs/modulebuilder/template/class/actions_mymodule.class.php
+++ b/htdocs/modulebuilder/template/class/actions_mymodule.class.php
@@ -23,6 +23,8 @@
  * Put detailed description here.
  */
 
+declare(strict_types=1);
+
 /**
  * Class ActionsMyModule
  */
@@ -31,36 +33,36 @@ class ActionsMyModule
 	/**
 	 * @var DoliDB Database handler.
 	 */
-	public $db;
+	public DoliDB $db;
 
 	/**
 	 * @var string Error code (or message)
 	 */
-	public $error = '';
+	public string $error = '';
 
 	/**
 	 * @var array Errors
 	 */
-	public $errors = array();
+	public array $errors = [];
 
 
 	/**
 	 * @var array Hook results. Propagated to $hookmanager->resArray for later reuse
 	 */
-	public $results = array();
+	public array $results = [];
 
 	/**
 	 * @var string String displayed by executeHook() immediately after return
 	 */
-	public $resprints;
+	public string $resprints;
 
 
 	/**
 	 * Constructor
 	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
-	public function __construct($db)
+	public function __construct(DoliDB $db)
 	{
 		$this->db = $db;
 	}
@@ -69,14 +71,16 @@ class ActionsMyModule
 	/**
 	 * Execute action
 	 *
-	 * @param	array			$parameters		Array of parameters
-	 * @param	CommonObject    $object         The object to process (an invoice if you are in invoice module, a propale in propale's module, etc...)
-	 * @param	string			$action      	'add', 'update', 'view'
-	 * @return	int         					<0 if KO,
-	 *                           				=0 if OK but we want to process standard actions too,
-	 *                            				>0 if OK and we want to replace standard actions.
+	 * @param array        $parameters Array of parameters
+	 * @param CommonObject $object     The object to process (an invoice if you are in invoice module,
+	 *                                 a propale in propale's module, etc...)
+	 * @param string       $action     'add', 'update', 'view'
+	 *
+	 * @return    int                            <0 if KO,
+	 *                                        =0 if OK, but we want to process standard actions too,
+	 *                                            >0 if OK and we want to replace standard actions.
 	 */
-	public function getNomUrl($parameters, &$object, &$action)
+	public function getNomUrl(array $parameters, CommonObject $object, string &$action): int
 	{
 		global $db, $langs, $conf, $user;
 		$this->resprints = '';
@@ -86,121 +90,144 @@ class ActionsMyModule
 	/**
 	 * Overloading the doActions function : replacing the parent's function with the one below
 	 *
-	 * @param   array           $parameters     Hook metadatas (context, etc...)
-	 * @param   CommonObject    $object         The object to process (an invoice if you are in invoice module, a propale in propale's module, etc...)
-	 * @param   string          $action         Current action (if set). Generally create or edit or null
-	 * @param   HookManager     $hookmanager    Hook manager propagated to allow calling another hook
+	 * @param array        $parameters  Hook metadatas (context, etc...)
+	 * @param CommonObject $object      The object to process (an invoice if you are in invoice module,
+	 *                                  a propale in propale's module, etc...)
+	 * @param string       $action      Current action (if set). Generally create or edit or null
+	 * @param HookManager  $hookmanager Hook manager propagated to allow calling another hook
+	 *
 	 * @return  int                             < 0 on error, 0 on success, 1 to replace standard code
 	 */
-	public function doActions($parameters, &$object, &$action, $hookmanager)
+	public function doActions(array $parameters, CommonObject $object, string &$action, HookManager $hookmanager): int
 	{
 		global $conf, $user, $langs;
 
 		$error = 0; // Error counter
 
 		/* print_r($parameters); print_r($object); echo "action: " . $action; */
-		if (in_array($parameters['currentcontext'], array('somecontext1', 'somecontext2'))) {	    // do something only for the context 'somecontext1' or 'somecontext2'
+		if (in_array($parameters['currentcontext'], ['somecontext1', 'somecontext2'])) {
+			// do something only for the context 'somecontext1' or 'somecontext2'
 			// Do what you want here...
-			// You can for example call global vars like $fieldstosearchall to overwrite them, or update database depending on $action and $_POST values.
+			// You can for example call global vars like $fieldstosearchall to overwrite them,
+			// or update database depending on $action and $_POST values.
 		}
 
-		if (!$error) {
-			$this->results = array('myreturn' => 999);
-			$this->resprints = 'A text to show';
-			return 0; // or return 1 to replace standard code
-		} else {
+		if ($error) {
 			$this->errors[] = 'Error message';
 			return -1;
 		}
+
+		$this->results = ['myreturn' => 999];
+		$this->resprints = 'A text to show';
+		return 0; // or return 1 to replace standard code
 	}
 
 
 	/**
 	 * Overloading the doMassActions function : replacing the parent's function with the one below
 	 *
-	 * @param   array           $parameters     Hook metadatas (context, etc...)
-	 * @param   CommonObject    $object         The object to process (an invoice if you are in invoice module, a propale in propale's module, etc...)
-	 * @param   string          $action         Current action (if set). Generally create or edit or null
-	 * @param   HookManager     $hookmanager    Hook manager propagated to allow calling another hook
+	 * @param array        $parameters  Hook metadatas (context, etc...)
+	 * @param CommonObject $object      The object to process (an invoice if you are in invoice module,
+	 *                                  a propale in propale's module, etc...)
+	 * @param string       $action      Current action (if set). Generally create or edit or null
+	 * @param HookManager  $hookmanager Hook manager propagated to allow calling another hook
+	 *
 	 * @return  int                             < 0 on error, 0 on success, 1 to replace standard code
 	 */
-	public function doMassActions($parameters, &$object, &$action, $hookmanager)
-	{
+	public function doMassActions(
+		array $parameters,
+		CommonObject $object,
+		string &$action,
+		HookManager $hookmanager
+	): int {
 		global $conf, $user, $langs;
 
 		$error = 0; // Error counter
 
 		/* print_r($parameters); print_r($object); echo "action: " . $action; */
-		if (in_array($parameters['currentcontext'], array('somecontext1', 'somecontext2'))) {		// do something only for the context 'somecontext1' or 'somecontext2'
+		if (in_array($parameters['currentcontext'], ['somecontext1', 'somecontext2'])) {
+			// do something only for the context 'somecontext1' or 'somecontext2'
 			foreach ($parameters['toselect'] as $objectid) {
 				// Do action on each object id
 			}
 		}
 
-		if (!$error) {
-			$this->results = array('myreturn' => 999);
-			$this->resprints = 'A text to show';
-			return 0; // or return 1 to replace standard code
-		} else {
+		if ($error) {
 			$this->errors[] = 'Error message';
 			return -1;
 		}
+
+		$this->results = ['myreturn' => 999];
+		$this->resprints = 'A text to show';
+		return 0; // or return 1 to replace standard code
 	}
 
 
 	/**
 	 * Overloading the addMoreMassActions function : replacing the parent's function with the one below
 	 *
-	 * @param   array           $parameters     Hook metadatas (context, etc...)
-	 * @param   CommonObject    $object         The object to process (an invoice if you are in invoice module, a propale in propale's module, etc...)
-	 * @param   string          $action         Current action (if set). Generally create or edit or null
-	 * @param   HookManager     $hookmanager    Hook manager propagated to allow calling another hook
+	 * @param array        $parameters  Hook metadatas (context, etc...)
+	 * @param CommonObject $object      The object to process (an invoice if you are in invoice module,
+	 *                                  a propale in propale's module, etc...)
+	 * @param string       $action      Current action (if set). Generally create or edit or null
+	 * @param HookManager  $hookmanager Hook manager propagated to allow calling another hook
+	 *
 	 * @return  int                             < 0 on error, 0 on success, 1 to replace standard code
 	 */
-	public function addMoreMassActions($parameters, &$object, &$action, $hookmanager)
-	{
+	public function addMoreMassActions(
+		array $parameters,
+		CommonObject $object,
+		string &$action,
+		HookManager $hookmanager
+	): int {
 		global $conf, $user, $langs;
 
 		$error = 0; // Error counter
 		$disabled = 1;
 
 		/* print_r($parameters); print_r($object); echo "action: " . $action; */
-		if (in_array($parameters['currentcontext'], array('somecontext1', 'somecontext2'))) {		// do something only for the context 'somecontext1' or 'somecontext2'
-			$this->resprints = '<option value="0"'.($disabled ? ' disabled="disabled"' : '').'>'.$langs->trans("MyModuleMassAction").'</option>';
+		if (in_array($parameters['currentcontext'], ['somecontext1', 'somecontext2'])) {
+			// do something only for the context 'somecontext1' or 'somecontext2'
+			$this->resprints = '<option value="0"' . ($disabled ? ' disabled="disabled"' : '') . '>' . $langs->trans(
+					'MyModuleMassAction'
+				) . '</option>';
 		}
 
-		if (!$error) {
-			return 0; // or return 1 to replace standard code
-		} else {
+		if ($error) {
 			$this->errors[] = 'Error message';
 			return -1;
 		}
-	}
 
+		return 0; // or return 1 to replace standard code
+	}
 
 
 	/**
 	 * Execute action
 	 *
-	 * @param	array	$parameters     Array of parameters
-	 * @param   Object	$object		   	Object output on PDF
-	 * @param   string	$action     	'add', 'update', 'view'
-	 * @return  int 		        	<0 if KO,
-	 *                          		=0 if OK but we want to process standard actions too,
-	 *  	                            >0 if OK and we want to replace standard actions.
+	 * @param array  $parameters Array of parameters
+	 * @param Object $object     Object output on PDF
+	 * @param string $action     'add', 'update', 'view'
+	 *
+	 * @return  int                    <0 if KO,
+	 *                                =0 if OK, but we want to process standard actions too,
+	 *                                >0 if OK and we want to replace standard actions.
+	 * @throws Exception
 	 */
-	public function beforePDFCreation($parameters, &$object, &$action)
+	public function beforePDFCreation(array $parameters, object $object, string &$action): int
 	{
 		global $conf, $user, $langs;
 		global $hookmanager;
 
 		$outputlangs = $langs;
 
-		$ret = 0; $deltemp = array();
-		dol_syslog(get_class($this).'::executeHooks action='.$action);
+		$ret = 0;
+		$deltemp = [];
+		dol_syslog(get_class($this) . '::executeHooks action=' . $action);
 
 		/* print_r($parameters); print_r($object); echo "action: " . $action; */
-		if (in_array($parameters['currentcontext'], array('somecontext1', 'somecontext2'))) {		// do something only for the context 'somecontext1' or 'somecontext2'
+		if (in_array($parameters['currentcontext'], ['somecontext1', 'somecontext2'])) {
+			// do something only for the context 'somecontext1' or 'somecontext2'
 		}
 
 		return $ret;
@@ -209,25 +236,28 @@ class ActionsMyModule
 	/**
 	 * Execute action
 	 *
-	 * @param	array	$parameters     Array of parameters
-	 * @param   Object	$pdfhandler     PDF builder handler
-	 * @param   string	$action         'add', 'update', 'view'
-	 * @return  int 		            <0 if KO,
-	 *                                  =0 if OK but we want to process standard actions too,
+	 * @param array  $parameters Array of parameters
+	 * @param Object $pdfhandler PDF builder handler
+	 * @param string $action     'add', 'update', 'view'
+	 *
+	 * @return  int                    <0 if KO,
+	 *                                  =0 if OK, but we want to process standard actions too,
 	 *                                  >0 if OK and we want to replace standard actions.
+	 * @throws Exception
 	 */
-	public function afterPDFCreation($parameters, &$pdfhandler, &$action)
+	public function afterPDFCreation(array $parameters, object $pdfhandler, string &$action): int
 	{
 		global $conf, $user, $langs;
 		global $hookmanager;
 
 		$outputlangs = $langs;
 
-		$ret = 0; $deltemp = array();
-		dol_syslog(get_class($this).'::executeHooks action='.$action);
+		$ret = 0;
+		$deltemp = [];
+		dol_syslog(get_class($this) . '::executeHooks action=' . $action);
 
 		/* print_r($parameters); print_r($object); echo "action: " . $action; */
-		if (in_array($parameters['currentcontext'], array('somecontext1', 'somecontext2'))) {
+		if (in_array($parameters['currentcontext'], ['somecontext1', 'somecontext2'])) {
 			// do something only for the context 'somecontext1' or 'somecontext2'
 		}
 
@@ -235,38 +265,38 @@ class ActionsMyModule
 	}
 
 
-
 	/**
 	 * Overloading the loadDataForCustomReports function : returns data to complete the customreport tool
 	 *
-	 * @param   array           $parameters     Hook metadatas (context, etc...)
-	 * @param   string          $action         Current action (if set). Generally create or edit or null
-	 * @param   HookManager     $hookmanager    Hook manager propagated to allow calling another hook
+	 * @param array       $parameters  Hook metadatas (context, etc...)
+	 * @param string      $action      Current action (if set). Generally create or edit or null
+	 * @param HookManager $hookmanager Hook manager propagated to allow calling another hook
+	 *
 	 * @return  int                             < 0 on error, 0 on success, 1 to replace standard code
 	 */
-	public function loadDataForCustomReports($parameters, &$action, $hookmanager)
+	public function loadDataForCustomReports(array $parameters, string &$action, HookManager $hookmanager): int
 	{
 		global $conf, $user, $langs;
 
-		$langs->load("mymodule@mymodule");
+		$langs->load('mymodule@mymodule');
 
-		$this->results = array();
+		$this->results = [];
 
-		$head = array();
+		$head = [];
 		$h = 0;
 
-		if ($parameters['tabfamily'] == 'mymodule') {
+		if ($parameters['tabfamily'] === 'mymodule') {
 			$head[$h][0] = dol_buildpath('/module/index.php', 1);
-			$head[$h][1] = $langs->trans("Home");
+			$head[$h][1] = $langs->trans('Home');
 			$head[$h][2] = 'home';
 			$h++;
 
-			$this->results['title'] = $langs->trans("MyModule");
+			$this->results['title'] = $langs->trans('MyModule');
 			$this->results['picto'] = 'mymodule@mymodule';
 		}
 
-		$head[$h][0] = 'customreports.php?objecttype='.$parameters['objecttype'].(empty($parameters['tabfamily']) ? '' : '&tabfamily='.$parameters['tabfamily']);
-		$head[$h][1] = $langs->trans("CustomReports");
+		$head[$h][0] = 'customreports.php?objecttype=' . $parameters['objecttype'] . (empty($parameters['tabfamily']) ? '' : '&tabfamily=' . $parameters['tabfamily']);
+		$head[$h][1] = $langs->trans('CustomReports');
 		$head[$h][2] = 'customreports';
 
 		$this->results['head'] = $head;
@@ -275,29 +305,28 @@ class ActionsMyModule
 	}
 
 
-
 	/**
 	 * Overloading the restrictedArea function : check permission on an object
 	 *
-	 * @param   array           $parameters     Hook metadatas (context, etc...)
-	 * @param   string          $action         Current action (if set). Generally create or edit or null
-	 * @param   HookManager     $hookmanager    Hook manager propagated to allow calling another hook
-	 * @return  int 		      			  	<0 if KO,
-	 *                          				=0 if OK but we want to process standard actions too,
-	 *  	                            		>0 if OK and we want to replace standard actions.
+	 * @param array       $parameters  Hook metadatas (context, etc...)
+	 * @param string      $action      Current action (if set). Generally create or edit or null
+	 * @param HookManager $hookmanager Hook manager propagated to allow calling another hook
+	 *
+	 * @return  int                            <0 if KO,
+	 *                                        =0 if OK, but we want to process standard actions too,
+	 *                                        >0 if OK and we want to replace standard actions.
 	 */
-	public function restrictedArea($parameters, &$action, $hookmanager)
+	public function restrictedArea(array $parameters, string &$action, HookManager $hookmanager): int
 	{
 		global $user;
 
-		if ($parameters['features'] == 'myobject') {
+		if ($parameters['features'] === 'myobject') {
 			if ($user->rights->mymodule->myobject->read) {
 				$this->results['result'] = 1;
-				return 1;
 			} else {
 				$this->results['result'] = 0;
-				return 1;
 			}
+			return 1;
 		}
 
 		return 0;
@@ -306,36 +335,48 @@ class ActionsMyModule
 	/**
 	 * Execute action completeTabsHead
 	 *
-	 * @param   array           $parameters     Array of parameters
-	 * @param   CommonObject    $object         The object to process (an invoice if you are in invoice module, a propale in propale's module, etc...)
-	 * @param   string          $action         'add', 'update', 'view'
-	 * @param   Hookmanager     $hookmanager    hookmanager
+	 * @param array        $parameters  Array of parameters
+	 * @param CommonObject $object      The object to process (an invoice if you are in invoice module,
+	 *                                  a propale in propale's module, etc...)
+	 * @param string       $action      'add', 'update', 'view'
+	 * @param Hookmanager  $hookmanager hookmanager
+	 *
 	 * @return  int                             <0 if KO,
-	 *                                          =0 if OK but we want to process standard actions too,
+	 *                                          =0 if OK, but we want to process standard actions too,
 	 *                                          >0 if OK and we want to replace standard actions.
 	 */
-	public function completeTabsHead(&$parameters, &$object, &$action, $hookmanager)
-	{
+	public function completeTabsHead(
+		array &$parameters,
+		CommonObject $object,
+		string &$action,
+		HookManager $hookmanager
+	): int {
 		global $langs, $conf, $user;
 
 		if (!isset($parameters['object']->element)) {
 			return 0;
 		}
-		if ($parameters['mode'] == 'remove') {
+		if ($parameters['mode'] === 'remove') {
 			// utilisé si on veut faire disparaitre des onglets.
 			return 0;
-		} elseif ($parameters['mode'] == 'add') {
+		}
+
+		if ($parameters['mode'] === 'add') {
 			$langs->load('mymodule@mymodule');
 			// utilisé si on veut ajouter des onglets.
 			$counter = count($parameters['head']);
 			$element = $parameters['object']->element;
 			$id = $parameters['object']->id;
 			// verifier le type d'onglet comme member_stats où ça ne doit pas apparaitre
-			// if (in_array($element, ['societe', 'member', 'contrat', 'fichinter', 'project', 'propal', 'commande', 'facture', 'order_supplier', 'invoice_supplier'])) {
+			// if (in_array($element, ['societe', 'member', 'contrat', 'fichinter',
+			// 'project', 'propal', 'commande', 'facture', 'order_supplier', 'invoice_supplier'])) {
 			if (in_array($element, ['context1', 'context2'])) {
 				$datacount = 0;
 
-				$parameters['head'][$counter][0] = dol_buildpath('/mymodule/mymodule_tab.php', 1) . '?id=' . $id . '&amp;module='.$element;
+				$parameters['head'][$counter][0] = dol_buildpath(
+						'/mymodule/mymodule_tab.php',
+						1
+					) . '?id=' . $id . '&amp;module=' . $element;
 				$parameters['head'][$counter][1] = $langs->trans('MyModuleTab');
 				if ($datacount > 0) {
 					$parameters['head'][$counter][1] .= '<span class="badge marginleftonlyshort">' . $datacount . '</span>';
@@ -347,10 +388,10 @@ class ActionsMyModule
 				$this->results = $parameters['head'];
 				// return 1 to replace standard code
 				return 1;
-			} else {
-				// en V14 et + $parameters['head'] est modifiable par référence
-				return 0;
 			}
+
+			// en V14 et + $parameters['head'] est modifiable par référence
+			return 0;
 		}
 	}
 

--- a/htdocs/modulebuilder/template/class/api_mymodule.class.php
+++ b/htdocs/modulebuilder/template/class/api_mymodule.class.php
@@ -188,12 +188,13 @@ class MyModuleApi extends DolibarrApi
 	}
 
 	/**
-	 * @param MyObject $tmpobject
-	 * @param string   $sql
-	 * @param int      $restrictonsocid
-	 * @param          $socid
-	 * @param int      $search_sale
-	 * @param string   $sqlfilters
+	 * @param MyObject $tmpobject 		Temporary object
+	 * @param string   $sql				SQL Query
+	 * @param int      $restrictonsocid Set to 1 if there is a field socid in table of object
+	 * @param int      $socid			Societe ID
+	 * @param int      $search_sale		User ID
+	 * @param string   $sqlfilters		Other criteria to filter answers separated by a comma.
+	 *                           		Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 *
 	 * @return string
 	 * @throws RestException

--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -696,7 +696,7 @@ class MyObject extends CommonObject
 			}
 		}
 		if (count($sqlwhere) > 0) {
-			$sql .= ' AND (' . implode(' ' . $filtermode . ' ', $sqlwhere) . ')';
+			$sql .= ' AND (' . implode(' ' . $this->db->escape($filtermode) . ' ', $sqlwhere) . ')';
 		}
 
 		if (!empty($sortfield)) {

--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -22,8 +22,10 @@
  * \brief       This file is a CRUD class file for MyObject (Create/Read/Update/Delete)
  */
 
+declare(strict_types=1);
+
 // Put here all includes required by your class file
-require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/class/commonobject.class.php';
 //require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 //require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 
@@ -35,7 +37,7 @@ class MyObject extends CommonObject
 	/**
 	 * @var string ID of module.
 	 */
-	public $module = 'mymodule';
+	public string $module = 'mymodule';
 
 	/**
 	 * @var string ID to identify managed object.
@@ -43,7 +45,8 @@ class MyObject extends CommonObject
 	public $element = 'myobject';
 
 	/**
-	 * @var string Name of table without prefix where object is stored. This is also the key used for extrafields management.
+	 * @var string Name of table without prefix where object is stored.
+	 * This is also the key used for extrafields management.
 	 */
 	public $table_element = 'mymodule_myobject';
 
@@ -51,89 +54,293 @@ class MyObject extends CommonObject
 	 * @var int  Does this object support multicompany module ?
 	 * 0=No test on entity, 1=Test with field entity, 'field@table'=Test with link by field@table
 	 */
-	public $ismultientitymanaged = 0;
+	public int $ismultientitymanaged = 0;
 
 	/**
 	 * @var int  Does object support extrafields ? 0=No, 1=Yes
 	 */
-	public $isextrafieldmanaged = 1;
+	public int $isextrafieldmanaged = 1;
 
 	/**
 	 * @var string String with name of icon for myobject. Must be the part after the 'object_' into object_myobject.png
 	 */
-	public $picto = 'myobject@mymodule';
+	public string $picto = 'myobject@mymodule';
 
 
-	const STATUS_DRAFT = 0;
-	const STATUS_VALIDATED = 1;
-	const STATUS_CANCELED = 9;
+	public const STATUS_DRAFT = 0;
+	public const STATUS_VALIDATED = 1;
+	public const STATUS_CANCELED = 9;
 
 
 	/**
-	 *  'type' field format ('integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter[:Sortfield]]]', 'sellist:TableName:LabelFieldName[:KeyFieldName[:KeyFieldParent[:Filter[:Sortfield]]]]', 'varchar(x)', 'double(24,8)', 'real', 'price', 'text', 'text:none', 'html', 'date', 'datetime', 'timestamp', 'duration', 'mail', 'phone', 'url', 'password')
-	 *         Note: Filter can be a string like "(t.ref:like:'SO-%') or (t.date_creation:<:'20160101') or (t.nature:is:NULL)"
+	 *  'type' field format ('integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter[:Sortfield]]]',
+	 *                        'sellist:TableName:LabelFieldName[:KeyFieldName[:KeyFieldParent[:Filter[:Sortfield]]]]',
+	 *                        'varchar(x)', 'double(24,8)', 'real', 'price', 'text', 'text:none', 'html', 'date',
+	 * 'datetime', 'timestamp', 'duration', 'mail', 'phone', 'url', 'password')
+	 *            Note: Filter can be a string like "(t.ref:like:'SO-%') or (t.date_creation:<:'20160101')
+	 *            or (t.nature:is:NULL)"
 	 *  'label' the translation key.
 	 *  'picto' is code of a picto to show before value in forms
 	 *  'enabled' is a condition when the field must be managed (Example: 1 or '$conf->global->MY_SETUP_PARAM)
 	 *  'position' is the sort order of field.
 	 *  'notnull' is set to 1 if not null in database. Set to -1 if we must set data to null if empty ('' or 0).
-	 *  'visible' says if field is visible in list (Examples: 0=Not visible, 1=Visible on list and create/update/view forms, 2=Visible on list only, 3=Visible on create/update/view form only (not list), 4=Visible on list and update/view form only (not create). 5=Visible on list and view only (not create/not update). Using a negative value means field is not shown by default on list but can be selected for viewing)
+	 *  'visible' says if field is visible in list (Examples: 0=Not visible,
+	 *                1=Visible on list and create/update/view forms,
+	 *              2=Visible on list only,
+	 *              3=Visible on create/update/view form only (not list),
+	 *              4=Visible on list and update/view form only (not create).
+	 *              5=Visible on list and view only (not create/not update). Using a negative value means field is
+	 *                    not shown by default on list but can be selected for viewing)
 	 *  'noteditable' says if field is not editable (1 or 0)
-	 *  'default' is a default value for creation (can still be overwrote by the Setup of Default Values if field is editable in creation form). Note: If default is set to '(PROV)' and field is 'ref', the default value will be set to '(PROVid)' where id is rowid when a new record is created.
+	 *  'default' is a default value for creation (can still be overwritten by the Setup of Default Values if field
+	 *          is editable in creation form). Note: If default is set to '(PROV)' and field is 'ref', the default
+	 *            value will be set to '(PROVid)' where id is rowid when a new record is created.
 	 *  'index' if we want an index in database.
 	 *  'foreignkey'=>'tablename.field' if the field is a foreign key (it is recommanded to name the field fk_...).
 	 *  'searchall' is 1 if we want to search in this field when making a search from the quick search button.
-	 *  'isameasure' must be set to 1 if you want to have a total on list for this field. Field type must be summable like integer or double(24,8).
-	 *  'css' and 'cssview' and 'csslist' is the CSS style to use on field. 'css' is used in creation and update. 'cssview' is used in view mode. 'csslist' is used for columns in lists. For example: 'css'=>'minwidth300 maxwidth500 widthcentpercentminusx', 'cssview'=>'wordbreak', 'csslist'=>'tdoverflowmax200'
-	 *  'help' is a 'TranslationString' to use to show a tooltip on field. You can also use 'TranslationString:keyfortooltiponlick' for a tooltip on click.
+	 *  'isameasure' must be set to 1 if you want to have a total on list for this field. Field type must be summable
+	 *            like integer or double(24,8).
+	 *  'css' and 'cssview' and 'csslist' is the CSS style to use on field. 'css' is used in creation and update.
+	 *        'cssview' is used in view mode. 'csslist' is used for columns in lists. For example: 'css'=>'minwidth300
+	 * maxwidth500 widthcentpercentminusx', 'cssview'=>'wordbreak', 'csslist'=>'tdoverflowmax200'
+	 *  'help' is a 'TranslationString' to use to show a tooltip on field. You can also
+	 *            use 'TranslationString:keyfortooltiponlick' for a tooltip on click.
 	 *  'showoncombobox' if value of the field must be visible into the label of the combobox that list record
-	 *  'disabled' is 1 if we want to have the field locked by a 'disabled' attribute. In most cases, this is never set into the definition of $fields into class, but is set dynamically by some part of code.
-	 *  'arrayofkeyval' to set a list of values if type is a list of predefined values. For example: array("0"=>"Draft","1"=>"Active","-1"=>"Cancel"). Note that type can be 'integer' or 'varchar'
-	 *  'autofocusoncreate' to have field having the focus on a create form. Only 1 field should have this property set to 1.
+	 *  'disabled' is 1 if we want to have the field locked by a 'disabled' attribute. In most cases, this is never set
+	 *        into the definition of $fields into class, but is set dynamically by some part of code.
+	 *  'arrayofkeyval' to set a list of values if type is a list of predefined values. For example:
+	 *        array("0"=>"Draft","1"=>"Active","-1"=>"Cancel"). Note that type can be 'integer' or 'varchar'
+	 *  'autofocusoncreate' to have field having the focus on a create form.
+	 *        Only 1 field should have this property set to 1.
 	 *  'comment' is not used. You can store here any text of your choice. It is not used by application.
-	 *	'validate' is 1 if need to validate with $this->validateField()
-	 *  'copytoclipboard' is 1 or 2 to allow to add a picto to copy value into clipboard (1=picto after label, 2=picto after value)
+	 *    'validate' is 1 if you need to validate with $this->validateField()
+	 *  'copytoclipboard' is 1 or 2 to allow to add a picto to copy value into clipboard
+	 *        (1=picto after label, 2=picto after value)
 	 *
-	 *  Note: To have value dynamic, you can set value to 0 in definition and edit the value on the fly into the constructor.
+	 *  Note: To have value dynamic, you can set value to 0 in definition and edit the
+	 *  value on the fly into the constructor.
 	 */
 
 	// BEGIN MODULEBUILDER PROPERTIES
 	/**
-	 * @var array  Array with all fields and their property. Do not use it as a static var. It may be modified by constructor.
+	 * @var array  Array with all fields and their property. Do not use it as a static var.
+	 * It may be modified by constructor.
 	 */
-	public $fields = array(
-		'rowid'         => array('type'=>'integer', 'label'=>'TechnicalID', 'enabled'=>1, 'visible'=>-2, 'noteditable'=>1, 'notnull'=> 1, 'index'=>1, 'position'=>1, 'comment'=>'Id', 'css'=>'left'),
-		'entity'        => array('type'=>'integer', 'label'=>'Entity', 'enabled'=>1, 'visible'=>0, 'notnull'=> 1, 'default'=>1, 'index'=>1, 'position'=>10),
-		'ref'           => array('type'=>'varchar(128)', 'label'=>'Ref', 'enabled'=>1, 'visible'=>1, 'noteditable'=>0, 'default'=>'', 'notnull'=> 1, 'showoncombobox'=>1, 'index'=>1, 'position'=>20, 'searchall'=>1, 'comment'=>'Reference of object', 'validate'=>1),
-		'label'         => array('type'=>'varchar(255)', 'label'=>'Label', 'enabled'=>1, 'visible'=>1, 'position'=>30, 'searchall'=>1, 'css'=>'minwidth300', 'cssview'=>'wordbreak', 'help'=>'Help text', 'showoncombobox'=>2, 'validate'=>1),
-		'amount'        => array('type'=>'price', 'label'=>'Amount', 'enabled'=>1, 'visible'=>1, 'default'=>'null', 'position'=>40, 'searchall'=>0, 'isameasure'=>1, 'help'=>'Help text for amount', 'validate'=>1),
-		'qty'           => array('type'=>'real', 'label'=>'Qty', 'enabled'=>1, 'visible'=>1, 'default'=>'0', 'position'=>45, 'searchall'=>0, 'isameasure'=>1, 'help'=>'Help text for quantity', 'css'=>'maxwidth75imp', 'validate'=>1),
-		'fk_soc' 		=> array('type'=>'integer:Societe:societe/class/societe.class.php:1:status=1 AND entity IN (__SHARED_ENTITIES__)', 'picto'=>'company', 'label'=>'ThirdParty', 'visible'=> 1, 'enabled'=>1, 'position'=>50, 'notnull'=>-1, 'index'=>1, 'help'=>'LinkToThirparty', 'validate'=>1),
-		'fk_project'    => array('type'=>'integer:Project:projet/class/project.class.php:1', 'label'=>'Project', 'picto'=>'project', 'enabled'=>1, 'visible'=>-1, 'position'=>52, 'notnull'=>-1, 'index'=>1, 'validate'=>1),
-		'description'   => array('type'=>'text', 'label'=>'Description', 'enabled'=>1, 'visible'=>3, 'position'=>60, 'validate'=>1),
-		'note_public'   => array('type'=>'html', 'label'=>'NotePublic', 'enabled'=>1, 'visible'=>0, 'position'=>61, 'validate'=>1),
-		'note_private'  => array('type'=>'html', 'label'=>'NotePrivate', 'enabled'=>1, 'visible'=>0, 'position'=>62, 'validate'=>1),
-		'date_creation' => array('type'=>'datetime', 'label'=>'DateCreation', 'enabled'=>1, 'visible'=>-2, 'notnull'=> 1, 'position'=>500),
-		'tms'           => array('type'=>'timestamp', 'label'=>'DateModification', 'enabled'=>1, 'visible'=>-2, 'notnull'=> 0, 'position'=>501),
-		//'date_validation '    =>array('type'=>'datetime',     'label'=>'DateCreation',     'enabled'=>1, 'visible'=>-2, 'position'=>502),
-		'fk_user_creat' => array('type'=>'integer:User:user/class/user.class.php', 'label'=>'UserAuthor', 'picto'=>'user', 'enabled'=>1, 'visible'=>-2, 'notnull'=> 1, 'position'=>510, 'foreignkey'=>'user.rowid'),
-		'fk_user_modif' => array('type'=>'integer:User:user/class/user.class.php', 'label'=>'UserModif', 'picto'=>'user', 'enabled'=>1, 'visible'=>-2, 'notnull'=>-1, 'position'=>511),
-		//'fk_user_valid' => array('type'=>'integer:User:user/class/user.class.php',      'label'=>'UserValidation',        'enabled'=>1, 'visible'=>-1, 'position'=>512),
-		'last_main_doc' => array('type'=>'varchar(255)', 'label'=>'LastMainDoc', 'enabled'=>1, 'visible'=>0, 'notnull'=>0, 'position'=>600),
-		'import_key'    => array('type'=>'varchar(14)', 'label'=>'ImportId', 'enabled'=>1, 'visible'=>-2, 'notnull'=>-1, 'index'=>0, 'position'=>1000),
-		'model_pdf' 	=> array('type'=>'varchar(255)', 'label'=>'Model pdf', 'enabled'=>1, 'visible'=>0, 'notnull'=>-1, 'position'=>1010),
-		'status'        => array('type'=>'smallint', 'label'=>'Status', 'enabled'=>1, 'visible'=>1, 'notnull'=> 1, 'default'=>0, 'index'=>1, 'position'=>1000, 'arrayofkeyval'=>array(0=>'Draft', 1=>'Validated', 9=>'Canceled'), 'validate'=>1),
-	);
+	public array $fields = [
+		'rowid' => [
+			'type' => 'integer',
+			'label' => 'TechnicalID',
+			'enabled' => 1,
+			'visible' => -2,
+			'noteditable' => 1,
+			'notnull' => 1,
+			'index' => 1,
+			'position' => 1,
+			'comment' => 'Id',
+			'css' => 'left'
+		],
+		'entity' => [
+			'type' => 'integer',
+			'label' => 'Entity',
+			'enabled' => 1,
+			'visible' => 0,
+			'notnull' => 1,
+			'default' => 1,
+			'index' => 1,
+			'position' => 10
+		],
+		'ref' => [
+			'type' => 'varchar(128)',
+			'label' => 'Ref',
+			'enabled' => 1,
+			'visible' => 1,
+			'noteditable' => 0,
+			'default' => '',
+			'notnull' => 1,
+			'showoncombobox' => 1,
+			'index' => 1,
+			'position' => 20,
+			'searchall' => 1,
+			'comment' => 'Reference of object',
+			'validate' => 1
+		],
+		'label' => [
+			'type' => 'varchar(255)',
+			'label' => 'Label',
+			'enabled' => 1,
+			'visible' => 1,
+			'position' => 30,
+			'searchall' => 1,
+			'css' => 'minwidth300',
+			'cssview' => 'wordbreak',
+			'help' => 'Help text',
+			'showoncombobox' => 2,
+			'validate' => 1
+		],
+		'amount' => [
+			'type' => 'price',
+			'label' => 'Amount',
+			'enabled' => 1,
+			'visible' => 1,
+			'default' => 'null',
+			'position' => 40,
+			'searchall' => 0,
+			'isameasure' => 1,
+			'help' => 'Help text for amount',
+			'validate' => 1
+		],
+		'qty' => [
+			'type' => 'real',
+			'label' => 'Qty',
+			'enabled' => 1,
+			'visible' => 1,
+			'default' => '0',
+			'position' => 45,
+			'searchall' => 0,
+			'isameasure' => 1,
+			'help' => 'Help text for quantity',
+			'css' => 'maxwidth75imp',
+			'validate' => 1
+		],
+		'fk_soc' => [
+			'type' => 'integer:Societe:societe/class/societe.class.php:1:status=1 AND entity IN (__SHARED_ENTITIES__)',
+			'picto' => 'company',
+			'label' => 'ThirdParty',
+			'visible' => 1,
+			'enabled' => 1,
+			'position' => 50,
+			'notnull' => -1,
+			'index' => 1,
+			'help' => 'LinkToThirparty',
+			'validate' => 1
+		],
+		'fk_project' => [
+			'type' => 'integer:Project:projet/class/project.class.php:1',
+			'label' => 'Project',
+			'picto' => 'project',
+			'enabled' => 1,
+			'visible' => -1,
+			'position' => 52,
+			'notnull' => -1,
+			'index' => 1,
+			'validate' => 1
+		],
+		'description' => [
+			'type' => 'text',
+			'label' => 'Description',
+			'enabled' => 1,
+			'visible' => 3,
+			'position' => 60,
+			'validate' => 1
+		],
+		'note_public' => [
+			'type' => 'html',
+			'label' => 'NotePublic',
+			'enabled' => 1,
+			'visible' => 0,
+			'position' => 61,
+			'validate' => 1
+		],
+		'note_private' => [
+			'type' => 'html',
+			'label' => 'NotePrivate',
+			'enabled' => 1,
+			'visible' => 0,
+			'position' => 62,
+			'validate' => 1
+		],
+		'date_creation' => [
+			'type' => 'datetime',
+			'label' => 'DateCreation',
+			'enabled' => 1,
+			'visible' => -2,
+			'notnull' => 1,
+			'position' => 500
+		],
+		'tms' => [
+			'type' => 'timestamp',
+			'label' => 'DateModification',
+			'enabled' => 1,
+			'visible' => -2,
+			'notnull' => 0,
+			'position' => 501
+		],
+		//'date_validation' =>array('type'=>'datetime',
+		//'label'=>'DateCreation', 'enabled'=>1, 'visible'=>-2, 'position'=>502),
+		'fk_user_creat' => [
+			'type' => 'integer:User:user/class/user.class.php',
+			'label' => 'UserAuthor',
+			'picto' => 'user',
+			'enabled' => 1,
+			'visible' => -2,
+			'notnull' => 1,
+			'position' => 510,
+			'foreignkey' => 'user.rowid'
+		],
+		'fk_user_modif' => [
+			'type' => 'integer:User:user/class/user.class.php',
+			'label' => 'UserModif',
+			'picto' => 'user',
+			'enabled' => 1,
+			'visible' => -2,
+			'notnull' => -1,
+			'position' => 511
+		],
+		//'fk_user_valid' => array('type'=>'integer:User:user/class/user.class.php',
+		//'label'=>'UserValidation', 'enabled'=>1, 'visible'=>-1, 'position'=>512),
+		'last_main_doc' => [
+			'type' => 'varchar(255)',
+			'label' => 'LastMainDoc',
+			'enabled' => 1,
+			'visible' => 0,
+			'notnull' => 0,
+			'position' => 600
+		],
+		'import_key' => [
+			'type' => 'varchar(14)',
+			'label' => 'ImportId',
+			'enabled' => 1,
+			'visible' => -2,
+			'notnull' => -1,
+			'index' => 0,
+			'position' => 1000
+		],
+		'model_pdf' => [
+			'type' => 'varchar(255)',
+			'label' => 'Model pdf',
+			'enabled' => 1,
+			'visible' => 0,
+			'notnull' => -1,
+			'position' => 1010
+		],
+		'status' => [
+			'type' => 'smallint',
+			'label' => 'Status',
+			'enabled' => 1,
+			'visible' => 1,
+			'notnull' => 1,
+			'default' => 0,
+			'index' => 1,
+			'position' => 1000,
+			'arrayofkeyval' => [0 => 'Draft', 1 => 'Validated', 9 => 'Canceled'],
+			'validate' => 1
+		],
+	];
 
 	/**
 	 * @var int ID
 	 */
-	public $rowid;
+	public int $rowid;
 
 	/**
 	 * @var string Ref
 	 */
 	public $ref;
+
+	/**
+	 * @var string Ref
+	 */
+	public string $oldref;
 
 	/**
 	 * @var int Entity
@@ -143,12 +350,12 @@ class MyObject extends CommonObject
 	/**
 	 * @var string label
 	 */
-	public $label;
+	public string $label;
 
 	/**
 	 * @var string amount
 	 */
-	public $amount;
+	public string $amount;
 
 	/**
 	 * @var int Status
@@ -156,24 +363,43 @@ class MyObject extends CommonObject
 	public $status;
 
 	/**
-	 * @var integer|string date_creation
+	 * @var int|string date_creation
 	 */
 	public $date_creation;
 
 	/**
-	 * @var integer tms
+	 * @var int tms
 	 */
-	public $tms;
+	public int $tms;
 
 	/**
 	 * @var int ID
 	 */
-	public $fk_user_creat;
+	public int $fk_user_creat;
+
+	/**
+	 * @var User ID
+	 */
+	public User $user_creation;
+
+	/**
+	 * @var User ID
+	 */
+	public User $user_validation;
+	/**
+	 * @var User ID
+	 */
+	public User $user_cloture;
+
+	/**
+	 * @var string Output
+	 */
+	public string $output;
 
 	/**
 	 * @var int ID
 	 */
-	public $fk_user_modif;
+	public int $fk_user_modif;
 
 	/**
 	 * @var string public $last_main_doc
@@ -222,7 +448,6 @@ class MyObject extends CommonObject
 	// public $lines = array();
 
 
-
 	/**
 	 * Constructor
 	 *
@@ -269,27 +494,28 @@ class MyObject extends CommonObject
 	/**
 	 * Create object into database
 	 *
-	 * @param  User $user      User that creates
-	 * @param  bool $notrigger false=launch triggers after, true=disable triggers
-	 * @return int             <0 if KO, Id of created object if OK
+	 * @param User $user      User that creates
+	 * @param bool $notrigger false=launch triggers after, true=disable triggers
+	 *
+	 * @return int             <0 if KO, ID of created object if OK
 	 */
-	public function create(User $user, $notrigger = false)
+	public function create(User $user, bool $notrigger): int
 	{
-		$resultcreate = $this->createCommon($user, $notrigger);
-
 		//$resultvalidate = $this->validate($user, $notrigger);
 
-		return $resultcreate;
+		return $this->createCommon($user, $notrigger);
 	}
 
 	/**
 	 * Clone an object into another one
 	 *
-	 * @param  	User 	$user      	User that creates
-	 * @param  	int 	$fromid     Id of object to clone
-	 * @return 	mixed 				New object created, <0 if KO
+	 * @param User $user   User that creates
+	 * @param int  $fromid ID of object to clone
+	 *
+	 * @return    int|MyObject                New object created, <0 if KO
+	 * @throws Exception
 	 */
-	public function createFromClone(User $user, $fromid)
+	public function createFromClone(User $user, int $fromid)
 	{
 		global $langs, $extrafields;
 		$error = 0;
@@ -311,16 +537,58 @@ class MyObject extends CommonObject
 		//	$line->fetch_optionals();
 
 		// Reset some properties
-		unset($object->id);
-		unset($object->fk_user_creat);
-		unset($object->import_key);
+		unset($object->id, $object->fk_user_creat, $object->import_key);
 
+		$this->createFromCloneClearFields($object, $langs, $extrafields);
+
+		// Create clone
+		$object->context['createfromclone'] = 'createfromclone';
+		$result = $object->createCommon($user);
+		if ($result < 0) {
+			$error++;
+			$this->error = $object->error;
+			$this->errors = $object->errors;
+		}
+
+		// copy internal contacts
+		if (!$error && $this->copy_linked_contact($object) < 0) {
+			$error++;
+		}
+
+		// copy external contacts if same company
+		if (!$error && property_exists(
+				$this,
+				'fk_soc'
+			) && $this->fk_soc === $object->socid && $this->copy_linked_contact($object, 'external') < 0) {
+			$error++;
+		}
+
+		unset($object->context['createfromclone']);
+
+		// End
+		if ($error) {
+			$this->db->rollback();
+			return -1;
+		}
+
+		$this->db->commit();
+		return $object;
+	}
+
+	/**
+	 * @param MyObject $object
+	 * @param          $langs
+	 * @param          $extrafields
+	 */
+	protected function createFromCloneClearFields(MyObject $object, $langs, $extrafields): void
+	{
 		// Clear fields
 		if (property_exists($object, 'ref')) {
-			$object->ref = empty($this->fields['ref']['default']) ? "Copy_Of_".$object->ref : $this->fields['ref']['default'];
+			$object->ref = empty($this->fields['ref']['default']) ? 'Copy_Of_' . $object->ref : $this->fields['ref']['default'];
 		}
 		if (property_exists($object, 'label')) {
-			$object->label = empty($this->fields['label']['default']) ? $langs->trans("CopyOf")." ".$object->label : $this->fields['label']['default'];
+			$object->label = empty($this->fields['label']['default']) ?
+				$langs->trans('CopyOf') . ' ' . $object->label : $this->fields['label']['default'];
 		}
 		if (property_exists($object, 'status')) {
 			$object->status = self::STATUS_DRAFT;
@@ -336,59 +604,24 @@ class MyObject extends CommonObject
 		if (is_array($object->array_options) && count($object->array_options) > 0) {
 			$extrafields->fetch_name_optionals_label($this->table_element);
 			foreach ($object->array_options as $key => $option) {
-				$shortkey = preg_replace('/options_/', '', $key);
+				$shortkey = str_replace('options_', '', $key);
 				if (!empty($extrafields->attributes[$this->table_element]['unique'][$shortkey])) {
 					//var_dump($key); var_dump($clonedObj->array_options[$key]); exit;
 					unset($object->array_options[$key]);
 				}
 			}
 		}
-
-		// Create clone
-		$object->context['createfromclone'] = 'createfromclone';
-		$result = $object->createCommon($user);
-		if ($result < 0) {
-			$error++;
-			$this->error = $object->error;
-			$this->errors = $object->errors;
-		}
-
-		if (!$error) {
-			// copy internal contacts
-			if ($this->copy_linked_contact($object, 'internal') < 0) {
-				$error++;
-			}
-		}
-
-		if (!$error) {
-			// copy external contacts if same company
-			if (property_exists($this, 'fk_soc') && $this->fk_soc == $object->socid) {
-				if ($this->copy_linked_contact($object, 'external') < 0) {
-					$error++;
-				}
-			}
-		}
-
-		unset($object->context['createfromclone']);
-
-		// End
-		if (!$error) {
-			$this->db->commit();
-			return $object;
-		} else {
-			$this->db->rollback();
-			return -1;
-		}
 	}
 
 	/**
 	 * Load object in memory from the database
 	 *
-	 * @param int    $id   Id object
-	 * @param string $ref  Ref
+	 * @param int         $id  Id object
+	 * @param string|null $ref Ref
+	 *
 	 * @return int         <0 if KO, 0 if not found, >0 if OK
 	 */
-	public function fetch($id, $ref = null)
+	public function fetch(int $id, string $ref = null): int
 	{
 		$result = $this->fetchCommon($id, $ref);
 		if ($result > 0 && !empty($this->table_element_line)) {
@@ -402,61 +635,68 @@ class MyObject extends CommonObject
 	 *
 	 * @return int         <0 if KO, 0 if not found, >0 if OK
 	 */
-	public function fetchLines()
+	public function fetchLines(): int
 	{
-		$this->lines = array();
+		$this->lines = [];
 
-		$result = $this->fetchLinesCommon();
-		return $result;
+		return $this->fetchLinesCommon();
 	}
 
 
 	/**
 	 * Load list of objects in memory from the database.
 	 *
-	 * @param  string      $sortorder    Sort Order
-	 * @param  string      $sortfield    Sort field
-	 * @param  int         $limit        limit
-	 * @param  int         $offset       Offset
-	 * @param  array       $filter       Filter array. Example array('field'=>'valueforlike', 'customurl'=>...)
-	 * @param  string      $filtermode   Filter mode (AND or OR)
+	 * @param string $sortorder  Sort Order
+	 * @param string $sortfield  Sort field
+	 * @param int    $limit      limit
+	 * @param int    $offset     Offset
+	 * @param array  $filter     Filter array. Example array('field'=>'valueforlike', 'customurl'=>...)
+	 * @param string $filtermode Filter mode (AND or)
+	 *
 	 * @return array|int                 int <0 if KO, array of pages if OK
+	 * @throws Exception
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
-	{
+	public function fetchAll(
+		string $sortorder = '',
+		string $sortfield = '',
+		int $limit = 0,
+		int $offset = 0,
+		array $filter = [],
+		string $filtermode = 'AND'
+	) {
 		global $conf;
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
 
-		$records = array();
+		$records = [];
 
-		$sql = "SELECT ";
+		$sql = 'SELECT ';
 		$sql .= $this->getFieldList('t');
-		$sql .= " FROM ".MAIN_DB_PREFIX.$this->table_element." as t";
-		if (isset($this->ismultientitymanaged) && $this->ismultientitymanaged == 1) {
-			$sql .= " WHERE t.entity IN (".getEntity($this->table_element).")";
+		$sql .= ' FROM ' . MAIN_DB_PREFIX . $this->table_element . ' as t';
+		if (isset($this->ismultientitymanaged) && $this->ismultientitymanaged === 1) {
+			$sql .= ' WHERE t.entity IN (' . getEntity($this->table_element) . ')';
 		} else {
-			$sql .= " WHERE 1 = 1";
+			$sql .= ' WHERE 1 = 1';
 		}
 		// Manage filter
-		$sqlwhere = array();
+		$sqlwhere = [];
 		if (count($filter) > 0) {
 			foreach ($filter as $key => $value) {
-				if ($key == 't.rowid') {
-					$sqlwhere[] = $key." = ".((int) $value);
-				} elseif (in_array($this->fields[$key]['type'], array('date', 'datetime', 'timestamp'))) {
-					$sqlwhere[] = $key." = '".$this->db->idate($value)."'";
-				} elseif ($key == 'customsql') {
+				if ($key === 't.rowid') {
+					$sqlwhere[] = $key . ' = ' . ((int) $value);
+				} elseif (in_array($this->fields[$key]['type'], ['date', 'datetime', 'timestamp'])) {
+					$sqlwhere[] = $key . " = '" . $this->db->idate($value) . "'";
+				} elseif ($key === 'customsql') {
 					$sqlwhere[] = $value;
-				} elseif (strpos($value, '%') === false) {
-					$sqlwhere[] = $key." IN (".$this->db->sanitize($this->db->escape($value)).")";
+				} elseif (strpos($value, '%') !== false) {
+					$sqlwhere[] = $key . " LIKE '%" . $this->db->escape($value) . "%'";
 				} else {
-					$sqlwhere[] = $key." LIKE '%".$this->db->escape($value)."%'";
+					$sqlwhere[] = $key . ' IN (' . $this->db->sanitize($this->db->escape($value)) . ')';
 				}
 			}
 		}
 		if (count($sqlwhere) > 0) {
-			$sql .= " AND (".implode(" ".$filtermode." ", $sqlwhere).")";
+			$sql .= ' AND (' . implode(' ' . $filtermode . ' ', $sqlwhere) . ')';
 		}
 
 		if (!empty($sortfield)) {
@@ -483,22 +723,23 @@ class MyObject extends CommonObject
 			$this->db->free($resql);
 
 			return $records;
-		} else {
-			$this->errors[] = 'Error '.$this->db->lasterror();
-			dol_syslog(__METHOD__.' '.join(',', $this->errors), LOG_ERR);
-
-			return -1;
 		}
+
+		$this->errors[] = 'Error ' . $this->db->lasterror();
+		dol_syslog(__METHOD__ . ' ' . implode(',', $this->errors), LOG_ERR);
+
+		return -1;
 	}
 
 	/**
 	 * Update object into database
 	 *
-	 * @param  User $user      User that modifies
-	 * @param  bool $notrigger false=launch triggers after, true=disable triggers
+	 * @param User $user      User that modifies
+	 * @param bool $notrigger false=launch triggers after, true=disable triggers
+	 *
 	 * @return int             <0 if KO, >0 if OK
 	 */
-	public function update(User $user, $notrigger = false)
+	public function update(User $user, bool $notrigger): int
 	{
 		return $this->updateCommon($user, $notrigger);
 	}
@@ -506,11 +747,12 @@ class MyObject extends CommonObject
 	/**
 	 * Delete object in database
 	 *
-	 * @param User $user       User that deletes
-	 * @param bool $notrigger  false=launch triggers after, true=disable triggers
+	 * @param User $user      User that deletes
+	 * @param bool $notrigger false=launch triggers after, true=disable triggers
+	 *
 	 * @return int             <0 if KO, >0 if OK
 	 */
-	public function delete(User $user, $notrigger = false)
+	public function delete(User $user, bool $notrigger): int
 	{
 		return $this->deleteCommon($user, $notrigger);
 		//return $this->deleteCommon($user, $notrigger, 1);
@@ -519,12 +761,13 @@ class MyObject extends CommonObject
 	/**
 	 *  Delete a line of object in database
 	 *
-	 *	@param  User	$user       User that delete
-	 *  @param	int		$idline		Id of line to delete
-	 *  @param 	bool 	$notrigger  false=launch triggers after, true=disable triggers
-	 *  @return int         		>0 if OK, <0 if KO
+	 * @param User $user      User that delete
+	 * @param int  $idline    ID of line to delete
+	 * @param bool $notrigger false=launch triggers after, true=disable triggers
+	 *
+	 * @return int                >0 if OK, <0 if KO
 	 */
-	public function deleteLine(User $user, $idline, $notrigger = false)
+	public function deleteLine(User $user, int $idline, bool $notrigger): int
 	{
 		if ($this->status < 0) {
 			$this->error = 'ErrorDeleteLineNotAllowedByObjectStatus';
@@ -536,28 +779,31 @@ class MyObject extends CommonObject
 
 
 	/**
-	 *	Validate object
+	 *    Validate object
 	 *
-	 *	@param		User	$user     		User making status change
-	 *  @param		int		$notrigger		1=Does not execute triggers, 0= execute triggers
-	 *	@return  	int						<=0 if OK, 0=Nothing done, >0 if KO
+	 * @param User $user      User making status change
+	 * @param int  $notrigger 1=Does not execute triggers, 0= execute triggers
+	 *
+	 * @return    int                        <=0 if OK, 0=Nothing done, >0 if KO
+	 * @throws Exception
 	 */
-	public function validate($user, $notrigger = 0)
+	public function validate(User $user, int $notrigger = 0): int
 	{
 		global $conf, $langs;
 
-		require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+		require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 
 		$error = 0;
 
 		// Protection
-		if ($this->status == self::STATUS_VALIDATED) {
-			dol_syslog(get_class($this)."::validate action abandonned: already validated", LOG_WARNING);
+		if ($this->status === self::STATUS_VALIDATED) {
+			dol_syslog(get_class($this) . '::validate action abandonned: already validated', LOG_WARNING);
 			return 0;
 		}
 
 		/*if (! ((empty($conf->global->MAIN_USE_ADVANCED_PERMS) && ! empty($user->rights->mymodule->myobject->write))
-		 || (! empty($conf->global->MAIN_USE_ADVANCED_PERMS) && ! empty($user->rights->mymodule->myobject->myobject_advance->validate))))
+		 || (! empty($conf->global->MAIN_USE_ADVANCED_PERMS) &&
+			!empty($user->rights->mymodule->myobject->myobject_advance->validate))))
 		 {
 		 $this->error='NotEnoughPermissions';
 		 dol_syslog(get_class($this)."::valid ".$this->error, LOG_ERR);
@@ -569,7 +815,8 @@ class MyObject extends CommonObject
 		$this->db->begin();
 
 		// Define new ref
-		if (!$error && (preg_match('/^[\(]?PROV/i', $this->ref) || empty($this->ref))) { // empty should not happened, but when it occurs, the test save life
+		if (!$error && (preg_match('/^[\(]?PROV/i', $this->ref) || empty($this->ref))) {
+			// empty should not happen, but when it occurs, the test save life
 			$num = $this->getNextNumRef();
 		} else {
 			$num = $this->ref;
@@ -578,18 +825,18 @@ class MyObject extends CommonObject
 
 		if (!empty($num)) {
 			// Validate
-			$sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element;
-			$sql .= " SET ref = '".$this->db->escape($num)."',";
-			$sql .= " status = ".self::STATUS_VALIDATED;
+			$sql = 'UPDATE ' . MAIN_DB_PREFIX . $this->table_element;
+			$sql .= " SET ref = '" . $this->db->escape($num) . "',";
+			$sql .= ' status = ' . self::STATUS_VALIDATED;
 			if (!empty($this->fields['date_validation'])) {
-				$sql .= ", date_validation = '".$this->db->idate($now)."'";
+				$sql .= ", date_validation = '" . $this->db->idate($now) . "'";
 			}
 			if (!empty($this->fields['fk_user_valid'])) {
-				$sql .= ", fk_user_valid = ".((int) $user->id);
+				$sql .= ', fk_user_valid = ' . ($user->id);
 			}
-			$sql .= " WHERE rowid = ".((int) $this->id);
+			$sql .= ' WHERE rowid = ' . ($this->id);
 
-			dol_syslog(get_class($this)."::validate()", LOG_DEBUG);
+			dol_syslog(get_class($this) . '::validate()', LOG_DEBUG);
 			$resql = $this->db->query($sql);
 			if (!$resql) {
 				dol_print_error($this->db);
@@ -607,42 +854,7 @@ class MyObject extends CommonObject
 			}
 		}
 
-		if (!$error) {
-			$this->oldref = $this->ref;
-
-			// Rename directory if dir was a temporary ref
-			if (preg_match('/^[\(]?PROV/i', $this->ref)) {
-				// Now we rename also files into index
-				$sql = 'UPDATE '.MAIN_DB_PREFIX."ecm_files set filename = CONCAT('".$this->db->escape($this->newref)."', SUBSTR(filename, ".(strlen($this->ref) + 1).")), filepath = 'myobject/".$this->db->escape($this->newref)."'";
-				$sql .= " WHERE filename LIKE '".$this->db->escape($this->ref)."%' AND filepath = 'myobject/".$this->db->escape($this->ref)."' and entity = ".$conf->entity;
-				$resql = $this->db->query($sql);
-				if (!$resql) {
-					$error++; $this->error = $this->db->lasterror();
-				}
-
-				// We rename directory ($this->ref = old ref, $num = new ref) in order not to lose the attachments
-				$oldref = dol_sanitizeFileName($this->ref);
-				$newref = dol_sanitizeFileName($num);
-				$dirsource = $conf->mymodule->dir_output.'/myobject/'.$oldref;
-				$dirdest = $conf->mymodule->dir_output.'/myobject/'.$newref;
-				if (!$error && file_exists($dirsource)) {
-					dol_syslog(get_class($this)."::validate() rename dir ".$dirsource." into ".$dirdest);
-
-					if (@rename($dirsource, $dirdest)) {
-						dol_syslog("Rename ok");
-						// Rename docs starting with $oldref with $newref
-						$listoffiles = dol_dir_list($conf->mymodule->dir_output.'/myobject/'.$newref, 'files', 1, '^'.preg_quote($oldref, '/'));
-						foreach ($listoffiles as $fileentry) {
-							$dirsource = $fileentry['name'];
-							$dirdest = preg_replace('/^'.preg_quote($oldref, '/').'/', $newref, $dirsource);
-							$dirsource = $fileentry['path'].'/'.$dirsource;
-							$dirdest = $fileentry['path'].'/'.$dirdest;
-							@rename($dirsource, $dirdest);
-						}
-					}
-				}
-			}
-		}
+		$error = $this->validateUpdateDatabase($error, $conf, $num);
 
 		// Set new ref and current status
 		if (!$error) {
@@ -650,24 +862,85 @@ class MyObject extends CommonObject
 			$this->status = self::STATUS_VALIDATED;
 		}
 
-		if (!$error) {
-			$this->db->commit();
-			return 1;
-		} else {
+		if ($error) {
 			$this->db->rollback();
 			return -1;
 		}
+
+		$this->db->commit();
+		return 1;
 	}
 
+	/**
+	 * @param int    $error
+	 * @param        $conf
+	 * @param string $num
+	 *
+	 * @return int
+	 * @throws Exception
+	 */
+	protected function validateUpdateDatabase(int $error, $conf, string $num): int
+	{
+		if (!$error) {
+			$this->oldref = $this->ref;
+
+			// Rename directory if dir was a temporary ref
+			if (preg_match('/^[\(]?PROV/i', $this->ref)) {
+				// Now we rename also files into index
+				$sql = 'UPDATE ' . MAIN_DB_PREFIX . "ecm_files set filename = CONCAT('" . $this->db->escape(
+						$this->newref
+					) . "',
+						SUBSTR(filename, " . (strlen($this->ref) + 1) . ")), filepath = 'myobject/" . $this->db->escape(
+						$this->newref
+					) . "'";
+				$sql .= " WHERE filename LIKE '" . $this->db->escape($this->ref) . "%'
+						AND filepath = 'myobject/" . $this->db->escape($this->ref) . "' and entity = " . $conf->entity;
+				$resql = $this->db->query($sql);
+				if (!$resql) {
+					$error++;
+					$this->error = $this->db->lasterror();
+				}
+
+				// We rename directory ($this->ref = old ref, $num = new ref) in order not to lose the attachments
+				$oldref = dol_sanitizeFileName($this->ref);
+				$newref = dol_sanitizeFileName($num);
+				$dirsource = $conf->mymodule->dir_output . '/myobject/' . $oldref;
+				$dirdest = $conf->mymodule->dir_output . '/myobject/' . $newref;
+				if (!$error && file_exists($dirsource)) {
+					dol_syslog(get_class($this) . '::validate() rename dir ' . $dirsource . ' into ' . $dirdest);
+
+					if (@rename($dirsource, $dirdest)) {
+						dol_syslog('Rename ok');
+						// Rename docs starting with $oldref with $newref
+						$listoffiles = dol_dir_list(
+							$conf->mymodule->dir_output . '/myobject/' . $newref,
+							'files',
+							1,
+							'^' . preg_quote($oldref, '/')
+						);
+						foreach ($listoffiles as $fileentry) {
+							$dirsource = $fileentry['name'];
+							$dirdest = preg_replace('/^' . preg_quote($oldref, '/') . '/', $newref, $dirsource);
+							$dirsource = $fileentry['path'] . '/' . $dirsource;
+							$dirdest = $fileentry['path'] . '/' . $dirdest;
+							@rename($dirsource, $dirdest);
+						}
+					}
+				}
+			}
+		}
+		return $error;
+	}
 
 	/**
-	 *	Set draft status
+	 *    Set draft status
 	 *
-	 *	@param	User	$user			Object user that modify
-	 *  @param	int		$notrigger		1=Does not execute triggers, 0=Execute triggers
-	 *	@return	int						<0 if KO, >0 if OK
+	 * @param User $user      Object user that modify
+	 * @param int  $notrigger 1=Does not execute triggers, 0=Execute triggers
+	 *
+	 * @return    int                        <0 if KO, >0 if OK
 	 */
-	public function setDraft($user, $notrigger = 0)
+	public function setDraft(User $user, int $notrigger = 0): int
 	{
 		// Protection
 		if ($this->status <= self::STATUS_DRAFT) {
@@ -675,7 +948,8 @@ class MyObject extends CommonObject
 		}
 
 		/*if (! ((empty($conf->global->MAIN_USE_ADVANCED_PERMS) && ! empty($user->rights->mymodule->write))
-		 || (! empty($conf->global->MAIN_USE_ADVANCED_PERMS) && ! empty($user->rights->mymodule->mymodule_advance->validate))))
+		 || (! empty($conf->global->MAIN_USE_ADVANCED_PERMS) &&
+			!empty($user->rights->mymodule->mymodule_advance->validate))))
 		 {
 		 $this->error='Permission denied';
 		 return -1;
@@ -685,21 +959,23 @@ class MyObject extends CommonObject
 	}
 
 	/**
-	 *	Set cancel status
+	 *    Set cancel status
 	 *
-	 *	@param	User	$user			Object user that modify
-	 *  @param	int		$notrigger		1=Does not execute triggers, 0=Execute triggers
-	 *	@return	int						<0 if KO, 0=Nothing done, >0 if OK
+	 * @param User $user      Object user that modify
+	 * @param int  $notrigger 1=Does not execute triggers, 0=Execute triggers
+	 *
+	 * @return    int                        <0 if KO, 0=Nothing done, >0 if OK
 	 */
-	public function cancel($user, $notrigger = 0)
+	public function cancel(User $user, int $notrigger = 0): int
 	{
 		// Protection
-		if ($this->status != self::STATUS_VALIDATED) {
+		if ($this->status !== self::STATUS_VALIDATED) {
 			return 0;
 		}
 
 		/*if (! ((empty($conf->global->MAIN_USE_ADVANCED_PERMS) && ! empty($user->rights->mymodule->write))
-		 || (! empty($conf->global->MAIN_USE_ADVANCED_PERMS) && ! empty($user->rights->mymodule->mymodule_advance->validate))))
+		 || (! empty($conf->global->MAIN_USE_ADVANCED_PERMS) &&
+			!empty($user->rights->mymodule->mymodule_advance->validate))))
 		 {
 		 $this->error='Permission denied';
 		 return -1;
@@ -709,21 +985,23 @@ class MyObject extends CommonObject
 	}
 
 	/**
-	 *	Set back to validated status
+	 *    Set back to validated status
 	 *
-	 *	@param	User	$user			Object user that modify
-	 *  @param	int		$notrigger		1=Does not execute triggers, 0=Execute triggers
-	 *	@return	int						<0 if KO, 0=Nothing done, >0 if OK
+	 * @param User $user      Object user that modify
+	 * @param int  $notrigger 1=Does not execute triggers, 0=Execute triggers
+	 *
+	 * @return    int                        <0 if KO, 0=Nothing done, >0 if OK
 	 */
-	public function reopen($user, $notrigger = 0)
+	public function reopen(User $user, int $notrigger = 0): int
 	{
 		// Protection
-		if ($this->status != self::STATUS_CANCELED) {
+		if ($this->status !== self::STATUS_CANCELED) {
 			return 0;
 		}
 
 		/*if (! ((empty($conf->global->MAIN_USE_ADVANCED_PERMS) && ! empty($user->rights->mymodule->write))
-		 || (! empty($conf->global->MAIN_USE_ADVANCED_PERMS) && ! empty($user->rights->mymodule->mymodule_advance->validate))))
+		 || (! empty($conf->global->MAIN_USE_ADVANCED_PERMS) &&
+			!empty($user->rights->mymodule->mymodule_advance->validate))))
 		 {
 		 $this->error='Permission denied';
 		 return -1;
@@ -735,15 +1013,22 @@ class MyObject extends CommonObject
 	/**
 	 *  Return a link to the object card (with optionaly the picto)
 	 *
-	 *  @param  int     $withpicto                  Include picto in link (0=No picto, 1=Include picto into link, 2=Only picto)
-	 *  @param  string  $option                     On what the link point to ('nolink', ...)
-	 *  @param  int     $notooltip                  1=Disable tooltip
-	 *  @param  string  $morecss                    Add more css on link
-	 *  @param  int     $save_lastsearch_value      -1=Auto, 0=No save of lastsearch_values when clicking, 1=Save lastsearch_values whenclicking
-	 *  @return	string                              String with URL
+	 * @param int    $withpicto             Include picto in link (0=No picto, 1=Include picto into link, 2=Only picto)
+	 * @param string $option                On what the link point to ('nolink', ...)
+	 * @param int    $notooltip             1=Disable tooltip
+	 * @param string $morecss               Add more css on link
+	 * @param int    $save_lastsearch_value -1=Auto, 0=No save of lastsearch_values when clicking,
+	 *                                      1=Save lastsearch_values whenclicking
+	 *
+	 * @return    string                              String with URL
 	 */
-	public function getNomUrl($withpicto = 0, $option = '', $notooltip = 0, $morecss = '', $save_lastsearch_value = -1)
-	{
+	public function getNomUrl(
+		int $withpicto = 0,
+		string $option = '',
+		int $notooltip = 0,
+		string $morecss = '',
+		int $save_lastsearch_value = -1
+	): string {
 		global $conf, $langs, $hookmanager;
 
 		if (!empty($conf->dol_no_mouse_hover)) {
@@ -752,7 +1037,7 @@ class MyObject extends CommonObject
 
 		$result = '';
 
-		$label = img_picto('', $this->picto).' <u>'.$langs->trans("MyObject").'</u>';
+		$label = img_picto('', $this->picto) . ' <u>' . $langs->trans('MyObject') . '</u>';
 		if (isset($this->status)) {
 			$label .= ' '.$this->getLibStatut(5);
 		}
@@ -761,10 +1046,10 @@ class MyObject extends CommonObject
 
 		$url = dol_buildpath('/mymodule/myobject_card.php', 1).'?id='.$this->id;
 
-		if ($option != 'nolink') {
+		if ($option !== 'nolink') {
 			// Add param to save lastsearch_values or not
-			$add_save_lastsearch_values = ($save_lastsearch_value == 1 ? 1 : 0);
-			if ($save_lastsearch_value == -1 && preg_match('/list\.php/', $_SERVER["PHP_SELF"])) {
+			$add_save_lastsearch_values = ($save_lastsearch_value === 1 ? 1 : 0);
+			if ($save_lastsearch_value === -1 && preg_match('/list\.php/', $_SERVER['PHP_SELF'])) {
 				$add_save_lastsearch_values = 1;
 			}
 			if ($add_save_lastsearch_values) {
@@ -775,8 +1060,8 @@ class MyObject extends CommonObject
 		$linkclose = '';
 		if (empty($notooltip)) {
 			if (!empty($conf->global->MAIN_OPTIMIZEFORTEXTBROWSER)) {
-				$label = $langs->trans("ShowMyObject");
-				$linkclose .= ' alt="'.dol_escape_htmltag($label, 1).'"';
+				$label = $langs->trans('ShowMyObject');
+				$linkclose .= ' alt="' . dol_escape_htmltag($label, 1) . '"';
 			}
 			$linkclose .= ' title="'.dol_escape_htmltag($label, 1).'"';
 			$linkclose .= ' class="classfortooltip'.($morecss ? ' '.$morecss : '').'"';
@@ -784,60 +1069,25 @@ class MyObject extends CommonObject
 			$linkclose = ($morecss ? ' class="'.$morecss.'"' : '');
 		}
 
-		if ($option == 'nolink') {
+		if ($option === 'nolink') {
 			$linkstart = '<span';
 		} else {
-			$linkstart = '<a href="'.$url.'"';
+			$linkstart = '<a href="' . $url . '"';
 		}
-		$linkstart .= $linkclose.'>';
-		if ($option == 'nolink') {
+		$linkstart .= $linkclose . '>';
+		if ($option === 'nolink') {
 			$linkend = '</span>';
 		} else {
 			$linkend = '</a>';
 		}
 
-		$result .= $linkstart;
-
-		if (empty($this->showphoto_on_popup)) {
-			if ($withpicto) {
-				$result .= img_object(($notooltip ? '' : $label), ($this->picto ? $this->picto : 'generic'), ($notooltip ? (($withpicto != 2) ? 'class="paddingright"' : '') : 'class="'.(($withpicto != 2) ? 'paddingright ' : '').'classfortooltip"'), 0, 0, $notooltip ? 0 : 1);
-			}
-		} else {
-			if ($withpicto) {
-				require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
-
-				list($class, $module) = explode('@', $this->picto);
-				$upload_dir = $conf->$module->multidir_output[$conf->entity]."/$class/".dol_sanitizeFileName($this->ref);
-				$filearray = dol_dir_list($upload_dir, "files");
-				$filename = $filearray[0]['name'];
-				if (!empty($filename)) {
-					$pospoint = strpos($filearray[0]['name'], '.');
-
-					$pathtophoto = $class.'/'.$this->ref.'/thumbs/'.substr($filename, 0, $pospoint).'_mini'.substr($filename, $pospoint);
-					if (empty($conf->global->{strtoupper($module.'_'.$class).'_FORMATLISTPHOTOSASUSERS'})) {
-						$result .= '<div class="floatleft inline-block valignmiddle divphotoref"><div class="photoref"><img class="photo'.$module.'" alt="No photo" border="0" src="'.DOL_URL_ROOT.'/viewimage.php?modulepart='.$module.'&entity='.$conf->entity.'&file='.urlencode($pathtophoto).'"></div></div>';
-					} else {
-						$result .= '<div class="floatleft inline-block valignmiddle divphotoref"><img class="photouserphoto userphoto" alt="No photo" border="0" src="'.DOL_URL_ROOT.'/viewimage.php?modulepart='.$module.'&entity='.$conf->entity.'&file='.urlencode($pathtophoto).'"></div>';
-					}
-
-					$result .= '</div>';
-				} else {
-					$result .= img_object(($notooltip ? '' : $label), ($this->picto ? $this->picto : 'generic'), ($notooltip ? (($withpicto != 2) ? 'class="paddingright"' : '') : 'class="'.(($withpicto != 2) ? 'paddingright ' : '').'classfortooltip"'), 0, 0, $notooltip ? 0 : 1);
-				}
-			}
-		}
-
-		if ($withpicto != 2) {
-			$result .= $this->ref;
-		}
-
-		$result .= $linkend;
-		//if ($withpicto != 2) $result.=(($addlabel && $this->label) ? $sep . dol_trunc($this->label, ($addlabel > 1 ? $addlabel : 0)) : '');
+		$result = $this->getNomUrlLink($linkstart, $result, $withpicto, $notooltip, $label, $conf, $linkend);
 
 		global $action, $hookmanager;
-		$hookmanager->initHooks(array('myobjectdao'));
-		$parameters = array('id'=>$this->id, 'getnomurl'=>$result);
-		$reshook = $hookmanager->executeHooks('getNomUrl', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+		$hookmanager->initHooks(['myobjectdao']);
+		$parameters = ['id' => $this->id, 'getnomurl' => $result];
+		$reshook = $hookmanager->executeHooks('getNomUrl', $parameters, $this, $action);
+		// Note that $action and $object may have been modified by some hooks
 		if ($reshook > 0) {
 			$result = $hookmanager->resPrint;
 		} else {
@@ -848,12 +1098,101 @@ class MyObject extends CommonObject
 	}
 
 	/**
+	 * @param string $linkstart
+	 * @param string $result
+	 * @param int    $withpicto
+	 * @param int    $notooltip
+	 * @param        $label
+	 * @param        $conf
+	 * @param string $linkend
+	 *
+	 * @return string
+	 */
+	protected function getNomUrlLink(
+		string $linkstart,
+		string $result,
+		int $withpicto,
+		int $notooltip,
+		$label,
+		$conf,
+		string $linkend
+	): string {
+		$result .= $linkstart;
+
+		if (empty($this->showphoto_on_popup)) {
+			if ($withpicto) {
+				$result .= img_object(
+					($notooltip ? '' : $label),
+					($this->picto ?: 'generic'),
+					($notooltip ? (
+					($withpicto !== 2) ? 'class="paddingright"' : '') : 'class="' . (($withpicto !== 2) ? 'paddingright ' : '') . 'classfortooltip"'),
+					0,
+					0,
+					$notooltip ? 0 : 1
+				);
+			}
+		} elseif ($withpicto) {
+			require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+
+			[$class, $module] = explode('@', $this->picto);
+			$upload_dir = $conf->$module->multidir_output[$conf->entity] . "/$class/" . dol_sanitizeFileName(
+					$this->ref
+				);
+			$filearray = dol_dir_list($upload_dir, 'files');
+			$filename = $filearray[0]['name'];
+			if (!empty($filename)) {
+				$pospoint = strpos($filearray[0]['name'], '.');
+
+				$pathtophoto = $class . '/' . $this->ref . '/thumbs/' . substr(
+						$filename,
+						0,
+						$pospoint
+					) . '_mini' . substr($filename, $pospoint);
+				if (empty($conf->global->{strtoupper($module . '_' . $class) . '_FORMATLISTPHOTOSASUSERS'})) {
+					$result .= '<div class="floatleft inline-block valignmiddle divphotoref">
+									<div class="photoref">
+									<img class="photo' . $module . '" alt="No photo"
+									src="' . DOL_URL_ROOT . '/viewimage.php?modulepart=' . $module . '
+									&entity=' . $conf->entity . '&file=' . urlencode($pathtophoto) . '"></div></div>';
+				} else {
+					$result .= '<div class="floatleft inline-block valignmiddle divphotoref">
+									<img class="photouserphoto userphoto" alt="No photo"
+									src="' . DOL_URL_ROOT . '/viewimage.php?modulepart=' . $module . '
+									&entity=' . $conf->entity . '&file=' . urlencode($pathtophoto) . '"></div>';
+				}
+
+				$result .= '</div>';
+			} else {
+				$result .= img_object(
+					($notooltip ? '' : $label),
+					($this->picto ?: 'generic'),
+					($notooltip ? (
+					($withpicto !== 2) ? 'class="paddingright"' : '') : 'class="' . (($withpicto !== 2) ? 'paddingright ' : '') . 'classfortooltip"'),
+					0,
+					0,
+					$notooltip ? 0 : 1
+				);
+			}
+		}
+
+		if ($withpicto !== 2) {
+			$result .= $this->ref;
+		}
+
+		$result .= $linkend;
+		return $result;
+		//if ($withpicto != 2) $result.=(($addlabel && $this->label) ? $sep . dol_trunc($this->label, ($addlabel > 1 ? $addlabel : 0)) : '');
+	}
+
+	/**
 	 *  Return the label of the status
 	 *
-	 *  @param  int		$mode          0=long label, 1=short label, 2=Picto + short label, 3=Picto, 4=Picto + long label, 5=Short label + Picto, 6=Long label + Picto
-	 *  @return	string 			       Label of status
+	 * @param int $mode 0=long label, 1=short label, 2=Picto + short label,
+	 *                  3=Picto, 4=Picto + long label, 5=Short label + Picto, 6=Long label + Picto
+	 *
+	 * @return    string                   Label of status
 	 */
-	public function getLabelStatus($mode = 0)
+	public function getLabelStatus(int $mode = 0): string
 	{
 		return $this->LibStatut($this->status, $mode);
 	}
@@ -861,23 +1200,28 @@ class MyObject extends CommonObject
 	/**
 	 *  Return the label of the status
 	 *
-	 *  @param  int		$mode          0=long label, 1=short label, 2=Picto + short label, 3=Picto, 4=Picto + long label, 5=Short label + Picto, 6=Long label + Picto
-	 *  @return	string 			       Label of status
+	 * @param int $mode 0=long label, 1=short label, 2=Picto + short label,
+	 *                  3=Picto, 4=Picto + long label, 5=Short label + Picto, 6=Long label + Picto
+	 *
+	 * @return    string                   Label of status
 	 */
-	public function getLibStatut($mode = 0)
+	public function getLibStatut(int $mode = 0): string
 	{
 		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+
 	/**
 	 *  Return the status
 	 *
-	 *  @param	int		$status        Id status
-	 *  @param  int		$mode          0=long label, 1=short label, 2=Picto + short label, 3=Picto, 4=Picto + long label, 5=Short label + Picto, 6=Long label + Picto
-	 *  @return string 			       Label of status
+	 * @param int $status Id status
+	 * @param int $mode   0=long label, 1=short label, 2=Picto + short label,
+	 *                    3=Picto, 4=Picto + long label, 5=Short label + Picto, 6=Long label + Picto
+	 *
+	 * @return string                   Label of status
 	 */
-	public function LibStatut($status, $mode = 0)
+	public function LibStatut(int $status, int $mode = 0): string
 	{
 		// phpcs:enable
 		if (empty($this->labelStatus) || empty($this->labelStatusShort)) {
@@ -893,7 +1237,7 @@ class MyObject extends CommonObject
 
 		$statusType = 'status'.$status;
 		//if ($status == self::STATUS_VALIDATED) $statusType = 'status1';
-		if ($status == self::STATUS_CANCELED) {
+		if ($status === self::STATUS_CANCELED) {
 			$statusType = 'status6';
 		}
 
@@ -901,17 +1245,18 @@ class MyObject extends CommonObject
 	}
 
 	/**
-	 *	Load the info information in the object
+	 *    Load the info information in the object
 	 *
-	 *	@param  int		$id       Id of object
-	 *	@return	void
+	 * @param int $id ID of object
+	 *
+	 * @return    void
 	 */
-	public function info($id)
+	public function info(int $id): void
 	{
-		$sql = "SELECT rowid, date_creation as datec, tms as datem,";
-		$sql .= " fk_user_creat, fk_user_modif";
-		$sql .= " FROM ".MAIN_DB_PREFIX.$this->table_element." as t";
-		$sql .= " WHERE t.rowid = ".((int) $id);
+		$sql = 'SELECT rowid, date_creation as datec, tms as datem,';
+		$sql .= ' fk_user_creat, fk_user_modif';
+		$sql .= ' FROM ' . MAIN_DB_PREFIX . $this->table_element . ' as t';
+		$sql .= ' WHERE t.rowid = ' . ($id);
 
 		$result = $this->db->query($sql);
 		if ($result) {
@@ -949,11 +1294,11 @@ class MyObject extends CommonObject
 
 	/**
 	 * Initialise object with example values
-	 * Id must be 0 if object instance is a specimen
+	 * ID must be 0 if object instance is a specimen
 	 *
 	 * @return void
 	 */
-	public function initAsSpecimen()
+	public function initAsSpecimen(): void
 	{
 		// Set here init that are not commonf fields
 		// $this->property1 = ...
@@ -969,30 +1314,29 @@ class MyObject extends CommonObject
 	 */
 	public function getLinesArray()
 	{
-		$this->lines = array();
+		$this->lines = [];
 
 		$objectline = new MyObjectLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, array('customsql'=>'fk_myobject = '.((int) $this->id)));
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['customsql' => 'fk_myobject = ' . ($this->id)]);
 
 		if (is_numeric($result)) {
-			$this->error = $this->error;
 			$this->errors = $this->errors;
 			return $result;
-		} else {
-			$this->lines = $result;
-			return $this->lines;
 		}
+
+		$this->lines = $result;
+		return $this->lines;
 	}
 
 	/**
-	 *  Returns the reference to the following non used object depending on the active numbering module.
+	 *  Returns the reference to the following non-used object depending on the active numbering module.
 	 *
-	 *  @return string      		Object free reference
+	 * @return string            Object free reference
 	 */
-	public function getNextNumRef()
+	public function getNextNumRef(): string
 	{
 		global $langs, $conf;
-		$langs->load("mymodule@mymodule");
+		$langs->load('mymodule@mymodule');
 
 		if (empty($conf->global->MYMODULE_MYOBJECT_ADDON)) {
 			$conf->global->MYMODULE_MYOBJECT_ADDON = 'mod_myobject_standard';
@@ -1001,20 +1345,20 @@ class MyObject extends CommonObject
 		if (!empty($conf->global->MYMODULE_MYOBJECT_ADDON)) {
 			$mybool = false;
 
-			$file = $conf->global->MYMODULE_MYOBJECT_ADDON.".php";
+			$file = $conf->global->MYMODULE_MYOBJECT_ADDON . '.php';
 			$classname = $conf->global->MYMODULE_MYOBJECT_ADDON;
 
 			// Include file with class
-			$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
+			$dirmodels = array_merge(['/'], $conf->modules_parts['models']);
 			foreach ($dirmodels as $reldir) {
-				$dir = dol_buildpath($reldir."core/modules/mymodule/");
+				$dir = dol_buildpath($reldir . 'core/modules/mymodule/');
 
 				// Load file with numbering class (if found)
 				$mybool |= @include_once $dir.$file;
 			}
 
 			if ($mybool === false) {
-				dol_print_error('', "Failed to include file ".$file);
+				dol_print_error('', 'Failed to include file ' . $file);
 				return '';
 			}
 
@@ -1022,42 +1366,46 @@ class MyObject extends CommonObject
 				$obj = new $classname();
 				$numref = $obj->getNextValue($this);
 
-				if ($numref != '' && $numref != '-1') {
+				if ($numref !== '' && $numref !== '-1') {
 					return $numref;
-				} else {
-					$this->error = $obj->error;
-					//dol_print_error($this->db,get_class($this)."::getNextNumRef ".$obj->error);
-					return "";
 				}
+
+				$this->error = $obj->error;
+				dol_print_error($this->db, get_class($this) . '::getNextNumRef ' . $obj->error);
 			} else {
-				print $langs->trans("Error")." ".$langs->trans("ClassNotFound").' '.$classname;
-				return "";
+				print $langs->trans('Error') . ' ' . $langs->trans('ClassNotFound') . ' ' . $classname;
 			}
 		} else {
-			print $langs->trans("ErrorNumberingModuleNotSetup", $this->element);
-			return "";
+			print $langs->trans('ErrorNumberingModuleNotSetup', $this->element);
 		}
 	}
 
 	/**
 	 *  Create a document onto disk according to template module.
 	 *
-	 *  @param	    string		$modele			Force template to use ('' to not force)
-	 *  @param		Translate	$outputlangs	objet lang a utiliser pour traduction
-	 *  @param      int			$hidedetails    Hide details of lines
-	 *  @param      int			$hidedesc       Hide description
-	 *  @param      int			$hideref        Hide ref
-	 *  @param      null|array  $moreparams     Array to provide more information
-	 *  @return     int         				0 if KO, 1 if OK
+	 * @param string     $modele      Force template to use ('' to not force)
+	 * @param Translate  $outputlangs objet lang a utiliser pour traduction
+	 * @param int        $hidedetails Hide details of lines
+	 * @param int        $hidedesc    Hide description
+	 * @param int        $hideref     Hide ref
+	 * @param array|null $moreparams  Array to provide more information
+	 *
+	 * @return     int                        0 if KO, 1 if OK
 	 */
-	public function generateDocument($modele, $outputlangs, $hidedetails = 0, $hidedesc = 0, $hideref = 0, $moreparams = null)
-	{
+	public function generateDocument(
+		string $modele,
+		Translate $outputlangs,
+		int $hidedetails = 0,
+		int $hidedesc = 0,
+		int $hideref = 0,
+		array $moreparams = null
+	): int {
 		global $conf, $langs;
 
 		$result = 0;
 		$includedocgeneration = 0;
 
-		$langs->load("mymodule@mymodule");
+		$langs->load('mymodule@mymodule');
 
 		if (!dol_strlen($modele)) {
 			$modele = 'standard_myobject';
@@ -1069,10 +1417,18 @@ class MyObject extends CommonObject
 			}
 		}
 
-		$modelpath = "core/modules/mymodule/doc/";
+		$modelpath = 'core/modules/mymodule/doc/';
 
 		if ($includedocgeneration && !empty($modele)) {
-			$result = $this->commonGenerateDocument($modelpath, $modele, $outputlangs, $hidedetails, $hidedesc, $hideref, $moreparams);
+			$result = $this->commonGenerateDocument(
+				$modelpath,
+				$modele,
+				$outputlangs,
+				$hidedetails,
+				$hidedesc,
+				$hideref,
+				$moreparams
+			);
 		}
 
 		return $result;
@@ -1083,9 +1439,10 @@ class MyObject extends CommonObject
 	 * CAN BE A CRON TASK. In such a case, parameters come from the schedule job setup field 'Parameters'
 	 * Use public function doScheduledJob($param1, $param2, ...) to get parameters
 	 *
-	 * @return	int			0 if OK, <>0 if KO (this function is used also by cron so only 0 is OK)
+	 * @return    int            0 if OK, <>0 if KO (this function is used also by cron so only 0 is OK)
+	 * @throws Exception
 	 */
-	public function doScheduledJob()
+	public function doScheduledJob(): int
 	{
 		global $conf, $langs;
 
@@ -1123,7 +1480,7 @@ class MyObjectLine extends CommonObjectLine
 	/**
 	 * @var int  Does object support extrafields ? 0=No, 1=Yes
 	 */
-	public $isextrafieldmanaged = 0;
+	public int $isextrafieldmanaged = 0;
 
 	/**
 	 * Constructor

--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -576,9 +576,9 @@ class MyObject extends CommonObject
 	}
 
 	/**
-	 * @param MyObject $object
-	 * @param          $langs
-	 * @param          $extrafields
+	 * @param MyObject	$object			Object created
+	 * @param mixed 	$langs			Define Languages used
+	 * @param mixed		$extrafields	Define extrafields
 	 */
 	protected function createFromCloneClearFields(MyObject $object, $langs, $extrafields): void
 	{
@@ -872,9 +872,9 @@ class MyObject extends CommonObject
 	}
 
 	/**
-	 * @param int    $error
-	 * @param        $conf
-	 * @param string $num
+	 * @param int    $error Error message
+	 * @param mixed  $conf  Global config
+	 * @param string $num	Number of returned rows
 	 *
 	 * @return int
 	 * @throws Exception
@@ -1098,13 +1098,13 @@ class MyObject extends CommonObject
 	}
 
 	/**
-	 * @param string $linkstart
-	 * @param string $result
-	 * @param int    $withpicto
-	 * @param int    $notooltip
-	 * @param        $label
-	 * @param        $conf
-	 * @param string $linkend
+	 * @param string $linkstart Start of link builder
+	 * @param string $result    Query result
+	 * @param int    $withpicto Use picto or not
+	 * @param int    $notooltip Use tooltip
+	 * @param string $label     Label of object
+	 * @param mixed  $conf      Global config
+	 * @param string $linkend   End of link builder
 	 *
 	 * @return string
 	 */
@@ -1113,7 +1113,7 @@ class MyObject extends CommonObject
 		string $result,
 		int $withpicto,
 		int $notooltip,
-		$label,
+		string $label,
 		$conf,
 		string $linkend
 	): string {

--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -579,6 +579,8 @@ class MyObject extends CommonObject
 	 * @param MyObject	$object			Object created
 	 * @param mixed 	$langs			Define Languages used
 	 * @param mixed		$extrafields	Define extrafields
+	 *
+	 * @return void
 	 */
 	protected function createFromCloneClearFields(MyObject $object, $langs, $extrafields): void
 	{

--- a/htdocs/modulebuilder/template/core/boxes/mymodulewidget1.php
+++ b/htdocs/modulebuilder/template/core/boxes/mymodulewidget1.php
@@ -25,7 +25,9 @@
  * Put detailed description here.
  */
 
-include_once DOL_DOCUMENT_ROOT."/core/boxes/modules_boxes.php";
+declare(strict_types=1);
+
+include_once DOL_DOCUMENT_ROOT . '/core/boxes/modules_boxes.php';
 
 
 /**
@@ -39,13 +41,13 @@ class mymodulewidget1 extends ModeleBoxes
 	/**
 	 * @var string Alphanumeric ID. Populated by the constructor.
 	 */
-	public $boxcode = "mymodulebox";
+	public string $boxcode = 'mymodulebox';
 
 	/**
 	 * @var string Box icon (in configuration page)
 	 * Automatically calls the icon named with the corresponding "object_" prefix
 	 */
-	public $boximg = "mymodule@mymodule";
+	public string $boximg = 'mymodule@mymodule';
 
 	/**
 	 * @var string Box label (in configuration page)
@@ -55,12 +57,12 @@ class mymodulewidget1 extends ModeleBoxes
 	/**
 	 * @var string[] Module dependencies
 	 */
-	public $depends = array('mymodule');
+	public array $depends = ['mymodule'];
 
 	/**
 	 * @var DoliDb Database handler
 	 */
-	public $db;
+	public DoliDB $db;
 
 	/**
 	 * @var mixed More parameters
@@ -68,19 +70,19 @@ class mymodulewidget1 extends ModeleBoxes
 	public $param;
 
 	/**
-	 * @var array Header informations. Usually created at runtime by loadBox().
+	 * @var array Header information. Usually created at runtime by loadBox().
 	 */
-	public $info_box_head = array();
+	public array $info_box_head = [];
 
 	/**
-	 * @var array Contents informations. Usually created at runtime by loadBox().
+	 * @var array Contents information. Usually created at runtime by loadBox().
 	 */
-	public $info_box_contents = array();
+	public array $info_box_contents = [];
 
 	/**
 	 * @var string 	Widget type ('graph' means the widget is a graph widget)
 	 */
-	public $widgettype = 'graph';
+	public string $widgettype = 'graph';
 
 
 	/**
@@ -92,26 +94,29 @@ class mymodulewidget1 extends ModeleBoxes
 	public function __construct(DoliDB $db, $param = '')
 	{
 		global $user, $conf, $langs;
-		$langs->load("boxes");
+		$langs->load('boxes');
 		$langs->load('mymodule@mymodule');
 
 		parent::__construct($db, $param);
 
-		$this->boxlabel = $langs->transnoentitiesnoconv("MyWidget");
+		$this->boxlabel = $langs->transnoentitiesnoconv('MyWidget');
 
 		$this->param = $param;
 
-		//$this->enabled = $conf->global->FEATURES_LEVEL > 0;         // Condition when module is enabled or not
-		//$this->hidden = ! ($user->rights->mymodule->myobject->read);   // Condition when module is visible by user (test on permission)
+		//$this->enabled = $conf->global->FEATURES_LEVEL > 0;
+		// Condition when module is enabled or not
+		//$this->hidden = ! ($user->rights->mymodule->myobject->read);
+		// Condition when module is visible by user (test on permission)
 	}
 
 	/**
 	 * Load data into info_box_contents array to show array later. Called by Dolibarr before displaying the box.
 	 *
 	 * @param int $max Maximum number of records to load
+	 *
 	 * @return void
 	 */
-	public function loadBox($max = 5)
+	public function loadBox(int $max = 5): void
 	{
 		global $langs;
 
@@ -121,8 +126,8 @@ class mymodulewidget1 extends ModeleBoxes
 		//dol_include_once("/mymodule/class/mymodule.class.php");
 
 		// Populate the head at runtime
-		$text = $langs->trans("MyModuleBoxDescription", $max);
-		$this->info_box_head = array(
+		$text = $langs->trans('MyModuleBoxDescription', $max);
+		$this->info_box_head = [
 			// Title text
 			'text' => $text,
 			// Add a link
@@ -139,12 +144,12 @@ class mymodulewidget1 extends ModeleBoxes
 			'limit' => 0,
 			// Adds translated " (Graph)" to a hidden form value's input (?)
 			'graph' => false
-		);
+		];
 
 		// Populate the contents at runtime
-		$this->info_box_contents = array(
-			0 => array( // First line
-				0 => array( // First Column
+		$this->info_box_contents = [
+			0 => [ // First line
+				0 => [ // First Column
 					//  HTML properties of the TR element. Only available on the first column.
 					'tr' => 'class="left"',
 					// HTML properties of the TD element
@@ -156,7 +161,8 @@ class mymodulewidget1 extends ModeleBoxes
 					'url' => 'http://example.com',
 					// Link's target HTML property
 					'target' => '_blank',
-					// Fist line logo (deprecated. Include instead logo html code into text or text2, and set asis property to true to avoid HTML cleaning)
+					// Fist line logo (deprecated. Include instead logo html code into text or text2,
+					// and set asis property to true to avoid HTML cleaning)
 					//'logo' => 'monmodule@monmodule',
 					// Unformatted text, added after text. Usefull to add/load javascript code
 					'textnoformat' => '',
@@ -170,34 +176,34 @@ class mymodulewidget1 extends ModeleBoxes
 					'asis' => false,
 					// Same for 'text2'
 					'asis2' => true
-				),
-				1 => array( // Another column
+				],
+				1 => [ // Another column
 					// No TR for n≠0
 					'td' => '',
 					'text' => 'Second cell',
-				)
-			),
-			1 => array( // Another line
-				0 => array( // TR
+				]
+			],
+			1 => [ // Another line
+				0 => [ // TR
 					'tr' => 'class="left"',
 					'text' => 'Another line'
-				),
-				1 => array( // TR
+				],
+				1 => [ // TR
 					'tr' => 'class="left"',
 					'text' => ''
-				)
-			),
-			2 => array( // Another line
-				0 => array( // TR
+				]
+			],
+			2 => [ // Another line
+				0 => [ // TR
 					'tr' => 'class="left"',
 					'text' => ''
-				),
-				1 => array( // TR
+				],
+				1 => [ // TR
 					'tr' => 'class="left"',
 					'text' => ''
-				)
-			),
-		);
+				]
+			],
+		];
 	}
 
 	/**
@@ -208,7 +214,7 @@ class mymodulewidget1 extends ModeleBoxes
 	 * @param int   $nooutput   No print, only return string
 	 * @return string
 	 */
-	public function showBox($head = null, $contents = null, $nooutput = 0)
+	public function showBox($head = null, $contents = null, $nooutput = 0): string
 	{
 		// You may make your own code here…
 		// … or use the parent's class function using the provided head and contents templates

--- a/htdocs/modulebuilder/template/core/modules/mailings/mailinglist_mymodule_myobject.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mailings/mailinglist_mymodule_myobject.modules.php
@@ -8,8 +8,10 @@
  * Code that need to be changed in this file are marked by "CHANGE THIS" tag.
  */
 
-include_once DOL_DOCUMENT_ROOT.'/core/modules/mailings/modules_mailings.php';
-dol_include_once("/mymodule/class/myobject.class.php");
+declare(strict_types=1);
+
+include_once DOL_DOCUMENT_ROOT . '/core/modules/mailings/modules_mailings.php';
+dol_include_once('/mymodule/class/myobject.class.php');
 
 
 /**
@@ -18,24 +20,24 @@ dol_include_once("/mymodule/class/myobject.class.php");
 class mailing_mailinglist_mymodule_myobject extends MailingTargets
 {
 	// CHANGE THIS: Put here a name not already used
-	public $name = 'mailinglist_mymodule_myobject';
+	public string $name = 'mailinglist_mymodule_myobject';
 	// CHANGE THIS: Put here a description of your selector module
-	public $desc = 'My object emailing target selector';
+	public string $desc = 'My object emailing target selector';
 	// CHANGE THIS: Set to 1 if selector is available for admin users only
-	public $require_admin = 0;
+	public int $require_admin = 0;
 
-	public $enabled = 0;
-	public $require_module = array();
+	public int $enabled = 0;
+	public array $require_module = [];
 
 	/**
 	 * @var string String with name of icon for myobject. Must be the part after the 'object_' into object_myobject.png
 	 */
-	public $picto = 'mymodule@mymodule';
+	public string $picto = 'mymodule@mymodule';
 
 	/**
 	 * @var DoliDB Database handler.
 	 */
-	public $db;
+	public DoliDB $db;
 
 
 	/**
@@ -49,7 +51,7 @@ class mailing_mailinglist_mymodule_myobject extends MailingTargets
 
 		$this->db = $db;
 		if (is_array($conf->modules)) {
-			$this->enabled = in_array('mymodule', $conf->modules) ? 1 : 0;
+			$this->enabled = in_array('mymodule', $conf->modules, true) ? 1 : 0;
 		}
 	}
 
@@ -59,21 +61,20 @@ class mailing_mailinglist_mymodule_myobject extends MailingTargets
 	 *
 	 *  @return     string      Retourne zone select
 	 */
-	public function formFilter()
+	public function formFilter(): string
 	{
 		global $langs;
-		$langs->load("members");
+		$langs->load('members');
 
 		$form = new Form($this->db);
 
-		$arraystatus = array(1=>'Option 1', 2=>'Option 2');
+		$arraystatus = [1 => 'Option 1', 2 => 'Option 2'];
 
-		$s = '';
-		$s .= $langs->trans("Status").': ';
+		$s = $langs->trans('Status') . ': ';
 		$s .= '<select name="filter" class="flat">';
 		$s .= '<option value="none">&nbsp;</option>';
 		foreach ($arraystatus as $status) {
-			$s .= '<option value="'.$status.'">'.$status.'</option>';
+			$s .= '<option value="' . $status . '">' . $status . '</option>';
 		}
 		$s .= '</select>';
 		$s .= '<br>';
@@ -85,35 +86,42 @@ class mailing_mailinglist_mymodule_myobject extends MailingTargets
 	/**
 	 *  Renvoie url lien vers fiche de la source du destinataire du mailing
 	 *
-	 *  @param      int         $id     ID
-	 *  @return     string              Url lien
+	 * @param int $id ID
+	 *
+	 * @return     string              Url lien
 	 */
-	public function url($id)
+	public function url(int $id): string
 	{
-		return '<a href="'.dol_buildpath('/mymodule/myobject_card.php', 1).'?id='.$id.'">'.img_object('', "generic").'</a>';
+		return '<a href="' . dol_buildpath('/mymodule/myobject_card.php', 1) . '?id=' . $id . '">' . img_object(
+				'',
+				'generic'
+			) . '</a>';
 	}
 
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+
 	/**
 	 *  This is the main function that returns the array of emails
 	 *
-	 *  @param  int     $mailing_id     Id of emailing
-	 *  @return int                     <0 if error, number of emails added if ok
+	 * @param int $mailing_id ID of emailing
+	 *
+	 * @return int                     <0 if error, number of emails added if ok
+	 * @throws Exception
 	 */
-	public function add_to_target($mailing_id)
+	public function add_to_target(int $mailing_id): int
 	{
 		// phpcs:enable
-		$target = array();
+		$target = [];
 		$j = 0;
 
-		$sql = " select rowid as id, email, firstname, lastname, plan, partner";
-		$sql .= " from ".MAIN_DB_PREFIX."myobject";
+		$sql = ' select rowid as id, email, firstname, lastname, plan, partner';
+		$sql .= ' from ' . MAIN_DB_PREFIX . 'myobject';
 		$sql .= " where email IS NOT NULL AND email != ''";
-		if (GETPOSTISSET('filter') && GETPOST('filter', 'alphanohtml') != 'none') {
-			$sql .= " AND status = '".$this->db->escape(GETPOST('filter', 'alphanohtml'))."'";
+		if (GETPOSTISSET('filter') && GETPOST('filter') !== 'none') {
+			$sql .= " AND status = '" . $this->db->escape(GETPOST('filter')) . "'";
 		}
-		$sql .= " ORDER BY email";
+		$sql .= ' ORDER BY email';
 
 		// Stocke destinataires dans target
 		$result = $this->db->query($sql);
@@ -121,13 +129,13 @@ class mailing_mailinglist_mymodule_myobject extends MailingTargets
 			$num = $this->db->num_rows($result);
 			$i = 0;
 
-			dol_syslog("mailinglist_mymodule_myobject.modules.php: mailing ".$num." targets found");
+			dol_syslog('mailinglist_mymodule_myobject.modules.php: mailing ' .$num. ' targets found');
 
 			$old = '';
 			while ($i < $num) {
 				$obj = $this->db->fetch_object($result);
-				if ($old <> $obj->email) {
-					$target[$j] = array(
+				if ($old !== $obj->email) {
+					$target[$j] = [
 						'email' => $obj->email,
 						'name' => $obj->lastname,
 						'id' => $obj->id,
@@ -136,7 +144,7 @@ class mailing_mailinglist_mymodule_myobject extends MailingTargets
 						'source_url' => $this->url($obj->id),
 						'source_id' => $obj->id,
 						'source_type' => 'dolicloud'
-					);
+					];
 					$old = $obj->email;
 					$j++;
 				}
@@ -170,14 +178,14 @@ class mailing_mailinglist_mymodule_myobject extends MailingTargets
 	 *
 	 *  @return array
 	 */
-	public function getSqlArrayForStats()
+	public function getSqlArrayForStats(): array
 	{
 		// CHANGE THIS: Optionnal
 
 		//var $statssql=array();
 		//$this->statssql[0]="SELECT field1 as label, count(distinct(email)) as nb FROM mytable WHERE email IS NOT NULL";
 
-		return array();
+		return [];
 	}
 
 
@@ -186,13 +194,17 @@ class mailing_mailinglist_mymodule_myobject extends MailingTargets
 	 *  For example if this selector is used to extract 500 different
 	 *  emails from a text file, this function must return 500.
 	 *
-	 *  @param  string  $filter     Filter
-	 *  @param  string	$option     Options
-	 *  @return int                 Nb of recipients or -1 if KO
+	 * @param string $filter Filter
+	 * @param string $option Options
+	 *
+	 * @return int                 Nb of recipients or -1 if KO
 	 */
-	public function getNbOfRecipients($filter = 1, $option = '')
+	public function getNbOfRecipients($filter = 1, string $option = ''): int
 	{
-		$a = parent::getNbOfRecipients("select count(distinct(email)) as nb from ".MAIN_DB_PREFIX."myobject as p where email IS NOT NULL AND email != ''");
+		$a = parent::getNbOfRecipients(
+			'select count(distinct(email)) as nb from ' . MAIN_DB_PREFIX . "myobject as p
+					where email IS NOT NULL AND email != ''"
+		);
 
 		if ($a < 0) {
 			return -1;

--- a/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
+++ b/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
@@ -19,17 +19,23 @@
  */
 
 /**
- * 	\defgroup   mymodule     Module MyModule
+ *    \defgroup   mymodule     Module MyModule
  *  \brief      MyModule module descriptor.
  *
  *  \file       htdocs/mymodule/core/modules/modMyModule.class.php
  *  \ingroup    mymodule
  *  \brief      Description and activation file for module MyModule
  */
-include_once DOL_DOCUMENT_ROOT.'/core/modules/DolibarrModules.class.php';
+
+declare(strict_types=1);
+
+include_once DOL_DOCUMENT_ROOT . '/core/modules/DolibarrModules.class.php';
 
 /**
  *  Description and activation class for module MyModule
+ *
+ * @property array $tabs
+ * @property array $dictionaries
  */
 class modMyModule extends DolibarrModules
 {
@@ -43,41 +49,47 @@ class modMyModule extends DolibarrModules
 		global $langs, $conf;
 		$this->db = $db;
 
-		// Id for module (must be unique).
-		// Use here a free id (See in Home -> System information -> Dolibarr for list of used modules id).
-		$this->numero = 500000; // TODO Go on page https://wiki.dolibarr.org/index.php/List_of_modules_id to reserve an id number for your module
+		// ID for module (must be unique).
+		// Use here a free id (See in Home -> System information -> Dolibarr for list of used modules' id).
+		$this->numero = 500000; // TODO Go on page https://wiki.dolibarr.org/index.php/List_of_modules_id
+		// to reserve an id number for your module
 
 		// Key text used to identify module (for permissions, menus, etc...)
 		$this->rights_class = 'mymodule';
 
-		// Family can be 'base' (core modules),'crm','financial','hr','projects','products','ecm','technic' (transverse modules),'interface' (link with external tools),'other','...'
+		// Family can be 'base' (core modules),'crm','financial','hr','projects','products','ecm','technic'
+		// (transverse modules),'interface' (link with external tools),'other','...'
 		// It is used to group modules by family in module setup page
-		$this->family = "other";
+		$this->family = 'other';
 
 		// Module position in the family on 2 digits ('01', '10', '20', ...)
 		$this->module_position = '90';
 
-		// Gives the possibility for the module, to provide his own family info and position of this family (Overwrite $this->family and $this->module_position. Avoid this)
+		// Gives the possibility for the module, to provide his own family info and position of this family
+		// (Overwrite $this->family and $this->module_position. Avoid this)
 		//$this->familyinfo = array('myownfamily' => array('position' => '01', 'label' => $langs->trans("MyOwnFamily")));
-		// Module label (no space allowed), used if translation string 'ModuleMyModuleName' not found (MyModule is name of module).
+		// Module label (no space allowed), used if translation string 'ModuleMyModuleName' not found
+		// (MyModule is name of module).
 		$this->name = preg_replace('/^mod/i', '', get_class($this));
 
 		// Module description, used if translation string 'ModuleMyModuleDesc' not found (MyModule is name of module).
-		$this->description = "MyModuleDescription";
+		$this->description = 'MyModuleDescription';
 		// Used only if file README.md and README-LL.md not found.
-		$this->descriptionlong = "MyModuleDescription";
+		$this->descriptionlong = 'MyModuleDescription';
 
 		// Author
 		$this->editor_name = 'Editor name';
 		$this->editor_url = 'https://www.example.com';
 
-		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
+		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated'
+		// or a version string like 'x.y.z'
 		$this->version = '1.0';
 		// Url to the file with your last numberversion of this module
 		//$this->url_last_version = 'http://www.example.com/versionmodule.txt';
 
-		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
-		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
+		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of
+		// property name of module in uppercase)
+		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);
 
 		// Name of image file used for this module.
 		// If file is in theme/yourtheme/img directory under name object_pictovalue.png, use this->picto='pictovalue'
@@ -86,79 +98,87 @@ class modMyModule extends DolibarrModules
 		$this->picto = 'generic';
 
 		// Define some features supported by module (triggers, login, substitutions, menus, css, etc...)
-		$this->module_parts = array(
+		$this->module_parts = [
 			// Set this to 1 if module has its own trigger directory (core/triggers)
 			'triggers' => 0,
 			// Set this to 1 if module has its own login method file (core/login)
 			'login' => 0,
 			// Set this to 1 if module has its own substitution function file (core/substitutions)
 			'substitutions' => 0,
-			// Set this to 1 if module has its own menus handler directory (core/menus)
+			// Set this to 1 if module has its own menus' handler directory (core/menus)
 			'menus' => 0,
 			// Set this to 1 if module overwrite template dir (core/tpl)
 			'tpl' => 0,
 			// Set this to 1 if module has its own barcode directory (core/modules/barcode)
 			'barcode' => 0,
-			// Set this to 1 if module has its own models directory (core/modules/xxx)
+			// Set this to 1 if module has its own models' directory (core/modules/xxx)
 			'models' => 0,
 			// Set this to 1 if module has its own printing directory (core/modules/printing)
 			'printing' => 0,
 			// Set this to 1 if module has its own theme directory (theme)
 			'theme' => 0,
 			// Set this to relative path of css file if module has its own css file
-			'css' => array(
+			'css' => [
 				//    '/mymodule/css/mymodule.css.php',
-			),
+			],
 			// Set this to relative path of js file if module must load a js on all pages
-			'js' => array(
+			'js' => [
 				//   '/mymodule/js/mymodule.js.php',
-			),
-			// Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *" on source code. You can also set hook context to 'all'
-			'hooks' => array(
+			],
+			// Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *"
+			// on source code. You can also set hook context to 'all'
+			'hooks' => [
 				//   'data' => array(
 				//       'hookcontext1',
 				//       'hookcontext2',
 				//   ),
 				//   'entity' => '0',
-			),
+			],
 			// Set this to 1 if features of module are opened to external users
 			'moduleforexternal' => 0,
-		);
+		];
 
 		// Data directories to create when module is enabled.
 		// Example: this->dirs = array("/mymodule/temp","/mymodule/subdir");
-		$this->dirs = array("/mymodule/temp");
+		$this->dirs = ['/mymodule/temp'];
 
-		// Config pages. Put here list of php page, stored into mymodule/admin directory, to use to setup module.
-		$this->config_page_url = array("setup.php@mymodule");
+		// Config pages. Put here list of php page, stored into mymodule/admin directory, to use to set up module.
+		$this->config_page_url = ['setup.php@mymodule'];
 
 		// Dependencies
 		// A condition to hide module
 		$this->hidden = false;
-		// List of module class names as string that must be enabled if this module is enabled. Example: array('always1'=>'modModuleToEnable1','always2'=>'modModuleToEnable2', 'FR1'=>'modModuleToEnableFR'...)
-		$this->depends = array();
-		$this->requiredby = array(); // List of module class names as string to disable if this one is disabled. Example: array('modModuleToDisable1', ...)
-		$this->conflictwith = array(); // List of module class names as string this module is in conflict with. Example: array('modModuleToDisable1', ...)
+		// List of module class names as string that must be enabled if this module is enabled. Example:
+		// array('always1'=>'modModuleToEnable1','always2'=>'modModuleToEnable2', 'FR1'=>'modModuleToEnableFR'...)
+		$this->depends = [];
+		$this->requiredby = []; // List of module class names as string to disable if this one is disabled.
+		// Example: array('modModuleToDisable1', ...)
+		$this->conflictwith = []; // List of module class names as string this module is in conflict with.
+		// Example: array('modModuleToDisable1', ...)
 
 		// The language file dedicated to your module
-		$this->langfiles = array("mymodule@mymodule");
+		$this->langfiles = ['mymodule@mymodule'];
 
 		// Prerequisites
-		$this->phpmin = array(5, 6); // Minimum version of PHP required by module
-		$this->need_dolibarr_version = array(11, -3); // Minimum version of Dolibarr required by module
+		$this->phpmin = [5, 6]; // Minimum version of PHP required by module
+		$this->need_dolibarr_version = [11, -3]; // Minimum version of Dolibarr required by module
 
 		// Messages at activation
-		$this->warnings_activation = array(); // Warning to show when we activate module. array('always'='text') or array('FR'='textfr','ES'='textes'...)
-		$this->warnings_activation_ext = array(); // Warning to show when we activate an external module. array('always'='text') or array('FR'='textfr','ES'='textes'...)
+		$this->warnings_activation = []; // Warning to show when we activate module. array('always'='text')
+		// or array('FR'='textfr','ES'='textes'...)
+		$this->warnings_activation_ext = []; // Warning to show when we activate an external module.
+		// array('always'='text') or array('FR'='textfr','ES'='textes'...)
 		//$this->automatic_activation = array('FR'=>'MyModuleWasAutomaticallyActivatedBecauseOfYourCountryChoice');
 		//$this->always_enabled = true;								// If true, can't be disabled
 
 		// Constants
-		// List of particular constants to add when module is enabled (key, 'chaine', value, desc, visible, 'current' or 'allentities', deleteonunactive)
-		// Example: $this->const=array(1 => array('MYMODULE_MYNEWCONST1', 'chaine', 'myvalue', 'This is a constant to add', 1),
-		//                             2 => array('MYMODULE_MYNEWCONST2', 'chaine', 'myvalue', 'This is another constant to add', 0, 'current', 1)
+		// List of particular constants to add when module is enabled (key, 'chaine', value, desc, visible,
+		// 'current' or 'allentities', deleteonunactive)
+		// Example: $this->const=array
+		//(1 => array('MYMODULE_MYNEWCONST1', 'chaine', 'myvalue', 'This is a constant to add', 1),
+		//2 => array('MYMODULE_MYNEWCONST2', 'chaine', 'myvalue', 'This is another constant to add', 0, 'current', 1)
 		// );
-		$this->const = array();
+		$this->const = [];
 
 		// Some keys to add into the overwriting translation tables
 		/*$this->overwrite_translation = array(
@@ -166,20 +186,21 @@ class modMyModule extends DolibarrModules
 			'fr_FR:ParentCompany'=>'Maison mère ou revendeur'
 		)*/
 
-		if (!isset($conf->mymodule) || !isset($conf->mymodule->enabled)) {
+		if (!isset($conf->mymodule, $conf->mymodule->enabled)) {
 			$conf->mymodule = new stdClass();
 			$conf->mymodule->enabled = 0;
 		}
 
 		// Array to add new pages in new tabs
-		$this->tabs = array();
+		$this->tabs = [];
 		// Example:
 		// $this->tabs[] = array('data'=>'objecttype:+tabname1:Title1:mylangfile@mymodule:$user->rights->mymodule->read:/mymodule/mynewtab1.php?id=__ID__');  					// To add a new tab identified by code tabname1
 		// $this->tabs[] = array('data'=>'objecttype:+tabname2:SUBSTITUTION_Title2:mylangfile@mymodule:$user->rights->othermodule->read:/mymodule/mynewtab2.php?id=__ID__',  	// To add another new tab identified by code tabname2. Label will be result of calling all substitution functions on 'Title2' key.
 		// $this->tabs[] = array('data'=>'objecttype:-tabname:NU:conditiontoremove');                                                     										// To remove an existing tab identified by code tabname
 		//
 		// Where objecttype can be
-		// 'categories_x'	  to add a tab in category view (replace 'x' by type of category (0=product, 1=supplier, 2=customer, 3=member)
+		// 'categories_x'	  to add a tab in category view (replace 'x' by type of category
+		// 						(0=product, 1=supplier, 2=customer, 3=member)
 		// 'contact'          to add a tab in contact view
 		// 'contract'         to add a tab in contract view
 		// 'group'            to add a tab in group view
@@ -200,7 +221,7 @@ class modMyModule extends DolibarrModules
 		// 'user'             to add a tab in user view
 
 		// Dictionaries
-		$this->dictionaries = array();
+		$this->dictionaries = [];
 		/* Example:
 		$this->dictionaries=array(
 			'langs'=>'mymodule@mymodule',
@@ -209,7 +230,9 @@ class modMyModule extends DolibarrModules
 			// Label of tables
 			'tablib'=>array("Table1", "Table2", "Table3"),
 			// Request to select fields
-			'tabsql'=>array('SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table1 as f', 'SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table2 as f', 'SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table3 as f'),
+			'tabsql'=>array('SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table1 as f',
+			'SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table2 as f',
+			'SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table3 as f'),
 			// Sort order
 			'tabsqlsort'=>array("label ASC", "label ASC", "label ASC"),
 			// List of fields (result of select to show dictionary)
@@ -227,18 +250,18 @@ class modMyModule extends DolibarrModules
 
 		// Boxes/Widgets
 		// Add here list of php file(s) stored in mymodule/core/boxes that contains a class to show a widget.
-		$this->boxes = array(
+		$this->boxes = [
 			//  0 => array(
 			//      'file' => 'mymodulewidget1.php@mymodule',
 			//      'note' => 'Widget provided by MyModule',
 			//      'enabledbydefaulton' => 'Home',
 			//  ),
 			//  ...
-		);
+		];
 
 		// Cronjobs (List of cron jobs entries to add when module is enabled)
 		// unit_frequency must be 60 for minute, 3600 for hour, 86400 for day, 604800 for week
-		$this->cronjobs = array(
+		$this->cronjobs = [
 			//  0 => array(
 			//      'label' => 'MyJob label',
 			//      'jobtype' => 'method',
@@ -253,101 +276,132 @@ class modMyModule extends DolibarrModules
 			//      'test' => '$conf->mymodule->enabled',
 			//      'priority' => 50,
 			//  ),
-		);
+		];
 		// Example: $this->cronjobs=array(
-		//    0=>array('label'=>'My label', 'jobtype'=>'method', 'class'=>'/dir/class/file.class.php', 'objectname'=>'MyClass', 'method'=>'myMethod', 'parameters'=>'param1, param2', 'comment'=>'Comment', 'frequency'=>2, 'unitfrequency'=>3600, 'status'=>0, 'test'=>'$conf->mymodule->enabled', 'priority'=>50),
-		//    1=>array('label'=>'My label', 'jobtype'=>'command', 'command'=>'', 'parameters'=>'param1, param2', 'comment'=>'Comment', 'frequency'=>1, 'unitfrequency'=>3600*24, 'status'=>0, 'test'=>'$conf->mymodule->enabled', 'priority'=>50)
+		//    0=>array('label'=>'My label', 'jobtype'=>'method', 'class'=>'/dir/class/file.class.php',
+		// 		'objectname'=>'MyClass', 'method'=>'myMethod', 'parameters'=>'param1, param2', 'comment'=>'Comment',
+		// 		'frequency'=>2, 'unitfrequency'=>3600, 'status'=>0, 'test'=>'$conf->mymodule->enabled', 'priority'=>50),
+		//    1=>array('label'=>'My label', 'jobtype'=>'command', 'command'=>'', 'parameters'=>'param1, param2',
+		// 		'comment'=>'Comment', 'frequency'=>1, 'unitfrequency'=>3600*24, 'status'=>0,
+		// 		'test'=>'$conf->mymodule->enabled', 'priority'=>50)
 		// );
 
 		// Permissions provided by this module
-		$this->rights = array();
+		$this->rights = [];
 		$r = 0;
 		// Add here entries to declare new permissions
 		/* BEGIN MODULEBUILDER PERMISSIONS */
-		$this->rights[$r][0] = $this->numero . sprintf("%02d", $r + 1); // Permission id (must not be already used)
+		$this->rights[$r][0] = $this->numero . sprintf('%02d', $r + 1); // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read objects of MyModule'; // Permission label
 		$this->rights[$r][4] = 'myobject';
-		$this->rights[$r][5] = 'read'; // In php code, permission will be checked by test if ($user->rights->mymodule->myobject->read)
+		$this->rights[$r][5] = 'read';
+		// In php code, permission will be checked by test if ($user->rights->mymodule->myobject->read)
 		$r++;
-		$this->rights[$r][0] = $this->numero . sprintf("%02d", $r + 1); // Permission id (must not be already used)
+		$this->rights[$r][0] = $this->numero . sprintf('%02d', $r + 1); // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Create/Update objects of MyModule'; // Permission label
 		$this->rights[$r][4] = 'myobject';
-		$this->rights[$r][5] = 'write'; // In php code, permission will be checked by test if ($user->rights->mymodule->myobject->write)
+		$this->rights[$r][5] = 'write';
+		// In php code, permission will be checked by test if ($user->rights->mymodule->myobject->write)
 		$r++;
-		$this->rights[$r][0] = $this->numero . sprintf("%02d", $r + 1); // Permission id (must not be already used)
+		$this->rights[$r][0] = $this->numero . sprintf('%02d', $r + 1); // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Delete objects of MyModule'; // Permission label
 		$this->rights[$r][4] = 'myobject';
-		$this->rights[$r][5] = 'delete'; // In php code, permission will be checked by test if ($user->rights->mymodule->myobject->delete)
+		$this->rights[$r][5] = 'delete';
+		// In php code, permission will be checked by test if ($user->rights->mymodule->myobject->delete)
 		$r++;
 		/* END MODULEBUILDER PERMISSIONS */
 
 		// Main menu entries to add
-		$this->menu = array();
+		$this->menu = [];
 		$r = 0;
 		// Add here entries to declare new menus
 		/* BEGIN MODULEBUILDER TOPMENU */
-		$this->menu[$r++] = array(
-			'fk_menu'=>'', // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
-			'type'=>'top', // This is a Top menu entry
-			'titre'=>'ModuleMyModuleName',
+		$this->menu[$r++] = [
+			'fk_menu' => '',
+			// '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx'
+			// or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
+			'type' => 'top',
+			// This is a Top menu entry
+			'titre' => 'ModuleMyModuleName',
 			'prefix' => img_picto('', $this->picto, 'class="paddingright pictofixedwidth valignmiddle"'),
-			'mainmenu'=>'mymodule',
-			'leftmenu'=>'',
-			'url'=>'/mymodule/mymoduleindex.php',
-			'langs'=>'mymodule@mymodule', // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
-			'position'=>1000 + $r,
-			'enabled'=>'$conf->mymodule->enabled', // Define condition to show or hide menu entry. Use '$conf->mymodule->enabled' if entry must be visible if module is enabled.
-			'perms'=>'1', // Use 'perms'=>'$user->rights->mymodule->myobject->read' if you want your menu with a permission rules
-			'target'=>'',
-			'user'=>2, // 0=Menu for internal users, 1=external users, 2=both
-		);
+			'mainmenu' => 'mymodule',
+			'leftmenu' => '',
+			'url' => '/mymodule/mymoduleindex.php',
+			'langs' => 'mymodule@mymodule',
+			// Lang files to use (without .lang) by module.
+			// File must be in langs/code_CODE/ directory.
+			'position' => 1000 + $r,
+			'enabled' => '$conf->mymodule->enabled',
+			// Define condition to show or hide menu entry.
+			// Use '$conf->mymodule->enabled' if entry must be visible if module is enabled.
+			'perms' => '1',
+			// Use 'perms'=>'$user->rights->mymodule->myobject->read' if you want your menu with a permission rules
+			'target' => '',
+			'user' => 2,
+			// 0=Menu for internal users, 1=external users, 2=both
+		];
 		/* END MODULEBUILDER TOPMENU */
 		/* BEGIN MODULEBUILDER LEFTMENU MYOBJECT
 		$this->menu[$r++]=array(
-			'fk_menu'=>'fk_mainmenu=mymodule',      // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
+			'fk_menu'=>'fk_mainmenu=mymodule',      // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx'
+				//or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
 			'type'=>'left',                          // This is a Top menu entry
 			'titre'=>'MyObject',
 			'prefix' => img_picto('', $this->picto, 'class="paddingright pictofixedwidth valignmiddle"'),
 			'mainmenu'=>'mymodule',
 			'leftmenu'=>'myobject',
 			'url'=>'/mymodule/mymoduleindex.php',
-			'langs'=>'mymodule@mymodule',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+			'langs'=>'mymodule@mymodule',	        // Lang file to use (without .lang) by module.
+				//File must be in langs/code_CODE/ directory.
 			'position'=>1000+$r,
-			'enabled'=>'$conf->mymodule->enabled',  // Define condition to show or hide menu entry. Use '$conf->mymodule->enabled' if entry must be visible if module is enabled.
-			'perms'=>'$user->rights->mymodule->myobject->read',			                // Use 'perms'=>'$user->rights->mymodule->level1->level2' if you want your menu with a permission rules
+			'enabled'=>'$conf->mymodule->enabled',  // Define condition to show or hide menu entry.
+				//Use '$conf->mymodule->enabled' if entry must be visible if module is enabled.
+			'perms'=>'$user->rights->mymodule->myobject->read',
+				// Use 'perms'=>'$user->rights->mymodule->level1->level2' if you want your menu with a permission rules
 			'target'=>'',
 			'user'=>2,				                // 0=Menu for internal users, 1=external users, 2=both
 		);
 		$this->menu[$r++]=array(
-			'fk_menu'=>'fk_mainmenu=mymodule,fk_leftmenu=myobject',	    // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
+			'fk_menu'=>'fk_mainmenu=mymodule,fk_leftmenu=myobject',	    // '' if this is a top menu. For left menu,
+				//use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a
+		leftmenucode
 			'type'=>'left',			                // This is a Left menu entry
 			'titre'=>'List_MyObject',
 			'mainmenu'=>'mymodule',
 			'leftmenu'=>'mymodule_myobject_list',
 			'url'=>'/mymodule/myobject_list.php',
-			'langs'=>'mymodule@mymodule',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+			'langs'=>'mymodule@mymodule',	        // Lang file to use (without .lang) by module.
+				//File must be in langs/code_CODE/ directory.
 			'position'=>1000+$r,
-			'enabled'=>'$conf->mymodule->enabled',  // Define condition to show or hide menu entry. Use '$conf->mymodule->enabled' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
-			'perms'=>'$user->rights->mymodule->myobject->read',			                // Use 'perms'=>'$user->rights->mymodule->level1->level2' if you want your menu with a permission rules
+			'enabled'=>'$conf->mymodule->enabled',  // Define condition to show or hide menu entry.
+				//Use '$conf->mymodule->enabled' if entry must be visible if module is enabled. Use
+		'$leftmenu==\'system\'' to show if leftmenu system is selected.
+			'perms'=>'$user->rights->mymodule->myobject->read',
+				// Use 'perms'=>'$user->rights->mymodule->level1->level2' if you want your menu with a permission rules
 			'target'=>'',
 			'user'=>2,				                // 0=Menu for internal users, 1=external users, 2=both
 		);
 		$this->menu[$r++]=array(
-			'fk_menu'=>'fk_mainmenu=mymodule,fk_leftmenu=myobject',	    // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
+			'fk_menu'=>'fk_mainmenu=mymodule,fk_leftmenu=myobject',	    // '' if this is a top menu. For left menu,
+				//use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
 			'type'=>'left',			                // This is a Left menu entry
 			'titre'=>'New_MyObject',
 			'mainmenu'=>'mymodule',
 			'leftmenu'=>'mymodule_myobject_new',
 			'url'=>'/mymodule/myobject_card.php?action=create',
-			'langs'=>'mymodule@mymodule',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+			'langs'=>'mymodule@mymodule',	        // Lang file to use (without .lang) by module.
+				//File must be in langs/code_CODE/ directory.
 			'position'=>1000+$r,
-			'enabled'=>'$conf->mymodule->enabled',  // Define condition to show or hide menu entry. Use '$conf->mymodule->enabled' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
-			'perms'=>'$user->rights->mymodule->myobject->write',			                // Use 'perms'=>'$user->rights->mymodule->level1->level2' if you want your menu with a permission rules
+			'enabled'=>'$conf->mymodule->enabled',  // Define condition to show or hide menu entry.
+				//Use '$conf->mymodule->enabled' if entry must be visible if module is enabled.
+				//Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+			'perms'=>'$user->rights->mymodule->myobject->write',
+				// Use 'perms'=>'$user->rights->mymodule->level1->level2' if you want your menu with a permission rules
 			'target'=>'',
 			'user'=>2,				                // 0=Menu for internal users, 1=external users, 2=both
 		);
 		END MODULEBUILDER LEFTMENU MYOBJECT */
-		// Exports profiles provided by this module
+		// Export profiles provided by this module
 		$r = 1;
 		/* BEGIN MODULEBUILDER EXPORT MYOBJECT */
 		/*
@@ -358,15 +412,20 @@ class modMyModule extends DolibarrModules
 		// Define $this->export_fields_array, $this->export_TypeFields_array and $this->export_entities_array
 		$keyforclass = 'MyObject'; $keyforclassfile='/mymodule/class/myobject.class.php'; $keyforelement='myobject@mymodule';
 		include DOL_DOCUMENT_ROOT.'/core/commonfieldsinexport.inc.php';
-		//$this->export_fields_array[$r]['t.fieldtoadd']='FieldToAdd'; $this->export_TypeFields_array[$r]['t.fieldtoadd']='Text';
+		//$this->export_fields_array[$r]['t.fieldtoadd']='FieldToAdd';
+		//$this->export_TypeFields_array[$r]['t.fieldtoadd']='Text';
 		//unset($this->export_fields_array[$r]['t.fieldtoremove']);
-		//$keyforclass = 'MyObjectLine'; $keyforclassfile='/mymodule/class/myobject.class.php'; $keyforelement='myobjectline@mymodule'; $keyforalias='tl';
+		//$keyforclass = 'MyObjectLine'; $keyforclassfile='/mymodule/class/myobject.class.php';
+		//$keyforelement='myobjectline@mymodule'; $keyforalias='tl';
 		//include DOL_DOCUMENT_ROOT.'/core/commonfieldsinexport.inc.php';
 		$keyforselect='myobject'; $keyforaliasextra='extra'; $keyforelement='myobject@mymodule';
 		include DOL_DOCUMENT_ROOT.'/core/extrafieldsinexport.inc.php';
 		//$keyforselect='myobjectline'; $keyforaliasextra='extraline'; $keyforelement='myobjectline@mymodule';
 		//include DOL_DOCUMENT_ROOT.'/core/extrafieldsinexport.inc.php';
-		//$this->export_dependencies_array[$r] = array('myobjectline'=>array('tl.rowid','tl.ref')); // To force to activate one or several fields if we select some fields that need same (like to select a unique key if we ask a field of a child to avoid the DISTINCT to discard them, or for computed field than need several other fields)
+		//$this->export_dependencies_array[$r] = array('myobjectline'=>array('tl.rowid','tl.ref'));
+				// To force to activate one or several fields if we select some fields that need same (like to select a unique
+				// key if we ask a field of a child to avoid the DISTINCT to discard them, or for computed field than
+		need several other fields)
 		//$this->export_special_array[$r] = array('t.field'=>'...');
 		//$this->export_examplevalues_array[$r] = array('t.field'=>'Example');
 		//$this->export_help_array[$r] = array('t.field'=>'FieldDescHelp');
@@ -378,7 +437,7 @@ class modMyModule extends DolibarrModules
 		$r++; */
 		/* END MODULEBUILDER EXPORT MYOBJECT */
 
-		// Imports profiles provided by this module
+		// Import profiles provided by this module
 		$r = 1;
 		/* BEGIN MODULEBUILDER IMPORT MYOBJECT */
 		/*
@@ -390,7 +449,10 @@ class modMyModule extends DolibarrModules
 		 include DOL_DOCUMENT_ROOT.'/core/commonfieldsinexport.inc.php';
 		 $keyforselect='myobject'; $keyforaliasextra='extra'; $keyforelement='myobject@mymodule';
 		 include DOL_DOCUMENT_ROOT.'/core/extrafieldsinexport.inc.php';
-		 //$this->export_dependencies_array[$r]=array('mysubobject'=>'ts.rowid', 't.myfield'=>array('t.myfield2','t.myfield3')); // To force to activate one or several fields if we select some fields that need same (like to select a unique key if we ask a field of a child to avoid the DISTINCT to discard them, or for computed field than need several other fields)
+		 //$this->export_dependencies_array[$r]=array('mysubobject'=>'ts.rowid', 't.myfield'=>array('t.myfield2','t.myfield3'));
+					// To force to activate one or several fields if we select some fields that need same
+					// (like to select a unique key if we ask a field of a child to avoid the DISTINCT to discard them, or for
+		computed field than need several other fields)
 		 $this->export_sql_start[$r]='SELECT DISTINCT ';
 		 $this->export_sql_end[$r]  =' FROM '.MAIN_DB_PREFIX.'myobject as t';
 		 $this->export_sql_end[$r] .=' WHERE 1 = 1';
@@ -407,13 +469,14 @@ class modMyModule extends DolibarrModules
 	 *  @param      string  $options    Options when enabling module ('', 'noboxes')
 	 *  @return     int             	1 if OK, 0 if KO
 	 */
-	public function init($options = '')
+	public function init($options = ''): int
 	{
 		global $conf, $langs;
 
 		$result = $this->_load_tables('/mymodule/sql/');
 		if ($result < 0) {
-			return -1; // Do not activate module if error 'not allowed' returned when loading module SQL queries (the _load_table run sql with run_sql with the error allowed parameter set to 'default')
+			return -1; // Do not activate module if error 'not allowed' returned when loading module SQL queries
+			// (the _load_table run sql with run_sql with the error allowed parameter set to 'default')
 		}
 
 		// Create extrafields during init
@@ -428,39 +491,51 @@ class modMyModule extends DolibarrModules
 		// Permissions
 		$this->remove($options);
 
-		$sql = array();
+		$sql = [];
 
 		// Document templates
 		$moduledir = 'mymodule';
-		$myTmpObjects = array();
-		$myTmpObjects['MyObject'] = array('includerefgeneration'=>0, 'includedocgeneration'=>0);
+		$myTmpObjects = [];
+		$myTmpObjects['MyObject'] = ['includerefgeneration' => 0, 'includedocgeneration' => 0];
 
 		foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
-			if ($myTmpObjectKey == 'MyObject') {
+			if ($myTmpObjectKey === 'MyObject') {
 				continue;
 			}
 			if ($myTmpObjectArray['includerefgeneration']) {
-				$src = DOL_DOCUMENT_ROOT.'/install/doctemplates/mymodule/template_myobjects.odt';
-				$dirodt = DOL_DATA_ROOT.'/doctemplates/mymodule';
-				$dest = $dirodt.'/template_myobjects.odt';
+				$src = DOL_DOCUMENT_ROOT . '/install/doctemplates/mymodule/template_myobjects.odt';
+				$dirodt = DOL_DATA_ROOT . '/doctemplates/mymodule';
+				$dest = $dirodt . '/template_myobjects.odt';
 
 				if (file_exists($src) && !file_exists($dest)) {
-					require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+					require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 					dol_mkdir($dirodt);
 					$result = dol_copy($src, $dest, 0, 0);
 					if ($result < 0) {
-						$langs->load("errors");
+						$langs->load('errors');
 						$this->error = $langs->trans('ErrorFailToCopyFile', $src, $dest);
 						return 0;
 					}
 				}
 
-				$sql = array_merge($sql, array(
-					"DELETE FROM ".MAIN_DB_PREFIX."document_model WHERE nom = 'standard_".strtolower($myTmpObjectKey)."' AND type = '".$this->db->escape(strtolower($myTmpObjectKey))."' AND entity = ".((int) $conf->entity),
-					"INSERT INTO ".MAIN_DB_PREFIX."document_model (nom, type, entity) VALUES('standard_".strtolower($myTmpObjectKey)."', '".$this->db->escape(strtolower($myTmpObjectKey))."', ".((int) $conf->entity).")",
-					"DELETE FROM ".MAIN_DB_PREFIX."document_model WHERE nom = 'generic_".strtolower($myTmpObjectKey)."_odt' AND type = '".$this->db->escape(strtolower($myTmpObjectKey))."' AND entity = ".((int) $conf->entity),
-					"INSERT INTO ".MAIN_DB_PREFIX."document_model (nom, type, entity) VALUES('generic_".strtolower($myTmpObjectKey)."_odt', '".$this->db->escape(strtolower($myTmpObjectKey))."', ".((int) $conf->entity).")"
-				));
+				$sql = array_merge($sql, [
+					'DELETE FROM ' . MAIN_DB_PREFIX . "document_model WHERE nom = 'standard_" . strtolower(
+						$myTmpObjectKey
+					) . "' AND type = '" . $this->db->escape(
+						strtolower($myTmpObjectKey)
+					) . "' AND entity = " . ((int) $conf->entity),
+					'INSERT INTO ' . MAIN_DB_PREFIX . "document_model (nom, type, entity) VALUES('standard_" . strtolower(
+						$myTmpObjectKey
+					) . "', '" . $this->db->escape(strtolower($myTmpObjectKey)) . "', " . ((int) $conf->entity) . ')',
+					'DELETE FROM ' . MAIN_DB_PREFIX . "document_model WHERE nom = 'generic_" . strtolower(
+						$myTmpObjectKey
+					) . "_odt' AND type = '" . $this->db->escape(
+						strtolower($myTmpObjectKey)
+					) . "' AND entity = " . ((int) $conf->entity),
+					'INSERT INTO ' . MAIN_DB_PREFIX . "document_model (nom, type, entity) VALUES('generic_" . strtolower(
+						$myTmpObjectKey
+					) . "_odt', '" . $this->db->escape(strtolower($myTmpObjectKey)) . "', " . ((int) $conf->entity) . ')'
+				]);
 			}
 		}
 
@@ -475,9 +550,9 @@ class modMyModule extends DolibarrModules
 	 *  @param      string	$options    Options when enabling module ('', 'noboxes')
 	 *  @return     int                 1 if OK, 0 if KO
 	 */
-	public function remove($options = '')
+	public function remove($options = ''): int
 	{
-		$sql = array();
+		$sql = [];
 		return $this->_remove($sql, $options);
 	}
 }

--- a/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
@@ -22,21 +22,45 @@
  */
 
 /**
- *	\file       htdocs/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
- *	\ingroup    mymodule
- *	\brief      File of class to build ODT documents for myobjects
+ *    \file       htdocs/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
+ *    \ingroup    mymodule
+ *    \brief      File of class to build ODT documents for myobjects
  */
 
+declare(strict_types=1);
+
 dol_include_once('/mymodule/core/modules/mymodule/modules_myobject.php');
-require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/doc.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 
 
 /**
- *	Class to build documents using ODF templates generator
+ *    Class to build documents using ODF templates generator
+ *
+ * @property string     $name
+ * @property int|string $description
+ * @property string     $scandir
+ * @property string     $type
+ * @property int        $page_largeur
+ * @property array      $format
+ * @property int        $page_hauteur
+ * @property int        $marge_gauche
+ * @property int        $marge_droite
+ * @property int        $marge_haute
+ * @property int        $marge_basse
+ * @property int        $option_logo
+ * @property int        $option_tva
+ * @property int        $option_modereg
+ * @property int        $option_condreg
+ * @property int        $option_codeproduitservice
+ * @property int        $option_multilang
+ * @property int        $option_escompte
+ * @property int        $option_credit_note
+ * @property int        $option_freetext
+ * @property int        $option_draft_watermark
  */
 class doc_generic_myobject_odt extends ModelePDFMyObject
 {
@@ -50,36 +74,42 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 	 * @var array Minimum version of PHP required by module.
 	 * e.g.: PHP ≥ 5.6 = array(5, 6)
 	 */
-	public $phpmin = array(5, 6);
+	public array $phpmin = [5, 6];
 
 	/**
 	 * @var string Dolibarr version of the loaded document
 	 */
-	public $version = 'dolibarr';
+	public string $version = 'dolibarr';
+
+	/**
+	 * @var string[]
+	 */
+	public array $result;
 
 
 	/**
-	 *	Constructor
+	 *    Constructor
 	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $conf, $langs, $mysoc;
 
 		// Load translation files required by the page
-		$langs->loadLangs(array("main", "companies"));
+		$langs->loadLangs(['main', 'companies']);
 
 		$this->db = $db;
-		$this->name = "ODT templates";
-		$this->description = $langs->trans("DocumentModelOdt");
-		$this->scandir = 'MYMODULE_MYOBJECT_ADDON_PDF_ODT_PATH'; // Name of constant that is used to save list of directories to scan
+		$this->name = 'ODT templates';
+		$this->description = $langs->trans('DocumentModelOdt');
+		$this->scandir = 'MYMODULE_MYOBJECT_ADDON_PDF_ODT_PATH';
+		// Name of constant that is used to save list of directories to scan
 
 		// Page size for A4 format
 		$this->type = 'odt';
 		$this->page_largeur = 0;
 		$this->page_hauteur = 0;
-		$this->format = array($this->page_largeur, $this->page_hauteur);
+		$this->format = [$this->page_largeur, $this->page_hauteur];
 		$this->marge_gauche = 0;
 		$this->marge_droite = 0;
 		$this->marge_haute = 0;
@@ -99,58 +129,63 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default, if not defined
 		}
 	}
 
 
 	/**
-	 *	Return description of a module
+	 *    Return description of a module
 	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
+	 * @param Translate $langs Lang objects to use for output
+	 *
+	 * @return string                Description
 	 */
-	public function info($langs)
+	public function info(Translate $langs): string
 	{
 		global $conf, $langs;
 
 		// Load translation files required by the page
-		$langs->loadLangs(array("errors", "companies"));
+		$langs->loadLangs(['errors', 'companies']);
 
 		$form = new Form($this->db);
 
-		$texte = $this->description.".<br>\n";
-		$texte .= '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
-		$texte .= '<input type="hidden" name="token" value="'.newToken().'">';
+		$texte = $this->description . ".<br>\n";
+		$texte .= '<form action="' . $_SERVER['PHP_SELF'] . '" method="POST">';
+		$texte .= '<input type="hidden" name="token" value="' . newToken() . '">';
 		$texte .= '<input type="hidden" name="action" value="setModuleOptions">';
 		$texte .= '<input type="hidden" name="param1" value="MYMODULE_MYOBJECT_ADDON_PDF_ODT_PATH">';
-		$texte .= '<table class="nobordernopadding" width="100%">';
+		$texte .= '<table class="nobordernopadding">';
 
 		// List of directories area
 		$texte .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectories");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim($conf->global->MYMODULE_MYOBJECT_ADDON_PDF_ODT_PATH)));
-		$listoffiles = array();
+		$texttitle = $langs->trans('ListOfDirectories');
+		$listofdir = explode(
+			',',
+			preg_replace('/[\r\n]+/', ',', trim($conf->global->MYMODULE_MYOBJECT_ADDON_PDF_ODT_PATH))
+		);
+		$listoffiles = [];
 		foreach ($listofdir as $key => $tmpdir) {
 			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
+			$tmpdir = str_replace('DOL_DATA_ROOT', DOL_DATA_ROOT, $tmpdir);
 			if (!$tmpdir) {
 				unset($listofdir[$key]);
 				continue;
 			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
+			if (is_dir($tmpdir)) {
 				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(ods|odt)');
 				if (count($tmpfiles)) {
 					$listoffiles = array_merge($listoffiles, $tmpfiles);
 				}
+			} else {
+				$texttitle .= img_warning($langs->trans('ErrorDirNotFound', $tmpdir), 0);
 			}
 		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenODT");
+		$texthelp = $langs->trans('ListOfDirectoriesForModelGenODT');
 		// Add list of substitution keys
-		$texthelp .= '<br>'.$langs->trans("FollowingSubstitutionKeysCanBeUsed").'<br>';
-		$texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
+		$texthelp .= '<br>' . $langs->trans('FollowingSubstitutionKeysCanBeUsed') . '<br>';
+		$texthelp .= $langs->transnoentitiesnoconv('FullListOnOnlineDocumentation');
+		// This contains an url, we don't modify it
 
 		$texte .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1);
 		$texte .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
@@ -158,13 +193,13 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 		$texte .= $conf->global->MYMODULE_MYOBJECT_ADDON_PDF_ODT_PATH;
 		$texte .= '</textarea>';
 		$texte .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$texte .= '<input type="submit" class="button small" name="Button"value="'.$langs->trans("Modify").'">';
+		$texte .= '<input type="submit" class="button small" name="Button"value="' . $langs->trans('Modify') . '">';
 		$texte .= '<br></div></div>';
 
 		// Scan directories
 		$nbofiles = count($listoffiles);
 		if (!empty($conf->global->MYMODULE_MYOBJECT_ADDON_PDF_ODT_PATH)) {
-			$texte .= $langs->trans("NumberOfModelFilesFound").': <b>';
+			$texte .= $langs->trans('NumberOfModelFilesFound') . ': <b>';
 			//$texte.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
 			$texte .= count($listoffiles);
 			//$texte.=$nbofiles?'</a>':'';
@@ -174,7 +209,9 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 		if ($nbofiles) {
 			$texte .= '<div id="div_'.get_class($this).'" class="hidden">';
 			foreach ($listoffiles as $file) {
-				$texte .= '- '.$file['name'].' <a href="'.DOL_URL_ROOT.'/document.php?modulepart=doctemplates&file=mymodule_myobject/'.urlencode(basename($file['name'])).'">'.img_picto('', 'listlight').'</a><br>';
+				$texte .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates
+				&file=mymodule_myobject/' . urlencode(basename($file['name'])) . '">
+				' . img_picto('', 'listlight') . '</a><br>';
 			}
 			$texte .= '</div>';
 		}
@@ -182,7 +219,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 		$texte .= '</td>';
 
 		$texte .= '<td rowspan="2" class="tdtop hideonsmartphone">';
-		$texte .= $langs->trans("ExampleOfDirectoriesForModelGen");
+		$texte .= $langs->trans('ExampleOfDirectoriesForModelGen');
 		$texte .= '</td>';
 		$texte .= '</tr>';
 
@@ -193,24 +230,33 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+
 	/**
 	 *  Function to build a document on disk using the generic odt module.
 	 *
-	 *	@param		MyObject	$object				Object source to build document
-	 *	@param		Translate	$outputlangs		Lang output object
-	 * 	@param		string		$srctemplatepath	Full path of source filename for generator using a template file
-	 *  @param		int			$hidedetails		Do not show line details
-	 *  @param		int			$hidedesc			Do not show desc
-	 *  @param		int			$hideref			Do not show ref
-	 *	@return		int         					1 if OK, <=0 if KO
+	 * @param MyObject  $object          Object source to build document
+	 * @param Translate $outputlangs     Lang output object
+	 * @param string    $srctemplatepath Full path of source filename for generator using a template file
+	 * @param int       $hidedetails     Do not show line details
+	 * @param int       $hidedesc        Do not show desc
+	 * @param int       $hideref         Do not show ref
+	 *
+	 * @return        int                            1 if OK, <=0 if KO
+	 * @throws Exception
 	 */
-	public function write_file($object, $outputlangs, $srctemplatepath, $hidedetails = 0, $hidedesc = 0, $hideref = 0)
-	{
+	public function write_file(
+		MyObject $object,
+		Translate $outputlangs,
+		string $srctemplatepath,
+		int $hidedetails = 0,
+		int $hidedesc = 0,
+		int $hideref = 0
+	) {
 		// phpcs:enable
 		global $user, $langs, $conf, $mysoc, $hookmanager;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_generic_odt::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_generic_odt::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -219,7 +265,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 			include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
-		$hookmanager->initHooks(array('odtgeneration'));
+		$hookmanager->initHooks(['odtgeneration']);
 		global $action;
 
 		if (!is_object($outputlangs)) {
@@ -228,14 +274,14 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
 
-		$outputlangs->loadLangs(array("main", "dict", "companies", "bills"));
+		$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills']);
 
 		if ($conf->mymodule->dir_output) {
 			// If $object is id instead of object
 			if (!is_object($object)) {
 				$id = $object;
 				$object = new MyObject($this->db);
-				$result = $object->fetch($id);
+				$result = $object->fetch((int) $id);
 				if ($result < 0) {
 					dol_print_error($this->db, $object->error);
 					return -1;
@@ -244,36 +290,34 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 
 			$object->fetch_thirdparty();
 
-			$dir = $conf->mymodule->multidir_output[isset($object->entity) ? $object->entity : 1];
+			$dir = $conf->mymodule->multidir_output[$object->entity ?? 1];
 			$objectref = dol_sanitizeFileName($object->ref);
-			if (!preg_match('/specimen/i', $objectref)) {
-				$dir .= "/".$objectref;
+			if (stripos($objectref, 'specimen') === false) {
+				$dir .= '/' . $objectref;
 			}
-			$file = $dir."/".$objectref.".odt";
+			$file = $dir . '/' . $objectref . '.odt';
 
-			if (!file_exists($dir)) {
-				if (dol_mkdir($dir) < 0) {
-					$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-					return -1;
-				}
+			if (!file_exists($dir) && dol_mkdir($dir) < 0) {
+				$this->error = $langs->transnoentities('ErrorCanNotCreateDir', $dir);
+				return -1;
 			}
 
 			if (file_exists($dir)) {
 				//print "srctemplatepath=".$srctemplatepath;	// Src filename
 				$newfile = basename($srctemplatepath);
 				$newfiletmp = preg_replace('/\.od(t|s)/i', '', $newfile);
-				$newfiletmp = preg_replace('/template_/i', '', $newfiletmp);
-				$newfiletmp = preg_replace('/modele_/i', '', $newfiletmp);
-				$newfiletmp = $objectref.'_'.$newfiletmp;
+				$newfiletmp = str_ireplace('template_', '', $newfiletmp);
+				$newfiletmp = str_ireplace('modele_', '', $newfiletmp);
+				$newfiletmp = $objectref . '_' . $newfiletmp;
 				//$file=$dir.'/'.$newfiletmp.'.'.dol_print_date(dol_now(),'%Y%m%d%H%M%S').'.odt';
 				// Get extension (ods or odt)
 				$newfileformat = substr($newfile, strrpos($newfile, '.') + 1);
 				if (!empty($conf->global->MAIN_DOC_USE_TIMING)) {
 					$format = $conf->global->MAIN_DOC_USE_TIMING;
-					if ($format == '1') {
+					if ($format === '1') {
 						$format = '%Y%m%d%H%M%S';
 					}
-					$filename = $newfiletmp.'-'.dol_print_date(dol_now(), $format).'.'.$newfileformat;
+					$filename = $newfiletmp . '-' . dol_print_date(dol_now(), $format) . '.' . $newfileformat;
 				} else {
 					$filename = $newfiletmp.'.'.$newfileformat;
 				}
@@ -285,8 +329,8 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 
 				dol_mkdir($conf->mymodule->dir_temp);
 				if (!is_writable($conf->mymodule->dir_temp)) {
-					$this->error = "Failed to write in temp directory ".$conf->mymodule->dir_temp;
-					dol_syslog('Error in write_file: '.$this->error, LOG_ERR);
+					$this->error = 'Failed to write in temp directory ' . $conf->mymodule->dir_temp;
+					dol_syslog('Error in write_file: ' . $this->error, LOG_ERR);
 					return -1;
 				}
 
@@ -302,31 +346,34 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 				$contactobject = null;
 				if (!empty($usecontact)) {
 					// We can use the company of contact instead of thirdparty company
-					if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
+					if ($object->contact->socid !== $object->thirdparty->id && (!isset(
+								$conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT
+							) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 						$object->contact->fetch_thirdparty();
 						$socobject = $object->contact->thirdparty;
-						$contactobject = $object->contact;
 					} else {
 						$socobject = $object->thirdparty;
-						// if we have a CUSTOMER contact and we dont use it as thirdparty recipient we store the contact object for later use
-						$contactobject = $object->contact;
+						// if we have a CUSTOMER contact, and we don't use it as thirdparty
+						// recipient we store the contact object for later use
 					}
+					$contactobject = $object->contact;
 				} else {
 					$socobject = $object->thirdparty;
 				}
 
 				// Make substitution
-				$substitutionarray = array(
+				$substitutionarray = [
 					'__FROM_NAME__' => $this->emetteur->name,
 					'__FROM_EMAIL__' => $this->emetteur->email,
 					'__TOTAL_TTC__' => $object->total_ttc,
 					'__TOTAL_HT__' => $object->total_ht,
 					'__TOTAL_VAT__' => $object->total_tva
-				);
+				];
 				complete_substitutions_array($substitutionarray, $langs, $object);
 				// Call the ODTSubstitution hook
-				$parameters = array('file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs, 'substitutionarray'=>&$substitutionarray);
-				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+				$parameters = compact('file', 'object', 'outputlangs', 'substitutionarray');
+				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
+				// Note that $action and $object may have been modified by some hooks
 
 				// Line of free text
 				$newfreetext = '';
@@ -336,20 +383,21 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 				}
 
 				// Open and load template
-				require_once ODTPHP_PATH.'odf.php';
+				require_once ODTPHP_PATH . 'odf.php';
 				try {
 					$odfHandler = new odf(
 						$srctemplatepath,
-						array(
-						'PATH_TO_TMP'	  => $conf->mymodule->dir_temp,
-						'ZIP_PROXY'		  => 'PclZipProxy', // PhpZipProxy or PclZipProxy. Got "bad compression method" error when using PhpZipProxy.
-						'DELIMITER_LEFT'  => '{',
-						'DELIMITER_RIGHT' => '}'
-						)
+						[
+							'PATH_TO_TMP' => $conf->mymodule->dir_temp,
+							'ZIP_PROXY' => 'PclZipProxy',
+							// PhpZipProxy or PclZipProxy. Got "bad compression method" error when using PhpZipProxy.
+							'DELIMITER_LEFT' => '{',
+							'DELIMITER_RIGHT' => '}'
+						]
 					);
 				} catch (Exception $e) {
 					$this->error = $e->getMessage();
-					dol_syslog($e->getMessage(), LOG_INFO);
+					dol_syslog($e->getMessage());
 					return -1;
 				}
 				// After construction $odfHandler->contentXml contains content and
@@ -363,7 +411,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 				try {
 					$odfHandler->setVars('free_text', $newfreetext, true, 'UTF-8');
 				} catch (OdfException $e) {
-					dol_syslog($e->getMessage(), LOG_INFO);
+					dol_syslog($e->getMessage());
 				}
 
 				// Define substitution array
@@ -375,17 +423,41 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 				$array_thirdparty = $this->get_substitutionarray_thirdparty($socobject, $outputlangs);
 				$array_other = $this->get_substitutionarray_other($outputlangs);
 				// retrieve contact information for use in object as contact_xxx tags
-				$array_thirdparty_contact = array();
+				$array_thirdparty_contact = [];
 				if ($usecontact && is_object($contactobject)) {
-					$array_thirdparty_contact = $this->get_substitutionarray_contact($contactobject, $outputlangs, 'contact');
+					$array_thirdparty_contact = $this->get_substitutionarray_contact(
+						$contactobject,
+						$outputlangs,
+						'contact'
+					);
 				}
 
-				$tmparray = array_merge($substitutionarray, $array_object_from_properties, $array_user, $array_soc, $array_thirdparty, $array_objet, $array_other, $array_thirdparty_contact);
+				$tmparray = array_merge(
+					$substitutionarray,
+					$array_object_from_properties,
+					$array_user,
+					$array_soc,
+					$array_thirdparty,
+					$array_objet,
+					$array_other,
+					$array_thirdparty_contact
+				);
 				complete_substitutions_array($tmparray, $outputlangs, $object);
 
 				// Call the ODTSubstitution hook
-				$parameters = array('odfHandler'=>&$odfHandler, 'file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs, 'substitutionarray'=>&$tmparray);
-				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+				$parameters = [
+					'odfHandler' => &$odfHandler,
+					'file' => $file,
+					'object' => $object,
+					'outputlangs' => $outputlangs,
+					'substitutionarray' => &$tmparray
+				];
+				$reshook = $hookmanager->executeHooks(
+					'ODTSubstitution',
+					$parameters,
+					$this,
+					$action
+				); // Note that $action and $object may have been modified by some hooks
 
 				foreach ($tmparray as $key => $value) {
 					try {
@@ -401,7 +473,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 							$odfHandler->setVars($key, $value, true, 'UTF-8');
 						}
 					} catch (OdfException $e) {
-						dol_syslog($e->getMessage(), LOG_INFO);
+						dol_syslog($e->getMessage());
 					}
 				}
 				// Replace tags of lines
@@ -412,24 +484,40 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 					} catch (OdfException $e) {
 						// We may arrive here if tags for lines not present into template
 						$foundtagforlines = 0;
-						dol_syslog($e->getMessage(), LOG_INFO);
+						dol_syslog($e->getMessage());
 					}
 					if ($foundtagforlines) {
 						$linenumber = 0;
 						foreach ($object->lines as $line) {
 							$linenumber++;
 							$tmparray = $this->get_substitutionarray_lines($line, $outputlangs, $linenumber);
-							complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
+							complete_substitutions_array(
+								$tmparray,
+								$outputlangs,
+								$object,
+								$line,
+								'completesubstitutionarray_lines'
+							);
 							// Call the ODTSubstitutionLine hook
-							$parameters = array('odfHandler'=>&$odfHandler, 'file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs, 'substitutionarray'=>&$tmparray, 'line'=>$line);
-							$reshook = $hookmanager->executeHooks('ODTSubstitutionLine', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+							$parameters = [
+								'odfHandler' => &$odfHandler,
+								'file' => $file,
+								'object' => $object,
+								'outputlangs' => $outputlangs,
+								'substitutionarray' => &$tmparray,
+								'line' => $line
+							];
+							$reshook = $hookmanager->executeHooks(
+								'ODTSubstitutionLine',
+								$parameters,
+								$this,
+								$action
+							); // Note that $action and $object may have been modified by some hooks
 							foreach ($tmparray as $key => $val) {
 								try {
 									$listlines->setVars($key, $val, true, 'UTF-8');
-								} catch (OdfException $e) {
-									dol_syslog($e->getMessage(), LOG_INFO);
 								} catch (SegmentException $e) {
-									dol_syslog($e->getMessage(), LOG_INFO);
+									dol_syslog($e->getMessage());
 								}
 							}
 							$listlines->merge();
@@ -448,14 +536,25 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 					try {
 						$odfHandler->setVars($key, $value, true, 'UTF-8');
 					} catch (OdfException $e) {
-						dol_syslog($e->getMessage(), LOG_INFO);
+						dol_syslog($e->getMessage());
 					}
 				}
 
 				// Call the beforeODTSave hook
 
-				$parameters = array('odfHandler'=>&$odfHandler, 'file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs, 'substitutionarray'=>&$tmparray);
-				$reshook = $hookmanager->executeHooks('beforeODTSave', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+				$parameters = [
+					'odfHandler' => &$odfHandler,
+					'file' => $file,
+					'object' => $object,
+					'outputlangs' => $outputlangs,
+					'substitutionarray' => &$tmparray
+				];
+				$reshook = $hookmanager->executeHooks(
+					'beforeODTSave',
+					$parameters,
+					$this,
+					$action
+				); // Note that $action and $object may have been modified by some hooks
 
 				// Write new file
 				if (!empty($conf->global->MAIN_ODT_AS_PDF)) {
@@ -463,7 +562,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 						$odfHandler->exportAsAttachedPDF($file);
 					} catch (Exception $e) {
 						$this->error = $e->getMessage();
-						dol_syslog($e->getMessage(), LOG_INFO);
+						dol_syslog($e->getMessage());
 						return -1;
 					}
 				} else {
@@ -471,13 +570,24 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 						$odfHandler->saveToDisk($file);
 					} catch (Exception $e) {
 						$this->error = $e->getMessage();
-						dol_syslog($e->getMessage(), LOG_INFO);
+						dol_syslog($e->getMessage());
 						return -1;
 					}
 				}
 
-				$parameters = array('odfHandler'=>&$odfHandler, 'file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs, 'substitutionarray'=>&$tmparray);
-				$reshook = $hookmanager->executeHooks('afterODTCreation', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+				$parameters = [
+					'odfHandler' => &$odfHandler,
+					'file' => $file,
+					'object' => $object,
+					'outputlangs' => $outputlangs,
+					'substitutionarray' => &$tmparray
+				];
+				$reshook = $hookmanager->executeHooks(
+					'afterODTCreation',
+					$parameters,
+					$this,
+					$action
+				); // Note that $action and $object may have been modified by some hooks
 
 				if (!empty($conf->global->MAIN_UMASK)) {
 					@chmod($file, octdec($conf->global->MAIN_UMASK));
@@ -485,13 +595,13 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 
 				$odfHandler = null; // Destroy object
 
-				$this->result = array('fullpath'=>$file);
+				$this->result = ['fullpath' => $file];
 
 				return 1; // Success
-			} else {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
 			}
+
+			$this->error = $langs->transnoentities('ErrorCanNotCreateDir', $dir);
+			return -1;
 		}
 
 		return -1;

--- a/htdocs/modulebuilder/template/core/modules/mymodule/doc/pdf_standard_myobject.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/doc/pdf_standard_myobject.modules.php
@@ -31,27 +31,41 @@
  *  \brief      File of class to generate document from standard template
  */
 
+declare(strict_types=1);
+
 dol_include_once('/mymodule/core/modules/mymodule/modules_myobject.php');
-require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/pdf.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 
 
 /**
- *	Class to manage PDF template standard_myobject
+ *    Class to manage PDF template standard_myobject
+ *
+ * @property int      $posxdesc
+ * @property int      $tabTitleHeight
+ * @property array    $tva
+ * @property array    $localtax1
+ * @property array    $localtax2
+ * @property int      $atleastoneratenotnull
+ * @property int      $atleastonediscount
+ * @property false    $atleastonephoto
+ * @property string[] $result
+ * @property array    $defaultContentsFieldsStyle
+ * @property array    $defaultTitlesFieldsStyle
  */
 class pdf_standard_myobject extends ModelePDFMyObject
 {
 	/**
 	 * @var DoliDb Database handler
 	 */
-	public $db;
+	public DoliDB $db;
 
 	/**
 	 * @var string model name
 	 */
-	public $name;
+	public string $name;
 
 	/**
 	 * @var string model description (short text)
@@ -61,24 +75,25 @@ class pdf_standard_myobject extends ModelePDFMyObject
 	/**
 	 * @var int     Save the name of generated file as the main doc when generating a doc with this template
 	 */
-	public $update_main_doc_field;
+	public int $update_main_doc_field;
 
 	/**
 	 * @var string document type
 	 */
-	public $type;
+	public string $type;
 
 	/**
 	 * @var array Minimum version of PHP required by module.
 	 * e.g.: PHP ≥ 5.6 = array(5, 6)
 	 */
-	public $phpmin = array(5, 6);
+	public array $phpmin = [5, 6];
 
 	/**
 	 * Dolibarr version of the loaded document
+	 *
 	 * @var string
 	 */
-	public $version = 'dolibarr';
+	public string $version = 'dolibarr';
 
 	/**
 	 * @var int page_largeur
@@ -93,7 +108,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 	/**
 	 * @var array format
 	 */
-	public $format;
+	public array $format;
 
 	/**
 	 * @var int marge_gauche
@@ -117,6 +132,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 
 	/**
 	 * Issuer
+	 *
 	 * @var Societe Object that emits
 	 */
 	public $emetteur;
@@ -124,7 +140,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 	/**
 	 * @var bool Situation invoice type
 	 */
-	public $situationinvoice;
+	public bool $situationinvoice;
 
 
 	/**
@@ -134,32 +150,33 @@ class pdf_standard_myobject extends ModelePDFMyObject
 
 
 	/**
-	 *	Constructor
+	 *    Constructor
 	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $conf, $langs, $mysoc;
 
 		// Translations
-		$langs->loadLangs(array("main", "bills"));
+		$langs->loadLangs(['main', 'bills']);
 
 		$this->db = $db;
-		$this->name = "standard";
+		$this->name = 'standard';
 		$this->description = $langs->trans('DocumentModelStandardPDF');
-		$this->update_main_doc_field = 1; // Save the name of generated file as the main doc when generating a doc with this template
+		$this->update_main_doc_field = 1;
+		// Save the name of generated file as the main doc when generating a doc with this template
 
 		// Dimension page
 		$this->type = 'pdf';
 		$formatarray = pdf_getFormat();
 		$this->page_largeur = $formatarray['width'];
 		$this->page_hauteur = $formatarray['height'];
-		$this->format = array($this->page_largeur, $this->page_hauteur);
-		$this->marge_gauche = isset($conf->global->MAIN_PDF_MARGIN_LEFT) ? $conf->global->MAIN_PDF_MARGIN_LEFT : 10;
-		$this->marge_droite = isset($conf->global->MAIN_PDF_MARGIN_RIGHT) ? $conf->global->MAIN_PDF_MARGIN_RIGHT : 10;
-		$this->marge_haute = isset($conf->global->MAIN_PDF_MARGIN_TOP) ? $conf->global->MAIN_PDF_MARGIN_TOP : 10;
-		$this->marge_basse = isset($conf->global->MAIN_PDF_MARGIN_BOTTOM) ? $conf->global->MAIN_PDF_MARGIN_BOTTOM : 10;
+		$this->format = [$this->page_largeur, $this->page_hauteur];
+		$this->marge_gauche = $conf->global->MAIN_PDF_MARGIN_LEFT ?? 10;
+		$this->marge_droite = $conf->global->MAIN_PDF_MARGIN_RIGHT ?? 10;
+		$this->marge_haute = $conf->global->MAIN_PDF_MARGIN_TOP ?? 10;
+		$this->marge_basse = $conf->global->MAIN_PDF_MARGIN_BOTTOM ?? 10;
 
 		// Get source company
 		$this->emetteur = $mysoc;
@@ -168,16 +185,16 @@ class pdf_standard_myobject extends ModelePDFMyObject
 		}
 
 		// Define position of columns
-		$this->posxdesc = $this->marge_gauche + 1; // used for notes ans other stuff
+		$this->posxdesc = $this->marge_gauche + 1; // used for notes and other stuff
 
 
 		$this->tabTitleHeight = 5; // default height
 
 		//  Use new system for position of columns, view  $this->defineColumnField()
 
-		$this->tva = array();
-		$this->localtax1 = array();
-		$this->localtax2 = array();
+		$this->tva = [];
+		$this->localtax1 = [];
+		$this->localtax2 = [];
 		$this->atleastoneratenotnull = 0;
 		$this->atleastonediscount = 0;
 		$this->situationinvoice = false;
@@ -185,23 +202,50 @@ class pdf_standard_myobject extends ModelePDFMyObject
 
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+
+	/**
+	 *  Return list of active generation modules
+	 *
+	 * @param DoliDB $db                Database handler
+	 * @param int    $maxfilenamelength Max length of value to show
+	 *
+	 * @return    array                        List of templates
+	 */
+	public static function liste_modeles(DoliDB $db, int $maxfilenamelength = 0): array
+	{
+		// phpcs:enable
+		return parent::liste_modeles($db, $maxfilenamelength); // TODO: Change the autogenerated stub
+	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+
 	/**
 	 *  Function to build pdf onto disk
 	 *
-	 *  @param		Object		$object				Object to generate
-	 *  @param		Translate	$outputlangs		Lang output object
-	 *  @param		string		$srctemplatepath	Full path of source filename for generator using a template file
-	 *  @param		int			$hidedetails		Do not show line details
-	 *  @param		int			$hidedesc			Do not show desc
-	 *  @param		int			$hideref			Do not show ref
-	 *  @return     int         	    			1=OK, 0=KO
+	 * @param Object    $object          Object to generate
+	 * @param Translate $outputlangs     Lang output object
+	 * @param string    $srctemplatepath Full path of source filename for generator using a template file
+	 * @param int       $hidedetails     Do not show line details
+	 * @param int       $hidedesc        Do not show desc
+	 * @param int       $hideref         Do not show ref
+	 *
+	 * @return     int                            1=OK, 0=KO
+	 * @throws Exception
 	 */
-	public function write_file($object, $outputlangs, $srctemplatepath = '', $hidedetails = 0, $hidedesc = 0, $hideref = 0)
-	{
+	public function write_file(
+		object $object,
+		Translate $outputlangs,
+		string $srctemplatepath = '',
+		int $hidedetails = 0,
+		int $hidedesc = 0,
+		int $hideref = 0
+	): int {
 		// phpcs:enable
 		global $user, $langs, $conf, $mysoc, $db, $hookmanager, $nblines;
 
-		dol_syslog("write_file outputlangs->defaultlang=".(is_object($outputlangs) ? $outputlangs->defaultlang : 'null'));
+		dol_syslog(
+			'write_file outputlangs->defaultlang=' . ($outputlangs->defaultlang)
+		);
 
 		if (!is_object($outputlangs)) {
 			$outputlangs = $langs;
@@ -212,13 +256,14 @@ class pdf_standard_myobject extends ModelePDFMyObject
 		}
 
 		// Load translation files required by the page
-		$outputlangs->loadLangs(array("main", "bills", "products", "dict", "companies"));
+		$outputlangs->loadLangs(['main', 'bills', 'products', 'dict', 'companies']);
 
-		if (!empty($conf->global->PDF_USE_ALSO_LANGUAGE_CODE) && $outputlangs->defaultlang != $conf->global->PDF_USE_ALSO_LANGUAGE_CODE) {
+		if (!empty($conf->global->PDF_USE_ALSO_LANGUAGE_CODE) && $outputlangs->defaultlang !==
+			$conf->global->PDF_USE_ALSO_LANGUAGE_CODE) {
 			global $outputlangsbis;
 			$outputlangsbis = new Translate('', $conf);
 			$outputlangsbis->setDefaultLang($conf->global->PDF_USE_ALSO_LANGUAGE_CODE);
-			$outputlangsbis->loadLangs(array("main", "bills", "products", "dict", "companies"));
+			$outputlangsbis->loadLangs(['main', 'bills', 'products', 'dict', 'companies']);
 		}
 
 		$nblines = (is_array($object->lines) ? count($object->lines) : 0);
@@ -228,8 +273,8 @@ class pdf_standard_myobject extends ModelePDFMyObject
 			$hidetop = $conf->global->MAIN_PDF_DISABLE_COL_HEAD_TITLE;
 		}
 
-		// Loop on each lines to detect if there is at least one image to show
-		$realpatharray = array();
+		// Loop on each line to detect if there is at least one image to show
+		$realpatharray = [];
 		$this->atleastonephoto = false;
 		/*
 		if (!empty($conf->global->MAIN_GENERATE_MYOBJECT_WITH_PICTURE))
@@ -258,7 +303,8 @@ class pdf_standard_myobject extends ModelePDFMyObject
 
 						foreach ($objphoto->liste_photos($dir, 1) as $key => $obj)
 						{
-							if (empty($conf->global->CAT_HIGH_QUALITY_IMAGES))		// If CAT_HIGH_QUALITY_IMAGES not defined, we use thumb if defined and then original photo
+							if (empty($conf->global->CAT_HIGH_QUALITY_IMAGES))
+								// If CAT_HIGH_QUALITY_IMAGES not defined, we use thumb if defined and then original photo
 							{
 								if ($obj['photo_vignette'])
 								{
@@ -284,35 +330,38 @@ class pdf_standard_myobject extends ModelePDFMyObject
 
 		//if (count($realpatharray) == 0) $this->posxpicture=$this->posxtva;
 
-		if ($conf->mymodule->dir_output.'/myobject') {
+		if ($conf->mymodule->dir_output . '/myobject') {
 			$object->fetch_thirdparty();
 
 			// Definition of $dir and $file
 			if ($object->specimen) {
-				$dir = $conf->mymodule->dir_output.'/myobject';
-				$file = $dir."/SPECIMEN.pdf";
+				$dir = $conf->mymodule->dir_output . '/myobject';
+				$file = $dir . '/SPECIMEN.pdf';
 			} else {
 				$objectref = dol_sanitizeFileName($object->ref);
-				$dir = $conf->mymodule->dir_output.'/myobject/'.$objectref;
-				$file = $dir."/".$objectref.".pdf";
+				$dir = $conf->mymodule->dir_output . '/myobject/' . $objectref;
+				$file = $dir . '/' . $objectref . '.pdf';
 			}
-			if (!file_exists($dir)) {
-				if (dol_mkdir($dir) < 0) {
-					$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-					return 0;
-				}
+			if (!file_exists($dir) && dol_mkdir($dir) < 0) {
+				$this->error = $langs->transnoentities('ErrorCanNotCreateDir', $dir);
+				return 0;
 			}
 
 			if (file_exists($dir)) {
 				// Add pdfgeneration hook
 				if (!is_object($hookmanager)) {
-					include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
+					include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 					$hookmanager = new HookManager($this->db);
 				}
-				$hookmanager->initHooks(array('pdfgeneration'));
-				$parameters = array('file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs);
+				$hookmanager->initHooks(['pdfgeneration']);
+				$parameters = compact('file', 'object', 'outputlangs');
 				global $action;
-				$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+				$reshook = $hookmanager->executeHooks(
+					'beforePDFCreation',
+					$parameters,
+					$object,
+					$action
+				); // Note that $action and $object may have been modified by some hooks
 
 				// Set nblines with the new facture lines content after hook
 				$nblines = (is_array($object->lines) ? count($object->lines) : 0);
@@ -320,11 +369,13 @@ class pdf_standard_myobject extends ModelePDFMyObject
 				// Create pdf instance
 				$pdf = pdf_getInstance($this->format);
 				$default_font_size = pdf_getPDFFontSize($outputlangs); // Must be after pdf_getInstance
-				$pdf->SetAutoPageBreak(1, 0);
+				$pdf->SetAutoPageBreak(1);
 
 				$heightforinfotot = 50; // Height reserved to output the info and total part and payment part
-				$heightforfreetext = (isset($conf->global->MAIN_PDF_FREETEXT_HEIGHT) ? $conf->global->MAIN_PDF_FREETEXT_HEIGHT : 5); // Height reserved to output the free text on last page
-				$heightforfooter = $this->marge_basse + (empty($conf->global->MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS) ? 12 : 22); // Height reserved to output the footer (value include bottom margin)
+				$heightforfreetext = ($conf->global->MAIN_PDF_FREETEXT_HEIGHT ?? 5);
+				// Height reserved to output the free text on last page
+				$heightforfooter = $this->marge_basse + (empty($conf->global->MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS) ? 12 : 22);
+				// Height reserved to output the footer (value include bottom margin)
 
 				if (class_exists('TCPDF')) {
 					$pdf->setPrintHeader(false);
@@ -334,7 +385,9 @@ class pdf_standard_myobject extends ModelePDFMyObject
 
 				// Set path to the background PDF File
 				if (!empty($conf->global->MAIN_ADD_PDF_BACKGROUND)) {
-					$pagecount = $pdf->setSourceFile($conf->mycompany->multidir_output[$object->entity].'/'.$conf->global->MAIN_ADD_PDF_BACKGROUND);
+					$pagecount = $pdf->setSourceFile(
+						$conf->mycompany->multidir_output[$object->entity] . '/' . $conf->global->MAIN_ADD_PDF_BACKGROUND
+					);
 					$tplidx = $pdf->importPage(1);
 				}
 
@@ -343,10 +396,14 @@ class pdf_standard_myobject extends ModelePDFMyObject
 				$pdf->SetDrawColor(128, 128, 128);
 
 				$pdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
-				$pdf->SetSubject($outputlangs->transnoentities("PdfTitle"));
-				$pdf->SetCreator("Dolibarr ".DOL_VERSION);
+				$pdf->SetSubject($outputlangs->transnoentities('PdfTitle'));
+				$pdf->SetCreator('Dolibarr ' . DOL_VERSION);
 				$pdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-				$pdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref)." ".$outputlangs->transnoentities("PdfTitle")." ".$outputlangs->convToOutputCharset($object->thirdparty->name));
+				$pdf->SetKeywords(
+					$outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities(
+						'PdfTitle'
+					) . ' ' . $outputlangs->convToOutputCharset($object->thirdparty->name)
+				);
 				if (!empty($conf->global->MAIN_DISABLE_PDF_COMPRESSION)) {
 					$pdf->SetCompression(false);
 				}
@@ -359,12 +416,12 @@ class pdf_standard_myobject extends ModelePDFMyObject
 				}
 				// If a certificate is found
 				if ($cert) {
-					$info = array(
+					$info = [
 						'Name' => $this->emetteur->name,
 						'Location' => getCountry($this->emetteur->country_code, 0),
 						'Reason' => 'MYOBJECT',
 						'ContactInfo' => $this->emetteur->email
-					);
+					];
 					$pdf->setSignature($cert, $cert, $this->emetteur->name, '', 2, $info);
 				}
 
@@ -434,7 +491,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 								$this->_pagehead($pdf, $object, 0, $outputlangs);
 							}
 							// $this->_pagefoot($pdf,$object,$outputlangs,1);
-							$pdf->setTopMargin($tab_top_newpage);
+							$pdf->SetTopMargin($tab_top_newpage);
 							// The only function to edit the bottom margin of current page to set it.
 							$pdf->setPageOrientation('', 1, $heightforfooter + $heightforfreetext);
 						}
@@ -443,17 +500,26 @@ class pdf_standard_myobject extends ModelePDFMyObject
 						$pdf->setPage($pageposbeforenote);
 						$pdf->setPageOrientation('', 1, $heightforfooter + $heightforfreetext);
 						$pdf->SetFont('', '', $default_font_size - 1);
-						$pdf->writeHTMLCell(190, 3, $this->posxdesc - 1, $tab_top, dol_htmlentitiesbr($notetoshow), 0, 1);
+						$pdf->writeHTMLCell(
+							190,
+							3,
+							$this->posxdesc - 1,
+							$tab_top,
+							dol_htmlentitiesbr($notetoshow),
+							0,
+							1
+						);
 						$pageposafternote = $pdf->getPage();
 
 						$posyafter = $pdf->GetY();
 
-						if ($posyafter > ($this->page_hauteur - ($heightforfooter + $heightforfreetext + 20))) {	// There is no space left for total+free text
+						if ($posyafter > ($this->page_hauteur - ($heightforfooter + $heightforfreetext + 20))) {
+							// There is no space left for total+free text
 							$pdf->AddPage('', '', true);
 							$pagenb++;
 							$pageposafternote++;
 							$pdf->setPage($pageposafternote);
-							$pdf->setTopMargin($tab_top_newpage);
+							$pdf->SetTopMargin($tab_top_newpage);
 							// The only function to edit the bottom margin of current page to set it.
 							$pdf->setPageOrientation('', 1, $heightforfooter + $heightforfreetext);
 							//$posyafter = $tab_top_newpage;
@@ -477,7 +543,11 @@ class pdf_standard_myobject extends ModelePDFMyObject
 							}
 
 							// Add footer
-							$pdf->setPageOrientation('', 1, 0); // The only function to edit the bottom margin of current page to set it.
+							$pdf->setPageOrientation(
+								'',
+								1,
+								0
+							); // The only function to edit the bottom margin of current page to set it.
 							$this->_pagefoot($pdf, $object, $outputlangs, 1);
 
 							$i++;
@@ -518,7 +588,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 						}
 					}
 
-					$tab_height = $tab_height - $height_note;
+					$tab_height -= $height_note;
 					$tab_top = $posyafter + 6;
 				} else {
 					$height_note = 0;
@@ -543,13 +613,14 @@ class pdf_standard_myobject extends ModelePDFMyObject
 					$pdf->SetTextColor(0, 0, 0);
 
 					// Define size of image if we need it
-					$imglinesize = array();
+					$imglinesize = [];
 					if (!empty($realpatharray[$i])) {
 						$imglinesize = pdf_getSizeForImage($realpatharray[$i]);
 					}
 
-					$pdf->setTopMargin($tab_top_newpage);
-					$pdf->setPageOrientation('', 1, $heightforfooter + $heightforfreetext + $heightforinfotot); // The only function to edit the bottom margin of current page to set it.
+					$pdf->SetTopMargin($tab_top_newpage);
+					$pdf->setPageOrientation('', 1, $heightforfooter + $heightforfreetext + $heightforinfotot);
+					// The only function to edit the bottom margin of current page to set it.
 					$pageposbefore = $pdf->getPage();
 
 					$showpricebeforepagebreak = 1;
@@ -557,7 +628,9 @@ class pdf_standard_myobject extends ModelePDFMyObject
 
 					if ($this->getColumnStatus('photo')) {
 						// We start with Photo of product line
-						if (isset($imglinesize['width']) && isset($imglinesize['height']) && ($curY + $imglinesize['height']) > ($this->page_hauteur - ($heightforfooter + $heightforfreetext + $heightforinfotot))) {	// If photo too high, we moved completely on new page
+						if (isset($imglinesize['width'], $imglinesize['height']) &&
+							($curY + $imglinesize['height']) > ($this->page_hauteur - ($heightforfooter + $heightforfreetext + $heightforinfotot))) {
+							// If photo too high, we moved completely on new page
 							$pdf->AddPage('', '', true);
 							if (!empty($tplidx)) {
 								$pdf->useTemplate($tplidx);
@@ -574,8 +647,18 @@ class pdf_standard_myobject extends ModelePDFMyObject
 							}
 						}
 
-						if (!empty($this->cols['photo']) && isset($imglinesize['width']) && isset($imglinesize['height'])) {
-							$pdf->Image($realpatharray[$i], $this->getColumnContentXStart('photo'), $curY, $imglinesize['width'], $imglinesize['height'], '', '', '', 2, 300); // Use 300 dpi
+						if (isset($imglinesize['width'], $imglinesize['height']) && !empty($this->cols['photo'])) {
+							$pdf->Image(
+								$realpatharray[$i],
+								$this->getColumnContentXStart('photo'),
+								$curY,
+								$imglinesize['width'],
+								$imglinesize['height'],
+								'',
+								'',
+								'',
+								2
+							); // Use 300 dpi
 							// $pdf->Image does not increase value return by getY, so we save it manually
 							$posYAfterImage = $curY + $imglinesize['height'];
 						}
@@ -588,31 +671,41 @@ class pdf_standard_myobject extends ModelePDFMyObject
 						$this->printColDescContent($pdf, $curY, 'desc', $object, $i, $outputlangs, $hideref, $hidedesc);
 						$pageposafter = $pdf->getPage();
 
-						if ($pageposafter > $pageposbefore) {	// There is a pagebreak
+						if ($pageposafter > $pageposbefore) {    // There is a pagebreak
 							$pdf->rollbackTransaction(true);
-							$pdf->setPageOrientation('', 1, $heightforfooter); // The only function to edit the bottom margin of current page to set it.
+							$pdf->setPageOrientation(
+								'',
+								1,
+								$heightforfooter
+							); // The only function to edit the bottom margin of current page to set it.
 
-							$this->printColDescContent($pdf, $curY, 'desc', $object, $i, $outputlangs, $hideref, $hidedesc);
+							$this->printColDescContent(
+								$pdf,
+								$curY,
+								'desc',
+								$object,
+								$i,
+								$outputlangs,
+								$hideref,
+								$hidedesc
+							);
 
 							$pageposafter = $pdf->getPage();
 							$posyafter = $pdf->GetY();
-							//var_dump($posyafter); var_dump(($this->page_hauteur - ($heightforfooter+$heightforfreetext+$heightforinfotot))); exit;
-							if ($posyafter > ($this->page_hauteur - ($heightforfooter + $heightforfreetext + $heightforinfotot))) {	// There is no space left for total+free text
-								if ($i == ($nblines - 1)) {	// No more lines, and no space left to show total, so we create a new page
+							if ($posyafter > ($this->page_hauteur - ($heightforfooter + $heightforfreetext + $heightforinfotot))) {
+								// There is no space left for total+free text
+								if ($i === ($nblines - 1)) {    // No more lines, and no space left to show total, so
+									// we create a new page
 									$pdf->AddPage('', '', true);
 									if (!empty($tplidx)) {
 										$pdf->useTemplate($tplidx);
 									}
 									$pdf->setPage($pageposafter + 1);
 								}
+							} elseif (!empty($conf->global->MAIN_PDF_DATA_ON_FIRST_PAGE)) {
+								$showpricebeforepagebreak = 1;
 							} else {
-								// We found a page break
-								// Allows data in the first page if description is long enough to break in multiples pages
-								if (!empty($conf->global->MAIN_PDF_DATA_ON_FIRST_PAGE)) {
-									$showpricebeforepagebreak = 1;
-								} else {
-									$showpricebeforepagebreak = 0;
-								}
+								$showpricebeforepagebreak = 0;
 							}
 						} else // No pagebreak
 						{
@@ -623,12 +716,17 @@ class pdf_standard_myobject extends ModelePDFMyObject
 					$nexY = $pdf->GetY();
 					$pageposafter = $pdf->getPage();
 					$pdf->setPage($pageposbefore);
-					$pdf->setTopMargin($this->marge_haute);
-					$pdf->setPageOrientation('', 1, 0); // The only function to edit the bottom margin of current page to set it.
+					$pdf->SetTopMargin($this->marge_haute);
+					$pdf->setPageOrientation(
+						'',
+						1,
+						0
+					); // The only function to edit the bottom margin of current page to set it.
 
 					// We suppose that a too long description or photo were moved completely on next page
 					if ($pageposafter > $pageposbefore && empty($showpricebeforepagebreak)) {
-						$pdf->setPage($pageposafter); $curY = $tab_top_newpage;
+						$pdf->setPage($pageposafter);
+						$curY = $tab_top_newpage;
 					}
 
 					$pdf->SetFont('', '', $default_font_size - 1); // On repositionne la police par defaut
@@ -645,7 +743,11 @@ class pdf_standard_myobject extends ModelePDFMyObject
 					if (!empty($object->lines[$i]->array_options)) {
 						foreach ($object->lines[$i]->array_options as $extrafieldColKey => $extrafieldValue) {
 							if ($this->getColumnStatus($extrafieldColKey)) {
-								$extrafieldValue = $this->getExtrafieldContent($object->lines[$i], $extrafieldColKey, $outputlangs);
+								$extrafieldValue = $this->getExtrafieldContent(
+									$object->lines[$i],
+									$extrafieldColKey,
+									$outputlangs
+								);
 								$this->printStdColumnContent($pdf, $curY, $extrafieldColKey, $extrafieldValue);
 								$nexY = max($pdf->GetY(), $nexY);
 							}
@@ -653,33 +755,25 @@ class pdf_standard_myobject extends ModelePDFMyObject
 					}
 
 
-					$parameters = array(
-						'object' => $object,
-						'i' => $i,
-						'pdf' =>& $pdf,
-						'curY' =>& $curY,
-						'nexY' =>& $nexY,
-						'outputlangs' => $outputlangs,
-						'hidedetails' => $hidedetails
-					);
-					$reshook = $hookmanager->executeHooks('printPDFline', $parameters, $this); // Note that $object may have been modified by hook
+					$parameters = compact('object', 'i', 'pdf', 'curY', 'nexY', 'outputlangs', 'hidedetails');
+					$reshook = $hookmanager->executeHooks('printPDFline', $parameters, $this);
+					// Note that $object may have been modified by hook
 
 
 					$sign = 1;
 					// Collecte des totaux par valeur de tva dans $this->tva["taux"]=total_tva
 					$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
-					if ($prev_progress > 0 && !empty($object->lines[$i]->situation_percent)) { // Compute progress from previous situation
-						if (!empty($conf->multicurrency->enabled) && $object->multicurrency_tx != 1) {
+					if ($prev_progress > 0 && !empty($object->lines[$i]->situation_percent)) {
+						// Compute progress from previous situation
+						if (!empty($conf->multicurrency->enabled) && $object->multicurrency_tx !== 1) {
 							$tvaligne = $sign * $object->lines[$i]->multicurrency_total_tva * ($object->lines[$i]->situation_percent - $prev_progress) / $object->lines[$i]->situation_percent;
 						} else {
 							$tvaligne = $sign * $object->lines[$i]->total_tva * ($object->lines[$i]->situation_percent - $prev_progress) / $object->lines[$i]->situation_percent;
 						}
+					} elseif (!empty($conf->multicurrency->enabled) && $object->multicurrency_tx !== 1) {
+						$tvaligne = $sign * $object->lines[$i]->multicurrency_total_tva;
 					} else {
-						if (!empty($conf->multicurrency->enabled) && $object->multicurrency_tx != 1) {
-							$tvaligne = $sign * $object->lines[$i]->multicurrency_total_tva;
-						} else {
-							$tvaligne = $sign * $object->lines[$i]->total_tva;
-						}
+						$tvaligne = $sign * $object->lines[$i]->total_tva;
 					}
 
 					$localtax1ligne = $object->lines[$i]->total_localtax1;
@@ -702,22 +796,23 @@ class pdf_standard_myobject extends ModelePDFMyObject
 					$vatrate = (string) $object->lines[$i]->tva_tx;
 
 					// Retrieve type from database for backward compatibility with old records
-					if ((!isset($localtax1_type) || $localtax1_type == '' || !isset($localtax2_type) || $localtax2_type == '') // if tax type not defined
+					if ((!isset($localtax1_type, $localtax2_type) || $localtax1_type === '' || $localtax2_type === '')
+						// if tax type not defined
 						&& (!empty($localtax1_rate) || !empty($localtax2_rate))) { // and there is local tax
 						$localtaxtmp_array = getLocalTaxesFromRate($vatrate, 0, $object->thirdparty, $mysoc);
-						$localtax1_type = isset($localtaxtmp_array[0]) ? $localtaxtmp_array[0] : '';
-						$localtax2_type = isset($localtaxtmp_array[2]) ? $localtaxtmp_array[2] : '';
+						$localtax1_type = $localtaxtmp_array[0] ?? '';
+						$localtax2_type = $localtaxtmp_array[2] ?? '';
 					}
 
 					// retrieve global local tax
-					if ($localtax1_type && $localtax1ligne != 0) {
+					if ($localtax1_type && $localtax1ligne !== 0) {
 						$this->localtax1[$localtax1_type][$localtax1_rate] += $localtax1ligne;
 					}
-					if ($localtax2_type && $localtax2ligne != 0) {
+					if ($localtax2_type && $localtax2ligne !== 0) {
 						$this->localtax2[$localtax2_type][$localtax2_rate] += $localtax2ligne;
 					}
 
-					if (($object->lines[$i]->info_bits & 0x01) == 0x01) {
+					if (($object->lines[$i]->info_bits & 0x01) === 0x01) {
 						$vatrate .= '*';
 					}
 					if (!isset($this->tva[$vatrate])) {
@@ -730,34 +825,78 @@ class pdf_standard_myobject extends ModelePDFMyObject
 					// Add line
 					if (!empty($conf->global->MAIN_PDF_DASH_BETWEEN_LINES) && $i < ($nblines - 1)) {
 						$pdf->setPage($pageposafter);
-						$pdf->SetLineStyle(array('dash'=>'1,1', 'color'=>array(80, 80, 80)));
+						$pdf->SetLineStyle(['dash' => '1,1', 'color' => [80, 80, 80]]);
 						//$pdf->SetDrawColor(190,190,200);
-						$pdf->line($this->marge_gauche, $nexY, $this->page_largeur - $this->marge_droite, $nexY);
-						$pdf->SetLineStyle(array('dash'=>0));
+						$pdf->Line($this->marge_gauche, $nexY, $this->page_largeur - $this->marge_droite, $nexY);
+						$pdf->SetLineStyle(['dash' => 0]);
 					}
 
 					// Detect if some page were added automatically and output _tableau for past pages
 					while ($pagenb < $pageposafter) {
 						$pdf->setPage($pagenb);
-						if ($pagenb == $pageposbeforeprintlines) {
-							$this->_tableau($pdf, $tab_top, $this->page_hauteur - $tab_top - $heightforfooter, 0, $outputlangs, $hidetop, 1, $object->multicurrency_code, $outputlangsbis);
+						if ($pagenb === $pageposbeforeprintlines) {
+							$this->_tableau(
+								$pdf,
+								(string) $tab_top,
+								$this->page_hauteur - $tab_top - $heightforfooter,
+								0,
+								$outputlangs,
+								$hidetop,
+								1,
+								$object->multicurrency_code,
+								$outputlangsbis
+							);
 						} else {
-							$this->_tableau($pdf, $tab_top_newpage, $this->page_hauteur - $tab_top_newpage - $heightforfooter, 0, $outputlangs, 1, 1, $object->multicurrency_code, $outputlangsbis);
+							$this->_tableau(
+								$pdf,
+								(string) $tab_top_newpage,
+								$this->page_hauteur - $tab_top_newpage - $heightforfooter,
+								0,
+								$outputlangs,
+								1,
+								1,
+								$object->multicurrency_code,
+								$outputlangsbis
+							);
 						}
 						$this->_pagefoot($pdf, $object, $outputlangs, 1);
 						$pagenb++;
 						$pdf->setPage($pagenb);
-						$pdf->setPageOrientation('', 1, 0); // The only function to edit the bottom margin of current page to set it.
+						$pdf->setPageOrientation(
+							'',
+							1,
+							0
+						); // The only function to edit the bottom margin of current page to set it.
 						if (empty($conf->global->MAIN_PDF_DONOTREPEAT_HEAD)) {
 							$this->_pagehead($pdf, $object, 0, $outputlangs);
 						}
 					}
 
 					if (isset($object->lines[$i + 1]->pagebreak) && $object->lines[$i + 1]->pagebreak) {
-						if ($pagenb == $pageposafter) {
-							$this->_tableau($pdf, $tab_top, $this->page_hauteur - $tab_top - $heightforfooter, 0, $outputlangs, $hidetop, 1, $object->multicurrency_code, $outputlangsbis);
+						if ($pagenb === $pageposafter) {
+							$this->_tableau(
+								$pdf,
+								(string) $tab_top,
+								$this->page_hauteur - $tab_top - $heightforfooter,
+								0,
+								$outputlangs,
+								$hidetop,
+								1,
+								$object->multicurrency_code,
+								$outputlangsbis
+							);
 						} else {
-							$this->_tableau($pdf, $tab_top_newpage, $this->page_hauteur - $tab_top_newpage - $heightforfooter, 0, $outputlangs, 1, 1, $object->multicurrency_code, $outputlangsbis);
+							$this->_tableau(
+								$pdf,
+								(string) $tab_top_newpage,
+								$this->page_hauteur - $tab_top_newpage - $heightforfooter,
+								0,
+								$outputlangs,
+								1,
+								1,
+								$object->multicurrency_code,
+								$outputlangsbis
+							);
 						}
 						$this->_pagefoot($pdf, $object, $outputlangs, 1);
 						// New page
@@ -773,13 +912,32 @@ class pdf_standard_myobject extends ModelePDFMyObject
 				}
 
 				// Show square
-				if ($pagenb == $pageposbeforeprintlines) {
-					$this->_tableau($pdf, $tab_top, $this->page_hauteur - $tab_top - $heightforinfotot - $heightforfreetext - $heightforfooter, 0, $outputlangs, $hidetop, 0, $object->multicurrency_code, $outputlangsbis);
-					$bottomlasttab = $this->page_hauteur - $heightforinfotot - $heightforfreetext - $heightforfooter + 1;
+				if ($pagenb === $pageposbeforeprintlines) {
+					$this->_tableau(
+						$pdf,
+						(string) $tab_top,
+						$this->page_hauteur - $tab_top - $heightforinfotot - $heightforfreetext - $heightforfooter,
+						0,
+						$outputlangs,
+						$hidetop,
+						0,
+						$object->multicurrency_code,
+						$outputlangsbis
+					);
 				} else {
-					$this->_tableau($pdf, $tab_top_newpage, $this->page_hauteur - $tab_top_newpage - $heightforinfotot - $heightforfreetext - $heightforfooter, 0, $outputlangs, 1, 0, $object->multicurrency_code, $outputlangsbis);
-					$bottomlasttab = $this->page_hauteur - $heightforinfotot - $heightforfreetext - $heightforfooter + 1;
+					$this->_tableau(
+						$pdf,
+						(string) $tab_top_newpage,
+						$this->page_hauteur - $tab_top_newpage - $heightforinfotot - $heightforfreetext - $heightforfooter,
+						0,
+						$outputlangs,
+						1,
+						0,
+						$object->multicurrency_code,
+						$outputlangsbis
+					);
 				}
+				$bottomlasttab = $this->page_hauteur - $heightforinfotot - $heightforfreetext - $heightforfooter + 1;
 
 				// Display infos area
 				//$posy = $this->drawInfoTable($pdf, $object, $bottomlasttab, $outputlangs);
@@ -789,7 +947,8 @@ class pdf_standard_myobject extends ModelePDFMyObject
 
 				// Display payment area
 				/*
-				if (($deja_regle || $amount_credit_notes_included || $amount_deposits_included) && empty($conf->global->INVOICE_NO_PAYMENT_DETAILS))
+				if (($deja_regle || $amount_credit_notes_included || $amount_deposits_included) &&
+					empty($conf->global->INVOICE_NO_PAYMENT_DETAILS))
 				{
 					$posy = $this->drawPaymentsTable($pdf, $object, $posy, $outputlangs);
 				}
@@ -806,10 +965,15 @@ class pdf_standard_myobject extends ModelePDFMyObject
 				$pdf->Output($file, 'F');
 
 				// Add pdfgeneration hook
-				$hookmanager->initHooks(array('pdfgeneration'));
-				$parameters = array('file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs);
+				$hookmanager->initHooks(['pdfgeneration']);
+				$parameters = compact('file', 'object', 'outputlangs');
 				global $action;
-				$reshook = $hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+				$reshook = $hookmanager->executeHooks(
+					'afterPDFCreation',
+					$parameters,
+					$this,
+					$action
+				); // Note that $action and $object may have been modified by some hooks
 				if ($reshook < 0) {
 					$this->error = $hookmanager->error;
 					$this->errors = $hookmanager->errors;
@@ -819,119 +983,58 @@ class pdf_standard_myobject extends ModelePDFMyObject
 					@chmod($file, octdec($conf->global->MAIN_UMASK));
 				}
 
-					$this->result = array('fullpath'=>$file);
+				$this->result = ['fullpath' => $file];
 
-					return 1; // No error
-			} else {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return 0;
+				return 1; // No error
 			}
-		} else {
-			$this->error = $langs->transnoentities("ErrorConstantNotDefined", "FAC_OUTPUTDIR");
+
+			$this->error = $langs->transnoentities('ErrorCanNotCreateDir', $dir);
 			return 0;
 		}
-	}
 
-	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
-	/**
-	 *  Return list of active generation modules
-	 *
-	 *  @param	DoliDB	$db     			Database handler
-	 *  @param  integer	$maxfilenamelength  Max length of value to show
-	 *  @return	array						List of templates
-	 */
-	public static function liste_modeles($db, $maxfilenamelength = 0)
-	{
-		// phpcs:enable
-		return parent::liste_modeles($db, $maxfilenamelength); // TODO: Change the autogenerated stub
+		$this->error = $langs->transnoentities('ErrorConstantNotDefined', 'FAC_OUTPUTDIR');
+		return 0;
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
-	/**
-	 *   Show table for lines
-	 *
-	 *   @param		tcpdf			$pdf     		Object PDF
-	 *   @param		string		$tab_top		Top position of table
-	 *   @param		string		$tab_height		Height of table (rectangle)
-	 *   @param		int			$nexY			Y (not used)
-	 *   @param		Translate	$outputlangs	Langs object
-	 *   @param		int			$hidetop		1=Hide top bar of array and title, 0=Hide nothing, -1=Hide only title
-	 *   @param		int			$hidebottom		Hide bottom bar of array
-	 *   @param		string		$currency		Currency code
-	 *   @param		Translate	$outputlangsbis	Langs object bis
-	 *   @return	void
-	 */
-	protected function _tableau(&$pdf, $tab_top, $tab_height, $nexY, $outputlangs, $hidetop = 0, $hidebottom = 0, $currency = '', $outputlangsbis = null)
-	{
-		global $conf;
 
-		// Force to disable hidetop and hidebottom
-		$hidebottom = 0;
-		if ($hidetop) {
-			$hidetop = -1;
-		}
-
-		$currency = !empty($currency) ? $currency : $conf->currency;
-		$default_font_size = pdf_getPDFFontSize($outputlangs);
-
-		// Amount in (at tab_top - 1)
-		$pdf->SetTextColor(0, 0, 0);
-		$pdf->SetFont('', '', $default_font_size - 2);
-
-		if (empty($hidetop)) {
-			$titre = $outputlangs->transnoentities("AmountInCurrency", $outputlangs->transnoentitiesnoconv("Currency".$currency));
-			if (!empty($conf->global->PDF_USE_ALSO_LANGUAGE_CODE) && is_object($outputlangsbis)) {
-				$titre .= ' - '.$outputlangsbis->transnoentities("AmountInCurrency", $outputlangsbis->transnoentitiesnoconv("Currency".$currency));
-			}
-
-			$pdf->SetXY($this->page_largeur - $this->marge_droite - ($pdf->GetStringWidth($titre) + 3), $tab_top - 4);
-			$pdf->MultiCell(($pdf->GetStringWidth($titre) + 3), 2, $titre);
-
-			//$conf->global->MAIN_PDF_TITLE_BACKGROUND_COLOR='230,230,230';
-			if (!empty($conf->global->MAIN_PDF_TITLE_BACKGROUND_COLOR)) {
-				$pdf->Rect($this->marge_gauche, $tab_top, $this->page_largeur - $this->marge_droite - $this->marge_gauche, $this->tabTitleHeight, 'F', null, explode(',', $conf->global->MAIN_PDF_TITLE_BACKGROUND_COLOR));
-			}
-		}
-
-		$pdf->SetDrawColor(128, 128, 128);
-		$pdf->SetFont('', '', $default_font_size - 1);
-
-		// Output Rect
-		$this->printRect($pdf, $this->marge_gauche, $tab_top, $this->page_largeur - $this->marge_gauche - $this->marge_droite, $tab_height, $hidetop, $hidebottom); // Rect takes a length in 3rd parameter and 4th parameter
-
-
-		$this->pdfTabTitles($pdf, $tab_top, $tab_height, $outputlangs, $hidetop);
-
-		if (empty($hidetop)) {
-			$pdf->line($this->marge_gauche, $tab_top + $this->tabTitleHeight, $this->page_largeur - $this->marge_droite, $tab_top + $this->tabTitleHeight); // line takes a position y in 2nd parameter and 4th parameter
-		}
-	}
-
-	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
 	 *  Show top header of page.
 	 *
-	 *  @param	Tcpdf			$pdf     		Object PDF
-	 *  @param  Object		$object     	Object to show
-	 *  @param  int	    	$showaddress    0=no, 1=yes
-	 *  @param  Translate	$outputlangs	Object lang for output
-	 *  @param  Translate	$outputlangsbis	Object lang for output bis
-	 *  @return	void
+	 * @param Tcpdf          $pdf            Object PDF
+	 * @param Object         $object         Object to show
+	 * @param int            $showaddress    0=no, 1=yes
+	 * @param Translate      $outputlangs    Object lang for output
+	 * @param Translate|null $outputlangsbis Object lang for output bis
+	 *
+	 * @return float|int
 	 */
-	protected function _pagehead(&$pdf, $object, $showaddress, $outputlangs, $outputlangsbis = null)
-	{
+	protected function _pagehead(
+		TCPDF $pdf,
+		object $object,
+		int $showaddress,
+		Translate $outputlangs,
+		Translate $outputlangsbis = null
+	) {
 		global $conf, $langs;
 
 		// Load traductions files required by page
-		$outputlangs->loadLangs(array("main", "bills", "propal", "companies"));
+		$outputlangs->loadLangs(['main', 'bills', 'propal', 'companies']);
 
 		$default_font_size = pdf_getPDFFontSize($outputlangs);
 
 		pdf_pagehead($pdf, $outputlangs, $this->page_hauteur);
 
 		// Show Draft Watermark
-		if ($object->statut == $object::STATUS_DRAFT && (!empty($conf->global->FACTURE_DRAFT_WATERMARK))) {
-			  pdf_watermark($pdf, $outputlangs, $this->page_hauteur, $this->page_largeur, 'mm', $conf->global->FACTURE_DRAFT_WATERMARK);
+		if ($object->statut === $object::STATUS_DRAFT && (!empty($conf->global->FACTURE_DRAFT_WATERMARK))) {
+			pdf_watermark(
+				$pdf,
+				$outputlangs,
+				$this->page_hauteur,
+				$this->page_largeur,
+				'mm',
+				$conf->global->FACTURE_DRAFT_WATERMARK
+			);
 		}
 
 		$pdf->SetTextColor(0, 0, 60);
@@ -952,9 +1055,9 @@ class pdf_standard_myobject extends ModelePDFMyObject
 					$logodir = $conf->mycompany->multidir_output[$object->entity];
 				}
 				if (empty($conf->global->MAIN_PDF_USE_LARGE_LOGO)) {
-					$logo = $logodir.'/logos/thumbs/'.$this->emetteur->logo_small;
+					$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
 				} else {
-					$logo = $logodir.'/logos/'.$this->emetteur->logo;
+					$logo = $logodir . '/logos/' . $this->emetteur->logo;
 				}
 				if (is_readable($logo)) {
 					$height = pdf_getHeightForLogo($logo);
@@ -962,8 +1065,8 @@ class pdf_standard_myobject extends ModelePDFMyObject
 				} else {
 					$pdf->SetTextColor(200, 0, 0);
 					$pdf->SetFont('', 'B', $default_font_size - 2);
-					$pdf->MultiCell($w, 3, $outputlangs->transnoentities("ErrorLogoFileNotFound", $logo), 0, 'L');
-					$pdf->MultiCell($w, 3, $outputlangs->transnoentities("ErrorGoToGlobalSetup"), 0, 'L');
+					$pdf->MultiCell($w, 3, $outputlangs->transnoentities('ErrorLogoFileNotFound', $logo), 0, 'L');
+					$pdf->MultiCell($w, 3, $outputlangs->transnoentities('ErrorGoToGlobalSetup'), 0, 'L');
 				}
 			} else {
 				$text = $this->emetteur->name;
@@ -974,10 +1077,10 @@ class pdf_standard_myobject extends ModelePDFMyObject
 		$pdf->SetFont('', 'B', $default_font_size + 3);
 		$pdf->SetXY($posx, $posy);
 		$pdf->SetTextColor(0, 0, 60);
-		$title = $outputlangs->transnoentities("PdfTitle");
+		$title = $outputlangs->transnoentities('PdfTitle');
 		if (!empty($conf->global->PDF_USE_ALSO_LANGUAGE_CODE) && is_object($outputlangsbis)) {
 			$title .= ' - ';
-			$title .= $outputlangsbis->transnoentities("PdfTitle");
+			$title .= $outputlangsbis->transnoentities('PdfTitle');
 		}
 		$pdf->MultiCell($w, 3, $title, '', 'R');
 
@@ -986,21 +1089,29 @@ class pdf_standard_myobject extends ModelePDFMyObject
 		$posy += 5;
 		$pdf->SetXY($posx, $posy);
 		$pdf->SetTextColor(0, 0, 60);
-		$textref = $outputlangs->transnoentities("Ref")." : ".$outputlangs->convToOutputCharset($object->ref);
-		if ($object->statut == $object::STATUS_DRAFT) {
+		$textref = $outputlangs->transnoentities('Ref') . ' : ' . $outputlangs->convToOutputCharset($object->ref);
+		if ($object->statut === $object::STATUS_DRAFT) {
 			$pdf->SetTextColor(128, 0, 0);
-			$textref .= ' - '.$outputlangs->transnoentities("NotValidated");
+			$textref .= ' - ' . $outputlangs->transnoentities('NotValidated');
 		}
 		$pdf->MultiCell($w, 4, $textref, '', 'R');
 
-		$posy += 1;
+		++$posy;
 		$pdf->SetFont('', '', $default_font_size - 2);
 
 		if ($object->ref_client) {
 			$posy += 4;
 			$pdf->SetXY($posx, $posy);
 			$pdf->SetTextColor(0, 0, 60);
-			$pdf->MultiCell($w, 3, $outputlangs->transnoentities("RefCustomer")." : ".$outputlangs->convToOutputCharset($object->ref_client), '', 'R');
+			$pdf->MultiCell(
+				$w,
+				3,
+				$outputlangs->transnoentities('RefCustomer') . ' : ' . $outputlangs->convToOutputCharset(
+					$object->ref_client
+				),
+				'',
+				'R'
+			);
 		}
 
 		if (!empty($conf->global->PDF_SHOW_PROJECT_TITLE)) {
@@ -1009,18 +1120,34 @@ class pdf_standard_myobject extends ModelePDFMyObject
 				$posy += 3;
 				$pdf->SetXY($posx, $posy);
 				$pdf->SetTextColor(0, 0, 60);
-				$pdf->MultiCell($w, 3, $outputlangs->transnoentities("Project")." : ".(empty($object->project->title) ? '' : $object->projet->title), '', 'R');
+				$pdf->MultiCell(
+					$w,
+					3,
+					$outputlangs->transnoentities(
+						'Project'
+					) . ' : ' . (empty($object->project->title) ? '' : $object->projet->title),
+					'',
+					'R'
+				);
 			}
 		}
 
 		if (!empty($conf->global->PDF_SHOW_PROJECT)) {
 			$object->fetch_projet();
 			if (!empty($object->project->ref)) {
-				$outputlangs->load("projects");
+				$outputlangs->load('projects');
 				$posy += 3;
 				$pdf->SetXY($posx, $posy);
 				$pdf->SetTextColor(0, 0, 60);
-				$pdf->MultiCell($w, 3, $outputlangs->transnoentities("RefProject")." : ".(empty($object->project->ref) ? '' : $object->project->ref), '', 'R');
+				$pdf->MultiCell(
+					$w,
+					3,
+					$outputlangs->transnoentities(
+						'RefProject'
+					) . ' : ' . (empty($object->project->ref) ? '' : $object->project->ref),
+					'',
+					'R'
+				);
 			}
 		}
 
@@ -1028,17 +1155,25 @@ class pdf_standard_myobject extends ModelePDFMyObject
 		$pdf->SetXY($posx, $posy);
 		$pdf->SetTextColor(0, 0, 60);
 
-		$title = $outputlangs->transnoentities("Date");
+		$title = $outputlangs->transnoentities('Date');
 		if (!empty($conf->global->PDF_USE_ALSO_LANGUAGE_CODE) && is_object($outputlangsbis)) {
-			$title .= ' - '.$outputlangsbis->transnoentities("Date");
+			$title .= ' - ' . $outputlangsbis->transnoentities('Date');
 		}
-		$pdf->MultiCell($w, 3, $title." : ".dol_print_date($object->date, "day", false, $outputlangs), '', 'R');
+		$pdf->MultiCell($w, 3, $title . ' : ' . dol_print_date($object->date, 'day', false, $outputlangs), '', 'R');
 
 		if ($object->thirdparty->code_client) {
 			$posy += 3;
 			$pdf->SetXY($posx, $posy);
 			$pdf->SetTextColor(0, 0, 60);
-			$pdf->MultiCell($w, 3, $outputlangs->transnoentities("CustomerCode")." : ".$outputlangs->transnoentities($object->thirdparty->code_client), '', 'R');
+			$pdf->MultiCell(
+				$w,
+				3,
+				$outputlangs->transnoentities('CustomerCode') . ' : ' . $outputlangs->transnoentities(
+					$object->thirdparty->code_client
+				),
+				'',
+				'R'
+			);
 		}
 
 		// Get contact
@@ -1050,23 +1185,37 @@ class pdf_standard_myobject extends ModelePDFMyObject
 				$posy += 4;
 				$pdf->SetXY($posx, $posy);
 				$pdf->SetTextColor(0, 0, 60);
-				$pdf->MultiCell($w, 3, $langs->transnoentities("SalesRepresentative")." : ".$usertmp->getFullName($langs), '', 'R');
+				$pdf->MultiCell(
+					$w,
+					3,
+					$langs->transnoentities('SalesRepresentative') . ' : ' . $usertmp->getFullName($langs),
+					'',
+					'R'
+				);
 			}
 		}
 
-		$posy += 1;
+		++$posy;
 
 		$top_shift = 0;
 		// Show list of linked objects
-		$current_y = $pdf->getY();
+		$current_y = $pdf->GetY();
 		$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, $w, 3, 'R', $default_font_size);
-		if ($current_y < $pdf->getY()) {
-			$top_shift = $pdf->getY() - $current_y;
+		if ($current_y < $pdf->GetY()) {
+			$top_shift = $pdf->GetY() - $current_y;
 		}
 
 		if ($showaddress) {
 			// Sender properties
-			$carac_emetteur = pdf_build_address($outputlangs, $this->emetteur, $object->thirdparty, '', 0, 'source', $object);
+			$carac_emetteur = pdf_build_address(
+				$outputlangs,
+				$this->emetteur,
+				$object->thirdparty,
+				'',
+				0,
+				'source',
+				$object
+			);
 
 			// Show sender
 			$posy = !empty($conf->global->MAIN_PDF_USE_ISO_LOCATION) ? 40 : 42;
@@ -1084,17 +1233,17 @@ class pdf_standard_myobject extends ModelePDFMyObject
 			$pdf->SetTextColor(0, 0, 0);
 			$pdf->SetFont('', '', $default_font_size - 2);
 			$pdf->SetXY($posx, $posy - 5);
-			$pdf->MultiCell(66, 5, $outputlangs->transnoentities("BillFrom").":", 0, 'L');
+			$pdf->MultiCell(66, 5, $outputlangs->transnoentities('BillFrom') . ':', 0, 'L');
 			$pdf->SetXY($posx, $posy);
 			$pdf->SetFillColor(230, 230, 230);
-			$pdf->MultiCell($widthrecbox, $hautcadre, "", 0, 'R', 1);
+			$pdf->MultiCell($widthrecbox, $hautcadre, '', 0, 'R', 1);
 			$pdf->SetTextColor(0, 0, 60);
 
 			// Show sender name
 			$pdf->SetXY($posx + 2, $posy + 3);
 			$pdf->SetFont('', 'B', $default_font_size);
 			$pdf->MultiCell($widthrecbox - 2, 4, $outputlangs->convToOutputCharset($this->emetteur->name), 0, 'L');
-			$posy = $pdf->getY();
+			$posy = $pdf->GetY();
 
 			// Show sender information
 			$pdf->SetXY($posx + 2, $posy);
@@ -1110,7 +1259,9 @@ class pdf_standard_myobject extends ModelePDFMyObject
 			}
 
 			// Recipient name
-			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
+			if ($object->contact->socid !== $object->thirdparty->id && (!isset(
+						$conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT
+					) || !empty($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT))) {
 				$thirdparty = $object->contact;
 			} else {
 				$thirdparty = $object->thirdparty;
@@ -1120,7 +1271,15 @@ class pdf_standard_myobject extends ModelePDFMyObject
 				$carac_client_name = pdfBuildThirdpartyName($thirdparty, $outputlangs);
 			}
 
-			$carac_client = pdf_build_address($outputlangs, $this->emetteur, $object->thirdparty, ($usecontact ? $object->contact : ''), $usecontact, 'target', $object);
+			$carac_client = pdf_build_address(
+				$outputlangs,
+				$this->emetteur,
+				$object->thirdparty,
+				($usecontact ? $object->contact : ''),
+				$usecontact,
+				'target',
+				$object
+			);
 
 			// Show recipient
 			$widthrecbox = !empty($conf->global->MAIN_PDF_USE_ISO_LOCATION) ? 92 : 100;
@@ -1138,7 +1297,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 			$pdf->SetTextColor(0, 0, 0);
 			$pdf->SetFont('', '', $default_font_size - 2);
 			$pdf->SetXY($posx + 2, $posy - 5);
-			$pdf->MultiCell($widthrecbox, 5, $outputlangs->transnoentities("BillTo").":", 0, 'L');
+			$pdf->MultiCell($widthrecbox, 5, $outputlangs->transnoentities('BillTo') . ':', 0, 'L');
 			$pdf->Rect($posx, $posy, $widthrecbox, $hautcadre);
 
 			// Show recipient name
@@ -1146,7 +1305,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 			$pdf->SetFont('', 'B', $default_font_size);
 			$pdf->MultiCell($widthrecbox, 2, $carac_client_name, 0, 'L');
 
-			$posy = $pdf->getY();
+			$posy = $pdf->GetY();
 
 			// Show recipient information
 			$pdf->SetFont('', '', $default_font_size - 1);
@@ -1159,47 +1318,168 @@ class pdf_standard_myobject extends ModelePDFMyObject
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
+
 	/**
-	 *   	Show footer of page. Need this->emetteur object
+	 *    Show footer of page. Need this->emetteur object
 	 *
-	 *   	@param	TCPDF		$pdf     			PDF
-	 * 		@param	Object		$object				Object to show
-	 *      @param	Translate	$outputlangs		Object lang for output
-	 *      @param	int			$hidefreetext		1=Hide free text
-	 *      @return	int								Return height of bottom margin including footer text
+	 * @param TCPDF     $pdf          PDF
+	 * @param Object    $object       Object to show
+	 * @param Translate $outputlangs  Object lang for output
+	 * @param int       $hidefreetext 1=Hide free text
+	 *
+	 * @return    int                                Return height of bottom margin including footer text
 	 */
-	protected function _pagefoot(&$pdf, $object, $outputlangs, $hidefreetext = 0)
+	protected function _pagefoot(TCPDF $pdf, object $object, Translate $outputlangs, int $hidefreetext = 0): int
 	{
 		global $conf;
 		$showdetails = empty($conf->global->MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS) ? 0 : $conf->global->MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS;
-		return pdf_pagefoot($pdf, $outputlangs, 'INVOICE_FREE_TEXT', $this->emetteur, $this->marge_basse, $this->marge_gauche, $this->page_hauteur, $object, $showdetails, $hidefreetext);
+		return pdf_pagefoot(
+			$pdf,
+			$outputlangs,
+			'INVOICE_FREE_TEXT',
+			$this->emetteur,
+			$this->marge_basse,
+			$this->marge_gauche,
+			$this->page_hauteur,
+			$object,
+			$showdetails,
+			$hidefreetext
+		);
+	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
+
+	/**
+	 *   Show table for lines
+	 *
+	 * @param tcpdf          $pdf            Object PDF
+	 * @param string         $tab_top        Top position of table
+	 * @param string         $tab_height     Height of table (rectangle)
+	 * @param int            $nexY           Y (not used)
+	 * @param Translate      $outputlangs    Langs object
+	 * @param int            $hidetop        1=Hide top bar of array and title, 0=Hide nothing, -1=Hide only title
+	 * @param int            $hidebottom     Hide bottom bar of array
+	 * @param string         $currency       Currency code
+	 * @param Translate|null $outputlangsbis Langs object bis
+	 *
+	 * @return    void
+	 */
+	protected function _tableau(
+		TCPDF $pdf,
+		string $tab_top,
+		string $tab_height,
+		int $nexY,
+		Translate $outputlangs,
+		int $hidetop = 0,
+		int $hidebottom = 0,
+		string $currency = '',
+		Translate $outputlangsbis = null
+	): void {
+		global $conf;
+
+		// Force disabling hidetop and hidebottom
+		$hidebottom = 0;
+		if ($hidetop) {
+			$hidetop = -1;
+		}
+
+		$currency = !empty($currency) ? $currency : $conf->currency;
+		$default_font_size = pdf_getPDFFontSize($outputlangs);
+
+		// Amount in (at tab_top - 1)
+		$pdf->SetTextColor(0, 0, 0);
+		$pdf->SetFont('', '', $default_font_size - 2);
+
+		if (empty($hidetop)) {
+			$titre = $outputlangs->transnoentities(
+				'AmountInCurrency',
+				$outputlangs->transnoentitiesnoconv('Currency' . $currency)
+			);
+			if (!empty($conf->global->PDF_USE_ALSO_LANGUAGE_CODE) && is_object($outputlangsbis)) {
+				$titre .= ' - ' . $outputlangsbis->transnoentities(
+						'AmountInCurrency',
+						$outputlangsbis->transnoentitiesnoconv(
+							'Currency' . $currency
+						)
+					);
+			}
+
+			$pdf->SetXY($this->page_largeur - $this->marge_droite - ($pdf->GetStringWidth($titre) + 3), $tab_top - 4);
+			$pdf->MultiCell(($pdf->GetStringWidth($titre) + 3), 2, $titre);
+
+			//$conf->global->MAIN_PDF_TITLE_BACKGROUND_COLOR='230,230,230';
+			if (!empty($conf->global->MAIN_PDF_TITLE_BACKGROUND_COLOR)) {
+				$pdf->Rect(
+					$this->marge_gauche,
+					$tab_top,
+					$this->page_largeur - $this->marge_droite - $this->marge_gauche,
+					$this->tabTitleHeight,
+					'F',
+					null,
+					explode(',', $conf->global->MAIN_PDF_TITLE_BACKGROUND_COLOR)
+				);
+			}
+		}
+
+		$pdf->SetDrawColor(128, 128, 128);
+		$pdf->SetFont('', '', $default_font_size - 1);
+
+		// Output Rect
+		$this->printRect(
+			$pdf,
+			$this->marge_gauche,
+			$tab_top,
+			$this->page_largeur - $this->marge_gauche - $this->marge_droite,
+			$tab_height,
+			$hidetop,
+			$hidebottom
+		);
+		// Rect takes a length in 3rd parameter and 4th parameter
+
+
+		$this->pdfTabTitles($pdf, $tab_top, $tab_height, $outputlangs, $hidetop);
+
+		if (empty($hidetop)) {
+			$pdf->Line(
+				$this->marge_gauche,
+				$tab_top + $this->tabTitleHeight,
+				$this->page_largeur - $this->marge_droite,
+				$tab_top + $this->tabTitleHeight
+			); // line takes a position y in 2nd parameter and 4th parameter
+		}
 	}
 
 	/**
 	 *  Define Array Column Field
 	 *
-	 *  @param	object			$object    		common object
-	 *  @param	Translate		$outputlangs    langs
-	 *  @param	int			   $hidedetails		Do not show line details
-	 *  @param	int			   $hidedesc		Do not show desc
-	 *  @param	int			   $hideref			Do not show ref
-	 *  @return	null
+	 * @param object    $object      common object
+	 * @param Translate $outputlangs langs
+	 * @param int       $hidedetails Do not show line details
+	 * @param int       $hidedesc    Do not show desc
+	 * @param int       $hideref     Do not show ref
+	 *
+	 * @return void
 	 */
-	public function defineColumnField($object, $outputlangs, $hidedetails = 0, $hidedesc = 0, $hideref = 0)
-	{
+	public function defineColumnField(
+		object $object,
+		Translate $outputlangs,
+		int $hidedetails = 0,
+		int $hidedesc = 0,
+		int $hideref = 0
+	): void {
 		global $conf, $hookmanager;
 
 		// Default field style for content
-		$this->defaultContentsFieldsStyle = array(
+		$this->defaultContentsFieldsStyle = [
 			'align' => 'R', // R,C,L
-			'padding' => array(1, 0.5, 1, 0.5), // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
-		);
+			'padding' => [1, 0.5, 1, 0.5], // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
+		];
 
 		// Default field style for content
-		$this->defaultTitlesFieldsStyle = array(
+		$this->defaultTitlesFieldsStyle = [
 			'align' => 'C', // R,C,L
-			'padding' => array(0.5, 0, 0.5, 0), // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
-		);
+			'padding' => [0.5, 0, 0.5, 0], // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
+		];
 
 		/*
 		 * For exemple
@@ -1220,134 +1500,136 @@ class pdf_standard_myobject extends ModelePDFMyObject
 		*/
 
 		$rank = 0; // do not use negative rank
-		$this->cols['desc'] = array(
+		$this->cols['desc'] = [
 			'rank' => $rank,
 			'width' => false, // only for desc
 			'status' => true,
-			'title' => array(
+			'title' => [
 				'textkey' => 'Designation', // use lang key is usefull in somme case with module
 				'align' => 'L',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
-				'padding' => array(0.5, 0.5, 0.5, 0.5), // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
-			),
-			'content' => array(
+				'padding' => [0.5, 0.5, 0.5, 0.5], // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
+			],
+			'content' => [
 				'align' => 'L',
-				'padding' => array(1, 0.5, 1, 1.5), // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
-			),
-		);
+				'padding' => [1, 0.5, 1, 1.5], // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
+			],
+		];
 
 		// PHOTO
-		$rank = $rank + 10;
-		$this->cols['photo'] = array(
+		$rank += 10;
+		$this->cols['photo'] = [
 			'rank' => $rank,
-			'width' => (empty($conf->global->MAIN_DOCUMENTS_WITH_PICTURE_WIDTH) ? 20 : $conf->global->MAIN_DOCUMENTS_WITH_PICTURE_WIDTH), // in mm
+			'width' => (empty($conf->global->MAIN_DOCUMENTS_WITH_PICTURE_WIDTH) ? 20 : $conf->global->MAIN_DOCUMENTS_WITH_PICTURE_WIDTH),
+			// in mm
 			'status' => false,
-			'title' => array(
+			'title' => [
 				'textkey' => 'Photo',
 				'label' => ' '
-			),
-			'content' => array(
-				'padding' => array(0, 0, 0, 0), // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
-			),
-			'border-left' => false, // remove left line separator
-		);
+			],
+			'content' => [
+				'padding' => [0, 0, 0, 0], // Like css 0 => top , 1 => right, 2 => bottom, 3 => left
+			],
+			'border-left' => false,
+			// remove left line separator
+		];
 
 		if (!empty($conf->global->MAIN_GENERATE_INVOICES_WITH_PICTURE) && !empty($this->atleastonephoto)) {
 			$this->cols['photo']['status'] = true;
 		}
 
 
-		$rank = $rank + 10;
-		$this->cols['vat'] = array(
+		$rank += 10;
+		$this->cols['vat'] = [
 			'rank' => $rank,
 			'status' => false,
 			'width' => 16, // in mm
-			'title' => array(
+			'title' => [
 				'textkey' => 'VAT'
-			),
+			],
 			'border-left' => true, // add left line separator
-		);
+		];
 
 		if (empty($conf->global->MAIN_GENERATE_DOCUMENTS_WITHOUT_VAT) && empty($conf->global->MAIN_GENERATE_DOCUMENTS_WITHOUT_VAT_COLUMN)) {
 			$this->cols['vat']['status'] = true;
 		}
 
-		$rank = $rank + 10;
-		$this->cols['subprice'] = array(
+		$rank += 10;
+		$this->cols['subprice'] = [
 			'rank' => $rank,
 			'width' => 19, // in mm
 			'status' => true,
-			'title' => array(
+			'title' => [
 				'textkey' => 'PriceUHT'
-			),
+			],
 			'border-left' => true, // add left line separator
-		);
+		];
 
-		$rank = $rank + 10;
-		$this->cols['qty'] = array(
+		$rank += 10;
+		$this->cols['qty'] = [
 			'rank' => $rank,
 			'width' => 16, // in mm
 			'status' => true,
-			'title' => array(
+			'title' => [
 				'textkey' => 'Qty'
-			),
+			],
 			'border-left' => true, // add left line separator
-		);
+		];
 
-		$rank = $rank + 10;
-		$this->cols['progress'] = array(
+		$rank += 10;
+		$this->cols['progress'] = [
 			'rank' => $rank,
 			'width' => 19, // in mm
 			'status' => false,
-			'title' => array(
+			'title' => [
 				'textkey' => 'Progress'
-			),
+			],
 			'border-left' => true, // add left line separator
-		);
+		];
 
 		if ($this->situationinvoice) {
 			$this->cols['progress']['status'] = true;
 		}
 
-		$rank = $rank + 10;
-		$this->cols['unit'] = array(
+		$rank += 10;
+		$this->cols['unit'] = [
 			'rank' => $rank,
 			'width' => 11, // in mm
 			'status' => false,
-			'title' => array(
+			'title' => [
 				'textkey' => 'Unit'
-			),
+			],
 			'border-left' => true, // add left line separator
-		);
+		];
 		if (!empty($conf->global->PRODUCT_USE_UNITS)) {
 			$this->cols['unit']['status'] = true;
 		}
 
-		$rank = $rank + 10;
-		$this->cols['discount'] = array(
+		$rank += 10;
+		$this->cols['discount'] = [
 			'rank' => $rank,
 			'width' => 13, // in mm
 			'status' => false,
-			'title' => array(
+			'title' => [
 				'textkey' => 'ReductionShort'
-			),
+			],
 			'border-left' => true, // add left line separator
-		);
+		];
 		if ($this->atleastonediscount) {
 			$this->cols['discount']['status'] = true;
 		}
 
-		$rank = $rank + 1000; // add a big offset to be sure is the last col because default extrafield rank is 100
-		$this->cols['totalexcltax'] = array(
+		$rank += 1000; // add a big offset to be sure is the last col because default extrafield rank is 100
+		$this->cols['totalexcltax'] = [
 			'rank' => $rank,
 			'width' => 26, // in mm
 			'status' => true,
-			'title' => array(
+			'title' => [
 				'textkey' => 'TotalHT'
-			),
+			],
 			'border-left' => true, // add left line separator
-		);
+		];
 
 		// Add extrafields cols
 		if (!empty($object->lines)) {
@@ -1355,15 +1637,13 @@ class pdf_standard_myobject extends ModelePDFMyObject
 			$this->defineColumnExtrafield($line, $outputlangs, $hidedetails);
 		}
 
-		$parameters = array(
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'hidedetails' => $hidedetails,
-			'hidedesc' => $hidedesc,
-			'hideref' => $hideref
-		);
+		$parameters = compact('object', 'outputlangs', 'hidedetails', 'hidedesc', 'hideref');
 
-		$reshook = $hookmanager->executeHooks('defineColumnField', $parameters, $this); // Note that $object may have been modified by hook
+		$reshook = $hookmanager->executeHooks(
+			'defineColumnField',
+			$parameters,
+			$this
+		); // Note that $object may have been modified by hook
 		if ($reshook < 0) {
 			setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 		} elseif (empty($reshook)) {

--- a/htdocs/modulebuilder/template/core/modules/mymodule/mod_myobject_advanced.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/mod_myobject_advanced.php
@@ -26,29 +26,32 @@
  * \brief      File containing class for advanced numbering model of MyObject
  */
 
+declare(strict_types=1);
+
 dol_include_once('/mymodule/core/modules/mymodule/modules_myobject.php');
 
 
 /**
- *	Class to manage customer Bom numbering rules advanced
+ *    Class to manage customer Bom numbering rules advanced
  */
 class mod_myobject_advanced extends ModeleNumRefMyObject
 {
 	/**
 	 * Dolibarr version of the loaded document
+	 *
 	 * @var string
 	 */
-	public $version = 'dolibarr'; // 'development', 'experimental', 'dolibarr'
+	public string $version = 'dolibarr'; // 'development', 'experimental', 'dolibarr'
 
 	/**
 	 * @var string Error message
 	 */
-	public $error = '';
+	public string $error = '';
 
 	/**
 	 * @var string name
 	 */
-	public $name = 'advanced';
+	public string $name = 'advanced';
 
 
 	/**
@@ -56,32 +59,52 @@ class mod_myobject_advanced extends ModeleNumRefMyObject
 	 *
 	 *  @return     string      Texte descripif
 	 */
-	public function info()
+	public function info(): string
 	{
 		global $conf, $langs, $db;
 
-		$langs->load("bills");
+		$langs->load('bills');
 
 		$form = new Form($db);
 
-		$texte = $langs->trans('GenericNumRefModelDesc')."<br>\n";
-		$texte .= '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
-		$texte .= '<input type="hidden" name="token" value="'.newToken().'">';
+		$texte = $langs->trans('GenericNumRefModelDesc') . "<br>\n";
+		$texte .= '<form action="' . $_SERVER['PHP_SELF'] . '" method="POST">';
+		$texte .= '<input type="hidden" name="token" value="' . newToken() . '">';
 		$texte .= '<input type="hidden" name="action" value="updateMask">';
 		$texte .= '<input type="hidden" name="maskconstBom" value="MYMODULE_MYOBJECT_ADVANCED_MASK">';
-		$texte .= '<table class="nobordernopadding" width="100%">';
+		$texte .= '<table class="nobordernopadding">';
 
-		$tooltip = $langs->trans("GenericMaskCodes", $langs->transnoentities("MyObject"), $langs->transnoentities("MyObject"));
-		$tooltip .= $langs->trans("GenericMaskCodes2");
-		$tooltip .= $langs->trans("GenericMaskCodes3");
-		$tooltip .= $langs->trans("GenericMaskCodes4a", $langs->transnoentities("MyObject"), $langs->transnoentities("MyObject"));
-		$tooltip .= $langs->trans("GenericMaskCodes5");
+		$tooltip = $langs->trans(
+			'GenericMaskCodes',
+			$langs->transnoentities('MyObject'),
+			$langs->transnoentities(
+				'MyObject'
+			)
+		);
+		$tooltip .= $langs->trans('GenericMaskCodes2');
+		$tooltip .= $langs->trans('GenericMaskCodes3');
+		$tooltip .= $langs->trans(
+			'GenericMaskCodes4a',
+			$langs->transnoentities('MyObject'),
+			$langs->transnoentities(
+				'MyObject'
+			)
+		);
+		$tooltip .= $langs->trans('GenericMaskCodes5');
 
 		// Parametrage du prefix
-		$texte .= '<tr><td>'.$langs->trans("Mask").':</td>';
-		$texte .= '<td class="right">'.$form->textwithpicto('<input type="text" class="flat minwidth175" name="maskMyObject" value="'.$conf->global->MYMODULE_MYOBJECT_ADVANCED_MASK.'">', $tooltip, 1, 1).'</td>';
+		$texte .= '<tr><td>' . $langs->trans('Mask') . ':</td>';
+		$texte .= '<td class="right">' . $form->textwithpicto(
+				'<input type="text" class="flat minwidth175" name="maskMyObject"
+						value="' . $conf->global->MYMODULE_MYOBJECT_ADVANCED_MASK . '">',
+				$tooltip,
+				1,
+				1
+			) . '</td>';
 
-		$texte .= '<td class="left" rowspan="2">&nbsp; <input type="submit" class="button button-edit" name="Button"value="'.$langs->trans("Modify").'"></td>';
+		$texte .= '<td class="left" rowspan="2">&nbsp;
+					<input type="submit" class="button button-edit" name="Button"
+					value="' . $langs->trans('Modify') . '"></td>';
 
 		$texte .= '</tr>';
 
@@ -122,10 +145,11 @@ class mod_myobject_advanced extends ModeleNumRefMyObject
 	/**
 	 * 	Return next free value
 	 *
-	 *  @param  Object		$object		Object we need next value for
+	 *  @param Object $object Object we need next value for
+	 *
 	 *  @return string      			Value if KO, <0 if KO
 	 */
-	public function getNextValue($object)
+	public function getNextValue(Object $object)
 	{
 		global $db, $conf;
 

--- a/htdocs/modulebuilder/template/core/modules/mymodule/mod_myobject_standard.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/mod_myobject_standard.php
@@ -22,21 +22,23 @@
  *  \ingroup    mymodule
  *  \brief      File of class to manage MyObject numbering rules standard
  */
+declare(strict_types=1);
+
 dol_include_once('/mymodule/core/modules/mymodule/modules_myobject.php');
 
-
 /**
- *	Class to manage customer order numbering rules standard
+ *    Class to manage customer order numbering rules standard
  */
 class mod_myobject_standard extends ModeleNumRefMyObject
 {
 	/**
 	 * Dolibarr version of the loaded document
+	 *
 	 * @var string
 	 */
-	public $version = 'dolibarr'; // 'development', 'experimental', 'dolibarr'
+	public string $version = 'dolibarr'; // 'development', 'experimental', 'dolibarr'
 
-	public $prefix = 'MYOBJECT';
+	public string $prefix = 'MYOBJECT';
 
 	/**
 	 * @var string Error code (or message)
@@ -46,7 +48,7 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 	/**
 	 * @var string name
 	 */
-	public $name = 'standard';
+	public string $name = 'standard';
 
 
 	/**
@@ -54,10 +56,10 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 	 *
 	 *  @return     string      Text with description
 	 */
-	public function info()
+	public function info(): string
 	{
 		global $langs;
-		return $langs->trans("SimpleNumRefModelDesc", $this->prefix);
+		return $langs->trans('SimpleNumRefModelDesc', $this->prefix);
 	}
 
 
@@ -66,9 +68,9 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 	 *
 	 *  @return     string      Example
 	 */
-	public function getExample()
+	public function getExample(): string
 	{
-		return $this->prefix."0501-0001";
+		return $this->prefix . '0501-0001';
 	}
 
 
@@ -76,22 +78,24 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 	 *  Checks if the numbers already in the database do not
 	 *  cause conflicts that would prevent this numbering working.
 	 *
-	 *  @param  Object		$object		Object we need next value for
-	 *  @return boolean     			false if conflict, true if ok
+	 * @param Object $object Object we need next value for
+	 *
+	 * @return bool                false if conflicted, true if ok
 	 */
-	public function canBeActivated($object)
+	public function canBeActivated(Object $object): bool
 	{
 		global $conf, $langs, $db;
 
-		$coyymm = ''; $max = '';
+		$coyymm = '';
+		$max = '';
 
 		$posindice = strlen($this->prefix) + 6;
-		$sql = "SELECT MAX(CAST(SUBSTRING(ref FROM ".$posindice.") AS SIGNED)) as max";
-		$sql .= " FROM ".MAIN_DB_PREFIX."mymodule_myobject";
-		$sql .= " WHERE ref LIKE '".$db->escape($this->prefix)."____-%'";
-		if ($object->ismultientitymanaged == 1) {
-			$sql .= " AND entity = ".$conf->entity;
-		} elseif ($object->ismultientitymanaged == 2) {
+		$sql = 'SELECT MAX(CAST(SUBSTRING(ref FROM ' . $posindice . ') AS SIGNED)) as max';
+		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'mymodule_myobject';
+		$sql .= " WHERE ref LIKE '" . $db->escape($this->prefix) . "____-%'";
+		if ($object->ismultientitymanaged === 1) {
+			$sql .= ' AND entity = ' . $conf->entity;
+		} elseif ($object->ismultientitymanaged === 2) {
 			// TODO
 		}
 
@@ -99,11 +103,12 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 		if ($resql) {
 			$row = $db->fetch_row($resql);
 			if ($row) {
-				$coyymm = substr($row[0], 0, 6); $max = $row[0];
+				$coyymm = substr($row[0], 0, 6);
+				$max = $row[0];
 			}
 		}
 		if ($coyymm && !preg_match('/'.$this->prefix.'[0-9][0-9][0-9][0-9]/i', $coyymm)) {
-			$langs->load("errors");
+			$langs->load('errors');
 			$this->error = $langs->trans('ErrorNumRefModel', $max);
 			return false;
 		}
@@ -112,23 +117,25 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 	}
 
 	/**
-	 * 	Return next free value
+	 *    Return next free value
 	 *
-	 *  @param  Object		$object		Object we need next value for
-	 *  @return string      			Value if KO, <0 if KO
+	 * @param Object $object Object we need next value for
+	 *
+	 * @return string                Value if KO, <0 if KO
+	 * @throws Exception
 	 */
-	public function getNextValue($object)
+	public function getNextValue(object $object)
 	{
 		global $db, $conf;
 
 		// first we get the max value
 		$posindice = strlen($this->prefix) + 6;
-		$sql = "SELECT MAX(CAST(SUBSTRING(ref FROM ".$posindice.") AS SIGNED)) as max";
-		$sql .= " FROM ".MAIN_DB_PREFIX."mymodule_myobject";
-		$sql .= " WHERE ref LIKE '".$db->escape($this->prefix)."____-%'";
-		if ($object->ismultientitymanaged == 1) {
-			$sql .= " AND entity = ".$conf->entity;
-		} elseif ($object->ismultientitymanaged == 2) {
+		$sql = 'SELECT MAX(CAST(SUBSTRING(ref FROM ' . $posindice . ') AS SIGNED)) as max';
+		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'mymodule_myobject';
+		$sql .= " WHERE ref LIKE '" . $db->escape($this->prefix) . "____-%'";
+		if ($object->ismultientitymanaged === 1) {
+			$sql .= ' AND entity = ' . $conf->entity;
+		} elseif ($object->ismultientitymanaged === 2) {
 			// TODO
 		}
 
@@ -136,26 +143,26 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 		if ($resql) {
 			$obj = $db->fetch_object($resql);
 			if ($obj) {
-				$max = intval($obj->max);
+				$max = (int) $obj->max;
 			} else {
 				$max = 0;
 			}
 		} else {
-			dol_syslog("mod_myobject_standard::getNextValue", LOG_DEBUG);
+			dol_syslog('mod_myobject_standard::getNextValue', LOG_DEBUG);
 			return -1;
 		}
 
 		//$date=time();
 		$date = $object->date_creation;
-		$yymm = strftime("%y%m", $date);
+		$yymm = strftime('%y%m', $date);
 
-		if ($max >= (pow(10, 4) - 1)) {
+		if ($max >= ((10 ** 4) - 1)) {
 			$num = $max + 1; // If counter > 9999, we do not format on 4 chars, we take number as it is
 		} else {
-			$num = sprintf("%04s", $max + 1);
+			$num = sprintf('%04s', $max + 1);
 		}
 
-		dol_syslog("mod_myobject_standard::getNextValue return ".$this->prefix.$yymm."-".$num);
-		return $this->prefix.$yymm."-".$num;
+		dol_syslog('mod_myobject_standard::getNextValue return ' . $this->prefix . $yymm . '-' . $num);
+		return $this->prefix . $yymm . '-' . $num;
 	}
 }

--- a/htdocs/modulebuilder/template/core/modules/mymodule/mod_myobject_standard.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/mod_myobject_standard.php
@@ -90,12 +90,12 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 		$max = '';
 
 		$posindice = strlen($this->prefix) + 6;
-		$sql = 'SELECT MAX(CAST(SUBSTRING(ref FROM ' . $posindice . ') AS SIGNED)) as max';
-		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'mymodule_myobject';
-		$sql .= ' WHERE ref LIKE "' . $db->escape($this->prefix) . '____-%"';
-		if ($object->ismultientitymanaged === 1) {
-			$sql .= ' AND entity = ' . $conf->entity;
-		} elseif ($object->ismultientitymanaged === 2) {
+		$sql = "SELECT MAX(CAST(SUBSTRING(ref FROM ".$posindice.") AS SIGNED)) as max";
+		$sql .= " FROM ".MAIN_DB_PREFIX."mymodule_myobject";
+		$sql .= " WHERE ref LIKE '".$db->escape($this->prefix)."____-%'";
+		if ($object->ismultientitymanaged == 1) {
+			$sql .= " AND entity = ".$conf->entity;
+		} elseif ($object->ismultientitymanaged == 2) {
 			// TODO
 		}
 
@@ -130,12 +130,12 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 
 		// first we get the max value
 		$posindice = strlen($this->prefix) + 6;
-		$sql = 'SELECT MAX(CAST(SUBSTRING(ref FROM ' . $posindice . ') AS SIGNED)) as max';
-		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'mymodule_myobject';
-		$sql .= ' WHERE ref LIKE "' . $db->escape($this->prefix) . '____-%"';
-		if ($object->ismultientitymanaged === 1) {
-			$sql .= ' AND entity = ' . $conf->entity;
-		} elseif ($object->ismultientitymanaged === 2) {
+		$sql = "SELECT MAX(CAST(SUBSTRING(ref FROM ".$posindice.") AS SIGNED)) as max";
+		$sql .= " FROM ".MAIN_DB_PREFIX."mymodule_myobject";
+		$sql .= " WHERE ref LIKE '".$db->escape($this->prefix)."____-%'";
+		if ($object->ismultientitymanaged == 1) {
+			$sql .= " AND entity = ".$conf->entity;
+		} elseif ($object->ismultientitymanaged == 2) {
 			// TODO
 		}
 

--- a/htdocs/modulebuilder/template/core/modules/mymodule/mod_myobject_standard.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/mod_myobject_standard.php
@@ -92,7 +92,7 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 		$posindice = strlen($this->prefix) + 6;
 		$sql = 'SELECT MAX(CAST(SUBSTRING(ref FROM ' . $posindice . ') AS SIGNED)) as max';
 		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'mymodule_myobject';
-		$sql .= " WHERE ref LIKE '" . $db->escape($this->prefix) . "____-%'";
+		$sql .= ' WHERE ref LIKE "' . $db->escape($this->prefix) . '____-%"';
 		if ($object->ismultientitymanaged === 1) {
 			$sql .= ' AND entity = ' . $conf->entity;
 		} elseif ($object->ismultientitymanaged === 2) {
@@ -132,7 +132,7 @@ class mod_myobject_standard extends ModeleNumRefMyObject
 		$posindice = strlen($this->prefix) + 6;
 		$sql = 'SELECT MAX(CAST(SUBSTRING(ref FROM ' . $posindice . ') AS SIGNED)) as max';
 		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'mymodule_myobject';
-		$sql .= " WHERE ref LIKE '" . $db->escape($this->prefix) . "____-%'";
+		$sql .= ' WHERE ref LIKE "' . $db->escape($this->prefix) . '____-%"';
 		if ($object->ismultientitymanaged === 1) {
 			$sql .= ' AND entity = ' . $conf->entity;
 		} elseif ($object->ismultientitymanaged === 2) {

--- a/htdocs/modulebuilder/template/core/modules/mymodule/modules_myobject.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/modules_myobject.php
@@ -23,17 +23,20 @@
  */
 
 /**
- *  \file			htdocs/core/modules/mymodule/modules_myobject.php
- *  \ingroup		mymodule
- *  \brief			File that contains parent class for myobjects document models and parent class for myobjects numbering models
+ *  \file            htdocs/core/modules/mymodule/modules_myobject.php
+ *  \ingroup        mymodule
+ *  \brief            File that contains parent class for myobjects document models
+ *                    and parent class for myobjects numbering models
  */
 
-require_once DOL_DOCUMENT_ROOT.'/core/class/commondocgenerator.class.php';
-require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php'; // required for use by classes that inherit
+declare(strict_types=1);
+
+require_once DOL_DOCUMENT_ROOT . '/core/class/commondocgenerator.class.php';
+require_once DOL_DOCUMENT_ROOT . '/compta/bank/class/account.class.php'; // required for use by classes that inherit
 
 
 /**
- *	Parent class for documents models
+ *    Parent class for documents models
  */
 abstract class ModelePDFMyObject extends CommonDocGenerator
 {
@@ -42,19 +45,20 @@ abstract class ModelePDFMyObject extends CommonDocGenerator
 	/**
 	 *  Return list of active generation modules
 	 *
-	 *  @param	DoliDB	$db     			Database handler
-	 *  @param  integer	$maxfilenamelength  Max length of value to show
-	 *  @return	array						List of templates
+	 * @param DoliDB $db                Database handler
+	 * @param int    $maxfilenamelength Max length of value to show
+	 *
+	 * @return    array                        List of templates
 	 */
-	public static function liste_modeles($db, $maxfilenamelength = 0)
+	public static function liste_modeles(DoliDB $db, int $maxfilenamelength = 0): array
 	{
 		// phpcs:enable
 		global $conf;
 
 		$type = 'myobject';
-		$list = array();
+		$list = [];
 
-		include_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
+		include_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
 		$list = getListOfModels($db, $type, $maxfilenamelength);
 
 		return $list;
@@ -71,14 +75,14 @@ abstract class ModeleNumRefMyObject
 	/**
 	 * @var string Error code (or message)
 	 */
-	public $error = '';
+	public string $error = '';
 
 	/**
-	 *	Return if a module can be used or not
+	 *    Return if a module can be used or not
 	 *
-	 *	@return		boolean     true if module can be used
+	 * @return        bool     true if module can be used
 	 */
-	public function isEnabled()
+	public function isEnabled(): bool
 	{
 		return true;
 	}
@@ -88,11 +92,11 @@ abstract class ModeleNumRefMyObject
 	 *
 	 *	@return     string      Texte descripif
 	 */
-	public function info()
+	public function info(): string
 	{
 		global $langs;
-		$langs->load("mymodule@mymodule");
-		return $langs->trans("NoDescription");
+		$langs->load('mymodule@mymodule');
+		return $langs->trans('NoDescription');
 	}
 
 	/**
@@ -100,35 +104,37 @@ abstract class ModeleNumRefMyObject
 	 *
 	 *	@return     string      Example
 	 */
-	public function getExample()
+	public function getExample(): string
 	{
 		global $langs;
-		$langs->load("mymodule@mymodule");
-		return $langs->trans("NoExample");
+		$langs->load('mymodule@mymodule');
+		return $langs->trans('NoExample');
 	}
 
 	/**
 	 *  Checks if the numbers already in the database do not
 	 *  cause conflicts that would prevent this numbering working.
 	 *
-	 *	@param	Object		$object		Object we need next value for
-	 *	@return boolean     			false if conflict, true if ok
+	 * @param Object $object Object we need next value for
+	 *
+	 * @return bool                false if conflicted, true if ok
 	 */
-	public function canBeActivated($object)
+	public function canBeActivated(object $object): bool
 	{
 		return true;
 	}
 
 	/**
-	 *	Returns next assigned value
+	 *    Returns next assigned value
 	 *
-	 *	@param	Object		$object		Object we need next value for
-	 *	@return	string      Valeur
+	 * @param Object $object Object we need next value for
+	 *
+	 * @return    string      Valeur
 	 */
-	public function getNextValue($object)
+	public function getNextValue(object $object): string
 	{
 		global $langs;
-		return $langs->trans("NotAvailable");
+		return $langs->trans('NotAvailable');
 	}
 
 	/**
@@ -139,20 +145,20 @@ abstract class ModeleNumRefMyObject
 	public function getVersion()
 	{
 		global $langs;
-		$langs->load("admin");
+		$langs->load('admin');
 
-		if ($this->version == 'development') {
-			return $langs->trans("VersionDevelopment");
+		if ($this->version === 'development') {
+			return $langs->trans('VersionDevelopment');
 		}
-		if ($this->version == 'experimental') {
-			return $langs->trans("VersionExperimental");
+		if ($this->version === 'experimental') {
+			return $langs->trans('VersionExperimental');
 		}
-		if ($this->version == 'dolibarr') {
+		if ($this->version === 'dolibarr') {
 			return DOL_VERSION;
 		}
 		if ($this->version) {
 			return $this->version;
 		}
-		return $langs->trans("NotAvailable");
+		return $langs->trans('NotAvailable');
 	}
 }

--- a/htdocs/modulebuilder/template/core/tpl/linkedobjectblock_myobject.tpl.php
+++ b/htdocs/modulebuilder/template/core/tpl/linkedobjectblock_myobject.tpl.php
@@ -15,6 +15,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+declare(strict_types=1);
+
 // Protection to avoid direct call of template
 if (empty($conf) || !is_object($conf)) {
 	print "Error, template page can't be called as URL";
@@ -32,26 +34,30 @@ $langs = $GLOBALS['langs'];
 $linkedObjectBlock = $GLOBALS['linkedObjectBlock'];
 
 // Load translation files required by the page
-$langs->load("mymodule");
+$langs->load('mymodule');
 
 $total = 0; $ilink = 0;
 foreach ($linkedObjectBlock as $key => $objectlink) {
 	$ilink++;
 
 	$trclass = 'oddeven';
-	if ($ilink == count($linkedObjectBlock) && empty($noMoreLinkedObjectBlockAfter) && count($linkedObjectBlock) <= 1) {
+	if ($ilink === count($linkedObjectBlock) && empty($noMoreLinkedObjectBlockAfter) && count($linkedObjectBlock) <=
+		1) {
 		$trclass .= ' liste_sub_total';
 	}
 	?>
-<tr class="<?php echo $trclass; ?>">
-	<td><?php echo $langs->trans("MyObject"); ?></td>
-	<td><?php echo $objectlink->getNomUrl(1); ?></td>
-	<td></td>
-	<td class="center"><?php echo dol_print_date($objectlink->date, 'day'); ?></td>
-	<td class="right"><?php echo ''; ?></td>
-	<td class="right"><?php echo $objectlink->getLibStatut(7); ?></td>
-	<td class="right"><a class="reposition" href="<?php echo $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=dellink&token='.newToken().'&dellinkid='.$key; ?>"><?php echo img_picto($langs->transnoentitiesnoconv("RemoveLink"), 'unlink'); ?></a></td>
-</tr>
+	<tr class="<?php echo $trclass ?>">
+		<td><?php echo $langs->trans('MyObject') ?></td>
+		<td><?php echo $objectlink->getNomUrl(1) ?></td>
+		<td></td>
+		<td class="center"><?php echo dol_print_date($objectlink->date, 'day') ?></td>
+		<td class="right"><?php echo '' ?></td>
+		<td class="right"><?php echo $objectlink->getLibStatut(7) ?>                                                        														 href="<?php echo $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=dellink&token=' . newToken(
+															) . '&dellinkid=' . $key ?>"><?php echo img_picto(
+					$langs->transnoentitiesnoconv('RemoveLink'),
+					'unlink'
+															   ) ?></a></td>
+	</tr>
 	<?php
 }
 

--- a/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
+++ b/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
@@ -32,6 +32,8 @@
  * - The name property name must be MyTrigger
  */
 
+declare(strict_types=1);
+
 require_once DOL_DOCUMENT_ROOT.'/core/triggers/dolibarrtriggers.class.php';
 
 
@@ -45,13 +47,13 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
 	 *
 	 * @param DoliDB $db Database handler
 	 */
-	public function __construct($db)
+	public function __construct(DoliDB $db)
 	{
 		$this->db = $db;
 
 		$this->name = preg_replace('/^Interface/i', '', get_class($this));
-		$this->family = "demo";
-		$this->description = "MyModule triggers.";
+		$this->family = 'demo';
+		$this->description = 'MyModule triggers.';
 		// 'development', 'experimental', 'dolibarr' or version
 		$this->version = 'development';
 		$this->picto = 'mymodule@mymodule';
@@ -62,7 +64,7 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
 	 *
 	 * @return string Name of trigger file
 	 */
-	public function getName()
+	public function getName(): string
 	{
 		return $this->name;
 	}
@@ -72,7 +74,7 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
 	 *
 	 * @return string Description of trigger file
 	 */
-	public function getDesc()
+	public function getDesc(): string
 	{
 		return $this->description;
 	}
@@ -83,14 +85,16 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
 	 * All functions "runTrigger" are triggered if file
 	 * is inside directory core/triggers
 	 *
-	 * @param string 		$action 	Event action code
-	 * @param CommonObject 	$object 	Object
-	 * @param User 			$user 		Object user
-	 * @param Translate 	$langs 		Object langs
-	 * @param Conf 			$conf 		Object conf
-	 * @return int              		<0 if KO, 0 if no triggered ran, >0 if OK
+	 * @param string       $action Event action code
+	 * @param CommonObject $object Object
+	 * @param User         $user   Object user
+	 * @param Translate    $langs  Object langs
+	 * @param Conf         $conf   Object conf
+	 *
+	 * @return int                    <0 if KO, 0 if no triggered ran, >0 if OK
+	 * @throws Exception
 	 */
-	public function runTrigger($action, $object, User $user, Translate $langs, Conf $conf)
+	public function runTrigger($action, $object, User $user, Translate $langs, Conf $conf): int
 	{
 		if (empty($conf->mymodule) || empty($conf->mymodule->enabled)) {
 			return 0; // If module is not enabled, we do nothing
@@ -99,17 +103,19 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
 		// Put here code you want to execute when a Dolibarr business events occurs.
 		// Data and type of action are stored into $object and $action
 
-		// You can isolate code for each action in a separate method: this method should be named like the trigger in camelCase.
-		// For example : COMPANY_CREATE => public function companyCreate($action, $object, User $user, Translate $langs, Conf $conf)
+		// You can isolate code for each action in a separate method: this method
+		// should be named like the trigger in camelCase.
+		// For example : COMPANY_CREATE => public function
+		// companyCreate($action, $object, User $user, Translate $langs, Conf $conf)
 		$methodName = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', strtolower($action)))));
-		$callback = array($this, $methodName);
+		$callback = [$this, $methodName];
 		if (is_callable($callback)) {
 			dol_syslog(
-				"Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id
+				"Trigger '".$this->name."' for action '$action' launched by ".__FILE__. '. id=' .$object->id
 			);
 
-			return call_user_func($callback, $action, $object, $user, $langs, $conf);
-		};
+			return $callback($action, $object, $user, $langs, $conf);
+		}
 
 		// Or you can execute some code here
 		switch ($action) {
@@ -316,7 +322,7 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
 			// and more...
 
 			default:
-				dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+				dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__. '. id=' .$object->id);
 				break;
 		}
 

--- a/htdocs/modulebuilder/template/css/mymodule.css.php
+++ b/htdocs/modulebuilder/template/css/mymodule.css.php
@@ -21,8 +21,13 @@
  * \brief   CSS file for module MyModule.
  */
 
-//if (! defined('NOREQUIREUSER')) define('NOREQUIREUSER','1');	// Not disabled because need to load personalized language
-//if (! defined('NOREQUIREDB'))   define('NOREQUIREDB','1');	// Not disabled. Language code is found on url.
+declare(strict_types=1);
+
+//if (! defined('NOREQUIREUSER')) define('NOREQUIREUSER','1');
+// Not disabled because need to load personalized language
+
+//if (! defined('NOREQUIREDB'))   define('NOREQUIREDB','1');
+// Not disabled. Language code is found on url.
 if (!defined('NOREQUIRESOC')) {
 	define('NOREQUIRESOC', '1');
 }
@@ -52,34 +57,43 @@ session_cache_limiter('public');
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/../main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/../main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
+}
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 
-// Load user to have $user->conf loaded (not done by default here because of NOLOGIN constant defined) and load permission if we need to use them in CSS
+// Load user to have $user->conf loaded (not done by default here because of NOLOGIN constant defined)
+// and load permission if we need to use them in CSS
+
 /*if (empty($user->id) && ! empty($_SESSION['dol_login'])) {
 	$user->fetch('',$_SESSION['dol_login']);
 	$user->getrights();

--- a/htdocs/modulebuilder/template/js/mymodule.js.php
+++ b/htdocs/modulebuilder/template/js/mymodule.js.php
@@ -17,6 +17,8 @@
  * Library javascript to enable Browser notifications
  */
 
+declare(strict_types=1);
+
 if (!defined('NOREQUIREUSER')) {
 	define('NOREQUIREUSER', '1');
 }
@@ -58,29 +60,36 @@ if (!defined('NOREQUIREAJAX')) {
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/../main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/../main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
+}
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 // Define js type

--- a/htdocs/modulebuilder/template/lib/mymodule.lib.php
+++ b/htdocs/modulebuilder/template/lib/mymodule.lib.php
@@ -21,22 +21,24 @@
  * \brief   Library files with common functions for MyModule
  */
 
+declare(strict_types=1);
+
 /**
  * Prepare admin pages header
  *
  * @return array
  */
-function mymoduleAdminPrepareHead()
+function mymoduleAdminPrepareHead(): array
 {
 	global $langs, $conf;
 
-	$langs->load("mymodule@mymodule");
+	$langs->load('mymodule@mymodule');
 
 	$h = 0;
-	$head = array();
+	$head = [];
 
-	$head[$h][0] = dol_buildpath("/mymodule/admin/setup.php", 1);
-	$head[$h][1] = $langs->trans("Settings");
+	$head[$h][0] = dol_buildpath('/mymodule/admin/setup.php', 1);
+	$head[$h][1] = $langs->trans('Settings');
 	$head[$h][2] = 'settings';
 	$h++;
 
@@ -47,8 +49,8 @@ function mymoduleAdminPrepareHead()
 	$h++;
 	*/
 
-	$head[$h][0] = dol_buildpath("/mymodule/admin/about.php", 1);
-	$head[$h][1] = $langs->trans("About");
+	$head[$h][0] = dol_buildpath('/mymodule/admin/about.php', 1);
+	$head[$h][1] = $langs->trans('About');
 	$head[$h][2] = 'about';
 	$h++;
 

--- a/htdocs/modulebuilder/template/lib/mymodule_myobject.lib.php
+++ b/htdocs/modulebuilder/template/lib/mymodule_myobject.lib.php
@@ -21,23 +21,26 @@
  * \brief   Library files with common functions for MyObject
  */
 
+declare(strict_types=1);
+
 /**
  * Prepare array of tabs for MyObject
  *
- * @param	MyObject	$object		MyObject
- * @return 	array					Array of tabs
+ * @param MyObject $object MyObject
+ *
+ * @return    array                    Array of tabs
  */
-function myobjectPrepareHead($object)
+function myobjectPrepareHead(MyObject $object): array
 {
 	global $db, $langs, $conf;
 
-	$langs->load("mymodule@mymodule");
+	$langs->load('mymodule@mymodule');
 
 	$h = 0;
-	$head = array();
+	$head = [];
 
-	$head[$h][0] = dol_buildpath("/mymodule/myobject_card.php", 1).'?id='.$object->id;
-	$head[$h][1] = $langs->trans("Card");
+	$head[$h][0] = dol_buildpath('/mymodule/myobject_card.php', 1) . '?id=' . $object->id;
+	$head[$h][1] = $langs->trans('Card');
 	$head[$h][2] = 'card';
 	$h++;
 
@@ -52,7 +55,8 @@ function myobjectPrepareHead($object)
 		$head[$h][0] = dol_buildpath('/mymodule/myobject_note.php', 1).'?id='.$object->id;
 		$head[$h][1] = $langs->trans('Notes');
 		if ($nbNote > 0) {
-			$head[$h][1] .= (empty($conf->global->MAIN_OPTIMIZEFORTEXTBROWSER) ? '<span class="badge marginleftonlyshort">'.$nbNote.'</span>' : '');
+			$head[$h][1] .= (empty($conf->global->MAIN_OPTIMIZEFORTEXTBROWSER) ? '
+							<span class="badge marginleftonlyshort">' . $nbNote . '</span>' : '');
 		}
 		$head[$h][2] = 'note';
 		$h++;
@@ -60,10 +64,10 @@ function myobjectPrepareHead($object)
 
 	require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 	require_once DOL_DOCUMENT_ROOT.'/core/class/link.class.php';
-	$upload_dir = $conf->mymodule->dir_output."/myobject/".dol_sanitizeFileName($object->ref);
+	$upload_dir = $conf->mymodule->dir_output. '/myobject/' .dol_sanitizeFileName($object->ref);
 	$nbFiles = count(dol_dir_list($upload_dir, 'files', 0, '', '(\.meta|_preview.*\.png)$'));
 	$nbLinks = Link::count($db, $object->element, $object->id);
-	$head[$h][0] = dol_buildpath("/mymodule/myobject_document.php", 1).'?id='.$object->id;
+	$head[$h][0] = dol_buildpath('/mymodule/myobject_document.php', 1).'?id='.$object->id;
 	$head[$h][1] = $langs->trans('Documents');
 	if (($nbFiles + $nbLinks) > 0) {
 		$head[$h][1] .= '<span class="badge marginleftonlyshort">'.($nbFiles + $nbLinks).'</span>';
@@ -71,8 +75,8 @@ function myobjectPrepareHead($object)
 	$head[$h][2] = 'document';
 	$h++;
 
-	$head[$h][0] = dol_buildpath("/mymodule/myobject_agenda.php", 1).'?id='.$object->id;
-	$head[$h][1] = $langs->trans("Events");
+	$head[$h][0] = dol_buildpath('/mymodule/myobject_agenda.php', 1).'?id='.$object->id;
+	$head[$h][1] = $langs->trans('Events');
 	$head[$h][2] = 'agenda';
 	$h++;
 

--- a/htdocs/modulebuilder/template/mymoduleindex.php
+++ b/htdocs/modulebuilder/template/mymoduleindex.php
@@ -19,46 +19,52 @@
  */
 
 /**
- *	\file       htdocs/modulebuilder/template/mymoduleindex.php
- *	\ingroup    mymodule
- *	\brief      Home page of mymodule top menu
+ *    \file       htdocs/modulebuilder/template/mymoduleindex.php
+ *    \ingroup    mymodule
+ *    \brief      Home page of mymodule top menu
  */
+
+declare(strict_types=1);
 
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
 
 // Load translation files required by the page
-$langs->loadLangs(array("mymodule@mymodule"));
+$langs->loadLangs(['mymodule@mymodule']);
 
 $action = GETPOST('action', 'aZ09');
 
@@ -91,9 +97,9 @@ $now = dol_now();
 $form = new Form($db);
 $formfile = new FormFile($db);
 
-llxHeader("", $langs->trans("MyModuleArea"));
+llxHeader('', $langs->trans('MyModuleArea'));
 
-print load_fiche_titre($langs->trans("MyModuleArea"), '', 'mymodule.png@mymodule');
+print load_fiche_titre($langs->trans('MyModuleArea'), '', 'mymodule.png@mymodule');
 
 print '<div class="fichecenter"><div class="fichethirdleft">';
 
@@ -104,7 +110,8 @@ if (! empty($conf->mymodule->enabled) && $user->rights->mymodule->read)
 {
 	$langs->load("orders");
 
-	$sql = "SELECT c.rowid, c.ref, c.ref_client, c.total_ht, c.tva as total_tva, c.total_ttc, s.rowid as socid, s.nom as name, s.client, s.canvas";
+	$sql = "SELECT c.rowid, c.ref, c.ref_client, c.total_ht, c.tva as total_tva, c.total_ttc, ';
+	$sql .= 's.rowid as socid, s.nom as name, s.client, s.canvas";
 	$sql.= ", s.code_client";
 	$sql.= " FROM ".MAIN_DB_PREFIX."commande as c";
 	$sql.= ", ".MAIN_DB_PREFIX."societe as s";
@@ -112,7 +119,9 @@ if (! empty($conf->mymodule->enabled) && $user->rights->mymodule->read)
 	$sql.= " WHERE c.fk_soc = s.rowid";
 	$sql.= " AND c.fk_statut = 0";
 	$sql.= " AND c.entity IN (".getEntity('commande').")";
-	if (! $user->rights->societe->client->voir && ! $socid) $sql.= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
+	if (! $user->rights->societe->client->voir && ! $socid) {
+		$sql.= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
+	}
 	if ($socid)	$sql.= " AND c.fk_soc = ".((int) $socid);
 
 	$resql = $db->query($sql);
@@ -123,7 +132,8 @@ if (! empty($conf->mymodule->enabled) && $user->rights->mymodule->read)
 
 		print '<table class="noborder centpercent">';
 		print '<tr class="liste_titre">';
-		print '<th colspan="3">'.$langs->trans("DraftMyObjects").($num?'<span class="badge marginleftonlyshort">'.$num.'</span>':'').'</th></tr>';
+		print '<th colspan="3">'.$langs->trans("DraftMyObjects").($num?'<span class="badge marginleftonlyshort">
+				'.$num.'</span>':'').'</th></tr>';
 
 		$var = true;
 		if ($num > 0)
@@ -153,7 +163,8 @@ if (! empty($conf->mymodule->enabled) && $user->rights->mymodule->read)
 			if ($total>0)
 			{
 
-				print '<tr class="liste_total"><td>'.$langs->trans("Total").'</td><td colspan="2" class="right">'.price($total)."</td></tr>";
+				print '<tr class="liste_total"><td>'.$langs->trans("Total").'</td>
+						<td colspan="2" class="right">'.price($total)."</td></tr>";
 			}
 		}
 		else
@@ -187,7 +198,9 @@ if (! empty($conf->mymodule->enabled) && $user->rights->mymodule->read)
 	$sql.= " FROM ".MAIN_DB_PREFIX."mymodule_myobject as s";
 	//if (! $user->rights->societe->client->voir && ! $socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 	$sql.= " WHERE s.entity IN (".getEntity($myobjectstatic->element).")";
-	//if (! $user->rights->societe->client->voir && ! $socid) $sql.= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
+	//if (! $user->rights->societe->client->voir && ! $socid) {
+		//$sql.= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
+	//}
 	//if ($socid)	$sql.= " AND s.rowid = $socid";
 	$sql .= " ORDER BY s.tms DESC";
 	$sql .= $db->plimit($max, 0);

--- a/htdocs/modulebuilder/template/myobject_agenda.php
+++ b/htdocs/modulebuilder/template/myobject_agenda.php
@@ -22,56 +22,77 @@
  *  \brief      Tab of events on MyObject
  */
 
+declare(strict_types=1);
+
 //if (! defined('NOREQUIREDB'))              define('NOREQUIREDB', '1');				// Do not create database handler $db
 //if (! defined('NOREQUIREUSER'))            define('NOREQUIREUSER', '1');				// Do not load object $user
 //if (! defined('NOREQUIRESOC'))             define('NOREQUIRESOC', '1');				// Do not load object $mysoc
 //if (! defined('NOREQUIRETRAN'))            define('NOREQUIRETRAN', '1');				// Do not load object $langs
-//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');		// Do not check injection attack on GET parameters
-//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');		// Do not check injection attack on POST parameters
-//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');				// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
-//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');				// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
-//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');				// Do not check style html tag into posted data
-//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');				// If there is no need to load and show top and left menu
-//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');				// If we don't need to load the html.form.class.php
+//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');
+//// Do not check injection attack on GET parameters
+//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');
+//// Do not check injection attack on POST parameters
+//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');
+//// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
+//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');
+//// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
+//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');
+//// Do not check style html tag into posted data
+//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');
+//// If there is no need to load and show top and left menu
+//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');
+//// If we don't need to load the html.form.class.php
 //if (! defined('NOREQUIREAJAX'))            define('NOREQUIREAJAX', '1');       	  	// Do not load ajax.lib.php library
-//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');					// If this page is public (can be called outside logged session). This include the NOIPCHECK too.
-//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');					// Do not check IP defined into conf $dolibarr_main_restrict_ip
-//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');					// Force lang to a particular value
-//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');	// Force authentication handler
-//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);		// The main.inc.php does not make a redirect if not logged, instead show simple error message
-//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');				// Disable all Content Security Policies
-//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');		// Force use of CSRF protection with tokens even for GET
-//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');				// Disable browser notification
+//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');
+//// If this page is public (can be called outside logged session). This includes the NOIPCHECK too.
+//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');
+//// Do not check IP defined into conf $dolibarr_main_restrict_ip
+//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');
+//// Force lang to a particular value
+//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');
+//// Force authentication handler
+//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);
+//// The main.inc.php does not make a redirect if not logged, instead show simple error message
+//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');
+//// Disable all Content Security Policies
+//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');
+//// Force use of CSRF protection with tokens even for GET
+//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');
+//// Disable browser notification
 
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
@@ -82,7 +103,7 @@ dol_include_once('/mymodule/lib/mymodule_myobject.lib.php');
 
 
 // Load translation files required by the page
-$langs->loadLangs(array("mymodule@mymodule", "other"));
+$langs->loadLangs(['mymodule@mymodule', 'other']);
 
 // Get parameters
 $id = GETPOST('id', 'int');
@@ -97,15 +118,18 @@ if (GETPOST('actioncode', 'array')) {
 		$actioncode = '0';
 	}
 } else {
-	$actioncode = GETPOST("actioncode", "alpha", 3) ? GETPOST("actioncode", "alpha", 3) : (GETPOST("actioncode") == '0' ? '0' : (empty($conf->global->AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT) ? '' : $conf->global->AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT));
+	$actioncode = GETPOST('actioncode', 'alpha', 3) ?: (GETPOST(
+		'actioncode'
+	) === '0' ? '0' : (empty($conf->global->AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT) ? '' :
+		$conf->global->AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT));
 }
 $search_agenda_label = GETPOST('search_agenda_label');
 
-$limit = GETPOST('limit', 'int') ? GETPOST('limit', 'int') : $conf->liste_limit;
-$sortfield = GETPOST("sortfield", 'alpha');
-$sortorder = GETPOST("sortorder", 'alpha');
-$page = GETPOSTISSET('pageplusone') ? (GETPOST('pageplusone') - 1) : GETPOST("page", 'int');
-if (empty($page) || $page == -1) {
+$limit = GETPOST('limit', 'int') ?: $conf->liste_limit;
+$sortfield = GETPOST('sortfield', 'alpha');
+$sortorder = GETPOST('sortorder', 'alpha');
+$page = GETPOSTISSET('pageplusone') ? (GETPOST('pageplusone') - 1) : GETPOST('page', 'int');
+if (empty($page) || $page === -1) {
 	$page = 0;
 }     // If $page is not defined, or '' or -1
 $offset = $limit * $page;
@@ -121,18 +145,20 @@ if (!$sortorder) {
 // Initialize technical objects
 $object = new MyObject($db);
 $extrafields = new ExtraFields($db);
-$diroutputmassaction = $conf->mymodule->dir_output.'/temp/massgeneration/'.$user->id;
-$hookmanager->initHooks(array('myobjectagenda', 'globalcard')); // Note that conf->hooks_modules contains array
+$diroutputmassaction = $conf->mymodule->dir_output . '/temp/massgeneration/' . $user->id;
+$hookmanager->initHooks(['myobjectagenda', 'globalcard']); // Note that conf->hooks_modules contains array
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
 
 // Load object
-include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be include, not include_once  // Must be include, not include_once. Include fetch and fetch_thirdparty but not fetch_optionals
+include DOL_DOCUMENT_ROOT . '/core/actions_fetchobject.inc.php';
+// Must be included, not include_once
+// Include fetch and fetch_thirdparty but not fetch_optionals
 if ($id > 0 || !empty($ref)) {
-	$upload_dir = $conf->mymodule->multidir_output[$object->entity]."/".$object->id;
+	$upload_dir = $conf->mymodule->multidir_output[$object->entity] . '/' . $object->id;
 }
 
-$permissiontoadd = $user->rights->mymodule->myobject->write; // Used by the include of actions_addupdatedelete.inc.php
+$permissiontoadd = $user->rights->mymodule->myobject->write; // Used by to include of actions_addupdatedelete.inc.php
 
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();
@@ -147,8 +173,9 @@ $permissiontoadd = $user->rights->mymodule->myobject->write; // Used by the incl
  *  Actions
  */
 
-$parameters = array('id'=>$id);
-$reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+$parameters = ['id' => $id];
+$reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action);
+// Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 }
@@ -156,12 +183,15 @@ if ($reshook < 0) {
 if (empty($reshook)) {
 	// Cancel
 	if (GETPOST('cancel', 'alpha') && !empty($backtopage)) {
-		header("Location: ".$backtopage);
+		header('Location: ' . $backtopage);
 		exit;
 	}
 
 	// Purge search criteria
-	if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter.x', 'alpha') || GETPOST('button_removefilter', 'alpha')) { // All tests are required to be compatible with all browsers
+	if (GETPOST('button_removefilter_x', 'alpha') ||
+		GETPOST('button_removefilter.x', 'alpha') ||
+		GETPOST('button_removefilter', 'alpha')) {
+		// All tests are required to be compatible with all browsers
 		$actioncode = '';
 		$search_agenda_label = '';
 	}
@@ -176,13 +206,14 @@ if (empty($reshook)) {
 $form = new Form($db);
 
 if ($object->id > 0) {
-	$title = $langs->trans("Agenda");
-	//if (! empty($conf->global->MAIN_HTML_TITLE) && preg_match('/thirdpartynameonly/',$conf->global->MAIN_HTML_TITLE) && $object->name) $title=$object->name." - ".$title;
+	$title = $langs->trans('Agenda');
+	//if (! empty($conf->global->MAIN_HTML_TITLE) && preg_match('/thirdpartynameonly/',$conf->global->MAIN_HTML_TITLE)
+	// && $object->name) $title=$object->name." - ".$title;
 	$help_url = 'EN:Module_Agenda_En';
 	llxHeader('', $title, $help_url);
 
 	if (!empty($conf->notification->enabled)) {
-		$langs->load("mails");
+		$langs->load('mails');
 	}
 	$head = myobjectPrepareHead($object);
 
@@ -191,7 +222,9 @@ if ($object->id > 0) {
 
 	// Object card
 	// ------------------------------------------------------------
-	$linkback = '<a href="'.dol_buildpath('/mymodule/myobject_list.php', 1).'?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="' . dol_buildpath('/mymodule/myobject_list.php', 1) . '?
+				restore_lastsearch_values=1' . (!empty($socid) ? '
+				&socid=' . $socid : '') . '">' . $langs->trans('BackToList') . '</a>';
 
 	$morehtmlref = '<div class="refidno">';
 	/*
@@ -246,22 +279,23 @@ if ($object->id > 0) {
 	print dol_get_fiche_end();
 
 
-
-	// Actions buttons
+	// Action buttons
 
 	$objthirdparty = $object;
 	$objcon = new stdClass();
 
-	$out = '&origin='.urlencode($object->element.'@'.$object->module).'&originid='.urlencode($object->id);
-	$urlbacktopage = $_SERVER['PHP_SELF'].'?id='.$object->id;
+	$out = '&origin=' . urlencode($object->element . '@' . $object->module) . '&originid=' . urlencode(
+			(string) $object->id
+		);
+	$urlbacktopage = $_SERVER['PHP_SELF'] . '?id=' . $object->id;
 	$out .= '&backtopage='.urlencode($urlbacktopage);
 	$permok = $user->rights->agenda->myactions->create;
 	if ((!empty($objthirdparty->id) || !empty($objcon->id)) && $permok) {
 		//$out.='<a href="'.DOL_URL_ROOT.'/comm/action/card.php?action=create';
-		if (get_class($objthirdparty) == 'Societe') {
-			$out .= '&socid='.urlencode($objthirdparty->id);
+		if (get_class($objthirdparty) === 'Societe') {
+			$out .= '&socid=' . urlencode((string) $objthirdparty->id);
 		}
-		$out .= (!empty($objcon->id) ? '&contactid='.urlencode($objcon->id) : '').'&percentage=-1';
+		$out .= (!empty($objcon->id) ? '&contactid=' . urlencode($objcon->id) : '') . '&percentage=-1';
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";
@@ -272,28 +306,31 @@ if ($object->id > 0) {
 
 	if (!empty($conf->agenda->enabled)) {
 		if (!empty($user->rights->agenda->myactions->create) || !empty($user->rights->agenda->allactions->create)) {
-			print '<a class="butAction" href="'.DOL_URL_ROOT.'/comm/action/card.php?action=create'.$out.'">'.$langs->trans("AddAction").'</a>';
+			print '<a class="butAction" href="' . DOL_URL_ROOT . '/comm/action/card.php?action=create' . $out . '">' . $langs->trans(
+					'AddAction'
+				) . '</a>';
 		} else {
-			print '<a class="butActionRefused classfortooltip" href="#">'.$langs->trans("AddAction").'</a>';
+			print '<a class="butActionRefused classfortooltip" href="#">' . $langs->trans('AddAction') . '</a>';
 		}
 	}
 
 	print '</div>';
 
-	if (!empty($conf->agenda->enabled) && (!empty($user->rights->agenda->myactions->read) || !empty($user->rights->agenda->allactions->read))) {
-		$param = '&id='.$object->id.'&socid='.$socid;
-		if (!empty($contextpage) && $contextpage != $_SERVER["PHP_SELF"]) {
-			$param .= '&contextpage='.urlencode($contextpage);
+	if (!empty($conf->agenda->enabled) && (!empty($user->rights->agenda->myactions->read) ||
+			!empty($user->rights->agenda->allactions->read))) {
+		$param = '&id=' . $object->id . '&socid=' . $socid;
+		if (!empty($contextpage) && $contextpage !== $_SERVER['PHP_SELF']) {
+			$param .= '&contextpage=' . urlencode($contextpage);
 		}
-		if ($limit > 0 && $limit != $conf->liste_limit) {
-			$param .= '&limit='.urlencode($limit);
+		if ($limit > 0 && $limit !== $conf->liste_limit) {
+			$param .= '&limit=' . urlencode($limit);
 		}
 
 
 		//print load_fiche_titre($langs->trans("ActionsOnMyObject"), '', '');
 
 		// List of all actions
-		$filters = array();
+		$filters = [];
 		$filters['search_agenda_label'] = $search_agenda_label;
 
 		// TODO Replace this with same code than into list.php

--- a/htdocs/modulebuilder/template/myobject_card.php
+++ b/htdocs/modulebuilder/template/myobject_card.php
@@ -17,61 +17,82 @@
  */
 
 /**
- *   	\file       htdocs/modulebuilder/template/myobject_card.php
- *		\ingroup    mymodule
- *		\brief      Page to create/edit/view myobject
+ *    \file       htdocs/modulebuilder/template/myobject_card.php
+ *        \ingroup    mymodule
+ *        \brief      Page to create/edit/view myobject
  */
+
+declare(strict_types=1);
 
 //if (! defined('NOREQUIREDB'))              define('NOREQUIREDB', '1');				// Do not create database handler $db
 //if (! defined('NOREQUIREUSER'))            define('NOREQUIREUSER', '1');				// Do not load object $user
 //if (! defined('NOREQUIRESOC'))             define('NOREQUIRESOC', '1');				// Do not load object $mysoc
 //if (! defined('NOREQUIRETRAN'))            define('NOREQUIRETRAN', '1');				// Do not load object $langs
-//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');		// Do not check injection attack on GET parameters
-//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');		// Do not check injection attack on POST parameters
-//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');				// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
-//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');				// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
-//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');				// Do not check style html tag into posted data
-//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');				// If there is no need to load and show top and left menu
-//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');				// If we don't need to load the html.form.class.php
+//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');
+//// Do not check injection attack on GET parameters
+//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');
+//// Do not check injection attack on POST parameters
+//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');
+//// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
+//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');
+//// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
+//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');
+//// Do not check style html tag into posted data
+//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');
+//// If there is no need to load and show top and left menu
+//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');
+//// If we don't need to load the html.form.class.php
 //if (! defined('NOREQUIREAJAX'))            define('NOREQUIREAJAX', '1');       	  	// Do not load ajax.lib.php library
-//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');					// If this page is public (can be called outside logged session). This include the NOIPCHECK too.
-//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');					// Do not check IP defined into conf $dolibarr_main_restrict_ip
-//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');					// Force lang to a particular value
-//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');	// Force authentication handler
-//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);		// The main.inc.php does not make a redirect if not logged, instead show simple error message
-//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');				// Disable all Content Security Policies
-//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');		// Force use of CSRF protection with tokens even for GET
-//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');				// Disable browser notification
+//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');
+//// If this page is public (can be called outside logged session). This includes the NOIPCHECK too.
+//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');
+//// Do not check IP defined into conf $dolibarr_main_restrict_ip
+//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');
+//// Force lang to a particular value
+//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');
+//// Force authentication handler
+//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);
+//// The main.inc.php does not make a redirect if not logged, instead show simple error message
+//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');
+//// Disable all Content Security Policies
+//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');
+//// Force use of CSRF protection with tokens even for GET
+//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');
+//// Disable browser notification
 
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
@@ -81,7 +102,7 @@ dol_include_once('/mymodule/class/myobject.class.php');
 dol_include_once('/mymodule/lib/mymodule_myobject.lib.php');
 
 // Load translation files required by the page
-$langs->loadLangs(array("mymodule@mymodule", "other"));
+$langs->loadLangs(['mymodule@mymodule', 'other']);
 
 // Get parameters
 $id = GETPOST('id', 'int');
@@ -89,7 +110,7 @@ $ref = GETPOST('ref', 'alpha');
 $action = GETPOST('action', 'aZ09');
 $confirm = GETPOST('confirm', 'alpha');
 $cancel = GETPOST('cancel', 'aZ09');
-$contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'myobjectcard'; // To manage different context of search
+$contextpage = GETPOST('contextpage', 'aZ') ?: 'myobjectcard'; // To manage different context of search
 $backtopage = GETPOST('backtopage', 'alpha');
 $backtopageforcancel = GETPOST('backtopageforcancel', 'alpha');
 //$lineid   = GETPOST('lineid', 'int');
@@ -97,8 +118,8 @@ $backtopageforcancel = GETPOST('backtopageforcancel', 'alpha');
 // Initialize technical objects
 $object = new MyObject($db);
 $extrafields = new ExtraFields($db);
-$diroutputmassaction = $conf->mymodule->dir_output.'/temp/massgeneration/'.$user->id;
-$hookmanager->initHooks(array('myobjectcard', 'globalcard')); // Note that conf->hooks_modules contains array
+$diroutputmassaction = $conf->mymodule->dir_output . '/temp/massgeneration/' . $user->id;
+$hookmanager->initHooks(['myobjectcard', 'globalcard']); // Note that conf->hooks_modules contains array
 
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
@@ -106,11 +127,11 @@ $extrafields->fetch_name_optionals_label($object->table_element);
 $search_array_options = $extrafields->getOptionalsFromPost($object->table_element, '', 'search_');
 
 // Initialize array of search criterias
-$search_all = GETPOST("search_all", 'alpha');
-$search = array();
+$search_all = GETPOST('search_all', 'alpha');
+$search = [];
 foreach ($object->fields as $key => $val) {
-	if (GETPOST('search_'.$key, 'alpha')) {
-		$search[$key] = GETPOST('search_'.$key, 'alpha');
+	if (GETPOST('search_' . $key, 'alpha')) {
+		$search[$key] = GETPOST('search_' . $key, 'alpha');
 	}
 }
 
@@ -119,15 +140,15 @@ if (empty($action) && empty($id) && empty($ref)) {
 }
 
 // Load object
-include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be include, not include_once.
+include DOL_DOCUMENT_ROOT . '/core/actions_fetchobject.inc.php'; // Must be included, not include_once.
 
 
 $permissiontoread = $user->rights->mymodule->myobject->read;
-$permissiontoadd = $user->rights->mymodule->myobject->write; // Used by the include of actions_addupdatedelete.inc.php and actions_lineupdown.inc.php
+$permissiontoadd = $user->rights->mymodule->myobject->write; // Used by to include of actions_addupdatedelete.inc.php and actions_lineupdown.inc.php
 $permissiontodelete = $user->rights->mymodule->myobject->delete || ($permissiontoadd && isset($object->status) && $object->status == $object::STATUS_DRAFT);
-$permissionnote = $user->rights->mymodule->myobject->write; // Used by the include of actions_setnotes.inc.php
-$permissiondellink = $user->rights->mymodule->myobject->write; // Used by the include of actions_dellink.inc.php
-$upload_dir = $conf->mymodule->multidir_output[isset($object->entity) ? $object->entity : 1].'/myobject';
+$permissionnote = $user->rights->mymodule->myobject->write; // Used by to include of actions_setnotes.inc.php
+$permissiondellink = $user->rights->mymodule->myobject->write; // Used by to include of actions_dellink.inc.php
+$upload_dir = $conf->mymodule->multidir_output[$object->entity ?? 1] . '/myobject';
 
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();
@@ -142,7 +163,7 @@ $upload_dir = $conf->mymodule->multidir_output[isset($object->entity) ? $object-
  * Actions
  */
 
-$parameters = array();
+$parameters = [];
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
@@ -207,7 +228,7 @@ $form = new Form($db);
 $formfile = new FormFile($db);
 $formproject = new FormProjets($db);
 
-$title = $langs->trans("MyObject");
+$title = $langs->trans('MyObject');
 $help_url = '';
 llxHeader('', $title, $help_url);
 
@@ -229,10 +250,14 @@ llxHeader('', $title, $help_url);
 
 // Part to create
 if ($action == 'create') {
-	print load_fiche_titre($langs->trans("NewObject", $langs->transnoentitiesnoconv("MyObject")), '', 'object_'.$object->picto);
+	print load_fiche_titre(
+		$langs->trans('NewObject', $langs->transnoentitiesnoconv('MyObject')),
+		'',
+		'object_' . $object->picto
+	);
 
-	print '<form method="POST" action="'.$_SERVER["PHP_SELF"].'">';
-	print '<input type="hidden" name="token" value="'.newToken().'">';
+	print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '">';
+	print '<input type="hidden" name="token" value="' . newToken() . '">';
 	print '<input type="hidden" name="action" value="add">';
 	if ($backtopage) {
 		print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
@@ -241,7 +266,7 @@ if ($action == 'create') {
 		print '<input type="hidden" name="backtopageforcancel" value="'.$backtopageforcancel.'">';
 	}
 
-	print dol_get_fiche_head(array(), '');
+	print dol_get_fiche_head([]);
 
 	// Set some default values
 	//if (! GETPOSTISSET('fieldname')) $_POST['fieldname'] = 'myvalue';
@@ -258,7 +283,7 @@ if ($action == 'create') {
 
 	print dol_get_fiche_end();
 
-	print $form->buttonsSaveCancel("Create");
+	print $form->buttonsSaveCancel('Create');
 
 	print '</form>';
 
@@ -267,10 +292,10 @@ if ($action == 'create') {
 
 // Part to edit record
 if (($id || $ref) && $action == 'edit') {
-	print load_fiche_titre($langs->trans("MyObject"), '', 'object_'.$object->picto);
+	print load_fiche_titre($langs->trans('MyObject'), '', 'object_' . $object->picto);
 
-	print '<form method="POST" action="'.$_SERVER["PHP_SELF"].'">';
-	print '<input type="hidden" name="token" value="'.newToken().'">';
+	print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '">';
+	print '<input type="hidden" name="token" value="' . newToken() . '">';
 	print '<input type="hidden" name="action" value="update">';
 	print '<input type="hidden" name="id" value="'.$object->id.'">';
 	if ($backtopage) {
@@ -304,28 +329,52 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	$res = $object->fetch_optionals();
 
 	$head = myobjectPrepareHead($object);
-	print dol_get_fiche_head($head, 'card', $langs->trans("Workstation"), -1, $object->picto);
+	print dol_get_fiche_head($head, 'card', $langs->trans('Workstation'), -1, $object->picto);
 
 	$formconfirm = '';
 
 	// Confirmation to delete
 	if ($action == 'delete') {
-		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('DeleteMyObject'), $langs->trans('ConfirmDeleteObject'), 'confirm_delete', '', 0, 1);
+		$formconfirm = $form->formconfirm(
+			$_SERVER['PHP_SELF'] . '?id=' . $object->id,
+			$langs->trans('DeleteMyObject'),
+			$langs->trans('ConfirmDeleteObject'),
+			'confirm_delete',
+			'',
+			0,
+			1
+		);
 	}
 	// Confirmation to delete line
 	if ($action == 'deleteline') {
-		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id.'&lineid='.$lineid, $langs->trans('DeleteLine'), $langs->trans('ConfirmDeleteLine'), 'confirm_deleteline', '', 0, 1);
+		$formconfirm = $form->formconfirm(
+			$_SERVER['PHP_SELF'] . '?id=' . $object->id . '&lineid=' . $lineid,
+			$langs->trans('DeleteLine'),
+			$langs->trans('ConfirmDeleteLine'),
+			'confirm_deleteline',
+			'',
+			0,
+			1
+		);
 	}
 	// Clone confirmation
 	if ($action == 'clone') {
 		// Create an array for form
-		$formquestion = array();
-		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToClone'), $langs->trans('ConfirmCloneAsk', $object->ref), 'confirm_clone', $formquestion, 'yes', 1);
+		$formquestion = [];
+		$formconfirm = $form->formconfirm(
+			$_SERVER['PHP_SELF'] . '?id=' . $object->id,
+			$langs->trans('ToClone'),
+			$langs->trans('ConfirmCloneAsk', $object->ref),
+			'confirm_clone',
+			$formquestion,
+			'yes',
+			1
+		);
 	}
 
 	// Confirmation of action xxxx
 	if ($action == 'xxx') {
-		$formquestion = array();
+		$formquestion = [];
 		/*
 		$forcecombo=0;
 		if ($conf->browser->name == 'ie') $forcecombo = 1;	// There is a bug in IE10 that make combo inside popup crazy
@@ -336,11 +385,20 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			// array('type' => 'other',    'name' => 'idwarehouse',   'label' => $langs->trans("SelectWarehouseForStockDecrease"), 'value' => $formproduct->selectWarehouses(GETPOST('idwarehouse')?GETPOST('idwarehouse'):'ifone', 'idwarehouse', '', 1, 0, 0, '', 0, $forcecombo))
 		);
 		*/
-		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('XXX'), $text, 'confirm_xxx', $formquestion, 0, 1, 220);
+		$formconfirm = $form->formconfirm(
+			$_SERVER['PHP_SELF'] . '?id=' . $object->id,
+			$langs->trans('XXX'),
+			$text,
+			'confirm_xxx',
+			$formquestion,
+			0,
+			1,
+			220
+		);
 	}
 
 	// Call Hook formConfirm
-	$parameters = array('formConfirm' => $formconfirm, 'lineid' => $lineid);
+	$parameters = ['formConfirm' => $formconfirm, 'lineid' => $lineid];
 	$reshook = $hookmanager->executeHooks('formConfirm', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	if (empty($reshook)) {
 		$formconfirm .= $hookmanager->resPrint;
@@ -354,7 +412,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 	// Object card
 	// ------------------------------------------------------------
-	$linkback = '<a href="'.dol_buildpath('/mymodule/myobject_list.php', 1).'?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="' . dol_buildpath(
+			'/mymodule/myobject_list.php',
+			1
+		) . '?restore_lastsearch_values=1' . (!empty($socid) ? '&socid=' . $socid : '') . '">' . $langs->trans(
+			'BackToList'
+		) . '</a>';
 
 	$morehtmlref = '<div class="refidno">';
 	/*
@@ -428,12 +491,15 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		// Show object lines
 		$result = $object->getLinesArray();
 
-		print '	<form name="addproduct" id="addproduct" action="'.$_SERVER["PHP_SELF"].'?id='.$object->id.(($action != 'editline') ? '' : '#line_'.GETPOST('lineid', 'int')).'" method="POST">
-		<input type="hidden" name="token" value="' . newToken().'">
-		<input type="hidden" name="action" value="' . (($action != 'editline') ? 'addline' : 'updateline').'">
+		print '	<form name="addproduct" id="addproduct" action="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . (($action != 'editline') ? '' : '#line_' . GETPOST(
+					'lineid',
+					'int'
+				)) . '" method="POST">
+		<input type="hidden" name="token" value="' . newToken() . '">
+		<input type="hidden" name="action" value="' . (($action != 'editline') ? 'addline' : 'updateline') . '">
 		<input type="hidden" name="mode" value="">
 		<input type="hidden" name="page_y" value="">
-		<input type="hidden" name="id" value="' . $object->id.'">
+		<input type="hidden" name="id" value="' . $object->id . '">
 		';
 
 		if (!empty($conf->use_javascript_ajax) && $object->status == 0) {
@@ -442,7 +508,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 		print '<div class="div-table-responsive-no-min">';
 		if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline')) {
-			print '<table id="tablelines" class="noborder noshadow" width="100%">';
+			print '<table id="tablelines" class="noborder noshadow">';
 		}
 
 		if (!empty($object->lines)) {
@@ -450,15 +516,21 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		}
 
 		// Form to add new line
-		if ($object->status == 0 && $permissiontoadd && $action != 'selectlines') {
-			if ($action != 'editline') {
-				// Add products/services form
+		if ($object->status == 0 && $permissiontoadd && $action != 'selectlines' && $action != 'editline') {
+			// Add products/services form
 
-				$parameters = array();
-				$reshook = $hookmanager->executeHooks('formAddObjectLine', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
-				if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
-				if (empty($reshook))
-					$object->formAddObjectLine(1, $mysoc, $soc);
+			$parameters = [];
+			$reshook = $hookmanager->executeHooks(
+				'formAddObjectLine',
+				$parameters,
+				$object,
+				$action
+			); // Note that $action and $object may have been modified by hook
+			if ($reshook < 0) {
+				setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+			}
+			if (empty($reshook)) {
+				$object->formAddObjectLine(1, $mysoc, $soc);
 			}
 		}
 
@@ -474,8 +546,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	// Buttons for actions
 
 	if ($action != 'presend' && $action != 'editline') {
-		print '<div class="tabsAction">'."\n";
-		$parameters = array();
+		print '<div class="tabsAction">' . "\n";
+		$parameters = [];
 		$reshook = $hookmanager->executeHooks('addMoreActionsButtons', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 		if ($reshook < 0) {
 			setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
@@ -484,23 +556,51 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		if (empty($reshook)) {
 			// Send
 			if (empty($user->socid)) {
-				print dolGetButtonAction($langs->trans('SendMail'), '', 'default', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=presend&mode=init&token='.newToken().'#formmailbeforetitle');
+				print dolGetButtonAction(
+					$langs->trans('SendMail'),
+					'',
+					'default',
+					$_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=presend&mode=init&token=' . newToken(
+					) . '#formmailbeforetitle'
+				);
 			}
 
 			// Back to draft
 			if ($object->status == $object::STATUS_VALIDATED) {
-				print dolGetButtonAction($langs->trans('SetToDraft'), '', 'default', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=confirm_setdraft&confirm=yes&token='.newToken(), '', $permissiontoadd);
+				print dolGetButtonAction(
+					$langs->trans('SetToDraft'),
+					'',
+					'default',
+					$_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=confirm_setdraft&confirm=yes&token=' . newToken(
+					),
+					'',
+					$permissiontoadd
+				);
 			}
 
-			print dolGetButtonAction($langs->trans('Modify'), '', 'default', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=edit&token='.newToken(), '', $permissiontoadd);
+			print dolGetButtonAction(
+				$langs->trans('Modify'),
+				'',
+				'default',
+				$_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit&token=' . newToken(),
+				'',
+				$permissiontoadd
+			);
 
 			// Validate
 			if ($object->status == $object::STATUS_DRAFT) {
 				if (empty($object->table_element_line) || (is_array($object->lines) && count($object->lines) > 0)) {
 					print dolGetButtonAction($langs->trans('Validate'), '', 'default', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=confirm_validate&confirm=yes&token='.newToken(), '', $permissiontoadd);
 				} else {
-					$langs->load("errors");
-					print dolGetButtonAction($langs->trans("ErrorAddAtLeastOneLineFirst"), $langs->trans("Validate"), 'default', '#', '', 0);
+					$langs->load('errors');
+					print dolGetButtonAction(
+						$langs->trans('ErrorAddAtLeastOneLineFirst'),
+						$langs->trans('Validate'),
+						'default',
+						'#',
+						'',
+						0
+					);
 				}
 			}
 
@@ -546,15 +646,15 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		if ($includedocgeneration) {
 			$objref = dol_sanitizeFileName($object->ref);
 			$relativepath = $objref.'/'.$objref.'.pdf';
-			$filedir = $conf->mymodule->dir_output.'/'.$object->element.'/'.$objref;
-			$urlsource = $_SERVER["PHP_SELF"]."?id=".$object->id;
+			$filedir = $conf->mymodule->dir_output . '/' . $object->element . '/' . $objref;
+			$urlsource = $_SERVER['PHP_SELF'] . '?id=' . $object->id;
 			$genallowed = $user->rights->mymodule->myobject->read; // If you can read, you can build the PDF to read content
 			$delallowed = $user->rights->mymodule->myobject->write; // If you can create/edit, you can remove a file on card
 			print $formfile->showdocuments('mymodule:MyObject', $object->element.'/'.$objref, $filedir, $urlsource, $genallowed, $delallowed, $object->model_pdf, 1, 0, 0, 28, 0, '', '', '', $langs->defaultlang);
 		}
 
 		// Show links to link elements
-		$linktoelem = $form->showLinkToObjectBlock($object, null, array('myobject'));
+		$linktoelem = $form->showLinkToObjectBlock($object, null, ['myobject']);
 		$somethingshown = $form->showLinkedObjectBlock($object, $linktoelem);
 
 
@@ -562,8 +662,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 		$MAXEVENT = 10;
 
-		$morehtmlright = '<a href="'.dol_buildpath('/mymodule/myobject_agenda.php', 1).'?id='.$object->id.'">';
-		$morehtmlright .= $langs->trans("SeeAll");
+		$morehtmlright = '<a href="' . dol_buildpath('/mymodule/myobject_agenda.php', 1) . '?id=' . $object->id . '">';
+		$morehtmlright .= $langs->trans('SeeAll');
 		$morehtmlright .= '</a>';
 
 		// List of actions on element

--- a/htdocs/modulebuilder/template/myobject_document.php
+++ b/htdocs/modulebuilder/template/myobject_document.php
@@ -22,56 +22,77 @@
  *  \brief      Tab for documents linked to MyObject
  */
 
+declare(strict_types=1);
+
 //if (! defined('NOREQUIREDB'))              define('NOREQUIREDB', '1');				// Do not create database handler $db
 //if (! defined('NOREQUIREUSER'))            define('NOREQUIREUSER', '1');				// Do not load object $user
 //if (! defined('NOREQUIRESOC'))             define('NOREQUIRESOC', '1');				// Do not load object $mysoc
 //if (! defined('NOREQUIRETRAN'))            define('NOREQUIRETRAN', '1');				// Do not load object $langs
-//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');		// Do not check injection attack on GET parameters
-//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');		// Do not check injection attack on POST parameters
-//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');				// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
-//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');				// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
-//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');				// Do not check style html tag into posted data
-//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');				// If there is no need to load and show top and left menu
-//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');				// If we don't need to load the html.form.class.php
+//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');
+//// Do not check injection attack on GET parameters
+//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');
+//// Do not check injection attack on POST parameters
+//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');
+//// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
+//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');
+//// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
+//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');
+//// Do not check style html tag into posted data
+//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');
+//// If there is no need to load and show top and left menu
+//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');
+//// If we don't need to load the html.form.class.php
 //if (! defined('NOREQUIREAJAX'))            define('NOREQUIREAJAX', '1');       	  	// Do not load ajax.lib.php library
-//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');					// If this page is public (can be called outside logged session). This include the NOIPCHECK too.
-//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');					// Do not check IP defined into conf $dolibarr_main_restrict_ip
-//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');					// Force lang to a particular value
-//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');	// Force authentication handler
-//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);		// The main.inc.php does not make a redirect if not logged, instead show simple error message
-//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');				// Disable all Content Security Policies
-//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');		// Force use of CSRF protection with tokens even for GET
-//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');				// Disable browser notification
+//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');
+//// If this page is public (can be called outside logged session). This includes the NOIPCHECK too.
+//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');
+//// Do not check IP defined into conf $dolibarr_main_restrict_ip
+//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');
+//// Force lang to a particular value
+//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');
+//// Force authentication handler
+//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);
+//// The main.inc.php does not make a redirect if not logged, instead show simple error message
+//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');
+//// Disable all Content Security Policies
+//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');
+//// Force use of CSRF protection with tokens even for GET
+//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');
+//// Disable browser notification
 
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
@@ -82,49 +103,57 @@ dol_include_once('/mymodule/class/myobject.class.php');
 dol_include_once('/mymodule/lib/mymodule_myobject.lib.php');
 
 // Load translation files required by the page
-$langs->loadLangs(array("mymodule@mymodule", "companies", "other", "mails"));
+$langs->loadLangs(['mymodule@mymodule', 'companies', 'other', 'mails']);
 
 
 $action = GETPOST('action', 'aZ09');
 $confirm = GETPOST('confirm');
-$id = (GETPOST('socid', 'int') ? GETPOST('socid', 'int') : GETPOST('id', 'int'));
+$id = (GETPOST('socid', 'int') ?: GETPOST('id', 'int'));
 $ref = GETPOST('ref', 'alpha');
 
 // Get parameters
-$limit = GETPOST('limit', 'int') ? GETPOST('limit', 'int') : $conf->liste_limit;
-$sortfield = GETPOST("sortfield", 'alpha');
-$sortorder = GETPOST("sortorder", 'alpha');
-$page = GETPOSTISSET('pageplusone') ? (GETPOST('pageplusone') - 1) : GETPOST("page", 'int');
-if (empty($page) || $page == -1) {
+$limit = GETPOST('limit', 'int') ?: $conf->liste_limit;
+$sortfield = GETPOST('sortfield', 'alpha');
+$sortorder = GETPOST('sortorder', 'alpha');
+$page = GETPOSTISSET('pageplusone') ? (GETPOST('pageplusone') - 1) : GETPOST('page', 'int');
+if (empty($page) || $page === -1) {
 	$page = 0;
 }     // If $page is not defined, or '' or -1
 $offset = $liste_limit * $page;
 $pageprev = $page - 1;
 $pagenext = $page + 1;
 if (!$sortorder) {
-	$sortorder = "ASC";
+	$sortorder = 'ASC';
 }
 if (!$sortfield) {
-	$sortfield = "name";
+	$sortfield = 'name';
 }
 //if (! $sortfield) $sortfield="position_name";
 
 // Initialize technical objects
 $object = new MyObject($db);
 $extrafields = new ExtraFields($db);
-$diroutputmassaction = $conf->mymodule->dir_output.'/temp/massgeneration/'.$user->id;
-$hookmanager->initHooks(array('myobjectdocument', 'globalcard')); // Note that conf->hooks_modules contains array
+$diroutputmassaction = $conf->mymodule->dir_output . '/temp/massgeneration/' . $user->id;
+$hookmanager->initHooks(['myobjectdocument', 'globalcard']); // Note that conf->hooks_modules contains array
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
 
 // Load object
-include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be include, not include_once  // Must be include, not include_once. Include fetch and fetch_thirdparty but not fetch_optionals
+include DOL_DOCUMENT_ROOT . '/core/actions_fetchobject.inc.php';
+// Must be included, not include_once. Include fetch and fetch_thirdparty but not fetch_optionals
 
 if ($id > 0 || !empty($ref)) {
-	$upload_dir = $conf->mymodule->multidir_output[$object->entity ? $object->entity : $conf->entity]."/myobject/".get_exdir(0, 0, 0, 1, $object);
+	$upload_dir = $conf->mymodule->multidir_output[$object->entity ?: $conf->entity] . '/myobject/' . get_exdir(
+			0,
+			0,
+			0,
+			1,
+			$object
+		);
 }
 
-$permissiontoadd = $user->rights->mymodule->myobject->write; // Used by the include of actions_addupdatedelete.inc.php and actions_linkedfiles.inc.php
+$permissiontoadd = $user->rights->mymodule->myobject->write;
+// Used by to include of actions_addupdatedelete.inc.php and actions_linkedfiles.inc.php
 
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();
@@ -148,7 +177,7 @@ include DOL_DOCUMENT_ROOT.'/core/actions_linkedfiles.inc.php';
 
 $form = new Form($db);
 
-$title = $langs->trans("MyObject").' - '.$langs->trans("Files");
+$title = $langs->trans('MyObject') . ' - ' . $langs->trans('Files');
 $help_url = '';
 //$help_url='EN:Module_Third_Parties|FR:Module_Tiers|ES:Empresas';
 llxHeader('', $title, $help_url);
@@ -163,7 +192,16 @@ if ($object->id) {
 
 
 	// Build file list
-	$filearray = dol_dir_list($upload_dir, "files", 0, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ?SORT_DESC:SORT_ASC), 1);
+	$filearray = dol_dir_list(
+		$upload_dir,
+		'files',
+		0,
+		'',
+		'(\.meta|_preview.*\.png)$',
+		$sortfield,
+		(strtolower($sortorder) === 'desc' ? SORT_DESC : SORT_ASC),
+		1
+	);
 	$totalsize = 0;
 	foreach ($filearray as $key => $file) {
 		$totalsize += $file['size'];
@@ -171,7 +209,12 @@ if ($object->id) {
 
 	// Object card
 	// ------------------------------------------------------------
-	$linkback = '<a href="'.dol_buildpath('/mymodule/myobject_list.php', 1).'?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="' . dol_buildpath(
+			'/mymodule/myobject_list.php',
+			1
+		) . '?restore_lastsearch_values=1' . (!empty($socid) ? '&socid=' . $socid : '') . '">' . $langs->trans(
+			'BackToList'
+		) . '</a>';
 
 	$morehtmlref = '<div class="refidno">';
 	/*
@@ -221,10 +264,16 @@ if ($object->id) {
 	print '<table class="border centpercent tableforfield">';
 
 	// Number of files
-	print '<tr><td class="titlefield">'.$langs->trans("NbOfAttachedFiles").'</td><td colspan="3">'.count($filearray).'</td></tr>';
+	print '<tr><td class="titlefield">' . $langs->trans('NbOfAttachedFiles') . '</td><td colspan="3">' . count(
+			$filearray
+		) . '</td></tr>';
 
 	// Total size
-	print '<tr><td>'.$langs->trans("TotalSizeOfAttachedFiles").'</td><td colspan="3">'.$totalsize.' '.$langs->trans("bytes").'</td></tr>';
+	print '<tr><td>' . $langs->trans(
+			'TotalSizeOfAttachedFiles'
+		) . '</td><td colspan="3">' . $totalsize . ' ' . $langs->trans(
+			'bytes'
+		) . '</td></tr>';
 
 	print '</table>';
 
@@ -244,7 +293,7 @@ if ($object->id) {
 
 	include DOL_DOCUMENT_ROOT.'/core/tpl/document_actions_post_headers.tpl.php';
 } else {
-	accessforbidden('', 0, 1);
+	accessforbidden('', 0);
 }
 
 // End of page

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -363,10 +363,10 @@ foreach ($search as $key => $val) {
 		$columnName = preg_replace('/(_dtstart|_dtend)$/', '', $key);
 		if (preg_match('/^(date|timestamp|datetime)/', $object->fields[$columnName]['type'])) {
 			if (preg_match('/_dtstart$/', $key)) {
-				$sql .= ' AND t.' . $columnName . " >= '" . $db->idate($val) . "'";
+				$sql .= ' AND t.' . $db->escape($columnName) . " >= '" . $db->idate($val) . "'";
 			}
 			if (preg_match('/_dtend$/', $key)) {
-				$sql .= ' AND t.' . $columnName . " <= '" . $db->idate($val) . "'";
+				$sql .= ' AND t.' . $db->escape($columnName) . " <= '" . $db->idate($val) . "'";
 			}
 		}
 	}

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -17,62 +17,82 @@
  */
 
 /**
- *   	\file       htdocs/modulebuilder/template/myobject_list.php
- *		\ingroup    mymodule
- *		\brief      List page for myobject
+ *    \file       htdocs/modulebuilder/template/myobject_list.php
+ *        \ingroup    mymodule
+ *        \brief      List page for myobject
  */
+
+declare(strict_types=1);
 
 //if (! defined('NOREQUIREDB'))              define('NOREQUIREDB', '1');				// Do not create database handler $db
 //if (! defined('NOREQUIREUSER'))            define('NOREQUIREUSER', '1');				// Do not load object $user
 //if (! defined('NOREQUIRESOC'))             define('NOREQUIRESOC', '1');				// Do not load object $mysoc
 //if (! defined('NOREQUIRETRAN'))            define('NOREQUIRETRAN', '1');				// Do not load object $langs
-//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');		// Do not check injection attack on GET parameters
-//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');		// Do not check injection attack on POST parameters
-//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');				// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
-//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');				// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
-//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');				// Do not check style html tag into posted data
-//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');				// If there is no need to load and show top and left menu
-//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');				// If we don't need to load the html.form.class.php
+//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');
+//// Do not check injection attack on GET parameters
+//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');
+//// Do not check injection attack on POST parameters
+//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');
+//// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
+//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');
+//// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
+//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');
+//// Do not check style html tag into posted data
+//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');
+//// If there is no need to load and show top and left menu
+//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');
+//// If we don't need to load the html.form.class.php
 //if (! defined('NOREQUIREAJAX'))            define('NOREQUIREAJAX', '1');       	  	// Do not load ajax.lib.php library
-//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');					// If this page is public (can be called outside logged session). This include the NOIPCHECK too.
-//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');					// Do not check IP defined into conf $dolibarr_main_restrict_ip
-//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');					// Force lang to a particular value
-//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');	// Force authentication handler
-//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);		// The main.inc.php does not make a redirect if not logged, instead show simple error message
-//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');				// Disable all Content Security Policies
-//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');		// Force use of CSRF protection with tokens even for GET
-//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');				// Disable browser notification
-//if (! defined('NOSESSION'))                define('NOSESSION', '1');					// On CLI mode, no need to use web sessions
+//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');
+//// If this page is public (can be called outside logged session). This includes the NOIPCHECK too.
+//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');
+//// Do not check IP defined into conf $dolibarr_main_restrict_ip
+//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');
+//// Force lang to a particular value
+//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');
+//// Force authentication handler
+//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);
+//// The main.inc.php does not make a redirect if not logged, instead show simple error message
+//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');
+//// Disable all Content Security Policies
+//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');
+//// Force use of CSRF protection with tokens even for GET
+//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');
+//// Disable browser notification
 
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
@@ -80,31 +100,31 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
 
 // load mymodule libraries
-require_once __DIR__.'/class/myobject.class.php';
+require_once __DIR__ . '/class/myobject.class.php';
 
-// for other modules
+// for other modules'
 //dol_include_once('/othermodule/class/otherobject.class.php');
 
 // Load translation files required by the page
-$langs->loadLangs(array("mymodule@mymodule", "other"));
+$langs->loadLangs(['mymodule@mymodule', 'other']);
 
-$action     = GETPOST('action', 'aZ09') ?GETPOST('action', 'aZ09') : 'view'; // The action 'add', 'create', 'edit', 'update', 'view', ...
+$action = GETPOST('action', 'aZ09') ?: 'view'; // The action 'add', 'create', 'edit', 'update', 'view', ...
 $massaction = GETPOST('massaction', 'alpha'); // The bulk action (combo box choice into lists)
 $show_files = GETPOST('show_files', 'int'); // Show files area generated by bulk actions ?
-$confirm    = GETPOST('confirm', 'alpha'); // Result of a confirmation
-$cancel     = GETPOST('cancel', 'alpha'); // We click on a Cancel button
-$toselect   = GETPOST('toselect', 'array'); // Array of ids of elements selected into a list
-$contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'myobjectlist'; // To manage different context of search
+$confirm = GETPOST('confirm', 'alpha'); // Result of a confirmation
+$cancel = GETPOST('cancel', 'alpha'); // We click on a Cancel button
+$toselect = GETPOST('toselect', 'array'); // Array of ids of elements selected into a list
+$contextpage = GETPOST('contextpage', 'aZ') ?: 'myobjectlist'; // To manage different context of search
 $backtopage = GETPOST('backtopage', 'alpha'); // Go back to a dedicated page
 $optioncss = GETPOST('optioncss', 'aZ'); // Option for the css output (always '' except when 'print')
 
 $id = GETPOST('id', 'int');
 
 // Load variable for pagination
-$limit = GETPOST('limit', 'int') ? GETPOST('limit', 'int') : $conf->liste_limit;
+$limit = GETPOST('limit', 'int') ?: $conf->liste_limit;
 $sortfield = GETPOST('sortfield', 'aZ09comma');
 $sortorder = GETPOST('sortorder', 'aZ09comma');
-$page = GETPOSTISSET('pageplusone') ? (GETPOST('pageplusone') - 1) : GETPOST("page", 'int');
+$page = GETPOSTISSET('pageplusone') ? (GETPOST('pageplusone') - 1) : GETPOST('page', 'int');
 if (empty($page) || $page < 0 || GETPOST('button_search', 'alpha') || GETPOST('button_removefilter', 'alpha')) {
 	// If $page is not defined, or '' or -1 or if we click on clear filters
 	$page = 0;
@@ -116,8 +136,8 @@ $pagenext = $page + 1;
 // Initialize technical objects
 $object = new MyObject($db);
 $extrafields = new ExtraFields($db);
-$diroutputmassaction = $conf->mymodule->dir_output.'/temp/massgeneration/'.$user->id;
-$hookmanager->initHooks(array('myobjectlist')); // Note that conf->hooks_modules contains array
+$diroutputmassaction = $conf->mymodule->dir_output . '/temp/massgeneration/' . $user->id;
+$hookmanager->initHooks(['myobjectlist']); // Note that conf->hooks_modules contains array
 
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
@@ -127,28 +147,42 @@ $search_array_options = $extrafields->getOptionalsFromPost($object->table_elemen
 
 // Default sort order (if not yet defined by previous GETPOST)
 if (!$sortfield) {
-	reset($object->fields);					// Reset is required to avoid key() to return null.
-	$sortfield = "t.".key($object->fields); // Set here default search field. By default 1st field in definition.
+	reset($object->fields);                    // Reset is required to avoid key() to return null.
+	$sortfield = 't.' . key($object->fields); // Set here default search field. By default, 1st field in definition.
 }
 if (!$sortorder) {
-	$sortorder = "ASC";
+	$sortorder = 'ASC';
 }
 
 // Initialize array of search criterias
-$search_all = GETPOST('search_all', 'alphanohtml');
-$search = array();
+$search_all = GETPOST('search_all');
+$search = [];
 foreach ($object->fields as $key => $val) {
-	if (GETPOST('search_'.$key, 'alpha') !== '') {
-		$search[$key] = GETPOST('search_'.$key, 'alpha');
+	if (GETPOST('search_' . $key, 'alpha') !== '') {
+		$search[$key] = GETPOST('search_' . $key, 'alpha');
 	}
 	if (preg_match('/^(date|timestamp|datetime)/', $val['type'])) {
-		$search[$key.'_dtstart'] = dol_mktime(0, 0, 0, GETPOST('search_'.$key.'_dtstartmonth', 'int'), GETPOST('search_'.$key.'_dtstartday', 'int'), GETPOST('search_'.$key.'_dtstartyear', 'int'));
-		$search[$key.'_dtend'] = dol_mktime(23, 59, 59, GETPOST('search_'.$key.'_dtendmonth', 'int'), GETPOST('search_'.$key.'_dtendday', 'int'), GETPOST('search_'.$key.'_dtendyear', 'int'));
+		$search[$key . '_dtstart'] = dol_mktime(
+			0,
+			0,
+			0,
+			GETPOST('search_' . $key . '_dtstartmonth', 'int'),
+			GETPOST('search_' . $key . '_dtstartday', 'int'),
+			GETPOST('search_' . $key . '_dtstartyear', 'int')
+		);
+		$search[$key . '_dtend'] = dol_mktime(
+			23,
+			59,
+			59,
+			GETPOST('search_' . $key . '_dtendmonth', 'int'),
+			GETPOST('search_' . $key . '_dtendday', 'int'),
+			GETPOST('search_' . $key . '_dtendyear', 'int')
+		);
 	}
 }
 
 // List of fields to search into when doing a "search in all"
-$fieldstosearchall = array();
+$fieldstosearchall = [];
 foreach ($object->fields as $key => $val) {
 	if (!empty($val['searchall'])) {
 		$fieldstosearchall['t.'.$key] = $val['label'];
@@ -156,18 +190,18 @@ foreach ($object->fields as $key => $val) {
 }
 
 // Definition of array of fields for columns
-$arrayfields = array();
+$arrayfields = [];
 foreach ($object->fields as $key => $val) {
 	// If $val['visible']==0, then we never show the field
 	if (!empty($val['visible'])) {
 		$visible = (int) dol_eval($val['visible'], 1);
-		$arrayfields['t.'.$key] = array(
-			'label'=>$val['label'],
-			'checked'=>(($visible < 0) ? 0 : 1),
-			'enabled'=>($visible != 3 && dol_eval($val['enabled'], 1)),
-			'position'=>$val['position'],
-			'help'=> isset($val['help']) ? $val['help'] : ''
-		);
+		$arrayfields['t.' . $key] = [
+			'label' => $val['label'],
+			'checked' => (($visible < 0) ? 0 : 1),
+			'enabled' => ($visible !== 3 && dol_eval($val['enabled'], 1)),
+			'position' => $val['position'],
+			'help' => $val['help'] ?? ''
+		];
 	}
 }
 // Extra fields
@@ -186,7 +220,9 @@ if (empty($conf->mymodule->enabled)) {
 }
 
 // Security check (enable the most restrictive one)
-if ($user->socid > 0) accessforbidden();
+if ($user->socid > 0) {
+	accessforbidden();
+}
 //if ($user->socid > 0) accessforbidden();
 //$socid = 0; if ($user->socid > 0) $socid = $user->socid;
 //$isdraft = (($object->status == $object::STATUS_DRAFT) ? 1 : 0);
@@ -204,34 +240,42 @@ if (GETPOST('cancel', 'alpha')) {
 	$action = 'list';
 	$massaction = '';
 }
-if (!GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend') {
+if (!GETPOST('confirmmassaction', 'alpha') && $massaction !== 'presend' && $massaction !== 'confirm_presend') {
 	$massaction = '';
 }
 
-$parameters = array();
-$reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+$parameters = [];
+$reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action);
+// Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 }
 
 if (empty($reshook)) {
 	// Selection of new fields
-	include DOL_DOCUMENT_ROOT.'/core/actions_changeselectedfields.inc.php';
+	include DOL_DOCUMENT_ROOT . '/core/actions_changeselectedfields.inc.php';
 
 	// Purge search criteria
-	if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter.x', 'alpha') || GETPOST('button_removefilter', 'alpha')) { // All tests are required to be compatible with all browsers
+	if (GETPOST('button_removefilter_x', 'alpha') ||
+		GETPOST('button_removefilter.x', 'alpha') ||
+		GETPOST('button_removefilter', 'alpha')) {
+		// All tests are required to be compatible with all browsers
 		foreach ($object->fields as $key => $val) {
 			$search[$key] = '';
 			if (preg_match('/^(date|timestamp|datetime)/', $val['type'])) {
-				$search[$key.'_dtstart'] = '';
-				$search[$key.'_dtend'] = '';
+				$search[$key . '_dtstart'] = '';
+				$search[$key . '_dtend'] = '';
 			}
 		}
-		$toselect = array();
-		$search_array_options = array();
+		$toselect = [];
+		$search_array_options = [];
 	}
-	if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter.x', 'alpha') || GETPOST('button_removefilter', 'alpha')
-		|| GETPOST('button_search_x', 'alpha') || GETPOST('button_search.x', 'alpha') || GETPOST('button_search', 'alpha')) {
+	if (GETPOST('button_removefilter_x', 'alpha') ||
+		GETPOST('button_removefilter.x', 'alpha') ||
+		GETPOST('button_removefilter', 'alpha') ||
+		GETPOST('button_search_x', 'alpha') ||
+		GETPOST('button_search.x', 'alpha') ||
+		GETPOST('button_search', 'alpha')) {
 		$massaction = ''; // Protection to avoid mass action if we force a new search during a mass action confirmation
 	}
 
@@ -239,9 +283,8 @@ if (empty($reshook)) {
 	$objectclass = 'MyObject';
 	$objectlabel = 'MyObject';
 	$uploaddir = $conf->mymodule->dir_output;
-	include DOL_DOCUMENT_ROOT.'/core/actions_massactions.inc.php';
+	include DOL_DOCUMENT_ROOT . '/core/actions_massactions.inc.php';
 }
-
 
 
 /*
@@ -254,9 +297,9 @@ $now = dol_now();
 
 //$help_url="EN:Module_MyObject|FR:Module_MyObject_FR|ES:Módulo_MyObject";
 $help_url = '';
-$title = $langs->trans('ListOf', $langs->transnoentitiesnoconv("MyObjects"));
-$morejs = array();
-$morecss = array();
+$title = $langs->trans('ListOf', $langs->transnoentitiesnoconv('MyObjects'));
+$morejs = [];
+$morecss = [];
 
 
 // Build and execute select
@@ -266,52 +309,64 @@ $sql .= $object->getFieldList('t');
 // Add fields from extrafields
 if (!empty($extrafields->attributes[$object->table_element]['label'])) {
 	foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $val) {
-		$sql .= ($extrafields->attributes[$object->table_element]['type'][$key] != 'separate' ? ", ef.".$key." as options_".$key : '');
+		$sql .= ($extrafields->attributes[$object->table_element]['type'][$key] !== 'separate' ? ', ef.' . $key . ' as options_' . $key : '');
 	}
 }
 // Add fields from hooks
-$parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters, $object); // Note that $action and $object may have been modified by hook
+$parameters = [];
+$reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters, $object);
+// Note that $action and $object may have been modified by hook
 $sql .= preg_replace('/^,/', '', $hookmanager->resPrint);
 $sql = preg_replace('/,\s*$/', '', $sql);
-$sql .= " FROM ".MAIN_DB_PREFIX.$object->table_element." as t";
-if (isset($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label'])) {
-	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX.$object->table_element."_extrafields as ef on (t.rowid = ef.fk_object)";
+$sql .= ' FROM ' . MAIN_DB_PREFIX . $object->table_element . ' as t';
+if (isset($extrafields->attributes[$object->table_element]['label']) &&
+	is_array($extrafields->attributes[$object->table_element]['label']) &&
+	count($extrafields->attributes[$object->table_element]['label'])) {
+	$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . $object->table_element . '_extrafields as ef on (t.rowid = ef.fk_object)';
 }
 // Add table from hooks
-$parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object); // Note that $action and $object may have been modified by hook
+$parameters = [];
+$reshook = $hookmanager->executeHooks(
+	'printFieldListFrom',
+	$parameters,
+	$object
+); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
-if ($object->ismultientitymanaged == 1) {
-	$sql .= " WHERE t.entity IN (".getEntity($object->element).")";
+if ($object->ismultientitymanaged === 1) {
+	$sql .= ' WHERE t.entity IN (' . getEntity($object->element) . ')';
 } else {
-	$sql .= " WHERE 1 = 1";
+	$sql .= ' WHERE 1 = 1';
 }
 foreach ($search as $key => $val) {
 	if (array_key_exists($key, $object->fields)) {
-		if ($key == 'status' && $search[$key] == -1) {
+		if ($key === 'status' && $val === -1) {
 			continue;
 		}
 		$mode_search = (($object->isInt($object->fields[$key]) || $object->isFloat($object->fields[$key])) ? 1 : 0);
-		if ((strpos($object->fields[$key]['type'], 'integer:') === 0) || (strpos($object->fields[$key]['type'], 'sellist:') === 0) || !empty($object->fields[$key]['arrayofkeyval'])) {
-			if ($search[$key] == '-1' || ($search[$key] === '0' && (empty($object->fields[$key]['arrayofkeyval']) || !array_key_exists('0', $object->fields[$key]['arrayofkeyval'])))) {
+		if ((strncmp($object->fields[$key]['type'], 'integer:', 8) === 0) || (strncmp(
+					$object->fields[$key]['type'],
+					'sellist:',
+					8
+				) === 0) || !empty($object->fields[$key]['arrayofkeyval'])) {
+			if ($val === '-1' || ($val === '0' && (empty($object->fields[$key]['arrayofkeyval']) || !array_key_exists(
+							'0',
+							$object->fields[$key]['arrayofkeyval']
+						)))) {
 				$search[$key] = '';
 			}
 			$mode_search = 2;
 		}
-		if ($search[$key] != '') {
-			$sql .= natural_search($key, $search[$key], (($key == 'status') ? 2 : $mode_search));
+		if ($search[$key] !== '') {
+			$sql .= natural_search($key, $search[$key], (($key === 'status') ? 2 : $mode_search));
 		}
-	} else {
-		if (preg_match('/(_dtstart|_dtend)$/', $key) && $search[$key] != '') {
-			$columnName = preg_replace('/(_dtstart|_dtend)$/', '', $key);
-			if (preg_match('/^(date|timestamp|datetime)/', $object->fields[$columnName]['type'])) {
-				if (preg_match('/_dtstart$/', $key)) {
-					$sql .= " AND t.".$columnName." >= '".$db->idate($search[$key])."'";
-				}
-				if (preg_match('/_dtend$/', $key)) {
-					$sql .= " AND t." . $columnName . " <= '" . $db->idate($search[$key]) . "'";
-				}
+	} elseif (preg_match('/(_dtstart|_dtend)$/', $key) && $val !== '') {
+		$columnName = preg_replace('/(_dtstart|_dtend)$/', '', $key);
+		if (preg_match('/^(date|timestamp|datetime)/', $object->fields[$columnName]['type'])) {
+			if (preg_match('/_dtstart$/', $key)) {
+				$sql .= ' AND t.' . $columnName . " >= '" . $db->idate($val) . "'";
+			}
+			if (preg_match('/_dtend$/', $key)) {
+				$sql .= ' AND t.' . $columnName . " <= '" . $db->idate($val) . "'";
 			}
 		}
 	}
@@ -321,10 +376,11 @@ if ($search_all) {
 }
 //$sql.= dolSqlDateFilter("t.field", $search_xxxday, $search_xxxmonth, $search_xxxyear);
 // Add where from extra fields
-include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
+include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_sql.tpl.php';
 // Add where from hooks
-$parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $object); // Note that $action and $object may have been modified by hook
+$parameters = [];
+$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $object);
+// Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
 
 /* If a group by is required
@@ -340,7 +396,8 @@ if (!empty($extrafields->attributes[$object->table_element]['label'])) {
 }
 // Add where from hooks
 $parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListGroupBy', $parameters, $object);    // Note that $action and $object may have been modified by hook
+$reshook = $hookmanager->executeHooks('printFieldListGroupBy', $parameters, $object);
+// Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
 $sql = preg_replace('/,\s*$/', '', $sql);
 */
@@ -348,7 +405,8 @@ $sql = preg_replace('/,\s*$/', '', $sql);
 // Add HAVING from hooks
 /*
 $parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListHaving', $parameters, $object); // Note that $action and $object may have been modified by hook
+$reshook = $hookmanager->executeHooks('printFieldListHaving', $parameters, $object);
+// Note that $action and $object may have been modified by hook
 $sql .= !empty($hookmanager->resPrint) ? (" HAVING 1=1 " . $hookmanager->resPrint) : "";
 */
 
@@ -365,11 +423,12 @@ if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST)) {
 		$nbtotalofrecords++;
 	}*/
 	/* The fast and low memory method to get and count full list converts the sql into a sql count */
-	$sqlforcount = preg_replace('/^SELECT[a-z0-9\._\s\(\),]+FROM/i', 'SELECT COUNT(*) as nbtotalofrecords FROM', $sql);
+	$sqlforcount = preg_replace('/^SELECT[a-z0-9._\s(),]+FROM/i', 'SELECT COUNT(*) as nbtotalofrecords FROM', $sql);
 	$resql = $db->query($sqlforcount);
 	$objforcount = $db->fetch_object($resql);
 	$nbtotalofrecords = $objforcount->nbtotalofrecords;
-	if (($page * $limit) > $nbtotalofrecords) {	// if total of record found is smaller than page * limit, goto and load page 0
+	if (($page * $limit) > $nbtotalofrecords) {
+		// if total of record found is smaller than page * limit, goto and load page 0
 		$page = 0;
 		$offset = 0;
 	}
@@ -392,10 +451,10 @@ $num = $db->num_rows($resql);
 
 
 // Direct jump if only one record found
-if ($num == 1 && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && !$page) {
+if ($num === 1 && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all && !$page) {
 	$obj = $db->fetch_object($resql);
 	$id = $obj->rowid;
-	header("Location: ".dol_buildpath('/mymodule/myobject_card.php', 1).'?id='.$id);
+	header('Location: ' . dol_buildpath('/mymodule/myobject_card.php', 1) . '?id=' . $id);
 	exit;
 }
 
@@ -420,79 +479,108 @@ llxHeader('', $title, $help_url, '', 0, 0, $morejs, $morecss, '', '');
 // });
 // </script>';
 
-$arrayofselected = is_array($toselect) ? $toselect : array();
+$arrayofselected = is_array($toselect) ? $toselect : [];
 
 $param = '';
-if (!empty($contextpage) && $contextpage != $_SERVER["PHP_SELF"]) {
-	$param .= '&contextpage='.urlencode($contextpage);
+if (!empty($contextpage) && $contextpage !== $_SERVER['PHP_SELF']) {
+	$param .= '&contextpage=' . urlencode($contextpage);
 }
-if ($limit > 0 && $limit != $conf->liste_limit) {
-	$param .= '&limit='.urlencode($limit);
+if ($limit > 0 && $limit !== $conf->liste_limit) {
+	$param .= '&limit=' . urlencode($limit);
 }
 foreach ($search as $key => $val) {
-	if (is_array($search[$key]) && count($search[$key])) {
-		foreach ($search[$key] as $skey) {
-			if ($skey != '') {
-				$param .= '&search_'.$key.'[]='.urlencode($skey);
+	if (is_array($val) && count($val)) {
+		foreach ($val as $skey) {
+			if ($skey !== '') {
+				$param .= '&search_' . $key . '[]=' . urlencode($skey);
 			}
 		}
-	} elseif ($search[$key] != '') {
-		$param .= '&search_'.$key.'='.urlencode($search[$key]);
+	} elseif ($val !== '') {
+		$param .= '&search_' . $key . '=' . urlencode($val);
 	}
 }
-if ($optioncss != '') {
-	$param .= '&optioncss='.urlencode($optioncss);
+if ($optioncss !== '') {
+	$param .= '&optioncss=' . urlencode($optioncss);
 }
 // Add $param from extra fields
-include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_param.tpl.php';
+include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_param.tpl.php';
 // Add $param from hooks
-$parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListSearchParam', $parameters, $object); // Note that $action and $object may have been modified by hook
+$parameters = [];
+$reshook = $hookmanager->executeHooks('printFieldListSearchParam', $parameters, $object);
+// Note that $action and $object may have been modified by hook
 $param .= $hookmanager->resPrint;
 
 // List of mass actions available
-$arrayofmassactions = array(
+$arrayofmassactions = [
 	//'validate'=>img_picto('', 'check', 'class="pictofixedwidth"').$langs->trans("Validate"),
 	//'generate_doc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("ReGeneratePDF"),
 	//'builddoc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("PDFMerge"),
 	//'presend'=>img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
-);
+];
 if ($permissiontodelete) {
-	$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
+	$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"') . $langs->trans('Delete');
 }
-if (GETPOST('nomassaction', 'int') || in_array($massaction, array('presend', 'predelete'))) {
-	$arrayofmassactions = array();
+if (GETPOST('nomassaction', 'int') || in_array($massaction, ['presend', 'predelete'])) {
+	$arrayofmassactions = [];
 }
 $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
 
-print '<form method="POST" id="searchFormList" action="'.$_SERVER["PHP_SELF"].'">'."\n";
-if ($optioncss != '') {
-	print '<input type="hidden" name="optioncss" value="'.$optioncss.'">';
+print '<form method="POST" id="searchFormList" action="' . $_SERVER['PHP_SELF'] . '">' . "\n";
+if ($optioncss !== '') {
+	print '<input type="hidden" name="optioncss" value="' . $optioncss . '">';
 }
-print '<input type="hidden" name="token" value="'.newToken().'">';
+print '<input type="hidden" name="token" value="' . newToken() . '">';
 print '<input type="hidden" name="formfilteraction" id="formfilteraction" value="list">';
 print '<input type="hidden" name="action" value="list">';
-print '<input type="hidden" name="sortfield" value="'.$sortfield.'">';
-print '<input type="hidden" name="sortorder" value="'.$sortorder.'">';
-print '<input type="hidden" name="page" value="'.$page.'">';
-print '<input type="hidden" name="contextpage" value="'.$contextpage.'">';
+print '<input type="hidden" name="sortfield" value="' . $sortfield . '">';
+print '<input type="hidden" name="sortorder" value="' . $sortorder . '">';
+print '<input type="hidden" name="page" value="' . $page . '">';
+print '<input type="hidden" name="contextpage" value="' . $contextpage . '">';
 
-$newcardbutton = dolGetButtonTitle($langs->trans('New'), '', 'fa fa-plus-circle', dol_buildpath('/mymodule/myobject_card.php', 1).'?action=create&backtopage='.urlencode($_SERVER['PHP_SELF']), '', $permissiontoadd);
+$newcardbutton = dolGetButtonTitle(
+	$langs->trans('New'),
+	'',
+	'fa fa-plus-circle',
+	dol_buildpath('/mymodule/myobject_card.php', 1) . '?action=create&backtopage=' . urlencode($_SERVER['PHP_SELF']),
+	'',
+	$permissiontoadd
+);
 
-print_barre_liste($title, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, 'object_'.$object->picto, 0, $newcardbutton, '', $limit, 0, 0, 1);
+print_barre_liste(
+	$title,
+	$page,
+	$_SERVER['PHP_SELF'],
+	$param,
+	$sortfield,
+	$sortorder,
+	$massactionbutton,
+	$num,
+	$nbtotalofrecords,
+	'object_' . $object->picto,
+	0,
+	$newcardbutton,
+	'',
+	$limit,
+	0,
+	0,
+	1
+);
 
 // Add code for pre mass action (confirmation or email presend form)
-$topicmail = "SendMyObjectRef";
-$modelmail = "myobject";
+$topicmail = 'SendMyObjectRef';
+$modelmail = 'myobject';
 $objecttmp = new MyObject($db);
-$trackid = 'xxxx'.$object->id;
-include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
+$trackid = 'xxxx' . $object->id;
+include DOL_DOCUMENT_ROOT . '/core/tpl/massactions_pre.tpl.php';
 
 if ($search_all) {
 	foreach ($fieldstosearchall as $key => $val) {
 		$fieldstosearchall[$key] = $langs->trans($val);
 	}
-	print '<div class="divsearchfieldfilter">'.$langs->trans("FilterOnInto", $search_all).join(', ', $fieldstosearchall).'</div>';
+	print '<div class="divsearchfieldfilter">' . $langs->trans('FilterOnInto', $search_all) . implode(
+			', ',
+			$fieldstosearchall
+		) . '</div>';
 }
 
 $moreforfilter = '';
@@ -500,8 +588,9 @@ $moreforfilter = '';
 $moreforfilter.= $langs->trans('MyFilter') . ': <input type="text" name="search_myfield" value="'.dol_escape_htmltag($search_myfield).'">';
 $moreforfilter.= '</div>';*/
 
-$parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldPreListTitle', $parameters, $object); // Note that $action and $object may have been modified by hook
+$parameters = [];
+$reshook = $hookmanager->executeHooks('printFieldPreListTitle', $parameters, $object);
+// Note that $action and $object may have been modified by hook
 if (empty($reshook)) {
 	$moreforfilter .= $hookmanager->resPrint;
 } else {
@@ -514,12 +603,17 @@ if (!empty($moreforfilter)) {
 	print '</div>';
 }
 
-$varpage = empty($contextpage) ? $_SERVER["PHP_SELF"] : $contextpage;
-$selectedfields = $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage); // This also change content of $arrayfields
+$varpage = empty($contextpage) ? $_SERVER['PHP_SELF'] : $contextpage;
+$selectedfields = $form::multiSelectArrayWithCheckbox(
+	'selectedfields',
+	$arrayfields,
+	$varpage
+); // This also change content of $arrayfields
 $selectedfields .= (count($arrayofmassactions) ? $form->showCheckAddButtons('checkforselect', 1) : '');
 
-print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-print '<table class="tagtable nobottomiftotal liste'.($moreforfilter ? " listwithfilterbefore" : "").'">'."\n";
+print '<div class="div-table-responsive">';
+// You can use div-table-responsive-no-min if you don't need reserved height for your table
+print '<table class="tagtable nobottomiftotal liste' . ($moreforfilter ? ' listwithfilterbefore' : '') . '">' . "\n";
 
 
 // Fields title search
@@ -527,51 +621,112 @@ print '<table class="tagtable nobottomiftotal liste'.($moreforfilter ? " listwit
 print '<tr class="liste_titre">';
 foreach ($object->fields as $key => $val) {
 	$cssforfield = (empty($val['csslist']) ? (empty($val['css']) ? '' : $val['css']) : $val['csslist']);
-	if ($key == 'status') {
-		$cssforfield .= ($cssforfield ? ' ' : '').'center';
-	} elseif (in_array($val['type'], array('date', 'datetime', 'timestamp'))) {
-		$cssforfield .= ($cssforfield ? ' ' : '').'center';
-	} elseif (in_array($val['type'], array('timestamp'))) {
-		$cssforfield .= ($cssforfield ? ' ' : '').'nowrap';
-	} elseif (in_array($val['type'], array('double(24,8)', 'double(6,3)', 'integer', 'real', 'price')) && $val['label'] != 'TechnicalID' && empty($val['arrayofkeyval'])) {
-		$cssforfield .= ($cssforfield ? ' ' : '').'right';
+	if ($key === 'status') {
+		$cssforfield .= ($cssforfield ? ' ' : '') . 'center';
+	} elseif (in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
+		$cssforfield .= ($cssforfield ? ' ' : '') . 'center';
+	} elseif ($val['type'] === 'timestamp') {
+		$cssforfield .= ($cssforfield ? ' ' : '') . 'nowrap';
+	} elseif (in_array($val['type'], ['double(24,8)', 'double(6,3)', 'integer', 'real', 'price']
+		) && $val['label'] !== 'TechnicalID' && empty($val['arrayofkeyval'])) {
+		$cssforfield .= ($cssforfield ? ' ' : '') . 'right';
 	}
-	if (!empty($arrayfields['t.'.$key]['checked'])) {
-		print '<td class="liste_titre'.($cssforfield ? ' '.$cssforfield : '').'">';
+	if (!empty($arrayfields['t.' . $key]['checked'])) {
+		print '<td class="liste_titre' . ($cssforfield ? ' ' . $cssforfield : '') . '">';
 		if (!empty($val['arrayofkeyval']) && is_array($val['arrayofkeyval'])) {
-			print $form->selectarray('search_'.$key, $val['arrayofkeyval'], (isset($search[$key]) ? $search[$key] : ''), $val['notnull'], 0, 0, '', 1, 0, 0, '', 'maxwidth100', 1);
-		} elseif ((strpos($val['type'], 'integer:') === 0) || (strpos($val['type'], 'sellist:') === 0)) {
-			print $object->showInputField($val, $key, (isset($search[$key]) ? $search[$key] : ''), '', '', 'search_', 'maxwidth125', 1);
+			print $form::selectarray(
+				'search_' . $key,
+				$val['arrayofkeyval'],
+				($search[$key] ?? ''),
+				$val['notnull'],
+				0,
+				0,
+				'',
+				1,
+				0,
+				0,
+				'',
+				'maxwidth100'
+			);
+		} elseif ((strncmp($val['type'], 'integer:', 8) === 0) || (strncmp($val['type'], 'sellist:', 8) === 0)) {
+			print $object->showInputField($val, $key, ($search[$key] ?? ''), '', '', 'search_', 'maxwidth125', 1);
 		} elseif (preg_match('/^(date|timestamp|datetime)/', $val['type'])) {
 			print '<div class="nowrap">';
-			print $form->selectDate($search[$key.'_dtstart'] ? $search[$key.'_dtstart'] : '', "search_".$key."_dtstart", 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
+			print $form->selectDate(
+				$search[$key . '_dtstart'] ?: '',
+				'search_' . $key . '_dtstart',
+				0,
+				0,
+				1,
+				'',
+				1,
+				0,
+				0,
+				'',
+				'',
+				'',
+				'',
+				1,
+				'',
+				$langs->trans('From')
+			);
 			print '</div>';
 			print '<div class="nowrap">';
-			print $form->selectDate($search[$key.'_dtend'] ? $search[$key.'_dtend'] : '', "search_".$key."_dtend", 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('to'));
+			print $form->selectDate(
+				$search[$key . '_dtend'] ?: '',
+				'search_' . $key . '_dtend',
+				0,
+				0,
+				1,
+				'',
+				1,
+				0,
+				0,
+				'',
+				'',
+				'',
+				'',
+				1,
+				'',
+				$langs->trans('to')
+			);
 			print '</div>';
-		} elseif ($key == 'lang') {
-			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
+		} elseif ($key === 'lang') {
+			require_once DOL_DOCUMENT_ROOT . '/core/class/html.formadmin.class.php';
 			$formadmin = new FormAdmin($db);
-			print $formadmin->select_language($search[$key], 'search_lang', 0, null, 1, 0, 0, 'minwidth150 maxwidth200', 2);
+			print $formadmin->select_language(
+				$search[$key],
+				'search_lang',
+				0,
+				null,
+				1,
+				0,
+				0,
+				'minwidth150 maxwidth200',
+				2
+			);
 		} else {
-			print '<input type="text" class="flat maxwidth75" name="search_'.$key.'" value="'.dol_escape_htmltag(isset($search[$key]) ? $search[$key] : '').'">';
+			print '<input type="text" class="flat maxwidth75" name="search_' . $key . '" value="' . dol_escape_htmltag(
+					$search[$key] ?? ''
+				) . '">';
 		}
 		print '</td>';
 	}
 }
 // Extra fields
-include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_input.tpl.php';
+include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_input.tpl.php';
 
 // Fields from hook
-$parameters = array('arrayfields'=>$arrayfields);
-$reshook = $hookmanager->executeHooks('printFieldListOption', $parameters, $object); // Note that $action and $object may have been modified by hook
+$parameters = ['arrayfields' => $arrayfields];
+$reshook = $hookmanager->executeHooks('printFieldListOption', $parameters, $object);
+// Note that $action and $object may have been modified by hook
 print $hookmanager->resPrint;
 // Action column
 print '<td class="liste_titre maxwidthsearch">';
 $searchpicto = $form->showFilterButtons();
 print $searchpicto;
 print '</td>';
-print '</tr>'."\n";
+print '</tr>' . "\n";
 
 
 // Fields title label
@@ -579,33 +734,62 @@ print '</tr>'."\n";
 print '<tr class="liste_titre">';
 foreach ($object->fields as $key => $val) {
 	$cssforfield = (empty($val['csslist']) ? (empty($val['css']) ? '' : $val['css']) : $val['csslist']);
-	if ($key == 'status') {
-		$cssforfield .= ($cssforfield ? ' ' : '').'center';
-	} elseif (in_array($val['type'], array('date', 'datetime', 'timestamp'))) {
-		$cssforfield .= ($cssforfield ? ' ' : '').'center';
-	} elseif (in_array($val['type'], array('timestamp'))) {
-		$cssforfield .= ($cssforfield ? ' ' : '').'nowrap';
-	} elseif (in_array($val['type'], array('double(24,8)', 'double(6,3)', 'integer', 'real', 'price')) && $val['label'] != 'TechnicalID' && empty($val['arrayofkeyval'])) {
-		$cssforfield .= ($cssforfield ? ' ' : '').'right';
+	if ($key === 'status') {
+		$cssforfield .= ($cssforfield ? ' ' : '') . 'center';
+	} elseif (in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
+		$cssforfield .= ($cssforfield ? ' ' : '') . 'center';
+	} elseif ($val['type'] === 'timestamp') {
+		$cssforfield .= ($cssforfield ? ' ' : '') . 'nowrap';
+	} elseif (in_array($val['type'], ['double(24,8)', 'double(6,3)', 'integer', 'real', 'price']
+		) && $val['label'] !== 'TechnicalID' && empty($val['arrayofkeyval'])) {
+		$cssforfield .= ($cssforfield ? ' ' : '') . 'right';
 	}
-	if (!empty($arrayfields['t.'.$key]['checked'])) {
-		print getTitleFieldOfList($arrayfields['t.'.$key]['label'], 0, $_SERVER['PHP_SELF'], 't.'.$key, '', $param, ($cssforfield ? 'class="'.$cssforfield.'"' : ''), $sortfield, $sortorder, ($cssforfield ? $cssforfield.' ' : ''))."\n";
+	if (!empty($arrayfields['t.' . $key]['checked'])) {
+		print getTitleFieldOfList(
+				$arrayfields['t.' . $key]['label'],
+				0,
+				$_SERVER['PHP_SELF'],
+				't.' . $key,
+				'',
+				$param,
+				($cssforfield ? 'class="' . $cssforfield . '"' : ''),
+				$sortfield,
+				$sortorder,
+				($cssforfield ? $cssforfield . ' ' : '')
+			) . "\n";
 	}
 }
 // Extra fields
-include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_title.tpl.php';
+include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_search_title.tpl.php';
 // Hook fields
-$parameters = array('arrayfields'=>$arrayfields, 'param'=>$param, 'sortfield'=>$sortfield, 'sortorder'=>$sortorder);
-$reshook = $hookmanager->executeHooks('printFieldListTitle', $parameters, $object); // Note that $action and $object may have been modified by hook
+$parameters = compact('arrayfields', 'param', 'sortfield', 'sortorder');
+$reshook = $hookmanager->executeHooks(
+	'printFieldListTitle',
+	$parameters,
+	$object
+); // Note that $action and $object may have been modified by hook
 print $hookmanager->resPrint;
 // Action column
-print getTitleFieldOfList($selectedfields, 0, $_SERVER["PHP_SELF"], '', '', '', '', $sortfield, $sortorder, 'center maxwidthsearch ')."\n";
-print '</tr>'."\n";
+print getTitleFieldOfList(
+		$selectedfields,
+		0,
+		$_SERVER['PHP_SELF'],
+		'',
+		'',
+		'',
+		'',
+		$sortfield,
+		$sortorder,
+		'center maxwidthsearch '
+	) . "\n";
+print '</tr>' . "\n";
 
 
 // Detect if we need a fetch on each output line
 $needToFetchEachLine = 0;
-if (isset($extrafields->attributes[$object->table_element]['computed']) && is_array($extrafields->attributes[$object->table_element]['computed']) && count($extrafields->attributes[$object->table_element]['computed']) > 0) {
+if (isset($extrafields->attributes[$object->table_element]['computed']) && is_array(
+		$extrafields->attributes[$object->table_element]['computed']
+	) && count($extrafields->attributes[$object->table_element]['computed']) > 0) {
 	foreach ($extrafields->attributes[$object->table_element]['computed'] as $key => $val) {
 		if (preg_match('/\$object/', $val)) {
 			$needToFetchEachLine++; // There is at least one compute field that use $object
@@ -617,7 +801,7 @@ if (isset($extrafields->attributes[$object->table_element]['computed']) && is_ar
 // Loop on record
 // --------------------------------------------------------------------
 $i = 0;
-$totalarray = array();
+$totalarray = [];
 $totalarray['nbfield'] = 0;
 while ($i < ($limit ? min($num, $limit) : $num)) {
 	$obj = $db->fetch_object($resql);
@@ -632,31 +816,32 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 	print '<tr class="oddeven">';
 	foreach ($object->fields as $key => $val) {
 		$cssforfield = (empty($val['csslist']) ? (empty($val['css']) ? '' : $val['css']) : $val['csslist']);
-		if (in_array($val['type'], array('date', 'datetime', 'timestamp'))) {
-			$cssforfield .= ($cssforfield ? ' ' : '').'center';
-		} elseif ($key == 'status') {
-			$cssforfield .= ($cssforfield ? ' ' : '').'center';
+		if (in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
+			$cssforfield .= ($cssforfield ? ' ' : '') . 'center';
+		} elseif ($key === 'status') {
+			$cssforfield .= ($cssforfield ? ' ' : '') . 'center';
 		}
 
-		if (in_array($val['type'], array('timestamp'))) {
-			$cssforfield .= ($cssforfield ? ' ' : '').'nowrap';
-		} elseif ($key == 'ref') {
-			$cssforfield .= ($cssforfield ? ' ' : '').'nowrap';
+		if ($val['type'] === 'timestamp') {
+			$cssforfield .= ($cssforfield ? ' ' : '') . 'nowrap';
+		} elseif ($key === 'ref') {
+			$cssforfield .= ($cssforfield ? ' ' : '') . 'nowrap';
 		}
 
-		if (in_array($val['type'], array('double(24,8)', 'double(6,3)', 'integer', 'real', 'price')) && !in_array($key, array('rowid', 'status')) && empty($val['arrayofkeyval'])) {
-			$cssforfield .= ($cssforfield ? ' ' : '').'right';
+		if (in_array($val['type'], ['double(24,8)', 'double(6,3)', 'integer', 'real', 'price']
+			) && !in_array($key, ['rowid', 'status']) && empty($val['arrayofkeyval'])) {
+			$cssforfield .= ($cssforfield ? ' ' : '') . 'right';
 		}
 		//if (in_array($key, array('fk_soc', 'fk_user', 'fk_warehouse'))) $cssforfield = 'tdoverflowmax100';
 
-		if (!empty($arrayfields['t.'.$key]['checked'])) {
-			print '<td'.($cssforfield ? ' class="'.$cssforfield.'"' : '').'>';
-			if ($key == 'status') {
+		if (!empty($arrayfields['t.' . $key]['checked'])) {
+			print '<td' . ($cssforfield ? ' class="' . $cssforfield . '"' : '') . '>';
+			if ($key === 'status') {
 				print $object->getLibStatut(5);
-			} elseif ($key == 'rowid') {
-				print $object->showOutputField($val, $key, $object->id, '');
+			} elseif ($key === 'rowid') {
+				print $object->showOutputField($val, $key, $object->id);
 			} else {
-				print $object->showOutputField($val, $key, $object->$key, '');
+				print $object->showOutputField($val, $key, $object->$key);
 			}
 			print '</td>';
 			if (!$i) {
@@ -664,32 +849,35 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 			}
 			if (!empty($val['isameasure'])) {
 				if (!$i) {
-					$totalarray['pos'][$totalarray['nbfield']] = 't.'.$key;
+					$totalarray['pos'][$totalarray['nbfield']] = 't.' . $key;
 				}
 				if (!isset($totalarray['val'])) {
-					$totalarray['val'] = array();
+					$totalarray['val'] = [];
 				}
-				if (!isset($totalarray['val']['t.'.$key])) {
-					$totalarray['val']['t.'.$key] = 0;
+				if (!isset($totalarray['val']['t.' . $key])) {
+					$totalarray['val']['t.' . $key] = 0;
 				}
-				$totalarray['val']['t.'.$key] += $object->$key;
+				$totalarray['val']['t.' . $key] += $object->$key;
 			}
 		}
 	}
 	// Extra fields
-	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_print_fields.tpl.php';
+	include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_print_fields.tpl.php';
 	// Fields from hook
-	$parameters = array('arrayfields'=>$arrayfields, 'object'=>$object, 'obj'=>$obj, 'i'=>$i, 'totalarray'=>&$totalarray);
-	$reshook = $hookmanager->executeHooks('printFieldListValue', $parameters, $object); // Note that $action and $object may have been modified by hook
+	$parameters = compact('arrayfields', 'object', 'obj', 'i', 'totalarray');
+	$reshook = $hookmanager->executeHooks('printFieldListValue', $parameters, $object);
+	// Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	// Action column
 	print '<td class="nowrap center">';
-	if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
+	if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined)
+		// or if we have already selected and sent an action ($massaction) defined
 		$selected = 0;
-		if (in_array($object->id, $arrayofselected)) {
+		if (in_array($object->id, $arrayofselected, true)) {
 			$selected = 1;
 		}
-		print '<input id="cb'.$object->id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$object->id.'"'.($selected ? ' checked="checked"' : '').'>';
+		print '<input id="cb' . $object->id . '" class="flat checkforselect" type="checkbox"
+				name="toselect[]" value="' . $object->id . '"' . ($selected ? ' checked="checked"' : '') . '>';
 	}
 	print '</td>';
 	if (!$i) {
@@ -705,46 +893,67 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 include DOL_DOCUMENT_ROOT.'/core/tpl/list_print_total.tpl.php';
 
 // If no record found
-if ($num == 0) {
+if ($num === 0) {
 	$colspan = 1;
 	foreach ($arrayfields as $key => $val) {
 		if (!empty($val['checked'])) {
 			$colspan++;
 		}
 	}
-	print '<tr><td colspan="'.$colspan.'" class="opacitymedium">'.$langs->trans("NoRecordFound").'</td></tr>';
+	print '<tr><td colspan="' . $colspan . '" class="opacitymedium">' . $langs->trans('NoRecordFound') . '</td></tr>';
 }
 
 
 $db->free($resql);
 
-$parameters = array('arrayfields'=>$arrayfields, 'sql'=>$sql);
-$reshook = $hookmanager->executeHooks('printFieldListFooter', $parameters, $object); // Note that $action and $object may have been modified by hook
+$parameters = compact('arrayfields', 'sql');
+$reshook = $hookmanager->executeHooks('printFieldListFooter', $parameters, $object);
+// Note that $action and $object may have been modified by hook
 print $hookmanager->resPrint;
 
-print '</table>'."\n";
-print '</div>'."\n";
+print '</table>' . "\n";
+print '</div>' . "\n";
 
-print '</form>'."\n";
+print '</form>' . "\n";
 
-if (in_array('builddoc', $arrayofmassactions) && ($nbtotalofrecords === '' || $nbtotalofrecords)) {
+if (in_array('builddoc', $arrayofmassactions, true) && ($nbtotalofrecords === '' || $nbtotalofrecords)) {
 	$hidegeneratedfilelistifempty = 1;
-	if ($massaction == 'builddoc' || $action == 'remove_file' || $show_files) {
+	if ($massaction === 'builddoc' || $action === 'remove_file' || $show_files) {
 		$hidegeneratedfilelistifempty = 0;
 	}
 
-	require_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
+	require_once DOL_DOCUMENT_ROOT . '/core/class/html.formfile.class.php';
 	$formfile = new FormFile($db);
 
 	// Show list of available documents
-	$urlsource = $_SERVER['PHP_SELF'].'?sortfield='.$sortfield.'&sortorder='.$sortorder;
+	$urlsource = $_SERVER['PHP_SELF'] . '?sortfield=' . $sortfield . '&sortorder=' . $sortorder;
 	$urlsource .= str_replace('&amp;', '&', $param);
 
 	$filedir = $diroutputmassaction;
 	$genallowed = $permissiontoread;
 	$delallowed = $permissiontoadd;
 
-	print $formfile->showdocuments('massfilesarea_mymodule', '', $filedir, $urlsource, 0, $delallowed, '', 1, 1, 0, 48, 1, $param, $title, '', '', '', null, $hidegeneratedfilelistifempty);
+	print $formfile->showdocuments(
+		'massfilesarea_mymodule',
+		'',
+		$filedir,
+		$urlsource,
+		0,
+		$delallowed,
+		'',
+		1,
+		1,
+		0,
+		48,
+		1,
+		$param,
+		$title,
+		'',
+		'',
+		'',
+		null,
+		$hidegeneratedfilelistifempty
+	);
 }
 
 // End of page

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -363,10 +363,10 @@ foreach ($search as $key => $val) {
 		$columnName = preg_replace('/(_dtstart|_dtend)$/', '', $key);
 		if (preg_match('/^(date|timestamp|datetime)/', $object->fields[$columnName]['type'])) {
 			if (preg_match('/_dtstart$/', $key)) {
-				$sql .= ' AND t.' . $db->escape($columnName) . " >= '" . $db->idate($val) . "'";
+				$sql .= ' AND t.' . $columnName . ' >= "' . $db->idate($val) . '"';
 			}
 			if (preg_match('/_dtend$/', $key)) {
-				$sql .= ' AND t.' . $db->escape($columnName) . " <= '" . $db->idate($val) . "'";
+				$sql .= ' AND t.' . $columnName . ' <= "' . $db->idate($val) . '"';
 			}
 		}
 	}

--- a/htdocs/modulebuilder/template/myobject_note.php
+++ b/htdocs/modulebuilder/template/myobject_note.php
@@ -22,87 +22,109 @@
  *  \brief      Tab for notes on MyObject
  */
 
+declare(strict_types=1);
+
 //if (! defined('NOREQUIREDB'))              define('NOREQUIREDB', '1');				// Do not create database handler $db
 //if (! defined('NOREQUIREUSER'))            define('NOREQUIREUSER', '1');				// Do not load object $user
 //if (! defined('NOREQUIRESOC'))             define('NOREQUIRESOC', '1');				// Do not load object $mysoc
 //if (! defined('NOREQUIRETRAN'))            define('NOREQUIRETRAN', '1');				// Do not load object $langs
-//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');		// Do not check injection attack on GET parameters
-//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');		// Do not check injection attack on POST parameters
-//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');				// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
-//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');				// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
-//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');				// Do not check style html tag into posted data
-//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');				// If there is no need to load and show top and left menu
-//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');				// If we don't need to load the html.form.class.php
+//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');
+//// Do not check injection attack on GET parameters
+//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');
+//// Do not check injection attack on POST parameters
+//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');
+//// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
+//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');
+//// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
+//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');
+//// Do not check style html tag into posted data
+//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');
+//// If there is no need to load and show top and left menu
+//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');
+//// If we don't need to load the html.form.class.php
 //if (! defined('NOREQUIREAJAX'))            define('NOREQUIREAJAX', '1');       	  	// Do not load ajax.lib.php library
-//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');					// If this page is public (can be called outside logged session). This include the NOIPCHECK too.
-//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');					// Do not check IP defined into conf $dolibarr_main_restrict_ip
-//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');					// Force lang to a particular value
-//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');	// Force authentication handler
-//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);		// The main.inc.php does not make a redirect if not logged, instead show simple error message
-//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');				// Disable all Content Security Policies
-//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');		// Force use of CSRF protection with tokens even for GET
-//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');				// Disable browser notification
+//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');
+//// If this page is public (can be called outside logged session). This includes the NOIPCHECK too.
+//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');
+//// Do not check IP defined into conf $dolibarr_main_restrict_ip
+//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');
+//// Force lang to a particular value
+//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');
+//// Force authentication handler
+//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);
+//// The main.inc.php does not make a redirect if not logged, instead show simple error message
+//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');
+//// Disable all Content Security Policies
+//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');
+//// Force use of CSRF protection with tokens even for GET
+//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');
+//// Disable browser notification
 
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
-	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
 // Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
 // Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
 }
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	die("Include of main fails");
+	die('Include of main fails');
 }
 
 dol_include_once('/mymodule/class/myobject.class.php');
 dol_include_once('/mymodule/lib/mymodule_myobject.lib.php');
 
 // Load translation files required by the page
-$langs->loadLangs(array("mymodule@mymodule", "companies"));
+$langs->loadLangs(['mymodule@mymodule', 'companies']);
 
 // Get parameters
 $id = GETPOST('id', 'int');
-$ref        = GETPOST('ref', 'alpha');
+$ref = GETPOST('ref', 'alpha');
 $action = GETPOST('action', 'aZ09');
-$cancel     = GETPOST('cancel', 'aZ09');
+$cancel = GETPOST('cancel', 'aZ09');
 $backtopage = GETPOST('backtopage', 'alpha');
 
 // Initialize technical objects
 $object = new MyObject($db);
 $extrafields = new ExtraFields($db);
-$diroutputmassaction = $conf->mymodule->dir_output.'/temp/massgeneration/'.$user->id;
-$hookmanager->initHooks(array('myobjectnote', 'globalcard')); // Note that conf->hooks_modules contains array
+$diroutputmassaction = $conf->mymodule->dir_output . '/temp/massgeneration/' . $user->id;
+$hookmanager->initHooks(['myobjectnote', 'globalcard']); // Note that conf->hooks_modules contains array
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
 
 // Load object
-include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be include, not include_once  // Must be include, not include_once. Include fetch and fetch_thirdparty but not fetch_optionals
+include DOL_DOCUMENT_ROOT . '/core/actions_fetchobject.inc.php';
+// Must be included, not include_once. Include fetch and fetch_thirdparty but not fetch_optionals
 if ($id > 0 || !empty($ref)) {
-	$upload_dir = $conf->mymodule->multidir_output[$object->entity]."/".$object->id;
+	$upload_dir = $conf->mymodule->multidir_output[$object->entity] . '/' . $object->id;
 }
 
-$permissionnote = $user->rights->mymodule->myobject->write; // Used by the include of actions_setnotes.inc.php
-$permissiontoadd = $user->rights->mymodule->myobject->write; // Used by the include of actions_addupdatedelete.inc.php
+$permissionnote = $user->rights->mymodule->myobject->write; // Used by to include of actions_setnotes.inc.php
+$permissiontoadd = $user->rights->mymodule->myobject->write; // Used by to include of actions_addupdatedelete.inc.php
 
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();
@@ -117,12 +139,17 @@ $permissiontoadd = $user->rights->mymodule->myobject->write; // Used by the incl
  * Actions
  */
 
-$reshook = $hookmanager->executeHooks('doActions', array(), $object, $action); // Note that $action and $object may have been modified by some hooks
+$reshook = $hookmanager->executeHooks(
+	'doActions',
+	[],
+	$object,
+	$action
+); // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 }
 if (empty($reshook)) {
-	include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php'; // Must be include, not include_once
+	include DOL_DOCUMENT_ROOT . '/core/actions_setnotes.inc.php'; // Must be included, not include_once
 }
 
 
@@ -145,47 +172,109 @@ if ($id > 0 || !empty($ref)) {
 
 	// Object card
 	// ------------------------------------------------------------
-	$linkback = '<a href="'.dol_buildpath('/mymodule/myobject_list.php', 1).'?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="' . dol_buildpath(
+			'/mymodule/myobject_list.php',
+			1
+		) . '?restore_lastsearch_values=1' . (!empty($socid) ? '&socid=' . $socid : '') . '">' . $langs->trans(
+			'BackToList'
+		) . '</a>';
 
 	$morehtmlref = '<div class="refidno">';
-	/*
-	 // Ref customer
-	 $morehtmlref.=$form->editfieldkey("RefCustomer", 'ref_client', $object->ref_client, $object, 0, 'string', '', 0, 1);
-	 $morehtmlref.=$form->editfieldval("RefCustomer", 'ref_client', $object->ref_client, $object, 0, 'string', '', null, null, '', 1);
-	 // Thirdparty
-	 $morehtmlref.='<br>'.$langs->trans('ThirdParty') . ' : ' . (is_object($object->thirdparty) ? $object->thirdparty->getNomUrl(1) : '');
-	 // Project
-	 if (! empty($conf->projet->enabled))
-	 {
-	 $langs->load("projects");
-	 $morehtmlref.='<br>'.$langs->trans('Project') . ' ';
-	 if ($permissiontoadd)
-	 {
-	 if ($action != 'classify')
-	 //$morehtmlref.='<a class="editfielda" href="' . $_SERVER['PHP_SELF'] . '?action=classify&token='.newToken().'&id=' . $object->id . '">' . img_edit($langs->transnoentitiesnoconv('SetProject')) . '</a> : ';
-	 $morehtmlref.=' : ';
-	 if ($action == 'classify') {
-	 //$morehtmlref.=$form->form_project($_SERVER['PHP_SELF'] . '?id=' . $object->id, $object->socid, $object->fk_project, 'projectid', 0, 0, 1, 1);
-	 $morehtmlref.='<form method="post" action="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'">';
-	 $morehtmlref.='<input type="hidden" name="action" value="classin">';
-	 $morehtmlref.='<input type="hidden" name="token" value="'.newToken().'">';
-	 $morehtmlref.=$formproject->select_projects($object->socid, $object->fk_project, 'projectid', $maxlength, 0, 1, 0, 1, 0, 0, '', 1);
-	 $morehtmlref.='<input type="submit" class="button valignmiddle" value="'.$langs->trans("Modify").'">';
-	 $morehtmlref.='</form>';
-	 } else {
-	 $morehtmlref.=$form->form_project($_SERVER['PHP_SELF'] . '?id=' . $object->id, $object->socid, $object->fk_project, 'none', 0, 0, 0, 1);
-	 }
-	 } else {
-	 if (! empty($object->fk_project)) {
-	 $proj = new Project($db);
-	 $proj->fetch($object->fk_project);
-	 $morehtmlref .= ': '.$proj->getNomUrl();
-	 } else {
-	 $morehtmlref .= '';
-	 }
-	 }
-	 }*/
-	 $morehtmlref .= '</div>';
+
+	// Ref customer
+	$morehtmlref .= $form->editfieldkey(
+		'RefCustomer',
+		'ref_client',
+		$object->ref_client,
+		$object,
+		0,
+		'string',
+		'',
+		0,
+		1
+	);
+	$morehtmlref .= $form->editfieldval(
+		'RefCustomer',
+		'ref_client',
+		$object->ref_client,
+		$object,
+		0,
+		'string',
+		'',
+		null,
+		null,
+		'',
+		1
+	);
+	// Thirdparty
+	$morehtmlref .= '<br>' . $langs->trans('ThirdParty') . ' : ' . (is_object(
+			$object->thirdparty
+		) ? $object->thirdparty->getNomUrl(1) : '');
+	// Project
+	if (!empty($conf->projet->enabled)) {
+		$langs->load('projects');
+		$morehtmlref .= '<br>' . $langs->trans('Project') . ' ';
+		if ($permissiontoadd) {
+			if ($action !== 'classify') {
+				$morehtmlref .= '<a class="editfielda" href="' . $_SERVER['PHP_SELF'] . '?action=classify
+			&token = ' . newToken() . ' & id = ' . $object->id . '">
+			' . img_edit($langs->transnoentitiesnoconv('SetProject')) . '</a> : ';
+			}
+			$morehtmlref .= ' : ';
+			if ($action === 'classify') {
+				$morehtmlref .= $form->form_project(
+					$_SERVER['PHP_SELF'] . '?id=' . $object->id,
+					$object->socid,
+					$object->fk_project,
+					'projectid',
+					0,
+					0,
+					1,
+					1
+				);
+
+				$morehtmlref .= '<form method="post" action = "' . $_SERVER['PHP_SELF'] . ' ? id = ' . $object->id . '">';
+				$morehtmlref .= '<input type="hidden" name="action" value="classin">';
+				$morehtmlref .= '<input type="hidden" name="token" value="' . newToken() . '">';
+				$morehtmlref .= $formproject->select_projects(
+					$object->socid,
+					$object->fk_project,
+					'projectid',
+					$maxlength,
+					0,
+					1,
+					0,
+					1,
+					0,
+					0,
+					'',
+					1
+				);
+				$morehtmlref .= '<input type="submit" class="button valignmiddle" value="' . $langs->trans(
+						'Modify'
+					) . '">';
+				$morehtmlref .= '</form>';
+			} else {
+				$morehtmlref .= $form->form_project(
+					$_SERVER['PHP_SELF'] . '?id=' . $object->id,
+					$object->socid,
+					$object->fk_project,
+					'none',
+					0,
+					0,
+					0,
+					1
+				);
+			}
+		} elseif (!empty($object->fk_project)) {
+			$proj = new Project($db);
+			$proj->fetch($object->fk_project);
+			$morehtmlref .= ': ' . $proj->getNomUrl();
+		} else {
+			$morehtmlref .= '';
+		}
+	}
+	$morehtmlref .= '</div>';
 
 
 	dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref', $morehtmlref);
@@ -195,8 +284,8 @@ if ($id > 0 || !empty($ref)) {
 	print '<div class="underbanner clearboth"></div>';
 
 
-	$cssclass = "titlefield";
-	include DOL_DOCUMENT_ROOT.'/core/tpl/notes.tpl.php';
+	$cssclass = 'titlefield';
+	include DOL_DOCUMENT_ROOT . '/core/tpl/notes.tpl.php';
 
 	print '</div>';
 

--- a/htdocs/modulebuilder/template/scripts/mymodule.php
+++ b/htdocs/modulebuilder/template/scripts/mymodule.php
@@ -23,36 +23,56 @@
  *      \brief      This file is an example for a command line script for module MyModule
  */
 
+declare(strict_types=1);
+
 //if (! defined('NOREQUIREDB'))              define('NOREQUIREDB', '1');				// Do not create database handler $db
 //if (! defined('NOREQUIREUSER'))            define('NOREQUIREUSER', '1');				// Do not load object $user
 //if (! defined('NOREQUIRESOC'))             define('NOREQUIRESOC', '1');				// Do not load object $mysoc
 //if (! defined('NOREQUIRETRAN'))            define('NOREQUIRETRAN', '1');				// Do not load object $langs
-//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');		// Do not check injection attack on GET parameters
-//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');		// Do not check injection attack on POST parameters
-//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');				// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
-//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');				// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
-//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');				// Do not check style html tag into posted data
-//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');				// If there is no need to load and show top and left menu
-//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');				// If we don't need to load the html.form.class.php
+//if (! defined('NOSCANGETFORINJECTION'))    define('NOSCANGETFORINJECTION', '1');
+//// Do not check injection attack on GET parameters
+//if (! defined('NOSCANPOSTFORINJECTION'))   define('NOSCANPOSTFORINJECTION', '1');
+//// Do not check injection attack on POST parameters
+//if (! defined('NOCSRFCHECK'))              define('NOCSRFCHECK', '1');
+//// Do not check CSRF attack (test on referer + on token if option MAIN_SECURITY_CSRF_WITH_TOKEN is on).
+//if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');
+//// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
+//if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');
+//// Do not check style html tag into posted data
+//if (! defined('NOREQUIREMENU'))            define('NOREQUIREMENU', '1');
+//// If there is no need to load and show top and left menu
+//if (! defined('NOREQUIREHTML'))            define('NOREQUIREHTML', '1');
+//// If we don't need to load the html.form.class.php
 //if (! defined('NOREQUIREAJAX'))            define('NOREQUIREAJAX', '1');       	  	// Do not load ajax.lib.php library
-//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');					// If this page is public (can be called outside logged session). This include the NOIPCHECK too.
-//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');					// Do not check IP defined into conf $dolibarr_main_restrict_ip
-//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');					// Force lang to a particular value
-//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');	// Force authentication handler
-//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);		// The main.inc.php does not make a redirect if not logged, instead show simple error message
-//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');				// Disable all Content Security Policies
-//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');		// Force use of CSRF protection with tokens even for GET
-//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');				// Disable browser notification
-if (!defined('NOSESSION')) define('NOSESSION', '1');	// On CLI mode, no need to use web sessions
+//if (! defined("NOLOGIN"))                  define("NOLOGIN", '1');
+//// If this page is public (can be called outside logged session). This includes the NOIPCHECK too.
+//if (! defined('NOIPCHECK'))                define('NOIPCHECK', '1');
+//// Do not check IP defined into conf $dolibarr_main_restrict_ip
+//if (! defined("MAIN_LANG_DEFAULT"))        define('MAIN_LANG_DEFAULT', 'auto');
+//// Force lang to a particular value
+//if (! defined("MAIN_AUTHENTICATION_MODE")) define('MAIN_AUTHENTICATION_MODE', 'aloginmodule');
+//// Force authentication handler
+//if (! defined("NOREDIRECTBYMAINTOLOGIN"))  define('NOREDIRECTBYMAINTOLOGIN', 1);
+//// The main.inc.php does not make a redirect if not logged, instead show simple error message
+//if (! defined("FORCECSP"))                 define('FORCECSP', 'none');
+//// Disable all Content Security Policies
+//if (! defined('CSRFCHECK_WITH_TOKEN'))     define('CSRFCHECK_WITH_TOKEN', '1');
+//// Force use of CSRF protection with tokens even for GET
+//if (! defined('NOBROWSERNOTIF'))     		 define('NOBROWSERNOTIF', '1');
+//// Disable browser notification
+if (!defined('NOSESSION')) {
+	define('NOSESSION', '1');
+}    // On CLI mode, no need to use web sessions
 
 
-$sapi_type = php_sapi_name();
+$sapi_type = PHP_SAPI;
 $script_file = basename(__FILE__);
 $path = __DIR__.'/';
 
 // Test if batch mode
-if (substr($sapi_type, 0, 3) == 'cgi') {
-	echo "Error: You are using PHP for CGI. To execute ".$script_file." from command line, you must use PHP for CLI mode.\n";
+if (strncmp($sapi_type, 'cgi', 3) === 0) {
+	echo 'Error: You are using PHP for CGI. To execute ' .$script_file."
+			from command line, you must use PHP for CLI mode.\n";
 	exit(-1);
 }
 
@@ -63,52 +83,62 @@ $error = 0;
 
 // -------------------- START OF YOUR CODE HERE --------------------
 @set_time_limit(0); // No timeout for this script
-define('EVEN_IF_ONLY_LOGIN_ALLOWED', 1); // Set this define to 0 if you want to lock your script when dolibarr setup is "locked to admin user only".
+const EVEN_IF_ONLY_LOGIN_ALLOWED = 1;
+// Set this defines to 0 if you want to lock your script when dolibarr setup is "locked to admin user only".
 
 // Load Dolibarr environment
 $res = 0;
-// Try master.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
+// Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
+if (!empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+	$res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'] . '/main.inc.php';
 }
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/master.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/master.inc.php";
+// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while (isset($tmp[$i], $tmp2[$j]) && $i > 0 && $j > 0 && $tmp[$i] === $tmp2[$j]) {
+	$i--;
+	$j--;
 }
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/master.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/master.inc.php";
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1)) . '/main.inc.php')) {
+	$res = @include substr($tmp, 0, ($i + 1)) . '/main.inc.php';
 }
-// Try master.inc.php using relative path
-if (!$res && file_exists("../master.inc.php")) {
-	$res = @include "../master.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php')) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1))) . '/main.inc.php';
 }
-if (!$res && file_exists("../../master.inc.php")) {
-	$res = @include "../../master.inc.php";
+// Try main.inc.php using relative path
+if (!$res && file_exists('../main.inc.php')) {
+	$res = @include '../main.inc.php';
 }
-if (!$res && file_exists("../../../master.inc.php")) {
-	$res = @include "../../../master.inc.php";
+if (!$res && file_exists('../../main.inc.php')) {
+	$res = @include '../../main.inc.php';
+}
+if (!$res && file_exists('../../../main.inc.php')) {
+	$res = @include '../../../main.inc.php';
 }
 if (!$res) {
-	print "Include of master fails";
-	exit(-1);
+	die('Include of main fails');
 }
-// After this $db, $mysoc, $langs, $conf and $hookmanager are defined (Opened $db handler to database will be closed at end of file).
+
+// After this $db, $mysoc, $langs, $conf and $hookmanager are defined
+// (Opened $db handler to database will be closed at end of file).
 // $user is created but empty.
 
 //$langs->setDefaultLang('en_US'); 	// To change default language of $langs
-$langs->load("main"); // To load language file for default language
+$langs->load('main'); // To load language file for default language
 
 // Load user and its permissions
 $result = $user->fetch('', 'admin'); // Load user for login 'admin'. Comment line to run as anonymous user.
-if (!$result > 0) {
+if ((!$result) > 0) {
 	dol_print_error('', $user->error); exit;
 }
 $user->getrights();
 
 
-print "***** ".$script_file." (".$version.") pid=".dol_getmypid()." *****\n";
+print '***** ' .$script_file. ' (' .$version. ') pid=' .dol_getmypid()." *****\n";
 if (!isset($argv[1])) {	// Check parameters
-	print "Usage: ".$script_file." param1 param2 ...\n";
+	print 'Usage: ' .$script_file." param1 param2 ...\n";
 	exit(-1);
 }
 print '--- start'."\n";
@@ -199,12 +229,12 @@ else
 
 // -------------------- END OF YOUR CODE --------------------
 
-if (!$error) {
-	$db->commit();
-	print '--- end ok'."\n";
-} else {
+if ($error) {
 	print '--- end error code='.$error."\n";
 	$db->rollback();
+} else {
+	$db->commit();
+	print '--- end ok'."\n";
 }
 
 $db->close(); // Close $db database opened handler

--- a/htdocs/modulebuilder/template/test/phpunit/MyModuleFunctionalTest.php
+++ b/htdocs/modulebuilder/template/test/phpunit/MyModuleFunctionalTest.php
@@ -24,8 +24,11 @@
  * Put detailed description here.
  */
 
+declare(strict_types=1);
+
 namespace test\functional;
 
+use PHPUnit_Extensions_Selenium2TestCase;
 use PHPUnit_Extensions_Selenium2TestCase_WebDriverException;
 
 /**
@@ -41,34 +44,34 @@ use PHPUnit_Extensions_Selenium2TestCase_WebDriverException;
  *
  * @package Testmymodule
  */
-class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
+class MyModuleFunctionalTest extends PHPUnit_Extensions_Selenium2TestCase
 {
 	// TODO: move to a global configuration file?
 	/** @var string Base URL of the webserver under test */
-	protected static $base_url = 'http://dev.zenfusion.fr';
+	protected static string $base_url = 'https://dev.zenfusion.fr';
 	/**
 	 * @var string Dolibarr admin username
 	 * @see authenticate
 	 */
-	protected static $dol_admin_user = 'admin';
+	protected static string $dol_admin_user = 'admin';
 	/**
 	 * @var string Dolibarr admin password
 	 * @see authenticate
 	 */
-	protected static $dol_admin_pass = 'admin';
+	protected static string $dol_admin_pass = 'admin';
 	/** @var int Dolibarr module ID */
-	private static $module_id = 500000; // TODO: autodetect?
+	private static int $module_id = 500000; // TODO: autodetect?
 
 	/** @var array Browsers to test with */
-	public static $browsers = array(
-		array(
+	public static array $browsers = [
+		[
 			'browser' => 'Google Chrome on Linux',
 			'browserName' => 'chrome',
 			'sessionStrategy' => 'shared',
-			'desiredCapabilities' => array()
-		),
+			'desiredCapabilities' => []
+		],
 		// Geckodriver does not keep the session at the moment?!
-		// XPath selectors also don't seem to work
+		// XPath's selectors also don't seem to work
 		//array(
 		//    'browser' => 'Mozilla Firefox on Linux',
 		//    'browserName' => 'firefox',
@@ -77,20 +80,21 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 		//        'marionette' => true,
 		//    ),
 		//)
-	);
+	];
 
 	/**
 	 * Helper function to select links by href
 	 *
-	 * @param  string  $value      Href
+	 * @param string $value Href
+	 *
 	 * @return mixed               Helper string
 	 */
-	protected function byHref($value)
+	protected function byHref(string $value)
 	{
 		$anchor = null;
 		$anchors = $this->elements($this->using('tag name')->value('a'));
 		foreach ($anchors as $anchor) {
-			if (strstr($anchor->attribute('href'), $value)) {
+			if (strpos($anchor->attribute('href'), $value) !== false) {
 				break;
 			}
 		}
@@ -101,7 +105,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * Global test setup
 	 * @return void
 	 */
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
 	}
 
@@ -109,7 +113,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * Unit test setup
 	 * @return void
 	 */
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->setSeleniumServerRequestsTimeout(3600);
 		$this->setBrowserUrl(self::$base_url);
@@ -119,7 +123,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * Verify pre conditions
 	 * @return void
 	 */
-	protected function assertPreConditions()
+	protected function assertPreConditions(): void
 	{
 	}
 
@@ -127,7 +131,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * Handle Dolibarr authentication
 	 * @return void
 	 */
-	private function authenticate()
+	private function authenticate(): void
 	{
 		try {
 			if ($this->byId('login')) {
@@ -148,7 +152,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * Test enabling developer mode
 	 * @return bool
 	 */
-	public function testEnableDeveloperMode()
+	public function testEnableDeveloperMode(): bool
 	{
 		$this->url('/admin/const.php');
 		$this->authenticate();
@@ -159,7 +163,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 		$this->byName('update')->click();
 		// Page reloaded, we need a new XPath
 		$main_features_level = $this->byXPath($main_features_level_path);
-		return $this->assertEquals('2', $main_features_level->value(), "MAIN_FEATURES_LEVEL value is 2");
+		return $this->assertEquals('2', $main_features_level->value(), 'MAIN_FEATURES_LEVEL value is 2');
 	}
 
 	/**
@@ -168,24 +172,16 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * @depends testEnableDeveloperMode
 	 * @return bool
 	 */
-	public function testModuleEnabled()
+	public function testModuleEnabled(): bool
 	{
 		$this->url('/admin/modules.php');
 		$this->authenticate();
-		$module_status_image_path = '//a[contains(@href, "'.self::$module_id.'")]/img';
+		$module_status_image_path = '//a[contains(@href, "' . self::$module_id . '")]/img';
 		$module_status_image = $this->byXPath($module_status_image_path);
-		if (strstr($module_status_image->attribute('src'), 'switch_off.png')) {
-			// Enable the module
-			$this->byHref('modMyModule')->click();
-		} else {
-			// Disable the module
-			$this->byHref('modMyModule')->click();
-			// Reenable the module
-			$this->byHref('modMyModule')->click();
-		}
+		$this->byHref('modMyModule')->click();
 		// Page reloaded, we need a new Xpath
 		$module_status_image = $this->byXPath($module_status_image_path);
-		return $this->assertContains('switch_on.png', $module_status_image->attribute('src'), "Module enabled");
+		return $this->assertContains('switch_on.png', $module_status_image->attribute('src'), 'Module enabled');
 	}
 
 	/**
@@ -194,7 +190,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * @depends testModuleEnabled
 	 * @return bool
 	 */
-	public function testConfigurationPage()
+	public function testConfigurationPage(): bool
 	{
 		$this->url('/custom/mymodule/admin/setup.php');
 		$this->authenticate();
@@ -207,7 +203,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * @depends testConfigurationPage
 	 * @return bool
 	 */
-	public function testAboutPage()
+	public function testAboutPage(): bool
 	{
 		$this->url('/custom/mymodule/admin/about.php');
 		$this->authenticate();
@@ -220,14 +216,14 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * @depends testAboutPage
 	 * @return bool
 	 */
-	public function testAboutPageRendersMarkdownReadme()
+	public function testAboutPageRendersMarkdownReadme(): bool
 	{
 		$this->url('/custom/mymodule/admin/about.php');
 		$this->authenticate();
 		return $this->assertEquals(
 			'Dolibarr Module Template (aka My Module)',
 			$this->byTag('h1')->text(),
-			"Readme title"
+			'Readme title'
 		);
 	}
 
@@ -237,11 +233,11 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * @depends testModuleEnabled
 	 * @return bool
 	 */
-	public function testBoxDeclared()
+	public function testBoxDeclared(): bool
 	{
 		$this->url('/admin/boxes.php');
 		$this->authenticate();
-		return $this->assertContains('mymodulewidget1', $this->source(), "Box enabled");
+		return $this->assertContains('mymodulewidget1', $this->source(), 'Box enabled');
 	}
 
 	/**
@@ -250,14 +246,14 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * @depends testModuleEnabled
 	 * @return bool
 	 */
-	public function testTriggerDeclared()
+	public function testTriggerDeclared(): bool
 	{
 		$this->url('/admin/triggers.php');
 		$this->authenticate();
 		return $this->assertContains(
 			'interface_99_modMyModule_MyModuleTriggers.class.php',
 			$this->byTag('body')->text(),
-			"Trigger declared"
+			'Trigger declared'
 		);
 	}
 
@@ -267,14 +263,16 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * @depends testTriggerDeclared
 	 * @return bool
 	 */
-	public function testTriggerEnabled()
+	public function testTriggerEnabled(): bool
 	{
 		$this->url('/admin/triggers.php');
 		$this->authenticate();
 		return $this->assertContains(
 			'tick.png',
-			$this->byXPath('//td[text()="interface_99_modMyModule_MyTrigger.class.php"]/following::img')->attribute('src'),
-			"Trigger enabled"
+			$this->byXPath('//td[text()="interface_99_modMyModule_MyTrigger.class.php"]/following::img')->attribute(
+				'src'
+			),
+			'Trigger enabled'
 		);
 	}
 
@@ -282,7 +280,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * Verify post conditions
 	 * @return void
 	 */
-	protected function assertPostConditions()
+	protected function assertPostConditions(): void
 	{
 	}
 
@@ -290,7 +288,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * Unit test teardown
 	 * @return void
 	 */
-	public function tearDown()
+	public function tearDown(): void
 	{
 	}
 
@@ -298,7 +296,7 @@ class MyModuleFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	 * Global test teardown
 	 * @return void
 	 */
-	public static function tearDownAfterClass()
+	public static function tearDownAfterClass(): void
 	{
 	}
 }

--- a/htdocs/modulebuilder/template/test/phpunit/MyObjectTest.php
+++ b/htdocs/modulebuilder/template/test/phpunit/MyObjectTest.php
@@ -22,11 +22,13 @@
  * \brief   PHPUnit test for MyObject class.
  */
 
+declare(strict_types=1);
+
 global $conf, $user, $langs, $db;
 //define('TEST_DB_FORCE_TYPE','mysql');	// This is to force using mysql driver
 //require_once 'PHPUnit/Autoload.php';
-require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
-require_once dirname(__FILE__).'/../../htdocs/mymodule/class/myobject.class.php';
+require_once __DIR__ . '/../../htdocs/master.inc.php';
+require_once __DIR__ . '/../../htdocs/mymodule/class/myobject.class.php';
 
 if (empty($user->id)) {
 	print "Load permissions for admin user nb 1\n";
@@ -35,7 +37,7 @@ if (empty($user->id)) {
 }
 $conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
-$langs->load("main");
+$langs->load('main');
 
 
 /**
@@ -56,7 +58,7 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 	 * Constructor
 	 * We save global variables into local variables
 	 *
-	 * @return MyObjectTest
+	 * @return void
 	 */
 	public function __construct()
 	{
@@ -69,7 +71,7 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 		$this->savlangs = $langs;
 		$this->savdb = $db;
 
-		print __METHOD__." db->type=".$db->type." user->id=".$user->id;
+		print __METHOD__ . ' db->type=' . $db->type . ' user->id=' . $user->id;
 		//print " - db ".$db->db;
 		print "\n";
 	}
@@ -79,12 +81,12 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return void
 	 */
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
 		global $conf, $user, $langs, $db;
 		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
 
-		print __METHOD__."\n";
+		print __METHOD__ . "\n";
 	}
 
 	/**
@@ -92,7 +94,7 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return void
 	 */
-	protected function setUp()
+	protected function setUp(): void
 	{
 		global $conf, $user, $langs, $db;
 		$conf = $this->savconf;
@@ -100,7 +102,7 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		print __METHOD__."\n";
+		print __METHOD__ . "\n";
 	}
 
 	/**
@@ -108,9 +110,9 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return void
 	 */
-	protected function tearDown()
+	protected function tearDown(): void
 	{
-		print __METHOD__."\n";
+		print __METHOD__ . "\n";
 	}
 
 	/**
@@ -118,12 +120,12 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return void
 	 */
-	public static function tearDownAfterClass()
+	public static function tearDownAfterClass(): void
 	{
 		global $conf, $user, $langs, $db;
 		$db->rollback();
 
-		print __METHOD__."\n";
+		print __METHOD__ . "\n";
 	}
 
 
@@ -132,7 +134,7 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return bool
 	 */
-	public function testSomething()
+	public function testSomething(): bool
 	{
 		global $conf, $user, $langs, $db;
 		$conf = $this->savconf;
@@ -142,7 +144,7 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 
 		$result = true;
 
-		print __METHOD__." result=".$result."\n";
+		print __METHOD__ . ' result=' . $result . "\n";
 		$this->assertTrue($result);
 
 		return $result;
@@ -153,7 +155,7 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return int
 	 */
-	public function testMyObjectCreate()
+	public function testMyObjectCreate(): int
 	{
 		global $conf, $user, $langs, $db;
 		$conf = $this->savconf;
@@ -165,7 +167,7 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 		$localobject->initAsSpecimen();
 		$result = $localobject->create($user);
 
-		print __METHOD__." result=".$result."\n";
+		print __METHOD__ . ' result=' . $result . "\n";
 		$this->assertLessThan($result, 0);
 
 		return $result;
@@ -174,13 +176,14 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * testMyObjectDelete
 	 *
-	 * @param	int		$id		Id of object
-	 * @return	int
+	 * @param int $id ID of object
 	 *
-	 * @depends	testMyObjectCreate
-	 * The depends says test is run only if previous is ok
+	 * @return    int
+	 *
+	 * @depends    testMyObjectCreate
+	 * The depends on says test is run only if previous is ok
 	 */
-	public function testMyObjectDelete($id)
+	public function testMyObjectDelete(int $id): int
 	{
 		global $conf, $user, $langs, $db;
 		$conf = $this->savconf;
@@ -192,7 +195,7 @@ class MyObjectTest extends \PHPUnit_Framework_TestCase
 		$result = $localobject->fetch($id);
 		$result = $localobject->delete($user);
 
-		print __METHOD__." id=".$id." result=".$result."\n";
+		print __METHOD__ . ' id=' . $id . ' result=' . $result . "\n";
 		$this->assertLessThan($result, 0);
 		return $result;
 	}


### PR DESCRIPTION
# Brief explanation
I've done some editions to module builder files to comply with PSR-12 requirements. There are still some errors, that I've decided to leave as they are for now. Some of them are:

* Unresolved include of "main.inc". There are complaints that the file cannot be found. As it is a kind of try/catch they are left.
* Some variable names do not apply to the coding convention [a-z][A-Z]. Their name includes underscoring. Left they are.
* Some lines are left long
* Some classes have large number of properties
* etc

# Changes made
## Fixes
Fixed "Unnecessary double quotes" (replaced with single quotes)
Fixed "Traditional array used" (converted to short syntax)
Fixed some invertedIF's
Fixed lines longer than 120 columns
Fixed some methods "Cyclomatic complexity" by breaking them into few methods
Fixed some obsolete attributes by removing them
Fixed some grammar
Fixed nested IF's by merging them
Fixed shor php tags used ("<?=" instead of "<?php")

## New
Added parameter's type declaration
Added propertie's type declaration
Added return type declaration for methods
Added "declare(strict_types=1);" to files

## Other
Removed redundant optional arguments
Strict comparissons applied ("===" instead of "==" and "!==" instead of "!=")

## Environment
All changes are made in PHPStorm with the PHP version set to 7.4