### PR TITLE
correction bug sur le filtre des langues module Emailing

### DIFF
--- a/htdocs/core/modules/mailings/contacts1.modules.php
+++ b/htdocs/core/modules/mailings/contacts1.modules.php
@@ -122,7 +122,7 @@ class mailing_contacts1 extends MailingTargets
 	 */
 	public function formFilter()
 	{
-		global $langs;
+		global $langs,$conf;
 
 		// Load translation files required by the page
 		$langs->loadLangs(array("commercial", "companies", "suppliers", "categories"));
@@ -307,11 +307,15 @@ class mailing_contacts1 extends MailingTargets
 
 		$s .= ajax_combobox("filter_category_supplier_contact");
 
-		// Choose language
-		require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
-		$formadmin = new FormAdmin($this->db);
-		$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
-		$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang', 0, 0, 1, 0, 0, '', 0, 0, 0, null, 1);
+		// Choose language if multilangue active
+
+		if (@$conf->global->MAIN_MULTILANGS==1)
+		{
+			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
+			$formadmin = new FormAdmin($this->db);
+			$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
+			$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang', 0, 0, 1, 0, 0, '', 0, 0, 0, null, 1);
+		}
 
 		return $s;
 	}
@@ -409,7 +413,7 @@ class mailing_contacts1 extends MailingTargets
 
 		// Filter on language
 		if (!empty($filter_lang)) {
-			$sql .= " AND sp.default_lang = '".$this->db->escape($filter_lang)."'";
+			$sql .= " AND sp.default_lang LIKE '".$this->db->escape($filter_lang)."%'";
 		}
 
 		// Filter on nature

--- a/htdocs/core/modules/mailings/contacts1.modules.php
+++ b/htdocs/core/modules/mailings/contacts1.modules.php
@@ -309,8 +309,7 @@ class mailing_contacts1 extends MailingTargets
 
 		// Choose language if multilangue active
 
