### PR TITLE
correction bug selection contact dans emailing

### DIFF
--- a/htdocs/core/modules/mailings/contacts1.modules.php
+++ b/htdocs/core/modules/mailings/contacts1.modules.php
@@ -122,7 +122,7 @@ class mailing_contacts1 extends MailingTargets
 	 */
 	public function formFilter()
 	{
-		global $langs;
+		global $langs,$conf;
 
 		// Load translation files required by the page
 		$langs->loadLangs(array("commercial", "companies", "suppliers", "categories"));
@@ -308,11 +308,12 @@ class mailing_contacts1 extends MailingTargets
 		$s .= ajax_combobox("filter_category_supplier_contact");
 
 		// Choose language
-		require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
-		$formadmin = new FormAdmin($this->db);
-		$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
-		$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang', 0, 0, 1, 0, 0, '', 0, 0, 0, null, 1);
-
+		if (getDolGlobalInt('MAIN_MULTILANGS')) {
+			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
+			$formadmin = new FormAdmin($this->db);
+			$s .= '<span class="opacitymedium">'.$langs->trans("DefaultLang").':</span> ';
+			$s .= $formadmin->select_language($langs->getDefaultLang(1), 'filter_lang', 0, 0, 1, 0, 0, '', 0, 0, 0, null, 1);
+		}
 		return $s;
 	}
 


### PR DESCRIPTION
Fix #23299 #Emailing to customers using filter langue select no contact
Fix #23238 #Emailing to customers using filter langue select no contact

correction bug sur le filtre des langues pour l'ajout aux liste d'emailing. Lorsque 'Activer la prise en charge multilingue pour la relation client ou fournisseur' était désactivé, le champ langue des contacts et des tiers est egal à NULL et ne correspond jamais au filtre de langue (le filtre de langue est donc maintenant désactivé dans les deux modules contacts1). Lorsque le multilangue est activé, la selection de la langue Française est en format court 'fr' dans le filtre, alors que dans le tiers ou le contact elle est en format long fr_FR (la requêtes SQL a été modifié avec un like '$filtre%' afin de pouvoir renvoyer des résultats)
