### PR TITLE
FIX Holiday month report

### DIFF
--- a/htdocs/holiday/month_report.php
+++ b/htdocs/holiday/month_report.php
@@ -84,7 +84,12 @@ $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."user u ON cp.fk_user = u.rowid";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_holiday_types ct ON cp.fk_type = ct.rowid";
 $sql .= " WHERE cp.rowid > 0";
 $sql .= " AND cp.statut = 3"; // Approved
-$sql .= " AND (date_format(cp.date_debut, '%Y-%m') = '".$db->escape($year_month)."' OR date_format(cp.date_fin, '%Y-%m') = '".$db->escape($year_month)."')";
+$sql .= " AND (";
+$sql .= " (date_format(cp.date_debut, '%Y-%m') = '".$db->escape($year_month)."' OR date_format(cp.date_fin, '%Y-%m') = '".$db->escape($year_month)."')";
+$sql .= " OR";
+// For work leave over several months
+$sql .= " (date_format(cp.date_debut, '%Y-%m') < '".$db->escape($year_month)."' AND date_format(cp.date_fin, '%Y-%m') > '".$db->escape($year_month)."') ";
+$sql .= " )";
 $sql .= " ORDER BY u.lastname, cp.date_debut";
 
 $resql = $db->query($sql);


### PR DESCRIPTION
# FIX 

The sql query did not take into account work leave spread over several months.

Example: a leave from 27/12/2021 to 17/04/2022.

By filtering on the month of December 2021, the 5 days of leave corresponding to the month of December are displayed.
However, if we filter on the month of January 2022, the leave in question is not displayed. 
We have to filter on the month of April 2022 to see the leave appear. 