### PR TITLE
fix: document linked in asset module permission

### DIFF
--- a/htdocs/asset/document.php
+++ b/htdocs/asset/document.php
@@ -72,7 +72,7 @@ if ($id > 0 || !empty($ref)) {
 	$upload_dir = $conf->asset->multidir_output[$object->entity ? $object->entity : $conf->entity]."/".get_exdir(0, 0, 0, 1, $object);
 }
 
-$permissiontoadd = $user->rights->asset->asset->write; // Used by the include of actions_addupdatedelete.inc.php and actions_linkedfiles.inc.php
+$permissiontoadd = $user->rights->asset->write; // Used by the include of actions_addupdatedelete.inc.php and actions_linkedfiles.inc.php
 
 // Security check (enable the most restrictive one)
 if ($user->socid > 0) accessforbidden();


### PR DESCRIPTION
Missing $permissionadd in asset/document.php