### PR TITLE
qual: phpstan - Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -585,7 +585,7 @@ class Propal extends CommonObject
 	 *		@param      int|string	$date_start       	Start date of the line
 	 *		@param      int|string	$date_end         	End date of the line
 	 *      @param		array		$array_options		extrafields array
-	 * 		@param 		string		$fk_unit 			Code of the unit to use. Null to use the default one
+	 * 		@param 		int|null	$fk_unit 			Code of the unit to use. Null to use the default one
 	 *      @param		string		$origin				Depend on global conf MAIN_CREATEFROM_KEEP_LINE_ORIGIN_INFORMATION can be 'orderdet', 'propaldet'..., else 'order','propal,'....
 	 *      @param		int			$origin_id			Depend on global conf MAIN_CREATEFROM_KEEP_LINE_ORIGIN_INFORMATION can be Id of origin object (aka line id), else object id
 	 * 		@param		double		$pu_ht_devise		Unit price in currency
@@ -835,7 +835,7 @@ class Propal extends CommonObject
 	 *	@param      int|string	$date_start       	Start date of the line
 	 *	@param      int|string	$date_end         	End date of the line
 	 *  @param		array		$array_options		extrafields array
-	 * 	@param 		string		$fk_unit 			Code of the unit to use. Null to use the default one
+	 * 	@param 		int|null	$fk_unit 			Code of the unit to use. Null to use the default one
 	 * 	@param		double		$pu_ht_devise		Unit price in currency
 	 * 	@param		int			$notrigger			disable line update trigger
 	 * @param       integer $rang   line rank

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1495,7 +1495,7 @@ class Commande extends CommonOrder
 	 *  @param		int				$pa_ht				Buying price (without tax)
 	 *  @param		string			$label				Label
 	 *  @param		array			$array_options		extrafields array. Example array('options_codeforfield1'=>'valueforfield1', 'options_codeforfield2'=>'valueforfield2', ...)
-	 * 	@param 		string			$fk_unit 			Code of the unit to use. Null to use the default one
+	 * 	@param 		int|null		$fk_unit 			Code of the unit to use. Null to use the default one
 	 * 	@param		string		    $origin				Depend on global conf MAIN_CREATEFROM_KEEP_LINE_ORIGIN_INFORMATION can be 'orderdet', 'propaldet'..., else 'order','propal,'....
 	 *  @param		int			    $origin_id			Depend on global conf MAIN_CREATEFROM_KEEP_LINE_ORIGIN_INFORMATION can be Id of origin object (aka line id), else object id
 	 * 	@param		double			$pu_ht_devise		Unit price in currency
@@ -3104,7 +3104,7 @@ class Commande extends CommonOrder
 	 *  @param		string			$label				Label
 	 *  @param		int				$special_code		Special code (also used by externals modules!)
 	 *  @param		array			$array_options		extrafields array
-	 * 	@param 		string			$fk_unit 			Code of the unit to use. Null to use the default one
+	 * 	@param 		int|null		$fk_unit 			Code of the unit to use. Null to use the default one
 	 *  @param		double			$pu_ht_devise		Amount in currency
 	 * 	@param		int				$notrigger			disable line update trigger
 	 * 	@param		string			$ref_ext			external reference

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -3773,7 +3773,7 @@ class Facture extends CommonInvoice
 	 *  @param		array		$array_options		extrafields array
 	 *  @param      int         $situation_percent  Situation advance percentage
 	 *  @param      int         $fk_prev_id         Previous situation line id reference
-	 *  @param 		string		$fk_unit 			Code of the unit to use. Null to use the default one
+	 *  @param 		int|null	$fk_unit 			Code of the unit to use. Null to use the default one
 	 *  @param		double		$pu_ht_devise		Unit price in foreign currency
 	 *  @param		string		$ref_ext		    External reference of the line
 	 *  @param		int			$noupdateafterinsertline	No update after insert of line
@@ -4068,7 +4068,7 @@ class Facture extends CommonInvoice
 	 * 	@param		int			$special_code		Special code (also used by externals modules!)
 	 *  @param		array		$array_options		extrafields array
 	 * 	@param      int         $situation_percent  Situation advance percentage
