### PR TITLE
stock transfert not stable : return to experimental

### DIFF
--- a/htdocs/core/modules/modStockTransfer.class.php
+++ b/htdocs/core/modules/modStockTransfer.class.php
@@ -63,7 +63,7 @@ class modStockTransfer extends DolibarrModules
 		// Used only if file README.md and README-LL.md not found.
 		$this->descriptionlong = "Advanced management of stock transfer orders with generation of stock transfer sheets";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-		$this->version = 'dolibarr';
+		$this->version = 'experimental';
 		// Url to the file with your last numberversion of this module
 		//$this->url_last_version = 'http://www.example.com/versionmodule.txt';
 


### PR DESCRIPTION
I detected quite a few bugs, absence of token, error in class definition on certain page... I don't understand how we could declare this module stable overnight without having a minimum of testing it.