### PR TITLE
FIX: Reduction Input wasn't recovered properly

### DIFF
--- a/htdocs/takepos/reduction.php
+++ b/htdocs/takepos/reduction.php
@@ -171,6 +171,7 @@ if (!isset($conf->global->TAKEPOS_NUMPAD_USE_PAYMENT_ICON) || !empty($conf->glob
 	function ValidateReduction()
 	{
 		console.log('ValidateReduction');
+		reductionTotal = jQuery('#reduction_total').val();
 
 		if (reductionTotal.length <= 0) {
 			console.error('Error no reduction');


### PR DESCRIPTION
A bug was detected on the takepos reduction screen. It was possible to add a reduction by tapping on the screen, but not by keyboard input. This was due to incorrect retrieval of the input field by JS. In the first case, the reductionTotal variable was defined in the AddReduction function, but this function is not called when there is a keyboard entry. 


[capture-video-du-05-02-2024-121040_6LXCh86p.webm](https://github.com/Dolibarr/dolibarr/assets/58433943/3bcd6fb4-c211-4ccc-b31c-968cdf1ef3c6)
