### PR TITLE
FIX extrafield on update card when visibility is list or read only

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2123,7 +2123,7 @@ class ExtraFields
 					continue;
 				}
 				$visibility_abs = abs($visibility);
-				// not modify if extra field is not in update form (0 : never, 2 or -2 : list only, 5 or - 5 : list and view only
+				// not modify if extra field is not in update form (0 : never, 2 or -2 : list only, 5 or - 5 : list and view only)
 				if (empty($visibility_abs) || $visibility_abs == 2 || $visibility_abs == 5) {
 					continue;
 				}

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2122,7 +2122,9 @@ class ExtraFields
 				) {
 					continue;
 				}
-				if (empty($visibility) || $visibility == 5) {
+				$visibility_abs = abs($visibility);
+				// not modify if extra field is not in update form (0 : never, 2 or -2 : list only, 5 or - 5 : list and view only
+				if (empty($visibility_abs) || $visibility_abs == 2 || $visibility_abs == 5) {
 					continue;
 				}
 				if (empty($perms)) {


### PR DESCRIPTION
FIX extrafield on update card when visibility is list or read only
- when you update a card with a visibility is list only [=-2 or =2] or read only [=5 or -5], the value is updated and set an empty value

**To reproduce**
1) try with theses extra fields
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/c58718da-ec76-4c84-be64-d70f0f074980)

2) set values in databases

3) update you third-party card with any changes

Finally theses extra fields are reset with an empty value