### PR TITLE
New supplier invoice model : just add a stamp on PDF

### DIFF
--- a/htdocs/core/modules/supplier_invoice/doc/pdf_paprika.modules.php
+++ b/htdocs/core/modules/supplier_invoice/doc/pdf_paprika.modules.php
@@ -292,10 +292,10 @@ class pdf_paprika extends ModelePDFSuppliersInvoices
 				foreach (glob($dir."/".$objectref."-*.pdf") as $otherpdf) {
 					$otherpdfindir = $otherpdf;
 				}
-                if (null !== $otherpdfindir) {
-                    $pagecount = $pdf->setSourceFile($otherpdfindir);
-                    $tplidx = $pdf->importPage(1);
-                }
+				if (null !== $otherpdfindir) {
+					$pagecount = $pdf->setSourceFile($otherpdfindir);
+					$tplidx = $pdf->importPage(1);
+				}
 
 				$pdf->Open();
 				$pagenb = 0;
@@ -389,9 +389,9 @@ class pdf_paprika extends ModelePDFSuppliersInvoices
 		$pdf->SetFont('', 'B', $default_font_size + 3);
 		$pdf->SetXY($posx, $posy);
 		$pdf->SetLineWidth(0.5);
-		$pdf->SetDrawColor(200,10,10);
-		$pdf->SetFillColor(255,255,255);
-        $pdf->RoundedRect($posx, $posy, $cellwidth, $cellheight*2, 1.5, '1111','FD');
+		$pdf->SetDrawColor(200, 10, 10);
+		$pdf->SetFillColor(255, 255, 255);
+		$pdf->RoundedRect($posx, $posy, $cellwidth, $cellheight*2, 1.5, '1111', 'FD');
 		$pdf->SetTextColor(200, 10, 10);
 		$pdf->MultiCell($cellwidth, $cellheight, $outputlangs->convToOutputCharset($object->ref), '', 'C');
 		$posy += 1;

