### PR TITLE
phpunit: use $db instead of $this->savdb

### DIFF
--- a/test/phpunit/AccountingAccountTest.php
+++ b/test/phpunit/AccountingAccountTest.php
@@ -143,7 +143,7 @@ class AccountingAccountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new AccountingAccount($this->savdb);
+		$localobject=new AccountingAccount($db);
 		$localobject->fk_pcg_version = 'PCG99-ABREGE';
 		$localobject->account_category = 0;
 		$localobject->pcg_type = 'XXXXX';
@@ -177,7 +177,7 @@ class AccountingAccountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new AccountingAccount($this->savdb);
+		$localobject=new AccountingAccount($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -229,7 +229,7 @@ class AccountingAccountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new AccountingAccount($this->savdb);
+		$localobject=new AccountingAccount($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/ActionCommTest.php
+++ b/test/phpunit/ActionCommTest.php
@@ -145,7 +145,7 @@ class ActionCommTest extends PHPUnit\Framework\TestCase
 
 		$now = dol_now();
 
-		$localobject=new ActionComm($this->savdb);
+		$localobject=new ActionComm($db);
 
 		$localobject->type_code   = 'AC_OTH_AUTO';		// Type of event ('AC_OTH', 'AC_OTH_AUTO', 'AC_XXX'...)
 		$localobject->code        = 'AC_PHPUNITTEST';
@@ -196,7 +196,7 @@ class ActionCommTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new ActionComm($this->savdb);
+		$localobject=new ActionComm($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -246,7 +246,7 @@ class ActionCommTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new ActionComm($this->savdb);
+		$localobject=new ActionComm($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/AdherentTest.php
+++ b/test/phpunit/AdherentTest.php
@@ -150,7 +150,7 @@ class AdherentTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new AdherentType($this->savdb);
+		$localobject=new AdherentType($db);
 		$localobject->statut=1;
 		$localobject->label='Adherent type test';
 		$localobject->subscription=1;
@@ -181,7 +181,7 @@ class AdherentTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Adherent($this->savdb);
+		$localobject=new Adherent($db);
 		$localobject->initAsSpecimen();
 		$localobject->typeid=$fk_adherent_type;
 		$result=$localobject->create($user);
@@ -211,7 +211,7 @@ class AdherentTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Adherent($this->savdb);
+		$localobject=new Adherent($db);
 		$result=$localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -235,7 +235,7 @@ class AdherentTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$newobject = new Adherent($this->savdb);
+		$newobject = new Adherent($db);
 		$result = $newobject->fetch_login($localobject->login);
 
 		$this->assertEquals($newobject, $localobject);
@@ -291,7 +291,7 @@ class AdherentTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
-		$newobject=new Adherent($this->savdb);
+		$newobject=new Adherent($db);
 		$result=$newobject->fetch($localobject->id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -579,7 +579,7 @@ class AdherentTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobjectat=new AdherentType($this->savdb);
+		$localobjectat=new AdherentType($db);
 		$result=$localobjectat->fetch($localobject->typeid);
 		$result=$localobjectat->delete();
 		print __METHOD__." result=".$result."\n";

--- a/test/phpunit/BOMTest.php
+++ b/test/phpunit/BOMTest.php
@@ -139,7 +139,7 @@ class BOMTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new BOM($this->savdb);
+		$localobject=new BOM($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -166,7 +166,7 @@ class BOMTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new BOM($this->savdb);
+		$localobject=new BOM($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/BankAccountTest.php
+++ b/test/phpunit/BankAccountTest.php
@@ -141,7 +141,7 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Account($this->savdb);
+		$localobject=new Account($db);
 		$localobject->initAsSpecimen();
 		$localobject->date_solde=dol_now();
 		$result=$localobject->create($user);
@@ -169,7 +169,7 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Account($this->savdb);
+		$localobject=new Account($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -212,7 +212,7 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 		$this->assertTrue($result);
 
 		// Test checkIbanForAccount for CI account
-		$localobject2=new Account($this->savdb);
+		$localobject2=new Account($db);
 		$localobject2->country = 'CI';
 		$localobject2->iban = 'CI77A12312341234123412341234';
 		$result = checkIbanForAccount($localobject2);
@@ -239,7 +239,7 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Account($this->savdb);
+		$localobject=new Account($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/BonPrelevementTest.php
+++ b/test/phpunit/BonPrelevementTest.php
@@ -150,7 +150,7 @@ class BonPrelevementTest extends PHPUnit\Framework\TestCase
 
 
 		// Create withdraw record and generate SEPA file
-		$localobject=new BonPrelevement($this->savdb);
+		$localobject=new BonPrelevement($db);
 		//$localobject->date_solde=dol_now();
 		$result=$localobject->Create(0, 0, 'simu');
 
@@ -180,7 +180,7 @@ class BonPrelevementTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new BonPrelevement($this->savdb);
+		$localobject=new BonPrelevement($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($id);
 

--- a/test/phpunit/BuildDocTest.php
+++ b/test/phpunit/BuildDocTest.php
@@ -192,10 +192,10 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 
 		$conf->facture->dir_output.='/temp';
 
-		$localobjectcom=new Commande($this->savdb);
+		$localobjectcom=new Commande($db);
 		$localobjectcom->initAsSpecimen();
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->createFromOrder($localobjectcom, $user);
 		$localobject->date_lim_reglement = dol_now() + 3600 * 24 *30;
 
@@ -270,7 +270,7 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 		$db=$this->savdb;
 
 		$conf->fournisseur->facture->dir_output.='/temp';
-		$localobject=new FactureFournisseur($this->savdb);
+		$localobject=new FactureFournisseur($db);
 		$localobject->initAsSpecimen();
 
 		// Canelle
@@ -297,7 +297,7 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 		$db=$this->savdb;
 
 		$conf->commande->dir_output.='/temp';
-		$localobject=new Commande($this->savdb);
+		$localobject=new Commande($db);
 		$localobject->initAsSpecimen();
 
 		// Einstein
@@ -325,7 +325,7 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 		$db=$this->savdb;
 
 		$conf->fournisseur->commande->dir_output.='/temp';
-		$localobject=new CommandeFournisseur($this->savdb);
+		$localobject=new CommandeFournisseur($db);
 		$localobject->initAsSpecimen();
 
 		// Muscadet
@@ -352,7 +352,7 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 		$db=$this->savdb;
 
 		$conf->propal->dir_output.='/temp';
-		$localobject=new Propal($this->savdb);
+		$localobject=new Propal($db);
 		$localobject->initAsSpecimen();
 
 		// Azur
@@ -378,7 +378,7 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 		$conf->project->dir_output.='/temp';
-		$localobject=new Project($this->savdb);
+		$localobject=new Project($db);
 		$localobject->initAsSpecimen();
 
 		// Baleine
@@ -405,7 +405,7 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 		$db=$this->savdb;
 
 		$conf->ficheinter->dir_output.='/temp';
-		$localobject=new Fichinter($this->savdb);
+		$localobject=new Fichinter($db);
 		$localobject->initAsSpecimen();
 
 		// Soleil
@@ -432,7 +432,7 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 		$db=$this->savdb;
 
 		$conf->expedition->dir_output.='/temp';
-		$localobject=new Expedition($this->savdb);
+		$localobject=new Expedition($db);
 		$localobject->initAsSpecimen();
 
 		// Merou

--- a/test/phpunit/CategorieTest.php
+++ b/test/phpunit/CategorieTest.php
@@ -140,7 +140,7 @@ class CategorieTest extends PHPUnit\Framework\TestCase
 
 
 		// We create a category
-		$localobject=new Categorie($this->savdb);
+		$localobject=new Categorie($db);
 		$localobject->initAsSpecimen();
 
 		// Check it does not exist (return 0)
@@ -154,7 +154,7 @@ class CategorieTest extends PHPUnit\Framework\TestCase
 		$this->assertGreaterThan(0, $resultFirstCreate);
 
 		// We try to create another one with same ref
-		$localobject2=new Categorie($this->savdb);
+		$localobject2=new Categorie($db);
 		$localobject2->initAsSpecimen();
 
 		// Check it does exist (return 1)
@@ -186,7 +186,7 @@ class CategorieTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobjecttmp=new Categorie($this->savdb);
+		$localobjecttmp=new Categorie($db);
 		$localobjecttmp->initAsSpecimen();
 		$localobjecttmp->label='Specimen Category for product';
 		$localobjecttmp->type=0;    // product category
@@ -196,12 +196,12 @@ class CategorieTest extends PHPUnit\Framework\TestCase
 		$this->assertGreaterThan(0, $catid);
 
 		// Try to create product linked to category
-		$localobject2=new Product($this->savdb);
+		$localobject2=new Product($db);
 		$localobject2->initAsSpecimen();
 		$localobject2->ref.='-CATEG';
 		$localobject2->tva_npr=1;
 		$result=$localobject2->create($user);
-		$cat = new Categorie($this->savdb);
+		$cat = new Categorie($db);
 		$cat->id = $catid;
 		$cat->type = 0;
 		$result=$cat->add_type($localobject2, "product");
@@ -210,7 +210,7 @@ class CategorieTest extends PHPUnit\Framework\TestCase
 		$this->assertGreaterThan(0, $result);
 
 		// Get list of categories for product
-		$localcateg=new Categorie($this->savdb);
+		$localcateg=new Categorie($db);
 		$listofcateg=$localcateg->containing($localobject2->id, Categorie::TYPE_PRODUCT, 'label');
 		$this->assertTrue(in_array('Specimen Category for product', $listofcateg), 'Categ not found linked to product when it should');
 
@@ -234,7 +234,7 @@ class CategorieTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Categorie($this->savdb);
+		$localobject=new Categorie($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -314,7 +314,7 @@ class CategorieTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Categorie($this->savdb);
+		$localobject=new Categorie($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 
@@ -338,7 +338,7 @@ class CategorieTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Categorie($this->savdb);
+		$localobject=new Categorie($db);
 		$retarray=$localobject->get_full_arbo(3);
 
 		print __METHOD__." retarray size=".count($retarray)."\n";

--- a/test/phpunit/ChargeSocialesTest.php
+++ b/test/phpunit/ChargeSocialesTest.php
@@ -137,7 +137,7 @@ class ChargeSocialesTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new ChargeSociales($this->savdb);
+		$localobject=new ChargeSociales($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user, $langs, $conf);
 		print __METHOD__." result=".$result."\n";
@@ -163,7 +163,7 @@ class ChargeSocialesTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new ChargeSociales($this->savdb);
+		$localobject=new ChargeSociales($db);
 		$result=$localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 
@@ -240,7 +240,7 @@ class ChargeSocialesTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new ChargeSociales($this->savdb);
+		$localobject=new ChargeSociales($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($id);
 

--- a/test/phpunit/CommandeFournisseurTest.php
+++ b/test/phpunit/CommandeFournisseurTest.php
@@ -261,7 +261,7 @@ class CommandeFournisseurTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new CommandeFournisseur($this->savdb);
+		$localobject=new CommandeFournisseur($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -389,7 +389,7 @@ class CommandeFournisseurTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new CommandeFournisseur($this->savdb);
+		$localobject=new CommandeFournisseur($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/CommandeTest.php
+++ b/test/phpunit/CommandeTest.php
@@ -143,7 +143,7 @@ class CommandeTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Commande($this->savdb);
+		$localobject=new Commande($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -169,7 +169,7 @@ class CommandeTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Commande($this->savdb);
+		$localobject=new Commande($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -296,7 +296,7 @@ class CommandeTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Commande($this->savdb);
+		$localobject=new Commande($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/CommonInvoiceTest.php
+++ b/test/phpunit/CommonInvoiceTest.php
@@ -138,7 +138,7 @@ class CommonInvoiceTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->fetch(1);
 		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 2010);
 

--- a/test/phpunit/CommonObjectTest.php
+++ b/test/phpunit/CommonObjectTest.php
@@ -139,7 +139,7 @@ class CommonObjectTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Commande($this->savdb);
+		$localobject=new Commande($db);
 		$localobject->fetch(1);
 
 		$result=$localobject->fetch_user(1);
@@ -162,7 +162,7 @@ class CommonObjectTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Commande($this->savdb);
+		$localobject=new Commande($db);
 		$localobject->fetch(1);
 		$result=$localobject->fetch_projet();
 
@@ -184,7 +184,7 @@ class CommonObjectTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Commande($this->savdb);
+		$localobject=new Commande($db);
 		$localobject->fetch(1);
 
 		$result=$localobject->fetch_thirdparty();

--- a/test/phpunit/CompanyBankAccountTest.php
+++ b/test/phpunit/CompanyBankAccountTest.php
@@ -138,7 +138,7 @@ class CompanyBankAccountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new CompanyBankAccount($this->savdb);
+		$localobject=new CompanyBankAccount($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -164,7 +164,7 @@ class CompanyBankAccountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new CompanyBankAccount($this->savdb);
+		$localobject=new CompanyBankAccount($db);
 		$result=$localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/ContactTest.php
+++ b/test/phpunit/ContactTest.php
@@ -145,7 +145,7 @@ class ContactTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Contact($this->savdb);
+		$localobject=new Contact($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -171,7 +171,7 @@ class ContactTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Contact($this->savdb);
+		$localobject=new Contact($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -228,7 +228,7 @@ class ContactTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Contact::update_note (public) error');
 
-		$newobject=new Contact($this->savdb);
+		$newobject=new Contact($db);
 		$result=$newobject->fetch($localobject->id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Contact::fetch error');
@@ -322,7 +322,7 @@ class ContactTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Contact($this->savdb);
+		$localobject=new Contact($db);
 		$result=$localobject->fetch($id);
 
 		$result=$localobject->delete(0);

--- a/test/phpunit/ContratTest.php
+++ b/test/phpunit/ContratTest.php
@@ -137,7 +137,7 @@ class ContratTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Contrat($this->savdb);
+		$localobject=new Contrat($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -164,7 +164,7 @@ class ContratTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Contrat($this->savdb);
+		$localobject=new Contrat($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -219,7 +219,7 @@ class ContratTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Contrat($this->savdb);
+		$localobject=new Contrat($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/DiscountTest.php
+++ b/test/phpunit/DiscountTest.php
@@ -138,7 +138,7 @@ class DiscountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new DiscountAbsolute($this->savdb);
+		$localobject=new DiscountAbsolute($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -164,7 +164,7 @@ class DiscountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new DiscountAbsolute($this->savdb);
+		$localobject=new DiscountAbsolute($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -189,7 +189,7 @@ class DiscountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new DiscountAbsolute($this->savdb);
+		$localobject=new DiscountAbsolute($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/EmailCollectorTest.php
+++ b/test/phpunit/EmailCollectorTest.php
@@ -175,7 +175,7 @@ class EmailCollectorTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new EmailCollector($this->savdb);
+		$localobject=new EmailCollector($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -224,7 +224,7 @@ class EmailCollectorTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new EmailCollector($this->savdb);
+		$localobject=new EmailCollector($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/EntrepotTest.php
+++ b/test/phpunit/EntrepotTest.php
@@ -143,7 +143,7 @@ class EntrepotTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Entrepot($this->savdb);
+		$localobject=new Entrepot($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -170,7 +170,7 @@ class EntrepotTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Entrepot($this->savdb);
+		$localobject=new Entrepot($db);
 		$result=$localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -243,7 +243,7 @@ class EntrepotTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Entrepot($this->savdb);
+		$localobject=new Entrepot($db);
 		$result=$localobject->fetch($id);
 
 		$result=$localobject->delete($user);

--- a/test/phpunit/ExpenseReportTest.php
+++ b/test/phpunit/ExpenseReportTest.php
@@ -184,7 +184,7 @@ class ExpenseReportTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new ExpenseReport($this->savdb);
+		$localobject=new ExpenseReport($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -305,7 +305,7 @@ class ExpenseReportTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new ExpenseReport($this->savdb);
+		$localobject=new ExpenseReport($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/FactureFournisseurTest.php
+++ b/test/phpunit/FactureFournisseurTest.php
@@ -138,7 +138,7 @@ class FactureFournisseurTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new FactureFournisseur($this->savdb);
+		$localobject=new FactureFournisseur($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -164,7 +164,7 @@ class FactureFournisseurTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new FactureFournisseur($this->savdb);
+		$localobject=new FactureFournisseur($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
@@ -267,7 +267,7 @@ class FactureFournisseurTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new FactureFournisseur($this->savdb);
+		$localobject=new FactureFournisseur($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/FactureRecTest.php
+++ b/test/phpunit/FactureRecTest.php
@@ -140,13 +140,13 @@ class FactureRecTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobjectinv=new Facture($this->savdb);
+		$localobjectinv=new Facture($db);
 		$localobjectinv->initAsSpecimen();
 		$result = $localobjectinv->create($user);
 
 		print __METHOD__." result=".$result."\n";
 
-		$localobject=new FactureRec($this->savdb);
+		$localobject=new FactureRec($db);
 		$localobject->initAsSpecimen();
 		$result = $localobject->create($user, $localobjectinv->id);
 
@@ -173,7 +173,7 @@ class FactureRecTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new FactureRec($this->savdb);
+		$localobject=new FactureRec($db);
 		$result = $localobject->fetch($id);
 
 		print __METHOD__." result=".$result."\n";

--- a/test/phpunit/FactureTest.php
+++ b/test/phpunit/FactureTest.php
@@ -147,7 +147,7 @@ class FactureTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 		$this->assertLessThan($result, 0);
@@ -172,7 +172,7 @@ class FactureTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -228,7 +228,7 @@ class FactureTest extends PHPUnit\Framework\TestCase
 		$this->assertLessThan($result, 0);
 
 		// Test everything are still same than specimen
-		$newlocalobject=new Facture($this->savdb);
+		$newlocalobject=new Facture($db);
 		$newlocalobject->initAsSpecimen();
 		$this->changeProperties($newlocalobject);
 
@@ -308,11 +308,11 @@ class FactureTest extends PHPUnit\Framework\TestCase
 		unset($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED);
 		unset($conf->global->INVOICE_CAN_NEVER_BE_REMOVED);
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$result=$localobject->fetch($id);
 
 		// Create another invoice and validate it after $localobject
-		$localobject2=new Facture($this->savdb);
+		$localobject2=new Facture($db);
 		$result=$localobject2->initAsSpecimen();
 		$result=$localobject2->create($user);
 		$result=$localobject2->validate($user);

--- a/test/phpunit/FactureTestRounding.php
+++ b/test/phpunit/FactureTestRounding.php
@@ -143,7 +143,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 
 		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->lines=array();
 		unset($localobject->total_ht);
@@ -156,7 +156,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 			$localobject->addline('Description '.$i, 1.24, 1, 10);
 		}
 
-		$newlocalobject=new Facture($this->savdb);
+		$newlocalobject=new Facture($db);
 		$newlocalobject->fetch($result);
 		//var_dump($newlocalobject);
 
@@ -185,7 +185,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 
 		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->lines=array();
 		unset($localobject->total_ht);
@@ -198,7 +198,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 			$localobject->addline('Description '.$i, 1.24, 1, 10);
 		}
 
-		$newlocalobject=new Facture($this->savdb);
+		$newlocalobject=new Facture($db);
 		$newlocalobject->fetch($result);
 		//var_dump($newlocalobject);
 
@@ -225,7 +225,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0
 		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
 
-		$localobject1a=new Facture($this->savdb);
+		$localobject1a=new Facture($db);
 		$localobject1a->initAsSpecimen('nolines');
 		$facid=$localobject1a->create($user);
 		$localobject1a->addline('Line 1', 6.36, 15, 21);	// This include update_price
@@ -237,7 +237,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 1
 		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=1;
 
-		$localobject1b=new Facture($this->savdb);
+		$localobject1b=new Facture($db);
 		$localobject1b->initAsSpecimen('nolines');
 		$facid=$localobject1b->create($user);
 		$localobject1b->addline('Line 1', 6.36, 15, 21);	// This include update_price
@@ -266,7 +266,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0
 		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
 
-		$localobject2=new Facture($this->savdb);
+		$localobject2=new Facture($db);
 		$localobject2->initAsSpecimen('nolines');
 		$facid=$localobject2->create($user);
 		$localobject2->addline('Line 1', 6.36, 5, 21);
@@ -280,7 +280,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 1
 		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=1;
 
-		$localobject2=new Facture($this->savdb);
+		$localobject2=new Facture($db);
 		$localobject2->initAsSpecimen('nolines');
 		$facid=$localobject2->create($user);
 		$localobject2->addline('Line 1', 6.36, 5, 21);
@@ -311,7 +311,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0
 		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
 
-		$localobject3=new Facture($this->savdb);
+		$localobject3=new Facture($db);
 		$localobject3->initAsSpecimen('nolines');
 		$facid=$localobject3->create($user);
 		$localobject3->addline('Line 1', 6.36, 3, 21);
@@ -327,7 +327,7 @@ class FactureTestRounding extends PHPUnit\Framework\TestCase
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 1
 		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=1;
 
-		$localobject3=new Facture($this->savdb);
+		$localobject3=new Facture($db);
 		$localobject3->initAsSpecimen('nolines');
 		$facid=$localobject3->create($user);
 		$localobject3->addline('Line 1', 6.36, 3, 21);

--- a/test/phpunit/FichinterTest.php
+++ b/test/phpunit/FichinterTest.php
@@ -137,7 +137,7 @@ class FichinterTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Fichinter($this->savdb);
+		$localobject=new Fichinter($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -164,7 +164,7 @@ class FichinterTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Fichinter($this->savdb);
+		$localobject=new Fichinter($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -243,7 +243,7 @@ class FichinterTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Fichinter($this->savdb);
+		$localobject=new Fichinter($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/FormAdminTest.php
+++ b/test/phpunit/FormAdminTest.php
@@ -138,7 +138,7 @@ class FormAdminTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new FormAdmin($this->savdb);
+		$localobject=new FormAdmin($db);
 		$result=$localobject->select_paper_format('', 'paperformat_id', 'A4', 0, 1);
 
 		$this->assertEquals($result, '<select class="flat" id="paperformat_id" name="paperformat_id"><option value="EUA4">Format A4 - 210x297 mm</option></select>');

--- a/test/phpunit/FormTest.php
+++ b/test/phpunit/FormTest.php
@@ -138,7 +138,7 @@ class FormTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Form($this->savdb);
+		$localobject=new Form($db);
 		$result=$localobject->select_produits_list('', 'productid', '', 5, 0, '', 1, 2, 1);
 
 		$this->assertEquals(count($result), 5);

--- a/test/phpunit/FunctionsLibTest.php
+++ b/test/phpunit/FunctionsLibTest.php
@@ -205,18 +205,20 @@ class FunctionsLibTest extends PHPUnit\Framework\TestCase
 	 */
 	public function testDolClone()
 	{
-		$newproduct1 = new Product($this->savdb);
+		global $db;
 
-		print __METHOD__." this->savdb has type ".(is_resource($this->savdb->db) ? get_resource_type($this->savdb->db) : (is_object($this->savdb->db) ? 'object' : 'unknown'))."\n";
+		$newproduct1 = new Product($db);
+
+		print __METHOD__." this->savdb has type ".(is_resource($db->db) ? get_resource_type($db->db) : (is_object($db->db) ? 'object' : 'unknown'))."\n";
 		print __METHOD__." newproduct1->db->db has type ".(is_resource($newproduct1->db->db) ? get_resource_type($newproduct1->db->db) : (is_object($newproduct1->db->db) ? 'object' : 'unknown'))."\n";
-		$this->assertEquals($this->savdb->connected, 1, 'Savdb is connected');
+		$this->assertEquals($db->connected, 1, 'Savdb is connected');
 		$this->assertNotNull($newproduct1->db->db, 'newproduct1->db is not null');
 
 		$newproductcloned1 = dol_clone($newproduct1);
 
-		print __METHOD__." this->savdb has type ".(is_resource($this->savdb->db) ? get_resource_type($this->savdb->db) : (is_object($this->savdb->db) ? 'object' : 'unknown'))."\n";
+		print __METHOD__." this->savdb has type ".(is_resource($db->db) ? get_resource_type($db->db) : (is_object($db->db) ? 'object' : 'unknown'))."\n";
 		print __METHOD__." newproduct1->db->db has type ".(is_resource($newproduct1->db->db) ? get_resource_type($newproduct1->db->db) : (is_object($newproduct1->db->db) ? 'object' : 'unknown'))."\n";
-		$this->assertEquals($this->savdb->connected, 1, 'Savdb is connected');
+		$this->assertEquals($db->connected, 1, 'Savdb is connected');
 		$this->assertNotNull($newproduct1->db->db, 'newproduct1->db is not null');
 
 		$newproductcloned2 = dol_clone($newproduct1, 2);

--- a/test/phpunit/HolidayTest.php
+++ b/test/phpunit/HolidayTest.php
@@ -140,7 +140,7 @@ class HolidayTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Holiday($this->savdb);
+		$localobject=new Holiday($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -166,7 +166,7 @@ class HolidayTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Holiday($this->savdb);
+		$localobject=new Holiday($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -224,7 +224,7 @@ class HolidayTest extends PHPUnit\Framework\TestCase
 		$this->assertLessThan($result, 0, 'Holiday::update_note (public) error');
 
 
-		$newobject=new Holiday($this->savdb);
+		$newobject=new Holiday($db);
 		$result=$newobject->fetch($localobject->id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Holiday::fetch error');
@@ -286,7 +286,7 @@ class HolidayTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Holiday($this->savdb);
+		$localobject=new Holiday($db);
 		$result=$localobject->fetch($id);
 
 		$result=$localobject->delete(0);
@@ -310,7 +310,7 @@ class HolidayTest extends PHPUnit\Framework\TestCase
 		$db=$this->savdb;
 
 		// Create a leave request the 1st morning only
-		$localobjecta=new Holiday($this->savdb);
+		$localobjecta=new Holiday($db);
 		$localobjecta->initAsSpecimen();
 		$localobjecta->date_debut = dol_mktime(0, 0, 0, 1, 1, 2020);
 		$localobjecta->date_fin = dol_mktime(0, 0, 0, 1, 1, 2020);
@@ -318,7 +318,7 @@ class HolidayTest extends PHPUnit\Framework\TestCase
 		$result=$localobjecta->create($user);
 
 		// Create a leave request the 2 afternoon only
-		$localobjectb=new Holiday($this->savdb);
+		$localobjectb=new Holiday($db);
 		$localobjectb->initAsSpecimen();
 		$localobjectb->date_debut = dol_mktime(0, 0, 0, 1, 2, 2020);
 		$localobjectb->date_fin = dol_mktime(0, 0, 0, 1, 2, 2020);
@@ -328,7 +328,7 @@ class HolidayTest extends PHPUnit\Framework\TestCase
 		$date_debut = dol_mktime(0, 0, 0, 1, 1, 2020);
 		$date_fin = dol_mktime(0, 0, 0, 1, 2, 2020);
 
-		$localobjectc=new Holiday($this->savdb);
+		$localobjectc=new Holiday($db);
 
 		$result=$localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_debut, 0);
 		$this->assertFalse($result, 'result should be false, there is overlapping, full day is not available.');
@@ -362,7 +362,9 @@ class HolidayTest extends PHPUnit\Framework\TestCase
 	 */
 	public function testUpdateBalance()
 	{
-		$localobjecta=new Holiday($this->savdb);
+		global $db;
+
+		$localobjecta=new Holiday($db);
 
 		$localobjecta->updateConfCP('lastUpdate', '20100101120000');
 		$result = $localobjecta->updateBalance();

--- a/test/phpunit/InventoryTest.php
+++ b/test/phpunit/InventoryTest.php
@@ -165,7 +165,7 @@ class InventoryTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Inventory($this->savdb);
+		$localobject=new Inventory($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -337,7 +337,7 @@ class InventoryTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Inventory($this->savdb);
+		$localobject=new Inventory($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 		print __METHOD__." id=".$id." result=".$result."\n";

--- a/test/phpunit/KnowledgeRecordTest.php
+++ b/test/phpunit/KnowledgeRecordTest.php
@@ -144,7 +144,7 @@ class KnowledgeRecordTest extends PHPUnit\Framework\TestCase
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		$localobject = new KnowledgeRecord($this->savdb);
+		$localobject = new KnowledgeRecord($db);
 		$localobject->initAsSpecimen();
 		$result = $localobject->create($user);
 
@@ -171,7 +171,7 @@ class KnowledgeRecordTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new KnowledgeRecord($this->savdb);
+		$localobject=new KnowledgeRecord($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -221,7 +221,7 @@ class KnowledgeRecordTest extends PHPUnit\Framework\TestCase
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		$localobject = new KnowledgeRecord($this->savdb);
+		$localobject = new KnowledgeRecord($db);
 		print __METHOD__." id=".$id."\n";
 		$result = $localobject->fetch($id);
 		print __METHOD__." result=".$result."\n";

--- a/test/phpunit/LoanTest.php
+++ b/test/phpunit/LoanTest.php
@@ -138,7 +138,7 @@ class LoanTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Loan($this->savdb);
+		$localobject=new Loan($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -164,7 +164,7 @@ class LoanTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Loan($this->savdb);
+		$localobject=new Loan($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -213,7 +213,7 @@ class LoanTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Loan($this->savdb);
+		$localobject=new Loan($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/MouvementStockTest.php
+++ b/test/phpunit/MouvementStockTest.php
@@ -186,7 +186,7 @@ class MouvementStockTest extends PHPUnit\Framework\TestCase
 		$warehouse2->description.=' phpunit 2';
 		$warehouse2id=$warehouse2->create($user);
 
-		$localobject=new MouvementStock($this->savdb);
+		$localobject=new MouvementStock($db);
 
 		$datetest1 = dol_mktime(0, 0, 0, 1, 1, 2000);
 		$datetest2 = dol_mktime(0, 0, 0, 1, 2, 2000);

--- a/test/phpunit/NumberingModulesTest.php
+++ b/test/phpunit/NumberingModulesTest.php
@@ -150,7 +150,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_REPLACEMENT='{yyyy}-{0000}';
 		$conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED=0;
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -168,7 +168,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result, 'Test for is_erasable, 1st invoice');						    // Can be deleted
 
-		$localobject2=new Facture($this->savdb);
+		$localobject2=new Facture($db);
 		$localobject2->initAsSpecimen();
 		$localobject2->fetch_thirdparty();
 
@@ -196,7 +196,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}-{0000@1}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}-{0000@1}';
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -208,7 +208,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1910-0001', $result, 'Test for {yyyy}-{0000@1} 1st invoice');				// counter must start to 1
 
-		$localobject2=new Facture($this->savdb);
+		$localobject2=new Facture($db);
 		$localobject2->initAsSpecimen();
 		$localobject2->fetch_thirdparty();
 
@@ -218,7 +218,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1910-0002', $result, 'Test for {yyyy}-{0000@1} 2nd invoice, same day');	// counter must be now 2
 
-		$localobject3=new Facture($this->savdb);
+		$localobject3=new Facture($db);
 		$localobject3->initAsSpecimen();
 		$localobject3->fetch_thirdparty();
 
@@ -232,7 +232,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@1}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@1}';
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -247,7 +247,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);						// Can be deleted
 
-		$localobject2=new Facture($this->savdb);
+		$localobject2=new Facture($db);
 		$localobject2->initAsSpecimen();
 		$localobject2->fetch_thirdparty();
 
@@ -268,7 +268,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		// Same but we add month before year and use a year on 2 digits
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='[mm}{yy}-{0000@1}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{mm}{yy}-{0000@1}';
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1925);	// we use year 1925 to be sure to not have existing invoice for this year
@@ -282,7 +282,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);						// Can be deleted
 
-		$localobject2=new Facture($this->savdb);
+		$localobject2=new Facture($db);
 		$localobject2->initAsSpecimen();
 		$localobject2->fetch_thirdparty();
 		$localobject2->date=dol_mktime(12, 0, 0, 1, 1, 1925);	// we use same year 1925 for second invoice (and there is a reset required)
@@ -299,7 +299,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertLessThanOrEqual(0, $result);						// Case 1 can not be deleted (because there is an invoice 2)
 
-		$localobject3=new Facture($this->savdb);
+		$localobject3=new Facture($db);
 		$localobject3->initAsSpecimen();
 		$localobject3->fetch_thirdparty();
 		$localobject3->date=dol_mktime(12, 0, 0, 1, 1, 1926);	// we use following year for third invoice (and there is a reset required)
@@ -317,7 +317,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@6}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@6}';
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -335,7 +335,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result for last=".$result."\n";
 		$this->assertEquals('193001-0001', $result);			// last ref into reset range should be same than last created
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -350,7 +350,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('193012-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -362,7 +362,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('193101-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -378,7 +378,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@0}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@0}';
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -390,7 +390,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('194001-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -402,7 +402,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('194012-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -414,7 +414,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('194101-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -430,7 +430,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@=}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@=}';
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -442,7 +442,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('195001-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -454,7 +454,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('195012-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -466,7 +466,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('195101-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -482,7 +482,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@-}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@-}';
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -494,7 +494,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('195901-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -506,7 +506,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('196012-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -518,7 +518,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('196001-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -534,7 +534,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@+}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@+}';
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -546,7 +546,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('197001-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -558,7 +558,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('197112-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -570,7 +570,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('197101-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -585,7 +585,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@99}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@99}';
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -597,7 +597,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('198001-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -609,7 +609,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('198001-0002', $result);	// counter must start to 2
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -621,7 +621,7 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('198002-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
@@ -638,11 +638,11 @@ class NumberingModulesTest extends PHPUnit\Framework\TestCase
 		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{t}{yyyy}{mm}-{0000}';
 		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{t}{yyyy}{mm}-{0000}';
 
-		$tmpthirdparty=new Societe($this->savdb);
+		$tmpthirdparty=new Societe($db);
 		$tmpthirdparty->initAsSpecimen();
 		$tmpthirdparty->typent_code = 'TE_ABC';
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 

--- a/test/phpunit/PdfDocTest.php
+++ b/test/phpunit/PdfDocTest.php
@@ -140,7 +140,7 @@ class PdfDocTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localproduct=new Product($this->savdb);
+		$localproduct=new Product($db);
 		$result = $localproduct->fetch(0, 'PINKDRESS');
 		if ($result < 0) {
 			print "\n".__METHOD__." Failed to make the fetch of product PINKDRESS. ".$localproduct->error; die(1);
@@ -150,10 +150,10 @@ class PdfDocTest extends PHPUnit\Framework\TestCase
 			print "\n".__METHOD__." A product with ref PINKDRESS must exists into database. Create it manually before running the test"; die(1);
 		}
 
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->lines=array();
-		$localobject->lines[0]=new FactureLigne($this->savdb);
+		$localobject->lines[0]=new FactureLigne($db);
 		$localobject->lines[0]->fk_product=$product_id;
 		$localobject->lines[0]->label='Label 1';
 		$localobject->lines[0]->desc="This is a description with a é accent\n(Country of origin: France)";

--- a/test/phpunit/PricesTest.php
+++ b/test/phpunit/PricesTest.php
@@ -324,14 +324,14 @@ class PricesTest extends PHPUnit\Framework\TestCase
 		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
 
 		// Two lines of 1.24 give 2.48 HT and 2.72 TTC with standard vat rounding mode
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen('nolines');
 		$invoiceid=$localobject->create($user);
 
 		$localobject->addline('Desc', 1.24, 1, 10, 0, 0, 0, 0, '', '', 0, 0, 0, 'HT');
 		$localobject->addline('Desc', 1.24, 1, 10, 0, 0, 0, 0, '', '', 0, 0, 0, 'HT');
 
-		$newlocalobject=new Facture($this->savdb);
+		$newlocalobject=new Facture($db);
 		$newlocalobject->fetch($invoiceid);
 
 		$this->assertEquals(2.48, $newlocalobject->total_ht, "testUpdatePrice test1");
@@ -340,14 +340,14 @@ class PricesTest extends PHPUnit\Framework\TestCase
 
 
 		// Two lines of 1.24 give 2.48 HT and 2.73 TTC with global vat rounding mode
-		$localobject=new Facture($this->savdb);
+		$localobject=new Facture($db);
 		$localobject->initAsSpecimen('nolines');
 		$invoiceid=$localobject->create($user);
 
 		$localobject->addline('Desc', 1.24, 1, 10, 0, 0, 0, 0, '', '', 0, 0, 0, 'HT');
 		$localobject->addline('Desc', 1.24, 1, 10, 0, 0, 0, 0, '', '', 0, 0, 0, 'HT');
 
-		$newlocalobject=new Facture($this->savdb);
+		$newlocalobject=new Facture($db);
 		$newlocalobject->fetch($invoiceid);
 
 		$this->assertEquals(2.48, $newlocalobject->total_ht, "testUpdatePrice test4");

--- a/test/phpunit/ProductTest.php
+++ b/test/phpunit/ProductTest.php
@@ -143,7 +143,7 @@ class ProductTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Product($this->savdb);
+		$localobject=new Product($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -170,7 +170,7 @@ class ProductTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Product($this->savdb);
+		$localobject=new Product($db);
 		$result=$localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -243,7 +243,7 @@ class ProductTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Product($this->savdb);
+		$localobject=new Product($db);
 		$result=$localobject->fetch($id);
 
 		$result=$localobject->delete($user);

--- a/test/phpunit/ProjectTest.php
+++ b/test/phpunit/ProjectTest.php
@@ -139,7 +139,7 @@ class ProjectTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Project($this->savdb);
+		$localobject=new Project($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -165,7 +165,7 @@ class ProjectTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Project($this->savdb);
+		$localobject=new Project($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -238,7 +238,7 @@ class ProjectTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Project($this->savdb);
+		$localobject=new Project($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/PropalTest.php
+++ b/test/phpunit/PropalTest.php
@@ -138,7 +138,7 @@ class PropalTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Propal($this->savdb);
+		$localobject=new Propal($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -164,7 +164,7 @@ class PropalTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Propal($this->savdb);
+		$localobject=new Propal($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -292,7 +292,7 @@ class PropalTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Propal($this->savdb);
+		$localobject=new Propal($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/SocieteTest.php
+++ b/test/phpunit/SocieteTest.php
@@ -152,7 +152,7 @@ class SocieteTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Societe($this->savdb);
+		$localobject=new Societe($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -179,7 +179,7 @@ class SocieteTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Societe($this->savdb);
+		$localobject=new Societe($db);
 		$result=$localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -237,7 +237,7 @@ class SocieteTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Holiday::update_note (public) error');
 
-		$newobject=new Societe($this->savdb);
+		$newobject=new Societe($db);
 		$result=$newobject->fetch($localobject->id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -395,7 +395,7 @@ class SocieteTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Societe($this->savdb);
+		$localobject=new Societe($db);
 		$localobject->fetch($id);
 
 		$result=$localobject->getOutstandingBills();
@@ -424,7 +424,7 @@ class SocieteTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Societe($this->savdb);
+		$localobject=new Societe($db);
 		$result=$localobject->fetch($id);
 
 		$result=$localobject->delete($id, $user);

--- a/test/phpunit/SupplierProposalTest.php
+++ b/test/phpunit/SupplierProposalTest.php
@@ -150,7 +150,7 @@ class SupplierProposalTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new SupplierProposal($this->savdb);
+		$localobject=new SupplierProposal($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -176,7 +176,7 @@ class SupplierProposalTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new SupplierProposal($this->savdb);
+		$localobject=new SupplierProposal($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -286,7 +286,7 @@ class SupplierProposalTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new SupplierProposal($this->savdb);
+		$localobject=new SupplierProposal($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/TargetTest.php
+++ b/test/phpunit/TargetTest.php
@@ -141,7 +141,7 @@ class TargetTest extends PHPUnit\Framework\TestCase
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		$localobject = new Target($this->savdb);
+		$localobject = new Target($db);
 		$localobject->initAsSpecimen();
 		$result = $localobject->create($user);
 
@@ -168,7 +168,7 @@ class TargetTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Target($this->savdb);
+		$localobject=new Target($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -218,7 +218,7 @@ class TargetTest extends PHPUnit\Framework\TestCase
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		$localobject = new Target($this->savdb);
+		$localobject = new Target($db);
 		$result = $localobject->fetch($id);
 		$result = $localobject->delete($user);
 

--- a/test/phpunit/TicketTest.php
+++ b/test/phpunit/TicketTest.php
@@ -139,7 +139,7 @@ class TicketTest extends PHPUnit\Framework\TestCase
 		$db=$this->savdb;
 
 		// Try to create one with bad values
-		$localobject=new Ticket($this->savdb);
+		$localobject=new Ticket($db);
 		$localobject->initAsSpecimen();
 		$localobject->ref = '';
 		$result=$localobject->create($user);
@@ -148,7 +148,7 @@ class TicketTest extends PHPUnit\Framework\TestCase
 		$this->assertEquals(-3, $result, $localobject->error.join(',', $localobject->errors));
 
 		// Try to create one with correct values
-		$localobject=new Ticket($this->savdb);
+		$localobject=new Ticket($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -175,7 +175,7 @@ class TicketTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Ticket($this->savdb);
+		$localobject=new Ticket($db);
 		$result=$localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -382,7 +382,7 @@ class TicketTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Ticket($this->savdb);
+		$localobject=new Ticket($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/UserGroupTest.php
+++ b/test/phpunit/UserGroupTest.php
@@ -138,7 +138,7 @@ class UserGroupTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new UserGroup($this->savdb);
+		$localobject=new UserGroup($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -163,7 +163,7 @@ class UserGroupTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new UserGroup($this->savdb);
+		$localobject=new UserGroup($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -280,7 +280,7 @@ class UserGroupTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new UserGroup($this->savdb);
+		$localobject=new UserGroup($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 

--- a/test/phpunit/UserTest.php
+++ b/test/phpunit/UserTest.php
@@ -145,7 +145,7 @@ class UserTest extends PHPUnit\Framework\TestCase
 
 		print __METHOD__." USER_PASSWORD_GENERATED=".getDolGlobalString('USER_PASSWORD_GENERATED')."\n";
 
-		$localobject=new User($this->savdb);
+		$localobject=new User($db);
 		$localobject->initAsSpecimen();
 		$result=$localobject->create($user);
 
@@ -170,7 +170,7 @@ class UserTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new User($this->savdb);
+		$localobject=new User($db);
 		$result=$localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
@@ -201,7 +201,7 @@ class UserTest extends PHPUnit\Framework\TestCase
 		$this->assertLessThan($result, 0);
 
 		// Test everything are still same than specimen
-		$newlocalobject=new User($this->savdb);
+		$newlocalobject=new User($db);
 		$newlocalobject->initAsSpecimen();
 		$this->changeProperties($newlocalobject);
 		$this->assertEquals($this->objCompare($localobject, $newlocalobject, true, array('id','socid','societe_id','specimen','note','ref','pass','pass_indatabase','pass_indatabase_crypted','pass_temp','datec','datem','datelastlogin','datepreviouslogin','flagdelsessionsbefore','iplastlogin','ippreviouslogin','trackid')), array());    // Actual, Expected
@@ -418,7 +418,7 @@ class UserTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new User($this->savdb);
+		$localobject=new User($db);
 		$result=$localobject->fetch($id);
 		$result=$localobject->delete($user);
 
@@ -443,7 +443,7 @@ class UserTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new User($this->savdb);
+		$localobject=new User($db);
 		$result=$localobject->fetch(1);			// Other tests use the user id 1
 		$result=$localobject->addrights(0, 'supplier_proposal');
 

--- a/test/phpunit/UtilsTest.php
+++ b/test/phpunit/UtilsTest.php
@@ -139,14 +139,14 @@ class UtilsTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		$localobject=new Utils($this->savdb);
+		$localobject=new Utils($db);
 		$result = $localobject->executeCLI('ls', $conf->admin->dir_temp.'/out.tmp', 1);
 		print var_export($result, true);
 		$this->assertEquals($result['result'], 0);
 		$this->assertEquals($result['error'], '');
 		//$this->assertEquals(preg_match('/phpunit/', $result['output']), 1);
 
-		$localobject=new Utils($this->savdb);
+		$localobject=new Utils($db);
 		$result = $localobject->executeCLI('ls', $conf->admin->dir_temp.'/out.tmp', 2);
 		print var_export($result, true);
 		$this->assertEquals($result['result'], 0);


### PR DESCRIPTION
This MR is neither a fix nor a feature since there should mostly be no functional changes.

The global variables are stored in `$this`, and in particular `$db` is used through this mean. But `$this->savdb` is supposed to be the immutable global state that is stored at the test class instantiation and restored at the beginning of each test.

For `$this->savdb`, I don't think any consequences are created by this (as opposed to, for instance, `$conf`), since the `$db` object is mostly a query object within a transaction, but future change could use this to inject a different stateful `$db` object to trace some behaviour in the test for instance, so make sure the correct one is used.

I've made a single commit for those since there is nothing special from one file to another.

The change is part of a large set of changes to simplify, unify the testsuite code and be able to run the whole testsuite locally without database configured nor `config.php`. Not everything is going green for now, thus why I send some partial changes first, and I'll probably be testing other changes against the CI to understand why.
