### PR TITLE
NEW #22531 Expense report - Add two fields into export : Qty & Unit price (excl.)

### DIFF
--- a/htdocs/core/modules/modExpenseReport.class.php
+++ b/htdocs/core/modules/modExpenseReport.class.php
@@ -1,6 +1,7 @@
 <?php
-/* Copyright (C) 2011 Dimitri Mouillard   <dmouillard@teclib.com>
- * Copyright (C) 2015 Laurent Destailleur <eldy@users.sourceforge.net>
+/* Copyright (C) 2011  Dimitri Mouillard    <dmouillard@teclib.com>
+ * Copyright (C) 2015  Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023  Alexandre Spangaro   <aspangaro@easya.solutions>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -186,17 +187,19 @@ class modExpenseReport extends DolibarrModules
 			'd.fk_statut'=>'Status', 'd.paid'=>'Paid',
 			'd.note_private'=>'NotePrivate', 'd.note_public'=>'NotePublic', 'd.detail_cancel'=>'MOTIF_CANCEL', 'd.detail_refuse'=>'MOTIF_REFUS',
 			'ed.rowid'=>'LineId', 'tf.code'=>'Type', 'ed.date'=>'Date', 'ed.tva_tx'=>'VATRate',
+			'ed.qty'=>"Quantity", 'ed.value_unit'=>"UnitPriceHT",
 			'ed.total_ht'=>'TotalHT', 'ed.total_tva'=>'TotalVAT', 'ed.total_ttc'=>'TotalTTC', 'ed.comments'=>'Comment', 'p.rowid'=>'ProjectId', 'p.ref'=>'Ref',
 			'u.lastname'=>'Lastname', 'u.firstname'=>'Firstname', 'u.login'=>"Login",
 			'user_rib.iban_prefix' => 'IBAN', 'user_rib.bic' => 'BIC', 'user_rib.code_banque' => 'BankCode', 'user_rib.bank' => 'BankName', 'user_rib.proprio' => 'BankAccountOwner',
 			'user_rib.owner_address' => 'BankAccountOwnerAddress'
 		);
 		$this->export_TypeFields_array[$r] = array(
-			'd.rowid'=>"Numeric", 'd.ref'=>'Text', 'd.date_debut'=>'Date', 'd.date_fin'=>'Date', 'd.date_create'=>'Date', 'd.date_approve'=>'Date',
+			'd.rowid'=>'Numeric', 'd.ref'=>'Text', 'd.date_debut'=>'Date', 'd.date_fin'=>'Date', 'd.date_create'=>'Date', 'd.date_approve'=>'Date',
 			'd.total_ht'=>"Numeric", 'd.total_tva'=>'Numeric', 'd.total_ttc'=>'Numeric',
 			'd.fk_statut'=>"Numeric", 'd.paid'=>'Numeric',
 			'd.note_private'=>'Text', 'd.note_public'=>'Text', 'd.detail_cancel'=>'Text', 'd.detail_refuse'=>'Text',
 			'ed.rowid'=>'Numeric', 'tf.code'=>'Code', 'ed.date'=>'Date', 'ed.tva_tx'=>'Numeric',
+			'ed.qty'=>'Numeric', 'ed.value_unit'=>'Numeric',
 			'ed.total_ht'=>'Numeric', 'ed.total_tva'=>'Numeric', 'ed.total_ttc'=>'Numeric', 'ed.comments'=>'Text', 'p.rowid'=>'Numeric', 'p.ref'=>'Text',
 			'u.lastname'=>'Text', 'u.firstname'=>'Text', 'u.login'=>"Text",
 			'user_rib.iban_prefix' => 'Text', 'user_rib.bic' => 'Text', 'user_rib.code_banque' => 'Text', 'user_rib.bank' => 'Text', 'user_rib.proprio' => 'Text',
@@ -204,6 +207,7 @@ class modExpenseReport extends DolibarrModules
 		);
 		$this->export_entities_array[$r] = array(
 			'ed.rowid'=>'expensereport_line', 'ed.date'=>'expensereport_line',
+			'ed.qty'=>'expensereport_line', 'ed.value_unit'=>'expensereport_line',
 			'ed.tva_tx'=>'expensereport_line', 'ed.total_ht'=>'expensereport_line', 'ed.total_tva'=>'expensereport_line', 'ed.total_ttc'=>'expensereport_line',
 			'ed.comments'=>'expensereport_line', 'tf.code'=>'expensereport_line', 'p.project_ref'=>'expensereport_line', 'p.rowid'=>'project', 'p.ref'=>'project',
 			'u.lastname'=>'user', 'u.firstname'=>'user', 'u.login'=>'user',


### PR DESCRIPTION
This two informations are missing in expense report export

Qty * Unit Price (excl.) = total_ht

![image](https://github.com/Dolibarr/dolibarr/assets/2341395/998f27c0-683d-4fec-9dbc-6714ef075e94)
