### PR TITLE
Ignore localtaxes if localtax1_type or localtax2_type is 0

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5688,22 +5688,20 @@ function isOnlyOneLocalTax($local)
 function get_localtax_by_third($local)
 {
 	global $db, $mysoc;
-	$sql = "SELECT t.localtax1_type, t.localtax2_type, t.localtax1, t.localtax2 ";
+
+	$sql  = " SELECT t.localtax$local as localtax";
 	$sql .= " FROM ".MAIN_DB_PREFIX."c_tva as t inner join ".MAIN_DB_PREFIX."c_country as c ON c.rowid=t.fk_pays";
 	$sql .= " WHERE c.code = '".$db->escape($mysoc->country_code)."' AND t.active = 1 AND t.taux=(";
 	$sql .= "  SELECT max(tt.taux) FROM ".MAIN_DB_PREFIX."c_tva as tt inner join ".MAIN_DB_PREFIX."c_country as c ON c.rowid=tt.fk_pays";
 	$sql .= "  WHERE c.code = '".$db->escape($mysoc->country_code)."' AND tt.active = 1";
-	$sql .= "  )";
+	$sql .= "  ) ";
+	$sql .= " AND t.localtax${local}_type > 0";
+	$sql .= " ORDER BY rowid DESC";
 
 	$resql = $db->query($sql);
 	if ($resql) {
-		while ($obj = $db->fetch_object($resql)) {
-			if ($local == 1 && $obj->localtax1_type > 0) {
-				return $obj->localtax1;
-			} elseif ($local == 2 && $obj->localtax2_type > 0) {
-				return $obj->localtax2;
-			}
-		}
+		$obj = $db->fetch_object($resql);
+		return $obj->localtax;
 	}
 
 	return 0;

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5689,13 +5689,13 @@ function get_localtax_by_third($local)
 {
 	global $db, $mysoc;
 
-	$sql  = " SELECT t.localtax$local as localtax";
+	$sql  = " SELECT t.localtax".$local." as localtax";
 	$sql .= " FROM ".MAIN_DB_PREFIX."c_tva as t inner join ".MAIN_DB_PREFIX."c_country as c ON c.rowid=t.fk_pays";
 	$sql .= " WHERE c.code = '".$db->escape($mysoc->country_code)."' AND t.active = 1 AND t.taux=(";
 	$sql .= "  SELECT max(tt.taux) FROM ".MAIN_DB_PREFIX."c_tva as tt inner join ".MAIN_DB_PREFIX."c_country as c ON c.rowid=tt.fk_pays";
 	$sql .= "  WHERE c.code = '".$db->escape($mysoc->country_code)."' AND tt.active = 1";
 	$sql .= "  ) ";
-	$sql .= " AND t.localtax${local}_type > 0";
+	$sql .= " AND t.localtax".$local."_type > 0";
 	$sql .= " ORDER BY rowid DESC";
 
 	$resql = $db->query($sql);

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5697,11 +5697,12 @@ function get_localtax_by_third($local)
 
 	$resql = $db->query($sql);
 	if ($resql) {
-		$obj = $db->fetch_object($resql);
-		if ($local == 1 && $obj->localtax1_type > 0) {
-			return $obj->localtax1;
-		} elseif ($local == 2 && $obj->localtax2_type > 0) {
-			return $obj->localtax2;
+		while ($obj = $db->fetch_object($resql)) {
+			if ($local == 1 && $obj->localtax1_type > 0) {
+				return $obj->localtax1;
+			} elseif ($local == 2 && $obj->localtax2_type > 0) {
+				return $obj->localtax2;
+			}
 		}
 	}
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5688,7 +5688,7 @@ function isOnlyOneLocalTax($local)
 function get_localtax_by_third($local)
 {
 	global $db, $mysoc;
-	$sql = "SELECT t.localtax1, t.localtax2 ";
+	$sql = "SELECT t.localtax1_type, t.localtax2_type, t.localtax1, t.localtax2 ";
 	$sql .= " FROM ".MAIN_DB_PREFIX."c_tva as t inner join ".MAIN_DB_PREFIX."c_country as c ON c.rowid=t.fk_pays";
 	$sql .= " WHERE c.code = '".$db->escape($mysoc->country_code)."' AND t.active = 1 AND t.taux=(";
 	$sql .= "  SELECT max(tt.taux) FROM ".MAIN_DB_PREFIX."c_tva as tt inner join ".MAIN_DB_PREFIX."c_country as c ON c.rowid=tt.fk_pays";
@@ -5698,9 +5698,9 @@ function get_localtax_by_third($local)
 	$resql = $db->query($sql);
 	if ($resql) {
 		$obj = $db->fetch_object($resql);
-		if ($local == 1) {
+		if ($local == 1 && $obj->localtax1_type > 0) {
 			return $obj->localtax1;
-		} elseif ($local == 2) {
+		} elseif ($local == 2 && $obj->localtax2_type > 0) {
 			return $obj->localtax2;
 		}
 	}


### PR DESCRIPTION
FIX|Fix https://github.com/Dolibarr/dolibarr/issues/24068 Ignore localtaxes if localtax type zero

The SQL query should ignore the rows where the "Use Local Tax" select in the dictionary page was set to "No" (localtax1_type or localtax2_type is 0 on DB)