### PR TITLE
fix: Download Accoutancy file result to Expired Token

### DIFF
--- a/htdocs/compta/accounting-files.php
+++ b/htdocs/compta/accounting-files.php
@@ -614,7 +614,7 @@ if (!empty($date_start) && !empty($date_stop)) {
 
 	echo dol_print_date($date_start, 'day', 'tzuserrel')." - ".dol_print_date($date_stop, 'day', 'tzuserrel');
 
-	print '<a class="marginleftonly small'.(empty($TData) ? ' butActionRefused' : ' butAction').'" href="'.$_SERVER["PHP_SELF"].'?action=dl&token='.newToken().'&output=file&file='.urlencode($filename).$param.'"';
+	print '<a class="marginleftonly small'.(empty($TData) ? ' butActionRefused' : ' butAction').'" href="'.$_SERVER["PHP_SELF"].'?action=dl&token='.currentToken().'&output=file&file='.urlencode($filename).$param.'"';
 	if (empty($TData)) {
 		print " disabled";
 	}


### PR DESCRIPTION
When run a search, there is a token so the "Download" Button that is not a form should get the currentToken and not a newToken to allow action 
![image](https://user-images.githubusercontent.com/1050053/192702603-dc073fb7-7c7a-46da-a437-5f223fc561ed.png)
