### PR TITLE
Compta report : lines didn't display

### DIFF
--- a/htdocs/compta/stats/supplier_turnover_by_thirdparty.php
+++ b/htdocs/compta/stats/supplier_turnover_by_thirdparty.php
@@ -330,7 +330,7 @@ if ($resql) {
 
 		$amount_ht[$obj->socid] = (empty($obj->amount) ? 0 : $obj->amount);
 		$amount[$obj->socid] = $obj->amount_ttc;
-		//$name[$obj->socid] = $obj->name.' '.$obj->firstname;
+		$name[$obj->socid] = $obj->name.' '.$obj->firstname;
 
 		$address_zip[$obj->socid] = $obj->zip;
 		$address_town[$obj->socid] = $obj->town;


### PR DESCRIPTION
# FIX|Fix #

The line was commented out to debug but not uncommented.
The report lines were no longer displayed when sorting by thirdparties (and so  when arriving directly on the page from the menu)
