### PR TITLE
FIX PaymentBankTransfer Type page management with Select and Input on create.php

### DIFF
--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -386,7 +386,10 @@ if ($resql) {
 	if (!empty($limit)) {
 		print '<input type="hidden" name="limit" value="'.$limit.'"/>';
 	}
-
+	if ($type != '') {
+		print '<input type="hidden" name="type" value="'.$type.'">';
+	}
+	
 	$title = $langs->trans("InvoiceWaitingWithdraw");
 	if ($type == 'bank-transfer') {
 		$title = $langs->trans("InvoiceWaitingPaymentByBankTransfer");

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -389,7 +389,7 @@ if ($resql) {
 	if ($type != '') {
 		print '<input type="hidden" name="type" value="'.$type.'">';
 	}
-	
+
 	$title = $langs->trans("InvoiceWaitingWithdraw");
 	if ($type == 'bank-transfer') {
 		$title = $langs->trans("InvoiceWaitingPaymentByBankTransfer");


### PR DESCRIPTION
# FIX
htdocs/compta/prelevement/create.php has a bug when type=bank-transfer is used. The Select of number of lines is redirecting to the wrong page when changing the value.
 