### PR TITLE
Fix issue variables whithread and errors

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -81,6 +81,7 @@ class FormTicket
 	public $withtitletopic;
 	public $withtopicreadonly;
 	public $withreadid;
+
 	public $withcompany;  // to show company drop-down list
 	public $withfromsocid;
 	public $withfromcontactid;
@@ -108,6 +109,7 @@ class FormTicket
 	 * @var string Error code (or message)
 	 */
 	public $error;
+	public $errors = array();
 
 
 	/**
@@ -1394,7 +1396,7 @@ class FormTicket
 
 		$result = $formmail->fetchAllEMailTemplate($this->param["models"], $user, $outputlangs);
 		if ($result < 0) {
-			setEventMessage($this->error, 'errors');
+			setEventMessages($this->error, $this->errors, 'errors');
 		}
 		$modelmail_array = array();
 		foreach ($formmail->lines_model as $line) {

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -126,7 +126,7 @@ class FormTicket
 		$this->withcompany = isModEnabled("societe");
 		$this->withfromsocid = 0;
 		$this->withfromcontactid = 0;
-		//$this->withreadid=0;
+		$this->withreadid=0;
 		//$this->withtitletopic='';
 		$this->withnotifytiersatcreate = 0;
 		$this->withusercreate = 1;
@@ -1394,7 +1394,7 @@ class FormTicket
 
 		$result = $formmail->fetchAllEMailTemplate($this->param["models"], $user, $outputlangs);
 		if ($result < 0) {
-			setEventMessages($this->error, $this->errors, 'errors');
+			setEventMessage($this->error, 'errors');
 		}
 		$modelmail_array = array();
 		foreach ($formmail->lines_model as $line) {

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -133,7 +133,7 @@ class FormTicket
 		$this->withnotifytiersatcreate = 0;
 		$this->withusercreate = 1;
 		$this->withcreatereadonly = 1;
-		//$this->withemail = 0;
+		$this->withemail = 0;
 		$this->withref = 0;
 		$this->withextrafields = 0;  // to show extrafields or not
 		//$this->withtopicreadonly=0;

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -133,7 +133,7 @@ class FormTicket
 		$this->withnotifytiersatcreate = 0;
 		$this->withusercreate = 1;
 		$this->withcreatereadonly = 1;
-		$this->withemail = 0;
+		//$this->withemail = 0;
 		$this->withref = 0;
 		$this->withextrafields = 0;  // to show extrafields or not
 		//$this->withtopicreadonly=0;


### PR DESCRIPTION
# FIX|Fix scrutinizer : htdocs/core/class/html.formticket.class.php
variable withread not initialize in construct and function setEventMessages() in place setEventMessage()
**link issue** : https://scrutinizer-ci.com/g/Dolibarr/dolibarr/issues/develop/files/htdocs/core/class/html.formticket.class.php?selectedSeverities%5B0%5D=10&orderField=path&order=asc&honorSelectedPaths=0
