### PR TITLE
Qual: Optimisation in load criteria (dol_dir_list)

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -87,9 +87,9 @@ function dol_dir_list($utf8_path, $types = "all", $recursive = 0, $filter = "", 
 		}
 	}
 
-	$loaddate = ($mode == 1 || $mode == 2 || $nbsecondsold != 0);
-	$loadsize = ($mode == 1 || $mode == 3);
-	$loadperm = ($mode == 1 || $mode == 4);
+	$loaddate = ($mode == 1 || $mode == 2 || $nbsecondsold != 0 || $sortcriteria == 'date');
+	$loadsize = ($mode == 1 || $mode == 3 || $sortcriteria == 'size');
+	$loadperm = ($mode == 1 || $mode == 4 || $sortcriteria == 'perm');
 
 	// Clean parameters
 	$utf8_path = preg_replace('/([\\/]+)$/', '', $utf8_path);


### PR DESCRIPTION
# Qual: Optimisation in load criteria (dol_dir_list)

By moving the "$sortcriteria" conditions into the load conditions, the comparison between strings is less frequent.

The original test can probably even be removed as it is part of load_*.

The only side-effect that I can see is with the hook, but I think in theory there should not be a negative side-effect, only a positive one as this tells the hook to load the data we need without relying on the hook to make the proper interpretation of the searchcriteria.