### PR TITLE
Fix : sall becomes search_all on top menu search also

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -2732,7 +2732,7 @@ function top_menu_search()
 	$buttonList .= '</div>';
 
 
-	$searchInput = '<input name="sall" id="top-global-search-input" class="dropdown-search-input" placeholder="'.$langs->trans('Search').'" autocomplete="off" >';
+	$searchInput = '<input name="search_all" id="top-global-search-input" class="dropdown-search-input" placeholder="'.$langs->trans('Search').'" autocomplete="off" >';
 
 	$dropDownHtml = '<form id="top-menu-action-search" name="actionsearch" method="GET" action="'.$defaultAction.'" >';
 


### PR DESCRIPTION
In 1033991486a43bda029873b46a187189a5b0f38e, the top menu search was missing to replace sall by search_all