### PR TITLE
NEW: TAKEPOS - add constant to hide stock on cart lines

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -1560,7 +1560,7 @@ if ($placeid > 0) {
 				$htmlforlines .= '<td class="right">';
 				if (!empty($conf->stock->enabled) && !empty($user->rights->stock->mouvement->lire)) {
 					$constantforkey = 'CASHDESK_ID_WAREHOUSE'.$_SESSION["takeposterminal"];
-					if (!empty($conf->global->$constantforkey) && $line->fk_product > 0) {
+					if (!empty($conf->global->$constantforkey) && $line->fk_product > 0 && empty($conf->global->TAKEPOS_HIDE_STOCK_ON_LINE)) {
 						$sql = "SELECT e.rowid, e.ref, e.lieu, e.fk_parent, e.statut, ps.reel, ps.rowid as product_stock_id, p.pmp";
 						$sql .= " FROM ".MAIN_DB_PREFIX."entrepot as e,";
 						$sql .= " ".MAIN_DB_PREFIX."product_stock as ps";


### PR DESCRIPTION
we introduce constant TAKEPOS_HIDE_STOCK_ON_LINE to not display stock information on cart lines