### PR TITLE
QUAL: DiscountAbsolute: inherit CommonObject to implement errorsToString

### DIFF
--- a/htdocs/core/class/discount.class.php
+++ b/htdocs/core/class/discount.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2005      Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (C) 2004-2018 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2024      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,11 +23,12 @@
  *		\brief      File of class to manage absolute discounts
  */
 
+require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
 
 /**
  *		Class to manage absolute discounts
  */
-class DiscountAbsolute
+class DiscountAbsolute extends CommonObject
 {
 	/**
 	 * @var DoliDB Database handler.

--- a/htdocs/core/class/discount.class.php
+++ b/htdocs/core/class/discount.class.php
@@ -31,26 +31,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
 class DiscountAbsolute extends CommonObject
 {
 	/**
-	 * @var DoliDB Database handler.
-	 */
-	public $db;
-
-	/**
-	 * @var string Error code (or message)
-	 */
-	public $error;
-
-	/**
-	 * @var string[]	Array of error strings
-	 */
-	public $errors = array();
-
-	/**
-	 * @var int 	ID discount
-	 */
-	public $id;
-
-	/**
 	 * @var int 	Thirdparty ID
 	 * @deprecated
 	 */


### PR DESCRIPTION
# QUAL: DiscountAbsolute: inherit CommonObject to implement errorsToString

$localobject->errorsToString() is available in most objects using $db or
other systems generating errors because they inherit from CommonObject.
However, DiscountAbsolute didn't inherit from it.

Extending CommonObject allows to implement the usual behaviour for core
objects like referencing the user creation the object.
