### PR TITLE
FIX Search List Select Extrafields with condition

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1084,6 +1084,9 @@ class ExtraFields
 						continue;
 					}
 
+					$valarray = explode('|', $val);
+					$val = $valarray[0];
+
 					if ($langfile && $val) {
 						$options[$okey] = $langs->trans($val);
 					} else {


### PR DESCRIPTION
# FIX|Fix #

Lists: "select" search fields of extrafields with condition display incorrectly. The label displays the conditions and not just the label.