### PR TITLE
Handle case where credit note has no source invoice

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2721,8 +2721,12 @@ if ($action == 'create') {
 		}
 		if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE) {
 			$facusing = new FactureFournisseur($db);
-			$facusing->fetch($object->fk_facture_source);
-			print ' ('.$langs->transnoentities("CorrectInvoice", $facusing->getNomUrl(1)).')';
+			if ($object->fk_facture_source > 0) {
+				$facusing->fetch($object->fk_facture_source);
+				print ' ('.$langs->transnoentities("CorrectInvoice", $facusing->getNomUrl(1)).')';
+			} else {
+				print ' ('.$langs->transnoentities("NoInvoiceToCorrect").')';
+			}
 		}
 
 		$facidavoir = $object->getListIdAvoirFromInvoice();

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -1,4 +1,4 @@
-<?php
+<?phpf
 /* Copyright (C) 2002-2005  Rodolphe Quiedeville    <rodolphe@quiedeville.org>
  * Copyright (C) 2004-2020	Laurent Destailleur 	<eldy@users.sourceforge.net>
  * Copyright (C) 2004		Christophe Combelles	<ccomb@free.fr>
@@ -2725,7 +2725,7 @@ if ($action == 'create') {
 				$facusing->fetch($object->fk_facture_source);
 				print ' ('.$langs->transnoentities("CorrectInvoice", $facusing->getNomUrl(1)).')';
 			} else {
-				print ' ('.$langs->transnoentities("CorrectInvoiceNotFound").')';
+				print ' ('.$langs->transnoentities("CorrectedInvoiceNotFound").')';
 			}
 		}
 

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2725,7 +2725,7 @@ if ($action == 'create') {
 				$facusing->fetch($object->fk_facture_source);
 				print ' ('.$langs->transnoentities("CorrectInvoice", $facusing->getNomUrl(1)).')';
 			} else {
-				print ' ('.$langs->transnoentities("NoInvoiceToCorrect").')';
+				print ' ('.$langs->transnoentities("CorrectInvoiceNotFound").')';
 			}
 		}
 


### PR DESCRIPTION
# NEW|New Display a message if credit note has no source invoice
When a credit note has no source invoice (`fk_facture_source` as null), dolibarr displays that is it link to the first invoice created in dolibarr. That information is wrong.

I changed so that it displays that there is no invoice to correct :
![image](https://user-images.githubusercontent.com/50613035/140068234-cff37535-fce5-4b91-b88d-90da958ad359.png)

That case is usually not possible with dolibarr but when we migrate to dolibarr we did not import all the invoices. We need to encode a new credit note related to an invoice that is not in doliabrr. So we encoded the credit note with a wrong invoice and I removed the "fk_facture_source" to be link to no invoice.

