### PR TITLE
Fix fill parameter for recruitment 14.0

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -766,13 +766,13 @@ function checkUserAccessToObject($user, array $featuresarray, $objectid = 0, $ta
 					if (empty($dbt_keyfield)) {
 						dol_print_error('', 'Param dbt_keyfield is required but not defined');
 					}
-					$sql = "SELECT COUNT(sc.fk_soc) as nb";
+					$sql = !empty($dbt_keyfield) ? "SELECT COUNT(sc.fk_soc) as nb" : "SELECT COUNT(dbt.".$dbt_select.") as nb";
 					$sql .= " FROM ".MAIN_DB_PREFIX.$dbtablename." as dbt";
-					$sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
+					if(!empty($dbt_keyfield)) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 					$sql .= " WHERE dbt.".$dbt_select." IN (".$db->sanitize($objectid, 1).")";
 					$sql .= " AND dbt.entity IN (".getEntity($sharedelement, 1).")";
-					$sql .= " AND sc.fk_soc = dbt.".$dbt_keyfield;
-					$sql .= " AND sc.fk_user = ".((int) $user->id);
+					if(!empty($dbt_keyfield)) $sql .= " AND sc.fk_soc = dbt.".$dbt_keyfield;
+					if(!empty($dbt_keyfield)) $sql .= " AND sc.fk_user = ".((int) $user->id);
 				} else {
 					// On ticket, the thirdparty is not mandatory, so we need a special test to accept record with no thirdparties.
 					$sql = "SELECT COUNT(dbt.".$dbt_select.") as nb";
@@ -790,7 +790,7 @@ function checkUserAccessToObject($user, array $featuresarray, $objectid = 0, $ta
 				$sql .= " AND dbt.entity IN (".getEntity($sharedelement, 1).")";
 			}
 		}
-		//print $sql;
+		print $sql;
 
 		if ($sql) {
 			$resql = $db->query($sql);

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -765,11 +765,11 @@ function checkUserAccessToObject($user, array $featuresarray, $objectid = 0, $ta
 				if ($feature != 'ticket') {
 					$sql = !empty($dbt_keyfield) ? "SELECT COUNT(sc.fk_soc) as nb" : "SELECT COUNT(dbt.".$dbt_select.") as nb";
 					$sql .= " FROM ".MAIN_DB_PREFIX.$dbtablename." as dbt";
-					if(!empty($dbt_keyfield)) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
+					if (!empty($dbt_keyfield)) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 					$sql .= " WHERE dbt.".$dbt_select." IN (".$db->sanitize($objectid, 1).")";
 					$sql .= " AND dbt.entity IN (".getEntity($sharedelement, 1).")";
-					if(!empty($dbt_keyfield)) $sql .= " AND sc.fk_soc = dbt.".$dbt_keyfield;
-					if(!empty($dbt_keyfield)) $sql .= " AND sc.fk_user = ".((int) $user->id);
+					if (!empty($dbt_keyfield)) $sql .= " AND sc.fk_soc = dbt.".$dbt_keyfield;
+					if (!empty($dbt_keyfield)) $sql .= " AND sc.fk_user = ".((int) $user->id);
 				} else {
 					// On ticket, the thirdparty is not mandatory, so we need a special test to accept record with no thirdparties.
 					$sql = "SELECT COUNT(dbt.".$dbt_select.") as nb";

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -763,9 +763,6 @@ function checkUserAccessToObject($user, array $featuresarray, $objectid = 0, $ta
 			} elseif (!empty($conf->societe->enabled) && !$user->rights->societe->client->voir) {
 				// If internal user: Check permission for internal users that are restricted on their objects
 				if ($feature != 'ticket') {
-					if (empty($dbt_keyfield)) {
-						dol_print_error('', 'Param dbt_keyfield is required but not defined');
-					}
 					$sql = !empty($dbt_keyfield) ? "SELECT COUNT(sc.fk_soc) as nb" : "SELECT COUNT(dbt.".$dbt_select.") as nb";
 					$sql .= " FROM ".MAIN_DB_PREFIX.$dbtablename." as dbt";
 					if(!empty($dbt_keyfield)) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";


### PR DESCRIPTION
# FIX : Recruitment access problem  

Same problem : https://github.com/Dolibarr/dolibarr/issues/20562

There is a problem on the recruitment access right.
En fact, with all recruitments rights but without any thirparty richts, we can't access to the recruitment cards.

It is due to the function checkUserAccessToObject
To correct it, I modified the function to take into account the case where the user does not have any thirparty permissions.

Is this correctoin good ?
Is there another way to correct this ? 