### PR TITLE
FIX error expedition qty 0

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -357,7 +357,7 @@ if (empty($reshook)) {
 								$entrepot_id = 0;
 							}
 
-							$ret = $object->addline($entrepot_id, GETPOST($idl, 'int'), GETPOST($qty, 'int'), $array_options[$i]);
+							$ret = $object->addline($entrepot_id, GETPOST($idl, 'int'), GETPOSTINT($qty), $array_options[$i]);
 							if ($ret < 0) {
 								setEventMessages($object->error, $object->errors, 'errors');
 								$error++;


### PR DESCRIPTION
When `SHIPMENT_GETS_ALL_ORDER_PRODUCTS` is enabled, if we have a qty set to 0 (because already sent or unavailable in current stock), it generates an error on creating the shipment, as `GETPOST($qty, 'int')` doesn't get any value when the field is disabled, whereas GETPOSTINT generates an integer.

It's linked to the following error:
https://github.com/Dolibarr/dolibarr/blob/a47f59c5adbca3c8bd0a3266fd0dd3fc1cb8853f/htdocs/expedition/class/expedition.class.php#L2705