### PR TITLE
FIX restrictedArea for payment delete

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -489,12 +489,12 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 				if (!$user->rights->fournisseur->commande->supprimer) {
 					$deleteok = 0;
 				}
-			} elseif ($feature == 'payment_supplier') {
+			} elseif ($feature == 'payment_supplier') {	// Permission to delete a payment of an invoice is permission to edit an invoice.
 				if (!$user->rights->fournisseur->facture->creer) {
 					$deleteok = 0;
 				}
-			} elseif ($feature == 'payment') {
-				if (!$user->rights->facture->supprimer) {
+			} elseif ($feature == 'payment') {	// Permission to delete a payment of an invoice is permission to edit an invoice.
+				if (!$user->rights->facture->creer) {
 						$deleteok = 0;
 				}
 			} elseif ($feature == 'banque') {

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -494,10 +494,10 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 					$deleteok = 0;
 				}
 			} elseif ($feature == 'payment') {
-                        	if (!$user->rights->facture->supprimer) {
-                                	$deleteok = 0;
-                        	}
-                	}elseif ($feature == 'banque') {
+				if (!$user->rights->facture->supprimer) {
+						$deleteok = 0;
+				}
+			} elseif ($feature == 'banque') {
 				if (!$user->rights->banque->modifier) {
 					$deleteok = 0;
 				}

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -493,7 +493,11 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 				if (!$user->rights->fournisseur->facture->creer) {
 					$deleteok = 0;
 				}
-			} elseif ($feature == 'banque') {
+			} elseif ($feature == 'payment') {
+                        	if (!$user->rights->facture->supprimer) {
+                                	$deleteok = 0;
+                        	}
+                	}elseif ($feature == 'banque') {
 				if (!$user->rights->banque->modifier) {
 					$deleteok = 0;
 				}


### PR DESCRIPTION
# FIX restrictedArea for payment delete
On payment card if we want to delete the payment, the restrictedArea Function was testing if  "$user->rights->payment->supprimer/delete/run" exists
These rights do not exist
instead, we must test invoice rights like in readok test