### PR TITLE
Add old fields on llx_element_tag 

### DIFF
--- a/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
+++ b/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
@@ -51,7 +51,10 @@
 -- VPGSQL8.2 ALTER TABLE llx_c_payment_term ALTER COLUMN rowid SET DEFAULT nextval('llx_c_payment_term_rowid_seq');
 -- VPGSQL8.2 SELECT setval('llx_c_payment_term_rowid_seq', MAX(rowid)) FROM llx_c_payment_term;
 
-
+ALTER TABLE llx_element_tag ADD COLUMN entity INTEGER DEFAULT 1 NOT NULL;
+ALTER TABLE llx_element_tag ADD COLUMN lang varchar(5) not null;
+ALTER TABLE llx_element_tag ADD COLUMN tag varchar(255) not null;
+ALTER TABLE llx_element_tag ADD COLUMN element varchar(64) not null;
 
 ALTER TABLE llx_c_transport_mode ADD UNIQUE INDEX uk_c_transport_mode (code, entity);
 
@@ -59,7 +62,7 @@ ALTER TABLE llx_c_shipment_mode MODIFY COLUMN tracking varchar(255) NULL;
 
 ALTER TABLE llx_holiday ADD COLUMN nb_open_day double(24,8) DEFAULT NULL;
 
-ALTER TABLE llx_element_tag ADD COLUMN fk_categorie INTEGER;
+--ALTER TABLE llx_element_tag ADD COLUMN fk_categorie INTEGER;
 
 
 insert into llx_c_type_resource (code, label, active) values ('RES_ROOMS', 'Rooms',  1);

--- a/htdocs/install/mysql/tables/llx_element_tag.key.sql
+++ b/htdocs/install/mysql/tables/llx_element_tag.key.sql
@@ -1,5 +1,6 @@
 -- ============================================================================
 -- Copyright (C) 2021 Maxime Kohlhaas       <support@atm-consulting.fr>
+-- Copyright (C) 2022 Charlene Benke        <charlene@patas-monkey.com>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -16,6 +17,4 @@
 --
 -- ============================================================================
 
-ALTER TABLE llx_element_tag ADD UNIQUE INDEX idx_element_tag_uk (fk_categorie, fk_element);
-
-ALTER TABLE llx_element_tag ADD CONSTRAINT fk_element_tag_categorie_rowid FOREIGN KEY (fk_categorie) REFERENCES llx_categorie (rowid);
+ALTER TABLE llx_element_tag ADD UNIQUE INDEX idx_element_tag_uk (tag, fk_element);

--- a/htdocs/install/mysql/tables/llx_element_tag.sql
+++ b/htdocs/install/mysql/tables/llx_element_tag.sql
@@ -1,5 +1,6 @@
 -- ============================================================================
 -- Copyright (C) 2021 Maxime Kohlhaas       <support@atm-consulting.fr>
+-- Copyright (C) 2022 Charlene Benke        <charlene@patas-monkey.com>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -19,7 +20,10 @@
 create table llx_element_tag
 (
   rowid integer AUTO_INCREMENT PRIMARY KEY,
-  fk_categorie  integer NOT NULL,
-  fk_element  integer NOT NULL,
+  entity			  integer DEFAULT 1 NOT NULL,			-- multi company id
+  lang				  varchar(5) NOT NULL,
+  tag				    varchar(255) NOT NULL,
+  fk_element		integer NOT NULL,
+  element			  varchar(64) NOT NULL,
   import_key    varchar(14)
 )ENGINE=innodb;


### PR DESCRIPTION
if we create the llx_element_tag table again, I suggest that we use the initial structure of the table (before its deletion in 2017)
For information, this table is not used except in one of my modules (and I bring the old structure since 2017)
In short, either we add the table with the old structure, or we do not add it with bullshit fields