### PR TITLE
fix ticket: wrong link sent to customer

### DIFF
--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -211,7 +211,7 @@ if ($action == 'create_ticket' && GETPOST('add', 'alpha')) {
 				$message .= ($conf->global->TICKET_MESSAGE_MAIL_NEW ? $conf->global->TICKET_MESSAGE_MAIL_NEW : $langs->transnoentities('TicketNewEmailBody'))."\n\n";
 				$message .= $langs->transnoentities('TicketNewEmailBodyInfosTicket')."\n";
 
-				$url_public_ticket = ($conf->global->TICKET_URL_PUBLIC_INTERFACE ? $conf->global->TICKET_URL_PUBLIC_INTERFACE : dol_buildpath('/public/ticket', 2)).'/view.php?track_id='.$object->track_id;
+				$url_public_ticket = ($conf->global->TICKET_URL_PUBLIC_INTERFACE ? $conf->global->TICKET_URL_PUBLIC_INTERFACE.'/view.php' : dol_buildpath('/public/ticket/view.php', 2)).'?track_id='.$object->track_id;
 				$infos_new_ticket = $langs->transnoentities('TicketNewEmailBodyInfosTrackId', '<a href="'.$url_public_ticket.'">'.$object->track_id.'</a>')."\n";
 				$infos_new_ticket .= $langs->transnoentities('TicketNewEmailBodyInfosTrackUrl')."\n\n";
 

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -211,7 +211,7 @@ if ($action == 'create_ticket' && GETPOST('add', 'alpha')) {
 				$message .= ($conf->global->TICKET_MESSAGE_MAIL_NEW ? $conf->global->TICKET_MESSAGE_MAIL_NEW : $langs->transnoentities('TicketNewEmailBody'))."\n\n";
 				$message .= $langs->transnoentities('TicketNewEmailBodyInfosTicket')."\n";
 
-				$url_public_ticket = ($conf->global->TICKET_URL_PUBLIC_INTERFACE ? $conf->global->TICKET_URL_PUBLIC_INTERFACE.'/' : dol_buildpath('/public/ticket/view.php', 2)).'?track_id='.$object->track_id;
+				$url_public_ticket = ($conf->global->TICKET_URL_PUBLIC_INTERFACE ? $conf->global->TICKET_URL_PUBLIC_INTERFACE : dol_buildpath('/public/ticket', 2)).'/view.php?track_id='.$object->track_id;
 				$infos_new_ticket = $langs->transnoentities('TicketNewEmailBodyInfosTrackId', '<a href="'.$url_public_ticket.'">'.$object->track_id.'</a>')."\n";
 				$infos_new_ticket .= $langs->transnoentities('TicketNewEmailBodyInfosTrackUrl')."\n\n";
 


### PR DESCRIPTION
When sending an email to the customer,
If a custom URL had been provided for ticket public interface,
the link provided in the email did lead to the index of the public interface.
We want it to lead to /view.php

example of current behavior:

- my public ticket interface has a custom URL https://custom.dolibarr.fr
- A customer creates a ticket
- A confirmation email is sent to them
- This email contains a link **to the ticket** that leads to https://custom.dolibarr.fr/?track_id=<track_id>
- this is the index page that does not show the ticket in any way.

Expected behavior :
- I want this link to lead to the view page : https://custom.dolibarr.fr/view.php?track_id=<track_id>