### PR TITLE
FIX SQL query construction using category as filter.

### DIFF
--- a/htdocs/product/stock/class/api_warehouses.class.php
+++ b/htdocs/product/stock/class/api_warehouses.class.php
@@ -107,7 +107,7 @@ class Warehouses extends DolibarrApi
 		$sql = "SELECT t.rowid";
 		$sql .= " FROM ".MAIN_DB_PREFIX."entrepot AS t LEFT JOIN ".MAIN_DB_PREFIX."entrepot_extrafields AS ef ON (ef.fk_object = t.rowid)"; // Modification VMR Global Solutions to include extrafields as search parameters in the API GET call, so we will be able to filter on extrafields
 		if ($category > 0) {
-			$sql .= ", ".$this->db->prefix()."categorie_societe as c";
+			$sql .= ", ".$this->db->prefix()."categorie_warehouse as c";
 		}
 		$sql .= ' WHERE t.entity IN ('.getEntity('stock').')';
 		// Select warehouses of given category


### PR DESCRIPTION
#FIX SQL table used for filtering warehouses by category in REST API

Just replaced wrong table used in SQL query built to filter warehouses by category in REST API : category_societe replaced with category_warehouse.
