### PR TITLE
remove '?' character returned by ut8_decode

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8500,7 +8500,7 @@ function dol_osencode($str)
 	}
 
 	if ($tmp == 'iso-8859-1') {
-		return utf8_decode($str);
+		return str_replace('?', '', utf8_decode($str));
 	}
 	return $str;
 }


### PR DESCRIPTION
remove '?' character returned by ut8_decode if a UTF-8 character do not exist in ISO-8859-1
this trigger an error when submiting a file in GED module
![Screenshot 2022-08-08 at 16-47-06 Espace GED](https://user-images.githubusercontent.com/34718682/183458846-2e6ddbee-b7bb-4a0e-8ad4-a3cfc085aeea.png)
