### PR TITLE
fix: add missing hook in supplier tab of thirdparty (same as in customer/prospect tab)

### DIFF
--- a/htdocs/fourn/card.php
+++ b/htdocs/fourn/card.php
@@ -870,6 +870,15 @@ if ($object->id > 0) {
 		}
 	}
 
+	// Allow external modules to add their own shortlist of recent objects
+	$parameters = array();
+	$reshook = $hookmanager->executeHooks('addMoreRecentObjects', $parameters, $object, $action);
+	if ($reshook < 0) {
+		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	} else {
+		print $hookmanager->resPrint;
+	}
+
 	print '</div></div>';
 	print '<div class="clearboth"></div>';
 


### PR DESCRIPTION
fix #27232 