### PR TITLE
Fix Reception: refactor code to simplify indentation

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1753,29 +1753,28 @@ class Reception extends CommonObject
 					$mouvS->origin = &$this;
 					$mouvS->setOrigin($this->element, $this->id);
 
-					if (empty($obj->batch)) {
-						// line without batch detail
+					$inventorycode = '';
+					$date_eatby = '';
+					$date_sellby = '';
+					$batch = '';
+					$fk_origin_stock = 0;
 
-						// We decrement stock of product (and sub-products) -> update table llx_product_stock (key of this table is fk_product+fk_entrepot) and add a movement record
-						$inventorycode = '';
-						$result = $mouvS->livraison($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price, $langs->trans("ReceptionUnClassifyCloseddInDolibarr", $numref), '', '', '', '', 0, $inventorycode);
+					if (!empty($obj->batch))
+					{
+						$date_eatby = $this->db->jdate($obj->eatby);
+						$date_sellby = $this->db->jdate($obj->sellby);
+						$batch = $obj->batch;
+						$fk_origin_stock = $obj->fk_origin_stock;
+					}
 
-						if ($result < 0) {
-							$this->error = $mouvS->error;
-							$this->errors = $mouvS->errors;
-							$error++; break;
-						}
-					} else {
-						// line with batch detail
+					$result = $mouvS->livraison($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price,
+						$langs->trans("ReceptionUnClassifyCloseddInDolibarr", $numref), '', $date_eatby, $date_sellby, $batch, $fk_origin_stock, $inventorycode);
 
-						// We decrement stock of product (and sub-products) -> update table llx_product_stock (key of this table is fk_product+fk_entrepot) and add a movement record
-						$inventorycode = '';
-						$result = $mouvS->livraison($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price, $langs->trans("ReceptionUnClassifyCloseddInDolibarr", $numref), '', $this->db->jdate($obj->eatby), $this->db->jdate($obj->sellby), $obj->batch, $obj->fk_origin_stock, $inventorycode);
-						if ($result < 0) {
-							$this->error = $mouvS->error;
-							$this->errors = $mouvS->errors;
-							$error++; break;
-						}
+					if ($result < 0) {
+						$this->error = $mouvS->error;
+						$this->errors = $mouvS->errors;
+						$this->db->rollback();
+						return -1;
 					}
 				}
 			}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1402,7 +1402,10 @@ class Reception extends CommonObject
 	public function setDeliveryDate($user, $delivery_date)
 	{
 		// phpcs:enable
-		if ($user->rights->reception->creer) {
+		if (!$user->rights->reception->creer)
+			return -2;
+
+		{
 			$sql = "UPDATE ".MAIN_DB_PREFIX."reception";
 			$sql .= " SET date_delivery = ".($delivery_date ? "'".$this->db->idate($delivery_date)."'" : 'null');
 			$sql .= " WHERE rowid = ".((int) $this->id);
@@ -1416,8 +1419,6 @@ class Reception extends CommonObject
 				$this->error = $this->db->error();
 				return -1;
 			}
-		} else {
-			return -2;
 		}
 	}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -987,15 +987,13 @@ class Reception extends CommonObject
 			$error++; $this->errors[] = "Error ".$this->db->lasterror();
 		}
 
-		if (!$error) {
-			if (!$notrigger) {
-				// Call trigger
-				$result = $this->call_trigger('RECEPTION_MODIFY', $user);
-				if ($result < 0) {
-					$error++;
-				}
-				// End call triggers
+		if (!$error && !$notrigger) {
+			// Call trigger
+			$result = $this->call_trigger('RECEPTION_MODIFY', $user);
+			if ($result < 0) {
+				$error++;
 			}
+			// End call triggers
 		}
 
 		// Commit or rollback

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1873,29 +1873,25 @@ class Reception extends CommonObject
 						$mouvS->origin = &$this;
 						$mouvS->setOrigin($this->element, $this->id);
 
-						if (empty($obj->batch)) {
-							// line without batch detail
+						$inventorycode = '';
+						$date_eatby = '';
+						$date_sellby = '';
+						$batch = '';
 
-							// We decrement stock of product (and sub-products) -> update table llx_product_stock (key of this table is fk_product+fk_entrepot) and add a movement record
-							$inventorycode = '';
-							$result = $mouvS->livraison($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price, $langs->trans("ReceptionBackToDraftInDolibarr", $this->ref), '', '', '', '', 0, $inventorycode);
-							if ($result < 0) {
-								$this->error = $mouvS->error;
-								$this->errors = $mouvS->errors;
-								$error++;
-								break;
-							}
-						} else {
-							// line with batch detail
+						if (!empty($obj->batch)) {
+							$date_eatby = $this->db->jdate($obj->eatby);
+							$date_sellby = $this->db->jdate($obj->sellby);
+							$batch = $obj->batch;
+						}
 
-							// We decrement stock of product (and sub-products) -> update table llx_product_stock (key of this table is fk_product+fk_entrepot) and add a movement record
-							$inventorycode = '';
-							$result = $mouvS->livraison($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price, $langs->trans("ReceptionBackToDraftInDolibarr", $this->ref), '', $this->db->jdate($obj->eatby), $this->db->jdate($obj->sellby), $obj->batch, 0, $inventorycode);
-							if ($result < 0) {
-								$this->error = $mouvS->error;
-								$this->errors = $mouvS->errors;
-								$error++; break;
-							}
+						$result = $mouvS->livraison($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price,
+							$langs->trans("ReceptionBackToDraftInDolibarr", $this->ref), '', $date_eatby, $date_sellby, $batch, 0, $inventorycode);
+
+						if ($result < 0) {
+							$this->error = $mouvS->error;
+							$this->errors = $mouvS->errors;
+							$this->db->rollback();
+							return -1;
 						}
 					}
 				}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1729,7 +1729,13 @@ class Reception extends CommonObject
 
 			dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
 			$resql = $this->db->query($sql);
-			if ($resql) {
+			if (!$resql) {
+				$this->error = $this->db->lasterror();
+				$this->db->rollback();
+				return -1;
+			}
+
+			{
 				$cpt = $this->db->num_rows($resql);
 				for ($i = 0; $i < $cpt; $i++) {
 					$obj = $this->db->fetch_object($resql);
@@ -1772,9 +1778,6 @@ class Reception extends CommonObject
 						}
 					}
 				}
-			} else {
-				$this->error = $this->db->lasterror();
-				$error++;
 			}
 		}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1784,7 +1784,8 @@ class Reception extends CommonObject
 			// Call trigger
 			$result = $this->call_trigger('RECEPTION_REOPEN', $user);
 			if ($result < 0) {
-				$error++;
+				$this->db->rollback();
+				return -1;
 			}
 		}
 
