### PR TITLE
FIX: API response codes on 'no entity found' set to 200 with empty result

### DIFF
--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -271,9 +271,6 @@ class Members extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve member list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No member found');
-		}
 
 		return $obj_ret;
 	}

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -540,10 +540,6 @@ class Members extends DolibarrApi
 
 		$result = $categories->getListForItem($id, 'member', $sortfield, $sortorder, $limit, $page);
 
-		if (empty($result)) {
-			throw new RestException(404, 'No category found');
-		}
-
 		if ($result < 0) {
 			throw new RestException(503, 'Error when retrieve category list : '.$categories->error);
 		}

--- a/htdocs/adherents/class/api_memberstypes.class.php
+++ b/htdocs/adherents/class/api_memberstypes.class.php
@@ -136,9 +136,6 @@ class MembersTypes extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve member type list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No member type found');
-		}
 
 		return $obj_ret;
 	}

--- a/htdocs/adherents/class/api_subscriptions.class.php
+++ b/htdocs/adherents/class/api_subscriptions.class.php
@@ -133,9 +133,6 @@ class Subscriptions extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve subscription list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No Subscription found');
-		}
 
 		return $obj_ret;
 	}

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -1156,10 +1156,6 @@ class Setup extends DolibarrApi
 			throw new RestException(503, 'Error when retrieving list of extra fields : '.$this->db->lasterror());
 		}
 
-		if (!count($list)) {
-			throw new RestException(404, 'No extrafield found');
-		}
-
 		return $list;
 	}
 

--- a/htdocs/bom/class/api_boms.class.php
+++ b/htdocs/bom/class/api_boms.class.php
@@ -182,9 +182,7 @@ class Boms extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve bom list');
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No bom found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -182,9 +182,7 @@ class Categories extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve category list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No category found');
-		}
+
 		return $obj_ret;
 	}
 
@@ -342,9 +340,6 @@ class Categories extends DolibarrApi
 		$categories = $this->category->getListForItem($id, $type, $sortfield, $sortorder, $limit, $page);
 
 		if (!is_array($categories)) {
-			if ($categories == 0) {
-				throw new RestException(404, 'No category found for this object');
-			}
 			throw new RestException(600, 'Error when fetching object categories', array_merge(array($this->category->error), $this->category->errors));
 		}
 		return $categories;

--- a/htdocs/comm/action/class/api_agendaevents.class.php
+++ b/htdocs/comm/action/class/api_agendaevents.class.php
@@ -192,9 +192,7 @@ class AgendaEvents extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve Agenda Event list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No Agenda Event found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -245,9 +245,7 @@ class Proposals extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve propal list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No proposal found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -259,9 +259,7 @@ class Orders extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve commande list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No order found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -281,9 +281,7 @@ class Invoices extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve invoice list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No invoice found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -181,9 +181,7 @@ class Contracts extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve contrat list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No contract found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/don/class/api_donations.class.php
+++ b/htdocs/don/class/api_donations.class.php
@@ -165,9 +165,6 @@ class Donations extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve donation list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No donation found');
-		}
 
 		return $obj_ret;
 	}

--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -179,9 +179,7 @@ class Shipments extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve commande list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No shipment found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/expensereport/class/api_expensereports.class.php
+++ b/htdocs/expensereport/class/api_expensereports.class.php
@@ -151,9 +151,7 @@ class ExpenseReports extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve Expense Report list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No Expense Report found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -190,9 +190,7 @@ class Interventions extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve intervention list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No intervention found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -193,9 +193,7 @@ class SupplierInvoices extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve supplier invoice list : ' . $this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No supplier invoice found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/fourn/class/api_supplier_orders.class.php
+++ b/htdocs/fourn/class/api_supplier_orders.class.php
@@ -215,9 +215,7 @@ class SupplierOrders extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve supplier order list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No supplier order found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
+++ b/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
@@ -227,7 +227,7 @@ class KnowledgeManagement extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving knowledgerecord list: '.$this->db->lasterror());
 		}
-		
+
 		return $obj_ret;
 	}
 

--- a/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
+++ b/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
@@ -231,9 +231,7 @@ class KnowledgeManagement extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving knowledgerecord list: '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No knowledgerecord found');
-		}
+		
 		return $obj_ret;
 	}
 

--- a/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
+++ b/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
@@ -109,10 +109,6 @@ class KnowledgeManagement extends DolibarrApi
 
 		$result = $categories->getListForItem($id, 'knowledgemanagement', $sortfield, $sortorder, $limit, $page);
 
-		if (empty($result)) {
-			throw new RestException(404, 'No category found');
-		}
-
 		if ($result < 0) {
 			throw new RestException(503, 'Error when retrieve category list : '.join(',', array_merge(array($categories->error), $categories->errors)));
 		}

--- a/htdocs/modulebuilder/template/class/api_mymodule.class.php
+++ b/htdocs/modulebuilder/template/class/api_mymodule.class.php
@@ -190,9 +190,7 @@ class MyModuleApi extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving myobject list: '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No myobject found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/mrp/class/api_mos.class.php
+++ b/htdocs/mrp/class/api_mos.class.php
@@ -180,9 +180,7 @@ class Mos extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve MO list');
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No MO found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/multicurrency/class/api_multicurrencies.class.php
+++ b/htdocs/multicurrency/class/api_multicurrencies.class.php
@@ -102,9 +102,6 @@ class MultiCurrencies extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve currencies list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No currencies found');
-		}
 
 		return $obj_ret;
 	}

