### PR TITLE
This allows the hook getFormMail to automatically add email recipients

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -1082,11 +1082,11 @@ class FormMail extends Form
 					$withtoselected = array_keys($tmparray);
 				}
 
-                // The function getFormMail is the only one that calls this one, so one uses the hook
-                // getFormMail to set $this->withtoselected via $object->withtoselected in the hook
-                if (!empty($this->withtoselected)) {
-                    $withtoselected = array_keys($this->withtoselected);
-                }
+				// The function getFormMail is the only one that calls this one, so one uses the hook
+				// getFormMail to set $this->withtoselected via $object->withtoselected in the hook
+				if (!empty($this->withtoselected)) {
+					$withtoselected = array_keys($this->withtoselected);
+				}
 
 				$out .= $form->multiselectarray("receiver", $tmparray, $withtoselected, null, null, 'inline-block minwidth500', null, "");
 			}

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -1082,6 +1082,12 @@ class FormMail extends Form
 					$withtoselected = array_keys($tmparray);
 				}
 
+                // The function getFormMail is the only one that calls this one, so one uses the hook
+                // getFormMail to set $this->withtoselected via $object->withtoselected in the hook
+                if (!empty($this->withtoselected)) {
+                    $withtoselected = array_keys($this->withtoselected);
+                }
+
 				$out .= $form->multiselectarray("receiver", $tmparray, $withtoselected, null, null, 'inline-block minwidth500', null, "");
 			}
 		}


### PR DESCRIPTION
# NEW|
This is a request for enhancement (RFE).  This change allows the hook getFormMail to automatically add email recipients as desired when a user clicks on the button SEND MAIL (language key `SendMail`).  The function `getFormMail ` is the only one that calls the function `getHtmlForTo`, so one uses the hook `getFormMail ` to set `$this->withtoselected` via `$object->withtoselected` in the hook `getHtmlForTo` to automatically add email recipients as desired.