### PR TITLE
NEW operation type in email collector to load or create contact

### DIFF
--- a/htdocs/admin/emailcollector_card.php
+++ b/htdocs/admin/emailcollector_card.php
@@ -668,6 +668,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	$arrayoftypes = array(
 		'loadthirdparty' => $langs->trans('LoadThirdPartyFromName', $langs->transnoentities("ThirdPartyName")),
 		'loadandcreatethirdparty' => $langs->trans('LoadThirdPartyFromNameOrCreate', $langs->transnoentities("ThirdPartyName")),
+		'loadandcreatecontact' => $langs->trans('LoadContactFromEmailOrCreate', $langs->transnoentities("Email")),
 		'recordjoinpiece' => 'AttachJoinedDocumentsToObject',
 		'recordevent' => 'RecordEvent'
 	);

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -2141,9 +2141,7 @@ class EmailCollector extends CommonObject
 									}
 								}
 							}
-						}
-						// Search and create contact
-						elseif ($operation['type'] == 'loadandcreatecontact') {
+						} elseif ($operation['type'] == 'loadandcreatecontact') { // Search and create contact
 							if (empty($operation['actionparam'])) {
 								$errorforactions++;
 								$this->error = "Action loadandcreatecontact has empty parameter. Must be 'SET:xxx' or 'EXTRACT:(body|subject):regex' to define how to extract data";

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -2141,6 +2141,120 @@ class EmailCollector extends CommonObject
 									}
 								}
 							}
