### PR TITLE
Fix supplier reccurent invoice if no pdf model

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1331,7 +1331,7 @@ class FactureFournisseurRec extends CommonInvoice
 						// We refresh the object in order to have all necessary data (like date_lim_reglement)
 						$new_fac_fourn->fetch($new_fac_fourn->id);
 						$result = $new_fac_fourn->generateDocument($facturerec->model_pdf, $langs);
-						if ($result <= 0) {
+						if ($result < 0) {
 							$this->errors = $new_fac_fourn->errors;
 							$this->error = $new_fac_fourn->error;
 							$error++;


### PR DESCRIPTION
On recurrent supplier invoices, if no pdf model is active, the generateDocument returns 0 ("For supplier invoice, we allow to disable all PDF generation"), so the result test was wrong