### PR TITLE
FIX: Deadlock over llx_actioncomm

### DIFF
--- a/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
+++ b/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
@@ -461,7 +461,7 @@ ALTER TABLE llx_partnership ADD COLUMN email_partnership varchar(64) after fk_me
 
 ALTER TABLE llx_contratdet ADD INDEX idx_contratdet_statut (statut);
 
--- Drop the composite unique index that exists on `llx_actioncomm` to rebuild a new one without unique feature.
+-- Drop the composite unique index that exists on llx_actioncomm to rebuild a new one without unique feature.
 -- The old design introduced a deadlock over traffic intense Dolibarr instance.
 -- VMYSQL4.1 DROP INDEX uk_actioncomm_ref on llx_table;
 -- VPGSQL8.2 DROP INDEX uk_actioncomm_ref;

--- a/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
+++ b/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
@@ -460,3 +460,9 @@ insert into llx_c_invoice_subtype (entity, fk_country, code, label, active) VALU
 ALTER TABLE llx_partnership ADD COLUMN email_partnership varchar(64) after fk_member;
 
 ALTER TABLE llx_contratdet ADD INDEX idx_contratdet_statut (statut);
+
+-- Drop the composite unique index that exists on `llx_actioncomm` to rebuild a new one without unique feature.
+-- The old design introduced a deadlock over traffic intense Dolibarr instance.
+-- VMYSQL4.1 DROP INDEX uk_actioncomm_ref on llx_table;
+-- VPGSQL8.2 DROP INDEX uk_actioncomm_ref;
+ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_ref (ref, entity);

--- a/htdocs/install/mysql/tables/llx_actioncomm.key.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm.key.sql
@@ -29,4 +29,4 @@ ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_recurid (recurid);
 ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_ref_ext (ref_ext);
 ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_percent (percent);
 
-ALTER TABLE llx_actioncomm ADD INDEX uk_actioncomm_ref (ref, entity);
+ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_ref (ref, entity);

--- a/htdocs/install/mysql/tables/llx_actioncomm.key.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm.key.sql
@@ -29,4 +29,4 @@ ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_recurid (recurid);
 ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_ref_ext (ref_ext);
 ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_percent (percent);
 
-ALTER TABLE llx_actioncomm ADD UNIQUE INDEX uk_actioncomm_ref (ref, entity);
+ALTER TABLE llx_actioncomm ADD INDEX uk_actioncomm_ref (ref, entity);


### PR DESCRIPTION
The unique property of the index was useless anyway because the content of the ref column is the content of the id column which is guaranteed to be unique by the DBMS.

https://github.com/Dolibarr/dolibarr/blob/cc229d2530b9677b2c35f78b6b06f450794fbed7/htdocs/comm/action/class/actioncomm.class.php#L607