### PR TITLE
FIX #21668 Disassemble BOM is not handling properly the Weighted average price

### DIFF
--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1169,7 +1169,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					print '<td class="right">'.$line->qty.'</td>';
 					if ($permissiontoupdatecost) {
 						// Defined $manufacturingcost
+						if ($object->mrptype==0) {  // manufacturing
 						$manufacturingcost = $bomcost;
+						}
+						else { 						// disassemble
+							$manufacturingcost = NULL;
+						}
 						if (empty($manufacturingcost)) {
 							$manufacturingcost = price2num($tmpproduct->cost_price, 'MU');
 						}
@@ -1273,7 +1278,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						print '<td class="right"><input type="text" class="width50 right" id="qtytoproduce-'.$line->id.'-'.$i.'" name="qtytoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';
 						if ($permissiontoupdatecost) {
 							// Defined $manufacturingcost
+							if ($object->mrptype==0) {  // manufacturing
 							$manufacturingcost = $bomcost;
+							}
+							else { 						// disassemble
+								$manufacturingcost = NULL;
+							}
 							if (empty($manufacturingcost)) {
 								$manufacturingcost = price2num($tmpproduct->cost_price, 'MU');
 							}

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1170,10 +1170,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					if ($permissiontoupdatecost) {
 						// Defined $manufacturingcost
 						if ($object->mrptype==0) {  // manufacturing
-						$manufacturingcost = $bomcost;
-						}
-						else { 						// disassemble
-							$manufacturingcost = NULL;
+							$manufacturingcost = $bomcost;
+						} else { 						// disassemble
+							$manufacturingcost = null;
 						}
 						if (empty($manufacturingcost)) {
 							$manufacturingcost = price2num($tmpproduct->cost_price, 'MU');
@@ -1279,10 +1278,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						if ($permissiontoupdatecost) {
 							// Defined $manufacturingcost
 							if ($object->mrptype==0) {  // manufacturing
-							$manufacturingcost = $bomcost;
-							}
-							else { 						// disassemble
-								$manufacturingcost = NULL;
+								$manufacturingcost = $bomcost;
+							} else { 						// disassemble
+								$manufacturingcost = null;
 							}
 							if (empty($manufacturingcost)) {
 								$manufacturingcost = price2num($tmpproduct->cost_price, 'MU');


### PR DESCRIPTION
In a normal manufacturing MO the sum of all product costs (WAP or cost price or buying price) is being used as stock movement cost for the final product of the MO. This works wonderful and you get WAP for manufactured products.

In the case you are disassemle a product with WAP then you go from 1 input product to lot of output products, each of the output producs like screws, glue, parts will increase in stock but the cost of the stock movement would be the one of the input product that is a very high one. This will cause suddenly all of the raw materials to have a very high WAP

This fix is ignoring the price of the input product in case of MO type disassemble