### PR TITLE
FIX #23704 Handle excess payments deposit invoices

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5534,7 +5534,7 @@ if ($action == 'create') {
 				}
 				// For down payment invoice (deposit)
 				if ($object->type == Facture::TYPE_DEPOSIT && $usercancreate && $object->statut > Facture::STATUS_DRAFT && empty($discount->id)) {
-					if (price2num($object->total_ttc, 'MT') == price2num($sumofpaymentall, 'MT') || ($object->type == Facture::STATUS_ABANDONED && in_array($object->close_code, array('bankcharge', 'discount_vat', 'other')))) {
+					if (price2num($object->total_ttc, 'MT') <= price2num($sumofpaymentall, 'MT') || ($object->type == Facture::STATUS_ABANDONED && in_array($object->close_code, array('bankcharge', 'discount_vat', 'other')))) {
 						// We can close a down payment only if paid amount is same than amount of down payment (by definition)
 						print '<a class="butAction'.($conf->use_javascript_ajax ? ' reposition' : '').'" href="'.$_SERVER["PHP_SELF"].'?facid='.$object->id.'&amp;action=converttoreduc">'.$langs->trans('ConvertToReduc').'</a>';
 					} else {
@@ -5550,8 +5550,9 @@ if ($action == 'create') {
 					($object->type == Facture::TYPE_DEPOSIT && $object->total_ttc > 0)
 				)
 			) {
-				if ($object->type == Facture::TYPE_DEPOSIT && price2num($object->total_ttc, 'MT') != price2num($sumofpaymentall, 'MT')) {
-					// We can close a down payment only if paid amount is same than amount of down payment (by definition)
+				if ($object->type == Facture::TYPE_DEPOSIT && price2num($object->total_ttc, 'MT') >= price2num($sumofpaymentall, 'MT')) {
+					// We can close a down payment only if paid amount is greater than or equal to amount of down payment 
+					// By definition, it should be equal, but in case of customer mistake upon payment (in excess) it can be greater
 					$params['attr']['title'] = $langs->trans('AmountPaidMustMatchAmountOfDownPayment');
 					print dolGetButtonAction($langs->trans('ClassifyPaid'), '', 'default', '#', '', false, $params);
 				} else {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5550,7 +5550,7 @@ if ($action == 'create') {
 					($object->type == Facture::TYPE_DEPOSIT && $object->total_ttc > 0)
 				)
 			) {
-				if ($object->type == Facture::TYPE_DEPOSIT && price2num($object->total_ttc, 'MT') >= price2num($sumofpaymentall, 'MT')) {
+				if ($object->type == Facture::TYPE_DEPOSIT && price2num($object->total_ttc, 'MT') > price2num($sumofpaymentall, 'MT')) {
 					// We can close a down payment only if paid amount is greater than or equal to amount of down payment
 					// By definition, it should be equal, but in case of customer mistake upon payment (in excess) it can be greater
 					$params['attr']['title'] = $langs->trans('AmountPaidMustMatchAmountOfDownPayment');

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5551,7 +5551,7 @@ if ($action == 'create') {
 				)
 			) {
 				if ($object->type == Facture::TYPE_DEPOSIT && price2num($object->total_ttc, 'MT') >= price2num($sumofpaymentall, 'MT')) {
-					// We can close a down payment only if paid amount is greater than or equal to amount of down payment 
+					// We can close a down payment only if paid amount is greater than or equal to amount of down payment
 					// By definition, it should be equal, but in case of customer mistake upon payment (in excess) it can be greater
 					$params['attr']['title'] = $langs->trans('AmountPaidMustMatchAmountOfDownPayment');
 					print dolGetButtonAction($langs->trans('ClassifyPaid'), '', 'default', '#', '', false, $params);


### PR DESCRIPTION
FIX #23704 Handle excess payments deposit invoices

Ensure we can handle excess payments in deposit invoices by:
+ Allowing to classify an overly paid deposit invoice as paid
+ Allowing to convert the invoice amount to a credit

This change 2 comparisons (`==` to `<=` and `!=` to `>`).

Fix #23704