### PR TITLE
FIX: discounts are applied twice for displaying best supplier price

### DIFF
--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -846,7 +846,7 @@ class ProductFournisseur extends Product
 						$this->fourn_qty                = $record["quantity"];
 						$this->fourn_remise_percent     = $record["remise_percent"];
 						$this->fourn_remise             = $record["remise"];
-						$this->fourn_unitprice          = $fourn_unitprice;
+						$this->fourn_unitprice          = !empty($conf->dynamicprices->enabled) ? $fourn_unitprice : $record["unitprice"];
 						$this->fourn_charges            = $record["charges"]; // deprecated
 						$this->fourn_tva_tx             = $record["tva_tx"];
 						$this->fourn_id                 = $record["fourn_id"];


### PR DESCRIPTION
## Context
Following [this forum thread](https://www.dolibarr.fr/forum/t/erreur-dans-le-calcul-du-meilleur-prix-dachat/), it appears that commit 2be2423dee0136679c95641f2db4a0fa9805dbaf introduced a bug by assigning to the unit price a variable for which the discount was already applied. Since Dolibarr applies the discount when displaying the price, it results in the discount being applies twice.

For instance, a supplier price of 100 with a discount of 50% will appear as "25" instead of "50".

I am not sure that my fix is the best because I don't know if the dynamic price parser also applier discounts or not, or whether it should do it at all, so maybe the fix should be different when using dynamic prices.