### PR TITLE
This corrects issue #22731. 

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_title.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_title.tpl.php
@@ -22,7 +22,7 @@ if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table
 
 		foreach ($extrafields->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
 			if (!empty($arrayfields[$extrafieldsobjectprefix.$key]['checked'])) {
-				$cssclass = $extrafields->getAlignFlag($key, $extrafieldsobjectkey);
+				$align = $extrafields->getAlignFlag($key);
 				$sortonfield = $extrafieldsobjectprefix.$key;
 				if (!empty($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key])) {
 					$sortonfield = '';
@@ -36,10 +36,7 @@ if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table
 
 					$tooltip = empty($extrafields->attributes[$extrafieldsobjectkey]['help'][$key]) ? '' : $extrafields->attributes[$extrafieldsobjectkey]['help'][$key];
 
-					print getTitleFieldOfList($extrafields->attributes[$extrafieldsobjectkey]['label'][$key], 0, $_SERVER["PHP_SELF"], $sortonfield, "", $param, ($cssclass ? 'class="'.$cssclass.'" data-titlekey="'.$key.'"' : 'data-titlekey="'.$key.'"'), $sortfield, $sortorder, '', $disablesortlink, $tooltip)."\n";
-					if (isset($totalarray) && isset($totalarray['nbfield'])) {
-						$totalarray['nbfield']++;
-					}
+					print getTitleFieldOfList($extrafields->attributes[$extrafieldsobjectkey]['label'][$key], 0, $_SERVER["PHP_SELF"], $sortonfield, "", $param, ($align ? 'align="'.$align.'" data-titlekey="'.$key.'"' : 'data-titlekey="'.$key.'"'), $sortfield, $sortorder, '', $disablesortlink, $tooltip)."\n";
 				}
 			}
 		}


### PR DESCRIPTION
# Fix #22731: Totals no longer align
The line of totals in the proposition or order lists no longer aligns when extra attributes are present as reported in #22731.
