### PR TITLE
NEW : add hook tabContentEditThirdparty

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -2026,532 +2026,538 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 			print dol_get_fiche_head($head, 'card', $langs->trans("ThirdParty"), 0, 'company');
 
 			print '<div class="fichecenter2">';
-			print '<table class="border centpercent">';
+			// Call Hook tabContentEditThirdparty
+			$parameters = array();
+			// Note that $action and $object may be modified by hook
+			$reshook = $hookmanager->executeHooks('tabContentEditThirdparty', $parameters, $object, $action);
+			if (empty($reshook)) {
+				print '<table class="border centpercent">';
 
-			// Ref/ID
-			if (!empty($conf->global->MAIN_SHOW_TECHNICAL_ID)) {
-				print '<tr><td class="titlefieldcreate">'.$langs->trans("ID").'</td><td colspan="3">';
-				print $object->ref;
+				// Ref/ID
+				if (!empty($conf->global->MAIN_SHOW_TECHNICAL_ID)) {
+					print '<tr><td class="titlefieldcreate">'.$langs->trans("ID").'</td><td colspan="3">';
+					print $object->ref;
+					print '</td></tr>';
+				}
+
+				// Name
+				print '<tr><td class="titlefieldcreate">'.$form->editfieldkey('ThirdPartyName', 'name', '', $object, 0, 'string', '', 1).'</td>';
+				print '<td colspan="3"><input type="text" class="minwidth300" maxlength="128" name="name" id="name" value="'.dol_escape_htmltag($object->name).'" autofocus="autofocus">';
+				print $form->widgetForTranslation("name", $object, $permissiontoadd, 'string', 'alpahnohtml', 'minwidth300');
 				print '</td></tr>';
-			}
 
-			// Name
-			print '<tr><td class="titlefieldcreate">'.$form->editfieldkey('ThirdPartyName', 'name', '', $object, 0, 'string', '', 1).'</td>';
-			print '<td colspan="3"><input type="text" class="minwidth300" maxlength="128" name="name" id="name" value="'.dol_escape_htmltag($object->name).'" autofocus="autofocus">';
-			print $form->widgetForTranslation("name", $object, $permissiontoadd, 'string', 'alpahnohtml', 'minwidth300');
-			print '</td></tr>';
+				// Alias names (commercial, trademark or alias names)
+				print '<tr id="name_alias"><td><label for="name_alias_input">'.$langs->trans('AliasNames').'</label></td>';
+				print '<td colspan="3"><input type="text" class="minwidth300" name="name_alias" id="name_alias_input" value="'.dol_escape_htmltag($object->name_alias).'"></td></tr>';
 
-			// Alias names (commercial, trademark or alias names)
-			print '<tr id="name_alias"><td><label for="name_alias_input">'.$langs->trans('AliasNames').'</label></td>';
-			print '<td colspan="3"><input type="text" class="minwidth300" name="name_alias" id="name_alias_input" value="'.dol_escape_htmltag($object->name_alias).'"></td></tr>';
-
-			// Prefix
-			if (!empty($conf->global->SOCIETE_USEPREFIX)) {  // Old not used prefix field
-				print '<tr><td>'.$form->editfieldkey('Prefix', 'prefix', '', $object, 0).'</td><td colspan="3">';
-				// It does not change the prefix mode using the auto numbering prefix
-				if (($prefixCustomerIsUsed || $prefixSupplierIsUsed) && $object->prefix_comm) {
-					print '<input type="hidden" name="prefix_comm" value="'.dol_escape_htmltag($object->prefix_comm).'">';
-					print $object->prefix_comm;
-				} else {
-					print '<input type="text" size="5" maxlength="5" name="prefix_comm" id="prefix" value="'.dol_escape_htmltag($object->prefix_comm).'">';
+				// Prefix
+				if (!empty($conf->global->SOCIETE_USEPREFIX)) {  // Old not used prefix field
+					print '<tr><td>'.$form->editfieldkey('Prefix', 'prefix', '', $object, 0).'</td><td colspan="3">';
+					// It does not change the prefix mode using the auto numbering prefix
+					if (($prefixCustomerIsUsed || $prefixSupplierIsUsed) && $object->prefix_comm) {
+						print '<input type="hidden" name="prefix_comm" value="'.dol_escape_htmltag($object->prefix_comm).'">';
+						print $object->prefix_comm;
+					} else {
+						print '<input type="text" size="5" maxlength="5" name="prefix_comm" id="prefix" value="'.dol_escape_htmltag($object->prefix_comm).'">';
+					}
+					print '</td>';
 				}
-				print '</td>';
-			}
 
-			// Prospect/Customer
-			print '<tr><td>'.$form->editfieldkey('ProspectCustomer', 'customerprospect', '', $object, 0, 'string', '', 1).'</td>';
-			print '<td class="maxwidthonsmartphone">';
-			print $formcompany->selectProspectCustomerType($object->client);
-			print '</td>';
-			if ($conf->browser->layout == 'phone') {
-				print '</tr><tr>';
-			}
-			print '<td>'.$form->editfieldkey('CustomerCode', 'customer_code', '', $object, 0).'</td><td>';
-
-			print '<table class="nobordernopadding"><tr><td>';
-			if ((!$object->code_client || $object->code_client == -1) && $modCodeClient->code_auto) {
-				$tmpcode = $object->code_client;
-				if (empty($tmpcode) && !empty($object->oldcopy->code_client)) {
-					$tmpcode = $object->oldcopy->code_client; // When there is an error to update a thirdparty, the number for supplier and customer code is kept to old value.
-				}
-				if (empty($tmpcode) && !empty($modCodeClient->code_auto)) {
-					$tmpcode = $modCodeClient->getNextValue($object, 0);
-				}
-				print '<input type="text" name="customer_code" id="customer_code" size="16" value="'.dol_escape_htmltag($tmpcode).'" maxlength="24">';
-			} elseif ($object->codeclient_modifiable()) {
-				print '<input type="text" name="customer_code" id="customer_code" size="16" value="'.dol_escape_htmltag($object->code_client).'" maxlength="24">';
-			} else {
-				print $object->code_client;
-				print '<input type="hidden" name="customer_code" value="'.dol_escape_htmltag($object->code_client).'">';
-			}
-			print '</td><td>';
-			$s = $modCodeClient->getToolTip($langs, $object, 0);
-			print $form->textwithpicto('', $s, 1);
-			print '</td></tr></table>';
-
-			print '</td></tr>';
-
-			// Supplier
-			if (((isModEnabled("fournisseur") && $user->hasRight('fournisseur', 'lire') && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || (isModEnabled("supplier_order") && $user->hasRight('supplier_order', 'lire')) || (isModEnabled("supplier_invoice") && $user->hasRight('supplier_invoice', 'lire')))
-				|| (isModEnabled('supplier_proposal') && $user->hasRight('supplier_proposal', 'lire'))) {
-				print '<tr>';
-				print '<td>'.$form->editfieldkey('Supplier', 'fournisseur', '', $object, 0, 'string', '', 1).'</td>';
+				// Prospect/Customer
+				print '<tr><td>'.$form->editfieldkey('ProspectCustomer', 'customerprospect', '', $object, 0, 'string', '', 1).'</td>';
 				print '<td class="maxwidthonsmartphone">';
-				print $form->selectyesno("fournisseur", $object->fournisseur, 1, false, 0, 1);
+				print $formcompany->selectProspectCustomerType($object->client);
 				print '</td>';
 				if ($conf->browser->layout == 'phone') {
 					print '</tr><tr>';
 				}
-				print '<td>';
-				if ((isModEnabled("fournisseur") && $user->hasRight('fournisseur', 'lire') && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || (isModEnabled("supplier_order") && $user->hasRight('supplier_order', 'lire')) || (isModEnabled("supplier_invoice") && $user->hasRight('supplier_invoice', 'lire'))) {
-					print $form->editfieldkey('SupplierCode', 'supplier_code', '', $object, 0);
-				}
-				print '</td>';
-				print '<td>';
+				print '<td>'.$form->editfieldkey('CustomerCode', 'customer_code', '', $object, 0).'</td><td>';
+
 				print '<table class="nobordernopadding"><tr><td>';
-				if ((!$object->code_fournisseur || $object->code_fournisseur == -1) && $modCodeFournisseur->code_auto) {
-					$tmpcode = $object->code_fournisseur;
-					if (empty($tmpcode) && !empty($object->oldcopy->code_fournisseur)) {
-						$tmpcode = $object->oldcopy->code_fournisseur; // When there is an error to update a thirdparty, the number for supplier and customer code is kept to old value.
+				if ((!$object->code_client || $object->code_client == -1) && $modCodeClient->code_auto) {
+					$tmpcode = $object->code_client;
+					if (empty($tmpcode) && !empty($object->oldcopy->code_client)) {
+						$tmpcode = $object->oldcopy->code_client; // When there is an error to update a thirdparty, the number for supplier and customer code is kept to old value.
 					}
-					if (empty($tmpcode) && !empty($modCodeFournisseur->code_auto)) {
-						$tmpcode = $modCodeFournisseur->getNextValue($object, 1);
+					if (empty($tmpcode) && !empty($modCodeClient->code_auto)) {
+						$tmpcode = $modCodeClient->getNextValue($object, 0);
 					}
-					print '<input type="text" name="supplier_code" id="supplier_code" size="16" value="'.dol_escape_htmltag($tmpcode).'" maxlength="24">';
-				} elseif ($object->codefournisseur_modifiable()) {
-					print '<input type="text" name="supplier_code" id="supplier_code" size="16" value="'.dol_escape_htmltag($object->code_fournisseur).'" maxlength="24">';
+					print '<input type="text" name="customer_code" id="customer_code" size="16" value="'.dol_escape_htmltag($tmpcode).'" maxlength="24">';
+				} elseif ($object->codeclient_modifiable()) {
+					print '<input type="text" name="customer_code" id="customer_code" size="16" value="'.dol_escape_htmltag($object->code_client).'" maxlength="24">';
 				} else {
-					print $object->code_fournisseur;
-					print '<input type="hidden" name="supplier_code" value="'.$object->code_fournisseur.'">';
+					print $object->code_client;
+					print '<input type="hidden" name="customer_code" value="'.dol_escape_htmltag($object->code_client).'">';
 				}
 				print '</td><td>';
-				$s = $modCodeFournisseur->getToolTip($langs, $object, 1);
+				$s = $modCodeClient->getToolTip($langs, $object, 0);
 				print $form->textwithpicto('', $s, 1);
 				print '</td></tr></table>';
+
 				print '</td></tr>';
-			}
 
-			// Barcode
-			if (isModEnabled('barcode')) {
-				print '<tr><td class="tdtop">'.$form->editfieldkey('Gencod', 'barcode', '', $object, 0).'</td>';
-				print '<td colspan="3">';
-				print img_picto('', 'barcode');
-				print '<input type="text" name="barcode" id="barcode" value="'.dol_escape_htmltag($object->barcode).'">';
-				print '</td></tr>';
-			}
-
-			// Status
-			print '<tr><td>'.$form->editfieldkey('Status', 'status', '', $object, 0).'</td><td colspan="3">';
-			print $form->selectarray('status', array('0'=>$langs->trans('ActivityCeased'), '1'=>$langs->trans('InActivity')), $object->status, 0, 0, 0, '', 0, 0, 0, '', 'minwidth100', 1);
-			print '</td></tr>';
-
-			// Address
-			print '<tr><td class="tdtop">'.$form->editfieldkey('Address', 'address', '', $object, 0).'</td>';
-			print '<td colspan="3"><textarea name="address" id="address" class="quatrevingtpercent" rows="3" wrap="soft">';
-			print dol_escape_htmltag($object->address, 0, 1);
-			print '</textarea>';
-			print $form->widgetForTranslation("address", $object, $permissiontoadd, 'textarea', 'alphanohtml', 'quatrevingtpercent');
-			print '</td></tr>';
-
-			// Zip / Town
-			print '<tr><td>'.$form->editfieldkey('Zip', 'zipcode', '', $object, 0).'</td><td'.($conf->browser->layout == 'phone' ? ' colspan="3"': '').'>';
-			print $formcompany->select_ziptown($object->zip, 'zipcode', array('town', 'selectcountry_id', 'state_id'), 0, 0, '', 'maxwidth100');
-			print '</td>';
-			if ($conf->browser->layout == 'phone') {
-				print '</tr><tr>';
-			}
-			print '<td>'.$form->editfieldkey('Town', 'town', '', $object, 0).'</td><td'.($conf->browser->layout == 'phone' ? ' colspan="3"': '').'>';
-			print $formcompany->select_ziptown($object->town, 'town', array('zipcode', 'selectcountry_id', 'state_id'));
-			print $form->widgetForTranslation("town", $object, $permissiontoadd, 'string', 'alphanohtml', 'maxwidth100 quatrevingtpercent');
-			print '</td></tr>';
-
-			// Country
-			print '<tr><td>'.$form->editfieldkey('Country', 'selectcounty_id', '', $object, 0).'</td><td colspan="3">';
-			print img_picto('', 'globe-americas', 'class="paddingrightonly"');
-			print $form->select_country((GETPOSTISSET('country_id') ? GETPOST('country_id') : $object->country_id), 'country_id', '', 0, 'minwidth300 maxwidth500 widthcentpercentminusx');
-			if ($user->admin) {
-				print info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"), 1);
-			}
-			print '</td></tr>';
-
-			// State
-			if (empty($conf->global->SOCIETE_DISABLE_STATE)) {
-				if ((getDolGlobalInt('MAIN_SHOW_REGION_IN_STATE_SELECT') == 1 || getDolGlobalInt('MAIN_SHOW_REGION_IN_STATE_SELECT') == 2)) {
-					print '<tr><td>'.$form->editfieldkey('Region-State', 'state_id', '', $object, 0).'</td><td colspan="3">';
-				} else {
-					print '<tr><td>'.$form->editfieldkey('State', 'state_id', '', $object, 0).'</td><td colspan="3">';
-				}
-
-				print img_picto('', 'state', 'class="pictofixedwidth"');
-				print $formcompany->select_state($object->state_id, $object->country_code);
-				print '</td></tr>';
-			}
-
-			// Phone / Fax
-			print '<tr><td>'.$form->editfieldkey('Phone', 'phone', GETPOST('phone', 'alpha'), $object, 0).'</td>';
-			print '<td'.($conf->browser->layout == 'phone' ? ' colspan="3"': '').'>'.img_picto('', 'object_phoning', 'class="pictofixedwidth"').' <input type="text" name="phone" id="phone" class="maxwidth200 widthcentpercentminusx" value="'.(GETPOSTISSET('phone') ? GETPOST('phone', 'alpha') : $object->phone).'"></td>';
-			if ($conf->browser->layout == 'phone') {
-				print '</tr><tr>';
-			}
-			print '<td>'.$form->editfieldkey('Fax', 'fax', GETPOST('fax', 'alpha'), $object, 0).'</td>';
-			print '<td'.($conf->browser->layout == 'phone' ? ' colspan="3"': '').'>'.img_picto('', 'object_phoning_fax', 'class="pictofixedwidth"').' <input type="text" name="fax" id="fax" class="maxwidth200 widthcentpercentminusx" value="'.(GETPOSTISSET('fax') ? GETPOST('fax', 'alpha') : $object->fax).'"></td>';
-			print '</tr>';
-
-			// Web
-			print '<tr><td>'.$form->editfieldkey('Web', 'url', GETPOST('url', 'alpha'), $object, 0).'</td>';
-			print '<td colspan="3">'.img_picto('', 'globe', 'class="pictofixedwidth"').' <input type="text" name="url" id="url" class="maxwidth200onsmartphone maxwidth300 widthcentpercentminusx " value="'.(GETPOSTISSET('url') ?GETPOST('url', 'alpha') : $object->url).'"></td></tr>';
-
-			// EMail
-			print '<tr><td>'.$form->editfieldkey('EMail', 'email', GETPOST('email', 'alpha'), $object, 0, 'string', '', (!empty($conf->global->SOCIETE_EMAIL_MANDATORY))).'</td>';
-			print '<td colspan="3">';
-			print img_picto('', 'object_email', 'class="pictofixedwidth"');
-			print '<input type="text" name="email" id="email" class="maxwidth500 widthcentpercentminusx" value="'.(GETPOSTISSET('email') ?GETPOST('email', 'alpha') : $object->email).'">';
-			print '</td></tr>';
-
-			// Unsubscribe
-			if (isModEnabled('mailing')) {
-				if ($conf->use_javascript_ajax && getDolGlobalInt('MAILING_CONTACT_DEFAULT_BULK_STATUS') == 2) {
-					print "\n".'<script type="text/javascript">'."\n";
-
-					print '
-					jQuery(document).ready(function () {
-						function init_check_no_email(input) {
-							if (input.val()!="") {
-								$(".noemail").addClass("fieldrequired");
-							} else {
-								$(".noemail").removeClass("fieldrequired");
-							}
-						}
-						$("#email").keyup(function() {
-							init_check_no_email($(this));
-						});
-						init_check_no_email($("#email"));
-					})'."\n";
-					print '</script>'."\n";
-				}
-				if (!GETPOSTISSET("no_email") && !empty($object->email)) {
-					$result = $object->getNoEmail();
-					if ($result < 0) {
-						setEventMessages($object->error, $object->errors, 'errors');
-					}
-				}
-				print '<tr>';
-				print '<td class="noemail"><label for="no_email">'.$langs->trans("No_Email").'</label></td>';
-				print '<td>';
-				$useempty = (getDolGlobalInt('MAILING_CONTACT_DEFAULT_BULK_STATUS') == 2);
-				print $form->selectyesno('no_email', (GETPOSTISSET("no_email") ? GETPOST("no_email", 'int') : $object->no_email), 1, false, $useempty);
-				print '</td>';
-				print '</tr>';
-			}
-
-			// Social network
-			if (isModEnabled('socialnetworks')) {
-				$object->showSocialNetwork($socialnetworks, ($conf->browser->layout == 'phone' ? 2 : 4));
-			}
-
-			// Prof ids
-			$i = 1;
-			$j = 0;
-			$NBCOLS = ($conf->browser->layout == 'phone' ? 1 : 2);
-			while ($i <= 6) {
-				$idprof = $langs->transcountry('ProfId'.$i, $object->country_code);
-				if ($idprof != '-') {
-					$key = 'idprof'.$i;
-
-					if (($j % $NBCOLS) == 0) {
-						print '<tr>';
-					}
-
-					$idprof_mandatory = 'SOCIETE_IDPROF'.($i).'_MANDATORY';
-					print '<td>'.$form->editfieldkey($idprof, $key, '', $object, 0, 'string', '', !(empty($conf->global->$idprof_mandatory) || !$object->isACompany())).'</td><td>';
-					print $formcompany->get_input_id_prof($i, $key, $object->$key, $object->country_code);
+				// Supplier
+				if (((isModEnabled("fournisseur") && $user->hasRight('fournisseur', 'lire') && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || (isModEnabled("supplier_order") && $user->hasRight('supplier_order', 'lire')) || (isModEnabled("supplier_invoice") && $user->hasRight('supplier_invoice', 'lire')))
+					|| (isModEnabled('supplier_proposal') && $user->hasRight('supplier_proposal', 'lire'))) {
+					print '<tr>';
+					print '<td>'.$form->editfieldkey('Supplier', 'fournisseur', '', $object, 0, 'string', '', 1).'</td>';
+					print '<td class="maxwidthonsmartphone">';
+					print $form->selectyesno("fournisseur", $object->fournisseur, 1, false, 0, 1);
 					print '</td>';
-					if (($j % $NBCOLS) == ($NBCOLS - 1)) {
-						print '</tr>';
+					if ($conf->browser->layout == 'phone') {
+						print '</tr><tr>';
 					}
-					$j++;
-				}
-				$i++;
-			}
-			if ($NBCOLS > 0 && $j % 2 == 1) {
-				print '<td colspan="2"></td></tr>';
-			}
-
-			// VAT is used
-			print '<tr><td>'.$form->editfieldkey('VATIsUsed', 'assujtva_value', '', $object, 0).'</td><td colspan="3">';
-			print '<input id="assujtva_value" name="assujtva_value" type="checkbox" ' . ($object->tva_assuj ? 'checked="checked"': '') . ' value="1">';
-			print '</td></tr>';
-
-			// Local Taxes
-			//TODO: Place into a function to control showing by country or study better option
-			if ($mysoc->localtax1_assuj == "1" && $mysoc->localtax2_assuj == "1") {
-				print '<tr><td>'.$form->editfieldkey($langs->transcountry("LocalTax1IsUsed", $mysoc->country_code), 'localtax1assuj_value', '', $object, 0).'</td><td>';
-				print '<input id="localtax1assuj_value" name="localtax1assuj_value" type="checkbox" ' . ($object->localtax1_assuj ? 'checked="checked"' : '') . ' value="1">';
-				if (!isOnlyOneLocalTax(1)) {
-					print '<span class="cblt1">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
-					$formcompany->select_localtax(1, $object->localtax1_value, "lt1");
-					print '</span>';
-				}
-				print '</td>';
-				print '</tr><tr>';
-				print '<td>'.$form->editfieldkey($langs->transcountry("LocalTax2IsUsed", $mysoc->country_code), 'localtax2assuj_value', '', $object, 0).'</td><td>';
-				print '<input id="localtax2assuj_value" name="localtax2assuj_value" type="checkbox" ' . ($object->localtax2_assuj ? 'checked="checked"' : '') . ' value="1"></td></tr>';
-				if (!isOnlyOneLocalTax(2)) {
-					print '<span class="cblt2">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
-					$formcompany->select_localtax(2, $object->localtax2_value, "lt2");
-					print '</span>';
-				}
-				print '</td></tr>';
-			} elseif ($mysoc->localtax1_assuj == "1" && $mysoc->localtax2_assuj != "1") {
-				print '<tr><td>'.$form->editfieldkey($langs->transcountry("LocalTax1IsUsed", $mysoc->country_code), 'localtax1assuj_value', '', $object, 0).'</td><td colspan="3">';
-				print '<input id="localtax1assuj_value" name="localtax1assuj_value" type="checkbox" ' . ($object->localtax1_assuj ? 'checked="checked"' : '') . ' value="1">';
-				if (!isOnlyOneLocalTax(1)) {
-					print '<span class="cblt1">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
-					$formcompany->select_localtax(1, $object->localtax1_value, "lt1");
-					print '</span>';
-				}
-				print '</td></tr>';
-			} elseif ($mysoc->localtax2_assuj == "1" && $mysoc->localtax1_assuj != "1") {
-				print '<tr><td>'.$form->editfieldkey($langs->transcountry("LocalTax2IsUsed", $mysoc->country_code), 'localtax2assuj_value', '', $object, 0).'</td><td colspan="3">';
-				print '<input id="localtax2assuj_value" name="localtax2assuj_value" type="checkbox" ' . ($object->localtax2_assuj ? 'checked="checked"' : '') . ' value="1">';
-				if (!isOnlyOneLocalTax(2)) {
-					print '<span class="cblt2">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
-					$formcompany->select_localtax(2, $object->localtax2_value, "lt2");
-					print '</span>';
-				}
-				print '</td></tr>';
-			}
-
-			// VAT reverse charge by default
-			if (!empty($conf->global->ACCOUNTING_FORCE_ENABLE_VAT_REVERSE_CHARGE)) {
-				print '<tr><td>' . $form->editfieldkey('VATReverseChargeByDefault', 'vat_reverse_charge', '', $object, 0) . '</td><td colspan="3">';
-				print '<input type="checkbox" name="vat_reverse_charge" '.($object->vat_reverse_charge == '1' ? ' checked' : '').'>';
-				print '</td></tr>';
-			}
-
-			// VAT Code
-			print '<tr><td>'.$form->editfieldkey('VATIntra', 'intra_vat', '', $object, 0).'</td>';
-			print '<td colspan="3">';
-			$s = '<input type="text" class="flat maxwidthonsmartphone" name="tva_intra" id="intra_vat" maxlength="20" value="'.$object->tva_intra.'">';
-
-			if (empty($conf->global->MAIN_DISABLEVATCHECK) && isInEEC($object)) {
-				$s .= ' &nbsp; ';
-
-				if ($conf->use_javascript_ajax) {
-					$widthpopup = 600;
-					if (!empty($conf->dol_use_jmobile)) {
-						$widthpopup = 350;
+					print '<td>';
+					if ((isModEnabled("fournisseur") && $user->hasRight('fournisseur', 'lire') && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || (isModEnabled("supplier_order") && $user->hasRight('supplier_order', 'lire')) || (isModEnabled("supplier_invoice") && $user->hasRight('supplier_invoice', 'lire'))) {
+						print $form->editfieldkey('SupplierCode', 'supplier_code', '', $object, 0);
 					}
-					$heightpopup = 400;
-					print "\n";
-					print '<script type="text/javascript">';
-					print "function CheckVAT(a) {\n";
-					if ($mysoc->country_code == 'GR' && $object->country_code == 'GR' && !empty($u)) {
-						print "GRVAT(a,'{$u}','{$p}','{$myafm}');\n";
+					print '</td>';
+					print '<td>';
+					print '<table class="nobordernopadding"><tr><td>';
+					if ((!$object->code_fournisseur || $object->code_fournisseur == -1) && $modCodeFournisseur->code_auto) {
+						$tmpcode = $object->code_fournisseur;
+						if (empty($tmpcode) && !empty($object->oldcopy->code_fournisseur)) {
+							$tmpcode = $object->oldcopy->code_fournisseur; // When there is an error to update a thirdparty, the number for supplier and customer code is kept to old value.
+						}
+						if (empty($tmpcode) && !empty($modCodeFournisseur->code_auto)) {
+							$tmpcode = $modCodeFournisseur->getNextValue($object, 1);
+						}
+						print '<input type="text" name="supplier_code" id="supplier_code" size="16" value="'.dol_escape_htmltag($tmpcode).'" maxlength="24">';
+					} elseif ($object->codefournisseur_modifiable()) {
+						print '<input type="text" name="supplier_code" id="supplier_code" size="16" value="'.dol_escape_htmltag($object->code_fournisseur).'" maxlength="24">';
 					} else {
-						print "newpopup('".DOL_URL_ROOT."/societe/checkvat/checkVatPopup.php?vatNumber='+a, '".dol_escape_js($langs->trans("VATIntraCheckableOnEUSite"))."', ".$widthpopup.", ".$heightpopup.");\n";
+						print $object->code_fournisseur;
+						print '<input type="hidden" name="supplier_code" value="'.$object->code_fournisseur.'">';
 					}
-					print "}\n";
-					print '</script>';
-					print "\n";
-					$s .= '<a href="#" class="hideonsmartphone" onclick="CheckVAT(document.formsoc.tva_intra.value);">'.$langs->trans("VATIntraCheck").'</a>';
-					$s = $form->textwithpicto($s, $langs->trans("VATIntraCheckDesc", $langs->transnoentitiesnoconv("VATIntraCheck")), 1);
-				} else {
-					$s .= '<a href="'.$langs->transcountry("VATIntraCheckURL", $object->country_id).'" class="hideonsmartphone" target="_blank" rel="noopener noreferrer">'.img_picto($langs->trans("VATIntraCheckableOnEUSite"), 'help').'</a>';
+					print '</td><td>';
+					$s = $modCodeFournisseur->getToolTip($langs, $object, 1);
+					print $form->textwithpicto('', $s, 1);
+					print '</td></tr></table>';
+					print '</td></tr>';
 				}
-			}
-			print $s;
-			print '</td>';
-			print '</tr>';
 
-			// Type - Workforce/Staff
-			print '<tr><td>'.$form->editfieldkey('ThirdPartyType', 'typent_id', '', $object, 0).'</td><td class="maxwidthonsmartphone"'.( ($conf->browser->layout == 'phone' || !empty($conf->global->SOCIETE_DISABLE_WORKFORCE)) ? ' colspan="3"' : '').'>';
-			print $form->selectarray("typent_id", $formcompany->typent_array(0), $object->typent_id, 1, 0, 0, '', 0, 0, 0, (empty($conf->global->SOCIETE_SORT_ON_TYPEENT) ? 'ASC' : $conf->global->SOCIETE_SORT_ON_TYPEENT), '', 1);
-			if ($user->admin) {
-				print info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"), 1);
-			}
-			if (empty($conf->global->SOCIETE_DISABLE_WORKFORCE)) {
+				// Barcode
+				if (isModEnabled('barcode')) {
+					print '<tr><td class="tdtop">'.$form->editfieldkey('Gencod', 'barcode', '', $object, 0).'</td>';
+					print '<td colspan="3">';
+					print img_picto('', 'barcode');
+					print '<input type="text" name="barcode" id="barcode" value="'.dol_escape_htmltag($object->barcode).'">';
+					print '</td></tr>';
+				}
+
+				// Status
+				print '<tr><td>'.$form->editfieldkey('Status', 'status', '', $object, 0).'</td><td colspan="3">';
+				print $form->selectarray('status', array('0'=>$langs->trans('ActivityCeased'), '1'=>$langs->trans('InActivity')), $object->status, 0, 0, 0, '', 0, 0, 0, '', 'minwidth100', 1);
+				print '</td></tr>';
+
+				// Address
+				print '<tr><td class="tdtop">'.$form->editfieldkey('Address', 'address', '', $object, 0).'</td>';
+				print '<td colspan="3"><textarea name="address" id="address" class="quatrevingtpercent" rows="3" wrap="soft">';
+				print dol_escape_htmltag($object->address, 0, 1);
+				print '</textarea>';
+				print $form->widgetForTranslation("address", $object, $permissiontoadd, 'textarea', 'alphanohtml', 'quatrevingtpercent');
+				print '</td></tr>';
+
+				// Zip / Town
+				print '<tr><td>'.$form->editfieldkey('Zip', 'zipcode', '', $object, 0).'</td><td'.($conf->browser->layout == 'phone' ? ' colspan="3"': '').'>';
+				print $formcompany->select_ziptown($object->zip, 'zipcode', array('town', 'selectcountry_id', 'state_id'), 0, 0, '', 'maxwidth100');
 				print '</td>';
 				if ($conf->browser->layout == 'phone') {
 					print '</tr><tr>';
 				}
-				print '<td>'.$form->editfieldkey('Workforce', 'effectif_id', '', $object, 0).'</td><td class="maxwidthonsmartphone">';
-				print $form->selectarray("effectif_id", $formcompany->effectif_array(0), $object->effectif_id, 0, 0, 0, '', 0, 0, 0, '', '', 1);
+				print '<td>'.$form->editfieldkey('Town', 'town', '', $object, 0).'</td><td'.($conf->browser->layout == 'phone' ? ' colspan="3"': '').'>';
+				print $formcompany->select_ziptown($object->town, 'town', array('zipcode', 'selectcountry_id', 'state_id'));
+				print $form->widgetForTranslation("town", $object, $permissiontoadd, 'string', 'alphanohtml', 'maxwidth100 quatrevingtpercent');
+				print '</td></tr>';
+
+				// Country
+				print '<tr><td>'.$form->editfieldkey('Country', 'selectcounty_id', '', $object, 0).'</td><td colspan="3">';
+				print img_picto('', 'globe-americas', 'class="paddingrightonly"');
+				print $form->select_country((GETPOSTISSET('country_id') ? GETPOST('country_id') : $object->country_id), 'country_id', '', 0, 'minwidth300 maxwidth500 widthcentpercentminusx');
 				if ($user->admin) {
 					print info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"), 1);
 				}
-			} else {
-				print '<input type="hidden" name="effectif_id" id="effectif_id" value="'.$object->effectif_id.'">';
-			}
-			print '</td></tr>';
+				print '</td></tr>';
 
-			// Juridical type
-			print '<tr><td>'.$form->editfieldkey('JuridicalStatus', 'forme_juridique_code', '', $object, 0).'</td><td class="maxwidthonsmartphone" colspan="3">';
-			print $formcompany->select_juridicalstatus($object->forme_juridique_code, $object->country_code, '', 'forme_juridique_code');
-			print '</td></tr>';
+				// State
+				if (empty($conf->global->SOCIETE_DISABLE_STATE)) {
+					if ((getDolGlobalInt('MAIN_SHOW_REGION_IN_STATE_SELECT') == 1 || getDolGlobalInt('MAIN_SHOW_REGION_IN_STATE_SELECT') == 2)) {
+						print '<tr><td>'.$form->editfieldkey('Region-State', 'state_id', '', $object, 0).'</td><td colspan="3">';
+					} else {
+						print '<tr><td>'.$form->editfieldkey('State', 'state_id', '', $object, 0).'</td><td colspan="3">';
+					}
 
-			// Capital
-			print '<tr><td>'.$form->editfieldkey('Capital', 'capital', '', $object, 0).'</td>';
-			print '<td colspan="3"><input type="text" name="capital" id="capital" size="10" value="';
-			print $object->capital != '' ? dol_escape_htmltag(price($object->capital)) : '';
-			if (isModEnabled("multicurrency")) {
-				print '"> <span class="hideonsmartphone">'.$langs->trans("Currency".$object->multicurrency_code).'</span></td></tr>';
-			} else {
-				print '"> <span class="hideonsmartphone">'.$langs->trans("Currency".$conf->currency).'</span></td></tr>';
-			}
+					print img_picto('', 'state', 'class="pictofixedwidth"');
+					print $formcompany->select_state($object->state_id, $object->country_code);
+					print '</td></tr>';
+				}
 
-			// Default language
-			if (getDolGlobalInt('MAIN_MULTILANGS')) {
-				print '<tr><td>'.$form->editfieldkey('DefaultLang', 'default_lang', '', $object, 0).'</td><td colspan="3">'."\n";
-				print img_picto('', 'language', 'class="pictofixedwidth"').$formadmin->select_language($object->default_lang, 'default_lang', 0, null, '1', 0, 0, 'maxwidth300 widthcentpercentminusx');
+				// Phone / Fax
+				print '<tr><td>'.$form->editfieldkey('Phone', 'phone', GETPOST('phone', 'alpha'), $object, 0).'</td>';
+				print '<td'.($conf->browser->layout == 'phone' ? ' colspan="3"': '').'>'.img_picto('', 'object_phoning', 'class="pictofixedwidth"').' <input type="text" name="phone" id="phone" class="maxwidth200 widthcentpercentminusx" value="'.(GETPOSTISSET('phone') ? GETPOST('phone', 'alpha') : $object->phone).'"></td>';
+				if ($conf->browser->layout == 'phone') {
+					print '</tr><tr>';
+				}
+				print '<td>'.$form->editfieldkey('Fax', 'fax', GETPOST('fax', 'alpha'), $object, 0).'</td>';
+				print '<td'.($conf->browser->layout == 'phone' ? ' colspan="3"': '').'>'.img_picto('', 'object_phoning_fax', 'class="pictofixedwidth"').' <input type="text" name="fax" id="fax" class="maxwidth200 widthcentpercentminusx" value="'.(GETPOSTISSET('fax') ? GETPOST('fax', 'alpha') : $object->fax).'"></td>';
+				print '</tr>';
+
+				// Web
+				print '<tr><td>'.$form->editfieldkey('Web', 'url', GETPOST('url', 'alpha'), $object, 0).'</td>';
+				print '<td colspan="3">'.img_picto('', 'globe', 'class="pictofixedwidth"').' <input type="text" name="url" id="url" class="maxwidth200onsmartphone maxwidth300 widthcentpercentminusx " value="'.(GETPOSTISSET('url') ?GETPOST('url', 'alpha') : $object->url).'"></td></tr>';
+
+				// EMail
+				print '<tr><td>'.$form->editfieldkey('EMail', 'email', GETPOST('email', 'alpha'), $object, 0, 'string', '', (!empty($conf->global->SOCIETE_EMAIL_MANDATORY))).'</td>';
+				print '<td colspan="3">';
+				print img_picto('', 'object_email', 'class="pictofixedwidth"');
+				print '<input type="text" name="email" id="email" class="maxwidth500 widthcentpercentminusx" value="'.(GETPOSTISSET('email') ?GETPOST('email', 'alpha') : $object->email).'">';
+				print '</td></tr>';
+
+				// Unsubscribe
+				if (isModEnabled('mailing')) {
+					if ($conf->use_javascript_ajax && getDolGlobalInt('MAILING_CONTACT_DEFAULT_BULK_STATUS') == 2) {
+						print "\n".'<script type="text/javascript">'."\n";
+
+						print '
+						jQuery(document).ready(function () {
+							function init_check_no_email(input) {
+								if (input.val()!="") {
+									$(".noemail").addClass("fieldrequired");
+								} else {
+									$(".noemail").removeClass("fieldrequired");
+								}
+							}
+							$("#email").keyup(function() {
+								init_check_no_email($(this));
+							});
+							init_check_no_email($("#email"));
+						})'."\n";
+						print '</script>'."\n";
+					}
+					if (!GETPOSTISSET("no_email") && !empty($object->email)) {
+						$result = $object->getNoEmail();
+						if ($result < 0) {
+							setEventMessages($object->error, $object->errors, 'errors');
+						}
+					}
+					print '<tr>';
+					print '<td class="noemail"><label for="no_email">'.$langs->trans("No_Email").'</label></td>';
+					print '<td>';
+					$useempty = (getDolGlobalInt('MAILING_CONTACT_DEFAULT_BULK_STATUS') == 2);
+					print $form->selectyesno('no_email', (GETPOSTISSET("no_email") ? GETPOST("no_email", 'int') : $object->no_email), 1, false, $useempty);
+					print '</td>';
+					print '</tr>';
+				}
+
+				// Social network
+				if (isModEnabled('socialnetworks')) {
+					$object->showSocialNetwork($socialnetworks, ($conf->browser->layout == 'phone' ? 2 : 4));
+				}
+
+				// Prof ids
+				$i = 1;
+				$j = 0;
+				$NBCOLS = ($conf->browser->layout == 'phone' ? 1 : 2);
+				while ($i <= 6) {
+					$idprof = $langs->transcountry('ProfId'.$i, $object->country_code);
+					if ($idprof != '-') {
+						$key = 'idprof'.$i;
+
+						if (($j % $NBCOLS) == 0) {
+							print '<tr>';
+						}
+
+						$idprof_mandatory = 'SOCIETE_IDPROF'.($i).'_MANDATORY';
+						print '<td>'.$form->editfieldkey($idprof, $key, '', $object, 0, 'string', '', !(empty($conf->global->$idprof_mandatory) || !$object->isACompany())).'</td><td>';
+						print $formcompany->get_input_id_prof($i, $key, $object->$key, $object->country_code);
+						print '</td>';
+						if (($j % $NBCOLS) == ($NBCOLS - 1)) {
+							print '</tr>';
+						}
+						$j++;
+					}
+					$i++;
+				}
+				if ($NBCOLS > 0 && $j % 2 == 1) {
+					print '<td colspan="2"></td></tr>';
+				}
+
+				// VAT is used
+				print '<tr><td>'.$form->editfieldkey('VATIsUsed', 'assujtva_value', '', $object, 0).'</td><td colspan="3">';
+				print '<input id="assujtva_value" name="assujtva_value" type="checkbox" ' . ($object->tva_assuj ? 'checked="checked"': '') . ' value="1">';
+				print '</td></tr>';
+
+				// Local Taxes
+				//TODO: Place into a function to control showing by country or study better option
+				if ($mysoc->localtax1_assuj == "1" && $mysoc->localtax2_assuj == "1") {
+					print '<tr><td>'.$form->editfieldkey($langs->transcountry("LocalTax1IsUsed", $mysoc->country_code), 'localtax1assuj_value', '', $object, 0).'</td><td>';
+					print '<input id="localtax1assuj_value" name="localtax1assuj_value" type="checkbox" ' . ($object->localtax1_assuj ? 'checked="checked"' : '') . ' value="1">';
+					if (!isOnlyOneLocalTax(1)) {
+						print '<span class="cblt1">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
+						$formcompany->select_localtax(1, $object->localtax1_value, "lt1");
+						print '</span>';
+					}
+					print '</td>';
+					print '</tr><tr>';
+					print '<td>'.$form->editfieldkey($langs->transcountry("LocalTax2IsUsed", $mysoc->country_code), 'localtax2assuj_value', '', $object, 0).'</td><td>';
+					print '<input id="localtax2assuj_value" name="localtax2assuj_value" type="checkbox" ' . ($object->localtax2_assuj ? 'checked="checked"' : '') . ' value="1"></td></tr>';
+					if (!isOnlyOneLocalTax(2)) {
+						print '<span class="cblt2">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
+						$formcompany->select_localtax(2, $object->localtax2_value, "lt2");
+						print '</span>';
+					}
+					print '</td></tr>';
+				} elseif ($mysoc->localtax1_assuj == "1" && $mysoc->localtax2_assuj != "1") {
+					print '<tr><td>'.$form->editfieldkey($langs->transcountry("LocalTax1IsUsed", $mysoc->country_code), 'localtax1assuj_value', '', $object, 0).'</td><td colspan="3">';
+					print '<input id="localtax1assuj_value" name="localtax1assuj_value" type="checkbox" ' . ($object->localtax1_assuj ? 'checked="checked"' : '') . ' value="1">';
+					if (!isOnlyOneLocalTax(1)) {
+						print '<span class="cblt1">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
+						$formcompany->select_localtax(1, $object->localtax1_value, "lt1");
+						print '</span>';
+					}
+					print '</td></tr>';
+				} elseif ($mysoc->localtax2_assuj == "1" && $mysoc->localtax1_assuj != "1") {
+					print '<tr><td>'.$form->editfieldkey($langs->transcountry("LocalTax2IsUsed", $mysoc->country_code), 'localtax2assuj_value', '', $object, 0).'</td><td colspan="3">';
+					print '<input id="localtax2assuj_value" name="localtax2assuj_value" type="checkbox" ' . ($object->localtax2_assuj ? 'checked="checked"' : '') . ' value="1">';
+					if (!isOnlyOneLocalTax(2)) {
+						print '<span class="cblt2">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
+						$formcompany->select_localtax(2, $object->localtax2_value, "lt2");
+						print '</span>';
+					}
+					print '</td></tr>';
+				}
+
+				// VAT reverse charge by default
+				if (!empty($conf->global->ACCOUNTING_FORCE_ENABLE_VAT_REVERSE_CHARGE)) {
+					print '<tr><td>' . $form->editfieldkey('VATReverseChargeByDefault', 'vat_reverse_charge', '', $object, 0) . '</td><td colspan="3">';
+					print '<input type="checkbox" name="vat_reverse_charge" '.($object->vat_reverse_charge == '1' ? ' checked' : '').'>';
+					print '</td></tr>';
+				}
+
+				// VAT Code
+				print '<tr><td>'.$form->editfieldkey('VATIntra', 'intra_vat', '', $object, 0).'</td>';
+				print '<td colspan="3">';
+				$s = '<input type="text" class="flat maxwidthonsmartphone" name="tva_intra" id="intra_vat" maxlength="20" value="'.$object->tva_intra.'">';
+
+				if (empty($conf->global->MAIN_DISABLEVATCHECK) && isInEEC($object)) {
+					$s .= ' &nbsp; ';
+
+					if ($conf->use_javascript_ajax) {
+						$widthpopup = 600;
+						if (!empty($conf->dol_use_jmobile)) {
+							$widthpopup = 350;
+						}
+						$heightpopup = 400;
+						print "\n";
+						print '<script type="text/javascript">';
+						print "function CheckVAT(a) {\n";
+						if ($mysoc->country_code == 'GR' && $object->country_code == 'GR' && !empty($u)) {
+							print "GRVAT(a,'{$u}','{$p}','{$myafm}');\n";
+						} else {
+							print "newpopup('".DOL_URL_ROOT."/societe/checkvat/checkVatPopup.php?vatNumber='+a, '".dol_escape_js($langs->trans("VATIntraCheckableOnEUSite"))."', ".$widthpopup.", ".$heightpopup.");\n";
+						}
+						print "}\n";
+						print '</script>';
+						print "\n";
+						$s .= '<a href="#" class="hideonsmartphone" onclick="CheckVAT(document.formsoc.tva_intra.value);">'.$langs->trans("VATIntraCheck").'</a>';
+						$s = $form->textwithpicto($s, $langs->trans("VATIntraCheckDesc", $langs->transnoentitiesnoconv("VATIntraCheck")), 1);
+					} else {
+						$s .= '<a href="'.$langs->transcountry("VATIntraCheckURL", $object->country_id).'" class="hideonsmartphone" target="_blank" rel="noopener noreferrer">'.img_picto($langs->trans("VATIntraCheckableOnEUSite"), 'help').'</a>';
+					}
+				}
+				print $s;
 				print '</td>';
 				print '</tr>';
-			}
 
-			// Incoterms
-			if (isModEnabled('incoterm')) {
-				print '<tr>';
-					print '<td>'.$form->editfieldkey('IncotermLabel', 'incoterm_id', '', $object, 0).'</td>';
-				print '<td colspan="3" class="maxwidthonsmartphone">';
-				print $form->select_incoterms((!empty($object->fk_incoterms) ? $object->fk_incoterms : ''), (!empty($object->location_incoterms) ? $object->location_incoterms : ''));
-				print '</td></tr>';
-			}
-
-			// Categories
-			if (isModEnabled('categorie') && $user->hasRight('categorie', 'lire')) {
-				// Customer
-				print '<tr class="visibleifcustomer"><td>'.$form->editfieldkey('CustomersCategoriesShort', 'custcats', '', $object, 0).'</td>';
-				print '<td colspan="3">';
-				$cate_arbo = $form->select_all_categories(Categorie::TYPE_CUSTOMER, null, null, null, null, 1);
-				$c = new Categorie($db);
-				$cats = $c->containing($object->id, Categorie::TYPE_CUSTOMER);
-				$arrayselected = array();
-				foreach ($cats as $cat) {
-					$arrayselected[] = $cat->id;
+				// Type - Workforce/Staff
+				print '<tr><td>'.$form->editfieldkey('ThirdPartyType', 'typent_id', '', $object, 0).'</td><td class="maxwidthonsmartphone"'.( ($conf->browser->layout == 'phone' || !empty($conf->global->SOCIETE_DISABLE_WORKFORCE)) ? ' colspan="3"' : '').'>';
+				print $form->selectarray("typent_id", $formcompany->typent_array(0), $object->typent_id, 1, 0, 0, '', 0, 0, 0, (empty($conf->global->SOCIETE_SORT_ON_TYPEENT) ? 'ASC' : $conf->global->SOCIETE_SORT_ON_TYPEENT), '', 1);
+				if ($user->admin) {
+					print info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"), 1);
 				}
-				print img_picto('', 'category', 'class="pictofixedwidth"').$form->multiselectarray('custcats', $cate_arbo, $arrayselected, 0, 0, 'quatrevingtpercent widthcentpercentminusx', 0, 0);
-				print "</td></tr>";
+				if (empty($conf->global->SOCIETE_DISABLE_WORKFORCE)) {
+					print '</td>';
+					if ($conf->browser->layout == 'phone') {
+						print '</tr><tr>';
+					}
+					print '<td>'.$form->editfieldkey('Workforce', 'effectif_id', '', $object, 0).'</td><td class="maxwidthonsmartphone">';
+					print $form->selectarray("effectif_id", $formcompany->effectif_array(0), $object->effectif_id, 0, 0, 0, '', 0, 0, 0, '', '', 1);
+					if ($user->admin) {
+						print info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"), 1);
+					}
+				} else {
+					print '<input type="hidden" name="effectif_id" id="effectif_id" value="'.$object->effectif_id.'">';
+				}
+				print '</td></tr>';
 
-				// Supplier
-				if ((isModEnabled("fournisseur") && $user->hasRight('fournisseur', 'lire') && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || (isModEnabled("supplier_order") && $user->hasRight('supplier_order', 'lire')) || (isModEnabled("supplier_invoice") && $user->hasRight('supplier_invoice', 'lire'))) {
-					print '<tr class="visibleifsupplier"><td>'.$form->editfieldkey('SuppliersCategoriesShort', 'suppcats', '', $object, 0).'</td>';
+				// Juridical type
+				print '<tr><td>'.$form->editfieldkey('JuridicalStatus', 'forme_juridique_code', '', $object, 0).'</td><td class="maxwidthonsmartphone" colspan="3">';
+				print $formcompany->select_juridicalstatus($object->forme_juridique_code, $object->country_code, '', 'forme_juridique_code');
+				print '</td></tr>';
+
+				// Capital
+				print '<tr><td>'.$form->editfieldkey('Capital', 'capital', '', $object, 0).'</td>';
+				print '<td colspan="3"><input type="text" name="capital" id="capital" size="10" value="';
+				print $object->capital != '' ? dol_escape_htmltag(price($object->capital)) : '';
+				if (isModEnabled("multicurrency")) {
+					print '"> <span class="hideonsmartphone">'.$langs->trans("Currency".$object->multicurrency_code).'</span></td></tr>';
+				} else {
+					print '"> <span class="hideonsmartphone">'.$langs->trans("Currency".$conf->currency).'</span></td></tr>';
+				}
+
+				// Default language
+				if (getDolGlobalInt('MAIN_MULTILANGS')) {
+					print '<tr><td>'.$form->editfieldkey('DefaultLang', 'default_lang', '', $object, 0).'</td><td colspan="3">'."\n";
+					print img_picto('', 'language', 'class="pictofixedwidth"').$formadmin->select_language($object->default_lang, 'default_lang', 0, null, '1', 0, 0, 'maxwidth300 widthcentpercentminusx');
+					print '</td>';
+					print '</tr>';
+				}
+
+				// Incoterms
+				if (isModEnabled('incoterm')) {
+					print '<tr>';
+						print '<td>'.$form->editfieldkey('IncotermLabel', 'incoterm_id', '', $object, 0).'</td>';
+					print '<td colspan="3" class="maxwidthonsmartphone">';
+					print $form->select_incoterms((!empty($object->fk_incoterms) ? $object->fk_incoterms : ''), (!empty($object->location_incoterms) ? $object->location_incoterms : ''));
+					print '</td></tr>';
+				}
+
+				// Categories
+				if (isModEnabled('categorie') && $user->hasRight('categorie', 'lire')) {
+					// Customer
+					print '<tr class="visibleifcustomer"><td>'.$form->editfieldkey('CustomersCategoriesShort', 'custcats', '', $object, 0).'</td>';
 					print '<td colspan="3">';
-					$cate_arbo = $form->select_all_categories(Categorie::TYPE_SUPPLIER, null, null, null, null, 1);
+					$cate_arbo = $form->select_all_categories(Categorie::TYPE_CUSTOMER, null, null, null, null, 1);
 					$c = new Categorie($db);
-					$cats = $c->containing($object->id, Categorie::TYPE_SUPPLIER);
+					$cats = $c->containing($object->id, Categorie::TYPE_CUSTOMER);
 					$arrayselected = array();
 					foreach ($cats as $cat) {
 						$arrayselected[] = $cat->id;
 					}
-					print img_picto('', 'category', 'class="pictofixedwidth"').$form->multiselectarray('suppcats', $cate_arbo, $arrayselected, 0, 0, 'quatrevingtpercent widthcentpercentminusx', 0, 0);
+					print img_picto('', 'category', 'class="pictofixedwidth"').$form->multiselectarray('custcats', $cate_arbo, $arrayselected, 0, 0, 'quatrevingtpercent widthcentpercentminusx', 0, 0);
 					print "</td></tr>";
+
+					// Supplier
+					if ((isModEnabled("fournisseur") && $user->hasRight('fournisseur', 'lire') && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || (isModEnabled("supplier_order") && $user->hasRight('supplier_order', 'lire')) || (isModEnabled("supplier_invoice") && $user->hasRight('supplier_invoice', 'lire'))) {
+						print '<tr class="visibleifsupplier"><td>'.$form->editfieldkey('SuppliersCategoriesShort', 'suppcats', '', $object, 0).'</td>';
+						print '<td colspan="3">';
+						$cate_arbo = $form->select_all_categories(Categorie::TYPE_SUPPLIER, null, null, null, null, 1);
+						$c = new Categorie($db);
+						$cats = $c->containing($object->id, Categorie::TYPE_SUPPLIER);
+						$arrayselected = array();
+						foreach ($cats as $cat) {
+							$arrayselected[] = $cat->id;
+						}
+						print img_picto('', 'category', 'class="pictofixedwidth"').$form->multiselectarray('suppcats', $cate_arbo, $arrayselected, 0, 0, 'quatrevingtpercent widthcentpercentminusx', 0, 0);
+						print "</td></tr>";
+					}
 				}
-			}
 
-			// Multicurrency
-			if (isModEnabled("multicurrency")) {
-				print '<tr>';
-				print '<td>'.$form->editfieldkey('Currency', 'multicurrency_code', '', $object, 0).'</td>';
-				print '<td colspan="3" class="maxwidthonsmartphone">';
-				print img_picto('', 'currency', 'class="pictofixedwidth"');
-				print $form->selectMultiCurrency((GETPOSTISSET('multicurrency_code') ? GETPOST('multicurrency_code') : ($object->multicurrency_code ? $object->multicurrency_code : $conf->currency)), 'multicurrency_code', 1, '', false, 'maxwidth150 widthcentpercentminusx');
-				print '</td></tr>';
-			}
+				// Multicurrency
+				if (isModEnabled("multicurrency")) {
+					print '<tr>';
+					print '<td>'.$form->editfieldkey('Currency', 'multicurrency_code', '', $object, 0).'</td>';
+					print '<td colspan="3" class="maxwidthonsmartphone">';
+					print img_picto('', 'currency', 'class="pictofixedwidth"');
+					print $form->selectMultiCurrency((GETPOSTISSET('multicurrency_code') ? GETPOST('multicurrency_code') : ($object->multicurrency_code ? $object->multicurrency_code : $conf->currency)), 'multicurrency_code', 1, '', false, 'maxwidth150 widthcentpercentminusx');
+					print '</td></tr>';
+				}
 
-			// Other attributes
-			$parameters = array('socid'=>$socid, 'colspan' => ' colspan="3"', 'colspanvalue' => '3');
-			include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_edit.tpl.php';
+				// Other attributes
+				$parameters = array('socid'=>$socid, 'colspan' => ' colspan="3"', 'colspanvalue' => '3');
+				include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_edit.tpl.php';
 
-			// Parent company
-			if (empty($conf->global->SOCIETE_DISABLE_PARENTCOMPANY)) {
-				print '<tr>';
-				print '<td>'.$langs->trans('ParentCompany').'</td>';
-				print '<td colspan="3" class="maxwidthonsmartphone">';
-				print img_picto('', 'company', 'class="pictofixedwidth"');
-				print $form->select_company(GETPOST('parent_company_id') ? GETPOST('parent_company_id') : $object->parent, 'parent_company_id', '', 'SelectThirdParty', 0, 0, null, 0, 'minwidth300 maxwidth500 widthcentpercentminusxx');
-				print '</td></tr>';
-			}
+				// Parent company
+				if (empty($conf->global->SOCIETE_DISABLE_PARENTCOMPANY)) {
+					print '<tr>';
+					print '<td>'.$langs->trans('ParentCompany').'</td>';
+					print '<td colspan="3" class="maxwidthonsmartphone">';
+					print img_picto('', 'company', 'class="pictofixedwidth"');
+					print $form->select_company(GETPOST('parent_company_id') ? GETPOST('parent_company_id') : $object->parent, 'parent_company_id', '', 'SelectThirdParty', 0, 0, null, 0, 'minwidth300 maxwidth500 widthcentpercentminusxx');
+					print '</td></tr>';
+				}
 
-			// Webservices url/key
-			if (!empty($conf->syncsupplierwebservices->enabled)) {
-				print '<tr><td>'.$form->editfieldkey('WebServiceURL', 'webservices_url', '', $object, 0).'</td>';
-				print '<td><input type="text" name="webservices_url" id="webservices_url" size="32" value="'.$object->webservices_url.'"></td>';
-				print '<td>'.$form->editfieldkey('WebServiceKey', 'webservices_key', '', $object, 0).'</td>';
-				print '<td><input type="text" name="webservices_key" id="webservices_key" size="32" value="'.$object->webservices_key.'"></td></tr>';
-			}
+				// Webservices url/key
+				if (!empty($conf->syncsupplierwebservices->enabled)) {
+					print '<tr><td>'.$form->editfieldkey('WebServiceURL', 'webservices_url', '', $object, 0).'</td>';
+					print '<td><input type="text" name="webservices_url" id="webservices_url" size="32" value="'.$object->webservices_url.'"></td>';
+					print '<td>'.$form->editfieldkey('WebServiceKey', 'webservices_key', '', $object, 0).'</td>';
+					print '<td><input type="text" name="webservices_key" id="webservices_key" size="32" value="'.$object->webservices_key.'"></td></tr>';
+				}
 
-			// Logo
-			print '<tr class="hideonsmartphone">';
-			print '<td>'.$form->editfieldkey('Logo', 'photoinput', '', $object, 0).'</td>';
-			print '<td colspan="3">';
-			if ($object->logo) {
-				print $form->showphoto('societe', $object);
-			}
-			$caneditfield = 1;
-			if ($caneditfield) {
+				// Logo
+				print '<tr class="hideonsmartphone">';
+				print '<td>'.$form->editfieldkey('Logo', 'photoinput', '', $object, 0).'</td>';
+				print '<td colspan="3">';
 				if ($object->logo) {
-					print "<br>\n";
+					print $form->showphoto('societe', $object);
 				}
-				print '<table class="nobordernopadding">';
-				if ($object->logo) {
-					print '<tr><td><input type="checkbox" class="flat photodelete" name="deletephoto" id="photodelete"> <label for="photodelete">'.$langs->trans("Delete").'</photo><br><br></td></tr>';
+				$caneditfield = 1;
+				if ($caneditfield) {
+					if ($object->logo) {
+						print "<br>\n";
+					}
+					print '<table class="nobordernopadding">';
+					if ($object->logo) {
+						print '<tr><td><input type="checkbox" class="flat photodelete" name="deletephoto" id="photodelete"> <label for="photodelete">'.$langs->trans("Delete").'</photo><br><br></td></tr>';
+					}
+					//print '<tr><td>'.$langs->trans("PhotoFile").'</td></tr>';
+					print '<tr><td>';
+					$maxfilesizearray = getMaxFileSizeArray();
+					$maxmin = $maxfilesizearray['maxmin'];
+					if ($maxmin > 0) {
+						print '<input type="hidden" name="MAX_FILE_SIZE" value="'.($maxmin * 1024).'">';	// MAX_FILE_SIZE must precede the field type=file
+					}
+					print '<input type="file" class="flat" name="photo" id="photoinput">';
+					print '</td></tr>';
+					print '</table>';
 				}
-				//print '<tr><td>'.$langs->trans("PhotoFile").'</td></tr>';
-				print '<tr><td>';
-				$maxfilesizearray = getMaxFileSizeArray();
-				$maxmin = $maxfilesizearray['maxmin'];
-				if ($maxmin > 0) {
-					print '<input type="hidden" name="MAX_FILE_SIZE" value="'.($maxmin * 1024).'">';	// MAX_FILE_SIZE must precede the field type=file
+				print '</td>';
+				print '</tr>';
+
+				// Assign sale representative
+				print '<tr>';
+				print '<td>'.$form->editfieldkey('AllocateCommercial', 'commercial_id', '', $object, 0).'</td>';
+				print '<td colspan="3" class="maxwidthonsmartphone">';
+				$userlist = $form->select_dolusers('', '', 0, null, 0, '', '', 0, 0, 0, 'AND u.statut = 1', 0, '', '', 0, 1);
+				$arrayselected = GETPOST('commercial', 'array');
+				if (empty($arrayselected)) {
+					$arrayselected = $object->getSalesRepresentatives($user, 1);
 				}
-				print '<input type="file" class="flat" name="photo" id="photoinput">';
+				print img_picto('', 'user', 'class="pictofixedwidth"').$form->multiselectarray('commercial', $userlist, $arrayselected, 0, 0, 'quatrevingtpercent widthcentpercentminusx', 0, 0, '', '', '', 1);
 				print '</td></tr>';
+
 				print '</table>';
-			}
-			print '</td>';
-			print '</tr>';
 
-			// Assign sale representative
-			print '<tr>';
-			print '<td>'.$form->editfieldkey('AllocateCommercial', 'commercial_id', '', $object, 0).'</td>';
-			print '<td colspan="3" class="maxwidthonsmartphone">';
-			$userlist = $form->select_dolusers('', '', 0, null, 0, '', '', 0, 0, 0, 'AND u.statut = 1', 0, '', '', 0, 1);
-			$arrayselected = GETPOST('commercial', 'array');
-			if (empty($arrayselected)) {
-				$arrayselected = $object->getSalesRepresentatives($user, 1);
-			}
-			print img_picto('', 'user', 'class="pictofixedwidth"').$form->multiselectarray('commercial', $userlist, $arrayselected, 0, 0, 'quatrevingtpercent widthcentpercentminusx', 0, 0, '', '', '', 1);
-			print '</td></tr>';
+				if (!empty($conf->global->ACCOUNTANCY_USE_PRODUCT_ACCOUNT_ON_THIRDPARTY)) {
+					print '<br>';
+					print '<table class="border centpercent">';
 
-			print '</table>';
+					if (isModEnabled('accounting')) {
+						// Accountancy_code_sell
+						print '<tr><td class="titlefield">'.$langs->trans("ProductAccountancySellCode").'</td>';
+						print '<td>';
+						print $formaccounting->select_account($object->accountancy_code_sell, 'accountancy_code_sell', 1, '', 1, 1);
+						print '</td></tr>';
 
-			if (!empty($conf->global->ACCOUNTANCY_USE_PRODUCT_ACCOUNT_ON_THIRDPARTY)) {
-				print '<br>';
-				print '<table class="border centpercent">';
+						// Accountancy_code_buy
+						print '<tr><td>'.$langs->trans("ProductAccountancyBuyCode").'</td>';
+						print '<td>';
+						print $formaccounting->select_account($object->accountancy_code_buy, 'accountancy_code_buy', 1, '', 1, 1);
+						print '</td></tr>';
+					} else { // For external software
+						// Accountancy_code_sell
+						print '<tr><td class="titlefield">'.$langs->trans("ProductAccountancySellCode").'</td>';
+						print '<td><input name="accountancy_code_sell" class="maxwidth200" value="'.$object->accountancy_code_sell.'">';
+						print '</td></tr>';
 
-				if (isModEnabled('accounting')) {
-					// Accountancy_code_sell
-					print '<tr><td class="titlefield">'.$langs->trans("ProductAccountancySellCode").'</td>';
-					print '<td>';
-					print $formaccounting->select_account($object->accountancy_code_sell, 'accountancy_code_sell', 1, '', 1, 1);
-					print '</td></tr>';
-
-					// Accountancy_code_buy
-					print '<tr><td>'.$langs->trans("ProductAccountancyBuyCode").'</td>';
-					print '<td>';
-					print $formaccounting->select_account($object->accountancy_code_buy, 'accountancy_code_buy', 1, '', 1, 1);
-					print '</td></tr>';
-				} else { // For external software
-					// Accountancy_code_sell
-					print '<tr><td class="titlefield">'.$langs->trans("ProductAccountancySellCode").'</td>';
-					print '<td><input name="accountancy_code_sell" class="maxwidth200" value="'.$object->accountancy_code_sell.'">';
-					print '</td></tr>';
-
-					// Accountancy_code_buy
-					print '<tr><td>'.$langs->trans("ProductAccountancyBuyCode").'</td>';
-					print '<td><input name="accountancy_code_buy" class="maxwidth200" value="'.$object->accountancy_code_buy.'">';
-					print '</td></tr>';
+						// Accountancy_code_buy
+						print '<tr><td>'.$langs->trans("ProductAccountancyBuyCode").'</td>';
+						print '<td><input name="accountancy_code_buy" class="maxwidth200" value="'.$object->accountancy_code_buy.'">';
+						print '</td></tr>';
+					}
+					print '</table>';
 				}
-				print '</table>';
 			}
 
 			print '</div>';


### PR DESCRIPTION
add a hook to personnalize thirdparty card edit form while keeping actions buttons and actions management.
the use case is a company that want thirdparty card fields in different order than the core standard, for example, if he does not want to show all the fields or if he wants extrafields at other position than the end.