### PR TITLE
Improve SQL Query performances

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2403,14 +2403,21 @@ class CommandeFournisseur extends CommonOrder
 		$ret = array();
 
 		// List of already dispatched lines
-		$sql = "SELECT p.ref, p.label,";
+		$sql = "SELECT p.rowid as pid, p.ref, p.label,";
 		$sql .= " e.rowid as warehouse_id, e.ref as entrepot,";
-		$sql .= " cfd.rowid as dispatchedlineid, cfd.fk_product, cfd.qty, cfd.eatby, cfd.sellby, cfd.batch, cfd.comment, cfd.status, cfd.fk_commandefourndet";
-		$sql .= " FROM ".MAIN_DB_PREFIX."product as p,";
-		$sql .= " ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as cfd";
+		$sql .= " cfd.rowid as dispatchlineid, cfd.fk_product, cfd.qty, cfd.eatby, cfd.sellby, cfd.batch, cfd.comment, cfd.status, cfd.datec";
+		$sql .= " ,cd.rowid, cd.subprice";
+		if ($conf->reception->enabled) {
+			$sql .= " ,cfd.fk_reception, r.date_delivery";
+		}
+		$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as cfd";
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p ON cfd.fk_product = p.rowid";
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = cfd.fk_commandefourndet";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."entrepot as e ON cfd.fk_entrepot = e.rowid";
-		$sql .= " WHERE cfd.fk_commande = ".((int) $this->id);
-		$sql .= " AND cfd.fk_product = p.rowid";
+		if ($conf->reception->enabled) {
+			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."reception as r ON cfd.fk_reception = r.rowid";
+		}
+		$sql .= " WHERE cfd.fk_commande = ".((int) $object->id);
 		if ($status >= 0) {
 			$sql .= " AND cfd.status = ".((int) $status);
 		}

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2411,9 +2411,9 @@ class CommandeFournisseur extends CommonOrder
 		}
 		$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as cfd";
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."product as p ON cfd.fk_product = p.rowid";
-		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = cfd.fk_commandefourndet";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."entrepot as e ON cfd.fk_entrepot = e.rowid";
 		if ($conf->reception->enabled) {
+			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = cfd.fk_commandefourndet";
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."reception as r ON cfd.fk_reception = r.rowid";
 		}
 		$sql .= " WHERE cfd.fk_commande = ".((int) $object->id);

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2406,12 +2406,11 @@ class CommandeFournisseur extends CommonOrder
 		$sql = "SELECT p.rowid as pid, p.ref, p.label,";
 		$sql .= " e.rowid as warehouse_id, e.ref as entrepot,";
 		$sql .= " cfd.rowid as dispatchlineid, cfd.fk_product, cfd.qty, cfd.eatby, cfd.sellby, cfd.batch, cfd.comment, cfd.status, cfd.datec";
-		$sql .= " ,cd.rowid, cd.subprice";
 		if ($conf->reception->enabled) {
 			$sql .= " ,cfd.fk_reception, r.date_delivery";
 		}
 		$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as cfd";
-		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p ON cfd.fk_product = p.rowid";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."product as p ON cfd.fk_product = p.rowid";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = cfd.fk_commandefourndet";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."entrepot as e ON cfd.fk_entrepot = e.rowid";
 		if ($conf->reception->enabled) {

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -1129,7 +1129,7 @@ if ($id > 0 || !empty($ref)) {
 		$sql .= " ,cfd.fk_reception, r.date_delivery";
 	}
 	$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as cfd";
-	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p ON cfd.fk_product = p.rowid";
+	$sql .= " INNER JOIN ".MAIN_DB_PREFIX."product as p ON cfd.fk_product = p.rowid";
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = cfd.fk_commandefourndet";
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."entrepot as e ON cfd.fk_entrepot = e.rowid";
 	if ($conf->reception->enabled) {

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -1128,16 +1128,15 @@ if ($id > 0 || !empty($ref)) {
 	if ($conf->reception->enabled) {
 		$sql .= " ,cfd.fk_reception, r.date_delivery";
 	}
-	$sql .= " FROM ".MAIN_DB_PREFIX."product as p,";
-	$sql .= " ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as cfd";
+	$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseur_dispatch as cfd";
+	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p ON cfd.fk_product = p.rowid";
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = cfd.fk_commandefourndet";
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."entrepot as e ON cfd.fk_entrepot = e.rowid";
 	if ($conf->reception->enabled) {
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."reception as r ON cfd.fk_reception = r.rowid";
 	}
 	$sql .= " WHERE cfd.fk_commande = ".((int) $object->id);
-	$sql .= " AND cfd.fk_product = p.rowid";
-	$sql .= " ORDER BY cfd.rowid ASC";
+	$sql .= " ORDER BY cfd.rowid";
 
 	$resql = $db->query($sql);
 	if ($resql) {


### PR DESCRIPTION
Instead of starting from products table and load a lot of data, we query from commande_fournisseur_dispatch, with less data to load.