### PR TITLE
FIX : Inventory lines saving with big inventory

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -265,6 +265,7 @@ if (empty($reshook)) {
 		$sql .= ' id.fk_product, id.batch, id.qty_stock, id.qty_view, id.qty_regulated';
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'inventorydet as id';
 		$sql .= ' WHERE id.fk_inventory = '.((int) $object->id);
+		$sql .= $db->order('id.rowid', 'ASC');
 		$sql .= $db->plimit($limit, $offset);
 
 		$db->begin();


### PR DESCRIPTION
When the inventory is displayed for the user there are an 'order by' on the initial query.

But when we save the inventory lines, the same request is played without the 'order by' so there is a lots of chance with a big inventory that your edited lines were not saved because Dolibarr doesn't find them with the query.