### PR TITLE
Fix default value for extrafields to avoid SQL 'cannot be null' error

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6169,6 +6169,7 @@ abstract class CommonObject
 				}
 			}
 
+			$attrs = $extrafields->attributes[$this->table_element];
 			foreach ($new_array_options as $key => $value) {
 				$attributeKey      = substr($key, 8); // Remove 'options_' prefix
 				$attributeType     = $extrafields->attributes[$this->table_element]['type'][$attributeKey];
@@ -6364,7 +6365,10 @@ abstract class CommonObject
 					if ($new_array_options[$key] != '' || $new_array_options[$key] == '0') {
 						$sql .= ",'".$this->db->escape($new_array_options[$key])."'";
 					} else {
-						$sql .= ",null";
+						$default = $attrs['default'][$attributeKey];
+						if ($default === null) $sql .= ',null';
+						elseif (is_numeric($default)) $sql .= ",$default";
+						else $sql .= ",'".$this->db->escape($default)."'";
 					}
 				}
 			}


### PR DESCRIPTION
# FIX default value for extrafields to avoid SQL 'cannot be null' error
Empty extrafields were being set to null, rather than using the `fielddefault` field from the `llx_extrafields` table.  This could result in a "Field 'xxx' cannot be null" error from MySQL.