### PR TITLE
Thirdparty email missing in send message form for ticket #27034

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1532,7 +1532,7 @@ class FormTicket
 					$ticketstat->socid = $ticketstat->fk_soc;
 					$ticketstat->fetch_thirdparty();
 
-					if (is_array($ticketstat->thirdparty->email) && !in_array($ticketstat->thirdparty->email, $sendto)) {
+					if (!empty($ticketstat->thirdparty->email) && !in_array($ticketstat->thirdparty->email, $sendto)) {
 						$sendto[] = $ticketstat->thirdparty->email.' <small class="opacitymedium">('.$langs->trans('Customer').')</small>';
 					}
 				}


### PR DESCRIPTION
all credit to TedinfoRegis who suggested this change in "Thirdparty email missing in send message form for ticket #27034 "

Fix #27034 Thirdparty email missing ticket
Thirdparty email missing in send message form for ticket, All credit to [TedinfoRegis](https://github.com/TedinfoRegis)