### PR TITLE
FIX Add missing argument

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9712,7 +9712,7 @@ function complete_head_from_modules($conf, $langs, $object, &$head, &$h, $type, 
 	// No need to make a return $head. Var is modified as a reference
 	if (!empty($hookmanager)) {
 		$parameters = array('object' => $object, 'mode' => $mode, 'head' => &$head, 'filterorigmodule' => $filterorigmodule);
-		$reshook = $hookmanager->executeHooks('completeTabsHead', $parameters);
+		$reshook = $hookmanager->executeHooks('completeTabsHead', $parameters, $object);
 		if ($reshook > 0) {		// Hook ask to replace completely the array
 			$head = $hookmanager->resArray;
 		} else {				// Hook


### PR DESCRIPTION
# FIX Missing argument to executeHooks() method
The `$hookmanager->executeHooks()` method does not require the `$object` parameter, but some hooks expect it to be there.  In this particular case, `$object` is included in the `$parameters` array, instead of being passed directly as the third argument to `executeHooks()`.  This seems to be a non-standard approach that should be corrected.