### PR TITLE
Fix : bug of upgrade when install not finished

### DIFF
--- a/htdocs/install/check.php
+++ b/htdocs/install/check.php
@@ -440,7 +440,7 @@ if (!file_exists($conffile)) {
 		if (empty($dolibarr_main_db_host)) {	// This means install process was not run
 			$allowupgrade = false;
 		}
-		if (defined("MAIN_NOT_INSTALLED")) {
+		if (getDolGlobalInt("MAIN_NOT_INSTALLED")) {
 			$allowupgrade = false;
 		}
 		if (GETPOST('allowupgrade')) {


### PR DESCRIPTION
function defined() return false when constant "MAIN_NOT_INSTALLED" is true so it displays upgrade instead of displaying only install choice