### PR TITLE
FIX: use the currency for propal signature page

### DIFF
--- a/htdocs/public/onlinesign/newonlinesign.php
+++ b/htdocs/public/onlinesign/newonlinesign.php
@@ -350,7 +350,7 @@ if ($source == 'proposal') {
 	// Amount
 	$amount = '<tr class="CTableRow2"><td class="CTableRow2">'.$langs->trans("Amount");
 	$amount .= '</td><td class="CTableRow2">';
-	$amount .= '<b>'.price($object->total_ttc, 0, $langs, 1, -1, -1, $conf->currency).'</b>';
+	$amount .= '<b>'.price($object->multicurrency_total_ttc, 0, $langs, 1, -1, -1, $object->multicurrency_code).'</b>';
 	$amount .= '</td></tr>'."\n";
 
 	// Call Hook amountPropalSign

--- a/htdocs/public/onlinesign/newonlinesign.php
+++ b/htdocs/public/onlinesign/newonlinesign.php
@@ -348,9 +348,13 @@ if ($source == 'proposal') {
 	print '</td></tr>'."\n";
 
 	// Amount
+
 	$amount = '<tr class="CTableRow2"><td class="CTableRow2">'.$langs->trans("Amount");
 	$amount .= '</td><td class="CTableRow2">';
-	$amount .= '<b>'.price($object->multicurrency_total_ttc, 0, $langs, 1, -1, -1, $object->multicurrency_code).'</b>';
+	$amount .= '<b>'.price($object->total_ttc, 0, $langs, 1, -1, -1, $conf->currency).'</b>';
+	if ($object->multicurrency_code != $conf->currency) {
+		$amount .= ' ('.price($object->multicurrency_total_ttc, 0, $langs, 1, -1, -1, $object->multicurrency_code).')';
+	}
 	$amount .= '</td></tr>'."\n";
 
 	// Call Hook amountPropalSign


### PR DESCRIPTION
# FIX Signature of propal now use the propal currency

From a client point of view, it is more pleasant to have the currency of the proposal which automatically comes from the client's currency during creation.

Of course, even if we do not activate "multicurrency" in the modules, the `multicurrency_code` and `multicurrency_total_ttc` fields are correctly used