### PR TITLE
FIX Srutinizer 'The property socid does not seem to exist on Recruitm…

### DIFF
--- a/htdocs/recruitment/recruitmentcandidature_list.php
+++ b/htdocs/recruitment/recruitmentcandidature_list.php
@@ -461,7 +461,7 @@ if ($jobposition->id > 0 && (empty($action) || ($action != 'edit' && $action != 
 				$morehtmlref .= '<input type="submit" class="button valignmiddle" value="'.$langs->trans("Modify").'">';
 				$morehtmlref .= '</form>';
 			} else {
-				$morehtmlref .= $form->form_project($_SERVER['PHP_SELF'].'?id='.$object->id, $object->socid, $object->fk_project, 'none', 0, 0, 0, 1);
+				$morehtmlref .= $form->form_project($_SERVER['PHP_SELF'].'?id='.$object->id, 0, $object->fk_project, 'none', 0, 0, 0, 1);
 			}
 		} else {
 			if (!empty($object->fk_project)) {


### PR DESCRIPTION
FIX Srutinizer 'The property socid does not seem to exist on RecruitmentJobPosition'


I think there is no need of a third-party id for a job application, but not sure if I should set it to "$object->fk_user_cret" to refer to the applicant id.