### PR TITLE
FIX #26553 Supplier invoice - Do not display the delete button for reconciled payment

### DIFF
--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -917,4 +917,17 @@ class PaiementFourn extends Paiement
 
 		return parent::fetch_thirdparty($force_thirdparty_id);
 	}
+
+
+	/**
+	 *  Return if payment is reconciled
+	 *
+	 *  @return     boolean     True if payment is reconciled
+	 */
+	public function isReconciled()
+	{
+	    $accountline = new AccountLine($this->db);
+		$accountline->fetch($this->bank_line);
+		return $accountline->rappro;
+	}
 }

--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -926,7 +926,7 @@ class PaiementFourn extends Paiement
 	 */
 	public function isReconciled()
 	{
-	    $accountline = new AccountLine($this->db);
+		$accountline = new AccountLine($this->db);
 		$accountline->fetch($this->bank_line);
 		return $accountline->rappro;
 	}

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -3551,7 +3551,8 @@ if ($action == 'create') {
 					
 					$paiementfourn = new PaiementFourn($db);
 			        $paiementfourn->fetch($objp->rowid);
-					if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0 && $user->socid == 0 && !$paiementfourn->isReconciled()) {
+					if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0 && $user->socid == 0 && !$paiementfourn->isReconciled())
+					{
 						print '<a href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=deletepayment&token='.newToken().'&paiement_id='.$objp->rowid.'">';
 						print img_delete();
 						print '</a>';

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -3548,11 +3548,10 @@ if ($action == 'create') {
 					}
 					print '<td class="right">'.price($sign * $objp->amount).'</td>';
 					print '<td class="center">';
-					
+
 					$paiementfourn = new PaiementFourn($db);
-			        $paiementfourn->fetch($objp->rowid);
-					if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0 && $user->socid == 0 && !$paiementfourn->isReconciled())
-					{
+					$paiementfourn->fetch($objp->rowid);
+					if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0 && $user->socid == 0 && !$paiementfourn->isReconciled()) {
 						print '<a href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=deletepayment&token='.newToken().'&paiement_id='.$objp->rowid.'">';
 						print img_delete();
 						print '</a>';

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -3548,7 +3548,10 @@ if ($action == 'create') {
 					}
 					print '<td class="right">'.price($sign * $objp->amount).'</td>';
 					print '<td class="center">';
-					if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0 && $user->socid == 0) {
+					
+					$paiementfourn = new PaiementFourn($db);
+			        $paiementfourn->fetch($objp->rowid);
+					if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0 && $user->socid == 0 && !$paiementfourn->isReconciled()) {
 						print '<a href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=deletepayment&token='.newToken().'&paiement_id='.$objp->rowid.'">';
 						print img_delete();
 						print '</a>';


### PR DESCRIPTION
I've tried to keep it simple by creating a function that could be reused elsewhere. 

For example here:
https://github.com/Dolibarr/dolibarr/blob/b709de584c33b4562baf981ede40f2f1aeb096f9/htdocs/fourn/class/paiementfourn.class.php#L455-L465

Or here:
https://github.com/Dolibarr/dolibarr/blob/b709de584c33b4562baf981ede40f2f1aeb096f9/htdocs/fourn/paiement/card.php#L236-L241

However I'm not sure how to handle the potential errors in this function (for example if the `PaiementFourn` wasn't fetched first and `$this->bank_line` is still empty ; or if the `fetch()` on the `AccountLine` returns KO).