### PR TITLE
FIX : llx_prospectlevel doesn't have rowid

### DIFF
--- a/htdocs/install/mysql/tables/llx_c_prospectlevel.sql
+++ b/htdocs/install/mysql/tables/llx_c_prospectlevel.sql
@@ -19,6 +19,7 @@
 
 create table llx_c_prospectlevel
 (
+  rowid           integer AUTO_INCREMENT PRIMARY KEY NOT NULL,
   code            varchar(12) PRIMARY KEY,
   label           varchar(128),
   sortorder       smallint,


### PR DESCRIPTION
# FIX
- llx_prospectlevel doesn't have rowid

$newid = ($obj->newid + 1);
=> This generates a fatal error in php 8 because we are trying to add a string (the code field) and an int

![image](https://github.com/Dolibarr/dolibarr/assets/139965072/b8183eaa-932b-418a-8bdd-3245cf071fec)
