### PR TITLE
FIX: Call of printOriginObjectLine hook

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4824,11 +4824,9 @@ abstract class CommonObject
 		if (!empty($this->lines)) {
 			foreach ($this->lines as $line) {
 				if (is_object($hookmanager) && (($line->product_type == 9 && !empty($line->special_code)) || !empty($line->fk_parent_line))) {
-					if (empty($line->fk_parent_line)) {
-						$parameters = array('line'=>$line, 'i'=>$i);
-						$action = '';
-						$hookmanager->executeHooks('printOriginObjectLine', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
-					}
+					$parameters = array('line' => $line, 'i' => $i);
+					$action = '';
+					$hookmanager->executeHooks('printOriginObjectLine', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 				} else {
 					$this->printOriginLine($line, '', $restrictlist, '/core/tpl', $selectedLines);
 				}


### PR DESCRIPTION
FIX: Call of printOriginObjectLine hook

This test is useless because we can't manage the children lines case with hook