### PR TITLE
fix: Contact prospection fields are visible in contact list even if THIRDPARTY_ENABLE_PROSPECTION_ON_ALTERNATIVE_ADRESSES is not set

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -1423,15 +1423,17 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 
 		$object->fetch_thirdparty();
 
+
+		print '<div class="fichehalfright">';
+
+		print '<div class="underbanner clearboth"></div>';
+		print '<table class="border tableforfield centpercent">';
+
+
 		if (!empty($conf->global->THIRDPARTY_ENABLE_PROSPECTION_ON_ALTERNATIVE_ADRESSES)) {
 			if ($object->thirdparty->client == 2 || $object->thirdparty->client == 3) {
-				print '<br>';
-
-				print '<div class="underbanner clearboth"></div>';
-				print '<table class="border" width="100%">';
-
 				// Level of prospect
-				print '<tr><td class="titlefield nowrap">';
+				print '<tr><td class="titlefield">';
 				print '<table width="100%" class="nobordernopadding"><tr><td class="nowrap">';
 				print $langs->trans('ProspectLevel');
 				print '<td>';
@@ -1463,16 +1465,8 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 					}
 				}
 				print '</div></td></tr>';
-
-				print "</table>";
-				print '</div>';
 			}
 		}
-
-		print '<div class="fichehalfright">';
-
-		print '<div class="underbanner clearboth"></div>';
-		print '<table class="border tableforfield centpercent">';
 
 		// Categories
 		if (isModEnabled('categorie') && !empty($user->rights->categorie->lire)) {

--- a/htdocs/contact/class/contact.class.php
+++ b/htdocs/contact/class/contact.class.php
@@ -112,7 +112,7 @@ class Contact extends CommonObject
 		'photo' =>array('type'=>'varchar(255)', 'label'=>'Photo', 'enabled'=>1, 'visible'=>3, 'position'=>170),
 		'priv' =>array('type'=>'smallint(6)', 'label'=>'ContactVisibility', 'enabled'=>1, 'visible'=>1, 'notnull'=>1, 'position'=>175),
 		'fk_stcommcontact' =>array('type'=>'integer', 'label'=>'ProspectStatus', 'enabled'=>1, 'visible'=>-1, 'notnull'=>1, 'position'=>220),
-		'fk_prospectlevel' =>array('type'=>'varchar(12)', 'label'=>'ProspectLevel', 'enabled'=>1, 'visible'=>-1, 'position'=>255),
+		'fk_prospectcontactlevel' =>array('type'=>'varchar(12)', 'label'=>'ProspectLevel', 'enabled'=>1, 'visible'=>-1, 'position'=>255),
 		'no_email' =>array('type'=>'smallint(6)', 'label'=>'No_Email', 'enabled'=>1, 'visible'=>-1, 'notnull'=>1, 'position'=>180),
 		'note_private' =>array('type'=>'text', 'label'=>'NotePrivate', 'enabled'=>1, 'visible'=>3, 'position'=>195, 'searchall'=>1),
 		'note_public' =>array('type'=>'text', 'label'=>'NotePublic', 'enabled'=>1, 'visible'=>3, 'position'=>200, 'searchall'=>1),
@@ -354,8 +354,8 @@ class Contact extends CommonObject
 		}
 
 		if (empty($conf->global->THIRDPARTY_ENABLE_PROSPECTION_ON_ALTERNATIVE_ADRESSES)) {	// Default behaviour
-			$this->field['fk_stcommcontact']['enabled'] = 0;
-			$this->field['fk_prospectcontactlevel']['enabled'] = 0;
+			$this->fields['fk_stcommcontact']['enabled'] = 0;
+			$this->fields['fk_prospectcontactlevel']['enabled'] = 0;
 		}
 
 		// Unset fields that are disabled


### PR DESCRIPTION
On contact list, fields fk_stcommcontact and fk_prospectcontactlevel are showable columns event if const THIRDPARTY_ENABLE_PROSPECTION_ON_ALTERNATIVE_ADRESSES is not set.

if THIRDPARTY_ENABLE_PROSPECTION_ON_ALTERNATIVE_ADRESSES is set to 1the column fk_prospectcontactlevel is selectable in column list but never display

And in card the display is broken
Before
![image](https://github.com/Dolibarr/dolibarr/assets/1050053/c155ad0a-0bb4-4c6b-9740-d2dd5ca7ea92)


After
![image](https://github.com/Dolibarr/dolibarr/assets/1050053/6ca09f71-6ef9-4c8d-afba-4a639841d057)

