### PR TITLE
New access to msg linked files via public interface

### DIFF
--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -357,7 +357,7 @@ class ActionsTicket
 								$filePath = DOL_DATA_ROOT.'/'.$doc->filepath.'/'.$doc->filename;
 								$mime = dol_mimetype($filePath);
 								$thumb = $arraymsgs['id'].'/thumbs/'.substr($doc->filename, 0, strrpos($doc->filename, '.')).'_mini'.substr($doc->filename, strrpos($doc->filename, '.'));
-								$doclink = dol_buildpath('document.php', 1)."?hashp=$doc->share";
+								$doclink = DOL_URL_ROOT.'/document.php?hashp='.urlencode($doc->share);
 
 								$mimeAttr = ' mime="'.$mime.'" ';
 								$class = '';

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -327,14 +327,14 @@ class ActionsTicket
 					//attachment
 
 					$documents = array();
-				
+
 					$sql = 'SELECT ecm.rowid as id, ecm.src_object_type, ecm.src_object_id';
 					$sql .= ', ecm.filepath, ecm.filename, ecm.share';
 					$sql .= ' FROM '.MAIN_DB_PREFIX.'ecm_files ecm';
 					$sql .= ' WHERE ecm.filepath = \'agenda/'.$arraymsgs['id'].'\'';
 					//$sql.= ' ecm.src_object_type = \''.$object->element.'\' AND ecm.src_object_id = '.$object->id; // Actually upload file doesn't add type
 					$sql .= ' ORDER BY ecm.position ASC';
-				
+
 					$resql = $this->db->query($sql);
 					if ($resql) {
 						if ($this->db->num_rows($resql)) {

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -374,8 +374,8 @@ class ActionsTicket
 						}
 						$footer .= '</div>';
 						if ($isshared == 1) {
-							print '<br />';
-							print '<br />';
+							print '<br>';
+							print '<br>';
 							print $footer;
 						}
 					}

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -331,7 +331,7 @@ class ActionsTicket
 					$sql = 'SELECT ecm.rowid as id, ecm.src_object_type, ecm.src_object_id';
 					$sql .= ', ecm.filepath, ecm.filename, ecm.share';
 					$sql .= ' FROM '.MAIN_DB_PREFIX.'ecm_files ecm';
-					$sql .= ' WHERE ecm.filepath = \'agenda/'.$arraymsgs['id'].'\'';
+					$sql .= " WHERE ecm.filepath = 'agenda/".$arraymsgs['id']."'";
 					$sql .= ' ORDER BY ecm.position ASC';
 
 					$resql = $this->db->query($sql);

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -323,6 +323,63 @@ class ActionsTicket
 					print '<tr class="oddeven">';
 					print '<td colspan="2">';
 					print $arraymsgs['message'];
+
+					//attachment
+
+					$documents = array();
+				
+					$sql = 'SELECT ecm.rowid as id, ecm.src_object_type, ecm.src_object_id';
+					$sql .= ', ecm.filepath, ecm.filename, ecm.share';
+					$sql .= ' FROM '.MAIN_DB_PREFIX.'ecm_files ecm';
+					$sql .= ' WHERE ecm.filepath = \'agenda/'.$arraymsgs['id'].'\'';
+					//$sql.= ' ecm.src_object_type = \''.$object->element.'\' AND ecm.src_object_id = '.$object->id; // Actually upload file doesn't add type
+					$sql .= ' ORDER BY ecm.position ASC';
+				
+					$resql = $this->db->query($sql);
+					if ($resql) {
+						if ($this->db->num_rows($resql)) {
+							while ($obj = $this->db->fetch_object($resql)) {
+								$documents[$obj->id] = $obj;
+							}
+						}
+					}
+					if (!empty($documents)) {
+						$isshared = 0;
+						$footer = '<div class="timeline-documents-container">';
+						foreach ($documents as $doc) {
+							if (!empty($doc->share)) {
+								$isshared = 1;
+								$footer .= '<span id="document_'.$doc->id.'" class="timeline-documents" ';
+								$footer .= ' data-id="'.$doc->id.'" ';
+								$footer .= ' data-path="'.$doc->filepath.'"';
+								$footer .= ' data-filename="'.dol_escape_htmltag($doc->filename).'" ';
+								$footer .= '>';
+
+								$filePath = DOL_DATA_ROOT.'/'.$doc->filepath.'/'.$doc->filename;
+								$mime = dol_mimetype($filePath);
+								$thumb = $arraymsgs['id'].'/thumbs/'.substr($doc->filename, 0, strrpos($doc->filename, '.')).'_mini'.substr($doc->filename, strrpos($doc->filename, '.'));
+								$doclink = dol_buildpath('document.php', 1)."?hashp=$doc->share";
+
+								$mimeAttr = ' mime="'.$mime.'" ';
+								$class = '';
+								if (in_array($mime, array('image/png', 'image/jpeg', 'application/pdf'))) {
+									$class .= ' documentpreview';
+								}
+
+								$footer .= '<a href="'.$doclink.'" class="btn-link '.$class.'" target="_blank"  '.$mimeAttr.' >';
+								$footer .= img_mime($filePath).' '.$doc->filename;
+								$footer .= '</a>';
+
+								$footer .= '</span>';
+							}
+						}
+						$footer .= '</div>';
+						if ($isshared == 1) {
+							print '<br />';
+							print '<br />';
+							print $footer;
+						}
+					}
 					print '</td>';
 					print '</tr>';
 				}

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -332,7 +332,6 @@ class ActionsTicket
 					$sql .= ', ecm.filepath, ecm.filename, ecm.share';
 					$sql .= ' FROM '.MAIN_DB_PREFIX.'ecm_files ecm';
 					$sql .= ' WHERE ecm.filepath = \'agenda/'.$arraymsgs['id'].'\'';
-					//$sql.= ' ecm.src_object_type = \''.$object->element.'\' AND ecm.src_object_id = '.$object->id; // Actually upload file doesn't add type
 					$sql .= ' ORDER BY ecm.position ASC';
 
 					$resql = $this->db->query($sql);


### PR DESCRIPTION
# New 

PR needed [*#24871*]

Now we can see and access the files linked to ticket messages that are shared inside the public interface

![test public side](https://github.com/Dolibarr/dolibarr/assets/122890855/d2bb258a-3c74-44b0-8b1e-295bfd842063)
