### PR TITLE
FIX Suppliers addlines never have VAT if buyprice for this supplier

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -775,7 +775,7 @@ if (!empty($usemargins) && $user->rights->margins->creer) {
 
 						// Now set the VAT
 						var stringforvatrateselection = tva_tx;
-						if (typeof default_vat_code != 'undefined' && default_vat_code != null) {
+						if (typeof default_vat_code != 'undefined' && default_vat_code != null && default_vat_code != '') {
 							stringforvatrateselection = stringforvatrateselection+' ('+default_vat_code+')';
 						}
 						// Set vat rate if field is an input box
@@ -997,7 +997,7 @@ if (!empty($usemargins) && $user->rights->margins->creer) {
 			if (typeof default_vat_code === 'undefined') { default_vat_code = jQuery('#idprodfournprice').attr('data-default-vat-code');}	// When select is done from HTML input with ajax autocomplete
 
 			var stringforvatrateselection = tva_tx;
-			if (typeof default_vat_code != 'undefined' && default_vat_code != null) {
+			if (typeof default_vat_code != 'undefined' && default_vat_code != null && default_vat_code != '') {
 				stringforvatrateselection = stringforvatrateselection+' ('+default_vat_code+')';
 			}
 
@@ -1059,7 +1059,7 @@ if (!empty($usemargins) && $user->rights->margins->creer) {
 			if (typeof default_vat_code === 'undefined') { default_vat_code = jQuery('#idprodfournprice').attr('data-default-vat-code');}	// When select is done from HTML input with ajax autocomplete
 
 			var stringforvatrateselection = tva_tx;
-			if (typeof default_vat_code != 'undefined' && default_vat_code != null) {
+			if (typeof default_vat_code != 'undefined' && default_vat_code != null && default_vat_code != '') {
 				stringforvatrateselection = stringforvatrateselection+' ('+default_vat_code+')';
 			}
 
@@ -1072,7 +1072,6 @@ if (!empty($usemargins) && $user->rights->margins->creer) {
 			$('#tva_tx option').removeAttr('selected');
 			console.log("stringforvatrateselection="+stringforvatrateselection+" -> value of option label for this key="+$('#tva_tx option[value="'+stringforvatrateselection+'"]').val());
 			$('#tva_tx option[value="'+stringforvatrateselection+'"]').prop('selected', true);
-
 			<?php
 			if (getDolGlobalInt('PRODUIT_AUTOFILL_DESC') == 1) {
 				if (!empty($conf->global->FCKEDITOR_ENABLE_DETAILS)) {


### PR DESCRIPTION
# FIX VAT FOR KNOWN BUYPRICE SUPPLIER
The issue was the following part :
When we added a line in a supplierOrder or supplierInvoice, the VAT is always to 0 if the supplier has a price for this product.

The problem isn't visible if the supplier dosn't have a price for the product. So i looked everywhere and find a bug in JS. we didn't checked the tva_tx var if empty (not null, not underfined just empty)

This PR fix it. The problem is here since 2022 December (V17 FIX)