### PR TITLE
Fix: remove unwanted var_dump()

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -7857,7 +7857,6 @@ function make_substitutions($text, $substitutionarray, $outputlangs = null, $con
 			} else {
 				if (! $msgishtml) {
 					$valueishtml = dol_textishtml($value, 1);
-					var_dump("valueishtml=".$valueishtml);
 
 					if ($valueishtml) {
 						$text = dol_htmlentitiesbr($text);


### PR DESCRIPTION
A var_dump() is appearing in public page of paiementok.php
![image](https://github.com/Dolibarr/dolibarr/assets/58433943/54165150-d9d8-4446-a430-285e70b9f40c)
