### PR TITLE
FIX Propagate extrafields from supplier order to reception

### DIFF
--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -871,7 +871,7 @@ if ($action == 'create') {
 				if ($objectsrc->fetch_optionals() > 0) {
 					$recept->array_options = array_merge($recept->array_options, $objectsrc->array_options);
 				}
-				print $object->showOptionals($extrafields, 'create', $parameters);
+				print $recept->showOptionals($extrafields, 'create', $parameters);
 			}
 
 			// Incoterms


### PR DESCRIPTION
Wrong object source. $recept = $objectsrc

Thanks @lvessiller-opendsi 

