### PR TITLE
FIX  #19860 

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -246,7 +246,8 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 
 	if (!$error) {
 		if (GETPOST('taskid', 'int') != $id) {		// GETPOST('taskid') is id of new task
-			$id = GETPOST('taskid', 'int');
+			$id_temp = GETPOST('taskid', 'int'); // should not overwrite $id
+			
 
 			$object->fetchTimeSpent(GETPOST('lineid', 'int'));
 
@@ -255,7 +256,7 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 				$result = $object->delTimeSpent($user);
 			}
 
-			$object->fetch($id, $ref);
+			$object->fetch($id_temp, $ref);
 
 			$object->timespent_note = GETPOST("timespent_note_line", 'alpha');
 			$object->timespent_old_duration = GETPOST("old_duration");

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -247,7 +247,7 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 	if (!$error) {
 		if (GETPOST('taskid', 'int') != $id) {		// GETPOST('taskid') is id of new task
 			$id_temp = GETPOST('taskid', 'int'); // should not overwrite $id
-			
+
 
 			$object->fetchTimeSpent(GETPOST('lineid', 'int'));
 


### PR DESCRIPTION
FIX #19860  
Changing task for time spent works properly only once
The value $id shouldn't be overwritten.

