### PR TITLE
FIX payment : language is not propagated to following pages

### DIFF
--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -97,6 +97,7 @@ if (!GETPOST("currency", 'alpha')) {
 }
 $source = GETPOST("s", 'aZ09') ?GETPOST("s", 'aZ09') : GETPOST("source", 'aZ09');
 $download = GETPOST('d', 'int') ?GETPOST('d', 'int') : GETPOST('download', 'int');
+$getpostlang = GETPOST('lang', 'aZ09');
 
 if (!$action) {
 	if (!GETPOST("amount", 'alpha') && !$source) {
@@ -241,6 +242,10 @@ if (!empty($SECUREKEY)) {
 if (!empty($entity)) {
 	$urlok .= 'e='.urlencode($entity).'&';
 	$urlko .= 'e='.urlencode($entity).'&';
+}
+if (!empty($getpostlang)) {
+	$urlok .= 'lang='.urlencode($getpostlang).'&';
+	$urlko .= 'lang='.urlencode($getpostlang).'&';
 }
 $urlok = preg_replace('/&$/', '', $urlok); // Remove last &
 $urlko = preg_replace('/&$/', '', $urlko); // Remove last &
@@ -814,7 +819,7 @@ $form = new Form($db);
 
 $head = '';
 if (!empty($conf->global->ONLINE_PAYMENT_CSS_URL)) {
-	$head = '<link rel="stylesheet" type="text/css" href="'.$conf->global->ONLINE_PAYMENT_CSS_URL.'?lang='.$langs->defaultlang.'">'."\n";
+	$head = '<link rel="stylesheet" type="text/css" href="'.$conf->global->ONLINE_PAYMENT_CSS_URL.'?lang='.(!empty($getpostlang) ? $getpostlang: $langs->defaultlang).'">'."\n";
 }
 
 $conf->dol_hide_topmenu = 1;
@@ -853,6 +858,7 @@ print '<input type="hidden" name="suffix" value="'.dol_escape_htmltag($suffix).'
 print '<input type="hidden" name="securekey" value="'.dol_escape_htmltag($SECUREKEY).'">'."\n";
 print '<input type="hidden" name="e" value="'.$entity.'" />';
 print '<input type="hidden" name="forcesandbox" value="'.GETPOST('forcesandbox', 'int').'" />';
+print '<input type="hidden" name="lang" value="'.$getpostlang.'">';
 print "\n";
 
 
@@ -2105,6 +2111,7 @@ if ($action != 'dopayment') {
 			}
 
 			if ((empty($paymentmethod) || $paymentmethod == 'paypal') && !empty($conf->paypal->enabled)) {
+
 				if (empty($conf->global->PAYPAL_API_INTEGRAL_OR_PAYPALONLY)) {
 					$conf->global->PAYPAL_API_INTEGRAL_OR_PAYPALONLY = 'integral';
 				}
@@ -2209,6 +2216,7 @@ if (preg_match('/^dopayment/', $action)) {			// If we choosed/click on the payme
 		print '<input type="hidden" name="forcesandbox" value="'.GETPOST('forcesandbox', 'int').'" />';
 		print '<input type="hidden" name="email" value="'.GETPOST('email', 'alpha').'" />';
 		print '<input type="hidden" name="thirdparty_id" value="'.GETPOST('thirdparty_id', 'int').'" />';
+		print '<input type="hidden" name="lang" value="'.$getpostlang.'">';
 
 		if (!empty($conf->global->STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION) || !empty($conf->global->STRIPE_USE_NEW_CHECKOUT)) {	// Use a SCA ready method
 			require_once DOL_DOCUMENT_ROOT.'/stripe/class/stripe.class.php';


### PR DESCRIPTION
Fix : on Stripe payment page, the &lang parameter is not correctly handled.

Context : the owner of the DLB instance is a french company (DLB default language is FR). It has some german customers thet pay with Stripe. But the Stripe portal is in French.

On payment page, a parameter &lang is used on the first page load but not on following screens.

first screen, german is OK : 

![Capture d’écran_2023-09-07_17-02-09](https://github.com/Easya-Solutions/dolibarr/assets/89838020/acadfaf6-ad2c-42f5-85ae-73f360e549dc)

second screen, german is broken : 

![Capture d’écran_2023-09-07_17-03-04](https://github.com/Easya-Solutions/dolibarr/assets/89838020/d44308f8-6c70-467b-9a36-04d05e56e1d4)

This PR fixes this behavior by passing lang as a parameter in forms.

