### PR TITLE
Fix: Use of deprecated fichinter in dynamic modulename

### DIFF
--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -233,12 +233,10 @@ if (!empty($reg[1]) && $reg[1] == 'explorer' && ($reg[2] == '/swagger.json' || $
 					$modulenameforenabled = $module;
 					if ($module == 'propale') {
 						$modulenameforenabled = 'propal';
-					}
-					if ($module == 'supplierproposal') {
+					} elseif ($module == 'supplierproposal') {
 						$modulenameforenabled = 'supplier_proposal';
-					}
-					if ($module == 'ficheinter') {
-						$modulenameforenabled = 'ficheinter';
+					} elseif ($module == 'ficheinter') {
+						$modulenameforenabled = 'intervention';
 					}
 
 					dol_syslog("Found module file ".$file." - module=".$module." - modulenameforenabled=".$modulenameforenabled." - moduledirforclass=".$moduledirforclass);


### PR DESCRIPTION
# Fix: Use of deprecated fichinter in dynamic modulename

The modulename is computed dynamically and could use deprecated fichinter module name.
Also optimised the test.

I would heve suggested the use of DEPRECATED_MODULE_MAPPING defined in functions.lib.php but that does not contain the mapping for supplierproposal .

Also, isModEnabled already takes care of the deprecations, so trying to fix that here seems like repeated code.
Anyway, this was not part of the automated module name replacements, but was detected by phan as a location where a deprecated modulename is used.

Finally, I think that some constants like DEPRECATED_MODULE_MAPPING would be better located in a file without dependencies on other dolibarr code so that it can be included in other parts (static code checking, fixers, and possibly tests).