### PR TITLE
fix Rename is not translated because its translation isn't declared

### DIFF
--- a/htdocs/compta/bank/releve.php
+++ b/htdocs/compta/bank/releve.php
@@ -371,7 +371,7 @@ if (empty($numref)) {
 				} else {
 					print '<input type="hidden" name="oldbankreceipt" value="'.$objp->numr.'">';
 					print '<input type="text" name="newbankreceipt" value="'.$objp->numr.'">';
-					print '<input type="submit" class="button smallpaddingimp" name="actionnewbankreceipt" value="'.$langs->trans("Rename").'">';
+					print '<input type="submit" class="button smallpaddingimp" name="actionnewbankreceipt" value="'.$langs->trans("Save").'">';
 					print '<input type="submit" class="button button-cancel smallpaddingimp" name="cancel" value="'.$langs->trans("Cancel").'">';
 				}
 				print '</td>';


### PR DESCRIPTION
`/htdocs/compta/bank/releve.php` calls for `$langs->trans("Rename")` at line 374 to print a button allowing to rename an existing bank receipt. 

However this translation doesn't exist in the `/langs` files.
(see `grep -Rl "Rename=" ./htdocs/langs/`)

Also, this translation seems (surprisingly) to be solely called by `/htdocs/compta/bank/releve.php`.
(see `grep -Rl '$langs->trans("Rename")' ./htdocs/`)

And since we use the term "Save" elsewhere in Dolibarr for similar actions, I propose to simply use "Save" here as well (instead of "Rename").