### PR TITLE
Fix: don setPaid sets paid field

### DIFF
--- a/htdocs/don/class/don.class.php
+++ b/htdocs/don/class/don.class.php
@@ -758,7 +758,7 @@ class Don extends CommonObject
 	 */
 	public function setPaid($id, $modepayment = 0)
 	{
-		$sql = "UPDATE ".MAIN_DB_PREFIX."don SET fk_statut = 2";
+		$sql = "UPDATE ".MAIN_DB_PREFIX."don SET fk_statut = 2, paid = 1";
 		if ($modepayment) {
 			$sql .= ", fk_payment = ".((int) $modepayment);
 		}
@@ -768,6 +768,7 @@ class Don extends CommonObject
 		if ($resql) {
 			if ($this->db->affected_rows($resql)) {
 				$this->statut = 2;
+				$this->paid = 1;
 				return 1;
 			} else {
 				return 0;


### PR DESCRIPTION
Bug probably present since the beginning until now.
**PR based off the 14.0 branch but will have to be merged in newer branches as well.**
Fonction and file have been renamed several times before 14.0 so patch would not apply cleanly on older versions.

# Fix: don setPaid sets paid field

When donation is classified as paid, paid field also needs to be set to 1 on top of changing the status so that accounting reports show the correct paid state.