### PR TITLE
FIX substitute project variables in invoice documents

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -118,6 +118,9 @@ if ($id > 0 || !empty($ref)) {
 			$fetch_situation = true;
 		}
 		$ret = $object->fetch($id, $ref, '', '', $fetch_situation);
+		if ($ret > 0 && isset($object->fk_project)) {
+			$ret = $object->fetch_project();
+		}
 	}
 }
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -7105,15 +7105,20 @@ function getCommonSubstitutionArray($outputlangs, $onlykey = 0, $exclude = null,
 				$substitutionarray['__CANDIDATE_LASTNAME__'] = $object->lastname;
 			}
 
+			$project = null;
 			if (is_object($object->project)) {
-				$substitutionarray['__PROJECT_ID__'] = (is_object($object->project) ? $object->project->id : '');
-				$substitutionarray['__PROJECT_REF__'] = (is_object($object->project) ? $object->project->ref : '');
-				$substitutionarray['__PROJECT_NAME__'] = (is_object($object->project) ? $object->project->title : '');
+				$project = $object->project;
+			} elseif (is_object($object->projet)) { // Deprecated, for backward compatibility
+				$project = $object->projet;
 			}
-			if (is_object($object->projet)) {	// Deprecated, for backward compatibility
-				$substitutionarray['__PROJECT_ID__'] = (is_object($object->projet) ? $object->projet->id : '');
-				$substitutionarray['__PROJECT_REF__'] = (is_object($object->projet) ? $object->projet->ref : '');
-				$substitutionarray['__PROJECT_NAME__'] = (is_object($object->projet) ? $object->projet->title : '');
+			if ($project) {
+				$substitutionarray['__PROJECT_ID__'] = $project->id;
+				$substitutionarray['__PROJECT_REF__'] = $project->ref;
+				$substitutionarray['__PROJECT_NAME__'] = $project->title;
+			} else {
+				$substitutionarray['__PROJECT_ID__'] = '';
+				$substitutionarray['__PROJECT_REF__'] = '';
+				$substitutionarray['__PROJECT_NAME__'] = '';
 			}
 			if (is_object($object) && $object->element == 'project') {
 				$substitutionarray['__PROJECT_NAME__'] = $object->title;

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -7115,10 +7115,6 @@ function getCommonSubstitutionArray($outputlangs, $onlykey = 0, $exclude = null,
 				$substitutionarray['__PROJECT_ID__'] = $project->id;
 				$substitutionarray['__PROJECT_REF__'] = $project->ref;
 				$substitutionarray['__PROJECT_NAME__'] = $project->title;
-			} else {
-				$substitutionarray['__PROJECT_ID__'] = '';
-				$substitutionarray['__PROJECT_REF__'] = '';
-				$substitutionarray['__PROJECT_NAME__'] = '';
 			}
 			if (is_object($object) && $object->element == 'project') {
 				$substitutionarray['__PROJECT_NAME__'] = $object->title;


### PR DESCRIPTION
FIX substitute project variables in invoice documents
- see FIX Add substitution variables from project into propal (PR 25656)
- related to FIX substitute project variables in document with free text #23820

If invoice is not linked to a project  : 
- substitute __PROJECT_ID__ with empty values

Example : 
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/e819024e-16d9-4dbc-92aa-dce8ab4c6624)