### PR TITLE
float casting empty value

### DIFF
--- a/htdocs/core/triggers/interface_50_modBlockedlog_ActionsBlockedLog.class.php
+++ b/htdocs/core/triggers/interface_50_modBlockedlog_ActionsBlockedLog.class.php
@@ -119,7 +119,7 @@ class InterfaceActionsBlockedLog extends DolibarrTriggers
 			$amounts = 0;
 			if (!empty($object->amounts)) {
 				foreach ($object->amounts as $amount) {
-					$amounts += floatval(price2num($amount));
+					$amounts += (double) $amount;
 				}
 			} elseif (!empty($object->amount)) {
 				$amounts = $object->amount;

--- a/htdocs/core/triggers/interface_50_modBlockedlog_ActionsBlockedLog.class.php
+++ b/htdocs/core/triggers/interface_50_modBlockedlog_ActionsBlockedLog.class.php
@@ -119,7 +119,7 @@ class InterfaceActionsBlockedLog extends DolibarrTriggers
 			$amounts = 0;
 			if (!empty($object->amounts)) {
 				foreach ($object->amounts as $amount) {
-					$amounts += price2num($amount);
+					$amounts += floatval(price2num($amount));
 				}
 			} elseif (!empty($object->amount)) {
 				$amounts = $object->amount;


### PR DESCRIPTION
# FIX price2num bad return
Fix case when price2num return an empty string => php8.2 through a fatal error when adding a string to an int

