### PR TITLE
FIX : rank duplicate on mass action invoice from multiple orders

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -604,7 +604,9 @@ if ($massaction == 'confirm_createbills')   // Create bills from orders
 	$nb_bills_created = 0;
 
 	$db->begin();
-	$nbOrders = is_array($orders) ?  count($orders) : 1;
+
+	$nbOrders = is_array($orders) ? count($orders) : 1;
+
 	foreach ($orders as $id_order)
 	{
 		$cmd = new Commande($db);

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -604,7 +604,7 @@ if ($massaction == 'confirm_createbills')   // Create bills from orders
 	$nb_bills_created = 0;
 
 	$db->begin();
-
+	$nbOrders = is_array($orders) ?  count($orders) : 1;
 	foreach ($orders as $id_order)
 	{
 		$cmd = new Commande($db);
@@ -726,7 +726,7 @@ if ($massaction == 'confirm_createbills')   // Create bills from orders
 							$lines[$i]->fetch_optionals();
 							$array_options = $lines[$i]->array_options;
 						}
-
+						$rankedLine = ($nbOrders > 1) ? -1 : $lines[$i]->rang;
 						$result = $objecttmp->addline(
 							$desc,
 							$lines[$i]->subprice,
@@ -744,7 +744,7 @@ if ($massaction == 'confirm_createbills')   // Create bills from orders
 							'HT',
 							0,
 							$product_type,
-							$lines[$i]->rang,
+							$rankedLine,
 							$lines[$i]->special_code,
 							$objecttmp->origin,
 							$lines[$i]->rowid,


### PR DESCRIPTION

we have to define the max rank for each line which makes it possible not to have a duplicate on the rank field in the case of several order massaction request.
