### PR TITLE
FIX Accountancy - Product Account - SQL Error with only_full_group_by option enabled FPC21+

### DIFF
--- a/htdocs/accountancy/admin/productaccount.php
+++ b/htdocs/accountancy/admin/productaccount.php
@@ -384,6 +384,7 @@ if ($search_onpurchase != '' && $search_onpurchase != '-1') {
 $sql .= " GROUP BY p.rowid, p.ref, p.label, p.description, p.tosell, p.tobuy, p.tva_tx,";
 $sql .= " p.fk_product_type,";
 $sql .= ' p.tms,';
+$sql .= ' aa.rowid,';
 if (empty($conf->global->MAIN_PRODUCT_PERENTITY_SHARED)) {
 	$sql .= " p.accountancy_code_sell, p.accountancy_code_sell_intra, p.accountancy_code_sell_export, p.accountancy_code_buy, p.accountancy_code_buy_intra, p.accountancy_code_buy_export";
 } else {


### PR DESCRIPTION
Error return : 


> Dolibarr a détecté une erreur technique.
> 
> Voici les informations qui pourront aider au diagnostic (Vous pouvez fixer l'option $dolibarr_main_prod sur '1' pour supprimer quelques notifications):
> 
> Date: 20220506102259
> 
> Dolibarr: 14.0.5 - https://www.dolibarr.org
> 
> Niveau de fonctionnalités: 0
> 
> PHP: 7.4.29
> 
> Serveur: Apache/2.4.37 (Oracle Linux) OpenSSL/1.1.1k
> 
> OS: Linux dc1srv137 5.4.17-2136.306.1.3.el8uek.x86_64 #2 SMP Fri Apr 8 14:50:24 PDT 2022 x86_64
> 
> UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.41 Safari/537.36
> 
> Url sollicitée: /dolibarr/accountancy/admin/productaccount.php?mainmenu=accountancy&leftmenu=accountancy_admin
> 
> Referer: https://xxxxxxxxxxxxxxxx/dolibarr/accountancy/index.php?leftmenu=accountancy_admin
> 
> 
> Type gestionnaire de base de données: mysqli
> 
> Requête dernier accès en base en erreur: SELECT p.rowid, p.ref, p.label, p.description, p.tosell, p.tobuy, p.tva_tx, ppe.accountancy_code_sell, ppe.accountancy_code_sell_intra, ppe.accountancy_code_sell_export, ppe.accountancy_code_buy, ppe.accountancy_code_buy_intra, ppe.accountancy_code_buy_export, p.tms, p.fk_product_type as product_type, aa.rowid as aaid FROM llx_product as p LEFT JOIN llx_product_perentity as ppe ON ppe.fk_product = p.rowid AND ppe.entity = 1 LEFT JOIN llx_accounting_account as aa ON aa.account_number = ppe.accountancy_code_sell AND aa.fk_pcg_version = 'PCG99-XXXXXX' WHERE p.entity IN (1) AND aa.account_number IS NULL GROUP BY p.rowid, p.ref, p.label, p.description, p.tosell, p.tobuy, p.tva_tx, p.fk_product_type, p.tms, ppe.accountancy_code_sell, ppe.accountancy_code_sell_intra, ppe.accountancy_code_sell_export, ppe.accountancy_code_buy, ppe.accountancy_code_buy_intra, ppe.accountancy_code_buy_export ORDER BY p.ref ASC LIMIT 51
> 
> Code retour dernier accès en base en erreur: DB_ERROR_1055
> 
> Information sur le dernier accès en base en erreur: Expression #16 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'dolibarr.aa.rowid' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by