### PR TITLE
Add missing loading of Societe Class. Fatal error during signing proposal without order

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -38,6 +38,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/commonobjectline.class.php';
 require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT.'/margin/lib/margins.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/multicurrency/class/multicurrency.class.php';
+require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
 
 
 /**


### PR DESCRIPTION
Current code relies on Societe Class being already imported by code executed previously,
thus in some cases you get a fatal error.
I have fatal error of undefined Societe class when i try to sign a Proposal that does not already have an order.

# Instructions
* To replicate issue 
- Use a Dolibarr installation without extra modules (that might be loading Societe class ?)
and then try to sign a Proposal that does not yet have an order. You get a fatal error due to undefined Societe Class
