### PR TITLE
Qual: Make phpcs messages in pre-commit extractable.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,10 +57,10 @@ repos:
     hooks:
       - id: php-cbf
         files: \.(php)$
-        args: [--standard=dev/setup/codesniffer/ruleset.xml -p]
+        args: [--standard=dev/setup/codesniffer/ruleset.xml]
       - id: php-cs
         files: \.(php)$
-        args: [--standard=dev/setup/codesniffer/ruleset.xml -p]
+        args: [--standard=dev/setup/codesniffer/ruleset.xml,--report=emacs]
       - id: php-lint
 
   # Prettier (format code, only for non common files)


### PR DESCRIPTION
# Qual: Make phpcs messages in pre-commit extractable.

To make messages extractable for annotation when phpcs is run in pre-commit, change the report style to emacs.
Also had to update logToCs.py.

Using checkstyle directly as an option would not make the output readable when pre-commit is run from the CLI, on commit.