### PR TITLE
Fix: Make all 'relative paths' absolute (phpcs config)

### DIFF
--- a/dev/setup/codesniffer/ruleset.xml
+++ b/dev/setup/codesniffer/ruleset.xml
@@ -5,20 +5,20 @@
 	<arg name="tab-width" value="4"/>
 	<arg name="extensions" value="php" />
 
-	<exclude-pattern type="relative">build/html</exclude-pattern>
-	<exclude-pattern type="relative">build/aps</exclude-pattern>
-	<exclude-pattern type="relative">dev/tools/test/namespacemig</exclude-pattern>
-	<!-- <exclude-pattern type="relative">dev/initdata/dbf/includes</exclude-pattern> -->
-	<exclude-pattern type="relative">documents</exclude-pattern>
-	<exclude-pattern type="relative">htdocs/core/class/lessc.class.php</exclude-pattern>
-	<exclude-pattern type="relative">htdocs/custom</exclude-pattern>
-	<exclude-pattern type="relative">htdocs/includes</exclude-pattern>
-	<exclude-pattern type="relative">htdocs/install/doctemplates/websites</exclude-pattern>
-	<exclude-pattern type="relative">htdocs/conf.php</exclude-pattern>
-	<exclude-pattern type="relative">*/nltechno*</exclude-pattern>
-	<exclude-pattern type="relative">source</exclude-pattern>
-	<exclude-pattern type="relative">.git</exclude-pattern>
-	<exclude-pattern type="relative">.cache</exclude-pattern>
+	<!-- info: '*' is replaced with '.*', so better use '+' in some cases -->
+	<!-- info: 'relative' paths are relative to the examined file, so not ok. -->
+	<exclude-pattern>/build/(html|aps)/</exclude-pattern>
+	<exclude-pattern>/dev/tools/test/namespacemig/</exclude-pattern>
+	<!-- <exclude-pattern>dev/initdata/dbf/includes</exclude-pattern> -->
+	<exclude-pattern>/documents/</exclude-pattern>
+	<exclude-pattern>/htdocs/core/class/lessc\.class\.php</exclude-pattern>
+	<exclude-pattern>/htdocs/(custom|includes)/</exclude-pattern>
+	<exclude-pattern>/htdocs/install/doctemplates/websites</exclude-pattern>
+	<exclude-pattern>/htdocs/([^/]+/)?conf\.php</exclude-pattern>
+	<exclude-pattern>*/nltechno*</exclude-pattern>
+	<exclude-pattern>/source/</exclude-pattern>
+	<exclude-pattern>/\.git/</exclude-pattern>
+	<exclude-pattern>/\.cache/</exclude-pattern>
 
 	<!-- List of all tests -->
 


### PR DESCRIPTION
# Fix: #28194 Make all 'relative paths' absolute

The phpcs ruleset xml file's relative exclude patterns are relative to the filename(s) provided on the command line.
Hence with partial verifications, the path exclusion does not function as we would like.
Removing the relative-path attribute from the patterns the exclusion works.
At the same time, the patterns were optimized and a comment was added.

Applied on 17.0 where partial phpcs verification is set up in ci (pre-commit).  Must be merged with all upper versions.