### PR TITLE
FIX Payment on customer invoice - Remove accountid in url if empty for apply default value

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5696,7 +5696,7 @@ if ($action == 'create') {
 						// Sometimes we can receive more, so we accept to enter more and will offer a button to convert into discount (but it is not a credit note, just a prepayment done)
 						//print '<a class="butAction" href="'.DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create&amp;accountid='.$object->fk_account.'">'.$langs->trans('DoPayment').'</a>';
 						$params['attr']['title'] = '';
-						print dolGetButtonAction($langs->trans('DoPayment'), '', 'default', DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create&amp;accountid='.$object->fk_account, '', true, $params);
+						print dolGetButtonAction($langs->trans('DoPayment'), '', 'default', DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create'.($object->fk_account > 0 ? '&amp;accountid='.$object->fk_account : ''), '', true, $params);
 					}
 				}
 			}


### PR DESCRIPTION
When we insert a payment in customer invoice, url contain and empty "accountid" if any bank account have been defined in customer invoice card.

![image](https://github.com/Dolibarr/dolibarr/assets/2341395/b738c7cf-b14a-4acb-b3c6-01f65f527b6e)

With the fix : If we want to use the default value function, accountid must not be present in the URL if it is empty.

![image](https://github.com/Dolibarr/dolibarr/assets/2341395/2555205f-d1a1-40f0-80d2-7fc4a06aea79)

![image](https://github.com/Dolibarr/dolibarr/assets/2341395/2fd6bdef-a517-40fb-a4d9-6651dbb0e9b3)

