### PR TITLE
Set default ticket type to OTHER if no default exists

### DIFF
--- a/htdocs/install/mysql/data/llx_c_ticket_type.sql
+++ b/htdocs/install/mysql/data/llx_c_ticket_type.sql
@@ -23,4 +23,4 @@ INSERT INTO llx_c_ticket_type (code, pos, label, active, use_default, descriptio
 INSERT INTO llx_c_ticket_type (code, pos, label, active, use_default, description) VALUES('PROBLEM', '22', 'Problem',                       0, 0, NULL);
 INSERT INTO llx_c_ticket_type (code, pos, label, active, use_default, description) VALUES('REQUEST', '25', 'Change or enhancement request', 1, 0, NULL);
 INSERT INTO llx_c_ticket_type (code, pos, label, active, use_default, description) VALUES('PROJECT', '30', 'Project',                       0, 0, NULL);
-INSERT INTO llx_c_ticket_type (code, pos, label, active, use_default, description) VALUES('OTHER',   '40', 'Other',                         1, 0, NULL);
+INSERT INTO llx_c_ticket_type (code, pos, label, active, use_default, description) VALUES('OTHER',   '40', 'Other',                         1, 1, NULL);

--- a/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
+++ b/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
@@ -251,3 +251,5 @@ ALTER TABLE llx_reception MODIFY COLUMN ref_supplier varchar(128);
 
 ALTER TABLE llx_bank_account ADD COLUMN pti_in_ctti smallint DEFAULT 0 AFTER domiciliation;
 
+-- Set default ticket type to OTHER if no default exists
+UPDATE llx_c_ticket_type SET use_default=1 WHERE code='OTHER' AND NOT EXISTS(SELECT * FROM (SELECT * FROM llx_c_ticket_type) AS t WHERE use_default=1);


### PR DESCRIPTION
In 15.0, no default type causes tickets created by the e-mail collector to show `TicketTypeShort` in the column Type of the ticket list.