### PR TITLE
FIX: disable pointer events on jQuery-UI tooltips to prevent a glitch

### DIFF
--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -5058,6 +5058,7 @@ div.ui-tooltip.mytooltip {
 	color: var(--tooltipfontcolor);
 	line-height: 1.6em;
 	min-width: 550px;
+    pointer-events: none;
 }
 
 <?php


### PR DESCRIPTION
# FIX Rich tooltip blinking fast
Under some circumstances, a jQuery UI rich tooltip (for instance on a getNomURL link) is not positioned properly. It appears right under the mouse cursor. This has two effects:
- it prevents clicking on the link (as soon as you hover over the link, the tooltip appears and grabs all click events)
- it blinks fast because as soon as the tooltip is shown, it steals the "hover" state from the the link; therefore the tooltip is removed, restoring the "hover" state to the link, triggering a new tooltip being shown, and so on… the blinking loop only ends when you move the cursor away.

Adding `pointer-events: none;` fixes the consequences (no blinking and the link remains clickable even if it is hidden behind the tooltip), but not the cause (wrong tooltip positioning). However, even if we find a better fix, I think `pointer-events: none;` is relevant to tooltips because, as far as I know, there is no reason to provide clickable tooltips in Dolibarr.