### PR TITLE
Fix: SIRET syntax check - Handle the specific case of "La Poste" businesses

### DIFF
--- a/htdocs/core/lib/profid.lib.php
+++ b/htdocs/core/lib/profid.lib.php
@@ -84,6 +84,16 @@ function isValidSiret($siret)
 		return false;
 	}
 
-	// TODO: handle the exception of "La Poste" (356 000 000 #####)
-	return isValidLuhn($siret);
+	if (isValidLuhn($siret)) {
+		return true;
+	} elseif ( (substr($siret, 0, 9) == "356000000") && (array_sum(str_split($siret)) %5 == 0) ) {
+		/**
+		 *  Specific case of "La Poste" businesses (SIRET such as "356 000 000 XXXXX"),
+		 *  for which the rule becomes: the sum of the 14 digits must be a multiple of 5.
+		 *  See https://fr.wikipedia.org/wiki/SIRET for details.
+		 */
+		return true;
+	} else {
+		return false;
+	}
 }


### PR DESCRIPTION
As seen on [https://fr.wikipedia.org/wiki/SIRET](https://fr.wikipedia.org/wiki/Syst%C3%A8me_d%27identification_du_r%C3%A9pertoire_des_%C3%A9tablissements#Exceptions_pour_le_groupe_de_%22La_Poste%22) :

> **Exceptions pour le groupe de "La Poste"**
Cependant il existe une exception : à l'occasion du changement de statut de La Poste en une société anonyme, l'ensemble de ses établissements a été regroupé sous le même SIREN (à 9 chiffres accolés) : 356000000. Le nombre desdits établissements, pour beaucoup des bureaux de poste de quartiers et de petites communes, étant trop important, les SIRET à 14 chiffres (le SIREN 356000000 précédent, suivi des cinq chiffres distinctifs du NIC) utilisent une autre formule de validation et ne sont donc pas valides au sens de la formule de Luhn.
Seul le SIRET 356000000 00048 du siège du groupe La Poste est conforme à la formule de Luhn.
Le contrôle de tous les autres SIRET est spécifique : la somme des 14 chiffres doit être un multiple de 5.