### PR TITLE
FIX: ModuleBuilder admin setup numbering rules

### DIFF
--- a/htdocs/modulebuilder/template/admin/setup.php
+++ b/htdocs/modulebuilder/template/admin/setup.php
@@ -320,9 +320,6 @@ $myTmpObjects['myobject'] = array('label'=>'MyObject', 'includerefgeneration'=>0
 
 
 foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
-	if ($myTmpObjectKey != $type) {
-		continue;
-	}
 	if ($myTmpObjectArray['includerefgeneration']) {
 		/*
 		 * Orders Numbering model


### PR DESCRIPTION
This condition prevents the editing of numbering rules if the object name was not 'myobject'. (Which is never the case)

See: https://github.com/Dolibarr/dolibarr/blob/21cfecd6088edb2cafc914de8782b7db4cabe816/htdocs/modulebuilder/template/admin/setup.php#L79