### PR TITLE
FIX: check if contact is active before creating associated ticket

### DIFF
--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -207,7 +207,7 @@ if (empty($reshook) && $action == 'create_ticket' && GETPOST('save', 'alpha')) {
 			$object->fk_soc = $searched_companies[0]->id;
 		}
 
-		if (is_array($contacts) and count($contacts) > 0) {
+		if (is_array($contacts) && count($contacts) > 0) {
 			$object->fk_soc = $contacts[$cid]->socid;
 			$usertoassign = $contacts[$cid]->id;
 		}

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -148,9 +148,8 @@ if (empty($reshook) && $action == 'create_ticket' && GETPOST('save', 'alpha')) {
 		// Ensure that contact is active and select first active contact
 		$cid = 0;
 		foreach ($contacts as $key => $contact) {
-			if ($contact->statut !== "1") {
-				$cid = $key + 1;
-			} else {
+			if ((int) $contact->statut == 1) {
+				$cid = $key;
 				break;
 			}
 		}

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -156,7 +156,7 @@ if (empty($reshook) && $action == 'create_ticket' && GETPOST('save', 'alpha')) {
 
 
 		// Option to require email exists to create ticket
-		if (!empty($conf->global->TICKET_EMAIL_MUST_EXISTS) && ($cid <= 0 || empty($contacts[$cid]->socid))) {
+		if (!empty($conf->global->TICKET_EMAIL_MUST_EXISTS) && ($cid < 0 || empty($contacts[$cid]->socid))) {
 			$error++;
 			array_push($object->errors, $langs->trans("ErrorEmailMustExistToCreateTicket"));
 			$action = '';

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -145,8 +145,19 @@ if (empty($reshook) && $action == 'create_ticket' && GETPOST('save', 'alpha')) {
 		// Le premier contact trouvé est utilisé pour déterminer le contact suivi
 		$contacts = $object->searchContactByEmail($origin_email);
 
+		// Ensure that contact is active and select first active contact
+		$cid = 0;
+		foreach ($contacts as $key => $contact) {
+			if ($contact->statut !== "1") {
+				$cid = $key + 1;
+			} else {
+				break;
+			}
+		}
+
+
 		// Option to require email exists to create ticket
-		if (!empty($conf->global->TICKET_EMAIL_MUST_EXISTS) && !$contacts[0]->socid) {
+		if (!empty($conf->global->TICKET_EMAIL_MUST_EXISTS) && !$contacts[$cid]->socid) {
 			$error++;
 			array_push($object->errors, $langs->trans("ErrorEmailMustExistToCreateTicket"));
 			$action = '';
@@ -198,8 +209,8 @@ if (empty($reshook) && $action == 'create_ticket' && GETPOST('save', 'alpha')) {
 		}
 
 		if (is_array($contacts) and count($contacts) > 0) {
-			$object->fk_soc = $contacts[0]->socid;
-			$usertoassign = $contacts[0]->id;
+			$object->fk_soc = $contacts[$cid]->socid;
+			$usertoassign = $contacts[$cid]->id;
 		}
 
 		$ret = $extrafields->setOptionalsFromPost(null, $object);

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -146,7 +146,7 @@ if (empty($reshook) && $action == 'create_ticket' && GETPOST('save', 'alpha')) {
 		$contacts = $object->searchContactByEmail($origin_email);
 
 		// Ensure that contact is active and select first active contact
-		$cid = 0;
+		$cid = -1;
 		foreach ($contacts as $key => $contact) {
 			if ((int) $contact->statut == 1) {
 				$cid = $key;
@@ -156,7 +156,7 @@ if (empty($reshook) && $action == 'create_ticket' && GETPOST('save', 'alpha')) {
 
 
 		// Option to require email exists to create ticket
-		if (!empty($conf->global->TICKET_EMAIL_MUST_EXISTS) && !$contacts[$cid]->socid) {
+		if (!empty($conf->global->TICKET_EMAIL_MUST_EXISTS) && ($cid <= 0 || empty($contacts[$cid]->socid))) {
 			$error++;
 			array_push($object->errors, $langs->trans("ErrorEmailMustExistToCreateTicket"));
 			$action = '';


### PR DESCRIPTION
If we use the public interface to create tickets, we check if the reporter’s email is known from Dolibarr and associate the ticket to the first contact whose email checks out. But we forget to ensure that said contact is currently active in Dolibarr. 
This corrects that.