### PR TITLE
fix error message ErrorThisBankReceiptIsAlreadyUsed is not translated

### DIFF
--- a/htdocs/compta/bank/releve.php
+++ b/htdocs/compta/bank/releve.php
@@ -201,7 +201,7 @@ if ($action == 'confirm_editbankreceipt' && !empty($oldbankreceipt) && !empty($n
 	if ($resql) {
 		$obj = $db->fetch_object($resql);
 		if ($obj && $obj->rowid) {
-			setEventMessages('ErrorThisBankReceiptIsAlreadyUsed', null, 'errors');
+			setEventMessages('ErrorBankReceiptAlreadyExists', null, 'errors');
 			$error++;
 		}
 	} else {

--- a/htdocs/langs/en_US/banks.lang
+++ b/htdocs/langs/en_US/banks.lang
@@ -16,6 +16,7 @@ CashAccounts=Cash accounts
 CurrentAccounts=Current accounts
 SavingAccounts=Savings accounts
 ErrorBankLabelAlreadyExists=Financial account label already exists
+ErrorBankReceiptAlreadyExists=Bank receipt reference already exists
 BankBalance=Balance
 BankBalanceBefore=Balance before
 BankBalanceAfter=Balance after

--- a/htdocs/langs/fr_FR/banks.lang
+++ b/htdocs/langs/fr_FR/banks.lang
@@ -16,6 +16,7 @@ CashAccounts=Comptes caisse/liquide
 CurrentAccounts=Comptes courants
 SavingAccounts=Comptes épargne/placements
 ErrorBankLabelAlreadyExists=Libellé de compte financier déjà existant
+ErrorBankReceiptAlreadyExists=Référence de relevé bancaire déjà existante
 BankBalance=Solde
 BankBalanceBefore=Solde avant
 BankBalanceAfter=Solde après


### PR DESCRIPTION
If you try to rename a bank receipt from `/htdocs/compta/bank/releve.php`, after clicking on the "modify pencil" and then directly on "Rename" or "Cancel", you'll get the untranslated error message `ErrorThisBankReceiptIsAlreadyUsed`.

This is because this error message isn't declared in the `/trans` files.

However, since there is already an error message called `ErrorBankLabelAlreadyExists` in `/langs/en_US/banks.lang`, I propose to reuse the same type of wording, and therefore use `ErrorBankReceiptAlreadyExists` instead.

