### PR TITLE
Enable by default INVOICE_CREDIT_NOTE_STANDALONE and PRODUCT_USE_UNITS for Greece

### DIFF
--- a/htdocs/master.inc.php
+++ b/htdocs/master.inc.php
@@ -241,6 +241,14 @@ if (!defined('NOREQUIREDB') && !defined('NOREQUIRESOC')) {
 		// The deposit invoice type is not allowed in Greece.
 		$conf->global->INVOICE_DISABLE_DEPOSIT = 1;
 	}
+	if ($mysoc->country_code == 'GR' && !isset($conf->global->INVOICE_CREDIT_NOTE_STANDALONE)) {
+		// Standalone credit note is compulsory in Greece.
+		$conf->global->INVOICE_CREDIT_NOTE_STANDALONE = 1;
+	}
+	if ($mysoc->country_code == 'GR' && !isset($conf->global->PRODUCT_USE_UNITS)) {
+		// Unit labels are required in Greek invoices.
+		$conf->global->PRODUCT_USE_UNITS = 1;
+	}
 	if (($mysoc->localtax1_assuj || $mysoc->localtax2_assuj) && !isset($conf->global->MAIN_NO_INPUT_PRICE_WITH_TAX)) {
 		// For countries using the 2nd or 3rd tax, we disable input/edit of lines using the price including tax (because 2nb and 3rd tax not yet taken into account).
 		// Work In Progress to support all taxes into unit price entry when MAIN_UNIT_PRICE_WITH_TAX_IS_FOR_ALL_TAXES is set.


### PR DESCRIPTION
Hi eldy 
Regarding PRODUCT_USE_UNITS and this issue #25370
The use case for Greece is to output the unit label in documents(mainly invoices and shipment sheets) and upload it as part of the invoice or shipment sheet data to the ministry db. 
We only use piece, kg and lt. 

From this 8 year old discussion nearly the same rules apply for Mexico
https://github.com/Dolibarr/dolibarr/commit/d843b1fbe442a198103cb9a66bcae4bd4fb08e35#diff-3a48cb158377e8951e07df9f6bb926c3932d307842720f379acdb0ebea36e3a0R436

So far this is the only implemented method for this use case(half baked as it is ) but it is hidden and not documented other than in [Setup_Other](https://wiki.dolibarr.org/index.php/Setup_Other) wiki page

Please instruct me how would you like this to be properly implemented so i can try and fix it