### PR TITLE
FIX : translation button

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -1594,7 +1594,7 @@ if ($object->id > 0) {
 								print '<div class="inline-block divButAction"><a class="butActionRefused classfortooltip" title="'.dol_escape_js($langs->trans("NoOrdersToInvoice")).'" href="#">'.$langs->trans("CreateInvoiceForThisCustomer").'</a></div>';
 							}
 						} else {
-							print '<div class="inline-block divButAction"><a class="butActionRefused classfortooltip" title="'.dol_escape_js($langs->trans("ThirdPartyMustBeEditAsCustomer")).'" href="#">'.$langs->trans("AddBill").'</a></div>';
+							print '<div class="inline-block divButAction"><a class="butActionRefused classfortooltip" title="'.dol_escape_js($langs->trans("ThirdPartyMustBeEditAsCustomer")).'" href="#">'.$langs->trans("CreateInvoiceForThisCustomer").'</a></div>';
 						}
 					}
 


### PR DESCRIPTION
Correction on the card of the third party for the prospects on the translation of button “Create an invoice or credit note” into “Invoice orders” because the button  “Create an invoice or credit note”
![1](https://github.com/Dolibarr/dolibarr/assets/91946767/9041eda9-7072-44f6-8bb5-75f1da08dfe1)
![2](https://github.com/Dolibarr/dolibarr/assets/91946767/94716bcd-1827-4727-98e5-d35f8f72435f)
.