### PR TITLE
FIX #26033 Stock Movement associated with project doesn't show up in Project / Overview window 

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -790,8 +790,8 @@ class Project extends CommonObject
 			$sql = "SELECT DISTINCT pt.rowid FROM ".MAIN_DB_PREFIX."projet_task as pt WHERE pt.fk_projet IN (".$this->db->sanitize($ids).")";
 		} elseif ($type == 'element_time') {	// Case we want to duplicate line foreach user
 			$sql = "SELECT DISTINCT pt.rowid, ptt.fk_user FROM ".MAIN_DB_PREFIX."projet_task as pt, ".MAIN_DB_PREFIX."element_time as ptt WHERE pt.rowid = ptt.fk_element AND ptt.elementtype = 'task' AND pt.fk_projet IN (".$this->db->sanitize($ids).")";
-		} elseif ($type == 'stock_mouvement') {
-			$sql = "SELECT ms.rowid, ms.fk_user_author as fk_user FROM ".MAIN_DB_PREFIX."stock_mouvement as ms, ".MAIN_DB_PREFIX."entrepot as e WHERE e.rowid = ms.fk_entrepot AND e.entity IN (".getEntity('stock').") AND ms.origintype = 'project' AND ms.fk_origin IN (".$this->db->sanitize($ids).") AND ms.type_mouvement = 1";
+		} elseif ($type == 'stocktransfer_stocktransfer') {
+			$sql = "SELECT ms.rowid, ms.fk_user_author as fk_user FROM ".MAIN_DB_PREFIX."stocktransfer_stocktransfer as ms, ".MAIN_DB_PREFIX."entrepot as e WHERE e.rowid = ms.fk_entrepot AND e.entity IN (".getEntity('stock').") AND ms.origintype = 'project' AND ms.fk_origin IN (".$this->db->sanitize($ids).") AND ms.type_mouvement = 1";
 		} elseif ($type == 'loan') {
 			$sql = "SELECT l.rowid, l.fk_user_author as fk_user FROM ".MAIN_DB_PREFIX."loan as l WHERE l.entity IN (".getEntity('loan').") AND l.fk_projet IN (".$this->db->sanitize($ids).")";
 		} else {
@@ -1928,7 +1928,7 @@ class Project extends CommonObject
 		if ($tableName == "actioncomm") {
 			$sql .= " SET fk_project=".$this->id;
 			$sql .= " WHERE id=".((int) $elementSelectId);
-		} elseif (in_array($tableName, ["entrepot","mrp_mo"])) {
+		} elseif (in_array($tableName, ["entrepot","mrp_mo","stocktransfer_stocktransfer"])) {
 			$sql .= " SET fk_project=".$this->id;
 			$sql .= " WHERE rowid=".((int) $elementSelectId);
 		} else {

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -101,6 +101,10 @@ if (isModEnabled('supplier_proposal')) {
 if (isModEnabled('tax')) {
 	require_once DOL_DOCUMENT_ROOT.'/compta/sociales/class/chargesociales.class.php';
 }
+if (isModEnabled('stocktransfer')) {
+	require_once DOL_DOCUMENT_ROOT.'/product/stock/stocktransfer/class/stocktransfer.class.php';
+	require_once DOL_DOCUMENT_ROOT.'/product/stock/stocktransfer/class/stocktransferline.class.php';
+}
 
 
 
@@ -139,6 +143,9 @@ if (isModEnabled('mrp')) {
 if (isModEnabled('eventorganization')) {
 	$langs->load("eventorganization");
 }
+//if (isModEnabled('stocktransfer')) {
+//	$langs->load("stockstransfer");
+//}
 
 $id = GETPOST('id', 'int');
 $ref = GETPOST('ref', 'alpha');
@@ -610,10 +617,11 @@ $listofreferent = array(
 	'stock_mouvement'=>array(
 		'name'=>"MouvementStockAssociated",
 		'title'=>"ListMouvementStockProject",
-		'class'=>'MouvementStock',
-		'table'=>'stock_mouvement',
+		'class'=>'StockTransfer',
+		'table'=>'stocktransfer_stocktransfer',
 		'datefieldname'=>'datem',
 		'margin'=>'minus',
+		'project_field'=>'fk_project',
 		'disableamount'=>0,
 		'test'=>isModEnabled('stock') && $user->hasRight('stock', 'mouvement', 'lire') && !empty($conf->global->STOCK_MOVEMENT_INTO_PROJECT_OVERVIEW)
 	),


### PR DESCRIPTION
# FIX #26033 Stock Movement associated with project doesn't show up in Project / Overview window 

Updates the old functionality of stock transfers associated with projects to properly display the "Advanced Stock Transfers" associated with it. 

Existing functionality was depreciated as it's not possible to associate normal stock movements with projects in any method that I tried, which is likely why this was hidden behind the undocumented global config variable that must be added to Other Setup.

I have only tested the changes in my own Dolibarr installation running 18.0.1 at this time.
