### PR TITLE
prevent error with php 8.2

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptSettings">
-    <option name="languageLevel" value="ES6" />
-  </component>
-</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="7.1">
-    <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />
-</project>
-

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>	
+<project version="7.1">	
+    <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />	
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>	
-<project version="7.1">	
-    <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />	
-</project>

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -999,9 +999,9 @@ class ExtraFields
 			} elseif ($type == 'radio') {
 				$morecss = 'width25';
 			} else {
-				if (empty($size) || round($size) < 12) {
+				if (empty($size) || round((float) $size) < 12) {
 					$morecss = 'minwidth100';
-				} elseif (round($size) <= 48) {
+				} elseif (round((float) $size) <= 48) {
 					$morecss = 'minwidth200';
 				} else {
 					$morecss = 'minwidth400';


### PR DESCRIPTION
# FIX prevent error with php 8.2

Fatal error: Uncaught TypeError: round(): Argument #1 ($num) must be of type int|float occur  with php 8.2



