### PR TITLE
Allow virtual stock to show on a line in product stocks list when no physical stock present.

### DIFF
--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1,6 +1,6 @@
 <?php
 /* Copyright (C) 2019-2020 	Laurent Destailleur  <eldy@users.sourceforge.net>
- * Copyright (C) 2023 		Christian Humpel  <christian.humpel@gmail.com>
+ * Copyright (C) 2023 		Christian Humpel     <christian.humpel@gmail.com>
  * Copyright (C) 2023 		Vincent de Grandpré  <vincent@de-grandpre.quebec>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2019-2020 	Laurent Destailleur  <eldy@users.sourceforge.net>
-/* Copyright (C) 2023 		Christian Humpel  <christian.humpel@gmail.com>
+ * Copyright (C) 2023 		Christian Humpel  <christian.humpel@gmail.com>
+ * Copyright (C) 2023 		Vincent de Grandpré  <vincent@de-grandpre.quebec>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -441,6 +442,11 @@ $newToken = newToken();
 if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'create'))) {
 	$res = $object->fetch_thirdparty();
 	$res = $object->fetch_optionals();
+
+	if(!empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) && $object->fk_warehouse > 0){
+		$tmpwarehouse->fetch($object->fk_warehouse);
+		$fk_default_warehouse = $object->fk_warehouse;
+	}
 
 	$head = moPrepareHead($object);
 
@@ -924,6 +930,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					print '</td>';
 					// Warehouse
 					print '<td>';
+					if(!empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) && $tmpwarehouse->id > 0) {
+						print img_picto('', $tmpwarehouse->picto)." ".$tmpwarehouse->label;
+					}
 					print '</td>';
 					// Stock
 					if (isModEnabled('stock')) {
@@ -932,7 +941,18 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 							if (!$line->disable_stock_change && $tmpproduct->stock_reel < ($line->qty - $alreadyconsumed)) {
 								print img_warning($langs->trans('StockTooLow')) . ' ';
 							}
-							print price2num($tmpproduct->stock_reel, 'MS'); // Available
+							if(empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) || empty($tmpwarehouse->id)) {
+								print price2num($tmpproduct->stock_reel, 'MS'); // Available
+							} else {
+								// Print only the stock in the selected warehouse
+								$tmpproduct->load_stock();
+								$wh_stock = $tmpproduct->stock_warehouse[$tmpwarehouse->id];
+								if(!empty($wh_stock)){
+									print price2num($wh_stock->real, 'MS');
+								} else {
+									print "0";
+								}							
+							}
 						}
 						print '</td>';
 					}
@@ -1123,6 +1143,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			});
 		</script>';
 
+		if (in_array($action, array('consumeorproduce', 'consumeandproduceall')) && 
+			!empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE)) {
+			print '<script>$(document).ready(function () {
+				$("#fk_default_warehouse").change();
+			});</script>';
+		}
 
 		// Lines to produce
 

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -443,7 +443,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	$res = $object->fetch_thirdparty();
 	$res = $object->fetch_optionals();
 
-	if(!empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) && $object->fk_warehouse > 0){
+	if (!empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) && $object->fk_warehouse > 0) {
 		$tmpwarehouse->fetch($object->fk_warehouse);
 		$fk_default_warehouse = $object->fk_warehouse;
 	}
@@ -930,7 +930,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					print '</td>';
 					// Warehouse
 					print '<td>';
-					if(!empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) && $tmpwarehouse->id > 0) {
+					if (!empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) && $tmpwarehouse->id > 0) {
 						print img_picto('', $tmpwarehouse->picto)." ".$tmpwarehouse->label;
 					}
 					print '</td>';
@@ -941,17 +941,17 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 							if (!$line->disable_stock_change && $tmpproduct->stock_reel < ($line->qty - $alreadyconsumed)) {
 								print img_warning($langs->trans('StockTooLow')) . ' ';
 							}
-							if(empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) || empty($tmpwarehouse->id)) {
+							if (empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) || empty($tmpwarehouse->id)) {
 								print price2num($tmpproduct->stock_reel, 'MS'); // Available
 							} else {
 								// Print only the stock in the selected warehouse
 								$tmpproduct->load_stock();
 								$wh_stock = $tmpproduct->stock_warehouse[$tmpwarehouse->id];
-								if(!empty($wh_stock)){
+								if (!empty($wh_stock)) {
 									print price2num($wh_stock->real, 'MS');
 								} else {
 									print "0";
-								}							
+								}
 							}
 						}
 						print '</td>';
@@ -1143,7 +1143,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			});
 		</script>';
 
-		if (in_array($action, array('consumeorproduce', 'consumeandproduceall')) && 
+		if (in_array($action, array('consumeorproduce', 'consumeandproduceall')) &&
 			!empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE)) {
 			print '<script>$(document).ready(function () {
 				$("#fk_default_warehouse").change();

--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -196,7 +196,7 @@ if (empty($conf->global->PRODUCT_STOCK_LIST_SHOW_VIRTUAL_WITH_NO_PHYSICAL)) {
 			) IS NOT NULL
 			OR (
 				SELECT SUM(ed3.qty) as qty 
-				FROM llx_expeditiondet as ed3 
+				FROM ".MAIN_DB_PREFIX."expeditiondet as ed3 
 				LEFT JOIN ".MAIN_DB_PREFIX."expedition as e3 ON e3.rowid = ed3.fk_expedition 
 				LEFT JOIN ".MAIN_DB_PREFIX."commandedet as cd3 ON ed3.fk_origin_line = cd3.rowid 
 				LEFT JOIN ".MAIN_DB_PREFIX."commande as c3 ON c3.rowid = cd3.fk_commande 

--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2013       Cédric Salvador         <csalvador@gpcsolutions.fr>
  * Copyright (C) 2015       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2019       Juanjo Menent			<jmenent@2byte.es>
- * Copyright (C) 2023 		Vincent de Grandpré  <vincent@de-grandpre.quebec>
+ * Copyright (C) 2023 		Vincent de Grandpré  	<vincent@de-grandpre.quebec>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -172,7 +172,44 @@ if (!empty($search_categ) && $search_categ != '-1') {
 	}
 	$sql .= ")";
 }
-$sql .= " AND EXISTS (SELECT e.rowid FROM ".MAIN_DB_PREFIX."entrepot as e WHERE e.rowid = s.fk_entrepot AND e.entity IN (".getEntity('stock')."))";
+if (empty($conf->global->PRODUCT_STOCK_LIST_SHOW_VIRTUAL_WITH_NO_PHYSICAL)) {
+	$sql .= " AND EXISTS (SELECT e.rowid FROM ".MAIN_DB_PREFIX."entrepot as e WHERE e.rowid = s.fk_entrepot AND e.entity IN (".getEntity('stock')."))";
+} else {
+	$sql .= " AND 
+		(
+			EXISTS 
+				(SELECT e.rowid 
+				 FROM ".MAIN_DB_PREFIX."entrepot as e 
+				 WHERE e.rowid = s.fk_entrepot AND e.entity IN (".getEntity('stock').")) 
+			OR (
+				SELECT SUM(cd1.qty) as qty 
+				FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as cd1 
+				LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseur as c1 
+					ON c1.rowid = cd1.fk_commande 
+				WHERE c1.entity IN (1) AND cd1.fk_product = p.rowid AND c1.fk_statut in (3,4) AND cd1.qty <> 0
+			) IS NOT NULL
+			OR (
+				SELECT SUM(cd2.qty) as qty 
+				FROM ".MAIN_DB_PREFIX."commandedet as cd2 
+				LEFT JOIN ".MAIN_DB_PREFIX."commande as c2 ON c2.rowid = cd2.fk_commande 
+				WHERE c2.entity IN (1) AND cd2.fk_product = p.rowid AND c2.fk_statut in (1,2) AND cd2.qty <> 0
+			) IS NOT NULL
+			OR (
+				SELECT SUM(ed3.qty) as qty 
+				FROM llx_expeditiondet as ed3 
+				LEFT JOIN ".MAIN_DB_PREFIX."expedition as e3 ON e3.rowid = ed3.fk_expedition 
+				LEFT JOIN ".MAIN_DB_PREFIX."commandedet as cd3 ON ed3.fk_origin_line = cd3.rowid 
+				LEFT JOIN ".MAIN_DB_PREFIX."commande as c3 ON c3.rowid = cd3.fk_commande 
+				WHERE e3.entity IN (1) AND cd3.fk_product = p.rowid AND c3.fk_statut IN (1,2) AND e3.fk_statut IN (1,2) AND ed3.qty <> 0
+			) IS NOT NULL
+			OR (
+				SELECT SUM(mp4.qty) as qty 
+				FROM ".MAIN_DB_PREFIX."mrp_production as mp4 
+				LEFT JOIN ".MAIN_DB_PREFIX."mrp_mo as m4 ON m4.rowid = mp4.fk_mo AND m4.entity IN (1) AND mp4.fk_product = p.rowid AND m4.status IN (1,2)
+				WHERE mp4.qty <> 0				
+			) IS NOT NULL
+			) ";
+}
 if ($sall) {
 	$sql .= natural_search(array('p.ref', 'p.label', 'p.description', 'p.note'), $sall);
 }

--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -206,8 +206,8 @@ if (empty($conf->global->PRODUCT_STOCK_LIST_SHOW_VIRTUAL_WITH_NO_PHYSICAL)) {
 			OR (
 				SELECT SUM(mp4.qty) as qty 
 				FROM ".MAIN_DB_PREFIX."mrp_production as mp4 
-				LEFT JOIN ".MAIN_DB_PREFIX."mrp_mo as m4 ON m4.rowid = mp4.fk_mo AND m4.entity IN (1) AND mp4.fk_product = p.rowid AND m4.status IN (1,2)
-				WHERE mp4.qty <> 0				
+				LEFT JOIN ".MAIN_DB_PREFIX."mrp_mo as m4 ON m4.rowid = mp4.fk_mo AND m4.entity IN (1) AND m4.status IN (1,2)
+				WHERE mp4.fk_product = p.rowid AND mp4.qty <> 0
 			) IS NOT NULL
 			) ";
 }

--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2013       Cédric Salvador         <csalvador@gpcsolutions.fr>
  * Copyright (C) 2015       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2019       Juanjo Menent			<jmenent@2byte.es>
+ * Copyright (C) 2023 		Vincent de Grandpré  <vincent@de-grandpre.quebec>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
# NEW|New #24445 Show product in stock line when there is virtual stock but no physical stock

**Dolibarr Version : 17.0.0**

As requested by our customer, we added a global variable PRODUCT_STOCK_LIST_SHOW_VIRTUAL_WITH_NO_PHYSICAL that, when it exists, append some OR conditions to the list query so that product with no physical stock but with virtual stocks can show up.

The sub-queries were constructed using all derivatives in load_virtual_stock() of the product class.
