### PR TITLE
this should be cleaned when we click on the eraser

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1408,7 +1408,7 @@ if ($action == 'create') {
 											$deliverableQty = GETPOST($inputName, 'int');
 										}
 
-										print '<input '.$tooltip.' name="qtyl'.$indiceAsked.'_'.$subj.'" id="qtyl'.$indiceAsked.'" type="text" size="4" value="'.$deliverableQty.'">';
+										print '<input '.$tooltip.' class="qtyl" name="qtyl'.$indiceAsked.'_'.$subj.'" id="qtyl'.$indiceAsked.'" type="text" size="4" value="'.$deliverableQty.'">';
 										print '<input name="ent1'.$indiceAsked.'_'.$subj.'" type="hidden" value="'.$warehouse_id.'">';
 									} else {
 										if (!empty($conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS)) {


### PR DESCRIPTION
When we ship an order, there is a neat eraser to reset all quantities. However, it previously missed some of them. This fixes it.
![expeditioncardActionCreate](https://user-images.githubusercontent.com/81741011/191049986-5a19429d-447b-4c07-a3db-27bd55e45af6.png)
