### PR TITLE
Qual Language scripts fixed/updated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,17 @@ repos:
     hooks:
       - id: no-commit-to-branch
         args: [--branch, develop, --pattern, \d+.0]
+      - id: check-xml
       - id: check-yaml
         args: [--unsafe]
       - id: check-json
       - id: mixed-line-ending
-        exclude: (?x)^(htdocs/includes/tecnickcom/tcpdf/fonts/.*)$
+        # alternative for dev/tools/fixdosfiles.sh
+        exclude: |
+          (?x)^(htdocs/includes/tecnickcom/tcpdf/fonts/.*
+               |.*/CRLF.*.php  # Files in swiftmailer
+               )$
+        args: [--fix=lf]
       - id: trailing-whitespace
         exclude_types: [markdown]
       - id: end-of-file-fixer
@@ -41,8 +47,8 @@ repos:
   #   ```shell
   #  #!/bin/bash
   #   MYDIR=$(dirname "$0")
-  #   CHANGED_INTERNALS=$(git diff --name-only | grep -v includes)
-  #   "$MYDIR/dev/tools/updatelicense.php" $CHANGED_INTERNALS
+  #   git diff HEAD --name-only | grep -v includes | \
+  #       xargs "$MYDIR/dev/tools/updatelicense.php"
   #   ```
   - repo: local
     hooks:
@@ -51,6 +57,13 @@ repos:
         language: system
         entry: bash -c '[ ! -x local.sh ] || ./local.sh'
         pass_filenames: false
+      - id: duplicate-lang-keys
+        name: Find duplicate language keys
+        files: (?x)^(htdocs/langs/en_US/.*\.lang)
+        language: script
+        entry: ./dev/tools/fixduplicatelanglines.sh
+        pass_filenames: false
+        args: [list]
 
   # Check PHP syntax
   - repo: https://github.com/mdeweerd/pre-commit-php

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,8 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, develop, --pattern, \d+.0]
       - id: check-xml
+        exclude: |
+          (?x)^(htdocs/includes/.*)$
       - id: check-yaml
         args: [--unsafe]
       - id: check-json
@@ -62,6 +64,13 @@ repos:
         files: (?x)^(htdocs/langs/en_US/.*\.lang)
         language: script
         entry: ./dev/tools/fixduplicatelanglines.sh
+        pass_filenames: false
+        args: [list]
+      - id: duplicate-lang-keys
+        name: Find duplicate language keys
+        files: (?x)^(htdocs/langs/en_US/.*\.lang)
+        language: script
+        entry: ./dev/tools/fixduplicatelangkey.sh
         pass_filenames: false
         args: [list]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
         entry: bash -c '[ ! -x local.sh ] || ./local.sh'
         pass_filenames: false
       - id: duplicate-lang-lines
+        stages: [manual]
         name: Find duplicate language lines
         files: (?x)^(htdocs/langs/en_US/.*\.lang)
         language: script
@@ -67,6 +68,7 @@ repos:
         pass_filenames: false
         args: [list]
       - id: duplicate-lang-keys
+        stages: [manual]
         name: Find duplicate language keys
         files: (?x)^(htdocs/langs/en_US/.*\.lang)
         language: script
@@ -74,6 +76,7 @@ repos:
         pass_filenames: false
         args: [list]
       - id: fix-alt-languages
+        stages: [manual]
         name: Fix alt languages
         # Selection: see fixaltlanguages.sh script
         files: (?x)^(htdocs/langs/(e[lnstu]|k[akmno]|s[lqrv]|b[nrs]|c[asy]|n[bel]|[ip]t|a[mr]|d[ae]|f[ar]|h[ei]|m[sy]|t[ag]|u[kr]|gl|ja|lo|ru|vi|zh)_[^/]*/.*\.lang)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,8 +59,8 @@ repos:
         language: system
         entry: bash -c '[ ! -x local.sh ] || ./local.sh'
         pass_filenames: false
