### PR TITLE
fix PRODUCT VARIANTS - Missing translation key for "Combination"

### DIFF
--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -352,6 +352,7 @@ PackagingForThisProductDesc=You will automaticaly purchase a multiple of this qu
 QtyRecalculatedWithPackaging=The quantity of the line were recalculated according to supplier packaging
 
 #Attributes
+Attributes=Attributes
 VariantAttributes=Variant attributes
 ProductAttributes=Variant attributes for products
 ProductAttributeName=Variant attribute %s

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -352,6 +352,7 @@ PackagingForThisProductDesc=Vous achèterez automatiquement un multiple de cette
 QtyRecalculatedWithPackaging=La quantité de la ligne a été recalculée en fonction de l'emballage du fournisseur
 
 #Attributes
+Attributes=Attributs
 VariantAttributes=Attributs de variante
 ProductAttributes=Attributs de variantes pour les produits
 ProductAttributeName=Attribut de variante %s

--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -689,7 +689,7 @@ if (!empty($id) || !empty($ref)) {
 			if (is_array($productCombination2ValuePairs1) && count($productCombination2ValuePairs1)) {
 				?>
 				<tr>
-					<td class="titlefieldcreate tdtop"><label for="features"><?php echo $langs->trans('Combination') ?></label></td>
+					<td class="titlefieldcreate tdtop"><label for="features"><?php echo $langs->trans('Attributes') ?></label></td>
 					<td class="tdtop">
 						<div class="inline-block valignmiddle quatrevingtpercent">
 					<?php
@@ -698,7 +698,7 @@ if (!empty($id) || !empty($ref)) {
 						$result2 = $prodattr_val->fetch($val->fk_prod_attr_val);
 						//print 'rr'.$result1.' '.$result2;
 						if ($result1 > 0 && $result2 > 0) {
-							print $prodattr->label.' - '.$prodattr_val->value.'<br>';
+							print $prodattr->label.' : '.$prodattr_val->value.'<br>';
 							// TODO Add delete link
 						}
 					}
@@ -910,7 +910,7 @@ if (!empty($id) || !empty($ref)) {
 				}
 				?>
 				<td class="liste_titre"><?php echo $langs->trans('Product') ?></td>
-				<td class="liste_titre"><?php echo $langs->trans('Combination') ?></td>
+				<td class="liste_titre"><?php echo $langs->trans('Attributes') ?></td>
 				<td class="liste_titre right"><?php echo $langs->trans('PriceImpact') ?></td>
 				<?php if ($object->isProduct()) {
 					print'<td class="liste_titre right">'.$langs->trans('WeightImpact').'</td>';


### PR DESCRIPTION
V18.0.3

On the `variants/combinations.php` page, at two places we found the word "Combination" not translated :
- In the title of the 2nd column of the table listing the product variants,
- When editing a variant.

In the code these are called by `$langs->trans('Combination')`.

However there is no such translation key in the translation files (`grep -Rn "Combination=" ./dolibarr/htdocs/langs/en_US`).

Now:
- since "combination" seems to be replaced by "attribute", I've chosen to use this word.
- since a product variant can have one or more attributes, I've chosen the plural version (since one or more attributes will be listed).