### PR TITLE
Fix: ajout indemnites kilometriques non fonctionnels avec mariadb >= 10.6

### DIFF
--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2706,7 +2706,7 @@ class ExpenseReport extends CommonObject
 		//Clean
 		$qty = price2num($qty);
 
-		$sql  = " SELECT r.range_ik, t.ikoffset as offset, t.coef";
+		$sql  = " SELECT r.range_ik, t.ikoffset as ikoffset, t.coef";
 		$sql .= " FROM ".MAIN_DB_PREFIX."expensereport_ik t";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_exp_tax_range r ON r.rowid = t.fk_range";
 		$sql .= " WHERE t.fk_c_exp_tax_cat = ".(int) $fk_cat;
@@ -2750,12 +2750,12 @@ class ExpenseReport extends CommonObject
 					if ($i < ($num - 1)) {
 						if ($qty > $ranges[$i]->range_ik && $qty < $ranges[$i+1]->range_ik) {
 							$coef = $ranges[$i]->coef;
-							$offset = $ranges[$i]->offset;
+							$offset = $ranges[$i]->ikoffset;
 						}
 					} else {
 						if ($qty > $ranges[$i]->range_ik) {
 							$coef = $ranges[$i]->coef;
-							$offset = $ranges[$i]->offset;
+							$offset = $ranges[$i]->ikoffset;
 						}
 					}
 				}


### PR DESCRIPTION
le mot-clef offset étant maintenant un mot clef mariadb, la requête n'était plus valide
