### PR TITLE
 NEW : Update card.php fichinter - Total duration in hours

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -9,6 +9,7 @@
  * Copyright (C) 2015-2016  Abbes Bahfir            <bafbes@gmail.com>
  * Copyright (C) 2018-2022 	Philippe Grand       	<philippe.grand@atoo-net.com>
  * Copyright (C) 2020       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2023       Benjamin Grembi         <benjamin@oarces.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1275,9 +1276,13 @@ if ($action == 'create') {
 	print '<table class="border tableforfield centpercent">';
 
 	if (empty($conf->global->FICHINTER_DISABLE_DETAILS)) {
-		// Duration
-		print '<tr><td class="titlefield">'.$langs->trans("TotalDuration").'</td>';
+		// Duration in time
+		print '<tr><td class="titlefield">'.$langs->trans("TotalDurationTime").'</td>';
 		print '<td>'.convertSecondToTime($object->duration, 'all', $conf->global->MAIN_DURATION_OF_WORKDAY).'</td>';
+		print '</tr>';
+		// Duration in hour format
+		print '<tr><td class="titlefield">'.$langs->trans("TotalDurationHour").'</td>';
+		print '<td>'.convertDurationtoHour($object->duration, "s").' '.$langs->trans("h").'</td>';
 		print '</tr>';
 	}
 

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -1277,12 +1277,8 @@ if ($action == 'create') {
 
 	if (empty($conf->global->FICHINTER_DISABLE_DETAILS)) {
 		// Duration in time
-		print '<tr><td class="titlefield">'.$langs->trans("TotalDurationTime").'</td>';
-		print '<td>'.convertSecondToTime($object->duration, 'all', $conf->global->MAIN_DURATION_OF_WORKDAY).'</td>';
-		print '</tr>';
-		// Duration in hour format
-		print '<tr><td class="titlefield">'.$langs->trans("TotalDurationHour").'</td>';
-		print '<td>'.convertDurationtoHour($object->duration, "s").' '.$langs->trans("h").'</td>';
+		print '<tr><td class="titlefield">'.$langs->trans("TotalDuration").'</td>';
+		print '<td>'.convertSecondToTime($object->duration, 'all', $conf->global->MAIN_DURATION_OF_WORKDAY).' ('.convertDurationtoHour($object->duration, "s").' '.$langs->trans("h").')</td>';
 		print '</tr>';
 	}
 


### PR DESCRIPTION
This code generates second row of a table to display the total duration of an employee, one in time format (DD HH:MM) and the other in hour format only (HH).

The first row (original code) displays the title "TotalDurationTime" using the "trans" method of the $langs object to translate the string. The total time is converted to HH:MM:SS format using the "convertSecondToTime" function, which takes into account the daily work time duration specified in the global variable $conf->global->MAIN_DURATION_OF_WORKDAY.

The second row displays the title "TotalDurationHour" using the "trans" method of the $langs object to translate the string. The total duration is converted to hours using the "convertDurationtoHour" function, specifying "s" as the time unit (seconds).


# NEW|New [Total duration also in hours]
When selling time tickets or time in batches, the conversion to number of days makes no sense.
Add second row of a table to display the total duration of an employee, one in time format (DD HH:MM) and the other in hour format only (HH).
