### PR TITLE
fix: ticket return list creates db error syntax

### DIFF
--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -391,7 +391,7 @@ foreach ($search as $key => $val) {
 		continue;
 	}
 	$mode_search = (($object->isInt($object->fields[$key]) || $object->isFloat($object->fields[$key])) ? 1 : 0);
-	if ($search[$key] != '') {
+	if ($search[$key] != '' && !empty($val)) {
 		$sql .= natural_search($key, $search[$key], $mode_search);
 	}
 }
@@ -609,9 +609,9 @@ if ($limit > 0 && $limit != $conf->liste_limit) {
 	$param .= '&limit='.urlencode($limit);
 }
 foreach ($search as $key => $val) {
-	if (is_array($search[$key]) && count($search[$key])) {
-		foreach ($search[$key] as $skey) {
-			$param .= '&search_'.$key.'[]='.urlencode($skey);
+	if (is_array($val) && count($val)) {
+		foreach ($val as $skey) {
+			$param .= (!empty($val)) ? '&search_'.$key.'[]='.urlencode($skey) : "";
 		}
 	} else {
 		$param .= '&search_'.$key.'='.urlencode($search[$key]);

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -391,7 +391,7 @@ foreach ($search as $key => $val) {
 		continue;
 	}
 	$mode_search = (($object->isInt($object->fields[$key]) || $object->isFloat($object->fields[$key])) ? 1 : 0);
-	if ($search[$key] != '' && !empty($val)) {
+	if ($search[$key] != '' && !is_array($val)) {
 		$sql .= natural_search($key, $search[$key], $mode_search);
 	}
 }


### PR DESCRIPTION
Fix for https://github.com/Dolibarr/dolibarr/issues/19589
This is a duplicate PR, previous one https://github.com/Dolibarr/dolibarr/pull/19076 seems old.

When accessing a ticket from a Thirdparty, then clicking on "return to list", one would get an error page, see below.

![db_error_syntax](https://user-images.githubusercontent.com/89838020/154306540-222d54b1-3701-4f08-bda3-9d3e8d2965fb.png)

