### PR TITLE
NEW: remove auto selected user for taxes-charges by default

### DIFF
--- a/htdocs/compta/sociales/card.php
+++ b/htdocs/compta/sociales/card.php
@@ -400,7 +400,7 @@ if ($action == 'create') {
 	print '<tr><td>';
 	print $langs->trans('Employee');
 	print '</td>';
-	print '<td>'.img_picto('', 'user', 'class="pictofixedwidth"').$form->select_dolusers($fk_user, 'userid', 1).'</td></tr>';
+	print '<td>'.img_picto('', 'user', 'class="pictofixedwidth"').$form->select_dolusers('', 'userid', 1).'</td></tr>';
 
 	// Project
 	if (isModEnabled('project')) {


### PR DESCRIPTION
# NEW auto selection of user when creating taxes-charge should be null by default

Currently, taxes and charges automatically select the current user.
However, it is very rare to register taxes for yourself.
In addition, removing the automatic selection helps avoid an inadvertent error if the tax is not to be attributed to someone.
Once the tax has been recorded as paid, if a user had been selected, it is impossible to go back to rectify the problem

It's more of a comfort modification.