### PR TITLE
Fix : contact backtopage on confirm_delete

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -316,8 +316,9 @@ if (empty($reshook)) {
 
 		$result = $object->delete(); // TODO Add $user as first param
 		if ($result > 0) {
-			if ($backtopage) {
-				header("Location: ".$backtopage);
+			setEventMessages("RecordDeleted", null, 'mesgs');
+			if ($backurlforlist) {
+				header("Location: ".$backurlforlist);
 				exit;
 			} else {
 				header("Location: ".DOL_URL_ROOT.'/contact/list.php');


### PR DESCRIPTION
change backtopage to backurlforlist because backtopage is equals to '/contact/card.php?id='.$id on confirm_delete action 