-      - id: duplicate-lang-keys
-        name: Find duplicate language keys
+      - id: duplicate-lang-lines
+        name: Find duplicate language lines
         files: (?x)^(htdocs/langs/en_US/.*\.lang)
         language: script
         entry: ./dev/tools/fixduplicatelanglines.sh
@@ -73,6 +73,13 @@ repos:
         entry: ./dev/tools/fixduplicatelangkey.sh
         pass_filenames: false
         args: [list]
+      - id: fix-alt-languages
+        name: Fix alt languages
+        # Selection: see fixaltlanguages.sh script
+        files: (?x)^(htdocs/langs/(e[lnstu]|k[akmno]|s[lqrv]|b[nrs]|c[asy]|n[bel]|[ip]t|a[mr]|d[ae]|f[ar]|h[ei]|m[sy]|t[ag]|u[kr]|gl|ja|lo|ru|vi|zh)_[^/]*/.*\.lang)
+        language: script
+        entry: ./dev/tools/fixaltlanguages_pre-commit.sh
+        pass_filenames: true
 
   # Check PHP syntax
   - repo: https://github.com/mdeweerd/pre-commit-php

--- a/dev/tools/fixaltlanguages_pre-commit.sh
+++ b/dev/tools/fixaltlanguages_pre-commit.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Wrapper to run 'fixaltlanguages.sh' from pre-commit hook
+#
+# Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+
+
+# Note: regex in pre-commit based on list of fixed alt languages when run for
+#       all cases (or all languages with more than one code in the project).
+#
+# Perl script:
+#
+#     ```perl
+#     use Regexp::Optimizer;
+#     my $o = Regexp::Optimizer->new;
+#     my $re= "am|ar|bn|br|bs|ca|cs|cy|da|de|el|en|es|et|eu|fa|fr|gl|he|hi"
+#           ."|it|ja|ka|kk|km|kn|ko|lo|ms|my|nb|ne|nl|pt|ru|sl|sq|sr|sv|ta"
+#           ."|tg|uk|ur|vi|zh";
+#     my $newRe=$o->optimize(qr/$re/);
+#     print $newRe;
+#     ```
+
+MYDIR=$(dirname "$(realpath "$0")")
+
+exit_code=0
+for file in "$@" ; do
+	if ! "${MYDIR}/fixaltlanguages.sh" fix "$file" ; then
+		exit_code=$?
+	fi
+done
+exit $exit_code

--- a/dev/tools/fixduplicatelangkey.sh
+++ b/dev/tools/fixduplicatelangkey.sh
@@ -26,7 +26,12 @@ then
 			sed "s/\s*\=/=/" | # Remove any whitespace before =
 			grep -Po "(^.*?)(?==)" | # Non greedy match everything before =
 			sort | uniq -d | # Find duplicates
-			awk '$0="'"$file"':"$0' # Prefix with filename (for ci)
+			while IFS= read -r key ; do
+				grep -n "^$key" "$file" |
+				# Format line to be recognised for code annotation by logToCs.py
+				echo "$file:$(cut -d ':' -f 1 | tail -n 1):error:Duplicate '$key'"
+			done
+			# awk '$0="'"$file"':"$0' # Prefix with filename (for ci)
 		)
 
 		if [ -n "$dupes" ]

--- a/dev/tools/fixduplicatelangkey.sh
+++ b/dev/tools/fixduplicatelangkey.sh
@@ -1,41 +1,47 @@
 #!/bin/sh
 # Helps find duplicate translation keys in language files
 #
-# Copyright (C) 2014 Raphaël Doursenaud - rdoursenaud@gpcsolutions.fr
+# Copyright (C) 2014		Raphaël Doursenaud					<rdoursenaud@gpcsolutions.fr>
+# Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
 
-# shellcheck disable=2006,2035,2044,2061,2166,2268
-
+exit_code=0
 # Syntax