-	 * 	@param 		string		$fk_unit 			Code of the unit to use. Null to use the default one
+	 * 	@param 		int|null	$fk_unit 			Code of the unit to use. Null to use the default one
 	 * 	@param		double		$pu_ht_devise		Unit price in currency
 	 * 	@param		int			$notrigger			disable line update trigger
 	 *  @param		string		$ref_ext		    External reference of the line

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1906,31 +1906,31 @@ class CommandeFournisseur extends CommonOrder
 	/**
 	 *	Add order line
 	 *
-	 *	@param      string	$desc            		Description
-	 *	@param      float	$pu_ht              	Unit price (used if $price_base_type is 'HT')
-	 *	@param      float	$qty             		Quantity
-	 *	@param      float	$txtva           		VAT Rate
-	 *	@param      float	$txlocaltax1        	Localtax1 tax
-	 *  @param      float	$txlocaltax2        	Localtax2 tax
-	 *	@param      int		$fk_product      		Id product
-	 *  @param      int		$fk_prod_fourn_price	Id supplier price
-	 *  @param      string	$ref_supplier			Supplier reference price
-	 *	@param      float	$remise_percent  		Remise
-	 *	@param      string	$price_base_type		HT or TTC
-	 *	@param		float	$pu_ttc					Unit price TTC (used if $price_base_type is 'TTC')
-	 *	@param		int		$type					Type of line (0=product, 1=service)
-	 *	@param		int		$info_bits				More information
-	 *  @param		int		$notrigger				Disable triggers
-	 *  @param		int		$date_start				Date start of service
-	 *  @param		int		$date_end				Date end of service
-	 *  @param		array	$array_options			extrafields array
-	 *  @param 		string	$fk_unit 				Code of the unit to use. Null to use the default one
-	 *  @param 		string	$pu_ht_devise			Amount in currency
-	 *  @param		string	$origin					'order', ...
-	 *  @param		int		$origin_id				Id of origin object
-	 *  @param		int		$rang					Rank
-	 * 	@param		int		$special_code			Special code
-	 *	@return     int             				Return integer <=0 if KO, >0 if OK
+	 *	@param      string		$desc            		Description
+	 *	@param      float		$pu_ht              	Unit price (used if $price_base_type is 'HT')
+	 *	@param      float		$qty             		Quantity
+	 *	@param      float		$txtva           		VAT Rate
+	 *	@param      float		$txlocaltax1        	Localtax1 tax
+	 *	@param      float		$txlocaltax2        	Localtax2 tax
+	 *	@param      int			$fk_product      		Id product
+	 *	@param      int			$fk_prod_fourn_price	Id supplier price
+	 *	@param      string		$ref_supplier			Supplier reference price
+	 *	@param      float		$remise_percent  		Remise
+	 *	@param      string		$price_base_type		HT or TTC
+	 *	@param		float		$pu_ttc					Unit price TTC (used if $price_base_type is 'TTC')
+	 *	@param		int			$type					Type of line (0=product, 1=service)
+	 *	@param		int			$info_bits				More information
+	 *	@param		int			$notrigger				Disable triggers
+	 *	@param		int			$date_start				Date start of service
+	 *	@param		int			$date_end				Date end of service
+	 *	@param		array		$array_options			extrafields array
+	 *	@param 		int|null	$fk_unit 				Code of the unit to use. Null to use the default one
+	 *	@param 		string		$pu_ht_devise			Amount in currency
+	 *	@param		string		$origin					'order', ...
+	 *	@param		int			$origin_id				Id of origin object
+	 *	@param		int			$rang					Rank
+	 *	@param		int			$special_code			Special code
+	 *	@return     int     	        				Return integer <=0 if KO, >0 if OK
 	 */
 	public function addline($desc, $pu_ht, $qty, $txtva, $txlocaltax1 = 0.0, $txlocaltax2 = 0.0, $fk_product = 0, $fk_prod_fourn_price = 0, $ref_supplier = '', $remise_percent = 0.0, $price_base_type = 'HT', $pu_ttc = 0.0, $type = 0, $info_bits = 0, $notrigger = 0, $date_start = null, $date_end = null, $array_options = [], $fk_unit = null, $pu_ht_devise = 0, $origin = '', $origin_id = 0, $rang = -1, $special_code = 0)
 	{
@@ -2888,7 +2888,7 @@ class CommandeFournisseur extends CommonOrder
 	 *  @param      integer     $date_start     	Date start of service
 	 *  @param      integer     $date_end       	Date end of service
 	 *  @param		array		$array_options		Extrafields array
-	 * 	@param 		string		$fk_unit 			Code of the unit to use. Null to use the default one
+	 * 	@param 		int|null	$fk_unit 			Code of the unit to use. Null to use the default one
 	 * 	@param		float		$pu_ht_devise		Unit price in currency
 	 *  @param		string		$ref_supplier		Supplier ref
 	 *	@return    	int         	    			Return integer < 0 if error, > 0 if ok

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2038,31 +2038,31 @@ class FactureFournisseur extends CommonInvoice
 	 *	by the get_default_tva method(vendor_company, buying company, idprod) and the desc must
 	 *	already have the right value (the caller has to manage the multilanguage).
 	 *
-	 *	@param    	string	$desc            	Description of the line
-	 *	@param    	double	$pu              	Unit price (HT or TTC according to price_base_type, > 0 even for credit note)
-	 *	@param    	double	$txtva           	Force Vat rate to use, -1 for auto.
-	 *	@param		double	$txlocaltax1		LocalTax1 Rate
-	 *	@param		double	$txlocaltax2		LocalTax2 Rate
-	 *	@param    	double	$qty             	Quantity
-	 *	@param    	int		$fk_product      	Product/Service ID predefined
-	 *	@param    	double	$remise_percent  	Percentage discount of the line
-	 *	@param    	int		$date_start      	Service start date
-	 * 	@param    	int		$date_end        	Service expiry date
-	 * 	@param    	int		$fk_code_ventilation   	Accounting breakdown code
-	 *	@param    	int		$info_bits			Line type bits
-	 *	@param    	string	$price_base_type 	HT or TTC
-	 *	@param		int		$type				Type of line (0=product, 1=service)
-	 *  @param      int		$rang            	Position of line
-	 *  @param		int		$notrigger			Disable triggers
-	 *  @param		array	$array_options		extrafields array
-	 * 	@param 		string	$fk_unit 			Code of the unit to use. Null to use the default one
-	 *  @param      int     $origin_id          id origin document
-	 *  @param		double	$pu_devise			Amount in currency
-	 *  @param		string	$ref_supplier		Supplier ref
-	 *  @param      string  $special_code       Special code
-	 *  @param		int		$fk_parent_line		Parent line id
-	 *  @param    	int		$fk_remise_except	Id discount used
-	 *	@return    	int             			>0 if OK, <0 if KO
+	 *	@param      string      $desc                   Description of the line
+	 *	@param      double      $pu                     Unit price (HT or TTC according to price_base_type, > 0 even for credit note)
+	 *	@param      double      $txtva                  Force Vat rate to use, -1 for auto.
+	 *	@param      double      $txlocaltax1            LocalTax1 Rate
+	 *	@param      double      $txlocaltax2            LocalTax2 Rate
+	 *	@param      double      $qty                    Quantity
+	 *	@param      int         $fk_product             Product/Service ID predefined
+	 *	@param      double      $remise_percent         Percentage discount of the line
+	 *	@param      int         $date_start             Service start date
+	 *	@param      int         $date_end               Service expiry date
+	 *	@param      int         $fk_code_ventilation    Accounting breakdown code
+	 *	@param      int         $info_bits              Line type bits
+	 *	@param      string      $price_base_type        HT or TTC
+	 *	@param      int         $type                   Type of line (0=product, 1=service)
+	 *	@param      int         $rang                   Position of line
+	 *	@param      int         $notrigger              Disable triggers
+	 *	@param      array       $array_options          extrafields array
+	 *	@param      int|null    $fk_unit                Code of the unit to use. Null to use the default one
+	 *	@param      int         $origin_id              id origin document
+	 *	@param      double      $pu_devise              Amount in currency
+	 *	@param      string      $ref_supplier           Supplier ref
+	 *	@param      string      $special_code           Special code
+	 *	@param      int         $fk_parent_line         Parent line id
+	 *	@param      int         $fk_remise_except       Id discount used
+	 *	@return     int                                 >0 if OK, <0 if KO
 	 */
 	public function addline($desc, $pu, $txtva, $txlocaltax1, $txlocaltax2, $qty, $fk_product = 0, $remise_percent = 0, $date_start = '', $date_end = '', $fk_code_ventilation = 0, $info_bits = '', $price_base_type = 'HT', $type = 0, $rang = -1, $notrigger = 0, $array_options = [], $fk_unit = null, $origin_id = 0, $pu_devise = 0, $ref_supplier = '', $special_code = '', $fk_parent_line = 0, $fk_remise_except = 0)
 	{
@@ -2321,7 +2321,7 @@ class FactureFournisseur extends CommonInvoice
 	 * @param      	integer 	$date_start     	Date start of service
 	 * @param      	integer     $date_end       	Date end of service
 	 * @param		array		$array_options		extrafields array
-	 * @param 		string		$fk_unit 			Code of the unit to use. Null to use the default one
+	 * @param 		int|null	$fk_unit 			Code of the unit to use. Null to use the default one
 	 * @param		double		$pu_devise			Amount in currency
 	 * @param		string		$ref_supplier		Supplier ref
 	 * @param	integer	$rang	line rank


### PR DESCRIPTION
htdocs/comm/propal/class/propal.class.php	746	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

htdocs/comm/propal/class/propal.class.php	963	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

htdocs/commande/class/commande.class.php	1692	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

htdocs/commande/class/commande.class.php	3273	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

htdocs/compta/facture/class/facture.class.php	3990	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

htdocs/compta/facture/class/facture.class.php	4243	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

htdocs/fourn/class/fournisseur.commande.class.php	2149	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

htdocs/fourn/class/fournisseur.commande.class.php	3031	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

htdocs/fourn/class/fournisseur.facture.class.php	2257	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.

htdocs/fourn/class/fournisseur.facture.class.php	2453	Property CommonObjectLine::$fk_unit (int|null) does not accept string|null.