### PR TITLE
Force $action = 'create' when there's errors

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -299,6 +299,7 @@ if (empty($reshook)) {
 			}
 		} else {
 			setEventMessages($object->error, $object->errors, 'errors');
+			$action = 'create';
 		}
 	}
 


### PR DESCRIPTION
# FIX|Fix #23169 Force $action = 'create' when there's errors

In htdocs\ticket\card.php when submitting the form to create a new ticket.

```php
// Action to add an action (not a message)
if (GETPOST('add', 'alpha') && $user->rights->ticket->write) {
	$error = 0;

	if (!GETPOST("subject", 'alphanohtml')) {
		$error++;
		setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("Subject")), null, 'errors');
		$action = 'create';
	} elseif (!GETPOST("message", 'restricthtml')) {
		$error++;
		setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("Message")), null, 'errors');
		$action = 'create';
	}
```

Here we change to action = 'create' when there's an error.

```php
	$ret = $extrafields->setOptionalsFromPost(null, $object);
	if ($ret < 0)	$error++;

	if (!$error) {
		$db->begin();

		$object->ref = GETPOST("ref", 'alphanohtml');
		$object->fk_soc = GETPOST("socid", 'int') > 0 ? GETPOST("socid", 'int') : 0;
		$object->subject = GETPOST("subject", 'alphanohtml');
		$object->message = GETPOST("message", 'restricthtml');
		$object->fk_user_assign = GETPOST("fk_user_assign", 'int');

		$object->type_code = GETPOST("type_code", 'alpha');
		$object->type_label = $langs->trans($langs->getLabelFromKey($db, $object->type_code, 'c_ticket_type', 'code', 'label'));
		$object->category_code = GETPOST("category_code", 'alpha');
		$object->category_label = $langs->trans($langs->getLabelFromKey($db, $object->category_code, 'c_ticket_category', 'code', 'label'));
		$object->severity_code = GETPOST("severity_code", 'alpha');
		$object->severity_label = $langs->trans($langs->getLabelFromKey($db, $object->severity_code, 'c_ticket_severity', 'code', 'label'));
		$object->email_from = $user->email;
		$notifyTiers = GETPOST("notify_tiers_at_create", 'alpha');
		$object->notify_tiers_at_create = empty($notifyTiers) ? 0 : 1;

		$object->fk_project = GETPOST('projectid', 'int');

		$id = $object->create($user);
		if ($id <= 0) {
			$error++;
			setEventMessages($object->error, $object->errors, 'errors');
			$action = 'create';
		}

		if (!$error) {
			// Add contact
			$contactid = GETPOST('contactid', 'int');
			$type_contact = GETPOST("type", 'alpha');

			if ($contactid > 0 && $type_contact) {
				$typeid = (GETPOST('typecontact') ? GETPOST('typecontact') : GETPOST('type'));
				$result = $object->add_contact($contactid, $typeid, 'external');
			}

			// altairis: link ticket to project
			if (GETPOST('projectid') > 0) {
				$object->setProject(GETPOST('projectid'));
			}

			// Auto assign user
			if ($conf->global->TICKET_AUTO_ASSIGN_USER_CREATE) {
				// evCustom, comentado, autoassign solo nos añade como contacto
				//$result = $object->assignUser($user, $user->id, 1);
				$object->add_contact($user->id, "SUPPORTTEC", 'internal');
			}

			// Auto assign contrat
			$contractid = 0;
			if ($conf->global->TICKET_AUTO_ASSIGN_CONTRACT_CREATE) {
				$contrat = new Contrat($db);
				$contrat->socid = $object->fk_soc;
				$list = $contrat->getListOfContracts();

				if (is_array($list) && !empty($list)) {
					if (count($list) == 1) {
						$contractid = $list[0]->id;
						$object->setContract($contractid);
					} else {
					}
				}
			}

			// Auto create fiche intervention
			if ($conf->global->TICKET_AUTO_CREATE_FICHINTER_CREATE) {
				$fichinter = new Fichinter($db);
				$fichinter->socid = $object->fk_soc;
				$fichinter->fk_project = GETPOST('projectid', 'int');
				$fichinter->fk_contrat = $contractid;
				$fichinter->author = $user->id;
				$fichinter->model_pdf = 'soleil';
				$fichinter->origin = $object->element;
				$fichinter->origin_id = $object->id;

				// Extrafields
				$extrafields->fetch_name_optionals_label($fichinter->table_element);
				$array_options = $extrafields->getOptionalsFromPost($fichinter->table_element);
				$fichinter->array_options = $array_options;

				$id = $fichinter->create($user);
				if ($id <= 0) {
					setEventMessages($fichinter->error, null, 'errors');
				}
			}
		}

		if (!$error) {
			// File transfer
			$object->copyFilesForTicket();
		}

		if (!$error) {
			$db->commit();

			if (!empty($backtopage)) {
				$url = $backtopage;
			} else {
				$url = 'card.php?track_id='.$object->track_id;
			}

			header("Location: ".$url);
			exit;
		} else {
			$db->rollback();
			setEventMessages($object->error, $object->errors, 'errors');
		}
```

Here we don't, if the error is from the first block then we alrrady changed the action variable, but if the error happened in `setOptionalsFromPost` then we're still in `$action == 'add'`
```php
	} else {
		setEventMessages($object->error, $object->errors, 'errors');
		$action = 'create'; // This is missing
	}
}
```