### PR TITLE
fix: result checks for PHP 8.1

### DIFF
--- a/htdocs/admin/translation.php
+++ b/htdocs/admin/translation.php
@@ -116,7 +116,7 @@ if ($action == 'update') {
 
 		$sql = "UPDATE ".MAIN_DB_PREFIX."overwrite_trans set transkey = '".$db->escape($transkey)."', transvalue = '".$db->escape($transvalue)."' WHERE rowid = ".((int) GETPOST('rowid', 'int'));
 		$result = $db->query($sql);
-		if ($result > 0) {
+		if ($result) {
 			$db->commit();
 			setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
 			$action = "";
@@ -154,7 +154,7 @@ if ($action == 'add') {
 
 		$sql = "INSERT INTO ".MAIN_DB_PREFIX."overwrite_trans(lang, transkey, transvalue, entity) VALUES ('".$db->escape($langcode)."','".$db->escape($transkey)."','".$db->escape($transvalue)."', ".((int) $conf->entity).")";
 		$result = $db->query($sql);
-		if ($result > 0) {
+		if ($result) {
 			$db->commit();
 			setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
 			$action = "";
@@ -176,7 +176,7 @@ if ($action == 'add') {
 if ($action == 'delete') {
 	$sql = "DELETE FROM ".MAIN_DB_PREFIX."overwrite_trans WHERE rowid = ".((int) $id);
 	$result = $db->query($sql);
-	if ($result >= 0) {
+	if ($result) {
 		setEventMessages($langs->trans("RecordDeleted"), null, 'mesgs');
 	} else {
 		dol_print_error($db);
@@ -296,7 +296,7 @@ foreach ($modulesdir as $keydir => $tmpsearchdir) {
 
 		$result = $newlang->load($langkey, 0, 0, '', 0); // Load translation files + database overwrite
 		$result = $newlangfileonly->load($langkey, 0, 0, '', 1); // Load translation files only
-		if ($result < 0) {
+		if (!$result) {
 			print 'Failed to load language file '.$tmpfile.'<br>'."\n";
 		} else {
 			$listoffiles[$langkey] = $tmpfile;


### PR DESCRIPTION
# fix: result checks for PHP 8.1

## Problem

In our Dolibarr 16.0.5 instance, overwriting of translation strings isn't working. For example, I go to `/admin/translation.php?mode=overwrite&transkey=Notifications` and I fill in the fields:

![Screenshot 2023-10-10 at 19-25-22 Setup](https://github.com/Dolibarr/dolibarr/assets/18473412/02e321e4-4b70-4e25-b584-0b9f37ac679f)

Then, when I click `ADD`, the page is reloaded, and I still see the button, but the overwrite isn't added.

After debugging the problem, I found out that the transaction was rollback. Our instance uses PHP 8.1, which is listed as supported for 16.0.5 in https://wiki.dolibarr.org/index.php/Versions, however, some `if` conditions no longer work as intended. In PHP 8.0 and older, `pg_query` returns a `resource`, so the following works

```php
if ($result > 0) {
	$db->commit();
} else {
	$db->rollback();
}
``` 

As of PHP 8.1, `pg_query` returns a [PgSql\Result](https://www.php.net/manual/en/class.pgsql-result.php) object. The check no longer works, we hit the `else` case even with a successful query.

## Solution

This PR fixes the checks in the `htdocs/admin/translation.php` file. It fixes the issue in our instance. I verified that the `if ($result)` condition works correctly in the oldest PHP version supported by Dolibarr 16.0.5 (PHP 5.6).

 

