### PR TITLE
qual: phpstan for commonobject.class.php : public $fk_element can be string or int

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -99,7 +99,8 @@ abstract class CommonObject
 	public $element;
 
 	/**
-	 * @var string		Fieldname with the ID of the parent object, if this object has a parent
+	 * @var string|int	Field with ID of parent key if this field has a parent (a string). For example 'fk_product'.
+	 *					ID of parent key itself (an int). For example in few classes like 'Comment', 'ActionComm' or 'AdvanceTargetingMailing'.
 	 */
 	public $fk_element;
 


### PR DESCRIPTION
htdocs/comm/action/class/actioncomm.class.php	291	PHPDoc type int of property ActionComm::$fk_element is not covariant with PHPDoc type string of overridden property CommonObject::$fk_element.

htdocs/comm/mailing/class/advtargetemailing.class.php	59	PHPDoc type int of property AdvanceTargetingMailing::$fk_element is not covariant with PHPDoc type string of overridden property CommonObject::$fk_element.

htdocs/core/class/comment.class.php	37	PHPDoc type int of property Comment::$fk_element is not covariant with PHPDoc type string of overridden property CommonObject::$fk_element.