### PR TITLE
fix: missing params in invoice supplier list

### DIFF
--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -871,6 +871,12 @@ if ($search_amount_all_tax) {
 if ($search_status >= 0) {
 	$param .= "&search_status=".urlencode($search_status);
 }
+if ($search_paymentmode) {
+	$param .= '&search_paymentmode='.urlencode($search_paymentmode);
+}
+if ($search_paymentcond) {
+	$param .= '&search_paymentcond='.urlencode($search_paymentcond);
+}
 if ($show_files) {
 	$param .= '&show_files='.urlencode($show_files);
 }


### PR DESCRIPTION
# FIX
Filter by payment mode or payment terms in supplier invoice list and sort the list by any columns, the filter on payment mode or payment terms is lost