### PR TITLE
Membership fixes

### DIFF
--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -612,13 +612,8 @@ if (empty($reshook)) {
 	if ($user->rights->adherent->supprimer && $action == 'confirm_delete' && $confirm == 'yes') {
 		$result = $object->delete($id, $user);
 		if ($result > 0) {
-			if (!empty($backtopage)) {
-				header("Location: ".$backtopage);
-				exit;
-			} else {
-				header("Location: list.php");
-				exit;
-			}
+			header("Location: list.php");
+			exit;
 		} else {
 			setEventMessages($object->error, null, 'errors');
 		}

--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -464,7 +464,7 @@ if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST)) {
 }
 
 // Complete request and execute it with limit
-$sql .= $db->order($sortfield, $sortorder);
+$sql .= $db->order($sortfield, $sortorder, $sortfield == "d.ref");
 if ($limit) {
 	$sql .= $db->plimit($limit + 1, $offset);
 }

--- a/htdocs/core/db/Database.interface.php
+++ b/htdocs/core/db/Database.interface.php
@@ -144,7 +144,7 @@ interface Database
 
 	 * @return  string            String to provide syntax of a sort sql string
 	 */
-	public function order($sortfield = null, $sortorder = null, $isnumeric=false);
+	public function order($sortfield = null, $sortorder = null, $isnumeric = false);
 
 	/**
 	 * Decrypt sensitive data in database

--- a/htdocs/core/db/Database.interface.php
+++ b/htdocs/core/db/Database.interface.php
@@ -140,9 +140,11 @@ interface Database
 	 *
 	 * @param   string $sortfield List of sort fields
 	 * @param   string $sortorder Sort order
+	 * @param   bool $isnumeric Sort order must be interpreted as a numeric value (integer)
+
 	 * @return  string            String to provide syntax of a sort sql string
 	 */
-	public function order($sortfield = null, $sortorder = null);
+	public function order($sortfield = null, $sortorder = null, $isnumeric=false);
 
 	/**
 	 * Decrypt sensitive data in database

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -264,7 +264,7 @@ abstract class DoliDB implements Database
 	 * @param   bool 		$isnumeric 		Sort order must be interpreted as a numeric value (integer)
 	 * @return	string						String to provide syntax of a sort sql string
 	 */
