### PR TITLE
qual: phpstan for htdocs/cron/class/cronjob.class.php

### DIFF
--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -941,7 +941,7 @@ class Cronjob extends CommonObject
 		$this->id = 0;
 		$this->ref = '';
 		$this->entity = 0;
-		$this->tms = '';
+		$this->tms = dol_now();
 		$this->datec = '';
 		$this->label = '';
 		$this->jobtype = '';


### PR DESCRIPTION
htdocs/cron/class/cronjob.class.php	944	Property CommonObject::$tms (int) does not accept string.