### PR TITLE
FIX #26416 BOM_SUB_BOM blank page

### DIFF
--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -168,7 +168,7 @@ if (empty($reshook)) {
 			$res = $object->add_object_linked('mo', $mo_parent->id);
 		}
 
-		header("Location: ".dol_buildpath('/mrp/mo_card.php?id='.((int) $moline->fk_mo), 1));
+		header("Location: ".dol_buildpath('/mrp/mo_card.php?id='.((int) $mo_parent->id), 1));
 		exit;
 	}
 


### PR DESCRIPTION
#26416
The `$moline->fk_mo` variable is empty and when we create a new MO with the sub BOM, we are redirected to a blank page because `id=0`.