### PR TITLE
FIX dol_compress_dir names files on archives

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -2193,7 +2193,7 @@ function dol_compress_dir($inputdir, $outputfile, $mode = "zip", $excludefiles =
 					if (!$file->isDir()) {
 						// Get real and relative path for current file
 						$filePath = $file->getRealPath();
-						$relativePath = ($rootdirinzip ? $rootdirinzip.'/' : '').substr($filePath, strlen($inputdir) + 1);
+						$relativePath = ($rootdirinzip ? $rootdirinzip.'/' : '').substr($filePath, strlen(realpath($inputdir)) + 1);
 
 						if (empty($excludefiles) || !preg_match($excludefiles, $filePath)) {
 							// Add current file to archive


### PR DESCRIPTION
FIX dol_compress_dir names files on archives

The function changes the name of files when compressing.
Archiving keeps exact file name now.
