### PR TITLE
FIX Accountancy - Journal - problem with displaying label in getNomUrl

### DIFF
--- a/htdocs/accountancy/class/accountingjournal.class.php
+++ b/htdocs/accountancy/class/accountingjournal.class.php
@@ -228,7 +228,7 @@ class AccountingJournal extends CommonObject
 	}
 
 	/**
-	 * Return clicable name (with picto eventually)
+	 * Return clickable name (with picto eventually)
 	 *
 	 * @param	int		$withpicto		0=No picto, 1=Include picto into link, 2=Only picto
 	 * @param	int		$withlabel		0=No label, 1=Include label of journal, 2=Include nature of journal
@@ -281,7 +281,7 @@ class AccountingJournal extends CommonObject
 		}
 
 		$label_link = $this->code;
-		if ($withlabel != 2 && !empty($this->label)) {
+		if ($withlabel == 1 && !empty($this->label)) {
 			$label_link .= ' - '.($nourl ? '<span class="opacitymedium">' : '').$langs->transnoentities($this->label).($nourl ? '</span>' : '');
 		}
 		if ($withlabel == 2 && !empty($this->nature)) {


### PR DESCRIPTION
By default, most of the time, you are asked not to display the journal label and it is displayed anyway.

Good display is:

![image](https://github.com/Dolibarr/dolibarr/assets/2341395/c5165391-cb4c-491b-ac44-6947a50fc751)
