### PR TITLE
fixed access to proposal (propal) variables for invoice ODT templates

### DIFF
--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -336,8 +336,9 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				$object->fetchObjectLinked('', '', '', '');
 				//print_r($object->linkedObjects['propal']); exit;
 
-				if (isset($object->linkedObjects['propal'][0])) {
-					$propal_object = $object->linkedObjects['propal'][0];
+				$propal_object = $object->linkedObjects['propal'];
+				if (isset($propal_object) && sizeof($propal_object)>0) {
+					$propal_object = array_values($object->linkedObjects['propal'])[0];
 				} else {
 					$propal_object = null;
 				}

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -336,9 +336,10 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				$object->fetchObjectLinked('', '', '', '');
 				//print_r($object->linkedObjects['propal']); exit;
 
-				$propal_object = $object->linkedObjects['propal'];
-				if (isset($propal_object) && sizeof($propal_object)>0) {
-					$propal_object = array_values($object->linkedObjects['propal'])[0];
+				$array_propal_object = $object->linkedObjects['propal'];
+				if (isset($array_propal_object) && is_array($array_propal_object) && count($array_propal_object) > 0) {
+					$tmparrayofvalue = array_values($array_propal_object);
+					$propal_object = $tmparrayofvalue[0];
 				} else {
 					$propal_object = null;
 				}


### PR DESCRIPTION
# FIX
If you use on OpenOffice (ODT) template for generating an invoice then it is not possible to access the information from a proposal from which the invoice has been created. My goal was to add the proposal number (as a refenerence ) to the invoice document for our customers.

I took a look in the code and found that this information should be available via the corresponding variables but a bug prevents this.

Therefore a changed three lines of code to fix this.
