### PR TITLE
In FR, activate constant INVOICE_DISABLE_REPLACEMENT by default

### DIFF
--- a/htdocs/master.inc.php
+++ b/htdocs/master.inc.php
@@ -227,6 +227,12 @@ if (!defined('NOREQUIREDB') && !defined('NOREQUIRESOC')) {
 		// For FR, default value of option to show category of operations is on by default. Decret n°2099-1299 2022-10-07
 		$conf->global->INVOICE_CATEGORY_OF_OPERATION = 1;
 	}
+	if ($mysoc->country_code == 'FR' && !isset($conf->global->INVOICE_DISABLE_REPLACEMENT)) {
+		// For FR, the replacement invoice type is not allowed.
+		// From an accounting point of view, this creates holes in the numbering of the invoice.
+		// This is very problematic during a fiscal control.
+		$conf->global->INVOICE_DISABLE_REPLACEMENT = 1;
+	}
 
 	if ($mysoc->localtax1_assuj || $mysoc->localtax2_assuj) {
 		// For countries using the 2nd or 3rd tax, we disable input/edit of lines using the price including tax (because 2nb and 3rd tax not yet taken into account).


### PR DESCRIPTION
In France, the replacement invoice type is not allowed. From an accounting point of view, this creates holes in the numbering of the invoice. This is problematic during a fiscal control.