### PR TITLE
FIX_THIRDPARTY_TYPE

### DIFF
--- a/htdocs/core/class/html.formcompany.class.php
+++ b/htdocs/core/class/html.formcompany.class.php
@@ -57,7 +57,7 @@ class FormCompany extends Form
 
 		$sql = "SELECT id, code, libelle";
 		$sql .= " FROM ".MAIN_DB_PREFIX."c_typent";
-		$sql .= " WHERE active = 1 AND (fk_country IS NULL OR fk_country = ".(empty($mysoc->country_id) ? '0' : $mysoc->country_id).")";
+		$sql .= " WHERE active = 1 AND (fk_country IS NULL OR fk_country ='".(empty($mysoc->country_id) ? '0' : $mysoc->country_id)."')";
 		if ($filter) {
 			$sql .= " ".$filter;
 		}
@@ -87,6 +87,7 @@ class FormCompany extends Form
 			}
 			$this->db->free($resql);
 		}
+
 
 		return $effs;
 	}


### PR DESCRIPTION
FIX select Thirdparty Type
The thirdparty type list is empty because of an sql request, there are no quotes surrounding the country_id which can be for example "FR" for France , so the sql request created into the "typent_array" method (which should return an array of thirdparty types)  returns an empty array