### PR TITLE
FIX: Update mod_codeclient_* constructor to have $db argument as in callers.

### DIFF
--- a/htdocs/core/modules/societe/mod_codeclient_elephant.php
+++ b/htdocs/core/modules/societe/mod_codeclient_elephant.php
@@ -89,8 +89,10 @@ class mod_codeclient_elephant extends ModeleThirdPartyCode
 
 	/**
 	 *	Constructor
+	 *
+	 *	@param DoliDB		$db		Database object
 	 */
-	public function __construct()
+	public function __construct($db)
 	{
 		$this->code_null = 0;
 		$this->code_modifiable = 1;

--- a/htdocs/core/modules/societe/mod_codeclient_leopard.php
+++ b/htdocs/core/modules/societe/mod_codeclient_leopard.php
@@ -65,8 +65,10 @@ class mod_codeclient_leopard extends ModeleThirdPartyCode
 
 	/**
 	 *	Constructor
+	 *
+	 *	@param DoliDB		$db		Database object
 	 */
-	public function __construct()
+	public function __construct($db)
 	{
 		$this->code_null = 1;
 		$this->code_modifiable = 1;

--- a/htdocs/core/modules/societe/mod_codeclient_monkey.php
+++ b/htdocs/core/modules/societe/mod_codeclient_monkey.php
@@ -65,8 +65,10 @@ class mod_codeclient_monkey extends ModeleThirdPartyCode
 
 	/**
 	 * 	Constructor
+	 *
+	 *	@param DoliDB		$db		Database object
 	 */
-	public function __construct()
+	public function __construct($db)
 	{
 		$this->nom = "Monkey";
 		$this->name = "Monkey";

--- a/htdocs/core/modules/societe/modules_societe.class.php
+++ b/htdocs/core/modules/societe/modules_societe.class.php
@@ -64,6 +64,14 @@ abstract class ModeleThirdPartyDoc extends CommonDocGenerator
  */
 abstract class ModeleThirdPartyCode
 {
+
+	/**
+	 * Constructor
+	 *
+	 *  @param DoliDB       $db     Database object
+	 */
+	abstract public function __construct($db);
+
 	/**
 	 * @var string Error code (or message)
 	 */

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -3163,7 +3163,7 @@ class Societe extends CommonObject
 					break;
 				}
 			}
-			$mod = new $module();
+			$mod = new $module($this->db);
 
 			$this->code_client = $mod->getNextValue($objsoc, $type);
 			$this->prefixCustomerIsRequired = $mod->prefixIsRequired;
@@ -3195,7 +3195,7 @@ class Societe extends CommonObject
 					break;
 				}
 			}
-			$mod = new $module();
+			$mod = new $module($this->db);
 
 			$this->code_fournisseur = $mod->getNextValue($objsoc, $type);
 
@@ -3225,7 +3225,7 @@ class Societe extends CommonObject
 				}
 			}
 
-			$mod = new $module();
+			$mod = new $module($this->db);
 
 			dol_syslog(get_class($this)."::codeclient_modifiable code_client=".$this->code_client." module=".$module);
 			if ($mod->code_modifiable_null && !$this->code_client) {
@@ -3265,7 +3265,7 @@ class Societe extends CommonObject
 				}
 			}
 
-			$mod = new $module();
+			$mod = new $module($this->db);
 
 			dol_syslog(get_class($this)."::codefournisseur_modifiable code_founisseur=".$this->code_fournisseur." module=".$module);
 			if ($mod->code_modifiable_null && !$this->code_fournisseur) {
@@ -3311,7 +3311,7 @@ class Societe extends CommonObject
 				}
 			}
 
-			$mod = new $module();
+			$mod = new $module($this->db);
 
 			dol_syslog(get_class($this)."::check_codeclient code_client=".$this->code_client." module=".$module);
 			$result = $mod->verif($this->db, $this->code_client, $this, 0);
@@ -3352,7 +3352,7 @@ class Societe extends CommonObject
 				}
 			}
 
-			$mod = new $module();
+			$mod = new $module($this->db);
 
 			dol_syslog(get_class($this)."::check_codefournisseur code_fournisseur=".$this->code_fournisseur." module=".$module);
 			$result = $mod->verif($this->db, $this->code_fournisseur, $this, 1);


### PR DESCRIPTION
# FIX: Remove  parameter in call to mod_codeclient_* constructor.

None of the mod_codeclient_* constructors has an argument.
Reported by phan as `PhanParamTooMany: Call with 1 arg(s) to \mod_codeclient_leopard::__construct() which only takes 0 arg(s) defined at htdocs/core/modules/societe/mod_codeclient_leopard.php:69`
in all modified files.
One exception in the card.php file because the code has no explicit detail,
but it also uses a mod_codeclient_ constructor.
