### PR TITLE
FIX opensurvey add hours

### DIFF
--- a/htdocs/opensurvey/wizard/choix_date.php
+++ b/htdocs/opensurvey/wizard/choix_date.php
@@ -179,6 +179,7 @@ if (GETPOST('confirmation')) {
 	// Add survey into database
 	if (!$erreur && $erreurNb == 0) {
 		$_SESSION["toutchoix"] = substr("$choixdate", 1);
+		unset($_SESSION["nbrecaseshoraires"]);
 
 		ajouter_sondage();
 	}
@@ -215,7 +216,7 @@ llxHeader('', $langs->trans("OpenSurvey"), "", '', 0, 0, $arrayofjs, $arrayofcss
 //nombre de cases par défaut
 if (!isset($_SESSION["nbrecaseshoraires"])) {
 	$_SESSION["nbrecaseshoraires"] = 5;
-} elseif (GETPOST('ajoutcases') && $_SESSION["nbrecaseshoraires"] == 5) {
+} elseif ((GETPOST('ajoutcases') || GETPOST("ajoutcases_y")) && $_SESSION["nbrecaseshoraires"] == 5) {
 	$_SESSION["nbrecaseshoraires"] = 10;
 }
 

--- a/htdocs/opensurvey/wizard/choix_date.php
+++ b/htdocs/opensurvey/wizard/choix_date.php
@@ -218,7 +218,19 @@ if (!isset($_SESSION["nbrecaseshoraires"])) {
 	$_SESSION["nbrecaseshoraires"] = 5;
 } elseif ((GETPOST('ajoutcases') || GETPOST("ajoutcases_y")) && $_SESSION["nbrecaseshoraires"] == 5) {
 	$_SESSION["nbrecaseshoraires"] = 10;
+	//On sauvegarde les heures deja entrées
+	if (issetAndNoEmpty('totalchoixjour', $_SESSION) === true) {
+		$nbofchoice = count($_SESSION["totalchoixjour"]);
+		for ($i = 0; $i < $nbofchoice; $i++) {
+			//affichage des 5 cases horaires
+			for ($j = 0; $j < $_SESSION["nbrecaseshoraires"]; $j++) {
+				$horairesi = GETPOST("horaires".$i);
+				$_SESSION["horaires$i"][$j] = $horairesi[$j];
+			}
+		}
+	}
 }
+
 
 //valeurs de la date du jour actuel
 $jourAJ = date("j");
@@ -408,7 +420,7 @@ if (issetAndNoEmpty('choixjourajout')) {
 			$k = $i + 1;
 			if (issetAndNoEmpty('horaires'.$i) === true && issetAndNoEmpty($i, $_POST['horaires'.$i]) === true) {
 				for ($j = 0; $j < $_SESSION["nbrecaseshoraires"]; $j++) {
-					$horairesi = GETPOST("horaires".$i);
+					$horairesi = GETPOST("horaires".$i, 'array');
 					$_SESSION["horaires$i"][$j] = $horairesi[$j];
 				}
 			}
@@ -453,7 +465,7 @@ if (issetAndNoEmpty('reporterhoraires')) {
 	}
 }
 
-//report des horaires dans toutes les cases
+//effacer les horaires dans toutes les cases
 if (issetAndNoEmpty('resethoraires')) {
 	$nbofchoice = count($_SESSION["totalchoixjour"]);
 	for ($i = 0; $i < $nbofchoice; $i++) {


### PR DESCRIPTION
FIX : button to add hours on opensurvey would not work

When creating a date survey, the button to add hours would : 
- not add hours
- erase previously entered hours

example : 

![image](https://github.com/Dolibarr/dolibarr/assets/89838020/785f8733-2a81-4103-8931-f398a85e4f34)

then click on (+)

![image](https://github.com/Dolibarr/dolibarr/assets/89838020/56820253-cff9-46b3-8a85-726da10a1a11)


This PR fixes these bad behaviors.
