### PR TITLE
FIX #17181 - Product Variant Value drop down not populated

### DIFF
--- a/htdocs/variants/ajax/get_attribute_values.php
+++ b/htdocs/variants/ajax/get_attribute_values.php
@@ -83,4 +83,4 @@ if ($res == -1) {
 	exit();
 }
 
-print json_encode($res);
+print json_encode($res, JSON_PARTIAL_OUTPUT_ON_ERROR);

--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -511,7 +511,7 @@ if (!empty($id) || !empty($ref)) {
 
 		<script type="text/javascript">
 
-			variants_available = <?php echo json_encode($prodattr_alljson); ?>;
+			variants_available = <?php echo json_encode($prodattr_alljson, JSON_PARTIAL_OUTPUT_ON_ERROR); ?>;
 			variants_selected = {
 				index: [],
 				info: []


### PR DESCRIPTION
# CLOSE #17181 - Product Variant Value drop down not populated
The solution is in the comment of [graillet](https://github.com/graillet) in the issue communication .. but didn't make it into the code by now .. this pull request should fix that.

Kind regards
Tasso