### PR TITLE
FIX: Homogenise handling of null extrafield value in create/update

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6350,7 +6350,7 @@ abstract class CommonObject
 			}
 
 			if ($linealreadyfound) {
-				if ($this->array_options["options_".$key] === null) {
+				if ($this->array_options["options_".$key] === null || $this->array_options["options_".$key] === "") {
 					$sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element."_extrafields SET ".$key." = null";
 				} else {
 					$sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element."_extrafields SET ".$key." = '".$this->db->escape($this->array_options["options_".$key])."'";

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6304,6 +6304,11 @@ abstract class CommonObject
 						$this->array_options["options_".$key] = null;
 					}
 					break;
+				case 'link':
+					if ($this->array_options["options_".$key] === '') {
+						$this->array_options["options_".$key] = null;
+  					}
+					break;
 				/*
 				case 'link':
 					$param_list = array_keys($attributeParam['options']);
@@ -6350,7 +6355,7 @@ abstract class CommonObject
 			}
 
 			if ($linealreadyfound) {
-				if ($this->array_options["options_".$key] === null || $this->array_options["options_".$key] === "") {
+				if ($this->array_options["options_".$key] === null) {
 					$sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element."_extrafields SET ".$key." = null";
 				} else {
 					$sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element."_extrafields SET ".$key." = '".$this->db->escape($this->array_options["options_".$key])."'";

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6307,7 +6307,7 @@ abstract class CommonObject
 				case 'link':
 					if ($this->array_options["options_".$key] === '') {
 						$this->array_options["options_".$key] = null;
-  					}
+					}
 					break;
 				/*
 				case 'link':


### PR DESCRIPTION
In *insertExtraFields* method the following check is made to check whether an extra field value is NULL:

https://github.com/Dolibarr/dolibarr/blob/5395a4ab4b6d9db3c1ecb4fdbf871ea3ff9cad31/htdocs/core/class/commonobject.class.php#L6028

In *updateExtraField* method the following check is made to check whether an extra field value is NULL:

https://github.com/Dolibarr/dolibarr/blob/5395a4ab4b6d9db3c1ecb4fdbf871ea3ff9cad31/htdocs/core/class/commonobject.class.php#L6353

---

Because of that when a user is trying to select empty value from extra field of type ‘link’ in the propal page Dolibarr tried to insert an empty value which cause an SQL error.

<img width="935" alt="image" src="https://user-images.githubusercontent.com/85104766/216021228-d9caba8f-e718-4ac8-9c8e-de716819e761.png">

The behaviour works in other page because *insertExtraFields* is used instead of *updateExtraField* .

These checks were not coherent so I homogenise them in order to ensure same behaviour.