### PR TITLE
Allow FileUpload to be used when $fk_element and $element are null

### DIFF
--- a/htdocs/core/class/fileupload.class.php
+++ b/htdocs/core/class/fileupload.class.php
@@ -207,11 +207,11 @@ class FileUpload
 				setEventMessage('If $fk_element = null or $element = null you must specify upload_dir on $options', 'errors');
 				throw new Exception('If $fk_element = null or $element = null you must specify upload_dir on $options');
 			} elseif (is_dir($this->options['upload_dir'])) {
-				setEventMessage('The directory '$this->options['upload_dir'].' doesn\'t exists', 'errors');
-				throw new Exception('The directory '$this->options['upload_dir'].' doesn\'t exists');
+				setEventMessage('The directory '.$this->options['upload_dir'].' doesn\'t exists', 'errors');
+				throw new Exception('The directory '.$this->options['upload_dir'].' doesn\'t exists');
 			} elseif (is_writable($this->options['upload_dir'])) {
-				setEventMessage('The directory '$this->options['upload_dir'].' is not writable', 'errors');
-				throw new Exception('The directory '$this->options['upload_dir'].' is not writable');
+				setEventMessage('The directory '.$this->options['upload_dir'].' is not writable', 'errors');
+				throw new Exception('The directory '.$this->options['upload_dir'].' is not writable');
 			}
 		}
 	}

--- a/htdocs/core/class/fileupload.class.php
+++ b/htdocs/core/class/fileupload.class.php
@@ -104,36 +104,40 @@ class FileUpload
 			$dir_output = $conf->$element->dir_output;
 		}
 
-		dol_include_once('/'.$pathname.'/class/'.$filename.'.class.php');
+		// If pathname and filename are null then we can still upload files
+		// IF we have specified upload_dir on $this->options
+		if ($pathname !== null && $filename !== null) {
+			dol_include_once('/'.$pathname.'/class/'.$filename.'.class.php');
 
-		$classname = ucfirst($filename);
+			$classname = ucfirst($filename);
 
-		if ($element == 'order_supplier') {
-			$classname = 'CommandeFournisseur';
-		} elseif ($element == 'invoice_supplier') {
-			$classname = 'FactureFournisseur';
-		}
-
-		$object = new $classname($db);
-
-		$object->fetch($fk_element);
-		if (!empty($parentForeignKey)) {
-			dol_include_once('/'.$parentElement.'/class/'.$parentObject.'.class.php');
-			$parent = new $parentClass($db);
-			$parent->fetch($object->$parentForeignKey);
-			if (!empty($parent->socid)) {
-				$parent->fetch_thirdparty();
+			if ($element == 'order_supplier') {
+				$classname = 'CommandeFournisseur';
+			} elseif ($element == 'invoice_supplier') {
+				$classname = 'FactureFournisseur';
 			}
-			$object->$parentObject = clone $parent;
-		} else {
-			$object->fetch_thirdparty();
-		}
 
-		$object_ref = dol_sanitizeFileName($object->ref);
-		if ($element == 'invoice_supplier') {
-			$object_ref = get_exdir($object->id, 2, 0, 0, $object, 'invoice_supplier').$object_ref;
-		} elseif ($element == 'project_task') {
-			$object_ref = $object->project->ref.'/'.$object_ref;
+			$object = new $classname($db);
+
+			$object->fetch($fk_element);
+			if (!empty($parentForeignKey)) {
+				dol_include_once('/'.$parentElement.'/class/'.$parentObject.'.class.php');
+				$parent = new $parentClass($db);
+				$parent->fetch($object->$parentForeignKey);
+				if (!empty($parent->socid)) {
+					$parent->fetch_thirdparty();
+				}
+				$object->$parentObject = clone $parent;
+			} else {
+				$object->fetch_thirdparty();
+			}
+
+			$object_ref = dol_sanitizeFileName($object->ref);
+			if ($element == 'invoice_supplier') {
+				$object_ref = get_exdir($object->id, 2, 0, 0, $object, 'invoice_supplier').$object_ref;
+			} elseif ($element == 'project_task') {
+				$object_ref = $object->project->ref.'/'.$object_ref;
+			}
 		}
 
 		$this->options = array(
@@ -194,6 +198,21 @@ class FileUpload
 
 		if ($options) {
 			$this->options = array_replace_recursive($this->options, $options);
+		}
+
+		// At this point we should have a valid upload_dir in options
+		//if ($pathname === null && $filename === null) { // OR or AND???
+		if ($pathname === null || $filename === null) {
+			if (!key_exists("upload_dir", $this->options)) {
+				setEventMessage('If $fk_element = null or $element = null you must specify upload_dir on $options', 'errors');
+				throw new Exception('If $fk_element = null or $element = null you must specify upload_dir on $options');
+			} elseif (is_dir($this->options['upload_dir'])) {
+				setEventMessage('The directory '$this->options['upload_dir'].' doesn\'t exists', 'errors');
+				throw new Exception('The directory '$this->options['upload_dir'].' doesn\'t exists');
+			} elseif (is_writable($this->options['upload_dir'])) {
+				setEventMessage('The directory '$this->options['upload_dir'].' is not writable', 'errors');
+				throw new Exception('The directory '$this->options['upload_dir'].' is not writable');
+			}
 		}
 	}
 

--- a/htdocs/core/class/fileupload.class.php
+++ b/htdocs/core/class/fileupload.class.php
@@ -206,10 +206,10 @@ class FileUpload
 			if (!key_exists("upload_dir", $this->options)) {
 				setEventMessage('If $fk_element = null or $element = null you must specify upload_dir on $options', 'errors');
 				throw new Exception('If $fk_element = null or $element = null you must specify upload_dir on $options');
-			} elseif (is_dir($this->options['upload_dir'])) {
+			} elseif (!is_dir($this->options['upload_dir'])) {
 				setEventMessage('The directory '.$this->options['upload_dir'].' doesn\'t exists', 'errors');
 				throw new Exception('The directory '.$this->options['upload_dir'].' doesn\'t exists');
-			} elseif (is_writable($this->options['upload_dir'])) {
+			} elseif (!is_writable($this->options['upload_dir'])) {
 				setEventMessage('The directory '.$this->options['upload_dir'].' is not writable', 'errors');
 				throw new Exception('The directory '.$this->options['upload_dir'].' is not writable');
 			}


### PR DESCRIPTION
# NEW #24001 Allow to upload files not linked to a class
This is a personal problem I had, I wanted to use FileUpload.class.php to upload a file in a custom module but since $fk_element and $element were null it failed when trying to instantiate a class with an empty $classname variable.

Since we don't create the upload_dir from a class then we must check either that the supplied options contains a valid upload_dir or that after the `overrideUploadOptions` hook `$this->options['upload_dir']` contains a valid upload_dir, so I added checks at the end of the constructor, lmk if that's not necessary.
