### PR TITLE
FIX #19064 - access forbidden when editing other user's password

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -411,11 +411,11 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 				}
 			} elseif (!empty($feature2)) {														// This is for permissions on one level
 				foreach ($feature2 as $subfeature) {
-					if ($subfeature == 'user' && $user->id == $objectid && $user->rights->user->self->creer) {
-						continue; // User can edit its own card
-					}
-					if ($subfeature == 'user' && $user->id == $objectid && $user->rights->user->self->password) {
-						continue; // User can edit its own password
+					if ($subfeature == 'user') {
+						if ($user->id == $objectid && $user->rights->user->self->creer) continue; // User can edit own card
+						if ($user->id != $objectid && $user->rights->user->user->creer) continue; // User can edit card of other users
+						if ($user->id == $objectid && $user->rights->user->self->password) continue; // User can edit own password
+						if ($user->id != $objectid && $user->rights->user->user->password) continue; // User can edit other users' passwords
 					}
 
 					if (empty($user->rights->$feature->$subfeature->creer)


### PR DESCRIPTION
# FIX #19064 
When a user does not have permission to create other users but has permission to edit other users' passwords, when they do so, they land on a rejection page.

Since this fix touches core security features, I wouldn't mind extra scrutiny to make sure it doesn't introduce any new vulnerability.