### PR TITLE
fix: in BOM we don't have standard PDF model, if not set in config should not generate

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1269,7 +1269,7 @@ class BOM extends CommonObject
 		$outputlangs->load("products");
 
 		if (!dol_strlen($modele)) {
-			$modele = 'standard';
+			$modele = '';
 
 			if ($this->model_pdf) {
 				$modele = $this->model_pdf;
@@ -1279,8 +1279,11 @@ class BOM extends CommonObject
 		}
 
 		$modelpath = "core/modules/bom/doc/";
-
-		return $this->commonGenerateDocument($modelpath, $modele, $outputlangs, $hidedetails, $hidedesc, $hideref, $moreparams);
+		if (!empty($modele)) {
+			return $this->commonGenerateDocument($modelpath, $modele, $outputlangs, $hidedetails, $hidedesc, $hideref, $moreparams);
+		} else {
+			return 0;
+		}
 	}
 
 	/**


### PR DESCRIPTION
By default in BOM setup 
![image](https://github.com/Dolibarr/dolibarr/assets/1050053/8ab479a2-4c5d-49ee-b146-6c6602e9a367)


But If you switch state of ODT model to "ON" and OFF, the default checkbox is unset at the same time,

![image](https://github.com/Dolibarr/dolibarr/assets/1050053/396b6094-e4da-4768-92ec-e7ba52ad2396)

 then when validate a BOM 
![image](https://github.com/Dolibarr/dolibarr/assets/1050053/a4fcebe0-69d3-4067-842f-9e7c00527f2c)
