### PR TITLE
FIX : export separator config with multientity

### DIFF
--- a/htdocs/admin/export.php
+++ b/htdocs/admin/export.php
@@ -40,15 +40,15 @@ if (!$user->admin) {
 }
 
 $action = GETPOST('action', 'aZ09');
-$value = GETPOST('value', 'alpha');
-$modulepart = GETPOST('modulepart', 'aZ09');	// Used by actions_setmoduleoptions.inc.php
 
 
 /*
  * Actions
  */
 
-include DOL_DOCUMENT_ROOT.'/core/actions_setmoduleoptions.inc.php';
+if ($action == 'save') {
+	dolibarr_set_const($db, 'EXPORT_CSV_SEPARATOR_TO_USE', GETPOST('EXPORT_CSV_SEPARATOR_TO_USE', 'alphanohtml'));
+}
 
 
 /*
@@ -77,21 +77,29 @@ print dol_get_fiche_head($head, 'setup', $langs->trans("ExportsArea"), -1, "tech
 
 print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
 print '<input type="hidden" name="token" value="'.newToken().'">';
-print '<input type="hidden" name="page_y" value="">';
-print '<input type="hidden" name="action" value="setModuleOptions">';
-print '<input type="hidden" name="param" value="EXPORT_CSV_SEPARATOR_TO_USE">';
+print '<input type="hidden" name="action" value="save">';
 
 print '<table class="noborder centpercent">';
+
 print '<tr class="liste_titre">';
 print '<td>'.$langs->trans("Parameters").'</td>'."\n";
 print '<td class="center" width="20">&nbsp;</td>';
 print '<td class="center" width="100"></td>'."\n";
 print '</tr>';
 
+/* No more need for this, you can set that a profile is public when saving it.
 print '<tr class="oddeven">';
-print '<td>'.$langs->trans("ExportCsvSeparator").' ('.$langs->trans("ByDefault").')</td>';
-print '<td width="60" align="center">'."<input size=\"3\" class=\"flat\" type=\"text\" name=\"value\" value=\"".(empty($conf->global->EXPORT_CSV_SEPARATOR_TO_USE) ? ',' : $conf->global->EXPORT_CSV_SEPARATOR_TO_USE)."\"></td>";
-print '<td class="right"><input type="submit" class="button button-edit reposition" value="'.$langs->trans("Modify").'"></td>';
+print '<td>'.$langs->trans("EXPORTS_SHARE_MODELS").'</td>';
+print '<td class="center" width="20">&nbsp;</td>';
+print '<td class="center" width="100">';
+print ajax_constantonoff('EXPORTS_SHARE_MODELS');
+print '</td></tr>';
+*/
+
+print '<tr class="oddeven">';
+print '<td>'.$langs->trans("ExportCsvSeparator").'</td>';
+print '<td width="60" align="center"><input class="flat width50" maxlength="3" type="text" name="EXPORT_CSV_SEPARATOR_TO_USE" value="'.(empty($conf->global->EXPORT_CSV_SEPARATOR_TO_USE) ? ',' : $conf->global->EXPORT_CSV_SEPARATOR_TO_USE).'"></td>';
+print '<td class="right"><input type="submit" class="button button-edit" value="'.$langs->trans("Modify").'"></td>';
 print '</tr>';
 
 print '</table>';

--- a/htdocs/admin/export.php
+++ b/htdocs/admin/export.php
@@ -47,7 +47,7 @@ $action = GETPOST('action', 'aZ09');
  */
 
 if ($action == 'save') {
-	dolibarr_set_const($db, 'EXPORT_CSV_SEPARATOR_TO_USE', GETPOST('EXPORT_CSV_SEPARATOR_TO_USE', 'alphanohtml'));
+	dolibarr_set_const($db, 'EXPORT_CSV_SEPARATOR_TO_USE', GETPOST('EXPORT_CSV_SEPARATOR_TO_USE', 'alphanohtml'), 'chaine', 0, '', $conf->entity);
 }
 
 

