### PR TITLE
FIX line extrafields title display error.

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6972,19 +6972,19 @@ abstract class CommonObject
 						if (!empty($conf->global->MAIN_VIEW_LINE_NUMBER) && $action == 'view') {
 							$out .= '<td></td>';
 						}
-						$out .= '<td class="wordbreak';
+						$out .= '<td';
 						//$out .= "titlefield";
 						//if (GETPOST('action', 'restricthtml') == 'create') $out.='create';
 						// BUG #11554 : For public page, use red dot for required fields, instead of bold label
 						$tpl_context = isset($params["tpl_context"]) ? $params["tpl_context"] : "none";
 						if ($tpl_context == "public") {	// Public page : red dot instead of fieldrequired characters
-							$out .= '">';
+							$out .= '>';
 							if (!empty($extrafields->attributes[$this->table_element]['help'][$key])) $out .= $form->textwithpicto($labeltoshow, $helptoshow);
 							else $out .= $labeltoshow;
 							if ($mode != 'view' && !empty($extrafields->attributes[$this->table_element]['required'][$key])) $out .= '&nbsp;<font color="red">*</font>';
 						} else {
-							if ($mode != 'view' && !empty($extrafields->attributes[$this->table_element]['required'][$key])) $out .= ' fieldrequired';
-							$out .= '">';
+							if ($mode != 'view' && !empty($extrafields->attributes[$this->table_element]['required'][$key])) $out .= '  class="fieldrequired"';
+							$out .= '>';
 							if (!empty($extrafields->attributes[$this->table_element]['help'][$key])) $out .= $form->textwithpicto($labeltoshow, $helptoshow);
 							else $out .= $labeltoshow;
 						}


### PR DESCRIPTION
I found out line extrafield title display error when browser resize small.

![Screen Shot 2021-12-13 at 2 44 15 PM](https://user-images.githubusercontent.com/29521447/145784489-40e0e0a5-178a-45e3-b567-f8ee9a974062.png)


After this commit.

![Screen Shot 2021-12-13 at 4 24 51 PM](https://user-images.githubusercontent.com/29521447/145785933-f6352100-b330-45fe-bfa7-fcd87ecc855a.png)



I think no need class "wordbreak" for line extrafield title.

Please review and comment.

Thank you.


