### PR TITLE
adding mariadb and mariadb-dump to the list of restricted os commands

### DIFF
--- a/htdocs/admin/system/security.php
+++ b/htdocs/admin/system/security.php
@@ -323,7 +323,7 @@ if (empty($dolibarr_main_restrict_os_commands)) {
 } else {
 	print $dolibarr_main_restrict_os_commands;
 }
-print ' <span class="opacitymedium">('.$langs->trans("RecommendedValueIs", 'mysqldump, mysql, pg_dump, pgrestore, clamdscan').')</span>';
+print ' <span class="opacitymedium">('.$langs->trans("RecommendedValueIs", 'mysqldump, mysql, pg_dump, pgrestore, mariadb, mariadb-dump, clamdscan').')</span>';
 print '<br>';
 
 if (empty($conf->global->SECURITY_DISABLE_TEST_ON_OBFUSCATED_CONF)) {

--- a/htdocs/conf/conf.php.example
+++ b/htdocs/conf/conf.php.example
@@ -284,11 +284,11 @@ $dolibarr_main_prod='1';
 // ==================================
 // To restrict commands you can execute by the backup feature, enter allowed command here.
 // Note: If you can, defining permission on OS linux (using SELinux for example) may be a better choice.
-// Default value: 'mysqldump, mysql, pg_dump, pgrestore'
+// Default value: 'mysqldump, mysql, pg_dump, pgrestore, mariadb, mariadb-dump'
 // Examples:
 // $dolibarr_main_restrict_os_commands='mysqldump, /usr/local/bin/otherdumptool';
 //
-$dolibarr_main_restrict_os_commands='mysqldump, mysql, pg_dump, pgrestore';
+$dolibarr_main_restrict_os_commands='mysqldump, mysql, pg_dump, pgrestore, mariadb, mariadb-dump';
 
 // dolibarr_main_restrict_ip
 // =========================

--- a/htdocs/install/step1.php
+++ b/htdocs/install/step1.php
@@ -920,7 +920,7 @@ function write_conf_file($conffile)
 		fputs($fp, '$dolibarr_main_force_https=\''.$main_force_https.'\';');
 		fputs($fp, "\n");
 
-		fputs($fp, '$dolibarr_main_restrict_os_commands=\'mysqldump, mysql, pg_dump, pgrestore, clamdscan, clamscan.exe\';');
+		fputs($fp, '$dolibarr_main_restrict_os_commands=\'mysqldump, mysql, pg_dump, pgrestore, mariadb, mariadb-dump, clamdscan, clamscan.exe\';');
 		fputs($fp, "\n");
 
 		fputs($fp, '$dolibarr_nocsrfcheck=\'0\';');


### PR DESCRIPTION
# NEW [*Add mariadb commands to allowed commands*]
[*mariadb uses different commands than mysql, so to make using mariadb with Dolibarr easier, dolibarr_main_restrict_os_commands was expanded with mariadb and mariadb-dump*]
