### PR TITLE
Fix undefined variable $nbrows warning

### DIFF
--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -498,9 +498,7 @@ if ($id > 0 || !empty($ref)) {
 		// WYSIWYG editor
 		include_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
 		$cked_enabled = (!empty($conf->global->FCKEDITOR_ENABLE_SOCIETE) ? $conf->global->FCKEDITOR_ENABLE_SOCIETE : 0);
-		if (!empty($conf->global->MAIN_INPUT_DESC_HEIGHT)) {
-			$nbrows = $conf->global->MAIN_INPUT_DESC_HEIGHT;
-		}
+		$nbrows = $conf->global->MAIN_INPUT_DESC_HEIGHT ?? null;
 		$doleditor = new DolEditor('description', $object->description, '', 80, 'dolibarr_details', '', false, true, $cked_enabled, $nbrows);
 		print $doleditor->Create();
 		print '</td></tr>';


### PR DESCRIPTION
Fix warning that may occur in PHP 8:

htdocs/projet/tasks/task.php on line 504: Undefined variable $nbrows