### PR TITLE
FIX : fatal error when margin enable, User::hasRight() when checking a margin right

### DIFF
--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -98,7 +98,7 @@ class FormMargin
 			}
 
 			$pv = $line->total_ht;
-			$pa_ht = (($pv < 0 || ($pv == 0 && $object->type == $object::TYPE_CREDIT_NOTE)) ? -$line->pa_ht : $line->pa_ht); // We choosed to have line->pa_ht always positive in database, so we guess the correct sign
+			$pa_ht = (($pv < 0 || ($pv == 0 && $object->element == 'facture' && $object->type == $object::TYPE_CREDIT_NOTE)) ? -$line->pa_ht : $line->pa_ht); // We choosed to have line->pa_ht always positive in database, so we guess the correct sign
 			if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {	// Special case for old situation mode
 				if (($object->element == 'facture' && $object->type == $object::TYPE_SITUATION)
 					|| ($object->element == 'facture' && $object->type == $object::TYPE_CREDIT_NOTE && getDolGlobalInt('INVOICE_USE_SITUATION_CREDIT_NOTE') && $object->situation_counter > 0)) {

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -715,7 +715,8 @@ class User extends CommonObject
 			'skill@hrm' => 'all@hrm', // skill / job / position objects rights are for the moment grouped into right level "all"
 			'job@hrm' => 'all@hrm', // skill / job / position objects rights are for the moment grouped into right level "all"
 			'position@hrm' => 'all@hrm', // skill / job / position objects rights are for the moment grouped into right level "all"
-			'facturerec' => 'facture'
+			'facturerec' => 'facture',
+			'margins' => 'margin',
 		);
 
 		if (!empty($moduletomoduletouse[$module])) {


### PR DESCRIPTION
- Fix a check on object element in FormMargin, otherwise a fatar error will occurs on order and propal.
- Fix User::hasRight() not working with margin right, $moduleRightsMapping is not enough, need a mapping too in $moduletomoduletouse