### PR TITLE
FIX escape HTML tags in return value of getFullName()

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -734,7 +734,7 @@ abstract class CommonObject
 
 		$ret .= dolGetFirstLastname($firstname, $lastname, $nameorder);
 
-		return dol_trunc($ret, $maxlen);
+		return dol_escape_htmltag(dol_trunc($ret, $maxlen));
 	}
 
 	/**


### PR DESCRIPTION
# FIX
Currently the result of CommonObject::getFullName() is printed as is (for instance on the contact list).

This can have unintended consequences if HTML tags are included in the `firstname` field of `llx_socpeople`.