### PR TITLE
fix: auto generated user login 'undefined' appears on login input)[fi…

### DIFF
--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -948,7 +948,7 @@ if ($action == 'create' || $action == 'adduserldap') {
 					login = "";
 					if(lastname) {
 						if(firstname) {
-							login = firstname + ".";
+							login = firstname + "'. getDolGlobalString("MAIN_USER_SEPARATOR_CHAR_FOR_GENERATED_LOGIN", "").'";
 						}
 						login += lastname;					
 					}

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -941,15 +941,19 @@ if ($action == 'create' || $action == 'adduserldap') {
 		print '<script>
 			jQuery(document).ready(function() {
 				$(".createloginauto").on("change", function(){
-					lastname = $("#lastname").val();
-					firstname = $("#firstname").val();
-					if($(this).attr("id") == "firstname"){
-						firstname = firstname.toLowerCase();
-						firstname = firstname[0];
+					lastname = $("#lastname").val().toLowerCase();
+					firstname = $("#firstname").val().toLowerCase()[0];
+
+					console.log("We generate login intell we have a valid lastname");
+					login = "";
+					if(lastname) {
+						if(firstname) {
+							login = firstname + ".";
+						}
+						login += lastname;					
 					}
-					lastname = lastname.toLowerCase();
 					console.log("We create a login from firstname and lastname");
-					$("#login").val(firstname+lastname);
+					$("#login").val(login);
 				})
 			});
 		</script>';


### PR DESCRIPTION
fix: auto generated user login 'undefined' appears on login input)[fix: auto generated user login 'undefined' appears on login input

When We enter a lastname then we enter a firstname the generated login looks fine
Example:
    - lastname = Yacine
    - firstname = Ahmaich
    - login = yahmaich
But if we clear the firstname or the lastname we got
    - lastname = Yacine
    - firstname =  // we clear the value of firstname
    - login = yundefined

I fix the issue and also add a dot in the generated login because 'y.ahmaich' as login looks better than 'yahmaich'