### PR TITLE
FIX: GetNextValue() adding regexsql() function

### DIFF
--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -79,6 +79,25 @@ abstract class DoliDB implements Database
 	{
 		return 'IF('.$test.','.$resok.','.$resko.')';
 	}
+    
+    
+    /**
+	 *	Format a SQL REGEXP
+	 *
+	 *	@param	string	$subject        string tested
+	 *	@param	string	$pattern        SQL pattern to match 
+	 *	@param	string	$sqlstring      whether or not the string being tested is an SQL expression
+	 *	@return	string          		SQL string
+	 */
+	public function regexpsql($subject, $pattern, $sqlstring = false)
+	{
+        if ($sqlstring) {
+            return "(". $subject ." REGEXP '" . $pattern . "')";
+        }
+        
+        return "('". $subject ."' REGEXP '" . $pattern . "')";
+	}
+
 
 	/**
 	 *   Convert (by PHP) a GM Timestamp date into a string date with PHP server TZ to insert into a date field.

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -79,23 +79,23 @@ abstract class DoliDB implements Database
 	{
 		return 'IF('.$test.','.$resok.','.$resko.')';
 	}
-    
-    
-    /**
+
+
+	/**
 	 *	Format a SQL REGEXP
 	 *
 	 *	@param	string	$subject        string tested
-	 *	@param	string	$pattern        SQL pattern to match 
+	 *	@param	string  $pattern        SQL pattern to match
 	 *	@param	string	$sqlstring      whether or not the string being tested is an SQL expression
 	 *	@return	string          		SQL string
 	 */
 	public function regexpsql($subject, $pattern, $sqlstring = false)
 	{
-        if ($sqlstring) {
-            return "(". $subject ." REGEXP '" . $pattern . "')";
-        }
-        
-        return "('". $subject ."' REGEXP '" . $pattern . "')";
+		if ($sqlstring) {
+			return "(". $subject ." REGEXP '" . $pattern . "')";
+		}
+
+		return "('". $subject ."' REGEXP '" . $pattern . "')";
 	}
 
 

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -724,24 +724,24 @@ class DoliDBPgsql extends DoliDB
 		return '(CASE WHEN '.$test.' THEN '.$resok.' ELSE '.$resko.' END)';
 	}
 
-    /**
+	/**
 	 *	Format a SQL REGEXP
 	 *
 	 *	@param	string	$subject        string tested
-	 *	@param	string	$pattern        SQL pattern to match 
+	 *	@param	string  $pattern        SQL pattern to match
 	 *	@param	string	$sqlstring      whether or not the string being tested is an SQL expression
 	 *	@return	string          		SQL string
 	 */
 	public function regexpsql($subject, $pattern, $sqlstring = false)
 	{
-        if ($sqlstring) {
-            return "(". $subject ." ~ '" . $pattern . "')";
-        }
-        
-        return "('". $subject ."' ~ '" . $pattern . "')";
+		if ($sqlstring) {
+			return "(". $subject ." ~ '" . $pattern . "')";
+		}
+
+		return "('". $subject ."' ~ '" . $pattern . "')";
 	}
 
-    
+
 	/**
 	 * Renvoie le code erreur generique de l'operation precedente.
 	 *

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -724,6 +724,24 @@ class DoliDBPgsql extends DoliDB
 		return '(CASE WHEN '.$test.' THEN '.$resok.' ELSE '.$resko.' END)';
 	}
 
+    /**
+	 *	Format a SQL REGEXP
+	 *
+	 *	@param	string	$subject        string tested
+	 *	@param	string	$pattern        SQL pattern to match 
+	 *	@param	string	$sqlstring      whether or not the string being tested is an SQL expression
+	 *	@return	string          		SQL string
+	 */
+	public function regexpsql($subject, $pattern, $sqlstring = false)
+	{
+        if ($sqlstring) {
+            return "(". $subject ." ~ '" . $pattern . "')";
+        }
+        
+        return "('". $subject ."' ~ '" . $pattern . "')";
+	}
+
+    
 	/**
 	 * Renvoie le code erreur generique de l'operation precedente.
 	 *

--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1282,11 +1282,11 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 	$sql .= " FROM ".MAIN_DB_PREFIX.$table;
 	$sql .= " WHERE ".$field." LIKE '".$db->escape($maskLike)."'";
 	$sql .= " AND ".$field." NOT LIKE '(PROV%)'";
-    
-    // To ensure that all variables within the MAX() brackets are integers
-  	$sql .= " AND ". $db->regexpsql($sqlstring, '^[0-9]+$', true);
 
-    
+	// To ensure that all variables within the MAX() brackets are integers
+	$sql .= " AND ". $db->regexpsql($sqlstring, '^[0-9]+$', true);
+
+
 	if ($bentityon) { // only if entity enable
 		$sql .= " AND entity IN (".getEntity($sharetable).")";
 	} elseif (!empty($forceentity)) {
@@ -1298,7 +1298,7 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 	if ($sqlwhere) {
 		$sql .= ' AND '.$sqlwhere;
 	}
-    
+
 	//print $sql.'<br>';
 	dol_syslog("functions2::get_next_value mode=".$mode."", LOG_DEBUG);
 	$resql = $db->query($sql);

--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1282,6 +1282,11 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 	$sql .= " FROM ".MAIN_DB_PREFIX.$table;
 	$sql .= " WHERE ".$field." LIKE '".$db->escape($maskLike)."'";
 	$sql .= " AND ".$field." NOT LIKE '(PROV%)'";
+    
+    // To ensure that all variables within the MAX() brackets are integers
+  	$sql .= " AND ". $db->regexpsql($sqlstring, '^[0-9]+$', true);
+
+    
 	if ($bentityon) { // only if entity enable
 		$sql .= " AND entity IN (".getEntity($sharetable).")";
 	} elseif (!empty($forceentity)) {
@@ -1293,7 +1298,7 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 	if ($sqlwhere) {
 		$sql .= ' AND '.$sqlwhere;
 	}
-
+    
 	//print $sql.'<br>';
 	dol_syslog("functions2::get_next_value mode=".$mode."", LOG_DEBUG);
 	$resql = $db->query($sql);


### PR DESCRIPTION
[Related To #21533](https://github.com/Dolibarr/dolibarr/pull/21533/files)

I realized that "CAST %s AS INTEGER" can't be used in postgre because in case of non integer value it will raise an error
I decide to implements the sql function REGEXP to be more more general.