### PR TITLE
array instead of string in @param pfx() function

### DIFF
--- a/htdocs/core/class/evalmath.class.php
+++ b/htdocs/core/class/evalmath.class.php
@@ -368,7 +368,7 @@ class EvalMath
 	/**
 	 * evaluate postfix notation
 	 *
-	 * @param string $tokens      	Expression
+	 * @param array $tokens      	Expression
 	 * @param array $vars       	Array
 	 * @return string 				Output
 	 */


### PR DESCRIPTION
Changing from string to array as the parameter should be an array.