### PR TITLE
Qual/inc travis php error reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -268,8 +268,9 @@ before_script:
 
   - |
     export CONF_FILE=htdocs/conf/conf.php
-    echo "Setting up Dolibarr $CONF_FILE"
+    echo "Setting up Dolibarr '$CONF_FILE'"
     echo '<?php' > $CONF_FILE
+    echo 'error_reporting(E_ALL);' >> $CONF_FILE
     echo '$'dolibarr_main_url_root=\'http://127.0.0.1\'';' >> $CONF_FILE
     echo '$'dolibarr_main_document_root=\'$TRAVIS_BUILD_DIR/htdocs\'';' >> $CONF_FILE
     echo '$'dolibarr_main_data_root=\'$TRAVIS_BUILD_DIR/documents\'';' >> $CONF_FILE

--- a/.travis.yml
+++ b/.travis.yml
@@ -394,6 +394,7 @@ script:
     # Ensure we catch errors
     set +e
     echo '<?php ' > $INSTALL_FORCED_FILE
+    echo 'error_reporting(E_ALL);' >> $INSTALL_FORCED_FILE
     echo '$'force_install_noedit=2';' >> $INSTALL_FORCED_FILE
     if [ "$DB" = 'mysql' ] || [ "$DB" = 'mariadb' ]; then
       echo '$'force_install_type=\'mysqli\'';' >> $INSTALL_FORCED_FILE


### PR DESCRIPTION
# Qual Increase PHP error logging sensitivity

I see that there are several reports regarding PHP8.* deprecations.

I test if these can be detected in travis by modifying the error logging level.


Question: As PHP7.0 compatibility is still desired (not ensured, but desired), should travis not run PHP7.0 tests as long as that is passing?

