### PR TITLE
FIX #10796 #8927 Accept both CLI argv and CGI modes in /script/cron_run_jobs.php

### DIFF
--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -49,10 +49,10 @@ $script_file = basename(__FILE__);
 $path = __DIR__.'/';
 
 // Error if Web mode
-if (substr($sapi_type, 0, 3) == 'cgi') { 
+if (substr($sapi_type, 0, 3) == 'cgi') {
 	echo "Warning: You are using PHP for CGI. To execute ".$script_file." from command line, you must use PHP for CLI mode.\n";
 	echo "PATH=".$path." \n";
-//	exit(-1); /* Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
+	//  exit(-1); /* Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
 }
 
 require_once $path."../../htdocs/master.inc.php";


### PR DESCRIPTION
Fix the case when crontab in shared hosting launch the script as PHP cgi mode and do not allow CLI mode. 
To fix it, this version of the script /script/cron_run_jobs.php accept both modes, and use the security key and username passed by argv in the case it was launched in CLI mode, and use key=$conf->global->CRON_KEY and $userlogin = "firstadmin" if it was launched in cgi mode.