### PR TITLE
Fix: pre-commit: Skip branch check in ci (+used sed in codespell exceptions generation)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run pre-commit hooks
         env:
           # SKIP is used by pre-commit to not execute certain hooks
-          SKIP: php-cs,php-cbf,trailing-whitespace,end-of-file-fixer
+          SKIP: no-commit-to-branch,php-cs,php-cbf,trailing-whitespace,end-of-file-fixer
         run: |
           set -o pipefail
           pre-commit gc

--- a/dev/tools/codespell/addCodespellIgnores.sh
+++ b/dev/tools/codespell/addCodespellIgnores.sh
@@ -40,7 +40,7 @@ fi
 #   - Run codespell;
 #   - For each line, create a grep command to find the lines;
 #   - Execute that command by evaluation
-codespell . | perl -p -e 's@^(.*?):\d+:\s(\S+)\s.*@grep -P '"'"'\\b$2\\b'"'"' "$1" >> '"${codespell_ignore_file}"'@;' | \
+codespell . | sed -n -E 's@^([^:]+):[[:digit:]]+:[[:space:]](\S+)[[:space:]].*@grep -P '\''\\b\2\\b'\'' "\1" >> '"${codespell_ignore_file}"'@p' | \
 	while read -r line ; do eval "$line" ; done
 
 # Finally, sort and remove duplicates to make merges easier.


### PR DESCRIPTION
# Qual: Fix checking commit branch.

I forgot to exclude branch commit checking for ci - done here.

This also updates the script to generate the exclusion to use 'sed', more commonly installe.