### PR TITLE
NEW Adds `EXPENSEREPORT_FILE_IS_REQUIRED` global var to force user to join file for each line of an expense report

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -118,6 +118,7 @@ $permissiontoadd = $user->rights->expensereport->creer; // Used by the include o
 $upload_dir = $conf->expensereport->dir_output.'/'.dol_sanitizeFileName($object->ref);
 
 $projectRequired = $conf->projet->enabled && ! empty($conf->global->EXPENSEREPORT_PROJECT_IS_REQUIRED);
+$fileRequired = !empty($conf->global->EXPENSEREPORT_FILE_IS_REQUIRED);
 
 if ($object->id > 0) {
 	// Check current user can read this expense report
@@ -1155,6 +1156,12 @@ if (empty($reshook)) {
 		if ($projectRequired && $fk_project <= 0) {
 			$error++;
 			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("Project")), null, 'errors');
+		}
+
+		// If no file associated
+		if ($fileRequired && $fk_ecm_files == 0) {
+			$error++;
+			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("File")), null, 'errors');
 		}
 
 		if (!$error) {


### PR DESCRIPTION
# NEW|New Adds the option to force the user to join a file to expensereport

Adds a global var `EXPENSEREPORT_FILE_IS_REQUIRED` that forces the users to attach file to each line of an expense report.