### PR TITLE
FIX Contract expired services link

### DIFF
--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -1435,7 +1435,7 @@ function get_left_menu_commercial($mainmenu, &$newmenu, $usemenuhider = 1, $left
 			if ($usemenuhider || empty($leftmenu) || $leftmenu == "contracts") {
 				$newmenu->add("/contrat/services_list.php?leftmenu=contracts&amp;search_status=0", $langs->trans("MenuInactiveServices"), 2, $user->hasRight('contrat', 'lire'));
 				$newmenu->add("/contrat/services_list.php?leftmenu=contracts&amp;search_status=4", $langs->trans("MenuRunningServices"), 2, $user->hasRight('contrat', 'lire'));
-				$newmenu->add("/contrat/services_list.php?leftmenu=contracts&amp;search_status=4&filter=expired", $langs->trans("MenuExpiredServices"), 2, $user->hasRight('contrat', 'lire'));
+				$newmenu->add("/contrat/services_list.php?leftmenu=contracts&amp;search_status=4%26filter=expired", $langs->trans("MenuExpiredServices"), 2, $user->hasRight('contrat', 'lire'));
 				$newmenu->add("/contrat/services_list.php?leftmenu=contracts&amp;search_status=5", $langs->trans("MenuClosedServices"), 2, $user->hasRight('contrat', 'lire'));
 			}
 		}


### PR DESCRIPTION
# FIX Contract expired services link
In order for code from #27970 #26664 in 5dbecd7 to work and #26283 to be fixed the **url** in the expired services link needs to be adjusted. The `filter` parameter needs to be included within the `status` parameter. The `&` character needs a specific http url encoding by using `%26`

Screenshots of GET before fix :

![Contracts Expired services GET with filter](https://github.com/Dolibarr/dolibarr/assets/31100265/2de81396-af5d-425d-aeb4-aceab4f33a7e)

Screenshots of GET after fix :

![Contracts Expired services GET without filter](https://github.com/Dolibarr/dolibarr/assets/31100265/8f2fff9c-1ff1-4fe3-a705-a19e91bc781d)

