### PR TITLE
FIX : reopen supplier order after line delete if needed

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -860,7 +860,6 @@ if (empty($reshook)) {
 			// reopen order if necessary
 			if ($object->status == CommandeFournisseur::STATUS_RECEIVED_COMPLETELY) {
 				if ($object->setStatus($user, CommandeFournisseur::STATUS_RECEIVED_PARTIALLY) < 0) {
-					$db->rollback();
 					setEventMessages($object->error, $object->errors, 'errors');
 					$error++;
 					$action = '';

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -857,8 +857,19 @@ if (empty($reshook)) {
 		}
 
 		if (!$error) {
-			$db->commit();
+			// reopen order if necessary
+			if ($object->status == CommandeFournisseur::STATUS_RECEIVED_COMPLETELY) {
+				if ($object->setStatus($user, CommandeFournisseur::STATUS_RECEIVED_PARTIALLY) < 0) {
+					$db->rollback();
+					setEventMessages($object->error, $object->errors, 'errors');
+					$error++;
+					$action = '';
+				}
+			}
+		}
 
+		if (!$error) {
+			$db->commit();
 			header('Location: '.$_SERVER["PHP_SELF"].'?id='.$object->id);
 			exit;
 		} else {


### PR DESCRIPTION
if the supplier order has status "All products received" but you delete a dispatch line, the status should be set to "Partially received".