### PR TITLE
FIX #26296 call trigger TICKET_ASSIGNED after creation of ticket, if a user got assigned

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -286,6 +286,11 @@ if (empty($reshook)) {
 			if (!$error) {
 				$db->commit();
 
+				// if a user got defined as an assigned user: run trigger
+				if (!empty($object->fk_user_assign)) {
+					$res = $object->call_trigger("TICKET_ASSIGNED", $user);
+				}
+
 				if (!empty($backtopage)) {
 					if (empty($id)) {
 						$url = $backtopage;


### PR DESCRIPTION
The trigger TICKET_ASSIGNED shall notify, whenever a user gets assigned to a ticket.

This is executed correctly when for an already created ticket a user gets assigned. 
But when a ticket gets newly created and a user is entered as an assigned user in the create page, the user is set as assigned, but the trigger is not called.

This PR calls the trigger TICKET_ASSIGNED once a new ticket has definitely been created (after the db->commit()). The trigger is called, when a user has been set from the drop-down-field or when the constant TICKET_AUTO_ASSIGN_USER_CREATE was set and the creator got automatically assigned.

Consistent notifications about assigns are required for a notification module, which informs users visually, when a new ticket got assigned to them.



