### PR TITLE
Fix PHPStan undefined hookmanager in accountingaccount class

### DIFF
--- a/htdocs/accountancy/class/accountingaccount.class.php
+++ b/htdocs/accountancy/class/accountingaccount.class.php
@@ -740,6 +740,7 @@ class AccountingAccount extends CommonObject
 	 */
 	public function getAccountingCodeToBind(Societe $buyer, Societe $seller, Product $product, $facture, $factureDet, $accountingAccount = array(), $type = '')
 	{
+		global $hookmanager;
 		// Instantiate hooks for external modules
 		$hookmanager->initHooks(array('accountancyBindingCalculation'));
 


### PR DESCRIPTION
# Fix PHPStan undefined hookmanager in accountingaccount class
htdocs/accountancy/class/accountingaccount.class.php	744	Undefined variable: $hookmanager
htdocs/accountancy/class/accountingaccount.class.php	748	Undefined variable: $hookmanager
htdocs/accountancy/class/accountingaccount.class.php	941	Undefined variable: $hookmanager
htdocs/accountancy/class/accountingaccount.class.php	941	Variable $hookmanager in empty() is never defined.
htdocs/accountancy/class/accountingaccount.class.php	942	Undefined variable: $hookmanager

