### PR TITLE
Fix: Change TCPDF::_out to public because of pdf.lib.php

### DIFF
--- a/dev/dolibarr_changes.txt
+++ b/dev/dolibarr_changes.txt
@@ -65,6 +65,20 @@ NUSOAP:
 
 TCPDF:
 ------
+* Modify in tcpdf.php: make TCPDF::_out public.
+  (htdocs/core/lib/pdf.lib.php uses it as a public method)
+
+  Change:
+      protected function _out($s)
+  to
+      public function _out($s)
+
+  Change in method's _out phpdoc:
+
+      * @protected
+  to
+      * @public
+
 * Replace in tcpdf.php:
             if (isset($this->imagekeys)) {
                 foreach($this->imagekeys as $file) {

--- a/htdocs/includes/tecnickcom/tcpdf/tcpdf.php
+++ b/htdocs/includes/tecnickcom/tcpdf/tcpdf.php
@@ -10516,9 +10516,9 @@ class TCPDF
 	/**
 	 * Output a string to the document.
 	 * @param $s (string) string to output.
-	 * @protected
+	 * @public
 	 */
-	protected function _out($s)
+	public function _out($s)
 	{
 		if ($this->state == 2) {
 			if ($this->inxobj) {


### PR DESCRIPTION
# Fix: Change TCPDF::_out to public because of pdf.lib.php

TCPDF::_out is used 2 times as ->_out(...) in htdocs/core/lib/pdf.lib.php.
Changing php.lib.php requires more analysis.  Making TCPDF::_out public is
the quick solution.
