### PR TITLE
NEW Support contact in post() document API

### DIFF
--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -666,13 +666,22 @@ class Documents extends DolibarrApi
 				$modulepart = 'propale';
 				require_once DOL_DOCUMENT_ROOT.'/comm/propal/class/propal.class.php';
 				$object = new Propal($this->db);
+			} elseif ($modulepart == 'contact' || $modulepart == 'socpeople') {
+				$modulepart = 'contact';
+				require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
+				$object = new Contact($this->db);
+				$fetchbyid = true;
 			} else {
 				// TODO Implement additional moduleparts
 				throw new RestException(500, 'Modulepart '.$modulepart.' not implemented yet.');
 			}
 
 			if (is_object($object)) {
-				$result = $object->fetch('', $ref);
+				if ($fetchbyid) {
+					$result = $object->fetch($ref);
+				} else {
+					$result = $object->fetch('', $ref);
+				}
 
 				if ($result == 0) {
 					throw new RestException(404, "Object with ref '".$ref."' was not found.");

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -607,7 +607,8 @@ class Documents extends DolibarrApi
 
 		if ($ref) {
 			$tmpreldir = '';
-
+			$fetchbyid = false;
+			
 			if ($modulepart == 'facture' || $modulepart == 'invoice') {
 				$modulepart = 'facture';
 


### PR DESCRIPTION
NEW Support contact in post() document API
When uploading a document via the API, add the modulepart "contact". By this, documents linked to a contact can be uploaded.
