### PR TITLE
FIX compute next value when year is on one digit for reset counter

### DIFF
--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1215,7 +1215,7 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 		} elseif ($yearlen == 2) {
 			$yearcomp = sprintf("%02d", date("y", $date) + $yearoffset);
 		} elseif ($yearlen == 1) {
-			$yearcomp = substr(date("y", $date), 2, 1) + $yearoffset;
+			$yearcomp = substr(date('y', $date), 1, 1) + $yearoffset;
 		}
 		if ($monthcomp > 1 && empty($resetEveryMonth)) {	// Test with month is useless if monthcomp = 0 or 1 (0 is same as 1) (regis: $monthcomp can't equal 0)
 			if ($yearlen == 4) {


### PR DESCRIPTION
FIX compute next value when year is on one digit for reset counter
- when you have a mask number with a reset counter in January : "@1" in counter mask
- and  you have only one digit in year mask : {y} in mask
- you got an error when you want to create the second object (proposal, customer order, etc)

For example when you have a mask number for customer orders like : CO{y}{mm}-{0000+3@1}
- you create a first order and it take "CO211-0004"
- you want to create an other order : you can't because you got this error : "Duplicate entry 'CO211-0004-1' for key 'llx_commande.uk_commande_ref'"



