### PR TITLE
FIX - Edit price product if status_buy or status is empty

### DIFF
--- a/htdocs/core/lib/product.lib.php
+++ b/htdocs/core/lib/product.lib.php
@@ -54,39 +54,39 @@ function product_prepare_head($object)
 	$head[$h][2] = 'card';
 	$h++;
 
-	if (!empty($object->status)) {
+	// if (!empty($object->status)) {
+	if ($usercancreadprice) {
+		$head[$h][0] = DOL_URL_ROOT."/product/price.php?id=".$object->id;
+		$head[$h][1] = $langs->trans("SellingPrices");
+		$head[$h][2] = 'price';
+		$h++;
+	} else {
+		$head[$h][0] = '#';
+		$head[$h][1] = $langs->trans("SellingPrices");
+		$head[$h][2] = 'price';
+		$head[$h][5] = 'disabled';
+		$h++;
+	}
+	// }
+
+	// if (!empty($object->status_buy) || (isModEnabled('margin') && !empty($object->status))) {   // If margin is on and product on sell, we may need the cost price even if product os not on purchase
+	if ((isModEnabled("supplier_proposal") || isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) && ($user->hasRight('fournisseur', 'lire') || $user->hasRight('supplier_order', 'read') || $user->hasRight('supplier_invoice', 'read'))
+		|| (isModEnabled('margin') && $user->hasRight("margin", "liretous"))
+		) {
 		if ($usercancreadprice) {
-			$head[$h][0] = DOL_URL_ROOT."/product/price.php?id=".$object->id;
-			$head[$h][1] = $langs->trans("SellingPrices");
-			$head[$h][2] = 'price';
+			$head[$h][0] = DOL_URL_ROOT."/product/fournisseurs.php?id=".$object->id;
+			$head[$h][1] = $langs->trans("BuyingPrices");
+			$head[$h][2] = 'suppliers';
 			$h++;
 		} else {
 			$head[$h][0] = '#';
-			$head[$h][1] = $langs->trans("SellingPrices");
-			$head[$h][2] = 'price';
+			$head[$h][1] = $langs->trans("BuyingPrices");
+			$head[$h][2] = 'suppliers';
 			$head[$h][5] = 'disabled';
 			$h++;
 		}
 	}
-
-	if (!empty($object->status_buy) || (isModEnabled('margin') && !empty($object->status))) {   // If margin is on and product on sell, we may need the cost price even if product os not on purchase
-		if ((isModEnabled("supplier_proposal") || isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) && ($user->hasRight('fournisseur', 'lire') || $user->hasRight('supplier_order', 'read') || $user->hasRight('supplier_invoice', 'read'))
-		|| (isModEnabled('margin') && $user->hasRight("margin", "liretous"))
-		) {
-			if ($usercancreadprice) {
-				$head[$h][0] = DOL_URL_ROOT."/product/fournisseurs.php?id=".$object->id;
-				$head[$h][1] = $langs->trans("BuyingPrices");
-				$head[$h][2] = 'suppliers';
-				$h++;
-			} else {
-				$head[$h][0] = '#';
-				$head[$h][1] = $langs->trans("BuyingPrices");
-				$head[$h][2] = 'suppliers';
-				$head[$h][5] = 'disabled';
-				$h++;
-			}
-		}
-	}
+	// }
 
 	// Multilangs
 	if (getDolGlobalInt('MAIN_MULTILANGS')) {


### PR DESCRIPTION
# FIX|Fix #[*Edit price product if status_buy or status is empty*]

For me it makes no sense not to be able to access the sale or purchase price depending on the status.

For several reasons

How to know the price history without having to change the status and taking a risk that it is sold at the same time

We can also change its price despite the status at 0 to follow its evolution in sale and purchase prices

In addition, if we have the variant module and the variants still on sale or purchase we cannot modify the prices directly on them because they are indexed to the master product.