### PR TITLE
fix #22478 - Align left the text in column "Accountability account / Compte comptable"

### DIFF
--- a/htdocs/accountancy/expensereport/lines.php
+++ b/htdocs/accountancy/expensereport/lines.php
@@ -417,7 +417,7 @@ if ($result) {
 		print '<td class="center">'.vatrate($objp->tva_tx.($objp->vat_src_code ? ' ('.$objp->vat_src_code.')' : '')).'</td>';
 
 		// Accounting account affected
-		print '<td class="center">';
+		print '<td>';
 		print $accountingaccountstatic->getNomUrl(0, 1, 1, '', 1);
 		print ' <a class="editfielda reposition marginleftonly marginrightonly" href="./card.php?id='.$objp->rowid.'&backtopage='.urlencode($_SERVER["PHP_SELF"].($param ? '?'.$param : '')).'">';
 		print img_edit();


### PR DESCRIPTION
This aligns to the left the text in column "Accountability account / Compte comptable" (instead of having the text centred and harder to read).