### PR TITLE
FIX #27705 empty parent company list column

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -1694,7 +1694,7 @@ while ($i < $imaxinloop) {
 		$companystatic->code_compta_fournisseur = $obj->code_compta_fournisseur;
 
 		$companystatic->fk_prospectlevel = $obj->fk_prospectlevel;
-		$companystatic->fk_parent = $obj->fk_parent;
+		$companystatic->parent = $obj->fk_parent;
 		$companystatic->entity = $obj->entity;
 	}
 


### PR DESCRIPTION
# FIX #27705 empty parent company list column
This fix is for v19+
This has been fixed in v18.0.5 with 0aae72b69472f60dfe4a72dfbd5e168f084cb20a but not completely in v19+