### PR TITLE
Fix Attributes values shall be ordered by position when retrieved

### DIFF
--- a/htdocs/variants/class/ProductAttributeValue.class.php
+++ b/htdocs/variants/class/ProductAttributeValue.class.php
@@ -290,6 +290,8 @@ class ProductAttributeValue extends CommonObjectLine
 
 		$query = $this->db->query($sql);
 
+		$sql .= " ORDER BY v.position ASC";
+
 		while ($result = $this->db->fetch_object($query)) {
 			if (empty($returnonlydata)) {
 				$tmp = new ProductAttributeValue($this->db);

--- a/htdocs/variants/class/ProductAttributeValue.class.php
+++ b/htdocs/variants/class/ProductAttributeValue.class.php
@@ -288,9 +288,9 @@ class ProductAttributeValue extends CommonObjectLine
 			$sql .= " AND c2v.rowid IS NOT NULL AND p.tosell = 1";
 		}
 
-		$query = $this->db->query($sql);
-
 		$sql .= " ORDER BY v.position ASC";
+
+		$query = $this->db->query($sql);
 
 		while ($result = $this->db->fetch_object($query)) {
 			if (empty($returnonlydata)) {


### PR DESCRIPTION
A user can manually order the values of a product/service attribute. 

This order is recorded with the `position` key in the `llx_product_attribute_value` table.

However, this order is not taken into account when the values of an attribute are retrieved via the function `fetchAllByProductAttribute()` from the `ProductAttributeValue.class.php` file.

This PR orders the values by their position key.

Now when you create a new variant (from Product > Variants or `/variants/combinations.php?id=xx&action=add`) the values are correctly ordered in the select menu.