### PR TITLE
Fix: formmail - add_attached_files - argument name consistency

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -440,9 +440,9 @@ class FormMail extends Form
 
 			if (GETPOST('mode', 'alpha') == 'init' || (GETPOST('modelselected') && GETPOST('modelmailselected', 'alpha') && GETPOST('modelmailselected', 'alpha') != '-1')) {
 				if (!empty($arraydefaultmessage->joinfiles) && !empty($this->param['fileinit']) && is_array($this->param['fileinit'])) {
-					foreach ($this->param['fileinit'] as $file) {
-						if (!empty($file)) {
-							$this->add_attached_files($file, basename($file), dol_mimetype($file));
+					foreach ($this->param['fileinit'] as $path) {
+						if (!empty($path)) {
+							$this->add_attached_files($path);
 						}
 					}
 				}


### PR DESCRIPTION
# Fix: formmail - add_attached_files - argument name consistency

Phan determined suspicious naming as arg https://github.com/Dolibarr/dolibarr/pull/2 to add_attached_files is  while
that was the name for the first argument by the caller.

Also, on examination, only the first parameter is needed as add_attached_files
handles the other two in the same manner.