### PR TITLE
improve translation string for action generation on email sent

### DIFF
--- a/htdocs/core/actions_sendmails.inc.php
+++ b/htdocs/core/actions_sendmails.inc.php
@@ -328,7 +328,7 @@ if (($action == 'send' || $action == 'relance') && !GETPOST('addfile') && !GETPO
 			$deliveryreceipt = GETPOST('deliveryreceipt');
 
 			if ($action == 'send' || $action == 'relance') {
-				$actionmsg2 = $langs->transnoentities('MailSentBy').' '.CMailFile::getValidAddress($from, 4, 0, 1).' '.$langs->transnoentities('To').' '.CMailFile::getValidAddress($sendto, 4, 0, 1);
+				$actionmsg2 = $langs->transnoentities('MailSentByTo', CMailFile::getValidAddress($from, 4, 0, 1), CMailFile::getValidAddress($sendto, 4, 0, 1));
 				/*if ($message) {
 					$actionmsg = $langs->transnoentities('MailFrom').': '.dol_escape_htmltag($from);
 					$actionmsg = dol_concatdesc($actionmsg, $langs->transnoentities('MailTo').': '.dol_escape_htmltag($sendto));

--- a/htdocs/langs/en_US/main.lang
+++ b/htdocs/langs/en_US/main.lang
@@ -701,6 +701,7 @@ Response=Response
 Priority=Priority
 SendByMail=Send by email
 MailSentBy=Email sent by
+MailSentByTo=Email sent by %s to %s
 NotSent=Not sent
 TextUsedInTheMessageBody=Email body
 SendAcknowledgementByMail=Send confirmation email


### PR DESCRIPTION
 to work better in different languages

The current string only works for languages /translations that have the same word order as in English.
For example in German: the translation for an independent 'to' does not fit and results in an incorrect translation