### PR TITLE
Add fk_default_workstation  on bom line and mrp production

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1732,6 +1732,12 @@ class BOMLine extends CommonObjectLine
 	 */
 	public $childBom = array();
 
+	/*
+	 * Service Workstation
+	 */
+	public $fk_default_workstation;
+
+
 
 	/**
 	 * Constructor

--- a/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
+++ b/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
@@ -394,3 +394,6 @@ ALTER TABLE llx_c_email_templates add COLUMN defaultfortype smallint DEFAULT 0;
 ALTER TABLE llx_mailing ADD COLUMN fk_user_modif integer AFTER fk_user_creat;
 ALTER TABLE llx_mailing ADD COLUMN evenunsubscribe smallint DEFAULT 0;
 ALTER TABLE llx_mailing ADD COLUMN name_from varchar(128) AFTER email_from;
+
+ALTER TABLE llx_bom_bomline ADD COLUMN fk_default_workstation integer DEFAULT NULL;
+ALTER TABLE llx_mrp_production ADD COLUMN fk_default_workstation integer DEFAULT NULL;

--- a/htdocs/install/mysql/tables/llx_bom_bomline.sql
+++ b/htdocs/install/mysql/tables/llx_bom_bomline.sql
@@ -26,6 +26,7 @@ CREATE TABLE llx_bom_bomline(
     disable_stock_change smallint DEFAULT 0, 
 	efficiency double(24,8) NOT NULL DEFAULT 1,
 	fk_unit integer NULL,
-	position integer NOT NULL DEFAULT 0
+	position integer NOT NULL DEFAULT 0,
+	fk_default_workstation integer DEFAULT NULL
 	-- END MODULEBUILDER FIELDS
 ) ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_mrp_production.sql
+++ b/htdocs/install/mysql/tables/llx_mrp_production.sql
@@ -33,6 +33,7 @@ CREATE TABLE llx_mrp_production(
 	tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, 
 	fk_user_creat integer NOT NULL, 
 	fk_user_modif integer, 
-	import_key varchar(14)
+	import_key varchar(14),
+	fk_default_workstation integer DEFAULT NULL
 ) ENGINE=innodb;
 

--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -1744,6 +1744,11 @@ class MoLine extends CommonObjectLine
 	public $import_key;
 	public $fk_parent_line;
 
+    /*
+	 * Service Workstation
+	 */
+    public $fk_default_workstation;
+
 	/**
 	 * Constructor
 	 *

--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -1744,10 +1744,10 @@ class MoLine extends CommonObjectLine
 	public $import_key;
 	public $fk_parent_line;
 
-    /*
+	/*
 	 * Service Workstation
 	 */
-    public $fk_default_workstation;
+	public $fk_default_workstation;
 
 	/**
 	 * Constructor


### PR DESCRIPTION
# NEW|New 
Add fk_default_workstation in llx_bom_bomline and llx_mrp_production to develop an editable field with default workstation of product as default value.
