### PR TITLE
Fix: Add facture->invoice modulepart translation

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -509,7 +509,7 @@ function dol_is_dir_empty($dir)
 function dol_is_file($pathoffile)
 {
 	$newpathoffile = dol_osencode($pathoffile);
-	return is_file($newpathoffile);
+	return is_file($newpathoffile);  // Throws error when outside open_basedir
 }
 
 /**
@@ -2660,14 +2660,14 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		}
 	}
 	// Fix modulepart for backward compatibility
-	if ($modulepart == 'users') {
+	if ($modulepart == 'facture') {
+		$modulepart = 'invoice';
+	} elseif ($modulepart == 'users') {
 		$modulepart = 'user';
-	}
-	if ($modulepart == 'tva') {
+	} elseif ($modulepart == 'tva') {
 		$modulepart = 'tax-vat';
-	}
-	// Fix modulepart delivery
-	if ($modulepart == 'expedition' && strpos($original_file, 'receipt/') === 0) {
+	} elseif ($modulepart == 'expedition' && strpos($original_file, 'receipt/') === 0) {
+		// Fix modulepart delivery
 		$modulepart = 'delivery';
 	}
 


### PR DESCRIPTION
# Fix: Add facture->invoice modulepart translation

Issue occurred when detecting use of deprecated properties in tests when DolDeprecatedHandler was added.

The comment on line 512 relates to another issue I encounter with open_basedir set, I removed the '@' that fixed that to keep issue resolutions separate.