### PR TITLE
NEW LDAP Active Directory UserAccountControl

### DIFF
--- a/htdocs/admin/ldap.php
+++ b/htdocs/admin/ldap.php
@@ -64,6 +64,9 @@ if (empty($reshook)) {
 		if (!dolibarr_set_const($db, 'LDAP_SERVER_TYPE', GETPOST("type", 'aZ09'), 'chaine', 0, '', $conf->entity)) {
 			$error++;
 		}
+		if (!dolibarr_set_const($db, 'LDAP_USERACCOUNTCONTROL', GETPOST("userAccountControl", 'int'), 'chaine', 0, '', $conf->entity)) {
+			$error++;
+		}
 		if (!dolibarr_set_const($db, 'LDAP_SERVER_PROTOCOLVERSION', GETPOST("LDAP_SERVER_PROTOCOLVERSION", 'aZ09'), 'chaine', 0, '', $conf->entity)) {
 			$error++;
 		}
@@ -193,6 +196,11 @@ print "</tr>\n";
 print '<tr class="oddeven"><td>'.$langs->trans("Type").'</td><td>';
 print $formldap->selectLdapServerType(getDolGlobalString('LDAP_SERVER_TYPE'), 'type');
 print '</td><td>&nbsp;</td></tr>';
+
+// userAccountControl
+print '<tr class="oddeven"><td>'.$langs->trans("LDAPUserAccountControl").'</td><td>';
+print '<input class="width75" type="text" name="userAccountControl" value="'.getDolGlobalString('LDAP_USERACCOUNTCONTROL', '512').'">';
+print '</td><td><span class="opacitymedium">'.$langs->trans("LDAPUserAccountControlExample").'</span></td></tr>';
 
 // Version
 print '<tr class="oddeven"><td>'.$langs->trans("Version").'</td><td>';

--- a/htdocs/core/modules/modLdap.class.php
+++ b/htdocs/core/modules/modLdap.class.php
@@ -86,6 +86,7 @@ class modLdap extends DolibarrModules
 		12=>array('LDAP_FIELD_FAX', 'chaine', 'facsimiletelephonenumber', '', 0),
 		13=>array('LDAP_FIELD_MOBILE', 'chaine', 'mobile', '', 0),
 		14=>array('LDAP_GROUP_FILTER', 'chaine', '&(objectClass=groupOfNames)', '', 0),
+		15=>array('LDAP_USERACCOUNTCONTROL', 'int', 512, '', 0),
 		);
 
 		// Boxes

--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -314,6 +314,15 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					$result = $ldap->add($dn, $info, $user);
 				}
 
+				// Avoid Ldap error due to empty member 
+				if(isset($info['member']) && empty($info['member'])){
+					unset($info['member']);
+				}
+
+				if ($ldap->serverType == "activedirectory") {
+					$info['sAMAccountName'] = $object->name;
+				}
+
 				if ($result < 0) {
 					$this->error = "ErrorLDAP ".$ldap->error;
 				}

--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -23,7 +23,7 @@
  *  \brief      Fichier de gestion des triggers LDAP
  */
 
