### PR TITLE
FIX #22530 : missing label columun in llx_establishment 

### DIFF
--- a/htdocs/install/mysql/tables/llx_establishment.sql
+++ b/htdocs/install/mysql/tables/llx_establishment.sql
@@ -22,7 +22,8 @@
 CREATE TABLE llx_establishment (
   rowid 			integer NOT NULL auto_increment PRIMARY KEY,
   entity 			integer NOT NULL DEFAULT 1,
-  ref				varchar(30),
+  ref				  varchar(30),
+  label				varchar(128),
   name				varchar(128),
   address           varchar(255),
   zip               varchar(25),


### PR DESCRIPTION
Label has been introduced in V13 : https://github.com/Dolibarr/dolibarr/blob/16.0/htdocs/install/mysql/migration/12.0.0-13.0.0.sql#L86
