### PR TITLE
fix: back port fix from issue #24429

### DIFF
--- a/htdocs/core/js/lib_head.js.php
+++ b/htdocs/core/js/lib_head.js.php
@@ -1302,14 +1302,14 @@ $(document).ready(function() {
 <?php
 if (empty($conf->global->MAIN_DISABLE_SELECT2_FOCUS_PROTECTION) && !defined('DISABLE_SELECT2_FOCUS_PROTECTION')) {
 	?>
-$(document).on('select2:open', () => {
+$(document).on('select2:open', (e) => {
 	console.log("Execute the focus (click on combo or use space when on component");
-	let allFound = document.querySelectorAll('.select2-container--open .select2-search__field');
-	$(this).one('mouseup keyup',()=>{
-		setTimeout(()=>{
-			allFound[allFound.length - 1].focus();
-		},0);
-	});
+	const target = $(e.target);
+	if (target && target.length) {
+		let id = target[0].id || target[0].name;
+		if (id.substr(-2) == "[]") id = id.substr(0,id.length-2);
+		document.querySelector('input[aria-controls*='+id+']').focus();
+	}
 });
 	<?php
 }


### PR DESCRIPTION
The issue #24429 exist on 17.0 on formmail receiver multiselectarray and the fix apply in 18.0 works (even if jQuery version is not the same)

Before fix :

https://github.com/Dolibarr/dolibarr/assets/1050053/ae962b7c-a16a-427b-a52a-a299b9200d54


After fix:


https://github.com/Dolibarr/dolibarr/assets/1050053/30895898-ed03-4698-a0a0-354b808a8318






