### PR TITLE
FIX : ToOfferALinkForOnlinePayment not translated

### DIFF
--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -1265,7 +1265,7 @@ class pdf_sponge extends ModelePDFFactures
 					require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
 					global $langs;
 
-					$langs->loadLangs(array('payment', 'paybox'));
+					$langs->loadLangs(array('payment', 'paybox', 'stripe'));
 					$servicename = $langs->transnoentities('Online');
 					$paiement_url = getOnlinePaymentUrl('', 'invoice', $object->ref, '', '', '');
 					$linktopay = $langs->trans("ToOfferALinkForOnlinePayment", $servicename).' <a href="'.$paiement_url.'">'.$outputlangs->transnoentities("ClickHere").'</a>';


### PR DESCRIPTION
# FIX ToOfferALinkForOnlinePayment not translated
ToOfferALinkForOnlinePayment is defined on stripe.lang

https://www.dolibarr.fr/forum/t/toofferalinkforonlinepayment-sur-les-factures/40327/