### PR TITLE
Fix extrafields view and perms on list

### DIFF
--- a/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
@@ -23,9 +23,9 @@ if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table
 				$arrayfields[$extrafieldsobjectprefix.$key] = array(
 					'label'    => $extrafields->attributes[$extrafieldsobjectkey]['label'][$key],
 					'type'     => $extrafields->attributes[$extrafieldsobjectkey]['type'][$key],
-					'checked'  => ((dol_eval($extrafields->attributes[$extrafieldsobjectkey]['list'][$key],1) <= 0) ? 0 : 1),
+					'checked'  => ((dol_eval($extrafields->attributes[$extrafieldsobjectkey]['list'][$key], 1) <= 0) ? 0 : 1),
 					'position' => $extrafields->attributes[$extrafieldsobjectkey]['pos'][$key],
-					'enabled'  => (abs((int) $extrafields->attributes[$extrafieldsobjectkey]['list'][$key]) != 3 && dol_eval($extrafields->attributes[$extrafieldsobjectkey]['perms'][$key],1)),
+					'enabled'  => (abs((int) $extrafields->attributes[$extrafieldsobjectkey]['list'][$key]) != 3 && dol_eval($extrafields->attributes[$extrafieldsobjectkey]['perms'][$key], 1)),
 					'langfile' => $extrafields->attributes[$extrafieldsobjectkey]['langfile'][$key],
 					'help'     => $extrafields->attributes[$extrafieldsobjectkey]['help'][$key],
 				);

--- a/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
@@ -18,13 +18,12 @@ if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table
 		if (empty($extrafieldsobjectprefix)) {
 			$extrafieldsobjectprefix = 'ef.';
 		}
-
 		foreach ($extrafields->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
 			if (!empty($extrafields->attributes[$extrafieldsobjectkey]['list'][$key])) {
 				$arrayfields[$extrafieldsobjectprefix.$key] = array(
 					'label'    => $extrafields->attributes[$extrafieldsobjectkey]['label'][$key],
 					'type'     => $extrafields->attributes[$extrafieldsobjectkey]['type'][$key],
-					'checked'  => (($extrafields->attributes[$extrafieldsobjectkey]['list'][$key] < 0) ? 0 : 1),
+					'checked'  => ((dol_eval($extrafields->attributes[$extrafieldsobjectkey]['list'][$key],1) <= 0) ? 0 : 1),
 					'position' => $extrafields->attributes[$extrafieldsobjectkey]['pos'][$key],
 					'enabled'  => (abs((int) $extrafields->attributes[$extrafieldsobjectkey]['list'][$key]) != 3 && $extrafields->attributes[$extrafieldsobjectkey]['perms'][$key]),
 					'langfile' => $extrafields->attributes[$extrafieldsobjectkey]['langfile'][$key],

--- a/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
@@ -25,7 +25,7 @@ if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table
 					'type'     => $extrafields->attributes[$extrafieldsobjectkey]['type'][$key],
 					'checked'  => ((dol_eval($extrafields->attributes[$extrafieldsobjectkey]['list'][$key],1) <= 0) ? 0 : 1),
 					'position' => $extrafields->attributes[$extrafieldsobjectkey]['pos'][$key],
-					'enabled'  => (abs((int) $extrafields->attributes[$extrafieldsobjectkey]['list'][$key]) != 3 && $extrafields->attributes[$extrafieldsobjectkey]['perms'][$key]),
+					'enabled'  => (abs((int) $extrafields->attributes[$extrafieldsobjectkey]['list'][$key]) != 3 && dol_eval($extrafields->attributes[$extrafieldsobjectkey]['perms'][$key],1)),
 					'langfile' => $extrafields->attributes[$extrafieldsobjectkey]['langfile'][$key],
 					'help'     => $extrafields->attributes[$extrafieldsobjectkey]['help'][$key],
 				);


### PR DESCRIPTION
# FIX extrafields visibility on lists
On the extrafields setup, the help tooltip for visibility says that it can be an expression like "($conf->mymodule->enabled && $user->rights->mymodule->read ? 5 : 0)".
This expression wasn't evaluated...

The perms of the extrafields can be an expression too like "$conf->mymodule->enabled" and must be evaluated too

