### PR TITLE
qual: phpstan for htdocs/comm/propal/card.php

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -444,7 +444,7 @@ if (empty($reshook)) {
 					$object->warehouse_id = GETPOSTINT('warehouse_id');
 					$object->duree_validite = $duration;
 					$object->cond_reglement_id = GETPOSTINT('cond_reglement_id');
-					$object->deposit_percent = GETPOST('cond_reglement_id_deposit_percent', 'alpha');
+					$object->deposit_percent = GETPOSTFLOAT('cond_reglement_id_deposit_percent');
 					$object->mode_reglement_id = GETPOSTINT('mode_reglement_id');
 					$object->fk_account = GETPOSTINT('fk_account');
 					$object->socid = GETPOSTINT('socid');
@@ -475,7 +475,7 @@ if (empty($reshook)) {
 				$object->warehouse_id = GETPOSTINT('warehouse_id');
 				$object->duree_validite = price2num(GETPOST('duree_validite', 'alpha'));
 				$object->cond_reglement_id = GETPOSTINT('cond_reglement_id');
-				$object->deposit_percent = GETPOST('cond_reglement_id_deposit_percent', 'alpha');
+				$object->deposit_percent = GETPOSTFLOAT('cond_reglement_id_deposit_percent');
 				$object->mode_reglement_id = GETPOSTINT('mode_reglement_id');
 				$object->fk_account = GETPOSTINT('fk_account');
 				$object->contact_id = GETPOSTINT('contactid');

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1230,7 +1230,7 @@ class Commande extends CommonOrder
 			if ($objsoc->fetch($socid) > 0) {
 				$this->socid = $objsoc->id;
 				$this->cond_reglement_id	= (!empty($objsoc->cond_reglement_id) ? $objsoc->cond_reglement_id : 0);
-				$this->deposit_percent		= (!empty($objsoc->deposit_percent) ? $objsoc->deposit_percent : null);
+				$this->deposit_percent		= (!empty($objsoc->deposit_percent) ? $objsoc->deposit_percent : 0);
 				$this->mode_reglement_id	= (!empty($objsoc->mode_reglement_id) ? $objsoc->mode_reglement_id : 0);
 				$this->fk_project = 0;
 				$this->fk_delivery_address = 0;

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -145,8 +145,8 @@ class Commande extends CommonOrder
 	public $cond_reglement_doc;
 
 	/**
-	 * @var string 	Deposit percent for payment terms.
-	 *				Populated by setPaymentTerms().
+	 * @var float 	Deposit percent for payment terms.
+	 *				Populated by $CommonObject->setPaymentTerms().
 	 * @see setPaymentTerms()
 	 */
 	public $deposit_percent;


### PR DESCRIPTION
htdocs/comm/propal/card.php	447	Property Propal::$deposit_percent (float) does not accept array|string.

htdocs/comm/propal/card.php	478	Property Propal::$deposit_percent (float) does not accept array|string.

htdocs/commande/card.php	297	Property Commande::$deposit_percent (string) does not accept float.

htdocs/commande/class/commande.class.php	152	PHPDoc type string of property Commande::$deposit_percent is not covariant with PHPDoc type float of overridden property CommonObject::$deposit_percent.

htdocs/commande/class/commande.class.php	1233	Property Commande::$deposit_percent (string) does not accept float|null.