### PR TITLE
FIX: Update mouvementstock.class.php

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -975,7 +975,7 @@ class MouvementStock extends CommonObject
 				if ($origin_type) {
 					// Separate originetype with "@" : left part is class name, right part is module name
 					$origin_type_array = explode('@', $origin_type);
-					$classname = ucfirst($origin_type_array[0]);
+					$classname = $origin_type_array[0];
 					$modulename = empty($origin_type_array[1]) ? $classname : $origin_type_array[1];
 					$result = dol_include_once('/'.$modulename.'/class/'.strtolower($classname).'.class.php');
 					if ($result) {

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -977,7 +977,7 @@ class MouvementStock extends CommonObject
 					$origin_type_array = explode('@', $origin_type);
 					$classname = $origin_type_array[0];
 					$modulename = empty($origin_type_array[1]) ? $classname : $origin_type_array[1];
-					$result = dol_include_once('/'.$modulename.'/class/'.strtolower($classname).'.class.php');
+					$result = dol_include_once('/'.$modulename.'/class/'.$classname.'.class.php');
 					if ($result) {
 						$classname = ucfirst($classname);
 						$origin = new $classname($this->db);


### PR DESCRIPTION
If first character changes to upper case, some external modules don't show its origin in mouvements.

