### PR TITLE
NEW #17123 added ExtraFields for Stock Mouvement

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -804,9 +804,6 @@ class ExtraFields
 		if ($elementtype == 'order_supplier') {
 			$elementtype = 'commande_fournisseur';
 		}
-		if ($elementtype == 'stock_mouvement') {
-			$elementtype = 'movement';
-		}
 
 		$array_name_label = array();
 

--- a/htdocs/core/lib/stock.lib.php
+++ b/htdocs/core/lib/stock.lib.php
@@ -109,6 +109,11 @@ function stock_admin_prepare_head()
 	$head[$h][2] = 'attributes';
 	$h++;
 
+	$head[$h][0] = DOL_URL_ROOT.'/product/admin/stock_mouvement_extrafields.php';
+	$head[$h][1] = $langs->trans("StockMouvementExtraFields");
+	$head[$h][2] = 'stockMouvementAttributes';
+	$h++;
+
 	complete_head_from_modules($conf, $langs, null, $head, $h, 'stock_admin', 'remove');
 
 	return $head;

--- a/htdocs/install/mysql/tables/llx_stock_mouvement_extrafields.sql
+++ b/htdocs/install/mysql/tables/llx_stock_mouvement_extrafields.sql
@@ -1,0 +1,24 @@
+-- ===================================================================
+-- Copyright (C) 2022	Salvatore Chiariello	<sal.chiariello@gmail.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ===================================================================
+
+CREATE TABLE llx_stock_mouvement_extrafields (
+    rowid integer AUTO_INCREMENT PRIMARY KEY,
+    tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    fk_object integer NOT NULL,
+    import_key varchar(14)
+)ENGINE=innodb;

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -410,3 +410,4 @@ DefaultBOMDesc=The default BOM recommended to use to manufacture this product. T
 Rank=Rank
 SwitchOnSaleStatus=Switch on sale status
 SwitchOnPurchaseStatus=Switch on purchase status
+StockMouvementExtraFields= Extra Fields (stock mouvement)

--- a/htdocs/langs/it_IT/products.lang
+++ b/htdocs/langs/it_IT/products.lang
@@ -410,3 +410,4 @@ DefaultBOMDesc=The default BOM recommended to use to manufacture this product. T
 Rank=Rank
 SwitchOnSaleStatus=Switch on sale status
 SwitchOnPurchaseStatus=Switch on purchase status
+StockMouvementExtraFields= Campi extra (movimenti scorte)

