### PR TITLE
ContactTest: assertStringContainsString instead of assertContains

### DIFF
--- a/test/phpunit/ContactTest.php
+++ b/test/phpunit/ContactTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -296,7 +297,7 @@ class ContactTest extends PHPUnit\Framework\TestCase
 
 		$result=$localobject->getFullAddress(1);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
-		$this->assertContains("New address\nNew zip New town\nBelgium", $result);
+		$this->assertStringContainsString("New address\nNew zip New town\nBelgium", $result);
 
 		$localobject->info($localobject->id);
 		print __METHOD__." localobject->date_creation=".$localobject->date_creation."\n";
@@ -357,7 +358,7 @@ class ContactTest extends PHPUnit\Framework\TestCase
 		$localobjectadd->town='New town';
 		$result=$localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
-		$this->assertContains("New address\nNew zip New town\nFrance", $result);
+		$this->assertStringContainsString("New address\nNew zip New town\nFrance", $result);
 
 		// Belgium
 		unset($localobjectadd->country_code);
@@ -368,7 +369,7 @@ class ContactTest extends PHPUnit\Framework\TestCase
 		$localobjectadd->town='New town';
 		$result=$localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
-		$this->assertContains("New address\nNew zip New town\nBelgium", $result);
+		$this->assertStringContainsString("New address\nNew zip New town\nBelgium", $result);
 
 		// Switzerland
 		unset($localobjectadd->country_code);
@@ -379,7 +380,7 @@ class ContactTest extends PHPUnit\Framework\TestCase
 		$localobjectadd->town='New town';
 		$result=$localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
-		$this->assertContains("New address\nNew zip New town\nSwitzerland", $result);
+		$this->assertStringContainsString("New address\nNew zip New town\nSwitzerland", $result);
 
 		// USA
 		unset($localobjectadd->country_code);
@@ -390,7 +391,7 @@ class ContactTest extends PHPUnit\Framework\TestCase
 		$localobjectadd->town='New town';
 		$result=$localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
-		$this->assertContains("New address\nNew town, New zip\nUnited States", $result);
+		$this->assertStringContainsString("New address\nNew town, New zip\nUnited States", $result);
 
 		return $localobjectadd->id;
 	}


### PR DESCRIPTION
PHPUnit >= 9 adds assertStringContainsString, which ought to replace assertContains, and PHPUnit >= 9 removed[^1] support for calling assertContains on strings.

**This moves phpunit dev dependency requirement to phpunit >= 9**.

[^1]: https://github.com/sebastianbergmann/phpunit/issues/3426