### PR TITLE
NEW: ModuileBuilder - Translate permissions label

### DIFF
--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -3008,7 +3008,7 @@ if ($module == 'initmodule')
 						print '</td>';
 
 						print '<td>';
-						print $perm[1];
+						print $langs->trans($perm[1]);
 						print '</td>';
 
 						print '<td>';


### PR DESCRIPTION
When working with the module builder, I figured out that the permissions label were not translated.

**Before**

![image](https://user-images.githubusercontent.com/8199428/162772160-a235c335-d097-4991-8e05-a24887626378.png)

**After**

![image](https://user-images.githubusercontent.com/8199428/162772465-db889362-5082-48e0-9998-3a2bf02415b9.png)
