### PR TITLE
fix origin id of order_supplier when creating one invoice_supplier

### DIFF
--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -362,6 +362,7 @@ if (empty($reshook)) {
 		$validate_invoices = GETPOST('validate_invoices', 'int');
 
 		$TFact = array();
+		/** @var FactureFournisseur[] $TFactThird */
 		$TFactThird = array();
 
 		$nb_bills_created = 0;
@@ -380,7 +381,7 @@ if (empty($reshook)) {
 
 			$objecttmp = new FactureFournisseur($db);
 			if (!empty($createbills_onebythird) && !empty($TFactThird[$cmd->socid])) {
-				$objecttmp = $TFactThird[$cmd->socid]; // If option "one bill per third" is set, we use already created order.
+				$objecttmp = $TFactThird[$cmd->socid]; // If option "one bill per third" is set, we use already created supplier invoice.
 			} else {
 				$objecttmp->socid = $cmd->socid;
 				$objecttmp->type = $objecttmp::TYPE_STANDARD;
@@ -505,7 +506,8 @@ if (empty($reshook)) {
 								false,
 								$lines[$i]->array_options,
 								$lines[$i]->fk_unit,
-								$objecttmp->origin_id,
+								// we use the id of each order, not the id of the first one stored in $objecttmp->origin_id
+								$lines[$i]->fk_commande,
 								$lines[$i]->pa_ht,
 								$lines[$i]->ref_supplier,
 								$lines[$i]->special_code,


### PR DESCRIPTION
when creating one supplier invoice by thirdparty for many supplier order, it is the first order id used stored in the invoice for adding lines instead the id of each orders