### PR TITLE
FIX: Invoice Thirdparty never loaded at this point

### DIFF
--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -362,6 +362,7 @@ class PaiementFourn extends Paiement
 								$newlang = '';
 								$outputlangs = $langs;
 								if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
+									$invoice->fetch_thirdparty();
 									$newlang = $invoice->thirdparty->default_lang;
 								}
 								if (!empty($newlang)) {


### PR DESCRIPTION
**WARNING** : Attempt to read property "default_lang" on null in /var/www/html/fourn/class/paiementfourn.class.php on line 353
**CAUSE**: Ask for $invoice->thirdparty->default_lang but $invoice->thirdparty not intiated by Invoie fetch(), this generate PHP warning on recenbt PHP versions
**TARGET**: All branches