--- a/htdocs/admin/export.php
+++ b/htdocs/admin/export.php
@@ -40,15 +40,15 @@ if (!$user->admin) {
 }
 
 $action = GETPOST('action', 'aZ09');
+$value = GETPOST('value', 'alpha');
+$modulepart = GETPOST('modulepart', 'aZ09');	// Used by actions_setmoduleoptions.inc.php
 
 
 /*
  * Actions
  */
 
-if ($action == 'save') {
-	dolibarr_set_const($db, 'EXPORT_CSV_SEPARATOR_TO_USE', GETPOST('EXPORT_CSV_SEPARATOR_TO_USE', 'alphanohtml'));
-}
+include DOL_DOCUMENT_ROOT.'/core/actions_setmoduleoptions.inc.php';
 
 
 /*
@@ -77,29 +77,21 @@ print dol_get_fiche_head($head, 'setup', $langs->trans("ExportsArea"), -1, "tech
 
 print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
 print '<input type="hidden" name="token" value="'.newToken().'">';
-print '<input type="hidden" name="action" value="save">';
+print '<input type="hidden" name="page_y" value="">';
+print '<input type="hidden" name="action" value="setModuleOptions">';
+print '<input type="hidden" name="param" value="EXPORT_CSV_SEPARATOR_TO_USE">';
 
 print '<table class="noborder centpercent">';
-
 print '<tr class="liste_titre">';
 print '<td>'.$langs->trans("Parameters").'</td>'."\n";
 print '<td class="center" width="20">&nbsp;</td>';
 print '<td class="center" width="100"></td>'."\n";
 print '</tr>';
 
-/* No more need for this, you can set that a profile is public when saving it.
 print '<tr class="oddeven">';
-print '<td>'.$langs->trans("EXPORTS_SHARE_MODELS").'</td>';
-print '<td class="center" width="20">&nbsp;</td>';
-print '<td class="center" width="100">';
-print ajax_constantonoff('EXPORTS_SHARE_MODELS');
-print '</td></tr>';
-*/
-
-print '<tr class="oddeven">';
-print '<td>'.$langs->trans("ExportCsvSeparator").'</td>';
-print '<td width="60" align="center"><input class="flat width50" maxlength="3" type="text" name="EXPORT_CSV_SEPARATOR_TO_USE" value="'.(empty($conf->global->EXPORT_CSV_SEPARATOR_TO_USE) ? ',' : $conf->global->EXPORT_CSV_SEPARATOR_TO_USE).'"></td>';
-print '<td class="right"><input type="submit" class="button button-edit" value="'.$langs->trans("Modify").'"></td>';
+print '<td>'.$langs->trans("ExportCsvSeparator").' ('.$langs->trans("ByDefault").')</td>';
+print '<td width="60" align="center">'."<input size=\"3\" class=\"flat\" type=\"text\" name=\"value\" value=\"".(empty($conf->global->EXPORT_CSV_SEPARATOR_TO_USE) ? ',' : $conf->global->EXPORT_CSV_SEPARATOR_TO_USE)."\"></td>";
+print '<td class="right"><input type="submit" class="button button-edit reposition" value="'.$langs->trans("Modify").'"></td>';
 print '</tr>';
 
 print '</table>';


### PR DESCRIPTION
I was trying to te set a default separator for export on another entity than the default one and i view it wasn't working.

After check the admin/import.php i notice some differences who shouldn't exist for me.

the changes come from this commit : 30b48a9ee3480fccf9e067ccd805874f695d6e22 (i don't really know why)

So i changed the file to be like before and like admin/import.php

--

Anyway if you prefere we can only fix the initial issue on change dolibarr_set_const() funciton like that :

`dolibarr_set_const($db, 'EXPORT_CSV_SEPARATOR_TO_USE', GETPOST('EXPORT_CSV_SEPARATOR_TO_USE', 'alphanohtml'), 'chaine', 0, '', $conf->entity);`