### PR TITLE
Fix regression in accountancy bookkeeping fo V14 and v15

### DIFF
--- a/htdocs/accountancy/bookkeeping/card.php
+++ b/htdocs/accountancy/bookkeeping/card.php
@@ -643,9 +643,11 @@ if ($action == 'create') {
 
 				print "</tr>\n";
 
-				// Add an empty line
-				$line = new BookKeepingLine();
-				$object->linesmvt[] = $line;
+				// Empty line is the first line of $object->linesmvt
+				// So we must get the first line (the empty one) and pu it at the end of the array
+				// in order to display it correctly to the user
+				$empty_line = array_shift($object->linesmvt);
+				$object->linesmvt[]= $empty_line;
 
 				foreach ($object->linesmvt as $line) {
 					print '<tr class="oddeven">';

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1721,6 +1721,11 @@ class BookKeeping extends CommonObject
 		dol_syslog(__METHOD__, LOG_DEBUG);
 		$result = $this->db->query($sql);
 		if ($result) {
+			// Add an empty line when transaction is validated to permit to add new line manually
+			if ($mode != "_tmp") {
+				$line = new BookKeepingLine();
+				$this->linesmvt[] = $line;
+			}
 			while ($obj = $this->db->fetch_object($result)) {
 				$line = new BookKeepingLine();
 


### PR DESCRIPTION
The two last commits into bookkeeping/card.php (https://github.com/Dolibarr/dolibarr/commit/900c71b5d6a5e32696a89981672bcb82ae7be3fb) and bookkeeping.class.php (https://github.com/Dolibarr/dolibarr/commit/e10d89dd369b901662f91e3cf9ef011b45a2354d) are creating a regression bug in transaction create mode as, by défaut two line with "add" button are displayed, but only one is stored.

To me, it can be a good idea to have two lines instead of one to be able to balance the movement in one step, but actually it doesn't store one of the transaction. So I would propose to revert these two commit on v14 and v15 and change the workflow in v16.

![IMG_20220609_071433](https://user-images.githubusercontent.com/8067223/172769559-d6ae39bc-1ba7-4b09-bd08-ce53fcdb0c36.jpg)
