### PR TITLE
can use isModEnabled("module") in extrafield enabled

### DIFF
--- a/htdocs/core/actions_extrafields.inc.php
+++ b/htdocs/core/actions_extrafields.inc.php
@@ -367,7 +367,7 @@ if ($action == 'update') {
 					$computedvalue,
 					(GETPOST('entitycurrentorall', 'alpha') ? 0 : ''),
 					GETPOST('langfile'),
-					GETPOST('enabled', 'restricthtml'),
+					GETPOST('enabled', 'nohtml'),
 					(GETPOST('totalizable', 'alpha') ? 1 : 0),
 					GETPOST('printable', 'alpha'),
 					array('css' => $css, 'cssview' => $cssview, 'csslist' => $csslist)

--- a/htdocs/core/actions_extrafields.inc.php
+++ b/htdocs/core/actions_extrafields.inc.php
@@ -367,7 +367,7 @@ if ($action == 'update') {
 					$computedvalue,
 					(GETPOST('entitycurrentorall', 'alpha') ? 0 : ''),
 					GETPOST('langfile'),
-					GETPOST('enabled', 'alpha'),
+					GETPOST('enabled', 'restricthtml'),
 					(GETPOST('totalizable', 'alpha') ? 1 : 0),
 					GETPOST('printable', 'alpha'),
 					array('css' => $css, 'cssview' => $cssview, 'csslist' => $csslist)

--- a/htdocs/core/tpl/admin_extrafields_edit.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_edit.tpl.php
@@ -143,7 +143,7 @@ $listofexamplesforlink = 'Societe:societe/class/societe.class.php<br>Contact:con
 <input type="hidden" name="attrname" value="<?php echo $attrname; ?>">
 <input type="hidden" name="action" value="update">
 <input type="hidden" name="rowid" value="<?php echo (empty($rowid) ? '' : $rowid) ?>">
-<input type="hidden" name="enabled" value="<?php echo htmlspecialchars($extrafields->attributes[$elementtype]['enabled'][$attrname]); ?>">
+<input type="hidden" name="enabled" value="<?php echo dol_escape_htmltag($extrafields->attributes[$elementtype]['enabled'][$attrname]); ?>">
 
 <?php print dol_get_fiche_head(); ?>
 

--- a/htdocs/core/tpl/admin_extrafields_edit.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_edit.tpl.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2010-2012	Laurent Destailleur	<eldy@users.sourceforge.net>
  * Copyright (C) 2012		Regis Houssin		<regis.houssin@inodbox.com>
- * Copyright (C) 2018       Frédéric France     <frederic.france@netlogic.fr>
+ * Copyright (C) 2018-2023  Frédéric France     <frederic.france@netlogic.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -143,7 +143,7 @@ $listofexamplesforlink = 'Societe:societe/class/societe.class.php<br>Contact:con
 <input type="hidden" name="attrname" value="<?php echo $attrname; ?>">
 <input type="hidden" name="action" value="update">
 <input type="hidden" name="rowid" value="<?php echo (empty($rowid) ? '' : $rowid) ?>">
-<input type="hidden" name="enabled" value="<?php echo $extrafields->attributes[$elementtype]['enabled'][$attrname]; ?>">
+<input type="hidden" name="enabled" value="<?php echo htmlspecialchars($extrafields->attributes[$elementtype]['enabled'][$attrname]); ?>">
 
 <?php print dol_get_fiche_head(); ?>
 


### PR DESCRIPTION
if you create an extrafield with enabled property like `isModEnabled("module")` it is broken on extrafield edit