### PR TITLE
FIX:  extrafields linked object type on external module object

### DIFF
--- a/htdocs/core/ajax/selectobject.php
+++ b/htdocs/core/ajax/selectobject.php
@@ -53,7 +53,7 @@ if (empty($htmlname)) {
 	httponly_accessforbidden('Bad value for param htmlname');
 }
 
-if (!empty($objectfield)) {
+if (!empty($objectfield && empty($objectdesc))) {
 	// Recommended method to call selectobject.
 	// $objectfield is Object:Field that contains the definition (in table $fields or extrafield). Example: 'Societe:t.ddd' or 'Societe:options_xxx'
 

--- a/htdocs/core/ajax/selectobject.php
+++ b/htdocs/core/ajax/selectobject.php
@@ -53,7 +53,7 @@ if (empty($htmlname)) {
 	httponly_accessforbidden('Bad value for param htmlname');
 }
 
-if (!empty($objectfield && empty($objectdesc))) {
+if (!empty($objectfield) && empty($objectdesc)) {
 	// Recommended method to call selectobject.
 	// $objectfield is Object:Field that contains the definition (in table $fields or extrafield). Example: 'Societe:t.ddd' or 'Societe:options_xxx'
 

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1601,7 +1601,7 @@ class ExtraFields
 			}
 
 			//$out = $form->selectForForms($param_list[0], $keyprefix.$key.$keysuffix, $value, $showempty, '', '', $morecss, '', 0, 0, '');
-			$out = $form->selectForForms($tmparray, $keyprefix.$key.$keysuffix, $value, $showempty, '', '', $morecss, '', 0, 0, '', $element.':options_'.$key);
+			$out = $form->selectForForms($param_list[0], $keyprefix.$key.$keysuffix, $value, $showempty, '', '', $morecss, '', 0, 0, '', $element.':options_'.$key);
 		} elseif ($type == 'password') {
 			// If prefix is 'search_', field is used as a filter, we use a common text field.
 			$out = '<input style="display:none" type="text" name="fakeusernameremembered">'; // Hidden field to reduce impact of evil Google Chrome autopopulate bug.

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1596,7 +1596,7 @@ class ExtraFields
 			$element = $extrafieldsobjectkey;		// $extrafieldsobjectkey comes from $object->table_element but we need $object->element
 			if ($element == 'socpeople') {
 				$element = 'contact';
-			} else if ( $element == 'projet' ) {
+			} elseif ( $element == 'projet' ) {
 				$element = 'project';
 			}
 

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1601,7 +1601,7 @@ class ExtraFields
 			}
 
 			//$out = $form->selectForForms($param_list[0], $keyprefix.$key.$keysuffix, $value, $showempty, '', '', $morecss, '', 0, 0, '');
-			$out = $form->selectForForms($tmparray[0], $keyprefix.$key.$keysuffix, $value, $showempty, '', '', $morecss, '', 0, 0, '', $element.':options_'.$key);
+			$out = $form->selectForForms($tmparray, $keyprefix.$key.$keysuffix, $value, $showempty, '', '', $morecss, '', 0, 0, '', $element.':options_'.$key);
 		} elseif ($type == 'password') {
 			// If prefix is 'search_', field is used as a filter, we use a common text field.
 			$out = '<input style="display:none" type="text" name="fakeusernameremembered">'; // Hidden field to reduce impact of evil Google Chrome autopopulate bug.

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8037,7 +8037,7 @@ class Form
 		$objecttmp = null;
 		$InfoFieldList = array();
 
-		if ($objectfield) {	// We must retreive the objectdesc from the field or extrafield
+		if ($objectfield && empty($objectdesc)) {	// We must retreive the objectdesc if empty from the field or extrafield
 			// Example: $objectfield = 'product:options_package'
 			$tmparray = explode(':', $objectfield);
 			$objectdesc = '';

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8037,7 +8037,7 @@ class Form
 		$objecttmp = null;
 		$InfoFieldList = array();
 
-		if ($objectfield && empty($objectdesc)) {	// We must retreive the objectdesc if empty from the field or extrafield
+		if ($objectfield && empty($objectdesc)) {	// We must retrieve the objectdesc, if empty, from the field or extrafield
 			// Example: $objectfield = 'product:options_package'
 			$tmparray = explode(':', $objectfield);
 			$objectdesc = '';


### PR DESCRIPTION
# FIX : test linkedObject extrafield type

When adding an extrafields of type linkedObject to an object from an external module, on a record of the object to which this extrafields is added and on the list, errors may occur sometimes, especially if ajax_autocompleter is called.

In selectobject.php, the test is only performed on objectfield, which is the calling object, without checking for the presence of objectdesc, which is the linked object type.

I have added this test in this file as well as in html.form.class.php.

In the call of the selectForForms function, I pass the complete array so that it remains operational in the following functions.