### PR TITLE
Fix : workflow on bill validate don't close propal when there is a deposit

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -168,9 +168,8 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 							$element->fetchObjectLinked('', '', null, $object->element);
 							dol_syslog("Nb invoices linked to propal " . $element->id . " : " . sizeof($element->linkedObjects));
 							if (!empty($element->linkedObjects)) {
-								foreach($element->linkedObjects['facture'] as $invoice) {
-									if (($invoice->statut == Facture::STATUS_VALIDATED || $invoice->statut == Facture::STATUS_CLOSED) && !in_array($invoice->id, $invoiceIds)) 
-									{
+								foreach ($element->linkedObjects['facture'] as $invoice) {
+									if (($invoice->statut == Facture::STATUS_VALIDATED || $invoice->statut == Facture::STATUS_CLOSED) && !in_array($invoice->id, $invoiceIds)) {
 										$totalinvoices += $invoice->total_ht;
 										$invoiceIds[] = $invoice->id;
 									}


### PR DESCRIPTION
On bill validate, workflow compares invoice amount and propal amount.
If a deposit is applied on invoice, propal and invoice don't have the same amount and propal is not closed.
We need to list every invoices linked to propals to have the real amount of invoices and compare to propal.