### PR TITLE
Fix: PHPUnit Object Test template

### DIFF
--- a/htdocs/modulebuilder/template/test/phpunit/MyObjectTest.php
+++ b/htdocs/modulebuilder/template/test/phpunit/MyObjectTest.php
@@ -1,6 +1,7 @@
 <?php
-/* Copyright (C) 2007-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
-/* Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
+/* Copyright (C) 2007-2017	Laurent Destailleur			<eldy@users.sourceforge.net>
+/* Copyright (C) 2023		Alexandre Janniaux			<alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) ---Put here your own copyright and developer email---
  *
  * This program is free software: you can redistribute it and/or modify
@@ -81,7 +82,7 @@ class MyObjectTest extends PHPUnit\Framework\TestCase
 	 *
 	 * @return void
 	 */
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
 		global $conf, $user, $langs, $db;
 		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
@@ -94,7 +95,7 @@ class MyObjectTest extends PHPUnit\Framework\TestCase
 	 *
 	 * @return void
 	 */
-	protected function setUp()
+	protected function setUp(): void
 	{
 		global $conf, $user, $langs, $db;
 		$conf = $this->savconf;
@@ -110,7 +111,7 @@ class MyObjectTest extends PHPUnit\Framework\TestCase
 	 *
 	 * @return void
 	 */
-	protected function tearDown()
+	protected function tearDown(): void
 	{
 		print __METHOD__."\n";
 	}
@@ -120,7 +121,7 @@ class MyObjectTest extends PHPUnit\Framework\TestCase
 	 *
 	 * @return void
 	 */
-	public static function tearDownAfterClass()
+	public static function tearDownAfterClass(): void
 	{
 		global $conf, $user, $langs, $db;
 		$db->rollback();


### PR DESCRIPTION
# Fix PHPUnit Object Test template

Fix some typing issues discovered when reusing the template.

(Reminder: this is the template for a test, not for code that impacts upgrades of an installation).