### PR TITLE
Qual: ci: Run pre-commit/php-cs with cache

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,7 +24,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           files: |
-             **.php
+            **.php
 
       # Checkout git sources to analyze
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           cache: pip
-          python-version: '3.11'
+          python-version: "3.11"
       - run: python -m pip install pre-commit regex
       # Restore previous cache of precommit
       - uses: actions/cache/restore@v4
@@ -68,18 +68,18 @@ jobs:
         uses: shivammathur/setup-php@v2
         # Install when we're going to run phpcs
         if: |
-         steps.changed-php.outputs.any_changed == 'true'
-         ||
-         (
-           github.event_name == 'push'
-           && (
-                github.event.ref == 'refs/heads/develop'
-              || endsWith(github.event.ref, '.0')
-           )
-         )
+          steps.changed-php.outputs.any_changed == 'true'
+          ||
+          (
+            github.event_name == 'push'
+            && (
+                 github.event.ref == 'refs/heads/develop'
+               || endsWith(github.event.ref, '.0')
+            )
+          )
         with:
           php-version: 8.1
-          coverage: none  # disable xdebug, pcov
+          coverage: none # disable xdebug, pcov
           tools: phpcs
 
       - name: Run some pre-commit hooks on selected changed files only
@@ -92,14 +92,16 @@ jobs:
 
       - name: Run some pre-commit hooks on all files on push to "main" branches
         if: |
-         github.event_name == 'push'
-         && (
-              github.event.ref == 'refs/heads/develop'
-            || endsWith(github.event.ref, '.0')
-         )
+          github.event_name == 'push'
+          && (
+               github.event.ref == 'refs/heads/develop'
+             || endsWith(github.event.ref, '.0')
+          )
         run: |
           set -o pipefail
-          pre-commit run -a php-cs | tee -a ${RAW_LOG}
+          ln -sf ~/.cache .cache  # Absolute path in .pre-commit-config.yaml
+          pre-commit run --hook-stage manual -a php-cs-with-cache | tee -a ${RAW_LOG}
+          ls -l ~/.cache/pre-commit/
 
       # If error, we convert log in the checkstyle format
       - name: Convert Raw Log to CheckStyle format
@@ -112,15 +114,14 @@ jobs:
         if: ${{ failure() }}
         with:
           files: ${{ env.CS_XML }}
-          notices-as-warnings: true  # optional
-          prepend-filename: true  # optional
+          notices-as-warnings: true # optional
+          prepend-filename: true # optional
       # Save the precommit cache
       - uses: actions/cache/save@v4
         if: ${{ ! cancelled() }}
         with:
           path: ~/.cache/pre-commit/
