### PR TITLE
FIX: project status bug when PROJECT_CREATE_NO_DRAFT is set

### DIFF
--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -191,7 +191,7 @@ if (empty($reshook)) {
 		}
 
 		// Create with status validated immediatly
-		if (!empty($conf->global->PROJECT_CREATE_NO_DRAFT)) {
+		if (!empty($conf->global->PROJECT_CREATE_NO_DRAFT) && !$error) {
 			$status = Project::STATUS_VALIDATED;
 		}
 


### PR DESCRIPTION
When PROJECT_CREATE_NO_DRAFT is set and form has errors, page refreshes with status Open. 