### PR TITLE
Fix bank statement can't use links in document tab

### DIFF
--- a/htdocs/core/tpl/document_actions_post_headers.tpl.php
+++ b/htdocs/core/tpl/document_actions_post_headers.tpl.php
@@ -121,7 +121,8 @@ $formfile->form_attach_new_file(
 	$object,
 	'',
 	1,
-	$savingdocmask
+	$savingdocmask,
+	0
 );
 
 // List of document
@@ -146,8 +147,4 @@ $formfile->list_of_documents(
 	$disablemove
 );
 
-print "<br>";
-
-//List of links
-$formfile->listOfLinks($object, $permission, $action, GETPOST('linkid', 'int'), $param);
 print "<br>";


### PR DESCRIPTION
The table links allows only elements having an id. A bank statement is not a real object, so it doesn't have an id. We can't add links to bank statement for now

Fix #13255