### PR TITLE
NEW test/phpunit: skip tests instead of die() when requirements are not met

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -479,7 +479,7 @@ script:
   echo "Unit testing"
   # Ensure we catch errors. Set this to +e instead of -e if you want to go to the end to see dolibarr.log file.
   set -e
-  phpunit -d memory_limit=-1 -c test/phpunit/phpunittest.xml test/phpunit/AllTests.php
+  phpunit -d memory_limit=-1 --fail-on-skipped -c test/phpunit/phpunittest.xml test/phpunit/AllTests.php
   phpunitresult=$?
   echo "Phpunit return code = $phpunitresult"
   set +e

--- a/test/phpunit/ActionCommTest.php
+++ b/test/phpunit/ActionCommTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2018 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -83,10 +84,6 @@ class ActionCommTest extends PHPUnit\Framework\TestCase
 		global $conf,$user,$langs,$db;
 		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
 
-		if (!isModEnabled('agenda')) {
-			print __METHOD__." module agenda must be enabled.\n"; die(1);
-		}
-
 		print __METHOD__."\n";
 	}
 
@@ -115,6 +112,10 @@ class ActionCommTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!isModEnabled('agenda')) {
+			$this->markTestSkipped(__METHOD__." module agenda must be enabled.");
+		}
 
 		print __METHOD__."\n";
 		//print $db->getVersion()."\n";

--- a/test/phpunit/AdherentTest.php
+++ b/test/phpunit/AdherentTest.php
@@ -118,10 +118,10 @@ class AdherentTest extends PHPUnit\Framework\TestCase
 		if (!empty($conf->global->MAIN_FIRSTNAME_NAME_POSITION)) {
 			$this->markTestSkipped(__METHOD__." Company must be setup to have name-firstname in order 'Firstname Lastname'");
 		}
