### PR TITLE
Fix : emailcollector must use socid to link event to thirdparty (instead of fk_soc)

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -2034,7 +2034,7 @@ class EmailCollector extends CommonObject
 								}
 
 								if (get_class($objectemail) != 'Societe') {
-									$thirdpartyid = $objectemail->fk_soc;
+									$thirdpartyid = $objectemail->fk_soc ?? $objectemail->socid;
 								} else {
 									$thirdpartyid = $objectemail->id;
 								}


### PR DESCRIPTION
Most of the object in Dolibarr use socid as an attribute and not fk_soc.