### PR TITLE
FIX: Barcode header cell not well displayed

### DIFF
--- a/htdocs/core/modules/printsheet/doc/pdf_tcpdflabel.class.php
+++ b/htdocs/core/modules/printsheet/doc/pdf_tcpdflabel.class.php
@@ -135,7 +135,7 @@ class pdf_tcpdflabel extends CommonStickerGenerator
 		// Top
 		if ($header != '') {
 			$pdf->SetXY($_PosX + $xleft, $_PosY + 1); // Only 1 mm and not ytop for top text
-			$pdf->Cell($this->_Width - 2 * $xleft, $this->_Line_Height, $outputlangs->convToOutputCharset($header), 0, 1, 'C');
+			$pdf->Cell(2 * strlen($header), $this->_Line_Height, $outputlangs->convToOutputCharset($header), 0, 1, 'C');
 		}
 
 		$ytop += (empty($header) ? 0 : (1 + $this->_Line_Height));


### PR DESCRIPTION
If a header is added to Barcode display by setting for instance  `$conf->global->BARCODE_LABEL_HEADER_TEXT`, it is not well displayed regardless of the size of header text.
![Capture d’écran du 2024-01-09 15-44-22](https://github.com/Dolibarr/dolibarr/assets/58433943/3ec048e0-0696-47c3-82ba-e545b52bb4cf)

After the fix
![Capture d’écran du 2024-01-09 15-45-06](https://github.com/Dolibarr/dolibarr/assets/58433943/19101d79-3ab6-4266-b2ca-e38482ec0715)
