### PR TITLE
FIX - Record count badge in custom modules tab

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8964,7 +8964,7 @@ function complete_head_from_modules($conf, $langs, $object, &$head, &$h, $type, 
 							complete_substitutions_array($substitutionarray, $langs, $object, array('needforkey'=>$values[2]));
 							$label = make_substitutions($reg[1], $substitutionarray);
 						} else {
-							$labeltemp = explode(':', $values[2]);
+							$labeltemp = explode(',', $values[2]);
 							$label = $langs->trans($labeltemp[0]);
 							if (!empty($labeltemp[1]) && is_object($object) && !empty($object->id)) {
 								dol_include_once($labeltemp[2]);


### PR DESCRIPTION
# FIX|Fix #[*issue_number Short description*]
[*Long description*]

This is not possible explode(':' because there is already an explode above with a comparison on the number. that's why I put explode(',' or 

Or another separator if you prefer