### PR TITLE
FIX : Wrong backtopage 

### DIFF
--- a/htdocs/product/stock/stocktransfer/stocktransfer_list.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_list.php
@@ -319,7 +319,7 @@ print '<input type="hidden" name="sortorder" value="'.$sortorder.'">';
 //print '<input type="hidden" name="page" value="'.$page.'">';
 print '<input type="hidden" name="contextpage" value="'.$contextpage.'">';
 
-$newcardbutton = dolGetButtonTitle($langs->trans('New'), '', 'fa fa-plus-circle', dol_buildpath('/product/stock/stocktransfer/stocktransfer_card.php', 1).'?action=create&backtopage='.urlencode($_SERVER['PHP_SELF']), '', $permissiontoadd);
+$newcardbutton = dolGetButtonTitle($langs->trans('New'), '', 'fa fa-plus-circle', dol_buildpath('/product/stock/stocktransfer/stocktransfer_card.php', 1).'?action=create', '', $permissiontoadd);
 
 print_barre_liste($title, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, 'object_'.$object->picto, 0, $newcardbutton, '', $limit, 0, 0, 1);
 


### PR DESCRIPTION
## FIX : Wrong backtopage 

When you create a stock transfer from the list (creation button, top right of the list), you are redirected to the list.
It makes more sense to redirect the user to the created stock transfer
