### PR TITLE
FIX Accountancy - Journal - Ajust terms by default like only sell, purchases, etc

### DIFF
--- a/htdocs/accountancy/journal/sellsjournal.php
+++ b/htdocs/accountancy/journal/sellsjournal.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2011       Juanjo Menent           <jmenent@2byte.es>
  * Copyright (C) 2012       Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2013       Christophe Battarel     <christophe.battarel@altairis.fr>
- * Copyright (C) 2013-2021  Alexandre Spangaro      <aspangaro@open-dsi.fr>
+ * Copyright (C) 2013-2023  Alexandre Spangaro      <aspangaro@open-dsi.fr>
  * Copyright (C) 2013-2016  Florian Henry           <florian.henry@open-concept.pro>
  * Copyright (C) 2013-2016  Olivier Geffroy         <jeff@jeffinfo.com>
  * Copyright (C) 2014       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>

--- a/htdocs/install/mysql/data/llx_accounting_abc.sql
+++ b/htdocs/install/mysql/data/llx_accounting_abc.sql
@@ -46,13 +46,13 @@
 
 -- Accounting Journals 
 
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('VT',  'ACCOUNTING_SELL_JOURNAL',          2, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('AC',  'ACCOUNTING_PURCHASE_JOURNAL',      3, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('BQ',  'FinanceJournal',                   4, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('OD',  'ACCOUNTING_MISCELLANEOUS_JOURNAL', 1, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('AN',  'ACCOUNTING_HAS_NEW_JOURNAL',       9, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('ER',  'ExpenseReportsJournal',            5, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('INV', 'InventoryJournal',                 8, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('VT',  'AccountingJournalType2', 2, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('AC',  'AccountingJournalType3', 3, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('BQ',  'AccountingJournalType4', 4, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('OD',  'AccountingJournalType1', 1, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('AN',  'AccountingJournalType9', 9, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('ER',  'AccountingJournalType5', 5, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('INV', 'AccountingJournalType8', 8, 1, 1);
 
 
 -- Accounting Charts / Plans (Templates) for Countries

--- a/htdocs/install/mysql/data/llx_accounting_abc.sql
+++ b/htdocs/install/mysql/data/llx_accounting_abc.sql
@@ -5,7 +5,7 @@
 -- Copyright (C) 2004      Guillaume Delecourt  <guillaume.delecourt@opensides.be>
 -- Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
 -- Copyright (C) 2007      Patrick Raguin       <patrick.raguin@gmail.com>
--- Copyright (C) 2011-2022 Alexandre Spangaro   <aspangaro@open-dsi.fr>
+-- Copyright (C) 2011-2023 Alexandre Spangaro   <aspangaro@open-dsi.fr>
 -- Copyright (C) 2015-2017 Juanjo Menent        <jmenent@2byte.es>
 -- Copyright (C) 2018      Abbes bahfir         <dolipar@dolipar.org>
 -- Copyright (C) 2020      Udo Tamm             <dev@dolibit.de>
@@ -46,13 +46,13 @@
 
 -- Accounting Journals 
 
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('VT',  'AccountingJournalType2', 2, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('AC',  'AccountingJournalType3', 3, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('BQ',  'AccountingJournalType4', 4, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('OD',  'AccountingJournalType1', 1, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('AN',  'AccountingJournalType9', 9, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('ER',  'AccountingJournalType5', 5, 1, 1);
-INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('INV', 'AccountingJournalType8', 8, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('VT',  'ACCOUNTING_SELL_JOURNAL',          2, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('AC',  'ACCOUNTING_PURCHASE_JOURNAL',      3, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('BQ',  'ACCOUNTING_BANK_JOURNAL',          4, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('OD',  'ACCOUNTING_MISCELLANEOUS_JOURNAL', 1, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('AN',  'ACCOUNTING_HAS_NEW_JOURNAL',       9, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('ER',  'ACCOUNTING_EXPENSEREPORT_JOURNAL', 5, 1, 1);
+INSERT INTO llx_accounting_journal (code, label, nature, active, entity) VALUES ('INV', 'ACCOUNTING_INVENTORY_JOURNAL',     8, 1, 1);
 
 
 -- Accounting Charts / Plans (Templates) for Countries

--- a/htdocs/langs/en_US/accountancy.lang
+++ b/htdocs/langs/en_US/accountancy.lang
@@ -166,14 +166,14 @@ ACCOUNTANCY_COMBO_FOR_AUX=Enable combo list for subsidiary account (may be slow 
 ACCOUNTING_DATE_START_BINDING=Define a date to start binding & transfer in accountancy. Below this date, the transactions will not be transferred to accounting.
 ACCOUNTING_DEFAULT_PERIOD_ON_TRANSFER=On accountancy transfer, what is the period selected by default
 
-ACCOUNTING_SELL_JOURNAL=Sales journal (sales and returns)
-ACCOUNTING_PURCHASE_JOURNAL=Purchase journal (purchase and returns)
-ACCOUNTING_BANK_JOURNAL=Cash journal (receipts and disbursements)
-ACCOUNTING_EXPENSEREPORT_JOURNAL=Expense report journal
-ACCOUNTING_MISCELLANEOUS_JOURNAL=General journal
-ACCOUNTING_HAS_NEW_JOURNAL=Has new Journal
-ACCOUNTING_INVENTORY_JOURNAL=Inventory journal
-ACCOUNTING_SOCIAL_JOURNAL=Social journal
+ACCOUNTING_SELL_JOURNAL=Sales
+ACCOUNTING_PURCHASE_JOURNAL=Purchase
+ACCOUNTING_BANK_JOURNAL=Bank
+ACCOUNTING_EXPENSEREPORT_JOURNAL=Expense report
+ACCOUNTING_MISCELLANEOUS_JOURNAL=Miscellaneous operations
+ACCOUNTING_HAS_NEW_JOURNAL=Has new
+ACCOUNTING_INVENTORY_JOURNAL=Inventory
+ACCOUNTING_SOCIAL_JOURNAL=Social
 
 ACCOUNTING_RESULT_PROFIT=Result accounting account (Profit)
 ACCOUNTING_RESULT_LOSS=Result accounting account (Loss)


### PR DESCRIPTION
By default with a fresh install of v17 when we create data of journal, the term must be simple. Please simplifiy terms based on translation.

And if users do not rename the journal labels in Accounting > Configuration > Journals, the default terms are too long and with brackets. This will cause problems for some software and will be problematic during the FEC control, which could lead to a refusal of the latter.

By default :  

![image](https://user-images.githubusercontent.com/2341395/221394802-db3209a0-a54c-4362-b523-8a14fd02f806.png)

Move to : (After transifex synchronisation)

![image](https://user-images.githubusercontent.com/2341395/221395030-a63e5d1a-438f-491b-8161-5499834f03ae.png)
 