-if [ "x$1" != "xlist" -a "x$1" != "xfix" ]
+if [ "$1" != "list" ] && [ "$1" != "fix" ]
 then
 	echo "Detect duplicate translation keys inside a file (there is no cross file check)."
 	echo "Usage: detectduplicatelangkey.sh (list|fix)"
+	exit_code=1
 fi
 
 
-if [ "x$1" = "xlist" ]
+ACTION=$1
+
+if [ "${ACTION}" = "list" ]
 then
 	echo "Search duplicate keys into en_US lang files (there is no cross file check)"
-	for file in `find htdocs/langs/en_US -name *.lang -type f`
+	for file in htdocs/langs/en_US/*.lang
 	do
 		dupes=$(
 			sed "s/^\s*//" "$file" | # Remove any leading whitespace
 			sed "s/\s*\=/=/" | # Remove any whitespace before =
-			grep -Po "(^.*?)=" | # Non greedeely match everything before =
-			sed "s/\=//" | # Remove trailing = so we get the key
-			sort | uniq -d # Find duplicates
+			grep -Po "(^.*?)(?==)" | # Non greedy match everything before =
+			sort | uniq -d | # Find duplicates
+			awk '$0="'"$file"':"$0' # Prefix with filename (for ci)
 		)
 
 		if [ -n "$dupes" ]
 		then
-			echo "Duplicates found in $file"
+			exit_code=1
 			echo "$dupes"
 		fi
 	done
 fi
 
 # To convert
-if [ "x$1" = "xfix" ]
+if [ "${ACTION}" = "fix" ]
 then
 	echo Feature not implemented. Please fix files manually.
+	exit_code=1
 fi
+
+exit $exit_code

--- a/dev/tools/fixduplicatelanglines.sh
+++ b/dev/tools/fixduplicatelanglines.sh
@@ -1,40 +1,47 @@
-#!/bin/sh
+#!/bin/bash
 # Recursively deduplicate file lines on a per file basis
 # Useful to deduplicate language files
 #
 # Needs awk 4.0 for the inplace fixing command
 #
-# Raphaël Doursenaud - rdoursenaud@gpcsolutions.fr
+# Copyright (C) 2016		Raphaël Doursenaud					<rdoursenaud@gpcsolutions.fr>
+# Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
 
-# shellcheck disable=2006,2035,2044,2046,2061,2166,2268
+exit_code=0
 
-# Syntax
-if [ "x$1" != "xlist" -a "x$1" != "xfix" ]
+# Check arguments
+if [ "$1" != "list" ] && [ "$1" != "fix" ]
 then
 	echo "Find exact duplicated lines into file (not cross file checking)"
-	echo "Usage: deduplicatefilelinesrecursively.sh [list|fix]"
+	echo "Usage: $(basename "$0") [list|fix]"
+	exit_code=1
 fi
 
+ACTION=$1
+
 # To detect
-if [ "x$1" = "xlist" ]
+if [ "${ACTION}" = "list" ] || [ "${ACTION}" = "fix" ]
 then
