### PR TITLE
NEW total line for third-parties list

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -13,6 +13,7 @@
  * Copyright (C) 2020       Open-Dsi         		<support@open-dsi.fr>
  * Copyright (C) 2021		Frédéric France			<frederic.france@netlogic.fr>
  * Copyright (C) 2022		Anthony Berton			<anthony.berton@bb2a.fr>
+ * Copyright (C) 2023		William Mead			<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1928,6 +1929,9 @@ while ($i < $imaxinloop) {
 	}
 	$i++;
 }
+
+// Show total line
+include DOL_DOCUMENT_ROOT.'/core/tpl/list_print_total.tpl.php';
 
 // Line that calls the select_status function by passing it js as the 5th parameter in order to activate the js script
 $formcompany->selectProspectStatus('status_prospect', $prospectstatic, null, null, "js");


### PR DESCRIPTION
# NEW Total line for third-parties list
In the case when a "_totalizable_" extrafield is added to third party, it can be useful to see the **sum** of this attribut in the third-parties list. This could be for example: population covered, stock value, number of company cars, etc.
This PR includes `/core/tpl/list_print_total.tpl.php` in `/societe/list.php`