### PR TITLE
PARTIAL FIX 14.0 - forbidden functions dol_eval() can be executed

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8110,14 +8110,15 @@ function dol_eval($s, $returnvalue = 0, $hideerrors = 1)
 	}
 
 	// We block using of php exec or php file functions
-	$forbiddenphpstrings = array("exec(", "passthru(", "shell_exec(", "system(", "proc_open(", "popen(", "eval(", "dol_eval(", "executeCLI(");
-	$forbiddenphpstrings = array_merge($forbiddenphpstrings, array("fopen(", "file_put_contents(", "fputs(", "fputscsv(", "fwrite(", "fpassthru(", "unlink(", "mkdir(", "rmdir(", "symlink(", "touch(", "umask("));
-	$forbiddenphpstrings = array_merge($forbiddenphpstrings, array('function(', '$$', 'call_user_func('));
-	$forbiddenphpstrings = array_merge($forbiddenphpstrings, array('_ENV', '_SESSION', '_COOKIE', '_GET', '_POST', '_REQUEST'));
-	$forbiddenphpregex = 'global\s+\$';
+	$forbiddenphpstrings = array(
+		"exec", "passthru", "shell_exec", "system", "proc_open", "popen", "eval", "dol_eval", "executeCLI",
+		"fopen", "file_put_contents", "fputs", "fputscsv", "fwrite", "fpassthru", "unlink", "mkdir", "rmdir",
+		"symlink", "touch", "umask", 'function', 'call_user_func',
+		'_ENV', '_SESSION', '_COOKIE', '_GET', '_POST', '_REQUEST'
+	);
+	$forbiddenphpregex = 'global\s+\$|\b(' . implode('|', $forbiddenphpstrings) . ')\b|\$\$';
 	do {
 		$oldstringtoclean = $s;
-		$s = str_ireplace($forbiddenphpstrings, '__forbiddenstring__', $s);
 		$s = preg_replace('/'.$forbiddenphpregex.'/', '__forbiddenstring__', $s);
 		//$s = preg_replace('/\$[a-zA-Z0-9_\->\$]+\(/i', '', $s);	// Remove $function( call and $mycall->mymethod(
 	} while ($oldstringtoclean != $s);


### PR DESCRIPTION
# FIX
Following [this forum thread](https://www.dolibarr.fr/forum/t/complementary-attribut-dans-le-module-third-party/38199/4), I realized just adding a space between the forbidden function's name and the opening parenthesis is enough to "avoid detection".

This fix tries to address this by banning the forbidden function names altogether if they are not part of another word (hence the use of boundary delimiters `\b`).

Not including the parenthesis in the detection also takes care of other possible detection avoidance methods such as putting an empty comment `/**/` between the function name and the parenthesis.

The drawback is that legitimate code containing words such as "function" or "touch" will no longer run, but this is a tradeoff.

**Note:** this does not completely prevent the execution of forbidden functions, but this makes it harder. I haven't found a solution regarding more intricate methods. Maybe there should be a warning telling users to never paste untrusted code into a calculated extrafield (it sounds obvious but who knows)?