### PR TITLE
Qual logevents action switch

### DIFF
--- a/htdocs/core/triggers/interface_20_all_Logevents.class.php
+++ b/htdocs/core/triggers/interface_20_all_Logevents.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2009-2017	Regis Houssin		<regis.houssin@inodbox.com>
  * Copyright (C) 2014		Marcos García		<marcosgdf@gmail.com>
  * Copyright (C) 2023		Udo Tamm			<dev@dolibit.de>
+ * Copyright (C) 2023		William Mead		<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/core/triggers/interface_20_all_Logevents.class.php
+++ b/htdocs/core/triggers/interface_20_all_Logevents.class.php
@@ -91,39 +91,33 @@ class InterfaceLogevents extends DolibarrTriggers
 				$text = "(UserLogged," . $object->login . ")";
 				$desc = "(UserLogged," . $object->login . ")";
 				break;
-			// USER_LOGIN_FAILED
 			case 'USER_LOGIN_FAILED':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				break;
-			// USER_LOGOUT
 			case 'USER_LOGOUT':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				// Initialize data (date,duree,text,desc)
 				$text = "(UserLogoff," . $object->login . ")";
 				$desc = "(UserLogoff," . $object->login . ")";
 				break;
-			// USER_CREATE
 			case 'USER_CREATE':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				// Initialize data (date,duree,text,desc)
 				$text = $langs->transnoentities("NewUserCreated", $object->login);
 				$desc = $langs->transnoentities("NewUserCreated", $object->login);
 				break;
-			// USER_MODIFY
 			case 'USER_MODIFY':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				// Initialize data (date,duree,text,desc)
 				$text = $langs->transnoentities("EventUserModified", $object->login);
 				$desc = $langs->transnoentities("EventUserModified", $object->login);
 				break;
-			// USER_NEW_PASSWORD
 			case 'USER_NEW_PASSWORD':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				// Initialize data (date,duree,text,desc)
 				$text = $langs->transnoentities("NewUserPassword", $object->login);
 				$desc = $langs->transnoentities("NewUserPassword", $object->login);
 				break;
-			// USER ENABLED/DISABLED
 			case 'USER_ENABLEDISABLE':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				// Initialize data (date,duree,text,desc)
@@ -136,28 +130,24 @@ class InterfaceLogevents extends DolibarrTriggers
 					$desc = $langs->transnoentities("UserDisabled", $object->login);
 				}
 				break;
-			// USER_DELETE
 			case 'USER_DELETE':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				// Initialize data (date,duree,text,desc)
 				$text = $langs->transnoentities("UserDeleted", $object->login);
 				$desc = $langs->transnoentities("UserDeleted", $object->login);
 				break;
-			// USERGROUP_CREATE
 			case 'USERGROUP_CREATE':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				// Initialize data (date,duree,text,desc)
 				$text = $langs->transnoentities("NewGroupCreated", $object->name);
 				$desc = $langs->transnoentities("NewGroupCreated", $object->name);
 				break;
-			// USERGROUP_MODIFY
 			case 'USERGROUP_MODIFY':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				// Initialize data (date,duree,text,desc)
 				$text = $langs->transnoentities("GroupModified", $object->name);
 				$desc = $langs->transnoentities("GroupModified", $object->name);
 				break;
-			// USERGROUP_DELETE
 			case 'USERGROUP_DELETE':
 				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				// Initialize data (date,duree,text,desc)

--- a/htdocs/core/triggers/interface_20_all_Logevents.class.php
+++ b/htdocs/core/triggers/interface_20_all_Logevents.class.php
@@ -155,6 +155,7 @@ class InterfaceLogevents extends DolibarrTriggers
 				$desc = $langs->transnoentities("GroupDeleted", $object->name);
 				break;
 			default:
+				dol_syslog("Unknown action. Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 				break;
 		}
 

--- a/htdocs/core/triggers/interface_20_all_Logevents.class.php
+++ b/htdocs/core/triggers/interface_20_all_Logevents.class.php
@@ -84,84 +84,88 @@ class InterfaceLogevents extends DolibarrTriggers
 		$langs->load("users");
 
 		// Actions
-		if ($action == 'USER_LOGIN') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			$text = "(UserLogged,".$object->login.")";
-			$desc = "(UserLogged,".$object->login.")";
-
+		switch ($action) {
+			case 'USER_LOGIN':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				$text = "(UserLogged," . $object->login . ")";
+				$desc = "(UserLogged," . $object->login . ")";
+				break;
 			// USER_LOGIN_FAILED
-		} elseif ($action == 'USER_LOGIN_FAILED') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-
+			case 'USER_LOGIN_FAILED':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				break;
 			// USER_LOGOUT
