### PR TITLE
#23611: product label update on propal/invoice/...

### DIFF
--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -111,7 +111,7 @@ $coldisplay++;
 			?>
 			</a>
 			<?php
-			echo ' - <input type="text" class="flat" name="product_label" value="'.nl2br($label) . '">';
+			echo ' - <input type="text" class="flat" name="product_label" value="'.$label. '">';
 			print '<input type="hidden" id="product_id" name="productid" value="'.(!empty($line->fk_product) ? $line->fk_product : 0).'">';
 			print '<input type="hidden" id="update_label" name="update_label" value="1">';
 		} else {

--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2012-2014  Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2013		Florian Henry		<florian.henry@open-concept.pro>
  * Copyright (C) 2018       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2022		Eric Seigne			<eric.seigne@cap-rel.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -110,8 +111,9 @@ $coldisplay++;
 			?>
 			</a>
 			<?php
-			echo ' - '.nl2br($line->product_label);
+			echo ' - <input type="text" class="flat" name="product_label" value="'.nl2br($label) . '">';
 			print '<input type="hidden" id="product_id" name="productid" value="'.(!empty($line->fk_product) ? $line->fk_product : 0).'">';
+			print '<input type="hidden" id="update_label" name="update_label" value="1">';
 		} else {
 			if ($senderissupplier) {
 				print $form->select_produits_fournisseurs(!empty($line->fk_product) ? $line->fk_product : 0, 'productid');


### PR DESCRIPTION
# CLOSE #23611

Update label product is back :-) very basic patch i hope you will include it into dolibarr core

Note: $label is defined in parent php file (commonobject.class.php) then we could use it in .tpl.php

`$label = (!empty($line->label) ? $line->label : (($line->fk_product > 0) ? $line->product_label : ''));`