### PR TITLE
FIX : right expensereport for admin

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -236,7 +236,8 @@ if (empty($reshook)) {
 		}
 		if (!$error) {
 			if (empty($conf->global->MAIN_USE_ADVANCED_PERMS) || empty($user->rights->expensereport->writeall_advance)) {
-				if (!in_array($object->fk_user_author, $childids)) {
+				if (!in_array($object->fk_user_author, $childids)
+					&& !(!empty($user->rights->expensereport->readall) && !empty($user->rights->expensereport->approve) && !empty($user->admin))) {
 					$error++;
 					setEventMessages($langs->trans("UserNotInHierachy"), null, 'errors');
 				}
@@ -1364,7 +1365,8 @@ if ($action == 'create') {
 		$defaultselectuser = GETPOST('fk_user_author', 'int');
 	}
 	$include_users = 'hierarchyme';
-	if (!empty($conf->global->MAIN_USE_ADVANCED_PERMS) && !empty($user->rights->expensereport->writeall_advance)) {
+	if ((!empty($conf->global->MAIN_USE_ADVANCED_PERMS) && !empty($user->rights->expensereport->writeall_advance))
+	|| (!empty($user->rights->expensereport->readall) && !empty($user->rights->expensereport->approve) && !empty($user->admin))) {
 		$include_users = array();
 	}
 	$s = $form->select_dolusers($defaultselectuser, "fk_user_author", 0, "", 0, $include_users, '', '0,'.$conf->entity);


### PR DESCRIPTION
# FIX

On create expense report card,  the admin user with all rights in Dolibarr can't select users not in his hierarchy 
it's possible by enabling MAIN_USE_ADVANCED_PERMS conf and $user->rights->expensereport->writeall_advance right but activating advance rights to unlock possibility to an admin with ALL RIGHTS to create expense report for all usesr isn't logical.