-	echo "Search duplicate line for lang en_US"
-	for file in `find htdocs/langs/en_US -type f -name *.lang`
+	echo "Search duplicate lines for lang en_US"
+	echo ""
+	for file in htdocs/langs/en_US/*.lang
 	do
-		if [ `sort "$file" | grep -v '^$' | uniq -d | wc -l` -gt 0 ]
+		if [ "$(sort "$file" | grep -v -P '^#?$' | uniq -d | wc -l)" -gt 0 ]
 		then
-			echo "***** $file"
-			sort "$file" | grep -v '^$' | uniq -d
+			sort "$file" | grep -v -P '^#?$' | uniq -d | awk '$0="'"$file"':"$0'
+			exit_code=1
 		fi
 	done
 fi
 
 # To fix
-if [ "x$1" = "xfix" ]
+if [ "${ACTION}" = "fix" ]
 then
 	echo "Fix duplicate line for lang en_US"
-	for file in `find htdocs/langs/en_US -type f -name *.lang`
-	do
+	# shellcheck disable=2016
+	for file in htdocs/langs/en_US/*.lang ; do
 		awk -i inplace ' !x[$0]++' "$file"
-	done;
+	done
 fi
+
+exit $exit_code

--- a/dev/tools/fixnotabfiles.sh
+++ b/dev/tools/fixnotabfiles.sh
@@ -6,23 +6,22 @@
 #------------------------------------------------------
 # Usage: fixnotabfiles.sh [list|fix]
 #------------------------------------------------------
-# shellcheck disable=2166,2268
 
 # Syntax
-if [ "x$1" != "xlist" -a "x$1" != "xfix" ]
+if [ "$1" != "list" ] && [ "$1" != "fix" ]
 then
-	echo "Detect .sh and .spec files that does not contains any tab inside"
+	echo "Detect .sh and .spec files that does not contain any tab"
 	echo "Usage: fixnotabfiles.sh [list|fix]"
 fi
 
-# To detec
-if [ "x$1" = "xlist" ]
+# List/Detect files
+if [ "$1" = "list" ]
 then
-	find build \( -iname "*.sh" -o -iname "*.spec" \) -exec grep -l -P '\t' {} \;
+	find build \( -iname "*.sh" -o -iname "*.spec" \) -exec grep -L -P '\t' {} \;
 fi
 
-# To convert
-if [ "x$1" = "xfix" ]
+# Fix/convert files
+if [ "$1" = "fix" ]
 then
 	echo Feature not implemented. Please fix files manually.
 fi

--- a/dev/translation/strip_language_file.php
+++ b/dev/translation/strip_language_file.php
@@ -2,6 +2,7 @@
 <?php
 /* Copyright (C) 2014 by FromDual GmbH, licensed under GPL v2
  * Copyright (C) 2014 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -141,7 +142,7 @@ foreach ($filesToProcess as $fileToProcess) {
 
 			$a = mb_split('=', trim($line), 2);
 			if (count($a) != 2) {
-				print "ERROR in file $lSecondaryFile, line $cnt: " . trim($line) . "\n";
+				print "File $lSecondaryFile:ERROR: ".trim($line)." in line $cnt.\n";
 				continue;
 			}
 
@@ -149,13 +150,13 @@ foreach ($filesToProcess as $fileToProcess) {
 
 			// key is redundant
 			if (array_key_exists($key, $aSecondary)) {
-				print "Key $key is redundant in file $lSecondaryFile (line: $cnt).\n";
+				print "File $lSecondaryFile:WARNING: Key $key is redundant in line $cnt.\n";
 				continue;
 			}
 
 			// String has no value
 			if ($value == '') {
-				print "Key $key has no value in file $lSecondaryFile (line: $cnt).\n";
+				print "File $lSecondaryFile:WARNING: Key $key has no value in line: $cnt.\n";
 				continue;
 			}
 
@@ -195,7 +196,7 @@ foreach ($filesToProcess as $fileToProcess) {
 
 			$a = mb_split('=', trim($line), 2);
 			if (count($a) != 2) {
-				print "ERROR in file $lEnglishFile, line $cnt: " . trim($line) . "\n";
+				print "File $lEnglishFile:ERROR: ".trim($line)." in line $cnt.\n";
 				continue;
 			}
 
@@ -203,13 +204,13 @@ foreach ($filesToProcess as $fileToProcess) {
 
 			// key is redundant
 			if (array_key_exists($key, $aEnglish)) {
-				print "Key $key is redundant in file $lEnglishFile (line: $cnt).\n";
+				print "File $lEnglishFile:WARNING: Key $key is redundant in line $cnt.\n";
 				continue;
 			}
 
 			// String has no value
 			if ($value == '') {
-				print "Key $key has no value in file $lEnglishFile (line: $cnt).\n";
+				print "File $lEnglishFile:WARNING: Key $key has no value in line $cnt.\n";
 				continue;
 			}
 
@@ -238,7 +239,7 @@ foreach ($filesToProcess as $fileToProcess) {
 
 	if ($handle = fopen($lPrimaryFile, 'r')) {
 		if (! $oh = fopen($output, 'w')) {
-			print "ERROR in writing to file ".$output."\n";
+			print "ERROR writing to file ".$output."\n";
 			exit;
 		}
 
@@ -264,7 +265,7 @@ foreach ($filesToProcess as $fileToProcess) {
 
 			$a = mb_split('=', trim($line), 2);
 			if (count($a) != 2) {
-				print "ERROR in file $lPrimaryFile, line $cnt: " . trim($line) . "\n";
+				print "File $lPrimaryFile:ERROR: ".trim($line)." in line $cnt.\n";
 				continue;
 			}
 
@@ -272,15 +273,17 @@ foreach ($filesToProcess as $fileToProcess) {
 
 			// key is redundant
 			if (array_key_exists($key, $aPrimary)) {
-				print "Key $key is redundant in file $lPrimaryFile (line: $cnt)";
+				$prefix = "File $lPrimaryFile:WARNING: Key $key is redundant";
+				$postfix = " in line $cnt.\n";
+
 				if (!empty($fileFirstFound[$key])) {
-					print " - Already found into ".$fileFirstFound[$key];
-					print " (line: ".$lineFirstFound[$key].").\n";
+					print "$prefix [Already found in '".$fileFirstFound[$key];
+					print "' (line: ".$lineFirstFound[$key].")]$postfix";";";
 				} else {
 					$fileFirstFound[$key] = $fileToProcess;
 					$lineFirstFound[$key] = $cnt;
 
-					print " - Already found into main file.\n";
+					print "$prefix [Already found in main file]$postfix";
 				}
 				continue;
 			} else {
@@ -290,7 +293,7 @@ foreach ($filesToProcess as $fileToProcess) {
 
 			// String has no value
 			if ($value == '') {
-				print "Key $key has no value in file $lPrimaryFile (line: $cnt).\n";
+				print "File $lPrimaryFile:WARNING: Key $key has no value in line $cnt.\n";
 				continue;
 			}
 
@@ -315,7 +318,7 @@ foreach ($filesToProcess as $fileToProcess) {
 			if ((!empty($aSecondary[$key]) && $aSecondary[$key] != $aPrimary[$key]
 				&& !empty($aEnglish[$key]) && $aSecondary[$key] != $aEnglish[$key])
 				|| in_array($key, $arrayofkeytoalwayskeep) || preg_match('/^FormatDate/', $key) || preg_match('/^FormatHour/', $key)
-				) {
+			) {
 				//print "Key $key differs (aSecondary=".$aSecondary[$key].", aPrimary=".$aPrimary[$key].", aEnglish=".$aEnglish[$key].") so we add it into new secondary language (line: $cnt).\n";
 				fwrite($oh, $key."=".(empty($aSecondary[$key]) ? $aPrimary[$key] : $aSecondary[$key])."\n");
 			}


### PR DESCRIPTION
# Qual Language scripts fixed/updated

#27712 was closed without explication, which I think is throwing the baby out with the bathwater.

I suppose that the (main) raison is that this is not wanted in ci.  It was added do ci only to:
- Compute and view the checks on github;
- Make it easier to run using pre-commit.

This PR now disables running these scripts automatically in pre-commit and therefore also in the ci-flow.

The scripts pre-exist in the Dolibarr project and I only corrected them and made some improvements.

So this PR is mainly towards keeping these improvements while not running the scripts automatically but only when wanted.

Example:

```bash
 pre-commit run --hook-stage manual duplicate-lang-keys -a
 pre-commit run --hook-stage manual duplicate-lang-lines -a
 pre-commit run --hook-stage manual fix-alt-languages -a
```