### PR TITLE
update php-iban lib to v4.1.1

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -13,7 +13,7 @@ The Dolibarr images resources (available in the doc directory) is distributed un
 
 
 The name Dolibarr is a trademark initially registered by Laurent Destailleur and ceased to the Dolibarr foundation. You can use the name Dolibarr
-for your own need as long as you follow the rules defined on the page https://wiki.dolibarr.org/index.php/Rules_to_use_the_brand_name_%22Dolibarr%22   
+for your own need as long as you follow the rules defined on the page https://wiki.dolibarr.org/index.php/Rules_to_use_the_brand_name_%22Dolibarr%22
 The use of the name DoliStore is also restricted to the same rules defined on https://wiki.dolibarr.org/index.php/Rules_to_use_the_brand_name_%22Dolibarr%22
 
 
@@ -31,11 +31,11 @@ Mobiledetect           2.8.39        MIT License                 Yes            
 NuSoap                 0.9.5         LGPL 2.1+                   Yes             Library to develop SOAP Web services (not into rpm and deb package)
 PEAR Mail_MIME         1.8.9         BSD                         Yes             NuSoap dependency
 ParseDown              1.6           MIT License                 Yes             Markdown parser
-PCLZip                 2.8.4         LGPL-3+                     Yes             Library to zip/unzip files             
+PCLZip                 2.8.4         LGPL-3+                     Yes             Library to zip/unzip files
 PHPDebugBar            1.15.1        MIT License                 Yes             Used only by the module "debugbar" for developers
 PHP-Imap               2.7.2         MIT License                 Yes             Library to use IMAP with OAuth
 PHPSpreadSheet         1.8.2         LGPL-2.1+                   Yes             Read/Write XLS files, read ODS files
-php-iban               4.1           LGPL-3+                     Yes             Parse and validate IBAN (and IIBAN) bank account information in PHP
+php-iban               4.1.1         LGPL-3+                     Yes             Parse and validate IBAN (and IIBAN) bank account information in PHP
 PHPoAuthLib            0.8.2         MIT License                 Yes             Library to provide oauth1 and oauth2 to different service
 PHPPrintIPP            1.3           GPL-2+                      Yes             Library to send print IPP requests
 PSR/Logs               1.0           MIT License                 Yes             Library for logs (used by DebugBar)

--- a/htdocs/includes/php-iban/README.md
+++ b/htdocs/includes/php-iban/README.md
@@ -9,10 +9,6 @@ php-iban
 
 All parts of an IBAN can be retrieved, including country code, checksum, BBAN, financial institution or bank code, account number, and where a fixed-length national system is in use, also branch/sort code. Legacy national checksums may also be retrieved, validated and correctly set, where available, whether they apply to the account number portion, bank and branch identifiers, part or all of the above. IBAN country codes can be converted in to ISO3166-1 alpha-2 and IANA formats, the parent IBAN country acting as registrar for dependent territories may be queried, the official national currency (ISO4217 alpha code format), central bank name and central bank URL may also be queried to ease integration. IBANs may be converted between human and machine representation. IBANs may be obfuscated for presentation to humans in special circumstances such as relative identification. A database of example/test IBANs from different countries is included. Finally, highly accurate suggestions for originally intended input can be made when an incorrect IBAN is detected and is due to mistranscription error.
 
