### PR TITLE
Fix createCommon line creation loop

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9529,10 +9529,7 @@ abstract class CommonObject
 
 		// Create lines
 		if (!empty($this->table_element_line) && !empty($this->fk_element)) {
-			$num = (is_array($this->lines) ? count($this->lines) : 0);
-			for ($i = 0; $i < $num; $i++) {
-				$line = $this->lines[$i];
-
+			foreach ($this->lines as $line) {
 				$keyforparent = $this->fk_element;
 				$line->$keyforparent = $this->id;
 


### PR DESCRIPTION
fix createCommon line creation loop to make possible the creation of lines if line id in object is not starting by 0

Example :
in skill class id of lines start from id > 0 if you create another object and clone it

foreach permit to avoid a fatal error of undefined array key

