### PR TITLE
FIX: case special char for password in email admin page

### DIFF
--- a/htdocs/admin/mails.php
+++ b/htdocs/admin/mails.php
@@ -420,11 +420,11 @@ if ($action == 'edit') {
 		print '</td><td>';
 		// SuperAdministrator access only
 		if (empty($conf->multicompany->enabled) || ($user->admin && !$user->entity)) {
-			print '<input class="flat" type="password" name="MAIN_MAIL_SMTPS_PW" size="32" value="'.$mainsmtppw.'" autocomplete="off">';
+			print '<input class="flat" type="password" name="MAIN_MAIL_SMTPS_PW" size="32" value="' . htmlspecialchars($mainsmtppw) . '" autocomplete="off">';
 		} else {
 			$htmltext = $langs->trans("ContactSuperAdminForChange");
 			print $form->textwithpicto($conf->global->MAIN_MAIL_SMTPS_PW, $htmltext, 1, 'superadmin');
-			print '<input type="hidden" name="MAIN_MAIL_SMTPS_PW" value="'.$mainsmtppw.'">';
+			print '<input type="hidden" name="MAIN_MAIL_SMTPS_PW" value="' . htmlspecialchars($mainsmtppw) . '">';
 		}
 		print '</td></tr>';
 	}


### PR DESCRIPTION
I have a problem with my email password, in admin email page. 
Indeed my email password contain a " char so when form is modified 

```php
<input class="flat" type="password" name="MAIN_MAIL_SMTPS_PW" size="32" value="' . $mainsmtppw . '" autocomplete="off">
```
This input only displays my password until it finds char / "/, invalidating my email configuration when I save the form again.


