### PR TITLE
fix: make ticket messages order by date desc by default

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -59,8 +59,8 @@ $backtopage = GETPOST('$backtopage', 'alpha');
 
 $notifyTiers = GETPOST("notify_tiers_at_create", 'alpha');
 
-$sortfield = GETPOST('sortfield', 'aZ09comma');
-$sortorder = GETPOST('sortorder', 'aZ09comma');
+$sortfield = GETPOST('sortfield', 'aZ09comma') ? GETPOST('sortfield', 'aZ09comma') : "a.datep";
+$sortorder = GETPOST('sortorder', 'aZ09comma') ? GETPOST('sortorder', 'aZ09comma') : "desc";
 
 if (GETPOST('actioncode', 'array')) {
 	$actioncode = GETPOST('actioncode', 'array', 3);


### PR DESCRIPTION
Fix: Order tickets messages by date by default

Ticket messages are not in the right order by default on ticket/card.php (I guess they are sorted by rowid...). TICKET_SHOW_MESSAGES_ON_CARD must be activated to display them.

This fix makes them **ordered by date descending by default**, to have the last message posted visible on top of the list.

current disposition:
![ticket_not_order](https://user-images.githubusercontent.com/89838020/156535775-7a8429d6-12ea-469c-8e8b-087d62fd68cd.png)

After the fix:
![ticket_messages_order](https://user-images.githubusercontent.com/89838020/156535814-b4524848-b946-44e5-b059-a714c418c6fc.png)

