### PR TITLE
FIX : Save email from the auto register form in Project module

### DIFF
--- a/htdocs/public/project/new.php
+++ b/htdocs/public/project/new.php
@@ -222,6 +222,7 @@ if (empty($reshook) && $action == 'add') {
 			} else {
 				$thirdparty->name = dolGetFirstLastname(GETPOST('firstname'), GETPOST('lastname'));
 			}
+			$thirdparty->email = GETPOST('email');
 			$thirdparty->address = GETPOST('address');
 			$thirdparty->zip = GETPOST('zip');
 			$thirdparty->town = GETPOST('town');


### PR DESCRIPTION
I found out that the email from the auto register form in the Project module didn't save the email input during the creation of the third party.

So I looked for the source code, and check that in my locahost version but I don't know if there is anywhere else in the code this had to be fixed.