### PR TITLE
QUAL PHP-CS-FIXER configuration and applied upgrade to PHP7.1 + Possiblity to fix PSR-12

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,30 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+	->in(__DIR__)
+	->exclude([
+		'htdocs/includes',
+	])
+	->notPath([
+		'vendor',
+	])
+;
+
+return (new PhpCsFixer\Config())
+	->setRules([
+		// Apply PSR-12 as per https://wiki.dolibarr.org/index.php?title=Langages_et_normes#PHP:~:text=utiliser%20est%20le-,PSR%2D12,-(https%3A//www
+		// '@PSR12' => true,  // Disabled for now to limit number of changes
+		// Minimum version Dolibarr v18.0.0
+		'@PHP71Migration' => true,
+		//'strict_param' => true,
+		//'array_syntax' => ['syntax' => 'short'],
+		'array_syntax' => false,
+	])
+	->setFinder($finder)
+	// TAB Indent violates PSR-12 "must" rule, but used in code
+	// (See https://www.php-fig.org/psr/psr-12/#24-indenting )
+	->setIndent("\t")
+	// All files MUST use the Unix LF line ending only
+	// https://www.php-fig.org/psr/psr-12/#22-files
+	->setLineEnding("\n")
+;

--- a/dev/tools/run-php-cs-fixer.sh
+++ b/dev/tools/run-php-cs-fixer.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#
+# Usage:
+#   Optionally set COMPOSER_CMD to the command to use to run composer.
+#   Optionally set COMPOSER_VENDOR_DIR to your vendor path for composer.
+#
+#   Run php-cs-fixer by calling this script:
+#     ./run-php-cs-fixer.sh check    # Only checks (the default)
+#     ./run-php-cs-fixer.sh fix      # Fixes
+#
+#   You can fix only a few files using
+#     ./run-php-cs-fixer.sh fix htdocs/path/to/myfile.php
+#
+#   You can run this from the root directory of dolibarr
+#     dev/tools/run-php-cs-fixer.sh fix htdocs/path/to/myfile.php
+#
+#   You can provide the environment variables on the CLI like this:
+#     COMPOSER_CMD="php ~/composer.phar" COMPOSER_VENDOR_DIR="~/vendor" ./run-php-cs-fixer.sh
+#
+#   or export them:
+#     export COMPOSER_CMD="php ~/composer.phar"
+#     export COMPOSER_VENDOR_DIR="~/vendor"
+#     ./run-php-cs-fixer.sh
+#
+#  Or some other method
+#
+
+
+MYDIR=$(dirname "$(realpath "$0")")
+export COMPOSER_VENDOR_DIR=${COMPOSER_VENDOR_DIR:=$MYDIR/vendor}
+COMPOSER_CMD=${COMPOSER_CMD:=composer}
+
+#
+# Install/update
+#
+PHP_CS_FIXER="${COMPOSER_VENDOR_DIR}/bin/php-cs-fixer"
+if [ ! -r "${PHP_CS_FIXER}" ] ; then
+  [[ ! -e "${COMPOSER_VENDOR_DIR}" ]] && ${COMPOSER_CMD} install
+  [[ -e "${COMPOSER_VENDOR_DIR}" ]] && ${COMPOSER_CMD} update
+  ${COMPOSER_CMD} require --dev friendsofphp/php-cs-fixer
+fi
+
+
+(
+  cd "${MYDIR}/../.." || exit
+  CMD=
+  # If no argument, run check by default
+  [[ "$1" == "" ]] && CMD=check
+  # shellcheck disable=SC2086
+  "${PHP_CS_FIXER}" $CMD "$@"
+)


### PR DESCRIPTION
# QUAL Use PHP-CS-FIXER for code upgrades

I propose a php-cs-fixer configuration which currently only upgrade the to PHP7.1 - and I disabled changes from array() to [].

I think this improves readability and performance (isset() replaced with ...??).

The configuration is contained in `.php-cs-fixer.dist.php` which is a configuration file detected by the tool so that fixing just requires:
```
.../php-cs-fixer fix
```