### PR TITLE
FIX hardspace before empty

### DIFF
--- a/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
+++ b/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
@@ -480,7 +480,7 @@ class StockTransfer extends CommonObject
 		if (($this->socid > 0 || $this->fk_soc > 0) && empty($this->thirdparty)) {
 			$this->fetch_thirdparty();
 		}
-		if (empty($this->socid) && empty($this->fk_soc)) {
+		if (empty($this->socid) && empty($this->fk_soc)) {
 			unset($this->thirdparty);
 		}
 		return $res;


### PR DESCRIPTION
# FIX hardspace before empty

 Was reported by phan as:
    htdocs/product/stock/stocktransfer/class/stocktransfer.class.php:483 PhanUndeclaredFunction Call to undeclared function \ empty()
