### PR TITLE
Add missing Canadian territories

### DIFF
--- a/htdocs/install/mysql/data/llx_20_c_departements.sql
+++ b/htdocs/install/mysql/data/llx_20_c_departements.sql
@@ -301,6 +301,9 @@ INSERT INTO llx_c_departements (fk_region, code_departement, cheflieu, tncc, ncc
 INSERT INTO llx_c_departements (fk_region, code_departement, cheflieu, tncc, ncc, nom) VALUES (1401, 'SK', '', 1, '', 'Saskatchewan');
 INSERT INTO llx_c_departements (fk_region, code_departement, cheflieu, tncc, ncc, nom) VALUES (1401, 'AB', '', 1, '', 'Alberta');
 INSERT INTO llx_c_departements (fk_region, code_departement, cheflieu, tncc, ncc, nom) VALUES (1401, 'NL', '', 1, '', 'Newfoundland and Labrador');
+INSERT INTO llx_c_departements (fk_region, code_departement, cheflieu, tncc, ncc, nom) VALUES (1401, 'YT', '', 1, '', 'Yukon');
+INSERT INTO llx_c_departements (fk_region, code_departement, cheflieu, tncc, ncc, nom) VALUES (1401, 'NT', '', 1, '', 'Northwest Territories');
+INSERT INTO llx_c_departements (fk_region, code_departement, cheflieu, tncc, ncc, nom) VALUES (1401, 'NU', '', 1, '', 'Nunavut');
 
 
 -- Chile Provinces (id country=67)


### PR DESCRIPTION
# FIX Add missing Canadian territories
The three Canadian territories were missing from table `d_c_departement`.  This adds them for new installations.  Note that rowid numbers will be different in a new installation, because the INSERT statements rely on AUTO_INCREMENT, and the changes have been inserted into the list to stay with Canadian provinces, rather than appending to the end of the file.