### PR TITLE
FIX #15273 : Provide correct remain to pay and already payed

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -408,8 +408,8 @@ abstract class CommonDocGenerator
 			$sumpayed = $object->getSommePaiement();
 			$sumdeposit = $object->getSumDepositsUsed();
 			$sumcreditnote = $object->getSumCreditNotesUsed();
-			$already_payed_all = $sumpayed + $sumdeposit + $sumcreditnote;
-			$remain_to_pay = $sumpayed - $sumdeposit - $sumcreditnote;
+			$already_payed_all = $sumpayed - $sumdeposit - $sumcreditnote;
+			$remain_to_pay = $sumpayed + $sumdeposit + $sumcreditnote;
 
 			if ($object->fk_account > 0) {
 				require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';


### PR DESCRIPTION

Provide a correct remain to pay and already payed value in each invoice. 
sumcreditnote and sumdeposit are negative value then we must minus them from each total.

Before :
![Capture d’écran de 2021-11-05 18-32-01](https://user-images.githubusercontent.com/209915/140554915-be5b2313-7a08-4cf4-8eb6-84fb0a247d34.png)

After : 
![Capture d’écran de 2021-11-05 18-30-48](https://user-images.githubusercontent.com/209915/140554918-60f66362-0d7b-4bff-b05d-117bf3582e63.png)

