### PR TITLE
FIX avoid from re-initializing result on nested hook getEntity

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -207,7 +207,7 @@ class HookManager
 		}
 
 		// Init return properties
-		$this->resPrint = '';
+		$localResPrint = '';
 		$this->resArray = array();
 		$this->resNbOfHooks = 0;
 
@@ -270,9 +270,9 @@ class HookManager
 						}
 						if (!empty($actionclassinstance->resprints)) {
 							if ($resactiontmp > 0) {
-								$this->resPrint = $actionclassinstance->resprints;
+								$localResPrint = $actionclassinstance->resprints;
 							} else {
-								$this->resPrint .= $actionclassinstance->resprints;
+								$localResPrint .= $actionclassinstance->resprints;
 							}
 						}
 					} else {
@@ -294,7 +294,7 @@ class HookManager
 							$this->resArray = array_merge($this->resArray, $actionclassinstance->results);
 						}
 						if (!empty($actionclassinstance->resprints)) {
-							$this->resPrint .= $actionclassinstance->resprints;
+							$localResPrint .= $actionclassinstance->resprints;
 						}
 						if (is_numeric($resactiontmp) && $resactiontmp < 0) {
 							$error++;
@@ -307,7 +307,7 @@ class HookManager
 						if (!is_array($resactiontmp) && !is_numeric($resactiontmp)) {
 							dol_syslog('Error: Bug into hook '.$method.' of module class '.get_class($actionclassinstance).'. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints', LOG_ERR);
 							if (empty($actionclassinstance->resprints)) {
-								$this->resPrint .= $resactiontmp;
+								$localResPrint .= $resactiontmp;
 							}
 						}
 					}
@@ -319,6 +319,8 @@ class HookManager
 				}
 			}
 		}
+
+		$this->resPrint = $localResPrint;
 
 		return ($error ? -1 : $resaction);
 	}

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -309,15 +309,13 @@ function getEntity($element, $shared = 1, $currentobject = null)
 		'currentobject' => $currentobject,
 		'out' => $out
 	);
-	// avoid from re-initializing results of previous hook (nested hooks)
-	$hookmanager2 = clone $hookmanager;
-	$reshook = $hookmanager2->executeHooks('hookGetEntity', $parameters, $currentobject, $action); // Note that $action and $object may have been modified by some hooks
+	$reshook = $hookmanager->executeHooks('hookGetEntity', $parameters, $currentobject, $action); // Note that $action and $object may have been modified by some hooks
 
 	if (is_numeric($reshook)) {
-		if ($reshook == 0 && !empty($hookmanager2->resPrint)) {
-			$out .= ','.$hookmanager2->resPrint; // add
+		if ($reshook == 0 && !empty($hookmanager->resPrint)) {
+			$out .= ','.$hookmanager->resPrint; // add
 		} elseif ($reshook == 1) {
-			$out = $hookmanager2->resPrint; // replace
+			$out = $hookmanager->resPrint; // replace
 		}
 	}
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -309,13 +309,15 @@ function getEntity($element, $shared = 1, $currentobject = null)
 		'currentobject' => $currentobject,
 		'out' => $out
 	);
-	$reshook = $hookmanager->executeHooks('hookGetEntity', $parameters, $currentobject, $action); // Note that $action and $object may have been modified by some hooks
+	// avoid from re-initializing results of previous hook (nested hooks)
+	$hookmanager2 = clone $hookmanager;
+	$reshook = $hookmanager2->executeHooks('hookGetEntity', $parameters, $currentobject, $action); // Note that $action and $object may have been modified by some hooks
 
 	if (is_numeric($reshook)) {
-		if ($reshook == 0 && !empty($hookmanager->resPrint)) {
-			$out .= ','.$hookmanager->resPrint; // add
+		if ($reshook == 0 && !empty($hookmanager2->resPrint)) {
+			$out .= ','.$hookmanager2->resPrint; // add
 		} elseif ($reshook == 1) {
-			$out = $hookmanager->resPrint; // replace
+			$out = $hookmanager2->resPrint; // replace
 		}
 	}
 


### PR DESCRIPTION
FIX avoid from re-initializing result on nested hook getEntity
- when you have a first hook such as "formBuilddocOptions" calling "getEntity()" function
- then "getEntity()" function executes the hook "hookGetEntity" (nested hook) and results of the previous hook are re-initialized

**For example**
We have two module : Module 1 and Module 2
1. Module 1 : hook "formBuilddocOptions" is adding some  (using "resPrint" of hook manager object)
2. Module 2 : hook "formBuilddocOptions" is calling getEntity() and then the global "hookmanager" is re-initialized and "resPrint" value is now empty
3. So the options before generating a document are lost (resPrint is empty)

**Before**
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/fb780792-0a3a-41b7-b61c-10073dafbed9)

**After**
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/e22adf80-93ae-468d-b2fb-2d0a04c42702)
