### PR TITLE
Fix issue #23023 

### DIFF
--- a/htdocs/admin/fckeditor.php
+++ b/htdocs/admin/fckeditor.php
@@ -100,7 +100,7 @@ foreach ($modules as $const => $desc) {
 		exit;
 	}
 	if ($action == 'disable_'.strtolower($const)) {
-		dolibarr_set_const($db, "FCKEDITOR_ENABLE_".$const, 0);
+		dolibarr_set_const($db, "FCKEDITOR_ENABLE_".$const, "0", 'chaine', 0, '', $conf->entity);
 		header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;
 	}

--- a/htdocs/admin/fckeditor.php
+++ b/htdocs/admin/fckeditor.php
@@ -100,7 +100,7 @@ foreach ($modules as $const => $desc) {
 		exit;
 	}
 	if ($action == 'disable_'.strtolower($const)) {
-		dolibarr_del_const($db, "FCKEDITOR_ENABLE_".$const, $conf->entity);
+		dolibarr_set_const($db, "FCKEDITOR_ENABLE_".$const, 0);
 		header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;
 	}


### PR DESCRIPTION
# FIX|Fix #23023 issue erase values during a module update 
replace dolibarr_del_const() by dolibarr_set_const() to maintain the setting of module before disable. 


