### PR TITLE
Fix #18961 : no_email field has been replaced by mailing_unsubscribe table

### DIFF
--- a/htdocs/contact/list.php
+++ b/htdocs/contact/list.php
@@ -175,7 +175,7 @@ $arrayfields = array(
 	'p.phone_mobile'=>array('label'=>"PhoneMobile", 'position'=>32, 'checked'=>1),
 	'p.fax'=>array('label'=>"Fax", 'position'=>33, 'checked'=>0),
 	'p.email'=>array('label'=>"EMail", 'position'=>40, 'checked'=>1),
-	'p.no_email'=>array('label'=>"No_Email", 'position'=>41, 'checked'=>0, 'enabled'=>(!empty($conf->mailing->enabled))),
+	'mu.rowid'=>array('label'=>"No_Email", 'position'=>41, 'checked'=>0, 'enabled'=>(!empty($conf->mailing->enabled))),
 	'p.thirdparty'=>array('label'=>"ThirdParty", 'position'=>50, 'checked'=>1, 'enabled'=>empty($conf->global->SOCIETE_DISABLE_CONTACTS)),
 	'p.priv'=>array('label'=>"ContactVisibility", 'checked'=>1, 'position'=>200),
 	'p.datec'=>array('label'=>"DateCreationShort", 'checked'=>0, 'position'=>500),
@@ -298,13 +298,16 @@ $contactstatic = new Contact($db);
 $title = (!empty($conf->global->SOCIETE_ADDRESSES_MANAGEMENT) ? $langs->trans("Contacts") : $langs->trans("ContactsAddresses"));
 
 $sql = "SELECT s.rowid as socid, s.nom as name,";
-$sql .= " p.rowid, p.lastname as lastname, p.statut, p.firstname, p.zip, p.town, p.poste, p.email, p.no_email,";
+$sql .= " p.rowid, p.lastname as lastname, p.statut, p.firstname, p.zip, p.town, p.poste, p.email,";
 $sql .= " p.socialnetworks, p.photo,";
 $sql .= " p.phone as phone_pro, p.phone_mobile, p.phone_perso, p.fax, p.fk_pays, p.priv, p.datec as date_creation, p.tms as date_update,";
 $sql .= " co.label as country, co.code as country_code";
 // Add fields from extrafields
 if (!empty($extrafields->attributes[$object->table_element]['label'])) {
 	foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $val) $sql .= ($extrafields->attributes[$object->table_element]['type'][$key] != 'separate' ? ", ef.".$key.' as options_'.$key : '');
+}
+if(!empty($conf->mailing->enabled)) {
+	$sql .= ", mu.rowid as no_email";
 }
 // Add fields from hooks
 $parameters = array();
@@ -318,6 +321,7 @@ if (!empty($search_categ)) $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX."categorie_conta
 if (!empty($search_categ_thirdparty)) $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX."categorie_societe as cs ON s.rowid = cs.fk_soc"; // We need this table joined to the select in order to filter by categ
 if (!empty($search_categ_supplier)) $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX."categorie_fournisseur as cs2 ON s.rowid = cs2.fk_soc"; // We need this table joined to the select in order to filter by categ
 if (!$user->rights->societe->client->voir && !$socid) $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON s.rowid = sc.fk_soc";
