### PR TITLE
FIX Handle projects for the api documents listing route

### DIFF
--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -502,6 +502,17 @@ class Documents extends DolibarrApi
 			// $upload_dir = $conf->ecm->dir_output;
 			// $type = 'all';
 			// $recursive = 0;
+		} elseif ($modulepart == 'projet' || $modulepart == 'project') {
+			$modulepart = 'project';
+			require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+
+			$object = new Project($this->db);
+			$result = $object->fetch($id, $ref);
+			if (!$result) {
+				throw new RestException(404, 'Project not found');
+			}
+
+			$upload_dir = $conf->projet->dir_output . "/" . get_exdir(0, 0, 0, 1, $object, 'project');
 		} else {
 			throw new RestException(500, 'Modulepart '.$modulepart.' not implemented yet.');
 		}
@@ -628,7 +639,7 @@ class Documents extends DolibarrApi
 
 					require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.commande.class.php';
 					$object = new CommandeFournisseur($this->db);
-			} elseif ($modulepart == 'project') {
+			} elseif ($modulepart == 'projet' || $modulepart == 'project') {
 				require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 				$object = new Project($this->db);
 			} elseif ($modulepart == 'task' || $modulepart == 'project_task') {


### PR DESCRIPTION
(I'm pretty glad to make my first contribution for Dolibarr after some years to work with!)

# Fix Handle projects for the api documents listing route

After some tests, I noticed that the api documents listing route `GET /api/index.php/documents` don't handle linked documents projects.

This PR fix this route and add the possibility to list all uploaded documents for one project given.

(I have target the `17.0` but I can rebase if needed! 😉)