### PR TITLE
Fix : in suppier order dispatch, if qty cleaned, bad error + clean code

### DIFF
--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -289,7 +289,7 @@ if ($action == 'dispatch' && $permissiontoreceive) {
 								$sql .= ", price=".price2num($pu, 'MU')."*quantity";
 								$sql .= ", remise_percent = ".((float) $dto);
 								$sql .= " WHERE fk_soc=".((int) $object->socid);
-								$sql .= " AND fk_product=".$productId;
+								$sql .= " AND fk_product=".((int) $productId);
 
 								$resql = $db->query($sql);
 							}
@@ -359,7 +359,7 @@ if ($action == 'dispatch' && $permissiontoreceive) {
 								$sql .= ", price = ".price2num($pu, 'MU', 2)." * quantity";
 								$sql .= ", remise_percent = ".price2num((empty($dto) ? 0 : $dto), 3, 2)."'";
 								$sql .= " WHERE fk_soc = ".((int) $object->socid);
-								$sql .= " AND fk_product=".($productId);
+								$sql .= " AND fk_product=".((int) $productId);
 
 								$resql = $db->query($sql);
 							}

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -240,12 +240,12 @@ if ($action == 'dispatch' && $permissiontoreceive) {
 			// $numline=$reg[2] + 1; // line of product
 			$numline = $pos;
 			$productId = GETPOSTINT("product_".$reg[1].'_'.$reg[2]);
-			$qty = (float)GETPOST("qty_".$reg[1].'_'.$reg[2], 'int');
+			$qty = (float) GETPOST("qty_".$reg[1].'_'.$reg[2], 'int');
 			$warehouseId = GETPOSTINT("entrepot_".$reg[1].'_'.$reg[2]);
 			if (empty($warehouseId)) {
 				$warehouseId = $fk_default_warehouse;
 			}
-			$pu = (float)GETPOST("pu_".$reg[1].'_'.$reg[2], 'int'); // This is unit price including discount
+			$pu = (float) GETPOST("pu_".$reg[1].'_'.$reg[2], 'int'); // This is unit price including discount
 			$fk_commandefourndet = GETPOSTINT("fk_commandefourndet_".$reg[1].'_'.$reg[2]);
 
 			if (getDolGlobalString('SUPPLIER_ORDER_CAN_UPDATE_BUYINGPRICE_DURING_RECEIPT')) {
@@ -305,10 +305,10 @@ if ($action == 'dispatch' && $permissiontoreceive) {
 			// eat-by date dispatch
 			$numline = $pos;
 			$productId = GETPOSTINT("product_batch_".$reg[1].'_'.$reg[2]);
-			$qty = (float)GETPOST("qty_".$reg[1].'_'.$reg[2], 'int');
+			$qty = (float) GETPOST("qty_".$reg[1].'_'.$reg[2], 'int');
 			$warehouseId = GETPOSTINT("entrepot_".$reg[1].'_'.$reg[2]);
 			//if (empty($warehouseId)) $warehouseId = $fk_default_warehouse; // to be activated in batch mode too ?
-			$pu = (float)GETPOST("pu_".$reg[1].'_'.$reg[2], 'int'); // This is unit price including discount
+			$pu = (float) GETPOST("pu_".$reg[1].'_'.$reg[2], 'int'); // This is unit price including discount
 			$fk_commandefourndet = GETPOSTINT("fk_commandefourndet_".$reg[1].'_'.$reg[2]);
 
 			$lot = trim(GETPOST('lot_number_'.$reg[1].'_'.$reg[2], 'alpha'));


### PR DESCRIPTION
# FIX in supplier order dispatch, if qty cleaned, bad error 

In supplier Order Dispatch, if you click on the rubber to clear qty and then you submit, you get a bad error :

> Incorrect double value: '' for column `erp-rec`.`llx_commande_fournisseur_dispatch`.`qty` at row 1

![cf screeshot](https://github.com/Dolibarr/dolibarr/assets/5389628/1ce94f8f-99a1-4681-b994-d0c79a101bed)

Looking at the code, the qty are bad tested ... 

and It appears that all the GETPOST wasn't cleanly used, I tried to correct them ...

