### PR TITLE
NEW: helper functions for dates + small demo case

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -11110,3 +11110,34 @@ function dolForgeCriteriaCallback($matches)
 
 	return $db->escape($operand).' '.$db->escape($operator)." ".$tmpescaped;
 }
+
+/**
+ * Helper function that combines values of a dolibarr DatePicker (such as Form::selectDate) for year, month, day (and
+ * optionally hour, minute, second) fields to return a timestamp.
+ *
+ * @param string $prefix Prefix used to build the date selector (for instance using Form::selectDate)
+ * @param bool $useHourTime If true, will also include hour, minute, second values from the HTTP request
+ * @param string $gm Passed to dol_mktime
+ * @return int|string  Date as a timestamp, '' or false if error
+ */
+function GETPOSTDATE($prefix, $useHourTime = false, $gm = 'auto') {
+	return dol_mktime($useHourTime ? (GETPOSTINT($prefix . 'hour')) : 0, $useHourTime ? (GETPOSTINT($prefix . 'minute')) : 0, $useHourTime ? (GETPOSTINT($prefix . 'second')) : 0, GETPOSTINT($prefix . 'month'), GETPOSTINT($prefix . 'day'), GETPOSTINT($prefix . 'year'), $gm);
+}
+
+/**
+ * Helper function that combines values of a dolibarr DatePicker (such as Form::selectDate) for year, month, day (and
+ * optionally hour, minute, second) fields to return a a portion of URL reproducing the values from the current HTTP
+ * request.
+ *
+ * @param string $prefix Prefix used to build the date selector (for instance using Form::selectDate)
+ * @param bool $useHourTime If true, will also include hour, minute, second values from the HTTP request
+ * @return string Portion of URL with query parameters for the specified date
+ */
+function buildParamDate($prefix, $useHourTime = false) {
+	$TParam = [$prefix . 'day' => GETPOST($prefix . 'day'), $prefix . 'month' => GETPOST($prefix . 'month'), $prefix . 'year' => GETPOST($prefix . 'year')];
+	if ($useHourTime) {
+		$TParam += [$prefix . 'hour' => GETPOST($prefix . 'hour'), $prefix . 'minute' => GETPOST($prefix . 'minute'), $prefix . 'second' => GETPOST($prefix . 'second')];
+	}
+
+	return '&' . http_build_query($TParam);
+}

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -11120,7 +11120,8 @@ function dolForgeCriteriaCallback($matches)
  * @param string $gm Passed to dol_mktime
  * @return int|string  Date as a timestamp, '' or false if error
  */
