### PR TITLE
FIX TakePOS receipt preview in admin

### DIFF
--- a/htdocs/takepos/receipt.php
+++ b/htdocs/takepos/receipt.php
@@ -111,7 +111,7 @@ if (!empty($hookmanager->resPrint)) {
 <br>
 <p class="left">
 <?php
-$constFreeText = 'TAKEPOS_HEADER'.$_SESSION['takeposterminal'];
+$constFreeText = 'TAKEPOS_HEADER'.($_SESSION['takeposterminal'] ?? '0');
 if (!empty($conf->global->TAKEPOS_HEADER) || !empty($conf->global->{$constFreeText})) {
 	$newfreetext = '';
 	$substitutionarray = getCommonSubstitutionArray($langs);
@@ -316,7 +316,7 @@ if ($conf->global->TAKEPOS_PRINT_PAYMENT_METHOD) {
 <br>
 <br>
 <?php
-$constFreeText = 'TAKEPOS_FOOTER'.$_SESSION['takeposterminal'];
+$constFreeText = 'TAKEPOS_FOOTER'.($_SESSION['takeposterminal'] ?? '0');
 if (!empty($conf->global->TAKEPOS_FOOTER) || !empty($conf->global->{$constFreeText})) {
 	$newfreetext = '';
 	$substitutionarray = getCommonSubstitutionArray($langs);


### PR DESCRIPTION
Receipt preview in admin shows header and footer repeating themselves because in preview, $constFreeText equals TAKEPOS_HEADER (as there is no $_SESSION['takeposterminal'] defined).

Back compatibility for #25648