### PR TITLE
Fixes expensereport downloads

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -892,8 +892,10 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 			}
 			if ($feature == 'expensereport') {
 				$useridtocheck = $object->fk_user_author;
-				if (!in_array($useridtocheck, $childids)) {
-					return false;
+				if (!$user->rights->expensereport->readall) {
+					if (!in_array($useridtocheck, $childids)) {
+						return false;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# FIX a bug when downloading files from expense  reports of others (childs)
When a user has the permission to see N-1's expense reports, he could not download the files anymore.

This fix add a check to allow downloading files.
