### PR TITLE
NEW uncheck send message when private message is checked

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1208,19 +1208,37 @@ class FormTicket
 		jQuery(document).ready(function() {
 			send_email=' . $send_email.';
 			if (send_email) {
+				if (!jQuery("#send_msg_email").is(":checked")) {
+					jQuery("#send_msg_email").prop("checked", true).trigger("change");
+				}
 				jQuery(".email_line").show();
 			} else {
+				if (!jQuery("#private_message").is(":checked")) {
+					jQuery("#private_message").prop("checked", true).trigger("change");
+				}
 				jQuery(".email_line").hide();
 			}
 
 			jQuery("#send_msg_email").click(function() {
 				if(jQuery(this).is(":checked")) {
+					if (jQuery("#private_message").is(":checked")) {
+						jQuery("#private_message").prop("checked", false).trigger("change");
+					}
 					jQuery(".email_line").show();
 				}
 				else {
 					jQuery(".email_line").hide();
 				}
-            });';
+            });
+
+            jQuery("#private_message").click(function() {
+				if (jQuery(this).is(":checked")) {
+					if (jQuery("#send_msg_email").is(":checked")) {
+						jQuery("#send_msg_email").prop("checked", false).trigger("change");
+					}
+					jQuery(".email_line").hide();
+				}
+			});';
 		print '});
 		</script>';
 


### PR DESCRIPTION
On a ticket card you can add a message and choose to : 
- send an email
- mark as private
![image](https://user-images.githubusercontent.com/45359511/167607483-063d2bfb-f8d6-40d1-90ef-fd624948330d.png)

When you click on "add a message", no option "send an email" or "mark as private" was selected.

So now we select one option by default determined by the GET or POST value of "send an email".
And after when we click to "send an email", the "private message" checkbox is unchecked.
And when we click to "private message" checkbox, the "send an email" checkbox is unchecked.
