### PR TITLE
Update import_xlsx.modules.php

### DIFF
--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -863,7 +863,7 @@ class ImportXlsx extends ModeleImports
 								if (empty($keyfield)) {
 									$keyfield = 'rowid';
 								}
-								$sqlSelect .= "WHERE " . $keyfield . " = " .((int) $lastinsertid);
+								$sqlSelect .= " WHERE " . $keyfield . " = " .((int) $lastinsertid);
 
 								$resql = $this->db->query($sqlSelect);
 								if ($resql) {


### PR DESCRIPTION
# FIX|Fix #21474[*Error importing products with additional fields*]
When importing products through xlsx file, if this product has additional fields and they are included in the file, it gives the following error in the database.
```
SELECT rowid FROM llx_product_extrafieldsWHERE fk_object = 3940
[DB_ERROR_SYNTAX] You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '= 3940' at line 1
```

