### PR TITLE
FIX: Use of line->insert instead of line->create

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9317,7 +9317,7 @@ abstract class CommonObject
 					$line = (object) $line;
 				}
 
-				$result = $line->create($user, 1);
+				$result = $line->insert($user, 1);
 				if ($result < 0) {
 					$this->error = $line->error;
 					$this->db->rollback();


### PR DESCRIPTION
When the function create_common copied line for example if called by a createFromClone method, an error occured because no object was implementing ObjectLine::create() but ObjectLine::insert() 