### PR TITLE
FIX Invoice - When you create an invoice and defined a thirdparty, fk_account is not retrieved from company card FPC21+

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2898,6 +2898,9 @@ if ($action == 'create') {
 			if (empty($mode_reglement_id)) {
 				$mode_reglement_id = $soc->mode_reglement_id;
 			}
+			if (empty($fk_account)) {
+				$fk_account = $soc->fk_account;
+			}
 			if (!$remise_percent) {
 				$remise_percent = $soc->remise_percent;
 			}
@@ -3003,6 +3006,11 @@ if ($action == 'create') {
 	// when payment mode is empty (means not override by payment mode form a other object, like third-party), try to use default value
 	if (empty($mode_reglement_id)) {
 		$mode_reglement_id = GETPOST("mode_reglement_id", 'int');
+	}
+
+	// when bank account is empty (means not override by payment mode form a other object, like third-party), try to use default value
+	if (empty($fk_account)) {
+		$fk_account = GETPOST("fk_account", 'int');
 	}
 
 	if (!empty($soc->id)) {
@@ -3607,8 +3615,8 @@ if ($action == 'create') {
 	// Bank Account
 	if (!empty($conf->banque->enabled)) {
 		print '<tr><td>'.$langs->trans('BankAccount').'</td><td colspan="2">';
-		$fk_account = GETPOST('fk_account', 'int');
-		print img_picto('', 'bank_account', 'class="pictofixedwidth"').$form->select_comptes(($fk_account < 0 ? '' : $fk_account), 'fk_account', 0, '', 1, '', 0, 'maxwidth200 widthcentpercentminusx', 1);
+		print img_picto('', 'bank_account', 'class="pictofixedwidth"');
+		print $form->select_comptes(GETPOSTISSET('fk_account') ? GETPOST('fk_account') : $fk_account, 'fk_account', 0, '', 1, '', 0, 'maxwidth200 widthcentpercentminusx', 1);
 		print '</td></tr>';
 	}
 

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3009,9 +3009,7 @@ if ($action == 'create') {
 	}
 
 	// when bank account is empty (means not override by payment mode form a other object, like third-party), try to use default value
-	if (empty($fk_account)) {
-		$fk_account = GETPOST("fk_account", 'int');
-	}
+	$fk_account = GETPOSTISSET("fk_account") ? GETPOST("fk_account", 'int') : $fk_account;
 
 	if (!empty($soc->id)) {
 		$absolute_discount = $soc->getAvailableDiscounts();
@@ -3616,7 +3614,7 @@ if ($action == 'create') {
 	if (!empty($conf->banque->enabled)) {
 		print '<tr><td>'.$langs->trans('BankAccount').'</td><td colspan="2">';
 		print img_picto('', 'bank_account', 'class="pictofixedwidth"');
-		print $form->select_comptes(GETPOSTISSET('fk_account') ? GETPOST('fk_account') : $fk_account, 'fk_account', 0, '', 1, '', 0, 'maxwidth200 widthcentpercentminusx', 1);
+		print $form->select_comptes($fk_account, 'fk_account', 0, '', 1, '', 0, 'maxwidth200 widthcentpercentminusx', 1);
 		print '</td></tr>';
 	}
 


### PR DESCRIPTION
If you are defined a bank account in company card, try to create an invoice. Bank account is not retrieved.

![image](https://user-images.githubusercontent.com/2341395/155264908-3ae3ea6d-5ba1-4ebb-9aa6-68f4e281dc53.png)

![image](https://user-images.githubusercontent.com/2341395/155264982-85ba80c7-860a-4f26-bf4a-d02c96ba64d6.png)
