### PR TITLE
fix #18654 : orders are partially received even if all products have been received

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -742,6 +742,8 @@ class Reception extends CommonObject
 				foreach ($supplierorderdispatch->lines as $dispatch_line) {
 					if (array_key_exists($dispatch_line->fk_product, $qty_received)) {
 						$qty_received[$dispatch_line->fk_product] += $dispatch_line->qty;
+					} else {
+						$qty_received[$dispatch_line->fk_product] = $dispatch_line->qty;
 					}
 				}
 


### PR DESCRIPTION
FIX: orders are partially received even if all products have been received

Commit a2c0eac re-introduced  bug #18654 .
This PR re-fixes it