### PR TITLE
Fix : makeStripeSepaRequest fatal error

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -1001,6 +1001,7 @@ abstract class CommonInvoice extends CommonObject
 					$this->db->begin();
 
 					// Create a prelevement_bon
+					require_once DOL_DOCUMENT_ROOT.'/compta/prelevement/class/bonprelevement.class.php';
 					$bon = new BonPrelevement($this->db);
 					if (!$error) {
 						if (empty($obj->fk_prelevement_bons)) {


### PR DESCRIPTION
Fix fatal error on missing include before call to object BonPrelevement on makeStripeSepaRequest() function in htdocs/core/class/commoninvoice.class.php