### PR TITLE
check batch on receptions->addline when module is enabled

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -765,7 +765,7 @@ class Reception extends CommonObject
 				return -1;
 			}
 		}
-		unset ($product);
+		unset($product);
 
 		// extrafields
 		$line->array_options = $supplierorderline->array_options;

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -759,11 +759,9 @@ class Reception extends CommonObject
 			$langs->load("errors");
 			if (!empty($product->status_batch) && empty($batch)) {
 				$this->error = $langs->trans('ErrorProductNeedBatchNumber', $product->ref);
-				setEventMessages($this->error, $this->errors, 'errors');
 				return -1;
 			} elseif (empty($product->status_batch) && !empty($batch)) {
 				$this->error = $langs->trans('ErrorProductDoesNotNeedBatchNumber', $product->ref);
-				setEventMessages($this->error, $this->errors, 'errors');
 				return -1;
 			}
 		}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -752,6 +752,23 @@ class Reception extends CommonObject
 			}
 		}
 
+		// Check batch is set
+		$product = new Product($this->db);
+		$product->fetch($fk_product);
+		if (!empty($conf->productbatch->enabled)) {
+			$langs->load("errors");
+			if (!empty($product->status_batch) && empty($batch)) {
+				$this->error = $langs->trans('ErrorProductNeedBatchNumber', $product->ref);
+				setEventMessages($this->error, $this->errors, 'errors');
+				return -1;
+			} elseif (empty($product->status_batch) && !empty($batch)) {
+				$this->error = $langs->trans('ErrorProductDoesNotNeedBatchNumber', $product->ref);
+				setEventMessages($this->error, $this->errors, 'errors');
+				return -1;
+			}
+		}
+		unset ($product);
+
 		// extrafields
 		$line->array_options = $supplierorderline->array_options;
 		if (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED) && is_array($array_options) && count($array_options) > 0) {


### PR DESCRIPTION
# FIX Check batch on reception

When Batch module is enabled and products need a batch number, batches are not checked in Reception::addline().
This allows to create receptions with empty batches.
This PR fixes this behavior.
