### PR TITLE
[FIX] extrafield with visibility '5' update bug

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2114,7 +2114,7 @@ class ExtraFields
 				) {
 					continue;
 				}
-				if (empty($visibility)) {
+				if (empty($visibility) || $visibility == 5) {
 					continue;
 				}
 				if (empty($perms)) {


### PR DESCRIPTION
When using a visibility = 5 (not editable extrafield, but visible on card and list), updating the object will result in an empty value in database for this extrafield.