### PR TITLE
FIX #20733 Inventory: Do not use batch qty even if present if batch module is disabled.

### DIFF
--- a/htdocs/product/inventory/class/inventory.class.php
+++ b/htdocs/product/inventory/class/inventory.class.php
@@ -310,7 +310,7 @@ class Inventory extends CommonObject
 
 					if ($conf->productbatch->enabled) {
 						$inventoryline->qty_stock = ($obj->batch ? $obj->qty : $obj->reel); // If there is batch detail, we take qty for batch, else global qty
-					}else{
+					} else {
 						$inventoryline->qty_stock = $obj->reel;
 					}
 

--- a/htdocs/product/inventory/class/inventory.class.php
+++ b/htdocs/product/inventory/class/inventory.class.php
@@ -306,8 +306,13 @@ class Inventory extends CommonObject
 					$inventoryline->fk_warehouse = $obj->fk_warehouse;
 					$inventoryline->fk_product = $obj->fk_product;
 					$inventoryline->batch = $obj->batch;
-					$inventoryline->qty_stock = ($obj->batch ? $obj->qty : $obj->reel); // If there is batch detail, we take qty for batch, else global qty
 					$inventoryline->datec = dol_now();
+
+					if ($conf->productbatch->enabled) {
+						$inventoryline->qty_stock = ($obj->batch ? $obj->qty : $obj->reel); // If there is batch detail, we take qty for batch, else global qty
+					}else{
+						$inventoryline->qty_stock = $obj->reel;
+					}
 
 					$resultline = $inventoryline->create($user);
 					if ($resultline <= 0) {


### PR DESCRIPTION
# FIX #20733 Inventory: Do not use batch qty even if present if batch module is disabled.

When creating / validating an inventory, the products lines should be filled with expected quantity from stock, but if the batch module has been enabled and used in the past, the expected quantity if filled in with old batch stock.