### PR TITLE
FIX #21507 remove ntoe update

### DIFF
--- a/htdocs/don/card.php
+++ b/htdocs/don/card.php
@@ -181,8 +181,6 @@ if (empty($reshook)) {
 			$object->date = $donation_date;
 			$object->public = $public_donation;
 			$object->fk_project = (int) GETPOST("fk_project", 'int');
-			$object->note_private = (string) GETPOST("note_private", 'restricthtml');
-			$object->note_public = (string) GETPOST("note_public", 'restricthtml');
 			$object->modepaymentid = (int) GETPOST('modepayment', 'int');
 
 			// Fill array 'array_options' with data from add form


### PR DESCRIPTION

# FIX|Fix #21507 

we have this on update action
$object->note_private = (string) GETPOST("note_private", 'restricthtml');
$object->note_public = (string) GETPOST("note_public", 'restricthtml');
i think the bug came from this two lines.
there is no sense to update public and private note at this point. the tab note do the job very well
a quik fix is to comment this two lines
