### PR TITLE
fix select_produits when $status_purchase == -1

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2638,10 +2638,10 @@ class Form
 			$sql .= " AND p.finished = ".((int) $finished);
 		} elseif ($finished == 1) {
 			$sql .= " AND p.finished = ".((int) $finished);
-			if ($status >= 0) {
+			if ($status >= 0 && $status_purchase != -1) {
 				$sql .= " AND p.tosell = ".((int) $status);
 			}
-		} elseif ($status >= 0) {
+		} elseif ($status >= 0 && $status_purchase != -1) {
 			$sql .= " AND p.tosell = ".((int) $status);
 		}
 		if ($status_purchase >= 0) {


### PR DESCRIPTION
There is a "race condition" with new parameter introduced into dolibarr 16.0 with select_produits function.

Here is what we can read into documentation:

```
	 *  @param		int		$status_purchase	Purchase status -1=Return all products, 0=Products not on purchase, 1=Products on purchase
```

but in fact if $status_purchase=1 sql request does not returns all products !