### PR TITLE
streamline template select on card+create

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1798,15 +1798,17 @@ if ($action == 'create') {
 		print '</td></tr>';
 	}
 
-	// Template to use by default
-	print '<tr class="field_model">';
-	print '<td class="titlefieldcreate">'.$langs->trans("DefaultModel").'</td>';
-	print '<td class="valuefieldcreate">';
-	print img_picto('', 'pdf', 'class="pictofixedwidth"');
-	$liste = ModelePDFPropales::liste_modeles($db);
-	$preselected = (!empty($conf->global->PROPALE_ADDON_PDF_ODT_DEFAULT) ? $conf->global->PROPALE_ADDON_PDF_ODT_DEFAULT : getDolGlobalString("PROPALE_ADDON_PDF"));
-	print $form->selectarray('model', $liste, $preselected, 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200 widthcentpercentminusx', 1);
-	print "</td></tr>";
+	// Document model
+	$list = ModelePDFPropales::liste_modeles($db);
+	if (!empty($list) && count($list) > 1) {
+		print '<tr class="field_model">';
+		print '<td class="titlefieldcreate">'.$langs->trans("DefaultModel").'</td>';
+		print '<td class="valuefieldcreate">';
+		print img_picto('', 'pdf', 'class="pictofixedwidth"');
+		$preselected = (!empty($conf->global->PROPALE_ADDON_PDF_ODT_DEFAULT) ? $conf->global->PROPALE_ADDON_PDF_ODT_DEFAULT : getDolGlobalString("PROPALE_ADDON_PDF"));
+		print $form->selectarray('model', $list, $preselected, 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200 widthcentpercentminusx', 1);
+		print "</td></tr>";
+	}
 
 	// Multicurrency
 	if (!empty($conf->multicurrency->enabled)) {

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1820,15 +1820,17 @@ if ($action == 'create' && $usercancreate) {
 		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 
-	// Template to use by default
-	print '<tr><td>'.$langs->trans('DefaultModel').'</td>';
-	print '<td>';
-	include_once DOL_DOCUMENT_ROOT.'/core/modules/commande/modules_commande.php';
-	$liste = ModelePDFCommandes::liste_modeles($db);
-	$preselected = $conf->global->COMMANDE_ADDON_PDF;
-	print img_picto('', 'pdf', 'class="pictofixedwidth"');
-	print $form->selectarray('model', $liste, $preselected, 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200 widthcentpercentminusx', 1);
-	print "</td></tr>";
+	// Document model
+	$list = ModelePDFCommandes::liste_modeles($db);
+	if (!empty($list) && count($list) > 1) {
+		print '<tr class="field_model">';
+		print '<td class="titlefieldcreate">'.$langs->trans("DefaultModel").'</td>';
+		print '<td class="valuefieldcreate">';
+		print img_picto('', 'pdf', 'class="pictofixedwidth"');
+		$preselected = $conf->global->COMMANDE_ADDON_PDF;
+		print $form->selectarray('model', $list, $preselected, 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200 widthcentpercentminusx', 1);
+		print "</td></tr>";
+	}
 
 	// Multicurrency
 	if (!empty($conf->multicurrency->enabled)) {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3698,21 +3698,23 @@ if ($action == 'create') {
 		print $object->showOptionals($extrafields, 'create', $parameters);
 	}
 
-	// Template to use by default
-	print '<tr><td>'.$langs->trans('Model').'</td>';
-	print '<td colspan="2">';
-	print img_picto('', 'pdf', 'class="pictofixedwidth"');
-	include_once DOL_DOCUMENT_ROOT.'/core/modules/facture/modules_facture.php';
-	$liste = ModelePDFFactures::liste_modeles($db);
-	if (!empty($conf->global->INVOICE_USE_DEFAULT_DOCUMENT)) {
-		// Hidden conf
-		$paramkey = 'FACTURE_ADDON_PDF_'.$object->type;
-		$preselected = !empty($conf->global->$paramkey) ? $conf->global->$paramkey : $conf->global->FACTURE_ADDON_PDF;
-	} else {
-		$preselected = $conf->global->FACTURE_ADDON_PDF;
+	// Document model
+	$list = ModelePDFFactures::liste_modeles($db);
+	if (!empty($list) && count($list) > 1) {
+		print '<tr class="field_model">';
+		print '<td class="titlefieldcreate">'.$langs->trans("DefaultModel").'</td>';
+		print '<td class="valuefieldcreate" colspan="2">';
+		print img_picto('', 'pdf', 'class="pictofixedwidth"');
+		if (!empty($conf->global->INVOICE_USE_DEFAULT_DOCUMENT)) {
+			// Hidden conf
+			$paramkey    = 'FACTURE_ADDON_PDF_'.$object->type;
+			$preselected = !empty($conf->global->$paramkey) ? $conf->global->$paramkey : $conf->global->FACTURE_ADDON_PDF;
+		} else {
+			$preselected = $conf->global->FACTURE_ADDON_PDF;
+		}
+		print $form->selectarray('model', $list, $preselected, 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200 widthcentpercentminusx', 1);
+		print "</td></tr>";
 	}
-	print $form->selectarray('model', $liste, $preselected, 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200 widthcentpercentminusx', 1);
-	print "</td></tr>";
 
 	// Multicurrency
 	if (!empty($conf->multicurrency->enabled)) {

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -706,7 +706,7 @@ class FormFile
 			$out .= '<th colspan="'.$colspan.'" class="formdoc liste_titre maxwidthonsmartphone center">';
 
 			// Model
-			if (!empty($modellist)) {
+			if (!empty($modellist) && count($modellist) > 1) {
 				asort($modellist);
 				$out .= '<span class="hideonsmartphone">'.$langs->trans('Model').' </span>';
 				if (is_array($modellist) && count($modellist) == 1) {    // If there is only one element

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1005,12 +1005,13 @@ if ($action == 'create') {
 			}
 
 			// Document model
-			include_once DOL_DOCUMENT_ROOT.'/core/modules/expedition/modules_expedition.php';
 			$list = ModelePdfExpedition::liste_modeles($db);
-			if (count($list) > 1) {
-				print "<tr><td>".$langs->trans("DefaultModel")."</td>";
-				print '<td colspan="3">';
-				print $form->selectarray('model', $list, $conf->global->EXPEDITION_ADDON_PDF);
+			if (!empty($list) && count($list) > 1) {
+				print '<tr class="field_model">';
+				print '<td class="titlefieldcreate">'.$langs->trans("DefaultModel").'</td>';
+				print '<td class="valuefieldcreate" colspan="3">';
+				$preselected = $conf->global->EXPEDITION_ADDON_PDF;
+				print $form->selectarray('model', $list, $preselected);
 				print "</td></tr>\n";
 			}
 

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -938,13 +938,16 @@ if ($action == 'create') {
 			print '</td></tr>';
 		}
 
-		// Model
-		print '<tr>';
-		print '<td>'.$langs->trans("DefaultModel").'</td>';
-		print '<td>';
-		$liste = ModelePDFFicheinter::liste_modeles($db);
-		print $form->selectarray('model', $liste, $conf->global->FICHEINTER_ADDON_PDF);
-		print "</td></tr>";
+		// Document model
+		$list = ModelePDFFicheinter::liste_modeles($db);
+		if (!empty($list) && count($list) > 1) {
+			print '<tr class="field_model">';
+			print '<td class="titlefieldcreate">'.$langs->trans("DefaultModel").'</td>';
+			print '<td class="valuefieldcreate">';
+			$preselected = $conf->global->FICHEINTER_ADDON_PDF;
+			print $form->selectarray('model', $list, $preselected);
+			print "</td></tr>";
+		}
 
 		// Public note
 		print '<tr>';

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1767,6 +1767,18 @@ if ($action == 'create') {
 		print '</td></tr>';
 	}
 
+	// Document model
+	$list = ModelePDFSuppliersOrders::liste_modeles($db);
+	if (!empty($list) && count($list) > 1) {
+		print '<tr class="field_model">';
+		print '<td class="titlefieldcreate">'.$langs->trans("DefaultModel").'</td>';
+		print '<td class="valuefieldcreate">';
+		print img_picto('', 'pdf', 'class="pictofixedwidth"');
+		$preselected = $conf->global->COMMANDE_SUPPLIER_ADDON_PDF;
+		print $form->selectarray('model', $list, $preselected, 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200 widthcentpercentminusx', 1);
+		print "</td></tr>";
+	}
+
 	// Multicurrency
 	if (!empty($conf->multicurrency->enabled)) {
 		print '<tr>';

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -901,13 +901,13 @@ if ($action == 'create') {
 			}
 
 			// Document model
-			include_once DOL_DOCUMENT_ROOT.'/core/modules/reception/modules_reception.php';
 			$list = ModelePdfReception::liste_modeles($db);
-
-			if (count($list) > 1) {
-				print "<tr><td>".$langs->trans("DefaultModel")."</td>";
-				print '<td colspan="3">';
-				print $form->selectarray('model', $list, $conf->global->RECEPTION_ADDON_PDF);
+			if (!empty($list) && count($list) > 1) {
+				print '<tr class="field_model">';
+				print '<td class="titlefieldcreate">'.$langs->trans("DefaultModel").'</td>';
+				print '<td class="valuefieldcreate" colspan="3">';
+				$preselected = $conf->global->RECEPTION_ADDON_PDF;
+				print $form->selectarray('model', $list, $preselected);
 				print "</td></tr>\n";
 			}
 

--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -1301,15 +1301,16 @@ if ($action == 'create') {
 	}
 	print '</td></tr>';
 
-
-	// Model
-	print '<tr>';
-	print '<td>'.$langs->trans("DefaultModel").'</td>';
-	print '<td colspan="2">';
+	// Document model
 	$list = ModelePDFSupplierProposal::liste_modeles($db);
-	$preselected = ($conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT ? $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT : $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF);
-	print $form->selectarray('model', $list, $preselected, 0, 0, 0, '', 0, 0, 0, '', '', 1);
-	print "</td></tr>";
+	if (!empty($list) && count($list) > 1) {
+		print '<tr class="field_model">';
+		print '<td class="titlefieldcreate">'.$langs->trans("DefaultModel").'</td>';
+		print '<td class="valuefieldcreate" colspan="2">';
+		$preselected = ($conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT ? $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF_ODT_DEFAULT : $conf->global->SUPPLIER_PROPOSAL_ADDON_PDF);
+		print $form->selectarray('model', $list, $preselected, 0, 0, 0, '', 0, 0, 0, '', '', 1);
+		print "</td></tr>\n";
+	}
 
 	// Project
 	if (!empty($conf->project->enabled)) {


### PR DESCRIPTION
show only of active template count > 1


on `card.php?action=create` the document template should only be shown if the count of active templates for that item type is greater 1
Otherwise it makes not sense to provide the select that give the user no option to change anything
