### PR TITLE
FIX : Supplier Reference is lost when page breaks

### DIFF
--- a/htdocs/core/modules/supplier_proposal/doc/pdf_aurore.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/pdf_aurore.modules.php
@@ -483,7 +483,7 @@ class pdf_aurore extends ModelePDFSupplierProposal
 						$pageposafter = $pageposbefore;
 						//print $pageposafter.'-'.$pageposbefore;exit;
 						$pdf->setPageOrientation('', 1, $heightforfooter); // The only function to edit the bottom margin of current page to set it.
-						pdf_writelinedesc($pdf, $object, $i, $outputlangs, $descWidth, 3, $curX, $curY, $hideref, $hidedesc);
+						pdf_writelinedesc($pdf, $object, $i, $outputlangs, $descWidth, 3, $curX, $curY, $hideref, $hidedesc, 1);
 
 						$pageposafter = $pdf->getPage();
 						$posyafter = $pdf->GetY();


### PR DESCRIPTION
https://www.dolibarr.org/forum/t/pdf-aurore-modules-php-seems-to-loose-track-of-supplier-references/22856
