### PR TITLE
Restoring missing VATIsNotUsed label

### DIFF
--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -482,6 +482,7 @@ PaymentByChequeOrderedToShort=Check payments (incl. tax) are payable to
 SendTo=sent to
 PaymentByTransferOnThisBankAccount=Payment by transfer to the following bank account
 VATIsNotUsedForInvoice=* Non applicable VAT art-293B of CGI
+VATIsNotUsedForInvoiceAsso=* Non applicable VAT art-261-7 of CGI
 LawApplicationPart1=By application of the law 80.335 of 12/05/80
 LawApplicationPart2=the goods remain the property of
 LawApplicationPart3=the seller until full payment of

--- a/htdocs/langs/fr_FR/bills.lang
+++ b/htdocs/langs/fr_FR/bills.lang
@@ -482,6 +482,7 @@ PaymentByChequeOrderedToShort=Règlement TTC par chèque à l'ordre de
 SendTo=envoyé à
 PaymentByTransferOnThisBankAccount=Règlement par virement sur le compte bancaire suivant
 VATIsNotUsedForInvoice=* TVA non applicable art-293B du CGI
+VATIsNotUsedForInvoiceAsso=* TVA non applicable art-261-7 du CGI
 LawApplicationPart1=Par application de la loi 80.335 du 12/05/80
 LawApplicationPart2=les marchandises demeurent la propriété du
 LawApplicationPart3=vendeur jusqu'à complet encaissement de


### PR DESCRIPTION
Restores new label introduced by https://github.com/Dolibarr/dolibarr/commit/7be9a98ef03e770f912f5d00392ed675740333ed 
Overwritten by a transiflex sync because of its absence in the en_US source.