+						}
+						// Search and create contact
+						elseif ($operation['type'] == 'loadandcreatecontact') {
+							if (empty($operation['actionparam'])) {
+								$errorforactions++;
+								$this->error = "Action loadandcreatecontact has empty parameter. Must be 'SET:xxx' or 'EXTRACT:(body|subject):regex' to define how to extract data";
+								$this->errors[] = $this->error;
+							} else {
+								$contact_static = new Contact($this->db);
+								// Overwrite values with values extracted from source email
+								$errorforthisaction = $this->overwritePropertiesOfObject($contact_static, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+								if ($errorforthisaction) {
+									$errorforactions++;
+								} else {
+									if (!empty($contact_static->email) && $contact_static->email != $from) $from = $contact_static->email;
+
+									$result = $contactstatic->fetch(0, null, '', $from);
+									if ($result < 0) {
+										$errorforactions++;
+										$this->error = 'Error when getting contact with email ' . $from;
+										$this->errors[] = $this->error;
+										break;
+									} elseif ($result == 0) {
+										dol_syslog("Contact with email " . $from . " was not found. We try to create it.");
+										$contactstatic = new Contact($this->db);
+
+										// Create contact
+										$contactstatic->email = $from;
+										$operationslog .= '<br>We set property email='.dol_escape_htmltag($from);
+
+										// Overwrite values with values extracted from source email
+										$errorforthisaction = $this->overwritePropertiesOfObject($contactstatic, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+
+										if ($errorforthisaction) {
+											$errorforactions++;
+										} else {
+											// Search country by name or code
+											if (!empty($contactstatic->country)) {
+												require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
+												$result = getCountry('', 3, $this->db, '', 1, $contactstatic->country);
+												if ($result == 'NotDefined') {
+													$errorforactions++;
+													$this->error = "Error country not found by this name '" . $contactstatic->country . "'";
+												} elseif (!($result > 0)) {
+													$errorforactions++;
+													$this->error = "Error when search country by this name '" . $contactstatic->country . "'";
+													$this->errors[] = $this->db->lasterror();
+												} else {
+													$contactstatic->country_id = $result;
+													$operationslog .= '<br>We set property country_id='.dol_escape_htmltag($result);
+												}
+											} elseif (!empty($contactstatic->country_code)) {
+												require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
+												$result = getCountry($contactstatic->country_code, 3, $this->db);
+												if ($result == 'NotDefined') {
+													$errorforactions++;
+													$this->error = "Error country not found by this code '" . $contactstatic->country_code . "'";
+												} elseif (!($result > 0)) {
+													$errorforactions++;
+													$this->error = "Error when search country by this code '" . $contactstatic->country_code . "'";
+													$this->errors[] = $this->db->lasterror();
+												} else {
+													$contactstatic->country_id = $result;
+													$operationslog .= '<br>We set property country_id='.dol_escape_htmltag($result);
+												}
+											}
+
+											if (!$errorforactions) {
+												// Search state by name or code (for country if defined)
+												if (!empty($contactstatic->state)) {
+													require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
+													$result = dol_getIdFromCode($this->db, $contactstatic->state, 'c_departements', 'nom', 'rowid');
+													if (empty($result)) {
+														$errorforactions++;
+														$this->error = "Error state not found by this name '" . $contactstatic->state . "'";
+													} elseif (!($result > 0)) {
+														$errorforactions++;
+														$this->error = "Error when search state by this name '" . $contactstatic->state . "'";
+														$this->errors[] = $this->db->lasterror();
+													} else {
+														$contactstatic->state_id = $result;
+														$operationslog .= '<br>We set property state_id='.dol_escape_htmltag($result);
+													}
+												} elseif (!empty($contactstatic->state_code)) {
+													require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
+													$result = dol_getIdFromCode($this->db, $contactstatic->state_code, 'c_departements', 'code_departement', 'rowid');
+													if (empty($result)) {
+														$errorforactions++;
+														$this->error = "Error state not found by this code '" . $contactstatic->state_code . "'";
+													} elseif (!($result > 0)) {
+														$errorforactions++;
+														$this->error = "Error when search state by this code '" . $contactstatic->state_code . "'";
+														$this->errors[] = $this->db->lasterror();
+													} else {
+														$contactstatic->state_id = $result;
+														$operationslog .= '<br>We set property state_id='.dol_escape_htmltag($result);
+													}
+												}
+											}
+
+											if (!$errorforactions) {
+												$result = $contactstatic->create($user);
+												if ($result <= 0) {
+													$errorforactions++;
+													$this->error = $contactstatic->error;
+													$this->errors = $contactstatic->errors;
+												} else {
+													$operationslog .= '<br>Contact created -> id = '.dol_escape_htmltag($contactstatic->id);
+												}
+											}
+										}
+									}
+								}
+							}
 						} elseif ($operation['type'] == 'recordevent') {
 							// Create event
 							$actioncomm = new ActionComm($this->db);

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -2119,6 +2119,7 @@ CodeLastResult=Latest result code
 NbOfEmailsInInbox=Number of emails in source directory
 LoadThirdPartyFromName=Load third party searching on %s (load only)
 LoadThirdPartyFromNameOrCreate=Load third party searching on %s (create if not found)
+LoadContactFromEmailOrCreate=Load contact searching on %s (create if not found)
 AttachJoinedDocumentsToObject=Save attached files into object documents if a ref of an object is found into email topic.
 WithDolTrackingID=Message from a conversation initiated by a first email sent from Dolibarr
 WithoutDolTrackingID=Message from a conversation initiated by a first email NOT sent from Dolibarr

--- a/htdocs/langs/fr_FR/admin.lang
+++ b/htdocs/langs/fr_FR/admin.lang
@@ -2115,6 +2115,7 @@ CodeLastResult=Dernier code de retour
 NbOfEmailsInInbox=Nombre de courriels dans le répertoire source
 LoadThirdPartyFromName=Charger le Tiers en cherchant sur %s (chargement uniquement)
 LoadThirdPartyFromNameOrCreate=Charger le Tiers en cherchant sur %s (créer si non trouvé)
+LoadContactFromEmailOrCreate=Charger le Contact en cherchant sur %s (créer si non trouvé)
 AttachJoinedDocumentsToObject=Enregistrez les fichiers joints dans des documents d'objet si la référence d'un objet est trouvée dans le sujet de l'e-mail.
 WithDolTrackingID=Message d'une conversation initiée par un premier mail envoyé depuis Dolibarr
 WithoutDolTrackingID=Message d'une conversation initiée par un premier e-mail NON envoyé depuis Dolibarr


### PR DESCRIPTION
NEW operation type in email collector to load or create contact
- add a new operation type in email collector card
- load or create a contact if not found by email
- add translated keys in "en_US" and "fr_FR" lang files
![image](https://user-images.githubusercontent.com/45359511/205098568-5db30424-4e7a-452b-bf5d-e6a5f5a1b47f.png)
