### PR TITLE
New : Notify thirdparty at ticket closing

### DIFF
--- a/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
+++ b/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
@@ -300,6 +300,171 @@ class InterfaceTicketEmail extends DolibarrTriggers
 
 			case 'TICKET_CLOSE':
 				dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+				$langs->load('ticket');
+				$langs->load('mails');
+
+				// Send email to notification email
+				if (!empty($conf->global->TICKET_NOTIFICATION_EMAIL_TO) && empty($object->context['disableticketemail'])) {
+					$sendto = empty($conf->global->TICKET_NOTIFICATION_EMAIL_TO) ? '' : $conf->global->TICKET_NOTIFICATION_EMAIL_TO;
+
+					if ($sendto) {
+						// Init to avoid errors
+						$filepath = array();
+						$filename = array();
+						$mimetype = array();
+
+						/* Send email to admin */
+						$subject = '['.$conf->global->MAIN_INFO_SOCIETE_NOM.'] '.$langs->trans('TicketCloseEmailSubjectAdmin');
+						$message_admin = $langs->trans('TicketCloseEmailBodyAdmin', $object->track_id).'<br><br>';
+						$message_admin .= '<ul><li>'.$langs->trans('Title').' : '.$object->subject.'</li>';
+						$message_admin .= '<li>'.$langs->trans('Type').' : '.$langs->getLabelFromKey($this->db, 'TicketTypeShort'.$object->type_code, 'c_ticket_type', 'code', 'label', $object->type_code).'</li>';
+						$message_admin .= '<li>'.$langs->trans('Category').' : '.$langs->getLabelFromKey($this->db, 'TicketCategoryShort'.$object->category_code, 'c_ticket_category', 'code', 'label', $object->category_code).'</li>';
+						$message_admin .= '<li>'.$langs->trans('Severity').' : '.$langs->getLabelFromKey($this->db, 'TicketSeverityShort'.$object->severity_code, 'c_ticket_severity', 'code', 'label', $object->severity_code).'</li>';
+						$message_admin .= '<li>'.$langs->trans('From').' : '.($object->email_from ? $object->email_from : ($object->fk_user_create > 0 ? $langs->trans('Internal') : '')).'</li>';
+						// Extrafields
+						$extraFields = new ExtraFields($this->db);
+						$extraFields->fetch_name_optionals_label($object->table_element);
+						if (is_array($object->array_options) && count($object->array_options) > 0) {
+							foreach ($object->array_options as $key => $value) {
+								$key = substr($key, 8); // remove "options_"
+								$message_admin .= '<li>'.$langs->trans($extraFields->attributes[$object->element]['label'][$key]).' : '.$extraFields->showOutputField($key, $value).'</li>';
+							}
+						}
+						$message_admin .= '</ul>';
+
+						if ($object->fk_soc > 0) {
+								  $object->fetch_thirdparty();
+								  $message_admin .= '<p>'.$langs->trans('Company').' : '.$object->thirdparty->name.'</p>';
+						}
+
+						$message = $object->message;
+						if (!dol_textishtml($message)) {
+							$message = dol_nl2br($message);
+						}
+						$message_admin .= '<p>'.$langs->trans('Message').' : <br>'.$message.'</p>';
+						$message_admin .= '<p><a href="'.dol_buildpath('/ticket/card.php', 2).'?track_id='.$object->track_id.'">'.$langs->trans('SeeThisTicketIntomanagementInterface').'</a></p>';
+
+						$from = $conf->global->MAIN_INFO_SOCIETE_NOM.'<'.$conf->global->TICKET_NOTIFICATION_EMAIL_FROM.'>';
+						$replyto = $from;
+
+						$trackid = 'tic'.$object->id;
+
+						if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
+							$old_MAIN_MAIL_AUTOCOPY_TO = $conf->global->MAIN_MAIL_AUTOCOPY_TO;
+							$conf->global->MAIN_MAIL_AUTOCOPY_TO = '';
+						}
+						include_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
+						$mailfile = new CMailFile($subject, $sendto, $from, $message_admin, $filepath, $mimetype, $filename, '', '', 0, -1, '', '', $trackid, '', 'ticket');
+						if ($mailfile->error) {
+							dol_syslog($mailfile->error, LOG_DEBUG);
+						} else {
+								 $result = $mailfile->sendfile();
+						}
+						if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
+							$conf->global->MAIN_MAIL_AUTOCOPY_TO = $old_MAIN_MAIL_AUTOCOPY_TO;
+						}
+					}
+				}
+
+				// Send email to customer
+
+				if (empty($conf->global->TICKET_DISABLE_CUSTOMER_MAILS) && empty($object->context['disableticketemail']) && $object->notify_tiers_at_closing) {
+					$sendto = '';
+
+					//if contact selected send to email's contact else send to email's thirdparty
+
+					$contactid = GETPOST('contactid', 'alpha');
+
+					if (!empty($contactid)) {
+						$contact = new Contact($this->db);
+						$res = $contact->fetch($contactid);
+					}
+
+					if ($res > 0 && !empty($contact->email) && !empty($contact->statut)) {
+						$sendto = $contact->email;
+					} elseif (!empty($object->fk_soc)) {
+						$object->fetch_thirdparty();
+						$sendto = $object->thirdparty->email;
+					}
+
+					if ($sendto) {
+						// Init to avoid errors
+						$filepath = array();
+						$filename = array();
+						$mimetype = array();
+
+						$subject = '['.$conf->global->MAIN_INFO_SOCIETE_NOM.'] '. $langs->transnoentities('TicketCloseEmailSubjectCustomer');
+						$message_customer = $langs->transnoentities('TicketCloseEmailBodyCustomer').'<br><br>';
+						$message_customer .= '<ul><li>'.$langs->trans('Title').' : '.$object->subject.'</li>';
+						$message_customer .= '<li>'.$langs->trans('Type').' : '.$langs->getLabelFromKey($this->db, 'TicketTypeShort'.$object->type_code, 'c_ticket_type', 'code', 'label', $object->type_code).'</li>';
+						$message_customer .= '<li>'.$langs->trans('Category').' : '.$langs->getLabelFromKey($this->db, 'TicketCategoryShort'.$object->category_code, 'c_ticket_category', 'code', 'label', $object->category_code).'</li>';
+						$message_customer .= '<li>'.$langs->trans('Severity').' : '.$langs->getLabelFromKey($this->db, 'TicketSeverityShort'.$object->severity_code, 'c_ticket_severity', 'code', 'label', $object->severity_code).'</li>';
+
+						// Extrafields
+						foreach ($this->attributes[$object->table_element]['label'] as $key => $value) {
+							$enabled = 1;
+							if ($enabled && isset($this->attributes[$object->table_element]['list'][$key])) {
+								$enabled = dol_eval($this->attributes[$object->table_element]['list'][$key], 1);
+							}
+							$perms = 1;
+							if ($perms && isset($this->attributes[$object->table_element]['perms'][$key])) {
+								$perms = dol_eval($this->attributes[$object->table_element]['perms'][$key], 1);
+							}
+
+							$qualified = true;
+							if (empty($enabled)) {
+								$qualified = false;
+							}
+							if (empty($perms)) {
+								$qualified = false;
+							}
+
+							if ($qualified) {
+								$message_customer .= '<li>'.$langs->trans($key).' : '.$value.'</li>';
+							}
+						}
+
+						$message_customer .= '</ul>';
+
+						$message = $object->message;
+						if (!dol_textishtml($message)) {
+							$message = dol_nl2br($message);
+						}
+						$message_customer .= '<p>'.$langs->trans('Message').' : <br>'.$message.'</p><br>';
+						$url_public_ticket = ($conf->global->TICKET_URL_PUBLIC_INTERFACE ? $conf->global->TICKET_URL_PUBLIC_INTERFACE.'/' : dol_buildpath('/public/ticket/view.php', 2)).'?track_id='.$object->track_id;
+						$message_customer .= '<p>'.$langs->trans('TicketNewEmailBodyInfosTrackUrlCustomer').' : <a href="'.$url_public_ticket.'">'.$url_public_ticket.'</a></p>';
+						$message_customer .= '<p>'.$langs->trans('TicketEmailPleaseDoNotReplyToThisEmail').'</p>';
+
+						$from = (empty($conf->global->MAIN_INFO_SOCIETE_NOM) ? '' : $conf->global->MAIN_INFO_SOCIETE_NOM.' ').'<'.$conf->global->TICKET_NOTIFICATION_EMAIL_FROM.'>';
+						$replyto = $from;
+
+						$trackid = 'tic'.$object->id;
+
+						if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
+							$old_MAIN_MAIL_AUTOCOPY_TO = $conf->global->MAIN_MAIL_AUTOCOPY_TO;
+							$conf->global->MAIN_MAIL_AUTOCOPY_TO = '';
+						}
+						include_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
+						$mailfile = new CMailFile($subject, $sendto, $from, $message_customer, $filepath, $mimetype, $filename, '', '', 0, -1, '', '', $trackid, '', 'ticket');
+						if ($mailfile->error) {
+							dol_syslog($mailfile->error, LOG_DEBUG);
+							$mesg = $langs->transnoentities('ErrorFailedToSendMail', dol_escape_htmltag($from), dol_escape_htmltag($sendto));
+							setEventMessage($mesg, 'errors');
+						} else {
+							$result = $mailfile->sendfile();
+							$mesg = $langs->trans('MailSuccessfulySent', $mailfile->getValidAddress($from, 2), $mailfile->getValidAddress($sendto, 2));
+							setEventMessage($mesg, 'mesgs');
+						}
+						if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
+							$conf->global->MAIN_MAIL_AUTOCOPY_TO = $old_MAIN_MAIL_AUTOCOPY_TO;
+						}
+					} else {
+						$mesg = $langs->trans('MailingStatusError'). ': ' .$langs->trans('ErrorMailRecipientIsEmptyForSendTicketMessage');
+						setEventMessage($mesg, 'errors');
+					}
+				}
+
+				$ok = 1;
 				break;
 		}
 

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -238,6 +238,7 @@ TicketChangeStatus=Change status
 TicketConfirmChangeStatus=Confirm the status change: %s ?
 TicketLogStatusChanged=Status changed: %s to %s
 TicketNotNotifyTiersAtCreate=Not notify company at create
