### PR TITLE
FIX permissions création d'absence

### DIFF
--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -910,7 +910,7 @@ $edit = false;
 
 if ((empty($id) && empty($ref)) || $action == 'create' || $action == 'add') {
 	// If user has no permission to create a leave
-	if ((in_array($fuserid, $childids) && empty($user->rights->holiday->write)) || (!in_array($fuserid, $childids) && (empty($conf->global->MAIN_USE_ADVANCED_PERMS) || empty($user->rights->holiday->writeall_advance)))) {
+	if ((in_array($fuserid, $childids) && empty($user->rights->holiday->write)) || (!in_array($fuserid, $childids) && ((!empty($conf->global->MAIN_USE_ADVANCED_PERMS) && empty($user->rights->holiday->writeall_advance) || empty($user->rights->holiday->writeall))))) {
 		$errors[] = $langs->trans('CantCreateCP');
 	} else {
 		// Form to add a leave request


### PR DESCRIPTION
# FIX

Actuellement, on a le droit de créer une absence pour un utilisateur dont on est le responsable hiérarchique si on a le droit de créer que pour soi-même.

On a aussi le droit de créer une absence pour un utilisateur qui n'est pas sous notre responsabilité hiérarchique si on a les droits avancés activés.

**Cependant, si on a le droit de créer pour tout le monde sans avoir les droits avancés activés**, on ne peut pas créer une absence pour tout le monde alors que l'on devrait pouvoir le faire.
