### PR TITLE
FIX : late warning calculation on action comm list

### DIFF
--- a/htdocs/comm/action/list.php
+++ b/htdocs/comm/action/list.php
@@ -657,6 +657,8 @@ if ($resql)
 		$actionstatic->label = $obj->label;
 		$actionstatic->location = $obj->location;
 		$actionstatic->note_private = dol_htmlentitiesbr($obj->note);
+		$actionstatic->datep = $db->jdate($obj->dp);
+		$actionstatic->percentage = $obj->percent;
 
 		$actionstatic->fetchResources();
 
@@ -738,10 +740,7 @@ if ($resql)
 			print '<td class="center nowraponall">';
 			print dol_print_date($db->jdate($obj->dp), $formatToUse, 'tzuser');
 			$late = 0;
-			if ($obj->percent == 0 && $obj->dp && $db->jdate($obj->dp) < ($now - $delay_warning)) $late = 1;
-			if ($obj->percent == 0 && !$obj->dp && $obj->dp2 && $db->jdate($obj->dp) < ($now - $delay_warning)) $late = 1;
-			if ($obj->percent > 0 && $obj->percent < 100 && $obj->dp2 && $db->jdate($obj->dp2) < ($now - $delay_warning)) $late = 1;
-			if ($obj->percent > 0 && $obj->percent < 100 && !$obj->dp2 && $obj->dp && $db->jdate($obj->dp) < ($now - $delay_warning)) $late = 1;
+			if($actioncomm->hasDelay() && $actioncomm->percentage >= 0 && $actioncomm->percentage < 100 ) $late = 1;
 			if ($late) print img_warning($langs->trans("Late")).' ';
 			print '</td>';
 		}

--- a/htdocs/comm/action/list.php
+++ b/htdocs/comm/action/list.php
@@ -740,7 +740,7 @@ if ($resql)
 			print '<td class="center nowraponall">';
 			print dol_print_date($db->jdate($obj->dp), $formatToUse, 'tzuser');
 			$late = 0;
-			if($actioncomm->hasDelay() && $actioncomm->percentage >= 0 && $actioncomm->percentage < 100 ) $late = 1;
+			if ($actioncomm->hasDelay() && $actioncomm->percentage >= 0 && $actioncomm->percentage < 100 ) $late = 1;
 			if ($late) print img_warning($langs->trans("Late")).' ';
 			print '</td>';
 		}


### PR DESCRIPTION
# FIX|Fix #
Late events number in event boxe and in event list are not same.

The number in boxe seems closer to the reality : it is an past event (minus $conf->agenda->warning_delay) with a percent >= 0 and < 100. 

I apply this condition for event list.