### PR TITLE
fix bad array index for multicurrency

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -527,13 +527,14 @@ if (empty($reshook)) {
 			$i = 0;
 			foreach ($object->lines as $line) {
 				if ($line->product_type < 9 && $line->total_ht != 0) { // Remove lines with product_type greater than or equal to 9 and no need to create discount if amount is null
+					$keyforvatrate = $line->tva_tx.($line->vat_src_code ? ' ('.$line->vat_src_code.')' : '');
 
-					$amount_ht[$line->tva_tx] += $line->total_ht;
-					$amount_tva[$line->tva_tx] += $line->total_tva;
-					$amount_ttc[$line->tva_tx] += $line->total_ttc;
-					$multicurrency_amount_ht[$line->tva_tx] += $line->multicurrency_total_ht;
-					$multicurrency_amount_tva[$line->tva_tx] += $line->multicurrency_total_tva;
-					$multicurrency_amount_ttc[$line->tva_tx] += $line->multicurrency_total_ttc;
+					$amount_ht[$keyforvatrate] += $line->total_ht;
+					$amount_tva[$keyforvatrate] += $line->total_tva;
+					$amount_ttc[$keyforvatrate] += $line->total_ttc;
+					$multicurrency_amount_ht[$keyforvatrate] += $line->multicurrency_total_ht;
+					$multicurrency_amount_tva[$keyforvatrate] += $line->multicurrency_total_tva;
+					$multicurrency_amount_ttc[$keyforvatrate] += $line->multicurrency_total_ttc;
 					$i++;
 				}
 			}

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -527,14 +527,13 @@ if (empty($reshook)) {
 			$i = 0;
 			foreach ($object->lines as $line) {
 				if ($line->product_type < 9 && $line->total_ht != 0) { // Remove lines with product_type greater than or equal to 9 and no need to create discount if amount is null
-					$keyforvatrate = $line->tva_tx.($line->vat_src_code ? ' ('.$line->vat_src_code.')' : '');
 
 					$amount_ht[$line->tva_tx] += $line->total_ht;
 					$amount_tva[$line->tva_tx] += $line->total_tva;
 					$amount_ttc[$line->tva_tx] += $line->total_ttc;
-					$multicurrency_amount_ht[$keyforvatrate] += $line->multicurrency_total_ht;
-					$multicurrency_amount_tva[$keyforvatrate] += $line->multicurrency_total_tva;
-					$multicurrency_amount_ttc[$keyforvatrate] += $line->multicurrency_total_ttc;
+					$multicurrency_amount_ht[$line->tva_tx] += $line->multicurrency_total_ht;
+					$multicurrency_amount_tva[$line->tva_tx] += $line->multicurrency_total_tva;
+					$multicurrency_amount_ttc[$line->tva_tx] += $line->multicurrency_total_ttc;
 					$i++;
 				}
 			}


### PR DESCRIPTION
# FIX bad index for multicurrency arrays
When converting a supplier credit note into reduc, the multicurrency amounts are lost because of the generation of a key that is potentially different from $line->tva_tx for multicurrency arrays.

This key must be the same as amounts arrays to be sure to get the good multicurrency amounts when creating the discount.

Consequence : when multicurrency is enabled and a credit note is applied on a supplier invoice, the remainToPay is calculated on the multicurrency amounts which as 0.

![ksnip_20220202-154610](https://user-images.githubusercontent.com/30891670/152176522-19d86dd9-dc0e-4be2-aa10-50a8c29a54c0.png)


P.S. : excuse my bad english.
