### PR TITLE
fix: wrong permission test on payment_sc

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -822,7 +822,7 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 		}
 
 		if ($feature == 'payment_sc') {
-			$feature = "chargesociales";
+			$feature = "charges";
 		}
 		$checkonentitydone = 0;
 


### PR DESCRIPTION
feature to test for payment_sc is `charges` and not `chargesociales` like it is done restrictedArea :
https://github.com/Dolibarr/dolibarr/blob/9300411ce3f5fe175732ba7a1e4ccd1febc8219d/htdocs/core/lib/security.lib.php#L491
https://github.com/Dolibarr/dolibarr/blob/9300411ce3f5fe175732ba7a1e4ccd1febc8219d/htdocs/core/lib/security.lib.php#L684