### PR TITLE
FIX weight is lost if it's comma on combinations card

### DIFF
--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -235,7 +235,7 @@ if (($action == 'add' || $action == 'create') && empty($massaction) && !GETPOST(
 		exit();
 	}
 
-	$prodcomb->variation_weight = $weight_impact;
+	$prodcomb->variation_weight = price2num($weight_impact);
 
 	// for conf PRODUIT_MULTIPRICES
 	if ($conf->global->PRODUIT_MULTIPRICES) {


### PR DESCRIPTION
When you edit a line where weight is a decimal qty, weight input use a comma then in save it doesnt work