### PR TITLE
modify select_change_categorie to get the category hierarchy in massaction

### DIFF
--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -73,7 +73,8 @@ if ($massaction == 'preaffecttag' && isModEnabled('category')) {
 	$formquestion = array();
 	if (!empty($categ_types)) {
 		foreach ($categ_types as $categ_type) {
-			$categ_arbo_tmp = $form->select_all_categories($categ_type['code'], null, 'parent', null, null, 2);
+			//$categ_arbo_tmp = $form->select_all_categories($categ_type['code'], null, 'parent', null, null, 2); //does not show the category hierarchy
+			$categ_arbo_tmp = $form->select_all_categories($categ_type['code'], '', 'parent', 64, 0, 1); //show the category hierarchy
 			$formquestion[] = array(
 				'type' => 'other',
 				'name' => 'affecttag_'.$categ_type['code'],


### PR DESCRIPTION
modify select_change_categorie to get the category hierarchy.
But in this case, we lose the category color marker.

Should we add a configuration variable to have one mode or the other? or add coloring according to the method's mode?
