### PR TITLE
Fix: Spelling in "hidden" files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -556,18 +556,18 @@ after_failure:
     # Show upgrade log files
     #for ficlog in `ls $TRAVIS_BUILD_DIR/*.log`
     #do
-      #echo "Debugging informations for file $ficlog"
+      #echo "Debugging information for file $ficlog"
       #cat $ficlog
     #done
     # Show Apache log file
-    echo "Debugging informations for file apache error.log"
+    echo "Debugging information for file apache error.log"
     sudo tail -n 200 /var/log/apache2/travis_error_log
     if [ "$DEBUG" = true ]; then
       # Dolibarr log file
-      echo "Debugging informations for file dolibarr.log (latest 50 lines)"
+      echo "Debugging information for file dolibarr.log (latest 50 lines)"
       tail -n 200 $TRAVIS_BUILD_DIR/documents/dolibarr.log
       # Database log file
-      echo "Debugging informations for file mysql error.log"
+      echo "Debugging information for file mysql error.log"
       sudo tail -n 200 /var/log/mysql/error.log
       # TODO: PostgreSQL log file
       echo

--- a/build/debian/apache/.htaccess
+++ b/build/debian/apache/.htaccess
@@ -8,7 +8,7 @@ Denied from all
 </IfVersion>
 
 
-# OPTIMIZE: To use cache on static pages (A259200 = 1 month, A7200 = 2 hours, A691600 = 8 days = recommanded for static resources).
+# OPTIMIZE: To use cache on static pages (A259200 = 1 month, A7200 = 2 hours, A691600 = 8 days = recommended for static resources).
 # Note that you must also enable the module mod_expires.
 #ExpiresActive On
 #ExpiresByType image/x-icon A2592000

--- a/dev/tools/php-cs-fixer/.php-cs-fixer.dist.php
+++ b/dev/tools/php-cs-fixer/.php-cs-fixer.dist.php
@@ -39,7 +39,7 @@ return (new PhpCsFixer\Config())
 
 		// Minimum version Dolibarr v18.0.0
 		// Compatibility with min 7.1 is announced with Dolibarr18.0 but
-		// app is still working with 7.0 so no reason to abandon compatiblity with this target for the moment.
+		// app is still working with 7.0 so no reason to abandon compatibility with this target for the moment.
 		// So we use target PHP70 for the moment.
 		'@PHP70Migration' => true,
 		//'@PHP71Migration' => true,


### PR DESCRIPTION
# Fix: Spelling in "hidden" files

Codespell was not active on hidden files - it will be and this corrects the spelling.