### PR TITLE
Fix : Updated function dol_eval, added error handling

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8946,6 +8946,7 @@ function verifCond($strToEvaluate)
  */
 function dol_eval($s, $returnvalue = 0, $hideerrors = 1, $onlysimplestring = '1')
 {
+    try {
 	// Only global variables can be changed by eval function and returned to caller
 	global $db, $langs, $user, $conf, $website, $websitepage;
 	global $action, $mainmenu, $leftmenu;
@@ -9049,6 +9050,13 @@ function dol_eval($s, $returnvalue = 0, $hideerrors = 1, $onlysimplestring = '1'
 			eval($s);
 		}
 	}
+    } catch (Error $e) {
+            $error = 'Caught error : ';
+            $error .= $e->getMessage() . ', ';
+            $error .= 'Trace : ';
+            $error .= json_encode($e->getTrace());
+            error_log($error, 1);
+    }
 }
 
 /**


### PR DESCRIPTION
*Updated function dol_eval, added error handling*
- There were cases that dol_eval() would break the whole system.

 - That was happening in case of using a new version plugin on an old version dolibarr. New plugin validates through isModActive() instead of $conf->moduleName->enabled. Even if you were deactivating the plugin, or totally delete it, the records were still on database for menu, so there were no obvious solution. This update adds a backwards compatibility, makes doli more stable and counterparts the use of eval, making it more safe.

- Use of eval is not bad, as well there are techniques in any project that are project-related useful and smart. For example, Linux kernel uses GOTO. But in such cases, there needs to be a safety net.

 - I found out this after a lot of trouble, I hope this small fix will save other developers.

P.S. After testing I found that @eval is not enough, I forgot to mention at this description.

:+1: