### PR TITLE
Improve margin calculation by updating buy price

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1455,6 +1455,12 @@ class Propal extends CommonObject
 							$line->subprice = $pu_ht;
 							$line->tva_tx = $tva_tx;
 							$line->remise_percent = $remise_percent;
+							// Update also cost price
+							$subpricetmp = isset($conf->global->ForceBuyingPriceIfNull) && $conf->global->ForceBuyingPriceIfNull > 0 ? 0 : $line->subprice;
+							$result = $object->defineBuyPrice($subpricetmp, $line->remise_percent, $line->fk_product);
+							if ($result > 0) {
+								$line->pa_ht = $result;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
In most cases, users use the cost price to calculate the margin from the best supplier price.
So, when they clone a proposal, they want to update the selling price and the buying price if the supplier's price list changes.
In this case, you can have a quick and precise view of the margin regardless of changes in customer or supplier prices.