### PR TITLE
bug l'IBAN client n'est pas repris dans les templates

### DIFF
--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -409,6 +409,13 @@ class doc_generic_proposal_odt extends ModelePDFPropales
 				$array_soc = $this->get_substitutionarray_mysoc($mysoc, $outputlangs);
 				$array_thirdparty = $this->get_substitutionarray_thirdparty($socobject, $outputlangs);
 				$array_other = $this->get_substitutionarray_other($outputlangs);
+
+				include_once DOL_DOCUMENT_ROOT.'/societe/class/companybankaccount.class.php';
+	            $companybankaccount = new CompanyBankAccount($this->db);
+	            $companybankaccount->fetch(0, $object->thirdparty->id);
+				$array_objet['company_default_bank_iban']=$companybankaccount->iban;
+				$array_objet['company_default_bank_bic']=$companybankaccount->bic;
+				
 				// retrieve contact information for use in object as contact_xxx tags
 				$array_thirdparty_contact = array();
 				if ($usecontact && is_object($contactobject)) {


### PR DESCRIPTION
company_default_bank_iban et
company_default_bank_bic ne sont pas substitués dans les templates ODT, ces champs sont calculés dans get_substitutionarray_object, mais vide maintenant, sans doute suite à l'introduction de compte bancaire multiples pour les fiches clients - j'en ai besoin pour preremplir des mandats SEPA sur la propal

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE" or "NEW" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]
