### PR TITLE
Fix of a missing $conf

### DIFF
--- a/htdocs/core/class/html.formaccounting.class.php
+++ b/htdocs/core/class/html.formaccounting.class.php
@@ -454,6 +454,7 @@ class FormAccounting extends Form
 	public function select_auxaccount($selectid, $htmlname = 'account_num_aux', $showempty = 0, $morecss = 'minwidth100 maxwidth300 maxwidthonsmartphone', $usecache = '', $labelhtmlname = '')
 	{
 		// phpcs:enable
+		global $conf;
 
 		$aux_account = array();
 


### PR DESCRIPTION
#Fix
missing a `global $conf` inside the function select_auxaccount from html.formaccounting.class.php where a `$conf->use_javascript_ajax is used`