### PR TITLE
FIX: Inventory lines values deleted when changing page length

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -297,7 +297,7 @@ if (empty($reshook)) {
 						$inventoryline->pmp_expected = price2num(GETPOST('expectedpmp_'.$lineid, 'alpha'), 'MS');
 						$resultupdate = $inventoryline->update($user);
 					}
-				} else {
+				} elseif (GETPOSTISSET('id_' . $lineid)) {
 					// Delete record
 					$result = $inventoryline->fetch($lineid);
 					if ($result > 0) {


### PR DESCRIPTION
# FIX
On page /product/inventory/inventory.php

1. With the default page limit of 20,
2. With an inventory containing more than 20 lines, let's say 30, thus displayed on 2 pages:

-> updating when changing page WITH ARROWS works well.
-> switching page length (limit) from 20 to more (say 30) WILL ERASE VALUES from line 21 to 30. the reason is that javascript posts the form with a limit value of 30 and values of line fields from 1 to 20 (values for lines 21 to 30 are not posted, they're not on the page!): the code evaluates values for line 21 to 30 to empty and wrongly deletes them.

The correction checks that values are really posted. I guess that updating (deleting) not posted values is not desired here.
