### PR TITLE
FIX 16.0 - missing quotes in SQL for frequency unit update for templa…

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1769,7 +1769,7 @@ class FactureFournisseurRec extends CommonInvoice
 		$sql = 'UPDATE '.MAIN_DB_PREFIX.$this->table_element;
 		$sql .= ' SET frequency = '.($frequency ? $this->db->escape($frequency) : 'null');
 		if (!empty($unit)) {
-			$sql .= ', unit_frequency = '.$this->db->escape($unit);
+			$sql .= ', unit_frequency = \''.$this->db->escape($unit).'\'';
 		}
 		$sql .= ' WHERE rowid = ' . (int) $this->id;
 


### PR DESCRIPTION
# FIX supplier invoice templates: missing quotes in SQL
When you change the frequency unit for a supplier invoice template using the single field edit button, you get a MySQL syntax error due to missing quotes around the string.

![image](https://user-images.githubusercontent.com/50440633/161734956-b3dd07a8-c50b-4dd0-871e-e3d01658a936.png)
