### PR TITLE
FIX Accountancy - Missing subledger user during integration of salaries/expensereport

### DIFF
--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -433,6 +433,9 @@ if ($result) {
 					$paymentsalstatic->label = $links[$key]['label'];
 					$tabpay[$obj->rowid]["lib"] .= ' '.$paymentsalstatic->getNomUrl(2);
 					$tabpay[$obj->rowid]["paymentsalid"] = $paymentsalstatic->id;
+					if ($compta_user) {
+						$tabtp[$obj->rowid][$compta_user] += $amounttouse;
+					}
 
 					// This part of code is no more required. it is here to solve case where a link were missing (ith v14.0.0) and keep writing in accountancy complete.
 					// Note: A better way to fix this is to delete payment of salary and recreate it, or to fix the bookkeeping table manually after.
@@ -475,6 +478,9 @@ if ($result) {
 					$paymentexpensereportstatic->id = $links[$key]['url_id'];
 					$tabpay[$obj->rowid]["lib"] .= $paymentexpensereportstatic->getNomUrl(2);
 					$tabpay[$obj->rowid]["paymentexpensereport"] = $paymentexpensereportstatic->id;
+					if ($compta_user) {
+						$tabtp[$obj->rowid][$compta_user] += $amounttouse;
+					}
 				} elseif ($links[$key]['type'] == 'payment_various') {
 					$paymentvariousstatic->id = $links[$key]['url_id'];
 					$paymentvariousstatic->ref = $links[$key]['url_id'];


### PR DESCRIPTION
Better fix for PR #26733 of @BurksEngineering 

It worked in the past, but not now

_Example on salary, same on expense report:_

![image](https://github.com/Dolibarr/dolibarr/assets/2341395/2e8a5d83-6eb2-46f5-acd7-b4caf1b37fc0)

![image](https://github.com/Dolibarr/dolibarr/assets/2341395/5cf2ce09-4d90-4a87-ac85-0bc422b818bd)

