### PR TITLE
qual: phpstan

### DIFF
--- a/htdocs/admin/defaultvalues.php
+++ b/htdocs/admin/defaultvalues.php
@@ -40,7 +40,7 @@ if (!$user->admin) {
 	accessforbidden();
 }
 
-$id = GETPOST('rowid', 'int');
+$id = GETPOSTINT('rowid');
 $action = GETPOST('action', 'aZ09');
 $optioncss = GETPOST('optionscss', 'alphanohtml');
 


### PR DESCRIPTION
htdocs/admin/defaultvalues.php	163	Property CommonObject::$id (int) does not accept array|string. htdocs/admin/defaultvalues.php	186	Property CommonObject::$id (int) does not accept array|string.