### PR TITLE
Fix : set_as_client can't use prospect/customer value if disabled

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -2135,7 +2135,7 @@ class Societe extends CommonObject
 		// phpcs:enable
 		if ($this->id) {
 			$newclient = 1;
-			if ($this->client == 2 || $this->client == 3) {
+			if (($this->client == 2 || $this->client == 3) && empty($conf->global->SOCIETE_DISABLE_PROSPECTSCUSTOMERS))
 				$newclient = 3; //If prospect, we keep prospect tag
 			}
 			$sql = "UPDATE ".MAIN_DB_PREFIX."societe";


### PR DESCRIPTION
When prospect/customer value is disabled in the thirdparty module setup, we should not use this value in set_as_client function.