### PR TITLE
FIX tcpdf roman numeral rendering bomb, cf. tecnickom/TCPDF PR 315

### DIFF
--- a/dev/dolibarr_changes.txt
+++ b/dev/dolibarr_changes.txt
@@ -175,6 +175,18 @@ In htdocs/includes/tecnickcom/tcpdf/tcpdf.php
 -       protected $default_monospaced_font = 'courier';
 +       protected $default_monospaced_font = 'freemono';
 
+* In tecnickcom/tcpdf/include/tcpdf_static, in function intToRoman, right at the beginning
+  of the function, replace:
+
+		$roman = '';
+
+with:
+
+		$roman = '';
+		if ($number >= 4000) {
+			// do not represent numbers above 4000 in Roman numerals
+			return strval($number);
+		}
 
 
 

--- a/htdocs/includes/tecnickcom/tcpdf/include/tcpdf_static.php
+++ b/htdocs/includes/tecnickcom/tcpdf/include/tcpdf_static.php
@@ -1440,6 +1440,10 @@ class TCPDF_STATIC {
 	 */
 	public static function intToRoman($number) {
 		$roman = '';
+		if ($number >= 4000) {
+			// do not represent numbers above 4000 in Roman numerals
+			return strval($number);
+		}
 		while ($number >= 1000) {
 			$roman .= 'M';
 			$number -= 1000;


### PR DESCRIPTION
# FIX

This protects Dolibarr against a scenario in which the HTML markup of the document asks tcpdf to render a large number as a roman number (cf. [the tecnickom PR](https://github.com/tecnickcom/TCPDF/pull/315)), which ends up using all available RAM.