### PR TITLE
FIX : Disable the product selection list 

### DIFF
--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -284,6 +284,7 @@ if ($action == 'create') {
 	?>
 	<script>
 		 $(document).ready(function () {
+             if (jQuery('#fk_bom').val() > 0) jQuery('#fk_product').prop('disabled', true);
 			 jQuery('#fk_bom').change(function() {
 				console.log('We change value of BOM with BOM of id '+jQuery('#fk_bom').val());
 				if (jQuery('#fk_bom').val() > 0)


### PR DESCRIPTION
## FIX : Disable the product selection list 

On the MO creation screen :
Users can select a BOM (it will set the linked product on the product selection list) and then changge the linked product even if that does not correspond to the selected BOM.

I think we must control that, and make impossible product change when the BOM is set 