### PR TITLE
FIX regression Undefined $datepaid

### DIFF
--- a/htdocs/don/class/paymentdonation.class.php
+++ b/htdocs/don/class/paymentdonation.class.php
@@ -130,7 +130,7 @@ class PaymentDonation extends CommonObject
 		$now = dol_now();
 
 		// Validate parameters
-		if (!$this->datepaid) {
+		if (!$this->datep) {
 			$this->error = 'ErrorBadValueForParameterCreatePaymentDonation';
 			return -1;
 		}
@@ -189,7 +189,7 @@ class PaymentDonation extends CommonObject
 			$sql .= " fk_typepayment, num_payment, note, ext_payment_id, ext_payment_site,";
 			$sql .= " fk_user_creat, fk_bank)";
 			$sql .= " VALUES (".((int) $this->chid).", '".$this->db->idate($now)."',";
-			$sql .= " '".$this->db->idate($this->datepaid)."',";
+			$sql .= " '".$this->db->idate($this->datep)."',";
 			$sql .= " ".((float) price2num($totalamount)).",";
 			$sql .= " ".((int) $this->paymenttype).", '".$this->db->escape($this->num_payment)."', '".$this->db->escape($this->note_public)."', ";
 			$sql .= " ".($this->ext_payment_id ? "'".$this->db->escape($this->ext_payment_id)."'" : "null").", ".($this->ext_payment_site ? "'".$this->db->escape($this->ext_payment_site)."'" : "null").",";
@@ -587,7 +587,7 @@ class PaymentDonation extends CommonObject
 
 			// Insert payment into llx_bank
 			$bank_line_id = $acc->addline(
-				$this->datepaid,
+				$this->datep,
 				$this->paymenttype, // Payment mode id or code ("CHQ or VIR for example")
 				$label,
 				$amount,


### PR DESCRIPTION
As until v16 there was a $payment->datepaid  set on line 97 of /don/payment/payement.php witch was corrected in v17 to  $payment->datep     = $datepaid de shall mot use this->datepaid in this class anymore

see discussion here:
https://www.dolibarr.fr/forum/t/probleme-enregistrement-versement-des-dons/42873