### PR TITLE
FIX #20208 regression V15 delete link action 

### DIFF
--- a/htdocs/core/tpl/document_actions_post_headers.tpl.php
+++ b/htdocs/core/tpl/document_actions_post_headers.tpl.php
@@ -66,7 +66,7 @@ if (in_array($modulepart, array('product', 'produit', 'societe', 'user', 'ticket
  * Confirm form to delete a file
  */
 
-if ($action == 'deletefile') {
+if ($action == 'deletefile' || $action == 'delete') {
 	$langs->load("companies"); // Need for string DeleteFile+ConfirmDeleteFiles
 	print $form->formconfirm(
 		$_SERVER["PHP_SELF"].'?id='.$object->id.'&urlfile='.urlencode(GETPOST("urlfile")).'&linkid='.GETPOST('linkid', 'int').(empty($param) ? '' : $param),


### PR DESCRIPTION
# FIX : delete link action
Starting from V15 you can no longer delete URL links in the linked files tab.