### PR TITLE
replace function each deprecated in php 7.2

### DIFF
--- a/htdocs/includes/printipp/http_class.php
+++ b/htdocs/includes/printipp/http_class.php
@@ -366,7 +366,9 @@ class http_class
         $content_length = 0;
         foreach ($this->arguments["BodyStream"] as $argument)
         {
-            list ($type, $value) = each ($argument);
+            // list ($type, $value) = each ($argument);
+            $type = key($argument);
+            $value = current($argument);
             reset ($argument);
             if ($type == "Data")
             {
@@ -420,7 +422,9 @@ class http_class
         }
         foreach ($this->arguments["BodyStream"] as $argument)
         {
-            list ($type, $value) = each ($argument);
+            // list ($type, $value) = each ($argument);
+            $type = key($argument);
+            $value = current($argument);
             reset ($argument);
             if ($type == "Data")
             {


### PR DESCRIPTION
Warning This function has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. Relying on this function is highly discouraged.

Avertissement Cette fonctionnalité est OBSOLÈTE à partir de PHP 7.2.0 et a été SUPPRIMÉE à partir de PHP 8.0.0.