### PR TITLE
Remove duplicate code

### DIFF
--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -651,9 +651,6 @@ if (!empty($searchCategoryProductList)) {
 		}
 	}
 }
-if ($search_status != '' && $search_status >= 0) {
-	$sql .= " AND f.fk_statut = ".((int) $search_status);
-}
 if ($filter && $filter != -1) {
 	$aFilter = explode(',', $filter);
 	foreach ($aFilter as $fil) {


### PR DESCRIPTION
# FIX Repeated code block
Remove second occurrence of duplicate code, previously used in lines 567-569:

```php
if ($search_status != '' && $search_status >= 0) { 
    $sql .= " AND f.fk_statut = ".((int) $search_status);
}
```