### PR TITLE
qual: phpstan

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -980,7 +980,7 @@ class Translate
 	 * 		@param	string	$fieldlabel		Field for label. This value must always be a hardcoded string and not a value coming from user input.
 	 *      @param	string	$keyforselect	Use another value than the translation key for the where into select
 	 *      @param  int		$filteronentity	Use a filter on entity
-	 *      @return string					Label in UTF8 (but without entities)
+	 *      @return string|int				Label in UTF8 (but without entities) or -1 if error
 	 *      @see dol_getIdFromCode()
 	 */
 	public function getLabelFromKey($db, $key, $tablename, $fieldkey, $fieldlabel, $keyforselect = '', $filteronentity = 0)


### PR DESCRIPTION
htdocs/core/class/translate.class.php	995	Method Translate::getLabelFromKey() should return string but returns int. htdocs/core/class/translate.class.php	1032	Method Translate::getLabelFromKey() should return string but returns int.