### PR TITLE
fix: reminder type label on Actioncomm Card

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -2213,7 +2213,7 @@ if ($id > 0) {
 				$tmpuserstatic = new User($db);
 
 				foreach ($object->reminders as $actioncommreminderid => $actioncommreminder) {
-					print $TRemindTypes[$actioncommreminder->typeremind];
+					print $TRemindTypes[$actioncommreminder->typeremind]['label'];
 					if ($actioncommreminder->fk_user > 0) {
 						$tmpuserstatic->fetch($actioncommreminder->fk_user);
 						print ' ('.$tmpuserstatic->getNomUrl(0, '', 0, 0, 16).')';


### PR DESCRIPTION
On Reminders field the labels "Array(SuperAdmin)  Array(SuperAdmin)"

Before
![image](https://user-images.githubusercontent.com/1050053/211336940-b824b04a-dc99-40b9-a981-8ba3d675e14f.png)



On Reminders field the labels "Email(SuperAdmin)  Notification par PopUp(SuperAdmin)"
After : 
![image](https://user-images.githubusercontent.com/1050053/211336827-56106d2c-41ac-40a9-839a-002c13b3f4fd.png)
