### PR TITLE
fix: php warning on sabre lib

### DIFF
--- a/htdocs/includes/sabre/sabre/vobject/lib/Component/VCard.php
+++ b/htdocs/includes/sabre/sabre/vobject/lib/Component/VCard.php
@@ -506,7 +506,7 @@ class VCard extends VObject\Document {
                 switch ($property->name) {
 
                     case 'VERSION':
-                        continue;
+                        continue 2;
 
                     case 'XML':
                         $value = $property->getParts();

--- a/htdocs/includes/sabre/sabre/vobject/lib/Component/VCard.php
+++ b/htdocs/includes/sabre/sabre/vobject/lib/Component/VCard.php
@@ -506,7 +506,7 @@ class VCard extends VObject\Document {
                 switch ($property->name) {
 
                     case 'VERSION':
-                        continue 2;
+                       break;
 
                     case 'XML':
                         $value = $property->getParts();


### PR DESCRIPTION
fix: php warning on sabre lib

What to do, this version of sabre is really old, we must in next Dolibarr version put the last ones 
https://github.com/sabre-io/vobject/releases/tag/4.5.3
is for php 7.4 minimum and dolibarr develop is php 7.0 minimum...

#24888
