### PR TITLE
NEW hook "changeHelpURL" to modify target of the help button

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1309,7 +1309,7 @@ if (!function_exists("llxHeader")) {
 	 */
 	function llxHeader($head = '', $title = '', $help_url = '', $target = '', $disablejs = 0, $disablehead = 0, $arrayofjs = '', $arrayofcss = '', $morequerystring = '', $morecssonbody = '', $replacemainareaby = '', $disablenofollow = 0)
 	{
-		global $conf;
+		global $conf, $hookmanager;
 
 		// html header
 		top_htmlhead($head, $title, $disablejs, $disablehead, $arrayofjs, $arrayofcss, 0, $disablenofollow);
@@ -1328,6 +1328,12 @@ if (!function_exists("llxHeader")) {
 		}
 
 		print '<body id="mainbody" class="'.$tmpcsstouse.'">'."\n";
+
+		$parameters = array('help_url' => $help_url);
+		$reshook = $hookmanager->executeHooks('changeHelpURL', $parameters);
+		if ($reshook > 0) {
+			$help_url = $hookmanager->resPrint;
+		}
 
 		// top menu and left menu area
 		if (empty($conf->dol_hide_topmenu) || GETPOST('dol_invisible_topmenu', 'int')) {


### PR DESCRIPTION
Use the hook `changeHelpURL` to modify the help_url parameter.

Example action:

```php
public function changeHelpURL( $parameters, &$object, &$action, $hookmanager ) {

	$context = $parameters['context'];
	
	switch ($context) {

		case 'main:mrpindex':
			$changed_url = 'https://doku.something.local/mrp';
		break;

		case 'main:index':
		default:
			$changed_url = 'https://doku.something.local/';
		break;
	}

	$hookmanager->resPrint = $changed_url;

	return 1;

}
``` 