### PR TITLE
NEW fetch object by element for website account card

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -12158,6 +12158,8 @@ function fetchObjectByElement($element_id, $element_type, $element_ref = '')
 		// extrafield for a service, it is not supported and not found when editing the product/service card. So we must keep 'product' for extrafields
 		// of service and we will return properties of a product.
 		$ismodenabled = (isModEnabled('product') || isModEnabled('service'));
+	} elseif ($element_prop['module'] == 'societeaccount') {
+		$ismodenabled = isModEnabled('website') || isModEnabled('webportal');
 	} else {
 		$ismodenabled = isModEnabled($element_prop['module']);
 	}


### PR DESCRIPTION
NEW fetch object by element for website account card
- fetch element on create a new website account card

**Before**
- you got errors on select fields :
`selectForForms: Error bad setup of field objectdescorig=Societe, objectfield=societeaccount:fk_soc`
`selectForForms: Error bad setup of field objectdescorig=Website, objectfield=societeaccount:fk_website`

![image](https://github.com/Dolibarr/dolibarr/assets/45359511/b9bb1c5e-5fdb-44fe-a22c-d1795407a248)


**After**
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/f71ed81d-c37f-4861-a6ef-43eec10f1395)
