### PR TITLE
FIX on public ticket list, pages > 1 were 404 errors

### DIFF
--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -211,7 +211,7 @@ if ($action == "view_ticketlist") {
 		$search_array_options = $extrafields->getOptionalsFromPost($object->table_element, '', 'search_');
 
 		$filter = array();
-		$param = 'action=view_ticketlist';
+		$param = '&action=view_ticketlist';
 
 		// Definition of fields for list
 		$arrayfields = array(
@@ -386,7 +386,7 @@ if ($action == "view_ticketlist") {
 			$resql = $db->query($sql);
 			if ($resql) {
 				$num = $db->num_rows($resql);
-				print_barre_liste($langs->trans('TicketList'), $page, 'public/list.php', $param, $sortfield, $sortorder, '', $num, $num_total, 'ticket');
+				print_barre_liste($langs->trans('TicketList'), $page, 'list.php', $param, $sortfield, $sortorder, '', $num, $num_total, 'ticket');
 
 				// Search bar
 				print '<form method="get" action="'.$url_form.'" id="searchFormList" >'."\n";


### PR DESCRIPTION
# FIX 404 errors on public ticket list interface

On public/ticket/list.php, when the list is long and there are many pages, the links to page 2 and further would lead to a 404 page. The URL address would be `http://localhost:8000/dolitest/htdocs/public/ticket/public/list.php?page=1action=view_ticketlist&sortfield=t.datec&sortorder=DESC` : there are two errors:
- the base URL `htdocs/public/ticket/public/list.php` should be `htdocs/public/ticket/list.php`
- there is no `&` parameter separators between `page` and `action`
- 
This PR fixes this behavior.