### PR TITLE
FIX Update fk_user_assign in DB during new ticket creation [23838]

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -500,8 +500,13 @@ class Ticket extends CommonObject
 				if ($this->add_contact($this->fk_user_assign, 'SUPPORTTEC', 'internal') < 0) {
 					$error++;
 				}
-			}
+				$ret = $this->assignUser($user, $this->fk_user_assign);
+				if ($ret < 0) {
+					$error ++;
+				setEventMessages($this->error, $this->errors, 'errors');
+				}
 
+			}
 
 			//Update extrafield
 			if (!$error) {


### PR DESCRIPTION


# FIX|Fix #[23838]
New ticket creation form
execute assignuser when a new ticket is created in order to update the row in the db with fk_user_assign value. This is missing today when you assign an user directly during ticket form creation. Works already well when ticket is already existing.
