### PR TITLE
FIX Content line substitution in email

### DIFF
--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -893,7 +893,7 @@ if ($resql) {
 			$valuetoshow = $langs->trans("Content"); $showfield = 0;
 		}
 		if ($fieldlist[$field] == 'content_lines') {
-			$valuetoshow = $langs->trans("ContentLines"); $showfield = 0;
+			$valuetoshow = $langs->trans("ContentForLines"); $showfield = 0;
 		}
 
 		// Show fields
@@ -970,6 +970,14 @@ if ($resql) {
 								$okforextended = false;
 							}
 							$doleditor = new DolEditor($tmpfieldlist.'-'.$rowid, (!empty($obj->{$tmpfieldlist}) ? $obj->{$tmpfieldlist} : ''), '', 500, 'dolibarr_mailings', 'In', 0, false, $okforextended, ROWS_6, '90%');
+							print $doleditor->Create(1);
+						}
+						if ($tmpfieldlist == 'content_lines') {
+							print $form->textwithpicto($langs->trans("ContentForLines"), $tabhelp[$id][$tmpfieldlist], 1, 'help', '', 0, 2, $tmpfieldlist).'<br>';
+							$okforextended = true;
+							if (empty($conf->global->FCKEDITOR_ENABLE_MAIL))
+								$okforextended = false;
+							$doleditor = new DolEditor($tmpfieldlist.'-'.$rowid, (! empty($obj->{$tmpfieldlist}) ? $obj->{$tmpfieldlist} : ''), '', 140, 'dolibarr_mailings', 'In', 0, false, $okforextended, ROWS_6, '90%');
 							print $doleditor->Create(1);
 						}
 						print '</td>';
@@ -1113,35 +1121,6 @@ if ($resql) {
 					//else print '<a href="#">'.img_delete().'</a>';    // Some dictionary can be edited by other profile than admin
 				}
 				print '</td>';
-
-				/*
-				$fieldsforcontent = array('content');
-				if (! empty($conf->global->MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES))
-				{
-					$fieldsforcontent = array('content', 'content_lines');
-				}
-				foreach ($fieldsforcontent as $tmpfieldlist)
-				{
-					$showfield = 1;
-					$align = "left";
-					$valuetoshow = $obj->{$tmpfieldlist};
-
-					$class = 'tddict';
-					// Show value for field
-					if ($showfield) {
-
-						print '</tr><tr class="oddeven" nohover tr-'.$tmpfieldlist.'-'.$i.' "><td colspan="5">'; // To create an artificial CR for the current tr we are on
-						$okforextended = true;
-						if (empty($conf->global->FCKEDITOR_ENABLE_MAIL))
-							$okforextended = false;
-						$doleditor = new DolEditor($tmpfieldlist.'-'.$i, (! empty($obj->{$tmpfieldlist}) ? $obj->{$tmpfieldlist} : ''), '', 140, 'dolibarr_mailings', 'In', 0, false, $okforextended, ROWS_6, '90%', 1);
-						print $doleditor->Create(1);
-						print '</td>';
-						print '<td></td><td></td><td></td>';
-
-					}
-				}*/
-
 				print "</tr>\n";
 			}
 

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -1523,7 +1523,7 @@ class FormMail extends Form
 					$product = new Product($this->db);
 					$product->fetch($line->fk_product, '', '', 1);
 					$product->fetch_optionals();
-					if (is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label']) > 0) {
+					if (is_array($extrafields->attributes[$product->table_element]['label']) && count($extrafields->attributes[$product->table_element]['label']) > 0) {
 						foreach ($extrafields->attributes[$product->table_element]['label'] as $key => $label) {
 							$substit_line['__PRODUCT_EXTRAFIELD_'.strtoupper($key).'__'] = $product->array_options['options_'.$key];
 						}

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -207,6 +207,7 @@ if ($action == 'presend') {
 	}
 
 	// Make substitution in email content
+	$formmail->setSubstitFromObject($object, $langs);
 	$substitutionarray = getCommonSubstitutionArray($outputlangs, 0, $arrayoffamiliestoexclude, $object);
 	$substitutionarray['__CHECK_READ__'] = (is_object($object) && is_object($object->thirdparty)) ? '<img src="'.DOL_MAIN_URL_ROOT.'/public/emailing/mailing-read.php?tag='.urlencode($object->thirdparty->tag).'&securitykey='.urlencode($conf->global->MAILING_EMAIL_UNSUBSCRIBE_KEY).'" width="1" height="1" style="width:1px;height:1px" border="0"/>' : '';
 	$substitutionarray['__PERSONALIZED__'] = ''; // deprecated

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -207,7 +207,9 @@ if ($action == 'presend') {
 	}
 
 	// Make substitution in email content
-	$formmail->setSubstitFromObject($object, $langs);
+	if ($object) {
+		$formmail->setSubstitFromObject($object, $langs);
+	}
 	$substitutionarray = getCommonSubstitutionArray($outputlangs, 0, $arrayoffamiliestoexclude, $object);
 	$substitutionarray['__CHECK_READ__'] = (is_object($object) && is_object($object->thirdparty)) ? '<img src="'.DOL_MAIN_URL_ROOT.'/public/emailing/mailing-read.php?tag='.urlencode($object->thirdparty->tag).'&securitykey='.urlencode($conf->global->MAILING_EMAIL_UNSUBSCRIBE_KEY).'" width="1" height="1" style="width:1px;height:1px" border="0"/>' : '';
 	$substitutionarray['__PERSONALIZED__'] = ''; // deprecated

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -278,6 +278,7 @@ SpaceX=Space X
 SpaceY=Space Y
 FontSize=Font size
 Content=Content
+ContentForLines=Content to display for each product or service (from variable __LINES__ of Content)
 NoticePeriod=Notice period
 NewByMonth=New by month
 Emails=Emails

--- a/htdocs/langs/es_ES/admin.lang
+++ b/htdocs/langs/es_ES/admin.lang
@@ -277,6 +277,7 @@ SpaceX=Área X
 SpaceY=Área Y
 FontSize=Tamaño de fuente
 Content=Contenido
+ContentForLines=Contenido a mostrar por cada línea de producto o servicio (de la variable __LINES__ definida en Contenido)
 NoticePeriod=Plazo de aviso
 NewByMonth=Nuevo por mes
 Emails=E-Mails


### PR DESCRIPTION
# FIX Content line substitution in email
- Fixed an error in templates mail page which did not display correctly the input text to edit the content line by producy if global variable MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES is set.
- Added properly translation "ContentForLines" that explains how it works.
![image](https://user-images.githubusercontent.com/16271402/138363916-a7b063f1-5623-47c1-9c81-476e1a0fd7f6.png)

- Removed old code that was commented (it has been placed in the right place).
- Fixed old PR https://github.com/Dolibarr/dolibarr/pull/14450, placing correctly the code that makes substitution lines