### PR TITLE
Fix: update status_batch documentation

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -272,7 +272,7 @@ class Product extends CommonObject
 	public $fk_default_bom;
 
 	/**
-	 * We must manage lot/batch number, sell-by date and so on : '1':yes '0':no
+	 * We must manage lot/batch number, sell-by date and so on : '0':no, '1':yes, '2": yes with unique serial number
 	 *
 	 * @var int
 	 */


### PR DESCRIPTION
$product->status_batch has a new possible value that was not documented.

# Fix update status_batch documentation
[*Long description*]
Several month ago, a new value for product->status_batch was added: if it is 2, you must have unique serial numbers. But this value was not documented in the class file. 
