### PR TITLE
feat: knowledgemanagement change answer column to longtext

### DIFF
--- a/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
+++ b/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
@@ -205,4 +205,6 @@ ALTER TABLE llx_c_tva ADD COLUMN type_vat smallint NOT NULL DEFAULT 0 AFTER fk_p
 
 ALTER TABLE llx_categorie ADD COLUMN position integer DEFAULT 0 AFTER color;
 
-ALTER TABLE llx_product DROP COLUMN onportal; 
+ALTER TABLE llx_product DROP COLUMN onportal;
+
+ALTER TABLE llx_knowledgemanagement_knowledgerecord MODIFY COLUMN answer longtext;

--- a/htdocs/install/mysql/tables/llx_knowledgemanagement_knowledgerecord-knowledgemanagement.sql
+++ b/htdocs/install/mysql/tables/llx_knowledgemanagement_knowledgerecord-knowledgemanagement.sql
@@ -29,7 +29,7 @@ CREATE TABLE llx_knowledgemanagement_knowledgerecord(
 	import_key varchar(14), 
 	model_pdf varchar(255), 
 	question text NOT NULL, 
-	answer text,
+	answer longtext,
 	url varchar(255),
 	fk_ticket integer,
 	fk_c_ticket_category integer,


### PR DESCRIPTION
As from 18.0 dolEditor accept media in dolibarr/htdocs/knowledgemanagement/knowledgerecord_card.php as link and copy past image transform them in base64, text type column is not enough, it should be longtext