### PR TITLE
FIX: fix the wrong position of the hook 'printFieldListTitle' and 'printFieldListValue' in the stock at date page

### DIFF
--- a/htdocs/product/stock/stockatdate.php
+++ b/htdocs/product/stock/stockatdate.php
@@ -502,12 +502,13 @@ if ($mode == 'future') {
 	print_liste_field_titre('', $_SERVER["PHP_SELF"]);
 	print_liste_field_titre('CurrentStock', $_SERVER["PHP_SELF"], $fieldtosortcurrentstock, $param, '', '', $sortfield, $sortorder, 'right ');
 }
-print_liste_field_titre('', $_SERVER["PHP_SELF"], '', $param, '', '', $sortfield, $sortorder, 'right ');
 
 // Hook fields
 $parameters = array('param'=>$param, 'sortfield'=>$sortfield, 'sortorder'=>$sortorder);
 $reshook = $hookmanager->executeHooks('printFieldListTitle', $parameters); // Note that $action and $object may have been modified by hook
 print $hookmanager->resPrint;
+
+print_liste_field_titre('', $_SERVER["PHP_SELF"], '', $param, '', '', $sortfield, $sortorder, 'right ');
 
 print "</tr>\n";
 
@@ -643,13 +644,13 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 			$totalcurrentstock += $currentstock;
 		}
 
-		// Action
-		print '<td class="right"></td>';
-
 		// Fields from hook
 		$parameters = array('objp'=>$objp);
 		$reshook = $hookmanager->executeHooks('printFieldListValue', $parameters); // Note that $action and $object may have been modified by hook
 		print $hookmanager->resPrint;
+
+		// Action
+		print '<td class="right"></td>';
 
 		print '</tr>'."\n";
 	}


### PR DESCRIPTION
FIX: fix the wrong position of the hook 'printFieldListTitle' and 'printFieldListValue' in the stock at date page