### PR TITLE
FIX check mandatory thirdparty fields for mass action

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -566,45 +566,6 @@ if (empty($reshook))
 
 		// Check parameters
 
-		// Check for mandatory fields in thirdparty (defined into setup)
-		$array_to_check = array('IDPROF1', 'IDPROF2', 'IDPROF3', 'IDPROF4', 'IDPROF5', 'IDPROF6', 'EMAIL');
-		foreach ($array_to_check as $key)
-		{
-			$keymin = strtolower($key);
-			$i = (int) preg_replace('/[^0-9]/', '', $key);
-			$vallabel = $object->thirdparty->$keymin;
-
-			if ($i > 0)
-			{
-				if ($object->thirdparty->isACompany())
-				{
-					// Check for mandatory prof id (but only if country is other than ours)
-					if ($mysoc->country_id > 0 && $object->thirdparty->country_id == $mysoc->country_id)
-					{
-						$idprof_mandatory = 'SOCIETE_'.$key.'_INVOICE_MANDATORY';
-						if (!$vallabel && !empty($conf->global->$idprof_mandatory))
-						{
-							$langs->load("errors");
-							$error++;
-							setEventMessages($langs->trans('ErrorProdIdIsMandatory', $langs->transcountry('ProfId'.$i, $object->thirdparty->country_code)).' ('.$langs->trans("ForbiddenBySetupRules").')', null, 'errors');
-						}
-					}
-				}
-			} else {
-				//var_dump($conf->global->SOCIETE_EMAIL_MANDATORY);
-				if ($key == 'EMAIL')
-				{
-					// Check for mandatory
-					if (!empty($conf->global->SOCIETE_EMAIL_INVOICE_MANDATORY) && !isValidEMail($object->thirdparty->email))
-					{
-						$langs->load("errors");
-						$error++;
-						setEventMessages($langs->trans("ErrorBadEMail", $object->thirdparty->email).' ('.$langs->trans("ForbiddenBySetupRules").')', null, 'errors');
-					}
-				}
-			}
-		}
-
 		// Check for mandatory fields in invoice
 		$array_to_check = array('REF_CUSTOMER'=>'RefCustomer');
 		foreach ($array_to_check as $key => $val)

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2531,7 +2531,7 @@ class Facture extends CommonInvoice
 						if (!$vallabel && !empty($conf->global->$idprof_mandatory))
 						{
 							$langs->load("errors");
-							$this->error = $langs->trans('ErrorProdIdIsMandatory', $langs->transcountry('ProfId'.$i, $this->thirdparty->country_code)).' ('.$langs->trans("ForbiddenBySetupRules").')'.' ['.$langs->trans('Company').' : '.$this->thirdparty->name.']';
+							$this->error = $langs->trans('ErrorProdIdIsMandatory', $langs->transcountry('ProfId'.$i, $this->thirdparty->country_code)).' ('.$langs->trans("ForbiddenBySetupRules").') ['.$langs->trans('Company').' : '.$this->thirdparty->name.']';
 							dol_syslog(__METHOD__.' '.$this->error, LOG_ERR);
 							return -1;
 						}
