### PR TITLE
Fix: Unsupported operand types

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -122,14 +122,11 @@ function getServerTimeZoneInt($refgmtdate = 'now')
 function dol_time_plus_duree($time, $duration_value, $duration_unit, $ruleforendofmonth = 0)
 {
 	global $conf;
-	if (empty($duration_value)){
+	if (empty($duration_value)) {
 		return $time;
 	}
 	if ($duration_unit == 's') {
 		return $time + ($duration_value);
-	}
-	if ($duration_value == 0) {
-		return $time;
 	}
 	if ($duration_unit == 'i') {
 		return $time + (60 * $duration_value);

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -122,6 +122,9 @@ function getServerTimeZoneInt($refgmtdate = 'now')
 function dol_time_plus_duree($time, $duration_value, $duration_unit, $ruleforendofmonth = 0)
 {
 	global $conf;
+	if (empty($duration_value)){
+		return $time;
+	}
 	if ($duration_unit == 's') {
 		return $time + ($duration_value);
 	}


### PR DESCRIPTION


# Fix 
in the contract, when calculating the duration from the product duration, if the duration is not configured, an Unsupported operand types error is displayed.

To reproduce this error:
* create a product with no defined duration
* place it in a contract
* start the service
