### PR TITLE
fix: prededefault setup values for public field (visibility) works

### DIFF
--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -615,11 +615,11 @@ if ($action == 'create' && $user->rights->projet->creer) {
 	}
 
 	if (count($array) > 0) {
-		print $form->selectarray('public', $array, GETPOSTISSET('public') ? GETPOST('public') : $object->public, 0, 0, 0, '', 0, 0, 0, '', '', 1);
+		print $form->selectarray('public', $array, GETPOST('public'), 0, 0, 0, '', 0, 0, 0, '', '', 1);
 	} else {
-		print '<input type="hidden" name="public" id="public" value="'.(GETPOSTISSET('public') ? GETPOST('public') : $object->public).'">';
+		print '<input type="hidden" name="public" id="public" value="'.GETPOST('public').'">';
 
-		if ( (GETPOSTISSET('public') ? GETPOST('public') : $object->public)==0) {
+		if (GETPOST('public') == 0) {
 			print $langs->trans("PrivateProject");
 		} else {
 			print $langs->trans("SharedProject");


### PR DESCRIPTION
from PR #20359 that you prefer to close in favor of commit 58f5cafc3497e2b3bcece75fa45587d746a56fd7 (in 15.0), the bug is detected in 14.0 so I need it fix in 14.0