### PR TITLE
FIX: Set update keys set in module descriptor by default in multiselectarray

### DIFF
--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -146,6 +146,10 @@ $separator_used     = str_replace('\t', "\t", $separator);
 $objimport = new Import($db);
 $objimport->load_arrays($user, ($step == 1 ? '' : $datatoimport));
 
+if (empty($updatekeys && !empty($objimport->array_import_updatekeys[0]))) {
+    $updatekeys = array_keys($objimport->array_import_updatekeys[0]);
+}
+
 $objmodelimport = new ModeleImports();
 
 $form = new Form($db);

--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -145,8 +145,7 @@ $separator_used     = str_replace('\t', "\t", $separator);
 
 $objimport = new Import($db);
 $objimport->load_arrays($user, ($step == 1 ? '' : $datatoimport));
-
-if (empty($updatekeys && !empty($objimport->array_import_updatekeys[0]))) {
+if (empty($updatekeys) && !empty($objimport->array_import_updatekeys[0])) {
     $updatekeys = array_keys($objimport->array_import_updatekeys[0]);
 }
 

--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -147,7 +147,7 @@ $objimport = new Import($db);
 $objimport->load_arrays($user, ($step == 1 ? '' : $datatoimport));
 
 if (empty($updatekeys && !empty($objimport->array_import_updatekeys[0]))) {
-    $updatekeys = array_keys($objimport->array_import_updatekeys[0]);
+	$updatekeys = array_keys($objimport->array_import_updatekeys[0]);
 }
 
 $objmodelimport = new ModeleImports();


### PR DESCRIPTION
To prevent SQL import error if user don't fill the multiselectarray, I think set modules values by default is a better option.
