### PR TITLE
FIX : Fatal error converting object of class User to string (php8)

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1323,7 +1323,7 @@ class FactureFournisseurRec extends CommonInvoice
 					}
 					if (!$error && ($facturerec->auto_validate || $forcevalidation)) {
 						$result = $new_fac_fourn->validate($user);
-						$laststep="Validate by user $user";
+						$laststep="Validate by user {$user->id}";
 						if ($result <= 0) {
 							$this->errors = $new_fac_fourn->errors;
 							$this->error = $new_fac_fourn->error;


### PR DESCRIPTION
# FIX php8 error
With php8, this error occurs when generating recurring supplier invoices using the cron :
```
PHP Fatal error:  Uncaught Error: Object of class User could not be converted to string
```

Which cause the cron to stop abruptly and it'll never be automatically rescheduled.