### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -107,7 +107,7 @@ NEW|New|QUAL|Qual|PERF|Perf Short description (In upper case to appear into Chan
 or
 Short description (when the commit is not introducing feature nor closing a bug)
 
-Long description (Can span accross multiple lines).
+Long description (Can span across multiple lines).
 </pre>
 
 ### Pull Requests


### PR DESCRIPTION
FIXES #26414 .

FIXES Typo Error.


# FIX|Fix #[*26414 - Typographical Error*]
The line contains a spell error - "Can span 'accross' multiple lines."

So it should be corrected as:
"Can span 'across' multiple lines."