### PR TITLE
Fix supplier llxHeader

### DIFF
--- a/htdocs/fourn/commande/index.php
+++ b/htdocs/fourn/commande/index.php
@@ -55,7 +55,6 @@ $hookmanager->initHooks(array('orderssuppliersindex'));
  * 	View
  */
 
-llxHeader('', $langs->trans("SuppliersOrdersArea"));
 llxHeader('', $langs->trans("SuppliersOrdersArea"), '', '', 0, 0, '', '', '', 'mod-supplier-order page-stats');
 
 $commandestatic = new CommandeFournisseur($db);

--- a/htdocs/fourn/commande/note.php
+++ b/htdocs/fourn/commande/note.php
@@ -79,7 +79,6 @@ if (empty($reshook)) {
 
 $title = $object->ref." - ".$langs->trans('Notes');
 $help_url = 'EN:Module_Suppliers_Orders|FR:CommandeFournisseur|ES:Módulo_Pedidos_a_proveedores';
-llxHeader('', $title, $help_url);
 llxHeader('', $title, $help_url, '', 0, 0, '', '', '', 'mod-supplier-order page-notes');
 
 $form = new Form($db);


### PR DESCRIPTION
# Fix supplier llxHeader
When accessing supplier order index or order notes, multiple header errors like :
Cannot modify header information - headers already sent by (output started at /var/www/dolibarr/20.0/htdocs/main.inc.php:2116) (/var/www/dolibarr/20.0/htdocs/main.inc.php:1598)

