### PR TITLE
Fix #17317 - Add default label for online subscription

### DIFF
--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -447,7 +447,7 @@ if ($ispaymentok) {
 				$amount = $FinalPaymentAmt;
 				// add default label for subscription before paymnetinfo if specified in module setup
 				$label = (empty($conf->global->MEMBER_NO_DEFAULT_LABEL)) ? $langs->trans("Subscription").' '.dol_print_date(($datefrom ? $datefrom :  dol_now()), "%Y") . ' - ': '';
-				$label = 'Online subscription '.dol_print_date($now, 'standard').' using '.$paymentmethod.' from '.$ipaddress.' - Transaction ID = '.$TRANSACTIONID;
+				$label .='Online subscription '.dol_print_date($now, 'standard').' using '.$paymentmethod.' from '.$ipaddress.' - Transaction ID = '.$TRANSACTIONID;
 
 				// Payment informations
 				$accountid = 0;

--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -446,7 +446,7 @@ if ($ispaymentok) {
 				$paymentdate = $now;
 				$amount = $FinalPaymentAmt;
 				// add default label for subscription before paymnetinfo if specified in module setup
-				$label = (empty($conf->global->MEMBER_NO_DEFAULT_LABEL)) ? $langs->trans("Subscription").' '.dol_print_date(($datefrom ? $datefrom : time()), "%Y") . ' - ': '';
+				$label = (empty($conf->global->MEMBER_NO_DEFAULT_LABEL)) ? $langs->trans("Subscription").' '.dol_print_date(($datefrom ? $datefrom :  dol_now()), "%Y") . ' - ': '';
 				$label = 'Online subscription '.dol_print_date($now, 'standard').' using '.$paymentmethod.' from '.$ipaddress.' - Transaction ID = '.$TRANSACTIONID;
 
 				// Payment informations

--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -445,6 +445,8 @@ if ($ispaymentok) {
 
 				$paymentdate = $now;
 				$amount = $FinalPaymentAmt;
+				// add default label for subscription before paymnetinfo if specified in module setup
+				$label = (empty($conf->global->MEMBER_NO_DEFAULT_LABEL)) ? $langs->trans("Subscription").' '.dol_print_date(($datefrom ? $datefrom : time()), "%Y") . ' - ': '';
 				$label = 'Online subscription '.dol_print_date($now, 'standard').' using '.$paymentmethod.' from '.$ipaddress.' - Transaction ID = '.$TRANSACTIONID;
 
 				// Payment informations


### PR DESCRIPTION
#Fix #17317 Subscription label is wrong when member pay online on renew and new form
Add default label for subscription before payment info if specified in module setup
