### PR TITLE
Fix api product : rang is now position

### DIFF
--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -1014,7 +1014,7 @@ class Products extends DolibarrApi
 			throw new RestException(401);
 		}
 
-		$sql = "SELECT t.rowid, t.ref, t.ref_ext, t.label, t.rang, t.entity";
+		$sql = "SELECT t.rowid, t.ref, t.ref_ext, t.label, t.position, t.entity";
 		$sql .= " FROM ".$this->db->prefix()."product_attribute as t";
 		$sql .= ' WHERE t.entity IN ('.getEntity('product').')';
 
@@ -1051,7 +1051,7 @@ class Products extends DolibarrApi
 			$tmp->ref = $result->ref;
 			$tmp->ref_ext = $result->ref_ext;
 			$tmp->label = $result->label;
-			$tmp->rang = $result->rang;
+			$tmp->position = $result->position;
 			$tmp->entity = $result->entity;
 
 			$return[] = $this->_cleanObjectDatas($tmp);
@@ -1088,7 +1088,7 @@ class Products extends DolibarrApi
 			throw new RestException(404, "Product attribute not found");
 		}
 
-		$fields = ["id", "ref", "ref_ext", "label", "rang", "entity"];
+		$fields = ["id", "ref", "ref_ext", "label", "position", "entity"];
 
 		foreach ($prodattr as $field => $value) {
 			if (!in_array($field, $fields)) {


### PR DESCRIPTION
In this commit https://github.com/Dolibarr/dolibarr/commit/75653395fd127e93e782bdb437c96fd7c491642b, the column "rang" has been renamed in "position". But renaming was forgotten in api_product class