### PR TITLE
Fix : dict data too long error

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -842,7 +842,7 @@ if (GETPOST('actionadd') || GETPOST('actionmodify'))
 			if ($db->errno() == 'DB_ERROR_RECORD_ALREADY_EXISTS') {
 				setEventMessages($langs->transnoentities("ErrorRecordAlreadyExists"), null, 'errors');
 			} else {
-				dol_print_error($db);
+				setEventMessages($db->error(), null, 'errors');
 			}
 		}
 	}


### PR DESCRIPTION
Fix #21624
In any dict, while trying to add an entry, if the "code" was too long, it led to a big error page message. But while trying to update an entry, a clean error message was displayed. Just uniformized the 2