### PR TITLE
Revert "FIX : llx_prospectlevel doesn't have rowid"

### DIFF
--- a/htdocs/install/mysql/tables/llx_c_prospectlevel.sql
+++ b/htdocs/install/mysql/tables/llx_c_prospectlevel.sql
@@ -19,7 +19,6 @@
 
 create table llx_c_prospectlevel
 (
-  rowid           integer AUTO_INCREMENT PRIMARY KEY NOT NULL,
   code            varchar(12) PRIMARY KEY,
   label           varchar(128),
   sortorder       smallint,


### PR DESCRIPTION
Reverts Dolibarr/dolibarr#27727

Generate critical regression. Table already has a primary key.