### PR TITLE
Fix: inventory card missing ability to add or remove tabs

### DIFF
--- a/htdocs/product/inventory/lib/inventory.lib.php
+++ b/htdocs/product/inventory/lib/inventory.lib.php
@@ -68,10 +68,17 @@ function inventoryAdminPrepareHead()
  */
 function inventoryPrepareHead(&$inventory, $title = 'Inventory', $get = '')
 {
-	global $langs;
+	global $langs, $conf;
 
-	return array(
+	$head = array(
 		array(dol_buildpath('/product/inventory/card.php?id='.$inventory->id.$get, 1), $langs->trans('Card'), 'card'),
 		array(dol_buildpath('/product/inventory/inventory.php?id='.$inventory->id.$get, 1), $langs->trans('Inventory'), 'inventory')
 	);
+
+	$h=2;
+
+	complete_head_from_modules($conf, $langs, $inventory, $head, $h, 'inventory');
+	complete_head_from_modules($conf, $langs, $inventory, $head, $h, 'inventory', 'remove');
+
+	return $head;
 }


### PR DESCRIPTION
All cards are providing a standard functionality for external modules to add or remove tabs.

The inventory card is missing the required function calls so that this feature is missing. It therefore cannot be extended by adding additional tabs form an external module.

Example of an additional tab:
![image](https://github.com/Dolibarr/dolibarr/assets/10772984/a8fe4a86-0639-434e-a425-934afcf0b2ec)
