### PR TITLE
Qual: Run php-cs on changed files only with pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,17 @@ jobs:
       - name: Install required tools
         run: sudo apt-get update && sudo apt-get install cppcheck
         if: false
+
+      # The next uses the git API because there is no clone yet.
+      # This is faster for a big repo.
+      - name: Get all changed php files (if PR)
+        id: changed-php
+        uses: tj-actions/changed-files@v42
+        if: github.event_name == 'pull_request'
+        with:
+          files: |
+             **.php
+
       # Checkout git sources to analyze
       - uses: actions/checkout@v4
       # Action setup-python needs a requirements.txt or pyproject.toml
@@ -42,6 +53,24 @@ jobs:
           set -o pipefail
           pre-commit gc
           pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
+
+      # The next uses git, which is slow for a bit repo.
+      # - name: Get all changed php files (if PR)
+      #   id: changed-php
+      #   uses: tj-actions/changed-files@v42
+      #   if: github.event_name == 'pull_request'
+      #   with:
+      #     files: |
+      #        **.php
+
+      - name: Run some pre-commit hooks on selected changed files only
+        if: steps.changed-php.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-php.outputs.all_changed_files }}
+        run: |
+          set -o pipefail
+          pre-commit run php-cs ${ALL_CHANGED_FILES} | tee -a ${RAW_LOG}
+
       # If error, we convert log in the checkstyle format
       - name: Convert Raw Log to CheckStyle format
         if: ${{ failure() }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: (?x)^( htdocs/includes/ckeditor/.* )
 repos:
   # Several miscellaneous checks and fix (on yaml files, end of files fix)
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: no-commit-to-branch
         args: [--branch, develop, --pattern, \d+.0]
@@ -87,7 +87,7 @@ repos:
 
   # Check format of yaml files
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.32.0
+    rev: v1.33.0
     hooks:
       - id: yamllint
         args:
@@ -97,7 +97,7 @@ repos:
 
   # Execute codespell to fix typo errors (setup of codespell into dev/tools/codespell/)
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
       - id: codespell
         # Due to a current limitation of configuration files,
@@ -142,7 +142,7 @@ repos:
 
   # Check some shell scripts
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.5
+    rev: v0.9.0.6
     hooks:
       - id: shellcheck
         args: [-W, '100']


### PR DESCRIPTION
# Qual: Run php-cs on changed files only with pre-commit

Use a github action to detect changed PHP files and run
php-cs on those files.
(The method suggested by the pre-commit documentation did not work).

EDIT: Some pre-commit hooks were updated.