### PR TITLE
don’t discard all menu pics

### DIFF
--- a/htdocs/theme/md/main_menu_fa_icons.inc.php
+++ b/htdocs/theme/md/main_menu_fa_icons.inc.php
@@ -22,8 +22,8 @@
 	font-size: 1.5em;
 }
 
-div.mainmenu {
-	background-image: none !important;
+div.mainmenu.menu {
+	background-image: none;
 }
 
 div.mainmenu.menu::before {


### PR DESCRIPTION
In md theme, if we use external modules, we cannot see their logos in the top menu, due to an !important clause banning them in css. I suggest we replace it the way it’s done in eldy theme.