### PR TITLE
Fix #25613

### DIFF
--- a/htdocs/core/class/smtps.class.php
+++ b/htdocs/core/class/smtps.class.php
@@ -653,6 +653,7 @@ class SMTPs
 	{
 		global $conf;
 
+		require_once DOL_DOCUMENT_ROOT.'/core/lib/geturl.lib.php';
 		/**
 		 * Default return value
 		 */


### PR DESCRIPTION
#FIX #25613
Missing core/lib/geturl.lib.php, function getDomainFromURL  is used in sendMsg()