### PR TITLE
FIX #25580 install/step1.php - command line + force_install

### DIFF
--- a/htdocs/install/step1.php
+++ b/htdocs/install/step1.php
@@ -84,21 +84,33 @@ if (@file_exists($forcedfile)) {
 	// If forced install is enabled, replace the post values. These are empty because form fields are disabled.
 	if ($force_install_noedit) {
 		$main_dir = detect_dolibarr_main_document_root();
-		if (!empty($argv[1])) {
-			$main_dir = $argv[1]; // override when executing the script in command line
+		if (!empty($argv[3])) {
+			$main_dir = $argv[3]; // override when executing the script in command line
 		}
 		if (!empty($force_install_main_data_root)) {
 			$main_data_dir = $force_install_main_data_root;
 		} else {
 			$main_data_dir = detect_dolibarr_main_data_root($main_dir);
 		}
+		if (!empty($argv[4])) {
+			$main_data_dir = $argv[4]; // override when executing the script in command line
+		}
 		$main_url = detect_dolibarr_main_url_root();
+		if (!empty($argv[5])) {
+			$main_url = $argv[5]; // override when executing the script in command line
+		}
 
 		if (!empty($force_install_databaserootlogin)) {
 			$userroot = parse_database_login($force_install_databaserootlogin);
 		}
+		if (!empty($argv[6])) {
+			$userroot = $argv[6]; // override when executing the script in command line
+		}
 		if (!empty($force_install_databaserootpass)) {
 			$passroot = parse_database_pass($force_install_databaserootpass);
+		}
+		if (!empty($argv[7])) {
+			$passroot = $argv[7]; // override when executing the script in command line
 		}
 	}
 	if ($force_install_noedit == 2) {


### PR DESCRIPTION
`install/step1.php` : wrong command line argument used for `$main_dir` in conjunction with force_install

Replaced `$argv[1]` by `$argv[3]`

Also added the override from command line arguments for:
- `$main_data_dir`: `$argv[4]`
- `$main_url`: `$argv[5]`
- `$userroot`: `$argv[6]`
- `$passroot`: `$argv[7]`