### PR TITLE
fix tooltip in element project

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -733,12 +733,12 @@ foreach ($listofreferent as $key => $value) {
 	}
 	$name = $langs->trans($value['name']);
 	$qualified = $value['test'];
-	$margin = empty($value['margin']) ? 0 : $value['margin'];
+	$margin = empty($value['margin']) ? '' : $value['margin'];
 	if ($qualified && isset($margin)) {		// If this element must be included into profit calculation ($margin is 'minus' or 'add')
-		if ($margin == 'add') {
+		if ($margin === 'add') {
 			$tooltiponprofitplus .= ' &gt; '.$name." (+)<br>\n";
 		}
-		if ($margin == 'minus') {
+		if ($margin === 'minus') {
 			$tooltiponprofitminus .= ' &gt; '.$name." (-)<br>\n";
 		}
 	}


### PR DESCRIPTION
if $margin = 0 then $margin == 'add' is true
do not compare int with string

![image](https://github.com/Dolibarr/dolibarr/assets/3624836/292a7121-0510-4a58-9163-b2a3dc3f81a5)

AFTER

![image](https://github.com/Dolibarr/dolibarr/assets/3624836/04135092-42e8-4cef-8322-339efa4dc5cf)

