### PR TITLE
Revert PR #20713 - No more empty wrong line added in bookkeeping confirme_create

### DIFF
--- a/htdocs/accountancy/bookkeeping/card.php
+++ b/htdocs/accountancy/bookkeeping/card.php
@@ -260,7 +260,7 @@ if ($action == "confirm_update") {
 			if ($mode != '_tmp') {
 				setEventMessages($langs->trans('RecordSaved'), null, 'mesgs');
 			}
-			$action = '';
+			$action = 'update';
 			$id = $object->id;
 			$piece_num = $object->piece_num;
 		}
@@ -643,12 +643,6 @@ if ($action == 'create') {
 
 				print "</tr>\n";
 
-				// Empty line is the first line of $object->linesmvt
-				// So we must get the first line (the empty one) and pu it at the end of the array
-				// in order to display it correctly to the user
-				$empty_line = array_shift($object->linesmvt);
-				$object->linesmvt[]= $empty_line;
-
 				foreach ($object->linesmvt as $line) {
 					print '<tr class="oddeven">';
 					$total_debit += $line->debit;
@@ -679,33 +673,7 @@ if ($action == 'create') {
 						print '<input type="hidden" name="id" value="'.$line->id.'">'."\n";
 						print '<input type="submit" class="button" name="update" value="'.$langs->trans("Update").'">';
 						print '</td>';
-					} elseif (empty($line->numero_compte) || (empty($line->debit) && empty($line->credit))) {
-						if ($action == "" || $action == 'add') {
-							print '<!-- td columns in add mode -->';
-							print '<td>';
-							print $formaccounting->select_account('', 'accountingaccount_number', 1, array(), 1, 1, '');
-							print '</td>';
-							print '<td>';
-							// TODO For the moment we keep a free input text instead of a combo. The select_auxaccount has problem because:
-							// It does not use the setup of "key pressed" to select a thirdparty and this hang browser on large databases.
-							// Also, it is not possible to use a value that is not in the list.
-							// Also, the label is not automatically filled when a value is selected.
-							if (!empty($conf->global->ACCOUNTANCY_COMBO_FOR_AUX)) {
-								print $formaccounting->select_auxaccount('', 'subledger_account', 1, 'maxwidth250', '', 'subledger_label');
-							} else {
-								print '<input type="text" class="maxwidth150" name="subledger_account" value="" placeholder="' . dol_escape_htmltag($langs->trans("SubledgerAccount")) . '">';
-							}
-							print '<br><input type="text" class="maxwidth150" name="subledger_label" value="" placeholder="' . dol_escape_htmltag($langs->trans("SubledgerAccountLabel")) . '">';
-							print '</td>';
-							print '<td><input type="text" class="minwidth200" name="label_operation" value="' . $label_operation . '"/></td>';
-							print '<td class="right"><input type="text" size="6" class="right" name="debit" value=""/></td>';
-							print '<td class="right"><input type="text" size="6" class="right" name="credit" value=""/></td>';
-							print '<td>';
-							print '<input type="submit" class="button" name="save" value="' . $langs->trans("Add") . '">';
-							print '</td>';
-						}
 					} else {
-						print '<!-- td columns in display mode -->';
 						$accountingaccount->fetch(null, $line->numero_compte, true);
 						print '<td>'.$accountingaccount->getNomUrl(0, 1, 1, '', 0).'</td>';
 						print '<td>'.length_accounta($line->subledger_account);
@@ -747,8 +715,33 @@ if ($action == 'create') {
 					setEventMessages(null, array($langs->trans('MvtNotCorrectlyBalanced', $total_debit, $total_credit)), 'warnings');
 				}
 
-				print '</table>';
-				print '</div>';
+				if (empty($object->date_export) && empty($object->date_validation)) {
+					if ($action == "" || $action == 'add') {
+						print '<tr class="oddeven">';
+						print '<!-- td columns in add mode -->';
+						print '<td>';
+						print $formaccounting->select_account('', 'accountingaccount_number', 1, array(), 1, 1, '');
+						print '</td>';
+						print '<td>';
+						// TODO For the moment we keep a free input text instead of a combo. The select_auxaccount has problem because:
+						// It does not use the setup of "key pressed" to select a thirdparty and this hang browser on large databases.
+						// Also, it is not possible to use a value that is not in the list.
+						// Also, the label is not automatically filled when a value is selected.
+						if (!empty($conf->global->ACCOUNTANCY_COMBO_FOR_AUX)) {
+							print $formaccounting->select_auxaccount('', 'subledger_account', 1);
+						} else {
+							print '<input type="text" class="maxwidth150" name="subledger_account" value="" placeholder="' . dol_escape_htmltag($langs->trans("SubledgerAccount")) . '">';
+						}
+						print '<br><input type="text" class="maxwidth150" name="subledger_label" value="" placeholder="' . dol_escape_htmltag($langs->trans("SubledgerAccountLabel")) . '">';
+						print '</td>';
+						print '<td><input type="text" class="minwidth200" name="label_operation" value="' . $label_operation . '"/></td>';
+						print '<td class="right"><input type="text" size="6" class="right" name="debit" value=""/></td>';
+						print '<td class="right"><input type="text" size="6" class="right" name="credit" value=""/></td>';
+						print '<td><input type="submit" class="button" name="save" value="' . $langs->trans("Add") . '"></td>';
+						print '</tr>';
+					}
+					print '</table>';
+				}
 
 				if ($mode == '_tmp' && $action == '') {
 					print '<br>';


### PR DESCRIPTION
With the fix #20713, You cannot validate manual accounting entries

Go Accounting > Ledger > "+".
Add a manuel entries and try to validate.
 You have this error  : 

![image](https://user-images.githubusercontent.com/2341395/169328169-f79bcf09-c207-422d-9dd2-f1094213a888.png)


