### PR TITLE
BUG FIX: evaluate() doesn't cover the case where $expr is empty

### DIFF
--- a/htdocs/core/class/evalmath.class.php
+++ b/htdocs/core/class/evalmath.class.php
@@ -144,6 +144,10 @@ class EvalMath
 	 */
 	public function evaluate($expr)
 	{
+		if (empty($expr)) {
+			return false;
+		}
+
 		$this->last_error = null;
 		$this->last_error_code = null;
 		$expr = trim($expr);
@@ -374,10 +378,6 @@ class EvalMath
 	 */
 	private function pfx($tokens, $vars = array())
 	{
-		if (empty($tokens)) {
-			return false;
-		}
-
 		$stack = new EvalMathStack();
 
 		foreach ($tokens as $token) { // nice and easy

--- a/htdocs/core/class/evalmath.class.php
+++ b/htdocs/core/class/evalmath.class.php
@@ -374,7 +374,7 @@ class EvalMath
 	 */
 	private function pfx($tokens, $vars = array())
 	{
-		if ($tokens == false) {
+		if (empty($tokens)) {
 			return false;
 		}
 

--- a/test/phpunit/EvalMathTest.php
+++ b/test/phpunit/EvalMathTest.php
@@ -1,0 +1,151 @@
+<?php
+/* Copyright (C) 2010 Laurent Destailleur   <eldy@users.sourceforge.net>
+ * Copyright (C) 2022 Quatadah Nasdami <quatadah.nasdami@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/InventoryTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test
+ *      \remarks    To run this script as CLI:  phpunit filename.php
+ */
+
+global $conf,$user,$langs,$db;
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/core/class/evalmath.class.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	$user->getrights();
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class InventoryTest extends PHPUnit\Framework\TestCase
+{
+	protected $savconf;
+	protected $savuser;
+	protected $savlangs;
+	protected $savdb;
+
+	/**
+	 * Constructor
+	 * We save global variables into local variables
+	 *
+	 * @return InventoryTest
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+
+		//$this->sharedFixture
+		global $conf,$user,$langs,$db;
+		$this->savconf=$conf;
+		$this->savuser=$user;
+		$this->savlangs=$langs;
+		$this->savdb=$db;
+
+		print __METHOD__." db->type=".$db->type." user->id=".$user->id;
+		//print " - db ".$db->db;
+		print "\n";
+	}
+
+	/**
+	 * setUpBeforeClass
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass()
+	{
+		global $conf,$user,$langs,$db;
+
+		$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
+
+		print __METHOD__."\n";
+	}
+
+	/**
+	 * tearDownAfterClass
+	 *
+	 * @return	void
+	 */
+	public static function tearDownAfterClass()
+	{
+		global $conf,$user,$langs,$db;
+		$db->rollback();
+
+		print __METHOD__."\n";
+	}
+
+	/**
+	 * Init phpunit tests
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		global $conf,$user,$langs,$db;
+		$conf=$this->savconf;
+		$user=$this->savuser;
+		$langs=$this->savlangs;
+		$db=$this->savdb;
+
+		print __METHOD__."\n";
+	}
+
+	/**
+	 * End phpunit tests
+	 *
+	 * @return  void
+	 */
+	protected function tearDown()
+	{
+		print __METHOD__."\n";
+	}
+
+	/**
+	 * test postfix evaluation function
+	 * @return void
+	 */
+	public function testEvaluate()
+	{
+		$localobject = new EvalMath();
+		$result = $localobject->evaluate('1+1');
+		$this->assertEquals($result, 2);
+		print __METHOD__." result=".$result."\n";
+
+		$result = $localobject->evaluate('10-4/4');
+		$this->assertEquals($result, 9);
+		print __METHOD__." result=".$result."\n";
+
+		$result = $localobject->evaluate('3^3');
+		$this->assertEquals($result, 27);
+		print __METHOD__." result=".$result."\n";
+
+		$result = $localobject->evaluate('');
+		$this->assertEquals($result, '');
+		print __METHOD__." result=". 'void' ."\n";
+	}
+}

--- a/test/phpunit/EvalMathTest.php
+++ b/test/phpunit/EvalMathTest.php
@@ -146,6 +146,6 @@ class InventoryTest extends PHPUnit\Framework\TestCase
 
 		$result = $localobject->evaluate('');
 		$this->assertEquals($result, '');
-		print __METHOD__." result=". 'void' ."\n";
+		print __METHOD__." result=".$result."\n";
 	}
 }


### PR DESCRIPTION
# FIX
The evaluate() function in evalmath.class.php doesn't cover the case where $expr is empty, + adding unit test.