### PR TITLE
Fix #20685 User Id not transmitted on Api addTimeSpent

### DIFF
--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -545,7 +545,7 @@ class Tasks extends DolibarrApi
 		$this->task->timespent_datehour = $newdate;
 		$this->task->timespent_withhour = 1;
 		$this->task->timespent_duration = $duration;
-		$this->task->timespent_fk_user  = $user_id;
+		$this->task->timespent_fk_user  = $uid;
 		$this->task->timespent_note     = $note;
 
 		$result = $this->task->addTimeSpent(DolibarrApiAccess::$user, 0);


### PR DESCRIPTION
Fix #20685 User Id not transmitted on Api addTimeSpent

The User ID will be transmitted to the API call (if 0 then, the user will be selected from API key)
