### PR TITLE
Fix: Remove unused invalid global $lang

### DIFF
--- a/htdocs/emailcollector/lib/emailcollector.lib.php
+++ b/htdocs/emailcollector/lib/emailcollector.lib.php
@@ -169,7 +169,6 @@ function getFileData($jk, $fpos, $type, $mbox)
  **/
 function saveAttachment($path, $filename, $data)
 {
-	global $lang;
 	$tmp = explode('.', $filename);
 	$ext = array_pop($tmp);
 	$filename = implode('.', $tmp);


### PR DESCRIPTION
# Fix: Remove unused invalid global

$lang was invalid but not used in function -> removed.