### PR TITLE
NEW #26312 Manage intermediate BIC - SQL Part

### DIFF
--- a/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
+++ b/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
@@ -146,3 +146,7 @@ ALTER TABLE llx_resource ADD COLUMN max_users integer DEFAULT NULL AFTER photo_f
 ALTER TABLE llx_resource ADD COLUMN phone varchar(255) DEFAULT NULL AFTER user_places;
 ALTER TABLE llx_resource ADD COLUMN email varchar(255) DEFAULT NULL AFTER phone;
 ALTER TABLE llx_resource ADD COLUMN url varchar(255) DEFAULT NULL AFTER email;
+
+ALTER TABLE llx_user_rib ADD COLUMN bic_intermediate varchar(11) AFTER bic;
+ALTER TABLE llx_bank_account ADD COLUMN bic_intermediate varchar(11) AFTER bic;
+ALTER TABLE llx_societe_rib ADD COLUMN bic_intermediate varchar(11) AFTER bic;

--- a/htdocs/install/mysql/tables/llx_bank_account.sql
+++ b/htdocs/install/mysql/tables/llx_bank_account.sql
@@ -1,8 +1,8 @@
 -- =============================================================================
--- Copyright (C) 2000-2004	Rodolphe Quiedeville	<rodolphe@quiedeville.org>
--- Copyright (C) 2004-2014	Laurent Destailleur 	<eldy@users.sourceforge.net>
--- Copyright (C) 2005-2012	Regis Houssin       	<regis.houssin@inodbox.com>
--- Copyright (C) 2014		Alexandre Spangaro		<aspangaro@open-dsi.fr>
+-- Copyright (C) 2000-2004  Rodolphe Quiedeville    <rodolphe@quiedeville.org>
+-- Copyright (C) 2004-2014  Laurent Destailleur     <eldy@users.sourceforge.net>
+-- Copyright (C) 2005-2012  Regis Houssin           <regis.houssin@inodbox.com>
+-- Copyright (C) 2014-2023  Alexandre Spangaro      <aspangaro@easya.solutions>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ create table llx_bank_account
   tms						timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   ref						varchar(12) NOT NULL,
   label						varchar(30) NOT NULL,
-  entity					integer DEFAULT 1 NOT NULL,	-- multi company id
+  entity					integer DEFAULT 1 NOT NULL, -- multi company id
   fk_user_author			integer,
   fk_user_modif				integer,
   bank						varchar(60),
@@ -37,12 +37,13 @@ create table llx_bank_account
   code_guichet				varchar(6),
   number					varchar(255),
   cle_rib					varchar(5),
-  bic						varchar(11),
+  bic						varchar(11),                -- 11 according to ISO 9362
+  bic_intermediate          varchar(11),                -- 11 according to ISO 9362. Same as bic but for intermediate bank
   iban_prefix				varchar(34),				-- full iban. 34 according to ISO 13616
   country_iban				varchar(2),					-- deprecated
   cle_iban					varchar(2),
   domiciliation				varchar(255),
-  pti_in_ctti         smallint DEFAULT 0,
+  pti_in_ctti               smallint DEFAULT 0,
   state_id					integer        DEFAULT NULL,
   fk_pays					integer        NOT NULL,
   proprio					varchar(60),
@@ -64,6 +65,6 @@ create table llx_bank_account
   model_pdf					varchar(255),
   import_key				varchar(14),
   extraparams			    varchar(255),				-- for other parameters with json format
-  ics						varchar(32),			-- Creditor Identifier CI
-  ics_transfer			varchar(32)				-- Creditor Identifier CI for transfer
+  ics						varchar(32),                -- Creditor Identifier CI
+  ics_transfer              varchar(32)                 -- Creditor Identifier CI for transfer
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_societe_rib.sql
+++ b/htdocs/install/mysql/tables/llx_societe_rib.sql
@@ -1,8 +1,9 @@
 -- =============================================================================
--- Copyright (C) 2000-2004 Rodolphe Quiedeville <rodolphe@quiedeville.org>
--- Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
--- Copyright (C) 2012	   Juanjo Menent        <jmenent@2byte.es>
--- Copyright (C) 2013      Peter Fontaine       <contact@peterfontaine.fr>
+-- Copyright (C) 2000-2004  Rodolphe Quiedeville    <rodolphe@quiedeville.org>
+-- Copyright (C) 2005-2009  Regis Houssin           <regis.houssin@inodbox.com>
+-- Copyright (C) 2012       Juanjo Menent           <jmenent@2byte.es>
+-- Copyright (C) 2013       Peter Fontaine          <contact@peterfontaine.fr>
+-- Copyright (C) 2023       Alexandre Spangaro      <aspangaro@easya.solutions>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -36,8 +37,9 @@ create table llx_societe_rib
   number         varchar(255),  -- account number
   cle_rib        varchar(5),    -- key of bank account
 
-  bic            varchar(20),   -- 11 according to ISO 9362 (we keep 20 for backward compatibility)
-  iban_prefix    varchar(34),	-- full iban. 34 according to ISO 13616
+  bic               varchar(20),    -- 11 according to ISO 9362 (we keep 20 for backward compatibility)
+  bic_intermediate  varchar(11),    -- 11 according to ISO 9362. Same as bic but for intermediate bank
+  iban_prefix       varchar(34),    -- full iban. 34 according to ISO 13616
 
   domiciliation  varchar(255),
   proprio        varchar(60),
@@ -51,42 +53,42 @@ create table llx_societe_rib
   last_main_doc	 varchar(255),					-- relative filepath+filename of last main generated document
 
   -- For BAN direct debit feature
