### PR TITLE
Dolibarr can now re-open ticket upon customer replay on the same ticket via email#28303

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -2591,8 +2591,10 @@ class EmailCollector extends CommonObject
 								//var_dump($alreadycreated);
 								//var_dump($operation['type']);
 								//var_dump($actioncomm);
+								//var_dump($objectemail);
 								//exit;
 
+								// Need to re-open the if it is closed or solved in past
 								if ($errorforthisaction) {
 									$errorforactions++;
 								} else {
@@ -2600,9 +2602,25 @@ class EmailCollector extends CommonObject
 									if ($result <= 0) {
 										$errorforactions++;
 										$this->errors = $actioncomm->errors;
-									} else {
-										$operationslog .= '<br>Event created -> id='.dol_escape_htmltag($actioncomm->id);
+									} else {										
+										if ($objectemail->status == Ticket::STATUS_CLOSED || $objectemail->status == Ticket::STATUS_CANCELED) {											
+											if(($objectemail->fk_user_assign != NULL)) {
+												$res = $objectemail->setStatut(Ticket::STATUS_ASSIGNED);
+											} else {
+												$res = $objectemail->setStatut(Ticket::STATUS_NOT_READ);
+											}
+											
+											if ($res) {
+												$operationslog .= '<br>Ticket Re-Opened successfully -> ref='.$objectemail->ref;
+											} else {
+												$errorforactions++;
+												$this->error = 'Error while changing the tcket status -> ref='.$objectemail->ref;
+												$this->errors[] = $this->error;
+											}
+										}
 									}
+									
+									$operationslog .= '<br>Event created -> id='.dol_escape_htmltag($actioncomm->id);
 								}
 							}
 						} elseif ($operation['type'] == 'recordjoinpiece') {

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -577,7 +577,11 @@ if (empty($reshook)) {
 		if ($object->fetch(GETPOST('id', 'int'), '', GETPOST('track_id', 'alpha')) >= 0) {
 			// prevent browser refresh from reopening ticket several times
 			if ($object->status == Ticket::STATUS_CLOSED || $object->status == Ticket::STATUS_CANCELED) {
-				$res = $object->setStatut(Ticket::STATUS_ASSIGNED);
+				if(($object->fk_user_assign != NULL)) {
+					$res = $object->setStatut(Ticket::STATUS_ASSIGNED);
+				} else {
+					$res = $object->setStatut(Ticket::STATUS_NOT_READ);
+				}
 				if ($res) {
 					// Log action in ticket logs table
 					//$log_action = $langs->trans('TicketLogReopen');


### PR DESCRIPTION
# Instructions
 [#28303 ](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) according to this feature, Dolibarr will re-open the ticket upon getting reply via email. Dolibarr email collector class will re-open the tick and make the status **Unread**, if the ticket is solved or closed and it is not assigned to any user. It will make the ticket status **Assigned**, if the ticket is closed or solved and it is assigned to a user already in past.

