### PR TITLE
FIX : VAT rate recalculation

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1275,6 +1275,13 @@ class Facture extends CommonInvoice
 			$object->lines[$i]->ref_ext = ''; // Do not clone ref_ext
 		}
 
+		if($objFrom->socid != $object->socid){
+			global $mysoc;
+
+			foreach ($object->lines as $line) {
+				$line->tva_tx = get_default_tva($mysoc, $objsoc, $line->fk_product);
+			}
+		}
 		// Create clone
 		$object->context['createfromclone'] = 'createfromclone';
 		$result = $object->create($user);

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1275,7 +1275,7 @@ class Facture extends CommonInvoice
 			$object->lines[$i]->ref_ext = ''; // Do not clone ref_ext
 		}
 
-		if($objFrom->socid != $object->socid){
+		if ($objFrom->socid != $object->socid) {
 			global $mysoc;
 
 			foreach ($object->lines as $line) {


### PR DESCRIPTION
## FIX : VAT rate recalculation

Whne we clone an invoice for another thirparty that don't come from the same country than the first thirdprty, the VAT rate can change.
So, I think, we must recalculate the vat rate on the clone 