### PR TITLE
FIX: Status propagation from Parent Product

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -490,12 +490,12 @@ class ProductCombination
 		$child->weight = $parent->weight;
 		// Only when Parent Status are updated
 		if ($parent->oldcopy && ($parent->status != $parent->oldcopy->status)) {
-            $child->status = $parent->status;
-        }
+			$child->status = $parent->status;
+		}
 		if ($parent->oldcopy && ($parent->status_buy != $parent->oldcopy->status_buy)) {
-            $child->status_buy = $parent->status_buy;
-        }
-		
+			$child->status_buy = $parent->status_buy;
+		}
+
 		if ($this->variation_weight) {	// If we must add a delta on weight
 			$child->weight = ($child->weight ? $child->weight : 0) + $this->variation_weight;
 		}

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -488,8 +488,14 @@ class ProductCombination
 
 		$child->price_autogen = $parent->price_autogen;
 		$child->weight = $parent->weight;
-		$child->status = $parent->status;
-
+		// Only when Parent Status are updated
+		if ($parent->oldcopy && ($parent->status != $parent->oldcopy->status)) {
+            $child->status = $parent->status;
+        }
+		if ($parent->oldcopy && ($parent->status_buy != $parent->oldcopy->status_buy)) {
+            $child->status_buy = $parent->status_buy;
+        }
+		
 		if ($this->variation_weight) {	// If we must add a delta on weight
 			$child->weight = ($child->weight ? $child->weight : 0) + $this->variation_weight;
 		}


### PR DESCRIPTION
# FIX
toSell or toBuy Status propagation should be done only when parent is updated. 

Otherwise, any modification made on the parent will overwrite the specific configuration made at the child level.
