### PR TITLE
FIX : translation string instead of error message text

### DIFF
--- a/htdocs/langs/en_US/productbatch.lang
+++ b/htdocs/langs/en_US/productbatch.lang
@@ -41,3 +41,5 @@ QCFrequency=Quality control frequency (in days)
 #Traceability - qc status
 OutOfOrder=Out of order
 InWorkingOrder=In working order
+
+CantMoveNonExistantSerial=Error. You ask a move on a record for a serial that does not exists anymore. May be you take the same serial on same warehouse several times in same shipment or it was used by another shipment. Remove this shipment and prepare another one.

--- a/htdocs/langs/fr_FR/productbatch.lang
+++ b/htdocs/langs/fr_FR/productbatch.lang
@@ -42,3 +42,4 @@ HideLots=Masquer les lots
 #Traceability - qc status
 OutOfOrder=Hors d'usage
 InWorkingOrder=En état de marche
+CantMoveNonExistantSerial=Erreur : Vous avez demandé un mouvement sur un numéro de série qui n’existe plus. Peut-être avez-vous requis le même numéro de série plusieurs fois dans une même expédition, ou il a déjà servi dans une autre expédition. Supprimez cette expédition et préparez-en une autre.

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -842,7 +842,9 @@ class MouvementStock extends CommonObject
 	 */
 	private function createBatch($dluo, $qty)
 	{
-		global $user;
+		global $user, $langs;
+
+		$langs->load('productbatch');
 
 		$pdluo = new Productbatch($this->db);
 
@@ -853,7 +855,7 @@ class MouvementStock extends CommonObject
 			$result = $pdluo->fetch($dluo);
 			if (empty($pdluo->id)) {
 				// We didn't find the line. May be it was deleted before by a previous move in same transaction.
-				$this->error = 'Error. You ask a move on a record for a serial that does not exists anymore. May be you take the same serial on same warehouse several times in same shipment or it was used by another shipment. Remove this shipment and prepare another one.';
+				$this->error = $langs->trans('CantMoveNonExistantSerial');
 				$this->errors[] = $this->error;
 				$result = -2;
 			}


### PR DESCRIPTION
When we ask for an impossible stock mouvement on an inaccessible serial number, we have an error message in english, embedded in MouvementStock::createBatch(). This PR replaces the message with a translation string.
![image](https://user-images.githubusercontent.com/81741011/154293112-25aba169-5590-4fd3-9164-38e89051a698.png)
