### PR TITLE
Encase database name in backticks

### DIFF
--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -678,7 +678,7 @@ class DoliDBMysqli extends DoliDB
 		}
 		$tmpdatabase = preg_replace('/[^a-z0-9\.\-\_]/i', '', $database);
 
-		$sql = "SHOW TABLES FROM ".$tmpdatabase." ".$like.";";
+		$sql = "SHOW TABLES FROM `".$tmpdatabase."` ".$like.";";
 		//print $sql;
 		$result = $this->query($sql);
 		if ($result) {


### PR DESCRIPTION
# FIX #23643 Encase database name in backticks
If the database name contains a hyphen `-` then the SQL query `SHOW TABLES FROM database-name` fails.