### PR TITLE
Fix bug project reset on supplier order when you select a supplier

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1649,8 +1649,9 @@ if ($action == 'create') {
 			$(document).ready(function() {
 				$("#socid").change(function() {
 					var socid = $(this).val();
+					var prjid = $("#projectid").val();
 					// reload page
-					window.location.href = "'.$_SERVER["PHP_SELF"].'?action=create&socid="+socid;
+					window.location.href = "'.$_SERVER["PHP_SELF"].'?action=create&socid="+socid+"&projectid="+prjid
 				});
 			});
 			</script>';


### PR DESCRIPTION
With the option RELOAD_PAGE_ON_SUPPLIER_CHANGE is enable
When you create a supplier order from a project, the card select the project but when you select a supplier this will remove the project selection


This modification will add the projectid in the url when the reload called