### PR TITLE
Qual: Cleanup method to ignore misspelled key

### DIFF
--- a/dev/tools/codespell/codespell-lines-ignore.txt
+++ b/dev/tools/codespell/codespell-lines-ignore.txt
@@ -1,4 +1,5 @@
-
+								$objMod->dictionaries = $objMod->{"dictionnaries"}; // For backward compatibility
+							if (empty($objMod->dictionaries) && !empty($objMod->{"dictionnaries"})) {
 							print '<a href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;id_entrepot='.$entrepotstatic->id.'&amp;action=transfert&amp;pdluoid='.$pdluo->id.'">';
 						$reponsesadd = str_split($obj->reponses);
 						$sql .= " SET reponses = '".$db->escape($reponsesadd)."'";

--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -1379,9 +1379,8 @@ function complete_dictionary_with_modules(&$taborder, &$tabname, &$tablib, &$tab
 
 							// phpcs:disable
 							// Complete the arrays &$tabname,&$tablib,&$tabsql,&$tabsqlsort,&$tabfield,&$tabfieldvalue,&$tabfieldinsert,&$tabrowid,&$tabcond
-							// Note: "diction"."naries" to prevent codespell from detecting a spelling error. 
-							if (empty($objMod->dictionaries) && !empty($objMod->{"dicton"."naries"})) {
-								$objMod->dictionaries = $objMod->{"diction"."naries"}; // For backward compatibility
+							if (empty($objMod->dictionaries) && !empty($objMod->{"dictionnaries"})) {
+								$objMod->dictionaries = $objMod->{"dictionnaries"}; // For backward compatibility
 							}
 							// phpcs:enable
 


### PR DESCRIPTION
# Qual: Cleanup method to ignore misspelled key

With the method to ignore lines, the code can be cleaned up to ignore the spelling issue.