### PR TITLE
FIX recruitment linked files

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -2857,6 +2857,10 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		// Wrapping for import module
 		$accessallowed = $user->rights->import->run;
 		$original_file = $conf->import->dir_temp.'/'.$original_file;
+	} elseif ($modulepart == 'recruitment' && !empty($conf->recruitment->dir_output)) {
+		// Wrapping for import module
+		$accessallowed = $user->rights->recruitment->recruitmentjobposition->read;
+		$original_file = $conf->recruitment->dir_output.'/'.$original_file;
 	} elseif ($modulepart == 'editor' && !empty($conf->fckeditor->dir_output)) {
 		// Wrapping for wysiwyg editor
 		$accessallowed = 1;


### PR DESCRIPTION
# FIX|Fix recruitment linked files

Acces is forbidden if you're not admin because rights isnt ->rights->recruitment->read