### PR TITLE
FIX insert extra fields when date time is a timestamp as string

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6270,7 +6270,7 @@ abstract class CommonObject
 					case 'date':
 					case 'datetime':
 						// If data is a string instead of a timestamp, we convert it
-						if (!is_int($this->array_options[$key])) {
+						if (!is_numeric($this->array_options[$key]) || $this->array_options[$key] != intval($this->array_options[$key])) {
 							$this->array_options[$key] = strtotime($this->array_options[$key]);
 						}
 						$new_array_options[$key] = $this->db->idate($this->array_options[$key]);


### PR DESCRIPTION
FIX insert extra fields when date time is a timestamp as string

**Before**
- a timestamp as string type wasn't an int type and the method strtotime() was called with a timestamp and returned a bad result

**After**
- a timestamp as string type is a numeric and the method strtotime() is not called
- if it's not an numeric and the extra field value is not equal with the integer value the method strtotime() is called
