### PR TITLE
FIX suggested end for membership can be in the past

### DIFF
--- a/htdocs/adherents/class/adherentstats.class.php
+++ b/htdocs/adherents/class/adherentstats.class.php
@@ -282,7 +282,7 @@ class AdherentStats extends Stats
 		$sql .= " GROUP BY c.rowid, c.label";
 		$sql .= " ORDER BY label ASC";
 
-		dol_syslog("box_members_by_type::select nb of members per type", LOG_DEBUG);
+		dol_syslog("box_members_by_tag::select nb of members per tag", LOG_DEBUG);
 		$result = $this->db->query($sql);
 
 		if ($result) {

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -990,9 +990,9 @@ if (($action == 'addsubscription' || $action == 'create_thirdparty') && $user->h
 	}
 	if (!$dateto) {
 		if (getDolGlobalInt('MEMBER_SUBSCRIPTION_SUGGEST_END_OF_MONTH')) {
-			$dateto = dol_get_last_day($currentyear, $currentmonth);
+			$dateto = dol_get_last_day(dol_print_date($datefrom, "%Y"),dol_print_date($datefrom, "%m"));
 		} elseif (getDolGlobalInt('MEMBER_SUBSCRIPTION_SUGGEST_END_OF_YEAR')) {
-			$dateto = dol_get_last_day($currentyear);
+			$dateto = dol_get_last_day(dol_print_date($datefrom, "%Y"));
 		} else {
 			$dateto = -1; // By default, no date is suggested
 		}

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -990,7 +990,7 @@ if (($action == 'addsubscription' || $action == 'create_thirdparty') && $user->h
 	}
 	if (!$dateto) {
 		if (getDolGlobalInt('MEMBER_SUBSCRIPTION_SUGGEST_END_OF_MONTH')) {
-			$dateto = dol_get_last_day(dol_print_date($datefrom, "%Y"),dol_print_date($datefrom, "%m"));
+			$dateto = dol_get_last_day(dol_print_date($datefrom, "%Y"), dol_print_date($datefrom, "%m"));
 		} elseif (getDolGlobalInt('MEMBER_SUBSCRIPTION_SUGGEST_END_OF_YEAR')) {
 			$dateto = dol_get_last_day(dol_print_date($datefrom, "%Y"));
 		} else {


### PR DESCRIPTION
MEMBER_SUBSCRIPTION_SUGGEST_END_OF_YEAR and MEMBER_SUBSCRIPTION_SUGGEST_END_OF_MONTH should be based on the subscription start date, not on the creation date

