### PR TITLE
FIX| Problem when we clone a "Debit" miscellaneous payment

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5208,7 +5208,7 @@ class Form
 							$more .= $input['label'] . '</div><div class="tagtd left">';
 						}
 						if ($input['type'] == 'select') {
-							$more .= $this->selectarray($input['name'], $input['values'], !empty($input['default']) ? $input['default'] : '-1', $show_empty, $key_in_label, $value_as_key, $moreattr, $translate, $maxlen, $disabled, $sort, $morecss);
+							$more .= $this->selectarray($input['name'], $input['values'], isset($input['default']) ? $input['default'] : '-1', $show_empty, $key_in_label, $value_as_key, $moreattr, $translate, $maxlen, $disabled, $sort, $morecss);
 						} else {
 							$more .= $this->multiselectarray($input['name'], $input['values'], is_array($input['default']) ? $input['default'] : [$input['default']], $key_in_label, $value_as_key, $morecss, $translate, $maxlen, $moreattr);
 						}


### PR DESCRIPTION
# FIX| Problem when we clone a "Debit" miscellaneous payment
When we clone a "Debit" miscellaneous payment, the Direction of the payment remains empty because it's equal 0 :

https://www.dolibarr.fr/forum/t/clone-dun-paiement-divers/43156

![image](https://user-images.githubusercontent.com/81772051/235866787-ac416a2f-6365-4987-9687-2f2841f6c52f.png)