-	public function order($sortfield = null, $sortorder = null, $isnumeric=false)
+	public function order($sortfield = null, $sortorder = null, $isnumeric = false)
 	{
 		if (!empty($sortfield)) {
 			$oldsortorder = '';
@@ -279,9 +279,9 @@ abstract class DoliDB implements Database
 					$return .= ', ';
 				}
 
-				if($isnumeric) $return .= 'CAST(';
+				if ($isnumeric) $return .= 'CAST(';
 				$return .= preg_replace('/[^0-9a-z_\.]/i', '', $val); // Add field
-				if($isnumeric) $return .= ' AS UNSIGNED)';
+				if ($isnumeric) $return .= ' AS UNSIGNED)';
 
 				$tmpsortorder = (empty($orders[$i]) ? '' : trim($orders[$i]));
 

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -261,9 +261,10 @@ abstract class DoliDB implements Database
 	 *
 	 * @param	string		$sortfield		List of sort fields, separated by comma. Example: 't1.fielda,t2.fieldb'
 	 * @param	string		$sortorder		Sort order, separated by comma. Example: 'ASC,DESC'. Note: If the quantity fo sortorder values is lower than sortfield, we used the last value for missing values.
+	 * @param   bool 		$isnumeric 		Sort order must be interpreted as a numeric value (integer)
 	 * @return	string						String to provide syntax of a sort sql string
 	 */
-	public function order($sortfield = null, $sortorder = null)
+	public function order($sortfield = null, $sortorder = null, $isnumeric=false)
 	{
 		if (!empty($sortfield)) {
 			$oldsortorder = '';
@@ -278,7 +279,9 @@ abstract class DoliDB implements Database
 					$return .= ', ';
 				}
 
+				if($isnumeric) $return .= 'CAST(';
 				$return .= preg_replace('/[^0-9a-z_\.]/i', '', $val); // Add field
+				if($isnumeric) $return .= ' AS UNSIGNED)';
 
 				$tmpsortorder = (empty($orders[$i]) ? '' : trim($orders[$i]));
 

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -122,6 +122,12 @@ function dol_time_plus_duree($time, $duration_value, $duration_unit, $ruleforend
 {
 	global $conf;
 
+	if ($ruleforendofmonth == 1 && $duration_unit == 'y') {
+		// Transform 1 year in 12 months to solve leap years problem
+		$duration_value *= 12;
+		$duration_unit = 'm';
+	}
+
 	if ($duration_value == 0) {
 		return $time;
 	}

--- a/htdocs/debugbar/class/TraceableDB.php
+++ b/htdocs/debugbar/class/TraceableDB.php
@@ -201,7 +201,7 @@ class TraceableDB extends DoliDB
 	 * @param   bool   $isnumeric Sort order must be interpreted as a numeric value (integer)
 	 * @return  string            String to provide syntax of a sort sql string
 	 */
-	public function order($sortfield = null, $sortorder = null, $isnumeric=false)
+	public function order($sortfield = null, $sortorder = null, $isnumeric = false)
 	{
 		return $this->db->order($sortfield, $sortorder, $isnumeric);
 	}

--- a/htdocs/debugbar/class/TraceableDB.php
+++ b/htdocs/debugbar/class/TraceableDB.php
@@ -198,11 +198,12 @@ class TraceableDB extends DoliDB
 	 *
 	 * @param   string $sortfield List of sort fields
 	 * @param   string $sortorder Sort order
+	 * @param   bool   $isnumeric Sort order must be interpreted as a numeric value (integer)
 	 * @return  string            String to provide syntax of a sort sql string
 	 */
-	public function order($sortfield = null, $sortorder = null)
+	public function order($sortfield = null, $sortorder = null, $isnumeric=false)
 	{
-		return $this->db->order($sortfield, $sortorder);
+		return $this->db->order($sortfield, $sortorder, $isnumeric);
 	}
 
 	/**

--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -397,7 +397,8 @@ if (empty($reshook) && $action == 'add') {
 				$urlback = $_SERVER["PHP_SELF"]."?action=added&token=".newToken();
 			}
 
-			if (!empty($conf->global->MEMBER_NEWFORM_PAYONLINE) && $conf->global->MEMBER_NEWFORM_PAYONLINE != '-1') {
+			$amount = GETPOST('amount')? GETPOST('amount'):-1;
+			if (!empty($conf->global->MEMBER_NEWFORM_PAYONLINE) && $conf->global->MEMBER_NEWFORM_PAYONLINE != '-1' && $amount>0) {
 				if (empty($conf->global->MEMBER_NEWFORM_EDITAMOUNT)) {			// If edition of amount not allowed
 					// TODO Check amount is same than the amount required for the type of member or if not defined as the defeault amount into $conf->global->MEMBER_NEWFORM_AMOUNT
 					// It is not so important because a test is done on return of payment validation.

--- a/test/phpunit/DateLibTest.php
+++ b/test/phpunit/DateLibTest.php
@@ -456,7 +456,7 @@ class DateLibTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('02/02/1971 00:00', $result);
 
-		// Test the fix for leap years when adding months or years 
+		// Test the fix for leap years when adding months or years
 		$result=dol_print_date(dol_time_plus_duree(dol_time_plus_duree($db->jdate('2024-02-29'), 12, 'm', 1), 2, 'y', 1), 'dayhour', true, $outputlangs);
 		$this->assertEquals('28/02/2027 00:00', $result);
 

--- a/test/phpunit/DateLibTest.php
+++ b/test/phpunit/DateLibTest.php
@@ -456,6 +456,16 @@ class DateLibTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('02/02/1971 00:00', $result);
 
+		// Test the fix for leap years when adding months or years 
+		$result=dol_print_date(dol_time_plus_duree(dol_time_plus_duree($db->jdate('2024-02-29'), 12, 'm', 1), 2, 'y', 1), 'dayhour', true, $outputlangs);
+		$this->assertEquals('28/02/2027 00:00', $result);
+
+		$result=dol_print_date(dol_time_plus_duree(dol_time_plus_duree($db->jdate('2024-02-25'), 12, 'm', 1), 2, 'y', 1), 'dayhour', true, $outputlangs);
+		$this->assertEquals('25/02/2027 00:00', $result);
+
+		$result=dol_print_date(dol_time_plus_duree($db->jdate('2024-02-29'), 4, 'y', 1), 'dayhour', true, $outputlangs);
+		$this->assertEquals('29/02/2028 00:00', $result);
+
 		return $result;
 	}
 


### PR DESCRIPTION
# FIX | Allow sorting non-integer values as numeric values
Allows to sort membership lists by their numerical ID (previously, string sorting applied, so after 1 we got 10)

# FIX | Fix $backtopage after member deletion
Go back to the list of members instead of an invalid card (because deleted)

# FIX | Fixed duration add for leap years + corresponding unit test
Convert 1y to 12m so that the `$ruleforendofmonth` also apply to additions made in years.

# FIX | Skip payment if amount = 0 
Subscriptions with amount = 0 will be recorded as drafts for later validation instead.