### PR TITLE
New trigger CRONJOB_ERROR

### DIFF
--- a/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
+++ b/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
@@ -311,6 +311,9 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
 			//case 'SHIPPING_REOPEN':
 			//case 'SHIPPING_DELETE':
 
+			// Cron jobs
+			//case 'CRONJOB_ERROR':
+
 			// and more...
 
 			default:

--- a/htdocs/public/cron/cron_run_jobs_by_url.php
+++ b/htdocs/public/cron/cron_run_jobs_by_url.php
@@ -139,6 +139,7 @@ $result = $object->fetchAll('ASC,ASC,ASC', 't.priority,t.entity,t.rowid', 0, 0, 
 if ($result < 0) {
 	echo "Error: ".$object->error;
 	dol_syslog("cron_run_jobs.php fetch Error".$object->error, LOG_ERR);
+	$object->call_trigger('CRONJOB_ERROR', $user);
 	exit;
 }
 
@@ -171,11 +172,13 @@ if (is_array($object->lines) && (count($object->lines) > 0)) {
 				if ($result < 0) {
 					echo "\nUser Error: ".$user->error."\n";
 					dol_syslog("cron_run_jobs.php:: User Error:".$user->error, LOG_ERR);
+					$object->call_trigger('CRONJOB_ERROR', $user);
 					exit(-1);
 				} else {
 					if ($result == 0) {
 						echo "\nUser login: ".$userlogin." does not exists for entity ".$conf->entity."\n";
 						dol_syslog("User login:".$userlogin." does not exists", LOG_ERR);
+						$object->call_trigger('CRONJOB_ERROR', $user);
 						exit(-1);
 					}
 				}
@@ -199,6 +202,7 @@ if (is_array($object->lines) && (count($object->lines) > 0)) {
 				echo "Error cronjobid: ".$line->id." cronjob->fetch: ".$cronjob->error."\n";
 				echo "Failed to fetch job ".$line->id."\n";
 				dol_syslog("cron_run_jobs.php::fetch Error".$cronjob->error, LOG_ERR);
+				$object->call_trigger('CRONJOB_ERROR', $user);
 				exit;
 			}
 			// Execute job
@@ -208,6 +212,7 @@ if (is_array($object->lines) && (count($object->lines) > 0)) {
 				echo "At least one job failed. Go on menu Home-Setup-Admin tools to see result for each job.\n";
 				echo "You can also enable module Log if not yet enabled, run again and take a look into dolibarr.log file\n";
 				dol_syslog("cron_run_jobs.php::run_jobs Error".$cronjob->error, LOG_ERR);
+				$object->call_trigger('CRONJOB_ERROR', $user);
 				$nbofjobslaunchedko++;
 			} else {
 				$nbofjobslaunchedok++;
@@ -221,6 +226,7 @@ if (is_array($object->lines) && (count($object->lines) > 0)) {
 				echo "Error cronjobid: ".$line->id." cronjob->reprogram_job: ".$cronjob->error."\n";
 				echo "Enable module Log if not yet enabled, run again and take a look into dolibarr.log file\n";
 				dol_syslog("cron_run_jobs.php::reprogram_jobs Error".$cronjob->error, LOG_ERR);
+				$object->call_trigger('CRONJOB_ERROR', $user);
 				exit;
 			}
 

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -171,6 +171,7 @@ if (!empty($id)) {
 	if (!is_numeric($id)) {
 		echo "Error: Bad value for parameter job id\n";
 		dol_syslog("cron_run_jobs.php Bad value for parameter job id", LOG_WARNING);
+		$object->call_trigger('CRONJOB_ERROR', $user);
 		exit();
 	}
 	$filter['t.rowid'] = $id;
@@ -180,6 +181,7 @@ $result = $object->fetchAll('ASC,ASC,ASC', 't.priority,t.entity,t.rowid', 0, 0, 
 if ($result < 0) {
 	echo "Error: ".$object->error;
 	dol_syslog("cron_run_jobs.php fetch Error ".$object->error, LOG_ERR);
+	$object->call_trigger('CRONJOB_ERROR', $user);
 	exit(-1);
 }
 
@@ -251,6 +253,7 @@ if (is_array($object->lines) && (count($object->lines) > 0)) {
 				echo " - Error cronjobid: ".$line->id." cronjob->fetch: ".$cronjob->error."\n";
 				echo "Failed to fetch job ".$line->id."\n";
 				dol_syslog("cron_run_jobs.php::fetch Error ".$cronjob->error, LOG_ERR);
+				$object->call_trigger('CRONJOB_ERROR', $user);
 				exit(-1);
 			}
 			// Execute job
@@ -260,6 +263,7 @@ if (is_array($object->lines) && (count($object->lines) > 0)) {
 				echo "At least one job failed. Go on menu Home-Setup-Admin tools to see result for each job.\n";
 				echo "You can also enable module Log if not yet enabled, run again and take a look into dolibarr.log file\n";
 				dol_syslog("cron_run_jobs.php::run_jobs Error ".$cronjob->error, LOG_ERR);
+				$object->call_trigger('CRONJOB_ERROR', $user);
 				$nbofjobslaunchedko++;
 				$resultstring = 'KO';
 			} else {
@@ -275,6 +279,7 @@ if (is_array($object->lines) && (count($object->lines) > 0)) {
 				echo " - Error cronjobid: ".$line->id." cronjob->reprogram_job: ".$cronjob->error."\n";
 				echo "Enable module Log if not yet enabled, run again and take a look into dolibarr.log file\n";
 				dol_syslog("cron_run_jobs.php::reprogram_jobs Error ".$cronjob->error, LOG_ERR);
+				$object->call_trigger('CRONJOB_ERROR', $user);
 				exit(-1);
 			}
 


### PR DESCRIPTION
# NEW trigger CRONJOB_ERROR

This trigger is called when a cronjob fails.
Purpose of this trigger is to get a versatile method to send any type of message if a cron job fails.
This trigger is primarily intended to be used in combination with the recent [webhook module](https://wiki.dolibarr.org/index.php?title=Module_Webhook) in order to send a notification to [ntfy.sh](https://ntfy.sh/) or any other notification system.
This trigger can also be used in a custom module to send an email (this could satisfy this old request https://github.com/Dolibarr/dolibarr/issues/14266 )



