### PR TITLE
FIX: formconfirm: pass action even when confirm is no

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4382,7 +4382,7 @@ class Form
 				$dialogconfirm .= '-'.$button;
 			}
 			$pageyes = $page.(preg_match('/\?/', $page) ? '&' : '?').'action='.$action.'&confirm=yes';
-			$pageno = ($useajax == 2 ? $page.(preg_match('/\?/', $page) ? '&' : '?').'confirm=no' : '');
+			$pageno = ($useajax == 2 ? $page.(preg_match('/\?/', $page) ? '&' : '?').'action='.$action.'&confirm=no' : '');
 			// Add input fields into list of fields to read during submit (inputok and inputko)
 			if (is_array($formquestion))
 			{


### PR DESCRIPTION
Obviously, one may question whether this is really a bugfix or a new feature (behavior change), but I'm kinda confident that this is not a breaking change for people who were relying on confirm=no without the action.

This change is really helpful if you want to handle the refusal of a specific action and do specific treatment later on.