### PR TITLE
FIX #22379 creating events on supplier order

### DIFF
--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -689,6 +689,7 @@ class User extends CommonObject
 			'inventory' => 'stock',
 			'invoice' => 'facture',
 			'invoice_supplier' => 'fournisseur',
+		    	'order_supplier' => 'fournisseur',
 			'knowledgerecord' => 'knowledgerecord@knowledgemanagement',
 			'skill@hrm' => 'all@hrm', // skill / job / position objects rights are for the moment grouped into right level "all"
 			'job@hrm' => 'all@hrm', // skill / job / position objects rights are for the moment grouped into right level "all"

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -689,7 +689,7 @@ class User extends CommonObject
 			'inventory' => 'stock',
 			'invoice' => 'facture',
 			'invoice_supplier' => 'fournisseur',
-		    	'order_supplier' => 'fournisseur',
+			'order_supplier' => 'fournisseur',
 			'knowledgerecord' => 'knowledgerecord@knowledgemanagement',
 			'skill@hrm' => 'all@hrm', // skill / job / position objects rights are for the moment grouped into right level "all"
 			'job@hrm' => 'all@hrm', // skill / job / position objects rights are for the moment grouped into right level "all"


### PR DESCRIPTION
Impossible to create an event on a supplier order.
User class does not provide rights to do it for supplier orders
