### PR TITLE
fix: phpstan

### DIFF
--- a/htdocs/core/lib/memory.lib.php
+++ b/htdocs/core/lib/memory.lib.php
@@ -287,7 +287,7 @@ function dol_setshmop($memoryid, $data, $expire)
  * 	Read a memory area shared by all users, all sessions on server
  *
  *  @param	string	$memoryid		Memory id of shared area ('main', 'agenda', ...)
- * 	@return	int						Return integer <0 if KO, data if OK, Null if no cache enabled or not found
+ * 	@return	int|null				Return integer <0 if KO, data if OK, null if no cache enabled or not found
  */
 function dol_getshmop($memoryid)
 {


### PR DESCRIPTION
htdocs/core/lib/memory.lib.php	299	Function dol_getshmop() should return int but returns null. htdocs/core/lib/memory.lib.php	303	Function dol_getshmop() should return int but returns null. htdocs/core/lib/memory.lib.php	317	Function dol_getshmop() should return int but returns null.