### PR TITLE
Bug: Cannot set Thirdparty customer accountancy code to an empty string

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -162,7 +162,7 @@ if (empty($reshook)) {
 	// set accountancy code
 	if ($action == 'setcustomeraccountancycode') {
 		$result = $object->fetch($id);
-		$object->code_compta = GETPOST("customeraccountancycode");
+		$object->code_compta_client = GETPOST("customeraccountancycode");
 		$result = $object->update($object->id, $user, 1, 1, 0);
 		if ($result < 0) {
 			setEventMessages($object->error, $object->errors, 'errors');
@@ -360,9 +360,9 @@ if ($object->id > 0) {
 
 		print '<tr>';
 		print '<td>';
-		print $form->editfieldkey("CustomerAccountancyCode", 'customeraccountancycode', $object->code_compta, $object, $user->rights->societe->creer);
+		print $form->editfieldkey("CustomerAccountancyCode", 'customeraccountancycode', $object->code_compta_client, $object, $user->rights->societe->creer);
 		print '</td><td>';
-		print $form->editfieldval("CustomerAccountancyCode", 'customeraccountancycode', $object->code_compta, $object, $user->rights->societe->creer);
+		print $form->editfieldval("CustomerAccountancyCode", 'customeraccountancycode', $object->code_compta_client, $object, $user->rights->societe->creer);
 		print '</td>';
 		print '</tr>';
 	}


### PR DESCRIPTION
FIX
Cannot change Thirdparty customer accountancy code to an empty string, due to property name deprecation (code_compta to code_compta_client).
