### PR TITLE
FIX user creation when LDAP is configured

### DIFF
--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -1058,7 +1058,7 @@ class Ldap
 		if (is_array($attributeArray)) {
 			// Return list with required fields
 			$attributeArray = array_values($attributeArray); // This is to force to have index reordered from 0 (not make ldap_search fails)
-			dol_syslog(get_class($this)."::getRecords connection=".get_resource_type($this->connection)." userDn=".$userDn." filter=".$filter." attributeArray=(".join(',', $attributeArray).")");
+			dol_syslog(get_class($this)."::getRecords connection=".$this->connectedServer.":".$this->serverPort." userDn=".$userDn." filter=".$filter." attributeArray=(".join(',', $attributeArray).")");
 			//var_dump($attributeArray);
 			$this->result = @ldap_search($this->connection, $userDn, $filter, $attributeArray);
 		} else {


### PR DESCRIPTION
# FIX user creation when LDAP is configured

## Problem

On Dolibarr 16.0.5, we can't create new users, the page is blank:

![Screenshot 2023-10-23 at 15-09-32 User card](https://github.com/Dolibarr/dolibarr/assets/18473412/aa752fb8-905d-4b09-8670-b36bd7b6edef)

This is an instance based on `tuxgasy/dolibarr:16.0.5` (PHP 8.1.20), with LDAP enabled.

There is no error in the debug logs, but they end unexpectedly:

```
2023-10-23 13:05:47 DEBUG   82.66.191.87    Ldap::connect_bind try bind anonymously on ldaps://ldap.xxxxxxxx.xxx
2023-10-23 13:05:47 DEBUG   82.66.191.87    Ldap::connect_bind return=1
2023-10-23 13:05:47 INFO    82.66.191.87    Ldap::getRecords search=* userDn=ou=xxxxxxxx,o=xxxxxxxx useridentifier=cn attributeArray=array(cn,sn,givenname,uid,userPassword,telephonenumber,facsimiletelephonenumber,mobile,mail) activefilter=1
2023-10-23 13:05:47 INFO    82.66.191.87    --- End access to /user/card.php
```

## Solution

This PR is similar to #23121 (which wasn't targeted against branch 16.0)

A dump of `$this->connection` gives an empty object:

```
LDAP\Connection Object
(
)
```

[get_resource_type](https://www.php.net/manual/fr/function.get-resource-type.php) can't be called on an object. `$this->connection` is created by [ldap_connect](https://www.php.net/manual/fr/function.ldap-connect.php), which returned a resource in PHP 8.0 and earlier, but returns an `LDAP\Connection` object now.


