### PR TITLE
Finishing auto TakePOS setup with default account

### DIFF
--- a/htdocs/core/modules/modTakePos.class.php
+++ b/htdocs/core/modules/modTakePos.class.php
@@ -267,7 +267,7 @@ class modTakePos extends DolibarrModules
 	 */
 	public function init($options = '')
 	{
-		global $conf, $db, $langs, $user;
+		global $conf, $db, $langs, $user, $mysoc;
 		$langs->load("cashdesk");
 
 		dolibarr_set_const($db, "TAKEPOS_PRINT_METHOD", "browser", 'chaine', 0, '', $conf->entity);

--- a/htdocs/core/modules/modTakePos.class.php
+++ b/htdocs/core/modules/modTakePos.class.php
@@ -327,14 +327,16 @@ class modTakePos extends DolibarrModules
 		if (!getDolGlobalInt('CASHDESK_ID_BANKACCOUNT_CASH1')) {
 			require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 			$cashaccount = new Account($db);
-			$cashaccount->ref = "CASH-POS";
-			$cashaccount->label = $langs->trans("DefaultCashPOSLabel");
-			$cashaccount->courant = 2;
-			$cashaccount->country_id = $mysoc->country_id ? $mysoc->country_id : 1;
-			$cashaccount->date_solde = dol_now();
-			$result = $cashaccount->create($user);
-			if ($result > 0) {
-				require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+			$searchaccountid = $cashaccount->fetch(0, "CASH-POS");
+			if ($searchaccountid == 0) {
+				$cashaccount->ref = "CASH-POS";
+				$cashaccount->label = $langs->trans("DefaultCashPOSLabel");
+				$cashaccount->courant = 2;
+				$cashaccount->country_id = $mysoc->country_id ? $mysoc->country_id : 1;
+				$cashaccount->date_solde = dol_now();
+				$searchaccountid = $cashaccount->create($user);
+			}
+			if ($searchaccountid > 0) {
 				dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CASH1", $result, 'chaine', 0, '', $conf->entity);
 			} else {
 				setEventMessages($societe->error, $category->errors, 'errors');

--- a/htdocs/core/modules/modTakePos.class.php
+++ b/htdocs/core/modules/modTakePos.class.php
@@ -327,7 +327,7 @@ class modTakePos extends DolibarrModules
 		if (!getDolGlobalInt('CASHDESK_ID_BANKACCOUNT_CASH1')) {
 			require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 			$cashaccount = new Account($db);
-			$cashaccount->ref = "cash_pos";
+			$cashaccount->ref = "CASH-POS";
 			$cashaccount->label = $langs->trans("DefaultCashPOSLabel");
 			$cashaccount->courant = 2;
 			$cashaccount->country_id = $mysoc->country_id ? $mysoc->country_id : 1;

--- a/htdocs/core/modules/modTakePos.class.php
+++ b/htdocs/core/modules/modTakePos.class.php
@@ -323,6 +323,24 @@ class modTakePos extends DolibarrModules
 			}
 		}
 
+		//Create cash account if not exists
+		if (empty(getDolGlobalInt('CASHDESK_ID_BANKACCOUNT_CASH'.$_SESSION["takeposterminal"]))) {
+			require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
+			$cashaccount = new Account($db);
+			$cashaccount->ref = "cash_pos";
+			$cashaccount->label = $langs->trans("DefaultCashPOSLabel");
+			$cashaccount->courant = 2;
+			$cashaccount->country_id = $mysoc->country_id ? $mysoc->country_id : 1;
+			$cashaccount->date_solde = dol_now();
+			$result = $cashaccount->create($user);
+			if ($result > 0) {
+				require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+				dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CASH".$_SESSION["takeposterminal"], $result, 'chaine', 0, '', $conf->entity);
+			} else {
+				setEventMessages($societe->error, $category->errors, 'errors');
+			}
+		}
+
 		$result = $this->_load_tables('/install/mysql/', 'takepos');
 		if ($result < 0) {
 			return -1; // Do not activate module if error 'not allowed' returned when loading module SQL queries (the _load_table run sql with run_sql with the error allowed parameter set to 'default')

--- a/htdocs/core/modules/modTakePos.class.php
+++ b/htdocs/core/modules/modTakePos.class.php
@@ -324,7 +324,7 @@ class modTakePos extends DolibarrModules
 		}
 
 		//Create cash account if not exists
-		if (empty(getDolGlobalInt('CASHDESK_ID_BANKACCOUNT_CASH'.$_SESSION["takeposterminal"]))) {
+		if (!getDolGlobalInt('CASHDESK_ID_BANKACCOUNT_CASH1')) {
 			require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 			$cashaccount = new Account($db);
 			$cashaccount->ref = "cash_pos";
@@ -335,7 +335,7 @@ class modTakePos extends DolibarrModules
 			$result = $cashaccount->create($user);
 			if ($result > 0) {
 				require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
-				dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CASH".$_SESSION["takeposterminal"], $result, 'chaine', 0, '', $conf->entity);
+				dolibarr_set_const($db, "CASHDESK_ID_BANKACCOUNT_CASH1", $result, 'chaine', 0, '', $conf->entity);
 			} else {
 				setEventMessages($societe->error, $category->errors, 'errors');
 			}


### PR DESCRIPTION
To finish auto TakePOS setup for Dolibarr 19, I liked @eldy proposal in the comments of:
https://github.com/Dolibarr/dolibarr/pull/25037
We create an account automatically without asking the user when the TakePOS module is enabled and there is no account.
It is tested, but if it is approved I will test more and find TakePOS bugs during current Devcamp.