### PR TITLE
Fix delete_module_parts with multicompany

### DIFF
--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -2285,7 +2285,6 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 		global $conf;
 
 		$err = 0;
-		$entity = $conf->entity;
 
 		if (is_array($this->module_parts) && !empty($this->module_parts)) {
 			dol_syslog(get_class($this)."::delete_module_parts", LOG_DEBUG);
@@ -2294,6 +2293,8 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 				// If entity is defined
 				if (is_array($value) && isset($value['entity'])) {
 					$entity = $value['entity'];
+				} else {
+					$entity = $conf->entity;
 				}
 
 				$sql = "DELETE FROM ".MAIN_DB_PREFIX."const";


### PR DESCRIPTION
# FIX delete_module_parts with multicompany

An error occurred when deactivating and reactivating a module created by ModuleBuilder with the multicompany module enabled:
```
ERROR: 23505: duplicate key value violates unique constraint 'uk_const' DETAIL: Key (name, entity)=(MAIN_MODULE_ORDERREQUEST_MODULEFOREXTERNAL, 6) already exists. SCHEMA NAME: public TABLE NAME: llx_const CONSTRAINT NAME: uk_const LOCATION: _bt_check_unique, nbtinsert.c:664
```