### PR TITLE
Fix: ticket/workflow: automatically create ficheinter

### DIFF
--- a/htdocs/admin/workflow.php
+++ b/htdocs/admin/workflow.php
@@ -72,10 +72,10 @@ $workflowcodes = array(
 		'picto'=>'bill'
 	),
 	'WORKFLOW_TICKET_CREATE_INTERVENTION' => array (
-        'family'=>'create',
-        'position'=>25,
-        'enabled'=>(!empty($conf->ticket->enabled) && !empty($conf->ficheinter->enabled)),
-        'picto'=>'ticket'
+		'family'=>'create',
+		'position'=>25,
+		'enabled'=>(!empty($conf->ticket->enabled) && !empty($conf->ficheinter->enabled)),
+		'picto'=>'ticket'
 	),
 
 	'separator1'=>array('family'=>'separator', 'position'=>25, 'title'=>''),

--- a/htdocs/admin/workflow.php
+++ b/htdocs/admin/workflow.php
@@ -71,6 +71,12 @@ $workflowcodes = array(
 		'enabled'=>(!empty($conf->commande->enabled) && !empty($conf->facture->enabled)),
 		'picto'=>'bill'
 	),
+	'WORKFLOW_TICKET_CREATE_INTERVENTION' => array (
+        'family'=>'create',
+        'position'=>25,
+        'enabled'=>(!empty($conf->ticket->enabled) && !empty($conf->ficheinter->enabled)),
+        'picto'=>'ticket'
+	),
 
 	'separator1'=>array('family'=>'separator', 'position'=>25, 'title'=>''),
 

--- a/htdocs/core/modules/modWorkflow.class.php
+++ b/htdocs/core/modules/modWorkflow.class.php
@@ -95,7 +95,8 @@ class modWorkflow extends DolibarrModules
 			8=>array('WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER', 'chaine', '1', 'WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER', 0, 'current', 0),
 			9=>array('WORKFLOW_BILL_ON_RECEPTION', 'chaine', '1', 'WORKFLOW_BILL_ON_RECEPTION', 0, 'current', 0),
 			10=>array('WORKFLOW_TICKET_LINK_CONTRACT', 'chaine', '0', 'Automatically link a ticket to available contracts', 0, 'current', 0),
-			11=>array('WORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS', 'chaine', '0', 'Search among parent companies contracts when automatically linking a ticket to available contracts', 0, 'current', 0)
+			11=>array('WORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS', 'chaine', '0', 'Search among parent companies contracts when automatically linking a ticket to available contracts', 0, 'current', 0),
+			11=>array('WORKFLOW_TICKET_CREATE_INTERVENTION', 'chaine', '1', 'WORKFLOW_TICKET_CREATE_INTERVENTION', 0, 'current', 0)
 		);
 
 		// Boxes

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -457,9 +457,9 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 				}
 			}
 			// Automatically create intervention
