### PR TITLE
NEW: add oldcopy to Ticket for modules intercepting TICKET_MODIFY

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -212,6 +212,11 @@ class Ticket extends CommonObject
 	 */
 	public $email_date;
 
+	/**
+	 * @var Ticket $oldcopy  State of this ticket as it was stored before an update operation (for triggers)
+	 */
+	public $oldcopy;
+
 
 	public $lines;
 
@@ -974,6 +979,10 @@ class Ticket extends CommonObject
 
 		if (!$error && !$notrigger) {
 			// Call trigger
+			if (empty($this->oldcopy)) {
+				$this->oldcopy = new self($this->db);
+				$this->oldcopy->fetch($this->id);
+			}
 			$result = $this->call_trigger('TICKET_MODIFY', $user);
 			if ($result < 0) {
 				$error++;

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -870,9 +870,8 @@ class Ticket extends CommonObject
 		global $conf, $langs, $hookmanager;
 		$error = 0;
 
-		if (empty($this->oldcopy) && empty($notrigger)) {
-			$this->oldcopy = new self($this->db);
-			$this->oldcopy->fetch($this->id);
+		if (empty($notrigger)) {
+			$this->oldcopy = dol_clone($this, 1);
 		}
 
 		// Clean parameters
@@ -1464,9 +1463,8 @@ class Ticket extends CommonObject
 		$error = 0;
 
 		if ($this->statut != self::STATUS_CANCELED) { // no closed
-			if (empty($this->oldcopy) && empty($notrigger)) {
-				$this->oldcopy = new self($this->db);
-				$this->oldcopy->fetch($this->id);
+			if (empty($notrigger)) {
+				$this->oldcopy = dol_clone($this, 1);
 			}
 			$this->db->begin();
 

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -870,6 +870,11 @@ class Ticket extends CommonObject
 		global $conf, $langs, $hookmanager;
 		$error = 0;
 
+		if (empty($this->oldcopy) && empty($notrigger)) {
+			$this->oldcopy = new self($this->db);
+			$this->oldcopy->fetch($this->id);
+		}
+
 		// Clean parameters
 		if (isset($this->ref)) {
 			$this->ref = trim($this->ref);
@@ -979,10 +984,6 @@ class Ticket extends CommonObject
 
 		if (!$error && !$notrigger) {
 			// Call trigger
-			if (empty($this->oldcopy)) {
-				$this->oldcopy = new self($this->db);
-				$this->oldcopy->fetch($this->id);
-			}
 			$result = $this->call_trigger('TICKET_MODIFY', $user);
 			if ($result < 0) {
 				$error++;
@@ -1463,6 +1464,10 @@ class Ticket extends CommonObject
 		$error = 0;
 
 		if ($this->statut != self::STATUS_CANCELED) { // no closed
+			if (empty($this->oldcopy) && empty($notrigger)) {
+				$this->oldcopy = new self($this->db);
+				$this->oldcopy->fetch($this->id);
+			}
 			$this->db->begin();
 
 			$sql = "UPDATE ".MAIN_DB_PREFIX."ticket";


### PR DESCRIPTION
## Rationale

Sometimes modules that intercept the `TICKET_MODIFY` trigger need to access old values of the ticket's properties.

With oldcopy, modules are now able to determine what was updated and can act accordingly.

**Note**: while reviewing how other core classes handle this, I saw that some just `clone` the object while others like `contrat.class.php` re-fetch it. Cloning is better in terms of performance, but maybe re-fetching is safer (because the clone is shallow so nested references might still point to the actual cloned object's counterpart).

If you feel that cloning is good enough, I can change that.