### PR TITLE
Fix: LABEL is required on the db classes.

### DIFF
--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -30,8 +30,10 @@ require_once DOL_DOCUMENT_ROOT.'/core/db/Database.interface.php';
  */
 abstract class DoliDB implements Database
 {
-	/** Force subclass to implement VERSIONMIN*/
+	/** Force subclass to implement VERSIONMIN - required DB version */
 	const VERSIONMIN = self::VERSIONMIN;
+	/** Force subclass to implement LABEL - description of DB type */
+	const LABEL = self::LABEL;
 
 	/** @var bool|resource|mysqli|SQLite3|PgSql\Connection Database handler */
 	public $db;


### PR DESCRIPTION
# Fix: LABEL is required on the db classes.

Define const in parent type so that it is required in the subclasses.