### PR TITLE
FIX : avoid draft and cancelled shippings when searching if order should be set delivered

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -332,6 +332,9 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 					foreach ($order->linkedObjects as $type => $shipping_array) {
 						if ($type == 'shipping' && is_array($shipping_array) && count($shipping_array) > 0) {
 							foreach ($shipping_array as $shipping) {
+								if ($shipping->statut <= 0) {
+									continue;
+								}
 								if (is_array($shipping->lines) && count($shipping->lines) > 0) {
 									foreach ($shipping->lines as $shippingline) {
 										$qtyshipped[$shippingline->fk_product] += $shippingline->qty;


### PR DESCRIPTION
draft and cancelled shipping lines were counted when checking if order has to be set as delivered (old bug)