### PR TITLE
fix: onligne Signaturelink is bad for locaorexternal

### DIFF
--- a/htdocs/core/lib/signature.lib.php
+++ b/htdocs/core/lib/signature.lib.php
@@ -35,7 +35,7 @@ function showOnlineSignatureUrl($type, $ref, $obj = null)
 	$servicename = 'Online';
 
 	$out = img_picto('', 'globe').' <span class="opacitymedium">'.$langs->trans("ToOfferALinkForOnlineSignature", $servicename).'</span><br>';
-	$url = getOnlineSignatureUrl(0, $type, $ref, $obj);
+	$url = getOnlineSignatureUrl(0, $type, $ref, 1, $obj);
 	$out .= '<div class="urllink">';
 	if ($url == $langs->trans("FeatureOnlineSignDisabled")) {
 		$out .= $url;


### PR DESCRIPTION
funciton  getOnlineSignatureUrl
as for parameters 
 * @param   int				$mode				0=True url, 1=Url formated with colors
 * @param   string			$type				Type of URL ('proposal', ...)
 * @param	string			$ref				Ref of object
 * @param   string  		$localorexternal  	0=Url for browser, 1=Url for external access
 * @param   Object  		$obj  				object (needed to make multicompany good links)
 * @return	string								Url string

In the call the is a missing parameters, $obj is send instead of $localorexternal