### PR TITLE
qual: phpstan

### DIFF
--- a/htdocs/admin/expensereport_ik.php
+++ b/htdocs/admin/expensereport_ik.php
@@ -39,10 +39,10 @@ $error = 0;
 $action = GETPOST('action', 'aZ09');
 
 $id = GETPOST('id', 'int');
-$ikoffset = GETPOST('ikoffset', 'int');
-$coef = GETPOST('coef', 'int');
-$fk_c_exp_tax_cat = GETPOST('fk_c_exp_tax_cat');
-$fk_range = GETPOST('fk_range', 'int');
+$ikoffset = (float) GETPOST('ikoffset', 'int');
+$coef = (float) GETPOST('coef', 'int');
+$fk_c_exp_tax_cat = GETPOSTINT('fk_c_exp_tax_cat');
+$fk_range = GETPOSTINT('fk_range');
 
 $expIk = new ExpenseReportIk($db);
 


### PR DESCRIPTION
htdocs/admin/expensereport_ik.php	66	Property ExpenseReportIk::$coef (float) does not accept array|string. htdocs/admin/expensereport_ik.php	67	Property ExpenseReportIk::$ikoffset (float) does not accept array|string. htdocs/admin/expensereport_ik.php	68	Property ExpenseReportIk::$fk_c_exp_tax_cat (int) does not accept array|string. htdocs/admin/expensereport_ik.php	69	Property ExpenseReportIk::$fk_range (int) does not accept array|string.

@eldy: I'm not sure how to best handle a float returned by `GETPOST()`, as `GETPOST($val, 'int')` let one think it returns an integer, while instead it checks for any numeric value ; as it uses `sanitizeVal()` which uses `is_numeric()`. So it returns a string which can be an integer, float or hexa.

So far I've used `(float) GETPOST($val, 'int')` but it's a bit misleading as it would let one think we're casting an integer to a float.

Is there a need to create a `GETPOSTFLOAT()` function returning `(float)  GETPOST($val, 'int', ...)`? or even add a clearer param_name to call `GETPOST($val, 'num')` instead of `GETPOST($val, 'int')`?