### PR TITLE
Add 'name' property for fetching user's name

### DIFF
--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -3844,7 +3844,7 @@ class User extends CommonObject
 	 *  Return property of user from its id
 	 *
 	 *  @param	int		$rowid      id of contact
-	 *  @param  string	$mode       'email' or 'mobile'
+	 *  @param  string	$mode       'email', 'mobile', or 'name'
 	 *  @return string  			Email of user with format: "Full name <email>"
 	 */
 	public function user_get_property($rowid, $mode)
@@ -3871,6 +3871,8 @@ class User extends CommonObject
 					$user_property = dolGetFirstLastname($obj->firstname, $obj->lastname)." <".$obj->email.">";
 				} elseif ($mode == 'mobile') {
 					$user_property = $obj->user_mobile;
+				} elseif ($mode == 'name') {
+					$user_property = dolGetFirstLastname($obj->firstname, $obj->lastname);
 				}
 			}
 			return $user_property;


### PR DESCRIPTION
# NEW Add 'name' property for fetching user's name
The `user_get_property()` method provides a simple way of retrieving the mobile number or email address for a single user.  This adds the option to retrieve the name, formatted according to the configuration.