### PR TITLE
Fix : add  info for acces right  on compta/ bank / info

### DIFF
--- a/htdocs/compta/bank/info.php
+++ b/htdocs/compta/bank/info.php
@@ -34,10 +34,12 @@ $ref = GETPOST('ref', 'alpha');
 
 // Security check
 $fieldvalue = (!empty($id) ? $id : (!empty($ref) ? $ref : ''));
+
 $fieldtype = (!empty($ref) ? 'ref' : 'rowid');
 if ($user->socid) {
 	$socid = $user->socid;
 }
+
 $result = restrictedArea($user, 'banque', $fieldvalue, 'bank_account', '', '', $fieldtype);
 if (!$user->rights->banque->lire && !$user->rights->banque->consolidate) {
 	accessforbidden();

--- a/htdocs/compta/bank/line.php
+++ b/htdocs/compta/bank/line.php
@@ -51,7 +51,7 @@ if (!empty($conf->salaries->enabled)) {
 }
 
 
-$id = (GETPOST('id', 'int') ? GETPOST('id', 'int') : GETPOST('account', 'int'));
+$id = (GETPOST('rowid', 'int') ? GETPOST('rowid', 'int') : GETPOST('account', 'int'));
 $ref = GETPOST('ref', 'alpha');
 $action = GETPOST('action', 'aZ09');
 $confirm = GETPOST('confirm', 'alpha');
@@ -66,6 +66,7 @@ $fieldtype = (!empty($ref) ? 'ref' : 'rowid');
 if ($user->socid) {
 	$socid = $user->socid;
 }
+
 $result = restrictedArea($user, 'banque', $fieldvalue, 'bank_account', '', '', $fieldtype);
 if (!$user->rights->banque->lire && !$user->rights->banque->consolidate) {
 	accessforbidden();

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -227,6 +227,10 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 	if ($features == 'product') {
 		$features = 'produit';
 	}
+	if ($features == 'banque') {
+		$parentfortableentity = 'fk_account@bank_account';
+	}
+
 
 	// Get more permissions checks from hooks
 	$parameters = array('features'=>$features, 'originalfeatures'=>$originalfeatures, 'objectid'=>$objectid, 'dbt_select'=>$dbt_select, 'idtype'=>$dbt_select, 'isdraft'=>$isdraft);


### PR DESCRIPTION
# FIX
due to the new way on acces with fonction restrictedArea()
ex : _$result = restrictedArea($user, 'banque', $fieldvalue, 'bank_account', '', '', $fieldtype);_

Establish the link with the $parenttableforentity variable to manage access right


