### PR TITLE
FIX: CommonObject - showOptionals - Display blank td when MAIN_VIEW_LINE_NUMBER is enabled and action is confirm_valid

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7542,7 +7542,7 @@ abstract class CommonObject
 
 						if ($display_type == 'card') {
 							$out .= '<tr '.($html_id ? 'id="'.$html_id.'" ' : '').$csstyle.' class="valuefieldcreate '.$class.$this->element.'_extras_'.$key.' trextrafields_collapse'.$extrafields_collapse_num.(!empty($this->id)?'_'.$this->id:'').'" '.$domData.' >';
-							if (!empty($conf->global->MAIN_VIEW_LINE_NUMBER) && ($action == 'view' || $action == 'valid' || $action == 'editline')) {
+							if (!empty($conf->global->MAIN_VIEW_LINE_NUMBER) && ($action == 'view' || $action == 'valid' || $action == 'editline' || $action == 'confirm_valid')) {
 								$out .= '<td></td>';
 							}
 							$out .= '<td class="wordbreak';

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7542,7 +7542,7 @@ abstract class CommonObject
 
 						if ($display_type == 'card') {
 							$out .= '<tr '.($html_id ? 'id="'.$html_id.'" ' : '').$csstyle.' class="valuefieldcreate '.$class.$this->element.'_extras_'.$key.' trextrafields_collapse'.$extrafields_collapse_num.(!empty($this->id)?'_'.$this->id:'').'" '.$domData.' >';
-							if (!empty($conf->global->MAIN_VIEW_LINE_NUMBER) && ($action == 'view' || $action == 'valid' || $action == 'editline' || $action == 'confirm_valid')) {
+							if (!empty($conf->global->MAIN_VIEW_LINE_NUMBER) && ($action == 'view' || $action == 'valid' || $action == 'editline' || $action == 'confirm_valid' || $action == 'confirm_cancel')) {
 								$out .= '<td></td>';
 							}
 							$out .= '<td class="wordbreak';


### PR DESCRIPTION
# The bug

When enabling line numbering (MAIN_VIEW_LINE_NUMBER), ``CommonObject::showOptionals`` display extra td element to ensure proper display of extrafield line:

![Screenshot 2022-12-09 at 11 41 02](https://user-images.githubusercontent.com/8199428/206685476-9eeeab0f-ab79-4177-ad2a-b96d0b2c48c8.png)

The thing is, when we confirm the expedition this extra td element is not present because of strange check done in ``CommonObject::showOptionals`` method. This result in the following output:

![Screenshot 2022-12-09 at 11 41 14](https://user-images.githubusercontent.com/8199428/206685768-e5d3c5ac-e822-4da0-9fb4-1f7ce9ecd754.png)

This strange behavior is happening because of the following line:

https://github.com/Dolibarr/dolibarr/blob/7dd0c6646de831777a4a044c515244606f0ed1c4/htdocs/core/class/commonobject.class.php#L7545

Dolibarr does not output the extra td element if the current action is not ``'view'``, ``'valid'`` or ``'editline'``. In our case, because we are validating the expedition the current action is ``'confirm_valid'``.

# The fix

To handle this bug we simply add the ``'confirm_valid'`` action to the whitelisted actions list. Therefore the output is now fixed.

One may ask himself: why do we need to check for the action here? Is there any legacy reason for it? Otherwise I would consider removing the whole $action check.