### PR TITLE
FIX discount wasn't taken into account when adding a line in BOM

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1058,8 +1058,10 @@ class BOM extends CommonObject
 						return -1;
 					}
 					$line->unit_cost = price2num((!empty($tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
-					if (empty($line->unit_cost)) {
-						if ($productFournisseur->find_min_price_product_fournisseur($line->fk_product) > 0) {
+					if ((empty($line->unit_cost)) && ($productFournisseur->find_min_price_product_fournisseur($line->fk_product) > 0)) {
+						if ($productFournisseur->fourn_remise_percent != "0") {
+							$line->unit_cost = $productFournisseur->fourn_unitprice_with_discount;
+						} else {
 							$line->unit_cost = $productFournisseur->fourn_unitprice;
 						}
 					}

--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1,5 +1,6 @@
 <?php
-/* Copyright (C) 2019  Laurent Destailleur <eldy@users.sourceforge.net>
+/* Copyright (C) 2019	Laurent Destailleur	<eldy@users.sourceforge.net>
+ * Copyright (C) 2023	Benjamin Falière	<benjamin.faliere@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
FIX

When a product was added to a BOM, if a discount was defined for a specific supplier, this one wasn't taken into account when adding the line, it was only the fourn_unitprice.
As the fourn_unitprice_with_discount is always defined, even if there is no discount, I used this one.