### PR TITLE
FIX show end hours in events linked to objects

### DIFF
--- a/htdocs/core/class/html.formactions.class.php
+++ b/htdocs/core/class/html.formactions.class.php
@@ -309,7 +309,7 @@ class FormActions
 						$tmpa = dol_getdate($actioncomm->datep);
 						$tmpb = dol_getdate($actioncomm->datef);
 						if ($tmpa['mday'] == $tmpb['mday'] && $tmpa['mon'] == $tmpb['mon'] && $tmpa['year'] == $tmpb['year']) {
-							if ($tmpa['hours'] != $tmpb['hours'] || $tmpa['minutes'] != $tmpb['minutes'] && $tmpa['seconds'] != $tmpb['seconds']) {
+							if ($tmpa['hours'] != $tmpb['hours'] || $tmpa['minutes'] != $tmpb['minutes']) {
 								print '-'.dol_print_date($actioncomm->datef, 'hour', 'tzuserrel');
 							}
 						} else {


### PR DESCRIPTION
FIX show end hours in events linked to objects

- when we have one event in the same hour, we not see the end date if minutes are different

To reproduce it, you can crete one event with : 

- start date : 17/11/2021 14h15
- end date : 17/11/2021 14h45

In the third partye linked to this event you won't see the end hour : 
![image](https://user-images.githubusercontent.com/45359511/137732573-1319e932-eb46-4f3c-b023-7387f1cfe0e4.png)


So with this fix, we will see this event : 
![image](https://user-images.githubusercontent.com/45359511/137732401-c54649d6-6278-4abd-b64d-24a7698ccace.png)