--- a/htdocs/core/modules/supplier_invoice/doc/pdf_paprika.modules.php
+++ b/htdocs/core/modules/supplier_invoice/doc/pdf_paprika.modules.php
@@ -1,0 +1,418 @@
+<?php
+/* Copyright (C) 2010-2011  Juanjo Menent        <jmenent@2byte.es>
+ * Copyright (C) 2010-2014  Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2015       Marcos García        <marcosgdf@gmail.com>
+ * Copyright (C) 2018-2021  Frédéric France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2022  		Éric <Seigne>		 <eric.seigne@cap-rel.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *	\file       htdocs/core/modules/supplier_invoice/doc/pdf_paprika.modules.php
+ *	\ingroup    fournisseur
+ *	\brief      Class file to generate the supplier invoices with the paprika model
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/core/modules/supplier_invoice/modules_facturefournisseur.php';
+require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/pdf.lib.php';
+
+
+/**
+ *	Class to generate the supplier invoices PDF with the template paprika
+ */
+class pdf_paprika extends ModelePDFSuppliersInvoices
+{
+	/**
+	 * @var DoliDb Database handler
+	 */
+	public $db;
+
+	/**
+	 * @var string model name
+	 */
+	public $name;
+
+	/**
+	 * @var string model description (short text)
+	 */
+	public $description;
+
+	/**
+	 * @var int 	Save the name of generated file as the main doc when generating a doc with this template
+	 */
+	public $update_main_doc_field;
+
+	/**
+	 * @var string document type
+	 */
+	public $type;
+
+	/**
+	 * @var array Minimum version of PHP required by module.
+	 * e.g.: PHP ≥ 5.6 = array(5, 6)
+	 */
+	public $phpmin = array(5, 6);
+
+	/**
+	 * Dolibarr version of the loaded document
+	 * @var string
+	 */
+	public $version = 'dolibarr';
+
+	/**
+	 * @var int page_largeur
+	 */
+	public $page_largeur;
+
+	/**
+	 * @var int page_hauteur
+	 */
+	public $page_hauteur;
+
+	/**
+	 * @var array format
+	 */
+	public $format;
+
+	/**
+	 * @var int marge_gauche
+	 */
+	public $marge_gauche;
+
+	/**
+	 * @var int marge_droite
+	 */
+	public $marge_droite;
+
+	/**
+	 * @var int marge_haute
+	 */
+	public $marge_haute;
+
+	/**
+	 * @var int marge_basse
+	 */
+	public $marge_basse;
+
+	/**
+	 * Issuer
+	 * @var Societe object that emits
+	 */
+	public $emetteur;
+
+
+
+	/**
+	 *	Constructor
+	 *
+	 *  @param	DoliDB		$db     	Database handler
+	 */
+	public function __construct($db)
+	{
+		global $conf, $langs, $mysoc;
+
+		// Translations
+		$langs->loadLangs(array("main", "bills"));
+
+		$this->db = $db;
+		$this->name = "paprika";
+		$this->description = $langs->trans('SuppliersInvoiceModel');
+		$this->update_main_doc_field = 1; // Save the name of generated file as the main doc when generating a doc with this template
+
+		// Page dimensions
+		$this->type = 'pdf';
+		$formatarray = pdf_getFormat();
+		$this->page_largeur = $formatarray['width'];
+		$this->page_hauteur = $formatarray['height'];
+		$this->format = array($this->page_largeur, $this->page_hauteur);
+		$this->marge_gauche = isset($conf->global->MAIN_PDF_MARGIN_LEFT) ? $conf->global->MAIN_PDF_MARGIN_LEFT : 10;
+		$this->marge_droite = isset($conf->global->MAIN_PDF_MARGIN_RIGHT) ? $conf->global->MAIN_PDF_MARGIN_RIGHT : 10;
+		$this->marge_haute = isset($conf->global->MAIN_PDF_MARGIN_TOP) ? $conf->global->MAIN_PDF_MARGIN_TOP : 10;
+		$this->marge_basse = isset($conf->global->MAIN_PDF_MARGIN_BOTTOM) ? $conf->global->MAIN_PDF_MARGIN_BOTTOM : 10;
+
+		$this->option_logo = 1; // Display logo
+		$this->option_tva = 1; // Manage the vat option FACTURE_TVAOPTION
+		$this->option_modereg = 1; // Display payment mode
+		$this->option_condreg = 1; // Display payment terms
+		$this->option_codeproduitservice = 1; // Display product-service code
+		$this->option_multilang = 1; // Available in several languages
+
+		// Define column position
+		$this->posxdesc = $this->marge_gauche + 1;
+		$this->posxtva = 112;
+		$this->posxup = 126;
+		$this->posxqty = 145;
+		$this->posxunit = 162;
+		$this->posxdiscount = 162;
+		$this->postotalht = 174;
+
+		if (!empty($conf->global->PRODUCT_USE_UNITS)) {
+			$this->posxtva = 99;
+			$this->posxup = 114;
+			$this->posxqty = 130;
+			$this->posxunit = 147;
+		}
+		//if (! empty($conf->global->MAIN_GENERATE_DOCUMENTS_WITHOUT_VAT)) $this->posxtva=$this->posxup;
+		$this->posxpicture = $this->posxtva - (empty($conf->global->MAIN_DOCUMENTS_WITH_PICTURE_WIDTH) ? 20 : $conf->global->MAIN_DOCUMENTS_WITH_PICTURE_WIDTH); // width of images
+		if ($this->page_largeur < 210) { // To work with US executive format
+			$this->posxpicture -= 20;
+			$this->posxtva -= 20;
+			$this->posxup -= 20;
+			$this->posxqty -= 20;
+			$this->posxunit -= 20;
+			$this->posxdiscount -= 20;
+			$this->postotalht -= 20;
+		}
+
+		$this->tva = array();
+		$this->tva_array = array();
+		$this->localtax1 = array();
+		$this->localtax2 = array();
+		$this->atleastoneratenotnull = 0;
+		$this->atleastonediscount = 0;
+	}
+
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *  Function to build pdf onto disk
+	 *
+	 *  @param		FactureFournisseur	$object				Object to generate
+	 *  @param		Translate			$outputlangs		Lang output object
+	 *  @param		string				$srctemplatepath	Full path of source filename for generator using a template file
+	 *  @param		int					$hidedetails		Do not show line details
+	 *  @param		int					$hidedesc			Do not show desc
+	 *  @param		int					$hideref			Do not show ref
+	 *  @return		int										1=OK, 0=KO
+	 */
+	public function write_file($object, $outputlangs = '', $srctemplatepath = '', $hidedetails = 0, $hidedesc = 0, $hideref = 0)
+	{
+		// phpcs:enable
+		global $user, $langs, $conf, $mysoc, $hookmanager, $nblines;
+
+		// Get source company
+		if (!is_object($object->thirdparty)) {
+			$object->fetch_thirdparty();
+		}
+		if (!is_object($object->thirdparty)) {
+			$object->thirdparty = $mysoc; // If fetch_thirdparty fails, object has no socid (specimen)
+		}
+
+		$this->emetteur = $object->thirdparty;
+		if (!$this->emetteur->country_code) {
+			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default, if was not defined
+		}
+
+		if (!is_object($outputlangs)) {
+			$outputlangs = $langs;
+		}
+		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
+		if (!empty($conf->global->MAIN_USE_FPDF)) {
+			$outputlangs->charset_output = 'ISO-8859-1';
+		}
+
+		// Load translation files required by the page
+		$outputlangs->loadLangs(array("main", "dict", "companies", "bills", "products"));
+
+		$nblines = count($object->lines);
+
+		if ($conf->fournisseur->facture->dir_output) {
+			// Definition of $dir and $file
+			if ($object->specimen) {
+				$dir = $conf->fournisseur->facture->dir_output;
+				$file = $dir."/SPECIMEN.pdf";
+			} else {
+				$objectref = dol_sanitizeFileName($object->ref);
+				$objectrefsupplier = dol_sanitizeFileName($object->ref_supplier);
+				$dir = $conf->fournisseur->facture->dir_output.'/'.get_exdir($object->id, 2, 0, 0, $object, 'invoice_supplier').$objectref;
+				$file = $dir."/".$objectref.".pdf";
+				if (!empty($conf->global->SUPPLIER_REF_IN_NAME)) {
+					$file = $dir."/".$objectref.($objectrefsupplier ? "_".$objectrefsupplier : "").".pdf";
+				}
+			}
+
+			if (!file_exists($dir)) {
+				if (dol_mkdir($dir) < 0) {
+					$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
+					return 0;
+				}
+			}
+
+			if (file_exists($dir)) {
+				// Add pdfgeneration hook
+				if (!is_object($hookmanager)) {
+					include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
+					$hookmanager = new HookManager($this->db);
+				}
+				$hookmanager->initHooks(array('pdfgeneration'));
+				$parameters = array('file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs);
+				global $action;
+				$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+
+				// Create pdf instance
+				$pdf = pdf_getInstance($this->format);
+				$default_font_size = pdf_getPDFFontSize($outputlangs); // Must be after pdf_getInstance
+				$pdf->SetAutoPageBreak(1, 0);
+
+				$heightforfreetext = (isset($conf->global->MAIN_PDF_FREETEXT_HEIGHT) ? $conf->global->MAIN_PDF_FREETEXT_HEIGHT : 5); // Height reserved to output the free text on last page
+				$heightforfooter = $this->marge_basse + 8; // Height reserved to output the footer (value include bottom margin)
+				if (!empty($conf->global->MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS)) {
+					$heightforfooter += 6;
+				}
+
+				if (class_exists('TCPDF')) {
+					$pdf->setPrintHeader(false);
+					$pdf->setPrintFooter(false);
+				}
+				$pdf->SetFont(pdf_getPDFFont($outputlangs));
+				// Set path to the background PDF File
+				if (!empty($conf->global->MAIN_ADD_PDF_BACKGROUND)) {
+					$pagecount = $pdf->setSourceFile($conf->mycompany->multidir_output[$object->entity].'/'.$conf->global->MAIN_ADD_PDF_BACKGROUND);
+					$tplidx = $pdf->importPage(1);
+				}
+				//search for a pdf file $object->ref-xxxx.pdf in same folder
+				$otherpdfindir = null;
+				foreach (glob($dir."/".$objectref."-*.pdf") as $otherpdf) {
+					$otherpdfindir = $otherpdf;
+				}
+                if (null !== $otherpdfindir) {
+                    $pagecount = $pdf->setSourceFile($otherpdfindir);
+                    $tplidx = $pdf->importPage(1);
+                }
+
+				$pdf->Open();
+				$pagenb = 0;
+				$pdf->SetDrawColor(128, 128, 128);
+
+				$pdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
+				$pdf->SetSubject($outputlangs->transnoentities("PdfInvoiceTitle"));
+				$pdf->SetCreator("Dolibarr ".DOL_VERSION);
+				$pdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
+				$pdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref)." ".$outputlangs->transnoentities("PdfInvoiceTitle")." ".$outputlangs->convToOutputCharset($object->thirdparty->name));
+				if (!empty($conf->global->MAIN_DISABLE_PDF_COMPRESSION)) {
+					$pdf->SetCompression(false);
+				}
+
+				$pdf->SetMargins($this->marge_gauche, $this->marge_haute, $this->marge_droite); // Left, Top, Right
+
+				// New page
+				$pdf->AddPage();
+				if (!empty($tplidx)) {
+					$pdf->useTemplate($tplidx);
+				}
+				$pagenb++;
+				$top_shift = $this->_pagehead($pdf, $object, 1, $outputlangs);
+				$pdf->SetFont('', '', $default_font_size - 1);
+				$pdf->MultiCell(0, 3, ''); // Set interline to 3
+				$pdf->SetTextColor(0, 0, 0);
+
+				$pdf->Close();
+
+				$pdf->Output($file, 'F');
+
+				// Add pdfgeneration hook
+				$hookmanager->initHooks(array('pdfgeneration'));
+				$parameters = array('file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs);
+				global $action;
+				$reshook = $hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+				if ($reshook < 0) {
+					$this->error = $hookmanager->error;
+					$this->errors = $hookmanager->errors;
+				}
+
+				if (!empty($conf->global->MAIN_UMASK)) {
+					@chmod($file, octdec($conf->global->MAIN_UMASK));
+				}
+
+				$this->result = array('fullpath'=>$file);
+
+				return 1; // No error
+			} else {
+				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
+				return 0;
+			}
+		} else {
+			$this->error = $langs->transnoentities("ErrorConstantNotDefined", "SUPPLIER_OUTPUTDIR");
+			return 0;
+		}
+	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
+	/**
+	 *  Show top header of page.
+	 *
+	 *  @param  TCPDF               $pdf            Object PDF
+	 *  @param  FactureFournisseur  $object         Object to show
+	 *  @param  int                 $showaddress    0=no, 1=yes
+	 *  @param  Translate           $outputlangs    Object lang for output
+	 *  @return int
+	 */
+	protected function _pagehead(&$pdf, $object, $showaddress, $outputlangs)
+	{
+		global $langs, $conf, $mysoc;
+
+		// Load translation files required by the page
+		$outputlangs->loadLangs(array("main", "orders", "companies", "bills"));
+
+		$default_font_size = pdf_getPDFFontSize($outputlangs);
+
+		// Do not add the BACKGROUND as this is for suppliers
+		//pdf_pagehead($pdf,$outputlangs,$this->page_hauteur);
+
+		$pdf->SetTextColor(0, 0, 60);
+		$pdf->SetFont('', 'B', $default_font_size + 3);
+
+		$cellwidth = 35;
+		$cellheight = 3;
+		$posy = $this->marge_haute;
+		$posx = $this->page_largeur - $this->marge_droite - $cellwidth;
+
+		$pdf->SetXY($this->marge_gauche, $posy);
+
+		$pdf->SetFont('', 'B', $default_font_size + 3);
+		$pdf->SetXY($posx, $posy);
+		$pdf->SetLineWidth(0.5);
+		$pdf->SetDrawColor(200,10,10);
+		$pdf->SetFillColor(255,255,255);
+        $pdf->RoundedRect($posx, $posy, $cellwidth, $cellheight*2, 1.5, '1111','FD');
+		$pdf->SetTextColor(200, 10, 10);
+		$pdf->MultiCell($cellwidth, $cellheight, $outputlangs->convToOutputCharset($object->ref), '', 'C');
+		$posy += 1;
+
+		return 0;
+	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
+	/**
+	 *  Show footer of page. Need this->emetteur object
+	 *
+	 *  @param  TCPDF               $pdf                PDF
+	 *  @param  FactureFournisseur  $object             Object to show
+	 *  @param  Translate           $outputlangs        Object lang for output
+	 *  @param  int                 $hidefreetext       1=Hide free text
+	 *  @return int                                     Return height of bottom margin including footer text
+	 */
+	protected function _pagefoot(&$pdf, $object, $outputlangs, $hidefreetext = 0)
+	{
+		global $conf;
+		$showdetails = empty($conf->global->MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS) ? 0 : $conf->global->MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS;
+		return pdf_pagefoot($pdf, $outputlangs, 'SUPPLIER_INVOICE_FREE_TEXT', $this->emetteur, $this->marge_basse, $this->marge_gauche, $this->page_hauteur, $object, $showdetails, $hidefreetext);
+	}
+}


### PR DESCRIPTION
# NEW : add a stamp on supplier invoice PDF

That new model add only a stamp on supplier PDF with internal dolibarr reference (for example "SI2205-0075") : so you don't have to take your pen and write that ref on paper when you make your paperwork (save time on accounting job).

Example: here is a screenshot of supplier invoice pushed in dolibarr

![image](https://user-images.githubusercontent.com/1468823/167245741-cccbe26c-092e-409d-8048-c6182828327c.png)

And here is the result with paprika model

![image](https://user-images.githubusercontent.com/1468823/167245757-7b365cfa-7389-49ac-bd86-1e3e8639777c.png)

Maybe you can find more informations on french forum : https://www.dolibarr.fr/forum/t/facture-fournisseur-compta-numerotation-perte-de-temps-et-automatisation/40032
