### PR TITLE
qual: phpstan for htdocs/compta/bank/class/account.class.php

### DIFF
--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -199,9 +199,9 @@ class Account extends CommonObject
 	public $type_lib = array();
 
 	/**
-	 * Variable containing all account statuses with their respective translated label.
+	 * Array listing all the potential status of an account.
 	 * Defined in __construct
-	 * @var array
+	 * @var array<int, string>		array: int of the status => translated label of the status
 	 */
 	public $status = array();
 
@@ -796,7 +796,7 @@ class Account extends CommonObject
 				$accline = new AccountLine($this->db);
 				$accline->datec = $now;
 				$accline->label = '('.$langs->trans("InitialBankBalance").')';
-				$accline->amount = price2num($balance);
+				$accline->amount = (float) price2num($balance);
 				$accline->fk_user_author = $user->id;
 				$accline->fk_account = $this->id;
 				$accline->datev = $this->date_solde;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -321,9 +321,9 @@ abstract class CommonObject
 
 	/**
 	 * @var int|array<int, string>      The object's status (an int).
-  	 *                                  Or an array listing all the potential status of the object:
+	 *                                  Or an array listing all the potential status of the object:
 	 *                                    array: int of the status => translated label of the status
-  	 *                                    See for example the Account class.
+	 *                                    See for example the Account class.
 	 * @see setStatut()
 	 */
 	public $status;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -320,7 +320,10 @@ abstract class CommonObject
 	public $statut;
 
 	/**
-	 * @var int 		The object's status
+	 * @var int|array<int, string>      The object's status (an int).
+  	 *                                  Or an array listing all the potential status of the object:
+	 *                                    array: int of the status => translated label of the status
+  	 *                                    See for example the Account class.
 	 * @see setStatut()
 	 */
 	public $status;


### PR DESCRIPTION
htdocs/compta/bank/class/account.class.php	206	PHPDoc type array of property Account::$status is not covariant with PHPDoc type int of overridden property CommonObject::$status.

htdocs/compta/bank/class/account.class.php	799	Property AccountLine::$amount (float) does not accept string.