### PR TITLE
Fix utf8_encoding/decoding (PHP8.2 deprecation)

### DIFF
--- a/htdocs/core/boxes/box_external_rss.php
+++ b/htdocs/core/boxes/box_external_rss.php
@@ -160,9 +160,9 @@ class box_external_rss extends ModeleBoxes
 
 			$isutf8 = utf8_check($title);
 			if (!$isutf8 && $conf->file->character_set_client == 'UTF-8') {
-				$title = utf8_encode($title);
+				$title = mb_convert_encoding($title, 'UTF-8', 'ISO-8859-1');
 			} elseif ($isutf8 && $conf->file->character_set_client == 'ISO-8859-1') {
-				$title = utf8_decode($title);
+				$title = mb_convert_encoding($title, 'ISO-8859-1');
 			}
 
 			$title = preg_replace("/([[:alnum:]])\?([[:alnum:]])/", "\\1'\\2", $title); // Gere probleme des apostrophes mal codee/decodee par utf8
@@ -173,9 +173,9 @@ class box_external_rss extends ModeleBoxes
 			$description = !empty($item['description']) ? $item['description'] : '';
 			$isutf8 = utf8_check($description);
 			if (!$isutf8 && $conf->file->character_set_client == 'UTF-8') {
-				$description = utf8_encode($description);
+				$description = mb_convert_encoding($description, 'UTF-8', 'ISO-8859-1');
 			} elseif ($isutf8 && $conf->file->character_set_client == 'ISO-8859-1') {
-				$description = utf8_decode($description);
+				$description = mb_convert_encoding($description, 'ISO-8859-1');
 			}
 			$description = preg_replace("/([[:alnum:]])\?([[:alnum:]])/", "\\1'\\2", $description);
 			$description = preg_replace("/^\s+/", "", $description);

--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -1750,7 +1750,7 @@ class CMailFile
 					$_retVal = $socket;
 				}
 			} else {
-				$this->error = utf8_check('Error '.$errno.' - '.$errstr) ? 'Error '.$errno.' - '.$errstr : utf8_encode('Error '.$errno.' - '.$errstr);
+				$this->error = utf8_check('Error '.$errno.' - '.$errstr) ? 'Error '.$errno.' - '.$errstr : mb_convert_encoding('Error '.$errno.' - '.$errstr, 'UTF-8', 'ISO-8859-1');
 			}
 		}
 		return $_retVal;

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -1511,10 +1511,10 @@ class Ldap
 	{
 		global $conf;
 		if ($pagecodefrom == 'ISO-8859-1' && $conf->file->character_set_client == 'UTF-8') {
-			$str = utf8_encode($str);
+			$str = mb_convert_encoding($str, 'UTF-8', 'ISO-8859-1');
 		}
 		if ($pagecodefrom == 'UTF-8' && $conf->file->character_set_client == 'ISO-8859-1') {
-			$str = utf8_decode($str);
+			$str = mb_convert_encoding($str, 'ISO-8859-1');
 		}
 		return $str;
 	}
@@ -1530,10 +1530,10 @@ class Ldap
 	{
 		global $conf;
 		if ($pagecodeto == 'ISO-8859-1' && $conf->file->character_set_client == 'UTF-8') {
-			$str = utf8_decode($str);
+			$str = mb_convert_encoding($str, 'ISO-8859-1');
 		}
 		if ($pagecodeto == 'UTF-8' && $conf->file->character_set_client == 'ISO-8859-1') {
-			$str = utf8_encode($str);
+			$str = mb_convert_encoding($str, 'UTF-8', 'ISO-8859-1');
 		}
 		return $str;
 	}

