### PR TITLE
FIX: expense report autofill ttc input if force ttc conf is enabled

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -2643,10 +2643,22 @@ if ($action == 'create') {
 							,async:false
 							,dataType:"json"
 							,success:function(response) {
-                                if (response.response_status == "success"){
-                                jQuery("#value_unit_ht").val(response.data);
-                                jQuery("#value_unit_ht").trigger("change");
-                                jQuery("#value_unit").val("");
+								if (response.response_status == "success"){';
+
+				if (!empty($conf->global->EXPENSEREPORT_FORCE_LINE_AMOUNTS_INCLUDING_TAXES_ONLY)) {
+					print '
+									jQuery("#value_unit").val(parseFloat(response.data) * (100 + parseFloat(tva)) / 100);
+									jQuery("#value_unit").trigger("change");
+				                    ';
+				} else {
+					print '
+									jQuery("#value_unit_ht").val(response.data);
+									jQuery("#value_unit_ht").trigger("change");
+									jQuery("#value_unit").val("");
+									';
+				}
+
+				print '
                                 } else if(response.response_status == "error" && response.errorMessage != undefined && response.errorMessage.length > 0 ){
                                     $.jnotify(response.errorMessage, "error", {timeout: 0, type: "error"},{ remove: function (){} } );
                                 }


### PR DESCRIPTION
When the EXPENSEREPORT_FORCE_LINE_AMOUNTS_INCLUDING_TAXES_ONLY option is activated, ttc unit_price should be filled in automatically instead of ht unit_price.
Indeed, if this option is activated, ttc unit_price is a mandatory field and currently the user must calculate it himself. 

![image](https://user-images.githubusercontent.com/58433943/235097887-d00c652e-8326-4367-8c9f-363829813a09.png)
