### PR TITLE
NEW accountancy bank journal when deposits are just payments is enabled

### DIFF
--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2011       Juanjo Menent           <jmenent@2byte.es>
  * Copyright (C) 2012       Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2013       Christophe Battarel     <christophe.battarel@altairis.fr>
- * Copyright (C) 2013-2021  Alexandre Spangaro      <aspangaro@open-dsi.fr>
+ * Copyright (C) 2013-2022  Open-DSI      			<support@open-dsi.fr>
  * Copyright (C) 2013-2014  Florian Henry           <florian.henry@open-concept.pro>
  * Copyright (C) 2013-2014  Olivier Geffroy         <jeff@jeffinfo.com>
  * Copyright (C) 2017-2021  Frédéric France         <frederic.france@netlogic.fr>
@@ -1415,9 +1415,15 @@ function getSourceDocRef($val, $typerecord)
 
 	$sqlmid = '';
 	if ($typerecord == 'payment') {
-		$sqlmid = 'SELECT payfac.fk_facture as id, f.ref as ref';
-		$sqlmid .= " FROM ".MAIN_DB_PREFIX."paiement_facture as payfac, ".MAIN_DB_PREFIX."facture as f";
-		$sqlmid .= " WHERE payfac.fk_facture = f.rowid AND payfac.fk_paiement=".((int) $val["paymentid"]);
+		$sqlmid .= "SELECT payfac.fk_facture as id, f.ref as ref";
+		$sqlmid .= " FROM ".$db->prefix()."paiement_facture as payfac";
+		if (getDolGlobalInt('FACTURE_DEPOSITS_ARE_JUST_PAYMENTS')) {
+			$sqlmid .= " INNER JOIN ".$db->prefix()."societe_remise_except as sre ON sre.fk_facture_source = payfac.fk_facture";
+			$sqlmid .= " INNER JOIN ".$db->prefix()."facture as f ON f.rowid = sre.fk_facture";
+		} else {
+			$sqlmid .= " INNER JOIN ".$db->prefix()."facture as f ON f.rowid = payfac.fk_facture";
+		}
+		$sqlmid .= " WHERE payfac.fk_paiement=".((int) $val['paymentid']);
 		$ref = $langs->transnoentitiesnoconv("Invoice");
 	} elseif ($typerecord == 'payment_supplier') {
 		$sqlmid = 'SELECT payfac.fk_facturefourn as id, f.ref';

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -1415,15 +1415,19 @@ function getSourceDocRef($val, $typerecord)
 
 	$sqlmid = '';
 	if ($typerecord == 'payment') {
-		$sqlmid .= "SELECT payfac.fk_facture as id, f.ref as ref";
-		$sqlmid .= " FROM ".$db->prefix()."paiement_facture as payfac";
 		if (getDolGlobalInt('FACTURE_DEPOSITS_ARE_JUST_PAYMENTS')) {
-			$sqlmid .= " INNER JOIN ".$db->prefix()."societe_remise_except as sre ON sre.fk_facture_source = payfac.fk_facture";
-			$sqlmid .= " INNER JOIN ".$db->prefix()."facture as f ON f.rowid = sre.fk_facture";
+			$sqlmid = "SELECT payfac.fk_facture as id, ".$db->ifsql('f1.rowid IS NULL', 'f.ref', 'f1.ref')." as ref";
+			$sqlmid .= " FROM ".$db->prefix()."paiement_facture as payfac";
+			$sqlmid .= " LEFT JOIN ".$db->prefix()."facture as f ON f.rowid = payfac.fk_facture";
+			$sqlmid .= " LEFT JOIN ".$db->prefix()."societe_remise_except as sre ON sre.fk_facture_source = payfac.fk_facture";
+			$sqlmid .= " LEFT JOIN ".$db->prefix()."facture as f1 ON f1.rowid = sre.fk_facture";
+			$sqlmid .= " WHERE payfac.fk_paiement=".((int) $val['paymentid']);
 		} else {
+			$sqlmid = "SELECT payfac.fk_facture as id, f.ref as ref";
+			$sqlmid .= " FROM ".$db->prefix()."paiement_facture as payfac";
 			$sqlmid .= " INNER JOIN ".$db->prefix()."facture as f ON f.rowid = payfac.fk_facture";
+			$sqlmid .= " WHERE payfac.fk_paiement=".((int) $val['paymentid']);
 		}
-		$sqlmid .= " WHERE payfac.fk_paiement=".((int) $val['paymentid']);
 		$ref = $langs->transnoentitiesnoconv("Invoice");
 	} elseif ($typerecord == 'payment_supplier') {
 		$sqlmid = 'SELECT payfac.fk_facturefourn as id, f.ref';


### PR DESCRIPTION
NEW accountancy bank journal when deposits are just payments is enabled

When "FACTURE_DEPOSITS_ARE_JUST_PAYMENTS" is enabled, the label in acountancy bookeeping is concatenated with the deposit invoice reference instead of being concatenated with invoice reference (invoice where discount was applied as a payment)

Example : the invoice where the discount was applied as a payment
![image](https://user-images.githubusercontent.com/45359511/207628522-b047d5ee-2ab8-4034-986d-05711411b48f.png)

**Before**
In accountancy bookeeping :
![image](https://user-images.githubusercontent.com/45359511/207627138-6ca0be7f-fa15-4da1-9533-80618fcff50a.png)

**After**
In accountancy bookeeping :
![image](https://user-images.githubusercontent.com/45359511/207626639-e7379cbf-829c-4ff4-95eb-454b51164f52.png)
