### PR TITLE
FIX: warning / fatal when dol_eval return value is non-empty && non-string

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8505,7 +8505,7 @@ function verifCond($strToEvaluate)
 		//dol_eval($str, 0, 1, '2'); // The dol_eval must contains all the global $xxx used into a condition
 		//var_dump($strToEvaluate);
 		$rep = dol_eval($strToEvaluate, 1, 1, '1'); // The dol_eval must contains all the global $xxx for all variables $xxx found into the string condition
-		$rights = (($rep && strpos($rep, 'Bad string syntax to evaluate') === false) ? true : false);
+		$rights = $rep && !is_string($rep) || strpos($rep, 'Bad string syntax to evaluate') === false;
 		//var_dump($rights);
 	}
 	return $rights;

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8505,7 +8505,7 @@ function verifCond($strToEvaluate)
 		//dol_eval($str, 0, 1, '2'); // The dol_eval must contains all the global $xxx used into a condition
 		//var_dump($strToEvaluate);
 		$rep = dol_eval($strToEvaluate, 1, 1, '1'); // The dol_eval must contains all the global $xxx for all variables $xxx found into the string condition
-		$rights = $rep && !is_string($rep) || strpos($rep, 'Bad string syntax to evaluate') === false;
+		$rights = $rep && (!is_string($rep) || strpos($rep, 'Bad string syntax to evaluate') === false);
 		//var_dump($rights);
 	}
 	return $rights;


### PR DESCRIPTION
# FIX
The function `verifCond()` calls `dol_eval()` and performs a string search on the returned value. When the return value of `dol_eval` is not a string but is non-empty, calling `strpos` on a non-string will trigger a warning in php7 and a fatal error in php8.