### PR TITLE
NEW: DolDeprecationHandler for deprecations

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -39,12 +39,17 @@
  *	\brief      File of parent class of all other business classes (invoices, contracts, proposals, orders, ...)
  */
 
+require_once DOL_DOCUMENT_ROOT.'/core/class/doldeprecationhandler.class.php';
 
 /**
  *	Parent class of all other business classes (invoices, contracts, proposals, orders, ...)
+ *
+ * @phan-forbid-undeclared-magic-properties
  */
 abstract class CommonObject
 {
+	use DolDeprecationHandler;
+
 	const TRIGGER_PREFIX = ''; // to be overridden in child class implementations, i.e. 'BILL', 'TASK', 'PROPAL', etc.
 
 	/**
@@ -225,17 +230,18 @@ abstract class CommonObject
 	public $fk_project;
 
 	/**
-	 * @var Project 		The related project object
-	 * @deprecated  Use $project instead
+	 * @var ?Project	 	The related project object
+	 * @deprecated  Use $project instead.
 	 * @see $project
 	 */
-	public $projet;
+	private $projet;
 
 	/**
-	 * @deprecated  Use $fk_project instead
+	 * @var int
+	 * @deprecated  Use $fk_project instead.
 	 * @see $fk_project
 	 */
-	public $fk_projet;
+	private $fk_projet;
 
 	/**
 	 * @var Contact|null 	A related contact object
@@ -280,19 +286,34 @@ abstract class CommonObject
 
 	/**
 	 * @var CommonObject|string|null	Sometimes the type of the originating object ('commande', 'facture', ...), sometimes the object (as with MouvementStock)
-	 * @deprecated						Use now $origin_type and $origin_id;
+	 * @deprecated						Use $origin_type and $origin_id instead.
 	 * @see fetch_origin()
 	 */
 	public $origin;
 
-	// TODO Remove this. Has been replaced with ->origin_object.
-	// This is set by fetch_origin() from this->origin and this->origin_id
-	/** @deprecated */
-	public $expedition;
-	/** @deprecated */
-	public $livraison;
-	/** @deprecated */
-	public $commandeFournisseur;
+	/**
+	 * TODO Remove this. Has been replaced with ->origin_object.
+	 * This is set by fetch_origin() from this->origin and this->origin_id
+	 *
+	 * @var CommonObject
+	 * @deprecated Use $origin_object instead.
+	 * @see $origin_object
+	 */
+	private $expedition;
+
+	/**
+	 * @var CommonObject
+	 * @deprecated Use $origin_object instead.
+	 * @see $origin_object
+	 */
+	private $livraison;
+
+	/**
+	 * @var CommonObject
+	 * @deprecated Use $origin_object instead.
+	 * @see $origin_object
+	 */
+	private $commandeFournisseur;
 
 
 	/**
@@ -321,11 +342,12 @@ abstract class CommonObject
 	public $newref;
 
 	/**
-	 * @var int 		The object's status. Use status instead.
-	 * @deprecated  Use $status instead
-	 * @see setStatut()
+	 * @var int|array<int, string>      The object's status. Use status instead.
+	 * @deprecated  Use $status instead.
+	 * @see $status
+	 * @see setStatut(), $status
 	 */
-	public $statut;
+	private $statut;
 
 	/**
 	 * @var int|array<int, string>      The object's status (an int).
@@ -446,11 +468,17 @@ abstract class CommonObject
 	public $transport_mode_id;
 
 	/**
-	 * @var int 		Payment terms ID
-	 * @deprecated Use $cond_reglement_id instead - Kept for compatibility
-	 * @see cond_reglement_id;
+	 * @var int|string 		Payment terms ID
+	 * @deprecated  Use $cond_reglement_id instead - Kept for compatibility
+	 * @see $cond_reglement_id
+	 *
+	 * Note: cond_reglement can not be aliased to cond_reglement!!!
 	 */
-	public $cond_reglement;
+	private $cond_reglement;  // Private to call DolDeprecationHandler
+	/**
+	 * @var int|string Internal to detect deprecated access
+	 */
+	protected $depr_cond_reglement;  // Internal value for deprecation
 
 	/**
 	 * @var int 		Delivery address ID
@@ -522,10 +550,10 @@ abstract class CommonObject
 
 	/**
 	 * @var string
-	 * @deprecated
+	 * @deprecated Use $model_pdf instead.
 	 * @see $model_pdf
 	 */
-	public $modelpdf;
+	private $modelpdf;
 
 	/**
 	 * @var string
@@ -559,10 +587,11 @@ abstract class CommonObject
 	public $note_private;
 
 	/**
-	 * @deprecated
+	 * @var string
+	 * @deprecated Use $note_private instead.
 	 * @see $note_private
 	 */
-	public $note;
+	private $note;
 
 	/**
 	 * @var float 		Total amount excluding taxes (HT = "Hors Taxe" in French)
@@ -655,6 +684,13 @@ abstract class CommonObject
 	public $tms;
 
 	/**
+	 * @var int|string|null
+	 * @deprecated Use $date_modification instead.
+	 * @see $date_modification
+	 */
+	private $date_update;
+
+	/**
 	 * @var integer|string|null		Object closing date
 	 */
 	public $date_cloture;
@@ -737,8 +773,10 @@ abstract class CommonObject
 	/**
 	 * @var	float		Amount already paid from getSommePaiement() (used to show correct status)
 	 * @deprecated		Use $totalpaid instead
+	 * @see $totalpaid
 	 */
-	public $alreadypaid;
+	private $alreadypaid;
+
 	/**
 	 * @var	float		Amount already paid from getSommePaiement() (used to show correct status)
 	 */
@@ -826,6 +864,27 @@ abstract class CommonObject
 	public $warehouse_id;
 
 	// No constructor as it is an abstract class
+
+	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>
+	 */
+	protected function deprecatedProperties()
+	{
+		return array(
+			'alreadypaid' => 'totalpaid',
+			'cond_reglement' => 'depr_cond_reglement',
+			'modelpdf' => 'model_pdf',
+			'note' => 'note_private',
+			'commandeFournisseur' => 'origin_object',
+			'expedition' => 'origin_object',
+			'fk_project' => 'fk_project',
+			'livraison' => 'origin_object',
+			'projet' => 'project',
+			'statut' => 'status',
+		);
+	}
 
 
 	/**
@@ -2520,7 +2579,7 @@ abstract class CommonObject
 
 		dol_syslog(get_class($this).'::setPaymentMethods('.$id.')');
 
-		if ($this->statut >= 0 || $this->element == 'societe') {
+		if ($this->status >= 0 || $this->element == 'societe') {
 			// TODO uniformize field name
 			$fieldname = 'fk_mode_reglement';
 			if ($this->element == 'societe') {
@@ -2567,7 +2626,7 @@ abstract class CommonObject
 			}
 		} else {
 			dol_syslog(get_class($this).'::setPaymentMethods, status of the object is incompatible');
-			$this->error = 'Status of the object is incompatible '.$this->statut;
+			$this->error = 'Status of the object is incompatible '.$this->status;
 			return -2;
 		}
 	}
@@ -2581,7 +2640,7 @@ abstract class CommonObject
 	public function setMulticurrencyCode($code)
 	{
 		dol_syslog(get_class($this).'::setMulticurrencyCode('.$code.')');
-		if ($this->statut >= 0 || $this->element == 'societe') {
+		if ($this->status >= 0 || $this->element == 'societe') {
 			$fieldname = 'multicurrency_code';
 
 			$sql = 'UPDATE '.$this->db->prefix().$this->table_element;
@@ -2604,7 +2663,7 @@ abstract class CommonObject
 			}
 		} else {
 			dol_syslog(get_class($this).'::setMulticurrencyCode, status of the object is incompatible');
-			$this->error = 'Status of the object is incompatible '.$this->statut;
+			$this->error = 'Status of the object is incompatible '.$this->status;
 			return -2;
 		}
 	}
@@ -2619,7 +2678,7 @@ abstract class CommonObject
 	public function setMulticurrencyRate($rate, $mode = 1)
 	{
 		dol_syslog(get_class($this).'::setMulticurrencyRate('.$rate.', '.$mode.')');
-		if ($this->statut >= 0 || $this->element == 'societe') {
+		if ($this->status >= 0 || $this->element == 'societe') {
 			$fieldname = 'multicurrency_tx';
 
 			$sql = 'UPDATE '.$this->db->prefix().$this->table_element;
@@ -2818,7 +2877,7 @@ abstract class CommonObject
 			}
 		} else {
 			dol_syslog(get_class($this).'::setMulticurrencyRate, status of the object is incompatible');
-			$this->error = 'Status of the object is incompatible '.$this->statut;
+			$this->error = 'Status of the object is incompatible '.$this->status;
 			return -2;
 		}
 	}
@@ -2833,7 +2892,7 @@ abstract class CommonObject
 	public function setPaymentTerms($id, $deposit_percent = null)
 	{
 		dol_syslog(get_class($this).'::setPaymentTerms('.$id.', '.var_export($deposit_percent, true).')');
-		if ($this->statut >= 0 || $this->element == 'societe') {
+		if ($this->status >= 0 || $this->element == 'societe') {
 			// TODO uniformize field name
 			$fieldname = 'fk_cond_reglement';
 			if ($this->element == 'societe') {
@@ -2874,7 +2933,7 @@ abstract class CommonObject
 			}
 		} else {
 			dol_syslog(get_class($this).'::setPaymentTerms, status of the object is incompatible');
-			$this->error = 'Status of the object is incompatible '.$this->statut;
+			$this->error = 'Status of the object is incompatible '.$this->status;
 			return -2;
 		}
 	}
@@ -2888,7 +2947,7 @@ abstract class CommonObject
 	public function setTransportMode($id)
 	{
 		dol_syslog(get_class($this).'::setTransportMode('.$id.')');
-		if ($this->statut >= 0 || $this->element == 'societe') {
+		if ($this->status >= 0 || $this->element == 'societe') {
 			$fieldname = 'fk_transport_mode';
 			if ($this->element == 'societe') {
 				$fieldname = 'transport_mode';
@@ -2915,7 +2974,7 @@ abstract class CommonObject
 			}
 		} else {
 			dol_syslog(get_class($this).'::setTransportMode, status of the object is incompatible');
-			$this->error = 'Status of the object is incompatible '.$this->statut;
+			$this->error = 'Status of the object is incompatible '.$this->status;
 			return -2;
 		}
 	}
@@ -2929,7 +2988,7 @@ abstract class CommonObject
 	public function setRetainedWarrantyPaymentTerms($id)
 	{
 		dol_syslog(get_class($this).'::setRetainedWarrantyPaymentTerms('.$id.')');
-		if ($this->statut >= 0 || $this->element == 'societe') {
+		if ($this->status >= 0 || $this->element == 'societe') {
 			$fieldname = 'retained_warranty_fk_cond_reglement';
 
 			$sql = 'UPDATE '.$this->db->prefix().$this->table_element;
@@ -2946,7 +3005,7 @@ abstract class CommonObject
 			}
 		} else {
 			dol_syslog(get_class($this).'::setRetainedWarrantyPaymentTerms, status of the object is incompatible');
-			$this->error = 'Status of the object is incompatible '.$this->statut;
+			$this->error = 'Status of the object is incompatible '.$this->status;
 			return -2;
 		}
 	}
@@ -4604,7 +4663,6 @@ abstract class CommonObject
 					} elseif ($fieldstatus == 'tobuy') {
 						$this->status_buy = $status;	// @phpstan-ignore-line
 					} else {
-						$this->statut = $status;
 						$this->status = $status;
 					}
 				}
@@ -5221,7 +5279,7 @@ abstract class CommonObject
 		}
 
 		// Line in update mode
-		if ($this->statut == 0 && $action == 'editline' && $selected == $line->id) {
+		if ($this->status == 0 && $action == 'editline' && $selected == $line->id) {
 			$label = (!empty($line->label) ? $line->label : (($line->fk_product > 0) ? $line->product_label : ''));
 
 			$line->pu_ttc = price2num($line->subprice * (1 + ($line->tva_tx / 100)), 'MU');

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -76,7 +76,7 @@ trait CommonPeople
 		$lastname = $this->lastname;
 		$firstname = $this->firstname;
 		if (empty($lastname)) {
-			$lastname = (isset($this->lastname) ? $this->lastname : (isset($this->name) ? $this->name : (isset($this->nom) ? $this->nom : (isset($this->societe) ? $this->societe : (isset($this->company) ? $this->company : '')))));
+			$lastname = (isset($this->lastname) ? $this->lastname : (isset($this->name) ? $this->name : (property_exists($this, 'nom') && isset($this->nom) ? $this->nom : (property_exists($this, 'societe') && isset($this->societe) ? $this->societe : (property_exists($this, 'company') && isset($this->company) ? $this->company : '')))));
 		}
 
 		$ret = '';

--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2004-2020 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2017 Regis Houssin      	<regis.houssin@inodbox.com>
  * Copyright (C) 2006 	   Jean Heimburger    	<jean@tiaris.info>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,6 +20,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+require_once DOL_DOCUMENT_ROOT.'/core/class/doldeprecationhandler.class.php';
+
 /**
  *	\file       	htdocs/core/class/conf.class.php
  *	\ingroup		core
@@ -28,9 +31,17 @@
 
 /**
  *  Class to stock current configuration
+ *
  */
 class Conf extends stdClass
 {
+	use DolDeprecationHandler;
+	/**
+	 * When true, indicates to the DeprecationHandler that this
+	 * class supports dynamic properties.
+	 */
+	protected $enableDynamicProperties = true;
+
 	/**
 	 * @var Object 	Associative array with properties found in conf file
 	 */
@@ -128,47 +139,179 @@ class Conf extends stdClass
 
 
 	// TODO Remove this part.
+
+	/**
+	 * @var stdClass  Supplier
+	 */
 	public $fournisseur;
+
+	/**
+	 * @var stdClass
+	 */
 	public $product;
+
 	/**
-	 * @deprecated Use product
+	 * @var stdClass
+	 * @deprecated      Use $product
+	 * @see $product
 	 */
-	public $produit;
+	private $produit;
+
+	/**
+	 * @var stdClass
+	 */
 	public $service;
+
 	/**
-	 * @deprecated Use contract
+	 * @var stdClass
+	 * @deprecated      Use $contract
+	 * @see $contract
 	 */
-	public $contrat;
+	private $contrat;
+
+	/**
+	 * @var stdClass
+	 */
 	public $contract;
+
+	/**
+	 * @var stdClass
+	 */
 	public $actions;
+
+	/**
+	 * @var stdClass
+	 */
 	public $agenda;
-	public $commande;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $order
+	 * @see $order
+	 */
+	private $commande;
+
+	/**
+	 * @var stdClass
+	 */
 	public $propal;
+
+	/**
+	 * @var stdClass
+	 */
 	public $order;
+
 	/**
-	 * @deprecated Use invoice
+	 * @var stdClass
+	 * @deprecated      Use $invoice
+	 * @see $invoice
 	 */
-	public $facture;
+	private $facture;
+
+
+	/**
+	 * @var stdClass
+	 */
 	public $invoice;
+
+	/**
+	 * @var stdClass
+	 */
 	public $user;
+
 	/**
-	 * @deprecated Use member
+	 * @var stdClass
+	 * @deprecated      Use $member
+	 * @see $member
 	 */
-	public $adherent;
+	private $adherent;
+
+
+	/**
+	 * @var stdClass
+	 */
 	public $member;
-	public $bank;
-	public $notification;
-	public $expensereport;
-	public $productbatch;
+
 	/**
-	 * @deprecated Use project
+	 * @var stdClass
 	 */
-	public $projet;
+	public $bank;
+
+	/**
+	 * @var stdClass
+	 */
+	public $notification;
+
+	/**
+	 * @var stdClass
+	 */
+	public $expensereport;
+
+	/**
+	 * @var stdClass
+	 */
+	public $productbatch;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $project
+	 * @see $project
+	 */
+	private $projet;
+
+
+	/**
+	 * @var stdClass
+	 */
 	public $project;
+
+	/**
+	 * @var stdClass
+	 */
 	public $supplier_proposal;
+
+	/**
+	 * @var stdClass
+	 */
 	public $supplier_order;
+
+	/**
+	 * @var stdClass
+	 */
 	public $supplier_invoice;
+
+	/**
+	 * @var stdClass
+	 */
 	public $category;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $category
+	 * @see $category
+	 */
+	private $categorie;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $supplier_proposal
+	 * @see $supplier_proposal
+	 */
+	private $supplierproposal;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $delivery_note
+	 * @see $delivery_note
+	 */
+	private $expedition;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $bank
+	 * @see $bank
+	 */
+	private $banque;
 
 
 	/**
@@ -221,19 +364,45 @@ class Conf extends stdClass
 		$this->fournisseur = new stdClass();
 		$this->product = new stdClass();
 		$this->service = new stdClass();
-		$this->contrat = new stdClass();
+		$this->contract = new stdClass();
 		$this->actions = new stdClass();
 		$this->agenda = new stdClass();
-		$this->commande = new stdClass();
+		$this->order = new stdClass();
 		$this->propal = new stdClass();
-		$this->facture = new stdClass();
+		$this->invoice = new stdClass();
 		$this->user	= new stdClass();
-		$this->adherent = new stdClass();
+		$this->member = new stdClass();
 		$this->bank = new stdClass();
 		$this->notification = new stdClass();
 		$this->expensereport = new stdClass();
 		$this->productbatch = new stdClass();
 	}
+
+	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>
+	 */
+	protected function deprecatedProperties()
+	{
+		return MODULE_MAPPING
+		+ array(
+			// Previously detected module names, already in mapping
+			//'adherent' => 'member',
+			//'banque' => 'bank',
+			//'categorie' => 'category',
+			//'commande' => 'order',
+			//'contrat' => 'contract',
+			//'expedition' => 'delivery_note',
+			//'facture' => 'invoice',
+			//'projet' => 'project',
+
+			// Other, not deprecated module names
+			'produit' => 'product',
+			'supplierproposal' => 'supplier_proposal',
+		);
+	}
+
 
 	/**
 	 * Load setup values into conf object (read llx_const) for a specified entity
@@ -288,14 +457,14 @@ class Conf extends stdClass
 		$this->fournisseur = new stdClass();
 		$this->product = new stdClass();
 		$this->service = new stdClass();
-		$this->contrat = new stdClass();
+		$this->contract = new stdClass();
 		$this->actions = new stdClass();
 		$this->agenda = new stdClass();
-		$this->commande = new stdClass();
+		$this->order = new stdClass();
 		$this->propal = new stdClass();
-		$this->facture = new stdClass();
+		$this->invoice = new stdClass();
 		$this->user	= new stdClass();
-		$this->adherent = new stdClass();
+		$this->member = new stdClass();
 		$this->bank = new stdClass();
 		$this->notification = new stdClass();
 		$this->expensereport = new stdClass();
@@ -396,11 +565,9 @@ class Conf extends stdClass
 							} elseif (preg_match('/^MAIN_MODULE_([0-9A-Z_]+)$/i', $key, $reg)) {
 								// If this is a module constant (must be at end)
 								$modulename = strtolower($reg[1]);
-								if ($modulename == 'propale') {
-									$modulename = 'propal';
-								}
-								if ($modulename == 'supplierproposal') {
-									$modulename = 'supplier_proposal';
+								$mapping = $this->deprecatedProperties();
+								if (array_key_exists($modulename, $mapping)) {
+									$modulename = $mapping[$modulename];
 								}
 								$this->modules[$modulename] = $modulename; // Add this module in list of enabled modules
 
@@ -630,12 +797,12 @@ class Conf extends stdClass
 			$this->productbatch->multidir_output = array($this->entity => $rootfordata."/productlot");
 			$this->productbatch->multidir_temp = array($this->entity => $rootfortemp."/productlot/temp");
 
-			// Module contrat
-			$this->contrat->multidir_output = array($this->entity => $rootfordata."/contract");
-			$this->contrat->multidir_temp = array($this->entity => $rootfortemp."/contract/temp");
+			// Module contract
+			$this->contract->multidir_output = array($this->entity => $rootfordata."/contract");
+			$this->contract->multidir_temp = array($this->entity => $rootfortemp."/contract/temp");
 			// For backward compatibility
-			$this->contrat->dir_output = $rootfordata."/contract";
-			$this->contrat->dir_temp = $rootfortemp."/contract/temp";
+			$this->contract->dir_output = $rootfordata."/contract";
+			$this->contract->dir_temp = $rootfortemp."/contract/temp";
 
 			// Module bank
 			$this->bank->multidir_output = array($this->entity => $rootfordata."/bank");
@@ -918,23 +1085,23 @@ class Conf extends stdClass
 			// Delay before warnings
 			// Avoid strict errors. TODO: Replace xxx->warning_delay with a property ->warning_delay_xxx
 			if (isset($this->agenda)) {
-				$this->adherent->subscription = new stdClass();
-				$this->adherent->subscription->warning_delay = (isset($this->global->MAIN_DELAY_MEMBERS) ? (int) $this->global->MAIN_DELAY_MEMBERS : 0) * 86400;
+				$this->member->subscription = new stdClass();
+				$this->member->subscription->warning_delay = (isset($this->global->MAIN_DELAY_MEMBERS) ? (int) $this->global->MAIN_DELAY_MEMBERS : 0) * 86400;
 			}
 			if (isset($this->agenda)) {
 				$this->agenda->warning_delay = (isset($this->global->MAIN_DELAY_ACTIONS_TODO) ? (int) $this->global->MAIN_DELAY_ACTIONS_TODO : 7) * 86400;
 			}
-			if (isset($this->projet)) {
-				$this->projet->warning_delay = (getDolGlobalInt('MAIN_DELAY_PROJECT_TO_CLOSE', 7) * 86400);
-				$this->projet->task = new StdClass();
-				$this->projet->task->warning_delay = (getDolGlobalInt('MAIN_DELAY_TASKS_TODO', 7) * 86400);
+			if (isset($this->project)) {
+				$this->project->warning_delay = (getDolGlobalInt('MAIN_DELAY_PROJECT_TO_CLOSE', 7) * 86400);
+				$this->project->task = new StdClass();
+				$this->project->task->warning_delay = (getDolGlobalInt('MAIN_DELAY_TASKS_TODO', 7) * 86400);
 			}
 
-			if (isset($this->commande)) {
-				$this->commande->client = new stdClass();
-				$this->commande->fournisseur = new stdClass();
-				$this->commande->client->warning_delay = (isset($this->global->MAIN_DELAY_ORDERS_TO_PROCESS) ? (int) $this->global->MAIN_DELAY_ORDERS_TO_PROCESS : 2) * 86400;
-				$this->commande->fournisseur->warning_delay = (isset($this->global->MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS) ? (int) $this->global->MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS : 7) * 86400;
+			if (isset($this->order)) {
+				$this->order->client = new stdClass();
+				$this->order->fournisseur = new stdClass();
+				$this->order->client->warning_delay = (isset($this->global->MAIN_DELAY_ORDERS_TO_PROCESS) ? (int) $this->global->MAIN_DELAY_ORDERS_TO_PROCESS : 2) * 86400;
+				$this->order->fournisseur->warning_delay = (isset($this->global->MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS) ? (int) $this->global->MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS : 7) * 86400;
 			}
 			if (isset($this->propal)) {
 				$this->propal->cloture = new stdClass();
@@ -942,20 +1109,20 @@ class Conf extends stdClass
 				$this->propal->cloture->warning_delay = (isset($this->global->MAIN_DELAY_PROPALS_TO_CLOSE) ? (int) $this->global->MAIN_DELAY_PROPALS_TO_CLOSE : 0) * 86400;
 				$this->propal->facturation->warning_delay = (isset($this->global->MAIN_DELAY_PROPALS_TO_BILL) ? (int) $this->global->MAIN_DELAY_PROPALS_TO_BILL : 0) * 86400;
 			}
-			if (isset($this->facture)) {
-				$this->facture->client = new stdClass();
-				$this->facture->fournisseur = new stdClass();
-				$this->facture->client->warning_delay = (isset($this->global->MAIN_DELAY_CUSTOMER_BILLS_UNPAYED) ? (int) $this->global->MAIN_DELAY_CUSTOMER_BILLS_UNPAYED : 0) * 86400;
-				$this->facture->fournisseur->warning_delay = (isset($this->global->MAIN_DELAY_SUPPLIER_BILLS_TO_PAY) ? (int) $this->global->MAIN_DELAY_SUPPLIER_BILLS_TO_PAY : 0) * 86400;
+			if (isset($this->invoice)) {
+				$this->invoice->client = new stdClass();
+				$this->invoice->fournisseur = new stdClass();
+				$this->invoice->client->warning_delay = (isset($this->global->MAIN_DELAY_CUSTOMER_BILLS_UNPAYED) ? (int) $this->global->MAIN_DELAY_CUSTOMER_BILLS_UNPAYED : 0) * 86400;
+				$this->invoice->fournisseur->warning_delay = (isset($this->global->MAIN_DELAY_SUPPLIER_BILLS_TO_PAY) ? (int) $this->global->MAIN_DELAY_SUPPLIER_BILLS_TO_PAY : 0) * 86400;
 			}
-			if (isset($this->contrat)) {
-				$this->contrat->services = new stdClass();
-				$this->contrat->services->inactifs = new stdClass();
-				$this->contrat->services->expires = new stdClass();
-				$this->contrat->services->inactifs->warning_delay = (isset($this->global->MAIN_DELAY_NOT_ACTIVATED_SERVICES) ? (int) $this->global->MAIN_DELAY_NOT_ACTIVATED_SERVICES : 0) * 86400;
-				$this->contrat->services->expires->warning_delay = (isset($this->global->MAIN_DELAY_RUNNING_SERVICES) ? (int) $this->global->MAIN_DELAY_RUNNING_SERVICES : 0) * 86400;
+			if (isset($this->contract)) {
+				$this->contract->services = new stdClass();
+				$this->contract->services->inactifs = new stdClass();
+				$this->contract->services->expires = new stdClass();
+				$this->contract->services->inactifs->warning_delay = (isset($this->global->MAIN_DELAY_NOT_ACTIVATED_SERVICES) ? (int) $this->global->MAIN_DELAY_NOT_ACTIVATED_SERVICES : 0) * 86400;
+				$this->contract->services->expires->warning_delay = (isset($this->global->MAIN_DELAY_RUNNING_SERVICES) ? (int) $this->global->MAIN_DELAY_RUNNING_SERVICES : 0) * 86400;
 			}
-			if (isset($this->commande)) {
+			if (isset($this->order)) {
 				$this->bank->rappro	= new stdClass();
 				$this->bank->cheque	= new stdClass();
 				$this->bank->rappro->warning_delay = (isset($this->global->MAIN_DELAY_TRANSACTIONS_TO_CONCILIATE) ? (int) $this->global->MAIN_DELAY_TRANSACTIONS_TO_CONCILIATE : 0) * 86400;
@@ -1057,35 +1224,6 @@ class Conf extends stdClass
 				unset($this->global->MAIN_NO_CONCAT_DESCRIPTION);
 			}
 
-			// product is new use
-			if (isset($this->product)) {
-				// For backward compatibility
-				$this->produit = $this->product;
-			}
-			// invoice is new use, facture is old use still initialised
-			if (isset($this->facture)) {
-				$this->invoice = $this->facture;
-			}
-			// order is new use, commande is old use still initialised
-			if (isset($this->commande)) {
-				$this->order = $this->commande;
-			}
-			// contract is new use, contrat is old use still initialised
-			if (isset($this->contrat)) {
-				$this->contract = $this->contrat;
-			}
-			// category is new use, categorie is old use still initialised
-			if (isset($this->categorie)) {
-				$this->category = $this->categorie;
-			}
-			// project is new use, projet is old use still initialised
-			if (isset($this->projet) && !isset($this->project)) {
-				$this->project = $this->projet;
-			}
-			// member is new use, adherent is old use still initialised
-			if (isset($this->adherent) && !isset($this->member)) {
-				$this->member = $this->adherent;
-			}
 
 			// Object $mc
 			if (!defined('NOREQUIREMC') && isModEnabled('multicompany')) {

--- a/htdocs/core/class/doldeprecationhandler.class.php
+++ b/htdocs/core/class/doldeprecationhandler.class.php
@@ -1,0 +1,255 @@
+<?php
+/* Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file          DeprecationHandler.php
+ * @ingroup       core
+ * @brief         trait for handling deprecated properties and methods
+ */
+
+/**
+ * Class for handling deprecated properties and methods
+ */
+trait DolDeprecationHandler
+{
+	// Define the following in the class using the trait
+	// to allow properties to not be defined when referenced.
+	// So only deprecated value generate exceptions.
+	//
+	// protected $enableDynamicProperties = true;
+
+	/**
+	 * Get deprecated property
+	 *
+	 * @param string 	$name	Name of property
+	 * @return mixed	Value for replacement property
+	 */
+	public function __get($name)
+	{
+		$deprecatedProperties = $this->deprecatedProperties();
+		if (isset($deprecatedProperties[$name])) {
+			$newProperty = $deprecatedProperties[$name];
+			$msg = "Accessing deprecated property '$name'. Use '$newProperty' instead.".self::getCallerInfoString();
+			dol_syslog($msg);
+			if ($this->isDeprecatedReportingEnabled()) {
+				trigger_error($msg, E_USER_DEPRECATED);
+			}
+			return $this->$newProperty;
+		}
+		if ($this->isDynamicPropertiesEnabled()) {
+			return null;  // If the property is set, then __get is not called.
+		}
+		$msg = "Undefined property '$name'".self::getCallerInfoString();
+		dol_syslog($msg);
+		trigger_error($msg, E_USER_NOTICE);
+		return $this->$name;  // Returning value anyway (graceful degradation)
+	}
+
+	/**
+	 * Set deprecated property
+	 *
+	 * @param string 	$name	Name of property
+	 * @param mixed		$value	Value of property
+	 * @return void
+	 */
+	public function __set($name, $value)
+	{
+		$deprecatedProperties = $this->deprecatedProperties();
+		if (isset($deprecatedProperties[$name])) {
+			$newProperty = $deprecatedProperties[$name];
+			$msg = "Setting value to deprecated property '$name'. Use '$newProperty' instead.".self::getCallerInfoString();
+			dol_syslog($msg);
+			if ($this->isDeprecatedReportingEnabled()) {
+				trigger_error($msg, E_USER_DEPRECATED);
+			}
+
+			$this->$newProperty = $value;
+			return;
+		}
+		if (!$this->isDynamicPropertiesEnabled()) {
+			$msg = "Undefined property '$name'".self::getCallerInfoString();
+			trigger_error("Undefined property '$name'".self::getCallerInfoString(), E_USER_NOTICE);
+			$this->$name = $value;  // Setting anyway for graceful degradation
+		} else {
+			$this->$name = $value;
+		}
+	}
+
+	/**
+	 * Unset deprecated property
+	 *
+	 * @param string 	$name	Name of property
+	 * @return void
+	 */
+	public function __unset($name)
+	{
+		$deprecatedProperties = $this->deprecatedProperties();
+		if (isset($deprecatedProperties[$name])) {
+			$newProperty = $deprecatedProperties[$name];
+			$msg = "Unsetting deprecated property '$name'. Use '$newProperty' instead.".self::getCallerInfoString();
+			dol_syslog($msg);
+			if ($this->isDeprecatedReportingEnabled()) {
+				trigger_error($msg, E_USER_DEPRECATED);
+			}
+			unset($this->$newProperty);
+			return;
+		}
+		if (!$this->isDynamicPropertiesEnabled()) {
+			$msg = "Undefined property '$name'".self::getCallerInfoString();
+			dol_syslog($msg);
+			trigger_error($msg, E_USER_NOTICE);
+		}
+	}
+
+	/**
+	 * Test if deprecated property is set
+	 *
+	 * @param string 	$name	Name of property
+	 * @return void
+	 */
+	public function __isset($name)
+	{
+		$deprecatedProperties = $this->deprecatedProperties();
+		if (isset($deprecatedProperties[$name])) {
+			$newProperty = $deprecatedProperties[$name];
+			$msg = "Accessing deprecated property '$name'. Use '$newProperty' instead.".self::getCallerInfoString();
+			dol_syslog($msg);
+			if ($this->isDeprecatedReportingEnabled()) {
+				trigger_error($msg, E_USER_DEPRECATED);
+			}
+			return isset($newProperty);
+		} elseif ($this->isDynamicPropertiesEnabled()) {
+			return isset($this->$name);
+		}
+		$msg = "Undefined property '$name'.".self::getCallerInfoString();
+		dol_syslog($msg);
+		// trigger_error("Undefined property '$name'.".self::getCallerInfoString(), E_USER_NOTICE);
+		return isset($this->$name);
+	}
+
+	/**
+	 * Call deprecated method
+	 *
+	 * @param string 	$name		Name of method
+	 * @param mixed[]	$arguments	Method arguments
+	 * @return mixed
+	 */
+	public function __call($name, $arguments)
+	{
+		$deprecatedMethods = $this->deprecatedMethods();
+		if (isset($deprecatedMethods[$name])) {
+			$newMethod = $deprecatedMethods[$name];
+			if ($this->isDeprecatedReportingEnabled()) {
+				trigger_error("Calling deprecated method '$name'. Use '$newMethod' instead.".self::getCallerInfoString(), E_USER_DEPRECATED);
+			}
+			if (method_exists($this, $newMethod)) {
+				return call_user_func_array([$this, $newMethod], $arguments);
+			} else {
+				trigger_error("Replacement method '$newMethod' not implemented.", E_USER_NOTICE);
+			}
+		}
+		trigger_error("Call to undefined method '$name'".self::getCallerInfoString(), E_USER_ERROR);
+	}
+
+
+	/**
+	 * Indicate if deprecations should be reported
+	 *
+	 * @return bool
+	 */
+	private function isDeprecatedReportingEnabled()
+	{
+		return (error_reporting() & E_DEPRECATED) === E_DEPRECATED;
+	}
+
+	/**
+	 * Indicate if dynamic properties are accepted
+	 *
+	 * @return bool
+	 */
+	private function isDynamicPropertiesEnabled()
+	{
+		// By default, if enableDynamicProperties is set, use that value.
+
+		if (property_exists($this, 'enableDynamicProperties')) {
+			// If the property exists, then we use it.
+			return (bool) $this->enableDynamicProperties;
+		}
+
+		// Otherwise it depends on a choice
+
+		// 1. Return true to accept DynamicProperties in all cases.
+		return true;
+		// 2. Accept dynamic properties only when not testing
+		// return !class_exists('PHPUnit\Framework\TestSuite')
+		// 3. Accept dynamic properties only when deprecation notifications are disabled
+		// return $this->isDeprecatedReportingEnabled();
+		// 4. Do not accept dynamic properties (should be the default eventually).
+		// return false;
+	}
+
+	/**
+	 * Provide list of deprecated properties
+	 *
+	 * Override this method in subclasses
+	 *
+	 * @return array<string,string>	Mapping of deprecated properties
+	 */
+	protected function deprecatedProperties()
+	{
+		// Define deprecated properties and their replacements
+		return array(
+			// 'oldProperty' => 'newProperty',
+			// Add  deprecated properties and their replacements in subclass implementation
+		);
+	}
+
+	/**
+	 * Provide list of deprecated methods
+	 *
+	 * Override this method in subclasses
+	 *
+	 * @return array<string,string>	Mapping of deprecated methods
+	 */
+	protected function deprecatedMethods()
+	{
+		// Define deprecated methods and their replacements
+		return array(
+			// 'oldMethod' => 'newMethod',
+			// Add  deprecated methods and their replacements in subclass implementation
+		);
+	}
+
+
+	/**
+	 * Get caller info
+	 *
+	 * @return string
+	 */
+	final protected static function getCallerInfoString()
+	{
+		$backtrace = debug_backtrace();
+		$msg = "";
+		if (count($backtrace) >= 2) {
+			$trace = $backtrace[1];
+			if (isset($trace['file'], $trace['line'])) {
+				$msg = " From {$trace['file']}:{$trace['line']}.";
+			}
+		}
+		return $msg;
+	}
+}

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -589,7 +589,6 @@ class User extends CommonObject
 				$this->admin		= $obj->admin;
 				$this->note_public = $obj->note_public;
 				$this->note_private = $obj->note_private;
-				$this->note			= $obj->note_private;	// deprecated
 
 				$this->statut		= $obj->status;			// deprecated
 				$this->status		= $obj->status;

--- a/test/phpunit/DolDeprecationHandlerTest.php
+++ b/test/phpunit/DolDeprecationHandlerTest.php
@@ -1,0 +1,373 @@
+<?php
+/* Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file          test/phpunit/DeprecationHandlerTest.php
+ * \ingroup       core
+ * \brief         PHPUnit test class for DeprecationHandler
+ * \remarks       To run this script from CLI: `phpunit test/phpunit/DeprecationHandlerTest.php`
+ */
+
+// require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/core/class/doldeprecationhandler.class.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * PHPUnit test class for DeprecationHandler
+ */
+class DolDeprecationHandlerTest extends CommonClassTest
+{
+	private $handler;
+	private $dynHandler;
+
+	/**
+	 * Constructor
+	 * We save global variables into local variables
+	 *
+	 * @param 	string	$name		Name
+	 */
+	public function __construct($name = '')
+	{
+		parent::__construct($name);
+
+		print __METHOD__."\n";
+	}
+
+	/**
+	 * Global test setup
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void
+	{
+		print __METHOD__."\n";
+	}
+
+	/**
+	 * Unit test setup
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void
+	{
+		parent::setUp();
+		print __METHOD__."\n";
+		$this->handler = new class () {
+			use DolDeprecationHandler;
+
+			/**
+			 * @var string Private var to check that magic
+			 *             is triggered.
+			 */
+			private $privateVarShouldTrigger;
+
+			/**
+			 * @var string Private deprecated var to check that magic
+			 *             is triggered.
+			 * @deprecated
+			 */
+			private $privateDeprecated;
+
+			/**
+			 * Define deprecated properties.
+			 *
+			 * @return array<string,string>
+			 */
+			protected function deprecatedProperties()
+			{
+				return [
+					'oldProperty' => 'newProperty',
+					'privateDeprecated' => 'newProperty',
+				];
+			}
+
+			/**
+			 * Define deprecated methods.
+			 *
+			 * @return array<string,string>
+			 */
+			protected function deprecatedMethods()
+			{
+				return [
+					'oldMethod' => 'newMethod',
+					'oldMethodArgs' => 'newMethodArgs',
+				];
+			}
+
+			// Mocking newProperty and new Methods for testing
+			/**
+			 * @var string New property
+			 */
+			public $newProperty;
+			/**
+			 * New method
+			 *
+			 * @return string Test value
+			 */
+			public function newMethod()
+			{
+				return "New method called";
+			}
+			/**
+			 * New method with arguments
+			 *
+			 * @param string $arg Test argument
+			 * @return string Test value
+			 */
+			public function newMethodArgs($arg)
+			{
+				return "New method called is $arg";
+			}
+		};
+
+		$this->dynHandler = new class () {
+			use DolDeprecationHandler;
+			protected $enableDynamicProperties = true;
+
+			/**
+			 * Define deprecated properties.
+			 *
+			 * @return array<string,string>
+			 */
+			protected function deprecatedProperties()
+			{
+				return [
+					'oldProperty' => 'newProperty',
+				];
+			}
+
+			/**
+			 * Define deprecated methods.
+			 *
+			 * @return array<string,string>
+			 */
+			protected function deprecatedMethods()
+			{
+				return [
+					'oldMethod' => 'newMethod',
+					'oldMethodArgs' => 'newMethodArgs',
+				];
+			}
+
+			// Mocking newProperty and new Methods for testing
+			/**
+			 * @var string New property
+			 */
+			public $newProperty;
+			/**
+			 * New method
+			 *
+			 * @return string Test value
+			 */
+			public function newMethod()
+			{
+				return "New method called";
+			}
+			/**
+			 * New method with arguments
+			 *
+			 * @param string $arg Test argument
+			 * @return string Test value
+			 */
+			public function newMethodArgs($arg)
+			{
+				return "New method called is $arg";
+			}
+		};
+	}
+
+	/**
+	 * Unit test teardown
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void
+	{
+		print __METHOD__."\n";
+	}
+
+	/**
+	 * Global test teardown
+	 *
+	 * @return void
+	 */
+	public static function tearDownAfterClass(): void
+	{
+		print __METHOD__."\n";
+	}
+
+
+	/**
+	 * Test that new property value is accessible from deprecated property
+	 *
+	 * @return void
+	 */
+	public function testDeprecatedPropertyAccess()
+	{
+		$this->handler->newProperty = "TestNew";
+		$this->assertEquals("TestNew", $this->handler->oldProperty);
+	}
+
+	/**
+	 * Test that new method is called when calling deprecated method
+	 *
+	 * @return void
+	 */
+	public function testDeprecatedMethodCall()
+	{
+		$this->assertEquals("New method called", $this->handler->oldMethod());
+	}
+
+	/**
+	 * Test that when setting the deprecated property, the value is available in the new property
+	 *
+	 * @return void
+	 */
+	public function testDeprecatedPropertyAssignment()
+	{
+		$this->handler->oldProperty = "TestOld";
+		$this->assertEquals("TestOld", $this->handler->newProperty);
+
+		$this->handler->privateDeprecated = "Deprecated";
+		$this->assertEquals("Deprecated", $this->handler->newProperty);
+	}
+
+	/**
+	 * Test that unsetting the deprecated property unsets the new property
+	 *
+	 * @return void
+	 */
+	public function testDeprecatedPropertyUnset()
+	{
+		$this->handler->newProperty = "TestUnset";
+		unset($this->handler->oldProperty);
+		$this->assertFalse(isset($this->handler->newProperty));
+	}
+
+	/**
+	 * Test that deprecated method call with arguments works
+	 *
+	 * @return void
+	 */
+	public function testDeprecatedMethodCallWithArgs()
+	{
+		$this->assertEquals("New method called is OK", $this->handler->oldMethodArgs("OK"));
+	}
+
+	/**
+	 * Test that that access to a private property triggers the deprecated error
+	 *
+	 * @return void
+	 */
+	#[WithoutErrorHandler]
+	public function testPrivatePropertyAccess()
+	{
+		$oldErrorReporting = error_reporting(E_ALL);
+		set_error_handler(static function (int $errno, string $errstr): never {
+			throw new Exception($errstr, $errno);
+		}, E_ALL);
+
+		// Enable E_USER_NOTICE in error_reporting
+		$this->expectExceptionMessage("Undefined property 'privateVarShouldTrigger'");
+		$this->handler->privateVarShouldTrigger;
+
+		$this->expectExceptionMessage("Accessing deprecated property 'privateDeprecated'. Use 'newProperty' instead.");
+		$this->handler->privateDeprecated;
+
+		// Restore error_reporting
+		error_reporting($oldErrorReporting);
+
+		restore_error_handler();
+	}
+
+	/**
+	 * Test that that access to an undefined property generates a notification
+	 *
+	 * @return void
+	 */
+	#[WithoutErrorHandler]
+	public function testUndefinedPropertyAccessDisallowed()
+	{
+		$oldErrorReporting = error_reporting(E_ALL);
+		set_error_handler(static function (int $errno, string $errstr): never {
+			throw new Exception($errstr, $errno);
+		}, E_ALL);
+
+		$this->handler->enableDynamicProperties = false;
+		// Enable E_USER_NOTICE in error_reporting
+		$this->expectExceptionMessage("undefinedProperty");
+		$this->handler->undefinedProperty;
+
+		restore_error_handler();
+
+		// Restore error_reporting
+		error_reporting($oldErrorReporting);
+	}
+
+
+	/**
+	 * Test that that access to an undefined property does not generate a notification
+	 * when allowed
+	 *
+	 * @return void
+	 */
+	#[WithoutErrorHandler]
+	public function testUndefinedPropertyAccess()
+	{
+		$oldErrorReporting = error_reporting(E_ALL);
+		set_error_handler(static function (int $errno, string $errstr): never {
+			throw new Exception($errstr, $errno);
+		}, E_ALL);
+
+		$this->handler->enableDynamicProperties = true;
+		// This does not throw an exception
+		$this->assertEquals(null, $this->handler->undefinedProperty);
+		restore_error_handler();
+
+		// Restore error_reporting
+		error_reporting($oldErrorReporting);
+	}
+
+	/**
+	 * Test that new dynamic property value is accessible
+	 *
+	 * @return void
+	 */
+	public function testDynamicPropertyAccess()
+	{
+		$this->assertEquals(null, $this->dynHandler->dynamicPropertyUndefined);
+
+		$this->dynHandler->dynamicProperty = "TestDynamic";
+		$this->assertEquals("TestDynamic", $this->dynHandler->dynamicProperty);
+	}
+
+
+	/**
+	 * Test that unsetting the dynamic property unsets it
+	 *
+	 * @return void
+	 */
+	public function testDynamicPropertyUnset()
+	{
+		$this->dynHandler->unsetProperty = "TestUnset";
+		unset($this->dynHandler->unsetProperty);
+		$this->assertFalse(isset($this->dynHandler->unsetProperty));
+	}
+}


### PR DESCRIPTION
# NEW: DolDeprecationHandler for deprecations
    
This reusable class avoids needed to implement double assignments while enabling
the detection of the use of deprecated variables and methods.
    
There is no efficiency overhead when the proper variables and methods are used.

Applied on CommonObject class (separate commit).
Fixed PHPUnit testing template as well (separate commit)