### PR TITLE
Fix 16.0 deprecate amount field on facture fourn?

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -79,6 +79,11 @@ class FactureFournisseurRec extends CommonInvoice
 
 	public $suspended;
 	public $libelle;
+
+	/**
+	 * @deprecated
+	 * @var double $amount
+	 */
 	public $amount;
 	public $remise;
 	public $vat_src_code;

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -181,6 +181,10 @@ class FactureFournisseur extends CommonInvoice
 	 */
 	public $date_echeance;
 
+	/**
+	 * @deprecated
+	 * @var double $amount
+	 */
 	public $amount = 0;
 	public $remise = 0;
 

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1178,7 +1178,8 @@ class FactureFournisseur extends CommonInvoice
 			$this->paye = trim($this->paye);
 		}
 		if (isset($this->amount)) {
-			$this->amount = trim($this->amount);
+			if (empty($this->amount)) $this->amount = 0;
+			else $this->amount = doubleval($this->amount);
 		}
 		if (isset($this->remise)) {
 			$this->remise = trim($this->remise);
@@ -1225,7 +1226,8 @@ class FactureFournisseur extends CommonInvoice
 			$this->fk_facture_source = trim($this->fk_facture_source);
 		}
 		if (isset($this->fk_project)) {
-			$this->fk_project = trim($this->fk_project);
+			if (empty($this->fk_project)) $this->fk_project = null;
+			else $this->fk_project = intval($this->fk_project);
 		}
 		if (isset($this->cond_reglement_id)) {
 			$this->cond_reglement_id = trim($this->cond_reglement_id);
@@ -1262,7 +1264,7 @@ class FactureFournisseur extends CommonInvoice
 		}
 		$sql .= " libelle=".(isset($this->label) ? "'".$this->db->escape($this->label)."'" : "null").",";
 		$sql .= " paye=".(isset($this->paye) ? $this->paye : "null").",";
-		$sql .= " amount=".(isset($this->amount) ? doubleval($this->amount) : "null").",";
+		$sql .= " amount=".(isset($this->amount) ? $this->amount : "null").",";
 		$sql .= " remise=".(isset($this->remise) ? $this->remise : "null").",";
 		$sql .= " close_code=".(isset($this->close_code) ? "'".$this->db->escape($this->close_code)."'" : "null").",";
 		$sql .= " close_note=".(isset($this->close_note) ? "'".$this->db->escape($this->close_note)."'" : "null").",";
@@ -1276,7 +1278,7 @@ class FactureFournisseur extends CommonInvoice
 		$sql .= " fk_user_author=".(isset($this->author) ? $this->author : "null").",";
 		$sql .= " fk_user_valid=".(isset($this->fk_user_valid) ? $this->fk_user_valid : "null").",";
 		$sql .= " fk_facture_source=".(isset($this->fk_facture_source) ? $this->fk_facture_source : "null").",";
-		$sql .= " fk_projet=".(isset($this->fk_project) ? intval($this->fk_project) : "null").",";
+		$sql .= " fk_projet=".(isset($this->fk_project) ? $this->fk_project : "null").",";
 		$sql .= " fk_cond_reglement=".(isset($this->cond_reglement_id) ? $this->cond_reglement_id : "null").",";
 		$sql .= " date_lim_reglement=".(dol_strlen($this->date_echeance) != 0 ? "'".$this->db->idate($this->date_echeance)."'" : 'null').",";
 		$sql .= " note_private=".(isset($this->note_private) ? "'".$this->db->escape($this->note_private)."'" : "null").",";

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1262,7 +1262,7 @@ class FactureFournisseur extends CommonInvoice
 		}
 		$sql .= " libelle=".(isset($this->label) ? "'".$this->db->escape($this->label)."'" : "null").",";
 		$sql .= " paye=".(isset($this->paye) ? $this->paye : "null").",";
-		$sql .= " amount=".(isset($this->amount) ? $this->amount : "null").",";
+		$sql .= " amount=".(isset($this->amount) ? doubleval($this->amount) : "null").",";
 		$sql .= " remise=".(isset($this->remise) ? $this->remise : "null").",";
 		$sql .= " close_code=".(isset($this->close_code) ? "'".$this->db->escape($this->close_code)."'" : "null").",";
 		$sql .= " close_note=".(isset($this->close_note) ? "'".$this->db->escape($this->close_note)."'" : "null").",";
@@ -1276,7 +1276,7 @@ class FactureFournisseur extends CommonInvoice
 		$sql .= " fk_user_author=".(isset($this->author) ? $this->author : "null").",";
 		$sql .= " fk_user_valid=".(isset($this->fk_user_valid) ? $this->fk_user_valid : "null").",";
 		$sql .= " fk_facture_source=".(isset($this->fk_facture_source) ? $this->fk_facture_source : "null").",";
-		$sql .= " fk_projet=".(isset($this->fk_project) ? $this->fk_project : "null").",";
+		$sql .= " fk_projet=".(isset($this->fk_project) ? intval($this->fk_project) : "null").",";
 		$sql .= " fk_cond_reglement=".(isset($this->cond_reglement_id) ? $this->cond_reglement_id : "null").",";
 		$sql .= " date_lim_reglement=".(dol_strlen($this->date_echeance) != 0 ? "'".$this->db->idate($this->date_echeance)."'" : 'null').",";
 		$sql .= " note_private=".(isset($this->note_private) ? "'".$this->db->escape($this->note_private)."'" : "null").",";


### PR DESCRIPTION
# NEW: deprecate `amount` field + FIX SQL error on update

I couldn't figure what `amount` field of supplier invoices is used for; I believe it is obsolete (if it is not, maybe this is an opportunity to document it).

I also noticed this field (as well as fk_project) causes an SQL error when it is set as an empty string (because `isset` will return true if the field value is `''`).
