### PR TITLE
fix : Fatal error: Uncaught TypeError: strlen(): Argument #1 () must …

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -725,6 +725,8 @@ class ExtraFields
 
 			if (is_array($param) && count($param) > 0) {
 				$params = serialize($param);
+			} elseif (is_array($param)) {
+				$params = '';
 			} elseif (strlen($param) > 0) {
 				$params = trim($param);
 			} else {


### PR DESCRIPTION
…be of type string, array given in /home/httpd/vhosts/aflac.fr/domains/dev.aflac.fr/httpdocs/core/class/extrafields.class.php on line 728

