### PR TITLE
FIX : bad check return for sendfile

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -508,7 +508,7 @@ if (!$error && $massaction == 'confirm_presend') {
 						$resaction .= '<div class="error">'.$mailfile->error.'</div>';
 					} else {
 						$result = $mailfile->sendfile();
-						if ($result) {
+						if ($result > 0) {
 							$resaction .= $langs->trans('MailSuccessfulySent', $mailfile->getValidAddress($from, 2), $mailfile->getValidAddress($sendto, 2)).'<br>'; // Must not contain "
 
 							$error = 0;

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -509,7 +509,7 @@ if (!$error && $massaction == 'confirm_presend') {
 					} else {
 						$result = $mailfile->sendfile();
 						if ($result > 0) {
-							$resaction .= $langs->trans('MailSuccessfulySent', $mailfile->getValidAddress($from, 2), $mailfile->getValidAddress($sendto, 2)).'<br>'; // Must not contain "
+							$resaction .= $langs->trans('MailSuccessfulySent', $mailfile->getValidAddress($mailfile->addr_from, 2), $mailfile->getValidAddress($mailfile->addr_to, 2)).'<br>'; // Must not contain "
 
 							$error = 0;
 


### PR DESCRIPTION
# FIX : bad check return for sendfile
If we use hook and return -1, sendfile return the reshook then if($result) is true whereas it should return false