### PR TITLE
Fix undefined array key warnings with external module fields

### DIFF
--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -1094,7 +1094,7 @@ function projectLinesa(&$inc, $parent, &$lines, &$level, $var, $showproject, &$t
 
 		//Check if Extrafields is totalizable
 		foreach ($extrafields->attributes['projet_task']['totalizable'] as $key=>$value) {
-			if ($arrayfields['ef.'.$key]['checked'] == 1) {
+			if (($arrayfields['ef.'.$key]['checked'] ?? null) == 1) {
 				print '<td align="right">';
 				if ($value == 1) {
 					print $totalarray['totalizable'][$key]['total'];


### PR DESCRIPTION
Fix the following issues that appear in htdocs/core/lib/project.lib.php on line 1097 with the Gantt Pro Advanced module from the DoliStore:

Trying to access array offset on value of type null
Undefined array key "ef.ganttproadvancedcolor"
Undefined array key "ef.ganttproadvanceddatejalon"
Undefined array key "ef.ganttproadvancednumberdayslate"
Undefined array key "ef.ganttproadvancedrelatedtask"
Undefined array key "ef.ganttproadvancedtyperelation"
