### PR TITLE
add private note on Facture::TYPE_REPLACEMENT and Facture::TYPE_CREDI…

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -966,7 +966,8 @@ if (empty($reshook))
 				$object->date = $dateinvoice;
 				$object->date_pointoftax = $date_pointoftax;
 				$object->note_public		= trim(GETPOST('note_public', 'restricthtml'));
-				// We do not copy the private note
+
+				$object->note_private		= trim(GETPOST('note_private', 'restricthtml'));
 				$object->ref_client			= GETPOST('ref_client');
 				//$object->ref_int = $_POST['ref_int'];
 				$object->model_pdf = GETPOST('model');
@@ -1023,7 +1024,8 @@ if (empty($reshook))
 				$object->date = $dateinvoice;
 				$object->date_pointoftax = $date_pointoftax;
 				$object->note_public		= trim(GETPOST('note_public', 'restricthtml'));
-				// We do not copy the private note
+				$object->note_private		= trim(GETPOST('note_private', 'restricthtml'));
+
 				$object->ref_client			= GETPOST('ref_client');
 				$object->model_pdf = GETPOST('model');
 				$object->fk_project			= GETPOST('projectid', 'int');


### PR DESCRIPTION
FIX :  add private note on Facture::TYPE_REPLACEMENT and Facture::TYPE_CREDI… 

This is a question in the form of a pr.
When creating a credit or replacement invoice, the public note is taken over but not the private note.
since these two fields come from two input textareas of the
 form create and do not come from a copy of the original invoice or the replacement invoice my question is :
 is there a business rule hidden behind this ? or my pr is valid ?