### PR TITLE
FIx : addline() $type default value is misleading

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -3147,7 +3147,7 @@ class Facture extends CommonInvoice
 		$fk_remise_except = '',
 		$price_base_type = 'HT',
 		$pu_ttc = 0,
-		$type = Product::TYPE_PRODUCT,
+		$type = 0,
 		$rang = -1,
 		$special_code = 0,
 		$origin = '',

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -3147,7 +3147,7 @@ class Facture extends CommonInvoice
 		$fk_remise_except = '',
 		$price_base_type = 'HT',
 		$pu_ttc = 0,
-		$type = self::TYPE_STANDARD,
+		$type = Product::TYPE_PRODUCT,
 		$rang = -1,
 		$special_code = 0,
 		$origin = '',


### PR DESCRIPTION
It should refer to a Product type, not an Invoice type.