### PR TITLE
FIX: Use max parameters of widget graph product distribution

### DIFF
--- a/htdocs/core/boxes/box_graph_product_distribution.php
+++ b/htdocs/core/boxes/box_graph_product_distribution.php
@@ -161,7 +161,7 @@ class box_graph_product_distribution extends ModeleBoxes
 				$showpointvalue = 1;
 				$nocolor = 0;
 				$stats_proposal = new PropaleStats($this->db, $socid, ($userid > 0 ? $userid : 0));
-				$data2 = $stats_proposal->getAllByProductEntry($year, (GETPOST('action', 'aZ09') == $refreshaction ?-1 : (3600 * 24)), 5);
+				$data2 = $stats_proposal->getAllByProductEntry($year, (GETPOST('action', 'aZ09') == $refreshaction ?-1 : (3600 * 24)), $max);
 				if (empty($data2)) {
 					$showpointvalue = 0;
 					$nocolor = 1;
@@ -224,7 +224,7 @@ class box_graph_product_distribution extends ModeleBoxes
 				$nocolor = 0;
 				$mode = 'customer';
 				$stats_order = new CommandeStats($this->db, $socid, $mode, ($userid > 0 ? $userid : 0));
-				$data3 = $stats_order->getAllByProductEntry($year, (GETPOST('action', 'aZ09') == $refreshaction ?-1 : (3600 * 24)), 5);
+				$data3 = $stats_order->getAllByProductEntry($year, (GETPOST('action', 'aZ09') == $refreshaction ?-1 : (3600 * 24)), $max);
 				if (empty($data3)) {
 					$showpointvalue = 0;
 					$nocolor = 1;
@@ -288,7 +288,7 @@ class box_graph_product_distribution extends ModeleBoxes
 				$nocolor = 0;
 				$mode = 'customer';
 				$stats_invoice = new FactureStats($this->db, $socid, $mode, ($userid > 0 ? $userid : 0));
-				$data1 = $stats_invoice->getAllByProductEntry($year, (GETPOST('action', 'aZ09') == $refreshaction ?-1 : (3600 * 24)), 5);
+				$data1 = $stats_invoice->getAllByProductEntry($year, (GETPOST('action', 'aZ09') == $refreshaction ?-1 : (3600 * 24)), $max);
 
 				if (empty($data1)) {
 					$showpointvalue = 0;


### PR DESCRIPTION
Widget **graph product distribution** loadbox method has a $max parameter which should be use to increase the maximum number of product displayed in the widget, but it was never used.