### PR TITLE
Fix: Always return value in get_element_list

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -916,6 +916,7 @@ class Project extends CommonObject
 		} else {
 			dol_print_error($this->db);
 		}
+		return -1;
 	}
 
 	/**


### PR DESCRIPTION
# Fix: Always return value in get_element_list

get_element_list did not always return a value.  Fixed.
