### PR TITLE
FIX : no filter on status in action/index.php

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -758,7 +758,7 @@ if ($type) {
 if ($status == '0') {
 	$sql .= " AND a.percent = 0";
 }
-if ($status == '-1' || $status == 'na') {
+if ($status == 'na') {
 	// Not applicable
 	$sql .= " AND a.percent = -1";
 }


### PR DESCRIPTION
# Fix no filter on status in action/index.php
When we filter with an empty select status on action/index.php, we should have all events status but we have only na status filtered