### PR TITLE
FIX query syntax for extrafields

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6077,7 +6077,7 @@ abstract class CommonObject
 			$sql = "SELECT rowid";
 			foreach ($optionsArray as $name => $label) {
 				if (empty($extrafields->attributes[$this->table_element]['type'][$name]) || $extrafields->attributes[$this->table_element]['type'][$name] != 'separate') {
-					$sql .= ", ".$name;
+					$sql .= ", `".$name."`";
 				}
 			}
 			$sql .= " FROM ".$this->db->prefix().$table_element."_extrafields";

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6077,7 +6077,7 @@ abstract class CommonObject
 			$sql = "SELECT rowid";
 			foreach ($optionsArray as $name => $label) {
 				if (empty($extrafields->attributes[$this->table_element]['type'][$name]) || $extrafields->attributes[$this->table_element]['type'][$name] != 'separate') {
-					$sql .= ", `".$name."`";
+					$sql .= ", `".$this->db->escape($name)."`";
 				}
 			}
 			$sql .= " FROM ".$this->db->prefix().$table_element."_extrafields";

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6077,7 +6077,7 @@ abstract class CommonObject
 			$sql = "SELECT rowid";
 			foreach ($optionsArray as $name => $label) {
 				if (empty($extrafields->attributes[$this->table_element]['type'][$name]) || $extrafields->attributes[$this->table_element]['type'][$name] != 'separate') {
-					$sql .= ", `".$this->db->escape($name)."`";
+					$sql .= ", ".MAIN_DB_PREFIX.$table_element."_extrafields.".$this->db->escape($name);
 				}
 			}
 			$sql .= " FROM ".$this->db->prefix().$table_element."_extrafields";

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6373,7 +6373,7 @@ abstract class CommonObject
 				$attributeKey = substr($key, 8); // Remove 'options_' prefix
 				// Add field of attribut
 				if ($extrafields->attributes[$this->table_element]['type'][$attributeKey] != 'separate') { // Only for other type than separator
-					$sql .= ",".$attributeKey;
+					$sql .= ",`".$attributeKey."`";
 				}
 			}
 			// We must insert a default value for fields for other entities that are mandatory to avoid not null error

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6373,7 +6373,7 @@ abstract class CommonObject
 				$attributeKey = substr($key, 8); // Remove 'options_' prefix
 				// Add field of attribut
 				if ($extrafields->attributes[$this->table_element]['type'][$attributeKey] != 'separate') { // Only for other type than separator
-					$sql .= ",`".$attributeKey."`";
+					$sql .= ",`".$this->db->escape($attributeKey)."`";
 				}
 			}
 			// We must insert a default value for fields for other entities that are mandatory to avoid not null error

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -893,7 +893,7 @@ class DoliDBMysqli extends DoliDB
 		// phpcs:enable
 		// cles recherchees dans le tableau des descriptions (field_desc) : type,value,attribute,null,default,extra
 		// ex. : $field_desc = array('type'=>'int','value'=>'11','null'=>'not null','extra'=> 'auto_increment');
-		$sql = "ALTER TABLE ".$table." ADD ".$field_name." ";
+		$sql = "ALTER TABLE ".$table." ADD `".$field_name."` ";
 		$sql .= $field_desc['type'];
 		if (preg_match("/^[^\s]/i", $field_desc['value'])) {
 			if (!in_array($field_desc['type'], array('date', 'datetime')) && $field_desc['value']) {

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -893,7 +893,7 @@ class DoliDBMysqli extends DoliDB
 		// phpcs:enable
 		// cles recherchees dans le tableau des descriptions (field_desc) : type,value,attribute,null,default,extra
 		// ex. : $field_desc = array('type'=>'int','value'=>'11','null'=>'not null','extra'=> 'auto_increment');
-		$sql = "ALTER TABLE ".$table." ADD `".$field_name."` ";
+		$sql = "ALTER TABLE ".$table." ADD `".$this->escape($field_name)."` ";
 		$sql .= $field_desc['type'];
 		if (preg_match("/^[^\s]/i", $field_desc['value'])) {
 			if (!in_array($field_desc['type'], array('date', 'datetime')) && $field_desc['value']) {


### PR DESCRIPTION
When we fetch optionals, or when we add an extrafield, we should use backticks to define the field.

Indeed, it prevents from getting errors when the field as the same name as an SQL instruction.
For example, on a product, if you have an extrafield 'option', you'll get an error with MySQL 8 since OPTION is now an SQL instruction.