### PR TITLE
FIX|Fix [#23075]

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -589,6 +589,7 @@ if ($action == 'confirm_generateinvoice') {
 				foreach ($arrayoftasks as $timespent_id => $value) {
 					$userid = $value['user'];
 					//$pu_ht = $value['timespent'] * $fuser->thm;
+					$pu_ht = $fuser->thm;
 
 					// Define qty per hour
 					$qtyhour = $value['timespent'] / 3600;


### PR DESCRIPTION
Wrong invoice unit price when billing Project task spent time

Instead of using the hourly rate for a user, the total time amount is put as a unit price