### PR TITLE
Qual: pre-commit: run phpcs on all files in 'main' branches.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -65,7 +65,17 @@ jobs:
 
       - name: Setup PHPCS
         uses: shivammathur/setup-php@v2
-        if: steps.changed-php.outputs.any_changed == 'true'
+        # Install when we're going to run phpcs
+        if: |
+         steps.changed-php.outputs.any_changed == 'true'
+         ||
+         (
+           github.event_name == 'push'
+           && (
+                github.event.ref == 'refs/heads/develop'
+              || endsWith(github.event.ref, '.0')
+           )
+         )
         with:
           php-version: 8.1
           coverage: none  # disable xdebug, pcov
@@ -78,6 +88,17 @@ jobs:
         run: |
           set -o pipefail
           pre-commit run php-cs --files ${ALL_CHANGED_FILES} | tee -a ${RAW_LOG}
+
+      - name: Run some pre-commit hooks on all files on push to "main" branches
+        if: |
+         github.event_name == 'push'
+         && (
+              github.event.ref == 'refs/heads/develop'
+            || endsWith(github.event.ref, '.0')
+         )
+        run: |
+          set -o pipefail
+          pre-commit run -a php-cs | tee -a ${RAW_LOG}
 
       # If error, we convert log in the checkstyle format
       - name: Convert Raw Log to CheckStyle format


### PR DESCRIPTION
This change to the workflow will run phpcs on all files in develop, 17.0, 18.0, ... (rule== branch ends in .0).

This ensures that phpcs is run in a github workflow for fast phpcs issue detection in the develop and other main branches.

Ultimately, this means that the PHPCS action can be disabled in branches where it is active.  But I propose to verify that the updated action does the job as expected (tested in a fork it is ok).