### PR TITLE
Fix TakePOS SumUp connector

### DIFF
--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -472,6 +472,9 @@ if (!getDolGlobalInt("TAKEPOS_NUMPAD")) {
 		if (amountpayed > <?php echo $invoice->total_ttc; ?>) {
 			amountpayed = <?php echo $invoice->total_ttc; ?>;
 		}
+		if (amountpayed == 0) {
+            amountpayed = <?php echo $invoice->total_ttc; ?>;
+        }
 
 		// Starting sumup app
 		window.open('sumupmerchant://pay/1.0?affiliate-key=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_AFFILIATE')) ?>&app-id=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_APPID')) ?>&amount=' + amountpayed + '&currency=EUR&title=' + invoiceid + '&callback=<?php echo DOL_MAIN_URL_ROOT ?>/takepos/smpcb.php');

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -474,7 +474,7 @@ if (!getDolGlobalInt("TAKEPOS_NUMPAD")) {
 		}
 
 		// Starting sumup app
-		window.open('sumupmerchant://pay/1.0?affiliate-key=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_AFFILIATE')) ?>&app-id=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_APPID')) ?>&total=' + amountpayed + '&currency=EUR&title=' + invoiceid + '&callback=<?php echo DOL_MAIN_URL_ROOT ?>/takepos/smpcb.php');
+		window.open('sumupmerchant://pay/1.0?affiliate-key=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_AFFILIATE')) ?>&app-id=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_APPID')) ?>&amount=' + amountpayed + '&currency=EUR&title=' + invoiceid + '&callback=<?php echo DOL_MAIN_URL_ROOT ?>/takepos/smpcb.php');
 
 		var loop = window.setInterval(function () {
 			$.ajax({

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -475,9 +475,10 @@ if (!getDolGlobalInt("TAKEPOS_NUMPAD")) {
 		if (amountpayed == 0) {
             amountpayed = <?php echo $invoice->total_ttc; ?>;
         }
+		var currencycode = "<?php echo $invoice->multicurrency_code; ?>";
 
 		// Starting sumup app
-		window.open('sumupmerchant://pay/1.0?affiliate-key=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_AFFILIATE')) ?>&app-id=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_APPID')) ?>&amount=' + amountpayed + '&currency=EUR&title=' + invoiceid + '&callback=<?php echo DOL_MAIN_URL_ROOT ?>/takepos/smpcb.php');
+	    window.open('sumupmerchant://pay/1.0?affiliate-key=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_AFFILIATE')) ?>&app-id=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_APPID')) ?>&amount=' + amountpayed + '&currency=' + currencycode + '&title=' + invoiceid + '&callback=<?php echo DOL_MAIN_URL_ROOT ?>/takepos/smpcb.php');
 
 		var loop = window.setInterval(function () {
 			$.ajax({

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -473,12 +473,12 @@ if (!getDolGlobalInt("TAKEPOS_NUMPAD")) {
 			amountpayed = <?php echo $invoice->total_ttc; ?>;
 		}
 		if (amountpayed == 0) {
-            amountpayed = <?php echo $invoice->total_ttc; ?>;
-        }
+			amountpayed = <?php echo $invoice->total_ttc; ?>;
+		}
 		var currencycode = "<?php echo $invoice->multicurrency_code; ?>";
 
 		// Starting sumup app
-	    window.open('sumupmerchant://pay/1.0?affiliate-key=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_AFFILIATE')) ?>&app-id=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_APPID')) ?>&amount=' + amountpayed + '&currency=' + currencycode + '&title=' + invoiceid + '&callback=<?php echo DOL_MAIN_URL_ROOT ?>/takepos/smpcb.php');
+		window.open('sumupmerchant://pay/1.0?affiliate-key=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_AFFILIATE')) ?>&app-id=<?php echo urlencode(getDolGlobalString('TAKEPOS_SUMUP_APPID')) ?>&amount=' + amountpayed + '&currency=' + currencycode + '&title=' + invoiceid + '&callback=<?php echo DOL_MAIN_URL_ROOT ?>/takepos/smpcb.php');
 
 		var loop = window.setInterval(function () {
 			$.ajax({


### PR DESCRIPTION
This PR fixes:
1) Add SumUp connector compatibility with SumUp app on iOS

**Explanation**

https://github.com/sumup/sumup-android-api
VS https://github.com/sumup/sumup-ios-url-scheme

The amount field is deprecated on the Android API but not on the iOS API. The iOS API does not support the total field, only the Android API does support the total field. Hopefully, the Android API supports as well the amount field that is only partially deprecated on the Android API. For maximum compatibility with both Android/iOS SumUp app, best to keep this field as "amount" rather than "total".

2) The second issue is the set amount was 0 instead of the real amount! It is now fixed.

3) TakePOS SumUp connector now has multicurrency support instead of only EUR that was hardcoded.