### PR TITLE
FIX 14.0 - due to a typo in the 'mode' parameter, the "first name" co…

### DIFF
--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -961,7 +961,7 @@ while ($i < min($num, $limit)) {
 	// Firstname
 	if (!empty($arrayfields['d.firstname']['checked'])) {
 		print '<td class="tdoverflowmax150" title="'.dol_escape_htmltag($obj->firstname).'">';
-		print $memberstatic->getNomUrl(0, 0, 'card', 'fistname');
+		print $memberstatic->getNomUrl(0, 0, 'card', 'firstname');
 		//print $obj->firstname;
 		print "</td>\n";
 		if (!$i) {


### PR DESCRIPTION
# FIX:
In the adherent list, the "first name" column shows the full name due to a typo in the $`mode` parameter when calling    `Adherent->getFullName()`.