### PR TITLE
NEW move htmlPrintOnlineFooter in their own lib

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -2227,3 +2227,66 @@ function addMailingEventTypeSQL($actioncode, $objcon, $filterobj)
 		return $sql2;
 	}
 }
+
+/**
+ * Get footer of company in HTML pages
+ *
+ * @param   Societe		$fromcompany	Third party
+ * @param   Translate	$langs			Output language
+ * @return	array 		Line1 and line2
+ */
+function htmlOnlineCompanyFooter($fromcompany, $langs)
+{
+	global $conf;
+
+	// Juridical status
+	$line1 = "";
+	if ($fromcompany->forme_juridique_code) {
+		$line1 .= ($line1 ? " - " : "").getFormeJuridiqueLabel($fromcompany->forme_juridique_code);
+	}
+	// Capital
+	if ($fromcompany->capital) {
+		$line1 .= ($line1 ? " - " : "").$langs->transnoentities("CapitalOf", $fromcompany->capital)." ".$langs->transnoentities("Currency".$conf->currency);
+	}
+	// Prof Id 1
+	if ($fromcompany->idprof1 && ($fromcompany->country_code != 'FR' || !$fromcompany->idprof2)) {
+		$field = $langs->transcountrynoentities("ProfId1", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof1;
+	}
+	// Prof Id 2
+	if ($fromcompany->idprof2) {
+		$field = $langs->transcountrynoentities("ProfId2", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof2;
+	}
+
+	// Second line of company infos
+	$line2 = "";
+	// Prof Id 3
+	if ($fromcompany->idprof3) {
+		$field = $langs->transcountrynoentities("ProfId3", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof3;
+	}
+	// Prof Id 4
+	if ($fromcompany->idprof4) {
+		$field = $langs->transcountrynoentities("ProfId4", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof4;
+	}
+	// IntraCommunautary VAT
+	if ($fromcompany->tva_intra != '') {
+		$line2 .= ($line2 ? " - " : "").$langs->transnoentities("VATIntraShort").": ".$fromcompany->tva_intra;
+	}
+
+	return array('line1' => $line1, 'line2' => $line2);
+}

--- a/htdocs/core/lib/payments.lib.php
+++ b/htdocs/core/lib/payments.lib.php
@@ -403,67 +403,23 @@ function getOnlinePaymentUrl($mode, $type, $ref = '', $amount = '9.99', $freetag
 
 
 /**
- * Show footer of company in HTML pages
+ * Show footer of payments in HTML pages
  *
- * @param   Societe		$fromcompany	Third party
- * @param   Translate	$langs			Output language
- * @param	int			$addformmessage	Add the payment form message
- * @param	string		$suffix			Suffix to use on constants
- * @param	Object		$object			Object related to payment
+ * @param   Societe		$fromcompany		Third party
+ * @param   Translate	$langs				Output language
+ * @param	int			$addformmessage		Add the payment form message
+ * @param	string		$suffix				Suffix to use on constants
+ * @param	Object		$object				Object related to payment
+ * @param	Object		$footerPosition		[=''] Footer position : 'fixed' to have footer on bottom of the page or '' to have footer after all content
  * @return	void
  */
-function htmlPrintOnlinePaymentFooter($fromcompany, $langs, $addformmessage = 0, $suffix = '', $object = null)
+function htmlPrintOnlinePaymentFooter($fromcompany, $langs, $addformmessage = 0, $suffix = '', $object = null, $footerPosition = '')
 {
 	global $conf;
 
-	// Juridical status
-	$line1 = "";
-	if ($fromcompany->forme_juridique_code) {
-		$line1 .= ($line1 ? " - " : "").getFormeJuridiqueLabel($fromcompany->forme_juridique_code);
-	}
-	// Capital
-	if ($fromcompany->capital) {
-		$line1 .= ($line1 ? " - " : "").$langs->transnoentities("CapitalOf", $fromcompany->capital)." ".$langs->transnoentities("Currency".$conf->currency);
-	}
-	// Prof Id 1
-	if ($fromcompany->idprof1 && ($fromcompany->country_code != 'FR' || !$fromcompany->idprof2)) {
-		$field = $langs->transcountrynoentities("ProfId1", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof1;
-	}
-	// Prof Id 2
-	if ($fromcompany->idprof2) {
-		$field = $langs->transcountrynoentities("ProfId2", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof2;
-	}
-
-	// Second line of company infos
-	$line2 = "";
-	// Prof Id 3
-	if ($fromcompany->idprof3) {
-		$field = $langs->transcountrynoentities("ProfId3", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof3;
-	}
-	// Prof Id 4
-	if ($fromcompany->idprof4) {
-		$field = $langs->transcountrynoentities("ProfId4", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof4;
-	}
-	// IntraCommunautary VAT
-	if ($fromcompany->tva_intra != '') {
-		$line2 .= ($line2 ? " - " : "").$langs->transnoentities("VATIntraShort").": ".$fromcompany->tva_intra;
-	}
+	$lineList = htmlOnlineCompanyFooter($fromcompany, $langs);
+	$line1 = $lineList['line1'];
+	$line2 = $lineList['line2'];
 
 	print '<!-- htmlPrintOnlinePaymentFooter -->'."\n";
 
@@ -492,14 +448,24 @@ function htmlPrintOnlinePaymentFooter($fromcompany, $langs, $addformmessage = 0,
 		}
 	}
 
-	print '<span style="font-size: 10px;"><br><hr>'."\n";
-	print $fromcompany->name.'<br>';
-	print $line1;
-	if (strlen($line1.$line2) > 50) {
-		print '<br>';
+	if ($footerPosition == 'fixed') {
+		print '</div>';
+		print '<div  class="center" style="font-size: 14px; position: fixed; bottom: 0px; width: 100%; z-index: -1;">';
+		print '<br><hr>';
+		print '<b>'.$fromcompany->name.'</b>';
+		print '<br>'.(!empty($line1) ? $line1.'<br>' : '');
+		print $line2.'<br>.&nbsp;';
+		print '	</div>';
 	} else {
-		print ' - ';
+		print '<span style="font-size: 10px;"><br><hr>' . "\n";
+		print $fromcompany->name . '<br>';
+		print $line1;
+		if (strlen($line1 . $line2) > 50) {
+			print '<br>';
+		} else {
+			print ' - ';
+		}
+		print $line2;
+		print '</span></div>' . "\n";
 	}
-	print $line2;
-	print '</span></div>'."\n";
 }

--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -220,7 +220,7 @@ function llxHeaderTicket($title, $head = "", $disablejs = 0, $disablehead = 0, $
 	top_htmlhead($head, $title, $disablejs, $disablehead, $arrayofjs, $arrayofcss, 0, 1); // Show html headers
 
 	print '<body id="mainbody" class="publicnewticketform" style="height: 100%;">';
-	print '<div class="publicnewticketform2" style="min-height: calc(100% - 100px); margin-bottom: 100px; position: relative;">';
+	print '<div class="publicnewticketform2 flexcontainer" style="min-height: 100%; min-width: 100%; ; flex-direction: column;">';
 	print '<header class="center" style="width: 100%;">';
 
 	// Define urllogo
@@ -282,8 +282,8 @@ function htmlPrintOnlineTicketFooter($fromcompany, $langs)
 	$line1 = $lineList['line1'];
 	$line2 = $lineList['line2'];
 
-	print '<footer class="center" style="width: 100%;">';
-	print '<div style="font-size: 14px; bottom: 0px; margin-top: auto; padding-top: 20px; width: 100%; height: 80px;">';
+	print '<footer class="center" style="width: 100%; margin-top: auto;">';
+	print '<div style="font-size: 14px; bottom: 0px; padding-top: 20px; width: 100%; height: 80px;">';
 	print '<hr>';
 	print '<b>'.$fromcompany->name.'</b>';
 	print '<br>'.(!empty($line1) ? $line1.'<br>' : '');

--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -221,7 +221,7 @@ function llxHeaderTicket($title, $head = "", $disablejs = 0, $disablehead = 0, $
 
 	print '<body id="mainbody" class="publicnewticketform" style="height: 100%;">';
 	print '<div class="publicnewticketform2" style="min-height: calc(100% - 100px); margin-bottom: 100px; position: relative;">';
-	print '<div class="center">';
+	print '<header class="center" style="width: 100%;">';
 
 	// Define urllogo
 	if (!empty($conf->global->TICKET_SHOW_COMPANY_LOGO) || !empty($conf->global->TICKET_PUBLIC_INTERFACE_TOPIC)) {
@@ -265,9 +265,7 @@ function llxHeaderTicket($title, $head = "", $disablejs = 0, $disablehead = 0, $
 		print '</div>';
 	}
 
-	print '</div>';
-
-	print '<div class="ticketlargemargin">';
+	print '</header>';
 }
 
 
@@ -284,14 +282,12 @@ function htmlPrintOnlineTicketFooter($fromcompany, $langs)
 	$line1 = $lineList['line1'];
 	$line2 = $lineList['line2'];
 
-	print '</div>'; // end div publicnewticketform from llxHeaderTicket
-	print '</div>'; // end div publicnewticketform2 from llxHeaderTicket
-	print '<div class="center" style="position: relative; float: left; width: 100%;">';
-	print '<div style="font-size: 14px; position: absolute; bottom: 0px; margin-top: 20px; padding-top: 20px; width: 100%; height: 80px;">';
+	print '<footer class="center" style="width: 100%;">';
+	print '<div style="font-size: 14px; bottom: 0px; margin-top: auto; padding-top: 20px; width: 100%; height: 80px;">';
 	print '<hr>';
 	print '<b>'.$fromcompany->name.'</b>';
 	print '<br>'.(!empty($line1) ? $line1.'<br>' : '');
 	print $line2;
 	print '</div>';
-	print '</div>';
+	print '</footer>';
 }

--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -219,7 +219,8 @@ function llxHeaderTicket($title, $head = "", $disablejs = 0, $disablehead = 0, $
 	$urllogo = "";
 	top_htmlhead($head, $title, $disablejs, $disablehead, $arrayofjs, $arrayofcss, 0, 1); // Show html headers
 
-	print '<body id="mainbody" class="publicnewticketform">';
+	print '<body id="mainbody" class="publicnewticketform" style="height: 100%;">';
+	print '<div class="publicnewticketform2" style="min-height: calc(100% - 100px); margin-bottom: 100px; position: relative;">';
 	print '<div class="center">';
 
 	// Define urllogo
@@ -267,4 +268,30 @@ function llxHeaderTicket($title, $head = "", $disablejs = 0, $disablehead = 0, $
 	print '</div>';
 
 	print '<div class="ticketlargemargin">';
+}
+
+
+/**
+ * Show footer of company in HTML pages
+ *
+ * @param   Societe		$fromcompany	Third party
+ * @param   Translate	$langs			Output language
+ * @return	void
+ */
+function htmlPrintOnlineTicketFooter($fromcompany, $langs)
+{
+	$lineList = htmlOnlineCompanyFooter($fromcompany, $langs);
+	$line1 = $lineList['line1'];
+	$line2 = $lineList['line2'];
+
+	print '</div>'; // end div publicnewticketform from llxHeaderTicket
+	print '</div>'; // end div publicnewticketform2 from llxHeaderTicket
+	print '<div class="center" style="position: relative; float: left; width: 100%;">';
+	print '<div style="font-size: 14px; position: absolute; bottom: 0px; margin-top: 20px; padding-top: 20px; width: 100%; height: 80px;">';
+	print '<hr>';
+	print '<b>'.$fromcompany->name.'</b>';
+	print '<br>'.(!empty($line1) ? $line1.'<br>' : '');
+	print $line2;
+	print '</div>';
+	print '</div>';
 }

--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -2654,7 +2654,7 @@ if (preg_match('/^dopayment/', $action)) {			// If we choosed/click on the payme
 }
 
 
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 1, $suffix, $object);
+htmlPrintOnlinePaymentFooter($mysoc, $langs, 1, $suffix, $object, 'fixed');
 
 llxFooter('', 'public');
 

--- a/htdocs/public/payment/paymentko.php
+++ b/htdocs/public/payment/paymentko.php
@@ -286,7 +286,7 @@ if ($type || $tag) {
 print "\n</div>\n";
 
 
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix);
+htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, null, 'fixed');
 
 
 llxFooter('', 'public');

--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -1778,7 +1778,7 @@ print "\n</div>\n";
 print "<!-- Info for payment: FinalPaymentAmt=".dol_escape_htmltag($FinalPaymentAmt)." paymentTypeId=".dol_escape_htmltag($paymentTypeId)." currencyCodeType=".dol_escape_htmltag($currencyCodeType)." -->\n";
 
 
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix);
+htmlPrintOnlineFooter($mysoc, $langs, 0, $suffix, null, 'fixed');
 
 
 // Clean session variables to avoid duplicate actions if post is resent

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -59,7 +59,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/html.formticket.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/ticket.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
@@ -71,7 +70,6 @@ $langs->loadLangs(array('companies', 'other', 'mails', 'ticket'));
 $id = GETPOST('id', 'int');
 $msg_id = GETPOST('msg_id', 'int');
 $socid = GETPOST('socid', 'int');
-$suffix = "";
 
 $action = GETPOST('action', 'aZ09');
 $cancel = GETPOST('cancel', 'aZ09');
@@ -543,7 +541,7 @@ if ($action != "infos_success") {
 print '</div>';
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 1, $suffix, $object);
+htmlPrintOnlineTicketFooter($mysoc, $langs);
 
 llxFooter('', 'public');
 

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -507,7 +507,7 @@ $arrayofcss = array('/opensurvey/css/style.css', '/ticket/css/styles.css.php');
 
 llxHeaderTicket($langs->trans("CreateTicket"), "", 0, 0, $arrayofjs, $arrayofcss);
 
-
+print '<main class="ticketlargemargin">';
 print '<div class="ticketpublicarea">';
 
 if ($action != "infos_success") {
@@ -538,11 +538,16 @@ if ($action != "infos_success") {
 	}
 }
 
-print '</div>';
+print '</div>'; // div class="ticketpublicarea"
+print '</main>';
 
 // End of page
 htmlPrintOnlineTicketFooter($mysoc, $langs);
 
+print '</div>'; // end div publicnewticketform2 from llxHeaderTicket()
+
 llxFooter('', 'public');
+
+print '</body>';
 
 $db->close();

--- a/htdocs/public/ticket/index.php
+++ b/htdocs/public/ticket/index.php
@@ -49,7 +49,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/html.formticket.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/ticket.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array('companies', 'other', 'ticket', 'errors'));
@@ -57,7 +56,6 @@ $langs->loadLangs(array('companies', 'other', 'ticket', 'errors'));
 // Get parameters
 $track_id = GETPOST('track_id', 'alpha');
 $action = GETPOST('action', 'aZ09');
-$suffix = "";
 
 if (!isModEnabled('ticket')) {
 	httponly_accessforbidden('Module Ticket not enabled');
@@ -94,7 +92,7 @@ print '</div>';
 print '</div>';
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
+htmlPrintOnlineTicketFooter($mysoc, $langs);
 
 llxFooter('', 'public');
 

--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -51,7 +51,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/ticket.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array("companies", "other", "ticket"));
@@ -62,7 +61,6 @@ $cancel = GETPOST('cancel', 'aZ09');
 
 $track_id = GETPOST('track_id', 'alpha');
 $email = strtolower(GETPOST('email', 'alpha'));
-$suffix = "";
 $moreforfilter = "";
 
 if (GETPOST('btn_view_ticket_list')) {
@@ -754,7 +752,7 @@ if ($action == "view_ticketlist") {
 }
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
+htmlPrintOnlineTicketFooter($mysoc, $langs);
 
 llxFooter('', 'public');
 

--- a/htdocs/public/ticket/view.php
+++ b/htdocs/public/ticket/view.php
@@ -52,7 +52,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/ticket.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array("companies", "other", "ticket"));
@@ -63,7 +62,6 @@ $cancel = GETPOST('cancel', 'aZ09');
 
 $track_id = GETPOST('track_id', 'alpha');
 $email    = GETPOST('email', 'email');
-$suffix = "";
 
 if (GETPOST('btn_view_ticket')) {
 	unset($_SESSION['email_customer']);
@@ -418,7 +416,7 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 print "</div>";
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
+htmlPrintOnlineTicketFooter($mysoc, $langs);
 
 llxFooter('', 'public');
 

--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -7019,14 +7019,11 @@ div.tabsElem a.tab {
 	/* margin-top: 25px !important; */
 }
 .ticketlargemargin {
-	padding-left: 50px;
-	padding-right: 50px;
 	padding-top: 30px;
 }
-@media only screen and (max-width: 767px)
+@media only screen and (max-width: 1180px)
 {
 	.ticketlargemargin {
-		padding-left: 5px; padding-right: 5px;
 		padding-top: 10px;
 	}
 	.ticketpublicarea {


### PR DESCRIPTION
NEW public and payment interface with footer at bottom

**Before**
Public interface

- Index
![image](https://user-images.githubusercontent.com/45359511/203943330-3d4e2f86-5605-4b4f-9146-2ab76b43de09.png)

- In list (a page with scroll-bar)
![image](https://user-images.githubusercontent.com/45359511/203943490-fb70f3ec-23ab-4bbb-84ac-78920e7a5623.png)

Payment interface

![image](https://user-images.githubusercontent.com/45359511/203943116-a793d342-6406-4a80-b951-dbb02bdb5d5d.png)


**After**
Public interface

- Index
![image](https://user-images.githubusercontent.com/45359511/203938541-b14c23b6-a6a3-428a-a9cb-7848034c17c9.png)

- In list (a page with scroll-bar)
![image](https://user-images.githubusercontent.com/45359511/203939116-69983c68-8a74-416d-8f25-715f91c895b3.png)

Payment interface

![image](https://user-images.githubusercontent.com/45359511/203939381-c24006d1-0161-4825-aaaa-b0aa795b4ce9.png)


The method "htmlPrintOnlinePaymentFooter" is reviewed and use a new method "htmlOnlineCompanyFooter" to get lines of company for footer.
This method "htmlOnlineCompanyFooter" is now introduced for all public footer to get lines of company for footer.
As the header, the footer is also separated.
