### PR TITLE
fix: defaulted value in configuration of agenda export make it always return no events

### DIFF
--- a/htdocs/public/agenda/agendaexport.php
+++ b/htdocs/public/agenda/agendaexport.php
@@ -89,7 +89,7 @@ if (empty($conf->agenda->enabled)) {
 }
 
 // Not older than
-if (!isset($conf->global->MAIN_AGENDA_EXPORT_PAST_DELAY)) {
+if (empty($conf->global->MAIN_AGENDA_EXPORT_PAST_DELAY)) {
 	$conf->global->MAIN_AGENDA_EXPORT_PAST_DELAY = 100; // default limit
 }
 


### PR DESCRIPTION
MAIN_AGENDA_EXPORT_PAST_DELAY is defaulted to 0 when key is generated the first time so !isset is always false, test empty seems to be a better option