### PR TITLE
FIX: confusing error codes in products API

### DIFF
--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -1727,8 +1727,12 @@ class Products extends DolibarrApi
 			throw new RestException(401);
 		}
 
-		if (empty($id) || empty($features) || !is_array($features)) {
-			throw new RestException(401);
+		if (empty($id)) {
+			throw new RestException(400, 'Product ID is mandatory');
+		}
+
+		if (empty($features) || !is_array($features)) {
+			throw new RestException(400, 'Features is mandatory and should be IDs of attribute values indexed by IDs of attributes');
 		}
 
 		$weight_impact = price2num($weight_impact);
@@ -1738,10 +1742,10 @@ class Products extends DolibarrApi
 		$prodattr_val = new ProductAttributeValue($this->db);
 		foreach ($features as $id_attr => $id_value) {
 			if ($prodattr->fetch((int) $id_attr) < 0) {
-				throw new RestException(401);
+				throw new RestException(400, 'Invalid attribute ID: '.$id_attr);
 			}
 			if ($prodattr_val->fetch((int) $id_value) < 0) {
-				throw new RestException(401);
+				throw new RestException(400, 'Invalid attribute value ID: '.$id_value);
 			}
 		}
 


### PR DESCRIPTION
# FIX confusing error messages in the products API

cf. issue https://github.com/Dolibarr/dolibarr/issues/23136

The HTTP response codes can be confusing because 401 is for requests by unauthorized users. In the issue above, the user is authorized but provided wrong parameter values.


[edit] Should I move the PR up one or two versions (v14)? I did it in v16 just because it was more convenient.