### PR TITLE
Qual: Review pre-commit configure - re-enable no-commit-to-branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,22 +5,30 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-      # This hook test the name of the branch and return error if the name is 'develop' or an official version 'x.y'
-      # so you can't commit if your branch name is not a custom branch name. Using a custom branch name is good
-      # practice that make easier to manage PR. You can enable/disable this if you want to commit or not on branch
-      # with common names.
-      #- id: no-commit-to-branch
-      #  args: [--branch, develop, --pattern, \d+.0]
-      # This check format of xml files
+      # This hook tests the name of the branch and return an error if the name is
+      #  'develop' or an official version 'x.y'
+      # So you can't commit if your branch name is not a custom branch name.
+      # Using a custom branch name is good practice that makes it easier to manage PRs.
+      # You can skip this:
+      #  - Permanently:
+      #      export SKIP=no-commit-to-branch   # In your .bashrc or session.
+      #  - Only this for one commit:
+      #      SKIP=no-commit-to-branch git commit -a -m "My message"
+      #  - Skipping all checks for a commit:
+      #      git commit -a -m "My message" --no-verify
+      #      (Recommendation: run git commit -a .. once, then with `--no-verify`)
+      - id: no-commit-to-branch
+        args: [--branch, develop, --pattern, \d+.0]
+      # This checks that xml files are correct
       - id: check-xml
         exclude: |
           (?x)^(htdocs/includes/.*)$
-      # This check format of yaml files
+      # This checks that yaml files are correct
       - id: check-yaml
         args: [--unsafe]
-      # This checl format of json files
+      # This checks that json files are correct
       - id: check-json
-      # Fix DOS end of files to get Unix end of files
+      # Fixes Fix files that have DOS end of line endings
       - id: mixed-line-ending
         # alternative for dev/tools/fixdosfiles.sh
         exclude: |
@@ -28,14 +36,14 @@ repos:
                |.*/CRLF.*.php  # Files in swiftmailer
                )$
         args: [--fix=lf]
-      # Remove trailing whitespace.
+      # Remove trailing whitespace
       - id: trailing-whitespace
         exclude_types: [markdown]
       # Fix the end of file
       - id: end-of-file-fixer
-      # Check if there is not completly merged conflict
+      # Check that there are no completely merged file conflicts
       - id: check-merge-conflict
-      # Chech the shebangs of shell files
+      # Check that files with shebangs have the executable bit set (in git)
       - id: check-executables-have-shebangs
       # Check that shell files are executables
       - id: check-shebang-scripts-are-executable
@@ -46,7 +54,7 @@ repos:
           |build/debian/dolibarr.config )$
       # Fix the first UTF8 byte
       - id: fix-byte-order-marker
-      # ???
+      # Check that there are no files that have are the same when uppercased (conflict on windows)
       - id: check-case-conflict
 
   # Beautify shell scripts
@@ -59,10 +67,10 @@ repos:
 
   # Run local script
   #
-  # For instance to update the license in edited files, you could add to local.sh:
+  # For example, to update the license in edited files, you could add to local.sh:
   #
   #   ```shell
-  #  #!/bin/bash
+  #   #!/bin/bash
   #   MYDIR=$(dirname "$0")
   #   git diff HEAD --name-only | grep -v includes | \
   #       xargs "$MYDIR/dev/tools/updatelicense.php"
@@ -183,8 +191,6 @@ repos:
           - dev/tools/codespell/codespell-ignore.txt
           - -x
           - dev/tools/codespell/codespell-lines-ignore.txt
-          - --uri-ignore-words-list
-          - ned
         exclude_types: [image]
         exclude: (?x)^(.phan/stubs/.*)$
         additional_dependencies: [tomli]

--- a/dev/tools/codespell/codespell-lines-ignore.txt
+++ b/dev/tools/codespell/codespell-lines-ignore.txt
@@ -265,6 +265,9 @@
 	public function getSumOfAmount($fuser = '', $dates = '', $datee = '')
 	return $TWeek;
 	unset($_SESSION["adresse"]);
+          - creat,unitl,alltime,datas,referers
+          - informations,medias,uptodate,reenable,crypted,developpers
+          - ned
  *	@param	array 		$TWeek			array of week numbers
  * @param	array		$TWeek					Array of week numbers
  * Copyright (C) 2019		Tim Otte    			<otte@meuser.it>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,9 @@ build-backend = "setuptools.build_meta"
 # `codespell` can be run as a standalone program from the CLI
 # with the appropriate default options.
 
-skip = "*/langs/*,*/build/exe/*,**.log,*.pdf,*dev/resources/*,*.phar,*.z,*.gz,*.sql,*.svg,*htdocs/includes/*,*/textiso.txt,*.js,*README-*,*build/rpm/*spec,*build/pad/*ml,*htdocs/includes/phpoffice/*,*htdocs/includes/tecnickcom/*,*dev/initdemo/removeconfdemo.sh,*dev/tools/codespell/*,*pyproject.toml,*build/exe/*,*fontawe*,*htdocs/theme/*/flags-sprite.inc.php,*dev/setup/codetemplates/codetemplates.xml,*/php.ini,*/html_cerfafr.*,*/lessc.class.php,*.asciidoc,*.xml,*opensurvey/css/style.css,*dev/tools/phan/stubs/*,*/documents"
+skip = "*/.*/*,*/langs/*,*/build/exe/*,**.log,*.pdf,*dev/resources/*,*.phar,*.z,*.gz,*.sql,*.svg,*htdocs/includes/*,*/textiso.txt,*.js,*README-*,*build/rpm/*spec,*build/pad/*ml,*htdocs/includes/phpoffice/*,*htdocs/includes/tecnickcom/*,*dev/initdemo/removeconfdemo.sh,*dev/tools/codespell/*,*pyproject.toml,*build/exe/*,*fontawe*,*htdocs/theme/*/flags-sprite.inc.php,*dev/setup/codetemplates/codetemplates.xml,*/php.ini,*/html_cerfafr.*,*/lessc.class.php,*.asciidoc,*.xml,*opensurvey/css/style.css,*dev/tools/phan/stubs/*,*/documents"
 
+check-hidden = true
 quiet-level=2
 ignore-regex = '\\[fnrstv]'
 builtin = "clear,rare,informal,usage,code,names"


### PR DESCRIPTION
# Qual: Review pre-commit configure - re-enable no-commit-to-branch

This reviews some of the documentation inside the pre-commit-config.yaml file. It also re-enables the no-commit-to-branch hook.

@eldy Just add
```bash
export SKIP=no-commit-to-branch   # In your .bashrc or session.
```

I've been commiting to develop several times now by mistake which could have been avoided with this hook.
It should be enabled for all of us, you're the exception (and you should be working in branches for some stuff).