### PR TITLE
send formconfirm as a POST

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5168,9 +5168,6 @@ class Form
                          		});
                          	}
 							if (pageyes.length > 0) {
-								console.log(page);
-								console.log(pageyes);
-								console.log(options);
 								var post = $.post(
 									pageyes,
 									options,
@@ -5194,8 +5191,6 @@ class Form
                          		});
                          	}
 							if (pageno.length > 0) {
-								console.log(pageno);
-								console.log(options);
 								var post = $.post(
 									pageno,
 									options,

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5182,6 +5182,7 @@ class Form
                         "'.dol_escape_js($langs->transnoentities($labelbuttonno)).'": function() {
                         	var options = "token='.urlencode(newToken()).'";
                          	var inputko = '.json_encode($inputko).';	/* List of fields into form */
+							var page = "'.dol_escape_js(!empty($page) ? $page : '').'";
                          	var pageno="'.dol_escape_js(!empty($pageno) ? $pageno : '').'";
                          	if (inputko.length>0) {
                          		$.each(inputko, function(i, inputname) {

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5148,8 +5148,9 @@ class Form
                     closeOnEscape: false,
                     buttons: {
                         "'.dol_escape_js($langs->transnoentities($labelbuttonyes)).'": function() {
-                        	var options = "&token='.urlencode(newToken()).'";
+							var options = "token='.urlencode(newToken()).'";
                         	var inputok = '.json_encode($inputok).';	/* List of fields into form */
+							var page = "'.dol_escape_js(!empty($page) ? $page : '').'";
                          	var pageyes = "'.dol_escape_js(!empty($pageyes) ? $pageyes : '').'";
                          	if (inputok.length>0) {
                          		$.each(inputok, function(i, inputname) {
@@ -5166,12 +5167,20 @@ class Form
                          			options += "&" + inputname + "=" + encodeURIComponent(inputvalue);
                          		});
                          	}
-                         	var urljump = pageyes + (pageyes.indexOf("?") < 0 ? "?" : "") + options;
-            				if (pageyes.length > 0) { location.href = urljump; }
+							if (pageyes.length > 0) {
+								console.log(page);
+								console.log(pageyes);
+								console.log(options);
+								var post = $.post(
+									pageyes,
+									options,
+									() => {location.assign(page)}
+								);
+							}
                             $(this).dialog("close");
                         },
                         "'.dol_escape_js($langs->transnoentities($labelbuttonno)).'": function() {
-                        	var options = "&token='.urlencode(newToken()).'";
+                        	var options = "token='.urlencode(newToken()).'";
                          	var inputko = '.json_encode($inputko).';	/* List of fields into form */
                          	var pageno="'.dol_escape_js(!empty($pageno) ? $pageno : '').'";
                          	if (inputko.length>0) {
@@ -5183,9 +5192,15 @@ class Form
                          			options += "&" + inputname + "=" + encodeURIComponent(inputvalue);
                          		});
                          	}
-                         	var urljump=pageno + (pageno.indexOf("?") < 0 ? "?" : "") + options;
-                         	//alert(urljump);
-            				if (pageno.length > 0) { location.href = urljump; }
+							if (pageno.length > 0) {
+								console.log(pageno);
+								console.log(options);
+								var post = $.post(
+									pageno,
+									options,
+									() => {location.assign(page)}
+								);
+							}
                             $(this).dialog("close");
                         }
                     }

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5174,7 +5174,7 @@ class Form
 								var post = $.post(
 									pageyes,
 									options,
-									() => {location.assign(page)}
+									(data) => {$("body").html(data)}
 								);
 							}
                             $(this).dialog("close");
@@ -5199,7 +5199,7 @@ class Form
 								var post = $.post(
 									pageno,
 									options,
-									() => {location.assign(page)}
+									(data) => {$("body").html(data)}
 								);
 							}
                             $(this).dialog("close");


### PR DESCRIPTION
# FIX Form::formconfirm() would send inputs as GET

The Form::formconfirm() method creates a confirmation form. The values are sent as GET parameters. This has two consequences:
- it exposes the CSRF token in the request
- it prevents modules to use advanced features such as rich text editors (which is a strange idea in a confirm box, but some do) since some chars (like '"') are allowed in POST requests but not in GET requests.

This PR changes the request method from GET to POST. The page is re-drawn with the response in order to display errors, if there are.




