### PR TITLE
harmonize hook name

### DIFF
--- a/htdocs/compta/bank/card.php
+++ b/htdocs/compta/bank/card.php
@@ -65,7 +65,7 @@ $extrafields = new ExtraFields($db);
 $extrafields->fetch_name_optionals_label($object->table_element);
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
-$hookmanager->initHooks(array('bankcard', 'globalcard'));
+$hookmanager->initHooks(array('bankaccountcard', 'globalcard'));
 
 // Security check
 $id = GETPOST("id", 'int') ? GETPOST("id", 'int') : GETPOST('ref', 'alpha');

--- a/htdocs/expedition/index.php
+++ b/htdocs/expedition/index.php
@@ -35,7 +35,7 @@ $hookmanager = new HookManager($db);
 $socid = GETPOST('socid', 'int');
 
 // Initialize technical object to manage hooks. Note that conf->hooks_modules contains array
-$hookmanager->initHooks(array('sendingindex'));
+$hookmanager->initHooks(array('expeditionindex'));
 
 // Load translation files required by the page
 $langs->loadLangs(array('orders', 'sendings'));

--- a/htdocs/expedition/list.php
+++ b/htdocs/expedition/list.php
@@ -105,7 +105,7 @@ $object = new Expedition($db);
 $form = new Form($db);
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
-$hookmanager->initHooks(array('shipmentlist'));
+$hookmanager->initHooks(array('expeditionlist'));
 $extrafields = new ExtraFields($db);
 
 // fetch optionals attributes and labels

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2014      Juanjo Menent		<jmenent@2byte.es>
  * Copyright (C) 2016      Ferran Marcet		<fmarcet@2byte.es>
  * Copyright (C) 2018-2021 Frédéric France		<frederic.france@netlogic.fr>
- * Copyright (C) 2018-2022 Charlene Benke		<charlene@patas-monkey.com>
+ * Copyright (C) 2018-2023 Charlene Benke		<charlene@patas-monkey.com>
  * Copyright (C) 2019      Nicolas Zabouri		<info@inovea-conseil.com>
  * Copyright (C) 2021-2023 Alexandre Spangaro   <aspangaro@open-dsi.fr>
  *

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -10,7 +10,7 @@
  * Copyright (C) 2015		Abbes Bahfir			<bafbes@gmail.com>
  * Copyright (C) 2015-2016	Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2017		Josep Lluís Amador		<joseplluis@lliuretic.cat>
- * Copyright (C) 2018-2022	Charlene Benke			<charlene@patas-monkey.com>
+ * Copyright (C) 2018-2023	Charlene Benke			<charlene@patas-monkey.com>
  * Copyright (C) 2018-2020	Frédéric France			<frederic.france@netlogic.fr>
  * Copyright (C) 2019-2021	Alexandre Spangaro		<aspangaro@open-dsi.fr>
  *
@@ -144,7 +144,7 @@ $now = dol_now();
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
 $object = new FactureFournisseur($db);
-$hookmanager->initHooks(array('supplierinvoicelist'));
+$hookmanager->initHooks(array('invoicesupplierlist'));
 $extrafields = new ExtraFields($db);
 
 // Fetch optionals attributes and labels

