### PR TITLE
Fix propal page reload : use thirdparty values

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1635,13 +1635,13 @@ if ($action == 'create') {
 	// Terms of payment
 	print '<tr><td class="nowrap">'.$langs->trans('PaymentConditionsShort').'</td><td>';
 	print img_picto('', 'paiment');
-	$form->select_conditions_paiements((GETPOSTISSET('cond_reglement_id') ? GETPOST('cond_reglement_id', 'int') : $soc->cond_reglement_id), 'cond_reglement_id', -1, 1);
+	$form->select_conditions_paiements((GETPOST('cond_reglement_id', 'int') > 0 ? GETPOST('cond_reglement_id', 'int') : $soc->cond_reglement_id), 'cond_reglement_id', -1, 1);
 	print '</td></tr>';
 
 	// Mode of payment
 	print '<tr><td>'.$langs->trans('PaymentMode').'</td><td>';
 	print img_picto('', 'bank').'&ensp;';
-	$form->select_types_paiements((GETPOSTISSET('mode_reglement_id') ? GETPOST('mode_reglement_id', 'int') : $soc->mode_reglement_id), 'mode_reglement_id', 'CRDT', 0, 1, 0, 0, 1, 'maxwidth200 widthcentpercentminusx');
+	$form->select_types_paiements((GETPOST('mode_reglement_id', 'int') > 0 ? GETPOST('mode_reglement_id', 'int') : $soc->mode_reglement_id), 'mode_reglement_id', 'CRDT', 0, 1, 0, 0, 1, 'maxwidth200 widthcentpercentminusx');
 	print '</td></tr>';
 
 	// Bank Account

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1635,13 +1635,13 @@ if ($action == 'create') {
 	// Terms of payment
 	print '<tr><td class="nowrap">'.$langs->trans('PaymentConditionsShort').'</td><td>';
 	print img_picto('', 'paiment');
-	$form->select_conditions_paiements((GETPOST('cond_reglement_id', 'int') > 0 ? GETPOST('cond_reglement_id', 'int') : $soc->cond_reglement_id), 'cond_reglement_id', -1, 1);
+	$form->select_conditions_paiements(((GETPOSTISSET('cond_reglement_id') && GETPOST('cond_reglement_id', 'int') > 0) ? GETPOST('cond_reglement_id', 'int') : $soc->cond_reglement_id), 'cond_reglement_id', -1, 1);
 	print '</td></tr>';
 
 	// Mode of payment
 	print '<tr><td>'.$langs->trans('PaymentMode').'</td><td>';
 	print img_picto('', 'bank').'&ensp;';
-	$form->select_types_paiements((GETPOST('mode_reglement_id', 'int') > 0 ? GETPOST('mode_reglement_id', 'int') : $soc->mode_reglement_id), 'mode_reglement_id', 'CRDT', 0, 1, 0, 0, 1, 'maxwidth200 widthcentpercentminusx');
+	$form->select_types_paiements(((GETPOSTISSET('mode_reglement_id') && GETPOST('mode_reglement_id', 'int') > 0) ? GETPOST('mode_reglement_id', 'int') : $soc->mode_reglement_id), 'mode_reglement_id', 'CRDT', 0, 1, 0, 0, 1, 'maxwidth200 widthcentpercentminusx');
 	print '</td></tr>';
 
 	// Bank Account


### PR DESCRIPTION
# Fix propal page reload : set values for the thirdparty

On a virgin propal creation page, when one sets the thirdparty, the page is reloaded but mode_reglement and cond_reglement are not set to the values configured for the thirdparty.

Step 1 : go to comm/propal/card.php and select a **client thirdparty that has mode_reglement and cond_reglement configured** 

![image](https://user-images.githubusercontent.com/89838020/198532151-d664d732-1511-4858-8df8-77b8ed3d2869.png)

Step 2 : the page is reloaded and these two fields are not set according to the client configuration

![image](https://user-images.githubusercontent.com/89838020/198532565-314d579a-f39b-4961-8de9-f35a2482196c.png)

This PR fixes this behavior.

note : We have the right behavior on supplier_proposal and commande cards.

