### PR TITLE
Fix: REST MO API - It's able to have a wrong value on the 'ref' Field

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -277,6 +277,7 @@ class Mo extends CommonObject
 
 		if ($this->fk_bom > 0) {
 			// If there is a nown BOM, we force the type of MO to the type of BOM
+			include_once DOL_DOCUMENT_ROOT.'/bom/class/bom.class.php';
 			$tmpbom = new BOM($this->db);
 			$tmpbom->fetch($this->fk_bom);
 


### PR DESCRIPTION
It's able to have a wrong value on the 'ref' Field by adding or updating a MO.
Additional a small bug: if fk_bom is set the class is not loading in the mo.class.

Same problem as then #23415 by the BOM API