### PR TITLE
QUAL Delete method isReconciled() because it is now inherited

### DIFF
--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -917,17 +917,4 @@ class PaiementFourn extends Paiement
 
 		return parent::fetch_thirdparty($force_thirdparty_id);
 	}
-
-
-	/**
-	 *  Return if payment is reconciled
-	 *
-	 *  @return     boolean     True if payment is reconciled
-	 */
-	public function isReconciled()
-	{
-		$accountline = new AccountLine($this->db);
-		$accountline->fetch($this->bank_line);
-		return $accountline->rappro;
-	}
 }


### PR DESCRIPTION
Since:

1. `fourn/class/paiementfourn.class.php` inherits from `compta/paiement/class/paiement.class.php`
https://github.com/Dolibarr/dolibarr/blob/9464c0a04096cc8b60f193b12b02c65e085bf7d6/htdocs/fourn/class/paiementfourn.class.php#L39

2. and the method `isReconciled()` has been introduced:
    - first in `paiementfourn.class.php` (see PR #26554):
https://github.com/Dolibarr/dolibarr/blob/9464c0a04096cc8b60f193b12b02c65e085bf7d6/htdocs/fourn/class/paiementfourn.class.php#L922-L933
    - and then in `paiement.class.php` (see PR #26568):
https://github.com/Dolibarr/dolibarr/blob/9464c0a04096cc8b60f193b12b02c65e085bf7d6/htdocs/compta/paiement/class/paiement.class.php#L1405-L1417

Therefore the methods in both child and parent classes are identical and we unnecessarily overrides the parent one.

This PR deletes the unnecessary method from the child class.