### PR TITLE
FIX template invoice list extrafield filters (backport v18)

### DIFF
--- a/htdocs/compta/facture/invoicetemplate_list.php
+++ b/htdocs/compta/facture/invoicetemplate_list.php
@@ -383,6 +383,8 @@ if ($search_date_when_start) {
 if ($search_date_when_end) {
 	$sql .= " AND f.date_when <= '".$db->idate($search_date_when_end)."'";
 }
+// Add where from extra fields
+include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 
 // Count total nb of records
 $nbtotalofrecords = '';

--- a/htdocs/compta/facture/invoicetemplate_list.php
+++ b/htdocs/compta/facture/invoicetemplate_list.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2012      Cedric Salvador      <csalvador@gpcsolutions.fr>
  * Copyright (C) 2015-2021 Alexandre Spangaro   <aspangaro@open-dsi.fr>
  * Copyright (C) 2016      Meziane Sof          <virtualsof@yahoo.fr>
+ * Copyright (C) 2023      William Mead			<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
# FIX Broken extrafield filter on template invoices list (backport v18)
This PR includes `/core/tpl/extrafields_list_search_sql.tpl.php` in `compta/facture/invoicetemplate_list.php`