### PR TITLE
FIX ref_client on Project Overview for propale

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1260,7 +1260,7 @@ foreach ($listofreferent as $key => $value) {
 						print ' - '.$element->ref_customer;
 					}
 					// Compatibility propale
-					if (empty($element->ref_customer) && !empty($element->ref_client)){
+					if (empty($element->ref_customer) && !empty($element->ref_client)) {
 						print ' - '.$element->ref_client;
 					}
 				}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1259,6 +1259,10 @@ foreach ($listofreferent as $key => $value) {
 					if (!empty($element->ref_customer)) {
 						print ' - '.$element->ref_customer;
 					}
+					// Compatibility propale
+					if (empty($element->ref_customer) && !empty($element->ref_client)){
+						print ' - '.$element->ref_client;
+					}
 				}
 				print "</td>\n";
 


### PR DESCRIPTION
The ref_customer in the propal object is name ref_client.  I just added another check if nothing is found.

# FIX #ref_client on Project Overview for propale
On the project overview page, customer references were not displayed for customer propale because of a difference of attribute names between propal class and others 
