### PR TITLE
FIX: separator extrafields display

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7096,18 +7096,17 @@ abstract class CommonObject
 					$langs->load($extrafields->attributes[$this->table_element]['langfile'][$key]);
 				}
 
-				$colspan = '';
+				$colspan = 1;
 				if (is_array($params) && count($params) > 0) {
-					if (array_key_exists('cols', $params)) {
-						$colspan = $params['cols'];
+					if (array_key_exists('cols', $params) && is_numeric($params['cols'])) {
+						$colspan = intval($params['cols']);
 					}
 					elseif (array_key_exists('colspan', $params)) {	// For backward compatibility. Use cols instead now.
 						$reg = array();
 						if (preg_match('/colspan="(\d+)"/', $params['colspan'], $reg)) {
-							$colspan = $reg[1];
-						}
-						else {
-							$colspan = $params['colspan'];
+							$colspan = intval($reg[1]);
+						} elseif (is_numeric($params['colspan'])) {
+							$colspan = intval($params['colspan']);
 						}
 					}
 				}
@@ -7151,7 +7150,7 @@ abstract class CommonObject
                         }
                     }
 
-					$out .= $extrafields->showSeparator($key, $this, ($colspan + 1));
+					$out .= $extrafields->showSeparator($key, $this, $colspan + 1);
 				}
 				else
 				{
@@ -7173,7 +7172,9 @@ abstract class CommonObject
 
 					$html_id = (empty($this->id) ? '' : 'extrarow-'.$this->element.'_'.$key.'_'.$this->id);
 
-					if (!empty($conf->global->MAIN_EXTRAFIELDS_USE_TWO_COLUMS) && ($e % 2) == 0) { $colspan = '0'; }
+					if (!empty($conf->global->MAIN_EXTRAFIELDS_USE_TWO_COLUMS) && ($e % 2) == 0) {
+						$colspan = 0;
+					}
 
 					if ($action == 'selectlines') { $colspan++; }
 

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1561,7 +1561,7 @@ else
 		}
 
 		// Other attributes
-		$parameters = array('socid'=>$socid, 'colspan' => ' colspan="3"', 'colspanvalue' => '3');
+		$parameters = array('socid'=>$socid, 'colspan' => ' colspan="3"', 'colspanvalue' => 3);
 		include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_add.tpl.php';
 
 		// Assign a sale representative
@@ -2206,7 +2206,7 @@ else
 			}
 
 			// Other attributes
-			$parameters = array('socid'=>$socid, 'colspan' => ' colspan="3"', 'colspanvalue' => '3');
+			$parameters = array('socid'=>$socid, 'colspan' => ' colspan="3"', 'colspanvalue' => 3);
 			include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_edit.tpl.php';
 
             // Webservices url/key

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -1245,7 +1245,6 @@ if ($action == 'create' || $action == 'adduserldap')
 	}
 
 	// Other attributes
-	$parameters = array('colspan' => ' colspan="3"');
 	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_add.tpl.php';
 
 	// Note


### PR DESCRIPTION
Wrong default colspan (should be 1 to cover both columns when incrementing at `showOptionals()` call) + bad colspan on user card.

I know this code has been modified on develop by #19124 , but it was only to remove a warning and not to fix the display problem.