### PR TITLE
qual: phpstan for $user_valid

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -243,11 +243,6 @@ class Commande extends CommonOrder
 	public $user_author_id;
 
 	/**
-	 * @var int User validator ID
-	 */
-	public $user_valid;
-
-	/**
 	 * @var OrderLine one line of an order
 	 */
 	public $line;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -122,13 +122,6 @@ class Facture extends CommonInvoice
 	public $fk_user_author;
 
 	/**
-	 * @var int ID
-	 * @deprecated
-	 * @see $fk_user_valid
-	 */
-	public $user_valid;
-
-	/**
 	 * @var int|null ID
 	 */
 	public $fk_user_valid;


### PR DESCRIPTION
htdocs/commande/class/commande.class.php	248	PHPDoc type int of property Commande::$user_valid is not covariant with PHPDoc type User of overridden property CommonObject::$user_valid.

htdocs/compta/facture/class/facture.class.php	129	PHPDoc type int of property Facture::$user_valid is not covariant with PHPDoc type User of overridden property CommonObject::$user_valid.

$user_valid is deprecated and inherited from CommonObject.
Not need to declare it again in these subclasses where it's not used anymore ($user_validation_id is used instead).