### PR TITLE
14.0 fix wrong total in custom category report

### DIFF
--- a/htdocs/accountancy/class/accountancycategory.class.php
+++ b/htdocs/accountancy/class/accountancycategory.class.php
@@ -785,12 +785,13 @@ class AccountancyCategory // extends CommonObject
 	}
 
 	/**
-	 * Return list of custom groups that are active
+	 * Return list of custom groups.
 	 *
 	 * @param	int			$categorytype		-1=All, 0=Only non computed groups, 1=Only computed groups
+	 * @param	int			$active				1= active, 0=not active
 	 * @return	array|int						Array of groups or -1 if error
 	 */
-	public function getCats($categorytype = -1)
+	public function getCats($categorytype = -1, $active = 1)
 	{
 		global $conf, $mysoc;
 
@@ -801,7 +802,7 @@ class AccountancyCategory // extends CommonObject
 
 		$sql = "SELECT c.rowid, c.code, c.label, c.formula, c.position, c.category_type, c.sens";
 		$sql .= " FROM ".MAIN_DB_PREFIX."c_accounting_category as c";
-		$sql .= " WHERE c.active = 1";
+		$sql .= " WHERE c.active = " . (int) $active;
 		$sql .= " AND c.entity = ".$conf->entity;
 		if ($categorytype >= 0) {
 			$sql .= " AND c.category_type = 1";

--- a/htdocs/compta/resultat/result.php
+++ b/htdocs/compta/resultat/result.php
@@ -327,7 +327,7 @@ if ($modecompta == 'CREANCES-DETTES') {
 				$vars = array();
 
 				// Unactive categories have a total of 0 to be used in the formula.
-				foreach($unactive_cats as $un_cat) {
+				foreach ($unactive_cats as $un_cat) {
 					$vars[$un_cat['code']] = 0;
 				}
 

--- a/htdocs/compta/resultat/result.php
+++ b/htdocs/compta/resultat/result.php
@@ -405,6 +405,9 @@ if ($modecompta == 'CREANCES-DETTES') {
 
 				// Set $cpts with array of accounts in the category/group
 				$cpts = $AccCat->getCptsCat($cat['rowid']);
+				// We should loop over empty $cpts array, else the category _code_ is used in the formula, which leads to wrong result if the code is a number.
+				if (empty($cpts)) $cpts[] = array();
+
 
 				$arrayofaccountforfilter = array();
 				foreach ($cpts as $i => $cpt) {    // Loop on each account.
@@ -477,7 +480,7 @@ if ($modecompta == 'CREANCES-DETTES') {
 				// Label of group
 				print '<td>';
 				print dol_escape_htmltag($cat['label']);
-				if (count($cpts) > 0) {    // Show example of 5 first accounting accounts
+				if (count($cpts) > 0 && !empty($cpts[0])) {    // Show example of 5 first accounting accounts
 					$i = 0;
 					foreach ($cpts as $cpt) {
 						if ($i > 5) {

--- a/htdocs/compta/resultat/result.php
+++ b/htdocs/compta/resultat/result.php
@@ -274,6 +274,7 @@ if ($modecompta == 'CREANCES-DETTES') {
 } elseif ($modecompta == "BOOKKEEPING") {
 	// Get array of all report groups that are active
 	$cats = $AccCat->getCats(); // WARNING: Computed groups must be after group they include
+	$unactive_cats = $AccCat->getCats(-1, 0);
 
 	/*
 	$sql = 'SELECT DISTINCT t.numero_compte as nb FROM '.MAIN_DB_PREFIX.'accounting_bookkeeping as t, '.MAIN_DB_PREFIX.'accounting_account as aa';
@@ -324,6 +325,11 @@ if ($modecompta == 'CREANCES-DETTES') {
 				print '</td>';
 
 				$vars = array();
+
+				// Unactive categories have a total of 0 to be used in the formula.
+				foreach($unactive_cats as $un_cat) {
+					$vars[$un_cat['code']] = 0;
+				}
 
 				// Previous Fiscal year (N-1)
 				foreach ($sommes as $code => $det) {


### PR DESCRIPTION
# CLOSE  #22022 Accounting report by personalized groups sometimes have wrong totals.

On some circumstances, the page compta/resultat/result.php displays wrong totals. This happens when the group code is a number and the group is 1. not configured, or 2. not active.



