### PR TITLE
FIX: VTA rounding calc option must be the same on update line as on create line

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -955,7 +955,7 @@ class Propal extends CommonObject
 					$this->line_order(true, 'DESC');
 				}
 
-				$this->update_price(1);
+				$this->update_price(1, 'auto');
 
 				$this->fk_propal = $this->id;
 				$this->rowid = $rowid;

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3313,7 +3313,7 @@ class Commande extends CommonOrder
 				}
 
 				// Mise a jour info denormalisees
-				$this->update_price(1);
+				$this->update_price(1, 'auto');
 
 				$this->db->commit();
 				return $result;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4083,7 +4083,7 @@ class Facture extends CommonInvoice
 				}
 
 				// Mise a jour info denormalisees au niveau facture
-				$this->update_price(1);
+				$this->update_price(1, 'auto');
 				$this->db->commit();
 				return $result;
 			} else {


### PR DESCRIPTION
On addline method the ronding method is set to auto, so on updateline it must be the same.

I have a case where
(PU HT = 24 €) X (Qty = 3) = 72 € - (Discount 16.66% = 11.9952 €) = 60,0048

VAT 5.5 of 60,0048 € = 3,300264 € => TOTAL VTA : rounding to 2 decimal 3.31 €
But
TOTAL HT = 60.00 €  => VTA 5.5 of 60.00 € = TOTAL VTA 3.30 €

OK, MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND is here for this case

it work nice on addline 
but If I click on update line to change the description and Save => the rule of MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND is not apply any more 
=> my VAT is back to 3.31 €
