### PR TITLE
Fix issue scrutinizer in htdocs/core/lib/project.lib.php

### DIFF
--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -1124,9 +1124,9 @@ function projectLinesPerAction(&$inc, $parent, $fuser, $lines, &$level, &$projec
 			$projectstatic->ref = $lines[$i]->project_ref;
 			$projectstatic->title = $lines[$i]->project_label;
 			$projectstatic->public = $lines[$i]->public;
-			$projectstatic->status = $lines[$i]->project_status;
+			$projectstatic->status = $lines[$i]->project->status;
 
-			$taskstatic->id = $lines[$i]->task_id;
+			$taskstatic->id = $lines[$i]->fk_statut;
 			$taskstatic->ref = ($lines[$i]->task_ref ? $lines[$i]->task_ref : $lines[$i]->task_id);
 			$taskstatic->label = $lines[$i]->task_label;
 			$taskstatic->date_start = $lines[$i]->date_start;


### PR DESCRIPTION


# FIX|Fix issue scrutinizer The property project_status and task_id
change property project_status to project->status and task_id to fk_statut
link to issue : https://scrutinizer-ci.com/g/Dolibarr/dolibarr/issues/develop/files/htdocs/core/lib/project.lib.php?selectedSeverities%5B0%5D=10&orderField=path&order=asc&fileId=htdocs/core/lib/product.lib.php&honorSelectedPaths=0