### PR TITLE
Fix Shipment Creation from Order via REST API

### DIFF
--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -1053,6 +1053,7 @@ class Orders extends DolibarrApi
 		}
 		$shipment = new Expedition($this->db);
 		$shipment->socid = $this->commande->socid;
+		$shipment->origin_id = $this->commande->id;
 		$result = $shipment->create(DolibarrApiAccess::$user);
 		if ($result <= 0) {
 			throw new RestException(500, 'Error on creating expedition :'.$this->db->lasterror());


### PR DESCRIPTION
The created shipment does not link to Order while using REST API.