### PR TITLE
Fix #23096 : add missing ip column on tables

### DIFF
--- a/htdocs/install/mysql/tables/llx_actioncomm.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm.sql
@@ -80,6 +80,8 @@ create table llx_actioncomm
   fk_element		integer DEFAULT NULL,			-- For link to an element (proposal, invoice, order, ...)
   elementtype		varchar(255) DEFAULT NULL,		-- For link to an element (proposal, invoice, order, ...)
 
+  ip            varchar(250),              --ip used to create record (for public submission page)
+
   import_key		varchar(14),
   extraparams		varchar(255)					-- for other parameters with json format
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_eventorganization_conferenceorboothattendee.sql
+++ b/htdocs/install/mysql/tables/llx_eventorganization_conferenceorboothattendee.sql
@@ -35,6 +35,7 @@ CREATE TABLE llx_eventorganization_conferenceorboothattendee(
 	fk_user_creat integer, 
 	fk_user_modif integer, 
 	last_main_doc varchar(255), 
+	ip varchar(250),              --ip used to create record (for public submission page)
 	import_key varchar(14), 
 	model_pdf varchar(255), 
 	status smallint NOT NULL

--- a/htdocs/install/mysql/tables/llx_opensurvey_comments-opensurvey.sql
+++ b/htdocs/install/mysql/tables/llx_opensurvey_comments-opensurvey.sql
@@ -22,5 +22,6 @@ CREATE TABLE llx_opensurvey_comments (
     tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     usercomment text
     date_creation datetime NOT NULL, 
+    ip varchar(250),              --ip used to create record (for public submission page)
 ) ENGINE=innodb;
 

--- a/htdocs/install/mysql/tables/llx_opensurvey_user_studs-opensurvey.sql
+++ b/htdocs/install/mysql/tables/llx_opensurvey_user_studs-opensurvey.sql
@@ -22,4 +22,5 @@ CREATE TABLE llx_opensurvey_user_studs (
     reponses VARCHAR(200) NOT NULL,		-- Not used for 'F' surveys
     tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
     date_creation datetime NOT NULL, 
+    ip varchar(250),              --ip used to create record (for public submission page)
 ) ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_projet.sql
+++ b/htdocs/install/mysql/tables/llx_projet.sql
@@ -57,6 +57,7 @@ create table llx_projet
   price_registration    double(24,8),
   price_booth    double(24,8),
   model_pdf        varchar(255),
+  ip            varchar(250),              --ip used to create record (for public submission page)
   last_main_doc	   varchar(255),				-- relative filepath+filename of last main generated document
   import_key	   varchar(14)					-- Import key
 )ENGINE=innodb;


### PR DESCRIPTION
Add missing ip column on multiple tables, these are changed in migration from 16 to 17 but wasn't created on fresh install