### PR TITLE
fix: On Object referent tab on item, supplier invoice status is not correct

### DIFF
--- a/htdocs/product/stats/facture_fournisseur.php
+++ b/htdocs/product/stats/facture_fournisseur.php
@@ -264,7 +264,7 @@ if ($id > 0 || !empty($ref)) {
 						print dol_print_date($db->jdate($objp->datef), 'dayhour')."</td>";
 						print '<td class="center">'.$objp->qty."</td>\n";
 						print '<td align="right">'.price($objp->line_total_ht)."</td>\n";
-						print '<td align="right">'.$supplierinvoicestatic->LibStatut($objp->paye, $objp->statut, 5).'</td>';
+						print '<td align="right">'.$supplierinvoicestatic->LibStatut($objp->paye, $objp->statut, 5, $supplierinvoicestatic->getSommePaiement()).'</td>';
 						print "</tr>\n";
 						$i++;
 					}


### PR DESCRIPTION
Amount already paid must be send to libStatus for supplier invoice to display correct status


Before
![image](https://github.com/Dolibarr/dolibarr/assets/1050053/0e3b60e8-7402-41f6-9014-6520b5480009)


After
![image](https://github.com/Dolibarr/dolibarr/assets/1050053/c5b32556-c100-4317-bef2-74b73d62f62b)
