### PR TITLE
NEW pre-filled extra fields with slected credit note

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3415,6 +3415,10 @@ if ($action == 'create') {
 					$optionsav .= '<option value="'.$key.'"';
 					if ($key == GETPOST('fac_avoir')) {
 						$optionsav .= ' selected';
+
+						// pre-filled extra fields with selected credit note
+						$newinvoice_static->fetch_optionals($key);
+						$object->array_options = $newinvoice_static->array_options;
 					}
 					$optionsav .= '>';
 					$optionsav .= $newinvoice_static->ref;


### PR DESCRIPTION
NEW pre-filled extra fields with slected credit note

- when you create a credit note from an invoice, extra fields are automatically pre-filled with the extra fields of the selected credit note