### PR TITLE
NEW Invoice - Force display idprof1 (SIREN) if it's not empty (Mandatory for professionals) and if receiver is french

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -641,7 +641,11 @@ function pdf_build_address($outputlangs, $sourcecompany, $targetcompany = '', $t
 			}
 
 			// Professionnal Ids
-			if (!empty($conf->global->MAIN_PROFID1_IN_ADDRESS) && !empty($targetcompany->idprof1)) {
+
+			// Force display idprof1 (SIREN) if it's not empty (Mandatory for professionals) and if receiver is french
+			// Decret n°2099-1299 2022-10-07
+			if (($targetcompany->country_code == 'FR' && !empty($targetcompany->idprof1))
+				|| (!empty($conf->global->MAIN_PROFID1_IN_ADDRESS) && !empty($targetcompany->idprof1))) {
 				$tmp = $outputlangs->transcountrynoentities("ProfId1", $targetcompany->country_code);
 				if (preg_match('/\((.+)\)/', $tmp, $reg)) {
 					$tmp = $reg[1];


### PR DESCRIPTION
In English : Since the decree n°2099-1299 of 2022/10/07 in France applicable from 2022/10/10 concerning the electronic invoicing 2024, the compulsory mentions evolve. The SIREN number (idprof1 in France) of the customer is now a mandatory mention on the invoices. This identification number is only mandatory if you are dealing with a professional (B2B). Note: It is possible to display the SIRET number (idprof2 in France) instead of the SIREN number if you have the latter. The display of the SIREN number was previously optional and could be applied via the constant MAIN_PROFID1_IN_ADDRESS. 

In french : Depuis le décret n°2099-1299 du 07/10/2022 en France applicable à partir du 10/10/2022 relatif à la facturation électronique 2024, les mentions obligatoires évoluent. Le numéro SIREN du client est désormais une mention obligatoire sur les factures. Ce numéro d'identification est obligatoire uniquement si vous traitez avec un professionnel (B2B). Précision : Il est possible d'afficher le numéro SIRET à la place d'un numéro SIREN si vous êtes en possession de ce dernier. L'affichage du numéro SIREN était facultatif auparavant et pouvait être appliqué via la constante MAIN_PROFID1_IN_ADDRESS. 

![image](https://user-images.githubusercontent.com/2341395/201461678-c8c9db84-013e-4058-b38a-7b526841995e.png)

![image](https://user-images.githubusercontent.com/2341395/201461578-d4a5043a-ce83-4dc3-a75b-25deac9f06d4.png)
