### PR TITLE
Fix: typo in template name

### DIFF
--- a/htdocs/adherents/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/adherents/tpl/linkedobjectblock.tpl.php
@@ -23,7 +23,7 @@ if (empty($conf) || !is_object($conf)) {
 	exit;
 }
 
-echo "<!-- BEGIN PHP TEMPLATE adherents/tpl/linkedopjectblock.tpl.php -->\n";
+echo "<!-- BEGIN PHP TEMPLATE adherents/tpl/linkedobjectblock.tpl.php -->\n";
 
 global $user;
 

--- a/htdocs/asset/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/asset/tpl/linkedobjectblock.tpl.php
@@ -23,7 +23,7 @@ if (empty($conf) || !is_object($conf)) {
 	exit;
 }
 
-print "<!-- BEGIN PHP TEMPLATE commande/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE commande/tpl/linkedobjectblock.tpl.php -->\n";
 
 global $user;
 global $noMoreLinkedObjectBlockAfter;

--- a/htdocs/bom/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/bom/tpl/linkedobjectblock.tpl.php
@@ -24,7 +24,7 @@ if (empty($conf) || !is_object($conf)) {
 	exit;
 }
 
-print "<!-- BEGIN PHP TEMPLATE bom/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE bom/tpl/linkedobjectblock.tpl.php -->\n";
 
 global $user, $db;
 global $noMoreLinkedObjectBlockAfter;

--- a/htdocs/comm/propal/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/comm/propal/tpl/linkedobjectblock.tpl.php
@@ -30,7 +30,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 
-print "<!-- BEGIN PHP TEMPLATE comm/propal/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE comm/propal/tpl/linkedobjectblock.tpl.php -->\n";
 
 global $user;
 

--- a/htdocs/commande/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/commande/tpl/linkedobjectblock.tpl.php
@@ -23,7 +23,7 @@ if (empty($conf) || !is_object($conf)) {
 	exit;
 }
 
-print "<!-- BEGIN PHP TEMPLATE commande/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE commande/tpl/linkedobjectblock.tpl.php -->\n";
 
 global $user;
 global $noMoreLinkedObjectBlockAfter;

--- a/htdocs/compta/facture/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/compta/facture/tpl/linkedobjectblock.tpl.php
@@ -23,7 +23,7 @@ if (empty($conf) || !is_object($conf)) {
 	exit;
 }
 
-print "<!-- BEGIN PHP TEMPLATE compta/facture/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE compta/facture/tpl/linkedobjectblock.tpl.php -->\n";
 
 global $user;
 global $noMoreLinkedObjectBlockAfter;

--- a/htdocs/compta/facture/tpl/linkedobjectblockForRec.tpl.php
+++ b/htdocs/compta/facture/tpl/linkedobjectblockForRec.tpl.php
@@ -24,7 +24,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 
-print "<!-- BEGIN PHP TEMPLATE compta/facture/tpl/linkedopjectblockForRec.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE compta/facture/tpl/linkedobjectblockForRec.tpl.php -->\n";
 
 
 global $user;

--- a/htdocs/contrat/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/contrat/tpl/linkedobjectblock.tpl.php
@@ -23,7 +23,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 
-print "<!-- BEGIN PHP TEMPLATE contrat/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE contrat/tpl/linkedobjectblock.tpl.php -->\n";
 
 
 global $user;

--- a/htdocs/don/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/don/tpl/linkedobjectblock.tpl.php
@@ -19,7 +19,7 @@
  *
  */
 
-print "<!-- BEGIN PHP TEMPLATE don/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE don/tpl/linkedobjectblock.tpl.php -->\n";
 
 global $user;
 global $noMoreLinkedObjectBlockAfter;

--- a/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
@@ -23,7 +23,7 @@ if (empty($conf) || !is_object($conf)) {
 	exit;
 }
 
