### PR TITLE
NEW Enable all types of fees in expense reports

### DIFF
--- a/htdocs/install/mysql/data/llx_c_type_fees.sql
+++ b/htdocs/install/mysql/data/llx_c_type_fees.sql
@@ -35,7 +35,14 @@
 insert into llx_c_type_fees (code,label,active) values ('TF_OTHER',    'Other',  1);
 insert into llx_c_type_fees (code,label,active) values ('TF_TRIP',     'Transportation',   1);
 insert into llx_c_type_fees (code,label,active) values ('TF_LUNCH',    'Lunch',  1);
-
+insert into llx_c_type_fees (code,label,active) values ('TF_METRO',    'Subway',  1);
+insert into llx_c_type_fees (code,label,active) values ('TF_TRAIN',    'Train',  1);
+insert into llx_c_type_fees (code,label,active) values ('TF_BUS',    'Bus',  1);
+insert into llx_c_type_fees (code,label,active) values ('TF_CAR',    'Car',  1);
+insert into llx_c_type_fees (code,label,active) values ('TF_PEAGE',    'Toll',  1);
+insert into llx_c_type_fees (code,label,active) values ('TF_ESSENCE',    'Fuel',  1);
+insert into llx_c_type_fees (code,label,active) values ('TF_HOTEL',    'Hotel',  1);
+insert into llx_c_type_fees (code,label,active) values ('TF_TAXI',    'Cab',  1);
 
 INSERT INTO llx_c_type_fees (code, label, active) VALUES('EX_KME',    'ExpLabelKm', 1);
 INSERT INTO llx_c_type_fees (code, label, active) VALUES('EX_FUE',    'ExpLabelFuelCV', 0);

--- a/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
+++ b/htdocs/install/mysql/migration/15.0.0-16.0.0.sql
@@ -648,4 +648,11 @@ ALTER TABLE llx_paiement MODIFY COLUMN ext_payment_id varchar(255);
 ALTER TABLE llx_payment_donation MODIFY COLUMN ext_payment_id varchar(255);
 ALTER TABLE llx_prelevement_facture_demande MODIFY COLUMN ext_payment_id varchar(255);
 
-
+INSERT INTO llx_c_type_fees (code,label,active) VALUES ('TF_METRO',    'Subway',  1);
+INSERT INTO llx_c_type_fees (code,label,active) VALUES ('TF_TRAIN',    'Train',  1);
+INSERT INTO llx_c_type_fees (code,label,active) VALUES ('TF_BUS',    'Bus',  1);
+INSERT INTO llx_c_type_fees (code,label,active) VALUES ('TF_CAR',    'Car',  1);
+INSERT INTO llx_c_type_fees (code,label,active) VALUES ('TF_PEAGE',    'Toll',  1);
+INSERT INTO llx_c_type_fees (code,label,active) VALUES ('TF_ESSENCE',    'Fuel',  1);
+INSERT INTO llx_c_type_fees (code,label,active) VALUES ('TF_HOTEL',    'Hotel',  1);
+INSERT INTO llx_c_type_fees (code,label,active) VALUES ('TF_TAXI',    'Cab',  1);


### PR DESCRIPTION
# NEW Enable all types of fees in expense reports
Some fee types were not enabled by default and no UI setting allowed to enable them

