### PR TITLE
NEW : Allow to have products not managed in stocks

### DIFF
--- a/htdocs/core/lib/product.lib.php
+++ b/htdocs/core/lib/product.lib.php
@@ -129,7 +129,7 @@ function product_prepare_head($object)
 		$h++;
 	}
 
-	if ($object->isProduct() || ($object->isService() && !empty($conf->global->STOCK_SUPPORTS_SERVICES))) {    // If physical product we can stock (or service with option)
+	if (($object->isProduct() || ($object->isService() && !empty($conf->global->STOCK_SUPPORTS_SERVICES))) && $object->not_managed_in_stock == Product::ENABLED_STOCK) {    // If physical product we can stock (or service with option)
 		if (isModEnabled('stock') && $user->hasRight('stock', 'lire')) {
 			$head[$h][0] = DOL_URL_ROOT."/product/stock/product.php?id=".$object->id;
 			$head[$h][1] = $langs->trans("Stock");

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -269,6 +269,7 @@ if (empty($reshook)) {
 			$subtotalqty = 0;
 
 			$j = 0;
+
 			$batch = "batchl".$i."_0";
 			$stockLocation = "ent1".$i."_0";
 			$qty = "qtyl".$i;
@@ -341,6 +342,31 @@ if (empty($reshook)) {
 					$qty = "qtyl".$i.'_'.$j;
 				}
 			} else {
+				$p = new Product($db);
+				$res = $p->fetch($objectsrc->lines[$i]->fk_product);
+				if($res > 0) {
+					if(GETPOST('entrepot_id', 'int') == -1) {
+						$qty .= '_'.$j;
+					}
+
+					if($p->not_managed_in_stock == Product::DISABLED_STOCK) {
+						$w = new Entrepot($db);
+						$Tw = $w->list_array();
+						if(count($Tw) > 0) {
+							$w_Id = array_keys($Tw);
+							$stockLine[$i][$j]['qty'] = GETPOST($qty, 'int');
+
+							// lorsque que l'on a le stock désactivé sur un produit/service
+							// on force l'entrepot pour passer le test  d'ajout de ligne dans expedition.class.php
+							//
+							$stockLine[$i][$j]['warehouse_id'] = $w_Id[0];
+							$stockLine[$i][$j]['ix_l'] = GETPOST($idl, 'int');
+						}
+						else {
+							setEventMessage($langs->trans('NoWarehouseInBase'));
+						}
+					}
+				}
 				//shipment line for product with no batch management and no multiple stock location
 				if (GETPOST($qty, 'int') > 0) {
 					$totalqty += price2num(GETPOST($qty, 'alpha'), 'MS');
@@ -1214,7 +1240,7 @@ if ($action == 'create') {
 						$text = $product_static->getNomUrl(1);
 						$text .= ' - '.(!empty($line->label) ? $line->label : $line->product_label);
 						$description = ($showdescinproductdesc ? '' : dol_htmlentitiesbr($line->desc));
-
+						$description .= $product->not_managed_in_stock ? $langs->trans('StockDisabled') : $langs->trans('StockEnabled') ;
 						print $form->textwithtooltip($text, $description, 3, '', '', $i);
 
 						// Show range
@@ -1320,8 +1346,11 @@ if ($action == 'create') {
 										if (!getDolGlobalInt('STOCK_ALLOW_NEGATIVE_TRANSFER')) {
 											$stockMin = 0;
 										}
-										print $formproduct->selectWarehouses($tmpentrepot_id, 'entl'.$indiceAsked, '', 1, 0, $line->fk_product, '', 1, 0, array(), 'minwidth200', '', 1, $stockMin, 'stock DESC, e.ref');
-
+										if ($product->not_managed_in_stock == Product::ENABLED_STOCK){
+											print $formproduct->selectWarehouses($tmpentrepot_id, 'entl'.$indiceAsked, '', 1, 0, $line->fk_product, '', 1, 0, array(), 'minwidth200', '', 1, $stockMin, 'stock DESC, e.ref');
+										} else {
+											print img_warning().' '.$langs->trans('StockDisabled') ;
+										}
 										if ($tmpentrepot_id > 0 && $tmpentrepot_id == $warehouse_id) {
 											//print $stock.' '.$quantityToBeDelivered;
 											if ($stock < $quantityToBeDelivered) {
@@ -1495,10 +1524,13 @@ if ($action == 'create') {
 									if (isModEnabled('stock')) {
 										print '<td class="left">';
 										if ($line->product_type == Product::TYPE_PRODUCT || !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
-											print $tmpwarehouseObject->getNomUrl(0).' ';
-
-											print '<!-- Show details of stock -->';
-											print '('.$stock.')';
+											if ($product->not_managed_in_stock == Product::ENABLED_STOCK){
+												print $tmpwarehouseObject->getNomUrl(0).' ';
+												print '<!-- Show details of stock -->';
+												print '('.$stock.')';
+											} else {
+												print img_warning().' '.$langs->trans('StockDisabled') ;
+											}
 										} else {
 											print $langs->trans("Service");
 										}
@@ -1642,6 +1674,10 @@ if ($action == 'create') {
 								if ($warehouse_selected_id <= 0) {		// We did not force a given warehouse, so we won't have no warehouse to change qty.
 									$disabled = 'disabled="disabled"';
 								}
+								// finally we overwrite the input with the product status not_managed_in_stock if it's disabled
+								if ( $product->not_managed_in_stock == Product::DISABLED_STOCK){
+									$disabled = '';
+								}
 								print '<input class="qtyl" name="qtyl'.$indiceAsked.'_'.$subj.'" id="qtyl'.$indiceAsked.'_'.$subj.'" type="text" size="4" value="0"'.($disabled ? ' '.$disabled : '').'> ';
 							} else {
 								print $langs->trans("NA");
@@ -1656,8 +1692,11 @@ if ($action == 'create') {
 									print img_warning().' '.$langs->trans("NoProductToShipFoundIntoStock", $warehouseObject->label);
 								} else {
 									if ($line->fk_product) {
-										print img_warning().' '.$langs->trans("StockTooLow");
-									} else {
+										if($product->not_managed_in_stock == Product::ENABLED_STOCK) {
+											print img_warning().' '.$langs->trans('StockTooLow');
+										} else {
+											print img_warning().' '.$langs->trans('StockDisabled');
+										}									} else {
 										print '';
 									}
 								}
@@ -2261,6 +2300,7 @@ if ($action == 'create') {
 				$product_static->surface_units = $lines[$i]->surface_units;
 				$product_static->volume = $lines[$i]->volume;
 				$product_static->volume_units = $lines[$i]->volume_units;
+				$product_static->not_managed_in_stock = $lines[$i]->not_managed_in_stock;
 
 				$text = $product_static->getNomUrl(1);
 				$text .= ' - '.$label;
@@ -2421,7 +2461,7 @@ if ($action == 'create') {
 				// Warehouse source
 				if (isModEnabled('stock')) {
 					print '<td class="linecolwarehousesource tdoverflowmax200">';
-					if ($lines[$i]->entrepot_id > 0) {
+					if ($lines[$i]->entrepot_id > 0 && $lines[$i]->product->not_managed_in_stock == Product::ENABLED_STOCK) {
 						$entrepot = new Entrepot($db);
 						$entrepot->fetch($lines[$i]->entrepot_id);
 						print $entrepot->getNomUrl(1);

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -918,7 +918,7 @@ class Expedition extends CommonObject
 					$isavirtualproduct = ($product->hasFatherOrChild(1) > 0);
 					// The product is qualified for a check of quantity (must be enough in stock to be added into shipment).
 					if (!$isavirtualproduct || empty($conf->global->PRODUIT_SOUSPRODUITS) || ($isavirtualproduct && empty($conf->global->STOCK_EXCLUDE_VIRTUAL_PRODUCTS))) {  // If STOCK_EXCLUDE_VIRTUAL_PRODUCTS is set, we do not manage stock for kits/virtual products.
-						if ($product_stock < $qty) {
+						if ($product_stock < $qty && $product->not_managed_in_stock == Product::ENABLED_STOCK) {
 							$langs->load("errors");
 							$this->error = $langs->trans('ErrorStockIsNotEnoughToAddProductOnShipment', $product->ref);
 							$this->errorhidden = 'ErrorStockIsNotEnoughToAddProductOnShipment';

--- a/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
+++ b/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
@@ -123,3 +123,5 @@ ALTER TABLE llx_links ADD UNIQUE INDEX uk_links (objectid, objecttype,label);
 
 ALTER TABLE llx_c_invoice_subtype MODIFY COLUMN entity integer DEFAULT 1 NOT NULL;
 
+-- Product/service not managed in stock
+ALTER TABLE llx_product ADD COLUMN not_managed_in_stock integer DEFAULT NULL;

--- a/htdocs/install/mysql/tables/llx_product.sql
+++ b/htdocs/install/mysql/tables/llx_product.sql
@@ -71,7 +71,7 @@ create table llx_product
   accountancy_code_sell_intra   varchar(32),                        -- Selling accountancy code for vat intracommunity
   accountancy_code_sell_export  varchar(32),                        -- Selling accountancy code for vat export
   accountancy_code_buy          varchar(32),                        -- Buying accountancy code
-  accountancy_code_buy_intra    varchar(32),                        -- Buying accountancy code for vat intracommunity
+  accountancy_code_buy_intra    varchar(32),                        -- Buying accountancy code for vat intra-community
   accountancy_code_buy_export   varchar(32),                        -- Buying accountancy code for vat export
   partnumber                    varchar(32),                        -- Part/Serial number. TODO To use it into screen if not a duplicate of barcode.
   net_measure                   float        DEFAULT NULL,
@@ -88,7 +88,8 @@ create table llx_product
   surface_units                 tinyint      DEFAULT NULL,
   volume                        float        DEFAULT NULL,
   volume_units                  tinyint      DEFAULT NULL,
-  stock                         real,                               -- Current physical stock (dernormalized field)
+  stock                         real,                               -- Current physical stock (denormalized field)
+  not_managed_in_stock          integer      DEFAULT NULL,
   pmp                           double(24,8) DEFAULT 0 NOT NULL,    -- To store valuation of stock calculated using average price method, for this product
   fifo                          double(24,8),                       -- To store valuation of stock calculated using fifo method, for this product. TODO Not used, should be replaced by stock value stored into movement table.
   lifo                          double(24,8),                       -- To store valuation of stock calculated using lifo method, for this product. TODO Not used, should be replaced by stock value stored into movement table.

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -431,3 +431,7 @@ ConfirmEditExtrafield = Select the extrafield you want modify
 ConfirmEditExtrafieldQuestion = Are you sure you want to modify this extrafield?
 ModifyValueExtrafields = Modify value of an extrafield
 OrProductsWithCategories=Or products with tags/categories
+NotManagedInStock=Disable stock management
+NotManagedInStockDescription=If this option is enabled, the stock modification for this element is not retained.
+StockDisabled=Stock disabled
+StockEnabled=Stock enabled

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -430,3 +430,7 @@ ConfirmEditExtrafield = Sélectionnez l'extrafield que vous souhaitez modifier
 ConfirmEditExtrafieldQuestion = Voulez-vous vraiment modifier cet extrafield ?
 ModifyValueExtrafields = Modifier la valeur d'un extrafield
 OrProductsWithCategories=Ou des produits avec des tags/catégories
+NotManagedInStock=Désactiver la gestion des stocks
+NotManagedInStockDescription=Si cette option est activée, la modification du stock pour cet élément n'est pas prise en compte. Les mouvements de stock ne seront pas pris en compte dans les commandes client, commande fournisseur, expédition, réception, ordre de fabrication.<br /> Dans les faits, cette option se comporte comme une activation/désactivation du module stock mais à l'échelle du produit/service
+StockDisabled=Stock désactivé
+StockEnabled=Stock activé

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -625,6 +625,9 @@ if (empty($reshook)) {
 				$object->fk_unit = null;
 			}
 
+			// managed_in_stock
+			$object->not_managed_in_stock	 = GETPOSTISSET('not_managed_in_stock');
+
 			$accountancy_code_sell = GETPOST('accountancy_code_sell', 'alpha');
 			$accountancy_code_sell_intra = GETPOST('accountancy_code_sell_intra', 'alpha');
 			$accountancy_code_sell_export = GETPOST('accountancy_code_sell_export', 'alpha');
@@ -800,6 +803,9 @@ if (empty($reshook)) {
 				} else {
 					$object->fk_default_bom = null;
 				}
+				
+				// managed_in_stock
+				$object->not_managed_in_stock   = GETPOSTISSET('not_managed_in_stock');
 
 				$units = GETPOST('units', 'int');
 				if ($units > 0) {
@@ -2076,6 +2082,10 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 				print '<input name="desiredstock" size="4" value="'.$object->desiredstock.'">';
 				print '</td></tr>';
 				*/
+
+				print '<tr><td valign="top">' . $langs->trans("NotManagedInStock") . '</td>';
+				$checked = $object->not_managed_in_stock == 1 ? "checked" : "";
+				print '<td><input type="checkbox" id="not_managed_in_stock" name="not_managed_in_stock" '. $checked . ' /></td></tr>';
 			}
 
 			if ($object->isService() && $conf->workstation->enabled) {
@@ -2108,6 +2118,12 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 				print '</label>';
 
 				print '</td></tr>';
+
+				if (!empty($conf->stock->enabled) && !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
+					print '<tr><td valign="top">' . $langs->trans("NotManagedInStock") . '</td>';
+					$checked = $object->not_managed_in_stock == 1 ? "checked" : "";
+					print '<td><input type="checkbox" id="not_managed_in_stock" name="not_managed_in_stock" ' . $checked . ' /></td></tr>';
+				}
 			} else {
 				if (empty($conf->global->PRODUCT_DISABLE_NATURE)) {
 					// Nature
@@ -2572,6 +2588,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 				print '</td>';
 			}
 
+			// Workstation
 			if ($object->isService() && isModEnabled('workstation')) {
 				$workstation = new Workstation($db);
 				$res = $workstation->fetch($object->fk_default_workstation);
@@ -2579,6 +2596,13 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 				print '<tr><td>'.$langs->trans("DefaultWorkstation").'</td><td>';
 				print (!empty($workstation->id) ? $workstation->getNomUrl(1) : '');
 				print '</td>';
+			} 
+
+			// View not_managed_in_stock
+			if (($object->isProduct() || ($object->isService() && !empty($conf->global->STOCK_SUPPORTS_SERVICES))) && !empty($conf->stock->enabled)) {
+				print '<tr><td valign="top">' . $form->textwithpicto($langs->trans("NotManagedInStock"), $langs->trans('NotManagedInStockDescription')) . '</td>';
+				$checked = $object->not_managed_in_stock == 1 ? $langs->trans('Yes') : $langs->trans('No');
+				print '<td>'. $checked .'</td></tr>';
 			}
 
 			// Parent product.
@@ -2623,6 +2647,13 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 				print $form->textwithpicto($langs->trans("mandatoryperiod"), $htmltooltip, 1, 0);
 
 				print '</td></tr>';
+
+				// view not_managed_in_stock
+				if (!empty($conf->stock->enabled) && !empty($conf->global->STOCK_SUPPORTS_SERVICES) ) {
+					print '<tr><td valign="top">' . $form->textwithpicto($langs->trans("NotManagedInStock"), $langs->trans('NotManagedInStockDescription')) . '</td>';
+					$checked = $object->not_managed_in_stock == 1 ? $langs->trans('Yes') : $langs->trans('No');
+					print '<td>'. $checked .'</td></tr>';
+				}
 			} else {
 				if (empty($conf->global->PRODUCT_DISABLE_NATURE)) {
 					// Nature

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -2601,8 +2601,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 			// View not_managed_in_stock
 			if (($object->isProduct() || ($object->isService() && !empty($conf->global->STOCK_SUPPORTS_SERVICES))) && !empty($conf->stock->enabled)) {
 				print '<tr><td valign="top">' . $form->textwithpicto($langs->trans("NotManagedInStock"), $langs->trans('NotManagedInStockDescription')) . '</td>';
-				$checked = $object->not_managed_in_stock == 1 ? $langs->trans('Yes') : $langs->trans('No');
-				print '<td>'. $checked .'</td></tr>';
+				print '<td><input type="checkbox" readonly disabled '.($object->not_managed_in_stock == 1 ? 'checked' : '').'></td></tr>';
 			}
 
 			// Parent product.

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -507,6 +507,12 @@ class Product extends CommonObject
 
 	public $mandatory_period;
 
+	/**
+	 * 0=This service or product is not managed in stock, 1=This service or product is managed in stock
+	 *
+	 * @var boolean
+	 */
+	public $not_managed_in_stock = 1;
 
 	/**
 	 *  'type' if the field format ('integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter]]', 'varchar(x)', 'double(24,8)', 'real', 'price', 'text', 'html', 'date', 'datetime', 'timestamp', 'duration', 'mail', 'phone', 'url', 'password')
@@ -559,6 +565,7 @@ class Product extends CommonObject
 		//'tosell'       =>array('type'=>'integer',      'label'=>'Status',           'enabled'=>1, 'visible'=>1,  'notnull'=>1, 'default'=>0, 'index'=>1,  'position'=>1000, 'arrayofkeyval'=>array(0=>'Draft', 1=>'Active', -1=>'Cancel')),
 		//'tobuy'        =>array('type'=>'integer',      'label'=>'Status',           'enabled'=>1, 'visible'=>1,  'notnull'=>1, 'default'=>0, 'index'=>1,  'position'=>1000, 'arrayofkeyval'=>array(0=>'Draft', 1=>'Active', -1=>'Cancel')),
 		'mandatory_period' => array('type'=>'integer', 'label'=>'mandatoryperiod', 'enabled'=>1, 'visible'=>1,  'notnull'=>1, 'default'=>0, 'index'=>1,  'position'=>1000),
+		'not_managed_in_stock'	=>array('type'=>'integer', 'label'=>'not_managed_in_stock', 'enabled'=>1, 'visible'=>1, 'default'=>0, 'notnull'=>1, 'index'=>1, 'position'=>502),
 	);
 
 	/**
@@ -578,6 +585,12 @@ class Product extends CommonObject
 	 */
 	const TYPE_STOCKKIT = 3;
 
+	/**
+	 * Not managed in stock
+	 */
+	const NOT_MANAGED_IN_STOCK = 0;
+	const DISABLED_STOCK = 1;
+	const ENABLED_STOCK = 0;
 
 	/**
 	 *  Constructor
@@ -678,6 +691,9 @@ class Product extends CommonObject
 		}
 		if (empty($this->status_buy)) {
 			$this->status_buy = 0;
+		}
+		if (empty($this->not_managed_in_stock)) {
+			$this->not_managed_in_stock = 0;
 		}
 
 		$price_ht = 0;
@@ -801,6 +817,7 @@ class Product extends CommonObject
 					$sql .= ", batch_mask";
 					$sql .= ", fk_unit";
 					$sql .= ", mandatory_period";
+					$sql .= ", not_managed_in_stock";
 					$sql .= ") VALUES (";
 					$sql .= "'".$this->db->idate($now)."'";
 					$sql .= ", ".(!empty($this->entity) ? (int) $this->entity : (int) $conf->entity);
@@ -830,6 +847,7 @@ class Product extends CommonObject
 					$sql .= ", '".$this->db->escape($this->batch_mask)."'";
 					$sql .= ", ".($this->fk_unit > 0 ? ((int) $this->fk_unit) : 'NULL');
 					$sql .= ", '".$this->db->escape($this->mandatory_period)."'";
+					$sql .= ", ".((int) $this->not_managed_in_stock);
 					$sql .= ")";
 
 					dol_syslog(get_class($this)."::Create", LOG_DEBUG);
@@ -1108,7 +1126,11 @@ class Product extends CommonObject
 			$this->state_id = 0;
 		}
 
-		// Barcode value
+		if (empty($this->not_managed_in_stock)) {
+			$this->not_managed_in_stock = 0;
+		}
+
+			// Barcode value
 		$this->barcode = trim($this->barcode);
 
 		$this->accountancy_code_buy = trim($this->accountancy_code_buy);
@@ -1254,6 +1276,8 @@ class Product extends CommonObject
 			$sql .= ", fk_price_expression = ".($this->fk_price_expression != 0 ? (int) $this->fk_price_expression : 'NULL');
 			$sql .= ", fk_user_modif = ".($user->id > 0 ? $user->id : 'NULL');
 			$sql .= ", mandatory_period = ".($this->mandatory_period );
+			$sql .= ", not_managed_in_stock = ".(int) $this->not_managed_in_stock;
+
 			// stock field is not here because it is a denormalized value from product_stock.
 			$sql .= " WHERE rowid = ".((int) $id);
 
@@ -2432,8 +2456,9 @@ class Product extends CommonObject
 		} else {
 			$sql .= " p.pmp,";
 		}
+
 		$sql .= " p.datec, p.tms, p.import_key, p.entity, p.desiredstock, p.tobatch, p.batch_mask, p.fk_unit,";
-		$sql .= " p.fk_price_expression, p.price_autogen, p.model_pdf,";
+		$sql .= " p.fk_price_expression, p.price_autogen, p.not_managed_in_stock, p.model_pdf,";
 		if ($separatedStock) {
 			$sql .= " SUM(sp.reel) as stock";
 		} else {
@@ -2545,12 +2570,12 @@ class Product extends CommonObject
 				$this->height = $obj->height;
 				$this->height_units = $obj->height_units;
 
-				$this->surface = $obj->surface;
-				$this->surface_units = $obj->surface_units;
-				$this->volume = $obj->volume;
-				$this->volume_units = $obj->volume_units;
-				$this->barcode = $obj->barcode;
-				$this->barcode_type = $obj->fk_barcode_type;
+				$this->surface							= $obj->surface;
+				$this->surface_units					= $obj->surface_units;
+				$this->volume							= $obj->volume;
+				$this->volume_units						= $obj->volume_units;
+				$this->barcode							= $obj->barcode;
+				$this->barcode_type						= $obj->fk_barcode_type;
 
 				$this->accountancy_code_buy = $obj->accountancy_code_buy;
 				$this->accountancy_code_buy_intra = $obj->accountancy_code_buy_intra;
@@ -2559,23 +2584,25 @@ class Product extends CommonObject
 				$this->accountancy_code_sell_intra = $obj->accountancy_code_sell_intra;
 				$this->accountancy_code_sell_export = $obj->accountancy_code_sell_export;
 
-				$this->fk_default_warehouse = $obj->fk_default_warehouse;
-				$this->fk_default_workstation = $obj->fk_default_workstation;
-				$this->seuil_stock_alerte = $obj->seuil_stock_alerte;
-				$this->desiredstock = $obj->desiredstock;
-				$this->stock_reel = $obj->stock;
-				$this->pmp = $obj->pmp;
+				$this->fk_default_warehouse				= $obj->fk_default_warehouse;
+				$this->fk_default_workstation 			= $obj->fk_default_workstation;
+				$this->seuil_stock_alerte				= $obj->seuil_stock_alerte;
+				$this->desiredstock						= $obj->desiredstock;
+				$this->stock_reel						= $obj->stock;
+				$this->not_managed_in_stock				= $obj->not_managed_in_stock;
+				$this->pmp								= $obj->pmp;
 
-				$this->date_creation = $obj->datec;
-				$this->date_modification = $obj->tms;
-				$this->import_key = $obj->import_key;
-				$this->entity = $obj->entity;
+				$this->date_creation					= $obj->datec;
+				$this->date_modification				= $obj->tms;
+				$this->import_key						= $obj->import_key;
+				$this->entity							= $obj->entity;
 
-				$this->ref_ext = $obj->ref_ext;
-				$this->fk_price_expression = $obj->fk_price_expression;
-				$this->fk_unit = $obj->fk_unit;
-				$this->price_autogen = $obj->price_autogen;
-				$this->model_pdf = $obj->model_pdf;
+				$this->ref_ext							= $obj->ref_ext;
+				$this->fk_price_expression				= $obj->fk_price_expression;
+				$this->fk_unit							= $obj->fk_unit;
+				$this->price_autogen					= $obj->price_autogen;
+
+				$this->model_pdf						= $obj->model_pdf;
 
 				$this->mandatory_period = $obj->mandatory_period;
 

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -424,7 +424,7 @@ class MouvementStock extends CommonObject
 					return -8;
 				}
 			} else {
-				if (empty($product->stock_warehouse[$entrepot_id]->real) || $product->stock_warehouse[$entrepot_id]->real < abs($qty)) {
+				if ((empty($product->stock_warehouse[$entrepot_id]->real) || $product->stock_warehouse[$entrepot_id]->real < abs($qty)) && $product->not_managed_in_stock == Product::ENABLED_STOCK) {
 					$langs->load("stocks");
 					$this->error = $langs->trans('qtyToTranferIsNotEnough').' : '.$product->ref;
 					$this->errors[] = $langs->trans('qtyToTranferIsNotEnough').' : '.$product->ref;
@@ -434,7 +434,7 @@ class MouvementStock extends CommonObject
 			}
 		}
 
-		if ($movestock) {	// Change stock for current product, change for subproduct is done after
+		if ($movestock && $product->not_managed_in_stock == PRODUCT::ENABLED_STOCK) {	// Change stock for current product, change for subproduct is done after
 			// Set $origin_type, origin_id and fk_project
 			$fk_project = $this->fk_project;
 			if (!empty($this->origin_type)) {			// This is set by caller for tracking reason
@@ -610,8 +610,10 @@ class MouvementStock extends CommonObject
 
 		if ($movestock && !$error) {
 			// Call trigger
-			$result = $this->call_trigger('STOCK_MOVEMENT', $user);
-			if ($result < 0) $error++;
+			if ($product->not_managed_in_stock != Product::NOT_MANAGED_IN_STOCK ) {
+				$result = $this->call_trigger('STOCK_MOVEMENT', $user);
+				if ($result < 0) $error++;
+			}
 			// End call triggers
 
 			// Check unicity for serial numbered equipments once all movement were done.


### PR DESCRIPTION
# NEW : Allow to have products not managed in stocks

When using product stocks, users may want to have some products for which they don't want to manage stocks, for example in case of subcontracting.

This PR:
- adds a field "Do not manage product in stocks" on product card (editable on update, not on create)
- hides the "stocks" tabs if this option is set
- does not manage stock movements for a product if this option is set.
