### PR TITLE
Fix #23248 Prices not updated when external user (client) create a propal or command

### DIFF
--- a/htdocs/product/ajax/products.php
+++ b/htdocs/product/ajax/products.php
@@ -59,7 +59,7 @@ $warehouseStatus = GETPOST('warehousestatus', 'alpha');
 $hidepriceinlabel = GETPOST('hidepriceinlabel', 'int');
 
 // Security check
-restrictedArea($user, 'produit|service', 0, 'product&product');
+restrictedArea($user, 'produit|service|commande|propal', 0, 'product&product');
 
 
 /*


### PR DESCRIPTION
Fix #23248 Prices not updated when external user (client) create a propal or command

In one of my projects, we allow some clients to connect to Dolibarr to create themselves their commands
They can add lines to the command, but if they choose a predefined product or service, its price is not copied in #price_ht input