### PR TITLE
FIX : dont change status displayed if error during stock movement

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1708,6 +1708,8 @@ class Reception extends CommonObject
 			$this->db->commit();
 			return 1;
 		} else {
+			$this->statut = self::STATUS_VALIDATED;
+			$this->status = self::STATUS_VALIDATED;
 			$this->db->rollback();
 			return -1;
 		}


### PR DESCRIPTION
the displayed status was "closed" even though it was not changed in database when an error occured