### PR TITLE
FIX: CommandeTest: fix create when no company exists

### DIFF
--- a/test/phpunit/CommandeTest.php
+++ b/test/phpunit/CommandeTest.php
@@ -146,11 +146,17 @@ class CommandeTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
+		$soc = new Societe($db);
+		$soc->name = "CommandeTest Unittest";
+		$socid = $soc->create($user);
+		$this->assertLessThan($socid, 0, $soc->errorsToString());
+
 		$localobject=new Commande($db);
 		$localobject->initAsSpecimen();
+		$localobject->socid = $socid;
 		$result=$localobject->create($user);
 
-		$this->assertLessThan($result, 0);
+		$this->assertLessThan($result, 0, $localobject->errorsToString());
 		print __METHOD__." result=".$result."\n";
 		return $result;
 	}


### PR DESCRIPTION
# FIX CommandeTest: fix testCommandCreate when no company exists

The testCommandeCreate() is using the default value for Commande::socid, which is defined by Command::initAsSpecimen to `0`. But if no companies have been created, the test will fail with the following error:

    Failed asserting that 0 is less than -1.

Or with the additional logging:

    ERROR:  23503: insert or update on table "llx_commande" violates foreign key constraint "fk_commande_fk_soc"
    DETAIL:  Key (fk_soc)=(1) is not present in table "llx_societe".                                            
    SCHEMA NAME:  public                                                                                        
    TABLE NAME:  llx_commande                                                                                   
    CONSTRAINT NAME:  fk_commande_fk_soc                                                                        
    LOCATION:  ri_ReportViolation, ri_triggers.c:2596,                                                          
    Failed asserting that 0 is less than -1.

The test doesn't really depends on specific test data so we can create the company directly instead.

