### PR TITLE
FIX : Bankaccounts API fetch with 'id' and 'socid'

### DIFF
--- a/htdocs/societe/class/companybankaccount.class.php
+++ b/htdocs/societe/class/companybankaccount.class.php
@@ -217,7 +217,7 @@ class CompanyBankAccount extends Account
 		if ($id) {
 			$sql .= " WHERE rowid = ".((int) $id);
 		}
-		if ($socid) {
+		elseif ($socid) {
 			$sql .= " WHERE fk_soc  = ".((int) $socid);
 			if ($default > -1) {
 				$sql .= " AND default_rib = ".((int) $default);


### PR DESCRIPTION
# Fix Bankaccounts API fetch with both `id` and `socid`
#20492 
The "PUT /thirdparties/{id}/bankaccounts/{bankaccount_id}" endpoint will perform a bankaccount fetch with both parameters `id` and `socid` which cause to output a SQL request with a duplicate of `WHERE` keyword