+TicketNotNotifyTiersAtClose=Do not notify
 Unread=Unread
 TicketNotCreatedFromPublicInterface=Not available. Ticket was not created from public interface.
 ErrorTicketRefRequired=Ticket reference name is required

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -241,6 +241,7 @@ TicketNotNotifyTiersAtCreate=Not notify company at create
 Unread=Unread
 TicketNotCreatedFromPublicInterface=Not available. Ticket was not created from public interface.
 ErrorTicketRefRequired=Ticket reference name is required
+NotifyThirdpartyOnTicketClosing=Notify a contact while closing the ticket
 
 #
 # Logs

--- a/htdocs/langs/fr_FR/ticket.lang
+++ b/htdocs/langs/fr_FR/ticket.lang
@@ -238,6 +238,7 @@ TicketChangeStatus=Changer l'état
 TicketConfirmChangeStatus=Confirmez le changement d'état: %s?
 TicketLogStatusChanged=Statut modifié: %s à %s
 TicketNotNotifyTiersAtCreate=Ne pas notifier l'entreprise à la création
+TicketNotNotifyTiersAtClose=Ne pas notifier
 Unread=Non lu
 TicketNotCreatedFromPublicInterface=Non disponible. Le ticket n’a pas été créé à partir de l'interface publique.
 ErrorTicketRefRequired=La référence du ticket est requise

