### PR TITLE
FIX: Update expedition.class.php to add product width and height in addition to length

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2740,13 +2740,13 @@ class ExpeditionLigne extends CommonObjectLine
  	* @var float width
   	*/
 	public $width;
-    public $width_units;
+	public $width_units;
 
 	/**
-	* @var float height
-	*/
-    public $height;
-    public $height_units;
+ 	* @var float height
+ 	*/
+	public $height;
+	public $height_units;
 
 	/**
 	* @var float surface

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1595,7 +1595,7 @@ class Expedition extends CommonObject
 		$sql .= ", cd.fk_multicurrency, cd.multicurrency_code, cd.multicurrency_subprice, cd.multicurrency_total_ht, cd.multicurrency_total_tva, cd.multicurrency_total_ttc, cd.rang";
 		$sql .= ", ed.rowid as line_id, ed.qty as qty_shipped, ed.fk_origin_line, ed.fk_entrepot";
 		$sql .= ", p.ref as product_ref, p.label as product_label, p.fk_product_type, p.barcode as product_barcode";
-		$sql .= ", p.weight, p.weight_units, p.length, p.length_units, p.surface, p.surface_units, p.volume, p.volume_units, p.tosell as product_tosell, p.tobuy as product_tobuy, p.tobatch as product_tobatch";
+		$sql .= ", p.weight, p.weight_units, p.length, p.length_units, p.width, p.width_units, p.height, p.height_units, p.surface, p.surface_units, p.volume, p.volume_units, p.tosell as product_tosell, p.tobuy as product_tobuy, p.tobatch as product_tobatch";
 		$sql .= " FROM ".MAIN_DB_PREFIX."expeditiondet as ed, ".MAIN_DB_PREFIX."commandedet as cd";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p ON p.rowid = cd.fk_product";
 		$sql .= " WHERE ed.fk_expedition = ".((int) $this->id);
@@ -1672,6 +1672,10 @@ class Expedition extends CommonObject
 				$line->weight_units   	= $obj->weight_units;
 				$line->length         	= $obj->length;
 				$line->length_units   	= $obj->length_units;
+				$line->width           = $obj->width;
+                $line->width_units     = $obj->width_units;
+                $line->height           = $obj->height;
+                $line->height_units     = $obj->height_units;
 				$line->surface        	= $obj->surface;
 				$line->surface_units = $obj->surface_units;
 				$line->volume         	= $obj->volume;
@@ -2727,19 +2731,30 @@ class ExpeditionLigne extends CommonObjectLine
 	public $weight_units;
 
 	/**
-	 * @var float weight
+	 * @var float lenght
 	 */
 	public $length;
 	public $length_units;
+	
+     /**
+	 * @var float width
+	 */
+	public $width;
+    public $width_units;
+     /**
+	 * @var float height
+	 */
+    public $height;
+    public $height_units;
 
 	/**
-	 * @var float weight
+	 * @var float surface
 	 */
 	public $surface;
 	public $surface_units;
 
 	/**
-	 * @var float weight
+	 * @var float volume
 	 */
 	public $volume;
 	public $volume_units;

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2731,7 +2731,7 @@ class ExpeditionLigne extends CommonObjectLine
 	public $weight_units;
 
 	/**
-	* @var float lenght
+	* @var float length
 	*/
 	public $length;
 	public $length_units;

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2726,7 +2726,7 @@ class ExpeditionLigne extends CommonObjectLine
 
 	/**
 	* @var float weight
- 	*/
+	*/
 	public $weight;
 	public $weight_units;
 
@@ -2737,14 +2737,14 @@ class ExpeditionLigne extends CommonObjectLine
 	public $length_units;
 
 	/**
- 	* @var float width
-  	*/
+	* @var float width
+	*/
 	public $width;
 	public $width_units;
 
 	/**
- 	* @var float height
- 	*/
+	* @var float height
+	*/
 	public $height;
 	public $height_units;
 

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1673,9 +1673,9 @@ class Expedition extends CommonObject
 				$line->length         	= $obj->length;
 				$line->length_units   	= $obj->length_units;
 				$line->width           = $obj->width;
-                $line->width_units     = $obj->width_units;
-                $line->height           = $obj->height;
-                $line->height_units     = $obj->height_units;
+				$line->width_units     = $obj->width_units;
+				$line->height           = $obj->height;
+				$line->height_units     = $obj->height_units;
 				$line->surface        	= $obj->surface;
 				$line->surface_units = $obj->surface_units;
 				$line->volume         	= $obj->volume;
@@ -2720,42 +2720,43 @@ class ExpeditionLigne extends CommonObjectLine
 	public $product_type = 0;
 
 	/**
-	 * @var int rang of line
-	 */
+	* @var int rang of line
+	*/
 	public $rang;
 
 	/**
-	 * @var float weight
-	 */
+	* @var float weight
+ 	*/
 	public $weight;
 	public $weight_units;
 
 	/**
-	 * @var float lenght
-	 */
+	* @var float lenght
+	*/
 	public $length;
 	public $length_units;
-	
-     /**
-	 * @var float width
-	 */
+
+	/**
+ 	* @var float width
+  	*/
 	public $width;
     public $width_units;
-     /**
-	 * @var float height
-	 */
+
+	/**
+	* @var float height
+	*/
     public $height;
     public $height_units;
 
 	/**
-	 * @var float surface
-	 */
+	* @var float surface
+	*/
 	public $surface;
 	public $surface_units;
 
 	/**
-	 * @var float volume
-	 */
+	* @var float volume
+	*/
 	public $volume;
 	public $volume_units;
 


### PR DESCRIPTION
# Instructions

It is possible to use the length in an expedition document (pdf) but not the product width / height.

Added the missing fields to the query and object build, fixed some copy & paste typos

