### PR TITLE
NEW better way to manage main.inc.php inclusion in modules generated …

### DIFF
--- a/htdocs/modulebuilder/template/admin/about.php
+++ b/htdocs/modulebuilder/template/admin/about.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2004-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023      Noé Cendrier         <noe.cendrier@altairis.fr>
  * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software: you can redistribute it and/or modify
@@ -28,23 +29,17 @@ $res = 0;
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/admin/about.php
+++ b/htdocs/modulebuilder/template/admin/about.php
@@ -25,6 +25,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/admin/about.php
+++ b/htdocs/modulebuilder/template/admin/about.php
@@ -39,7 +39,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/admin/myobject_extrafields.php
+++ b/htdocs/modulebuilder/template/admin/myobject_extrafields.php
@@ -29,6 +29,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/admin/myobject_extrafields.php
+++ b/htdocs/modulebuilder/template/admin/myobject_extrafields.php
@@ -43,7 +43,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/admin/myobject_extrafields.php
+++ b/htdocs/modulebuilder/template/admin/myobject_extrafields.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2012		Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2014		Florian Henry			<florian.henry@open-concept.pro>
  * Copyright (C) 2015		Jean-François Ferry		<jfefe@aternatik.fr>
+ * Copyright (C) 2023      Noé Cendrier         <noe.cendrier@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,23 +33,17 @@ $res = 0;
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/admin/setup.php
+++ b/htdocs/modulebuilder/template/admin/setup.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2004-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023      Noé Cendrier         <noe.cendrier@altairis.fr>
  * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software: you can redistribute it and/or modify
@@ -28,23 +29,17 @@ $res = 0;
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/admin/setup.php
+++ b/htdocs/modulebuilder/template/admin/setup.php
@@ -25,6 +25,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/admin/setup.php
+++ b/htdocs/modulebuilder/template/admin/setup.php
@@ -39,7 +39,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/ajax/myobject.php
+++ b/htdocs/modulebuilder/template/ajax/myobject.php
@@ -59,7 +59,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/ajax/myobject.php
+++ b/htdocs/modulebuilder/template/ajax/myobject.php
@@ -45,6 +45,10 @@ if (!defined('NOREQUIREHTML')) {
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/ajax/myobject.php
+++ b/htdocs/modulebuilder/template/ajax/myobject.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2022 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Noé Cendrier         <noe.cendrier@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,7 +44,26 @@ if (!defined('NOREQUIREHTML')) {
 }
 
 // Load Dolibarr environment
-require '../../main.inc.php';
+$res = 0;
+// Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
+if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+}
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
+}
+if (!$res) {
+	die("Include of main fails");
+}
 
 $mode = GETPOST('mode', 'aZ09');
 

--- a/htdocs/modulebuilder/template/css/mymodule.css.php
+++ b/htdocs/modulebuilder/template/css/mymodule.css.php
@@ -1,5 +1,6 @@
 <?php
