### PR TITLE
fix: VCARD RFC 6350 conformity

### DIFF
--- a/htdocs/core/class/vcard.class.php
+++ b/htdocs/core/class/vcard.class.php
@@ -266,7 +266,9 @@ class vCard
 	public function setEmail($address, $type = "")
 	{
 		$key = "EMAIL";
-		if ($type != "") {
+		if ($type == "PREF") {
+			$key .= ";PREF=1";
+		} elseif (!empty($type)) {
 			$key .= ";TYPE=".dol_strtolower($type);
 		}
 		$this->properties[$key] = $address;

--- a/htdocs/core/class/vcard.class.php
+++ b/htdocs/core/class/vcard.class.php
@@ -260,14 +260,14 @@ class vCard
 	 *	Add a e-mail address to this vCard
 	 *
 	 *	@param	string	$address		E-mail address
-	 *	@param	string	$type			(optional) The type of the e-mail (typical "PREF;INTERNET" or "INTERNET")
+	 *	@param	string	$type			(optional) The type of the e-mail (typical "PREF" or "INTERNET")
 	 *	@return	void
 	 */
 	public function setEmail($address, $type = "")
 	{
 		$key = "EMAIL";
 		if ($type != "") {
-			$key .= ";".$type;
+			$key .= ";TYPE=".dol_strtolower($type);
 		}
 		$this->properties[$key] = $address;
 	}


### PR DESCRIPTION
As in RFC 
https://www.rfc-editor.org/rfc/rfc6350#page-36

Email type : 
EMAIL;PREF=1 
or 
EMAIL;TYPE=xxx 

not 
EMAIL;XXXX:test@test.fr