### PR TITLE
FIX php8.1 warning on lists with total due to unset array key

### DIFF
--- a/htdocs/core/tpl/list_print_total.tpl.php
+++ b/htdocs/core/tpl/list_print_total.tpl.php
@@ -13,7 +13,7 @@ if (isset($totalarray['pos'])) {
 	while ($i < $totalarray['nbfield']) {
 		$i++;
 		if (!empty($totalarray['pos'][$i])) {
-			switch ($totalarray['type'][$i]) {
+			switch (isset($totalarray['type'][$i]) ? $totalarray['type'][$i] : false) {
 				case 'duration';
 					print '<td class="right">';
 					print (!empty($totalarray['val'][$totalarray['pos'][$i]])?convertSecondToTime($totalarray['val'][$totalarray['pos'][$i]], 'allhourmin'):0);


### PR DESCRIPTION
# FIX PHP8.1 warning on lists with a total row

On lists that display a "Total" row at the bottom of the main table (such as the list of Manufacturing Orders in the core MRP module), `$totalarray['type'][$i]` is queried without first checking that the item exists. Earlier versions of PHP coerce that to null and throw a Notice whereas PHP8.1 throws a Warning.