### PR TITLE
FIX Disable customer type by default if type prospect/customer is disabled

### DIFF
--- a/htdocs/societe/admin/societe.php
+++ b/htdocs/societe/admin/societe.php
@@ -4,7 +4,6 @@
  * Copyright (C) 2005-2011  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012  Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2011-2012  Juanjo Menent           <jmenent@2byte.es>
- * Copyright (C) 2022       Alexandre Spangaro      <aspangaro@open-dsi.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -230,8 +229,6 @@ if ($action == "setaskforshippingmet") {
 if ($action == "setdisableprospectcustomer") {
 	$setdisableprospectcustomer = GETPOST('value', 'int');
 	$res = dolibarr_set_const($db, "SOCIETE_DISABLE_PROSPECTSCUSTOMERS", $setdisableprospectcustomer, 'yesno', 0, '', $conf->entity);
-	// Remove customer type by default if type prospect/customer is disabled
-	$res = dolibarr_del_const($db, "THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT", $conf->entity);
 	if (!($res > 0)) {
 		$error++;
 	}

--- a/htdocs/societe/admin/societe.php
+++ b/htdocs/societe/admin/societe.php
@@ -1,9 +1,10 @@
 <?php
-/* Copyright (C) 2004      Rodolphe Quiedeville <rodolphe@quiedeville.org>
- * Copyright (C) 2004      Eric Seigne          <eric.seigne@ryxeo.com>
- * Copyright (C) 2005-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
- * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@inodbox.com>
- * Copyright (C) 2011-2012 Juanjo Menent        <jmenent@2byte.es>
+/* Copyright (C) 2004       Rodolphe Quiedeville    <rodolphe@quiedeville.org>
+ * Copyright (C) 2004       Eric Seigne             <eric.seigne@ryxeo.com>
+ * Copyright (C) 2005-2011  Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2005-2012  Regis Houssin           <regis.houssin@inodbox.com>
+ * Copyright (C) 2011-2012  Juanjo Menent           <jmenent@2byte.es>
+ * Copyright (C) 2022       Alexandre Spangaro      <aspangaro@open-dsi.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -225,10 +226,12 @@ if ($action == "setaskforshippingmet") {
 	}
 }
 
-//Activate "Disable prospect/customer type"
+// Activate "Disable prospect/customer type"
 if ($action == "setdisableprospectcustomer") {
 	$setdisableprospectcustomer = GETPOST('value', 'int');
 	$res = dolibarr_set_const($db, "SOCIETE_DISABLE_PROSPECTSCUSTOMERS", $setdisableprospectcustomer, 'yesno', 0, '', $conf->entity);
+	// Remove customer type by default if type prospect/customer is disabled
+	$res = dolibarr_del_const($db, "THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT", $conf->entity);
 	if (!($res > 0)) {
 		$error++;
 	}

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -6,7 +6,7 @@
  * Copyright (C) 2005-2017  Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2008       Patrick Raguin          <patrick.raguin@auguria.net>
  * Copyright (C) 2010-2020  Juanjo Menent           <jmenent@2byte.es>
- * Copyright (C) 2011-2013  Alexandre Spangaro      <aspangaro@open-dsi.fr>
+ * Copyright (C) 2011-2022  Alexandre Spangaro      <aspangaro@open-dsi.fr>
  * Copyright (C) 2015       Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2015       Marcos García           <marcosgdf@gmail.com>
  * Copyright (C) 2015       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
@@ -986,21 +986,24 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 		$modCodeFournisseur = new $module;
 
 		// Define if customer/prospect or supplier status is set or not
-		if (GETPOST("type") != 'f') {
+		if (GETPOST("type", 'aZ') != 'f') {
 			$object->client = -1;
 			if (!empty($conf->global->THIRDPARTY_CUSTOMERPROSPECT_BY_DEFAULT)) {
 				$object->client = 3;
 			}
 		}
 		// Prospect / Customer
-		if (GETPOST("type") == 'c') {
+		if (GETPOST("type", 'aZ') == 'c') {
 			if (!empty($conf->global->THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT)) {
 				$object->client = $conf->global->THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT;
 			} else {
 				$object->client = 3;
 			}
 		}
-		if (GETPOST("type") == 'p') {
+		if (!empty($conf->global->SOCIETE_DISABLE_PROSPECTSCUSTOMERS)) {
+			$object->client = 1;
+		}
+		if (GETPOST("type", 'aZ') == 'p') {
 			$object->client = 2;
 		}
 		if (((!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || !empty($conf->supplier_order->enabled) || !empty($conf->supplier_invoice->enabled)) && (GETPOST("type") == 'f' || (GETPOST("type") == '' && !empty($conf->global->THIRDPARTY_SUPPLIER_BY_DEFAULT)))) {
@@ -1757,21 +1760,21 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 
 			if (GETPOSTISSET('name')) {
 				// We overwrite with values if posted
-				$object->name = GETPOST('name', 'alphanohtml');
-				$object->prefix_comm			= GETPOST('prefix_comm', 'alphanohtml');
-				$object->client = GETPOST('client', 'int');
-				$object->code_client			= GETPOST('customer_code', 'alpha');
-				$object->fournisseur			= GETPOST('fournisseur', 'int');
-				$object->code_fournisseur = GETPOST('supplier_code', 'alpha');
-				$object->address = GETPOST('address', 'alphanohtml');
-				$object->zip = GETPOST('zipcode', 'alphanohtml');
-				$object->town = GETPOST('town', 'alphanohtml');
-				$object->country_id = GETPOST('country_id') ?GETPOST('country_id', 'int') : $mysoc->country_id;
-				$object->state_id = GETPOST('state_id', 'int');
-				//$object->skype				= GETPOST('skype', 'alpha');
-				//$object->twitter				= GETPOST('twitter', 'alpha');
-				//$object->facebook				= GETPOST('facebook', 'alpha');
-				//$object->linkedin				= GETPOST('linkedin', 'alpha');
+				$object->name				= GETPOST('name', 'alphanohtml');
+				$object->prefix_comm		= GETPOST('prefix_comm', 'alphanohtml');
+				$object->client				= GETPOST('client', 'int');
+				$object->code_client		= GETPOST('customer_code', 'alpha');
+				$object->fournisseur		= GETPOST('fournisseur', 'int');
+				$object->code_fournisseur	= GETPOST('supplier_code', 'alpha');
+				$object->address			= GETPOST('address', 'alphanohtml');
+				$object->zip				= GETPOST('zipcode', 'alphanohtml');
+				$object->town				= GETPOST('town', 'alphanohtml');
+				$object->country_id			= GETPOST('country_id') ?GETPOST('country_id', 'int') : $mysoc->country_id;
+				$object->state_id			= GETPOST('state_id', 'int');
+				//$object->skype			= GETPOST('skype', 'alpha');
+				//$object->twitter			= GETPOST('twitter', 'alpha');
+				//$object->facebook			= GETPOST('facebook', 'alpha');
+				//$object->linkedin			= GETPOST('linkedin', 'alpha');
 				$object->socialnetworks = array();
 				if (!empty($conf->socialnetworks->enabled)) {
 					foreach ($socialnetworks as $key => $value) {

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1000,7 +1000,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 				$object->client = 3;
 			}
 		}
-		if (!empty($conf->global->SOCIETE_DISABLE_PROSPECTSCUSTOMERS)) {
+		if (!empty($conf->global->SOCIETE_DISABLE_PROSPECTSCUSTOMERS) && $object->client == 3) {
 			$object->client = 1;
 		}
 		if (GETPOST("type", 'aZ') == 'p') {


### PR DESCRIPTION
# Instructions

1. Define customer type by default on prospect/customer

![image](https://user-images.githubusercontent.com/2341395/153753865-55fda13c-5d26-4435-8673-75a1b2910890.png)


2. Disable customer type prospect/customer

![image](https://user-images.githubusercontent.com/2341395/153753772-54611426-cbda-4491-99ba-aff4329aecb1.png)


Now, create new customer with menu entry : 

![image](https://user-images.githubusercontent.com/2341395/153754013-567df907-3f3c-4aae-aea1-e8413a31e56b.png)


Solution : 
Force to value "Customer" (1) if type customer/prospect in closed. 
