### PR TITLE
FIX: Hook order execution

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -131,8 +131,10 @@ class HookManager
 			dol_syslog(get_class($this)."::initHooks Loading hooks: ".join(', ', $arraytolog), LOG_DEBUG);
 		}
 
-		if (!empty($this->hooks[$context])) {
-			ksort($this->hooks[$context], SORT_NATURAL);
+		foreach ($arraycontext as $context) {
+			if (!empty($this->hooks[$context])) {
+				ksort($this->hooks[$context], SORT_NATURAL);
+			}
 		}
 
 		return 1;


### PR DESCRIPTION
Hooks were not executed in order according to their priority because sort was not executed on each context

