### PR TITLE
fix #25275: tms default timestamp

### DIFF
--- a/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
+++ b/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
@@ -34,6 +34,8 @@
 
 -- v17
 
+ALTER TABLE llx_emailcollector_emailcollector CHANGE COLUMN tms tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
 -- VMYSQL4.3 ALTER TABLE llx_hrm_skillrank CHANGE COLUMN `rank` rankorder integer;
 -- VPGSQL8.2 ALTER TABLE llx_hrm_skillrank CHANGE COLUMN rank rankorder integer;
 


### PR DESCRIPTION
Add default timestamp to dolibarr 18.0 for people coming from 17.0