### PR TITLE
Fix conf.class.php: add missing syslog property

### DIFF
--- a/test/phpunit/FilesLibTest.php
+++ b/test/phpunit/FilesLibTest.php
@@ -418,7 +418,6 @@ class FilesLibTest extends PHPUnit\Framework\TestCase
 
 		dol_mkdir($conf->admin->dir_temp);
 		$conf->global->MAIN_ENABLE_LOG_TO_HTML=1;
-		$conf->syslog->enabled=1;
 		$conf->modules['syslog'] = 'syslog';
 		$_REQUEST['logtohtml']=1;
 		$conf->logbuffer=array();
@@ -450,7 +449,6 @@ class FilesLibTest extends PHPUnit\Framework\TestCase
 
 		dol_mkdir($conf->admin->dir_temp);
 		$conf->global->MAIN_ENABLE_LOG_TO_HTML=1;
-		$conf->syslog->enabled=1;
 		$conf->modules['syslog'] = 'syslog';
 		$_REQUEST['logtohtml']=1;
 		$conf->logbuffer=array();


### PR DESCRIPTION
# Fix conf.class.php: fix dynamic property warning

Fix a deprecated dynamic property warning:

    Deprecated: Creation of dynamic property Conf::$syslog is
    deprecated in dolibarr/htdocs/install/inc.php on line 441
