### PR TITLE
Work for #21780 Add pid field to Cronjob class and store PID on job execution

### DIFF
--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -718,7 +718,7 @@ class Cronjob extends CommonObject
 		}
 
 		if (empty($this->pid)) {
-			$this->pid = NULL;
+			$this->pid = null;
 		}
 
 		// Check parameters
@@ -939,7 +939,7 @@ class Cronjob extends CommonObject
 		$this->frequency = '';
 		$this->status = 0;
 		$this->processing = 0;
-		$this->pid = NULL;
+		$this->pid = null;
 		$this->fk_user_author = 0;
 		$this->fk_user_mod = 0;
 		$this->note_private = '';
@@ -1332,7 +1332,7 @@ class Cronjob extends CommonObject
 
 		$this->datelastresult = dol_now();
 		$this->processing = 0;
-		$this->pid = NULL;
+		$this->pid = null;
 		$result = $this->update($user); // This include begin/commit
 		if ($result < 0) {
 			dol_syslog(get_class($this)."::run_jobs ".$this->error, LOG_ERR);

--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -138,6 +138,11 @@ class Cronjob extends CommonObject
 	public $processing;
 
 	/**
+	 * @var int The job current PID
+	 */
+	public $pid;
+
+	/**
 	 * @var int ID
 	 */
 	public $fk_user_author;
@@ -422,6 +427,7 @@ class Cronjob extends CommonObject
 		$sql .= " t.frequency,";
 		$sql .= " t.status,";
 		$sql .= " t.processing,";
+		$sql .= " t.pid,";
 		$sql .= " t.fk_user_author,";
 		$sql .= " t.fk_user_mod,";
 		$sql .= " t.note as note_private,";
@@ -470,6 +476,7 @@ class Cronjob extends CommonObject
 				$this->frequency = $obj->frequency;
 				$this->status = $obj->status;
 				$this->processing = $obj->processing;
+				$this->pid = $obj->pid;
 				$this->fk_user_author = $obj->fk_user_author;
 				$this->fk_user_mod = $obj->fk_user_mod;
 				$this->note_private = $obj->note_private;
@@ -530,6 +537,7 @@ class Cronjob extends CommonObject
 		$sql .= " t.frequency,";
 		$sql .= " t.status,";
 		$sql .= " t.processing,";
+		$sql .= " t.pid,";
 		$sql .= " t.fk_user_author,";
 		$sql .= " t.fk_user_mod,";
 		$sql .= " t.note as note_private,";
@@ -606,6 +614,7 @@ class Cronjob extends CommonObject
 					$line->frequency = $obj->frequency;
 					$line->status = $obj->status;
 					$line->processing = $obj->processing;
+					$line->pid = $obj->pid;
 					$line->fk_user_author = $obj->fk_user_author;
 					$line->fk_user_mod = $obj->fk_user_mod;
 					$line->note_private = $obj->note_private;
@@ -708,6 +717,10 @@ class Cronjob extends CommonObject
 			$this->processing = 0;
 		}
 
+		if (empty($this->pid)) {
+			$this->pid = NULL;
+		}
+
 		// Check parameters
 		// Put here code to add a control on parameters values
 		if (dol_strlen($this->datenextrun) == 0) {
@@ -773,6 +786,7 @@ class Cronjob extends CommonObject
 		$sql .= " frequency=".(isset($this->frequency) ? $this->frequency : "null").",";
 		$sql .= " status=".(isset($this->status) ? $this->status : "null").",";
 		$sql .= " processing=".((isset($this->processing) && $this->processing > 0) ? $this->processing : "0").",";
+		$sql .= " pid=".(isset($this->pid) ? $this->pid : "null").",";
 		$sql .= " fk_user_mod=".$user->id.",";
 		$sql .= " note=".(isset($this->note_private) ? "'".$this->db->escape($this->note_private)."'" : "null").",";
 		$sql .= " nbrun=".((isset($this->nbrun) && $this->nbrun > 0) ? $this->nbrun : "null").",";
@@ -925,6 +939,7 @@ class Cronjob extends CommonObject
 		$this->frequency = '';
 		$this->status = 0;
 		$this->processing = 0;
+		$this->pid = NULL;
 		$this->fk_user_author = 0;
 		$this->fk_user_mod = 0;
 		$this->note_private = '';
@@ -1125,6 +1140,7 @@ class Cronjob extends CommonObject
 		$this->lastoutput = '';
 		$this->lastresult = '';
 		$this->processing = 1; // To know job was started
+		$this->pid = dol_getmypid();
 		$this->nbrun = $this->nbrun + 1;
 		$result = $this->update($user); // This include begin/commit
 		if ($result < 0) {
@@ -1316,6 +1332,7 @@ class Cronjob extends CommonObject
 
 		$this->datelastresult = dol_now();
 		$this->processing = 0;
+		$this->pid = NULL;
 		$result = $this->update($user); // This include begin/commit
 		if ($result < 0) {
 			dol_syslog(get_class($this)."::run_jobs ".$this->error, LOG_ERR);


### PR DESCRIPTION
# Work for #21780 Add pid field to Cronjob class and store PID on job execution

Add the new pid column to the Cronjob class internal value and functions

Store the current PID on job execution during run_jobs


I use the CLOSE keyword, but I end up closing the unfinished initial feature request. Should I use another keyword or none ?