### PR TITLE
Fix: Always return value as suggested

### DIFF
--- a/htdocs/core/class/canvas.class.php
+++ b/htdocs/core/class/canvas.class.php
@@ -224,5 +224,6 @@ class Canvas
 			$ret = $this->control->doActions($action, $id);
 			return $ret;
 		}
+		return null;
 	}
 }


### PR DESCRIPTION
# Fix: Always return value as suggested

Always return a value in doAction (as per PHPDoc type hint).