### PR TITLE
Load product data optional fields to the line

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -559,6 +559,15 @@ abstract class CommonDocGenerator
 			$resarray = $this->fill_substitutionarray_with_extrafields($object, $resarray, $extrafields, $array_key, $outputlangs);
 		}
 
+		// Load product data optional fields to the line -> enables to use "line_options_{extrafield}"
+		if (isset($line->fk_product) && $line->fk_product > 0)
+		{
+			$tmpproduct = new Product($this->db);
+			$result = $tmpproduct->fetch($line->fk_product);
+			foreach($tmpproduct->array_options as $key=>$label)
+				$resarray["line_".$key] = $label;
+		}
+		
 		return $resarray;
 	}
 

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -560,14 +560,13 @@ abstract class CommonDocGenerator
 		}
 
 		// Load product data optional fields to the line -> enables to use "line_options_{extrafield}"
-		if (isset($line->fk_product) && $line->fk_product > 0)
-		{
+		if (isset($line->fk_product) && $line->fk_product > 0) {
 			$tmpproduct = new Product($this->db);
 			$result = $tmpproduct->fetch($line->fk_product);
-			foreach($tmpproduct->array_options as $key=>$label)
+			foreach ($tmpproduct->array_options as $key=>$label)
 				$resarray["line_".$key] = $label;
 		}
-		
+
 		return $resarray;
 	}
 


### PR DESCRIPTION
# Optional Fields
This fix enables to use optional fields from product in invoices or offers at the line.

