### PR TITLE
Fix: Sitemap generation - fix invalid replacement regex

### DIFF
--- a/htdocs/website/index.php
+++ b/htdocs/website/index.php
@@ -2673,7 +2673,7 @@ if ($action == 'generatesitemaps' && $usercanedit) {
 
 	// Add the entry Sitemap: into the robot file.
 	$robotcontent = @file_get_contents($filerobot);
-	$result = preg_replace('@<?php // BEGIN PHP[^?]END PHP ?>\n@ims', '', $robotcontent);
+	$result = preg_replace('/<?php \/\/ BEGIN PHP[^?]END PHP ?>\n/ims', '', $robotcontent);
 	if ($result) {
 		$robotcontent = $result;
 	}

--- a/htdocs/website/index.php
+++ b/htdocs/website/index.php
@@ -2673,7 +2673,7 @@ if ($action == 'generatesitemaps' && $usercanedit) {
 
 	// Add the entry Sitemap: into the robot file.
 	$robotcontent = @file_get_contents($filerobot);
-	$result = preg_replace('/<?php // BEGIN PHP[^?]END PHP ?>\n/ims', '', $robotcontent);
+	$result = preg_replace('@<?php // BEGIN PHP[^?]END PHP ?>\n@ims', '', $robotcontent);
 	if ($result) {
 		$robotcontent = $result;
 	}


### PR DESCRIPTION
# Fix: Sitemap generation - fix invalid replacement regex

The regex is invalid because the delimiters are slashes which are also present in the text to match.
Fixed by changing the delimiters.