### PR TITLE
FIX Accountancy - Label of VAT account is empty FPC21+

### DIFF
--- a/htdocs/accountancy/journal/expensereportsjournal.php
+++ b/htdocs/accountancy/journal/expensereportsjournal.php
@@ -328,7 +328,7 @@ if ($action == 'writebookkeeping') {
 
 				foreach ($arrayofvat[$key] as $k => $mt) {
 					if ($mt) {
-						$accountingaccount->fetch($k, null, true);	// TODO Use a cache for label
+						$accountingaccount->fetch(null, $k, true);	// TODO Use a cache for label
 						$account_label = $accountingaccount->label;
 
 						// get compte id and label

--- a/htdocs/accountancy/journal/purchasesjournal.php
+++ b/htdocs/accountancy/journal/purchasesjournal.php
@@ -441,7 +441,7 @@ if ($action == 'writebookkeeping') {
 
 				foreach ($arrayofvat[$key] as $k => $mt) {
 					if ($mt) {
-						$accountingaccount->fetch($k, null, true);		// TODO Use a cache for label
+						$accountingaccount->fetch(null, $k, true);		// TODO Use a cache for label
 						$label_account = $accountingaccount->label;
 
 						$bookkeeping = new BookKeeping($db);

--- a/htdocs/accountancy/journal/sellsjournal.php
+++ b/htdocs/accountancy/journal/sellsjournal.php
@@ -453,7 +453,7 @@ if ($action == 'writebookkeeping') {
 
 				foreach ($arrayofvat[$key] as $k => $mt) {
 					if ($mt) {
-						$accountingaccount->fetch($k, null, true);	// TODO Use a cache for label
+						$accountingaccount->fetch(null, $k, true);	// TODO Use a cache for label
 						$label_account = $accountingaccount->label;
 
 						$bookkeeping = new BookKeeping($db);


### PR DESCRIPTION
Accounting account is fetch on a rowid  while we have an accounting account number....

Result : $label_account is empty and is retrieved from the products/services account called before.

![image](https://user-images.githubusercontent.com/2341395/180456719-bb76ed91-c81f-4079-9f72-017d392a004e.png)
