### PR TITLE
Qual phpstan utils class

### DIFF
--- a/htdocs/core/class/utils.class.php
+++ b/htdocs/core/class/utils.class.php
@@ -1380,7 +1380,7 @@ class Utils
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
 
-		$this->error = strval($error);
+		$this->error = "Error sending backp file ".((string) $error);
 		$this->output = $output;
 
 		if ($result) {

--- a/htdocs/core/class/utils.class.php
+++ b/htdocs/core/class/utils.class.php
@@ -1,8 +1,8 @@
 <?php
-/* Copyright (C) 2016	Laurent Destailleur <eldy@users.sourceforge.net>
- * Copyright (C) 2021	Regis Houssin		<regis.houssin@inodbox.com>
- * Copyright (C) 2022	Anthony Berton		<anthony.berton@bb2a.fr>
- * Copyright (C) 2023	William Mead		<william.mead@manchenumerique.fr>
+/* Copyright (C) 2016		Laurent Destailleur <eldy@users.sourceforge.net>
+ * Copyright (C) 2021		Regis Houssin		<regis.houssin@inodbox.com>
+ * Copyright (C) 2022		Anthony Berton		<anthony.berton@bb2a.fr>
+ * Copyright (C) 2023-2024	William Mead		<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1369,9 +1369,10 @@ class Utils
 			}
 		}
 
+		$result = false;
 		if (!$error) {
 			$result = $mailfile->sendfile();
-			if ($result <= 0) {
+			if (!$result) {
 				$error++;
 				$output = $mailfile->error;
 			}
@@ -1379,13 +1380,13 @@ class Utils
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
 
-		$this->error = $error;
+		$this->error = strval($error);
 		$this->output = $output;
 
-		if ($result == true) {
+		if ($result) {
 			return 0;
 		} else {
-			return $result;
+			return -1;
 		}
 	}
 


### PR DESCRIPTION
# Qual utils.class.php phpstan lvl3
htdocs/core/class/utils.class.php	1382	Property Utils::$error (string) does not accept int.
htdocs/core/class/utils.class.php	1388	Method Utils::sendBackup() should return int but returns false.

Fixed with PR #27974 :
htdocs/core/class/utils.class.php	1444	Property Cronjob::$pid (int) does not accept null.