### PR TITLE
Fix: 'tabhelp' must be present in every module

### DIFF
--- a/htdocs/core/modules/modIncoterm.class.php
+++ b/htdocs/core/modules/modIncoterm.class.php
@@ -94,7 +94,8 @@ class modIncoterm extends DolibarrModules
 			'tabfieldvalue'=>array("code,libelle"), // List of fields (list of fields to edit a record)
 			'tabfieldinsert'=>array("code,libelle"), // List of fields (list of fields for insert)
 			'tabrowid'=>array("rowid"), // Name of columns with primary key (try to always name it 'rowid')
-			'tabcond'=>array($conf->incoterm->enabled)
+			'tabcond'=>array($conf->incoterm->enabled),
+			'tabhelp' => array(array())
 		);
 
 		$this->boxes = array(); // List of boxes

--- a/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
+++ b/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
@@ -221,7 +221,10 @@ class modMyModule extends DolibarrModules
 			// Name of columns with primary key (try to always name it 'rowid')
 			'tabrowid'=>array("rowid", "rowid", "rowid"),
 			// Condition to show each dictionary
-			'tabcond'=>array($conf->mymodule->enabled, $conf->mymodule->enabled, $conf->mymodule->enabled)
+			'tabcond'=>array($conf->mymodule->enabled, $conf->mymodule->enabled, $conf->mymodule->enabled),
+			// Tooltip for every fields of dictionaries: DO NOT PUT AN EMPTY ARRAY
+			'tabhelp'=>array(array('field1' => 'field1tooltip', 'field2' => 'field2tooltip'), array('field1' => 'field1tooltip', 'field2' => 'field2tooltip'), ...),
+
 		);
 		*/
 


### PR DESCRIPTION
When I wanted to add tool-tips to the fields of my modules' dictionaries, I realized that a 'tabhelp' array was missing in the Incoterm module, which blocked the display for my dictionary.

In order to be used by new modules, 'tabhelp' must be **present** AND **not empty**  in each existing module, so I also add it in  the module-builder template. 