### PR TITLE
FIX: Multicurrency REST API wrong number of parameters on addRate()

### DIFF
--- a/htdocs/multicurrency/class/api_multicurrencies.class.php
+++ b/htdocs/multicurrency/class/api_multicurrencies.class.php
@@ -218,7 +218,7 @@ class MultiCurrencies extends DolibarrApi
 
 		// Add default rate if defined
 		if (isset($request_data['rate']) && $request_data['rate'] > 0) {
-			if ($multicurrency->addRate(DolibarrApiAccess::$user, $request_data['rate']) < 0) {
+			if ($multicurrency->addRate($request_data['rate']) < 0) {
 				throw new RestException(500, "Error adding currency rate", array_merge(array($multicurrency->error), $multicurrency->errors));
 			}
 


### PR DESCRIPTION
# FIX: Multicurrency REST API wrong number of parameters on addRate()
The Qodana platform reported an error on the number of parameters provided when calling this method, in fact I had forgotten an extra parameter during my previous contribution.
