### PR TITLE
NEW: default use MAIN_USE_EXIF_ROTATION on new install

### DIFF
--- a/htdocs/install/mysql/data/llx_const.sql
+++ b/htdocs/install/mysql/data/llx_const.sql
@@ -109,3 +109,7 @@ INSERT INTO llx_const (name, entity, value, type, visible) VALUES ('PRODUCT_PRIC
 --
 INSERT INTO llx_const (name, entity, value, type, visible) VALUES ('ADHERENT_LOGIN_NOT_REQUIRED', 0, '1', 'string', 0);
 
+--
+-- EXIF IMAGE
+--
+INSERT INTO llx_const (name, entity, value, type, visible) VALUES ('MAIN_USE_EXIF_ROTATION', 0, '1', 'string', 0);


### PR DESCRIPTION
NEW: default use MAIN_USE_EXIF_ROTATION on new install

fix: #19421 