### PR TITLE
Fix some items detected by phan (see #26262)

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1334,7 +1334,7 @@ class ActionComm extends CommonObject
 		// Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
-			$hookmanager = new HookManager($db);
+			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(array('agendadao'));
 

--- a/htdocs/core/menus/standard/empty.php
+++ b/htdocs/core/menus/standard/empty.php
@@ -105,7 +105,7 @@ class MenuManager
 				$classname = 'class="tmenu menuhider nohover"';
 				$idsel = 'menu';
 
-				$this->menu->add('#', '', 0, $showmode, $atarget, "xxx", '', 0, $id, $idsel, $classname);
+				$this->menu->add('#', '', 0, $showmode, $this->atarget, "xxx", '', 0, $id, $idsel, $classname);
 			}
 
 			// Home
@@ -125,7 +125,7 @@ class MenuManager
 					print_start_menu_entry_empty($menuval['idsel'], $menuval['classname'], $menuval['enabled']);
 				}
 				if (empty($noout)) {
-					print_text_menu_entry_empty($menuval['titre'], $menuval['enabled'], ($menuval['url'] != '#' ?DOL_URL_ROOT:'').$menuval['url'], $menuval['id'], $menuval['idsel'], $menuval['classname'], ($menuval['target'] ? $menuval['target'] : $atarget));
+					print_text_menu_entry_empty($menuval['titre'], $menuval['enabled'], ($menuval['url'] != '#' ?DOL_URL_ROOT:'').$menuval['url'], $menuval['id'], $menuval['idsel'], $menuval['classname'], ($menuval['target'] ? $menuval['target'] : $this->atarget));
 				}
 				if (empty($noout)) {
 					print_end_menu_entry_empty($menuval['enabled']);

--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1078,7 +1078,7 @@ class FactureFournisseurRec extends CommonInvoice
 
 		$facid = $this->id;
 
-		dol_syslog(get_class($this). '::updateline facid=' .$facid." rowid=$rowid, desc=$desc, pu_ht=$pu_ht, qty=$qty, txtva=$txtva, txlocaltax1=$txlocaltax1, txlocaltax2=$txlocaltax2, fk_product=$fk_product, remise_percent=$remise_percent, info_bits=$info_bits, fk_remise_except=$fk_remise_except, price_base_type=$price_base_type, pu_ttc=$pu_ttc, type=$type, fk_unit=$fk_unit, pu_ht_devise=$pu_ht_devise", LOG_DEBUG);
+		dol_syslog(get_class($this). '::updateline facid=' .$facid." rowid=$rowid, desc=$desc, pu_ht=$pu_ht, qty=$qty, txtva=$txtva, txlocaltax1=$txlocaltax1, txlocaltax2=$txlocaltax2, fk_product=$fk_product, remise_percent=$remise_percent, info_bits=$info_bits, fk_remise_except=$fk_remise_except, price_base_type=$price_base_type, pu_ht=$pu_ht, type=$type, fk_unit=$fk_unit, pu_ht_devise=$pu_ht_devise", LOG_DEBUG);
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
 
 		// Check parameters
@@ -1094,7 +1094,7 @@ class FactureFournisseurRec extends CommonInvoice
 			$qty = price2num($qty);
 			$info_bits = empty($info_bits) ? 0 : $info_bits;
 			$pu_ht          = price2num($pu_ht);
-			$pu_ttc         = price2num($pu_ttc);
+			$pu_ttc         = price2num($pu_ht+$pu_ht*$txtva); // TODO: is ttc with txlocaltax?
 			$pu_ht_devise = price2num($pu_ht_devise);
 
 			if (!preg_match('/\((.*)\)/', $txtva)) {

--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1057,7 +1057,7 @@ class FactureFournisseurRec extends CommonInvoice
 	 * @param double 	$pu_ht 				Unit price HT (> 0 even for credit note)
 	 * @param double 	$qty 				Quantity
 	 * @param int 		$remise_percent 	Percentage discount of the line
-	 * @param double 	$txtva 				VAT rate forced, or -1
+	 * @param double 	$txtva 				VAT rate forced with format '5.0 (XXX)', or -1
 	 * @param int 		$txlocaltax1 		Local tax 1 rate (deprecated)
 	 * @param int 		$txlocaltax2 		Local tax 2 rate (deprecated)
 	 * @param string 	$price_base_type 	HT or TTC
@@ -1095,7 +1095,7 @@ class FactureFournisseurRec extends CommonInvoice
 			$qty = price2num($qty);
 			$info_bits = empty($info_bits) ? 0 : $info_bits;
 			$pu_ht          = price2num($pu_ht);
-			$pu_ttc         = price2num($pu_ttc); // TODO: is ttc with txlocaltax?
+			$pu_ttc         = price2num($pu_ttc);
 			$pu_ht_devise = price2num($pu_ht_devise);
 
 			if (!preg_match('/\((.*)\)/', $txtva)) {

--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1054,10 +1054,10 @@ class FactureFournisseurRec extends CommonInvoice
 	 * @param string	$ref				Ref
 	 * @param string 	$label 				Label of the line
 	 * @param string 	$desc 				Description de la ligne
-	 * @param double 	$pu_ht 				Prix unitaire HT (> 0 even for credit note)
+	 * @param double 	$pu_ht 				Unit price HT (> 0 even for credit note)
 	 * @param double 	$qty 				Quantity
 	 * @param int 		$remise_percent 	Percentage discount of the line
-	 * @param double 	$txtva 				Taux de tva force, sinon -1
+	 * @param double 	$txtva 				VAT rate forced, or -1
 	 * @param int 		$txlocaltax1 		Local tax 1 rate (deprecated)
 	 * @param int 		$txlocaltax2 		Local tax 2 rate (deprecated)
 	 * @param string 	$price_base_type 	HT or TTC
@@ -1068,7 +1068,8 @@ class FactureFournisseurRec extends CommonInvoice
 	 * @param int 		$special_code 		Special code
 	 * @param int 		$rang 				Position of line
 	 * @param string 	$fk_unit 			Unit
-	 * @param int 		$pu_ht_devise 		Unit price in currency
+	 * @param double	$pu_ht_devise 		Unit price in currency
+     * @param double    $pu_ttc             Unit price TTC (> 0 even for credit note)
 	 * @return int  		                <0 if KO, Id of line if OK
 	 * @throws Exception
 	 */
@@ -1078,7 +1079,7 @@ class FactureFournisseurRec extends CommonInvoice
 
 		$facid = $this->id;
 
-		dol_syslog(get_class($this). '::updateline facid=' .$facid." rowid=$rowid, desc=$desc, pu_ht=$pu_ht, qty=$qty, txtva=$txtva, txlocaltax1=$txlocaltax1, txlocaltax2=$txlocaltax2, fk_product=$fk_product, remise_percent=$remise_percent, info_bits=$info_bits, fk_remise_except=$fk_remise_except, price_base_type=$price_base_type, pu_ht=$pu_ht, type=$type, fk_unit=$fk_unit, pu_ht_devise=$pu_ht_devise", LOG_DEBUG);
+		dol_syslog(get_class($this). '::updateline facid=' .$facid." rowid=$rowid, desc=$desc, pu_ht=$pu_ht, qty=$qty, txtva=$txtva, txlocaltax1=$txlocaltax1, txlocaltax2=$txlocaltax2, fk_product=$fk_product, remise_percent=$remise_percent, info_bits=$info_bits, fk_remise_except=$fk_remise_except, price_base_type=$price_base_type, pu_ttc=$pu_ttc, type=$type, fk_unit=$fk_unit, pu_ht_devise=$pu_ht_devise", LOG_DEBUG);
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
 
 		// Check parameters
@@ -1094,7 +1095,7 @@ class FactureFournisseurRec extends CommonInvoice
 			$qty = price2num($qty);
 			$info_bits = empty($info_bits) ? 0 : $info_bits;
 			$pu_ht          = price2num($pu_ht);
-			$pu_ttc         = price2num($pu_ht+$pu_ht*$txtva); // TODO: is ttc with txlocaltax?
+			$pu_ttc         = price2num($pu_ttc); // TODO: is ttc with txlocaltax?
 			$pu_ht_devise = price2num($pu_ht_devise);
 
 			if (!preg_match('/\((.*)\)/', $txtva)) {

--- a/htdocs/hrm/position.php
+++ b/htdocs/hrm/position.php
@@ -780,7 +780,7 @@ if ($job->id > 0 && (empty($action) || ($action != 'edit' && $action != 'create'
  */
 function DisplayPositionList()
 {
-	global $user, $langs, $db, $conf, $extrafields, $hookmanager, $permissiontoadd, $permissiontodelete;
+	global $user, $langs, $db, $conf, $extrafields, $hookmanager, $permissiontoadd, $permissiontodelete, $permissiontoread;
 
 	$action 	 = GETPOST('action', 'aZ09') ? GETPOST('action', 'aZ09') : 'view'; // The action 'add', 'create', 'edit', 'update', 'view', ...
 	$massaction  = GETPOST('massaction', 'alpha'); // The bulk action (combo box choice into lists)

--- a/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
+++ b/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
@@ -353,7 +353,7 @@ class StockTransfer extends CommonObject
 	 * @param	Object	$b		2nd element to test
 	 * @return int
 	 */
-	public function cmp($a, $b)
+	static public function cmp($a, $b)
 	{
 		if ($a->rang == $b->rang) {
 			return 0;

--- a/htdocs/public/onlinesign/newonlinesign.php
+++ b/htdocs/public/onlinesign/newonlinesign.php
@@ -180,7 +180,7 @@ if ($action == 'confirm_refusepropal' && $confirm == 'yes') {
 	$sql .= " SET fk_statut = ".((int) $object::STATUS_NOTSIGNED).", note_private = '".$db->escape($object->note_private)."', date_signature='".$db->idate(dol_now())."'";
 	$sql .= " WHERE rowid = ".((int) $object->id);
 
-	dol_syslog(__METHOD__, LOG_DEBUG);
+	dol_syslog(__FILE__, LOG_DEBUG);
 	$resql = $db->query($sql);
 	if (!$resql) {
 		$error++;

--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -1339,7 +1339,7 @@ if ($action == 'create') {
 	print '<td colspan="2">';
 	print img_picto('', 'action', 'class="pictofixedwidth"');
 	$datedelivery = dol_mktime(0, 0, 0, GETPOST('liv_month'), GETPOST('liv_day'), GETPOST('liv_year'));
-	if (in_numeric(getDolGlobalString('DATE_LIVRAISON_WEEK_DELAY'))) {	// If value set to 0 or a num, not empty
+	if (is_numeric(getDolGlobalString('DATE_LIVRAISON_WEEK_DELAY'))) {	// If value set to 0 or a num, not empty
 		$tmpdte = time() + (7 * getDolGlobalInt('DATE_LIVRAISON_WEEK_DELAY') * 24 * 60 * 60);
 		$syear = date("Y", $tmpdte);
 		$smonth = date("m", $tmpdte);


### PR DESCRIPTION
# FIX|Fix #26262 (Partial)

Fix some of the issues detected by phan:

> htdocs\comm\action\class\actioncomm.class.php:1337 PhanUndeclaredVariable Variable $db i
s undeclared (Did you mean $this->db)
> htdocs\core\menus\standard\empty.php:108 PhanUndeclaredVariable Variable $atarget is und
eclared (Did you mean $this->atarget)
> htdocs\core\menus\standard\empty.php:128 PhanUndeclaredVariable Variable $atarget is und
eclared (Did you mean $this->atarget)
htdocs\fourn\class\fournisseur.facture-rec.class.php:1081 PhanUndeclaredVariable Variabl
e $pu_ttc is undeclared (Did you mean $pu_ht)
htdocs\fourn\class\fournisseur.facture-rec.class.php:1097 PhanUndeclaredVariable Variabl
e $pu_ttc is undeclared (Did you mean $pu_ht)
htdocs\hrm\position.php:1328 PhanUndeclaredVariable Variable $permissiontoread is undecl
ared (Did you mean $permissiontoadd)
htdocs\product\stock\stocktransfer\class\stocktransfer.class.php:345 PhanStaticCallToNon
Static Static call to non-static method \StockTransfer::cmp defined at htdocs\product\stoc
k\stocktransfer\class\stocktransfer.class.php:356. This is an Error in PHP 8.0+.
htdocs\public\onlinesign\newonlinesign.php:183 PhanUndeclaredMagicConstant Reference to 
magic constant __METHOD__ that is undeclared in the current scope: used outside of a funct
ionlike
htdocs\supplier_proposal\card.php:1342 PhanUndeclaredFunction Call to undeclared functio
n \in_numeric() (Did you mean \is_numeric())
