### PR TITLE
Fix phpstan contrat

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3433,12 +3433,7 @@ class ContratLigne extends CommonObjectLine
 		$this->fk_remise_except = (int) $this->fk_remise_except;
 		$this->subprice = price2num($this->subprice);
 		$this->price_ht = price2num($this->price_ht);
-		$this->total_ht = (float) trim($this->total_ht);
-		$this->total_tva = (float) trim($this->total_tva);
-		$this->total_localtax1 = (float) trim($this->total_localtax1);
-		$this->total_localtax2 = (float) trim($this->total_localtax2);
-		$this->total_ttc = (float) trim($this->total_ttc);
-		$this->info_bits = trim($this->info_bits);
+		$this->info_bits = (int) $this->info_bits;
 		$this->fk_user_author = (int) $this->fk_user_author;
 		$this->fk_user_ouverture = (int) $this->fk_user_ouverture;
 		$this->fk_user_cloture = (int) $this->fk_user_cloture;

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -965,9 +965,9 @@ class Contrat extends CommonObject
 
 		// Now set the global properties on contract not stored into database.
 		$this->nbofservices = count($this->lines);
-		$this->total_ttc = price2num($total_ttc);
-		$this->total_tva = price2num($total_vat);
-		$this->total_ht = price2num($total_ht);
+		$this->total_ttc = (float) price2num($total_ttc);
+		$this->total_tva = (float) price2num($total_vat);
+		$this->total_ht = (float) price2num($total_ht);
 
 		return $this->lines;
 	}
@@ -1586,8 +1586,9 @@ class Contrat extends CommonObject
 
 			// if buy price not defined, define buyprice as configured in margin admin
 			if ($pa_ht == 0) {
-				if (($result = $this->defineBuyPrice($pu_ht, $remise_percent, $fk_product)) < 0) {
-					return $result;
+				$result = $this->defineBuyPrice($pu_ht, $remise_percent, $fk_product);
+				if ($result < 0) {
+					return -1;
 				} else {
 					$pa_ht = $result;
 				}
@@ -1783,8 +1784,9 @@ class Contrat extends CommonObject
 
 		// if buy price not defined, define buyprice as configured in margin admin
 		if ($pa_ht == 0) {
-			if (($result = $this->defineBuyPrice($pu, $remise_percent)) < 0) {
-				return $result;
+			$result = $this->defineBuyPrice($pu, $remise_percent);
+			if ($result < 0) {
+				return -1;
 			} else {
 				$pa_ht = $result;
 			}
@@ -3430,11 +3432,11 @@ class ContratLigne extends CommonObjectLine
 		$this->fk_remise_except = (int) $this->fk_remise_except;
 		$this->subprice = price2num($this->subprice);
 		$this->price_ht = price2num($this->price_ht);
-		$this->total_ht = trim($this->total_ht);
-		$this->total_tva = trim($this->total_tva);
-		$this->total_localtax1 = trim($this->total_localtax1);
-		$this->total_localtax2 = trim($this->total_localtax2);
-		$this->total_ttc = trim($this->total_ttc);
+		$this->total_ht = (float) trim($this->total_ht);
+		$this->total_tva = (float) trim($this->total_tva);
+		$this->total_localtax1 = (float) trim($this->total_localtax1);
+		$this->total_localtax2 = (float) trim($this->total_localtax2);
+		$this->total_ttc = (float) trim($this->total_ttc);
 		$this->info_bits = trim($this->info_bits);
 		$this->fk_user_author = (int) $this->fk_user_author;
 		$this->fk_user_ouverture = (int) $this->fk_user_ouverture;
@@ -3496,8 +3498,9 @@ class ContratLigne extends CommonObjectLine
 
 		// if buy price not defined, define buyprice as configured in margin admin
 		if ($this->pa_ht == 0) {
-			if (($result = $this->defineBuyPrice($this->subprice, $this->remise_percent, $this->fk_product)) < 0) {
-				return $result;
+			$result = $this->defineBuyPrice($this->subprice, $this->remise_percent, $this->fk_product);
+			if ($result < 0) {
+				return -1;
 			} else {
 				$this->pa_ht = $result;
 			}

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -11,6 +11,7 @@
  * Copyright (C) 2018   	Nicolas ZABOURI			<info@inovea-conseil.com>
  * Copyright (C) 2018-2023  Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2015-2018	Ferran Marcet			<fmarcet@2byte.es>
+ * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
# Fix contrat.class.php phpstan lvl3
htdocs/contrat/class/contrat.class.php	968	Property CommonObject::$total_ttc (float) does not accept string.
htdocs/contrat/class/contrat.class.php	969	Property CommonObject::$total_tva (float) does not accept string.
htdocs/contrat/class/contrat.class.php	970	Property CommonObject::$total_ht (float) does not accept string.
htdocs/contrat/class/contrat.class.php	1590	Method Contrat::addline() should return int but returns float.
htdocs/contrat/class/contrat.class.php	1787	Method Contrat::updateline() should return int but returns float.
htdocs/contrat/class/contrat.class.php	3433	Property ContratLigne::$total_ht (float) does not accept string.
htdocs/contrat/class/contrat.class.php	3434	Property ContratLigne::$total_tva (float) does not accept string.
htdocs/contrat/class/contrat.class.php	3435	Property ContratLigne::$total_localtax1 (float) does not accept string.
htdocs/contrat/class/contrat.class.php	3436	Property ContratLigne::$total_localtax2 (float) does not accept string.
htdocs/contrat/class/contrat.class.php	3437	Property ContratLigne::$total_ttc (float) does not accept string.
htdocs/contrat/class/contrat.class.php	3500	Method ContratLigne::update() should return int but returns float.