### PR TITLE
FIX: payment card: misleading message when delete button disabled

### DIFF
--- a/htdocs/compta/paiement/card.php
+++ b/htdocs/compta/paiement/card.php
@@ -522,8 +522,14 @@ if (!empty($conf->global->BILL_ADD_PAYMENT_VALIDATION)) {
 	}
 }
 
+$params = array();
+
+if (! empty($title_button)) {
+    $params['attr'] = array('title' => $title_button);
+}
+
 if ($user->socid == 0 && $action == '') {
-	print dolGetButtonAction($langs->trans("Delete"), '', 'delete', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=delete&token='.newToken(), 'delete', $user->rights->facture->paiement && !$disable_delete);
+	print dolGetButtonAction($langs->trans("Delete"), '', 'delete', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=delete&token='.newToken(), 'delete', $user->rights->facture->paiement && !$disable_delete, $params);
 }
 
 print '</div>';


### PR DESCRIPTION
Variable `$title_button` is defined earlier in the script but never used, so the message displayed in this case mentions missing permissions.