### PR TITLE
qual: phpstan for htdocs/adherents/class/adherent_type.class.php

### DIFF
--- a/htdocs/adherents/class/adherent_type.class.php
+++ b/htdocs/adherents/class/adherent_type.class.php
@@ -126,9 +126,6 @@ class AdherentType extends CommonObject
 	/** @var array Array of members */
 	public $members = array();
 
-	/** @var string string other */
-	public $other = array();
-
 	/**
 	 * @var string description
 	 */


### PR DESCRIPTION
htdocs/adherents/class/adherent_type.class.php	130	Property AdherentType::$other (string) does not accept default value of type array.

I'm not sur why the variable `$other` is declared:
- It is not used in its own class `adherent_type.class.php`
- It is not declared nor found in its parent class `htdocs/core/class/commonobject.class.php`