### PR TITLE
Fix: addCodespellIgnores.sh regex was broken.

### DIFF
--- a/dev/tools/codespell/addCodespellIgnores.sh
+++ b/dev/tools/codespell/addCodespellIgnores.sh
@@ -58,7 +58,7 @@ fi
 #   - For each line, create a grep command to find the lines;
 #   - Execute that command by evaluation
 codespell . \
-	| sed -n -E 's@^([^:]+)@\1@p' \
+	| sed -n -E 's@^([^:]+):.*@\1@p' \
 	| xargs -r git ls-files -- \
 	| xargs -r codespell -- \
 	| sed -n -E 's@^([^:]+):[[:digit:]]+:[[:space:]](\S+)[[:space:]].*@grep -P '\''\\b\2\\b'\'' -- "\1" >> '"${codespell_ignore_file}"'@p' \


### PR DESCRIPTION
# Fix: addCodespellIgnores.sh regex was broken.

A part of a regex used in the script was remove by mistake.