### PR TITLE
FIX right access on salary card and tabs

### DIFF
--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -85,8 +85,7 @@ if ($id > 0 || !empty($ref)) {
 	$canread = 0;
 	if (!empty($user->rights->salaries->readall)) {
 		$canread = 1;
-	}
-	if (!empty($user->rights->salaries->read) && $object->fk_user > 0 && in_array($object->fk_user, $childids)) {
+	} elseif (!empty($user->rights->salaries->read) && $object->fk_user > 0 && in_array($object->fk_user, $childids)) {
 		$canread = 1;
 	}
 	if (!$canread) {

--- a/htdocs/salaries/document.php
+++ b/htdocs/salaries/document.php
@@ -63,8 +63,21 @@ if (!$sortfield) {
 }
 
 $object = new Salary($db);
+$childids = $user->getAllChildIds(1);
 if ($id > 0 || !empty($ref)) {
 	$object->fetch($id, $ref);
+
+	// Check current user can read this salary
+	$canread = 0;
+	if (!empty($user->rights->salaries->readall)) {
+		$canread = 1;
+	} elseif (!empty($user->rights->salaries->read) && $object->fk_user > 0 && in_array($object->fk_user, $childids)) {
+		$canread = 1;
+	}
+
+	if (!$canread) {
+		accessforbidden();
+	}
 }
 
 $upload_dir = $conf->salaries->dir_output.'/'.dol_sanitizeFileName($object->id);

--- a/htdocs/salaries/info.php
+++ b/htdocs/salaries/info.php
@@ -37,8 +37,21 @@ $ref = GETPOST('ref', 'alpha');
 $action = GETPOST('action', 'aZ09');
 
 $object = new Salary($db);
+$childids = $user->getAllChildIds(1);
 if ($id > 0 || !empty($ref)) {
 	$object->fetch($id, $ref);
+
+	// Check current user can read this salary
+	$canread = 0;
+	if (!empty($user->rights->salaries->readall)) {
+		$canread = 1;
+	} elseif (!empty($user->rights->salaries->read) && $object->fk_user > 0 && in_array($object->fk_user, $childids)) {
+		$canread = 1;
+	}
+
+	if (!$canread) {
+		accessforbidden();
+	}
 }
 
 // Security check


### PR DESCRIPTION
FIX right access on salary card and tabs
- without this fix you can access on others salaries cards even if theses cards are not yours

**To Reproduce**
1) crate two salaries cards : one for "user1" and another to "user2"
2) log-in with "user1" and go to your salary card
3) then go on "document" or "info" tab of salary card
4) navigate to other cards and you will see the salary card of "user2"
