### PR TITLE
Fix: Add missing argument in getOnlineSignatureUrl

### DIFF
--- a/htdocs/core/lib/signature.lib.php
+++ b/htdocs/core/lib/signature.lib.php
@@ -35,7 +35,7 @@ function showOnlineSignatureUrl($type, $ref, $obj = null)
 	$servicename = 'Online';
 
 	$out = img_picto('', 'globe').' <span class="opacitymedium">'.$langs->trans("ToOfferALinkForOnlineSignature", $servicename).'</span><br>';
-	$url = getOnlineSignatureUrl(0, $type, $ref, $obj);
+	$url = getOnlineSignatureUrl(0, $type, $ref, 1, $obj);
 	$out .= '<div class="urllink">';
 	if ($url == $langs->trans("FeatureOnlineSignDisabled")) {
 		$out .= $url;


### PR DESCRIPTION
# Fix: Add missing argument in getOnlineSignatureUrl.

The function requires 5 arguments and only had 4.