### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/exakat.yml
+++ b/.github/workflows/exakat.yml
@@ -5,6 +5,9 @@ on:
   schedule:
   - cron: "0 20 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   exakat:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
