### PR TITLE
FIX: Missing return 0 if object not found

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4138,6 +4138,12 @@ class OrderLine extends CommonOrderLine
 		$result = $this->db->query($sql);
 		if ($result) {
 			$objp = $this->db->fetch_object($result);
+
+			if (!$objp) {
+				$this->error = 'OrderLine with id '. $rowid .' not found sql='.$sql;
+				return 0;
+			}
+
 			$this->rowid            = $objp->rowid;
 			$this->id = $objp->rowid;
 			$this->fk_commande      = $objp->fk_commande;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5293,6 +5293,11 @@ class FactureLigne extends CommonInvoiceLine
 		if ($result) {
 			$objp = $this->db->fetch_object($result);
 
+			if (!$objp) {
+				$this->error = 'InvoiceLine with id '. $rowid .' not found sql='.$sql;
+				return 0;
+			}
+
 			$this->rowid = $objp->rowid;
 			$this->id = $objp->rowid;
 			$this->fk_facture = $objp->fk_facture;


### PR DESCRIPTION
A return 0 was missing in function fetch for FactureLigne and OrderLine

