### PR TITLE
FIX: total_time at bottom in project overview only showing last value, instead of a sum of all records

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1003,6 +1003,7 @@ print '<br><br>';
 print '<br>';
 
 
+$total_time = 0;
 
 // Detail
 foreach ($listofreferent as $key => $value) {
@@ -1314,7 +1315,6 @@ foreach ($listofreferent as $key => $value) {
 				// Date or TimeSpent
 				$date = '';
 				$total_time_by_line = null;
-				$total_time = 0;
 				if ($tablename == 'expensereport_det') {
 					$date = $element->date; // No draft status on lines
 				} elseif ($tablename == 'stock_mouvement') {


### PR DESCRIPTION
# FIX | #26962 Fix the total_time variable, that is always showing only the last line value, instead of a sum.

This PR is related to https://github.com/Dolibarr/dolibarr/issues/26962
