### PR TITLE
Fix prelevement line : the link to the facture was to a customer fac, not fourn fac

### DIFF
--- a/htdocs/compta/prelevement/line.php
+++ b/htdocs/compta/prelevement/line.php
@@ -309,7 +309,11 @@ if ($id) {
 			print img_object($langs->trans("ShowBill"), "bill");
 			print '</a>&nbsp;';
 
-			print '<a href="'.DOL_URL_ROOT.'/compta/facture/card.php?facid='.$obj->facid.'">'.$obj->ref."</a></td>\n";
+			if ($type == 'bank-transfer') {
+				print '<a href="'.DOL_URL_ROOT.'/fourn/facture/card.php?facid='.$obj->facid.'">'.$obj->ref."</a></td>\n";
+			} else {
+				print '<a href="'.DOL_URL_ROOT.'/compta/facture/card.php?facid='.$obj->facid.'">'.$obj->ref."</a></td>\n";
+			}
 
 			print '<td><a href="'.DOL_URL_ROOT.'/comm/card.php?socid='.$obj->socid.'">';
 			print img_object($langs->trans("ShowCompany"), "company").' '.$obj->name."</a></td>\n";


### PR DESCRIPTION
# FIX # Prelevement line : the link to facture was to a customer invoice, not a fourn invoice

On compta/prelevement/line.php

If type = bank-transfer , then we look for facturefourn data.
But the link to the facture points to compta/facture/card.php, which is customer invoice.
We have to make it point to fourn/facture/card.php.

**Current behavior :** 

This is the prelevement line. The related invoice is a facturefourn.
![image](https://user-images.githubusercontent.com/89838020/217306508-209c0f34-caa0-43b2-991d-298d4d0a6315.png)
... However, the link leads to the customer facture of same ID (note : the ref is different)

![Capture d’écran_2023-02-07_17-38-59](https://user-images.githubusercontent.com/89838020/217307318-14d77c68-8881-4f1b-a93e-0941bf9abb49.png)

**Expected behavior :** 

The link should lead to the right facture fourn.

