### PR TITLE
FIX account code binding for supplier invoice in eec

### DIFF
--- a/htdocs/accountancy/class/accountingaccount.class.php
+++ b/htdocs/accountancy/class/accountingaccount.class.php
@@ -841,7 +841,7 @@ class AccountingAccount extends CommonObject
 					}
 					$suggestedid = $accountingAccount['dom']; // There is a doubt for this case. Is it an error on vat or we just forgot to fill vat number ?
 					$suggestedaccountingaccountfor = 'eecwithoutvatnumber';
-				} elseif ($isSellerInEEC && $isBuyerInEEC && !empty($product->accountancy_code_sell_intra)) {
+				} elseif ($isSellerInEEC && $isBuyerInEEC && (($type == 'customer' && !empty($product->accountancy_code_sell_intra)) || ($type == 'supplier' && !empty($product->accountancy_code_buy_intra)))) {
 					// European intravat sale
 					if ($type == 'customer' && !empty($product->accountancy_code_sell_intra)) {
 						$code_p = $product->accountancy_code_sell_intra;


### PR DESCRIPTION
Context : 
- supplier invoice
- supplier in the EEC
- tva tax = 0%
- product accounting code sell intra **empty**
- product accounting code buy intra **not empty**
Result of getAccountingCodeToBind suggests export account and not intra account because there is no accounting code **sell** intra for the product.
But there is a case when you can buy product in eec and only sell it in your country (you don't have any client in eec)
