### PR TITLE
Add a substitution Category Of Operations into ODT generation for Invoices

### DIFF
--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -343,7 +343,6 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				$nbProduct = 0;
 				$nbService = 0;
 				foreach ($object->lines as $line) {
-					
 					// determine category of operation
 					if ($categoryOfOperation < 2) {
 						$lineProductType = $line->product_type;

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -338,6 +338,35 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 
 				$propal_object = $object->linkedObjects['propal'][0];
 
+				// and determine category of operation
+				$categoryOfOperation = 0;
+				$nbProduct = 0;
+				$nbService = 0;
+				foreach ($object->lines as $line) {
+					
+					// determine category of operation
+					if ($categoryOfOperation < 2) {
+						$lineProductType = $line->product_type;
+						if ($lineProductType == Product::TYPE_PRODUCT) {
+							$nbProduct++;
+						} elseif ($lineProductType == Product::TYPE_SERVICE) {
+							$nbService++;
+						}
+						if ($nbProduct > 0 && $nbService > 0) {
+							// mixed products and services
+							$categoryOfOperation = 2;
+						}
+					}
+				}
+
+				// determine category of operation
+				if ($categoryOfOperation <= 0) {
+					// only services
+					if ($nbProduct == 0 && $nbService > 0) {
+						$categoryOfOperation = 1;
+					}
+				}
+
 				// Make substitution
 				$substitutionarray = array(
 				'__FROM_NAME__' => $this->emetteur->name,
@@ -420,6 +449,7 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				$tmparray['object_PREVIOUS_YEAR'] = dol_print_date(dol_time_plus_duree($this->date, -1, 'y'), '%Y');
 				$tmparray['object_YEAR'] = dol_print_date($this->date, '%Y');
 				$tmparray['object_NEXT_YEAR'] = dol_print_date(dol_time_plus_duree($this->date, 1, 'y'), '%Y');
+				$tmparray['object_category_operation'] = $outputlangs->transnoentities("MentionCategoryOfOperations" . $categoryOfOperation);
 
 				// Call the ODTSubstitution hook
 				$parameters = array('odfHandler'=>&$odfHandler, 'file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs, 'substitutionarray'=>&$tmparray);


### PR DESCRIPTION
I saw recently this PR : https://github.com/Dolibarr/dolibarr/pull/23242
I tested it and it worked great for crabe and sponge PDF models. 
For my personnal Dolibarr i use for Invoices an ODT Template. 

This is my first PR in Dolibarr and i am not really a Dev, so i don't know if the things i wrote are OKAY or totally Awkward. 
I tested this modification on my own test instance and it worked. 

Hope this PR can be review or improved.

I just add a substitution string {object_category_operation} 