@@ -1793,9 +1794,10 @@ class Reception extends CommonObject
 			$commande->fetch($this->origin_id);
 			$result = $commande->setStatus($user, 4);
 			if ($result < 0) {
-				$error++;
 				$this->error = $commande->error;
 				$this->errors = $commande->errors;
+				$this->db->rollback();
+				return -1;
 			}
 		}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1153,7 +1153,11 @@ class Reception extends CommonObject
 		$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."commande_fournisseur_dispatch WHERE fk_reception = ".((int) $this->id);
 		$resql = $this->db->query($sql);
 
-		if (!empty($resql)) {
+		if (empty($resql)) {
+			return -1;
+		}
+
+		{
 			while ($obj = $this->db->fetch_object($resql)) {
 				$line = new CommandeFournisseurDispatch($this->db);
 
@@ -1210,8 +1214,6 @@ class Reception extends CommonObject
 			}
 
 			return 1;
-		} else {
-			return -1;
 		}
 	}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1092,7 +1092,13 @@ class Reception extends CommonObject
 					$sql = "DELETE FROM ".MAIN_DB_PREFIX."reception";
 					$sql .= " WHERE rowid = ".((int) $this->id);
 
-					if ($this->db->query($sql)) {
+					if (!$this->db->query($sql)) {
+						$this->error = $this->db->lasterror()." - sql=$sql";
+						$this->db->rollback();
+						return -3;
+					}
+
+					{
 						// Call trigger
 						$result = $this->call_trigger('RECEPTION_DELETE', $user);
 						if ($result < 0) {
@@ -1139,10 +1145,6 @@ class Reception extends CommonObject
 							$this->db->rollback();
 							return -1;
 						}
-					} else {
-						$this->error = $this->db->lasterror()." - sql=$sql";
-						$this->db->rollback();
-						return -3;
 					}
 				}
 			}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1700,7 +1700,13 @@ class Reception extends CommonObject
 		$sql .= " WHERE rowid = ".((int) $this->id).' AND fk_statut > 0';
 
 		$resql = $this->db->query($sql);
-		if ($resql) {
+		if (!$resql) {
+			$this->errors[] = $this->db->lasterror();
+			$this->db->rollback();
+			return -1;
+		}
+
+		{
 			$this->statut = self::STATUS_VALIDATED;
 			$this->status = self::STATUS_VALIDATED;
 			$this->billed = 0;
@@ -1791,9 +1797,6 @@ class Reception extends CommonObject
 					$this->errors = $commande->errors;
 				}
 			}
-		} else {
-			$error++;
-			$this->errors[] = $this->db->lasterror();
 		}
 
 		if ($error) {

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1905,7 +1905,8 @@ class Reception extends CommonObject
 				// Call trigger
 				$result = $this->call_trigger('RECEPTION_UNVALIDATE', $user);
 				if ($result < 0) {
-					$error++;
+					$this->db->rollback();
+					return -1;
 				}
 			}
 			if ($this->origin == 'order_supplier') {

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1083,10 +1083,12 @@ class Reception extends CommonObject
 				// Delete linked object
 				$res = $this->deleteObjectLinked();
 				if ($res < 0) {
-					$error++;
+					$this->error = $this->db->lasterror()." - sql=$sql";
+					$this->db->rollback();
+					return -2;
 				}
 
-				if (!$error) {
+				{
 					$sql = "DELETE FROM ".MAIN_DB_PREFIX."reception";
 					$sql .= " WHERE rowid = ".((int) $this->id);
 
@@ -1142,10 +1144,6 @@ class Reception extends CommonObject
 						$this->db->rollback();
 						return -3;
 					}
-				} else {
-					$this->error = $this->db->lasterror()." - sql=$sql";
-					$this->db->rollback();
-					return -2;
 				}
 			}
 		}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1119,7 +1119,12 @@ class Reception extends CommonObject
 							}
 						}
 
-						if (!$error) {
+						if ($error) {
+							$this->db->rollback();
+							return -1;
+						}
+
+						{
 							$this->db->commit();
 
 							// We delete PDFs
@@ -1141,9 +1146,6 @@ class Reception extends CommonObject
 							}
 
 							return 1;
-						} else {
-							$this->db->rollback();
-							return -1;
 						}
 					}
 				}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -12,6 +12,7 @@
  * Copyright (C) 2016-2022	Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2018		Quentin Vial-Gouteyron  <quentin.vial-gouteyron@atm-consulting.fr>
  * Copyright (C) 2022-2023  Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2023       Alexandre Janniaux      <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -286,7 +287,14 @@ class Reception extends CommonObject
 
 		$resql = $this->db->query($sql);
 
