### PR TITLE
Fix API right check

### DIFF
--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -1048,7 +1048,7 @@ class Thirdparties extends DolibarrApi
     {
 		global $db, $conf;
 
-		if (!DolibarrApiAccess::$user->rights->facture->lire) {
+		if (!DolibarrApiAccess::$user->rights->societe->lire) {
 			throw new RestException(401);
 		}
 		if (empty($id)) {


### PR DESCRIPTION
The GET bankaccount API in the api_thirdparties was checking the user right on the "facture" module instead of societe