### PR TITLE
NEW: Can now edit service name for oauth token

### DIFF
--- a/htdocs/admin/oauth.php
+++ b/htdocs/admin/oauth.php
@@ -123,9 +123,10 @@ if ($action == 'update') {
 				$oldlabel = preg_replace('/^.*-/', '', $oldname);
 				$newlabel = preg_replace('/^.*-/', '', $newconstvalue);
 
+
 				$sql = "UPDATE ".MAIN_DB_PREFIX."oauth_token";
-				$sql.= " SET service = '".$oldprovider."-".$newlabel."'";
-				$sql.= " WHERE  service = '".$oldprovider."-".$oldlabel."'";
+				$sql.= " SET service = '".$db->escape($oldprovider."-".$newlabel)."'";
+				$sql.= " WHERE  service = '".$db->escape($oldprovider."-".$oldlabel)."'";
 
 
 				$resql = $db->query($sql);


### PR DESCRIPTION
Note that when a token is renamed, it requires other few changes, especially where the token is used (for instance, if this token was used to send mails, settings of mails have to be updated to match with the new token name).