### PR TITLE
FIX : wrong prefilter status on agenda index

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -133,9 +133,6 @@ if (GETPOST('search_actioncode', 'array:aZ09')) {
 	$actioncode = GETPOST("search_actioncode", "alpha", 3) ?GETPOST("search_actioncode", "alpha", 3) : (GETPOST("search_actioncode") == '0' ? '0' : ((empty($conf->global->AGENDA_DEFAULT_FILTER_TYPE) || $disabledefaultvalues) ? '' : $conf->global->AGENDA_DEFAULT_FILTER_TYPE));
 }
 
-if ($status == '' && !GETPOSTISSET('search_status')) {
-	$status = ((empty($conf->global->AGENDA_DEFAULT_FILTER_STATUS) || $disabledefaultvalues) ? '' : $conf->global->AGENDA_DEFAULT_FILTER_STATUS);
-}
 
 $defaultview = (empty($conf->global->AGENDA_DEFAULT_VIEW) ? 'show_month' : $conf->global->AGENDA_DEFAULT_VIEW);
 $defaultview = (empty($user->conf->AGENDA_DEFAULT_VIEW) ? $defaultview : $user->conf->AGENDA_DEFAULT_VIEW);


### PR DESCRIPTION
#Fix wrong prefilter status on agenda index

We have few problems with these lines : 

1. Conf says : "Default event status when creating an event from the form" or it is used in this page
2. The filter isn't preselected
3. We can't filter on every status

