### PR TITLE
FIX: #22509 default value on integer fields don't retrieve by setSaveQuery

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8829,7 +8829,11 @@ abstract class CommonObject
 				// $this->{$field} may be null, '', 0, '0', 123, '123'
 				if ((isset($this->{$field}) && $this->{$field} != '') || !empty($info['notnull'])) {
 					if (!isset($this->{$field})) {
-						$queryarray[$field] = 0;
+						if (!empty($info['default'])) {
+							$queryarray[$field] = $info['default'];
+						} else {
+							$queryarray[$field] = 0;
+						}
 					} else {
 						$queryarray[$field] = (int) $this->{$field};		// If '0', it may be set to null later if $info['notnull'] == -1
 					}


### PR DESCRIPTION
## Behavior

If you use a integer fields type like :
'amount' => array('type'=>'integer', 'label'=>'Amount', 'enabled'=>'1', 'position'=>40, 'notnull'=>1, 'visible'=>5, 'default'=>1, 'validate'=>'1'),
After creation you can see that 
![image](https://user-images.githubusercontent.com/52404047/204063971-d105c1b0-975d-4754-8301-9e21d91a4f7d.png)

By default for integer that value is set a 0 instead of default value set by fields
