### PR TITLE
FIX : There's no field "ref" in llx_facture_fourn_rec table

### DIFF
--- a/htdocs/install/mysql/tables/llx_facture_fourn_rec.key.sql
+++ b/htdocs/install/mysql/tables/llx_facture_fourn_rec.key.sql
@@ -16,7 +16,7 @@
 -- ============================================================================
 
 
-ALTER TABLE llx_facture_fourn_rec ADD UNIQUE INDEX uk_facture_fourn_rec_ref (ref, entity);
+ALTER TABLE llx_facture_fourn_rec ADD UNIQUE INDEX uk_facture_fourn_rec_ref (titre, entity);
 ALTER TABLE llx_facture_fourn_rec ADD UNIQUE INDEX uk_facture_fourn_rec_ref_supplier (ref_supplier, fk_soc, entity);
 
 ALTER TABLE llx_facture_fourn_rec ADD INDEX idx_facture_fourn_rec_date_lim_reglement (date_lim_reglement);


### PR DESCRIPTION
### FIX : There's no field "ref" in llx_facture_fourn_rec table

![image](https://user-images.githubusercontent.com/67913809/153871794-cab75a0d-a6f3-4b0f-bdf9-0bdbde9158f7.png)

An error occures when we tried to install a develop Dolibarr
It's caused by  "llx_facture_fourn_rec" table keys 