### PR TITLE
Protection against deletion of ref_employee and national_registration…

### DIFF
--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -420,13 +420,13 @@ if (empty($reshook)) {
 				/*
 				* Protection against deletion of ref_employee while the field is not present in the user tab
 				*/
-				if (GETPOSTISSET("ref_employee")){
+				if (GETPOSTISSET("ref_employee")) {
 					$object->ref_employee = GETPOST("ref_employee", 'alphanohtml');
 				}
 				/*
 				* Protection against deletion of national_registration_number while the field is not present in the user tab
 				*/
-				if (GETPOSTISSET("national_registration_number")){
+				if (GETPOSTISSET("national_registration_number")) {
 					$object->national_registration_number = GETPOST("national_registration_number", 'alphanohtml');
 				}
 				$object->gender = GETPOST("gender", 'aZ09');

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -417,8 +417,18 @@ if (empty($reshook)) {
 				$object->civility_code = GETPOST("civility_code", 'aZ09');
 				$object->lastname = GETPOST("lastname", 'alphanohtml');
 				$object->firstname = GETPOST("firstname", 'alphanohtml');
-				$object->ref_employee = GETPOST("ref_employee", 'alphanohtml');
-				$object->national_registration_number = GETPOST("national_registration_number", 'alphanohtml');
+				/*
+				* Protection against deletion of ref_employee while the field is not present in the user tab
+				*/
+				if (GETPOSTISSET("ref_employee")){
+					$object->ref_employee = GETPOST("ref_employee", 'alphanohtml');
+				}
+				/*
+				* Protection against deletion of national_registration_number while the field is not present in the user tab
+				*/
+				if (GETPOSTISSET("national_registration_number")){
+					$object->national_registration_number = GETPOST("national_registration_number", 'alphanohtml');
+				}
 				$object->gender = GETPOST("gender", 'aZ09');
 				$object->pass = GETPOST("password", 'none');	// We can keep 'none' for password fields
 				$object->api_key = (GETPOST("api_key", 'alphanohtml')) ? GETPOST("api_key", 'alphanohtml') : $object->api_key;


### PR DESCRIPTION
# FIX
Protection against deletion of ref_employee and national_registration_number while fields are not presents in the user tab
When you set ref_employee and/or national_registration_number in the RH & bank tab if you edit the user tab and save, the 2 fields are erased.
There is two other solution to solve this issue. The first is to set the two fields on the user tab, the second, delete the two lines in the actions "add" and "edit".
I don't know wich is the best solution. 
My solution is only a temporary patch in wait of a  decision.