### PR TITLE
NEW start and end date for due date filter on invoice list

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -145,8 +145,8 @@ $search_fac_rec_source_title = GETPOST("search_fac_rec_source_title", 'alpha');
 $search_btn = GETPOST('button_search', 'alpha');
 $search_remove_btn = GETPOST('button_removefilter', 'alpha');
 
-$option = GETPOST('search_option');
-if ($option == 'late') {
+$search_late = GETPOST('search_late');
+if ($search_late == 'late') {
 	$search_status = '1';
 }
 $filtre = GETPOST('filtre', 'alpha');
@@ -376,7 +376,7 @@ if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter', 
 	$toselect = array();
 	$search_array_options = array();
 	$search_categ_cus = 0;
-	$option = '';
+	$search_late = '';
 	$socid = 0;
 }
 
@@ -815,7 +815,7 @@ if ($search_datelimit_start) {
 if ($search_datelimit_end) {
 	$sql .= " AND f.date_lim_reglement <= '".$db->idate($search_datelimit_end)."'";
 }
-if ($option == 'late') {
+if ($search_late == 'late') {
 	$sql .= " AND f.date_lim_reglement < '".$db->idate(dol_now() - $conf->facture->client->warning_delay)."'";
 }
 if ($search_sale > 0) {
@@ -1153,8 +1153,8 @@ if ($resql) {
 	if ($show_files) {
 		$param .= '&show_files='.urlencode($show_files);
 	}
-	if ($option) {
-		$param .= "&search_option=".urlencode($option);
+	if ($search_late) {
+		$param .= "&search_option=".urlencode($search_late);
 	}
 	if ($optioncss != '') {
 		$param .= '&optioncss='.urlencode($optioncss);
@@ -1291,6 +1291,11 @@ if ($resql) {
 		$moreforfilter .= img_picto($tmptitle, 'category', 'class="pictofixedwidth"').$formother->select_categories('customer', $search_categ_cus, 'search_categ_cus', 1, $tmptitle);
 		$moreforfilter .= '</div>';
 	}
+	// alert on due date
+	$moreforfilter .= '<div class="divsearchfield">';
+	$moreforfilter .= $langs->trans('Alert').' <input type="checkbox" name="search_late" value="late"'.($search_late == 'late' ? ' checked' : '').'>';
+	$moreforfilter .= '</div>';
+
 	$parameters = array();
 	$reshook = $hookmanager->executeHooks('printFieldPreListTitle', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	if (empty($reshook)) {
@@ -1386,14 +1391,10 @@ if ($resql) {
 	if (!empty($arrayfields['f.date_lim_reglement']['checked'])) {
 		print '<td class="liste_titre center">';
 		print '<div class="nowrap">';
-		/*
-		 print $langs->trans('From').' ';
-		 print $form->selectDate($search_datelimit_start ? $search_datelimit_start : -1, 'search_datelimit_start', 0, 0, 1);
-		 print '</div>';
-		 print '<div class="nowrap">';
-		 print $langs->trans('to').' ';*/
-		print $form->selectDate($search_datelimit_end ? $search_datelimit_end : -1, 'search_datelimit_end', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans("Before"));
-		print '<br><input type="checkbox" name="search_option" value="late"'.($option == 'late' ? ' checked' : '').'> '.$langs->trans("Alert");
+		print $form->selectDate($search_datelimit_start ? $search_datelimit_start : -1, 'search_datelimit_start', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
+		print '</div>';
+		print '<div class="nowrap">';
+		print $form->selectDate($search_datelimit_end ? $search_datelimit_end : -1, 'search_datelimit_end', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('to'));
 		print '</div>';
 		print '</td>';
 	}

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -1154,7 +1154,7 @@ if ($resql) {
 		$param .= '&show_files='.urlencode($show_files);
 	}
 	if ($search_late) {
-		$param .= "&search_option=".urlencode($search_late);
+		$param .= "&search_late=".urlencode($search_late);
 	}
 	if ($optioncss != '') {
 		$param .= '&optioncss='.urlencode($optioncss);


### PR DESCRIPTION
NEW start and end date for due date filter on invoice list
- add start date on due date filter
- keep "alert" filter in more filter (on the top of this list)

With theses 3 filters (start date, end date and alert) on due date, we keep compatibility with others Dolibarr versions and we can filter between start and end dates like on others dates filters.

![image](https://github.com/Dolibarr/dolibarr/assets/45359511/fa1a6c1d-edf1-4c64-9e75-28d685140a8d)

@eldy it will better to rename "Alert" with "Overdue invoices" ?
And perhaps remove this filter when "due date" filter is hidden ?