### PR TITLE
NEW resize parent company column in order list

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -1466,8 +1466,8 @@ if ($resql) {
 	}
 	// Parent company
 	if (!empty($arrayfields['s2.nom']['checked'])) {
-		print '<td class="liste_titre center">';
-		print '<input class="flat searchstring maxwidth75imp" type="text" name="search_parent_name" value="'.dol_escape_htmltag($search_parent_name).'">';
+		print '<td class="liste_titre">';
+		print '<input class="flat maxwidth100" type="text" name="search_parent_name" value="'.dol_escape_htmltag($search_parent_name).'">';
 		print '</td>';
 	}
 	// Town
@@ -1727,7 +1727,7 @@ if ($resql) {
 		print_liste_field_titre($arrayfields['s.name_alias']['label'], $_SERVER["PHP_SELF"], 's.name_alias', '', $param, '', $sortfield, $sortorder);
 	}
 	if (!empty($arrayfields['s2.nom']['checked'])) {
-		print_liste_field_titre($arrayfields['s2.nom']['label'], $_SERVER['PHP_SELF'], 's2.nom', '', $param, '', $sortfield, $sortorder, 'center ');
+		print_liste_field_titre($arrayfields['s2.nom']['label'], $_SERVER['PHP_SELF'], 's2.nom', '', $param, '', $sortfield, $sortorder);
 	}
 	if (!empty($arrayfields['s.town']['checked'])) {
 		print_liste_field_titre($arrayfields['s.town']['label'], $_SERVER["PHP_SELF"], 's.town', '', $param, '', $sortfield, $sortorder);
@@ -2032,7 +2032,7 @@ if ($resql) {
 
 		// Parent company
 		if (!empty($arrayfields['s2.nom']['checked'])) {
-			print '<td class="center tdoverflowmax100">';
+			print '<td class="tdoverflowmax200">';
 			if ($obj->fk_parent > 0) {
 				if (!isset($company_url_list[$obj->fk_parent])) {
 					$companyparent = new Societe($db);


### PR DESCRIPTION
NEW resize parent company column in order list
- to complete PR #22472 : the size of parent company column was too small
- and the search filter position is now left (before it was center)