### PR TITLE
Fix : payment card delete button

### DIFF
--- a/htdocs/don/payment/card.php
+++ b/htdocs/don/payment/card.php
@@ -216,7 +216,7 @@ if (empty($action)) {
 		if (!$disable_delete) {
 			print dolGetButtonAction($langs->trans('Delete'), '', 'delete', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=delete&token='.newToken(), '', 1);
 		} else {
-			print dolGetButtonAction($langs->trans("CantRemovePaymentWithOneInvoicePaid"), $langs->trans('Delete'), 'delete', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=delete&token='.newToken(), '', 1);
+			print dolGetButtonAction($langs->trans("CantRemovePaymentWithOneInvoicePaid"), $langs->trans('Delete'), '', $_SERVER["PHP_SELF"].'?id='.$object->id.'#', '', 1, [ 'attr' => ['classOverride' => 'butActionRefused']]);
 		}
 	}
 }


### PR DESCRIPTION
Fix a behavior on htdocs/don/payment/card.php.

The button delete was still clickable when a payment was liked to a payed invoice.