### PR TITLE
 Fix default enddate subscription must be in futur

### DIFF
--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -943,8 +943,10 @@ if ($rowid > 0) {
 		}
 		if (!$datefrom) {
 			$datefrom = $object->datevalid;
-			if ($object->datefin > 0) {
-				$datefrom = dol_time_plus_duree($object->datefin, 1, 'd');
+			if ($object->datefin > 0 && dol_now() > dol_time_plus_duree(dol_time_plus_duree($object->datefin, 2 * $defaultdelay, $defaultdelayunit), -1, 'd') {
+				$datefrom = dol_time_plus_duree($object->datefin, 1, 'd');	
+			} else {
+				$datefrom = dol_get_first_day(dol_print_date(time(), "%Y"));
 			}
 		}
 		print $form->selectDate($datefrom, '', '', '', '', "subscription", 1, 1);

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -943,7 +943,7 @@ if ($rowid > 0) {
 		}
 		if (!$datefrom) {
 			$datefrom = $object->datevalid;
-			if ($object->datefin > 0 && dol_now() > dol_time_plus_duree(dol_time_plus_duree($object->datefin, 2 * $defaultdelay, $defaultdelayunit), -1, 'd') {
+			if ($object->datefin > 0 && dol_now() > dol_time_plus_duree(dol_time_plus_duree($object->datefin, 2 * $defaultdelay, $defaultdelayunit), -1, 'd')) {
 				$datefrom = dol_time_plus_duree($object->datefin, 1, 'd');	
 			} else {
 				$datefrom = dol_get_first_day(dol_print_date(time(), "%Y"));

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -944,7 +944,7 @@ if ($rowid > 0) {
 		if (!$datefrom) {
 			$datefrom = $object->datevalid;
 			if ($object->datefin > 0 && dol_now() < dol_time_plus_duree(dol_time_plus_duree($object->datefin, 2 * $defaultdelay, $defaultdelayunit), -1, 'd')) {
-				$datefrom = dol_time_plus_duree($object->datefin, 1, 'd');	
+				$datefrom = dol_time_plus_duree($object->datefin, 1, 'd');
 			} else {
 				$datefrom = dol_get_first_day(dol_print_date(time(), "%Y"));
 			}

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -943,7 +943,7 @@ if ($rowid > 0) {
 		}
 		if (!$datefrom) {
 			$datefrom = $object->datevalid;
-			if ($object->datefin > 0 && dol_now() < dol_time_plus_duree(dol_time_plus_duree($object->datefin, 2 * $defaultdelay, $defaultdelayunit), -1, 'd')) {
+			if ($object->datefin > 0 && dol_time_plus_duree($object->datefin, $defaultdelay, $defaultdelayunit) < dol_now()) {
 				$datefrom = dol_time_plus_duree($object->datefin, 1, 'd');
 			} else {
 				$datefrom = dol_get_first_day(dol_print_date(time(), "%Y"));

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -943,7 +943,7 @@ if ($rowid > 0) {
 		}
 		if (!$datefrom) {
 			$datefrom = $object->datevalid;
-			if ($object->datefin > 0 && dol_now() > dol_time_plus_duree(dol_time_plus_duree($object->datefin, 2 * $defaultdelay, $defaultdelayunit), -1, 'd')) {
+			if ($object->datefin > 0 && dol_now() < dol_time_plus_duree(dol_time_plus_duree($object->datefin, 2 * $defaultdelay, $defaultdelayunit), -1, 'd')) {
 				$datefrom = dol_time_plus_duree($object->datefin, 1, 'd');	
 			} else {
 				$datefrom = dol_get_first_day(dol_print_date(time(), "%Y"));


### PR DESCRIPTION
Currently, the first proposed date for a new subscription is the date immediately following the end of the last contribution. However, the proposed subscription may already have expired if a member has not renewed for longer than the default period. 
My proposition is to use the first day of the present year, as the "Now link" is already enabled.