### PR TITLE
CLOSE #24658 Allow custom rowid when adding timespent

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9176,7 +9176,6 @@ abstract class CommonObject
 		if (array_key_exists('fk_user_creat', $fieldvalues) && !($fieldvalues['fk_user_creat'] > 0)) {
 			$fieldvalues['fk_user_creat'] = $user->id;
 		}
-		unset($fieldvalues['rowid']); // The field 'rowid' is reserved field name for autoincrement field so we don't need it into insert.
 		if (array_key_exists('ref', $fieldvalues)) {
 			$fieldvalues['ref'] = dol_string_nospecial($fieldvalues['ref']); // If field is a ref, we sanitize data
 		}

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -515,13 +515,14 @@ class Tasks extends DolibarrApi
 	 * @param   int         $duration           Duration in seconds (3600 = 1h)
 	 * @param   int         $user_id            User (Use 0 for connected user)
 	 * @param   string      $note               Note
+	 * @param   int         $timespent_id       Timespent ID, to bypass AUTO_INCREMENT
 	 *
 	 * @url POST    {id}/addtimespent
 	 *      NOTE: Should be "POST {id}/timespent", since POST already implies "add"
 	 *
 	 * @return  array
 	 */
-	public function addTimeSpent($id, $date, $duration, $user_id = 0, $note = '')
+	public function addTimeSpent($id, $date, $duration, $user_id = 0, $note = '', $timespent_id = null)
 	{
 		if (!DolibarrApiAccess::$user->rights->projet->creer) {
 			throw new RestException(401);
@@ -547,6 +548,7 @@ class Tasks extends DolibarrApi
 		$this->task->timespent_duration = $duration;
 		$this->task->timespent_fk_user  = $uid;
 		$this->task->timespent_note     = $note;
+		$this->task->timespent_id       = $timespent_id;
 
 		$result = $this->task->addTimeSpent(DolibarrApiAccess::$user, 0);
 		if ($result == 0) {

--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1270,6 +1270,7 @@ class Task extends CommonObjectLine
 		$this->db->begin();
 
 		$timespent = new TimeSpent($this->db);
+		if (!empty($this->timespent_id)) $timespent->rowid = $this->timespent_id;
 		$timespent->fk_element = $this->id;
 		$timespent->elementtype = 'task';
 		$timespent->element_date = $this->timespent_date;


### PR DESCRIPTION
CLOSE #24658 Allow custom rowid when adding timespent
Allows developers to override rowid AUTO_INCREMENT value when creating any business object, though the immediate use case is for timespent records belonging to Task objects, where this option is exposed via the REST API.