### PR TITLE
FIX 12.0: run_sql() removes significant whitespace when concatenating lines of SQL, sometimes resulting in invalid syntax

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -216,6 +216,8 @@ if (empty($reshook))
 		$result = $object->deleteline($user, $lineid);
 		if ($result > 0)
 		{
+			// reorder lines
+			$object->line_order(true);
 			// Define output language
 			$outputlangs = $langs;
 			$newlang = '';

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -243,6 +243,8 @@ if (empty($reshook))
 
 		$result = $object->deleteline(GETPOST('lineid'));
 		if ($result > 0) {
+			// reorder lines
+			$object->line_order(true);
 			// Define output language
 			$outputlangs = $langs;
 			$newlang = '';

--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -209,6 +209,7 @@ function run_sql($sqlfile, $silent = 1, $entity = '', $usesavepoint = 1, $handle
             if ($nocommentremoval || !preg_match('/^\s*--/', $buf))
             {
             	if (empty($nocommentremoval)) $buf = preg_replace('/([,;ERLT\)])\s*--.*$/i', '\1', $buf); //remove comment from a line that not start with -- before add it to the buffer
+                if ($buffer) $buffer .= ' ';
                 $buffer .= trim($buf);
             }
 

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -805,6 +805,8 @@ if (empty($reshook))
 		$result = $object->deleteline($lineid);
 		if ($result > 0)
 		{
+			// reorder lines
+			$object->line_order(true);
 			// Define output language
 			$outputlangs = $langs;
 			$newlang = '';

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -253,6 +253,8 @@ if (empty($reshook))
 		$result = $object->deleteline($lineid);
 		if ($result > 0)
 		{
+			// reorder lines
+			$object->line_order(true);
 			// Define output language
 			/*$outputlangs = $langs;
 			$newlang = '';


### PR DESCRIPTION
# Issue
When concatenating a multi-line query, `run_sql()` trims whitespace from each line before concatenating. Most of the time it doesn't cause any problem because, fortunately, typical queries are formatted in such a way that this will only remove non-significant whitespace, for instance:
```sql
CREATE TABLE llx_test (
   rowid int(11) AUTO_INCREMENT PRIMARY KEY,
   fk_thingy int(11) NOT NULL
) ENGINE = InnoDB;
```
Will be run by Dolibarr as:
```sql
CREATE TABLE llx_test (rowid int(11) AUTO_INCREMENT PRIMARY KEY,fk_thingy int(11) NOT NULL) ENGINE = InnoDB;
```
But if you choose to format it differently (while keeping the initial SQL perfectly valid), the SQL Dolibarr will run is going to be invalid:
```sql
CREATE TABLE llx_test (
   rowid
         int(11) AUTO_INCREMENT PRIMARY KEY,
   fk_thingy
         int(11) NOT NULL
) ENGINE = InnoDB;
```

Will be run by Dolibarr as:
```sql
CREATE TABLE llx_test (rowidint(11) AUTO_INCREMENT PRIMARY KEY,fk_thingyint(11) NOT NULL) ENGINE = InnoDB;
```
which is not valid syntax (`rowidint` / `fk_thingyint`), resulting in a failure.

It is especially problematic when creating a view because it is hard to format a "CREATE VIEW" query in a way that is both readable and that doesn't involve separating two words with a newline character.

Example:

```sql
CREATE VIEW llx_v_ticket_count AS
    SELECT u.rowid AS fk_user, count(*) AS ticket_count, t.entity
    FROM llx_ticket AS t
    INNER JOIN llx_user u ON t.fk_user_assign = u.rowid
    GROUP BY u.rowid, t.entity;
```

Will be run as the following invalid statement:
```sql
CREATE VIEW llx_v_ticket_count ASSELECT u.rowid AS fk_user, count(*) AS ticket_count, t.entityFROM llx_ticket AS tINNER JOIN llx_user u ON t.fk_user_assign = u.rowidGROUP BY u.rowid, t.entity;
```

# This fix
The fix just adds one space between lines when concatenating them.

To test it, I created a new (blank) installation of Dolibarr to let it create all the tables, which involves running many SQL files. It didn't fail, so I think this modification is safe.
