### PR TITLE
Fix bug - List of supplier order - to show total line

### DIFF
--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -1274,9 +1274,7 @@ if ($resql) {
 	$projectstatic = new Project($db);
 
 	$i = 0;
-	$totalarray = array();
-	$totalarray['nbfield'] = 0;
-	$totalarray['val'] = array();
+	$totalarray = array('nbfield' => 0, 'val' => array(), 'pos' => array());
 	$totalarray['val']['cf.total_ht'] = 0;
 	$totalarray['val']['cf.total_ttc'] = 0;
 	while ($i < min($num, $limit)) {


### PR DESCRIPTION
To tally with the array setup in list_print_total.tpl.php, then the total line will show up.