### PR TITLE
FIX MO produced product WAP calculation when MO is based on BOM (not free lines)

### DIFF
--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -808,7 +808,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					$tmpproduct->fetch($line->fk_product);
 					$linecost = price2num($tmpproduct->pmp, 'MT');
 
-					if ($line->origin_type == 'free' && $object->qty > 0) {
+					if ($object->qty > 0) {
 						// add free consume line cost to bomcost
 						$costprice = price2num((!empty($tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
 						if (empty($costprice)) {
@@ -822,12 +822,6 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						}
 						$linecost = price2num(($line->qty * $costprice) / $object->qty, 'MT');
 						$bomcost += $linecost;
-					} elseif ($line->origin_id > 0 && $line->origin_type == 'bom' && $object->qty > 0) {
-						foreach ($bom->lines as $bomline) {
-							if ($bomline->id == $line->origin_id) {
-								$linecost = price2num(($line->qty * $bomline->unit_cost) / $object->qty, 'MT');
-							}
-						}
 					}
 
 					$bomcost = price2num($bomcost, 'MU');


### PR DESCRIPTION
# FIX MO produced product WAP calculation when MO is based on BOM (not free lines)
Fixing the bug where if an MO is based on a BOM the cost (WAP) of the produced product is not updated based on the BOMs total cost. The current implementaiton is differentiating if the lines to be consumed are from BOM or free lines added to the MO manually. The MO class itself is dealing with this in the instantiation there is no need of the code to deal with it as a seperate case. So in the case that an MO will be based on a BOM (most common case) the product to be produced will have zero pmp cost (weight average) or the cost price that was set in the product. 
This is a necessary behavior, as the raw material slowly increasing in price the resulted manufactured products reflect this change in their WAP cost. 

Also the code is dead because there is a type (type='bom' but it is suppose to be 'bomline') so the else_if statement is never running and the bomcost variable is not being updated in this case making a completely unused code.