-		if ($resql) {
+		if (!$resql) {
+			$error++;
+			$this->error = $this->db->error()." - sql=$sql";
+			$this->db->rollback();
+			return -1;
+		}
+
+		{
 			$this->id = $this->db->last_insert_id(MAIN_DB_PREFIX."reception");
 
 			$sql = "UPDATE ".MAIN_DB_PREFIX."reception";
@@ -346,11 +354,6 @@ class Reception extends CommonObject
 				$this->db->rollback();
 				return -2;
 			}
-		} else {
-			$error++;
-			$this->error = $this->db->error()." - sql=$sql";
-			$this->db->rollback();
-			return -1;
 		}
 	}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1059,7 +1059,12 @@ class Reception extends CommonObject
 			}
 		}
 
-		if (!$error) {
+		if ($error) {
+			$this->db->rollback();
+			return -1;
+		}
+
+		{
 			$main = MAIN_DB_PREFIX.'commande_fournisseur_dispatch';
 			$ef = $main."_extrafields";
 
@@ -1141,9 +1146,6 @@ class Reception extends CommonObject
 				$this->db->rollback();
 				return -1;
 			}
-		} else {
-			$this->db->rollback();
-			return -1;
 		}
 	}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1692,8 +1692,6 @@ class Reception extends CommonObject
 	{
 		global $conf, $langs, $user;
 
-		$error = 0;
-
 		$this->db->begin();
 
 		$sql = 'UPDATE '.MAIN_DB_PREFIX.'reception SET fk_statut=1, billed=0';
@@ -1711,7 +1709,7 @@ class Reception extends CommonObject
 		$this->billed = 0;
 
 		// If stock increment is done on closing
-		if (!$error && isModEnabled('stock') && getDolGlobalInt('STOCK_CALCULATE_ON_RECEPTION_CLOSE')) {
+		if (isModEnabled('stock') && getDolGlobalInt('STOCK_CALCULATE_ON_RECEPTION_CLOSE')) {
 			require_once DOL_DOCUMENT_ROOT.'/product/stock/class/mouvementstock.class.php';
 			$numref = $this->ref;
 			$langs->load("agenda");
@@ -1780,7 +1778,7 @@ class Reception extends CommonObject
 			}
 		}
 
-		if (!$error) {
+		{
 			// Call trigger
 			$result = $this->call_trigger('RECEPTION_REOPEN', $user);
 			if ($result < 0) {
@@ -1789,7 +1787,7 @@ class Reception extends CommonObject
 			}
 		}
 
-		if (!$error && $this->origin == 'order_supplier') {
+		if ($this->origin == 'order_supplier') {
 			$commande = new CommandeFournisseur($this->db);
 			$commande->fetch($this->origin_id);
 			$result = $commande->setStatus($user, 4);
@@ -1799,11 +1797,6 @@ class Reception extends CommonObject
 				$this->db->rollback();
 				return -1;
 			}
-		}
-
-		if ($error) {
-			$this->db->rollback();
-			return -1;
 		}
 
 		$this->db->commit();

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1733,58 +1733,53 @@ class Reception extends CommonObject
 				return -1;
 			}
 
-			{
-				$cpt = $this->db->num_rows($resql);
-				for ($i = 0; $i < $cpt; $i++) {
-					$obj = $this->db->fetch_object($resql);
+			$cpt = $this->db->num_rows($resql);
+			for ($i = 0; $i < $cpt; $i++) {
+				$obj = $this->db->fetch_object($resql);
 
-					$qty = $obj->qty;
+				$qty = $obj->qty;
 
-					if ($qty <= 0) {
-						continue;
-					}
+				if ($qty <= 0) {
+					continue;
+				}
 
-					dol_syslog(get_class($this)."::reopen reception movement index ".$i." ed.rowid=".$obj->rowid);
+				dol_syslog(get_class($this)."::reopen reception movement index ".$i." ed.rowid=".$obj->rowid);
 
-					//var_dump($this->lines[$i]);
-					$mouvS = new MouvementStock($this->db);
-					$mouvS->origin = &$this;
-					$mouvS->setOrigin($this->element, $this->id);
+				//var_dump($this->lines[$i]);
+				$mouvS = new MouvementStock($this->db);
+				$mouvS->origin = &$this;
+				$mouvS->setOrigin($this->element, $this->id);
 
-					$inventorycode = '';
-					$date_eatby = '';
-					$date_sellby = '';
-					$batch = '';
-					$fk_origin_stock = 0;
+				$inventorycode = '';
+				$date_eatby = '';
+				$date_sellby = '';
+				$batch = '';
+				$fk_origin_stock = 0;
 
-					if (!empty($obj->batch))
-					{
-						$date_eatby = $this->db->jdate($obj->eatby);
-						$date_sellby = $this->db->jdate($obj->sellby);
-						$batch = $obj->batch;
-						$fk_origin_stock = $obj->fk_origin_stock;
-					}
+				if (!empty($obj->batch)) {
+					$date_eatby = $this->db->jdate($obj->eatby);
+					$date_sellby = $this->db->jdate($obj->sellby);
+					$batch = $obj->batch;
+					$fk_origin_stock = $obj->fk_origin_stock;
+				}
 
-					$result = $mouvS->livraison($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price,
-						$langs->trans("ReceptionUnClassifyCloseddInDolibarr", $numref), '', $date_eatby, $date_sellby, $batch, $fk_origin_stock, $inventorycode);
+				$result = $mouvS->livraison($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price,
+					$langs->trans("ReceptionUnClassifyCloseddInDolibarr", $numref), '', $date_eatby, $date_sellby, $batch, $fk_origin_stock, $inventorycode);
 
-					if ($result < 0) {
-						$this->error = $mouvS->error;
-						$this->errors = $mouvS->errors;
-						$this->db->rollback();
-						return -1;
-					}
+				if ($result < 0) {
+					$this->error = $mouvS->error;
+					$this->errors = $mouvS->errors;
+					$this->db->rollback();
+					return -1;
 				}
 			}
 		}
 
-		{
-			// Call trigger
-			$result = $this->call_trigger('RECEPTION_REOPEN', $user);
-			if ($result < 0) {
-				$this->db->rollback();
-				return -1;
-			}
+		// Call trigger
+		$result = $this->call_trigger('RECEPTION_REOPEN', $user);
+		if ($result < 0) {
+			$this->db->rollback();
+			return -1;
 		}
 
 		if ($this->origin == 'order_supplier') {

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1609,29 +1609,28 @@ class Reception extends CommonObject
 						$mouvS->origin = &$this;
 						$mouvS->setOrigin($this->element, $this->id);
 
-						if (empty($obj->batch)) {
-							// line without batch detail
+						$inventorycode = '';
+						$date_eatby = '';
+						$date_sellby = '';
+						$batch = '';
 
-							// We decrement stock of product (and sub-products) -> update table llx_product_stock (key of this table is fk_product+fk_entrepot) and add a movement record
-							$inventorycode = '';
-							$result = $mouvS->reception($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price, $langs->trans("ReceptionClassifyClosedInDolibarr", $this->ref), '', '', '', '', 0, $inventorycode);
-							if ($result < 0) {
-								$this->error = $mouvS->error;
-								$this->errors = $mouvS->errors;
-								$error++; break;
-							}
-						} else {
+						if (!empty($obj->batch)) {
 							// line with batch detail
-
-							// We decrement stock of product (and sub-products) -> update table llx_product_stock (key of this table is fk_product+fk_entrepot) and add a movement record
 							$inventorycode = '';
-							$result = $mouvS->reception($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price, $langs->trans("ReceptionClassifyClosedInDolibarr", $this->ref), $this->db->jdate($obj->eatby), $this->db->jdate($obj->sellby), $obj->batch, '', 0, $inventorycode);
+							$date_eatby = $this->db->jdate($obj->eatby);
+							$date_sellby = $this->db->jdate($obj->sellby);
+							$batch = $obj->batch;
+						}
 
-							if ($result < 0) {
-								$this->error = $mouvS->error;
-								$this->errors = $mouvS->errors;
-								$error++; break;
-							}
+						// We decrement stock of product (and sub-products) -> update table llx_product_stock (key of this table is fk_product+fk_entrepot) and add a movement record
+						$result = $mouvS->reception($user, $obj->fk_product, $obj->fk_entrepot, $qty, $obj->cost_price,
+							$langs->trans("ReceptionClassifyClosedInDolibarr", $this->ref), $date_eatby, $date_sellby, $batch, '', 0, $inventorycode);
+
+						if ($result < 0) {
+							$this->error = $mouvS->error;
+							$this->errors = $mouvS->errors;
+							$this->db->rollback();
+							return -1;
 						}
 					}
 				}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -139,8 +139,57 @@ class Reception extends CommonObject
 	// We can use this to know warehouse planned to be used for each lot.
 	public $detail_batch;
 
+	/**
+	 * Workflow of the status variables:
+	 *
+	 * A reception is first created as a draft. It can then be validated
+	 * to apply the changes in the stock, and the closed when the stock
+	 * parts have been received.
+	 *
+	 * Only draft reception can have the stock lines modified.
+	 *
+	 * @codingStandardsIgnoreStart
+     * \verbatim
+     *              Creation
+     *                 |
+     *                 v
+     *           STATUS_DRAFT
+     *              |    ^
+     *     valid()  |    |  setDraft()
+     *              v    |
+     *         STATUS_VALIDATED
+     *              |    ^
+     * setClosed()  |    |  reOpen()
+     *              v    |
+     *           STATUS_CLOSED
+     *  \endverbatim
+	 * @codingStandardsIgnoreStop
+     */
+
+	/**
+	 * Set as Reception::status.
+	 *
+	 * The status is assigned when Reception::setDraft() is called on an
+	 * instance with Reception::status == Reception::STATUS_VALIDATED.
+	 **/
 	const STATUS_DRAFT = 0;
+
+	/**
+	 * Set as Reception::status.
+	 *
+	 * The status is assigned when Reception::valid() is called on an
+	 * instance with Reception::status == Reception::STATUS_DRAFT or when
+	 * Reception::reOpen() is called on an instance with Reception::status
+	 * == Reception::STATUS_CLOSED.
+	 **/
 	const STATUS_VALIDATED = 1;
+
+	/**
+	 * Set as Reception::status.
+	 *
+	 * The status is assigned when Reception::setClosed() is called on an
+	 * instance with Reception::status == Reception::STATUS_VALIDATED.
+	 **/
 	const STATUS_CLOSED = 2;
 
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1534,7 +1534,13 @@ class Reception extends CommonObject
 		$sql .= " WHERE rowid = ".((int) $this->id).' AND fk_statut > 0';
 
 		$resql = $this->db->query($sql);
-		if ($resql) {
+		if (!$resql) {
+			dol_print_error($this->db);
+			$this->db->rollback();
+			return -1;
+		}
+
+		{
 			// Set order billed if 100% of order is received (qty in reception lines match qty in order lines)
 			if ($this->origin == 'order_supplier' && $this->origin_id > 0) {
 				$order = new CommandeFournisseur($this->db);
@@ -1636,9 +1642,6 @@ class Reception extends CommonObject
 					$error++;
 				}
 			}
-		} else {
-			dol_print_error($this->db);
-			$error++;
 		}
 
 		if (!$error) {

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1587,8 +1587,13 @@ class Reception extends CommonObject
 
 				dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
 				$resql = $this->db->query($sql);
+				if (!$resql) {
+					$this->error = $this->db->lasterror();
+					$this->db->rollback();
+					return -1;
+				}
 
-				if ($resql) {
+				{
 					$cpt = $this->db->num_rows($resql);
 					for ($i = 0; $i < $cpt; $i++) {
 						$obj = $this->db->fetch_object($resql);
@@ -1629,9 +1634,6 @@ class Reception extends CommonObject
 							}
 						}
 					}
-				} else {
-					$this->error = $this->db->lasterror();
-					$error++;
 				}
 			}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1042,7 +1042,13 @@ class Reception extends CommonObject
 
 			dol_syslog(get_class($this)."::delete select details", LOG_DEBUG);
 			$resql = $this->db->query($sql);
-			if ($resql) {
+			if (!$resql) {
+				$this->errors[] = "Error ".$this->db->lasterror();
+				$this->db->rollback();
+				return -1;
+			}
+
+			{
 				$cpt = $this->db->num_rows($resql);
 				for ($i = 0; $i < $cpt; $i++) {
 					dol_syslog(get_class($this)."::delete movement index ".$i);
@@ -1054,8 +1060,6 @@ class Reception extends CommonObject
 
 					$result = $mouvS->livraison($user, $obj->fk_product, $obj->fk_entrepot, $obj->qty, 0, $langs->trans("ReceptionDeletedInDolibarr", $this->ref), '', $obj->eatby, $obj->sellby, $obj->batch); // Price is set to 0, because we don't want to see WAP changed
 				}
-			} else {
-				$error++; $this->errors[] = "Error ".$this->db->lasterror();
 			}
 		}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1157,64 +1157,62 @@ class Reception extends CommonObject
 			return -1;
 		}
 
-		{
-			while ($obj = $this->db->fetch_object($resql)) {
-				$line = new CommandeFournisseurDispatch($this->db);
+		while ($obj = $this->db->fetch_object($resql)) {
+			$line = new CommandeFournisseurDispatch($this->db);
 
-				$line->fetch($obj->rowid);
+			$line->fetch($obj->rowid);
 
-				// TODO Remove or keep this ?
-				$line->fetch_product();
+			// TODO Remove or keep this ?
+			$line->fetch_product();
 
-				$sql_commfourndet = 'SELECT qty, ref, label, description, tva_tx, vat_src_code, subprice, multicurrency_subprice, remise_percent, total_ht, total_ttc, total_tva';
-				$sql_commfourndet .= ' FROM '.MAIN_DB_PREFIX.'commande_fournisseurdet';
-				$sql_commfourndet .= ' WHERE rowid = '.((int) $line->fk_commandefourndet);
-				$sql_commfourndet .= ' ORDER BY rang';
+			$sql_commfourndet = 'SELECT qty, ref, label, description, tva_tx, vat_src_code, subprice, multicurrency_subprice, remise_percent, total_ht, total_ttc, total_tva';
+			$sql_commfourndet .= ' FROM '.MAIN_DB_PREFIX.'commande_fournisseurdet';
+			$sql_commfourndet .= ' WHERE rowid = '.((int) $line->fk_commandefourndet);
+			$sql_commfourndet .= ' ORDER BY rang';
 
-				$resql_commfourndet = $this->db->query($sql_commfourndet);
-				if (!empty($resql_commfourndet)) {
-					$obj = $this->db->fetch_object($resql_commfourndet);
-					$line->qty_asked = $obj->qty;
-					$line->description = $obj->description;
-					$line->desc = $obj->description;
-					$line->tva_tx = $obj->tva_tx;
-					$line->vat_src_code = $obj->vat_src_code;
-					$line->subprice = $obj->subprice;
-					$line->multicurrency_subprice = $obj->multicurrency_subprice;
-					$line->remise_percent = $obj->remise_percent;
-					$line->label = !empty($obj->label) ? $obj->label : $line->product->label;
-					$line->ref_supplier = $obj->ref;
-					$line->total_ht = $obj->total_ht;
-					$line->total_ttc = $obj->total_ttc;
-					$line->total_tva = $obj->total_tva;
-				} else {
-					$line->qty_asked = 0;
-					$line->description = '';
-					$line->desc = '';
-					$line->label = $obj->label;
-				}
-
-				$pu_ht = ($line->subprice * $line->qty) * (100 - $line->remise_percent) / 100;
-				$tva = $pu_ht * $line->tva_tx / 100;
-				$this->total_ht += $pu_ht;
-				$this->total_tva += $pu_ht * $line->tva_tx / 100;
-
-				$this->total_ttc += $pu_ht + $tva;
-
-				if (isModEnabled('productbatch') && !empty($line->batch)) {
-					$detail_batch = new stdClass();
-					$detail_batch->eatby = $line->eatby;
-					$detail_batch->sellby = $line->sellby;
-					$detail_batch->batch = $line->batch;
-					$detail_batch->qty = $line->qty;
-					$line->detail_batch[] = $detail_batch;
-				}
-
-				$this->lines[] = $line;
+			$resql_commfourndet = $this->db->query($sql_commfourndet);
+			if (!empty($resql_commfourndet)) {
+				$obj = $this->db->fetch_object($resql_commfourndet);
+				$line->qty_asked = $obj->qty;
+				$line->description = $obj->description;
+				$line->desc = $obj->description;
+				$line->tva_tx = $obj->tva_tx;
+				$line->vat_src_code = $obj->vat_src_code;
+				$line->subprice = $obj->subprice;
+				$line->multicurrency_subprice = $obj->multicurrency_subprice;
+				$line->remise_percent = $obj->remise_percent;
+				$line->label = !empty($obj->label) ? $obj->label : $line->product->label;
+				$line->ref_supplier = $obj->ref;
+				$line->total_ht = $obj->total_ht;
+				$line->total_ttc = $obj->total_ttc;
+				$line->total_tva = $obj->total_tva;
+			} else {
+				$line->qty_asked = 0;
+				$line->description = '';
+				$line->desc = '';
+				$line->label = $obj->label;
 			}
 
-			return 1;
+			$pu_ht = ($line->subprice * $line->qty) * (100 - $line->remise_percent) / 100;
+			$tva = $pu_ht * $line->tva_tx / 100;
+			$this->total_ht += $pu_ht;
+			$this->total_tva += $pu_ht * $line->tva_tx / 100;
+
+			$this->total_ttc += $pu_ht + $tva;
+
+			if (isModEnabled('productbatch') && !empty($line->batch)) {
+				$detail_batch = new stdClass();
+				$detail_batch->eatby = $line->eatby;
+				$detail_batch->sellby = $line->sellby;
+				$detail_batch->batch = $line->batch;
+				$detail_batch->qty = $line->qty;
+				$line->detail_batch[] = $detail_batch;
+			}
+
+			$this->lines[] = $line;
 		}
+
+		return 1;
 	}
 
 	/**

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1827,7 +1827,12 @@ class Reception extends CommonObject
 		$sql .= " WHERE rowid = ".((int) $this->id);
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
-		if ($this->db->query($sql)) {
+		if (!$this->db->query($sql)) {
+			$this->error = $this->db->error();
+			$this->db->rollback();
+			return -1;
+		}
+		{
 			// If stock increment is done on closing
 			if (isModEnabled('stock') && getDolGlobalInt('STOCK_CALCULATE_ON_RECEPTION')) {
 				require_once DOL_DOCUMENT_ROOT.'/product/stock/class/mouvementstock.class.php';
@@ -1933,10 +1938,6 @@ class Reception extends CommonObject
 				$this->db->commit();
 				return 1;
 			}
-		} else {
-			$this->error = $this->db->error();
-			$this->db->rollback();
-			return -1;
 		}
 	}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1405,20 +1405,18 @@ class Reception extends CommonObject
 		if (!$user->rights->reception->creer)
 			return -2;
 
-		{
-			$sql = "UPDATE ".MAIN_DB_PREFIX."reception";
-			$sql .= " SET date_delivery = ".($delivery_date ? "'".$this->db->idate($delivery_date)."'" : 'null');
-			$sql .= " WHERE rowid = ".((int) $this->id);
+		$sql = "UPDATE ".MAIN_DB_PREFIX."reception";
+		$sql .= " SET date_delivery = ".($delivery_date ? "'".$this->db->idate($delivery_date)."'" : 'null');
+		$sql .= " WHERE rowid = ".((int) $this->id);
 
-			dol_syslog(get_class($this)."::setDeliveryDate", LOG_DEBUG);
-			$resql = $this->db->query($sql);
-			if ($resql) {
-				$this->date_delivery = $delivery_date;
-				return 1;
-			} else {
-				$this->error = $this->db->error();
-				return -1;
-			}
+		dol_syslog(get_class($this)."::setDeliveryDate", LOG_DEBUG);
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			$this->date_delivery = $delivery_date;
+			return 1;
+		} else {
+			$this->error = $this->db->error();
+			return -1;
 		}
 	}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1849,7 +1849,13 @@ class Reception extends CommonObject
 
 				dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
 				$resql = $this->db->query($sql);
-				if ($resql) {
+				if (!$resql) {
+					$this->error = $this->db->lasterror();
+					$this->db->rollback();
+					return -1;
+				}
+
+				{
 					$cpt = $this->db->num_rows($resql);
 					for ($i = 0; $i < $cpt; $i++) {
 						$obj = $this->db->fetch_object($resql);
@@ -1892,9 +1898,6 @@ class Reception extends CommonObject
 							}
 						}
 					}
-				} else {
-					$this->error = $this->db->lasterror();
-					$error++;
 				}
 			}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -592,8 +592,7 @@ class Reception extends CommonObject
 
 						if (intval($result) < 0) {
 							$error++;
-							$this->errors[] = $mouvS->error;
-							$this->errors = array_merge($this->errors, $mouvS->errors);
+							$this->setErrorsFromObject($mouvS);
 							break;
 						}
 					} else {
@@ -606,8 +605,7 @@ class Reception extends CommonObject
 
 						if (intval($result) < 0) {
 							$error++;
-							$this->errors[] = $mouvS->error;
-							$this->errors = array_merge($this->errors, $mouvS->errors);
+							$this->setErrorsFromObject($mouvS);
 							break;
 						}
 					}
@@ -629,7 +627,7 @@ class Reception extends CommonObject
 				$ret = $this->commandeFournisseur->Livraison($user, dol_now(), 'tot', '');
 				if ($ret < 0) {
 					$error++;
-					$this->errors = array_merge($this->errors, $this->commandeFournisseur->errors);
+					$this->setErrorsFromObject($commandeFournisseur);
 				}
 			} else {
 				$ret = $this->setStatut($status, $this->origin_id, 'commande_fournisseur', $trigger_key);
@@ -739,8 +737,7 @@ class Reception extends CommonObject
 
 			$ret = $supplierorderdispatch->fetchAll('', '', 0, 0, $filter);
 			if ($ret < 0) {
-				$this->error = $supplierorderdispatch->error;
-				$this->errors = $supplierorderdispatch->errors;
+				$this->setErrorsFromObject($supplierorderdispatch);
 				return $ret;
 			} else {
 				// build array with quantity received by product in all supplier orders (origin)
@@ -823,8 +820,7 @@ class Reception extends CommonObject
 		$supplierorderline = new CommandeFournisseurLigne($this->db);
 		$result = $supplierorderline->fetch($id);
 		if ($result <= 0) {
-			$this->error = $supplierorderline->error;
-			$this->errors = $supplierorderline->errors;
+			$this->setErrorsFromObject($supplierorderline);
 			return -1;
 		}
 
@@ -1620,8 +1616,7 @@ class Reception extends CommonObject
 					$langs->trans("ReceptionClassifyClosedInDolibarr", $this->ref), $date_eatby, $date_sellby, $batch, '', 0, $inventorycode);
 
 				if ($result < 0) {
-					$this->error = $mouvS->error;
-					$this->errors = $mouvS->errors;
+					$this->setErrorsFromObject($mouvS);
 					$this->db->rollback();
 					return -1;
 				}
@@ -1631,8 +1626,7 @@ class Reception extends CommonObject
 		// Call trigger
 		$result = $this->call_trigger('RECEPTION_CLOSED', $user);
 		if ($result < 0) {
-			$this->error = $mouvS->error;
-			$this->errors = $mouvS->errors;
+			$this->setErrorsFromObject($mouvS);
 			$this->db->rollback();
 			return -1;
 		}
@@ -1765,8 +1759,7 @@ class Reception extends CommonObject
 					$langs->trans("ReceptionUnClassifyCloseddInDolibarr", $numref), '', $date_eatby, $date_sellby, $batch, $fk_origin_stock, $inventorycode);
 
 				if ($result < 0) {
-					$this->error = $mouvS->error;
-					$this->errors = $mouvS->errors;
+					$this->setErrorsFromObject($mouvS);
 					$this->db->rollback();
 					return -1;
 				}
@@ -1785,8 +1778,7 @@ class Reception extends CommonObject
 			$commande->fetch($this->origin_id);
 			$result = $commande->setStatus($user, 4);
 			if ($result < 0) {
-				$this->error = $commande->error;
-				$this->errors = $commande->errors;
+				$this->setErrorsFromObject($commande);
 				$this->db->rollback();
 				return -1;
 			}
@@ -1889,8 +1881,7 @@ class Reception extends CommonObject
 					$langs->trans("ReceptionBackToDraftInDolibarr", $this->ref), '', $date_eatby, $date_sellby, $batch, 0, $inventorycode);
 
 				if ($result < 0) {
-					$this->error = $mouvS->error;
-					$this->errors = $mouvS->errors;
+					$this->setErrorsFromObject($mouvS);
 					$this->db->rollback();
 					return -1;
 				}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1809,8 +1809,6 @@ class Reception extends CommonObject
 		// phpcs:enable
 		global $conf, $langs;
 
-		$error = 0;
-
 		// Protection
 		if ($this->statut <= self::STATUS_DRAFT) {
 			return 0;
@@ -1831,7 +1829,7 @@ class Reception extends CommonObject
 		dol_syslog(__METHOD__, LOG_DEBUG);
 		if ($this->db->query($sql)) {
 			// If stock increment is done on closing
-			if (!$error && isModEnabled('stock') && getDolGlobalInt('STOCK_CALCULATE_ON_RECEPTION')) {
+			if (isModEnabled('stock') && getDolGlobalInt('STOCK_CALCULATE_ON_RECEPTION')) {
 				require_once DOL_DOCUMENT_ROOT.'/product/stock/class/mouvementstock.class.php';
 
 				$langs->load("agenda");
@@ -1897,7 +1895,7 @@ class Reception extends CommonObject
 				}
 			}
 
-			if (!$error) {
+			{
 				// Call trigger
 				$result = $this->call_trigger('RECEPTION_UNVALIDATE', $user);
 				if ($result < 0) {
@@ -1929,14 +1927,11 @@ class Reception extends CommonObject
 				}
 			}
 
-			if (!$error) {
+			{
 				$this->statut = self::STATUS_DRAFT;
 				$this->status = self::STATUS_DRAFT;
 				$this->db->commit();
 				return 1;
-			} else {
-				$this->db->rollback();
-				return -1;
 			}
 		} else {
 			$this->error = $this->db->error();

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1579,7 +1579,7 @@ class Reception extends CommonObject
 			$sql .= " WHERE ed.fk_reception = ".((int) $this->id);
 			$sql .= " AND cd.rowid = ed.fk_commandefourndet";
 
-			dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
+			dol_syslog(get_class($this)."::setClosed select details", LOG_DEBUG);
 			$resql = $this->db->query($sql);
 			if (!$resql) {
 				$this->error = $this->db->lasterror();
@@ -1596,7 +1596,7 @@ class Reception extends CommonObject
 				if ($qty <= 0) {
 					continue;
 				}
-				dol_syslog(get_class($this)."::valid movement index ".$i." ed.rowid=".$obj->rowid." edb.rowid=".$obj->edbrowid);
+				dol_syslog(get_class($this)."::setClosed movement index ".$i." ed.rowid=".$obj->rowid." edb.rowid=".$obj->edbrowid);
 
 				$mouvS = new MouvementStock($this->db);
 				$mouvS->origin = &$this;

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -490,7 +490,7 @@ class Reception extends CommonObject
 	 *
 	 *  @param      User		$user       Object user that validate
 	 *  @param		int			$notrigger	1=Does not execute triggers, 0= execute triggers
-	 *  @return     int						<0 if OK, >0 if KO
+	 *  @return     int						>0 if OK, <= 0 if KO
 	 */
 	public function valid($user, $notrigger = 0)
 	{

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1073,7 +1073,13 @@ class Reception extends CommonObject
 			$sql = "DELETE FROM ".MAIN_DB_PREFIX."commande_fournisseur_dispatch";
 			$sql .= " WHERE fk_reception = ".((int) $this->id);
 
-			if ($this->db->query($sqlef) && $this->db->query($sql)) {
+			if (!$this->db->query($sqlef) || !$this->db->query($sql)) {
+				$this->error = $this->db->lasterror()." - sql=$sql";
+				$this->db->rollback();
+				return -1;
+			}
+
+			{
 				// Delete linked object
 				$res = $this->deleteObjectLinked();
 				if ($res < 0) {
@@ -1141,10 +1147,6 @@ class Reception extends CommonObject
 					$this->db->rollback();
 					return -2;
 				}
-			} else {
-				$this->error = $this->db->lasterror()." - sql=$sql";
-				$this->db->rollback();
-				return -1;
 			}
 		}
 	}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1004,10 +1004,10 @@ class Reception extends CommonObject
 			}
 			$this->db->rollback();
 			return -1 * $error;
-		} else {
-			$this->db->commit();
-			return 1;
 		}
