### PR TITLE
FIX missing call to executeHooks()

### DIFF
--- a/htdocs/core/boxes/box_dolibarr_state_board.php
+++ b/htdocs/core/boxes/box_dolibarr_state_board.php
@@ -79,9 +79,9 @@ class box_dolibarr_state_board extends ModeleBoxes
 		if (empty($user->socid) && empty($conf->global->MAIN_DISABLE_GLOBAL_BOXSTATS)) {
 			$hookmanager = new HookManager($this->db);
 			$hookmanager->initHooks(array('index'));
-            $object = new stdClass;
-            $action = '';
-            $hookmanager->executeHooks('addStatisticLine', array(), $object, $action);
+			$object = new stdClass;
+			$action = '';
+			$hookmanager->executeHooks('addStatisticLine', array(), $object, $action);
 			$boxstatItems = array();
 			$boxstatFromHook = '';
 			$boxstatFromHook = $hookmanager->resPrint;

--- a/htdocs/core/boxes/box_dolibarr_state_board.php
+++ b/htdocs/core/boxes/box_dolibarr_state_board.php
@@ -79,6 +79,9 @@ class box_dolibarr_state_board extends ModeleBoxes
 		if (empty($user->socid) && empty($conf->global->MAIN_DISABLE_GLOBAL_BOXSTATS)) {
 			$hookmanager = new HookManager($this->db);
 			$hookmanager->initHooks(array('index'));
+            $object = new stdClass;
+            $action = '';
+            $hookmanager->executeHooks('addStatisticLine', array(), $object, $action);
 			$boxstatItems = array();
 			$boxstatFromHook = '';
 			$boxstatFromHook = $hookmanager->resPrint;


### PR DESCRIPTION
# FIX: hook ready but no call to executeHooks()
The hook for adding more statistics is already implemented (hookmanager instantiated, its results used) but the call to `executeHooks` is missing.

Example after adding the hook:
![image](https://user-images.githubusercontent.com/50440633/161094613-2ea2f536-75f7-4f16-9666-e6e979c0cbaf.png)
