### PR TITLE
Harmonize CSS for tables in fichehalfleft/fichehalfright

### DIFF
--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -3549,7 +3549,7 @@ td.border, div.tagtable div div.border {
 }
 
 
-.fichehalfright table.noborder {
+.fichehalfright table.noborder , .fichehalfleft table.noborder{
 	margin: 0px 0px 0px 0px;
 }
 table.liste, table.noborder, table.formdoc, div.noborder {


### PR DESCRIPTION
On an object card, CSS is not coherent for table.noborder elements.
`.fichehalfleft table.noborder` bottom margin is 20px (due to line 3562) but `.fichehalfright table.noborder` bottom margin is 0px.

This PR deletes bottom border for tables in .fichehalfleft and .fichehalfright.

Another way to harmonize would be to remove exception for .fichehalfleft ; this way, tables would have a bottom margin in both fiche parts.

Here you see the problem (on a custom module) :
![Capture d’écran du 2023-01-19 11-29-43](https://user-images.githubusercontent.com/89838020/213419905-e88ca208-4bdd-4dc7-a113-c0378dbe87cb.png)

