### PR TITLE
FIX phpunit: fix tests erroring out on phpunit 10.0.7

### DIFF
--- a/test/phpunit/EvalMathTest.php
+++ b/test/phpunit/EvalMathTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur   <eldy@users.sourceforge.net>
  * Copyright (C) 2022 Quatadah Nasdami <quatadah.nasdami@gmail.com>
+ * Copyright (C) 2023 Alexandre Janniaux    <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,7 +44,7 @@ $conf->global->MAIN_DISABLE_ALL_MAILS=1;
  * @backupStaticAttributes enabled
  * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
  */
-class InventoryTest extends PHPUnit\Framework\TestCase
+class EvalMathTest extends PHPUnit\Framework\TestCase
 {
 	protected $savconf;
 	protected $savuser;

--- a/test/phpunit/ODFTest.php
+++ b/test/phpunit/ODFTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2007-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 - Thomas Negre - contact@open-dsi.fr
+ * Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -79,7 +80,7 @@ class ODFTest extends PHPUnit\Framework\TestCase
 	 *
 	 * @return void
 	 */
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
 		global $conf,$user,$langs,$db;
 		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
@@ -92,7 +93,7 @@ class ODFTest extends PHPUnit\Framework\TestCase
 	 *
 	 * @return	void
 	 */
-	public static function tearDownAfterClass()
+	public static function tearDownAfterClass(): void
 	{
 		global $conf,$user,$langs,$db;
 		$db->rollback();
@@ -105,7 +106,7 @@ class ODFTest extends PHPUnit\Framework\TestCase
 	 *
 	 * @return  void
 	 */
-	protected function setUp()
+	protected function setUp(): void
 	{
 		global $conf,$user,$langs,$db;
 		$conf=$this->savconf;
@@ -121,7 +122,7 @@ class ODFTest extends PHPUnit\Framework\TestCase
 	 *
 	 * @return  void
 	 */
-	protected function tearDown()
+	protected function tearDown(): void
 	{
 		print __METHOD__."\n";
 	}


### PR DESCRIPTION
# FIX phpunit: fix tests erroring out on phpunit 10.0.7

Fix ODFTest erroring out because of missing type annotation (like in 6c17c2f04468c3d7e60bcf2fc0da70a22dcf6c7c) and fix EvalMathTest classname being `InventoryTest`
