### PR TITLE
Qual: Spelling - ' to " to avoid triggering codespell

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -894,7 +894,7 @@ if ($search_billed != '' && $search_billed >= 0) {
 if ($search_status != '') {
 	if ($search_status <= 3 && $search_status >= -1) {	// status from -1 to 3 are real status (other are virtual combination)
 		if ($search_status == 1 && !isModEnabled('expedition')) {
-			$sql .= ' AND c.fk_statut IN (1,2)'; // If module expedition disabled, we include order with status 'sending in process' into 'validated'
+			$sql .= ' AND c.fk_statut IN (1,2)'; // If module expedition disabled, we include order with status "sending in process" into "validated"
 		} else {
 			$sql .= ' AND c.fk_statut = '.((int) $search_status); // draft, validated, in process or canceled
 		}

--- a/htdocs/commande/list_det.php
+++ b/htdocs/commande/list_det.php
@@ -473,7 +473,7 @@ if ($search_billed != '' && $search_billed >= 0) {
 if ($search_status != '') {
 	if ($search_status <= 3 && $search_status >= -1) {	// status from -1 to 3 are real status (other are virtual combination)
 		if ($search_status == 1 && !isModEnabled('expedition')) {
-			$sql .= ' AND c.fk_statut IN (1,2)'; // If module expedition disabled, we include order with status 'sending in process' into 'validated'
+			$sql .= ' AND c.fk_statut IN (1,2)'; // If module expedition disabled, we include order with status "sending in process" into "validated"
 		} else {
 			$sql .= ' AND c.fk_statut = '.((int) $search_status); // brouillon, validee, en cours, annulee
 		}


### PR DESCRIPTION
# Qual: Spelling - ' to " to avoid triggering codespell
    
The single tick in `process'` is recognized as port of the word,
to changing it to a double quote (`"`) helps codespell.

As mentioned in #27392
