### PR TITLE
CLOSE #20736 Allow extrafields SQL filters on REST API product lookup

### DIFF
--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -195,7 +195,7 @@ class Products extends DolibarrApi
 		}
 
 		if ($allow_extrafields_sqlfilters) {
-			$sql .= " LEFT JOIN llx_product_extrafields AS ef ON ef.fk_object = t.rowid";
+			$sql .= ", ".MAIN_DB_PREFIX."product_extrafields AS ef";
 		}
 
 		$sql .= ' WHERE t.entity IN ('.getEntity('product').')';
@@ -223,6 +223,11 @@ class Products extends DolibarrApi
 			// Show only services
 			$sql .= " AND t.fk_product_type = 1";
 		}
+
+		if ($allow_extrafields_sqlfilters) {
+			$sql .= " AND ef.fk_object = t.rowid";
+		}
+
 		// Add sql filters
 		if ($sqlfilters) {
 			$errormessage = '';

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -189,12 +189,10 @@ class Products extends DolibarrApi
 
 		$sql = "SELECT t.rowid, t.ref, t.ref_ext";
 		$sql .= " FROM ".$this->db->prefix()."product as t";
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product_extrafields AS ef ON ef.fk_object = t.rowid";	// So we will be able to filter on extrafields
 		if ($category > 0) {
 			$sql .= ", ".$this->db->prefix()."categorie_product as c";
 		}
-
-		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product_extrafields AS ef ON (ef.fk_object = t.rowid)";
-
 		$sql .= ' WHERE t.entity IN ('.getEntity('product').')';
 
 		if ($variant_filter == 1) {

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -173,9 +173,10 @@ class Products extends DolibarrApi
 	 * @param  int    $variant_filter   	Use this param to filter list (0 = all, 1=products without variants, 2=parent of variants, 3=variants only)
 	 * @param  bool   $pagination_data   	If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0
 	 * @param  int    $includestockdata		Load also information about stock (slower)
+	 * @param  bool   $allow_extrafields_sqlfilters Allow sqlfilters to contain extrafields filter (slower).
 	 * @return array                		Array of product objects
 	 */
-	public function index($sortfield = "t.ref", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $ids_only = false, $variant_filter = 0, $pagination_data = false, $includestockdata = 0)
+	public function index($sortfield = "t.ref", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $ids_only = false, $variant_filter = 0, $pagination_data = false, $includestockdata = 0, $allow_extrafields_sqlfilters = false)
 	{
 		global $db, $conf;
 
@@ -192,6 +193,11 @@ class Products extends DolibarrApi
 		if ($category > 0) {
 			$sql .= ", ".$this->db->prefix()."categorie_product as c";
 		}
+
+		if ($allow_extrafields_sqlfilters) {
+			$sql .= " LEFT JOIN llx_product_extrafields AS ef ON ef.fk_object = t.rowid";
+		}
+
 		$sql .= ' WHERE t.entity IN ('.getEntity('product').')';
 
 		if ($variant_filter == 1) {

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -173,10 +173,9 @@ class Products extends DolibarrApi
 	 * @param  int    $variant_filter   	Use this param to filter list (0 = all, 1=products without variants, 2=parent of variants, 3=variants only)
 	 * @param  bool   $pagination_data   	If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0
 	 * @param  int    $includestockdata		Load also information about stock (slower)
-	 * @param  bool   $allow_extrafields_sqlfilters Allow sqlfilters to contain extrafields filter (slower).
 	 * @return array                		Array of product objects
 	 */
-	public function index($sortfield = "t.ref", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $ids_only = false, $variant_filter = 0, $pagination_data = false, $includestockdata = 0, $allow_extrafields_sqlfilters = false)
+	public function index($sortfield = "t.ref", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $ids_only = false, $variant_filter = 0, $pagination_data = false, $includestockdata = 0)
 	{
 		global $db, $conf;
 
@@ -194,9 +193,7 @@ class Products extends DolibarrApi
 			$sql .= ", ".$this->db->prefix()."categorie_product as c";
 		}
 
-		if ($allow_extrafields_sqlfilters) {
-			$sql .= ", ".MAIN_DB_PREFIX."product_extrafields AS ef";
-		}
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product_extrafields AS ef ON (ef.fk_object = t.rowid)";
 
 		$sql .= ' WHERE t.entity IN ('.getEntity('product').')';
 
@@ -222,10 +219,6 @@ class Products extends DolibarrApi
 		} elseif ($mode == 2) {
 			// Show only services
 			$sql .= " AND t.fk_product_type = 1";
-		}
-
-		if ($allow_extrafields_sqlfilters) {
-			$sql .= " AND ef.fk_object = t.rowid";
 		}
 
 		// Add sql filters


### PR DESCRIPTION
# CLOSE #20736 Allow extrafields SQL filters on REST API product lookup

Allow SQL filters to contain filters related to extrafields in REST API "GET /products". 
This will allow external apps to filters products based on extrafields.

