### PR TITLE
FIX Accountancy - Some manuals operations are displayed in subledger FPC21+

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -892,6 +892,7 @@ class BookKeeping extends CommonObject
 		// Affichage par compte comptable
 		if (!empty($option)) {
 			$sql .= ' AND t.subledger_account IS NOT NULL';
+			$sql .= ' AND t.subledger_account != ""';
 			$sql .= ' ORDER BY t.subledger_account ASC';
 		} else {
 			$sql .= ' ORDER BY t.numero_compte ASC';

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -891,11 +891,11 @@ class BookKeeping extends CommonObject
 		}
 		// Affichage par compte comptable
 		if (!empty($option)) {
-			$sql .= ' AND t.subledger_account IS NOT NULL';
-			$sql .= ' AND t.subledger_account != ""';
-			$sql .= ' ORDER BY t.subledger_account ASC';
+			$sql .= " AND t.subledger_account IS NOT NULL";
+			$sql .= " AND t.subledger_account != ''";
+			$sql .= " ORDER BY t.subledger_account ASC";
 		} else {
-			$sql .= ' ORDER BY t.numero_compte ASC';
+			$sql .= " ORDER BY t.numero_compte ASC";
 		}
 
 		if (!empty($sortfield)) {


### PR DESCRIPTION
When you add a manual operation in accountancy, subsidiary account can be empty, not only NULL