### PR TITLE
Fix: make PrestaShopWebservice::executeRequest method public

### DIFF
--- a/htdocs/admin/dolistore/class/PSWebServiceLibrary.class.php
+++ b/htdocs/admin/dolistore/class/PSWebServiceLibrary.class.php
@@ -170,7 +170,7 @@ class PrestaShopWebservice
 	 *
 	 * @throws PrestaShopWebserviceException
 	 */
-	protected function executeRequest($url, $curl_params = array())
+	public function executeRequest($url, $curl_params = array())
 	{
 		$defaultParams = $this->getCurlDefaultParams();
 

--- a/htdocs/admin/dolistore/class/README.md
+++ b/htdocs/admin/dolistore/class/README.md
@@ -4,9 +4,13 @@ Source updated from:
 
 https://github.com/PrestaShop/PrestaShop-webservice-lib/blob/master/PSWebServiceLibrary.php
 
-## Compatibility analysis
+## License compatibility analysis
 
 https://www.gnu.org/licenses/license-list.html#OSL
 
 
+## Local changes
+
+- Change `executeRequest` to public method because
+  `htdocs/admin/dolistore/ajax/image.php#` uses it.
 


### PR DESCRIPTION
# Fix: Make executeRequest public
   
htdocs/admin/dolistore/ajax/image.php uses executeRequest which is protected.
Changing dolibarr's usage is more effort than making the method public.
