### PR TITLE
Fix #24267: loading the extrafields of the related product in dynamic price expression

### DIFF
--- a/htdocs/product/dynamic_price/class/price_parser.class.php
+++ b/htdocs/product/dynamic_price/class/price_parser.class.php
@@ -156,11 +156,10 @@ class PriceParser
 
 		//Retrieve all extrafield for product and add it to values
 		$extrafields = new ExtraFields($this->db);
+        $extralabels = $extrafields->fetch_name_optionals_label($product->table_element);
 		$product->fetch_optionals();
-		if (is_array($extrafields->attributes[$product->table_element]['label'])) {
-			foreach ($extrafields->attributes[$product->table_element]['label'] as $key => $label) {
-				$values["extrafield_".$key] = $product->array_options['options_'.$key];
-			}
+		foreach ($extralabels as $key => $label) {
+			$values["extrafield_".$key] = $product->array_options['options_'.$key];
 		}
 
 		//Process any pending updaters

--- a/htdocs/product/dynamic_price/class/price_parser.class.php
+++ b/htdocs/product/dynamic_price/class/price_parser.class.php
@@ -156,7 +156,7 @@ class PriceParser
 
 		//Retrieve all extrafield for product and add it to values
 		$extrafields = new ExtraFields($this->db);
-        $extralabels = $extrafields->fetch_name_optionals_label($product->table_element);
+		$extralabels = $extrafields->fetch_name_optionals_label($product->table_element);
 		$product->fetch_optionals();
 		foreach ($extralabels as $key => $label) {
 			$values["extrafield_".$key] = $product->array_options['options_'.$key];


### PR DESCRIPTION
In the price expression of dynamic prices, the extrafields of the product were not loaded correctly. Amended the routine to fetch the extrafileds/optionals.
