### PR TITLE
Fix: Direct download don't work with multicompany

### DIFF
--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2010	   Pierre Morin         <pierre.morin@auguria.net>
  * Copyright (C) 2010	   Juanjo Menent        <jmenent@2byte.es>
+ * Copyright (C) 2022	   Ferran Marcet        <fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -139,6 +140,11 @@ if (!empty($hashp))
 		} else {
 			$modulepart = $moduleparttocheck;
 			$original_file = (($tmp[1] ? $tmp[1].'/' : '').$ecmfile->filename); // this is relative to module dir
+		}
+		$entity = $ecmfile->entity;
+		if ($entity != $conf->entity) {
+			$conf->entity = $entity;
+			$conf->setValues($db);
 		}
 	} else {
 		$langs->load("errors");


### PR DESCRIPTION
If the document has been generated, for example, in entity 2, we cannot download it because by default it always considers that we are in entity 1.