-		} elseif ($action == 'USER_LOGOUT') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			$text = "(UserLogoff,".$object->login.")";
-			$desc = "(UserLogoff,".$object->login.")";
-
+			case 'USER_LOGOUT':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				$text = "(UserLogoff," . $object->login . ")";
+				$desc = "(UserLogoff," . $object->login . ")";
+				break;
 			// USER_CREATE
-		} elseif ($action == 'USER_CREATE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			$text = $langs->transnoentities("NewUserCreated", $object->login);
-			$desc = $langs->transnoentities("NewUserCreated", $object->login);
-
+			case 'USER_CREATE':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				$text = $langs->transnoentities("NewUserCreated", $object->login);
+				$desc = $langs->transnoentities("NewUserCreated", $object->login);
+				break;
 			// USER_MODIFY
-		} elseif ($action == 'USER_MODIFY') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			$text = $langs->transnoentities("EventUserModified", $object->login);
-			$desc = $langs->transnoentities("EventUserModified", $object->login);
-
+			case 'USER_MODIFY':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				$text = $langs->transnoentities("EventUserModified", $object->login);
+				$desc = $langs->transnoentities("EventUserModified", $object->login);
+				break;
 			// USER_NEW_PASSWORD
-		} elseif ($action == 'USER_NEW_PASSWORD') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			$text = $langs->transnoentities("NewUserPassword", $object->login);
-			$desc = $langs->transnoentities("NewUserPassword", $object->login);
-
+			case 'USER_NEW_PASSWORD':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				$text = $langs->transnoentities("NewUserPassword", $object->login);
+				$desc = $langs->transnoentities("NewUserPassword", $object->login);
+				break;
 			// USER ENABLED/DISABLED
-		} elseif ($action == 'USER_ENABLEDISABLE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			if ($object->statut == 0) {
-				$text = $langs->transnoentities("UserEnabled", $object->login);
-				$desc = $langs->transnoentities("UserEnabled", $object->login);
-			}
-			if ($object->statut == 1) {
-				$text = $langs->transnoentities("UserDisabled", $object->login);
-				$desc = $langs->transnoentities("UserDisabled", $object->login);
-			}
-
+			case 'USER_ENABLEDISABLE':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				if ($object->statut == 0) {
+					$text = $langs->transnoentities("UserEnabled", $object->login);
+					$desc = $langs->transnoentities("UserEnabled", $object->login);
+				}
+				if ($object->statut == 1) {
+					$text = $langs->transnoentities("UserDisabled", $object->login);
+					$desc = $langs->transnoentities("UserDisabled", $object->login);
+				}
+				break;
 			// USER_DELETE
-		} elseif ($action == 'USER_DELETE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			$text = $langs->transnoentities("UserDeleted", $object->login);
-			$desc = $langs->transnoentities("UserDeleted", $object->login);
-
+			case 'USER_DELETE':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				$text = $langs->transnoentities("UserDeleted", $object->login);
+				$desc = $langs->transnoentities("UserDeleted", $object->login);
+				break;
 			// USERGROUP_CREATE
-		} elseif ($action == 'USERGROUP_CREATE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			$text = $langs->transnoentities("NewGroupCreated", $object->name);
-			$desc = $langs->transnoentities("NewGroupCreated", $object->name);
-
+			case 'USERGROUP_CREATE':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				$text = $langs->transnoentities("NewGroupCreated", $object->name);
+				$desc = $langs->transnoentities("NewGroupCreated", $object->name);
+				break;
 			// USERGROUP_MODIFY
-		} elseif ($action == 'USERGROUP_MODIFY') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			$text = $langs->transnoentities("GroupModified", $object->name);
-			$desc = $langs->transnoentities("GroupModified", $object->name);
-
+			case 'USERGROUP_MODIFY':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				$text = $langs->transnoentities("GroupModified", $object->name);
+				$desc = $langs->transnoentities("GroupModified", $object->name);
+				break;
 			// USERGROUP_DELETE
-		} elseif ($action == 'USERGROUP_DELETE') {
-			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
-			// Initialize data (date,duree,text,desc)
-			$text = $langs->transnoentities("GroupDeleted", $object->name);
-			$desc = $langs->transnoentities("GroupDeleted", $object->name);
+			case 'USERGROUP_DELETE':
+				dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
+				// Initialize data (date,duree,text,desc)
+				$text = $langs->transnoentities("GroupDeleted", $object->name);
+				$desc = $langs->transnoentities("GroupDeleted", $object->name);
+				break;
+			default:
+				break;
 		}
 
 		// Add more information into desc from the context property


### PR DESCRIPTION
# Code quality: use switch case instead of if elseif statements for actions
In order to make code more readable and also cleaner a `switch` statement could be used instead of `if elseif else`. When there are more than 3 statements with simple conditions to check a `switch` shows better intent.
As for performance, I cannot see any difference between the two control structures.
If there is a reason for not using `switch` statements in Dolibarr I would be interested to know. I can see a lot of other code that code benefit from better readability in the same manner.
Thanks

