### PR TITLE
Fix deprecations for PHP 7.2 and up

### DIFF
--- a/htdocs/includes/nusoap/lib/Mail/mime.php
+++ b/htdocs/includes/nusoap/lib/Mail/mime.php
@@ -183,7 +183,7 @@ class Mail_mime
 
         // Update build parameters
         if (!empty($params) && is_array($params)) {
-            while (list($key, $value) = each($params)) {
+            foreach ($params as $key => $value) {
                 $this->_build_params[$key] = $value;
             }
         }
@@ -838,7 +838,7 @@ class Mail_mime
     function get($params = null, $filename = null, $skip_head = false)
     {
         if (isset($params)) {
-            while (list($key, $value) = each($params)) {
+            foreach ($params as $key => $value) {
                 $this->_build_params[$key] = $value;
             }
         }
@@ -1275,7 +1275,7 @@ class Mail_mime
     function _encodeHeaders($input, $params = array())
     {
         $build_params = $this->_build_params;
-        while (list($key, $value) = each($params)) {
+        foreach ($params as $key => $value) {
             $build_params[$key] = $value;
         }
 

--- a/htdocs/includes/nusoap/lib/Mail/mimePart.php
+++ b/htdocs/includes/nusoap/lib/Mail/mimePart.php
@@ -603,10 +603,9 @@ class Mail_mimePart
         $escape = '=';
         $output = '';
 
-        while (list($idx, $line) = each($lines)) {
+        foreach ($lines as $idx => $line) {
             $newline = '';
             $i = 0;
-
             while (isset($line[$i])) {
                 $char = $line[$i];
                 $dec  = ord($char);

--- a/htdocs/includes/symfony/var-dumper/Dumper/AbstractDumper.php
+++ b/htdocs/includes/symfony/var-dumper/Dumper/AbstractDumper.php
@@ -43,7 +43,7 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
 	public function __construct($output = null, $charset = null, $flags = 0)
 	{
 		$this->flags = (int) $flags;
-		$this->setCharset($charset ?: ini_get('php.output_encoding') ?: ini_get('default_charset') ?: 'UTF-8');
+		$this->setCharset(($charset ?: ini_get('php.output_encoding') ?: ini_get('default_charset')) ?: 'UTF-8');
 		$this->decimalPoint = localeconv();
 		$this->decimalPoint = $this->decimalPoint['decimal_point'];
 		$this->setOutput($output ?: static::$defaultOutput);

--- a/htdocs/includes/tecnickcom/tcpdf/include/barcodes/pdf417.php
+++ b/htdocs/includes/tecnickcom/tcpdf/include/barcodes/pdf417.php
@@ -878,7 +878,7 @@ class PDF417 {
 				$txtarr = array(); // array of characters and sub-mode switching characters
 				$codelen = strlen($code);
 				for ($i = 0; $i < $codelen; ++$i) {
-					$chval = ord($code{$i});
+					$chval = ord($code[$i]);
 					if (($k = array_search($chval, $this->textsubmodes[$submode])) !== false) {
 						// we are on the same sub-mode
 						$txtarr[] = $k;
@@ -888,7 +888,7 @@ class PDF417 {
 							// search new sub-mode
 							if (($s != $submode) AND (($k = array_search($chval, $this->textsubmodes[$s])) !== false)) {
 								// $s is the new submode
-								if (((($i + 1) == $codelen) OR ((($i + 1) < $codelen) AND (array_search(ord($code{($i + 1)}), $this->textsubmodes[$submode]) !== false))) AND (($s == 3) OR (($s == 0) AND ($submode == 1)))) {
+								if (((($i + 1) == $codelen) OR ((($i + 1) < $codelen) AND (array_search(ord($code[$i + 1]), $this->textsubmodes[$submode]) !== false))) AND (($s == 3) OR (($s == 0) AND ($submode == 1)))) {
 									// shift (temporary change only for this char)
 									if ($s == 3) {
 										// shift to puntuaction
@@ -952,7 +952,7 @@ class PDF417 {
 						$cw = array_merge($cw, $cw6);
 					} else {
 						for ($i = 0; $i < $sublen; ++$i) {
-							$cw[] = ord($code{$i});
+							$cw[] = ord($code[$i]);
 						}
 					}
 					$code = $rest;

--- a/htdocs/includes/tecnickcom/tcpdf/include/barcodes/qrcode.php
+++ b/htdocs/includes/tecnickcom/tcpdf/include/barcodes/qrcode.php
@@ -1718,7 +1718,7 @@ class QRcode {
 			return -1;
 		}
 		$buf = array($size, $index, $parity);
-		$entry = $this->newInputItem(QR_MODE_ST, 3, buf);
+		$entry = $this->newInputItem(QR_MODE_ST, 3, $buf);
 		array_unshift($items, $entry);
 		return $items;
 	}

--- a/htdocs/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/CarbonInterval.php
+++ b/htdocs/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/CarbonInterval.php
@@ -1804,7 +1804,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
 
             $aTime = $aUnit ? $handleDeclensions('a_'.$unit, $count) : null;
 
-            $time = $aTime ?: $handleDeclensions($unit, $count) ?: $time;
+            $time = ($aTime ?: $handleDeclensions($unit, $count)) ?: $time;
         }
 
         $time = [':time' => $time];

--- a/htdocs/includes/webklex/php-imap/vendor/symfony/polyfill-php80/Php80.php
+++ b/htdocs/includes/webklex/php-imap/vendor/symfony/polyfill-php80/Php80.php
@@ -54,7 +54,7 @@ final class Php80
             return $class;
         }
 
-        return (get_parent_class($class) ?: key(class_implements($class)) ?: 'class').'@anonymous';
+        return ((get_parent_class($class) ?: key(class_implements($class))) ?: 'class').'@anonymous';
     }
 
     public static function get_resource_id($res): int


### PR DESCRIPTION
# Fix PHP7.2 and up deprecations

The deprecations are found in branch develop and are can be fixed from vers 17.0 upwards/

Fix issue with nested ternary operators:
https://www.php.net/manual/en/migration74.deprecated.php

Fix use of deprecated each()
https://wiki.php.net/rfc/deprecations_php_7_2#each

Fix use of access to string acces using curly brackets
https://www.php.net/manual/en/migration74.deprecated.php

Note: bug in qrcode library was found because of "invalid" fix by rector.