### PR TITLE
Qual phpstan DolibarrModules class

### DIFF
--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -866,7 +866,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	/**
 	 * Gives the module position
 	 *
-	 * @return int  	Module position (an external module should never return a value lower than 100000. 1-100000 are reserved for core)
+	 * @return string	Module position (an external module should never return a value lower than 100000. 1-100000 are reserved for core)
 	 */
 	public function getModulePosition()
 	{
@@ -876,7 +876,8 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 			if ($this->module_position >= 100000) {
 				return $this->module_position;
 			} else {
-				return $this->module_position + 100000;
+				$position = intval($this->module_position) + 100000;
+				return strval($position);
 			}
 		}
 	}
@@ -2270,7 +2271,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	public function insert_module_parts()
 	{
 		// phpcs:enable
-		global $conf;
+		global $conf, $langs;
 
 		$error = 0;
 


### PR DESCRIPTION
# Qual DolibarrModules.class.php phpstan lvl3
htdocs/core/modules/DolibarrModules.class.php	874	Method DolibarrModules::getModulePosition() should return int but returns string.
htdocs/core/modules/DolibarrModules.class.php	877	Method DolibarrModules::getModulePosition() should return int but returns string.
htdocs/core/modules/DolibarrModules.class.php	2303	Undefined variable: $langs
htdocs/core/modules/DolibarrModules.class.php	2304	Undefined variable: $langs

