### PR TITLE
QUAL Fix typing hint for date (which is int|string)

### DIFF
--- a/htdocs/salaries/class/paymentsalary.class.php
+++ b/htdocs/salaries/class/paymentsalary.class.php
@@ -57,14 +57,14 @@ class PaymentSalary extends CommonObject
 	public $tms = '';
 
 	/**
-	 * @var date date of payment
+	 * @var int|string date of payment
 	 * @deprecated
 	 * @see datep
 	 */
 	public $datepaye = '';
 
 	/**
-	 * @var date date of payment
+	 * @var int|string date of payment
 	 */
 	public $datep = '';
 


### PR DESCRIPTION
# QUAL Fix typing hint for date (which is int|string)
Date is represented as int or string according to return from DoliDb::jdate() .  'date' was not a valid type.

