### PR TITLE
Ignore localtaxes if localtax type zero

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4843,7 +4843,9 @@ class Form
 						$more .= '<div class="tagtr"><div class="tagtd'.(empty($input['tdclass']) ? '' : (' '.$input['tdclass'])).'">'.$input['label'].'</div>';
 						$more .= '<div class="tagtd">';
 						$addnowlink = (empty($input['datenow']) ? 0 : 1);
-						$more .= $this->selectDate($input['value'], $input['name'], 0, 0, 0, '', 1, $addnowlink);
+						$h = $input['hours'] ?: 0;
+						$m = $input['minutes'] ?: 0;
+						$more .= $this->selectDate($input['value'], $input['name'], $h, $m, 0, '', 1, $addnowlink);
 						$more .= '</div></div>'."\n";
 						$formquestion[] = array('name'=>$input['name'].'day');
 						$formquestion[] = array('name'=>$input['name'].'month');

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5688,7 +5688,7 @@ function isOnlyOneLocalTax($local)
 function get_localtax_by_third($local)
 {
 	global $db, $mysoc;
-	$sql = "SELECT t.localtax1, t.localtax2 ";
+	$sql = "SELECT t.localtax1_type, t.localtax2_type, t.localtax1, t.localtax2 ";
 	$sql .= " FROM ".MAIN_DB_PREFIX."c_tva as t inner join ".MAIN_DB_PREFIX."c_country as c ON c.rowid=t.fk_pays";
 	$sql .= " WHERE c.code = '".$db->escape($mysoc->country_code)."' AND t.active = 1 AND t.taux=(";
 	$sql .= "  SELECT max(tt.taux) FROM ".MAIN_DB_PREFIX."c_tva as tt inner join ".MAIN_DB_PREFIX."c_country as c ON c.rowid=tt.fk_pays";
@@ -5698,9 +5698,9 @@ function get_localtax_by_third($local)
 	$resql = $db->query($sql);
 	if ($resql) {
 		$obj = $db->fetch_object($resql);
-		if ($local == 1) {
+		if ($local == 1 && $obj->localtax1_type > 0) {
 			return $obj->localtax1;
-		} elseif ($local == 2) {
+		} elseif ($local == 2 && $obj->localtax2_type > 0) {
 			return $obj->localtax2;
 		}
 	}


### PR DESCRIPTION
# FIX|Fix #24068 Ignore localtaxes if localtax type zero
The SQL query should ignore the rows where the "Use Local Tax" select in the dictionary page was set to "No" (localtax1_type or localtax2_type is 0 on DB)