### PR TITLE
QUAL Send API response data before completing post-processing tasks

### DIFF
--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -411,19 +411,19 @@ Luracast\Restler\Defaults::$returnResponse = $usecompression;
 
 // Call API (we suppose we found it).
 // The handle will use the file api/temp/routes.php to get data to run the API. If the file exists and the entry for API is not found, it will return 404.
-$result = $api->r->handle();
+$responsedata = $api->r->handle();
 
 if (Luracast\Restler\Defaults::$returnResponse) {
 	// We try to compress the data received data
 	if (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'br') !== false && function_exists('brotli_compress') && defined('BROTLI_TEXT')) {
 		header('Content-Encoding: br');
-		$result = brotli_compress($result, 11, constant('BROTLI_TEXT'));
+		$result = brotli_compress($responsedata, 11, constant('BROTLI_TEXT'));
 	} elseif (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'bz') !== false && function_exists('bzcompress')) {
 		header('Content-Encoding: bz');
-		$result = bzcompress($result, 9);
+		$result = bzcompress($responsedata, 9);
 	} elseif (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== false && function_exists('gzencode')) {
 		header('Content-Encoding: gzip');
-		$result = gzencode($result, 9);
+		$result = gzencode($responsedata, 9);
 	} else {
 		header('Content-Encoding: text/html');
 		print "No compression method found. Try to disable compression by adding API_DISABLE_COMPRESSION=1";
@@ -432,6 +432,24 @@ if (Luracast\Restler\Defaults::$returnResponse) {
 
 	// Restler did not output data yet, we return it now
 	echo $result;
+}
+
+// Now flush output buffers so that response data is sent to request client
+ob_end_flush();
+ob_flush();
+flush();
+
+// If you're using PHP-FPM, this function will allow you to send the response and then continue processing
+if (function_exists('fastcgi_finish_request')) {
+	fastcgi_finish_request();
+}
+
+// Check the existence of a terminate callback to call for the API method that was executed
+$o = &$api->r->apiMethodInfo;
+$terminateCall = '_terminate_' . $o->methodName . '_' . $api->r->responseFormat->getExtension();
+if (method_exists($o->className, $terminateCall)) {
+	// Call the terminate callback with response data as parameter
+	call_user_func(array(Scope::get($o->className), $terminateCall), $responsedata);
 }
 
 //session_destroy();

--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -444,12 +444,7 @@ if (function_exists('fastcgi_finish_request')) {
 	fastcgi_finish_request();
 }
 
-// Check the existence of a terminate callback to call for the API method that was executed
-$o = &$api->r->apiMethodInfo;
-$terminateCall = '_terminate_' . $o->methodName . '_' . $api->r->responseFormat->getExtension();
-if (method_exists($o->className, $terminateCall)) {
-	// Call the terminate callback with response data as parameter
-	call_user_func(array(Scope::get($o->className), $terminateCall), $responsedata);
-}
+// Call API termination method
+$api->r->terminate();
 
 //session_destroy();

--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -447,7 +447,7 @@ require_once DOL_DOCUMENT_ROOT.'/includes/restler/framework/Luracast/Restler/Sco
 $apiMethodInfo = &$api->r->apiMethodInfo;
 $terminateCall = '_terminate_' . $apiMethodInfo->methodName . '_' . $api->r->responseFormat->getExtension();
 if (method_exists($apiMethodInfo->className, $terminateCall)) {
-  call_user_func(array(Scope::get($apiMethodInfo->className), $terminateCall), $responsedata);
+	call_user_func(array(Scope::get($apiMethodInfo->className), $terminateCall), $responsedata);
 }
 
 //session_destroy();

--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -436,8 +436,6 @@ if (Luracast\Restler\Defaults::$returnResponse) {
 
 // Now flush output buffers so that response data is sent to request client
 ob_end_flush();
-ob_flush();
-flush();
 
 // If you're using PHP-FPM, this function will allow you to send the response and then continue processing
 if (function_exists('fastcgi_finish_request')) {
@@ -445,6 +443,11 @@ if (function_exists('fastcgi_finish_request')) {
 }
 
 // Call API termination method
-$api->r->terminate();
+require_once DOL_DOCUMENT_ROOT.'/includes/restler/framework/Luracast/Restler/Scope.php';
+$apiMethodInfo = &$api->r->apiMethodInfo;
+$terminateCall = '_terminate_' . $apiMethodInfo->methodName . '_' . $api->r->responseFormat->getExtension();
+if (method_exists($apiMethodInfo->className, $terminateCall)) {
+  call_user_func(array(Scope::get($apiMethodInfo->className), $terminateCall), $responsedata);
+}
 
 //session_destroy();

--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -443,11 +443,10 @@ if (function_exists('fastcgi_finish_request')) {
 }
 
 // Call API termination method
-require_once DOL_DOCUMENT_ROOT.'/includes/restler/framework/Luracast/Restler/Scope.php';
 $apiMethodInfo = &$api->r->apiMethodInfo;
 $terminateCall = '_terminate_' . $apiMethodInfo->methodName . '_' . $api->r->responseFormat->getExtension();
 if (method_exists($apiMethodInfo->className, $terminateCall)) {
-	call_user_func(array(Scope::get($apiMethodInfo->className), $terminateCall), $responsedata);
+	call_user_func(array(Luracast\Restler\Scope::get($apiMethodInfo->className), $terminateCall), $responsedata);
 }
 
 //session_destroy();

--- a/htdocs/includes/restler/framework/Luracast/Restler/Restler.php
+++ b/htdocs/includes/restler/framework/Luracast/Restler/Restler.php
@@ -1700,7 +1700,7 @@ class Restler extends EventDispatcher
         $o = & $this->apiMethodInfo;
         $terminateCall = '_terminate_' . $o->methodName . '_' .
             $this->responseFormat->getExtension();
-        if (method_exists($o->className, $postCall)) {
+        if (method_exists($o->className, $terminateCall)) {
             $this->dispatch('terminateCall');
             $this->responseData = call_user_func(array(
                 Scope::get($o->className),

--- a/htdocs/includes/restler/framework/Luracast/Restler/Restler.php
+++ b/htdocs/includes/restler/framework/Luracast/Restler/Restler.php
@@ -1686,27 +1686,4 @@ class Restler extends EventDispatcher
             ), $this->responseData);
         }
     }
-	
-    /**
-     * terminate call
-     *
-     * Call _terminate_{methodName}_{extension} if exists with the composed and
-     * serialized (applying the reponse format) response data
-     *
-     * @example _terminate_post_json
-     */
-    public function terminate()
-    {
-        $o = & $this->apiMethodInfo;
-        $terminateCall = '_terminate_' . $o->methodName . '_' .
-            $this->responseFormat->getExtension();
-        if (method_exists($o->className, $terminateCall)) {
-            $this->dispatch('terminateCall');
-            $this->responseData = call_user_func(array(
-                Scope::get($o->className),
-                $terminateCall
-            ), $this->responseData);
-        }
-    }
-
 }

--- a/htdocs/includes/restler/framework/Luracast/Restler/Restler.php
+++ b/htdocs/includes/restler/framework/Luracast/Restler/Restler.php
@@ -1686,4 +1686,27 @@ class Restler extends EventDispatcher
             ), $this->responseData);
         }
     }
+	
+    /**
+     * terminate call
+     *
+     * Call _terminate_{methodName}_{extension} if exists with the composed and
+     * serialized (applying the reponse format) response data
+     *
+     * @example _terminate_post_json
+     */
+    public function terminate()
+    {
+        $o = & $this->apiMethodInfo;
+        $terminateCall = '_terminate_' . $o->methodName . '_' .
+            $this->responseFormat->getExtension();
+        if (method_exists($o->className, $postCall)) {
+            $this->dispatch('terminateCall');
+            $this->responseData = call_user_func(array(
+                Scope::get($o->className),
+                $terminateCall
+            ), $this->responseData);
+        }
+    }
+
 }


### PR DESCRIPTION
This commit allows Rester to immediately send response data back to the client before completing some time consuming post-processing tasks (such as sending emails) in a termination callback if defined.

Termination callback should be created into the same class as the API method it terminates. Callback name must match the following format : `"_terminate_" + <API_METHOD_NAME> + "_" + <API_METHOD_RESPONSE_FORMAT_EXTENSION>`.

For instance, termination callback for orders _post_ method defined in `htdocs/commande/class/api_orders.class.php` must be named __terminate_post_json_.