### PR TITLE
CLOSE #20867 Add Hook to extend $arrayofmassactions in list.php

### DIFF
--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -988,6 +988,12 @@ if ($resql) {
 		$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
 	}
 
+	$parameters = ['arrayofmassactions'=>&$arrayofmassactions];
+	$reshook = $hookmanager->executeHooks('doListMassActions', $parameters);
+	if ($reshook < 0) {
+		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	}
+
 	if (in_array($massaction, array('presend', 'predelete', 'closed'))) {
 		$arrayofmassactions = array();
 	}

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -1223,6 +1223,13 @@ if ($resql) {
 	if ($permissiontodelete) {
 		$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
 	}
+
+	$parameters = ['arrayofmassactions'=>&$arrayofmassactions];
+	$reshook = $hookmanager->executeHooks('doListMassActions', $parameters);
+	if ($reshook < 0) {
+		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	}
+
 	if (in_array($massaction, array('presend', 'predelete', 'createbills'))) {
 		$arrayofmassactions = array();
 	}

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -1123,6 +1123,13 @@ if ($resql) {
 			$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
 		}
 	}
+
+	$parameters = ['arrayofmassactions'=>&$arrayofmassactions];
+	$reshook = $hookmanager->executeHooks('doListMassActions', $parameters);
+	if ($reshook < 0) {
+		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	}
+
 	if (in_array($massaction, array('presend', 'predelete', 'makepayment'))) {
 		$arrayofmassactions = array();
 	}


### PR DESCRIPTION
Add a Hook to permit the extend of $arrayofmassactions in list.php for Propal, Commande, Facture, etc. into custom modules
Thie hook is added after the default and common mass actions, it is able to modify the entire array.
But, it is added before the test `in_array($massaction, array('presend', 'predelete', 'makepayment'))` so that in that case, no mass action is displayed.