-		if (!empty($conf->global->MAIN_MODULE_LDAP)) {
+		if (isModEnabled('ldap')) {
 			$this->markTestSkipped(__METHOD__." module LDAP must be disabled.");
 		}
-		if (!empty($conf->global->MAIN_MODULE_MAILMANSPIP)) {
+		if (isModEnabled('mailmanspip')) {
 			$this->markTestSkipped(__METHOD__." module MailmanSpip must be disabled.");
 		}
 

--- a/test/phpunit/AdherentTest.php
+++ b/test/phpunit/AdherentTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010      Laurent Destailleur   <eldy@users.sourceforge.net>
  * Copyright (C) 2013      Marcos García         <marcosgdf@gmail.com>
+ * Copyright (C) 2023      Alexandre Janniaux    <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -85,17 +86,6 @@ class AdherentTest extends PHPUnit\Framework\TestCase
 		global $conf,$user,$langs,$db;
 		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
 
-		if (!empty($conf->global->MAIN_FIRSTNAME_NAME_POSITION)) {
-			print "\n".__METHOD__." Company must be setup to have name-firstname in order 'Firstname Lastname'\n";
-			die(1);
-		}
-		if (!empty($conf->global->MAIN_MODULE_LDAP)) {
-			print "\n".__METHOD__." module LDAP must be disabled.\n"; die(1);
-		}
-		if (!empty($conf->global->MAIN_MODULE_MAILMANSPIP)) {
-			print "\n".__METHOD__." module MailmanSpip must be disabled.\n"; die(1);
-		}
-
 		print __METHOD__."\n";
 	}
 
@@ -124,6 +114,16 @@ class AdherentTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!empty($conf->global->MAIN_FIRSTNAME_NAME_POSITION)) {
+			$this->markTestSkipped(__METHOD__." Company must be setup to have name-firstname in order 'Firstname Lastname'");
+		}
+		if (!empty($conf->global->MAIN_MODULE_LDAP)) {
+			$this->markTestSkipped(__METHOD__." module LDAP must be disabled.");
+		}
+		if (!empty($conf->global->MAIN_MODULE_MAILMANSPIP)) {
+			$this->markTestSkipped(__METHOD__." module MailmanSpip must be disabled.");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/BuildDocTest.php
+++ b/test/phpunit/BuildDocTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010-2012  Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2012       Regis Houssin       <regis.houssin@inodbox.com>
+ * Copyright (C) 2023       Alexandre Janniaux  <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -112,28 +113,6 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf,$user,$langs,$db;
 
-		if (!isModEnabled('facture')) {
-			print __METHOD__." invoice module not enabled\n"; die(1);
-		}
-		if (!isModEnabled('commande')) {
-			print __METHOD__." order module not enabled\n"; die(1);
-		}
-		if (!isModEnabled('propal')) {
-			print __METHOD__." propal module not enabled\n"; die(1);
-		}
-		if (!isModEnabled('projet')) {
-			print __METHOD__." project module not enabled\n"; die(1);
-		}
-		if (!isModEnabled('expedition')) {
-			print __METHOD__." shipment module not enabled\n"; die(1);
-		}
-		if (!isModEnabled('ficheinter')) {
-			print __METHOD__." intervention module not enabled\n"; die(1);
-		}
-		if (!isModEnabled('expensereport')) {
-			print __METHOD__." expensereport module not enabled\n"; die(1);
-		}
-
 		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
 
 		print __METHOD__."\n";
@@ -164,6 +143,28 @@ class BuildDocTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!isModEnabled('facture')) {
+			$this->markTestSkipped(__METHOD__." invoice module not enabled");
+		}
+		if (!isModEnabled('commande')) {
+			$this->markTestSkipped(__METHOD__." order module not enabled");
+		}
+		if (!isModEnabled('propal')) {
+			$this->markTestSkipped(__METHOD__." propal module not enabled");
+		}
+		if (!isModEnabled('projet')) {
+			$this->markTestSkipped(__METHOD__." project module not enabled");
+		}
+		if (!isModEnabled('expedition')) {
+			$this->markTestSkipped(__METHOD__." shipment module not enabled");
+		}
+		if (!isModEnabled('ficheinter')) {
+			$this->markTestSkipped(__METHOD__." intervention module not enabled");
+		}
+		if (!isModEnabled('expensereport')) {
+			$this->markTestSkipped(__METHOD__." expensereport module not enabled");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/CommandeTest.php
+++ b/test/phpunit/CommandeTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -83,10 +84,6 @@ class CommandeTest extends PHPUnit\Framework\TestCase
 		global $conf,$user,$langs,$db;
 		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
 
-		if (!isModEnabled('commande')) {
-			print __METHOD__." module customer order must be enabled.\n"; die(1);
-		}
-
 		print __METHOD__."\n";
 	}
 
@@ -115,6 +112,10 @@ class CommandeTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!isModEnabled('commande')) {
+			$this->markTestSkipped(__METHOD__." module customer order must be enabled.");
+		}
 
 		print __METHOD__."\n";
 		//print $db->getVersion()."\n";

--- a/test/phpunit/DateLibTzFranceTest.php
+++ b/test/phpunit/DateLibTzFranceTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2013 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,13 +83,6 @@ class DateLibTzFranceTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf,$user,$langs,$db;
 
-		if (getServerTimeZoneString() != 'Europe/Paris' && getServerTimeZoneString() != 'Europe/Berlin') {
-			print "\n".__METHOD__." This PHPUnit test can be launched manually only onto a server with PHP timezone set to TZ=Europe/Paris, not a TZ=".getServerTimeZoneString().".\n";
-			print "You can launch the test from command line with:\n";
-			print "php -d date.timezone='Europe/Paris' phpunit DateLibTzFranceTest.php\n";
-			die(1);
-		}
-
 		$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
 
 		print __METHOD__."\n";
