### PR TITLE
qual: phpdoc for classes using $num_payment (and not inheriting it from another class)

### DIFF
--- a/htdocs/compta/bank/class/paymentvarious.class.php
+++ b/htdocs/compta/bank/class/paymentvarious.class.php
@@ -87,7 +87,8 @@ class PaymentVarious extends CommonObject
 	public $type_payment;
 
 	/**
-	 * @var string Payment reference
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
 	 */
 	public $num_payment;
 

--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -147,14 +147,15 @@ class Paiement extends CommonObject
 	public $type_code;
 
 	/**
-	 * @var string							Numero du CHQ, VIR, etc...
+	 * @var string
 	 * @deprecated
 	 * @see $num_payment
 	 */
 	public $num_paiement;
 
 	/**
-	 * @var string Numero du CHQ, VIR, etc...
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
 	 */
 	public $num_payment;
 

--- a/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
+++ b/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
@@ -98,11 +98,13 @@ class PaymentSocialContribution extends CommonObject
 	/**
 	 * @var string
 	 * @deprecated
+  	 * @see $num_payment
 	 */
 	public $num_paiement;
 
 	/**
-	 * @var string
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
 	 */
 	public $num_payment;
 

--- a/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
+++ b/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
@@ -98,7 +98,7 @@ class PaymentSocialContribution extends CommonObject
 	/**
 	 * @var string
 	 * @deprecated
-  	 * @see $num_payment
+	 * @see $num_payment
 	 */
 	public $num_paiement;
 

--- a/htdocs/compta/tva/class/paymentvat.class.php
+++ b/htdocs/compta/tva/class/paymentvat.class.php
@@ -73,11 +73,13 @@ class PaymentVAT extends CommonObject
 	/**
 	 * @var string
 	 * @deprecated
+  	 * @see $num_payment
 	 */
 	public $num_paiement;
 
 	/**
-	 * @var string
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
 	 */
 	public $num_payment;
 

--- a/htdocs/compta/tva/class/paymentvat.class.php
+++ b/htdocs/compta/tva/class/paymentvat.class.php
@@ -73,7 +73,7 @@ class PaymentVAT extends CommonObject
 	/**
 	 * @var string
 	 * @deprecated
-  	 * @see $num_payment
+	 * @see $num_payment
 	 */
 	public $num_paiement;
 

--- a/htdocs/compta/tva/class/tva.class.php
+++ b/htdocs/compta/tva/class/tva.class.php
@@ -60,6 +60,11 @@ class Tva extends CommonObject
 	public $datev;
 	public $amount;
 	public $type_payment;
+
+	/**
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
+	 */
 	public $num_payment;
 
 	/**

--- a/htdocs/don/class/don.class.php
+++ b/htdocs/don/class/don.class.php
@@ -139,6 +139,10 @@ class Don extends CommonObject
 	 */
 	public $fk_typepayment;
 
+	/**
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
+	 */
 	public $num_payment;
 	public $date_valid;
 

--- a/htdocs/don/class/paymentdonation.class.php
+++ b/htdocs/don/class/paymentdonation.class.php
@@ -67,6 +67,10 @@ class PaymentDonation extends CommonObject
 	public $fk_typepayment;	// Payment mode ID
 	public $paymenttype;	// Payment mode ID or Code. TODO Use only the code in this field.
 
+	/**
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
+	 */
 	public $num_payment;
 
 	/**

--- a/htdocs/expensereport/class/paymentexpensereport.class.php
+++ b/htdocs/expensereport/class/paymentexpensereport.class.php
@@ -66,6 +66,10 @@ class PaymentExpenseReport extends CommonObject
 	 */
 	public $fk_typepayment;
 
+	/**
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
+	 */
 	public $num_payment;
 
 	/**

--- a/htdocs/loan/class/loanschedule.class.php
+++ b/htdocs/loan/class/loanschedule.class.php
@@ -66,7 +66,8 @@ class LoanSchedule extends CommonObject
 	public $fk_typepayment;
 
 	/**
-	 * @var int Payment ID
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
 	 */
 	public $num_payment;
 

--- a/htdocs/loan/class/paymentloan.class.php
+++ b/htdocs/loan/class/paymentloan.class.php
@@ -77,7 +77,8 @@ class PaymentLoan extends CommonObject
 	public $fk_typepayment;
 
 	/**
-	 * @var string Payment ID (ex: 12345-chq1)
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
 	 */
 	public $num_payment;
 

--- a/htdocs/salaries/class/paymentsalary.class.php
+++ b/htdocs/salaries/class/paymentsalary.class.php
@@ -110,7 +110,8 @@ class PaymentSalary extends CommonObject
 	public $num_paiement;
 
 	/**
-	 * @var string			Payment reference
+	 * @var string      Payment reference
+	 *                  (Cheque or bank transfer reference. Can be "ABC123")
 	 */
 	public $num_payment;
 


### PR DESCRIPTION
FYI : I've checked all files declaring `public $num_payment` and they mostly (all?) inherit directly from `commonobject.class.php`.

While I was expecting to see inheritance from some `payment.class.php` generic class.

I'm not sure, but this might be a suggestion for improvement.

![image](https://github.com/Dolibarr/dolibarr/assets/7697736/a6105d67-1ce8-4828-8a22-0a40f472c71d)
