### PR TITLE
QUAL No return values in __construct(), correct PHPDoc for  typing

### DIFF
--- a/htdocs/compta/bank/class/api_bankaccounts.class.php
+++ b/htdocs/compta/bank/class/api_bankaccounts.class.php
@@ -23,7 +23,7 @@ require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 /**
  * API class for accounts
  *
- * @property DoliDB db
+ * @property DoliDB $db
  * @access protected
  * @class DolibarrApiAccess {@requires user,external}
  */

--- a/htdocs/core/class/dolgeoip.class.php
+++ b/htdocs/core/class/dolgeoip.class.php
@@ -71,20 +71,20 @@ class DolGeoIP
 			}
 		} else {
 			print 'ErrorBadParameterInConstructor';
-			return 0;
+			return;
 		}
 
 		// Here, function exists (embedded into PHP or exists because we made include)
 		if (empty($type) || empty($datfile)) {
 			$this->errorlabel = 'Constructor was called with no datafile parameter';
 			dol_syslog('DolGeoIP '.$this->errorlabel, LOG_ERR);
-			return 0;
+			return;
 		}
 		if (!file_exists($datfile) || !is_readable($datfile)) {
 			$this->error = 'ErrorGeoIPClassNotInitialized';
 			$this->errorlabel = "Datafile ".$datfile." not found";
 			dol_syslog('DolGeoIP '.$this->errorlabel, LOG_ERR);
-			return 0;
+			return;
 		}
 
 		if ($geoipversion == '2') {
@@ -93,7 +93,7 @@ class DolGeoIP
 			} catch (Exception $e) {
 				$this->error = $e->getMessage();
 				dol_syslog('DolGeoIP '.$this->errorlabel, LOG_ERR);
-				return 0;
+				return;
 			}
 		} elseif (function_exists('geoip_open') && defined('GEOIP_STANDARD')) {
 			$this->gi = geoip_open($datfile, constant('GEOIP_STANDARD'));

--- a/htdocs/core/class/menubase.class.php
+++ b/htdocs/core/class/menubase.class.php
@@ -172,7 +172,6 @@ class Menubase
 	{
 		$this->db = $db;
 		$this->menu_handler = $menu_handler;
-		return 1;
 	}
 
 

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -101,7 +101,7 @@ class DoliDBPgsql extends DoliDB
 			$this->ok = false;
 			$this->error = "Pgsql PHP functions are not available in this version of PHP";
 			dol_syslog(get_class($this)."::DoliDBPgsql : Pgsql PHP functions are not available in this version of PHP", LOG_ERR);
-			return $this->ok;
+			return;
 		}
 
 		if (!$host) {
@@ -109,7 +109,7 @@ class DoliDBPgsql extends DoliDB
 			$this->ok = false;
 			$this->error = $langs->trans("ErrorWrongHostParameter");
 			dol_syslog(get_class($this)."::DoliDBPgsql : Erreur Connect, wrong host parameters", LOG_ERR);
-			return $this->ok;
+			return;
 		}
 
 		// Essai connexion serveur
@@ -144,8 +144,6 @@ class DoliDBPgsql extends DoliDB
 			// Pas de selection de base demandee, ok ou ko
 			$this->database_selected = false;
 		}
-
-		return $this->ok;
 	}
 
 

--- a/htdocs/core/db/sqlite3.class.php
+++ b/htdocs/core/db/sqlite3.class.php
@@ -86,7 +86,7 @@ class DoliDBSqlite3 extends DoliDB
 			$this->ok = false;
 			$this->error="Sqlite PHP functions for using Sqlite driver are not available in this version of PHP. Try to use another driver.";
 			dol_syslog(get_class($this)."::DoliDBSqlite3 : Sqlite PHP functions for using Sqlite driver are not available in this version of PHP. Try to use another driver.",LOG_ERR);
-			return $this->ok;
+			return;
 		}*/
 
 		/*if (! $host)
@@ -95,7 +95,7 @@ class DoliDBSqlite3 extends DoliDB
 			$this->ok = false;
 			$this->error=$langs->trans("ErrorWrongHostParameter");
 			dol_syslog(get_class($this)."::DoliDBSqlite3 : Erreur Connect, wrong host parameters",LOG_ERR);
-			return $this->ok;
+			return;
 		}*/
 
 		// Essai connexion serveur
@@ -126,8 +126,6 @@ class DoliDBSqlite3 extends DoliDB
 			//$this->error=sqlite_connect_error();
 			dol_syslog(get_class($this)."::DoliDBSqlite3 : Error Connect ".$this->error, LOG_ERR);
 		}
-
-		return $this->ok;
 	}
 
 

--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -116,7 +116,7 @@ class ImportXlsx extends ModeleImports
 		if (!class_exists('ZipArchive')) {	// For Excel2007
 			$langs->load("errors");
 			$this->error = $langs->trans('ErrorPHPNeedModule', 'zip');
-			return -1;
+			return;
 		}
 		$this->label_lib = 'PhpSpreadSheet';
 		$this->version_lib = '1.8.0';

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -24,7 +24,7 @@ require_once DOL_DOCUMENT_ROOT . '/fourn/class/paiementfourn.class.php';
 /**
  * API class for supplier invoices
  *
- * @property DoliDB db
+ * @property DoliDB $db
  * @access protected
  * @class  DolibarrApiAccess {@requires user,external}
  */

--- a/htdocs/product/class/propalmergepdfproduct.class.php
+++ b/htdocs/product/class/propalmergepdfproduct.class.php
@@ -577,6 +577,6 @@ class PropalmergepdfproductLine
 	 */
 	public function __construct()
 	{
-		return 1;
+		return;
 	}
 }


### PR DESCRIPTION
# QUAL Updates to fix phan notices

- __construct() methods have not return value;
- PHPDoc for $db typing hint was incorrect.

