### PR TITLE
FIX hide details option in supplier order PDF model

### DIFF
--- a/htdocs/core/modules/supplier_order/doc/pdf_muscadet.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/pdf_muscadet.modules.php
@@ -567,7 +567,7 @@ class pdf_muscadet extends ModelePDFSuppliersOrders
 
 					// Total HT line
 					if (empty($conf->global->MAIN_GENERATE_DOCUMENTS_PURCHASE_ORDER_WITHOUT_TOTAL_COLUMN)) {
-						$total_excl_tax = pdf_getlinetotalexcltax($object, $i, $outputlangs);
+						$total_excl_tax = pdf_getlinetotalexcltax($object, $i, $outputlangs, $hidedetails);
 						$pdf->SetXY($this->postotalht, $curY);
 						$pdf->MultiCell($this->page_largeur - $this->marge_droite - $this->postotalht, 3, $total_excl_tax, 0, 'R', 0);
 					}


### PR DESCRIPTION
FIX hide details option in supplier order PDF model
- when PDF option "Hide details" was enabled 
![image](https://user-images.githubusercontent.com/45359511/211313463-916eceee-d037-40b8-b085-68541b55e4bb.png)
- the column "Total HT" with the amount was shown in supplier order

**Before**
![image](https://user-images.githubusercontent.com/45359511/211313983-f10356dd-9c2d-4394-aaf2-f1d5997d89b3.png)

**After**
![image](https://user-images.githubusercontent.com/45359511/211314117-2813d7fb-3c56-4edf-865e-78d2e1003bd8.png)