+if(!empty($conf->mailing->enabled)) $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."mailing_unsubscribe as mu ON mu.email = p.email";
 $sql .= ' WHERE p.entity IN ('.getEntity('socpeople').')';
 if (!$user->rights->societe->client->voir && !$socid) //restriction
 {
@@ -374,8 +378,8 @@ if (strlen($search_town))   		$sql .= natural_search("p.town", $search_town);
 if (count($search_roles) > 0) {
 	$sql .= " AND p.rowid IN (SELECT sc.fk_socpeople FROM ".MAIN_DB_PREFIX."societe_contacts as sc WHERE sc.fk_c_type_contact IN (".implode(',', $search_roles)."))";
 }
-
-if ($search_no_email != '' && $search_no_email >= 0) $sql .= " AND p.no_email = ".$db->escape($search_no_email);
+if ($search_no_email != -1 && $search_no_email > 0) $sql .= " AND mu.rowid IS NOT NULL";
+if ($search_no_email != -1 && $search_no_email == 0) $sql .= " AND mu.rowid IS NULL";
 if ($search_status != '' && $search_status >= 0) $sql .= " AND p.statut = ".$db->escape($search_status);
 if ($search_import_key)             $sql .= natural_search("p.import_key", $search_import_key);
 if ($type == "o")        // filtre sur type
@@ -662,7 +666,7 @@ if (!empty($arrayfields['p.email']['checked']))
 	print '<input class="flat" type="text" name="search_email" size="6" value="'.dol_escape_htmltag($search_email).'">';
 	print '</td>';
 }
