### PR TITLE
FIX 14.0: move splitting of module:submodule string out of condition

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -463,6 +463,15 @@ class FormFile
 			$titletoshow = ($title == 'none' ? '' : $title);
 		}
 
+		$submodulepart = $modulepart;
+
+		// modulepart = 'nameofmodule' or 'nameofmodule:NameOfObject'
+		$tmp = explode(':', $modulepart);
+		if (!empty($tmp[1])) {
+			$modulepart = $tmp[0];
+			$submodulepart = $tmp[1];
+		}
+
 		// Show table
 		if ($genallowed) {
 			$modellist = array();
@@ -662,15 +671,6 @@ class FormFile
 					$modellist = ModelePDFUserGroup::liste_modeles($this->db);
 				}
 			} else {
-				$submodulepart = $modulepart;
-
-				// modulepart = 'nameofmodule' or 'nameofmodule:NameOfObject'
-				$tmp = explode(':', $modulepart);
-				if (!empty($tmp[1])) {
-					$modulepart = $tmp[0];
-					$submodulepart = $tmp[1];
-				}
-
 				// For normalized standard modules
 				$file = dol_buildpath('/core/modules/'.$modulepart.'/modules_'.strtolower($submodulepart).'.php', 0);
 				if (file_exists($file)) {


### PR DESCRIPTION
## Rationale
Currently, `showdocuments` can be used with external modules by specifying a submodule name in `$modulepart`.

Example : suppose we have a module named "carmanagement" with several objects, among which "driverslicense" for which we can generate a PDF. To show the generated PDF files, we can call:
```php
$genallowed = 1;
$delallowed = 1;
$dir = $conf->carmanagement->dir_output . '/dl';
$subdir = $object->ref;
$formfile->showdocuments('carmanagement:driverslicense', $subdir, $dir, $urlsource, $genallowed, $delallowed, $object->modelpdf);
```

Based on this, Dolibarr will automatically include the class file `carmanagement/core/modules/carmanagement/modules_driverslicense.php`. The links to the PDF files will also be correct.

So far so good.

But if you set `$genallowed` to 0 instead of 1, the links to download the PDF files will no longer be correct because the submodule name will not have been separated from the `$modulepart` variable.

When a user clicks on a link, they will see an error message like:

> Error call dol_check_secure_access_document with not supported value for modulepart parameter (carmanagement:driverslicense)

because the URL of the link will contain `carmanagement:driverslicense` instead of just `carmanagement`.

## This PR

I moved up the splitting of `$modulepart` so that it no longer depends on `genallowed` and it seems to do the trick in my (limited) tests.