### PR TITLE
Fix the function fill_substitutionarray_with_extrafields when the type is datetime

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -979,7 +979,7 @@ abstract class CommonDocGenerator
 					}
 					$array_to_fill = array_merge($array_to_fill, array($array_key.'_options_'.$key.'_locale' => $object->array_options['options_'.$key.'_locale']));
 					$array_to_fill = array_merge($array_to_fill, array($array_key.'_options_'.$key.'_rfc' => $object->array_options['options_'.$key.'_rfc']));
-				} elseif ($extrafields->attributes[$object->table_element]['label'][$key] == 'datetime') {
+				} elseif ($extrafields->attributes[$object->table_element]['type'][$key] == 'datetime') {
 					$datetime = $object->array_options['options_'.$key];
 					$object->array_options['options_'.$key] = ($datetime != "0000-00-00 00:00:00" ?dol_print_date($object->array_options['options_'.$key], 'dayhour') : ''); // using company output language
 					$object->array_options['options_'.$key.'_locale'] = ($datetime != "0000-00-00 00:00:00" ?dol_print_date($object->array_options['options_'.$key], 'dayhour', 'tzserver', $outputlangs) : ''); // using output language format


### PR DESCRIPTION
# Fix
Fix the function fill_substitutionarray_with_extrafields where "label" was used instead of "type" which caused "datetime" type to not work correctly