### PR TITLE
FIX: SQL error "unknown column p.fk_soc"

### DIFF
--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -248,7 +248,7 @@ class PropaleStats extends Stats
 		global $user;
 
 		$sql = "SELECT product.ref, COUNT(product.ref) as nb, SUM(tl.".$this->field_line.") as total, AVG(tl.".$this->field_line.") as avg";
-		$sql .= " FROM ".$this->from.", ".$this->from_line.", ".MAIN_DB_PREFIX."product as product";
+		$sql .= " FROM (".$this->from.", ".$this->from_line.", ".MAIN_DB_PREFIX."product as product)";
 		if (empty($user->rights->societe->client->voir) && !$user->socid) {
 			$sql .= "  INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON p.fk_soc = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 		}

--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -247,19 +247,18 @@ class PropaleStats extends Stats
 	{
 		global $user;
 
-		$sql = 'SELECT product.ref, COUNT(product.ref) as nb, SUM(tl.' . $this->field_line . ') as total, AVG(tl.' . $this->field_line . ') as avg';
-		$sql .= ' FROM ' . $this->from;
-		$sql .= ' INNER JOIN ' . $this->from_line . ' ON p.rowid = tl.fk_propal';
-		$sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product as product ON tl.fk_product = product.rowid';
-		if (empty($user->rights->societe->client->voir) && ! $user->socid) {
-			$sql .= '  INNER JOIN ' . MAIN_DB_PREFIX . 'societe_commerciaux as sc ON p.fk_soc = sc.fk_soc AND sc.fk_user = ' . ((int) $user->id);
+		$sql = "SELECT product.ref, COUNT(product.ref) as nb, SUM(tl.".$this->field_line.") as total, AVG(tl.".$this->field_line.") as avg";
+		$sql .= " FROM ".$this->from;
+		$sql .= " INNER JOIN ".$this->from_line." ON p.rowid = tl.fk_propal";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."product as product ON tl.fk_product = product.rowid";
+		if (empty($user->rights->societe->client->voir) && !$user->socid) {
+			$sql .= "  INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON p.fk_soc = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 		}
 		$sql .= $this->join;
-		$sql .= ' WHERE ' . $this->where;
-		$sql .= ' AND ' . $this->field_date . " BETWEEN '" . $this->db->idate(dol_get_first_day($year, 1, false)) . "' AND '" . $this->db->idate(dol_get_last_day($year, 12, false)) . "'";
-		$sql .= ' GROUP BY product.ref';
+		$sql .= " WHERE ".$this->where;
+		$sql .= " AND ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year, 1, false))."' AND '".$this->db->idate(dol_get_last_day($year, 12, false))."'";
+		$sql .= " GROUP BY product.ref";
 		$sql .= $this->db->order('nb', 'DESC');
-
 		//$sql.= $this->db->plimit(20);
 
 		return $this->_getAllByProduct($sql, $limit);

--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -247,17 +247,19 @@ class PropaleStats extends Stats
 	{
 		global $user;
 
-		$sql = "SELECT product.ref, COUNT(product.ref) as nb, SUM(tl.".$this->field_line.") as total, AVG(tl.".$this->field_line.") as avg";
-		$sql .= " FROM (".$this->from.", ".$this->from_line.", ".MAIN_DB_PREFIX."product as product)";
-		if (empty($user->rights->societe->client->voir) && !$user->socid) {
-			$sql .= "  INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON p.fk_soc = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
+		$sql = 'SELECT product.ref, COUNT(product.ref) as nb, SUM(tl.' . $this->field_line . ') as total, AVG(tl.' . $this->field_line . ') as avg';
+		$sql .= ' FROM ' . $this->from;
+		$sql .= ' INNER JOIN ' . $this->from_line . ' ON p.rowid = tl.fk_propal';
+		$sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product as product ON tl.fk_product = product.rowid';
+		if (empty($user->rights->societe->client->voir) && ! $user->socid) {
+			$sql .= '  INNER JOIN ' . MAIN_DB_PREFIX . 'societe_commerciaux as sc ON p.fk_soc = sc.fk_soc AND sc.fk_user = ' . ((int) $user->id);
 		}
 		$sql .= $this->join;
-		$sql .= " WHERE ".$this->where;
-		$sql .= " AND p.rowid = tl.fk_propal AND tl.fk_product = product.rowid";
-		$sql .= " AND ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year, 1, false))."' AND '".$this->db->idate(dol_get_last_day($year, 12, false))."'";
-		$sql .= " GROUP BY product.ref";
+		$sql .= ' WHERE ' . $this->where;
+		$sql .= ' AND ' . $this->field_date . " BETWEEN '" . $this->db->idate(dol_get_first_day($year, 1, false)) . "' AND '" . $this->db->idate(dol_get_last_day($year, 12, false)) . "'";
+		$sql .= ' GROUP BY product.ref';
 		$sql .= $this->db->order('nb', 'DESC');
+
 		//$sql.= $this->db->plimit(20);
 
 		return $this->_getAllByProduct($sql, $limit);


### PR DESCRIPTION
# FIX error on home page

### To reproduce the bug:
1) remove the right `societe->client->voir` from your user
2) remove any cache files for statistics (`documents/user/temp/*`)
3) go to home page of Dolibarr

#### Result:

**Latest database access request error:** SELECT product.ref, COUNT(product.ref) as nb, SUM(tl.total_ht) as total, AVG(tl.total_ht) as avg FROM llx_propal as p, llx_propaldet as tl, llx_product as product INNER JOIN llx_societe_commerciaux as sc ON p.fk_soc = sc.fk_soc AND sc.fk_user = 1 WHERE p.entity IN (1) AND p.rowid = tl.fk_propal AND tl.fk_product = product.rowid AND p.datep BETWEEN '2023-01-01 00:00:00' AND '2023-12-31 23:59:59' GROUP BY product.ref ORDER BY nb DESC
**Return code for latest database access request error:** DB_ERROR_NOSUCHFIELD
**Information for latest database access request error:** Unknown column 'p.fk_soc' in 'on clause'

### Analysis
After researching it a bit, I found [this stackoverflow topic](https://stackoverflow.com/questions/4065985/mysql-unknown-column-in-on-clause) which explains the problem: ANSI-92 joins (i.e. joins using the LEFT JOIN, INNER JOIN etc. keywords) take precedence over ANSI-89 joins (i.e. joins by comma in table list) and therefore the join on `llx_societe_commerciaux` occurs before the join on `llx_propal` but its `ON` clause requires `llx_propal` to be joined first.

Basically,
```sql
SELECT * from A, B left join C on C.xyz = A.xyz;
-- → error: unknown column 'A.xyz' in 'on clause'
```
 is not the same as
```sql
SELECT * from (A, B) left join C on C.xyz = A.xyz;
-- → no error
```

The responder also recommended not to mix the two styles of joins in one request, but I found it easier to not rewrite the whole query (but we could keep this in mind for the future).
