### PR TITLE
FIX : $sign is useless

### DIFF
--- a/htdocs/compta/facture/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/compta/facture/tpl/linkedobjectblock.tpl.php
@@ -72,13 +72,9 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	print '<td class="linkedcol-date center">'.dol_print_date($objectlink->date, 'day').'</td>';
 	print '<td class="linkedcol-amount right">';
 	if (!empty($objectlink) && $objectlink->element == 'facture' && $user->hasRight('facture', 'lire')) {
-		$sign = 1;
-		if ($objectlink->type == Facture::TYPE_CREDIT_NOTE) {
-			$sign = -1;
-		}
 		if ($objectlink->statut != 3) {
 			// If not abandonned
-			$total = $total + $sign * $objectlink->total_ht;
+			$total += $objectlink->total_ht;
 			echo price($objectlink->total_ht);
 		} else {
 			echo '<strike>'.price($objectlink->total_ht).'</strike>';


### PR DESCRIPTION
@eldy on this commit : https://github.com/Dolibarr/dolibarr/commit/d4db4480d708bb1697dab8539aa0590735a0b07c
it seems you added a correction by changing $object->type into $objectlink->type and it created a bug :
![image](https://user-images.githubusercontent.com/5585819/203524468-d1c71fc1-7615-4e94-8596-0424b01b68dc.png)


If we look at invoice list, it always uses sum of all total_ht value to get global total :
![image](https://user-images.githubusercontent.com/5585819/203525125-74131e35-6dbc-4ef7-abb6-0f06c884ea89.png)

Then i removed all "$sign" code, i think it's useless but i let you check.