### PR TITLE
FIX: default values were not set for specimen objects

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9453,6 +9453,7 @@ abstract class CommonObject
 			}
 		}
 
+		// Force values to default values when known
 		foreach ($this->fields as $key => $value) {
 			// If fields are already set, do nothing
 			if (array_key_exists($key, $fields)) {
@@ -9460,7 +9461,7 @@ abstract class CommonObject
 			}
 
 			if (!empty($value['default'])) {
-				$this->{$key} = $value['default'];
+				$this->$key = $value['default'];
 			}
 		}
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9452,6 +9452,18 @@ abstract class CommonObject
 				$this->{$key} = $value;
 			}
 		}
+
+		foreach ($this->fields as $key => $value) {
+			// If fields are already set, do nothing
+			if (array_key_exists($key, $fields)) {
+				continue;
+			}
+
+			if (!empty($value['default'])) {
+				$this->{$key} = $value['default'];
+			}
+		}
+
 		return 1;
 	}
 


### PR DESCRIPTION
Default values have not been defined for the specimens, which could cause problems for unit testing or pdf generation.