### PR TITLE
Fix misspelled @throw -> @throws

### DIFF
--- a/htdocs/admin/dolistore/class/PSWebServiceLibrary.class.php
+++ b/htdocs/admin/dolistore/class/PSWebServiceLibrary.class.php
@@ -225,7 +225,7 @@ class PrestaShopWebservice
 	 * @param 	string 				$response 	String from a CURL response
 	 * @return 	SimpleXMLElement|boolean		status_code, response
 	 *
-	 * @throw PrestaShopWebserviceException
+	 * @throws PrestaShopWebserviceException
 	 */
 	protected function parseXML($response)
 	{
@@ -257,7 +257,7 @@ class PrestaShopWebservice
 	 * @param 	array 				$options	Options
 	 * @return 	SimpleXMLElement|boolean 		status_code, response
 	 *
-	 * @throw PrestaShopWebserviceException
+	 * @throws PrestaShopWebserviceException
 	 */
 	public function add($options)
 	{
@@ -310,7 +310,7 @@ class PrestaShopWebservice
 	 * @param 	array 			$options 	Array representing resource to get.
 	 * @return 	SimpleXMLElement|boolean	status_code, response
 	 *
-	 * @throw PrestaShopWebserviceException
+	 * @throws PrestaShopWebserviceException
 	 */
 	public function get($options)
 	{
@@ -351,7 +351,7 @@ class PrestaShopWebservice
 	 * @param 	array 				$options 	Array representing resource for head request.
 	 * @return 	SimpleXMLElement 				status_code, response
 	 *
-	 * @throw PrestaShopWebserviceException
+	 * @throws PrestaShopWebserviceException
 	 */
 	public function head($options)
 	{
@@ -393,7 +393,7 @@ class PrestaShopWebservice
 	 * @param 	array 				$options 	Array representing resource to edit.
 	 * @return	SimpleXMLElement|boolean 		status_code, response
 	 *
-	 * @throw PrestaShopWebserviceException
+	 * @throws PrestaShopWebserviceException
 	 */
 	public function edit($options)
 	{


### PR DESCRIPTION
# FIX

PHPDoc `@throw` should be `@throws`

Identified using phan, see #26262