### PR TITLE
Fix Bad Behaviour using custom constant STOCK_UPDATE_AWP_EVEN_WHEN_ENTRY_PRICE_IS_NULL

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -516,7 +516,7 @@ class MouvementStock extends CommonObject
 					// After a stock increase
 					// Note: PMP is calculated on stock input only (type of movement = 0 or 3). If type == 0 or 3, qty should be > 0.
 					// Note: Price should always be >0 or 0. PMP should be always >0 (calculated on input)
-					if ($price > 0 || (!empty($conf->global->STOCK_UPDATE_AWP_EVEN_WHEN_ENTRY_PRICE_IS_NULL) && $price == 0)) {
+					if ($price > 0 || (!empty($conf->global->STOCK_UPDATE_AWP_EVEN_WHEN_ENTRY_PRICE_IS_NULL) && $price == 0 && in_array($this->origin_type, array('order_supplier', 'invoice_supplier')))) {
 						$oldqtytouse = ($oldqty >= 0 ? $oldqty : 0);
 						// We make a test on oldpmp>0 to avoid to use normal rule on old data with no pmp field defined
 						if ($oldpmp > 0) {


### PR DESCRIPTION
# FIX Bad Behaviour with custom constant STOCK_UPDATE_AWP_EVEN_WHEN_ENTRY_PRICE_IS_NULL

## Unwanted effect
The stock movements generated by reopen or set to draft a customer order/invoice (depending of stock configuration) cause the AWP to decrease tending to 0.

## Solution found
Added a filter to trigger the AWP calculation with price == 0.
Now, constant STOCK_UPDATE_AWP_EVEN_WHEN_ENTRY_PRICE_IS_NULL must be specified AND the origin_type for the stock_movement must be supplier_order or supplier_invoice. 

P.S. : I'll apply the same fix for the Multicompany PMP per entity Trigger 

