### PR TITLE
NEW : Product supplier price: autofill default supplier VAT

### DIFF
--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -506,6 +506,43 @@ if ($id > 0 || $ref) {
 							print '</a>';
 						}
 					}
+					print '<script type="text/javascript">
+					$(document).ready(function () {
+						$("#search_id_fourn").change(load_vat)
+						console.log("Requesting default VAT rate for the supplier...")
+					});
+					function load_vat() {
+						// get soc id
+						let socid = $("#id_fourn")[0].value
+	
+						// load available VAT rates
+						let vat_url = "'.dol_buildpath('/core/ajax/vatrates.php', 1).'"
+						//Make GET request with params 
+						let options = "";
+						options += "id=" + socid
+						options += "&htmlname=tva_tx"
+						options += "&action=default" // not defined in vatrates.php, default behavior.
+	
+						var get = $.getJSON(
+							vat_url,
+							options,
+							(data) => {
+								rate_options = $.parseHTML(data.value)
+								rate_options.forEach(opt => {
+									if (opt.selected) {
+										replaceVATWithSupplierValue(opt.value)
+										return
+									}
+								})
+							}
+						);
+	
+					}
+					function replaceVATWithSupplierValue(vat_rate) {
+						console.log("Default VAT rate for the supplier: " + vat_rate + "%")
+						$("[name=\'tva_tx\']")[0].value = vat_rate;
+					}
+				</script>';
 				}
 				print '</td></tr>';
 


### PR DESCRIPTION
# NEW Product supplier price: autofill default supplier VAT

On product supplier price creation, when one chooses a supplier, the default VAT rate is not updated.
To reproduce:
- create a supplier with tva_assuj = 0
- navigate to any product, supplier price ( htdocs/product/fournisseurs.php?id=XXX&action=add_price )
- chose the supplier -> the VAT stays to default (20).

This PR adds an AJAX call to update the VAT rate that matches the rules for the supplier.
