### PR TITLE
FIX :  lang load in validate class and fix test for numeric values

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7595,7 +7595,7 @@ abstract class CommonObject
 			} else { return true; }
 		} elseif (in_array($type, array('double', 'real', 'price'))) {
 			// is numeric
-			if (!$validate->isDuration($fieldValue)) {
+			if (!$validate->isNumeric($fieldValue)) {
 				$this->setFieldError($fieldKey, $validate->error);
 				return false;
 			} else { return true; }

--- a/htdocs/core/class/validate.class.php
+++ b/htdocs/core/class/validate.class.php
@@ -55,18 +55,17 @@ class Validate
 	{
 		global $langs;
 
-		if ($outputLang) {
+		if (empty($outputLang)) {
 			$this->outputLang = $langs;
 		} else {
 			$this->outputLang = $outputLang;
 		}
 
-		if (!is_object($this->outputLang) || !method_exists($outputLang, 'load')) {
+		if (!is_object($this->outputLang) || !method_exists($this->outputLang, 'load')) {
 			return false;
 		}
 
-		/** @var Translate $outputLang */
-		$outputLang->load('validate');
+		$this->outputLang->loadLangs(array('validate', 'errors'));
 
 		$this->db = $db;
 	}
@@ -224,6 +223,21 @@ class Validate
 	{
 		if (!is_int($duration) && $duration >= 0) {
 			$this->error = $this->outputLang->trans('RequireValidDuration');
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Check Duration validity
+	 *
+	 * @param mixed $string to validate
+	 * @return boolean Validity is ok or not
+	 */
+	public function isNumeric($string)
+	{
+		if (!is_numeric($string)) {
+			$this->error = $this->outputLang->trans('RequireValidNumeric');
 			return false;
 		}
 		return true;

--- a/htdocs/core/class/validate.class.php
+++ b/htdocs/core/class/validate.class.php
@@ -229,7 +229,7 @@ class Validate
 	}
 
 	/**
-	 * Check Duration validity
+	 * Check numeric validity
 	 *
 	 * @param mixed $string to validate
 	 * @return boolean Validity is ok or not

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -315,6 +315,7 @@ RequireAtLeastXString = Requires at least %s character(s)
 RequireXStringMax = Requires %s character(s) max
 RequireAtLeastXDigits = Requires at least %s digit(s)
 RequireXDigitsMax = Requires %s digit(s) max
+RequireValidNumeric = Requires a numeric value
 RequireValidEmail = Email address is not valid
 RequireMaxLength = Length must be less than %s chars
 RequireMinLength = Length must be more than %s char(s)


### PR DESCRIPTION
- Fix lang load in validate class constructor
- Fix wrong usage of method isDuration instead of isNumeric (not the same test to perform)