### PR TITLE
qual: phpstan for htdocs/core/class/commonobject.class.php

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9601,7 +9601,7 @@ abstract class CommonObject
 	 *
 	 * @param 	string|int	$value			Value to protect
 	 * @param	array		$fieldsentry	Properties of field
-	 * @return 	string
+	 * @return 	string|int
 	 */
 	protected function quote($value, $fieldsentry)
 	{


### PR DESCRIPTION
htdocs/core/class/commonobject.class.php	9613	Method CommonObject::quote() should return string but returns int.