### PR TITLE
NEW: FormSetupItem: show picto in front of confs applied across all entitie

### DIFF
--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -825,7 +825,12 @@ class FormSetupItem
 		if (!empty($this->nameText)) {
 			return $this->nameText;
 		}
-		return (($this->langs->trans($this->confKey) != $this->confKey) ? $this->langs->trans($this->confKey) : $this->langs->trans('MissingTranslationForConfKey', $this->confKey));
+		$out = (($this->langs->trans($this->confKey) != $this->confKey) ? $this->langs->trans($this->confKey) : $this->langs->trans('MissingTranslationForConfKey', $this->confKey));
+
+		// if conf defined on entity 0, prepend a picto to indicate it will apply across all entities
+		if ($this->entity == 0) $out = $out . '<span class="fas fa-globe-americas pictofixedwidth" style="color: #aaa;"></span> ';
+
+		return $out;
 	}
 
 	/**

--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -828,7 +828,7 @@ class FormSetupItem
 		$out = (($this->langs->trans($this->confKey) != $this->confKey) ? $this->langs->trans($this->confKey) : $this->langs->trans('MissingTranslationForConfKey', $this->confKey));
 
 		// if conf defined on entity 0, prepend a picto to indicate it will apply across all entities
-		if ($this->entity == 0) $out = $out . '<span class="fas fa-globe-americas pictofixedwidth" style="color: #aaa;"></span> ';
+		if (isModEnabled('multicompany') && $this->entity == 0) img_picto($this->langs->trans('AllEntities'), 'fa-globe-americas em088 opacityhigh') . '&nbsp;' . $out;
 
 		return $out;
 	}

--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -828,7 +828,7 @@ class FormSetupItem
 		$out = (($this->langs->trans($this->confKey) != $this->confKey) ? $this->langs->trans($this->confKey) : $this->langs->trans('MissingTranslationForConfKey', $this->confKey));
 
 		// if conf defined on entity 0, prepend a picto to indicate it will apply across all entities
-		if (isModEnabled('multicompany') && $this->entity == 0) img_picto($this->langs->trans('AllEntities'), 'fa-globe-americas em088 opacityhigh') . '&nbsp;' . $out;
+		if (isModEnabled('multicompany') && $this->entity == 0) $out = img_picto($this->langs->trans('AllEntities'), 'fa-globe-americas em088 opacityhigh') . '&nbsp;' . $out;
 
 		return $out;
 	}


### PR DESCRIPTION
# NEW: in Setup pages, show a picto before name of confs applied to all entities
Unless overridden, it will inform the user whenever a conf shown by FormSetup is set on entity 0 (i.e. applies to all entities).


```php
$formSetup = new FormSetup($db);
// […]
$item = $formSetup->newItem('ALERT_THRESHOLD_PERCENT');
$item->entity = 0; // set conf as cross-entity
// […]
print $formSetup->generateOutput();
```

This is how it looks:
![image](https://github.com/Dolibarr/dolibarr/assets/50440633/21bc78ae-c64c-44ad-97e8-cce3a23b836f)

