### PR TITLE
Remove unnecessary queries

### DIFF
--- a/htdocs/accountancy/journal/purchasesjournal.php
+++ b/htdocs/accountancy/journal/purchasesjournal.php
@@ -325,6 +325,12 @@ if ($result) {
 	dol_print_error($db);
 }
 
+// Check for too many invoices first.
+if (count($tabfac) > 10000) { // Global config in htdocs/admin/const.php???
+	$error++;
+	setEventMessages("TooManyInvoicesToProcessPleaseUseAMoreSelectiveFilter", null, 'errors');
+}
+
 $errorforinvoice = array();
 
 /*
@@ -357,6 +363,7 @@ WHERE
     fd.product_type <= 2
     AND fd.fk_code_ventilation <= 0
     AND fd.total_ttc <> 0
+	AND fk_facture_fourn IN (".$db->sanitize(join(",", array_keys($tabfac))).")
 GROUP BY fk_facture_fourn
 ";
 $resql = $db->query($sql);

--- a/htdocs/accountancy/journal/purchasesjournal.php
+++ b/htdocs/accountancy/journal/purchasesjournal.php
@@ -361,7 +361,7 @@ GROUP BY fk_facture_fourn
 ";
 $resql = $db->query($sql);
 
-$num = $db->num_rows($result);
+$num = $db->num_rows($resql);
 $i = 0;
 while ($i < $num) {
 	$obj = $db->fetch_object($resql);

--- a/htdocs/accountancy/journal/purchasesjournal.php
+++ b/htdocs/accountancy/journal/purchasesjournal.php
@@ -368,6 +368,7 @@ while ($i < $num) {
 	if ($obj->nb > 0) {
 		$errorforinvoice[$obj->fk_facture_fourn] = 'somelinesarenotbound';
 	}
+	$i++;
 }
 //var_dump($errorforinvoice);exit;
 


### PR DESCRIPTION
# NEW|New Remove unnecessary queries in `accountancy/journal/purchasesjournal.php`
To address https://github.com/Dolibarr/dolibarr/issues/25762, for every invoice there were 2 unnecessary queries, 1 to get vat data with `getTaxesFromId()` and 1 to detect lines with not binding lines.

The first one is fixed by creating an array to store already retrieved vat data.
The second one is fixed by getting all invoices with unbound lines at once (should be faster than multiple queries) and populating the `$errorforinvoice` array with thos eunbound lines. As far as I can see `$errorforinvoice` is always accessed like `$errorforinvoice[$key]` inside a `foreach $array as $key => $value` loop so even if we add to `$errorforinvoice` invoices that are not shown the errors won't be shown either.