### PR TITLE
qual: phpstan - Property CommonDict::$active (int) does not accept string.

### DIFF
--- a/htdocs/core/class/ccountry.class.php
+++ b/htdocs/core/class/ccountry.class.php
@@ -73,7 +73,7 @@ class Ccountry extends CommonDict
 			$this->label = trim($this->label);
 		}
 		if (isset($this->active)) {
-			$this->active = trim($this->active);
+			$this->active = (int) $this->active;
 		}
 
 		// Check parameters
@@ -195,7 +195,7 @@ class Ccountry extends CommonDict
 			$this->label = trim($this->label);
 		}
 		if (isset($this->active)) {
-			$this->active = trim($this->active);
+			$this->active = (int) $this->active;
 		}
 
 

--- a/htdocs/core/class/cgenericdic.class.php
+++ b/htdocs/core/class/cgenericdic.class.php
@@ -97,7 +97,7 @@ class CGenericDic extends CommonDict
 			$this->label = trim($this->label);
 		}
 		if (isset($this->active)) {
-			$this->active = trim($this->active);
+			$this->active = (int) $this->active;
 		}
 
 		// Insert request
@@ -321,7 +321,7 @@ class CGenericDic extends CommonDict
 			$this->label = trim($this->label);
 		}
 		if (isset($this->active)) {
-			$this->active = trim($this->active);
+			$this->active = (int) $this->active;
 		}
 
 		// Check parameters


### PR DESCRIPTION
htdocs/core/class/ccountry.class.php	76	Property CommonDict::$active (int) does not accept string.
htdocs/core/class/ccountry.class.php	198	Property CommonDict::$active (int) does not accept string.
htdocs/core/class/cgenericdic.class.php	100	Property CGenericDic::$active (int) does not accept string.
htdocs/core/class/cgenericdic.class.php	324	Property CGenericDic::$active (int) does not accept string.