### PR TITLE
FIX replace print error with event message when error on update line …

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -792,8 +792,7 @@ if (empty($reshook))
 		{
 			$db->rollback();
 
-			dol_print_error($db, $object->error);
-			exit;
+			setEventMessages($object->error, $object->errors, 'errors');
 		}
 	}
 


### PR DESCRIPTION
FIX replace print error with event message when error on update line in supplier order
- when you have an error on trigger for example you return -1 and you got an error page without messages