### PR TITLE
FIX header location when creating sub MO is not working

### DIFF
--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -168,7 +168,7 @@ if (empty($reshook)) {
 			$res = $object->add_object_linked('mo', $mo_parent->id);
 		}
 
-		header("Location: ".dol_buildpath('/mrp/mo_card.php?id='.((int) $moline->fk_mo), 1));
+		header("Location: ".dol_buildpath('/mrp/mo_card.php?id='.((int) $tmpmoline->fk_mo), 1));
 		exit;
 	}
 


### PR DESCRIPTION
FIX|Fix https://github.com/Dolibarr/dolibarr/issues/26416 Bug: BOM_SUB_BOM blank page
Fix header location when creating sub MO is not working because $moline is an empty object, we need to use new $tmpmoline (remplacement of #26524)

