### PR TITLE
Fix: #20521 removed downcasing and abbreviation of already translated term for day

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -286,7 +286,7 @@ function convertSecondToTime($iSecond, $format = 'all', $lengthOfDay = 86400, $l
 			if ($sDay > 1) {
 				$dayTranslate = $langs->trans("Days");
 			}
-			$sTime .= $sDay.' '.strtolower(dol_substr($dayTranslate, 0, 1)).'. ';
+			$sTime .= $sDay.' '.$dayTranslate.' ';
 		}
 
 		if ($format == 'all') {


### PR DESCRIPTION
Best is to see the long description in the issue #20521.

Brief version:
Word for day gets translated into target language.
But then it got downcased, the first character taken and a . added.

This is unfortunately not the way, the word for Day gets abbreviated in most languages.

If a one letter version is really needed somewhere (could not find a place so far), it would be better to create a dedicated translation key and translate it in other languages as needed.