### PR TITLE
Fix: Spelling, Phan warnings, preg quoting, array size

### DIFF
--- a/htdocs/website/class/website.class.php
+++ b/htdocs/website/class/website.class.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2015       Florian Henry       <florian.henry@open-concept.pro>
  * Copyright (C) 2015       Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2018       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -726,6 +727,7 @@ class Website extends CommonObject
 		}
 
 		if (!$error) {
+			// @phan-suppress-next-line PhanPluginSuspiciousParamOrder
 			dolCopyDir($pathofwebsiteold, $pathofwebsitenew, getDolGlobalString('MAIN_UMASK'), 0, null, 2);
 
 			// Check symlink to medias and restore it if ko
@@ -1460,30 +1462,30 @@ class Website extends CommonObject
 		}
 
 		$arrayofspecialmainlanguages = array(
-			'en'=>'en_US',
-			'sq'=>'sq_AL',
-			'ar'=>'ar_SA',
-			'eu'=>'eu_ES',
-			'bn'=>'bn_DB',
-			'bs'=>'bs_BA',
-			'ca'=>'ca_ES',
-			'zh'=>'zh_CN',
-			'cs'=>'cs_CZ',
-			'da'=>'da_DK',
-			'et'=>'et_EE',
-			'ka'=>'ka_GE',
-			'el'=>'el_GR',
-			'he'=>'he_IL',
-			'kn'=>'kn_IN',
-			'km'=>'km_KH',
-			'ko'=>'ko_KR',
-			'lo'=>'lo_LA',
-			'nb'=>'nb_NO',
-			'fa'=>'fa_IR',
-			'sr'=>'sr_RS',
-			'sl'=>'sl_SI',
-			'uk'=>'uk_UA',
-			'vi'=>'vi_VN'
+			'en' => 'en_US',
+			'sq' => 'sq_AL',
+			'ar' => 'ar_SA',
+			'eu' => 'eu_ES',
+			'bn' => 'bn_DB',
+			'bs' => 'bs_BA',
+			'ca' => 'ca_ES',
+			'zh' => 'zh_CN',
+			'cs' => 'cs_CZ',
+			'da' => 'da_DK',
+			'et' => 'et_EE',
+			'ka' => 'ka_GE',
+			'el' => 'el_GR',
+			'he' => 'he_IL',
+			'kn' => 'kn_IN',
+			'km' => 'km_KH',
+			'ko' => 'ko_KR',
+			'lo' => 'lo_LA',
+			'nb' => 'nb_NO',
+			'fa' => 'fa_IR',
+			'sr' => 'sr_RS',
+			'sl' => 'sl_SI',
+			'uk' => 'uk_UA',
+			'vi' => 'vi_VN'
 		);
 
 		// Load tmppage if we have $websitepagefile defined
@@ -1731,19 +1733,19 @@ class Website extends CommonObject
 									if (!touch($destdir.'/containers/'."page" . $nextpage . ".tpl.php")) {
 										setEventMessages("Please check permission to create  <b>page" . $nextpage . ".tpl.php</b> in template <b>".$website->name_template."</b>", null, 'errors');
 									}
