### PR TITLE
NEW: Automatically fill matching extra fields of object on line creation.

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -821,13 +821,13 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 
 						// Set values for any fields in the form options_SOMETHING
 						for (var key in data.array_options) {
-						  if (data.array_options.hasOwnProperty(key)) {
-						    var field = jQuery("#" + key);
-							if(field.length > 0){
-						    	console.log("objectline_create.tpl set content of options_" + key);
-								field.val(data.array_options[key]);
+							if (data.array_options.hasOwnProperty(key)) {
+								var field = jQuery("#" + key);
+								if(field.length > 0){
+									console.log("objectline_create.tpl set content of options_" + key);
+									field.val(data.array_options[key]);
+								}
 							}
-						  }
 						}
 
 						var tva_tx = data.tva_tx;

--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -819,6 +819,17 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 							jQuery("#price_ht").val(data.price_ht);
 						}
 
+						// Set values for any fields in the form options_SOMETHING
+						for (var key in data.array_options) {
+						  if (data.array_options.hasOwnProperty(key)) {
+						    var field = jQuery("#" + key);
+							if(field.length > 0){
+						    	console.log("objectline_create.tpl set content of options_" + key);
+								field.val(data.array_options[key]);
+							}
+						  }
+						}
+
 						var tva_tx = data.tva_tx;
 						var default_vat_code = data.default_vat_code;
 


### PR DESCRIPTION
# NEW|New [*Automatically fill matching extra fields of object on line creation.*]
This modification allows to automatically fill the matching extra field of an object (product/service) when both the object and the form (for example, when adding the object to a propale or invoice) have a same-named extra-field.

