### PR TITLE
Fix update bom net needs table

### DIFF
--- a/htdocs/bom/bom_net_needs.php
+++ b/htdocs/bom/bom_net_needs.php
@@ -296,20 +296,30 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 		<script type="text/javascript" language="javascript">
 			$(document).ready(function() {
+
+                function folderManage(element) {
+                    var id_bom_line = element.attr('id').replace('collapse-', '');
+                    let TSubLines = $('[parentid="'+ id_bom_line +'"]');
+
+                    if(element.html().indexOf('folder-open') <= 0) {
+                        $('[parentid="'+ id_bom_line +'"]').show();
+                        element.html('<?php echo dol_escape_js(img_picto('', 'folder-open')); ?>');
+                    }
+                    else {
+                        for (let i = 0; i < TSubLines.length; i++) {
+                            let subBomFolder = $(TSubLines[i]).children('.linecoldescription').children('.collapse_bom');
+                            if (subBomFolder.length > 0) {
+                                folderManage(subBomFolder);
+                            }
+                        }
+                        TSubLines.hide();
+                        element.html('<?php echo dol_escape_js(img_picto('', 'folder')); ?>');
+                    }
+                }
+
 				// When clicking on collapse
 				$(".collapse_bom").click(function() {
-					console.log("We click on collapse");
-					var id_bom_line = $(this).attr('id').replace('collapse-', '');
-					console.log($(this).html().indexOf('folder-open'));
-					if($(this).html().indexOf('folder-open') <= 0) {
-						$('[parentid="'+ id_bom_line +'"]').show();
-						$(this).html('<?php echo dol_escape_js(img_picto('', 'folder-open')); ?>');
-					}
-					else {
-						$('[parentid="'+ id_bom_line +'"]').hide();
-						$(this).html('<?php echo dol_escape_js(img_picto('', 'folder')); ?>');
-					}
-
+                    folderManage($(this));
 					return false;
 				});
 

--- a/htdocs/bom/bom_net_needs.php
+++ b/htdocs/bom/bom_net_needs.php
@@ -214,6 +214,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		print '<a id="hide_all" href="#">'.img_picto('', 'folder', 'class="paddingright"').$langs->trans("UndoExpandAll").'</a>&nbsp;';
 	}
 	print '</td>';
+    if($action == 'treeview') print '<td class="left">'.$langs->trans('ProducedBy').'</td>';
 	print '<td class="linecolqty right">'.$langs->trans('Quantity').'</td>';
 	print '<td class="linecolstock right">'.$form->textwithpicto($langs->trans("PhysicalStock"), $text_stock_options, 1).'</td>';
 	print '<td class="linecoltheoricalstock right">'.$form->textwithpicto($langs->trans("VirtualStock"), $langs->trans("VirtualStockDesc")).'</td>';
@@ -226,13 +227,17 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			foreach ($TChildBom as $fk_bom => $TProduct) {
 				$repeatChar = '&emsp;';
 				if (!empty($TProduct['bom'])) {
+					$prod = new Product($db);
+					$prod->fetch($TProduct['bom']->fk_product);
 					if ($TProduct['parentid'] != $object->id) print '<tr class="sub_bom_lines oddeven" parentid="'.$TProduct['parentid'].'">';
 					else print '<tr class="oddeven">';
-					print '<td class="linecoldescription">'.str_repeat($repeatChar, $TProduct['level']).$TProduct['bom']->getNomUrl(1);
+					if($action == 'treeview') print '<td class="linecoldescription">'.str_repeat($repeatChar, $TProduct['level']).$prod->getNomUrl(1);
+                    else print '<td class="linecoldescription">'.str_repeat($repeatChar, $TProduct['level']).$TProduct['bom']->getNomUrl(1);
 					print ' <a class="collapse_bom" id="collapse-'.$fk_bom.'" href="#">';
 					print img_picto('', 'folder-open');
 					print '</a>';
 					print  '</td>';
+					if($action == 'treeview') print '<td class="left">'.$TProduct['bom']->getNomUrl(1).'</td>';
 					print '<td class="linecolqty right">'.$TProduct['qty'].'</td>';
 					print '<td class="linecolstock right"></td>';
 					print '<td class="linecoltheoricalstock right"></td>';
@@ -247,6 +252,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						if ($fk_bom != $object->id) print '<tr class="sub_bom_lines oddeven" parentid="'.$fk_bom.'">';
 						else print '<tr class="oddeven">';
 						print '<td class="linecoldescription">'.str_repeat($repeatChar, $TInfos['level']).$prod->getNomUrl(1).'</td>';
+						if($action == 'treeview') print '<td></td>';
 						print '<td class="linecolqty right">'.$TInfos['qty'].'</td>';
 						print '<td class="linecolstock right">'.price2num($prod->stock_reel, 'MS').'</td>';
 						print '<td class="linecoltheoricalstock right">'.$prod->stock_theorique.'</td>';

--- a/htdocs/bom/bom_net_needs.php
+++ b/htdocs/bom/bom_net_needs.php
@@ -214,7 +214,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		print '<a id="hide_all" href="#">'.img_picto('', 'folder', 'class="paddingright"').$langs->trans("UndoExpandAll").'</a>&nbsp;';
 	}
 	print '</td>';
-    if($action == 'treeview') print '<td class="left">'.$langs->trans('ProducedBy').'</td>';
+	if ($action == 'treeview') print '<td class="left">'.$langs->trans('ProducedBy').'</td>';
 	print '<td class="linecolqty right">'.$langs->trans('Quantity').'</td>';
 	print '<td class="linecolstock right">'.$form->textwithpicto($langs->trans("PhysicalStock"), $text_stock_options, 1).'</td>';
 	print '<td class="linecoltheoricalstock right">'.$form->textwithpicto($langs->trans("VirtualStock"), $langs->trans("VirtualStockDesc")).'</td>';
@@ -231,13 +231,13 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					$prod->fetch($TProduct['bom']->fk_product);
 					if ($TProduct['parentid'] != $object->id) print '<tr class="sub_bom_lines oddeven" parentid="'.$TProduct['parentid'].'">';
 					else print '<tr class="oddeven">';
-					if($action == 'treeview') print '<td class="linecoldescription">'.str_repeat($repeatChar, $TProduct['level']).$prod->getNomUrl(1);
-                    else print '<td class="linecoldescription">'.str_repeat($repeatChar, $TProduct['level']).$TProduct['bom']->getNomUrl(1);
+					if ($action == 'treeview') print '<td class="linecoldescription">'.str_repeat($repeatChar, $TProduct['level']).$prod->getNomUrl(1);
+					else print '<td class="linecoldescription">'.str_repeat($repeatChar, $TProduct['level']).$TProduct['bom']->getNomUrl(1);
 					print ' <a class="collapse_bom" id="collapse-'.$fk_bom.'" href="#">';
 					print img_picto('', 'folder-open');
 					print '</a>';
 					print  '</td>';
-					if($action == 'treeview') print '<td class="left">'.$TProduct['bom']->getNomUrl(1).'</td>';
+					if ($action == 'treeview') print '<td class="left">'.$TProduct['bom']->getNomUrl(1).'</td>';
 					print '<td class="linecolqty right">'.$TProduct['qty'].'</td>';
 					print '<td class="linecolstock right"></td>';
 					print '<td class="linecoltheoricalstock right"></td>';
@@ -252,7 +252,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						if ($fk_bom != $object->id) print '<tr class="sub_bom_lines oddeven" parentid="'.$fk_bom.'">';
 						else print '<tr class="oddeven">';
 						print '<td class="linecoldescription">'.str_repeat($repeatChar, $TInfos['level']).$prod->getNomUrl(1).'</td>';
-						if($action == 'treeview') print '<td></td>';
+						if ($action == 'treeview') print '<td></td>';
 						print '<td class="linecolqty right">'.$TInfos['qty'].'</td>';
 						print '<td class="linecolstock right">'.price2num($prod->stock_reel, 'MS').'</td>';
 						print '<td class="linecoltheoricalstock right">'.$prod->stock_theorique.'</td>';
@@ -297,29 +297,29 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		<script type="text/javascript" language="javascript">
 			$(document).ready(function() {
 
-                function folderManage(element) {
-                    var id_bom_line = element.attr('id').replace('collapse-', '');
-                    let TSubLines = $('[parentid="'+ id_bom_line +'"]');
+				function folderManage(element) {
+					var id_bom_line = element.attr('id').replace('collapse-', '');
+					let TSubLines = $('[parentid="'+ id_bom_line +'"]');
 
-                    if(element.html().indexOf('folder-open') <= 0) {
-                        $('[parentid="'+ id_bom_line +'"]').show();
-                        element.html('<?php echo dol_escape_js(img_picto('', 'folder-open')); ?>');
-                    }
-                    else {
-                        for (let i = 0; i < TSubLines.length; i++) {
-                            let subBomFolder = $(TSubLines[i]).children('.linecoldescription').children('.collapse_bom');
-                            if (subBomFolder.length > 0) {
-                                folderManage(subBomFolder);
-                            }
-                        }
-                        TSubLines.hide();
-                        element.html('<?php echo dol_escape_js(img_picto('', 'folder')); ?>');
-                    }
-                }
+					if(element.html().indexOf('folder-open') <= 0) {
+						$('[parentid="'+ id_bom_line +'"]').show();
+						element.html('<?php echo dol_escape_js(img_picto('', 'folder-open')); ?>');
+					}
+					else {
+						for (let i = 0; i < TSubLines.length; i++) {
+							let subBomFolder = $(TSubLines[i]).children('.linecoldescription').children('.collapse_bom');
+							if (subBomFolder.length > 0) {
+								folderManage(subBomFolder);
+							}
+						}
+						TSubLines.hide();
+						element.html('<?php echo dol_escape_js(img_picto('', 'folder')); ?>');
+					}
+				}
 
 				// When clicking on collapse
 				$(".collapse_bom").click(function() {
-                    folderManage($(this));
+					folderManage($(this));
 					return false;
 				});
 

--- a/htdocs/langs/en_US/mrp.lang
+++ b/htdocs/langs/en_US/mrp.lang
@@ -118,3 +118,4 @@ BomCantAddChildBom=The nomenclature %s is already present in the tree leading to
 BOMNetNeeds = BOM Net Needs
 BOMProductsList=BOM's products
 BOMServicesList=BOM's services
+ProducedBy=Produced by

--- a/htdocs/langs/fr_FR/mrp.lang
+++ b/htdocs/langs/fr_FR/mrp.lang
@@ -119,3 +119,4 @@ BomCantAddChildBom=La nomenclature %s est déjà présente dans l'arbre menant �
 BOMNetNeeds = Besoins nets
 BOMProductsList=Les produits de BOM
 BOMServicesList=Les services de BOM
+ProducedBy=Produit par


### PR DESCRIPTION
## FIX : Update BOM Nets Needs page : 

- Update the BOM Nets Needs table : Add a new column (Produced By) to show the associated BOM on the products that are sub-BOMs
![image](https://user-images.githubusercontent.com/67913809/220128925-81e0d6c4-6f91-4611-b038-d0cd40fe9907.png)

- Correction on folder feature that permits to show or hide sub-BOM lines : When we open a sub-BOM folder and then we close one of his parent ones, its sub-BOM lines stay showed 
