### PR TITLE
Bugfix fetch_optionals before the line update to not lose the invisible fields

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -607,7 +607,7 @@ if (empty($reshook)) {
 		// Extrafields
 		$extrafields->fetch_name_optionals_label($object->table_element_line);
 		$array_options = $extrafields->getOptionalsFromPost($object->table_element_line);
-		$objectline->array_options = $array_options;
+		$objectline->array_options = array_merge($objectline->array_options, $array_options);
 
 		$result = $objectline->update($user);
 		if ($result < 0) {


### PR DESCRIPTION
# Fix
Fix a problem where I was losing my invisible extra fields data every time I was updating a line inside fichinter card

Now we are doing an array_merge to update the EF changed and not lose the invisible EF data who are not sent via GET/POST and in consequences are not present when we use the function `getOptionalsFromPost`