### PR TITLE
Qual: Improve test messages to help locate errors + php-cs-fixer on tests

### DIFF
--- a/dev/tools/codespell/codespell-lines-ignore.txt
+++ b/dev/tools/codespell/codespell-lines-ignore.txt
@@ -152,8 +152,8 @@
 		$sql = "SELECT p.rowid, p.fk_statut as status, p.fk_opp_status, p.datee as datee";
 		$sql = "SELECT rowid, entity, datea, url, label, objecttype, objectid FROM ".$this->db->prefix()."links";
 		$sql = 'SELECT c.rowid, date_creation as datec, tms as datem, date_valid as date_validation, date_approve as datea, date_approve2 as datea2,';
+		$test = "<IMG SRC=\"jav&#x0D;ascript:alert('XSS');\">";	// Same
 		$test = '/javas:cript/google.com';
-		$test="<IMG SRC=\"jav&#x0D;ascript:alert('XSS');\">";	// Same
 		$this->periode = $this->date_creation + 3600 * 24 * 30;
 		$title = $langs->trans('Product')." ".$shortlabel." - ".$langs->trans('Referers');
 		$title = $langs->trans('Service')." ".$shortlabel." - ".$langs->trans('Referers');

--- a/test/phpunit/AccountingAccountTest.php
+++ b/test/phpunit/AccountingAccountTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -75,12 +75,12 @@ class AccountingAccountTest extends CommonClassTest
 	public function testAccountingAccountCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new AccountingAccount($db);
+		$localobject = new AccountingAccount($db);
 		$localobject->fk_pcg_version = 'PCG99-ABREGE';
 		$localobject->account_category = 0;
 		$localobject->pcg_type = 'XXXXX';
@@ -89,7 +89,7 @@ class AccountingAccountTest extends CommonClassTest
 		$localobject->account_parent = 0;
 		$localobject->label = 'Account specimen';
 		$localobject->active = 0;
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -109,13 +109,13 @@ class AccountingAccountTest extends CommonClassTest
 	public function testAccountingAccountFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new AccountingAccount($db);
-		$result=$localobject->fetch($id);
+		$localobject = new AccountingAccount($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -135,13 +135,13 @@ class AccountingAccountTest extends CommonClassTest
 	public function testAccountingAccountUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->label='New label';
-		$result=$localobject->update($user);
+		$localobject->label = 'New label';
+		$result = $localobject->update($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -161,14 +161,14 @@ class AccountingAccountTest extends CommonClassTest
 	public function testAccountingAccountDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new AccountingAccount($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new AccountingAccount($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/ActionCommTest.php
+++ b/test/phpunit/ActionCommTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -75,14 +75,14 @@ class ActionCommTest extends CommonClassTest
 	public function testActionCommCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$now = dol_now();
 
-		$localobject=new ActionComm($db);
+		$localobject = new ActionComm($db);
 
 		$localobject->type_code   = 'AC_OTH_AUTO';		// Type of event ('AC_OTH', 'AC_OTH_AUTO', 'AC_XXX'...)
 		$localobject->code        = 'AC_PHPUNITTEST';
@@ -128,13 +128,13 @@ class ActionCommTest extends CommonClassTest
 	public function testActionCommFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new ActionComm($db);
-		$result=$localobject->fetch($id);
+		$localobject = new ActionComm($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -153,13 +153,13 @@ class ActionCommTest extends CommonClassTest
 	public function testActionCommUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->label='New label';
-		$result=$localobject->update($user);
+		$localobject->label = 'New label';
+		$result = $localobject->update($user);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -178,14 +178,14 @@ class ActionCommTest extends CommonClassTest
 	public function testActionCommDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new ActionComm($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new ActionComm($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/AdherentTest.php
+++ b/test/phpunit/AdherentTest.php
@@ -38,7 +38,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -85,19 +85,19 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentTypeCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new AdherentType($db);
-		$localobject->statut=1;
-		$localobject->label='Adherent type test';
-		$localobject->subscription=1;
-		$localobject->amount=0;
-		$localobject->vote=1;
-		$localobject->company='Old company label';
-		$result=$localobject->create($user);
+		$localobject = new AdherentType($db);
+		$localobject->statut = 1;
+		$localobject->label = 'Adherent type test';
+		$localobject->subscription = 1;
+		$localobject->amount = 0;
+		$localobject->vote = 1;
+		$localobject->company = 'Old company label';
+		$result = $localobject->create($user);
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -116,15 +116,15 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentCreate($fk_adherent_type)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Adherent($db);
+		$localobject = new Adherent($db);
 		$localobject->initAsSpecimen();
-		$localobject->typeid=$fk_adherent_type;
-		$result=$localobject->create($user);
+		$localobject->typeid = $fk_adherent_type;
+		$result = $localobject->create($user);
 		print __METHOD__." result=".$result."\n";
 		if ($result < 0) {
 			print $localobject->error;
@@ -146,13 +146,13 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Adherent($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Adherent($db);
+		$result = $localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 		return $localobject;
@@ -170,10 +170,10 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentFetchLogin(Adherent $localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$newobject = new Adherent($db);
 		$result = $newobject->fetch_login($localobject->login);
@@ -195,44 +195,44 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentUpdate(Adherent $localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$timestamp = dol_now();
 
 		$localobject->civility_id = 0;
-		$localobject->login='newlogin';
-		$localobject->company='New company label';
-		$localobject->note_public='New note public after update';
-		$localobject->note_private='New note private after update';
-		$localobject->lastname='New name';
-		$localobject->firstname='New firstname';
-		$localobject->gender='man';
-		$localobject->address='New address';
-		$localobject->zip='New zip';
-		$localobject->town='New town';
-		$localobject->country_id=2;
-		$localobject->statut=0;
-		$localobject->morphy=0;
-		$localobject->phone='New tel pro';
-		$localobject->phone_perso='New tel perso';
-		$localobject->phone_mobile='New tel mobile';
-		$localobject->email='newemail@newemail.com';
-		$localobject->birth=$timestamp;
-		$result=$localobject->update($user);
+		$localobject->login = 'newlogin';
+		$localobject->company = 'New company label';
+		$localobject->note_public = 'New note public after update';
+		$localobject->note_private = 'New note private after update';
+		$localobject->lastname = 'New name';
+		$localobject->firstname = 'New firstname';
+		$localobject->gender = 'man';
+		$localobject->address = 'New address';
+		$localobject->zip = 'New zip';
+		$localobject->town = 'New town';
+		$localobject->country_id = 2;
+		$localobject->statut = 0;
+		$localobject->morphy = 0;
+		$localobject->phone = 'New tel pro';
+		$localobject->phone_perso = 'New tel perso';
+		$localobject->phone_mobile = 'New tel mobile';
+		$localobject->email = 'newemail@newemail.com';
+		$localobject->birth = $timestamp;
+		$result = $localobject->update($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
-		$result=$localobject->update_note($localobject->note_private, '_private');
+		$result = $localobject->update_note($localobject->note_private, '_private');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
-		$result=$localobject->update_note($localobject->note_public, '_public');
+		$result = $localobject->update_note($localobject->note_public, '_public');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
-		$newobject=new Adherent($db);
-		$result=$newobject->fetch($localobject->id);
+		$newobject = new Adherent($db);
+		$result = $newobject->fetch($localobject->id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -274,10 +274,10 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentMakeSubstitution(Adherent $localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$conf->global->MAIN_FIRSTNAME_NAME_POSITION = 0;	// Force setup for firstname+lastname
 
@@ -308,10 +308,10 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentSetUserId(Adherent $localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		//We associate member with user
 		$result = $localobject->setUserId($user->id);
@@ -350,10 +350,10 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentSetThirdPartyId(Adherent $localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		//Create a Third Party
 		$thirdparty = new Societe($db);
@@ -399,12 +399,12 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentValidate(Adherent $localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->validate($user);
+		$result = $localobject->validate($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -423,10 +423,10 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentOther(Adherent $localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -452,10 +452,10 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentResiliate(Adherent $localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		//Let's resilie un adherent
 		$result = $localobject->resiliate($user);
@@ -489,12 +489,12 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentDelete($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->delete($localobject->id, $user);
+		$result = $localobject->delete($localobject->id, $user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -514,14 +514,14 @@ class AdherentTest extends CommonClassTest
 	public function testAdherentTypeDelete($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobjectat=new AdherentType($db);
-		$result=$localobjectat->fetch($localobject->typeid);
-		$result=$localobjectat->delete($user);
+		$localobjectat = new AdherentType($db);
+		$result = $localobjectat->fetch($localobject->typeid);
+		$result = $localobjectat->delete($user);
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 

--- a/test/phpunit/AdminLibTest.php
+++ b/test/phpunit/AdminLibTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -59,21 +59,21 @@ class AdminLibTest extends CommonClassTest
 	public function testVersionCompare()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=versioncompare(array(3,1,-4), array(3,1,1));
+		$result = versioncompare(array(3,1,-4), array(3,1,1));
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(-3, $result);
-		$result=versioncompare(array(3,1,0), array(3,1,1));
+		$result = versioncompare(array(3,1,0), array(3,1,1));
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(-3, $result);
-		$result=versioncompare(array(3,1,0), array(3,2,0));
+		$result = versioncompare(array(3,1,0), array(3,2,0));
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(-2, $result);
-		$result=versioncompare(array(3,1,0), array(3,1,0));
+		$result = versioncompare(array(3,1,0), array(3,1,0));
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(0, $result);
 
@@ -91,7 +91,7 @@ class AdminLibTest extends CommonClassTest
 
 		require_once dirname(__FILE__).'/../../htdocs/core/modules/modExpenseReport.class.php';
 		print "Enable module modExpenseReport";
-		$moduledescriptor=new modExpenseReport($db);
+		$moduledescriptor = new modExpenseReport($db);
 
 		$result = $moduledescriptor->remove();
 
@@ -102,7 +102,7 @@ class AdminLibTest extends CommonClassTest
 
 		require_once dirname(__FILE__).'/../../htdocs/core/modules/modApi.class.php';
 		print "Enable module modAPI";
-		$moduledescriptor=new modApi($db);
+		$moduledescriptor = new modApi($db);
 
 		$result = $moduledescriptor->remove();
 

--- a/test/phpunit/AllTests.php
+++ b/test/phpunit/AllTests.php
@@ -53,8 +53,8 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
-$conf->global->MAIN_UMASK='666';
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+$conf->global->MAIN_UMASK = '666';
 
 
 /**

--- a/test/phpunit/AssetModelTest.php
+++ b/test/phpunit/AssetModelTest.php
@@ -85,13 +85,13 @@ class AssetModelTest extends CommonClassTest
 	public function testAssetModelFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new AssetModel($db);
-		$result=$localobject->fetch($id);
+		$localobject = new AssetModel($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -114,7 +114,7 @@ class AssetModelTest extends CommonClassTest
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		$localobject->note_private='New note private after update';
+		$localobject->note_private = 'New note private after update';
 		$result = $localobject->update($user);
 
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/BOMTest.php
+++ b/test/phpunit/BOMTest.php
@@ -35,7 +35,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 $langs->load("main");
 
@@ -57,14 +57,14 @@ class BOMTest extends CommonClassTest
 	public function testBOMCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new BOM($db);
+		$localobject = new BOM($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -84,14 +84,14 @@ class BOMTest extends CommonClassTest
 	public function testBOMDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new BOM($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new BOM($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/BankAccountTest.php
+++ b/test/phpunit/BankAccountTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 $langs->load("main");
 
@@ -59,15 +59,15 @@ class BankAccountTest extends CommonClassTest
 	public function testBankAccountCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$localobject = new Account($db);
 		$localobject->initAsSpecimen();
 		$localobject->date_solde = dol_now();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -87,13 +87,13 @@ class BankAccountTest extends CommonClassTest
 	public function testBankAccountFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Account($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Account($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -113,10 +113,10 @@ class BankAccountTest extends CommonClassTest
 	public function testBankAccountOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -135,7 +135,7 @@ class BankAccountTest extends CommonClassTest
 		$this->assertTrue($result);
 
 		// Test checkIbanForAccount for CI account
-		$localobject2=new Account($db);
+		$localobject2 = new Account($db);
 		$localobject2->country = 'CI';
 		$localobject2->iban = 'CI77A12312341234123412341234';
 		$result = checkIbanForAccount($localobject2);
@@ -157,14 +157,14 @@ class BankAccountTest extends CommonClassTest
 	public function testBankAccountDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Account($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Account($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/BarcodeTest.php
+++ b/test/phpunit/BarcodeTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 $langs->load("main");
 
@@ -58,10 +58,10 @@ class BarcodeTest extends CommonClassTest
 	public function testBarcodeZATCAEncode()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$company = new Societe($db);
 		$company->name = 'Specimen company';
@@ -92,10 +92,10 @@ class BarcodeTest extends CommonClassTest
 	public function testBarcodeZATCADecode()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		//$string_zatca_base64 = "AQZSYWZlZXECDTEyMzQ1Njc4OVQxMjUDFDIwMjEtMDctMTJUMTQ6MjU6MDlaBAM3ODYFAjI1";
 		$string_zatca_base64 = "ARBTcGVjaW1lbiBjb21wYW55AgkxMjM0NTY3ODkDFDIwMjAtMDEtMDFUMDk6MzQ6NTZaBAMxMjAFAjIw";

--- a/test/phpunit/BonPrelevementTest.php
+++ b/test/phpunit/BonPrelevementTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 $langs->load("main");
 
@@ -58,10 +58,10 @@ class BonPrelevementTest extends CommonClassTest
 	public function testBonPrelevementCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// TODO
 		// Create invoice
@@ -74,9 +74,9 @@ class BonPrelevementTest extends CommonClassTest
 
 
 		// Create withdraw record and generate SEPA file
-		$localobject=new BonPrelevement($db);
+		$localobject = new BonPrelevement($db);
 		//$localobject->date_solde=dol_now();
-		$result=$localobject->Create(0, 0, 'simu');
+		$result = $localobject->Create(0, 0, 'simu');
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 0);

--- a/test/phpunit/BuildDocTest.php
+++ b/test/phpunit/BuildDocTest.php
@@ -66,7 +66,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -132,19 +132,19 @@ class BuildDocTest extends CommonClassTest
 	public function testFactureBuild()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$conf->facture->dir_output.='/temp';
+		$conf->facture->dir_output .= '/temp';
 
-		$localobjectcom=new Commande($db);
+		$localobjectcom = new Commande($db);
 		$localobjectcom->initAsSpecimen();
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->createFromOrder($localobjectcom, $user);
-		$localobject->date_lim_reglement = dol_now() + 3600 * 24 *30;
+		$localobject->date_lim_reglement = dol_now() + 3600 * 24 * 30;
 		$localobject->status = Facture::STATUS_DRAFT;
 
 		// To be sure we are not using the Swiss QR Code addition
@@ -155,7 +155,7 @@ class BuildDocTest extends CommonClassTest
 		$conf->global->MAIN_DISABLE_TCPDI = 1;
 
 		// Crabe (english)
-		$localobject->model_pdf='crabe';
+		$localobject->model_pdf = 'crabe';
 		$result = $localobject->generateDocument($localobject->model_pdf, $langs);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result." for generation from crabe\n";
@@ -164,55 +164,55 @@ class BuildDocTest extends CommonClassTest
 		$conf->global->MAIN_DISABLE_TCPDI = 0;
 
 		// Crabe (english)
-		$localobject->model_pdf='crabe';
+		$localobject->model_pdf = 'crabe';
 		$result = $localobject->generateDocument($localobject->model_pdf, $langs);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result." for generation from crabe with MAIN_DISABLE_TCPDI and a watermark\n";
 
 		// Crabe (japanese)
-		$newlangs1=new Translate("", $conf);
+		$newlangs1 = new Translate("", $conf);
 		$newlangs1->setDefaultLang('ja_JP');
-		$localobject->model_pdf='crabe';
+		$localobject->model_pdf = 'crabe';
 		$result = $localobject->generateDocument($localobject->model_pdf, $newlangs1);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
 
 		// Crabe (saudiarabia)
-		$newlangs2a=new Translate("", $conf);
+		$newlangs2a = new Translate("", $conf);
 		$newlangs2a->setDefaultLang('sa_SA');
-		$localobject->model_pdf='crabe';
+		$localobject->model_pdf = 'crabe';
 		$result = $localobject->generateDocument($localobject->model_pdf, $newlangs2a);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
 
 		// Crabe (english_saudiarabia)
-		$newlangs2b=new Translate("", $conf);
+		$newlangs2b = new Translate("", $conf);
 		$newlangs2b->setDefaultLang('en_SA');
-		$localobject->model_pdf='crabe';
+		$localobject->model_pdf = 'crabe';
 		$result = $localobject->generateDocument($localobject->model_pdf, $newlangs2b);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
 
 		// Crabe (greek)
-		$newlangs3=new Translate("", $conf);
+		$newlangs3 = new Translate("", $conf);
 		$newlangs3->setDefaultLang('el_GR');
-		$localobject->model_pdf='crabe';
+		$localobject->model_pdf = 'crabe';
 		$result = $localobject->generateDocument($localobject->model_pdf, $newlangs3);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
 
 		// Crabe (chinese)
-		$newlangs4=new Translate("", $conf);
+		$newlangs4 = new Translate("", $conf);
 		$newlangs4->setDefaultLang('zh_CN');
-		$localobject->model_pdf='crabe';
+		$localobject->model_pdf = 'crabe';
 		$result = $localobject->generateDocument($localobject->model_pdf, $newlangs4);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
 
 		// Crabe (russian)
-		$newlangs5=new Translate("", $conf);
+		$newlangs5 = new Translate("", $conf);
 		$newlangs5->setDefaultLang('ru_RU');
-		$localobject->model_pdf='crabe';
+		$localobject->model_pdf = 'crabe';
 		$result = $localobject->generateDocument($localobject->model_pdf, $newlangs5);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
@@ -228,17 +228,17 @@ class BuildDocTest extends CommonClassTest
 	public function testFactureFournisseurBuild()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$conf->fournisseur->facture->dir_output.='/temp';
-		$localobject=new FactureFournisseur($db);
+		$conf->fournisseur->facture->dir_output .= '/temp';
+		$localobject = new FactureFournisseur($db);
 		$localobject->initAsSpecimen();
 
 		// Canelle
-		$localobject->model_pdf='canelle';
+		$localobject->model_pdf = 'canelle';
 		$result = $localobject->generateDocument($localobject->model_pdf, $langs);
 
 		$this->assertLessThan($result, 0);
@@ -255,17 +255,17 @@ class BuildDocTest extends CommonClassTest
 	public function testCommandeBuild()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$conf->commande->dir_output.='/temp';
-		$localobject=new Commande($db);
+		$conf->commande->dir_output .= '/temp';
+		$localobject = new Commande($db);
 		$localobject->initAsSpecimen();
 
 		// Einstein
-		$localobject->model_pdf='einstein';
+		$localobject->model_pdf = 'einstein';
 		$result = $localobject->generateDocument($localobject->model_pdf, $langs);
 
 		$this->assertLessThan($result, 0);
@@ -283,18 +283,18 @@ class BuildDocTest extends CommonClassTest
 	public function testCommandeFournisseurBuild()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$conf->fournisseur->commande->dir_output.='/temp';
-		$localobject=new CommandeFournisseur($db);
+		$conf->fournisseur->commande->dir_output .= '/temp';
+		$localobject = new CommandeFournisseur($db);
 		$localobject->initAsSpecimen();
 
 		// Muscadet
-		$localobject->model_pdf='muscadet';
-		$result= $localobject->generateDocument($localobject->model_pdf, $langs);
+		$localobject->model_pdf = 'muscadet';
+		$result = $localobject->generateDocument($localobject->model_pdf, $langs);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
@@ -310,17 +310,17 @@ class BuildDocTest extends CommonClassTest
 	public function testPropalBuild()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$conf->propal->dir_output.='/temp';
-		$localobject=new Propal($db);
+		$conf->propal->dir_output .= '/temp';
+		$localobject = new Propal($db);
 		$localobject->initAsSpecimen();
 
 		// Azur
-		$localobject->model_pdf='azur';
+		$localobject->model_pdf = 'azur';
 		$result = $localobject->generateDocument($localobject->model_pdf, $langs);
 
 		$this->assertLessThan($result, 0);
@@ -337,16 +337,16 @@ class BuildDocTest extends CommonClassTest
 	public function testProjectBuild()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
-		$conf->project->dir_output.='/temp';
-		$localobject=new Project($db);
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+		$conf->project->dir_output .= '/temp';
+		$localobject = new Project($db);
 		$localobject->initAsSpecimen();
 
 		// Baleine
-		$localobject->model_pdf='baleine';
+		$localobject->model_pdf = 'baleine';
 		$result = $localobject->generateDocument($localobject->model_pdf, $langs);
 
 		$this->assertLessThan($result, 0);
@@ -363,18 +363,18 @@ class BuildDocTest extends CommonClassTest
 	public function testFichinterBuild()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$conf->ficheinter->dir_output.='/temp';
-		$localobject=new Fichinter($db);
+		$conf->ficheinter->dir_output .= '/temp';
+		$localobject = new Fichinter($db);
 		$localobject->initAsSpecimen();
 
 		// Soleil
-		$localobject->model_pdf='soleil';
-		$result=fichinter_create($db, $localobject, $localobject->model_pdf, $langs);
+		$localobject->model_pdf = 'soleil';
+		$result = fichinter_create($db, $localobject, $localobject->model_pdf, $langs);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
@@ -390,25 +390,25 @@ class BuildDocTest extends CommonClassTest
 	public function testExpeditionBuild()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$conf->expedition->dir_output.='/temp';
-		$localobject=new Expedition($db);
+		$conf->expedition->dir_output .= '/temp';
+		$localobject = new Expedition($db);
 		$localobject->initAsSpecimen();
 
 		// Merou
-		$localobject->model_pdf='merou';
-		$result= $localobject->generateDocument($localobject->model_pdf, $langs);
+		$localobject->model_pdf = 'merou';
+		$result = $localobject->generateDocument($localobject->model_pdf, $langs);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
 
 		// Rouget
-		$localobject->model_pdf='rouget';
-		$result= $localobject->generateDocument($localobject->model_pdf, $langs);
+		$localobject->model_pdf = 'rouget';
+		$result = $localobject->generateDocument($localobject->model_pdf, $langs);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";

--- a/test/phpunit/CMailFileTest.php
+++ b/test/phpunit/CMailFileTest.php
@@ -163,28 +163,29 @@ class CMailFileTest extends CommonClassTest
 		$this->assertEquals($result, 2);
 
 
-		foreach ($localobject->html_images as $i => $val)
-		if ($localobject->html_images[$i]) {
-			if (preg_match('/img250x20\.png/i', $localobject->html_images[$i]['fullpath'])) {
-				print __METHOD__ . " content type must be image png =" . $localobject->html_images[$i]['content_type'] . "\n";
-				$this->assertEquals($localobject->html_images[$i]['content_type'], 'image/png');
+		foreach ($localobject->html_images as $i => $val) {
+			if ($localobject->html_images[$i]) {
+				if (preg_match('/img250x20\.png/i', $localobject->html_images[$i]['fullpath'])) {
+					print __METHOD__ . " content type must be image png =" . $localobject->html_images[$i]['content_type'] . "\n";
+					$this->assertEquals($localobject->html_images[$i]['content_type'], 'image/png');
 
-				print __METHOD__ . " type must be cidfromurl =" . $localobject->html_images[$i]['type'] . "\n";
-				$this->assertEquals($localobject->html_images[$i]['type'], 'cidfromurl');
+					print __METHOD__ . " type must be cidfromurl =" . $localobject->html_images[$i]['type'] . "\n";
+					$this->assertEquals($localobject->html_images[$i]['type'], 'cidfromurl');
 
-				$fileSize = 9744;
-				print __METHOD__ . " File size must be =" . $fileSize . "\n";
-				$this->assertEquals(dol_filesize($localobject->html_images[$i]['fullpath']), $fileSize);
-			} elseif (preg_match('/\.png/i', $localobject->html_images[$i]['fullpath'])) {
-				print __METHOD__ . " content type must be image png =" . $localobject->html_images[$i]['content_type'] . "\n";
-				$this->assertEquals($localobject->html_images[$i]['content_type'], 'image/png');
+					$fileSize = 9744;
+					print __METHOD__ . " File size must be =" . $fileSize . "\n";
+					$this->assertEquals(dol_filesize($localobject->html_images[$i]['fullpath']), $fileSize);
+				} elseif (preg_match('/\.png/i', $localobject->html_images[$i]['fullpath'])) {
+					print __METHOD__ . " content type must be image png =" . $localobject->html_images[$i]['content_type'] . "\n";
+					$this->assertEquals($localobject->html_images[$i]['content_type'], 'image/png');
 
-				print __METHOD__ . " type must be cidfromdata =" . $localobject->html_images[$i]['type'] . "\n";
-				$this->assertEquals($localobject->html_images[$i]['type'], 'cidfromdata');
+					print __METHOD__ . " type must be cidfromdata =" . $localobject->html_images[$i]['type'] . "\n";
+					$this->assertEquals($localobject->html_images[$i]['type'], 'cidfromdata');
 
-				$fileSize = 85;
-				print __METHOD__ . " File size must be =" . $fileSize . "\n";
-				$this->assertEquals(dol_filesize($localobject->html_images[$i]['fullpath']), $fileSize);
+					$fileSize = 85;
+					print __METHOD__ . " File size must be =" . $fileSize . "\n";
+					$this->assertEquals(dol_filesize($localobject->html_images[$i]['fullpath']), $fileSize);
+				}
 			}
 		}
 

--- a/test/phpunit/CategorieTest.php
+++ b/test/phpunit/CategorieTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -57,36 +57,36 @@ class CategorieTest extends CommonClassTest
 	public function testCategorieCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 
 		// We create a category
-		$localobject=new Categorie($db);
+		$localobject = new Categorie($db);
 		$localobject->initAsSpecimen();
 
 		// Check it does not exist (return 0)
-		$resultCheck=$localobject->already_exists();
+		$resultCheck = $localobject->already_exists();
 		print __METHOD__." resultCheck=".$resultCheck."\n";
 		$this->assertEquals(0, $resultCheck);
 
 		// Create
-		$resultFirstCreate=$localobject->create($user);
+		$resultFirstCreate = $localobject->create($user);
 		print __METHOD__." resultFirstCreate=".$resultFirstCreate."\n";
 		$this->assertGreaterThan(0, $resultFirstCreate);
 
 		// We try to create another one with same ref
-		$localobject2=new Categorie($db);
+		$localobject2 = new Categorie($db);
 		$localobject2->initAsSpecimen();
 
 		// Check it does exist (return 1)
-		$resultCheck=$localobject2->already_exists();
+		$resultCheck = $localobject2->already_exists();
 		print __METHOD__." resultCheck=".$resultCheck."\n";
 		$this->assertGreaterThan(0, $resultCheck);
 
-		$resultSecondCreate=$localobject2->create($user);
+		$resultSecondCreate = $localobject2->create($user);
 		print __METHOD__." result=".$resultSecondCreate."\n";
 		$this->assertEquals(-4, $resultSecondCreate);
 
@@ -105,37 +105,37 @@ class CategorieTest extends CommonClassTest
 	public function testCategorieProduct($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobjecttmp=new Categorie($db);
+		$localobjecttmp = new Categorie($db);
 		$localobjecttmp->initAsSpecimen();
-		$localobjecttmp->label='Specimen Category for product';
-		$localobjecttmp->type=0;    // product category
-		$catid=$localobjecttmp->create($user);
+		$localobjecttmp->label = 'Specimen Category for product';
+		$localobjecttmp->type = 0;    // product category
+		$catid = $localobjecttmp->create($user);
 
 		print __METHOD__." catid=".$catid."\n";
 		$this->assertGreaterThan(0, $catid);
 
 		// Try to create product linked to category
-		$localobject2=new Product($db);
+		$localobject2 = new Product($db);
 		$localobject2->initAsSpecimen();
-		$localobject2->ref.='-CATEG';
-		$localobject2->tva_npr=1;
-		$result=$localobject2->create($user);
+		$localobject2->ref .= '-CATEG';
+		$localobject2->tva_npr = 1;
+		$result = $localobject2->create($user);
 		$cat = new Categorie($db);
 		$cat->id = $catid;
 		$cat->type = 0;
-		$result=$cat->add_type($localobject2, "product");
+		$result = $cat->add_type($localobject2, "product");
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
 
 		// Get list of categories for product
-		$localcateg=new Categorie($db);
-		$listofcateg=$localcateg->containing($localobject2->id, Categorie::TYPE_PRODUCT, 'label');
+		$localcateg = new Categorie($db);
+		$listofcateg = $localcateg->containing($localobject2->id, Categorie::TYPE_PRODUCT, 'label');
 		$this->assertTrue(in_array('Specimen Category for product', $listofcateg), 'Categ not found linked to product when it should');
 
 		return $id;
@@ -153,13 +153,13 @@ class CategorieTest extends CommonClassTest
 	public function testCategorieFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Categorie($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Categorie($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
@@ -178,13 +178,13 @@ class CategorieTest extends CommonClassTest
 	public function testCategorieUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->note_private ='New note after update';
-		$result=$localobject->update($user);
+		$localobject->note_private = 'New note after update';
+		$result = $localobject->update($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
@@ -204,17 +204,17 @@ class CategorieTest extends CommonClassTest
 	public function testCategorieOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 		*/
 
-		$retarray=$localobject->liste_photos('/');
+		$retarray = $localobject->liste_photos('/');
 		print __METHOD__." retarray size=".count($retarray)."\n";
 		$this->assertTrue(is_array($retarray));
 
@@ -233,14 +233,14 @@ class CategorieTest extends CommonClassTest
 	public function testCategorieDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Categorie($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Categorie($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
@@ -257,13 +257,13 @@ class CategorieTest extends CommonClassTest
 	public function testCategorieStatic()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Categorie($db);
-		$retarray=$localobject->get_full_arbo(3);
+		$localobject = new Categorie($db);
+		$retarray = $localobject->get_full_arbo(3);
 
 		print __METHOD__." retarray size=".count($retarray)."\n";
 		$this->assertTrue(is_array($retarray));

--- a/test/phpunit/ChargeSocialesTest.php
+++ b/test/phpunit/ChargeSocialesTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,14 +56,14 @@ class ChargeSocialesTest extends CommonClassTest
 	public function testChargeSocialesCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new ChargeSociales($db);
+		$localobject = new ChargeSociales($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user, $langs, $conf);
+		$result = $localobject->create($user, $langs, $conf);
 		print __METHOD__." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -82,13 +82,13 @@ class ChargeSocialesTest extends CommonClassTest
 	public function testChargeSocialesFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new ChargeSociales($db);
-		$result=$localobject->fetch($id);
+		$localobject = new ChargeSociales($db);
+		$result = $localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -107,12 +107,12 @@ class ChargeSocialesTest extends CommonClassTest
 	public function testChargeSocialesValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setPaid($user);
+		$result = $localobject->setPaid($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -131,16 +131,16 @@ class ChargeSocialesTest extends CommonClassTest
 	public function testChargeSocialesOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->getNomUrl(1);
+		$result = $localobject->getNomUrl(1);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertNotEquals($result, '');
 
-		$result=$localobject->getSommePaiement();
+		$result = $localobject->getSommePaiement();
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThanOrEqual($result, 0);
 
@@ -160,14 +160,14 @@ class ChargeSocialesTest extends CommonClassTest
 	{
 		global $conf,$user,$langs,$db;
 
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new ChargeSociales($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new ChargeSociales($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/CodingPhpTest.php
+++ b/test/phpunit/CodingPhpTest.php
@@ -68,7 +68,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -88,10 +88,10 @@ class CodingPhpTest extends CommonClassTest
 	public function testPHP()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 		$filesarray = dol_dir_list(DOL_DOCUMENT_ROOT, 'files', 1, '\.php', null, 'fullname', SORT_ASC, 0, 1, '', 1);
@@ -117,7 +117,7 @@ class CodingPhpTest extends CommonClassTest
 			}
 
 			//print 'Check php file '.$file['relativename']."\n";
-			$filecontent=file_get_contents($file['fullname']);
+			$filecontent = file_get_contents($file['fullname']);
 
 			if (preg_match('/\.class\.php/', $file['relativename'])
 				|| preg_match('/boxes\/box_/', $file['relativename'])
@@ -136,12 +136,12 @@ class CodingPhpTest extends CommonClassTest
 					'multicurrency.class.php'
 				))) {
 					// Must not find $db->
-					$ok=true;
-					$matches=array();
+					$ok = true;
+					$matches = array();
 					// Check string $db-> inside a class.php file (it should be $this->db-> into such classes)
 					preg_match_all('/'.preg_quote('$db->', '/').'/', $filecontent, $matches, PREG_SET_ORDER);
 					foreach ($matches as $key => $val) {
-						$ok=false;
+						$ok = false;
 						break;
 					}
 					//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
@@ -200,12 +200,12 @@ class CodingPhpTest extends CommonClassTest
 					'DoliStorage.php'
 				))) {
 					// Must not found $this->db->
-					$ok=true;
-					$matches=array();
+					$ok = true;
+					$matches = array();
 					// Check string $this->db-> into a non class.php file (it should be $db-> into such classes)
 					preg_match_all('/'.preg_quote('$this->db->', '/').'/', $filecontent, $matches, PREG_SET_ORDER);
 					foreach ($matches as $key => $val) {
-						$ok=false;
+						$ok = false;
 						break;
 					}
 					//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
@@ -217,11 +217,11 @@ class CodingPhpTest extends CommonClassTest
 			// Check we don't miss top_httphead() into any ajax pages
 			if (preg_match('/ajax\//', $file['relativename'])) {
 				print "Analyze ajax page ".$file['relativename']."\n";
-				$ok=true;
-				$matches=array();
+				$ok = true;
+				$matches = array();
 				preg_match_all('/top_httphead/', $filecontent, $matches, PREG_SET_ORDER);
 				if (count($matches) == 0) {
-					$ok=false;
+					$ok = false;
 				}
 				//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
 				$this->assertTrue($ok, 'Did not find top_httphead into the ajax page '.$file['relativename']);
@@ -231,13 +231,13 @@ class CodingPhpTest extends CommonClassTest
 			// Check if a var_dump has been forgotten
 			if (!preg_match('/test\/phpunit/', $file['fullname'])) {
 				if (! in_array($file['name'], array('class.nusoap_base.php'))) {
-					$ok=true;
-					$matches=array();
+					$ok = true;
+					$matches = array();
 					preg_match_all('/(.)\s*var_dump\(/', $filecontent, $matches, PREG_SET_ORDER);
 					//var_dump($matches);
 					foreach ($matches as $key => $val) {
 						if ($val[1] != '/' && $val[1] != '*') {
-							$ok=false;
+							$ok = false;
 							break;
 						}
 						break;
@@ -249,11 +249,11 @@ class CodingPhpTest extends CommonClassTest
 			}
 
 			// Check get_class followed by __METHOD__
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/'.preg_quote('get_class($this)."::".__METHOD__', '/').'/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
@@ -261,12 +261,12 @@ class CodingPhpTest extends CommonClassTest
 			//exit;
 
 			// Check string $this->db->idate without quotes
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/(..)\s*\.\s*\$this->db->idate\(/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if ($val[1] != '\'"' && $val[1] != '\'\'') {
-					$ok=false;
+					$ok = false;
 					break;
 				}
 				//if ($reg[0] != 'db') $ok=false;
@@ -278,8 +278,8 @@ class CodingPhpTest extends CommonClassTest
 
 			// Check sql string DELETE|OR|AND|WHERE|INSERT ... yyy = ".$xxx
 			//  with xxx that is not 'thi' (for $this->db->sanitize) and 'db-' (for $db->sanitize). It means we forget a ' if string, or an (int) if int, when forging sql request.
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/(DELETE|OR|AND|WHERE|INSERT)\s.*([^\s][^\s][^\s])\s*=\s*(\'|")\s*\.\s*\$(...)/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if ($val[2] == 'ity' && $val[4] == 'con') {		// exclude entity = ".$conf->entity
@@ -292,7 +292,7 @@ class CodingPhpTest extends CommonClassTest
 					continue;
 				}
 				var_dump($matches);
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
@@ -300,13 +300,13 @@ class CodingPhpTest extends CommonClassTest
 			//exit;
 
 			// Check that forged sql string is using ' instead of " as string PHP quotes
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/\$sql \.= \'\s*VALUES.*\$/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				//if ($val[1] != '\'"' && $val[1] != '\'\'') {
 				var_dump($matches);
-				$ok=false;
+				$ok = false;
 				break;
 				//}
 				//if ($reg[0] != 'db') $ok=false;
@@ -316,20 +316,20 @@ class CodingPhpTest extends CommonClassTest
 			//exit;
 
 			// Check that forged sql string is using ' instead of " as string PHP quotes
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/\$sql \.?= \'SELECT.*\$/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				var_dump($matches);
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			$this->assertTrue($ok, 'Found a forged SQL string that mix on same line the use of \' for PHP string and PHP variables into file '.$file['relativename'].' Use " to forge PHP string like this: $sql = "SELECT ".$myvar...');
 
 			// Check sql string VALUES ... , ".$xxx
 			//  with xxx that is not 'db-' (for $db->escape). It means we forget a ' if string, or an (int) if int, when forging sql request.
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/(VALUES).*,\s*"\s*\.\s*\$(...)/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if ($val[1] == 'VALUES' && $val[2] == 'db-') {		// exclude $db->escape(
@@ -339,7 +339,7 @@ class CodingPhpTest extends CommonClassTest
 					continue;
 				}
 				var_dump($matches);
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			//print __METHOD__." Result for checking we don't have non escaped string in sql requests for file ".$file."\n";
@@ -349,12 +349,12 @@ class CodingPhpTest extends CommonClassTest
 			// Check '".$xxx non escaped
 
 			// Check string   ='".$this->xxx   with xxx that is not 'escape'. It means we forget a db->escape when forging sql request.
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/=\s*\'"\s*\.\s*\$this->(....)/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if ($val[1] != 'db->' && $val[1] != 'esca') {
-					$ok=false;
+					$ok = false;
 					break;
 				}
 			}
@@ -362,12 +362,12 @@ class CodingPhpTest extends CommonClassTest
 			$this->assertTrue($ok, 'Found non escaped string in building of a sql request (case 1) in '.$file['relativename'].' - Bad.');
 
 			// Check string sql|set|WHERE|...'".$yyy->xxx   with xxx that is not 'escape', 'idate', .... It means we forget a db->escape when forging sql request.
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/(sql|SET|WHERE|INSERT|VALUES|LIKE).+\s*\'"\s*\.\s*\$(.......)/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if (! in_array($val[2], array('this->d', 'this->e', 'db->esc', 'dbs->es', 'dbs->id', 'mydb->e', 'dbsessi', 'db->ida', 'escaped', 'exclude', 'include'))) {
-					$ok=false;	// This will generate error
+					$ok = false;	// This will generate error
 					break;
 				}
 				//if ($reg[0] != 'db') $ok=false;
@@ -377,12 +377,12 @@ class CodingPhpTest extends CommonClassTest
 			//exit;
 
 			// Check string sql|set...'.$yyy->xxx   with xxx that is not 'escape', 'idate', .... It means we forget a db->escape when forging sql request.
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/(\$sql|SET\s|WHERE\s|INSERT\s|VALUES\s|VALUES\().+\s*\'\s*\.\s*\$(.........)/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if (! in_array($val[2], array('this->db-', 'db->prefi', 'db->sanit', 'dbs->pref', 'dbs->sani', 'conf->ent', 'key : \'\')', 'key])."\')', 'excludefi', 'regexstri', ''))) {
-					$ok=false;
+					$ok = false;
 					var_dump($matches);
 					break;
 				}
@@ -395,13 +395,13 @@ class CodingPhpTest extends CommonClassTest
 			// Checks with IN
 
 			// Check string ' IN (".xxx' or ' IN (\'.xxx'  with xxx that is not '$this->db->sanitize' and not '$db->sanitize'. It means we forget a db->sanitize when forging sql request.
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/\s+IN\s*\([\'"]\s*\.\s*(.........)/i', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				//var_dump($val);
 				if (!in_array($val[1], array('$db->sani', '$this->db', 'getEntity', 'WON\',\'L', 'self::STA', 'Commande:', 'CommandeF', 'Entrepot:', 'Facture::', 'FactureFo', 'ExpenseRe', 'Societe::', 'Ticket::S'))) {
-					$ok=false;
+					$ok = false;
 					break;
 				}
 				//if ($reg[0] != 'db') $ok=false;
@@ -411,13 +411,13 @@ class CodingPhpTest extends CommonClassTest
 			//exit;
 
 			// Check string ' IN (\'".xxx'   with xxx that is not '$this->db->sanitize' and not '$db->sanitize'. It means we forget a db->sanitize when forging sql request.
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/\s+IN\s*\(\'"\s*\.\s*(.........)/i', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				//var_dump($val);
 				if (!in_array($val[1], array('$db->sani', '$this->db', 'getEntity', 'WON\',\'L', 'self::STA', 'Commande:', 'CommandeF', 'Entrepot:', 'Facture::', 'FactureFo', 'ExpenseRe', 'Societe::', 'Ticket::S'))) {
-					$ok=false;
+					$ok = false;
 					break;
 				}
 				//if ($reg[0] != 'db') $ok=false;
@@ -427,12 +427,12 @@ class CodingPhpTest extends CommonClassTest
 			//exit;
 
 			// Test that output of $_SERVER\[\'QUERY_STRING\'\] is escaped.
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/(..............)\$_SERVER\[\'QUERY_STRING\'\]/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if ($val[1] != 'scape_htmltag(' && $val[1] != 'ing_nohtmltag(' && $val[1] != 'dol_escape_js(') {
-					$ok=false;
+					$ok = false;
 					break;
 				}
 			}
@@ -440,8 +440,8 @@ class CodingPhpTest extends CommonClassTest
 
 
 			// Check GETPOST(... 'none');
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/GETPOST\s*\(([^\)]+),\s*["\']none["\']/i', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				//var_dump($val);
@@ -450,7 +450,7 @@ class CodingPhpTest extends CommonClassTest
 						'"mysqldump"', '"postgresqldump"',
 						"'db_pass_root'", "'db_pass'", '"pass"', '"pass1"', '"pass2"', '"password"', "'password'",
 						'"MAIN_MAIL_SMTPS_PW"', '"MAIN_MAIL_SMTPS_PW_EMAILING"', '"MAIN_MAIL_SMTPS_PW_TICKET"'))) {
-					$ok=false;
+					$ok = false;
 					break;
 				}
 				//if ($reg[0] != 'db') $ok=false;
@@ -461,24 +461,24 @@ class CodingPhpTest extends CommonClassTest
 
 
 			// Test that first param of print_liste_field_titre is a translation key and not the translated value
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			// Check string ='print_liste_field_titre\(\$langs'.
 			preg_match_all('/print_liste_field_titre\(\$langs/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			$this->assertTrue($ok, 'Found a use of print_liste_field_titre with first parameter that is a translated value instead of just the translation key in file '.$file['relativename'].'. Bad.');
 
 
 			// Test we don't have <br />
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/<br\s+\/>/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if ($file['name'] != 'functions.lib.php') {
-					$ok=false;
+					$ok = false;
 					break;
 				}
 			}
@@ -486,12 +486,12 @@ class CodingPhpTest extends CommonClassTest
 
 
 			// Test we don't have name="token" value="'.$_SESSION['newtoken'], we must use name="token" value="'.newToken() instead.
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/name="token" value="\'\s*\.\s*\$_SESSION/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if ($file['name'] != 'excludefile.php') {
-					$ok=false;
+					$ok = false;
 					break;
 				}
 			}
@@ -499,12 +499,12 @@ class CodingPhpTest extends CommonClassTest
 
 
 			// Test we don't have preg_grep with a param without preg_quote
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/preg_grep\(.*\$/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
 				if (strpos($val[0], 'preg_quote') === false) {
-					$ok=false;
+					$ok = false;
 					break;
 				}
 			}
@@ -512,62 +512,62 @@ class CodingPhpTest extends CommonClassTest
 
 
 			// Test we don't have "if ($resql >"
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/if \(\$resql >/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			$this->assertTrue($ok, 'Found a if $resql with a > operator (when $resql is a boolean or resource) in file '.$file['relativename'].'. Please remove the > ... part.');
 
 			// Test we don't have empty($user->hasRight
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/empty\(\$user->hasRight/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			$this->assertTrue($ok, 'Found code empty($user->hasRight in file '.$file['relativename'].'. empty() must not be used on a var not on a function.');
 
 			// Test we don't have empty(DolibarrApiAccess::$user->hasRight
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/empty\(DolibarrApiAccess::\$user->hasRight/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			$this->assertTrue($ok, 'Found code empty(DolibarrApiAccess::$user->hasRight in file '.$file['relativename'].'. empty() must not be used on a var not on a function.');
 
 			// Test we don't have empty($user->hasRight
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/empty\(getDolGlobal/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			$this->assertTrue($ok, 'Found code empty(getDolGlobal... in file '.$file['relativename'].'. empty() must be used on a var not on a function.');
 
 			// Test we don't have @var array(
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/@var\s+array\(/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			$this->assertTrue($ok, 'Found a declaration @var array() instead of @var array in file '.$file['relativename'].'.');
 
 
 			// Test we don't have CURDATE()
-			$ok=true;
-			$matches=array();
+			$ok = true;
+			$matches = array();
 			preg_match_all('/CURDATE\(\)/', $filecontent, $matches, PREG_SET_ORDER);
 			foreach ($matches as $key => $val) {
-				$ok=false;
+				$ok = false;
 				break;
 			}
 			$this->assertTrue($ok, 'Found a CURDATE\(\) into code. Do not use this SQL method in file '.$file['relativename'].'. You must use the PHP function dol_now() instead.');

--- a/test/phpunit/CodingSqlTest.php
+++ b/test/phpunit/CodingSqlTest.php
@@ -68,7 +68,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -88,10 +88,10 @@ class CodingSqlTest extends CommonClassTest
 	public function testEscape()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		if ($db->type == 'mysqli') {
 			$a = 'abc"\'def';	// string is abc"'def
@@ -115,10 +115,10 @@ class CodingSqlTest extends CommonClassTest
 	public function testEscapeForLike()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$a = 'abc"\'def_ghi%klm\\nop';
 		//print $a;
@@ -134,10 +134,10 @@ class CodingSqlTest extends CommonClassTest
 	public function testSql()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$listofsqldir = array(DOL_DOCUMENT_ROOT.'/install/mysql/data', DOL_DOCUMENT_ROOT.'/install/mysql/tables', DOL_DOCUMENT_ROOT.'/install/mysql/migration');
 
@@ -161,37 +161,37 @@ class CodingSqlTest extends CommonClassTest
 				//$filecontent = preg_replace('/^--.*$/', '', $filecontent);
 				$filecontent = preg_replace('/--.*?\n/', '', $filecontent);
 
-				$result=strpos($filecontent, '`');
+				$result = strpos($filecontent, '`');
 				//print __METHOD__." Result for checking we don't have back quote = ".$result."\n";
-				$this->assertTrue($result===false, 'Found back quote into '.$file.'. Bad.');
+				$this->assertTrue($result === false, 'Found back quote into '.$file.'. Bad.');
 
-				$result=strpos($filecontent, '"');
+				$result = strpos($filecontent, '"');
 				//print __METHOD__." Result for checking we don't have double quote = ".$result."\n";
-				$this->assertTrue($result===false, 'Found double quote that is not [" neither {" (used for json content) neither (" (used for content with string like isModEnabled("")) into '.$file.'. Bad.');
+				$this->assertTrue($result === false, 'Found double quote that is not [" neither {" (used for json content) neither (" (used for content with string like isModEnabled("")) into '.$file.'. Bad.');
 
-				$result=strpos($filecontent, 'int(');
+				$result = strpos($filecontent, 'int(');
 				//print __METHOD__." Result for checking we don't have 'int(' instead of 'integer' = ".$result."\n";
-				$this->assertTrue($result===false, 'Found int(x) or tinyint(x) instead of integer or tinyint into '.$file.'. Bad.');
+				$this->assertTrue($result === false, 'Found int(x) or tinyint(x) instead of integer or tinyint into '.$file.'. Bad.');
 
-				$result=strpos($filecontent, 'ON DELETE CASCADE');
+				$result = strpos($filecontent, 'ON DELETE CASCADE');
 				//print __METHOD__." Result for checking we don't have 'ON DELETE CASCADE' = ".$result."\n";
-				$this->assertTrue($result===false, 'Found ON DELETE CASCADE into '.$file.'. Bad.');
+				$this->assertTrue($result === false, 'Found ON DELETE CASCADE into '.$file.'. Bad.');
 
-				$result=strpos($filecontent, 'NUMERIC(');
+				$result = strpos($filecontent, 'NUMERIC(');
 				//print __METHOD__." Result for checking we don't have 'NUMERIC(' = ".$result."\n";
-				$this->assertTrue($result===false, 'Found NUMERIC( into '.$file.'. Bad.');
+				$this->assertTrue($result === false, 'Found NUMERIC( into '.$file.'. Bad.');
 
-				$result=strpos($filecontent, 'NUMERIC(');
+				$result = strpos($filecontent, 'NUMERIC(');
 				//print __METHOD__." Result for checking we don't have 'curdate(' = ".$result."\n";
-				$this->assertTrue($result===false, 'Found curdate( into '.$file.'. Bad. Current date must be generated with PHP.');
+				$this->assertTrue($result === false, 'Found curdate( into '.$file.'. Bad. Current date must be generated with PHP.');
 
-				$result=strpos($filecontent, 'integer(');
+				$result = strpos($filecontent, 'integer(');
 				//print __METHOD__." Result for checking we don't have 'integer(' = ".$result."\n";
-				$this->assertTrue($result===false, 'Found value in parenthesis after the integer. It must be integer not integer(x) into '.$file.'. Bad.');
+				$this->assertTrue($result === false, 'Found value in parenthesis after the integer. It must be integer not integer(x) into '.$file.'. Bad.');
 
-				$result=strpos($filecontent, 'timestamp,');
+				$result = strpos($filecontent, 'timestamp,');
 				//print __METHOD__." Result for checking we don't have 'NUMERIC(' = ".$result."\n";
-				$this->assertTrue($result===false, 'Found type timestamp with option DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP after into '.$file.'. Bad.');
+				$this->assertTrue($result === false, 'Found type timestamp with option DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP after into '.$file.'. Bad.');
 
 				if ($dir == DOL_DOCUMENT_ROOT.'/install/mysql/migration') {
 					// Test for migration files only
@@ -202,11 +202,11 @@ class CodingSqlTest extends CommonClassTest
 						// Test for key files only
 					} else {
 						// Test for non key files only
-						$result=(strpos($filecontent, 'KEY ') && strpos($filecontent, 'PRIMARY KEY') == 0);
+						$result = (strpos($filecontent, 'KEY ') && strpos($filecontent, 'PRIMARY KEY') == 0);
 						//print __METHOD__." Result for checking we don't have ' KEY ' instead of a sql file to create index = ".$result."\n";
-						$this->assertTrue($result===false, 'Found KEY into '.$file.'. Bad.');
+						$this->assertTrue($result === false, 'Found KEY into '.$file.'. Bad.');
 
-						$result=stripos($filecontent, 'ENGINE=innodb');
+						$result = stripos($filecontent, 'ENGINE=innodb');
 						//print __METHOD__." Result for checking we have the ENGINE=innodb string = ".$result."\n";
 						$this->assertGreaterThan(0, $result, 'The ENGINE=innodb was not found into '.$file.'. Add it or just fix syntax to match case.');
 					}
@@ -225,10 +225,10 @@ class CodingSqlTest extends CommonClassTest
 	public function testInitData()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$filesarray = scandir(DOL_DOCUMENT_ROOT.'/../dev/initdemo');
 		foreach ($filesarray as $key => $file) {
@@ -237,19 +237,19 @@ class CodingSqlTest extends CommonClassTest
 			}
 
 			print 'Check sql file '.$file."\n";
-			$filecontent=file_get_contents(DOL_DOCUMENT_ROOT.'/../dev/initdemo/'.$file);
+			$filecontent = file_get_contents(DOL_DOCUMENT_ROOT.'/../dev/initdemo/'.$file);
 
-			$result=strpos($filecontent, '@gmail.com');
+			$result = strpos($filecontent, '@gmail.com');
 			print __METHOD__." Result for checking we don't have personal data = ".$result."\n";
-			$this->assertTrue($result===false, 'Found a bad key @gmail into file '.$file);
+			$this->assertTrue($result === false, 'Found a bad key @gmail into file '.$file);
 
-			$result=strpos($filecontent, 'eldy@');
+			$result = strpos($filecontent, 'eldy@');
 			print __METHOD__." Result for checking we don't have personal data = ".$result."\n";
-			$this->assertTrue($result===false, 'Found a bad key eldy@ into file '.$file);
+			$this->assertTrue($result === false, 'Found a bad key eldy@ into file '.$file);
 
-			$result=strpos($filecontent, 'INSERT INTO `llx_oauth_token`');
+			$result = strpos($filecontent, 'INSERT INTO `llx_oauth_token`');
 			print __METHOD__." Result for checking we don't have data into llx_oauth_token = ".$result."\n";
-			$this->assertTrue($result===false, 'Found a non expected insert into file '.$file);
+			$this->assertTrue($result === false, 'Found a non expected insert into file '.$file);
 		}
 
 		return;

--- a/test/phpunit/CommandeFournisseurTest.php
+++ b/test/phpunit/CommandeFournisseurTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 
@@ -58,71 +58,71 @@ class CommandeFournisseurTest extends CommonClassTest
 	public function testCommandeFournisseurCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Set supplier and product to use
-		$socid=1;
-		$societe=new Societe($db);
+		$socid = 1;
+		$societe = new Societe($db);
 		$societe->fetch($socid);
-		$product=new ProductFournisseur($db);
+		$product = new ProductFournisseur($db);
 		$product->fetch(0, 'PINKDRESS');
 		if ($product->id <= 0) {
 			print "\n".__METHOD__." A product with ref PINKDRESS must exists into database";
 			die(1);
 		}
 
-		$quantity=10;
-		$ref_fourn='SUPPLIER_REF_PHPUNIT';
-		$tva_tx=19.6;
+		$quantity = 10;
+		$ref_fourn = 'SUPPLIER_REF_PHPUNIT';
+		$tva_tx = 19.6;
 
 		// Delete existing supplier prices
 		// TODO
 
 		// Create 1 supplier price with min qty = 10;
-		$result=$product->add_fournisseur($user, $societe->id, $ref_fourn, $quantity);    // This insert record with no value for price. Values are update later with update_buyprice
+		$result = $product->add_fournisseur($user, $societe->id, $ref_fourn, $quantity);    // This insert record with no value for price. Values are update later with update_buyprice
 		print __METHOD__." add_fournisseur result=".$result."\n";
 		$this->assertGreaterThanOrEqual(0, $result, 'Create 1 supplier price with min qty = 10 if not exists');
-		$result=$product->update_buyprice($quantity, 20, $user, 'HT', $societe, '', $ref_fourn, $tva_tx, 0, 0);
+		$result = $product->update_buyprice($quantity, 20, $user, 'HT', $societe, '', $ref_fourn, $tva_tx, 0, 0);
 		print __METHOD__." update_buyprice result=".$result."\n";
 		$this->assertGreaterThanOrEqual(0, $result, 'Update buyprice');
 
 		// Create purchase order with a too low quantity and option SUPPLIER_ORDER_WITH_PREDEFINED_PRICES_ONLY is on
 		$conf->global->SUPPLIER_ORDER_WITH_PREDEFINED_PRICES_ONLY = 1;
 
-		$localobject=new CommandeFournisseur($db);
+		$localobject = new CommandeFournisseur($db);
 		$localobject->initAsSpecimen();
-		$localobject->lines=array();    // Overwrite lines of order
-		$line=new CommandeFournisseurLigne($db);
-		$line->desc=$langs->trans("Description")." specimen line with qty too low";
-		$line->qty=1;                   // So lower than $quantity
-		$line->subprice=100;
-		$line->fk_product=$product->id;
-		$line->ref_fourn=$ref_fourn;
-		$localobject->lines[]=$line;
+		$localobject->lines = array();    // Overwrite lines of order
+		$line = new CommandeFournisseurLigne($db);
+		$line->desc = $langs->trans("Description")." specimen line with qty too low";
+		$line->qty = 1;                   // So lower than $quantity
+		$line->subprice = 100;
+		$line->fk_product = $product->id;
+		$line->ref_fourn = $ref_fourn;
+		$localobject->lines[] = $line;
 
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(-1, $result, 'Creation of too low quantity');   // must be -1 because quantity is lower than minimum of supplier price
 
-		$sql="DELETE FROM ".MAIN_DB_PREFIX."commande_fournisseur where ref IN ('', '(PROV)')";
+		$sql = "DELETE FROM ".MAIN_DB_PREFIX."commande_fournisseur where ref IN ('', '(PROV)')";
 		$db->query($sql);
 
 		// Create purchase order
-		$localobject2=new CommandeFournisseur($db);
+		$localobject2 = new CommandeFournisseur($db);
 		$localobject2->initAsSpecimen();    // This create 5 lines of first product found for socid 1
-		$localobject2->lines=array();       // Overwrite lines of order
-		$line=new CommandeFournisseurLigne($db);
-		$line->desc=$langs->trans("Description")." specimen line ok";
-		$line->qty=10;                      // So enough quantity
-		$line->subprice=100;
-		$line->fk_product=$product->id;
-		$line->ref_fourn=$ref_fourn;
-		$localobject2->lines[]=$line;
+		$localobject2->lines = array();       // Overwrite lines of order
+		$line = new CommandeFournisseurLigne($db);
+		$line->desc = $langs->trans("Description")." specimen line ok";
+		$line->qty = 10;                      // So enough quantity
+		$line->subprice = 100;
+		$line->fk_product = $product->id;
+		$line->ref_fourn = $ref_fourn;
+		$localobject2->lines[] = $line;
 
-		$result=$localobject2->create($user);
+		$result = $localobject2->create($user);
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
 
@@ -130,37 +130,37 @@ class CommandeFournisseurTest extends CommonClassTest
 		// Create purchase order with a too low quantity but option SUPPLIER_ORDER_WITH_PREDEFINED_PRICES_ONLY is off
 		$conf->global->SUPPLIER_ORDER_WITH_PREDEFINED_PRICES_ONLY = 0;
 
-		$localobject3=new CommandeFournisseur($db);
+		$localobject3 = new CommandeFournisseur($db);
 		$localobject3->initAsSpecimen();
-		$localobject3->lines=array();    // Overwrite lines of order
-		$line=new CommandeFournisseurLigne($db);
-		$line->desc=$langs->trans("Description")." specimen line with qty too low";
-		$line->qty=1;                   // So lower than $quantity
-		$line->subprice=100;
-		$line->fk_product=$product->id;
-		$line->ref_fourn=$ref_fourn;
-		$localobject3->lines[]=$line;
+		$localobject3->lines = array();    // Overwrite lines of order
+		$line = new CommandeFournisseurLigne($db);
+		$line->desc = $langs->trans("Description")." specimen line with qty too low";
+		$line->qty = 1;                   // So lower than $quantity
+		$line->subprice = 100;
+		$line->fk_product = $product->id;
+		$line->ref_fourn = $ref_fourn;
+		$localobject3->lines[] = $line;
 
-		$result=$localobject3->create($user);
+		$result = $localobject3->create($user);
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, 'Creation of too low quantity should be ok');   // must be id of line because there is no test on minimum quantity
 
-		$sql="DELETE FROM ".MAIN_DB_PREFIX."commande_fournisseur where ref=''";
+		$sql = "DELETE FROM ".MAIN_DB_PREFIX."commande_fournisseur where ref=''";
 		$db->query($sql);
 
 		// Create purchase order
-		$localobject4=new CommandeFournisseur($db);
+		$localobject4 = new CommandeFournisseur($db);
 		$localobject4->initAsSpecimen();    // This create 5 lines of first product found for socid 1
-		$localobject4->lines=array();       // Overwrite lines of order
-		$line=new CommandeFournisseurLigne($db);
-		$line->desc=$langs->trans("Description")." specimen line ok";
-		$line->qty=10;                      // So enough quantity
-		$line->subprice=100;
-		$line->fk_product=$product->id;
-		$line->ref_fourn=$ref_fourn;
-		$localobject4->lines[]=$line;
+		$localobject4->lines = array();       // Overwrite lines of order
+		$line = new CommandeFournisseurLigne($db);
+		$line->desc = $langs->trans("Description")." specimen line ok";
+		$line->qty = 10;                      // So enough quantity
+		$line->subprice = 100;
+		$line->fk_product = $product->id;
+		$line->ref_fourn = $ref_fourn;
+		$localobject4->lines[] = $line;
 
-		$result=$localobject4->create($user);
+		$result = $localobject4->create($user);
 		print __METHOD__." id for purchase order created by testCommandeFournisseurCreate = ".$result."\n";
 		$this->assertGreaterThan(0, $result, 'Test to create a purchase order by testCommandeFournisseurCreate');
 
@@ -180,13 +180,13 @@ class CommandeFournisseurTest extends CommonClassTest
 	public function testCommandeFournisseurFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new CommandeFournisseur($db);
-		$result=$localobject->fetch($id);
+		$localobject = new CommandeFournisseur($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Failed to fetch supplier order with id '.$id);
@@ -205,12 +205,12 @@ class CommandeFournisseurTest extends CommonClassTest
 	public function testCommandeFournisseurValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->valid($user);
+		$result = $localobject->valid($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -229,12 +229,12 @@ class CommandeFournisseurTest extends CommonClassTest
 	public function testCommandeFournisseurApprove($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->approve($user);
+		$result = $localobject->approve($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -253,12 +253,12 @@ class CommandeFournisseurTest extends CommonClassTest
 	public function testCommandeFournisseurCancel($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->cancel($user);
+		$result = $localobject->cancel($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -277,10 +277,10 @@ class CommandeFournisseurTest extends CommonClassTest
 	public function testCommandeFournisseurOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -308,14 +308,14 @@ class CommandeFournisseurTest extends CommonClassTest
 	public function testCommandeFournisseurDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new CommandeFournisseur($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new CommandeFournisseur($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/CommandeTest.php
+++ b/test/phpunit/CommandeTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -75,20 +75,20 @@ class CommandeTest extends CommonClassTest
 	public function testCommandeCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$soc = new Societe($db);
 		$soc->name = "CommandeTest Unittest";
 		$socid = $soc->create($user);
 		$this->assertLessThan($socid, 0, $soc->errorsToString());
 
-		$localobject=new Commande($db);
+		$localobject = new Commande($db);
 		$localobject->initAsSpecimen();
 		$localobject->socid = $socid;
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
 		print __METHOD__." result=".$result."\n";
@@ -107,13 +107,13 @@ class CommandeTest extends CommonClassTest
 	public function testCommandeFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Commande($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Commande($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -132,13 +132,13 @@ class CommandeTest extends CommonClassTest
 	public function testCommandeUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->note_private='New note private after update';
-		$result=$localobject->update($user);
+		$localobject->note_private = 'New note private after update';
+		$result = $localobject->update($user);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -157,12 +157,12 @@ class CommandeTest extends CommonClassTest
 	public function testCommandeValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->valid($user);
+		$result = $localobject->valid($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -181,12 +181,12 @@ class CommandeTest extends CommonClassTest
 	public function testCommandeCancel($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->cancel();
+		$result = $localobject->cancel();
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -205,10 +205,10 @@ class CommandeTest extends CommonClassTest
 	public function testCommandeOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -234,14 +234,14 @@ class CommandeTest extends CommonClassTest
 	public function testCommandeDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Commande($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Commande($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/CommonClassTest.class.php
+++ b/test/phpunit/CommonClassTest.class.php
@@ -34,7 +34,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -63,10 +63,10 @@ class CommonClassTest extends PHPUnit\Framework\TestCase
 
 		//$this->sharedFixture
 		global $conf,$user,$langs,$db;
-		$this->savconf=$conf;
-		$this->savuser=$user;
-		$this->savlangs=$langs;
-		$this->savdb=$db;
+		$this->savconf = $conf;
+		$this->savuser = $user;
+		$this->savlangs = $langs;
+		$this->savdb = $db;
 
 		print __METHOD__." db->type=".$db->type." user->id=".$user->id;
 		//print " - db ".$db->db;
@@ -128,10 +128,10 @@ class CommonClassTest extends PHPUnit\Framework\TestCase
 	{
 		global $conf,$user,$langs,$db;
 
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		print __METHOD__."\n";
 		//print $db->getVersion()."\n";

--- a/test/phpunit/CommonInvoiceTest.php
+++ b/test/phpunit/CommonInvoiceTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,12 +56,12 @@ class CommonInvoiceTest extends CommonClassTest
 	public function testCalculateDateLimReglement()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->fetch(1);
 		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 2010);
 

--- a/test/phpunit/CommonObjectTest.php
+++ b/test/phpunit/CommonObjectTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -57,15 +57,15 @@ class CommonObjectTest extends CommonClassTest
 	public function testFetchUser()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Commande($db);
+		$localobject = new Commande($db);
 		$localobject->fetch(1);
 
-		$result=$localobject->fetch_user(1);
+		$result = $localobject->fetch_user(1);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($localobject->user->id, 0);
@@ -80,14 +80,14 @@ class CommonObjectTest extends CommonClassTest
 	public function testFetchProject()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Commande($db);
+		$localobject = new Commande($db);
 		$localobject->fetch(1);
-		$result=$localobject->fetch_projet();
+		$result = $localobject->fetch_projet();
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThanOrEqual($result, 0);
@@ -102,15 +102,15 @@ class CommonObjectTest extends CommonClassTest
 	public function testFetchThirdParty()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Commande($db);
+		$localobject = new Commande($db);
 		$localobject->fetch(1);
 
-		$result=$localobject->fetch_thirdparty();
+		$result = $localobject->fetch_thirdparty();
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThanOrEqual($result, 0);

--- a/test/phpunit/CompanyBankAccountTest.php
+++ b/test/phpunit/CompanyBankAccountTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,20 +56,20 @@ class CompanyBankAccountTest extends CommonClassTest
 	public function testCompanyBankAccountCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$soc = new Societe($db);
 		$soc->name = "CompanyBankAccountTest Unittest";
 		$socid = $soc->create($user);
 		$this->assertLessThan($socid, 0, $soc->errorsToString());
 
-		$localobject=new CompanyBankAccount($db);
+		$localobject = new CompanyBankAccount($db);
 		$localobject->initAsSpecimen();
 		$localobject->socid = $socid;
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result." id=".$localobject->id."\n";
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
@@ -88,13 +88,13 @@ class CompanyBankAccountTest extends CommonClassTest
 	public function testCompanyBankAccountFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new CompanyBankAccount($db);
-		$result=$localobject->fetch($id);
+		$localobject = new CompanyBankAccount($db);
+		$result = $localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 		return $localobject;
@@ -111,12 +111,12 @@ class CompanyBankAccountTest extends CommonClassTest
 	public function testCompanyBankAccountSetAsDefault($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setAsDefault($localobject->id);
+		$result = $localobject->setAsDefault($localobject->id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 		return $localobject;
@@ -134,13 +134,13 @@ class CompanyBankAccountTest extends CommonClassTest
 	public function testCompanyBankAccountUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->owner='New owner';
-		$result=$localobject->update($user);
+		$localobject->owner = 'New owner';
+		$result = $localobject->update($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -159,13 +159,13 @@ class CompanyBankAccountTest extends CommonClassTest
 	public function testCompanyBankAccountOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->owner='New owner';
-		$result=$localobject->update($user);
+		$localobject->owner = 'New owner';
+		$result = $localobject->update($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/CompanyLibTest.php
+++ b/test/phpunit/CompanyLibTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,19 +56,19 @@ class CompanyLibTest extends CommonClassTest
 	public function testNameCurrency()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=currency_name('USD');
+		$result = currency_name('USD');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('US Dollars', $result, 'Test to get currency name USD in default language '.$langs->defaultlang);
 
-		$outputlangs=new Translate('', $conf);
+		$outputlangs = new Translate('', $conf);
 		$outputlangs->setDefaultLang('fr_FR');
 
-		$result=currency_name('USD', 1, $outputlangs);
+		$result = currency_name('USD', 1, $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('USD - Dollars US', $result, 'Test to get currency name USD in default language '.$outputlangs->getDefaultLang());
 

--- a/test/phpunit/ContactTest.php
+++ b/test/phpunit/ContactTest.php
@@ -44,7 +44,7 @@ if (empty($user->id)) {
 	$user->getrights();
 }
 
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -64,14 +64,14 @@ class ContactTest extends CommonClassTest
 	public function testContactCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Contact($db);
+		$localobject = new Contact($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -90,13 +90,13 @@ class ContactTest extends CommonClassTest
 	public function testContactFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Contact($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Contact($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -116,44 +116,44 @@ class ContactTest extends CommonClassTest
 	public function testContactUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$localobject->oldcopy = clone $localobject;
 
-		$localobject->note_private='New private note after update';
-		$localobject->note_public='New public note after update';
-		$localobject->lastname='New name';
-		$localobject->firstname='New firstname';
-		$localobject->address='New address';
-		$localobject->zip='New zip';
-		$localobject->town='New town';
-		$localobject->country_id=2;
+		$localobject->note_private = 'New private note after update';
+		$localobject->note_public = 'New public note after update';
+		$localobject->lastname = 'New name';
+		$localobject->firstname = 'New firstname';
+		$localobject->address = 'New address';
+		$localobject->zip = 'New zip';
+		$localobject->town = 'New town';
+		$localobject->country_id = 2;
 		//$localobject->status=0;
-		$localobject->phone_pro='New tel pro';
-		$localobject->phone_perso='New tel perso';
-		$localobject->phone_mobile='New tel mobile';
-		$localobject->fax='New fax';
-		$localobject->email='newemail@newemail.com';
-		$localobject->socialnetworks['jabber']='New im id';
-		$localobject->default_lang='es_ES';
+		$localobject->phone_pro = 'New tel pro';
+		$localobject->phone_perso = 'New tel perso';
+		$localobject->phone_mobile = 'New tel mobile';
+		$localobject->fax = 'New fax';
+		$localobject->email = 'newemail@newemail.com';
+		$localobject->socialnetworks['jabber'] = 'New im id';
+		$localobject->default_lang = 'es_ES';
 
-		$result=$localobject->update($localobject->id, $user);
+		$result = $localobject->update($localobject->id, $user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Contact::update error');
 
-		$result=$localobject->update_note($localobject->note_private, '_private');
+		$result = $localobject->update_note($localobject->note_private, '_private');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Contact::update_note (private) error');
 
-		$result=$localobject->update_note($localobject->note_public, '_public');
+		$result = $localobject->update_note($localobject->note_public, '_public');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Contact::update_note (public) error');
 
-		$newobject=new Contact($db);
-		$result=$newobject->fetch($localobject->id);
+		$newobject = new Contact($db);
+		$result = $newobject->fetch($localobject->id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Contact::fetch error');
 
@@ -207,18 +207,18 @@ class ContactTest extends CommonClassTest
 	public function testContactOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		//$localobject->fetch($localobject->id);
 
-		$result=$localobject->getNomUrl(1);
+		$result = $localobject->getNomUrl(1);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertNotEquals($result, '');
 
-		$result=$localobject->getFullAddress(1);
+		$result = $localobject->getFullAddress(1);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertStringContainsString("New address\nNew zip New town\nBelgium", $result);
 
@@ -241,15 +241,15 @@ class ContactTest extends CommonClassTest
 	public function testContactDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Contact($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Contact($db);
+		$result = $localobject->fetch($id);
 
-		$result=$localobject->delete($user);
+		$result = $localobject->delete($user);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -264,55 +264,55 @@ class ContactTest extends CommonClassTest
 	public function testContactGetFullAddress()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobjectadd=new Contact($db);
+		$localobjectadd = new Contact($db);
 		$localobjectadd->initAsSpecimen();
 
 		// France
 		unset($localobjectadd->country_code);
-		$localobjectadd->country_id=1;
-		$localobjectadd->name='New name';
-		$localobjectadd->address='New address';
-		$localobjectadd->zip='New zip';
-		$localobjectadd->town='New town';
-		$result=$localobjectadd->getFullAddress(1);
+		$localobjectadd->country_id = 1;
+		$localobjectadd->name = 'New name';
+		$localobjectadd->address = 'New address';
+		$localobjectadd->zip = 'New zip';
+		$localobjectadd->town = 'New town';
+		$result = $localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
 		$this->assertStringContainsString("New address\nNew zip New town\nFrance", $result);
 
 		// Belgium
 		unset($localobjectadd->country_code);
-		$localobjectadd->country_id=2;
-		$localobjectadd->name='New name';
-		$localobjectadd->address='New address';
-		$localobjectadd->zip='New zip';
-		$localobjectadd->town='New town';
-		$result=$localobjectadd->getFullAddress(1);
+		$localobjectadd->country_id = 2;
+		$localobjectadd->name = 'New name';
+		$localobjectadd->address = 'New address';
+		$localobjectadd->zip = 'New zip';
+		$localobjectadd->town = 'New town';
+		$result = $localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
 		$this->assertStringContainsString("New address\nNew zip New town\nBelgium", $result);
 
 		// Switzerland
 		unset($localobjectadd->country_code);
-		$localobjectadd->country_id=6;
-		$localobjectadd->name='New name';
-		$localobjectadd->address='New address';
-		$localobjectadd->zip='New zip';
-		$localobjectadd->town='New town';
-		$result=$localobjectadd->getFullAddress(1);
+		$localobjectadd->country_id = 6;
+		$localobjectadd->name = 'New name';
+		$localobjectadd->address = 'New address';
+		$localobjectadd->zip = 'New zip';
+		$localobjectadd->town = 'New town';
+		$result = $localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
 		$this->assertStringContainsString("New address\nNew zip New town\nSwitzerland", $result);
 
 		// USA
 		unset($localobjectadd->country_code);
-		$localobjectadd->country_id=11;
-		$localobjectadd->name='New name';
-		$localobjectadd->address='New address';
-		$localobjectadd->zip='New zip';
-		$localobjectadd->town='New town';
-		$result=$localobjectadd->getFullAddress(1);
+		$localobjectadd->country_id = 11;
+		$localobjectadd->name = 'New name';
+		$localobjectadd->address = 'New address';
+		$localobjectadd->zip = 'New zip';
+		$localobjectadd->town = 'New town';
+		$result = $localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
 		$this->assertStringContainsString("New address\nNew town, New zip\nUnited States", $result);
 

--- a/test/phpunit/ContratTest.php
+++ b/test/phpunit/ContratTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,20 +56,20 @@ class ContratTest extends CommonClassTest
 	public function testContratCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$soc = new Societe($db);
 		$soc->name = "ContratTest Unittest";
 		$socid = $soc->create($user);
 		$this->assertLessThan($socid, 0, $soc->errorsToString());
 
-		$localobject=new Contrat($db);
+		$localobject = new Contrat($db);
 		$localobject->initAsSpecimen();
 		$localobject->socid = $socid;
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
@@ -89,13 +89,13 @@ class ContratTest extends CommonClassTest
 	public function testContratFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Contrat($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Contrat($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -115,10 +115,10 @@ class ContratTest extends CommonClassTest
 	public function testContratOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -144,14 +144,14 @@ class ContratTest extends CommonClassTest
 	public function testContratDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Contrat($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Contrat($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/CoreTest.php
+++ b/test/phpunit/CoreTest.php
@@ -92,7 +92,7 @@ class CoreTest extends CommonClassTest
 		global $dolibarr_main_db_type;
 		global $dolibarr_main_db_prefix;
 
-		$testtodo=0;
+		$testtodo = 0;
 
 		// Case 1:
 		// Test for subdir dolibarrnew (that point to htdocs) in root directory /var/www
@@ -101,12 +101,12 @@ class CoreTest extends CommonClassTest
 		// - Create link from htdocs to /var/www/dolibarrnew
 		// - Put into conf.php $dolibarr_main_document_root='/var/www/dolibarrnew';
 		if ($testtodo == 1) {
-			$_SERVER["HTTPS"]='';
-			$_SERVER["SERVER_NAME"]='localhost';
-			$_SERVER["SERVER_PORT"]='80';
-			$_SERVER["DOCUMENT_ROOT"]='/var/www';
-			$_SERVER["SCRIPT_NAME"]='/dolibarrnew/admin/system/phpinfo.php';
-			$expectedresult='/dolibarrnew';
+			$_SERVER["HTTPS"] = '';
+			$_SERVER["SERVER_NAME"] = 'localhost';
+			$_SERVER["SERVER_PORT"] = '80';
+			$_SERVER["DOCUMENT_ROOT"] = '/var/www';
+			$_SERVER["SCRIPT_NAME"] = '/dolibarrnew/admin/system/phpinfo.php';
+			$expectedresult = '/dolibarrnew';
 		}
 
 		// Case 2:
@@ -116,12 +116,12 @@ class CoreTest extends CommonClassTest
 		// - Create link from dolibarr to /var/www/aaa
 		// - Put into conf.php $dolibarr_main_document_root='/var/www/aaa/htdocs';
 		if ($testtodo == 2) {
-			$_SERVER["HTTPS"]='';
-			$_SERVER["SERVER_NAME"]='localhost';
-			$_SERVER["SERVER_PORT"]='80';
-			$_SERVER["DOCUMENT_ROOT"]='/var/www';
-			$_SERVER["SCRIPT_NAME"]='/aaa/htdocs/admin/system/phpinfo.php';
-			$expectedresult='/aaa/htdocs';
+			$_SERVER["HTTPS"] = '';
+			$_SERVER["SERVER_NAME"] = 'localhost';
+			$_SERVER["SERVER_PORT"] = '80';
+			$_SERVER["DOCUMENT_ROOT"] = '/var/www';
+			$_SERVER["SCRIPT_NAME"] = '/aaa/htdocs/admin/system/phpinfo.php';
+			$expectedresult = '/aaa/htdocs';
 		}
 
 		// Case 3:
@@ -132,12 +132,12 @@ class CoreTest extends CommonClassTest
 		// - Create virtual host localhostdolibarrnew that point to /home/ldestailleur/git/dolibarr/htdocs
 		// - Put into conf.php $dolibarr_main_document_root='/home/ldestailleur/git/dolibarr/htdocs';
 		if ($testtodo == 3) {
-			$_SERVER["HTTPS"]='';
-			$_SERVER["SERVER_NAME"]='localhostdolibarrnew';
-			$_SERVER["SERVER_PORT"]='80';
-			$_SERVER["DOCUMENT_ROOT"]='/home/ldestailleur/git/dolibarr/htdocs';
-			$_SERVER["SCRIPT_NAME"]='/admin/system/phpinfo.php';
-			$expectedresult='';
+			$_SERVER["HTTPS"] = '';
+			$_SERVER["SERVER_NAME"] = 'localhostdolibarrnew';
+			$_SERVER["SERVER_PORT"] = '80';
+			$_SERVER["DOCUMENT_ROOT"] = '/home/ldestailleur/git/dolibarr/htdocs';
+			$_SERVER["SCRIPT_NAME"] = '/admin/system/phpinfo.php';
+			$expectedresult = '';
 		}
 
 		// Case 4:
@@ -145,12 +145,12 @@ class CoreTest extends CommonClassTest
 		// a symbolic link
 		// URL: http://localhostdolibarrnew/admin/system/phpinfo.php
 		if ($testtodo == 4) {
-			$_SERVER["HTTPS"]='';
-			$_SERVER["SERVER_NAME"]='localhostdolibarrnew';
-			$_SERVER["SERVER_PORT"]='80';
-			$_SERVER["DOCUMENT_ROOT"]='/var/www/dolibarr';	// This is a link that point to /home/ldestail/workspace/dolibarr/htdocs
-			$_SERVER["SCRIPT_NAME"]='/admin/system/phpinfo.php';
-			$expectedresult='';
+			$_SERVER["HTTPS"] = '';
+			$_SERVER["SERVER_NAME"] = 'localhostdolibarrnew';
+			$_SERVER["SERVER_PORT"] = '80';
+			$_SERVER["DOCUMENT_ROOT"] = '/var/www/dolibarr';	// This is a link that point to /home/ldestail/workspace/dolibarr/htdocs
+			$_SERVER["SCRIPT_NAME"] = '/admin/system/phpinfo.php';
+			$expectedresult = '';
 		}
 
 		// Case 5:
@@ -161,12 +161,12 @@ class CoreTest extends CommonClassTest
 		// - Put into conf.php $dolibarr_main_document_root='/var/www/dolibarr/htdocs';
 		// - Put into conf.php $dolibarr_main_url_root='http://localhost/dolibarralias';  (because autodetect will fails in this case)
 		if ($testtodo == 5) {
-			$_SERVER["HTTPS"]='';
-			$_SERVER["SERVER_NAME"]='localhost';
-			$_SERVER["SERVER_PORT"]='80';
-			$_SERVER["DOCUMENT_ROOT"]='/var/www';
-			$_SERVER["SCRIPT_NAME"]='/dolibarralias/admin/system/phpinfo.php';
-			$expectedresult='/dolibarralias';
+			$_SERVER["HTTPS"] = '';
+			$_SERVER["SERVER_NAME"] = 'localhost';
+			$_SERVER["SERVER_PORT"] = '80';
+			$_SERVER["DOCUMENT_ROOT"] = '/var/www';
+			$_SERVER["SCRIPT_NAME"] = '/dolibarralias/admin/system/phpinfo.php';
+			$expectedresult = '/dolibarralias';
 		}
 
 		// Force to rerun filefunc.inc.php

--- a/test/phpunit/DateLibTest.php
+++ b/test/phpunit/DateLibTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 print "\n".$langs->trans("CurrentTimeZone").' : '.getServerTimeZoneString();
 print "\n".$langs->trans("CurrentHour").' : '.dol_print_date(dol_now('gmt'), 'dayhour', 'tzserver');
@@ -60,44 +60,44 @@ class DateLibTest extends CommonClassTest
 	public function testNumBetweenDay()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// With same hours
-		$date1=dol_mktime(0, 0, 0, 1, 1, 2012, 'gmt');
-		$date2=dol_mktime(0, 0, 0, 1, 2, 2012, 'gmt');
+		$date1 = dol_mktime(0, 0, 0, 1, 1, 2012, 'gmt');
+		$date2 = dol_mktime(0, 0, 0, 1, 2, 2012, 'gmt');
 
-		$result=num_between_day($date1, $date2, 1);
+		$result = num_between_day($date1, $date2, 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(2, $result);
 
-		$result=num_between_day($date1, $date2, 0);
+		$result = num_between_day($date1, $date2, 0);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(1, $result);
 
 		// With different hours
-		$date1=dol_mktime(0, 0, 0, 1, 1, 2012, 'gmt');
-		$date2=dol_mktime(12, 0, 0, 1, 2, 2012, 'gmt');
+		$date1 = dol_mktime(0, 0, 0, 1, 1, 2012, 'gmt');
+		$date2 = dol_mktime(12, 0, 0, 1, 2, 2012, 'gmt');
 
-		$result=num_between_day($date1, $date2, 1);
+		$result = num_between_day($date1, $date2, 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(2, $result);
 
-		$result=num_between_day($date1, $date2, 0);
+		$result = num_between_day($date1, $date2, 0);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(1, $result);
 
 		// With different date before and after sunlight hour (day to change sunlight hour is 2014-03-30)
-		$date1=dol_mktime(0, 0, 0, 3, 28, 2014, true);
-		$date2=dol_mktime(0, 0, 0, 3, 31, 2014, true);
+		$date1 = dol_mktime(0, 0, 0, 3, 28, 2014, true);
+		$date2 = dol_mktime(0, 0, 0, 3, 31, 2014, true);
 
-		$result=num_between_day($date1, $date2, 1);
+		$result = num_between_day($date1, $date2, 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(4, $result);
 
-		$result=num_between_day($date1, $date2, 0);
+		$result = num_between_day($date1, $date2, 0);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(3, $result);
 
@@ -112,62 +112,62 @@ class DateLibTest extends CommonClassTest
 	public function testNumPublicHoliday()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// With same hours - Tuesday/Wednesday jan 2013
-		$date1=dol_mktime(0, 0, 0, 1, 1, 2013, 'gmt');
-		$date2=dol_mktime(0, 0, 0, 1, 2, 2013, 'gmt');
-		$date3=dol_mktime(0, 0, 0, 1, 3, 2013, 'gmt');
+		$date1 = dol_mktime(0, 0, 0, 1, 1, 2013, 'gmt');
+		$date2 = dol_mktime(0, 0, 0, 1, 2, 2013, 'gmt');
+		$date3 = dol_mktime(0, 0, 0, 1, 3, 2013, 'gmt');
 
-		$result=num_public_holiday($date1, $date2, 'FR', 1);
+		$result = num_public_holiday($date1, $date2, 'FR', 1);
 		print __METHOD__." for Tuesday 1 - Wednesday 2 jan 2013 for FR result=".$result."\n";
 		$this->assertEquals(1, $result, 'NumPublicHoliday for Tuesday 1 - Wednesday 2 jan 2013 for FR');   // 1 closed days (country france)
 
-		$result=num_public_holiday($date1, $date2, 'XX', 1);
+		$result = num_public_holiday($date1, $date2, 'XX', 1);
 		print __METHOD__." for Tuesday 1 - Wednesday 2 jan 2013 for XX result=".$result."\n";
 		$this->assertEquals(1, $result, 'NumPublicHoliday for Tuesday 1 - Wednesday 2 jan 2013 for XX');   // 1 closed days (country unknown)
 
 		print '----'."\n";
-		$result=num_public_holiday($date2, $date3, 'FR', 1);
+		$result = num_public_holiday($date2, $date3, 'FR', 1);
 		print __METHOD__." for Wednesday 2 - Thursday 3 jan 2013 for FR result=".$result."\n";
 		$this->assertEquals(0, $result, 'NumPublicHoliday for Wednesday 2 - Thursday 3 jan 2013 for FR');   // no closed days
 
 		// Check with easter monday
-		$date1=dol_mktime(0, 0, 0, 4, 21, 2019, 'gmt');
-		$date2=dol_mktime(0, 0, 0, 4, 23, 2019, 'gmt');
+		$date1 = dol_mktime(0, 0, 0, 4, 21, 2019, 'gmt');
+		$date2 = dol_mktime(0, 0, 0, 4, 23, 2019, 'gmt');
 
-		$result=num_public_holiday($date1, $date2, 'XX', 1);
+		$result = num_public_holiday($date1, $date2, 'XX', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(1, $result, 'NumPublicHoliday including eastermonday for XX');   // 2 opened day, 1 closed days (sunday)
 
-		$result=num_public_holiday($date1, $date2, 'FR', 1);
+		$result = num_public_holiday($date1, $date2, 'FR', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(2, $result, 'NumPublicHoliday including eastermonday for FR');   // 1 opened day, 2 closed days (sunday + easter monday)
 
 		// Check for sunday/saturday - Friday 4 - Sunday 6 jan 2013
-		$date1=dol_mktime(0, 0, 0, 1, 4, 2013, 'gmt');
-		$date2=dol_mktime(0, 0, 0, 1, 6, 2013, 'gmt');
+		$date1 = dol_mktime(0, 0, 0, 1, 4, 2013, 'gmt');
+		$date2 = dol_mktime(0, 0, 0, 1, 6, 2013, 'gmt');
 
-		$result=num_public_holiday($date1, $date2, 'FR', 1);
+		$result = num_public_holiday($date1, $date2, 'FR', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(2, $result, 'NumPublicHoliday for FR');   // 1 opened day, 2 closed days
 
-		$result=num_public_holiday($date1, $date2, 'FR', 1, 1, 1);
+		$result = num_public_holiday($date1, $date2, 'FR', 1, 1, 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(2, $result, 'NumPublicHoliday for FR');   // 1 opened day, 2 closed days
 
-		$result=num_public_holiday($date1, $date2, 'FR', 1, 1, 0);
+		$result = num_public_holiday($date1, $date2, 'FR', 1, 1, 0);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(1, $result, 'NumPublicHoliday for FR');   // 2 opened day, 1 closed days
 
-		$result=num_public_holiday($date1, $date2, 'FR', 1, 0, 0);
+		$result = num_public_holiday($date1, $date2, 'FR', 1, 0, 0);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(0, $result, 'NumPublicHoliday for FR');   // 3 opened day, 0 closed days
 
-		$result=num_public_holiday($date1, $date2, 'XX', 1);
+		$result = num_public_holiday($date1, $date2, 'XX', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(2, $result, 'NumPublicHoliday for XX');   // 1 opened day, 2 closed days (even if country unknown)
 	}
@@ -180,48 +180,48 @@ class DateLibTest extends CommonClassTest
 	public function testNumOpenDay()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// With same hours - Tuesday/Wednesday jan 2013
-		$date1=dol_mktime(0, 0, 0, 1, 1, 2013, 'gmt');	// tuesday
-		$date2=dol_mktime(0, 0, 0, 1, 2, 2013, 'gmt');	// wednesday
-		$date3=dol_mktime(0, 0, 0, 1, 3, 2013, 'gmt');	// thursday
+		$date1 = dol_mktime(0, 0, 0, 1, 1, 2013, 'gmt');	// tuesday
+		$date2 = dol_mktime(0, 0, 0, 1, 2, 2013, 'gmt');	// wednesday
+		$date3 = dol_mktime(0, 0, 0, 1, 3, 2013, 'gmt');	// thursday
 
-		$result=num_open_day($date1, $date2, 0, 1, 0, 'FR');
+		$result = num_open_day($date1, $date2, 0, 1, 0, 'FR');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(1, $result, 'NumOpenDay Tuesday 1 - Wednesday 2 jan 2013 for FR');   // 1 opened days (country france)
 
-		$result=num_open_day($date1, $date2, 0, 1, 0, 'XX');
+		$result = num_open_day($date1, $date2, 0, 1, 0, 'XX');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(1, $result, 'NumOpenDay Tuesday 1 - Wednesday 2 jan 2013 for XX');   // 1 opened days (country unknown)
 
-		$result=num_open_day($date2, $date3, 0, 1, 0, 'FR');
+		$result = num_open_day($date2, $date3, 0, 1, 0, 'FR');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(2, $result, 'NumOpenDay Wednesday 2 - Thursday 3 jan 2013 for FR');   // 2 opened days
 
 		// With same hours - Friday/Sunday jan 2013
-		$date1=dol_mktime(0, 0, 0, 1, 4, 2013, 'gmt');	// friday
-		$date2=dol_mktime(0, 0, 0, 1, 6, 2013, 'gmt');	// sunday
+		$date1 = dol_mktime(0, 0, 0, 1, 4, 2013, 'gmt');	// friday
+		$date2 = dol_mktime(0, 0, 0, 1, 6, 2013, 'gmt');	// sunday
 
-		$result=num_open_day($date1, $date2, 0, 1, 0, 'FR');
+		$result = num_open_day($date1, $date2, 0, 1, 0, 'FR');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(1, $result, 'NumOpenDay for FR');   // 1 opened day, 2 closed
 
-		$result=num_open_day($date1, $date2, 'XX', 1);
+		$result = num_open_day($date1, $date2, 'XX', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(1, $result, 'NumOpenDay for XX');   // 1 opened day, 2 closes (even if country unknown)
 
 		// Test option MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY and MAIN_NON_WORKING_DAYS_INCLUDE_SUNDAY
 		$conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SATURDAY = 0;
-		$result=num_open_day($date1, $date2, 0, 1, 0, 'FR');
+		$result = num_open_day($date1, $date2, 0, 1, 0, 'FR');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(2, $result, 'NumOpenDay for FR when saturday is a working day');   //2 opened day, 1 closed
 
 		$conf->global->MAIN_NON_WORKING_DAYS_INCLUDE_SUNDAY = 0;
-		$result=num_open_day($date1, $date2, 'XX', 1);
+		$result = num_open_day($date1, $date2, 'XX', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(3, $result, 'NumOpenDay for XX when saturday + sunday are working days');   // 3 opened day, 0 closes (even if country unknown)
 	}
@@ -234,12 +234,12 @@ class DateLibTest extends CommonClassTest
 	public function testConvertTime2Seconds()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=convertTime2Seconds(1, 1, 2);
+		$result = convertTime2Seconds(1, 1, 2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(3662, $result);
 
@@ -254,16 +254,16 @@ class DateLibTest extends CommonClassTest
 	public function testConvertSecondToTime()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=convertSecondToTime(0, 'all', 86400);
+		$result = convertSecondToTime(0, 'all', 86400);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('0', $result);
 
-		$result=convertSecondToTime(86400, 'all', 86400);
+		$result = convertSecondToTime(86400, 'all', 86400);
 		print __METHOD__." result=".$result."\n";
 		$this->assertSame('1 '.$langs->trans("d"), $result);
 
@@ -278,63 +278,63 @@ class DateLibTest extends CommonClassTest
 	public function testDolPrintDate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Check %Y-%m-%d %H:%M:%S format
-		$result=dol_print_date('1970-01-01', '%Y-%m-%d %H:%M:%S', true);	// A case for compatibility check
+		$result = dol_print_date('1970-01-01', '%Y-%m-%d %H:%M:%S', true);	// A case for compatibility check
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1970-01-01 00:00:00', $result);
 
 
 		// Check %Y-%m-%d %H:%M:%S format
-		$result=dol_print_date(0, '%Y-%m-%d %H:%M:%S', true);
+		$result = dol_print_date(0, '%Y-%m-%d %H:%M:%S', true);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1970-01-01 00:00:00', $result);
 
 		// Same with T and Z
-		$result=dol_print_date(0, '%Y-%m-%dT%H:%M:%SZ', true);
+		$result = dol_print_date(0, '%Y-%m-%dT%H:%M:%SZ', true);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1970-01-01T00:00:00Z', $result);
 
 		// Check %Y-%m-%d %H:%M:%S format
-		$result=dol_print_date(16725225600, '%Y-%m-%d %H:%M:%S', true);	// http://www.epochconverter.com/
+		$result = dol_print_date(16725225600, '%Y-%m-%d %H:%M:%S', true);	// http://www.epochconverter.com/
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('2500-01-01 00:00:00', $result);
 
 		// Check %Y-%m-%d %H:%M:%S format
-		$result=dol_print_date(-1830384000, '%Y-%m-%d %H:%M:%S', true);	// http://www.epochconverter.com/
+		$result = dol_print_date(-1830384000, '%Y-%m-%d %H:%M:%S', true);	// http://www.epochconverter.com/
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1912-01-01 00:00:00', $result);	// dol_print_date use TZ (good) but epoch converter does not use it.
 
 		// Check %Y-%m-%d %H:%M:%S format
-		$result=dol_print_date(-11676096000, '%Y-%m-%d %H:%M:%S', true);	// http://www.epochconverter.com/
+		$result = dol_print_date(-11676096000, '%Y-%m-%d %H:%M:%S', true);	// http://www.epochconverter.com/
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1600-01-01 00:00:00', $result);
 
 		// test with negative timezone
-		$result=dol_print_date(-1, '%Y-%m-%d %H:%M:%S', true);	// http://www.epochconverter.com/
+		$result = dol_print_date(-1, '%Y-%m-%d %H:%M:%S', true);	// http://www.epochconverter.com/
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1969-12-31 23:59:59', $result);
 
 		// Check dayhour format for fr_FR
-		$outputlangs=new Translate('', $conf);
+		$outputlangs = new Translate('', $conf);
 		$outputlangs->setDefaultLang('fr_FR');
 		$outputlangs->load("main");
 
-		$result=dol_print_date(0+24*3600, 'dayhour', true, $outputlangs);
+		$result = dol_print_date(0 + 24 * 3600, 'dayhour', true, $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('02/01/1970 00:00', $result);
 
 		// Check %a and %b format for fr_FR
-		$result=dol_print_date(0, '%a %b %B', true, $outputlangs);
+		$result = dol_print_date(0, '%a %b %B', true, $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('Jeu Jan. Janvier', $result);
 
 
-		$result=dol_print_date(1619388000, '%Y-%m-%d %a', 'gmt', $outputlangs);
+		$result = dol_print_date(1619388000, '%Y-%m-%d %a', 'gmt', $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('2021-04-25 Dim', $result);
 
@@ -345,16 +345,16 @@ class DateLibTest extends CommonClassTest
 		*/
 
 		// Check day format for en_US
-		$outputlangs=new Translate('', $conf);
+		$outputlangs = new Translate('', $conf);
 		$outputlangs->setDefaultLang('en_US');
 		$outputlangs->load("main");
 
-		$result=dol_print_date(0+24*3600, 'day', true, $outputlangs);
+		$result = dol_print_date(0 + 24 * 3600, 'day', true, $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('01/02/1970', $result);
 
 		// Check %a and %b format for en_US
-		$result=dol_print_date(0, '%a %b %B', true, $outputlangs);
+		$result = dol_print_date(0, '%a %b %B', true, $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('Thu Jan January', $result);
 
@@ -369,17 +369,17 @@ class DateLibTest extends CommonClassTest
 	public function testDolTimePlusDuree()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Check dayhour format for fr_FR
-		$outputlangs=new Translate('', $conf);
+		$outputlangs = new Translate('', $conf);
 		$outputlangs->setDefaultLang('fr_FR');
 		$outputlangs->load("main");
 
-		$result=dol_print_date(dol_time_plus_duree(dol_time_plus_duree(dol_time_plus_duree(0, 1, 'm'), 1, 'y'), 1, 'd'), 'dayhour', true, $outputlangs);
+		$result = dol_print_date(dol_time_plus_duree(dol_time_plus_duree(dol_time_plus_duree(0, 1, 'm'), 1, 'y'), 1, 'd'), 'dayhour', true, $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('02/02/1971 00:00', $result);
 
@@ -394,33 +394,33 @@ class DateLibTest extends CommonClassTest
 	public function testDolStringToTime()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$stime='19700102';
-		$result=dol_stringtotime($stime);
+		$stime = '19700102';
+		$result = dol_stringtotime($stime);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(86400, $result);
 
-		$stime='1970-01-01T02:00:00Z';
-		$result=dol_stringtotime($stime);
+		$stime = '1970-01-01T02:00:00Z';
+		$result = dol_stringtotime($stime);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(7200, $result);
 
-		$stime='1970-01-01 02:00:00';
-		$result=dol_stringtotime($stime);
+		$stime = '1970-01-01 02:00:00';
+		$result = dol_stringtotime($stime);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(7200, $result);
 
-		$stime='19700101T020000Z';
-		$result=dol_stringtotime($stime);
+		$stime = '19700101T020000Z';
+		$result = dol_stringtotime($stime);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(7200, $result);
 
-		$stime='19700101020000';
-		$result=dol_stringtotime($stime);
+		$stime = '19700101020000';
+		$result = dol_stringtotime($stime);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(7200, $result);
 
@@ -436,16 +436,16 @@ class DateLibTest extends CommonClassTest
 	{
 		global $conf;
 
-		$day=3;
-		$month=2;
-		$year=2015;
+		$day = 3;
+		$month = 2;
+		$year = 2015;
 		$conf->global->MAIN_START_WEEK = 1;	// start on monday
 		$prev = dol_get_first_day_week($day, $month, $year);
 		$this->assertEquals(2, (int) $prev['first_day']);		// monday for month 2, year 2014 is the 2
 
-		$day=3;
-		$month=2;
-		$year=2015;
+		$day = 3;
+		$month = 2;
+		$year = 2015;
 		$conf->global->MAIN_START_WEEK = 0;	// start on sunday
 		$prev = dol_get_first_day_week($day, $month, $year);
 		$this->assertEquals(1, (int) $prev['first_day']);		// sunday for month 2, year 2015 is the 1st

--- a/test/phpunit/DateLibTzFranceTest.php
+++ b/test/phpunit/DateLibTzFranceTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -82,68 +82,68 @@ class DateLibTzFranceTest extends CommonClassTest
 	public function testDolPrintDateTzFrance()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Check %Y-%m-%d %H:%M:%S format
-		$result=dol_print_date(0, '%Y-%m-%d %H:%M:%S', false);
+		$result = dol_print_date(0, '%Y-%m-%d %H:%M:%S', false);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1970-01-01 01:00:00', $result);
 
 		// Check %Y-%m-%d %H:%M:%S format
-		$result=dol_print_date(16725225600, '%Y-%m-%d %H:%M:%S', false);
+		$result = dol_print_date(16725225600, '%Y-%m-%d %H:%M:%S', false);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('2500-01-01 01:00:00', $result);
 
 		// Check %Y-%m-%d %H:%M:%S format
-		$result=dol_print_date(-1830384000, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
+		$result = dol_print_date(-1830384000, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1912-01-01 01:00:00', $result);		// dol_print_date use a timezone, not epoch converter as it did not exists this year
 
 		// Specific cas during war
 
 		// 1940, no timezone
-		$result=dol_print_date(-946771200, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
+		$result = dol_print_date(-946771200, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1940-01-01 01:00:00', $result);		//  dol_print_date use a modern timezone, not epoch converter as it did not exists this year
 
 		// 1941, timezone is added by germany to +2 (same for 1942)
-		$result=dol_print_date(-915148800, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
+		$result = dol_print_date(-915148800, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1941-01-01 01:00:00', $result);		// dol_print_date use a modern timezone, epoch converter use historic timezone
 
 		// 1943, timezone is +1
-		$result=dol_print_date(-852076800, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
+		$result = dol_print_date(-852076800, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1943-01-01 01:00:00', $result);
 
 		// test with negative timezone
-		$result=dol_print_date(-1, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
+		$result = dol_print_date(-1, '%Y-%m-%d %H:%M:%S', false);	// http://www.epochconverter.com/
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1970-01-01 00:59:59', $result);
 
 		// Check dayhour format for fr_FR
-		$outputlangs=new Translate('', $conf);
+		$outputlangs = new Translate('', $conf);
 		$outputlangs->setDefaultLang('fr_FR');
 		$outputlangs->load("main");
 
-		$result=dol_print_date(0+24*3600, 'dayhour', false, $outputlangs);
+		$result = dol_print_date(0 + 24 * 3600, 'dayhour', false, $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('02/01/1970 01:00', $result);
 
 		// Check day format for en_US
-		$outputlangs=new Translate('', $conf);
+		$outputlangs = new Translate('', $conf);
 		$outputlangs->setDefaultLang('en_US');
 		$outputlangs->load("main");
 
-		$result=dol_print_date(0+24*3600, 'day', false, $outputlangs);
+		$result = dol_print_date(0 + 24 * 3600, 'day', false, $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('01/02/1970', $result);
 
 		// Check %a and %b format for en_US
-		$result=dol_print_date(0, '%a %b', false, $outputlangs);
+		$result = dol_print_date(0, '%a %b', false, $outputlangs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('Thu Jan', $result);
 

--- a/test/phpunit/DiscountTest.php
+++ b/test/phpunit/DiscountTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,20 +56,20 @@ class DiscountTest extends CommonClassTest
 	public function testDiscountCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$soc = new Societe($db);
 		$soc->name = "CommandeTest Unittest";
 		$socid = $soc->create($user);
 		$this->assertLessThan($socid, 0, $soc->errorsToString());
 
-		$localobject=new DiscountAbsolute($db);
+		$localobject = new DiscountAbsolute($db);
 		$localobject->initAsSpecimen();
 		$localobject->fk_soc = $socid;
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
@@ -88,13 +88,13 @@ class DiscountTest extends CommonClassTest
 	public function testDiscountFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new DiscountAbsolute($db);
-		$result=$localobject->fetch($id);
+		$localobject = new DiscountAbsolute($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -113,14 +113,14 @@ class DiscountTest extends CommonClassTest
 	public function testDiscountDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new DiscountAbsolute($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new DiscountAbsolute($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/DoliDBTest.php
+++ b/test/phpunit/DoliDBTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,10 +56,10 @@ class DoliDBTest extends CommonClassTest
 	public function testDDLUpdateField()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		print __METHOD__.' db->type = '.$db->type."\n";
 
@@ -74,14 +74,14 @@ class DoliDBTest extends CommonClassTest
 		}
 
 		// Set new field
-		$field_desc = array('type'=>'varchar', 'value'=>'17', 'null'=>'NOT NULL');
+		$field_desc = array('type' => 'varchar', 'value' => '17', 'null' => 'NOT NULL');
 
 		$result = $db->DDLUpdateField($db->prefix().'c_paper_format', 'code', $field_desc);
 		$this->assertEquals(1, $result);
 		print __METHOD__." result=".$result."\n";
 
 		// TODO Use $savtype and $savnull instead of hard coded
-		$field_desc = array('type'=>'varchar', 'value'=>'16', 'null'=>'NOT NULL');
+		$field_desc = array('type' => 'varchar', 'value' => '16', 'null' => 'NOT NULL');
 
 		$result = $db->DDLUpdateField($db->prefix().'c_paper_format', 'code', $field_desc);
 		$this->assertEquals(1, $result);

--- a/test/phpunit/EmailCollectorTest.php
+++ b/test/phpunit/EmailCollectorTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 
@@ -58,22 +58,22 @@ class EmailCollectorTest extends CommonClassTest
 	public function testEmailCollectorCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$langs->load("main");
 
 		// Create supplier order with a too low quantity
-		$localobject=new EmailCollector($db);
+		$localobject = new EmailCollector($db);
 		$localobject->initAsSpecimen();         // Init a specimen with lines
 
 		$this->filters = array();
 
 		$this->actions = array();
 
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, "Error on test EmailCollector create: ".$localobject->error.' '.join(',', $localobject->errors));
 
@@ -93,13 +93,13 @@ class EmailCollectorTest extends CommonClassTest
 	public function testEmailCollectorFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new EmailCollector($db);
-		$result=$localobject->fetch($id);
+		$localobject = new EmailCollector($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -118,12 +118,12 @@ class EmailCollectorTest extends CommonClassTest
 	public function testEmailCollectorCollect($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->getConnectStringIMAP();
+		$result = $localobject->getConnectStringIMAP();
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertEquals('{localhost:993/service=imap/ssl/novalidate-cert}', $result, 'Error in getConnectStringIMAP '.$localobject->error);
 
@@ -142,14 +142,14 @@ class EmailCollectorTest extends CommonClassTest
 	public function testEmailCollectorDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new EmailCollector($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new EmailCollector($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);

--- a/test/phpunit/EntrepotTest.php
+++ b/test/phpunit/EntrepotTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,14 +56,14 @@ class EntrepotTest extends CommonClassTest
 	public function testEntrepotCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Entrepot($db);
+		$localobject = new Entrepot($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
@@ -83,13 +83,13 @@ class EntrepotTest extends CommonClassTest
 	public function testEntrepotFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Entrepot($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Entrepot($db);
+		$result = $localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -108,13 +108,13 @@ class EntrepotTest extends CommonClassTest
 	public function testEntrepotUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->note='New note after update';
-		$result=$localobject->update($localobject->id, $user);
+		$localobject->note = 'New note after update';
+		$result = $localobject->update($localobject->id, $user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -133,10 +133,10 @@ class EntrepotTest extends CommonClassTest
 	public function testEntrepotOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$result = $localobject->get_full_arbo();
 		$this->assertEquals('WAREHOUSE SPECIMEN', $result);
@@ -156,15 +156,15 @@ class EntrepotTest extends CommonClassTest
 	public function testEntrepotDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Entrepot($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Entrepot($db);
+		$result = $localobject->fetch($id);
 
-		$result=$localobject->delete($user);
+		$result = $localobject->delete($user);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
 

--- a/test/phpunit/EvalMathTest.php
+++ b/test/phpunit/EvalMathTest.php
@@ -35,7 +35,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**

--- a/test/phpunit/ExpenseReportTest.php
+++ b/test/phpunit/ExpenseReportTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 
@@ -57,32 +57,32 @@ class ExpenseReportTest extends CommonClassTest
 	public function testExpenseReportCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Create supplier order with a too low quantity
-		$localobject=new ExpenseReport($db);
+		$localobject = new ExpenseReport($db);
 		$localobject->initAsSpecimen();         // Init a specimen with lines
 		$localobject->status = 0;
 		$localobject->fk_statut = 0;
 		$localobject->date_fin = null;  // Force bad value
 
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(-1, $result, "Error on test ExpenseReport create 1 : ".$localobject->error);       // must be -1 because of missing mandatory fields
 
-		$sql="DELETE FROM ".MAIN_DB_PREFIX."expensereport where ref=''";
+		$sql = "DELETE FROM ".MAIN_DB_PREFIX."expensereport where ref=''";
 		$db->query($sql);
 
 		// Create supplier order
-		$localobject2=new ExpenseReport($db);
+		$localobject2 = new ExpenseReport($db);
 		$localobject2->initAsSpecimen();        // Init a specimen with lines
 		$localobject2->status = 0;
 		$localobject2->fk_statut = 0;
 
-		$result=$localobject2->create($user);
+		$result = $localobject2->create($user);
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThanOrEqual(0, $result, "Error on test ExpenseReport create 2 : ".$localobject2->error);
 
@@ -102,13 +102,13 @@ class ExpenseReportTest extends CommonClassTest
 	public function testExpenseReportFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new ExpenseReport($db);
-		$result=$localobject->fetch($id);
+		$localobject = new ExpenseReport($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -127,12 +127,12 @@ class ExpenseReportTest extends CommonClassTest
 	public function testExpenseReportValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setValidate($user);
+		$result = $localobject->setValidate($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -151,12 +151,12 @@ class ExpenseReportTest extends CommonClassTest
 	public function testExpenseReportApprove($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setApproved($user);
+		$result = $localobject->setApproved($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -175,12 +175,12 @@ class ExpenseReportTest extends CommonClassTest
 	public function testExpenseReportCancel($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->set_cancel($user, 'Because...');
+		$result = $localobject->set_cancel($user, 'Because...');
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -199,12 +199,12 @@ class ExpenseReportTest extends CommonClassTest
 	public function testExpenseReportOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->getSumPayments();
+		$result = $localobject->getSumPayments();
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertGreaterThanOrEqual(0, $result);
 
@@ -223,14 +223,14 @@ class ExpenseReportTest extends CommonClassTest
 	public function testExpenseReportDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new ExpenseReport($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new ExpenseReport($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);

--- a/test/phpunit/ExportTest.php
+++ b/test/phpunit/ExportTest.php
@@ -82,7 +82,7 @@ class ExportTest extends CommonClassTest
 	{
 		global $conf,$user,$langs,$db;
 
-		$model='csvutf8';
+		$model = 'csvutf8';
 
 		$conf->global->EXPORT_CSV_SEPARATOR_TO_USE = ',';
 		print 'EXPORT_CSV_SEPARATOR_TO_USE = ' . getDolGlobalString('EXPORT_CSV_SEPARATOR_TO_USE');
@@ -97,31 +97,31 @@ class ExportTest extends CommonClassTest
 		// First test without option USE_STRICT_CSV_RULES
 		unset($conf->global->USE_STRICT_CSV_RULES);
 
-		$valtotest='A simple string';
+		$valtotest = 'A simple string';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 'A simple string');
 
-		$valtotest='A string with , and ; inside';
+		$valtotest = 'A string with , and ; inside';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with , and ; inside"', 'Error in csvClean for '.$file);
 
-		$valtotest='A string with " inside';
+		$valtotest = 'A string with " inside';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with "" inside"');
 
-		$valtotest='A string with " inside and '."\r\n".' carriage returns';
+		$valtotest = 'A string with " inside and '."\r\n".' carriage returns';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with "" inside and \n carriage returns"');
 
-		$valtotest='A string with <a href="aaa"><strong>html<br>content</strong></a> inside<br>'."\n";
+		$valtotest = 'A string with <a href="aaa"><strong>html<br>content</strong></a> inside<br>'."\n";
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
@@ -130,31 +130,31 @@ class ExportTest extends CommonClassTest
 		// Same tests with strict mode
 		$conf->global->USE_STRICT_CSV_RULES = 1;
 
-		$valtotest='A simple string';
+		$valtotest = 'A simple string';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 'A simple string');
 
-		$valtotest='A string with , and ; inside';
+		$valtotest = 'A string with , and ; inside';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with , and ; inside"');
 
-		$valtotest='A string with " inside';
+		$valtotest = 'A string with " inside';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with "" inside"');
 
-		$valtotest='A string with " inside and '."\r\n".' carriage returns';
+		$valtotest = 'A string with " inside and '."\r\n".' carriage returns';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, "\"A string with \"\" inside and \r\n carriage returns\"");
 
-		$valtotest='A string with <a href="aaa"><strong>html<br>content</strong></a> inside<br>'."\n";
+		$valtotest = 'A string with <a href="aaa"><strong>html<br>content</strong></a> inside<br>'."\n";
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
@@ -171,7 +171,7 @@ class ExportTest extends CommonClassTest
 	{
 		global $conf,$user,$langs,$db;
 
-		$model='csviso';
+		$model = 'csviso';
 
 		$conf->global->EXPORT_CSV_SEPARATOR_TO_USE = ',';
 		print 'EXPORT_CSV_SEPARATOR_TO_USE = ' . getDolGlobalString('EXPORT_CSV_SEPARATOR_TO_USE');
@@ -186,31 +186,31 @@ class ExportTest extends CommonClassTest
 		// First test without option USE_STRICT_CSV_RULES
 		unset($conf->global->USE_STRICT_CSV_RULES);
 
-		$valtotest='A simple string';
+		$valtotest = 'A simple string';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 'A simple string');
 
-		$valtotest='A string with , and ; inside';
+		$valtotest = 'A string with , and ; inside';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with , and ; inside"', 'Error in csvClean for '.$file);
 
-		$valtotest='A string with " inside';
+		$valtotest = 'A string with " inside';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with "" inside"');
 
-		$valtotest='A string with " inside and '."\r\n".' carriage returns';
+		$valtotest = 'A string with " inside and '."\r\n".' carriage returns';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with "" inside and \n carriage returns"');
 
-		$valtotest='A string with <a href="aaa"><strong>html<br>content</strong></a> inside<br>'."\n";
+		$valtotest = 'A string with <a href="aaa"><strong>html<br>content</strong></a> inside<br>'."\n";
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
@@ -219,31 +219,31 @@ class ExportTest extends CommonClassTest
 		// Same tests with strict mode
 		$conf->global->USE_STRICT_CSV_RULES = 1;
 
-		$valtotest='A simple string';
+		$valtotest = 'A simple string';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 'A simple string');
 
-		$valtotest='A string with , and ; inside';
+		$valtotest = 'A string with , and ; inside';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with , and ; inside"');
 
-		$valtotest='A string with " inside';
+		$valtotest = 'A string with " inside';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '"A string with "" inside"');
 
-		$valtotest='A string with " inside and '."\r\n".' carriage returns';
+		$valtotest = 'A string with " inside and '."\r\n".' carriage returns';
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, "\"A string with \"\" inside and \r\n carriage returns\"");
 
-		$valtotest='A string with <a href="aaa"><strong>html<br>content</strong></a> inside<br>'."\n";
+		$valtotest = 'A string with <a href="aaa"><strong>html<br>content</strong></a> inside<br>'."\n";
 		print __METHOD__." valtotest=".$valtotest."\n";
 		$result = $objmodel->csvClean($valtotest, $langs->charset_output);
 		print __METHOD__." result=".$result."\n";
@@ -262,50 +262,50 @@ class ExportTest extends CommonClassTest
 
 		$sql = "SELECT f.ref as f_ref, f.total_ht as f_total, f.total_tva as f_tva FROM ".MAIN_DB_PREFIX."facture f";
 
-		$objexport=new Export($db);
+		$objexport = new Export($db);
 		//$objexport->load_arrays($user,$datatoexport);
 
 		// Define properties
-		$datatoexport='test';
-		$array_selected = array("f.ref"=>1, "f.total"=>2, "f.tva"=>3);
-		$array_export_fields = array("f.ref"=>"FacNumber", "f.total"=>"FacTotal", "f.tva"=>"FacVat");
-		$array_alias = array("f_ref"=>"ref", "f_total"=>"total", "f_tva"=>"tva");
-		$objexport->array_export_fields[0]=$array_export_fields;
-		$objexport->array_export_alias[0]=$array_alias;
+		$datatoexport = 'test';
+		$array_selected = array("f.ref" => 1, "f.total" => 2, "f.tva" => 3);
+		$array_export_fields = array("f.ref" => "FacNumber", "f.total" => "FacTotal", "f.tva" => "FacVat");
+		$array_alias = array("f_ref" => "ref", "f_total" => "total", "f_tva" => "tva");
+		$objexport->array_export_fields[0] = $array_export_fields;
+		$objexport->array_export_alias[0] = $array_alias;
 
 		dol_mkdir($conf->export->dir_temp);
 
-		$model='csviso';
+		$model = 'csviso';
 
 		// Build export file
 		print "Process build_file for model = ".$model."\n";
-		$result=$objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
+		$result = $objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
 		$expectedresult = 1;
 		$this->assertEquals($expectedresult, $result, 'Error in CSV export');
 
-		$model='csvutf8';
+		$model = 'csvutf8';
 
 		// Build export file
 		print "Process build_file for model = ".$model."\n";
-		$result=$objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
+		$result = $objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
 		$expectedresult = 1;
 		$this->assertEquals($expectedresult, $result, 'Error in CSV export');
 
-		$model='tsv';
+		$model = 'tsv';
 
 		// Build export file
 		print "Process build_file for model = ".$model."\n";
-		$result=$objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
-		$expectedresult=1;
+		$result = $objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
+		$expectedresult = 1;
 		$this->assertEquals($expectedresult, $result, 'Error in TSV export');
 
-		$model='excel2007';
+		$model = 'excel2007';
 
 		// Build export file
 		/* ko on php 7.4 on travis (zip not available) */
 		print "Process build_file for model = ".$model."\n";
-		$result=$objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
-		$expectedresult=1;
+		$result = $objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
+		$expectedresult = 1;
 		$this->assertEquals($expectedresult, $result, 'Error in Excel2007 export');
 
 		return true;
@@ -373,36 +373,36 @@ class ExportTest extends CommonClassTest
 	{
 		global $conf,$user,$langs,$db;
 
-		$model='csviso';
+		$model = 'csviso';
 
-		$filterdatatoexport='';
+		$filterdatatoexport = '';
 		//$filterdatatoexport='';
 		//$array_selected = array("s.rowid"=>1, "s.nom"=>2);	// Must be fields found into declaration of dataset
 
 		// Load properties of arrays to make export
-		$objexport=new Export($db);
-		$result=$objexport->load_arrays($user, $filterdatatoexport);	// This load ->array_export_xxx properties for datatoexport
+		$objexport = new Export($db);
+		$result = $objexport->load_arrays($user, $filterdatatoexport);	// This load ->array_export_xxx properties for datatoexport
 
 		// Loop on each dataset
 		foreach ($objexport->array_export_code as $key => $datatoexport) {
-			$exportfile=$conf->export->dir_temp.'/'.$user->id.'/export_'.$datatoexport.'.csv';
+			$exportfile = $conf->export->dir_temp.'/'.$user->id.'/export_'.$datatoexport.'.csv';
 			print "Process export for dataset ".$datatoexport." into ".$exportfile."\n";
 			dol_delete_file($exportfile);
 
 			// Generate $array_selected
-			$i=0;
-			$array_selected=array();
+			$i = 0;
+			$array_selected = array();
 			foreach ($objexport->array_export_fields[$key] as $key => $val) {
-				$array_selected[$key]=$i++;
+				$array_selected[$key] = $i++;
 			}
 			//var_dump($array_selected);
 
 			// Build export file
 			$sql = "";
-			$result=$objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
+			$result = $objexport->build_file($user, $model, $datatoexport, $array_selected, array(), $sql);
 			$expectedresult = 1;
 			$this->assertEquals($expectedresult, $result, "Call build_file() to export ".$exportfile.' failed: '.$objexport->error);
-			$result=dol_is_file($exportfile);
+			$result = dol_is_file($exportfile);
 			$this->assertTrue($result, 'File '.$exportfile.' not found');
 		}
 

--- a/test/phpunit/FactureFournisseurTest.php
+++ b/test/phpunit/FactureFournisseurTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -57,14 +57,14 @@ class FactureFournisseurTest extends CommonClassTest
 	public function testFactureFournisseurCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new FactureFournisseur($db);
+		$localobject = new FactureFournisseur($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
 		print __METHOD__." result=".$result."\n";
@@ -83,13 +83,13 @@ class FactureFournisseurTest extends CommonClassTest
 	public function testFactureFournisseurFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new FactureFournisseur($db);
-		$result=$localobject->fetch($id);
+		$localobject = new FactureFournisseur($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -108,13 +108,13 @@ class FactureFournisseurTest extends CommonClassTest
 	public function testFactureFournisseurUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->note='New note after update';
-		$result=$localobject->update($user);
+		$localobject->note = 'New note after update';
+		$result = $localobject->update($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
@@ -133,12 +133,12 @@ class FactureFournisseurTest extends CommonClassTest
 	public function testFactureFournisseurValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->validate($user);
+		$result = $localobject->validate($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
@@ -157,10 +157,10 @@ class FactureFournisseurTest extends CommonClassTest
 	public function testFactureFournisseurOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -186,14 +186,14 @@ class FactureFournisseurTest extends CommonClassTest
 	public function testFactureFournisseurDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new FactureFournisseur($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new FactureFournisseur($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0, $localobject->errorsToString());

--- a/test/phpunit/FactureRecTest.php
+++ b/test/phpunit/FactureRecTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -58,18 +58,18 @@ class FactureRecTest extends CommonClassTest
 	{
 		global $conf,$user,$langs,$db;
 
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobjectinv=new Facture($db);
+		$localobjectinv = new Facture($db);
 		$localobjectinv->initAsSpecimen();
 		$result = $localobjectinv->create($user);
 
 		print __METHOD__." result=".$result."\n";
 
-		$localobject=new FactureRec($db);
+		$localobject = new FactureRec($db);
 		$localobject->initAsSpecimen();
 		$result = $localobject->create($user, $localobjectinv->id);
 
@@ -91,12 +91,12 @@ class FactureRecTest extends CommonClassTest
 	public function testFactureRecFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new FactureRec($db);
+		$localobject = new FactureRec($db);
 		$result = $localobject->fetch($id);
 
 		print __METHOD__." result=".$result."\n";
@@ -114,7 +114,7 @@ class FactureRecTest extends CommonClassTest
 	 */
 	public function changeProperties(&$localobject)
 	{
-		$localobject->note_private='New note';
+		$localobject->note_private = 'New note';
 		//$localobject->note='New note after update';
 	}
 
@@ -129,23 +129,23 @@ class FactureRecTest extends CommonClassTest
 	 */
 	public function objCompare($oA, $oB, $ignoretype = true, $fieldstoignorearray = array('id'))
 	{
-		$retAr=array();
+		$retAr = array();
 
 		if (get_class($oA) !== get_class($oB)) {
-			$retAr[]="Supplied objects are not of same class.";
+			$retAr[] = "Supplied objects are not of same class.";
 		} else {
-			$oVarsA=get_object_vars($oA);
-			$oVarsB=get_object_vars($oB);
-			$aKeys=array_keys($oVarsA);
+			$oVarsA = get_object_vars($oA);
+			$oVarsB = get_object_vars($oB);
+			$aKeys = array_keys($oVarsA);
 			foreach ($aKeys as $sKey) {
 				if (in_array($sKey, $fieldstoignorearray)) {
 					continue;
 				}
 				if (! $ignoretype && ($oVarsA[$sKey] !== $oVarsB[$sKey])) {
-					$retAr[]=$sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
+					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
 				}
 				if ($ignoretype && ($oVarsA[$sKey] != $oVarsB[$sKey])) {
-					$retAr[]=$sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
+					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
 				}
 			}
 		}

--- a/test/phpunit/FactureTest.php
+++ b/test/phpunit/FactureTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -81,14 +81,14 @@ class FactureTest extends CommonClassTest
 	public function testFactureCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
 		return $result;
@@ -106,13 +106,13 @@ class FactureTest extends CommonClassTest
 	public function testFactureFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Facture($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Facture($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -131,13 +131,13 @@ class FactureTest extends CommonClassTest
 	public function testFactureUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$this->changeProperties($localobject);
-		$result=$localobject->update($user);
+		$result = $localobject->update($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -156,18 +156,18 @@ class FactureTest extends CommonClassTest
 	public function testFactureValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->validate($user);
+		$result = $localobject->validate($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
 
 		// Test everything are still same than specimen
-		$newlocalobject=new Facture($db);
+		$newlocalobject = new Facture($db);
 		$newlocalobject->initAsSpecimen();
 		$this->changeProperties($newlocalobject);
 
@@ -205,10 +205,10 @@ class FactureTest extends CommonClassTest
 	public function testFactureOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -219,7 +219,7 @@ class FactureTest extends CommonClassTest
 		print __METHOD__." localobject->date_creation=".$localobject->date_creation."\n";
 		$this->assertNotEquals($localobject->date_creation, '');
 
-		$result=$localobject->demande_prelevement($user);
+		$result = $localobject->demande_prelevement($user);
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -238,43 +238,43 @@ class FactureTest extends CommonClassTest
 	public function testFactureDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Force default setup
 		unset($conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED);
 		unset($conf->global->INVOICE_CAN_NEVER_BE_REMOVED);
 
-		$localobject=new Facture($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Facture($db);
+		$result = $localobject->fetch($id);
 
 		// Create another invoice and validate it after $localobject
-		$localobject2=new Facture($db);
-		$result=$localobject2->initAsSpecimen();
-		$result=$localobject2->create($user);
-		$result=$localobject2->validate($user);
+		$localobject2 = new Facture($db);
+		$result = $localobject2->initAsSpecimen();
+		$result = $localobject2->create($user);
+		$result = $localobject2->validate($user);
 		print 'Invoice $localobject ref = '.$localobject->ref."\n";
 		print 'Invoice $localobject2 created with ref = '.$localobject2->ref."\n";
 
 		$conf->global->INVOICE_CAN_NEVER_BE_REMOVED = 1;
 
-		$result=$localobject2->delete($user);					// Deletion is KO, option INVOICE_CAN_NEVER_BE_REMOVED is on
+		$result = $localobject2->delete($user);					// Deletion is KO, option INVOICE_CAN_NEVER_BE_REMOVED is on
 		print __METHOD__." id=".$localobject2->id." ref=".$localobject2->ref." result=".$result."\n";
 		$this->assertEquals(0, $result, 'Deletion should fail, option INVOICE_CAN_NEVER_BE_REMOVED is on');
 
 		unset($conf->global->INVOICE_CAN_NEVER_BE_REMOVED);
 
-		$result=$localobject->delete($user);					// Deletion is KO, it is not last invoice
+		$result = $localobject->delete($user);					// Deletion is KO, it is not last invoice
 		print __METHOD__." id=".$localobject->id." ref=".$localobject->ref." result=".$result."\n";
 		$this->assertEquals(0, $result, 'Deletion should fail, it is not last invoice');
 
-		$result=$localobject2->delete($user);					// Deletion is OK, it is last invoice
+		$result = $localobject2->delete($user);					// Deletion is OK, it is last invoice
 		print __METHOD__." id=".$localobject2->id." ref=".$localobject2->ref." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, 'Deletion should work, it is last invoice');
 
-		$result=$localobject->delete($user);					// Deletion is KO, it is not last invoice
+		$result = $localobject->delete($user);					// Deletion is KO, it is not last invoice
 		print __METHOD__." id=".$localobject->id." ref=".$localobject->ref." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, 'Deletion should work, it is again last invoice');
 
@@ -289,7 +289,7 @@ class FactureTest extends CommonClassTest
 	 */
 	public function changeProperties(&$localobject)
 	{
-		$localobject->note_private='New note';
+		$localobject->note_private = 'New note';
 		//$localobject->note='New note after update';
 	}
 
@@ -304,23 +304,23 @@ class FactureTest extends CommonClassTest
 	 */
 	public function objCompare($oA, $oB, $ignoretype = true, $fieldstoignorearray = array('id'))
 	{
-		$retAr=array();
+		$retAr = array();
 
 		if (get_class($oA) !== get_class($oB)) {
-			$retAr[]="Supplied objects are not of same class.";
+			$retAr[] = "Supplied objects are not of same class.";
 		} else {
-			$oVarsA=get_object_vars($oA);
-			$oVarsB=get_object_vars($oB);
-			$aKeys=array_keys($oVarsA);
+			$oVarsA = get_object_vars($oA);
+			$oVarsB = get_object_vars($oB);
+			$aKeys = array_keys($oVarsA);
 			foreach ($aKeys as $sKey) {
 				if (in_array($sKey, $fieldstoignorearray)) {
 					continue;
 				}
 				if (! $ignoretype && ($oVarsA[$sKey] !== $oVarsB[$sKey])) {
-					$retAr[]=$sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
+					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
 				}
 				if ($ignoretype && ($oVarsA[$sKey] != $oVarsB[$sKey])) {
-					$retAr[]=$sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
+					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
 				}
 			}
 		}

--- a/test/phpunit/FactureTestRounding.php
+++ b/test/phpunit/FactureTestRounding.php
@@ -35,7 +35,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,27 +56,27 @@ class FactureTestRounding extends CommonClassTest
 	public function testFactureRoundingCreate1()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0;
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
-		$localobject->lines=array();
+		$localobject->lines = array();
 		unset($localobject->total_ht);
 		unset($localobject->total_ttc);
 		unset($localobject->total_tva);
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		// Add two lines
-		for ($i=0; $i<2; $i++) {
+		for ($i = 0; $i < 2; $i++) {
 			$localobject->addline('Description '.$i, 1.24, 1, 10);
 		}
 
-		$newlocalobject=new Facture($db);
+		$newlocalobject = new Facture($db);
 		$newlocalobject->fetch($result);
 		//var_dump($newlocalobject);
 
@@ -98,27 +98,27 @@ class FactureTestRounding extends CommonClassTest
 	public function testFactureRoundingCreate2()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0;
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
-		$localobject->lines=array();
+		$localobject->lines = array();
 		unset($localobject->total_ht);
 		unset($localobject->total_ttc);
 		unset($localobject->total_vat);
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		// Add two lines
-		for ($i=0; $i<2; $i++) {
+		for ($i = 0; $i < 2; $i++) {
 			$localobject->addline('Description '.$i, 1.24, 1, 10);
 		}
 
-		$newlocalobject=new Facture($db);
+		$newlocalobject = new Facture($db);
 		$newlocalobject->fetch($result);
 		//var_dump($newlocalobject);
 
@@ -137,17 +137,17 @@ class FactureTestRounding extends CommonClassTest
 	public function testFactureAddLine1()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0
-		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0;
 
-		$localobject1a=new Facture($db);
+		$localobject1a = new Facture($db);
 		$localobject1a->initAsSpecimen('nolines');
-		$facid=$localobject1a->create($user);
+		$facid = $localobject1a->create($user);
 		$localobject1a->addline('Line 1', 6.36, 15, 21);	// This include update_price
 		print __METHOD__." id=".$facid." total_ttc=".$localobject1a->total_ttc."\n";
 		$this->assertEquals(95.40, $localobject1a->total_ht);
@@ -155,11 +155,11 @@ class FactureTestRounding extends CommonClassTest
 		$this->assertEquals(115.43, $localobject1a->total_ttc);
 
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 1
-		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=1;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 1;
 
-		$localobject1b=new Facture($db);
+		$localobject1b = new Facture($db);
 		$localobject1b->initAsSpecimen('nolines');
-		$facid=$localobject1b->create($user);
+		$facid = $localobject1b->create($user);
 		$localobject1b->addline('Line 1', 6.36, 15, 21);	// This include update_price
 		print __METHOD__." id=".$facid." total_ttc=".$localobject1b->total_ttc."\n";
 		$this->assertEquals(95.40, $localobject1b->total_ht, 'testFactureAddLine1 total_ht');
@@ -178,17 +178,17 @@ class FactureTestRounding extends CommonClassTest
 	public function testFactureAddLine2()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0
-		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0;
 
-		$localobject2=new Facture($db);
+		$localobject2 = new Facture($db);
 		$localobject2->initAsSpecimen('nolines');
-		$facid=$localobject2->create($user);
+		$facid = $localobject2->create($user);
 		$localobject2->addline('Line 1', 6.36, 5, 21);
 		$localobject2->addline('Line 2', 6.36, 5, 21);
 		$localobject2->addline('Line 3', 6.36, 5, 21);
@@ -198,11 +198,11 @@ class FactureTestRounding extends CommonClassTest
 		$this->assertEquals(115.44, $localobject2->total_ttc);
 
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 1
-		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=1;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 1;
 
-		$localobject2=new Facture($db);
+		$localobject2 = new Facture($db);
 		$localobject2->initAsSpecimen('nolines');
-		$facid=$localobject2->create($user);
+		$facid = $localobject2->create($user);
 		$localobject2->addline('Line 1', 6.36, 5, 21);
 		$localobject2->addline('Line 2', 6.36, 5, 21);
 		$localobject2->addline('Line 3', 6.36, 5, 21);
@@ -223,17 +223,17 @@ class FactureTestRounding extends CommonClassTest
 	public function testFactureAddLine3()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0
-		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0;
 
-		$localobject3=new Facture($db);
+		$localobject3 = new Facture($db);
 		$localobject3->initAsSpecimen('nolines');
-		$facid=$localobject3->create($user);
+		$facid = $localobject3->create($user);
 		$localobject3->addline('Line 1', 6.36, 3, 21);
 		$localobject3->addline('Line 2', 6.36, 3, 21);
 		$localobject3->addline('Line 3', 6.36, 3, 21);
@@ -245,11 +245,11 @@ class FactureTestRounding extends CommonClassTest
 		$this->assertEquals(115.45, $localobject3->total_ttc);
 
 		// With option MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 1
-		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=1;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 1;
 
-		$localobject3=new Facture($db);
+		$localobject3 = new Facture($db);
 		$localobject3->initAsSpecimen('nolines');
-		$facid=$localobject3->create($user);
+		$facid = $localobject3->create($user);
 		$localobject3->addline('Line 1', 6.36, 3, 21);
 		$localobject3->addline('Line 2', 6.36, 3, 21);
 		$localobject3->addline('Line 3', 6.36, 3, 21);

--- a/test/phpunit/FichinterTest.php
+++ b/test/phpunit/FichinterTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,20 +56,20 @@ class FichinterTest extends CommonClassTest
 	public function testFichinterCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$soc = new Societe($db);
 		$soc->name = "FichinterTest Unittest";
 		$socid = $soc->create($user);
 		$this->assertLessThan($socid, 0, $soc->errorsToString());
 
-		$localobject=new Fichinter($db);
+		$localobject = new Fichinter($db);
 		$localobject->initAsSpecimen();
 		$localobject->socid = $socid;
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
@@ -89,13 +89,13 @@ class FichinterTest extends CommonClassTest
 	public function testFichinterFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Fichinter($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Fichinter($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
@@ -115,12 +115,12 @@ class FichinterTest extends CommonClassTest
 	public function testFichinterValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setValid($user);
+		$result = $localobject->setValid($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0, $localobject->errorsToString());
@@ -139,10 +139,10 @@ class FichinterTest extends CommonClassTest
 	public function testFichinterOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -168,14 +168,14 @@ class FichinterTest extends CommonClassTest
 	public function testFichinterDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Fichinter($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Fichinter($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0, $localobject->errorsToString());

--- a/test/phpunit/FormAdminTest.php
+++ b/test/phpunit/FormAdminTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,13 +56,13 @@ class FormAdminTest extends CommonClassTest
 	public function testSelectPaperFormat()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new FormAdmin($db);
-		$result=$localobject->select_paper_format('', 'paperformat_id', 'A4', 0, 1);
+		$localobject = new FormAdmin($db);
+		$result = $localobject->select_paper_format('', 'paperformat_id', 'A4', 0, 1);
 
 		$this->assertEquals($result, '<select class="flat" id="paperformat_id" name="paperformat_id"><option value="EUA4">Format A4 - 210x297 mm</option></select>');
 		print __METHOD__." result=".$result."\n";

--- a/test/phpunit/FormTest.php
+++ b/test/phpunit/FormTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,13 +56,13 @@ class FormTest extends CommonClassTest
 	public function testSelectProduitsList()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Form($db);
-		$result=$localobject->select_produits_list('', 'productid', '', 5, 0, '', 1, 2, 1);
+		$localobject = new Form($db);
+		$result = $localobject->select_produits_list('', 'productid', '', 5, 0, '', 1, 2, 1);
 
 		$this->assertEquals(count($result), 5);
 		print __METHOD__." count result=".count($result)."\n";
@@ -70,7 +70,7 @@ class FormTest extends CommonClassTest
 		$conf->global->ENTREPOT_EXTRA_STATUS = 1;
 
 		// Exclude stock in warehouseinternal
-		$result=$localobject->select_produits_list('', 'productid', '', 5, 0, '', 1, 2, 1, 0, '1', 0, '', 0, 'warehouseclosed,warehouseopen');
+		$result = $localobject->select_produits_list('', 'productid', '', 5, 0, '', 1, 2, 1, 0, '1', 0, '', 0, 'warehouseclosed,warehouseopen');
 		$this->assertEquals(count($result), 5);
 		print __METHOD__." count result=".count($result)."\n";
 

--- a/test/phpunit/Functions2LibTest.php
+++ b/test/phpunit/Functions2LibTest.php
@@ -79,7 +79,7 @@ class Functions2LibTest extends CommonClassTest
 	 */
 	public function testJsUnEscape()
 	{
-		$result=jsUnEscape('%u03BD%u03B5%u03BF');
+		$result = jsUnEscape('%u03BD%u03B5%u03BF');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('νεο', $result);
 	}
@@ -173,35 +173,35 @@ class Functions2LibTest extends CommonClassTest
 	public function testIsIP()
 	{
 		// Not valid
-		$ip='a299.299.299.299';
-		$result=is_ip($ip);
+		$ip = 'a299.299.299.299';
+		$result = is_ip($ip);
 		print __METHOD__." for ".$ip." result=".$result."\n";
 		$this->assertEquals(0, $result, $ip);
 
 		// Reserved IP range (not checked by is_ip function)
-		$ip='169.254.0.0';
-		$result=is_ip($ip);
+		$ip = '169.254.0.0';
+		$result = is_ip($ip);
 		print __METHOD__." for ".$ip." result=".$result."\n";
 		//$this->assertEquals(2,$result,$ip);      // Assertion disabled because returned value differs between PHP patch version
 
-		$ip='1.2.3.4';
-		$result=is_ip($ip);
+		$ip = '1.2.3.4';
+		$result = is_ip($ip);
 		print __METHOD__." for ".$ip." result=".$result."\n";
 		$this->assertEquals(1, $result, $ip);
 
 		// Private IP ranges
-		$ip='10.0.0.0';
-		$result=is_ip($ip);
+		$ip = '10.0.0.0';
+		$result = is_ip($ip);
 		print __METHOD__." for ".$ip." result=".$result."\n";
 		$this->assertEquals(2, $result, $ip);
 
-		$ip='172.16.0.0';
-		$result=is_ip($ip);
+		$ip = '172.16.0.0';
+		$result = is_ip($ip);
 		print __METHOD__." for ".$ip." result=".$result."\n";
 		$this->assertEquals(2, $result, $ip);
 
-		$ip='192.168.0.0';
-		$result=is_ip($ip);
+		$ip = '192.168.0.0';
+		$result = is_ip($ip);
 		print __METHOD__." for ".$ip." result=".$result."\n";
 		$this->assertEquals(2, $result, $ip);
 	}

--- a/test/phpunit/FunctionsLibTest.php
+++ b/test/phpunit/FunctionsLibTest.php
@@ -217,17 +217,17 @@ class FunctionsLibTest extends CommonClassTest
 		global $conf, $langs, $db;
 
 		// An attempt for SQL injection
-		$filter='if(now()=sysdate()%2Csleep(6)%2C0)';
+		$filter = 'if(now()=sysdate()%2Csleep(6)%2C0)';
 		$sql = forgeSQLFromUniversalSearchCriteria($filter);
 		$this->assertEquals('Filter error - Bad syntax of the search string', $sql);
 
 		// A real search string
-		$filter='(((statut:=:1) or (entity:in:__AAA__)) and (abc:<:2.0) and (abc:!=:1.23))';
+		$filter = '(((statut:=:1) or (entity:in:__AAA__)) and (abc:<:2.0) and (abc:!=:1.23))';
 		$sql = forgeSQLFromUniversalSearchCriteria($filter);
 		$this->assertEquals(' AND ((((statut = 1) or (entity IN (__AAA__))) and (abc < 2) and (abc <> 1.23)))', $sql);
 
 		// A real search string
-		$filter="(t.ref:like:'SO-%') or (t.date_creation:<:'20160101') or (t.date_creation:<:'2016-01-01 12:30:00') or (t.nature:is:NULL)";
+		$filter = "(t.ref:like:'SO-%') or (t.date_creation:<:'20160101') or (t.date_creation:<:'2016-01-01 12:30:00') or (t.nature:is:NULL)";
 		$sql = forgeSQLFromUniversalSearchCriteria($filter);
 		$this->assertEquals(" AND ((t.ref LIKE 'SO-%') or (t.date_creation < '20160101') or (t.date_creation < 0) or (t.nature IS NULL))", $sql);
 
@@ -326,23 +326,23 @@ class FunctionsLibTest extends CommonClassTest
 	{
 		// Nb of line is same than entry text
 
-		$input="bidon@bademail";
-		$result=isValidEmail($input);
+		$input = "bidon@bademail";
+		$result = isValidEmail($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertFalse($result, 'Check isValidEmail '.$input);
 
-		$input="test@yahoo.com";
-		$result=isValidEmail($input);
+		$input = "test@yahoo.com";
+		$result = isValidEmail($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertTrue($result, 'Check isValidEmail '.$input);
 
-		$input="The name of sender <test@yahoo.com>";
-		$result=isValidEmail($input);
+		$input = "The name of sender <test@yahoo.com>";
+		$result = isValidEmail($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertFalse($result, 'Check isValidEmail '.$input);
 
-		$input="1234.abcdefg@domainame.com.br";
-		$result=isValidEmail($input);
+		$input = "1234.abcdefg@domainame.com.br";
+		$result = isValidEmail($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertTrue($result, 'Check isValidEmail '.$input);
 	}
@@ -356,18 +356,18 @@ class FunctionsLibTest extends CommonClassTest
 	{
 		// Nb of line is same than entry text
 
-		$input="yahoo.com";
-		$result=isValidMXRecord($input);
+		$input = "yahoo.com";
+		$result = isValidMXRecord($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(1, $result);
 
-		$input="yhaoo.com";
-		$result=isValidMXRecord($input);
+		$input = "yhaoo.com";
+		$result = isValidMXRecord($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(0, $result);
 
-		$input="dolibarr.fr";
-		$result=isValidMXRecord($input);
+		$input = "dolibarr.fr";
+		$result = isValidMXRecord($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(0, $result);
 	}
@@ -381,57 +381,57 @@ class FunctionsLibTest extends CommonClassTest
 	{
 		// Nb of line is same than entry text
 
-		$input="aaaa";
-		$result=dolGetFirstLineOfText($input);
+		$input = "aaaa";
+		$result = dolGetFirstLineOfText($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa", $result);
 
-		$input="aaaa\nbbbbbbbbbbbb\n";
-		$result=dolGetFirstLineOfText($input, 2);
+		$input = "aaaa\nbbbbbbbbbbbb\n";
+		$result = dolGetFirstLineOfText($input, 2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa\nbbbbbbbbbbbb", $result);
 
-		$input="aaaa<br>bbbbbbbbbbbb<br>";
-		$result=dolGetFirstLineOfText($input, 2);
+		$input = "aaaa<br>bbbbbbbbbbbb<br>";
+		$result = dolGetFirstLineOfText($input, 2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa<br>\nbbbbbbbbbbbb", $result);
 
 		// Nb of line is lower
 
-		$input="aaaa\nbbbbbbbbbbbb\ncccccc\n";
-		$result=dolGetFirstLineOfText($input);
+		$input = "aaaa\nbbbbbbbbbbbb\ncccccc\n";
+		$result = dolGetFirstLineOfText($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa...", $result);
 
-		$input="aaaa<br>bbbbbbbbbbbb<br>cccccc<br>";
-		$result=dolGetFirstLineOfText($input);
+		$input = "aaaa<br>bbbbbbbbbbbb<br>cccccc<br>";
+		$result = dolGetFirstLineOfText($input);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa...", $result);
 
-		$input="aaaa\nbbbbbbbbbbbb\ncccccc\n";
-		$result=dolGetFirstLineOfText($input, 2);
+		$input = "aaaa\nbbbbbbbbbbbb\ncccccc\n";
+		$result = dolGetFirstLineOfText($input, 2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa\nbbbbbbbbbbbb...", $result);
 
-		$input="aaaa<br>bbbbbbbbbbbb<br>cccccc<br>";
-		$result=dolGetFirstLineOfText($input, 2);
+		$input = "aaaa<br>bbbbbbbbbbbb<br>cccccc<br>";
+		$result = dolGetFirstLineOfText($input, 2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa<br>\nbbbbbbbbbbbb...", $result);
 
 		// Nb of line is higher
 
-		$input="aaaa<br>bbbbbbbbbbbb<br>cccccc";
-		$result=dolGetFirstLineOfText($input, 100);
+		$input = "aaaa<br>bbbbbbbbbbbb<br>cccccc";
+		$result = dolGetFirstLineOfText($input, 100);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa<br>\nbbbbbbbbbbbb<br>\ncccccc", $result, 'dolGetFirstLineOfText with nb 100 a');
 
-		$input="aaaa<br>bbbbbbbbbbbb<br>cccccc<br>";
-		$result=dolGetFirstLineOfText($input, 100);
+		$input = "aaaa<br>bbbbbbbbbbbb<br>cccccc<br>";
+		$result = dolGetFirstLineOfText($input, 100);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa<br>\nbbbbbbbbbbbb<br>\ncccccc", $result, 'dolGetFirstLineOfText with nb 100 b');
 
-		$input="aaaa<br>bbbbbbbbbbbb<br>cccccc<br>\n";
-		$result=dolGetFirstLineOfText($input, 100);
+		$input = "aaaa<br>bbbbbbbbbbbb<br>cccccc<br>\n";
+		$result = dolGetFirstLineOfText($input, 100);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("aaaa<br>\nbbbbbbbbbbbb<br>\ncccccc", $result, 'dolGetFirstLineOfText with nb 100 c');
 	}
@@ -452,11 +452,11 @@ class FunctionsLibTest extends CommonClassTest
 		var_dump($tmp);
 		*/
 
-		$result=dol_buildpath('/google/oauth2callback.php', 2);
+		$result = dol_buildpath('/google/oauth2callback.php', 2);
 		print __METHOD__." dol_buildpath result=".$result."\n";
 		$this->assertStringStartsWith('http', $result);
 
-		$result=dol_buildpath('/google/oauth2callback.php', 3);
+		$result = dol_buildpath('/google/oauth2callback.php', 3);
 		print __METHOD__." dol_buildpath result=".$result."\n";
 		$this->assertStringStartsWith('http', $result);
 	}
@@ -470,8 +470,8 @@ class FunctionsLibTest extends CommonClassTest
 	public function testGetBrowserInfo()
 	{
 		// MSIE 5.0
-		$user_agent ='Mozilla/4.0 (compatible; MSIE 5.0; Windows 98; DigExt; KITV4 Wanadoo; KITV5 Wanadoo)';
-		$tmp=getBrowserInfo($user_agent);
+		$user_agent = 'Mozilla/4.0 (compatible; MSIE 5.0; Windows 98; DigExt; KITV4 Wanadoo; KITV5 Wanadoo)';
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('ie', $tmp['browsername']);
 		$this->assertEquals('5.0', $tmp['browserversion']);
 		$this->assertEmpty($tmp['phone']);
@@ -479,40 +479,40 @@ class FunctionsLibTest extends CommonClassTest
 		$this->assertEquals('classic', $tmp['layout']);
 
 		// Firefox 0.9.1
-		$user_agent ='Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.5a) Gecko/20030728 Mozilla Firefox/0.9.1';
-		$tmp=getBrowserInfo($user_agent);
+		$user_agent = 'Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.5a) Gecko/20030728 Mozilla Firefox/0.9.1';
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('firefox', $tmp['browsername']);
 		$this->assertEquals('0.9.1', $tmp['browserversion']);
 		$this->assertEmpty($tmp['phone']);
 		$this->assertFalse($tmp['tablet']);
 		$this->assertEquals('classic', $tmp['layout']);
 
-		$user_agent ='Mozilla/3.0 (Windows 98; U) Opera 6.03  [en]';
-		$tmp=getBrowserInfo($user_agent);
+		$user_agent = 'Mozilla/3.0 (Windows 98; U) Opera 6.03  [en]';
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('opera', $tmp['browsername']);
 		$this->assertEquals('6.03', $tmp['browserversion']);
 		$this->assertEmpty($tmp['phone']);
 		$this->assertFalse($tmp['tablet']);
 		$this->assertEquals('classic', $tmp['layout']);
 
-		$user_agent ='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.21 (KHTML, like Gecko) Chrome/19.0.1042.0 Safari/535.21';
-		$tmp=getBrowserInfo($user_agent);
+		$user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.21 (KHTML, like Gecko) Chrome/19.0.1042.0 Safari/535.21';
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('chrome', $tmp['browsername']);
 		$this->assertEquals('19.0.1042.0', $tmp['browserversion']);
 		$this->assertEmpty($tmp['phone']);
 		$this->assertFalse($tmp['tablet']);
 		$this->assertEquals('classic', $tmp['layout']);
 
-		$user_agent ='chrome (Mozilla/5.0 (X11; Linux i686) AppleWebKit/535.11 (KHTML, like Gecko) Chrome/17.0.963.56 Safari/535.11)';
-		$tmp=getBrowserInfo($user_agent);
+		$user_agent = 'chrome (Mozilla/5.0 (X11; Linux i686) AppleWebKit/535.11 (KHTML, like Gecko) Chrome/17.0.963.56 Safari/535.11)';
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('chrome', $tmp['browsername']);
 		$this->assertEquals('17.0.963.56', $tmp['browserversion']);
 		$this->assertEmpty($tmp['phone']);
 		$this->assertFalse($tmp['tablet']);
 		$this->assertEquals('classic', $tmp['layout']);
 
-		$user_agent ='Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1';
-		$tmp=getBrowserInfo($user_agent);
+		$user_agent = 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1';
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('safari', $tmp['browsername']);
 		$this->assertEquals('533.21.1', $tmp['browserversion']);
 		$this->assertEmpty($tmp['phone']);
@@ -521,7 +521,7 @@ class FunctionsLibTest extends CommonClassTest
 
 		//Internet Explorer 11
 		$user_agent = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
-		$tmp=getBrowserInfo($user_agent);
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('ie', $tmp['browsername']);
 		$this->assertEquals('11.0', $tmp['browserversion']);
 		$this->assertEmpty($tmp['phone']);
@@ -530,7 +530,7 @@ class FunctionsLibTest extends CommonClassTest
 
 		//Internet Explorer 11 bis
 		$user_agent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; NP06; rv:11.0) like Gecko';
-		$tmp=getBrowserInfo($user_agent);
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('ie', $tmp['browsername']);
 		$this->assertEquals('11.0', $tmp['browserversion']);
 		$this->assertEmpty($tmp['phone']);
@@ -539,7 +539,7 @@ class FunctionsLibTest extends CommonClassTest
 
 		//iPad
 		$user_agent = 'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25';
-		$tmp=getBrowserInfo($user_agent);
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('safari', $tmp['browsername']);
 		$this->assertEquals('8536.25', $tmp['browserversion']);
 		$this->assertEquals('ios', $tmp['browseros']);
@@ -548,7 +548,7 @@ class FunctionsLibTest extends CommonClassTest
 
 		//Lynx
 		$user_agent = 'Lynx/2.8.8dev.3 libwww‑FM/2.14 SSL‑MM/1.4.1';
-		$tmp=getBrowserInfo($user_agent);
+		$tmp = getBrowserInfo($user_agent);
 		$this->assertEquals('lynxlinks', $tmp['browsername']);
 		$this->assertEquals('2.8.8', $tmp['browserversion']);
 		$this->assertEquals('unknown', $tmp['browseros']);
@@ -615,71 +615,71 @@ class FunctionsLibTest extends CommonClassTest
 	public function testDolTextIsHtml()
 	{
 		// True
-		$input='<html>xxx</html>';
-		$after=dol_textishtml($input);
+		$input = '<html>xxx</html>';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with html tag');
-		$input='<body>xxx</body>';
-		$after=dol_textishtml($input);
+		$input = '<body>xxx</body>';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with body tag');
-		$input='xxx <b>yyy</b> zzz';
-		$after=dol_textishtml($input);
+		$input = 'xxx <b>yyy</b> zzz';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with b tag');
-		$input='xxx <u>yyy</u> zzz';
-		$after=dol_textishtml($input);
+		$input = 'xxx <u>yyy</u> zzz';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with u tag');
-		$input='text with <div>some div</div>';
-		$after=dol_textishtml($input);
+		$input = 'text with <div>some div</div>';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with div tag');
-		$input='text with HTML &nbsp; entities';
-		$after=dol_textishtml($input);
+		$input = 'text with HTML &nbsp; entities';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with entities tag');
-		$input='xxx<br>';
-		$after=dol_textishtml($input);
+		$input = 'xxx<br>';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with entities br');
-		$input='xxx<br >';
-		$after=dol_textishtml($input);
+		$input = 'xxx<br >';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with entities br');
-		$input='xxx<br style="eee">';
-		$after=dol_textishtml($input);
+		$input = 'xxx<br style="eee">';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with entities br and attributes');
-		$input='xxx<br style="eee" >';
-		$after=dol_textishtml($input);
+		$input = 'xxx<br style="eee" >';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with entities br and attributes bis');
-		$input='<h2>abc</h2>';
-		$after=dol_textishtml($input);
+		$input = '<h2>abc</h2>';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with entities h2');
-		$input='<img id="abc" src="https://xxx.com/aaa/image.png" />';
-		$after=dol_textishtml($input);
+		$input = '<img id="abc" src="https://xxx.com/aaa/image.png" />';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with img tag');
-		$input='<a class="azerty" href="https://xxx.com/aaa/image.png" />';
-		$after=dol_textishtml($input);
+		$input = '<a class="azerty" href="https://xxx.com/aaa/image.png" />';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with a tag');
-		$input='This is a text with&nbsp;html spaces';
-		$after=dol_textishtml($input);
+		$input = 'This is a text with&nbsp;html spaces';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with a &nbsp;');
-		$input='This is a text with accent &eacute;';
-		$after=dol_textishtml($input);
+		$input = 'This is a text with accent &eacute;';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with a &eacute;');
-		$input='<i class="abc">xxx</i>';
-		$after=dol_textishtml($input);
+		$input = '<i class="abc">xxx</i>';
+		$after = dol_textishtml($input);
 		$this->assertTrue($after, 'Test with i tag and class;');
 
 		// False
-		$input='xxx < br>';
-		$after=dol_textishtml($input);
+		$input = 'xxx < br>';
+		$after = dol_textishtml($input);
 		$this->assertFalse($after);
-		$input='xxx <email@email.com>';	// <em> is html, <em... is not
-		$after=dol_textishtml($input);
+		$input = 'xxx <email@email.com>';	// <em> is html, <em... is not
+		$after = dol_textishtml($input);
 		$this->assertFalse($after);
-		$input='xxx <brstyle="ee">';
-		$after=dol_textishtml($input);
+		$input = 'xxx <brstyle="ee">';
+		$after = dol_textishtml($input);
 		$this->assertFalse($after);
-		$input='This is a text with html comments <!-- comment -->';	// we suppose this is not enough to be html content
-		$after=dol_textishtml($input);
+		$input = 'This is a text with html comments <!-- comment -->';	// we suppose this is not enough to be html content
+		$after = dol_textishtml($input);
 		$this->assertFalse($after);
 
-		$input="A text\nwith a link https://aaa?param=abc&amp;param2=def";
-		$after=dol_textishtml($input);
+		$input = "A text\nwith a link https://aaa?param=abc&amp;param2=def";
+		$after = dol_textishtml($input);
 		$this->assertFalse($after);
 	}
 
@@ -691,32 +691,32 @@ class FunctionsLibTest extends CommonClassTest
 	 */
 	public function testDolHtmlCleanLastBr()
 	{
-		$input="A string\n";
-		$after=dol_htmlcleanlastbr($input);
+		$input = "A string\n";
+		$after = dol_htmlcleanlastbr($input);
 		$this->assertEquals("A string", $after);
 
-		$input="A string first\nA string second\n";
-		$after=dol_htmlcleanlastbr($input);
+		$input = "A string first\nA string second\n";
+		$after = dol_htmlcleanlastbr($input);
 		$this->assertEquals("A string first\nA string second", $after);
 
-		$input="A string\n\n\n";
-		$after=dol_htmlcleanlastbr($input);
+		$input = "A string\n\n\n";
+		$after = dol_htmlcleanlastbr($input);
 		$this->assertEquals("A string", $after);
 
-		$input="A string<br>";
-		$after=dol_htmlcleanlastbr($input);
+		$input = "A string<br>";
+		$after = dol_htmlcleanlastbr($input);
 		$this->assertEquals("A string", $after);
 
-		$input="A string first<br>\nA string second<br>";
-		$after=dol_htmlcleanlastbr($input);
+		$input = "A string first<br>\nA string second<br>";
+		$after = dol_htmlcleanlastbr($input);
 		$this->assertEquals("A string first<br>\nA string second", $after);
 
-		$input="A string\n<br type=\"_moz\" />\n";
-		$after=dol_htmlcleanlastbr($input);
+		$input = "A string\n<br type=\"_moz\" />\n";
+		$after = dol_htmlcleanlastbr($input);
 		$this->assertEquals("A string", $after);
 
-		$input="A string\n<br><br />\n\n";
-		$after=dol_htmlcleanlastbr($input);
+		$input = "A string\n<br><br />\n\n";
+		$after = dol_htmlcleanlastbr($input);
 		$this->assertEquals("A string", $after);
 
 		return true;
@@ -729,19 +729,19 @@ class FunctionsLibTest extends CommonClassTest
 	 */
 	public function testDolConcat()
 	{
-		$text1="A string 1";
-		$text2="A string 2";	// text 1 and 2 are text, concat need only \n
-		$after=dol_concatdesc($text1, $text2);
+		$text1 = "A string 1";
+		$text2 = "A string 2";	// text 1 and 2 are text, concat need only \n
+		$after = dol_concatdesc($text1, $text2);
 		$this->assertEquals("A string 1\nA string 2", $after);
 
-		$text1="A<br>string 1";
-		$text2="A string 2";	// text 1 is html, concat need <br>\n
-		$after=dol_concatdesc($text1, $text2);
+		$text1 = "A<br>string 1";
+		$text2 = "A string 2";	// text 1 is html, concat need <br>\n
+		$after = dol_concatdesc($text1, $text2);
 		$this->assertEquals("A<br>string 1<br>\nA string 2", $after);
 
-		$text1="A string 1";
-		$text2="A <b>string</b> 2";	// text 2 is html, concat need <br>\n
-		$after=dol_concatdesc($text1, $text2);
+		$text1 = "A string 1";
+		$text2 = "A <b>string</b> 2";	// text 2 is html, concat need <br>\n
+		$after = dol_concatdesc($text1, $text2);
 		$this->assertEquals("A string 1<br>\nA <b>string</b> 2", $after);
 
 		return true;
@@ -779,52 +779,52 @@ class FunctionsLibTest extends CommonClassTest
 	 */
 	public function testDolStringNohtmltag()
 	{
-		$text="A\nstring\n\nand more\n";
-		$after=dol_string_nohtmltag($text, 0);
+		$text = "A\nstring\n\nand more\n";
+		$after = dol_string_nohtmltag($text, 0);
 		$this->assertEquals("A\nstring\n\nand more", $after, "test1a");
 
-		$text="A <b>string<b><br>\n<br>\n\nwith html tag<br>\n";
-		$after=dol_string_nohtmltag($text, 0);
+		$text = "A <b>string<b><br>\n<br>\n\nwith html tag<br>\n";
+		$after = dol_string_nohtmltag($text, 0);
 		$this->assertEquals("A string\n\n\n\n\nwith html tag", $after, 'test2a 2 br and 3 \n give 5 \n');
 
-		$text="A <b>string<b><br>\n<br>\n\nwith html tag<br>\n";
-		$after=dol_string_nohtmltag($text, 1);
+		$text = "A <b>string<b><br>\n<br>\n\nwith html tag<br>\n";
+		$after = dol_string_nohtmltag($text, 1);
 		$this->assertEquals("A string with html tag", $after, 'test2b 2 br and 3 \n give 1 space');
 
-		$text="A <b>string<b><br>\n<br>\n\nwith html tag<br>\n";
-		$after=dol_string_nohtmltag($text, 2);
+		$text = "A <b>string<b><br>\n<br>\n\nwith html tag<br>\n";
+		$after = dol_string_nohtmltag($text, 2);
 		$this->assertEquals("A string\n\nwith html tag", $after, 'test2c 2 br and 3 \n give 2 \n');
 
-		$text="A <b>string<b><br>\r\n<br>\r\n\r\nwith html tag<br>\n";
-		$after=dol_string_nohtmltag($text, 2);
+		$text = "A <b>string<b><br>\r\n<br>\r\n\r\nwith html tag<br>\n";
+		$after = dol_string_nohtmltag($text, 2);
 		$this->assertEquals("A string\n\nwith html tag", $after, 'test2c 2 br and 3 \r\n give 2 \n');
 
-		$text="A string<br>Another string";
-		$after=dol_string_nohtmltag($text, 0);
+		$text = "A string<br>Another string";
+		$after = dol_string_nohtmltag($text, 0);
 		$this->assertEquals("A string\nAnother string", $after, "test4");
 
-		$text="A string<br>Another string";
-		$after=dol_string_nohtmltag($text, 1);
+		$text = "A string<br>Another string";
+		$after = dol_string_nohtmltag($text, 1);
 		$this->assertEquals("A string Another string", $after, "test5");
 
-		$text='<a href="/myurl" title="<u>Afficher projet</u>">ABC</a>';
-		$after=dol_string_nohtmltag($text, 1);
+		$text = '<a href="/myurl" title="<u>Afficher projet</u>">ABC</a>';
+		$after = dol_string_nohtmltag($text, 1);
 		$this->assertEquals("ABC", $after, "test6");
 
-		$text='<a href="/myurl" title="&lt;u&gt;Afficher projet&lt;/u&gt;">DEF</a>';
-		$after=dol_string_nohtmltag($text, 1);
+		$text = '<a href="/myurl" title="&lt;u&gt;Afficher projet&lt;/u&gt;">DEF</a>';
+		$after = dol_string_nohtmltag($text, 1);
 		$this->assertEquals("DEF", $after, "test7");
 
-		$text='<a href="/myurl" title="<u>A title</u>">HIJ</a>';
-		$after=dol_string_nohtmltag($text, 0);
+		$text = '<a href="/myurl" title="<u>A title</u>">HIJ</a>';
+		$after = dol_string_nohtmltag($text, 0);
 		$this->assertEquals("HIJ", $after, "test8");
 
-		$text="A <b>string<b>\n\nwith html tag and '<' chars<br>\n";
-		$after=dol_string_nohtmltag($text, 0);
+		$text = "A <b>string<b>\n\nwith html tag and '<' chars<br>\n";
+		$after = dol_string_nohtmltag($text, 0);
 		$this->assertEquals("A string\n\nwith html tag and '<' chars", $after, "test9");
 
-		$text="A <b>string<b>\n\nwith tag with < chars<br>\n";
-		$after=dol_string_nohtmltag($text, 1);
+		$text = "A <b>string<b>\n\nwith tag with < chars<br>\n";
+		$after = dol_string_nohtmltag($text, 1);
 		$this->assertEquals("A string with tag with < chars", $after, "test10");
 
 		return true;
@@ -841,38 +841,38 @@ class FunctionsLibTest extends CommonClassTest
 	{
 		// Text not already HTML
 
-		$input="A string\nwith a é, &, < and >.";
-		$after=dol_htmlentitiesbr($input, 0);    // Add <br> before \n
+		$input = "A string\nwith a é, &, < and >.";
+		$after = dol_htmlentitiesbr($input, 0);    // Add <br> before \n
 		$this->assertEquals("A string<br>\nwith a &eacute;, &amp;, &lt; and &gt;.", $after);
 
-		$input="A string\nwith a é, &, < and >.";
-		$after=dol_htmlentitiesbr($input, 1);    // Replace \n with <br>
+		$input = "A string\nwith a é, &, < and >.";
+		$after = dol_htmlentitiesbr($input, 1);    // Replace \n with <br>
 		$this->assertEquals("A string<br>with a &eacute;, &amp;, &lt; and &gt;.", $after);
 
-		$input="A string\nwith a é, &, < and >.\n\n";	// With some \n at end that should be cleaned
-		$after=dol_htmlentitiesbr($input, 0);    // Add <br> before \n
+		$input = "A string\nwith a é, &, < and >.\n\n";	// With some \n at end that should be cleaned
+		$after = dol_htmlentitiesbr($input, 0);    // Add <br> before \n
 		$this->assertEquals("A string<br>\nwith a &eacute;, &amp;, &lt; and &gt;.", $after);
 
-		$input="A string\nwith a é, &, < and >.\n\n";	// With some \n at end that should be cleaned
-		$after=dol_htmlentitiesbr($input, 1);    // Replace \n with <br>
+		$input = "A string\nwith a é, &, < and >.\n\n";	// With some \n at end that should be cleaned
+		$after = dol_htmlentitiesbr($input, 1);    // Replace \n with <br>
 		$this->assertEquals("A string<br>with a &eacute;, &amp;, &lt; and &gt;.", $after);
 
 		// Text already HTML, so &,<,> should not be converted
 
-		$input="A string<br>\nwith a é, &, < and >.";
-		$after=dol_htmlentitiesbr($input);
+		$input = "A string<br>\nwith a é, &, < and >.";
+		$after = dol_htmlentitiesbr($input);
 		$this->assertEquals("A string<br>\nwith a &eacute;, &, < and >.", $after);
 
-		$input="<li>\nA string with a é, &, < and >.</li>\nAnother string";
-		$after=dol_htmlentitiesbr($input);
+		$input = "<li>\nA string with a é, &, < and >.</li>\nAnother string";
+		$after = dol_htmlentitiesbr($input);
 		$this->assertEquals("<li>\nA string with a &eacute;, &, < and >.</li>\nAnother string", $after);
 
-		$input="A string<br>\nwith a é, &, < and >.<br>";	// With some <br> at end that should be cleaned
-		$after=dol_htmlentitiesbr($input);
+		$input = "A string<br>\nwith a é, &, < and >.<br>";	// With some <br> at end that should be cleaned
+		$after = dol_htmlentitiesbr($input);
 		$this->assertEquals("A string<br>\nwith a &eacute;, &, < and >.", $after);
 
-		$input="<li>\nA string with a é, &, < and >.</li>\nAnother string<br>";	// With some <br> at end that should be cleaned
-		$after=dol_htmlentitiesbr($input);
+		$input = "<li>\nA string with a é, &, < and >.</li>\nAnother string<br>";	// With some <br> at end that should be cleaned
+		$after = dol_htmlentitiesbr($input);
 		$this->assertEquals("<li>\nA string with a &eacute;, &, < and >.</li>\nAnother string", $after);
 
 		// TODO Add test with param $removelasteolbr = 0
@@ -889,18 +889,18 @@ class FunctionsLibTest extends CommonClassTest
 	public function testDolNbOfLinesBis()
 	{
 		// This is not a html string so nb of lines depends on \n
-		$input="A string\nwith a é, &, < and > and bold tag.\nThird line";
-		$after=dol_nboflines_bis($input, 0);
+		$input = "A string\nwith a é, &, < and > and bold tag.\nThird line";
+		$after = dol_nboflines_bis($input, 0);
 		$this->assertEquals($after, 3);
 
 		// This is a html string so nb of lines depends on <br>
-		$input="A string\nwith a é, &, < and > and <b>bold</b> tag.\nThird line";
-		$after=dol_nboflines_bis($input, 0);
+		$input = "A string\nwith a é, &, < and > and <b>bold</b> tag.\nThird line";
+		$after = dol_nboflines_bis($input, 0);
 		$this->assertEquals($after, 1);
 
 		// This is a html string so nb of lines depends on <br>
-		$input="A string<br>with a é, &, < and > and <b>bold</b> tag.<br>Third line";
-		$after=dol_nboflines_bis($input, 0);
+		$input = "A string<br>with a é, &, < and > and <b>bold</b> tag.<br>Third line";
+		$after = dol_nboflines_bis($input, 0);
 		$this->assertEquals($after, 3);
 
 		return true;
@@ -916,8 +916,8 @@ class FunctionsLibTest extends CommonClassTest
 	{
 		// Text not already HTML
 
-		$input="A string\nwith a à ä é è ë ï ü ö ÿ, &, < and >.";
-		$after=dol_string_unaccent($input);
+		$input = "A string\nwith a à ä é è ë ï ü ö ÿ, &, < and >.";
+		$after = dol_string_unaccent($input);
 		$this->assertEquals("A string\nwith a a a e e e i u o y, &, < and >.", $after);
 	}
 
@@ -930,17 +930,17 @@ class FunctionsLibTest extends CommonClassTest
 	public function testDolUtf8Check()
 	{
 		// True
-		$result=utf8_check('azerty');
+		$result = utf8_check('azerty');
 		$this->assertTrue($result);
 
-		$file=dirname(__FILE__).'/textutf8.txt';
-		$filecontent=file_get_contents($file);
-		$result=utf8_check($filecontent);
+		$file = dirname(__FILE__).'/textutf8.txt';
+		$filecontent = file_get_contents($file);
+		$result = utf8_check($filecontent);
 		$this->assertTrue($result);
 
-		$file=dirname(__FILE__).'/textiso.txt';
-		$filecontent=file_get_contents($file);
-		$result=utf8_check($filecontent);
+		$file = dirname(__FILE__).'/textiso.txt';
+		$filecontent = file_get_contents($file);
+		$result = utf8_check($filecontent);
 		$this->assertFalse($result);
 	}
 
@@ -952,15 +952,15 @@ class FunctionsLibTest extends CommonClassTest
 	public function testDolAsciiCheck()
 	{
 		// True
-		$result=ascii_check('azerty');
+		$result = ascii_check('azerty');
 		$this->assertTrue($result);
 
-		$result=ascii_check('é');
+		$result = ascii_check('é');
 		$this->assertFalse($result);
 
-		$file=dirname(__FILE__).'/textutf8.txt';
-		$filecontent=file_get_contents($file);
-		$result=ascii_check($filecontent);
+		$file = dirname(__FILE__).'/textutf8.txt';
+		$filecontent = file_get_contents($file);
+		$result = ascii_check($filecontent);
 		$this->assertFalse($result);
 	}
 
@@ -972,49 +972,49 @@ class FunctionsLibTest extends CommonClassTest
 	public function testDolTrunc()
 	{
 		// Default trunc (will add … if truncation truncation or keep last char if only one char)
-		$input="éeéeéeàa";
-		$after=dol_trunc($input, 3);
+		$input = "éeéeéeàa";
+		$after = dol_trunc($input, 3);
 		$this->assertEquals("éeé…", $after, 'Test A1');
-		$after=dol_trunc($input, 2);
+		$after = dol_trunc($input, 2);
 		$this->assertEquals("ée…", $after, 'Test A2');
-		$after=dol_trunc($input, 1);
+		$after = dol_trunc($input, 1);
 		$this->assertEquals("é…", $after, 'Test A3');
-		$input="éeée";
-		$after=dol_trunc($input, 3);
+		$input = "éeée";
+		$after = dol_trunc($input, 3);
 		$this->assertEquals("éeée", $after, 'Test B1');
-		$after=dol_trunc($input, 2);
+		$after = dol_trunc($input, 2);
 		$this->assertEquals("ée…", $after, 'Test B2');
-		$after=dol_trunc($input, 1);
+		$after = dol_trunc($input, 1);
 		$this->assertEquals("é…", $after, 'Test B3');
-		$input="éeée";
-		$after=dol_trunc($input, 3);
+		$input = "éeée";
+		$after = dol_trunc($input, 3);
 		$this->assertEquals("éeée", $after, 'Test C1');
-		$after=dol_trunc($input, 2);
+		$after = dol_trunc($input, 2);
 		$this->assertEquals("ée…", $after, 'Test C2');
-		$after=dol_trunc($input, 1);
+		$after = dol_trunc($input, 1);
 		$this->assertEquals("é…", $after, 'Test C3');
-		$input="éeé";
-		$after=dol_trunc($input, 3);
+		$input = "éeé";
+		$after = dol_trunc($input, 3);
 		$this->assertEquals("éeé", $after, 'Test C');
-		$after=dol_trunc($input, 2);
+		$after = dol_trunc($input, 2);
 		$this->assertEquals("éeé", $after, 'Test D');
-		$after=dol_trunc($input, 1);
+		$after = dol_trunc($input, 1);
 		$this->assertEquals("é…", $after, 'Test E');
 		// Trunc with no …
-		$input="éeéeéeàa";
-		$after=dol_trunc($input, 3, 'right', 'UTF-8', 1);
+		$input = "éeéeéeàa";
+		$after = dol_trunc($input, 3, 'right', 'UTF-8', 1);
 		$this->assertEquals("éeé", $after, 'Test F');
-		$after=dol_trunc($input, 2, 'right', 'UTF-8', 1);
+		$after = dol_trunc($input, 2, 'right', 'UTF-8', 1);
 		$this->assertEquals("ée", $after, 'Test G');
-		$input="éeé";
-		$after=dol_trunc($input, 3, 'right', 'UTF-8', 1);
+		$input = "éeé";
+		$after = dol_trunc($input, 3, 'right', 'UTF-8', 1);
 		$this->assertEquals("éeé", $after, 'Test H');
-		$after=dol_trunc($input, 2, 'right', 'UTF-8', 1);
+		$after = dol_trunc($input, 2, 'right', 'UTF-8', 1);
 		$this->assertEquals("ée", $after, 'Test I');
-		$after=dol_trunc($input, 1, 'right', 'UTF-8', 1);
+		$after = dol_trunc($input, 1, 'right', 'UTF-8', 1);
 		$this->assertEquals("é", $after, 'Test J');
-		$input="éeéeéeàa";
-		$after=dol_trunc($input, 4, 'middle');
+		$input = "éeéeéeàa";
+		$after = dol_trunc($input, 4, 'middle');
 		$this->assertEquals("ée…àa", $after, 'Test K');
 
 		return true;
@@ -1029,49 +1029,49 @@ class FunctionsLibTest extends CommonClassTest
 	{
 		global $conf;
 
-		$savtz=date_default_timezone_get();
+		$savtz = date_default_timezone_get();
 
 		// Some test for UTC TZ
 		date_default_timezone_set('UTC');
 
 		// Check bad hours
-		$result=dol_mktime(25, 0, 0, 1, 1, 1970, 1, 1);    // Error (25 hours)
+		$result = dol_mktime(25, 0, 0, 1, 1, 1970, 1, 1);    // Error (25 hours)
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('', $result);
-		$result=dol_mktime(2, 61, 0, 1, 1, 1970, 1, 1);    // Error (61 minutes)
+		$result = dol_mktime(2, 61, 0, 1, 1, 1970, 1, 1);    // Error (61 minutes)
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('', $result);
-		$result=dol_mktime(2, 1, 61, 1, 1, 1970, 1, 1);    // Error (61 seconds)
+		$result = dol_mktime(2, 1, 61, 1, 1, 1970, 1, 1);    // Error (61 seconds)
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('', $result);
-		$result=dol_mktime(2, 1, 1, 1, 32, 1970, 1, 1);    // Error (day 32)
+		$result = dol_mktime(2, 1, 1, 1, 32, 1970, 1, 1);    // Error (day 32)
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('', $result);
-		$result=dol_mktime(2, 1, 1, 13, 1, 1970, 1, 1);    // Error (month 13)
+		$result = dol_mktime(2, 1, 1, 13, 1, 1970, 1, 1);    // Error (month 13)
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('', $result);
 
-		$result=dol_mktime(2, 1, 1, 1, 1, 1970, 1);    // 1970-01-01 02:01:01 in GMT area -> 7261
+		$result = dol_mktime(2, 1, 1, 1, 1, 1970, 1);    // 1970-01-01 02:01:01 in GMT area -> 7261
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(7261, $result);
 
-		$result=dol_mktime(2, 0, 0, 1, 1, 1970, 0);                // 1970-01-01 02:00:00 = 7200 in local area Europe/Paris = 3600 GMT
+		$result = dol_mktime(2, 0, 0, 1, 1, 1970, 0);                // 1970-01-01 02:00:00 = 7200 in local area Europe/Paris = 3600 GMT
 		print __METHOD__." result=".$result."\n";
-		$tz=getServerTimeZoneInt('winter');                  // +1 in Europe/Paris at this time (this time is winter)
-		$this->assertEquals(7200-($tz*3600), $result);        // 7200 if we are at greenwich winter, 7200-($tz*3600) at local winter
+		$tz = getServerTimeZoneInt('winter');                  // +1 in Europe/Paris at this time (this time is winter)
+		$this->assertEquals(7200 - ($tz * 3600), $result);        // 7200 if we are at greenwich winter, 7200-($tz*3600) at local winter
 
 		// Some test for local TZ Europe/Paris
 		date_default_timezone_set('Europe/Paris');
 
 		// Check that tz for paris in winter is used
-		$result=dol_mktime(2, 0, 0, 1, 1, 1970, 'server');         // 1970-01-01 02:00:00 = 7200 in local area Europe/Paris = 3600 GMT
+		$result = dol_mktime(2, 0, 0, 1, 1, 1970, 'server');         // 1970-01-01 02:00:00 = 7200 in local area Europe/Paris = 3600 GMT
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(3600, $result);        			 // 7200 if we are at greenwich winter, 3600 at Europe/Paris
 
 		// Check that daylight saving time is used
-		$result=dol_mktime(2, 0, 0, 6, 1, 2014, 0);         		// 2014-06-01 02:00:00 = 1401588000-3600(location)-3600(daylight) in local area Europe/Paris = 1401588000 GMT
+		$result = dol_mktime(2, 0, 0, 6, 1, 2014, 0);         		// 2014-06-01 02:00:00 = 1401588000-3600(location)-3600(daylight) in local area Europe/Paris = 1401588000 GMT
 		print __METHOD__." result=".$result."\n";
-		$this->assertEquals(1401588000-3600-3600, $result);  // 1401588000 are at greenwich summer, 1401588000-3600(location)-3600(daylight) at Europe/Paris summer
+		$this->assertEquals(1401588000 - 3600 - 3600, $result);  // 1401588000 are at greenwich summer, 1401588000-3600(location)-3600(daylight) at Europe/Paris summer
 
 		date_default_timezone_set($savtz);
 	}
@@ -1084,14 +1084,14 @@ class FunctionsLibTest extends CommonClassTest
 	 */
 	public function testDolEscapeJs()
 	{
-		$input="x&<b>#</b>,\"'";    // " will be converted into '
-		$result=dol_escape_js($input);
+		$input = "x&<b>#</b>,\"'";    // " will be converted into '
+		$result = dol_escape_js($input);
 		$this->assertEquals("x&<b>#</b>,\'\'", $result, "Test mode=0");
 
-		$result=dol_escape_js($input, 1);
+		$result = dol_escape_js($input, 1);
 		$this->assertEquals("x&<b>#</b>,\"\'", $result, "Test mode=1");
 
-		$result=dol_escape_js($input, 2);
+		$result = dol_escape_js($input, 2);
 		$this->assertEquals("x&<b>#</b>,\\\"'", $result, "Test mode=2");
 	}
 
@@ -1103,12 +1103,12 @@ class FunctionsLibTest extends CommonClassTest
 	*/
 	public function testDolEscapeHtmlTag()
 	{
-		$input='x&<b>#</b>,"';    // & and " are converted into html entities, <b> are removed
-		$result=dol_escape_htmltag($input);
+		$input = 'x&<b>#</b>,"';    // & and " are converted into html entities, <b> are removed
+		$result = dol_escape_htmltag($input);
 		$this->assertEquals('x&amp;#,&quot;', $result);
 
-		$input='x&<b>#</b>,"';    // & and " are converted into html entities, <b> are not removed
-		$result=dol_escape_htmltag($input, 1);
+		$input = 'x&<b>#</b>,"';    // & and " are converted into html entities, <b> are not removed
+		$result = dol_escape_htmltag($input, 1);
 		$this->assertEquals('x&amp;&lt;b&gt;#&lt;/b&gt;,&quot;', $result);
 	}
 
@@ -1121,32 +1121,32 @@ class FunctionsLibTest extends CommonClassTest
 	public function testDolFormatAddress()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$object=new Societe($db);
+		$object = new Societe($db);
 		$object->initAsSpecimen();
 
-		$object->country_code='FR';
-		$address=dol_format_address($object);
+		$object->country_code = 'FR';
+		$address = dol_format_address($object);
 		$this->assertEquals("21 jump street\n99999 MyTown", $address);
 
-		$object->country_code='GB';
-		$address=dol_format_address($object);
+		$object->country_code = 'GB';
+		$address = dol_format_address($object);
 		$this->assertEquals("21 jump street\nMyTown, MyState\n99999", $address);
 
-		$object->country_code='US';
-		$address=dol_format_address($object);
+		$object->country_code = 'US';
+		$address = dol_format_address($object);
 		$this->assertEquals("21 jump street\nMyTown, MyState, 99999", $address);
 
-		$object->country_code='AU';
-		$address=dol_format_address($object);
+		$object->country_code = 'AU';
+		$address = dol_format_address($object);
 		$this->assertEquals("21 jump street\nMyTown, MyState, 99999", $address);
 
-		$object->country_code='JP';
-		$address=dol_format_address($object);
+		$object->country_code = 'JP';
+		$address = dol_format_address($object);
 		$this->assertEquals("21 jump street\nMyState, MyTown 99999", $address);
 	}
 
@@ -1159,28 +1159,28 @@ class FunctionsLibTest extends CommonClassTest
 	public function testDolPrintPhone()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$object=new Societe($db);
+		$object = new Societe($db);
 		$object->initAsSpecimen();
 
-		$object->country_code='FR';
-		$phone=dol_print_phone('1234567890', $object->country_code);
+		$object->country_code = 'FR';
+		$phone = dol_print_phone('1234567890', $object->country_code);
 		$this->assertEquals('<span style="margin-right: 10px;">12&nbsp;34&nbsp;56&nbsp;78&nbsp;90</span>', $phone, 'Phone for FR 1');
 
-		$object->country_code='FR';
-		$phone=dol_print_phone('1234567890', $object->country_code, 0, 0, 0, '');
+		$object->country_code = 'FR';
+		$phone = dol_print_phone('1234567890', $object->country_code, 0, 0, 0, '');
 		$this->assertEquals('<span style="margin-right: 10px;">1234567890</span>', $phone, 'Phone for FR 2');
 
-		$object->country_code='FR';
-		$phone=dol_print_phone('1234567890', $object->country_code, 0, 0, 0, ' ');
+		$object->country_code = 'FR';
+		$phone = dol_print_phone('1234567890', $object->country_code, 0, 0, 0, ' ');
 		$this->assertEquals('<span style="margin-right: 10px;">12 34 56 78 90</span>', $phone, 'Phone for FR 3');
 
-		$object->country_code='CA';
-		$phone=dol_print_phone('1234567890', $object->country_code, 0, 0, 0, ' ');
+		$object->country_code = 'CA';
+		$phone = dol_print_phone('1234567890', $object->country_code, 0, 0, 0, ' ');
 		$this->assertEquals('<span style="margin-right: 10px;">(123) 456-7890</span>', $phone, 'Phone for CA 1');
 	}
 
@@ -1192,24 +1192,24 @@ class FunctionsLibTest extends CommonClassTest
 	 */
 	public function testImgPicto()
 	{
-		$s=img_picto('title', 'user');
+		$s = img_picto('title', 'user');
 		print __METHOD__." s=".$s."\n";
 		$this->assertStringContainsStringIgnoringCase('fa-user', $s, 'testImgPicto1');
 
-		$s=img_picto('title', 'img.png', 'style="float: right"', 0);
+		$s = img_picto('title', 'img.png', 'style="float: right"', 0);
 		print __METHOD__." s=".$s."\n";
 		$this->assertStringContainsStringIgnoringCase('theme', $s, 'testImgPicto2');
 		$this->assertStringContainsStringIgnoringCase('style="float: right"', $s, 'testImgPicto2');
 
-		$s=img_picto('title', '/fullpath/img.png', '', 1);
+		$s = img_picto('title', '/fullpath/img.png', '', 1);
 		print __METHOD__." s=".$s."\n";
 		$this->assertEquals('<img src="/fullpath/img.png" alt="" title="title" class="inline-block">', $s, 'testImgPicto3');
 
-		$s=img_picto('title', '/fullpath/img.png', '', true);
+		$s = img_picto('title', '/fullpath/img.png', '', true);
 		print __METHOD__." s=".$s."\n";
 		$this->assertEquals('<img src="/fullpath/img.png" alt="" title="title" class="inline-block">', $s, 'testImgPicto4');
 
-		$s=img_picto('title', 'delete', '', 0, 1);
+		$s = img_picto('title', 'delete', '', 0, 1);
 		print __METHOD__." s=".$s."\n";
 		$this->assertEquals(DOL_URL_ROOT.'/theme/eldy/img/delete.png', $s, 'testImgPicto5');
 	}
@@ -1221,10 +1221,10 @@ class FunctionsLibTest extends CommonClassTest
 	 */
 	public function testDolNow()
 	{
-		$now=dol_now('gmt');
-		$nowtzserver=dol_now('tzserver');
-		print __METHOD__." getServerTimeZoneInt=".(getServerTimeZoneInt('now')*3600)."\n";
-		$this->assertEquals(getServerTimeZoneInt('now')*3600, ($nowtzserver-$now));
+		$now = dol_now('gmt');
+		$nowtzserver = dol_now('tzserver');
+		print __METHOD__." getServerTimeZoneInt=".(getServerTimeZoneInt('now') * 3600)."\n";
+		$this->assertEquals(getServerTimeZoneInt('now') * 3600, ($nowtzserver - $now));
 	}
 
 	/**
@@ -1234,25 +1234,25 @@ class FunctionsLibTest extends CommonClassTest
 	 */
 	public function testVerifCond()
 	{
-		$verifcond=verifCond('1==1');
+		$verifcond = verifCond('1==1');
 		$this->assertTrue($verifcond, 'Test a true comparison');
 
-		$verifcond=verifCond('1==2');
+		$verifcond = verifCond('1==2');
 		$this->assertFalse($verifcond, 'Test a false comparison');
 
-		$verifcond=verifCond('isModEnabled("facture")');
+		$verifcond = verifCond('isModEnabled("facture")');
 		$this->assertTrue($verifcond, 'Test that the conf property of a module reports true when enabled');
 
-		$verifcond=verifCond('isModEnabled("moduledummy")');
+		$verifcond = verifCond('isModEnabled("moduledummy")');
 		$this->assertFalse($verifcond, 'Test that the conf property of a module reports false when disabled');
 
-		$verifcond=verifCond(0);
+		$verifcond = verifCond(0);
 		$this->assertFalse($verifcond, 'Test that verifConf(0) return False');
 
-		$verifcond=verifCond("0");
+		$verifcond = verifCond("0");
 		$this->assertFalse($verifcond, 'Test that verifConf("0") return False');
 
-		$verifcond=verifCond('');
+		$verifcond = verifCond('');
 		$this->assertTrue($verifcond, 'Test that verifConf("") return False (special case)');
 	}
 
@@ -1264,74 +1264,74 @@ class FunctionsLibTest extends CommonClassTest
 	public function testGetDefaultTva()
 	{
 		global $conf,$user,$langs,$db;
-		$this->savconf=$conf;
-		$this->savuser=$user;
-		$this->savlangs=$langs;
-		$this->savdb=$db;
+		$this->savconf = $conf;
+		$this->savuser = $user;
+		$this->savlangs = $langs;
+		$this->savdb = $db;
 
 		// Sellers
-		$companyfrnovat=new Societe($db);
-		$companyfrnovat->country_code='FR';
-		$companyfrnovat->tva_assuj=0;
+		$companyfrnovat = new Societe($db);
+		$companyfrnovat->country_code = 'FR';
+		$companyfrnovat->tva_assuj = 0;
 
-		$companyfr=new Societe($db);
-		$companyfr->country_code='FR';
-		$companyfr->tva_assuj=1;
-		$companyfr->tva_intra='FR9999';
+		$companyfr = new Societe($db);
+		$companyfr->country_code = 'FR';
+		$companyfr->tva_assuj = 1;
+		$companyfr->tva_intra = 'FR9999';
 
 		// Buyers
-		$companymc=new Societe($db);
-		$companymc->country_code='MC';
-		$companymc->tva_assuj=1;
-		$companyfr->tva_intra='MC9999';
+		$companymc = new Societe($db);
+		$companymc->country_code = 'MC';
+		$companymc->tva_assuj = 1;
+		$companyfr->tva_intra = 'MC9999';
 
-		$companyit=new Societe($db);
-		$companyit->country_code='IT';
-		$companyit->tva_assuj=1;
-		$companyit->tva_intra='IT99999';
+		$companyit = new Societe($db);
+		$companyit->country_code = 'IT';
+		$companyit->tva_assuj = 1;
+		$companyit->tva_intra = 'IT99999';
 
-		$companyde=new Societe($db);
-		$companyde->country_code='DE';
-		$companyde->tva_assuj=1;
-		$companyde->tva_intra='DE99999';
+		$companyde = new Societe($db);
+		$companyde->country_code = 'DE';
+		$companyde->tva_assuj = 1;
+		$companyde->tva_intra = 'DE99999';
 
-		$notcompanyde=new Societe($db);
-		$notcompanyde->country_code='DE';
-		$notcompanyde->tva_assuj=0;
-		$notcompanyde->tva_intra='';
-		$notcompanyde->typent_code='TE_PRIVATE';
+		$notcompanyde = new Societe($db);
+		$notcompanyde->country_code = 'DE';
+		$notcompanyde->tva_assuj = 0;
+		$notcompanyde->tva_intra = '';
+		$notcompanyde->typent_code = 'TE_PRIVATE';
 
-		$companyus=new Societe($db);
-		$companyus->country_code='US';
-		$companyus->tva_assuj=1;
-		$companyus->tva_intra='';
+		$companyus = new Societe($db);
+		$companyus->country_code = 'US';
+		$companyus->tva_assuj = 1;
+		$companyus->tva_intra = '';
 
 
 		// Test RULE 0 (FR-DE)
 		// Not tested
 
 		// Test RULE 1
-		$vat=get_default_tva($companyfrnovat, $companymc, 0);
+		$vat = get_default_tva($companyfrnovat, $companymc, 0);
 		$this->assertEquals(0, $vat, 'RULE 1');
 
 		// Test RULE 2 (FR-FR)
-		$vat=get_default_tva($companyfr, $companyfr, 0);
+		$vat = get_default_tva($companyfr, $companyfr, 0);
 		$this->assertEquals(20, $vat, 'RULE 2');
 
 		// Test RULE 2 (FR-MC)
-		$vat=get_default_tva($companyfr, $companymc, 0);
+		$vat = get_default_tva($companyfr, $companymc, 0);
 		$this->assertEquals(20, $vat, 'RULE 2');
 
 		// Test RULE 3 (FR-DE company)
-		$vat=get_default_tva($companyfr, $companyit, 0);
+		$vat = get_default_tva($companyfr, $companyit, 0);
 		$this->assertEquals(0, $vat, 'RULE 3');
 
 		// Test RULE 4 (FR-DE not a company)
-		$vat=get_default_tva($companyfr, $notcompanyde, 0);
+		$vat = get_default_tva($companyfr, $notcompanyde, 0);
 		$this->assertEquals(20, $vat, 'RULE 4');
 
 		// Test RULE 5 (FR-US)
-		$vat=get_default_tva($companyfr, $companyus, 0);
+		$vat = get_default_tva($companyfr, $companyus, 0);
 		$this->assertEquals(0, $vat, 'RULE 5');
 
 
@@ -1339,23 +1339,23 @@ class FunctionsLibTest extends CommonClassTest
 		$conf->global->SERVICE_ARE_ECOMMERCE_200238EC = 1;
 
 		// Test RULE 1 (FR-US)
-		$vat=get_default_tva($companyfr, $companyus, 0);
+		$vat = get_default_tva($companyfr, $companyus, 0);
 		$this->assertEquals(0, $vat, 'RULE 1 ECOMMERCE_200238EC');
 
 		// Test RULE 2 (FR-FR)
-		$vat=get_default_tva($companyfr, $companyfr, 0);
+		$vat = get_default_tva($companyfr, $companyfr, 0);
 		$this->assertEquals(20, $vat, 'RULE 2 ECOMMERCE_200238EC');
 
 		// Test RULE 3 (FR-DE company)
-		$vat=get_default_tva($companyfr, $companyde, 0);
+		$vat = get_default_tva($companyfr, $companyde, 0);
 		$this->assertEquals(0, $vat, 'RULE 3 ECOMMERCE_200238EC');
 
 		// Test RULE 4 (FR-DE not a company)
-		$vat=get_default_tva($companyfr, $notcompanyde, 0);
+		$vat = get_default_tva($companyfr, $notcompanyde, 0);
 		$this->assertEquals(19, $vat, 'RULE 4 ECOMMERCE_200238EC');
 
 		// Test RULE 5 (FR-US)
-		$vat=get_default_tva($companyfr, $companyus, 0);
+		$vat = get_default_tva($companyfr, $companyus, 0);
 		$this->assertEquals(0, $vat, 'RULE 5 ECOMMERCE_200238EC');
 	}
 
@@ -1367,72 +1367,72 @@ class FunctionsLibTest extends CommonClassTest
 	public function testGetDefaultLocalTax()
 	{
 		global $conf,$user,$langs,$db;
-		$this->savconf=$conf;
-		$this->savuser=$user;
-		$this->savlangs=$langs;
-		$this->savdb=$db;
+		$this->savconf = $conf;
+		$this->savuser = $user;
+		$this->savlangs = $langs;
+		$this->savdb = $db;
 
-		$companyfrnovat=new Societe($db);
-		$companyfrnovat->country_code='FR';
-		$companyfrnovat->tva_assuj=0;
-		$companyfrnovat->localtax1_assuj=0;
-		$companyfrnovat->localtax2_assuj=0;
+		$companyfrnovat = new Societe($db);
+		$companyfrnovat->country_code = 'FR';
+		$companyfrnovat->tva_assuj = 0;
+		$companyfrnovat->localtax1_assuj = 0;
+		$companyfrnovat->localtax2_assuj = 0;
 
-		$companyes=new Societe($db);
-		$companyes->country_code='ES';
-		$companyes->tva_assuj=1;
-		$companyes->localtax1_assuj=1;
-		$companyes->localtax2_assuj=1;
+		$companyes = new Societe($db);
+		$companyes->country_code = 'ES';
+		$companyes->tva_assuj = 1;
+		$companyes->localtax1_assuj = 1;
+		$companyes->localtax2_assuj = 1;
 
-		$companymc=new Societe($db);
-		$companymc->country_code='MC';
-		$companymc->tva_assuj=1;
-		$companymc->localtax1_assuj=0;
-		$companymc->localtax2_assuj=0;
+		$companymc = new Societe($db);
+		$companymc->country_code = 'MC';
+		$companymc->tva_assuj = 1;
+		$companymc->localtax1_assuj = 0;
+		$companymc->localtax2_assuj = 0;
 
-		$companyit=new Societe($db);
-		$companyit->country_code='IT';
-		$companyit->tva_assuj=1;
-		$companyit->tva_intra='IT99999';
-		$companyit->localtax1_assuj=0;
-		$companyit->localtax2_assuj=0;
+		$companyit = new Societe($db);
+		$companyit->country_code = 'IT';
+		$companyit->tva_assuj = 1;
+		$companyit->tva_intra = 'IT99999';
+		$companyit->localtax1_assuj = 0;
+		$companyit->localtax2_assuj = 0;
 
-		$notcompanyit=new Societe($db);
-		$notcompanyit->country_code='IT';
-		$notcompanyit->tva_assuj=1;
-		$notcompanyit->tva_intra='';
-		$notcompanyit->typent_code='TE_PRIVATE';
-		$notcompanyit->localtax1_assuj=0;
-		$notcompanyit->localtax2_assuj=0;
+		$notcompanyit = new Societe($db);
+		$notcompanyit->country_code = 'IT';
+		$notcompanyit->tva_assuj = 1;
+		$notcompanyit->tva_intra = '';
+		$notcompanyit->typent_code = 'TE_PRIVATE';
+		$notcompanyit->localtax1_assuj = 0;
+		$notcompanyit->localtax2_assuj = 0;
 
-		$companyus=new Societe($db);
-		$companyus->country_code='US';
-		$companyus->tva_assuj=1;
-		$companyus->tva_intra='';
-		$companyus->localtax1_assuj=0;
-		$companyus->localtax2_assuj=0;
+		$companyus = new Societe($db);
+		$companyus->country_code = 'US';
+		$companyus->tva_assuj = 1;
+		$companyus->tva_intra = '';
+		$companyus->localtax1_assuj = 0;
+		$companyus->localtax2_assuj = 0;
 
 		// Test RULE FR-MC
-		$vat1=get_default_localtax($companyfrnovat, $companymc, 1, 0);
-		$vat2=get_default_localtax($companyfrnovat, $companymc, 2, 0);
+		$vat1 = get_default_localtax($companyfrnovat, $companymc, 1, 0);
+		$vat2 = get_default_localtax($companyfrnovat, $companymc, 2, 0);
 		$this->assertEquals(0, $vat1);
 		$this->assertEquals(0, $vat2);
 
 		// Test RULE ES-ES
-		$vat1=get_default_localtax($companyes, $companyes, 1, 0);
-		$vat2=get_default_localtax($companyes, $companyes, 2, 0);
+		$vat1 = get_default_localtax($companyes, $companyes, 1, 0);
+		$vat2 = get_default_localtax($companyes, $companyes, 2, 0);
 		$this->assertEquals($vat1, 5.2);
 		$this->assertStringStartsWith((string) $vat2, '-19:-15:-9');       // Can be -19 (old version) or '-19:-15:-9' (new setup)
 
 		// Test RULE ES-IT
-		$vat1=get_default_localtax($companyes, $companyit, 1, 0);
-		$vat2=get_default_localtax($companyes, $companyit, 2, 0);
+		$vat1 = get_default_localtax($companyes, $companyit, 1, 0);
+		$vat2 = get_default_localtax($companyes, $companyit, 2, 0);
 		$this->assertEquals(0, $vat1);
 		$this->assertEquals(0, $vat2);
 
 		// Test RULE ES-IT
-		$vat1=get_default_localtax($companyes, $notcompanyit, 1, 0);
-		$vat2=get_default_localtax($companyes, $notcompanyit, 2, 0);
+		$vat1 = get_default_localtax($companyes, $notcompanyit, 1, 0);
+		$vat2 = get_default_localtax($companyes, $notcompanyit, 2, 0);
 		$this->assertEquals(0, $vat1);
 		$this->assertEquals(0, $vat2);
 
@@ -1440,8 +1440,8 @@ class FunctionsLibTest extends CommonClassTest
 		// Not tested
 
 		// Test RULE ES-US
-		$vat1=get_default_localtax($companyes, $companyus, 1, 0);
-		$vat2=get_default_localtax($companyes, $companyus, 2, 0);
+		$vat1 = get_default_localtax($companyes, $companyus, 1, 0);
+		$vat2 = get_default_localtax($companyes, $companyus, 2, 0);
 		$this->assertEquals(0, $vat1);
 		$this->assertEquals(0, $vat2);
 	}
@@ -1475,14 +1475,14 @@ class FunctionsLibTest extends CommonClassTest
 	 */
 	public function testDolExplodeIntoArray()
 	{
-		$stringtoexplode='AA=B/B.CC=.EE=FF.HH=GG;.';
-		$tmp=dolExplodeIntoArray($stringtoexplode, '.', '=');
+		$stringtoexplode = 'AA=B/B.CC=.EE=FF.HH=GG;.';
+		$tmp = dolExplodeIntoArray($stringtoexplode, '.', '=');
 
 		print __METHOD__." tmp=".json_encode($tmp)."\n";
 		$this->assertEquals('{"AA":"B\/B","CC":"","EE":"FF","HH":"GG;"}', json_encode($tmp));
 
-		$stringtoexplode="AA=B/B;CC=\n\rEE=FF\nHH=GG;;;\nII=JJ\n";
-		$tmp=dolExplodeIntoArray($stringtoexplode, "(\r\n|\n|\r|;)", '=');
+		$stringtoexplode = "AA=B/B;CC=\n\rEE=FF\nHH=GG;;;\nII=JJ\n";
+		$tmp = dolExplodeIntoArray($stringtoexplode, "(\r\n|\n|\r|;)", '=');
 
 		print __METHOD__." tmp=".json_encode($tmp)."\n";
 		$this->assertEquals('{"AA":"B\/B","CC":"","EE":"FF","HH":"GG","II":"JJ"}', json_encode($tmp));
@@ -1610,18 +1610,18 @@ class FunctionsLibTest extends CommonClassTest
 
 		$conf->global->MAIN_START_WEEK = 0;
 
-		$tmp=dol_getdate(24*60*60+1, false, 'UTC');		// 2/1/1970 and 1 second = friday
+		$tmp = dol_getdate(24 * 60 * 60 + 1, false, 'UTC');		// 2/1/1970 and 1 second = friday
 		$this->assertEquals(5, $tmp['wday'], 'Bad value of day in week');
 
 		$conf->global->MAIN_START_WEEK = 1;
 
-		$tmp=dol_getdate(1, false, 'UTC');				// 1/1/1970 and 1 second = thirday
+		$tmp = dol_getdate(1, false, 'UTC');				// 1/1/1970 and 1 second = thirday
 		$this->assertEquals(4, $tmp['wday'], 'Bad value of day in week');
 
-		$tmp=dol_getdate(24*60*60+1, false, 'UTC');		// 2/1/1970 and 1 second = friday
+		$tmp = dol_getdate(24 * 60 * 60 + 1, false, 'UTC');		// 2/1/1970 and 1 second = friday
 		$this->assertEquals(5, $tmp['wday'], 'Bad value of day in week');
 
-		$tmp=dol_getdate(1, false, "Europe/Paris");						// 1/1/1970 and 1 second = thirday
+		$tmp = dol_getdate(1, false, "Europe/Paris");						// 1/1/1970 and 1 second = thirday
 		$this->assertEquals(1970, $tmp['year']);
 		$this->assertEquals(1, $tmp['mon']);
 		$this->assertEquals(1, $tmp['mday']);
@@ -1631,7 +1631,7 @@ class FunctionsLibTest extends CommonClassTest
 		$this->assertEquals(0, $tmp['minutes']);
 		$this->assertEquals(1, $tmp['seconds']);
 
-		$tmp=dol_getdate(15638401, false, "Europe/Paris");					// 1/7/1970 and 1 second = wednesday
+		$tmp = dol_getdate(15638401, false, "Europe/Paris");					// 1/7/1970 and 1 second = wednesday
 		$this->assertEquals(1970, $tmp['year']);
 		$this->assertEquals(7, $tmp['mon']);
 		$this->assertEquals(1, $tmp['mday']);
@@ -1641,7 +1641,7 @@ class FunctionsLibTest extends CommonClassTest
 		$this->assertEquals(0, $tmp['minutes']);
 		$this->assertEquals(1, $tmp['seconds']);
 
-		$tmp=dol_getdate(1593561601, false, "Europe/Paris");				// 1/7/2020 and 1 second = wednesday
+		$tmp = dol_getdate(1593561601, false, "Europe/Paris");				// 1/7/2020 and 1 second = wednesday
 		$this->assertEquals(2020, $tmp['year']);
 		$this->assertEquals(7, $tmp['mon']);
 		$this->assertEquals(1, $tmp['mday']);
@@ -1651,7 +1651,7 @@ class FunctionsLibTest extends CommonClassTest
 		$this->assertEquals(0, $tmp['minutes']);
 		$this->assertEquals(1, $tmp['seconds']);
 
-		$tmp=dol_getdate(1, false, 'UTC');						// 1/1/1970 and 1 second = thirday
+		$tmp = dol_getdate(1, false, 'UTC');						// 1/1/1970 and 1 second = thirday
 		$this->assertEquals(1970, $tmp['year']);
 		$this->assertEquals(1, $tmp['mon']);
 		$this->assertEquals(1, $tmp['mday']);
@@ -1662,7 +1662,7 @@ class FunctionsLibTest extends CommonClassTest
 		$this->assertEquals(0, $tmp['minutes']);
 		$this->assertEquals(1, $tmp['seconds']);
 
-		$tmp=dol_getdate(15638401, false, 'UTC');				// 1/7/1970 and 1 second = wednesday
+		$tmp = dol_getdate(15638401, false, 'UTC');				// 1/7/1970 and 1 second = wednesday
 		$this->assertEquals(1970, $tmp['year']);
 		$this->assertEquals(7, $tmp['mon']);
 		$this->assertEquals(1, $tmp['mday']);
@@ -1673,7 +1673,7 @@ class FunctionsLibTest extends CommonClassTest
 		$this->assertEquals(0, $tmp['minutes']);
 		$this->assertEquals(1, $tmp['seconds']);
 
-		$tmp=dol_getdate(1593561601, false, 'UTC');				// 1/7/2020 and 1 second = wednesday
+		$tmp = dol_getdate(1593561601, false, 'UTC');				// 1/7/2020 and 1 second = wednesday
 		$this->assertEquals(2020, $tmp['year']);
 		$this->assertEquals(7, $tmp['mon']);
 		$this->assertEquals(1, $tmp['mday']);
@@ -1699,7 +1699,7 @@ class FunctionsLibTest extends CommonClassTest
 		$langs->load("main");
 
 		// Try simple replacement
-		$substit = array("__AAA__"=>'Not used', "__BBB__"=>'Not used', "__CCC__"=>"C instead", "DDD"=>"D instead");
+		$substit = array("__AAA__" => 'Not used', "__BBB__" => 'Not used', "__CCC__" => "C instead", "DDD" => "D instead");
 		$substit += getCommonSubstitutionArray($langs);
 
 		$chaine = 'This is a string with theme constant __[MAIN_THEME]__ and __(DIRECTION)__ and __CCC__ and DDD and __MYCOMPANY_NAME__ and __YEAR__';
@@ -1708,7 +1708,7 @@ class FunctionsLibTest extends CommonClassTest
 		$this->assertEquals($newstring, 'This is a string with theme constant eldy and ltr and C instead and D instead and '.$mysoc->name.' and '.dol_print_date(dol_now(), '%Y', 'gmt'));
 
 		// Try mix HTML not HTML, no change on initial text
-		$substit = array("__NOHTML__"=>'No html', "__HTML__"=>'<b>HTML</b>');
+		$substit = array("__NOHTML__" => 'No html', "__HTML__" => '<b>HTML</b>');
 
 		$chaine = "This is a text with\nNew line\nThen\n__NOHTML__\nThen\n__HTML__";
 		$newstring = make_substitutions($chaine, $substit, $langs);
@@ -1716,7 +1716,7 @@ class FunctionsLibTest extends CommonClassTest
 		$this->assertEquals($newstring, "This is a text with\nNew line\nThen\nNo html\nThen\n<b>HTML</b>", 'Test on make_substitutions with conversion of inserted values only');
 
 		// Try mix HTML not HTML, accept to change initial text
-		$substit = array("__NOHTML__"=>'No html', "__HTML__"=>'<b>HTML</b>');
+		$substit = array("__NOHTML__" => 'No html', "__HTML__" => '<b>HTML</b>');
 
 		$chaine = "This is a text with\nNew line\nThen\n__NOHTML__\nThen\n__HTML__";
 		$newstring = make_substitutions($chaine, $substit, $langs, 1);
@@ -1735,11 +1735,11 @@ class FunctionsLibTest extends CommonClassTest
 	{
 		global $conf, $langs;
 
-		$chaine='This is an ISO string';
+		$chaine = 'This is an ISO string';
 		$result = dol_string_is_good_iso($chaine);
 		$this->assertEquals($result, 1);
 
-		$chaine='This is a not ISO string '.chr(0);
+		$chaine = 'This is a not ISO string '.chr(0);
 		$result = dol_string_is_good_iso($chaine);
 		$this->assertEquals($result, 0);
 
@@ -1795,18 +1795,18 @@ class FunctionsLibTest extends CommonClassTest
 	{
 		global $conf, $langs;
 
-		$_SERVER['HTTP_X_FORWARDED_FOR']='1.2.3.4';
-		$_SERVER['HTTP_CLIENT_IP']='5.6.7.8';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.2.3.4';
+		$_SERVER['HTTP_CLIENT_IP'] = '5.6.7.8';
 		$result = getUserRemoteIP();
 		$this->assertEquals($result, '1.2.3.4');
 
-		$_SERVER['HTTP_X_FORWARDED_FOR']='1.2.3.4<corrupted>';
-		$_SERVER['HTTP_CLIENT_IP']='5.6.7.8';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.2.3.4<corrupted>';
+		$_SERVER['HTTP_CLIENT_IP'] = '5.6.7.8';
 		$result = getUserRemoteIP();
 		$this->assertEquals($result, '5.6.7.8');
 
-		$_SERVER['HTTP_X_FORWARDED_FOR']='[1:2:3:4]';
-		$_SERVER['HTTP_CLIENT_IP']='5.6.7.8';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '[1:2:3:4]';
+		$_SERVER['HTTP_CLIENT_IP'] = '5.6.7.8';
 		$result = getUserRemoteIP();
 		$this->assertEquals($result, '[1:2:3:4]');
 

--- a/test/phpunit/GetUrlLibTest.php
+++ b/test/phpunit/GetUrlLibTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -57,40 +57,40 @@ class GetUrlLibTest extends CommonClassTest
 	public function testGetRootURLFromURL()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=getRootURLFromURL('http://www.dolimed.com/screenshots/afile');
+		$result = getRootURLFromURL('http://www.dolimed.com/screenshots/afile');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('http://www.dolimed.com', $result, 'Test 1');
 
-		$result=getRootURLFromURL('https://www.dolimed.com/screenshots/afile');
+		$result = getRootURLFromURL('https://www.dolimed.com/screenshots/afile');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('https://www.dolimed.com', $result, 'Test 2');
 
-		$result=getRootURLFromURL('http://www.dolimed.com/screenshots');
+		$result = getRootURLFromURL('http://www.dolimed.com/screenshots');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('http://www.dolimed.com', $result);
 
-		$result=getRootURLFromURL('https://www.dolimed.com/screenshots');
+		$result = getRootURLFromURL('https://www.dolimed.com/screenshots');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('https://www.dolimed.com', $result);
 
-		$result=getRootURLFromURL('http://www.dolimed.com/');
+		$result = getRootURLFromURL('http://www.dolimed.com/');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('http://www.dolimed.com', $result);
 
-		$result=getRootURLFromURL('https://www.dolimed.com/');
+		$result = getRootURLFromURL('https://www.dolimed.com/');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('https://www.dolimed.com', $result);
 
-		$result=getRootURLFromURL('http://www.dolimed.com');
+		$result = getRootURLFromURL('http://www.dolimed.com');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('http://www.dolimed.com', $result);
 
-		$result=getRootURLFromURL('https://www.dolimed.com');
+		$result = getRootURLFromURL('https://www.dolimed.com');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('https://www.dolimed.com', $result);
 
@@ -105,64 +105,64 @@ class GetUrlLibTest extends CommonClassTest
 	public function testGetDomainFromURL()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Tests with param 0
 
-		$result=getDomainFromURL('http://localhost');
+		$result = getDomainFromURL('http://localhost');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('localhost', $result, 'Test localhost 0');
 
-		$result=getDomainFromURL('http://localhost', 1);
+		$result = getDomainFromURL('http://localhost', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('localhost', $result, 'Test localhost 1');
 
-		$result=getDomainFromURL('https://dolimed.com');
+		$result = getDomainFromURL('https://dolimed.com');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('dolimed', $result, 'Test dolimed.com 0');
 
-		$result=getDomainFromURL('http://www.dolimed.com/screenshots/afile');
+		$result = getDomainFromURL('http://www.dolimed.com/screenshots/afile');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('dolimed', $result, 'Test dolimed.com/... 0');
 
-		$result=getDomainFromURL('http://www.with.dolimed.com/screenshots/afile');
+		$result = getDomainFromURL('http://www.with.dolimed.com/screenshots/afile');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('dolimed', $result, 'Test ...dolimed.com/ 0');
 
 		// Tests with param 1
 
-		$result=getDomainFromURL('https://dolimed.com', 1);
+		$result = getDomainFromURL('https://dolimed.com', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('dolimed.com', $result, 'Test dolimed.com 1');
 
-		$result=getDomainFromURL('http://www.dolimed.com/screenshots/afile', 1);
+		$result = getDomainFromURL('http://www.dolimed.com/screenshots/afile', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('dolimed.com', $result, 'Test dolimed.com/... 1');
 
-		$result=getDomainFromURL('http://www.with.dolimed.com/screenshots/afile', 1);
+		$result = getDomainFromURL('http://www.with.dolimed.com/screenshots/afile', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('dolimed.com', $result, 'Test .../dolimed.com 1');
 
 		// Tests with param 2
 
-		$result=getDomainFromURL('http://www.with.dolimed.com/screenshots/afile', 2);
+		$result = getDomainFromURL('http://www.with.dolimed.com/screenshots/afile', 2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('with.dolimed.com', $result, 'Test .../dolimed.com 2');
 
 		// For domains with top domain on 2 levels
 
-		$result=getDomainFromURL('https://www.with.dolimed.com.mx', 0);
+		$result = getDomainFromURL('https://www.with.dolimed.com.mx', 0);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('dolimed', $result, 'Test dolimed.com.mx 0');
 
-		$result=getDomainFromURL('https://www.with.dolimed.com.mx', 1);
+		$result = getDomainFromURL('https://www.with.dolimed.com.mx', 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('dolimed.com.mx', $result, 'Test dolimed.com.mx 1');
 
-		$result=getDomainFromURL('https://www.with.dolimed.com.mx', 2);
+		$result = getDomainFromURL('https://www.with.dolimed.com.mx', 2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('with.dolimed.com.mx', $result, 'Test dolimed.com.mx 2');
 
@@ -177,16 +177,16 @@ class GetUrlLibTest extends CommonClassTest
 	public function testRemoveHtmlComment()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=removeHtmlComment('abc<!--[if lt IE 8]>aaaa<![endif]-->def');
+		$result = removeHtmlComment('abc<!--[if lt IE 8]>aaaa<![endif]-->def');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('abcdef', $result, 'Test 1');
 
-		$result=removeHtmlComment('abc<!--[if lt IE 8]>aa-->bb<!--aa<![endif]-->def');
+		$result = removeHtmlComment('abc<!--[if lt IE 8]>aa-->bb<!--aa<![endif]-->def');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('abcbbdef', $result, 'Test 1');
 

--- a/test/phpunit/HolidayTest.php
+++ b/test/phpunit/HolidayTest.php
@@ -59,14 +59,14 @@ class HolidayTest extends CommonClassTest
 	public function testHolidayCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Holiday($db);
+		$localobject = new Holiday($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -85,13 +85,13 @@ class HolidayTest extends CommonClassTest
 	public function testHolidayFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Holiday($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Holiday($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -111,45 +111,45 @@ class HolidayTest extends CommonClassTest
 	public function testHolidayUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$localobject->oldcopy = clone $localobject;
 
-		$localobject->note_private='New private note after update';
-		$localobject->note_public='New public note after update';
-		$localobject->lastname='New name';
-		$localobject->firstname='New firstname';
-		$localobject->address='New address';
-		$localobject->zip='New zip';
-		$localobject->town='New town';
-		$localobject->country_id=2;
+		$localobject->note_private = 'New private note after update';
+		$localobject->note_public = 'New public note after update';
+		$localobject->lastname = 'New name';
+		$localobject->firstname = 'New firstname';
+		$localobject->address = 'New address';
+		$localobject->zip = 'New zip';
+		$localobject->town = 'New town';
+		$localobject->country_id = 2;
 		//$localobject->status=0;
-		$localobject->phone_pro='New tel pro';
-		$localobject->phone_perso='New tel perso';
-		$localobject->phone_mobile='New tel mobile';
-		$localobject->fax='New fax';
-		$localobject->email='newemail@newemail.com';
-		$localobject->jabberid='New im id';
-		$localobject->default_lang='es_ES';
+		$localobject->phone_pro = 'New tel pro';
+		$localobject->phone_perso = 'New tel perso';
+		$localobject->phone_mobile = 'New tel mobile';
+		$localobject->fax = 'New fax';
+		$localobject->email = 'newemail@newemail.com';
+		$localobject->jabberid = 'New im id';
+		$localobject->default_lang = 'es_ES';
 
-		$result=$localobject->update($localobject->id, $user);
+		$result = $localobject->update($localobject->id, $user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Holiday::update error');
 
-		$result=$localobject->update_note($localobject->note_private, '_private');
+		$result = $localobject->update_note($localobject->note_private, '_private');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Holiday::update_note (private) error');
 
-		$result=$localobject->update_note($localobject->note_public, '_public');
+		$result = $localobject->update_note($localobject->note_public, '_public');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Holiday::update_note (public) error');
 
 
-		$newobject=new Holiday($db);
-		$result=$newobject->fetch($localobject->id);
+		$newobject = new Holiday($db);
+		$result = $newobject->fetch($localobject->id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Holiday::fetch error');
 
@@ -173,10 +173,10 @@ class HolidayTest extends CommonClassTest
 	public function testHolidayOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$result = $localobject->fetchUsers(true, true, '');
 		$this->assertNotEquals($result, -1);
@@ -205,15 +205,15 @@ class HolidayTest extends CommonClassTest
 	public function testHolidayDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Holiday($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Holiday($db);
+		$result = $localobject->fetch($id);
 
-		$result=$localobject->delete($user);
+		$result = $localobject->delete($user);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -228,54 +228,54 @@ class HolidayTest extends CommonClassTest
 	public function testVerifDateHolidayCP()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Create a leave request the 1st morning only
-		$localobjecta=new Holiday($db);
+		$localobjecta = new Holiday($db);
 		$localobjecta->initAsSpecimen();
 		$localobjecta->date_debut = dol_mktime(0, 0, 0, 1, 1, 2020);
 		$localobjecta->date_fin = dol_mktime(0, 0, 0, 1, 1, 2020);
 		$localobjecta->halfday = 1;
-		$result=$localobjecta->create($user);
+		$result = $localobjecta->create($user);
 
 		// Create a leave request the 2 afternoon only
-		$localobjectb=new Holiday($db);
+		$localobjectb = new Holiday($db);
 		$localobjectb->initAsSpecimen();
 		$localobjectb->date_debut = dol_mktime(0, 0, 0, 1, 2, 2020);
 		$localobjectb->date_fin = dol_mktime(0, 0, 0, 1, 2, 2020);
 		$localobjectb->halfday = -1;
-		$result=$localobjectb->create($user);
+		$result = $localobjectb->create($user);
 
 		$date_debut = dol_mktime(0, 0, 0, 1, 1, 2020);
 		$date_fin = dol_mktime(0, 0, 0, 1, 2, 2020);
 
-		$localobjectc=new Holiday($db);
+		$localobjectc = new Holiday($db);
 
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_debut, 0);
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_debut, 0);
 		$this->assertFalse($result, 'result should be false, there is overlapping, full day is not available.');
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_fin, 0);
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_fin, 0);
 		$this->assertFalse($result, 'result should be false, there is overlapping, full day is not available.');
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_fin, $date_fin, 0);
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_fin, $date_fin, 0);
 		$this->assertFalse($result, 'result should be false, there is overlapping, full day is not available.');
 
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_debut, 1);
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_debut, 1);
 		$this->assertFalse($result, 'result should be false, there is overlapping, morning of first day is not available.');
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_fin, 1);
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_fin, 1);
 		$this->assertFalse($result, 'result should be false, there is overlapping, morning of first day is not available.');
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_fin, $date_fin, 1);
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_fin, $date_fin, 1);
 		$this->assertTrue($result, 'result should be true, there is no overlapping');
 
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_debut, -1);
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_debut, -1);
 		$this->assertTrue($result, 'result should be true, there is no overlapping');
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_fin, -1);
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_fin, -1);
 		$this->assertFalse($result, 'result should be false, there is overlapping, afternoon of second day is not available');
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_fin, $date_fin, -1);
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_fin, $date_fin, -1);
 		$this->assertFalse($result, 'result should be false, there is overlapping, afternoon of second day is not available');
 
-		$result=$localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_fin, 2);	// start afternoon and end morning
+		$result = $localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_fin, 2);	// start afternoon and end morning
 		$this->assertTrue($result, 'result should be true, there is no overlapping');
 	}
 
@@ -288,7 +288,7 @@ class HolidayTest extends CommonClassTest
 	{
 		global $db;
 
-		$localobjecta=new Holiday($db);
+		$localobjecta = new Holiday($db);
 
 		$localobjecta->updateConfCP('lastUpdate', '20100101120000');
 		$result = $localobjecta->updateBalance();

--- a/test/phpunit/ImagesLibTest.php
+++ b/test/phpunit/ImagesLibTest.php
@@ -38,7 +38,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -57,14 +57,14 @@ class ImagesLibTest extends CommonClassTest
 	 */
 	public function testgetImageSize()
 	{
-		$file=dirname(__FILE__).'/img250x50.jpg';
-		$tmp=dol_getImageSize($file);
+		$file = dirname(__FILE__).'/img250x50.jpg';
+		$tmp = dol_getImageSize($file);
 		print __METHOD__." result=".$tmp['width'].'/'.$tmp['height']."\n";
 		$this->assertEquals($tmp['width'], 250);
 		$this->assertEquals($tmp['height'], 50);
 
-		$file=dirname(__FILE__).'/img250x20.png';
-		$tmp=dol_getImageSize($file);
+		$file = dirname(__FILE__).'/img250x20.png';
+		$tmp = dol_getImageSize($file);
 		print __METHOD__." result=".$tmp['width'].'/'.$tmp['height']."\n";
 		$this->assertEquals($tmp['width'], 250);
 		$this->assertEquals($tmp['height'], 20);
@@ -87,8 +87,8 @@ class ImagesLibTest extends CommonClassTest
 	{
 		global $conf;
 
-		$file=dirname(__FILE__).'/img250x20.png';
-		$filetarget=$conf->admin->dir_temp.'/img250x20.jpg';
+		$file = dirname(__FILE__).'/img250x20.png';
+		$filetarget = $conf->admin->dir_temp.'/img250x20.jpg';
 		dol_delete_file($filetarget);
 		$result = dol_imageResizeOrCrop($file, 0, 0, 0, 0, 0, $filetarget);
 		print __METHOD__." result=".$result."\n";

--- a/test/phpunit/ImportTest.php
+++ b/test/phpunit/ImportTest.php
@@ -78,7 +78,7 @@ class ImportTest extends CommonClassTest
 	 */
 	public function testImportSample1()
 	{
-		$file=dirname(__FILE__).'/Example_import_company_1.csv';
+		$file = dirname(__FILE__).'/Example_import_company_1.csv';
 
 		// TODO
 		// Run import on file and check the record with field "auto" are filled

--- a/test/phpunit/InventoryTest.php
+++ b/test/phpunit/InventoryTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -57,14 +57,14 @@ class InventoryTest extends CommonClassTest
 	public function testInventoryCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Inventory($db);
+		$localobject = new Inventory($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
 		return $result;
@@ -82,13 +82,13 @@ class InventoryTest extends CommonClassTest
 	public function testInventoryFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Inventory($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Inventory($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -107,14 +107,14 @@ class InventoryTest extends CommonClassTest
 	public function testInventoryUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$localobject->status = 9;
 		$localobject->title = 'test';
-		$result=$localobject->update($user, $user);
+		$result = $localobject->update($user, $user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 		return $localobject;
@@ -133,12 +133,12 @@ class InventoryTest extends CommonClassTest
 	public function testInventoryValidate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->validate($user);
+		$result = $localobject->validate($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -158,12 +158,12 @@ class InventoryTest extends CommonClassTest
 	public function testInventorySetDraft($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setDraft($user);
+		$result = $localobject->setDraft($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -183,12 +183,12 @@ class InventoryTest extends CommonClassTest
 	public function testInventorySetRecorded($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setRecorded($user);
+		$result = $localobject->setRecorded($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -208,12 +208,12 @@ class InventoryTest extends CommonClassTest
 	public function testInventorySetCanceled($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setCanceled($user);
+		$result = $localobject->setCanceled($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -232,10 +232,10 @@ class InventoryTest extends CommonClassTest
 	public function testInventoryOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$localobject->info($localobject->id);
 		print __METHOD__." localobject->date_creation=".$localobject->date_creation."\n";
@@ -254,14 +254,14 @@ class InventoryTest extends CommonClassTest
 	public function testInventoryDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Inventory($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Inventory($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -279,23 +279,23 @@ class InventoryTest extends CommonClassTest
 	 */
 	public function objCompare($oA, $oB, $ignoretype = true, $fieldstoignorearray = array('id'))
 	{
-		$retAr=array();
+		$retAr = array();
 
 		if (get_class($oA) !== get_class($oB)) {
-			$retAr[]="Supplied objects are not of same class.";
+			$retAr[] = "Supplied objects are not of same class.";
 		} else {
-			$oVarsA=get_object_vars($oA);
-			$oVarsB=get_object_vars($oB);
-			$aKeys=array_keys($oVarsA);
+			$oVarsA = get_object_vars($oA);
+			$oVarsB = get_object_vars($oB);
+			$aKeys = array_keys($oVarsA);
 			foreach ($aKeys as $sKey) {
 				if (in_array($sKey, $fieldstoignorearray)) {
 					continue;
 				}
 				if (! $ignoretype && ($oVarsA[$sKey] !== $oVarsB[$sKey])) {
-					$retAr[]=$sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
+					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
 				}
 				if ($ignoretype && ($oVarsA[$sKey] != $oVarsB[$sKey])) {
-					$retAr[]=$sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
+					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
 				}
 			}
 		}

--- a/test/phpunit/JsonLibTest.php
+++ b/test/phpunit/JsonLibTest.php
@@ -80,55 +80,55 @@ class JsonLibTest extends CommonClassTest
 	{
 		//$this->sharedFixture
 		global $conf,$user,$langs,$db;
-		$this->savconf=$conf;
-		$this->savuser=$user;
-		$this->savlangs=$langs;
-		$this->savdb=$db;
+		$this->savconf = $conf;
+		$this->savuser = $user;
+		$this->savlangs = $langs;
+		$this->savdb = $db;
 
 		// Try to decode a string encoded with serialize
 		$encoded = 'a:1:{s:7:"options";a:3:{s:3:"app";s:11:"Application";s:6:"system";s:6:"System";s:6:"option";s:6:"Option";}}';
-		$decoded=json_decode($encoded, true);
+		$decoded = json_decode($encoded, true);
 		$this->assertEquals(null, $decoded, 'test to json_decode() a string that was encoded with serialize()');
 
 		$encoded = 'rubishstring!aa{bcd';
-		$decoded=json_decode($encoded, true);
+		$decoded = json_decode($encoded, true);
 		$this->assertEquals(null, $decoded, 'test to json_decode() a string that was encoded with serialize()');
 
 		// Do a test with an array starting with 0
-		$arraytotest=array(0=>array('key'=>1,'value'=>'PRODREF','label'=>'Product ref with é and special chars \\ \' "'));
-		$arrayencodedexpected='[{"key":1,"value":"PRODREF","label":"Product ref with \u00e9 and special chars \\\\ \' \""}]';
+		$arraytotest = array(0 => array('key' => 1,'value' => 'PRODREF','label' => 'Product ref with é and special chars \\ \' "'));
+		$arrayencodedexpected = '[{"key":1,"value":"PRODREF","label":"Product ref with \u00e9 and special chars \\\\ \' \""}]';
 
-		$encoded=json_encode($arraytotest);
+		$encoded = json_encode($arraytotest);
 		$this->assertEquals($arrayencodedexpected, $encoded);
-		$decoded=json_decode($encoded, true);
+		$decoded = json_decode($encoded, true);
 		$this->assertEquals($arraytotest, $decoded, 'test for json_xxx');
 
-		$encoded=dol_json_encode($arraytotest);
+		$encoded = dol_json_encode($arraytotest);
 		$this->assertEquals($arrayencodedexpected, $encoded);
-		$decoded=dol_json_decode($encoded, true);
+		$decoded = dol_json_decode($encoded, true);
 		$this->assertEquals($arraytotest, $decoded, 'test for dol_json_xxx');
 
 		// Same test but array start with 2 instead of 0
-		$arraytotest=array(2=>array('key'=>1,'value'=>'PRODREF','label'=>'Product ref with é and special chars \\ \' "'));
-		$arrayencodedexpected='{"2":{"key":1,"value":"PRODREF","label":"Product ref with \u00e9 and special chars \\\\ \' \""}}';
+		$arraytotest = array(2 => array('key' => 1,'value' => 'PRODREF','label' => 'Product ref with é and special chars \\ \' "'));
+		$arrayencodedexpected = '{"2":{"key":1,"value":"PRODREF","label":"Product ref with \u00e9 and special chars \\\\ \' \""}}';
 
-		$encoded=json_encode($arraytotest);
+		$encoded = json_encode($arraytotest);
 		$this->assertEquals($arrayencodedexpected, $encoded);
-		$decoded=json_decode($encoded, true);
+		$decoded = json_decode($encoded, true);
 		$this->assertEquals($arraytotest, $decoded, 'test for json_xxx');
 
-		$encoded=dol_json_encode($arraytotest);
+		$encoded = dol_json_encode($arraytotest);
 		$this->assertEquals($arrayencodedexpected, $encoded);
-		$decoded=dol_json_decode($encoded, true);
+		$decoded = dol_json_decode($encoded, true);
 		$this->assertEquals($arraytotest, $decoded, 'test for dol_json_xxx');
 
 		// Test with object
-		$now=gmmktime(12, 0, 0, 1, 1, 1970);
-		$objecttotest=new stdClass();
-		$objecttotest->property1='abc';
-		$objecttotest->property2=1234;
-		$objecttotest->property3=$now;
-		$encoded=dol_json_encode($objecttotest);
+		$now = gmmktime(12, 0, 0, 1, 1, 1970);
+		$objecttotest = new stdClass();
+		$objecttotest->property1 = 'abc';
+		$objecttotest->property2 = 1234;
+		$objecttotest->property3 = $now;
+		$encoded = dol_json_encode($objecttotest);
 		$this->assertEquals('{"property1":"abc","property2":1234,"property3":43200}', $encoded);
 	}
 }

--- a/test/phpunit/KnowledgeRecordTest.php
+++ b/test/phpunit/KnowledgeRecordTest.php
@@ -104,13 +104,13 @@ class KnowledgeRecordTest extends CommonClassTest
 	public function testKnowledgeRecordFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new KnowledgeRecord($db);
-		$result=$localobject->fetch($id);
+		$localobject = new KnowledgeRecord($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -133,7 +133,7 @@ class KnowledgeRecordTest extends CommonClassTest
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		$localobject->note_private='New note private after update';
+		$localobject->note_private = 'New note private after update';
 		$result = $localobject->update($user);
 
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/LangTest.php
+++ b/test/phpunit/LangTest.php
@@ -68,7 +68,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -88,10 +88,10 @@ class LangTest extends CommonClassTest
 	public function testLang()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		include_once DOL_DOCUMENT_ROOT.'/core/class/translate.class.php';
 
@@ -102,32 +102,32 @@ class LangTest extends CommonClassTest
 			}
 
 			print 'Check language file for lang code='.$code."\n";
-			$tmplangs=new Translate('', $conf);
-			$langcode=$code;
+			$tmplangs = new Translate('', $conf);
+			$langcode = $code;
 			$tmplangs->setDefaultLang($langcode);
 			$tmplangs->load("main");
 
-			$result=$tmplangs->transnoentitiesnoconv("FONTFORPDF");
+			$result = $tmplangs->transnoentitiesnoconv("FONTFORPDF");
 			print __METHOD__." FONTFORPDF=".$result."\n";
 			$this->assertTrue(in_array($result, array('msungstdlight', 'stsongstdlight', 'helvetica', 'DejaVuSans', 'cid0jp', 'cid0kr', 'freemono', 'freeserif')), 'Error bad value '.$result.' for FONTFORPDF in main.lang file '.$code);
 
-			$result=$tmplangs->transnoentitiesnoconv("DIRECTION");
+			$result = $tmplangs->transnoentitiesnoconv("DIRECTION");
 			print __METHOD__." DIRECTION=".$result."\n";
 			$this->assertTrue(in_array($result, array('rtl', 'ltr')), 'Error bad value for DIRECTION in main.lang file '.$code);
 
-			$result=$tmplangs->transnoentitiesnoconv("SeparatorDecimal");
+			$result = $tmplangs->transnoentitiesnoconv("SeparatorDecimal");
 			print __METHOD__." SeparatorDecimal=".$result."\n";
 			$this->assertTrue(in_array($result, array('.',',','/',' ','','None')), 'Error on decimal separator for lang code '.$code);	// Note that ، that is coma for RTL languages is not supported
 
-			$result=$tmplangs->transnoentitiesnoconv("SeparatorThousand");
+			$result = $tmplangs->transnoentitiesnoconv("SeparatorThousand");
 			print __METHOD__." SeparatorThousand=".$result."\n";
 			$this->assertTrue(in_array($result, array('.',',','/',' ','','\'','None','Space')), 'Error on thousand separator for lang code '.$code);	// Note that ، that is coma for RTL languages is not supported
 
 			// Test java string contains only d,M,y,/,-,. and not m,...
-			$result=$tmplangs->transnoentitiesnoconv("FormatDateShortJava");
+			$result = $tmplangs->transnoentitiesnoconv("FormatDateShortJava");
 			print __METHOD__." FormatDateShortJava=".$result."\n";
 			$this->assertRegExp('/^[dMy\/\-\.]+$/', $result, 'FormatDateShortJava KO for lang code '.$code);
-			$result=$tmplangs->trans("FormatDateShortJavaInput");
+			$result = $tmplangs->trans("FormatDateShortJavaInput");
 			print __METHOD__." FormatDateShortJavaInput=".$result."\n";
 			$this->assertRegExp('/^[dMy\/\-\.]+$/', $result, 'FormatDateShortJavaInput KO for lang code '.$code);
 
@@ -141,21 +141,21 @@ class LangTest extends CommonClassTest
 				}
 
 				//print 'Check lang file '.$file."\n";
-				$filecontent=file_get_contents(DOL_DOCUMENT_ROOT.'/langs/'.$code.'/'.$file);
+				$filecontent = file_get_contents(DOL_DOCUMENT_ROOT.'/langs/'.$code.'/'.$file);
 
-				$result=preg_match('/=--$/m', $filecontent);	// A special % char we don't want. We want the common one.
+				$result = preg_match('/=--$/m', $filecontent);	// A special % char we don't want. We want the common one.
 				//print __METHOD__." Result for checking we don't have bad percent char = ".$result."\n";
 				$this->assertTrue($result == 0, 'Found a translation KEY=-- into file '.$code.'/'.$file.'. We probably want Key=- instead.');
 
-				$result=strpos($filecontent, '％');	// A special % char we don't want. We want the common one.
+				$result = strpos($filecontent, '％');	// A special % char we don't want. We want the common one.
 				//print __METHOD__." Result for checking we don't have bad percent char = ".$result."\n";
 				$this->assertTrue($result === false, 'Found a bad percent char ％ instead of % into file '.$code.'/'.$file);
 
-				$result=preg_match('/%n/m', $filecontent);	// A sequence of char we don't want
+				$result = preg_match('/%n/m', $filecontent);	// A sequence of char we don't want
 				//print __METHOD__." Result for checking we don't have bad percent char = ".$result."\n";
 				$this->assertTrue($result == 0, 'Found a sequence %n into the translation file '.$code.'/'.$file.'. We probably want %s');
 
-				$result=preg_match('/<<<<</m', $filecontent);	// A sequence of char we don't want
+				$result = preg_match('/<<<<</m', $filecontent);	// A sequence of char we don't want
 				//print __METHOD__." Result for checking we don't have bad percent char = ".$result."\n";
 				$this->assertTrue($result == 0, 'Found a sequence <<<<< into the translation file '.$code.'/'.$file.'. Probably a bad merge of code were done.');
 			}
@@ -172,13 +172,13 @@ class LangTest extends CommonClassTest
 	public function testTrans()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$tmplangs=new Translate('', $conf);
-		$langcode='en_US';
+		$tmplangs = new Translate('', $conf);
+		$langcode = 'en_US';
 		$tmplangs->setDefaultLang($langcode);
 		$tmplangs->load("main");
 

--- a/test/phpunit/LesscTest.php
+++ b/test/phpunit/LesscTest.php
@@ -68,7 +68,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -88,10 +88,10 @@ class LesscTest extends CommonClassTest
 	public function testLessc()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		include_once DOL_DOCUMENT_ROOT.'/core/class/lessc.class.php';
 

--- a/test/phpunit/LoanTest.php
+++ b/test/phpunit/LoanTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,14 +56,14 @@ class LoanTest extends CommonClassTest
 	public function testLoanCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Loan($db);
+		$localobject = new Loan($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
@@ -82,13 +82,13 @@ class LoanTest extends CommonClassTest
 	public function testLoanFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Loan($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Loan($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -107,12 +107,12 @@ class LoanTest extends CommonClassTest
 	public function testLoanOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setPaid($user);
+		$result = $localobject->setPaid($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -131,14 +131,14 @@ class LoanTest extends CommonClassTest
 	public function testLoanDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Loan($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Loan($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/MarginsLibTest.php
+++ b/test/phpunit/MarginsLibTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,12 +56,12 @@ class MarginsLibTest extends CommonClassTest
 	public function testGetMarginInfos()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=getMarginInfos(10, 0, 19.6, 0, 0, 0, 8);
+		$result = getMarginInfos(10, 0, 19.6, 0, 0, 0, 8);
 		//var_dump($result);
 		print __METHOD__." result[0]=".$result[0]."\n";
 		$this->assertEquals(8, $result[0]);
@@ -70,13 +70,13 @@ class MarginsLibTest extends CommonClassTest
 		print __METHOD__." result[2]=".$result[2]."\n";
 		$this->assertEquals(20, $result[2]);
 
-		$result=getMarginInfos(10, 10, 19.6, 0, 0, 0, 8);
+		$result = getMarginInfos(10, 10, 19.6, 0, 0, 0, 8);
 		print __METHOD__." result[0]=".$result[0]."\n";
 		$this->assertEquals(8, $result[0]);
 		print __METHOD__." result[1]=".$result[1]."\n";
 		$this->assertEquals(12.5, $result[1]);
 		print __METHOD__." result[2]=".$result[2]."\n";
-		$this->assertEquals(1/9*100, $result[2]);
+		$this->assertEquals(1 / 9 * 100, $result[2]);
 
 		return 0;
 	}

--- a/test/phpunit/ModulesTest.php
+++ b/test/phpunit/ModulesTest.php
@@ -35,7 +35,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -55,12 +55,12 @@ class ModulesTest extends CommonClassTest
 	public function testModulesInit()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$modulelist=array('Accounting','Adherent','Agenda','Api','Asset','Banque','Barcode','BlockedLog','Bom','Bookmark',
+		$modulelist = array('Accounting','Adherent','Agenda','Api','Asset','Banque','Barcode','BlockedLog','Bom','Bookmark',
 		'Categorie','ClickToDial','Collab','Commande','Comptabilite','Contrat','Cron','DataPolicy','Dav','DebugBar','Deplacement','DocumentGeneration','Don','DynamicPrices',
 		'ECM','EmailCollector','EventOrganization','Expedition','ExpenseReport','Export','ExternalRss','ExternalSite',
 		'Facture','Fckeditor','Ficheinter','Fournisseur','FTP','GeoIPMaxmind','Gravatar','Holiday','HRM','Import','Incoterm','Intracommreport',
@@ -72,17 +72,17 @@ class ModulesTest extends CommonClassTest
 		'TakePos','Tax','Ticket','User','Variants','WebServices','WebServicesClient','Website','Workflow','Workstation','Zapier');
 		foreach ($modulelist as $modlabel) {
 			require_once DOL_DOCUMENT_ROOT.'/core/modules/mod'.$modlabel.'.class.php';
-			$class='mod'.$modlabel;
-			$mod=new $class($db);
+			$class = 'mod'.$modlabel;
+			$mod = new $class($db);
 
-			$result=$mod->remove();
-			$result=$mod->init();
+			$result = $mod->remove();
+			$result = $mod->init();
 
 			$this->assertLessThan($result, 0, $modlabel." ".$mod->error);
 			print __METHOD__." test remove/init for module ".$modlabel.", result=".$result."\n";
 
 			if (in_array($modlabel, array('Ldap', 'MailmanSpip'))) {
-				$result=$mod->remove();
+				$result = $mod->remove();
 			}
 		}
 

--- a/test/phpunit/MouvementStockTest.php
+++ b/test/phpunit/MouvementStockTest.php
@@ -38,7 +38,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -58,10 +58,10 @@ class MouvementStockTest extends CommonClassTest
 	protected function setUp(): void
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		if (!isModEnabled('productbatch')) {
 			print "\n".__METHOD__." module Lot/Serial must be enabled.\n";
@@ -80,97 +80,97 @@ class MouvementStockTest extends CommonClassTest
 	public function testMouvementCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// We create a product for tests
-		$product0=new Product($db);
+		$product0 = new Product($db);
 		$product0->initAsSpecimen();
-		$product0->ref.=' phpunit 0';
-		$product0->label.=' phpunit 0';
+		$product0->ref .= ' phpunit 0';
+		$product0->label .= ' phpunit 0';
 		$product0->status_batch = 1;
-		$product0id=$product0->create($user);
+		$product0id = $product0->create($user);
 
 		print __METHOD__." product0id=".$product0id."\n";
 		$this->assertGreaterThan(0, $product0id, 'Failed to create product');
 
-		$product1=new Product($db);
+		$product1 = new Product($db);
 		$product1->initAsSpecimen();
-		$product1->ref.=' phpunit 1';
-		$product1->label.=' phpunit 1';
-		$product1id=$product1->create($user);
+		$product1->ref .= ' phpunit 1';
+		$product1->label .= ' phpunit 1';
+		$product1id = $product1->create($user);
 
-		$product2=new Product($db);
+		$product2 = new Product($db);
 		$product2->initAsSpecimen();
-		$product2->ref.=' phpunit 2';
-		$product2->label.=' phpunit 2';
-		$product2id=$product2->create($user);
+		$product2->ref .= ' phpunit 2';
+		$product2->label .= ' phpunit 2';
+		$product2id = $product2->create($user);
 
 		// We create a product for tests
-		$warehouse0=new Entrepot($db);
+		$warehouse0 = new Entrepot($db);
 		$warehouse0->initAsSpecimen();
-		$warehouse0->label.=' phpunit 0';
-		$warehouse0->description.=' phpunit 0';
+		$warehouse0->label .= ' phpunit 0';
+		$warehouse0->description .= ' phpunit 0';
 		$warehouse0->statut = 0;
-		$warehouse0id=$warehouse0->create($user);
+		$warehouse0id = $warehouse0->create($user);
 
-		$warehouse1=new Entrepot($db);
+		$warehouse1 = new Entrepot($db);
 		$warehouse1->initAsSpecimen();
-		$warehouse1->label.=' phpunit 1';
-		$warehouse1->description.=' phpunit 1';
-		$warehouse1id=$warehouse1->create($user);
+		$warehouse1->label .= ' phpunit 1';
+		$warehouse1->description .= ' phpunit 1';
+		$warehouse1id = $warehouse1->create($user);
 
-		$warehouse2=new Entrepot($db);
+		$warehouse2 = new Entrepot($db);
 		$warehouse2->initAsSpecimen();
-		$warehouse2->label.=' phpunit 2';
-		$warehouse2->description.=' phpunit 2';
-		$warehouse2id=$warehouse2->create($user);
+		$warehouse2->label .= ' phpunit 2';
+		$warehouse2->description .= ' phpunit 2';
+		$warehouse2id = $warehouse2->create($user);
 
-		$localobject=new MouvementStock($db);
+		$localobject = new MouvementStock($db);
 
 		$datetest1 = dol_mktime(0, 0, 0, 1, 1, 2000);
 		$datetest2 = dol_mktime(0, 0, 0, 1, 2, 2000);
 
 		// Create an input movement movement (type = 3) with value for eatby date and a lot $datetest1
-		$result=$localobject->reception($user, $product0id, $warehouse0id, 5, 999, 'Movement for unit test with batch', $datetest1, $datetest1, 'anotyetuselotnumberA', '', 0, 'Inventory Code Test with batch');
+		$result = $localobject->reception($user, $product0id, $warehouse0id, 5, 999, 'Movement for unit test with batch', $datetest1, $datetest1, 'anotyetuselotnumberA', '', 0, 'Inventory Code Test with batch');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, 'Failed to create a movement with a lot number '.$datetest1.' for product id='.$product0id.' with status_batch=1');
 
-		$result=$localobject->reception($user, $product0id, $warehouse0id, 5, 999, 'Movement for unit test with batch', $datetest1, $datetest1, 'anotyetuselotnumberB', '', 0, 'Inventory Code Test with batch');
+		$result = $localobject->reception($user, $product0id, $warehouse0id, 5, 999, 'Movement for unit test with batch', $datetest1, $datetest1, 'anotyetuselotnumberB', '', 0, 'Inventory Code Test with batch');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, 'Test to check we can create a movement a eatby dare different when lot number is different');
 
 		// Create same input movement movement (type = 3) with same lot but a different value of eatby date
-		$result=$localobject->reception($user, $product0id, $warehouse0id, 5, 999, 'Movement for unit test with batch', $datetest2, $datetest1, 'anotyetuselotnumberA', '', 0, 'Inventory Code Test with batch');
+		$result = $localobject->reception($user, $product0id, $warehouse0id, 5, 999, 'Movement for unit test with batch', $datetest2, $datetest1, 'anotyetuselotnumberA', '', 0, 'Inventory Code Test with batch');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(-3, $result, 'Test to check we can t create a movement for a lot with a different eatby date');
 
 		// Do a list of movement into warehouse 1
 
 		// Create an input movement (type = 3) of price 9.9 -> should update PMP to 9.9
-		$result=$localobject->reception($user, $product1id, $warehouse1id, 10, 9.9, 'Movement for unit test 1', '', '', '', '', 0, 'Inventory Code Test');
+		$result = $localobject->reception($user, $product1id, $warehouse1id, 10, 9.9, 'Movement for unit test 1', '', '', '', '', 0, 'Inventory Code Test');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, 'Return code of 0 was expected for the reception test 1');
 
 		// Create an input movement (type = 3) of price 9.7 -> should update PMP to 9.9/9.7 = 9.8
-		$result=$localobject->reception($user, $product1id, $warehouse1id, 10, 9.7, 'Movement for unit test 2', '', '', '', '', 0, 'Inventory Code Test');
+		$result = $localobject->reception($user, $product1id, $warehouse1id, 10, 9.7, 'Movement for unit test 2', '', '', '', '', 0, 'Inventory Code Test');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
 
 		// Create an output movement (type = 2) of price 9.7 -> should update PMP to 9.9/9.7 = 9.8
-		$result=$localobject->livraison($user, $product1id, $warehouse1id, 5, 999, 'Movement for unit test 3', '', '', '', '', 0, 'Inventory Code Test');
+		$result = $localobject->livraison($user, $product1id, $warehouse1id, 5, 999, 'Movement for unit test 3', '', '', '', '', 0, 'Inventory Code Test');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
 
 		// Create an output movement (type = 1) of price 9.7 -> should update PMP to 9.9/9.7 = 9.8
-		$result=$localobject->_create($user, $product1id, $warehouse1id, 1, 0, 0, 'Input from transfer', 'Transfert X');
+		$result = $localobject->_create($user, $product1id, $warehouse1id, 1, 0, 0, 'Input from transfer', 'Transfert X');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
 
 		// Create an output movement (type = 1) of price 9.7 -> should update PMP to 9.9/9.7 = 9.8
-		$result=$localobject->_create($user, $product1id, $warehouse1id, -2, 1, 0, 'Output from transfer', 'Transfert Y');
+		$result = $localobject->_create($user, $product1id, $warehouse1id, -2, 1, 0, 'Output from transfer', 'Transfert Y');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
 
@@ -178,27 +178,27 @@ class MouvementStockTest extends CommonClassTest
 		// Do same but into warehouse 2
 
 		// Create an input movement (type = 3) of price 9.9 -> should update PMP to 9.9
-		$result=$localobject->reception($user, $product1id, $warehouse2id, 10, 9.9, 'Movement for unit test 1 wh 2', '', '', '', '', 0, 'Inventory Code Test 2');
+		$result = $localobject->reception($user, $product1id, $warehouse2id, 10, 9.9, 'Movement for unit test 1 wh 2', '', '', '', '', 0, 'Inventory Code Test 2');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
 
 		// Create an input movement (type = 3) of price 9.7 -> should update PMP to 9.9/9.7 = 9.8
-		$result=$localobject->reception($user, $product1id, $warehouse2id, 10, 9.7, 'Movement for unit test 2 wh 2', '', '', '', '', 0, 'Inventory Code Test 2');
+		$result = $localobject->reception($user, $product1id, $warehouse2id, 10, 9.7, 'Movement for unit test 2 wh 2', '', '', '', '', 0, 'Inventory Code Test 2');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
 
 		// Create an output movement (type = 2) of price 9.7 -> should update PMP to 9.9/9.7 = 9.8
-		$result=$localobject->livraison($user, $product1id, $warehouse2id, 5, 999, 'Movement for unit test 3 wh 2', '', '', '', '', 0, 'Inventory Code Test 2');
+		$result = $localobject->livraison($user, $product1id, $warehouse2id, 5, 999, 'Movement for unit test 3 wh 2', '', '', '', '', 0, 'Inventory Code Test 2');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
 
 		// Create an output movement (type = 1) of price 9.7 -> should update PMP to 9.9/9.7 = 9.8
-		$result=$localobject->_create($user, $product1id, $warehouse2id, 1, 0, 0, 'Input from transfer wh 2', 'Transfert X 2');
+		$result = $localobject->_create($user, $product1id, $warehouse2id, 1, 0, 0, 'Input from transfer wh 2', 'Transfert X 2');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, 'Test create A');
 
 		// Create an output movement (type = 1) of price 9.7 -> should update PMP to 9.9/9.7 = 9.8
-		$result=$localobject->_create($user, $product1id, $warehouse2id, -2, 1, 0, 'Output from transfer wh 2', 'Transfert Y 2');
+		$result = $localobject->_create($user, $product1id, $warehouse2id, -2, 1, 0, 'Output from transfer wh 2', 'Transfert Y 2');
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, 'Test create B');
 
@@ -217,10 +217,10 @@ class MouvementStockTest extends CommonClassTest
 	public function testMouvementCheck($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$productid = $localobject->product_id;
 		$warehouseid = $localobject->entrepot_id;

--- a/test/phpunit/NumberingModulesTest.php
+++ b/test/phpunit/NumberingModulesTest.php
@@ -35,7 +35,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -55,524 +55,524 @@ class NumberingModulesTest extends CommonClassTest
 	public function testFactureMercure()
 	{
 		global $conf,$user,$langs,$db,$mysoc;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		require_once dirname(__FILE__).'/../../htdocs/compta/facture/class/facture.class.php';
 		require_once dirname(__FILE__).'/../../htdocs/core/modules/facture/mod_facture_mercure.php';
 
 		// First we try with a simple mask, with no reset
 		// and we test counter is still increase second year.
-		$conf->global->FACTURE_ADDON='mercure';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}-{0000}';
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}-{0000}';
-		$conf->global->FACTURE_MERCURE_MASK_DEPOSIT='{yyyy}-{0000}';
-		$conf->global->FACTURE_MERCURE_MASK_REPLACEMENT='{yyyy}-{0000}';
-		$conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED=0;
+		$conf->global->FACTURE_ADDON = 'mercure';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}-{0000}';
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}-{0000}';
+		$conf->global->FACTURE_MERCURE_MASK_DEPOSIT = '{yyyy}-{0000}';
+		$conf->global->FACTURE_MERCURE_MASK_REPLACEMENT = '{yyyy}-{0000}';
+		$conf->global->INVOICE_CAN_ALWAYS_BE_REMOVED = 0;
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1915);	// we use year 1915 to be sure to not have existing invoice for this year (useful only if numbering is {0000@1}
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1915);	// we use year 1915 to be sure to not have existing invoice for this year (useful only if numbering is {0000@1}
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1915-0001', $result, 'Test for {yyyy}-{0000}, 1st invoice');				// counter must start to 1
-		$result2=$localobject->create($user, 1);
+		$result2 = $localobject->create($user, 1);
 		print __METHOD__." result2=".$result."\n";
-		$result3=$localobject->validate($user, $result);		// create invoice by forcing ref
+		$result3 = $localobject->validate($user, $result);		// create invoice by forcing ref
 		print __METHOD__." result3=".$result."\n";
 		$this->assertEquals(1, $result3, 'Test validation of invoice with forced ref is ok');	// counter must start to 1
-		$result=$localobject->is_erasable();
+		$result = $localobject->is_erasable();
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result, 'Test for is_erasable, 1st invoice');						    // Can be deleted
 
-		$localobject2=new Facture($db);
+		$localobject2 = new Facture($db);
 		$localobject2->initAsSpecimen();
 		$localobject2->fetch_thirdparty();
 
-		$localobject2->date=dol_mktime(12, 0, 0, 1, 1, 1916);	// we use following year for second invoice (there is no reset into mask)
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject2, 'last');
+		$localobject2->date = dol_mktime(12, 0, 0, 1, 1, 1916);	// we use following year for second invoice (there is no reset into mask)
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject2, 'last');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1915-0001', $result, "Test to get last value with param 'last'");
-		$result=$numbering->getNextValue($mysoc, $localobject2);
+		$result = $numbering->getNextValue($mysoc, $localobject2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1916-0002', $result);				// counter must be now 2 (not reset)
-		$result2=$localobject2->create($user, 1);
+		$result2 = $localobject2->create($user, 1);
 		print __METHOD__." result2=".$result."\n";
-		$result3=$localobject2->validate($user, $result);		// create invoice by forcing ref
+		$result3 = $localobject2->validate($user, $result);		// create invoice by forcing ref
 		print __METHOD__." result3=".$result."\n";
 		$this->assertEquals(1, $result3, 'Test validation of invoice with forced ref is ok');	// counter must start to 1
-		$result=$localobject2->is_erasable();
+		$result = $localobject2->is_erasable();
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);						// Can be deleted
-		$result=$localobject->is_erasable();
+		$result = $localobject->is_erasable();
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertLessThanOrEqual(0, $result, 'Test for {yyyy}-{0000} that is_erasable is 0 for 1st invoice');						// 1 can no more be deleted (2 is more recent)
 
 		// Now we try with a reset
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}-{0000@1}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}-{0000@1}';
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}-{0000@1}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}-{0000@1}';
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1910);	// we use year 1910 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1910);	// we use year 1910 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1910-0001', $result, 'Test for {yyyy}-{0000@1} 1st invoice');				// counter must start to 1
 
-		$localobject2=new Facture($db);
+		$localobject2 = new Facture($db);
 		$localobject2->initAsSpecimen();
 		$localobject2->fetch_thirdparty();
 
-		$localobject2->date=dol_mktime(12, 0, 0, 1, 1, 1910);	// we use same year for second invoice (and there is a reset required)
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject2);
+		$localobject2->date = dol_mktime(12, 0, 0, 1, 1, 1910);	// we use same year for second invoice (and there is a reset required)
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1910-0002', $result, 'Test for {yyyy}-{0000@1} 2nd invoice, same day');	// counter must be now 2
 
-		$localobject3=new Facture($db);
+		$localobject3 = new Facture($db);
 		$localobject3->initAsSpecimen();
 		$localobject3->fetch_thirdparty();
 
-		$localobject3->date=dol_mktime(12, 0, 0, 1, 1, 1911);	// we use next year for third invoice (and there is a reset required)
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject3);
+		$localobject3->date = dol_mktime(12, 0, 0, 1, 1, 1911);	// we use next year for third invoice (and there is a reset required)
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject3);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('1911-0001', $result, 'Test for {yyyy}-{0000@1} 3rd invoice, same day');	// counter must be now 1
 
 		// Same but we add month after year
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@1}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@1}';
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}{mm}-{0000@1}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}{mm}-{0000@1}';
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1920);	// we use year 1920 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1920);	// we use year 1920 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('192001-0001', $result, 'Test for {yyyy}{mm}-{0000@1} 1st invoice');			// counter must start to 1
-		$result=$localobject->is_erasable();
+		$result = $localobject->is_erasable();
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);						// Can be deleted
 
-		$localobject2=new Facture($db);
+		$localobject2 = new Facture($db);
 		$localobject2->initAsSpecimen();
 		$localobject2->fetch_thirdparty();
 
-		$localobject2->date=dol_mktime(12, 0, 0, 1, 1, 1921);	// we use following year for second invoice (and there is a reset required)
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject2);
-		$result2=$localobject2->create($user, 1);
-		$result3=$localobject2->validate($user, $result);
+		$localobject2->date = dol_mktime(12, 0, 0, 1, 1, 1921);	// we use following year for second invoice (and there is a reset required)
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject2);
+		$result2 = $localobject2->create($user, 1);
+		$result3 = $localobject2->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('192101-0001', $result);			// counter must be reset to 1
-		$result=$localobject2->is_erasable();
+		$result = $localobject2->is_erasable();
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);						// Can be deleted
-		$result=$localobject->is_erasable();
+		$result = $localobject->is_erasable();
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);						// Case 1 can be deleted (because there was a reset for case 2)
 
 		// Same but we add month before year and use a year on 2 digits
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='[mm}{yy}-{0000@1}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{mm}{yy}-{0000@1}';
-		$localobject=new Facture($db);
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '[mm}{yy}-{0000@1}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{mm}{yy}-{0000@1}';
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1925);	// we use year 1925 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1925);	// we use year 1925 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('0125-0001', $result, 'Test for {mm}{yy}-{0000@1} 1st invoice');				// counter must start to 1
-		$result=$localobject->is_erasable();					// This call get getNextNumRef with param 'last'
+		$result = $localobject->is_erasable();					// This call get getNextNumRef with param 'last'
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);						// Can be deleted
 
-		$localobject2=new Facture($db);
+		$localobject2 = new Facture($db);
 		$localobject2->initAsSpecimen();
 		$localobject2->fetch_thirdparty();
-		$localobject2->date=dol_mktime(12, 0, 0, 1, 1, 1925);	// we use same year 1925 for second invoice (and there is a reset required)
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject2);
-		$result2=$localobject2->create($user, 1);
-		$result3=$localobject2->validate($user, $result);
+		$localobject2->date = dol_mktime(12, 0, 0, 1, 1, 1925);	// we use same year 1925 for second invoice (and there is a reset required)
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject2);
+		$result2 = $localobject2->create($user, 1);
+		$result3 = $localobject2->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('0125-0002', $result, 'Test for {mm}{yy}-{0000@1} 2nd invoice');			// counter must be now 2
-		$result=$localobject2->is_erasable();
+		$result = $localobject2->is_erasable();
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);						// Can be deleted
-		$result=$localobject->is_erasable();
+		$result = $localobject->is_erasable();
 		print __METHOD__." is_erasable=".$result."\n";
 		$this->assertLessThanOrEqual(0, $result);						// Case 1 can not be deleted (because there is an invoice 2)
 
-		$localobject3=new Facture($db);
+		$localobject3 = new Facture($db);
 		$localobject3->initAsSpecimen();
 		$localobject3->fetch_thirdparty();
-		$localobject3->date=dol_mktime(12, 0, 0, 1, 1, 1926);	// we use following year for third invoice (and there is a reset required)
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject3);
+		$localobject3->date = dol_mktime(12, 0, 0, 1, 1, 1926);	// we use following year for third invoice (and there is a reset required)
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject3);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('0126-0001', $result, 'Test for {mm}{yy}-{0000@1} 3rd invoice');			// counter must be now 1
 
 		// Try an offset when an invoice already exists
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000+9990}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000+9990}';
-		$result=$numbering->getNextValue($mysoc, $localobject2);
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}{mm}-{0000+9990}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}{mm}-{0000+9990}';
+		$result = $numbering->getNextValue($mysoc, $localobject2);
 
 		// Now we try with a different fiscal month (forced by mask)
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@6}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@6}';
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}{mm}-{0000@6}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}{mm}-{0000@6}';
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1930);	// we use year 1930 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject, 'last');
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1930);	// we use year 1930 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject, 'last');
 		print __METHOD__." result for last=".$result."\n";
 		$this->assertEquals('', $result);						// no existing ref into reset range
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('193001-0001', $result);			// counter must start to 1
-		$result=$numbering->getNextValue($mysoc, $localobject, 'last');
+		$result = $numbering->getNextValue($mysoc, $localobject, 'last');
 		print __METHOD__." result for last=".$result."\n";
 		$this->assertEquals('193001-0001', $result);			// last ref into reset range should be same than last created
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1930);	// we use same year but fiscal month after
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject, 'last');
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1930);	// we use same year but fiscal month after
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject, 'last');
 		print __METHOD__." result for last=".$result."\n";
 		$this->assertEquals('', $result);						// last ref into reset range should be ''
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('193012-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1931);	// we use same fiscal year but different year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1931);	// we use same fiscal year but different year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('193101-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1931);	// we use different fiscal year but same year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1931);	// we use different fiscal year but same year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('193112-0001', $result);	// counter must be reset to 1
 
 
 		// Now we try with a different fiscal month (defined by SOCIETE_FISCAL_MONTH_START)
-		$conf->global->SOCIETE_FISCAL_MONTH_START=6;
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@0}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@0}';
+		$conf->global->SOCIETE_FISCAL_MONTH_START = 6;
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}{mm}-{0000@0}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}{mm}-{0000@0}';
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1940);	// we use year 1940 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1940);	// we use year 1940 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('194001-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1940);	// we use same year but fiscal month after
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1940);	// we use same year but fiscal month after
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('194012-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1941);	// we use same fiscal year but different year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1941);	// we use same fiscal year but different year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('194101-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1941);	// we use different discal year but same year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1941);	// we use different discal year but same year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('194112-0001', $result);	// counter must be reset to 1
 
 
 		// Now we try with a different fiscal month (defined by SOCIETE_FISCAL_MONTH_START) and we always want year of element
-		$conf->global->SOCIETE_FISCAL_MONTH_START=6;
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@=}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@=}';
+		$conf->global->SOCIETE_FISCAL_MONTH_START = 6;
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}{mm}-{0000@=}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}{mm}-{0000@=}';
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1950);	// we use year 1950 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1950);	// we use year 1950 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('195001-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1950);	// we use same year but fiscal month after
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1950);	// we use same year but fiscal month after
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('195012-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1951);	// we use same fiscal year but different year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1951);	// we use same fiscal year but different year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('195101-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1951);	// we use different discal year but same year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1951);	// we use different discal year but same year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('195112-0001', $result);	// counter must be reset to 1
 
 
 		// Now we try with a different fiscal month (defined by SOCIETE_FISCAL_MONTH_START) and we always want start year
-		$conf->global->SOCIETE_FISCAL_MONTH_START=6;
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@-}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@-}';
+		$conf->global->SOCIETE_FISCAL_MONTH_START = 6;
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}{mm}-{0000@-}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}{mm}-{0000@-}';
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1960);	// we use year 1960 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1960);	// we use year 1960 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('195901-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1960);	// we use same year but fiscal month after
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1960);	// we use same year but fiscal month after
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('196012-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1961);	// we use same fiscal year but different year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1961);	// we use same fiscal year but different year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('196001-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1961);	// we use different discal year but same year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1961);	// we use different discal year but same year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('196112-0001', $result);	// counter must be reset to 1
 
 
 		// Now we try with a different fiscal month (defined by SOCIETE_FISCAL_MONTH_START) and we always want end year
-		$conf->global->SOCIETE_FISCAL_MONTH_START=6;
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@+}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@+}';
+		$conf->global->SOCIETE_FISCAL_MONTH_START = 6;
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}{mm}-{0000@+}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}{mm}-{0000@+}';
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1970);	// we use year 1970 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1970);	// we use year 1970 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('197001-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1970);	// we use same year but fiscal month after
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1970);	// we use same year but fiscal month after
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('197112-0001', $result);	// counter must be reset to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1971);	// we use same fiscal year but different year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1971);	// we use same fiscal year but different year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('197101-0002', $result);	// counter must be 2
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 12, 1, 1971);	// we use different fiscal year but same year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
+		$localobject->date = dol_mktime(12, 0, 0, 12, 1, 1971);	// we use different fiscal year but same year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('197212-0001', $result);	// counter must be reset to 1
 
 		// Now we try with a reset every month (@99)
-		$conf->global->SOCIETE_FISCAL_MONTH_START=6;
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{yyyy}{mm}-{0000@99}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{yyyy}{mm}-{0000@99}';
+		$conf->global->SOCIETE_FISCAL_MONTH_START = 6;
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{yyyy}{mm}-{0000@99}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{yyyy}{mm}-{0000@99}';
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1980);	// we use year 1980 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1980);	// we use year 1980 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('198001-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1980);	// we use year 1980 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1980);	// we use year 1980 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('198001-0002', $result);	// counter must start to 2
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 2, 1, 1980);	// we use year 1980 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 2, 1, 1980);	// we use year 1980 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('198002-0001', $result);	// counter must start to 1
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1981);	// we use year 1981 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($mysoc, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1981);	// we use year 1981 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($mysoc, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('198101-0001', $result);	// counter must start to 1
 
 		// Test with {t} tag
-		$conf->global->SOCIETE_FISCAL_MONTH_START=1;
-		$conf->global->FACTURE_MERCURE_MASK_CREDIT='{t}{yyyy}{mm}-{0000}';
-		$conf->global->FACTURE_MERCURE_MASK_INVOICE='{t}{yyyy}{mm}-{0000}';
+		$conf->global->SOCIETE_FISCAL_MONTH_START = 1;
+		$conf->global->FACTURE_MERCURE_MASK_CREDIT = '{t}{yyyy}{mm}-{0000}';
+		$conf->global->FACTURE_MERCURE_MASK_INVOICE = '{t}{yyyy}{mm}-{0000}';
 
-		$tmpthirdparty=new Societe($db);
+		$tmpthirdparty = new Societe($db);
 		$tmpthirdparty->initAsSpecimen();
 		$tmpthirdparty->typent_code = 'TE_ABC';
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
-		$localobject->date=dol_mktime(12, 0, 0, 1, 1, 1982);	// we use year 1982 to be sure to not have existing invoice for this year
-		$numbering=new mod_facture_mercure();
-		$result=$numbering->getNextValue($tmpthirdparty, $localobject);
-		$result2=$localobject->create($user, 1);
-		$result3=$localobject->validate($user, $result);
+		$localobject->date = dol_mktime(12, 0, 0, 1, 1, 1982);	// we use year 1982 to be sure to not have existing invoice for this year
+		$numbering = new mod_facture_mercure();
+		$result = $numbering->getNextValue($tmpthirdparty, $localobject);
+		$result2 = $localobject->create($user, 1);
+		$result3 = $localobject->validate($user, $result);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('A198201-0001', $result);	// counter must start to 1
 
@@ -589,21 +589,21 @@ class NumberingModulesTest extends CommonClassTest
 	public function testShipmentSafor()
 	{
 		global $conf,$user,$langs,$db,$mysoc;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		require_once dirname(__FILE__).'/../../htdocs/expedition/class/expedition.class.php';
 		require_once dirname(__FILE__).'/../../htdocs/core/modules/expedition/mod_expedition_safor.php';
 
-		$localobject=new Expedition($db);
+		$localobject = new Expedition($db);
 		$localobject->initAsSpecimen();
 		$localobject->fetch_thirdparty();
 
 		$localobject->date_creation = dol_mktime(12, 0, 0, 1, 1, 1980);	// we use year 1915 to be sure to not have existing invoice for this year (useful only if numbering is {0000@1}
-		$numbering=new mod_expedition_safor();
-		$result=$numbering->getNextValue($mysoc, $localobject);
+		$numbering = new mod_expedition_safor();
+		$result = $numbering->getNextValue($mysoc, $localobject);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('SH8001-0003', $result);	// counter must start to 1

--- a/test/phpunit/ODFTest.php
+++ b/test/phpunit/ODFTest.php
@@ -35,7 +35,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 $langs->load("main");
 
@@ -57,10 +57,10 @@ class ODFTest extends CommonClassTest
 	public function testODFconvertVarToOdf()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// we test using template_invoice, it does not matter, we just need a valid odt.
 		$filename = '../../htdocs/install/doctemplates/invoices/template_invoice.odt';
@@ -283,7 +283,7 @@ class ODFTest extends CommonClassTest
 			],
 		];
 
-		$odf=new Odf($filename, array());
+		$odf = new Odf($filename, array());
 		if (is_object($odf)) {
 			$result = 1;
 		} // Just to test

--- a/test/phpunit/PaypalTest.php
+++ b/test/phpunit/PaypalTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -77,15 +77,15 @@ class PaypalTest extends CommonClassTest
 	public function testPaypalOk()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$urltotest=getOnlinePaymentUrl(0, 'free');
+		$urltotest = getOnlinePaymentUrl(0, 'free');
 		print "urltotest=".$urltotest."\n";
 
-		$result=getURLContent($urltotest, 'GET', '', 1, array(), array('http', 'https'), 2);
+		$result = getURLContent($urltotest, 'GET', '', 1, array(), array('http', 'https'), 2);
 
 		print __METHOD__." result=".$result['http_code']."\n";
 		$this->assertEquals(200, $result['http_code']);

--- a/test/phpunit/PdfDocTest.php
+++ b/test/phpunit/PdfDocTest.php
@@ -40,7 +40,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -60,12 +60,12 @@ class PdfDocTest extends CommonClassTest
 	public function testPdfDocGetLineDesc()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localproduct=new Product($db);
+		$localproduct = new Product($db);
 		$result = $localproduct->fetch(0, 'PINKDRESS');
 		if ($result < 0) {
 			print "\n".__METHOD__." Failed to make the fetch of product PINKDRESS. ".$localproduct->error;
@@ -77,19 +77,19 @@ class PdfDocTest extends CommonClassTest
 			die(1);
 		}
 
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen();
-		$localobject->lines=array();
-		$localobject->lines[0]=new FactureLigne($db);
-		$localobject->lines[0]->fk_product=$product_id;
-		$localobject->lines[0]->label='Label 1';
-		$localobject->lines[0]->desc="This is a description with a é accent\n(Country of origin: France)";
+		$localobject->lines = array();
+		$localobject->lines[0] = new FactureLigne($db);
+		$localobject->lines[0]->fk_product = $product_id;
+		$localobject->lines[0]->label = 'Label 1';
+		$localobject->lines[0]->desc = "This is a description with a é accent\n(Country of origin: France)";
 
-		$result=pdf_getlinedesc($localobject, 0, $langs);
+		$result = pdf_getlinedesc($localobject, 0, $langs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("PINKDRESS - Label 1<br>This is a description with a &eacute; accent<br>(Country of origin: France)", $result);
 
-		$result=doc_getlinedesc($localobject->lines[0], $langs);
+		$result = doc_getlinedesc($localobject->lines[0], $langs);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("PINKDRESS - Label 1\nThis is a description with a é accent\n(Country of origin: France)", $result);
 	}
@@ -101,12 +101,12 @@ class PdfDocTest extends CommonClassTest
 	*/
 	public function testPdfGetHeightForLogo()
 	{
-		$file=dirname(__FILE__).'/img250x50.jpg';
-		$result=pdf_getHeightForLogo($file);
+		$file = dirname(__FILE__).'/img250x50.jpg';
+		$result = pdf_getHeightForLogo($file);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 20);
-		$file=dirname(__FILE__).'/img250x20.png';
-		$result=pdf_getHeightForLogo($file);
+		$file = dirname(__FILE__).'/img250x20.png';
+		$result = pdf_getHeightForLogo($file);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 10.4);
 	}

--- a/test/phpunit/PgsqlTest.php
+++ b/test/phpunit/PgsqlTest.php
@@ -39,7 +39,7 @@ if (empty($user->id)) {
 	$user->getrights();
 }
 
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -59,10 +59,10 @@ class PgsqlTest extends CommonClassTest
 	public function testConvertSQLFromMysql()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Create a dummy db handler for pgsql
 		$tmpdb = new DoliDBPgsql('pqsql', 'host', 'user', 'pass');
@@ -75,50 +75,50 @@ class PgsqlTest extends CommonClassTest
 		*/
 
 		$sql = "ALTER TABLE llx_bank_account MODIFY COLUMN state_id integer USING state_id::integer;";
-		$result=$tmpdb->convertSQLFromMysql($sql);
+		$result = $tmpdb->convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, "-- ALTER TABLE llx_bank_account MODIFY COLUMN state_id integer USING state_id::integer; replaced by --\nALTER TABLE llx_bank_account ALTER COLUMN state_id TYPE integer USING state_id::integer;");
 
-		$sql="ALTER TABLE llx_table RENAME TO llx_table_new;";
-		$result=$tmpdb->convertSQLFromMysql($sql);
+		$sql = "ALTER TABLE llx_table RENAME TO llx_table_new;";
+		$result = $tmpdb->convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, "ALTER TABLE llx_table RENAME TO llx_table_new;");
 
-		$sql="ALTER TABLE llx_table ADD COLUMN newcol varchar(60) NOT NULL DEFAULT '0' AFTER existingcol;";
-		$result=$tmpdb->convertSQLFromMysql($sql);
+		$sql = "ALTER TABLE llx_table ADD COLUMN newcol varchar(60) NOT NULL DEFAULT '0' AFTER existingcol;";
+		$result = $tmpdb->convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, "ALTER TABLE llx_table ADD COLUMN newcol varchar(60) NOT NULL DEFAULT '0';");
 
-		$sql="ALTER TABLE llx_table CHANGE COLUMN oldname newname varchar(60);";
-		$result=$tmpdb->convertSQLFromMysql($sql);
+		$sql = "ALTER TABLE llx_table CHANGE COLUMN oldname newname varchar(60);";
+		$result = $tmpdb->convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, "-- ALTER TABLE llx_table CHANGE COLUMN oldname newname varchar(60); replaced by --\nALTER TABLE llx_table RENAME COLUMN oldname TO newname");
 
-		$sql="ALTER TABLE llx_table DROP COLUMN oldname;";
-		$result=$tmpdb->convertSQLFromMysql($sql);
+		$sql = "ALTER TABLE llx_table DROP COLUMN oldname;";
+		$result = $tmpdb->convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, $sql);
 
-		$sql="ALTER TABLE llx_table MODIFY name varchar(60);";
-		$result=$tmpdb->convertSQLFromMysql($sql);
+		$sql = "ALTER TABLE llx_table MODIFY name varchar(60);";
+		$result = $tmpdb->convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, "-- ALTER TABLE llx_table MODIFY name varchar(60); replaced by --\nALTER TABLE llx_table ALTER COLUMN name TYPE varchar(60);");
 
 		// Create a constraint
-		$sql='ALTER TABLE llx_tablechild ADD CONSTRAINT fk_tablechild_fk_fieldparent FOREIGN KEY (fk_fieldparent) REFERENCES llx_tableparent (rowid)';
-		$result=$tmpdb->convertSQLFromMysql($sql);
+		$sql = 'ALTER TABLE llx_tablechild ADD CONSTRAINT fk_tablechild_fk_fieldparent FOREIGN KEY (fk_fieldparent) REFERENCES llx_tableparent (rowid)';
+		$result = $tmpdb->convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, $sql.' DEFERRABLE INITIALLY IMMEDIATE;');
 
 		// Test GROUP_CONCAT (without SEPARATOR)
-		$sql="SELECT a.b, GROUP_CONCAT(a.c) FROM table GROUP BY a.b";
-		$result=$tmpdb->convertSQLFromMysql($sql);
+		$sql = "SELECT a.b, GROUP_CONCAT(a.c) FROM table GROUP BY a.b";
+		$result = $tmpdb->convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, "SELECT a.b, STRING_AGG(a.c, ',') FROM table GROUP BY a.b", 'Test GROUP_CONCAT (without SEPARATOR)');
 
 		// Test GROUP_CONCAT (with SEPARATOR)
-		$sql="SELECT a.b, GROUP_CONCAT(a.c SEPARATOR ',') FROM table GROUP BY a.b";
-		$result=$tmpdb->convertSQLFromMysql($sql);
+		$sql = "SELECT a.b, GROUP_CONCAT(a.c SEPARATOR ',') FROM table GROUP BY a.b";
+		$result = $tmpdb->convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, "SELECT a.b, STRING_AGG(a.c, ',') FROM table GROUP BY a.b", 'Test GROUP_CONCAT (with SEPARATOR)');
 

--- a/test/phpunit/PricesTest.php
+++ b/test/phpunit/PricesTest.php
@@ -38,7 +38,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 if (getDolGlobalString('MAIN_ROUNDING_RULE_TOT')) {
 	print "Parameter MAIN_ROUNDING_RULE_TOT must be set to 0 or not set.\n";
@@ -63,38 +63,38 @@ class PricesTest extends CommonClassTest
 	public function testCalculPriceTotal()
 	{
 		global $conf,$user,$langs,$db;
-		$this->savconf=$conf;
-		$this->savuser=$user;
-		$this->savlangs=$langs;
-		$this->savdb=$db;
+		$this->savconf = $conf;
+		$this->savuser = $user;
+		$this->savlangs = $langs;
+		$this->savdb = $db;
 
 		global $mysoc;
-		$mysoc=new Societe($db);
+		$mysoc = new Societe($db);
 
 		/*
 		 *  Country France
 		 */
 
 		// qty=1, unit_price=1.24, discount_line=0, vat_rate=10, price_base_type='HT' (method we provide value)
-		$mysoc->country_code='FR';
-		$mysoc->country_id=1;
-		$result1=calcul_price_total(1, 1.24, 0, 10, 0, 0, 0, 'HT', 0, 0);
+		$mysoc->country_code = 'FR';
+		$mysoc->country_id = 1;
+		$result1 = calcul_price_total(1, 1.24, 0, 10, 0, 0, 0, 'HT', 0, 0);
 		print __METHOD__." result1=".join(', ', $result1)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(1.24, 0.12, 1.36, 1.24, 0.124, 1.364, 1.24, 0.12, 1.36, 0, 0, 0, 0, 0, 0, 0, 1.24, 0.12, 1.36, 1.24, 0.124, 1.364, 1.24, 0.12, 1.36, 0, 0), $result1, 'Test1 FR');
 
 		// qty=1, unit_price=1.24, discount_line=0, vat_rate=10, price_base_type='HT', multicurrency_tx=1.09205 (method we provide value)
-		$mysoc->country_code='FR';
-		$mysoc->country_id=1;
-		$result1=calcul_price_total(2, 8.56, 0, 10, 0, 0, 0, 'HT', 0, 0, '', '', 100, 1.09205);
+		$mysoc->country_code = 'FR';
+		$mysoc->country_id = 1;
+		$result1 = calcul_price_total(2, 8.56, 0, 10, 0, 0, 0, 'HT', 0, 0, '', '', 100, 1.09205);
 		print __METHOD__." result1=".join(', ', $result1)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(17.12, 1.71, 18.83, 8.56, 0.856, 9.416, 17.12, 1.71, 18.83, 0, 0, 0, 0, 0, 0, 0, 18.7, 1.87, 20.57, 9.34795, 0.93479, 10.28274, 18.7, 1.87, 20.57, 0, 0), $result1, 'Test1b FR');
 
 		// qty=2, unit_price=0, discount_line=0, vat_rate=10, price_base_type='HT', multicurrency_tx=1.09205 (method we provide value), pu_ht_devise=100
-		$mysoc->country_code='FR';
-		$mysoc->country_id=1;
-		$result1=calcul_price_total(2, 0, 0, 10, 0, 0, 0, 'HT', 0, 0, '', '', 100, 1.09205, 20);
+		$mysoc->country_code = 'FR';
+		$mysoc->country_id = 1;
+		$result1 = calcul_price_total(2, 0, 0, 10, 0, 0, 0, 'HT', 0, 0, '', '', 100, 1.09205, 20);
 		print __METHOD__." result1=".join(', ', $result1)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(36.63, 3.66, 40.29, 18.31418, 1.83142, 20.1456, 36.63, 3.66, 40.29, 0, 0, 0, 0, 0, 0, 0, 40, 4, 44, 20, 2, 22, 40, 4, 44, 0, 0), $result1, 'Test1c FR');
@@ -104,21 +104,21 @@ class PricesTest extends CommonClassTest
 		 */
 
 		// 10 * 10 HT - 0% discount with 10% vat, seller not using localtax1, not localtax2 (method we provide value)
-		$mysoc->country_code='ES';
-		$mysoc->country_id=4;
-		$mysoc->localtax1_assuj=0;
-		$mysoc->localtax2_assuj=0;
-		$result2=calcul_price_total(10, 10, 0, 10, 0, 0, 0, 'HT', 0, 0);	// 10 * 10 HT - 0% discount with 10% vat and 1.4% localtax1, 0% localtax2
+		$mysoc->country_code = 'ES';
+		$mysoc->country_id = 4;
+		$mysoc->localtax1_assuj = 0;
+		$mysoc->localtax2_assuj = 0;
+		$result2 = calcul_price_total(10, 10, 0, 10, 0, 0, 0, 'HT', 0, 0);	// 10 * 10 HT - 0% discount with 10% vat and 1.4% localtax1, 0% localtax2
 		print __METHOD__." result2=".join(', ', $result2)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(100, 10, 110, 10, 1, 11, 100, 10, 110, 0, 0, 0, 0, 0, 0, 0, 100, 10, 110, 10, 1, 11, 100, 10, 110, 0, 0), $result2, 'Test1 ES');
 
 		// 10 * 10 HT - 0% discount with 10% vat, seller not using localtax1, not localtax2 (other method autodetect)
-		$mysoc->country_code='ES';
-		$mysoc->country_id=4;
-		$mysoc->localtax1_assuj=0;
-		$mysoc->localtax2_assuj=0;
-		$result2=calcul_price_total(10, 10, 0, 10, -1, -1, 0, 'HT', 0, 0);	// 10 * 10 HT - 0% discount with 10% vat and 1.4% localtax1, 0% localtax2
+		$mysoc->country_code = 'ES';
+		$mysoc->country_id = 4;
+		$mysoc->localtax1_assuj = 0;
+		$mysoc->localtax2_assuj = 0;
+		$result2 = calcul_price_total(10, 10, 0, 10, -1, -1, 0, 'HT', 0, 0);	// 10 * 10 HT - 0% discount with 10% vat and 1.4% localtax1, 0% localtax2
 		print __METHOD__." result2=".join(', ', $result2)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(100, 10, 110, 10, 1, 11, 100, 10, 110, 0, 0, 0, 0, 0, 0, 0, 100, 10, 110, 10, 1, 11, 100, 10, 110, 0, 0), $result2, 'Test2 ES');
@@ -126,21 +126,21 @@ class PricesTest extends CommonClassTest
 		// --------------------------------------------------------
 
 		// 10 * 10 HT - 0% discount with 10% vat and 1.4% localtax1 type 3, 0% localtax2 type 5 (method we provide value)
-		$mysoc->country_code='ES';
-		$mysoc->country_id=4;
-		$mysoc->localtax1_assuj=1;
-		$mysoc->localtax2_assuj=0;
-		$result2=calcul_price_total(10, 10, 0, 10, 1.4, 0, 0, 'HT', 0, 0);
+		$mysoc->country_code = 'ES';
+		$mysoc->country_id = 4;
+		$mysoc->localtax1_assuj = 1;
+		$mysoc->localtax2_assuj = 0;
+		$result2 = calcul_price_total(10, 10, 0, 10, 1.4, 0, 0, 'HT', 0, 0);
 		print __METHOD__." result2=".join(', ', $result2)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(100, 10, 111.4, 10, 1, 11.14, 100, 10, 111.4, 1.4, 0, 0.14, 0, 0, 1.4, 0, 100, 10, 111.4, 10, 1, 11.14, 100, 10, 111.4, 1.4, 0), $result2, 'Test3 ES');
 
 		// 10 * 10 HT - 0% discount with 10% vat and 1.4% localtax1 type 3, 0% localtax2 type 5 (other method autodetect)
-		$mysoc->country_code='ES';
-		$mysoc->country_id=4;
-		$mysoc->localtax1_assuj=1;
-		$mysoc->localtax2_assuj=0;
-		$result2=calcul_price_total(10, 10, 0, 10, -1, -1, 0, 'HT', 0, 0);
+		$mysoc->country_code = 'ES';
+		$mysoc->country_id = 4;
+		$mysoc->localtax1_assuj = 1;
+		$mysoc->localtax2_assuj = 0;
+		$result2 = calcul_price_total(10, 10, 0, 10, -1, -1, 0, 'HT', 0, 0);
 		print __METHOD__." result2=".join(', ', $result2)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(100, 10, 111.4, 10, 1, 11.14, 100, 10, 111.4, 1.4, 0, 0.14, 0, 0, 1.4, 0, 100, 10, 111.4, 10, 1, 11.14, 100, 10, 111.4, 1.4, 0), $result2, 'Test4 ES');
@@ -148,30 +148,30 @@ class PricesTest extends CommonClassTest
 		// --------------------------------------------------------
 
 		// 10 * 10 HT - 0% discount with 10% vat and 0% localtax1 type 3, 19% localtax2 type 5 (method we provide value), we provide a service and not a product
-		$mysoc->country_code='ES';
-		$mysoc->country_id=4;
-		$mysoc->localtax1_assuj=0;
-		$mysoc->localtax2_assuj=1;
-		$result2=calcul_price_total(10, 10, 0, 10, 0, -19, 0, 'HT', 0, 1);
+		$mysoc->country_code = 'ES';
+		$mysoc->country_id = 4;
+		$mysoc->localtax1_assuj = 0;
+		$mysoc->localtax2_assuj = 1;
+		$result2 = calcul_price_total(10, 10, 0, 10, 0, -19, 0, 'HT', 0, 1);
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(100, 10, 91, 10, 1, 9.1, 100, 10, 91, 0, -19, 0, -1.90, 0, 0, -19, 100, 10, 91, 10, 1, 9.1, 100, 10, 91, 0, -19), $result2, 'Test5 ES for service');
 
 		// 10 * 10 HT - 0% discount with 10% vat and 0% localtax1 type 3, 21% localtax2 type 5 (other method autodetect), we provide a service and not a product
-		$mysoc->country_code='ES';
-		$mysoc->country_id=4;
-		$mysoc->localtax1_assuj=0;
-		$mysoc->localtax2_assuj=1;
-		$result2=calcul_price_total(10, 10, 0, 10, -1, -1, 0, 'HT', 0, 0);
+		$mysoc->country_code = 'ES';
+		$mysoc->country_id = 4;
+		$mysoc->localtax1_assuj = 0;
+		$mysoc->localtax2_assuj = 1;
+		$result2 = calcul_price_total(10, 10, 0, 10, -1, -1, 0, 'HT', 0, 0);
 		print __METHOD__." result2=".join(', ', $result2)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(100, 10, 110, 10, 1, 11, 100, 10, 110, 0, 0, 0, 0, 0, 0, 0, 100, 10, 110, 10, 1, 11, 100, 10, 110, 0, 0), $result2, 'Test6 ES for product');
 
 		// 10 * 10 HT - 0% discount with 10% vat and 0% localtax1 type 3, 21% localtax2 type 5 (other method autodetect), we provide a product and not a service
-		$mysoc->country_code='ES';
-		$mysoc->country_id=4;
-		$mysoc->localtax1_assuj=0;
-		$mysoc->localtax2_assuj=1;
-		$result2=calcul_price_total(10, 10, 0, 10, -1, -1, 0, 'HT', 0, 1);
+		$mysoc->country_code = 'ES';
+		$mysoc->country_id = 4;
+		$mysoc->localtax1_assuj = 0;
+		$mysoc->localtax2_assuj = 1;
+		$result2 = calcul_price_total(10, 10, 0, 10, -1, -1, 0, 'HT', 0, 1);
 		print __METHOD__." result2=".join(', ', $result2)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(100, 10, 91, 10, 1, 9.1, 100, 10, 91, 0, -19, 0, -1.90, 0, 0, -19, 100, 10, 91, 10, 1, 9.1, 100, 10, 91, 0, -19), $result2, 'Test6 ES for service');
@@ -179,21 +179,21 @@ class PricesTest extends CommonClassTest
 		// --------------------------------------------------------
 
 		// Credit Note: 10 * -10 HT - 0% discount with 10% vat and 0% localtax1 type 3, 19% localtax2 type 5 (method we provide value), we provide a product and not a service
-		$mysoc->country_code='ES';
-		$mysoc->country_id=4;
-		$mysoc->localtax1_assuj=0;
-		$mysoc->localtax2_assuj=1;
-		$result2=calcul_price_total(10, -10, 0, 10, 0, 19, 0, 'HT', 0, 0);
+		$mysoc->country_code = 'ES';
+		$mysoc->country_id = 4;
+		$mysoc->localtax1_assuj = 0;
+		$mysoc->localtax2_assuj = 1;
+		$result2 = calcul_price_total(10, -10, 0, 10, 0, 19, 0, 'HT', 0, 0);
 		print __METHOD__." result2=".join(', ', $result2)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(-100, -10, -110, -10, -1, -11, -100, -10, -110, 0, 0, 0, 0, 0, 0, 0, -100, -10, -110, -10, -1, -11, -100, -10, -110, 0, 0), $result2, 'Test7 ES for product');
 
 		// Credit Note: 10 * -10 HT - 0% discount with 10% vat and 1.4% localtax1 type 3, 0% localtax2 type 5 (other method autodetect), we provide a service and not a product
-		$mysoc->country_code='ES';
-		$mysoc->country_id=4;
-		$mysoc->localtax1_assuj=0;
-		$mysoc->localtax2_assuj=1;
-		$result2=calcul_price_total(10, -10, 0, 10, -1, -1, 0, 'HT', 0, 1);
+		$mysoc->country_code = 'ES';
+		$mysoc->country_id = 4;
+		$mysoc->localtax1_assuj = 0;
+		$mysoc->localtax2_assuj = 1;
+		$result2 = calcul_price_total(10, -10, 0, 10, -1, -1, 0, 'HT', 0, 1);
 		print __METHOD__." result2=".join(', ', $result2)."\n";
 		$this->assertEquals(array(-100, -10, -91, -10, -1, -9.1, -100, -10, -91, 0, 19, 0, 1.90, 0, 0, 19, -100, -10, -91, -10, -1, -9.1, -100, -10, -91, 0, 19), $result2, 'Test8 ES for service');
 
@@ -203,23 +203,23 @@ class PricesTest extends CommonClassTest
 		 */
 
 		// 10 * 10 HT - 0% discount with 18% vat, seller using localtax1 type 2, not localtax2 (method we provide value)
-		$mysoc->country_code='CI';
-		$mysoc->country_id=21;
-		$mysoc->localtax1_assuj=1;
-		$mysoc->localtax2_assuj=0;
+		$mysoc->country_code = 'CI';
+		$mysoc->country_id = 21;
+		$mysoc->localtax1_assuj = 1;
+		$mysoc->localtax2_assuj = 0;
 		//$localtaxes=getLocalTaxesFromRate(18, 0, null, $mysoc);
 		//var_dump($locataxes);
-		$result3=calcul_price_total(10, 10, 0, 18, 7.5, 0, 0, 'HT', 0, 0);	// 10 * 10 HT - 0% discount with 18% vat and 7.5% localtax1, 0% localtax2
+		$result3 = calcul_price_total(10, 10, 0, 18, 7.5, 0, 0, 'HT', 0, 0);	// 10 * 10 HT - 0% discount with 18% vat and 7.5% localtax1, 0% localtax2
 		print __METHOD__." result3=".join(', ', $result3)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(100, 18, 126.85, 10, 1.8, 12.685, 100, 18, 126.85, 8.85, 0, 0.885, 0, 0, 8.85, 0, 100, 18, 126.85, 10, 1.8, 12.685, 100, 18, 126.85, 8.85, 0), $result3, 'Test9 CI');
 
 		// 10 * 10 HT - 0% discount with 18% vat, seller using localtax1 type 2, not localtax2 (other method autodetect)
-		$mysoc->country_code='CI';
-		$mysoc->country_id=21;
-		$mysoc->localtax1_assuj=1;
-		$mysoc->localtax2_assuj=0;
-		$result3=calcul_price_total(10, 10, 0, 18, -1, -1, 0, 'HT', 0, 0);	// 10 * 10 HT - 0% discount with 18% vat and 7.5% localtax1, 0% localtax2
+		$mysoc->country_code = 'CI';
+		$mysoc->country_id = 21;
+		$mysoc->localtax1_assuj = 1;
+		$mysoc->localtax2_assuj = 0;
+		$result3 = calcul_price_total(10, 10, 0, 18, -1, -1, 0, 'HT', 0, 0);	// 10 * 10 HT - 0% discount with 18% vat and 7.5% localtax1, 0% localtax2
 		print __METHOD__." result3=".join(', ', $result3)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
 		$this->assertEquals(array(100, 18, 126.85, 10, 1.8, 12.685, 100, 18, 126.85, 8.85, 0, 0.885, 0, 0, 8.85, 0, 100, 18, 126.85, 10, 1.8, 12.685, 100, 18, 126.85, 8.85, 0), $result3, 'Test10 CI');
@@ -238,22 +238,22 @@ class PricesTest extends CommonClassTest
 	{
 		//$this->sharedFixture
 		global $conf,$user,$langs,$db;
-		$this->savconf=$conf;
-		$this->savuser=$user;
-		$this->savlangs=$langs;
-		$this->savdb=$db;
+		$this->savconf = $conf;
+		$this->savuser = $user;
+		$this->savlangs = $langs;
+		$this->savdb = $db;
 
-		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND=0;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = 0;
 
 		// Two lines of 1.24 give 2.48 HT and 2.72 TTC with standard vat rounding mode
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen('nolines');
-		$invoiceid=$localobject->create($user);
+		$invoiceid = $localobject->create($user);
 
 		$localobject->addline('Desc', 1.24, 1, 10, 0, 0, 0, 0, '', '', 0, 0, 0, 'HT');
 		$localobject->addline('Desc', 1.24, 1, 10, 0, 0, 0, 0, '', '', 0, 0, 0, 'HT');
 
-		$newlocalobject=new Facture($db);
+		$newlocalobject = new Facture($db);
 		$newlocalobject->fetch($invoiceid);
 
 		$this->assertEquals(2.48, $newlocalobject->total_ht, "testUpdatePrice test1");
@@ -262,14 +262,14 @@ class PricesTest extends CommonClassTest
 
 
 		// Two lines of 1.24 give 2.48 HT and 2.73 TTC with global vat rounding mode
-		$localobject=new Facture($db);
+		$localobject = new Facture($db);
 		$localobject->initAsSpecimen('nolines');
-		$invoiceid=$localobject->create($user);
+		$invoiceid = $localobject->create($user);
 
 		$localobject->addline('Desc', 1.24, 1, 10, 0, 0, 0, 0, '', '', 0, 0, 0, 'HT');
 		$localobject->addline('Desc', 1.24, 1, 10, 0, 0, 0, 0, '', '', 0, 0, 0, 'HT');
 
-		$newlocalobject=new Facture($db);
+		$newlocalobject = new Facture($db);
 		$newlocalobject->fetch($invoiceid);
 
 		$this->assertEquals(2.48, $newlocalobject->total_ht, "testUpdatePrice test4");

--- a/test/phpunit/ProductTest.php
+++ b/test/phpunit/ProductTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -76,14 +76,14 @@ class ProductTest extends CommonClassTest
 	public function testProductCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Product($db);
+		$localobject = new Product($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThanOrEqual($result, 0, "Creation of product");
@@ -103,13 +103,13 @@ class ProductTest extends CommonClassTest
 	public function testProductFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Product($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Product($db);
+		$result = $localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -128,14 +128,14 @@ class ProductTest extends CommonClassTest
 	public function testProductUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$localobject->note_public = 'New public note after update';
 		$localobject->note_private = 'New private note after update';
-		$result=$localobject->update($localobject->id, $user);
+		$result = $localobject->update($localobject->id, $user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Error '.$localobject->error);
 
@@ -154,10 +154,10 @@ class ProductTest extends CommonClassTest
 	public function testProductOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$this->assertEquals(0, 0);
 
@@ -176,15 +176,15 @@ class ProductTest extends CommonClassTest
 	public function testProductDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Product($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Product($db);
+		$result = $localobject->fetch($id);
 
-		$result=$localobject->delete($user);
+		$result = $localobject->delete($user);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 

--- a/test/phpunit/ProjectTest.php
+++ b/test/phpunit/ProjectTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -57,14 +57,14 @@ class ProjectTest extends CommonClassTest
 	public function testProjectCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Project($db);
+		$localobject = new Project($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
@@ -83,13 +83,13 @@ class ProjectTest extends CommonClassTest
 	public function testProjectFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Project($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Project($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -108,12 +108,12 @@ class ProjectTest extends CommonClassTest
 	public function testProjectValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setValid($user);
+		$result = $localobject->setValid($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -132,12 +132,12 @@ class ProjectTest extends CommonClassTest
 	public function testProjectOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setClose($user);
+		$result = $localobject->setClose($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -156,14 +156,14 @@ class ProjectTest extends CommonClassTest
 	public function testProjectDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Project($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Project($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/PropalTest.php
+++ b/test/phpunit/PropalTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,14 +56,14 @@ class PropalTest extends CommonClassTest
 	public function testPropalCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Propal($db);
+		$localobject = new Propal($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
@@ -82,13 +82,13 @@ class PropalTest extends CommonClassTest
 	public function testPropalFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Propal($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Propal($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -107,10 +107,10 @@ class PropalTest extends CommonClassTest
 	public function testPropalUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$localobject->note_private = 'New note private after update';
 		$result = $localobject->update($user);
@@ -132,13 +132,13 @@ class PropalTest extends CommonClassTest
 	public function testPropalAddLine($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$localobject->fetch_thirdparty();
-		$result=$localobject->addline('Added line', 10, 2, 19.6);
+		$result = $localobject->addline('Added line', 10, 2, 19.6);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -157,12 +157,12 @@ class PropalTest extends CommonClassTest
 	public function testPropalValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->valid($user);
+		$result = $localobject->valid($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -181,10 +181,10 @@ class PropalTest extends CommonClassTest
 	public function testPropalOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -210,14 +210,14 @@ class PropalTest extends CommonClassTest
 	public function testPropalDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Propal($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Propal($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/ReceptionTest.php
+++ b/test/phpunit/ReceptionTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 /**
  * Class for PHPUnit tests
@@ -56,10 +56,10 @@ class ReceptionTest extends CommonClassTest
 	public function testReceptionCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$soc = new Societe($db);
 		$soc->name = "ReceptionTest Unittest";

--- a/test/phpunit/RepositoryTest.php
+++ b/test/phpunit/RepositoryTest.php
@@ -67,7 +67,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -91,12 +91,12 @@ class RepositoryTest extends CommonClassTest
 		global $conf,$user,$langs,$db;
 
 		// Scan dir to guarantee we don't have library jquery twice
-		$foundfiles=dol_dir_list(DOL_DOCUMENT_ROOT.'/includes/', 'files', 1, '^jquery\.js', array('ckeditor'));
+		$foundfiles = dol_dir_list(DOL_DOCUMENT_ROOT.'/includes/', 'files', 1, '^jquery\.js', array('ckeditor'));
 		print __METHOD__." count(founddirs)=".count($foundfiles)."\n";
 		$this->assertEquals(1, count($foundfiles), 'We found jquery lib (jquery.js) twice');
 
 		// Scan dir to guarantee we don't have library jquery twice
-		$foundfiles=dol_dir_list(DOL_DOCUMENT_ROOT.'/includes/', 'files', 1, '^jquery\.min\.js', array('ckeditor'));
+		$foundfiles = dol_dir_list(DOL_DOCUMENT_ROOT.'/includes/', 'files', 1, '^jquery\.min\.js', array('ckeditor'));
 		print __METHOD__." count(founddirs)=".count($foundfiles)."\n";
 		$this->assertEquals(1, count($foundfiles), 'We found jquery lib (jquery.min.js) twice '.(empty($foundfiles[0]) ? '' : $foundfiles[0]['fullname']).' '.(empty($foundfiles[1]) ? '' : $foundfiles[1]['fullname']));
 	}
@@ -110,10 +110,10 @@ class RepositoryTest extends CommonClassTest
 	public function testRepository()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 		$filesarray = dol_dir_list(DOL_DOCUMENT_ROOT, 'directories', 1, '', array('\/custom\/'), 'fullname', SORT_ASC, 0, 1, '', 1);

--- a/test/phpunit/RestAPIContactTest.php
+++ b/test/phpunit/RestAPIContactTest.php
@@ -37,8 +37,8 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
-$conf->global->MAIN_UMASK='0666';
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+$conf->global->MAIN_UMASK = '0666';
 
 
 /**
@@ -79,19 +79,19 @@ class RestAPIContactTest extends CommonClassTest
 	protected function setUp(): void
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$this->api_url = DOL_MAIN_URL_ROOT.'/api/index.php';
 
-		$login='admin';
-		$password='admin';
-		$url=$this->api_url.'/login?login='.$login.'&password='.$password;
+		$login = 'admin';
+		$password = 'admin';
+		$url = $this->api_url.'/login?login='.$login.'&password='.$password;
 		// Call the API login method to save api_key for this test class.
 		// At first call, if token is not defined a random value is generated and returned.
-		$result=getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
+		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
 		print __METHOD__." result = ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
@@ -124,7 +124,7 @@ class RestAPIContactTest extends CommonClassTest
 		print __METHOD__." result for get on unexisting contact: ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
-		$object=json_decode($result['content'], true);
+		$object = json_decode($result['content'], true);
 		$this->assertNotNull($object, "Parsing of json result must not be null");
 		$this->assertEquals(404, $object['error']['code'], 'Error code is not 404');
 
@@ -132,11 +132,11 @@ class RestAPIContactTest extends CommonClassTest
 		$url = $this->api_url.'/contacts/1?api_key='.$this->api_key;
 
 		print __METHOD__." Request GET url=".$url."\n";
-		$result=getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
+		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
 		print __METHOD__." result for get on an existing contact: ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
-		$object=json_decode($result['content'], true);
+		$object = json_decode($result['content'], true);
 		$this->assertNotNull($object, "Parsing of json result must not be null");
 		$this->assertEquals(1, $object['statut']);
 	}
@@ -154,16 +154,16 @@ class RestAPIContactTest extends CommonClassTest
 		global $conf,$user,$langs,$db;
 		// attempt to create without mandatory fields
 		$url = $this->api_url.'/contacts?api_key='.$this->api_key;
-		$addheaders=array('Content-Type: application/json');
+		$addheaders = array('Content-Type: application/json');
 
-		$bodyobj= array(
+		$bodyobj = array(
 			"firstname" => "firstname"
 		);
 
 		$body = json_encode($bodyobj);
 
 		//print __METHOD__." Request POST url=".$url."\n";
-		$result=getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
+		$result = getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
 		//print __METHOD__." Result for creating incomplete contact".var_export($result, true)."\n";
 		//print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
@@ -209,7 +209,7 @@ class RestAPIContactTest extends CommonClassTest
 		global $conf,$user,$langs,$db;
 		// attempt to create without mandatory fields
 		$url = $this->api_url.'/contacts?api_key='.$this->api_key;
-		$addheaders=array('Content-Type: application/json');
+		$addheaders = array('Content-Type: application/json');
 
 		//update the contact
 

--- a/test/phpunit/RestAPIDocumentTest.php
+++ b/test/phpunit/RestAPIDocumentTest.php
@@ -85,12 +85,12 @@ class RestAPIDocumentTest extends CommonClassTest
 
 		$this->api_url = DOL_MAIN_URL_ROOT.'/api/index.php';
 
-		$login='admin';
-		$password='admin';
-		$url=$this->api_url.'/login?login='.$login.'&password='.$password;
+		$login = 'admin';
+		$password = 'admin';
+		$url = $this->api_url.'/login?login='.$login.'&password='.$password;
 		// Call the API login method to save api_key for this test class.
 		// At first call, if token is not defined a random value is generated and returned.
-		$result=getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
+		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
 		print __METHOD__." result = ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
@@ -125,13 +125,13 @@ class RestAPIDocumentTest extends CommonClassTest
 
 		//$data = '{ "filename": "mynewfile.txt", "modulepart": "medias", "ref": "", "subdir": "mysubdir1/mysubdir2", "filecontent": "content text", "fileencoding": "" }';
 		$data = array(
-			'filename'=>"mynewfile.txt",
-			'modulepart'=>"medias",
-			'subdir'=>"tmpphpunit/tmpphpunit1",
-			'filecontent'=>"content text",
-			'fileencoding'=>"",
-			'overwriteifexists'=>0,
-			'createdirifnotexists'=>0
+			'filename' => "mynewfile.txt",
+			'modulepart' => "medias",
+			'subdir' => "tmpphpunit/tmpphpunit1",
+			'filecontent' => "content text",
+			'fileencoding' => "",
+			'overwriteifexists' => 0,
+			'createdirifnotexists' => 0
 		);
 
 		$param = '';
@@ -154,14 +154,14 @@ class RestAPIDocumentTest extends CommonClassTest
 		dol_mkdir(DOL_DATA_ROOT.'/medias/tmpphpunit/tmpphpunit2');
 
 		$data = array(
-			'filename'=>"mynewfile.txt",
-			'modulepart'=>"medias",
-			'ref'=>"",
-			'subdir'=>"tmpphpunit/tmpphpunit2",
-			'filecontent'=>"content text",
-			'fileencoding'=>"",
-			'overwriteifexists'=>0,
-			'createdirifnotexists'=>0
+			'filename' => "mynewfile.txt",
+			'modulepart' => "medias",
+			'ref' => "",
+			'subdir' => "tmpphpunit/tmpphpunit2",
+			'filecontent' => "content text",
+			'fileencoding' => "",
+			'overwriteifexists' => 0,
+			'createdirifnotexists' => 0
 		);
 
 		$param = '';
@@ -182,14 +182,14 @@ class RestAPIDocumentTest extends CommonClassTest
 		dol_delete_dir_recursive(DOL_DATA_ROOT.'/medias/tmpphpunit/tmpphpunit3');
 
 		$data = array(
-			'filename'=>"mynewfile.txt",
-			'modulepart'=>"medias",
-			'ref'=>"",
-			'subdir'=>"tmpphpunit/tmpphpunit3",
-			'filecontent'=>"content text",
-			'fileencoding'=>"",
-			'overwriteifexists'=>0,
-			'createdirifnotexists'=>1
+			'filename' => "mynewfile.txt",
+			'modulepart' => "medias",
+			'ref' => "",
+			'subdir' => "tmpphpunit/tmpphpunit3",
+			'filecontent' => "content text",
+			'fileencoding' => "",
+			'overwriteifexists' => 0,
+			'createdirifnotexists' => 1
 		);
 
 		$param = '';

--- a/test/phpunit/RestAPIUserTest.php
+++ b/test/phpunit/RestAPIUserTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,8 +38,8 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
-$conf->global->MAIN_UMASK='0666';
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+$conf->global->MAIN_UMASK = '0666';
 
 
 /**
@@ -79,19 +80,19 @@ class RestAPIUserTest extends CommonClassTest
 	protected function setUp(): void
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$this->api_url = DOL_MAIN_URL_ROOT.'/api/index.php';
 
-		$login='admin';
-		$password='admin';
-		$url=$this->api_url.'/login?login='.$login.'&password='.$password;
+		$login = 'admin';
+		$password = 'admin';
+		$url = $this->api_url.'/login?login='.$login.'&password='.$password;
 		// Call the API login method to save api_key for this test class.
 		// At first call, if token is not defined a random value is generated and returned.
-		$result=getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
+		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
 		print __METHOD__." result = ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
@@ -120,22 +121,22 @@ class RestAPIUserTest extends CommonClassTest
 		//$addheaders=array('Content-Type: application/json');
 
 		print __METHOD__." Request GET url=".$url."\n";
-		$result=getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
+		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
 		//print __METHOD__." result for get on unexisting user: ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
-		$object=json_decode($result['content'], true);
+		$object = json_decode($result['content'], true);
 		$this->assertNotNull($object, "Parsing of json result must not be null");
 		$this->assertEquals(404, (empty($object['error']['code']) ? 0 : $object['error']['code']), 'Error code is not 404');
 
 		$url = $this->api_url.'/users/1?api_key='.$this->api_key;
 
 		print __METHOD__." Request GET url=".$url."\n";
-		$result=getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
+		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
 		print __METHOD__." result for get on an existing user: ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
-		$object=json_decode($result['content'], true);
+		$object = json_decode($result['content'], true);
 		$this->assertNotNull($object, "Parsing of json result must not be null");
 		$this->assertEquals(1, $object['statut']);
 
@@ -154,35 +155,35 @@ class RestAPIUserTest extends CommonClassTest
 	{
 		// attempt to create without mandatory fields :
 		$url = $this->api_url.'/users?api_key='.$this->api_key;
-		$addheaders=array('Content-Type: application/json');
+		$addheaders = array('Content-Type: application/json');
 
 		$bodyobj = array(
-			"lastname"=>"testRestUser",
-			"password"=>"testRestPassword",
-			"email"=>"test@restuser.com"
+			"lastname" => "testRestUser",
+			"password" => "testRestPassword",
+			"email" => "test@restuser.com"
 		);
 		$body = json_encode($bodyobj);
 
 		print __METHOD__." Request POST url=".$url."\n";
-		$result=getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
+		$result = getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
 		//print __METHOD__." Result for creating incomplete user".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
-		$object=json_decode($result['content'], true);
+		$object = json_decode($result['content'], true);
 		$this->assertNotNull($object, "Parsing of json result must no be null");
 		$this->assertEquals(500, (empty($object['error']['code']) ? 0 : $object['error']['code']), 'Error'.(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
 
 		// create regular user
 		unset($result);
 		$bodyobj = array(
-			"login"=>"testRestLogin".mt_rand(),
-			"lastname"=>"testRestUser",
-			"password"=>"testRestPassword",
-			"email"=>"test".mt_rand()."@restuser.com"
+			"login" => "testRestLogin".mt_rand(),
+			"lastname" => "testRestUser",
+			"password" => "testRestPassword",
+			"email" => "test".mt_rand()."@restuser.com"
 		);
 		$body = json_encode($bodyobj);
 		print __METHOD__." Request POST url=".$url."\n";
-		$result=getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
+		$result = getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
 		print __METHOD__." result code for creating non existing user = ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
@@ -194,11 +195,11 @@ class RestAPIUserTest extends CommonClassTest
 
 		// attempt to create duplicated user
 		print __METHOD__." Request POST url=".$url."\n";
-		$result=getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
+		$result = getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
 		//print __METHOD__." Result for creating duplicate user".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
 		$this->assertEquals($result['curl_error_no'], '');
-		$object=json_decode($result['content'], true);
+		$object = json_decode($result['content'], true);
 		$this->assertNotNull($object, "Parsing of json result must no be null");
 		$this->assertEquals(500, (empty($object['error']['code']) ? 0 : $object['error']['code']), 'Error'.(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
 	}

--- a/test/phpunit/RestAPIUserTest.php
+++ b/test/phpunit/RestAPIUserTest.php
@@ -87,6 +87,7 @@ class RestAPIUserTest extends CommonClassTest
 
 		$this->api_url = DOL_MAIN_URL_ROOT.'/api/index.php';
 
+		$test = "API Test Setup - ";
 		$login = 'admin';
 		$password = 'admin';
 		$url = $this->api_url.'/login?login='.$login.'&password='.$password;
@@ -95,11 +96,11 @@ class RestAPIUserTest extends CommonClassTest
 		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
 		print __METHOD__." result = ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
-		$this->assertEquals($result['curl_error_no'], '');
+		$this->assertEquals('', $result['curl_error_no'], "$test Should not have a curl error");
 		$object = json_decode($result['content'], true);	// If success content is just an id, if not an array
 
-		$this->assertNotNull($object, "Parsing of json result must not be null");
-		$this->assertNotEquals(500, (empty($object['error']['code']) ? 0 : $object['error']['code']), 'Error'.(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
+		$this->assertNotNull($object, "$test Parsing of JSON result must not be null");
+		$this->assertNotEquals(500, (empty($object['error']['code']) ? 0 : $object['error']['code']), "$test Error".(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
 		$this->assertEquals('200', $object['success']['code']);
 
 		$this->api_key = $object['success']['token'];
@@ -117,6 +118,7 @@ class RestAPIUserTest extends CommonClassTest
 	{
 		global $conf,$user,$langs,$db;
 
+		$test = "Invalid User -";
 		$url = $this->api_url.'/users/123456789?api_key='.$this->api_key;
 		//$addheaders=array('Content-Type: application/json');
 
@@ -124,20 +126,21 @@ class RestAPIUserTest extends CommonClassTest
 		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
 		//print __METHOD__." result for get on unexisting user: ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
-		$this->assertEquals($result['curl_error_no'], '');
+		$this->assertEquals('', $result['curl_error_no'], "$test Should not have a curl error");
 		$object = json_decode($result['content'], true);
-		$this->assertNotNull($object, "Parsing of json result must not be null");
-		$this->assertEquals(404, (empty($object['error']['code']) ? 0 : $object['error']['code']), 'Error code is not 404');
+		$this->assertNotNull($object, "$test Parsing of JSON result must not be null");
+		$this->assertEquals(404, (empty($object['error']['code']) ? 0 : $object['error']['code']), "$test Error code is not 404");
 
+		$test = "Existing User -";
 		$url = $this->api_url.'/users/1?api_key='.$this->api_key;
 
 		print __METHOD__." Request GET url=".$url."\n";
 		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
-		print __METHOD__." result for get on an existing user: ".var_export($result, true)."\n";
+		print __METHOD__." $test result for get: ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
-		$this->assertEquals($result['curl_error_no'], '');
+		$this->assertEquals('', $result['curl_error_no'], "$test should have no error");
 		$object = json_decode($result['content'], true);
-		$this->assertNotNull($object, "Parsing of json result must not be null");
+		$this->assertNotNull($object, "$test Parsing of JSON result must not be null");
 		$this->assertEquals(1, $object['statut']);
 
 		return $object['id'];
@@ -154,6 +157,7 @@ class RestAPIUserTest extends CommonClassTest
 	public function testRestCreateUser()
 	{
 		// attempt to create without mandatory fields :
+		$test = "Create User Missing Fields -";
 		$url = $this->api_url.'/users?api_key='.$this->api_key;
 		$addheaders = array('Content-Type: application/json');
 
@@ -168,12 +172,13 @@ class RestAPIUserTest extends CommonClassTest
 		$result = getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
 		//print __METHOD__." Result for creating incomplete user".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
-		$this->assertEquals($result['curl_error_no'], '');
+		$this->assertEquals('', $result['curl_error_no'], "$test Should not have a curl error");
 		$object = json_decode($result['content'], true);
-		$this->assertNotNull($object, "Parsing of json result must no be null");
-		$this->assertEquals(500, (empty($object['error']['code']) ? 0 : $object['error']['code']), 'Error'.(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
+		$this->assertNotNull($object, "$test Parsing of JSON result must not be null");
+		$this->assertEquals(500, (empty($object['error']['code']) ? 0 : $object['error']['code']), "$test Error".(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
 
 		// create regular user
+		$test = "Create Regular User -";
 		unset($result);
 		$bodyobj = array(
 			"login" => "testRestLogin".mt_rand(),
@@ -186,21 +191,22 @@ class RestAPIUserTest extends CommonClassTest
 		$result = getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
 		print __METHOD__." result code for creating non existing user = ".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
-		$this->assertEquals($result['curl_error_no'], '');
+		$this->assertEquals('', $result['curl_error_no'], "$test Should not have a curl error");
 		$object = json_decode($result['content'], true);	// If success content is just an id, if not an array
 
-		$this->assertNotNull($object, "Parsing of json result must no be null");
-		$this->assertNotEquals(500, ((is_scalar($object) || empty($object['error']) || empty($object['error']['code'])) ? 0 : $object['error']['code']), 'Error'.(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
+		$this->assertNotNull($object, "$test Parsing of JSON result must not be null");
+		$this->assertNotEquals(500, ((is_scalar($object) || empty($object['error']) || empty($object['error']['code'])) ? 0 : $object['error']['code']), "$test Error".(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
 		$this->assertGreaterThan(0, $object, 'ID returned is no > 0');
 
 		// attempt to create duplicated user
+		$test = "Create Duplicate User -";
 		print __METHOD__." Request POST url=".$url."\n";
 		$result = getURLContent($url, 'POST', $body, 1, $addheaders, array('http', 'https'), 2);
 		//print __METHOD__." Result for creating duplicate user".var_export($result, true)."\n";
 		print __METHOD__." curl_error_no: ".$result['curl_error_no']."\n";
-		$this->assertEquals($result['curl_error_no'], '');
+		$this->assertEquals('', $result['curl_error_no'], "$test Should not have a curl error");
 		$object = json_decode($result['content'], true);
-		$this->assertNotNull($object, "Parsing of json result must no be null");
-		$this->assertEquals(500, (empty($object['error']['code']) ? 0 : $object['error']['code']), 'Error'.(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
+		$this->assertNotNull($object, "$test Parsing of JSON result must not be null");
+		$this->assertEquals(500, (empty($object['error']['code']) ? 0 : $object['error']['code']), "$test Error".(empty($object['error']['message']) ? '' : ' '.$object['error']['message']));
 	}
 }

--- a/test/phpunit/ScriptsTest.php
+++ b/test/phpunit/ScriptsTest.php
@@ -68,7 +68,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -88,17 +88,17 @@ class ScriptsTest extends CommonClassTest
 	public function testBank()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$script=dirname(__FILE__).'/../../scripts/bank/export-bank-receipts.php BANKDUMMY RECEIPTDUMMY excel2007 lang=fr_FR';
+		$script = dirname(__FILE__).'/../../scripts/bank/export-bank-receipts.php BANKDUMMY RECEIPTDUMMY excel2007 lang=fr_FR';
 
 		$returnvar = 0;
 		$output = array();
 
-		$result=exec($script, $output, $returnvar);
+		$result = exec($script, $output, $returnvar);
 
 		print __METHOD__." result=".$result."\n";
 		print __METHOD__." output=".join("\n", $output)."\n";
@@ -118,10 +118,10 @@ class ScriptsTest extends CommonClassTest
 	public function testCompany()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*
 		$script=dirname(__FILE__).'/../../scripts/company/sync_contacts_dolibarr_2ldap now';
@@ -147,30 +147,30 @@ class ScriptsTest extends CommonClassTest
 	public function testContracts()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$returnvar = 0;
 		$output = array();
 
-		$script=dirname(__FILE__).'/../../scripts/contracts/email_expire_services_to_customers.php test thirdparties';
-		$result=exec($script, $output, $returnvar);
+		$script = dirname(__FILE__).'/../../scripts/contracts/email_expire_services_to_customers.php test thirdparties';
+		$result = exec($script, $output, $returnvar);
 		print __METHOD__." result=".$result."\n";
 		print __METHOD__." output=".join("\n", $output)."\n";
 		print __METHOD__." returnvar=".$returnvar."\n";
 		$this->assertEquals($returnvar, 0, 'email_expire_services_to_customers.php thirdparties');
 
-		$script=dirname(__FILE__).'/../../scripts/contracts/email_expire_services_to_customers.php test contacts -30';
-		$result=exec($script, $output, $returnvar);
+		$script = dirname(__FILE__).'/../../scripts/contracts/email_expire_services_to_customers.php test contacts -30';
+		$result = exec($script, $output, $returnvar);
 		print __METHOD__." result=".$result."\n";
 		print __METHOD__." output=".join("\n", $output)."\n";
 		print __METHOD__." returnvar=".$returnvar."\n";
 		$this->assertEquals($returnvar, 0, 'email_expire_services_to_customers.php contacts');
 
-		$script=dirname(__FILE__).'/../../scripts/contracts/email_expire_services_to_representatives.php test -30';
-		$result=exec($script, $output, $returnvar);
+		$script = dirname(__FILE__).'/../../scripts/contracts/email_expire_services_to_representatives.php test -30';
+		$result = exec($script, $output, $returnvar);
 		print __METHOD__." result=".$result."\n";
 		print __METHOD__." output=".join("\n", $output)."\n";
 		print __METHOD__." returnvar=".$returnvar."\n";
@@ -188,30 +188,30 @@ class ScriptsTest extends CommonClassTest
 	public function testInvoices()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$returnvar = 0;
 		$output = array();
 
-		$script=dirname(__FILE__).'/../../scripts/invoices/email_unpaid_invoices_to_customers.php test thirdparties';
-		$result=exec($script, $output, $returnvar);
+		$script = dirname(__FILE__).'/../../scripts/invoices/email_unpaid_invoices_to_customers.php test thirdparties';
+		$result = exec($script, $output, $returnvar);
 		print __METHOD__." result=".$result."\n";
 		print __METHOD__." output=".join("\n", $output)."\n";
 		print __METHOD__." returnvar=".$returnvar."\n";
 		$this->assertEquals($returnvar, 0, 'email_unpaid_invoices_to_customers.php thirdparties');
 
-		$script=dirname(__FILE__).'/../../scripts/invoices/email_unpaid_invoices_to_customers.php test contacts -30';
-		$result=exec($script, $output, $returnvar);
+		$script = dirname(__FILE__).'/../../scripts/invoices/email_unpaid_invoices_to_customers.php test contacts -30';
+		$result = exec($script, $output, $returnvar);
 		print __METHOD__." result=".$result."\n";
 		print __METHOD__." output=".join("\n", $output)."\n";
 		print __METHOD__." returnvar=".$returnvar."\n";
 		$this->assertEquals($returnvar, 0, 'email_unpaid_invoices_to_customers.php contacts');
 
-		$script=dirname(__FILE__).'/../../scripts/invoices/email_unpaid_invoices_to_representatives.php test thirdparties';
-		$result=exec($script, $output, $returnvar);
+		$script = dirname(__FILE__).'/../../scripts/invoices/email_unpaid_invoices_to_representatives.php test thirdparties';
+		$result = exec($script, $output, $returnvar);
 		print __METHOD__." result=".$result."\n";
 		print __METHOD__." output=".join("\n", $output)."\n";
 		print __METHOD__." returnvar=".$returnvar."\n";

--- a/test/phpunit/SecurityTest.php
+++ b/test/phpunit/SecurityTest.php
@@ -63,7 +63,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -83,7 +83,7 @@ class SecurityTest extends CommonClassTest
 	public function testSetLang()
 	{
 		global $conf;
-		$conf=$this->savconf;
+		$conf = $this->savconf;
 
 		$tmplangs = new Translate('', $conf);
 
@@ -105,7 +105,7 @@ class SecurityTest extends CommonClassTest
 		// More on https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
 
 		// Should be OK
-		$expectedresult=0;
+		$expectedresult = 0;
 
 		/*
 		$test = '';
@@ -113,107 +113,107 @@ class SecurityTest extends CommonClassTest
 		$this->assertGreaterThanOrEqual(0, $result, 'Error on testSqlAndScriptInject kkk');
 		*/
 
-		$_SERVER["PHP_SELF"]='/DIR WITH SPACE/htdocs/admin/index.php';
-		$result=testSqlAndScriptInject($_SERVER["PHP_SELF"], 2);
+		$_SERVER["PHP_SELF"] = '/DIR WITH SPACE/htdocs/admin/index.php';
+		$result = testSqlAndScriptInject($_SERVER["PHP_SELF"], 2);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject for PHP_SELF that should be ok');
 
 		$test = 'This is a < inside string with < and > also and tag like <a> before the >';
-		$result=testSqlAndScriptInject($test, 0);
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject expected 0b');
 
 		$test = 'This is the union of all for the selection of the best';
-		$result=testSqlAndScriptInject($test, 0);
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject expected 0c');
 
-		$test='/user/perms.php?id=1&action=addrights&entity=1&rights=123&confirm=yes&token=123456789&updatedmodulename=lmscoursetracking';
-		$result=testSqlAndScriptInject($test, 1);
+		$test = '/user/perms.php?id=1&action=addrights&entity=1&rights=123&confirm=yes&token=123456789&updatedmodulename=lmscoursetracking';
+		$result = testSqlAndScriptInject($test, 1);
 		print "test=".$test." result=".$result."\n";
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject with a valid url');
 
 		// Should detect attack
-		$expectedresult=1;
+		$expectedresult = 1;
 
-		$_SERVER["PHP_SELF"]='/DIR WITH SPACE/htdocs/admin/index.php/<svg>';
-		$result=testSqlAndScriptInject($_SERVER["PHP_SELF"], 2);
+		$_SERVER["PHP_SELF"] = '/DIR WITH SPACE/htdocs/admin/index.php/<svg>';
+		$result = testSqlAndScriptInject($_SERVER["PHP_SELF"], 2);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject for PHP_SELF that should detect XSS');
 
 		$test = 'select @@version';
-		$result=testSqlAndScriptInject($test, 0);
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject for SQL1a. Should find an attack on POST param and did not.');
 
 		$test = 'select @@version';
-		$result=testSqlAndScriptInject($test, 1);
+		$result = testSqlAndScriptInject($test, 1);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject for SQL1b. Should find an attack on GET param and did not.');
 
 		$test = '... update ... set ... =';
-		$result=testSqlAndScriptInject($test, 1);
+		$result = testSqlAndScriptInject($test, 1);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject for SQL2a. Should find an attack on GET param and did not.');
 
 		$test = "delete\nfrom";
-		$result=testSqlAndScriptInject($test, 1);
+		$result = testSqlAndScriptInject($test, 1);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject for SQL2b. Should find an attack on GET param and did not.');
 
 		$test = 'action=update& ... set ... =';
-		$result=testSqlAndScriptInject($test, 1);
+		$result = testSqlAndScriptInject($test, 1);
 		$this->assertEquals(0, $result, 'Error on testSqlAndScriptInject for SQL2b. Should not find an attack on GET param and did.');
 
 		$test = '... union ... selection ';
-		$result=testSqlAndScriptInject($test, 1);
+		$result = testSqlAndScriptInject($test, 1);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject for SQL2c. Should find an attack on GET param and did not.');
 
 		$test = 'j&#x61;vascript:';
-		$result=testSqlAndScriptInject($test, 0);
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject for javascript1. Should find an attack and did not.');
 
 		$test = 'j&#x61vascript:';
-		$result=testSqlAndScriptInject($test, 0);
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject for javascript2. Should find an attack and did not.');
 
 		$test = 'javascript&colon&#x3B;alert(1)';
-		$result=testSqlAndScriptInject($test, 0);
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject for javascript2');
 
-		$test="<img src='1.jpg' onerror =javascript:alert('XSS')>";
-		$result=testSqlAndScriptInject($test, 0);
+		$test = "<img src='1.jpg' onerror =javascript:alert('XSS')>";
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject aaa1');
 
-		$test="<img src='1.jpg' onerror =javascript:alert('XSS')>";
-		$result=testSqlAndScriptInject($test, 2);
+		$test = "<img src='1.jpg' onerror =javascript:alert('XSS')>";
+		$result = testSqlAndScriptInject($test, 2);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject aaa2');
 
-		$test='<IMG SRC=# onmouseover="alert(1)">';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<IMG SRC=# onmouseover="alert(1)">';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject aaa3');
-		$test='<IMG SRC onmouseover="alert(1)">';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<IMG SRC onmouseover="alert(1)">';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject aaa4');
-		$test='<IMG onmouseover="alert(1)">';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<IMG onmouseover="alert(1)">';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject aaa5');
-		$test='<IMG SRC=/ onerror="alert(1)">';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<IMG SRC=/ onerror="alert(1)">';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject aaa6');
-		$test='<IMG SRC=" &#14;  javascript:alert(1);">';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<IMG SRC=" &#14;  javascript:alert(1);">';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject aaa7');
 
-		$test='<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;>';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;>';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject bbb');
 
-		$test='<SCRIPT SRC=http://xss.rocks/xss.js></SCRIPT>';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<SCRIPT SRC=http://xss.rocks/xss.js></SCRIPT>';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject ccc');
 
-		$test='<IMG SRC="javascript:alert(\'XSS\');">';
-		$result=testSqlAndScriptInject($test, 1);
+		$test = '<IMG SRC="javascript:alert(\'XSS\');">';
+		$result = testSqlAndScriptInject($test, 1);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject ddd');
 
-		$test='<IMG """><SCRIPT>alert("XSS")</SCRIPT>">';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<IMG """><SCRIPT>alert("XSS")</SCRIPT>">';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject eee');
 
-		$test='<!-- Google analytics -->
+		$test = '<!-- Google analytics -->
 			<script>
 			  (function(i,s,o,g,r,a,m){i[\'GoogleAnalyticsObject\']=r;i[r]=i[r]||function(){
 			  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -224,60 +224,60 @@ class SecurityTest extends CommonClassTest
 			  ga(\'send\', \'pageview\');
 
 			</script>';
-		$result=testSqlAndScriptInject($test, 0);
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject eee');
 
-		$test="<IMG SRC=\"jav\tascript:alert('XSS');\">";		// Is locked by some browser like chrome because the default directive no-referrer-when-downgrade is sent when requesting the SRC and then refused because of browser protection on img src load without referrer.
-		$test="<IMG SRC=\"jav&#x0D;ascript:alert('XSS');\">";	// Same
+		$test = "<IMG SRC=\"jav\tascript:alert('XSS');\">";		// Is locked by some browser like chrome because the default directive no-referrer-when-downgrade is sent when requesting the SRC and then refused because of browser protection on img src load without referrer.
+		$test = "<IMG SRC=\"jav&#x0D;ascript:alert('XSS');\">";	// Same
 
-		$test='<SCRIPT/XSS SRC="http://xss.rocks/xss.js"></SCRIPT>';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<SCRIPT/XSS SRC="http://xss.rocks/xss.js"></SCRIPT>';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject fff1');
-		$test='<SCRIPT/SRC="http://xss.rocks/xss.js"></SCRIPT>';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<SCRIPT/SRC="http://xss.rocks/xss.js"></SCRIPT>';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject fff2');
 
 		// This case seems to be filtered by browsers now.
-		$test='<BODY onload!#$%&()*~+-_.,:;?@[/|\]^`=alert(1)>';
+		$test = '<BODY onload!#$%&()*~+-_.,:;?@[/|\]^`=alert(1)>';
 		//$result=testSqlAndScriptInject($test, 0);
 		//$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject ggg');
 
-		$test='<iframe src=http://xss.rocks/scriptlet.html <';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<iframe src=http://xss.rocks/scriptlet.html <';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject hhh');
 
-		$test='Set.constructor`alert\x281\x29```';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = 'Set.constructor`alert\x281\x29```';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject iii');
 
-		$test="on<!-- ab\nc -->error=alert(1)";
-		$result=testSqlAndScriptInject($test, 0);
+		$test = "on<!-- ab\nc -->error=alert(1)";
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject jjj');
 
-		$test="<img src=x one<a>rror=alert(document.location)";
-		$result=testSqlAndScriptInject($test, 0);
+		$test = "<img src=x one<a>rror=alert(document.location)";
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject kkk');
 
-		$test="<a onpointerdown=alert(document.domain)>XSS</a>";
-		$result=testSqlAndScriptInject($test, 0);
+		$test = "<a onpointerdown=alert(document.domain)>XSS</a>";
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject lll');
 
-		$test='<a onscrollend=alert(1) style="display:block;overflow:auto;border:1px+dashed;width:500px;height:100px;"><br><br><br><br><br><span+id=x>test</span></a>';	// Add the char %F6 into the variable
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<a onscrollend=alert(1) style="display:block;overflow:auto;border:1px+dashed;width:500px;height:100px;"><br><br><br><br><br><span+id=x>test</span></a>';	// Add the char %F6 into the variable
+		$result = testSqlAndScriptInject($test, 0);
 		//print "test=".$test." result=".$result."\n";
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject mmm');
 
 
-		$test="Text with ' encoded with the numeric html entity converted into text entity &#39; (like when submitted by CKEditor)";
-		$result=testSqlAndScriptInject($test, 0);	// result must be 0
+		$test = "Text with ' encoded with the numeric html entity converted into text entity &#39; (like when submitted by CKEditor)";
+		$result = testSqlAndScriptInject($test, 0);	// result must be 0
 		$this->assertEquals(0, $result, 'Error on testSqlAndScriptInject mmm, result should be 0 and is not');
 
-		$test ='<a href="j&Tab;a&Tab;v&Tab;asc&NewLine;ri&Tab;pt:&lpar;a&Tab;l&Tab;e&Tab;r&Tab;t&Tab;(document.cookie)&rpar;">XSS</a>';
-		$result=testSqlAndScriptInject($test, 0);
+		$test = '<a href="j&Tab;a&Tab;v&Tab;asc&NewLine;ri&Tab;pt:&lpar;a&Tab;l&Tab;e&Tab;r&Tab;t&Tab;(document.cookie)&rpar;">XSS</a>';
+		$result = testSqlAndScriptInject($test, 0);
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject nnn, result should be >= 1 and is not');
 
-		$test="/dolibarr/htdocs/index.php/".chr('246')."abc";	// Add the char %F6 into the variable
-		$result=testSqlAndScriptInject($test, 2);
+		$test = "/dolibarr/htdocs/index.php/".chr('246')."abc";	// Add the char %F6 into the variable
+		$result = testSqlAndScriptInject($test, 2);
 		//print "test=".$test." result=".$result."\n";
 		$this->assertGreaterThanOrEqual($expectedresult, $result, 'Error on testSqlAndScriptInject with a non valid UTF8 char');
 	}
@@ -290,10 +290,10 @@ class SecurityTest extends CommonClassTest
 	public function testGETPOST()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Force default mode
 		$conf->global->MAIN_RESTRICTHTML_ONLY_VALID_HTML = 0;
@@ -301,211 +301,211 @@ class SecurityTest extends CommonClassTest
 		$conf->global->MAIN_RESTRICTHTML_REMOVE_ALSO_BAD_ATTRIBUTES = 0;
 		$conf->global->MAIN_DISALLOW_URL_INTO_DESCRIPTIONS = 0;
 
-		$_COOKIE["id"]=111;
-		$_POST["param0"]='A real string with <a href="rrr" title="aa&quot;bb">aaa</a> and " and \' and &amp; inside content';
-		$_GET["param1"]="222";
-		$_POST["param1"]="333";
-		$_GET["param2"]='a/b#e(pr)qq-rr\cc';
-		$_GET["param3"]='"&#110;a/b#e(pr)qq-rr\cc';    // Same than param2 + " and &#110;
-		$_GET["param4a"]='..&#47;../dir';
-		$_GET["param4b"]='..&#92;..\dirwindows';
-		$_GET["param5"]="a_1-b";
-		$_POST["param6"]="&quot;&gt;<svg o&#110;load='console.log(&quot;123&quot;)'&gt;";
-		$_POST["param6b"]='<<<../>../>../svg><<<../>../>../animate =alert(1)>abc';
-		$_GET["param7"]='"c:\this is a path~1\aaa&#110; &#x&#x31;&#x31;&#x30;;" abc<bad>def</bad>';
-		$_POST["param8a"]="Hacker<svg o&#110;load='console.log(&quot;123&quot;)'";	// html tag is not closed so it is not detected as html tag but is still harmfull
-		$_POST['param8b']='<img src=x onerror=alert(document.location) t=';		// this is html obfuscated by non closing tag
-		$_POST['param8c']='< with space after is ok';
-		$_POST['param8d']='<abc123 is html to clean';
-		$_POST['param8e']='<123abc is not html to clean';	// other similar case: '<2021-12-12'
-		$_POST['param8f']='abc<<svg <><<animate onbegin=alert(document.domain) a';
-		$_POST["param9"]='is_object($object) ? ($object->id < 10 ? round($object->id / 2, 2) : (2 * $user->id) * (int) substr($mysoc->zip, 1, 2)) : \'objnotdefined\'';
-		$_POST["param10"]='is_object($object) ? ($object->id < 10 ? round($object->id / 2, 2) : (2 * $user->id) * (int) substr($mysoc->zip, 1, 2)) : \'<abc>objnotdefined\'';
-		$_POST["param11"]=' Name <email@email.com> ';
-		$_POST["param12"]='<!DOCTYPE html><html>aaa</html>';
-		$_POST["param13"]='&#110; &#x6E; &gt; &lt; &quot; <a href=\"j&#x61;vascript:alert(document.domain)\">XSS</a>';
-		$_POST["param13b"]='&#110; &#x6E; &gt; &lt; &quot; <a href=\"j&#x61vascript:alert(document.domain)\">XSS</a>';
-		$_POST["param13c"]='aaa:<:bbb';
-		$_POST["param14"]="Text with ' encoded with the numeric html entity converted into text entity &#39; (like when submitted by CKEditor)";
-		$_POST["param15"]="<img onerror<=alert(document.domain)> src=>0xbeefed";
+		$_COOKIE["id"] = 111;
+		$_POST["param0"] = 'A real string with <a href="rrr" title="aa&quot;bb">aaa</a> and " and \' and &amp; inside content';
+		$_GET["param1"] = "222";
+		$_POST["param1"] = "333";
+		$_GET["param2"] = 'a/b#e(pr)qq-rr\cc';
+		$_GET["param3"] = '"&#110;a/b#e(pr)qq-rr\cc';    // Same than param2 + " and &#110;
+		$_GET["param4a"] = '..&#47;../dir';
+		$_GET["param4b"] = '..&#92;..\dirwindows';
+		$_GET["param5"] = "a_1-b";
+		$_POST["param6"] = "&quot;&gt;<svg o&#110;load='console.log(&quot;123&quot;)'&gt;";
+		$_POST["param6b"] = '<<<../>../>../svg><<<../>../>../animate =alert(1)>abc';
+		$_GET["param7"] = '"c:\this is a path~1\aaa&#110; &#x&#x31;&#x31;&#x30;;" abc<bad>def</bad>';
+		$_POST["param8a"] = "Hacker<svg o&#110;load='console.log(&quot;123&quot;)'";	// html tag is not closed so it is not detected as html tag but is still harmfull
+		$_POST['param8b'] = '<img src=x onerror=alert(document.location) t=';		// this is html obfuscated by non closing tag
+		$_POST['param8c'] = '< with space after is ok';
+		$_POST['param8d'] = '<abc123 is html to clean';
+		$_POST['param8e'] = '<123abc is not html to clean';	// other similar case: '<2021-12-12'
+		$_POST['param8f'] = 'abc<<svg <><<animate onbegin=alert(document.domain) a';
+		$_POST["param9"] = 'is_object($object) ? ($object->id < 10 ? round($object->id / 2, 2) : (2 * $user->id) * (int) substr($mysoc->zip, 1, 2)) : \'objnotdefined\'';
+		$_POST["param10"] = 'is_object($object) ? ($object->id < 10 ? round($object->id / 2, 2) : (2 * $user->id) * (int) substr($mysoc->zip, 1, 2)) : \'<abc>objnotdefined\'';
+		$_POST["param11"] = ' Name <email@email.com> ';
+		$_POST["param12"] = '<!DOCTYPE html><html>aaa</html>';
+		$_POST["param13"] = '&#110; &#x6E; &gt; &lt; &quot; <a href=\"j&#x61;vascript:alert(document.domain)\">XSS</a>';
+		$_POST["param13b"] = '&#110; &#x6E; &gt; &lt; &quot; <a href=\"j&#x61vascript:alert(document.domain)\">XSS</a>';
+		$_POST["param13c"] = 'aaa:<:bbb';
+		$_POST["param14"] = "Text with ' encoded with the numeric html entity converted into text entity &#39; (like when submitted by CKEditor)";
+		$_POST["param15"] = "<img onerror<=alert(document.domain)> src=>0xbeefed";
 		//$_POST["param15b"]="<html><head><title>Example HTML</title></head><body><div><p>This is a paragraph.</div><ul><li>Item 1</li><li>Item 2</li></ol></body><html>";
-		$_POST["param16"]='<a style="z-index: 1000">abc</a>';
-		$_POST["param17"]='<span style="background-image: url(logout.php)">abc</span>';
-		$_POST["param18"]='<span style="background-image: url(...?...action=aaa)">abc</span>';
-		$_POST["param19"]='<a href="j&Tab;a&Tab;v&Tab;asc&NewLine;ri&Tab;pt:&lpar;alert(document.cookie)&rpar;">XSS</a>';
+		$_POST["param16"] = '<a style="z-index: 1000">abc</a>';
+		$_POST["param17"] = '<span style="background-image: url(logout.php)">abc</span>';
+		$_POST["param18"] = '<span style="background-image: url(...?...action=aaa)">abc</span>';
+		$_POST["param19"] = '<a href="j&Tab;a&Tab;v&Tab;asc&NewLine;ri&Tab;pt:&lpar;alert(document.cookie)&rpar;">XSS</a>';
 		//$_POST["param19"]='<a href="javascript:alert(document.cookie)">XSS</a>';
 
 
 
-		$result=GETPOST('id', 'int');              // Must return nothing
+		$result = GETPOST('id', 'int');              // Must return nothing
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('', $result);
 
-		$result=GETPOST("param1", 'int');
+		$result = GETPOST("param1", 'int');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(222, $result, 'Test on param1 with no 3rd param');
 
-		$result=GETPOST("param1", 'int', 2);
+		$result = GETPOST("param1", 'int', 2);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(333, $result, 'Test on param1 with 3rd param = 2');
 
 		// Test with alpha
 
-		$result=GETPOST("param0", 'alpha');		// a simple format, so " completely removed
+		$result = GETPOST("param0", 'alpha');		// a simple format, so " completely removed
 		$resultexpected = 'A real string with aaa and and \' and & inside content';
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($resultexpected, $result, 'Test on param0');
 
-		$result=GETPOST("param2", 'alpha');
+		$result = GETPOST("param2", 'alpha');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, $_GET["param2"], 'Test on param2');
 
-		$result=GETPOST("param3", 'alpha');  // Must return string sanitized from char "
+		$result = GETPOST("param3", 'alpha');  // Must return string sanitized from char "
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 'na/b#e(pr)qq-rr\cc', 'Test on param3');
 
-		$result=GETPOST("param4a", 'alpha');  // Must return string sanitized from ../
+		$result = GETPOST("param4a", 'alpha');  // Must return string sanitized from ../
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 'dir');
 
-		$result=GETPOST("param4b", 'alpha');  // Must return string sanitized from ../
+		$result = GETPOST("param4b", 'alpha');  // Must return string sanitized from ../
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, 'dirwindows');
 
 		// Test with aZ09
 
-		$result=GETPOST("param1", 'aZ09');
+		$result = GETPOST("param1", 'aZ09');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, $_GET["param1"]);
 
-		$result=GETPOST("param2", 'aZ09');  // Must return '' as string contains car not in aZ09 definition
+		$result = GETPOST("param2", 'aZ09');  // Must return '' as string contains car not in aZ09 definition
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '');
 
-		$result=GETPOST("param3", 'aZ09');  // Must return '' as string contains car not in aZ09 definition
+		$result = GETPOST("param3", 'aZ09');  // Must return '' as string contains car not in aZ09 definition
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($result, '');
 
-		$result=GETPOST("param4a", 'aZ09');  // Must return '' as string contains car not in aZ09 definition
+		$result = GETPOST("param4a", 'aZ09');  // Must return '' as string contains car not in aZ09 definition
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('', $result);
 
-		$result=GETPOST("param4b", 'aZ09');  // Must return '' as string contains car not in aZ09 definition
+		$result = GETPOST("param4b", 'aZ09');  // Must return '' as string contains car not in aZ09 definition
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('', $result);
 
-		$result=GETPOST("param5", 'aZ09');
+		$result = GETPOST("param5", 'aZ09');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($_GET["param5"], $result);
 
 		// Test with nohtml
 
-		$result=GETPOST("param6", 'nohtml');
+		$result = GETPOST("param6", 'nohtml');
 		print __METHOD__." result6=".$result."\n";
 		$this->assertEquals('">', $result);
 
 		// Test with alpha = alphanohtml. We must convert the html entities like &#110; and disable all entities
 
-		$result=GETPOST("param6", 'alphanohtml');
+		$result = GETPOST("param6", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('>', $result);
 
-		$result=GETPOST("param6b", 'alphanohtml');
+		$result = GETPOST("param6b", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('abc', $result);
 
-		$result=GETPOST("param8a", 'alphanohtml');
+		$result = GETPOST("param8a", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("Hackersvg onload='console.log(123)'", $result);
 
-		$result=GETPOST("param8b", 'alphanohtml');
+		$result = GETPOST("param8b", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('img src=x onerror=alert(document.location) t=', $result, 'Test a string with non closing html tag with alphanohtml');
 
-		$result=GETPOST("param8c", 'alphanohtml');
+		$result = GETPOST("param8c", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($_POST['param8c'], $result, 'Test a string with non closing html tag with alphanohtml');
 
-		$result=GETPOST("param8d", 'alphanohtml');
+		$result = GETPOST("param8d", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('abc123 is html to clean', $result, 'Test a string with non closing html tag with alphanohtml');
 
-		$result=GETPOST("param8e", 'alphanohtml');
+		$result = GETPOST("param8e", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($_POST['param8e'], $result, 'Test a string with non closing html tag with alphanohtml');
 
-		$result=GETPOST("param8f", 'alphanohtml');
+		$result = GETPOST("param8f", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('abcsvg animate onbegin=alert(document.domain) a', $result, 'Test a string with html tag open with several <');
 
-		$result=GETPOST("param9", 'alphanohtml');
+		$result = GETPOST("param9", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($_POST["param9"], $result);
 
-		$result=GETPOST("param10", 'alphanohtml');
+		$result = GETPOST("param10", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($_POST["param9"], $result, 'We should get param9 after processing param10');
 
-		$result=GETPOST("param11", 'alphanohtml');
+		$result = GETPOST("param11", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("Name", $result, 'Test an email string with alphanohtml');
 
-		$result=GETPOST("param13", 'alphanohtml');
+		$result = GETPOST("param13", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('n n > <  XSS', $result, 'Test that html entities are decoded with alpha');
 
-		$result=GETPOST("param13c", 'alphanohtml');
+		$result = GETPOST("param13c", 'alphanohtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('aaa:<:bbb', $result, 'Test 13c');
 
 
 		// Test with alphawithlgt
 
-		$result=GETPOST("param11", 'alphawithlgt');
+		$result = GETPOST("param11", 'alphawithlgt');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(trim($_POST["param11"]), $result, 'Test an email string with alphawithlgt');
 
 
 		// Test with restricthtml: we must remove html open/close tag and content but not htmlentities (we can decode html entities for ascii chars like &#110;)
 
-		$result=GETPOST("param0", 'restricthtml');
+		$result = GETPOST("param0", 'restricthtml');
 		$resultexpected = 'A real string with <a href="rrr" title="aa&quot;bb">aaa</a> and " and \' and &amp; inside content';
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals($resultexpected, $result, 'Test on param0');
 
-		$result=GETPOST("param6", 'restricthtml');
+		$result = GETPOST("param6", 'restricthtml');
 		print __METHOD__." result for param6=".$result." - before=".$_POST["param6"]."\n";
 		$this->assertEquals('&quot;&gt;', $result);
 
-		$result=GETPOST("param7", 'restricthtml');
+		$result = GETPOST("param7", 'restricthtml');
 		print __METHOD__." result param7 = ".$result."\n";
 		$this->assertEquals('"c:\this is a path~1\aaan &#x;;;;" abcdef', $result);
 
-		$result=GETPOST("param8e", 'restricthtml');
+		$result = GETPOST("param8e", 'restricthtml');
 		print __METHOD__." result param8e = ".$result."\n";
 		$this->assertEquals('', $result);
 
-		$result=GETPOST("param12", 'restricthtml');
+		$result = GETPOST("param12", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(trim($_POST["param12"]), $result, 'Test a string with DOCTYPE and restricthtml');
 
-		$result=GETPOST("param13", 'restricthtml');
+		$result = GETPOST("param13", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('n n &gt; &lt; &quot; <a href=\"alert(document.domain)\">XSS</a>', $result, 'Test 13 that HTML entities are decoded with restricthtml, but only for common alpha chars');
 
-		$result=GETPOST("param13b", 'restricthtml');
+		$result = GETPOST("param13b", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('n n &gt; &lt; &quot; <a href=\"alert(document.domain)\">XSS</a>', $result, 'Test 13b that HTML entities are decoded with restricthtml, but only for common alpha chars');
 
-		$result=GETPOST("param14", 'restricthtml');
+		$result = GETPOST("param14", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("Text with ' encoded with the numeric html entity converted into text entity &#39; (like when submitted by CKEditor)", $result, 'Test 14');
 
-		$result=GETPOST("param15", 'restricthtml');		// param15 = <img onerror<=alert(document.domain)> src=>0xbeefed that is a dangerous string
+		$result = GETPOST("param15", 'restricthtml');		// param15 = <img onerror<=alert(document.domain)> src=>0xbeefed that is a dangerous string
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals("<img onerror=alert(document.domain) src=>0xbeefed", $result, 'Test 15');	// The GETPOST return a harmull string
 
-		$result=GETPOST("param19", 'restricthtml');
+		$result = GETPOST("param19", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('<a href="&lpar;alert(document.cookie)&rpar;">XSS</a>', $result, 'Test 19');
 
@@ -515,22 +515,22 @@ class SecurityTest extends CommonClassTest
 		$conf->global->MAIN_RESTRICTHTML_ONLY_VALID_HTML_TIDY = 0;
 
 		//$_POST["param0"] = 'A real string with <a href="rrr" title="aabb">aaa</a> and " inside content';
-		$result=GETPOST("param0", 'restricthtml');
+		$result = GETPOST("param0", 'restricthtml');
 		$resultexpected = 'A real string with <a href="rrr" title=\'aa"bb\'>aaa</a> and " and \' and &amp; inside content';
 		print __METHOD__." result for param0=".$result."\n";
 		$this->assertEquals($resultexpected, $result, 'Test on param0');
 
-		$result=GETPOST("param15", 'restricthtml');		// param15 = <img onerror<=alert(document.domain)> src=>0xbeefed that is a dangerous string
+		$result = GETPOST("param15", 'restricthtml');		// param15 = <img onerror<=alert(document.domain)> src=>0xbeefed that is a dangerous string
 		print __METHOD__." result for param15=".$result."\n";
 		//$this->assertEquals('InvalidHTMLStringCantBeCleaned', $result, 'Test 15b');   // With some PHP and libxml version, we got this result when parsing invalid HTML, but ...
 		//$this->assertEquals('<img onerror> src=&gt;0xbeefed', $result, 'Test 15b');	// ... on other PHP and libxml versions, we got a HTML that has been cleaned
 
-		$result=GETPOST("param6", 'restricthtml');		// param6 = "&quot;&gt;<svg o&#110;load='console.log(&quot;123&quot;)'&gt;"
+		$result = GETPOST("param6", 'restricthtml');		// param6 = "&quot;&gt;<svg o&#110;load='console.log(&quot;123&quot;)'&gt;"
 		print __METHOD__." result for param6=".$result." - before=".$_POST["param6"]."\n";
 		//$this->assertEquals('InvalidHTMLStringCantBeCleaned', $result, 'Test 15b');   // With some PHP and libxml version, we got this result when parsing invalid HTML, but ...
 		//$this->assertEquals('"&gt;', $result);										// ... on other PHP and libxml versions, we got a HTML that has been cleaned
 
-		$result=GETPOST("param7", 'restricthtml');		// param7 = "c:\this is a path~1\aaa&#110; &#x&#x31;&#x31;&#x30;;" abc<bad>def</bad>
+		$result = GETPOST("param7", 'restricthtml');		// param7 = "c:\this is a path~1\aaa&#110; &#x&#x31;&#x31;&#x30;;" abc<bad>def</bad>
 		print __METHOD__." result param7 = ".$result."\n";
 		//$this->assertEquals('InvalidHTMLStringCantBeCleaned', $result, 'Test 15b');   // With some PHP and libxml version, we got this result when parsing invalid HTML, but ...
 		//$this->assertEquals('"c:\this is a path~1\aaan 110;" abcdef', $result);		// ... on other PHP and libxml versions, we got a HTML that has been cleaned
@@ -542,19 +542,19 @@ class SecurityTest extends CommonClassTest
 			$conf->global->MAIN_RESTRICTHTML_ONLY_VALID_HTML = 0;
 			$conf->global->MAIN_RESTRICTHTML_ONLY_VALID_HTML_TIDY = 1;
 
-			$result=GETPOST("param0", 'restricthtml');
+			$result = GETPOST("param0", 'restricthtml');
 			$resultexpected = 'A real string with <a href="rrr" title="aa&quot;bb">aaa</a> and " and \' and & inside content';
 			print __METHOD__." result for param0=".$result."\n";
 			$this->assertEquals($resultexpected, $result, 'Test on param0');
 
-			$result=GETPOST("param15", 'restricthtml');		// param15 = <img onerror<=alert(document.domain)> src=>0xbeefed that is a dangerous string
+			$result = GETPOST("param15", 'restricthtml');		// param15 = <img onerror<=alert(document.domain)> src=>0xbeefed that is a dangerous string
 			print __METHOD__." result=".$result."\n";
 
-			$result=GETPOST("param6", 'restricthtml');
+			$result = GETPOST("param6", 'restricthtml');
 			print __METHOD__." result for param6=".$result." - before=".$_POST["param6"]."\n";
 			$this->assertEquals('"&gt;', $result);
 
-			$result=GETPOST("param7", 'restricthtml');
+			$result = GETPOST("param7", 'restricthtml');
 			print __METHOD__." result param7 = ".$result."\n";
 			$this->assertEquals('"c:\this is a path~1\aaan &amp;#x110;" abcdef', $result);
 		}
@@ -566,19 +566,19 @@ class SecurityTest extends CommonClassTest
 			$conf->global->MAIN_RESTRICTHTML_ONLY_VALID_HTML = 1;
 			$conf->global->MAIN_RESTRICTHTML_ONLY_VALID_HTML_TIDY = 1;
 
-			$result=GETPOST("param0", 'restricthtml');
+			$result = GETPOST("param0", 'restricthtml');
 			$resultexpected = 'A real string with <a href="rrr" title=\'aa"bb\'>aaa</a> and " and \' and & inside content';
 			print __METHOD__." result for param0=".$result."\n";
 			$this->assertEquals($resultexpected, $result, 'Test on param0');
 
-			$result=GETPOST("param15", 'restricthtml');		// param15 = <img onerror<=alert(document.domain)> src=>0xbeefed that is a dangerous string
+			$result = GETPOST("param15", 'restricthtml');		// param15 = <img onerror<=alert(document.domain)> src=>0xbeefed that is a dangerous string
 			print __METHOD__." result=".$result."\n";
 
-			$result=GETPOST("param6", 'restricthtml');
+			$result = GETPOST("param6", 'restricthtml');
 			print __METHOD__." result for param6=".$result." - before=".$_POST["param6"]."\n";
 			$this->assertEquals('"&gt;', $result);
 
-			$result=GETPOST("param7", 'restricthtml');
+			$result = GETPOST("param7", 'restricthtml');
 			print __METHOD__." result param7 = ".$result."\n";
 			$this->assertEquals('"c:\this is a path~1\aaan 110;" abcdef', $result);
 		}
@@ -590,19 +590,19 @@ class SecurityTest extends CommonClassTest
 		unset($conf->global->MAIN_RESTRICTHTML_ONLY_VALID_HTML_TIDY);
 		$conf->global->MAIN_RESTRICTHTML_REMOVE_ALSO_BAD_ATTRIBUTES = 1;
 
-		$result=GETPOST("param15", 'restricthtml');
+		$result = GETPOST("param15", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('<img src="">0xbeefed', $result, 'Test 15c');
 
-		$result=GETPOST('param16', 'restricthtml');
+		$result = GETPOST('param16', 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('<a style=" 1000">abc</a>', $result, 'Test tag a with forbidden attribute z-index');
 
-		$result=GETPOST('param17', 'restricthtml');
+		$result = GETPOST('param17', 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('<span style="background-image: url()">abc</span>', $result, 'Test anytag with a forbidden value for attribute');
 
-		$result=GETPOST('param18', 'restricthtml');
+		$result = GETPOST('param18', 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('<span style="background-image: url(...?...aaa)">abc</span>', $result, 'Test anytag with a forbidden value for attribute');
 
@@ -611,75 +611,75 @@ class SecurityTest extends CommonClassTest
 
 		// Special test for GETPOST of backtopage, backtolist or backtourl parameter
 
-		$_POST["backtopage"]='//www.google.com';
-		$result=GETPOST("backtopage");
+		$_POST["backtopage"] = '//www.google.com';
+		$result = GETPOST("backtopage");
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('www.google.com', $result, 'Test for backtopage param');
 
-		$_POST["backtopage"]='https:https://www.google.com';
-		$result=GETPOST("backtopage");
+		$_POST["backtopage"] = 'https:https://www.google.com';
+		$result = GETPOST("backtopage");
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('www.google.com', $result, 'Test for backtopage param');
 
-		$_POST["backtolist"]='::HTTPS://www.google.com';
-		$result=GETPOST("backtolist");
+		$_POST["backtolist"] = '::HTTPS://www.google.com';
+		$result = GETPOST("backtolist");
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('www.google.com', $result, 'Test for backtopage param');
 
-		$_POST["backtopage"]='http:www.google.com';
-		$result=GETPOST("backtopage");
+		$_POST["backtopage"] = 'http:www.google.com';
+		$result = GETPOST("backtopage");
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('httpwww.google.com', $result, 'Test for backtopage param');
 
-		$_POST["backtopage"]='/mydir/mypage.php?aa=a%10a';
-		$result=GETPOST("backtopage");
+		$_POST["backtopage"] = '/mydir/mypage.php?aa=a%10a';
+		$result = GETPOST("backtopage");
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('/mydir/mypage.php?aa=a%10a', $result, 'Test for backtopage param');
 
-		$_POST["backtopage"]='javascripT&javascript#javascriptxjavascript3a alert(1)';
-		$result=GETPOST("backtopage");
+		$_POST["backtopage"] = 'javascripT&javascript#javascriptxjavascript3a alert(1)';
+		$result = GETPOST("backtopage");
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('x3aalert(1)', $result, 'Test for backtopage param');
 
 
 		$conf->global->MAIN_SECURITY_MAX_IMG_IN_HTML_CONTENT = 3;
-		$_POST["pagecontentwithlinks"]='<img src="aaa"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>';
-		$result=GETPOST("pagecontentwithlinks", 'restricthtml');
+		$_POST["pagecontentwithlinks"] = '<img src="aaa"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>';
+		$result = GETPOST("pagecontentwithlinks", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('ErrorTooManyLinksIntoHTMLString', $result, 'Test on limit on GETPOST fails');
 
 		// Test that img src="data:..." is excluded from the count of external links
 		$conf->global->MAIN_SECURITY_MAX_IMG_IN_HTML_CONTENT = 3;
-		$_POST["pagecontentwithlinks"]='<img src="data:abc"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>';
-		$result=GETPOST("pagecontentwithlinks", 'restricthtml');
+		$_POST["pagecontentwithlinks"] = '<img src="data:abc"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>';
+		$result = GETPOST("pagecontentwithlinks", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('<img src="data:abc"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>', $result, 'Test on limit on GETPOST fails');
 
 		$conf->global->MAIN_DISALLOW_URL_INTO_DESCRIPTIONS = 2;
 
 		// Test that no links is allowed
-		$_POST["pagecontentwithlinks"]='<img src="data:abc"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>';
-		$result=GETPOST("pagecontentwithlinks", 'restricthtml');
+		$_POST["pagecontentwithlinks"] = '<img src="data:abc"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>';
+		$result = GETPOST("pagecontentwithlinks", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('ErrorHTMLLinksNotAllowed', $result, 'Test on limit on MAIN_DISALLOW_URL_INTO_DESCRIPTIONS = 2 (no links allowed)');
 
 		$conf->global->MAIN_DISALLOW_URL_INTO_DESCRIPTIONS = 1;
 
 		// Test that links on wrapper or local url are allowed
-		$_POST["pagecontentwithnowrapperlinks"]='<img src="data:abc"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>';
-		$result=GETPOST("pagecontentwithnowrapperlinks", 'restricthtml');
+		$_POST["pagecontentwithnowrapperlinks"] = '<img src="data:abc"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>';
+		$result = GETPOST("pagecontentwithnowrapperlinks", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('<img src="data:abc"><img src="bbb"><img src="/ccc"><span style="background: url(/ddd)"></span>', $result, 'Test on MAIN_DISALLOW_URL_INTO_DESCRIPTIONS = 1 (links on data or relative links ar allowed)');
 
 		// Test that links not on wrapper and not data are disallowed
-		$_POST["pagecontentwithnowrapperlinks"]='<img src="https://aaa">';
-		$result=GETPOST("pagecontentwithnowrapperlinks", 'restricthtml');
+		$_POST["pagecontentwithnowrapperlinks"] = '<img src="https://aaa">';
+		$result = GETPOST("pagecontentwithnowrapperlinks", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('ErrorHTMLExternalLinksNotAllowed', $result, 'Test on MAIN_DISALLOW_URL_INTO_DESCRIPTIONS = 1 (no links to http allowed)');
 
 		// Test that links not on wrapper and not data are disallowed
-		$_POST["pagecontentwithnowrapperlinks"]='<span style="background: url(http://ddd)"></span>';
-		$result=GETPOST("pagecontentwithnowrapperlinks", 'restricthtml');
+		$_POST["pagecontentwithnowrapperlinks"] = '<span style="background: url(http://ddd)"></span>';
+		$result = GETPOST("pagecontentwithnowrapperlinks", 'restricthtml');
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('ErrorHTMLExternalLinksNotAllowed', $result, 'Test on MAIN_DISALLOW_URL_INTO_DESCRIPTIONS = 1 (no links to http allowed)');
 
@@ -693,15 +693,15 @@ class SecurityTest extends CommonClassTest
 	 */
 	public function testEncodeDecode()
 	{
-		$stringtotest="This is a string to test encode/decode. This is a string to test encode/decode. This is a string to test encode/decode.";
+		$stringtotest = "This is a string to test encode/decode. This is a string to test encode/decode. This is a string to test encode/decode.";
 
-		$encodedstring=dol_encode($stringtotest);
-		$decodedstring=dol_decode($encodedstring);
+		$encodedstring = dol_encode($stringtotest);
+		$decodedstring = dol_decode($encodedstring);
 		print __METHOD__." encodedstring=".$encodedstring." ".base64_encode($stringtotest)."\n";
 		$this->assertEquals($stringtotest, $decodedstring, 'Use dol_encode/decode with no parameter');
 
-		$encodedstring=dol_encode($stringtotest, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
-		$decodedstring=dol_decode($encodedstring, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
+		$encodedstring = dol_encode($stringtotest, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
+		$decodedstring = dol_decode($encodedstring, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
 		print __METHOD__." encodedstring=".$encodedstring." ".base64_encode($stringtotest)."\n";
 		$this->assertEquals($stringtotest, $decodedstring, 'Use dol_encode/decode with a key parameter');
 
@@ -720,7 +720,7 @@ class SecurityTest extends CommonClassTest
 		$this->assertEquals('a &colon; b " c \' d &apos; e é', $decodedstring, 'Function did not sanitize correclty');
 
 		$stringtotest = 'a &colon; b &quot; c &#039; d &apos; e &eacute;';
-		$decodedstring = dol_html_entity_decode($stringtotest, ENT_QUOTES|ENT_HTML5);
+		$decodedstring = dol_html_entity_decode($stringtotest, ENT_QUOTES | ENT_HTML5);
 		$this->assertEquals('a : b " c \' d \' e é', $decodedstring, 'Function did not sanitize correclty');
 
 		return 0;
@@ -784,21 +784,21 @@ class SecurityTest extends CommonClassTest
 	{
 		global $conf;
 
-		$genpass1=getRandomPassword(true);				// Should be a string return by dol_hash (if no option set, will be md5)
+		$genpass1 = getRandomPassword(true);				// Should be a string return by dol_hash (if no option set, will be md5)
 		print __METHOD__." genpass1=".$genpass1."\n";
 		$this->assertEquals(strlen($genpass1), 32);
 
-		$genpass1=getRandomPassword(true, array('I'));	// Should be a string return by dol_hash (if no option set, will be md5)
+		$genpass1 = getRandomPassword(true, array('I'));	// Should be a string return by dol_hash (if no option set, will be md5)
 		print __METHOD__." genpass1=".$genpass1."\n";
 		$this->assertEquals(strlen($genpass1), 32);
 
-		$conf->global->USER_PASSWORD_GENERATED='None';
-		$genpass2=getRandomPassword(false);				// Should return an empty string
+		$conf->global->USER_PASSWORD_GENERATED = 'None';
+		$genpass2 = getRandomPassword(false);				// Should return an empty string
 		print __METHOD__." genpass2=".$genpass2."\n";
 		$this->assertEquals($genpass2, '');
 
-		$conf->global->USER_PASSWORD_GENERATED='Standard';
-		$genpass3=getRandomPassword(false);				// Should return a password of 12 chars
+		$conf->global->USER_PASSWORD_GENERATED = 'Standard';
+		$genpass3 = getRandomPassword(false);				// Should return a password of 12 chars
 		print __METHOD__." genpass3=".$genpass3."\n";
 		$this->assertEquals(strlen($genpass3), 12);
 
@@ -813,15 +813,15 @@ class SecurityTest extends CommonClassTest
 	public function testRestrictedArea()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		//$dummyuser=new User($db);
 		//$result=restrictedArea($dummyuser,'societe');
 
-		$result=restrictedArea($user, 'societe');
+		$result = restrictedArea($user, 'societe');
 		$this->assertEquals(1, $result);
 	}
 
@@ -898,21 +898,21 @@ class SecurityTest extends CommonClassTest
 	public function testDolSanitizeUrl()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$test = 'javascripT&javascript#x3a alert(1)';
-		$result=dol_sanitizeUrl($test);
+		$result = dol_sanitizeUrl($test);
 		$this->assertEquals('x3a alert(1)', $result, 'Test on dol_sanitizeUrl A');
 
 		$test = 'javajavascriptscript&cjavascriptolon;alert(1)';
-		$result=dol_sanitizeUrl($test);
+		$result = dol_sanitizeUrl($test);
 		$this->assertEquals('alert(1)', $result, 'Test on dol_sanitizeUrl B');
 
 		$test = '/javas:cript/google.com';
-		$result=dol_sanitizeUrl($test);
+		$result = dol_sanitizeUrl($test);
 		$this->assertEquals('google.com', $result, 'Test on dol_sanitizeUrl C');
 	}
 
@@ -924,25 +924,25 @@ class SecurityTest extends CommonClassTest
 	public function testDolSanitizeEmail()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$test = 'aaa@mycompany.com <My name>, bbb@mycompany.com <Another name>';
-		$result=dol_sanitizeEmail($test);
+		$result = dol_sanitizeEmail($test);
 		$this->assertEquals($test, $result, 'Test on dol_sanitizeEmail A');
 
 		$test = "aaa@mycompany.com <My name>,\nbbb@mycompany.com <Another name>";
-		$result=dol_sanitizeEmail($test);
+		$result = dol_sanitizeEmail($test);
 		$this->assertEquals('aaa@mycompany.com <My name>,bbb@mycompany.com <Another name>', $result, 'Test on dol_sanitizeEmail B');
 
 		$test = 'aaa@mycompany.com <My name>,\nbbb@mycompany.com <Another name>';
-		$result=dol_sanitizeEmail($test);
+		$result = dol_sanitizeEmail($test);
 		$this->assertEquals('aaa@mycompany.com <My name>,nbbb@mycompany.com <Another name>', $result, 'Test on dol_sanitizeEmail C');
 
 		$test = 'aaa@mycompany.com <My name>, "bcc:bbb"@mycompany.com <Another name>';
-		$result=dol_sanitizeEmail($test);
+		$result = dol_sanitizeEmail($test);
 		$this->assertEquals('aaa@mycompany.com <My name>, bccbbb@mycompany.com <Another name>', $result, 'Test on dol_sanitizeEmail D');
 	}
 
@@ -954,18 +954,18 @@ class SecurityTest extends CommonClassTest
 	public function testDolSanitizeFileName()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		//$dummyuser=new User($db);
 		//$result=restrictedArea($dummyuser,'societe');
 
-		$result=dol_sanitizeFileName('bad file | evilaction');
+		$result = dol_sanitizeFileName('bad file | evilaction');
 		$this->assertEquals('bad file _ evilaction', $result);
 
-		$result=dol_sanitizeFileName('bad file -evilparam --evilparam ---evilparam ----evilparam');
+		$result = dol_sanitizeFileName('bad file -evilparam --evilparam ---evilparam ----evilparam');
 		$this->assertEquals('bad file _evilparam _evilparam _evilparam _evilparam', $result);
 	}
 
@@ -977,16 +977,16 @@ class SecurityTest extends CommonClassTest
 	public function testDolEval()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=dol_eval('1==1', 1, 0);
+		$result = dol_eval('1==1', 1, 0);
 		print "result1 = ".$result."\n";
 		$this->assertTrue($result);
 
-		$result=dol_eval('1==2', 1, 0);
+		$result = dol_eval('1==2', 1, 0);
 		print "result2 = ".$result."\n";
 		$this->assertFalse($result);
 
@@ -994,7 +994,7 @@ class SecurityTest extends CommonClassTest
 		include_once DOL_DOCUMENT_ROOT.'/projet/class/task.class.php';
 
 		$s = '(($reloadedobj = new Task($db)) && ($reloadedobj->fetchNoCompute($object->id) > 0) && ($secondloadedobj = new Project($db)) && ($secondloadedobj->fetchNoCompute($reloadedobj->fk_project) > 0)) ? $secondloadedobj->ref : "Parent project not found"';
-		$result=dol_eval($s, 1, 1, '2');
+		$result = dol_eval($s, 1, 1, '2');
 		print "result3 = ".$result."\n";
 		$this->assertEquals('Parent project not found', $result);
 
@@ -1035,48 +1035,48 @@ class SecurityTest extends CommonClassTest
 		print "result12 = ".$result."\n";
 		$this->assertStringContainsString('Bad string syntax to evaluate', $result);
 
-		$result=dol_eval("90402.38+267678+0", 1, 1, 1);
+		$result = dol_eval("90402.38+267678+0", 1, 1, 1);
 		print "result13 = ".$result."\n";
 		$this->assertEquals('358080.38', $result);
 
 		global $leftmenu;	// Used into strings to eval
 
 		$leftmenu = 'AAA';
-		$result=dol_eval('$conf->currency && preg_match(\'/^(AAA|BBB)/\',$leftmenu)', 1, 1, '1');
+		$result = dol_eval('$conf->currency && preg_match(\'/^(AAA|BBB)/\',$leftmenu)', 1, 1, '1');
 		print "result = ".$result."\n";
 		$this->assertTrue($result);
 
 		// Same with a value that does not match
 		$leftmenu = 'XXX';
-		$result=dol_eval('$conf->currency && preg_match(\'/^(AAA|BBB)/\',$leftmenu)', 1, 1, '1');
+		$result = dol_eval('$conf->currency && preg_match(\'/^(AAA|BBB)/\',$leftmenu)', 1, 1, '1');
 		print "result14 = ".$result."\n";
 		$this->assertFalse($result);
 
 		$leftmenu = 'AAA';
-		$result=dol_eval('$conf->currency && isStringVarMatching(\'leftmenu\', \'(AAA|BBB)\')', 1, 1, '1');
+		$result = dol_eval('$conf->currency && isStringVarMatching(\'leftmenu\', \'(AAA|BBB)\')', 1, 1, '1');
 		print "result15 = ".$result."\n";
 		$this->assertTrue($result);
 
 		$leftmenu = 'XXX';
-		$result=dol_eval('$conf->currency && isStringVarMatching(\'leftmenu\', \'(AAA|BBB)\')', 1, 1, '1');
+		$result = dol_eval('$conf->currency && isStringVarMatching(\'leftmenu\', \'(AAA|BBB)\')', 1, 1, '1');
 		print "result16 = ".$result."\n";
 		$this->assertFalse($result);
 
 		$string = '(isModEnabled("agenda") || isModEnabled("resource")) && getDolGlobalInt("MAIN_FEATURES_LEVEL") >= 0 && preg_match(\'/^(admintools|all|XXX)/\', $leftmenu)';
-		$result=dol_eval($string, 1, 1, '1');
+		$result = dol_eval($string, 1, 1, '1');
 		print "result17 = ".$result."\n";
 		$this->assertTrue($result);
 
-		$result=dol_eval('1 && getDolGlobalInt("doesnotexist1") && $conf->global->MAIN_FEATURES_LEVEL', 1, 0);	// Should return false and not a 'Bad string syntax to evaluate ...'
+		$result = dol_eval('1 && getDolGlobalInt("doesnotexist1") && $conf->global->MAIN_FEATURES_LEVEL', 1, 0);	// Should return false and not a 'Bad string syntax to evaluate ...'
 		print "result18 = ".$result."\n";
 		$this->assertFalse($result);
 
-		$a='ab';
+		$a = 'ab';
 		$result = (string) dol_eval("(\$a.'s')", 1, 0);
 		print "result19 = ".$result."\n";
 		$this->assertStringContainsString('Bad string syntax to evaluate', $result);
 
-		$leftmenu='abs';
+		$leftmenu = 'abs';
 		$result = (string) dol_eval('$leftmenu(-5)', 1, 0);
 		print "result20 = ".$result."\n";
 		$this->assertStringContainsString('Bad string syntax to evaluate', $result);
@@ -1161,23 +1161,23 @@ class SecurityTest extends CommonClassTest
 	 */
 	public function testCheckLoginPassEntity()
 	{
-		$login=checkLoginPassEntity('loginbidon', 'passwordbidon', 1, array('dolibarr'));
+		$login = checkLoginPassEntity('loginbidon', 'passwordbidon', 1, array('dolibarr'));
 		print __METHOD__." login=".$login."\n";
 		$this->assertEquals($login, '');
 
-		$login=checkLoginPassEntity('admin', 'passwordbidon', 1, array('dolibarr'));
+		$login = checkLoginPassEntity('admin', 'passwordbidon', 1, array('dolibarr'));
 		print __METHOD__." login=".$login."\n";
 		$this->assertEquals($login, '');
 
-		$login=checkLoginPassEntity('admin', 'admin', 1, array('dolibarr'));            // Should works because admin/admin exists
+		$login = checkLoginPassEntity('admin', 'admin', 1, array('dolibarr'));            // Should works because admin/admin exists
 		print __METHOD__." login=".$login."\n";
 		$this->assertEquals($login, 'admin', 'The test to check if pass of user "admin" is "admin" has failed');
 
-		$login=checkLoginPassEntity('admin', 'admin', 1, array('http','dolibarr'));    // Should work because of second authentication method
+		$login = checkLoginPassEntity('admin', 'admin', 1, array('http','dolibarr'));    // Should work because of second authentication method
 		print __METHOD__." login=".$login."\n";
 		$this->assertEquals($login, 'admin');
 
-		$login=checkLoginPassEntity('admin', 'admin', 1, array('forceuser'));
+		$login = checkLoginPassEntity('admin', 'admin', 1, array('forceuser'));
 		print __METHOD__." login=".$login."\n";
 		$this->assertEquals('', $login, 'Error');    // Expected '' because should failed because login 'auto' does not exists
 	}

--- a/test/phpunit/SocieteTest.php
+++ b/test/phpunit/SocieteTest.php
@@ -38,7 +38,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -87,14 +87,14 @@ class SocieteTest extends CommonClassTest
 	public function testSocieteCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Societe($db);
+		$localobject = new Societe($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThanOrEqual($result, 0);
@@ -114,17 +114,17 @@ class SocieteTest extends CommonClassTest
 	public function testSocieteFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Societe($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Societe($db);
+		$result = $localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
-		$result=$localobject->verify();
+		$result = $localobject->verify();
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertEquals($result, 0);
 
@@ -143,42 +143,42 @@ class SocieteTest extends CommonClassTest
 	public function testSocieteUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->note_private='New private note after update';
-		$localobject->note_public='New public note after update';
-		$localobject->name='New name';
-		$localobject->address='New address';
-		$localobject->zip='New zip';
-		$localobject->town='New town';
-		$localobject->country_id=2;
-		$localobject->status=0;
-		$localobject->phone='New tel';
-		$localobject->fax='New fax';
-		$localobject->email='newemail@newemail.com';
-		$localobject->url='New url';
-		$localobject->idprof1='new idprof1';
-		$localobject->idprof2='new idprof2';
-		$localobject->idprof3='new idprof3';
-		$localobject->idprof4='new idprof4';
+		$localobject->note_private = 'New private note after update';
+		$localobject->note_public = 'New public note after update';
+		$localobject->name = 'New name';
+		$localobject->address = 'New address';
+		$localobject->zip = 'New zip';
+		$localobject->town = 'New town';
+		$localobject->country_id = 2;
+		$localobject->status = 0;
+		$localobject->phone = 'New tel';
+		$localobject->fax = 'New fax';
+		$localobject->email = 'newemail@newemail.com';
+		$localobject->url = 'New url';
+		$localobject->idprof1 = 'new idprof1';
+		$localobject->idprof2 = 'new idprof2';
+		$localobject->idprof3 = 'new idprof3';
+		$localobject->idprof4 = 'new idprof4';
 
-		$result=$localobject->update($localobject->id, $user);
+		$result = $localobject->update($localobject->id, $user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
-		$result=$localobject->update_note($localobject->note_private, '_private');
+		$result = $localobject->update_note($localobject->note_private, '_private');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Holiday::update_note (private) error');
 
-		$result=$localobject->update_note($localobject->note_public, '_public');
+		$result = $localobject->update_note($localobject->note_public, '_public');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0, 'Holiday::update_note (public) error');
 
-		$newobject=new Societe($db);
-		$result=$newobject->fetch($localobject->id);
+		$newobject = new Societe($db);
+		$result = $newobject->fetch($localobject->id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -215,42 +215,42 @@ class SocieteTest extends CommonClassTest
 	public function testIdProfCheck($localobject)
 	{
 		// OK FR
-		$localobject->country_code='FR';
-		$localobject->idprof1=493861496;
-		$localobject->idprof2=49386149600021;
-		$result=$localobject->id_prof_check(1, $localobject);    // Must be > 0
+		$localobject->country_code = 'FR';
+		$localobject->idprof1 = 493861496;
+		$localobject->idprof2 = 49386149600021;
+		$result = $localobject->id_prof_check(1, $localobject);    // Must be > 0
 		print __METHOD__." OK FR idprof1 result=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);
-		$result=$localobject->id_prof_check(2, $localobject);    // Must be > 0
+		$result = $localobject->id_prof_check(2, $localobject);    // Must be > 0
 		print __METHOD__." OK FR idprof2 result=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);
 
 		// KO FR
-		$localobject->country_code='FR';
-		$localobject->idprof1='id1ko';
-		$localobject->idprof2='id2ko';
-		$result=$localobject->id_prof_check(1, $localobject);    // Must be <= 0
+		$localobject->country_code = 'FR';
+		$localobject->idprof1 = 'id1ko';
+		$localobject->idprof2 = 'id2ko';
+		$result = $localobject->id_prof_check(1, $localobject);    // Must be <= 0
 		print __METHOD__." KO FR idprof1 result=".$result."\n";
 		$this->assertLessThan(1, $result);
-		$result=$localobject->id_prof_check(2, $localobject);    // Must be <= 0
+		$result = $localobject->id_prof_check(2, $localobject);    // Must be <= 0
 		print __METHOD__." KO FR idprof2 result=".$result."\n";
 		$this->assertLessThan(1, $result);
 
 		// KO ES
-		$localobject->country_code='ES';
-		$localobject->idprof1='id1ko';
-		$result=$localobject->id_prof_check(1, $localobject);    // Must be <= 0
+		$localobject->country_code = 'ES';
+		$localobject->idprof1 = 'id1ko';
+		$result = $localobject->id_prof_check(1, $localobject);    // Must be <= 0
 		print __METHOD__." KO ES idprof1 result=".$result."\n";
 		$this->assertLessThan(1, $result);
 
 		// OK AR
-		$localobject->country_code='AR';
-		$localobject->idprof1='id1ko';
-		$localobject->idprof2='id2ko';
-		$result=$localobject->id_prof_check(1, $localobject);    // Must be > 0
+		$localobject->country_code = 'AR';
+		$localobject->idprof1 = 'id1ko';
+		$localobject->idprof2 = 'id2ko';
+		$result = $localobject->id_prof_check(1, $localobject);    // Must be > 0
 		print __METHOD__." OK AR idprof1 result=".$result."\n";
 		$this->assertGreaterThanOrEqual(0, $result);
-		$result=$localobject->id_prof_check(2, $localobject);    // Must be > 0
+		$result = $localobject->id_prof_check(2, $localobject);    // Must be > 0
 		print __METHOD__." OK AR idprof2 result=".$result."\n";
 		$this->assertGreaterThanOrEqual(1, $result);
 
@@ -270,36 +270,36 @@ class SocieteTest extends CommonClassTest
 	public function testSocieteOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setAsCustomer();
+		$result = $localobject->setAsCustomer();
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
-		$result=$localobject->setPriceLevel(1, $user);
+		$result = $localobject->setPriceLevel(1, $user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
-		$result=$localobject->set_remise_client(10, 'Gift', $user);
+		$result = $localobject->set_remise_client(10, 'Gift', $user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
-		$result=$localobject->getNomUrl(1);
+		$result = $localobject->getNomUrl(1);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertNotEquals($result, '');
 
 		$localobject->country_code = 'FR';
 
-		$result=$localobject->isInEEC();
+		$result = $localobject->isInEEC();
 		print __METHOD__." id=".$localobject->id." country_code=".$localobject->country_code." result=".$result."\n";
 		$this->assertTrue($result);
 
 		$localobject->country_code = 'US';
 
-		$result=$localobject->isInEEC();
+		$result = $localobject->isInEEC();
 		print __METHOD__." id=".$localobject->id." country_code=".$localobject->country_code." result=".$result."\n";
 		$this->assertFalse($result);
 
@@ -330,15 +330,15 @@ class SocieteTest extends CommonClassTest
 	public function testGetOutstandingBills($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Societe($db);
+		$localobject = new Societe($db);
 		$localobject->fetch($id);
 
-		$result=$localobject->getOutstandingBills();
+		$result = $localobject->getOutstandingBills();
 
 		print __METHOD__." id=".$id." result=".var_export($result, true)."\n";
 		$this->assertTrue(array_key_exists('opened', $result), 'Result of getOutstandingBills failed');
@@ -359,15 +359,15 @@ class SocieteTest extends CommonClassTest
 	public function testSocieteDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Societe($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Societe($db);
+		$result = $localobject->fetch($id);
 
-		$result=$localobject->delete($id, $user);
+		$result = $localobject->delete($id, $user);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
@@ -383,56 +383,56 @@ class SocieteTest extends CommonClassTest
 	public function testSocieteGetFullAddress()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobjectadd=new Societe($db);
+		$localobjectadd = new Societe($db);
 		$localobjectadd->initAsSpecimen();
 
 		// France
 		unset($localobjectadd->country_code);
-		$localobjectadd->country_id=1;
-		$localobjectadd->name='New name';
-		$localobjectadd->address='New address';
-		$localobjectadd->zip='New zip';
-		$localobjectadd->town='New town';
-		$result=$localobjectadd->getFullAddress(1);
+		$localobjectadd->country_id = 1;
+		$localobjectadd->name = 'New name';
+		$localobjectadd->address = 'New address';
+		$localobjectadd->zip = 'New zip';
+		$localobjectadd->town = 'New town';
+		$result = $localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
 		$this->assertStringContainsString("New address\nNew zip New town\nFrance", $result);
 
 		// Belgium
 		unset($localobjectadd->country_code);
-		$localobjectadd->country_id=2;
-		$localobjectadd->name='New name';
-		$localobjectadd->address='New address';
-		$localobjectadd->zip='New zip';
-		$localobjectadd->town='New town';
-		$result=$localobjectadd->getFullAddress(1);
+		$localobjectadd->country_id = 2;
+		$localobjectadd->name = 'New name';
+		$localobjectadd->address = 'New address';
+		$localobjectadd->zip = 'New zip';
+		$localobjectadd->town = 'New town';
+		$result = $localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
 		$this->assertStringContainsString("New address\nNew zip New town\nBelgium", $result);
 
 		// Switzerland
 		unset($localobjectadd->country_code);
-		$localobjectadd->country_id=6;
-		$localobjectadd->name='New name';
-		$localobjectadd->address='New address';
-		$localobjectadd->zip='New zip';
-		$localobjectadd->town='New town';
-		$result=$localobjectadd->getFullAddress(1);
+		$localobjectadd->country_id = 6;
+		$localobjectadd->name = 'New name';
+		$localobjectadd->address = 'New address';
+		$localobjectadd->zip = 'New zip';
+		$localobjectadd->town = 'New town';
+		$result = $localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
 		$this->assertStringContainsString("New address\nNew zip New town\nSwitzerland", $result);
 
 		// USA
 		unset($localobjectadd->country_code);
-		$localobjectadd->country_id=11;
-		$localobjectadd->name='New name';
-		$localobjectadd->address='New address';
-		$localobjectadd->zip='New zip';
-		$localobjectadd->town='New town';
-		$localobjectadd->state='New state';
-		$result=$localobjectadd->getFullAddress(1);
+		$localobjectadd->country_id = 11;
+		$localobjectadd->name = 'New name';
+		$localobjectadd->address = 'New address';
+		$localobjectadd->zip = 'New zip';
+		$localobjectadd->town = 'New town';
+		$localobjectadd->state = 'New state';
+		$result = $localobjectadd->getFullAddress(1);
 		print __METHOD__." id=".$localobjectadd->id." result=".$result."\n";
 		$this->assertStringContainsString("New address\nNew town, New state, New zip\nUnited States", $result);
 

--- a/test/phpunit/StripeTest.php
+++ b/test/phpunit/StripeTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -77,15 +77,15 @@ class StripeTest extends CommonClassTest
 	public function testStripeOk()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$urltotest=getOnlinePaymentUrl(0, 'free');
+		$urltotest = getOnlinePaymentUrl(0, 'free');
 		print "urltotest=".$urltotest."\n";
 
-		$result=getURLContent($urltotest, 'GET', '', 1, array(), array('http', 'https'), 2);
+		$result = getURLContent($urltotest, 'GET', '', 1, array(), array('http', 'https'), 2);
 
 		print __METHOD__." result=".$result['http_code']."\n";
 		$this->assertEquals(200, $result['http_code']);

--- a/test/phpunit/SupplierProposalTest.php
+++ b/test/phpunit/SupplierProposalTest.php
@@ -39,7 +39,7 @@ if (empty($user->id)) {
 
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -77,10 +77,10 @@ class SupplierProposalTest extends CommonClassTest
 	protected function setUp(): void
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		print __METHOD__."\n";
 		//print $db->getVersion()."\n";
@@ -98,14 +98,14 @@ class SupplierProposalTest extends CommonClassTest
 	public function testSupplierProposalCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new SupplierProposal($db);
+		$localobject = new SupplierProposal($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
@@ -124,13 +124,13 @@ class SupplierProposalTest extends CommonClassTest
 	public function testSupplierProposalFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new SupplierProposal($db);
-		$result=$localobject->fetch($id);
+		$localobject = new SupplierProposal($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -149,13 +149,13 @@ class SupplierProposalTest extends CommonClassTest
 	public function testSupplierProposalAddLine($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$localobject->fetch_thirdparty();
-		$result=$localobject->addline('Added line', 10, 2, 19.6);
+		$result = $localobject->addline('Added line', 10, 2, 19.6);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -174,10 +174,10 @@ class SupplierProposalTest extends CommonClassTest
 	public function testSupplierProposalValid($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$result = $user->addrights(0, 'supplier_proposal');
 		$this->assertLessThan($result, 0);
@@ -185,7 +185,7 @@ class SupplierProposalTest extends CommonClassTest
 		$result = $user->getrights('supplier_proposal', 1);
 		//$this->assertLessThan($result, 0);
 
-		$result=$localobject->valid($user);
+		$result = $localobject->valid($user);
 		$this->assertLessThan($result, 0);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -205,10 +205,10 @@ class SupplierProposalTest extends CommonClassTest
 	public function testSupplierProposalOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -234,14 +234,14 @@ class SupplierProposalTest extends CommonClassTest
 	public function testSupplierProposalDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new SupplierProposal($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new SupplierProposal($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/TargetTest.php
+++ b/test/phpunit/TargetTest.php
@@ -85,13 +85,13 @@ class TargetTest extends CommonClassTest
 	public function testTargetFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Target($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Target($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -114,7 +114,7 @@ class TargetTest extends CommonClassTest
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		$localobject->note_private='New note private after update';
+		$localobject->note_private = 'New note private after update';
 		$result = $localobject->update($user);
 
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/TicketTest.php
+++ b/test/phpunit/TicketTest.php
@@ -37,7 +37,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -57,24 +57,24 @@ class TicketTest extends CommonClassTest
 	public function testTicketCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Try to create one with bad values
-		$localobject=new Ticket($db);
+		$localobject = new Ticket($db);
 		$localobject->initAsSpecimen();
 		$localobject->ref = '';
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals(-3, $result, $localobject->error.join(',', $localobject->errors));
 
 		// Try to create one with correct values
-		$localobject=new Ticket($db);
+		$localobject = new Ticket($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertGreaterThan(0, $result, $localobject->error.join(',', $localobject->errors));
@@ -94,13 +94,13 @@ class TicketTest extends CommonClassTest
 	public function testTicketFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Ticket($db);
-		$result=$localobject->fetch($id);
+		$localobject = new Ticket($db);
+		$result = $localobject->fetch($id);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);
@@ -120,12 +120,12 @@ class TicketTest extends CommonClassTest
 	public function testTicketmarkAsRead($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->markAsRead($user);
+		$result = $localobject->markAsRead($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertGreaterThan(0, $result);
@@ -144,14 +144,14 @@ class TicketTest extends CommonClassTest
 	public function testTicketsetProject($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$project_id = 1;
 
-		$result=$localobject->setProject($project_id);
+		$result = $localobject->setProject($project_id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertGreaterThan(0, $result);
@@ -170,14 +170,14 @@ class TicketTest extends CommonClassTest
 	public function testTicketsetContract($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$contract_id = 1;
 
-		$result=$localobject->setContract($contract_id);
+		$result = $localobject->setContract($contract_id);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertGreaterThan(0, $result);
@@ -196,14 +196,14 @@ class TicketTest extends CommonClassTest
 	public function testTicketsetProgression($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$percent = 80;
 
-		$result=$localobject->setProgression($percent);
+		$result = $localobject->setProgression($percent);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertGreaterThan(0, $result);
@@ -222,14 +222,14 @@ class TicketTest extends CommonClassTest
 	public function testTicketassignUser($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$user_id_to_assign = 1;
 
-		$result=$localobject->assignUser($user, $user_id_to_assign);
+		$result = $localobject->assignUser($user, $user_id_to_assign);
 		;
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
@@ -249,14 +249,14 @@ class TicketTest extends CommonClassTest
 	public function testTicketassignUserOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$user_id_to_assign = 2;
 
-		$result=$localobject->assignUser($user, $user_id_to_assign);
+		$result = $localobject->assignUser($user, $user_id_to_assign);
 		;
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
@@ -276,12 +276,12 @@ class TicketTest extends CommonClassTest
 	public function testTicketclose($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->close($user);
+		$result = $localobject->close($user);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertGreaterThan(0, $result);
@@ -301,14 +301,14 @@ class TicketTest extends CommonClassTest
 	public function testTicketDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Ticket($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new Ticket($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertGreaterThan(0, $result);

--- a/test/phpunit/UserGroupTest.php
+++ b/test/phpunit/UserGroupTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,14 +56,14 @@ class UserGroupTest extends CommonClassTest
 	public function testUserGroupCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new UserGroup($db);
+		$localobject = new UserGroup($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." result=".$result."\n";
@@ -81,13 +81,13 @@ class UserGroupTest extends CommonClassTest
 	public function testUserGroupFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new UserGroup($db);
-		$result=$localobject->fetch($id);
+		$localobject = new UserGroup($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -105,13 +105,13 @@ class UserGroupTest extends CommonClassTest
 	public function testUserGroupUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject->note='New note after update';
-		$result=$localobject->update($user);
+		$localobject->note = 'New note after update';
+		$result = $localobject->update($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -129,12 +129,12 @@ class UserGroupTest extends CommonClassTest
 	public function testUserGroupAddRight($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->addrights(1, 'bookmarks');
+		$result = $localobject->addrights(1, 'bookmarks');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -152,12 +152,12 @@ class UserGroupTest extends CommonClassTest
 	public function testUserGroupDelRight($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->delrights(1, 'bookmarks');
+		$result = $localobject->delrights(1, 'bookmarks');
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -175,10 +175,10 @@ class UserGroupTest extends CommonClassTest
 	public function testUserGroupOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$result = $localobject->generateDocument('templatenamethadoesnotexist', $langs);
 		print __METHOD__." result=".$result."\n";
@@ -198,14 +198,14 @@ class UserGroupTest extends CommonClassTest
 	public function testUserGroupDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new UserGroup($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new UserGroup($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);

--- a/test/phpunit/UserTest.php
+++ b/test/phpunit/UserTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -75,16 +75,16 @@ class UserTest extends CommonClassTest
 	public function testUserCreate()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		print __METHOD__." USER_PASSWORD_GENERATED=".getDolGlobalString('USER_PASSWORD_GENERATED')."\n";
 
-		$localobject=new User($db);
+		$localobject = new User($db);
 		$localobject->initAsSpecimen();
-		$result=$localobject->create($user);
+		$result = $localobject->create($user);
 
 		$this->assertLessThan($result, 0, 'Creation of user has failed: '.$localobject->error);
 		print __METHOD__." result=".$result."\n";
@@ -102,13 +102,13 @@ class UserTest extends CommonClassTest
 	public function testUserFetch($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new User($db);
-		$result=$localobject->fetch($id);
+		$localobject = new User($db);
+		$result = $localobject->fetch($id);
 
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
@@ -126,19 +126,19 @@ class UserTest extends CommonClassTest
 	public function testUserUpdate($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$this->changeProperties($localobject);
-		$result=$localobject->update($user);
+		$result = $localobject->update($user);
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
 		// Test everything are still same than specimen
-		$newlocalobject=new User($db);
+		$newlocalobject = new User($db);
 		$newlocalobject->initAsSpecimen();
 		$this->changeProperties($newlocalobject);
 		$this->assertEquals($this->objCompare($localobject, $newlocalobject, true, array('id','socid','societe_id','specimen','note','ref','pass','pass_indatabase','pass_indatabase_crypted','pass_temp','datec','datem','datelastlogin','datepreviouslogin','flagdelsessionsbefore','iplastlogin','ippreviouslogin','trackid')), array());    // Actual, Expected
@@ -157,12 +157,12 @@ class UserTest extends CommonClassTest
 	public function testUserDisable($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$result=$localobject->setstatus(0);
+		$result = $localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 
 		$this->assertLessThan($result, 0);
@@ -181,10 +181,10 @@ class UserTest extends CommonClassTest
 	public function testUserOther($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
@@ -207,10 +207,10 @@ class UserTest extends CommonClassTest
 	public function testUserHasRight($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 		/*$result=$localobject->setstatus(0);
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -239,10 +239,10 @@ class UserTest extends CommonClassTest
 	public function testUserSetPassword($localobject)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		// Test the 'none' password generator
 
@@ -352,14 +352,14 @@ class UserTest extends CommonClassTest
 	public function testUserDelete($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new User($db);
-		$result=$localobject->fetch($id);
-		$result=$localobject->delete($user);
+		$localobject = new User($db);
+		$result = $localobject->fetch($id);
+		$result = $localobject->delete($user);
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -377,14 +377,14 @@ class UserTest extends CommonClassTest
 	public function testUserAddPermission($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new User($db);
-		$result=$localobject->fetch(1);			// Other tests use the user id 1
-		$result=$localobject->addrights(0, 'supplier_proposal');
+		$localobject = new User($db);
+		$result = $localobject->fetch(1);			// Other tests use the user id 1
+		$result = $localobject->addrights(0, 'supplier_proposal');
 
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
@@ -401,7 +401,7 @@ class UserTest extends CommonClassTest
 	 */
 	public function changeProperties(&$localobject)
 	{
-		$localobject->note_private='New note after update';
+		$localobject->note_private = 'New note after update';
 	}
 
 	/**
@@ -415,23 +415,23 @@ class UserTest extends CommonClassTest
 	 */
 	public function objCompare($oA, $oB, $ignoretype = true, $fieldstoignorearray = array('id'))
 	{
-		$retAr=array();
+		$retAr = array();
 
 		if (get_class($oA) !== get_class($oB)) {
-			$retAr[]="Supplied objects are not of same class.";
+			$retAr[] = "Supplied objects are not of same class.";
 		} else {
-			$oVarsA=get_object_vars($oA);
-			$oVarsB=get_object_vars($oB);
-			$aKeys=array_keys($oVarsA);
+			$oVarsA = get_object_vars($oA);
+			$oVarsB = get_object_vars($oB);
+			$aKeys = array_keys($oVarsA);
 			foreach ($aKeys as $sKey) {
 				if (in_array($sKey, $fieldstoignorearray)) {
 					continue;
 				}
 				if (! $ignoretype && ($oVarsA[$sKey] !== $oVarsB[$sKey])) {
-					$retAr[]=$sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
+					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
 				}
 				if ($ignoretype && ($oVarsA[$sKey] != $oVarsB[$sKey])) {
-					$retAr[]=$sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
+					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
 				}
 			}
 		}

--- a/test/phpunit/UtilsTest.php
+++ b/test/phpunit/UtilsTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,19 +56,19 @@ class UtilsTest extends CommonClassTest
 	public function testExecuteCLI()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$localobject=new Utils($db);
+		$localobject = new Utils($db);
 		$result = $localobject->executeCLI('ls', $conf->admin->dir_temp.'/out.tmp', 1);
 		print var_export($result, true);
 		$this->assertEquals($result['result'], 0);
 		$this->assertEquals($result['error'], '');
 		//$this->assertEquals(preg_match('/phpunit/', $result['output']), 1);
 
-		$localobject=new Utils($db);
+		$localobject = new Utils($db);
 		$result = $localobject->executeCLI('ls', $conf->admin->dir_temp.'/out.tmp', 2);
 		print var_export($result, true);
 		$this->assertEquals($result['result'], 0);

--- a/test/phpunit/WebservicesInvoicesTest.php
+++ b/test/phpunit/WebservicesInvoicesTest.php
@@ -37,9 +37,9 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
-$conf->global->MAIN_UMASK='0666';
+$conf->global->MAIN_UMASK = '0666';
 
 
 /**
@@ -73,17 +73,17 @@ class WebservicesInvoicesTest extends CommonClassTest
 
 		//$this->sharedFixture
 		global $conf,$user,$langs,$db;
-		$this->savconf=$conf;
-		$this->savuser=$user;
-		$this->savlangs=$langs;
-		$this->savdb=$db;
+		$this->savconf = $conf;
+		$this->savuser = $user;
+		$this->savlangs = $langs;
+		$this->savdb = $db;
 
 		// Set the WebService URL
 		$WS_DOL_URL = DOL_MAIN_URL_ROOT.'/webservices/server_invoice.php';
 		print __METHOD__." create nusoap_client for URL=".$WS_DOL_URL."\n";
 		$this->soapclient = new nusoap_client($WS_DOL_URL);
 		if ($this->soapclient) {
-			$this->soapclient->soap_defencoding='UTF-8';
+			$this->soapclient->soap_defencoding = 'UTF-8';
 			$this->soapclient->decodeUTF8(false);
 		}
 
@@ -116,18 +116,18 @@ class WebservicesInvoicesTest extends CommonClassTest
 		// transaction commit. So if the invoice is created in the same
 		// transaction than the third party, the FK constraint fails.
 		// See this post for more detail: http://stackoverflow.com/a/5014744/5187108
-		$societe=new Societe($db);
-		$societe->ref='';
-		$societe->name='name';
-		$societe->ref_ext='ref-phpunit';
-		$societe->status=1;
-		$societe->client=1;
-		$societe->code_client='CU0901-1234';
-		$societe->code_fournisseur='SU0901-1234';
-		$societe->fournisseur=0;
-		$societe->date_creation=$now;
-		$societe->tva_assuj=0;
-		$societe->particulier=0;
+		$societe = new Societe($db);
+		$societe->ref = '';
+		$societe->name = 'name';
+		$societe->ref_ext = 'ref-phpunit';
+		$societe->status = 1;
+		$societe->client = 1;
+		$societe->code_client = 'CU0901-1234';
+		$societe->code_fournisseur = 'SU0901-1234';
+		$societe->fournisseur = 0;
+		$societe->date_creation = $now;
+		$societe->tva_assuj = 0;
+		$societe->particulier = 0;
 
 		$societe->create($user);
 		if (empty($societe->id)) {
@@ -153,10 +153,10 @@ class WebservicesInvoicesTest extends CommonClassTest
 	public function testWSInvoicesCreateInvoice()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$WS_METHOD  = 'createInvoice';
 
@@ -203,22 +203,22 @@ class WebservicesInvoicesTest extends CommonClassTest
 					);
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-		'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-		'sourceapplication'=>'DEMO',
-		'login'=>'admin',
-		'password'=>$this->pass,
-		'entity'=>'');
+		$authentication = array(
+		'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+		'sourceapplication' => 'DEMO',
+		'login' => 'admin',
+		'password' => $this->pass,
+		'entity' => '');
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication,'invoice'=>$body);
+		$result = '';
+		$parameters = array('authentication' => $authentication,'invoice' => $body);
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $this->soapclient->call($WS_METHOD, $parameters, $this->ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			//var_dump($soapclient);
@@ -250,30 +250,30 @@ class WebservicesInvoicesTest extends CommonClassTest
 	public function testWSInvoicesGetInvoiceByRefExt($result)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$WS_METHOD  = 'getInvoice';
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-		'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-		'sourceapplication'=>'DEMO',
-		'login'=>'admin',
-		'password'=>$this->pass,
-		'entity'=>'');
+		$authentication = array(
+		'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+		'sourceapplication' => 'DEMO',
+		'login' => 'admin',
+		'password' => $this->pass,
+		'entity' => '');
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication, 'id'=>null, 'ref'=>null, 'ref_ext'=>'ref-phpunit-2');
+		$result = '';
+		$parameters = array('authentication' => $authentication, 'id' => null, 'ref' => null, 'ref_ext' => 'ref-phpunit-2');
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $this->soapclient->call($WS_METHOD, $parameters, $this->ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			print $this->soapclient->error_str;
@@ -303,10 +303,10 @@ class WebservicesInvoicesTest extends CommonClassTest
 	public function testWSInvoicesUpdateInvoiceByRefExt($result)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$WS_METHOD  = 'updateInvoice';
 
@@ -355,22 +355,22 @@ class WebservicesInvoicesTest extends CommonClassTest
 			);
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-		'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-		'sourceapplication'=>'DEMO',
-		'login'=>'admin',
-		'password'=>$this->pass,
-		'entity'=>'');
+		$authentication = array(
+		'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+		'sourceapplication' => 'DEMO',
+		'login' => 'admin',
+		'password' => $this->pass,
+		'entity' => '');
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication,'invoice'=>$body);
+		$result = '';
+		$parameters = array('authentication' => $authentication,'invoice' => $body);
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $this->soapclient->call($WS_METHOD, $parameters, $this->ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			print 'Error: '.$this->soapclient->error_str;

--- a/test/phpunit/WebservicesOrdersTest.php
+++ b/test/phpunit/WebservicesOrdersTest.php
@@ -37,9 +37,9 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
-$conf->global->MAIN_UMASK='0666';
+$conf->global->MAIN_UMASK = '0666';
 
 
 /**
@@ -59,40 +59,40 @@ class WebservicesOrdersTest extends CommonClassTest
 	public function testWSOrderGetOrder()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$WS_DOL_URL = DOL_MAIN_URL_ROOT.'/webservices/server_order.php';
 		$WS_METHOD  = 'getOrder';
-		$ns='http://www.dolibarr.org/ns/';
+		$ns = 'http://www.dolibarr.org/ns/';
 
 		// Set the WebService URL
 		print __METHOD__." create nusoap_client for URL=".$WS_DOL_URL."\n";
 		$soapclient = new nusoap_client($WS_DOL_URL);
 		if ($soapclient) {
-			$soapclient->soap_defencoding='UTF-8';
+			$soapclient->soap_defencoding = 'UTF-8';
 			$soapclient->decodeUTF8(false);
 		}
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-			'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-			'sourceapplication'=>'DEMO',
-			'login'=>'admin',
-			'password'=>'admin',
-			'entity'=>''
+		$authentication = array(
+			'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+			'sourceapplication' => 'DEMO',
+			'login' => 'admin',
+			'password' => 'admin',
+			'entity' => ''
 		);
 
 		// Test URL
-		$parameters = array('authentication'=>$authentication,'id'=>1);
+		$parameters = array('authentication' => $authentication,'id' => 1);
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $soapclient->call($WS_METHOD, $parameters, $ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			//var_dump($soapclient);

--- a/test/phpunit/WebservicesOtherTest.php
+++ b/test/phpunit/WebservicesOtherTest.php
@@ -37,9 +37,9 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
-$conf->global->MAIN_UMASK='0666';
+$conf->global->MAIN_UMASK = '0666';
 
 
 /**
@@ -59,45 +59,45 @@ class WebservicesOtherTest extends CommonClassTest
 	public function testWSOtherGetVersions()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$WS_DOL_URL = DOL_MAIN_URL_ROOT.'/webservices/server_other.php';
 		$WS_METHOD  = 'getVersions';
-		$ns='http://www.dolibarr.org/ns/';
+		$ns = 'http://www.dolibarr.org/ns/';
 
 		// Set the WebService URL
 		print __METHOD__." create nusoap_client for URL=".$WS_DOL_URL."\n";
 		$soapclient = new nusoap_client($WS_DOL_URL);
 		if ($soapclient) {
-			$soapclient->soap_defencoding='UTF-8';
+			$soapclient->soap_defencoding = 'UTF-8';
 			$soapclient->decodeUTF8(false);
 		}
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-			'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-			'sourceapplication'=>'DEMO',
-			'login'=>'admin',
-			'password'=>'admin',
-			'entity'=>''
+		$authentication = array(
+			'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+			'sourceapplication' => 'DEMO',
+			'login' => 'admin',
+			'password' => 'admin',
+			'entity' => ''
 		);
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication);
+		$result = '';
+		$parameters = array('authentication' => $authentication);
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $soapclient->call($WS_METHOD, $parameters, $ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (!empty($result['faultstring'])) {
 			print $result['faultstring']."\n";
-			$result=0;
+			$result = 0;
 		}
 		if (! $result) {
 			//var_dump($soapclient);
@@ -113,15 +113,15 @@ class WebservicesOtherTest extends CommonClassTest
 		$this->assertEquals('OK', $result['result']['result_code']);
 
 		// Test method that does not exists
-		$WS_METHOD='methodthatdoesnotexists';
-		$result='';
-		$parameters = array('authentication'=>$authentication);
+		$WS_METHOD = 'methodthatdoesnotexists';
+		$result = '';
+		$parameters = array('authentication' => $authentication);
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $soapclient->call($WS_METHOD, $parameters, $ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			//var_dump($soapclient);

--- a/test/phpunit/WebservicesProductsTest.php
+++ b/test/phpunit/WebservicesProductsTest.php
@@ -39,9 +39,9 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
-$conf->global->MAIN_UMASK='0666';
+$conf->global->MAIN_UMASK = '0666';
 
 if (!isModEnabled('service')) {
 	print "Error: Module service must be enabled.\n";
@@ -65,47 +65,47 @@ class WebservicesProductsTest extends CommonClassTest
 	public function testWSProductsCreateProductOrService()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$datestring=dol_print_date(dol_now(), 'dayhourlog');
+		$datestring = dol_print_date(dol_now(), 'dayhourlog');
 
 		$WS_DOL_URL = DOL_MAIN_URL_ROOT.'/webservices/server_productorservice.php';
 		$WS_METHOD  = 'createProductOrService';
-		$ns='http://www.dolibarr.org/ns/';
+		$ns = 'http://www.dolibarr.org/ns/';
 
 		// Set the WebService URL
 		print __METHOD__." create nusoap_client for URL=".$WS_DOL_URL."\n";
 		$soapclient = new nusoap_client($WS_DOL_URL);
 		if ($soapclient) {
-			$soapclient->soap_defencoding='UTF-8';
+			$soapclient->soap_defencoding = 'UTF-8';
 			$soapclient->decodeUTF8(false);
 		}
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-			'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-			'sourceapplication'=>'DEMO',
-			'login'=>'admin',
-			'password'=>'admin',
-			'entity'=>''
+		$authentication = array(
+			'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+			'sourceapplication' => 'DEMO',
+			'login' => 'admin',
+			'password' => 'admin',
+			'entity' => ''
 		);
 
 		// Test URL
-		$result='';
+		$result = '';
 		$parameters = array(
-			'authentication'=>$authentication,'product'=>array(
-				'ref'=>'NewProductFromWS'.$datestring,
-				'label'=>'New Product From WS '.$datestring,
-				'type'=>1,
-				'description'=>'This is a new product created from WS PHPUnit test case',
-				'barcode'=>'123456789012',
-				'barcode_type'=>2,
-				'price_net'=>10,
-				'status_tosell'=>1,
-				'status_tobuy'=>1
+			'authentication' => $authentication,'product' => array(
+				'ref' => 'NewProductFromWS'.$datestring,
+				'label' => 'New Product From WS '.$datestring,
+				'type' => 1,
+				'description' => 'This is a new product created from WS PHPUnit test case',
+				'barcode' => '123456789012',
+				'barcode_type' => 2,
+				'price_net' => 10,
+				'status_tosell' => 1,
+				'status_tobuy' => 1
 			)
 		);
 		print __METHOD__." call method ".$WS_METHOD."\n";
@@ -113,7 +113,7 @@ class WebservicesProductsTest extends CommonClassTest
 			$result = $soapclient->call($WS_METHOD, $parameters, $ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring']) || $result['result']['result_code'] != 'OK') {
 			//var_dump($soapclient);
@@ -142,41 +142,41 @@ class WebservicesProductsTest extends CommonClassTest
 	public function testWSProductsGetProductOrService($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$WS_DOL_URL = DOL_MAIN_URL_ROOT.'/webservices/server_productorservice.php';
 		$WS_METHOD  = 'getProductOrService';
-		$ns='http://www.dolibarr.org/ns/';
+		$ns = 'http://www.dolibarr.org/ns/';
 
 		// Set the WebService URL
 		print __METHOD__." create nusoap_client for URL=".$WS_DOL_URL."\n";
 		$soapclient = new nusoap_client($WS_DOL_URL);
 		if ($soapclient) {
-			$soapclient->soap_defencoding='UTF-8';
+			$soapclient->soap_defencoding = 'UTF-8';
 			$soapclient->decodeUTF8(false);
 		}
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-			'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-			'sourceapplication'=>'DEMO',
-			'login'=>'admin',
-			'password'=>'admin',
-			'entity'=>''
+		$authentication = array(
+			'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+			'sourceapplication' => 'DEMO',
+			'login' => 'admin',
+			'password' => 'admin',
+			'entity' => ''
 		);
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication,'id'=>$id,'ref'=>'');
+		$result = '';
+		$parameters = array('authentication' => $authentication,'id' => $id,'ref' => '');
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $soapclient->call($WS_METHOD, $parameters, $ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			//var_dump($soapclient);
@@ -205,41 +205,41 @@ class WebservicesProductsTest extends CommonClassTest
 	public function testWSProductsDeleteProductOrService($id)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$WS_DOL_URL = DOL_MAIN_URL_ROOT.'/webservices/server_productorservice.php';
 		$WS_METHOD  = 'deleteProductOrService';
-		$ns='http://www.dolibarr.org/ns/';
+		$ns = 'http://www.dolibarr.org/ns/';
 
 		// Set the WebService URL
 		print __METHOD__." create nusoap_client for URL=".$WS_DOL_URL."\n";
 		$soapclient = new nusoap_client($WS_DOL_URL);
 		if ($soapclient) {
-			$soapclient->soap_defencoding='UTF-8';
+			$soapclient->soap_defencoding = 'UTF-8';
 			$soapclient->decodeUTF8(false);
 		}
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-			'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-			'sourceapplication'=>'DEMO',
-			'login'=>'admin',
-			'password'=>'admin',
-			'entity'=>''
+		$authentication = array(
+			'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+			'sourceapplication' => 'DEMO',
+			'login' => 'admin',
+			'password' => 'admin',
+			'entity' => ''
 		);
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication,'listofid'=>$id);
+		$result = '';
+		$parameters = array('authentication' => $authentication,'listofid' => $id);
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $soapclient->call($WS_METHOD, $parameters, $ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring']) || $result['result']['result_code'] != 'OK') {
 			//var_dump($soapclient);

--- a/test/phpunit/WebservicesThirdpartyTest.php
+++ b/test/phpunit/WebservicesThirdpartyTest.php
@@ -37,9 +37,9 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
-$conf->global->MAIN_UMASK='0666';
+$conf->global->MAIN_UMASK = '0666';
 
 
 /**
@@ -53,7 +53,7 @@ class WebservicesThirdpartyTest extends CommonClassTest
 {
 	protected $soapclient;
 
-	private $ns='http://www.dolibarr.org/ns/';
+	private $ns = 'http://www.dolibarr.org/ns/';
 
 
 	/**
@@ -69,10 +69,10 @@ class WebservicesThirdpartyTest extends CommonClassTest
 
 		//$this->sharedFixture
 		global $conf,$user,$langs,$db;
-		$this->savconf=$conf;
-		$this->savuser=$user;
-		$this->savlangs=$langs;
-		$this->savdb=$db;
+		$this->savconf = $conf;
+		$this->savuser = $user;
+		$this->savlangs = $langs;
+		$this->savdb = $db;
 
 		$WS_DOL_URL = DOL_MAIN_URL_ROOT.'/webservices/server_thirdparty.php';
 
@@ -80,7 +80,7 @@ class WebservicesThirdpartyTest extends CommonClassTest
 		print __METHOD__." create nusoap_client for URL=".$WS_DOL_URL."\n";
 		$this->soapclient = new nusoap_client($WS_DOL_URL);
 		if ($this->soapclient) {
-			$this->soapclient->soap_defencoding='UTF-8';
+			$this->soapclient->soap_defencoding = 'UTF-8';
 			$this->soapclient->decodeUTF8(false);
 		}
 
@@ -98,21 +98,21 @@ class WebservicesThirdpartyTest extends CommonClassTest
 	public function testWSThirdpartycreateThirdParty()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$WS_METHOD  = 'createThirdParty';
 
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-				'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-				'sourceapplication'=>'DEMO',
-				'login'=>'admin',
-				'password'=>'admin',
-				'entity'=>'');
+		$authentication = array(
+				'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+				'sourceapplication' => 'DEMO',
+				'login' => 'admin',
+				'password' => 'admin',
+				'entity' => '');
 
 		$body = array(
 				"id" => null,
@@ -153,14 +153,14 @@ class WebservicesThirdpartyTest extends CommonClassTest
 		);
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication, 'thirdparty'=>$body);
+		$result = '';
+		$parameters = array('authentication' => $authentication, 'thirdparty' => $body);
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $this->soapclient->call($WS_METHOD, $parameters, $this->ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			//var_dump($soapclient);
@@ -191,30 +191,30 @@ class WebservicesThirdpartyTest extends CommonClassTest
 	public function testWSThirdpartygetThirdPartyById($result)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 		$id = $result['id'];
 
 		$WS_METHOD  = 'getThirdParty';
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-		'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-		'sourceapplication'=>'DEMO',
-		'login'=>'admin',
-		'password'=>'admin',
-		'entity'=>'');
+		$authentication = array(
+		'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+		'sourceapplication' => 'DEMO',
+		'login' => 'admin',
+		'password' => 'admin',
+		'entity' => '');
 
-		$result='';
-		$parameters = array('authentication'=>$authentication, 'id'=>$id);
+		$result = '';
+		$parameters = array('authentication' => $authentication, 'id' => $id);
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $this->soapclient->call($WS_METHOD, $parameters, $this->ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			//var_dump($soapclient);
@@ -252,31 +252,31 @@ class WebservicesThirdpartyTest extends CommonClassTest
 	public function testWSThirdpartygetThirdPartyByRefExt($result)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 		$id = $result['id'];
 
 		$WS_METHOD  = 'getThirdParty';
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-				'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-				'sourceapplication'=>'DEMO',
-				'login'=>'admin',
-				'password'=>'admin',
-				'entity'=>'');
+		$authentication = array(
+				'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+				'sourceapplication' => 'DEMO',
+				'login' => 'admin',
+				'password' => 'admin',
+				'entity' => '');
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication, 'id'=>'', 'ref'=>'', 'ref_ext'=>'12');
+		$result = '';
+		$parameters = array('authentication' => $authentication, 'id' => '', 'ref' => '', 'ref_ext' => '12');
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $this->soapclient->call($WS_METHOD, $parameters, $this->ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		print $this->soapclient->response;
 		if (! $result || !empty($result['faultstring'])) {
@@ -313,30 +313,30 @@ class WebservicesThirdpartyTest extends CommonClassTest
 	public function testWSThirdpartydeleteThirdPartyById($result)
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 		$id = $result['id'];
 
 		$WS_METHOD  = 'deleteThirdParty';
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-				'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-				'sourceapplication'=>'DEMO',
-				'login'=>'admin',
-				'password'=>'admin',
-				'entity'=>'');
+		$authentication = array(
+				'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+				'sourceapplication' => 'DEMO',
+				'login' => 'admin',
+				'password' => 'admin',
+				'entity' => '');
 
-		$result='';
-		$parameters = array('authentication'=>$authentication, 'id'=>$id, 'ref'=>'', 'ref_ext'=>'');
+		$result = '';
+		$parameters = array('authentication' => $authentication, 'id' => $id, 'ref' => '', 'ref_ext' => '');
 		print __METHOD__." call method ".$WS_METHOD."\n";
 		try {
 			$result = $this->soapclient->call($WS_METHOD, $parameters, $this->ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			print 'Error: '.$this->soapclient->error_str;

--- a/test/phpunit/WebservicesUserTest.php
+++ b/test/phpunit/WebservicesUserTest.php
@@ -37,9 +37,9 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
-$conf->global->MAIN_UMASK='0666';
+$conf->global->MAIN_UMASK = '0666';
 
 
 /**
@@ -59,47 +59,47 @@ class WebservicesUserTest extends CommonClassTest
 	public function testWSUserGetUser()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
 		$WS_DOL_URL = DOL_MAIN_URL_ROOT.'/webservices/server_user.php';
 		$WS_METHOD  = 'getUser';
-		$ns='http://www.dolibarr.org/ns/';
+		$ns = 'http://www.dolibarr.org/ns/';
 
 		// Set the WebService URL
 		print __METHOD__." Create nusoap_client for URL=".$WS_DOL_URL."\n";
 		$soapclient = new nusoap_client($WS_DOL_URL);
 		if ($soapclient) {
-			$soapclient->soap_defencoding='UTF-8';
+			$soapclient->soap_defencoding = 'UTF-8';
 			$soapclient->decodeUTF8(false);
 		}
 
 		//$soapclient->setDebugLevel(5);
 
 		// Call the WebService method and store its result in $result.
-		$authentication=array(
-			'dolibarrkey'=>getDolGlobalString('WEBSERVICES_KEY'),
-			'sourceapplication'=>'DEMO',
-			'login'=>'admin',
-			'password'=>'admin',
-			'entity'=>''
+		$authentication = array(
+			'dolibarrkey' => getDolGlobalString('WEBSERVICES_KEY'),
+			'sourceapplication' => 'DEMO',
+			'login' => 'admin',
+			'password' => 'admin',
+			'entity' => ''
 		);
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication,'id'=>0,'ref'=>'admin');
+		$result = '';
+		$parameters = array('authentication' => $authentication,'id' => 0,'ref' => 'admin');
 		print __METHOD__." Call method ".$WS_METHOD."\n";
 		try {
 			$result = $soapclient->call($WS_METHOD, $parameters, $ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (!empty($result['faultstring'])) {
 			print $result['faultstring']."\n";
-			$result=0;
+			$result = 0;
 		}
 		if (! $result) {
 			//var_dump($soapclient);
@@ -115,14 +115,14 @@ class WebservicesUserTest extends CommonClassTest
 		$this->assertEquals('OK', empty($result['result']['result_code']) ? '' : $result['result']['result_code'], 'Test on ref admin');
 
 		// Test URL
-		$result='';
-		$parameters = array('authentication'=>$authentication,'id'=>0,'ref'=>'refthatdoesnotexists');
+		$result = '';
+		$parameters = array('authentication' => $authentication,'id' => 0,'ref' => 'refthatdoesnotexists');
 		print __METHOD__."Call method ".$WS_METHOD."\n";
 		try {
 			$result = $soapclient->call($WS_METHOD, $parameters, $ns, '');
 		} catch (SoapFault $exception) {
 			echo $exception;
-			$result=0;
+			$result = 0;
 		}
 		if (! $result || !empty($result['faultstring'])) {
 			//var_dump($soapclient);

--- a/test/phpunit/WebsiteTest.php
+++ b/test/phpunit/WebsiteTest.php
@@ -69,7 +69,7 @@ if (empty($user->id)) {
 		$user->rights->website = new stdClass();
 	}
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**

--- a/test/phpunit/XCalLibTest.php
+++ b/test/phpunit/XCalLibTest.php
@@ -36,7 +36,7 @@ if (empty($user->id)) {
 	$user->fetch(1);
 	$user->getrights();
 }
-$conf->global->MAIN_DISABLE_ALL_MAILS=1;
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 
 /**
@@ -56,17 +56,17 @@ class XCalLibTest extends CommonClassTest
 	public function testQuotedPrintEncodeDecode()
 	{
 		global $conf,$user,$langs,$db;
-		$conf=$this->savconf;
-		$user=$this->savuser;
-		$langs=$this->savlangs;
-		$db=$this->savdb;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
 
-		$stringtoencode='ABCD=1234;';
-		$result=quotedPrintEncode($stringtoencode);
+		$stringtoencode = 'ABCD=1234;';
+		$result = quotedPrintEncode($stringtoencode);
 		print __METHOD__." result=".$result."\n";
 		$this->assertEquals('ABCD=3D1234;', $result);
 
-		$resultback=quotedPrintDecode($result);
+		$resultback = quotedPrintDecode($result);
 		print __METHOD__." result=".$resultback."\n";
 		$this->assertEquals($stringtoencode, $resultback);
 	}

--- a/test/phpunit/functional/TakePosFunctionalTest.php
+++ b/test/phpunit/functional/TakePosFunctionalTest.php
@@ -158,7 +158,7 @@ class TakePosFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	{
 		$this->url('/admin/const.php');
 		$this->authenticate();
-		$main_features_level_path='//input[@value="MAIN_FEATURES_LEVEL"]/following::input[@type="text"]';
+		$main_features_level_path = '//input[@value="MAIN_FEATURES_LEVEL"]/following::input[@type="text"]';
 		$main_features_level = $this->byXPath($main_features_level_path);
 		$main_features_level->clear();
 		$main_features_level->value('2');
@@ -179,7 +179,7 @@ class TakePosFunctionalTest extends \PHPUnit_Extensions_Selenium2TestCase
 	{
 		$this->url('/admin/modules.php');
 		$this->authenticate();
-		$module_status_image_path='//a[contains(@href, "' . self::$module_id . '")]/img';
+		$module_status_image_path = '//a[contains(@href, "' . self::$module_id . '")]/img';
 		$module_status_image = $this->byXPath($module_status_image_path);
 		if (strstr($module_status_image->attribute('src'), 'switch_off.png')) {
 			// Enable the module


### PR DESCRIPTION
# Qual: Improve test messages to help locate errors.

Included a description of the test in the failing assertions to help locate the error c696c46724a.

Also applied php-cs-fixer on tests so the future manual changes stand out.

One file per commit to limit merging issues if any.