### PR TITLE
add a trigger BEFORE delete

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1170,6 +1170,11 @@ abstract class CommonObject
 		// phpcs:enable
 		global $user;
 
+		$result = $this->call_trigger(strtoupper($this->element).'_BEFORE_DELETE_CONTACT', $user);
+		if ($result < 0) {
+			$this->db->rollback();
+			return -1;
+		}
 
 		$this->db->begin();
 


### PR DESCRIPTION
If we make some interactions with trigger, we can add something when a user is added to a ficheinter but we can't do the job in case of FICHINTER_DELETE_CONTACT.

Example with FICHINTER: 

- on FICHINTER_ADD_CONTACT i could send an email to the contact to explain what we must to do on that interventions
- but if sometime after we delete that contact i can't send a new email with new instructions like "please forget the previous mail about that intervention, it's not for you"