--- a/htdocs/fourn/paiement/list.php
+++ b/htdocs/fourn/paiement/list.php
@@ -110,7 +110,7 @@ $arrayfields = array(
 $arrayfields = dol_sort_array($arrayfields, 'position');
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
-$hookmanager->initHooks(array('paymentsupplierlist'));
+$hookmanager->initHooks(array('supplierpaymentlist'));
 $object = new PaiementFourn($db);
 
 // Security check

--- a/htdocs/intracommreport/card.php
+++ b/htdocs/intracommreport/card.php
@@ -70,7 +70,7 @@ $form = new Form($db);
 $formother = new FormOther($db);
 
 // Initialize technical object to manage hooks. Note that conf->hooks_modules contains array
-$hookmanager->initHooks(array('intracommcard', 'globalcard'));
+$hookmanager->initHooks(array('intracommreportcard', 'globalcard'));
 
 $error = 0;
 

--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -149,7 +149,7 @@ if ((string) $type == '0') {
 
 // Initialize technical object to manage hooks. Note that conf->hooks_modules contains array of hooks
 $object = new Product($db);
-$hookmanager->initHooks(array('productservicelist'));
+$hookmanager->initHooks(array('productlist'));
 $extrafields = new ExtraFields($db);
 $form = new Form($db);
 $formcompany = new FormCompany($db);

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -74,7 +74,7 @@ $backtopage = GETPOST('backtopage', 'alpha');
 $result = restrictedArea($user, 'stock');
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
-$hookmanager->initHooks(array('warehousecard', 'globalcard'));
+$hookmanager->initHooks(array('stockcard', 'globalcard'));
 
 $object = new Entrepot($db);
 $extrafields = new ExtraFields($db);

--- a/htdocs/product/stock/productlot_list.php
+++ b/htdocs/product/stock/productlot_list.php
@@ -69,7 +69,7 @@ $pagenext = $page + 1;
 $object = new Productlot($db);
 $extrafields = new ExtraFields($db);
 $diroutputmassaction = $conf->productbatch->dir_output.'/temp/massgeneration/'.$user->id;
-$hookmanager->initHooks(array('product_lotlist'));
+$hookmanager->initHooks(array('productlotlist'));
 
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);

--- a/htdocs/projet/tasks/list.php
+++ b/htdocs/projet/tasks/list.php
@@ -108,7 +108,7 @@ $contextpage = GETPOST('contextpage', 'aZ') ?GETPOST('contextpage', 'aZ') : 'tas
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
 $object = new Task($db);
-$hookmanager->initHooks(array('tasklist'));
+$hookmanager->initHooks(array('projecttasklist'));
 $extrafields = new ExtraFields($db);
 
 // fetch optionals attributes and labels

--- a/htdocs/resource/card.php
+++ b/htdocs/resource/card.php
@@ -69,7 +69,7 @@ $permissiontodelete = $user->rights->resource->delete;
  * Actions
  */
 
-$hookmanager->initHooks(array('resource', 'resource_card', 'globalcard'));
+$hookmanager->initHooks(array('resource', 'resourcecard', 'globalcard'));
 $parameters = array('resource_id'=>$id);
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) {

--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -82,7 +82,7 @@ $childids = $user->getAllChildIds(1);
 $extrafields->fetch_name_optionals_label($object->table_element);
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
-$hookmanager->initHooks(array('salarycard', 'globalcard'));
+$hookmanager->initHooks(array('salariescard', 'globalcard'));
 
 if ($id > 0 || !empty($ref)) {
 	$object->fetch($id, $ref);

--- a/htdocs/salaries/document.php
+++ b/htdocs/salaries/document.php
@@ -79,7 +79,7 @@ $childids = $user->getAllChildIds(1);
 $extrafields->fetch_name_optionals_label($object->table_element);
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
-$hookmanager->initHooks(array('salarydoc', 'globalcard'));
+$hookmanager->initHooks(array('salariesdoc', 'globalcard'));
 
 if ($id > 0 || !empty($ref)) {
 	$object->fetch($id, $ref);

--- a/htdocs/salaries/payments.php
+++ b/htdocs/salaries/payments.php
@@ -19,7 +19,7 @@
  */
 
 /**
- *	    \file       htdocs/salaries/list.php
+ *	    \file       htdocs/salaries/payments.php
  *      \ingroup    salaries
  *		\brief     	List of salaries payments
  */
@@ -68,7 +68,7 @@ if (!$sortorder) {
 $object = new PaymentSalary($db);
 $extrafields = new ExtraFields($db);
 $diroutputmassaction = $conf->user->dir_output.'/temp/massgeneration/'.$user->id;
-$hookmanager->initHooks(array('salarieslist')); // Note that conf->hooks_modules contains array
+$hookmanager->initHooks(array('salariespaymentslist')); // Note that conf->hooks_modules contains array
 
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);


### PR DESCRIPTION
I went around all the calls to the inihook function and I spotted names by module that are not "harmonious"
my solution to rename all the hooks is probably brutal, we could probably also use both names for a certain period but I wonder how to indicate then that there is deprecation of the old name
__ 

j'ai fait le tour de toute les appels à la fonction inihook et j'ai repéré par module des noms qui ne sont pas "harmonieux"
ma solution de renommer tout les hook est sans doute brutale,  on pourrait sans doute aussi utiliser les deux noms durant une certaine période mais je me demande comment indiquer ensuite qu'il y a dépréciation de l'ancien nom