### PR TITLE
qual: phpstan for htdocs/compta/paiement/class/paiement.class.php

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -471,12 +471,14 @@ abstract class CommonObject
 	public $fk_multicurrency;
 
 	/**
-	 * @var string		Multicurrency code
+	 * @var string|array<int,string>    Multicurrency code
+	 *                                  Or, just for the Paiement object, an array: invoice ID => currency code for that invoice.
 	 */
 	public $multicurrency_code;
 
 	/**
-	 * @var float		Multicurrency rate
+	 * @var float|array<int,float>      Multicurrency rate ("tx" = "taux" in French)
+	 *                                  Or, just for the Paiement object, an array: invoice ID => currency rate for that invoice.
 	 */
 	public $multicurrency_tx;
 


### PR DESCRIPTION
htdocs/compta/paiement/class/paiement.class.php	115	PHPDoc type array<int, float> of property Paiement::$multicurrency_tx is not covariant with PHPDoc type float of overridden property CommonObject::$multicurrency_tx.

htdocs/compta/paiement/class/paiement.class.php	120	PHPDoc type array<int, string> of property Paiement::$multicurrency_code is not covariant with PHPDoc type string of overridden property CommonObject::$multicurrency_code.