### PR TITLE
FIX : Set the fields authorid to see my own events

### DIFF
--- a/htdocs/comm/action/list.php
+++ b/htdocs/comm/action/list.php
@@ -916,6 +916,7 @@ while ($i < $imaxinloop) {
 	$actionstatic->note_private = dol_htmlentitiesbr($obj->note);
 	$actionstatic->datep = $db->jdate($obj->dp);
 	$actionstatic->percentage = $obj->percent;
+	$actionstatic->authorid = $obj->fk_user_author;
 
 	// Initialize $this->userassigned && this->socpeopleassigned array && this->userownerid
 	// but only if we need it


### PR DESCRIPTION
## FIX : Set the fields authorid to see my own events

Set the fields authorid to see my own events when the permission "$user->rights->agenda->allactions->read" isn't set for me
