### PR TITLE
fix: phpstan

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -430,7 +430,7 @@ function pdfBuildThirdpartyName($thirdparty, Translate $outputlangs, $includeali
  * 		@param	int			          $usecontact		    Use contact instead of company
  * 		@param	string  	          $mode				    Address type ('source', 'target', 'targetwithdetails', 'targetwithdetails_xxx': target but include also phone/fax/email/url)
  *      @param  Object                $object               Object we want to build document for
- * 		@return	string					    		        String with full address
+ * 		@return	string|int				    		        String with full address or -1 if KO
  */
 function pdf_build_address($outputlangs, $sourcecompany, $targetcompany = '', $targetcontact = '', $usecontact = 0, $mode = 'source', $object = null)
 {


### PR DESCRIPTION
htdocs/core/lib/pdf.lib.php	440	Function pdf_build_address() should return string but returns int.
htdocs/core/lib/pdf.lib.php	443	Function pdf_build_address() should return string but returns int.