### PR TITLE
Correct dolForgeCriteriaCallback

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -10757,7 +10757,7 @@ function dolForgeCriteriaCallback($matches)
 
 	$operand = preg_replace('/[^a-z0-9\._]/i', '', trim($tmp[0]));
 
-	$operator = strtoupper(preg_replace('/[^a-z<>=]/i', '', trim($tmp[1])));
+	$operator = strtoupper(preg_replace('/[^a-z<>!=]/i', '', trim($tmp[1])));
 	if ($operator == 'NOTLIKE') {
 		$operator = 'NOT LIKE';
 	}


### PR DESCRIPTION
Linked to #24161

The character "!" was never caught by preg_replace so the for example token 
` finished != 0` was replace by ` finished = 0` in sql request causing filters trouble.

In V17 we have 
```php
	$operator = strtoupper(preg_replace('/[^a-z<>=]/i', '', trim($tmp[1])));

	if ($operator == '!=') {
		$operator = '<>';
	}
```

And since operator cannot have the "!" character this condition is never applied