### PR TITLE
Change modulepart to expedition

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -1093,7 +1093,7 @@ if ($object->id > 0) {
 						}
 					}
 					$relativepath = dol_sanitizeFileName($objp->ref).'/'.dol_sanitizeFileName($objp->ref).'.pdf';
-					print $formfile->showPreview($file_list, $sendingstatic->element, $relativepath, 0, $param);
+					print $formfile->showPreview($file_list, $sendingstatic->table_element, $relativepath, 0, $param);
 				}
 				// $filename = dol_sanitizeFileName($objp->ref);
 				// $filedir = $conf->expedition->multidir_output[$objp->entity].'/'.dol_sanitizeFileName($objp->ref);


### PR DESCRIPTION
This fixes a bug on a thirdparty's client tab where when you hit the preview button on the latest shipments a warning appears.
The Modulepart sent is Expedition->element ('shipping') where it should be Expedition->table_element ('expedition') in order for the preview to work properly.
