### PR TITLE
Fix add a translation override with PostgreSQL

### DIFF
--- a/htdocs/admin/translation.php
+++ b/htdocs/admin/translation.php
@@ -116,7 +116,7 @@ if ($action == 'update') {
 
 		$sql = "UPDATE ".MAIN_DB_PREFIX."overwrite_trans set transkey = '".$db->escape($transkey)."', transvalue = '".$db->escape($transvalue)."' WHERE rowid = ".((int) GETPOST('rowid', 'int'));
 		$result = $db->query($sql);
-		if ($result > 0) {
+		if ($result) {
 			$db->commit();
 			setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
 			$action = "";


### PR DESCRIPTION
When you try to add a translation override, after a submission, nothing is modified.

Database : PostgreSQL