### PR TITLE
NEW Show stock only from selected warehouse in product list and sh…

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2683,7 +2683,7 @@ class Form
 			$sql .= " LEFT JOIN " . $this->db->prefix() . "product_stock as ps on ps.fk_product = p.rowid";
 			$sql .= " LEFT JOIN " . $this->db->prefix() . "entrepot as e on ps.fk_entrepot = e.rowid AND e.entity IN (" . getEntity('stock') . ")";
 			if (count($warehouseStatusArray) == 1 && is_numeric($warehouseStatusArray[0])) {
-				$sql .= ' AND e.rowid = ' . $this->db->sanitize($warehouseStatusArray[0]); // Return line if product is inside the selected warehouse.
+				$sql .= ' AND e.rowid IN ('.$this->db->sanitize($warehouseStatusArray[0]).')'; // Return line if product is inside the selected warehouse.
 			} else {
 				$sql .= ' AND e.statut IN ('.$this->db->sanitize($this->db->escape(implode(',', $warehouseStatusArray))).')'; // Return line if product is inside the selected stock. If not, an empty line will be returned so we will count 0.
 			}

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2683,7 +2683,7 @@ class Form
 			$sql .= " LEFT JOIN " . $this->db->prefix() . "product_stock as ps on ps.fk_product = p.rowid";
 			$sql .= " LEFT JOIN " . $this->db->prefix() . "entrepot as e on ps.fk_entrepot = e.rowid AND e.entity IN (" . getEntity('stock') . ")";
 			if (count($warehouseStatusArray) == 1 && is_numeric($warehouseStatusArray[0])) {
-				$sql .= ' AND e.rowid = ' . $warehouseStatusArray[0]; // Return line if product is inside the selected warehouse.
+				$sql .= ' AND e.rowid = ' . $this->db->sanitize($warehouseStatusArray[0]); // Return line if product is inside the selected warehouse.
 			} else {
 				$sql .= ' AND e.statut IN ('.$this->db->sanitize($this->db->escape(implode(',', $warehouseStatusArray))).')'; // Return line if product is inside the selected stock. If not, an empty line will be returned so we will count 0.
 			}

--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -11,6 +11,7 @@
  * Copyright (C) 2019		Nicolas ZABOURI		<info@inovea-conseil.com>
  * Copyright (C) 2022		OpenDSI				<support@open-dsi.fr>
  * Copyright (C) 2022      	Gauthier VERDOL     <gauthier.verdol@atm-consulting.fr>
+ * Copyright (C) 2023      	Vincent de Grandpré <vincent@de-grandpre.quebec>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -261,6 +262,7 @@ if ($nolinesbefore) {
 				$statustoshow = 1;
 				$statuswarehouse = 'warehouseopen,warehouseinternal';
 				if (!empty($conf->global->ENTREPOT_WAREHOUSEINTERNAL_NOT_SELL)) $statuswarehouse = 'warehouseopen';
+				if (!empty($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) && $object->warehouse_id > 0) $statuswarehouse = $object->warehouse_id;
 				if (!empty($conf->global->ENTREPOT_EXTRA_STATUS)) {
 					// hide products in closed warehouse, but show products for internal transfer
 					$form->select_produits(GETPOST('idprod'), 'idprod', $filtertype, $conf->product->limit_size, $buyer->price_level, $statustoshow, 2, '', 1, array(), $buyer->id, '1', 0, 'maxwidth500', 0, $statuswarehouse, GETPOST('combinations', 'array'));

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -793,7 +793,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			print '<!-- Add line to consume -->'."\n";
 			print '<tr class="liste_titre">';
 			print '<td>';
-			print $form->select_produits('', 'productidtoadd', '', 0, 0, -1, 2, '', 1, array(), 0, '1', 0, 'maxwidth300');
+			// Allow to show only quantity from manufacturing warehouse
+			$warehouseStatus = '';
+			if ($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) {
+				if (!empty($tmpwarehouse)) {
+					$warehouseStatus = $tmpwarehouse->id;
+				}
+			}
+			print $form->select_produits('', 'productidtoadd', '', 0, 0, -1, 2, '', 1, array(), 0, '1', 0, 'maxwidth300', 0, $warehouseStatus);
 			print '</td>';
 			// Qty
 			print '<td class="right"><input type="text" name="qtytoadd" value="1" class="width50 right"></td>';
@@ -1228,7 +1235,15 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			// Product
 			print '<td>';
-			print $form->select_produits('', 'productidtoadd', '', 0, 0, -1, 2, '', 1, array(), 0, '1', 0, 'maxwidth300');
+
+			// Allow to show only quantity from manufacturing warehouse
+			$warehouseStatus = '';
+			if ($conf->global->STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE) {
+				if (!empty($tmpwarehouse)) {
+					$warehouseStatus = $tmpwarehouse->id;
+				}
+			}
+			print $form->select_produits('', 'productidtoadd', '', 0, 0, -1, 2, '', 1, array(), 0, '1', 0, 'maxwidth300', 0, $warehouseStatus);
 			print '</td>';
 			// Qty
 			print '<td class="right"><input type="text" name="qtytoadd" value="1" class="width50 right"></td>';


### PR DESCRIPTION
…ow line as stock-OK where virtual stock but no physical stock

# NEW|New #24482 [Improvements to product list requested by customer](https://github.com/Dolibarr/dolibarr/issues/24482)

1. *Show stock quantity of selected warehouse only in customer order and MO*

- Using global variable STOCK_CONSUMPTION_FROM_MANUFACTURING_WAREHOUSE and an associated warehouse in manufacturing order or in customer order product lists
- In Customer order product list, global ENTREPOT_EXTRA_STATUS need also to be set.

2. *Show product line as stock-OK when there are virtual stock but no physical stock*

- Using global variable PRODUCT_STOCK_LIST_SHOW_VIRTUAL_WITH_NO_PHYSICAL along with STOCK_SHOW_VIRTUAL_STOCK_IN_PRODUCTS_COMBO to show product lines as stock-OK in manufacturing order (add production item) product list and customer order defined product list.

