### PR TITLE
Fix #19672 : email unicity was checked when email was null

### DIFF
--- a/htdocs/recruitment/recruitmentcandidature_card.php
+++ b/htdocs/recruitment/recruitmentcandidature_card.php
@@ -260,6 +260,8 @@ if (empty($reshook)) {
 			$nuser->employee = 1;
 			$nuser->firstname = $object->firstname;
 			$nuser->lastname = $object->lastname;
+			$nuser->email = '';
+			$nuser->personal_email = $object->email;
 			$nuser->personal_mobile = $object->phone;
 			$nuser->birth = $object->date_birth;
 			$nuser->salary = $object->remuneration_proposed;


### PR DESCRIPTION
Email was null for user creation from a recruitment application. And user class checks email unicity if !== ''
I also added the missing personal email field