### PR TITLE
Fix display in take post  when special caracter are store in database

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -232,7 +232,7 @@ function PrintCategories(first) {
 			continue;
 		}
 		$("#catdivdesc"+i).show();
-		$("#catdesc"+i).text(categories[parseInt(i)+parseInt(first)]['label']);
+		$("#catdesc"+i).html(categories[parseInt(i)+parseInt(first)]['label']);
 		$("#catimg"+i).attr("src","genimg/index.php?query=cat&id="+categories[parseInt(i)+parseInt(first)]['rowid']);
 		$("#catdiv"+i).data("rowid",categories[parseInt(i)+parseInt(first)]['rowid']);
 		$("#catdiv"+i).attr('class', 'wrapper');
@@ -266,7 +266,7 @@ function MoreCategories(moreorless) {
 			continue;
 		}
 		$("#catdivdesc"+i).show();
-		$("#catdesc"+i).text(categories[i+(<?php echo ($MAXCATEG - 2); ?> * pagecategories)]['label']);
+		$("#catdesc"+i).html(categories[i+(<?php echo ($MAXCATEG - 2); ?> * pagecategories)]['label']);
 		$("#catimg"+i).attr("src","genimg/index.php?query=cat&id="+categories[i+(<?php echo ($MAXCATEG - 2); ?> * pagecategories)]['rowid']);
 		$("#catdiv"+i).data("rowid",categories[i+(<?php echo ($MAXCATEG - 2); ?> * pagecategories)]['rowid']);
 		$("#catwatermark"+i).show();
@@ -295,8 +295,8 @@ function LoadProducts(position, issubcat) {
 	jQuery.each(subcategories, function(i, val) {
 		if (currentcat==val.fk_parent) {
 			$("#prodivdesc"+ishow).show();
-			$("#prodesc"+ishow).text(val.label);
-			$("#probutton"+ishow).text(val.label);
+			$("#prodesc"+ishow).html(val.label);
+			$("#probutton"+ishow).html(val.label);
 			$("#probutton"+ishow).show();
 			$("#proprice"+ishow).attr("class", "hidden");
 			$("#proprice"+ishow).html("");
@@ -343,13 +343,13 @@ function LoadProducts(position, issubcat) {
 					if (getDolGlobalInt('TAKEPOS_SHOW_PRODUCT_REFERENCE') == 1) {
 						echo '$("#prodesc"+ishow).html(data[parseInt(idata)][\'ref\'].bold() + \' - \' + data[parseInt(idata)][\'label\']);';
 					} else {
-						echo '$("#prodesc"+ishow).text(data[parseInt(idata)][\'label\']);';
+						echo '$("#prodesc"+ishow).html(data[parseInt(idata)][\'label\']);';
 					}
 					echo '$("#proimg"+ishow).attr("title", titlestring);';
 					echo '$("#proimg"+ishow).attr("src", "genimg/index.php?query=pro&id="+data[idata][\'id\']);';
 				} else {
 					echo '$("#probutton"+ishow).show();';
-					echo '$("#probutton"+ishow).text(data[parseInt(idata)][\'label\']);';
+					echo '$("#probutton"+ishow).html(data[parseInt(idata)][\'label\']);';
 				}
 				?>
 				if (data[parseInt(idata)]['price_formated']) {
@@ -414,9 +414,9 @@ function MoreProducts(moreorless) {
 				if (getDolGlobalInt('TAKEPOS_SHOW_PRODUCT_REFERENCE') == 1) { ?>
 					$("#prodesc"+ishow).html(data[parseInt(idata)]['ref'].bold() + ' - ' + data[parseInt(idata)]['label']);
 				<?php } else { ?>
-					$("#prodesc"+ishow).text(data[parseInt(idata)]['label']);
+					$("#prodesc"+ishow).html(data[parseInt(idata)]['label']);
 				<?php } ?>
-				$("#probutton"+ishow).text(data[parseInt(idata)]['label']);
+				$("#probutton"+ishow).html(data[parseInt(idata)]['label']);
 				$("#probutton"+ishow).show();
 				if (data[parseInt(idata)]['price_formated']) {
 					$("#proprice"+ishow).attr("class", "productprice");
@@ -597,10 +597,10 @@ function Search2(keyCodeForEnter) {
 					if (getDolGlobalInt('TAKEPOS_SHOW_PRODUCT_REFERENCE') == 1) { ?>
 					$("#prodesc" + i).html(data[i]['ref'].bold() + ' - ' + data[i]['label']);
 					<?php } else { ?>
-						$("#prodesc" + i).text(data[i]['label']);
+						$("#prodesc" + i).html(data[i]['label']);
 					<?php } ?>
 					$("#prodivdesc" + i).show();
-					$("#probutton" + i).text(data[i]['label']);
+					$("#probutton" + i).html(data[i]['label']);
 					$("#probutton" + i).show();
 					if (data[i]['price_formated']) {
 						$("#proprice" + i).attr("class", "productprice");


### PR DESCRIPTION
Replace call function
text( ) by html() to fix display in take post  when spécial caracter are store in database:

&eacute;&egrave;&agrave; become éàè

# Instructions
TakePos Doesn't display special caracter in TPV screen dispite the fact other screen is working in dolibarr.
ex : rather than display éèà in the screen we obtain &eacute;&egrave;&agrave;

To fix change call fonction in the folowing file \htdocs\takepos\index.php

//* ("#catdesc"+i).text(categories[parseInt(i)+parseInt(first)][‹ label ›]);
should be ("#catdesc"+i).html(categories[parseInt(i)+parseInt(first)][‹ label ›]);

# FIX #17242 : TakePos display problem: special characters
([url](https://github.com/Dolibarr/dolibarr/issues/17242))

