### PR TITLE
fix sql query for external users

### DIFF
--- a/htdocs/commande/class/commandestats.class.php
+++ b/htdocs/commande/class/commandestats.class.php
@@ -245,13 +245,14 @@ class CommandeStats extends Stats
 		global $user;
 
 		$sql = "SELECT product.ref, COUNT(product.ref) as nb, SUM(tl.".$this->field_line.") as total, AVG(tl.".$this->field_line.") as avg";
-		$sql .= " FROM ".$this->from.", ".$this->from_line.", ".MAIN_DB_PREFIX."product as product";
+		$sql .= " FROM ".$this->from;
+		$sql .= " LEFT JOIN ".$this->from_line." ON c.rowid = tl.fk_commande ";
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as product ON tl.fk_product = product.rowid";
 		if (empty($user->rights->societe->client->voir) && !$user->socid) {
 			$sql .= "  INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON c.fk_soc = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 		}
 		$sql .= $this->join;
 		$sql .= " WHERE ".$this->where;
-		$sql .= " AND c.rowid = tl.fk_commande AND tl.fk_product = product.rowid";
 		$sql .= " AND c.date_commande BETWEEN '".$this->db->idate(dol_get_first_day($year, 1, false))."' AND '".$this->db->idate(dol_get_last_day($year, 12, false))."'";
 		$sql .= " GROUP BY product.ref";
 		$sql .= $this->db->order('nb', 'DESC');

--- a/htdocs/commande/class/commandestats.class.php
+++ b/htdocs/commande/class/commandestats.class.php
@@ -246,8 +246,8 @@ class CommandeStats extends Stats
 
 		$sql = "SELECT product.ref, COUNT(product.ref) as nb, SUM(tl.".$this->field_line.") as total, AVG(tl.".$this->field_line.") as avg";
 		$sql .= " FROM ".$this->from;
-		$sql .= " LEFT JOIN ".$this->from_line." ON c.rowid = tl.fk_commande ";
-		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as product ON tl.fk_product = product.rowid";
+		$sql .= " INNER JOIN ".$this->from_line." ON c.rowid = tl.fk_commande ";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."product as product ON tl.fk_product = product.rowid";
 		if (empty($user->rights->societe->client->voir) && !$user->socid) {
 			$sql .= "  INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON c.fk_soc = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 		}


### PR DESCRIPTION
# FIX Sql query returning an error
When the user is an external user and the box is display, it returns an error because the query structure

Type gestionnaire de base de données: mysqli
Requête dernier accès en base en erreur: SELECT product.ref, COUNT(product.ref) as nb, SUM(tl.total_ht) as total, AVG(tl.total_ht) as avg FROM llx_commande as c, llx_commandedet as tl, llx_product as product INNER JOIN llx_societe_commerciaux as sc ON c.fk_soc = sc.fk_soc AND sc.fk_user = 66 WHERE c.entity IN (2,1) AND c.rowid = tl.fk_commande AND tl.fk_product = product.rowid AND c.date_commande BETWEEN '2023-01-01 00:00:00' AND '2023-12-31 23:59:59' GROUP BY product.ref ORDER BY nb DESC
Code retour dernier accès en base en erreur: DB_ERROR_NOSUCHFIELD
Information sur le dernier accès en base en erreur: Unknown column 'c.fk_soc' in 'on clause'

