### PR TITLE
Update ticket.class.php - SQL Syntax Error

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1318,7 +1318,7 @@ class Ticket extends CommonObject
 		$sql = "SELECT rowid, code, label, use_default, pos, description, public, active, force_severity, fk_parent";
 		$sql .= " FROM ".MAIN_DB_PREFIX."c_ticket_category";
 		$sql .= " WHERE entity IN (".getEntity('c_ticket_category').")";
-		$sql .= " WHERE active > 0";
+		$sql .= " AND active > 0";
 		if ($publicgroup > -1) {
 			$sql .= " AND public = ".((int) $publicgroup);
 		}


### PR DESCRIPTION
Function "loadCacheCategoriesTickets" query had two WHERE clauses.  Change the second "WHERE" to "AND".


# FIX|Fix #[26052]

Dolibarr V.18 introduces a new error in the Ticket module.

dolibarr/htdocs/ticket/class/ticket.class.php LINE: 1287
function loadCacheCategoriesTickets

Duplicate "WHERE" changed to "AND".

