### PR TITLE
fix: 15 fix bad call massaction delete on actioncomm delete parameters

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1324,6 +1324,8 @@ if (!$error && ($massaction == 'delete' || ($action == 'delete' && $confirm == '
 
 			if (in_array($objecttmp->element, array('societe', 'member'))) {
 				$result = $objecttmp->delete($objecttmp->id, $user, 1);
+			} elseif (in_array($objecttmp->element, array('action'))) {
+				$result = $objecttmp->delete();
 			} else {
 				$result = $objecttmp->delete($user);
 			}


### PR DESCRIPTION
On List event, 
Check some lines, make delete mass action, it's OK, but trigger ACTION_DELETE is not call

actioncomm method declaration is 
function delete($notrigger) 
not 

function delete($user,$notrigger)

mass action delete was calling it with $objecttmp->delete($user)

So trigger ACTION_DELETE was never executed because $notrigger get $user value