### PR TITLE
Fix #20712 - No more empty wrong line added in bookkeeping confirme_create

### DIFF
--- a/htdocs/accountancy/bookkeeping/card.php
+++ b/htdocs/accountancy/bookkeeping/card.php
@@ -642,7 +642,7 @@ if ($action == 'create') {
 				}
 
 				print "</tr>\n";
-				
+
 				// Empty line is the first line of $object->linesmvt
 				// So we must get the first line (the empty one) and pu it at the end of the array
 				// in order to display it correctly to the user
@@ -703,7 +703,7 @@ if ($action == 'create') {
 							print '<td>';
 							print '<input type="submit" class="button" name="save" value="' . $langs->trans("Add") . '">';
 							print '</td>';
-						} 
+						}
 					} else {
 						print '<!-- td columns in display mode -->';
 						$accountingaccount->fetch(null, $line->numero_compte, true);

--- a/htdocs/accountancy/bookkeeping/card.php
+++ b/htdocs/accountancy/bookkeeping/card.php
@@ -679,7 +679,7 @@ if ($action == 'create') {
 						print '<input type="hidden" name="id" value="'.$line->id.'">'."\n";
 						print '<input type="submit" class="button" name="update" value="'.$langs->trans("Update").'">';
 						print '</td>';
-					} elseif (empty($line->numero_compte) || (empty($line->debit) &&empty($line->creit))) {
+					} elseif (empty($line->numero_compte) || (empty($line->debit) && empty($line->credit))) {
 						if ($action == "" || $action == 'add') {
 							print '<!-- td columns in add mode -->';
 							print '<td>';

--- a/htdocs/accountancy/bookkeeping/card.php
+++ b/htdocs/accountancy/bookkeeping/card.php
@@ -260,7 +260,7 @@ if ($action == "confirm_update") {
 			if ($mode != '_tmp') {
 				setEventMessages($langs->trans('RecordSaved'), null, 'mesgs');
 			}
-			$action = 'update';
+			$action = '';
 			$id = $object->id;
 			$piece_num = $object->piece_num;
 		}
@@ -642,6 +642,12 @@ if ($action == 'create') {
 				}
 
 				print "</tr>\n";
+				
+				// Empty line is the first line of $object->linesmvt
+				// So we must get the first line (the empty one) and pu it at the end of the array
+				// in order to display it correctly to the user
+				$empty_line = array_shift($object->linesmvt);
+				$object->linesmvt[]= $empty_line;
 
 				foreach ($object->linesmvt as $line) {
 					print '<tr class="oddeven">';
@@ -673,7 +679,33 @@ if ($action == 'create') {
 						print '<input type="hidden" name="id" value="'.$line->id.'">'."\n";
 						print '<input type="submit" class="button" name="update" value="'.$langs->trans("Update").'">';
 						print '</td>';
+					} elseif (empty($line->numero_compte) || (empty($line->debit) &&empty($line->creit))) {
+						if ($action == "" || $action == 'add') {
+							print '<!-- td columns in add mode -->';
+							print '<td>';
+							print $formaccounting->select_account('', 'accountingaccount_number', 1, array(), 1, 1, '');
+							print '</td>';
+							print '<td>';
+							// TODO For the moment we keep a free input text instead of a combo. The select_auxaccount has problem because:
+							// It does not use the setup of "key pressed" to select a thirdparty and this hang browser on large databases.
+							// Also, it is not possible to use a value that is not in the list.
+							// Also, the label is not automatically filled when a value is selected.
+							if (!empty($conf->global->ACCOUNTANCY_COMBO_FOR_AUX)) {
+								print $formaccounting->select_auxaccount('', 'subledger_account', 1, 'maxwidth250', '', 'subledger_label');
+							} else {
+								print '<input type="text" class="maxwidth150" name="subledger_account" value="" placeholder="' . dol_escape_htmltag($langs->trans("SubledgerAccount")) . '">';
+							}
+							print '<br><input type="text" class="maxwidth150" name="subledger_label" value="" placeholder="' . dol_escape_htmltag($langs->trans("SubledgerAccountLabel")) . '">';
+							print '</td>';
+							print '<td><input type="text" class="minwidth200" name="label_operation" value="' . $label_operation . '"/></td>';
+							print '<td class="right"><input type="text" size="6" class="right" name="debit" value=""/></td>';
+							print '<td class="right"><input type="text" size="6" class="right" name="credit" value=""/></td>';
+							print '<td>';
+							print '<input type="submit" class="button" name="save" value="' . $langs->trans("Add") . '">';
+							print '</td>';
+						} 
 					} else {
+						print '<!-- td columns in display mode -->';
 						$accountingaccount->fetch(null, $line->numero_compte, true);
 						print '<td>'.$accountingaccount->getNomUrl(0, 1, 1, '', 0).'</td>';
 						print '<td>'.length_accounta($line->subledger_account);
@@ -715,33 +747,8 @@ if ($action == 'create') {
 					setEventMessages(null, array($langs->trans('MvtNotCorrectlyBalanced', $total_debit, $total_credit)), 'warnings');
 				}
 
-				if (empty($object->date_export) && empty($object->date_validation)) {
-					if ($action == "" || $action == 'add') {
-						print '<tr class="oddeven">';
-						print '<!-- td columns in add mode -->';
-						print '<td>';
-						print $formaccounting->select_account('', 'accountingaccount_number', 1, array(), 1, 1, '');
-						print '</td>';
-						print '<td>';
-						// TODO For the moment we keep a free input text instead of a combo. The select_auxaccount has problem because:
-						// It does not use the setup of "key pressed" to select a thirdparty and this hang browser on large databases.
-						// Also, it is not possible to use a value that is not in the list.
-						// Also, the label is not automatically filled when a value is selected.
-						if (!empty($conf->global->ACCOUNTANCY_COMBO_FOR_AUX)) {
-							print $formaccounting->select_auxaccount('', 'subledger_account', 1);
-						} else {
-							print '<input type="text" class="maxwidth150" name="subledger_account" value="" placeholder="' . dol_escape_htmltag($langs->trans("SubledgerAccount")) . '">';
-						}
-						print '<br><input type="text" class="maxwidth150" name="subledger_label" value="" placeholder="' . dol_escape_htmltag($langs->trans("SubledgerAccountLabel")) . '">';
-						print '</td>';
-						print '<td><input type="text" class="minwidth200" name="label_operation" value="' . $label_operation . '"/></td>';
-						print '<td class="right"><input type="text" size="6" class="right" name="debit" value=""/></td>';
-						print '<td class="right"><input type="text" size="6" class="right" name="credit" value=""/></td>';
-						print '<td><input type="submit" class="button" name="save" value="' . $langs->trans("Add") . '"></td>';
-						print '</tr>';
-					}
-					print '</table>';
-				}
+				print '</table>';
+				print '</div>';
 
 				if ($mode == '_tmp' && $action == '') {
 					print '<br>';


### PR DESCRIPTION
# FIX #20712 - No more empty wrong line added in bookkeeping confirme_create

Add (and not modify) on create mode
![FixCreatemode](https://user-images.githubusercontent.com/8067223/165169965-0b986c55-58f8-48a6-80b5-d32cebfe7873.png)

No more pen or modify link on transaction movement during editing mode
![FixEditJournal](https://user-images.githubusercontent.com/8067223/165169977-897772fc-c143-44f8-87d8-e87289f7fa4f.png)

No more empty line when setting new journal
![FixSetJournal](https://user-images.githubusercontent.com/8067223/165169983-b8484304-8516-486a-8f1b-490d40cc2c2f.png)
