### PR TITLE
Fix: centered output of BOM date in linked objects block

### DIFF
--- a/htdocs/bom/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/bom/tpl/linkedobjectblock.tpl.php
@@ -62,7 +62,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 		$product_static->getNomUrl(1);
 	}
 	print '</td>';
-	echo '<td class="linkedcol-date">'.dol_print_date($objectlink->date_creation, 'day').'</td>';
+	echo '<td class="linkedcol-date center">'.dol_print_date($objectlink->date_creation, 'day').'</td>';
 	echo '<td class="linkedcol-amount right">';
 	if ($user->rights->commande->lire) {
 		$total = $total + $objectlink->total_ht;


### PR DESCRIPTION
In the linked object block on the cards, the date of the linked object is in most cases formatted centered (e.g. proposal/Angebot). Just for BOMs/Stücklisten the class center was missing and the output was left aligned.

Screenshot after change:
<img width="870" alt="image" src="https://github.com/Dolibarr/dolibarr/assets/10772984/9b32e141-d359-4fc0-ade4-0f17246ad735">


