### PR TITLE
fix duplicate ticket information

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -236,6 +236,7 @@ if (empty($reshook)) {
 			$object->category_label = $langs->trans($langs->getLabelFromKey($db, $object->category_code, 'c_ticket_category', 'code', 'label'));
 			$object->severity_code = GETPOST("severity_code", 'alpha');
 			$object->severity_label = $langs->trans($langs->getLabelFromKey($db, $object->severity_code, 'c_ticket_severity', 'code', 'label'));
+			$object->fk_user_create = $user->id;
 			$object->email_from = $user->email;
 			$object->origin_email = null;
 			$notifyTiers = GETPOST("notify_tiers_at_create", 'alpha');

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -226,29 +226,32 @@ if (empty($reshook)) {
 				$object->ref = $getRef;
 			}
 
-			$object->fk_soc = $object->socid = GETPOST("socid", 'int') > 0 ? GETPOST("socid", 'int') : 0;
-			$object->subject = GETPOST("subject", 'alphanohtml');
-			$object->message = GETPOST("message", 'restricthtml');
+			$object->fk_soc 					= $object->socid = GETPOST("socid", 'int') > 0 ? GETPOST("socid", 'int') : 0;
+			$object->subject 					= GETPOST("subject", 'alphanohtml');
+			$object->message 					= GETPOST("message", 'restricthtml');
 
-			$object->type_code = GETPOST("type_code", 'alpha');
-			$object->type_label = $langs->trans($langs->getLabelFromKey($db, $object->type_code, 'c_ticket_type', 'code', 'label'));
-			$object->category_code = GETPOST("category_code", 'alpha');
-			$object->category_label = $langs->trans($langs->getLabelFromKey($db, $object->category_code, 'c_ticket_category', 'code', 'label'));
-			$object->severity_code = GETPOST("severity_code", 'alpha');
-			$object->severity_label = $langs->trans($langs->getLabelFromKey($db, $object->severity_code, 'c_ticket_severity', 'code', 'label'));
-			$object->fk_user_create = $user->id;
-			$object->email_from = $user->email;
-			$object->origin_email = null;
-			$notifyTiers = GETPOST("notify_tiers_at_create", 'alpha');
-			$object->notify_tiers_at_create = empty($notifyTiers) ? 0 : 1;
-			$fk_user_assign = GETPOST("fk_user_assign", 'int');
+			$object->type_code 					= GETPOST("type_code", 'alpha');
+			$object->type_label 				= $langs->trans($langs->getLabelFromKey($db, $object->type_code, 'c_ticket_type', 'code', 'label'));
+			$object->category_code 				= GETPOST("category_code", 'alpha');
+			$object->category_label 			= $langs->trans($langs->getLabelFromKey($db, $object->category_code, 'c_ticket_category', 'code', 'label'));
+			$object->severity_code 				= GETPOST("severity_code", 'alpha');
+			$object->severity_label 			= $langs->trans($langs->getLabelFromKey($db, $object->severity_code, 'c_ticket_severity', 'code', 'label'));
+			$object->fk_user_create 			= $user->id;
+			$object->email_from 				= $user->email;
+			$object->origin_email 				= null;
+
+			$notifyTiers 						= GETPOST("notify_tiers_at_create", 'alpha');
+			$object->notify_tiers_at_create 	= empty($notifyTiers) ? 0 : 1;
+
+			$fk_user_assign 				= GETPOST("fk_user_assign", 'int');
 			if ($fk_user_assign > 0) {
-				$object->fk_user_assign = $fk_user_assign;
-				$object->status = $object::STATUS_ASSIGNED;
+				$object->fk_user_assign 	= $fk_user_assign;
+				$object->status 			= $object::STATUS_ASSIGNED;
 			}
 
-			$object->fk_project = $projectid;
-			$object->fk_contract = GETPOST('fk_contract', 'int');
+			$object->fk_project 				= $projectid;
+			$object->fk_contract 				= GETPOST('fk_contract', 'int');
+
 
 			$id = $object->create($user);
 			if ($id <= 0) {


### PR DESCRIPTION
Fix : wrong ticket information when tickets created at the same time

Case : creating two tickets at the same time from both public interface (sent first) and backoffice.
Consequence : Information from first (public) ticket was reported on backoffice ticket.

https://github.com/Dolibarr/dolibarr/pull/25643 has begun to fix this bug.

This PR overrides fk_user_create from "first" ticket that were still used in "second" ticket.

`$object->fk_user_create 			= $user->id;`