### PR TITLE
Fix: files.lib.php - Add sort argument to array_multisort for static checks

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -292,7 +292,7 @@ function dol_dir_list_in_database($path, $filter = "", $excludefilter = null, $s
 			}
 			// Sort the data
 			if ($sortorder) {
-				array_multisort($myarray, $sortorder, $file_list);
+				array_multisort($myarray, $sortorder, SORT_REGULAR, $file_list);
 			}
 		}
 


### PR DESCRIPTION
Fix: files.lib.php - Add optional sort argument to array_multisort for static tool check

# Fix: files.lib.php - Add optional sort argument to array_multisort for static tool check

Phan flags the call to array_multisort as suspicious - adding the optional sort argument
avoids this.
