### PR TITLE
FIX #25400 fatal error when text value starts with equal sign

### DIFF
--- a/htdocs/core/modules/export/export_excel2007.modules.php
+++ b/htdocs/core/modules/export/export_excel2007.modules.php
@@ -361,8 +361,9 @@ class ExportExcel2007 extends ModeleExports
 				$this->workbook->getActiveSheet()->getStyle($coord)->getNumberFormat()->setFormatCode('yyyy-mm-dd h:mm:ss');
 			} else {
 				if ($typefield == 'Text' || $typefield == 'TextAuto') {
-					// If $newvalue start with an equal sign we don't want it to be interpreted as a formula
-					$newvalue = mb_substr($newvalue, 0, 1) === '=' ? '\'' . (string)$newvalue : (string)$newvalue;
+					// If $newvalue start with an equal sign we don't want it to be interpreted as a formula, so we add a '. Such transformation should be
+					// done by SetCellValueByColumnAndRow but it is not, so we do it ourself.
+					$newvalue = (mb_substr($newvalue, 0, 1) === '=' ? '\'' : '') . (string) $newvalue;
 					$this->workbook->getActiveSheet()->SetCellValueByColumnAndRow($this->col, $this->row + 1, (string) $newvalue);
 					$coord = $this->workbook->getActiveSheet()->getCellByColumnAndRow($this->col, $this->row + 1)->getCoordinate();
 					$this->workbook->getActiveSheet()->getStyle($coord)->getNumberFormat()->setFormatCode('@');

--- a/htdocs/core/modules/export/export_excel2007.modules.php
+++ b/htdocs/core/modules/export/export_excel2007.modules.php
@@ -361,6 +361,8 @@ class ExportExcel2007 extends ModeleExports
 				$this->workbook->getActiveSheet()->getStyle($coord)->getNumberFormat()->setFormatCode('yyyy-mm-dd h:mm:ss');
 			} else {
 				if ($typefield == 'Text' || $typefield == 'TextAuto') {
+					// If $newvalue start with an equal sign we don't want it to be interpreted as a formula
+					$newvalue = mb_substr($newvalue, 0, 1) === '=' ? '\'' . (string)$newvalue : (string)$newvalue;
 					$this->workbook->getActiveSheet()->SetCellValueByColumnAndRow($this->col, $this->row + 1, (string) $newvalue);
 					$coord = $this->workbook->getActiveSheet()->getCellByColumnAndRow($this->col, $this->row + 1)->getCoordinate();
 					$this->workbook->getActiveSheet()->getStyle($coord)->getNumberFormat()->setFormatCode('@');


### PR DESCRIPTION
# FIX #25400
A text value that starts with an equal sign has to be escaped in order to not to be evaluated as an excel formula



