### PR TITLE
qual: phpstan for htdocs/compta/sociales/class/paymentsocialcontribution.class.php

### DIFF
--- a/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
+++ b/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
@@ -536,7 +536,7 @@ class PaymentSocialContribution extends CommonObject
 		$this->tms = dol_now();
 		$this->datep = dol_now();
 		$this->amount = 100;
-		$this->fk_typepaiement = '';
+		$this->fk_typepaiement = 0;
 		$this->num_payment = 'ABC123';
 		$this->note_private = '';
 		$this->note_public = '';


### PR DESCRIPTION
htdocs/compta/sociales/class/paymentsocialcontribution.class.php	539	Property PaymentSocialContribution::$fk_typepaiement (int) does not accept string.