### PR TITLE
Fix a bug with fetch with the object used to create the ticket

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -217,7 +217,8 @@ if (empty($reshook)) {
 			$db->begin();
 
 			$getRef = GETPOST("ref", 'alphanohtml');
-			if ($object->fetch('', $getRef) > 0) {
+			$test = new Ticket($db);
+			if ($test->fetch('', $getRef) > 0) {
 				$object->ref = $object->getDefaultRef();
 				$object->track_id = null;
 				setEventMessage($langs->trans('TicketRefAlreadyUsed', $getRef, $object->ref));


### PR DESCRIPTION
# Fix
we have a case when we do the fetch that we get the information of the pre-existing ticket at the old ref and cause problem in the creation of the ticket. to fix this, I use a $test Ticket and not the $object to check if the ref already exist