### PR TITLE
FIX: Add missing hook in warehouse product list

### DIFF
--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -814,7 +814,7 @@ if ($action == 'create') {
 				} else {
 					print $hookmanager->resPrint;
 				}
-				
+
 				print '<td class="liste_total right">';
 				$valtoshow = price2num($totalunit, 'MS');
 				if (empty($conf->global->PRODUCT_USE_UNITS) || $sameunits) {

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -806,18 +806,18 @@ if ($action == 'create') {
 				// Total
 				print '<tr class="liste_total"><td class="liste_total" colspan="2">'.$langs->trans("Total").'</td>';
 
-                $parameters = array();
-                // Note that $action and $object may have been modified by hook
-                $reshook = $hookmanager->executeHooks('printFieldListTotal', $parameters, $object);
+				$parameters = array();
+				// Note that $action and $object may have been modified by hook
+				$reshook = $hookmanager->executeHooks('printFieldListTotal', $parameters, $object);
 
-                if ($reshook < 0) {
-                    dol_print_error($db, $hookmanager->error, $hookmanager->errors);
-                    llxFooter();
-                    $db->close();
-                    exit;
-                }
+				if ($reshook < 0) {
+					dol_print_error($db, $hookmanager->error, $hookmanager->errors);
+					llxFooter();
+					$db->close();
+					exit;
+				}
 
-                print $hookmanager->resPrint;
+				print $hookmanager->resPrint;
 
 				print '<td class="liste_total right">';
 				$valtoshow = price2num($totalunit, 'MS');

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -809,16 +809,12 @@ if ($action == 'create') {
 				$parameters = array();
 				// Note that $action and $object may have been modified by hook
 				$reshook = $hookmanager->executeHooks('printFieldListTotal', $parameters, $object);
-
 				if ($reshook < 0) {
-					dol_print_error($db, $hookmanager->error, $hookmanager->errors);
-					llxFooter();
-					$db->close();
-					exit;
+					setEventMessages($hookmanager->error, $hookmanager->errors);
+				} else {
+					print $hookmanager->resPrint;
 				}
-
-				print $hookmanager->resPrint;
-
+				
 				print '<td class="liste_total right">';
 				$valtoshow = price2num($totalunit, 'MS');
 				if (empty($conf->global->PRODUCT_USE_UNITS) || $sameunits) {

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -805,6 +805,18 @@ if ($action == 'create') {
 
 				// Total
 				print '<tr class="liste_total"><td class="liste_total" colspan="2">'.$langs->trans("Total").'</td>';
+
+                $parameters = array();
+                // Note that $action and $object may have been modified by hook
+                $reshook = $hookmanager->executeHooks('printFieldListTotal', $parameters, $object);
+
+                if ($reshook < 0) {
+                    dol_print_error($db, $hookmanager->error, $hookmanager->errors);
+                    llxFooter();
+                    $db->close();
+                    exit;
+                }
+
 				print '<td class="liste_total right">';
 				$valtoshow = price2num($totalunit, 'MS');
 				if (empty($conf->global->PRODUCT_USE_UNITS) || $sameunits) {

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -817,6 +817,8 @@ if ($action == 'create') {
                     exit;
                 }
 
+                print $hookmanager->resPrint;
+
 				print '<td class="liste_total right">';
 				$valtoshow = price2num($totalunit, 'MS');
 				if (empty($conf->global->PRODUCT_USE_UNITS) || $sameunits) {


### PR DESCRIPTION
As it is possible to add columns to the list of products contained in the warehouse using the **printFieldListValue** and **printFieldListValue** hooks. I think it would be wise to add a hook to add content to the total row. Otherwise alignment with other columns is lost.