### PR TITLE
FIX|Fix dispatch correct status by ignoring lines with specific product type 9 

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -358,7 +358,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 				if (is_array($order->lines) && count($order->lines) > 0) {
 					foreach ($order->lines as $orderline) {
 						// Exclude lines not qualified for shipment, similar code is found into calcAndSetStatusDispatch() for vendors
-						if (empty($conf->global->STOCK_SUPPORTS_SERVICES) && $orderline->product_type > 0) {
+						if ((empty($conf->global->STOCK_SUPPORTS_SERVICES) && $orderline->product_type > 0) || $orderline->product_type == 9) {
 							continue;
 						}
 						$qtyordred[$orderline->fk_product] += $orderline->qty;
@@ -427,7 +427,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 				if (is_array($order->lines) && count($order->lines) > 0) {
 					foreach ($order->lines as $orderline) {
 						// Exclude lines not qualified for shipment, similar code is found into calcAndSetStatusDispatch() for vendors
-						if (empty($conf->global->STOCK_SUPPORTS_SERVICES) && $orderline->product_type > 0) {
+						if ((empty($conf->global->STOCK_SUPPORTS_SERVICES) && $orderline->product_type > 0)  || $orderline->product_type == 9) {
 							continue;
 						}
 						$qtyordred[$orderline->fk_product] += $orderline->qty;

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3405,7 +3405,7 @@ class CommandeFournisseur extends CommonOrder
 					}
 					foreach ($this->lines as $line) {
 						// Exclude lines not qualified for shipment, similar code is found into interface_20_modWrokflow for customers
-						if (empty($conf->global->STOCK_SUPPORTS_SERVICES) && $line->product_type > 0) {
+						if ((empty($conf->global->STOCK_SUPPORTS_SERVICES) && $line->product_type > 0) || $line->product_type == 9) {
 							continue;
 						}
 						$qtywished[$line->fk_product] += $line->qty;

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -761,7 +761,7 @@ class Reception extends CommonObject
 				// qty wished in order supplier (origin)
 				foreach ($this->commandeFournisseur->lines as $origin_line) {
 					// exclude lines not qualified for reception
-					if (empty($conf->global->STOCK_SUPPORTS_SERVICES) && $origin_line->product_type > 0) {
+					if ((empty($conf->global->STOCK_SUPPORTS_SERVICES) && $origin_line->product_type > 0)|| $origin_line->product_type == 9) {
 						continue;
 					}
 


### PR DESCRIPTION
Ignoring lines with specific product type 9 to calculate differences, remaining quantities and dispatch the correct status for orders
To reproduce :
Make a supplier order with lines of text from the subtotal module. Create a receipt with all quantities received, the order changes to 'partially received' status instead of 'fully received'.
The quantity of 50 of the text line is taken into account to calculate if there are still products to be received