### PR TITLE
FIX Broken Permissions check, $object is null.

### DIFF
--- a/htdocs/compta/prelevement/line.php
+++ b/htdocs/compta/prelevement/line.php
@@ -61,7 +61,7 @@ if ($sortfield == "") {
 	$sortfield = "pl.fk_soc";
 }
 
-$type = $object->type;
+
 if ($type == 'bank-transfer') {
 	$result = restrictedArea($user, 'paymentbybanktransfer', '', '', '');
 } else {


### PR DESCRIPTION
# FIX  Broken Permissions check, $object is null.
This code was probably copy&paste'd from `htdocs/compta/prelevement/card.php` where the `$object` variable exists. 

On `htdocs/compta/prelevement/line.php` `$object` is not defined, and `$type` comes from the `$type = GETPOST('type', 'aZ09');` which ends up being overwritten with null.

Then only `$result = restrictedArea($user, 'prelevement', '', '', 'bons');` ends up being checked. Meaning a person without permission can still access `htdocs/compta/prelevement/line.php?type=bank-transfer`
