### PR TITLE
FIX: ContratTest: fix create when no societe exists

### DIFF
--- a/test/phpunit/ContratTest.php
+++ b/test/phpunit/ContratTest.php
@@ -139,8 +139,14 @@ class ContratTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
+		$soc = new Societe($db);
+		$soc->name = "ContratTest Unittest";
+		$socid = $soc->create($user);
+		$this->assertLessThan($socid, 0, $soc->errorsToString());
+
 		$localobject=new Contrat($db);
 		$localobject->initAsSpecimen();
+		$localobject->socid = $socid;
 		$result=$localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";

--- a/test/phpunit/ContratTest.php
+++ b/test/phpunit/ContratTest.php
@@ -150,7 +150,7 @@ class ContratTest extends PHPUnit\Framework\TestCase
 		$result=$localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
-		$this->assertLessThan($result, 0);
+		$this->assertLessThan($result, 0, $localobject->errorsToString());
 
 		return $result;
 	}


### PR DESCRIPTION
# FIX: ContratTest: fix create when no societe exists

The testContratCreate() is using the default value for Contrat::socid,
which is defined by Contrat::initAsSpecimen to `0`. But if no companies
have been created, the test will fail with the following error:

    Failed asserting that 0 is less than -1.

Or with the additional logging:

    UnknownError: ERROR:  23503: insert or update on table "llx_contrat" violates foreign key constraint "fk_contrat_fk_soc"
    DETAIL:  Key (fk_soc)=(1) is not present in table "llx_societe".                                                        
    SCHEMA NAME:  public                                                                                                    
    TABLE NAME:  llx_contrat                                                                                                
    CONSTRAINT NAME:  fk_contrat_fk_soc                                                                                     
    LOCATION:  ri_ReportViolation, ri_triggers.c:2596 -,                                                                    
    Failed asserting that 0 is less than -1.

The test doesn't really depends on specific test data so we can create
the company directly instead.