### PR TITLE
Add a setting to send subscription reminder to a cc address

### DIFF
--- a/htdocs/adherents/admin/member_emails.php
+++ b/htdocs/adherents/admin/member_emails.php
@@ -63,6 +63,7 @@ $constantes = array(
 	'ADHERENT_EMAIL_TEMPLATE_CANCELATION'			=>array('type'=>'emailtemplate:member'),
 	'ADHERENT_EMAIL_TEMPLATE_EXCLUSION'				=>array('type'=>'emailtemplate:member'),
 	'ADHERENT_MAIL_FROM'							=>array('type'=>'string'),
+	'ADHERENT_CC_MAIL_FROM'							=>array('type'=>'string'),
 	'ADHERENT_AUTOREGISTER_NOTIF_MAIL_SUBJECT'		=>array('type'=>'string'),
 	'ADHERENT_AUTOREGISTER_NOTIF_MAIL'				=>array('type'=>'html', 'tooltip'=>$helptext)
 );

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -3146,12 +3146,13 @@ class Adherent extends CommonObject
 							$msg = make_substitutions($arraydefaultmessage->content, $substitutionarray, $outputlangs);
 							$from = getDolGlobalString('ADHERENT_MAIL_FROM');
 							$to = $adherent->email;
+							$cc = getDolGlobalString('ADHERENT_CC_MAIL_FROM');
 
 							$trackid = 'mem'.$adherent->id;
 							$moreinheader = 'X-Dolibarr-Info: sendReminderForExpiredSubscription'."\r\n";
 
 							include_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
-							$cmail = new CMailFile($subject, $to, $from, $msg, array(), array(), array(), '', '', 0, 1, '', '', $trackid, $moreinheader);
+							$cmail = new CMailFile($subject, $to, $from, $msg, array(), array(), array(), $cc, '', 0, 1, '', '', $trackid, $moreinheader);
 							$result = $cmail->sendfile();
 							if (!$result) {
 								$error++;

--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -1766,7 +1766,7 @@ function form_constantes($tableau, $strictw3c = 0, $helptext = '', $text = 'Valu
 				}
 				print '</div>';
 				//print 'http://lists.example.com/cgi-bin/mailman/admin/%LISTE%/members/remove?adminpw=%MAILMAN_ADMINPW%&unsubscribees=%EMAIL%';
-			} elseif ($const == 'ADHERENT_MAIL_FROM') {
+			} elseif (in_array($const, ['ADHERENT_MAIL_FROM', 'ADHERENT_CC_MAIL_FROM'])) {
 				print ' '.img_help(1, $langs->trans("EMailHelpMsgSPFDKIM"));
 			}
 

--- a/htdocs/langs/en_US/members.lang
+++ b/htdocs/langs/en_US/members.lang
@@ -162,6 +162,7 @@ DescADHERENT_EMAIL_TEMPLATE_REMIND_EXPIRATION=Email template to use to send emai
 DescADHERENT_EMAIL_TEMPLATE_CANCELATION=Email template to use to send email to a member on member cancelation
 DescADHERENT_EMAIL_TEMPLATE_EXCLUSION=Email template to use to send email to a member on member exclusion
 DescADHERENT_MAIL_FROM=Sender Email for automatic emails
+DescADHERENT_CC_MAIL_FROM=Send automatic email copy to
 DescADHERENT_ETIQUETTE_TYPE=Format of labels page
 DescADHERENT_ETIQUETTE_TEXT=Text printed on member address sheets
 DescADHERENT_CARD_TYPE=Format of cards page

--- a/htdocs/langs/fr_FR/members.lang
+++ b/htdocs/langs/fr_FR/members.lang
@@ -158,6 +158,7 @@ DescADHERENT_EMAIL_TEMPLATE_REMIND_EXPIRATION=Modèle d'email électronique à u
 DescADHERENT_EMAIL_TEMPLATE_CANCELATION=Modèle d'email utilisé pour envoyer un email à un adhérent lors de l'annulation d'adhésion
 DescADHERENT_EMAIL_TEMPLATE_EXCLUSION=Modèle de courriel à utiliser pour envoyer un courriel à un adhérent lors de son exclusion
 DescADHERENT_MAIL_FROM=Email émetteur pour les mails automatiques
+DescADHERENT_CC_MAIL_FROM=Email en copie des mails automatiques
 DescADHERENT_ETIQUETTE_TYPE=Format pages étiquettes
 DescADHERENT_ETIQUETTE_TEXT=Texte imprimé sur les planches d'adresses adhérent
 DescADHERENT_CARD_TYPE=Format pages cartes d'adhérent


### PR DESCRIPTION
# NEW Add a Cc field for subscription reminders

In some foundations it is useful for the treasurer to receive a copy of the reminders sent to members when their subscription is expiring.

This can be used for instance when moral persons subscription prices are negotiated each year : the treasurer receives the reminder at the same time than the member and can create a proposal