### PR TITLE
[Agenda] Fix summary encoding of holidays events for the exports

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -2179,7 +2179,7 @@ class ActionComm extends CommonObject
 
 			if ($exportholiday == 1) {
 				$langs->load("holiday");
-				$title = $langs->trans("Holidays");
+				$title = $langs->transnoentities("Holidays");
 
 				$sql = "SELECT u.rowid as uid, u.lastname, u.firstname, u.email, u.statut, x.rowid, x.date_debut as date_start, x.date_fin as date_end, x.halfday, x.statut as status";
 				$sql .= " FROM ".MAIN_DB_PREFIX."holiday as x, ".MAIN_DB_PREFIX."user as u";


### PR DESCRIPTION
a small fix to not HTML encode the holidays' events summaries like this:

![image](https://github.com/Dolibarr/dolibarr/assets/26152831/50a16736-dc4b-46c7-b3fb-f288562409a4)

