### PR TITLE
Fix: allow changing dates on refused expense report

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -320,7 +320,7 @@ if (empty($reshook)) {
 		}
 	}
 
-	if ($action == 'update' && $user->rights->expensereport->creer) {
+	if (($action == 'update' || $action == 'updateFromRefuse') && $user->rights->expensereport->creer) {
 		$object = new ExpenseReport($db);
 		$object->fetch($id);
 


### PR DESCRIPTION
# Fix: allow changing dates on refused expense report

## Problem

In refused expense reports, the creator has a `Modify` button, which allows to change start and end dates. However, the dates are not changed. To reproduce in Dolibarr 16.0.5:

* Create an expense report
* Submit for approval
* Deny the expense report from another account
* From the creator account, click on `Modify`
* Change a date, click on `Modify` again

Expected: The date is changed

Actual: The date is not changed. No errors are displayed

[Screencast from 2023-10-11 17-11-20.webm](https://github.com/Dolibarr/dolibarr/assets/18473412/67728e63-1388-4c4b-962d-f140f897259b)

## Solution

On refused expense reports, `$action` is `updateFromRefuse`, so we don't enter the code that handles the date modification. This PR fixes the condition.