### PR TITLE
NEW  #25188 :  Add a status shipment in process

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -370,7 +370,11 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 				$diff_array = array_diff_assoc($qtyordred, $qtyshipped);
 				if (count($diff_array) == 0) {
 					//No diff => mean everythings is shipped
-					$ret = $order->setStatut(Commande::STATUS_CLOSED, $object->origin_id, $object->origin, 'ORDER_CLOSE');
+					if ($action == 'SHIPPING_VALIDATE') {
+						$ret = $order->setStatut(Commande::STATUS_SHIPMENTONPROCESS, $object->origin_id, $object->origin, 'ORDER_MODIFY');
+					} else { // $action == 'SHIPPING_CLOSED'
+						$ret = $order->setStatut(Commande::STATUS_CLOSED, $object->origin_id, $object->origin, 'ORDER_CLOSE');
+					}
 					if ($ret < 0) {
 						$this->error = $order->error;
 						$this->errors = $order->errors;


### PR DESCRIPTION
Actually, when an expedition is Validated, the linked order is closed (marked as delivered) instead of being marked as SHIPMENTONPROCESS