### PR TITLE
Fix Computed Extrafields on Contacts list

### DIFF
--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -1127,6 +1127,8 @@ while ($i < $imaxinloop) {
 	}
 	$memberstatic->company = $companyname;
 
+	$object = $memberstatic;
+
 	if ($mode == 'kanban') {
 		if ($i == 0) {
 			print '<tr class="trkanban"><td colspan="'.$savnbfield.'">';

--- a/htdocs/contact/list.php
+++ b/htdocs/contact/list.php
@@ -1390,6 +1390,8 @@ while ($i < $imaxinloop) {
 	$contactstatic->photo = $obj->photo;
 	$contactstatic->fk_prospectlevel = $obj->fk_prospectlevel;
 
+	$object = $contactstatic;
+
 	if ($mode == 'kanban') {
 		if ($i == 0) {
 			print '<tr class="trkanban"><td colspan="'.$savnbfield.'">';


### PR DESCRIPTION
FIX empty $object / $objectoffield in core/tpl/extrafields_list_print_fields.tpl.php for computed extrafields to work contacts list (in addition to #25631 and #27307).