### PR TITLE
Fix #27265 Limits and precision : bad control on MAIN_MAX_DECIMALS_SHOWN

### DIFF
--- a/htdocs/admin/limits.php
+++ b/htdocs/admin/limits.php
@@ -94,7 +94,7 @@ if ($action == 'update' && !$cancel) {
 		setEventMessages($langs->trans("ErrorValueCantBeNull", dol_trunc(dol_string_nohtmltag($langs->transnoentitiesnoconv("MAIN_MAX_DECIMALS_SHOWN")), 40)), null, 'errors');
 		$action = 'edit';
 	}
-	if (! $error && ((float) $valmainmaxdecimalsshown < $valmainmaxdecimalsunit) { // Fix #27265 : || (float) $valmainmaxdecimalsshown < $valmainmaxdecimalstot)
+	if (! $error && ((float) $valmainmaxdecimalsshown < $valmainmaxdecimalsunit)) { // Fix #27265 : || (float) $valmainmaxdecimalsshown < $valmainmaxdecimalstot)
 		$langs->load("errors");
 		$error++;
 		setEventMessages($langs->trans("ErrorValueForTooLow", dol_trunc(dol_string_nohtmltag($langs->transnoentitiesnoconv("MAIN_MAX_DECIMALS_SHOWN")), 40)), null, 'errors');

--- a/htdocs/admin/limits.php
+++ b/htdocs/admin/limits.php
@@ -94,7 +94,7 @@ if ($action == 'update' && !$cancel) {
 		setEventMessages($langs->trans("ErrorValueCantBeNull", dol_trunc(dol_string_nohtmltag($langs->transnoentitiesnoconv("MAIN_MAX_DECIMALS_SHOWN")), 40)), null, 'errors');
 		$action = 'edit';
 	}
-	if (! $error && ((float) $valmainmaxdecimalsshown < $valmainmaxdecimalsunit || (float) $valmainmaxdecimalsshown < $valmainmaxdecimalstot)) {
+	if (! $error && ((float) $valmainmaxdecimalsshown < $valmainmaxdecimalsunit) { // Fix #27265 : || (float) $valmainmaxdecimalsshown < $valmainmaxdecimalstot)
 		$langs->load("errors");
 		$error++;
 		setEventMessages($langs->trans("ErrorValueForTooLow", dol_trunc(dol_string_nohtmltag($langs->transnoentitiesnoconv("MAIN_MAX_DECIMALS_SHOWN")), 40)), null, 'errors');


### PR DESCRIPTION
Fix #27265 Limits and precision : bad control on MAIN_MAX_DECIMALS_SHOWN

In admin ->limit and precision, it's not allowed to set MAIN_MAX_DECIMALS_TOT>MAIN_MAX_DECIMALS_SHOWN
This throws an error and I don't understand why, I think the test is inverted
For example, you want the HT totals calculated with 5 digits (when applying VAT afterwards for example), but you want only 2 digits displayed; but that's now impossible

It would be more logical to throw and error if MAIN_MAX_DECIMALS_TOT < MAIN_MAX_DECIMALS_SHOWN . Or may be **not comparing these 2 values at all : that's done in this PR**