### PR TITLE
FIX supplier invoice status on bank transfer line

### DIFF
--- a/htdocs/compta/prelevement/line.php
+++ b/htdocs/compta/prelevement/line.php
@@ -116,7 +116,13 @@ if ($action == 'confirm_rejet') {
  * View
  */
 
-$invoicestatic = new Facture($db);
+if ($type == 'bank-transfer') {
+	require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
+	$invoicestatic = new FactureFournisseur($db);
+} else {
+	require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
+	$invoicestatic = new Facture($db);
+}
 
 $title = $langs->trans("WithdrawalsLine");
 if ($type == 'bank-transfer') {


### PR DESCRIPTION
FIX supplier invoice status on bank transfer line
- always got "Draft" status label on bank transfer line
