### PR TITLE
Fix #27273 MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND doesn't work as expected

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -529,7 +529,7 @@ if (empty($reshook)) {
 		$object->fetch($id);
 		$object->revenuestamp = GETPOST('revenuestamp');
 		$result = $object->update($user);
-		$object->update_price(1);
+		$object->update_price(1, 'auto');
 		if ($result < 0) {
 			dol_print_error($db, $object->error);
 		} else {
@@ -1276,7 +1276,7 @@ if (empty($reshook)) {
 							}
 						}
 
-						$object->update_price(1);
+						$object->update_price(1, 'auto');
 					}
 				}
 

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2646,7 +2646,7 @@ class Facture extends CommonInvoice
 
 			$lineid = $facligne->insert();
 			if ($lineid > 0) {
-				$result = $this->update_price(1);
+				$result = $this->update_price(1, 'auto');
 				if ($result > 0) {
 					// Create link between discount and invoice line
 					$result = $remise->link_to_invoice($lineid, 0);
@@ -3331,7 +3331,7 @@ class Facture extends CommonInvoice
 		$this->newref = dol_sanitizeFileName($num);
 
 		if ($num) {
-			$this->update_price(1);
+			$this->update_price(1, 'auto');
 
 			// Validate
 			$sql = 'UPDATE '.MAIN_DB_PREFIX.'facture';
@@ -4340,7 +4340,7 @@ class Facture extends CommonInvoice
 
 		// sometimes it is better to not update price for each line, ie when updating situation on all lines
 		if ($update_price) {
-			$this->update_price(1);
+			$this->update_price(1, 'auto');
 		}
 	}
 
@@ -4385,7 +4385,7 @@ class Facture extends CommonInvoice
 		$line->oldline = $staticline;
 
 		if ($line->delete($user) > 0) {
-			$result = $this->update_price(1);
+			$result = $this->update_price(1, 'auto');
 
 			if ($result > 0) {
 				$this->db->commit();
@@ -4466,7 +4466,7 @@ class Facture extends CommonInvoice
 
 			if (!$error) {
 				$this->remise_percent = $remise;
-				$this->update_price(1);
+				$this->update_price(1, 'auto');
 
 				$this->db->commit();
 				return 1;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3670,7 +3670,7 @@ abstract class CommonObject
 		}
 
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
-		
+
 		$forcedroundingmode = $roundingadjust;
 		if ($forcedroundingmode == 'auto' && isset($conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND)) {
 			$forcedroundingmode = getDolGlobalString('MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND');
@@ -3803,7 +3803,7 @@ abstract class CommonObject
 				if ($forcedroundingmode == '1') {	// Check if we need adjustement onto line for vat. TODO This works on the company currency but not on foreign currency
 					$tmpvat = price2num($total_ht_by_vats[$obj->vatrate] * $obj->vatrate / 100, 'MT', 1);
 					$diff = price2num($total_tva_by_vats[$obj->vatrate] - $tmpvat, 'MT', 1);
-//					print 'Line '.$i.' rowid='.$obj->rowid.' vat_rate='.$obj->vatrate.' total_ht='.$obj->total_ht.' total_tva='.$obj->total_tva.' total_ttc='.$obj->total_ttc.' total_ht_by_vats='.$total_ht_by_vats[$obj->vatrate].' total_tva_by_vats='.$total_tva_by_vats[$obj->vatrate].' (new calculation = '.$tmpvat.') total_ttc_by_vats='.$total_ttc_by_vats[$obj->vatrate].($diff?" => DIFF":"")."<br>\n";
+					// print 'Line '.$i.' rowid='.$obj->rowid.' vat_rate='.$obj->vatrate.' total_ht='.$obj->total_ht.' total_tva='.$obj->total_tva.' total_ttc='.$obj->total_ttc.' total_ht_by_vats='.$total_ht_by_vats[$obj->vatrate].' total_tva_by_vats='.$total_tva_by_vats[$obj->vatrate].' (new calculation = '.$tmpvat.') total_ttc_by_vats='.$total_ttc_by_vats[$obj->vatrate].($diff?" => DIFF":"")."<br>\n";
 					if ($diff) {
 						if (abs($diff) > (10 * pow(10, -1 * getDolGlobalInt('MAIN_MAX_DECIMALS_TOT', 0)))) {
 							// If error is more than 10 times the accurancy of rounding. This should not happen.

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -797,7 +797,7 @@ class FactureFournisseur extends CommonInvoice
 
 
 			// Update total price
-			$result = $this->update_price(1);
+			$result = $this->update_price(1, 'auto');
 			if ($result > 0) {
 				// Actions on extra fields
 				if (!$error) {
@@ -1381,7 +1381,7 @@ class FactureFournisseur extends CommonInvoice
 
 			$lineid = $facligne->insert();
 			if ($lineid > 0) {
-				$result = $this->update_price(1);
+				$result = $this->update_price(1, 'auto');
 				if ($result > 0) {
 					// Create link between discount and invoice line
 					$result = $remise->link_to_invoice($lineid, 0);
@@ -2523,7 +2523,7 @@ class FactureFournisseur extends CommonInvoice
 			$this->db->rollback();
 			return -3;
 		} else {
-			$res = $this->update_price(1);
+			$res = $this->update_price(1, 'auto');
 
 			if ($res > 0) {
 				$this->db->commit();

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -1959,7 +1959,7 @@ if (empty($reshook)) {
 	// Make calculation according to calculationrule
 	if ($action == 'calculate') {
 		$calculationrule = GETPOST('calculationrule');
-		switch($calculationrule) {
+		switch ($calculationrule) {
 			case 'totalofround':
 				$roundingadjust = '0';
 				break;

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -1959,10 +1959,19 @@ if (empty($reshook)) {
 	// Make calculation according to calculationrule
 	if ($action == 'calculate') {
 		$calculationrule = GETPOST('calculationrule');
-
+		switch($calculationrule) {
+			case 'totalofround':
+				$roundingadjust = '0';
+				break;
+			case 'roundoftotal':
+				$roundingadjust = '1';
+				break;
+			default:
+				$roundingadjust = 'auto';
+		}
 		$object->fetch($id);
 		$object->fetch_thirdparty();
-		$result = $object->update_price(0, (($calculationrule == 'totalofround') ? '0' : '1'), 0, $object->thirdparty);
+		$result = $object->update_price(0, $roundingadjust, 0, $object->thirdparty);
 		if ($result <= 0) {
 			dol_print_error($db, $result);
 			exit;


### PR DESCRIPTION
# FIX #27273 MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND doesn't work as expected

Even in mode 2 wih MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=1, the sum of vat is calculated with sum of vat lines (rounded to 2 dec by default), and is eventualy corrected by $diff (see in the code).
That's seems to me unlogical.
I think the total(s) vat should be calculated at the end of the loop on lines using $total_ht_by_vats array * vat_rate

I suggest like in the followig PR to add another mode MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=2 which use total_ht_by_vats array, so that it doesn't break existing configurations

Inspecting the code, I found in facture and in supplier facture some incoherencies : sometimes
update_price()
is called
update_price(1)
some other times, it's called
update_price(1, 'auto')

As the default value for 2nd param of update_price is 'none', the invoice's total may vary when validated.

So I changed every call to
update_price(1, 'auto')
