### PR TITLE
Fix wrong variable used to fetch replaced invoice

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2940,7 +2940,7 @@ if ($action == 'create') {
 		}
 		if (isset($objectidnext) && $objectidnext > 0) {
 			$facthatreplace = new FactureFournisseur($db);
-			$facthatreplace->fetch($facidnext);
+			$facthatreplace->fetch($objectidnext);
 			print ' ('.$langs->transnoentities("ReplacedByInvoice", $facthatreplace->getNomUrl(1)).')';
 		}
 		if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE || $object->type == FactureFournisseur::TYPE_DEPOSIT) {


### PR DESCRIPTION
# FIX|Fix #23586 Wrong variable name used
`$facidnext` does not exist, `$objectidnext` was meant to be used (and is what's check in the `if` condition)