### PR TITLE
Fix tcpdi_parser infinite loop

### DIFF
--- a/htdocs/includes/tcpdi/tcpdi_parser.php
+++ b/htdocs/includes/tcpdi/tcpdi_parser.php
@@ -715,8 +715,7 @@ class tcpdi_parser {
 				$next = strcspn($data, "\r\n", $offset);
 				if ($next > 0) {
 					$offset += $next;
-					list($obj, $unused) = $this->getRawObject($offset, $data);
-					return $obj;
+					return $this->getRawObject($offset, $data);
 				}
 				break;
 			}


### PR DESCRIPTION
When mergin some old PDF we may have an infinite loop with this warning : "PHP Warning:  Illegal string offset 'Type' in ./htdocs/includes/tcpdi/tcpdi_parser.php on line 706"