### PR TITLE
fix: if field is boolean in fileds array, it must be boolean as datatype for PgSQL

### DIFF
--- a/htdocs/install/mysql/tables/llx_asset-asset.sql
+++ b/htdocs/install/mysql/tables/llx_asset-asset.sql
@@ -43,13 +43,13 @@ CREATE TABLE llx_asset(
     acquisition_type        smallint        DEFAULT 0 NOT NULL,
     asset_type              smallint        DEFAULT 0 NOT NULL,
 
-    not_depreciated         integer         DEFAULT 0,
+    not_depreciated         boolean         DEFAULT false,
 
     disposal_date           date,
     disposal_amount_ht      double(24,8),
     fk_disposal_type        integer,
-    disposal_depreciated    integer         DEFAULT 0,
-    disposal_subject_to_vat integer         DEFAULT 0,
+    disposal_depreciated    boolean         DEFAULT false,
+    disposal_subject_to_vat boolean         DEFAULT false,
 
     note_public             text,
     note_private            text,

--- a/htdocs/install/mysql/tables/llx_asset_depreciation_options_economic-asset.sql
+++ b/htdocs/install/mysql/tables/llx_asset_depreciation_options_economic-asset.sql
@@ -27,7 +27,7 @@ CREATE TABLE llx_asset_depreciation_options_economic(
     fk_asset_model						integer,
 
     depreciation_type					smallint		DEFAULT 0 NOT NULL,		-- 0:linear, 1:degressive, 2:exceptional
-    accelerated_depreciation_option		integer,								-- activate accelerated depreciation mode (fiscal)
+    accelerated_depreciation_option		boolean DEFAULT false,								-- activate accelerated depreciation mode (fiscal)
     degressive_coefficient				double(24,8),
     duration							smallint		NOT NULL,
     duration_type						smallint		DEFAULT 0  NOT NULL,	-- 0:annual, 1:monthly, 2:daily


### PR DESCRIPTION
I didn't put migration script as this module is still in develop state in 18.0 and in develop branch

Else you've got this type of message

ERROR: 42804: column 'not_depreciated' is of type integer but expression is of type boolean LINE 1: ...tatus) VALUES ('qsdsqd', 'qsdqsd', NULL, 0, 0, 0, true, '202... ^ HINT: You will need to rewrite or cast the expression. LOCATION: transformAssignedExpr, parse_target.c:583