### PR TITLE
Fixed undefined thirdparty_id property

### DIFF
--- a/htdocs/core/tpl/contacts.tpl.php
+++ b/htdocs/core/tpl/contacts.tpl.php
@@ -201,6 +201,7 @@ foreach (array('internal', 'external') as $source) {
 		$entry->type = $contact['libelle'];
 		$entry->nature = "";
 		$entry->nature_html = "";
+		$entry->thirdparty_id = 0;
 		$entry->thirdparty_html = "";
 		$entry->thirdparty_name = "";
 		$entry->contact_html = "";


### PR DESCRIPTION
# Fix undefined thirdparty_id property
On some contacts tabs (commercial proposal, resource, etc ...) the following error was thrown :
_Undefined property: stdClass::$thirdparty_id (/var/www/dolibarr/19.0/htdocs/core/tpl/contacts.tpl.php:307)_
