### PR TITLE
Qual: command: forward database error on failure

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1191,7 +1191,7 @@ class Commande extends CommonOrder
 
 			return 0;
 		} else {
-			dol_print_error($this->db);
+			$this->error = $this->db->lasterror();
 			$this->db->rollback();
 			return -1;
 		}


### PR DESCRIPTION
# Qual: command: forward database error on failure

If the database triggered a failure, it wasn't reported in the tests because `$this->error` was not set. Conversely, the error was always printed through `dol_print_error()` whose documentation explicitely states that it should not be used for class and `$this->error` should be used instead.