### PR TITLE
FIX : v15 linked object block center order date

### DIFF
--- a/htdocs/commande/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/commande/tpl/linkedobjectblock.tpl.php
@@ -53,7 +53,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	echo '</td>';
 	echo '<td class="linkedcol-name nowraponall" >'.$objectlink->getNomUrl(1).'</td>';
 	echo '<td class="linkedcol-ref">'.$objectlink->ref_client.'</td>';
-	echo '<td class="linkedcol-date">'.dol_print_date($objectlink->date, 'day').'</td>';
+	echo '<td class="linkedcol-date center">'.dol_print_date($objectlink->date, 'day').'</td>';
 	echo '<td class="linkedcol-amount right">';
 	if ($user->rights->commande->lire) {
 		$total = $total + $objectlink->total_ht;


### PR DESCRIPTION
FIX : v15 linked object block center order date

![image](https://user-images.githubusercontent.com/85485123/174607539-eaae2e4f-71e1-46cc-ad4d-db0a6fc5ce62.png)
