### PR TITLE
fix: always display security warning on home page

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -116,22 +116,20 @@ if (!empty($lockfile) && !file_exists($lockfile) && is_dir(DOL_DOCUMENT_ROOT."/i
 	$message .= info_admin($langs->trans("WarningLockFileDoesNotExists", DOL_DATA_ROOT).' '.$langs->trans("WarningUntilDirRemoved", DOL_DOCUMENT_ROOT."/install"), 0, 0, '1', 'clearboth');
 }
 
-// Security warning repertoire install existe (si utilisateur admin)
-if ($user->admin && empty($conf->global->MAIN_REMOVE_INSTALL_WARNING)) {
-	// Conf files must be in read only mode
-	if (is_writable($conffile)) {
-		$langs->load("errors");
-		//$langs->load("other");
-		//if (! empty($message)) $message.='<br>';
-		$message .= info_admin($langs->transnoentities("WarningConfFileMustBeReadOnly").' '.$langs->trans("WarningUntilDirRemoved", DOL_DOCUMENT_ROOT."/install"), 0, 0, '1', 'clearboth');
-	}
-
-	if ($message) {
-		print $message;
-		//$message.='<br>';
-		//print info_admin($langs->trans("WarningUntilDirRemoved",DOL_DOCUMENT_ROOT."/install"));
-	}
+// Conf files must be in read only mode
+if (is_writable($conffile)) {
+	$langs->load("errors");
+	//$langs->load("other");
+	//if (! empty($message)) $message.='<br>';
+	$message .= info_admin($langs->transnoentities("WarningConfFileMustBeReadOnly").' '.$langs->trans("WarningUntilDirRemoved", DOL_DOCUMENT_ROOT."/install"), 0, 0, '1', 'clearboth');
 }
+
+if ($message) {
+	print $message;
+	//$message.='<br>';
+	//print info_admin($langs->trans("WarningUntilDirRemoved",DOL_DOCUMENT_ROOT."/install"));
+}
+
 
 /*
  * Dashboard Dolibarr states (statistics)

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -106,18 +106,18 @@ if (!empty($conf->global->MAIN_MOTD)) {
  * Show security warnings
  */
 
+$message = '';
+
+// Check if install lock file is present
+$lockfile = DOL_DATA_ROOT.'/install.lock';
+if (!empty($lockfile) && !file_exists($lockfile) && is_dir(DOL_DOCUMENT_ROOT."/install")) {
+	$langs->load("errors");
+	//if (! empty($message)) $message.='<br>';
+	$message .= info_admin($langs->trans("WarningLockFileDoesNotExists", DOL_DATA_ROOT).' '.$langs->trans("WarningUntilDirRemoved", DOL_DOCUMENT_ROOT."/install"), 0, 0, '1', 'clearboth');
+}
+
 // Security warning repertoire install existe (si utilisateur admin)
 if ($user->admin && empty($conf->global->MAIN_REMOVE_INSTALL_WARNING)) {
-	$message = '';
-
-	// Check if install lock file is present
-	$lockfile = DOL_DATA_ROOT.'/install.lock';
-	if (!empty($lockfile) && !file_exists($lockfile) && is_dir(DOL_DOCUMENT_ROOT."/install")) {
-		$langs->load("errors");
-		//if (! empty($message)) $message.='<br>';
-		$message .= info_admin($langs->trans("WarningLockFileDoesNotExists", DOL_DATA_ROOT).' '.$langs->trans("WarningUntilDirRemoved", DOL_DOCUMENT_ROOT."/install"), 0, 0, '1', 'clearboth');
-	}
-
 	// Conf files must be in read only mode
 	if (is_writable($conffile)) {
 		$langs->load("errors");


### PR DESCRIPTION
For all user and admin MAIN_REMOVE_INSTALL_WARNING shouldn't exists. We are no more in CareBear world

Bad Dolibarr installation should always trigger a warning