### PR TITLE
fix missing 2 translation keys used in commande/list.php

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -718,9 +718,9 @@ if ($action == 'shipped' && $permissiontoadd) {
 			if ($objecttmp->fetch($checked)) {
 				if ($objecttmp->statut == 1 || $objecttmp->statut == 2) {
 					if ($objecttmp->cloture($user)) {
-						setEventMessages($langs->trans('PassedInClosedStatus', $objecttmp->ref), null, 'mesgs');
+						setEventMessages($langs->trans('StatusOrderDelivered', $objecttmp->ref), null, 'mesgs');
 					} else {
-						setEventMessages($langs->trans('CantBeClosed'), null, 'errors');
+						setEventMessages($langs->trans('ErrorOrderStatusCantBeSetToDelivered'), null, 'errors');
 						$error++;
 					}
 				} else {

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -103,6 +103,7 @@ ErrorFileIsInfectedWithAVirus=The antivirus program was not able to validate the
 ErrorNumRefModel=A reference exists into database (%s) and is not compatible with this numbering rule. Remove record or renamed reference to activate this module.
 ErrorQtyTooLowForThisSupplier=Quantity too low for this vendor or no price defined on this product for this vendor
 ErrorOrdersNotCreatedQtyTooLow=Some orders haven't been created because of too-low quantities
+ErrorOrderStatusCantBeSetToDelivered=Order status can't be set to delivered.
 ErrorModuleSetupNotComplete=Setup of module %s looks to be uncomplete. Go on Home - Setup - Modules to complete.
 ErrorBadMask=Error on mask
 ErrorBadMaskFailedToLocatePosOfSequence=Error, mask without sequence number

--- a/htdocs/langs/fr_FR/errors.lang
+++ b/htdocs/langs/fr_FR/errors.lang
@@ -103,6 +103,7 @@ ErrorFileIsInfectedWithAVirus=L'antivirus n'a pas pu valider ce fichier (il est 
 ErrorNumRefModel=Une référence existe en base (%s) et est incompatible avec cette numérotation. Supprimez la ligne ou renommez la référence pour activer ce module.
 ErrorQtyTooLowForThisSupplier=Quantité insuffisante pour ce fournisseur ou aucun tarif défini sur ce produit pour ce fournisseur
 ErrorOrdersNotCreatedQtyTooLow=Certaines commandes n'ont pas été créées en raison de quantités trop faibles
+ErrorOrderStatusCantBeSetToDelivered=La commande ne peut pas être classé livrée.
 ErrorModuleSetupNotComplete=La configuration du module %s semble incomplète. Aller sur la page Accueil - Configuration - Modules pour corriger.
 ErrorBadMask=Erreur sur le masque
 ErrorBadMaskFailedToLocatePosOfSequence=Erreur, masque sans numéro de séquence


### PR DESCRIPTION
If you try to set to "delivered" multiple customer orders, you sometimes notice an error message which isn't translated: `PassedInClosedStatus`. 

To reproduce : go to Commerce > Commande > Liste, select a few orders and choose the action "Classer livrée". If some of the selected orders can't be set to "Delivered", then the error message appears.

Looking at the code, I've noticed there is a second missing translation key in the same area. Therefore:
- to correct the missing `PassedInClosedStatus` translation key (line 721):
  - I propose to simply reuse the existing translation key `StatusOrderDelivered` located at: https://github.com/Dolibarr/dolibarr/blob/0c9610641c184d3336abf57aba269274d250f264/htdocs/langs/en_US/orders.lang#L42
- to correct the missing `CantBeClosed` translation key (line 723):
  - I propose to create a new translation key in `errors.lang`, next to another key used for orders.