### PR TITLE
Fix #26501

### DIFF
--- a/htdocs/compta/sociales/card.php
+++ b/htdocs/compta/sociales/card.php
@@ -334,7 +334,7 @@ if (isModEnabled('project')) {
 $now = dol_now();
 
 $title = $langs->trans("SocialContribution").' - '.$langs->trans("Card");
-$help_url = 'EN:Module_Taxes_and_social_contributions|FR:Module Taxes et dividendes|ES:M&oacute;dulo Impuestos y cargas sociales (IVA, impuestos)';
+$help_url = 'EN:Module_Taxes_and_social_contributions|FR:Module_Taxes_et_charges_spéciales|ES:M&oacute;dulo Impuestos y cargas sociales (IVA, impuestos)';
 llxHeader("", $title, $help_url);
 
 


### PR DESCRIPTION
French wiki url of the help button changed:
- from: `http://wiki.dolibarr.org/index.php/Module+Taxes+et+dividendes`
- to: `http://wiki.dolibarr.org/index.php/Module_Taxes_et_charges_spéciales`