### PR TITLE
Fix PHP7.0 incompatibility (void is introduced in 7.1)

### DIFF
--- a/htdocs/bom/class/api_boms.class.php
+++ b/htdocs/bom/class/api_boms.class.php
@@ -546,7 +546,7 @@ class Boms extends DolibarrApi
 	 *
 	 * @return void
 	 */
-	private function checkRefNumbering(): void
+	private function checkRefNumbering()
 	{
 		$ref = substr($this->bom->ref, 1, 4);
 		if ($this->bom->status > 0 && $ref == 'PROV') {


### PR DESCRIPTION
As indicated by @eldy in https://github.com/Dolibarr/dolibarr/pull/26969#discussion_r1417460346 - the codebase should remain compatible with PHP7.0 for the moment.