### PR TITLE
fix addupdatedelete action for update_extras

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -349,26 +349,26 @@ if (preg_match('/^set(\w+)$/', $action, $reg) && GETPOST('id', 'int') > 0 && !em
 if ($action == "update_extras" && GETPOST('id', 'int') > 0 && !empty($permissiontoadd)) {
 	$object->fetch(GETPOST('id', 'int'));
 
-	$attributekey = GETPOST('attribute', 'alpha');
-	$attributekeylong = 'options_'.$attributekey;
+    $error = 0;
 
-	if (GETPOSTISSET($attributekeylong.'day') && GETPOSTISSET($attributekeylong.'month') && GETPOSTISSET($attributekeylong.'year')) {
-		// This is properties of a date
-		$object->array_options['options_'.$attributekey] = dol_mktime(GETPOST($attributekeylong.'hour', 'int'), GETPOST($attributekeylong.'min', 'int'), GETPOST($attributekeylong.'sec', 'int'), GETPOST($attributekeylong.'month', 'int'), GETPOST($attributekeylong.'day', 'int'), GETPOST($attributekeylong.'year', 'int'));
-		//var_dump(dol_print_date($object->array_options['options_'.$attributekey]));exit;
-	} else {
-		$object->array_options['options_'.$attributekey] = GETPOST($attributekeylong, 'alpha');
-	}
+    $ret = $extrafields->setOptionalsFromPost(null, $object, '@GETPOSTISSET');
+    if ($ret < 0) {
+        $error++;
+        setEventMessages($extrafields->error, $object->errors, 'errors');
+        $action = 'edit_extras';
+    }
+    else {
+        $result = $object->insertExtraFields(empty($triggermodname) ? '' : $triggermodname, $user);
+        if ($result > 0) {
+            setEventMessages($langs->trans('RecordSaved'), null, 'mesgs');
+            $action = 'view';
+        } else {
+            $error++;
+            setEventMessages($object->error, $object->errors, 'errors');
+            $action = 'edit_extras';
+        }
+    }
 
-	$result = $object->insertExtraFields(empty($triggermodname) ? '' : $triggermodname, $user);
-	if ($result > 0) {
-		setEventMessages($langs->trans('RecordSaved'), null, 'mesgs');
-		$action = 'view';
-	} else {
-		$error++;
-		setEventMessages($object->error, $object->errors, 'errors');
-		$action = 'edit_extras';
-	}
 }
 
 // Action to delete


### PR DESCRIPTION
# FIX addupdatedelete action for update_extras

As the second parameter of GETPOST is 'alpha', this template comes to an issue with the html extrafields. It prevent these extrafields to have formatting.

using $extrafields->setOptionalsFromPost manage every type of extrafields properly for the current object.