### PR TITLE
Ticket public pages : reformat footer

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -2264,3 +2264,76 @@ function addMailingEventTypeSQL($actioncode, $objcon, $filterobj)
 		return $sql2;
 	}
 }
+
+/**
+ * Show footer of company in HTML pages
+ *
+ * @param   Societe		$fromcompany	Third party
+ * @param   Translate	$langs			Output language
+ * @param	Object		$object			Object related to payment
+ * @return	void
+ */
+function htmlPrintOnlineCompanyFooter($fromcompany, $langs)
+{
+	global $conf;
+
+	// Juridical status
+	$line1 = "";
+	if ($fromcompany->forme_juridique_code) {
+		$line1 .= ($line1 ? " - " : "").getFormeJuridiqueLabel($fromcompany->forme_juridique_code);
+	}
+	// Capital
+	if ($fromcompany->capital) {
+		$line1 .= ($line1 ? " - " : "").$langs->transnoentities("CapitalOf", $fromcompany->capital)." ".$langs->transnoentities("Currency".$conf->currency);
+	}
+	// Prof Id 1
+	if ($fromcompany->idprof1 && ($fromcompany->country_code != 'FR' || !$fromcompany->idprof2)) {
+		$field = $langs->transcountrynoentities("ProfId1", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof1;
+	}
+	// Prof Id 2
+	if ($fromcompany->idprof2) {
+		$field = $langs->transcountrynoentities("ProfId2", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof2;
+	}
+
+	// Second line of company infos
+	$line2 = "";
+	// Prof Id 3
+	if ($fromcompany->idprof3) {
+		$field = $langs->transcountrynoentities("ProfId3", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof3;
+	}
+	// Prof Id 4
+	if ($fromcompany->idprof4) {
+		$field = $langs->transcountrynoentities("ProfId4", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof4;
+	}
+	// IntraCommunautary VAT
+	if ($fromcompany->tva_intra != '') {
+		$line2 .= ($line2 ? " - " : "").$langs->transnoentities("VATIntraShort").": ".$fromcompany->tva_intra;
+	}
+
+	print '<span style="font-size: 10px;"><br><hr>'."\n";
+	print $fromcompany->name.'<br>';
+	print $line1;
+	if (strlen($line1.$line2) > 50) {
+		print '<br>';
+	} else {
+		print ' - ';
+	}
+	print $line2;
+	print '</span>'."\n";
+}

--- a/htdocs/core/lib/payments.lib.php
+++ b/htdocs/core/lib/payments.lib.php
@@ -432,55 +432,6 @@ function htmlPrintOnlinePaymentFooter($fromcompany, $langs, $addformmessage = 0,
 {
 	global $conf;
 
-	// Juridical status
-	$line1 = "";
-	if ($fromcompany->forme_juridique_code) {
-		$line1 .= ($line1 ? " - " : "").getFormeJuridiqueLabel($fromcompany->forme_juridique_code);
-	}
-	// Capital
-	if ($fromcompany->capital) {
-		$line1 .= ($line1 ? " - " : "").$langs->transnoentities("CapitalOf", $fromcompany->capital)." ".$langs->transnoentities("Currency".$conf->currency);
-	}
-	// Prof Id 1
-	if ($fromcompany->idprof1 && ($fromcompany->country_code != 'FR' || !$fromcompany->idprof2)) {
-		$field = $langs->transcountrynoentities("ProfId1", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof1;
-	}
-	// Prof Id 2
-	if ($fromcompany->idprof2) {
-		$field = $langs->transcountrynoentities("ProfId2", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof2;
-	}
-
-	// Second line of company infos
-	$line2 = "";
-	// Prof Id 3
-	if ($fromcompany->idprof3) {
-		$field = $langs->transcountrynoentities("ProfId3", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof3;
-	}
-	// Prof Id 4
-	if ($fromcompany->idprof4) {
-		$field = $langs->transcountrynoentities("ProfId4", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof4;
-	}
-	// IntraCommunautary VAT
-	if ($fromcompany->tva_intra != '') {
-		$line2 .= ($line2 ? " - " : "").$langs->transnoentities("VATIntraShort").": ".$fromcompany->tva_intra;
-	}
-
 	print '<!-- htmlPrintOnlinePaymentFooter -->'."\n";
 
 	print '<br>';
@@ -508,14 +459,8 @@ function htmlPrintOnlinePaymentFooter($fromcompany, $langs, $addformmessage = 0,
 		}
 	}
 
-	print '<span style="font-size: 10px;"><br><hr>'."\n";
-	print $fromcompany->name.'<br>';
-	print $line1;
-	if (strlen($line1.$line2) > 50) {
-		print '<br>';
-	} else {
-		print ' - ';
-	}
-	print $line2;
-	print '</span></div>'."\n";
+	require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
+	htmlPrintOnlineCompanyFooter($fromcompany, $langs);
+
+	print '</div>'."\n";
 }

--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -220,7 +220,7 @@ function llxHeaderTicket($title, $head = "", $disablejs = 0, $disablehead = 0, $
 	top_htmlhead($head, $title, $disablejs, $disablehead, $arrayofjs, $arrayofcss, 0, 1); // Show html headers
 
 	print '<body id="mainbody" class="publicnewticketform">';
-	print '<div class="center">';
+	print '<header class="center">';
 
 	// Define urllogo
 	if (getDolGlobalInt('TICKET_SHOW_COMPANY_LOGO') || getDolGlobalString('TICKET_PUBLIC_INTERFACE_TOPIC')) {
@@ -264,7 +264,5 @@ function llxHeaderTicket($title, $head = "", $disablejs = 0, $disablehead = 0, $
 		print '</div>';
 	}
 
-	print '</div>';
-
-	print '<div class="ticketlargemargin">';
+	print '</header>';
 }

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -514,6 +514,7 @@ $arrayofcss = array('/opensurvey/css/style.css', '/ticket/css/styles.css.php');
 llxHeaderTicket($langs->trans("CreateTicket"), "", 0, 0, $arrayofjs, $arrayofcss);
 
 
+print '<main class="ticketlargemargin">';
 print '<div class="ticketpublicarea">';
 
 if ($action != "infos_success") {
@@ -545,9 +546,12 @@ if ($action != "infos_success") {
 }
 
 print '</div>';
+print '</main>';
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 1, $suffix, $object);
+print '<footer class="center">';
+htmlPrintOnlineCompanyFooter($mysoc, $langs);
+print '</footer>';
 
 llxFooter('', 'public');
 

--- a/htdocs/public/ticket/index.php
+++ b/htdocs/public/ticket/index.php
@@ -80,8 +80,8 @@ $arrayofcss = array('/ticket/css/styles.css.php');
 
 llxHeaderTicket($langs->trans("Tickets"), "", 0, 0, $arrayofjs, $arrayofcss);
 
-print '<main class="ticketpublicarea">';
-
+print '<main class="ticketlargemargin">';
+print '<div class="ticketpublicarea">';
 print '<p style="text-align: center">'.(getDolGlobalString("TICKET_PUBLIC_TEXT_HOME", '<span class="opacitymedium">'.$langs->trans("TicketPublicDesc")).'</span></p>').'</p>';
 print '<br>';
 
@@ -90,6 +90,7 @@ print '<a href="create_ticket.php?action=create'.(!empty($entity) && isModEnable
 print '<a href="list.php'.(!empty($entity) && isModEnabled('multicompany')?'?entity='.$entity:'').'" rel="nofollow noopener" class="butAction marginbottomonly"><div class="index_display bigrounded"><span class="fa fa-15 fa-list-alt valignmiddle btnTitle-icon"></span><br>'.dol_escape_htmltag($langs->trans("ViewMyTicketList")).'</div></a>';
 print '<a href="view.php'.(!empty($entity) && isModEnabled('multicompany')?'?entity='.$entity:'').'" rel="nofollow noopener" class="butAction marginbottomonly"><div class="index_display bigrounded">'.img_picto('', 'ticket', 'class="fa-15"').'<br>'.dol_escape_htmltag($langs->trans("ShowTicketWithTrackId")).'</div></a>';
 print '<div style="clear:both;"></div>';
+print '</div>';
 print '</div>';
 print '</main>';
 

--- a/htdocs/public/ticket/index.php
+++ b/htdocs/public/ticket/index.php
@@ -80,7 +80,7 @@ $arrayofcss = array('/ticket/css/styles.css.php');
 
 llxHeaderTicket($langs->trans("Tickets"), "", 0, 0, $arrayofjs, $arrayofcss);
 
-print '<div class="ticketpublicarea">';
+print '<main class="ticketpublicarea">';
 
 print '<p style="text-align: center">'.(getDolGlobalString("TICKET_PUBLIC_TEXT_HOME", '<span class="opacitymedium">'.$langs->trans("TicketPublicDesc")).'</span></p>').'</p>';
 print '<br>';
@@ -91,11 +91,12 @@ print '<a href="list.php'.(!empty($entity) && isModEnabled('multicompany')?'?ent
 print '<a href="view.php'.(!empty($entity) && isModEnabled('multicompany')?'?entity='.$entity:'').'" rel="nofollow noopener" class="butAction marginbottomonly"><div class="index_display bigrounded">'.img_picto('', 'ticket', 'class="fa-15"').'<br>'.dol_escape_htmltag($langs->trans("ShowTicketWithTrackId")).'</div></a>';
 print '<div style="clear:both;"></div>';
 print '</div>';
-print '</div>';
+print '</main>';
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
-
+print '<footer class="center">';
+htmlPrintOnlineCompanyFooter($mysoc, $langs);
+print '</footer>';
 llxFooter('', 'public');
 
 $db->close();

--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -193,9 +193,8 @@ $arrayofcss = array('/ticket/css/styles.css.php');
 llxHeaderTicket($langs->trans("Tickets"), "", 0, 0, $arrayofjs, $arrayofcss);
 
 
-
 if ($action == "view_ticketlist") {
-	print '<div class="ticketpublicarealist">';
+	print '<main class="ticketpublicarealist ticketlargemargin">';
 
 	print '<br>';
 	if ($display_ticket_list) {
@@ -724,7 +723,7 @@ if ($action == "view_ticketlist") {
 
 	print '</div>';
 } else {
-	print '<div class="ticketpublicarea">';
+	print '<main class="ticketpublicarea">';
 
 	print '<p class="center opacitymedium">'.$langs->trans("TicketPublicMsgViewLogIn").'</p>';
 	print '<br>';
@@ -751,12 +750,13 @@ if ($action == "view_ticketlist") {
 
 	print "</form>\n";
 	print "</div>\n";
-
-	print "</div>";
 }
+print "</main>";
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
+print '<footer class="center">';
+htmlPrintOnlineCompanyFooter($mysoc, $langs);
+print '</footer>';
 
 llxFooter('', 'public');
 

--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -192,9 +192,10 @@ $arrayofcss = array('/ticket/css/styles.css.php');
 
 llxHeaderTicket($langs->trans("Tickets"), "", 0, 0, $arrayofjs, $arrayofcss);
 
+print '<main class="ticketlargemargin">';
 
 if ($action == "view_ticketlist") {
-	print '<main class="ticketpublicarealist ticketlargemargin">';
+	print '<div class="ticketpublicarealist">';
 
 	print '<br>';
 	if ($display_ticket_list) {
@@ -723,7 +724,7 @@ if ($action == "view_ticketlist") {
 
 	print '</div>';
 } else {
-	print '<main class="ticketpublicarea">';
+	print '<div class="ticketpublicarea">';
 
 	print '<p class="center opacitymedium">'.$langs->trans("TicketPublicMsgViewLogIn").'</p>';
 	print '<br>';
@@ -751,6 +752,8 @@ if ($action == "view_ticketlist") {
 	print "</form>\n";
 	print "</div>\n";
 }
+
+print "</div>"; // class "ticketpublicarea" or "ticketpublicarealist"
 print "</main>";
 
 // End of page

--- a/htdocs/public/ticket/view.php
+++ b/htdocs/public/ticket/view.php
@@ -229,6 +229,7 @@ $arrayofcss = array('/ticket/css/styles.css.php');
 
 llxHeaderTicket($langs->trans("Tickets"), "", 0, 0, $arrayofjs, $arrayofcss);
 
+print '<main class="ticketlargemargin">';
 print '<div class="ticketpublicarea">';
 
 if ($action == "view_ticket" || $action == "presend" || $action == "close" || $action == "confirm_public_close") {
@@ -416,9 +417,13 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 }
 
 print "</div>";
+print "</main>";
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
+// htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
+print '<footer class="center">';
+htmlPrintOnlineCompanyFooter($mysoc, $langs);
+print '</footer>';
 
 llxFooter('', 'public');
 

--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -7110,6 +7110,7 @@ div.tabsElem a.tab {
 }
 .publicnewticketform {
 	/* margin-top: 25px !important; */
+	height: 100%;
 	width: 100%;
 	display: flex;
 	flex-direction: column;

--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -7110,6 +7110,18 @@ div.tabsElem a.tab {
 }
 .publicnewticketform {
 	/* margin-top: 25px !important; */
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: start;
+    align-items: stretch;
+}
+.publicnewticketform > header {
+	margin: 0px 0px 0px 0px;
+}
+.publicnewticketform > footer {
+	margin: auto 0px 0px 0px; /* Footer should be at bottom of screen */
+    padding-bottom: 10px;
 }
 .ticketlargemargin {
 	padding-left: 50px;


### PR DESCRIPTION
# NEW Cleaner footer for ticket public pages

This is a cleaner version of PR https://github.com/Dolibarr/dolibarr/pull/22960 by @lvessiller-opendsi , focused on ticket interface.

This PR:
- Reformats htmlPrintOnlinePaymentFooter() in payment.lib.php and creates a function htmlPrintOnlineCompanyFooter() in company.lib.php. Now, one can display the company informations in the footer without displaying payment information.
- Cleans the structure of public ticket pages, using meaningful tags header, main, footer. Using only div tags did lead to a bug where one div was not properly closed, leading to wrong display.

### Before 
- in public interface
![image](https://user-images.githubusercontent.com/45359511/203943330-3d4e2f86-5605-4b4f-9146-2ab76b43de09.png)

- in list, with few elements (the footer is not at the bottom of the page)
![image](https://user-images.githubusercontent.com/89838020/216649585-7d96d20b-1fce-4168-b603-06c5e2a5e2aa.png)



### After 
- in public interface
![image](https://user-images.githubusercontent.com/45359511/203938541-b14c23b6-a6a3-428a-a9cb-7848034c17c9.png)

- in lists, with few elements
![image](https://user-images.githubusercontent.com/89838020/216650586-168a06a3-856d-4ad8-b392-7aab50df1a0c.png)
