### PR TITLE
FIX bug alias extra in extrafields syntax configuration

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1233,7 +1233,7 @@ class ExtraFields
 							$InfoFieldList[4] = str_replace('$ID$', '0', $InfoFieldList[4]);
 						}
 						//We have to join on extrafield table
-						if (strpos($InfoFieldList[4], 'extra') !== false) {
+						if (strpos($InfoFieldList[4], 'extra.') !== false) {
 							$sql .= ' as main, '.$this->db->prefix().$InfoFieldList[0].'_extrafields as extra';
 							$sqlwhere .= " WHERE extra.fk_object=main.".$InfoFieldList[2]." AND ".$InfoFieldList[4];
 						} else {


### PR DESCRIPTION
# FIX|Fix #

Extrafields with value doesn't work : 
![image](https://user-images.githubusercontent.com/52402938/217495392-a29772e0-d1e2-4ff3-8981-d6829622b51c.png)

Because this case breaks sql request : 
![image](https://user-images.githubusercontent.com/52402938/217495886-d46d3697-e56f-42b8-8168-259ce1fe9628.png)

I propose to look on "extra." instead of "extra" to fix bug for filter parameter.