### PR TITLE
Adds possibility to add senders name to $formmail->fromname

### DIFF
--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -124,22 +124,22 @@ if ($action == 'presend') {
 
 	if ($object->element === 'facture' && !empty($conf->global->INVOICE_EMAIL_SENDER)) {
 		$formmail->frommail = $conf->global->INVOICE_EMAIL_SENDER;
-		$formmail->fromname = '';
+		(!empty($conf->global->INVOICE_EMAIL_SENDER_NAME) ? $formmail->fromname = $conf->global->INVOICE_EMAIL_SENDER_NAME : $formmail->fromname = '');
 		$formmail->fromtype = 'special';
 	}
 	if ($object->element === 'shipping' && !empty($conf->global->SHIPPING_EMAIL_SENDER)) {
 		$formmail->frommail = $conf->global->SHIPPING_EMAIL_SENDER;
-		$formmail->fromname = '';
+		(!empty($conf->global->SHIPPING_EMAIL_SENDER_NAME) ? $formmail->fromname = $conf->global->SHIPPING_EMAIL_SENDER_NAME : $formmail->fromname = '');
 		$formmail->fromtype = 'special';
 	}
 	if ($object->element === 'commande' && !empty($conf->global->COMMANDE_EMAIL_SENDER)) {
 		$formmail->frommail = $conf->global->COMMANDE_EMAIL_SENDER;
-		$formmail->fromname = '';
+		(!empty($conf->global->COMMANDE_EMAIL_SENDER_NAME) ? $formmail->fromname = $conf->global->COMMANDE_EMAIL_SENDER_NAME : $formmail->fromname = '');
 		$formmail->fromtype = 'special';
 	}
 	if ($object->element === 'order_supplier' && !empty($conf->global->ORDER_SUPPLIER_EMAIL_SENDER)) {
 		$formmail->frommail = $conf->global->ORDER_SUPPLIER_EMAIL_SENDER;
-		$formmail->fromname = '';
+		(!empty($conf->global->ORDER_SUPPLIER_EMAIL_SENDER_NAME) ? $formmail->fromname = $conf->global->ORDER_SUPPLIER_EMAIL_SENDER_NAME : $formmail->fromname = '');
 		$formmail->fromtype = 'special';
 	}
 

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -124,26 +124,24 @@ if ($action == 'presend') {
 
 	if ($object->element === 'facture' && !empty($conf->global->INVOICE_EMAIL_SENDER)) {
 		$formmail->frommail = $conf->global->INVOICE_EMAIL_SENDER;
-		(!empty($conf->global->INVOICE_EMAIL_SENDER_NAME) ? $formmail->fromname = $conf->global->INVOICE_EMAIL_SENDER_NAME : $formmail->fromname = '');
+		$formmail->fromname = (!empty($conf->global->INVOICE_EMAIL_SENDER_NAME) ? $conf->global->INVOICE_EMAIL_SENDER_NAME : '');
 		$formmail->fromtype = 'special';
 	}
 	if ($object->element === 'shipping' && !empty($conf->global->SHIPPING_EMAIL_SENDER)) {
 		$formmail->frommail = $conf->global->SHIPPING_EMAIL_SENDER;
-		(!empty($conf->global->SHIPPING_EMAIL_SENDER_NAME) ? $formmail->fromname = $conf->global->SHIPPING_EMAIL_SENDER_NAME : $formmail->fromname = '');
+		$formmail->fromname = (!empty($conf->global->SHIPPING_EMAIL_SENDER_NAME) ? $conf->global->SHIPPING_EMAIL_SENDER_NAME : '');
 		$formmail->fromtype = 'special';
 	}
 	if ($object->element === 'commande' && !empty($conf->global->COMMANDE_EMAIL_SENDER)) {
 		$formmail->frommail = $conf->global->COMMANDE_EMAIL_SENDER;
-		(!empty($conf->global->COMMANDE_EMAIL_SENDER_NAME) ? $formmail->fromname = $conf->global->COMMANDE_EMAIL_SENDER_NAME : $formmail->fromname = '');
+		$formmail->fromname = (!empty($conf->global->COMMANDE_EMAIL_SENDER_NAME) ? $conf->global->COMMANDE_EMAIL_SENDER_NAME : '');
 		$formmail->fromtype = 'special';
 	}
 	if ($object->element === 'order_supplier' && !empty($conf->global->ORDER_SUPPLIER_EMAIL_SENDER)) {
 		$formmail->frommail = $conf->global->ORDER_SUPPLIER_EMAIL_SENDER;
-		(!empty($conf->global->ORDER_SUPPLIER_EMAIL_SENDER_NAME) ? $formmail->fromname = $conf->global->ORDER_SUPPLIER_EMAIL_SENDER_NAME : $formmail->fromname = '');
+		$formmail->fromname = (!empty($conf->global->ORDER_SUPPLIER_EMAIL_SENDER_NAME) ? $conf->global->ORDER_SUPPLIER_EMAIL_SENDER_NAME : '');
 		$formmail->fromtype = 'special';
 	}
-
-
 
 	$formmail->trackid = $trackid;
 	$formmail->withfrom = 1;


### PR DESCRIPTION
If INVOICE_EMAIL_SENDER_NAME, SHIPPING_EMAIL_SENDER_NAME, COMMANDE_EMAIL_SENDER_NAME or ORDER_SUPPLIER_EMAIL_SENDER_NAME is beeing set, use it as sender name. If not, keep $formmail->fromname blank