### PR TITLE
Access forbidden when the password of other users is changed

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -418,7 +418,7 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 						continue; // User can edit its own password
 					}
 					if ($subfeature == 'user' && $user->id != $objectid && $user->rights->user->user->password) {
-						continue; // User can edit its own password
+						continue; // User can edit another user's password
 					}
 
 					if (empty($user->rights->$feature->$subfeature->creer)

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -417,6 +417,9 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 					if ($subfeature == 'user' && $user->id == $objectid && $user->rights->user->self->password) {
 						continue; // User can edit its own password
 					}
+					if ($subfeature == 'user' && $user->id != $objectid && $user->rights->user->user->password) {
+						continue; // User can edit its own password
+					}
 
 					if (empty($user->rights->$feature->$subfeature->creer)
 					&& empty($user->rights->$feature->$subfeature->write)

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -2036,7 +2036,11 @@ if ($action == 'create' || $action == 'adduserldap') {
 
 			// Civility
 			print '<tr><td class="titlefieldcreate"><label for="civility_code">'.$langs->trans("UserTitle").'</label></td><td colspan="3">';
-			print $formcompany->select_civility(GETPOSTISSET("civility_code") ? GETPOST("civility_code", 'aZ09') : $object->civility_code, 'civility_code');
+			if ($caneditfield && !$object->ldap_sid) {
+				print $formcompany->select_civility(GETPOSTISSET("civility_code") ? GETPOST("civility_code", 'aZ09') : $object->civility_code, 'civility_code');
+			} elseif ($object->civility_code) {
+				print $langs->trans("Civility".$object->civility_code);
+			}
 			print '</td></tr>';
 
 			// Lastname


### PR DESCRIPTION
# Close #19064 Access forbidden when the password of other users is changed
Environment

    Version: 14.0.2
    OS: All
    Web server: All
    PHP: 7.4.13
    Database: MariaDB 10.6.4
    URL(s): /htdocs/user/card.php?id=xx

Steps to reproduce the behavior

User with lire and password (user) perms, but no creer.

When this user saves or cancels the edition of the password of another user, he is sent to the prohibited page

