### PR TITLE
Fix undefined property

### DIFF
--- a/htdocs/adherents/type.php
+++ b/htdocs/adherents/type.php
@@ -145,6 +145,7 @@ if ($action == 'add' && $user->rights->adherent->configurer) {
 		$sql = "SELECT libelle FROM ".MAIN_DB_PREFIX."adherent_type WHERE libelle='".$db->escape($object->label)."'";
 		$sql .= " WHERE entity IN (".getEntity('member_type').")";
 		$result = $db->query($sql);
+		$num = null;
 		if ($result) {
 			$num = $db->num_rows($result);
 		}

--- a/htdocs/core/boxes/box_birthdays_members.php
+++ b/htdocs/core/boxes/box_birthdays_members.php
@@ -104,7 +104,6 @@ class box_birthdays_members extends ModeleBoxes
 					$memberstatic->id = $objp->rowid;
 					$memberstatic->firstname = $objp->firstname;
 					$memberstatic->lastname = $objp->lastname;
-					$memberstatic->email = $objp->email;
 					$dateb = $this->db->jdate($objp->birth);
 					$age = date('Y', dol_now()) - date('Y', $dateb);
 


### PR DESCRIPTION
# FIX undefined property stdClass::$email on birthday box
On home screen, the birthday box triggers a warning for undefined property stdClass::$email since this field is not retrieved from DB but yet accessed