### PR TITLE
FIX : Recursive management for showing/hiding sub-BOM lines on MOs

### DIFF
--- a/htdocs/bom/lib/bom.lib.php
+++ b/htdocs/bom/lib/bom.lib.php
@@ -156,22 +156,33 @@ function mrpCollapseBomManagement()
 	<script type="text/javascript" language="javascript">
 
 		$(document).ready(function () {
-			// When clicking on collapse
-			$(".collapse_bom").click(function() {
-				console.log("We click on collapse");
-				var id_bom_line = $(this).attr('id').replace('collapse-', '');
-				console.log($(this).html().indexOf('folder-open'));
-				if($(this).html().indexOf('folder-open') <= 0) {
-					$('[parentid="'+ id_bom_line +'"]').show();
-					$(this).html('<?php echo dol_escape_js(img_picto('', 'folder-open')); ?>');
-				}
-				else {
-					$('[parentid="'+ id_bom_line +'"]').hide();
-					$(this).html('<?php echo dol_escape_js(img_picto('', 'folder')); ?>');
-				}
+            function folderManage(element, onClose = 0) {
+                let id_bom_line = element.attr('id').replace('collapse-', '');
+                let TSubLines = $('[parentid="'+ id_bom_line +'"]');
 
-				return false;
-			});
+                if(element.html().indexOf('folder-open') <= 0 && onClose < 1) {
+                    $('[parentid="'+ id_bom_line +'"]').show();
+                    element.html('<?php echo dol_escape_js(img_picto('', 'folder-open')); ?>');
+                }
+                else {
+                    for (let i = 0; i < TSubLines.length; i++) {
+                        let subBomFolder = $(TSubLines[i]).children('.linecoldescription').children('.collapse_bom');
+
+                        if (subBomFolder.length > 0) {
+                            onClose = 1
+                            folderManage(subBomFolder, onClose);
+                        }
+                    }
+                    TSubLines.hide();
+                    element.html('<?php echo dol_escape_js(img_picto('', 'folder')); ?>');
+                }
+            }
+
+            // When clicking on collapse
+            $(".collapse_bom").click(function() {
+                folderManage($(this));
+                return false;
+            });
 
 			// To Show all the sub bom lines
 			$("#show_all").click(function() {

--- a/htdocs/bom/lib/bom.lib.php
+++ b/htdocs/bom/lib/bom.lib.php
@@ -156,33 +156,33 @@ function mrpCollapseBomManagement()
 	<script type="text/javascript" language="javascript">
 
 		$(document).ready(function () {
-            function folderManage(element, onClose = 0) {
-                let id_bom_line = element.attr('id').replace('collapse-', '');
-                let TSubLines = $('[parentid="'+ id_bom_line +'"]');
+			function folderManage(element, onClose = 0) {
+				let id_bom_line = element.attr('id').replace('collapse-', '');
+				let TSubLines = $('[parentid="'+ id_bom_line +'"]');
 
-                if(element.html().indexOf('folder-open') <= 0 && onClose < 1) {
-                    $('[parentid="'+ id_bom_line +'"]').show();
-                    element.html('<?php echo dol_escape_js(img_picto('', 'folder-open')); ?>');
-                }
-                else {
-                    for (let i = 0; i < TSubLines.length; i++) {
-                        let subBomFolder = $(TSubLines[i]).children('.linecoldescription').children('.collapse_bom');
+				if(element.html().indexOf('folder-open') <= 0 && onClose < 1) {
+					$('[parentid="'+ id_bom_line +'"]').show();
+					element.html('<?php echo dol_escape_js(img_picto('', 'folder-open')); ?>');
+				}
+				else {
+					for (let i = 0; i < TSubLines.length; i++) {
+						let subBomFolder = $(TSubLines[i]).children('.linecoldescription').children('.collapse_bom');
 
-                        if (subBomFolder.length > 0) {
-                            onClose = 1
-                            folderManage(subBomFolder, onClose);
-                        }
-                    }
-                    TSubLines.hide();
-                    element.html('<?php echo dol_escape_js(img_picto('', 'folder')); ?>');
-                }
-            }
+						if (subBomFolder.length > 0) {
+							onClose = 1
+							folderManage(subBomFolder, onClose);
+						}
+					}
+					TSubLines.hide();
+					element.html('<?php echo dol_escape_js(img_picto('', 'folder')); ?>');
+				}
+			}
 
-            // When clicking on collapse
-            $(".collapse_bom").click(function() {
-                folderManage($(this));
-                return false;
-            });
+			// When clicking on collapse
+			$(".collapse_bom").click(function() {
+				folderManage($(this));
+				return false;
+			});
 
 			// To Show all the sub bom lines
 			$("#show_all").click(function() {


### PR DESCRIPTION
## FIX : Recursive management for showing/hiding sub-BOM lines on MOs

Same problème on this : https://github.com/Dolibarr/dolibarr/pull/23969

- Correction on folder feature that permits to show or hide sub-BOM lines : When we open a sub-BOM folder and then we close one of his parent ones, its sub-BOM lines stay showed