### PR TITLE
fix: phpstan

### DIFF
--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -307,8 +307,8 @@ if (empty($reshook)) {
 			$object->address     = trim(GETPOST("address", 'alphanohtml'));
 			$object->zip         = trim(GETPOST("zipcode", 'alphanohtml'));
 			$object->town        = trim(GETPOST("town", 'alphanohtml'));
-			$object->state_id    = GETPOST("state_id", 'int');
-			$object->country_id  = GETPOST("country_id", 'int');
+			$object->state_id    = GETPOSTINT("state_id");
+			$object->country_id  = GETPOSTINT("country_id");
 
 			$object->phone       = trim(GETPOST("phone", 'alpha'));
 			$object->phone_perso = trim(GETPOST("phone_perso", 'alpha'));
@@ -334,9 +334,9 @@ if (empty($reshook)) {
 			}
 
 			// Get status and public property
-			$object->statut = GETPOST("statut", 'alpha');
-			$object->status = GETPOST("statut", 'alpha');
-			$object->public = GETPOST("public", 'alpha');
+			$object->statut = GETPOSTINT("statut");
+			$object->status = GETPOSTINT("statut");
+			$object->public = GETPOSTINT("public");
 
 			// Fill array 'array_options' with data from add form
 			$ret = $extrafields->setOptionalsFromPost(null, $object, '@GETPOSTISSET');


### PR DESCRIPTION
htdocs/adherents/card.php	310	Property CommonObject::$state_id (int) does not accept array|string. htdocs/adherents/card.php	311	Property CommonObject::$country_id (int) does not accept array|string. htdocs/adherents/card.php	337	Property CommonObject::$statut (int) does not accept array|string. htdocs/adherents/card.php	338	Property CommonObject::$status (int) does not accept array|string. htdocs/adherents/card.php	339	Property Adherent::$public (int) does not accept array|string.