### PR TITLE
Fix: Improve test configuration

### DIFF
--- a/test/phpunit/phpunittest.xml
+++ b/test/phpunit/phpunittest.xml
@@ -1,45 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE phpunit SYSTEM "phpunit.dtd" >
 <phpunit
-	backupGlobals="false"
-	backupStaticAttributes="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	colors="true"
-	processIsolation="false"
-	stopOnFailure="true">
-	<php>
-		<ini name="max_execution_time" value="1800"/>
-		<ini name="max_input_time" value="1800"/>
-        <ini name="memory_limit" value="4G" />
-        <!-- Also don't forget to change suhosin.memory_limit=4G -->
-	</php>
-	<filter>
-	  <whitelist addUncoveredFilesFromWhitelist="true">
-	    <directory suffix=".class.php">../../htdocs/</directory>
-	    <directory suffix=".lib.php">../../htdocs/</directory>
-	    <directory suffix=".inc.php">../../htdocs/</directory>
-	    <directory suffix=".modules.php">../../htdocs/</directory>
-	    <file>../../htdocs/core/modules/facture/modules_facture.php</file>
-	    <file>../../htdocs/core/modules/commande/modules_commande.php</file>
-	    <file>../../htdocs/core/modules/propale/modules_propale.php</file>
-	    <file>../../htdocs/core/modules/project/modules_project.php</file>
-	    <file>../../htdocs/core/modules/fichinter/modules_fichinter.php</file>
-	    <exclude>
-	    <directory suffix=".php">../../build/</directory>
-	    <directory suffix=".php">../../dev/</directory>
-	    <directory suffix=".php">../../doc/</directory>
-	    <directory suffix=".php">../../test/</directory>
-	    <directory suffix=".php">../../documents/</directory>
-	    <directory suffix=".php">../../htdocs/custom/</directory>
-	    <directory suffix=".php">../../htdocs/documents/custom/</directory>
-	    <directory suffix=".php">../../htdocs/nltechno/</directory>
-	    <directory suffix=".php">../../htdocs/products/canvas/</directory>
-	    <directory suffix=".php">../../htdocs/contact/canvas/</directory>
-	    <directory suffix=".php">../../htdocs/societe/canvas/</directory>
-	    <directory suffix=".php">../../htdocs/includes/</directory>
-	    </exclude>
-	  </whitelist>
-	</filter>
+  backupGlobals="false"
+  backupStaticAttributes="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  colors="true"
+  processIsolation="false"
+  stopOnFailure="false">
+  <php>
+    <ini name="max_execution_time" value="1800"/>
+    <!-- Also don't forget to change suhosin.memory_limit=4G -->
+    <ini name="max_input_time" value="1800"/>
+    <ini name="fail_on_warning" value="On"/>
+    <ini name="fail_on_deprecation" value="On"/>
+    <ini name="fail_on_notice" value="On"/>
+    <ini name="display_startup_errors" value="On"/>
+    <ini name="display_errors" value="On"/>
+    <ini name="display_notices" value="On"/>
+    <ini name="display_warnings" value="On"/>
+    <ini name="display_deprecations" value="On"/>
+    <ini name="memory_limit" value="4G" />
+  </php>
+  <coverage>
+    <include>
+      <directory suffix=".class.php">../../htdocs/</directory>
+      <directory suffix=".lib.php">../../htdocs/</directory>
+      <directory suffix=".inc.php">../../htdocs/</directory>
+      <directory suffix=".modules.php">../../htdocs/</directory>
+      <file>../../htdocs/core/modules/facture/modules_facture.php</file>
+      <file>../../htdocs/core/modules/commande/modules_commande.php</file>
+      <file>../../htdocs/core/modules/propale/modules_propale.php</file>
+      <file>../../htdocs/core/modules/project/modules_project.php</file>
+      <file>../../htdocs/core/modules/fichinter/modules_fichinter.php</file>
+    </include>
+    <exclude>
+      <directory suffix=".php">../../build/</directory>
+      <directory suffix=".php">../../dev/</directory>
+      <directory suffix=".php">../../doc/</directory>
+      <directory suffix=".php">../../test/</directory>
+      <directory suffix=".php">../../documents/</directory>
+      <directory suffix=".php">../../htdocs/custom/</directory>
+      <directory suffix=".php">../../htdocs/documents/custom/</directory>
+      <directory suffix=".php">../../htdocs/nltechno/</directory>
+      <directory suffix=".php">../../htdocs/products/canvas/</directory>
+      <directory suffix=".php">../../htdocs/contact/canvas/</directory>
+      <directory suffix=".php">../../htdocs/societe/canvas/</directory>
+      <directory suffix=".php">../../htdocs/includes/</directory>
+    </exclude>
+  </coverage>
 </phpunit>


### PR DESCRIPTION
# Fix: Improve test configuration

## Do not fail early when running tests (stopOnFailure->false)

Finishing the phpunits tests does not require a lot of extra time so rather than quiting early, run them all.

Also, when needed this option can be enabled on the CLI, but it can not be disabled.  So when desired, it can still be added in a ci-flow or local script.

## Improve reporting

We want to report Notices and Warnings and with enough detail to help during debug.  These options are explicitly activated.