### PR TITLE
FIX Solving non-blocking bug in user login

### DIFF
--- a/htdocs/core/login/functions_dolibarr.php
+++ b/htdocs/core/login/functions_dolibarr.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2007-2015 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2007-2015 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2010-2011 Juanjo Menent		<jmenent@2byte.es>
+ * Copyright (C) 2022      Harry Winner Kamdem  <harry@sense.africa>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -104,7 +105,7 @@ function check_user_password_dolibarr($usertotest, $passwordtotest, $entitytotes
 				}
 				// Check crypted password according to crypt algorithm
 				if ($cryptType == 'auto') {
-					if (dol_verifyHash($passtyped, $passcrypted, '0')) {
+					if ($passcrypted && dol_verifyHash($passtyped, $passcrypted, '0')) {
 						$passok = true;
 						dol_syslog("functions_dolibarr::check_user_password_dolibarr Authentification ok - hash ".$cryptType." of pass is ok");
 					}


### PR DESCRIPTION
When using the function **check_user_password_dolibarr** to authenticate a user, a call is made to the function **dol_verifyHash** which requires a pre-calculated hash. This hash is not available with programmatically-created never-used accounts. Hence, in suce cases we receive the following warning:
_Notice: Trying to access array offset on value of type null in .../htdocs/core/lib/security.lib.php on line 156_
This fix solves that bug by avoiding that unnecessary call

PS: This is my first PR ever, to project I use a lot. Starting small. Thanks for your time building this.