### PR TITLE
Fix: colorseries is already a simple array (fix phan notice)

### DIFF
--- a/htdocs/core/boxes/box_graph_new_vs_close_ticket.php
+++ b/htdocs/core/boxes/box_graph_new_vs_close_ticket.php
@@ -133,7 +133,7 @@ class box_graph_new_vs_close_ticket extends ModeleBoxes
 				$px1 = new DolGraph();
 				$mesg = $px1->isGraphKo();
 				if (!$mesg) {
-					$px1->SetDataColor(array_values($colorseries));
+					$px1->SetDataColor($colorseries);
 					$px1->SetData($data);
 					$px1->setShowLegend(2);
 					if (!empty($conf->dol_optimize_smallscreen)) {


### PR DESCRIPTION
# Fix: colorseries is already a simple array (fix phan notice)

This is reported by phan as a conversion to a list of an array that already is a list.