### PR TITLE
fix #20477: add online_payment_url on orders API requests

### DIFF
--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -135,6 +135,11 @@ class Orders extends DolibarrApi
 		// Add external contacts ids
 		$this->commande->contacts_ids = $this->commande->liste_contact(-1, 'external', $contact_list);
 		$this->commande->fetchObjectLinked();
+
+		// Add online_payment_url, cf #20477
+		require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
+		$this->commande->online_payment_url = getOnlinePaymentUrl(0, 'order', $this->commande->ref);
+
 		return $this->_cleanObjectDatas($this->commande);
 	}
 

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -230,6 +230,10 @@ class Orders extends DolibarrApi
 				if ($commande_static->fetch($obj->rowid)) {
 					// Add external contacts ids
 					$commande_static->contacts_ids = $commande_static->liste_contact(-1, 'external', 1);
+					// Add online_payment_url, cf #20477
+					require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
+					$commande_static->online_payment_url = getOnlinePaymentUrl(0, 'order', $commande_static->ref);
+
 					$obj_ret[] = $this->_cleanObjectDatas($commande_static);
 				}
 				$i++;
@@ -734,6 +738,10 @@ class Orders extends DolibarrApi
 		$result = $this->commande->fetch($id);
 
 		$this->commande->fetchObjectLinked();
+
+		//fix #20477 : add online_payment_url
+		require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
+		$this->commande->online_payment_url = getOnlinePaymentUrl(0, 'order', $this->commande->ref);
 
 		return $this->_cleanObjectDatas($this->commande);
 	}

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -266,6 +266,11 @@ class Commande extends CommonOrder
 	 */
 	public $expeditions;
 
+	/**
+	 * @var string payment url
+	 */
+	public $online_payment_url;
+
 
 	/**
 	 *  'type' if the field format ('integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter]]', 'varchar(x)', 'double(24,8)', 'real', 'price', 'text', 'html', 'date', 'datetime', 'timestamp', 'duration', 'mail', 'phone', 'url', 'password')


### PR DESCRIPTION
# Fix #20477

That patch add a new online_payment_url attribute on orders API requests to be able to make a link to online payment if needed
