### PR TITLE
FIX to avoid wrong path of file

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -808,7 +808,7 @@ class FormMail extends Form
 							$relativepathtofile = substr($val, (strlen(DOL_DATA_ROOT) - strlen($val)));
 
 							if ($conf->entity > 1) {
-								$relativepathtofile = str_replace($conf->entity.'/', '', $relativepathtofile);
+								$relativepathtofile = str_replace('/'.$conf->entity.'/', '/', $relativepathtofile);
 							}
 							// Try to extract data from full path
 							$formfile_params = array();


### PR DESCRIPTION
@eldy

this is to avoid side effects on child entities.
eg: if we are on entity 2 and the document number ends with the number 2 we have this:

/2/invoice/FA2302-0002/FA2302-0002.pdf

it gave:

/invoice/FA2302-000FA2302-0002.pdf

instead of :

/invoice/FA2302-0002/FA2302-0002.pdf
