### PR TITLE
Fix Computed Extrafields on list

### DIFF
--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -34,10 +34,7 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 				}
 				// If field is a computed field, we make computation to get value
 				if ($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key]) {
-					//global $obj, $object;
-					//var_dump($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key]);
-					//var_dump($obj);
-					//var_dump($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key]);
+					$objectoffield = $object; //For compatibily with the computed formula
 					$value = dol_eval($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key], 1, 1, '0');
 					if (is_numeric(price2num($value)) && $extrafields->attributes[$extrafieldsobjectkey]['totalizable'][$key]) {
 						$obj->$tmpkey = price2num($value);


### PR DESCRIPTION
# FIX|Fix # Computed Extrafields on list
The computed extrafields were not calculated on list views. 
The formula asks to write $objectoffield to reference the actual object. Otherwise the template called by list.php has the object referenced in $object. 
I simply added a reference to $object name $objectoffield 
I removed debug commentaries also. 
