### PR TITLE
FIX: modification of complementary attributes in invoices

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2795,7 +2795,7 @@ if (empty($reshook)) {
 
 
 	if ($action == 'update_extras') {
-		$object->oldcopy = dol_clone($object);
+		$object->oldcopy = dol_clone($object, 2);
 
 		// Fill array 'array_options' with data from add form
 		$ret = $extrafields->setOptionalsFromPost(null, $object, GETPOST('attribute', 'restricthtml'));


### PR DESCRIPTION
# FIX: modification of complementary attributes in invoices

Similar to #26115 , this PR fixes the modification of complementary attributes in invoices, which was leading to a blank page with the following error:

```
PHP Fatal error:  Uncaught Exception: Serialization of PgSql\Connection is not allowed in /var/www/html/core/lib/functions.lib.php:1168
Stack trace:
#0 /var/www/html/core/lib/functions.lib.php(1168): serialize()
#1 /var/www/html/compta/facture/card.php(2798): dol_clone()
#2 {main}
```