### PR TITLE
FIX 16.0 - computed extrafields are not displayed if the object has no classic extrafields

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6031,14 +6031,15 @@ abstract class CommonObject
 							//var_dump('key '.$key.' '.$value.' type='.$extrafields->attributes[$this->table_element]['type'][$key].' '.$this->array_options["options_".$key]);
 						}
 					}
+				}
 
-					// If field is a computed field, value must become result of compute
-					foreach ($tab as $key => $value) {
-						if (!empty($extrafields->attributes[$this->table_element]) && !empty($extrafields->attributes[$this->table_element]['computed'][$key])) {
-							//var_dump($conf->disable_compute);
-							if (empty($conf->disable_compute)) {
-								$this->array_options["options_".$key] = dol_eval($extrafields->attributes[$this->table_element]['computed'][$key], 1, 0, '');
-							}
+				// If field is a computed field, value must become result of compute (regardless of whether a row exists
+				// in the element's extrafields table)
+				foreach ($extrafields->attributes[$this->table_element]['label'] as $key => $val) {
+					if (!empty($extrafields->attributes[$this->table_element]) && !empty($extrafields->attributes[$this->table_element]['computed'][$key])) {
+						//var_dump($conf->disable_compute);
+						if (empty($conf->disable_compute)) {
+							$this->array_options["options_".$key] = dol_eval($extrafields->attributes[$this->table_element]['computed'][$key], 1, 0, '');
 						}
 					}
 				}


### PR DESCRIPTION
# How to reproduce
1. on a vanilla Dolibarr v16, enable module project (for instance)
2. create an extrafield "testcompute", type string (1 line) and put something simple (like `1+1`) in "Computed field".
3. make sure there are no other extrafields (in case your Dolibarr already has some data)
4. create a project
5. **Expected**: the extrafield is shown on the card with the value `2`
6. **Actual**: the extrafield is shown on the card with no value

----

The extrafield definition:
![image](https://user-images.githubusercontent.com/50440633/194542967-6a383836-dea8-4320-a93c-353da441c66e.png)

----

Actual result: no `2`
![image](https://user-images.githubusercontent.com/50440633/194542887-5d8846df-3bf0-4aef-b36a-56860d1c8ac1.png)

# Why
The part that computes the values of the extrafields in `fetch_optionals` is enclosed in a condition that is only true if there is a row in `llx_projet_extrafields` (in our example) for the current project. Since computed extrafields don't insert anything in the database, the row in question cannot exist unless there are other "classic" extrafields.

# This fix
I only moved the loop for computed extrafields outside the `if` in question. The bug might exist in earlier versions but the code is a bit different so I couldn't just backport it (it would have required more effort).