### PR TITLE
NEW shipment can include service (for information and invoicing)

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -403,7 +403,7 @@ class Expedition extends CommonObject
 				// Insert of lines
 				$num = count($this->lines);
 				for ($i = 0; $i < $num; $i++) {
-					if (empty($this->lines[$i]->product_type) || !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
+					if (empty($this->lines[$i]->product_type) || !empty($conf->global->STOCK_SUPPORTS_SERVICES) || !empty($conf->global->SHIPMENT_SUPPORTS_SERVICES)) {
 						if (!isset($this->lines[$i]->detail_batch)) {	// no batch management
 							if ($this->create_line($this->lines[$i]->entrepot_id, $this->lines[$i]->origin_line_id, $this->lines[$i]->qty, $this->lines[$i]->rang, $this->lines[$i]->array_options) <= 0) {
 								$error++;

--- a/htdocs/expedition/shipment.php
+++ b/htdocs/expedition/shipment.php
@@ -764,7 +764,7 @@ if ($id > 0 || !empty($ref)) {
 
 					// Qty remains to ship
 					print '<td class="center">';
-					if ($type == 0 || !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
+					if ($type == 0 || !empty($conf->global->STOCK_SUPPORTS_SERVICES)|| !empty($conf->global->SHIPMENT_SUPPORTS_SERVICES)) {
 						$toBeShipped[$objp->fk_product] = $objp->qty - $qtyAlreadyShipped;
 						$toBeShippedTotal += $toBeShipped[$objp->fk_product];
 						print $toBeShipped[$objp->fk_product];
@@ -790,6 +790,8 @@ if ($id > 0 || !empty($ref)) {
 							}
 						}
 						print '</td>';
+					} elseif ($objp->fk_product > 0 && $type == Product::TYPE_SERVICE && !empty($conf->global->SHIPMENT_SUPPORTS_SERVICES) && isModEnabled('stock')) {
+						print '<td><span class="opacitymedium">('.$langs->trans("Service").')</span></td>';
 					} else {
 						print '<td>&nbsp;</td>';
 					}


### PR DESCRIPTION
add an optionnal option for include service on shipment because some business need invoicing only from shipment so actually dont get services on invoice autmatically (ex deposit or caution or fee of rent liked to a product

no change for everyone who don't activate the option with the hidden option SHIPMENT_SUPPORTS_SERVICES