### PR TITLE
FIX : Missing begin transaction

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -520,6 +520,8 @@ class FactureFournisseurRec extends CommonInvoice
 		$sql .= " auto_validate = ". (!empty($this->auto_validate) ? ((int) $this->auto_validate) : 0);
 		$sql .= " WHERE rowid = ". (int) $this->id;
 
+		$this->db->begin();
+
 		dol_syslog(get_class($this)."::update", LOG_DEBUG);
 		$resql = $this->db->query($sql);
 		if ($resql) {


### PR DESCRIPTION
# FIX Missing begin transaction
In the `update` function of the `FactureFournisseurRec` class, there's no instruction to start the database transaction while there are the `commit` and `rollback` instructions at the end of it.
So it could cause an error like this:
```
Error, the balance begin/close of db transactions has been broken into trigger ... with action=BILL_SUPPLIER_CREATE before=2 after=1
```