### PR TITLE
Change SQL request for MAX and MIN

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2047,7 +2047,12 @@ abstract class CommonObject
 		if ($restrictiononfksoc && !$user->rights->societe->client->voir && !$socid) {
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON ".$aliastablesociete.".rowid = sc.fk_soc";
 		}
-		$sql .= " WHERE te.".$fieldid." < '".$this->db->escape($fieldid == 'rowid' ? $this->id : $this->ref)."'"; // ->ref must always be defined (set to id if field does not exists)
+    if($fieldid == 'rowid') {
+		  $sql .= " WHERE 1=1";
+    }
+    else {
+		  $sql .= " WHERE te." . $fieldid . " < '" . $this->db->escape($this->ref) . "'"; // ->ref must always be defined (set to id if field does not exists)
+    }
 		if ($restrictiononfksoc == 1 && !$user->rights->societe->client->voir && !$socid) {
 			$sql .= " AND sc.fk_user = ".((int) $user->id);
 		}
@@ -2117,7 +2122,12 @@ abstract class CommonObject
 		if ($restrictiononfksoc && !$user->rights->societe->client->voir && !$socid) {
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON ".$aliastablesociete.".rowid = sc.fk_soc";
 		}
-		$sql .= " WHERE te.".$fieldid." > '".$this->db->escape($fieldid == 'rowid' ? $this->id : $this->ref)."'"; // ->ref must always be defined (set to id if field does not exists)
+    if($fieldid == 'rowid') {
+		  $sql .= " WHERE 1=1";
+    }
+    else {
+		  $sql .= " WHERE te." . $fieldid . " > '" . $this->db->escape($this->ref) . "'"; // ->ref must always be defined (set to id if field does not exists)
+    }
 		if ($restrictiononfksoc == 1 && !$user->rights->societe->client->voir && !$socid) {
 			$sql .= " AND sc.fk_user = ".((int) $user->id);
 		}


### PR DESCRIPTION

FIX *Change SQL for MIN and MAX search id for rowid*
*When looking for the MAX and MIN id of the rowid field (the primary key), the SQL query is not optimized.
On a table with a million records, the query takes a few seconds to get a response. With correction, the request is instantaneous*


