### PR TITLE
FIX : Can't access to rec supplier invoice card

### DIFF
--- a/htdocs/fourn/facture/card-rec.php
+++ b/htdocs/fourn/facture/card-rec.php
@@ -72,7 +72,7 @@ $month_date_when = GETPOST('month_date_when');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-$objecttype = 'facturefournisseur_rec';
+$objecttype = 'facture_fourn_rec';
 if ($action == "create" || $action == "add") {
 	$objecttype = '';
 }


### PR DESCRIPTION
## FIX : Can't access to rec supplier invoice card

We can't access to the supplier invoice rec card. 
Indeed, it seems that $objecttype value must be equal to the name of the table used for supplier invoice rec