### PR TITLE
FIX: Add info Tab. Update invoice.lib.php

### DIFF
--- a/htdocs/core/lib/invoice.lib.php
+++ b/htdocs/core/lib/invoice.lib.php
@@ -152,6 +152,11 @@ function facture_prepare_head($object)
 	$head[$h][2] = 'agenda';
 	$h++;
 
+	$head[$h][0] = DOL_URL_ROOT.'/compta/facture/info.php?facid='.$object->id;
+	$head[$h][1] = $langs->trans('Info');
+	$head[$h][2] = 'info';
+	$h++;
+
 	complete_head_from_modules($conf, $langs, $object, $head, $h, 'invoice', 'add', 'external');
 
 	complete_head_from_modules($conf, $langs, $object, $head, $h, 'invoice', 'remove');


### PR DESCRIPTION
FIX: Add info Tab

The info Tab at invoices has disappeared in version 18, why?
