### PR TITLE
Fix : random bug when attaching file to email : no file attached

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -1644,9 +1644,9 @@ class CMailFile
 		$filename_list_size = count($filename_list);
 		for ($i = 0; $i < $filename_list_size; $i++) {
 			if ($filename_list[$i]) {
-				dol_syslog("CMailFile::write_files: i=$i");
+				dol_syslog("CMailFile::write_files: i=$i ".$filename_list[$i]);
 				$encoded = $this->_encode_file($filename_list[$i]);
-				if ($encoded >= 0) {
+				if ($encoded !== -1) {
 					if ($mimefilename_list[$i]) {
 						$filename_list[$i] = $mimefilename_list[$i];
 					}


### PR DESCRIPTION
# FIX : random bug when attaching file(s) to email : no file attached

quite tricky : due to a bad test of return of function `_encode_file` from `write_files` in `CmailFile.class.php` : 
sometimes, the result string from _encode_file (which is ok) can be "equal" to -1 
