### PR TITLE
Set MAIN_DO_NOT_SANITIZE_PRODUCT_REF to not sanitize product ref and label on database entry (storage).

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -472,7 +472,7 @@ function GETPOSTISARRAY($paramname, $method = 0)
  *                               'aZ'=check it's a-z only
  *                               'aZ09'=check it's simple alpha string (recommended for keys)
  *                               'san_alpha'=Use filter_var with FILTER_SANITIZE_STRING (do not use this for free text string)
- *                               'nohtml'=check there is no html content and no " and no ../
+ *                               'nohtml'=check there is no html content
  *                               'restricthtml'=check html content is restricted to some tags only
  *                               'custom'= custom filter specify $filter and $options)
  *  @param	int		$method	     Type of method (0 = get then post, 1 = only get, 2 = only post, 3 = post then get)

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -365,7 +365,7 @@ if (empty($reshook)) {
 					}
 				} else {
 					// batch mode
-					if ($batch_line[$i]['qty'] > 0) {
+					if ($batch_line[$i]['qty'] > 0 || ($batch_line[$i]['qty'] == 0 && $conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS)) {
 						$ret = $object->addline_batch($batch_line[$i], $array_options[$i]);
 						if ($ret < 0) {
 							setEventMessages($object->error, $object->errors, 'errors');

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -994,11 +994,11 @@ class Expedition extends CommonObject
 		global $conf, $langs;
 
 		$num = count($this->lines);
-		if ($dbatch['qty'] > 0) {
+		if ($dbatch['qty'] > 0 || ($dbatch['qty'] == 0 && $conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS)) {
 			$line = new ExpeditionLigne($this->db);
 			$tab = array();
 			foreach ($dbatch['detail'] as $key => $value) {
-				if ($value['q'] > 0) {
+				if ($value['q'] > 0 || ($value['q']  == 0 && $conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS)) {
 					// $value['q']=qty to move
 					// $value['id_batch']=id into llx_product_batch of record to move
 					//var_dump($value);
@@ -1010,7 +1010,10 @@ class Expedition extends CommonObject
 						return -1;
 					}
 					$linebatch->qty = $value['q'];
-					$tab[] = $linebatch;
+                    if ($linebatch->qty == 0 && $conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS) {
+                        $linebatch->batch = null;
+                    }
+                    $tab[] = $linebatch;
 
 					if ($conf->global->STOCK_MUST_BE_ENOUGH_FOR_SHIPMENT) {
 						require_once DOL_DOCUMENT_ROOT.'/product/class/productbatch.class.php';

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1010,10 +1010,10 @@ class Expedition extends CommonObject
 						return -1;
 					}
 					$linebatch->qty = $value['q'];
-                    if ($linebatch->qty == 0 && $conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS) {
-                        $linebatch->batch = null;
-                    }
-                    $tab[] = $linebatch;
+					if ($linebatch->qty == 0 && $conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS) {
+						$linebatch->batch = null;
+					}
+					$tab[] = $linebatch;
 
 					if ($conf->global->STOCK_MUST_BE_ENOUGH_FOR_SHIPMENT) {
 						require_once DOL_DOCUMENT_ROOT.'/product/class/productbatch.class.php';

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -88,7 +88,11 @@ $mesg = ''; $error = 0; $errors = array();
 $refalreadyexists = 0;
 
 $id = GETPOST('id', 'int');
-$ref = (GETPOSTISSET('ref') ? GETPOST('ref', 'alpha') : null);
+if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
+	$ref = (GETPOSTISSET('ref') ? GETPOST('ref', 'nohtml') : null);
+} else {
+	$ref = (GETPOSTISSET('ref') ? GETPOST('ref', 'alpha') : null);
+}
 $type = (GETPOSTISSET('type') ? GETPOST('type', 'int') : Product::TYPE_PRODUCT);
 $action = (GETPOST('action', 'alpha') ? GETPOST('action', 'alpha') : 'view');
 $cancel = GETPOST('cancel', 'alpha');
@@ -107,7 +111,11 @@ $accountancy_code_buy_export = GETPOST('accountancy_code_buy_export', 'alpha');
 
 $checkmandatory = GETPOST('accountancy_code_buy_export', 'alpha');
 // by default 'alphanohtml' (better security); hidden conf MAIN_SECURITY_ALLOW_UNSECURED_LABELS_WITH_HTML allows basic html
-$label_security_check = empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_LABELS_WITH_HTML) ? 'alphanohtml' : 'restricthtml';
+if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
+	$label_security_check = empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_LABELS_WITH_HTML) ? 'nohtml' : 'restricthtml';
+} else {
+	$label_security_check = empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_LABELS_WITH_HTML) ? 'alphanohtml' : 'restricthtml';
+}
 
 if (!empty($user->socid)) {
 	$socid = $user->socid;

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -88,7 +88,7 @@ $mesg = ''; $error = 0; $errors = array();
 $refalreadyexists = 0;
 
 $id = GETPOST('id', 'int');
-if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
+if (!empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_REF_LABELS)) {
 	$ref = (GETPOSTISSET('ref') ? GETPOST('ref', 'nohtml') : null);
 } else {
 	$ref = (GETPOSTISSET('ref') ? GETPOST('ref', 'alpha') : null);
@@ -111,8 +111,8 @@ $accountancy_code_buy_export = GETPOST('accountancy_code_buy_export', 'alpha');
 
 $checkmandatory = GETPOST('accountancy_code_buy_export', 'alpha');
 // by default 'alphanohtml' (better security); hidden conf MAIN_SECURITY_ALLOW_UNSECURED_LABELS_WITH_HTML allows basic html
-if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
-	$label_security_check = empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_LABELS_WITH_HTML) ? 'nohtml' : 'restricthtml';
+if (!empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_REF_LABELS)) {
+	$label_security_check = 'nohtml';
 } else {
 	$label_security_check = empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_LABELS_WITH_HTML) ? 'alphanohtml' : 'restricthtml';
 }

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -532,7 +532,7 @@ class Product extends CommonObject
 	{
 		global $conf;
 
-		if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
+		if (!empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_REF_LABELS)) {
 			$this->ref = trim($this->ref);
 		} else {
 			$this->ref = dol_sanitizeFileName(stripslashes($this->ref));
@@ -568,7 +568,7 @@ class Product extends CommonObject
 		$error = 0;
 
 		// Clean parameters
-		if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
+		if (!empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_REF_LABELS)) {
 			$this->ref = trim($this->ref);
 		} else {
 			$this->ref = dol_sanitizeFileName(dol_string_nospecial(trim($this->ref)));
@@ -967,7 +967,7 @@ class Product extends CommonObject
 		}
 
 		// Clean parameters
-		if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
+		if (!empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_REF_LABELS)) {
 			$this->ref = trim($this->ref);
 		} else {
 			$this->ref = dol_string_nospecial(trim($this->ref));

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -530,7 +530,13 @@ class Product extends CommonObject
 	 */
 	public function check()
 	{
-		$this->ref = dol_sanitizeFileName(stripslashes($this->ref));
+        global $conf;
+
+		if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
+		    $this->ref = trim($this->ref);
+		} else {
+		    $this->ref = dol_sanitizeFileName(stripslashes($this->ref));
+		}
 
 		$err = 0;
 		if (dol_strlen(trim($this->ref)) == 0) {
@@ -562,7 +568,11 @@ class Product extends CommonObject
 		$error = 0;
 
 		// Clean parameters
-		$this->ref = dol_sanitizeFileName(dol_string_nospecial(trim($this->ref)));
+		if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
+		    $this->ref = trim($this->ref);
+		} else {
+		    $this->ref = dol_sanitizeFileName(dol_string_nospecial(trim($this->ref)));
+		}
 		$this->label = trim($this->label);
 		$this->price_ttc = price2num($this->price_ttc);
 		$this->price = price2num($this->price);
@@ -957,7 +967,11 @@ class Product extends CommonObject
 		}
 
 		// Clean parameters
-		$this->ref = dol_string_nospecial(trim($this->ref));
+		if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
+		    $this->ref = trim($this->ref);
+		} else {
+		    $this->ref = dol_string_nospecial(trim($this->ref));
+		}
 		$this->label = trim($this->label);
 		$this->description = trim($this->description);
 		$this->note = (isset($this->note) ? trim($this->note) : null);

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -530,12 +530,12 @@ class Product extends CommonObject
 	 */
 	public function check()
 	{
-        global $conf;
+		global $conf;
 
 		if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
-		    $this->ref = trim($this->ref);
+			$this->ref = trim($this->ref);
 		} else {
-		    $this->ref = dol_sanitizeFileName(stripslashes($this->ref));
+			$this->ref = dol_sanitizeFileName(stripslashes($this->ref));
 		}
 
 		$err = 0;
