### PR TITLE
NEW: Send Notification Without File when E-mail Template doesn't attach file

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -615,7 +615,7 @@ class Notify
 
 						$ref = dol_sanitizeFileName($newref);
 						$pdf_path = $dir_output."/".$ref.".pdf";
-						if (!dol_is_file($pdf_path)) {
+						if (!dol_is_file($pdf_path)||!$arraydefaultmessage->joinfiles) {
 							// We can't add PDF as it is not generated yet.
 							$filepdf = '';
 						} else {

--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -615,7 +615,7 @@ class Notify
 
 						$ref = dol_sanitizeFileName($newref);
 						$pdf_path = $dir_output."/".$ref.".pdf";
-						if (!dol_is_file($pdf_path)||!$arraydefaultmessage->joinfiles) {
+						if (!dol_is_file($pdf_path)||(is_object($arraydefaultmessage) && $arraydefaultmessage->id > 0 && !$arraydefaultmessage->joinfiles)) {
 							// We can't add PDF as it is not generated yet.
 							$filepdf = '';
 						} else {


### PR DESCRIPTION
When we create an Email Template that doesn't require main file to be attached, we still send notification with an attached file, eg: when we send a notification when validating proposal it send proposal with attached file with mention NOT VALIDATED.
I added OR condition on checking pdf_path.