### PR TITLE
FIX: use dol_substr instead of dol_trunc for truncating openssl initialization vector

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -152,7 +152,7 @@ function dolEncrypt($chain, $key = '', $ciphering = 'AES-256-CTR', $forceseed = 
 		if (empty($forceseed)) {
 			$ivseed = dolGetRandomBytes($ivlen);
 		} else {
-			$ivseed = dol_trunc(md5($forceseed), $ivlen, 'right', 'UTF-8', 1);
+			$ivseed = dol_substr(md5($forceseed), 0, $ivlen, 'ascii', 1);
 		}
 
 		$newchain = openssl_encrypt($chain, $ciphering, $key, 0, $ivseed);


### PR DESCRIPTION
## Rationale
`openssl_encrypt` expects an initialization vector (IV) with a specific length (depending on the algorithm used).

`dolEncrypt()` uses `openssl_encrypt` and can generate an IV from a string using a hash algorithm. The hash is truncated to the desired length (for instance, md5 generates a 32 byte string which must be truncated to 16 bytes for the `AES-256-CTR` cipher).

Currently, Dolibarr uses `dol_trunc()` for this truncation, but `dol_trunc`'s behaviour can vary (for instance by configuring **`MAIN_DISABLE_TRUNC`**). When this conf is on, the generated IV can be too long. Since encryption is used on some confs and also on user API Keys, we have a situation where a warning is generated every time a user is fetched, which in turn inflates our error logs to unwieldy sizes.

## This PR

I think using a lower level function like `dol_substr()` would be preferable in this specific case to ensure the IV has the right length regardless of instance / user configuration.

## Suggestion

Maybe we could also truncate the IV in _dolDecrypt()_ so that wrongly generated IVs don't cause a warning when decrypting (but we could also argue that a warning is desired in that case because it indicates a data anomaly, so I leave it to your judgement).
