### PR TITLE
fix signature style in email template

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -935,7 +935,7 @@ class FormMail extends Form
 					$out .= '<input type="hidden" id="message" name="message" value="'.$defaultmessage.'" />';
 				} else {
 					if (!isset($this->ckeditortoolbar)) {
-						$this->ckeditortoolbar = 'dolibarr_notes';
+						$this->ckeditortoolbar = 'dolibarr_mailings';
 					}
 
 					// Editor wysiwyg


### PR DESCRIPTION
Fix : HTML signature style in email template

When creating an email signature with divs in html templates, this is not kept in email composing forms. We should use dolibarr_mailings as editor toolbar style.
