### PR TITLE
FIX avoid Unknown column 'pfp.ref_fourn'

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -432,7 +432,21 @@ if (!empty($conf->global->PRODUCT_USE_UNITS)) {
 
 $sql .= ' WHERE p.entity IN ('.getEntity('product').')';
 if ($sall) {
-	$sql .= natural_search(array_keys($fieldstosearchall), $sall);
+	// Clean $fieldstosearchall
+	$newfieldstosearchall = $fieldstosearchall;
+	unset($newfieldstosearchall['pfp.ref_fourn']);
+	unset($newfieldstosearchall['pfp.barcode']);
+
+	$sql .= ' AND (';
+	$sql .= natural_search(array_keys($newfieldstosearchall), $sall, 0, 1);
+	// Search also into a supplier reference 'pfp.ref_fourn'="RefSupplier"
+	$sql .= ' OR EXISTS (SELECT rowid FROM '.MAIN_DB_PREFIX.'product_fournisseur_price as pfp WHERE pfp.fk_product = p.rowid';
+	$sql .= ' AND ('.natural_search('pfp.ref_fourn', $sall, 0, 1);
+	if (isModEnabled('barcode')) {
+		// Search also into a supplier barcode 'pfp.barcode'='GencodBuyPrice';
+		$sql .= ' OR '.natural_search('pfp.barcode', $sall, 0, 1);
+	}
+	$sql .= ')))';
 }
 // if the type is not 1, we show all products (type = 0,2,3)
 if (dol_strlen($search_type) && $search_type != '-1') {


### PR DESCRIPTION
@eldy backport to avoid error : 

`Error url=/product/list.php?sall=sardine, query_string=sall=sardine, sql=SELECT COUNT(*) as nbtotalofrecords FROM llx_product as p LEFT JOIN llx_product_extrafields as ef on (p.rowid = ef.fk_object) LEFT JOIN llx_c_units cu ON cu.rowid = p.fk_unit WHERE p.entity IN (1) AND ((p.ref LIKE '%sardine%' OR pfp.ref_fourn LIKE '%sardine%' OR p.label LIKE '%sardine%' OR p.description LIKE '%sardine%' OR p.note LIKE '%sardine%' OR p.barcode LIKE '%sardine%' OR pfp.barcode LIKE '%sardine%')), db_error=Unknown column 'pfp.ref_fourn' in 'where clause'`