### PR TITLE
Add missing table_element

### DIFF
--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2680,6 +2680,11 @@ class ExpenseReportLine extends CommonObjectLine
 	 * @var DoliDB Database handler.
 	 */
 	public $db;
+	
+	/**
+     * @var string Name of table without prefix where object is stored
+     */
+    public $table_element = 'expensereport_det';
 
 	/**
 	 * @var string Error code (or message)

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2680,11 +2680,11 @@ class ExpenseReportLine extends CommonObjectLine
 	 * @var DoliDB Database handler.
 	 */
 	public $db;
-	
+
 	/**
-     * @var string Name of table without prefix where object is stored
-     */
-    public $table_element = 'expensereport_det';
+	 * @var string Name of table without prefix where object is stored
+	 */
+	public $table_element = 'expensereport_det';
 
 	/**
 	 * @var string Error code (or message)


### PR DESCRIPTION
This allow usage of extrafields logic on detail lines (still missing table and setup pages)

# FIX|Fix #23641
[*Basic part of fix, this allow usage of extrafields on the element without touch the core components*]

