### PR TITLE
Perf: Optimise dol_mimetype

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -10870,374 +10870,326 @@ function dol_mimetype($file, $default = 'application/octet-stream', $mode = 0)
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.rtx$/i', $tmpfile)) {
+	} elseif (preg_match('/\.rtx$/i', $tmpfile)) {
 		$mime = 'text/richtext';
 		$imgmime = 'text.png';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.csv$/i', $tmpfile)) {
+	} elseif (preg_match('/\.csv$/i', $tmpfile)) {
 		$mime = 'text/csv';
 		$imgmime = 'text.png';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.tsv$/i', $tmpfile)) {
+	} elseif (preg_match('/\.tsv$/i', $tmpfile)) {
 		$mime = 'text/tab-separated-values';
 		$imgmime = 'text.png';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.(cf|conf|log)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(cf|conf|log)$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.ini$/i', $tmpfile)) {
+	} elseif (preg_match('/\.ini$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'ini';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.md$/i', $tmpfile)) {
+	} elseif (preg_match('/\.md$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'md';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.css$/i', $tmpfile)) {
+	} elseif (preg_match('/\.css$/i', $tmpfile)) {
 		$mime = 'text/css';
 		$imgmime = 'css.png';
 		$srclang = 'css';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.lang$/i', $tmpfile)) {
+	} elseif (preg_match('/\.lang$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'lang';
 		$famime = 'file-text-o';
-	}
+	}  // phpcs:ignore
 	// Certificate files
