### PR TITLE
FIX CommonObject::getRights()

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8457,8 +8457,9 @@ abstract class CommonObject
 			$element = 'facture';
 		} elseif ($element == 'invoice_supplier_rec') {
 			return $user->rights->fournisseur->facture;
-		} elseif ($element == 'evaluation') {
-			return $user->rights->hrm->evaluation;
+		} elseif (!empty($user->rights->{$this->module}->{$element})) {
+			// for modules built with ModuleBuilder
+			return $user->rights->{$this->module}->{$element};
 		}
 
 		return $user->rights->{$element};


### PR DESCRIPTION
# FIX
Currently, the getRights() method of CommonObject doesn't return the rights of objects created using modulebuilder (including the `hrm` core module).
