### PR TITLE
QUAL Limit size of the description in Vinci pdf

### DIFF
--- a/htdocs/core/modules/mrp/doc/pdf_vinci.modules.php
+++ b/htdocs/core/modules/mrp/doc/pdf_vinci.modules.php
@@ -1178,7 +1178,7 @@ class pdf_vinci extends ModelePDFMo
 			$pdf->SetFont('', 'B', $default_font_size + 3);
 			$pdf->SetXY($posx, $posy);
 			$pdf->SetTextColor(0, 0, 60);
-			$pdf->MultiCell($w, 3, html_entity_decode($prodToMake->description), '', 'R');
+			$pdf->MultiCell($w, 3, html_entity_decode($prodToMake->description), '', 'R', false, 1, '', '', true, 0, false, true, 51, 'T', true);
 			$posy = $pdf->GetY() - 5;
 
 			// dimensions


### PR DESCRIPTION
Limit the size of the product description to avoid overflow when it is too voluminous.
![description overflow](https://github.com/Dolibarr/dolibarr/assets/21126730/f2a4f9b9-58d1-4529-b4cd-8740be8436d3)
