### PR TITLE
FIX Ticket - Duplicate field project when we create ticket from project

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1,16 +1,17 @@
 <?php
-/* Copyright (C) 2013-2015  Jean-François FERRY     <hello@librethic.io>
- * Copyright (C) 2016       Christophe Battarel     <christophe@altairis.fr>
- * Copyright (C) 2019       Frédéric France         <frederic.france@netlogic.fr>
+/* Copyright (C) 2013-2015  Jean-François FERRY	<hello@librethic.io>
+ * Copyright (C) 2016       Christophe Battarel <christophe@altairis.fr>
+ * Copyright (C) 2019       Frédéric France     <frederic.france@netlogic.fr>
+ * Copyright (C) 2021      Alexandre Spangaro   <aspangaro@open-dsi.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -351,12 +352,13 @@ class FormTicket
 			}
 		}
 
-		if (!empty($conf->projet->enabled) && !$this->ispublic)
-		{
-			$formproject = new FormProjets($this->db);
-			print '<tr><td><label for="project"><span class="">'.$langs->trans("Project").'</span></label></td><td>';
-			print $formproject->select_projects(-1, GETPOST('projectid', 'int'), 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 0, 0, 'maxwidth500');
-			print '</td></tr>';
+		if($subelement != 'project') {
+			if (!empty($conf->projet->enabled) && !$this->ispublic) {
+				$formproject = new FormProjets($this->db);
+				print '<tr><td><label for="project"><span class="">' . $langs->trans("Project") . '</span></label></td><td>';
+				print $formproject->select_projects(-1, GETPOST('projectid', 'int'), 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 0, 0, 'maxwidth500');
+				print '</td></tr>';
+			}
 		}
 
 		// Attached files

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -1,7 +1,8 @@
 <?php
-/* Copyright (C) 2013-2016 Jean-François FERRY <hello@librethic.io>
- * Copyright (C) 2016      Christophe Battarel <christophe@altairis.fr>
- * Copyright (C) 2018      Laurent Destailleur <eldy@users.sourceforge.net>
+/* Copyright (C) 2013-2016 Jean-François FERRY  <hello@librethic.io>
+ * Copyright (C) 2016      Christophe Battarel  <christophe@altairis.fr>
+ * Copyright (C) 2018      Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2021      Alexandre Spangaro   <aspangaro@open-dsi.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -192,9 +193,15 @@ if (empty($reshook)) {
 					$result = $object->add_contact($contactid, GETPOST("type"), 'external');
 				}
 
-				// altairis: link ticket to project
-				if (GETPOST('projectid') > 0) {
-					$object->setProject(GETPOST('projectid'));
+				// Link ticket to project
+				if(GETPOST('origin', 'alpha') == 'projet') {
+					$projectid = GETPOST('originid', 'int');
+				} else {
+					$projectid = GETPOST('projectid', 'int');
+				}
+
+				if ($projectid > 0) {
+					$object->setProject($projectid);
 				}
 
 				// Auto assign user


### PR DESCRIPTION
When we create a ticket from a project, field "Project" is show twice, but only the 2nd field work...

When origin is project, remove other field et register id project

![image](https://user-images.githubusercontent.com/2341395/139557996-718717a5-50f3-4d69-a9fc-c091485dcfda.png)