### PR TITLE
Fix: Fix var_dump checker

### DIFF
--- a/test/phpunit/CodingPhpTest.php
+++ b/test/phpunit/CodingPhpTest.php
@@ -138,7 +138,7 @@ class CodingPhpTest extends CommonClassTest
 			|| preg_match('/modules\/.*\/doc\/(doc|pdf)_/', $file['relativename'])
 			|| preg_match('/modules\/(import|mailings|printing)\//', $file['relativename'])
 			|| in_array($file['name'], array('modules_boxes.php', 'TraceableDB.php'))) {
-			// Check into Class files
+			// Check Class files
 			if (! in_array($file['name'], array(
 				'api.class.php',
 				'commonobject.class.php',
@@ -152,18 +152,18 @@ class CodingPhpTest extends CommonClassTest
 				// Must not find $db->
 				$ok = true;
 				$matches = array();
-				// Check string $db-> inside a class.php file (it should be $this->db-> into such classes)
+				// Check string $db-> inside a class.php file (it should be $this->db-> in such classes)
 				preg_match_all('/'.preg_quote('$db->', '/').'/', $filecontent, $matches, PREG_SET_ORDER);
 				foreach ($matches as $key => $val) {
 					$ok = false;
 					break;
 				}
 				//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
-				$this->assertTrue($ok, 'Found string $db-> into a .class.php file in '.$file['relativename'].'. Inside a .class file, you should use $this->db-> instead.');
+				$this->assertTrue($ok, 'Found string $db-> in a .class.php file in '.$file['relativename'].'. Inside a .class file, you should use $this->db-> instead.');
 				//exit;
 			}
 
-			if (preg_match('/\.class\.php/', $file['relativename']) && ! in_array($file['relativename'], array(
+			if (preg_match('/\.class\.php$/', $file['relativename']) && ! in_array($file['relativename'], array(
 				'adherents/canvas/actions_adherentcard_common.class.php',
 				'contact/canvas/actions_contactcard_common.class.php',
 				'compta/facture/class/facture.class.php',
@@ -191,7 +191,7 @@ class CodingPhpTest extends CommonClassTest
 				// Must not find GETPOST
 				$ok = true;
 				$matches = array();
-				// Check string GETPOSTFLOAT a class.php file (should not be found into classes)
+				// Check string GETPOSTFLOAT a class.php file (should not be found in classes)
 				preg_match_all('/GETPOST\(["\'](....)/', $filecontent, $matches, PREG_SET_ORDER);
 				foreach ($matches as $key => $val) {
 					if (in_array($val[1], array('lang', 'forc', 'mass', 'conf'))) {
@@ -201,11 +201,10 @@ class CodingPhpTest extends CommonClassTest
 					$ok = false;
 					break;
 				}
-				//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
-				$this->assertTrue($ok, 'Found string GETPOST into a .class.php file in '.$file['relativename'].'.');
+				$this->assertTrue($ok, 'Found string GETPOST in a .class.php file in '.$file['relativename'].'.');
 			}
 		} else {
-			// Check into Include files
+			// Check Include files
 			if (! in_array($file['name'], array(
 				'objectline_view.tpl.php',
 				'extrafieldsinexport.inc.php',
@@ -216,7 +215,7 @@ class CodingPhpTest extends CommonClassTest
 				// Must not found $this->db->
 				$ok = true;
 				$matches = array();
-				// Check string $this->db-> into a non class.php file (it should be $db-> into such classes)
+				// Check string $this->db-> in a non class.php file (it should be $db-> in such classes)
 				preg_match_all('/'.preg_quote('$this->db->', '/').'/', $filecontent, $matches, PREG_SET_ORDER);
 				foreach ($matches as $key => $val) {
 					$ok = false;
@@ -228,9 +227,9 @@ class CodingPhpTest extends CommonClassTest
 			}
 		}
 
-		// Check we don't miss top_httphead() into any ajax pages
+		// Check we don't miss top_httphead() in any ajax pages
 		if (preg_match('/ajax\//', $file['relativename'])) {
-			print "Analyze ajax page ".$file['relativename']."\n";
+			//print "Analyze ajax page ".$file['relativename']."\n";
 			$ok = true;
 			$matches = array();
 			preg_match_all('/top_httphead/', $filecontent, $matches, PREG_SET_ORDER);
@@ -238,28 +237,27 @@ class CodingPhpTest extends CommonClassTest
 				$ok = false;
 			}
 			//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
-			$this->assertTrue($ok, 'Did not find top_httphead into the ajax page '.$file['relativename']);
+			$this->assertTrue($ok, 'Did not find top_httphead in the ajax page '.$file['relativename']);
 			//exit;
 		}
 
 		// Check if a var_dump has been forgotten
 		if (!preg_match('/test\/phpunit/', $file['fullname'])) {
-			if (! in_array($file['name'], array('class.nusoap_base.php'))) {
-				$ok = true;
-				$matches = array();
-				preg_match_all('/(.)\s*var_dump\(/', $filecontent, $matches, PREG_SET_ORDER);
-				//var_dump($matches);
-				foreach ($matches as $key => $val) {
-					if ($val[1] != '/' && $val[1] != '*') {
-						$ok = false;
-						break;
-					}
+			$ok = true;
+			$matches = array();
+			preg_match_all('/(^|\S)[ \t]*?var_dump\(/m', $filecontent, $matches, PREG_SET_ORDER);
+			$failing_string = "";
+			//var_dump($matches);
+			foreach ($matches as $key => $val) {
+				if ($val[1] != '/' && $val[1] != '*') {
+					$ok = false;
+					$failing_string = $val[0];
 					break;
 				}
-				//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
-				$this->assertTrue($ok, 'Found string var_dump that is not just after /* or // in '.$file['relativename']);
-				//exit;
 			}
+			//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
+			$this->assertTrue($ok, 'Found string var_dump that is not just after /* or // in htdocs/'.$file['relativename'].": $failing_string");
+			//exit;
 		}
 
 		// Check get_class followed by __METHOD__
@@ -311,7 +309,7 @@ class CodingPhpTest extends CommonClassTest
 			break;
 		}
 		//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
-		$this->assertTrue($ok, 'Found non quoted or not casted var into sql request '.$file['relativename'].' - Bad.');
+		$this->assertTrue($ok, 'Found non quoted or not casted var in sql request '.$file['relativename'].' - Bad.');
 		//exit;
 
 		// Check that forged sql string is using ' instead of " as string PHP quotes
@@ -327,7 +325,7 @@ class CodingPhpTest extends CommonClassTest
 			//if ($reg[0] != 'db') $ok=false;
 		}
 		//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
-		$this->assertTrue($ok, 'Found a forged SQL string that mix on same line the use of \' for PHP string and PHP variables into file '.$file['relativename'].' Use " to forge PHP string like this: $sql = "SELECT ".$myvar...');
+		$this->assertTrue($ok, 'Found a forged SQL string that mix on same line the use of \' for PHP string and PHP variables in file '.$file['relativename'].' Use " to forge PHP string like this: $sql = "SELECT ".$myvar...');
 		//exit;
 
 		// Check that forged sql string is using ' instead of " as string PHP quotes
@@ -339,7 +337,7 @@ class CodingPhpTest extends CommonClassTest
 			$ok = false;
 			break;
 		}
-		$this->assertTrue($ok, 'Found a forged SQL string that mix on same line the use of \' for PHP string and PHP variables into file '.$file['relativename'].' Use " to forge PHP string like this: $sql = "SELECT ".$myvar...');
+		$this->assertTrue($ok, 'Found a forged SQL string that mix on same line the use of \' for PHP string and PHP variables in file '.$file['relativename'].' Use " to forge PHP string like this: $sql = "SELECT ".$myvar...');
 
 		// Check sql string VALUES ... , ".$xxx
 		//  with xxx that is not 'db-' (for $db->escape). It means we forget a ' if string, or an (int) if int, when forging sql request.
@@ -358,7 +356,7 @@ class CodingPhpTest extends CommonClassTest
 			break;
 		}
 		//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
-		$this->assertTrue($ok, 'Found non quoted or not casted var into sql request '.$file['relativename'].' - Bad.');
+		$this->assertTrue($ok, 'Found non quoted or not casted var in sql request '.$file['relativename'].' - Bad.');
 		//exit;
 
 		// Check '".$xxx non escaped
@@ -514,7 +512,7 @@ class CodingPhpTest extends CommonClassTest
 				break;
 			}
 		}
-		$this->assertTrue($ok, 'Found a forbidden string sequence into '.$file['relativename'].' : name="token" value="\'.$_SESSION[..., you must use a newToken() instead of $_SESSION[\'newtoken\'].');
+		$this->assertTrue($ok, 'Found a forbidden string sequence in '.$file['relativename'].' : name="token" value="\'.$_SESSION[..., you must use a newToken() instead of $_SESSION[\'newtoken\'].');
 
 
 		// Test we don't have preg_grep with a param without preg_quote
@@ -589,7 +587,7 @@ class CodingPhpTest extends CommonClassTest
 			$ok = false;
 			break;
 		}
-		$this->assertTrue($ok, 'Found a CURDATE\(\) into code. Do not use this SQL method in file '.$file['relativename'].'. You must use the PHP function dol_now() instead.');
+		$this->assertTrue($ok, 'Found a CURDATE\(\) in code. Do not use this SQL method in file '.$file['relativename'].'. You must use the PHP function dol_now() instead.');
 	}
 
 


### PR DESCRIPTION
# Fix: Fix var_dump checker
   
The core issue was that in PHP whitespace includes newlines by default, the m modifier
is needed to not match multilines.

# Discussion:
On windows the test found a file with an unauthorized var_dump.  Turns out that this was due the file filter not working because the separator is \ on windows and / is being matched.

I update the test, but the real question is: do the functions in files.lib.php need to be updated knowing that in php the '/' eventually convert to the system's directory separator when accessing files (I did not formally check that that is true, but I suppose it is).
I also notice that the $path in dol_dir_list is cleaned, but it supposes that it's a unix-like path.

To ensure that the regexes work, there should also be some files inside a test related directory where the tests can find positive matches.  The test should then exclude the match from the errors, but increment a counter for the false matches to be certain that the expected count of false matches was found.