### PR TITLE
fix: phpstan

### DIFF
--- a/htdocs/ecm/dir_card.php
+++ b/htdocs/ecm/dir_card.php
@@ -204,9 +204,9 @@ if ($action == 'update' && !GETPOST('cancel', 'alpha') && $permissiontoadd) {
 
 		// Fetch was already done
 		$ecmdir->label = dol_sanitizeFileName(GETPOST("label"));
-		$fk_parent = GETPOST("catParent", 'int');
-		if ($fk_parent == "-1") {
-			$ecmdir->fk_parent = "0";
+		$fk_parent = GETPOSTINT("catParent");
+		if ($fk_parent == -1) {
+			$ecmdir->fk_parent = 0;
 		} else {
 			$ecmdir->fk_parent = $fk_parent;
 		}


### PR DESCRIPTION
htdocs/ecm/dir_card.php	209	Property EcmDirectory::$fk_parent (int) does not accept string.
htdocs/ecm/dir_card.php	211	Property EcmDirectory::$fk_parent (int) does not accept array|string.