--- a/htdocs/langs/fr_FR/ticket.lang
+++ b/htdocs/langs/fr_FR/ticket.lang
@@ -241,6 +241,7 @@ TicketNotNotifyTiersAtCreate=Ne pas notifier l'entreprise à la création
 Unread=Non lu
 TicketNotCreatedFromPublicInterface=Non disponible. Le ticket n’a pas été créé à partir de l'interface publique.
 ErrorTicketRefRequired=La référence du ticket est requise
+NotifyThirdpartyOnTicketClosing=Notifier un contact à la fermeture du ticket
 
 #
 # Logs
@@ -262,7 +263,7 @@ TicketPublicDesc=Vous pouvez créer un ticket ou consulter à partir d'un ID de 
 YourTicketSuccessfullySaved=Le ticket a été enregistré avec succès
 MesgInfosPublicTicketCreatedWithTrackId=Un nouveau ticket a été créé avec l'ID %s et la référence %s.
 PleaseRememberThisId=Merci de conserver le code de suivi du ticket, il vous sera peut-être nécessaire ultérieurement
-TicketNewEmailSubject=Confirmation de création de ticket - Réf %s(ID publique tu ticket %s)
+TicketNewEmailSubject=Confirmation de création de ticket - Réf %s(ID publique du ticket %s)
 TicketNewEmailSubjectCustomer=Nouveau ticket
 TicketNewEmailBody=Ceci est un message automatique pour confirmer l'enregistrement de votre ticket.
 TicketNewEmailBodyCustomer=Ceci est un email automatique pour confirmer qu'un nouveau ticket vient d'être créé dans votre compte.
