### PR TITLE
FIX fk_account is lost when we update payment information

### DIFF
--- a/htdocs/compta/bank/line.php
+++ b/htdocs/compta/bank/line.php
@@ -130,9 +130,9 @@ if ($user->rights->banque->modifier && $action == "update") {
 
 	$actarget = new Account($db);
 	if (GETPOST('accountid', 'int') > 0 && !$acline->rappro && !$acline->getVentilExportCompta()) {	// We ask to change bank account
-		$actarget->fetch(GETPOST('accountid', 'int'));
+		$account_id = $actarget->fetch(GETPOST('accountid', 'int'));
 	} else {
-		$actarget->fetch($id);
+		$account_id = $acline->fk_account;
 	}
 
 	if ($actarget->courant == Account::TYPE_CASH && GETPOST('value', 'alpha') != 'LIQ') {
@@ -176,7 +176,7 @@ if ($user->rights->banque->modifier && $action == "update") {
 				$sql .= " datev = '".$db->idate($dateval)."',";
 			}
 		}
-		$sql .= " fk_account = ".((int) $actarget->id);
+		$sql .= " fk_account = ".((int) $account_id);
 		$sql .= " WHERE rowid = ".((int) $acline->id);
 
 		$result = $db->query($sql);


### PR DESCRIPTION
Refer to this post in french forum : https://www.dolibarr.fr/forum/t/bug-ecriture-casse-apres-modification-du-mode-de-paiement-si-lecriture-est-rapproche/39977/2

A description of the conditions in which the bug occurs
(If needed screen copy/logs...)
Anomaly 1 : Writing on internal transfer

    I create an internal transfer whatever the account and the amount.
    I enter a statement name and reconcile the entry by checking the box.
    To break the entry, I forget to uncheck the box Entry reconciled with the bank statement and I change the payment method.
    The entry is broken and impossible to modify.
    If I check the box for reconciliation again, the entry is no longer linked.
    *It is still possible to delete one of the two entries, the other is no longer displayed in the list of entries but when you export the entries in csv, it appears in the export.

Anomaly 2: Entry on miscellaneous payment
I create a miscellaneous payment regardless of the amount, the account and the debit/credit direction.

    I enter a statement name and reconcile the entry by checking the box.
    To break the entry, I forget to uncheck the box Entry reconciled with the bank statement and I change the payment method.
    The entry is broken and it is impossible to modify or delete it because it is transformed into a cash entry and does not appear in the cashier's entry.
    *The entry is present in the csv export of the various payment entries.

When the entry is cleared, it is possible to change the payment mode in the drop-down list. I think that this field should be blocked if the entry is reconciled.