### PR TITLE
qual: phpstan for htdocs/compta/paiement/cheque/card.php

### DIFF
--- a/htdocs/compta/paiement/cheque/card.php
+++ b/htdocs/compta/paiement/cheque/card.php
@@ -37,7 +37,7 @@ require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 // Load translation files required by the page
 $langs->loadLangs(array('banks', 'categories', 'bills', 'companies', 'compta'));
 
-$id = GETPOST('id', 'int');
+$id = GETPOSTINT('id');
 $ref = GETPOST('ref', 'alpha');
 $action = GETPOST('action', 'aZ09');
 $confirm = GETPOST('confirm', 'alpha');


### PR DESCRIPTION
htdocs/compta/paiement/cheque/card.php	179	Property CommonObject::$id (int) does not accept array|string. htdocs/compta/paiement/cheque/card.php	190	Property CommonObject::$id (int) does not accept array|string.