### PR TITLE
Allow hook 'checkSecureAccess' to change original_file

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -2867,6 +2867,7 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		if ($fuser->admin) {
 			$accessallowed = 1; // If user is admin
 		}
+
 		$tmpmodulepart = explode('-', $modulepart);
 		if (!empty($tmpmodulepart[1])) {
 				$modulepart = $tmpmodulepart[0];
@@ -2946,6 +2947,9 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		);
 		$reshook = $hookmanager->executeHooks('checkSecureAccess', $parameters, $object);
 		if ($reshook > 0) {
+			if (!empty($hookmanager->resArray['original_file'])) {
+				$original_file = $hookmanager->resArray['original_file'];
+			}
 			if (!empty($hookmanager->resArray['accessallowed'])) {
 				$accessallowed = $hookmanager->resArray['accessallowed'];
 			}


### PR DESCRIPTION
# NEW Allow `checkSecureAccess` hook to redefine the file
That small change let the user to change the file path using the `checkSecureAccess` hook.

The use case : need to access all supplier invoices (of all entities) from the main entities. Using that hook let the possibility to change the path according to the entity of the supplier invoice