-echo "<!-- BEGIN PHP TEMPLATE eventorganization/tpl/linkedopjectblock.tpl.php -->\n";
+echo "<!-- BEGIN PHP TEMPLATE eventorganization/tpl/linkedobjectblock.tpl.php -->\n";
 
 global $user;
 

--- a/htdocs/expedition/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/expedition/tpl/linkedobjectblock.tpl.php
@@ -23,7 +23,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 
-print "<!-- BEGIN PHP TEMPLATE expedition/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE expedition/tpl/linkedobjectblock.tpl.php -->\n";
 
 
 global $user;

--- a/htdocs/expensereport/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/expensereport/tpl/linkedobjectblock.tpl.php
@@ -24,7 +24,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 
-print "<!-- BEGIN PHP TEMPLATE expensereport/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE expensereport/tpl/linkedobjectblock.tpl.php -->\n";
 
 
 global $user;

--- a/htdocs/fichinter/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/fichinter/tpl/linkedobjectblock.tpl.php
@@ -22,7 +22,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 
-print "<!-- BEGIN PHP TEMPLATE fichinter/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE fichinter/tpl/linkedobjectblock.tpl.php -->\n";
 
 
 global $user;

--- a/htdocs/fourn/commande/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/fourn/commande/tpl/linkedobjectblock.tpl.php
@@ -23,7 +23,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 
-print "<!-- BEGIN PHP TEMPLATE fourn/commande/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE fourn/commande/tpl/linkedobjectblock.tpl.php -->\n";
 
 
 global $user;

--- a/htdocs/fourn/facture/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/fourn/facture/tpl/linkedobjectblock.tpl.php
@@ -25,7 +25,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 
-print "<!-- BEGIN PHP TEMPLATE fourn/facture/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE fourn/facture/tpl/linkedobjectblock.tpl.php -->\n";
 
 
 global $user;

--- a/htdocs/modulebuilder/template/core/tpl/linkedobjectblock_myobject.tpl.php
+++ b/htdocs/modulebuilder/template/core/tpl/linkedobjectblock_myobject.tpl.php
@@ -22,7 +22,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 
-print "<!-- BEGIN PHP TEMPLATE mymodule/core/tpl/linkedopjectblock_myobject.tpl.php  -->\n";
+print "<!-- BEGIN PHP TEMPLATE mymodule/core/tpl/linkedobjectblock_myobject.tpl.php  -->\n";
 
 
 global $user;

--- a/htdocs/mrp/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/mrp/tpl/linkedobjectblock.tpl.php
@@ -24,7 +24,7 @@ if (empty($conf) || !is_object($conf)) {
 	exit;
 }
 
-print "<!-- BEGIN PHP TEMPLATE mrp/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE mrp/tpl/linkedobjectblock.tpl.php -->\n";
 
 global $user, $db;
 global $noMoreLinkedObjectBlockAfter;

--- a/htdocs/reception/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/reception/tpl/linkedobjectblock.tpl.php
@@ -25,7 +25,7 @@ if (empty($conf) || !is_object($conf)) {
 
 ?>
 
-<!-- BEGIN PHP TEMPLATE reception/tpl/linkedopjectblock.tpl.php  -->
+<!-- BEGIN PHP TEMPLATE reception/tpl/linkedobjectblock.tpl.php  -->
 
 <?php
 

--- a/htdocs/ticket/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/ticket/tpl/linkedobjectblock.tpl.php
@@ -21,7 +21,7 @@ if (empty($conf) || !is_object($conf)) {
 	exit;
 }
 
-print "<!-- BEGIN PHP TEMPLATE ticket/tpl/linkedopjectblock.tpl.php -->\n";
+print "<!-- BEGIN PHP TEMPLATE ticket/tpl/linkedobjectblock.tpl.php -->\n";
 
 
 global $user;


### PR DESCRIPTION
There was a typo in generated HTML comment.

# Fix Typo in template name
[*Long description*]
linkedopjectblock.tpl.php => linkedobjectblock.tpl.php in the «BEGIN PHP TEMPLATE» comment.