@@ -569,9 +569,9 @@ class Product extends CommonObject
 
 		// Clean parameters
 		if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
-		    $this->ref = trim($this->ref);
+			$this->ref = trim($this->ref);
 		} else {
-		    $this->ref = dol_sanitizeFileName(dol_string_nospecial(trim($this->ref)));
+			$this->ref = dol_sanitizeFileName(dol_string_nospecial(trim($this->ref)));
 		}
 		$this->label = trim($this->label);
 		$this->price_ttc = price2num($this->price_ttc);
@@ -968,9 +968,9 @@ class Product extends CommonObject
 
 		// Clean parameters
 		if (!empty($conf->global->MAIN_DO_NOT_SANITIZE_PRODUCT_REF)) {
-		    $this->ref = trim($this->ref);
+			$this->ref = trim($this->ref);
 		} else {
-		    $this->ref = dol_string_nospecial(trim($this->ref));
+			$this->ref = dol_string_nospecial(trim($this->ref));
 		}
 		$this->label = trim($this->label);
 		$this->description = trim($this->description);


### PR DESCRIPTION
# NEW
This is a request for enhancement to set MAIN_DO_NOT_SANITIZE_PRODUCT_REF to not sanitize product ref and label values on database entry (storage).

Sanitizing product ref and label entries before storage into the database is not the correct policy for us and possibly others.  For example, we have suppliers who use slashes (/) in references and who have label information with double quotes (") to represent inches.  For instance, stripping this information on database entry yields PDF documents such as supplier orders that have incorrect information from the point of view of our supplier.

We propose a global constant MAIN_DO_NOT_SANITIZE_PRODUCT_REF  to disable this sanitation of product ref and label values on database entry which changes to

- `htdocs/product/card.php`
- `htdocs/product/class/product.class.php`

Our experience indicates that not sanitizing product ref and label values on database entry is not a problem

- Over a year ago, we imported initially via SQL scripts non-sanitized product ref and label information into our production environment without incident of usage since the import.
- We examined Dolibarr code with for example `find htdocs -name \*.php | xargs fgrep -i sanitize | egrep "\$ref|->ref" | egrep -v "dol_sanitizeFileName|sanitizeVal"` indicating that the community for example fetches product ref and label entries, sanitizes them, and then uses them for filesystem pathnames.


