### PR TITLE
Fix expensereport add ndf

### DIFF
--- a/htdocs/expensereport/class/expensereport_ik.class.php
+++ b/htdocs/expensereport/class/expensereport_ik.class.php
@@ -198,9 +198,9 @@ class ExpenseReportIk extends CommonObject
 		$default_range = (int) $userauthor->default_range; // if not defined, then 0
 		$ranges = $this->getRangesByCategory($fk_c_exp_tax_cat);
 		// prevent out of range -1 indice
-		$indice = $default_range > 0 ? $default_range - 1 : 0;
+		$indice = $default_range  - 1;
 		// substract 1 because array start from 0
-		if (empty($ranges) || !isset($ranges[$indice])) {
+		if (empty($ranges) || $indice < 0 || !isset($ranges[$indice])) {
 			return false;
 		} else {
 			return $ranges[$indice];


### PR DESCRIPTION
Fix expensereport add ndf

Sur l'ajout d'une NDF de type "frais kilométriques" la valeur P.U HT changé à l'enregistrement
