### PR TITLE
Qual Ease the use of phpcs with configuration file at root

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <!--
+      Documentation:
+      https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
+      -->
+
+    <rule ref="dev/setup/codesniffer/ruleset.xml"/>
+
+    <arg value="p"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php,inc" />
+</ruleset>


### PR DESCRIPTION
#Qual Add .phpcs.xml.dist
    
This configuration file at the root still references the configuration
file used in the CI flows, but it allows running 'phpcs' from the root
without having to specify anything else than the files you want to check.

