### PR TITLE
Qual: Lower severity on php-cs messages that should not block

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         args: [--standard=dev/setup/codesniffer/ruleset.xml]
       - id: php-cs
         files: \.(php)$
-        args: [--standard=dev/setup/codesniffer/ruleset.xml, --report=emacs]
+        args: [--standard=dev/setup/codesniffer/ruleset.xml, --report=emacs, --severity=5]
       - id: php-lint
       - id: php-stan
         stages: [manual]

--- a/dev/setup/codesniffer/ruleset.xml
+++ b/dev/setup/codesniffer/ruleset.xml
@@ -68,6 +68,17 @@
 		<severity>0</severity>
     </rule>
 
+    <!-- Lower severity on warnings we do not want to show in the pre-commit reports -->
+    <rule ref="Generic.Files.LineLength.TooLong">
+		<severity>4</severity>
+    </rule>
+    <rule ref="Generic.Metrics.CyclomaticComplexity.TooHigh">
+		<severity>4</severity>
+    </rule>
+    <rule ref="Generic.Metrics.NestingLevel.TooHigh">
+		<severity>4</severity>
+    </rule>
+
 
     <!-- Warnings on TODO -->
     <!-- Disabled: We want to keep TODO as normal


### PR DESCRIPTION
# Qual: Lower severity on php-cs messages that should not block

Some warning messages result in php-cs having an exit code of 2 and others only have an exit ocde of 1.  When the exit code is 2, the warnings are fixable by php-cbf.

In order to be able to filter on the warnings in the github ci flow, but still show them in the travis flow, I lower the level of the warnings that should not be blocking to 4.

At the same time, the php-cs configuration in pre-commit now requires that the severity is minimum 5 to show the message (level 5 is the default for all warnings and errors).

So this will limit the warning messages to the ones that should result in a failing ci action.  If any new cases are discovered, they should also be lowered in the php-cs configuration file.