--- a/htdocs/product/admin/stock_mouvement_extrafields.php
+++ b/htdocs/product/admin/stock_mouvement_extrafields.php
@@ -1,0 +1,126 @@
+<?php
+/* Copyright (C) 2001-2002	Rodolphe Quiedeville	<rodolphe@quiedeville.org>
+ * Copyright (C) 2003		Jean-Louis Bergamo		<jlb@j1b.org>
+ * Copyright (C) 2004-2011	Laurent Destailleur		<eldy@users.sourceforge.net>
+ * Copyright (C) 2012		Regis Houssin			<regis.houssin@inodbox.com>
+ * Copyright (C) 2014		Florian Henry			<florian.henry@open-concept.pro>
+ * Copyright (C) 2015		Jean-François Ferry		<jfefe@aternatik.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *      \file       htdocs/product/admin/stock_mouvement_extrafields.php
+ *		\ingroup    stock
+ *		\brief      Page to setup extra fields of stock mouvement
+ */
+
+// Load Dolibarr environment
+$res = 0;
+// Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
+if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) $res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
+while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) { $i--; $j--; }
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) $res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) $res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+// Try main.inc.php using relative path
+if (!$res && file_exists("../../main.inc.php")) $res = @include "../../main.inc.php";
+if (!$res && file_exists("../../../main.inc.php")) $res = @include "../../../main.inc.php";
+if (!$res) die("Include of main fails");
+
+require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/stock.lib.php';
+
+// Load translation files required by the page
+$langs->loadLangs(array('stock@stock', 'admin'));
+
+$extrafields = new ExtraFields($db);
+$form = new Form($db);
+
+// List of supported format
+$tmptype2label = ExtraFields::$type2label;
+$type2label = array('');
+foreach ($tmptype2label as $key => $val) $type2label[$key] = $langs->transnoentitiesnoconv($val);
+
+$action = GETPOST('action', 'aZ09');
+$attrname = GETPOST('attrname', 'alpha');
+$elementtype = 'stock_mouvement'; //Must be the $table_element of the class that manage extrafield
+
+if (!$user->admin) accessforbidden();
+
+
+/*
+ * Actions
+ */
+
+require DOL_DOCUMENT_ROOT.'/core/actions_extrafields.inc.php';
+
+
+
+/*
+ * View
+ */
+
+
+llxHeader('', $langs->trans("StockSetup"), $help_url);
+
+
+$linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php?restore_lastsearch_values=1">'.$langs->trans("BackToModuleList").'</a>';
+print load_fiche_titre($langs->trans("StockSetup"), $linkback, 'title_setup');
+
+
+$head = stock_admin_prepare_head();
+
+print dol_get_fiche_head($head, 'stockMouvementAttributes', $langs->trans("StockMouvementExtraFields"), -1, 'account');
+
+require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_view.tpl.php';
+
+print dol_get_fiche_end();
+
+
+// Buttons
+if ($action != 'create' && $action != 'edit')
+{
+    print '<div class="tabsAction">';
+    print "<a class=\"butAction\" href=\"".$_SERVER["PHP_SELF"]."?action=create#newattrib\">".$langs->trans("NewAttribute")."</a>";
+    print "</div>";
+}
+
+
+/*
+ * Creation of an optional field
+ */
+if ($action == 'create')
+{
+    print '<br><div id="newattrib"></div>';
+    print load_fiche_titre($langs->trans('NewAttribute'));
+
+    require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_add.tpl.php';
+}
+
+/*
+ * Edition of an optional field
+ */
+if ($action == 'edit' && !empty($attrname))
+{
+    print "<br>";
+    print load_fiche_titre($langs->trans("FieldEdition", $attrname));
+
+    require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_edit.tpl.php';
+}
+
+// End of page
+llxFooter();
+$db->close();

--- a/htdocs/product/admin/stock_mouvement_extrafields.php
+++ b/htdocs/product/admin/stock_mouvement_extrafields.php
@@ -91,34 +91,31 @@ print dol_get_fiche_end();
 
 
 // Buttons