-Tested on PHP versions: ![PHP 5.2](https://img.shields.io/badge/version-PHP%205.2%2B-lightgrey.svg) ![PHP 5.3](https://img.shields.io/badge/version-PHP%205.3%2B-lightgrey.svg) ![PHP 5.4](https://img.shields.io/badge/version-PHP%205.4%2B-lightgrey.svg) ![PHP 5.5](https://img.shields.io/badge/version-PHP%205.5%2B-lightgrey.svg) ![PHP 5.6](https://img.shields.io/badge/version-PHP%205.6%2B-lightgrey.svg) ![PHP 7.0](https://img.shields.io/badge/version-PHP%207.0%2B-lightgrey.svg) ![PHP 7.4](https://img.shields.io/badge/version-PHP%207.4%2B-lightgrey.svg)
-
-Test on HHVM versions: ![HHVM 3.3](https://img.shields.io/badge/version-HHVM%203.3%2B-lightgrey.svg) ![HHVM 3.6](https://img.shields.io/badge/version-HHVM%203.6%2B-lightgrey.svg) ![HHVM 3.9](https://img.shields.io/badge/version-HHVM%203.9%2B-lightgrey.svg) ![HHVM 3.12](https://img.shields.io/badge/version-HHVM%203.12%2B-lightgrey.svg) ![HHVM 3.15](https://img.shields.io/badge/version-HHVM%203.15%2B-lightgrey.svg) ![HHVM 3.18](https://img.shields.io/badge/version-HHVM%203.18%2B-lightgrey.svg)
-
 The parser was built using regular expressions to adapt the contents of the _official_ IBAN registry available from SWIFT then manually modified for special cases such as [errors and omissions in SWIFT's official specifications](https://raw.githubusercontent.com/globalcitizen/php-iban/master/docs/COMEDY-OF-ERRORS).
 
 Various deficiencies in the initial adaptation have since been rectified, and the current version should be a fairly correct and reliable implementation.
@@ -256,14 +252,14 @@ The following table compares __php-iban__ to other PHP projects offering IBAN-re
 
 | Project                                                    | Lic. | Proc | OO  | Began  | Latest | Star | Watch | Fork | Installs | Home culture | Deps    |
 | ---------------------------------------------------------- | ---- | ---- | --- | ------ | ------ | ---- | ----- | ---- | -------- | ------------ | ------- |
-| __php-iban__                                               | LGPL | ✔    | ✔   | 2009   | 4.1.0  | 344  | 26    | 76   | ~2M*    | Global*      | *none*  |
+| __php-iban__                                               | LGPL | ✔    | ✔   | 2009   | 4.1.1  | 414  | 28    | 98   | ~3.5M*   | Global*      | *none*  |
 | [Iban](https://github.com/jschaedl/Iban)                   | MIT  | ✘    | ✔   | 2013   | 1.3.0  | 50   | 9     | 19   | 178.39k  | German       | lots    |
 | [IsoCodes](https://github.com/ronanguilloux/IsoCodes)      | GPL3 | ✘    | ✔   | 2012   | 2.1.1  | 466  | 22    | 54   | 145k     | French       | lots    |
 | [SepaUtil's](https://github.com/AbcAeffchen/SepaUtilities) | GPL3 | ✘    | ✔   | 2014   | 1.2.3  | 8    | 4     | 3    | 25k      | German       | phpunit |
 | [Symfony](https://github.com/symfony/symfony)              | MIT  | ✘    | ✔   | 2013   | 3.3.6  | 15k  | 1214  | 5.6k | 23M+     | French       | lots    |
 
 Notes:
- * Original download records for __php-iban__ releases were hosted on Google Code and are now lost. Prior to establishing a release process on Github, we just expected that people would download the code... so we're really not sure how many installs exist, but this is a fair guess (~11k + composer installs + a little bit now and then).
+ * Original download records for __php-iban__ releases were hosted on Google Code and are now lost. Prior to establishing a release process on Github, we just expected that people would download the code... so we're really not sure how many installs exist, but this is a fair guess (now over 3M composer installs + all prior google code and Github installs).
  * __php-iban__ also powers:
     * [adm-gravity-iban](https://github.com/InternativeNL/adm-gravity-iban)
     * [Azzana consulting's XML Solver for ISO20022](http://www.azzana-consulting.com/xmlsolver/)
@@ -323,6 +319,12 @@ Your Help Wanted
   * __Mauritania__ (MR) has a dual character checksum system but our example IBAN does not match MOD97-10 which would be the expected system. Previously the IBAN here was always fixed to '13' checksum digits, however as of registry v66 it is now dynamic, which suggests a changed or at least now nationally relaxed checksum system.
 
  * If you are willing to spend some time searching, we could do with some more test IBANs for most countries, especially smaller ones...
+
+News: August 2022
+-----------------
+
+__[Version 4.1.1](https://github.com/globalcitizen/php-iban/releases/tag/v4.1.1)__ has been released.
+ * Long-standing bug affecting Belgian pre-IBAN national checksum verification fixed - thanks to [Arne Peirs](https://github.com/Olympic1) for a [very well documented pull request](https://github.com/globalcitizen/php-iban/pull/119).
 
 News: July 2021
 ---------------

--- a/htdocs/includes/php-iban/php-iban.php
+++ b/htdocs/includes/php-iban/php-iban.php
@@ -29,7 +29,7 @@ function verify_iban($iban,$machine_format_only=false) {
  # Check regex
  if(preg_match($regex,$iban)) {
   # Regex passed, check checksum
-  if(!iban_verify_checksum($iban)) {
+  if(!iban_verify_checksum($iban)) { 
    return false;
   }
  }
@@ -56,9 +56,9 @@ function iban_to_machine_format($iban) {
 
 # Convert an IBAN to human format. To do this, we
 # simply insert spaces right now, as per the ECBS
-# (European Committee for Banking Standards)
+# (European Committee for Banking Standards) 
 # recommendations available at:
-# http://www.europeanpaymentscouncil.eu/knowledge_bank_download.cfm?file=ECBS%20standard%20implementation%20guidelines%20SIG203V3.2.pdf
+# http://www.europeanpaymentscouncil.eu/knowledge_bank_download.cfm?file=ECBS%20standard%20implementation%20guidelines%20SIG203V3.2.pdf 
 function iban_to_human_format($iban) {
  # Remove all spaces
  $iban = str_replace(' ','',$iban);
@@ -71,15 +71,15 @@ function iban_to_human_format($iban) {
 # asterisk, except for the final four characters, and then
 # return in human format, ie.
 #  HU69107000246667654851100005 -> HU** **** **** **** **** **** 0005
-#
+# 
 # We avoid the checksum as it may be used to infer the rest
 # of the IBAN in cases where the country has few valid banks
 # and branches, or other information about the account such
 # as bank, branch, or date issued is known (where a sequential
 # issuance scheme is in use).
-#
-# Note that output of this function should be presented with
-# other information to a user, such as the date last used or
+# 
+# Note that output of this function should be presented with 
+# other information to a user, such as the date last used or 
 # the date added to their account, in order to better facilitate
 # unambiguous relative identification.
 function iban_to_obfuscated_format($iban) {
@@ -439,10 +439,10 @@ function iban_country_get_is_eu_member($iban_country) {
 #   - turkish TL/TK thing
 #   - norway NO gets dropped due to mis-identification with "No." for number (ie. if no country code try prepending NO)
 function iban_mistranscription_suggestions($incorrect_iban) {
-
+ 
  # remove funky characters
  $incorrect_iban = iban_to_machine_format($incorrect_iban);
-
+ 
  # abort on ridiculous length input (but be liberal)
  $length = strlen($incorrect_iban);
  if($length<5 || $length>34) { return array('(supplied iban length insane)'); }
@@ -663,7 +663,7 @@ function _iban_nationalchecksum_set($iban,$nationalchecksum) {
  return $fixed_iban;
 }
 
-# Currently unused but may be useful for Norway.
+# Currently unused but may be useful for Norway. 
 # ISO7064 MOD11-2
 # Adapted from https://gist.github.com/andreCatita/5714353 by Andrew Catita
 function _iso7064_mod112_catita($input) {
@@ -678,7 +678,7 @@ function _iso7064_mod112_catita($input) {
  return $result;
 }
 
-# Currently unused but may be useful for Norway.
+# Currently unused but may be useful for Norway. 
 # ISO 7064:1983.MOD 11-2
 # by goseaside@sina.com
 function _iso7064_mod112_goseaside($vString) {
@@ -688,10 +688,10 @@ function _iso7064_mod112_goseaside($vString) {
  $i_size = strlen($vString);
  $bModify = '?' == substr($vString, -1);
  $i_size1 = $bModify ? $i_size : $i_size + 1;
- for ($i = 1; $i <= $i_size; $i++) {
+ for ($i = 1; $i <= $i_size; $i++) { 
   $i1 = $vString[$i - 1] * 1;
   $w1 = $wi[($i_size1 - $i) % 10];
-  $sigma += ($i1 * $w1) % 11;
+  $sigma += ($i1 * $w1) % 11; 
  }
  if($bModify) return str_replace('?', $hash_map[($sigma % 11)], $vString);
  else return $hash_map[($sigma % 11)];
@@ -714,13 +714,13 @@ function _iso7064_mod97_10($str) {
 }
 
 # Implement the national checksum for a Belgium (BE) IBAN
-#  (Credit: @gaetan-be)
+#  (Credit: @gaetan-be, fixed by @Olympic1)
 function _iban_nationalchecksum_implementation_be($iban,$mode) {
  if($mode != 'set' && $mode != 'find' && $mode != 'verify') { return ''; } # blank value on return to distinguish from correct execution
  $nationalchecksum = iban_get_nationalchecksum_part($iban);
- $account = iban_get_account_part($iban);
- $account_less_checksum = substr($account,strlen($account)-2);
- $expected_nationalchecksum = $account_less_checksum % 97;
+ $bban = iban_get_bban_part($iban);
+ $bban_less_checksum = substr($bban, 0, -strlen($nationalchecksum));
+ $expected_nationalchecksum = $bban_less_checksum % 97;
  if($mode=='find') {
   return $expected_nationalchecksum;
  }
@@ -776,8 +776,8 @@ function _iban_nationalchecksum_implementation_es($iban,$mode) {
 function _iban_nationalchecksum_implementation_fr_letters2numbers_helper($bban) {
  $allNumbers = "";
  $conversion = array(
-                     "A" => 1, "B" => 2, "C" => 3, "D" => 4, "E" => 5, "F" => 6, "G" => 7, "H" => 8, "I" => 9,
-                     "J" => 1, "K" => 2, "L" => 3, "M" => 4, "N" => 5, "O" => 6, "P" => 7, "Q" => 8, "R" => 9,
+                     "A" => 1, "B" => 2, "C" => 3, "D" => 4, "E" => 5, "F" => 6, "G" => 7, "H" => 8, "I" => 9, 
+                     "J" => 1, "K" => 2, "L" => 3, "M" => 4, "N" => 5, "O" => 6, "P" => 7, "Q" => 8, "R" => 9, 
                      "S" => 2, "T" => 3, "U" => 4, "V" => 5, "W" => 6, "X" => 7, "Y" => 8, "Z" => 9
                     );
  for ($i=0; $i < strlen($bban); $i++) {
@@ -852,7 +852,7 @@ function _iban_nationalchecksum_implementation_mc($iban,$mode) {
 }
 
 # Implement the national checksum for a France (FR) IBAN
-#  (Credit: @gaetan-be, http://www.credit-card.be/BankAccount/ValidationRules.htm#FR_Validation and
+#  (Credit: @gaetan-be, http://www.credit-card.be/BankAccount/ValidationRules.htm#FR_Validation and 
 #           https://docs.oracle.com/cd/E18727_01/doc.121/e13483/T359831T498954.htm)
 function _iban_nationalchecksum_implementation_fr($iban,$mode) {
  if($mode != 'set' && $mode != 'find' && $mode != 'verify') { return ''; } # blank value on return to distinguish from correct execution
@@ -1100,7 +1100,7 @@ function _iban_nationalchecksum_implementation_pt($iban,$mode) {
 }
 
 # Implement the national checksum for an Serbia (RS) IBAN
-#  (NOTE: Reverse engineered, including bank 'Narodna banka Srbije' (908) exception. For two
+#  (NOTE: Reverse engineered, including bank 'Narodna banka Srbije' (908) exception. For two 
 #         separately published and legitimate looking IBANs from that bank, there appears to
 #         be a +97 offset on the checksum, so we simply ignore all checksums for this bank.)
 function _iban_nationalchecksum_implementation_rs($iban,$mode) {
@@ -1118,7 +1118,7 @@ function _iban_nationalchecksum_implementation_rs($iban,$mode) {
 function _iban_nationalchecksum_implementation_si($iban,$mode) {
  $bank = iban_get_bank_part($iban);
  # Bank of Slovenia does not use the legacy checksum scheme.
- #  Accounts in this namespace appear to be the central bank
+ #  Accounts in this namespace appear to be the central bank 
  #  accounts for licensed local banks.
  if($bank == '01') {
   return '';
@@ -1277,7 +1277,7 @@ function _iban_nationalchecksum_implementation_sm($iban,$mode) {
 
 # Italian (and San Marino's) checksum
 # (Credit: Translated by Francesco Zanoni from http://community.visual-basic.it/lucianob/archive/2004/12/26/2464.aspx)
-# (Source: European Commettee of Banking Standards' Register of European Account Numbers (TR201 V3.23 — FEBRUARY 2007),
+# (Source: European Commettee of Banking Standards' Register of European Account Numbers (TR201 V3.23 — FEBRUARY 2007), 
 #          available at URL http://www.cnb.cz/cs/platebni_styk/iban/download/TR201.pdf)
 function _italian($input)
 {


### PR DESCRIPTION
From php-iban changelog :

Long-standing bug affecting Belgian pre-IBAN national checksum verification fixed - thanks to [Arne Peirs](https://github.com/Olympic1) for a https://github.com/globalcitizen/php-iban/pull/119.