### PR TITLE
13 fix update public note error when document model not found

### DIFF
--- a/htdocs/core/actions_setnotes.inc.php
+++ b/htdocs/core/actions_setnotes.inc.php
@@ -58,7 +58,7 @@ if ($action == 'setnote_public' && !empty($permissionnote) && !GETPOST('cancel',
 			//but the note is saved, so just add a notification will be enought
 			$resultGenDoc = $object->generateDocument($model, $outputlangs, $hidedetails, $hidedesc, $hideref);
 			if ($resultGenDoc < 0) {
-				setEventMessages($object->error, $object->errors, 'errors');
+				setEventMessages($object->error, $object->errors, 'warnings');
 			}
 
 			if ($result < 0) dol_print_error($db, $result);

--- a/htdocs/core/actions_setnotes.inc.php
+++ b/htdocs/core/actions_setnotes.inc.php
@@ -54,7 +54,12 @@ if ($action == 'setnote_public' && !empty($permissionnote) && !GETPOST('cancel',
 			$hidedesc = (GETPOST('hidedesc', 'int') ? GETPOST('hidedesc', 'int') : (!empty($conf->global->MAIN_GENERATE_DOCUMENTS_HIDE_DESC) ? 1 : 0));
 			$hideref = (GETPOST('hideref', 'int') ? GETPOST('hideref', 'int') : (!empty($conf->global->MAIN_GENERATE_DOCUMENTS_HIDE_REF) ? 1 : 0));
 
-			$result = $object->generateDocument($model, $outputlangs, $hidedetails, $hidedesc, $hideref);
+			//see #21072: Update a public note with a "document model not found" is not really a problem : the PDF is not created/updated
+			//but the note is saved, so just add a notification will be enought
+			$resultGenDoc = $object->generateDocument($model, $outputlangs, $hidedetails, $hidedesc, $hideref);
+			if ($resultGenDoc < 0) {
+				setEventMessages($object->error, $object->errors, 'errors');
+			}
 
 			if ($result < 0) dol_print_error($db, $result);
 		}


### PR DESCRIPTION
# Fix #21072 : bad error on public note update if document model does not exists

There was a race condition on generateDocument called by actions if the document model does not exists (old dolibarr, migration, old model name ...).