### PR TITLE
Fix - add product line - always fail to input multicurrency price if product price is by default 0 (supplier invoice, sales order &  invoice)

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -798,7 +798,12 @@ if (empty($reshook)) {
 
 				// if price ht is forced (ie: calculated by margin rate and cost price). TODO Why this ?
 				if (!empty($price_ht) || $price_ht === '0') {
-					$pu_ht = price2num($price_ht, 'MU');
+					if($price_ht === '0' && $price_ht_devise != '') { //added test to record multicurrency price while the default price is 0.
+						$pu_ht_devise = price2num($price_ht_devise, 'MU');
+						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
+					} else {
+						$pu_ht = price2num($price_ht, 'MU');
+					}
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
 				} elseif ($tmpvat != $tmpprodvat) {
 					// On reevalue prix selon taux tva car taux tva transaction peut etre different

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -798,7 +798,7 @@ if (empty($reshook)) {
 
 				// if price ht is forced (ie: calculated by margin rate and cost price). TODO Why this ?
 				if (!empty($price_ht) || $price_ht === '0') {
-					if($price_ht === '0' && $price_ht_devise != '') { //added test to record multicurrency price while the default price is 0.
+					if ($price_ht === '0' && $price_ht_devise != '') { //added test to record multicurrency price while the default price is 0.
 						$pu_ht_devise = price2num($price_ht_devise, 'MU');
 						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
 					} else {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2101,7 +2101,12 @@ if (empty($reshook)) {
 
 				// if price ht was forced (ie: from gui when calculated by margin rate and cost price). TODO Why this ?
 				if (!empty($price_ht) || $price_ht === '0') {
-					$pu_ht = price2num($price_ht, 'MU');
+					if($price_ht === '0' && $price_ht_devise != '') { //added test to record multicurrency price while the default price is 0.
+						$pu_ht_devise = price2num($price_ht_devise, 'MU');
+						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
+					} else {
+						$pu_ht = price2num($price_ht, 'MU');
+					}
 					$pu_ttc = price2num($pu_ht * (1 + ($tmpvat / 100)), 'MU');
 				} elseif ($tmpvat != $tmpprodvat) {
 					// On reevalue prix selon taux tva car taux tva transaction peut etre different

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2101,7 +2101,7 @@ if (empty($reshook)) {
 
 				// if price ht was forced (ie: from gui when calculated by margin rate and cost price). TODO Why this ?
 				if (!empty($price_ht) || $price_ht === '0') {
-					if($price_ht === '0' && $price_ht_devise != '') { //added test to record multicurrency price while the default price is 0.
+					if ($price_ht === '0' && $price_ht_devise != '') { //added test to record multicurrency price while the default price is 0.
 						$pu_ht_devise = price2num($price_ht_devise, 'MU');
 						$pu_ht = price2num(GETPOST('price_ht', 'MU'));
 					} else {

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -1449,10 +1449,10 @@ if (empty($reshook)) {
 				}
 
 				$type = $productsupplier->type;
-				if (GETPOST('price_ht') != '' || GETPOST('price_ht_devise') != '') {
+				if ($price_ht != '' || $price_ht_devise != '') {
 					$price_base_type = 'HT';
 					$pu = price2num($price_ht, 'MU');
-					$pu_ht_devise = price2num($price_ht_devise, 'CU');
+					$pu_ht_devise = price2num($price_ht_devise, 'MU');
 				} else {
 					$price_base_type = ($productsupplier->fourn_price_base_type ? $productsupplier->fourn_price_base_type : 'HT');
 					if (empty($object->multicurrency_code) || ($productsupplier->fourn_multicurrency_code != $object->multicurrency_code)) {	// If object is in a different currency and price not in this currency


### PR DESCRIPTION
For my cases, the product selling price is not pre-defined in Dolibarr and the system set it at 0 by default for selling prices and NULL for purchase.

![image](https://user-images.githubusercontent.com/3304600/138624541-cd9cf094-b0a0-4279-8080-1cba29edc25d.png)

![image](https://user-images.githubusercontent.com/3304600/138624561-501a4516-7068-4b5a-b4d0-d12f60a22790.png)

As multicurrency is enabled, the current coding will not register the U.P. in order currency manually input while adding a predefined product in supplier invoice / sales order / customer invoice. 

It means that when a pre-defined product is added, a U.P. main currency can be registered but if a user tries to input the U.P. (currency) (let's say 1$) then the product lines upon added will show a price of 0 in both U.P. of main currency and multicurrency and the user has to re-edit the product line in order to update the multicurrency price to correct value.

With the proposed fix, multi-currency U.P. can be input / registered successfully when a new product line is added into supplier invoice / sales order / customer invoice.