### PR TITLE
fix sql error in case of balance is empty

### DIFF
--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -650,6 +650,14 @@ class Account extends CommonObject
 			return -1;
 		}
 
+		$balance = $this->balance;
+		if (empty($balance) && !empty($this->solde)) {
+			$balance = $this->solde;
+		}
+		if (empty($balance)) {
+			$balance = 0;
+		}
+
 		// Chargement librairie pour acces fonction controle RIB
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/bank.lib.php';
 
@@ -721,7 +729,7 @@ class Account extends CommonObject
 				$accline = new AccountLine($this->db);
 				$accline->datec = $this->db->idate($now);
 				$accline->label = '('.$langs->trans("InitialBankBalance").')';
-				$accline->amount = price2num($this->solde);
+				$accline->amount = price2num($balance);
 				$accline->fk_user_author = $user->id;
 				$accline->fk_account = $this->id;
 				$accline->datev = $this->db->idate($this->date_solde);


### PR DESCRIPTION
# FIX create bank account with empty field on balance - sql error

![image](https://github.com/Dolibarr/dolibarr/assets/1468823/dde96d1d-3c8c-496e-9e94-84f8ce104e3c)

Ui set default balance to 0 but in case of user remove 0 and keep empty field -> sql error.

One solution could be on card form (and balance as required field) but the bug will be back in case of other way to call -> create on that object ... then my fix is against the class.