### PR TITLE
FIX: Task events not displayed

### DIFF
--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -644,8 +644,7 @@ if ($id > 0 || !empty($ref)) {
 		// List of actions on element
 		include_once DOL_DOCUMENT_ROOT.'/core/class/html.formactions.class.php';
 		$formactions = new FormActions($db);
-		$defaultthirdpartyid = $socid > 0 ? $socid : $object->project->socid;
-		$formactions->showactions($object, 'task', $defaultthirdpartyid, 1, '', 10, 'withproject='.$withproject);
+		$formactions->showactions($object, 'project_task', 0, 1, '', 10, 'withproject='.$withproject);
 
 		print '</div></div>';
 	}


### PR DESCRIPTION
Task `elementtype` is 'project_task' and not 'task' and in `llx_projet_task` there is no column name fk_soc so thirdparty is never registered when project_task event is registered.

Without those elements, getAction sql query did not fetch well task's events.