### PR TITLE
FIx: modulenames

### DIFF
--- a/htdocs/core/customreports.php
+++ b/htdocs/core/customreports.php
@@ -97,7 +97,7 @@ $ObjectClassName = '';
 // Objects available by default
 $arrayoftype = array(
 	'thirdparty' => array('langs'=>'companies', 'label' => 'ThirdParties', 'picto'=>'company', 'ObjectClassName' => 'Societe', 'enabled' => isModEnabled('societe'), 'ClassPath' => "/societe/class/societe.class.php"),
-	'contact' => array('label' => 'Contacts', 'picto'=>'contact', 'ObjectClassName' => 'Contact', 'enabled' => isModEnabled('societ'), 'ClassPath' => "/contact/class/contact.class.php"),
+	'contact' => array('label' => 'Contacts', 'picto'=>'contact', 'ObjectClassName' => 'Contact', 'enabled' => isModEnabled('societe'), 'ClassPath' => "/contact/class/contact.class.php"),
 	'proposal' => array('label' => 'Proposals', 'picto'=>'proposal', 'ObjectClassName' => 'Propal', 'enabled' => isModEnabled('propal'), 'ClassPath' => "/comm/propal/class/propal.class.php"),
 	'order' => array('label' => 'Orders', 'picto'=>'order', 'ObjectClassName' => 'Commande', 'enabled' => isModEnabled('commande'), 'ClassPath' => "/commande/class/commande.class.php"),
 	'invoice' => array('langs'=>'facture', 'label' => 'Invoices', 'picto'=>'bill', 'ObjectClassName' => 'Facture', 'enabled' => isModEnabled('facture'), 'ClassPath' => "/compta/facture/class/facture.class.php"),

--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -2094,7 +2094,7 @@ function get_left_menu_products($mainmenu, &$newmenu, $usemenuhider = 1, $leftme
 			$newmenu->add("/product/card.php?leftmenu=service&amp;action=create&amp;type=1", $langs->trans("NewService"), 1, $user->hasRight('service', 'creer'));
 			$newmenu->add("/product/list.php?leftmenu=service&amp;type=1", $langs->trans("List"), 1, $user->hasRight('service', 'read'));
 
-			if (isModEnabled('Stock') && getDolGlobalString('STOCK_SUPPORTS_SERVICES')) {
+			if (isModEnabled('stock') && getDolGlobalString('STOCK_SUPPORTS_SERVICES')) {
 				$newmenu->add("/product/reassort.php?type=1", $langs->trans("MenuStocks"), 1, $user->hasRight('service', 'read') && $user->hasRight('stock', 'lire'));
 			}
 			if (isModEnabled('variants')) {

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -3858,7 +3858,7 @@ if ($action == 'create') {
 				print '<td class="right'.($resteapayeraffiche ? ' amountremaintopay' : (' '.$cssforamountpaymentcomplete)).'">'.price($resteapayeraffiche).'</td><td>&nbsp;</td></tr>';
 
 				// Remainder to pay Multicurrency
-				if (isModEnabled('multicurreny') && $object->multicurrency_code != $conf->currency || $object->multicurrency_tx != 1) {
+				if (isModEnabled('multicurrency') && $object->multicurrency_code != $conf->currency || $object->multicurrency_tx != 1) {
 					print '<tr><td colspan="'.$nbcols.'" class="right">';
 					print '<span class="opacitymedium">';
 					print $langs->trans('RemainderToPayMulticurrency');
@@ -3892,7 +3892,7 @@ if ($action == 'create') {
 				print '<td class="right'.($resteapayeraffiche ? ' amountremaintopay' : (' '.$cssforamountpaymentcomplete)).'">'.price($sign * $resteapayeraffiche).'</td><td>&nbsp;</td></tr>';
 
 				// Remainder to pay back Multicurrency
-				if (isModEnabled('multicurreny') && $object->multicurrency_code != $conf->currency || $object->multicurrency_tx != 1) {
+				if (isModEnabled('multicurrency') && $object->multicurrency_code != $conf->currency || $object->multicurrency_tx != 1) {
 					print '<tr><td colspan="'.$nbcols.'" class="right">';
 					print '<span class="opacitymedium">';
 					print $langs->trans('RemainderToPayBackMulticurrency');


### PR DESCRIPTION
# FIX: modulenames

A few misspellings on the module names that impact functionnality - perhaps something to check in CodingPHP as well.

I propose this on the develop branch, but this may need to be modified on older versions as well - I let you choose which version should benefit from this.

Out of curiosity I checked the names used because I saw a commit just being accepting introducing a new line of code using categorie and not category.

I composed a list of modulenames in use (maybe a few in sample scripts) that are not misspelled, but some old:

'compta' and 'compabilite' may be aliases that I did not notice treated as such in the code.

```plaintext
accounting
adherent
agenda
ai
anothermodule
api
asset
bank
banque
barcode
blockedlog
bom
bookcal
bookmark
cashdesk
categorie
category
clicktodial
commande
compta
comptabilite
contract
contrat
cron
datapolicy
debugbar
deplacement
don
dynamicprices
ecm
ecotax
emailcollector
eventorganization
expedition
expensereport
export
externalsite
facture
fckeditor
ficheinter
fournisseur
ftp
google
gravatar
holiday
hrm
import
incoterm
intracommreport
invoice
knowledgemanagement
ldap
loan
mailing
mailman
mailmanspip
margin
margins
memcached
modulebuilder
mrp
multicompany
multicurrency
mymodule
notification
numberwords
openstreetmap
opensurvey
order
partnership
paybox
paymentbybanktransfer
paypal
paypalplus
prelevement
product
productbatch
project
projet
propal
receiptprinter
reception
recruitment
resource
salaries
service
socialnetworks
societe
stock
stocktransfer
stripe
supplier_invoice
supplier_order
supplier_proposal
syslog
takepos
tax
ticket
user
variants
webhook
webportal
webservices
website
workflow
workstation
zapier
```