### PR TITLE
FIX arrayname to array value (/dereference arrayname to array value)

### DIFF
--- a/htdocs/mrp/class/api_mos.class.php
+++ b/htdocs/mrp/class/api_mos.class.php
@@ -366,7 +366,7 @@ class Mos extends DolibarrApi
 			$pos = 0;
 			$arrayofarrayname = array("arraytoconsume","arraytoproduce");
 			foreach ($arrayofarrayname as $arrayname) {
-				foreach ($arrayname as $value) {
+				foreach (${$arrayname} as $value) {
 					$tmpproduct = new Product($this->db);
 					if (empty($value["objectid"])) {
 						throw new RestException(500, "Field objectid required in ".$arrayname);


### PR DESCRIPTION
# FIX Dereferencing variable
The intention of the code is clearly to loop over the array that arrayname references, otherwise this would try to loop (foreach) over a string.

Was detected by phan as:
`htdocs/mrp/class/api_mos.class.php:369 PhanTypeMismatchForeach 'arraytoconsume'|'arraytoproduce' passed to foreach instead of array`