### PR TITLE
FIX: product ref fourn same size in supplier order/invoice as in product price fourn

### DIFF
--- a/htdocs/install/mysql/migration/14.0.0-15.0.0.sql
+++ b/htdocs/install/mysql/migration/14.0.0-15.0.0.sql
@@ -530,3 +530,6 @@ ALTER TABLE llx_element_tag ADD CONSTRAINT fk_element_tag_categorie_rowid FOREIG
 -- Idea is to update this column manually in v15 with value in currency of company for bank that are not into the main currency and the transfer
 -- into accounting will use it in priority if value is not null. The script repair.sql contains the sequence to fix datas in llx_bank.
 ALTER TABLE llx_bank ADD COLUMN amount_main_currency double(24,8) NULL;
+
+ALTER TABLE llx_commande_fournisseurdet MODIFY COLUMN ref varchar(128);
+ALTER TABLE llx_facture_fourn_det MODIFY COLUMN ref varchar(128);

--- a/htdocs/install/mysql/tables/llx_commande_fournisseurdet.sql
+++ b/htdocs/install/mysql/tables/llx_commande_fournisseurdet.sql
@@ -25,7 +25,7 @@ create table llx_commande_fournisseurdet
   fk_commande                integer      NOT NULL,
   fk_parent_line             integer      NULL,
   fk_product                 integer,
-  ref                        varchar(50),               -- supplier product ref
+  ref                        varchar(128),              -- supplier product ref
   label                      varchar(255),              -- product label
   description                text,
   vat_src_code               varchar(10)  DEFAULT '',   -- Vat code used as source of vat fields. Not strict foreign key here.

--- a/htdocs/install/mysql/tables/llx_facture_fourn_det.sql
+++ b/htdocs/install/mysql/tables/llx_facture_fourn_det.sql
@@ -24,7 +24,7 @@ create table llx_facture_fourn_det
   fk_facture_fourn  integer NOT NULL,
   fk_parent_line    integer NULL,
   fk_product        integer NULL,
-  ref               varchar(50),   -- supplier product ref
+  ref               varchar(128),  -- supplier product ref
   label             varchar(255),  -- product label
   description       text,
   pu_ht             double(24,8), -- unit price excluding tax


### PR DESCRIPTION
As in llx_product_fournisseur_price column ref size is varchar(128), it must be the same in llx_commande_fournisseurdet and llx_facture_fourn_det or it can be a message : data to long for column 'ref' at row