### PR TITLE
New :add explicit right on read draft leave

### DIFF
--- a/htdocs/core/modules/modHoliday.class.php
+++ b/htdocs/core/modules/modHoliday.class.php
@@ -209,7 +209,12 @@ class modHoliday extends DolibarrModules
 		$this->rights[$r][4] = 'define_holiday'; // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = ''; // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$r++;
-
+		$this->rights[$r][0] = 20008; // Permission id (must not be already used)
+		$this->rights[$r][1] = 'Read leave on status draft'; // Permission label
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
+		$this->rights[$r][4] = 'read_draft_leave'; // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$this->rights[$r][5] = ''; // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$r++;
 
 		// Menus
 		//-------

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -986,6 +986,7 @@ Permission20004=Read all leave requests (even those of user not subordinates)
 Permission20005=Create/modify leave requests for everybody (even those of user not subordinates)
 Permission20006=Administer leave requests (setup and update balance)
 Permission20007=Approve leave requests
+Permission20008=Read leave on status draft
 Permission23001=Read Scheduled job
 Permission23002=Create/update Scheduled job
 Permission23003=Delete Scheduled job


### PR DESCRIPTION
# New  
creation of a right to explicitly read leave requests with draft status

(which could give rise to a fine adjustment : 
I can see the requests and subordinate to the status validate and/or draft)

