### PR TITLE
FIX_reload_linked_objects_on_propal_closeas

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -700,6 +700,7 @@ if (empty($reshook)) {
 			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("CloseAs")), null, 'errors');
 			$action = 'closeas';
 		} elseif (GETPOST('statut', 'int') == $object::STATUS_SIGNED || GETPOST('statut', 'int') == $object::STATUS_NOTSIGNED) {
+			$locationTarget = '';
 			// prevent browser refresh from closing proposal several times
 			if ($object->statut == $object::STATUS_VALIDATED || ( ! empty($conf->global->PROPAL_SKIP_ACCEPT_REFUSE) && $object->statut == $object::STATUS_DRAFT)) {
 				$db->begin();
@@ -708,10 +709,12 @@ if (empty($reshook)) {
 				if ($result < 0) {
 					setEventMessages($object->error, $object->errors, 'errors');
 					$error++;
+				} else {
+					// Needed if object linked modified by trigger (because linked objects can't be fetched two times : linkedObjectsFullLoaded)
+					$locationTarget = DOL_URL_ROOT . '/comm/propal/card.php?id=' . $object->id;
 				}
 
 				$deposit = null;
-				$locationTarget = '';
 
 				$deposit_percent_from_payment_terms = getDictionaryValue('c_payment_term', 'deposit_percent', $object->cond_reglement_id);
 


### PR DESCRIPTION
# FIX
Needed if object linked modified by trigger on propal closeas (because linked objects can't be fetched two times : linkedObjectsFullLoaded)

# USE CASE
We want to linked order with propal on propal signed trigger but the attribute linkedObjectsFullLoaded is already set before the trigger, so the linked objects by the trigger can't be reloaded by the fetchObjectLinked(). So we need to reload the page manually to show new linked objects.

# SECURITY ENHANCE
Furthermore, don't show arg in the URL is better for the final user (prevent doing action again on refresh page). 