### PR TITLE
Fix #25260 VAT tax_mode in settings always shows first option 

### DIFF
--- a/htdocs/admin/taxes.php
+++ b/htdocs/admin/taxes.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2005-2009  Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2011-2013  Juanjo Menent           <jmenent@2byte.es>
  * Copyright (C) 2015-2022  Alexandre Spangaro		<aspangaro@open-dsi.fr>
+ * Copyright (C) 2023  		Joachim Kueter			<git-jk@bloxera.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,25 +48,30 @@ $action = GETPOST('action', 'aZ09');
  * Actions
  */
 
-// 0=normal, 1=option vat for services is on debit
+// 0=normal, 1=option vat for services is on debit, 2=option vat for product and service on credit
 
-// TAX_MODE=0 (most cases):
+// TAX_MODE=0 (most cases in FR):
 //              Buy                     Sell
 // Product      On delivery             On delivery
 // Service      On payment              On payment
 
-// TAX_MODE=1 (option):
+// TAX_MODE=1 (option, VAT is due at invoice date):
 //              Buy                     Sell
-// Product      On delivery             On delivery
+// Product      On delivery/invoice     On delivery/invoice
 // Service      On invoice              On invoice
 
-$tax_mode = getDolGlobalString('TAX_MODE') ? 0 : getDolGlobalInt('TAX_MODE');
+// TAX_MODE=2 (option, VAT is due on payment date):
+//              Buy                     Sell
+// Product      On payment              On payment
+// Service      On payment              On payment
+
+$tax_mode = getDolGlobalInt('TAX_MODE');
 
 if ($action == 'update') {
 	$error = 0;
 
 	// Tax mode
-	$tax_mode = GETPOST('tax_mode', 'alpha');
+	$tax_mode = GETPOST('tax_mode', 'int');
 
 	$db->begin();
 


### PR DESCRIPTION
VAT $tax_mode in settings always showed first option after changing, storing and reloading

