### PR TITLE
New POS admin setting to disable sales to the default customer

### DIFF
--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -1871,6 +1871,7 @@ ClickToDialUseTelLinkDesc=Use this method if your users have a softphone or a so
 CashDesk=Point of Sale
 CashDeskSetup=Point of Sales module setup
 CashDeskThirdPartyForSell=Default generic third party to use for sales
+ForbidSalesToTheDefaultCustomer=Forbid sales to the generic third party
 CashDeskBankAccountForSell=Default account to use to receive cash payments
 CashDeskBankAccountForCheque=Default account to use to receive payments by check
 CashDeskBankAccountForCB=Default account to use to receive payments by credit cards

--- a/htdocs/langs/en_US/cashdesk.lang
+++ b/htdocs/langs/en_US/cashdesk.lang
@@ -68,6 +68,7 @@ PrintCustomerOnReceipts=Print customer on tickets|receipts
 EnableBarOrRestaurantFeatures=Enable features for Bar or Restaurant
 ConfirmDeletionOfThisPOSSale=Do your confirm the deletion of this current sale ?
 ConfirmDiscardOfThisPOSSale=Do you want to discard this current sale ?
+NoClientErrorMessage=Please select a customer first
 History=History
 ValidateAndClose=Validate and close
 Terminal=Terminal

--- a/htdocs/takepos/admin/terminal.php
+++ b/htdocs/takepos/admin/terminal.php
@@ -164,6 +164,11 @@ $filter = '((s.client:IN:1,2,3) AND (s.status:=:1))';
 print $form->select_company(getDolGlobalInt('CASHDESK_ID_THIRDPARTY'.$terminaltouse), 'socid', $filter, 1, 0, 0, array(), 0, 'maxwidth500 widthcentpercentminusx');
 print '</td></tr>';
 
+print '<tr class="oddeven"><td>'.$langs->trans("ForbidSalesToTheDefaultCustomer").'</td>';
+print '<td>';
+print ajax_constantonoff("TAKEPOS_FORBID_SALES_TO_DEFAULT_CUSTOMER", array(), $conf->entity, 0, 0, 1, 0);
+print '</td></tr>';
+
 $atleastonefound = 0;
 if (isModEnabled("banque")) {
 	print '<tr class="oddeven"><td>'.$langs->trans("CashDeskBankAccountForSell").'</td>';

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -539,6 +539,14 @@ function Reduction() {
 }
 
 function CloseBill() {
+	<?php
+	if (!empty($conf->global->TAKEPOS_FORBID_SALES_TO_DEFAULT_CUSTOMER)) {
+		echo "customerAnchorTag = document.querySelector('a[id=\"customer\"]'); ";
+		echo "if (customerAnchorTag && customerAnchorTag.innerText.trim() === '".$langs->trans("Customer")."') { ";
+		echo "alert('".$langs->trans("NoClientErrorMessage")."'); ";
+		echo "return; } \n";
+	}
+	?>
 	invoiceid = $("#invoiceid").val();
 	console.log("Open popup to enter payment on invoiceid="+invoiceid);
 	$.colorbox({href:"pay.php?place="+place+"&invoiceid="+invoiceid, width:"80%", height:"90%", transition:"none", iframe:"true", title:""});


### PR DESCRIPTION
# NEW POS admin setting to disable sales to the default customer
Added a new setting in the TakePOS admin section to disable sales to the default third party. If enabled, the POS requires the user to select a customer if (s)he did not.



