### PR TITLE
Fix::Correct full path tcpdf

### DIFF
--- a/htdocs/includes/tecnickcom/tcpdf/tcpdf.php
+++ b/htdocs/includes/tecnickcom/tcpdf/tcpdf.php
@@ -19243,7 +19243,7 @@ class TCPDF
 							// convert URL to server path
 							$imgsrc = str_replace(K_PATH_MAIN, K_PATH_URL, $imgsrc);
 						}
-					} elseif (($imgsrc[0] === '/') AND !empty($_SERVER['DOCUMENT_ROOT']) AND ($_SERVER['DOCUMENT_ROOT'] != '/')) {
+					} elseif (!file_exists($imgsrc) && ($imgsrc[0] === '/') AND !empty($_SERVER['DOCUMENT_ROOT']) AND ($_SERVER['DOCUMENT_ROOT'] != '/')) {
 							// fix image path
 						$findroot = strpos($imgsrc, $_SERVER['DOCUMENT_ROOT']);
 						if (($findroot === false) OR ($findroot > 1)) {


### PR DESCRIPTION
### FIX
When the absolute path is good it duplicates Document_Root