### PR TITLE
Fix #19070 : Api subproducts was returning false

### DIFF
--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -405,7 +405,7 @@ class Products extends DolibarrApi
 
 		$childsArbo = $this->product->getChildsArbo($id, 1);
 
-		$keys = ['rowid', 'qty', 'fk_product_type', 'label', 'incdec'];
+		$keys = ['rowid', 'qty', 'fk_product_type', 'label', 'incdec', 'ref'];
 		$childs = [];
 		foreach ($childsArbo as $values) {
 			$childs[] = array_combine($keys, $values);


### PR DESCRIPTION
getChildsArbo is now returning 6 values so the keys array must also have 6 params or array_combine returns false