### PR TITLE
FIX TakePOS receipt preview in admin

### DIFF
--- a/htdocs/takepos/receipt.php
+++ b/htdocs/takepos/receipt.php
@@ -111,7 +111,7 @@ if (!empty($hookmanager->resPrint)) {
 <br>
 <p class="left">
 <?php
-$constFreeText = 'TAKEPOS_HEADER'.$_SESSION['takeposterminal'];
+$constFreeText = 'TAKEPOS_HEADER'.($_SESSION['takeposterminal'] ?? '0');
 if (!empty($conf->global->TAKEPOS_HEADER) || getDolGlobalString($constFreeText)) {
 	$newfreetext = '';
 	$substitutionarray = getCommonSubstitutionArray($langs);
@@ -352,7 +352,7 @@ if (getDolGlobalString('TAKEPOS_PRINT_PAYMENT_METHOD')) {
 <br>
 <br>
 <?php
-$constFreeText = 'TAKEPOS_FOOTER'.$_SESSION['takeposterminal'];
+$constFreeText = 'TAKEPOS_FOOTER'.($_SESSION['takeposterminal'] ?? '0');
 if (!empty($conf->global->TAKEPOS_FOOTER) || !empty($conf->global->{$constFreeText})) {
 	$newfreetext = '';
 	$substitutionarray = getCommonSubstitutionArray($langs);


### PR DESCRIPTION
Receipt preview in admin shows header and footer repeating themselves because in preview, `$constFreeText` equals `TAKEPOS_HEADER` (as there is no `$_SESSION['takeposterminal']` defined).

<img width="900" alt="Capture d’écran 2023-08-19 à 12 18 33" src="https://github.com/Dolibarr/dolibarr/assets/531249/1d644d08-ea88-4bf1-88f3-f1cfd4b5ec18">
<img width="482" alt="Capture d’écran 2023-08-19 à 12 18 41" src="https://github.com/Dolibarr/dolibarr/assets/531249/3f0af8b9-d5e6-45fd-bd98-aa646f073124">
