### PR TITLE
FIX #25983

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -1557,6 +1557,8 @@ if ($id > 0) {
 		print '<tr class="oddeven nodrag nodrop nohover">';
 
 		$obj = new stdClass();
+		$ent = getEntity($tabname[$id]); 
+		if (!empty($ent)) $obj->entity = $ent; // always needed
 		// If data was already input, we define them in obj to populate input fields.
 		if (GETPOST('actionadd')) {
 			foreach ($fieldlist as $key => $val) {

--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -1557,7 +1557,7 @@ if ($id > 0) {
 		print '<tr class="oddeven nodrag nodrop nohover">';
 
 		$obj = new stdClass();
-		$ent = getEntity($tabname[$id]); 
+		$ent = getEntity($tabname[$id]);
 		if (!empty($ent)) $obj->entity = $ent; // always needed
 		// If data was already input, we define them in obj to populate input fields.
 		if (GETPOST('actionadd')) {


### PR DESCRIPTION
# FIX|Fix #25983 Creation of paymentmethods in dictionnary]
An error is shown: Field 'entity' is required

Same error on other dictionnaries (payment terms ..) because of 
code change in function fieldList(
if ($value == 'entity' && isset($obj->$value)) {
			$withentity = $obj->$value;
			continue;
		}
When adding an item, $obj->entity is always empty so $withentity remain empty instead of sending the entity number