-function GETPOSTDATE($prefix, $useHourTime = false, $gm = 'auto') {
+function GETPOSTDATE($prefix, $useHourTime = false, $gm = 'auto')
+{
 	return dol_mktime($useHourTime ? (GETPOSTINT($prefix . 'hour')) : 0, $useHourTime ? (GETPOSTINT($prefix . 'minute')) : 0, $useHourTime ? (GETPOSTINT($prefix . 'second')) : 0, GETPOSTINT($prefix . 'month'), GETPOSTINT($prefix . 'day'), GETPOSTINT($prefix . 'year'), $gm);
 }
 
@@ -11133,7 +11134,8 @@ function GETPOSTDATE($prefix, $useHourTime = false, $gm = 'auto') {
  * @param bool $useHourTime If true, will also include hour, minute, second values from the HTTP request
  * @return string Portion of URL with query parameters for the specified date
  */
-function buildParamDate($prefix, $useHourTime = false) {
+function buildParamDate($prefix, $useHourTime = false)
+{
 	$TParam = [$prefix . 'day' => GETPOST($prefix . 'day'), $prefix . 'month' => GETPOST($prefix . 'month'), $prefix . 'year' => GETPOST($prefix . 'year')];
 	if ($useHourTime) {
 		$TParam += [$prefix . 'hour' => GETPOST($prefix . 'hour'), $prefix . 'minute' => GETPOST($prefix . 'minute'), $prefix . 'second' => GETPOST($prefix . 'second')];

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -11117,7 +11117,7 @@ function dolForgeCriteriaCallback($matches)
  *
  * @param string $prefix Prefix used to build the date selector (for instance using Form::selectDate)
  * @param string $hourTime  'getpost' to include hour, minute, second values from the HTTP request, 'XX:YY:ZZ' to set
- *                             hour, minute, second respectively (for instance '23:59:59')
+ *                          hour, minute, second respectively (for instance '23:59:59')
  * @param string $gm Passed to dol_mktime
  * @return int|string  Date as a timestamp, '' or false if error
  */
@@ -11128,9 +11128,9 @@ function GETPOSTDATE($prefix, $hourTime = '', $gm = 'auto')
 		$minute = GETPOSTINT($prefix . 'minute');
 		$second = GETPOSTINT($prefix . 'second');
 	} elseif (preg_match('/^(\d\d):(\d\d):(\d\d)$/', $hourTime, $m)) {
-		$hour   = (int)$m[1];
-		$minute = (int)$m[2];
-		$second = (int)$m[3];
+		$hour   = intval($m[1]);
+		$minute = intval($m[2]);
+		$second = intval($m[3]);
 	} else {
 		$hour = $minute = $second = 0;
 	}

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -98,8 +98,8 @@ $search_country = GETPOST("search_country", 'int');
 $search_type_thirdparty = GETPOST("search_type_thirdparty", 'int');
 $search_user = GETPOST('search_user', 'int');
 $search_sale = GETPOST('search_sale', 'int');
-$search_date_start = GETPOSTDATE('search_date_start', false, 'tzserver');
-$search_date_end = GETPOSTDATE('search_date_end', false, 'tzserver');
+$search_date_start = GETPOSTDATE('search_date_start', '', 'tzserver');
+$search_date_end = GETPOSTDATE('search_date_end', '23:59:59', 'tzserver');
 $search_datelimit_startday = GETPOST('search_datelimit_startday', 'int');
 $search_datelimit_startmonth = GETPOST('search_datelimit_startmonth', 'int');
 $search_datelimit_startyear = GETPOST('search_datelimit_startyear', 'int');
@@ -695,10 +695,10 @@ if ($resql) {
 		$param .= '&search_all='.urlencode($search_all);
 	}
 	if ($search_date_start) {
-		$param .= buildParamDate('search_date_start', false);
+		$param .= buildParamDate('search_date_start', null, '', 'tzserver');
 	}
 	if ($search_date_end) {
-		$param .= buildParamDate('search_date_end', false);
+		$param .= buildParamDate('search_date_end', null, '', 'tzserver');
 	}
 	if ($search_datelimit_startday) {
 		$param .= '&search_datelimit_startday='.urlencode($search_datelimit_startday);

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -98,14 +98,8 @@ $search_country = GETPOST("search_country", 'int');
 $search_type_thirdparty = GETPOST("search_type_thirdparty", 'int');
 $search_user = GETPOST('search_user', 'int');
 $search_sale = GETPOST('search_sale', 'int');
-$search_date_startday = GETPOST('search_date_startday', 'int');
-$search_date_startmonth = GETPOST('search_date_startmonth', 'int');
-$search_date_startyear = GETPOST('search_date_startyear', 'int');
-$search_date_endday = GETPOST('search_date_endday', 'int');
-$search_date_endmonth = GETPOST('search_date_endmonth', 'int');
-$search_date_endyear = GETPOST('search_date_endyear', 'int');
-$search_date_start = dol_mktime(0, 0, 0, $search_date_startmonth, $search_date_startday, $search_date_startyear);	// Use tzserver
-$search_date_end = dol_mktime(23, 59, 59, $search_date_endmonth, $search_date_endday, $search_date_endyear);
+$search_date_start = GETPOSTDATE('search_date_start', false, 'tzserver');
+$search_date_end = GETPOSTDATE('search_date_end', false, 'tzserver');
 $search_datelimit_startday = GETPOST('search_datelimit_startday', 'int');
 $search_datelimit_startmonth = GETPOST('search_datelimit_startmonth', 'int');
 $search_datelimit_startyear = GETPOST('search_datelimit_startyear', 'int');
@@ -274,12 +268,6 @@ if (empty($reshook)) {
 		$search_type = '';
 		$search_country = '';
 		$search_type_thirdparty = '';
-		$search_date_startday = '';
-		$search_date_startmonth = '';
-		$search_date_startyear = '';
-		$search_date_endday = '';
-		$search_date_endmonth = '';
-		$search_date_endyear = '';
 		$search_date_start = '';
 		$search_date_end = '';
 		$search_datelimit_startday = '';
@@ -706,23 +694,11 @@ if ($resql) {
 	if ($search_all) {
 		$param .= '&search_all='.urlencode($search_all);
 	}
-	if ($search_date_startday) {
-		$param .= '&search_date_startday='.urlencode($search_date_startday);
+	if ($search_date_start) {
+		$param .= buildParamDate('search_date_start', false);
 	}
-	if ($search_date_startmonth) {
-		$param .= '&search_date_startmonth='.urlencode($search_date_startmonth);
-	}
-	if ($search_date_startyear) {
-		$param .= '&search_date_startyear='.urlencode($search_date_startyear);
-	}
-	if ($search_date_endday) {
-		$param .= '&search_date_endday='.urlencode($search_date_endday);
-	}
-	if ($search_date_endmonth) {
-		$param .= '&search_date_endmonth='.urlencode($search_date_endmonth);
-	}
-	if ($search_date_endyear) {
-		$param .= '&search_date_endyear='.urlencode($search_date_endyear);
+	if ($search_date_end) {
+		$param .= buildParamDate('search_date_end', false);
 	}
 	if ($search_datelimit_startday) {
 		$param .= '&search_datelimit_startday='.urlencode($search_datelimit_startday);


### PR DESCRIPTION
# NEW helper functions for dates

Adds 2 functions: `GETPOSTDATE()` and `buildParamDate()`. These functions could help make code more readable and remove potential for typos (when we have to use the same prefix 3 or 6 times, we sometimes make typos or copy-paste bloopers).

**As an illustration**, I included in this PR a modification to the list of supplier invoices to show how the functions can make code more readable and less prone to small copy-paste errors.

I don't expect the PR to be merged as is (there are probably things that need improving or options to take into account, for instance I am wondering if it would be better if `buildParamDate` took a timestamp as a parameter instead of calling `GETPOST`). However I feel confident that, once it is ready, it could improve programmer experience with Dolibarr :slightly_smiling_face: .