### PR TITLE
forceduedate is an option of the function

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -530,8 +530,6 @@ class Facture extends CommonInvoice
 			// We do not add link to template invoice or next invoice will be linked to all generated invoices
 			//$this->linked_objects['facturerec'][0] = $this->fac_rec;
 
-			$forceduedate = $this->calculate_date_lim_reglement();
-
 			// For recurring invoices, update date and number of last generation of recurring template invoice, before inserting new invoice
 			if ($_facrec->frequency > 0)
 			{


### PR DESCRIPTION
# FIX forceduedate is a function arg

That's so strange to get that here because $forceduedate is an argument of the function and some lines after there is a if(empty($forceduedate .../...

