### PR TITLE
FIX: Copy line label if there is no description given

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1347,7 +1347,7 @@ if (empty($reshook)) {
 								$object->special_code = $lines[$i]->special_code;
 
 								$result = $object->addline(
-									$desc,
+									empty($desc) ? $label : $desc,
 									$lines[$i]->subprice,
 									$lines[$i]->qty,
 									$tva_tx,


### PR DESCRIPTION
When we create a supplier Order from another object, lines have to be cloned, if there is no description on a parent line but a label, Label should be copied instead of leaving description empty. 