### PR TITLE
Fix Bad count of subscription by year

### DIFF
--- a/htdocs/core/boxes/box_members_subscriptions_by_year.php
+++ b/htdocs/core/boxes/box_members_subscriptions_by_year.php
@@ -111,7 +111,7 @@ class box_members_subscriptions_by_year extends ModeleBoxes
 				$i = 0;
 				while ($i < $num) {
 					$objp = $this->db->fetch_object($result);
-					$year = dol_print_date($this->db->jdate($objp->dateh), "%Y", 'gmt');
+					$year = dol_print_date($this->db->jdate($objp->dateh), "%Y");
 					$Total[$year] = (isset($Total[$year]) ? $Total[$year] : 0) + $objp->subscription;
 					$Number[$year] = (isset($Number[$year]) ? $Number[$year] : 0) + 1;
 					$tot += $objp->subscription;


### PR DESCRIPTION
Count is false if timezone was not GMT and subscriptions begin on ****-01-01 00:00:00