### PR TITLE
NEW display errors in a message box after generating documents

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5380,16 +5380,19 @@ abstract class CommonObject
 					return 1;
 				} else {
 					$outputlangs->charset_output = $sav_charset_output;
-					dol_print_error($this->db, "Error generating document for ".__CLASS__.". Error: ".$obj->error, $obj->errors);
+					dol_syslog("Error generating document for ".__CLASS__.". Error: ".$obj->error, LOG_ERR);
+					setEventMessages($obj->error, $obj->errors, 'errors');
 					return -1;
 				}
 			} else {
 				if (!$filefound) {
 					$this->error = $langs->trans("Error").' Failed to load doc generator with modelpaths='.$modelspath.' - modele='.$modele;
-					dol_print_error('', $this->error);
+					dol_syslog($this->error, LOG_ERR);
+					setEventMessage($this->error, 'errors');
 				} else {
 					$this->error = $langs->trans("Error")." ".$langs->trans("ErrorFileDoesNotExists", $filefound);
-					dol_print_error('', $this->error);
+					dol_syslog($this->error, LOG_ERR);
+					setEventMessage($this->error, 'errors');
 				}
 				return -1;
 			}

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5380,19 +5380,20 @@ abstract class CommonObject
 					return 1;
 				} else {
 					$outputlangs->charset_output = $sav_charset_output;
+					$this->error = $obj->error;
+					$this->errors = $obj->errors;
 					dol_syslog("Error generating document for ".__CLASS__.". Error: ".$obj->error, LOG_ERR);
-					setEventMessages($obj->error, $obj->errors, 'errors');
 					return -1;
 				}
 			} else {
 				if (!$filefound) {
 					$this->error = $langs->trans("Error").' Failed to load doc generator with modelpaths='.$modelspath.' - modele='.$modele;
+					$this->errors[] = $this->error;
 					dol_syslog($this->error, LOG_ERR);
-					setEventMessage($this->error, 'errors');
 				} else {
 					$this->error = $langs->trans("Error")." ".$langs->trans("ErrorFileDoesNotExists", $filefound);
+					$this->errors[] = $this->error;
 					dol_syslog($this->error, LOG_ERR);
-					setEventMessage($this->error, 'errors');
 				}
 				return -1;
 			}


### PR DESCRIPTION
NEW display errors in a message box after generating documents

When errors occur on generating a document :

- before errors were displayed with "dol_print_error" method : 
![GeneratePrintError1](https://user-images.githubusercontent.com/45359511/161791211-0d4c50ef-bc39-4578-8098-33a47931d4b0.png)

- now errors are displayed in a message box : 
![GeneratePrintError2](https://user-images.githubusercontent.com/45359511/161791246-b3345e97-141a-444b-a3d6-4bf56abf207e.png)

And errors are logged in log file
