### PR TITLE
FIX: Show supplier product reference input field

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -1148,7 +1148,7 @@ if (!empty($usemargins) && $user->rights->margins->creer) {
 			jQuery("#multicurrency_price_ttc").val('').hide();
 			jQuery("#title_up_ttc, #title_up_ttc_currency").hide();
 		<?php } ?>
-		jQuery("#fourn_ref, #tva_tx, #title_vat").hide();
+		jQuery("#tva_tx, #title_vat").hide();
 		/* jQuery("#title_fourn_ref").hide(); */
 		jQuery("#np_marginRate, #np_markRate, .np_marginRate, .np_markRate, #units, #title_units").hide();
 		jQuery("#buying_price").show();


### PR DESCRIPTION
The title of ref_fournis is displayed but not the input field

Here you have disabled the show of the title but not of the input field

 /* jQuery("#title_fourn_ref").hide(); */

