### PR TITLE
FIX 15.0 missing transactions / triggers

### DIFF
--- a/htdocs/societe/paymentmodes.php
+++ b/htdocs/societe/paymentmodes.php
@@ -167,8 +167,10 @@ if (empty($reshook)) {
 			}
 
 			$result = $companybankaccount->update($user);
-			if (!$result) {
+			if ($result <= 0) {
+				// Display error message and get back to edit mode
 				setEventMessages($companybankaccount->error, $companybankaccount->errors, 'errors');
+				$action = 'edit';
 			} else {
 				// If this account is the default bank account, we disable others
 				if ($companybankaccount->default_rib) {


### PR DESCRIPTION
- missing sql transaction and trigger in CompanyBankAccount::update()
- missing sql transaction in CompanyBankAccount::create()
- missing override of fields `element` and `table_element` (the values inherited from Account are misleading)

Note: after adding the transaction in `create()`, I did not remove the transactions already present in the processing of action `add` in `paymentmodes.php` because a failure to set the UMR number (line 310) should also roll back the creation.

I did not analyze deeply enough, but maybe a next step would be to set the UMR directly in the `create()` method so that third party bank information created from elsewhere (API etc.) would also benefit from the automatic UMR number ?