### PR TITLE
Work for #21780 Add pid integer column to llx_cronjob

### DIFF
--- a/htdocs/install/mysql/migration/16.0.0-17.0.0.sql
+++ b/htdocs/install/mysql/migration/16.0.0-17.0.0.sql
@@ -84,3 +84,5 @@ ALTER TABLE llx_societe ADD last_main_doc VARCHAR(255) NULL AFTER model_pdf;
 ALTER TABLE llx_ticket ADD COLUMN ip varchar(250);
 
 ALTER TABLE llx_ticket ADD email_date datetime after email_msgid;
+
+ALTER TABLE llx_cronjob ADD COLUMN pid integer;

--- a/htdocs/install/mysql/tables/llx_cronjob.sql
+++ b/htdocs/install/mysql/tables/llx_cronjob.sql
@@ -47,6 +47,7 @@ CREATE TABLE llx_cronjob
     autodelete      integer DEFAULT 0,				-- 0=Job is kept unchanged once nbrun > maxrun or date > dateend, 2=Job must be archived (archive = status 2) once nbrun > maxrun or date > dateend 
   	status 			integer NOT NULL DEFAULT 1,		-- 0=disabled, 1=enabled, 2=archived
   	processing 		integer NOT NULL DEFAULT 0,		-- 1=process currently running
+  	pid             integer,                        -- The cronjob PID, NULL if not in processing
   	test		    varchar(255) DEFAULT '1',
   	fk_user_author 	integer DEFAULT NULL,
   	fk_user_mod 	integer DEFAULT NULL,


### PR DESCRIPTION
# Work for #21780 Add pid integer column to llx_cronjob

Store the PID of the cronjob to allow cleanup if the process is no longer present in the system