### PR TITLE
FIX : Add hidden conf to add extrafields in canelle template : INVOICE_ADD_EXTRAFIELD_IN_NOTE

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@ English Dolibarr ChangeLog
 --------------------------------------------------------------
 
 ***** ChangeLog for 17.0.2 compared to 17.0.1 *****
-
+FIX : Add hidden conf to add extrafields in canelle template : INVOICE_ADD_EXTRAFIELD_IN_NOTE
 FIX: #24414
 FIX: #24798 Deleting member subscription is not possible
 FIX: add a test for updating date on task update in tab time consummed pro…

--- a/htdocs/core/modules/supplier_invoice/doc/pdf_canelle.modules.php
+++ b/htdocs/core/modules/supplier_invoice/doc/pdf_canelle.modules.php
@@ -370,6 +370,14 @@ class pdf_canelle extends ModelePDFSuppliersInvoices
 				// Displays notes
 				$notetoshow = empty($object->note_public) ? '' : $object->note_public;
 
+				// Extrafields in note
+				if (!empty($conf->global->INVOICE_ADD_EXTRAFIELD_IN_NOTE)) {
+					$extranote = $this->getExtrafieldsInHtml($object, $outputlangs);
+					if (!empty($extranote)) {
+						$notetoshow = dol_concatdesc($notetoshow, $extranote);
+					}
+				}
+
 				if ($notetoshow) {
 					$tab_top -= 2;
 


### PR DESCRIPTION
# FIX|
Add hidden conf to add extrafields in canelle template : INVOICE_ADD_EXTRAFIELD_IN_NOTE
