### PR TITLE
Fix: default values would not work for fk_account.

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2981,7 +2981,9 @@ if ($action == 'create') {
 	}
 
 	// when bank account is empty (means not override by payment mode form a other object, like third-party), try to use default value
-	$fk_account = GETPOSTISSET("fk_account") ? GETPOST("fk_account", 'int') : $fk_account;
+	if (empty($fk_account) && !empty($socid)) {
+		$fk_account = GETPOST("fk_account", 'int');
+	}
 
 	if (!empty($soc->id)) {
 		$absolute_discount = $soc->getAvailableDiscounts();


### PR DESCRIPTION
# Fix : Default value is not used for fk_account on an invoice creation

**Current behavior:**
On page admin/defaultvalues.php we set this parameter :
![image](https://user-images.githubusercontent.com/89838020/217883669-9f6eb339-f7fc-4749-8a73-c0ecc061a2ee.png)

Problem : it is not used on the compta/facture/card.php page (Compte bancaire).
![image](https://user-images.githubusercontent.com/89838020/217884176-66cf5fe3-a53f-43e2-b888-31707640d741.png)

But once we select a thirdparty, the value is set to the account configured on the thirdparty (here CIC).
![image](https://user-images.githubusercontent.com/89838020/217884669-f0bc1d4e-d6c5-4812-aed4-632c9c588db5.png)

And if the thirdparty does not have an account configured, the account stays blank. The default value is never used.

**Expected behavior:**

When default value is set for fk_account:
- on a virgin page, fk_account should not be set.
- If the page has been reloaded with parameter &socid:
  - if fk_account is defined for thirdparty, use this value
  - else, use the default value by using GETPOST() function.

