### PR TITLE
Close Remove trigger ORDER_SUPPLIER_DISPATCH #18486

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ WARNING:
 
 Following changes may create regressions for some external modules, but were necessary to make Dolibarr better:
 * The signature of method getNomUrl() of class ProductFournisseur has been modified to match the signature of method Product
+* Trigger ORDER_SUPPLIER_DISPATCH is removed, use ORDER_SUPPLIER_RECEIVE and/or LINEORDER_SUPPLIER_DISPATCH instead.
 
 
 ***** ChangeLog for 16.0.0 compared to 15.0.0 *****

--- a/htdocs/core/triggers/interface_99_modZapier_ZapierTriggers.class.php
+++ b/htdocs/core/triggers/interface_99_modZapier_ZapierTriggers.class.php
@@ -236,7 +236,7 @@ class InterfaceZapierTriggers extends DolibarrTriggers
 			// case 'ORDER_SUPPLIER_REFUSE':
 			// case 'ORDER_SUPPLIER_CANCEL':
 			// case 'ORDER_SUPPLIER_SENTBYMAIL':
-			// case 'ORDER_SUPPLIER_DISPATCH':
+			// case 'ORDER_SUPPLIER_RECEIVE':
 			// case 'LINEORDER_SUPPLIER_DISPATCH':
 			// case 'LINEORDER_SUPPLIER_CREATE':
 			// case 'LINEORDER_SUPPLIER_UPDATE':

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -373,19 +373,6 @@ if ($action == 'dispatch' && $permissiontoreceive) {
 		}
 	}
 
-	if (!$error) {
-		global $conf, $langs, $user;
-		// Call trigger
-
-		$result = $object->call_trigger('ORDER_SUPPLIER_DISPATCH', $user);
-		// End call triggers
-
-		if ($result < 0) {
-			setEventMessages($object->error, $object->errors, 'errors');
-			$error++;
-		}
-	}
-
 	if ($result >= 0 && !$error) {
 		$db->commit();
 

--- a/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
+++ b/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
@@ -177,7 +177,7 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
 			//case 'ORDER_SUPPLIER_REFUSE':
 			//case 'ORDER_SUPPLIER_CANCEL':
 			//case 'ORDER_SUPPLIER_SENTBYMAIL':
-			//case 'ORDER_SUPPLIER_DISPATCH':
+			//case 'ORDER_SUPPLIER_RECEIVE':
 			//case 'LINEORDER_SUPPLIER_DISPATCH':
 			//case 'LINEORDER_SUPPLIER_CREATE':
 			//case 'LINEORDER_SUPPLIER_UPDATE':


### PR DESCRIPTION
ORDER_SUPPLIER_DISPATCH does same as ORDER_SUPPLIER_RECEIVE called by calcAndSetStatusDispatch. Also triggers should be called from class not from page.