### PR TITLE
NEW Add emptyObjectVars() to CommonObject

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9137,6 +9137,16 @@ abstract class CommonObject
 	}
 
 	/**
+	 * Sets all object fields to null. Useful for example in lists, when printing multiple lines and a different object os fetched for each line.
+	 * @return void
+	 */
+	public function emtpyObjectVars() {
+		foreach ($this->fields as $field => $arr) {
+			$this->$field = null;
+		}
+	}
+	
+	/**
 	 * Function to concat keys of fields
 	 *
 	 * @param   string   $alias   	String of alias of table for fields. For example 't'. It is recommended to use '' and set alias into fields defintion.


### PR DESCRIPTION
NEW Add emptyObjectVars() to CommonObject
This function enables to unset all variables of an object without unsetting the object itself. I find it useful when in a loop I fetch each time a different object. This issue is not solved by setVarsFromObj. Consider this:
```php
$resql = "some sql resultset";
for ($i < $numlines) {
$obj = $db->fetch_object($resql);
$object->setVarsFromObj($obj);
print $object->ref;
$contact->fetch($object->foreign_key_contact);
print $contact->firstname;
}
``` 

In this example, if an object has foreign_key_contact = null the loop will print the last fetched value until a new contact is fetched. Here an empty function comes handy.