### PR TITLE
Fix security access on create supplier order and invoice

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -402,7 +402,6 @@ function restrictedArea(User $user, $features, $object = 0, $tableandshare = '',
 	}
 	if ($features == 'fournisseur') {	// When vendor invoice and pruchase order are into module 'fournisseur'
 		$features = 'fournisseur';
-		$feature2 = '';
 		if ($object->element == 'invoice_supplier') {
 			$feature2 = 'facture';
 		} elseif ($object->element == 'order_supplier') {


### PR DESCRIPTION
Fix security access on create supplier order and invoice
-can't create supplier order or invoice even if I have all rights enabled
![image](https://user-images.githubusercontent.com/45359511/229499256-8de1c3b0-21fd-44c7-b2e1-fc058aabf2a6.png)

- parameter "feature2" is set on supplier order and invoice card : 
1. restrictedArea($user, 'fournisseur', $id, 'commande_fournisseur', 'commande', 'fk_soc', 'rowid', $isdraft);
2. restrictedArea($user, 'fournisseur', $id, 'facture_fourn', 'facture', 'fk_soc', 'rowid', $isdraft);
- but this parameter 'feature2" is set to empty in security lib