-          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml')
-            }}
+          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       # Upload result log files of precommit into the Artifact shared store
       - name: Provide log as artifact
         uses: actions/upload-artifact@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,8 @@ repos:
       - id: check-merge-conflict
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
-        exclude: (?x)^( dev/tools/dolibarr-postgres2mysql.php |test/other/test_serialize.php
+        exclude:
+          (?x)^( dev/tools/dolibarr-postgres2mysql.php |test/other/test_serialize.php
           |test/phpunit/textutf8.txt |test/phpunit/textiso.txt |htdocs/includes/.*
           |htdocs/modulebuilder/template/.* |build/debian/dolibarr.postrm |build/debian/dolibarr.postinst
           |build/debian/dolibarr.config )$
@@ -53,14 +54,32 @@ repos:
 
   # Check PHP syntax
   - repo: https://github.com/mdeweerd/pre-commit-php
-    rev: v1.6.3
+    rev: v1.6.5
     hooks:
       - id: php-cbf
         files: \.(php)$
         args: [--standard=dev/setup/codesniffer/ruleset.xml]
       - id: php-cs
         files: \.(php)$
-        args: [--standard=dev/setup/codesniffer/ruleset.xml, --report=emacs, --severity=5]
+        args:
+          [
+            --standard=dev/setup/codesniffer/ruleset.xml,
+            --report=emacs,
+            --severity=5,
+          ]
+      - alias: php-cs-with-cache
+        id: php-cs
+        # Configuration for ci - run on all files with cache
+        stages: [manual]
+        args:
+          [
+            --standard=dev/setup/codesniffer/ruleset.xml,
+            --report=emacs,
+            --severity=5,
+            --cache=.cache/pre-commit/dolibarr-php-cs.cache,
+            .,
+          ]
+        pass_filenames: false # Run on all files
       - id: php-lint
       - id: php-stan
         stages: [manual]
@@ -72,7 +91,8 @@ repos:
     hooks:
       - id: prettier
         stages: [manual]
-        exclude: (?x)^( .*\.(phar |min\.css |lock) |htdocs/(includes|theme/common)/.*
+        exclude:
+          (?x)^( .*\.(phar |min\.css |lock) |htdocs/(includes|theme/common)/.*
           )$
         exclude_types:
           - php
@@ -96,7 +116,7 @@ repos:
         args:
           - --no-warnings
           - -d
-          - '{extends: relaxed, rules: {line-length: {max: 120}}}'
+          - "{extends: relaxed, rules: {line-length: {max: 120}}}"
 
   # Execute codespell to fix typo errors (setup of codespell into dev/tools/codespell/)
   - repo: https://github.com/codespell-project/codespell
@@ -109,7 +129,7 @@ repos:
         # dev/tools/codespell/addCodespellIgnores.sh
         args:
           - -D
-          - '-'
+          - "-"
           - -D
           - dev/tools/codespell/codespell-dict.txt
           - -I
@@ -129,7 +149,7 @@ repos:
         files: ^htdocs/langs/en_US/.*$
         args:
           - -D
-          - '-'
+          - "-"
           - -D
           - dev/tools/codespell/codespell-dict.txt
           - -L
@@ -148,4 +168,4 @@ repos:
     rev: v0.9.0.6
     hooks:
       - id: shellcheck
-        args: [-W, '100']
+        args: [-W, "100"]

--- a/dev/setup/codesniffer/ruleset.xml
+++ b/dev/setup/codesniffer/ruleset.xml
@@ -3,6 +3,7 @@
 <ruleset name="Dolibarr">
 	<description>Dolibarr coding standard.</description>
 	<arg name="tab-width" value="4"/>
+	<arg name="extensions" value="php" />
 
 	<exclude-pattern type="relative">build/html</exclude-pattern>
 	<exclude-pattern type="relative">build/aps</exclude-pattern>
@@ -17,8 +18,7 @@
 	<exclude-pattern type="relative">*/nltechno*</exclude-pattern>
 	<exclude-pattern type="relative">source</exclude-pattern>
 	<exclude-pattern type="relative">.git</exclude-pattern>
-	<exclude-pattern>htdocs/includes</exclude-pattern>
-	<exclude-pattern>htdocs/install/doctemplates/websites</exclude-pattern>
+	<exclude-pattern type="relative">.cache</exclude-pattern>
 
 	<!-- List of all tests -->
 
@@ -32,41 +32,41 @@
 
 	<!-- We want to allow empty statement: It allows to put some code comments into the else for examples -->
 	<rule ref="Generic.CodeAnalysis.EmptyStatement">
-        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedIf"/>
-        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedElse"/>
-        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedElseif"/>
-        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
-        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedForeach"/>
-    </rule>
+	<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedIf"/>
+	<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedElse"/>
+	<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedElseif"/>
+	<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
+	<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedForeach"/>
+	</rule>
 
-    <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop" />
-    <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall" />
+	<rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop" />
+	<rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall" />
 
-    <rule ref="Generic.CodeAnalysis.JumbledIncrementer" />
+	<rule ref="Generic.CodeAnalysis.JumbledIncrementer" />
 
-    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement" />
+	<rule ref="Generic.CodeAnalysis.UnconditionalIfStatement" />
 
-    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier" />
+	<rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier" />
 
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter" />
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.Found">
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter" />
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.Found">
 		<severity>0</severity>
-    </rule>
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed">
+	</rule>
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed">
 		<severity>0</severity>
-    </rule>
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed">
+	</rule>
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed">
 		<severity>0</severity>
-    </rule>
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass">
+	</rule>
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass">
 		<severity>0</severity>
-    </rule>
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed">
+	</rule>
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed">
 		<severity>0</severity>
-    </rule>
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed">
+	</rule>
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed">
 		<severity>0</severity>
-    </rule>
+	</rule>
 
     <!-- Lower severity on warnings we do not want to show in the pre-commit reports -->
     <rule ref="Generic.Files.LineLength.TooLong">
@@ -80,14 +80,14 @@
     </rule>
 
 
-    <!-- Warnings on TODO -->
-    <!-- Disabled: We want to keep TODO as normal
-    <rule ref="Generic.Commenting.Todo" />
-    -->
+	<!-- Warnings on TODO -->
+	<!-- Disabled: We want to keep TODO as normal
+	<rule ref="Generic.Commenting.Todo" />
+	-->
 
 
-    <!-- PHP code MUST use only UTF-8 without BOM. -->
-    <rule ref="Generic.Files.ByteOrderMark"/>
+	<!-- PHP code MUST use only UTF-8 without BOM. -->
+	<rule ref="Generic.Files.ByteOrderMark"/>
 
 	<!-- Lines can be 85 chars long, but never show errors -->
 	<rule ref="Generic.Files.LineLength">
@@ -105,57 +105,57 @@
 	</rule>
 
 
-    <!-- Disallow several statements on same line -->
+	<!-- Disallow several statements on same line -->
 
 	<!-- Warning if action on same line than if -->
-	<!-- Disabled: We want to allow this for better code compacity and readability
-		<rule ref="Generic.ControlStructures.InlineControlStructure">
+	<!-- Disabled: We want to allow this for better code compactness and readability
+	<rule ref="Generic.ControlStructures.InlineControlStructure">
 		<properties>
 			<property name="error" value="false"/>
 		</properties>
-		</rule>
+	</rule>
 	-->
-	<!--  We want to allow 'if () { ...small code... }' on same line for better code compacity and readability -->
+	<!--  We want to allow 'if () { ...small code... }' on a single line for better code compactness and readability -->
 	<!-- <rule ref="Generic.Formatting.DisallowMultipleStatements">
 		<severity>0</severity>
 	</rule> -->
 
 
-	<!-- Check assignment have the = align on each line. Have 20 chars padding maximum and always show as errors -->
+	<!-- Check that assignments have the = aligned on each line. Have 20 chars padding maximum and always show as errors -->
 	<!--  Disabled: Report some false warning
-		<rule ref="Generic.Formatting.MultipleStatementAlignment">
+	<rule ref="Generic.Formatting.MultipleStatementAlignment">
 		<properties>
-		<property name="maxPadding" value="20"/>
-		<property name="ignoreMultiLine" value="true"/>
-		</properties>
-		</rule>
+			<property name="maxPadding" value="20"/>
+			<property name="ignoreMultiLine" value="true"/>
+			</properties>
+	</rule>
 	-->
 
 	<rule ref="Generic.Formatting.SpaceAfterCast" />
 
-    <rule ref="Generic.Functions.CallTimePassByReference" />
+	<rule ref="Generic.Functions.CallTimePassByReference" />
 
 	<rule ref="Generic.Functions.FunctionCallArgumentSpacing" />
 
-    <!-- Disallow several spaces after comma -->
+	<!-- Disallow several spaces after comma -->
 	<!-- We want to allow this because we want to be able to align params on several similare functions on different lines -->
 	<rule ref="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma">
 		<severity>0</severity>
 	</rule>
 
-    <!-- Tweaks to metrics -->
-    <rule ref="Generic.Metrics.CyclomaticComplexity">
-        <properties>
-            <property name="complexity" value="250" />
-            <property name="absoluteComplexity" value="500" />
-        </properties>
-    </rule>
-    <rule ref="Generic.Metrics.NestingLevel">
-        <properties>
-            <property name="nestingLevel" value="12" />
-            <property name="absoluteNestingLevel" value="50" />
-        </properties>
-    </rule>
+	<!-- Tweaks to metrics -->
+	<rule ref="Generic.Metrics.CyclomaticComplexity">
+	<properties>
+		<property name="complexity" value="250" />
+		<property name="absoluteComplexity" value="500" />
+	</properties>
+	</rule>
+	<rule ref="Generic.Metrics.NestingLevel">
+	<properties>
+		<property name="nestingLevel" value="12" />
+		<property name="absoluteNestingLevel" value="50" />
+	</properties>
+	</rule>
 
 	<rule ref="Generic.NamingConventions.ConstructorName" />
 	<!-- Check if we use PHP4 constructor instead of __construct() -->
@@ -163,20 +163,20 @@
 
 	<rule ref="Generic.NamingConventions.UpperCaseConstantName" />
 
-    <rule ref="Generic.PHP.DeprecatedFunctions" />
-    <rule ref="Generic.PHP.DeprecatedFunctions.Deprecated">
-        <severity>0</severity>
-    </rule>
+	<rule ref="Generic.PHP.DeprecatedFunctions" />
+	<rule ref="Generic.PHP.DeprecatedFunctions.Deprecated">
+		<severity>0</severity>
+	</rule>
 
 	<rule ref="Generic.PHP.DisallowShortOpenTag" />
 
-    <rule ref="Generic.PHP.ForbiddenFunctions" />
+	<rule ref="Generic.PHP.ForbiddenFunctions" />
 
-    <!-- Warning when using @ before functions -->
-    <!-- We want this. Some features need this -->
-    <rule ref="Generic.PHP.NoSilencedErrors">
-        <severity>0</severity>
-    </rule>
+	<!-- Disable warning when using @ before functions -->
+	<!-- We want the '@' symbols. Some features need this. -->
+	<rule ref="Generic.PHP.NoSilencedErrors">
+		<severity>0</severity>
+	</rule>
 
 	<!-- Say if null, true, false must be uppercase (Rule 2.5 of PSR2 https://www.php-fig.org/psr/psr-2/) -->
 	<rule ref="Generic.PHP.LowerCaseConstant" />
@@ -194,123 +194,122 @@
 	<!-- <rule ref="Generic.WhiteSpace.ScopeIndent" /> -->
 
 	<rule ref="Generic.WhiteSpace.ScopeIndent">
-	  <properties>
-	    <property name="indent" value="4"/>
-	    <property name="tabIndent" value="true"/>
-	  </properties>
+		<properties>
+			<property name="indent" value="4"/>
+			<property name="tabIndent" value="true"/>
+		</properties>
 	</rule>
 
-    <!-- Check for duplicate class names -->
-    <!-- Disabled: We need this for dependency injection.
-    <rule ref="Generic.Classes.DuplicateClassName" />
-    -->
+	<!-- Check for duplicate class names -->
+	<!-- Disabled: We need this for dependency injection.
+	<rule ref="Generic.Classes.DuplicateClassName" />
+	-->
 
 
- 	<!-- Rules from Squiz Standard -->
+	<!-- Rules from Squiz Standard -->
 
-    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.Indent" />
+	<rule ref="Squiz.WhiteSpace.ScopeClosingBrace.Indent" />
 
-    <!-- There MUST NOT be trailing whitespace at the end of non-blank lines. -->
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-        <properties>
-            <property name="ignoreBlankLines" value="false"/>
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile" />
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile" />
-    <!-- Disabled: We want to have 2 empty line as separator sometimes -->
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" >
-        <severity>0</severity>
-    </rule>
-
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen" />
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
-
-    <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis" />
-    <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
-    <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword" />
-
-    <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceAfterOpen" />
-    <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceBeforeClose" />
-
-    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration" />
-	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction">
+	<!-- There MUST NOT be trailing whitespace at the end of non-blank lines. -->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+		<properties>
+			<property name="ignoreBlankLines" value="false"/>
+		</properties>
 	</rule>
-    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
-        <properties>
-            <property name="equalsSpacing" value="1"/>
-        </properties>
-    </rule>
-    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterHint">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Scope.MethodScope.Missing" />
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile" />
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile" />
+	<!-- Disabled: We want to have 2 empty line as separator sometimes -->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" >
+		<severity>0</severity>
+	</rule>
+
+	<rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen" />
+	<rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
+
+	<rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis" />
+	<rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
+	<rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword" />
+
+	<rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceAfterOpen" />
+	<rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceBeforeClose" />
+
+	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration" />
+	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+		<properties>
+			<property name="equalsSpacing" value="1"/>
+		</properties>
+	</rule>
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterHint">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Squiz.Scope.MethodScope.Missing" />
 
 
-    <!-- Rules from PEAR Standard -->
+	<!-- Rules from PEAR Standard -->
 
-    <rule ref="PEAR.Classes.ClassDeclaration" />
+	<rule ref="PEAR.Classes.ClassDeclaration" />
 
-    <rule ref="PEAR.Commenting.ClassComment" />
+	<rule ref="PEAR.Commenting.ClassComment" />
 
-    <rule ref="PEAR.Commenting.ClassComment.Missing" />
+	<rule ref="PEAR.Commenting.ClassComment.Missing" />
 
-    <rule ref="PEAR.Commenting.ClassComment.MissingTag" />
+	<rule ref="PEAR.Commenting.ClassComment.MissingTag" />
 
-    <rule ref="PEAR.Commenting.ClassComment.MissingAuthorTag">
-        <severity>0</severity>
-    </rule>
+	<rule ref="PEAR.Commenting.ClassComment.MissingAuthorTag">
+		<severity>0</severity>
+	</rule>
 
-    <rule ref="PEAR.Commenting.ClassComment.MissingCategoryTag">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.ClassComment.MissingLicenseTag">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.ClassComment.MissingLinkTag">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.ClassComment.MissingPackageTag">
-        <severity>0</severity>
-    </rule>
+	<rule ref="PEAR.Commenting.ClassComment.MissingCategoryTag">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Commenting.ClassComment.MissingLicenseTag">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Commenting.ClassComment.MissingLinkTag">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Commenting.ClassComment.MissingPackageTag">
+		<severity>0</severity>
+	</rule>
 
-    <rule ref="PEAR.Commenting.FunctionComment" />
+	<rule ref="PEAR.Commenting.FunctionComment" />
 
-    <rule ref="PEAR.Commenting.FunctionComment.Empty" />
+	<rule ref="PEAR.Commenting.FunctionComment.Empty" />
 
-    <rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParamType" />
+	<rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParamType" />
 
-    <rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParamName">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParamType">
-        <severity>0</severity>
-    </rule>
+	<rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParamName">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParamType">
+		<severity>0</severity>
+	</rule>
 
-    <rule ref="PEAR.Commenting.FunctionComment.ReturnNotRequired" />
+	<rule ref="PEAR.Commenting.FunctionComment.ReturnNotRequired" />
 
-    <rule ref="PEAR.Commenting.FunctionComment.WrongStyle" />
+	<rule ref="PEAR.Commenting.FunctionComment.WrongStyle" />
 
-    <rule ref="PEAR.Commenting.FunctionComment.SpacingBeforeParamType">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.SpacingAfterLongType">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.SpacingAfterLongName">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParams">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.ParameterCommentsNotAligned">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Commenting.FunctionComment.ParameterNamesNotAligned">
-        <severity>0</severity>
-    </rule>
+	<rule ref="PEAR.Commenting.FunctionComment.SpacingBeforeParamType">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Commenting.FunctionComment.SpacingAfterLongType">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Commenting.FunctionComment.SpacingAfterLongName">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParams">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Commenting.FunctionComment.ParameterCommentsNotAligned">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.Commenting.FunctionComment.ParameterNamesNotAligned">
+		<severity>0</severity>
+	</rule>
 
-    <rule ref="PEAR.Commenting.InlineComment" />
+	<rule ref="PEAR.Commenting.InlineComment" />
 
 	<!-- Check position of { after a control structure like if (), while (), etc... -->
 	<!--
@@ -323,37 +322,37 @@
 	<rule ref="PEAR.Files.IncludingFile" />
 
 	<!-- We disable this: We must be able to make require inside if -->
-    <rule ref="PEAR.Files.IncludingFile.UseInclude">
-        <severity>0</severity>
-    </rule>
+	<rule ref="PEAR.Files.IncludingFile.UseInclude">
+		<severity>0</severity>
+	</rule>
 
-    <!-- We disable this. We must be allowed to use strict require instead of non strict include anywhere -->
-    <rule ref="PEAR.Files.IncludingFile.UseIncludeOnce">
-        <severity>0</severity>
-    </rule>
+	<!-- We disable this. We must be allowed to use strict require instead of non strict include anywhere -->
+	<rule ref="PEAR.Files.IncludingFile.UseIncludeOnce">
+		<severity>0</severity>
+	</rule>
 
-    <rule ref="PEAR.Files.IncludingFile.UseRequire">
-     	<severity>0</severity>
-    </rule>
+	<rule ref="PEAR.Files.IncludingFile.UseRequire">
+		<severity>0</severity>
+	</rule>
 
-    <!-- We disable this: We want to allow include_once -->
-    <rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
-        <severity>0</severity>
-    </rule>
+	<!-- We disable this: We want to allow include_once -->
+	<rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
+		<severity>0</severity>
+	</rule>
 
 	<rule ref="PEAR.Formatting.MultiLineAssignment" />
 
 	<rule ref="PEAR.Functions.FunctionCallSignature" />
 
-    <!-- We disable this: It returns a lot of false positive -->
-    <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
-        <severity>0</severity>
-    </rule>
+	<!-- We disable this: It returns a lot of false positive -->
+	<rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
+		<severity>0</severity>
+	</rule>
 
-    <!-- We disable this: We want to allow small function on 1 line -->
-    <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
-        <severity>0</severity>
-    </rule>
+	<!-- We disable this: We want to allow small function on 1 line -->
+	<rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
+		<severity>0</severity>
+	</rule>
 
 	<rule ref="PEAR.Functions.FunctionCallSignature.EmptyLine" />
 
@@ -362,14 +361,14 @@
 		<severity>0</severity>
 	</rule>
 
-    <rule ref="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
-    <rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterCloseBracket" />
+	<rule ref="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
+	<rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterCloseBracket" />
 
 	<rule ref="PEAR.Functions.ValidDefaultValue" />
 
 	<rule ref="PEAR.NamingConventions.ValidClassName" />
 	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
-        <severity>0</severity>
+		<severity>0</severity>
 	</rule>
 
 	<!-- We disable this: there is a lot of existing method not starting with a capital letter (class modXxxx, ...) -->
@@ -378,7 +377,7 @@
 	</rule>
 	<!-- some phpcs have a typo error in rule, so we add it this rule too with term "Captial" instead of "Capital" -->
 	<rule ref="PEAR.NamingConventions.ValidClassName.StartWithCaptial">
-        <severity>0</severity>
+		<severity>0</severity>
 	</rule>
 
 	<rule ref="PEAR.NamingConventions.ValidFunctionName" />
@@ -386,26 +385,26 @@
 
 	<!-- We disable this: there is a lot of existing function not starting with a capital letter (class modXxxx, ...) -->
 	<rule ref="PEAR.NamingConventions.ValidFunctionName.FunctionNameInvalid">
-        <severity>0</severity>
+		<severity>0</severity>
 	</rule>
 	<rule ref="PEAR.NamingConventions.ValidFunctionName.FunctionNoCapital">
-        <severity>0</severity>
+		<severity>0</severity>
 	</rule>
 	<!-- some phpcs have a typo error in rule, so we add it this rule too with term "Captial" instead of "Capital" -->
 	<rule ref="PEAR.NamingConventions.ValidFunctionName.FunctionNoCaptial">
-        <severity>0</severity>
+		<severity>0</severity>
 	</rule>
 
-    <!--<rule ref="PEAR.NamingConventions.ValidFunctionName.NotCamelCaps">
-        <severity>0</severity>
-    </rule>-->
+	<!--<rule ref="PEAR.NamingConventions.ValidFunctionName.NotCamelCaps">
+		<severity>0</severity>
+	</rule>-->
 	<!--<rule ref="PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
-        <severity>0</severity>
+		<severity>0</severity>
 	</rule>-->
 
 	<!-- We disable this: We don't want to have private methods prefixed with an underscore -->
 	<rule ref="PEAR.NamingConventions.ValidFunctionName.PrivateNoUnderscore">
-        <severity>0</severity>
+		<severity>0</severity>
 	</rule>
 
 	<rule ref="PEAR.NamingConventions.ValidVariableName" />
@@ -413,35 +412,35 @@
 	<!-- This is not in PSR2 -->
 	<!-- We disable this: We don't want to have private methods prefixed with an underscore -->
 	<rule ref="PEAR.NamingConventions.ValidVariableName.PrivateNoUnderscore">
-        <severity>0</severity>
-    </rule>
+		<severity>0</severity>
+	</rule>
 
 	<rule ref="PEAR.WhiteSpace.ObjectOperatorIndent" />
 
 	<!-- Need to be commented to be disabled
 	<rule ref="PEAR.WhiteSpace.ScopeClosingBrace">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.WhiteSpace.ScopeClosingBrace.Line">
-        <severity>0</severity>
-    </rule>
+		<severity>0</severity>
+	</rule>
+	<rule ref="PEAR.WhiteSpace.ScopeClosingBrace.Line">
+		<severity>0</severity>
+	</rule>
 	-->
 
-    <!-- Already found as a Generic rule -->
+	<!-- Already found as a Generic rule -->
 	<!-- <rule ref="PEAR.WhiteSpace.ScopeIndent" /> -->
 
 
 	<!--  Rules PSR 2 -->
-    <rule ref="PSR2.Classes.ClassDeclaration" />
-    <rule ref="PSR2.Methods.FunctionClosingBrace" />
-    <rule ref="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed" />
-    <rule ref="PSR2.Classes.ClassDeclaration" />
-    <rule ref="PSR2.Methods.FunctionClosingBrace" />
-    <rule ref="PSR2.Files.EndFileNewline.TooMany" />
+	<rule ref="PSR2.Classes.ClassDeclaration" />
+	<rule ref="PSR2.Methods.FunctionClosingBrace" />
+	<rule ref="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed" />
+	<rule ref="PSR2.Classes.ClassDeclaration" />
+	<rule ref="PSR2.Methods.FunctionClosingBrace" />
+	<rule ref="PSR2.Files.EndFileNewline.TooMany" />
 	<rule ref="PSR2.Files.EndFileNewline.NoneFound" />
 	<rule ref="PSR2.Methods.FunctionCallSignature.SpaceBeforeOpenBracket" />
 	<rule ref="PSR2.Classes.PropertyDeclaration.VarUsed" />
-    <!-- The closing ?> tag MUST be omitted from files containing only PHP. -->
-    <rule ref="PSR2.Files.ClosingTag"/>
+	<!-- The closing ?> tag MUST be omitted from files containing only PHP. -->
+	<rule ref="PSR2.Files.ClosingTag"/>
 
 </ruleset>


### PR DESCRIPTION
This adds a hook to .pre-commit-config.yaml and updates the workflow to run php-cs with cache when it is run for all files. When running on changed files only, the cache is not useful.

The php-codesniffer ruleset.xml was cleaned up (duplicates removal/formatted)
