### PR TITLE
fix: contact export s.client and s.fournisseur must be numric as in thirdparty export ( to do filter like >0)

### DIFF
--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -385,7 +385,7 @@ class modSociete extends DolibarrModules
 			'c.statut'=>"Status",
 			's.rowid'=>"List:societe:nom::thirdparty", 's.nom'=>"Text", 's.status'=>"Status", 's.code_client'=>"Text", 's.code_fournisseur'=>"Text",
 			's.code_compta'=>"Text", 's.code_compta_fournisseur'=>"Text",
-			's.client'=>"Text", 's.fournisseur'=>"Text",
+			's.client'=>"Numeric", 's.fournisseur'=>"Numeric",
 			's.address'=>"Text", 's.zip'=>"Text", 's.town'=>"Text", 's.phone'=>"Text", 's.email'=>"Text",
 			't.libelle'=>"Text"
 		);


### PR DESCRIPTION
Actually in contact export if you set filter on s.client or s.fournisseur as >0 the query result is 
`.... WHERE and s.client = '>0'`