### PR TITLE
Fix #25452 disable Bom & Mo when product disabled

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -68,7 +68,7 @@ class modProduct extends DolibarrModules
 		// Dependencies
 		$this->hidden = false; // A condition to hide module
 		$this->depends = array(); // List of module class names as string that must be enabled if this module is enabled
-		$this->requiredby = array("modStock", "modBarcode", "modProductBatch", "modVariants"); // List of module ids to disable if this one is disabled
+		$this->requiredby = array("modStock", "modBarcode", "modProductBatch", "modVariants", "modBom"); // List of module ids to disable if this one is disabled
 		$this->conflictwith = array(); // List of module class names as string this module is in conflict with
 		$this->phpmin = array(7, 0); // Minimum version of PHP required by module
 


### PR DESCRIPTION
When we disable product also disable BOM & MO module because product is needed for theses modules