### PR TITLE
FIX: Propagate correct origin/origin_id when creating order from proposal

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1325,6 +1325,9 @@ class Commande extends CommonOrder
 			$line->marge_tx			= $marginInfos[1];
 			$line->marque_tx		= $marginInfos[2];
 
+			$line->origin           = $object->element;
+			$line->origin_id        = $object->lines[$i]->id;
+
 			// get extrafields from original line
 			$object->lines[$i]->fetch_optionals();
 			foreach ($object->lines[$i]->array_options as $options_key => $value) {


### PR DESCRIPTION
When creating an order from a proposal using `\Commande::createFromProposal` the original line information were lost, rendering any trigger on `LINEORDER_INSERT` useless.

This PR add the original line information to the order line which in conjunction with `MAIN_CREATEFROM_KEEP_LINE_ORIGIN_INFORMATION` allows to receive original line information in a `LINEORDER_INSERT` trigger.