### PR TITLE
FIX : Time Difference on events

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -1494,19 +1494,19 @@ if ($id > 0) {
 		print '</td><td td colspan="3">';
 		//print '<tr><td class="nowrap"><span class="fieldrequired">'.$langs->trans("DateActionStart").' - '.$langs->trans("DateActionEnd").'</span></td><td colspan="3">';
 		if (GETPOST("afaire") == 1) {
-			print $form->selectDate($datep ? $datep : $object->datep, 'ap', 1, 1, 0, "action", 1, 1, 0, 'fulldaystart', '', '', '', 1, '', '', 'tzuser');
+			print $form->selectDate($datep ? $datep : $object->datep, 'ap', 1, 1, 0, "action", 1, 1, 0, 'fulldaystart');
 		} elseif (GETPOST("afaire") == 2) {
-			print $form->selectDate($datep ? $datep : $object->datep, 'ap', 1, 1, 1, "action", 1, 1, 0, 'fulldaystart', '', '', '', 1, '', '', 'tzuser');
+			print $form->selectDate($datep ? $datep : $object->datep, 'ap', 1, 1, 1, "action", 1, 1, 0, 'fulldaystart');
 		} else {
-			print $form->selectDate($datep ? $datep : $object->datep, 'ap', 1, 1, 1, "action", 1, 1, 0, 'fulldaystart', '', '', '', 1, '', '', 'tzuser');
+			print $form->selectDate($datep ? $datep : $object->datep, 'ap', 1, 1, 1, "action", 1, 1, 0, 'fulldaystart');
 		}
 		print ' - ';
 		if (GETPOST("afaire") == 1) {
-			print $form->selectDate($datef ? $datef : $object->datef, 'p2', 1, 1, 1, "action", 1, 1, 0, 'fulldayend', '', '', '', 1, '', '', 'tzuser');
+			print $form->selectDate($datef ? $datef : $object->datef, 'p2', 1, 1, 1, "action", 1, 1, 0, 'fulldayend');
 		} elseif (GETPOST("afaire") == 2) {
-			print $form->selectDate($datef ? $datef : $object->datef, 'p2', 1, 1, 1, "action", 1, 1, 0, 'fulldayend', '', '', '', 1, '', '', 'tzuser');
+			print $form->selectDate($datef ? $datef : $object->datef, 'p2', 1, 1, 1, "action", 1, 1, 0, 'fulldayend');
 		} else {
-			print $form->selectDate($datef ? $datef : $object->datef, 'p2', 1, 1, 1, "action", 1, 1, 0, 'fulldayend', '', '', '', 1, '', '', 'tzuser');
+			print $form->selectDate($datef ? $datef : $object->datef, 'p2', 1, 1, 1, "action", 1, 1, 0, 'fulldayend');
 		}
 		print '</td></tr>';
 
@@ -1941,9 +1941,9 @@ if ($id > 0) {
 		// Date start
 		print '<tr><td>'.$langs->trans("DateActionStart").'</td><td>';
 		if (!$object->fulldayevent) {
-			print dol_print_date($object->datep, 'dayhour', 'tzuser');
+			print dol_print_date($object->datep, 'dayhour');
 		} else {
-			print dol_print_date($object->datep, 'day', 'tzuser');
+			print dol_print_date($object->datep, 'day');
 		}
 		if ($object->percentage == 0 && $object->datep && $object->datep < ($now - $delay_warning)) {
 			print img_warning($langs->trans("Late"));
@@ -1954,9 +1954,9 @@ if ($id > 0) {
 		// Date end
 		print '<tr><td>'.$langs->trans("DateActionEnd").'</td><td>';
 		if (!$object->fulldayevent) {
-			print dol_print_date($object->datef, 'dayhour', 'tzuser');
+			print dol_print_date($object->datef, 'dayhour');
 		} else {
-			print dol_print_date($object->datef, 'day', 'tzuser');
+			print dol_print_date($object->datef, 'day');
 		}
 		if ($object->percentage > 0 && $object->percentage < 100 && $object->datef && $object->datef < ($now - $delay_warning)) {
 			print img_warning($langs->trans("Late"));


### PR DESCRIPTION
# FIX

Décalage d'horaires entre la fiche événement et la liste d’événements sur l'onglet événement du tiers
Un des paramètres ("tzuser") de la fonction selectDate et dol_print_date décalait l'horaire de -1 h.