### PR TITLE
Qual: Clean up codespell exceptions

### DIFF
--- a/dev/tools/codespell/codespell-ignore.txt
+++ b/dev/tools/codespell/codespell-ignore.txt
@@ -5,69 +5,39 @@ provid
 # PostgreSQL
 postgresql
 
-alltime
+# Inside email
 ba
 blacklist
-whitelist
 bu
-captial
 categorie
 categories
-crypted
 clos
-contaxt
-courant
-datea
-datee
+crypted
 errorstring
 exten
 falsy
 master
 medias
-noe
-NOO
-noo
-od
-nd
-udate
-periode
 projet
-referer
-referers
-scrit
-ser
+ro
 slave
-savvy
-# Inside email
-suport
 te
 technic
 thead
-udo
 ue
-ro
+whitelist
 ws
 # Code string
 ect
 tempdate
-# checkES
-checkes
 sav
 files'
-# Used as array ke
+# Used as array key
 seeked
-# Used as translation key
-developpers
-# Used as var
-pice
 # Used as key
 marge
-# htdocs/projet/activity/permonth.php
-tweek
 # moral (var name)
 mor
-# reyear, remonth, reday
-reday
 # Strings used as keys for translation
 uptodate
 reenable
@@ -87,5 +57,3 @@ dur
 fonction
 espace
 methode
-# Proper names
-tim

