### PR TITLE
FIX include oauth.lib.php, not require_once as it defines local varia…

### DIFF
--- a/htdocs/admin/emailcollector_card.php
+++ b/htdocs/admin/emailcollector_card.php
@@ -403,7 +403,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			if ($object->acces_type == 1) {
 				// Mode OAUth2 with PHP-IMAP
-				require_once DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // define $supportedoauth2array
+				include DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // define $supportedoauth2array
 				$keyforsupportedoauth2array = $object->oauth_service;
 				if (preg_match('/^.*-/', $keyforsupportedoauth2array)) {
 					$keyforprovider = preg_replace('/^.*-/', '', $keyforsupportedoauth2array);

--- a/htdocs/admin/oauth.php
+++ b/htdocs/admin/oauth.php
@@ -27,7 +27,7 @@
 // Load Dolibarr environment
 require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php';
+include DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php';
 
 // $supportedoauth2array is defined into oauth.lib.php
 

--- a/htdocs/admin/oauthlogintokens.php
+++ b/htdocs/admin/oauthlogintokens.php
@@ -26,7 +26,7 @@
 // Load Dolibarr environment
 require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // This define $list and $supportedoauth2array
+include DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // This define $list and $supportedoauth2array
 require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
 use OAuth\Common\Storage\DoliStorage;
 

--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -924,7 +924,7 @@ class CMailFile
 				if (getDolGlobalString($keyforsmtpauthtype) === "XOAUTH2") {
 					$supportedoauth2array = array();
 
-					require_once DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // define $supportedoauth2array
+					include DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // define $supportedoauth2array
 
 					$keyforsupportedoauth2array = $conf->global->$keyforsmtpoauthservice;
 					if (preg_match('/^.*-/', $keyforsupportedoauth2array)) {
@@ -1079,7 +1079,7 @@ class CMailFile
 				if (getDolGlobalString($keyforsmtpauthtype) === "XOAUTH2") {
 					$supportedoauth2array = array();
 
-					require_once DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // define $supportedoauth2array
+					include DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // define $supportedoauth2array
 
 					$keyforsupportedoauth2array = getDolGlobalString($keyforsmtpoauthservice);
 					if (preg_match('/^.*-/', $keyforsupportedoauth2array)) {

--- a/htdocs/core/lib/oauth.lib.php
+++ b/htdocs/core/lib/oauth.lib.php
@@ -320,32 +320,33 @@ $list = array(
 );
 
 
+if (!function_exists('oauthadmin_prepare_head')) {
+	/**
+	 * Return array of tabs to used on pages to setup cron module.
+	 *
+	 * @return 	array				Array of tabs
+	 */
+	function oauthadmin_prepare_head()
+	{
+		global $langs, $conf;
+		$h = 0;
+		$head = array();
 
-/**
- * Return array of tabs to used on pages to setup cron module.
- *
- * @return 	array				Array of tabs
- */
-function oauthadmin_prepare_head()
-{
-	global $langs, $conf;
-	$h = 0;
-	$head = array();
+		$head[$h][0] = dol_buildpath('/admin/oauth.php', 1);
+		$head[$h][1] = $langs->trans("OAuthServices");
+		$head[$h][2] = 'services';
+		$h++;
 
-	$head[$h][0] = dol_buildpath('/admin/oauth.php', 1);
-	$head[$h][1] = $langs->trans("OAuthServices");
-	$head[$h][2] = 'services';
-	$h++;
+		$head[$h][0] = dol_buildpath('/admin/oauthlogintokens.php', 1);
+		$head[$h][1] = $langs->trans("TokenManager");
+		$head[$h][2] = 'tokengeneration';
+		$h++;
 
-	$head[$h][0] = dol_buildpath('/admin/oauthlogintokens.php', 1);
-	$head[$h][1] = $langs->trans("TokenManager");
-	$head[$h][2] = 'tokengeneration';
-	$h++;
+		complete_head_from_modules($conf, $langs, null, $head, $h, 'oauthadmin');
 
-	complete_head_from_modules($conf, $langs, null, $head, $h, 'oauthadmin');
-
-	complete_head_from_modules($conf, $langs, null, $head, $h, 'oauthadmin', 'remove');
+		complete_head_from_modules($conf, $langs, null, $head, $h, 'oauthadmin', 'remove');
 
 
-	return $head;
+		return $head;
+	}
 }

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1134,7 +1134,7 @@ class EmailCollector extends CommonObject
 				// Mode OAUth2 with PHP-IMAP
 				$supportedoauth2array = array();
 
-				require_once DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // define $supportedoauth2array
+				include DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php'; // define $supportedoauth2array
 				$keyforsupportedoauth2array = $this->oauth_service;
 				if (preg_match('/^.*-/', $keyforsupportedoauth2array)) {
 					$keyforprovider = preg_replace('/^.*-/', '', $keyforsupportedoauth2array);


### PR DESCRIPTION
# FIX include, not require_once a oath.lib.php which defines locals.

DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php' defines locals.
"require_once" would make the code fail on multiple calls or when the file is included in multiple locations in the same execution.

So this must be included every time.