### PR TITLE
end fix #10417 : custom payment number for supplier invoices

### DIFF
--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -973,7 +973,7 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 
 	if (!is_object($objsoc)) {
 		$valueforccc = $objsoc;
-	} elseif ($table == "commande_fournisseur" || $table == "facture_fourn") {
+	} elseif ($table == "commande_fournisseur" || $table == "facture_fourn" || $table == "paiementfourn") {
 		$valueforccc = dol_string_unaccent($objsoc->code_fournisseur);
 	} else {
 		$valueforccc = dol_string_unaccent($objsoc->code_client);


### PR DESCRIPTION
# FIX #10417 

One little thing was missing on #10417 fix ... with that commit you can now use {cccc} into payment numbers