-  rum            varchar(32),	 				-- RUM value to use for SEPA generation
-  date_rum		 date,							-- Date of mandate
-  frstrecur      varchar(16) default 'FRST',    -- 'FRST' or 'RECUR'
+  rum           varchar(32),	 				-- RUM value to use for SEPA generation
+  date_rum      date,							-- Date of mandate
+  frstrecur     varchar(16) default 'FRST',     -- 'FRST' or 'RECUR'
 
   -- For credit card
-  last_four varchar(4),										-- last 4
-  card_type varchar(255),									-- card type 'VISA', 'MC' , ...
-  cvn varchar(255),
-  exp_date_month INTEGER,
-  exp_date_year INTEGER,
-  country_code varchar(10),
+  last_four         varchar(4),					-- last 4
+  card_type         varchar(255),				-- card type 'VISA', 'MC' , ...
+  cvn               varchar(255),
+  exp_date_month    integer,
+  exp_date_year     integer,
+  country_code      varchar(10),
 
   -- For Paypal
-  approved INTEGER DEFAULT 0,
-  email varchar(255),
-  ending_date date,
-  max_total_amount_of_all_payments double(24,8),
-  preapproval_key varchar(255),
-  starting_date date,
-  total_amount_of_all_payments double(24,8),
+  approved                          integer DEFAULT 0,
+  email                             varchar(255),
+  ending_date                       date,
+  max_total_amount_of_all_payments  double(24,8),
+  preapproval_key                   varchar(255),
+  starting_date                     date,
+  total_amount_of_all_payments      double(24,8),
 
   --For Stripe, Stancer, ...
-  stripe_card_ref varchar(128),								-- 'card_...'
-  stripe_account varchar(128),								-- 'pk_live_...'
+  stripe_card_ref   varchar(128),               -- card_...'
+  stripe_account    varchar(128),				-- 'pk_live_...'
 
-  ext_payment_site varchar(128),						    -- name of external paymentmode (for example 'StripeLive')
+  ext_payment_site  varchar(128),               -- name of external paymentmode (for example 'StripeLive')
 
-  extraparams    varchar(255),                      -- for other parameters with json format
+  extraparams       varchar(255),               -- for other parameters with json format
   
   -- For Online Sign
-  date_signature		datetime,
-  online_sign_ip		varchar(48),
-  online_sign_name		varchar(64),
+  date_signature    datetime,
+  online_sign_ip    varchar(48),
+  online_sign_name  varchar(64),
   
-  comment        varchar(255),
-  ipaddress      varchar(68),
-  status integer NOT NULL DEFAULT 1,						-- 1=ACTIVE, 0=IN_TRASH
-  import_key     varchar(14)    -- import key
+  comment           varchar(255),
+  ipaddress         varchar(68),
+  status            integer NOT NULL DEFAULT 1, -- 1=ACTIVE, 0=IN_TRASH
+  import_key        varchar(14)                 -- import key
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_user_rib.sql
+++ b/htdocs/install/mysql/tables/llx_user_rib.sql
@@ -1,5 +1,5 @@
 -- =============================================================================
--- Copyright (C) 2015     Alexandre Spangaro  <aspangaro@open-dsi.fr>
+-- Copyright (C) 2015-2023  Alexandre Spangaro  <aspangaro@easya.solutions>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -18,23 +18,24 @@
 
 create table llx_user_rib
 (
-  rowid          integer AUTO_INCREMENT PRIMARY KEY,
-  fk_user        integer      NOT NULL,
-  entity         integer DEFAULT 1 NOT NULL,	-- multi company id
-  datec          datetime,
-  tms            timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  label          varchar(30),
-  bank           varchar(255),  -- bank name
-  code_banque    varchar(128),  -- bank code
-  code_guichet   varchar(6),    -- desk code
-  number         varchar(255),  -- account number
-  cle_rib        varchar(5),    -- key of bank account
-  bic            varchar(11),   -- 11 according to ISO 9362
-  iban_prefix    varchar(34),	-- full iban. 34 according to ISO 13616
-  domiciliation  varchar(255),
-  proprio        varchar(60),
-  owner_address  varchar(255),
-  state_id       integer,
-  fk_country     integer,
-  currency_code  varchar(3)
+  rowid             integer AUTO_INCREMENT PRIMARY KEY,
+  fk_user           integer      NOT NULL,
+  entity            integer DEFAULT 1 NOT NULL,	-- multi company id
+  datec             datetime,
+  tms               timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  label             varchar(30),
+  bank              varchar(255),  -- bank name
+  code_banque       varchar(128),  -- bank code
+  code_guichet      varchar(6),    -- desk code
+  number            varchar(255),  -- account number
+  cle_rib           varchar(5),    -- key of bank account
+  bic               varchar(11),   -- 11 according to ISO 9362
+  bic_intermediate  varchar(11),   -- 11 according to ISO 9362. Same as bic but for intermediate bank
+  iban_prefix       varchar(34),   -- full iban. 34 according to ISO 13616
+  domiciliation     varchar(255),
+  proprio           varchar(60),
+  owner_address     varchar(255),
+  state_id          integer,
+  fk_country        integer,
+  currency_code     varchar(3)
 )ENGINE=innodb;


### PR DESCRIPTION
When a new player in the banking world is created, it's common for a partnership to be formed with another banking player to receive SWIFT transfers.

The intermediary bank BIC must therefore be added to the standard BIC when sending a SWIFT transfer.