### PR TITLE
FIX: FichinterTest: create Societe object in test

### DIFF
--- a/test/phpunit/FichinterTest.php
+++ b/test/phpunit/FichinterTest.php
@@ -139,8 +139,14 @@ class FichinterTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
+		$soc = new Societe($db);
+		$soc->name = "FichinterTest Unittest";
+		$socid = $soc->create($user);
+		$this->assertLessThan($socid, 0, $soc->errorsToString());
+
 		$localobject=new Fichinter($db);
 		$localobject->initAsSpecimen();
+		$localobject->socid = $socid;
 		$result=$localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";


### PR DESCRIPTION
# FIX: FichinterTest: create Societe object in test

Fix the following error when running without the dataset.

    Fichinter
     ✘ Fichinter create
       ┐
       ├ ERROR:  23503: insert or update on table "llx_fichinter" violates foreign key constraint "fk_fichinter_fk_soc"
       ├ DETAIL:  Key (fk_soc)=(1) is not present in table "llx_societe".
       ├ SCHEMA NAME:  public
       ├ TABLE NAME:  llx_fichinter
       ├ CONSTRAINT NAME:  fk_fichinter_fk_soc
       ├ LOCATION:  ri_ReportViolation, ri_triggers.c:2596,
       ├ Failed asserting that 0 is less than -1.
       │
       │ dolibarr/test/phpunit/FichinterTest.php:147
       ┴
