### PR TITLE
fix #25275: tms default timestamp

### DIFF
--- a/htdocs/install/mysql/migration/16.0.0-17.0.0.sql
+++ b/htdocs/install/mysql/migration/16.0.0-17.0.0.sql
@@ -33,6 +33,9 @@
 
 
 -- Missing in v16 or lower
+
+ALTER TABLE llx_emailcollector_emailcollector CHANGE COLUMN tms tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
 ALTER TABLE llx_accounting_account DROP FOREIGN KEY fk_accounting_account_fk_pcg_version;
 ALTER TABLE llx_accounting_system MODIFY COLUMN pcg_version varchar(32) NOT NULL;
 ALTER TABLE llx_accounting_account ADD CONSTRAINT fk_accounting_account_fk_pcg_version FOREIGN KEY (fk_pcg_version) REFERENCES llx_accounting_system (pcg_version);


### PR DESCRIPTION
Add default timestamp to dolibarr 17.0 for people coming from 16.0