### PR TITLE
FIX syntax errors in Advanced Stock Transfer and adds checks for null values

### DIFF
--- a/htdocs/product/stock/stocktransfer/class/stocktransferline.class.php
+++ b/htdocs/product/stock/stocktransfer/class/stocktransferline.class.php
@@ -153,7 +153,7 @@ class StockTransferLine extends CommonObjectLine
 		// Translate some data of arrayofkeyval
 		if (is_object($langs)) {
 			foreach ($this->fields as $key => $val) {
-				if (is_array($val['arrayofkeyval'])) {
+				if (isset($val['arrayofkeyval']) && is_array($val['arrayofkeyval'])) {
 					foreach ($val['arrayofkeyval'] as $key2 => $val2) {
 						$this->fields[$key]['arrayofkeyval'][$key2] = $langs->trans($val2);
 					}

--- a/htdocs/product/stock/stocktransfer/stocktransfer_card.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_card.php
@@ -195,7 +195,7 @@ if (empty($reshook)) {
 			$line->pmp = $prod->pmp;
 			if ($line->id > 0) $line->update($user);
 			else {
-				$line->rang = count($object->lines) + 1;
+				$line->rang = (is_array($object->lines) || $object->lines instanceof Countable) ? count($object->lines) + 1 : 1;
 				$line->create($user);
 			}
 			$object->fetchLines();


### PR DESCRIPTION
FIX #26194 Advanced Stock Transfer errors

Fixes some errors in Advanced Stock transfer - namely some syntax and null checking