### PR TITLE
FIX: Don't blindly unset api object notes

### DIFF
--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -133,7 +133,6 @@ class DolibarrApi
 
 		unset($object->mode_reglement);		// We use mode_reglement_id now
 		unset($object->cond_reglement);		// We use cond_reglement_id now
-		unset($object->note);				// We use note_public or note_private now
 		unset($object->contact);			// We use contact_id now
 		unset($object->thirdparty);			// We use thirdparty_id or fk_soc or socid now
 


### PR DESCRIPTION
# FIX|Fix #19833

`DolibarrApi` class is extended by 32 classes.

17 of them already unset their object notes in their extended `_cleanObjectDatas` methods. These are:

- AgendaEvents
- Boms
- Categories
- Contacts
- Donations
- ExpenseReports
- Invoices
- Mos
- Orders
- Products
- Projects
- Proposals
- Shipments
- StockMovements
- Tasks
- Thirdparties
- Tickets

Take, for instance `AgendaEvents`:  https://github.com/Dolibarr/dolibarr/blob/1ae01ba2fcb9adeb762b812a70cb62c0421560e5/htdocs/comm/action/class/api_agendaevents.class.php#L359

For various reasons, 3 of them are irrelevants:

- Documents
- MyModuleApi
- Setup

2 of them has no `note` fields at all:

- Warehouses
- ZapierApi

1 one them has only a `note_public` field:

- BankAccounts

6 of them have both `note_public` and `note_private` fields:

- Contracts
- Interventions
- Members
- SupplierInvoices
- SupplierOrders
- Supplierproposals

1 of them have both `note` and `note_public` fields:

- Users

2 of them have *only* a `note` field:

- MembersTypes
- Subscriptions

By blindly unset object notes in parent method, the last two classes (`MembersTypes` and `Subscriptions`) lost their absolutely relevant `note` field when exposed via api.
This unsetting should happen on the children level, aka. extended `_cleanObjectDatas` method.

In facts, that's already happen in the first 17 classes group :)
In the other class groups, only `Users` *SHOULD*  *MAYBE*  (up to you) unset it, so that `MembersTypes` and `Subscriptions` could keep their `note` field.


