### PR TITLE
FIX compute rule in FEC import

### DIFF
--- a/htdocs/accountancy/class/accountancyimport.class.php
+++ b/htdocs/accountancy/class/accountancyimport.class.php
@@ -55,8 +55,8 @@ class AccountancyImport
 			$fieldname = $fieldArr[1];
 		}
 
-		$debit  = trim($arrayrecord[11]['val']);
-		$credit = trim($arrayrecord[12]['val']);
+		$debit  = floatval(trim($arrayrecord[11]['val']));
+		$credit = floatval(trim($arrayrecord[12]['val']));
 		if (!empty($debit)) {
 			$amount = $debit;
 		} else {
@@ -86,7 +86,7 @@ class AccountancyImport
 			$fieldname = $fieldArr[1];
 		}
 
-		$debit = trim($arrayrecord[11]['val']);
+		$debit = floatval(trim($arrayrecord[11]['val']));
 		if (!empty($debit)) {
 			$sens = 'D';
 		} else {

--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -736,6 +736,29 @@ class ImportCsv extends ModeleImports
 							$tmp = explode('-', $val, 2);
 							$listfields[] = preg_replace('/^'.preg_quote($alias, '/').'\./', '', $key);
 							$listvalues[] = "'".$tmp[1]."'";
+						} elseif (preg_match('/^rule-/', $val)) {
+							$fieldname = $key;
+							if (!empty($objimport->array_import_convertvalue[0][$fieldname])) {
+								if ($objimport->array_import_convertvalue[0][$fieldname]['rule'] == 'compute') {
+									$file = (empty($objimport->array_import_convertvalue[0][$fieldname]['classfile']) ? $objimport->array_import_convertvalue[0][$fieldname]['file'] : $objimport->array_import_convertvalue[0][$fieldname]['classfile']);
+									$class = $objimport->array_import_convertvalue[0][$fieldname]['class'];
+									$method = $objimport->array_import_convertvalue[0][$fieldname]['method'];
+									$resultload = dol_include_once($file);
+									if (empty($resultload)) {
+										dol_print_error('', 'Error trying to call file=' . $file . ', class=' . $class . ', method=' . $method);
+										break;
+									}
+									$classinstance = new $class($this->db);
+									$res = call_user_func_array(array($classinstance, $method), array(&$arrayrecord, $fieldname, &$listfields, &$listvalues));
+									if ($res < 0) {
+										if (!empty($objimport->array_import_convertvalue[0][$fieldname]['dict'])) $this->errors[$error]['lib'] = $langs->trans('ErrorFieldValueNotIn', $key, end($listvalues), 'code', $langs->transnoentitiesnoconv($objimport->array_import_convertvalue[0][$fieldname]['dict']));
+										else $this->errors[$error]['lib'] = 'ErrorFieldValueNotIn';
+										$this->errors[$error]['type'] = 'FOREIGNKEY';
+										$errorforthistable++;
+										$error++;
+									}
+								}
+							}
 						} else {
 							$this->errors[$error]['lib'] = 'Bad value of profile setup '.$val.' for array_import_fieldshidden';
 							$this->errors[$error]['type'] = 'Import profile setup';

--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -141,6 +141,7 @@ $endatlinenb		= (GETPOST('endatlinenb') ? GETPOST('endatlinenb') : '');
 $updatekeys			= (GETPOST('updatekeys', 'array') ? GETPOST('updatekeys', 'array') : array());
 $separator			= (GETPOST('separator', 'nohtml') ? GETPOST('separator', 'nohtml') : (!empty($conf->global->IMPORT_CSV_SEPARATOR_TO_USE) ? $conf->global->IMPORT_CSV_SEPARATOR_TO_USE : ','));
 $enclosure			= (GETPOST('enclosure', 'nohtml') ? GETPOST('enclosure', 'nohtml') : '"');
+$separator_used     = str_replace('\t', "\t", $separator);
 
 $objimport = new Import($db);
 $objimport->load_arrays($user, ($step == 1 ? '' : $datatoimport));
@@ -773,7 +774,7 @@ if ($step == 4 && $datatoimport) {
 	require_once $dir.$file;
 	$obj = new $classname($db, $datatoimport);
 	if ($model == 'csv') {
-		$obj->separator = $separator;
+		$obj->separator = $separator_used;
 		$obj->enclosure = $enclosure;
 	}
 	if ($model == 'xlsx') {
@@ -1334,7 +1335,7 @@ if ($step == 5 && $datatoimport) {
 	require_once $dir.$file;
 	$obj = new $classname($db, $datatoimport);
 	if ($model == 'csv') {
-		$obj->separator = $separator;
+		$obj->separator = $separator_used;
 		$obj->enclosure = $enclosure;
 	}
 
@@ -1783,7 +1784,7 @@ if ($step == 6 && $datatoimport) {
 	require_once $dir.$file;
 	$obj = new $classname($db, $datatoimport);
 	if ($model == 'csv') {
-		$obj->separator = $separator;
+		$obj->separator = $separator_used;
 		$obj->enclosure = $enclosure;
 	}
 


### PR DESCRIPTION
FIX compute rule in FEC import
- fix CSV separator (tabulation is not supported with GETPOST filters) and now "\t" character is used to replace it
- add rule to compute hidden fields (the field is not in import file but is in accounting table) such as "b.montant" and "b.sens"