### PR TITLE
Allow anonymous LDAP user lookups 

### DIFF
--- a/htdocs/core/login/functions_ldap.php
+++ b/htdocs/core/login/functions_ldap.php
@@ -109,9 +109,9 @@ function check_user_password_ldap($usertotest, $passwordtotest, $entitytotest)
 			$userSearchFilter = str_replace('%1%', $usertotest, $dolibarr_main_auth_ldap_filter);
 		}
 
-		// If admin login provided
+		// If admin login or ldap auth filter provided
 		// Code to get user in LDAP from an admin connection (may differ from user connection, done later)
-		if ($ldapadminlogin) {
+		if ($ldapadminlogin || $dolibarr_main_auth_ldap_filter) {
 			$result = $ldap->connect_bind();
 			if ($result > 0) {
 				$resultFetchLdapUser = $ldap->fetch($usertotest, $userSearchFilter);


### PR DESCRIPTION
# NEW|New Allow anonymos LDAP user lookups
Currently you need to have a service user to lookup a user DN before actually authenticating. This patch allows to do this lookup anonymously as long as a '$dolibarr_main_auth_ldap_filter' is set.
