### PR TITLE
FIX dol_print_error parameters on ticket fetch method

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -557,7 +557,7 @@ class Ticket extends CommonObject
 		// Check parameters
 		if (empty($id) && empty($ref) && empty($track_id) && empty($email_msgid)) {
 			$this->error = 'ErrorWrongParameters';
-			dol_print_error(get_class($this)."::fetch ".$this->error);
+			dol_print_error('', get_class($this)."::fetch ".$this->error);
 			return -1;
 		}
 


### PR DESCRIPTION
FIX dol_print_error parameters on ticket fetch method
- dol_print_error() method need db handler in first parameter
- keep first parameter empty : it's not concern SQL error