@@ -119,6 +113,13 @@ class DateLibTzFranceTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (getServerTimeZoneString() != 'Europe/Paris' && getServerTimeZoneString() != 'Europe/Berlin') {
+			$this->markTestSkipped(
+				__METHOD__.": This PHPUnit test can be launched manually only onto a server with PHP timezone set to TZ=Europe/Paris, not a TZ=".getServerTimeZoneString().".\n" .
+				"You can launch the test from command line with:\n" .
+				"php -d date.timezone='Europe/Paris' phpunit DateLibTzFranceTest.php");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/EntrepotTest.php
+++ b/test/phpunit/EntrepotTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,10 +83,6 @@ class EntrepotTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf,$user,$langs,$db;
 
-		if (!isModEnabled('stock')) {
-			print __METHOD__." Module Stock must be enabled.\n"; die(1);
-		}
-
 		$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
 
 		print __METHOD__."\n";
@@ -116,6 +113,10 @@ class EntrepotTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!isModEnabled('stock')) {
+			$this->markTestSkipped(__METHOD__." Module Stock must be enabled.");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/FunctionsLibTest.php
+++ b/test/phpunit/FunctionsLibTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010-2014 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2015	   Juanjo Menent		<jmenent@2byte.es>
+ * Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -115,18 +116,6 @@ class FunctionsLibTest extends PHPUnit\Framework\TestCase
 		global $conf,$user,$langs,$db;
 		//$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
 
-		if (! function_exists('mb_substr')) {
-			print "\n".__METHOD__." function mb_substr must be enabled.\n"; die(1);
-		}
-
-		if ($conf->global->MAIN_MAX_DECIMALS_UNIT != 5) {
-			print "\n".__METHOD__." bad setup for number of digits for unit amount. Must be 5 for this test.\n"; die(1);
-		}
-
-		if ($conf->global->MAIN_MAX_DECIMALS_TOT != 2) {
-			print "\n".__METHOD__." bad setup for number of digits for unit amount. Must be 2 for this test.\n"; die(1);
-		}
-
 		print __METHOD__."\n";
 	}
 