@@ -270,6 +271,8 @@ TicketNewEmailBodyInfosTicket=Informations pour la surveillance du ticket
 TicketNewEmailBodyInfosTrackId=Numéro de suivi du ticket : %s
 TicketNewEmailBodyInfosTrackUrl=Vous pouvez voir la progression du ticket en cliquant sur le lien ci-dessus.
 TicketNewEmailBodyInfosTrackUrlCustomer=Vous pouvez voir la progression du ticket en cliquant sur le lien ci-dessus.
+TicketCloseEmailSubjectCustomer=Ticket clôturé
+TicketCloseEmailBodyCustomer=Ceci est un email automatique pour vous indiquer qu'un ticket vient d'être clôturé dans votre compte.
 TicketEmailPleaseDoNotReplyToThisEmail=Merci de ne pas répondre directement à ce courriel ! Utilisez le lien pour répondre via l'interface.
 TicketPublicInfoCreateTicket=Ce formulaire vous permet d'enregistrer un ticket dans notre système de gestion.
 TicketPublicPleaseBeAccuratelyDescribe=Veuillez décrire avec précision le problème. Fournissez le plus d'informations possibles pour nous permettre d'identifier correctement votre demande.
@@ -283,6 +286,8 @@ ViewMyTicketList=Voir la liste de mes tickets
 ErrorEmailMustExistToCreateTicket=Erreur: adresse email introuvable dans notre base de données
 TicketNewEmailSubjectAdmin=Nouveau ticket créé - Réf %s(ID publique du ticket %s)
 TicketNewEmailBodyAdmin=<p> Le ticket vient d'être créé avec l'ID # %s, voir les informations: </p>
+TicketCloseEmailSubjectAdmin=Ticket clôturé - Réf %s(ID publique du ticket %s)
+TicketCloseEmailBodyAdmin=<p> Le ticket vient d'être clôturé avec l'ID # %s, voir les informations: </p>
 SeeThisTicketIntomanagementInterface=Voir ticket dans l'interface de gestion
 TicketPublicInterfaceForbidden=L'interface publique pour les tickets n'a pas été activée
 ErrorEmailOrTrackingInvalid=Mauvaise valeur pour l'ID de suivi ou l'e-mail

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -823,7 +823,7 @@ if ($action == 'create' || $action == 'presend') {
 		if ($action == 'close') {
 
 			$thirdparty_contacts = $object->getInfosTicketExternalContact();
-			$contacts_select = array();
+			$contacts_select = array('0' => $langs->trans('TicketNotNotifyTiersAtClose'));
 			foreach ($thirdparty_contacts as $thirdparty_contact) {
 				$contacts_select[$thirdparty_contact['id']] = $thirdparty_contact['civility'] . ' ' . $thirdparty_contact['lastname'] . ' ' . $thirdparty_contact['firstname'];
 			}
@@ -833,7 +833,8 @@ if ($action == 'create' || $action == 'presend') {
 					'name' => 'contactid',
 					'type' => 'select',
 					'label' => $langs->trans('NotifyThirdpartyOnTicketClosing'),
-					'values' => $contacts_select
+					'values' => $contacts_select,
+					'default' => '0'
 				),
 			);
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("CloseATicket"), $langs->trans("ConfirmCloseAticket"), "confirm_close", $formquestion, '', 1 );

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -198,6 +198,11 @@ class Ticket extends CommonObject
 	public $notify_tiers_at_create;
 
 	/**
+	 * @var int Notify thirdparty at closing
+	 */
+	public $notify_tiers_at_closing = 0;
+
+	/**
 	 * @var string msgid
 	 */
 	public $email_msgid;


### PR DESCRIPTION
Notify thirdparty when closing a ticket.

A contact can be chosen in the closing confirmation modal.

On mass ticket closing, no notification is sent.