### PR TITLE
Fix #25250 : Wrong class name in function

### DIFF
--- a/htdocs/reception/class/api_receptions.class.php
+++ b/htdocs/reception/class/api_receptions.class.php
@@ -709,7 +709,7 @@ class Receptions extends DolibarrApi
 	private function _validate($data)
 	{
 		$reception = array();
-		foreach (Shipments::$FIELDS as $field) {
+		foreach (Receptions::$FIELDS as $field) {
 			if (!isset($data[$field])) {
 				throw new RestException(400, "$field field missing");
 			}


### PR DESCRIPTION
fix bad class name in api function that results on a fatal error