### PR TITLE
Update API products for multiprices api_products.class.php

### DIFF
--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -322,12 +322,33 @@ class Products extends DolibarrApi
 			throw new RestException(500, "Error creating product", array_merge(array($this->product->error), $this->product->errors));
 		}
 
+		if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
+			for ($key = 1; $key <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $key++) {
+				$newvat = $this->product->multiprices_tva_tx[$key];
+				$newnpr = 0;
+				$newvatsrccode = $this->product->default_vat_code;
+				$newprice = $this->product->multiprices[$key];
+				$newpricemin = $this->product->multiprices_min[$key];
+				$newbasetype = $this->product->multiprices_base_type[$key];
+				if (empty($newbasetype) || $newbasetype == '') {
+					$newbasetype = $this->product->price_base_type;
+				}
+				if ($newbasetype == 'TTC') {
+					$newprice = $this->product->multiprices_ttc[$key];
+					$newpricemin = $this->product->multiprices_min_ttc[$key];
+				}
+				if ($newprice > 0) {
+					$result = $this->product->updatePrice($newprice, $newbasetype, DolibarrApiAccess::$user, $newvat, $newpricemin, $key, $newnpr, 0, 0, array(), $newvatsrccode);
+				}
+			}
+		}
+
 		return $this->product->id;
 	}
 
 	/**
 	 * Update product.
-	 * Price will be updated by this API only if option is set on "One price per product". See other APIs for other price modes.
+	 * Price will be updated by this API (supports PRODUCT_PRICE_UNIQ / PRODUIT_MULTIPRICES)
 	 *
 	 * @param  int   $id           Id of product to update
 	 * @param  array $request_data Datas
@@ -338,7 +359,7 @@ class Products extends DolibarrApi
 	 */
 	public function put($id, $request_data = null)
 	{
-		global $conf;
+		// global $conf;
 
 		if (!DolibarrApiAccess::$user->rights->produit->creer) {
 			throw new RestException(401);
@@ -378,7 +399,8 @@ class Products extends DolibarrApi
 			$pricemodified = false;
 			if ($this->product->price_base_type != $oldproduct->price_base_type) {
 				$pricemodified = true;
-			} else {
+			} 
+			else {
 				if ($this->product->tva_tx != $oldproduct->tva_tx) {
 					$pricemodified = true;
 				}
@@ -396,7 +418,9 @@ class Products extends DolibarrApi
 					if ($this->product->price_min_ttc != $oldproduct->price_min_ttc) {
 						$pricemodified = true;
 					}
-				} else {
+				}
+				else
+				{
 					if ($this->product->price != $oldproduct->price) {
 						$pricemodified = true;
 					}
@@ -419,6 +443,41 @@ class Products extends DolibarrApi
 				}
 
 				$result = $this->product->updatePrice($newprice, $this->product->price_base_type, DolibarrApiAccess::$user, $newvat, $newpricemin, 0, $newnpr, 0, 0, array(), $newvatsrccode);
+			}
+		}
+
+		if ($result > 0 && getDolGlobalString('PRODUIT_MULTIPRICES')) {
+			for ($key = 1; $key <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $key++) {
+				$pricemodified = false;
+				if ($this->product->multiprices_base_type[$key] != $oldproduct->multiprices_base_type[$key]) {
+					$pricemodified = true;
+				} else {
+					if ($this->product->multiprices_tva_tx[$key] != $oldproduct->multiprices_tva_tx[$key]) $pricemodified = true;
+					if ($this->product->multiprices_base_type[$key] == 'TTC') {
+						if ($this->product->multiprices_ttc[$key] != $oldproduct->multiprices_ttc[$key]) $pricemodified = true;
+						if ($this->product->multiprices_min_ttc[$key] != $oldproduct->multiprices_min_ttc[$key]) $pricemodified = true;
+					} else {
+						if ($this->product->multiprices[$key] != $oldproduct->multiprices[$key]) $pricemodified = true;
+						if ($this->product->multiprices_min[$key] != $oldproduct->multiprices[$key]) $pricemodified = true;
+					}
+				}
+				if ($pricemodified && $result > 0) {
+					$newvat = $this->product->multiprices_tva_tx[$key];
+					$newnpr = 0;
+					$newvatsrccode = $this->product->default_vat_code;
+					$newprice = $this->product->multiprices[$key];
+					$newpricemin = $this->product->multiprices_min[$key];
+					$newbasetype = $this->product->multiprices_base_type[$key];
+					if (empty($newbasetype) || $newbasetype == '') {
+						$newbasetype = $this->product->price_base_type;
+					}
+					if ($newbasetype == 'TTC') {
+						$newprice = $this->product->multiprices_ttc[$key];
+						$newpricemin = $this->product->multiprices_min_ttc[$key];
+					}
+
+					$result = $this->product->updatePrice($newprice, $newbasetype, DolibarrApiAccess::$user, $newvat, $newpricemin, $key, $newnpr, 0, 0, array(), $newvatsrccode);
+				}
 			}
 		}
 


### PR DESCRIPTION
_cancelled due to some checks not passing, will submit after corrections_

PRODUIT_MULTIPRICES is currently supported by get function, but not post and update
this code, credited to @ruemmlernet,  adds PRODUIT_MULTIPRICES support in post and put functions

# FIX|Fix #18080
allow to pass objects with multiprices during creation or update of a product

example with python Dolibarr API  and 7 levels of prices: 
```
p = {   
    "ref": " P9999",
    "label": "test product", 
    "price_base_type": "HT",
    "default_vat_code": "20",
    "tva_tx": "20.0000",
    "price": 199.98,
    "multiprices": {"1": "199.98", "2": "180", "3": "170", "4": "160", "5": "150", "6": "140", "7": "139.99"},
    "multiprices_base_type": {"1": "HT", "2": "HT", "3": "HT", "4": "HT", "5": "HT", "6": "HT", "7": "HT"},
    "multiprices_tva_tx": {"1": "20", "2": "20", "3": "20", "4": "20", "5": "20", "6": "20", "7": "20"}
}
last_id = dolibarr_inst.call_create_api('products', p)
print( dolibarr_inst.call_get_api('products', last_id) )
```

