### PR TITLE
NEW order by batch number in product batch find all method

### DIFF
--- a/htdocs/product/class/productbatch.class.php
+++ b/htdocs/product/class/productbatch.class.php
@@ -493,6 +493,9 @@ class Productbatch extends CommonObject
 		if ($fk_product > 0) { $sql .= "pl.eatby ASC, pl.sellby ASC, "; }
 		$sql .= "t.eatby ASC, t.sellby ASC ";
 		$sql .= ", t.qty ".(empty($conf->global->DO_NOT_TRY_TO_DEFRAGMENT_STOCKS_WAREHOUSE)?'ASC':'DESC'); // Note : qty ASC is important for expedition card, to avoid stock fragmentation
+		if (getDolGlobalInt('PRODUCTBATCH_ORDER_BY_BATCH_NUMBER')) {
+			$sql .= ", t.batch ASC";
+		}
 
 		dol_syslog("productbatch::findAll", LOG_DEBUG);
 

--- a/htdocs/product/class/productbatch.class.php
+++ b/htdocs/product/class/productbatch.class.php
@@ -493,9 +493,7 @@ class Productbatch extends CommonObject
 		if ($fk_product > 0) { $sql .= "pl.eatby ASC, pl.sellby ASC, "; }
 		$sql .= "t.eatby ASC, t.sellby ASC ";
 		$sql .= ", t.qty ".(empty($conf->global->DO_NOT_TRY_TO_DEFRAGMENT_STOCKS_WAREHOUSE)?'ASC':'DESC'); // Note : qty ASC is important for expedition card, to avoid stock fragmentation
-		if (getDolGlobalInt('PRODUCTBATCH_ORDER_BY_BATCH_NUMBER')) {
-			$sql .= ", t.batch ASC";
-		}
+		$sql .= ", t.batch ASC";
 
 		dol_syslog("productbatch::findAll", LOG_DEBUG);
 


### PR DESCRIPTION
NEW order by batch number in product batch find all method
- when you have a lot a batches with the same warehouse and the same quantity, it's difficult to choose a specific batch without order
- add an hidden const "PRODUCTBATCH_ORDER_BY_BATCH_NUMBER" to order by batch number
- this order is after DLC and DLUO orders and after qty

@eldy
- I prefer to add an hidden const but I wonder if it's needed ?
