### PR TITLE
fix #20304 Inconsistency with propal date and validity date

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -2053,7 +2053,7 @@ class Propal extends CommonObject
 			$this->db->begin();
 
 			$sql = "UPDATE ".MAIN_DB_PREFIX."propal SET fin_validite = ".($date_fin_validite != '' ? "'".$this->db->idate($date_fin_validite)."'" : 'null');
-			$sql .= " WHERE rowid = ".((int) $this->id)." AND fk_statut = ".self::STATUS_DRAFT;
+			$sql .= " WHERE rowid = ".((int) $this->id);
 
 			dol_syslog(__METHOD__, LOG_DEBUG);
 			$resql = $this->db->query($sql);

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1997,7 +1997,7 @@ class Propal extends CommonObject
 			$this->db->begin();
 
 			$sql = "UPDATE ".MAIN_DB_PREFIX."propal SET datep = '".$this->db->idate($date)."'";
-			$sql .= " WHERE rowid = ".((int) $this->id)." AND fk_statut = ".self::STATUS_DRAFT;
+			$sql .= " WHERE rowid = ".((int) $this->id);
 
 			dol_syslog(__METHOD__, LOG_DEBUG);
 			$resql = $this->db->query($sql);


### PR DESCRIPTION
# FIX #20304 Inconsistency with propal date and validity date when STATUS_VALIDATED
Problem concerns this two propal dates :

    date (function Propal::set_date)
    validity date (function Propal::set_echeance)

When propal status is STATUS_VALIDATED, this two dates seems to be editable (on propal card) but can't be changed because of queries in corresponding functions : queries require status to be STATUS_DRAFT.

Suggestion : Update should be possible OR edition (pencil) should be removed.

Done, removed the status draft control. If field is editable should be controlled in card.php

