### PR TITLE
Add juridic form SARL-S for Luxembourg

### DIFF
--- a/htdocs/install/mysql/data/llx_c_forme_juridique.sql
+++ b/htdocs/install/mysql/data/llx_c_forme_juridique.sql
@@ -332,6 +332,7 @@ INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (140, 
 INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (140, '14006', 'Société anonyme (SA)', 1);
 INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (140, '14007', 'Société coopérative (SC)', 1);
 INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (140, '14008', 'Société européenne (SE)', 1);
+INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (140, '14009', 'Société à responsabilité limitée simplifiée (SARL-S)', 1);
 
 -- Romania
 INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (188, '18801', 'AFJ - Alte forme juridice', 1);


### PR DESCRIPTION
# NEW Add juridic form SARL-S for Luxembourg
The simplified limited liability company (Société à responsabilité limitée simplifiée – SARL-S) is a form of commercial company that is subject to rules that are somewhat different to those that apply to a conventional private limited liability company (Société à responsabilité limitée – SARL).

La société à responsabilité limitée simplifiée (SARL-S) est une forme de société commerciale qui déroge à certaines règles propres à la société à responsabilité limitée (SARL) classique.

https://guichet.public.lu/fr/entreprises/creation-developpement/forme-juridique/societe-capitaux/sarl-s.html
