### PR TITLE
FIX : Warehouse Global amounts issue

### DIFF
--- a/htdocs/product/stock/list.php
+++ b/htdocs/product/stock/list.php
@@ -613,7 +613,6 @@ if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 }
 print '</tr>'."\n";
 
-$totalarray = array();
 $totalarray['nbfield'] = 0;
 
 // Fields title label
@@ -686,7 +685,6 @@ $warehouse = new Entrepot($db);
 // --------------------------------------------------------------------
 $i = 0;
 $savnbfield = $totalarray['nbfield'];
-$totalarray = array();
 $totalarray['nbfield'] = 0;
 $imaxinloop = ($limit ? min($num, $limit) : $num);
 while ($i < $imaxinloop) {


### PR DESCRIPTION
# FIX|Fix #[26463 BUG : Stock Total Calculation does not work]
This fix is to repaired the Warehouse Global Amounts that are not displayed anymore starting from v18.x
in product/stock/list.php.
To fix it To fix it, I removed line 616 and line 689 which includes the following code :
$totalarray = array();

https://github.com/Dolibarr/dolibarr/issues/26463

