### PR TITLE
next fix for  #17665 : autoloader collision

### DIFF
--- a/dev/dolibarr_changes.txt
+++ b/dev/dolibarr_changes.txt
@@ -152,9 +152,9 @@ with
         elseif (strpos($filename, '://') === false)
 
 * To avoid to have QRcode changed because generated with a random mask, replace
-define('QR_FIND_FROM_RANDOM', 2);
-with
-define('QR_FIND_FROM_RANDOM', false);
+	define('QR_FIND_FROM_RANDOM', 2);
+	with:
+	define('QR_FIND_FROM_RANDOM', false);
 
 * Removed useless directories ("examples", "tools")
 
@@ -173,15 +173,15 @@ In htdocs/includes/tecnickcom/tcpdf/tcpdf.php
 * In tecnickcom/tcpdf/include/tcpdf_static, in function intToRoman, right at the beginning
   of the function, replace:
 
-		$roman = '';
+	$roman = '';
 
-with:
+	with:
 
-		$roman = '';
-		if ($number >= 4000) {
-			// do not represent numbers above 4000 in Roman numerals
-			return strval($number);
-		}
+	$roman = '';
+	if ($number >= 4000) {
+		// do not represent numbers above 4000 in Roman numerals
+		return strval($number);
+	}
 
 
 
@@ -192,14 +192,14 @@ Add fpdf_tpl.php 1.2
 Add tcpdi.php
 
 Add tcpdi_parser.php and replace:
-require_once(dirname(__FILE__).'/include/tcpdf_filters.php');
-with:
-require_once(dirname(__FILE__).'/../tecnickcom/tcpdf/include/tcpdf_filters.php');
+	require_once(dirname(__FILE__).'/include/tcpdf_filters.php');
+	with:
+	require_once(dirname(__FILE__).'/../tecnickcom/tcpdf/include/tcpdf_filters.php');
 
 
 * Fix by replacing
 	} elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1] >= 2))) {
-with
+	with
 	} elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1]) >= 2)) {
 
 
@@ -262,16 +262,22 @@ Change content of file htdocs/includes/restler/framework/Luracast/Restler/explor
     	// @CHANGE LDR
         if (!is_string($haystack)) return false;
 
-* Add a test into AutoLoader.php to complete function loadThisLoader and test if property exists before calling it
+* Add a test into AutoLoader.php to complete function loadThisLoader and test if property exists before calling it. For this replace code
 
-			//avoid PHP Fatal error:  Uncaught Error: Access to undeclared static property: Composer\\Autoload\\ClassLoader::$loader
-			//in case of multiple autoloader systems
-			if(property_exists($b, $loader[1])) {
-				if (false !== $file = $b::$loader[1]($className)
-					&& $this->exists($className, $b::$loader[1])) {
-				return $file;
-				}
-			}
+	if (false !== $file = $b::$loader[1]($className) && $this->exists($className, $b::$loader[1])) {
+        	return $file;
+        }
+
+	with:
+
+	//avoid PHP Fatal error:  Uncaught Error: Access to undeclared static property: Composer\\Autoload\\ClassLoader::$loader
+	//in case of multiple autoloader systems
+	if(property_exists($b, $loader[1])) {
+		if (false !== $file = $b::$loader[1]($className)
+			&& $this->exists($className, $b::$loader[1])) {
+			return $file;
+		}
+	}
 
 
 PARSEDOWN
@@ -285,11 +291,10 @@ PARSEDOWN
 	...
 
 	// @CHANGE LDR
-    if (preg_match('/{([^}]+)}/', $remainder, $matches2))
-    {
-        $Element['attributes']['class'] = $matches2[1];
-       	$remainder = preg_replace('/{'.preg_quote($matches2[1],'/').'}/', '', $remainder);
-    }
+	if (preg_match('/{([^}]+)}/', $remainder, $matches2)) {
+		$Element['attributes']['class'] = $matches2[1];
+       		$remainder = preg_replace('/{'.preg_quote($matches2[1],'/').'}/', '', $remainder);
+    	}
 
 
 	// @CHANGE LDR

--- a/dev/dolibarr_changes.txt
+++ b/dev/dolibarr_changes.txt
@@ -102,7 +102,7 @@ with
 * Replace in tcpdf.php
 
 			if (!@TCPDF_STATIC::file_exists($file)) {
-				return false;	
+				return false;
 			}
 
 with
@@ -110,9 +110,9 @@ with
 			if (!@TCPDF_STATIC::file_exists($file)) {
 				// DOL CHANGE If we keep this, the image is not visible on pages after the first one.
 				//var_dump($file.' '.(!@TCPDF_STATIC::file_exists($file)));
-				//return false;	
+				//return false;
 			}
-			
+
 * Replace in tcpdf.php
 
 		if (($imgsrc[0] === '/') AND !empty($_SERVER['DOCUMENT_ROOT']) AND ($_SERVER['DOCUMENT_ROOT'] != '/')) {
@@ -133,7 +133,7 @@ with
 			}
 		}
 		elseif (($imgsrc[0] === '/') AND !empty($_SERVER['DOCUMENT_ROOT']) AND ($_SERVER['DOCUMENT_ROOT'] != '/')) {
-					
+
 
 
 * In tecnickcom/tcpdf/include/tcpdf_static, in function fopenLocal, replace
@@ -158,10 +158,10 @@ define('QR_FIND_FROM_RANDOM', false);
 
 * Removed useless directories ("examples", "tools")
 
-* Optionnaly, removed all fonts except 
-    dejavusans* (used by greek, arab, persan, romanian, turkish), 
-    freemono* (russian), 
-    cid*+msungstdlight+stsongstdlight+uni2cid* (chinese), 
+* Optionnaly, removed all fonts except
+    dejavusans* (used by greek, arab, persan, romanian, turkish),
+    freemono* (russian),
+    cid*+msungstdlight+stsongstdlight+uni2cid* (chinese),
     helvetica* (all other languages),
     zapfdingbats.php (for special chars like form checkboxes)
 
@@ -215,11 +215,11 @@ window.location.href=pRef
 
 * Replace
 vTmpDiv=this.newNode(vTmpCell, 'div', null, null, vTaskList[i].getResource());
-with                       
+with
 var vTmpNode=this.newNode(vTmpCell, 'div', null, '');
 vTmpNode=this.newNode(vTmpNode, 'a', null, '', vLangs[vLang]['moreinfo']);
 vTmpNode.setAttribute('href',vTaskList[i].getLink());
-                        
+
 * Replace '% Comp.' to have a smaller text column header
 'comp':'% Comp.'
 with
@@ -262,6 +262,17 @@ Change content of file htdocs/includes/restler/framework/Luracast/Restler/explor
     	// @CHANGE LDR
         if (!is_string($haystack)) return false;
 
+* Add a test into AutoLoader.php to complete function loadThisLoader and test if property exists before calling it
+
+			//avoid PHP Fatal error:  Uncaught Error: Access to undeclared static property: Composer\\Autoload\\ClassLoader::$loader
+			//in case of multiple autoloader systems
+			if(property_exists($b, $loader[1])) {
+				if (false !== $file = $b::$loader[1]($className)
+					&& $this->exists($className, $b::$loader[1])) {
+				return $file;
+				}
+			}
+
 
 PARSEDOWN
 ---------
@@ -269,10 +280,10 @@ PARSEDOWN
 * Add support of css by adding in Parsedown.php:
 
 	// @CHANGE LDR
-	'class' => $Link['element']['attributes']['class'] 
+	'class' => $Link['element']['attributes']['class']
 
 	...
-	
+
 	// @CHANGE LDR
     if (preg_match('/{([^}]+)}/', $remainder, $matches2))
     {
@@ -311,7 +322,7 @@ Add into Class Google of file OAuth2/Service/Google:
         }
         $this->approvalPrompt = $prompt;
     }
