### PR TITLE
FIX: ExpenseReport card was not reloaded after addline 

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1161,9 +1161,9 @@ if (empty($reshook)) {
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}
-		
-        header("Location: ".$_SERVER["PHP_SELF"]."?id=".GETPOST('id', 'int'));
-        exit;
+
+		header("Location: ".$_SERVER["PHP_SELF"]."?id=".GETPOST('id', 'int'));
+		exit;
 	}
 
 	if ($action == 'confirm_delete_line' && GETPOST("confirm", 'alpha') == "yes" && $user->rights->expensereport->creer) {

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1161,8 +1161,9 @@ if (empty($reshook)) {
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}
-
-		$action = '';
+		
+        header("Location: ".$_SERVER["PHP_SELF"]."?id=".GETPOST('id', 'int'));
+        exit;
 	}
 
 	if ($action == 'confirm_delete_line' && GETPOST("confirm", 'alpha') == "yes" && $user->rights->expensereport->creer) {


### PR DESCRIPTION
The expensereport card  was not reloaded after adding a line, which leads to the creation of a new line when the F5 key is pressed, as the post values remained the same