@@ -156,6 +145,18 @@ class FunctionsLibTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 		$mysoc=$this->savmysoc;
+
+		if (! function_exists('mb_substr')) {
+			$this->markTestSkipped(__METHOD__." function mb_substr must be enabled.");
+		}
+
+		if ($conf->global->MAIN_MAX_DECIMALS_UNIT != 5) {
+			$this->markTestSkipped(__METHOD__." bad setup for number of digits for unit amount. Must be 5 for this test.");
+		}
+
+		if ($conf->global->MAIN_MAX_DECIMALS_TOT != 2) {
+			$this->markTestSkipped(__METHOD__." bad setup for number of digits for unit amount. Must be 2 for this test.");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/KnowledgeRecordTest.php
+++ b/test/phpunit/KnowledgeRecordTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2007-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2021 SuperAdmin
+ * Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -85,10 +86,6 @@ class KnowledgeRecordTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf, $user, $langs, $db;
 		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
-
-		if (!isModEnabled('knowledgemanagement')) {
-			print __METHOD__." module knowledgemanagement must be enabled.\n"; die(1);
-		}
 	}
 
 	/**
@@ -103,6 +100,10 @@ class KnowledgeRecordTest extends PHPUnit\Framework\TestCase
 		$user = $this->savuser;
 		$langs = $this->savlangs;
 		$db = $this->savdb;
+
+		if (!isModEnabled('knowledgemanagement')) {
+			$this->markTestSkipped(__METHOD__." module knowledgemanagement must be enabled.");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/MouvementStockTest.php
+++ b/test/phpunit/MouvementStockTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -115,7 +116,7 @@ class MouvementStockTest extends PHPUnit\Framework\TestCase
 		$db=$this->savdb;
 
 		if (!isModEnabled('productbatch')) {
-			print "\n".__METHOD__." module Lot/Serial must be enabled.\n"; die(1);
+			$this->markTestSkipped(__METHOD__." module Lot/Serial must be enabled.");
 		}
 
 		print __METHOD__."\n";

--- a/test/phpunit/PaypalTest.php
+++ b/test/phpunit/PaypalTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2014 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -83,10 +84,6 @@ class PaypalTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf,$user,$langs,$db;
 
-		if (!isModEnabled('paypal')) {
-			print __METHOD__." Module Paypal must be enabled.\n"; die(1);
-		}
-
 		$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
 
 		print __METHOD__."\n";
@@ -117,6 +114,10 @@ class PaypalTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!isModEnabled('paypal')) {
+			$this->markTestSkipped(__METHOD__." Module Paypal must be enabled.");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/PdfDocTest.php
+++ b/test/phpunit/PdfDocTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -142,13 +143,10 @@ class PdfDocTest extends PHPUnit\Framework\TestCase
 
 		$localproduct=new Product($db);
 		$result = $localproduct->fetch(0, 'PINKDRESS');
-		if ($result < 0) {
-			print "\n".__METHOD__." Failed to make the fetch of product PINKDRESS. ".$localproduct->error; die(1);
-		}
+		$this->assertTrue($result >= 0, __METHOD__." Failed to make the fetch of product PINKDRESS. ".$localproduct->error);
+
 		$product_id = $localproduct->id;
-		if ($product_id <= 0) {
-			print "\n".__METHOD__." A product with ref PINKDRESS must exists into database. Create it manually before running the test"; die(1);
-		}
+		$this->assertTrue($product_id > 0, __METHOD__." A product with ref PINKDRESS must exists into database. Create it manually before running the test");
 
 		$localobject=new Facture($db);
 		$localobject->initAsSpecimen();

--- a/test/phpunit/ProductTest.php
+++ b/test/phpunit/ProductTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,10 +83,6 @@ class ProductTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf,$user,$langs,$db;
 
-		if (!isModEnabled('product')) {
-			print __METHOD__." Module Product must be enabled.\n"; die(1);
-		}
-
 		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
 
 		print __METHOD__."\n";
@@ -116,6 +113,10 @@ class ProductTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!isModEnabled('product')) {
+			$this->markTestSkipped(__METHOD__." Module Product must be enabled.");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/RestAPIUserTest.php
+++ b/test/phpunit/RestAPIUserTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -73,10 +74,6 @@ class RestAPIUserTest extends PHPUnit\Framework\TestCase
 		$this->savlangs=$langs;
 		$this->savdb=$db;
 
-		if (!isModEnabled('api')) {
-			print __METHOD__." module api must be enabled.\n"; die(1);
-		}
-
 		print __METHOD__." db->type=".$db->type." user->id=".$user->id;
 		//print " - db ".$db->db;
 		print "\n";
@@ -120,6 +117,11 @@ class RestAPIUserTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!isModEnabled('api')) {
+			$this->markTestSkipped(__METHOD__." module api must be enabled.");
+			return;
+		}
 
 		$this->api_url=DOL_MAIN_URL_ROOT.'/api/index.php';
 

--- a/test/phpunit/SocieteTest.php
+++ b/test/phpunit/SocieteTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -83,18 +84,6 @@ class SocieteTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf,$user,$langs,$db;
 
-		if ($conf->global->SOCIETE_CODECLIENT_ADDON != 'mod_codeclient_monkey') {
-			print "\n".__METHOD__." third party ref checker must be setup to 'mod_codeclient_monkey' not to '".$conf->global->SOCIETE_CODECLIENT_ADDON."'.\n"; die(1);
-		}
-
-		if (!empty($conf->global->MAIN_DISABLEPROFIDRULES)) {
-			print "\n".__METHOD__." constant MAIN_DISABLEPROFIDRULES must be empty (if a module set it, disable module).\n"; die(1);
-		}
-
-		if ($langs->defaultlang != 'en_US') {
-			print "\n".__METHOD__." default language of company must be set to autodetect.\n"; die(1);
-		}
-
 		$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
 
 		print __METHOD__."\n";
@@ -125,6 +114,18 @@ class SocieteTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if ($conf->global->SOCIETE_CODECLIENT_ADDON != 'mod_codeclient_monkey') {
+			$this->markTestSkipped(__METHOD__." third party ref checker must be setup to 'mod_codeclient_monkey' not to '".$conf->global->SOCIETE_CODECLIENT_ADDON."'.");
+		}
+
+		if (!empty($conf->global->MAIN_DISABLEPROFIDRULES)) {
+			$this->markTestSkipped(__METHOD__." constant MAIN_DISABLEPROFIDRULES must be empty (if a module set it, disable module).");
+		}
+
+		if ($langs->defaultlang != 'en_US') {
+			$this->markTestSkipped(__METHOD__." default language of company must be set to autodetect.");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/StripeTest.php
+++ b/test/phpunit/StripeTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2020 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -83,10 +84,6 @@ class StripeTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf,$user,$langs,$db;
 
-		if (!isModEnabled('stripe')) {
-			print __METHOD__." Module Stripe must be enabled.\n"; die(1);
-		}
-
 		$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
 
 		print __METHOD__."\n";
@@ -117,6 +114,10 @@ class StripeTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!isModEnabled('stripe')) {
+			$this->markTestSkipped(__METHOD__." Module Stripe must be enabled.");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/SupplierProposalTest.php
+++ b/test/phpunit/SupplierProposalTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2017 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -86,10 +87,6 @@ class SupplierProposalTest extends PHPUnit\Framework\TestCase
 		global $conf,$user,$langs,$db;
 		$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
 
-		if (empty($conf->global->MAIN_MODULE_SUPPLIERPROPOSAL)) {
-			print "\n".__METHOD__." module Supplier proposal must be enabled.\n"; die(1);
-		}
-
 		print __METHOD__."\n";
 	}
 
@@ -118,6 +115,10 @@ class SupplierProposalTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (empty($conf->global->MAIN_MODULE_SUPPLIERPROPOSAL)) {
+			$this->markTestSkipped(__METHOD__." module Supplier proposal must be enabled.");
+		}
 
 		print __METHOD__."\n";
 		//print $db->getVersion()."\n";

--- a/test/phpunit/SupplierProposalTest.php
+++ b/test/phpunit/SupplierProposalTest.php
@@ -116,8 +116,9 @@ class SupplierProposalTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		if (empty($conf->global->MAIN_MODULE_SUPPLIERPROPOSAL)) {
+		if (!isModEnabled('supplier_proposal')) {
 			$this->markTestSkipped(__METHOD__." module Supplier proposal must be enabled.");
+			return;
 		}
 
 		print __METHOD__."\n";

--- a/test/phpunit/UserTest.php
+++ b/test/phpunit/UserTest.php
@@ -114,7 +114,7 @@ class UserTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		if (!empty($conf->global->MAIN_MODULE_LDAP)) {
+		if (isModuleEnabled('ldap')) {
 			$this->markTestSkipped(__METHOD__." module LDAP must be disabled.");
 		}
 

--- a/test/phpunit/UserTest.php
+++ b/test/phpunit/UserTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010-2015 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,10 +83,6 @@ class UserTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf,$user,$langs,$db;
 
-		if (!empty($conf->global->MAIN_MODULE_LDAP)) {
-			print "\n".__METHOD__." module LDAP must be disabled.\n"; die(1);
-		}
-
 		$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
 
 		print __METHOD__."\n";
@@ -116,6 +113,10 @@ class UserTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (!empty($conf->global->MAIN_MODULE_LDAP)) {
+			$this->markTestSkipped(__METHOD__." module LDAP must be disabled.");
+		}
 
 		print __METHOD__."\n";
 	}

--- a/test/phpunit/WebservicesProductsTest.php
+++ b/test/phpunit/WebservicesProductsTest.php
@@ -123,7 +123,7 @@ class WebservicesProductsTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
-		if (empty($conf->service->enabled)) {
+		if (!isModuleEnabled('service')) {
 			$this->markTestSkipped("Error: Module service must be enabled.");
 		}
 

--- a/test/phpunit/WebservicesProductsTest.php
+++ b/test/phpunit/WebservicesProductsTest.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -121,6 +122,10 @@ class WebservicesProductsTest extends PHPUnit\Framework\TestCase
 		$user=$this->savuser;
 		$langs=$this->savlangs;
 		$db=$this->savdb;
+
+		if (empty($conf->service->enabled)) {
+			$this->markTestSkipped("Error: Module service must be enabled.");
+		}
 
 		print __METHOD__."\n";
 	}


### PR DESCRIPTION
# NEW test/phpunit: skip tests instead of die() when requirements are not met

The whole MR revolves around making tests that require modules that are not present fallible instead of die() the whole testsuite at construct time.

It also adds the --fail-on-skipped flag in the CI to ensure the behaviour stays the same and the CI coverage stays the largest possible, and fixes a few inconsistencies in the testsuite in some of the modified files.