### PR TITLE
FIX: Show tickets created by current user

### DIFF
--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -448,6 +448,7 @@ if ($search_dateclose_end) {
 
 if (!$user->socid && ($mode == "mine" || (!$user->admin && $conf->global->TICKET_LIMIT_VIEW_ASSIGNED_ONLY))) {
 	$sql .= " AND (t.fk_user_assign = ".((int) $user->id);
+	$sql .= " OR t.fk_user_create = ".((int) $user->id);
 	if (empty($conf->global->TICKET_LIMIT_VIEW_ASSIGNED_ONLY)) {
 		$sql .= " OR t.fk_user_create = ".((int) $user->id);
 	}


### PR DESCRIPTION
List should shows tickets created by or flagged for the current user Currently, only shows flagged for the current user not created by See : https://www.dolibarr.org/forum/t/hortcut-to-check-my-tickets/24877
