### PR TITLE
FIX|Fix #24298 No error or 0.00 instead of NULL in database anymore w…

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1393,7 +1393,7 @@ if (empty($reshook)) {
 			$error++;
 		}
 		if (!$error) {
-			$result = $object->updateExtraField(GETPOST('attribute', 'restricthtml'), 'PROPAL_MODIFY', $user);
+			$result = $object->insertExtraFields('PROPAL_MODIFY');
 			if ($result < 0) {
 				setEventMessages($object->error, $object->errors, 'errors');
 				$error++;


### PR DESCRIPTION
FIX|Fix #24298 No error or 0.00 instead of NULL in database anymore when emptying an extrafield of type price on a propal card
