### PR TITLE
CLOSE 21748 Maillage sur ErrorProductAlreadyExists en créant produit

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -668,14 +668,14 @@ if (empty($reshook)) {
 					setEventMessages($object->error, $object->errors, 'errors');
 				} else {
 					if ($object->error == 'ErrorProductAlreadyExists') {
-						// permet une action personnallisée quand il y a tentative d'ajouter un produit
-						// avec un numéro de référence existant.
+						// allow to hook on ErrorProductAlreadyExists in any module
 						$reshook = $hookmanager->executeHooks('onProductAlreadyExists', $parameters, $object, $action);
 						if ($reshook < 0) {
 							setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 						}
 						if ($object->error) {
-							// L'erreur de l'objet a pu être effacée par la fonction
+							// check again to prevent translation issue, 
+							// as error may have been cleared in hook function
 							setEventMessages($langs->trans($object->error), null, 'errors');
 						}
 					} else {

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -667,16 +667,16 @@ if (empty($reshook)) {
 				if (count($object->errors)) {
 					setEventMessages($object->error, $object->errors, 'errors');
 				} else {
-					if($object->error == 'ErrorProductAlreadyExists') {	
-						// permet une action personnallisée quand il y a tentative d'ajouter un produit 
+					if ($object->error == 'ErrorProductAlreadyExists') {
+						// permet une action personnallisée quand il y a tentative d'ajouter un produit
 						// avec un numéro de référence existant.
 						$reshook = $hookmanager->executeHooks('onProductAlreadyExists', $parameters, $object, $action);
 						if ($reshook < 0) {
 							setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
-						}							
-						if($object->error) {
+						}
+						if ($object->error) {
 							// L'erreur de l'objet a pu être effacée par la fonction
-							setEventMessages($langs->trans($object->error), null, 'errors');	
+							setEventMessages($langs->trans($object->error), null, 'errors');
 						}
 					} else {
 						setEventMessages($langs->trans($object->error), null, 'errors');

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -19,6 +19,7 @@
  * Copyright (C) 2019-2022  Frédéric France      <frederic.france@netlogic.fr>
  * Copyright (C) 2019-2020  Thibault FOUCART     <support@ptibogxiv.net>
  * Copyright (C) 2020  		Pierre Ardoin     	 <mapiolca@me.com>
+ * Copyright (C) 2022  		Vincent de Grandpré  <vincent@de-grandpre.quebec>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -666,7 +667,20 @@ if (empty($reshook)) {
 				if (count($object->errors)) {
 					setEventMessages($object->error, $object->errors, 'errors');
 				} else {
-					setEventMessages($langs->trans($object->error), null, 'errors');
+					if($object->error == 'ErrorProductAlreadyExists') {	
+						// permet une action personnallisée quand il y a tentative d'ajouter un produit 
+						// avec un numéro de référence existant.
+						$reshook = $hookmanager->executeHooks('onProductAlreadyExists', $parameters, $object, $action);
+						if ($reshook < 0) {
+							setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+						}							
+						if($object->error) {
+							// L'erreur de l'objet a pu être effacée par la fonction
+							setEventMessages($langs->trans($object->error), null, 'errors');	
+						}
+					} else {
+						setEventMessages($langs->trans($object->error), null, 'errors');
+					}
 				}
 				$action = "create";
 			}

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -674,7 +674,7 @@ if (empty($reshook)) {
 							setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 						}
 						if ($object->error) {
-							// check again to prevent translation issue, 
+							// check again to prevent translation issue,
 							// as error may have been cleared in hook function
 							setEventMessages($langs->trans($object->error), null, 'errors');
 						}


### PR DESCRIPTION
# CLOSE 21748 Maillage sur ErrorProductAlreadyExists en créant produit

Permet à un module de définir une fonction de maillage « onProductAlreadyExists » afin de réagir à cette exception.