### PR TITLE
Fix supplier proposal line edit

### DIFF
--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -186,6 +186,7 @@ $coldisplay++;
 		?>
 		<td class="right"><input id="fourn_ref" name="fourn_ref" class="flat minwidth50 maxwidth150" value="<?php echo ($line->ref_supplier ? $line->ref_supplier : $line->ref_fourn); ?>"></td>
 		<?php
+		print('<input type="hidden" id="fournprice" name="fournprice"  class="" value="'.$line->fk_fournprice.'">');
 	}
 
 	$coldisplay++;

--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -186,7 +186,7 @@ $coldisplay++;
 		?>
 		<td class="right"><input id="fourn_ref" name="fourn_ref" class="flat minwidth50 maxwidth150" value="<?php echo ($line->ref_supplier ? $line->ref_supplier : $line->ref_fourn); ?>"></td>
 		<?php
-		print('<input type="hidden" id="fournprice" name="fournprice"  class="" value="'.$line->fk_fournprice.'">');
+		print '<input type="hidden" id="fournprice" name="fournprice"  class="" value="'.$line->fk_fournprice.'">';
 	}
 
 	$coldisplay++;


### PR DESCRIPTION
# Fix #Supplier proposal line edit

When editing a supplier proposal line, the supplier is not kept on the line.

Original line:
![supplier propal](https://user-images.githubusercontent.com/89838020/195805604-b0da6ed4-ffb5-4e67-a67f-83ae2f76dde0.png)

After quantity modification:
![supplier proposal2](https://user-images.githubusercontent.com/89838020/195805613-d72eea45-33e1-41ee-9781-8cab4f095a95.png)


We add the hidden field "fournprice" so the information is sent when editing line and is used in supplier_proposal/card.php
see supplier_proposal/card.php in $action == 'updateligne'  part
- l.789 : `$fournprice = (GETPOST('fournprice') ? GETPOST('fournprice') : '');`
- l.836:  `			$result = $object->updateline(GETPOST('lineid'), ...$fournprice, ...);`

