### PR TITLE
qual: phspstan for htdocs/core/modules/syslog/mod_syslog_syslog.php

### DIFF
--- a/htdocs/core/modules/syslog/mod_syslog_syslog.php
+++ b/htdocs/core/modules/syslog/mod_syslog_syslog.php
@@ -52,10 +52,10 @@ class mod_syslog_syslog extends LogHandler implements LogHandlerInterface
 
 		// This function does not exists on some ISP (Ex: Free in France)
 		if (!function_exists('openlog')) {
-			return 0;
+			return false;
 		}
 
-		return !getDolGlobalString('SYSLOG_DISABLE_LOGHANDLER_SYSLOG') ? 1 : 0; // Set SYSLOG_DISABLE_LOGHANDLER_SYSLOG to 1 to disable this loghandler
+		return !getDolGlobalString('SYSLOG_DISABLE_LOGHANDLER_SYSLOG') ? true : false; // Set SYSLOG_DISABLE_LOGHANDLER_SYSLOG to 1 to disable this loghandler
 	}
 
 	/**


### PR DESCRIPTION
htdocs/core/modules/syslog/mod_syslog_syslog.php	49	Return type (int) of method mod_syslog_syslog::isActive() should be compatible with return type (bool) of method LogHandler::isActive()

htdocs/core/modules/syslog/mod_syslog_syslog.php	49	Return type (int) of method mod_syslog_syslog::isActive() should be compatible with return type (bool) of method LogHandlerInterface::isActive()