### PR TITLE
qual: phpstan for htdocs/public/bookcal/index.php

### DIFF
--- a/htdocs/public/bookcal/index.php
+++ b/htdocs/public/bookcal/index.php
@@ -50,7 +50,7 @@ require_once DOL_DOCUMENT_ROOT.'/comm/action/class/actioncomm.class.php';
 $langs->loadLangs(array("main", "other", "dict", "agenda", "errors", "companies"));
 
 $action = GETPOST('action', 'aZ09');
-$id = GETPOST('id', 'int');
+$id = GETPOSTINT('id');
 $id_availability = GETPOST('id_availability', 'int');
 
 $year = GETPOST("year", "int") ? GETPOST("year", "int") : date("Y");
@@ -236,7 +236,7 @@ if ($action == 'add') {
 		$actioncomm->label = $langs->trans("BookcalBookingTitle");
 		$actioncomm->type = 'AC_RDV';
 		$actioncomm->type_id = 5;
-		$actioncomm->datep = GETPOST("datetimebooking", 'int');
+		$actioncomm->datep = GETPOSTINT("datetimebooking");
 		$actioncomm->datef = $dateend;
 		$actioncomm->note_private = GETPOST("description");
 		$actioncomm->percentage = -1;


### PR DESCRIPTION
htdocs/public/bookcal/index.php	239	Property ActionComm::$datep (int) does not accept array|string.
htdocs/public/bookcal/index.php	243	Property ActionComm::$fk_bookcal_calendar (int) does not accept array|string.