### PR TITLE
Fix : bug with object id -1 in security check

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -353,6 +353,9 @@ function restrictedArea(User $user, $features, $object = 0, $tableandshare = '',
 	} else {
 		$objectid = $object;		// $objectid can be X or 'X,Y,Z'
 	}
+	if ($objectid == "-1") {
+		$objectid = 0;
+	}
 	if ($objectid) {
 		$objectid = preg_replace('/[^0-9\.\,]/', '', $objectid);	// For the case value is coming from a non sanitized user input
 	}


### PR DESCRIPTION
Fix a bug where if a user select nothing in a selectbox (value = -1) then on security check we verify on object rowid = 1
So if there is no product with rowid = 1 then we restrict area to user