### PR TITLE
NEW 15.0: (minor) replicate extrafields of origin onto new intervention

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -837,6 +837,10 @@ if ($action == 'create') {
 			$note_private = (!empty($objectsrc->note) ? $objectsrc->note : (!empty($objectsrc->note_private) ? $objectsrc->note_private : GETPOST('note_private', 'restricthtml')));
 			$note_public = (!empty($objectsrc->note_public) ? $objectsrc->note_public : GETPOST('note_public', 'restricthtml'));
 
+			// Replicate extrafields
+			$objectsrc->fetch_optionals();
+			$object->array_options = $objectsrc->array_options;
+
 			// Object source contacts list
 			$srccontactslist = $objectsrc->liste_contact(-1, 'external', 1);
 		}


### PR DESCRIPTION
# NEW feature
When you create an intervention from an existing object (let's say from an order), if extrafields have the same name on interventions and on orders, they could be copied automatically as is already the case for some other object types such as invoices.

To achieve this, I copy-pasted the 3 lines from `facture/card.php`.