### PR TITLE
NEW inventory without virtual products (kits)

### DIFF
--- a/htdocs/product/inventory/class/inventory.class.php
+++ b/htdocs/product/inventory/class/inventory.class.php
@@ -302,6 +302,13 @@ class Inventory extends CommonObject
 				$sql .= " AND cp.fk_categorie IN (".$this->db->sanitize($this->categories_product).")";
 				$sql .= ")";
 			}
+			if (getDolGlobalInt('PRODUIT_SOUSPRODUITS')) {
+				$sql .= " AND NOT EXISTS (";
+				$sql .= " SELECT pa.rowid";
+				$sql .= " FROM ".$this->db->prefix()."product_association as pa";
+				$sql .= " WHERE pa.fk_product_pere = ps.fk_product";
+				$sql .= ")";
+			}
 
 			$inventoryline = new InventoryLine($this->db);
 


### PR DESCRIPTION
NEW inventory without virtual products (kits)
- remove virtual products in inventory, only keep children
- it's in accordance with #21088

**Before**
When you start an inventory for a warehouse, you could have some virtual products :
- PANIER1 is a virtual product
![image](https://user-images.githubusercontent.com/45359511/206729111-29ec4717-3d7f-4a77-b72c-d60e928b3cd1.png)

- MINIPANIERGARNI is a virtual product (sub-component of PANIER1)
![image](https://user-images.githubusercontent.com/45359511/206729373-3d252cca-4523-439d-9fb3-6b7a93c2a16b.png)

And in the inventory :
![image](https://user-images.githubusercontent.com/45359511/206728604-a426e76e-13e8-4344-b2ad-3578eb0e72c4.png)


**After**
In the inventory :
![image](https://user-images.githubusercontent.com/45359511/206729565-38b64d6d-adc0-497e-845e-0096ff1918d8.png)

So we keep only final sub-components of virtual products (kits)