### PR TITLE
14.0 FIX #18716 , #18606 , #18589 , #18617 permissions problem trying to open a file attached to a task

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -2660,7 +2660,7 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 				include_once DOL_DOCUMENT_ROOT.'/projet/class/task.class.php';
 				$tmptask = new Task($db);
 				$tmptask->fetch('', $refname);
-				$accessallowed = checkUserAccessToObject($user, array('projet_task'), $tmptask->id, 'projet&project', '', '', 'rowid', '');
+				$accessallowed = checkUserAccessToObject($user, array('projet_task'), $tmptask->id, 'projet_task&project_task', '', '', 'rowid', '');
 			}
 		}
 		$original_file = $conf->projet->dir_output.'/'.$original_file;

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -49,33 +49,45 @@ $script_file = basename(__FILE__);
 $path = __DIR__.'/';
 
 // Error if Web mode
-if (substr($sapi_type, 0, 3) == 'cgi') {
-	echo "Error: You are using PHP for CGI. To execute ".$script_file." from command line, you must use PHP for CLI mode.\n";
-	exit(-1);
+if (substr($sapi_type, 0, 3) == 'cgi') { 
+	echo "Warning: You are using PHP for CGI. To execute ".$script_file." from command line, you must use PHP for CLI mode.\n";
+	echo "PATH=".$path." \n";
+//	exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
 }
 
-require_once $path."../../htdocs/master.inc.php";
+//require_once $path."../../htdocs/master.inc.php"; EDU deleted "/htdocs" part in the path of master.inc.php
+require_once $path."../../master.inc.php";
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 
-// Check parameters
-if (!isset($argv[1]) || !$argv[1]) {
-	usage($path, $script_file);
-	exit(-1);
-}
+// Check parameters, EDU: if WEBmode instead the expected CLImode setup the security key and user login name from config instead args of command line
 $key = $argv[1];
-
-if (!isset($argv[2]) || !$argv[2]) {
-	usage($path, $script_file);
-	exit(-1);
+if (!isset($argv[1]) || !$argv[1]) {
+	if (substr($sapi_type, 0, 3) == 'cgi') {
+	    $key = $conf->global->CRON_KEY;
+	    echo "Scheduled job management setup securitykey=".$key;
+	}
+	else {
+	    usage($path, $script_file);
+	    exit(-1);
+	}
 }
 
 $userlogin = $argv[2];
+if (!isset($argv[2]) || !$argv[2]) {
+	if (substr($sapi_type, 0, 3) == 'cgi') {
+	    $userlogin = "firstadmin"; /* Reserver word 'firstadmin' to search in DB the fist user loginname with admin rights */
+	}
+    else {
+        echo "ARGV2 USAGE ERROR ".$userlogin." \n";
+        usage($path, $script_file);
+        exit(-1);
+    }
+}
 
 // Global variables
 $version = DOL_VERSION;
 $error = 0;
-
 
 /*
  * Main
@@ -286,6 +298,7 @@ if (is_array($qualifiedjobs) && (count($qualifiedjobs) > 0)) {
 }
 
 $db->close();
+echo "\n\n";
 
 if ($nbofjobslaunchedko) {
 	exit(1);

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -55,8 +55,9 @@ if (substr($sapi_type, 0, 3) == 'cgi') {
 	//  exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
 }
 
-//require_once $path."../../htdocs/master.inc.php"; EDU deleted "/htdocs" part in the path of master.inc.php
-require_once $path."../../master.inc.php";
+//The $path of master.inc.php is different if the Dolibarr instance was updated  from older versions or using tools like Cpanel or automatic installer tools.   
+if  file_exists($path."../../htdocs/master.inc.php") {require_once $path."../../htdocs/master.inc.php";}
+if  file_exists($path."../../master.inc.php") {require_once $path."../../master.inc.php";}
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -56,8 +56,8 @@ if (substr($sapi_type, 0, 3) == 'cgi') {
 }
 
 //The $path of master.inc.php is different if the Dolibarr instance was updated  from older versions or using tools like Cpanel or automatic installer tools.
-if file_exists($path."../../htdocs/master.inc.php") {require_once $path."../../htdocs/master.inc.php";}
-if file_exists($path."../../master.inc.php") {require_once $path."../../master.inc.php";}
+if (file_exists($path."../../htdocs/master.inc.php")) {require_once $path."../../htdocs/master.inc.php";}
+if (file_exists($path."../../master.inc.php")) {require_once $path."../../master.inc.php";}
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -49,10 +49,10 @@ $script_file = basename(__FILE__);
 $path = __DIR__.'/';
 
 // Error if Web mode
-if (substr($sapi_type, 0, 3) == 'cgi') { 
+if (substr($sapi_type, 0, 3) == 'cgi') {
 	echo "Warning: You are using PHP for CGI. To execute ".$script_file." from command line, you must use PHP for CLI mode.\n";
 	echo "PATH=".$path." \n";
-//	exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
+	//  exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
 }
 
 //require_once $path."../../htdocs/master.inc.php"; EDU deleted "/htdocs" part in the path of master.inc.php
@@ -64,25 +64,23 @@ require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 $key = $argv[1];
 if (!isset($argv[1]) || !$argv[1]) {
 	if (substr($sapi_type, 0, 3) == 'cgi') {
-	    $key = $conf->global->CRON_KEY;
-	    echo "Scheduled job management setup securitykey=".$key;
-	}
-	else {
-	    usage($path, $script_file);
-	    exit(-1);
+		$key = $conf->global->CRON_KEY;
+		echo "Scheduled job management setup securitykey=".$key;
+	} else {
+		usage($path, $script_file);
+		exit(-1);
 	}
 }
 
 $userlogin = $argv[2];
 if (!isset($argv[2]) || !$argv[2]) {
 	if (substr($sapi_type, 0, 3) == 'cgi') {
-	    $userlogin = "firstadmin"; /* Reserver word 'firstadmin' to search in DB the fist user loginname with admin rights */
+		$userlogin = "firstadmin"; /* Reserver word 'firstadmin' to search in DB the fist user loginname with admin rights */
+	} else {
+		echo "ARGV2 USAGE ERROR ".$userlogin." \n";
+		usage($path, $script_file);
+		exit(-1);
 	}
-    else {
-        echo "ARGV2 USAGE ERROR ".$userlogin." \n";
-        usage($path, $script_file);
-        exit(-1);
-    }
 }
 
 // Global variables

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -55,9 +55,9 @@ if (substr($sapi_type, 0, 3) == 'cgi') {
 	//  exit(-1); /* EDU: Even in web mode, accept the request instead exit, and setup the security key and user login name from config instead args of command line */
 }
 
-//The $path of master.inc.php is different if the Dolibarr instance was updated  from older versions or using tools like Cpanel or automatic installer tools.   
-if  file_exists($path."../../htdocs/master.inc.php") {require_once $path."../../htdocs/master.inc.php";}
-if  file_exists($path."../../master.inc.php") {require_once $path."../../master.inc.php";}
+//The $path of master.inc.php is different if the Dolibarr instance was updated  from older versions or using tools like Cpanel or automatic installer tools.
+if file_exists($path."../../htdocs/master.inc.php") {require_once $path."../../htdocs/master.inc.php";}
+if file_exists($path."../../master.inc.php") {require_once $path."../../master.inc.php";}
 require_once DOL_DOCUMENT_ROOT."/cron/class/cronjob.class.php";
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 


### PR DESCRIPTION
The permissions problem trying to open a file attached to a task is mentioned in multiple Issues. With this small update described below, can be fixed and closed #18716 , #18606 , #18589 , #18617, #19770

Replace **projet&project** by **projet_task&project_task** in the line number 2665 of the file  /htdocs/dolibarr/htdocs/core/lib/files.lib.php in version 14.0.5
This small update fix the problem.