### PR TITLE
OF child Creation : redirection

### DIFF
--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -162,7 +162,7 @@ if (empty($reshook)) {
 			$res = $object->add_object_linked('mo', $mo_parent->id);
 		}
 
-		header("Location: ".dol_buildpath('/mrp/mo_list.php', 1));
+		header("Location: ".dol_buildpath('/mrp/mo_card.php?id='.$moline->fk_mo, 1));
 		exit;
 	}
 


### PR DESCRIPTION
# FIX|Fix 
 When I create a child MO, I have to be redirected to parent MO card and not to MO list
