### PR TITLE
Fix #26005 - link for EU VAT ID validation changed

### DIFF
--- a/htdocs/langs/en_US/companies.lang
+++ b/htdocs/langs/en_US/companies.lang
@@ -387,7 +387,7 @@ EditCompany=Edit company
 ThisUserIsNot=This user is not a prospect, customer or vendor
 VATIntraCheck=Check
 VATIntraCheckDesc=The VAT ID must include the country prefix. The link <b>%s</b> uses the European VAT checker service (VIES) which requires internet access from the Dolibarr server.
-VATIntraCheckURL=http://ec.europa.eu/taxation_customs/vies/vieshome.do
+VATIntraCheckURL=https://ec.europa.eu/taxation_customs/vies/#/vat-validation
 VATIntraCheckableOnEUSite=Check the intra-Community VAT ID on the European Commission website
 VATIntraManualCheck=You can also check manually on the European Commission website <a href="%s" target="_blank" rel="noopener noreferrer">%s</a>
 ErrorVATCheckMS_UNAVAILABLE=Check not possible. Check service is not provided by the member state (%s).


### PR DESCRIPTION
Note: The validation link is defined as a Transifex translation key, but same value/URL has now to be incorporated in all languages. Therefore a change just in Transifex and just for e.g. the German version would not make sense, same value needs to be incorporated in all languages, therefore changed via pull request.

In theory, if EU offered different pages for different member countries, it could be adopted. Currently it's the same link for everyone.

