### PR TITLE
FIX : Impossible to create value for product attribute (variant)

### DIFF
--- a/htdocs/variants/card.php
+++ b/htdocs/variants/card.php
@@ -330,9 +330,7 @@ if ($action == 'create') {
 			print '<table id="tablelines" class="noborder centpercent">';
 		}
 
-		if (!empty($object->lines)) {
-			$object->printObjectLines($action, $mysoc, null, GETPOST('lineid', 'int'), 1, '/variants/tpl', ($permissiontoedit ? 1 : 0));
-		}
+		$object->printObjectLines($action, $mysoc, null, GETPOST('lineid', 'int'), 1, '/variants/tpl', ($permissiontoedit ? 1 : 0));
 
 		if (!empty($object->lines) || ($permissiontoedit && $action != 'selectlines' && $action != 'editline')) {
 			print '</table>';

--- a/htdocs/variants/tpl/productattributevalueline_create.tpl.php
+++ b/htdocs/variants/tpl/productattributevalueline_create.tpl.php
@@ -40,20 +40,6 @@ $objectline = null;
 
 print "<!-- BEGIN PHP TEMPLATE productattributevalueline_create.tpl.php -->\n";
 $nolinesbefore = (count($this->lines) == 0 || $forcetoshowtitlelines);
-if ($nolinesbefore) {
-	?>
-	<tr class="liste_titre<?php echo ($nolinesbefore ? '' : ' liste_titre_add_') ?> nodrag nodrop">
-		<?php if (!empty($conf->global->MAIN_VIEW_LINE_NUMBER)) { ?>
-			<td class="linecolnum center"></td>
-		<?php } ?>
-		<td class="linecolref">
-			<div id="add"></div><span class="hideonsmartphone"><?php echo $langs->trans('AddNewLine'); ?></span>
-		</td>
-		<td class="linecolvalue"><span id="title_vat"><?php echo $langs->trans('Value'); ?></span></td>
-		<td class="linecoledit" colspan="<?php echo $colspan; ?>">&nbsp;</td>
-	</tr>
-	<?php
-}
 ?>
 <tr class="pair nodrag nodrop nohoverpair<?php echo $nolinesbefore ? '' : ' liste_titre_create'; ?>">
 	<?php


### PR DESCRIPTION
## FIX : Can't create value for product attribute 

It seems that when an attribute does not have any value, the table is not displayed on the page. 
Nevertheless, we need this table to create some value for attributes 

![image](https://user-images.githubusercontent.com/67913809/220942740-f43f5d98-8774-4380-8de8-442c5e847eda.png)
