### PR TITLE
FIX Max version of PHP

### DIFF
--- a/htdocs/install/check.php
+++ b/htdocs/install/check.php
@@ -99,7 +99,7 @@ if (empty($force_install_nophpinfo)) {
 print "<br>\n";
 
 // Check PHP version max
-$arrayphpmaxversionwarning = array(8, 1, 0);
+$arrayphpmaxversionwarning = array(8, 2, 0);
 if (versioncompare(versionphparray(), $arrayphpmaxversionwarning) > 0 && versioncompare(versionphparray(), $arrayphpmaxversionwarning) < 3) {        // Maximum to use (warning if higher)
 	print '<img src="../theme/eldy/img/error.png" alt="Error" class="valignmiddle"> '.$langs->trans("ErrorPHPVersionTooHigh", versiontostring($arrayphpmaxversionwarning));
 	$checksok = 1; // 0=error, 1=warning


### PR DESCRIPTION
For v18, this table in wiki define PHP8.2 as maximum version: https://wiki.dolibarr.org/index.php?title=Versions

Also this morning with an update test in 18.0.2 :

![Clipboard - 23 octobre 2023 06 42](https://github.com/Dolibarr/dolibarr/assets/2341395/70877835-c7ba-479c-9388-c323d5670005)
