### PR TITLE
FIX id null generates errors

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -1464,7 +1464,7 @@ class Categorie extends CommonObject
 		$ways = array();
 
 		$parents = $this->get_meres();
-		if (is_array($parents)) {
+		if ((is_array($parents)) && ($parents['id'] > 0)) {
 			foreach ($parents as $parent) {
 				$allways = $parent->get_all_ways();
 				foreach ($allways as $way) {


### PR DESCRIPTION
FIX

If the id in array is null, it generates an error with SQL request on rowid.