### PR TITLE
FIX: CompanyBankAccountTest: fix create when no societe exists

### DIFF
--- a/test/phpunit/CompanyBankAccountTest.php
+++ b/test/phpunit/CompanyBankAccountTest.php
@@ -140,12 +140,18 @@ class CompanyBankAccountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
+		$soc = new Societe($db);
+		$soc->name = "CompanyBankAccountTest Unittest";
+		$socid = $soc->create($user);
+		$this->assertLessThan($socid, 0, $soc->errorsToString());
+
 		$localobject=new CompanyBankAccount($db);
 		$localobject->initAsSpecimen();
+		$localobject->socid = $socid;
 		$result=$localobject->create($user);
 
 		print __METHOD__." result=".$result." id=".$localobject->id."\n";
-		$this->assertLessThan($result, 0);
+		$this->assertLessThan($result, 0, $localobject->errorsToString());
 		return $localobject->id;
 	}
 


### PR DESCRIPTION
# FIX: CompanyBankAccountTest: fix create when no societe exists

The testCompanyBankAccountCreate() is using the default value for CompanyBankAccount::socid, which is defined by
CompanyBankAccount::initAsSpecimen to `0`. But if no companies have been created, the test will fail with the following error:

    Failed asserting that 0 is less than -1.

Or with the additional logging:

    ERROR:  23503: insert or update on table "llx_societe_rib" violates foreign key constraint "llx_societe_rib_fk_societe"                                                   
    DETAIL:  Key (fk_soc)=(1) is not present in table "llx_societe".                                                                                                          
    SCHEMA NAME:  public                                                                                                                                                      
    TABLE NAME:  llx_societe_rib                                                                                                                                              
    CONSTRAINT NAME:  llx_societe_rib_fk_societe                                                                                                                              
    LOCATION:  ri_ReportViolation, ri_triggers.c:2596, ERROR:  23503: insert or update on table "llx_societe_rib" violates foreign key constraint "llx_societe_rib_fk_societe"
    DETAIL:  Key (fk_soc)=(1) is not present in table "llx_societe".                                                                                                          
    SCHEMA NAME:  public                                                                                                                                                      
    TABLE NAME:  llx_societe_rib                                                                                                                                              
    CONSTRAINT NAME:  llx_societe_rib_fk_societe                                                                                                                              
    LOCATION:  ri_ReportViolation, ri_triggers.c:2596                                                                                                                         
    Failed asserting that 0 is less than -1.

The test doesn't really depends on specific test data so we can create the company directly instead.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

