### PR TITLE
NEW : Stock transfer on products deserialization

### DIFF
--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -427,3 +427,4 @@ RealValuation=Real Valuation
 ConfirmEditExtrafield = Select the extrafield you want modify
 ConfirmEditExtrafieldQuestion = Are you sure you want to modify this extrafield?
 ModifyValueExtrafields = Modify value of an extrafield
+WarningTransferBatchStockMouvToGlobal = If you want to deserialize this product, all its serialized stock will be transformed into global stock (without serial number)

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -427,4 +427,4 @@ RealValuation=Real Valuation
 ConfirmEditExtrafield = Select the extrafield you want modify
 ConfirmEditExtrafieldQuestion = Are you sure you want to modify this extrafield?
 ModifyValueExtrafields = Modify value of an extrafield
-WarningTransferBatchStockMouvToGlobal = If you want to deserialize this product, all its serialized stock will be transformed into global stock (without serial number)
+WarningTransferBatchStockMouvToGlobal = If you want to deserialize this product, all its serialized stock will be transformed into global stock

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1874,6 +1874,22 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 					print '<tr><td>'.$langs->trans("ManageLotSerial").'</td><td>';
 					$statutarray = array('0' => $langs->trans("ProductStatusNotOnBatch"), '1' => $langs->trans("ProductStatusOnBatch"), '2' => $langs->trans("ProductStatusOnSerial"));
 					print $form->selectarray('status_batch', $statutarray, $object->status_batch);
+					print '<span id="statusBatchWarning" class="warning" style="display: none;">'.img_warning().'&nbsp;'.$langs->trans("WarningTransferBatchStockMouvToGlobal").'</span>';
+
+					if($object->status_batch){
+						print '<script type="text/javascript">
+							$(document).ready(function() {
+                                console.log($("#statusBatchWarning"))
+                                $("#status_batch").on("change", function() {
+                                    if ($("#status_batch")[0].value == 0){
+                                        $("#statusBatchWarning").show()
+                                    } else {
+                                        $("#statusBatchWarning").hide()
+                                    }
+                                })
+							})</script>';
+					}
+
 					print '</td></tr>';
 					if (!empty($object->status_batch) || !empty($conf->use_javascript_ajax)) {
 						$langs->load("admin");

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1876,7 +1876,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 					print $form->selectarray('status_batch', $statutarray, $object->status_batch);
 					print '<span id="statusBatchWarning" class="warning" style="display: none;">'.img_warning().'&nbsp;'.$langs->trans("WarningTransferBatchStockMouvToGlobal").'</span>';
 
-					if($object->status_batch){
+					if ($object->status_batch) {
 						print '<script type="text/javascript">
 							$(document).ready(function() {
                                 console.log($("#statusBatchWarning"))

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1221,7 +1221,7 @@ class Product extends CommonObject
 					}
 				}
 
-				if (!$this->hasbatch() && $this->oldcopy->hasbatch()){
+				if (!$this->hasbatch() && $this->oldcopy->hasbatch()) {
 					// Selection of all product stock mouvements that contains batchs
 					$sql = 'SELECT * FROM '.MAIN_DB_PREFIX.'stock_mouvement sm';
 					$sql .= ' WHERE fk_product = '.$this->id;
@@ -1241,12 +1241,12 @@ class Product extends CommonObject
 							//To know how to revert stockMouvement (add or remove)
 							$addOremove = $value > 0 ? 1 : 0; // 1 if remove, 0 if add
 							$label = $langs->trans('BatchStockMouvementReverting');
-							$res = $this->correct_stock_batch($user, $fk_entrepot, $value, $addOremove, $label, $price, $dlc, $dluo, $batch, $inventorycode, '',null, 0);
-							if($res > 0){
+							$res = $this->correct_stock_batch($user, $fk_entrepot, $value, $addOremove, $label, $price, $dlc, $dluo, $batch, $inventorycode, '', null, 0);
+							if ($res > 0) {
 								$label = $langs->trans('BatchStockMouvementAddInGlobal');
 								$addOremove = $addOremove == 0 ? 1 : 0;
-								$res = $this->correct_stock($user, $fk_entrepot, $value, $addOremove, $label, $price, $inventorycode, '',null, 0);
-								if($res < 0) {
+								$res = $this->correct_stock($user, $fk_entrepot, $value, $addOremove, $label, $price, $inventorycode, '', null, 0);
+								if ($res < 0) {
 									$error++;
 								}
 							} else {

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1224,7 +1224,7 @@ class Product extends CommonObject
 				if (!$this->hasbatch() && $this->oldcopy->hasbatch()){
 					// Selection of all product stock mouvements that contains batchs
 					$sql = 'SELECT * FROM '.MAIN_DB_PREFIX.'stock_mouvement sm';
-					$sql .= ' WHERE fk_product = '.$this->id;
+					$sql .= ' WHERE fk_product = '.(int) $this->id;
 					$sql .= ' AND batch IS NOT NULL';
 
 					$resql = $this->db->query($sql);


### PR DESCRIPTION
## NEW : Stock transfer on products deserialization

When an user deserialize a product, the serialized stock stay in place. This can be a problem.

To avoid this problem, on the deserialization of a product, for each serialized stock mouvements :
- Clone of the serialized stock mouvement into a global stock mouvement (without batch)
- Creation of a reverse serialized stock mouvements to cancel the serialized stock mouvement 
- Displaying an alert on deserialization 
