### PR TITLE
FIX Date filters are lost when clicking on a title

### DIFF
--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -457,12 +457,8 @@ foreach ($search as $key => $val) {
 				$param .= '&search_'.$key.'[]='.urlencode($skey);
 			}
 		}
-	} elseif (preg_match('/dtstart/', $key) && !empty($val)) {
-		$param .= '&search'.$key.'month='.urlencode(GETPOST('search_'.$key.'month', 'int'));
-		$param .= '&search_'.$key.'day='.urlencode(GETPOST('search_'.$key.'day', 'int'));
-		$param .= '&search_'.$key.'year='.urlencode(GETPOST('search_'.$key.'year', 'int'));
-	} elseif (preg_match('/dtend/', $key) && !empty($val)) {
-		$param .= '&search'.$key.'month='.urlencode(GETPOST('search_'.$key.'month', 'int'));
+	} elseif (preg_match('/(_dtstart|_dtend)$/', $key) && !empty($val)) {
+		$param .= '&search_'.$key.'month='.urlencode(GETPOST('search_'.$key.'month', 'int'));
 		$param .= '&search_'.$key.'day='.urlencode(GETPOST('search_'.$key.'day', 'int'));
 		$param .= '&search_'.$key.'year='.urlencode(GETPOST('search_'.$key.'year', 'int'));
 	} elseif ($search[$key] != '') {

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -458,9 +458,9 @@ foreach ($search as $key => $val) {
 			}
 		}
 	} elseif (preg_match('/(_dtstart|_dtend)$/', $key) && !empty($val)) {
-		$param .= '&search_'.$key.'month='.urlencode(GETPOST('search_'.$key.'month', 'int'));
-		$param .= '&search_'.$key.'day='.urlencode(GETPOST('search_'.$key.'day', 'int'));
-		$param .= '&search_'.$key.'year='.urlencode(GETPOST('search_'.$key.'year', 'int'));
+		$param .= '&search_'.$key.'month='.((int) GETPOST('search_'.$key.'month', 'int'));
+		$param .= '&search_'.$key.'day='.((int) GETPOST('search_'.$key.'day', 'int'));
+		$param .= '&search_'.$key.'year='.((int) GETPOST('search_'.$key.'year', 'int'));
 	} elseif ($search[$key] != '') {
 		$param .= '&search_'.$key.'='.urlencode($search[$key]);
 	}

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -147,13 +147,9 @@ foreach ($object->fields as $key => $val) {
 	if (preg_match('/^(date|timestamp|datetime)/', $val['type'])) {
 		if (empty(GETPOST('search_'.$key.'_dtstart', 'int'))) {
 			$search[$key.'_dtstart'] = dol_mktime(0, 0, 0, GETPOST('search_'.$key.'_dtstartmonth', 'int'), GETPOST('search_'.$key.'_dtstartday', 'int'), GETPOST('search_'.$key.'_dtstartyear', 'int'));
-		} else {
-			$search[$key.'_dtstart'] = GETPOST('search_'.$key.'_dtstart', 'int');
 		}
 		if (empty(GETPOST('search_'.$key.'_dtend', 'int'))) {
 			$search[$key.'_dtend'] = dol_mktime(23, 59, 59, GETPOST('search_'.$key.'_dtendmonth', 'int'), GETPOST('search_'.$key.'_dtendday', 'int'), GETPOST('search_'.$key.'_dtendyear', 'int'));
-		} else {
-			$search[$key.'_dtend'] = GETPOST('search_'.$key.'_dtend', 'int');
 		}
 	}
 }
@@ -465,6 +461,14 @@ foreach ($search as $key => $val) {
 				$param .= '&search_'.$key.'[]='.urlencode($skey);
 			}
 		}
