### PR TITLE
emailcollector : hookmanager is null

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -2008,6 +2008,7 @@ class EmailCollector extends CommonObject
 									'object' => 'Mo'),
 							);
 
+							global $hookmanager;
 							$hookmanager->initHooks(array('emailcolector'));
 							$parameters = array('arrayobject' => $arrayobject);
 							$reshook = $hookmanager->executeHooks('addmoduletoeamailcollectorjoinpiece', $parameters);    // Note that $action and $object may have been modified by some hooks


### PR DESCRIPTION
# FIX hookmanager is null

just a missing global call ...

```
PHP Fatal error:  Uncaught Error: Call to a member function initHooks() on null in /var/www/dolibarr-15/htdocs/emailcollector/class/emailcollector.class.php
```
