### PR TITLE
FIX Add tms field into llx_bom_bomline table

### DIFF
--- a/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
+++ b/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
@@ -203,3 +203,5 @@ ALTER TABLE llx_expensereport DROP INDEX idx_expensereport_fk_refuse, ADD INDEX 
 INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle) VALUES (1,'66','Société publique locale');
 
 ALTER TABLE llx_prelevement_lignes ADD COLUMN tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+ALTER TABLE llx_bom_bomline ADD COLUMN tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;

--- a/htdocs/install/mysql/tables/llx_bom_bomline.sql
+++ b/htdocs/install/mysql/tables/llx_bom_bomline.sql
@@ -19,6 +19,7 @@ CREATE TABLE llx_bom_bomline(
 	fk_bom integer NOT NULL, 
 	fk_product integer NOT NULL,
 	fk_bom_child integer NULL,
+	tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, 
 	description text, 
 	import_key varchar(14), 
 	qty double(24,8) NOT NULL, 


### PR DESCRIPTION
Trying to update a bom line fails with the following error :

<code>
 ERROR: 42703: record 'new' has no field 'tms' CONTEXT: PL/pgSQL assignment 'NEW.tms = now()' PL/pgSQL function update_modified_column_tms() line 1 at assignment LOCATION: plpgsql_exec_get_datum_type_info, pl_exec.c:5604
</code>

This pull request adds the missing _tms_ field into the _llx_bom_bomline_ table schema definition, and sets the corresponding ALTER TABLE query so that migration changes the _llx_bom_bomline_ schema.