### PR TITLE
FIX : Documents API inconsistency

### DIFF
--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -463,7 +463,7 @@ class Documents extends DolibarrApi
 		}
 
 		$objectType = $modulepart;
-		if(! empty($object->id) && ! empty($object->table_element)) $objectType = $object->table_element;
+		if (! empty($object->id) && ! empty($object->table_element)) $objectType = $object->table_element;
 
 		$filearray = dol_dir_list($upload_dir, $type, $recursive, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ?SORT_DESC:SORT_ASC), 1);
 		if (empty($filearray)) {
@@ -476,8 +476,8 @@ class Documents extends DolibarrApi
 				if ($result < 0) {
 					throw new RestException(503, 'Error when retrieve ecm list : ' . $this->db->lasterror());
 				} elseif (is_array($ecmfile->lines) && count($ecmfile->lines) > 0) {
-					for($i = 0 ; $i < count($filearray) ; $i++) {
-						if($filearray[$i]['name'] == $ecmfile->lines[$i]->filename) $filearray[$i] = array_merge($filearray[$i], (array) $ecmfile->lines[0]);
+					for ($i = 0 ; $i < count($filearray); $i++) {
+						if ($filearray[$i]['name'] == $ecmfile->lines[$i]->filename) $filearray[$i] = array_merge($filearray[$i], (array) $ecmfile->lines[0]);
 					}
 				}
 			}

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -462,6 +462,9 @@ class Documents extends DolibarrApi
 			throw new RestException(500, 'Modulepart '.$modulepart.' not implemented yet.');
 		}
 
+		$objectType = $modulepart;
+		if(! empty($object->id) && ! empty($object->table_element)) $objectType = $object->table_element;
+
 		$filearray = dol_dir_list($upload_dir, $type, $recursive, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ?SORT_DESC:SORT_ASC), 1);
 		if (empty($filearray)) {
 			throw new RestException(404, 'Search for modulepart '.$modulepart.' with Id '.$object->id.(!empty($object->ref) ? ' or Ref '.$object->ref : '').' does not return any document.');
@@ -469,11 +472,13 @@ class Documents extends DolibarrApi
 			if (($object->id) > 0 && !empty($modulepart)) {
 				require_once DOL_DOCUMENT_ROOT . '/ecm/class/ecmfiles.class.php';
 				$ecmfile = new EcmFiles($this->db);
-				$result = $ecmfile->fetchAll('', '', 0, 0, array('t.src_object_type' => $modulepart, 't.src_object_id' => $object->id));
+				$result = $ecmfile->fetchAll('', '', 0, 0, array('t.src_object_type' => $objectType, 't.src_object_id' => $object->id));
 				if ($result < 0) {
 					throw new RestException(503, 'Error when retrieve ecm list : ' . $this->db->lasterror());
 				} elseif (is_array($ecmfile->lines) && count($ecmfile->lines) > 0) {
-					$filearray['ecmfiles_infos'] = $ecmfile->lines;
+					for($i = 0 ; $i < count($filearray) ; $i++) {
+						if($filearray[$i]['name'] == $ecmfile->lines[$i]->filename) $filearray[$i] = array_merge($filearray[$i], (array) $ecmfile->lines[0]);
+					}
 				}
 			}
 		}

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -476,7 +476,8 @@ class Documents extends DolibarrApi
 				if ($result < 0) {
 					throw new RestException(503, 'Error when retrieve ecm list : ' . $this->db->lasterror());
 				} elseif (is_array($ecmfile->lines) && count($ecmfile->lines) > 0) {
-					for ($i = 0 ; $i < count($filearray); $i++) {
+					$count = count($filearray);
+					for ($i = 0 ; $i < $count ; $i++) {
 						if ($filearray[$i]['name'] == $ecmfile->lines[$i]->filename) $filearray[$i] = array_merge($filearray[$i], (array) $ecmfile->lines[0]);
 					}
 				}


### PR DESCRIPTION
# Fix Documents list API inconsistency
#18572
This fix includes two things.
It allow the "GET /documents" endpoint to handle on a better way the modulepart for the ECM part
And in order to make this endpoint consistent with its return, it merge the `dol_dir_list` results with the potential ECM results

Without this fix, it will output something like this

```json
{
  "0": {
    "name": "SH2211-0001.pdf",
    "path": "/pathToFiles/documents/expedition/sending/SH2211-0001",
    "level1name": "SH2211-0001",
    "relativename": "SH2211-0001.pdf",
    "fullname": "/pathToFiles/documents/expedition/sending/SH2211-0001/SH2211-0001.pdf",
    "date": 1669411905,
    "size": 7725,
    "type": "file"
  },
  "ecmfiles_infos": [
    {
      "label": "f3f1e40e2f3f8ddaddd93aac79ae4252",
      "entity": "1",
      "filename": "SH2211-0001.pdf",
      "filepath": "expedition/sending/SH2211-0001",
      "fullpath_orig": "",
      "description": "",
      "keywords": "",
      "cover": null,
      "position": "1",
      "gen_or_uploaded": "generated",
      "extraparams": null,
      "date_c": 1669411900,
      "date_m": 1669411905,
      "fk_user_c": "1",
      "fk_user_m": "1",
      "acl": null,
      "src_object_type": "expedition",
      "src_object_id": "1",
      "id": "2",
      "ref": null,
      "share": null
    }
  ]
}
```

And with this fix :
```json
[
  {
    "name": "SH2211-0001.pdf",
    "path": "/pathToFiles/documents/expedition/sending/SH2211-0001",
    "level1name": "SH2211-0001",
    "relativename": "SH2211-0001.pdf",
    "fullname": "/pathToFiles/documents/expedition/sending/SH2211-0001/SH2211-0001.pdf",
    "date": 1669411905,
    "size": 7725,
    "type": "file",
    "label": "f3f1e40e2f3f8ddaddd93aac79ae4252",
    "entity": "1",
    "filename": "SH2211-0001.pdf",
    "filepath": "expedition/sending/SH2211-0001",
    "fullpath_orig": "",
    "description": "",
    "keywords": "",
    "cover": null,
    "position": "1",
    "gen_or_uploaded": "generated",
    "extraparams": null,
    "date_c": 1669411900,
    "date_m": 1669411905,
    "fk_user_c": "1",
    "fk_user_m": "1",
    "acl": null,
    "src_object_type": "expedition",
    "src_object_id": "1",
    "id": "2",
    "ref": null,
    "share": null
  }
]
```