### PR TITLE
FIX sql request parenthesis

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -468,7 +468,7 @@ class Translate
 		if (! $found && ! empty($conf->global->MAIN_ENABLE_OVERWRITE_TRANSLATION))
 		{
     		// Overwrite translation with database read
-            $sql ="SELECT transkey, transvalue FROM ".MAIN_DB_PREFIX."overwrite_trans where lang='".$db->escape($this->defaultlang)."' OR lang IS NULL";
+            $sql ="SELECT transkey, transvalue FROM ".MAIN_DB_PREFIX."overwrite_trans where (lang='".$db->escape($this->defaultlang)."' OR lang IS NULL)";
             $sql.=" AND entity IN (0, ".getEntity('overwrite_trans').")";
             $sql.=$db->order("lang", "DESC");
 		    $resql=$db->query($sql);


### PR DESCRIPTION
# Fix SQL request parenthesis
Without theses parenthesis, the entity filter is bypassed due to the higher precedence of the `AND` operator.
Which cause to load overwrited translations for every entity without exception.

The SQL request will output like this without this fix :
```
[...]
WHERE lang='fr_FR' OR lang IS NULL
  AND entity IN (0, 1);
```
Which is equivalent to this
```
[...]
WHERE lang='fr_FR'
   OR (lang IS NULL AND entity IN (0, 1));
```