### PR TITLE
qual: phpstan for htdocs/compta/tva/class/tva.class.php

### DIFF
--- a/htdocs/compta/tva/class/tva.class.php
+++ b/htdocs/compta/tva/class/tva.class.php
@@ -63,7 +63,7 @@ class Tva extends CommonObject
 	public $num_payment;
 
 	/**
-	 * @var DateTime
+	 * @var int     Creation date
 	 */
 	public $datec;
 
@@ -81,11 +81,6 @@ class Tva extends CommonObject
 	 * @var int
 	 */
 	public $rappro;
-
-	/**
-	 * @var integer|string totalpaid
-	 */
-	public $totalpaid;
 
 	/**
 	 * @var string label
@@ -426,9 +421,9 @@ class Tva extends CommonObject
 		$this->amount = '';
 		$this->label = '';
 		$this->note = '';
-		$this->fk_bank = '';
-		$this->fk_user_creat = '';
-		$this->fk_user_modif = '';
+		$this->fk_bank = 0;
+		$this->fk_user_creat = 0;
+		$this->fk_user_modif = 0;
 	}
 
 


### PR DESCRIPTION
htdocs/compta/tva/class/tva.class.php	88	PHPDoc type int|string of property Tva::$totalpaid is not covariant with PHPDoc type float of overridden property CommonObject::$totalpaid. 
htdocs/compta/tva/class/tva.class.php	429	Property Tva::$fk_bank (int) does not accept string.
htdocs/compta/tva/class/tva.class.php	430	Property Tva::$fk_user_creat (int) does not accept string.
htdocs/compta/tva/class/tva.class.php	431	Property Tva::$fk_user_modif (int) does not accept string.
htdocs/compta/tva/class/tva.class.php	579	Property Tva::$datec (DateTime) does not accept int.