### PR TITLE
NEW inc.php: handle parameters from argv

### DIFF
--- a/htdocs/install/inc.php
+++ b/htdocs/install/inc.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2012       Marcos García           <marcosgdf@gmail.com>
  * Copyright (C) 2016       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2021       Charlene Benke      	<charlene@patas-monkey.com>
+ * Copyright (C) 2023       Alexandre Janniaux      <alexandre.janniaux@gmail.com>
 *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -70,6 +71,92 @@ $conffiletoshow = "htdocs/conf/conf.php";
 //$conffile = "/etc/dolibarr/conf.php";
 //$conffiletoshow = "/etc/dolibarr/conf.php";
 
+$short_options = "c:h";
+$long_options = array(
+	"config:",
+	"help",
+);
+
+/**
+ * Print the usage when executing scripts from install/.
+ *
+ * Print the help text exposing the available options when executing
+ * update or install script (ie. from htdocs/install/) from CLI with
+ * the `php` executable. This function does not `exit` the program and
+ * the caller should then call `exit` themselves since they should
+ * determine whether it was an error or not.
+ *
+ * @param string $program the script that was originally run
+ * @param string $header  the message to signal to the user
+ * @return void
+ */
+function usage($program, $header)
+{
+	echo $header."\n";
+	echo "  php ".$program." [options] previous_version new_version [script options]\n";
+	echo "\n";
+	echo "Script options when using upgrade.php:\n";
+	echo "\n";
+	echo "  dirmodule:\n";
+	echo "      Specify dirmodule to provide a path for an external module\n";
+	echo "      so the migration is done using a script from a module.\n";
+	echo "\n";
+	echo "  ignoredbversion:\n";
+	echo "      Allow to run migration even if database version does\n";
+	echo "      not match start version of migration.\n";
+	echo "\n";
+	echo "Script options when using upgrade2.php:\n";
+	echo "\n";
+	echo "  MODULE_NAME1_TO_ENABLE,MODULE_NAME2_TO_ENABLE:\n";
+	echo "      Specify a list of module-name to enable, joined by comma.\n";
+	echo "\n";
+	echo "Options:\n";
+	echo "  -c, --config <filename>:\n";
+	echo "      Provide a different conf.php file to use.\n";
+	echo "\n";
+	echo "  -h, --help:\n";
+	echo "      Display this help message.\n";
+}
+
+if (php_sapi_name() === "cli") {
+	$rest_index = 0;
+	$opts = getopt($short_options, $long_options, $rest_index);
+
+	foreach ($opts as $opt => $arg) switch ($opt) {
+		case 'c':
+		case 'config':
+			$conffile = $arg;
+			$conffiletoshow = $arg;
+			break;
+		case 'h':
+		case 'help':
+			usage($argv[0], "Usage:");
+			exit(0);
+	}
+
+	// In the following test, only dash-prefixed arguments will trigger an
+	// error, given that scripts options can allow a variable number of
+	// additional non-prefixed argument and we mostly want to check for
+	// typo right now.
+	if ($rest_index < $argc && $argv[$rest_index][0] == "-") {
+		usage($argv[0], "Unknown option ".$argv[$rest_index]. ", usage:");
+		exit(1);
+	}
+
+	// Currently, scripts using inc.php will require addtional arguments,
+	// see help above for more details.
+	if ($rest_index > $argc - 2) {
+		usage($argv[0], "Missing mandatory arguments, usage:");
+		exit(1);
+	}
+
+	// Tricky argument list hack, should be removed someday.
+	// Reset argv to remove the argument that were parsed. This is needed
+	// currently because some install code, like in upgrade.php, are using
+	// $argv[] directly with fixed index to fetch some arguments.
+	$argv = array_merge(array($argv[0]), array_slice($argv, $rest_index));
+	$argc = count($argv);
+}
 
 // Load conf file if it is already defined
 if (!defined('DONOTLOADCONF') && file_exists($conffile) && filesize($conffile) > 8) { // Test on filesize is to ensure that conf file is more that an empty template with just <?php in first line


### PR DESCRIPTION

# NEW|New inc.php: handle parameters from argv

This commit adds support for --help and --config to provide a different config file when running upgrade.php from commandline. The argv array is patched afterwards as if the options were never given so that it stays transparent for the code path that are not aware of those arguments.

The intention behind is incrementally move the usage of argc/argv to this location and force help/usage from there, in particular for upgrading.

The rationale for the --config addition is to be able to provide a different path for conf.php when multiple dolibarr instance are using the same readonly htdocs folder, which is already possible by modifying the `include_path` from PHP for the htdocs/ directory but not for the htdocs/install directory since relative paths are used to fetch the config file. Since the use-case is to upgrade/migrate a Dolibarr instance from CLI, it makes sense to be able to select for which instance (and database parameters) the upgrade should take place.

---

Hi, this is my first merge request to the project. I've tried to discuss this point on the Discord but we can discuss here or I can first create an issue if needed. I wasn't sure whether I should create the issue first since it would have included multiple point on upgrade.php CLI usage and maybe that's not the target for the project? However, if it was preferred, I'll create new issues before sending more patches on this topic.

 