### PR TITLE
FIX #24352 Wrong emailing delay in prompt in mailing-send.php

### DIFF
--- a/scripts/emailings/mailing-send.php
+++ b/scripts/emailings/mailing-send.php
@@ -87,7 +87,7 @@ if (!isModEnabled('mailing')) {
 print "***** ".$script_file." (".$version.") pid=".dol_getmypid()." *****\n";
 
 if (!empty($conf->global->MAILING_DELAY)) {
-	print 'A delay of '.((float) $conf->global->MAILING_DELAY * 1000000).' seconds has been set between each email'."\n";
+	print 'A delay of '.((float) $conf->global->MAILING_DELAY).' seconds has been set between each email'."\n";
 }
 
 if ($conf->global->MAILING_LIMIT_SENDBYCLI == '-1') {


### PR DESCRIPTION
# FIX|Fix #[*24352 Wrong emailing delay in prompt*]

The delay between email announced in prompt is not right : when the delay is called, usleep() takes useconds as argument and MAILING_DELAY is multiplied by 1000000, but prompt information doesn't have to as it's admitted that is seconds


