### PR TITLE
BUG FIX : changing function name to the exisiting one (3)

### DIFF
--- a/htdocs/core/class/stats.class.php
+++ b/htdocs/core/class/stats.class.php
@@ -124,6 +124,13 @@ abstract class Stats
 	}
 
 	/**
+	 * @param	int		$year			year number
+	 * @param	int 	$format			0=Label of abscissa is a translated text, 1=Label of abscissa is month number, 2=Label of abscissa is first letter of month
+	 * @return 	int						value
+	 */
+	protected abstract function getAmountByMonth($year, $format = 0);
+
+	/**
 	 * Return amount of elements by month for several years.
 	 * Criterias used to build request are defined into the constructor of parent class into xxx/class/xxxstats.class.php
 	 * The caller of class can add more filters into sql request by adding criteris into the $stats->where property just after
@@ -180,7 +187,7 @@ abstract class Stats
 				$year = $year - 1;
 			}
 			while ($year <= $endyear) {
-				$datay[$year] = $this->_getAmountByMonth($year, $format);
+				$datay[$year] = $this->getAmountByMonth($year, $format);
 				$year++;
 			}
 
@@ -459,7 +466,6 @@ abstract class Stats
 
 		return $data;
 	}
-
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**

--- a/htdocs/core/class/stats.class.php
+++ b/htdocs/core/class/stats.class.php
@@ -180,7 +180,7 @@ abstract class Stats
 				$year = $year - 1;
 			}
 			while ($year <= $endyear) {
-				$datay[$year] = $this->getAmountByMonth($year, $format);
+				$datay[$year] = $this->_getAmountByMonth($year, $format);
 				$year++;
 			}
 


### PR DESCRIPTION
changing from getAmountByMonth() to _getAmountByMonth() because it's the one that exists.
However, this function still needs the parameter `$sql`.