### PR TITLE
FIX 17.0 - php8 warnings: test for $field existence before checking is_null

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9086,7 +9086,7 @@ abstract class CommonObject
 
 		foreach ($this->fields as $field => $info) {
 			if ($this->isDate($info)) {
-				if (is_null($obj->{$field}) || $obj->{$field} === '' || $obj->{$field} === '0000-00-00 00:00:00' || $obj->{$field} === '1000-01-01 00:00:00') {
+				if (!isset($obj->{$field}) || is_null($obj->{$field}) || $obj->{$field} === '' || $obj->{$field} === '0000-00-00 00:00:00' || $obj->{$field} === '1000-01-01 00:00:00') {
 					$this->{$field} = '';
 				} else {
 					$this->{$field} = $db->jdate($obj->{$field});
@@ -9102,7 +9102,7 @@ abstract class CommonObject
 							$this->{$field} = (double) $obj->{$field};
 						}
 					} else {
-						if (!is_null($obj->{$field}) || (isset($info['notnull']) && $info['notnull'] == 1)) {
+						if (isset($obj->{$field}) && (!is_null($obj->{$field}) || (isset($info['notnull']) && $info['notnull'] == 1))) {
 							$this->{$field} = (int) $obj->{$field};
 						} else {
 							$this->{$field} = null;
@@ -9117,7 +9117,7 @@ abstract class CommonObject
 						$this->{$field} = (double) $obj->{$field};
 					}
 				} else {
-					if (!is_null($obj->{$field}) || (isset($info['notnull']) && $info['notnull'] == 1)) {
+					if (isset($obj->{$field}) && (!is_null($obj->{$field}) || (isset($info['notnull']) && $info['notnull'] == 1))) {
 						$this->{$field} = (double) $obj->{$field};
 					} else {
 						$this->{$field} = null;


### PR DESCRIPTION
# FIX php8 warnings in CommonObject

```php
is_null($this_variable_is_not_set);
```
In php7 ⇒ notice. In php8 ⇒ warning.

Maybe this fix could be refactored by moving the `isset()` test to the beginning of the loop. I felt more comfortable doing it inside each test that has the warning because with less analysis comes less risk for misanalysis.

