### PR TITLE
More generic management of parentline

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1213,7 +1213,7 @@ class Propal extends CommonObject
 							break;
 						}
 						// Defined the new fk_parent_line
-						if ($result > 0 && $line->product_type == 9) {
+						if ($result > 0) {
 							$fk_parent_line = $result;
 						}
 					}

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -401,7 +401,7 @@ if (empty($reshook))
 								}
 
 								// Defined the new fk_parent_line
-								if ($result > 0 && $lines[$i]->product_type == 9) {
+								if ($result > 0) {
 									$fk_parent_line = $result;
 								}
 							}

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1054,7 +1054,7 @@ class Commande extends CommonOrder
 						return -1;
 					}
 					// Defined the new fk_parent_line
-					if ($result > 0 && $line->product_type == 9) {
+					if ($result > 0) {
 						$fk_parent_line = $result;
 					}
 				}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1220,7 +1220,7 @@ if (empty($reshook))
 							$object->lines[] = $line; // insert new line in current object
 
 							// Defined the new fk_parent_line
-							if ($result > 0 && $line->product_type == 9) {
+							if ($result > 0) {
 								$fk_parent_line = $result;
 							}
 						}
@@ -1666,7 +1666,7 @@ if (empty($reshook))
 										}
 
 										// Defined the new fk_parent_line
-										if ($result > 0 && $lines[$i]->product_type == 9) {
+										if ($result > 0) {
 											$fk_parent_line = $result;
 										}
 									}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -790,7 +790,7 @@ class Facture extends CommonInvoice
 						$result = $newinvoiceline->insert();
 
 						// Defined the new fk_parent_line
-						if ($result > 0 && $newinvoiceline->product_type == 9) {
+						if ($result > 0) {
 							$fk_parent_line = $result;
 						}
 					}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -755,6 +755,9 @@ class Facture extends CommonInvoice
 				foreach ($this->lines as $i => $val)
 				{
 					$newinvoiceline = $this->lines[$i];
+
+					$newinvoiceline->context = $this->context;
+
 					$newinvoiceline->fk_facture = $this->id;
 
 					$newinvoiceline->origin = $this->lines[$i]->element;


### PR DESCRIPTION
Parent line information was lost during workflows, clones, or manual creation from (ie when creating an order from a propal).
The fix was to memorize parent line information even for non subtotal lines (product type 9).
It is useful for other external modules than subtotal (ie ecotaxdeee with product type = 2).
Please note that i also had to memorize context on lines when cloning an invoice (the process is strangely different than clone of orders or propals)