### PR TITLE
Qual phpstan societeaccount class

### DIFF
--- a/htdocs/societe/class/societeaccount.class.php
+++ b/htdocs/societe/class/societeaccount.class.php
@@ -45,7 +45,7 @@ class SocieteAccount extends CommonObject
 	public $table_element = 'societe_account';
 
 	/**
-	 * @var array  Does societeaccount support multicompany module ? 0=No test on entity, 1=Test with field entity, 2=Test with link by societe
+	 * @var int Does societeaccount support multicompany module ? 0=No test on entity, 1=Test with field entity, 2=Test with link by societe
 	 */
 	public $ismultientitymanaged = 0;
 


### PR DESCRIPTION
# Qual societeaccount.class.php phpstan lvl3
htdocs/societe/class/societeaccount.class.php	50	PHPDoc type array of property SocieteAccount::$ismultientitymanaged is not covariant with PHPDoc type int of overridden property CommonObject::$ismultientitymanaged.
htdocs/societe/class/societeaccount.class.php	50	Property SocieteAccount::$ismultientitymanaged (array) does not accept default value of type int.





