### PR TITLE
Fix: remove filter_type parameter in getSelectInvoiceSubtype call

### DIFF
--- a/htdocs/compta/facture/card-rec.php
+++ b/htdocs/compta/facture/card-rec.php
@@ -1006,7 +1006,7 @@ if ($action == 'create') {
 		// Invoice subtype
 		if (getDolGlobalInt('INVOICE_SUBTYPE_ENABLED')) {
 			print "<tr><td>".$langs->trans("InvoiceSubtype")."</td><td>";
-			print $form->getSelectInvoiceSubtype(GETPOSTISSET('subtype') ? GETPOST('subtype') : $object->subtype, 'subtype', -1, 0, 0, '');
+			print $form->getSelectInvoiceSubtype(GETPOSTISSET('subtype') ? GETPOST('subtype') : $object->subtype, 'subtype', 0, 0, '');
 			print "</td></tr>";
 		}
 


### PR DESCRIPTION
# Fix: remove parameter in  getSelectInvoiceSubtype call
    
Parameters were already invalid when this was added in 65b9f4e6defe.
See https://github.com/Dolibarr/dolibarr/blob/65b9f4e6defede20d488e62f11083c4c0ef5d20b/htdocs/core/class/html.form.class.php#L10865C59-L10865C59 .
