### PR TITLE
FIX : Adjust signature td width on user details page

### DIFF
--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -1431,7 +1431,7 @@ else
 		if ($action == 'create_thirdparty')
 		{
 			$companyalias = '';
-			$fullname = $object->lastname . ' ' . $object->firstname;
+			$fullname = $object->getFullName($langs);
 
 			if ($object->morphy == 'mor')
 			{

--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -1431,7 +1431,7 @@ else
 		if ($action == 'create_thirdparty')
 		{
 			$companyalias = '';
-			$fullname = $object->getFullName($langs);
+			$fullname = $object->lastname . ' ' . $object->firstname;
 
 			if ($object->morphy == 'mor')
 			{

--- a/htdocs/compta/facture/class/facturestats.class.php
+++ b/htdocs/compta/facture/class/facturestats.class.php
@@ -122,12 +122,13 @@ class FactureStats extends Stats
 	public function getNbByMonth($year, $format = 0)
 	{
 		global $user;
+        global $conf;
 
 		$sql = "SELECT date_format(f.datef,'%m') as dm, COUNT(*) as nb";
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
         $sql .= $this->join;
-		$sql .= " WHERE f.datef BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
+		$sql .= " WHERE f.datef BETWEEN '".$this->db->idate(dol_get_first_day($year, empty($conf->global->SOCIETE_FISCAL_MONTH_START) ? 1 : $conf->global->SOCIETE_FISCAL_MONTH_START))."' AND '".$this->db->idate(dol_get_last_day($year + 1, empty($conf->global->SOCIETE_FISCAL_MONTH_START) ? 12 : $conf->global->SOCIETE_FISCAL_MONTH_START -1))."'";
 		$sql .= " AND ".$this->where;
 		$sql .= " GROUP BY dm";
         $sql .= $this->db->order('dm', 'DESC');
@@ -146,8 +147,9 @@ class FactureStats extends Stats
 	public function getNbByYear()
 	{
 		global $user;
+		global $conf;
 
-		$sql = "SELECT date_format(f.datef,'%Y') as dm, COUNT(*), SUM(c.".$this->field.")";
+		$sql = "SELECT (CASE WHEN ( EXTRACT(month FROM f.datef ) >=  '" . $conf->global->SOCIETE_FISCAL_MONTH_START. "') THEN date_format(f.datef,'%Y') ELSE date_format(f.datef,'%Y') - 1 END ) as dm, COUNT(*), SUM(c.".$this->field.")";
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
         $sql .= $this->join;
@@ -169,12 +171,13 @@ class FactureStats extends Stats
 	public function getAmountByMonth($year, $format = 0)
 	{
 		global $user;
+		global $conf;
 
 		$sql = "SELECT date_format(datef,'%m') as dm, SUM(f.".$this->field.")";
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
         $sql .= $this->join;
-		$sql .= " WHERE f.datef BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
+		$sql .= " WHERE f.datef BETWEEN '".$this->db->idate(dol_get_first_day($year, empty($conf->global->SOCIETE_FISCAL_MONTH_START) ? 1 : $conf->global->SOCIETE_FISCAL_MONTH_START))."' AND '".$this->db->idate(dol_get_last_day($year + 1, empty($conf->global->SOCIETE_FISCAL_MONTH_START) ? 12 : $conf->global->SOCIETE_FISCAL_MONTH_START -1))."'";
 		$sql .= " AND ".$this->where;
         $sql .= " GROUP BY dm";
         $sql .= $this->db->order('dm', 'DESC');
@@ -193,12 +196,13 @@ class FactureStats extends Stats
 	public function getAverageByMonth($year)
 	{
 		global $user;
+        global $conf;
 
 		$sql = "SELECT date_format(datef,'%m') as dm, AVG(f.".$this->field.")";
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
         $sql .= $this->join;
-        $sql .= " WHERE f.datef BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
+        $sql .= " WHERE f.datef BETWEEN '".$this->db->idate(dol_get_first_day($year, empty($conf->global->SOCIETE_FISCAL_MONTH_START) ? 1 : $conf->global->SOCIETE_FISCAL_MONTH_START))."' AND '".$this->db->idate(dol_get_last_day($year + 1, empty($conf->global->SOCIETE_FISCAL_MONTH_START) ? 12 : $conf->global->SOCIETE_FISCAL_MONTH_START -1))."'";
 		$sql .= " AND ".$this->where;
         $sql .= " GROUP BY dm";
         $sql .= $this->db->order('dm', 'DESC');
@@ -214,8 +218,9 @@ class FactureStats extends Stats
 	public function getAllByYear()
 	{
 		global $user;
+		global $conf;
 
-		$sql = "SELECT date_format(datef,'%Y') as year, COUNT(*) as nb, SUM(f.".$this->field.") as total, AVG(f.".$this->field.") as avg";
+		$sql = "SELECT (CASE WHEN EXTRACT(month FROM f.datef ) >=  '" . $conf->global->SOCIETE_FISCAL_MONTH_START . "' THEN date_format(f.datef,'%Y') ELSE date_format(f.datef,'%Y') - 1 END ) as year, COUNT(*) as nb, SUM(f.".$this->field.") as total, AVG(f.".$this->field.") as avg";
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
         $sql .= $this->join;

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -1868,7 +1868,7 @@ else
 			}
 
 			// Signature
-			print '<tr><td class="tdtop">'.$langs->trans('Signature').'</td><td>';
+			print '<tr><td class="tdtop">'.$langs->trans('Signature').'</td><td class="wordbreak">';
 			print dol_htmlentitiesbr($object->signature);
 			print "</td></tr>\n";
 


### PR DESCRIPTION
FIX #4020 Fix signature td width on user details page

The fix was by adding class wordbreak to the signature value td in file /user/card.php in order to break the size of the TD and don't show the horizontal scrollbar.