### PR TITLE
FIX: Bad link in getNomUrl

### DIFF
--- a/htdocs/fourn/facture/list-rec.php
+++ b/htdocs/fourn/facture/list-rec.php
@@ -708,7 +708,7 @@ if ($resql) {
 				}
 			}
 			if (!empty($arrayfields['s.nom']['checked'])) {
-				print '<td class="tdoverflowmax200">'.$companystatic->getNomUrl(1, 'customer').'</td>';
+				print '<td class="tdoverflowmax200">'.$companystatic->getNomUrl(1, 'supplier').'</td>';
 				if (!$i) {
 					$totalarray['nbfield']++;
 				}


### PR DESCRIPTION
```$companystatic->getNomUrl(1, 'customer')```  generate a link to ```/comm/card.php?socid=1234``` instead of ```/fourn/card.php?socid=1234```  
![image](https://github.com/Dolibarr/dolibarr/assets/58433943/6c43eccf-f9b9-4969-bc7a-46961e6f7c6e)
