### PR TITLE
add comment

### DIFF
--- a/htdocs/core/lib/oauth.lib.php
+++ b/htdocs/core/lib/oauth.lib.php
@@ -25,18 +25,66 @@
 
 // Supported OAUTH (a provider is supported when a file xxx_oauthcallback.php is available into htdocs/core/modules/oauth)
 $supportedoauth2array = array(
-	'OAUTH_GOOGLE_NAME'=>array('callbackfile' => 'google', 'picto' => 'google', 'urlforapp' => 'OAUTH_GOOGLE_DESC', 'name'=>'Google', 'urlforcredentials'=>'https://console.developers.google.com/',
-		'availablescopes'=> 'userinfo_email,userinfo_profile,openid,email,profile,cloud_print,admin_directory_user,gmail_full,contact,https://www.googleapis.com/auth/contacts,https://www.googleapis.com/auth/calendar', 'returnurl'=>'/core/modules/oauth/google_oauthcallback.php'),
+	'OAUTH_GOOGLE_NAME' => array(
+		'callbackfile' => 'google',
+		'picto' => 'google',
+		'urlforapp' => 'OAUTH_GOOGLE_DESC',
+		'name' => 'Google',
+		'urlforcredentials' => 'https://console.developers.google.com/',
+		'availablescopes' => 'userinfo_email,userinfo_profile,openid,email,profile,cloud_print,admin_directory_user,gmail_full,contact,https://www.googleapis.com/auth/contacts,https://www.googleapis.com/auth/calendar',
+		'returnurl' => '/core/modules/oauth/google_oauthcallback.php'
+	),
 );
 if (isModEnabled('stripe')) {
-	$supportedoauth2array['OAUTH_STRIPE_TEST_NAME'] = array('callbackfile' => 'stripetest', 'picto' => 'stripe', 'urlforapp' => '', 'name'=>'StripeTest', 'urlforcredentials'=>'', 'availablescopes'=>'read_write', 'returnurl'=>'/core/modules/oauth/stripetest_oauthcallback.php');
-	$supportedoauth2array['OAUTH_STRIPE_LIVE_NAME'] = array('callbackfile' => 'stripelive', 'picto' => 'stripe', 'urlforapp' => '', 'name'=>'StripeLive', 'urlforcredentials'=>'', 'availablescopes'=>'read_write', 'returnurl'=>'/core/modules/oauth/stripelive_oauthcallback.php');
+	$supportedoauth2array['OAUTH_STRIPE_TEST_NAME'] = array(
+		'callbackfile' => 'stripetest',
+		'picto' => 'stripe',
+		'urlforapp' => '',
+		'name' => 'StripeTest',
+		'urlforcredentials' => '',
+		'availablescopes' => 'read_write',
+		'returnurl' => '/core/modules/oauth/stripetest_oauthcallback.php'
+	);
+	$supportedoauth2array['OAUTH_STRIPE_LIVE_NAME'] = array(
+		'callbackfile' => 'stripelive',
+		'picto' => 'stripe',
+		'urlforapp' => '',
+		'name' => 'StripeLive',
+		'urlforcredentials' => '',
+		'availablescopes' => 'read_write',
+		'returnurl' => '/core/modules/oauth/stripelive_oauthcallback.php'
+	);
 }
-$supportedoauth2array['OAUTH_GITHUB_NAME'] = array('callbackfile' => 'github', 'picto' => 'github', 'urlforapp' => 'OAUTH_GITHUB_DESC', 'name'=>'GitHub', 'urlforcredentials'=>'https://github.com/settings/developers', 'availablescopes'=>'user,public_repo', 'returnurl'=>'/core/modules/oauth/github_oauthcallback.php');
-$supportedoauth2array['OAUTH_MICROSOFT_NAME'] = array('callbackfile' => 'microsoft', 'picto' => 'microsoft', 'urlforapp' => 'OAUTH_MICROSOFT_DESC', 'name'=>'Microsoft', 'urlforcredentials'=>'https://portal.azure.com/', 'availablescopes'=>'openid,offline_access,profile,email,User.Read,https://outlook.office365.com/IMAP.AccessAsUser.All,https://outlook.office365.com/SMTP.Send', 'returnurl'=>'/core/modules/oauth/microsoft_oauthcallback.php');
+$supportedoauth2array['OAUTH_GITHUB_NAME'] = array(
+	'callbackfile' => 'github',
+	'picto' => 'github',
+	'urlforapp' => 'OAUTH_GITHUB_DESC',
+	'name' => 'GitHub',
+	'urlforcredentials' => 'https://github.com/settings/developers',
+	'availablescopes' => 'user,public_repo',
+	'returnurl' => '/core/modules/oauth/github_oauthcallback.php'
+);
+// See https://learn.microsoft.com/fr-fr/azure/active-directory/develop/quickstart-register-app#register-an-application
+$supportedoauth2array['OAUTH_MICROSOFT_NAME'] = array(
+	'callbackfile' => 'microsoft',
+	'picto' => 'microsoft',
+	'urlforapp' => 'OAUTH_MICROSOFT_DESC',
+	'name' => 'Microsoft',
+	'urlforcredentials' => 'https://portal.azure.com/',
+	// User.Read is a microsoftgraph scope, if it's not working, do not select it
+	'availablescopes' => 'openid,offline_access,profile,email,User.Read,https://outlook.office365.com/IMAP.AccessAsUser.All,https://outlook.office365.com/SMTP.Send',
+	'returnurl' => '/core/modules/oauth/microsoft_oauthcallback.php'
+);
 if (getDolGlobalInt('MAIN_FEATURES_LEVEL') >= 2) {
-	$supportedoauth2array['OAUTH_OTHER_NAME'] = array('callbackfile' => 'generic', 'picto' => 'generic', 'urlforapp' => 'OAUTH_OTHER_DESC', 'name'=>'Other', 'urlforcredentials'=>'', 'availablescopes'=>'Standard', 'returnurl'=>'/core/modules/oauth/generic_oauthcallback.php');
-	// See https://learn.microsoft.com/fr-fr/azure/active-directory/develop/quickstart-register-app#register-an-application
+	$supportedoauth2array['OAUTH_OTHER_NAME'] = array(
+		'callbackfile' => 'generic',
+		'picto' => 'generic',
+		'urlforapp' => 'OAUTH_OTHER_DESC',
+		'name' => 'Other',
+		'urlforcredentials' => '',
+		'availablescopes' => 'Standard',
+		'returnurl' => '/core/modules/oauth/generic_oauthcallback.php'
+	);
 }
 
 


### PR DESCRIPTION
https://stackoverflow.com/questions/61597263/office-365-xoauth2-for-imap-and-smtp-authentication-fails

IMAP, SMTP scopes are targeted for Exchange resource and not Graph. Whereas User.Read, Mail.ReadWrite are meant for Graph resource.

We do not support generation of tokens that are meant for two resources. Hence the error "Provided value for the input parameter scope is not valid because it contains more than one resource."

You should generate two tokens separately by two calls to /token. 1. One with the IMAP, SMTP scopes generated for the Exchange resource. 2. The other with Graph scopes (User.Read, Mail.ReadWrite) meant for Graph resource.
