### PR TITLE
add option AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT

### DIFF
--- a/htdocs/admin/agenda_other.php
+++ b/htdocs/admin/agenda_other.php
@@ -392,6 +392,18 @@ print '<td class="right">'."\n";
 $formactions->form_select_status_action('agenda', $conf->global->AGENDA_DEFAULT_FILTER_STATUS, 1, 'AGENDA_DEFAULT_FILTER_STATUS', 1, 2, 'minwidth100');
 print '</td></tr>'."\n";
 
+// AGENDA EVENT SENT BY MAIL USE SUBJECT
+print '<tr class="oddeven">'."\n";
+print '<td>'.$langs->trans("AGENDA_EVENT_SENT_MAIL_USE_SUBJECT").'</td>'."\n";
+print '<td class="center">&nbsp;</td>'."\n";
+print '<td class="right">'."\n";
+if (empty($conf->global->AGENDA_EVENT_SENT_MAIL_USE_SUBJECT)) {
+    print '<a href="'.$_SERVER['PHP_SELF'].'?action=set_AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT">'.img_picto($langs->trans("Disabled"), 'switch_off').'</a>';
+} else {
+    print '<a href="'.$_SERVER['PHP_SELF'].'?action=del_AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT">'.img_picto($langs->trans("Enabled"), 'switch_on').'</a>';
+}
+print '</td></tr>'."\n";
+
 print '</table>';
 
 print dol_get_fiche_end();

--- a/htdocs/admin/agenda_other.php
+++ b/htdocs/admin/agenda_other.php
@@ -398,9 +398,9 @@ print '<td>'.$langs->trans("AGENDA_EVENT_SENT_MAIL_USE_SUBJECT").'</td>'."\n";
 print '<td class="center">&nbsp;</td>'."\n";
 print '<td class="right">'."\n";
 if (empty($conf->global->AGENDA_EVENT_SENT_MAIL_USE_SUBJECT)) {
-    print '<a href="'.$_SERVER['PHP_SELF'].'?action=set_AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT">'.img_picto($langs->trans("Disabled"), 'switch_off').'</a>';
+	print '<a href="'.$_SERVER['PHP_SELF'].'?action=set_AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT">'.img_picto($langs->trans("Disabled"), 'switch_off').'</a>';
 } else {
-    print '<a href="'.$_SERVER['PHP_SELF'].'?action=del_AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT">'.img_picto($langs->trans("Enabled"), 'switch_on').'</a>';
+	print '<a href="'.$_SERVER['PHP_SELF'].'?action=del_AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT">'.img_picto($langs->trans("Enabled"), 'switch_on').'</a>';
 }
 print '</td></tr>'."\n";
 

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -867,7 +867,7 @@ class ActionComm extends CommonObject
 				$this->num_vote = $obj->num_vote;
 				$this->event_paid = $obj->event_paid;
 				$this->status = $obj->status;
-				
+
 				//email information
 				$this->email_msgid=$obj->email_msgid;
 				$this->email_from=$obj->email_from;
@@ -1559,7 +1559,7 @@ class ActionComm extends CommonObject
 		}
 
 		$label = $this->label;
-		if($conf->global->AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT && !empty($this->email_subject)){
+		if ($conf->global->AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT && !empty($this->email_subject)) {
 			$label = $this->email_subject;
 		}
 		if (empty($label)) {

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -867,6 +867,16 @@ class ActionComm extends CommonObject
 				$this->num_vote = $obj->num_vote;
 				$this->event_paid = $obj->event_paid;
 				$this->status = $obj->status;
+				
+				//email information
+				$this->email_msgid=$obj->email_msgid;
+				$this->email_from=$obj->email_from;
+				$this->email_sender=$obj->email_sender;
+				$this->email_to=$obj->email_to;
+				$this->email_tocc=$obj->email_tocc;
+				$this->email_tobcc=$obj->email_tobcc;
+				$this->email_subject=$obj->email_subject;
+				$this->errors_to=$obj->errors_to;
 
 				$this->fetch_optionals();
 
@@ -1549,6 +1559,9 @@ class ActionComm extends CommonObject
 		}
 
 		$label = $this->label;
+		if($conf->global->AGENDA_EVENT_SENT_BY_MAIL_USE_SUBJECT && !empty($this->email_subject)){
+			$label = $this->email_subject;
+		}
 		if (empty($label)) {
 			$label = $this->libelle; // For backward compatibility
 		}

--- a/htdocs/langs/en_US/agenda.lang
+++ b/htdocs/langs/en_US/agenda.lang
@@ -172,3 +172,4 @@ AddReminder=Create an automatic reminder notification for this event
 ErrorReminderActionCommCreation=Error creating the reminder notification for this event
 BrowserPush=Browser Popup Notification
 ActiveByDefault=Enabled by default
+AGENDA_EVENT_SENT_MAIL_USE_SUBJECT=Send mail events use the mail object as the event title

--- a/htdocs/langs/fr_FR/agenda.lang
+++ b/htdocs/langs/fr_FR/agenda.lang
@@ -172,3 +172,4 @@ AddReminder=Créer une notification de rappel automatique pour cet événement
 ErrorReminderActionCommCreation=Erreur lors de la création de la notification de rappel pour cet événement
 BrowserPush=Notification par Popup navigateur
 ActiveByDefault=Activé par défaut
+AGENDA_EVENT_SENT_MAIL_USE_SUBJECT=Les évenements "envoi de mail" utilisent l'object du mail comme titre d'événement


### PR DESCRIPTION
# NEW add option in agenda setup other to use subject in event object short list
add an option in the miscellaneous options page of the agenda module to display the subject of the email sent instead of the event label
