### PR TITLE
FIX #20476 migration postgresql 13.0.x to 14.0.x packaging type

### DIFF
--- a/htdocs/install/mysql/migration/13.0.0-14.0.0.sql
+++ b/htdocs/install/mysql/migration/13.0.0-14.0.0.sql
@@ -85,7 +85,8 @@ UPDATE llx_const set value = __ENCRYPT('eldy')__ WHERE __DECRYPT('value')__ = 'c
 DELETE FROM llx_user_param where param = 'MAIN_THEME' and value in ('auguria', 'amarok', 'cameleo');
 
 ALTER TABLE llx_product_fournisseur_price ADD COLUMN packaging real DEFAULT NULL;
-ALTER TABLE llx_product_fournisseur_price MODIFY COLUMN packaging real DEFAULT NULL;
+-- VMYSQL4.3 ALTER TABLE llx_product_fournisseur_price MODIFY COLUMN packaging real DEFAULT NULL;
+-- VPGSQL8.2 ALTER TABLE llx_product_fournisseur_price MODIFY COLUMN packaging real DEFAULT NULL USING packaging::real;
 
 
 -- For v14


### PR DESCRIPTION
Taken from ff35bf8d47650b453f7224ced7857e2bbc53ecd5

This is similar to the pull-request [20714 ](https://github.com/Dolibarr/dolibarr/pull/20714) but for the 13 -> 14 step of the upgrade, where the following message appears :
```
Error DB_ERROR_42804: ALTER TABLE llx_product_fournisseur_price MODIFY COLUMN packaging real DEFAULT NULL;
ERREUR: 42804: la colonne  « packaging » ne peut pas être convertie vers le type real HINT: Vous pouvez avoir besoin de spécifier "USING packaging::real". LOCATION: ATPrepAlterColumnType, tablecmds.c:8003
```

I create this pull-request as a draft towards the branch `15.0` while I try to understand why there are many differences in the file `13.0.0-14.0.0.sql` between branches `15.0` and `develop`. The sql query is not present in the branch `develop`.
