### PR TITLE
Fix: pre-commit & codespell configuration.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
       - id: trailing-whitespace
         exclude_types: [markdown]
       - id: end-of-file-fixer
-        types: [yaml]
       - id: check-merge-conflict
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
@@ -77,7 +76,7 @@ repos:
           - css
           - yaml
 
-  # Check format of yam files
+  # Check format of yaml files
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.32.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,26 @@ requires = ["setuptools>=61.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.codespell]
+# The configuration must be kept here to ensure that
+# `codespell` can be run as a standalone program from the CLI
+# with the appropriate default options.
+
 skip = "*/langs/*,*/build/exe/*,**.log,*.pdf,*dev/resources/*,*.phar,*.z,*.gz,*.sql,*htdocs/includes/*,*/textiso.txt,*.js,*README-*,*build/rpm/*spec,*build/pad/*ml,*htdocs/includes/phpoffice/*,*htdocs/includes/tecnickcom/*,*dev/initdemo/removeconfdemo.sh,*dev/tools/codespell/*,*pyproject.toml,*build/exe/*,*fontawe*,*htdocs/theme/*/flags-sprite.inc.php,*dev/setup/codetemplates/codetemplates.xml,*/php.ini,*/html_cerfafr.*,*/lessc.class.php,*.asciidoc,*.xml,*opensurvey/css/style.css"
 
 quiet-level=2
 ignore-regex = '\\[fnrstv]'
 builtin = "clear,rare,informal,usage,code,names"
-#D = "-"
-#dictionary = "dev/tools/codespell/codespell-dict.txt"
+
+ignore-words = "dev/tools/codespell/codespell-ignore.txt"
+exclude-file = "dev/tools/codespell/codespell-lines-ignore.txt"
+uri-ignore-words-list="ned"
+
+# For future reference: it is not currently possible to specify
+# the standard dictionnary and the custom dictionnary in the configuration
+# file
+#  D = "-"
+#  dictionary = "dev/tools/codespell/codespell-dict.txt"
+
 
 [tool.setuptools]
 include-package-data = false


### PR DESCRIPTION
# Fix: pre-commit & codespell configuration.

When codespell is run from the CLI it gets its configuration from pyproject.toml or .codespellrc .
`pyproject.toml` was used because other tools also use that while .codespellrc is specific.

A typo was fixed in the pre-commit configuration.

The end of file fixer was limited to yaml files, but that was mainly to fix the yamllint errors that were reported in ci. This hook can be applied on the files this normally applies to without requiring it (not in ci, only local).


ℹ️  Spelling errors are in files not related to this PR.