### PR TITLE
FIX : duplicate ticket information

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -226,7 +226,7 @@ if (empty($reshook)) {
 				$object->ref = $getRef;
 			}
 
-			$object->fk_soc = GETPOST("socid", 'int') > 0 ? GETPOST("socid", 'int') : 0;
+			$object->fk_soc = $object->socid = GETPOST("socid", 'int') > 0 ? GETPOST("socid", 'int') : 0;
 			$object->subject = GETPOST("subject", 'alphanohtml');
 			$object->message = GETPOST("message", 'restricthtml');
 
@@ -236,7 +236,7 @@ if (empty($reshook)) {
 			$object->category_label = $langs->trans($langs->getLabelFromKey($db, $object->category_code, 'c_ticket_category', 'code', 'label'));
 			$object->severity_code = GETPOST("severity_code", 'alpha');
 			$object->severity_label = $langs->trans($langs->getLabelFromKey($db, $object->severity_code, 'c_ticket_severity', 'code', 'label'));
-			$object->email_from = $user->email;
+			$object->email_from = $object->origin_email = $user->email;
 			$notifyTiers = GETPOST("notify_tiers_at_create", 'alpha');
 			$object->notify_tiers_at_create = empty($notifyTiers) ? 0 : 1;
 			$fk_user_assign = GETPOST("fk_user_assign", 'int');


### PR DESCRIPTION
FIX : wrong ticket information when tickets created at the same time

Case : creating two tickets at the same time from both public interface (sent first) and backoffice.
Consequence : Information from first (public) ticket was reported on backoffice ticket.

https://github.com/Dolibarr/dolibarr/pull/25643 has begun to fix this bug.

This PR overrides other information from "first" ticket that were still used in "second" ticket.