### PR TITLE
Fix: The resource dropdown does not show the values

### DIFF
--- a/htdocs/resource/class/html.formresource.class.php
+++ b/htdocs/resource/class/html.formresource.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) - 2013-2015 Jean-François FERRY	<jfefe@aternatik.fr>
  * Copyright (C) 2019       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2022       Ferran Marcet           <fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -224,9 +225,10 @@ class FormResource
 					$value = ($maxlength ?dol_trunc($arraytypes['label'], $maxlength) : $arraytypes['label']);
 				} elseif ($format == 3) {
 					$value = $arraytypes['code'];
-				} elseif (empty($value)) {
-					print  '&nbsp;';
+				} else {
+					$value = '&nbsp;';
 				}
+				print $value;
 				print '</option>';
 			}
 		}

--- a/htdocs/resource/class/html.formresource.class.php
+++ b/htdocs/resource/class/html.formresource.class.php
@@ -225,7 +225,8 @@ class FormResource
 					$value = ($maxlength ?dol_trunc($arraytypes['label'], $maxlength) : $arraytypes['label']);
 				} elseif ($format == 3) {
 					$value = $arraytypes['code'];
-				} else {
+				}
+				if (empty($value)) {
 					$value = '&nbsp;';
 				}
 				print $value;


### PR DESCRIPTION
The values of the dictionary were not being displayed on the screen and the drop-down menu was empty.