### PR TITLE
Simplify redundant code while fixing undefined index errors

### DIFF
--- a/htdocs/projet/class/tasks-tab-common.class.php
+++ b/htdocs/projet/class/tasks-tab-common.class.php
@@ -1,0 +1,23 @@
+<?php
+/**
+Common code for different parts of tasks tab.
+**/
+
+class TasksTabCommon {
+	public static function getViewButtons(object $object, object $langs, string $selected, string $extraCssClass=''): string {
+		$buttons = [
+			['title'=>'ViewList', 'css'=>'fa fa-bars', 'url'=>'/projet/tasks.php?id='.$object->id],
+			['title'=>'ViewGantt', 'css'=>'fa fa-stream', 'url'=>'/projet/ganttview.php?id='.$object->id.'&withproject=1']
+		];
+		$links = '';
+		foreach ($buttons as $button) {
+			$morecss = 'reposition';
+			if ($button['title'] == $selected) $morecss .= ' btnTitleSelected';
+			$links .= dolGetButtonTitle($langs->trans($button['title']), '',
+				$button['css']." imgforviewmode $extraCssClass",
+				DOL_URL_ROOT.$button['url'], '', 1, ['morecss'=>$morecss]);
+		}
+
+		return $links;
+	}
+}

--- a/htdocs/projet/ganttview.php
+++ b/htdocs/projet/ganttview.php
@@ -26,6 +26,7 @@
 require "../main.inc.php";
 require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 require_once DOL_DOCUMENT_ROOT.'/projet/class/task.class.php';
+require_once DOL_DOCUMENT_ROOT.'/projet/class/tasks-tab-common.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/project.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
@@ -253,8 +254,7 @@ if ($user->rights->projet->all->creer || $user->rights->projet->creer) {
 
 $linktocreatetask = dolGetButtonTitle($langs->trans('AddTask'), '', 'fa fa-plus-circle', DOL_URL_ROOT.'/projet/tasks.php?id='.$object->id.'&action=create'.$param.'&backtopage='.urlencode($_SERVER['PHP_SELF'].'?id='.$object->id), '', $linktocreatetaskUserRight, $linktocreatetaskParam);
 
-$linktotasks = dolGetButtonTitle($langs->trans('ViewList'), '', 'fa fa-bars paddingleft imgforviewmode', DOL_URL_ROOT.'/projet/tasks.php?id='.$object->id, '', 1, array('morecss'=>'reposition'));
-$linktotasks .= dolGetButtonTitle($langs->trans('ViewGantt'), '', 'fa fa-stream paddingleft imgforviewmode', DOL_URL_ROOT.'/projet/ganttview.php?id='.$object->id.'&withproject=1', '', 1, array('morecss'=>'reposition marginleftonly btnTitleSelected'));
+$linktotasks = TasksTabCommon::getViewButtons($object,$langs,'ViewGantt','paddingleft');
 
 //print_barre_liste($title, 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, $linktotasks, $num, $totalnboflines, 'generic', 0, '', '', 0, 1);
 print load_fiche_titre($title, $linktotasks.' &nbsp; '.$linktocreatetask, 'projecttask');

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -26,6 +26,7 @@
 require "../main.inc.php";
 require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 require_once DOL_DOCUMENT_ROOT.'/projet/class/task.class.php';
+require_once DOL_DOCUMENT_ROOT.'/projet/class/tasks-tab-common.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/project.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
@@ -878,8 +879,7 @@ if ($action == 'create' && $user->rights->projet->creer && (empty($object->third
 	print '<input type="hidden" name="contextpage" value="'.$contextpage.'">';
 
 	$title = $langs->trans("ListOfTasks");
-	$linktotasks = dolGetButtonTitle($langs->trans('ViewList'), '', 'fa fa-bars imgforviewmode', DOL_URL_ROOT.'/projet/tasks.php?id='.$object->id, '', 1, array('morecss'=>'reposition btnTitleSelected'));
-	$linktotasks .= dolGetButtonTitle($langs->trans('ViewGantt'), '', 'fa fa-stream imgforviewmode', DOL_URL_ROOT.'/projet/ganttview.php?id='.$object->id.'&withproject=1', '', 1, array('morecss'=>'reposition marginleftonly'));
+	$linktotasks = TasksTabCommon::getViewButtons($object,$langs,'ViewList');
 
 	//print_barre_liste($title, 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, $linktotasks, $num, $totalnboflines, 'generic', 0, '', '', 0, 1);
 	print load_fiche_titre($title, $linktotasks.' &nbsp; '.$linktocreatetask, 'projecttask', '', '', '', $massactionbutton);


### PR DESCRIPTION
Fix undefined index errors that appear in PHP 8.  Refactoring applied to simplify redundant code.