### PR TITLE
FIX dictionary table name in incoterms for Debug v16

### DIFF
--- a/htdocs/core/modules/modIncoterm.class.php
+++ b/htdocs/core/modules/modIncoterm.class.php
@@ -85,7 +85,7 @@ class modIncoterm extends DolibarrModules
 		}
 		$this->dictionaries = array(
 			'langs'=>'incoterm',
-			'tabname'=>array(MAIN_DB_PREFIX."c_incoterms"), // List of tables we want to see into dictonnary editor
+			'tabname'=>array("c_incoterms"), // List of tables we want to see into dictonnary editor
 			'tablib'=>array("Incoterms"), // Label of tables
 			'tabsql'=>array('SELECT rowid, code, libelle, active FROM '.MAIN_DB_PREFIX.'c_incoterms'), // Request to select fields
 			'tabsqlsort'=>array("rowid ASC"), // Sort order


### PR DESCRIPTION
FIX dictionary table name in incoterms for Debug v16
- you can't add or update a line in the incoterms dictionary
- remove "MAIN_DB_PREFIX" in dictionary table name