### PR TITLE
FIX: 'user_logo' in the user substitution array, it results in a <ErrorFileNotFound>

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -193,7 +193,7 @@ abstract class CommonDocGenerator
 		// phpcs:enable
 		global $conf, $extrafields;
 
-		$logotouse = $conf->user->dir_output.'/'.get_exdir($user->id, 2, 0, 1, $user, 'user').'/'.$user->photo;
+		$logotouse = $conf->user->dir_output . '/' . get_exdir(0, 0, 0, 0, $user, 'user') . 'photos/' . getImageFileNameForSize($user->photo, '_small');
 
 		$array_user = array(
 			'myuser_lastname'=>$user->lastname,


### PR DESCRIPTION
myuser_logo in user substitution array result in a **ErrorFileNotFound** appear in generated odt (template_user.odt) and every custom odt template.

This error is caused by not reading from the /photos directory where the profile image is stored alongside with thumbs.

Note: We use the small variant because its size makes it look perfect in the generated docs.