### PR TITLE
Fix #25860 not allow encrypt data if key and instance_unique_id are empty

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -144,6 +144,10 @@ function dolEncrypt($chain, $key = '', $ciphering = 'AES-256-CTR', $forceseed = 
 	$newchain = $chain;
 
 	if (function_exists('openssl_encrypt') && empty($dolibarr_disable_dolcrypt_for_debug)) {
+                if (empty($key)) {
+                        return 'Error dolEncrypt encrypt key is empty';
+                }
+
 		$ivlen = 16;
 		if (function_exists('openssl_cipher_iv_length')) {
 			$ivlen = openssl_cipher_iv_length($ciphering);

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -145,7 +145,7 @@ function dolEncrypt($chain, $key = '', $ciphering = 'AES-256-CTR', $forceseed = 
 
 	if (function_exists('openssl_encrypt') && empty($dolibarr_disable_dolcrypt_for_debug)) {
                 if (empty($key)) {
-                        return 'Error dolEncrypt encrypt key is empty';
+                        return $chain;
                 }
 
 		$ivlen = 16;


### PR DESCRIPTION
# Fix #25860
Not allow encrypt data if key and instance_unique_id are empty (as decrypt function) to avoid losing data into database configuration llx_const.

The config **instance_unique_id** is added automatically only for new installation since Dolibarr 10. Some users may not added it after an upgrade.