### PR TITLE
Qual: New Phan plugin for testing that argument matches regex

### DIFF
--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -4,6 +4,43 @@
 define('DOL_PROJECT_ROOT', __DIR__.'/../../..');
 define('DOL_DOCUMENT_ROOT', DOL_PROJECT_ROOT.'/htdocs');
 define('PHAN_DIR', __DIR__);
+$dolPostFilter
+	= '/^(array:)?(?:'.implode(
+		'|',
+		array(
+			// Documented:
+			'none',
+			'array',
+			'int',
+			'intcomma',
+			'alpha',
+			'alphawithlgt',
+			'alphanohtml',
+			'MS',
+			'aZ',
+			'aZ09',
+			'aZ09arobase',
+			'aZ09comma',
+			'san_alpha',
+			'restricthtml',
+			'nohtml',
+			'custom',
+			// Not documented:
+			'email',
+			'restricthtmlallowclass',
+			'restricthtmlallowunvalid',
+			'restricthtmlnolink',
+			//'ascii',
+			//'categ_id',
+			//'chaine',
+
+			//'html',
+			//'boolean',
+			//'double',
+			//'float',
+			//'string',
+		)
+	).')*$/';
 /**
  * This configuration will be read and overlaid on top of the
  * default configuration. Command line arguments will be applied
@@ -71,6 +108,7 @@ return [
 		.'|htdocs/includes/restler/.*'  // @phpstan-ignore-line
 		// Included as stub (did not seem properly analysed by phan without it)
 		.'|htdocs/includes/stripe/.*'  // @phpstan-ignore-line
+		// .'|htdocs/[^h].*/.*'  // For testing @phpstan-ignore-line
 		.')@',  // @phpstan-ignore-line
 
 	// A list of plugin files to execute.