@@ -2544,7 +2544,7 @@ class Facture extends CommonInvoice
 					if (!empty($conf->global->SOCIETE_EMAIL_INVOICE_MANDATORY) && !isValidEMail($this->thirdparty->email))
 					{
 						$langs->load("errors");
-						$this->error = $langs->trans("ErrorBadEMail", $this->thirdparty->email).' ('.$langs->trans("ForbiddenBySetupRules").')'.' ['.$langs->trans('Company').' : '.$this->thirdparty->name.']';
+						$this->error = $langs->trans("ErrorBadEMail", $this->thirdparty->email).' ('.$langs->trans("ForbiddenBySetupRules").') ['.$langs->trans('Company').' : '.$this->thirdparty->name.']';
 						dol_syslog(__METHOD__.' '.$this->error, LOG_ERR);
 						return -1;
 					}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2518,6 +2518,20 @@ class Facture extends CommonInvoice
 		{
 			$keymin = strtolower($key);
 			$i = (int) preg_replace('/[^0-9]/', '', $key);
+			if ($i == 1) {
+				if (!is_object($this->thirdparty)) {
+					$langs->load('errors');
+					$this->error = $langs->trans('ErrorInvoiceLoadThirdParty', $this->ref);
+					dol_syslog(__METHOD__.' '.$this->error, LOG_ERR);
+					return -1;
+				}
+			}
+			if (!property_exists($this->thirdparty, $keymin)) {
+				$langs->load('errors');
+				$this->error = $langs->trans('ErrorInvoiceLoadThirdPartyKey', $keymin, $this->ref);
+				dol_syslog(__METHOD__.' '.$this->error, LOG_ERR);
+				return -1;
+			}
 			$vallabel = $this->thirdparty->$keymin;
 
 			if ($i > 0)

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2470,7 +2470,7 @@ class Facture extends CommonInvoice
 	 */
 	public function validate($user, $force_number = '', $idwarehouse = 0, $notrigger = 0, $batch_rule = 0)
 	{
-		global $conf, $langs;
+		global $conf, $langs, $mysoc;
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 
 		$productStatic = null;
@@ -2510,6 +2510,46 @@ class Facture extends CommonInvoice
 			$this->error = 'Permission denied';
 			dol_syslog(get_class($this)."::validate ".$this->error.' MAIN_USE_ADVANCED_PERMS='.$conf->global->MAIN_USE_ADVANCED_PERMS, LOG_ERR);
 			return -1;
+		}
+
+		// Check for mandatory fields in thirdparty (defined into setup)
+		$array_to_check = array('IDPROF1', 'IDPROF2', 'IDPROF3', 'IDPROF4', 'IDPROF5', 'IDPROF6', 'EMAIL');
+		foreach ($array_to_check as $key)
+		{
+			$keymin = strtolower($key);
+			$i = (int) preg_replace('/[^0-9]/', '', $key);
+			$vallabel = $this->thirdparty->$keymin;
+
+			if ($i > 0)
+			{
+				if ($this->thirdparty->isACompany())
+				{
+					// Check for mandatory prof id (but only if country is other than ours)
+					if ($mysoc->country_id > 0 && $this->thirdparty->country_id == $mysoc->country_id)
+					{
+						$idprof_mandatory = 'SOCIETE_'.$key.'_INVOICE_MANDATORY';
+						if (!$vallabel && !empty($conf->global->$idprof_mandatory))
+						{
+							$langs->load("errors");
+							$this->error = $langs->trans('ErrorProdIdIsMandatory', $langs->transcountry('ProfId'.$i, $this->thirdparty->country_code)).' ('.$langs->trans("ForbiddenBySetupRules").')'.' ['.$langs->trans('Company').' : '.$this->thirdparty->name.']';
+							dol_syslog(__METHOD__.' '.$this->error, LOG_ERR);
+							return -1;
+						}
+					}
+				}
+			} else {
+				if ($key == 'EMAIL')
+				{
+					// Check for mandatory
+					if (!empty($conf->global->SOCIETE_EMAIL_INVOICE_MANDATORY) && !isValidEMail($this->thirdparty->email))
+					{
+						$langs->load("errors");
+						$this->error = $langs->trans("ErrorBadEMail", $this->thirdparty->email).' ('.$langs->trans("ForbiddenBySetupRules").')'.' ['.$langs->trans('Company').' : '.$this->thirdparty->name.']';
+						dol_syslog(__METHOD__.' '.$this->error, LOG_ERR);
+						return -1;
+					}
+				}
+			}
 		}
 
 		$this->db->begin();

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -257,6 +257,8 @@ ErrorLanguageRequiredIfPageIsTranslationOfAnother=The language of new page must 
 ErrorLanguageMustNotBeSourceLanguageIfPageIsTranslationOfAnother=The language of new page must not be the source language if it is set as a translation of another page
 ErrorAParameterIsRequiredForThisOperation=A parameter is mandatory for this operation
 ErrorYouMustFirstSetupYourChartOfAccount=You must first setup your chart of account
+ErrorInvoiceLoadThirdParty=Can't load third-party object for invoice "%s"
+ErrorInvoiceLoadThirdPartyKey=Third-party key "%s" no set for invoice "%s"
 
 # Warnings
 WarningParamUploadMaxFileSizeHigherThanPostMaxSize=Your PHP parameter upload_max_filesize (%s) is higher than PHP parameter post_max_size (%s). This is not a consistent setup.


### PR DESCRIPTION
FIX check mandatory thirdparty fields for mass action
- when you validate several invoices from mass action, mandatory fields rules in company setup were not checked
