### PR TITLE
FIX: Langs was not loaded for extrafields error

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1991,6 +1991,8 @@ class ExtraFields
 					continue;
 				}
 
+				$langs->load($this->attributes[$object->table_element]['langfile'][$key]);
+
 				if ($this->attributes[$object->table_element]['required'][$key]) {	// Value is required
 					// Check if functionally empty without using GETPOST (depending on the type of extrafield, a
 					// technically non-empty value may be treated as empty functionally).

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1991,8 +1991,6 @@ class ExtraFields
 					continue;
 				}
 
-				$langs->load($this->attributes[$object->table_element]['langfile'][$key]);
-
 				if ($this->attributes[$object->table_element]['required'][$key]) {	// Value is required
 					// Check if functionally empty without using GETPOST (depending on the type of extrafield, a
 					// technically non-empty value may be treated as empty functionally).
@@ -2002,6 +2000,9 @@ class ExtraFields
 						|| (!is_array($_POST["options_".$key]) && isset($_POST["options_".$key]) && $this->attributes[$object->table_element]['type'][$key] == 'sellist' && $_POST['options_'.$key] == '0')
 						|| (is_array($_POST["options_".$key]) && empty($_POST["options_".$key]))) {
 						//print 'ccc'.$value.'-'.$this->attributes[$object->table_element]['required'][$key];
+						if (!empty($this->attributes[$object->table_element]['langfile'][$key])) {
+							$langs->load($this->attributes[$object->table_element]['langfile'][$key]);
+						}
 						$nofillrequired++;
 						$error_field_required[] = $langs->transnoentitiesnoconv($value);
 					}


### PR DESCRIPTION
If an error was generated, extrafields labels were not translated. 