### PR TITLE
FIX: order to shipment: debug hidden conf SHIPMENT_GETS_ALL_ORDER_PRODUCTS

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1245,13 +1245,17 @@ if ($action == 'create')
 						{
 							// Quantity to send
 							print '<td class="center">';
-							if ($line->product_type == Product::TYPE_PRODUCT || !empty($conf->global->STOCK_SUPPORTS_SERVICES))
-							{
-	                            if (GETPOST('qtyl'.$indiceAsked, 'int')) $deliverableQty = GETPOST('qtyl'.$indiceAsked, 'int');
-	                            print '<input name="idl'.$indiceAsked.'" type="hidden" value="'.$line->id.'">';
+							print '<input name="idl'.$indiceAsked.'" type="hidden" value="'.$line->id.'">';
+							if ($line->product_type == Product::TYPE_PRODUCT || !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
+								if (GETPOST('qtyl'.$indiceAsked, 'int')) $deliverableQty = GETPOST('qtyl'.$indiceAsked, 'int');
 								print '<input name="qtyl'.$indiceAsked.'" id="qtyl'.$indiceAsked.'" type="text" size="4" value="'.$deliverableQty.'">';
+							} else {
+								if (! empty($conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS)) {
+									print '<input name="qtyl'.$indiceAsked.'" id="qtyl'.$indiceAsked.'" type="hidden" value="0">';
+								}
+
+								print $langs->trans("NA");
 							}
-							else print $langs->trans("NA");
 							print '</td>';
 
 							// Stock
@@ -1420,8 +1424,13 @@ if ($action == 'create')
 									{
 										print '<input name="qtyl'.$indiceAsked.'_'.$subj.'" id="qtyl'.$indiceAsked.'" type="text" size="4" value="'.$deliverableQty.'">';
 										print '<input name="ent1'.$indiceAsked.'_'.$subj.'" type="hidden" value="'.$warehouse_id.'">';
+									} else {
+										if (! empty($conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS)) {
+											print '<input name="qtyl'.$indiceAsked.'_'.$subj.'" id="qtyl'.$indiceAsked.'" type="hidden" value="0">';
+										}
+
+										print $langs->trans("NA");
 									}
-									else print $langs->trans("NA");
 									print '</td>';
 
 									// Stock


### PR DESCRIPTION
This conf requires some hidden parameters that are not passed with hidden `<input>`s.

This still doesn't work when  no warehouse is preselected in `/htdocs/expedition/shipment.php`, but it would likely require heavier  changes.

