### PR TITLE
fix: prededefault setup values for public field (visibility) works

### DIFF
--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -615,7 +615,7 @@ if ($action == 'create' && $user->rights->projet->creer) {
 	}
 
 	if (count($array) > 0) {
-		print $form->selectarray('public', $array, GETPOSTISSET('public') ? GETPOST('public') : $object->public, 0, 0, 0, '', 0, 0, 0, '', '', 1);
+		print $form->selectarray('public', $array, GETPOST('public') ? GETPOST('public') : $object->public, 0, 0, 0, '', 0, 0, 0, '', '', 1);
 	} else {
 		print '<input type="hidden" name="public" id="public" value="'.(GETPOSTISSET('public') ? GETPOST('public') : $object->public).'">';
 


### PR DESCRIPTION
Into admin/defaultvalues.php
![image](https://user-images.githubusercontent.com/1050053/158364999-d0ebcbf0-8374-4f01-ada7-092ef2da619f.png)

Test on GETPOSTISSET do not check predefault values, use of GETPOST instead make it works