### PR TITLE
Fix #18916 : mass stock movements not displayed if error while adding line

### DIFF
--- a/htdocs/product/stock/massstockmove.php
+++ b/htdocs/product/stock/massstockmove.php
@@ -443,6 +443,7 @@ if ($action == 'confirm_deletefile' && $confirm == 'yes') {
  */
 
 $now = dol_now();
+$error = 0;
 
 $form = new Form($db);
 $formproduct = new FormProduct($db);


### PR DESCRIPTION
$error is used in the action part of the file, and again in the view part ;)