### PR TITLE
NEW Bank module not enabled by default in TakePOS

### DIFF
--- a/htdocs/core/modules/modTakePos.class.php
+++ b/htdocs/core/modules/modTakePos.class.php
@@ -98,7 +98,7 @@ class modTakePos extends DolibarrModules
 
 		// Dependencies
 		$this->hidden = false; // A condition to hide module
-		$this->depends = array('always1'=>"modBanque", 'always2'=>"modFacture", 'always3'=>"modProduct", 'always4'=>'modCategorie', 'FR1'=>'modBlockedLog'); // List of module class names as string that must be enabled if this module is enabled
+		$this->depends = array('always1'=>"modFacture", 'always2'=>"modProduct", 'always3'=>'modCategorie', 'FR1'=>'modBlockedLog'); // List of module class names as string that must be enabled if this module is enabled
 		$this->requiredby = array(); // List of module ids to disable if this one is disabled
 		$this->conflictwith = array(); // List of module class names as string this module is in conflict with
 		$this->langfiles = array("cashdesk");


### PR DESCRIPTION
TakePOS can work without the bank module from https://github.com/Dolibarr/dolibarr/pull/21135 Many users do not use the functionality of the bank module in TakePOS. Why force all users to configure all these options? Many users get confused to configure TakePOS because many things have to be created and configured.