### PR TITLE
FIX: holiday list: only mass delete if leave request is not in draft, canceled or refused, like in card

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1320,7 +1320,8 @@ if (!$error && ($massaction == 'delete' || ($action == 'delete' && $confirm == '
 	if (!$error)
 	{
 		if ($nbok > 1) setEventMessages($langs->trans("RecordsDeleted", $nbok), null, 'mesgs');
-		else setEventMessages($langs->trans("RecordDeleted", $nbok), null, 'mesgs');
+		elseif ($nbok > 0) setEventMessages($langs->trans("RecordDeleted", $nbok), null, 'mesgs');
+		else setEventMessages($langs->trans("NoRecordDeleted"), null, 'mesgs');
 		$db->commit();
 	}
 	else

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1280,6 +1280,12 @@ if (!$error && ($massaction == 'delete' || ($action == 'delete' && $confirm == '
 				continue;
 			}
 
+			if ($objectclass == 'Holiday' && ! in_array($objecttmp->statut, array(Holiday::STATUS_DRAFT, Holiday::STATUS_CANCELED, Holiday::STATUS_REFUSED))) {
+				$nbignored++;
+				setEventMessage($langs->trans('ErrorLeaveRequestMustBeDraftCanceledOrRefusedToBeDeleted', $objecttmp->ref));
+				continue;
+			}
+
 			if ($objectclass == "Task" && $objecttmp->hasChildren() > 0)
 			{
 				$sql = "UPDATE ".MAIN_DB_PREFIX."projet_task SET fk_task_parent = 0 WHERE fk_task_parent = ".$objecttmp->id;

--- a/htdocs/langs/en_US/holiday.lang
+++ b/htdocs/langs/en_US/holiday.lang
@@ -132,3 +132,4 @@ FreeLegalTextOnHolidays=Free text on PDF
 WatermarkOnDraftHolidayCards=Watermarks on draft leave requests
 HolidaysToApprove=Holidays to approve
 NobodyHasPermissionToValidateHolidays=Nobody has permission to validate holidays
+ErrorLeaveRequestMustBeDraftCanceledOrRefusedToBeDeleted=Leave request %s must be draft, canceled or refused to be deleted


### PR DESCRIPTION
And a bonus track : FIX: holiday mass deletion: correct return of record deleted