### PR TITLE
Add column "fk_parent_line" to llx_mrp_mo

### DIFF
--- a/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
+++ b/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
@@ -94,3 +94,5 @@ CREATE TABLE llx_stock_mouvement_extrafields (
     fk_object integer NOT NULL,
     import_key varchar(14)
 )ENGINE=innodb;
+
+ALTER TABLE llx_mrp_mo ADD COLUMN fk_parent_line integer;

--- a/htdocs/install/mysql/tables/llx_mrp_mo.sql
+++ b/htdocs/install/mysql/tables/llx_mrp_mo.sql
@@ -40,6 +40,7 @@ CREATE TABLE llx_mrp_mo(
 	date_end_planned datetime, 
 	fk_bom integer, 
 	fk_project integer,
-	last_main_doc varchar(255)
-	-- END MODULEBUILDER FIELDS
+	last_main_doc varchar(255),
+    fk_parent_line integer
+    -- END MODULEBUILDER FIELDS
 ) ENGINE=innodb;


### PR DESCRIPTION
# NEW|New [*Add column "fk_parent_line" to llx_mrp_mo*]

Data to develop new feature "Manufacturing Order Child". We would like two things :

**1.** A specific link between Manufacturing Order and Manufacturing Order line parent for futur developments
**2.**  "Manufacturing Order line Parent" in card and list information

I have two proposals : 

**1. Create 2 columns "fk_parent_line" and "fk_parent" in llx_mrp_mo**

We have a specific link between line and child for futur developments.
Manufacturing Order Parent displays like a field without specific behaviour.

**2. Create 1 column "fk_parent_line" and develop the display of Manufacturing Order Parent**

We have a specific link between line and child for futur developments.
Manufacturing Order Parent diplays with a specific behaviour.

Which proposition do you think is better @eldy  ? For now, I applied solution 2 in merge request.