### PR TITLE
bad internal filter with forgeSQLFromUniversalSearchCriteria

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1376,7 +1376,7 @@ class Form
 	 * @param string 	$selected 		Preselected type
 	 * @param string 	$htmlname 		Name of field in form
 	 * @param string 	$filter 		Optional filters criteras. WARNING: To avoid SQL injection, only few chars [.a-z0-9 =<>] are allowed here, example: 's.rowid <> x'
-	 * 									If you need parenthesis, use the Universal Filter Syntax, example: '(s.client:in:(1,3))'
+	 * 									If you need parenthesis, use the Universal Filter Syntax, example: '(s.client:in:1,3)'
 	 * 									Do not use a filter coming from input of users.
 	 * @param string 	$showempty 		Add an empty field (Can be '1' or text to use on empty line like 'SelectThirdParty')
 	 * @param int 		$showtype 		Show third party type in combolist (customer, prospect or supplier)


### PR DESCRIPTION
the filter "(s.client:in:(1,2))" not work, same problem with "s.client in (1,2)"

we need to use now :  "(s.client:in:1,2)"

I corrected the comment for lack of anything better but I am concerned about the scope of this problem