### PR TITLE
FIX: do not let closed inventories reset stock with URL

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -118,7 +118,7 @@ if (empty($reshook)) {
 	}
 
 	// Close inventory by recording the stock movements
-	if ($action == 'update' && !empty($user->rights->stock->mouvement->creer)) {
+	if ($action == 'update' && !empty($user->rights->stock->mouvement->creer) && $object->status == $object::STATUS_VALIDATED) {
 		$stockmovment = new MouvementStock($db);
 		$stockmovment->setOrigin($object->element, $object->id);
 


### PR DESCRIPTION
# FIX: do not let closed inventories reset stock with URL 
The url `/product/inventory/inventory.php?id=4&action=update&confirm=yes&token=token` in Dolibarr, which is the resulting URL when we click the “Generate movements and close” button does regenerate the stock movements, even if we already closed the inventory, resulting in a mess in stocks.
This adds a minimal control on the inventory’s status, forbidding any action to be taken if we do not have a validated status, which is the status from which the button is active.