--- a/dev/tools/codespell/codespell-lines-ignore.txt
+++ b/dev/tools/codespell/codespell-lines-ignore.txt
@@ -1,2606 +1,331 @@
-													'capture' => true,							// Charge immediatly
-												// Save a stripe payment was done in realy life so later we will be able to force a commit on recorded payments
-											$pdf->SetFont('', '', $default_font_size - 1); // On repositionne la police par defaut
-											// Conversion du PDF en image png si fichier png non existant
-											// Save a stripe payment was done in realy life so later we will be able to force a commit on recorded payments
-											// To make a Stripe SEPA payment request, we must have the payment mode source already saved into societe_rib and retreived with ->sepaStripe
-										// If old value crypted in database is same than submited new value, it means we don't change it, so we don't update.
-										//break;	// No break for sortfield and sortorder so we can cumulate fields (is it realy usefull ?)
-									$errmsg = 'Failed to retreive paymentintent or charge from id';
-									$minifile = getImageFileNameForSize($fileinfo['basename'], '_mini'); // For new thumbs using same ext (in lower case howerver) than original
-									$more .= '<div clas="tagtd' . (empty($input['tdclass']) ? '' : (' "' . $input['tdclass'])) . '">&nbsp;</div>';
-									$more .= '<div clas="tagtd'.(empty($input['tdclass']) ? '' : (' "'.$input['tdclass'])).'">&nbsp;</div>';
-									$this->errors[] = "Error on updateing fk_prelevement_bons to ".$bon->id;
-									// Defaut
-									// Table of entities for export / Tableau des entites a exporter (cle=champ, valeur=entite)
-									// Table of entities requiring DISTINCT abandonment / Tableau des entites qui requiert abandon du DISTINCT (cle=entite, valeur=champ id child records)
-									// Table of fields to be filtered / Tableau des champs a filtrer (cle=champ, valeur1=type de donnees) on verifie que le module a des filtres
-									// Tableau des entites qui requiert abandon du DISTINCT (cle=entite, valeur=champ id child records)
-									console.log("We hide childs tickets of '.$groupcodefather.' group ticket")
-									console.log("We show childs tickets of '.$groupcodefather.' group ticket")
-									if (isset($this->oldcopy->array_options[$key]) && $this->array_options[$key] == $this->oldcopy->array_options[$key]) {	// If old value crypted in database is same than submited new value, it means we don't change it, so we don't update.
-									print '<input type="text" size="8" class="amount" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">'; // class is requied to be used by javascript callForResult();
-								$objMod->dictionaries = $objMod->dictionnaries; // For backward compatibility
+									|| !empty($dates) && empty($datee) && $loanSchedule->datep >= $dates && $loanSchedule->datep <= dol_now()
+									|| empty($dates) && !empty($datee) && $loanSchedule->datep <= $datee
 								$objMod->dictionaries = $objMod->{"dictionnaries"}; // For backward compatibility
-								$pdf->SetFont('', '', $default_font_size - 1); // On repositionne la police par defaut
-								$repid[$idforallfornewmodule] = $langs->trans("ActionAC_ALL_".strtoupper($module));
-								$repid[-98] = $langs->trans("ActionAC_AUTO");
-								$repid[-99] = $langs->trans("ActionAC_MANUAL");
-								// 0=Recommanded, 1=Experimental, 2=Developpement, 3=Other
-								// Batch number managment
-								// Defaut
-								// Detailed virtual stock, looks bugged, uncomplete and need heavy load.
-								// Dont try to send email when no recipient
-								// Note: For extrafield tablename, we have in importfieldshidden_array an enty 'extra.fk_object'=>'lastrowid-tableparent' so $keyfield is 'fk_object'
-								// On retire les espaces autour des = et parenthèses
-								// remove invalid value, as it didnt match anything
-								// we dont use the rank from orderline because we may have lines from several orders
-								dol_syslog("makeStripeSepaRequest get stripe connet account", LOG_DEBUG);
-								if (isset($this->oldcopy->array_options["options_".$key]) && $this->array_options["options_".$key] == $this->oldcopy->array_options["options_".$key]) {	// If old value crypted in database is same than submited new value, it means we don't change it, so we don't update.
-								print '<input type="hidden" class="amount" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">'; // class is requied to be used by javascript callForResult();
-								print '<input type="text" size="8" class="amount" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">'; // class is requied to be used by javascript callForResult();
-								print 'jQuery("select[name=\''.$paramkey.'\']").focus();'."\n"; // Not really usefull, but we keep it in case of.
-							$filles[$obj->fk_categorie_fille] = 1; // Set record for this child
-							$i2++; // a criteria for 1 more field was added to string (we can add several citeria for the same field as it is a multiselect search criteria)
-							$invoiceid = -1; // There is more than one invoice payed by this payment
-							$line->pa_ht = $line->pa_ht; // we choosed to have buy/cost price always positive, so no revert of sign here
-							$mesg .= '<br>Unkown Error, please refers to your administrator';
-							$result = $adh->setPassword($user, $this->pass, (!getDolGlobalString('DATABASE_PWD_ENCRYPTED') ? 0 : 1), 1); // Cryptage non gere dans module adherent
-							$result = $adh->setPassword($user, $this->pass, (empty($conf->global->DATABASE_PWD_ENCRYPTED) ? 0 : 1), 1); // Cryptage non gere dans module adherent
-							$result = $line->insert(0, 1); // When creating credit note with same lines than source, we must ignore error if discount alreayd linked
-							$s = array();    // Array with size of each page. Exemple array(w'=>210, 'h'=>297);
-							$value = ((!empty($this->array_options) && array_key_exists("options_".$key.$keysuffix, $this->array_options)) ? $this->array_options["options_".$key.$keysuffix] : null); // Value may be cleaned or formated later
-							$ways = $c->print_all_ways(' &gt;&gt; ', 'none', 0, 1); // $ways[0] = "ccc2 >> ccc2a >> ccc2a1" with html formated text
-							'capture'  => true, // Charge immediatly
-							'description'=>$fille->description,
-							'id'=>$fille->id,
-							'label'=>$fille->label,
-							'photos' => $fille->liste_photos($dir, $nbmax)
-							'socid'=>$fille->socid,
-							'type'=>$fille->type,
-							/* Force to recompute the width of a select2 field when it was hidden and then shown programatically */
-							// Batch number managment
-							// Detailed virtual stock, looks bugged, uncomplete and need heavy load.
-							// Example for remplacement
-							// If error is more than 10 times the accurancy of rounding. This should not happen.
-							// If margin is calculated on Cost price, we set it by defaut (but only if value is not 0)
-							// If margin is calculated on PMP, we set it by defaut (but only if value is not 0)
-							// If margin is calculated on best supplier price, we set it by defaut (but only if value is not 0)
-							// On remplace la virgule et l'arobase pour ne pas avoir de problème par la suite
-							// Removing space arount =, ( and )
-							// Show subproducts of product (not recommanded)
-							// TODO Que faire si update echoue car on update avec un login deja existant pour un autre compte.
-							// dont try to send email if no recipient
-							// note: $cs->mandate contians ID of mandate on Stripe side
-							// nous avons au moins une reponse
-							// nous n'avons pas de reponse => n'existe pas
-							//'visible'=>$fille->visible,
-							break; // break for loop incase of error
-							dol_syslog("functions_dolibarr::check_user_password_dolibarr Authentification ok - found old pass in database", LOG_WARNING);
-							dol_syslog("functions_dolibarr::check_user_password_dolibarr Authentification ok - hash ".$cryptType." of pass is ok");
-							hide: { delay: 50 }, 	/* If I enable effect:\'toggle\' here, a bug appears: the tooltip is shown when collpasing a new dir if it was shown before */
-							if ($reg[1] == 'thi') {   // Third-party
-							if (empty($objMod->dictionaries) && !empty($objMod->dictionnaries)) {
+								if (($loanSchedule->datep >= $dates && $loanSchedule->datep <= $datee) // dates filter is defined
+							$datee = $langs->trans("Unknown");
+							$datee = dol_print_date($objectligne->date_end, 'day', false, $outputlangs, true);
+							$txt .= $outputlangs->transnoentities("DateStartPlannedShort")." : <strong>".$datei."</strong> - ".$outputlangs->transnoentities("DateEndPlanned")." : <strong>".$datee.'</strong>';
 							if (empty($objMod->dictionaries) && !empty($objMod->{"dictionnaries"})) {
 							print '<a href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;id_entrepot='.$entrepotstatic->id.'&amp;action=transfert&amp;pdluoid='.$pdluo->id.'">';
-						$additionnalparam .= ($additionnalparam ? ' ' : '').'-U '.$additionnalparam; // Use -U to add additionnal params
-						$cat['filles'][] = array(
-						$invoiceid = -1; // There is more than one invoice payed by this payment
-						$newarrayres[$key]['type'] = (dol_strlen($val) ? 1 : -1); // If empty we considere it's null
-						$objectobj->thirdparty = $objectobj; // Hack so following code is comaptible when objectobj is a thirdparty
-						$outtva_tx_formated = price($objp->tva_tx);	// formated for langage user because is inserted into input field
-						$pdf->SetFont('', '', $default_font_size - 1); // On repositionne la police par defaut
-						$pdir = get_exdir($fille->id, 2, 0, 0, $categorie, 'category').$fille->id."/photos/";
-						$prods[$rec['rowid']]['childs'][$keyChild] = $valueChild;
-						$repid[$obj->id] = $label;
+						$object->date_ech = $object->periode;
+						$object->periode = $object->date_ech;
 						$reponsesadd = str_split($obj->reponses);
-						$s = array(); 	// Array with size of each page. Exemple array(w'=>210, 'h'=>297);
-						$s = array();    // Array with size of each page. Exemple array(w'=>210, 'h'=>297);
-						$serie[$i] .= 'd' . $i . '.push([' . $x . ', ' . $y . ']);' . "\n";
-						$serie[$i] .= 'd' . $i . '.push({"label":"' . dol_escape_js($legends[$x]) . '", "data":' . $y . '});' . "\n";
 						$sql .= " SET reponses = '".$db->escape($reponsesadd)."'";
 						$sql .= " SET reponses = '0".$db->escape($obj->reponses)."'";
-						$translationKey = 'CompanyHasAbsoluteDiscount'; // If we want deposit to be substracted to payments only and not to total of final invoice
-						$translationKey = 'HasAbsoluteDiscountFromSupplier'; // If we want deposit to be substracted to payments only and not to total of final invoice
-						$ways = $c->print_all_ways(' &gt;&gt; ', 'none', 0, 1); // $ways[0] = "ccc2 >> ccc2a >> ccc2a1" with html formated text
-						/*case 'select':	// Not required, we chosed value='0' for undefined values
-						// Batch number managment
-						// Case we dont use the list of available qty for each warehouse/lot
-						// Change each progression persent on each lines
-						// Conversion du PDF en image png si fichier png non existant
-						// Convert float submited string into real php numeric (value in memory must be a php numeric)
-						// If assignement was done and after, was removed from contact of project, then we can hide the line.
-						// If we want to closed payed invoices
-						// Information if theres a rule restriction
-						// Jump on next occurence
-						// Label mouvement
-						// Login is successfull with this method
-						// Lot/serie
-						// Message-ID=A, In-Reply-To=B, References=B and message can BE an answer but may be NOT (for example a transfer of an email rewriten)
-						// Message-ID=A, In-Reply-To=B, References=B and message can BE an answer or NOT (a transfer rewriten)
-						// Not a recongized record
-						// Note: This suppose that "pass_indatabase_crypted" is a md5 (guaranted by the previous test if "(empty($conf->global->MAIN_SECURITY_HASH_ALGO))"
-						// Objet
-						// On verifie si le login a change et on met a jour les attributs dolibarr
-						// Should not happend. Entries are added
-						// Si traduction existe, on l'utilise, sinon on prend le libelle par defaut
-						// TODO Check amount is same than the amount required for the type of member or if not defined as the defeault amount into $conf->global->MEMBER_NEWFORM_AMOUNT
-						// Tableau des entites a exporter (cle=champ, valeur=entite)
-						// This user is linked with a member, so we also update members informations
-						// apply note frame to previus pages
-						// because assignement on task can be done only on contact of project.
-						// by ths page itself with a .change on the combolist '#idprodfournprice'
-						// if we have a BILLING contact and we dont use it as thirdparty recipient we store the contact object for later use
-						// if we have a CUSTOMER contact and we dont use it as recipient we store the contact object for later use
-						// if we have a CUSTOMER contact and we dont use it as thirdparty recipient we store the contact object for later use
-						// if we have a SHIPPING contact and we dont use it as thirdparty recipient we store the contact object for later use
-						// service and we setted mandatory_period to true
-						//Time ressources
-						//comparaison des heures de fin et de debut
-						console.log("objectline_create.tpl Load desciption into text area : "+proddesc);
-						continue; // The field was not submited to be saved
-						dol_syslog("Entity was not set on http header with HTTP_DOLAPIENTITY (recommanded for performance purpose), so we switch now on entity of user (".$conf->entity.") and we have to reload configuration.", LOG_WARNING);
-						dol_syslog("functions_dolibarr::check_user_password_dolibarr Authentification ok - found old pass in database", LOG_WARNING);
-						dol_syslog("functions_dolibarr::check_user_password_dolibarr Authentification ok - found pass in database");
-						dol_syslog("functions_dolibarr::check_user_password_dolibarr Authentification ok - hash ".$cryptType." of pass is ok");
-						dol_syslog('We found unconsistent data into detailed line (diff_on_current_total = '.$diff_on_current_total.') for line rowid = '.$obj->rowid." (ht=".$obj->total_ht." vat=".$obj->total_tva." tax1=".$obj->total_localtax1." tax2=".$obj->total_localtax2." ttc=".$obj->total_ttc."). We fix the total_vat and total_ttc of line by running sqlfix = ".$sqlfix, LOG_WARNING);
-						dol_syslog(get_class($this)."::create ".$this->error, LOG_WARNING); // do not use dol_print_error here as it may be a functionnal error
-						foreach ($childrens as $child) {
-						if ($iinstack % 2) {	// We increase agressiveness of reference color for color 2, 4, 6, ...
-						if (empty($objecttmp->linkedObjectsIds['order_supplier']) || !in_array($value, $objecttmp->linkedObjectsIds['order_supplier'])) { //Dont try to link if already linked
-						print "\n<!-- NO JS CODE TO ENABLE the anonymous Ping. An error already occured this month, we will try later. -->\n";
+						$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.od(s|t)$', '', 'name', SORT_ASC, 0);
+						// $object->periode = dol_get_last_day(year of $object->date_ech - 1m, month or $object->date_ech -1m)
+						//$pice = '<i class="fas fa-briefcase inline-block"></i>';
+						//$typea = ($objp->typea == 'birth') ? $picb : $pice;
 						print '<td class="center"><a href="'.DOL_URL_ROOT.'/product/stock/product.php?dwid='.$object->id.'&id='.$objp->rowid.'&action=transfert&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$id).'">';
-						setEventMessage("actions.lib::show_actions_messaging Error fetch ressource", 'errors');
-						setEventMessage("company.lib::show_actions_done Error fetch ressource", 'errors');
-						} else {				// We decrease agressiveness of reference color for color 3, 5, 7, ..
-					$_SESSION["dol_loginmesg"] = "Failed to login using Google. OAuth callback URL retreives a token with non valid data";
-					$alreadygrabbed[$urltograbbis] = 1; // Track that file was alreay grabbed.
-					$childrens = $this->getChildrenOfLine($row[0]);
-					$cluser = new User($this->db);
-					$cluser->fetch($obj->fk_user_closing);
-					$cluser->fetch($obj->fk_user_cloture);
-					$erorr++;
-					$heigth = $tmp[3];
-					$info[$conf->global->LDAP_FIELD_PASSWORD] = $this->pass_indatabase; // $this->pass_indatabase = mot de passe non crypte
-					$info[$conf->global->LDAP_MEMBER_FIELD_PASSWORD] = $this->pass_indatabase; // $this->pass_indatabase = mot de passe non crypte
-					$info[getDolGlobalString('LDAP_FIELD_PASSWORD')] = $this->pass_indatabase; // $this->pass_indatabase = mot de passe non crypte
-					$info[getDolGlobalString('LDAP_MEMBER_FIELD_PASSWORD')] = $this->pass_indatabase; // $this->pass_indatabase = mot de passe non crypte
-					$objectoffield = $object; //For compatibily with the computed formula
-					$optstart .= ' data-tvatx-formated="' . dol_escape_htmltag(price($objp->tva_tx, 0, $langs, 1, -1, 2)) . '"';
-					$optstart .= ' data-tvatx-formated="'.dol_escape_htmltag(price($objp->tva_tx, 0, $langs, 1, -1, 2)).'"';
-					$outprice_ht = price($objp->price);			// formated for langage user because is inserted into input field
-					$outprice_ttc = price($objp->price_ttc);	// formated for langage user because is inserted into input field
-					$pdf->SetFont('', '', $default_font_size - 1); // On repositionne la police par defaut
-					$pdf->SetFont('','',  $default_font_size - 1);   // On repositionne la police par defaut
-					$postactionmessages[] = 'Payment donation can\'t be payed with diffent currency than '.$conf->currency;
-					$serie[$i] .= ($j > 0 ? ", " : "") . $y;
-					$serie[$i] .= ($j > 0 ? ", " : "") . 'null';
-					$this->fetch_prod_arbo($desc_pere['childs'], $compl_path.$desc_pere[3]." -> ", $desc_pere[1] * $multiply, $level + 1, $id, $ignore_stock_load);
-					$this->tva[$vatrate] += $tvaligne;	// ->tva is abandonned, we use now ->tva_array that is more complete
-					$this->user_closing = $cluser;
-					$this->user_cloture = $cluser;
-					$usertime = 0; // We dont modify date because we want to have date into memory datep and datef stored as GMT date. Compensation will be done during output.
-					$valuetoshow = ucfirst($value); // Par defaut
-					$ways = $c->print_all_ways(' &gt;&gt; ', 'none', 0, 1); // $ways[0] = "ccc2 >> ccc2a >> ccc2a1" with html formated text
-					&& $obj->status != $tmpobject::STATUS_ABANDONED	    // Not abandonned
-					'adress'=>$obj->adress,
-					'capture'  => true, // Charge immediatly
-					'transparency'=>$object->transparency, // Force transparency on onwer from preoperty of event
-					/* Remove selected id as soon as we type or delete a char (it means old selection is wrong). Use keyup/down instead of change to avoid loosing the product id. This is needed only for select of predefined product */
-					/*case 'select':	// Not required, we chosed value='0' for undefined values
-					// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again whith the caller
-					// Batch number managment
-					// Calculcate number of days consumed
-					// Cas des factures liees par un autre objet (ex: commande)
-					// Check string $this->db-> into a non class.php file (it shoud be $db-> into such classes)
-					// Classe facture
-					// Dates of service planed and real
-					// For exemple, we may have error: 'No such customer: cus_XXXXX; a similar object exists in live mode, but a test mode key was used to make this request.'
-					// For full day events, date are also GMT but they wont but converted using tz during output
-					// If translation exists, we use it, otherwise, we use tha had coded label
-					// If we want to closed payed invoices
-					// Line dates planed
-					// Message-ID=A, In-Reply-To=B, References=B and message can BE an answer or NOT (a transfer rewriten)
-					// Note: $obj->halfday is  0:Full days, 2:Sart afternoon end morning, -1:Start afternoon, 1:End morning
-					// Objet
-					// On charge les attributs du user ldap
-					// On selectionne les groupes auquel fait parti le user
-					// On verifie l'emplacement du modele
-					// Onwer
-					// Option to reload page to retrieve customer informations. Note, this clear other input
-					// Produit non deja existant
-					// Search submenu fot this mainmenu entry
-					// Selection of all product stock mouvements that contains batchs
-					// Si safe_mode on et command hors du parametre exec, on a un fichier out vide donc errormsg vide
-					// Si traduction existe, on l'utilise, sinon on prend le libelle par defaut
-					// Strip off the beggining '<'
-					// TODO If not defined, use $objectobj->model_pdf (or defaut invoice config) to know what is template to use to regenerate doc.
-					// TODO Replace this with a checkbox for each payment mode: "Send request to PaymentModeManager immediatly..."
-					// TODO Replace this with a checkbox for each payment mode: "Send request to XXX immediatly..."
-					// TODO Show vat amout per tax level
-					// The image must have the class 'boxhandle' beause it's value used in DOM draggable objects to define the area used to catch the full object
-					// This member is linked with a thirdparty, so we also update thirdparty informations
-					// This member is linked with a user, so we also update users informations
-					// This part of code is no more required. it is here to solve case where a link were missing (ith v14.0.0) and keep writing in accountancy complete.
-					// Time ressources
-					// Unformatted text, added after text. Usefull to add/load javascript code
-					// Upgrade connexion to TLS, if requested by the configuration
-					// We check if lines of invoice are not already transfered into accountancy
-					// We dont use dol_escape_htmltag to get the html formating active, but this need we must also
-					// after the first line, we only need to check for it in the middle, not at the beginning of an insert (becuase the beginning will be on the first line)
-					// at a time, and thats just stupid, so lets just hope this doesnt appear anywhere in the actual data
-					// de ceux du produit par defaut (par exemple si pays different entre vendeur et acheteur).
-					// if we have a PROJECTLEADER contact and we dont use it as recipient we store the contact object for later use
-					// multiselect array convert html entities into options tags, even if we dont want this, so we encode them a second time
-					// save curent cell padding
-					//$sql .= " AND (status <> 3 OR close_code <> 'abandon')";		// Not abandonned for undefined reason
-					//Esle it's separated key/value and coma list
-					//If text set in desc is the same as product descpription (as now it's preloaded) whe add it only one time
-					//No diff => mean everythings is received
-					//No diff => mean everythings is shipped
-					<p class="content">Nam elementum nisl et mi a commodo porttitor. Morbi sit amet nisl eu arcu faucibus hendrerit vel a risus. Nam a orci mi, elementum ac arcu sit amet, fermentum pellentesque et purus. Integer maximus varius lorem, sed convallis diam accumsan sed. Etiam porttitor placerat sapien, sed eleifend a enim pulvinar faucibus semper quis ut arcu. Ut non nisl a mollis est efficitur vestibulum. Integer eget purus nec nulla mattis et accumsan ut magna libero. Morbi auctor iaculis porttitor. Sed ut magna ac risus et hendrerit scelerisque. Praesent eleifend lacus in lectus aliquam porta. Cras eu ornare dui curabitur lacinia.</p>
+					$date = $overview[0]->udate;
+					$dateb = $this->db->jdate($data[$j]->datea);
+					$link->datea = $this->db->jdate($obj->datea);
+					$object->periode = $newdateperiod;
+					$out .= dol_print_date($file->datea, 'dayhour');
+					$pice = '<i class="fas fa-briefcase inline-block"></i>';
+					$taskstatic->date_end = $this->db->jdate($objp->datee);
+					$tmp = $element->getSumOfAmount($idofelementuser ? $elementuser : '', $dates, $datee);
+					$tmpprojtime = $element->getSumOfAmount($idofelementuser ? $elementuser : '', $dates, $datee); // $element is a task. $elementuser may be empty
+					$typea = ($data[$j]->typea == 'birth') ? $picb : $pice;
+					//var_dump("$key, $tablename, $datefieldname, $dates, $datee");
 					GETPOST("mouvement", 'int'),
-					console.log("Clik on #topmenulogincompanyinfo-btn");
-					console.log("Clik on #topmenuloginmoreinfo-btn");
-					console.log("Clik on topmenulogincompanyinfo-btn");
-					console.log("Clik on topmenuloginmoreinfo-btn");
-					console.log("chartofaccounts seleted = "+$("#chartofaccounts").val());
-					dol_syslog("Function: deleteThirdParty cant delete");
-					dol_syslog('Save lastsearch_values_tmp_'.$key.'='.json_encode($val, 0)." (systematic recording of last search criterias)");
-					error="Database $dbname NOT successfully droped. You have to do it manually."
-					foreach ($cats as $fille) {
-					if (!empty($childrens)) {
-					if (!getDolGlobalString('PROJECT_DISABLE_UNLINK_FROM_OVERVIEW') || $user->admin) {		// PROJECT_DISABLE_UNLINK_FROM_OVERVIEW is empty by defaut, so this test true
-					if (!isset($filles[$obj->fk_categorie_fille])) {	// Only one record as child (a child has only on parent).
-					if ($conf->file->mailing_limit_sendbyweb != '-1') {  // MAILING_LIMIT_SENDBYWEB was set to -1 in database, but it is allowed ot increase it.
-					if ($login && $login != '--bad-login-validity--') {	// Login is successfull
-					if (((isModEnabled("fournisseur") && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || isModEnabled("supplier_order")) && !empty($conf->global->WORKFLOW_BILL_ON_RECEPTION)) {  // Quand l'option est on, il faut avoir le bouton en plus et non en remplacement du Close ?
-					if (count($diff_array) == 0 && count($keysinwishednotindelivered) == 0 && count($keysindeliverednotinwished) == 0) { //No diff => mean everythings is received
-					if (empty($conf->global->PROJECT_DISABLE_UNLINK_FROM_OVERVIEW) || $user->admin) {		// PROJECT_DISABLE_UNLINK_FROM_OVERVIEW is empty by defaut, so this test true
-					if (isModEnabled("supplier_order") && !empty($conf->global->WORKFLOW_BILL_ON_RECEPTION)) {  // Quand l'option est on, il faut avoir le bouton en plus et non en remplacement du Close ?
-					if (isModEnabled('facture') && !empty($conf->global->WORKFLOW_BILL_ON_SHIPMENT)) {  // Quand l'option est on, il faut avoir le bouton en plus et non en remplacement du Close ?
-					if (isNaN(pbq)) { console.log("We use experimental option PRODUIT_CUSTOMER_PRICES_BY_QTY or PRODUIT_CUSTOMER_PRICES_BY_QTY but we could not get the id of pbq from product combo list, so load of price may be 0 if product has differet prices"); }
+					dol_syslog("msgid=".$overview[0]->message_id." date=".dol_print_date($overview[0]->udate, 'dayrfc', 'gmt')." from=".$overview[0]->from." to=".$overview[0]->to." subject=".$overview[0]->subject);
+					if ((empty($dates) && empty($datee)) || (intval($dates) <= $element->datestart && intval($datee) >= $element->dateend)) {
 					jQuery("#mouvement option").removeAttr("selected").change();
 					jQuery("#mouvement option[value=0]").attr("selected","selected").trigger("change");
 					jQuery("#mouvement option[value=1]").attr("selected","selected").trigger("change");
 					jQuery("#mouvement").trigger("change");
-					print "ERROR: Failed to include file '".$filephp."'. Try to edit and re-save page ith this ID.";
-					print '<div class="div-table-responsive-no-min">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-					setEventMessages($langs->trans('Bad value for email, emai lwas not verified by Google'), null, 'errors');
-					} else { // Pour les autres schémas, les membres sont listés sous forme de DN complets
-				 $newmenu->add("/compta/stats/comp.php?leftmenu=report","Transforme",2,$user->hasRight('compta',  'resultat', 'lire'));
-				 * Section Creditor (sepa Crediteurs bloc lines)
-				 * Section Debitor (sepa Debiteurs bloc lines)
-				"confirm" => $confirmnow, // Do not confirm immediatly during creation of intent
-				"confirm" => $confirmnow, // try to confirm immediatly after create (if conditions are ok)
-				$ErrorLongMsg = "Session expired. Can't retreive PaymentType. Payment has not been validated.";
-				$accountparent->account_number = $obj->account_number2; // Sotre an account number for output
+					print '<td colspan="'.(6 + count($TWeek)).'">';
+				$TFirstDay = getFirstDayOfEachWeek($TWeek, date('Y', $firstdaytoshow));
+				$TFirstDay[reset($TWeek)] = 1;
 				$action = 'transfert';
-				$allways = $parent->get_all_ways();
-				$bugbaseurl .= urlencode("## [Attached files](https://help.github.com/articles/issue-attachments) (Screenshots, screencasts, dolibarr.log, debugging informations…)\n");
-				$childs[] = array_combine($keys, $values);
-				$curent = getDolGlobalString($thisTypeConfName, getDolGlobalString('FACTURE_ADDON_PDF'));
-				$filterabsolutediscount = "fk_facture_source IS NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-				$filtercreditnote = "fk_facture_source IS NOT NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-				$info[$conf->global->LDAP_FIELD_PASSWORD] = $this->pass; // this->pass = mot de passe non crypte
-				$info[$conf->global->LDAP_MEMBER_FIELD_PASSWORD] = $this->pass; // this->pass = mot de passe non crypte
-				$info[getDolGlobalString('LDAP_FIELD_PASSWORD')] = $this->pass; // this->pass = mot de passe non crypte
-				$info[getDolGlobalString('LDAP_MEMBER_FIELD_PASSWORD')] = $this->pass; // this->pass = mot de passe non crypte
-				$initialY = $tab_top + 7;
-				$invoicestatic->statut = $obj->fk_statut;	// For backward comaptibility
-				$jsListType .= (!empty($jsListType) ? ',' : '').'"'.$type.'":"'.$curent.'"';
-				$newmenu->add("/projet/list.php?leftmenu=projets".($search_project_user ? '&search_project_user='.$search_project_user : ''), $langs->trans("List"), 1, $showmode, '', 'project', 'list');
-				$newmenu->add("/projet/list.php?leftmenu=projets".($search_project_user ? '&search_project_user='.$search_project_user : '').'&search_status=99', $langs->trans("List"), 1, $showmode, '', 'project', 'list');
-				$object->actionmsg = dol_concatdesc($object->actionmsg, "\n".$langs->transnoentities("AttachedFiles").': '.$attachs);
-				$paramfortooltipimg .= ' title="' . ($noencodehtmltext ? $htmltext : dol_escape_htmltag($htmltext, 1)) . '"'; // Attribut to put on img tag to store tooltip
-				$paramfortooltipimg .= ' title="'.($noencodehtmltext ? $htmltext : dol_escape_htmltag($htmltext, 1)).'"'; // Attribut to put on img tag to store tooltip
-				$paramfortooltiptd .= ' title="' . ($noencodehtmltext ? $htmltext : dol_escape_htmltag($htmltext, 1)) . '"'; // Attribut to put on td tag to store tooltip
-				$paramfortooltiptd .= ' title="'.($noencodehtmltext ? $htmltext : dol_escape_htmltag($htmltext, 1)).'"'; // Attribut to put on td tag to store tooltip
-				$showfield = 1; // Par defaut
-				$societe->note_private = "Default customer automaticaly created by Point Of Sale module activation. Can be used as the default generic customer in the Point Of Sale setup. Can also be edited or removed if you don't need a generic customer.";
-				$tagdatabase = true; // We don't know what it was before, so now we consider we are version choosed.
+				$addform .= '<input type="hidden" name="dateerfc" value="'.dol_print_date($datee, 'dayhourrfc').'">';
+				$date_liv = dol_mktime(GETPOST('rehour'), GETPOST('remin'), GETPOST('resec'), GETPOST("remonth"), GETPOST("reday"), GETPOST("reyear"));
+				$newfiletmp = preg_replace('/\.od(s|t)/i', '', $newfile);
+				$newfiletmp = preg_replace('/\.od[ts]/i', '', $newfile);
+				$object->period = dol_time_plus_duree($object->periode, 1, 'm');
+				$object->periode = dol_time_plus_duree($object->periode, 1, 'm');
+				$project_static->date_end = $this->db->jdate($obj->datee);
+				$projectstatic->date_end = $db->jdate($objp->datee);
+				$ret = projectLinesPerMonth($inc, $firstdaytoshow, $fuser, $lines[$i]->id, ($parent == 0 ? $lineswithoutlevel0 : $lines), $level, $projectsrole, $tasksrole, $mine, $restricteditformytask, $isavailable, $oldprojectforbreak, $TWeek);
+				$taskstatic->datee = $lines[$i]->date_end; // deprecated
 				$this->category->childs[] = $this->_cleanObjectDatas($cat);
-				$this->civility_id = $obj->civility_code; // Bad. Kept for backard compatibility
-				$this->date_delivery        = $this->db->jdate($obj->date_delivery); // Date planed
-				$this->liste_array = $repid;
-				$this->statut = self::STATUS_DRAFT;	// dperecated
-				$this->stringtoshow .= $serie[$i] . "\n";
-				$this->stringtoshow .= $this->mirrorGraphValues ? '[' . -$serie[$i] . ',' . $serie[$i] . ']' : $serie[$i];
-				$this->stringtoshow .= $this->mirrorGraphValues ? '[-' . $serie[$i] . ',' . $serie[$i] . ']' : $serie[$i];
-				$this->stringtoshow .= '  data: [' . $serie[$i] . ']';
-				$this->stringtoshow .= '<!-- Serie ' . $i . ' -->' . "\n";
+				$this->date_approbation = $this->db->jdate($obj->datea);
+				$this->date_approval = $this->db->jdate($obj->datea);
+				$this->date_approve      = $this->db->jdate($obj->datea);
+				$this->datea = $this->db->jdate($obj->datea);
+				$this->datee        = $this->db->jdate($obj->datee);
+				$this->periode = $this->db->jdate($obj->period);
 				$tmp = array('id_users'=>$obj->id_users, 'nom'=>$obj->name, 'reponses'=>$obj->reponses);
-				$valuetoshow = ucfirst($fieldlist[$field]); // Par defaut
-				$ways = $c->print_all_ways(' &gt;&gt; ', ($nolink ? 'none' : ''), 0, 1); // $ways[0] = "ccc2 >> ccc2a >> ccc2a1" with html formated text
-				'align' => 'L', // text alignement :  R,C,L
-				'dol_company' => $mysoc->name, // Usefull when using multicompany
-				'textkey' => 'Designation', // use lang key is usefull in somme case with module
-				/* If page_y set, we set scollbar with it */
-				/* Removed due to awful harcoded values
-				/*case 'select':	// Not required, we chosed value='0' for undefined values
-				// $pdf->GetY() here can't be used. It is bottom of the second addresse box but first one may be higher
-				// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again whith the caller
-				// Add entry into bank accoun
-				// Add field of attribut
-				// Add link to the Direct Debit if invoice redused ('InvoiceRefused') in bank_url
-				// Ajout de l'utilisateur dans le groupe
-				// Batch number managment
-				// By default, electronic transfert from bank to bank
-				// Calculcate number of days consumed
-				// Complete object by loading several other informations
-				// Default and recommended: New method using ajax without submiting a page making a javascript history.go(-1) back
-				// Define $fileEmetteurSection. Start of bloc PmtInf. Will contains all $nbtotalDrctDbtTxInf
-				// Define heigth of table for lines (for first page)
-				// Define message to recommand from command line
-				// Definie date debut et fin par defaut
-				// Desactivation des modules qui entrent en conflit
-				// Dont display separator yet even is set to be displayed (not compatible yet)
-				// Exemple of var_dump $outarray
-				// Files missings
-				// Fix Get multicurrency param for transmited
-				// Fonctions de conversion non presente dans ce PHP
-				// Get lines of sources alread delivered
-				// Get next free nuber for the ref of bon
-				// Get next free nunber for the ref of bon prelevement
-				// If create form is coming from same page, it means that post was sent but an error occured
-				// If not abandonned
-				// If option "one bill per third" is set, and an invoice for this thirdparty was already created, we re-use it.
-				// If this->filter/this->filtergroup is empty, make fiter on * (all)
-				// Information if theres a rule restriction
-				// Informations on receipt
-				// Lop on each packacge of the metapackage
-				// MAILING_LIMIT_SENDBYCLI may be defined ot not (-1=forbidden, 0 or undefined=no limit).
-				// MAILING_LIMIT_SENDBYDAY may be defined ot not (0 or undefined=no limit).
-				// Mise a jour informations denormalisees au niveau de la commande meme
-				// Mise a jour informations denormalisees au niveau de la facture meme
-				// Mise a jour informations denormalisees au niveau de la propale meme
-				// No break, we sould test if another rule is violated
-				// No temp directory provided, so we are not able to support convertion of data:image into physical images.
-				// On verifie l'emplacement du modele
-				// Option to reload page to retrieve customer informations. Note, this clear other input
-				// Or set status to "In porgress" if the client has answered and if the ticket has started
-				// Ordre SQL ne necessitant pas de connexion a une base (exemple: CREATE DATABASE)
-				// Payment informations
-				// Proprietes particulieres a facture de remplacement
-				// Recursive call if there is childs to child
-				// Retreive lines
-				// See example with selectsearchbox.php. This case is reserverd for the selectesearchbox.php so we can
-				// Seperate "Real Name" from eMail address
-				// Should not happend. Entries are added
-				// Si on a un gestionnaire de generation de mot de passe actif
-				// Si traduction existe, on l'utilise, sinon on prend le libelle par defaut
-				// Situations totals migth be wrong on huge amounts with old mode 1
-				// Subscription informations
-				// TODO : if base exists in unit dictionary table, remove this convertion exception and update convertion infos in database.
-				// TODO Can we set it to submited ?
-				// TODO Replace this with a checkbox for each payment mode: "Send request to XXX immediatly..."
-				// TODO We can't, we dont' have full path of file, only last_main_doc and ->element, so we must first rebuild full path $destfull
-				// This convert an embedd file with src="/viewimage.php?modulepart... into a cid link
-				// This make 12 calls for each accountancy account (12 monthes M)
-				// Validate immediatly the order
-				// Warning, the function may add a LF so we are forced to trim to compare with old $out without having always a difference and an infinit loop.
-				// We chack if file exists
-				// We check if lines of invoice are not already transfered into accountancy
-				// We dont want on all entities, we delete all and current
-				// We must filter on assignement table
-				// at a time, and thats just stupid, so lets just hope this doesnt appear anywhere in the actual data
-				// caculate new total line qty
-				// category calculed
-				// dont display if empty
-				// if credit note, dont allow to modify margin
-				// in after, we need to watch out for escape format strings, ie (E'escaped \r in a string'), and ('bla',E'escaped \r in a string'), but could also be (number, E'string'); so we cant search for the previoous '
-				// multiselect array convert html entities into options tags, even if we dont want this, so we encode them a second time
-				// to display inport button on tpl
-				//$newstatus=3;  // Submited
-				//$sql.= " AND entity IN (0,".$conf->entity.")";      Do not test on entity here. We want to see if there is still on field remaning in other entities before deleting field in table
-				//$this->stringtoshow .= $serie[$i]."\n";
-				//$vat_src_code_for_line = $line->vat_src_code;		// TODO We chek sign of total per vat without taking into account the vat code because for the moment the vat code is lost/unknown when we add a down payment.
-				//Check tms timestamp field case (in Mysql this field is defautled to now and
-				//If text set in desc is the same as product descpription (as now it's preloaded) whe add it only one time
-				//If text set in desc is the same as product description (as now it's preloaded) whe add it only one time
-				//Libellé manuel
+				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.od(s|t)$', '', 'name', SORT_ASC, 0, true); // Disable hook for the moment
 				//si les reponses ne concerne pas la colonne effacée, on concatenate
-				//si les reponses ne concerne pas la colonne effacée, on concatene
 				GETPOST("mouvement", "int"),
 				GETPOST("mouvement", 'alpha'),
 				GETPOST("mouvement", 'int'),
-				console.log("Capture paymentIntent successfull "+paymentIntentId);
-				continue; // The field was not submited to be saved
-				dol_syslog("The user login has a validity between [".$user->datestartvalidity." and ".$user->dateendvalidity."], curren date is ".dol_now());
-				dol_syslog("functions_isallowed::check_user_api_key Authentication KO for '".$login."': The user login has a validity between [".$fuser->datestartvalidity." and ".$fuser->dateendvalidity."], curren date is ".dol_now());
-				dol_syslog('Bad password, connexion refused (see a previous notice message for more info)', LOG_NOTICE);
-				dol_syslog('Bad password, connexion refused', LOG_DEBUG);
-				dol_syslog('Bad value for code, connexion refused');
-				dol_syslog('Bad value for code, connexion refused', LOG_NOTICE);
-				dol_syslog('Call fetch_barcode with barcode_type not defined and cant be guessed', LOG_WARNING);
-				foreach ($allways as $way) {
-				foreach ($legends as $val) {	// Loop on each serie
-				fwrite($handle, "\n-- WARNING: Show create table ".$table." return empy string when it should not.\n");
-				if ($ex) { // are we expecting an operator but have a number/variable/function/opening parethesis?
-				if ($forcedroundingmode == '1') {	// Check if we need adjustement onto line for vat. TODO This works on the company currency but not on foreign currency
-				if ($forcedroundingmode == '1') {	// Check if we need adjustement onto line for vat. TODO This works on the company currency but not on multicurrency
-				if (isModEnabled('facture') && !empty($conf->global->WORKFLOW_BILL_ON_RECEPTION)) {  // Quand l'option est on, il faut avoir le bouton en plus et non en remplacement du Close ?
-				if (isModEnabled('facture') && !empty($conf->global->WORKFLOW_BILL_ON_SHIPMENT)) {  // Quand l'option est on, il faut avoir le bouton en plus et non en remplacement du Close ?
-				if (isset($desc_pere['childs']) && is_array($desc_pere['childs'])) {
+				foreach ($TWeek as $weekIndex => $weekNb) {
+				if (count($arrayfields) > 0 && !empty($arrayfields['t.datee']['checked'])) {
 				if (jQuery("#mouvement").val() == \'0\') jQuery("#unitprice").removeAttr("disabled");
-				if (preg_match('/\+(thi|ctc|use|mem|sub|proj|tas|con|tic|pro|ord|inv|spro|sor|sin|leav|stockinv|job|surv|salary)([0-9]+)@/', $emailto, $reg)) {
-				include_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php'; // The compoent may be included into ajax page that does not include the Form class
-				log="${log}Droping database $dbname."
 				print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=transfert">'.$langs->trans("TransferStock").'</a>';
-				print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=transfert">'.$langs->trans("TransferStock").'</a>';
-				print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-				print '<div class="div-table-responsive-no-min">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-				print '<div class="inline-block marginrightonly">';	// Button include dynamic contant
-				return $this->trigger(9, "an unexpected error occured");
-				} // don't wast resourses if we don't need them...
-				} elseif ($links[$key]['type'] == 'banktransfert') {	// transfert between 1 local account and another local account
-			 *  'foreignkey'=>'tablename.field' if the field is a foreign key (it is recommanded to name the field fk_...).
-			 *  @param  array	$menu_array_before 	       	Table of menu entries to show before entries of menu handler. This param is deprectaed and must be provided to ''.
-			 * @param 	string 	$head			 Optionnal head lines
-			 * Ouput html header of a page. It calls also top_httphead()
-			$action = ''; // Do not show form post if there was at least one successfull sent
+				print '<td class="center">'.dol_print_date($link->datea, "dayhour", "tzuser").'</td>';
 			$action = 'transfert';
-			$alreadyfound = array($id=>1); // We init array of found object to start of tree, so if we found it later (should not happened), we stop immediatly
-			$api_key = $_SERVER['HTTP_DOLAPIKEY']; // With header method (recommanded)
-			$attachs = $_SESSION['listofnames-'.$object->trackid];
-			$buyingprice = price2num(GETPOST('buying_price'.$predef) != '' ? GETPOST('buying_price'.$predef) : ''); // If buying_price is '0', we muste keep this value
-			$canconvert = 1; // we can convert credit note into discount if credit note is not payed back and not already converted and amount of payment is 0 (see real condition into condition used to show button converttoreduc)
-			$canconvert = 1; // we can convert deposit into discount if deposit is payed (completely, partially or not at all) and not already converted (see real condition into condition used to show button converttoreduc)
-			$childs = array();
-			$childs[] = array_combine($keys, $values);
-			$curent = !empty($conf->global->{$thisTypeConfName}) ? $conf->global->{$thisTypeConfName}:$conf->global->FACTURE_ADDON_PDF;
+			$date_com = dol_mktime(GETPOST('rehour', 'int'), GETPOST('remin', 'int'), GETPOST('resec', 'int'), GETPOST('remonth', 'int'), GETPOST('reday', 'int'), GETPOST('reyear', 'int'));
+			$date_next_execution = (GETPOST('remonth') ? dol_mktime(12, 0, 0, GETPOST('remonth'), GETPOST('reday'), GETPOST('reyear')) : -1);
+			$date_next_execution = dol_mktime($rehour, $remin, 0, $remonth, $reday, $reyear);
+			$datee = dol_get_last_day(GETPOST('yeartoexport', 'int'), GETPOST('monthtoexport', 'int') ? GETPOST('monthtoexport', 'int') : 12);
+			$datesubscription = dol_mktime(12, 0, 0, GETPOST("remonth", 'int'), GETPOST("reday", "int"), GETPOST("reyear", "int"));
 			$ensemblereponses = $obj->reponses;
-			$event->datep = dol_mktime(0, 0, 0, $datearray['mon'], $datearray['mday'], $year, true); // For full day events, date are also GMT but they wont but converted during output
-			$ext = 'version='.GETPOST('version', 'int'); // usefull to force no cache on css/js
-			$filles = array();
-			$filterabsolutediscount = "fk_facture_source IS NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-			$filterabsolutediscount = "fk_invoice_supplier_source IS NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-			$filtercreditnote = "fk_facture_source IS NOT NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-			$filtercreditnote = "fk_invoice_supplier_source IS NOT NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-			$invoicestatic->statut = $obj->fk_statut;	// For backward comaptibility
-			$jsListType .= (!empty($jsListType) ? ',' : '').'"'.$type.'":"'.$curent.'"';
-			$level = 0; // if $level = -1, we dont' use sublevel recursion, we show all lines
-			$line->pa_ht = $line->pa_ht; // we choosed to have buy/cost price always positive, so no revert of sign here
-			$msgishtml = -1; // Unknow = autodetect by default
-			$msgishtml = -1; // Unknow by default
-			$paht_ret = $paht;
-			$paramfortooltipimg = ($extracss ? ' class="' . $extracss . '"' : '') . ($extrastyle ? ' style="' . $extrastyle . '"' : ''); // Attribut to put on td text tag
-			$paramfortooltipimg = ($extracss ? ' class="'.$extracss.'"' : '').($extrastyle ? ' style="'.$extrastyle.'"' : ''); // Attribut to put on td text tag
-			$paramfortooltiptd = ($extracss ? ' class="' . $extracss . '"' : '') . ($extrastyle ? ' style="' . $extrastyle . '"' : ''); // Attribut to put on td text tag
-			$paramfortooltiptd = ($extracss ? ' class="'.$extracss.'"' : '').($extrastyle ? ' style="'.$extrastyle.'"' : ''); // Attribut to put on td text tag
-			$pdf->MultiCell($this->posxdiscount - $this->posxunit, 2, $outputlangs->transnoentities("Label Mouvement"), '', 'C');
-			$pdf->MultiCell(190, 5, $outputlangs->transnoentities("Informations"), '', 'L');*/
-			$pdf->SetXY($this->getColumnContentXStart($colKey), $curY); // Set curent position
-			$result -= $amountToBreakdown; // And canceled substraction has been replaced by breakdown
-			$result = $ldap->add($dn, $info, $user); // Wil fail if already exists
-			$result = $line->insert(0, 1); // When creating credit note with same lines than source, we must ignore error if discount alreayd linked
-			$serie[$i] = "";
-			$serie[$i] = "var d" . $i . " = [];\n";
-			$showfield = 1; // By defaut
-			$sql .= " AND f.fk_statut = 2"; // payed     Not that some corrupted data may contains f.fk_statut = 1 AND f.paye = 1 (it means payed too but should not happend. If yes, reopen and reclassify billed)
-			$sql .= " AND f.fk_statut = 3"; // abandonned
-			$sql .= " WHERE c.entity IN (".getEntity('commande').")"; // Dont't use entity if you use rowid
-			$sql .= " WHERE fk_facture_source = ".((int) $this->fk_facture_source); // Delete all lines of same serie
-			$sql .= " WHERE fk_invoice_supplier_source = ".((int) $this->fk_invoice_supplier_source); // Delete all lines of same serie
-			$sql .= " WHERE p.entity IN (0,".getEntity('partnership').")"; // Dont't use entity if you use rowid
-			$sql .= '(SELECT MAX(fs.rowid)'; // This select returns several ID becasue of the group by later
-			$sql = 'INSERT INTO '.MAIN_DB_PREFIX.'opensurvey_user_studs (nom, id_sondage, reponses)';
+			$object->datee = $datee;
+			$object->periode = $dateperiod;
+			$return .= '<br><span class="opacitymedium">'.$langs->trans("Payement").'</span> : <span class="info-box-label">'.$this->type_payment.'</span>';
+			$sortfield = "datea";
+			$sql .= " '".$db->escape($conf->currency)."' as currency, 0 as fk_soc, t.date_ech as date, t.periode as date_due, 'SocialContributions' as item, '' as thirdparty_name, '' as thirdparty_code, '' as country_code, '' as vatnum, ".PAY_DEBIT." as sens";
+			$sql .= " , datee = ".(!empty($obj->datee) ? "'".$this->db->escape($obj->datee)."'" : "null");
+			$sql .= " AND (".$datefieldname." <= '".$this->db->idate($datee)."' OR ".$datefieldname." IS NULL)";
+			$sql .= " AND (p.datee IS NULL OR p.datee >= ".$db->idate(dol_get_first_day($project_year_filter, 1, false)).")";
+			$sql .= " AND date_creation BETWEEN '".$db->idate($dates)."' AND '".$db->idate($datee)."'";
+			$sql .= " AND er.datee >= '".$this->db->idate($date)."'";
+			$sql .= " ORDER BY pt.datee ASC, pt.dateo ASC";
+			$sql .= " t.datec, t.dateo, t.datee, t.tms,";
+			$sql .= " t.dateo, t.datee, t.planned_workload, t.rang,";
+			$sql .= ", datee = ".($this->date_end != '' ? "'".$this->db->idate($this->date_end)."'" : 'null');
+			$sql .= "SELECT u.rowid, u.firstname, u.lastname, u.dateemployment as datea, date_format(u.dateemployment, '%d') as daya, 'employment' as typea, u.email, u.statut as status";
+			$sql = "SELECT pt.rowid, pt.ref, pt.fk_projet, pt.fk_task_parent, pt.datec, pt.dateo, pt.datee, pt.datev, pt.label, pt.description, pt.duration_effective, pt.planned_workload, pt.progress";
+			$sql = "SELECT u.rowid, u.firstname, u.lastname, u.birth as datea, date_format(u.birth, '%d') as daya, 'birth' as typea, u.email, u.statut as status";
 			$sql = 'INSERT INTO '.MAIN_DB_PREFIX.'opensurvey_user_studs (nom, id_sondage, reponses, date_creation)';
 			$sql = 'INSERT INTO '.MAIN_DB_PREFIX.'opensurvey_user_studs (nom, id_sondage, reponses, ip, date_creation)';
 			$sql = 'SELECT s.reponses';
 			$sql2 .= " SET reponses = '".$db->escape($newcar)."'";
+			$taskstatic->datee = $db->jdate($obj->date_end);
 			$this->category->childs = array();
-			$this->db->query('INSERT INTO '.MAIN_DB_PREFIX.'c_type_contact(rowid, element, source, code, libelle, active, module, position) VALUES('.((int) $nextid).', "StockTransfer", "external", "STDEST", "Contact destinataire transfert de stocks", 1, NULL, 0)');
-			$this->db->query('INSERT INTO '.MAIN_DB_PREFIX.'c_type_contact(rowid, element, source, code, libelle, active, module, position) VALUES('.((int) $nextid).', "StockTransfer", "external", "STFROM", "Contact expéditeur transfert de stocks", 1, NULL, 0)');
-			$this->db->query('INSERT INTO '.MAIN_DB_PREFIX.'c_type_contact(rowid, element, source, code, libelle, active, module, position) VALUES('.((int) $nextid).', "StockTransfer", "internal", "STRESP", "Responsable du transfert de stocks", 1, NULL, 0)');
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // Par defaut, si n'etait pas defini
-			$this->error = 'update_note was called on objet with property table_element not defined';
-			$this->modelpdf = $modelpdf; // For bakward compatibility
-			$this->output .= ' Send email successfuly to '.$nbok.' members';
-			$this->product->sousprods = $childs;
-			$this->tpl['yn_assujtva'] = $form->selectyesno('assujtva_value', $this->tpl['tva_assuj'], 1); // Assujeti par defaut en creation
-			$title = preg_replace("/([[:alnum:]])\?([[:alnum:]])/", "\\1'\\2", $title); // Gere probleme des apostrophes mal codee/decodee par utf8
-			$title = preg_replace("/^\s+/", "", $title); // Supprime espaces de debut
-			$trans_colour = imagecolorallocate($imgTarget, 255, 255, 255); // On procede autrement pour le format GIF
-			$trans_colour = imagecolorallocate($imgThumb, 255, 255, 255); // On procede autrement pour le format GIF
-			$txtforsticker = "%PHOTO%"; // Photo will be barcode image, %BARCODE% posible when using TCPDF generator
-			$values = array(); // Array with horizontal y values (specific values of a serie) for each abscisse x
-			$values = array(); // Array with horizontal y values (specific values of a serie) for each abscisse x (with x=0,1,2,...)
-			$valuetoshow = ucfirst($fieldlist[$field]); // By defaut
-			$valuetoshow = ucfirst($fieldlist[$field]); // Par defaut
-			$valuetoshow = ucfirst($value); // Par defaut
-			$ways = $c->print_all_ways(' &gt;&gt; ', 'none', 0, 1); // $ways[0] = "ccc2 >> ccc2a >> ccc2a1" with html formated text
-			'sr.type' => "Type ban is defaut",
-			/* Disabled because bcc must remain by defintion not visible
-			// $_POST contains fk_commandefourndet_X_Y    where Y is num of product line and X is number of splitted line
-			// $new_array_options will be used for direct update, so must contains formated data for the UPDATE.
-			// $opt['filter[id]'] contais list of product id that are result of search
-			// 1 - Association des utilisateurs du groupe LDAP au groupe Dolibarr
-			// 2 - Suppression des utilisateurs du groupe Dolibarr qui ne sont plus dans le groupe LDAP
-			// A redirect is added if API call successfull
-			// Action according to choosed sending method
-			// Action according to the choosed sending method
-			// Add entry into bank accoun
-			// Add personnal information
-			// Adding <b> may convert the original string into a HTML string. Sowe have to first
-			// Adding a RSS feed into a sitemap should nto be required. The RSS contains pages that are already included into
-			// Amount payed
-			// Atom support many links per containging element.
-			// Aucun model par defaut.
-			// Batch number managment
-			// Bloc to update dates of service (month by month only if previously filled and similare to start and end of month)
-			// By default, electronic transfert from bank to bank
-			// CNAT
-			// Calculating a theorical value
-			// Check if the page we are translation of is alreayd a translation of a source page. if yes, we will use source id instead
-			// Check unicity for serial numbered equipments once all movement were done.
-			// Chercher un contact existant avec cette adresse email
-			// Color of earch arc
-			// Defaut
-			// Delivery date planed
-			// Discard check of mandatory fiedls for other fields
-			// Documents are stored above the web pages root to prevent being downloaded without authentification
-			// Dont't use entity if you use rowid
-			// Dynamic max line heigh calculation
-			// Editer une facture deja validee, sans paiement effectue et pas exporte en compta
-			// Exemple : ALTER TABLE llx_adherent ADD CONSTRAINT adherent_fk_soc FOREIGN KEY (fk_soc) REFERENCES llx_societe (rowid)
-			// Exemple, now $urltograbdirwithoutslash is https://www.dolimed.com/screenshots
-			// Fonctions de conversion non presente dans ce PHP
-			// Fonctions of conversion not available in this PHP
-			// For invoice, we don't want to have a reference line on document. Image we are using recuring invoice, we will have a line longer than document width.
-			// Gestion des groupes
-			// Gestion des utilisateurs associés au groupe
-			// Groupes
-			// If a bank account is prodived and we ask to use it as creditor, we use the bank address
-			// If googleoauth_login has been set (by google_oauthcallback after a successfull OAUTH2 request on openid scope
-			// If not abandonned
-			// If stock decrease is on invoice validation, the theorical stock continue to
-			// If there is a nown BOM, we force the type of MO to the type of BOM
-			// If this is the requestor or has read/write rights
-			// If value contains the unique code of vat line (new recommanded method), we use it to find npr and local taxes
-			// Informations for expense report (dates and users workflow)
-			// Keep invoices that are not situation invoices or that are the last in serie if it is a situation invoice
-			// Les contraintes indesirables ont un nom qui commence par 0_ ou se termine par ibfk_999
-			// Limit and truncate with "…" the displayed text lenght, 0 = disabled
-			// Message must be formated and translated to be used with javascript directly
-			// Microsoft is a service that does not need state to be stored as second paramater of requestAccessToken
-			// Note: We accept disabled account as parent account so we can build a hierarchy and use only childs
-			// Note: We are here only if $conf->global->MAIN_AGENDA_ACTIONAUTO_action is on (tested at begining of this function).
-			// Nouveau système du comon object renvoi des rowid et non un id linéaire de 1 à n
-			// On create mode, force separator group to not be collapsable
-			// On nettoie le header pour qu'il ne se termine pas par un retour chariot.
-			// On parcourt donc une liste d'objets en tant qu'objet unique
-			// On selectionne les users qui ne sont pas deja dans le groupe
-			// On verifie l'emplacement du modele
-			// On verifie si aucun paiement n'a ete effectue
-			// On verifie si la balise prefix est utilisee
-			// On verifie si la facture a des paiements
-			// Option to reload page to retrieve customer informations.
-			// Option to reload page to retrieve customer informations. Note, this clear other input
-			// Parameteres execution
-			// Programm next run
-			// Replace espacing \' by ''.
-			// Replace protected special codes with matching number of _ as wild card caracter
-			// Retained warranty : usualy use on construction industry
-			// Select des informations du projet
-			// Set default encryption to yes, generate a salt and set default encryption algorythm (but only if there is no user yet into database)
-			// Show var initialized by include fo paypal lib at begin of this file
-			// Si il y a eu echec de connexion, $this->db n'est pas valide pour mysqli_error.
-			// Si il y a eu echec de connexion, $this->db n'est pas valide pour sqlite_error.
-			// Si il y a eu echec de connexion, $this->db n'est pas valide.
-			// Si on a demande supression d'un droit en particulier, on recupere
-			// Si on a selectionne une demande a copier, on realise la copie
-			// So we wil know the payment that have generated the bank transaction
-			// Sort array by date ASC to calucalte balance
-			// Succes
-			// TODO : revoir la gestion des groupes (ou script de sync groupes)
-			// TODO A virer quand sera gere par l'appelant
-			// TODO Add a link "Show more..." for all ohter informations.
-			// TODO Use a cahe on user
-			// TODO We can't, we dont' have full path of file, only last_main_doc and ->element, so we must first rebuild full path $destfull
-			// TODO We show localtax from $object, but this properties may not be correct. Only value $object->default_vat_code is guaranted.
-			// TODO mettre dans une classe propre au pays
-			// Tableau des parametres complementaires du post
-			// The entity on the table usergroup_user should be useless and should never be used because it is alreay into gr and r.
-			// This is when PHP session is ran outside a web server, like from Linux command line (Not always defined, but usefull if OS defined it).
-			// This need a lot of time, that's why enabling alternative dir like "custom" dir is not recommanded
-			// Update hourly rate of this time spent entry, but only if it was not set initialy
-			// We choosed to have line->pa_ht always positive in database, so we guess the correct sign
-			// We dont have printers so return blank array
-			// We keep it with value ForceBuyingPriceIfNull = 2 for retroactive effect but results are unpredicable.
-			// We must filter on assignement table
-			// We need to keep the 10 lastest number of invoice doc_ref not the beginning part that is the unusefull almost same part
-			// We use invoice date $data->doc_date not $date_ecriture which is the transfert date
-			// We use invoice date $line->doc_date not $date_ecriture which is the transfert date
-			// add substition variable for ticket
-			// add variables subtitutions ticket
-			// count the orders to ship in theorical stock when some are already removed by invoice validation.
-			// de ceux du produit par defaut (par exemple si pays different entre vendeur et acheteur).
-			// employee informations
-			// et on met la quantité de la ligne dans la limite du "budget" indiqué par dispatch.qty
-			// if "frequency" is empty or = 0, the reccurence is disabled
+			$this->datea = dol_now();
+			'datee' => $date_end,
 			// mise a jour des reponses utilisateurs dans la base
-			// note:  i don't think this is actually neccessary
-			// of the amount and currency retreived from the POST.
-			// on verifie si l'objet est utilisé
-			// only if socid not filled else it's allready done upper
-			// procédure de remplacement de la table pour ajouter la contrainte
-			// reload page to retrieve customer informations
-			// reload page to retrieve supplier informations
-			// save curent cell padding
-			// si le curseur est un booleen on retourne la valeur 0
-			// this conf is actually hidden, by default we use 10% for "be carefull or warning"
-			//Add hook to filter on user (for exemple on usergroup define in custom modules)
-			//Another call for easy debugg
-			//Calcultate new task end date with difference between origin proj end date and origin task end date
-			//Calcultate new task start date with difference between old proj start date and origin task start date
-			//Calcultate new task start date with difference between origin proj start date and origin task start date
-			//Chek special NIF
-			//Origin project strat date
-			//Stock mouvement
-			//We use invoice date $data->doc_date not $date_ecriture which is the transfert date
-			//We use invoice date $line->doc_date not $date_ecriture which is the transfert date
-			//XXX: Should be done just befor commit no ?
-			//but the note is saved, so just add a notification will be enought
-			//if ($user->socid > 0) $socid = $user->socid;    // For external user, no check is done on company because readability is managed by public status of project and assignement.
-			//print  $langs->trans("Desription").' : ';
-			//print "connexion de type=".$conf->db->type." sur host=".$conf->db->host." port=".$conf->db->port." user=".$conf->db->user." name=".$conf->db->name;
-			//si le sujet n'est pas celui qui a été effacé alors on concatene
-			//si on voit une erreur, le fond de la case est rouge
-			The selectForForms is called with parameter $objectfield defined, so tha app can retreive the filter inside the ajax component instead of being provided as parameters. The
-			console.log("Load desciption into text area : "+description);
-			continue; // We discard parametes starting with ?
-			dol_print_error('', get_class($this)."::load_previous_next_ref was called on objet with property table_element not defined");
-			dol_syslog("Can't remove thirdparty with id ".$id.". There is ".$objectisused." childs", LOG_WARNING);
-			dol_syslog("Failed to read image using Imagick (Try to install package 'apt-get install php-imagick ghostscript' and check there is no policy to disable ".$ext." convertion in /etc/ImageMagick*/policy.xml): ".$e->getMessage(), LOG_WARNING);
-			dol_syslog("Fichier invalide",LOG_WARNING);
-			dol_syslog("RejetPrelevement::_send_email Userid invalide");
-			dol_syslog('User not found or not valid, connexion refused');
-			dol_syslog('User not found, connexion refused');
-			dol_syslog(get_class($this) . "::validate action abandonned: already validated", LOG_WARNING);
-			dol_syslog(get_class($this). '::setFrequencyAndUnit was called on objet with params frequency defined but unit not defined', LOG_ERR);
-			dol_syslog(get_class($this). '::setFrequencyAndUnit was called on objet with property table_element not defined', LOG_ERR);
-			dol_syslog(get_class($this)."::accept action abandonned: already acceptd", LOG_WARNING);
-			dol_syslog(get_class($this)."::add successfull", LOG_DEBUG);
-			dol_syslog(get_class($this)."::add_attribute successfull", LOG_DEBUG);
-			dol_syslog(get_class($this)."::deleteAttribute successfull", LOG_DEBUG);
-			dol_syslog(get_class($this)."::line_order was called on objet with property fk_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::line_order was called on objet with property table_element_line not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::modify successfull", LOG_DEBUG);
-			dol_syslog(get_class($this)."::rename successfull", LOG_DEBUG);
-			dol_syslog(get_class($this)."::setAutoValidate was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setBankAccount was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setContract was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setDocModel was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setFrequencyAndUnit was called on objet with params frequency defined but unit not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setFrequencyAndUnit was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setGeneratePdf was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setMaxPeriod was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setModelPdf was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setNextDate was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setProject was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setShippingMethod was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setVATReverseCharge was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::setWarehouse was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::updateAttribute successfull", LOG_DEBUG);
-			dol_syslog(get_class($this)."::update_note was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::update_ref_ext was called on objet with property table_element not defined", LOG_ERR);
-			dol_syslog(get_class($this)."::valid action abandonned: already validated", LOG_WARNING);
-			dol_syslog(get_class($this)."::validate action abandonned: already validated", LOG_WARNING);
-			dol_syslog(get_class($this).'::setAutoValidate was called on objet with property table_element not defined', LOG_ERR);
-			dol_syslog(get_class($this).'::setGeneratePdf was called on objet with property table_element not defined', LOG_ERR);
-			dol_syslog(get_class($this).'::setMaxPeriod was called on objet with property table_element not defined', LOG_ERR);
-			dol_syslog(get_class($this).'::setModelPdf was called on objet with property table_element not defined', LOG_ERR);
-			dol_syslog(get_class($this).'::setNextDate was called on objet with property table_element not defined', LOG_ERR);
-			for ($i = 0; $i < $nbseries; $i++) {	// Loop on each serie
-			foreach ($criterias as $criteriafamilykey => $criteriafamilyval) {
-			foreach ($legends as $val) {	// Loop on each serie
-			header("Location: ".$_SERVER["PHP_SELF"].'?id='.$id.($backtopage ? '&backtopage='.urlencode($backtopage) : '')); // To avoid pb whith back
-			idata++; //Next data everytime
-			if (!empty($_facrec->frequency)) {  // Invoice are created on same thirdparty than template when there is a recurrence, but not necessarly when there is no recurrence.
-			if ($attachs && strpos($action, 'SENTBYMAIL')) {
+			if (!empty($arrayfields['t.datee']['checked'])) {
 			if ($user->hasRight('stock', 'mouvement', 'lire')) {
-			if ($value) {		// If we have -1 here, pb is into insert, not into ouptut (fix insert instead of changing code here to compensate)
-			if (empty($objimport->array_import_convertvalue[0][$tmpcode])) {	// If source file does not need convertion
+			if (empty($reyear) || empty($remonth) || empty($reday)) {
 			jQuery("#mouvement").change(function() {
-			let hours = hour.getHours().toString().padStart(2, "0"); // Formater pour obtenir deux chiffres
-			let mins = hour.getMinutes().toString().padStart(2, "0"); // Formater pour obtenir deux chiffres
-			preg_match('/\((.+)\)/i', $objp->label, $reg); // Si texte entoure de parenthese on tente recherche de traduction
-			print " - Error cant find payment mode for ".$condpayment."\n";
-			print "Expedition inexistante ou acces refuse";
-			print "\n<!-- A script section to add menuhider handler on backoffice, manage focus and madatory fields, tuning info, ... -->\n";
-			print '<!-- Minimim amount for orders -->'."\n";
+			print $form->selectDate($object->periode, 'period', 0, 0, 0, 'charge', 1);
 			print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$id.'&action=transfert">'.$langs->trans("TransferStock").'</a>';
-			print '<a class="cursoradd" href="'.$urltocreate.'">'; // Explicit link, usefull for nojs interfaces
-			print '<div class="div-table-responsive-no-min">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-			print '<input id="assujtva_value" name="assujtva_value" type="checkbox" ' . (GETPOSTISSET('assujtva_value') ? 'checked="checked"' : 'checked="checked"') . ' value="1">'; // Assujeti par defaut en creation
-			print __METHOD__." module accouting must be enabled.\n";
-			print __METHOD__." module accouting must be enabled.\n"; exit(-1);
-			return -1; // Alternate souce not found
-			return false; // Sould be 6
-			return false; // Sould be 6 but can be 123-456
-			setEventMessage('The element '.$element.' is not supported for uploading file. dir_output is unknow.', 'errors');
-			throw new Exception('The element '.$element.' is not supported for uploading file. dir_output is unknow.');
-			throw new RestException(403, 'Forbidden. This parameter cant be read with APIs');
-			while ($i < $nblot) {	// Loop on each serie
-			|| empty($fk_price_level) // if fetch an unique level dont erase all already fetched
-		 'align' => 'L', // text alignement :  R,C,L
-		 * Confirmation envoi mot de passe
-		 * Confirmation reinitialisation mot de passe
-		 * Exemple from old module builder setup page
-		 * For exemple
-		 9, an unexpected error occured
-		$("input[name='price_ht']:first").val(price);	// TODO Must use a function like php price to have here a formated value
-		$MAXLENGTHBOX = 60; // Mettre 0 pour pas de limite
-		$_POST["param14"]="Text with ' encoded with the numeric html entity converted into text entity &#39; (like when submited by CKEditor)";
-		$action = ''; // Do not show form post if there was at least one successfull sent
+			print '<span class="opacitymedium">'.$langs->trans("ClinkOnALinkOfColumn", $langs->transnoentitiesnoconv("Referers")).'</span>';
+			print '<td class="center nowraponall">'.dol_print_date($db->jdate($obj->periode), 'day').'</td>';
+			print dol_print_date($object->periode, "day");
+		$TWeek[$week_number] = $week_number;
 		$action = 'transfert';
-		$allways = $this->get_all_ways(); // Load array of categories
-		$asciiDocTable = "[options=\"header\"]\n|===\n|Objet | URLs\n";
-		$buyingprice = (GETPOST('buying_price') != '' ? GETPOST('buying_price') : ''); // If buying_price is '0', we muste keep this value
-		$buyingprice = price2num(GETPOST('buying_price') != '' ? GETPOST('buying_price') : ''); // If buying_price is '0', we muste keep this value
-		$canbedeleted = $object->can_be_deleted(); // Renvoi vrai si compte sans mouvements
-		$childs = array();
-		$couleur = imagecolorallocate($image, $rouge, $vert, $bleu);
-		$date_time = $enveloppe->addChild('DateTime');
-		$declaration = $enveloppe->addChild('Declaration');
+		$cle_rib = strtolower(checkES($rib, $CCC));
+		$date_com = dol_mktime(GETPOST('rehour'), GETPOST('remin'), GETPOST('resec'), GETPOST("remonth"), GETPOST("reday"), GETPOST("reyear"));
+		$date_next_execution = isset($date_next_execution) ? $date_next_execution : (GETPOST('remonth') ? dol_mktime(12, 0, 0, GETPOST('remonth'), GETPOST('reday'), GETPOST('reyear')) : -1);
+		$datefrom = dol_mktime(0, 0, 0, GETPOST('remonth', 'int'), GETPOST('reday', 'int'), GETPOST('reyear', 'int'));
+		$datesubscription = dol_mktime(0, 0, 0, GETPOST("remonth", "int"), GETPOST("reday", "int"), GETPOST("reyear", "int"));
+		$datetouse = ($this->date_end > 0) ? $this->date_end : ((isset($this->datee) && $this->datee > 0) ? $this->datee : 0);
+		$elementarray = $object->get_element_list($key, $tablename, $datefieldname, $dates, $datee, !empty($project_field) ? $project_field : 'fk_projet');
 		$ensemblereponses = $obj->reponses;
-		$enveloppe = $e->addChild('Envelope');
-		$enveloppe->addChild('envelopeId', $conf->global->INTRACOMMREPORT_NUM_AGREMENT);
-		$enveloppe->addChild('softwareUsed', 'Dolibarr');
-		$fils++;
-		$filterabsolutediscount = "fk_facture_source IS NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-		$filterabsolutediscount = "fk_invoice_supplier_source IS NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-		$filtercreditnote = "fk_facture_source IS NOT NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-		$filtercreditnote = "fk_invoice_supplier_source IS NOT NULL"; // If we want deposit to be substracted to payments only and not to total of final invoice
-		$genericcompanyname = $langs->trans('EventParticipant').' '.($emailcompany ? $emailcompany : $email);	// Keep this label simple so we can retreive same thirdparty for another event
-		$keyval = substr($nvpstr, $intial, $keypos);
-		$ldap = new Ldap(); // Les parametres sont passes et recuperes via $conf
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1915);	// we use year 1915 to be sure to not have existing invoice for this year (usefull only if numbering is {0000@1}
-		$localobject->date_creation = dol_mktime(12, 0, 0, 1, 1, 1980);	// we use year 1915 to be sure to not have existing invoice for this year (usefull only if numbering is {0000@1}
-		$mail = 'bidon@unvalid.unvalid';
-		$myclone = clone $object; // PHP clone is a shallow copy only, not a real clone, so properties of references will keep the reference (refering to the same target/variable)
-		$nbofsubproducts = count($prodschild); // This include only first level of childs
-		$object->date_delivery = $date_delivery; // Date delivery planed
-		$object->fields['label']=array(); // Usefull to get only agenda events linked to position (this object doesn't need label of ref field, but show_actions_done() needs it to work correctly)
-		$object->km = price2num(GETPOST('km', 'alpha'), 'MU'); // Not 'int', it may be a formated amount
-		$objet = $this->db->fetch_object($result);
-		$out .= '<!-- code to open popup and variables to retreive returned variables -->';
-		$out .= '<b>XDebug informations:</b>'."<br>\n";
-		$out = str_replace(array(':', ';', '@', "\t", ' '), '', $out);		// Can be before the loop because only 1 char is replaced. No risk to retreive it after other replacements.
-		$paht_ret = $paht;
-		$party = $enveloppe->addChild('Party');
-		$repid = array();
-		$result = $ldap->add($dn, $info, $user); // Wil fail if already exists
-		$result = dol_delete_file($pathtodelete, 1); // Delete uploded Files
-		$result0bis = price2num($tot_avec_remise / (1 + ($txtva / 100)), 'MT'); // Si TVA consideree normale (non NPR)
-		$result2bis = price2num($tot_avec_remise * (1 + ($txtva / 100)) + $localtaxes[1], 'MT'); // Si TVA consideree normale (non NPR)
-		$result3bis = price2num($pu / (1 + ($txtva / 100)), 'MU'); // Si TVA consideree normale (non NPR)
-		$result5bis = price2num($pu * (1 + ($txtva / 100)) + $localtaxes[2], 'MU'); // Si TVA consideree normale (non NPR)
-		$result6bis = price2num($tot_sans_remise / (1 + ($txtva / 100)), 'MT'); // Si TVA consideree normale (non NPR)
-		$result8bis = price2num($tot_sans_remise * (1 + ($txtva / 100)) + $localtaxes[0], 'MT'); // Si TVA consideree normale (non NPR)
-		$result=dol_basename('adir/afile');
-		$result=dol_basename('adir/afile/');
-		$rouge = hexdec(substr($color, 0, 2)); //conversion du canal rouge
-		$serie = array();
-		$showfield = 1; // By defaut
-		$sql .= " AND (p.last_check_backlink IS NULL OR p.last_check_backlink <= '".$this->db->idate($now - 24 * 3600)."')"; // Never more than 1 check every day to check that website contains a referal link.
-		$sql .= " AND ff.fk_statut IS NULL"; // Renvoi vrai si pas facture de remplacement
-		$sql .= " AND ff.type IS NULL"; // Renvoi vrai si pas facture de remplacement
-		$sql .= " AND mc.statut NOT IN (-1,0)"; // -1 erreur, 0 non envoye, 1 envoye avec succes
-		$sql .= " WHERE u.email != ''"; // u.email IS NOT NULL est implicite dans ce test
-		$sql .= " WHERE u.email <> ''"; // u.email IS NOT NULL est implicite dans ce test
-		$sql .= " label = 'Annulation mouvement ID ".((int) $this->id)."',";
-		$sql .= " tms = tms"; // La date de derniere modif doit changer sauf pour la mise a jour de date de derniere connexion
-		$sql .= ", '".$this->db->escape($url)."'";		// dperecated
+		$head[$h][1] = $langs->trans("Referers");
+		$head[$tab][1] = $langs->trans("Referers");
+		$out .= "<b>".$langs->trans("Referer").":</b> ".(isset($_SERVER["HTTP_REFERER"]) ? dol_htmlentities($_SERVER["HTTP_REFERER"], ENT_COMPAT) : '')."<br>\n";
+		$reday = GETPOST('reday', 'int');
+		$reday = GETPOSTINT('reday');
+		$sql  = "SELECT p.rowid as id, p.entity, p.title, p.ref, p.public, p.dateo as do, p.datee as de, p.fk_statut as status, p.fk_opp_status, p.opp_amount, p.opp_percent, p.tms as date_update, p.budget_amount";
+		$sql  = 'SELECT p.rowid as id, p.entity, p.title, p.ref, p.public, p.dateo as do, p.datee as de, p.fk_statut as status, p.fk_opp_status, p.opp_amount, p.opp_percent, p.tms as date_update, p.budget_amount';
+		$sql .= "   (cs.periode IS NOT NULL AND cs.periode between '".$db->idate(dol_get_first_day($year))."' AND '".$db->idate(dol_get_last_day($year))."')";
+		$sql .= " OR (cs.periode IS NULL AND cs.date_ech between '".$db->idate(dol_get_first_day($year))."' AND '".$db->idate(dol_get_last_day($year))."')";
+		$sql .= " VALUES (".$conf->entity.", '".$this->db->idate($this->datea)."'";
+		$sql .= " datee=".($this->date_end != '' ? "'".$this->db->idate($this->date_end)."'" : 'null').",";
+		$sql .= " f.date_approval as datea,";
+		$sql .= " f.date_approve as datea,";
+		$sql .= " f.datec, f.dateo, f.datee, f.datet, f.fk_user_author,";
+		$sql .= " t.datee as date_end,";
+		$sql .= " t.dateo as date_start, t.datee as date_end";
+		$sql .= " t.dateo as date_start, t.datee as date_end, t.planned_workload, t.rang,";
+		$sql .= " tms, dateo as date_start, datee as date_end, date_close, fk_soc, fk_user_creat, fk_user_modif, fk_user_close, fk_statut as status, fk_opp_status, opp_percent,";
+		$sql .= ", '".$this->db->idate($this->periode)."'";
+		$sql .= ", cs.libelle as label, cs.fk_type, cs.amount, cs.fk_projet as fk_project, cs.paye, cs.periode as period, cs.import_key";
+		$sql .= ", datea = '".$this->db->idate(dol_now())."'";
+		$sql .= ", datee";
+		$sql .= ", periode='".$this->db->idate($this->periode)."'";
+		$sql = "INSERT INTO ".$this->db->prefix()."links (entity, datea, url, label, objecttype, objectid)";
+		$sql = "INSERT INTO ".MAIN_DB_PREFIX."chargesociales (fk_type, fk_account, fk_mode_reglement, libelle, date_ech, periode, amount, fk_projet, entity, fk_user_author, fk_user, date_creation)";
+		$sql = "SELECT SUM(duree) as total_duration, min(date) as dateo, max(date) as datee ";
 		$sql = "SELECT id_users, nom as name, id_sondage, reponses";
 		$sql = "SELECT id_users, nom as name, reponses";
+		$sql = "SELECT p.rowid, p.fk_statut as status, p.fk_opp_status, p.datee as datee";
+		$sql = "SELECT rowid, entity, datea, url, label, objecttype, objectid FROM ".$this->db->prefix()."links";
+		$sql = 'SELECT c.rowid, date_creation as datec, tms as datem, date_valid as date_validation, date_approve as datea, date_approve2 as datea2,';
 		$test = '/javas:cript/google.com';
 		$test="<IMG SRC=\"jav&#x0D;ascript:alert('XSS');\">";	// Same
-		$test="Text with ' encoded with the numeric html entity converted into text entity &#39; (like when submited by CKEditor)";
-		$this->assertEquals("Text with ' encoded with the numeric html entity converted into text entity &#39; (like when submited by CKEditor)", $result, 'Test 14');
-		$this->assertEquals('0125-0002', $result, 'Test for {mm}{yy}-{0000@1} 2st invoice');			// counter must be now 2
-		$this->assertEquals('1911-0001', $result, 'Test for {yyyy}-{0000@1} 3nd invoice, same day');	// counter must be now 1
-		$this->assertEquals('1916-0002', $result);				// counter must be now 2 (not reseted)
-		$this->assertEquals('192101-0001', $result);			// counter must be reseted to 1
-		$this->assertEquals('<a href="aaa">bbbڴ', $decodedstring, 'Function did not sanitize correclty with test 1');
-		$this->assertEquals('<a href="aaa">bbbڴ', $decodedstring, 'Function did not sanitize correclty with test 2');
-		$this->assertEquals('<a href="aaa">bbbڴ', $decodedstring, 'Function did not sanitize correclty with test 3');
-		$this->assertEquals('<div><a href="123"><span class="abc">abc</span></a></div>', $decodedstring, 'Function did not sanitize correclty with test 2');
-		$this->assertEquals('a &colon; b " c \' d &apos; e é', $decodedstring, 'Function did not sanitize correclty');
-		$this->assertEquals('a : b " c \' d \' e é', $decodedstring, 'Function did not sanitize correclty');
-		$this->assertEquals('afile', $result);
-		$this->assertEquals('e&eacute;e', $decodedstring, 'Function did not sanitize correclty with test 1');
-		$this->assertEquals('text  text', $decodedstring, 'Function did not sanitize correclty with test 4a');
-		$this->assertEquals('text <link href="aaa"> text', $decodedstring, 'Function did not sanitize correclty with test 4b');
-		$this->assertTrue($result, 'move of directory with directory whitout rename needed in directory');
-		$this->assertTrue($result, 'move of directory with file whitout rename needed in directory');
-		$this->const[$r][2] = "DOL_DATA_ROOT/doctemplates/stocks/mouvements";
-		$this->const[$r][3] = "Mot de passe Admin des liste mailman";
-		$this->description = "A tool for developper adding a debug bar in your browser.";
-		$this->description = "Ajout de files d'informations RSS dans les ecrans Dolibarr";
-		$this->description = "Gestion des projets";
-		$this->object->address = GETPOST("adresse");
-		$this->posxdesc = $this->marge_gauche + 1; // For module retrocompatibility support durring PDF transition: TODO remove this at the end
-		$this->posxdesc = $this->marge_gauche + 1; // used for notes ans other stuff
-		$this->rights[$r][1] = 'Exporter les commande fournisseurs, attributs';
-		$this->rights[$r][1] = 'Exporter les factures fournisseurs, attributs et reglements';
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par defaut
-		$this->rights[$r][3] = 1; // La permission est-elle une permission par defaut
-		$this->rights[1][1] = 'Lire ses notes de frais et deplacements et celles de sa hierarchy';
-		$this->rights[1][3] = 0; // La permission est-elle une permission par defaut
-		$this->rights[1][3] = 1; // La permission est-elle une permission par defaut
-		$this->rights[2][3] = 0; // La permission est-elle une permission par defaut
-		$this->rights[3][1] = 'Lire mouvements de stocks';
-		$this->rights[4][1] = 'Creer/modifier mouvements de stocks';
-		$this->rights[4][3] = 0; // La permission est-elle une permission par defaut
-		$this->signature_line = dol_hash($keyforsignature, '5'); // Not really usefull
-		$this->tva_intra = empty($conf->global->MAIN_INFO_TVAINTRA) ? '' : $conf->global->MAIN_INFO_TVAINTRA; // VAT number, not necessarly INTRA.
-		$this->tva_intra = getDolGlobalString('MAIN_INFO_TVAINTRA'); // VAT number, not necessarly INTRA.
-		$valuetoshow = ucfirst($fieldlist[$field]); // Par defaut
-		'filles' => array('name'=>'filles', 'type'=>'tns:FillesArray')
-		'fk_statut' =>array('type'=>'smallint(6)', 'label'=>'Status', 'enabled'=>1, 'visible'=>1, 'notnull'=>1, 'position'=>1000, 'arrayofkeyval'=>array(0=>'Draft', 1=>'Validated', 2=>'Paid', 3=>'Abandonned')),
-		'qty_regulated' => array('type'=>'double', 'label'=>'QtyDelta', 'visible'=>1, 'enabled'=>1, 'position'=>34, 'index'=>1, 'help'=>'Qty aadded or removed (filled once movements are validated)'),
-		'type_mouvement' =>array('type'=>'smallint(6)', 'label'=>'Type mouvement', 'enabled'=>1, 'visible'=>-1, 'position'=>45),
-		/* Definition de la date limite */
-		/* Liste des taches et role sur les projets ou taches */
-		/* width: ...px; If I use with, there is trouble on size of flex boxes solved with min + (max that is a little bit higer than min) */
-		/*if (getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO'))    // For backward compatiblity, we scan also old dirs
-		// $boxidactivatedforuser will be array of boxes choosed by user
-		// $options is array with filter criterias
-		// $placeid is the invoice id (it differs from place) and is defined if the place is set and the ref of invoice is '(PROV-POS'.$_SESSION["takeposterminal"].'-'.$place.')', so the fetch at begining of page works.
-		// $this->rights[$r][1]     Libelle par defaut si traduction de cle "PermissionXXX" non trouvee (XXX = Id permission)
-		// $this->rights[$r][3]     1=Permis par defaut, 0=Non permis par defaut
-		// 'member'				to add a tab in fundation member view
-		// 'member'           to add a tab in fundation member view
-		// - If not set, we accept ot have amount defined as parameter (for backward compatibility).
-		// Action according to choosed sending method
-		// Add a where here keeping only the citeria on $tabletouse
-		// Add code to open url using the popup. Add also hidden field to retreive the returned variables
-		// Add infor from $object->xxx where xxx has been loaded by fetch_origin() of shipment
-		// Add the count of record only for the main/first level object. Parents are necessarly unique for each record.
-		// Alow external links to svg ?
-		// Amount keys formated in a currency
-		// Build file for Other Countries with unknow format
-		// Build filter to diplay only concerned lines
-		// By default, electronic transfert from bank to bank
-		// CHANGE THIS: Optionnal
-		// Chargement de labels et data_xxx pour tableau 4 Mouvements
-		// Chargement librairie pour acces fonction controle RIB
-		// Check if field was submited to be edited
-		// Check paramaters
-		// Check that the redirect_uri that wil be used is same than url of current domain
-		// Classif "paid partialy"
-		// Clean paramater $typeofdata
-		// Clear all fields out of interrest
-		// Concatenation des differents codes.
-		// Confirm cancelation
-		// Confirm deleteion
-		// Connexion ldap
-		// Convert MySQL syntax to PostgresSQL syntax
-		// Create with status validated immediatly
-		// Creation de la classe d'import du model Import_XXX
-		// Creation objet
-		// Date delivery planed
-		// Delivery date planed
-		// Dependancies
-		// Don't log Luracast Restler Explorer recources calls
-		// Essai connexion serveur
-		// Event into a serie
-		// Exclude unsubscribed email adresses
-		// Files missings
-		// First, we get the max value (reponse immediate car champ indexe)
-		// For a string that is already HTML (contains HTML tags) but badly formated
-		// For a string that is already HTML (contains HTML tags) with special tags but badly formated
-		// For backward compatiblity, we detect file stored into an old path
-		// For each file build select list with PDF extention
-		// For exemple if element is project
-		// For external user, no check is done on company because readability is managed by public status of project and assignement.
-		// For external user, no check is done on company permission because readability is managed by public status of project and assignement.
-		// Forced filter on socid is similar to forced filter on project. TODO Use project assignement to allow to not use filter on project
-		// Github is a service that does not need state to be stored as second paramater of requestAccessToken
-		// Hooks on successfull login
-		// How the date for data are formated (format used bu jsgantt)
-		// How the date for data are formated (format used by dol_print_date)
-		// If lib not found in language file, we get label from cache/databse
-		// If on smartphone or optmized for small screen
-		// If option choosed, we create invoice
-		// If resultset not provided, we take the last used by connexion
-		// If stock increment is done on reception (recommanded choice)
-		// If stock increment is done on sending (recommanded choice)
-		// If value contains the unique code of vat line (new recommanded method), we use it to find npr and local taxes
-		// Initialisation objet actioncomm
-		// Initialise parametres
-		// Insert into bank account directlty (if option choosed for) + link to llx_subscription if option is 'bankdirect'
-		// Keep the orginal
-		// Limite acces si droits non corrects
-		// Links beetween objects are stored in this table
-		// Load extrafields if not allready done
-		// Load extrafiels if not allready does
-		// Load librairies to check BAN
-		// Log the init of hook but only for hooks thare are declared to be managed
-		// Loop on each line keword was found into file.
-		// Mis a jour contact
-		// More informations
-		// Multiplication de chaque groupe par les coef du tableau
-		// Nettoyage parametres
-		// No check is done on company permission because readability is managed by public status of project and assignement.
-		// Now complete $this->newmenu->list to add entries found into $tabMenu that are childs of mainmenu=$menutopid, using the fk_menu link that is int (old method)
-		// On definit fin de ligne
-		// On recherche les formes juridiques actives des pays actifs
-		// On recherche les groupes
-		// On remplace les eventuelles lettres par des chiffres.
-		// On va boucler sur chaque ligne du document d'origine pour completer objet reception
-		// On verifie signe facture
-		// Only record into stock tables wil be disabled by this (the rest like writing into lot table or movement of subproucts are done)
-		// Option to reload page to retrieve customer informations.
-		// Ordre SQL ne necessitant pas de connexion a une base (exemple: CREATE DATABASE)
-		// Ouput page under the Dolibarr top menu
-		// Parameteres execution
-		// Permet de commencer l'impression de l'etiquette desiree dans le cas ou la page a deja servie
-		// Permettre l'exclusion de groupes
-		// Permettre l'inclusion de groupes
-		// Positionne parametres
-		// Positionning
-		// Refresh / Reload web site (for non javascript browers)
-		// Remove '<' into remainging, so remove non closing html tags like '<abc' or '<<abc'. Note: '<123abc' is not a html tag (can be kept), but '<abc123' is (must be removed).
-		// Remove fields not relevent to categories
-		// Renaming can be done when we rename globaly a bank receipt but not when changing 1 line from one receipt into another one.
-		// Replace protected special codes with matching number of _ as wild card caracter
-		// Reset the substraction for this amount
-		// Retained warranty : usualy use on construction industry
-		// S'il y a une facture de remplacement pas encore validee (etat brouillon),
-		// Scan dir to guarante we don't have library jquery twice
-		// Separation du rib en 3 groupes de 7 + 1 groupe de 2.
-		// Seperate "Real Name" from eMail address, if we have one
-		// Serch departements/cantons/province active d'une region et pays actif
-		// Set enviorment variables
-		// Should not be enabled by defaut because does not work yet correctly because
-		// Show planed date of delivery
-		// Si connexion serveur ok et si connexion base demandee, on essaie connexion base
-		// Si edition contact deja existant
-		// Si le fichier passe en parametre n'existe pas
-		// Si le resultset n'est pas fourni, on prend le dernier utilise sur cette connexion
-		// Stripe is a service that does not need state to be stored as second paramater of requestAccessToken
-		// Suppression de la chaine de caractere ../ dans $original_file
-		// Syntaxe ko
-		// Syntaxe ok
-		// TODO Check the lineid $lineid is a line of ojbect
-		// TODO Remove hooks with type 'output' (exemple createFrom). All hooks must be converted into 'addreplace' hooks.
-		// TODO Remove hooks with type 'output' (exemple getNomUrl). All hooks must be converted into 'addreplace' hooks.
-		// Tableau des parametres complementaires du post
-		// Test with restricthtml + MAIN_RESTRICTHTML_ONLY_VALID_HTML + MAIN_RESTRICTHTML_ONLY_VALID_HTML_TIDY to test disabling of bad atrributes
-		// Test with restricthtml + MAIN_RESTRICTHTML_ONLY_VALID_HTML only to test disabling of bad atrributes
-		// Test with restricthtml + MAIN_RESTRICTHTML_ONLY_VALID_HTML to test disabling of bad atrributes
-		// Test with restricthtml + MAIN_RESTRICTHTML_ONLY_VALID_HTML_TIDY only to test disabling of bad atrributes
-		// Test with restricthtml + MAIN_RESTRICTHTML_REMOVE_ALSO_BAD_ATTRIBUTES to test disabling of bad atrributes
-		// The image must have the class 'boxhandle' beause it's value used in DOM draggable objects to define the area used to catch the full object
-		// This improvment as provided by 'SirSir' to
-		// This may contains binary data, so we dont output reponse by default.
-		// This term is allready paid
-		// To wxrite into  afile onto disk
-		// Validate parametres
-		// Verifie SIRET si pays FR
-		// We do not try to connect to database, only to server. Connect to database is done later in constrcutor
-		// We must set mask just before creating dir, becaause it can be set differently by dol_copy
-		// We set all data according to choosed sending method.
-		// We should use dol_now function not time however this is wrong date to transfert in accounting
-		// We start scan from the not before so if two tabs were opend at differents seconds and we close one (so the js timer),
-		// Wrapping pour les projets
-		// accomodate both SMTP AND ESMTP capable servers
-		// add menu manualy
-		// additionnal list with adherents of company
-		// admin login no exectued.
-		// attemp to create without mandatory fields :
-		// delete menu manuelly
-		// for js desabled compatibility set $url as call to confirm action and $params['confirm']['url'] to confirmed action
-		// groupe
-		// if "frequency" is empty or = 0, the reccurence is disabled
-		// if no test failled all is ok
-		// information if it failes to connect because it can't find the HOST
-		// l'adherent n'est pas public par defaut
-		// need to be ignored from scrutinizer setTypeFromTypeString was created as deprecated to incite developper to use object oriented usage
-		// on verifie si l'objet est en numerotation provisoire
-		// parcourir les objets
-		// personnal stocks are not tagged into table llx_entrepot
-		// reload page to retrieve customer informations
-		// reload page to retrieve supplier informations
-		// save curent cell padding
-		// submited to nothing.
-		// substract 1 because array start from 0
-		// this conf is actually hidden, by default we use 10% for "be carefull or warning"
-		// to allow mask usage for dir, we shoul introduce a new param "isdir" to 1 to complete newmask like this
-		// variable submitted at all, so no way to make a difference between variable not submited and variable
-		//$array_selected = array("s.rowid"=>1, "s.nom"=>2);	// Mut be fields found into declaration of dataset
-		//$signature_line = dol_hash($keyforsignature, '5'); // Not really usefull
-		//Add hook to filter on user (for exemple on usergroup define in custom modules)
-		//If dispach process running we add the number of item to dispatch into the head
-		//If invoice has been converted and the conversion has been used, we dont have remain to pay on invoice
-		//If no task avaiblable, redirec to to add confirm
-		//In some case $object is not instanciate (for paiement on custom object) We need to deal with payment
-		//Iterate over each expression splitted by $separator_chr
-		//Label mouvement
-		//Lot/serie Product
-		//We should use dol_now function not time however this is wrong date to transfert in accounting
-		//check if tag type submited exists into Tag Map categorie class
-		//decoding the respose
-		//fetch informations needs on this mode
-		//http_response_code(500);		// If we use 500, message is not ouput with some command line tools
-		//postion of Key
-		//prevents agains infinite loop when we can't create root folder
-		//print "L'EAN se compose de 8 caracteres, 7 chiffres plus une cle de controle.<br>";
-		//print $rouge.$vert.$bleu;
-		//sinon on remplace les choix de l'utilisateur par une ligne de checkbox pour recuperer de nouvelles valeurs
-		//sinon on remplace les choix de l'utilisateur par une ligne de checkbox pour saisie
-		//var_dump($serie);
-		console.log("Cancel check_events() with dolnotif_nb_test_for_page="+dolnotif_nb_test_for_page+". Check is useless because javascript Notification.permission is "+Notification.permission+" (blocked manualy or web site is not https).");
-		console.log("Change montly amount echeance="+echeance+" idcap="+idcap+" capital="+capital);
-		dol_syslog("The user login has a validity between [".$user->datestartvalidity." and ".$user->dateendvalidity."], curren date is ".dol_now());
-		dol_syslog("Warning: Function form_constantes is calle with parameter strictw3c = 0, this is deprecated. Value must be 2 now.", LOG_DEBUG);
-		dol_syslog("line.php update bank line to set the new bank receipt nuber", LOG_DEBUG);
-		dol_syslog(get_class($this)."::getCustomerAccount Try to find the first system customer id for ".$site." of thirdparty id=".$id." (exemple: cus_.... for stripe)", LOG_DEBUG);
-		dol_syslog(get_class($this)."::setCategoriesCommon Oject Id:".$this->id.' type_categ:'.$type_categ.' nb tag add:'.count($categories), LOG_DEBUG);
-		foreach ($allways as $way) {
-		foreach ($arrayofcriterias as $criterias) {
-		foreach ($parent as $key => $value) {        // key=label, value is array of childs
-		header("Location: ".$_SERVER["PHP_SELF"].'?id='.$id); // To avoid pb whith back
-		http_response_code(202);		// If we use 202, this is not really an error message, but this allow to ouput message on command line tools
-		if (!$login || (in_array('ldap', $authmode) && empty($passwordtotest))) {	// With LDAP we refused empty password because some LDAP are "opened" for anonymous access so connexion is a success.
-		if (!empty($this->phone)) {	// If a phone of thirdparty is defined, we add it ot mobile of contacts
-		if (!getDolGlobalString('PDF_BANK_HIDE_NUMBER_SHOW_ONLY_BICIBAN')) {    // Note that some countries still need bank number, BIC/IBAN not enougth for them
-		if (!is_array($this->userassigned) && !empty($this->userassigned)) {	// For backward compatibility when userassigned was an int instead fo array
-		if ($lines[$i]->fk_parent == $parent || $level < 0) {       // if $level = -1, we dont' use sublevel recursion, we show all lines
-		if ($lines[$i]->fk_task_parent == $parent || $level < 0) {       // if $level = -1, we dont' use sublevel recursion, we show all lines
-		if ($objectfield) {	// We must retreive the objectdesc from the field or extrafield
-		if ($this->label == 'Annulation mouvement ID'.$this->id) {
+		$this->periode = $this->date_creation + 3600 * 24 * 30;
+		$title = $langs->trans('Product')." ".$shortlabel." - ".$langs->trans('Referers');
+		$title = $langs->trans('Service')." ".$shortlabel." - ".$langs->trans('Referers');
+		$title = $langs->transnoentities("Balance")." - ".$langs->transnoentities("AllTime");
+		'datee' => $datee
+		'datee' =>array('type'=>'date', 'label'=>'DateEnd', 'enabled'=>1, 'visible'=>1, 'position'=>35),
+		'datee' =>array('type'=>'date', 'label'=>'Datee', 'enabled'=>1, 'visible'=>-1, 'position'=>90),
+		,'datee'=>array('type'=>'date')
+		// ceci afin d'etre compatible avec les cas ou la periode n'etait pas obligatoire
+		echo dol_print_date($rule->datee, 'day');
+		foreach ($TWeek as $weekNb) {
+		if (!empty($arrayfields['cs.periode']['checked'])) {
+		if (!empty($arrayfields['p.datee']['checked'])) {
+		if ($datee > 0) {
+		if ($newamount == 0 || empty($this->date_ech) || (empty($this->period) && empty($this->periode))) {
 		if ($user->hasRight('stock', 'mouvement', 'creer')) {
-		if (GETPOST('import_name')) {	// If we have submited a form, we take value used fot the update try
-		if (dol_strlen($phone) == 10) {// fixe 6 chiffres +352_AA_BB_CC
-		if (empty($conf->global->PDF_BANK_HIDE_NUMBER_SHOW_ONLY_BICIBAN)) {    // Note that some countries still need bank number, BIC/IBAN not enougth for them
-		if (empty($res)) $this->db->query('INSERT INTO '.MAIN_DB_PREFIX.'c_type_contact(rowid, element, source, code, libelle, active, module, position) VALUES('.((int) $nextid).', "StockTransfer", "external", "STDEST", "Contact destinataire transfert de stocks", 1, NULL, 0)');
-		if (empty($res)) $this->db->query('INSERT INTO '.MAIN_DB_PREFIX.'c_type_contact(rowid, element, source, code, libelle, active, module, position) VALUES('.((int) $nextid).', "StockTransfer", "external", "STFROM", "Contact expéditeur transfert de stocks", 1, NULL, 0)');
-		if (empty($res)) $this->db->query('INSERT INTO '.MAIN_DB_PREFIX.'c_type_contact(rowid, element, source, code, libelle, active, module, position) VALUES('.((int) $nextid).', "StockTransfer", "internal", "STRESP", "Responsable du transfert de stocks", 1, NULL, 0)');
-		if (empty($tabtp[$obj->rowid]) && !empty($tabmoreinfo[$obj->rowid]['withdraw'])) {	// If we dont find 'company' link because it is an old 'withdraw' record
-		if (getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {    // For backward compatiblity, we scan also old dirs
-		jQuery("#tva_tx").click(function() {						/* somtimes field is a text, sometimes a combo */
-		jQuery("#tva_tx").keyup(function() {						/* somtimes field is a text, sometimes a combo */
-		preg_match('/\((.+)\)/i', $objp->label, $reg); // Si texte entoure de parenthese on tente recherche de traduction
-		print "(currenlty not available)";
-		print "Expedition inexistante ou acces refuse";
-		print $form->selectyesno('assujtva_value', GETPOSTISSET('assujtva_value') ?GETPOST('assujtva_value', 'int') : 1, 1); // Assujeti par defaut en creation
-		print $langs->trans("SFTP (FTP as a subsytem of SSH)").': <b>'.yn($conf->global->FTP_CONNECT_WITH_SFTP).'</b><br>';
-		print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-		print '<div class="div-table-responsive-no-min borderbottom">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-		print '<div class="div-table-responsive-no-min">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-		print '<td class="nobottom nowrap right"><input class="falt right" type="text" size="1" value="" name="progress"><span class="opacitymedium hideonsmartphone">%</span></td>';
-		print '<td classe="somme"><div class="center">'.$langs->trans("Time").' '.$j.'</div></td>'."\n";
-		print '<td classe="somme"><input type="image" name="ajoutcases" src="../img/add-16.png"></td>'."\n";
-		print 'This website or feature is currently temporarly not available or failed after a technical error.<br><br>This may be due to a maintenance operation. Current status of operation ('.dol_print_date(dol_now(), 'dayhourrfc').') are on next line...<br><br>'."\n";
-		return $childs;
-		return $objet->compteur;
-		setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("Lable")), null, 'errors');
-		unset($object->supplierprices);	// Mut use another API to get them
-		while ($i < $nblot) {	// Loop on each serie
-		} else // We decrease agressiveness
-		} else {	// If thirdparty unkown, output the waiting account
-		} else { // We decrease agressiveness
-		} else { // old method. deprecated because ot can't retrieve type
-		} elseif (!empty($this->childtables)) {	// If object has childs linked with a foreign key field, we check all child tables.
-		} elseif (!empty($this->fk_element) && !empty($this->childtables)) {	// If object has childs linked with a foreign key field, we check all child tables.
-		} elseif (dol_strlen($phone) == 11) {// fixe 7 chiffres +352_AA_BB_CC_D
-		} elseif (dol_strlen($phone) == 12) {// fixe 8 chiffres +352_AA_BB_CC_DD
-	    			        echo Only one line remainging into file $fic, we delete it;
-	  // TODO Check the lineid $lineid is a line of ojbect
-	 *				fullname = nom avec chemin complet du user
-	 *				fullpath = chemin complet compose des id: "_grandparentid_parentid_id"
-	 *		@param	DoliDB		$db			Handler acces base
-	 *		@param	Societe		$soc		Objet societe
-	 *		Functiun to exlude (set adherent.status to -2) a member
-	 *		Renvoi si un code est pris ou non (par autre tiers)
-	 *	 @param		mixed	$gm			'gmt'=Input informations are GMT values, 'tzserver'=Local to server TZ
-	 *	'Fiche LDAP' qui affiche champ lisibles par defaut.
-	 *	(Status validated or abandonned for a reason 'other') + not payed + no payment at all + not already replaced
-	 *	(validated + payment on process) or classified (payed completely or payed partiely) + not already replaced + not already a credit note
-	 *	@param		User		$user		Handler du user connecte
-	 *	@param		User	$user 		Objet user that make creation
-	 *	@param		int			$info_bits			Miscellaneous informations
-	 *	@param		int		   $closepaidinvoices   1=Also close payed invoices to paid, 0=Do nothing more
-	 *	@param		int		$closepaidcontrib   	1=Also close payed contributions to paid, 0=Do nothing more
-	 *	@param		integer	$alreadypaid	0=No payment already done, >0=Some payments were already done (we recommand to put here amount payed if you have it, -1 otherwise)
-	 *	@param	    string	$pass		Mot de passe
-	 *	@param	Adherent	$object		        Member object. Old usage: Array of record informations (array('textleft'=>,'textheader'=>, ...'id'=>,'photo'=>)
-	 *	@param	DoliDB		$db			Handler acces base
-	 *	@param	DoliDB	$db				Handler acces base de donnees
-	 *	@param	DoliDB	$db				Handler acces data base
-	 *	@param	Product		$product	Objet product
-	 *	@param	Societe		$thirdparty	Objet third-party
-	 *	@param	Translate			$outputlangs	Objet langs
-	 *	@param	Translate		$outputlangs	Objet langs
-	 *	@param	Translate	$outputlangs	Objet langs
-	 *	@param	Translate	$outputlangs	objet lang a utiliser pour traduction
-	 *	@param	User			$user			Objet user that modify
-	 *	@param	User		$user		Objet user that create
-	 *	@param	User		$user		Objet user that modify
-	 *	@param	User	$user			Objet user making update
-	 *	@param	User	$user      	Objet user qui valide
-	 *	@param	User	$user        	Objet user qui demande la creation
-	 *	@param	array		$arrayofrecords		Array of record informations (array('textleft'=>,'textheader'=>, ..., 'id'=>,'photo'=>)
-	 *	@param	array 				$extra_values       Any aditional values for expression
-	 *	@param	array 				$extra_values   Any aditional values for expression
-	 *	@param	int			$socid      	Id ot third party or 0 for all or -1 for empty list
-	 *	@param	int		$id      Id du paiement dont il faut afficher les infos
-	 *	@param	mixed				$gm			'gmt'=Input informations are GMT values, 'tzserver'=Local to server TZ
-	 *	@param	string		$method		Method of transmision to bank (0=Internet, 1=Api...)
-	 *	@param	string		$method		method of transmision to bank
-	 *	@param	string		$method		method of transmision to bank (0=Internet, 1=Api...)
-	 *	@param	string	$dolibarr_main_db_pass 		Mot de passe user a creer
-	 *	@param	string	$field_desc 		Tableau associatif de description du champ a inserer[nom du parametre][valeur du parametre]
-	 *	@param	string	$resko          resultat si test non egal
-	 *	@param	string	$resok          resultat si test egal
-	 *	@param          User	$user   Objet user
-	 *	@param      User			$user        		Objet user making change
-	 *	@param      User			$user        		Objet user that modify
-	 *	@param      User			$user        		Objet utilisateur qui modifie
-	 *	@param      User	$user        		Objet utilisateur qui modifie
-	 *	@param      int			$info_bits        	Miscellaneous informations
-	 *	@param      string	$get_params    				Parametres added to url
-	 *	@param      string	$get_params    	          Parametres added to url
-	 *	@param     int	$idremise			Id de la remise fixe
-	 *	@param  bool	$multiple       add [] in the name of element and add 'multiple' attribut
-	 *	@param  string	$close_code	Code indicates whether the class has paid in full while payment is incomplete. Not implementd yet.
-	 *	@param  string	$close_code	Code renseigne si on classe a payee completement alors que paiement incomplet (cas escompte par exemple)
-	 *	@param  string	$close_note	Comment informs if the class has been paid while payment is incomplete. Not implementd yet.
-	 *	@param  string	$close_note	Commentaire renseigne si on classe a payee alors que paiement incomplet (cas escompte par exemple)
-	 *	@return		array		Tableau info des attributs
-	 *	@return		int                     < 0 if KO (infinit loop), >= 0 if OK
-	 *	@return		int                     Return integer < 0 if KO (infinit loop), >= 0 if OK
-	 *	@return	array				Tableau des informations des champs de la table
-	 *	@return	string		Error code (Exemples: DB_ERROR_TABLE_ALREADY_EXISTS, DB_ERROR_RECORD_ALREADY_EXISTS...)
-	 *	@return 	int		0 en cas de succes
-	 *	@return     boolean     false if conflit, true if ok
-	 *	Charge indicateurs this->nb de tableau de bord
-	 *	Charge indicateurs this->nb pour le tableau de bord
-	 *	Charge les informations d'ordre info dans l'objet commande
-	 *	Charge les informations d'ordre info dans l'objet facture
-	 *	Classify the reception as invoiced (used for exemple by trigger when WORKFLOW_RECEPTION_CLASSIFY_BILLED_INVOICE is on)
-	 *	Classify the shipping as invoiced (used for exemple by trigger when WORKFLOW_SHIPPING_CLASSIFY_BILLED_INVOICE is on)
-	 *	Connexion to server
-	 *	Define properties fullpath, fullrelativename, fulllabel of a directory of array this->cats and all its childs.
-	 *	For category id_categ and its childs available in this->cats, define property fullpath and fulllabel.
-	 *	For user id_user and its childs available in this->users, define property fullpath and fullname.
-	 *	Function to build PDF on disk, then output on HTTP strem.
-	 *	Informations of vat payment object
-	 *	Init array $this->hooks with instantiated action controlers.
-	 *	Initialise tableau info (tableau des attributs LDAP)
-	 *	Les parametres sont deja cense etre juste et avec valeurs finales a l'appel
-	 *	Libere le dernier resultset utilise sur cette connexion
-	 *	Renvoie la description par defaut du modele de numerotation
-	 *	Renvoie un exemple de numerotation
-	 *	Retourne chaine DN complete dans l'annuaire LDAP pour l'objet
-	 *	Return HTML to show the search and clear seach button
-	 *	Return array of log objects (with criterias)
-	 *	Set withdrawal to transmited status
-	 *	TODO	Remplacer les appels a cette fonction par generation objet Ligne
-	 *	TODO	Replace calls to this function by generation objet Ligne
-	 *	This create an opened connexion to a database server and eventually to a database
-	 *	Upate ProductFournisseur
-	 *	Update the link betwen localtax payment and the line into llx_bank
-	 *	car conflit majuscule-minuscule. A n'utiliser que pour les pages
-	 *	get available output_modes for tcpdf class wth its translated description
-	 *	mise en forme du nom complet
-	 *	mise en forme du nom formate
-	 * 		Les parametres sont deja cense etre juste et avec valeurs finales a l'appel
-	 * 	@param		Product $product				contain informations to update
-	 * 	@param	bool			$multiple		add [] in the name of element and add 'multiple' attribut (not working with ajax_autocompleter)
-	 * 	@param	bool	$multiple       add [] in the name of element and add 'multiple' attribut
-	 * 	@param     	int			$info_bits 		    Miscellaneous informations
-	 * 	@param      User	$user       Objet user that close
-	 * 	@param  bool	$multiple				add [] in the name of element and add 'multiple' attribut (not working with ajax_autocompleter)
-	 * 	@return	resource|int         		1 if cancelation is ok or transaction not open, 0 if error
-	 * 	Charge les informations d'ordre info dans l'objet entrepot
-	 * 	Class line Contructor
-	 * 	Load the array of extrafields defintion $this->attributes
-	 * 	Renvoi la description par defaut du modele de numerotation
-	 * 	Return list of all child users id in herarchy (all sublevels).
-	 * 	Total of the VAT payed
-	 * 	VAT payed
-	 * 	set no_email attribut to 1 or 0
-	 *  									For exemple  jean;joe;jim%%;!jimo;!jima%> will target all jean, joe, start with jim but not jimo and not everythnig taht start by jima
-	 *                  					      Si (vendeur et acheteur dans Communaute europeenne) et bien vendu = moyen de transports neuf (auto, bateau, avion), TVA par defaut=0 (La TVA doit etre paye par l'acheteur au centre d'impots de son pays et non au vendeur). Fin de regle.
-	 *                  					      Si le (pays vendeur = pays acheteur) alors la TVA par defaut=TVA du produit vendu. Fin de regle.
-	 *                  					      Sinon la TVA proposee par defaut=0. Fin de regle.
-	 *                  		                  Si vendeur non assujeti a TVA, TVA par defaut=0. Fin de regle.
-	 *                                 		 		- string (categories ids seprated by comma)
-	 *                                                          - string (categories ids seprated by comma)
-	 *                                      - string (categories ids seprated by comma)
-	 *                                      All types can also return some values into an array ->results that will be finaly merged into this->resArray for caller.
-	 *                         Si (vendeur et acheteur dans Communaute europeenne) et bien vendu = moyen de transports neuf (auto, bateau, avion), TVA par defaut=0 (La TVA doit etre paye par l'acheteur au centre d'impots de son pays et non au vendeur). Fin de regle.
-	 *                         Si le (pays vendeur = pays acheteur) alors la TVA par defaut=TVA du produit vendu. Fin de regle.
-	 *                         Si vendeur non assujeti a TVA, TVA par defaut=0. Fin de regle.
-	 *                         Sinon la TVA proposee par defaut=0. Fin de regle.
-	 *                fulllabel = nom avec chemin complet de la categorie
-	 *                fullpath = chemin complet compose des id
-	 *      @param	User	$user   		Objet user
-	 *      @param	User	$user        		Objet user
-	 *      @param	User	$user           Objet user
-	 *      @param      User	$user       	Objet user
-	 *      @param      User	$user        	Objet user making change
-	 *      @param      User	$user       Objet user
-	 *      @param  User	$user       Objet user
-	 *      @param  string	$vatrate     		VAT rate (may contain the vat code too). Exemple: '1.23', '1.23 (ABC)', ...
-	 *      Build the conditionnal string from filter the query
-	 *      Charge indicateurs this->nb de tableau de bord
-	 *      Charge indicateurs this->nb pour le tableau de bord
-	 *      Update informations into database
-	 *     @param  	string			$page        	   	Url of page to call if confirmation is OK. Can contains parameters (param 'action' and 'confirm' will be reformated)
-	 *    $this->code_client = -1 and $this->code_fournisseur = -1 means automatic assignement.
-	 *    @param	DoliDB	$db				Handler acces base de donnees
-	 *    @param	int		$mode		0=Close solved, 1=Close abandonned
-	 *    @param    int		$isencrypted    0 ou 1 si il faut crypter le mot de passe en base (0 par defaut)
-	 *    @param    int		$socid				Id third pary
-	 *    @param   DoliDB	$db             Handler acces base de donnees
-	 *    @param   int     $id      id du paiement dont il faut afficher les infos
-	 *    @return     integer erreur <0, si ok renvoi le nbre de droits par defaut positionnes
-	 *    Connexion to server
-	 *    Constructor de la classe
-	 *    Note: To complete search with a particular filter on select, you can set $object->next_prev_filter set to define SQL criterias.
-	 *    Remove tag payed on TVA
-	 *    Remove tag payed on social contribution
-	 *    Renvoi si un compte peut etre supprimer ou non (sans mouvements)
-	 *    Retourne la liste deroulante des differents etats d'une note de frais.
-	 *    Retourne la liste deroulante des formes juridiques tous pays confondus ou pour un pays donne.
-	 *    Return HTML to show the search and clear seach button
-	 *    Return combo list of differents status of a proposal
-	 *    Return incoterms informations
-	 *    Return incoterms informations for pdf display
-	 *    Return list of categories having choosed type
-	 *    Tag TVA as payed completely
-	 *    Tag social contribution as payed completely
-	 *   @param     Conf		$conf       Objet conf
-	 *   @param     Translate	$langs      Objet lang
-	 *   @param     User		$user       Objet user
-	 *   @param     object		$object     Objet concerned. Some context information may also be provided into array property object->context.
-	 *   Charge indicateurs this->nb de tableau de bord
-	 *   Retourne la liste deroulante des regions actives dont le pays est actif
-	 *  'foreignkey'=>'tablename.field' if the field is a foreign key (it is recommanded to name the field fk_...).
-	 *  @param		Translate	$outputlangs	objet lang a utiliser pour traduction
-	 *  @param		User	$user 		Objet user that make creation
-	 *  @param		int				$disablestockchangeforsubproduct	Disable stock change for sub-products of kit (usefull only if product is a subproduct)
-	 *  @param		string		$criteria	Use %% as magic caracters. For exemple to find all item like <b>jean, joe, jim</b>, you can input <b>j%%</b>, you can also use ; as separator for value,
-	 *  @param		string	$filter				SQL filter on users. This parameter must not come from user intput.
-	 *  @param	    string	$pass		Mot de passe
-	 *  @param	 int			$disablecrop		Disable crop feature on images (-1 = auto, prefer to set it explicitely to 0 or 1)
-	 *  @param	 int	$disablecrop		Disable crop feature on images (-1 = auto, prefer to set it explicitely to 0 or 1)
-	 *  @param	DoliDB		$db			Handler acces base
-	 *  @param	Product		$product		Objet product
-	 *  @param	Translate	$outputlangs	Objet lang to use for translation
-	 *  @param	Translate	$outputlangs	objet lang a utiliser pour traduction
-	 *  @param	User		$user		Objet user that update
-	 *  @param	User		$user       Objet User who activate contract
-	 *  @param	User		$user       Objet User who close contract
-	 *  @param	User	$user      	Objet user qui valide
-	 *  @param	User	$user        	Objet user doing creation
-	 *  @param	User	$user       Objet du user qui cree
-	 *  @param	array			$excludelinksto		Do not show links of this type, for exemple array('order') or array('supplier_order'). null or array() if no exclusion.
-	 *  @param	array			$restrictlinksto	Restrict links to some elements, for exemple array('order') or array('supplier_order'). null or array() if no restriction.
-	 *  @param	array		$arrayofrecords  	Array of record informations (array('textleft'=>,'textheader'=>, ..., 'id'=>,'photo'=>)
-	 *  @param	bool		$multiple		add [] in the name of element and add 'multiple' attribut
-	 *  @param	float		$curY    		curent Y position
-	 *  @param	float		$curY    	curent Y position
-	 *  @param	int			$fk_product_stock	id product_stock for objet
-	 *  @param	int			$fk_product_stock   id product_stock for objet
-	 *  @param	int			$fk_socpeople       Id of thirdparty contact (if source = 'external') or id of user (if souce = 'internal') to link
-	 *  @param	int			$idprof         1,2,3,4 (Exemple: 1=siren,2=siret,3=naf,4=rcs/rm)
-	 *  @param	int			$lowmemorydump	   1=Use the low memory method. If $lowmemorydump is set, it means we want to make the compression using an external pipe instead retreiving the content of the dump in PHP memory array $output_arr and then print it into the PHP pipe open with xopen().
-	 *  @param	int		$maxlength				Max number of charaters into label. If negative, use the ref as label.
-	 *  @param	int		$no_email	1=Do not send mailing, 0=Ok to recieve mailling
-	 *  @param	int		$socid      	Id ot third party or 0 for all
-	 *  @param	int  		$categorie		Category id (optionnal)
-	 *  @param	string			$list				Visibilty ('0'=never visible, '1'=visible on list+forms, '2'=list only, '3'=form only or 'eval string')
-	 *  @param	string			$list			Visibily
-	 *  @param	string		$elemtype		Type of element we show ('category', ...). Will execute a formating function on it. To use in readonly mode if js component support HTML formatting.
-	 *  @param	string		$label			Descripton
-	 *  @param	string		$modele			force le modele a utiliser ('' par defaut)
-	 *  @param	string		$table		Nmae of table filter ('xxx%')
-	 *  @param	string	$errors_to			erros to
-	 *  @param	string	$list				Visiblity
-	 *  @param	string	$resko          resultat si test non egal
-	 *  @param	string	$resok          resultat si test egal
-	 *  @param	string	$selected       Id remise fixe pre-selectionnee
-	 *  @param 		User	$user   Objet utilisateur qui met a jour le don
-	 *  @param 	User	$user       Objet du user qui cree
-	 *  @param 	User	$user       Objet user
-	 *  @param 	array 		$params    		array of additionals parameters
-	 *  @param    	int				$info_bits        	Miscellaneous informations on line
-	 *  @param    	int		$socid			Id third pary
-	 *  @param      Translate   $outputlangs    objet lang a utiliser pour traduction
-	 *  @param      User	$excluser      	Objet user to exclude
-	 *  @param      int         	$showcode       1=Add language code into label at begining, 2=Add language code into label at end
-	 *  @param      integer	$alreadypaid    0=No payment already done, >0=Some payments were already done (we recommand to put here amount payed if you have it, 1 otherwise)
-	 *  @param     int		$fk_cat           Category of the vehicule used
-	 *  @param  DoliDB  $db     Handler acces base de donnees
-	 *  @param  Object		$object			Objet livraison
-	 *  @param  Societe		$soc            Objet societe
-	 *  @param  array	$tabMenu        Array to store new entries found (in most cases, it's empty, but may be alreay filled)
-	 *  @param  array 				$extra_values   Any aditional values for expression
-	 *  @param  bool			$multiple       add [] in the name of element and add 'multiple' attribut
-	 *  @param  double	$alreadypaid	0=No payment already done, >0=Some payments were already done (we recommand to put here amount paid if you have it, 1 otherwise)
-	 *  @param  double	$alreadypaid	0=No payment already done, >0=Some payments were already done (we recommand to put here amount payed if you have it, 1 otherwise)
-	 *  @param  int		  $closepaidinvoices   	1=Also close payed invoices to paid, 0=Do nothing more
-	 *  @param  integer	$alreadypaid	0=No payment already done, >0=Some payments were already done (we recommand to put here amount paid if you have it, 1 otherwise)
-	 *  @param  integer	$searchalt      Search also alernate language file
-	 *  @param  string	$filter         Optionnal filters criteras (example: 's.rowid <> x')
-	 *  @param array $params    array of additionals parameters
-	 *  @param int $showform Show form tags and submit button (recommanded is to use with value 0)
-	 *  @return	string          		chaine formate SQL
-	 *  @return     bool     True if disconnect successfull, false otherwise
-	 *  @return     boolean     True if disconnect successfull, false otherwise
-	 *  @return    array				array('opened'=>Amount including tax that remains to pay, 'total_ht'=>Total amount without tax of all objects paid or not, 'total_ttc'=>Total amunt including tax of all object paid or not)
-	 *  @return string 			          		If OK return clear password, 0 if no change (warning, you may retreive 1 instead of 0 even if password was same), < 0 if error
-	 *  Charge dans l'objet group, la liste des permissions auquels le groupe a droit
-	 *  Charge les informations d'ordre info dans l'objet commande
-	 *  Charge les informations d'ordre info dans l'objet contrat
-	 *  Charge les informations d'ordre info dans l'objet facture
-	 *  Charge les informations sur le contact, depuis la base
-	 *  Charge un objet group avec toutes ses caracteristiques (except ->members array)
-	 *  Clean fields (triming)
-	 *  Close database connexion
-	 *  Create a document onto disk accordign to template module.
-	 *  Delete object in database. If fk_facture_source is defined, we delete all familiy with same fk_facture_source. If not, only with id is removed
-	 *  Deplace fichier uploade sous le nom $file dans le repertoire sdir
-	 *  Fonction appelee lors d'une nouvelle connexion
-	 *  Fonction qui dit si cet utilisateur est un redacteur existant dans spip
-	 *  Function to build PDF on disk, then output on HTTP strem.
-	 *  Les parametres sont deja cense etre juste et avec valeurs finales a l'appel
-	 *  Mise a jour de l'objet ligne de commande en base
-	 *  Mise a jour en base de la date de derniere connexion d'un utilisateur
-	 *  On compare juste manuellement si la database choisie est bien celle activee par la connexion
-	 *  Renvoi la description par defaut du modele de numerotation
-	 *  Renvoi si un code est pris ou non (par autre tiers)
-	 *  Renvoi si un code respecte la syntaxe
-	 *  Retourne la version traduite du texte passe en parametre complete du code pays
-	 *  Retrieve informations about internal contacts
-	 *  Return a HTML link to the user card (with optionaly the picto)
-	 *  Return a link (with optionaly the picto)
-	 *  Return a link to the a lot card (with optionaly the picto)
-	 *  Return a link to the object card (with optionaly the picto)
-	 *  Return a link to the object card (with optionaly the picto).
-	 *  Return a link to the user card (with optionaly the picto)
-	 *  Return an array formated for showing graphs
-	 *  Return childs of product $id
-	 *  Return clickable link of login (eventualy with picto)
-	 *  Return combo list of differents status of a orders
-	 *  Returns if a profid sould be verified to be unique
-	 *  Show 2 HTML widget to input a date or combo list for day, month, years and optionaly hours and minutes.
-	 *  Show a HTML widget to input a date or combo list for day, month, years and optionaly hours and minutes.
-	 *  Show top header of page. This include the logo, ref and address blocs
-	 *  This create an opened connexion to a database server and eventually to a database
-	 *  WARNING: This method change temporarly context $conf->entity to be in correct context for each recurring invoice found.
-	 *  When initHooks function is called, with initHooks(list_of_contexts), an array $this->hooks is defined with instance of controler
-	 *  \brief Compute the cost of the kilometers expense based on the number of kilometers and the vehicule category
-	 *  or partialy (if close_code filled) + appel trigger BILL_PAYED => this->fk_statut=2, this->paye stay 0
-	 *  pour l'instant on ne definit pas les unites dans la base
-	 * $this->${field} should be a clean and string value (so date are formated for SQL insert).
-	 * (validated + payment on process) or classified (paid completely or paid partialy) + not already replaced + not already a credit note
-	 * - $_aryEmail[org]  = orignal string
-	 * - 'sockets' [0] - conect via network to SMTP server
-	 * - 'sockets' [0] - conect via network to SMTP server - default
-	 * - La semaine 1 de toute annee est celle qui contient le 4 janvier ou que la semaine 1 de toute annee est celle qui contient le 1er jeudi de janvier.
-	 * - Then data_xxx.sql (usualy provided by external modules only)
-	 * - Then update_xxx.sql (usualy provided by external modules only)
-	 * @deprecated yes this setTypeFromTypeString came deprecated because it exists only for manage setup convertion
-	 * @param	  	int			$info_bits			Miscellaneous informations of line
-	 * @param	Societe		$objsoc		Objet societe
-	 * @param	User	$user   			Objet user
-	 * @param	User	$user      		Objet User
-	 * @param	User	$user   Objet user
-	 * @param	array		$arrayofcriterias			          Array of available search criterias. Example: array($object->element => $object->fields, 'otherfamily' => otherarrayoffields, ...)
-	 * @param	array		$search_component_params	          Array of selected search criterias
-	 * @param	bool			$gm			1=Input informations are GMT values, otherwise local to server TZ
-	 * @param	int			$fk_product_stock	id product_stock for objet
-	 * @param	int		$disabledoutputofmessages	Clear all messages stored into session without diplaying them
-	 * @param	int		$lineid		Id of production line to filter childs
-	 * @param	int		$noescapecommand	1=Do not escape command. Warning: Using this parameter needs you alreay have sanitized the $command parameter. If not, it will lead to security vulnerability.
-	 * @param	int		$showpointvalue		1=Show value for each point, as tooltip or inline (default), 0=Hide value, 2=Show values for each serie on same point
-	 * @param	int		$update_main_doc_field	Update field main_doc fied into the table of object.
-	 * @param	integer		$mode		0=Use path to find record, 1=Use src_object_xxx fields (Mode 1 is recommanded for new objects)
-	 * @param	integer 	$selected  		defaut selected
-	 * @param	string		$search_component_params_hidden		  String with $search_component_params criterias
-	 * @param	string		$sortorder		Sort order, separated by comma. Example: 'ASC,DESC'. Note: If the quantity fo sortorder values is lower than sortfield, we used the last value for missing values.
-	 * @param	string	$editvalue		When in edit mode, use this value as $value instead of value (for example, you can provide here a formated price instead of numeric value). Use '' to use same than $value
-	 * @param	string	$filter			additionnal filter on project (statut, ref, ...)
-	 * @param	string	$images_dir		Location of where to store physicaly images files. For example $dolibarr_main_data_root.'/medias'
-	 * @param 	Contact 	$contact 	Contact Obejct
-	 * @param 	Object			$objecttmp			Object to knwo the table to scan for combo.
-	 * @param 	User		$user		User wich display
-	 * @param 	array	$type		Array with type for each serie. Example: array('type1', 'type2', ...) where type can be:
-	 * @param 	array 			$excludelinksto 	Do not show links of this type, for exemple array('order') or array('supplier_order'). null or array() if no exclusion.
-	 * @param 	array 			$restrictlinksto 	Restrict links to some elements, for exemple array('order') or array('supplier_order'). null or array() if no restriction.
-	 * @param 	array 	$arrayofcriterias 					Array of available search criterias. Example: array($object->element => $object->fields, 'otherfamily' => otherarrayoffields, ...)
-	 * @param 	array 	$search_component_params 			Array of selected search criterias
-	 * @param 	int		$no_email	    1=Do not send mailing, 0=Ok to recieve mailling
-	 * @param 	object		$line_ext			Objet with full information of line. $line_ext->detail_batch must be an array of ExpeditionLineBatch
-	 * @param 	string		$uploaded_file		Uploade file
-	 * @param 	string	$label				Label (Example: 'Leave', 'Manual update', 'Leave request cancelation'...)
-	 * @param 	string	$uploaded_file		Uploade file
-	 * @param 	string 			$head				Optionnal head lines
-	 * @param 	string 		$elemtype 		Type of element we show ('category', ...). Will execute a formating function on it. To use in readonly mode if js component support HTML formatting.
-	 * @param 	string 		$type_categ 		Category type ('customer', 'supplier', 'website_page', ...) definied into const class Categorie type
-	 * @param 	string 	$search_component_params_hidden 	String with $search_component_params criterias
-	 * @param    User 	$user 			Objet User who close contract
-	 * @param    int	$rowid      Id of third party to load (Use 0 to get a specimen record, use null to use other search criterias)
-	 * @param    string $dolibarr_main_db_pass 	Mot de passe user a creer
-	 * @param    string $field_desc 		Tableau associatif de description du champ a inserer[nom du parametre][valeur du parametre]
-	 * @param   Facture		$invoice	Objet facture
-	 * @param   User 		$user 		Objet User who activate contract
-	 * @param   array   $info   content informations of field
-	 * @param   boolean $confirmnow                         false=default, true=try to confirm immediatly after create (if conditions are ok)
-	 * @param   double		$alreadypaid	0=No payment already done, >0=Some payments were already done (we recommand to put here amount payed if you have it, 1 otherwise)
-	 * @param   int		$fk_socpeople			Id of thirdparty contact (if source = 'external') or id of user (if souce = 'internal') to link
-	 * @param   int 	$fk_socpeople       	Id of thirdparty contact (if source = 'external') or id of user (if souce = 'internal') to link
-	 * @param   int         	$default_font_size  default siez of font
-	 * @param   int     $id      id du paiement dont il faut afficher les infos
-	 * @param   string   $alias   	String of alias of table for fields. For example 't'. It is recommended to use '' and set alias into fields defintion.
-	 * @param   string  $alias   		String of alias of table for fields. For example 't'. It is recommended to use '' and set alias into fields defintion.
-	 * @param   string  $ref                	Reference of object (This will define subdir automatically and store submited file into it)
-	 * @param   string $resko resultat si test non egal
-	 * @param   string $resok resultat si test egal
-	 * @param  int	    $disablestockchangeforsubproduct	Disable stock change for sub-products of kit (usefull only if product is a subproduct)
-	 * @param  int	  $disablestockchangeforsubproduct	Disable stock change for sub-products of kit (usefull only if product is a subproduct)
-	 * @param  int    $nbmax 	Number maxium of photos (0=no maximum)
-	 * @param  int $id             		Id of product to search childs of
-	 * @param  string        $extrafieldsobjectkey	The key to use to store retreived data (commonly $object->table_element)
-	 * @param  string        $extrafieldsobjectkey	The key to use to store retreived data (for example $object->table_element)
-	 * @param  string  $moreparam      			To add more parametes on html input tag
-	 * @param  string  $moreparam      To add more parametes on html input tag
-	 * @param Object 		$objecttmp 			Object to knwo the table to scan for combo.
-	 * @param Translate $outputlangs objet lang a utiliser pour traduction
-	 * @param array    $dict      Array of dictionnary for translation
-	 * @param array  $array_receiver   	  Array of receiver. exemple array('name' => 'John Doe', 'email' => 'john@doe.com', etc...)
-	 * @param bool 			$multiple 			add [] in the name of element and add 'multiple' attribut
-	 * @param bool 			$multiple 		add [] in the name of element and add 'multiple' attribut
-	 * @param bool 		$multiple 			add [] in the name of element and add 'multiple' attribut (not working with ajax_autocompleter)
-	 * @param bool 		$multiple 		add [] in the name of element and add 'multiple' attribut
-	 * @param bool $multiple add [] in the name of element and add 'multiple' attribut (not working with ajax_autocompleter)
-	 * @param int			$mode 				O for create, R for regenerate (Look always 0 ment toujours 0 within the framework of XML exchanges according to documentation)
-	 * @param int 			$socid 				Id ot third party or 0 for all or -1 for empty list
-	 * @param int 		$socid 			Id ot third party or 0 for all
-	 * @param int 	$i 		Rank from which we want to create skilldets (level $i to HRM_MAXRANK wil be created)
-	 * @param int       $month 				Specifig month - Can be empty
-	 * @param int       $year 				Specifig year - Can be empty
-	 * @param int $_type  Interger value representing Mail Transport Type
-	 * @param string			$properties			Restrict the data returned to theses properties. Ignored if empty. Comma separated list of properties names
-	 * @param string		   $properties			Restrict the data returned to theses properties. Ignored if empty. Comma separated list of properties names
-	 * @param string	$str 		Original string to encode and optionaly truncate
-	 * @param string 		$page 				Url of page to call if confirmation is OK. Can contains parameters (param 'action' and 'confirm' will be reformated)
-	 * @param string 	$editvalue 		When in edit mode, use this value as $value instead of value (for example, you can provide here a formated price instead of numeric value, or a select combo). Use '' to use same than $value
-	 * @param string 	$output_format 	(html/opton (for option html only)/array (to return options arrays
-	 * @param string    $page           Page name (website id must also be filled if this parameter is used). Exemple 'myaliaspage' or 'fr/myaliaspage'
-	 * @param string    $properties			Restrict the data returned to theses properties. Ignored if empty. Comma separated list of properties names
-	 * @param string    $properties		  Restrict the data returned to theses properties. Ignored if empty. Comma separated list of properties names
-	 * @param string    $properties		Restrict the data returned to theses properties. Ignored if empty. Comma separated list of properties names
-	 * @param string    $properties	Restrict the data returned to theses properties. Ignored if empty. Comma separated list of properties names
-	 * @param string  $properties			Restrict the data returned to theses properties. Ignored if empty. Comma separated list of properties names
-	 * @param string  $properties Restrict the data returned to theses properties. Ignored if empty. Comma separated list of properties names
-	 * @param string $_path Path to the sendmail execuable
-	 * @param string $key Authentification key
-	 * @param string $selected Id remise fixe pre-selectionnee
-	 * @return	        string      Id connexion
-	 * @return	int         			1 if transaction successfuly opened or already opened, 0 if error
-	 * @return	string							Formated value
-	 * @return	string		Error code (Exemples: DB_ERROR_TABLE_ALREADY_EXISTS, DB_ERROR_RECORD_ALREADY_EXISTS...)
-	 * @return 	float|string			Total amout of discount
-	 * @return 	int            				<0 if KO, number of equipments found if OK
-	 * @return 	int            				Return integer <0 if KO, number of equipments found if OK
-	 * @return 	string			Javacript code to manage dependency
-	 * @return    string        Error code (Exemples: DB_ERROR_TABLE_ALREADY_EXISTS, DB_ERROR_RECORD_ALREADY_EXISTS...)
-	 * @return  array                			Array with inforation on table
-	 * @return  boolean     					True if disconnect successfull, false otherwise
-	 * @return  int      				1 if transaction successfuly opened or already opened, 0 if error
-	 * @return  int         			1 if transaction successfuly opened or already opened, 0 if error
-	 * @return  int                1 if cancelation ok or transaction not open, 0 if error
-	 * @return  string      Id connexion
-	 * @return array                    Aray of resources
-	 * @return boolean     True if mandatory_period setted to 1
-	 * @return int            Minimum recommanded price that is higher price among all suppliers * PRODUCT_MINIMUM_RECOMMENDED_PRICE
-	 * @return string                     Customer ref formated
-	 * @return string                     Supplier ref formated
-	 * @var array Childs
-	 * @var array Contents informations. Usually created at runtime by loadBox().
-	 * @var array Custom family informations
-	 * @var array Header informations. Usually created at runtime by loadBox().
-	 * @var array box dependancies
-	 * @var boolean $standard_conforming_string		Set this to true if postgres accept only standard encoding of sting using '' and not \'
-	 * @var int	Postion
-	 * @var int 	Date for cancelation
-	 * @var int 	ID for cancelation
-	 * @var int -1=Unkown duration
-	 * @var int Amount can be choosen by the visitor during subscription (0 or 1)
-	 * @var int Code modifiable si il est invalide
-	 * @var int Subsription required (0 or 1)
-	 * @var int availabilty ID
-	 * @var integer|string Date delivery planed
-	 * @var string	The name of constant to use to scan ODT files (Exemple: 'COMMANDE_ADDON_PDF_ODT_PATH')
-	 * @var string Hash to identify ticket publically
-	 * @var string availabilty code
-	 * @var string availabilty label
-	 * @var string ref custome
-	 * Active Directory ne supporte pas les connexions anonymes
-	 * Attention ce module est utilise par defaut si aucun module n'a
-	 * Boundary String for MIME seperation
-	 * CAN BE A CRON TASK. In such a case, paramerts come from the schedule job setup field 'Parameters'
-	 * Charge indicateurs this->nb pour le tableau de bord
-	 * Close database connexion
-	 * Connexion to server
-	 * Constructes and returns message header
-	 * Correct an uncomplete html string
-	 * Creditor Identifier CI. Some banks use different ICS for direct debit and bank tranfer
-	 * Criterias used to build request are defined into the constructor of parent class into xxx/class/xxxstats.class.php
-	 * DN des groupes
-	 * Dont add LIMIT to your query, it will be added by this method
-	 * Empty function to prevent errors on call of this function must be overload if usefull
-	 * Exemple of POST query :
-	 * Exemple: { "socid": 2, "date": 1595196000, "type": 0, "lines": [{ "fk_product": 2, "qty": 1 }] }
-	 * Flag to 1 if we must clean ambiguous charaters for the autogeneration of password (List of ambiguous char is in $this->Ambi)
-	 * Function to know all custom groupd from an accounting account
-	 * Function to shwo the combo select to chose a type of field (varchar, int, email, ...)
-	 * Function used to return childs of Mo
-	 * If paid completelly, this->close_code will be null
-	 * Inserts all informations into database.
-	 * Libere le dernier resultset utilise sur cette connexion
-	 * Load all informations of accountancy document
-	 * Method exists only for manage setup convertion
-	 * Method used to test  module builder convertion to this form usage
-	 * Method was used to test  module builder convertion to this form usage.
-	 * Mot de passe de l'administrateur
-	 * Multi-diminsional array containg addresses the message will
-	 * Note: To complete search with a particular filter on select, you can set $object->next_prev_filter set to define SQL criterias.
-	 * Optionaly with $selected_warehouse_id parameter user can get stock of specific warehouse
-	 * Parse criteria to return a SQL qury formated
-	 * Path to the sendmail execuable
-	 * Permet le chargement d'une fonction personnalisee dans le moteur de base de donnees.
-	 * Put in array _translatedFiles[$file], line of a new tranlated pair
-	 * Recommanded solution is to recreate a new payment intent each time we need one (old one will be automatically closed after a delay),
-	 * Renvoi la description par defaut du modele de numerotation
-	 * Retrieve informations about external contacts
-	 * Retrieve informations about internal contacts
-	 * Retrieve number of equipments for a product lot/serial
-	 * Return Unix time from ical date time fomrat (YYYYMMDD[T]HHMMSS[Z] or YYYYMMDD[T]HHMMSS)
-	 * Return an array with Agenda Events informations
-	 * Return an array with Currency informations
-	 * Return an array with Expense Report informations
-	 * Return an array with MO informations
-	 * Return an array with bom informations
-	 * Return an array with candidature informations
-	 * Return an array with category informations
-	 * Return an array with commercial proposal informations
-	 * Return an array with contact informations
-	 * Return an array with contract informations
-	 * Return an array with donation informations
-	 * Return an array with group informations
-	 * Return an array with hook informations
-	 * Return an array with invoice informations
-	 * Return an array with jobposition informations
-	 * Return an array with knowledgerecord informations
-	 * Return an array with member informations
-	 * Return an array with member type informations
-	 * Return an array with myobject informations
-	 * Return an array with order informations
-	 * Return an array with partnership informations
-	 * Return an array with project informations
-	 * Return an array with proposal informations
-	 * Return an array with reception informations
-	 * Return an array with shipment informations
-	 * Return an array with stock movement informations
-	 * Return an array with subscription informations
-	 * Return an array with supplier proposal informations
-	 * Return an array with task informations
-	 * Return an array with thirdparty informations
-	 * Return an array with ticket informations
-	 * Return an array with warehouse informations
-	 * Return and array with all instanciated first level children users of current user
-	 * Return connexion ID
-	 * Return direct childs id of a category into an array
-	 * Return list of auxilary accounts. Cumulate list from customers, suppliers and users.
-	 * Return list of categories having choosed type
-	 * Return list of product formated for output
-	 * Return the addtional SQL JOIN query for filtering a list by a category
-	 * Return the addtional SQL SELECT query for filtering a list by a category
-	 * Return verion of data file
-	 * Returns the partial diff for the specificed sequences, in reverse order.
-	 * Serivce expiration unit
-	 * The string return is not formated (translated with transnoentitiesnoconv).
-	 * This can be changed for 2byte characers sets
-	 * This method takes a list of given addresses, via an array or a COMMA delimted string, and inserts them into a highly
-	 * Udpate the percent value of a event with the given id
-	 * Unsuscribe all : 1 = contact has globaly unsubscribe of all mass emailings
-	 * and restore it into another database with different id wihtout comprimising checksums
-	 * be carefull with this method use it only with some limit of results to avoid performences loss.
-	 * build RECIPIENT List, all addresses who will recieve this message
-	 * ete definit dans la configuration
-	 * or a COMMA delimted string, and inserts them into a highly
-	 * reload conf value from databases is an aliase of loadValueFromConf
-	 * reverse mouvement for object by updating infos
-	 * statique et publique. Le nombre de parametres est determine automatiquement.
-	 * the tagret is useful with hooks : that allow externals modules to add setup items on good place
-	 * the underlaying array is destroyed and reconstructed.
-	 * to define the UNIX file system path to the sendmail execuable
-	 If an error occured, show the resulting errors
-	# ---------------------------- mot de passe admin mysql
-	# Add cach performance directives
-	# Log directoves
-	# Log directoves        
-	$IBS_RETOUR = "montant:M;ref:R;auto:A;trans:T"; // Format des parametres du get de validation en reponse (url a definir sous paybox)
-	$alwaysuncheckedmodules = array('dav', 'dynamicprices', 'incoterm', 'loan', 'multicurrency', 'paybox', 'paypal', 'stripe', 'google', 'printing', 'scanner', 'skype', 'website'); // Module we dont want by default
-	$alwaysuncheckedmodules = array('dav', 'dynamicprices', 'incoterm', 'loan', 'multicurrency', 'paybox', 'paypal', 'stripe', 'google', 'printing', 'scanner', 'socialnetworks', 'website'); // Module we dont want by default
-	$amount = (is_numeric($amount) ? $amount : 0); // Check if amount is numeric, for example, an error occured when amount value = o (letter) instead 0 (number)
-	$controle = $tableau[$report][10];
-	$data = getDecodeValue($mege, $type);
-	$daytoparse = dol_mktime(0, 0, 0, $month, $day, $year); // this are value submited after submit of action 'submitdateselect'
+		if (GETPOSTISSET("reday") && GETPOSTISSET("remonth") && GETPOSTISSET("reyear")) {
+		if (count($arrayfields) > 0 && !empty($arrayfields['t.datee']['checked'])) {
+		if (empty($datee)) {
+		if (empty($reyear) || empty($remonth) || empty($reday)) {
+		if (empty($this->datea)) {
+		if (in_array('01', $TWeek) && in_array('52', $TWeek) && $weekNb == '01') {
+		print $form->selectDate(strtotime(date('Y-m-d', $object->datee)), 'end', '', '', 0, '', 1, 0);
+		print $object->datee ? dol_print_date($object->datee, 'daytext') : '&nbsp;';
+		print '<tr><td>'.$langs->trans("Datee").'</td>';
+		print_liste_field_titre($arrayfields['t.datee']['label'], $_SERVER["PHP_SELF"], "t.datee", '', $param, '', $sortfield, $sortorder, 'center ');
+	 *  @param		string		$datee		End date (ex 23:59:59)
+	 *  @param  float|string  $selectedrate       Force preselected vat rate. Can be '8.5' or '8.5 (NOO)' for example. Use '' for no forcing.
+	$TWeek = array();
+	$date = $obj->periode;
+	$datee = dol_mktime(12, 0, 0, GETPOST('endmonth'), GETPOST('endday'), GETPOST('endyear'));
+	$datee = dol_stringtotime($dateerfc);
+	$datepaid = dol_mktime(12, 0, 0, GETPOST("remonth"), GETPOST("reday"), GETPOST("reyear"));
+	$datepaid = dol_mktime(12, 0, 0, GETPOST("remonth", 'int'), GETPOST("reday", 'int'), GETPOST("reyear", 'int'));
+	$datepaye = dol_mktime(12, 0, 0, GETPOST("remonth", "int"), GETPOST("reday", "int"), GETPOST("reyear", "int"));
+	$datepaye = dol_mktime(12, 0, 0, GETPOST("remonth", 'int'), GETPOST("reday", 'int'), GETPOST("reyear", 'int'));
+	$datepaye = dol_mktime(GETPOST("rehour", 'int'), GETPOST("remin", 'int'), GETPOST("resec", 'int'), GETPOST("remonth", 'int'), GETPOST("reday", 'int'), GETPOST("reyear", 'int'));
+	$datepaye = dol_mktime(GETPOST("rehour", 'int'), GETPOST("remin", 'int'), GETPOST("resec", 'int'), GETPOST("remonth", 'int'), GETPOST("reday", 'int'), GETPOST("reyear", 'int'), 'tzuserrel');
 	$ensemblereponses = $obj->reponses;
-	$fils = 0;
-	$i1 = 0;	// count the nb of and criteria added (all fields / criterias)
-	$intial = 0;
-	$ldaprecords = $ldap->getRecords('*', $conf->global->LDAP_MEMBER_DN, $conf->global->LDAP_KEY_MEMBERS, $required_fields, 'member'); // Fiter on 'member' filter param
-	$ldaprecords = $ldap->getRecords('*', $conf->global->LDAP_USER_DN, $conf->global->LDAP_KEY_USERS, $required_fields, 'user'); // Fiter on 'user' filter param
-	$ldaprecords = $ldap->getRecords('*', getDolGlobalString('LDAP_MEMBER_DN'), getDolGlobalString('LDAP_KEY_MEMBERS'), $required_fields, 'member'); // Fiter on 'member' filter param
-	$ldaprecords = $ldap->getRecords('*', getDolGlobalString('LDAP_USER_DN'), getDolGlobalString('LDAP_KEY_USERS'), $required_fields, 'user'); // Fiter on 'user' filter param
-	$mege = imap_fetchbody($mbox, $jk, $fpos);
-	$mege = imap_fetchbody($mbox, $jk, $fpos, FT_UID);
-	$object->status = $object->fk_statut; // for backwad compatibility
+	$head[$h][1] = $langs->trans('Referers');
+	$morewherefilterarray[] = " t.datee <= '".$db->idate($search_date_end_end)."'";
+	$morewherefilterarray[] = " t.datee >= '".$db->idate($search_date_end_start)."'";
 	$opensurveysondage->mail_admin = $_SESSION['adresse'];
 	$pdf->SetXY($savx, $savy);
+	$projectstatic->datee = $db->jdate($obj->projectdatee);
+	$reday = GETPOST('reday');
 	$savy = $pdf->getY();
-	$showfield = 1; // By defaut
 	$somethingshown = $formactions->showactions($object, 'mouvement', 0, 1, '', $MAXEVENT, '', $morehtmlcenter); // Show all action for product
+	$sql .= "   (cs.periode IS NOT NULL AND cs.periode between '".$db->idate(dol_get_first_day($year))."' AND '".$db->idate(dol_get_last_day($year))."')";
+	$sql .= " AND cs.periode <= '".$db->idate($search_date_limit_end)."'";
+	$sql .= " AND cs.periode >= '".$db->idate($search_date_limit_start)."'";
+	$sql .= " AND p.datee <= '".$db->idate($search_date_end_end)."'";
+	$sql .= " AND p.datee >= '".$db->idate($search_date_end_start)."'";
+	$sql .= " AND t.datee <= '".$db->idate($search_datelimit_end)."'";
+	$sql .= " AND t.datee >= '".$db->idate($search_datelimit_start)."'";
+	$sql .= " GROUP BY p.ref, p.title, p.rowid, p.fk_statut, p.fk_opp_status, p.public, p.dateo, p.datee, t.label, t.rowid, t.planned_workload, t.duration_effective, t.progress, t.dateo, t.datee";
+	$sql .= " GROUP BY p.rowid, p.ref, p.title, p.fk_statut, p.datee, p.fk_opp_status, p.public, p.fk_user_creat,";
+	$sql .= " OR (cs.periode IS NULL AND cs.date_ech between '".$db->idate(dol_get_first_day($year))."' AND '".$db->idate(dol_get_last_day($year))."')";
+	$sql .= " ORDER BY t.dateo DESC, t.rowid DESC, t.datee DESC";
 	$sql .= " SET reponses = '".$db->escape($nouveauchoix)."'";
-	$sql = "UPDATE ".MAIN_DB_PREFIX."ecm_directories set cachenbofdoc = -1 WHERE cachenbofdoc < 0"; // If pb into cahce counting, we set to value -1 = "unknown"
-	$tmpday = -date("w", dol_mktime(12, 0, 0, $month, 1, $year, 'gmt')) + 2; // date('w') is 0 fo sunday
-	$valuetoshow = ucfirst($fieldlist[$field]); // By defaut
-	/* intput, input[type=text], */
-	/* width: 168px; If I use with, there is trouble on size of flex boxes solved with min+max that is a little bit higer than min */
-	/**     Renvoi la description par defaut du modele de numerotation
-	/** @var string Authentification key */
-	//	-> 7=Canceled/Never received -> (reopen) 3=Process runing
-	//	0=Draft -> 1=Validated -> 2=Approved -> 3=Process runing -> 4=Received partially -> 5=Received totally -> (reopen) 4=Received partially
-	//                                                                                          -> 7=Canceled/Never received -> (reopen) 3=Process runing
-	// (usefull to sort holidays, sick days or similar on the top)
-	// Add LEFT JOIN for all parent tables mentionned into the Group by
-	// Add LEFT JOIN for all parent tables mentionned into the Xaxis
-	// Add LEFT JOIN for all parent tables mentionned into the Yaxis
-	// Add format informations and link to download example
-	// Affichage de la liste des projets de la semaine
-	// Bit 1:	0 ligne normale - 1 si ligne de remise fixe
-	// Build filter to diplay only concerned lines
-	// By default use tls decied by PHP.
-	// Cas des parametres TAX_MODE_SELL/BUY_SERVICE/PRODUCT
-	// Chargement de la classe
-	// Chargement de labels et data_xxx pour tableau 4 Mouvements
-	// Chars '--' can be used into filename to inject special paramaters like --use-compress-program to make command with file as parameter making remote execution of command
-	// Compare version with last install database version (upgrades never occured)
-	// Confirm cancelation
-	// Confirm deleteion
-	// Confirmation desactivation
-	// Confirmation du classement abandonne
-	// Contacts of task, disabled because available by default jsut after
-	// Create MO with Childs
-	// Create classe to use for import
-	// Create or edit a varian
-	// Create temporary encryption key if nedded
-	// Date appoval
-	// Date delivery planed
-	// Definition des parametres vente produit pour paybox
-	// Definition, nettoyage parametres
-	// Delivery date planed
-	// Donwload file
-	// Edition des varibales globales
-	// FIX for compatibity habitual tabs
-	// Fixe les dimensions de la vignette
-	// Fixed by Matelli (see http://matelli.fr/showcases/patchs-dolibarr/fix-cleaning-url.html)
-	// For example to avoid to have substition done when object is generic and not yet defined.
-	// Force parametres en chaine
-	// Get the main request informaiton.
-	// Hauteur par defaut d'une ligne
-	// If there is a translation, we can send immediatly the label
-	// If we are here, this means authentication was successfull.
-	// Initialisation objet cactioncomm
-	// Initialize array of search criterias
-	// Link for delivery fields ref and date. Does not duplicate the line because we should always have ony 1 link or 0 per shipment
-	// List of fiels for action=list
-	// None. Beeing connected is enough.
-	// Nunber of files
-	// On remet cette lecture de permission ici car nécessaire d'avoir le nouveau statut de l'objet après toute action exécutée dessus (après incrémentation par exemple, le bouton supprimer doit disparaître)
-	// Parameteres execution
-	// Payment informations
-	// Payments not linked to an invoice. Should not happend. For debug only.
-	// Peut valoir un nombre ou liste de nombre separes par virgules
-	// Properties to store project informations
-	// Replace HTML coments
-	// Replace protected special codes with matching number of _ as wild card caracter
-	// Search parent to set task_parent_alternate_id (requird by ganttchart)
-	// Set also dependencies between use taks and bill time
-	// Show autofill date for recuring invoices
-	// Show image to selecte between date survey or other survey
-	// Si (vendeur dans Communaute europeene et acheteur hors Communaute europeenne et acheteur particulier) alors TVA par defaut=TVA du produit vendu. Fin de regle
-	// Si (vendeur et acheteur dans Communaute europeenne) et (acheteur = entreprise) alors TVA par defaut=0. Fin de regle
-	// Si (vendeur et acheteur dans Communaute europeenne) et (acheteur = particulier) alors TVA par defaut=TVA du produit vendu. Fin de regle
-	// Si (vendeur et acheteur dans Communaute europeenne) et (bien vendu = moyen de transports neuf comme auto, bateau, avion) alors TVA par defaut=0 (La TVA doit etre paye par l'acheteur au centre d'impots de son pays et non au vendeur). Fin de regle.
-	// Si le (pays vendeur = pays acheteur) alors la TVA par defaut=TVA du produit vendu. Fin de regle.
-	// Sinon la TVA proposee par defaut=0. Fin de regle.
-	// Subscription informations
-	// Tableau des parametres complementaires du post
-	// The feature to define the numbering module of lot or serial is no enabled bcause it is not used anywhere in Dolibarr code: You can set it
-	// Update ressource
-	// Verification parametres
-	// Warning: Do not set default value into property defintion. it must stay null.
-	// We keep it with value ForceBuyingPriceIfNull = 2 for retroactive effect but results are unpredicable.
-	// We open a list of transaction of a dedicated account and no page was set by defaut
-	// When a dictionnary is commented
-	// add properties and declare them in consturctor
-	// buil format asciidoc for urls in table
-	// but in some situations that is required (update legal informations for example)
-	// for gravatar use get_avatar_from_service('gravatar', md5 hash email@adress, size-in-px )
-	// on transfert les données de l'un vers l'autre
-	// rewrite dictionnary if
-	// si le filtrage est parametre pour l'export ou pas
-	// start and end date that change with time andd that may be different that the period of reference for price.
-	// verify informations entred
-	//' If an error occured, show the resulting errors
-	//' If the API call succeded, then redirect the buyer to PayPal to begin to authorize payment.
-	//' of the authorization, incuding any shipping information of the
-	//'__PERSONALIZED__' => 'TESTPersonalized'	// Hiden because not used yet
-	//'options_attr2'=>'Attr2 balbal' //Extra field exemple where field code is attr2
-	//,'options_attr1'=>'Attr1 balbal', //Extra field exemple where field code is attr1
-	//If invoice has been converted and the conversion has been used, we dont have remain to pay on invoice
-	//If no task avaiblable, redirec to to add confirm
-	//TODO : Note and docuement
-	//console.log("amount before="+amount+" rouding="+rounding)
-	//if ($val['notnull'] > 0) $rightpart .= ' fieldrequired';		// No fieldrequired inthe view output
-	//search and get all permssion in stirng
-	<dt>pRes</dt><dd>(optional) resource name</dd>
+	$sql .= " cs.rowid, cs.libelle, cs.fk_type as type, cs.periode as period, cs.date_ech, cs.amount as total,";
+	$sql .= " t.datec, t.dateo, t.datee, t.tms,";
+	$sql .= " t.label, t.rowid as taskid, t.planned_workload, t.duration_effective, t.progress, t.dateo as date_start, t.datee as date_end, SUM(tasktime.element_duration) as timespent";
+	$sql = "SELECT p.ref, p.title, p.rowid as projectid, p.fk_statut as status, p.fk_opp_status as opp_status, p.public, p.dateo as projdate_start, p.datee as projdate_end,";
+	$sql.= " ".MAIN_DB_PREFIX."notify_def as nd,";
+	$sql.= " AND nd.fk_action = ad.rowid";
+	$sql.= " WHERE u.rowid = nd.fk_user";
+	$sql.= " nd.rowid, ad.code, ad.label";
+	$sql2 .= " p.dateo, p.datee,";
+	$sql2 .= " s.logo, s.email, s.entity, p.fk_user_creat, p.public, p.fk_statut, p.fk_opp_status, p.opp_percent, p.opp_amount, p.dateo, p.datee";
+	$title = $langs->trans('Batch')." ".$shortlabel." - ".$langs->trans('Referers');
+	$totalforvisibletasks = projectLinesPerMonth($j, $firstdaytoshow, $usertoprocess, 0, $tasksarray, $level, $projectsrole, $tasksrole, $mine, $restrictviewformytask, $isavailable, 0, $TWeek);
+	'cs.periode'	=>array('label'=>"PeriodEndDate", 'checked'=>1, 'position'=>50),
+	't.datee'=>array('label'=>"Deadline", 'checked'=>1, 'position'=>101),
+	't.datee'=>array('label'=>"Deadline", 'checked'=>1, 'position'=>5),
+	// Ligne de la periode d'analyse du rapport
+	// ceci afin d'etre compatible avec les cas ou la periode n'etait pas obligatoire
+	//$datee=$now
+	//$dates=dol_time_plus_duree($datee, -1, 'y');
 	<strong>TaskItem(<em>pID, pName, pStart, pEnd, pColor, pLink, pMile, pRes, pComp, pGroup, pParent, pOpen, pDepend, pCaption, pNotes, pGantt</em>)</strong></p>
-	<td colspan="3"><textarea name="adress" cols="40" rows="3"><?php echo $this->control->tpl['address']; ?></textarea></td>
-	<td colspan="3"><textarea name="adresse" cols="40" rows="3"><?php echo $this->control->tpl['address']; ?></textarea></td>
-	Une ligne represente un element : data[$x]
-	accessforbidden('Not enought permissions');
-	const CLOSECODE_ABANDONED = 'abandon'; // Abandonned - other
-	const CLOSECODE_BADDEBT = 'badcustomer'; // Abandonned remain - bad customer
-	const CLOSECODE_BANKCHARGE = 'bankcharge'; // Abandonned remain - bank charge
-	const CLOSECODE_DISCOUNTVAT = 'discount_vat'; // Abandonned remain - escompte
-	const CLOSECODE_OTHER = 'other'; // Abandonned remain - other
-	const TRIGGER_PREFIX = ''; // to be overriden in child class implementations, i.e. 'BILL', 'TASK', 'PROPAL', etc.
-	display: inline-block;	/* this will be modifiy on the fly by the copy-paste js code in lib_foot.js.php to have copy feature working */
-	dol_syslog("complete_dictionary_with_modules Search external modules to complete the list of dictionnary tables", LOG_DEBUG, 1);
-	dol_syslog("getURLContent response size=".strlen($response)); // This may contains binary data, so we dont output it
-	dolibarr_del_const($db, 'SYSLOG_HANDLERS', -1); // To be sure ther is not a setup into another entity
-	echo $line->disable_stock_change ? yn($line->disable_stock_change) : ''; // Yes, it is a quantity, not a price, but we just want the formating role of function price
-	global $conf, $db, $hookmanager, $langs, $mysoc, $user, $website, $websitepage, $weblangs, $pagelangs; // Very important. Required to have var available when running inluded containers.
-	global $conf, $db, $hookmanager, $langs, $mysoc, $user, $website, $websitepage, $weblangs; // Very important. Required to have var available when running inluded containers.
-	httponly_accessforbidden('Module Memebership no enabled');
+	foreach ($TWeek as $weekNb) {
+	foreach ($TWeek as $week_number) {
+	if (!empty($arrayfields['t.datee']['checked'])) {
 	if ($action == "transfert") {
-	if ($fils == 0) {
-	if ($fk_pa > 0 && empty($paht)) {
-	if (empty($shmkeys[$memoryid])) {	// No room reserved for thid memoryid, no way to use cache
-	if (getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {    // For backward compatiblity, we scan also old dirs
-	min-height: 26px !important;	/* We cant use height because it's a div and it should be higher if content is more. but min-height doe not work either for div */
-	min-height: 26px !important;	/* We cant use height because it's a div and it should be higher if content is more. but min-height does not work either for div */
-	padding: .19em .35em;			/* more than 0.19 generate a change into heigth of lines */
-	print "Load joomla news and create them into Dolibarr database (if they don't alreay exist).\n";
-	print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-	print '<div class="div-table-responsive-no-min">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-	print '<div class="info">The recommanded value for MAIN_SECURITY_HASH_ALGO is now \'password_hash\' but setting it now will make ALL existing passwords of all users not valid, so update is not possible.<br>';
+	if (GETPOST("reyear", "int") && GETPOST("remonth", "int") && GETPOST("reday", "int")) {
+	if (GETPOST('reday')) {
+	print $form->selectDate($datee, 'datee', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans("to"));
 	print '<option value="1"'.(GETPOST('mouvement') ? ' selected="selected"' : '').'>'.$langs->trans("Delete").'</option>';
 	print '<select name="mouvement" id="mouvement" class="minwidth100 valignmiddle">';
-	print '<tr><td colspan="2"><br>*** Force modules not found physicaly to be disabled (only modules adding js, css or hooks can be detected as removed physicaly)</td></tr>';
-	print 'Failed to open '.$outputfile.' for ouput.'."\n";
-	print 'Missing paramater s, c or a';
-	print 'Sorry, it seems your internet connexion is off.<br>';
+	print '<td class="left" width="25%">'.$langs->trans("Referers").'</td>';
+	print '<td class="right">'.$langs->trans("NbOfMembers").' <span class="opacitymedium">('.$langs->trans("AllTime").')</span></td>';
+	print '<tr><td>'.$langs->trans("Period")."</td><td>".dol_print_date($charge->periode, 'day')."</td></tr>\n";
 	print ajax_combobox("mouvement");
-	print img_picto($langs->trans("Activited"), 'switch_on');
-	print price($line->qty, 0, '', 0, 0); // Yes, it is a quantity, not a price, but we just want the formating role of function price
-	private $cache_childids; // Cache array of already loaded childs
-	public $cacheconvert = array(); // Array to cache list of value found after a convertion
+	print_liste_field_titre("Employee", $_SERVER["PHP_SELF"], "u.lastname,cs.periode", "", $param, 'class="left"', $sortfield, $sortorder);
+	print_liste_field_titre($arrayfields['cs.amount']['label'], $_SERVER["PHP_SELF"], "cs.amount,cs.periode", '', $param, 'class="right"', $sortfield, $sortorder);
+	print_liste_field_titre($arrayfields['cs.date_ech']['label'], $_SERVER["PHP_SELF"], "cs.date_ech,cs.periode", '', $param, '', $sortfield, $sortorder, 'center ');
+	print_liste_field_titre($arrayfields['cs.fk_account']['label'], $_SERVER["PHP_SELF"], "cs.fk_account,cs.periode", '', $param, '', $sortfield, $sortorder);
+	print_liste_field_titre($arrayfields['cs.fk_mode_reglement']['label'], $_SERVER["PHP_SELF"], "cs.fk_mode_reglement,cs.periode", '', $param, '', $sortfield, $sortorder);
+	print_liste_field_titre($arrayfields['cs.fk_type']['label'], $_SERVER["PHP_SELF"], "cs.fk_type,cs.periode", '', $param, '', $sortfield, $sortorder);
+	print_liste_field_titre($arrayfields['cs.libelle']['label'], $_SERVER["PHP_SELF"], "cs.libelle,cs.periode", '', $param, '', $sortfield, $sortorder);
+	print_liste_field_titre($arrayfields['cs.paye']['label'], $_SERVER["PHP_SELF"], "cs.paye,cs.periode", '', $param, 'class="right"', $sortfield, $sortorder);
+	print_liste_field_titre($arrayfields['cs.periode']['label'], $_SERVER["PHP_SELF"], "cs.periode", '', $param, '', $sortfield, $sortorder, 'center ');
+	print_liste_field_titre($arrayfields['p.datee']['label'], $_SERVER["PHP_SELF"], "p.datee", "", $param, '', $sortfield, $sortorder, 'center ');
+	print_liste_field_titre($arrayfields['t.datee']['label'], $_SERVER["PHP_SELF"], "t.datee", "", $param, '', $sortfield, $sortorder, 'center ');
 	public $childs = array();
-	public $code_modifiable_invalide = 1; // Code modifiable si il est invalide
-	public $code_modifiable_invalide; // Code modifiable si il est invalide
-	public $date_delivery; // Date delivery planed
-	public $debug_api; // usefull if no dialog
-	public $emetteur; // Objet societe qui emet
-	public $fk_origin_stock;		// rowid in llx_product_batch table (not usefull)
-	public $graph; // Objet Graph (Artichow, Phplot...)
-	public $infofiles; // Used to return informations by function getDocumentsLink
-	public $lastsearch_values; // To store last saved search criterias for user
-	public $lastsearch_values_tmp; // To store current search criterias for user
-	public $recurid;		/* A string YYYYMMDDHHMMSS shared by allevent of same serie */
-	public $require_module = array("none"); // This module should not be displayed as Selector in mailling
-	public $societe; // Objet societe
-	public $special_code; // Tag for special lines (exlusive tags)
-	public $statut; // 0=Draft -> 1=Validated -> 2=Approved -> 3=Ordered/Process runing -> 4=Received partially -> 5=Received totally -> (reopen) 4=Received partially
-	return ($controle == $bv);
+	public $datea;
+	public $datee;
+	public $periode;
+	public function getSumOfAmount($fuser = '', $dates = '', $datee = '')
+	return $TWeek;
 	unset($_SESSION["adresse"]);
-	|| (($user->id != $id) && $user->hasRight("user", "user", "passsword")));
-	} elseif (preg_match('/^([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])$/', GETPOST("datep"), $reg)) {		// Try to not use this. Use insteead '&datep=now'
-    		if (/\);/i) {	# end of create table squence
-                                                    <a href="plan-a.php" class="btn btn-rect btn-primary d-block d-md-inline-block" id="plana">Subcribe</a>
-                                <input type="hidden" name="toekn" value="<?php echo newToken(); ?>">
-                            <q>We were skeptical to work with a consultant to optimize our sales emails, but they were highly recommended by many other startups we knew. They helped us to reach our objective of 20% turnover increase, in 4 monthes.</q>
-                            tempora nam reprehenderit quia itaque debitis,
-        // prevent submiting form on press ENTER
-        print "Package $target built succeessfully in $DESTI\n";
-       SOCIETE_USEPREFIX can restore old feature.
-       miscelaneous contries.
-      * the tagret is useful with hooks : that allow externals modules to add setup items on good place
-      - htdocs/modulebuilder/template/test/phpunit/functionnal
-      <!-- Looking for our sevices -->
-      description: Screenshots, screencasts, dolibarr.log, debugging informations
-      | dolibar  |          |
-      | dolibar  | pass     |
-      | dolibar  | password |
-    - name: Chech Apache availability
-    /* height of an item in any tree / collapsable table */
-    dejavusans* (used by greek, arab, persan, romanian, turkish),
-  Replaced phplot and phplot5 librairies by artichow.
-  for a personnal address book.
-  fundation module.
-  where {TYPE} is contact type code (BILLING, SHIPPING, CUSTOMER, ... see contact type dictionnary).
- *									non defini=>renvoi un salt pour cryptage par defaut
- *					Initialy built by build_class_from_table on 2016-05-17 12:22
- *					The payment was already really recorded. So an error here must send warning to admin but must still infor user that payment is ok.
- *				Initialy built by build_class_from_table on 2013-03-10 00:32
- *				et la classe mere de numerotation des bons de livraisons
- *		@param	int					$trunc			1=Truncate if there is more decimals than MAIN_MAX_DECIMALS_SHOWN (default), 0=Does not truncate. Deprecated because amount are rounded (to unit or total amount accurancy) before beeing inserted into database or after a computation, so this parameter should be useless.
- *		@param	int		$info_bits					Miscellaneous informations on line
- *		@return	string								String with formated amount
- *		\brief      Ensemble de fonctions de base pour la gestion des utilisaterus et groupes
- *		\brief      Ensemble de fonctions de base pour les adherents
- *		\brief      Ensemble de fonctions de base pour les contacts
- *		\brief      Ensemble de fonctions de base pour les deplacements
- *		\brief      Fichier contenant la classe du modele de numerotation de reference de commande fournisseur Muguet
- *		\brief      Fichier contenant la classe mere des boites
- *		\brief      Fichier de la classe des charges sociales
- *		\brief      File for Tanslate class
- *		\brief      Page des informations d'un utilisateur
- *		\brief      Page des informations d'une action
- *		\brief      Page des informations d'une facture
- *		\brief      Page des informations d'une facture fournisseur
- *		\brief      Page to adminsiter email sender profiles
- *		\brief      Page to setup extra fields of stock mouvement
- *		\brief      Tabe to enter counting
- *	 Si le (pays vendeur = pays acheteur) alors TVA par defaut=TVA du produit vendu. Fin de regle.
- *	 Sinon TVA proposee par defaut=0. Fin de regle.
- *	 VATRULE 2: Si le (pays vendeur = pays acheteur) alors TVA par defaut=TVA du produit vendu. Fin de regle.
- *	 VATRULE 3: Si (vendeur et acheteur dans Communaute europeenne) et (bien vendu = moyen de transports neuf comme auto, bateau, avion) alors TVA par defaut=0 (La TVA doit etre paye par acheteur au centre d'impots de son pays et non au vendeur). Fin de regle.
- *	 VATRULE 4: Si (vendeur et acheteur dans Communaute europeenne) et (acheteur = particulier) alors TVA par defaut=TVA du produit vendu. Fin de regle
- *	 VATRULE 5: Si (vendeur et acheteur dans Communaute europeenne) et (acheteur = entreprise) alors TVA par defaut=0. Fin de regle
- *	 VATRULE 6: Sinon TVA proposee par defaut=0. Fin de regle.
- *	@param	    string		$address    			email (Ex: "toto@examle.com". Long form "John Do <johndo@example.com>" will be false)
- *	@param	Societe		$thirdparty_seller    	Objet societe vendeuse
- *	@param	Translate	$outputlangs		Objet lang a utiliser pour traduction
- *	@param	int			$color			0=texte only, 1=Text is formated with a color font style ('ok' or 'error'), 2=Text is formated with 'ok' color.
- *	@param	int		$maxlinesize  	Largeur de ligne en caracteres (ou 0 si pas de limite - defaut)
- *	@param	mixed		$gm				True or 1 or 'gmt'=Input informations are GMT values
- *	@param	object	$object			Objet to show
- *	@param	string	    $morehtmlcenter     String in the middle ('' by default). We often find here string $massaction comming from $form->selectMassAction()
- *	@param	string	$begin       		("" by defaut)
- *	@param	string	$begin       ("" by defaut)
- *	@param  Societe		$thirdparty_buyer   	Objet societe acheteuse
- *	@param  string	$moreattrib  		Add more attributes on th ("" by defaut). To add more css class, use param $prefix.
- *	@param  string	$moreattrib  Options of attribute td ("" by defaut)
- *	@return	array						Array of informations
- *	@return	string						Formated reduction
- *	@return string					Formated profID
- *	Class for accesing price expression table
- *	Class for accesing price global variables table
- *	Class to buld vCard files
- *	Class to manage numbering of intervention cards with rule Artic.
- *	Classe de gestion des factures recurrentes/Modeles
- *	Classe du modele de numerotation de reference de commande fournisseur Muguet
- *	Classe du modele de numerotation de reference de commande fournisseur Orchidee
- *	Classe mere des modeles de bon de livraison
- *	Classe mere des modeles de numerotation des references de propales
- *	Classe mere des modeles de propale
- *	Classe permettant de generer les borderaux envoi au modele Squille
- *	Classe permettant de generer les projets au modele Ban
- *	Classe permettant de generer les rapports de paiement
- *	Classe permettant la generation de composants html autre
- *	Classe permettant la gestion des paiements des charges
- *	Classe permettant la gestion des stats des deplacements et notes de frais
- *	Classe permettant la gestion des stats des salaires
- *	Classe permettant la gestion des tiers par defaut
- *	Classe permettant la gestion monkey des codes tiers
- *	Decode a string with a symetric encryption. Used to decrypt sensitive data saved into database.
- *	Encode a string with a symetric encryption. Used to encrypt sensitive data into database.
- *	Get formated messages to output (Used to show messages on html output).
- *	Parent class to manage warehouse mouvement document templates
- *	Print formated messages to output (Used to show messages on html output).
- *	Return a string with VAT rate label formated for view output
- *	Return a timestamp date built from detailed informations (by default a local PHP server timestamp)
- *	Return nb of lines of a formated text with \n and <br> (WARNING: string must not have mixed \n and br separators)
- *	Returns formated reduction
- *	Save personnal parameter
- *	Show informations on an object
- *	Show logo editer/modifier fiche
- *	\brief		Fichier de la classe permettant d'editer au format PDF des etiquettes au format Avery ou personnalise
- *	\brief 		Classe permettant la gestion leopard des codes produits
- *	\brief      Classe du modele de numerotation de reference de livraison Saphir
- *	\brief      Classe permettant la gestion des contacts par defaut
- *	\brief      Ensemble de fonctions de base pour le module categorie
- *	\brief      Ensemble de fonctions de base pour le module fichinter
- *	\brief      Ensemble de fonctions de base pour le module prelevement
- *	\brief      Ensemble de fonctions de base pour le module propal
- *	\brief      Ensemble de fonctions de base pour le module societe
- *	\brief      Fichier contenant la classe du modele de numerotation de reference de commande fournisseur Orchidee
- *	\brief      Fichier contenant la classe du modele de numerotation de reference de livraison Saphir
- *	\brief      Fichier contenant la classe du modele de numerotation de reference de projet Universal
- *	\brief      Fichier contenant la classe mere de generation de bon de livraison en PDF
- *	\brief      Fichier de la classe Thirdparty card controller (common)
- *	\brief      Fichier de la classe Thirdparty card controller (individual canvas)
- *	\brief      Fichier de la classe Thirdparty contact card controller (common)
- *	\brief      Fichier de la classe Thirdparty contact card controller (default canvas)
- *	\brief      Fichier de la classe de gestion des stats des adhérents
- *	\brief      Fichier de la classe des factures fournisseursrecurentes
- *	\brief      Fichier de la classe des fonctions predefinie de composants html
- *	\brief      Fichier de la classe des fonctions predefinie de composants html autre
- *	\brief      Fichier de la classe permettant de generer les bordereaux envoi au modele Squille
- *	\brief      Fichier de la classe permettant de gerer une base pgsql
- *	\brief      File of class to manage receving receipts with template Storm
- *	\brief      File of class to manage receving receipts with template Typhon
- *	\brief      Gantt diagramm of a project
- *	\brief      Management of direct debit order or credit tranfer of invoices
- *	\brief      Module pour inclure des informations externes RSS
- *	\brief      Module to build boxe for events
- *	\brief      Page des informations d'un entrepot
- *	\file       htdocs/opensurvey/fonctions.php
- * 												Note: In database, dates are always fot the server TZ.
- * 		        	               	     	'member'           to add a tab in fundation member view
- * 		@return boolean           		True if informations are valid, false otherwise
- * 		Check account number informations for a bank account
- * 		\brief      Module pour inclure des fonctions de saisies des taxes (tva) et charges sociales
- * 	@param	int			$alpha		    0=Keep number only to forge path, 1=Use alpha part afer the - (By default, use 0). (deprecated, global option will be used in future)
- * 	@param	int			$showdetails	Show company adress details into footer (0=Nothing, 1=Show address, 2=Show managers, 3=Both)
- * 	@param 		string		$replace			Replacement character (defaul: *)
- * 	@return string 				    Formated phone number
- * 	@return string 				Formated IP, with country if GeoIP module is enabled
- * 	@return string      				Formated date or '' if time is null
- * 	Classe du modele de numerotation de reference de projet Universal
- * 	Return a html list with rank informations
- * 	Return an IP formated to be shown on screen
- * 	\brief      Fichier de la classe des gestion des fiches interventions
- *  			et la classe mere de numerotation des propales
- *   	Return a string with full address formated for output on documents
- *    	@param     string	$extName        	Extension to differenciate thumb file name ('_small', '_mini')
- *    	@return     string		 		 	Formated text of duration
- *       			 This Ajax service is oftenly called when option MAIN_DIRECT_STATUS_UPDATE is set.
- *                          				'contract'		   to add a tabl in contract view
- *                              'action-btn-label' => '', // Overide label of action button,  if empty default label use "Confirm" lang key
- *                              'cancel-btn-label' => '', // Overide label of cancel button,  if empty default label use "CloseDialog" lang key
- *                              'content' => '', // Overide text of content,  if empty default content use "ConfirmBtnCommonContent" lang key
- *                              'title' => '', // Overide title of modal,  if empty default title use "ConfirmBtnCommonTitle" lang key
- *                              'url' => 'http://', // Overide Url to go when user click on action btn, if empty default url is $url.?confirm=yes, for no js compatibility use $url for fallback confirm.
- *                          'action-btn-label' => '', // Overide label of action button,  if empty default label use "Confirm" lang key
- *                          'cancel-btn-label' => '', // Overide label of cancel button,  if empty default label use "CloseDialog" lang key
- *                          'content' => '', // Overide text of content,  if empty default content use "ConfirmBtnCommonContent" lang key
- *                          'title' => '', // Overide title of modal,  if empty default title use "ConfirmBtnCommonTitle" lang key
- *                          'url' => 'http://', // Overide Url to go when user click on action btn, if empty default url is $url.?confirm=yes, for no js compatibility use $url for fallback confirm.
- *                  This token and session can be used to get more informations.
- *                  This token can be used to get more informations.
- *              - Le nom de la classe doit etre InterfaceMytrigger
- *              Initialy built by build_class_from_table on 2015-02-24 10:38
- *              Initialy built by build_class_from_table on 2016-05-17 12:22
- *       \brief      Fichier de la classe de gestion des stats des deplacement et notes de frais
- *       \brief      Fichier de la classe de gestion des stats des expensereport et notes de frais
- *       \brief      Fichier de la classe de gestion des stats des factures
- *       \brief      Fichier de la classe de gestion des stats des tickets
- *       \brief      Fichier de la classe des gestion leopard des codes clients
- *       \brief      Fichier de la classe des gestion leopard des codes produits
- *       \brief      Fichier de la classe des gestion lion des codes clients
- *       \brief      Fichier de la classe permettant la generation du formulaire html d'envoi de mail unitaire
- *       \brief      Onglet informations personnelles d'un contact
- *       \brief      Page fiche LDAP groupe
- *       \brief      Tab to manage contacts/adresses of proposal
- *      @return boolean                 	True if informations are valid, false otherwise
- *      @return boolean                 True if informations are valid, false otherwise
- *      @return string						Formated string
- *      @return string				Return list fo image format
- *      Check IBAN number informations for a bank account.
- *      Check SWIFT informations for a bank account
- *      Classe permettant la generation du formulaire d'envoi de Sms
- *      Classe permettant la generation du formulaire html d'envoi de mail unitaire
- *      Return a formated address (part address/zip/town/state) according to country rules.
- *      \brief      Classe to manage GeoIP
- *      \brief      Fichier de la classe des fonctions predefinie de composants html
- *      \brief      Fichier de la classe des fonctions predefinie de composants html cron
- *      \brief      Page des informations dolistore
- *     Classe du modele de numerotation de reference de projet Universal
- *     \brief      Page list of invoice paied by direct debit or credit transfer
- *    Also modified to handle attachements.
- *    \brief      Fichier contenant la classe du modele de numerotation de reference de projet Universal
- *   - corrected the defualt value for 'setPriority()'
- *   Si vendeur non assujeti a TVA, TVA par defaut=0. Fin de regle.
- *   VATRULE 1: Si vendeur non assujeti a TVA, TVA par defaut=0. Fin de regle.
- *   \brief			Fichier de la classe de gestion des triggers
- *   \brief      Fichier contenant la classe du modele de numerotation de reference de bon de livraison Jade
- *  - 'getBodyContent()' builds full messsage body, even multi-part
- *  - 'setAttachment()' will add an MD5 checksum to attachements if above property is set
- *  - added '_server_authenticate()' as a seperate method to handle server authentication.
- *  - added _server_connect()' as a seperate method to handle server connectivity.
- *  - added propery "Close message boundry" tomessage block
- *  - basic shell with some commets
- *  - modifed 'getFrom()' to handle "striping" the email address
- *  - modified getHeader() to ustilize new Message Sensitivity and Priorty properties
- *  - removed leading dashes from message boundry
- *  @param		int			$onlysqltoimportwebsite		Only sql resquests used to import a website template are allowed
- *  @param		int		$onlysqltoimportwebsite		Only sql resquests used to import a website template are allowed
- *  @param		string		$context		'add'=Output field for the "add form", 'edit'=Output field for the "edit form", 'hide'=Output field for the "add form" but we dont want it to be rendered
- *  @param		string	$context		'add'=Output field for the "add form", 'edit'=Output field for the "edit form", 'hide'=Output field for the "add form" but we dont want it to be rendered
- *  @param	DoliDB		$db  			objet base de donnee
- *  @param	Translate	$outputlangs	objet lang a utiliser pour traduction
- *  @param	array	$authentication     Array with authentication informations ('login'=>,'password'=>,'entity'=>,'dolibarrkey'=>)
- *  @param	array|null	$logcontext				If defined, an array with extra informations (can be used by some log handlers)
- *  @param	int					$mode			Mode (0=default, 1=return without dieing)
- *  @param	int		$cleanalsojavascript	Remove also occurence of 'javascript:'.
- *  @param	int		$disabledoutputofmessages	Clear all messages stored into session without diplaying them
- *  @param	int		$ts			Timesamp (If is_gmt is true, timestamp is already includes timezone and daylight saving offset, if is_gmt is false, timestamp is a GMT timestamp and we must compensate with server PHP TZ)
- *  @param	string		$clean		Clean if it is not an ISO. Warning, if file is utf8, you will get a bad formated file.
- *  @param	string		$modele			force le modele a utiliser ('' par defaut)
- *  @param	string	$fieldref   	Nom du champ objet ref (object->ref) a utiliser pour select next et previous
- *  @param      int			$natsort			1=use "natural" sort (natsort) for a search criteria thats is strings or unknown, 0=use "standard" sort (asort) for numbers
- *  @param      string  $context        'add'=Output field for the "add form", 'edit'=Output field for the "edit form", 'hide'=Output field for the "add form" but we dont want it to be rendered
- *  @param  array	$menu_array_before 	       	Table of menu entries to show before entries of menu handler. This param is deprectaed and must be provided to ''.
- *  @param  int     $donoresetalreadyloaded     Do not reset global array $donoresetalreadyloaded used to avoid to go down on an aleady processed record
- *  @return	string					String with formated amounts ('19,6' or '19,6%' or '8.5% (NPR)' or '8.5% *' or '19,6 (CODEX)')
- *  @return array|int               Array with details of VATs (per rate), -1 if no accountancy module, -2 if not yet developped, -3 if error
- *  @return array|int               Array with details of VATs (per third parties), -1 if no accountancy module, -2 if not yet developped, -3 if error
- *  Classe mere des modeles de numerotation des references de bon de livraison
- *  Classe mere des modeles de numerotation des references de members
- *  Classe mere des modeles de numerotation des references de projets
- *  Classe mere des modeles de numerotation des tickets de caisse
- *  Classe permettant la gestion des stats des expensereports et notes de frais
- *  Delete files into database index using search criterias.
- *  Get formated error messages to output (Used to show messages on html output).
- *  If constant MAIN_SECURITY_HASH_ALGO is defined, we use this function as hashing function (recommanded value is 'password_hash')
- *  If constant MAIN_SECURITY_SALT is defined, we use it as a salt (used only if hashing algorightm is something else than 'password_hash').
- *  Note that PHP_OS returns only OS (not version) and OS PHP was built on, not necessarly OS PHP runs on.
- *  Print formated error messages to output (Used to show messages on html output).
- *  Return a login if login/pass was successfull
- *  Return array head with list of tabs to view object informations
- *  Return array head with list of tabs to view object informations.
- *  Return array head with list of tabs to view object stats informations
- *  Show bank informations for PDF generation
- *  This is called when MAIN_DIRECT_STATUS_UPDATE is set and it use tha ajax service objectonoff.php
- *  WARNING: This function use PHP server timezone by default to return locale informations.
- *  \brief      Classe du modele de numerotation de reference de bon de livraison Jade
- *  \brief      Classe mere des modeles de numerotation des references de bon de livraison
- *  \brief      Classe mere des modeles de numerotation des tickets de caisse
- *  \brief      Ensemble de fonctions de base pour le module commande
- *  \brief      Ensemble de fonctions de base pour le module import
- *  \brief      Fichier contenant la classe mere de generation des propales en PDF
- *  \brief      Fichier de la classe de gestion des entrepots
- *  \brief      Fichier de la classe de gestion des expeditions
- *  \brief      Fichier de la classe de gestion des receptions
- *  \brief      Fichier de la classe de gestion du menu gauche
- *  \brief      Fichier de la classe des factures recurentes
- *  \brief      Fichier de la classe permettant d'editer au format PDF des etiquettes au format Avery ou personnalise
- *  \brief      File of class fo tmanage reception statistics
- *  \brief      File of class fo tmanage shipment statistics
- *  \brief      Page to show Dolibarr informations
- *  create an array of lines [ skillLabel,dscription, maxrank on group1 , minrank needed for this skill ]
- *  no need to call it explicitely.
- * $m->evalute($expr)
- * @param		array		$replaceambiguouschars	Discard ambigous characters. For example array('I').
- * @param	array		$arrayofmesures	Array of mesures already filled
- * @param	mixed	$position		key of postion to insert to
- * @param	string		$phpfullcodestring			PHP new string. For exemple "<?php echo 'a' ?><php echo 'c' ?>"
- * @param	string		$phpfullcodestringold		PHP old string. For exemple "<?php echo 'a' ?><php echo 'b' ?>"
- * @param	string	$modulepart			Module of document ('module', 'module_user_temp', 'module_user' or 'module_temp'). Exemple: 'medias', 'invoice', 'logs', 'tax-vat', ...
- * @param	string	intput		Array of complementary actions to do if success
- * @param	string    $param			    Parameters of URL (x=value1&y=value2) or may be a formated content with $postorget='PUTALREADYFORMATED'
- * @param	{string}	intput		Array of complementary actions to do if success
- * @param 	float	$paht				Buying price without tax
- * @param 	int		$fk_pa				Id of buying price (prefer set this to 0 and provide $paht instead. With id, buying price may have change)
- * @param 	string		$urltograb		URL to grab (exemple: http://www.nltechno.com/ or http://www.nltechno.com/dir1/ or http://www.nltechno.com/dir1/mapage1)
- * @param 	string	$filterd		Filter of done by user
- * @param 	string 	$head			 Optionnal head lines
- * @param 	string    $htmlcontent		HTML Contect
- * @param   array       $arrayfields            Array with displayed coloumn information
- * @param   array   $params     various params for future : recommended rather than adding more fuction arguments. array('attr'=>array('title'=>'abc'))
- * @param   bool|string $label              true = auto, false = dont display, string = replace output
- * @param   bool|string $progressNumber     true = auto, false = dont display, string = replace output
- * @param   int				$mode				0=True url, 1=Url formated with colors
- * @param   int			$mode		      0=True url, 1=Url formated with colors
- * @param   int		$mode		      0=True url, 1=Url formated with colors
- * @param   string		$where			To add a filter on selection (for exemple to filter on invoice types)
- * @param   string    $replaceimagepath     Replace path to image with another path. Exemple: ('doc/'=>'xxx/aaa/')
- * @param   string  $extName        Extension to differenciate thumb file name ('', '_small', '_mini')
- * @param   string $resourceType    ressource type
- * @param boolean	$extraRightColumn		(optional)	Add a addtional column after the summary word and total number
- * @param int         $action          0 for delete, 1 for add, 2 for update, -1 when delete object completly, -2 for generate rights after add
- * @param string	$noneWord				(optional)	The word that is shown when the table has no entires ($num === 0)
- * @param string   $objectname   name of object whant to remove
- * @retun   boolean
- * @return	array					returns an associtive array containing the response from the server.
- * @return	string							Formated string
- * @return	string				A HTML table that conatins a list with open (unpaid) supplier invoices
- * @return	string			Formated value
- * @return 	array						Array of mesures
- * @return 	string		Formated size
- * @return  array								Array with time spent for $fuser for each day of week on tasks in $lines and substasks
- * @return  string          Formated value
- * @return string		Array of id of orders wit all dispathing already done or not required
- * @return string      Formated size
- * Abort invoice creationg with a given error message
- * Check whether given extension is in html etensions list
- * Classe permettant la gestion des stats des deplacements et notes de frais
- * Classe to manage lines of shipment
- * Code to ouput content when action is presend
- * Copyright (C) 2004		Sebastien Di Cintio			<sdicintio@ressource-toi.org>
- * Copyright (C) 2005-2019	Laurent Destailleur		<eldy@uers.sourceforge.net>
- * Copyright (C) 2005-2021 Laurent Destailleur  <eldy@uers.sourceforge.net>
- * Copyright (C) 2005-2023 Laurent Destailleur  <eldy@uers.sourceforge.net>
- * Copyright (C) 2016 Laurent Destailleur  <eldy@uers.sourceforge.net>
- * Correspondance des expeditions et des commandes clients dans la table llx_co_exp
- * Correspondance des livraisons et des commandes clients dans la table llx_co_liv
- * Creation objet $langs (must be before all other code)
- * For action=add, use:     $var = GETPOST('var');		// No GETPOSTISSET, so GETPOST always called and default value is retreived if not a form POST, and value of form is retreived if it is a form POST.
- * Generate Urls and add them to documentaion module
- * It is usefull to search for a particular key and displaying arrays.
- * Lattest modified orders
- * Les catégories filles, sous tableau dez la catégorie
- * List of salaries payed
- * List of social contributions payed
- * Migrate event assignement to owner
- * Note: For ip 169.254.0.0, it returns 0 with some PHP (5.6.24) and 2 with some minor patchs of PHP (5.6.25). See https://github.com/php/php-src/pull/1954.
- * Ouput html header of a page. It calls also top_httphead()
- * Ouput javacript to autoset a generated password using default module into a HTML element.
- * Output a task line into a perday intput mode
- * Output a task line into a pertime intput mode
- * Parametre
- * Return a string of random bytes (hexa string) with length = $length fro cryptographic purposes.
- * Return array head with list of tabs to view object informations.
- * Return if we are using a HTTPS connexion
- * Return string with formated size
- * Start a table with headers and a optinal clickable number (don't forget to use "finishSimpleTable()" after the last table row)
- * Test de la connexion
- * This will call doldir_list_indatabase to complate filearray.
- * To use other version than embeded libraries, define here constant to path. Use '' to use include class path autodetect.
- * Used to ouput the page on the Preview from backoffice.
- * Used to ouput the page when viewed from a server (Dolibarr or Apache).
- * We supose dir separator for input is '/'.
- * \brief      Ensemble de fonctions de base pour le module LDAP
- * \brief      Ensemble de fonctions de base pour le module banque
- * \brief      Ensemble de fonctions de base pour le module contrat
- * \brief      Ensemble de fonctions de base pour le module ecm
- * \brief      Ensemble de fonctions de base pour le module produit et service
- * \brief      Ensemble de fonctions de base pour le module propal
- * \brief      Fichier contenant la classe du modele de numerotation de reference de note de frais Sand
- * \brief      Module pour inclure des fonctions de comptabilite (gestion de comptes comptables et rapports)
- * \brief   Fichier de la classe des fonctions predefinies de composant html advtargetemailing
- * \brief   Page to show the result of updating it Data policiy preferences after an email campaign using sendMailDataPolicyContact()
- * \brief Migrate news from a Joomla databse into a Dolibarr website
- * \brief Script de mise a jour des groupes dans LDAP depuis base Dolibarr
- * only be guaranted by escaping data during output.
- * that lack the multibye string extension.
- Badge style is based on boostrap framework
- The ckeditor is tripple licensed under the GNU General Public License (GPL),
- progress style is based on boostrap and admin lte framework
-# Detecte repertoire du script
-# Enable comented out UTF8 charset/collation options
-# Examle of rule you can add to fail2ban to restrict bruteforce attacks.
-# If phpcs check fail and AUTOFIX is set to 1, then it run phpcbf to fix automaticaly the syntax, and git commit is canceled.
-# NOTE: Using this script is depcrecated, you can now convert generated ODT to PDF on the fly by setting the value MAIN_ODT_AS_PDF
-# Script to extrac a database with demo values.
-# The output patch file can then be submited on Dolibarr dev mailing-list,
-# a logarithmic scale so increasing the size by one will rougly double the
-# causing a significant performance penality.
-# dpkg -I package.deb                    Give informations on package
-#export DH_COMPAT=7    # This is the debhelper compatability version to use, now defined into compat file
-$FULLTAG = GETPOST("fulltag", 'alpha'); // fulltag is tag with more informations
-$array = array(1=>'Value 1', 2=>'Value 2', 3=>'Value 3 ith a very long text. aze eazeae e ae aeae a e a ea ea ea e a e aea e ae aeaeaeaze.');
-$conf = new stdClass(); // instantiate $conf explicitely
-$html .= ' monthes people</b><br>';
-$permissiontoadd = $user->rights->stock->mouvement->creer;
-$permissiontodelete = $user->rights->stock->mouvement->creer; // There is no deletion permission for stock movement as we shoul dnever delete
-$permissiontodelete = $user->rights->stock->mouvement->creer; // There is no deletion permission for stock movement as we should never delete
-$permissiontoread = $user->rights->stock->mouvement->lire;
-$seledted = !getDolGlobalString('BLOCKEDLOG_DISABLE_NOT_ALLOWED_FOR_COUNTRY') ? array() : explode(',', getDolGlobalString('BLOCKEDLOG_DISABLE_NOT_ALLOWED_FOR_COUNTRY'));
-$seledted = empty($conf->global->BLOCKEDLOG_DISABLE_NOT_ALLOWED_FOR_COUNTRY) ? array() : explode(',', $conf->global->BLOCKEDLOG_DISABLE_NOT_ALLOWED_FOR_COUNTRY);
+ *	@param	array 		$TWeek			array of week numbers
+ * @param	array		$TWeek					Array of week numbers
+ * Copyright (C) 2019		Tim Otte    			<otte@meuser.it>
+ * Copyright (C) 2019       Tim Otte		    <otte@meuser.it>
+ * Copyright (C) 2019      Tim Otte			    <otte@meuser.it>
+ * Copyright (C) 2020      Thibault FOUCART     <suport@ptibogxiv.net>
+ * Copyright (C) 2020-2021  Udo Tamm            <dev@dolibit.de>
+ * Copyright (C) 2021		Noé Cendrier			<noe.cendrier@altairis.fr>
+ * Copyright (C) 2021       Noé Cendrier			<noe.cendrier@altairis.fr>
+ * Copyright (C) 2021       Noé Cendrier         <noe.cendrier@altairis.fr>
+ * Copyright (C) 2021      Noé Cendrier         <noe.cendrier@altairis.fr>
+ * Copyright (C) 2022       Udo Tamm				<dev@dolibit.de>
+ * Copyright (C) 2022       Udo Tamm                <dev@dolibit.de>
+ * Copyright (C) 2022-2023  Udo Tamm            <dev@dolibit.de>
+ * Copyright (C) 2023		Udo Tamm			<dev@dolibit.de>
+ * add german links 2020    Udo Tamm            <dev@dolibit.de>
+$TFirstDays = getFirstDayOfEachWeek($TWeek, $year);
+$TFirstDays[reset($TWeek)] = '01'; //first day of month
+$TLastDays = getLastDayOfEachWeek($TWeek, $year);
+$TLastDays[end($TWeek)] = date("t", strtotime($year.'-'.$month.'-'.$day)); //last day of month
+$TWeek = getWeekNumbersOfMonth($month, $year);
+$datee = dol_mktime(23, 59, 59, GETPOST('dateemonth'), GETPOST('dateeday'), GETPOST('dateeyear'));
+$moresql = dolSqlDateFilter('t.datee', $search_dtendday, $search_dtendmonth, $search_dtendyear, 1);
+$parameters = array('id' => $id, 'taskid' => $taskid, 'projectid' => $projectid, 'TWeek' => $TWeek, 'TFirstDays' => $TFirstDays, 'TLastDays' => $TLastDays);
+$permissiontoadd = $user->hasRight('stock', 'mouvement', 'creer');
+$permissiontodelete = $user->hasRight('stock', 'mouvement', 'creer'); // There is no deletion permission for stock movement as we should never delete
+$permissiontoread = $user->hasRight('stock', 'mouvement', 'lire');
+$sql .= " GROUP BY cs.rowid, cs.fk_type, cs.fk_user, cs.amount, cs.date_ech, cs.libelle, cs.paye, cs.periode, cs.fk_account, c.libelle, c.accountancy_code, ba.label, ba.ref, ba.number, ba.account_number, ba.iban_prefix, ba.bic, ba.currency_code, ba.clos, pay.code";
+$sql .= " cs.amount, cs.date_ech, cs.libelle as label, cs.paye, cs.periode, cs.fk_account,";
+$sql .= " cs.rowid, cs.libelle as label_sc, cs.fk_type as type, cs.periode, cs.date_ech, cs.amount as total, cs.paye,";
+$sql .= " p.datec as date_creation, p.dateo as date_start, p.datee as date_end, p.opp_amount, p.opp_percent, (p.opp_amount*p.opp_percent/100) as opp_weighted_amount, p.tms as date_update, p.budget_amount,";
+$sql .= " t.datec as date_creation, t.dateo as date_start, t.datee as date_end, t.tms as date_update,";
+$sql .= dolSqlDateFilter('p.datee', $search_eday, $search_emonth, $search_eyear);
+$sql = "SELECT ".$distinct." p.rowid as projectid, p.ref as projectref, p.title as projecttitle, p.fk_statut as projectstatus, p.datee as projectdatee, p.fk_opp_status, p.public, p.fk_user_creat as projectusercreate, p.usage_bill_time,";
 $sql = "SELECT id_users, nom as name, id_sondage, reponses";
+$sql = "SELECT p.rowid, p.ref, p.title, p.dateo as date_start, p.datee as date_end, p.fk_statut as status, p.tms as datem";
+$sql = "SELECT s.rowid, s.nom as name, s.client, s.town, s.datec, s.datea";
 $sql = 'SELECT nom as name, reponses';
-$tag = GETPOST('tag');	// To retreive the emailing, and recipient
-$tmpday = -date("w", dol_mktime(12, 0, 0, $month, 1, $year, 'gmt')) + 2; // date('w') is 0 fo sunday
-$usercancreate = $user->rights->stock->mouvement->creer;
-$usercancreate = (($user->rights->stock->mouvement->creer));
-$usercandelete = $user->rights->stock->mouvement->creer;
-$usercandelete = (($user->rights->stock->mouvement->supprimer));
-$usercanread = $user->rights->stock->mouvement->lire;
-$usercanread = (($user->rights->stock->mouvement->lire));
-*  Return array head with list of tabs to view object informations.
-*  TODO: use color definition vars above for define badges color status X -> exemple $badgeStatusValidate, $badgeStatusClosed, $badgeStatusActive ....
-* ALL EXTERNAL MODULES THAT WERE NOT CORRECTLY DEVELOPPED WILL NOT WORK ON V15 (All modules that forgot to manage the security token field
-* All functions fetch_all() have been set to deprecated for naming consitency, use fetchAll() instead.
-* Core has introduced a Universal Filter Syntax for seach criteria. Example: ((((field1:=:value1) OR (field2:in:1,2,3)) AND ...). In rare case, some filters
-* ONLY security reports on modules provided by default and with the "stable" status are valid (troubles into "experimental", "developement" or external modules are not valid vulnerabilities).
-* Optionnaly, made freemono the default monotype font if we removed courier
-* Optionnaly, removed all fonts except
-* Removed the method 4 of GETPOST (to get $_COOKIE). It was not used and not recommanded to use in Dolibarr.
-* Sensitive datas like keys in setup pages, that need encyption (for example the API keys of users, the CRON security key, the keys into the Stripe module, or
-* Sensitive datas like keys in setup pages, that need encyption (for example the API keys of users, the CRON security key, the keys into the Stripe module, or 
-* The deprecated subsitution key __SIGNATURE__ has been removed. Replace it with __USER_SIGNATURE__ if you used the old syntax in your email templates.
-* The substition key __SIGNATURE__ was renamed into __USER_SIGNATURE__ to follow naming conventions.
-* You can test patching of serie with "quilt push" (autant de fois que de patch). Avec "quilt pop -a", on revient a l'état du upstream sans les patch.
-* v14 seems to work correctly on PHP v8 but it generates a lot of verbose warnings. Currently, v14 i snot yet officialy supported with PHP 8.
-- A module can add subsitution keys in makesubsitutions() functions.
-- A new paramater sqlfilters was introduced to allow filter on any fields int the REST API. Few old parameters,
-- Change in tanslation to make Dolibarr easier to understand.
-- Check all files are commited.
-- Delivery/Receiption
-- Fields of classes were renamed to be normalized (nom, prenom, cp, ville, adresse, tel
-- Fix: Stock value is not reset when product is transfered into other warehouse.
-- Fix: [bug #270] PostgreSQL backend try to connect throught TCP socket for
-- Fix: withdrawal create error if in the same month are deleted previus withdrawals.
-- For Dev, you can also add link serie to GIT HEAD.
-- More informations reported in system information pages.
-- New : Genrate auto the PDF for supplier invoice.
-- New/NEW: for an unreferenced new feature (Opening a feature request and using close is prefered)
-- New: Add ES formated address country rule.
-- New: Add Gant diagramm on project module.
-- New: Add field oustanding limit into thirdparty properties.
-- New: Add management of triger FICHEINTER_VALIDATE
-- New: Add more "hooks" (like hooks to change way of showing/editing lines into dictionnaries).
-- New: Default approver for holidays is set by default to hierchical parent.
-- New: Dictionary setup works with very large external dictionnaries (Add
-- New: Form to add a photo is immediatly available on photo page if
-- New: POS module can works with only one payment method (cach, chq, credit card).
-- New: When creating a contact from a third party, informations from third
-- New: [ task #1204 ] add Numering contrat module free (like leopard in product module).
-- New: [ task #826 ] Optionnal increase stock when deleting an invoice already validated.
-- Properties "dictionnaries" into module descriptor files have been renamed into "dictionaries".
-- Save and show last connexion date for users.
-- Support multi-langual description for products.
-- To build developper documentation, launch the script
-- Uncompress the downloaded .zip archive to copy the "dolibarr/htdocs" directory and all its files inside your web server root or get the files directly from GitHub (recommanded if you know git as it makes it easier if you want to upgrade later):
-/* <style type="text/css" > dont remove this line it's an ide hack */
-/* Advance Targeting Emailling for mass emailing module
-/* Affichage de la liste des projets d'hier */
-/* Affichage de la liste des projets de l'annee */
-/* Affichage de la liste des projets du mois */
-/* Badge style is based on boostrap framework */
-/* Force values on one colum for small screen */
-/* The buttonplus isgrowing on hover (dont know why). This is to avoid to have the cellegrowing too */
-/* To make a div popup, we must use a position aboluste inside a position relative */
-/* USING IMAGES FOR WEATHER INTEAD OF FONT AWESOME */
-/* Warning: setting this may make screen not beeing refreshed after a combo selection */
-/* default color for status : After a quick check, somme status can have oposite function according to objects
-/** @var bool Hide PHP informations */
-/** @var boolean	$force_install_nophpinfo 		Hide PHP informations */
-//				  and printing in millimiter by setting unit to 'mm' in constructor.
-//		font-size	: defaut char size (can be changed by calling Set_Char_Size(xx);
-// "commitment engagment" method and "cash accounting" method
-// $db->close();	Not database connexion yet
-// A Better solution to be able to sort on already payed or remain to pay is to store amount_payed in a denormalized field.
-// Action desactivation d'un sous module du module adherent
-// Activate FileCache - Developement
-// Additionnal information for each payment system
-// Affichage alerte date prévue de départ si transfert concerné
-// Affichage attributs LDAP
-// Change default WIDHT and HEIGHT (we need a smaller than default for both desktop and smartphone)
-// Chargement des includes principaux de librairies communes
-// Check if there is no uncompatible choice
-// Creation de la classe d'export du model ExportXXX
-// Customer Default Langauge
-// DN pour les groupes
-// Date appoval
-// Defaut sortorder
-// Defini objet langs
-// Defini si peux lire/modifier permisssions
-// Defini si peux lire/modifier utilisateurs et permisssions
-// Filter on array of ids of all childs
-// For external user, no check is done on company because readability is managed by public status of project and assignement.
-// For external user, no check is done on company permission because readability is managed by public status of project and assignement.
-// From this pont to the end of the file, we only take care of sub-BOM lines
-// Get Paramters
-// Get account informations
-// Get informations of journal
-// If on smartphone or optmized for small screen
-// Initialize array of search criterias
-// Label of mouvement of id of inventory
-// Limite acces si droits non corrects
-// Loop on each year to ouput
-// Loop to complete the sql search criterias from extrafields
-// Merge all entrie after the $KEEPNFIRST one into one entry called "Other..." (to avoid to have too much entries in graphic).
-// No cahce on PHP
-// No check is done on company permission because readability is managed by public status of project and assignement.
-// Nomber of try
-// None. Beeing connected is enough.
-// Now database connexion is known, so we can forget password
-// Personal informations
-// Personalized search criterias. Example: $conf->global->PRODUCT_QUICKSEARCH_ON_FIELDS = 'p.ref=ProductRef;p.label=ProductLabel;p.description=Description;p.note=Note;'
-// Personalized search criterias. Example: $conf->global->THIRDPARTY_QUICKSEARCH_ON_FIELDS = 's.nom=ThirdPartyName;s.name_alias=AliasNameShort;s.code_client=CustomerCode'
-// Place customer adress to the ISO location
-// Repair llx_commande_fournisseur to eleminate duplicate reference
-// SQL Aliase adherent
-// SQL Aliase adherent_type
-// Sauvegardes parametres
-// Search Criterias
-// Securite acces client
-// Seems used onyl by Paypal
-// Select every potentiels, and note each potentiels which fit in search parameters
-// Set current line with last unpaid line (only if shedule is used)
-// Setup conf BOOKCAL_MYPARAM4 : exemple of quick define write style
-// Setup conf MYMODULE_MYPARAM4 : exemple of quick define write style
-// Spécifiez le type d'extension par laquelle vous poste est connecte.
-// Swicth in Bold
-// Synchro utilisateurs/groupes active
-// TODO Better solution to be able to sort on already payed or remain to pay is to store amount_payed in a denormalized field.
-// TODO ajouter regle pour restreindre acces paiement
-// Table to store complete informations (will replace all other table). Key is table name.
-// Test to check image can be publically viewed is done inside the viewimage.php wrapper.
-// The session_set_save_handler() at end of this fille will replace default session management.
-// This 2 lines are usefull only if we want to exclude some Urls from the explorer
-// This refresh list of dirs, not list of files (for preformance reason). List of files is refresh only if dir was not synchronized.
-// To disable a constant whithout javascript
-// To enable a constant whithout javascript
-// Visualiser description produit dans les formulaires activation/desactivation
-// We keep it with value ForceBuyingPriceIfNull = 2 for retroactive effect but results are unpredicable.
-// We must filter on assignement table
-// badge color ajustement for color blind
-// chek if salary pl
-// current rule: uptodate = the end date is in future or no subcription required
-// librarie core
-// librarie jobs
-// reverse mouvement of stock
-// status color ajustement for color blind
-//Activate Set adress in list
-//Another call for easy debugg
-//Chosse action to do
-//dol_syslog('We found some compression algoithm: '.$foundonealgorithm.' -> usecompression='.$usecompression, LOG_DEBUG);
-//if ($user->socid > 0) $socid = $user->socid;	  // For external user, no check is done on company because readability is managed by public status of project and assignement.
-//if ($user->socid > 0) $socid = $user->socid;    // For external user, no check is done on company because readability is managed by public status of project and assignement.
-//include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php';  // Can't use generic include because when creating a project, ref is defined and we dont want error if fetch fails from ref.
-4. Write a report with as much detail as possible (Use [screenshots](https://help.github.com/articles/issue-attachments) or even screencasts and provide logging and debugging informations whenever possible).
-6) Trigger LINEPROPAL_MODIFY is renamed into LINEPROPAL_UPDATE and
-<!-- END PHP TEMPLATE BLOC SHOW/HIDE -->
-<br><hr><br>Example 0a : Table with div+div+div containg a select that should be overflowed and truncated => Use this to align text or form<br>
-<br><hr><br>Example 0b: Table with div+form+div containg a select that should be overflowed and truncated => Use this to align text or form<br>
-<br><hr><br>Example 0c: Table with table+tr+td containg a select that should be overflowed and truncated => Use this to align text or form<br>
-> To build manually the .exe from Windows (running from makepack-dolibarr.pl script is however recommanded),
-> To build manually the .exe from Windows (running from makepack-dolibarr.pl script is however recommanded), 
-> schroot -c name_of_chroot  (exemple schroot -c unstable-amd64-sbuild)
-Confirm Delete Dictionnary
-DELAY = 0					# Delay beetween each HTTP request (-1 wait a key, 0 no delay, n number of seconds)
-Decription of htdocs/core/login directory
-Example fo recurring event, 1 week, no end, exported by Google
-Example fo recurring event, every 2 month, no end, exported by Google
-FIX: #3836 Unable to upload a document to an invoice under some circunstances
-FIX: #3996 Dictionnary hooks are not working in 3.8
-FIX: #4043 Incorrect translation in error mesage in menu creation admin page
-FIX: #4737 Bank transacion type selector translation is cropped
-FIX: #5629 PgSQL Interger string stylish error
-FIX: Accountancy - Format Quadra export - Missing line type C to create automaticly a subledger account with label
-FIX: Accountancy - SQL error when insert a manuel transaction
-FIX: Accountancy - Some ajustments on length of the account (general & auxiliary)
-FIX: Add a test to save life when ref of object (invoice ref, order ref, ...) was empty. The was no way to go back to a clean situation, even after vaidating again the object.
-FIX: Assignement of actors on tasks
-FIX: Attachement of linked files on ticket when sending a message
-FIX: Bad ressource list in popup in gantt view
-FIX: Bad rigths to send contract
-FIX: Can create Proposal on close thridparty #3526
-FIX: Can make a stock transfert on product not on sale/purchase.
-FIX: Can use formated float number on old expense report module.
-FIX: Can't modify vendor invoice if transfered into accountancy
-FIX: Category for suplements not saved
-FIX: Change date format of the inventorycode to be equal as mass stock transfert
-FIX: Correct problem of rights beetween tax and salaries module
-FIX: Creation of the second ressource type fails.
-FIX: Default vat is not set correctly when an error occured and we use VAT identified by a code.
-FIX: Fix detect dispached product and set to received completely when the supplier order have services (support STOCK_SUPPORTS_SERVICES)
-FIX: Force downlaod of file with .noexe as octet-stream mime type
-FIX: If option to hide automatic ECM is on, dont show menu.
-FIX: If we can change vendor status, we must be able to chane vendor code
-FIX: Implementation of a Luracast recommandation for the REST api server
-FIX: Implementation of a Luracast recommandation for the REST api server (#7370)
-FIX: Merge of thirdparties : "unknow column fk_soc" + "Delivery" label
-FIX: Missing contracts into list in page of Refering objects of a thirdparty.
-FIX: PGSQL Int type does not have a free lenght
-FIX: PGSQL Integer type does not have a free lenght
-FIX: Payed invoices are showed as canceled FIX: Bad date filter on customer order
-FIX: PgSQL Module Ressource list crash #5637
-FIX: Projet is not prefilled when created from overwiew page
-FIX: Properties updated if update successfull.
-FIX: Protection against bad value into accurancy setup
-FIX: Remane of project
-FIX: Remove  column creation for table llx_product_fournisseur_price, the column use un calss is fk_supplier_price_expression, and fk_price_expression does not exist into lx_product_fournisseur_price sql file declaration
-FIX: Rich text is not diplayed
-FIX: Search ambigous field on MO list
-FIX: Support or multicompany for sheduled jobs
-FIX: Take into consideration work leave over serveral months
-FIX: The admin flag is mising.
-FIX: The max size for upload file was not corectly shown
-FIX: The new feature to attach document on lines was not correclty
-FIX: Use priority to define order of sheduled jobs
-FIX: VAT rate can be negative. Example spain selling to morroco.
-FIX: Vat not visible in dictionnary
-FIX: Warning on attribut
-FIX: When clearing filter, we must not save tmp criterias in session
-FIX: When we make a direct assignement on a task to a user, we must check he is also assigned to project (and if not assign it)
-FIX: action not appear before an update because of a lack of line in action ressource
-FIX: add a test for updating date on task update in tab time consummed pro…
-FIX: alignement of intervention status
-FIX: amount opened on thirdparty card dont care of credit note not converted
-FIX: assign member cateogry to a member
-FIX: attached files list with link file was broked
-FIX: base64_decode should be forbiden in dol_eval
-FIX: cant empty action comm desc
-FIX: class not found when creating recuring invoice from invoice+discount
-FIX: compatibility if javascript not actived
-FIX: contact country had wrong display if the country dont have translate
-FIX: contact/adress tab: when changing company ajax combo, the first contact change is not taken into account
-FIX: dasboard wrong for late invoice
-FIX: deletion on draft is allowed if we are allwoed to create
-FIX: doc of dictionnary API
-FIX: don't see the sales representative of anothers entities
-FIX: dont get empty "Incoterms : - " string if no incoterm
-FIX: dont lose supplier ref if no supplier price in database
-FIX: dont print empty date in CommonObject::showOutputField
-FIX: dont retrieve new buying price on margin display
-FIX: etrafield with visibilty=5 were not in read only.
-FIX: expedition ceate line new parameter is not required.
-FIX: export extrafields must not include separe type
-FIX: extrafields of taks not visible in creation
-FIX: fk_expedition in $line can be usefull for triggers
-FIX: formating of prices with foreign languages
-FIX: fourn payment modes musn't be available on customer docs
-FIX: if we dont use SUPPLIER_ORDER_USE_HOUR_FOR_DELIVERY_DATE the hour is displayed on pdf
-FIX: input hidden with fk_product of line on mo production can be usefull
-FIX: inventory code must be different at each transation
-FIX: invoice: inpossible to create an invoice because of very bad check + warnings when trying to print tabs for invoice with no ID
-FIX: limit+1 dosn't show Total line
-FIX: link for projets not linked to a thirdparties
-FIX: load multicurrency informations on supplier order and bill lines fetch
-FIX: load tranlate array after setting lang
-FIX: mandatory date for service didnt work for invoice
-FIX: menu enty when url is external link
-FIX: missing column into SQL on thridparty list
-FIX: multicurrency: fields in discount unitialized when creating deposit
-FIX: nblignes not calculated after hook and hook can't modify this value. Usefull for modules
-FIX: product stats all bloc module without enbaled test
-FIX: propal and order stats broken on Tag+User(retricted customer list)
-FIX: ressource list with extrafields
-FIX: restore last seach criteria
-FIX: search on date into supplier invoice list dont work because of status -1
-FIX: supplier invoice payment total dont care about deposit or credit
-FIX: tag object_total_vat_x need x to be a string with unknown decimal lenght. Now use for x the real vat real with no more decimal (x = 20 or x = 8.5 or x = 5.99, ...)
-FIX: the time spent on project was not visible in its overwiew
-FIX: typo on ckeck method
-FIX: use event.key instead event.wich to avoid keyboard difference
-FIX: when fetch_optionnal_by_label in Extrafields with $this->db cannot work because this->db is never instanciated
-FIX: wrong occurence number of contract on contact card, we must only count externals
-FIX: wrong path sociales/index.php doesnt exist anymore
-FIX: wrong personnal project time spent
-Fix: Compatiblity with multicompany module.
-Fix: Supplier price displayed on document lines and margin infos didnt take discount.
-Fix: [ bug #1522 ] Element list into associate object into project are no more filterd by project thirdparty
-Fix: update extrafield do not display immediatly after update.
-Fo example: Dolibarr
-For more informations, see the [translator's documentation](https://wiki.dolibarr.org/index.php/Translator_documentation).
-For more licenses compatibility informations: https://www.gnu.org/licenses/licenses.en.html
-Long description (Can span accross multiple lines).
-Mysql version 5.5.40 has a very critical bug making your data beeing definitely lost.
-NEW: #17123 added ExtraFields for Stock Mouvement
-NEW: #18401 Add __NEWREF__ subtitute to get new object reference.
-NEW: A new function getImageFileNameForSize was also introduced to choose image best size according to usage to save bandwith.
-NEW: Accounting - Add default accounting account for member subcriptions.
-NEW: Add "depends on" and "required by" into module informations
-NEW: Add SQL contraint on product_stock table to allow only exsting product and warehouse #23543
-NEW: Add email in event history, for reminder email of expired subsription
-NEW: Add exemple of setup for multitail to render dolibarr log files
-NEW: Add hidden option MAIN_EMAIL_SUPPORT_ACK to restore Email ack checkbox (feature abandonned by mailers)
-NEW: Add more company informations (ProfId7 to 10) (#25266)
-NEW: Add option to disable globaly some notifications emails.
-NEW: Add option to display thirdparty adress in combolist
-NEW: Add ressource extrafields.
-NEW: Add somes hooks in bank planned entries
-NEW: Add statistics on number of projets on home page
-NEW: Add subtitution variables for url of document in backoffice
-NEW: Add tooltip in payment term edition in dictionnary.
-NEW: Add workflow to classifed propal bill on invoice validation.
-NEW: All language tranlsations (except source en_US) is now managed on https://www.transifex.com/projects/p/dolibarr/.
-NEW: Architecture to manage search criteria persistance (using save_lastsearch_values=1 on exit links and restore_lastsearch_values=1 in entry links)
-NEW: Authentication: add experimental support for Google OAuth2 connexion
-NEW: Better reponsive design
-NEW: Can edit account on miscellaneous payment (if not transfered)
-NEW: Can edit list of prospect status for customers/prospects. Add a new entry into dictionary table to manage list fo status.
-NEW: Can edit list of prospect status for customers/prospects. Add a new entry into dictionary table to manage list fo status. Removed deprecated files.
-NEW: Can filter on code in dictionnaries
-NEW: Can select dynamicaly number of lines to show on page on product, shipment, contact, orders, thirdparties.
-NEW: Can select lot from a combo list of existing batch numbers (in MRP consumtion)
-NEW: Can use a "|" to make a OR search on several different criterias into search text filters of tables.
-NEW: Can use a "|" to make a OR search on several different criterias into text filters of tables.
-NEW: Column of p...arent company is available in list of third parties
-NEW: Database: Can store the session into database (instead of beeing managed by PHP)
-NEW: Default value for MAIN_SECURITY_CSRF_WITH_TOKEN is now 2 (GET are also protected agains CSRF attacks)
-NEW: Dictionaries - Availibility dictionnary has a new column unit and number
-NEW: Each user can set its prefered default calendar page
-NEW: FEATURE PROPOSAL: on proposal, order or invoice creation from scratch, reload page after customer selection so its informations can be loaded
-NEW: Hidden option THEME_ELDY_USE_HOVER is stable enough to become officialy visible into setup.
-NEW: Implement option SUPPLIER_ORDER_USE_DISPATCH_STATUS to add a status into each dispathing line of supplier order to "verify" a reception is ok. Status of order can be set to "total/done" only if line is verified.
-NEW: Introduce position of records into dictionnary of type of contacts
-NEW: Introduce use of cache for thumbs images of users to save bandwith.
-NEW: Look and feel v11: Some setup pages are by default direclty in edit mode.
-NEW: Menu editor is reponsive
-NEW: Merge all boxes "related objects" into one. This save a lot of room on most card and avoid often horizontal scoll.
-NEW: ModuleBuilder - More feature that can be modifed after module generation
-NEW: ModuleBuilder: for edit name of dictionnary and delete it in MB
-NEW: On page to see/edit contact of an ojbect, the status of contact is visible (for both external and internal users).
-NEW: Page to check if the operations/items created between two dates have attached item(s) and possibility to download all attachements
-NEW: Payment: Can edit account on miscellaneous payment (if not transfered)
-NEW: Product stock and subproduct stock are independant
-NEW: Products: Add SQL contraint on product_stock table to allow only existing product and warehouse #23543
-NEW: Remove tooltip tipTip library replaced with standatd jquery tooltip
-NEW: Start to introduce search filters on dictionnaries for vat list.
-NEW: Support of deployement of metapackages
-NEW: When a new field to show into lists is selected, the form is automatically submited and field added.
-NEW: When an user unset the batch management of products, transformation of each batch stock mouvement in global stock mouvement
-NEW: X-Axis on graph are shown verticaly when there is a lot of values.
-NEW: add API shipment mode dictionnary
-NEW: add a prospect status for the contact with managment of custom icon
-NEW: add constant  MAIN_COMPANY_PERENTITY_SHARED                    to manage some informations (Accounting account) when company is shared on several entities
-NEW: add constant  MAIN_PRODUCT_PERENTITY_SHARED                    to manage some informations (Accounting account) when product is shared on several entities
-NEW: add convertion of images to webp for a single image in website media editor
-NEW: add price in burger menu on mouvement list
-NEW: add show preview for mail attachement on form mail
-NEW: batch referential objets
-NEW: can substitue project title in mail template
-NEW: comment in api_mymodule for seperate methods
-NEW: conditionnal add member button by statut
-NEW: contacts type dictionnary in api_setup.class.php
-NEW: get state dictionnary by REST API
-NEW: get user connected informations in REST API
-NEW: hook getnomurltooltip is replaced with hook getNomUrl more powerfull
-NEW: only get openned contact from liste_contact function, to not have acces to closed contact as mail receiver
-NEW: option to copy into attachement files of events, files send by mail (with auto event creation)
-NEW: possibilty to group payments by mode and show their subtotal
-NEW: show place from events on import calender
-NEW: show user on external calender events (when found)
-NEW: template invoices support substition key
-NEW: when we delete several objects with massaction, if somes object has child we must see which objects are concerned and nevertheless delete objects which can be deleted
-Note: You can use git-buildpackage -us -uc --git-ignore-new  if you want to test build with uncommited file
-Store, search and retreive any article to keep your knowledge into a database. It can be used to manage a list of FAQ, or a database
-The keyword can be ommitted if your commit does not fit in any of the following categories:
-The output patch file can then be submited on Dolibarr
-The output patch file can then be submited on Dolibarr dev mailing-list, with explanation on its goal, for inclusion in main branch.
-This directory contains ruleset files to use to develop Dolibarr EPR & CRM.
-This directory contains several subdirectories with entries for informations on Dolibarr.<br>
-This docker image intended for developpement usage.
-This docker image is intended for developpement usage.
-This module provides a sheduled job that scan regularly one or several IMAP email boxes, with filtering rules, to automatically record data in your application, like
-Une ligne represente un element : data[$x]
-Upgrading to any other version or database system is abolutely required BEFORE trying to
-We recommand to install Dolibarr ERP CRM on your own server (as most Open Source software, download and use is free: [https://www.dolibarr.org/download](https://www.dolibarr.org/download)) to get access on every side of application.
-You must avoid tests that could cause degradation or interruption of our service (refrain from using automated tools, and limit yourself about requests per second), that's why we recommand to install software on your own platform.
-class ModeleBoxes // Can't be abtract as it is instantiated to build "empty" boxes
-class ModeleExports extends CommonDocGenerator    // This class can't be abstract as there is instance propreties loaded by listOfAvailableExportFormat
-class ModeleExports extends CommonDocGenerator    // This class can't be abstract as there is instance propreties loaded by liste_modeles
-define('DOL_CLASS_PATH', 'class/'); // Filsystem path to class dir
-echo price($line->qty, 0, '', 0, 0); // Yes, it is a quantity, not a price, but we just want the formating role of function price
-elseif ($year && $month && $day) $daytoparsegmt = dol_mktime(0, 0, 0, $month, $day, $year, 'gmt'); // this are value submited after submit of action 'submitdateselect'
-function getMarginInfos($pvht, $remise_percent, $tva_tx, $localtax1_tx, $localtax2_tx, $fk_pa, $paht)
-function print_actions_filter($form, $canedit, $status, $year, $month, $day, $showbirthday, $filtera, $filtert, $filterd, $pid, $socid, $action, $showextcals = array(), $actioncode = '', $usergroupid = '', $excludetype = '', $resourceid = 0)
+$title = $langs->trans("Referers", $object->name);
+$usercancreate = $user->hasRight('stock', 'mouvement', 'creer');
+$usercancreate = (($user->hasRight('stock', 'mouvement', 'creer')));
+$usercandelete = $user->hasRight('stock', 'mouvement', 'creer');
+$usercandelete = (($user->hasRight('stock', 'mouvement', 'supprimer')));
+$usercanread = $user->hasRight('stock', 'mouvement', 'lire');
+$usercanread = (($user->hasRight('stock', 'mouvement', 'lire')));
+* The hook contaxt commcard has been renamed thirdpartycomm
+* The hook contaxt thirdpartycard has been renamed thirdpartycontact
+* The private array ->status_short, ->statuts and ->status_long are now array ->labelStatusShort and ->labelStatus everywhere.
+- New: Add proposals into referer page of thirdparty.
+foreach ($TWeek as $week_number) {
+function checkES($IentOfi, $InumCta)
+function getFirstDayOfEachWeek($TWeek, $year)
+function getLastDayOfEachWeek($TWeek, $year)
+function projectLinesPerMonth(&$inc, $firstdaytoshow, $fuser, $parent, $lines, &$level, &$projectsrole, &$tasksrole, $mine, $restricteditformytask, &$isavailable, $oldprojectforbreak = 0, $TWeek = array())
 if (!$user->hasRight('stock', 'mouvement', 'lire')) {
-if (!empty($conf->variants->eabled) && !getDolGlobalString('VARIANT_ALLOW_STOCK_MOVEMENT_ON_VARIANT_PARENT')) {	// Add test to exclude products that has variants
-if (!empty($conf->variants->eabled) && empty($conf->global->VARIANT_ALLOW_STOCK_MOVEMENT_ON_VARIANT_PARENT)) {	// Add test to exclude products that has variants
-if (!empty($contactname)) { // acces a partir du module de recherche
+if (!empty($arrayfields['cs.periode']['checked'])) {
+if (!empty($arrayfields['p.datee']['checked'])) {
+if (!empty($arrayfields['t.datee']['checked'])) {
 if ($action == "transfert") {
-if (preg_match('/^dopayment/', $action)) {			// If we choosed/click on the payment mode
-if you restore or duplicate the data from another instance dump, you must also update this parameter in ther conf.php file to allow decryption in the new instance, or
-if you restore or duplicate the data from another instance dump, you must also update this parameter in ther conf.php file to allow decryption in the new instance, or 
-print $form->multiselectarray('BLOCKEDLOG_DISABLE_NOT_ALLOWED_FOR_COUNTRY', $countryArray, $seledted);
-print $langs->trans("Size").': '.ini_get('xcache.size').' &nbsp; &nbsp; &nbsp; '.$langs->trans("Recommanded").': 16*Split<br>'."\n";
-print $langs->trans("Split").': '.ini_get('xcache.count').' &nbsp; &nbsp; &nbsp; '.$langs->trans("Recommanded").': (cat /proc/cpuinfo | grep -c processor) + 1<br>'."\n";
-print $langs->trans("xcache.optimizer").': '.yn(ini_get('xcache.optimizer')).' (will be usefull only with xcache v2)<br>'."\n";
-print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-print '<div class="div-table-responsive-no-min">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-print_barre_liste($langs->trans("Sessions"), $page, $_SERVER["PHP_SELF"], "", $sortfield, $sortorder, '', $num, ($num ? $num : ''), 'setup'); // Do not show numer (0) if no session found (it means we can't know)
-print_liste_field_titre("Prority", $_SERVER["PHP_SELF"], "t.priority", "", $param, '', $sortfield, $sortorder);
-session_start(); // To be able to keep info into session (used for not losing pass during navigation. pass must not transit through parmaeters)
-} // this are value submited after submit of action 'submitdateselect'
+if (empty($datee) && !empty($dateerfc)) {	// deprecated
+print $langs->trans("Developpers").':';
+print '<input type="hidden" id="numberOfFirstLine" name="numberOfFirstLine" value="'.(reset($TWeek)).'"/>'."\n";
+print '<td class="right">'.$langs->trans("NbOfMembers").' <span class="opacitymedium">('.$langs->trans("AllTime").')</span></td>';
+print_liste_field_titre("PeriodEndDate", $_SERVER["PHP_SELF"], "cs.periode", "", $param, '', $sortfield, $sortorder, 'center ');
+select#date_startday, select#date_startmonth, select#date_endday, select#date_endmonth, select#reday, select#remonth
+select#date_startday, select#date_startmonth, select#date_endday, select#date_endmonth, select#reday, select#remonth,

--- a/dev/tools/rector/src/Renaming/EmptyGlobalToFunction.php
+++ b/dev/tools/rector/src/Renaming/EmptyGlobalToFunction.php
@@ -178,7 +178,7 @@ class EmptyGlobalToFunction extends AbstractRector
 	 * Check if node is a global access with format conf->global->XXX
 	 *
 	 * @param Node 	$node 	A node
-	 * @return bool			Return true if noe is conf->global->XXX
+	 * @return bool			Return true if node is conf->global->XXX
 	 */
 	private function isGlobalVar($node)
 	{

--- a/dev/tools/rector/src/Renaming/EmptyUserRightsToFunction.php
+++ b/dev/tools/rector/src/Renaming/EmptyUserRightsToFunction.php
@@ -204,7 +204,7 @@ class EmptyUserRightsToFunction extends AbstractRector
 	 * Check if node is a global access with format conf->global->XXX
 	 *
 	 * @param Node 	$node 	A node
-	 * @return bool			Return true if noe is conf->global->XXX
+	 * @return bool			Return true if node is conf->global->XXX
 	 */
 	private function isGlobalVar($node)
 	{

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1477,19 +1477,19 @@ class Form
 			$sql .= " AND (";
 			$prefix = !getDolGlobalString('COMPANY_DONOTSEARCH_ANYWHERE') ? '%' : ''; // Can use index if COMPANY_DONOTSEARCH_ANYWHERE is on
 			// For natural search
-			$scrit = explode(' ', $filterkey);
+			$search_crit = explode(' ', $filterkey);
 			$i = 0;
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= "(";
 			}
-			foreach ($scrit as $crit) {
+			foreach ($search_crit as $crit) {
 				if ($i > 0) {
 					$sql .= " AND ";
 				}
 				$sql .= "(s.nom LIKE '" . $this->db->escape($prefix . $crit) . "%')";
 				$i++;
 			}
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= ")";
 			}
 			if (isModEnabled('barcode')) {
@@ -2889,12 +2889,12 @@ class Form
 			$sql .= ' AND (';
 			$prefix = !getDolGlobalString('PRODUCT_DONOTSEARCH_ANYWHERE') ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
 			// For natural search
-			$scrit = explode(' ', $filterkey);
+			$search_crit = explode(' ', $filterkey);
 			$i = 0;
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= "(";
 			}
-			foreach ($scrit as $crit) {
+			foreach ($search_crit as $crit) {
 				if ($i > 0) {
 					$sql .= " AND ";
 				}
@@ -2917,7 +2917,7 @@ class Form
 				$sql .= ")";
 				$i++;
 			}
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= ")";
 			}
 			if (isModEnabled('barcode')) {
@@ -3537,12 +3537,12 @@ class Form
 			$sql .= ' AND (';
 			$prefix = !getDolGlobalString('PRODUCT_DONOTSEARCH_ANYWHERE') ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
 			// For natural search
-			$scrit = explode(' ', $filterkey);
+			$search_crit = explode(' ', $filterkey);
 			$i = 0;
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= "(";
 			}
-			foreach ($scrit as $crit) {
+			foreach ($search_crit as $crit) {
 				if ($i > 0) {
 					$sql .= " AND ";
 				}
@@ -3553,7 +3553,7 @@ class Form
 				$sql .= ")";
 				$i++;
 			}
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= ")";
 			}
 			if (isModEnabled('barcode')) {
@@ -7469,12 +7469,12 @@ class Form
 			$sql .= ' AND (';
 			$prefix = !getDolGlobalString('TICKET_DONOTSEARCH_ANYWHERE') ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
 			// For natural search
-			$scrit = explode(' ', $filterkey);
+			$search_crit = explode(' ', $filterkey);
 			$i = 0;
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= "(";
 			}
-			foreach ($scrit as $crit) {
+			foreach ($search_crit as $crit) {
 				if ($i > 0) {
 					$sql .= " AND ";
 				}
@@ -7482,7 +7482,7 @@ class Form
 				$sql .= ")";
 				$i++;
 			}
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= ")";
 			}
 			$sql .= ')';
@@ -7694,12 +7694,12 @@ class Form
 			$sql .= ' AND (';
 			$prefix = !getDolGlobalString('TICKET_DONOTSEARCH_ANYWHERE') ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
 			// For natural search
-			$scrit = explode(' ', $filterkey);
+			$search_crit = explode(' ', $filterkey);
 			$i = 0;
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= "(";
 			}
-			foreach ($scrit as $crit) {
+			foreach ($search_crit as $crit) {
 				if ($i > 0) {
 					$sql .= " AND ";
 				}
@@ -7707,7 +7707,7 @@ class Form
 				$sql .= "";
 				$i++;
 			}
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= ")";
 			}
 			$sql .= ')';
@@ -7927,12 +7927,12 @@ class Form
 			$sql .= ' AND (';
 			$prefix = !getDolGlobalString('MEMBER_DONOTSEARCH_ANYWHERE') ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
 			// For natural search
-			$scrit = explode(' ', $filterkey);
+			$search_crit = explode(' ', $filterkey);
 			$i = 0;
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= "(";
 			}
-			foreach ($scrit as $crit) {
+			foreach ($search_crit as $crit) {
 				if ($i > 0) {
 					$sql .= " AND ";
 				}
@@ -7940,7 +7940,7 @@ class Form
 				$sql .= " OR p.lastname LIKE '" . $this->db->escape($prefix . $crit) . "%')";
 				$i++;
 			}
-			if (count($scrit) > 1) {
+			if (count($search_crit) > 1) {
 				$sql .= ")";
 			}
 			$sql .= ')';

--- a/htdocs/public/webportal/css/themes/custom.css.php
+++ b/htdocs/public/webportal/css/themes/custom.css.php
@@ -55,7 +55,7 @@ $webPortalTheme = new WebPortalTheme();
 	}
 
 	if (!empty($webPortalTheme->loginLogoUrl)) {
-		print '--login-logo: url("'.$webPortalTheme->loginLogoUrl.'"); /* for relative path, must be relative od the css file or use full url starting by http:// */'."\n";
+		print '--login-logo: url("'.$webPortalTheme->loginLogoUrl.'"); /* for relative path, must be relative to the css file or use full url starting by http:// */'."\n";
 	}
 	?>
 }

--- a/test/phpunit/UserTest.php
+++ b/test/phpunit/UserTest.php
@@ -398,7 +398,7 @@ class UserTest extends PHPUnit\Framework\TestCase
 
 		$localobject->error = '';
 		$result = $localobject->setPassword($user, '$*11145678AA');
-		print __METHOD__." set a password with noo too much consecutive chars\n";
+		print __METHOD__." set a password with not too much consecutive chars\n";
 		print __METHOD__." localobject->error=".$localobject->error."\n";
 		$this->assertEquals('$*11145678AA', $result, 'We must get the password as it is valid (pass has not too much similar consecutive chars) and we did not here');
 


### PR DESCRIPTION
The files with exceptions can be updated as there are many less cases to exclude.

In the project files there are a few minor spelling corrections, and `$scrit` was changed to `$search_crit` to avoid a spelling suggestion.