@@ -82,8 +120,12 @@ return [
 	//
 	// Alternately, you can pass in the full path to a PHP file
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
+	'ParamMatchRegexPlugin' => [
+		'/^GETPOST$/' => [1, $dolPostFilter],
+	],
 	'plugins' => [
 		__DIR__.'/plugins/NoVarDumpPlugin.php',
+		__DIR__.'/plugins/ParamMatchRegexPlugin.php',
 		// checks if a function, closure or method unconditionally returns.
 		// can also be written as 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php'
 		//'DeprecateAliasPlugin',

--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -183,7 +183,7 @@ $VALID_MODULE_MAPPING = array(
 	'zapier' => 'Zapier',
 );
 
-$moduleNameRegex = '/^(?:'.implode('|', array_merge(array_keys($DEPRECATED_MODULE_MAPPING), array_keys($VALID_MODULE_MAPPING))).')$/';
+$moduleNameRegex = '/^(?:'.implode('|', array_merge(array_keys($DEPRECATED_MODULE_MAPPING), array_keys($VALID_MODULE_MAPPING), array('\$modulename'))).')$/';
 
 /**
  * This configuration will be read and overlaid on top of the

--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -4,7 +4,7 @@
 define('DOL_PROJECT_ROOT', __DIR__.'/../../..');
 define('DOL_DOCUMENT_ROOT', DOL_PROJECT_ROOT.'/htdocs');
 define('PHAN_DIR', __DIR__);
-$dolPostFilter
+$sanitizeRegex
 	= '/^(array:)?(?:'.implode(
 		'|',
 		array(
@@ -73,7 +73,7 @@ $VALID_MODULE_MAPPING = array(
 	'accounting' => 'Accounting',
 	'agenda' => 'Agenda',
 	'ai' => 'Ai',
-	'anothermodule' => null,  // Not used in code, used in translations.lang
+	'anothermodule' => null,
 	'api' => 'Api',
 	'asset' => 'Asset',
 	'bank' => 'Banque',
@@ -82,10 +82,10 @@ $VALID_MODULE_MAPPING = array(
 	'bom' => 'Bom',
 	'bookcal' => 'BookCal',
 	'bookmark' => 'Bookmark',
-	'cashdesk' => null,
+	'cashdesk' => null,  // TODO: fill in proper class
 	'category' => 'Categorie',
 	'clicktodial' => 'ClickToDial',
-	'collab' => 'Collab',  // TODO: fill in proper name
+	'collab' => 'Collab',
 	'comptabilite' => 'Comptabilite',
 	'contact' => null,  // TODO: fill in proper class
 	'contract' => 'Contrat',
@@ -95,7 +95,7 @@ $VALID_MODULE_MAPPING = array(
 	'debugbar' => 'DebugBar',
 	'delivery_note' => 'Expedition',
 	'deplacement' => 'Deplacement',
-	"documentgeneration" => 'DocumentGeneration',  // TODO: fill in proper name
+	"documentgeneration" => 'DocumentGeneration',
 	'don' => 'Don',
 	'dynamicprices' => 'DynamicPrices',
 	'ecm' => 'ECM',
@@ -104,12 +104,12 @@ $VALID_MODULE_MAPPING = array(
 	'eventorganization' => 'EventOrganization',
 	'expensereport' => 'ExpenseReport',
 	'export' => 'Export',
-	'externalrss' => 'ExternalRss',  // TODO: fill in proper name
+	'externalrss' => 'ExternalRss',
 	'externalsite' => 'ExternalSite',
 	'fckeditor' => 'Fckeditor',
 	'fournisseur' => 'Fournisseur',
 	'ftp' => 'FTP',
-	'geoipmaxmind' => 'GeoIPMaxmind',  // TODO: fill in proper name
+	'geoipmaxmind' => 'GeoIPMaxmind',
 	'google' => null,  // External ?
 	'gravatar' => 'Gravatar',
 	'holiday' => 'Holiday',
@@ -146,7 +146,7 @@ $VALID_MODULE_MAPPING = array(
 	'paypal' => 'Paypal',
 	'paypalplus' => null,
 	'prelevement' => 'Prelevement',
-	'printing' => 'Printing', // TODO: set proper name
+	'printing' => 'Printing',
 	'product' => 'Product',
 	'productbatch' => 'ProductBatch',
 	'productprice' => null,
@@ -176,7 +176,7 @@ $VALID_MODULE_MAPPING = array(
 	'webhook' => 'Webhook',
 	'webportal' => 'WebPortal',
 	'webservices' => 'WebServices',
-	'webservicesclient' => 'WebServicesClient',  // TODO: set proper name
+	'webservicesclient' => 'WebServicesClient',
 	'website' => 'Website',
 	'workflow' => 'Workflow',
 	'workstation' => 'Workstation',
@@ -265,8 +265,9 @@ return [
 	// Alternately, you can pass in the full path to a PHP file
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
 	'ParamMatchRegexPlugin' => [
-		'/^GETPOST$/' => [1, $dolPostFilter],
+		'/^GETPOST$/' => [1, $sanitizeRegex],
 		'/^isModEnabled$/' => [0, $moduleNameRegex],
+		'/^sanitizeVal$/' => [1, $sanitizeRegex],
 	],
 	'plugins' => [
 		__DIR__.'/plugins/NoVarDumpPlugin.php',

--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -41,6 +41,150 @@ $dolPostFilter
 			//'string',
 		)
 	).')*$/';
+
+/**
+ * Map deprecated module names to new module names
+ */
+$DEPRECATED_MODULE_MAPPING = array(
+	'actioncomm' => 'agenda',
+	'adherent' => 'member',
+	'adherent_type' => 'member_type',
+	'banque' => 'bank',
+	'categorie' => 'category',
+	'commande' => 'order',
+	'contrat' => 'contract',
+	'entrepot' => 'stock',
+	'expedition' => 'delivery_note',
+	'facture' => 'invoice',
+	'ficheinter' => 'intervention',
+	'product_fournisseur_price' => 'productsupplierprice',
+	'product_price' => 'productprice',
+	'projet'  => 'project',
+	'propale' => 'propal',
+	'socpeople' => 'contact',
+);
+
+/**
+ * Map module names to the 'class' name (the class is: mod<CLASSNAME>)
+ * Value is null when the module is not internal to the default
+ * Dolibarr setup.
+ */
+$VALID_MODULE_MAPPING = array(
+	'accounting' => 'Accounting',
+	'agenda' => 'Agenda',
+	'ai' => 'Ai',
+	'anothermodule' => null,  // Not used in code, used in translations.lang
+	'api' => 'Api',
+	'asset' => 'Asset',
+	'bank' => 'Banque',
+	'barcode' => 'Barcode',
+	'blockedlog' => 'BlockedLog',
+	'bom' => 'Bom',
+	'bookcal' => 'BookCal',
+	'bookmark' => 'Bookmark',
+	'cashdesk' => null,
+	'category' => 'Categorie',
+	'clicktodial' => 'ClickToDial',
+	'collab' => 'Collab',  // TODO: fill in proper name
+	'comptabilite' => 'Comptabilite',
+	'contact' => null,  // TODO: fill in proper class
+	'contract' => 'Contrat',
+	'cron' => 'Cron',
+	'datapolicy' => 'DataPolicy',
+	'dav' => 'Dav',
+	'debugbar' => 'DebugBar',
+	'delivery_note' => 'Expedition',
+	'deplacement' => 'Deplacement',
+	"documentgeneration" => 'DocumentGeneration',  // TODO: fill in proper name
+	'don' => 'Don',
+	'dynamicprices' => 'DynamicPrices',
+	'ecm' => 'ECM',
+	'ecotax' => null,  // TODO: External module ?
+	'emailcollector' => 'EmailCollector',
+	'eventorganization' => 'EventOrganization',
+	'expensereport' => 'ExpenseReport',
+	'export' => 'Export',
+	'externalrss' => 'ExternalRss',  // TODO: fill in proper name
+	'externalsite' => 'ExternalSite',
+	'fckeditor' => 'Fckeditor',
+	'fournisseur' => 'Fournisseur',
+	'ftp' => 'FTP',
+	'geoipmaxmind' => 'GeoIPMaxmind',  // TODO: fill in proper name
+	'google' => null,  // External ?
+	'gravatar' => 'Gravatar',
+	'holiday' => 'Holiday',
+	'hrm' => 'HRM',
+	'import' => 'Import',
+	'incoterm' => 'Incoterm',
+	'intervention' => 'Ficheinter',
+	'intracommreport' => 'Intracommreport',
+	'invoice' => 'Facture',
+	'knowledgemanagement' => 'KnowledgeManagement',
+	'label' => 'Label',
+	'ldap' => 'Ldap',
+	'loan' => 'Loan',
+	'mailing' => 'Mailing',
+	'mailman' => null,  // Same module as mailmanspip -> MailmanSpip ??
+	'mailmanspip' => 'MailmanSpip',
+	'margin' => 'Margin',
+	'member' => 'Adherent',
+	'memcached' => null, // TODO: External module?
+	'modulebuilder' => 'ModuleBuilder',
+	'mrp' => 'Mrp',
+	'multicompany' => null, // Not provided by default, no module tests
+	'multicurrency' => 'MultiCurrency',
+	'mymodule' => null, // modMyModule - Name used in module builder (avoid false positives)
+	'notification' => 'Notification',
+	'numberwords' => null, // Not provided by default, no module tests
+	'oauth' => 'Oauth',
+	'openstreetmap' => null,  // External module?
+	'opensurvey' => 'OpenSurvey',
+	'order' => 'Commande',
+	'partnership' => 'Partnership',
+	'paybox' => 'Paybox',
+	'paymentbybanktransfer' => 'PaymentByBankTransfer',
+	'paypal' => 'Paypal',
+	'paypalplus' => null,
+	'prelevement' => 'Prelevement',
+	'printing' => 'Printing', // TODO: set proper name
+	'product' => 'Product',
+	'productbatch' => 'ProductBatch',
+	'productprice' => null,
+	'productsupplierprice' => null,
+	'project' => 'Projet',
+	'propal' => 'Propale',
+	'receiptprinter' => 'ReceiptPrinter',
+	'reception' => 'Reception',
+	'recruitment' => 'Recruitment',
+	'resource' => 'Resource',
+	'salaries' => 'Salaries',
+	'service' => 'Service',
+	'socialnetworks' => 'SocialNetworks',
+	'societe' => 'Societe',
+	'stock' => 'Stock',
+	'stocktransfer' => 'StockTransfer',
+	'stripe' => 'Stripe',
+	'supplier_invoice' => null,  // Special case, uses invoice
+	'supplier_order' => null,  // Special case, uses invoice
+	'supplier_proposal' => 'SupplierProposal',
+	'syslog' => 'Syslog',
+	'takepos' => 'TakePos',
+	'tax' => 'Tax',
+	'ticket' => 'Ticket',
+	'user' => 'User',
+	'variants' => 'Variants',
+	'webhook' => 'Webhook',
+	'webportal' => 'WebPortal',
+	'webservices' => 'WebServices',
+	'webservicesclient' => 'WebServicesClient',  // TODO: set proper name
+	'website' => 'Website',
+	'workflow' => 'Workflow',
+	'workstation' => 'Workstation',
+	'zapier' => 'Zapier',
+);
+
+$moduleNameRegex = '/^(?:'.implode('|', array_merge(array_keys($DEPRECATED_MODULE_MAPPING), array_keys($VALID_MODULE_MAPPING))).')$/';
+
 /**
  * This configuration will be read and overlaid on top of the
  * default configuration. Command line arguments will be applied
@@ -122,6 +266,7 @@ return [
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
 	'ParamMatchRegexPlugin' => [
 		'/^GETPOST$/' => [1, $dolPostFilter],
+		'/^isModEnabled$/' => [0, $moduleNameRegex],
 	],
 	'plugins' => [
 		__DIR__.'/plugins/NoVarDumpPlugin.php',

--- a/dev/tools/phan/config_extended.php
+++ b/dev/tools/phan/config_extended.php
@@ -43,6 +43,149 @@ $dolPostFilter
 	).')*$/';
 
 /**
+ * Map deprecated module names to new module names
+ */
+$DEPRECATED_MODULE_MAPPING = array(
+	'actioncomm' => 'agenda',
+	'adherent' => 'member',
+	'adherent_type' => 'member_type',
+	'banque' => 'bank',
+	'categorie' => 'category',
+	'commande' => 'order',
+	'contrat' => 'contract',
+	'entrepot' => 'stock',
+	'expedition' => 'delivery_note',
+	'facture' => 'invoice',
+	'ficheinter' => 'intervention',
+	'product_fournisseur_price' => 'productsupplierprice',
+	'product_price' => 'productprice',
+	'projet'  => 'project',
+	'propale' => 'propal',
+	'socpeople' => 'contact',
+);
+
+/**
+ * Map module names to the 'class' name (the class is: mod<CLASSNAME>)
+ * Value is null when the module is not internal to the default
+ * Dolibarr setup.
+ */
+$VALID_MODULE_MAPPING = array(
+	'accounting' => 'Accounting',
+	'agenda' => 'Agenda',
+	'ai' => 'Ai',
+	'anothermodule' => null,  // Not used in code, used in translations.lang
+	'api' => 'Api',
+	'asset' => 'Asset',
+	'bank' => 'Banque',
+	'barcode' => 'Barcode',
+	'blockedlog' => 'BlockedLog',
+	'bom' => 'Bom',
+	'bookcal' => 'BookCal',
+	'bookmark' => 'Bookmark',
+	'cashdesk' => null,
+	'category' => 'Categorie',
+	'clicktodial' => 'ClickToDial',
+	'collab' => 'Collab',  // TODO: fill in proper name
+	'comptabilite' => 'Comptabilite',
+	'contact' => null,  // TODO: fill in proper class
+	'contract' => 'Contrat',
+	'cron' => 'Cron',
+	'datapolicy' => 'DataPolicy',
+	'dav' => 'Dav',
+	'debugbar' => 'DebugBar',
+	'delivery_note' => 'Expedition',
+	'deplacement' => 'Deplacement',
+	"documentgeneration" => 'DocumentGeneration',  // TODO: fill in proper name
+	'don' => 'Don',
+	'dynamicprices' => 'DynamicPrices',
+	'ecm' => 'ECM',
+	'ecotax' => null,  // TODO: External module ?
+	'emailcollector' => 'EmailCollector',
+	'eventorganization' => 'EventOrganization',
+	'expensereport' => 'ExpenseReport',
+	'export' => 'Export',
+	'externalrss' => 'ExternalRss',  // TODO: fill in proper name
+	'externalsite' => 'ExternalSite',
+	'fckeditor' => 'Fckeditor',
+	'fournisseur' => 'Fournisseur',
+	'ftp' => 'FTP',
+	'geoipmaxmind' => 'GeoIPMaxmind',  // TODO: fill in proper name
+	'google' => null,  // External ?
+	'gravatar' => 'Gravatar',
+	'holiday' => 'Holiday',
+	'hrm' => 'HRM',
+	'import' => 'Import',
+	'incoterm' => 'Incoterm',
+	'intervention' => 'Ficheinter',
+	'intracommreport' => 'Intracommreport',
+	'invoice' => 'Facture',
+	'knowledgemanagement' => 'KnowledgeManagement',
+	'label' => 'Label',
+	'ldap' => 'Ldap',
+	'loan' => 'Loan',
+	'mailing' => 'Mailing',
+	'mailman' => null,  // Same module as mailmanspip -> MailmanSpip ??
+	'mailmanspip' => 'MailmanSpip',
+	'margin' => 'Margin',
+	'member' => 'Adherent',
+	'memcached' => null, // TODO: External module?
+	'modulebuilder' => 'ModuleBuilder',
+	'mrp' => 'Mrp',
+	'multicompany' => null, // Not provided by default, no module tests
+	'multicurrency' => 'MultiCurrency',
+	'mymodule' => null, // modMyModule - Name used in module builder (avoid false positives)
+	'notification' => 'Notification',
+	'numberwords' => null, // Not provided by default, no module tests
+	'oauth' => 'Oauth',
+	'openstreetmap' => null,  // External module?
+	'opensurvey' => 'OpenSurvey',
+	'order' => 'Commande',
+	'partnership' => 'Partnership',
+	'paybox' => 'Paybox',
+	'paymentbybanktransfer' => 'PaymentByBankTransfer',
+	'paypal' => 'Paypal',
+	'paypalplus' => null,
+	'prelevement' => 'Prelevement',
+	'printing' => 'Printing', // TODO: set proper name
+	'product' => 'Product',
+	'productbatch' => 'ProductBatch',
+	'productprice' => null,
+	'productsupplierprice' => null,
+	'project' => 'Projet',
+	'propal' => 'Propale',
+	'receiptprinter' => 'ReceiptPrinter',
+	'reception' => 'Reception',
+	'recruitment' => 'Recruitment',
+	'resource' => 'Resource',
+	'salaries' => 'Salaries',
+	'service' => 'Service',
+	'socialnetworks' => 'SocialNetworks',
+	'societe' => 'Societe',
+	'stock' => 'Stock',
+	'stocktransfer' => 'StockTransfer',
+	'stripe' => 'Stripe',
+	'supplier_invoice' => null,  // Special case, uses invoice
+	'supplier_order' => null,  // Special case, uses invoice
+	'supplier_proposal' => 'SupplierProposal',
+	'syslog' => 'Syslog',
+	'takepos' => 'TakePos',
+	'tax' => 'Tax',
+	'ticket' => 'Ticket',
+	'user' => 'User',
+	'variants' => 'Variants',
+	'webhook' => 'Webhook',
+	'webportal' => 'WebPortal',
+	'webservices' => 'WebServices',
+	'webservicesclient' => 'WebServicesClient',  // TODO: set proper name
+	'website' => 'Website',
+	'workflow' => 'Workflow',
+	'workstation' => 'Workstation',
+	'zapier' => 'Zapier',
+);
+
+$moduleNameRegex = '/^(?:'.implode('|', array_merge(array_keys($DEPRECATED_MODULE_MAPPING), array_keys($VALID_MODULE_MAPPING))).')$/';
+
+/**
  * This configuration will be read and overlaid on top of the
  * default configuration. Command line arguments will be applied
  * after this file is read.
@@ -122,6 +265,7 @@ return [
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
 	'ParamMatchRegexPlugin' => [
 		'/^GETPOST$/' => [1, $dolPostFilter],
+		'/^isModEnabled$/' => [0, $moduleNameRegex],
 	],
 	'plugins' => [
 		__DIR__.'/plugins/NoVarDumpPlugin.php',

--- a/dev/tools/phan/config_extended.php
+++ b/dev/tools/phan/config_extended.php
@@ -4,7 +4,7 @@
 define('DOL_PROJECT_ROOT', __DIR__.'/../../..');
 define('DOL_DOCUMENT_ROOT', DOL_PROJECT_ROOT.'/htdocs');
 define('PHAN_DIR', __DIR__);
-$dolPostFilter
+$sanitizeRegex
 	= '/^(array:)?(?:'.implode(
 		'|',
 		array(
@@ -73,7 +73,7 @@ $VALID_MODULE_MAPPING = array(
 	'accounting' => 'Accounting',
 	'agenda' => 'Agenda',
 	'ai' => 'Ai',
-	'anothermodule' => null,  // Not used in code, used in translations.lang
+	'anothermodule' => null,
 	'api' => 'Api',
 	'asset' => 'Asset',
 	'bank' => 'Banque',
@@ -82,10 +82,10 @@ $VALID_MODULE_MAPPING = array(
 	'bom' => 'Bom',
 	'bookcal' => 'BookCal',
 	'bookmark' => 'Bookmark',
-	'cashdesk' => null,
+	'cashdesk' => null,  // TODO: fill in proper class
 	'category' => 'Categorie',
 	'clicktodial' => 'ClickToDial',
-	'collab' => 'Collab',  // TODO: fill in proper name
+	'collab' => 'Collab',
 	'comptabilite' => 'Comptabilite',
 	'contact' => null,  // TODO: fill in proper class
 	'contract' => 'Contrat',
@@ -95,7 +95,7 @@ $VALID_MODULE_MAPPING = array(
 	'debugbar' => 'DebugBar',
 	'delivery_note' => 'Expedition',
 	'deplacement' => 'Deplacement',
-	"documentgeneration" => 'DocumentGeneration',  // TODO: fill in proper name
+	"documentgeneration" => 'DocumentGeneration',
 	'don' => 'Don',
 	'dynamicprices' => 'DynamicPrices',
 	'ecm' => 'ECM',
@@ -104,12 +104,12 @@ $VALID_MODULE_MAPPING = array(
 	'eventorganization' => 'EventOrganization',
 	'expensereport' => 'ExpenseReport',
 	'export' => 'Export',
-	'externalrss' => 'ExternalRss',  // TODO: fill in proper name
+	'externalrss' => 'ExternalRss',
 	'externalsite' => 'ExternalSite',
 	'fckeditor' => 'Fckeditor',
 	'fournisseur' => 'Fournisseur',
 	'ftp' => 'FTP',
-	'geoipmaxmind' => 'GeoIPMaxmind',  // TODO: fill in proper name
+	'geoipmaxmind' => 'GeoIPMaxmind',
 	'google' => null,  // External ?
 	'gravatar' => 'Gravatar',
 	'holiday' => 'Holiday',
@@ -146,7 +146,7 @@ $VALID_MODULE_MAPPING = array(
 	'paypal' => 'Paypal',
 	'paypalplus' => null,
 	'prelevement' => 'Prelevement',
-	'printing' => 'Printing', // TODO: set proper name
+	'printing' => 'Printing',
 	'product' => 'Product',
 	'productbatch' => 'ProductBatch',
 	'productprice' => null,
@@ -176,7 +176,7 @@ $VALID_MODULE_MAPPING = array(
 	'webhook' => 'Webhook',
 	'webportal' => 'WebPortal',
 	'webservices' => 'WebServices',
-	'webservicesclient' => 'WebServicesClient',  // TODO: set proper name
+	'webservicesclient' => 'WebServicesClient',
 	'website' => 'Website',
 	'workflow' => 'Workflow',
 	'workstation' => 'Workstation',
@@ -264,8 +264,9 @@ return [
 	// Alternately, you can pass in the full path to a PHP file
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
 	'ParamMatchRegexPlugin' => [
-		'/^GETPOST$/' => [1, $dolPostFilter],
+		'/^GETPOST$/' => [1, $sanitizeRegex],
 		'/^isModEnabled$/' => [0, $moduleNameRegex],
+		'/^sanitizeVal$/' => [1, $sanitizeRegex],
 	],
 	'plugins' => [
 		__DIR__.'/plugins/NoVarDumpPlugin.php',

--- a/dev/tools/phan/config_fixer.php
+++ b/dev/tools/phan/config_fixer.php
@@ -4,44 +4,6 @@
 define('DOL_PROJECT_ROOT', __DIR__.'/../../..');
 define('DOL_DOCUMENT_ROOT', DOL_PROJECT_ROOT.'/htdocs');
 define('PHAN_DIR', __DIR__);
-$dolPostFilter
-	= '/^(array:)?(?:'.implode(
-		'|',
-		array(
-			// Documented:
-			'none',
-			'array',
-			'int',
-			'intcomma',
-			'alpha',
-			'alphawithlgt',
-			'alphanohtml',
-			'MS',
-			'aZ',
-			'aZ09',
-			'aZ09arobase',
-			'aZ09comma',
-			'san_alpha',
-			'restricthtml',
-			'nohtml',
-			'custom',
-			// Not documented:
-			'email',
-			'restricthtmlallowclass',
-			'restricthtmlallowunvalid',
-			'restricthtmlnolink',
-			//'ascii',
-			//'categ_id',
-			//'chaine',
-
-			//'html',
-			//'boolean',
-			//'double',
-			//'float',
-			//'string',
-		)
-	).')*$/';
-
 /**
  * This configuration will be read and overlaid on top of the
  * default configuration. Command line arguments will be applied
@@ -120,13 +82,12 @@ return [
 	//
 	// Alternately, you can pass in the full path to a PHP file
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
-	'ParamMatchRegexPlugin' => [
-		'/^GETPOST$/' => [1, $dolPostFilter],
-	],
 	'plugins' => [
-		__DIR__.'/plugins/NoVarDumpPlugin.php',
-		__DIR__.'/plugins/ParamMatchRegexPlugin.php',
-		'DeprecateAliasPlugin',
+		//'DeprecateAliasPlugin',
+		// __DIR__.'/plugins/NoVarDumpPlugin.php',
+		//'PHPDocToRealTypesPlugin',
+
+	/*
 		//'EmptyMethodAndFunctionPlugin',
 		'InvalidVariableIssetPlugin',
 		//'MoreSpecificElementTypePlugin',
@@ -145,7 +106,7 @@ return [
 		'NonBoolBranchPlugin', // Requires test on bool, nont on ints
 		'NonBoolInLogicalArithPlugin',
 		'NumericalComparisonPlugin',
-		// 'PHPDocToRealTypesPlugin',  // Report/Add types to function definitions
+		'PHPDocToRealTypesPlugin',
 		'PHPDocInWrongCommentPlugin', // Missing /** (/* was used)
 		//'ShortArrayPlugin', // Checks that [] is used
 		//'StrictLiteralComparisonPlugin',
@@ -153,7 +114,6 @@ return [
 		'UnknownElementTypePlugin',
 		'WhitespacePlugin',
 		//'RemoveDebugStatementPlugin', // Reports echo, print, ...
-		'SimplifyExpressionPlugin',
 		//'StrictComparisonPlugin', // Expects ===
 		'SuspiciousParamOrderPlugin',
 		'UnsafeCodePlugin',
@@ -172,6 +132,7 @@ return [
 		'UseReturnValuePlugin',
 		'EmptyStatementListPlugin',
 		'LoopVariableReusePlugin',
+	*/
 	],
 
 	// Add any issue types (such as 'PhanUndeclaredMethod')
@@ -181,11 +142,13 @@ return [
 		'PhanPluginCanUsePHP71Void',	// Dolibarr is maintaining 7.0 compatibility
 		'PhanPluginShortArray',			// Dolibarr uses array()
 		'PhanPluginShortArrayList',		// Dolibarr uses array()
+		// The following may require that --quick is not used
 		// Fixers From PHPDocToRealTypesPlugin:
-		'PhanPluginCanUseParamType',			// Fixer - Report/Add types in the function definition (function abc(string $var) (adds string)
-		'PhanPluginCanUseReturnType',			// Fixer - Report/Add return types in the function definition (function abc(string $var) (adds string)
+		'PhanPluginCanUseParamType',	// Fixer - Report/Add types in the function definition (function abc(string $var) (adds string)
+		'PhanPluginCanUseReturnType',	// Fixer - Report/Add return types in the function definition (function abc(string $var) (adds string)
 		'PhanPluginCanUseNullableParamType',	// Fixer - Report/Add nullable parameter types in the function definition
 		'PhanPluginCanUseNullableReturnType',	// Fixer - Report/Add nullable return types in the function definition
+
 		'PhanPluginNonBoolBranch',			// Not essential - 31240+ occurrences
 		'PhanPluginNumericalComparison',	// Not essential - 19870+ occurrences
 		'PhanTypeMismatchArgument',			// Not essential - 12300+ occurrences

--- a/dev/tools/phan/plugins/ParamMatchRegexPlugin.php
+++ b/dev/tools/phan/plugins/ParamMatchRegexPlugin.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Copyright (C) 2024        MDW                            <mdeweerd@users.noreply.github.com>
+ *
+ * Phan Plugin to validate that arguments match a regex
+ */
+declare(strict_types=1);
+
+
+use ast\Node;
+use Phan\Codebase;
+use Phan\Config;
+use Phan\Language\Context;
+use Phan\AST\ContextNode;
+use Phan\AST\UnionTypeVisitor;
+use Phan\Exception\CodeBaseException;
+//use Phan\Language\Element\FunctionInterface;
+use Phan\Language\UnionType;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
+
+/**
+ * ParamMatchPlugin hooks into one event:
+ *
+ * - getPostAnalyzeNodeVisitorClassName
+ *   This method returns a visitor that is called on every AST node from every
+ *   file being analyzed
+ *
+ * A plugin file must
+ *
+ * - Contain a class that inherits from \Phan\PluginV3
+ *
+ * - End by returning an instance of that class.
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ */
+class ParamMatchPlugin extends PluginV3 implements PostAnalyzeNodeCapability
+{
+	/**
+	 * @return string - name of PluginAwarePostAnalysisVisitor subclass
+	 */
+	public static function getPostAnalyzeNodeVisitorClassName(): string
+	{
+		return ParamMatchVisitor::class;
+	}
+}
+
+/**
+ * When __invoke on this class is called with a node, a method
+ * will be dispatched based on the `kind` of the given node.
+ *
+ * Visitors such as this are useful for defining lots of different
+ * checks on a node based on its kind.
+ */
+class ParamMatchVisitor extends PluginAwarePostAnalysisVisitor
+{
+	// A plugin's visitors should not override visit() unless they need to.
+
+	/**
+	 * @override
+	 *
+	 * @param Node $node A node to analyze
+	 *
+	 * @return void
+	 */
+	public function visitCall(Node $node): void
+	{
+		$name = $node->children['expr']->children['name'] ?? null;
+		if (!is_string($name)) {
+			return;
+		}
+
+		$rules = Config::getValue('ParamMatchRegexPlugin');
+
+		foreach ($rules as $regex => $rule) {
+			if (preg_match($regex, $name)) {
+				$this->checkParam($node, $rule[0], $rule[1]);
+			}
+		}
+	}
+
+	/**
+	 * @param Node   $node        Visited node for which to verify arguments match regex
+	 * @param int    $argPosition Position of argument to check
+	 * @param string $argRegex    Regex to validate against argument
+	 *
+	 * @return void
+	 */
+	public function checkParam(Node $node, int $argPosition, string $argRegex): void
+	{
+		$functionName = $node->children['expr']->children['name'] ?? null;
+		$args = $node->children['args']->children;
+
+		if (!array_key_exists($argPosition, $args)) {
+			/*
+			$this->emitPluginIssue(
+				$this->code_base,
+				$this->context,
+				'ParamMatchMissingArgument',
+				"Argument at %s for %s is missing",
+				[$argPosition, $function_name]
+			);
+			*/
+			return;
+		}
+		$expr = $args[$argPosition];
+		try {
+			$expr_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $expr, false);
+		} catch (Exception $_) {
+			return;
+		}
+
+		$expr_value = $expr_type->getRealUnionType()->asValueOrNullOrSelf();
+		if (!is_object($expr_value)) {
+			$list = [(string) $expr_value];
+		} elseif ($expr_value instanceof UnionType) {
+			$list = $expr_value->asStringScalarValues();
+		} else {
+			// Note: maybe more types could be supported
+			return;
+		}
+
+		foreach ($list as $argValue) {
+			if (!preg_match($argRegex, $argValue)) {
+				// Emit an issue if the argument does not match the expected regex pattern
+				$this->emitPluginIssue(
+					$this->code_base,
+					$this->context,
+					'ParamMatchRegexError',
+					"Argument {POS} function {FUNCTION} can have value '{VALUE}' that does not match the expected pattern '{PATTERN}'",
+					[$argPosition, $functionName, $argValue, $argRegex]
+				);
+			}
+		}
+	}
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new ParamMatchPlugin();

--- a/dev/tools/phan/plugins/ParamMatchRegexPlugin.php
+++ b/dev/tools/phan/plugins/ParamMatchRegexPlugin.php
@@ -221,21 +221,22 @@ class ParamMatchVisitor extends PluginAwarePostAnalysisVisitor
 		if (!is_object($expr_value)) {
 			$list = [(string) $expr_value];
 		} elseif ($expr_value instanceof UnionType) {
-			$list = $expr_value->asStringScalarValues();
+			$list = $expr_value->asScalarValues();
 		} else {
 			// Note: maybe more types could be supported
 			return;
 		}
 
 		foreach ($list as $argValue) {
-			if (!\preg_match($argRegex, $argValue)) {
+			if (!\preg_match($argRegex, (string) $argValue)) {
 				// Emit an issue if the argument does not match the expected regex pattern
+				// var_dump([$node,$expr_value,$expr_type->getRealUnionType()]); // Information about node
 				$this->emitPluginIssue(
 					$this->code_base,
 					$this->context,
 					$messageCode ?? 'ParamMatchRegexError',
-					"Argument {POS} function {FUNCTION} can have value '{VALUE}' that does not match the expected pattern '{PATTERN}'",
-					[$argPosition, $functionName, $argValue, $argRegex]
+					"Argument {POS} function {FUNCTION} can have value {VALUE} that does not match the expected pattern '{PATTERN}'",
+					[$argPosition, $functionName, json_encode($argValue), $argRegex]
 				);
 			}
 		}

--- a/dev/tools/phan/plugins/ParamMatchRegexPlugin.php
+++ b/dev/tools/phan/plugins/ParamMatchRegexPlugin.php
@@ -235,7 +235,7 @@ class ParamMatchVisitor extends PluginAwarePostAnalysisVisitor
 					$this->code_base,
 					$this->context,
 					$messageCode ?? 'ParamMatchRegexError',
-					"Argument {POS} function {FUNCTION} can have value {VALUE} that does not match the expected pattern '{PATTERN}'",
+					"Argument {INDEX} function {FUNCTION} can have value {STRING_LITERAL} that does not match the expected pattern '{STRING_LITERAL}'",
 					[$argPosition, $functionName, json_encode($argValue), $argRegex]
 				);
 			}

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -932,6 +932,7 @@ function GETPOST($paramname, $check = 'alphanohtml', $method = 0, $filter = null
 			$out = preg_replace('/([<>])([-+]?\d)/', '\1 \2', $out);
 		}
 
+		// @phan-suppress-next-line ParamMatchRegexError
 		$out = sanitizeVal($out, $check, $filter, $options);
 	}
 

