### PR TITLE
FIX: contact card: bad colspan value for separator extrafield in creation/modification form

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -850,7 +850,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 			}
 
 			// Other attributes
-			$parameters = array('socid' => $socid, 'objsoc' => $objsoc, 'colspan' => ' colspan="3"', 'cols' => 3);
+			$parameters = array('socid' => $socid, 'objsoc' => $objsoc, 'colspan' => ' colspan="3"', 'cols' => 3, 'colspanvalue' => 3);
 			include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_add.tpl.php';
 
 			print "</table><br>";
@@ -1161,7 +1161,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 			}
 
 			// Other attributes
-			$parameters = array('colspan' => ' colspan="3"', 'cols'=> '3');
+			$parameters = array('colspan' => ' colspan="3"', 'cols'=> '3', 'colspanvalue'=> '3');
 			include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_edit.tpl.php';
 
 			$object->load_ref_elements();


### PR DESCRIPTION
This card used to use a direct call to `showOptionals()` before 14.0, but then switched to `/htdocs/core/tpl/extrafields_[add/edit].tpl.php`. But the correct way to pass a colspan to `showOptionals()` with those tpl files, which is to use `colspanvalue` index, was not modified.