### PR TITLE
NEW: hidden conf to disable use of dns_get_record (which can become u…

### DIFF
--- a/htdocs/admin/mails.php
+++ b/htdocs/admin/mails.php
@@ -862,7 +862,7 @@ if ($action == 'edit') {
 		}
 		$companyemail = getDolGlobalString('MAIN_INFO_SOCIETE_MAIL');
 		$dnsinfo = false;
-		if (!empty($companyemail) && function_exists('dns_get_record')) {
+		if (!empty($companyemail) && function_exists('dns_get_record') && empty($conf->global->MAIN_DISABLE_DNS_GET_RECORD)) {
 			$arrayofemailparts = explode('@', $companyemail);
 			if (count($arrayofemailparts) == 2) {
 				$domain = $arrayofemailparts[1];


### PR DESCRIPTION
# NEW hidden conf MAIN_DISABLE_DNS_GET_RECORD
On some servers, for reasons unknown, the PHP function `dns_get_record()` gets completely unresponsive and blocks the whole apache server while waiting for a DNS resolution until it eventually times out. 

We tried to troubleshoot the issue (by trying to call the function from a php cli, by comparing with other DNS tools like `resolveip` or `dig`, by modifying `/etc/resolv.conf`, etc) but we did not find a reliable solution yet, so the hidden conf solution can be helpful for cases like this.

