### PR TITLE
FIX missing accent characters in contact name (backport v17)

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -734,7 +734,7 @@ abstract class CommonObject
 
 		$ret .= dolGetFirstLastname($firstname, $lastname, $nameorder);
 
-		return dol_escape_htmltag(dol_trunc($ret, $maxlen));
+		return dol_escape_htmltag(dol_trunc($ret, $maxlen), 0, 0, '', 1);
 	}
 
 	/**


### PR DESCRIPTION
# FIX missing accent characters in contact name
On generation of various PDF (cyan, eratosthene, ...), if the contact name contains accents they aren't properly outputed in the sender part of the document. This fix adds the proper arguments to the `dol_escape_htmltag` method used in the `getFullName` method of the `CommonObject` in order to not escape special characters. 

This was already fixed in V18+. If I'm not mistaken the `getFullName` method was moved to the User class and stopped making use of the `dol_escape_htmltag` method.

