### PR TITLE
FIX : update product quantity

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -541,7 +541,7 @@ class MouvementStock extends CommonObject
 			// Update stock quantity
 			if (!$error) {
 				if ($alreadyarecord > 0) {
-					$sql = "UPDATE ".$this->db->prefix()."product_stock SET reel = COALESCE(reel, 0) + ".((float) $qty);
+					$sql = "UPDATE ".$this->db->prefix()."product_stock SET reel = " . ((float) $oldqtywarehouse + (float) $qty);
 					$sql .= " WHERE fk_entrepot = ".((int) $entrepot_id)." AND fk_product = ".((int) $fk_product);
 				} else {
 					$sql = "INSERT INTO ".$this->db->prefix()."product_stock";


### PR DESCRIPTION
When i updated a product quantity by doing a stock correction i got a bug.

I have done a first stock correction with adding 96.6 on quantity and a second one by adding 59.8, and in database on table product_stock i got this in reel :

<img width="506" alt="image" src="https://github.com/Dolibarr/dolibarr/assets/85104766/287485c0-99a1-4896-8257-9945b4df913e">



I have fix this by doing the calculation in php and now i got the right quantity :

<img width="478" alt="image" src="https://github.com/Dolibarr/dolibarr/assets/85104766/9bea3d2c-0022-428c-a183-805ce2df3740">