-/* Copyright (C) ---Put here your own copyright and developer email---
+/* Copyright (C) 2023 Noé Cendrier         <noe.cendrier@altairis.fr>
+ * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,23 +54,17 @@ $res = 0;
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/../main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/../main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/css/mymodule.css.php
+++ b/htdocs/modulebuilder/template/css/mymodule.css.php
@@ -50,6 +50,10 @@ session_cache_limiter('public');
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/css/mymodule.css.php
+++ b/htdocs/modulebuilder/template/css/mymodule.css.php
@@ -64,7 +64,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/js/mymodule.js.php
+++ b/htdocs/modulebuilder/template/js/mymodule.js.php
@@ -1,5 +1,6 @@
 <?php
-/* Copyright (C) ---Put here your own copyright and developer email---
+/* Copyright (C) 2023 Noé Cendrier         <noe.cendrier@altairis.fr>
+ * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,7 +49,6 @@ if (!defined('NOREQUIREAJAX')) {
 	define('NOREQUIREAJAX', '1');
 }
 
-
 /**
  * \file    htdocs/modulebuilder/template/js/mymodule.js.php
  * \ingroup mymodule
@@ -61,23 +61,17 @@ $res = 0;
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/../main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/../main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/js/mymodule.js.php
+++ b/htdocs/modulebuilder/template/js/mymodule.js.php
@@ -57,6 +57,10 @@ if (!defined('NOREQUIREAJAX')) {
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/js/mymodule.js.php
+++ b/htdocs/modulebuilder/template/js/mymodule.js.php
@@ -71,7 +71,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/mymoduleindex.php
+++ b/htdocs/modulebuilder/template/mymoduleindex.php
@@ -27,6 +27,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/mymoduleindex.php
+++ b/htdocs/modulebuilder/template/mymoduleindex.php
@@ -41,7 +41,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/mymoduleindex.php
+++ b/htdocs/modulebuilder/template/mymoduleindex.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2004-2015 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2015      Jean-François Ferry	<jfefe@aternatik.fr>
+ * Copyright (C) 2023      Noé Cendrier         <noe.cendrier@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,26 +31,17 @@ $res = 0;
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
-}
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_agenda.php
+++ b/htdocs/modulebuilder/template/myobject_agenda.php
@@ -44,6 +44,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/myobject_agenda.php
+++ b/htdocs/modulebuilder/template/myobject_agenda.php
@@ -58,7 +58,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_agenda.php
+++ b/htdocs/modulebuilder/template/myobject_agenda.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2017 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Noé Cendrier         <noe.cendrier@altairis.fr>
  * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software; you can redistribute it and/or modify
@@ -47,26 +48,17 @@ $res = 0;
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
-}
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_card.php
+++ b/htdocs/modulebuilder/template/myobject_card.php
@@ -47,6 +47,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/myobject_card.php
+++ b/htdocs/modulebuilder/template/myobject_card.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2017 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Noé Cendrier         <noe.cendrier@altairis.fr>
  * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software; you can redistribute it and/or modify
@@ -44,33 +45,23 @@
 //if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');					// Do not check style html tag into posted data
 //if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');					// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
 
-
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
-}
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_card.php
+++ b/htdocs/modulebuilder/template/myobject_card.php
@@ -61,7 +61,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_contact.php
+++ b/htdocs/modulebuilder/template/myobject_contact.php
@@ -25,6 +25,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/myobject_contact.php
+++ b/htdocs/modulebuilder/template/myobject_contact.php
@@ -39,7 +39,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_document.php
+++ b/htdocs/modulebuilder/template/myobject_document.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2007-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023      Noé Cendrier         <noe.cendrier@altairis.fr>
  * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software; you can redistribute it and/or modify
@@ -49,26 +50,17 @@ $res = 0;
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
-}
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_document.php
+++ b/htdocs/modulebuilder/template/myobject_document.php
@@ -46,6 +46,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/myobject_document.php
+++ b/htdocs/modulebuilder/template/myobject_document.php
@@ -60,7 +60,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -47,6 +47,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -61,7 +61,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2007-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023      Noé Cendrier         <noe.cendrier@altairis.fr>
  * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software; you can redistribute it and/or modify
@@ -44,34 +45,23 @@
 //if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');					// Do not check style html tag into posted data
 //if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');					// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
 
-
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--;
-	$j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
-}
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_note.php
+++ b/htdocs/modulebuilder/template/myobject_note.php
@@ -46,6 +46,10 @@
 
 // Load Dolibarr environment
 $res = 0;
+// Try main.inc.php into web root defined in DOCUMENT_ROOT, very frequently defined
+if (!$res && !empty($_SERVER["DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["DOCUMENT_ROOT"]."/main.inc.php";
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";

--- a/htdocs/modulebuilder/template/myobject_note.php
+++ b/htdocs/modulebuilder/template/myobject_note.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2007-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023      Noé Cendrier         <noe.cendrier@altairis.fr>
  * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software; you can redistribute it and/or modify
@@ -43,33 +44,23 @@
 //if (! defined('NOSTYLECHECK'))             define('NOSTYLECHECK', '1');					// Do not check style html tag into posted data
 //if (! defined('NOTOKENRENEWAL'))           define('NOTOKENRENEWAL', '1');					// Do not roll the Anti CSRF token (used if MAIN_SECURITY_CSRF_WITH_TOKEN is on)
 
-
 // Load Dolibarr environment
 $res = 0;
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
 }
-// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
-$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
-while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
-	$i--; $j--;
-}
-if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
-	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
-}
-if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
-	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
-}
-// Try main.inc.php using relative path
-if (!$res && file_exists("../main.inc.php")) {
-	$res = @include "../main.inc.php";
-}
-if (!$res && file_exists("../../main.inc.php")) {
-	$res = @include "../../main.inc.php";
-}
-if (!$res && file_exists("../../../main.inc.php")) {
-	$res = @include "../../../main.inc.php";
+// Try main.inc.php in all parent folders (cope with symlinks)
+if (!$res) {
+	$dolipath = dirname($_SERVER['SCRIPT_FILENAME']);
+	while (!file_exists($dolipath."/main.inc.php")) {
+		$abspath = $dolipath;
+		$dolipath = dirname($dolipath);
+		if ($abspath == $dolipath) { // cope with no main.inc.php all the way to filesystem root
+			break;
+		}
+	}
+	$res = @include($dolipath."/main.inc.php");
 }
 if (!$res) {
 	die("Include of main fails");

--- a/htdocs/modulebuilder/template/myobject_note.php
+++ b/htdocs/modulebuilder/template/myobject_note.php
@@ -60,7 +60,7 @@ if (!$res) {
 			break;
 		}
 	}
-	$res = @include($dolipath."/main.inc.php");
+	$res = @include $dolipath."/main.inc.php";
 }
 if (!$res) {
 	die("Include of main fails");


### PR DESCRIPTION
NEW better way to manage main.inc.php inclusion in modules generated with module builder.
Right now, in order to include `main.inc.php` in files which need it, we use a test on a pretty obscure path string comparison, which looks like this :
```php
// Load Dolibarr environment
$res = 0;
// Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
}
// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME']; $tmp2 = realpath(__FILE__); $i = strlen($tmp) - 1; $j = strlen($tmp2) - 1;
while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
	$i--; $j--;
}
if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
}
if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/../main.inc.php")) {
	$res = @include substr($tmp, 0, ($i + 1))."/../main.inc.php";
}
// Try main.inc.php using relative path
if (!$res && file_exists("../../main.inc.php")) {
	$res = @include "../../main.inc.php";
}
if (!$res && file_exists("../../../main.inc.php")) {
	$res = @include "../../../main.inc.php";
}
if (!$res) {
	die("Include of main fails");
}
```
It really is not readable and it seems to me that it is more complicated than it should.
The replacement that I suggest will simply explore recursively the parents folders in the paths of `$_SERVER['SCRIPT_FILENAME']` until it finds `main.inc.php`.
It works event if the module’s folder is a symlink, and fails if there is no `main.inc.php` in the path on the server.
Thanks for any feedback.