### PR TITLE
qual: phpstan for htdocs/core/modules/barcode/modules_barcode.class.php

### DIFF
--- a/htdocs/core/modules/barcode/modules_barcode.class.php
+++ b/htdocs/core/modules/barcode/modules_barcode.class.php
@@ -53,14 +53,9 @@ abstract class ModeleBarCode
  */
 abstract class ModeleNumRefBarCode extends CommonNumRefGenerator
 {
-	/**
-	 * @var int Code facultatif
-	 */
-	public $code_null;
 
-	/**
-	 * @var int Automatic numbering
-	 */
+	// variables inherited from CoomonNumRefGenerator
+	public $code_null;
 	public $code_auto;
 
 

--- a/htdocs/core/modules/barcode/modules_barcode.class.php
+++ b/htdocs/core/modules/barcode/modules_barcode.class.php
@@ -54,7 +54,7 @@ abstract class ModeleBarCode
 abstract class ModeleNumRefBarCode extends CommonNumRefGenerator
 {
 
-	// variables inherited from CoomonNumRefGenerator
+	// variables inherited from CommonNumRefGenerator
 	public $code_null;
 	public $code_auto;
 


### PR DESCRIPTION
htdocs/core/modules/barcode/modules_barcode.class.php	59	PHPDoc type int of property ModeleNumRefBarCode::$code_null is not covariant with PHPDoc type int<0, 1> of overridden property CommonNumRefGenerator::$code_null.

htdocs/core/modules/barcode/modules_barcode.class.php	64	PHPDoc type int of property ModeleNumRefBarCode::$code_auto is not covariant with PHPDoc type int<0, 1> of overridden property CommonNumRefGenerator::$code_auto.