### PR TITLE
Fix null dir_output

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9055,8 +9055,7 @@ abstract class CommonObject
 		}
 
 		$id = $this->id;
-
-		$dir = $conf->$newmodulepart->dir_output;
+		$dir = $conf->$newmodulepart->dir_output ?? '';
 		if (!empty($this->photo)) {
 			if (dolIsAllowedForPreview($this->photo)) {
 				if ((string) $imagesize == 'mini') {


### PR DESCRIPTION
# Fix null dir_output 
Following warnings on agenda event cards & resource cards :
Undefined property: Conf::$unknown (/var/www/dolibarr/20.0/htdocs/core/class/commonobject.class.php:9058)
Attempt to read property "dir_output" on null (/var/www/dolibarr/20.0/htdocs/core/class/commonobject.class.php:9058)