-if ($action != 'create' && $action != 'edit')
-{
-    print '<div class="tabsAction">';
-    print "<a class=\"butAction\" href=\"".$_SERVER["PHP_SELF"]."?action=create#newattrib\">".$langs->trans("NewAttribute")."</a>";
-    print "</div>";
+if ($action != 'create' && $action != 'edit') {
+	print '<div class="tabsAction">';
+	print "<a class=\"butAction\" href=\"".$_SERVER["PHP_SELF"]."?action=create#newattrib\">".$langs->trans("NewAttribute")."</a>";
+	print "</div>";
 }
 
 
 /*
  * Creation of an optional field
  */
-if ($action == 'create')
-{
-    print '<br><div id="newattrib"></div>';
-    print load_fiche_titre($langs->trans('NewAttribute'));
+if ($action == 'create') {
+	print '<br><div id="newattrib"></div>';
+	print load_fiche_titre($langs->trans('NewAttribute'));
 
-    require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_add.tpl.php';
+	require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_add.tpl.php';
 }
 
 /*
  * Edition of an optional field
  */
-if ($action == 'edit' && !empty($attrname))
-{
-    print "<br>";
-    print load_fiche_titre($langs->trans("FieldEdition", $attrname));
+if ($action == 'edit' && !empty($attrname)) {
+	print "<br>";
+	print load_fiche_titre($langs->trans("FieldEdition", $attrname));
 
-    require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_edit.tpl.php';
+	require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_edit.tpl.php';
 }
 
 // End of page

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5122,7 +5122,7 @@ class Product extends CommonObject
 	 * @param  int	  $disablestockchangeforsubproduct	Disable stock change for sub-products of kit (usefull only if product is a subproduct)
 	 * @return int                     <0 if KO, >0 if OK
 	 */
-	public function correct_stock($user, $id_entrepot, $nbpiece, $movement, $label = '', $price = 0, $inventorycode = '', $origin_element = '', $origin_id = null, $disablestockchangeforsubproduct = 0,$extrafields = null)
+	public function correct_stock($user, $id_entrepot, $nbpiece, $movement, $label = '', $price = 0, $inventorycode = '', $origin_element = '', $origin_id = null, $disablestockchangeforsubproduct = 0, $extrafields = null)
 	{
 		// phpcs:enable
 		if ($id_entrepot) {
@@ -5145,7 +5145,7 @@ class Product extends CommonObject
 			$result = $movementstock->_create($user, $this->id, $id_entrepot, $op[$movement], $movement, $price, $label, $inventorycode, '', '', '', '', false, 0, $disablestockchangeforsubproduct);
 
 			if ($result >= 0) {
-				if($extrafields){
+				if ($extrafields) {
 					$array_options = $extrafields->getOptionalsFromPost('stock_mouvement');
 					$movementstock->array_options = $array_options;
 					$movementstock->insertExtraFields();
@@ -5181,7 +5181,7 @@ class Product extends CommonObject
 	 * @param  int	    $disablestockchangeforsubproduct	Disable stock change for sub-products of kit (usefull only if product is a subproduct)
 	 * @return int                      <0 if KO, >0 if OK
 	 */
-	public function correct_stock_batch($user, $id_entrepot, $nbpiece, $movement, $label = '', $price = 0, $dlc = '', $dluo = '', $lot = '', $inventorycode = '', $origin_element = '', $origin_id = null, $disablestockchangeforsubproduct = 0,$extrafields = null)
+	public function correct_stock_batch($user, $id_entrepot, $nbpiece, $movement, $label = '', $price = 0, $dlc = '', $dluo = '', $lot = '', $inventorycode = '', $origin_element = '', $origin_id = null, $disablestockchangeforsubproduct = 0, $extrafields = null)
 	{
 		// phpcs:enable
 		if ($id_entrepot) {
@@ -5204,7 +5204,7 @@ class Product extends CommonObject
 			$result = $movementstock->_create($user, $this->id, $id_entrepot, $op[$movement], $movement, $price, $label, $inventorycode, '', $dlc, $dluo, $lot, false, 0, $disablestockchangeforsubproduct);
 
 			if ($result >= 0) {
-				if($extrafields){
+				if ($extrafields) {
 					$array_options = $extrafields->getOptionalsFromPost('stock_mouvement');
 					$movementstock->array_options = $array_options;
 					$movementstock->insertExtraFields();

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5122,7 +5122,7 @@ class Product extends CommonObject
 	 * @param  int	  $disablestockchangeforsubproduct	Disable stock change for sub-products of kit (usefull only if product is a subproduct)
 	 * @return int                     <0 if KO, >0 if OK
 	 */
-	public function correct_stock($user, $id_entrepot, $nbpiece, $movement, $label = '', $price = 0, $inventorycode = '', $origin_element = '', $origin_id = null, $disablestockchangeforsubproduct = 0)
+	public function correct_stock($user, $id_entrepot, $nbpiece, $movement, $label = '', $price = 0, $inventorycode = '', $origin_element = '', $origin_id = null, $disablestockchangeforsubproduct = 0,$extrafields = null)
 	{
 		// phpcs:enable
 		if ($id_entrepot) {
@@ -5145,6 +5145,11 @@ class Product extends CommonObject
 			$result = $movementstock->_create($user, $this->id, $id_entrepot, $op[$movement], $movement, $price, $label, $inventorycode, '', '', '', '', false, 0, $disablestockchangeforsubproduct);
 
 			if ($result >= 0) {
+				if($extrafields){
+					$array_options = $extrafields->getOptionalsFromPost('stock_mouvement');
+					$movementstock->array_options = $array_options;
+					$movementstock->insertExtraFields();
+				}
 				$this->db->commit();
 				return 1;
 			} else {
@@ -5176,7 +5181,7 @@ class Product extends CommonObject
 	 * @param  int	    $disablestockchangeforsubproduct	Disable stock change for sub-products of kit (usefull only if product is a subproduct)
 	 * @return int                      <0 if KO, >0 if OK
 	 */
-	public function correct_stock_batch($user, $id_entrepot, $nbpiece, $movement, $label = '', $price = 0, $dlc = '', $dluo = '', $lot = '', $inventorycode = '', $origin_element = '', $origin_id = null, $disablestockchangeforsubproduct = 0)
+	public function correct_stock_batch($user, $id_entrepot, $nbpiece, $movement, $label = '', $price = 0, $dlc = '', $dluo = '', $lot = '', $inventorycode = '', $origin_element = '', $origin_id = null, $disablestockchangeforsubproduct = 0,$extrafields = null)
 	{
 		// phpcs:enable
 		if ($id_entrepot) {
@@ -5199,6 +5204,11 @@ class Product extends CommonObject
 			$result = $movementstock->_create($user, $this->id, $id_entrepot, $op[$movement], $movement, $price, $label, $inventorycode, '', $dlc, $dluo, $lot, false, 0, $disablestockchangeforsubproduct);
 
 			if ($result >= 0) {
+				if($extrafields){
+					$array_options = $extrafields->getOptionalsFromPost('stock_mouvement');
+					$movementstock->array_options = $array_options;
+					$movementstock->insertExtraFields();
+				}
 				$this->db->commit();
 				return 1;
 			} else {

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -139,6 +139,9 @@ $arrayfields = array(
 	//'m.datec'=>array('label'=>"DateCreation", 'checked'=>0, 'position'=>500),
 	//'m.tms'=>array('label'=>"DateModificationShort", 'checked'=>0, 'position'=>500)
 );
+
+include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
+
 if (!empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
 	unset($arrayfields['pl.sellby']);
 }
@@ -381,7 +384,9 @@ if ($action == "correct_stock") {
 				$batch,
 				GETPOST('inventorycode', 'alphanohtml'),
 				$origin_element,
-				$origin_id
+				$origin_id,
+				0,
+				$extrafields
 			); // We do not change value of stock for a correction
 		} else {
 			$result = $product->correct_stock(
@@ -393,7 +398,9 @@ if ($action == "correct_stock") {
 				price2num(GETPOST('unitprice'), 'MT'),
 				GETPOST('inventorycode', 'alphanohtml'),
 				$origin_element,
-				$origin_id
+				$origin_id,
+				0,
+				$extrafields
 			); // We do not change value of stock for a correction
 		}
 
@@ -500,7 +507,11 @@ if ($action == "transfert_stock" && !$cancel) {
 						$eatby,
 						$sellby,
 						$batch,
-						GETPOST('inventorycode')
+						GETPOST('inventorycode'),
+						'',
+						null,
+						0,
+						$extrafields
 					);
 					// Add stock
 					$result2 = $product->correct_stock_batch(
@@ -513,7 +524,11 @@ if ($action == "transfert_stock" && !$cancel) {
 						$eatby,
 						$sellby,
 						$batch,
-						GETPOST('inventorycode', 'alphanohtml')
+						GETPOST('inventorycode', 'alphanohtml'),
+						'',
+						null,
+						0,
+						$extrafields
 					);
 				}
 			} else {
@@ -525,7 +540,11 @@ if ($action == "transfert_stock" && !$cancel) {
 					1,
 					GETPOST("label", 'san_alpha'),
 					$pricesrc,
-					GETPOST('inventorycode', 'alphanohtml')
+					GETPOST('inventorycode', 'alphanohtml'),
+					'',
+					null,
+					0,
+					$extrafields
 				);
 
 				// Add stock
@@ -536,7 +555,11 @@ if ($action == "transfert_stock" && !$cancel) {
 					0,
 					GETPOST("label", 'san_alpha'),
 					$pricedest,
-					GETPOST('inventorycode', 'alphanohtml')
+					GETPOST('inventorycode', 'alphanohtml'),
+					'',
+					null,
+					0,
+					$extrafields
 				);
 			}
 			if (!$error && $result1 >= 0 && $result2 >= 0) {
@@ -1434,6 +1457,7 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 	}
 
 	// Extra fields
+	$object = $movement;
 	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_print_fields.tpl.php';
 	// Fields from hook
 	$parameters = array('arrayfields'=>$arrayfields, 'object'=>$object, 'obj'=>$obj, 'i'=>$i, 'totalarray'=>&$totalarray);

--- a/htdocs/product/stock/tpl/extrafields_add.tpl.php
+++ b/htdocs/product/stock/tpl/extrafields_add.tpl.php
@@ -1,0 +1,52 @@
+<?php
+/* Copyright (C) 2014	Maxime Kohlhaas		<support@atm-consulting.fr>
+ * Copyright (C) 2014	Juanjo Menent		<jmenent@2byte.es>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Need to have following variables defined:
+ * $object (invoice, order, ...)
+ * $action
+ * $conf
+ * $langs
+ *
+ * $parameters
+ * $cols
+ */
+
+// Protection to avoid direct call of template
+if (empty($conf) || !is_object($conf))
+{
+	print "Error, template page can't be called as URL";
+	exit;
+}
+
+?>
+<!-- BEGIN PHP TEMPLATE extrafields_add.tpl.php -->
+<?php
+
+// Other attributes
+if (!isset($parameters)) $parameters = array();
+
+$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $movement, $action); // Note that $action and $object may have been modified by hook
+print $hookmanager->resPrint;
+if (empty($reshook)) {
+	$params = array();
+	if (isset($tpl_context)) $params['tpl_context'] = $tpl_context;
+	$params['cols'] = $parameters['colspanvalue'];
+	print $movement->showOptionals($extrafields, 'create', $params);
+}
+
+?>
+<!-- END PHP TEMPLATE extrafields_add.tpl.php -->

--- a/htdocs/product/stock/tpl/extrafields_add.tpl.php
+++ b/htdocs/product/stock/tpl/extrafields_add.tpl.php
@@ -26,8 +26,7 @@
  */
 
 // Protection to avoid direct call of template
-if (empty($conf) || !is_object($conf))
-{
+if (empty($conf) || !is_object($conf)) {
 	print "Error, template page can't be called as URL";
 	exit;
 }

--- a/htdocs/product/stock/tpl/stockcorrection.tpl.php
+++ b/htdocs/product/stock/tpl/stockcorrection.tpl.php
@@ -179,6 +179,9 @@ print '<input class="maxwidth100onsmartphone" name="inventorycode" id="inventory
 print '</td>';
 print '</tr>';
 
+// Extrafield template
+include 'extrafields_add.tpl.php';
+
 print '</table>';
 
 print dol_get_fiche_end();

--- a/htdocs/product/stock/tpl/stocktransfer.tpl.php
+++ b/htdocs/product/stock/tpl/stocktransfer.tpl.php
@@ -136,6 +136,9 @@ print '<input class="maxwidth100onsmartphone" name="inventorycode" id="inventory
 print '</td>';
 print '</tr>';
 
+// Extrafield template
+include 'extrafields_add.tpl.php';
+
 print '</table>';
 
 print dol_get_fiche_end();


### PR DESCRIPTION
# NEW added ExtraFields for Stock Mouvement

Fixes #17123

Added new tab in Stock module setup for stock movement extrafields
![Schermata 2022-01-28 alle 15 08 52](https://user-images.githubusercontent.com/7082009/151582797-4eee9b24-dd8e-46a0-b4f4-56be4f120921.png)

added extrafields in "correct stock"/"transfer stock" and in movements table

![Schermata 2022-01-28 alle 17 24 10](https://user-images.githubusercontent.com/7082009/151583992-96b6639b-cfd1-495d-b135-100b3a37cc8f.png)

![Schermata 2022-01-28 alle 17 24 21](https://user-images.githubusercontent.com/7082009/151585424-fe12b763-b70d-445b-b189-828d9d5d874c.png)

![Schermata 2022-01-28 alle 17 28 37](https://user-images.githubusercontent.com/7082009/151585504-fc6bf81f-d5ee-466f-9eba-1f9a454bbd47.png)