### PR TITLE
FIX 14.0 - civility field of private third party creation form has inadequate width

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1151,7 +1151,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
                         	$("#typent_id").change();
                         	$("#effectif_id").val(id_ef15);
                         	$("#effectif_id").change();
-							/* Force recompute width of a select2 field when it was hidden and then shown */
+							/* Force to recompute the width of a select2 field when it was hidden and then shown programatically */
 							if ($("#civility_id").data("select2")) {
 								$("#civility_id").select2({width: "resolve"});
 							}

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1151,6 +1151,9 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
                         	$("#typent_id").change();
                         	$("#effectif_id").val(id_ef15);
                         	$("#effectif_id").change();
+							if ($("#civility_id").data("select2")) {
+								$("#civility_id").select2({width: "resolve"});
+							}
                         	$("#TypeName").html(document.formsoc.LastName.value);
                         	document.formsoc.private.value=1;
                         });

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1151,6 +1151,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
                         	$("#typent_id").change();
                         	$("#effectif_id").val(id_ef15);
                         	$("#effectif_id").change();
+							/* Force recompute width of a select2 field when it was hidden and then shown */
 							if ($("#civility_id").data("select2")) {
 								$("#civility_id").select2({width: "resolve"});
 							}


### PR DESCRIPTION
# FIX
When you open the creation form of a third party, when you click on the radio button "Create a third party + a child contact", the civility field (select2) has a very small width. This is due to select2 calculating the width while the `<select>` has no width because it is not displayed.

The fix forces select2 to recompute the width when the element is shown.
