### PR TITLE
NEW dol_debug function to send message to the debugbar

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1910,6 +1910,25 @@ function dol_syslog($message, $level = LOG_INFO, $ident = 0, $suffixinfilename =
 }
 
 /**
+ *	Write messages into the debugbar
+ *
+ * 	@param  mixed		$message				Message to write into the debugbar. Can be text or any php object
+ * 	@param  string		$level					Log level
+ *
+ *  @return	void
+ */
+function dol_debug($message, $level = 'debug')
+{
+	global $debugbar;
+
+	// If debugbar module enabled
+	if (!isModEnabled('debugbar') || !isset($debugbar) || !isset($debugbar['messages'])) {
+		return;
+	}
+	$debugbar['messages']->addMessage($message, $level);
+}
+
+/**
  *	Return HTML code to output a button to open a dialog popup box.
  *  Such buttons must be included inside a HTML form.
  *

--- a/htdocs/debugbar/class/DebugBar.php
+++ b/htdocs/debugbar/class/DebugBar.php
@@ -53,7 +53,7 @@ class DolibarrDebugBar extends DebugBar
 		global $conf;
 
 		//$this->addCollector(new PhpInfoCollector());
-		//$this->addCollector(new DolMessagesCollector());
+		$this->addCollector(new DolMessagesCollector());
 		$this->addCollector(new DolRequestDataCollector());
 		//$this->addCollector(new DolConfigCollector());      // Disabled for security purpose
 		$this->addCollector(new DolTimeDataCollector());


### PR DESCRIPTION
# NEW dol_debug function : easily send a message to the debugbar

The debugbar is a powerfull tool that is not commonly used by developpers (see https://www.dolibarr.fr/forum/t/comment-dumper-une-variable-dans-la-debugbar/44491/3)
This new function will allow to send messages to the debugbar in a similar way that dol_syslog operates: dol_debug instructions can stay in the code and will only be triggered if the debugbar module is active.