### PR TITLE
FIX : user off constants not saved

### DIFF
--- a/htdocs/admin/agenda.php
+++ b/htdocs/admin/agenda.php
@@ -91,7 +91,7 @@ if ($action == "save" && empty($cancel)) {
 	foreach ($triggers as $trigger) {
 		$keyparam = 'MAIN_AGENDA_ACTIONAUTO_'.$trigger['code'];
 		if ($search_event === '' || preg_match('/'.preg_quote($search_event, '/').'/i', $keyparam)) {
-			$res = dolibarr_set_const($db, $keyparam, (GETPOST($keyparam, 'alpha') ?GETPOST($keyparam, 'alpha') : ''), 'chaine', 0, '', $conf->entity);
+			$res = dolibarr_set_const($db, $keyparam, (GETPOST($keyparam, 'alpha') ?GETPOST($keyparam, 'alpha') : '0'), 'chaine', 0, '', $conf->entity);
 			if (!($res > 0)) {
 				$error++;
 			}

--- a/htdocs/admin/ecm.php
+++ b/htdocs/admin/ecm.php
@@ -57,7 +57,7 @@ if (preg_match('/set_([a-z0-9_\-]+)/i', $action, $reg)) {
 // delete
 if (preg_match('/del_([a-z0-9_\-]+)/i', $action, $reg)) {
 	$code = $reg[1];
-	if (dolibarr_del_const($db, $code, $conf->entity) > 0) {
+	if (dolibarr_set_const($db, $code, 0, 'chaine', 0, '', $conf->entity) > 0) {
 		header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;
 	} else {

--- a/htdocs/core/ajax/constantonoff.php
+++ b/htdocs/core/ajax/constantonoff.php
@@ -72,7 +72,8 @@ if (!empty($action) && !empty($name)) {
 		if ($action == 'set') {
 			dolibarr_set_const($db, $name, $value, 'chaine', 0, '', $entity);
 		} elseif ($action == 'del') {
-			dolibarr_del_const($db, $name, $entity);
+			// We should save the constant as 0 instead of deleting the constant.
+			dolibarr_set_const($db, $name, 0, 'chaine', 0, '', $entity);
 		}
 	}
 } else {


### PR DESCRIPTION
# FIX https://github.com/Dolibarr/dolibarr/issues/23023 : module parameters set to OFF are deleted
This is a port of PR #23050 from branch 14.0 to develop branch.

On module config, when user sets parameters to OFF, the related constants are deleted from DB through dolibarr_del_const(). When re-enabling a module, if the module has default parameters set to 'ON', these parameters override the users choice.
We should save OFF parameters as set to 0 instead of deleting the llx_const line.

(Started in develop on PR https://github.com/Dolibarr/dolibarr/pull/23025)

