### PR TITLE
FIX : don't display product's extrafields for transer / correction stock

### DIFF
--- a/htdocs/product/stock/tpl/stockcorrection.tpl.php
+++ b/htdocs/product/stock/tpl/stockcorrection.tpl.php
@@ -179,9 +179,6 @@ print '<input class="maxwidth100onsmartphone" name="inventorycode" id="inventory
 print '</td>';
 print '</tr>';
 
-// Extrafield template
-include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_add.tpl.php';
-
 print '</table>';
 
 print dol_get_fiche_end();

--- a/htdocs/product/stock/tpl/stocktransfer.tpl.php
+++ b/htdocs/product/stock/tpl/stocktransfer.tpl.php
@@ -136,9 +136,6 @@ print '<input class="maxwidth100onsmartphone" name="inventorycode" id="inventory
 print '</td>';
 print '</tr>';
 
-// Extrafield template
-include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_add.tpl.php';
-
 print '</table>';
 
 print dol_get_fiche_end();


### PR DESCRIPTION
# FIX|Fix #
Don't display product's extrafields for transer / correction stock
