### PR TITLE
FIX : Display the real_PMP on inventory when its value is equal to 0

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -1086,7 +1086,7 @@ if ($object->id > 0) {
 					print '<td class="right">';
 
 
-					if (! empty($obj->pmp_real) || $obj->pmp_real == 0) $pmp_real = $obj->pmp_real;
+					if (! empty($obj->pmp_real) || (string) $obj->pmp_real === '0') $pmp_real = $obj->pmp_real;
 					else $pmp_real = $product_static->pmp;
 					$pmp_valuation_real = $pmp_real * $qty_view;
 					print '<input type="text" class="maxwidth75 right realpmp'.$obj->fk_product.'" name="realpmp_'.$obj->rowid.'" id="id_'.$obj->rowid.'_input_pmp" value="'.price2num($pmp_real).'">';

--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -1086,7 +1086,7 @@ if ($object->id > 0) {
 					print '<td class="right">';
 
 
-					if (! empty($obj->pmp_real)) $pmp_real = $obj->pmp_real;
+					if ($obj->pmp_real >= 0) $pmp_real = $obj->pmp_real;
 					else $pmp_real = $product_static->pmp;
 					$pmp_valuation_real = $pmp_real * $qty_view;
 					print '<input type="text" class="maxwidth75 right realpmp'.$obj->fk_product.'" name="realpmp_'.$obj->rowid.'" id="id_'.$obj->rowid.'_input_pmp" value="'.price2num($pmp_real).'">';

--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -1086,7 +1086,7 @@ if ($object->id > 0) {
 					print '<td class="right">';
 
 
-					if ($obj->pmp_real >= 0) $pmp_real = $obj->pmp_real;
+					if (! empty($obj->pmp_real) || $obj->pmp_real == 0) $pmp_real = $obj->pmp_real;
 					else $pmp_real = $product_static->pmp;
 					$pmp_valuation_real = $pmp_real * $qty_view;
 					print '<input type="text" class="maxwidth75 right realpmp'.$obj->fk_product.'" name="realpmp_'.$obj->rowid.'" id="id_'.$obj->rowid.'_input_pmp" value="'.price2num($pmp_real).'">';


### PR DESCRIPTION
## FIX : Display the real_PMP on inventory when its value is equal to 0

When we setted the real_PMP to 0 and then save it, the expected_PMP took the real_PMP place.
