### PR TITLE
FIX 28251 Fixing subpermission name in api_multicurrencies.class.php

### DIFF
--- a/htdocs/multicurrency/class/api_multicurrencies.class.php
+++ b/htdocs/multicurrency/class/api_multicurrencies.class.php
@@ -196,7 +196,7 @@ class MultiCurrencies extends DolibarrApi
 	 */
 	public function post($request_data = null)
 	{
-		if (!DolibarrApiAccess::$user->rights->multicurrency->currency->create) {
+		if (!DolibarrApiAccess::$user->rights->multicurrency->currency->write) {
 			throw new RestException(401, "Insufficient rights to create currency");
 		}
 
@@ -240,7 +240,7 @@ class MultiCurrencies extends DolibarrApi
 	 */
 	public function put($id, $request_data = null)
 	{
-		if (!DolibarrApiAccess::$user->rights->multicurrency->currency->create) {
+		if (!DolibarrApiAccess::$user->rights->multicurrency->currency->write) {
 			throw new RestException(401, "Insufficient rights to update currency");
 		}
 
@@ -307,7 +307,7 @@ class MultiCurrencies extends DolibarrApi
 	 */
 	public function updateRate($id, $request_data = null)
 	{
-		if (!DolibarrApiAccess::$user->rights->multicurrency->currency->create) {
+		if (!DolibarrApiAccess::$user->rights->multicurrency->currency->write) {
 			throw new RestException(401, "Insufficient rights to update currency rate");
 		}
 


### PR DESCRIPTION
# FIX|Fix #28251 Multicurrency API does not consider user's write permission

I checked the subpermissions names on table rights_def for module multicurrency and it seems to me the correct one is 'write' and not 'create'. So I changed it in api_multicurrencies.class.php and it worked.

I'm open to discuss the solution should you have any comment.

Kind regards

Ilidio