### PR TITLE
FIX: warning when Workboard Responses display non numeric strings

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -437,7 +437,7 @@ if (empty($conf->global->MAIN_DISABLE_GLOBAL_WORKBOARD)) {
 
 	// We calculate $totallate. Must be defined before start of next loop because it is show in first fetch on next loop
 	foreach ($valid_dashboardlines as $board) {
-		if ($board->nbtodolate > 0) {
+		if ($board->nbtodolate > 0 && is_numeric($board->nbtodo) && is_numeric($board->nbtodolate)) {
 			$totaltodo += $board->nbtodo;
 			$totallate += $board->nbtodolate;
 		}

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -437,7 +437,7 @@ if (empty($conf->global->MAIN_DISABLE_GLOBAL_WORKBOARD)) {
 
 	// We calculate $totallate. Must be defined before start of next loop because it is show in first fetch on next loop
 	foreach ($valid_dashboardlines as $board) {
-		if ($board->nbtodolate > 0 && is_numeric($board->nbtodo) && is_numeric($board->nbtodolate)) {
+		if (is_numeric($board->nbtodo) && is_numeric($board->nbtodolate) && $board->nbtodolate > 0) {
 			$totaltodo += $board->nbtodo;
 			$totallate += $board->nbtodolate;
 		}


### PR DESCRIPTION
# FIX home page warning when workboard responses have non numeric data
Some external modules use workboards to show data that is not exclusively numeric.

Here is a (fictitious) example:
![image](https://github.com/Dolibarr/dolibarr/assets/50440633/c0354ec8-83e7-4344-9d90-abf04f0ff53d)

This is a convenient way to display more than just an integer, but it causes warnings when Dolibarr sums overdue / pending elements.

We would like to keep this simple way of showing slightly more detailed information without impacting the overdue/pending calculation.