### PR TITLE
Fix: vcard - add missing db argument in call to dol_print_error

### DIFF
--- a/htdocs/contact/vcard.php
+++ b/htdocs/contact/vcard.php
@@ -41,7 +41,7 @@ $result = restrictedArea($user, 'contact', $id, 'socpeople&societe');
 
 $result = $contact->fetch($id);
 if ($result <= 0) {
-	dol_print_error($contact->error);
+	dol_print_error($db, $contact->error);
 	exit;
 }
 


### PR DESCRIPTION
    
# Fix: vcard - add missing db argument in call to dol_print_error

The first argument is the DoliDB object
