### PR TITLE
FIX 16.0 - parent company gets emptied when updating a third party from the card in edit mode

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -453,7 +453,7 @@ if (empty($reshook)) {
 			}
 			$object->entity					= (GETPOSTISSET('entity') ? GETPOST('entity', 'int') : $conf->entity);
 			$object->name_alias				= GETPOST('name_alias', 'alphanohtml');
-			$object->parent					= GETPOST('parent_company_id', 'int');
+			$object->parent					= GETPOSTISSET('parent_company_id') ? GETPOST('parent_company_id', 'int') : $object->parent;
 			$object->address				= GETPOST('address', 'alphanohtml');
 			$object->zip					= GETPOST('zipcode', 'alphanohtml');
 			$object->town					= GETPOST('town', 'alphanohtml');


### PR DESCRIPTION
# FIX 16.0 parent company empty after editing a third party card

### Reproducing in Dolibarr 16

1. Create two third parties named A and B
2. Set A as the parent company of B
3. Go to third party card for B, edit (button "Modify"), change nothing, save

**Expected**: B still has a parent company (A)
**Actual**: B no longer has a parent company

This is because in v16.0, in edit mode, there is no form input for the parent company, but the field is still set using `GETPOST('parent_company_id', 'int')`.

In v17, there is a form input for the parent company in edit mode, which fixes the bug. However, backporting this in v16 would arguably be a new feature.