### PR TITLE
NEW: include limit in bookmark url params

### DIFF
--- a/htdocs/bookmarks/bookmarks.lib.php
+++ b/htdocs/bookmarks/bookmarks.lib.php
@@ -63,7 +63,7 @@ function printDropdownBookmarksList()
 	}
 	if (!empty($_POST) && is_array($_POST)) {
 		foreach ($_POST as $key => $val) {
-			if ((preg_match('/^search_/', $key) || in_array($key, $authorized_var))
+			if ((preg_match('/^search_|^limit$/', $key) || in_array($key, $authorized_var))
 				&& $val != ''
 				&& !array_key_exists($key, $url_param)) {
 				if (is_array($val)) {


### PR DESCRIPTION
# NEW: include limit in bookmark url params
When we choose to “Add current page to bookmarks", we should keep the limit parameter from a list, or the bookmark will not be the *same* page.
