### PR TITLE
Fix Issue of empty description in multilanguage

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1502,7 +1502,7 @@ function pdf_getlinedesc($object, $i, $outputlangs, $hideref = 0, $hidedesc = 0,
 			} else {
 				$textwasnotmodified = ($desc == $prodser->description);
 			}
-			if (!empty($prodser->multilangs[$outputlangs->defaultlang]["description"])) {
+			if (!empty($prodser->multilangs[$outputlangs->defaultlang]["label"])) {
 				if ($textwasnotmodified) {
 					$desc = str_replace($prodser->description, $prodser->multilangs[$outputlangs->defaultlang]["description"], $desc);
 				} elseif ($translatealsoifmodified) {


### PR DESCRIPTION
# FIX|Fix #[*issue_number Short description*]
When you generate a document when a product description is empty, the default language is displayed


