### PR TITLE
FIX #19896

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN chown www-data:www-data /var/documents
 COPY docker-run.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-run.sh
 
-RUN pecl install xdebug && docker-php-ext-enable xdebug
+RUN pecl install xdebug-3.1.6 && docker-php-ext-enable xdebug
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20180731/xdebug.so"' >> ${PHP_INI_DIR}/php.ini
 RUN echo 'xdebug.mode=debug' >> ${PHP_INI_DIR}/php.ini
 RUN echo 'xdebug.start_with_request=yes' >> ${PHP_INI_DIR}/php.ini


### PR DESCRIPTION
La dernière version de xdebug sortie jeudi dernier n'est plus compatible avec php 7.3 pour cause de faille de sécurité il est plus que supporter par php 8.
C'est fixer dans la PR . Avec l'utilisation de docker en PHP7 j'ai forcer la version XDebug version 3.1.6
![image](https://user-images.githubusercontent.com/71641704/208679891-daf00ad3-e3c5-480c-ad8e-ac36c128f54c.png)

