### PR TITLE
FIX_23838 launch Trigger TICKET_ASSIGNED when an user is assigned on Ticket creation form

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -500,6 +500,14 @@ class Ticket extends CommonObject
 				if ($this->add_contact($this->fk_user_assign, 'SUPPORTTEC', 'internal') < 0) {
 					$error++;
 				}
+				if (!$error && !$notrigger) {
+					// Call trigger
+					$result = $this->call_trigger('TICKET_ASSIGNED', $user);
+					if ($result < 0) {
+						$error++;
+					}
+				}
+					// End call triggers
 			}
 
 


### PR DESCRIPTION

# FIX|23838_trigger TICKET_ASSIGNED not executed during function create ticket
[*Long description*]
Currently, if you assign an user on ticket creation form, the trigger TICKET_ASSIGNED is not executed.
This trigger occurs only when an user is assigned on an existing ticket.

Replace the pull request 25097to execute function assign_user which update DB fk_user_assign and execute trigger. no DB update needed, fk_user_assign is already filled by function create

