### PR TITLE
Fix v17 White bg-color for chart and badge in darkmode

### DIFF
--- a/htdocs/core/class/dolgraph.class.php
+++ b/htdocs/core/class/dolgraph.class.php
@@ -1211,7 +1211,7 @@ class DolGraph
 					$tmp = str_replace('#', '', $this->datacolor[$i]);
 					if (strpos($tmp, '-') !== false) {
 						$foundnegativecolor++;
-						$color = '#FFFFFF'; // If $val is '-123'
+						$color = 'rgba(0,0,0,.0)'; // If $val is '-123'
 					} else {
 						$color = "#" . $tmp; // If $val is '123' or '#123'
 					}

--- a/htdocs/theme/eldy/badges.inc.php
+++ b/htdocs/theme/eldy/badges.inc.php
@@ -246,7 +246,7 @@ function _createStatusBadgeCss($statusName, $statusVarNamePrefix = '', $commentL
 
 		if (in_array((string) $statusName, $TBadgeBorderOnly)) {
 			$thisBadgeTextColor = '#212529';
-			$thisBadgeBackgroundColor = "#fff";
+			$thisBadgeBackgroundColor = "";
 		}
 
 		if (in_array((string) $statusName, array('0', '5', '9'))) {


### PR DESCRIPTION
use transparency instead of white background

Befor PR
![image](https://user-images.githubusercontent.com/8067223/209001727-8e4b2ef7-5275-4a85-98b2-a8d57a1650fd.png)


After PR
![image](https://user-images.githubusercontent.com/8067223/209001575-5a91d667-e2e3-4f61-b8d8-a642a6659651.png)
