### PR TITLE
Fix link, label and badge color status in box_members_by_tags

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -2510,8 +2510,8 @@ class Adherent extends CommonObject
 				$labelStatusShort = $langs->trans("MemberStatusNoSubscriptionShort");
 			} elseif (!$date_end_subscription) {
 				$statusType = 'status1';
-				$labelStatus = $langs->trans("MemberStatusActive");
-				$labelStatusShort = $langs->trans("MemberStatusActiveShort");
+				$labelStatus = $langs->trans("WaitingSubscription");
+				$labelStatusShort = $langs->trans("WaitingSubscriptionShort");
 			} elseif ($date_end_subscription < dol_now()) {	// expired
 				$statusType = 'status8';
 				$labelStatus = $langs->trans("MemberStatusActiveLate");

--- a/htdocs/core/boxes/box_members_by_tags.php
+++ b/htdocs/core/boxes/box_members_by_tags.php
@@ -149,18 +149,18 @@ class box_members_by_tags extends ModeleBoxes
 				);
 				$line++;
 				foreach ($sumMembers as $key => $data) {
-					$adhtype = new AdherentType($this->db);
-					$adhtype->id = $key;
+					$adhtag = new Categorie($db);
+					$adhtag->id = $key;
 
 					if ($key=='total') {
 						break;
 					}
-					$adhtype->label = $data['label'];
-					$AdherentType[$key] = $adhtype;
+					$adhtag->label = $data['label'];
+					$AdherentTag[$key] = $adhtag;
 
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="tdoverflowmax150 maxwidth150onsmartphone"',
-						'text' => $adhtype->getNomUrl(1, dol_size(32)),
+						'text' => $adhtag->getNomUrl(0, '', dol_size(32), '&backtolist='.urlencode($_SERVER["PHP_SELF"])),
 						'asis' => 1,
 					);
 					$this->info_box_contents[$line][] = array(
@@ -195,7 +195,7 @@ class box_members_by_tags extends ModeleBoxes
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="right"',
-						'text' => (isset($data['total_adhtype']) && $data['total_adhtype'] > 0 ? $data['total_adhtype'] : ''),
+						'text' => (isset($data['total_adhtag']) && $data['total_adhtag'] > 0 ? $data['total_adhtag'] : ''),
 						'asis' => 1,
 					);
 					$line++;

--- a/htdocs/core/boxes/box_members_by_tags.php
+++ b/htdocs/core/boxes/box_members_by_tags.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2004-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2015-2023 Frédéric France      <frederic.france@netlogic.fr>
- * Copyright (C) 2021-2022 Waël Almoman         <info@almoman.com>
+ * Copyright (C) 2021-2023 Waël Almoman         <info@almoman.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -119,13 +119,13 @@ class box_members_by_tags extends ModeleBoxes
 					'text' => $labelstatus,
 				);
 				// Up to date
-				$labelstatus = $staticmember->LibStatut($staticmember::STATUS_VALIDATED, 1, dol_now() + 86400, 1);
+				$labelstatus = $staticmember->LibStatut($staticmember::STATUS_VALIDATED, 1, $now + 86400, 1);
 				$this->info_box_contents[$line][] = array(
 					'td' => 'class="right tdoverflowmax100" width="10%" title="'.dol_escape_htmltag($labelstatus).'"',
 					'text' => $labelstatus,
 				);
 				// Expired
-				$labelstatus = $staticmember->LibStatut($staticmember::STATUS_VALIDATED, 1, dol_now() - 86400, 1);
+				$labelstatus = $staticmember->LibStatut($staticmember::STATUS_VALIDATED, 1, $now - 86400, 1);
 				$this->info_box_contents[$line][] = array(
 					'td' => 'class="right tdoverflowmax100" width="10%" title="'.dol_escape_htmltag($labelstatus).'"',
 					'text' => $labelstatus
@@ -143,7 +143,6 @@ class box_members_by_tags extends ModeleBoxes
 					'text' => $labelstatus
 				);
 				// Total row
-				$labelstatus = $staticmember->LibStatut($staticmember::STATUS_RESILIATED, 0, 0, 1);
 				$this->info_box_contents[$line][] = array(
 					'td' => 'class="right tdoverflowmax100" width="10%" title="'.dol_escape_htmltag($langs->trans("Total")).'"',
 					'text' => $langs->trans("Total")
@@ -171,17 +170,17 @@ class box_members_by_tags extends ModeleBoxes
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="right"',
-						'text' => (isset($data['members_pending']) && $data['members_pending'] > 0 ? $data['members_pending'] : '') . ' ' . $staticmember->LibStatut(Adherent::STATUS_VALIDATED, 1, $now, 3),
+						'text' => (isset($data['members_pending']) && $data['members_pending'] > 0 ? $data['members_pending'] : '') . ' ' . $staticmember->LibStatut(Adherent::STATUS_VALIDATED, 1, 0, 3),
 						'asis' => 1,
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="right"',
-						'text' => (isset($data['members_uptodate']) && $data['members_uptodate'] > 0 ? $data['members_uptodate'] : '') . ' ' . $staticmember->LibStatut(Adherent::STATUS_VALIDATED, 0, 0, 3),
+						'text' => (isset($data['members_uptodate']) && $data['members_uptodate'] > 0 ? $data['members_uptodate'] : '') . ' ' . $staticmember->LibStatut(Adherent::STATUS_VALIDATED, 0, $now + 86400, 3),
 						'asis' => 1,
 					);
 					$this->info_box_contents[$line][] = array(
 						'td' => 'class="right"',
-						'text' => (isset($data['members_expired']) && $data['members_expired'] > 0 ? $data['members_expired'] : '') . ' ' . $staticmember->LibStatut(Adherent::STATUS_VALIDATED, 1, 1, 3),
+						'text' => (isset($data['members_expired']) && $data['members_expired'] > 0 ? $data['members_expired'] : '') . ' ' . $staticmember->LibStatut(Adherent::STATUS_VALIDATED, 1, $now - 86400, 3),
 						'asis' => 1,
 					);
 					$this->info_box_contents[$line][] = array(

--- a/htdocs/langs/en_US/members.lang
+++ b/htdocs/langs/en_US/members.lang
@@ -41,6 +41,7 @@ EndSubscription=End of membership
 SubscriptionId=Contribution ID
 WithoutSubscription=Without membership
 WaitingSubscription=Membership pending
+WaitingSubscriptionShort=Pending
 MemberId=Member Id
 MemberRef=Member Ref
 NewMember=New member


### PR DESCRIPTION
Pending members are listed as green instead of orange

Validate member short label is used instead of pending member short label

Link on tag was pointing to member type instead of member tag

