### PR TITLE
FIX - Workstation in BOM

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1475,9 +1475,9 @@ class BOM extends CommonObject
 					$unitforline = measuringUnitString($line->fk_unit, '', '', 1);
 					$qtyhourforline = convertDurationtoHour($line->qty, $unitforline);
 
-					if (isModEnabled('workstation') && !empty($line->fk_default_workstation)) {
+					if (isModEnabled('workstation') && !empty($tmpproduct->fk_default_workstation)) {
 						$workstation = new Workstation($this->db);
-						$res = $workstation->fetch($line->fk_default_workstation);
+						$res = $workstation->fetch($tmpproduct->fk_default_workstation);
 
 						if ($res > 0) {
 							$line->total_cost = price2num($qtyhourforline * ($workstation->thm_operator_estimated + $workstation->thm_machine_estimated), 'MT');


### PR DESCRIPTION
# FIX - Workstation in BOM
The management of workstations has recently been modified, which creates a bug. To manage the services in the Bom you must use the product workstation and not the line.
