### PR TITLE
Make the "public" setting clearer in the UI

### DIFF
--- a/htdocs/langs/en_US/members.lang
+++ b/htdocs/langs/en_US/members.lang
@@ -201,7 +201,7 @@ LastMemberDate=Latest membership date
 LatestSubscriptionDate=Latest contribution date
 MemberNature=Nature of the member
 MembersNature=Nature of the members
-Public=Information is public
+Public=%s can publish my membership in <a target="_blank" href="%s">the public register</a>
 NewMemberbyWeb=New member added. Awaiting approval
 NewMemberForm=New member form
 SubscriptionsStatistics=Contributions statistics

--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -692,7 +692,9 @@ if (!empty($conf->global->MEMBER_SKIP_TABLE) || !empty($conf->global->MEMBER_NEW
 	print '<tr><td>'.$langs->trans("URLPhoto").'</td><td><input type="text" name="photo" class="minwidth150" value="'.dol_escape_htmltag(GETPOST('photo')).'"></td></tr>'."\n";
 
 	// Public
-	print '<tr><td>'.$langs->trans("Public").'</td><td><input type="checkbox" name="public"></td></tr>'."\n";
+	$linkofpubliclist = DOL_MAIN_URL_ROOT.'/public/members/public_list.php'.((isModEnabled('multicompany')) ? '?entity='.$conf->entity : '');
+	$publiclabel = $langs->trans("Public", $conf->global->MAIN_INFO_SOCIETE_NOM, $linkofpubliclist);
+	print '<tr><td>'.$publiclabel.'</td><td><input type="checkbox" name="public"></td></tr>'."\n";
 
 	// Other attributes
 	$parameters['tpl_context']='public';	// define template context to public


### PR DESCRIPTION
# Instructions
In the self-registration form, the "public" attribute just says "information is public" in the UI, this is not helpful. This is a proposal to rephrase that setting.

At the same time, I'm also dubious that this setting is still in line with the regulation, especially GDPR. But I am not aware about what is feasible or not.

# NEW Make the "public" setting clearer in the UI

