### PR TITLE
Fix Correct call to dolibarr_set_const for CONTRACT_ALLOW_ONLINESIGN

### DIFF
--- a/htdocs/admin/contract.php
+++ b/htdocs/admin/contract.php
@@ -157,7 +157,7 @@ if ($action == 'updateMask') {
 		setEventMessages($langs->trans("Error"), null, 'errors');
 	}
 } elseif ($action == "allowonlinesign") {
-	if (!dolibarr_set_const($db, "CONTRACT_ALLOW_ONLINESIGN", $value, 0, 'int', $conf->entity)) {
+	if (!dolibarr_set_const($db, "CONTRACT_ALLOW_ONLINESIGN", $value, 'int', 0, '', $conf->entity)) {
 		$error++;
 	}
 } elseif (preg_match('/set_(.*)/', $action, $reg)) {


### PR DESCRIPTION
# Fix Correct call to dolibarr_set_const for CONTRACT_ALLOW_ONLINESIGN
An argument to the function call was missing (invalid parameter offset) and the type 'int' was not in the correct position.