### PR TITLE
NEW: use account address in sepa mandate

### DIFF
--- a/htdocs/core/modules/bank/doc/pdf_sepamandate.modules.php
+++ b/htdocs/core/modules/bank/doc/pdf_sepamandate.modules.php
@@ -309,7 +309,9 @@ class pdf_sepamandate extends ModeleBankAccountDoc
 				$pdf->MultiCell($this->page_largeur - $this->marge_gauche - $this->marge_droite, 3, $sepavatid, 0, 'L');
 
 				$address = '______________________________________________';
-				if ($thirdparty->id > 0) {
+				if(!empty($object->owner_address)) {
+					$address = $object->owner_address;
+				} elseif ($thirdparty->id > 0) {
 					$tmpaddresswithoutcountry = $thirdparty->getFullAddress();	// we test on address without country
 					if ($tmpaddresswithoutcountry) {
 						$address = $thirdparty->getFullAddress(1);	// full address

--- a/htdocs/core/modules/bank/doc/pdf_sepamandate.modules.php
+++ b/htdocs/core/modules/bank/doc/pdf_sepamandate.modules.php
@@ -309,7 +309,7 @@ class pdf_sepamandate extends ModeleBankAccountDoc
 				$pdf->MultiCell($this->page_largeur - $this->marge_gauche - $this->marge_droite, 3, $sepavatid, 0, 'L');
 
 				$address = '______________________________________________';
-				if(!empty($object->owner_address)) {
+				if (!empty($object->owner_address)) {
 					$address = $object->owner_address;
 				} elseif ($thirdparty->id > 0) {
 					$tmpaddresswithoutcountry = $thirdparty->getFullAddress();	// we test on address without country


### PR DESCRIPTION
# NEW use account address in sepa mandate

In SEPA mandate pdf model, the account owner and address are the ones of the thirdparty.
However, users are allowed to define an owner and an address for the account, that are different from the name and address of the thirdparty.

This PR introduces option PRELEVEMENT_PREFER_ACCOUNT_OWNER_AND_ADDRESS that displays account owner + account address instead of thirdparty name + thirdparty address.
