### PR TITLE
FIX check parameter socid before cloning a customer proposal

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -179,8 +179,8 @@ if (empty($reshook)) {
 
 	// Action clone object
 	if ($action == 'confirm_clone' && $confirm == 'yes' && $usercancreate) {
-		if (!GETPOST('socid', 3)) {
-			setEventMessages($langs->trans("NoCloneOptionsSpecified"), null, 'errors');
+		if (!($socid > 0)) {
+			setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('IdThirdParty')), null, 'errors');
 		} else {
 			if ($object->id > 0) {
 				if (!empty($conf->global->PROPAL_CLONE_DATE_DELIVERY)) {


### PR DESCRIPTION
FIX check parameter "socid" before cloning a customer proposal
- the check "GETPOST('socid', 3)" has a wrong parameter "3" (the second parameter of GETPOST is the type of field "alpha", "int", "alphanohtml", etc)
- the event message "NoCloneOptionsSpecified" is a wrong message for the user and it's unuseful here

So I replaced with a check of "socid" and if this parameter is not positive, I put a required field error message.