### PR TITLE
Fix #24489: Remove unnecessary output of extrafields

### DIFF
--- a/htdocs/bom/tpl/objectline_create.tpl.php
+++ b/htdocs/bom/tpl/objectline_create.tpl.php
@@ -195,10 +195,6 @@ if ($filtertype != 1) {
 	print '</td>';
 	print '</tr>';
 
-
-if (is_object($objectline)) {
-	print $objectline->showOptionals($extrafields, 'edit', array('style'=>$bcnd[$var], 'colspan'=>$coldisplay), '', '', 1, 'line');
-}
 ?>
 
 <script>


### PR DESCRIPTION
The extrafields for a bom line are already output at line 130 (correct within html tags).

The additional output here (without any html tags) causes the extrafields to be displayed additionally on top of all line items.

Fixes issue #24489.