### PR TITLE
FIX Tax 2 is lost when order is invoiced

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -657,6 +657,7 @@ if ($massaction == 'confirm_createbills') {   // Create bills from orders.
 		} else {
 			// If we want one invoice per order or if there is no first invoice yet for this thirdparty.
 			$objecttmp->socid = $cmd->socid;
+			$objecttmp->fetch_thirdparty();
 			$objecttmp->type = $objecttmp::TYPE_STANDARD;
 			$objecttmp->cond_reglement_id = !empty($cmd->cond_reglement_id) ? $cmd->cond_reglement_id : $cmd->thirdparty->cond_reglement_id;
 			$objecttmp->mode_reglement_id = !empty($cmd->mode_reglement_id) ? $cmd->mode_reglement_id : $cmd->thirdparty->mode_reglement_id;


### PR DESCRIPTION
Tax 2 is lost when an order is invoiced from mass actions.
Reported in:
https://github.com/Dolibarr/dolibarr/issues/11335
https://github.com/Dolibarr/dolibarr/issues/6471

I have observed this issue happening from a lot of years and in the current version it is still happening.