### PR TITLE
Fix bug within contact tabs of invoice

### DIFF
--- a/htdocs/compta/facture/contact.php
+++ b/htdocs/compta/facture/contact.php
@@ -52,7 +52,7 @@ if ($user->socid) {
 $object = new Facture($db);
 // Load object
 if ($id > 0 || !empty($ref)) {
-	$ret = $object->fetch($id, $ref, '', '', $conf->global->INVOICE_USE_SITUATION);
+		$object->fetch($id, $ref, '', '', $conf->global->INVOICE_USE_SITUATION);
 }
 
 $result = restrictedArea($user, 'facture', $object->id);


### PR DESCRIPTION
# Fix #19519

Contact tab in invoice can't work. we never get the invoice from database
object->id stay null so we always fall under the exit (and ErrorRecordNotFound).

This commit tries to fix this issue by fetching the object directly after the creation
of "Facture" object before those line :

```
if (empty($object->id)) {
        llxHeader();
        $langs->load('errors');
        echo '<div class="error">'.$langs->trans("ErrorRecordNotFound").'</div>';
        llxFooter();
        exit;
}

```
