### PR TITLE
FIX - Auto fill the field end of period with end of month when cloning a salary

### DIFF
--- a/htdocs/langs/en_US/salaries.lang
+++ b/htdocs/langs/en_US/salaries.lang
@@ -25,3 +25,4 @@ SalariesAndPayments=Salaries and payments
 ConfirmDeleteSalaryPayment=Do you want to delete this salary payment ?
 FillFieldFirst=Fill employee field first
 UpdateAmountWithLastSalary=Set amount of last salary
+FillEndOfMonth=Fill with end of month

--- a/htdocs/langs/fr_FR/salaries.lang
+++ b/htdocs/langs/fr_FR/salaries.lang
@@ -25,3 +25,4 @@ SalariesAndPayments=Salaires et paiements
 ConfirmDeleteSalaryPayment=Voulez-vous supprimer ce paiement de salaire ?
 FillFieldFirst=Remplissez d'abord le champ de l'employé
 UpdateAmountWithLastSalary=Définir sur le montant du dernier salaire
+FillEndOfMonth=Remplir avec la fin du mois

--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -741,17 +741,17 @@ if ($id > 0) {
 
 		//Add fill with end of month button
 		$formconfirm .= "<script>
-			$('#clone_date_end').after($('<button id=\"fill_end_of_month\" class=\"dpInvisibleButtons\" style=\"color: var(--colortextlink);font-size: 0.8em;opacity: 0.7;margin-left:4px;\" type=\"button\">". $langs->trans('FillEndOfMonth')."</button>'));
+			$('#clone_date_end').after($('<button id=\"fill_end_of_month\" class=\"dpInvisibleButtons\" style=\"color: var(--colortextlink);font-size: 0.8em;opacity: 0.7;margin-left:4px;\" type=\"button\">".$langs->trans('FillEndOfMonth')."</button>'));
 			$('#fill_end_of_month').click(function(){
 				var clone_date_startmonth = +$('#clone_date_startmonth').val();
 				var clone_date_startyear = +$('#clone_date_startyear').val();
 				var end_date = new Date(clone_date_startyear, clone_date_startmonth, 0);
 				end_date.setMonth(clone_date_startmonth - 1);
-				$('#clone_date_end').val( (new Intl.DateTimeFormat('".str_replace("_", "-", $langs->shortlang)."',{year: 'numeric',month: '2-digit',day: '2-digit'})).format(end_date));
+				$('#clone_date_end').val(formatDate(end_date,'".$langs->trans("FormatDateShortJavaInput")."'));
 				$('#clone_date_endday').val(end_date.getDate());
 				$('#clone_date_endmonth').val(end_date.getMonth() + 1);
 				$('#clone_date_endyear').val(end_date.getFullYear());
-			});					
+			});
 		</script>";
 	}
 

--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -741,17 +741,16 @@ if ($id > 0) {
 
 		//Add fill with end of month button
 		$formconfirm .= "<script>
-			$('#clone_date_end').after($('<button id=\"fill_end_of_month\" class=\"dpInvisibleButtons\" style=\"color: var(--colortextlink);font-size: 0.8em;opacity: 0.7;margin-left:4px;\" type=\"button\">".$langs->trans('FillEndOfMonth')."</button>'));
+			$('#clone_date_end').after($('<button id=\"fill_end_of_month\" class=\"dpInvisibleButtons\" style=\"color: var(--colortextlink);font-size: 0.8em;opacity: 0.7;margin-left:4px;\" type=\"button\">". $langs->trans('FillEndOfMonth')."</button>'));
 			$('#fill_end_of_month').click(function(){
-				var jsDate = $('#clone_date_start').datepicker('getDate');
-				if (jsDate !== null) {
-					jsDate instanceof Date;
-					var lastDate = new Date(jsDate.getFullYear(), jsDate.getMonth() + 1, 0);
-					$('#clone_date_endday').val(lastDate.getDate());
-					$('#clone_date_endmonth').val(lastDate.getMonth() + 1);
-					$('#clone_date_endyear').val(lastDate.getFullYear());
-					$('#clone_date_end').datepicker().datepicker('setDate', lastDate);
-				}
+				var clone_date_startmonth = +$('#clone_date_startmonth').val();
+				var clone_date_startyear = +$('#clone_date_startyear').val();
+				var end_date = new Date(clone_date_startyear, clone_date_startmonth, 0);
+				end_date.setMonth(clone_date_startmonth - 1);
+				$('#clone_date_end').val( (new Intl.DateTimeFormat('".str_replace("_", "-", $langs->shortlang)."',{year: 'numeric',month: '2-digit',day: '2-digit'})).format(end_date));
+				$('#clone_date_endday').val(end_date.getDate());
+				$('#clone_date_endmonth').val(end_date.getMonth() + 1);
+				$('#clone_date_endyear').val(end_date.getFullYear());
 			});					
 		</script>";
 	}

--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -738,6 +738,22 @@ if ($id > 0) {
 		$formquestion[] = array('type' => 'text', 'name' => 'amount', 'label' => $langs->trans("Amount"), 'value' => price($object->amount), 'morecss' => 'width100 right');
 
 		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToClone'), $langs->trans('ConfirmCloneSalary', $object->ref), 'confirm_clone', $formquestion, 'yes', 1, 280);
+
+		//Add fill with end of month button
+		$formconfirm .= "<script>
+			$('#clone_date_end').after($('<button id=\"fill_end_of_month\" class=\"dpInvisibleButtons\" style=\"color: var(--colortextlink);font-size: 0.8em;opacity: 0.7;margin-left:4px;\" type=\"button\">".$langs->trans('FillEndOfMonth')."</button>'));
+			$('#fill_end_of_month').click(function(){
+				var jsDate = $('#clone_date_start').datepicker('getDate');
+				if (jsDate !== null) {
+					jsDate instanceof Date;
+					var lastDate = new Date(jsDate.getFullYear(), jsDate.getMonth() + 1, 0);
+					$('#clone_date_endday').val(lastDate.getDate());
+					$('#clone_date_endmonth').val(lastDate.getMonth() + 1);
+					$('#clone_date_endyear').val(lastDate.getFullYear());
+					$('#clone_date_end').datepicker().datepicker('setDate', lastDate);
+				}
+			});					
+		</script>";
 	}
 
 	if ($action == 'paid') {


### PR DESCRIPTION
# Done
Adding button to auto fill the field end of period with end of month when cloning a salary.
![Capture](https://github.com/Dolibarr/dolibarr/assets/16115679/44dfb2f6-825c-4107-8660-164c82782216)

- #21425

# Suggestion
I suggest removing this button and make it more easy by filling directely the field end date once the value of start date changes.

