### PR TITLE
NEW MAIN_SEARCH_CAT_OR_BY_DEFAULT const for search by category

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -65,7 +65,12 @@ $search_barcode = GETPOST("search_barcode", 'alpha');
 $search_label = GETPOST("search_label", 'alpha');
 $search_type = GETPOST("search_type", 'int');
 $search_vatrate = GETPOST("search_vatrate", 'alpha');
-$searchCategoryProductOperator = (GETPOST('search_category_product_operator', 'int') ? GETPOST('search_category_product_operator', 'int') : 0);
+$searchCategoryProductOperator = 0;
+if (GETPOSTISSET('formfilteraction')) {
+	$searchCategoryProductOperator = GETPOST('search_category_product_operator', 'int');
+} elseif (!empty($conf->global->MAIN_SEARCH_CAT_OR_BY_DEFAULT)) {
+	$searchCategoryProductOperator = $conf->global->MAIN_SEARCH_CAT_OR_BY_DEFAULT;
+}
 $searchCategoryProductList = GETPOST('search_category_product_list', 'array');
 $search_tosell = GETPOST("search_tosell", 'int');
 $search_tobuy = GETPOST("search_tobuy", 'int');


### PR DESCRIPTION
NEW MAIN_SEARCH_CAT_OR_BY_DEFAULT const for search by category
- add const to enable "OR" operator by default in list when filter category is applied (

For example on product list :

![image](https://user-images.githubusercontent.com/45359511/149969045-798943e9-ef8b-4d6f-9baf-c18dcc60ca28.png)
