### PR TITLE
FIX  #[23799] - External users are not able to create events - correction

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -90,8 +90,8 @@ if ($fulldayevent) {
 // Security check
 $socid = GETPOST('socid', 'int');
 $id = GETPOST('id', 'int');
-if ($user->socid) {
-	$socid = $user->socid;
+if ($user->socid && ($socid != $user->socid)) {
+	accessforbidden();
 }
 
 $error = GETPOST("error");
@@ -142,9 +142,6 @@ if (!empty($conf->global->AGENDA_REMINDER_EMAIL)) {
 $TDurationTypes = array('y'=>$langs->trans('Years'), 'm'=>$langs->trans('Month'), 'w'=>$langs->trans('Weeks'), 'd'=>$langs->trans('Days'), 'h'=>$langs->trans('Hours'), 'i'=>$langs->trans('Minutes'));
 
 $result = restrictedArea($user, 'agenda', $object->id, 'actioncomm&societe', 'myactions|allactions', 'fk_soc', 'id');
-if ($user->socid && $socid) {
-	$result = restrictedArea($user, 'societe', $socid);
-}
 
 
 /*


### PR DESCRIPTION
# FIX|Fix #[23799]
External users are not able to create events

2nd PR because of problem in first PR23802. PR23802 just included the corrected code proposal in the discussion, but not in the PR itself. Therefore the wrong code has been merged. Here is now the corrected PR


