### PR TITLE
FIX #26326 service list total quantity (backport v18)

### DIFF
--- a/htdocs/contrat/services_list.php
+++ b/htdocs/contrat/services_list.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2018       Ferran Marcet           <fmarcet@2byte.es>
  * Copyright (C) 2018       Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2019      Juanjo Menent		<jmenent@2byte.es>
+ * Copyright (C) 2023		William Mead			<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -814,9 +815,6 @@ while ($i < min($num, $limit)) {
 		}
 		if (!$i) {
 			$totalarray['pos'][$totalarray['nbfield']] = 'cd.qty';
-		}
-		if (!$i) {
-			$totalarray['val']['cd.qty'] = $obj->qty;
 		}
 		$totalarray['val']['cd.qty'] += $obj->qty;
 	}


### PR DESCRIPTION
# FIX #26326 service list total quantity (backport v18)
Bug fix for total service count in contract service list. It seems this bug was introduced in _v18_ and still exists in _v19_. _v17_ is OK. 
Next version being in beta/feature freeze will the bug fix need a separate PR for _v19_ ?