### PR TITLE
fix: 15 fix search user

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -682,7 +682,7 @@ function GETPOST($paramname, $check = 'alphanohtml', $method = 0, $filter = null
 			// - posted value not empty, or
 			// - if posted value is empty and a default value exists that is not empty (it means we did a filter to an empty value when default was not).
 
-			if ($out != '') {		// $out = '0' or 'abc', it is a search criteria to keep
+			if ($out != '' && isset($user)) {// $out = '0' or 'abc', it is a search criteria to keep
 				$user->lastsearch_values_tmp[$relativepathstring][$paramname] = $out;
 			}
 		}


### PR DESCRIPTION
On /user/home.php
search a user by name

![image](https://user-images.githubusercontent.com/1050053/175029334-50c9b7e4-c809-4c30-bb98-953b55589411.png)


/core/search.php have DEFINE('NOLOGIN', 1)

So in GETPOST() function global $user is empty
$user->lastsearch_values_tmp => Warning: Creating default object from empty value in /var/www/html/core/lib/functions.lib.php on line 686