### PR TITLE
TakePOS compatible without the banks module

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -1136,7 +1136,7 @@ if (isset($_SESSION["takeposterminal"]) && $_SESSION["takeposterminal"]) {
 		}
 	}
 
-	if (empty($paiementsModes)) {
+	if (empty($paiementsModes) && !empty($conf->banque->enabled)) {
 		$langs->load('errors');
 		setEventMessages($langs->trans("ErrorModuleSetupNotComplete", $langs->transnoentitiesnoconv("TakePOS")), null, 'errors');
 		setEventMessages($langs->trans("ProblemIsInSetupOfTerminal", $_SESSION["takeposterminal"]), null, 'errors');

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -204,7 +204,7 @@ if (empty($reshook)) {
 			}
 		}
 
-		if ($bankaccount <= 0 && $pay != "delayed") {
+		if ($bankaccount <= 0 && $pay != "delayed" && !empty($conf->banque->enabled)) {
 			$errormsg = $langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("BankAccount"));
 			$error++;
 		}

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -111,7 +111,7 @@ if ($resql) {
 			$arrayOfValidBankAccount[$conf->global->$accountname] = $conf->global->$accountname;
 			$arrayOfValidPaymentModes[] = $obj;
 		}
-		
+
 		if (empty($conf->banque->enabled)) {
 			if ($paycode == 'CASH' || $paycode == 'CB') $arrayOfValidPaymentModes[] = $obj;
 		}

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -111,6 +111,10 @@ if ($resql) {
 			$arrayOfValidBankAccount[$conf->global->$accountname] = $conf->global->$accountname;
 			$arrayOfValidPaymentModes[] = $obj;
 		}
+		
+		if (empty($conf->banque->enabled)) {
+			if ($paycode == 'CASH' || $paycode == 'CB') $arrayOfValidPaymentModes[] = $obj;
+		}
 	}
 }
 ?>


### PR DESCRIPTION
When the banks module is disabled, TakePOS may not work correctly. There are people who do not need the banks module. PR for Dolibarr 17.