### PR TITLE
use Product instance for dol_banner

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project version="7.1">
-    <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />
+<project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="highlightLevel" value="WARNING" />
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
 </project>
-

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -102,8 +102,10 @@ if (!$sortorder) {
 $hookmanager->initHooks(array('pricesuppliercard', 'globalcard'));
 
 $object = new ProductFournisseur($db);
+$prod = new Product($db);
 if ($id > 0 || $ref) {
 	$object->fetch($id, $ref);
+    $prod->fetch($id, $ref);
 }
 
 $usercanread = (($object->type == Product::TYPE_PRODUCT && $user->rights->produit->lire) || ($object->type == Product::TYPE_SERVICE && $user->hasRight('service', 'lire')));
@@ -396,7 +398,7 @@ if ($id > 0 || $ref) {
 				$shownav = 0;
 			}
 
-			dol_banner_tab($object, 'ref', $linkback, $shownav, 'ref');
+			dol_banner_tab($prod, 'ref', $linkback, $shownav, 'ref');
 
 			print '<div class="fichecenter">';
 


### PR DESCRIPTION
# FIX Dol_banner on product/fournisseur.php
the use of a ProductFournisseur object comes with an issue on banner display. The status of the product is different from the other tabs.

![ksnip_20230908-103635](https://github.com/Dolibarr/dolibarr/assets/30891670/c07acbfd-acc1-4ca5-8c4c-1f45d0940fe0)

If we use a Product instance in banner, it displays the status better

![ksnip_20230908-103826](https://github.com/Dolibarr/dolibarr/assets/30891670/11964683-1cd5-4cf4-8c70-d5ffb3cb66e2)
