### PR TITLE
qual:phpstan

### DIFF
--- a/htdocs/cron/list.php
+++ b/htdocs/cron/list.php
@@ -40,7 +40,7 @@ $confirm = GETPOST('confirm', 'alpha');
 $toselect   = GETPOST('toselect', 'array'); // Array of ids of elements selected into a list
 $contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'cronjoblist'; // To manage different context of search
 
-$id = GETPOST('id', 'int');
+$id = GETPOSTINT('id');
 
 $limit = GETPOST('limit', 'int') ? GETPOST('limit', 'int') : $conf->liste_limit;
 $sortfield = GETPOST('sortfield', 'aZ09comma');


### PR DESCRIPTION
htdocs/cron/list.php	143	Property CommonObject::$id (int) does not accept array|string.