### PR TITLE
fix: limit filename lenght to show glasses into document boxes

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -892,7 +892,7 @@ class FormFile
 					}
 					$out .= '>';
 					$out .= img_mime($file["name"], $langs->trans("File").': '.$file["name"]);
-					$out .= dol_trunc($file["name"], 150);
+					$out .= dol_trunc($file["name"], 40);
 					$out .= '</a>'."\n";
 					$out .= $this->showPreview($file, $modulepart, $relativepath, 0, $param);
 					$out .= '</td>';


### PR DESCRIPTION
fix: limit filename length to show glasses into document boxes

Before
![image](https://user-images.githubusercontent.com/1050053/167411998-37cfbabf-41c3-4858-bd2b-80f020a44747.png)

After
![image](https://user-images.githubusercontent.com/1050053/167412157-40aeea06-cd98-42a5-b4f1-1ff82917da0a.png)
