### PR TITLE
fix permission on supplier_order document upload

### DIFF
--- a/htdocs/supplier_proposal/document.php
+++ b/htdocs/supplier_proposal/document.php
@@ -75,7 +75,7 @@ if ($object->id > 0) {
 	$upload_dir = $conf->supplier_proposal->dir_output.'/'.dol_sanitizeFileName($object->ref);
 }
 
-
+$permissiontoadd = $user->rights->supplier_proposal->creer;
 
 /*
  * Actions


### PR DESCRIPTION
on the document.php for supplier_proposals the $permissiontoadd var was not filled like it should be best practice
also project details in the header was not set the "standard" way