### PR TITLE
Quick fix to allow JSON in extrafields POST parameters

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2184,6 +2184,8 @@ class ExtraFields
 						$label_security_check = empty($conf->global->MAIN_SECURITY_ALLOW_UNSECURED_LABELS_WITH_HTML) ? 'alphanohtml' : 'restricthtml';
 					}
 					$value_key = GETPOST("options_".$key, $label_security_check);
+				} elseif (in_array($key_type, array('json'))) {
+					$value_key = GETPOST("options_".$key, 'none');
 				} else {
 					$value_key = GETPOST("options_".$key);
 					if (in_array($key_type, array('link')) && $value_key == '-1') {


### PR DESCRIPTION
# FIX Cannot use JSON for extrafields parameters
We have a complex field that needs to be submitted as JSON.  None of the available filters in `setOptionalsFromPost()` allow for this.  This is a quick fix which does no filtering at all.  Additional validation should probably be performed.