### PR TITLE
fix: Undefined property: Contrat::$pa_ht

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -1562,7 +1562,7 @@ class Contrat extends CommonObject
 
 
 			// if buy price not defined, define buyprice as configured in margin admin
-			if ($this->pa_ht == 0) {
+			if ($pa_ht == 0) {
 				if (($result = $this->defineBuyPrice($pu_ht, $remise_percent, $fk_product)) < 0) {
 					return $result;
 				} else {


### PR DESCRIPTION
# FIX *Undefined property: Contrat::$pa_ht*
In `addline()` method of Contrat class, property member $this->pa_ht is used instead of local function variable $pa_ht leading to an `Undefined property` error.
