### PR TITLE
Avoid grouping lines with ordered lines

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -535,7 +535,7 @@ if ($action == "addline") {
 	}
 
 	$idoflineadded = 0;
-	if (!empty($conf->global->TAKEPOS_GROUP_SAME_PRODUCT)) {
+	if (!empty($conf->global->TAKEPOS_GROUP_SAME_PRODUCT) && $line->special_code != "4") {
 		foreach ($invoice->lines as $line) {
 			if ($line->product_ref == $prod->ref) {
 				if ($line->special_code==4) continue; // If this line is sended to printer create new line

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -535,6 +535,7 @@ if ($action == "addline") {
 	}
 
 	$idoflineadded = 0;
+	// Group if enabled. Skip group if line already sent to the printer
 	if (!empty($conf->global->TAKEPOS_GROUP_SAME_PRODUCT) && $line->special_code != "4") {
 		foreach ($invoice->lines as $line) {
 			if ($line->product_ref == $prod->ref) {


### PR DESCRIPTION
It makes no sense to group a new line inside line already sent to the kitchen. If it is grouped, it is not printed in the kitchen and different prices or notes cannot be applied.