### PR TITLE
Qual: codespell: Limit adding exceptions to git files only

### DIFF
--- a/dev/tools/codespell/addCodespellIgnores.sh
+++ b/dev/tools/codespell/addCodespellIgnores.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+
 #
 # Script to add codespell exceptions to the ignores lines file.
 #
@@ -18,7 +20,7 @@
 #
 # :warning:
 #
-# This script only works properly if codespell is install for your CLI.
+# This script only works properly if codespell is installed for your CLI.
 # As the configuration is in pyproject.toml, you also need tomli.
 #
 # ```shell
@@ -50,11 +52,17 @@ fi
 [ -r "${codespell_ignore_file}" ] || { echo "${codespell_ignore_file} not found" ; exit 1 ; }
 # Then:
 #   - Run codespell;
+#   - Identify files that have fixes;
+#   - Limit to files under git control;
+#   - Run codespell on selected files;
 #   - For each line, create a grep command to find the lines;
 #   - Execute that command by evaluation
-codespell . | sed -n -E 's@^([^:]+):[[:digit:]]+:[[:space:]](\S+)[[:space:]].*@grep -P '\''\\b\2\\b'\'' "\1" >> '"${codespell_ignore_file}"'@p' | \
-	while read -r line ; do eval "$line" ; done
+codespell . \
+	| sed -n -E 's@^([^:]+)@\1@p' \
+	| xargs -r git ls-files -- \
+	| xargs -r codespell -- \
+	| sed -n -E 's@^([^:]+):[[:digit:]]+:[[:space:]](\S+)[[:space:]].*@grep -P '\''\\b\2\\b'\'' -- "\1" >> '"${codespell_ignore_file}"'@p' \
+	| while read -r line ; do eval "$line" ; done
 
 # Finally, sort and remove duplicates to make merges easier.
 sort -u -o "${codespell_ignore_file}"{,}
-

--- a/dev/tools/codespell/codespell-dict.txt
+++ b/dev/tools/codespell/codespell-dict.txt
@@ -1,9 +1,10 @@
+# Please add in alphabetical order->(`sort -u` like).
+EPR->ERP
+alpahnohtml->alphanohtml
+choosed->chosen
 dolibar->dolibarr
 dollibar->dolibarr
 dollibarr->dolibarr
-not de passe->password
 mot de passe->password
-choosed->chosen
+not de passe->password
 tableau de bord->state board
-#DoliDB->DoliDB
-alpahnohtml->alphanohtml


### PR DESCRIPTION
# Qual: codespell: Limit adding exceptions to git files only

addCodespellIgnores.sh was applied on all files, now limit to git controlled files only.

I also added a rule for EPR->ERP, misspelled in another script, fix proposed in #27702 .