### PR TITLE
FIX #20738 Inventory: Add missing <td....> for movement number / card.

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -1115,11 +1115,11 @@ if ($object->id > 0) {
 					print '<td class="right">';
 					print price($pmp_valuation_real);
 					print '</td>';
-					print '<td class="nowraponall right">';
 
 					$totalExpectedValuation += $pmp_valuation;
 					$totalRealValuation += $pmp_valuation_real;
 				}
+				
 				print '<td class="nowraponall right">';
 				if ($obj->fk_movement > 0) {
 					$stockmovment = new MouvementStock($db);

--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -1120,6 +1120,7 @@ if ($object->id > 0) {
 					$totalExpectedValuation += $pmp_valuation;
 					$totalRealValuation += $pmp_valuation_real;
 				}
+				print '<td class="nowraponall right">';
 				if ($obj->fk_movement > 0) {
 					$stockmovment = new MouvementStock($db);
 					$stockmovment->fetch($obj->fk_movement);


### PR DESCRIPTION
# FIX #20738 Inventory: Add missing <td....> for movement number / card.
The movement numbers / cards are all displayed at the top instead of at the end of their respective line.
This is because of a <td...> markup that got lost.