### PR TITLE
FIX: missing nbfield++ on some columns

### DIFF
--- a/htdocs/expedition/list.php
+++ b/htdocs/expedition/list.php
@@ -1023,6 +1023,9 @@ while ($i < min($num, $limit)) {
 			print '<td class="center">';
 			print dol_print_date($db->jdate($obj->delivery_date), "dayhour");
 			print "</td>\n";
+			if (!$i) {
+				$totalarray['nbfield']++;
+			}
 		}
 		if (!empty($arrayfields['e.fk_shipping_method']['checked'])) {
 			// Get code using getLabelFromKey
@@ -1030,6 +1033,9 @@ while ($i < min($num, $limit)) {
 			print '<td class="center tdoverflowmax150" title="'.dol_escape_htmltag($langs->trans("SendingMethod".strtoupper($code))).'">';
 			if ($shipment->shipping_method_id > 0) print $langs->trans("SendingMethod".strtoupper($code));
 			print '</td>';
+			if (!$i) {
+				$totalarray['nbfield']++;
+			}
 		}
 		// Tracking number
 		if (!empty($arrayfields['e.tracking_number']['checked'])) {


### PR DESCRIPTION
In expedition/list.php, $totalarray['nbfield'] is not always incremented, creating a shift when using the printFieldListFooter hook to add a total line.