### PR TITLE
FIX - Filter status orders in list no invoiced if validated + in progress + delivered

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -888,19 +888,19 @@ if ($search_status <> '') {
 		if ($search_status == 1 && empty($conf->expedition->enabled)) {
 			$sql .= ' AND c.fk_statut IN (1,2)'; // If module expedition disabled, we include order with status 'sending in process' into 'validated'
 		} else {
-			$sql .= ' AND c.fk_statut = '.((int) $search_status); // brouillon, validee, en cours, annulee
+			$sql .= ' AND c.fk_statut = '.((int) $search_status); // draft, validated, in process or canceled
 		}
 	}
-	if ($search_status == -2) {	// To process
+	if ($search_status == -2) {	// "validated + in process"
 		//$sql.= ' AND c.fk_statut IN (1,2,3) AND c.facture = 0';
 		$sql .= " AND ((c.fk_statut IN (1,2)) OR (c.fk_statut = 3 AND c.facture = 0))"; // If status is 2 and facture=1, it must be selected
 	}
-	if ($search_status == -3) {	// To bill
+	if ($search_status == -3) {	// "validated + in process + delivered"
 		//$sql.= ' AND c.fk_statut in (1,2,3)';
 		//$sql.= ' AND c.facture = 0'; // invoice not created
 		$sql .= ' AND (c.fk_statut IN (1,2,3))'; // validated, in process or closed
 	}
-	if ($search_status == -4) {	//  "validate and in progress"
+	if ($search_status == -4) {	//  "validate + in progress"
 		$sql .= ' AND (c.fk_statut IN (1,2))'; // validated, in process
 	}
 }

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -898,7 +898,7 @@ if ($search_status <> '') {
 	if ($search_status == -3) {	// To bill
 		//$sql.= ' AND c.fk_statut in (1,2,3)';
 		//$sql.= ' AND c.facture = 0'; // invoice not created
-		$sql .= ' AND ((c.fk_statut IN (1,2)) OR (c.fk_statut = 3 AND c.facture = 0))'; // validated, in process or closed but not billed
+		$sql .= ' AND (c.fk_statut IN (1,2,3))'; // validated, in process or closed
 	}
 	if ($search_status == -4) {	//  "validate and in progress"
 		$sql .= ' AND (c.fk_statut IN (1,2))'; // validated, in process


### PR DESCRIPTION
# FIX|Fix #[*Filter status orders in list no invoiced if validated + in progress + delivered*]

[en]
Where delivered orders are displayed, there are invoiced orders.

Logic dictates that when the orders validated + in progress + delivered are displayed, there are also the orders invoiced.

In addition we have a filter with the invoiced column.

It is penalizing to have all the orders without the drafts and those canceled

[fr]
Lorque l'on affiche les commandes livrées il y a les commande facturé.

La logique veux lorsque lon affiche les commandes validé + en cours + livré il y ai également les commandes facturées.

De plus nous avons un filtre avec la colonne facturé.

Ce ci est pénalisant pour avoir la totalité des commandes sans les brouillons et les annulées