### PR TITLE
FIX Activate widget Alert product on stock only on home

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -104,7 +104,7 @@ class modProduct extends DolibarrModules
 		// Boxes
 		$this->boxes = array(
 			0=>array('file'=>'box_produits.php', 'enabledbydefaulton'=>'Home'),
-			1=>array('file'=>'box_produits_alerte_stock.php', 'enabledbydefaulton'=>''),
+			1=>array('file'=>'box_produits_alerte_stock.php', 'enabledbydefaulton'=>'Home'),
 			2=>array('file'=>'box_graph_product_distribution.php', 'enabledbydefaulton'=>'Home')
 		);
 


### PR DESCRIPTION
Without defining the area where it should be activated, the widget is activated everywhere....

Limit to home

![image](https://user-images.githubusercontent.com/2341395/221344570-b067d022-dff5-43a4-941a-7b0a881342da.png)
