### PR TITLE
Github Issues: Removed the required Code of Conduct checkbox so it doesn't show "done 1 task" on issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,12 +69,3 @@ body:
     attributes:
       label: Attached files
       description: Screenshots, screencasts, dolibarr.log, debugging informations
-      
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/Dolibarr/dolibarr/blob/develop/.github/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -33,12 +33,3 @@ body:
     attributes:
       label: Suggested steps
       description: List of tasks to achieve goal
-      
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/Dolibarr/dolibarr/blob/develop/.github/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true


### PR DESCRIPTION
Removed the required Code of Conduct checkbox so it doesn't show "done 1/1 task" on issues.