### PR TITLE
FIX contact creation and contact project display

### DIFF
--- a/htdocs/core/lib/contact.lib.php
+++ b/htdocs/core/lib/contact.lib.php
@@ -71,7 +71,7 @@ function contact_prepare_head(Contact $object)
 			$sql .= ' FROM '.MAIN_DB_PREFIX.'projet as n';
 			$sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'element_contact as cc ON (n.rowid = cc.element_id)';
 			$sql .= ' WHERE cc.fk_socpeople = '.((int) $object->id);
-			$sql .= ' AND cc.fk_c_type_contact IN (SELECT rowid FROM '.MAIN_DB_PREFIX.'c_type_contact WHERE element="project" AND source="external")';
+			$sql .= ' AND cc.fk_c_type_contact IN (SELECT rowid FROM '.MAIN_DB_PREFIX."c_type_contact WHERE element='project' AND source='external')";
 			$sql .= ' AND n.entity IN ('.getEntity('project').')';
 			$resql = $db->query($sql);
 			if ($resql) {
@@ -190,7 +190,7 @@ function show_contacts_projects($conf, $langs, $db, $object, $backtopage = '', $
 		$sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'element_contact as cc ON (p.rowid = cc.element_id)';
 		$sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'c_type_contact as ctc ON (ctc.rowid = cc.fk_c_type_contact)';
 		$sql .= ' WHERE cc.fk_socpeople = '.((int) $object->id);
-		$sql .= ' AND ctc.element="project" AND ctc.source="external"';
+		$sql .= " AND ctc.element='project' AND ctc.source='external'";
 		$sql .= ' AND p.entity IN ('.getEntity('project').')';
 		$sql .= ' ORDER BY p.dateo DESC';
 


### PR DESCRIPTION
In Dolibarr 16.0.5, an error is shown after creating a contact (contact/card.php?action=create), and contact projects fail to appear (contact/project.php?id=xxxx).

By setting `$dolibarr_main_prod='0'`, I realized that this comes from SQL syntax errors. This PR fixes them.

For the record, here is the relevant part of the error after contact creation:

```
Modules/Applications: syslog, user, ldap, prelevement, export, projet, propal, tax, fckeditor, blockedlog, accounting, agenda, banque, don, expensereport, facture, fournisseur, holiday, salaries, service, societe, import
Type gestionnaire de base de données: pgsql
Requête dernier accès en base en erreur: SELECT COUNT(n.rowid) as nb FROM llx_projet as n INNER JOIN llx_element_contact as cc ON (n.rowid = cc.element_id) WHERE cc.fk_socpeople = 935 AND cc.fk_c_type_contact IN (SELECT rowid FROM llx_c_type_contact WHERE element="project" AND source="external") AND n.entity IN (1)
Code retour dernier accès en base en erreur: DB_ERROR_NOSUCHFIELD
Information sur le dernier accès en base en erreur: ERROR: 42703: column "project" does not exist\nLINE 1: ...ELECT rowid FROM llx_c_type_contact WHERE element="project" ...\n ^\nLOCATION: errorMissingColumn, parse_relation.c:3638
```
