### PR TITLE
Qual ldap class phpcs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,22 @@
 English Dolibarr ChangeLog
 --------------------------------------------------------------
 
+***** ChangeLog for 20.0.0 compared to 19.0.0 *****
+
+For users:
+----------
+NEW: Compatibility with PHP 8.3
+...
+
+For developers or integrators:
+------------------------------
+...
+
+WARNING:
+--------
+
+The following changes may create regressions for some external modules, but were necessary to make Dolibarr better:
+* Ldap class methods connect_bind() & dump_content() have been renamed
 
 ***** ChangeLog for 19.0.0 compared to 18.0.0 *****
 

--- a/htdocs/adherents/ldap.php
+++ b/htdocs/adherents/ldap.php
@@ -79,7 +79,7 @@ $result = restrictedArea($user, 'adherent', $object->id, '', '', 'socid', 'rowid
 
 if ($action == 'dolibarr2ldap') {
 	$ldap = new Ldap();
-	$result = $ldap->connect_bind();
+	$result = $ldap->connectBind();
 
 	if ($result > 0) {
 		$info = $object->_load_ldap_info();
@@ -183,7 +183,7 @@ print '</tr>';
 
 // Lecture LDAP
 $ldap = new Ldap();
-$result = $ldap->connect_bind();
+$result = $ldap->connectBind();
 if ($result > 0) {
 	$info = $object->_load_ldap_info();
 	$dn = $object->_load_ldap_dn($info, 1);

--- a/htdocs/adherents/type_ldap.php
+++ b/htdocs/adherents/type_ldap.php
@@ -59,7 +59,7 @@ if ($reshook < 0) {
 if (empty($reshook)) {
 	if ($action == 'dolibarr2ldap') {
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 
 		if ($result > 0) {
 			$object->listMembersForMemberType('', 1);
@@ -149,7 +149,7 @@ print '</tr>';
 
 // LDAP reading
 $ldap = new Ldap();
-$result = $ldap->connect_bind();
+$result = $ldap->connectBind();
 if ($result > 0) {
 	$info = $object->_load_ldap_info();
 	$dn = $object->_load_ldap_dn($info, 1);

--- a/htdocs/admin/ldap.php
+++ b/htdocs/admin/ldap.php
@@ -279,7 +279,7 @@ if (function_exists("ldap_connect")) {
 	if ($action == 'test') {
 		$ldap = new Ldap(); // The parameters are provided and recovered through $conf
 
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 		if ($result > 0) {
 			// Test ldap connect and bind
 			print img_picto('', 'info').' ';

--- a/htdocs/admin/ldap_contacts.php
+++ b/htdocs/admin/ldap_contacts.php
@@ -323,7 +323,7 @@ if (function_exists("ldap_connect")) {
 
 			print "<br>\n";
 			print "LDAP input file used for test:<br><br>\n";
-			print nl2br($ldap->dump_content($dn, $info));
+			print nl2br($ldap->dumpContent($dn, $info));
 			print "\n<br>";
 		} else {
 			print img_picto('', 'error').' ';

--- a/htdocs/admin/ldap_contacts.php
+++ b/htdocs/admin/ldap_contacts.php
@@ -300,7 +300,7 @@ if (function_exists("ldap_connect")) {
 
 		// Test synchro
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 
 		if ($result > 0) {
 			$info = $object->_load_ldap_info();

--- a/htdocs/admin/ldap_groups.php
+++ b/htdocs/admin/ldap_groups.php
@@ -244,7 +244,7 @@ if (function_exists("ldap_connect")) {
 
 		// Test synchro
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 
 		if ($result > 0) {
 			$info = $object->_load_ldap_info();
@@ -288,7 +288,7 @@ if (function_exists("ldap_connect")) {
 
 		// Test synchro
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 
 		if ($result > 0) {
 			$required_fields = array(

--- a/htdocs/admin/ldap_groups.php
+++ b/htdocs/admin/ldap_groups.php
@@ -272,7 +272,7 @@ if (function_exists("ldap_connect")) {
 
 			print "<br>\n";
 			print "LDAP input file used for test:<br><br>\n";
-			print nl2br($ldap->dump_content($dn, $info));
+			print nl2br($ldap->dumpContent($dn, $info));
 			print "\n<br>";
 		} else {
 			print img_picto('', 'error').' ';

--- a/htdocs/admin/ldap_members.php
+++ b/htdocs/admin/ldap_members.php
@@ -474,7 +474,7 @@ if (function_exists("ldap_connect")) {
 
 			print "<br>\n";
 			print "LDAP input file used for test:<br><br>\n";
-			print nl2br($ldap->dump_content($dn, $info));
+			print nl2br($ldap->dumpContent($dn, $info));
 			print "\n<br>";
 		} else {
 			print img_picto('', 'error').' ';

--- a/htdocs/admin/ldap_members.php
+++ b/htdocs/admin/ldap_members.php
@@ -451,7 +451,7 @@ if (function_exists("ldap_connect")) {
 
 		// Test synchro
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 
 		if ($result > 0) {
 			$info = $object->_load_ldap_info();

--- a/htdocs/admin/ldap_members_types.php
+++ b/htdocs/admin/ldap_members_types.php
@@ -235,7 +235,7 @@ if (function_exists("ldap_connect")) {
 
 			print "<br>\n";
 			print "LDAP input file used for test:<br><br>\n";
-			print nl2br($ldap->dump_content($dn, $info));
+			print nl2br($ldap->dumpContent($dn, $info));
 			print "\n<br>";
 		} else {
 			print img_picto('', 'error').' ';

--- a/htdocs/admin/ldap_members_types.php
+++ b/htdocs/admin/ldap_members_types.php
@@ -207,7 +207,7 @@ if (function_exists("ldap_connect")) {
 
 		// Test synchro
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 
 		if ($result > 0) {
 			$info = $object->_load_ldap_info();

--- a/htdocs/admin/ldap_users.php
+++ b/htdocs/admin/ldap_users.php
@@ -446,7 +446,7 @@ if (function_exists("ldap_connect")) {
 
 			print "<br>\n";
 			print "LDAP input file used for test:<br><br>\n";
-			print nl2br($ldap->dump_content($dn, $info));
+			print nl2br($ldap->dumpContent($dn, $info));
 			print "\n<br>";
 		} else {
 			print img_picto('', 'error').' ';

--- a/htdocs/admin/ldap_users.php
+++ b/htdocs/admin/ldap_users.php
@@ -423,7 +423,7 @@ if (function_exists("ldap_connect")) {
 
 		// Test synchro
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 
 		if ($result > 0) {
 			$info = $object->_load_ldap_info();
@@ -466,7 +466,7 @@ if (function_exists("ldap_connect")) {
 
 		// Test synchro
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 
 		if ($result > 0) {
 			$required_fields = array(

--- a/htdocs/contact/ldap.php
+++ b/htdocs/contact/ldap.php
@@ -56,7 +56,7 @@ if ($action == 'dolibarr2ldap') {
 	$db->begin();
 
 	$ldap = new Ldap();
-	$result = $ldap->connect_bind();
+	$result = $ldap->connectBind();
 
 	$info = $object->_load_ldap_info();
 	$dn = $object->_load_ldap_dn($info);
@@ -161,7 +161,7 @@ print '</tr>';
 
 // Lecture LDAP
 $ldap = new Ldap();
-$result = $ldap->connect_bind();
+$result = $ldap->connectBind();
 if ($result > 0) {
 	$info = $object->_load_ldap_info();
 	$dn = $object->_load_ldap_dn($info, 1);

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -322,20 +322,20 @@ class Ldap
 		$ldapdebug = ((empty($dolibarr_main_auth_ldap_debug) || $dolibarr_main_auth_ldap_debug == "false") ? false : true);
 
 		if ($ldapdebug) {
-			dol_syslog(get_class($this)."::connect_bind");
-			print "DEBUG: connect_bind<br>\n";
+			dol_syslog(get_class($this)."::connectBind");
+			print "DEBUG: connectBind<br>\n";
 		}
 
 		// Check parameters
 		if (count($this->server) == 0 || empty($this->server[0])) {
 			$this->error = 'LDAP setup (file conf.php) is not complete';
-			dol_syslog(get_class($this)."::connect_bind ".$this->error, LOG_WARNING);
+			dol_syslog(get_class($this)."::connectBind ".$this->error, LOG_WARNING);
 			return -1;
 		}
 
 		if (!function_exists("ldap_connect")) {
 			$this->error = 'LDAPFunctionsNotAvailableOnPHP';
-			dol_syslog(get_class($this)."::connect_bind ".$this->error, LOG_WARNING);
+			dol_syslog(get_class($this)."::connectBind ".$this->error, LOG_WARNING);
 			return -1;
 		}
 
@@ -351,7 +351,7 @@ class Ldap
 
 				if ($this->serverPing($host, $this->serverPort)) {
 					if ($ldapdebug) {
-						dol_syslog(get_class($this)."::connect_bind serverPing true, we try ldap_connect to ".$host, LOG_DEBUG);
+						dol_syslog(get_class($this)."::connectBind serverPing true, we try ldap_connect to ".$host, LOG_DEBUG);
 					}
 					$this->connection = ldap_connect($host, $this->serverPort);
 				} else {
@@ -359,12 +359,12 @@ class Ldap
 						// With host = ldaps://server, the serverPing to ssl://server sometimes fails, even if the ldap_connect succeed, so
 						// we test this case and continue in such a case even if serverPing fails.
 						if ($ldapdebug) {
-							dol_syslog(get_class($this)."::connect_bind serverPing false, we try ldap_connect to ".$host, LOG_DEBUG);
+							dol_syslog(get_class($this)."::connectBind serverPing false, we try ldap_connect to ".$host, LOG_DEBUG);
 						}
 						$this->connection = ldap_connect($host, $this->serverPort);
 					} else {
 						if ($ldapdebug) {
-							dol_syslog(get_class($this)."::connect_bind serverPing false, no ldap_connect ".$host, LOG_DEBUG);
+							dol_syslog(get_class($this)."::connectBind serverPing false, no ldap_connect ".$host, LOG_DEBUG);
 						}
 						continue;
 					}
@@ -372,7 +372,7 @@ class Ldap
 
 				if (is_resource($this->connection) || is_object($this->connection)) {
 					if ($ldapdebug) {
-						dol_syslog(get_class($this)."::connect_bind this->connection is ok", LOG_DEBUG);
+						dol_syslog(get_class($this)."::connectBind this->connection is ok", LOG_DEBUG);
 					}
 
 					// Upgrade connection to TLS, if requested by the configuration
@@ -384,7 +384,7 @@ class Ldap
 
 						$resulttls = ldap_start_tls($this->connection);
 						if (!$resulttls) {
-							dol_syslog(get_class($this)."::connect_bind failed to start tls", LOG_WARNING);
+							dol_syslog(get_class($this)."::connectBind failed to start tls", LOG_WARNING);
 							$this->error = 'ldap_start_tls Failed to start TLS '.ldap_errno($this->connection).' '.ldap_error($this->connection);
 							$connected = 0;
 							$this->unbind();
@@ -397,7 +397,7 @@ class Ldap
 
 					if ($this->serverType == "activedirectory") {
 						$result = $this->setReferrals();
-						dol_syslog(get_class($this)."::connect_bind try bindauth for activedirectory on ".$host." user=".$this->searchUser." password=".preg_replace('/./', '*', $this->searchPassword), LOG_DEBUG);
+						dol_syslog(get_class($this)."::connectBind try bindauth for activedirectory on ".$host." user=".$this->searchUser." password=".preg_replace('/./', '*', $this->searchPassword), LOG_DEBUG);
 						$this->result = $this->bindauth($this->searchUser, $this->searchPassword);
 						if ($this->result) {
 							$this->bind = $this->result;
@@ -410,7 +410,7 @@ class Ldap
 					} else {
 						// Try in auth mode
 						if ($this->searchUser && $this->searchPassword) {
-							dol_syslog(get_class($this)."::connect_bind try bindauth on ".$host." user=".$this->searchUser." password=".preg_replace('/./', '*', $this->searchPassword), LOG_DEBUG);
+							dol_syslog(get_class($this)."::connectBind try bindauth on ".$host." user=".$this->searchUser." password=".preg_replace('/./', '*', $this->searchPassword), LOG_DEBUG);
 							$this->result = $this->bindauth($this->searchUser, $this->searchPassword);
 							if ($this->result) {
 								$this->bind = $this->result;
@@ -423,7 +423,7 @@ class Ldap
 						}
 						// Try in anonymous
 						if (!$this->bind) {
-							dol_syslog(get_class($this)."::connect_bind try bind anonymously on ".$host, LOG_DEBUG);
+							dol_syslog(get_class($this)."::connectBind try bind anonymously on ".$host, LOG_DEBUG);
 							$result = $this->bind();
 							if ($result) {
 								$this->bind = $this->result;
@@ -444,11 +444,11 @@ class Ldap
 		}
 
 		if ($connected) {
-			dol_syslog(get_class($this)."::connect_bind ".$connected, LOG_DEBUG);
+			dol_syslog(get_class($this)."::connectBind ".$connected, LOG_DEBUG);
 			return $connected;
 		} else {
 			$this->error = 'Failed to connect to LDAP'.($this->error ? ': '.$this->error : '');
-			dol_syslog(get_class($this)."::connect_bind ".$this->error, LOG_WARNING);
+			dol_syslog(get_class($this)."::connectBind ".$this->error, LOG_WARNING);
 			return -1;
 		}
 	}

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -303,7 +303,6 @@ class Ldap
 
 	// Connection handling methods -------------------------------------------
 
-	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *	Connect and bind
 	 * 	Use this->server, this->serverPort, this->ldapProtocolVersion, this->serverType, this->searchUser, this->searchPassword
@@ -311,9 +310,8 @@ class Ldap
 	 *
 	 *	@return		int		if KO: <0 || if bind anonymous: 1 || if bind auth: 2
 	 */
-	public function connect_bind()
+	public function connectBind()
 	{
-		// phpcs:enable
 		global $dolibarr_main_auth_ldap_debug;
 
 		$connected = 0;

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -304,11 +304,12 @@ class Ldap
 	// Connection handling methods -------------------------------------------
 
 	/**
-	 *	Connect and bind
-	 * 	Use this->server, this->serverPort, this->ldapProtocolVersion, this->serverType, this->searchUser, this->searchPassword
-	 * 	After return, this->connection and $this->bind are defined
+	 * Connect and bind
+	 * Use this->server, this->serverPort, this->ldapProtocolVersion, this->serverType, this->searchUser, this->searchPassword
+	 * After return, this->connection and $this->bind are defined
 	 *
-	 *	@return		int		if KO: <0 || if bind anonymous: 1 || if bind auth: 2
+	 * @see connect_bind renamed
+	 * @return		int		if KO: <0 || if bind anonymous: 1 || if bind auth: 2
 	 */
 	public function connectBind()
 	{
@@ -805,11 +806,12 @@ class Ldap
 	}
 
 	/**
-	 * 	Build an LDAP message
+	 * Build an LDAP message
 	 *
-	 *	@param	string		$dn			DN entry key
-	 *	@param	array		$info		Attributes array
-	 *	@return	string					Content of file
+	 * @see dump_content renamed
+	 * @param	string		$dn			DN entry key
+	 * @param	array		$info		Attributes array
+	 * @return	string					Content of file
 	 */
 	public function dumpContent($dn, $info)
 	{

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -804,7 +804,6 @@ class Ldap
 		return -1;
 	}
 
-	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 * 	Build an LDAP message
 	 *
@@ -812,9 +811,8 @@ class Ldap
 	 *	@param	array		$info		Attributes array
 	 *	@return	string					Content of file
 	 */
-	public function dump_content($dn, $info)
+	public function dumpContent($dn, $info)
 	{
-		// phpcs:enable
 		$content = '';
 
 		// Create file content
@@ -854,7 +852,7 @@ class Ldap
 		global $conf;
 		$ldapDirTemp = $conf->ldap->dir_temp;
 		// Create content
-		$content = $this->dump_content($dn, $info);
+		$content = $this->dumpContent($dn, $info);
 
 		//Create directory & file
 		$result = dol_mkdir($ldapDirTemp);

--- a/htdocs/core/login/functions_ldap.php
+++ b/htdocs/core/login/functions_ldap.php
@@ -112,7 +112,7 @@ function check_user_password_ldap($usertotest, $passwordtotest, $entitytotest)
 		// If admin login or ldap auth filter provided
 		// Code to get user in LDAP from an admin connection (may differ from user connection, done later)
 		if ($ldapadminlogin || $dolibarr_main_auth_ldap_filter) {
-			$result = $ldap->connect_bind();
+			$result = $ldap->connectBind();
 			if ($result > 0) {
 				$resultFetchLdapUser = $ldap->fetch($usertotest, $userSearchFilter);
 				//dol_syslog('functions_ldap::check_user_password_ldap resultFetchLdapUser='.$resultFetchLdapUser);
@@ -148,7 +148,7 @@ function check_user_password_ldap($usertotest, $passwordtotest, $entitytotest)
 
 		// Test with this->seachUser and this->searchPassword
 		//print $resultFetchLdapUser."-".$ldap->ldapUserDN."-".$ldap->searchUser.'-'.$ldap->searchPassword;exit;
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 		if ($result > 0) {
 			if ($result == 2) {	// Connection is ok for user/pass into LDAP
 				$login = $usertotest;

--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -83,7 +83,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_SYNCHRO_ACTIVE') && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
@@ -105,7 +105,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_SYNCHRO_ACTIVE') && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
@@ -184,7 +184,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_SYNCHRO_ACTIVE') && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
@@ -217,7 +217,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalInt("LDAP_SYNCHRO_ACTIVE") === Ldap::SYNCHRO_DOLIBARR_TO_LDAP && getDolGlobalString('LDAP_SERVER_TYPE') == "activedirectory") {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
 					$dn = $object->_load_ldap_dn($info);
@@ -246,7 +246,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_SYNCHRO_ACTIVE') && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
@@ -264,7 +264,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_SYNCHRO_ACTIVE') && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
@@ -295,7 +295,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_SYNCHRO_ACTIVE') && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
@@ -328,7 +328,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_SYNCHRO_ACTIVE') && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
@@ -346,7 +346,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_CONTACT_ACTIVE')) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
@@ -363,7 +363,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_CONTACT_ACTIVE')) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
@@ -396,7 +396,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_CONTACT_ACTIVE')) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
@@ -414,7 +414,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_MEMBER_ACTIVE') && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
@@ -459,7 +459,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				// If status field is setup to be synchronized
 				if (getDolGlobalString('LDAP_FIELD_MEMBER_STATUS')) {
 					$ldap = new Ldap();
-					$result = $ldap->connect_bind();
+					$result = $ldap->connectBind();
 
 					if ($result > 0) {
 						$info = $object->_load_ldap_info();
@@ -484,7 +484,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					|| getDolGlobalString('LDAP_FIELD_MEMBER_LASTSUBSCRIPTION_AMOUNT')
 					|| getDolGlobalString('LDAP_FIELD_MEMBER_END_LASTSUBSCRIPTION')) {
 					$ldap = new Ldap();
-					$result = $ldap->connect_bind();
+					$result = $ldap->connectBind();
 
 					if ($result > 0) {
 						$info = $object->_load_ldap_info();
@@ -503,7 +503,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_MEMBER_ACTIVE') && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
@@ -593,7 +593,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				// If password field is setup to be synchronized
 				if (getDolGlobalString('LDAP_FIELD_PASSWORD') || getDolGlobalString('LDAP_FIELD_PASSWORD_CRYPTED')) {
 					$ldap = new Ldap();
-					$result = $ldap->connect_bind();
+					$result = $ldap->connectBind();
 
 					if ($result > 0) {
 						$info = $object->_load_ldap_info();
@@ -614,7 +614,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 				// If status field is setup to be synchronized
 				if (getDolGlobalString('LDAP_FIELD_MEMBER_STATUS')) {
 					$ldap = new Ldap();
-					$result = $ldap->connect_bind();
+					$result = $ldap->connectBind();
 
 					if ($result > 0) {
 						$info = $object->_load_ldap_info();
@@ -633,7 +633,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_MEMBER_ACTIVE') && getDolGlobalInt('LDAP_MEMBER_ACTIVE') == Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
@@ -681,7 +681,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_MEMBER_TYPE_ACTIVE') && getDolGlobalInt('LDAP_MEMBER_TYPE_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();
@@ -703,7 +703,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_MEMBER_TYPE_ACTIVE') && getDolGlobalInt('LDAP_MEMBER_TYPE_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					if (empty($object->oldcopy) || !is_object($object->oldcopy)) {
@@ -740,7 +740,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_MEMBER_TYPE_ACTIVE') && getDolGlobalInt('LDAP_MEMBER_TYPE_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
 				$ldap = new Ldap();
-				$result = $ldap->connect_bind();
+				$result = $ldap->connectBind();
 
 				if ($result > 0) {
 					$info = $object->_load_ldap_info();

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -721,7 +721,7 @@ if (empty($reshook)) {
 		}
 
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 		if ($result >= 0) {
 			// Remove from required_fields all entries not configured in LDAP (empty) and duplicated
 			$required_fields = array_unique(array_values(array_filter($required_fields, "dol_validElement")));
@@ -808,7 +808,7 @@ if ($action == 'create' || $action == 'adduserldap') {
 	if (isModEnabled('ldap') && (isset($conf->global->LDAP_SYNCHRO_ACTIVE) && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_LDAP_TO_DOLIBARR)) {
 		// Show form to add an account from LDAP if sync LDAP -> Dolibarr is set
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 		if ($result >= 0) {
 			$required_fields = array(
 				$conf->global->LDAP_KEY_USERS,
@@ -1415,7 +1415,7 @@ if ($action == 'create' || $action == 'adduserldap') {
 		// pour recuperer passDoNotExpire et userChangePassNextLogon
 		if (isModEnabled('ldap') && !empty($object->ldap_sid)) {
 			$ldap = new Ldap();
-			$result = $ldap->connect_bind();
+			$result = $ldap->connectBind();
 			if ($result > 0) {
 				$userSearchFilter = '(' . getDolGlobalString('LDAP_FILTER_CONNECTION').'('.$ldap->getUserIdentifier().'='.$object->login.'))';
 				$entries = $ldap->fetch($object->login, $userSearchFilter);

--- a/htdocs/user/group/ldap.php
+++ b/htdocs/user/group/ldap.php
@@ -63,7 +63,7 @@ if (getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
 
 if ($action == 'dolibarr2ldap') {
 	$ldap = new Ldap();
-	$result = $ldap->connect_bind();
+	$result = $ldap->connectBind();
 
 	if ($result > 0) {
 		$info = $object->_load_ldap_info();
@@ -174,7 +174,7 @@ print '</tr>';
 
 // Lecture LDAP
 $ldap = new Ldap();
-$result = $ldap->connect_bind();
+$result = $ldap->connectBind();
 if ($result > 0) {
 	$info = $object->_load_ldap_info();
 	$dn = $object->_load_ldap_dn($info, 1);

--- a/htdocs/user/ldap.php
+++ b/htdocs/user/ldap.php
@@ -66,7 +66,7 @@ if ($reshook < 0) {
 if (empty($reshook)) {
 	if ($action == 'dolibarr2ldap') {
 		$ldap = new Ldap();
-		$result = $ldap->connect_bind();
+		$result = $ldap->connectBind();
 
 		if ($result > 0) {
 			$info = $object->_load_ldap_info();
@@ -124,7 +124,7 @@ print '</tr>';
 
 if (getDolGlobalString('LDAP_SERVER_TYPE') == "activedirectory") {
 	$ldap = new Ldap();
-	$result = $ldap->connect_bind();
+	$result = $ldap->connectBind();
 	if ($result > 0) {
 		$userSID = $ldap->getObjectSid($object->login);
 	}
@@ -181,7 +181,7 @@ print '</tr>';
 
 // Lecture LDAP
 $ldap = new Ldap();
-$result = $ldap->connect_bind();
+$result = $ldap->connectBind();
 if ($result > 0) {
 	$info = $object->_load_ldap_info();
 	$dn = $object->_load_ldap_dn($info, 1);

--- a/scripts/company/sync_contacts_dolibarr2ldap.php
+++ b/scripts/company/sync_contacts_dolibarr2ldap.php
@@ -121,7 +121,7 @@ if ($resql) {
 	$i = 0;
 
 	$ldap = new Ldap();
-	$ldap->connect_bind();
+	$ldap->connectBind();
 
 	while ($i < $num) {
 		$ldap->error = "";

--- a/scripts/members/sync_members_dolibarr2ldap.php
+++ b/scripts/members/sync_members_dolibarr2ldap.php
@@ -122,7 +122,7 @@ if ($resql) {
 	$i = 0;
 
 	$ldap = new Ldap();
-	$ldap->connect_bind();
+	$ldap->connectBind();
 
 	while ($i < $num) {
 		$ldap->error = "";

--- a/scripts/members/sync_members_ldap2dolibarr.php
+++ b/scripts/members/sync_members_ldap2dolibarr.php
@@ -187,7 +187,7 @@ if ($resql) {
 }
 
 $ldap = new Ldap();
-$result = $ldap->connect_bind();
+$result = $ldap->connectBind();
 if ($result >= 0) {
 	$justthese = array();
 	$pricefirst = 0;

--- a/scripts/members/sync_members_types_dolibarr2ldap.php
+++ b/scripts/members/sync_members_types_dolibarr2ldap.php
@@ -87,7 +87,7 @@ if ($resql) {
 	$i = 0;
 
 	$ldap = new Ldap();
-	$result = $ldap->connect_bind();
+	$result = $ldap->connectBind();
 
 	if ($result > 0) {
 		while ($i < $num) {

--- a/scripts/members/sync_members_types_ldap2dolibarr.php
+++ b/scripts/members/sync_members_types_ldap2dolibarr.php
@@ -128,7 +128,7 @@ if (!getDolGlobalString('LDAP_MEMBER_TYPE_DN')) {
 }
 
 $ldap = new Ldap();
-$result = $ldap->connect_bind();
+$result = $ldap->connectBind();
 if ($result >= 0) {
 	$justthese = array();
 

--- a/scripts/user/sync_groups_dolibarr2ldap.php
+++ b/scripts/user/sync_groups_dolibarr2ldap.php
@@ -79,7 +79,7 @@ if ($resql) {
 	$i = 0;
 
 	$ldap = new Ldap();
-	$ldap->connect_bind();
+	$ldap->connectBind();
 
 	while ($i < $num) {
 		$ldap->error = "";

--- a/scripts/user/sync_groups_ldap2dolibarr.php
+++ b/scripts/user/sync_groups_ldap2dolibarr.php
@@ -127,7 +127,7 @@ if (!getDolGlobalString('LDAP_GROUP_DN')) {
 }
 
 $ldap = new Ldap();
-$result = $ldap->connect_bind();
+$result = $ldap->connectBind();
 if ($result >= 0) {
 	$justthese = array();
 

--- a/scripts/user/sync_users_dolibarr2ldap.php
+++ b/scripts/user/sync_users_dolibarr2ldap.php
@@ -79,7 +79,7 @@ if ($resql) {
 	$i = 0;
 
 	$ldap = new Ldap();
-	$ldap->connect_bind();
+	$ldap->connectBind();
 
 	while ($i < $num) {
 		$ldap->error = "";

--- a/scripts/user/sync_users_ldap2dolibarr.php
+++ b/scripts/user/sync_users_ldap2dolibarr.php
@@ -173,7 +173,7 @@ if ($resql) {
 }
 
 $ldap = new Ldap();
-$result = $ldap->connect_bind();
+$result = $ldap->connectBind();
 if ($result >= 0) {
 	$justthese = array();
 


### PR DESCRIPTION
# Qual fix phpcs ldap class methods
This PR renames **connect_bind** & **dump_content** methods to remove disabled PHPCS warnings.
I've tested this with our LDAP server.

