### PR TITLE
Fix Computed Extrafields on list

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -1696,6 +1696,8 @@ while ($i < $imaxinloop) {
 		$companystatic->fk_prospectlevel = $obj->fk_prospectlevel;
 		$companystatic->fk_parent = $obj->fk_parent;
 		$companystatic->entity = $obj->entity;
+
+		$object = $companystatic;
 	}
 
 	if ($mode == 'kanban') {


### PR DESCRIPTION
FIX empty $object / $objectoffield in core/tpl/extrafields_list_print_fields.tpl.php for computed extrafields to work thirdparties in list 
(in addition to https://github.com/Dolibarr/dolibarr/pull/25631).