### PR TITLE
Fix stock on disapproval

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1268,7 +1268,8 @@ class CommandeFournisseur extends CommonOrder
 					$up_ht_disc = price2num($up_ht_disc * (100 - $this->lines[$i]->remise_percent) / 100, 'MU');
 				}
 				$originEntrepot = "SELECT fk_entrepot FROM " . MAIN_DB_PREFIX . "stock_mouvement ";
-				$originEntrepot .= "WHERE fk_origin = " . (int) $this->id . " AND origintype = '" . $this->db->sanitize($this->element) . "' AND value = " . (int) $this->lines[$i]->qty . " AND price = " . $up_ht_disc . " ";
+				$originEntrepot .= "WHERE fk_origin = " . (int) $this->id . " AND origintype = '" . $this->db->sanitize($this->element) . "' ";
+				$originEntrepot .= "AND value = " . (int) $this->lines[$i]->qty . " AND price = " . (float) $up_ht_disc . " ";
 				$originEntrepot .= "AND fk_product = " . (int) $this->lines[$i]->fk_product . " ORDER BY rowid DESC LIMIT 1";
 				$resEntrepot = $this->db->query($originEntrepot);
 				$fk_entrepot = $this->db->fetch_object($resEntrepot)->fk_entrepot;

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1243,9 +1243,10 @@ class CommandeFournisseur extends CommonOrder
 	/**
 	 * Create reverse Stock Moves and apply them on disapproval
 	 *
+  	 *	@param	User	$user			Object user
 	 * @return int 		<0 if KO, >0 if OK
 	 */
-	public function rollbackStockMovesOnDisapproval()
+	public function rollbackStockMovesOnDisapproval($user)
 	{
 		global $langs, $conf;
 
@@ -1267,8 +1268,8 @@ class CommandeFournisseur extends CommonOrder
 					$up_ht_disc = price2num($up_ht_disc * (100 - $this->lines[$i]->remise_percent) / 100, 'MU');
 				}
 				$originEntrepot = "SELECT fk_entrepot FROM " . MAIN_DB_PREFIX . "stock_mouvement ";
-				$originEntrepot .= "WHERE fk_origin = " . $this->id . " AND origintype = '" . $this->element . "' AND value = " . $this->lines[$i]->qty . " AND price = " . $up_ht_disc . " ";
-				$originEntrepot .= "AND fk_product = " . $this->lines[$i]->fk_product . " ORDER BY rowid DESC LIMIT 1";
+				$originEntrepot .= "WHERE fk_origin = " . (int) $this->id . " AND origintype = '" . $this->db->sanitize($this->element) . "' AND value = " . (int) $this->lines[$i]->qty . " AND price = " . $up_ht_disc . " ";
+				$originEntrepot .= "AND fk_product = " . (int) $this->lines[$i]->fk_product . " ORDER BY rowid DESC LIMIT 1";
 				$resEntrepot = $this->db->query($originEntrepot);
 				$fk_entrepot = $this->db->fetch_object($resEntrepot)->fk_entrepot;
 

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1243,7 +1243,7 @@ class CommandeFournisseur extends CommonOrder
 	/**
 	 * Create reverse Stock Moves and apply them on disapproval
 	 *
-  	 *	@param	User	$user			Object user
+  	 * @param User	$user	Object user
 	 * @return int 		<0 if KO, >0 if OK
 	 */
 	public function rollbackStockMovesOnDisapproval($user)

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1243,7 +1243,7 @@ class CommandeFournisseur extends CommonOrder
 	/**
 	 * Create reverse Stock Moves and apply them on disapproval
 	 *
-  	 * @param User	$user	Object user
+	 *	@param	User	$user			Object user
 	 * @return int 		<0 if KO, >0 if OK
 	 */
 	public function rollbackStockMovesOnDisapproval($user)

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1239,10 +1239,10 @@ class CommandeFournisseur extends CommonOrder
 		}
 		return -1;
 	}
-	
+
 	/**
 	 * Create reverse Stock Moves and apply them on disapproval
-	 * 
+	 *
 	 * @return int 		<0 if KO, >0 if OK
 	 */
 	public function rollbackStockMovesOnDisapproval()
@@ -1285,7 +1285,7 @@ class CommandeFournisseur extends CommonOrder
 			return 1;
 		}
 	}
-	
+
 	/**
 	 * 	Refuse an order
 	 *

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -375,7 +375,7 @@ if (empty($reshook)) {
 			$result = $object->setStatus($user, $newstatus);
 			// If stock is incremented on validate order, we must create inverse stock movements
 			if ($result > 0 && $reverseStockMoves) {
-				$resStock = $object->rollbackStockMovesOnDisapproval();
+				$resStock = $object->rollbackStockMovesOnDisapproval($user);
 			}
 
 			if ($result > 0 && (!$reverseStockMoves || $resStock > 0)) {

--- a/htdocs/langs/en_US/agenda.lang
+++ b/htdocs/langs/en_US/agenda.lang
@@ -202,3 +202,4 @@ AppointmentDuration = Appointment Duration : %s
 BookingSuccessfullyBooked=Your booking has been saved
 BookingReservationHourAfter=We confirm the reservation of your meeting at the date %s
 BookcalBookingTitle=Online appointment
+OrderDisapprovedInDolibarr=Order %s disapproved


### PR DESCRIPTION
# FIX Stock on supplier order disapproval
## Bug
If the stock configuration is set to increments on supplier order approval, no action was planned on disapproval. 
So stocks were incremented twice if the supplier order was reopened.

## Expected Behaviour
On reopen, with this stock configuration, stocks must be reversed.   

## Solution 
Check if concerned, and for each line of the suppplier_order, create a livraison which invert the recent receptions 