### PR TITLE
NEW : memorize model name for pdf hooks

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5410,6 +5410,11 @@ abstract class CommonObject
 				// output format that does not support UTF8.
 				$sav_charset_output = $outputlangs->charset_output;
 
+				// memorize model name for pdf hooks (ie pdf_writelinedesc when validating a shipping)
+				if (empty($this->model_pdf)) {
+					$this->model_pdf = $modele;
+				}
+
 				if (in_array(get_class($this), array('Adherent'))) {
 					$resultwritefile = $obj->write_file($this, $outputlangs, $srctemplatepath, 'member', 1, 'tmp_cards', $moreparams);
 				} else {


### PR DESCRIPTION
for instance when you validate a shipping, you don't already know the pdf model name in the pdf_writelinedesc function