### PR TITLE
FIX : in result by custom accounting account groups report, if we add…

### DIFF
--- a/htdocs/compta/resultat/result.php
+++ b/htdocs/compta/resultat/result.php
@@ -334,7 +334,7 @@ if ($modecompta == 'CREANCES-DETTES') {
 
 				//var_dump($result);
 				//$r = $AccCat->calculate($result);
-				$r = dol_eval($result, 1, 1, '1');
+				$r = dol_eval($result, 1, 1, 0);
 				//var_dump($r);
 
 				print '<td class="liste_total right"><span class="amount">'.price($r).'</span></td>';
@@ -353,7 +353,7 @@ if ($modecompta == 'CREANCES-DETTES') {
 				$result = strtr($formula, $vars);
 
 				//$r = $AccCat->calculate($result);
-				$r = dol_eval($result, 1, 1, 1);
+				$r = dol_eval($result, 1, 1, 0);
 
 				print '<td class="liste_total right"><span class="amount">'.price($r).'</span></td>';
 				$sommes[$code]['N'] += $r;
@@ -367,7 +367,7 @@ if ($modecompta == 'CREANCES-DETTES') {
 						$result = strtr($formula, $vars);
 
 						//$r = $AccCat->calculate($result);
-						$r = dol_eval($result, 1, 1, 1);
+						$r = dol_eval($result, 1, 1, 0);
 
 						print '<td class="liste_total right"><span class="amount">'.price($r).'</span></td>';
 						$sommes[$code]['M'][$k] += $r;
@@ -381,7 +381,7 @@ if ($modecompta == 'CREANCES-DETTES') {
 						$result = strtr($formula, $vars);
 
 						//$r = $AccCat->calculate($result);
-						$r = dol_eval($result, 1, 1, 1);
+						$r = dol_eval($result, 1, 1, 0);
 
 						print '<td class="liste_total right"><span class="amount">'.price($r).'</span></td>';
 						$sommes[$code]['M'][$k] += $r;


### PR DESCRIPTION
… 1 to param "onlysimplestring", a formula like GRP1+GRP2 never works because "+" char is matched by the regex in the test "if ($onlysimplestring == '1')"

Before my correction :
![image](https://user-images.githubusercontent.com/5585819/158554909-b5792221-7a54-4196-b21d-87e99f9ea4c1.png)

After my correction :
![image](https://user-images.githubusercontent.com/5585819/158555008-440c9721-56ce-45c7-aed1-0dc9833df378.png)

Maybe the right correction should be to correct the regex ? i'm not sure but in all cases there is a correction to do