-if (!empty($arrayfields['p.no_email']['checked']))
+if (!empty($arrayfields['mu.rowid']['checked']))
 {
 	print '<td class="liste_titre center">';
 	print $form->selectarray('search_no_email', array('-1'=>'', '0'=>$langs->trans('No'), '1'=>$langs->trans('Yes')), $search_no_email);
@@ -751,7 +755,7 @@ if (!empty($arrayfields['p.phone_perso']['checked']))         print_liste_field_
 if (!empty($arrayfields['p.phone_mobile']['checked']))        print_liste_field_titre($arrayfields['p.phone_mobile']['label'], $_SERVER["PHP_SELF"], "p.phone_mobile", $begin, $param, '', $sortfield, $sortorder);
 if (!empty($arrayfields['p.fax']['checked']))                 print_liste_field_titre($arrayfields['p.fax']['label'], $_SERVER["PHP_SELF"], "p.fax", $begin, $param, '', $sortfield, $sortorder);
 if (!empty($arrayfields['p.email']['checked']))               print_liste_field_titre($arrayfields['p.email']['label'], $_SERVER["PHP_SELF"], "p.email", $begin, $param, '', $sortfield, $sortorder);
-if (!empty($arrayfields['p.no_email']['checked']))            print_liste_field_titre($arrayfields['p.no_email']['label'], $_SERVER["PHP_SELF"], "p.no_email", $begin, $param, '', $sortfield, $sortorder, 'center ');
+if (!empty($arrayfields['mu.rowid']['checked']))              print_liste_field_titre($arrayfields['mu.rowid']['label'], $_SERVER["PHP_SELF"], "mu.rowid", $begin, $param, '', $sortfield, $sortorder, 'center ');
 if (!empty($conf->socialnetworks->enabled)) {
 	foreach ($socialnetworks as $key => $value) {
 		if ($value['active'] && !empty($arrayfields['p.'.$key]['checked'])) {
@@ -905,9 +909,9 @@ while ($i < min($num, $limit))
 		if (!$i) $totalarray['nbfield']++;
 	}
 	// No EMail
-	if (!empty($arrayfields['p.no_email']['checked']))
+	if (!empty($arrayfields['mu.rowid']['checked']))
 	{
-		print '<td class="center">'.yn($obj->no_email).'</td>';
+		print '<td class="center">'.yn(!is_null($obj->no_email) ? 1 : 0).'</td>';
 		if (!$i) $totalarray['nbfield']++;
 	}
 	if (!empty($conf->socialnetworks->enabled)) {

--- a/htdocs/contact/list.php
+++ b/htdocs/contact/list.php
@@ -175,7 +175,7 @@ $arrayfields = array(
 	'p.phone_mobile'=>array('label'=>"PhoneMobile", 'position'=>32, 'checked'=>1),
 	'p.fax'=>array('label'=>"Fax", 'position'=>33, 'checked'=>0),
 	'p.email'=>array('label'=>"EMail", 'position'=>40, 'checked'=>1),
-	'mu.rowid'=>array('label'=>"No_Email", 'position'=>41, 'checked'=>0, 'enabled'=>(!empty($conf->mailing->enabled))),
+	'unsubscribed'=>array('label'=>"No_Email", 'position'=>41, 'checked'=>0, 'enabled'=>(!empty($conf->mailing->enabled))),
 	'p.thirdparty'=>array('label'=>"ThirdParty", 'position'=>50, 'checked'=>1, 'enabled'=>empty($conf->global->SOCIETE_DISABLE_CONTACTS)),
 	'p.priv'=>array('label'=>"ContactVisibility", 'checked'=>1, 'position'=>200),
 	'p.datec'=>array('label'=>"DateCreationShort", 'checked'=>0, 'position'=>500),
@@ -307,7 +307,7 @@ if (!empty($extrafields->attributes[$object->table_element]['label'])) {
 	foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $val) $sql .= ($extrafields->attributes[$object->table_element]['type'][$key] != 'separate' ? ", ef.".$key.' as options_'.$key : '');
 }
 if(!empty($conf->mailing->enabled)) {
-	$sql .= ", mu.rowid as no_email";
+	$sql .= ", (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = p.email) as unsubscribed";
 }
 // Add fields from hooks
 $parameters = array();
@@ -321,7 +321,6 @@ if (!empty($search_categ)) $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX."categorie_conta
 if (!empty($search_categ_thirdparty)) $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX."categorie_societe as cs ON s.rowid = cs.fk_soc"; // We need this table joined to the select in order to filter by categ
 if (!empty($search_categ_supplier)) $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX."categorie_fournisseur as cs2 ON s.rowid = cs2.fk_soc"; // We need this table joined to the select in order to filter by categ
 if (!$user->rights->societe->client->voir && !$socid) $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON s.rowid = sc.fk_soc";
-if(!empty($conf->mailing->enabled)) $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."mailing_unsubscribe as mu ON mu.email = p.email";
 $sql .= ' WHERE p.entity IN ('.getEntity('socpeople').')';
 if (!$user->rights->societe->client->voir && !$socid) //restriction
 {
@@ -378,8 +377,8 @@ if (strlen($search_town))   		$sql .= natural_search("p.town", $search_town);
 if (count($search_roles) > 0) {
 	$sql .= " AND p.rowid IN (SELECT sc.fk_socpeople FROM ".MAIN_DB_PREFIX."societe_contacts as sc WHERE sc.fk_c_type_contact IN (".implode(',', $search_roles)."))";
 }
-if ($search_no_email != -1 && $search_no_email > 0) $sql .= " AND mu.rowid IS NOT NULL";
-if ($search_no_email != -1 && $search_no_email == 0) $sql .= " AND mu.rowid IS NULL";
+if ($search_no_email != -1 && $search_no_email > 0) $sql .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = p.email) > 0";
+if ($search_no_email != -1 && $search_no_email == 0) $sql .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = p.email) = 0";
 if ($search_status != '' && $search_status >= 0) $sql .= " AND p.statut = ".$db->escape($search_status);
 if ($search_import_key)             $sql .= natural_search("p.import_key", $search_import_key);
 if ($type == "o")        // filtre sur type
@@ -666,7 +665,7 @@ if (!empty($arrayfields['p.email']['checked']))
 	print '<input class="flat" type="text" name="search_email" size="6" value="'.dol_escape_htmltag($search_email).'">';
 	print '</td>';
 }
-if (!empty($arrayfields['mu.rowid']['checked']))
+if (!empty($arrayfields['unsubscribed']['checked']))
 {
 	print '<td class="liste_titre center">';
 	print $form->selectarray('search_no_email', array('-1'=>'', '0'=>$langs->trans('No'), '1'=>$langs->trans('Yes')), $search_no_email);
@@ -755,7 +754,7 @@ if (!empty($arrayfields['p.phone_perso']['checked']))         print_liste_field_
 if (!empty($arrayfields['p.phone_mobile']['checked']))        print_liste_field_titre($arrayfields['p.phone_mobile']['label'], $_SERVER["PHP_SELF"], "p.phone_mobile", $begin, $param, '', $sortfield, $sortorder);
 if (!empty($arrayfields['p.fax']['checked']))                 print_liste_field_titre($arrayfields['p.fax']['label'], $_SERVER["PHP_SELF"], "p.fax", $begin, $param, '', $sortfield, $sortorder);
 if (!empty($arrayfields['p.email']['checked']))               print_liste_field_titre($arrayfields['p.email']['label'], $_SERVER["PHP_SELF"], "p.email", $begin, $param, '', $sortfield, $sortorder);
-if (!empty($arrayfields['mu.rowid']['checked']))              print_liste_field_titre($arrayfields['mu.rowid']['label'], $_SERVER["PHP_SELF"], "mu.rowid", $begin, $param, '', $sortfield, $sortorder, 'center ');
+if (!empty($arrayfields['unsubscribed']['checked']))          print_liste_field_titre($arrayfields['unsubscribed']['label'], $_SERVER["PHP_SELF"], "unsubscribed", $begin, $param, '', $sortfield, $sortorder, 'center ');
 if (!empty($conf->socialnetworks->enabled)) {
 	foreach ($socialnetworks as $key => $value) {
 		if ($value['active'] && !empty($arrayfields['p.'.$key]['checked'])) {
@@ -909,9 +908,9 @@ while ($i < min($num, $limit))
 		if (!$i) $totalarray['nbfield']++;
 	}
 	// No EMail
-	if (!empty($arrayfields['mu.rowid']['checked']))
+	if (!empty($arrayfields['unsubscribed']['checked']))
 	{
-		print '<td class="center">'.yn(!is_null($obj->no_email) ? 1 : 0).'</td>';
+		print '<td class="center">'.yn(($obj->unsubscribed > 0) ? 1 : 0).'</td>';
 		if (!$i) $totalarray['nbfield']++;
 	}
 	if (!empty($conf->socialnetworks->enabled)) {

--- a/htdocs/core/modules/mailings/contacts1.modules.php
+++ b/htdocs/core/modules/mailings/contacts1.modules.php
@@ -80,7 +80,7 @@ class mailing_contacts1 extends MailingTargets
 		$statssql[0] .= " FROM ".MAIN_DB_PREFIX."socpeople as c";
 		$statssql[0] .= " WHERE c.entity IN (".getEntity('socpeople').")";
 		$statssql[0] .= " AND c.email != ''"; // Note that null != '' is false
-		$statssql[0] .= " AND c.no_email = 0";
+		$statssql[0] .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = c.email) = 0";
 		$statssql[0] .= " AND c.statut = 1";
 
 		return $statssql;
@@ -104,7 +104,6 @@ class mailing_contacts1 extends MailingTargets
     	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON s.rowid = c.fk_soc";
 		$sql .= " WHERE c.entity IN (".getEntity('socpeople').")";
 		$sql .= " AND c.email != ''"; // Note that null != '' is false
-		$sql .= " AND c.no_email = 0";
 		$sql .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = c.email) = 0";
 		// exclude unsubscribed users
 		$sql .= " AND c.statut = 1";
@@ -132,9 +131,8 @@ class mailing_contacts1 extends MailingTargets
 		$sql = "SELECT sp.poste, count(distinct(sp.email)) AS nb";
 		$sql .= " FROM ".MAIN_DB_PREFIX."socpeople as sp";
 		$sql .= " WHERE sp.entity IN (".getEntity('socpeople').")";
-		/*$sql.= " AND sp.email != ''";    // Note that null != '' is false
-		 $sql.= " AND sp.no_email = 0";
-		 $sql.= " AND sp.statut = 1";*/
+		$sql .= " AND sp.email != ''";    // Note that null != '' is false
+		$sql .= " AND sp.statut = 1";
 		$sql .= " AND (sp.poste IS NOT NULL AND sp.poste != '')";
 		$sql .= " GROUP BY sp.poste";
 		$sql .= " ORDER BY sp.poste";
@@ -166,10 +164,9 @@ class mailing_contacts1 extends MailingTargets
 		$sql .= " ".MAIN_DB_PREFIX."socpeople as sp,";
 		$sql .= " ".MAIN_DB_PREFIX."categorie as c,";
 		$sql .= " ".MAIN_DB_PREFIX."categorie_contact as cs";
-		$sql .= " WHERE sp.statut = 1"; // Note that null != '' is false
-		//$sql.= " AND sp.no_email = 0";
-		//$sql.= " AND sp.email != ''";
-		//$sql.= " AND sp.entity IN (".getEntity('socpeople').")";
+		$sql .= " WHERE sp.entity IN (".getEntity('socpeople').")";
+		$sql .= " AND sp.email != ''";    // Note that null != '' is false
+		$sql .= " AND sp.statut = 1";
 		$sql .= " AND cs.fk_categorie = c.rowid";
 		$sql .= " AND cs.fk_socpeople = sp.rowid";
 		$sql .= " GROUP BY c.label";
@@ -241,10 +238,9 @@ class mailing_contacts1 extends MailingTargets
 		$sql .= " ".MAIN_DB_PREFIX."socpeople as sp,";
 		$sql .= " ".MAIN_DB_PREFIX."categorie as c,";
 		$sql .= " ".MAIN_DB_PREFIX."categorie_societe as cs";
-		$sql .= " WHERE sp.statut = 1"; // Note that null != '' is false
-		//$sql.= " AND sp.no_email = 0";
-		//$sql.= " AND sp.email != ''";
-		//$sql.= " AND sp.entity IN (".getEntity('socpeople').")";
+		$sql .= " WHERE sp.entity IN (".getEntity('socpeople').")";
+		$sql .= " AND sp.email != ''";    // Note that null != '' is false
+		$sql .= " AND sp.statut = 1";
 		$sql .= " AND cs.fk_categorie = c.rowid";
 		$sql .= " AND cs.fk_soc = sp.fk_soc";
 		$sql .= " GROUP BY c.label";
@@ -283,10 +279,9 @@ class mailing_contacts1 extends MailingTargets
 		$sql .= " ".MAIN_DB_PREFIX."socpeople as sp,";
 		$sql .= " ".MAIN_DB_PREFIX."categorie as c,";
 		$sql .= " ".MAIN_DB_PREFIX."categorie_fournisseur as cs";
-		$sql .= " WHERE sp.statut = 1"; // Note that null != '' is false
-		//$sql.= " AND sp.no_email = 0";
-		//$sql.= " AND sp.email != ''";
-		//$sql.= " AND sp.entity IN (".getEntity('socpeople').")";
+		$sql .= " WHERE sp.entity IN (".getEntity('socpeople').")";
+		$sql .= " AND sp.email != ''";    // Note that null != '' is false
+		$sql .= " AND sp.statut = 1";
 		$sql .= " AND cs.fk_categorie = c.rowid";
 		$sql .= " AND cs.fk_soc = sp.fk_soc";
 		$sql .= " GROUP BY c.label";
@@ -385,7 +380,6 @@ class mailing_contacts1 extends MailingTargets
     	if ($filter_category_supplier <> 'all') $sql .= ", ".MAIN_DB_PREFIX."categorie_fournisseur as c3s";
     	$sql .= " WHERE sp.entity IN (".getEntity('socpeople').")";
 		$sql .= " AND sp.email <> ''";
-		$sql .= " AND sp.no_email = 0";
 		$sql .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = sp.email) = 0";
 		// Exclude unsubscribed email adresses
 		$sql .= " AND sp.statut = 1";

--- a/htdocs/core/modules/mailings/contacts1.modules.php
+++ b/htdocs/core/modules/mailings/contacts1.modules.php
@@ -79,7 +79,7 @@ class mailing_contacts1 extends MailingTargets
 		$statssql[0] .= " count(distinct(c.email)) as nb";
 		$statssql[0] .= " FROM ".MAIN_DB_PREFIX."socpeople as c";
 		$statssql[0] .= " WHERE c.entity IN (".getEntity('socpeople').")";
-		$statssql[0] .= " AND c.email != ''"; // Note that null != '' is false
+		$statssql[0] .= " AND c.email <> ''"; // Note that null != '' is false
 		$statssql[0] .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = c.email) = 0";
 		$statssql[0] .= " AND c.statut = 1";
 
@@ -103,7 +103,7 @@ class mailing_contacts1 extends MailingTargets
 		$sql .= " FROM ".MAIN_DB_PREFIX."socpeople as c";
     	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON s.rowid = c.fk_soc";
 		$sql .= " WHERE c.entity IN (".getEntity('socpeople').")";
-		$sql .= " AND c.email != ''"; // Note that null != '' is false
+		$sql .= " AND c.email <> ''"; // Note that null != '' is false
 		$sql .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = c.email) = 0";
 		// exclude unsubscribed users
 		$sql .= " AND c.statut = 1";
@@ -131,9 +131,9 @@ class mailing_contacts1 extends MailingTargets
 		$sql = "SELECT sp.poste, count(distinct(sp.email)) AS nb";
 		$sql .= " FROM ".MAIN_DB_PREFIX."socpeople as sp";
 		$sql .= " WHERE sp.entity IN (".getEntity('socpeople').")";
-		$sql .= " AND sp.email != ''";    // Note that null != '' is false
+		$sql .= " AND sp.email <> ''";    // Note that null != '' is false
 		$sql .= " AND sp.statut = 1";
-		$sql .= " AND (sp.poste IS NOT NULL AND sp.poste != '')";
+		$sql .= " AND (sp.poste IS NOT NULL AND sp.poste <> '')";
 		$sql .= " GROUP BY sp.poste";
 		$sql .= " ORDER BY sp.poste";
 		$resql = $this->db->query($sql);
@@ -165,7 +165,7 @@ class mailing_contacts1 extends MailingTargets
 		$sql .= " ".MAIN_DB_PREFIX."categorie as c,";
 		$sql .= " ".MAIN_DB_PREFIX."categorie_contact as cs";
 		$sql .= " WHERE sp.entity IN (".getEntity('socpeople').")";
-		$sql .= " AND sp.email != ''";    // Note that null != '' is false
+		$sql .= " AND sp.email <> ''";    // Note that null != '' is false
 		$sql .= " AND sp.statut = 1";
 		$sql .= " AND cs.fk_categorie = c.rowid";
 		$sql .= " AND cs.fk_socpeople = sp.rowid";
@@ -239,7 +239,7 @@ class mailing_contacts1 extends MailingTargets
 		$sql .= " ".MAIN_DB_PREFIX."categorie as c,";
 		$sql .= " ".MAIN_DB_PREFIX."categorie_societe as cs";
 		$sql .= " WHERE sp.entity IN (".getEntity('socpeople').")";
-		$sql .= " AND sp.email != ''";    // Note that null != '' is false
+		$sql .= " AND sp.email <> ''";    // Note that null != '' is false
 		$sql .= " AND sp.statut = 1";
 		$sql .= " AND cs.fk_categorie = c.rowid";
 		$sql .= " AND cs.fk_soc = sp.fk_soc";
@@ -280,7 +280,7 @@ class mailing_contacts1 extends MailingTargets
 		$sql .= " ".MAIN_DB_PREFIX."categorie as c,";
 		$sql .= " ".MAIN_DB_PREFIX."categorie_fournisseur as cs";
 		$sql .= " WHERE sp.entity IN (".getEntity('socpeople').")";
-		$sql .= " AND sp.email != ''";    // Note that null != '' is false
+		$sql .= " AND sp.email <> ''";    // Note that null != '' is false
 		$sql .= " AND sp.statut = 1";
 		$sql .= " AND cs.fk_categorie = c.rowid";
 		$sql .= " AND cs.fk_soc = sp.fk_soc";

--- a/htdocs/core/modules/mailings/modules_mailings.php
+++ b/htdocs/core/modules/mailings/modules_mailings.php
@@ -209,24 +209,6 @@ class MailingTargets // This can't be abstract as it is used for some method
 
         dol_syslog(__METHOD__.": mailing ".$j." targets added");
 
-        /*
-        //Update the status to show thirdparty mail that don't want to be contacted anymore'
-        $sql = "UPDATE ".MAIN_DB_PREFIX."mailing_cibles";
-        $sql .= " SET statut=3";
-        $sql .= " WHERE fk_mailing=".$mailing_id." AND email in (SELECT email FROM ".MAIN_DB_PREFIX."societe where fk_stcomm=-1)";
-        $sql .= " AND source_type='thirdparty'";
-        dol_syslog(__METHOD__.": mailing update status to display thirdparty mail that do not want to be contacted");
-        $result=$this->db->query($sql);
-
-        //Update the status to show contact mail that don't want to be contacted anymore'
-        $sql = "UPDATE ".MAIN_DB_PREFIX."mailing_cibles";
-        $sql .= " SET statut=3";
-        $sql .= " WHERE fk_mailing=".$mailing_id." AND source_type='contact' AND (email in (SELECT sc.email FROM ".MAIN_DB_PREFIX."socpeople AS sc ";
-        $sql .= " INNER JOIN ".MAIN_DB_PREFIX."societe s ON s.rowid=sc.fk_soc WHERE s.fk_stcomm=-1 OR no_email=1))";
-        dol_syslog(__METHOD__.": mailing update status to display contact mail that do not want to be contacted",LOG_DEBUG);
-        $result=$this->db->query($sql);
-		*/
-
         $sql = "UPDATE ".MAIN_DB_PREFIX."mailing_cibles";
         $sql .= " SET statut=3";
         $sql .= " WHERE fk_mailing=".$mailing_id." AND email IN (SELECT mu.email FROM ".MAIN_DB_PREFIX."mailing_unsubscribe AS mu WHERE mu.entity IN ('".getEntity('mailing')."'))";

--- a/htdocs/public/emailing/mailing-unsubscribe.php
+++ b/htdocs/public/emailing/mailing-unsubscribe.php
@@ -100,20 +100,6 @@ if (!empty($tag) && ($unsuscrib == '1'))
 	$resql = $db->query($sql);
 	if (!$resql) dol_print_error($db);
 
-	/*
-	// Update status communication of thirdparty prospect (old usage)
-	$sql = "UPDATE ".MAIN_DB_PREFIX."societe SET fk_stcomm=-1 WHERE rowid IN (SELECT source_id FROM ".MAIN_DB_PREFIX."mailing_cibles WHERE tag = '".$db->escape($tag)."' AND source_type='thirdparty' AND source_id is not null)";
-
-	$resql=$db->query($sql);
-	if (! $resql) dol_print_error($db);
-
-    // Update status communication of contact prospect (old usage)
-	$sql = "UPDATE ".MAIN_DB_PREFIX."socpeople SET no_email=1 WHERE rowid IN (SELECT source_id FROM ".MAIN_DB_PREFIX."mailing_cibles WHERE tag = '".$db->escape($tag)."' AND source_type='contact' AND source_id is not null)";
-
-	$resql=$db->query($sql);
-	if (! $resql) dol_print_error($db);
-	*/
-
 	// Update status communication of email (new usage)
 	$sql = "INSERT INTO ".MAIN_DB_PREFIX."mailing_unsubscribe (date_creat, entity, email) VALUES ('".$db->idate(dol_now())."', ".$db->escape($obj->entity).", '".$db->escape($obj->email)."')";
 


### PR DESCRIPTION
The old_email field of the contacts table has been now replaced by a table called mailing_unsubscribe. But it was not used in the contact list.
I also cleaned the mailing target module "contact1".
The no_mail column should be removed soon.