-    
+
 
 
 JEDITABLE.JS

--- a/htdocs/includes/restler/framework/Luracast/Restler/AutoLoader.php
+++ b/htdocs/includes/restler/framework/Luracast/Restler/AutoLoader.php
@@ -290,10 +290,14 @@ class AutoLoader
         if (is_array($loader)
             && is_callable($loader)) {
             $b = new $loader[0];
-            if (false !== $file = $b::$loader[1]($className)
-                    && $this->exists($className, $b::$loader[1])) {
-                return $file;
-            }
+			//avoid PHP Fatal error:  Uncaught Error: Access to undeclared static property: Composer\\Autoload\\ClassLoader::$loader
+			//in case of multiple autoloader systems
+			if(property_exists($b, $loader[1])) {
+				if (false !== $file = $b::$loader[1]($className)
+					&& $this->exists($className, $b::$loader[1])) {
+				return $file;
+				}
+			}
         } elseif (is_callable($loader)
             && false !== $file = $loader($className)
                 && $this->exists($className, $loader)) {


### PR DESCRIPTION


#FIX 17665 : restler autoload and other autoloader

In case of other autoload classes it could happens a sort of collision with restler (when using api).

That patch fix the "PHP Fatal error: Uncaught Error: Access to undeclared static property: $loader" problem when Restler try to manage classes autoloaded by other systems like composer.

Why do i put it in dolibarr 13.0 ? just because of one of my customer has that bug and uses that dolibarr version, please let me know if i have to make the job for newer versions of dolibarr.

thanks
Éric
