### PR TITLE
FIX 15.0: modules cannot declare more than 1 cron job using the same method with different parameters

### DIFF
--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -1430,6 +1430,9 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 				if ($command) {
 					$sql .= " AND command = '".$this->db->escape($command)."'";
 				}
+				if ($parameters) {
+					$sql .= " AND params = '".$this->db->escape($parameters)."'";
+				}
 				$sql .= " AND entity = ".((int) $entity); // Must be exact entity
 
 				$now = dol_now();


### PR DESCRIPTION
# Rationale
Sometimes, you need several cron jobs to call the same method using different parameters (for instance, a method that sends e-mails and takes the template ID as a parameter, or a method that imports files from a directory passed as a parameter).

Currently Dolibarr checks for existing cron jobs on module activation to avoid duplicates, except that two nearly identical cron jobs with different parameters are not duplicates.

# This fix
This fix adds a condition to the query that checks for duplicate so that it doesn't inhib cronjob registration when there are several jobs using the same method with different parameters.
