### PR TITLE
Fix #23740 ticket stats can't show amounts

### DIFF
--- a/htdocs/ticket/stats/index.php
+++ b/htdocs/ticket/stats/index.php
@@ -118,7 +118,7 @@ $data = $stats->getAmountByMonthWithPrevYear($endyear, $startyear);
 //var_dump($data);
 // $data = array(array('Lib',val1,val2,val3),...)
 
-if (empty($user->rights->societe->client->voir) || $user->socid) {
+/*if (empty($user->rights->societe->client->voir) || $user->socid) {
 	$filenameamount = $dir.'/ticketsamountinyear-'.$user->id.'-'.$year.'.png';
 	$fileurlamount = DOL_URL_ROOT.'/viewimage.php?modulepart=ticketstats&file=ticketsamountinyear-'.$user->id.'-'.$year.'.png';
 } else {
@@ -181,7 +181,7 @@ if (!$mesg) {
 	$px3->SetTitle($langs->trans("AmountAverage"));
 
 	$px3->draw($filename_avg, $fileurl_avg);
-}
+}*/
 
 
 


### PR DESCRIPTION
Even if the 2 graphs are not displayed, data for the graphs were retrieved and causing a SQL error with PGSQL, trying to sum the column "timing" which is not a numerci value...