### PR TITLE
FIX 16.0 - supplier invoice card creates two invoices instead of one

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -903,7 +903,7 @@ if (empty($reshook)) {
 				$object->date            = $dateinvoice;
 				$object->note_public = trim(GETPOST('note_public', 'restricthtml'));
 				$object->note_private    = trim(GETPOST('note_private', 'restricthtml'));
-				$object->ref_client      = GETPOST('ref_client');
+				$object->ref_supplier    = GETPOST('ref_supplier', 'nohtml');
 				$object->model_pdf = GETPOST('model');
 				$object->fk_project = GETPOST('projectid', 'int');
 				$object->cond_reglement_id	= (GETPOST('type') == 3 ? 1 : GETPOST('cond_reglement_id'));

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -929,7 +929,7 @@ if (empty($reshook)) {
 		}
 
 		// Standard invoice or Deposit invoice, not from a Predefined template invoice
-		if (GETPOST('type') == FactureFournisseur::TYPE_STANDARD || GETPOST('type') == FactureFournisseur::TYPE_DEPOSIT && GETPOST('fac_rec') <= 0) {
+		elseif (GETPOST('type') == FactureFournisseur::TYPE_STANDARD || GETPOST('type') == FactureFournisseur::TYPE_DEPOSIT && GETPOST('fac_rec') <= 0) {
 			if (GETPOST('socid', 'int') < 1) {
 				setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentities('Supplier')), null, 'errors');
 				$action = 'create';


### PR DESCRIPTION
# FIX double supplier invoice creation from template

The conditions of the two `if`s overlap, causing the supplier invoice to be created twice (once from the block handling creation from templates and once from the block handling standard creation).

I also renamed a variable (`$fac_rec` -> `$fac_recid`) and used it instead of GETPOST
 + changed some conditions to not just test empty but also negative values for `$fac_recid` in case the `<select>`'s empty value changes
 + fixed a missing supplier ref assignment