-	if (preg_match('/\.(crt|cer|key|pub)$/i', $tmpfile)) {
+	elseif (preg_match('/\.(crt|cer|key|pub)$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$famime = 'file-text-o';
-	}
+	}  // phpcs:ignore
 	// XML based (HTML/XML/XAML)
-	if (preg_match('/\.(html|htm|shtml)$/i', $tmpfile)) {
+	elseif (preg_match('/\.(html|htm|shtml)$/i', $tmpfile)) {
 		$mime = 'text/html';
 		$imgmime = 'html.png';
 		$srclang = 'html';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.(xml|xhtml)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(xml|xhtml)$/i', $tmpfile)) {
 		$mime = 'text/xml';
 		$imgmime = 'other.png';
 		$srclang = 'xml';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.xaml$/i', $tmpfile)) {
+	} elseif (preg_match('/\.xaml$/i', $tmpfile)) {
 		$mime = 'text/xml';
 		$imgmime = 'other.png';
 		$srclang = 'xaml';
 		$famime = 'file-text-o';
-	}
+	}  // phpcs:ignore
 	// Languages
-	if (preg_match('/\.bas$/i', $tmpfile)) {
+	elseif (preg_match('/\.bas$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'bas';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.(c)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(c)$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'c';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.(cpp)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(cpp)$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'cpp';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.cs$/i', $tmpfile)) {
+	} elseif (preg_match('/\.cs$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'cs';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.(h)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(h)$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'h';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.(java|jsp)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(java|jsp)$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'java';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.php([0-9]{1})?$/i', $tmpfile)) {
+	} elseif (preg_match('/\.php([0-9]{1})?$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'php.png';
 		$srclang = 'php';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.phtml$/i', $tmpfile)) {
+	} elseif (preg_match('/\.phtml$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'php.png';
 		$srclang = 'php';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.(pl|pm)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(pl|pm)$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'pl.png';
 		$srclang = 'perl';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.sql$/i', $tmpfile)) {
+	} elseif (preg_match('/\.sql$/i', $tmpfile)) {
 		$mime = 'text/plain';
 		$imgmime = 'text.png';
 		$srclang = 'sql';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.js$/i', $tmpfile)) {
+	} elseif (preg_match('/\.js$/i', $tmpfile)) {
 		$mime = 'text/x-javascript';
 		$imgmime = 'jscript.png';
 		$srclang = 'js';
 		$famime = 'file-code-o';
-	}
+	}  // phpcs:ignore
 	// Open office
-	if (preg_match('/\.odp$/i', $tmpfile)) {
+	elseif (preg_match('/\.odp$/i', $tmpfile)) {
 		$mime = 'application/vnd.oasis.opendocument.presentation';
 		$imgmime = 'ooffice.png';
 		$famime = 'file-powerpoint-o';
-	}
-	if (preg_match('/\.ods$/i', $tmpfile)) {
+	} elseif (preg_match('/\.ods$/i', $tmpfile)) {
 		$mime = 'application/vnd.oasis.opendocument.spreadsheet';
 		$imgmime = 'ooffice.png';
 		$famime = 'file-excel-o';
-	}
-	if (preg_match('/\.odt$/i', $tmpfile)) {
+	} elseif (preg_match('/\.odt$/i', $tmpfile)) {
 		$mime = 'application/vnd.oasis.opendocument.text';
 		$imgmime = 'ooffice.png';
 		$famime = 'file-word-o';
-	}
+	}  // phpcs:ignore
 	// MS Office
-	if (preg_match('/\.mdb$/i', $tmpfile)) {
+	elseif (preg_match('/\.mdb$/i', $tmpfile)) {
 		$mime = 'application/msaccess';
 		$imgmime = 'mdb.png';
 		$famime = 'file-o';
-	}
-	if (preg_match('/\.doc[xm]?$/i', $tmpfile)) {
+	} elseif (preg_match('/\.doc[xm]?$/i', $tmpfile)) {
 		$mime = 'application/msword';
 		$imgmime = 'doc.png';
 		$famime = 'file-word-o';
-	}
-	if (preg_match('/\.dot[xm]?$/i', $tmpfile)) {
+	} elseif (preg_match('/\.dot[xm]?$/i', $tmpfile)) {
 		$mime = 'application/msword';
 		$imgmime = 'doc.png';
 		$famime = 'file-word-o';
-	}
-	if (preg_match('/\.xlt(x)?$/i', $tmpfile)) {
+	} elseif (preg_match('/\.xlt(x)?$/i', $tmpfile)) {
 		$mime = 'application/vnd.ms-excel';
 		$imgmime = 'xls.png';
 		$famime = 'file-excel-o';
-	}
-	if (preg_match('/\.xla(m)?$/i', $tmpfile)) {
+	} elseif (preg_match('/\.xla(m)?$/i', $tmpfile)) {
 		$mime = 'application/vnd.ms-excel';
 		$imgmime = 'xls.png';
 		$famime = 'file-excel-o';
-	}
-	if (preg_match('/\.xls$/i', $tmpfile)) {
+	} elseif (preg_match('/\.xls$/i', $tmpfile)) {
 		$mime = 'application/vnd.ms-excel';
 		$imgmime = 'xls.png';
 		$famime = 'file-excel-o';
-	}
-	if (preg_match('/\.xls[bmx]$/i', $tmpfile)) {
+	} elseif (preg_match('/\.xls[bmx]$/i', $tmpfile)) {
 		$mime = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 		$imgmime = 'xls.png';
 		$famime = 'file-excel-o';
-	}
-	if (preg_match('/\.pps[mx]?$/i', $tmpfile)) {
+	} elseif (preg_match('/\.pps[mx]?$/i', $tmpfile)) {
 		$mime = 'application/vnd.ms-powerpoint';
 		$imgmime = 'ppt.png';
 		$famime = 'file-powerpoint-o';
-	}
-	if (preg_match('/\.ppt[mx]?$/i', $tmpfile)) {
+	} elseif (preg_match('/\.ppt[mx]?$/i', $tmpfile)) {
 		$mime = 'application/x-mspowerpoint';
 		$imgmime = 'ppt.png';
 		$famime = 'file-powerpoint-o';
-	}
+	}  // phpcs:ignore
 	// Other
-	if (preg_match('/\.pdf$/i', $tmpfile)) {
+	elseif (preg_match('/\.pdf$/i', $tmpfile)) {
 		$mime = 'application/pdf';
 		$imgmime = 'pdf.png';
 		$famime = 'file-pdf-o';
-	}
+	}  // phpcs:ignore
 	// Scripts
-	if (preg_match('/\.bat$/i', $tmpfile)) {
+	elseif (preg_match('/\.bat$/i', $tmpfile)) {
 		$mime = 'text/x-bat';
 		$imgmime = 'script.png';
 		$srclang = 'dos';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.sh$/i', $tmpfile)) {
+	} elseif (preg_match('/\.sh$/i', $tmpfile)) {
 		$mime = 'text/x-sh';
 		$imgmime = 'script.png';
 		$srclang = 'bash';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.ksh$/i', $tmpfile)) {
+	} elseif (preg_match('/\.ksh$/i', $tmpfile)) {
 		$mime = 'text/x-ksh';
 		$imgmime = 'script.png';
 		$srclang = 'bash';
 		$famime = 'file-code-o';
-	}
-	if (preg_match('/\.bash$/i', $tmpfile)) {
+	} elseif (preg_match('/\.bash$/i', $tmpfile)) {
 		$mime = 'text/x-bash';
 		$imgmime = 'script.png';
 		$srclang = 'bash';
 		$famime = 'file-code-o';
-	}
+	}  // phpcs:ignore
 	// Images
-	if (preg_match('/\.ico$/i', $tmpfile)) {
+	elseif (preg_match('/\.ico$/i', $tmpfile)) {
 		$mime = 'image/x-icon';
 		$imgmime = 'image.png';
 		$famime = 'file-image-o';
-	}
-	if (preg_match('/\.(jpg|jpeg)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(jpg|jpeg)$/i', $tmpfile)) {
 		$mime = 'image/jpeg';
 		$imgmime = 'image.png';
 		$famime = 'file-image-o';
-	}
-	if (preg_match('/\.png$/i', $tmpfile)) {
+	} elseif (preg_match('/\.png$/i', $tmpfile)) {
 		$mime = 'image/png';
 		$imgmime = 'image.png';
 		$famime = 'file-image-o';
-	}
-	if (preg_match('/\.gif$/i', $tmpfile)) {
+	} elseif (preg_match('/\.gif$/i', $tmpfile)) {
 		$mime = 'image/gif';
 		$imgmime = 'image.png';
 		$famime = 'file-image-o';
-	}
-	if (preg_match('/\.bmp$/i', $tmpfile)) {
+	} elseif (preg_match('/\.bmp$/i', $tmpfile)) {
 		$mime = 'image/bmp';
 		$imgmime = 'image.png';
 		$famime = 'file-image-o';
-	}
-	if (preg_match('/\.(tif|tiff)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(tif|tiff)$/i', $tmpfile)) {
 		$mime = 'image/tiff';
 		$imgmime = 'image.png';
 		$famime = 'file-image-o';
-	}
-	if (preg_match('/\.svg$/i', $tmpfile)) {
+	} elseif (preg_match('/\.svg$/i', $tmpfile)) {
 		$mime = 'image/svg+xml';
 		$imgmime = 'image.png';
 		$famime = 'file-image-o';
-	}
-	if (preg_match('/\.webp$/i', $tmpfile)) {
+	} elseif (preg_match('/\.webp$/i', $tmpfile)) {
 		$mime = 'image/webp';
 		$imgmime = 'image.png';
 		$famime = 'file-image-o';
-	}
+	}  // phpcs:ignore
 	// Calendar
-	if (preg_match('/\.vcs$/i', $tmpfile)) {
+	elseif (preg_match('/\.vcs$/i', $tmpfile)) {
 		$mime = 'text/calendar';
 		$imgmime = 'other.png';
 		$famime = 'file-text-o';
-	}
-	if (preg_match('/\.ics$/i', $tmpfile)) {
+	} elseif (preg_match('/\.ics$/i', $tmpfile)) {
 		$mime = 'text/calendar';
 		$imgmime = 'other.png';
 		$famime = 'file-text-o';
-	}
+	}  // phpcs:ignore
 	// Other
-	if (preg_match('/\.torrent$/i', $tmpfile)) {
+	elseif (preg_match('/\.torrent$/i', $tmpfile)) {
 		$mime = 'application/x-bittorrent';
 		$imgmime = 'other.png';
 		$famime = 'file-o';
-	}
+	}  // phpcs:ignore
 	// Audio
-	if (preg_match('/\.(mp3|ogg|au|wav|wma|mid)$/i', $tmpfile)) {
+	elseif (preg_match('/\.(mp3|ogg|au|wav|wma|mid)$/i', $tmpfile)) {
 		$mime = 'audio';
 		$imgmime = 'audio.png';
 		$famime = 'file-audio-o';
-	}
+	}  // phpcs:ignore
 	// Video
-	if (preg_match('/\.mp4$/i', $tmpfile)) {
+	elseif (preg_match('/\.mp4$/i', $tmpfile)) {
 		$mime = 'video/mp4';
 		$imgmime = 'video.png';
 		$famime = 'file-video-o';
-	}
-	if (preg_match('/\.ogv$/i', $tmpfile)) {
+	} elseif (preg_match('/\.ogv$/i', $tmpfile)) {
 		$mime = 'video/ogg';
 		$imgmime = 'video.png';
 		$famime = 'file-video-o';
-	}
-	if (preg_match('/\.webm$/i', $tmpfile)) {
+	} elseif (preg_match('/\.webm$/i', $tmpfile)) {
 		$mime = 'video/webm';
 		$imgmime = 'video.png';
 		$famime = 'file-video-o';
-	}
-	if (preg_match('/\.avi$/i', $tmpfile)) {
+	} elseif (preg_match('/\.avi$/i', $tmpfile)) {
 		$mime = 'video/x-msvideo';
 		$imgmime = 'video.png';
 		$famime = 'file-video-o';
-	}
-	if (preg_match('/\.divx$/i', $tmpfile)) {
+	} elseif (preg_match('/\.divx$/i', $tmpfile)) {
 		$mime = 'video/divx';
 		$imgmime = 'video.png';
 		$famime = 'file-video-o';
-	}
-	if (preg_match('/\.xvid$/i', $tmpfile)) {
+	} elseif (preg_match('/\.xvid$/i', $tmpfile)) {
 		$mime = 'video/xvid';
 		$imgmime = 'video.png';
 		$famime = 'file-video-o';
-	}
-	if (preg_match('/\.(wmv|mpg|mpeg)$/i', $tmpfile)) {
+	} elseif (preg_match('/\.(wmv|mpg|mpeg)$/i', $tmpfile)) {
 		$mime = 'video';
 		$imgmime = 'video.png';
 		$famime = 'file-video-o';
-	}
+	}  // phpcs:ignore
 	// Archive
-	if (preg_match('/\.(zip|rar|gz|tgz|z|cab|bz2|7z|tar|lzh|zst)$/i', $tmpfile)) {
+	elseif (preg_match('/\.(zip|rar|gz|tgz|z|cab|bz2|7z|tar|lzh|zst)$/i', $tmpfile)) {
+		// application/xxx where zzz is zip, ...
 		$mime = 'archive';
 		$imgmime = 'archive.png';
 		$famime = 'file-archive-o';
-	}    // application/xxx where zzz is zip, ...
+	}  // phpcs:ignore
 	// Exe
-	if (preg_match('/\.(exe|com)$/i', $tmpfile)) {
+	elseif (preg_match('/\.(exe|com)$/i', $tmpfile)) {
 		$mime = 'application/octet-stream';
 		$imgmime = 'other.png';
 		$famime = 'file-o';
-	}
+	}  // phpcs:ignore
 	// Lib
-	if (preg_match('/\.(dll|lib|o|so|a)$/i', $tmpfile)) {
+	elseif (preg_match('/\.(dll|lib|o|so|a)$/i', $tmpfile)) {
 		$mime = 'library';
 		$imgmime = 'library.png';
 		$famime = 'file-o';
-	}
+	}  // phpcs:ignore
 	// Err
-	if (preg_match('/\.err$/i', $tmpfile)) {
+	elseif (preg_match('/\.err$/i', $tmpfile)) {
 		$mime = 'error';
 		$imgmime = 'error.png';
 		$famime = 'file-text-o';
-	}
+	}  // phpcs:ignore
 
-	// Return string
-	if ($mode == 1) {
-		$tmp = explode('/', $mime);
-		return (!empty($tmp[1]) ? $tmp[1] : $tmp[0]);
-	}
-	if ($mode == 2) {
-		return $imgmime;
-	}
-	if ($mode == 3) {
-		return $srclang;
-	}
-	if ($mode == 4) {
-		return $famime;
+	// Return mimetype string
+	switch ((int) $mode) {
+		case 1:
+			$tmp = explode('/', $mime);
+			return (!empty($tmp[1]) ? $tmp[1] : $tmp[0]);
+		case 2:
+			return $imgmime;
+		case 3:
+			return $srclang;
+		case 4:
+			return $famime;
 	}
 	return $mime;
 }


### PR DESCRIPTION
# Perf: Optimise dol_mimetype

All preg_match() calls were executed even if they are all exclusive.

Further optimisations are possible:
- lowercase the string to match, instead of '/i';
- extract and match only the extension - all regexes match the extension (smaller comparison, no need to find and match the dot each time);
- order the tests in order of decreasing probability/impact on user experience;
- use a constant array(has) where the keys are the extensions to match and the value the result (for most extensions), and only use regex when that array did not match.