### PR TITLE
change restrictedarera call on pages

### DIFF
--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -43,7 +43,7 @@ $langs->loadLangs(array('banks', 'categories', 'withdrawals', 'companies', 'bill
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '' );
+$result = restrictedArea($user, 'prelevement', '', '');
 
 $type = GETPOST('type', 'aZ09');
 

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -43,7 +43,7 @@ $langs->loadLangs(array('banks', 'categories', 'withdrawals', 'companies', 'bill
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '', 'bons');
+$result = restrictedArea($user, 'prelevement', '', '' );
 
 $type = GETPOST('type', 'aZ09');
 
@@ -141,7 +141,7 @@ if (empty($reshook)) {
 		}
 	}
 	$objectclass = "BonPrelevement";
-	$uploaddir = $conf->prelevement->dir_output;
+	$uploaddir = $conf->paymentbybanktransfer->dir_output;
 	include DOL_DOCUMENT_ROOT.'/core/actions_massactions.inc.php';
 }
 

--- a/htdocs/compta/prelevement/demandes.php
+++ b/htdocs/compta/prelevement/demandes.php
@@ -40,7 +40,7 @@ $status = GETPOST('status', 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '' );
+$result = restrictedArea($user, 'prelevement', '', '');
 
 $contextpage = GETPOST('contextpage', 'aZ') ?GETPOST('contextpage', 'aZ') : 'directdebitcredittransferlist'; // To manage different context of search
 $backtopage = GETPOST('backtopage', 'alpha'); // Go back to a dedicated page

--- a/htdocs/compta/prelevement/demandes.php
+++ b/htdocs/compta/prelevement/demandes.php
@@ -40,7 +40,7 @@ $status = GETPOST('status', 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '', 'bons');
+$result = restrictedArea($user, 'prelevement', '', '' );
 
 $contextpage = GETPOST('contextpage', 'aZ') ?GETPOST('contextpage', 'aZ') : 'directdebitcredittransferlist'; // To manage different context of search
 $backtopage = GETPOST('backtopage', 'alpha'); // Go back to a dedicated page

--- a/htdocs/compta/prelevement/list.php
+++ b/htdocs/compta/prelevement/list.php
@@ -47,7 +47,7 @@ $socid = GETPOST('socid', 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '' );
+$result = restrictedArea($user, 'prelevement', '', '');
 
 $type = GETPOST('type', 'aZ09');
 

--- a/htdocs/compta/prelevement/list.php
+++ b/htdocs/compta/prelevement/list.php
@@ -47,7 +47,7 @@ $socid = GETPOST('socid', 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '', 'bons');
+$result = restrictedArea($user, 'prelevement', '', '' );
 
 $type = GETPOST('type', 'aZ09');
 

--- a/htdocs/compta/prelevement/orders_list.php
+++ b/htdocs/compta/prelevement/orders_list.php
@@ -38,7 +38,7 @@ $socid = GETPOST('socid', 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '', 'bons');
+$result = restrictedArea($user, 'prelevement', '', '');
 
 $type = GETPOST('type', 'aZ09');
 

--- a/htdocs/compta/prelevement/rejets.php
+++ b/htdocs/compta/prelevement/rejets.php
@@ -38,7 +38,7 @@ $socid = GETPOST('socid', 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '', 'bons');
+$result = restrictedArea($user, 'prelevement', '', '' );
 
 $type = GETPOST('type', 'aZ09');
 

--- a/htdocs/compta/prelevement/rejets.php
+++ b/htdocs/compta/prelevement/rejets.php
@@ -38,7 +38,7 @@ $socid = GETPOST('socid', 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '' );
+$result = restrictedArea($user, 'prelevement', '', '');
 
 $type = GETPOST('type', 'aZ09');
 

--- a/htdocs/compta/prelevement/stats.php
+++ b/htdocs/compta/prelevement/stats.php
@@ -36,7 +36,7 @@ $socid = GETPOST('socid', 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '', 'bons');
+$result = restrictedArea($user, 'prelevement', '', '' );
 
 $type = GETPOST('type', 'aZ09');
 

--- a/htdocs/compta/prelevement/stats.php
+++ b/htdocs/compta/prelevement/stats.php
@@ -36,7 +36,7 @@ $socid = GETPOST('socid', 'int');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$result = restrictedArea($user, 'prelevement', '', '' );
+$result = restrictedArea($user, 'prelevement', '', '');
 
 $type = GETPOST('type', 'aZ09');
 

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -228,6 +228,9 @@ function restrictedArea($user, $features, $objectid = 0, $tableandshare = '', $f
 		$features = 'produit';
 	}
 
+	if ($features == 'prelevement') {
+		$features = 'paymentbybanktransfer';
+	}
 
 	// Get more permissions checks from hooks
 	$parameters = array('features'=>$features, 'originalfeatures'=>$originalfeatures, 'objectid'=>$objectid, 'dbt_select'=>$dbt_select, 'idtype'=>$dbt_select, 'isdraft'=>$isdraft);


### PR DESCRIPTION
# fix  : 

impossible to read the payment transfer due to a bad definition of the object even if the rights are defined for the user


1) added paymentbybanktransfer feature in security lib.
2) modified calls to restrictedArea
3) replacing the conf->module call with the correct module name