### PR TITLE
Create new line when add ordered product in TakePOS

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -537,6 +537,7 @@ if ($action == "addline") {
 	if (!empty($conf->global->TAKEPOS_GROUP_SAME_PRODUCT)) {
 		foreach ($invoice->lines as $line) {
 			if ($line->product_ref == $prod->ref) {
+				if ($line->special_code==4) continue; // If this line is sended to printer create new line
 				$result = $invoice->updateline($line->id, $line->desc, $line->subprice, $line->qty + 1, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit);
 				if ($result < 0) {
 					dol_htmloutput_errors($invoice->error, $invoice->errors, 1);


### PR DESCRIPTION
When TAKEPOS_GROUP_SAME_PRODUCT is enabled in TakePOS and you add product, avoid group it if product is ordered
