### PR TITLE
FIX #20296

### DIFF
--- a/htdocs/comm/propal/contact.php
+++ b/htdocs/comm/propal/contact.php
@@ -65,7 +65,6 @@ if (!$error) {
 // Security check
 if (!empty($user->socid)) {
 	$socid = $user->socid;
-	$object->id = $user->socid;
 }
 restrictedArea($user, 'propal', $object->id);
 

--- a/htdocs/comm/propal/contact.php
+++ b/htdocs/comm/propal/contact.php
@@ -63,6 +63,7 @@ if (!$error) {
 }
 
 // Security check
+$socid = '';
 if (!empty($user->socid)) {
 	$socid = $user->socid;
 }

--- a/htdocs/comm/propal/document.php
+++ b/htdocs/comm/propal/document.php
@@ -77,6 +77,7 @@ $object->fetch($id, $ref);
 $permissiontoadd = $user->rights->propal->creer;
 
 // Security check
+$socid = '';
 if (!empty($user->socid)) {
 	$socid = $user->socid;
 }

--- a/htdocs/comm/propal/document.php
+++ b/htdocs/comm/propal/document.php
@@ -45,13 +45,6 @@ $confirm = GETPOST('confirm', 'alpha');
 $id = GETPOST('id', 'int');
 $ref = GETPOST('ref', 'alpha');
 
-// Security check
-$socid = '';
-if (!empty($user->socid)) {
-	$socid = $user->socid;
-}
-$result = restrictedArea($user, 'propal', $id);
-
 // Get parameters
 $limit = GETPOST('limit', 'int') ? GETPOST('limit', 'int') : $conf->liste_limit;
 $sortfield = GETPOST('sortfield', 'aZ09comma');
@@ -86,7 +79,6 @@ $permissiontoadd = $user->rights->propal->creer;
 // Security check
 if (!empty($user->socid)) {
 	$socid = $user->socid;
-	$object->id = $user->socid;
 }
 restrictedArea($user, 'propal', $object->id);
 

--- a/htdocs/comm/propal/note.php
+++ b/htdocs/comm/propal/note.php
@@ -49,6 +49,7 @@ if ($id > 0 || !empty($ref)) {
 }
 
 // Security check
+$socid = '';
 if ($user->socid > 0) {
 	$socid = $user->socid;
 }

--- a/htdocs/comm/propal/note.php
+++ b/htdocs/comm/propal/note.php
@@ -51,7 +51,6 @@ if ($id > 0 || !empty($ref)) {
 // Security check
 if ($user->socid > 0) {
 	$socid = $user->socid;
-	$object->id = $user->socid;
 }
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context


### PR DESCRIPTION
# FIX #20296
Wrong assignment of object id in socid in comm/propal/note.php, document.php and contact.php for external users security check.
In document.php, check was done twice.
In card.php, same correction was done by **Fix Bad assignation for external users access #23913**