### PR TITLE
# FIX : rank duplicate on mass action

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -791,7 +791,6 @@ if ($massaction == 'confirm_createbills') {   // Create bills from orders.
 							'HT',
 							0,
 							$product_type,
-							
 							//we have define the max rank for each line which makes it possible not to have a duplicate on the rank field in the case of several orders
 							//-1 will give us the right number
 							-1, // rank

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -641,7 +641,7 @@ if ($massaction == 'confirm_createbills') {   // Create bills from orders.
 	$lastref = '';
 
 	$db->begin();
-
+	$nbOrders = is_array($orders) ?  count($orders) : 1;
 	foreach ($orders as $id_order) {
 		$cmd = new Commande($db);
 		if ($cmd->fetch($id_order) <= 0) {
@@ -773,7 +773,7 @@ if ($massaction == 'confirm_createbills') {   // Create bills from orders.
 						}
 
 						$objecttmp->context['createfromclone'];
-
+						$rankedLine = ($nbOrders > 1) ? -1 : $lines[$i]->rang;
 						$result = $objecttmp->addline(
 							$desc,
 							$lines[$i]->subprice,
@@ -793,7 +793,7 @@ if ($massaction == 'confirm_createbills') {   // Create bills from orders.
 							$product_type,
 							//we have define the max rank for each line which makes it possible not to have a duplicate on the rank field in the case of several orders
 							//-1 will give us the right number
-							-1, // rank
+							$rankedLine, // rank
 							$lines[$i]->special_code,
 							$objecttmp->origin,
 							$lines[$i]->rowid,

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -641,7 +641,9 @@ if ($massaction == 'confirm_createbills') {   // Create bills from orders.
 	$lastref = '';
 
 	$db->begin();
-	$nbOrders = is_array($orders) ?  count($orders) : 1;
+	
+	$nbOrders = is_array($orders) ? count($orders) : 1;
+	
 	foreach ($orders as $id_order) {
 		$cmd = new Commande($db);
 		if ($cmd->fetch($id_order) <= 0) {

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -791,7 +791,10 @@ if ($massaction == 'confirm_createbills') {   // Create bills from orders.
 							'HT',
 							0,
 							$product_type,
-							$lines[$i]->rang,
+							
+							//we have define the max rank for each line which makes it possible not to have a duplicate on the rank field in the case of several orders
+							//-1 will give us the right number
+							-1, // rank
 							$lines[$i]->special_code,
 							$objecttmp->origin,
 							$lines[$i]->rowid,


### PR DESCRIPTION
# FIX :  rank duplicate on mass action  invoice from multiple orders

we have to  define the max rank for each line which makes it possible not to have a duplicate on the rank field in the case of several order massaction request.