-			if (!empty($conf->ficheinter->enabled) && !empty($conf->ticket->enabled) && !empty($conf->workflow->enabled) && !empty($conf->global->WORKFLOW_TICKET_CREATE_INTERVENTION) && !empty($object->fk_soc)) {
+			if (!empty($conf->ficheinter->enabled) && !empty($conf->ticket->enabled) && !empty($conf->workflow->enabled) && !empty($conf->global->WORKFLOW_TICKET_CREATE_INTERVENTION)) {
 				$fichinter = new Fichinter($this->db);
-				$fichinter->socid = $object->fk_soc;
+				$fichinter->socid = (int) $object->fk_soc;
 				$fichinter->fk_project = $projectid;
 				$fichinter->fk_contrat = (int) $object->fk_contract;
 				$fichinter->author = $user->id;

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -463,7 +463,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 				$fichinter->fk_project = $projectid;
 				$fichinter->fk_contrat = (int) $object->fk_contract;
 				$fichinter->author = $user->id;
-				$fichinter->model_pdf = 'soleil';
+				$fichinter->model_pdf = (!empty($conf->global->FICHEINTER_ADDON_PDF)) ? $conf->global->FICHEINTER_ADDON_PDF : 'soleil';
 				$fichinter->origin = $object->element;
 				$fichinter->origin_id = $object->id;
 

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -255,7 +255,7 @@ class Fichinter extends CommonObject
 		}
 
 		if ($this->socid <= 0) {
-			$this->error = 'ErrorBadParameterForFunc';
+			$this->error = 'ErrorFicheinterCompanyDoesNotExist';
 			dol_syslog(get_class($this)."::create ".$this->error, LOG_ERR);
 			return -1;
 		}

--- a/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
+++ b/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
@@ -117,6 +117,7 @@ INSERT INTO llx_c_action_trigger (code,label,description,elementtype,rang) value
 ALTER TABLE llx_ticket ADD COLUMN date_last_msg_sent datetime AFTER date_read;
 
 UPDATE llx_const SET name = 'WORKFLOW_TICKET_LINK_CONTRACT' WHERE name = 'TICKET_AUTO_ASSIGN_CONTRACT_CREATE';
+UPDATE llx_const SET name = 'WORKFLOW_TICKET_CREATE_INTERVENTION' WHERE name = 'TICKET_AUTO_CREATE_FICHINTER_CREATE';
 
 CREATE TABLE llx_stock_mouvement_extrafields (
     rowid integer AUTO_INCREMENT PRIMARY KEY,

--- a/htdocs/langs/en_US/interventions.lang
+++ b/htdocs/langs/en_US/interventions.lang
@@ -67,3 +67,4 @@ ToCreateAPredefinedIntervention=To create a predefined or recurring intervention
 ConfirmReopenIntervention=Are you sure you want to open back the intervention <b>%s</b>?
 GenerateInter=Generate intervention
 FichinterNoContractLinked=Intervention %s has been created without a linked contract.
+ErrorFicheinterCompanyDoesNotExist=Company does not exist. Intervention has not been created.

--- a/htdocs/langs/en_US/workflow.lang
+++ b/htdocs/langs/en_US/workflow.lang
@@ -7,6 +7,7 @@ descWORKFLOW_PROPAL_AUTOCREATE_ORDER=Automatically create a sales order after a 
 descWORKFLOW_PROPAL_AUTOCREATE_INVOICE=Automatically create a customer invoice after a commercial proposal is signed (the new invoice will have same amount as the proposal)
 descWORKFLOW_CONTRACT_AUTOCREATE_INVOICE=Automatically create a customer invoice after a contract is validated
 descWORKFLOW_ORDER_AUTOCREATE_INVOICE=Automatically create a customer invoice after a sales order is closed (the new invoice will have same amount as the order)
+descWORKFLOW_TICKET_CREATE_INTERVENTION=Create an intervention when opening a ticket from backend and link it to the ticket.
 # Autoclassify customer proposal or order
 descWORKFLOW_ORDER_CLASSIFY_BILLED_PROPAL=Classify linked source proposal as billed when sales order is set to billed (and if the amount of the order is the same as the total amount of the signed linked proposal)
 descWORKFLOW_INVOICE_CLASSIFY_BILLED_PROPAL=Classify linked source proposal as billed when customer invoice is validated (and if the amount of the invoice is the same as the total amount of the signed linked proposal)

--- a/htdocs/langs/en_US/workflow.lang
+++ b/htdocs/langs/en_US/workflow.lang
@@ -7,7 +7,7 @@ descWORKFLOW_PROPAL_AUTOCREATE_ORDER=Automatically create a sales order after a 
 descWORKFLOW_PROPAL_AUTOCREATE_INVOICE=Automatically create a customer invoice after a commercial proposal is signed (the new invoice will have same amount as the proposal)
 descWORKFLOW_CONTRACT_AUTOCREATE_INVOICE=Automatically create a customer invoice after a contract is validated
 descWORKFLOW_ORDER_AUTOCREATE_INVOICE=Automatically create a customer invoice after a sales order is closed (the new invoice will have same amount as the order)
-descWORKFLOW_TICKET_CREATE_INTERVENTION=Create an intervention when opening a ticket from backend and link it to the ticket.
+descWORKFLOW_TICKET_CREATE_INTERVENTION=On ticket creation, automatically create an intervention.
 # Autoclassify customer proposal or order
 descWORKFLOW_ORDER_CLASSIFY_BILLED_PROPAL=Classify linked source proposal as billed when sales order is set to billed (and if the amount of the order is the same as the total amount of the signed linked proposal)
 descWORKFLOW_INVOICE_CLASSIFY_BILLED_PROPAL=Classify linked source proposal as billed when customer invoice is validated (and if the amount of the invoice is the same as the total amount of the signed linked proposal)

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -254,28 +254,6 @@ if (empty($reshook)) {
 					$result = $object->assignUser($user, $user->id, 1);
 					$object->add_contact($user->id, "SUPPORTTEC", 'internal');
 				}
-
-				// Auto create fiche intervention
-				if (!empty($conf->global->TICKET_AUTO_CREATE_FICHINTER_CREATE)) {
-					$fichinter = new Fichinter($db);
-					$fichinter->socid = $object->fk_soc;
-					$fichinter->fk_project = $projectid;
-					$fichinter->fk_contrat = $object->fk_contract;
-					$fichinter->author = $user->id;
-					$fichinter->model_pdf = 'soleil';
-					$fichinter->origin = $object->element;
-					$fichinter->origin_id = $object->id;
-
-					// Extrafields
-					$extrafields->fetch_name_optionals_label($fichinter->table_element);
-					$array_options = $extrafields->getOptionalsFromPost($fichinter->table_element);
-					$fichinter->array_options = $array_options;
-
-					$id = $fichinter->create($user);
-					if ($id <= 0) {
-						setEventMessages($fichinter->error, null, 'errors');
-					}
-				}
 			}
 
 			if (!$error) {


### PR DESCRIPTION
On ticket module, the option TICKET_AUTO_CREATE_FICHINTER_CREATE does not have any effect on tickets created from ~~backend~~ public interface. See issue #20391

This PR:
- fixes this issue by moving the ficheinter creation from ticket/card.php to triggers
- moves the option from the Ticket module to the Workflow module
- should be merged after https://github.com/Dolibarr/dolibarr/pull/20225 that deals with ticket->contract automatic link