### PR TITLE
Fix #24260: Fix of hook in parseExpression for dynamic prices

### DIFF
--- a/htdocs/product/dynamic_price/class/price_parser.class.php
+++ b/htdocs/product/dynamic_price/class/price_parser.class.php
@@ -127,13 +127,25 @@ class PriceParser
 		global $user;
 		global $hookmanager;
 		$action = 'PARSEEXPRESSION';
-		if ($result = $hookmanager->executeHooks('doDynamiPrice', array(
-								'expression' =>$expression,
-								'product' => $product,
-								'values' => $values
-		), $this, $action)) {
-			return $result;
+		$reshook = $hookmanager->executeHooks('doDynamicPrice', array(
+			'expression' =>$expression,
+			'product' => $product,
+			'values' => $values
+			), $this, $action);
+
+		if ($reshook > 0) {
+			// this function is replaced by hook, >0 also for incorrect expressions
+			return $hookmanager->resArray['return'];
+		} elseif ($reshook < 0) {
+			// internal error in hook, should not happen
+			$this->error_parser = array(100, $expression);
+			return -100;
+		} elseif ($reshook == 0) {
+			// hook preprocessed values and expression for further use in this function
+			$values = array_merge($values, $hookmanager->resArray['values']);
+			$expression = $hookmanager->resArray['expression'];
 		}
+
 		//Check if empty
 		$expression = trim($expression);
 		if (empty($expression)) {


### PR DESCRIPTION
The previously existing hook was not working, as in case of successful parsing the expression, the return value was always 1, not the calculated value of the expression.

Corrected the bug so that the hook now can either replace the existing function or it can be used to preprocess the input values.

There was a typo in the name of the hook (doDynamiPrice instead of doDynami**c**Price, c was missing). This correction is a somewhat breaking change, but since the hook was not functional anyways, I think it's reasonable to correct it as well.