### PR TITLE
FIX: URGENT: impossible to create an invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2756,15 +2756,6 @@ if (empty($reshook))
  * View
  */
 
-if (empty($object->id)) {
-	llxHeader();
-	$head = facture_prepare_head($object);
-	$langs->load('errors');
-	echo dol_get_fiche_head($head, 'compta', $langs->trans("InvoiceCustomer"), -1, 'bill'),
-		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
-	llxFooter();
-	exit;
-}
 
 $form = new Form($db);
 $formother = new FormOther($db);
@@ -3679,6 +3670,15 @@ if ($action == 'create')
 }
 elseif ($id > 0 || !empty($ref))
 {
+	if (empty($object->id)) {
+		llxHeader();
+		$langs->load('errors');
+		echo '<div class="error">'.$langs->trans("ErrorRecordNotFound");
+		echo ' <a href="javascript:history.go(-1)">'.$langs->trans('GoBack').'</div>';
+		llxFooter();
+		exit;
+	}
+
 	/*
 	 * Show object in view mode
 	 */

--- a/htdocs/compta/facture/contact.php
+++ b/htdocs/compta/facture/contact.php
@@ -120,10 +120,9 @@ elseif ($action == 'deletecontact' && $user->rights->facture->creer)
 
 if (empty($object->id)) {
 	llxHeader();
-	$head = facture_prepare_head($object);
 	$langs->load('errors');
-	echo dol_get_fiche_head($head, 'contact', $langs->trans("InvoiceCustomer"), -1, 'bill'),
-		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
+	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound");
+	echo ' <a href="javascript:history.go(-1)">'.$langs->trans('GoBack').'</div>';
 	llxFooter();
 	exit;
 }

--- a/htdocs/compta/facture/contact.php
+++ b/htdocs/compta/facture/contact.php
@@ -121,8 +121,7 @@ elseif ($action == 'deletecontact' && $user->rights->facture->creer)
 if (empty($object->id)) {
 	llxHeader();
 	$langs->load('errors');
-	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound");
-	echo ' <a href="javascript:history.go(-1)">'.$langs->trans('GoBack').'</div>';
+	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound").'</div>';
 	llxFooter();
 	exit;
 }

--- a/htdocs/compta/facture/document.php
+++ b/htdocs/compta/facture/document.php
@@ -88,8 +88,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/actions_linkedfiles.inc.php';
 if (empty($object->id)) {
 	llxHeader();
 	$langs->load('errors');
-	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound");
-	echo ' <a href="javascript:history.go(-1)">'.$langs->trans('GoBack').'</div>';
+	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound").'</div>';
 	llxFooter();
 	exit;
 }

--- a/htdocs/compta/facture/document.php
+++ b/htdocs/compta/facture/document.php
@@ -87,10 +87,9 @@ require_once DOL_DOCUMENT_ROOT.'/core/actions_linkedfiles.inc.php';
 
 if (empty($object->id)) {
 	llxHeader();
-	$head = facture_prepare_head($object);
 	$langs->load('errors');
-	echo dol_get_fiche_head($head, 'documents', $langs->trans("InvoiceCustomer"), -1, 'bill'),
-		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
+	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound");
+	echo ' <a href="javascript:history.go(-1)">'.$langs->trans('GoBack').'</div>';
 	llxFooter();
 	exit;
 }

--- a/htdocs/compta/facture/info.php
+++ b/htdocs/compta/facture/info.php
@@ -46,8 +46,7 @@ $ref = GETPOST("ref", 'alpha');
 if (empty($object->id)) {
 	llxHeader();
 	$langs->load('errors');
-	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound");
-	echo ' <a href="javascript:history.go(-1)">'.$langs->trans('GoBack').'</div>';
+	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound").'</div>';
 	llxFooter();
 	exit;
 }

--- a/htdocs/compta/facture/info.php
+++ b/htdocs/compta/facture/info.php
@@ -45,10 +45,9 @@ $ref = GETPOST("ref", 'alpha');
 
 if (empty($object->id)) {
 	llxHeader();
-	$head = facture_prepare_head($object);
 	$langs->load('errors');
-	echo dol_get_fiche_head($head, 'info', $langs->trans("InvoiceCustomer"), -1, 'bill'),
-		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
+	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound");
+	echo ' <a href="javascript:history.go(-1)">'.$langs->trans('GoBack').'</div>';
 	llxFooter();
 	exit;
 }

--- a/htdocs/compta/facture/note.php
+++ b/htdocs/compta/facture/note.php
@@ -67,8 +67,7 @@ include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php';	// Must be include, 
 if (empty($object->id)) {
 	llxHeader();
 	$langs->load('errors');
-	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound");
-	echo ' <a href="javascript:history.go(-1)">'.$langs->trans('GoBack').'</div>';
+	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound").'</div>';
 	llxFooter();
 	exit;
 }

--- a/htdocs/compta/facture/note.php
+++ b/htdocs/compta/facture/note.php
@@ -66,10 +66,9 @@ include DOL_DOCUMENT_ROOT.'/core/actions_setnotes.inc.php';	// Must be include, 
 
 if (empty($object->id)) {
 	llxHeader();
-	$head = facture_prepare_head($object);
 	$langs->load('errors');
-	echo dol_get_fiche_head($head, 'note', $langs->trans("InvoiceCustomer"), -1, 'bill'),
-		'<div class="error">' . $langs->trans("ErrorRecordNotFound") . '</div>';
+	echo '<div class="error">'.$langs->trans("ErrorRecordNotFound");
+	echo ' <a href="javascript:history.go(-1)">'.$langs->trans('GoBack').'</div>';
 	llxFooter();
 	exit;
 }


### PR DESCRIPTION
A very bad check introduced and validated in #18931 resulted in invoice creation to be inaccessible. $object->id was checked for emptyness to display an error page, but it is empty when creating a new invoice.

Furthermore, the new UI introduced prints tabs that are useless because the $object has no id, and generate PHP warnings. Replaced with a simple back to last page link.

Impacts branches 11.0 through develop.