### PR TITLE
Fix lost POST data when redirection after drag'n'drop in agenda 

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -756,7 +756,7 @@ if (empty($reshook) && GETPOST('actionmove', 'alpha') == 'mupdate') {
 
 	$newdate = GETPOST('newdate', 'alpha');
 	if (empty($newdate) || strpos($newdate, 'dayevent_') != 0) {
-		header("Location: ".$backtopage);
+		header("Location: ".$backtopage, true, 307);
 		exit;
 	}
 
@@ -841,7 +841,7 @@ if (empty($reshook) && GETPOST('actionmove', 'alpha') == 'mupdate') {
 		}
 	}
 	if (!empty($backtopage)) {
-		header("Location: ".$backtopage);
+		header("Location: ".$backtopage, true, 307);
 		exit;
 	} else {
 		$action = '';


### PR DESCRIPTION
# Fix
Quand on drag'n'drop un événement dans l'agenda, lors de la redirection, nous perdons les données POST ce qui fait que nous perdons les filtres.
exemple:
avant le drag'n'drop:

![before](https://github.com/Dolibarr/dolibarr/assets/122890855/2ffe91cd-b721-4e44-85f7-838b75122c8b)

après:

![after](https://github.com/Dolibarr/dolibarr/assets/122890855/59c5790e-5d84-4a2f-ad88-4af269b07167)

La modification que je fais permet de garder les paramètres POST lors de la redirection