### PR TITLE
fix  #26244 todelete could contains dupplicate val

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1291,7 +1291,9 @@ if (!$error && ($massaction == 'delete' || ($action == 'delete' && $confirm == '
 
 	$objecttmp = new $objectclass($db);
 	$nbok = 0;
-	foreach ($toselect as $toselectid) {
+	//$toselect could contain duplicate entries, cf https://github.com/Dolibarr/dolibarr/issues/26244
+	$unique_arr = array_unique($toselect);
+	foreach ($unique_arr as $toselectid) {
 		$result = $objecttmp->fetch($toselectid);
 		if ($result > 0) {
 			// Refuse deletion for some objects/status


### PR DESCRIPTION
fix  #26244 : in case of delete mass action with fichinter todelete array could contain duplicate values

And in that case fichinter object is not deleted but there is a bug agains database with ecm table (second fix will come for that specific point).

With that fix we take unique values from array and delete proper object