### PR TITLE
NEW - Conf allow modify ticket classification even if closed

### DIFF
--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -600,6 +600,21 @@ print $formcategory->textwithpicto('', $langs->trans("TicketsDelayBetweenAnswers
 print '</td>';
 print '</tr>';
 
+//Allow classification modification even if the ticket is closed
+print '<tr class="oddeven"><td>'.$langs->trans("TicketsAllowClassificationModificationIfClosed").'</td>';
+print '<td class="left">';
+if ($conf->use_javascript_ajax) {
+	print ajax_constantonoff('TICKET_ALLOW_CLASSIFICATION_MODIFICATION_EVEN_IF_CLOSED');
+} else {
+	$arrval = array('0' => $langs->trans("No"), '1' => $langs->trans("Yes"));
+	print $formcategory->selectarray("TICKET_ALLOW_CLASSIFICATION_MODIFICATION_EVEN_IF_CLOSED", $arrval, getDolGlobalString('TICKET_ALLOW_CLASSIFICATION_MODIFICATION_EVEN_IF_CLOSED'));
+}
+print '</td>';
+print '<td class="center">';
+print $formcategory->textwithpicto('', $langs->trans("TicketsAllowClassificationModificationIfClosedHelp"), 1, 'help');
+print '</td>';
+print '</tr>';
+
 print '</table><br>';
 
 print $formcategory->buttonsSaveCancel("Save", '', array(), 0, 'reposition');

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -158,6 +158,8 @@ TicketChooseProductCategory=Product category for ticket support
 TicketChooseProductCategoryHelp=Select the product category of ticket support. This will be used to automatically link a contract to a ticket.
 TicketUseCaptchaCode=Use graphical code (CAPTCHA) when creating a ticket
 TicketUseCaptchaCodeHelp=Adds CAPTCHA verification when creating a new ticket.
+TicketsAllowClassificationModificationIfClosed=Allow to modify classification of a closed ticket
+TicketsAllowClassificationModificationIfClosed=Allow to modify classification (type, ticket group, severity) even if tickets are closed.
 
 #
 # Index & list page

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -158,8 +158,8 @@ TicketChooseProductCategory=Product category for ticket support
 TicketChooseProductCategoryHelp=Select the product category of ticket support. This will be used to automatically link a contract to a ticket.
 TicketUseCaptchaCode=Use graphical code (CAPTCHA) when creating a ticket
 TicketUseCaptchaCodeHelp=Adds CAPTCHA verification when creating a new ticket.
-TicketsAllowClassificationModificationIfClosed=Allow to modify classification of a closed ticket
-TicketsAllowClassificationModificationIfClosed=Allow to modify classification (type, ticket group, severity) even if tickets are closed.
+TicketsAllowClassificationModificationIfClosed=Allow to modify classification of closed tickets
+TicketsAllowClassificationModificationIfClosedHelp=Allow to modify classification (type, ticket group, severity) even if tickets are closed.
 
 #
 # Index & list page

--- a/htdocs/langs/fr_FR/ticket.lang
+++ b/htdocs/langs/fr_FR/ticket.lang
@@ -158,8 +158,8 @@ TicketChooseProductCategory=Catégorie de produit pour les tickets
 TicketChooseProductCategoryHelp=Sélectionnez la catégorie de produit du support de ticket. Celui-ci sera utilisé pour lier automatiquement un contrat à un ticket.
 TicketUseCaptchaCode=Utiliser le code graphique (CAPTCHA) lors de la création d'un ticket
 TicketUseCaptchaCodeHelp=Ajoute la vérification CAPTCHA lors de la création d'un nouveau ticket.
-TicketsAllowClassificationModificationIfClosed=Permettre la modification de la classification des tickets résolus.
-TicketsAllowClassificationModificationIfClosed=Permettre la modification de la classification (type, groupe de ticket et sévérité) même si les tickets sont résolus.
+TicketsAllowClassificationModificationIfClosed=Permettre la modification de la classification des tickets résolus
+TicketsAllowClassificationModificationIfClosedHelp=Permettre la modification de la classification (type, groupe de ticket et sévérité) même si les tickets sont résolus.
 
 #
 # Index & list page

--- a/htdocs/langs/fr_FR/ticket.lang
+++ b/htdocs/langs/fr_FR/ticket.lang
@@ -158,6 +158,8 @@ TicketChooseProductCategory=Catégorie de produit pour les tickets
 TicketChooseProductCategoryHelp=Sélectionnez la catégorie de produit du support de ticket. Celui-ci sera utilisé pour lier automatiquement un contrat à un ticket.
 TicketUseCaptchaCode=Utiliser le code graphique (CAPTCHA) lors de la création d'un ticket
 TicketUseCaptchaCodeHelp=Ajoute la vérification CAPTCHA lors de la création d'un nouveau ticket.
+TicketsAllowClassificationModificationIfClosed=Permettre la modification de la classification des tickets résolus.
+TicketsAllowClassificationModificationIfClosed=Permettre la modification de la classification (type, groupe de ticket et sévérité) même si les tickets sont résolus.
 
 #
 # Index & list page

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -1245,7 +1245,7 @@ if ($action == 'create' || $action == 'presend') {
 			print '<input type="submit" class="button small" name="btn_update_ticket_prop" value="'.$langs->trans("Modify").'" />';
 		} else {
 			// Button to edit Properties
-			if (isset($object->status) && $object->status < $object::STATUS_NEED_MORE_INFO && $user->rights->ticket->write) {
+			if (isset($object->status) && ($object->status < $object::STATUS_NEED_MORE_INFO || !empty($conf->global->TICKET_ALLOW_CLASSIFICATION_MODIFICATION_EVEN_IF_CLOSED)) && $user->rights->ticket->write) {
 				print ' <a class="editfielda" href="card.php?track_id='.$object->track_id.'&set=properties">'.img_edit($langs->trans('Modify')).'</a>';
 			}
 		}


### PR DESCRIPTION
# NEW|New configuration to allow to modify ticket classification even if closed
New configuration in ticket module to allow to change classification (type, group and severity) for tiekcts even if tickets are closed.
This is a very useful feature when we need to change classification for reporting purposes when the ticket is already closed. 
We can do it by coming back in a previous status but when we close again the ticket we change the closed date and it's not good for reporting.
