### PR TITLE
fix ticket card: set origin_email to null

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -236,7 +236,8 @@ if (empty($reshook)) {
 			$object->category_label = $langs->trans($langs->getLabelFromKey($db, $object->category_code, 'c_ticket_category', 'code', 'label'));
 			$object->severity_code = GETPOST("severity_code", 'alpha');
 			$object->severity_label = $langs->trans($langs->getLabelFromKey($db, $object->severity_code, 'c_ticket_severity', 'code', 'label'));
-			$object->email_from = $object->origin_email = $user->email;
+			$object->email_from = $user->email;
+			$object->origin_email = null;
 			$notifyTiers = GETPOST("notify_tiers_at_create", 'alpha');
 			$object->notify_tiers_at_create = empty($notifyTiers) ? 0 : 1;
 			$fk_user_assign = GETPOST("fk_user_assign", 'int');


### PR DESCRIPTION
# Fix No origin_email registration on a ticket card

When a ticket is created on a ticket card, the field origin_email must be empty. It is used when the ticket is created from public interface.

