### PR TITLE
NEW No overwrite of optionals during put() contact

### DIFF
--- a/htdocs/societe/class/api_contacts.class.php
+++ b/htdocs/societe/class/api_contacts.class.php
@@ -326,8 +326,13 @@ class Contacts extends DolibarrApi
 		foreach ($request_data as $field => $value) {
 			if ($field == 'id') {
 				continue;
+			} elseif ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->contact->array_options[$index] = $val;
+				}
+			} else {
+				$this->contact->$field = $value;
 			}
-			$this->contact->$field = $value;
 		}
 
 		if (isModEnabled('mailing') && !empty($this->contact->email) && isset($this->contact->no_email)) {


### PR DESCRIPTION
# NEW No overwrite of optionals during put()
When making a PUT request, only the sent fields should be changed. This should apply for optionals too. However up until now the array_options field gets changed as whole and therefore overwritten if only one optional fields gets send.
