### PR TITLE
FIX : missing require_once .'/core/lib/security.lib.php' for dol_hash()

### DIFF
--- a/htdocs/install/step2.php
+++ b/htdocs/install/step2.php
@@ -27,6 +27,7 @@
 include 'inc.php';
 require_once $dolibarr_main_document_root.'/core/class/conf.class.php';
 require_once $dolibarr_main_document_root.'/core/lib/admin.lib.php';
+require_once $dolibarr_main_document_root.'/core/lib/security.lib.php';
 
 global $langs;
 


### PR DESCRIPTION
# FIX
FIX : missing require_once .'/core/lib/security.lib.php' for dol_hash() with fresh install


