### PR TITLE
Fix: Do not reuse $key from scope as foreach key

### DIFF
--- a/htdocs/core/lib/modulebuilder.lib.php
+++ b/htdocs/core/lib/modulebuilder.lib.php
@@ -1167,7 +1167,7 @@ function updateDictionaryInFile($module, $file, $dicts)
 			$dicData .= "array(" . implode(",", $conditions) . ")";
 		} elseif ($key === 'tabhelp') {
 			$helpItems = array();
-			foreach ($value as $key => $helpValue) {
+			foreach ($value as $helpValue) {
 				$helpItems[] = "array('code'=>\$langs->trans('".$helpValue['code']."'), 'field2' => 'field2tooltip')";
 			}
 			$dicData .= "array(" . implode(",", $helpItems) . ")";


### PR DESCRIPTION
#Fix: Do not reuse  from scope as foreach key

Phan report: Variable  used in loop was also used in an outer loop.