### PR TITLE
Clean templates when re-enable receipt printer module

### DIFF
--- a/htdocs/core/modules/modReceiptPrinter.class.php
+++ b/htdocs/core/modules/modReceiptPrinter.class.php
@@ -141,7 +141,7 @@ class modReceiptPrinter extends DolibarrModules
 		$sql = array(
 			"CREATE TABLE IF NOT EXISTS ".MAIN_DB_PREFIX."printer_receipt (rowid integer AUTO_INCREMENT PRIMARY KEY, name varchar(128), fk_type integer, fk_profile integer, parameter varchar(128), entity integer) ENGINE=innodb;",
 			"CREATE TABLE IF NOT EXISTS ".MAIN_DB_PREFIX."printer_receipt_template (rowid integer AUTO_INCREMENT PRIMARY KEY, name varchar(128), template text, entity integer) ENGINE=innodb;",
-			"DELETE FROM ".MAIN_DB_PREFIX."printer_receipt_template WHERE name = '".$this->db->escape($langs->trans('Example'))."';",
+			"TRUNCATE TABLE ".MAIN_DB_PREFIX."printer_receipt_template;",
 			"INSERT INTO ".MAIN_DB_PREFIX."printer_receipt_template (name,template,entity) VALUES ('".$this->db->escape($langs->trans('Example'))."', '".$this->db->escape($templateexample)."', 1);",
 		);
 		return $this->_init($sql, $options);


### PR DESCRIPTION
Improve cleaning when the module is disabled. Currently, when you disable and re-enable the receipt printer module, templates can be duplicated. Now with this code we clean the table correctly and also ensure that a template with rowid 1 exists, because hardware connectors need it.