-		if (@$conf->global->MAIN_MULTILANGS==1)
-		{
+		if (@$conf->global->MAIN_MULTILANGS==1) {
 			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
 			$formadmin = new FormAdmin($this->db);
 			$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';

--- a/htdocs/core/modules/mailings/thirdparties.modules.php
+++ b/htdocs/core/modules/mailings/thirdparties.modules.php
@@ -316,12 +316,14 @@ class mailing_thirdparties extends MailingTargets
 		$s .= '</select>';
 		$s .= ajax_combobox("filter_status_thirdparties");
 
-		// Choose language
-		require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
-		$formadmin = new FormAdmin($this->db);
-		$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
-		$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang_thirdparties', 0, null, 1, 0, 0, '', 0, 0, 0, null, 1);
-
+		// Choose language if multilangue active
+		if (@$conf->global->MAIN_MULTILANGS==1)
+		{
+			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
+			$formadmin = new FormAdmin($this->db);
+			$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
+			$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang_thirdparties', 0, null, 1, 0, 0, '', 0, 0, 0, null, 1);
+		}
 		return $s;
 	}
 

--- a/htdocs/core/modules/mailings/thirdparties.modules.php
+++ b/htdocs/core/modules/mailings/thirdparties.modules.php
@@ -317,8 +317,7 @@ class mailing_thirdparties extends MailingTargets
 		$s .= ajax_combobox("filter_status_thirdparties");
 
 		// Choose language if multilangue active
-		if (@$conf->global->MAIN_MULTILANGS==1)
-		{
+		if (@$conf->global->MAIN_MULTILANGS==1) {
 			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
 			$formadmin = new FormAdmin($this->db);
 			$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';

--- a/htdocs/user/param_ihm.php
+++ b/htdocs/user/param_ihm.php
@@ -183,32 +183,43 @@ llxHeader();
 
 // List of possible landing pages
 $tmparray = array('index.php'=>'Dashboard');
-if (!empty($conf->societe->enabled)) {
-	$tmparray['societe/index.php?mainmenu=companies&leftmenu='] = 'ThirdPartiesArea';
-}
-if (!empty($conf->project->enabled)) {
-	$tmparray['projet/index.php?mainmenu=project&leftmenu='] = 'ProjectsArea';
-}
-if (!empty($conf->holiday->enabled) || !empty($conf->expensereport->enabled)) {
-	$tmparray['hrm/index.php?mainmenu=hrm&leftmenu='] = 'HRMArea'; // TODO Complete list with first level of menus
-}
-if (!empty($conf->product->enabled) || !empty($conf->service->enabled)) {
-	$tmparray['product/index.php?mainmenu=products&leftmenu='] = 'ProductsAndServicesArea';
-}
-if (!empty($conf->propal->enabled) || !empty($conf->commande->enabled) || !empty($conf->ficheinter->enabled) || !empty($conf->contrat->enabled)) {
-	$tmparray['comm/index.php?mainmenu=commercial&leftmenu='] = 'CommercialArea';
-}
-if (!empty($conf->comptabilite->enabled) || !empty($conf->accounting->enabled)) {
-	$tmparray['compta/index.php?mainmenu=compta&leftmenu='] = 'AccountancyTreasuryArea';
-}
-if (!empty($conf->adherent->enabled)) {
-	$tmparray['adherents/index.php?mainmenu=members&leftmenu='] = 'MembersArea';
-}
-if (isModEnabled('agenda')) {
-	$tmparray['comm/action/index.php?mainmenu=agenda&leftmenu='] = 'Agenda';
-}
-if (!empty($conf->ticket->enabled)) {
-	$tmparray['ticket/list.php?mainmenu=ticket&leftmenu='] = 'Tickets';
+
+// List of translation item correspondance for core modules titles
+$correspondance=array(
+	'agenda'=>'Agenda',
+	'ticket'=>'Tickets',
+	'societe'=>'ThirdPartiesArea',
+	'projet'=>'ProjectsArea',
+	'hrm'=>'HRMArea',
+	'product'=>'ProductsAndServicesArea',
+	'comm'=>'CommercialArea',
+	'compta'=>'AccountancyTreasuryArea',
+	'knowledgemanagement'=>'KnowledgeManagementArea',
+	'opensurvey'=>'OpenSurveyArea'
+);
+
+// Generate list of possible landing pages from database
+$resql=$db->query("SELECT * FROM `".MAIN_DB_PREFIX."menu`");
+if ($resql)
+{
+	while ($el=$db->fetch_object($resql))
+	{
+		eval("\$enabled={$el->enabled};");
+		eval("\$perms={$el->perms};");
+		if ($perms===1 && $enabled===true) {
+			$linkchar=(strpos($el->url,"?")===false)?"?":"&";
+			$url=$el->url.$linkchar."mainmenu={$el->mainmenu}&leftmenu={$el->leftmenu}";
+			if (substr($url,0,1)=="/") {
+				$url=substr($url,1,-1);
+			}
+			if (isset($correspondance[$el->module])) {
+				$tmparray[$url]=$langs->trans($correspondance[$el->module])." - ".$langs->trans($el->titre);
+			}
+			else {
+				$tmparray[$url]=$langs->trans("Module".ucfirst($el->module)."Name")." - ".$langs->trans($el->titre);
+			}
+		}
+	}
 }
 
 $head = user_prepare_head($object);


### PR DESCRIPTION
correction bug sur le filtre des langues pour l'ajout aux liste d'emailing. Lorsque 'Activer la prise en charge multilingue pour la relation client ou fournisseur' était désactivé, le champ langue des contacts et des tiers est egal à NULL et ne correspond jamais au filtre de langue (le filtre de langue est donc maintenant désactivé dans les deux modules contacts1 et thirdparties). Lorsque le multilangue est activé, la selection de la langue Française est en format court 'fr' dans le filtre, alors que dans le tiers ou le contact elle est en format long fr_FR (la requêtes SQL a été modifié avec un like '$filtre%' afin de pouvoir renvoyer des résultats)

Fix #23299 
Fix #23238 