### PR TITLE
FIX: PGSQL Integer type does not have a free lenght

### DIFF
--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -1182,7 +1182,7 @@ class DoliDBPgsql extends DoliDB
 		// phpcs:enable
 		$sql = "ALTER TABLE ".$table;
 		$sql .= " MODIFY COLUMN ".$field_name." ".$field_desc['type'];
-		if (in_array($field_desc['type'], array('double', 'tinyint', 'int', 'varchar')) && $field_desc['value']) {
+		if (in_array($field_desc['type'], array('double', 'varchar')) && $field_desc['value']) {
 			$sql .= "(".$field_desc['value'].")";
 		}
 


### PR DESCRIPTION
https://www.postgresql.org/docs/15/datatype-numeric.html#DATATYPE-INT

A postgreSQL error occurs when updating a field  

```
  DoliDBPgsql::query SQL Error query: -- ALTER TABLE llx_asset_extrafields MODIFY COLUMN responsable int(11) replaced by --
ALTER TABLE llx_asset_extrafields ALTER COLUMN responsable TYPE int(11)
2022-12-01 14:09:31 ERR     127.0.0.1       DoliDBPgsql::query SQL Error message: ERROR:  42601: syntax error at or near "("
LINE 2: ...t_extrafields ALTER COLUMN responsable TYPE int(11)
```
Indeed we cannot assign a length to an integer, which is on 4 bytes
