### PR TITLE
FIX : user creation from admin user

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -644,7 +644,7 @@ function checkUserAccessToObject($user, array $featuresarray, $objectid = 0, $ta
 						$sql .= " WHERE dbt.".$dbt_select." IN (".$db->sanitize($objectid, 1).")";
 						$sql .= " AND ((ug.fk_user = dbt.rowid";
 						$sql .= " AND ug.entity IN (".getEntity('usergroup')."))";
-						$sql .= " OR dbt.entity = 0)"; // Show always superadmin
+						$sql .= " OR dbt.entity IN (0, ".$conf->entity."))"; // Show always superadmin
 					}
 				} else {
 					$sql .= " WHERE dbt.".$dbt_select." IN (".$db->sanitize($objectid, 1).")";


### PR DESCRIPTION
### NEW : User creation with multicompany 

If multicompany and the config MULTICOMPANY_TRANSVERSE_MODE enabled, when an admin user tries to create another user, the admin user can't access to created user card. 

There was an error message just after the creation, when the redirection / user tries to access to the created user card.

