### PR TITLE
qual: phpstan for htdocs/emailcollector/class/emailcollector.class.php

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -821,7 +821,7 @@ class EmailCollector extends CommonObject
 	 * Convert str to UTF-7 imap. Used to forge mailbox names.
 	 *
 	 * @param 	string $str			String to encode
-	 * @return 	string				Encode string
+	 * @return 	string|false		Encoded string, or false if error
 	 */
 	public function getEncodedUtf7($str)
 	{
@@ -2893,7 +2893,7 @@ class EmailCollector extends CommonObject
 
 								$projecttocreate->title = $subject;
 								$projecttocreate->date_start = $date;	// date of email
-								$projecttocreate->date_end = '';
+								$projecttocreate->date_end = 0;
 								$projecttocreate->opp_status = $id_opp_status;
 								$projecttocreate->opp_percent = $percent_opp_status;
 								$projecttocreate->description = dol_concatdesc(dolGetFirstLineOfText(dol_string_nohtmltag($description, 2), 10), '...'.$langs->transnoentities("SeePrivateNote").'...');


### PR DESCRIPTION
htdocs/emailcollector/class/emailcollector.class.php	844	Method EmailCollector::getEncodedUtf7() should return string but returns false. 
htdocs/emailcollector/class/emailcollector.class.php	2896	Property Project::$date_end (int) does not accept string.
