### PR TITLE
FIX 17.0: deprecated field should only be a fallback

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -695,7 +695,7 @@ class Facture extends CommonInvoice
 		$sql .= ", ".(empty($this->date_pointoftax) ? "null" : "'".$this->db->idate($this->date_pointoftax)."'");
 		$sql .= ", ".($this->note_private ? "'".$this->db->escape($this->note_private)."'" : "null");
 		$sql .= ", ".($this->note_public ? "'".$this->db->escape($this->note_public)."'" : "null");
-		$sql .= ", ".($this->ref_client ? "'".$this->db->escape($this->ref_client)."'" : "null");
+		$sql .= ", ".($this->ref_customer ? "'".$this->db->escape($this->ref_customer)."'" : ($this->ref_client ? "'".$this->db->escape($this->ref_client)."'" : "null"));
 		$sql .= ", ".($this->fk_account > 0 ? $this->fk_account : 'NULL');
 		$sql .= ", ".($this->module_source ? "'".$this->db->escape($this->module_source)."'" : "null");
 		$sql .= ", ".($this->pos_source != '' ? "'".$this->db->escape($this->pos_source)."'" : "null");


### PR DESCRIPTION
# FIX v17.0 `ref_client` deprecated but still required
```php
$facture = new Facture($db);
$facture->ref_customer = 'test';
// (...) fill other required informations
$facture->create($user);
```
You would expect the invoice to have the customer ref "test" but it doesn't work because create() only uses the deprecated field `ref_client`.

I wrote this fix in a hurry so maybe it isn't the best (or maybe it isn't even working).