### PR TITLE
Fix query selector for array name

### DIFF
--- a/htdocs/core/js/lib_head.js.php
+++ b/htdocs/core/js/lib_head.js.php
@@ -1324,7 +1324,8 @@ $(document).on('select2:open', (e) => {
 	console.log("Execute the focus (click on combo or use space when on component");
 	const target = $(e.target);
 	if (target && target.length) {
-		const id = target[0].id || target[0].name;
+		let id = target[0].id || target[0].name;
+		if (id.substr(-2) == "[]") id = id.substr(0,id.length-2);
 		document.querySelector('input[aria-controls*='+id+']').focus();
 	}
 });


### PR DESCRIPTION
# FIX query selector when element name ends with '[]'
The project selector element in the Advanced Professional Gantt module (https://www.dolistore.com/en/modules/1897-Advanced-Professional-Gantt-Dolibarr.html) sets `name="search_projects[]"`, which breaks the querySelector in the hacky fix for a bug in select2.  This fixes the issue by removing the '[]' suffix if found.