### PR TITLE
FIX: Bump length of llx_reception.ref_supplier to 255

### DIFF
--- a/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
+++ b/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
@@ -466,3 +466,7 @@ ALTER TABLE llx_contratdet ADD INDEX idx_contratdet_statut (statut);
 -- VMYSQL4.1 DROP INDEX uk_actioncomm_ref on llx_actioncomm;
 -- VPGSQL8.2 DROP INDEX uk_actioncomm_ref;
 ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_ref (ref, entity);
+
+-- Bump llx_reception.ref_supplier to allow up to 255 characters to match llx_commande_fournisseur.ref_supplier.
+-- See: https://github.com/Dolibarr/dolibarr/pull/25034
+ALTER TABLE llx_reception MODIFY COLUMN ref_supplier varchar(255);

--- a/htdocs/install/mysql/tables/llx_reception.sql
+++ b/htdocs/install/mysql/tables/llx_reception.sql
@@ -29,7 +29,7 @@ create table llx_reception
   fk_projet             integer  DEFAULT NULL,
   
   ref_ext               varchar(30),					-- reference into an external system (not used by dolibarr)
-  ref_supplier          varchar(128),					-- supplier number
+  ref_supplier          varchar(255),					-- supplier number
   
   date_creation         datetime,						-- date de creation
   fk_user_author        integer,						-- author of creation


### PR DESCRIPTION
- llx_commande_fournisseur.ref_supplier currently allows up to 255 characters. https://github.com/Dolibarr/dolibarr/blob/574c9c7ac6f929f17b0713effaf5cb46c3877a7f/htdocs/install/mysql/tables/llx_commande_fournisseur.sql#L30
- llx_reception.ref_supplier allow only 128 characters. https://github.com/Dolibarr/dolibarr/blob/574c9c7ac6f929f17b0713effaf5cb46c3877a7f/htdocs/install/mysql/tables/llx_reception.sql#L32

Therefore when creating a reception from a supplier order the creation may fails if the column content is > 128.

<img width="1010" alt="image" src="https://github.com/Dolibarr/dolibarr/assets/8199428/dca05952-302d-47f3-b809-3c8bcfa3f30b">
