### PR TITLE
NEW LDAP Active Directory UserAccountControl

### DIFF
--- a/htdocs/admin/ldap.php
+++ b/htdocs/admin/ldap.php
@@ -65,6 +65,9 @@ if (empty($reshook)) {
 		if (!dolibarr_set_const($db, 'LDAP_SERVER_TYPE', GETPOST("type", 'aZ09'), 'chaine', 0, '', $conf->entity)) {
 			$error++;
 		}
+		if (!dolibarr_set_const($db, 'LDAP_USERACCOUNTCONTROL', GETPOST("userAccountControl", 'int'), 'chaine', 0, '', $conf->entity)) {
+			$error++;
+		}
 		if (!dolibarr_set_const($db, 'LDAP_SERVER_PROTOCOLVERSION', GETPOST("LDAP_SERVER_PROTOCOLVERSION", 'aZ09'), 'chaine', 0, '', $conf->entity)) {
 			$error++;
 		}
@@ -194,6 +197,11 @@ print "</tr>\n";
 print '<tr class="oddeven"><td>'.$langs->trans("Type").'</td><td>';
 print $formldap->selectLdapServerType(getDolGlobalString('LDAP_SERVER_TYPE'), 'type');
 print '</td><td>&nbsp;</td></tr>';
+
+// userAccountControl
+print '<tr class="oddeven"><td>'.$langs->trans("LDAPUserAccountControl").'</td><td>';
+print '<input class="width75" type="text" name="userAccountControl" value="'.getDolGlobalString('LDAP_USERACCOUNTCONTROL', '512').'">';
+print '</td><td><span class="opacitymedium">'.$langs->trans("LDAPUserAccountControlExample").'</span></td></tr>';
 
 // Version
 print '<tr class="oddeven"><td>'.$langs->trans("Version").'</td><td>';

--- a/htdocs/core/modules/modLdap.class.php
+++ b/htdocs/core/modules/modLdap.class.php
@@ -86,6 +86,7 @@ class modLdap extends DolibarrModules
 		12=>array('LDAP_FIELD_FAX', 'chaine', 'facsimiletelephonenumber', '', 0),
 		13=>array('LDAP_FIELD_MOBILE', 'chaine', 'mobile', '', 0),
 		14=>array('LDAP_GROUP_FILTER', 'chaine', '&(objectClass=groupOfNames)', '', 0),
+		15=>array('LDAP_USERACCOUNTCONTROL', 'int', 512, '', 0),
 		);
 
 		// Boxes

--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -89,6 +89,11 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					$info = $object->_load_ldap_info();
 					$dn = $object->_load_ldap_dn($info);
 
+					//For compatibility with Samba 4 AD
+					if ($ldap->serverType == "activedirectory") {
+						$info['userAccountControl'] = $conf->global->LDAP_USERACCOUNTCONTROL;
+					}
+
 					$result = $ldap->add($dn, $info, $user);
 				}
 
@@ -210,6 +215,33 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			}
 		} elseif ($action == 'USER_ENABLEDISABLE') {
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			if (intval($conf->global->LDAP_SYNCHRO_ACTIVE) === Ldap::SYNCHRO_DOLIBARR_TO_LDAP && $conf->global->LDAP_SERVER_TYPE == "activedirectory") {
+				$ldap = new Ldap();
+				$result = $ldap->connect_bind();
+				if ($result > 0) {
+					$info = $object->_load_ldap_info();
+					$dn = $object->_load_ldap_dn($info);
+					$search = "(" . $object->_load_ldap_dn($info, 2) . ")";
+					$uAC = $ldap->getAttributeValues($search, "userAccountControl");
+					if ($uAC["count"] == 1) {
+						$userAccountControl = intval($uAC[0]);
+						$enabledBitMask = 0x2;
+						$isEnabled = ($userAccountControl & $enabledBitMask) === 0;
+						if ($isEnabled && intval($object->statut) === 1) {
+							$userAccountControl += 2;
+						} else if (!$isEnabled && intval($object->statut) === 0) {
+							$userAccountControl -= 2;
+						}
+						$info['userAccountControl'] = $userAccountControl;
+						$resUpdate = $ldap->update($dn, $info, $user, $dn);
+						if ($resUpdate < 0) {
+							$this->error = "ErrorLDAP " . $ldap->error;
+						}
+					}
+				} else {
+					$this->error = "ErrorLDAP " . $ldap->error;
+				}
+			}
 		} elseif ($action == 'USER_DELETE') {
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (!empty($conf->global->LDAP_SYNCHRO_ACTIVE) && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {

--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -314,6 +314,15 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					$result = $ldap->add($dn, $info, $user);
 				}
 
+				// Avoid Ldap error due to empty member 
+				if(isset($info['member']) && empty($info['member'])){
+					unset($info['member']);
+				}
+
+				if ($ldap->serverType == "activedirectory") {
+					$info['sAMAccountName'] = $object->name;
+				}
+
 				if ($result < 0) {
 					$this->error = "ErrorLDAP ".$ldap->error;
 				}

--- a/htdocs/langs/en_US/ldap.lang
+++ b/htdocs/langs/en_US/ldap.lang
@@ -29,3 +29,5 @@ LDAPPasswordHashType=Password hash type
 LDAPPasswordHashTypeExample=Type of password hash used on the server
 SupportedForLDAPExportScriptOnly=Only supported by an ldap export script
 SupportedForLDAPImportScriptOnly=Only supported by an ldap import script
+LDAPUserAccountControl = userAccountControl on creation (active directory)
+LDAPUserAccountControlExample = 512 Normal Account / 546 Normal Account + No Passwd + Disabled (see : https://fr.wikipedia.org/wiki/Active_Directory)


### PR DESCRIPTION
In the mode Dolibarr -> LDAP sync with activedirectory, there were some issues.

Now, in the LDAP Admin page, you can set a default userAccountControl for user creation (with examples)

The creation and the enable/disable action now updates this param while updating your ldap entry.

#25496 on branch develop instead of 16.0