### PR TITLE
Fix LDAP Authentification failure with error 500

### DIFF
--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -396,7 +396,7 @@ class Ldap
 	public function unbind()
 	{
 		$this->result = true;
-		if (is_resource($this->connection)) {
+		if (is_resource($this->connection) || is_object($this->connection)) {
 			$this->result = @ldap_unbind($this->connection);
 		}
 		if ($this->result) {

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -344,12 +344,7 @@ class Ldap
 	 */
 	public function close()
 	{
-		$r_type = get_resource_type($this->connection);
-		if ($this->connection && ($r_type === "Unknown" || !@ldap_close($this->connection))) {
-			return false;
-		} else {
-			return true;
-		}
+		return $this->unbind();
 	}
 
 	/**
@@ -401,7 +396,7 @@ class Ldap
 	public function unbind()
 	{
 		$this->result = true;
-		if ($this->connection) {
+		if (is_resource($this->connection)) {
 			$this->result = @ldap_unbind($this->connection);
 		}
 		if ($this->result) {


### PR DESCRIPTION
# FIX LDAP Authentification failure with error 500
This PR fix the LDAP Authentification when an username/password couple doesn't exist in LDAP and throws an error 500.

This bug was fixed in 6a52b96 (PR: #19726) , but was broken with massive rename of `$ldap->close()` to `$ldap->unbind()` in f497492

It is happening because there are too many closing LDAP connection calls. I'm sorry, I doesn't have the time to fix the source of the problem (with removing `$ldap->unlink()` spares) and don't want to break anything else. That's why I have only patched the closing function instead.

It will be nice to have this fix in 16.0.x version.

Thank you ;)