### PR TITLE
Fix proposal line ids when cloning

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1264,10 +1264,10 @@ class Propal extends CommonObject
 							dol_print_error($this->db);
 							break;
 						}
-						
-                        // Set the id on created row
-                        $line->id = $result;
-						
+
+						// Set the id on created row
+						$line->id = $result;
+
 						// Defined the new fk_parent_line
 						if ($result > 0 && $line->product_type == 9) {
 							$fk_parent_line = $result;
@@ -1401,9 +1401,8 @@ class Propal extends CommonObject
 				}
 
 				foreach ($object->lines as $line) {
-                    
-                    $line->id = 0;
-                    
+					$line->id = 0;
+
 					if ($line->fk_product > 0) {
 						$prod = new Product($this->db);
 						$res = $prod->fetch($line->fk_product);

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1264,6 +1264,10 @@ class Propal extends CommonObject
 							dol_print_error($this->db);
 							break;
 						}
+						
+                        // Set the id on created row
+                        $line->id = $result;
+						
 						// Defined the new fk_parent_line
 						if ($result > 0 && $line->product_type == 9) {
 							$fk_parent_line = $result;
@@ -1397,6 +1401,9 @@ class Propal extends CommonObject
 				}
 
 				foreach ($object->lines as $line) {
+                    
+                    $line->id = 0;
+                    
 					if ($line->fk_product > 0) {
 						$prod = new Product($this->db);
 						$res = $prod->fetch($line->fk_product);


### PR DESCRIPTION
Fix IDs on created proposal lines when cloning so the hook createFrom has all the clone infos update (otherwise the old line ids was set on the cloned object passed into the hook)