### PR TITLE
NEW payment default values when supplier order created from reception

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2050,10 +2050,9 @@ if ($action == 'create') {
 				$currency_tx = $objectsrc->multicurrency_tx;
 			}
 		}
-
-		$dateinvoice = empty($conf->global->MAIN_AUTOFILL_DATE) ?-1 : '';
+		
 		$datetmp = dol_mktime(12, 0, 0, GETPOST('remonth', 'int'), GETPOST('reday', 'int'), GETPOST('reyear', 'int'));
-		$dateinvoice = ($datetmp == '' ? (empty($conf->global->MAIN_AUTOFILL_DATE) ?-1 : '') : $datetmp);
+		$dateinvoice = ($datetmp == '' ? (empty($conf->global->MAIN_AUTOFILL_DATE) ? -1 : '') : $datetmp);
 		$datetmp = dol_mktime(12, 0, 0, GETPOST('echmonth', 'int'), GETPOST('echday', 'int'), GETPOST('echyear', 'int'));
 		$datedue = ($datetmp == '' ?-1 : $datetmp);
 

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2050,7 +2050,7 @@ if ($action == 'create') {
 				$currency_tx = $objectsrc->multicurrency_tx;
 			}
 		}
-		
+
 		$datetmp = dol_mktime(12, 0, 0, GETPOST('remonth', 'int'), GETPOST('reday', 'int'), GETPOST('reyear', 'int'));
 		$dateinvoice = ($datetmp == '' ? (empty($conf->global->MAIN_AUTOFILL_DATE) ? -1 : '') : $datetmp);
 		$datetmp = dol_mktime(12, 0, 0, GETPOST('echmonth', 'int'), GETPOST('echday', 'int'), GETPOST('echyear', 'int'));

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -1954,15 +1954,93 @@ if ($action == 'create') {
 
 		$projectid = (!empty($objectsrc->fk_project) ? $objectsrc->fk_project : '');
 		//$ref_client			= (!empty($objectsrc->ref_client)?$object->ref_client:'');
-
 		$soc = $objectsrc->thirdparty;
-		$cond_reglement_id 	= (!empty($objectsrc->cond_reglement_id) ? $objectsrc->cond_reglement_id : (!empty($soc->cond_reglement_supplier_id) ? $soc->cond_reglement_supplier_id : 0)); // TODO maybe add default value option
-		$mode_reglement_id 	= (!empty($objectsrc->mode_reglement_id) ? $objectsrc->mode_reglement_id : (!empty($soc->mode_reglement_supplier_id) ? $soc->mode_reglement_supplier_id : 0));
-		$fk_account         = (!empty($objectsrc->fk_account) ? $objectsrc->fk_account : (!empty($soc->fk_account) ? $soc->fk_account : 0));
-		$remise_percent 	= (!empty($objectsrc->remise_percent) ? $objectsrc->remise_percent : (!empty($soc->remise_supplier_percent) ? $soc->remise_supplier_percent : 0));
-		$remise_absolue 	= (!empty($objectsrc->remise_absolue) ? $objectsrc->remise_absolue : (!empty($soc->remise_absolue) ? $soc->remise_absolue : 0));
-		$dateinvoice = empty($conf->global->MAIN_AUTOFILL_DATE) ?-1 : '';
-		$transport_mode_id = (!empty($objectsrc->transport_mode_id) ? $objectsrc->transport_mode_id : (!empty($soc->transport_mode_id) ? $soc->transport_mode_id : 0));
+
+		$cond_reglement_id = 0;
+		$mode_reglement_id = 0;
+		$fk_account = 0;
+		$remise_percent = 0;
+		$remise_absolue = 0;
+		$transport_mode_id = 0;
+
+		// set from object source
+		if (!empty($objectsrc->cond_reglement_id)) {
+			$cond_reglement_id = $objectsrc->cond_reglement_id;
+		}
+		if (!empty($objectsrc->mode_reglement_id)) {
+			$mode_reglement_id = $objectsrc->mode_reglement_id;
+		}
+		if (!empty($objectsrc->fk_account)) {
+			$fk_account = $objectsrc->fk_account;
+		}
+		if (!empty($objectsrc->remise_percent)) {
+			$remise_percent = $objectsrc->remise_percent;
+		}
+		if (!empty($objectsrc->remise_absolue)) {
+			$remise_absolue = $objectsrc->remise_absolue;
+		}
+		if (!empty($objectsrc->transport_mode_id)) {
+			$transport_mode_id = $objectsrc->transport_mode_id;
+		}
+
+		if (empty($cond_reglement_id)
+			|| empty($mode_reglement_id)
+			|| empty($fk_account)
+			|| empty($remise_percent)
+			|| empty($remise_absolue)
+			|| empty($transport_mode_id)
+		) {
+			if ($origin == 'reception') {
+				// try to get from source of reception (supplier order)
+				if (!isset($objectsrc->supplier_order)) {
+					$objectsrc->fetch_origin();
+				}
+
+				if (!empty($objectsrc->commandeFournisseur)) {
+					$supplierOrder = $objectsrc->commandeFournisseur;
+					if (empty($cond_reglement_id) && !empty($supplierOrder->cond_reglement_id)) {
+						$cond_reglement_id = $supplierOrder->cond_reglement_id;
+					}
+					if (empty($mode_reglement_id) && !empty($supplierOrder->mode_reglement_id)) {
+						$mode_reglement_id = $supplierOrder->mode_reglement_id;
+					}
+					if (empty($fk_account) && !empty($supplierOrder->fk_account)) {
+						$fk_account = $supplierOrder->fk_account;
+					}
+					if (empty($remise_percent) && !empty($supplierOrder->remise_percent)) {
+						$remise_percent = $supplierOrder->remise_percent;
+					}
+					if (empty($remise_absolue) && !empty($supplierOrder->remise_absolue)) {
+						$remise_absolue = $supplierOrder->remise_absolue;
+					}
+					if (empty($transport_mode_id) && !empty($supplierOrder->transport_mode_id)) {
+						$transport_mode_id = $supplierOrder->transport_mode_id;
+					}
+				}
+			}
+
+			// try to get from third-party of source object
+			if (!empty($soc)) {
+				if (empty($cond_reglement_id) && !empty($soc->cond_reglement_supplier_id)) {
+					$cond_reglement_id = $soc->cond_reglement_supplier_id;
+				}
+				if (empty($mode_reglement_id) && !empty($soc->mode_reglement_supplier_id)) {
+					$mode_reglement_id = $soc->mode_reglement_supplier_id;
+				}
+				if (empty($fk_account) && !empty($soc->fk_account)) {
+					$fk_account = $soc->fk_account;
+				}
+				if (empty($remise_percent) && !empty($soc->remise_supplier_percent)) {
+					$remise_percent = $soc->remise_supplier_percent;
+				}
+				if (empty($remise_absolue) && !empty($soc->remise_absolue)) {
+					$remise_absolue = $soc->remise_absolue;
+				}
+				if (empty($transport_mode_id) && !empty($soc->transport_mode_id)) {
+					$transport_mode_id = $soc->transport_mode_id;
+				}
+			}
+		}
 
 		if (isModEnabled("multicurrency")) {
 			if (!empty($objectsrc->multicurrency_code)) {
@@ -1973,6 +2051,7 @@ if ($action == 'create') {
 			}
 		}
 
+		$dateinvoice = empty($conf->global->MAIN_AUTOFILL_DATE) ?-1 : '';
 		$datetmp = dol_mktime(12, 0, 0, GETPOST('remonth', 'int'), GETPOST('reday', 'int'), GETPOST('reyear', 'int'));
 		$dateinvoice = ($datetmp == '' ? (empty($conf->global->MAIN_AUTOFILL_DATE) ?-1 : '') : $datetmp);
 		$datetmp = dol_mktime(12, 0, 0, GETPOST('echmonth', 'int'), GETPOST('echday', 'int'), GETPOST('echyear', 'int'));

--- a/htdocs/reception/list.php
+++ b/htdocs/reception/list.php
@@ -219,15 +219,98 @@ if (empty($reshook)) {
 					}
 				}
 			} else {
+				$cond_reglement_id = 0;
+				$mode_reglement_id = 0;
+				$fk_account = 0;
+				$remise_percent = 0;
+				$remise_absolue = 0;
+				$transport_mode_id = 0;
+				if (!empty($rcp->cond_reglement_id)) {
+					$cond_reglement_id = $rcp->cond_reglement_id;
+				}
+				if (!empty($rcp->mode_reglement_id)) {
+					$mode_reglement_id = $rcp->mode_reglement_id;
+				}
+				if (!empty($rcp->fk_account)) {
+					$fk_account = $rcp->fk_account;
+				}
+				if (!empty($rcp->remise_percent)) {
+					$remise_percent = $rcp->remise_percent;
+				}
+				if (!empty($rcp->remise_absolue)) {
+					$remise_absolue = $rcp->remise_absolue;
+				}
+				if (!empty($rcp->transport_mode_id)) {
+					$transport_mode_id = $rcp->transport_mode_id;
+				}
+
+				if (empty($cond_reglement_id)
+					|| empty($mode_reglement_id)
+					|| empty($fk_account)
+					|| empty($remise_percent)
+					|| empty($remise_absolue)
+					|| empty($transport_mode_id)
+				) {
+					if (!isset($rcp->supplier_order)) {
+						$rcp->fetch_origin();
+					}
+
+					// try to get from source of reception (supplier order)
+					if (!empty($rcp->commandeFournisseur)) {
+						$supplierOrder = $rcp->commandeFournisseur;
+						if (empty($cond_reglement_id) && !empty($supplierOrder->cond_reglement_id)) {
+							$cond_reglement_id = $supplierOrder->cond_reglement_id;
+						}
+						if (empty($mode_reglement_id) && !empty($supplierOrder->mode_reglement_id)) {
+							$mode_reglement_id = $supplierOrder->mode_reglement_id;
+						}
+						if (empty($fk_account) && !empty($supplierOrder->fk_account)) {
+							$fk_account = $supplierOrder->fk_account;
+						}
+						if (empty($remise_percent) && !empty($supplierOrder->remise_percent)) {
+							$remise_percent = $supplierOrder->remise_percent;
+						}
+						if (empty($remise_absolue) && !empty($supplierOrder->remise_absolue)) {
+							$remise_absolue = $supplierOrder->remise_absolue;
+						}
+						if (empty($transport_mode_id) && !empty($supplierOrder->transport_mode_id)) {
+							$transport_mode_id = $supplierOrder->transport_mode_id;
+						}
+					}
+
+					// try get from third-party of reception
+					if (!empty($rcp->thirdparty)) {
+						$soc = $rcp->thirdparty;
+						if (empty($cond_reglement_id) && !empty($soc->cond_reglement_supplier_id)) {
+							$cond_reglement_id = $soc->cond_reglement_supplier_id;
+						}
+						if (empty($mode_reglement_id) && !empty($soc->mode_reglement_supplier_id)) {
+							$mode_reglement_id = $soc->mode_reglement_supplier_id;
+						}
+						if (empty($fk_account) && !empty($soc->fk_account)) {
+							$fk_account = $soc->fk_account;
+						}
+						if (empty($remise_percent) && !empty($soc->remise_supplier_percent)) {
+							$remise_percent = $soc->remise_supplier_percent;
+						}
+						if (empty($remise_absolue) && !empty($soc->remise_absolue)) {
+							$remise_absolue = $soc->remise_absolue;
+						}
+						if (empty($transport_mode_id) && !empty($soc->transport_mode_id)) {
+							$transport_mode_id = $soc->transport_mode_id;
+						}
+					}
+				}
+
 				// If we want one invoice per reception or if there is no first invoice yet for this thirdparty.
 				$objecttmp->socid = $rcp->socid;
 				$objecttmp->type = $objecttmp::TYPE_STANDARD;
-				$objecttmp->cond_reglement_id	= $rcp->cond_reglement_id || $rcp->thirdparty->cond_reglement_supplier_id;
-				$objecttmp->mode_reglement_id	= $rcp->mode_reglement_id || $rcp->thirdparty->mode_reglement_supplier_id;
-
-				$objecttmp->fk_account = !empty($rcp->thirdparty->fk_account) ? $rcp->thirdparty->fk_account : 0;
-				$objecttmp->remise_percent 	= !empty($rcp->thirdparty->remise_percent) ? $rcp->thirdparty->remise_percent : 0;
-				$objecttmp->remise_absolue 	= !empty($rcp->thirdparty->remise_absolue) ? $rcp->thirdparty->remise_absolue : 0;
+				$objecttmp->cond_reglement_id = $cond_reglement_id;
+				$objecttmp->mode_reglement_id = $mode_reglement_id;
+				$objecttmp->fk_account = $fk_account;
+				$objecttmp->remise_percent = $remise_percent;
+				$objecttmp->remise_absolue = $remise_absolue;
+				$objecttmp->transport_mode_id = $transport_mode_id;
 
 				$objecttmp->fk_project			= $rcp->fk_project;
 				//$objecttmp->multicurrency_code = $rcp->multicurrency_code;
@@ -246,6 +329,11 @@ if (empty($reshook)) {
 				$objecttmp->date = $datefacture;
 				$objecttmp->origin    = 'reception';
 				$objecttmp->origin_id = $id_reception;
+
+				// Auto calculation of date due if not filled by user
+				if (empty($objecttmp->date_echeance)) {
+					$objecttmp->date_echeance = $objecttmp->calculate_date_lim_reglement();
+				}
 
 				$objecttmp->array_options = $rcp->array_options; // Copy extrafields
 


### PR DESCRIPTION
NEW payment default values when supplier order created from reception

**Before**
1) Create a supplier order
![image](https://user-images.githubusercontent.com/45359511/188884600-dde3b13c-3797-484b-8a6e-2b61f6f7e796.png)

2) Create a reception from this supplier order
![image](https://user-images.githubusercontent.com/45359511/188884745-e602f337-183d-40f6-b6d6-b9bf19e00781.png)

3) Create a supplier invoice from this reception
![image](https://user-images.githubusercontent.com/45359511/188884912-9f7f3e84-7478-4f05-9887-67914b94dfe6.png)

The payment terms and conditions are not propagated.

**In this feature**
1) Create supplier order from reception card
Elements are propagate when we create a supplier invoice from a reception :
- payment terms and conditions
- bank account id
- percent ans absolute discount
- transport mode id
All theses elements come from supplier order linked to the reception.

For other elements :
- project id
- pulic and private notes
- extra fields
Are set from reception object (source object of supplier order)

2) Create from "create bills" mass action
When we use "create bills" mass action from reception list we also propagate elements like in case 1 (see above).


