### PR TITLE
FIX: Product lot document management should not use batch but ref (is lot id)

### DIFF
--- a/htdocs/product/stock/productlot_card.php
+++ b/htdocs/product/stock/productlot_card.php
@@ -93,7 +93,7 @@ if ($id || $ref) {
 	$object->fetch($id, $productid, $batch);
 	$object->ref = $object->batch; // Old system for document management ( it uses $object->ref)
 	$upload_dir = $conf->productbatch->multidir_output[$object->entity].'/'.get_exdir(0, 0, 0, 1, $object, $modulepart);
-	$filearray = dol_dir_list($upload_dir, "files", 0, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ?SORT_DESC:SORT_ASC), 1);
+	$filearray = dol_dir_list($upload_dir, "files");
 	if (empty($filearray)) {
 		// If no files linked yet, use new system on lot id. (Batch is not unique and can be same on different product)
 		$object->fetch($id, $productid, $batch);

--- a/htdocs/product/stock/productlot_card.php
+++ b/htdocs/product/stock/productlot_card.php
@@ -28,6 +28,7 @@ require '../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/product.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 require_once DOL_DOCUMENT_ROOT.'/product/stock/class/productlot.class.php';
@@ -90,7 +91,13 @@ if ($id || $ref) {
 		$batch = $tmp[1];
 	}
 	$object->fetch($id, $productid, $batch);
-	$object->ref = $object->batch; // For document management ( it use $object->ref)
+	$object->ref = $object->batch; // Old system for document management ( it uses $object->ref)
+	$upload_dir = $conf->productbatch->multidir_output[$object->entity].'/'.get_exdir(0, 0, 0, 1, $object, $modulepart);
+	$filearray = dol_dir_list($upload_dir, "files", 0, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ?SORT_DESC:SORT_ASC), 1);
+	if (empty($filearray)) {
+		// If no files linked yet, use new system on lot id. (Batch is not unique and can be same on different product)
+		$object->fetch($id, $productid, $batch);
+	}
 }
 
 // Initialize technical object to manage hooks of modules. Note that conf->hooks_modules contains array array

--- a/htdocs/product/stock/productlot_document.php
+++ b/htdocs/product/stock/productlot_document.php
@@ -87,7 +87,7 @@ if ($id || $ref) {
 
 	if (!empty($conf->productbatch->enabled)) {
 		$upload_dir = $conf->productbatch->multidir_output[$object->entity].'/'.get_exdir(0, 0, 0, 1, $object, $modulepart);
-		$filearray = dol_dir_list($upload_dir, "files", 0, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ?SORT_DESC:SORT_ASC), 1);
+		$filearray = dol_dir_list($upload_dir, "files");
 		if (empty($filearray)) {
 			// If no files linked yet, use new system on lot id. (Batch is not unique and can be same on different product)
 			$object->fetch($id, $productid, $batch);

--- a/htdocs/product/stock/productlot_document.php
+++ b/htdocs/product/stock/productlot_document.php
@@ -83,10 +83,16 @@ if ($id || $ref) {
 		$batch = $tmp[1];
 	}
 	$object->fetch($id, $productid, $batch);
-	$object->ref = $object->batch; // For document management ( it use $object->ref)
+	$object->ref = $object->batch; // Old system for document management ( it uses $object->ref)
 
 	if (!empty($conf->productbatch->enabled)) {
 		$upload_dir = $conf->productbatch->multidir_output[$object->entity].'/'.get_exdir(0, 0, 0, 1, $object, $modulepart);
+		$filearray = dol_dir_list($upload_dir, "files", 0, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ?SORT_DESC:SORT_ASC), 1);
+		if (empty($filearray)) {
+			// If no files linked yet, use new system on lot id. (Batch is not unique and can be same on different product)
+			$object->fetch($id, $productid, $batch);
+			$upload_dir = $conf->productbatch->multidir_output[$object->entity].'/'.get_exdir(0, 0, 0, 1, $object, $modulepart);
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #20711 
If no files linked keep batch code for doc folder, else use lot id.