### PR TITLE
Function should return string|null but return statement is missing.

### DIFF
--- a/htdocs/core/lib/barcode.lib.php
+++ b/htdocs/core/lib/barcode.lib.php
@@ -510,6 +510,8 @@ function barcode_outimage($text, $bars, $scale = 1, $mode = "png", $total_y = 0,
 		header("Content-Type: image/png; name=\"barcode.png\"");
 		imagepng($im);
 	}
+
+	return;
 }
 
 /**


### PR DESCRIPTION
![image](https://github.com/Dolibarr/dolibarr/assets/3624836/ede54d7b-803f-4f57-99f4-723387413786)

this is the last one, we can remove : 

![image](https://github.com/Dolibarr/dolibarr/assets/3624836/565d7203-e3ff-43db-9127-2bb3a9f0dc9c)

![image](https://github.com/Dolibarr/dolibarr/assets/3624836/04db1f6a-fa43-4dd5-b147-6765067612fc)

