### PR TITLE
FIX: Missing error message on CommandeFourn creation

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1372,6 +1372,7 @@ if (empty($reshook)) {
 								);
 
 								if ($result < 0) {
+									setEventMessages($object->error, $object->errors, 'errors');
 									$error++;
 									break;
 								}


### PR DESCRIPTION
Add error message if addline function returns errors