### PR TITLE
Fix: Do not reuse same variable names in inner scope foreach.

### DIFF
--- a/htdocs/holiday/define_holiday.php
+++ b/htdocs/holiday/define_holiday.php
@@ -534,7 +534,7 @@ if (count($typeleaves) == 0) {
 		foreach ($arrayfields as $key => $val) {
 			if (!empty($val['checked'])) {
 				if ($key == 'cp.nbHoliday') {
-					foreach ($typeleaves as $key => $val) {
+					foreach ($typeleaves as $leave_key => $leave_val) {
 						$colspan++;
 					}
 				} else {


### PR DESCRIPTION
# Fix: Do not reuse same variable names in inner scope foreach.

Phan reports:  PhanPluginLoopVariableReuse: Variable  used in loop was also used in an outer loop