### PR TITLE
FIX: Fix css error on wordbreak for view extrafields (case on type 'text')

### DIFF
--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -212,7 +212,7 @@ if (empty($reshook) && isset($extrafields->attributes[$object->table_element]['l
 
 			$html_id = !empty($object->id) ? $object->element.'_extras_'.$tmpkeyextra.'_'.$object->id : '';
 
-			print '<td id="'.$html_id.'" class="valuefield '.$object->element.'_extras_'.$tmpkeyextra.' wordbreak"'.(!empty($cols) ? ' colspan="'.$cols.'"' : '').'>';
+			print '<td id="' . $html_id . '" class="valuefield ' . $object->element . '_extras_' . $tmpkeyextra . ' wordbreakimp"' . (!empty($cols) ? ' colspan="' . $cols . '"' : '') . '>';
 
 			// Convert date into timestamp format
 			if (in_array($extrafields->attributes[$object->table_element]['type'][$tmpkeyextra], array('date'))) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/28301879/228779716-1a73e060-b750-4a6e-bdd4-1a696dba0f3a.png)

After:
![image](https://user-images.githubusercontent.com/28301879/228779934-762b50bf-faaa-4fc5-b61c-04b9677b21fa.png)
