### PR TITLE
Fix PHP undefined variable warning

### DIFF
--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -1330,7 +1330,7 @@ class Cronjob extends CommonObject
 					$error++;
 				} else {
 					dol_syslog(get_class($this)."::run_jobs END");
-					$this->lastoutput = dol_substr((empty($object->output) ? "" : $object->output."\n").$errmsg, 0, $this::MAXIMUM_LENGTH_FOR_LASTOUTPUT_FIELD, 'UTF-8', 1);
+					$this->lastoutput = dol_substr((empty($object->output) ? "" : $object->output."\n"), 0, $this::MAXIMUM_LENGTH_FOR_LASTOUTPUT_FIELD, 'UTF-8', 1);
 					$this->lastresult = var_export($result, true);
 					$retval = $this->lastresult;
 				}


### PR DESCRIPTION
# Fix Undefined variable warning
Fixes `PHP Warning:  Undefined variable $errmsg in /var/www/dolibarr/htdocs/cron/class/cronjob.class.php on line 1322`.