### PR TITLE
Prevent PHP Warning in error log file, when the generated doc file does not exists. 

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5671,7 +5671,7 @@ abstract class CommonObject
 					$update_main_doc_field = 1;
 				}
 
-				// Check that the file exists, before indexing it. 
+				// Check that the file exists, before indexing it.
 				// Hint: It does not exist, if we create a PDF and auto delete the ODT File
 				if (file_exists($destfull)) {
 					$this->indexFile($destfull, $update_main_doc_field);

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5671,7 +5671,11 @@ abstract class CommonObject
 					$update_main_doc_field = 1;
 				}
 
-				$this->indexFile($destfull, $update_main_doc_field);
+				// Check that the file exists, before indexing it. 
+				// Hint: It does not exist, if we create a PDF and auto delete the ODT File
+				if (file_exists($destfull)) {
+					$this->indexFile($destfull, $update_main_doc_field);
+				}
 			} else {
 				dol_syslog('Method ->write_file was called on object '.get_class($obj).' and return a success but the return array ->result["fullpath"] was not set.', LOG_WARNING);
 			}

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5673,7 +5673,7 @@ abstract class CommonObject
 
 				// Check that the file exists, before indexing it.
 				// Hint: It does not exist, if we create a PDF and auto delete the ODT File
-				if (file_exists($destfull)) {
+				if (dol_is_file($destfull)) {
 					$this->indexFile($destfull, $update_main_doc_field);
 				}
 			} else {


### PR DESCRIPTION
This is the case when we create a PDF file out of a ODT file and automatically delete the ODT.
The indexed file will then be the ODT, which can't be found on drive (because it has been deleted when converting to PDF) and therefore creates an error log entry.