-require_once DOL_DOCUMENT_ROOT.'/core/triggers/dolibarrtriggers.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/triggers/dolibarrtriggers.class.php';
 
 
 /**
@@ -73,14 +73,14 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			return 0;
 		}
 
-		require_once DOL_DOCUMENT_ROOT."/core/class/ldap.class.php";
-		require_once DOL_DOCUMENT_ROOT."/user/class/usergroup.class.php";
+		require_once DOL_DOCUMENT_ROOT . "/core/class/ldap.class.php";
+		require_once DOL_DOCUMENT_ROOT . "/user/class/usergroup.class.php";
 
 		$result = 0;
 
 		// Users
 		if ($action == 'USER_CREATE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -89,22 +89,27 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					$info = $object->_load_ldap_info();
 					$dn = $object->_load_ldap_dn($info);
 
+					//For compatibility with Samba 4 AD
+					if ($ldap->serverType == "activedirectory") {
+						$info['userAccountControl'] = $conf->global->LDAP_USERACCOUNTCONTROL; 			//Account enabled
+					}
+
 					$result = $ldap->add($dn, $info, $user);
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'USER_MODIFY') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
-						dol_syslog("Trigger ".$action." was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
+						dol_syslog("Trigger " . $action . " was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
 						$object->oldcopy = clone $object;
 					}
 
@@ -113,7 +118,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 					// Verify if entry exist
 					$container = $object->oldcopy->_load_ldap_dn($oldinfo, 1);
-					$search = "(".$object->oldcopy->_load_ldap_dn($oldinfo, 2).")";
+					$search = "(" . $object->oldcopy->_load_ldap_dn($oldinfo, 2) . ")";
 					$records = $ldap->search($container, $search);
 					if (count($records) && $records['count'] == 0) {
 						$olddn = '';
@@ -136,7 +141,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 						// Verify if entry exist
 						$container = $usergroup->_load_ldap_dn($oldinfo, 1);
-						$search = "(".$usergroup->_load_ldap_dn($oldinfo, 2).")";
+						$search = "(" . $usergroup->_load_ldap_dn($oldinfo, 2) . ")";
 						$records = $ldap->search($container, $search);
 						if (count($records) && $records['count'] == 0) {
 							$olddn = '';
@@ -158,7 +163,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 						// Verify if an entry exists
 						$container = $usergroup->_load_ldap_dn($oldinfo, 1);
-						$search = "(".$usergroup->_load_ldap_dn($oldinfo, 2).")";
+						$search = "(" . $usergroup->_load_ldap_dn($oldinfo, 2) . ")";
 						$records = $ldap->search($container, $search);
 						if (count($records) && $records['count'] == 0) {
 							$olddn = '';
@@ -172,18 +177,18 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'USER_NEW_PASSWORD') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
-						dol_syslog("Trigger ".$action." was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
+						dol_syslog("Trigger " . $action . " was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
 						$object->oldcopy = clone $object;
 					}
 
@@ -192,7 +197,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 					// Verify if entry exist
 					$container = $object->oldcopy->_load_ldap_dn($oldinfo, 1);
-					$search = "(".$object->oldcopy->_load_ldap_dn($oldinfo, 2).")";
+					$search = "(" . $object->oldcopy->_load_ldap_dn($oldinfo, 2) . ")";
 					$records = $ldap->search($container, $search);
 					if (count($records) && $records['count'] == 0) {
 						$olddn = '';
@@ -205,13 +210,40 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'USER_ENABLEDISABLE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+			if (intval($conf->global->LDAP_SYNCHRO_ACTIVE) === Ldap::SYNCHRO_DOLIBARR_TO_LDAP && $conf->global->LDAP_SERVER_TYPE == "activedirectory") {
+				$ldap = new Ldap();
+				$result = $ldap->connect_bind();
+				if ($result > 0) {
+					$info = $object->_load_ldap_info();
+					$dn = $object->_load_ldap_dn($info);
+					$search = "(" . $object->_load_ldap_dn($info, 2) . ")";
+					$uAC = $ldap->getAttributeValues($search, "userAccountControl");
+					if ($uAC["count"] == 1) {
+						$userAccountControl = intval($uAC[0]);
+						$enabledBitMask = 0x2;
+						$isEnabled = ($userAccountControl & $enabledBitMask) === 0;
+						if ($isEnabled && intval($object->statut) === 1) {
+							$userAccountControl += 2;
+						} else if (!$isEnabled && intval($object->statut) === 0) {
+							$userAccountControl -= 2;
+						}
+						$info['userAccountControl'] = $userAccountControl;
+						$resUpdate = $ldap->update($dn, $info, $user, $dn);
+						if ($resUpdate < 0) {
+							$this->error = "ErrorLDAP " . $ldap->error;
+						}
+					}
+				} else {
+					$this->error = "ErrorLDAP " . $ldap->error;
+				}
+			}
 		} elseif ($action == 'USER_DELETE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -224,7 +256,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 			/*} elseif ($action == 'USER_SETINGROUP') {
@@ -297,7 +329,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			} */
 		} elseif ($action == 'USERGROUP_CREATE') {
 			// Groupes
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -315,7 +347,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				// Avoid Ldap error due to empty member 
-				if(isset($info['member']) && empty($info['member'])){
+				if (isset($info['member']) && empty($info['member'])) {
 					unset($info['member']);
 				}
 
@@ -324,18 +356,18 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'USERGROUP_MODIFY') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
-						dol_syslog("Trigger ".$action." was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
+						dol_syslog("Trigger " . $action . " was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
 						$object->oldcopy = clone $object;
 					}
 
@@ -344,7 +376,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 					// Verify if entry exist
 					$container = $object->oldcopy->_load_ldap_dn($oldinfo, 1);
-					$search = "(".$object->oldcopy->_load_ldap_dn($oldinfo, 2).")";
+					$search = "(" . $object->oldcopy->_load_ldap_dn($oldinfo, 2) . ")";
 					$records = $ldap->search($container, $search);
 					if (count($records) && $records['count'] == 0) {
 						$olddn = '';
@@ -357,11 +389,11 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'USERGROUP_DELETE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -374,12 +406,12 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'CONTACT_CREATE') {
 			// Contacts
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_CONTACT_ACTIVE)) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -392,18 +424,18 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'CONTACT_MODIFY') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_CONTACT_ACTIVE)) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
-						dol_syslog("Trigger ".$action." was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
+						dol_syslog("Trigger " . $action . " was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
 						$object->oldcopy = clone $object;
 					}
 
@@ -412,7 +444,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 					// Verify if entry exist
 					$container = $object->oldcopy->_load_ldap_dn($oldinfo, 1);
-					$search = "(".$object->oldcopy->_load_ldap_dn($oldinfo, 2).")";
+					$search = "(" . $object->oldcopy->_load_ldap_dn($oldinfo, 2) . ")";
 					$records = $ldap->search($container, $search);
 					if (count($records) && $records['count'] == 0) {
 						$olddn = '';
@@ -425,11 +457,11 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'CONTACT_DELETE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_CONTACT_ACTIVE)) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -442,12 +474,12 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'MEMBER_CREATE') {
 			// Members
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -461,7 +493,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					// For member type
 					if (!empty($conf->global->LDAP_MEMBER_TYPE_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_TYPE_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 						if ($object->typeid > 0) {
-							require_once DOL_DOCUMENT_ROOT."/adherents/class/adherent_type.class.php";
+							require_once DOL_DOCUMENT_ROOT . "/adherents/class/adherent_type.class.php";
 							$membertype = new AdherentType($this->db);
 							$membertype->fetch($object->typeid);
 							$membertype->listMembersForMemberType('', 1);
@@ -471,7 +503,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 							// Verify if entry exist
 							$container = $membertype->_load_ldap_dn($oldinfo, 1);
-							$search = "(".$membertype->_load_ldap_dn($oldinfo, 2).")";
+							$search = "(" . $membertype->_load_ldap_dn($oldinfo, 2) . ")";
 							$records = $ldap->search($container, $search);
 							if (count($records) && $records['count'] == 0) {
 								$olddn = '';
@@ -486,11 +518,11 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result < 0) {
-					$this->error = "ErrorLDAP ".$ldap->error;
+					$this->error = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'MEMBER_VALIDATE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				// If status field is setup to be synchronized
 				if (!empty($conf->global->LDAP_FIELD_MEMBER_STATUS)) {
@@ -506,19 +538,21 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					}
 
 					if ($result < 0) {
-						$this->error = "ErrorLDAP ".$ldap->error;
+						$this->error = "ErrorLDAP " . $ldap->error;
 					}
 				}
 			}
 		} elseif ($action == 'MEMBER_SUBSCRIPTION') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				// If subscriptions fields are setup to be synchronized
-				if (!empty($conf->global->LDAP_FIELD_MEMBER_FIRSTSUBSCRIPTION_DATE)
+				if (
+					!empty($conf->global->LDAP_FIELD_MEMBER_FIRSTSUBSCRIPTION_DATE)
 					|| !empty($conf->global->LDAP_FIELD_MEMBER_FIRSTSUBSCRIPTION_AMOUNT)
 					|| !empty($conf->global->LDAP_FIELD_MEMBER_LASTSUBSCRIPTION_DATE)
 					|| !empty($conf->global->LDAP_FIELD_MEMBER_LASTSUBSCRIPTION_AMOUNT)
-					|| !empty($conf->global->LDAP_FIELD_MEMBER_END_LASTSUBSCRIPTION)) {
+					|| !empty($conf->global->LDAP_FIELD_MEMBER_END_LASTSUBSCRIPTION)
+				) {
 					$ldap = new Ldap();
 					$result = $ldap->connect_bind();
 
@@ -531,19 +565,19 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					}
 
 					if ($result < 0) {
-						$this->error = "ErrorLDAP ".$ldap->error;
+						$this->error = "ErrorLDAP " . $ldap->error;
 					}
 				}
 			}
 		} elseif ($action == 'MEMBER_MODIFY') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
-						dol_syslog("Trigger ".$action." was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
+						dol_syslog("Trigger " . $action . " was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
 						$object->oldcopy = clone $object;
 					}
 
@@ -552,7 +586,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 					// Verify if entry exist
 					$container = $object->oldcopy->_load_ldap_dn($oldinfo, 1);
-					$search = "(".$object->oldcopy->_load_ldap_dn($oldinfo, 2).")";
+					$search = "(" . $object->oldcopy->_load_ldap_dn($oldinfo, 2) . ")";
 					$records = $ldap->search($container, $search);
 					if (count($records) && $records['count'] == 0) {
 						$olddn = '';
@@ -567,7 +601,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 					// For member type
 					if (!empty($conf->global->LDAP_MEMBER_TYPE_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_TYPE_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
-						require_once DOL_DOCUMENT_ROOT."/adherents/class/adherent_type.class.php";
+						require_once DOL_DOCUMENT_ROOT . "/adherents/class/adherent_type.class.php";
 
 						/*
 						 * Change member info
@@ -581,7 +615,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 						// Verify if entry exist
 						$container = $newmembertype->_load_ldap_dn($oldinfo, 1);
-						$search = "(".$newmembertype->_load_ldap_dn($oldinfo, 2).")";
+						$search = "(" . $newmembertype->_load_ldap_dn($oldinfo, 2) . ")";
 						$records = $ldap->search($container, $search);
 						if (count($records) && $records['count'] == 0) {
 							$olddn = '';
@@ -605,7 +639,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 							// Verify if entry exist
 							$container = $oldmembertype->_load_ldap_dn($oldinfo, 1);
-							$search = "(".$oldmembertype->_load_ldap_dn($oldinfo, 2).")";
+							$search = "(" . $oldmembertype->_load_ldap_dn($oldinfo, 2) . ")";
 							$records = $ldap->search($container, $search);
 							if (count($records) && $records['count'] == 0) {
 								$olddn = '';
@@ -620,11 +654,11 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result <= 0) {
-					$this->errors[] = "ErrorLDAP ".$ldap->error;
+					$this->errors[] = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'MEMBER_NEW_PASSWORD') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				// If password field is setup to be synchronized
 				if (!empty($conf->global->LDAP_FIELD_PASSWORD) || !empty($conf->global->LDAP_FIELD_PASSWORD_CRYPTED)) {
@@ -640,12 +674,12 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					}
 
 					if ($result <= 0) {
-						$this->errors[] = "ErrorLDAP ".$ldap->error;
+						$this->errors[] = "ErrorLDAP " . $ldap->error;
 					}
 				}
 			}
 		} elseif ($action == 'MEMBER_RESILIATE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				// If status field is setup to be synchronized
 				if (!empty($conf->global->LDAP_FIELD_MEMBER_STATUS)) {
@@ -661,12 +695,12 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					}
 
 					if ($result <= 0) {
-						$this->errors[] = "ErrorLDAP ".$ldap->error;
+						$this->errors[] = "ErrorLDAP " . $ldap->error;
 					}
 				}
 			}
 		} elseif ($action == 'MEMBER_DELETE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -680,21 +714,21 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					// For member type
 					if (!empty($conf->global->LDAP_MEMBER_TYPE_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_TYPE_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 						if ($object->typeid > 0) {
-							require_once DOL_DOCUMENT_ROOT."/adherents/class/adherent_type.class.php";
+							require_once DOL_DOCUMENT_ROOT . "/adherents/class/adherent_type.class.php";
 
 							/*
 							 * Remove member in member type
 							 */
 							$membertype = new AdherentType($this->db);
 							$membertype->fetch($object->typeid);
-							$membertype->listMembersForMemberType('a.rowid != '.$object->id, 1); // remove deleted member from the list
+							$membertype->listMembersForMemberType('a.rowid != ' . $object->id, 1); // remove deleted member from the list
 
 							$oldinfo = $membertype->_load_ldap_info();
 							$olddn = $membertype->_load_ldap_dn($oldinfo);
 
 							// Verify if entry exist
 							$container = $membertype->_load_ldap_dn($oldinfo, 1);
-							$search = "(".$membertype->_load_ldap_dn($oldinfo, 2).")";
+							$search = "(" . $membertype->_load_ldap_dn($oldinfo, 2) . ")";
 							$records = $ldap->search($container, $search);
 							if (count($records) && $records['count'] == 0) {
 								$olddn = '';
@@ -709,12 +743,12 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result <= 0) {
-					$this->errors[] = "ErrorLDAP ".$ldap->error;
+					$this->errors[] = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'MEMBER_TYPE_CREATE') {
 			// Members types
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_TYPE_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_TYPE_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -732,18 +766,18 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result <= 0) {
-					$this->errors[] = "ErrorLDAP ".$ldap->error;
+					$this->errors[] = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'MEMBER_TYPE_MODIFY') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_TYPE_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_TYPE_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
-						dol_syslog("Trigger ".$action." was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
+						dol_syslog("Trigger " . $action . " was called by a function that did not set previously the property ->oldcopy onto object", LOG_WARNING);
 						$object->oldcopy = clone $object;
 					}
 
@@ -754,7 +788,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 					// Verify if entry exist
 					$container = $object->oldcopy->_load_ldap_dn($oldinfo, 1);
-					$search = "(".$object->oldcopy->_load_ldap_dn($oldinfo, 2).")";
+					$search = "(" . $object->oldcopy->_load_ldap_dn($oldinfo, 2) . ")";
 					$records = $ldap->search($container, $search);
 					if (count($records) && $records['count'] == 0) {
 						$olddn = '';
@@ -769,11 +803,11 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result <= 0) {
-					$this->errors[] = "ErrorLDAP ".$ldap->error;
+					$this->errors[] = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		} elseif ($action == 'MEMBER_TYPE_DELETE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 			if (!empty($conf->global->LDAP_MEMBER_TYPE_ACTIVE) && getDolGlobalInt('LDAP_MEMBER_TYPE_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
 				$result = $ldap->connect_bind();
@@ -786,7 +820,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				}
 
 				if ($result <= 0) {
-					$this->errors[] = "ErrorLDAP ".$ldap->error;
+					$this->errors[] = "ErrorLDAP " . $ldap->error;
 				}
 			}
 		}

--- a/htdocs/langs/en_US/ldap.lang
+++ b/htdocs/langs/en_US/ldap.lang
@@ -29,3 +29,5 @@ LDAPPasswordHashType=Password hash type
 LDAPPasswordHashTypeExample=Type of password hash used on the server
 SupportedForLDAPExportScriptOnly=Only supported by an ldap export script
 SupportedForLDAPImportScriptOnly=Only supported by an ldap import script
+LDAPUserAccountControl = userAccountControl on creation (active directory)
+LDAPUserAccountControlExample = 512 Normal Account / 546 Normal Account + No Passwd + Disabled (see : https://fr.wikipedia.org/wiki/Active_Directory)


### PR DESCRIPTION
# NEW|New [UserAccountControl can be set]
In the mode Dolibarr -> LDAP sync with activedirectory, there were some issues.

Now, in the LDAP Admin page, you can set a default userAccountControl for user creation (with examples)

The creation and the enable/disable action now updates this param while updating your ldap entry.
