### PR TITLE
FIX #24653 modulebuilder: replace /myobject/ in includes

### DIFF
--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2004-2019 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2018-2019	   Nicolas ZABOURI	<info@inovea-conseil.com>
+ * Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1334,6 +1335,11 @@ if ($dirins && $action == 'initobject' && $module && $objectname) {
 						setEventMessages($langs->trans("FileAlreadyExists", $destfile), null, 'warnings');
 					}
 				}
+				$arrayreplacement = array(
+					'/myobject\.class\.php/' => strtolower($objectname).'.class.php',
+					'/myobject\.lib\.php/' => strtolower($objectname).'.lib.php',
+				);
+				dolReplaceInFile($destdir.'/'.$destfile, $arrayreplacement, '', 0, 0, 1);
 			}
 		}
 


### PR DESCRIPTION
# FIX #24653

The templates view, like myobject_card.php are including the following files:

    dol_include_once('/mymodule/class/myobject.class.php');
    dol_include_once('/mymodule/lib/mymodule_myobject.lib.php');

The mymodule value was replaced correctly, but the myobject value wasn't, leading to another classfile beind included when, for instance, creating new `myobject` objects (whatever myobject actually was, except myobject of course), and resulting in PHP errors like:

     Fatal error: Uncaught Error: Class "DemoObject" not found in
     /var/www/html/custom/demobug/demoobject_card.php:105 Stack trace:
     #0 {main} thrown in
     /var/www/html/custom/demobug/demoobject_card.php on line 105

Fixes #24653