### PR TITLE
FIX: DiscountTest: fix create when no societe exists

### DIFF
--- a/test/phpunit/DiscountTest.php
+++ b/test/phpunit/DiscountTest.php
@@ -140,8 +140,14 @@ class DiscountTest extends PHPUnit\Framework\TestCase
 		$langs=$this->savlangs;
 		$db=$this->savdb;
 
+		$soc = new Societe($db);
+		$soc->name = "CommandeTest Unittest";
+		$socid = $soc->create($user);
+		$this->assertLessThan($socid, 0, $soc->errorsToString());
+
 		$localobject=new DiscountAbsolute($db);
 		$localobject->initAsSpecimen();
+		$localobject->fk_soc = $socid;
 		$result=$localobject->create($user);
 
 		$this->assertLessThan($result, 0);


### PR DESCRIPTION
# FIX: DiscountTest: fix create when no societe exists

Fix the following error when running without the dataset.

    ✘ Discount create
    ┐
    ├ ERROR:  23503: insert or update on table "llx_societe_remise_except" violates foreign key constraint "fk_soc_remise_fk_soc"                                                                                                                                                                                                                                                                                                                                      
    ├ DETAIL:  Key (fk_soc)=(1) is not present in table "llx_societe".                                                                                                                                                                                                                                                                                                                                                                                                 
    ├ SCHEMA NAME:  public                                                                                                                                                                                                                                                                                                                                                                                                                                             
    ├ TABLE NAME:  llx_societe_remise_except                                                                                                                                                                                                                                                                                                                                                                                                                           
    ├ CONSTRAINT NAME:  fk_soc_remise_fk_soc                                                                                                                                                                                                                                                                                                                                                                                                                           
    ├ LOCATION:  ri_ReportViolation, ri_triggers.c:2596 - sql=INSERT INTO llx_societe_remise_except (entity, datec, fk_soc, discount_type, fk_user, description, amount_ht, amount_tva, amount_ttc, tva_tx, vat_src_code, multicurrency_amount_ht, multicurrency_amount_tva, multicurrency_amount_ttc, fk_facture_source, fk_invoice_supplier_source) VALUES (1, '2024-01-05 14:05:20', 1, 0, 1, 'Specimen discount', 10, 1.96, 11.96, 19.6, '', 0, 0, 0,  null, null),
    ├ Failed asserting that 0 is less than -1.                                                                                                                                                                                                                                                                                                                                                                                                                         
    │
    │ dolibarr/test/phpunit/DiscountTest.php:147
    ┴
