### PR TITLE
Edit button now available on subscription card when Bank module disabled

### DIFF
--- a/htdocs/adherents/subscription/card.php
+++ b/htdocs/adherents/subscription/card.php
@@ -352,7 +352,7 @@ if ($rowid && $action != 'edit') {
 	print '<div class="tabsAction">';
 
 	if ($user->hasRight('adherent', 'cotisation', 'creer')) {
-		if (!empty($bankline->rappro)) {
+		if (!empty($bankline->rappro) || empty($bankline)) {
 			print '<div class="inline-block divButAction"><a class="butAction" href="'.$_SERVER["PHP_SELF"]."?rowid=".$object->id.'&action=edit&token='.newToken().'">'.$langs->trans("Modify")."</a></div>";
 		} else {
 			print '<div class="inline-block divButAction"><a class="butActionRefused classfortooltip" title="'.$langs->trans("BankLineConciliated")."\" href=\"#\">".$langs->trans("Modify")."</a></div>";


### PR DESCRIPTION
# FIX|Fix #24435 Cannot edit subscription when Bank module is disabled
Fixes a condition that was defaulting to not being able to modify a subscription when no bankline were found.