### PR TITLE
Fix: add hook to modify amount to pay for supplier invoice

### DIFF
--- a/htdocs/compta/facture/prelevement.php
+++ b/htdocs/compta/facture/prelevement.php
@@ -676,6 +676,16 @@ if ($object->id > 0) {
 
 	$resteapayer = price2num($object->total_ttc - $totalpaid - $totalcreditnotes - $totaldeposits, 'MT');
 
+	// Hook to change amount for other reasons, e.g. apply cash discount for payment before agreed date
+	$parameters = array('remaintopay' => $resteapayer);
+	$reshook = $hookmanager->executeHooks('finalizeAmountOfSupplierInvoice', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+	if ($reshook > 0) {
+		print $hookmanager->resPrint;
+		if (!empty($remaintopay = $hookmanager->resArray['remaintopay'])) {
+			$resteapayer = $remaintopay;
+		}
+	}
+
 	// TODO Replace this by an include with same code to show already done payment visible in invoice card
 	print '<tr><td>'.$langs->trans('RemainderToPay').'</td><td class="nowrap">'.price($resteapayer, 1, '', 1, - 1, - 1, $conf->currency).'</td></tr>';
 


### PR DESCRIPTION
Payment terms for supplier invoices may contain specific cash discount agreements, e.g. 5% discount for paying within 7 days.

The tab for creating a bank transfer/credit transfer for a supplier invoice did not allow to consider these agreements, e.g. by calling a hooked function. The added hook allows the printout of additional lines to detail the exact cash discount and it can modify the calculated amount that remains to be paid and which is proposed in the bank transfer entry field.

Example of how this can be used by a custom module for cash discount handling:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/10772984/228496711-24a2e70c-c19a-435c-b968-ca4fe7cd6429.png">