-									$fileFounded = '';
+									$filesFound = '';
 									foreach ($arraySourcedir as $file) {
 										if ($file['name'] == $nomFichierModifie) {
 											$fileContent = file_get_contents($file['fullname']);
 											$matches = array();
 											if (preg_match("/page\d+\.tpl\.php/", $fileContent, $matches)) {
-												$fileFounded = $matches[0];
+												$filesFound = $matches[0];
 												break;
 											}
 										}
 									}
 									foreach ($arraySourcedir as $file) {
-										if ($file['name'] == $fileFounded) {
+										if ($file['name'] == $filesFound) {
 											if (!is_writable($file['fullname'])) {
 												dolChmod($file['fullname'], '0664');
 											}
@@ -1948,7 +1950,7 @@ class Website extends CommonObject
 		$fichierWithNoPage = [];
 		$fichierWithNoPageInDest = [];
 
-		//  filter files source
+		// Filter source files
 		foreach (dol_dir_list($dossierSource, "files") as $file) {
 			if (preg_match('/^page\d+/', $file['name']) && !str_contains($file['name'], '.old')) {
 				$fichiersSource[] = $file;
@@ -1957,7 +1959,7 @@ class Website extends CommonObject
 			}
 		}
 
-		//  filter files destination
+		// Filter destination files
 		foreach (dol_dir_list($dossierDestination, "all", 1) as $file) {
 			if (preg_match('/^page\d+/', $file['name']) && !str_contains($file['name'], '.old')) {
 				$fichiersDestination[] = $file;
@@ -1976,29 +1978,29 @@ class Website extends CommonObject
 		}
 
 		//search numPage where was declared
-		$fileFounded = array();
+		$filesFound = array();
 		foreach ($fichierWithNoPage as $filesource) {
 			$fileContent = file_get_contents($filesource['fullname']);
 			if (strpos($fileContent, "require './page".$numOfPageSource.".tpl.php'") !== false) {
-				$fileFounded = $filesource;
+				$filesFound = $filesource;
 				break;
 			}
 		}
 		// find file with same name and extract num page in destination folder
-		$numPageFounded = '';
+		$numPagesFound = '';
 		foreach ($fichierWithNoPageInDest as $filedest) {
-			if ($filedest['name'] === $fileFounded['name']) {
+			if ($filedest['name'] === $filesFound['name']) {
 				$fileContent = file_get_contents($filedest['fullname']);
 				if (preg_match("/page\d+\.tpl\.php/", $fileContent, $matches)) {
-					$numPageFounded = $matches[0];
+					$numPagesFound = $matches[0];
 					break;
 				}
 			}
 		}
-		//search file with the number of page founded
+		//search file with the number of pages found
 		$fileNeeded = array();
 		foreach ($fichiersDestination as $index => $file) {
-			if ($file['name'] == $numPageFounded) {
+			if ($file['name'] == $numPagesFound) {
 				$fileNeeded = $file;
 				break;
 			}
@@ -2019,7 +2021,7 @@ class Website extends CommonObject
 	}
 
 	/**
-	 * remove espace in string
+	 * Remove spaces in string
 	 * @param   string   $str    string
 	 * @return string
 	 */
@@ -2033,7 +2035,7 @@ class Website extends CommonObject
 	/**
 	 * show difference between to string
 	 * @param string  $str1   first string
-	 * @param string  $str2   seconde string
+	 * @param string  $str2   second string
 	 * @param array  $exceptNumPge    num of page files we don't want to change
 	 * @return array|int      -1 if KO, array if OK
 	 */
@@ -2046,70 +2048,73 @@ class Website extends CommonObject
 		$lines1 = explode("\n", $str1);
 		$lines2 = explode("\n", $str2);
 
-		$linesShouldnChange = array();
-		$linesShouldnNotChange = array();
+		$linesShouldChange = array();
+		$linesShouldNotChange = array();
 		$linefound = array();
 		$countNumPage = count($exceptNumPge);
 
-		for ($i = 0;$i< $countNumPage; $i++) {
+		for ($i = 0;$i < $countNumPage; $i++) {
+			$linefound[$i] = array();
 			$linefound[$i]['meta'] = '/content="' . preg_quote($exceptNumPge[$i], '/') . '" \/>/';
 			$linefound[$i]['output'] = '/dolWebsiteOutput\(\$tmp, "html", ' . preg_quote($exceptNumPge[$i], '/') . '\);/';
 		}
 
-		$maxLines = max(count($lines1), count($lines2));
-		for ($lineNum = 0; $lineNum < $maxLines; $lineNum++) {
-			$lineContent1 = $lines1[$lineNum] ?? '';
-			$lineContent2 = $lines2[$lineNum] ?? '';
-			if (preg_match($linefound[0]['output'], $lineContent1)) {
-				$linesShouldnChange[] = $lineContent1;
-			}
-			if (preg_match($linefound[0]['meta'], $lineContent1)) {
-				$linesShouldnChange[] = $lineContent1;
-			}
-			if (preg_match($linefound[1]['output'], $lineContent2)) {
-				$linesShouldnNotChange[] = $lineContent2;
-			}
-			if (preg_match($linefound[1]['meta'], $lineContent2)) {
-				$linesShouldnNotChange[] = $lineContent2;
-			}
-			if ($lineContent1 !== $lineContent2) {
-				if (isset($lines1[$lineNum]) && !isset($lines2[$lineNum])) {
-					// Ligne deleted de la source
-					$diff["Supprimée à la ligne " . ($lineNum + 1)] = $lineContent1;
-				} elseif (!isset($lines1[$lineNum]) && isset($lines2[$lineNum])) {
-					// Nouvelle ligne added dans la destination
-					$diff["Ajoutée à la ligne " . ($lineNum + 1)] = $lineContent2;
-				} else {
-					// Différence found it
-					$diff["Modifiée à la ligne " . ($lineNum + 1)] = $lineContent2;
+		if ($countNumPage >= 2) {
+			$maxLines = max(count($lines1), count($lines2));
+			for ($lineNum = 0; $lineNum < $maxLines; $lineNum++) {
+				$lineContent1 = $lines1[$lineNum] ?? '';
+				$lineContent2 = $lines2[$lineNum] ?? '';
+				if (preg_match($linefound[0]['output'], $lineContent1)) {
+					$linesShouldChange[] = $lineContent1;
+				}
+				if (preg_match($linefound[0]['meta'], $lineContent1)) {
+					$linesShouldChange[] = $lineContent1;
+				}
+				if (preg_match($linefound[1]['output'], $lineContent2)) {
+					$linesShouldNotChange[] = $lineContent2;
+				}
+				if (preg_match($linefound[1]['meta'], $lineContent2)) {
+					$linesShouldNotChange[] = $lineContent2;
+				}
+				if ($lineContent1 !== $lineContent2) {
+					if (isset($lines1[$lineNum]) && !isset($lines2[$lineNum])) {
+						// Ligne deleted de la source
+						$diff["Supprimée à la ligne " . ($lineNum + 1)] = $lineContent1;
+					} elseif (!isset($lines1[$lineNum]) && isset($lines2[$lineNum])) {
+						// Nouvelle ligne added dans la destination
+						$diff["Ajoutée à la ligne " . ($lineNum + 1)] = $lineContent2;
+					} else {
+						// Différence found it
+						$diff["Modifiée à la ligne " . ($lineNum + 1)] = $lineContent2;
+					}
 				}
 			}
 		}
 
 
-		if (empty($linesShouldnChange)) {
-			$linesShouldnChange[0] = '<meta name="dolibarr:pageid" content="'.$exceptNumPge[0].'" />';
-			$linesShouldnChange[1] = '$tmp = ob_get_contents(); ob_end_clean(); dolWebsiteOutput($tmp, "html", '.$exceptNumPge[0].');';
+		if (empty($linesShouldChange)) {
+			$linesShouldChange[0] = '<meta name="dolibarr:pageid" content="'.$exceptNumPge[0].'" />';
+			$linesShouldChange[1] = '$tmp = ob_get_contents(); ob_end_clean(); dolWebsiteOutput($tmp, "html", '.$exceptNumPge[0].');';
 		}
 
-		$pairesRemplacement = array();
-		if (!empty($linesShouldnNotChange)) {
-			$i =0;
-			foreach ($linesShouldnNotChange as $numLigne => $ligneRemplacement) {
-				if (isset($linesShouldnChange[$numLigne])) {
-					$pairesRemplacement[$ligneRemplacement] = $linesShouldnChange[$numLigne];
+		$replacementMapping = array();
+		if (!empty($linesShouldNotChange)) {
+			$i = 0;
+			foreach ($linesShouldNotChange as $numLigne => $ligneRemplacement) {
+				if (isset($linesShouldChange[$numLigne])) {
+					$replacementMapping[$ligneRemplacement] = $linesShouldChange[$numLigne];
 				} else {
-					$pairesRemplacement[$ligneRemplacement] = $linesShouldnChange[$i];
+					$replacementMapping[$ligneRemplacement] = $linesShouldChange[$i];
 				}
 				$i++;
 			}
-			$diff['lignes_dont_change'] = $pairesRemplacement;
+			$diff['lignes_dont_change'] = $replacementMapping;
 		}
-		// search path of image and replace it with the correcte path
-		$pattern = '/medias\/image\/'.$this->ref.'\/([^\'"\s]+)/';
+		// search path of image and replace it with the correct path
+		$pattern = '/medias\/image\/'.preg_quote($this->ref, '/').'\/([^\'"\s]+)/';
 
 		foreach ($diff as $key => $value) {
-			// Assurez-vous que la valeur est une chaîne
+			// Ensure the value is a string
 			if (is_string($value)) {
 				if (preg_match($pattern, $value)) {
 					$newValue = preg_replace($pattern, 'medias/image/'.$this->name_template.'/$1', $value);
@@ -2121,23 +2126,23 @@ class Website extends CommonObject
 	}
 
 	/**
-	 * Replace line by line in file using num of line
+	 * Replace line by line in file using numbers of the lines
 	 *
-	 * @param 	string 		$desfFile   	path of file dest
+	 * @param 	string 		$inplaceFile	path of file to modify in place
 	 * @param 	array 		$differences 	array of differences between files
 	 * @return 	int  						Return 0 if we can replace, <0 if not (-2=not writable)
 	 */
-	protected function replaceLineUsingNum($desfFile, $differences)
+	protected function replaceLineUsingNum($inplaceFile, $differences)
 	{
-		if (file_exists($desfFile)) {
-			dolChmod($desfFile, '0664');
+		if (file_exists($inplaceFile)) {
+			dolChmod($inplaceFile, '0664');
 		}
-		if (!is_writable($desfFile)) {
+		if (!is_writable($inplaceFile)) {
 			return -2;
 		}
 
 		unset($differences['file_destination']);
-		$contentDest = file($desfFile, FILE_IGNORE_NEW_LINES);
+		$contentDest = file($inplaceFile, FILE_IGNORE_NEW_LINES);
 		foreach ($differences as $key => $ligneSource) {
 			$matches = array();
 			if (preg_match('/(Ajoutée|Modifiée) à la ligne (\d+)/', $key, $matches)) {
@@ -2157,10 +2162,10 @@ class Website extends CommonObject
 		// Reindex the table keys
 		$contentDest = array_values($contentDest);
 		$stringreplacement = implode("\n", $contentDest);
-		file_put_contents($desfFile, $stringreplacement);
+		file_put_contents($inplaceFile, $stringreplacement);
 		foreach ($differences['lignes_dont_change'] as $linechanged => $line) {
 			if (in_array($linechanged, $contentDest)) {
-				dolReplaceInFile($desfFile, array($linechanged => $line));
+				dolReplaceInFile($inplaceFile, array($linechanged => $line));
 			}
 		}
 


### PR DESCRIPTION
# Fix: Spelling, PHan warnings, preg quoting, array size

Initial reasons:
website.class.php: PhanPluginSuspiciousParamOrder: Suspicious order for arguments named pathofwebsiteold and pathofwebsitenew - These are being passed to parameters #1 (string $srcfile) and #2 (string $destfile) of \dolCopyDir(string $srcfile, string $destfile, string $newmask, int $overwriteifexists, array&lt;string,string&gt; $arrayreplacement = null, int $excludesubdir = 0, string[] $excludefileext = null) defined at htdocs/core/lib/files.lib.php:871 Warning: website.class.php: PhanTypeArraySuspiciousNull: Suspicious array access to $linefound[1] of type null Warning: website.class.php: PhanTypeArraySuspiciousNull: Suspicious array access to $linefound[1] of type null

Also fixed spelling, added preg_quote, fixed spelling for several comments and variables