### PR TITLE
fix #20894: debian package (compress options)

### DIFF
--- a/build/debian/source/options
+++ b/build/debian/source/options
@@ -1,0 +1,3 @@
+# Use bzip2 instead of gzip
+compression = "bzip2"
+compression-level = 9


### PR DESCRIPTION
# FIX|Fix #20894 

Force debian compress to bzip2 to avoid problem of older debian os without new compress tools