+	} elseif (preg_match('/dtstart/', $key) && !empty($val)) {
+		$param .= '&search'.$key.'month='.urlencode(GETPOST('search_'.$key.'month', 'int'));
+		$param .= '&search_'.$key.'day='.urlencode(GETPOST('search_'.$key.'day', 'int'));
+		$param .= '&search_'.$key.'year='.urlencode(GETPOST('search_'.$key.'year', 'int'));
+	} elseif (preg_match('/dtend/', $key) && !empty($val)) {
+		$param .= '&search'.$key.'month='.urlencode(GETPOST('search_'.$key.'month', 'int'));
+		$param .= '&search_'.$key.'day='.urlencode(GETPOST('search_'.$key.'day', 'int'));
+		$param .= '&search_'.$key.'year='.urlencode(GETPOST('search_'.$key.'year', 'int'));
 	} elseif ($search[$key] != '') {
 		$param .= '&search_'.$key.'='.urlencode($search[$key]);
 	}

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -145,12 +145,8 @@ foreach ($object->fields as $key => $val) {
 		$search[$key] = GETPOST('search_'.$key, 'alpha');
 	}
 	if (preg_match('/^(date|timestamp|datetime)/', $val['type'])) {
-		if (empty(GETPOST('search_'.$key.'_dtstart', 'int'))) {
-			$search[$key.'_dtstart'] = dol_mktime(0, 0, 0, GETPOST('search_'.$key.'_dtstartmonth', 'int'), GETPOST('search_'.$key.'_dtstartday', 'int'), GETPOST('search_'.$key.'_dtstartyear', 'int'));
-		}
-		if (empty(GETPOST('search_'.$key.'_dtend', 'int'))) {
-			$search[$key.'_dtend'] = dol_mktime(23, 59, 59, GETPOST('search_'.$key.'_dtendmonth', 'int'), GETPOST('search_'.$key.'_dtendday', 'int'), GETPOST('search_'.$key.'_dtendyear', 'int'));
-		}
+		$search[$key.'_dtstart'] = dol_mktime(0, 0, 0, GETPOST('search_'.$key.'_dtstartmonth', 'int'), GETPOST('search_'.$key.'_dtstartday', 'int'), GETPOST('search_'.$key.'_dtstartyear', 'int'));
+		$search[$key.'_dtend'] = dol_mktime(23, 59, 59, GETPOST('search_'.$key.'_dtendmonth', 'int'), GETPOST('search_'.$key.'_dtendday', 'int'), GETPOST('search_'.$key.'_dtendyear', 'int'));
 	}
 }
 

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -145,8 +145,16 @@ foreach ($object->fields as $key => $val) {
 		$search[$key] = GETPOST('search_'.$key, 'alpha');
 	}
 	if (preg_match('/^(date|timestamp|datetime)/', $val['type'])) {
-		$search[$key.'_dtstart'] = dol_mktime(0, 0, 0, GETPOST('search_'.$key.'_dtstartmonth', 'int'), GETPOST('search_'.$key.'_dtstartday', 'int'), GETPOST('search_'.$key.'_dtstartyear', 'int'));
-		$search[$key.'_dtend'] = dol_mktime(23, 59, 59, GETPOST('search_'.$key.'_dtendmonth', 'int'), GETPOST('search_'.$key.'_dtendday', 'int'), GETPOST('search_'.$key.'_dtendyear', 'int'));
+		if (empty(GETPOST('search_'.$key.'_dtstart', 'int'))) {
+			$search[$key.'_dtstart'] = dol_mktime(0, 0, 0, GETPOST('search_'.$key.'_dtstartmonth', 'int'), GETPOST('search_'.$key.'_dtstartday', 'int'), GETPOST('search_'.$key.'_dtstartyear', 'int'));
+		} else {
+			$search[$key.'_dtstart'] = GETPOST('search_'.$key.'_dtstart', 'int');
+		}
+		if (empty(GETPOST('search_'.$key.'_dtend', 'int'))) {
+			$search[$key.'_dtend'] = dol_mktime(23, 59, 59, GETPOST('search_'.$key.'_dtendmonth', 'int'), GETPOST('search_'.$key.'_dtendday', 'int'), GETPOST('search_'.$key.'_dtendyear', 'int'));
+		} else {
+			$search[$key.'_dtend'] = GETPOST('search_'.$key.'_dtend', 'int');
+		}
 	}
 }
 


### PR DESCRIPTION
# FIX #[Date filters are lost when clicking on a title in lists]
[When filtering on a date, $param ONLY contains that entire date. I don't know if it's better to fill $param with month, day and year or get the full date (unix time)]
