### PR TITLE
Qual: Store phpstan cache only if not loaded or successful run

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -44,7 +44,8 @@ jobs:
 
       # Restore old cache
       - name: Restore phpstan cache
-        uses: actions/cache/restore@v3
+        id: cache
+        uses: actions/cache/restore@v4
         with:
           path: ./.github/tmp
           key: "phpstan-cache-${{ matrix.php-version }}-${{ github.run_id }}"
@@ -55,13 +56,14 @@ jobs:
 
       # Run PHPStan
       - name: Run PHPStan
+        id: phpstan
         run: phpstan -vvv analyse --error-format=checkstyle --memory-limit 4G -a build/phpstan/bootstrap_action.php -c phpstan.neon | cs2pr --graceful-warnings
         # continue-on-error: true
 
       # Save cache
       - name: "Save phpstan cache"
-        uses: actions/cache/save@v3
-        if: always()
+        uses: actions/cache/save@v4
+        if: ${{ success() || ( ! cancelled() && steps.cache.outputs.cache-hit != 'true' ) }}
         with:
           path: ./.github/tmp
           key: "phpstan-cache-${{ matrix.php-version }}-${{ github.run_id }}"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install pre-commit regex
       # Restore previous cache of precommit
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: ~/.cache/pre-commit/
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -54,8 +54,8 @@ jobs:
           notices-as-warnings: true  # optional
           prepend-filename: true  # optional
       # Save the precommit cache
-      - uses: actions/cache/save@v3
-        if: ${{ always() }}
+      - uses: actions/cache/save@v4
+        if: ${{ ! cancelled() }}
         with:
           path: ~/.cache/pre-commit/
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml')
@@ -63,7 +63,7 @@ jobs:
       # Upload result log files of precommit into the Artifact shared store
       - name: Provide log as artifact
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: ${{ ! cancelled() }}
         with:
           name: precommit-logs
           path: |


### PR DESCRIPTION
The PHPStan steps run a long time for the latest runs and I suspect that this may be because of a bad cache, possibly includeing:
```
Result cache was not saved because of non-ignorable exception: Syntax error, unexpected } on line 378
```

This change should only save the cache if the run was successful or if no cache was loaded.  The possibly preserves a cache that still reduces the run time.

For instance, the following got an empty cache, saved at 2024-01-19T21:28:22.18Z.
- https://github.com/Dolibarr/dolibarr/actions/runs/7589384926 That was an aborted run:
- https://github.com/Dolibarr/dolibarr/actions/runs/7589372703/job/20673878193

So I added `cancelled()` to avoid overwriting valid cache and phpstan cache will only be written if the outcome was success or if the cache could not be loaded before.

I also updated the version for the cache action.