### PR TITLE
FIx #18304 No adh create if error on public form

### DIFF
--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -279,7 +279,10 @@ if ($action == 'add')
         $ret = $extrafields->setOptionalsFromPost(null, $adh);
 		if ($ret < 0) $error++;
 
-        $result = $adh->create($user);
+        if (empty($error)) {
+			$result = $adh->create($user);
+		}
+		
         if ($result > 0)
         {
 			require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';

--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -282,7 +282,7 @@ if ($action == 'add')
         if (empty($error)) {
 			$result = $adh->create($user);
 		}
-		
+
         if ($result > 0)
         {
 			require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';


### PR DESCRIPTION
FIX #18304 - Member subscription confirmation email sent even if mandatory fields are missing
