### PR TITLE
Fix #25150 : add trans for api permission

### DIFF
--- a/htdocs/core/modules/modApi.class.php
+++ b/htdocs/core/modules/modApi.class.php
@@ -141,7 +141,7 @@ class modApi extends DolibarrModules
 		// Add here list of permission defined by an id, a label, a boolean and two constant strings.
 		// Example:
 		$this->rights[$r][0] = $this->numero + $r;	// Permission id (must not be already used)
-		$this->rights[$r][1] = 'Générer / modifier la clé API des utilisateurs';	// Permission label
+		$this->rights[$r][1] = 'Generate/modify users API key';	// Permission label
 		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'apikey';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = 'generate';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -974,6 +974,7 @@ Permission2501=Read/Download documents
 Permission2502=Download documents
 Permission2503=Submit or delete documents
 Permission2515=Setup documents directories
+Permission2610=Generate/modify users API key
 Permission2801=Use FTP client in read mode (browse and download only)
 Permission2802=Use FTP client in write mode (delete or upload files)
 Permission3200=Read archived events and fingerprints


### PR DESCRIPTION
Fix wrong api label for api permission because of missing trans code