### PR TITLE
Qual: Add custom phan plugin to detect var_dump

### DIFF
--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -83,6 +83,7 @@ return [
 	// Alternately, you can pass in the full path to a PHP file
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
 	'plugins' => [
+		__DIR__.'/plugins/NoVarDumpPlugin.php',
 		// checks if a function, closure or method unconditionally returns.
 		// can also be written as 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php'
 		//'DeprecateAliasPlugin',
@@ -149,9 +150,13 @@ return [
 		'PhanPluginShortArray',
 		'PhanPluginNumericalComparison',
 		'PhanPluginUnknownObjectMethodCall',
-		'PhanPluginCanUseParamType',
 		'PhanPluginNonBoolInLogicalArith',
-		'PhanPluginCanUseReturnType',
+		// Fixers From PHPDocToRealTypesPlugin:
+		'PhanPluginCanUseParamType',			// Fixer - Report/Add types in the function definition (function abc(string $var) (adds string)
+		'PhanPluginCanUseReturnType',			// Fixer - Report/Add return types in the function definition (function abc(string $var) (adds string)
+		'PhanPluginCanUseNullableParamType',	// Fixer - Report/Add nullable parameter types in the function definition
+		'PhanPluginCanUseNullableReturnType',	// Fixer - Report/Add nullable return types in the function definition
+
 		// 'PhanPluginNotFullyQualifiedFunctionCall',
 		'PhanPluginConstantVariableScalar',
 		// 'PhanPluginNoCommentOnPublicProperty',
@@ -166,7 +171,6 @@ return [
 		'PhanPluginUnknownArrayMethodReturnType',
 		'PhanTypeMismatchArgumentInternal',
 		'PhanPluginDuplicateAdjacentStatement',
-		'PhanPluginCanUseNullableParamType',
 		'PhanTypeInvalidLeftOperandOfNumericOp',
 		'PhanTypeMismatchProperty',
 		// 'PhanPluginNoCommentOnPublicMethod',
@@ -190,7 +194,6 @@ return [
 		'PhanTypeInvalidLeftOperandOfAdd',
 		// 'PhanPluginNoCommentOnPrivateProperty',
 		// 'PhanPluginNoCommentOnFunction',
-		'PhanPluginCanUseNullableReturnType',
 		'PhanPluginUnknownArrayFunctionParamType',
 		// 'PhanPluginDescriptionlessCommentOnPublicProperty',
 		'PhanPluginUnknownFunctionParamType',

--- a/dev/tools/phan/config_extended.php
+++ b/dev/tools/phan/config_extended.php
@@ -83,6 +83,7 @@ return [
 	// Alternately, you can pass in the full path to a PHP file
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
 	'plugins' => [
+		__DIR__.'/plugins/NoVarDumpPlugin.php',
 		'DeprecateAliasPlugin',
 		//'EmptyMethodAndFunctionPlugin',
 		'InvalidVariableIssetPlugin',
@@ -102,7 +103,7 @@ return [
 		'NonBoolBranchPlugin', // Requires test on bool, nont on ints
 		'NonBoolInLogicalArithPlugin',
 		'NumericalComparisonPlugin',
-		'PHPDocToRealTypesPlugin',
+		// 'PHPDocToRealTypesPlugin',  // Report/Add types to function definitions
 		'PHPDocInWrongCommentPlugin', // Missing /** (/* was used)
 		//'ShortArrayPlugin', // Checks that [] is used
 		//'StrictLiteralComparisonPlugin',
@@ -138,10 +139,11 @@ return [
 		'PhanPluginCanUsePHP71Void',	// Dolibarr is maintaining 7.0 compatibility
 		'PhanPluginShortArray',			// Dolibarr uses array()
 		'PhanPluginShortArrayList',		// Dolibarr uses array()
-		// The following may require that --quick is not used
-		'PhanPluginCanUseParamType',	// Does not seem useful: is reporting types already in PHPDoc?
-		'PhanPluginCanUseReturnType',	// Does not seem useful: is reporting types already in PHPDoc?
-		'PhanPluginCanUseNullableParamType',	// Does not seem useful: is reporting types already in PHPDoc?
+		// Fixers From PHPDocToRealTypesPlugin:
+		'PhanPluginCanUseParamType',			// Fixer - Report/Add types in the function definition (function abc(string $var) (adds string)
+		'PhanPluginCanUseReturnType',			// Fixer - Report/Add return types in the function definition (function abc(string $var) (adds string)
+		'PhanPluginCanUseNullableParamType',	// Fixer - Report/Add nullable parameter types in the function definition
+		'PhanPluginCanUseNullableReturnType',	// Fixer - Report/Add nullable return types in the function definition
 		'PhanPluginNonBoolBranch',			// Not essential - 31240+ occurrences
 		'PhanPluginNumericalComparison',	// Not essential - 19870+ occurrences
 		'PhanTypeMismatchArgument',			// Not essential - 12300+ occurrences

--- a/dev/tools/phan/plugins/NoVarDumpPlugin.php
+++ b/dev/tools/phan/plugins/NoVarDumpPlugin.php
@@ -1,0 +1,81 @@
+<?php
+/* Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ */
+
+declare(strict_types=1);
+
+use ast\Node;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
+
+/**
+ * NoVarDumpPlugin hooks into one event:
+ *
+ * - getPostAnalyzeNodeVisitorClassName
+ *   This method returns a visitor that is called on every AST node from every
+ *   file being analyzed
+ *
+ * A plugin file must
+ *
+ * - Contain a class that inherits from \Phan\PluginV3
+ *
+ * - End by returning an instance of that class.
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ */
+class NoVarDumpPlugin extends PluginV3 implements PostAnalyzeNodeCapability
+{
+	/**
+	 * @return string - name of PluginAwarePostAnalysisVisitor subclass
+	 */
+	public static function getPostAnalyzeNodeVisitorClassName(): string
+	{
+		return NoVarDumpVisitor::class;
+	}
+}
+
+/**
+ * When __invoke on this class is called with a node, a method
+ * will be dispatched based on the `kind` of the given node.
+ *
+ * Visitors such as this are useful for defining lots of different
+ * checks on a node based on its kind.
+ */
+class NoVarDumpVisitor extends PluginAwarePostAnalysisVisitor
+{
+	// A plugin's visitors should not override visit() unless they need to.
+
+	/**
+	 * @param Node $node A node to analyze
+	 *
+	 * @return void
+	 *
+	 * @override
+	 */
+	public function visitCall(Node $node): void
+	{
+		$name = $node->children['expr']->children['name'] ?? null;
+		if (!is_string($name)) {
+			return;
+		}
+		if (strcasecmp($name, 'var_dump') !== 0) {
+			return;
+		}
+		$this->emitPluginIssue(
+			$this->code_base,
+			$this->context,
+			'NoVarDumpPlugin',
+			'var_dump() should be commented in submitted code',
+			[]
+		);
+	}
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new NoVarDumpPlugin();


### PR DESCRIPTION
# Qual: Add custom phan plugin to detect var_dump

This adds a custom plugin to detect the presence of var_dump.

Also disable a standard plugin in the extended configuration (avoid reporting suggestions to add typing to the function definitions (/declarations).