### PR TITLE
Fix #26504 Default value extrafield line object

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8527,7 +8527,7 @@ abstract class CommonObject
 
 						// HTML, text, select, integer and varchar: take into account default value in database if in create mode
 						if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('html', 'text', 'varchar', 'select', 'int', 'boolean'))) {
-							if ($action == 'create') {
+							if ($action == 'create' || $mode == 'create') {
 								$value = (GETPOSTISSET($keyprefix.'options_'.$key.$keysuffix) || $value) ? $value : $extrafields->attributes[$this->table_element]['default'][$key];
 							}
 						}


### PR DESCRIPTION
Fix https://github.com/Dolibarr/dolibarr/issues/26504 Default value extrafield line object
Handle the default value for the extrafields ofa line of an object such as proposal, invoice, etc
For example : a boolean extrafield checked by default.