### PR TITLE
fixing the total ttc in the multicurrency section

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -2741,7 +2741,7 @@ if ($action == 'create' && $usercancreate) {
 		print '<td class="valuefield nowrap right amountcard">' . price($object->total_ttc, 1, '', 1, -1, -1, $conf->currency) . '</td>';
 		if (isModEnabled("multicurrency") && ($object->multicurrency_code && $object->multicurrency_code != $conf->currency)) {
 			// Multicurrency Amount TTC
-			print '<td class="valuefield nowrap right amountcard">' . price($object->total_ttc, 1, '', 1, -1, -1, $object->multicurrency_code) . '</td>';
+			print '<td class="valuefield nowrap right amountcard">' . price($object->multicurrency_total_ttc, 1, '', 1, -1, -1, $object->multicurrency_code) . '</td>';
 		}
 		print '</tr>';
 


### PR DESCRIPTION
fixing the total ttc in the multicurrency section, the problem was that the multicurrency total did not match the value calculation
![Capture d’écran du 2023-06-06 00-13-53](https://github.com/Dolibarr/dolibarr/assets/36703787/9ab98ea3-053e-4674-aafc-39072139001c)
