### PR TITLE
NEW : add new hook AfterImportInsert

### DIFF
--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -2328,6 +2328,13 @@ if ($step == 6 && $datatoimport) {
 				if (!count($obj->errors) && !count($obj->warnings)) {
 					$nbok++;
 				}
+
+				$reshook = $hookmanager->executeHooks('AfterImportInsert', $parameters);
+				if ($reshook < 0) {
+					$arrayoferrors[$sourcelinenb][] = [
+						'lib' => implode("<br>", array_merge([$hookmanager->error], $hookmanager->errors))
+					];
+				}
 			}
 		}
 		// Close file


### PR DESCRIPTION
add hook AfterImportInsert that will be executed after line import.

use case : you want to call the validate method on en object after it was imported in database (not only update the status but do all the stuff in the validate function including triggers)