### PR TITLE
Improve option update prices on proposal cloning

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1431,6 +1431,9 @@ class Propal extends CommonObject
 							$line->subprice = $pu_ht;
 							$line->tva_tx = $tva_tx;
 							$line->remise_percent = $remise_percent;
+							// Update also cost price
+							$result = $object->defineBuyPrice($line->subprice, $line->remise_percent, $line->fk_product);
+							if ($result > 0)	$line->pa_ht = $result;
 						}
 					}
 				}


### PR DESCRIPTION
When we clone a commercial proposal, if we want to update prices we should also update cost price.