### PR TITLE
Fix supplier proposal clone : when a line subprice is empty, it should be saved as 0 in the Database, not null.

### DIFF
--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -3035,7 +3035,7 @@ class SupplierProposalLine extends CommonObjectLine
 		$sql .= " ".price2num($this->localtax2_tx).",";
 		$sql .= " '".$this->db->escape($this->localtax1_type)."',";
 		$sql .= " '".$this->db->escape($this->localtax2_type)."',";
-		$sql .= " ".(!empty($this->subprice) ?price2num($this->subprice) : "null").",";
+		$sql .= " ".(!empty($this->subprice) ?price2num($this->subprice) : 0).",";
 		$sql .= " ".price2num($this->remise_percent).",";
 		$sql .= " ".(isset($this->info_bits) ? "'".$this->db->escape($this->info_bits)."'" : "null").",";
 		$sql .= " ".price2num($this->total_ht).",";


### PR DESCRIPTION
# FIX When cloning a supplier proposal with prices set to 0, the next command created does not have the lines where subprice = 0

## Situation

We are creating supplier proposals with subprice = 0.000...
When cloning a proposal, the new subprices are saved as 'null' in the database, and not '0'. This does not cause any problem on the proposal itself. Cloned proposal:
![image](https://user-images.githubusercontent.com/89838020/201144943-8157dcaa-b5d0-4416-9695-272850fa07d0.png)

After accepting the new proposal, we create a supplier order. All lines appear in the creation form.

![image](https://user-images.githubusercontent.com/89838020/201145747-a6bebdf3-3ac7-48c1-95d1-5fde50430c6d.png)

**BUG** : in the new order, the lines where subprice is null do not appear.

![image](https://user-images.githubusercontent.com/89838020/201146045-50a1fd5a-b405-48b2-9c73-2ada8721ddba.png)

## Solution
Save the subprices as 0 in DB instead of null when adding a line.

