### PR TITLE
Allow to upload documents to fichinter module through API REST

### DIFF
--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -632,6 +632,9 @@ class Documents extends DolibarrApi
 				$modulepart = 'propale';
 				require_once DOL_DOCUMENT_ROOT.'/comm/propal/class/propal.class.php';
 				$object = new Propal($this->db);
+			} elseif ($modulepart == 'fichinter'){
+			        require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php'
+				$object = new Fichinter($this->db);	
 			} else {
 				// TODO Implement additional moduleparts
 				throw new RestException(500, 'Modulepart '.$modulepart.' not implemented yet.');

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -633,7 +633,7 @@ class Documents extends DolibarrApi
 				require_once DOL_DOCUMENT_ROOT.'/comm/propal/class/propal.class.php';
 				$object = new Propal($this->db);
 			} elseif ($modulepart == 'fichinter'){
-			        require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php'
+			        require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
 				$object = new Fichinter($this->db);	
 			} else {
 				// TODO Implement additional moduleparts

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -632,9 +632,9 @@ class Documents extends DolibarrApi
 				$modulepart = 'propale';
 				require_once DOL_DOCUMENT_ROOT.'/comm/propal/class/propal.class.php';
 				$object = new Propal($this->db);
-			} elseif ($modulepart == 'fichinter'){
-			        require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php'
-				$object = new Fichinter($this->db);	
+			} elseif ($modulepart == 'fichinter') {
+					require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php'
+				$object = new Fichinter($this->db);
 			} else {
 				// TODO Implement additional moduleparts
 				throw new RestException(500, 'Modulepart '.$modulepart.' not implemented yet.');

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -632,9 +632,9 @@ class Documents extends DolibarrApi
 				$modulepart = 'propale';
 				require_once DOL_DOCUMENT_ROOT.'/comm/propal/class/propal.class.php';
 				$object = new Propal($this->db);
-			} elseif ($modulepart == 'fichinter'){
-			        require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
-				$object = new Fichinter($this->db);	
+			} elseif ($modulepart == 'fichinter') {
+					require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
+				$object = new Fichinter($this->db);
 			} else {
 				// TODO Implement additional moduleparts
 				throw new RestException(500, 'Modulepart '.$modulepart.' not implemented yet.');


### PR DESCRIPTION
#Close #19879
Add to the file upload API REST method the ability to upload fichinter documents. POST /documents/upload

