### PR TITLE
fix #26551 Supplier Invoice - Display the error message when trying to delete an already reconciled payment

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -701,9 +701,11 @@ if (empty($reshook)) {
 		if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0) {
 			$paiementfourn = new PaiementFourn($db);
 			$result = $paiementfourn->fetch(GETPOST('paiement_id'));
-			if ($result > 0) {
-				$result = $paiementfourn->delete(); // If fetch ok and found
-				header("Location: ".$_SERVER['PHP_SELF']."?id=".$id);
+			if ($result > 0) { 
+				$result = $paiementfourn->delete(); 
+				if ($result > 0) { 
+					header("Location: ".$_SERVER['PHP_SELF']."?id=".$id);
+				}
 			}
 			if ($result < 0) {
 				setEventMessages($paiementfourn->error, $paiementfourn->errors, 'errors');

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -701,9 +701,9 @@ if (empty($reshook)) {
 		if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0) {
 			$paiementfourn = new PaiementFourn($db);
 			$result = $paiementfourn->fetch(GETPOST('paiement_id'));
-			if ($result > 0) { 
-				$result = $paiementfourn->delete(); 
-				if ($result > 0) { 
+			if ($result > 0) {
+				$result = $paiementfourn->delete();
+				if ($result > 0) {
 					header("Location: ".$_SERVER['PHP_SELF']."?id=".$id);
 				}
 			}


### PR DESCRIPTION
This allows reloading the page only if the payment has been correctly deleted.
Otherwise it displays an error message explaining why the payment hasn't been deleted.