### PR TITLE
fix: Show error message on inventory input line for serial num product #Evarisk

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -307,6 +307,7 @@ if (empty($reshook)) {
 	include DOL_DOCUMENT_ROOT.'/core/actions_sendmails.inc.php';*/
 
 	if (GETPOST('addline', 'alpha')) {
+		$qty= (GETPOST('qtytoadd') != '' ? price2num(GETPOST('qtytoadd', 'MS')) : null);
 		if ($fk_warehouse <= 0) {
 			$error++;
 			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("Warehouse")), null, 'errors');
@@ -323,12 +324,17 @@ if (empty($reshook)) {
 			$tmpproduct = new Product($db);
 			$result = $tmpproduct->fetch($fk_product);
 
-			if (!$error && $tmpproduct->status_batch && !$batch) {
+			if (empty($error) && $tmpproduct->status_batch>0 && empty($batch)) {
 				$error++;
 				$langs->load("errors");
 				setEventMessages($langs->trans("ErrorProductNeedBatchNumber", $tmpproduct->ref), null, 'errors');
 			}
-			if (!$error && !$tmpproduct->status_batch && $batch) {
+			if (empty($error) && $tmpproduct->status_batch==2 && !empty($batch) && $qty>1) {
+				$error++;
+				$langs->load("errors");
+				setEventMessages($langs->trans("TooManyQtyForSerialNumber", $tmpproduct->ref, $batch), null, 'errors');
+			}
+			if (empty($error) && empty($tmpproduct->status_batch) && !empty($batch)) {
 				$error++;
 				$langs->load("errors");
 				setEventMessages($langs->trans("ErrorProductDoesNotNeedBatchNumber", $tmpproduct->ref), null, 'errors');
@@ -341,7 +347,7 @@ if (empty($reshook)) {
 			$tmp->fk_product = $fk_product;
 			$tmp->batch = $batch;
 			$tmp->datec = $now;
-			$tmp->qty_view = (GETPOST('qtytoadd') != '' ? price2num(GETPOST('qtytoadd', 'MS')) : null);
+			$tmp->qty_view = $qty;
 
 			$result = $tmp->create($user);
 			if ($result < 0) {

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -597,7 +597,7 @@ class MouvementStock extends CommonObject
 				if ($product->status_batch == 2 && $qty > 0) {	// We check only if we increased qty
 					if ($this->getBatchCount($fk_product, $batch) > 1) {
 						$error++;
-						$this->errors[] = $langs->trans("TooManyQtyForSerialNumber", $batch, $product->ref);
+						$this->errors[] = $langs->trans("TooManyQtyForSerialNumber", $product->ref, $batch);
 					}
 				}
 			}


### PR DESCRIPTION
fix: Show error message on inventory input line for serial num product

Actually the control is done on "Generate Stock Mvt" (with an understandable error message)
![image](https://user-images.githubusercontent.com/1050053/161217956-fe01ee6e-32d5-45b1-b743-61e6adf89da8.png)


The control must be done on input lines

closes #20475