### PR TITLE
Fix attempt to access stdClass::$* on query result

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4256,6 +4256,10 @@ abstract class CommonObject
 			return -1;
 		}
 
+		if (!preg_match('/^[_a-zA-Z0-9]+$/', $field_select)) {
+			error_log("ERROR: Invalid value '$field_select' for parameter \$field_select in call to getAllItemsLinkedByObjectID(). Must be a single field name.");
+		}
+
 		global $db;
 
 		$sql = "SELECT ".$field_select." FROM ".$db->prefix().$table_element." WHERE ".$field_where." = ".((int) $fk_object_where);
@@ -4269,6 +4273,33 @@ abstract class CommonObject
 		}
 
 		return $TRes;
+	}
+
+	/**
+	 * Count items linked to an object id in association table
+	 *
+	 * @param	int		$fk_object_where		id of object we need to get linked items
+	 * @param	string	$field_where			name of field of object we need to get linked items
+	 * @param	string	$table_element			name of association table
+	 * @return 	array|int						Array of record, -1 if empty
+	 */
+	public static function getCountOfItemsLinkedByObjectID($fk_object_where, $field_where, $table_element)
+	{
+		if (empty($fk_object_where) || empty($field_where) || empty($table_element)) {
+			return -1;
+		}
+
+		global $db;
+
+		$sql = "SELECT COUNT(*) n FROM ".$db->prefix().$table_element." WHERE ".$field_where." = ".((int) $fk_object_where);
+		$resql = $db->query($sql);
+		$n = 0;
+		if ($resql) {
+			$res = $db->fetch_object($resql);
+			if ($res) $n = $res->n;
+		}
+
+		return $n;
 	}
 
 	/**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4290,12 +4290,14 @@ abstract class CommonObject
 
 		global $db;
 
-		$sql = "SELECT COUNT(*) n FROM ".$db->prefix().$table_element." WHERE ".$field_where." = ".((int) $fk_object_where);
+		$sql = "SELECT COUNT(*) as nb FROM ".$db->prefix().$table_element." WHERE ".$field_where." = ".((int) $fk_object_where);
 		$resql = $db->query($sql);
 		$n = 0;
 		if ($resql) {
 			$res = $db->fetch_object($resql);
-			if ($res) $n = $res->n;
+			if ($res) {
+				$n = $res->nb;
+			}
 		}
 
 		return $n;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4255,9 +4255,8 @@ abstract class CommonObject
 		if (empty($fk_object_where) || empty($field_where) || empty($table_element)) {
 			return -1;
 		}
-
 		if (!preg_match('/^[_a-zA-Z0-9]+$/', $field_select)) {
-			error_log("ERROR: Invalid value '$field_select' for parameter \$field_select in call to getAllItemsLinkedByObjectID(). Must be a single field name.");
+			dol_syslog('Invalid value $field_select for parameter '.$field_select.' in call to getAllItemsLinkedByObjectID(). Must be a single field name.', LOG_ERR);
 		}
 
 		global $db;

--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -214,7 +214,7 @@ function project_prepare_head(Project $project, $moreparam = '')
 	if (isModEnabled('ticket') && $user->hasRight('ticket', 'read')) {
 		require_once DOL_DOCUMENT_ROOT.'/ticket/class/ticket.class.php';
 		$Tickettatic = new Ticket($db);
-		$nbTicket = count($Tickettatic->getAllItemsLinkedByObjectID($project->id, '*', 'fk_project', 'ticket'));
+		$nbTicket = $Tickettatic->getCountOfItemsLinkedByObjectID($project->id, 'fk_project', 'ticket');
 		$head[$h][0] = DOL_URL_ROOT.'/ticket/list.php?projectid='.((int) $project->id);
 		$head[$h][1] = $langs->trans("Ticket");
 		if ($nbTicket > 0) {


### PR DESCRIPTION
# FIX attempt to access stdClass::$* on query result
Existing code resulted in a PHP 'undefined property' warning, and was also inefficient, pulling the whole list from the database for PHP to count.  The change:
- warns if the `$field_select` argument to `getAllItemsLinkedByObjectID()` is invalid
- gets the database to count the records in this case and return a single result