### PR TITLE
Fix duplicate index in llx_expensereport

### DIFF
--- a/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
+++ b/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
@@ -196,3 +196,5 @@ ALTER TABLE llx_salary ADD COLUM ref_ext varchar(255);
 ALTER TABLE llx_salary ADD COLUM note_public text;
 
 ALTER TABLE llx_commande_fournisseur_dispatch ADD COLUMN element_type varchar(50) DEFAULT 'supplier_order' NOT NULL;
+
+ALTER TABLE llx_expensereport DROP INDEX idx_expensereport_fk_refuse, ADD INDEX idx_expensereport_fk_refuse(fk_user_refuse);

--- a/htdocs/install/mysql/tables/llx_expensereport.key.sql
+++ b/htdocs/install/mysql/tables/llx_expensereport.key.sql
@@ -27,7 +27,7 @@ ALTER TABLE llx_expensereport ADD INDEX idx_expensereport_fk_statut (fk_statut);
 ALTER TABLE llx_expensereport ADD INDEX idx_expensereport_fk_user_author (fk_user_author);
 ALTER TABLE llx_expensereport ADD INDEX idx_expensereport_fk_user_valid (fk_user_valid);
 ALTER TABLE llx_expensereport ADD INDEX idx_expensereport_fk_user_approve (fk_user_approve);
-ALTER TABLE llx_expensereport ADD INDEX idx_expensereport_fk_refuse (fk_user_approve);
+ALTER TABLE llx_expensereport ADD INDEX idx_expensereport_fk_refuse (fk_user_refuse);
 
 --ALTER TABLE llx_expensereport ADD CONSTRAINT fk_expensereport_fk_user_author		FOREIGN KEY (fk_user_author)	 REFERENCES llx_user (rowid);
 --ALTER TABLE llx_expensereport ADD CONSTRAINT fk_expensereport_fk_user_valid 		FOREIGN KEY (fk_user_valid)		 REFERENCES llx_user (rowid);


### PR DESCRIPTION
# Fix duplicate index

There is a duplicate index in https://github.com/Dolibarr/dolibarr/blob/599632c6710bb64711e9f30b6805137b8a9bfcba/htdocs/install/mysql/tables/llx_expensereport.key.sql#L29-L30
Index `idx_expensereport_fk_refuse` should be on column `fk_user_refuse`


