### PR TITLE
QUAL continuation of request made by eldy in #25946

### DIFF
--- a/htdocs/admin/stock.php
+++ b/htdocs/admin/stock.php
@@ -776,7 +776,7 @@ if ($conf->use_javascript_ajax) {
 	print ajax_constantonoff('STOCK_SUPPORTS_SERVICES');
 } else {
 	$arrval = array('0' => $langs->trans("No"), '1' => $langs->trans("Yes"));
-	print $form->selectarray("STOCK_SUPPORTS_SERVICES", $arrval, $conf->global->STOCK_SUPPORTS_SERVICES);
+	print $form->selectarray("STOCK_SUPPORTS_SERVICES", $arrval, getDolGlobalString('STOCK_SUPPORTS_SERVICES'));
 }
 print "</td>\n";
 print "</tr>\n";


### PR DESCRIPTION
Fix #25946 Adding stock menu point to services menu
This commit is not really a fix of #25946, but it does a code change that eldy commented in #25946 should generally be done, and Fix seemed to be the best choice as this is not something New, and the rest of the acronyms was not understood.


[eldy](https://github.com/eldy) [on Sep 19](https://github.com/Dolibarr/dolibarr/pull/25946#discussion_r1330738978)
```
Can you replace $conf->global->STOCK... with
getDolGlobalString('STOCK...')
```