### PR TITLE
QUAL Fix php-cs-fixer config to avoid 'public const' not ok for PHP7.0

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -41,6 +41,8 @@ return (new PhpCsFixer\Config())
 		// So we use target PHP70 for the moment.
 		'@PHP70Migration' => true,
 		//'@PHP71Migration' => true,
+                // Avoid adding public to const (incompatible with PHP 7.0):
+                'visibility_required' => ['elements'=>['property', 'method']],
 
 		//'strict_param' => true,
 		//'array_syntax' => ['syntax' => 'short'],


### PR DESCRIPTION
Do not create incompatibility with PHP7.0 with php-cs-fixer.

From #26969
> Also PR the add dev tools to change code, must be separated from PR that is the result of code changed.
I just added a few files here to test that the commit works.  It does on a push request, but not on a pull request - the latter might be possible by looking for the source repository and try to push the change there.

> Even if we target PHP 7.1+, there is currently nothing that force us to break compatibility with php 7.0

Ok, I'll remove this from the rules - I'll submit another PR to change the ruleset.

_Originally posted by @mdeweerd in https://github.com/Dolibarr/dolibarr/pull/26969#discussion_r1417490279_
            