### PR TITLE
fix : Fatal error: Uncaught Error: Object of class Conf could not be …

### DIFF
--- a/htdocs/core/modules/societe/mod_codecompta_aquarium.php
+++ b/htdocs/core/modules/societe/mod_codecompta_aquarium.php
@@ -106,7 +106,7 @@ class mod_codecompta_aquarium extends ModeleAccountancyCode
 		$texte .= $langs->trans("ModuleCompanyCodeSupplier".$this->name, '{s1}')."<br>\n";
 		$texte = str_replace(array('{s1}', '{s2}'), array($s1, $s2), $texte);
 		$texte .= "<br>\n";
-		if (!isset($conf->global->COMPANY_AQUARIUM_REMOVE_SPECIAL) || !empty($conf->global->$conf->global->COMPANY_AQUARIUM_REMOVE_SPECIAL)) {
+		if (getDolGlobalInt('COMPANY_AQUARIUM_REMOVE_SPECIAL')) {
 			$texte .= $langs->trans('RemoveSpecialChars').' = '.yn(1)."<br>\n";
 		}
 		//if (!empty($conf->global->COMPANY_AQUARIUM_REMOVE_ALPHA)) $texte.=$langs->trans('COMPANY_AQUARIUM_REMOVE_ALPHA').' = '.yn($conf->global->COMPANY_AQUARIUM_REMOVE_ALPHA)."<br>\n";


### PR DESCRIPTION
…converted to string in /srv/users/dolibarr/apps/dolibarr/htdocs/core/modules/societe/mod_codecompta_aquarium.php:98 Stack trace: #0 /srv/users/dolibarr/apps/dolibarr/htdocs/societe/admin/societe.php(495): mod_codecompta_aquarium->info(Object(Translate)) #1 {main} thrown in /srv/users/dolibarr/apps/dolibarr/htdocs/core/modules/societe/mod_codecompta_aquarium.php on line 98

