### PR TITLE
FIX: Bar code verification should be done by entity because generation does

### DIFF
--- a/htdocs/core/modules/barcode/mod_barcode_product_standard.php
+++ b/htdocs/core/modules/barcode/mod_barcode_product_standard.php
@@ -291,8 +291,6 @@ class mod_barcode_product_standard extends ModeleNumRefBarCode
 	 */
 	public function verif_dispo($db, $code, $product)
 	{
-		global $entity;
-
 		// phpcs:enable
 		$sql = "SELECT barcode FROM ".MAIN_DB_PREFIX."product";
 		$sql .= " WHERE barcode = '".$db->escape($code)."'";

--- a/htdocs/core/modules/barcode/mod_barcode_product_standard.php
+++ b/htdocs/core/modules/barcode/mod_barcode_product_standard.php
@@ -296,12 +296,10 @@ class mod_barcode_product_standard extends ModeleNumRefBarCode
 		// phpcs:enable
 		$sql = "SELECT barcode FROM ".MAIN_DB_PREFIX."product";
 		$sql .= " WHERE barcode = '".$db->escape($code)."'";
+		$sql .= " AND entity IN (".getEntity('product').")";
+
 		if ($product->id > 0) {
 			$sql .= " AND rowid <> ".$product->id;
-		}
-
-		if (!empty($entity)) {
-			$sql .= " AND entity = " . intval($entity);
 		}
 
 		$resql = $db->query($sql);

--- a/htdocs/core/modules/barcode/mod_barcode_product_standard.php
+++ b/htdocs/core/modules/barcode/mod_barcode_product_standard.php
@@ -291,11 +291,17 @@ class mod_barcode_product_standard extends ModeleNumRefBarCode
 	 */
 	public function verif_dispo($db, $code, $product)
 	{
+		global $entity;
+
 		// phpcs:enable
 		$sql = "SELECT barcode FROM ".MAIN_DB_PREFIX."product";
 		$sql .= " WHERE barcode = '".$db->escape($code)."'";
 		if ($product->id > 0) {
 			$sql .= " AND rowid <> ".$product->id;
+		}
+
+		if (!empty($entity)) {
+			$sql .= " AND entity = " . intval($entity);
 		}
 
 		$resql = $db->query($sql);


### PR DESCRIPTION
Barcode getNextValue function generate by default a new value by entity but the verification of this barcode does not check it so it generate an error "This barcode already exists". 