### PR TITLE
FIX: Fiscal year list ref display

### DIFF
--- a/htdocs/accountancy/admin/fiscalyear.php
+++ b/htdocs/accountancy/admin/fiscalyear.php
@@ -143,6 +143,7 @@ if ($result) {
 		while ($i < $num && $i < $max) {
 			$obj = $db->fetch_object($result);
 
+			$fiscalyearstatic->ref = $obj->rowid;
 			$fiscalyearstatic->id = $obj->rowid;
 
 			print '<tr class="oddeven">';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58433943/232740063-64466cee-9bd2-43e1-a33c-ca867ea50efb.png)
As fiscal year is a static object, ref was kept  between lines.