### PR TITLE
Fix cstate class for use by custom modules

### DIFF
--- a/htdocs/core/class/cstate.class.php
+++ b/htdocs/core/class/cstate.class.php
@@ -292,4 +292,20 @@ class Cstate // extends CommonObject
 			return 1;
 		}
 	}
+
+	/**
+	 *  Return a link to the object card (with optionaly the picto)
+	 *
+	 *	@param	int		$withpicto					Include picto in link (0=No picto, 1=Include picto into link, 2=Only picto)
+	 *	@param	string	$option						On what the link point to ('nolink', ...)
+	 *  @param	int  	$notooltip					1=Disable tooltip
+	 *  @param  string  $morecss            		Add more css on link
+	 *  @param  int     $save_lastsearch_value    	-1=Auto, 0=No save of lastsearch_values when clicking, 1=Save lastsearch_values whenclicking
+	 *	@return	string								String with URL
+	 */
+	public function getNomUrl($withpicto = 0, $option = '', $notooltip = 0, $morecss = '', $save_lastsearch_value = -1)
+	{
+		global $langs;
+		return $langs->trans($this->name);
+	}
 }


### PR DESCRIPTION
# FIX Cstate class for use by custom modules
With Module Builder, the subclass of CommonObject has a `$fields` array property that is used to auto-generate fields on the card.  The following elements in `$fields` should create country and state selectors, but the state selector fails without this patch:

```
'country' => array('type'=>'integer:Ccountry:core/class/ccountry.class.php:0:((active:=:1))', 'label'=>'Country', 'enabled'=>'1', 'position'=>40, 'notnull'=>1, 'visible'=>1, 'css'=>'maxwidth500 widthcentpercentminusxx', 'csslist'=>'tdoverflowmax150', 'validate'=>'1',),
'state' => array('type'=>'integer:Cstate:core/class/cstate.class.php:0:((active:=:1))', 'label'=>'State/Prov', 'enabled'=>'1', 'position'=>41, 'notnull'=>-1, 'visible'=>1, 'css'=>'maxwidth500 widthcentpercentminusxx', 'csslist'=>'tdoverflowmax150', 'validate'=>'1',),
```