### PR TITLE
Fix uninitialized var in oauth

### DIFF
--- a/htdocs/admin/oauth.php
+++ b/htdocs/admin/oauth.php
@@ -210,7 +210,7 @@ print dol_get_fiche_end();
 
 print '</form>';
 
-
+$listinsetup = [];
 // Define $listinsetup
 foreach ($conf->global as $key => $val) {
 	if (!empty($val) && preg_match('/^OAUTH_.*_ID$/', $key)) {


### PR DESCRIPTION
# FIX|Fix uninitialized var in oauth

```
[php:error] [pid 9969] [client 172.18.0.2:60266] PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /var/www/html/admin/oauth.php:153\nStack trace:\n#0 {main}\n  thrown in /var/www/html/admin/oauth.php on line 153, referer: https://erp.hype-assets.eu/admin/oauthlogintokens.php
```