### PR TITLE
Fix(Scrutinizer) add public

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -54,6 +54,11 @@ class Propal extends CommonObject
 	use CommonIncoterm;
 
 	/**
+	 * @var string code
+	 */
+	public $code = "";
+
+	/**
 	 * @var string ID to identify managed object
 	 */
 	public $element = 'propal';

--- a/htdocs/core/class/commonorder.class.php
+++ b/htdocs/core/class/commonorder.class.php
@@ -31,6 +31,11 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/commonincoterm.class.php';
 abstract class CommonOrder extends CommonObject
 {
 	use CommonIncoterm;
+
+	/**
+	 * @var string code
+	 */
+	public $code = "";
 }
 
 /**

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -51,6 +51,11 @@ class Reception extends CommonObject
 	use CommonIncoterm;
 
 	/**
+	 * @var string code
+	 */
+	public $code = "";
+
+	/**
 	 * @var string element name
 	 */
 	public $element = "reception";


### PR DESCRIPTION
# FIX|Fix #[scrutinizer]
Added $code to resolve errors of type :
The trait CommonIncoterm requires the property $code which is not provided by Reception.