### PR TITLE
FIX add short civility

### DIFF
--- a/htdocs/langs/en_US/dict.lang
+++ b/htdocs/langs/en_US/dict.lang
@@ -250,7 +250,9 @@ CountryMF=Saint Martin
 
 ##### Civilities #####
 CivilityMME=Mrs.
+CivilityMMEShort=CivilityMMEShort
 CivilityMR=Mr.
+CivilityMRShort=CivilityMRShort
 CivilityMLE=Ms.
 CivilityMTRE=Master
 CivilityDR=Doctor

--- a/htdocs/langs/en_US/dict.lang
+++ b/htdocs/langs/en_US/dict.lang
@@ -250,9 +250,9 @@ CountryMF=Saint Martin
 
 ##### Civilities #####
 CivilityMME=Mrs.
-CivilityMMEShort=CivilityMMEShort
+CivilityMMEShort=Mrs.
 CivilityMR=Mr.
-CivilityMRShort=CivilityMRShort
+CivilityMRShort=Mr.
 CivilityMLE=Ms.
 CivilityMTRE=Master
 CivilityDR=Doctor


### PR DESCRIPTION


# FIX : add short civility
In some languages, it is used civilityMME and Civility MR with diminutives in French for example one can have Madame et Monsieur and M. aisin que Mme.
this fix deals with this distinction by adding two keys in dict.lang that can be used by the languages ​​concerned.