--- a/htdocs/partnership/class/api_partnerships.class.php
+++ b/htdocs/partnership/class/api_partnerships.class.php
@@ -187,9 +187,7 @@ class Partnerships extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving partnership list: '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No partnership found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -277,9 +277,6 @@ class Products extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve product list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No product found');
-		}
 
 		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
 		if ($pagination_data) {
@@ -600,10 +597,6 @@ class Products extends DolibarrApi
 		$categories = new Categorie($this->db);
 
 		$result = $categories->getListForItem($id, 'product', $sortfield, $sortorder, $limit, $page);
-
-		if (empty($result)) {
-			throw new RestException(404, 'No category found');
-		}
 
 		if ($result < 0) {
 			throw new RestException(503, 'Error when retrieve category list : '.join(',', array_merge(array($categories->error), $categories->errors)));
@@ -953,9 +946,7 @@ class Products extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve product list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No product found');
-		}
+
 		return $obj_ret;
 	}
 
@@ -1078,10 +1069,6 @@ class Products extends DolibarrApi
 			$tmp->entity = $obj->entity;
 
 			$return[] = $this->_filterObjectProperties($this->_cleanObjectDatas($tmp), $properties);
-		}
-
-		if (!count($return)) {
-			throw new RestException(404, 'No product attribute found');
 		}
 
 		return $return;
@@ -1947,10 +1934,6 @@ class Products extends DolibarrApi
 					unset($stockData[$warehouse_id]);
 				}
 			}
-		}
-
-		if (empty($stockData)) {
-			throw new RestException(404, 'No stock found');
 		}
 
 		return array('stock_warehouses'=>$stockData);

--- a/htdocs/product/stock/class/api_stockmovements.class.php
+++ b/htdocs/product/stock/class/api_stockmovements.class.php
@@ -144,9 +144,7 @@ class StockMovements extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve stock movement list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No stock movement found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/product/stock/class/api_warehouses.class.php
+++ b/htdocs/product/stock/class/api_warehouses.class.php
@@ -150,9 +150,7 @@ class Warehouses extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve warehouse list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No warehouse found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -190,9 +190,7 @@ class Projects extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve project list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No project found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -185,9 +185,7 @@ class Tasks extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve task list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No task found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/reception/class/api_receptions.class.php
+++ b/htdocs/reception/class/api_receptions.class.php
@@ -178,9 +178,7 @@ class Receptions extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve commande list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No reception found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/recruitment/class/api_recruitments.class.php
+++ b/htdocs/recruitment/class/api_recruitments.class.php
@@ -226,9 +226,7 @@ class Recruitments extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving jobposition list: '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No jobposition found');
-		}
+
 		return $obj_ret;
 	}
 
@@ -333,9 +331,7 @@ class Recruitments extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving candidature list: '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No candidature found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/societe/class/api_contacts.class.php
+++ b/htdocs/societe/class/api_contacts.class.php
@@ -465,10 +465,6 @@ class Contacts extends DolibarrApi
 
 		$result = $categories->getListForItem($id, 'contact', $sortfield, $sortorder, $limit, $page);
 
-		if (empty($result)) {
-			throw new RestException(404, 'No category found');
-		}
-
 		if ($result < 0) {
 			throw new RestException(503, 'Error when retrieve category list : '.$categories->error);
 		}

--- a/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
+++ b/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
@@ -171,9 +171,7 @@ class SupplierProposals extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving supplier proposal list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No supplier proposal found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -285,9 +285,7 @@ class Tickets extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve ticket list');
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No ticket found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -134,9 +134,7 @@ class Users extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve User list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No User found');
-		}
+
 		return $obj_ret;
 	}
 
@@ -590,9 +588,7 @@ class Users extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve Group list : '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No Group found');
-		}
+
 		return $obj_ret;
 	}
 

--- a/htdocs/zapier/class/api_zapier.class.php
+++ b/htdocs/zapier/class/api_zapier.class.php
@@ -230,9 +230,7 @@ class Zapier extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve hook list');
 		}
-		if (!count($obj_ret)) {
-			throw new RestException(404, 'No hook found');
-		}
+		
 		return $obj_ret;
 	}
 

--- a/htdocs/zapier/class/api_zapier.class.php
+++ b/htdocs/zapier/class/api_zapier.class.php
@@ -230,7 +230,7 @@ class Zapier extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve hook list');
 		}
-		
+
 		return $obj_ret;
 	}
 


### PR DESCRIPTION
# FIX|Fix #19872 Error on API method GET
According to [RFC2616](https://www.rfc-editor.org/rfc/rfc2616#section-10.2), APIs should return 2xx status codes if the request was correct.
The response should be status 200 with an empty result array.
This PR files this problem so user agents can work correctly with the dolibarr api.

So, for example, for the endpoint `/invoice`, instead of returning
```
{
  error: { code: 404, message: 'Not Found: No invoice found' },
  debug: {
    source: 'api_invoices.class.php:284 at call stage',
    stages: { success: [Array], failure: [Array] }
  }
}
```
now will be returned:
```
[]
```