### PR TITLE
Add contact to project and tasks : formconfirm get url too long

### DIFF
--- a/htdocs/projet/contact.php
+++ b/htdocs/projet/contact.php
@@ -126,7 +126,7 @@ if ($action == 'addcontact') {
 			$formquestion[] = array('type'=> 'other', 'name'=>'tasksavailable', 'label'=>'', 'value' => '<input type="hidden" id="tasksavailable" name="tasksavailable" value="'.implode(',', array_keys($task_to_affect)).'">');
 		}
 
-		$formconfirmtoaddtasks = $form->formconfirm($_SERVER['PHP_SELF'] . $url_redirect, $text, '', 'addcontact_confirm', $formquestion, '', 1, 300, 590);
+		$formconfirmtoaddtasks = $form->formconfirm($_SERVER['PHP_SELF'] . $url_redirect, $text, '', 'addcontact_confirm', $formquestion, '', ((count($formquestion) > 10) ? 0 : 1), 300, 590);
 		$formconfirmtoaddtasks .='
 		 <script>
 		 $(document).ready(function() {
@@ -150,7 +150,13 @@ if ($action == 'addcontact') {
 
 // Add new contact
 if ($action == 'addcontact_confirm' && $user->rights->projet->creer) {
-	$contactid = (GETPOST('userid') ? GETPOST('userid', 'int') : GETPOST('contactid', 'int'));
+
+    if (GETPOST('confirm', 'alpha') == 'no') {
+            header("Location: ".$_SERVER['PHP_SELF']."?id=".$object->id);
+            exit;
+    }
+
+    $contactid = (GETPOST('userid') ? GETPOST('userid', 'int') : GETPOST('contactid', 'int'));
 	$typeid = (GETPOST('typecontact') ? GETPOST('typecontact') : GETPOST('type'));
 
 	if (! ($contactid > 0)) {


### PR DESCRIPTION
# FIX|Fix #Add contact to project and tasks : formconfirm get url too long

If we use ajax and if there are a lot of tasks to check there is an error : data in url is too long. We must use POST. 

It's a fix for this page but a feature is needed for manage values in POST when formconfirm() is used : https://github.com/Dolibarr/dolibarr/issues/27078