--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -4186,6 +4186,7 @@ if ($module == 'initmodule') {
 								print '<a class="reposition editfielda" href="'.$_SERVER['PHP_SELF'].'?tab='.urlencode($tab).'&tabobj='.$tabobj.'&module='.$module.($forceddirread ? '@'.$dirread : '').'&action=confirm_removefile&token='.newToken().'&file='.urlencode($pathtoapi).'">'.img_picto($langs->trans("Delete"), 'delete').'</a>';
 								print $form->textwithpicto('', $langs->trans("InfoForApiFile"), 1, 'warning');
 								print ' &nbsp; ';
+								// @phan-suppress-next-line ParamMatchRegexError
 								if (!isModEnabled($modulelowercase)) {	// If module is not activated
 									print '<a href="#" class="classfortooltip" target="apiexplorer" title="'.$langs->trans("ModuleMustBeEnabled", $module).'"><strike>'.$langs->trans("ApiExplorer").'</strike></a>';
 								} else {


### PR DESCRIPTION
# Qual: New Phan plugin for testing that argument matches regex

This Plugin - currently applied to GETPOST - allows verifying that a selected argument of a function matches a regular expression.

There are several cases where the argument is invalid.  I let the codeowners correct those.

Also added a test for isModEnabled - it detects 3 cases where the value may be invalid - maybe the best solution is to add a '@phan-ignore... ParamMatchRegexError' annotation for these cases.