### PR TITLE
Fix: Crash in mo_list.php - missing BOM class file.

### DIFF
--- a/htdocs/mrp/mo_list.php
+++ b/htdocs/mrp/mo_list.php
@@ -27,6 +27,7 @@ require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/bom/class/bom.class.php';
 
 // load mrp libraries
 require_once __DIR__.'/class/mo.class.php';


### PR DESCRIPTION
After the kanban the list is crashing.

This new line needs to load the bom class file.
https://github.com/Dolibarr/dolibarr/blob/2d2164550f2744d15ba8a757f532414868edc727/htdocs/mrp/mo_list.php#L594