### PR TITLE
Fixed issue where last days in current and previous month produce incorrect results in timezones west of GMT

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -315,8 +315,8 @@ if (empty($mode) || $mode == 'show_month') {
 	$next_year  = $next['year'];
 	$next_month = $next['month'];
 
-	$max_day_in_prev_month = date("t", dol_mktime(0, 0, 0, $prev_month, 1, $prev_year, 'gmt')); // Nb of days in previous month
-	$max_day_in_month = date("t", dol_mktime(0, 0, 0, $month, 1, $year)); // Nb of days in next month
+	$max_day_in_prev_month = date("t", dol_mktime(12, 0, 0, $prev_month, 1, $prev_year, 'gmt')); // Nb of days in previous month
+	$max_day_in_month = date("t", dol_mktime(12, 0, 0, $month, 1, $year)); // Nb of days in next month
 	// tmpday is a negative or null cursor to know how many days before the 1st to show on month view (if tmpday=0, 1st is monday)
 	$tmpday = -date("w", dol_mktime(12, 0, 0, $month, 1, $year, 'gmt')) + 2; // date('w') is 0 fo sunday
 	$tmpday += ((isset($conf->global->MAIN_START_WEEK) ? $conf->global->MAIN_START_WEEK : 1) - 1);

--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -316,7 +316,7 @@ if (empty($mode) || $mode == 'show_month') {
 	$next_month = $next['month'];
 
 	$max_day_in_prev_month = date("t", dol_mktime(12, 0, 0, $prev_month, 1, $prev_year, 'gmt')); // Nb of days in previous month
-	$max_day_in_month = date("t", dol_mktime(12, 0, 0, $month, 1, $year)); // Nb of days in next month
+	$max_day_in_month = date("t", dol_mktime(12, 0, 0, $month, 1, $year, 'gmt')); // Nb of days in next month
 	// tmpday is a negative or null cursor to know how many days before the 1st to show on month view (if tmpday=0, 1st is monday)
 	$tmpday = -date("w", dol_mktime(12, 0, 0, $month, 1, $year, 'gmt')) + 2; // date('w') is 0 fo sunday
 	$tmpday += ((isset($conf->global->MAIN_START_WEEK) ? $conf->global->MAIN_START_WEEK : 1) - 1);


### PR DESCRIPTION
# NEW Fixed issue where last days in current and previous months are calculated incorrectly in time zones west of GMT

This problem happens when a date is created by making a call to dol_mktime() with a time of 00:00:00, a date of the 1st of the month, and a time zone of GTM, which is then passed to the date() function the calculate the last day of the current month.

When this code is run in the EST time zone, for example, the date function converts the time to the local time zone first, which results in a time that is 4 or 5 hours earlier, pushing it into the previous month. The last day of the month is therefore calculated for the wrong month in some circumstances. The result of this in my instance was an incorrectly displayed month view in the calendar in November and February as well as other months.
