### PR TITLE
Fix Project stock movements only displayed one way

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -792,7 +792,11 @@ class Project extends CommonObject
 		} elseif ($type == 'element_time') {	// Case we want to duplicate line foreach user
 			$sql = "SELECT DISTINCT pt.rowid, ptt.fk_user FROM ".MAIN_DB_PREFIX."projet_task as pt, ".MAIN_DB_PREFIX."element_time as ptt WHERE pt.rowid = ptt.fk_element AND ptt.elementtype = 'task' AND pt.fk_projet IN (".$this->db->sanitize($ids).")";
 		} elseif ($type == 'stock_mouvement') {
-			$sql = "SELECT ms.rowid, ms.fk_user_author as fk_user FROM ".MAIN_DB_PREFIX."stock_mouvement as ms, ".MAIN_DB_PREFIX."entrepot as e WHERE e.rowid = ms.fk_entrepot AND e.entity IN (".getEntity('stock').") AND ms.origintype = 'project' AND ms.fk_origin IN (".$this->db->sanitize($ids).") AND ms.type_mouvement = 1";
+			if (!empty($conf->global->PROJECT_ALLOW_NEGATIVE_STOCK_MVT)) {
+				$sql = "SELECT ms.rowid, ms.fk_user_author as fk_user FROM ".MAIN_DB_PREFIX."stock_mouvement as ms, ".MAIN_DB_PREFIX."entrepot as e WHERE e.rowid = ms.fk_entrepot AND e.entity IN (".getEntity('stock').") AND ((ms.origintype = 'project' AND ms.fk_origin IN ({$parameters['ids']})) OR ms.fk_projet in ({$parameters['ids']})) ";
+			} else {
+				$sql = "SELECT ms.rowid, ms.fk_user_author as fk_user FROM ".MAIN_DB_PREFIX."stock_mouvement as ms, ".MAIN_DB_PREFIX."entrepot as e WHERE e.rowid = ms.fk_entrepot AND e.entity IN (".getEntity('stock').") AND ((ms.origintype = 'project' AND ms.fk_origin IN ({$parameters['ids']})) OR ms.fk_projet in ({$parameters['ids']})) AND ms.type_mouvement = 1";
+			}
 		} elseif ($type == 'loan') {
 			$sql = "SELECT l.rowid, l.fk_user_author as fk_user FROM ".MAIN_DB_PREFIX."loan as l WHERE l.entity IN (".getEntity('loan').") AND l.fk_projet IN (".$this->db->sanitize($ids).")";
 		} else {

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -851,7 +851,11 @@ foreach ($listofreferent as $key => $value) {
 				} elseif ($tablename == 'fichinter') {
 					$total_ht_by_line = $element->getAmount();
 				} elseif ($tablename == 'stock_mouvement') {
-					$total_ht_by_line = $element->price * abs($element->qty);
+					if (!empty($conf->global->PROJECT_ALLOW_NEGATIVE_STOCK_MVT)) {
+						$total_ht_by_line = $element->price * $element->qty;
+					} else {
+						$total_ht_by_line = $element->price * abs($element->qty);
+					}
 				} elseif ($tablename == 'projet_task') {
 					if ($idofelementuser) {
 						$tmp = $element->getSumOfAmount($elementuser, $dates, $datee);
@@ -893,7 +897,11 @@ foreach ($listofreferent as $key => $value) {
 				} elseif ($tablename == 'fichinter') {
 					$total_ttc_by_line = $element->getAmount();
 				} elseif ($tablename == 'stock_mouvement') {
-					$total_ttc_by_line = $element->price * abs($element->qty);
+					if (!empty($conf->global->PROJECT_ALLOW_NEGATIVE_STOCK_MVT)) {
+						$total_ttc_by_line = $element->price * $element->qty;
+					} else {
+						$total_ttc_by_line = $element->price * abs($element->qty);
+					}
 				} elseif ($tablename == 'projet_task') {
 					$defaultvat = get_default_tva($mysoc, $mysoc);
 					$total_ttc_by_line = price2num($total_ht_by_line * (1 + ($defaultvat / 100)), 'MT');
@@ -1395,7 +1403,11 @@ foreach ($listofreferent as $key => $value) {
 					} elseif ($tablename == 'fichinter') {
 						$total_ht_by_line = $element->getAmount();
 					} elseif ($tablename == 'stock_mouvement') {
-						$total_ht_by_line = $element->price * abs($element->qty);
+						if (!empty($conf->global->PROJECT_ALLOW_NEGATIVE_STOCK_MVT)) {
+							$total_ht_by_line = $element->price * $element->qty;
+						} else {
+							$total_ht_by_line = $element->price * abs($element->qty);
+						}
 					} elseif (in_array($tablename, array('projet_task'))) {
 						if (isModEnabled('salaries')) {
 							// TODO Permission to read daily rate to show value
@@ -1449,7 +1461,11 @@ foreach ($listofreferent as $key => $value) {
 					} elseif ($tablename == 'fichinter') {
 						$total_ttc_by_line = $element->getAmount();
 					} elseif ($tablename == 'stock_mouvement') {
-						$total_ttc_by_line = $element->price * abs($element->qty);
+						if (!empty($conf->global->PROJECT_ALLOW_NEGATIVE_STOCK_MVT)) {
+							$total_ttc_by_line = $element->price * $element->qty;
+						} else {
+							$total_ttc_by_line = $element->price * abs($element->qty);
+						}
 					} elseif ($tablename == 'projet_task') {
 						if (isModEnabled('salaries')) {
 							// TODO Permission to read daily rate


### PR DESCRIPTION
Fix #20010 
And fix another thing : stock mouvements can now directly be attached to a project with fk_project (instead of origin_type and fk_origin)

Add a new conf constant PROJECT_ALLOW_NEGATIVE_STOCK_MVT