### PR TITLE
qual: Update ProfidLibTest.php - uncomment line testing that BE TIN shall start by 0 or 1

### DIFF
--- a/test/phpunit/ProfidLibTest.php
+++ b/test/phpunit/ProfidLibTest.php
@@ -252,7 +252,7 @@ class ProfidLibTest extends PHPUnit\Framework\TestCase
 		$this->assertTrue(isValidTinForBE("0123.123.123"));
 		$this->assertTrue(isValidTinForBE("1234.123.123"));
 		// Tests NOK
-		//$this->assertFalse(isValidTinForBE("2345.123.123"));		// First digit shall be 0 or 1
+		$this->assertFalse(isValidTinForBE("2345.123.123"));		// First digit shall be 0 or 1
 		$this->assertFalse(isValidTinForBE("1234 123 123"));		// formatted with spaces instead of dots
 		$this->assertFalse(isValidTinForBE("1234123123"));			// without dots formatting
 		$this->assertFalse(isValidTinForBE("ABCD.123.123"));		// not digits only


### PR DESCRIPTION
Since PR #27829 has been merged, we can now uncomment the line testing that a the Belgium Tax Identification Number shall start by 0 or 1.