### PR TITLE
FIX - 19725 - Authentification LDAP échoue avec erreur 500

### DIFF
--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -301,7 +301,8 @@ class Ldap
 	 */
 	public function close()
 	{
-		if ($this->connection && !@ldap_close($this->connection)) {
+		$r_type = get_resource_type($this->connection);
+		if ($this->connection && ($r_type == "Unknown" || !@ldap_close($this->connection))) {
 			return false;
 		} else {
 			return true;

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -302,7 +302,7 @@ class Ldap
 	public function close()
 	{
 		$r_type = get_resource_type($this->connection);
-		if ($this->connection && ($r_type == "Unknown" || !@ldap_close($this->connection))) {
+		if ($this->connection && ($r_type === "Unknown" || !@ldap_close($this->connection))) {
 			return false;
 		} else {
 			return true;


### PR DESCRIPTION
Correction pour sortir de la fonction d'authentification quand il y a deux appels succincts à la fermeture de la liaison.