### PR TITLE
next fix for  #17665 : autoloader collision

### DIFF
--- a/htdocs/includes/restler/framework/Luracast/Restler/AutoLoader.php
+++ b/htdocs/includes/restler/framework/Luracast/Restler/AutoLoader.php
@@ -290,10 +290,14 @@ class AutoLoader
         if (is_array($loader)
             && is_callable($loader)) {
             $b = new $loader[0];
-            if (false !== $file = $b::$loader[1]($className)
-                    && $this->exists($className, $b::$loader[1])) {
-                return $file;
-            }
+			//avoid PHP Fatal error:  Uncaught Error: Access to undeclared static property: Composer\\Autoload\\ClassLoader::$loader
+			//in case of multiple autoloader systems
+			if(property_exists($b, $loader[1])) {
+				if (false !== $file = $b::$loader[1]($className)
+					&& $this->exists($className, $b::$loader[1])) {
+				return $file;
+				}
+			}
         } elseif (is_callable($loader)
             && false !== $file = $loader($className)
                 && $this->exists($className, $loader)) {


### PR DESCRIPTION
#FIX 17665 : restler autoload and other autoloader

In case of other autoload classes it could happens a sort of collision with restler (when using api).

That patch fix the "PHP Fatal error:  Uncaught Error: Access to undeclared static property: $loader" problem when Restler try to manage classes autoloaded by other systems like composer.

Why do i put it in dolibarr 13.0 ? just because of one of my customer has that bug and uses that dolibarr version, please let me know if i have to make the job for newer versions of dolibarr.

thanks
Éric