### PR TITLE
FIX: Add 'recruitment' into check array

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -616,7 +616,7 @@ function checkUserAccessToObject($user, array $featuresarray, $objectid = 0, $ta
 			$feature = 'projet_task';
 		}
 
-		$check = array('adherent', 'banque', 'bom', 'don', 'mrp', 'user', 'usergroup', 'payment', 'payment_supplier', 'product', 'produit', 'service', 'produit|service', 'categorie', 'resource', 'expensereport', 'holiday', 'salaries', 'website'); // Test on entity only (Objects with no link to company)
+		$check = array('adherent', 'banque', 'bom', 'don', 'mrp', 'user', 'usergroup', 'payment', 'payment_supplier', 'product', 'produit', 'service', 'produit|service', 'categorie', 'resource', 'expensereport', 'holiday', 'salaries', 'website', 'recruitment'); // Test on entity only (Objects with no link to company)
 		$checksoc = array('societe'); // Test for societe object
 		$checkother = array('contact', 'agenda'); // Test on entity + link to third party on field $dbt_keyfield. Allowed if link is empty (Ex: contacts...).
 		$checkproject = array('projet', 'project'); // Test for project object


### PR DESCRIPTION
## FIX : Recruitment access problem

Same problem : https://github.com/Dolibarr/dolibarr/issues/20562

See closed PR : https://github.com/Dolibarr/dolibarr/pull/20575


There is a problem on the recruitment access right.
En fact, with all recruitments rights but without any thirparty richts, we can't access to the recruitment cards.

It is due to the function checkUserAccessToObject
To correct it, I modified the function to take into account the case where the user does not have any thirparty permissions.

Is this correctoin good ?
Is there another way to correct this ?