### PR TITLE
FIX 13.0: printFieldListWhere called twice on same query

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -505,11 +505,6 @@ if ($includeproductswithoutdesiredqty == 'on') {
 	$includeproductswithoutdesiredqtychecked = 'checked';
 }
 
-// Add where from hooks
-$parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters); // Note that $action and $object may have been modified by hook
-$sql .= $hookmanager->resPrint;
-
 $nbtotalofrecords = '';
 if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST)) {
 	$result = $db->query($sql);


### PR DESCRIPTION
# Fix
On the replenish page from version 13.0 through develop, the hook `printFieldListWhere` is called twice ([here](https://github.com/Dolibarr/dolibarr/blob/develop/htdocs/product/stock/replenish.php#L401) and [here](https://github.com/Dolibarr/dolibarr/blob/develop/htdocs/product/stock/replenish.php#L535)).

Commit eeef78760a260e90dda94bfe9d6a5049b3189526 moved the hook call to a different location in the file, but I suppose the original call was put back (I couldn't trace the commit that did it, but I suppose it could have been caused by a bad merge).

This can cause problems when modules try to use this hook to alter the query.

## Warning
This fix might cause problems for some modules that use the second hook call (I have one example where the hook replaces the whole content of `$sql`: this will no longer be possible after this fix, but we are releasing a separate fix for our module - I still think this PR is pertinent).