### PR TITLE
Fix undefined variable & array key warnings in forgotten password code

### DIFF
--- a/htdocs/core/tpl/passwordforgotten.tpl.php
+++ b/htdocs/core/tpl/passwordforgotten.tpl.php
@@ -27,7 +27,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 // DDOS protection
-$size = (int) $_SERVER['CONTENT_LENGTH'];
+$size = (int) ($_SERVER['CONTENT_LENGTH'] ?? 0);
 if ($size > 10000) {
 	$langs->loadLangs(array("errors", "install"));
 	httponly_accessforbidden('<center>'.$langs->trans("ErrorRequestTooLarge").'<br><a href="'.DOL_URL_ROOT.'">'.$langs->trans("ClickHereToGoToApp").'</a></center>', 413, 1);

--- a/htdocs/user/passwordforgotten.php
+++ b/htdocs/user/passwordforgotten.php
@@ -84,7 +84,7 @@ $parameters = array('username' => $username);
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) {
 	$message = $hookmanager->error;
-}
+} else $message = '';
 
 if (empty($reshook)) {
 	// Validate new password


### PR DESCRIPTION
Fix undefined variable & array keys that appear in PHP 8:

htdocs/core/tpl/passwordforgotten.tpl.php on line 30: Undefined array key "CONTENT_LENGTH"
htdocs/user/passwordforgotten.php on line 146: Undefined variable $message