### PR TITLE
[Agenda] change date time zone for full day event

### DIFF
--- a/htdocs/core/lib/xcal.lib.php
+++ b/htdocs/core/lib/xcal.lib.php
@@ -203,9 +203,9 @@ function build_calfile($format, $title, $desc, $events_array, $outputfile)
 				$startdatef = dol_print_date($startdate, "dayhourxcard", 'gmt');
 
 				if ($fulldayevent) {
-					// Local time
+					// Local time should be used to prevent users in time zones earlier than GMT from being one day earlier
 					$prefix     = ";VALUE=DATE";
-					$startdatef = dol_print_date($startdate, "dayxcard", 'gmt');
+					$startdatef = dol_print_date($startdate, "dayxcard", 'tzserver');
 				}
 
 				fwrite($calfileh, "DTSTART".$prefix.":".$startdatef."\n");
@@ -232,7 +232,7 @@ function build_calfile($format, $title, $desc, $events_array, $outputfile)
 					// We add 1 second so we reach the +1 day needed for full day event (DTEND must be next day after event)
 					// This is mention in https://datatracker.ietf.org/doc/html/rfc5545:
 					// "The "DTEND" property for a "VEVENT" calendar component specifies the non-inclusive end of the event."
-					$enddatef = dol_print_date($enddate + 1, "dayxcard", 'gmt');
+					$enddatef = dol_print_date($enddate + 1, "dayxcard", 'tzserver');
 				}
 
 				fwrite($calfileh, "DTEND".$prefix.":".$enddatef."\n");


### PR DESCRIPTION
Because the start date used for a full day event in `htdocs/comm/action/class/actioncomm.class.php` use the local time zone, it's mandatory to keep the same time zone to prevent who are in time zones earlier than GMT to have events a day ealier.

For example for a dolibarr in Europe/Paris time zone (UTC +2), the `date_start` of the event will be `2023-06-22 00:00:00` in their time zone, but when building the ICAL file, it will be converted to GMT and will become `2023-06-21 22:00:00`, then will be formatted in ICAL format to `20230621`