### PR TITLE
NEW: Add global STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES to force do not clean empty lines on movement stock

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -611,7 +611,7 @@ class MouvementStock extends CommonObject
 				}
 			}
 
-			if (empty($donotcleanemptylines)) {
+			if (empty($donotcleanemptylines) && !getDolGlobalInt('STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES')) {
 				// If stock is now 0, we can remove entry into llx_product_stock, but only if there is no child lines into llx_product_batch (detail of batch, because we can imagine
 				// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
 				$sql = "DELETE FROM ".$this->db->prefix()."product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM ".$this->db->prefix()."product_batch as pb)";

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1011,8 +1011,10 @@ if (!$variants || getDolGlobalString('VARIANT_ALLOW_STOCK_MOVEMENT_ON_VARIANT_PA
 	$sql .= " FROM ".MAIN_DB_PREFIX."entrepot as e,";
 	$sql .= " ".MAIN_DB_PREFIX."product_stock as ps";
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p ON p.rowid = ps.fk_product";
-	$sql .= " WHERE ps.reel != 0";
-	$sql .= " AND ps.fk_entrepot = e.rowid";
+	$sql .= " WHERE ps.fk_entrepot = e.rowid";
+	if (!getDolGlobalInt('STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES')) {
+		$sql .= " AND ps.reel != 0";
+	}
 	$sql .= " AND e.entity IN (".getEntity('stock').")";
 	$sql .= " AND ps.fk_product = ".((int) $object->id);
 	$sql .= " ORDER BY e.ref";


### PR DESCRIPTION
Add global STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES to force do not clean empty lines on movement stock.

Because customer need to see the warehouse when the product previously even if the stock is at 0.

And when in the reassort page, the product with a stock at 0 don't display and block the repleinishment of the stock of the product.
