### PR TITLE
Fix: Allow new & old names to check if module is loaded.

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -226,7 +226,7 @@ function isModEnabled($module)
 		'expedition' => 'delivery_note',
 		'facture' => 'invoice',
 		'projet' => 'project',
-		'propal' => 'propale',
+		'propale' => 'propal',
 	);
 
 	if (!getDolGlobalString('MAIN_USE_NEW_SUPPLIERMOD')) {

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -216,23 +216,31 @@ function isModEnabled($module)
 {
 	global $conf;
 
-	// Fix special cases
+	// Fix old names (map to new names)
 	$arrayconv = array(
-		'bank' => 'banque',
-		'category' => 'categorie',
-		'contract' => 'contrat',
-		'project' => 'projet',
-		'delivery_note' => 'expedition'
+		'adherent' =>	'member',
+		'banque' => 'bank',
+		'categorie' => 'category',
+		'commande' => 'order',
+		'contrat' => 'contract',
+		'expedition' => 'delivery_note',
+		'facture' => 'invoice',
+		'projet' => 'project',
+		'propal' => 'propale',
 	);
+
 	if (!getDolGlobalString('MAIN_USE_NEW_SUPPLIERMOD')) {
+		// Special cases: both use the same module.
 		$arrayconv['supplier_order'] = 'fournisseur';
 		$arrayconv['supplier_invoice'] = 'fournisseur';
 	}
+
+	$module_alt = $module;
 	if (!empty($arrayconv[$module])) {
-		$module = $arrayconv[$module];
+		$module_alt = $arrayconv[$module];
 	}
 
-	return !empty($conf->modules[$module]);
+	return !empty($conf->modules[$module]) || !empty($conf->modules[$module_alt]);
 	//return !empty($conf->$module->enabled);
 }
 


### PR DESCRIPTION
# Fix: Allow new & old names to check if module is loaded.

The method 'isModEnabled()' was already checking some modules for their new name, but after transitioning Conf this was not working for 'member'.  Now testing for both names as 'Conf' can handle both and deprecation will be reported.

Several issues were discovered after removing deprecated values.