### PR TITLE
fix #27883 : zero could be a value stored

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -51,7 +51,7 @@ function getDolGlobalString($key)
 {
 	global $conf;
 	// return $conf->global->$key ?? '';
-	return (string) (empty($conf->global->$key) ? '' : $conf->global->$key);
+	return (string) (isset($conf->global->$key) ? $conf->global->$key : '');
 }
 
 /**
@@ -63,7 +63,7 @@ function getDolGlobalInt($key)
 {
 	global $conf;
 	// return $conf->global->$key ?? 0;
-	return (int) (empty($conf->global->$key) ? 0 : $conf->global->$key);
+	return (int) (isset($conf->global->$key) ? $conf->global->$key : 0);
 }
 
 /**


### PR DESCRIPTION
If you want - for example - store a key with Product or Service code into a configuration key for your module:

```
dolibarr_set_const($db, 'ONEKEY', Product::TYPE_PRODUCT, 'chaine', 0, '', $conf->entity);
dolibarr_set_const($db, 'OTHERKEY', Product::TYPE_SERVICE, 'chaine', 0, '', $conf->entity);
```

then you store "0" as value in database for ONEKEY but getDolGlobalString will return '', not "0" ...