+
+		$this->db->commit();
+		return 1;
 	}
 
 	/**

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1411,13 +1411,13 @@ class Reception extends CommonObject
 
 		dol_syslog(get_class($this)."::setDeliveryDate", LOG_DEBUG);
 		$resql = $this->db->query($sql);
-		if ($resql) {
-			$this->date_delivery = $delivery_date;
-			return 1;
-		} else {
+		if (!$resql) {
 			$this->error = $this->db->error();
 			return -1;
 		}
+
+		$this->date_delivery = $delivery_date;
+		return 1;
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -302,7 +302,15 @@ class Reception extends CommonObject
 			$sql .= " WHERE rowid = ".((int) $this->id);
 
 			dol_syslog(get_class($this)."::create", LOG_DEBUG);
-			if ($this->db->query($sql)) {
+
+			if (!$this->db->query($sql)) {
+				$error++;
+				$this->error = $this->db->lasterror()." - sql=$sql";
+				$this->db->rollback();
+				return -2;
+			}
+
+			{
 				// Insert of lines
 				$num = count($this->lines);
 				for ($i = 0; $i < $num; $i++) {
@@ -348,11 +356,6 @@ class Reception extends CommonObject
 					$this->db->rollback();
 					return -1 * $error;
 				}
-			} else {
-				$error++;
-				$this->error = $this->db->lasterror()." - sql=$sql";
-				$this->db->rollback();
-				return -2;
 			}
 		}
 	}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -345,16 +345,18 @@ class Reception extends CommonObject
 					// End call triggers
 				}
 
-				if (!$error) {
-					$this->db->commit();
-					return $this->id;
-				} else {
+				if ($error) {
 					foreach ($this->errors as $errmsg) {
 						dol_syslog(get_class($this)."::create ".$errmsg, LOG_ERR);
 						$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
 					}
 					$this->db->rollback();
 					return -1 * $error;
+				}
+
+				{
+					$this->db->commit();
+					return $this->id;
 				}
 			}
 		}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1021,9 +1021,7 @@ class Reception extends CommonObject
 		global $conf, $langs, $user;
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 
-		$error = 0;
 		$this->error = '';
-
 
 		$this->db->begin();
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1796,13 +1796,13 @@ class Reception extends CommonObject
 			$this->errors[] = $this->db->lasterror();
 		}
 
-		if (!$error) {
-			$this->db->commit();
-			return 1;
-		} else {
+		if ($error) {
 			$this->db->rollback();
 			return -1;
 		}
+
+		$this->db->commit();
+		return 1;
 	}
 
 	 /**

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1651,7 +1651,6 @@ class Reception extends CommonObject
 	public function setBilled()
 	{
 		global $user;
-		$error = 0;
 
 		$this->db->begin();
 
@@ -1670,25 +1669,18 @@ class Reception extends CommonObject
 			return -1;
 		}
 
-		{
-			$this->billed = 1;
+		$this->billed = 1;
 
-			// Call trigger
-			$result = $this->call_trigger('RECEPTION_BILLED', $user);
-			if ($result < 0) {
-				$this->billed = 0;
-				$this->db->rollback();
-				return -1;
-			}
-		}
-
-		if (empty($error)) {
-			$this->db->commit();
-			return 1;
-		} else {
+		// Call trigger
+		$result = $this->call_trigger('RECEPTION_BILLED', $user);
+		if ($result < 0) {
+			$this->billed = 0;
 			$this->db->rollback();
 			return -1;
 		}
+
+		$this->db->commit();
+		return 1;
 	}
 
 	/**

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1106,7 +1106,9 @@ class Reception extends CommonObject
 						// Call trigger
 						$result = $this->call_trigger('RECEPTION_DELETE', $user);
 						if ($result < 0) {
-							$error++;
+							$this->error = $this->db->lasterror()." - sql=$sql";
+							$this->db->rollback();
+							return -1;
 						}
 						// End call triggers
 
@@ -1121,11 +1123,6 @@ class Reception extends CommonObject
 									$this->$origin->setStatut(3); // ordered
 								}
 							}
-						}
-
-						if ($error) {
-							$this->db->rollback();
-							return -1;
 						}
 
 						{

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1664,18 +1664,22 @@ class Reception extends CommonObject
 		$sql .= " WHERE rowid = ".((int) $this->id).' AND fk_statut > 0';
 
 		$resql = $this->db->query($sql);
-		if ($resql) {
+		if (!$resql) {
+			$this->errors[] = $this->db->lasterror;
+			$this->db->rollback();
+			return -1;
+		}
+
+		{
 			$this->billed = 1;
 
 			// Call trigger
 			$result = $this->call_trigger('RECEPTION_BILLED', $user);
 			if ($result < 0) {
 				$this->billed = 0;
-				$error++;
+				$this->db->rollback();
+				return -1;
 			}
-		} else {
-			$error++;
-			$this->errors[] = $this->db->lasterror;
 		}
 
 		if (empty($error)) {


### PR DESCRIPTION
# Fix Simplify the Reception class by erroring out faster 

This merge request refactor the Reception class in the following ways:
 - Early return is used when the error path is terminal for the function, moving the error handling closer to the call making the error and removing (a lot of) indentation level for the success path.
 -  Almost identical branches are refactored together with specific assignment to the parameter instead.
 - `$error` variable is removed when it's not used anymore.

In addition, some fixes are included:
 - Documentation fixes (**reviewer**: see `reception: fix typo in doc` to ensure the fix is correct).
 - Copy-paste typos when logging to the syslog.
 - `CommonObjet::setErrorsFromObject` is used instead of assigning `error` and `errors` manually.

Finally, a new test was added in previous MR #26310 to check that nothing was broken by the previous changes, except for the function `setBilled`, `setDeliveryDate` and `fetch_lines` which I haven't tested yet, but I can provide those tests before the merge if needed. 