### PR TITLE
FIX: viewimage.php blocks requests with multicompany from other enties

### DIFF
--- a/htdocs/viewimage.php
+++ b/htdocs/viewimage.php
@@ -185,7 +185,7 @@ $refname = basename(dirname($original_file)."/");
 // Security check
 if (empty($modulepart)) accessforbidden('Bad value for parameter modulepart', 0, 0, 1);
 
-$check_access = dol_check_secure_access_document($modulepart, $original_file, $entity, $refname);
+$check_access = dol_check_secure_access_document($modulepart, $original_file, $entity, $user, $refname);
 $accessallowed              = $check_access['accessallowed'];
 $sqlprotectagainstexternals = $check_access['sqlprotectagainstexternals'];
 $fullpath_original_file     = $check_access['original_file']; // $fullpath_original_file is now a full path name


### PR DESCRIPTION
Because of a bad call to dol_check_secure_access_document() since v3.5, when $user param was added !