### PR TITLE
NEW Simplify the verification of context in hook

### DIFF
--- a/htdocs/core/class/commonhookactions.class.php
+++ b/htdocs/core/class/commonhookactions.class.php
@@ -36,4 +36,26 @@ abstract class CommonHookActions
 	 * @var array 	Array of results.
 	 */
 	public $results = array();
+
+	/**
+	 * Check context of hook
+	 * @param array $parameters Hook parameters.
+	 * @param array|string $allContexts Context to check
+	 * @return bool
+	 */
+	protected function isContext($parameters, $allContexts)
+	{
+		if (is_array($allContexts)) {
+			foreach ($allContexts as $context) {
+				if ($this->isContext($parameters, $context)) {
+					return true;
+				}
+			}
+		}
+		if ($parameters['currentcontext'] == $allContexts) {
+			return true;
+		}
+		$contexts = explode(':', $parameters['context']);
+		return in_array($allContexts, $contexts);
+	}
 }

--- a/htdocs/core/class/commonhookactions.class.php
+++ b/htdocs/core/class/commonhookactions.class.php
@@ -51,6 +51,7 @@ abstract class CommonHookActions
 					return true;
 				}
 			}
+			return false;
 		}
 		if ($parameters['currentcontext'] == $allContexts) {
 			return true;


### PR DESCRIPTION
# New

it add a method to simplify the verification of context.

usage:

```php
if ($this->isContext($parameters, 'propalcard')) {
```


```php
if ($this->isContext($parameters, ['propalcard', 'invoicecard', 'ticketcard'])) {
```


