### PR TITLE
NEW: Add global PRODUCT_DONOTSHOW_PRODUCTWITHNOSUPPLIERPRICE

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3355,6 +3355,9 @@ class Form
 			$sql .= " LEFT JOIN " . $this->db->prefix() . "c_units u ON u.rowid = p.fk_unit";
 		}
 		$sql .= " WHERE p.entity IN (" . getEntity('product') . ")";
+		if (empty($alsoproductwithnosupplierprice) && !empty($conf->global->PRODUCT_DONOTSHOW_PRODUCTWITHNOSUPPLIERPRICE)) {
+			$sql .= " AND pfp.rowid IS NOT NULL";
+		}
 		if ($statut != -1) {
 			$sql .= " AND p.tobuy = " . ((int) $statut);
 		}


### PR DESCRIPTION
NEW: Add global PRODUCT_DONOTSHOW_PRODUCTWITHNOSUPPLIERPRICE for do not show the product without supplier price instead of show all product and disabled these products

Case when $alsoproductwithnosupplierprice is equal at 0 for the select_produits_fournisseurs_list() function
