### PR TITLE
new: add GETPOSTFLOAT() function

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -946,17 +946,31 @@ function GETPOST($paramname, $check = 'alphanohtml', $method = 0, $filter = null
 }
 
 /**
- *  Return value of a param into GET or POST supervariable.
+ *  Return the value of a $_GET or $_POST supervariable, converted into integer.
  *  Use the property $user->default_values[path]['creatform'] and/or $user->default_values[path]['filters'] and/or $user->default_values[path]['sortorder']
  *  Note: The property $user->default_values is loaded by main.php when loading the user.
  *
- *  @param  string  $paramname   Name of parameter to found
- *  @param	int		$method	     Type of method (0 = get then post, 1 = only get, 2 = only post, 3 = post then get)
- *  @return int                  Value found (int)
+ *  @param  string  $paramname   Name of the $_GET or $_POST parameter
+ *  @param  int     $method      Type of method (0 = $_GET then $_POST, 1 = only $_GET, 2 = only $_POST, 3 = $_POST then $_GET)
+ *  @return int                  Value converted into integer
  */
 function GETPOSTINT($paramname, $method = 0)
 {
 	return (int) GETPOST($paramname, 'int', $method, null, null, 0);
+}
+
+
+/**
+ *  Return the value of a $_GET or $_POST supervariable, converted into float.
+ *
+ *  @param  string          $paramname      Name of the $_GET or $_POST parameter
+ *  @param  string|int      $rounding       Type of rounding ('', 'MU', 'MT, 'MS', 'CU', 'CT', integer) {@see price2num()} 
+ *  @return float                           Value converted into float
+ */
+function GETPOSTFLOAT($paramname, $rounding = '')
+{
+	// price2num() is used to sanitize any valid user input (such as "1 234.5", "1 234,5", "1'234,5", "1·234,5", "1,234.5", etc.)
+	return (float) price2num(GETPOST($paramname), $rounding);
 }
 
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -964,7 +964,7 @@ function GETPOSTINT($paramname, $method = 0)
  *  Return the value of a $_GET or $_POST supervariable, converted into float.
  *
  *  @param  string          $paramname      Name of the $_GET or $_POST parameter
- *  @param  string|int      $rounding       Type of rounding ('', 'MU', 'MT, 'MS', 'CU', 'CT', integer) {@see price2num()} 
+ *  @param  string|int      $rounding       Type of rounding ('', 'MU', 'MT, 'MS', 'CU', 'CT', integer) {@see price2num()}
  *  @return float                           Value converted into float
  */
 function GETPOSTFLOAT($paramname, $rounding = '')


### PR DESCRIPTION
This function is introduced following phpstan errors which required corrections using long code such as 
```
$val = (float) price2num(GETPOST('name','alpha'));
```

@eldy: I kept this new function short and simple but you might want to change it if needed.

Especially:
- I did not mention `$check='alpha'`because `GETPOST()` uses `'alphanohtml'` by default. https://github.com/Dolibarr/dolibarr/blob/6c6adc5333790b1e3d90a5b195ee14a86877a892/htdocs/core/lib/functions.lib.php#L640
    and
https://github.com/Dolibarr/dolibarr/blob/6c6adc5333790b1e3d90a5b195ee14a86877a892/htdocs/core/lib/functions.lib.php#L623
- I did include the parameter `$rounding` from `price2num()`, since it might be useful
- I didn't include the `$method` parameter from `GETPOST()`
    - So it's a bit different from the existing similar function: https://github.com/Dolibarr/dolibarr/blob/6c6adc5333790b1e3d90a5b195ee14a86877a892/htdocs/core/lib/functions.lib.php#L957 