### PR TITLE
correction bug sur le filtre des langues module Emailing

### DIFF
--- a/htdocs/core/modules/mailings/contacts1.modules.php
+++ b/htdocs/core/modules/mailings/contacts1.modules.php
@@ -122,7 +122,7 @@ class mailing_contacts1 extends MailingTargets
 	 */
 	public function formFilter()
 	{
-		global $langs;
+		global $langs,$conf;
 
 		// Load translation files required by the page
 		$langs->loadLangs(array("commercial", "companies", "suppliers", "categories"));
@@ -307,11 +307,14 @@ class mailing_contacts1 extends MailingTargets
 
 		$s .= ajax_combobox("filter_category_supplier_contact");
 
-		// Choose language
-		require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
-		$formadmin = new FormAdmin($this->db);
-		$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
-		$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang', 0, 0, 1, 0, 0, '', 0, 0, 0, null, 1);
+		// Choose language if multilangue active
+
+		if (@$conf->global->MAIN_MULTILANGS==1) {
+			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
+			$formadmin = new FormAdmin($this->db);
+			$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
+			$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang', 0, 0, 1, 0, 0, '', 0, 0, 0, null, 1);
+		}
 
 		return $s;
 	}
@@ -409,7 +412,7 @@ class mailing_contacts1 extends MailingTargets
 
 		// Filter on language
 		if (!empty($filter_lang)) {
-			$sql .= " AND sp.default_lang = '".$this->db->escape($filter_lang)."'";
+			$sql .= " AND sp.default_lang LIKE '".$this->db->escape($filter_lang)."%'";
 		}
 
 		// Filter on nature

--- a/htdocs/core/modules/mailings/thirdparties.modules.php
+++ b/htdocs/core/modules/mailings/thirdparties.modules.php
@@ -316,12 +316,13 @@ class mailing_thirdparties extends MailingTargets
 		$s .= '</select>';
 		$s .= ajax_combobox("filter_status_thirdparties");
 
-		// Choose language
-		require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
-		$formadmin = new FormAdmin($this->db);
-		$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
-		$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang_thirdparties', 0, null, 1, 0, 0, '', 0, 0, 0, null, 1);
-
+		// Choose language if multilangue active
+		if (@$conf->global->MAIN_MULTILANGS==1) {
+			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
+			$formadmin = new FormAdmin($this->db);
+			$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
+			$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang_thirdparties', 0, null, 1, 0, 0, '', 0, 0, 0, null, 1);
+		}
 		return $s;
 	}
 


### PR DESCRIPTION
Fix #23299 #Emailing to customers using filter langue select no contact
Fix #23238 #Emailing to customers using filter langue select no contact

correction bug sur le filtre des langues pour l'ajout aux liste d'emailing. Lorsque 'Activer la prise en charge multilingue pour la relation client ou fournisseur' était désactivé, le champ langue des contacts et des tiers est egal à NULL et ne correspond jamais au filtre de langue (le filtre de langue est donc maintenant désactivé dans les deux modules contacts1 et thirdparties). Lorsque le multilangue est activé, la selection de la langue Française est en format court 'fr' dans le filtre, alors que dans le tiers ou le contact elle est en format long fr_FR (la requêtes SQL a été modifié avec un like '$filtre%' afin de pouvoir renvoyer des résultats)