### PR TITLE
Fix #25671 product clone fatal error

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -904,7 +904,7 @@ if (empty($reshook)) {
 		} else {
 			if ($object->id > 0) {
 				$error = 0;
-				$clone = dol_clone($object, 2);
+				$clone = dol_clone($object, 1);
 
 				$clone->id = null;
 				$clone->ref = GETPOST('clone_ref', 'alphanohtml');


### PR DESCRIPTION
Fix a fatal error on product clone due to dol_clone($object, 2) return being an Std Class and trying to use a function that doesn't exist on this Std Class