### PR TITLE
FIX #10796 #8927 Accept both CLI argv and CGI modes in /script/cron_run_jobs.php

### DIFF
--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -49,33 +49,45 @@ $script_file = basename(__FILE__);
 $path = __DIR__.'/';
 
 // Error if Web mode
-if (substr($sapi_type, 0, 3) == 'cgi') {
-	echo "Error: You are using PHP for CGI. To execute ".$script_file." from command line, you must use PHP for CLI mode.\n";
-	exit(-1);
+if (substr($sapi_type, 0, 3) == 'cgi') { 
+	echo "Warning: You are using PHP for CGI. To execute ".$script_file." from command line, you must use PHP for CLI mode.\n";
+	echo "PATH=".$path." \n";
+//	exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
 }
 
-require_once $path."../../htdocs/master.inc.php";
+//require_once $path."../../htdocs/master.inc.php"; EDU deleted "/htdocs" part in the path of master.inc.php
+require_once $path."../../master.inc.php";
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 
-// Check parameters
-if (!isset($argv[1]) || !$argv[1]) {
-	usage($path, $script_file);
-	exit(-1);
-}
+// Check parameters, EDU: if WEBmode instead the expected CLImode setup the security key and user login name from config instead args of command line
 $key = $argv[1];
-
-if (!isset($argv[2]) || !$argv[2]) {
-	usage($path, $script_file);
-	exit(-1);
+if (!isset($argv[1]) || !$argv[1]) {
+	if (substr($sapi_type, 0, 3) == 'cgi') {
+	    $key = $conf->global->CRON_KEY;
+	    echo "Scheduled job management setup securitykey=".$key;
+	}
+	else {
+	    usage($path, $script_file);
+	    exit(-1);
+	}
 }
 
 $userlogin = $argv[2];
+if (!isset($argv[2]) || !$argv[2]) {
+	if (substr($sapi_type, 0, 3) == 'cgi') {
+	    $userlogin = "firstadmin"; /* Reserver word 'firstadmin' to search in DB the fist user loginname with admin rights */
+	}
+    else {
+        echo "ARGV2 USAGE ERROR ".$userlogin." \n";
+        usage($path, $script_file);
+        exit(-1);
+    }
+}
 
 // Global variables
 $version = DOL_VERSION;
 $error = 0;
-
 
 /*
  * Main
@@ -286,6 +298,7 @@ if (is_array($qualifiedjobs) && (count($qualifiedjobs) > 0)) {
 }
 
 $db->close();
+echo "\n\n";
 
 if ($nbofjobslaunchedko) {
 	exit(1);

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -55,8 +55,9 @@ if (substr($sapi_type, 0, 3) == 'cgi') {
 	//  exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
 }
 
-//require_once $path."../../htdocs/master.inc.php"; EDU deleted "/htdocs" part in the path of master.inc.php
-require_once $path."../../master.inc.php";
+//The $path of master.inc.php is different if the Dolibarr instance was updated  from older versions or using tools like Cpanel or automatic installer tools.   
+if  file_exists($path."../../htdocs/master.inc.php") {require_once $path."../../htdocs/master.inc.php";}
+if  file_exists($path."../../master.inc.php") {require_once $path."../../master.inc.php";}
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -56,8 +56,8 @@ if (substr($sapi_type, 0, 3) == 'cgi') {
 }
 
 //The $path of master.inc.php is different if the Dolibarr instance was updated  from older versions or using tools like Cpanel or automatic installer tools.
-if file_exists($path."../../htdocs/master.inc.php") {require_once $path."../../htdocs/master.inc.php";}
-if file_exists($path."../../master.inc.php") {require_once $path."../../master.inc.php";}
+if (file_exists($path."../../htdocs/master.inc.php")) {require_once $path."../../htdocs/master.inc.php";}
+if (file_exists($path."../../master.inc.php")) {require_once $path."../../master.inc.php";}
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -49,10 +49,10 @@ $script_file = basename(__FILE__);
 $path = __DIR__.'/';
 
 // Error if Web mode
-if (substr($sapi_type, 0, 3) == 'cgi') { 
+if (substr($sapi_type, 0, 3) == 'cgi') {
 	echo "Warning: You are using PHP for CGI. To execute ".$script_file." from command line, you must use PHP for CLI mode.\n";
 	echo "PATH=".$path." \n";
-//	exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
+	//  exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
 }
 
 //require_once $path."../../htdocs/master.inc.php"; EDU deleted "/htdocs" part in the path of master.inc.php
@@ -64,25 +64,23 @@ require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 $key = $argv[1];
 if (!isset($argv[1]) || !$argv[1]) {
 	if (substr($sapi_type, 0, 3) == 'cgi') {
-	    $key = $conf->global->CRON_KEY;
-	    echo "Scheduled job management setup securitykey=".$key;
-	}
-	else {
-	    usage($path, $script_file);
-	    exit(-1);
+		$key = $conf->global->CRON_KEY;
+		echo "Scheduled job management setup securitykey=".$key;
+	} else {
+		usage($path, $script_file);
+		exit(-1);
 	}
 }
 
 $userlogin = $argv[2];
 if (!isset($argv[2]) || !$argv[2]) {
 	if (substr($sapi_type, 0, 3) == 'cgi') {
-	    $userlogin = "firstadmin"; /* Reserver word 'firstadmin' to search in DB the fist user loginname with admin rights */
+		$userlogin = "firstadmin"; /* Reserver word 'firstadmin' to search in DB the fist user loginname with admin rights */
+	} else {
+		echo "ARGV2 USAGE ERROR ".$userlogin." \n";
+		usage($path, $script_file);
+		exit(-1);
 	}
-    else {
-        echo "ARGV2 USAGE ERROR ".$userlogin." \n";
-        usage($path, $script_file);
-        exit(-1);
-    }
 }
 
 // Global variables

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -55,9 +55,9 @@ if (substr($sapi_type, 0, 3) == 'cgi') {
 	//  exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
 }
 
-//The $path of master.inc.php is different if the Dolibarr instance was updated  from older versions or using tools like Cpanel or automatic installer tools.   
-if  file_exists($path."../../htdocs/master.inc.php") {require_once $path."../../htdocs/master.inc.php";}
-if  file_exists($path."../../master.inc.php") {require_once $path."../../master.inc.php";}
+//The $path of master.inc.php is different if the Dolibarr instance was updated  from older versions or using tools like Cpanel or automatic installer tools.
+if file_exists($path."../../htdocs/master.inc.php") {require_once $path."../../htdocs/master.inc.php";}
+if file_exists($path."../../master.inc.php") {require_once $path."../../master.inc.php";}
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 


### PR DESCRIPTION
Fix the case when crontab in shared hosting launch the script as PHP cgi mode and do not allow CLI mode.
To fix it, this version of the script /script/cron_run_jobs.php accept both modes, and use the security key and username passed by argv in the case it was launched in CLI mode, and use key=$conf->global->CRON_KEY and $userlogin = "firstadmin" if it was launched in cgi mode.
