### PR TITLE
Fix link object to categories

### DIFF
--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -174,7 +174,8 @@ if ($elemid && $action == 'addintocategory' &&
 	 ($type == Categorie::TYPE_CUSTOMER && $user->rights->societe->creer) ||
 	 ($type == Categorie::TYPE_SUPPLIER && $user->rights->societe->creer) ||
 		($type == Categorie::TYPE_TICKET && $user->rights->ticket->write) ||
-		($type == Categorie::TYPE_PROJECT && $user->rights->projet->creer)
+		($type == Categorie::TYPE_PROJECT && $user->rights->projet->creer)||
+		($type == Categorie::TYPE_MEMBER && $user->rights->projet->creer)
    )) {
 	if ($type == Categorie::TYPE_PRODUCT) {
 		require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
@@ -196,6 +197,10 @@ if ($elemid && $action == 'addintocategory' &&
 		require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 		$newobject = new Project($db);
 		$elementtype = 'project';
+	} elseif ($type == Categorie::TYPE_MEMBER) {
+		require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
+		$newobject = new Adherent($db);
+		$elementtype = 'member';
 	}
 	$result = $newobject->fetch($elemid);
 
@@ -701,6 +706,26 @@ if ($type == Categorie::TYPE_MEMBER) {
 	if ($prods < 0) {
 		dol_print_error($db, $object->error, $object->errors);
 	} else {
+		// Form to add record into a category
+		$showclassifyform = 1;
+		if ($showclassifyform) {
+			print '<br>';
+			print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
+			print '<input type="hidden" name="token" value="'.newToken().'">';
+			print '<input type="hidden" name="typeid" value="'.$typeid.'">';
+			print '<input type="hidden" name="type" value="'.$typeid.'">';
+			print '<input type="hidden" name="id" value="'.$object->id.'">';
+			print '<input type="hidden" name="action" value="addintocategory">';
+			print '<table class="noborder centpercent">';
+			print '<tr class="liste_titre"><td>';
+			print $langs->trans("AddMemberIntoCategory").' &nbsp;';
+			print $form->selectMembers('', 'elemid');
+			print '<input type="submit" class="button buttongen" value="'.$langs->trans("ClassifyInCategory").'"></td>';
+			print '</tr>';
+			print '</table>';
+			print '</form>';
+		}
+
 		print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
 		print '<input type="hidden" name="token" value="'.newToken().'">';
 		print '<input type="hidden" name="typeid" value="'.$typeid.'">';

--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -811,7 +811,7 @@ if ($type == Categorie::TYPE_CONTACT) {
 			print '<table class="noborder centpercent">';
 			print '<tr class="liste_titre"><td>';
 			print $langs->trans("AddContactIntoCategory").' &nbsp;';
-			print $form->selectContacts('', '','elemid');
+			print $form->selectContacts('', '', 'elemid');
 			print '<input type="submit" class="button buttongen" value="'.$langs->trans("ClassifyInCategory").'"></td>';
 			print '</tr>';
 			print '</table>';

--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -177,7 +177,8 @@ if ($elemid && $action == 'addintocategory' &&
 	 ($type == Categorie::TYPE_PROJECT && $user->rights->projet->creer) ||
 	 ($type == Categorie::TYPE_MEMBER && $user->rights->projet->creer) ||
 	 ($type == Categorie::TYPE_CONTACT && $user->rights->societe->creer) ||
-	 ($type == Categorie::TYPE_USER && $user->rights->user->user->creer)
+	 ($type == Categorie::TYPE_USER && $user->rights->user->user->creer) ||
+	 ($type == Categorie::TYPE_ACCOUNT && $user->rights->banque->configurer)
    )) {
 	if ($type == Categorie::TYPE_PRODUCT) {
 		require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
@@ -211,6 +212,10 @@ if ($elemid && $action == 'addintocategory' &&
 		require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 		$newobject = new User($db);
 		$elementtype = 'user';
+	} elseif ($type == Categorie::TYPE_ACCOUNT) {
+		require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
+		$newobject = new User($db);
+		$elementtype = 'bank_account';
 	}
 	$result = $newobject->fetch($elemid);
 
@@ -558,6 +563,7 @@ if ($type == Categorie::TYPE_PRODUCT) {
 	}
 }
 
+// List of customers
 if ($type == Categorie::TYPE_CUSTOMER) {
 	$permission = $user->rights->societe->creer;
 
@@ -631,7 +637,7 @@ if ($type == Categorie::TYPE_CUSTOMER) {
 	}
 }
 
-
+// List of suppliers
 if ($type == Categorie::TYPE_SUPPLIER) {
 	$permission = $user->rights->societe->creer;
 
@@ -876,6 +882,26 @@ if ($type == Categorie::TYPE_ACCOUNT) {
 	if ($accounts < 0) {
 		dol_print_error($db, $object->error, $object->errors);
 	} else {
+		// Form to add record into a category
+		$showclassifyform = 1;
+		if ($showclassifyform) {
+			print '<br>';
+			print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
+			print '<input type="hidden" name="token" value="'.newToken().'">';
+			print '<input type="hidden" name="typeid" value="'.$typeid.'">';
+			print '<input type="hidden" name="type" value="'.$typeid.'">';
+			print '<input type="hidden" name="id" value="'.$object->id.'">';
+			print '<input type="hidden" name="action" value="addintocategory">';
+			print '<table class="noborder centpercent">';
+			print '<tr class="liste_titre"><td>';
+				print $langs->trans("AddAccountIntoCategory").' &nbsp;';
+			$form->select_comptes('', 'elemid');
+			print '<input type="submit" class="button buttongen" value="'.$langs->trans("ClassifyInCategory").'"></td>';
+			print '</tr>';
+			print '</table>';
+			print '</form>';
+		}
+
 		print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
 		print '<input type="hidden" name="token" value="'.newToken().'">';
 		print '<input type="hidden" name="typeid" value="'.$typeid.'">';

--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -173,9 +173,10 @@ if ($elemid && $action == 'addintocategory' &&
 	(($type == Categorie::TYPE_PRODUCT && ($user->rights->produit->creer || $user->rights->service->creer)) ||
 	 ($type == Categorie::TYPE_CUSTOMER && $user->rights->societe->creer) ||
 	 ($type == Categorie::TYPE_SUPPLIER && $user->rights->societe->creer) ||
-		($type == Categorie::TYPE_TICKET && $user->rights->ticket->write) ||
-		($type == Categorie::TYPE_PROJECT && $user->rights->projet->creer)||
-		($type == Categorie::TYPE_MEMBER && $user->rights->projet->creer)
+	 ($type == Categorie::TYPE_TICKET && $user->rights->ticket->write) ||
+	 ($type == Categorie::TYPE_PROJECT && $user->rights->projet->creer) ||
+	 ($type == Categorie::TYPE_MEMBER && $user->rights->projet->creer) ||
+	 ($type == Categorie::TYPE_CONTACT && $user->rights->societe->creer)
    )) {
 	if ($type == Categorie::TYPE_PRODUCT) {
 		require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
@@ -201,6 +202,10 @@ if ($elemid && $action == 'addintocategory' &&
 		require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
 		$newobject = new Adherent($db);
 		$elementtype = 'member';
+	} elseif ($type == Categorie::TYPE_CONTACT) {
+		require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
+		$newobject = new Contact($db);
+		$elementtype = 'contact';
 	}
 	$result = $newobject->fetch($elemid);
 
@@ -782,6 +787,25 @@ if ($type == Categorie::TYPE_CONTACT) {
 	if ($contacts < 0) {
 		dol_print_error($db, $object->error, $object->errors);
 	} else {
+		// Form to add record into a category
+		$showclassifyform = 1;
+		if ($showclassifyform) {
+			print '<br>';
+			print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
+			print '<input type="hidden" name="token" value="'.newToken().'">';
+			print '<input type="hidden" name="typeid" value="'.$typeid.'">';
+			print '<input type="hidden" name="type" value="'.$typeid.'">';
+			print '<input type="hidden" name="id" value="'.$object->id.'">';
+			print '<input type="hidden" name="action" value="addintocategory">';
+			print '<table class="noborder centpercent">';
+			print '<tr class="liste_titre"><td>';
+			print $langs->trans("AddContactIntoCategory").' &nbsp;';
+			print $form->selectContacts('', '','elemid');
+			print '<input type="submit" class="button buttongen" value="'.$langs->trans("ClassifyInCategory").'"></td>';
+			print '</tr>';
+			print '</table>';
+			print '</form>';
+		}
 		print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
 		print '<input type="hidden" name="token" value="'.newToken().'">';
 		print '<input type="hidden" name="typeid" value="'.$typeid.'">';

--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -173,7 +173,8 @@ if ($elemid && $action == 'addintocategory' &&
 	(($type == Categorie::TYPE_PRODUCT && ($user->rights->produit->creer || $user->rights->service->creer)) ||
 	 ($type == Categorie::TYPE_CUSTOMER && $user->rights->societe->creer) ||
 	 ($type == Categorie::TYPE_SUPPLIER && $user->rights->societe->creer) ||
-	 ($type == Categorie::TYPE_TICKET && $user->rights->ticket->write)
+		($type == Categorie::TYPE_TICKET && $user->rights->ticket->write) ||
+		($type == Categorie::TYPE_PROJECT && $user->rights->projet->creer)
    )) {
 	if ($type == Categorie::TYPE_PRODUCT) {
 		require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
@@ -191,6 +192,10 @@ if ($elemid && $action == 'addintocategory' &&
 		require_once DOL_DOCUMENT_ROOT.'/ticket/class/ticket.class.php';
 		$newobject = new Ticket($db);
 		$elementtype = 'ticket';
+	} elseif ($type == Categorie::TYPE_PROJECT) {
+		require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
+		$newobject = new Project($db);
+		$elementtype = 'project';
 	}
 	$result = $newobject->fetch($elemid);
 
@@ -874,6 +879,26 @@ if ($type == Categorie::TYPE_PROJECT) {
 	if ($objects < 0) {
 		dol_print_error($db, $object->error, $object->errors);
 	} else {
+		// Form to add record into a category
+		$showclassifyform = 1;
+		if ($showclassifyform) {
+			print '<br>';
+			print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
+			print '<input type="hidden" name="token" value="'.newToken().'">';
+			print '<input type="hidden" name="typeid" value="'.$typeid.'">';
+			print '<input type="hidden" name="type" value="'.$typeid.'">';
+			print '<input type="hidden" name="id" value="'.$object->id.'">';
+			print '<input type="hidden" name="action" value="addintocategory">';
+			print '<table class="noborder centpercent">';
+			print '<tr class="liste_titre"><td>';
+			print $langs->trans("AddProjectIntoCategory").' &nbsp;';
+			$form->selectProjects('', 'elemid');
+			print '<input type="submit" class="button buttongen" value="'.$langs->trans("ClassifyInCategory").'"></td>';
+			print '</tr>';
+			print '</table>';
+			print '</form>';
+		}
+
 		print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
 		print '<input type="hidden" name="token" value="'.newToken().'">';
 		print '<input type="hidden" name="typeid" value="'.$typeid.'">';

--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -176,7 +176,8 @@ if ($elemid && $action == 'addintocategory' &&
 	 ($type == Categorie::TYPE_TICKET && $user->rights->ticket->write) ||
 	 ($type == Categorie::TYPE_PROJECT && $user->rights->projet->creer) ||
 	 ($type == Categorie::TYPE_MEMBER && $user->rights->projet->creer) ||
-	 ($type == Categorie::TYPE_CONTACT && $user->rights->societe->creer)
+	 ($type == Categorie::TYPE_CONTACT && $user->rights->societe->creer) ||
+	 ($type == Categorie::TYPE_USER && $user->rights->user->user->creer)
    )) {
 	if ($type == Categorie::TYPE_PRODUCT) {
 		require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
@@ -206,6 +207,10 @@ if ($elemid && $action == 'addintocategory' &&
 		require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 		$newobject = new Contact($db);
 		$elementtype = 'contact';
+	} elseif ($type == Categorie::TYPE_USER) {
+		require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
+		$newobject = new User($db);
+		$elementtype = 'user';
 	}
 	$result = $newobject->fetch($elemid);
 
@@ -1004,6 +1009,25 @@ if ($type == Categorie::TYPE_USER) {
 	if ($users < 0) {
 		dol_print_error($db, $object->error, $object->errors);
 	} else {
+		// Form to add record into a category
+		$showclassifyform = 1;
+		if ($showclassifyform) {
+			print '<br>';
+			print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
+			print '<input type="hidden" name="token" value="'.newToken().'">';
+			print '<input type="hidden" name="typeid" value="'.$typeid.'">';
+			print '<input type="hidden" name="type" value="'.$typeid.'">';
+			print '<input type="hidden" name="id" value="'.$object->id.'">';
+			print '<input type="hidden" name="action" value="addintocategory">';
+			print '<table class="noborder centpercent">';
+			print '<tr class="liste_titre"><td>';
+			print $langs->trans("AddProjectIntoCategory").' &nbsp;';
+			$form->select_users('', 'elemid');
+			print '<input type="submit" class="button buttongen" value="'.$langs->trans("ClassifyInCategory").'"></td>';
+			print '</tr>';
+			print '</table>';
+			print '</form>';
+		}
 		print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
 		print '<input type="hidden" name="token" value="'.newToken().'">';
 		print '<input type="hidden" name="typeid" value="'.$typeid.'">';

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6839,7 +6839,7 @@ class Form
 	}
 
 	/**
-	 *  Return list of tickets in Ajax if Ajax activated or go to selectTicketsList
+	 *  Return list of projects in Ajax if Ajax activated or go to selectTicketsList
 	 *
 	 *  @param		int			$selected				Preselected tickets
 	 *  @param		string		$htmlname				Name of HTML select field (must be unique in page).
@@ -6897,7 +6897,6 @@ class Form
 		if (empty($nooutput)) print $out;
 		else return $out;
 	}
-
 
 	/**
 	 *	Return list of projects.
@@ -7006,7 +7005,7 @@ class Form
 	}
 
 	/**
-	 * constructTicketListOption.
+	 * constructProjectListOption.
 	 * This define value for &$opt and &$optJson.
 	 *
 	 * @param 	resource	$objp			    Result set of fetch
@@ -7017,6 +7016,213 @@ class Form
 	 * @return	void
 	 */
 	protected function constructProjectListOption(&$objp, &$opt, &$optJson, $selected, $filterkey = '')
+	{
+		global $langs, $conf, $user, $db;
+
+		$outkey = '';
+		$outval = '';
+		$outref = '';
+		$outlabel = '';
+		$outtype = '';
+
+		$label = $objp->label;
+
+		$outkey = $objp->rowid;
+		$outref = $objp->ref;
+		$outlabel = $objp->label;
+		$outtype = $objp->fk_product_type;
+
+		$opt = '<option value="'.$objp->rowid.'"';
+		$opt .= ($objp->rowid == $selected) ? ' selected' : '';
+		$opt .= '>';
+		$opt .= $objp->ref;
+		$objRef = $objp->ref;
+		if (!empty($filterkey) && $filterkey != '') $objRef = preg_replace('/('.preg_quote($filterkey, '/').')/i', '<strong>$1</strong>', $objRef, 1);
+		$outval .= $objRef;
+
+		$opt .= "</option>\n";
+		$optJson = array('key'=>$outkey, 'value'=>$outref, 'type'=>$outtypem);
+	}
+
+
+	/**
+	 *  Return list of members in Ajax if Ajax activated or go to selectTicketsList
+	 *
+	 *  @param		int			$selected				Preselected tickets
+	 *  @param		string		$htmlname				Name of HTML select field (must be unique in page).
+	 *  @param  	string		$filtertype     		To add a filter
+	 *  @param		int			$limit					Limit on number of returned lines
+	 *  @param		int			$status					Ticket status
+	 *  @param		string		$selected_input_value	Value of preselected input text (for use with ajax)
+	 *  @param		int			$hidelabel				Hide label (0=no, 1=yes, 2=show search icon (before) and placeholder, 3 search icon after)
+	 *  @param		array		$ajaxoptions			Options for ajax_autocompleter
+	 *  @param      int			$socid					Thirdparty Id (to get also price dedicated to this customer)
+	 *  @param		string		$showempty				'' to not show empty line. Translation key to show an empty line. '1' show empty line with no text.
+	 * 	@param		int			$forcecombo				Force to use combo box
+	 *  @param      string      $morecss                Add more css on select
+	 *  @param 		array 		$selected_combinations 	Selected combinations. Format: array([attrid] => attrval, [...])
+	 *  @param		string		$nooutput				No print, return the output into a string
+	 *  @return		void|string
+	 */
+	public function selectMembers($selected = '', $htmlname = 'adherentid', $filtertype = '', $limit = 0, $status = 1, $selected_input_value = '', $hidelabel = 0, $ajaxoptions = array(), $socid = 0, $showempty = '1', $forcecombo = 0, $morecss = '', $selected_combinations = null, $nooutput = 0)
+	{
+		global $langs, $conf;
+
+		$out = '';
+
+		// check parameters
+		if (is_null($ajaxoptions)) $ajaxoptions = array();
+
+		if (!empty($conf->use_javascript_ajax) && !empty($conf->global->TICKET_USE_SEARCH_TO_SELECT)) {
+			$placeholder = '';
+
+			if ($selected && empty($selected_input_value)) {
+				require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
+				$adherenttmpselect = new Member($this->db);
+				$adherenttmpselect->fetch($selected);
+				$selected_input_value = $adherenttmpselect->ref;
+				unset($adherenttmpselect);
+			}
+
+			$out .= ajax_autocompleter($selected, $htmlname, DOL_URL_ROOT.'/adherents/ajax/adherents.php', $urloption, $conf->global->PRODUIT_USE_SEARCH_TO_SELECT, 1, $ajaxoptions);
+
+			if (empty($hidelabel)) $out .= $langs->trans("RefOrLabel").' : ';
+			elseif ($hidelabel > 1) {
+				$placeholder = ' placeholder="'.$langs->trans("RefOrLabel").'"';
+				if ($hidelabel == 2) {
+					$out .= img_picto($langs->trans("Search"), 'search');
+				}
+			}
+			$out .= '<input type="text" class="minwidth100" name="search_'.$htmlname.'" id="search_'.$htmlname.'" value="'.$selected_input_value.'"'.$placeholder.' '.(!empty($conf->global->PRODUCT_SEARCH_AUTOFOCUS) ? 'autofocus' : '').' />';
+			if ($hidelabel == 3) {
+				$out .= img_picto($langs->trans("Search"), 'search');
+			}
+		} else {
+			$out .= $this->selectMembersList($selected, $htmlname, $filtertype, $limit, $status, 0, $socid, $showempty, $forcecombo, $morecss);
+		}
+
+		if (empty($nooutput)) print $out;
+		else return $out;
+	}
+
+	/**
+	 *	Return list of adherents.
+	 *  Called by selectMembers.
+	 *
+	 *	@param      int		$selected           Preselected adherent
+	 *	@param      string	$htmlname           Name of select html
+	 *  @param		string	$filtertype         Filter on adherent type
+	 *	@param      int		$limit              Limit on number of returned lines
+	 * 	@param      string	$filterkey          Filter on adherent ref or subject
+	 *	@param		int		$status             Ticket status
+	 *  @param      int		$outputmode         0=HTML select string, 1=Array
+	 *  @param		string	$showempty		    '' to not show empty line. Translation key to show an empty line. '1' show empty line with no text.
+	 * 	@param		int		$forcecombo		    Force to use combo box
+	 *  @param      string  $morecss            Add more css on select
+	 *  @return     array    				    Array of keys for json
+	 */
+	public function selectMembersList($selected = '', $htmlname = 'adherentid', $filtertype = '', $limit = 20, $filterkey = '', $status = 1, $outputmode = 0, $showempty = '1', $forcecombo = 0, $morecss = '')
+	{
+		global $langs, $conf, $user, $db;
+
+		$out = '';
+		$outarray = array();
+
+		$selectFields = " p.rowid, p.ref";
+
+		$sql = "SELECT ";
+		$sql .= $selectFields;
+		$sql .= " FROM ".MAIN_DB_PREFIX."adherent as p";
+		$sql .= ' WHERE p.entity IN ('.getEntity('adherent').')';
+
+		// Add criteria on ref/label
+		if ($filterkey != '') {
+			$sql .= ' AND (';
+			$prefix = empty($conf->global->TICKET_DONOTSEARCH_ANYWHERE) ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
+			// For natural search
+			$scrit = explode(' ', $filterkey);
+			$i = 0;
+			if (count($scrit) > 1) $sql .= "(";
+			foreach ($scrit as $crit) {
+				if ($i > 0) $sql .= " AND ";
+				$sql .= "p.ref LIKE '".$this->db->escape($prefix.$crit)."%'";
+				$sql .= "";
+				$i++;
+			}
+			if (count($scrit) > 1) $sql .= ")";
+			$sql .= ')';
+		}
+
+		$sql .= $this->db->plimit($limit, 0);
+
+		// Build output string
+		dol_syslog(get_class($this)."::selectMembersList search adherents", LOG_DEBUG);
+		$result = $this->db->query($sql);
+		if ($result) {
+			require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/member.lib.php';
+
+			$num = $this->db->num_rows($result);
+
+			$events = null;
+
+			if (!$forcecombo) {
+				include_once DOL_DOCUMENT_ROOT.'/core/lib/ajax.lib.php';
+				$out .= ajax_combobox($htmlname, $events, $conf->global->PROJECT_USE_SEARCH_TO_SELECT);
+			}
+
+			$out .= '<select class="flat'.($morecss ? ' '.$morecss : '').'" name="'.$htmlname.'" id="'.$htmlname.'">';
+
+			$textifempty = '';
+			// Do not use textifempty = ' ' or '&nbsp;' here, or search on key will search on ' key'.
+			//if (! empty($conf->use_javascript_ajax) || $forcecombo) $textifempty='';
+			if (!empty($conf->global->PROJECT_USE_SEARCH_TO_SELECT)) {
+				if ($showempty && !is_numeric($showempty)) $textifempty = $langs->trans($showempty);
+				else $textifempty .= $langs->trans("All");
+			} else {
+				if ($showempty && !is_numeric($showempty)) $textifempty = $langs->trans($showempty);
+			}
+			if ($showempty) $out .= '<option value="0" selected>'.$textifempty.'</option>';
+
+			$i = 0;
+			while ($num && $i < $num) {
+				$opt = '';
+				$optJson = array();
+				$objp = $this->db->fetch_object($result);
+
+				$this->constructMemberListOption($objp, $opt, $optJson, $selected, $filterkey);
+				// Add new entry
+				// "key" value of json key array is used by jQuery automatically as selected value
+				// "label" value of json key array is used by jQuery automatically as text for combo box
+				$out .= $opt;
+				array_push($outarray, $optJson);
+
+				$i++;
+			}
+
+			$out .= '</select>';
+
+			$this->db->free($result);
+
+			if (empty($outputmode)) return $out;
+			return $outarray;
+		} else {
+			dol_print_error($db);
+		}
+	}
+
+	/**
+	 * constructMemberListOption.
+	 * This define value for &$opt and &$optJson.
+	 *
+	 * @param 	resource	$objp			    Result set of fetch
+	 * @param 	string		$opt			    Option (var used for returned value in string option format)
+	 * @param 	string		$optJson		    Option (var used for returned value in json format)
+	 * @param 	string		$selected		    Preselected value
+	 * @param   string      $filterkey          Filter key to highlight
+	 * @return	void
+	 */
+	protected function constructMemberListOption(&$objp, &$opt, &$optJson, $selected, $filterkey = '')
 	{
 		global $langs, $conf, $user, $db;
 

--- a/htdocs/langs/fr_FR/categories.lang
+++ b/htdocs/langs/fr_FR/categories.lang
@@ -89,6 +89,7 @@ CategorieRecursiv=Lier automatiquement avec le(a) tag/catégorie parent(e)
 CategorieRecursivHelp=Si l'option est activé, quand un produit est ajouté dans une sous-catégorie, le produit sera ajouté aussi dans la catégorie parente.
 AddProductServiceIntoCategory=Ajouter le produit/service suivant
 AddCustomerIntoCategory=Assigner cette catégorie au client
+AddProjectIntoCategory=Assigner cette catégorie au projet
 AddTicketIntoCategory=Assigner cette catégorie au ticket
 AddSupplierIntoCategory=Assigner cette catégorie au fournisseur
 ShowCategory=Afficher tag/catégorie

--- a/htdocs/langs/fr_FR/categories.lang
+++ b/htdocs/langs/fr_FR/categories.lang
@@ -89,6 +89,7 @@ CategorieRecursiv=Lier automatiquement avec le(a) tag/catégorie parent(e)
 CategorieRecursivHelp=Si l'option est activé, quand un produit est ajouté dans une sous-catégorie, le produit sera ajouté aussi dans la catégorie parente.
 AddProductServiceIntoCategory=Ajouter le produit/service suivant
 AddCustomerIntoCategory=Assigner cette catégorie au client
+AddMemberIntoCategory=Assigner cette catégorie au membre
 AddProjectIntoCategory=Assigner cette catégorie au projet
 AddTicketIntoCategory=Assigner cette catégorie au ticket
 AddSupplierIntoCategory=Assigner cette catégorie au fournisseur

--- a/htdocs/langs/fr_FR/categories.lang
+++ b/htdocs/langs/fr_FR/categories.lang
@@ -91,6 +91,7 @@ AddProductServiceIntoCategory=Ajouter le produit/service suivant
 AddCustomerIntoCategory=Assigner cette catégorie au client
 AddMemberIntoCategory=Assigner cette catégorie au membre
 AddContactIntoCategory=Assigner cette catégorie au contact
+AddUserIntoCategory=Assigner cette catégorie à l'utilisateur
 AddProjectIntoCategory=Assigner cette catégorie au projet
 AddTicketIntoCategory=Assigner cette catégorie au ticket
 AddSupplierIntoCategory=Assigner cette catégorie au fournisseur

--- a/htdocs/langs/fr_FR/categories.lang
+++ b/htdocs/langs/fr_FR/categories.lang
@@ -93,6 +93,7 @@ AddMemberIntoCategory=Assigner cette catégorie au membre
 AddContactIntoCategory=Assigner cette catégorie au contact
 AddUserIntoCategory=Assigner cette catégorie à l'utilisateur
 AddProjectIntoCategory=Assigner cette catégorie au projet
+AddAccountIntoCategory=Assigner cette catégorie au compte
 AddTicketIntoCategory=Assigner cette catégorie au ticket
 AddSupplierIntoCategory=Assigner cette catégorie au fournisseur
 ShowCategory=Afficher tag/catégorie

--- a/htdocs/langs/fr_FR/categories.lang
+++ b/htdocs/langs/fr_FR/categories.lang
@@ -90,6 +90,7 @@ CategorieRecursivHelp=Si l'option est activé, quand un produit est ajouté dans
 AddProductServiceIntoCategory=Ajouter le produit/service suivant
 AddCustomerIntoCategory=Assigner cette catégorie au client
 AddMemberIntoCategory=Assigner cette catégorie au membre
+AddContactIntoCategory=Assigner cette catégorie au contact
 AddProjectIntoCategory=Assigner cette catégorie au projet
 AddTicketIntoCategory=Assigner cette catégorie au ticket
 AddSupplierIntoCategory=Assigner cette catégorie au fournisseur


### PR DESCRIPTION
#19091

add quick link between categories and account, user, contact, adherent & project.

couldn't add this functionality to actioncomm & website page :
-  actioncomm : the rowid database field is named id so an error occurs when getting linked objects to the category
- website_page : database doesn't have an entity column