### PR TITLE
fix: Unknown column 'fk_projet' in 'field list' when trying to link...

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -1923,7 +1923,7 @@ class Project extends CommonObject
 		if ($tableName == "actioncomm") {
 			$sql .= " SET fk_project=".$this->id;
 			$sql .= " WHERE id=".((int) $elementSelectId);
-		} elseif ($tableName == "entrepot") {
+		} elseif (in_array($tableName, ["entrepot","mrp_mo"])) {
 			$sql .= " SET fk_project=".$this->id;
 			$sql .= " WHERE rowid=".((int) $elementSelectId);
 		} else {


### PR DESCRIPTION
# FIX Unknown column 'fk_projet' in 'field list'
When trying to link "List of manufacturing orders related to the project", `projet/class/project.class.php` tries to update the `fk_projet` column, which doesn't exist.  The correct name is `fk_project`.