--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -803,10 +803,10 @@ class Translate
 	public function convToOutputCharset($str, $pagecodefrom = 'UTF-8')
 	{
 		if ($pagecodefrom == 'ISO-8859-1' && $this->charset_output == 'UTF-8') {
-			$str = utf8_encode($str);
+			$str = mb_convert_encoding($str, 'UTF-8', 'ISO-8859-1');
 		}
 		if ($pagecodefrom == 'UTF-8' && $this->charset_output == 'ISO-8859-1') {
-			$str = utf8_decode(str_replace('€', chr(128), $str));
+			$str = mb_convert_encoding(str_replace('€', chr(128), $str), 'ISO-8859-1');
 			// TODO Replace with iconv("UTF-8", "ISO-8859-1", str_replace('€', chr(128), $str)); ?
 		}
 		return $str;

--- a/htdocs/core/filemanagerdol/connectors/php/connector.lib.php
+++ b/htdocs/core/filemanagerdol/connectors/php/connector.lib.php
@@ -926,7 +926,7 @@ function ConvertToXmlAttribute($value)
 	}
 
 	if (strtoupper(substr($os, 0, 3)) === 'WIN' || FindBadUtf8($value)) {
-		return (utf8_encode(htmlspecialchars($value)));
+		return (mb_convert_encoding(htmlspecialchars($value), 'UTF-8', 'ISO-8859-1'));
 	} else {
 		return (htmlspecialchars($value));
 	}

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -113,7 +113,7 @@ function dol_dir_list($path, $types = "all", $recursive = 0, $filter = "", $excl
 			$fileperm = '';
 			while (false !== ($file = readdir($dir))) {        // $file is always a basename (into directory $newpath)
 				if (!utf8_check($file)) {
-					$file = utf8_encode($file); // To be sure data is stored in utf8 in memory
+					$file = mb_convert_encoding($file, 'UTF-8', 'ISO-8859-1'); // To be sure data is stored in utf8 in memory
 				}
 				$fullpathfile = ($newpath ? $newpath.'/' : '').$file;
 
@@ -1515,7 +1515,7 @@ function dol_delete_dir_recursive($dir, $count = 0, $nophperrors = 0, $onlysub =
 		if ($handle = opendir("$dir_osencoded")) {
 			while (false !== ($item = readdir($handle))) {
 				if (!utf8_check($item)) {
-					$item = utf8_encode($item); // should be useless
+					$item = mb_convert_encoding($item, 'UTF-8', 'ISO-8859-1'); // should be useless
 				}
 
 				if ($item != "." && $item != "..") {

--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -53,7 +53,7 @@ function jsUnEscape($source)
 				$unicodeHexVal = substr($source, $pos, 4);
 				$unicode = hexdec($unicodeHexVal);
 				$entity = "&#".$unicode.';';
-				$decodedStr .= utf8_encode($entity);
+				$decodedStr .= mb_convert_encoding($entity, 'UTF-8', 'ISO-8859-1');
 				$pos += 4;
 			} else {
 				// we have an escaped ascii character
@@ -154,9 +154,9 @@ function dol_print_file($langs, $filename, $searchalt = 0)
 			$content = file_get_contents($formfile);
 			$isutf8 = utf8_check($content);
 			if (!$isutf8 && $conf->file->character_set_client == 'UTF-8') {
-				print utf8_encode($content);
+				print mb_convert_encoding($content, 'UTF-8', 'ISO-8859-1');
 			} elseif ($isutf8 && $conf->file->character_set_client == 'ISO-8859-1') {
-				print utf8_decode($content);
+				print mb_convert_encoding($content, 'ISO-8859-1');
 			} else {
 				print $content;
 			}

--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -256,7 +256,7 @@ class ImportCsv extends ModeleImports
 						$newarrayres[$key]['val'] = $val;
 						$newarrayres[$key]['type'] = (dol_strlen($val) ? 1 : -1); // If empty we considere it's null
 					} else {
-						$newarrayres[$key]['val'] = utf8_encode($val);
+						$newarrayres[$key]['val'] = mb_convert_encoding($val, 'UTF-8', 'ISO-8859-1');
 						$newarrayres[$key]['type'] = (dol_strlen($val) ? 1 : -1); // If empty we considere it's null
 					}
 				} else { // Autodetect format (UTF8 or ISO)
@@ -264,7 +264,7 @@ class ImportCsv extends ModeleImports
 						$newarrayres[$key]['val'] = $val;
 						$newarrayres[$key]['type'] = (dol_strlen($val) ? 1 : -1); // If empty we considere it's null
 					} else {
-						$newarrayres[$key]['val'] = utf8_encode($val);
+						$newarrayres[$key]['val'] = mb_convert_encoding($val, 'UTF-8', 'ISO-8859-1');
 						$newarrayres[$key]['type'] = (dol_strlen($val) ? 1 : -1); // If empty we considere it's null
 					}
 				}

--- a/htdocs/ftp/index.php
+++ b/htdocs/ftp/index.php
@@ -101,7 +101,7 @@ $mesg = '';
 if ($action == 'uploadfile') {
 	// set up a connection or die
 	if (!$conn_id) {
-		$newsectioniso = utf8_decode($section);
+		$newsectioniso = mb_convert_encoding($section, 'ISO-8859-1');
 		$resultarray = dol_ftp_connect($ftp_server, $ftp_port, $ftp_user, $ftp_password, $newsectioniso, $ftp_passive);
 		$conn_id = $resultarray['conn_id'];
 		$ok = $resultarray['ok'];
@@ -131,7 +131,7 @@ if ($action == 'uploadfile') {
 if ($action == 'addfolder') {
 	// set up a connection or die
 	if (!$conn_id) {
-		$newsectioniso = utf8_decode($section);
+		$newsectioniso = mb_convert_encoding($section, 'ISO-8859-1');
 		$resultarray = dol_ftp_connect($ftp_server, $ftp_port, $ftp_user, $ftp_password, $newsectioniso, $ftp_passive);
 		$conn_id = $resultarray['conn_id'];
 		$ok = $resultarray['ok'];
@@ -173,7 +173,7 @@ if ($action == 'add' && $user->hasRight('ftp', 'setup')) {
 if ($action == 'confirm_deletefile' && GETPOST('confirm') == 'yes') {
 	// set up a connection or die
 	if (!$conn_id) {
-		$newsectioniso = utf8_decode($section);
+		$newsectioniso = mb_convert_encoding($section, 'ISO-8859-1');
 		$resultarray = dol_ftp_connect($ftp_server, $ftp_port, $ftp_user, $ftp_password, $newsectioniso, $ftp_passive);
 		$conn_id = $resultarray['conn_id'];
 		$ok = $resultarray['ok'];
@@ -201,7 +201,7 @@ if ($action == 'confirm_deletefile' && GETPOST('confirm') == 'yes') {
 if (GETPOST("const", 'array') && GETPOST("delete") && GETPOST("delete") == $langs->trans("Delete")) {
 	// set up a connection or die
 	if (!$conn_id) {
-		$newsectioniso = utf8_decode($section);
+		$newsectioniso = mb_convert_encoding($section, 'ISO-8859-1');
 		$resultarray = dol_ftp_connect($ftp_server, $ftp_port, $ftp_user, $ftp_password, $newsectioniso, $ftp_passive);
 		$conn_id = $resultarray['conn_id'];
 		$ok = $resultarray['ok'];
@@ -240,7 +240,7 @@ if (GETPOST("const", 'array') && GETPOST("delete") && GETPOST("delete") == $lang
 if ($action == 'confirm_deletesection' && $confirm == 'yes') {
 	// set up a connection or die
 	if (!$conn_id) {
-		$newsectioniso = utf8_decode($section);
+		$newsectioniso = mb_convert_encoding($section, 'ISO-8859-1');
 		$resultarray = dol_ftp_connect($ftp_server, $ftp_port, $ftp_user, $ftp_password, $newsectioniso, $ftp_passive);
 		$conn_id = $resultarray['conn_id'];
 		$ok = $resultarray['ok'];
@@ -270,7 +270,7 @@ if ($action == 'confirm_deletesection' && $confirm == 'yes') {
 if ($action == 'download') {
 	// set up a connection or die
 	if (!$conn_id) {
-		$newsectioniso = utf8_decode($section);
+		$newsectioniso = mb_convert_encoding($section, 'ISO-8859-1');
 		$resultarray = dol_ftp_connect($ftp_server, $ftp_port, $ftp_user, $ftp_password, $newsectioniso, $ftp_passive);
 		$conn_id = $resultarray['conn_id'];
 		$ok = $resultarray['ok'];
@@ -454,7 +454,7 @@ if (!function_exists('ftp_connect')) {
 			//$type = ftp_systype($conn_id);
 
 			$newsection = $section;
-			$newsectioniso = utf8_decode($section);
+			$newsectioniso = mb_convert_encoding($section, 'ISO-8859-1');
 			//$newsection='/home';
 
 			// List content of directory ($newsection = '/', '/home', ...)
@@ -497,12 +497,12 @@ if (!function_exists('ftp_connect')) {
 			$i = 0;
 			$nbofentries = 0;
 			while ($i < $nboflines && $i < 1000) {
-				$vals = preg_split('@ +@', utf8_encode($buff[$i]), 9);
+				$vals = preg_split('@ +@', mb_convert_encoding($buff[$i], 'UTF-8', 'ISO-8859-1'), 9);
 				//$vals=preg_split('@ +@','drwxr-xr-x 2 root root 4096 Aug 30 2008 backup_apollon1',9);
 				$file = $vals[8];
 				if (empty($file)) {
 					$rawlisthasfailed = true;
-					$file = utf8_encode($contents[$i]);
+					$file = mb_convert_encoding($contents[$i], 'UTF-8', 'ISO-8859-1');
 				}
 
 				if ($file == '.' || ($file == '..' && $section == '/')) {
@@ -530,7 +530,7 @@ if (!function_exists('ftp_connect')) {
 					//print preg_match('@[\\\/]$@',"aaa\\").'Y';
 					$remotefile = $section.(preg_match('@[\\\/]$@', $section) ? '' : '/').preg_replace('@^[\\\/]@', '', $file);
 					//print 'A'.$remotefile.'A';
-					$newremotefileiso = utf8_decode($remotefile);
+					$newremotefileiso = mb_convert_encoding($remotefile, 'ISO-8859-1');
 					//print 'Z'.$newremotefileiso.'Z';
 					$is_directory = ftp_isdir($conn_id, $newremotefileiso);
 				}

--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -713,7 +713,7 @@ if ($step == 3 && $datatoimport) {
 
 			// readdir return value in ISO and we want UTF8 in memory
 			if (!utf8_check($file)) {
-				$file = utf8_encode($file);
+				$file = mb_convert_encoding($file, 'UTF-8', 'ISO-8859-1');
 			}
 
 			if (preg_match('/^\./', $file)) {
@@ -2468,7 +2468,7 @@ function show_elem($fieldssource, $pos, $key, $var, $nostyle = '')
 		}
 		if ($example) {
 			if (!utf8_check($example)) {
-				$example = utf8_encode($example);
+				$example = mb_convert_encoding($example, 'UTF-8', 'ISO-8859-1');
 			}
 			if (!empty($conf->dol_optimize_smallscreen)) {
 				//print '<br>';

--- a/htdocs/includes/nusoap/lib/nusoap.php
+++ b/htdocs/includes/nusoap/lib/nusoap.php
@@ -6936,7 +6936,7 @@ class nusoap_parser extends nusoap_base {
 			// raw UTF-8 that, e.g., might not map to iso-8859-1
 			// TODO: this can also be handled with xml_parser_set_option($this->parser, XML_OPTION_TARGET_ENCODING, "ISO-8859-1");
 			if($this->decode_utf8){
-				$data = utf8_decode($data);
+				$data = mb_convert_encoding($data, 'ISO-8859-1');
 			}
 		}
         $this->message[$pos]['cdata'] .= $data;

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -330,7 +330,7 @@ class Odf
 	private function encode_chars($text, $encode = false, $charset = '')
 	{
 		$newtext = $encode ? htmlspecialchars($text, ENT_QUOTES | ENT_XML1) : $text;
-		$newtext = ($charset == 'ISO-8859') ? utf8_encode($newtext) : $newtext;
+		$newtext = ($charset == 'ISO-8859') ? mb_convert_encoding($newtext, 'UTF-8', 'ISO-8859-1') : $newtext;
 		return $newtext;
 	}
 

--- a/htdocs/includes/sabre/sabre/http/lib/functions.php
+++ b/htdocs/includes/sabre/sabre/http/lib/functions.php
@@ -421,7 +421,7 @@ function decodePathSegment(string $path): string
 
     switch ($encoding) {
         case 'ISO-8859-1':
-            $path = utf8_encode($path);
+            $path = mb_convert_encoding($path, 'UTF-8', 'ISO-8859-1');
     }
 
     return $path;

--- a/htdocs/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/Traits/Date.php
+++ b/htdocs/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/Traits/Date.php
@@ -1857,7 +1857,7 @@ trait Date
             ? (
                 \function_exists('mb_convert_encoding')
                 ? mb_convert_encoding($formatted, 'UTF-8', mb_list_encodings())
-                : utf8_encode($formatted)
+                : mb_convert_encoding($formatted, 'UTF-8', 'ISO-8859-1')
             )
             : $formatted;
     }

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5975,7 +5975,7 @@ class Product extends CommonObject
 			if (is_resource($handle)) {
 				while (($file = readdir($handle)) !== false) {
 					if (!utf8_check($file)) {
-						$file = utf8_encode($file); // To be sure data is stored in UTF8 in memory
+						$file = mb_convert_encoding($file, 'UTF-8', 'ISO-8859-1'); // To be sure data is stored in UTF8 in memory
 					}
 					if (dol_is_file($dir.$file) && image_format_supported($file) >= 0) {
 						return true;
@@ -6008,7 +6008,7 @@ class Product extends CommonObject
 		if (is_resource($handle)) {
 			while (($file = readdir($handle)) !== false) {
 				if (!utf8_check($file)) {
-					$file = utf8_encode($file); // readdir returns ISO
+					$file = mb_convert_encoding($file, 'UTF-8', 'ISO-8859-1'); // readdir returns ISO
 				}
 				if (dol_is_file($dir.$file) && image_format_supported($file) >= 0) {
 					$nbphoto++;

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -2387,7 +2387,7 @@ class Ticket extends CommonObject
 			if (is_resource($handle)) {
 				while (($file = readdir($handle)) !== false) {
 					if (!utf8_check($file)) {
-						$file = utf8_encode($file);	// To be sure data is stored in UTF8 in memory
+						$file = mb_convert_encoding($file, 'UTF-8', 'ISO-8859-1');	// To be sure data is stored in UTF8 in memory
 					}
 					if (dol_is_file($dir.$file)) {
 						return true;


### PR DESCRIPTION
# Fix utf8_encode/utf8_decode deprecation in PHP8.2

Alternative is implemented in functions.lib.php which is still good for external modules, but static code analysis identifies utf8_encode as deprecated and IMHO its better to fix the source code.

The test cases for the replacement functions have not been upgraded of course.


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

