### PR TITLE
NEW no need to create invoice supplier object on supplier card for standalone credit note

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -3100,7 +3100,7 @@ if ($action == 'create') {
 				$facusing->fetch($object->fk_facture_source);
 				print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("CorrectInvoice", $facusing->getNomUrl(1)).'</span>';
 			} else {
-				print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("NoInvoiceToCorrect").'</span>';
+				print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("CorrectedInvoiceNotFound").'</span>';
 			}
 		}
 

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -3095,12 +3095,12 @@ if ($action == 'create') {
 			print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("ReplaceInvoice", $facreplaced->getNomUrl(1)).'</span>';
 		}
 		if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE) {
-			$facusing = new FactureFournisseur($db);
 			if ($object->fk_facture_source > 0) {
+				$facusing = new FactureFournisseur($db);
 				$facusing->fetch($object->fk_facture_source);
 				print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("CorrectInvoice", $facusing->getNomUrl(1)).'</span>';
 			} else {
-				print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("CorrectedInvoiceNotFound").'</span>';
+				print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("NoInvoiceToCorrect").'</span>';
 			}
 		}
 


### PR DESCRIPTION
NEW no need to create invoice supplier object on supplier card for standalone credit note

- no need to use constructor method of supplier invoice "new FactureFournisseur()" if its a standalone credit note
- "CorrectedInvoiceNotFound" was not found in lang files and I suggest to replace with "NoInvoiceToCorrect" (translated for "fr_FR" : Pas de facture à corriger)