### PR TITLE
llx_product_extrafields should probably also use fk_product

### DIFF
--- a/htdocs/install/mysql/migration/repair.sql
+++ b/htdocs/install/mysql/migration/repair.sql
@@ -129,7 +129,7 @@ update llx_commande set fk_user_valid = null where fk_user_valid not in (select 
 
 delete from llx_societe_extrafields where fk_object not in (select rowid from llx_societe);
 delete from llx_adherent_extrafields where fk_object not in (select rowid from llx_adherent);
-delete from llx_product_extrafields where fk_object not in (select rowid from llx_product);
+delete from llx_product_extrafields where fk_product not in (select rowid from llx_product);
 --delete from llx_societe_commerciaux where fk_soc not in (select rowid from llx_societe);
 
 UPDATE llx_product SET datec = tms WHERE datec IS NULL;

--- a/htdocs/install/mysql/tables/llx_product_extrafields.key.sql
+++ b/htdocs/install/mysql/tables/llx_product_extrafields.key.sql
@@ -17,4 +17,4 @@
 -- ===================================================================
 
 
-ALTER TABLE llx_product_extrafields ADD INDEX idx_product_extrafields (fk_object);
+ALTER TABLE llx_product_extrafields ADD INDEX idx_product_extrafields (fk_product);

--- a/htdocs/install/mysql/tables/llx_product_extrafields.sql
+++ b/htdocs/install/mysql/tables/llx_product_extrafields.sql
@@ -20,6 +20,6 @@ create table llx_product_extrafields
 (
   rowid                     integer AUTO_INCREMENT PRIMARY KEY,
   tms                       timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  fk_object                 integer NOT NULL,
+  fk_product                integer NOT NULL,
   import_key                varchar(14)                          		-- import key
 ) ENGINE=innodb;


### PR DESCRIPTION
# NEW [*llx_product_extrafields now uses fk_product just like other llx_product tables*]

[*llx_product_extrafields used fk_object, where as all these tables uses fk_product. llx_product_extrafields should probably also use fk_product just like these other tables below

llx_product_association
llx_product_attribute_combination
llx_product_attribute_combination_price_level
llx_product_attribute_value
llx_product_batch
llx_product_customer_price
llx_product_customer_price_log
llx_product_fournisseur_price
llx_product_fournisseur_price_log
llx_product_lang
llx_product_lot
llx_product_price
llx_product_price_by_qty
llx_product_stock
llx_product_warehouse_properties

These 2 tables also contains fk_object, but I have no data in them, so I am unsure if they are really the same data: llx_product_fournisseur_price_extrafields, llx_product_lot_extrafields*]

