### PR TITLE
NEW ADD: custom compute for exports

### DIFF
--- a/htdocs/exports/class/export.class.php
+++ b/htdocs/exports/class/export.class.php
@@ -706,6 +706,44 @@ class Export
 									$remaintopay = $tmpobjforcomputecall->getRemainToPay();
 								}
 								$obj->$alias = $remaintopay;
+							} elseif (is_array($this->array_export_special[$indice][$key]) &&
+								!empty($this->array_export_special[$indice][$key]['rule']) &&
+								$this->array_export_special[$indice][$key]['rule'] == 'compute'
+							) {
+								// Custom compute
+								$alias = str_replace(array('.', '-', '(', ')'), '_', $key);
+								$value = '';
+								if (!empty($this->array_export_special[$indice][$key]['class']) &&
+									!empty($this->array_export_special[$indice][$key]['classfile']) &&
+									!empty($this->array_export_special[$indice][$key]['method'])
+								) {
+									if (!dol_include_once($this->array_export_special[$indice][$key]['classfile'])) {
+										$this->error = "Computed field bad configuration: {$this->array_export_special[$indice][$key]['classfile']} not found";
+										return -1;
+									}
+
+									if (!class_exists($this->array_export_special[$indice][$key]['class'])) {
+										$this->error = "Computed field bad configuration: {$this->array_export_special[$indice][$key]['class']} class doesn't exist";
+										return -1;
+									}
+
+									$className = $this->array_export_special[$indice][$key]['class'];
+									$tmpObject = new $className($this->db);
+									if (!method_exists($tmpObject, $this->array_export_special[$indice][$key]['method'])) {
+										$this->error = "Computed field bad configuration: {$this->array_export_special[$indice][$key]['method']} method doesn't exist";
+										return -1;
+									}
+
+									$methodName = $this->array_export_special[$indice][$key]['method'];
+									$params = [];
+									if (!empty($this->array_export_special[$indice][$key]['method_params'])) {
+										foreach ($this->array_export_special[$indice][$key]['method_params'] as $paramName) {
+											$params[] = $obj->$paramName ?? null;
+										}
+									}
+									$value = $tmpObject->$methodName(...$params);
+								}
+								$obj->$alias = $value;
 							} else {
 								// TODO FIXME
 								// Export of compute field does not work. $obj contains $obj->alias_field and formula may contains $obj->field


### PR DESCRIPTION
NEW : add custom compute feature for exports

I needed a way to compute some values in my module export, like the remainToPay on invoice export... Unfortunately I realized  it was hardcoded it the export.class.php, with some other specific cases. So i used a similar way to import compute fields. Here's an example how to define a custom computed field in your export (i used the array_export_special prop) :

`		$this->export_special_array[$r] = [
			'none.encours' => [
				'rule' => 'compute',
				'classfile' => 'mymodule/lib/ExportLibrary.class.php',
				'class' => 'ExportLibrary',
				'method' => 'calculateMyCustomValue',
				'method_params' => [
					'rowid'
				]
			]
		];
`
