### PR TITLE
FIX: update currency by selected supplier

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2624,7 +2624,7 @@ if ($action == 'create') {
 		print '<td>'.$form->editfieldkey('Currency', 'multicurrency_code', '', $object, 0).'</td>';
 		print '<td class="maxwidthonsmartphone">';
 		print img_picto('', 'currency', 'class="pictofixedwidth"');
-		print $form->selectMultiCurrency((GETPOSTISSET('multicurrency_code') ?GETPOST('multicurrency_code', 'alpha') : $currency_code), 'multicurrency_code');
+		print $form->selectMultiCurrency($currency_code, 'multicurrency_code');
 		print '</td></tr>';
 	}
 


### PR DESCRIPTION
# FIX In supplier invoice, update currency by the selected one

in the creation of a supplier invoice, when you select the supplier, the page reloads with the information but does not change the currency with it.

This behavior is annoying with multi-currencies.

However, having made the change, the page reload no longer takes the user's selection since it systematically takes that of the provider.

Is this a viable behavior?