### PR TITLE
Fix #24260: Fix of hook in parseExpression for dynamic prices

### DIFF
--- a/htdocs/product/dynamic_price/class/price_parser.class.php
+++ b/htdocs/product/dynamic_price/class/price_parser.class.php
@@ -127,12 +127,12 @@ class PriceParser
 		global $user;
 		global $hookmanager;
 		$action = 'PARSEEXPRESSION';
-		if ($result = $hookmanager->executeHooks('doDynamiPrice', array(
-								'expression' =>$expression,
-								'product' => $product,
-								'values' => $values
+		if ($reshook = $hookmanager->executeHooks('doDynamiPrice', array(
+								'expression' => &$expression,
+								'product' => &$product,
+								'values' => &$values
 		), $this, $action)) {
-			return $result;
+			return $hookmanager->resArray['return'];
 		}
 		//Check if empty
 		$expression = trim($expression);


### PR DESCRIPTION
The hook in the function parseExpression for dynamic prices had two problems:

a) reshook was taken as the return value, but a valid price can also be 0. In this case, the existing code of parseExpression would not be replaced by the hooked function, but also executed.

Fix: provide return value for reshook by hooked function as -1, 0, 1 and explicitly return the computed value in resArray as the value to be finally returned by parseExpression.

b) the relevant values (variables in $values and the $expression as the term to be parsed) are provided as $parameters and called by value without an option to modify them in the hook for further use by parseExpression function

Fix: changed from call by value to call by reference. Now, a hook can define additional variables for the price expression or pre-parse parts of the $expression and modify it for further use by the original parseExpression function.
