### PR TITLE
Qual: Enable detection of deprecated modulename & GETPOST(...,'int')

### DIFF
--- a/dev/tools/phan/PHAN.BAT
+++ b/dev/tools/phan/PHAN.BAT
@@ -1,0 +1,46 @@
+@ECHO OFF
+REM Usage (use from root of project):
+REM  - Standard checks:
+REM    PHAN.BAT
+REM  - Extended checks:
+REM    PHAN.BAT extended
+REM  - Use fixer configuration:
+REM    PHAN.BAT fix
+REM
+REM  Standard phan options can be added on the command line.
+
+set MEMOPT=--memory-limit=4G
+set CONFIG=--config-file
+set CONFIG_FILE=dev/tools/phan/config.php
+set FIX=
+set USERARGS=
+SET TWICE=--analyze-twice
+
+rem Iterate through each argument
+for %%i in (%*) do (
+    if "%%i"=="--memory-limit" (
+        set MEMOPT=""
+    )
+    if "%%i"=="extended" (
+	set CONFIG="--config-file"
+	set CONFIG_FILE=dev/tools/phan/config_extended.php
+        goto :nextloop
+    )
+    if "%%i"=="fix" (
+        set FIX="--automatic-fix"
+	set CONFIG="--config-file"
+	set CONFIG_FILE=dev/tools/phan/config_fixer.php
+	set TWICE=
+        goto :nextloop
+    )
+    if "%%i"=="--config-file" (
+        set CONFIG=
+        set CONFIG_FILE=
+    )
+    set "USERARGS=%USERARGS% %%i"
+
+    :nextloop
+    REM NEXTLOOP
+)
+
+../phan/vendor/bin/phan.bat %TWICE% %MEMOPT% %FIX% %CONFIG% %CONFIG_FILE% %USERARGS%

--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -184,6 +184,7 @@ $VALID_MODULE_MAPPING = array(
 );
 
 $moduleNameRegex = '/^(?:'.implode('|', array_merge(array_keys($DEPRECATED_MODULE_MAPPING), array_keys($VALID_MODULE_MAPPING), array('\$modulename'))).')$/';
+$deprecatedModuleNameRegex = '/^(?!(?:'.implode('|', array_keys($DEPRECATED_MODULE_MAPPING)).')$).*/';
 
 /**
  * This configuration will be read and overlaid on top of the
@@ -266,12 +267,15 @@ return [
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
 	'ParamMatchRegexPlugin' => [
 		'/^GETPOST$/' => [1, $sanitizeRegex],
-		'/^isModEnabled$/' => [0, $moduleNameRegex],
+		'/^isModEnabled$/' => [0, $moduleNameRegex, 'UnknownModuleName'],
+		// Note: trick to have different key for same regex:
+		'/^isModEnable[d]$/' => [0, $deprecatedModuleNameRegex, "DeprecatedModuleName"],
 		'/^sanitizeVal$/' => [1, $sanitizeRegex],
 	],
 	'plugins' => [
 		__DIR__.'/plugins/NoVarDumpPlugin.php',
 		__DIR__.'/plugins/ParamMatchRegexPlugin.php',
+		__DIR__.'/plugins/GetPostFixerPlugin.php',   // Only detects without --automatic-fix
 		// checks if a function, closure or method unconditionally returns.
 		// can also be written as 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php'
 		//'DeprecateAliasPlugin',

--- a/dev/tools/phan/config_extended.php
+++ b/dev/tools/phan/config_extended.php
@@ -185,6 +185,8 @@ $VALID_MODULE_MAPPING = array(
 
 $moduleNameRegex = '/^(?:'.implode('|', array_merge(array_keys($DEPRECATED_MODULE_MAPPING), array_keys($VALID_MODULE_MAPPING))).')$/';
 
+$deprecatedModuleNameRegex = '/^(?!(?:'.implode('|', array_keys($DEPRECATED_MODULE_MAPPING)).')$).*/';
+
 /**
  * This configuration will be read and overlaid on top of the
  * default configuration. Command line arguments will be applied
@@ -265,12 +267,15 @@ return [
 	// with the plugin's implementation (e.g. 'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php')
 	'ParamMatchRegexPlugin' => [
 		'/^GETPOST$/' => [1, $sanitizeRegex],
-		'/^isModEnabled$/' => [0, $moduleNameRegex],
+		'/^isModEnabled$/' => [0, $moduleNameRegex, 'UnknownModuleName'],
+		// Note: trick to have different key for same regex:
+		'/^isModEnable[d]$/' => [0, $deprecatedModuleNameRegex, "DeprecatedModuleName"],
 		'/^sanitizeVal$/' => [1, $sanitizeRegex],
 	],
 	'plugins' => [
 		__DIR__.'/plugins/NoVarDumpPlugin.php',
 		__DIR__.'/plugins/ParamMatchRegexPlugin.php',
+		__DIR__.'/plugins/GetPostFixerPlugin.php',   // Only detects without --automatic-fix
 		'DeprecateAliasPlugin',
 		//'EmptyMethodAndFunctionPlugin',
 		'InvalidVariableIssetPlugin',

--- a/dev/tools/phan/config_fixer.php
+++ b/dev/tools/phan/config_fixer.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once __DIR__.'/plugins/DeprecatedModuleNameFixer.php';
+
 /* Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  */
 define('DOL_PROJECT_ROOT', __DIR__.'/../../..');

--- a/dev/tools/phan/plugins/GetPostFixerPlugin/fixers.php
+++ b/dev/tools/phan/plugins/GetPostFixerPlugin/fixers.php
@@ -46,7 +46,7 @@ call_user_func(static function (): void {
 				continue;
 			}
 			$arguments = $node->children;
-			if (count($arguments) != 3) {
+			if (!in_array(count($arguments), [3, 5])) {  // ',' included !
 				print "Arg Count is ".count($arguments)." - Skip $instance".PHP_EOL;
 				continue;
 			}

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -9,6 +9,7 @@
  * Copyright (C) 2015      Alexandre Spangaro   <aspangaro@open-dsi.fr>
  * Copyright (C) 2018-2023 Frédéric France      <frederic.france@netlogic.fr>
  * Copyright (C) 2019	   Ferran Marcet	    <fmarcet@2byte.es>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -145,13 +146,13 @@ if ($reshook < 0) {
 
 $TRemindTypes = array();
 if (getDolGlobalString('AGENDA_REMINDER_BROWSER')) {
-	$TRemindTypes['browser'] = array('label'=>$langs->trans('BrowserPush'), 'disabled'=>(!getDolGlobalString('AGENDA_REMINDER_BROWSER') ? 1 : 0));
+	$TRemindTypes['browser'] = array('label' => $langs->trans('BrowserPush'), 'disabled' => (!getDolGlobalString('AGENDA_REMINDER_BROWSER') ? 1 : 0));
 }
 if (getDolGlobalString('AGENDA_REMINDER_EMAIL')) {
-	$TRemindTypes['email'] = array('label'=>$langs->trans('EMail'), 'disabled'=>(!getDolGlobalString('AGENDA_REMINDER_EMAIL') ? 1 : 0));
+	$TRemindTypes['email'] = array('label' => $langs->trans('EMail'), 'disabled' => (!getDolGlobalString('AGENDA_REMINDER_EMAIL') ? 1 : 0));
 }
 
-$TDurationTypes = array('y'=>$langs->trans('Years'), 'm'=>$langs->trans('Month'), 'w'=>$langs->trans('Weeks'), 'd'=>$langs->trans('Days'), 'h'=>$langs->trans('Hours'), 'i'=>$langs->trans('Minutes'));
+$TDurationTypes = array('y' => $langs->trans('Years'), 'm' => $langs->trans('Month'), 'w' => $langs->trans('Weeks'), 'd' => $langs->trans('Days'), 'h' => $langs->trans('Hours'), 'i' => $langs->trans('Minutes'));
 
 $result = restrictedArea($user, 'agenda', $object, 'actioncomm&societe', 'myactions|allactions', 'fk_soc', 'id');
 
@@ -229,7 +230,7 @@ if (empty($reshook) && (GETPOST('addassignedtouser') || GETPOST('updateassignedt
 		if (!empty($_SESSION['assignedtouser'])) {
 			$assignedtouser = json_decode($_SESSION['assignedtouser'], true);
 		}
-		$assignedtouser[GETPOST('assignedtouser')] = array('id'=>GETPOSTINT('assignedtouser'), 'transparency'=>GETPOST('transparency'), 'mandatory'=>1);
+		$assignedtouser[GETPOST('assignedtouser')] = array('id' => GETPOSTINT('assignedtouser'), 'transparency' => GETPOST('transparency'), 'mandatory' => 1);
 		$_SESSION['assignedtouser'] = json_encode($assignedtouser);
 	}
 	$donotclearsession = 1;
@@ -251,7 +252,7 @@ if (empty($reshook) && (GETPOST('addassignedtoresource') || GETPOST('updateassig
 		if (!empty($_SESSION['assignedtoresource'])) {
 			$assignedtoresource = json_decode($_SESSION['assignedtoresource'], true);
 		}
-		$assignedtoresource[GETPOST('assignedtoresource')] = array('id'=>GETPOSTINT('assignedtoresource'), 'transparency'=>GETPOST('transparency'), 'mandatory'=>1);
+		$assignedtoresource[GETPOST('assignedtoresource')] = array('id' => GETPOSTINT('assignedtoresource'), 'transparency' => GETPOST('transparency'), 'mandatory' => 1);
 		$_SESSION['assignedtoresource'] = json_encode($assignedtoresource);
 	}
 	$donotclearsession = 1;
@@ -419,7 +420,7 @@ if (empty($reshook) && $action == 'add') {
 				$object->transparency = $transparency;
 			}
 
-			$object->userassigned[$value['id']] = array('id'=>$value['id'], 'transparency'=>$transparency);
+			$object->userassigned[$value['id']] = array('id' => $value['id'], 'transparency' => $transparency);
 
 			$i++;
 		}
@@ -476,7 +477,8 @@ if (empty($reshook) && $action == 'add') {
 	// Fill array 'array_options' with data from add form
 	$ret = $extrafields->setOptionalsFromPost(null, $object);
 	if ($ret < 0) {
-		$error++; $donotclearsession = 1;
+		$error++;
+		$donotclearsession = 1;
 		$action = 'create';
 	}
 
@@ -857,7 +859,7 @@ if (empty($reshook) && $action == 'update') {
 		} else {
 			$assignedtouser = (!empty($object->userownerid) && $object->userownerid > 0 ? $object->userownerid : 0);
 			if ($assignedtouser) {
-				$listofuserid[$assignedtouser] = array('id'=>$assignedtouser, 'mandatory'=>0, 'transparency'=>($user->id == $assignedtouser ? $transparency : '')); // Owner first
+				$listofuserid[$assignedtouser] = array('id' => $assignedtouser, 'mandatory' => 0, 'transparency' => ($user->id == $assignedtouser ? $transparency : '')); // Owner first
 			}
 		}
 		$object->userassigned = array();
@@ -867,7 +869,7 @@ if (empty($reshook) && $action == 'update') {
 			if ($i == 0) {
 				$object->userownerid = $val['id'];
 			}
-			$object->userassigned[$val['id']] = array('id'=>$val['id'], 'mandatory'=>0, 'transparency'=>($user->id == $val['id'] ? $transparency : ''));
+			$object->userassigned[$val['id']] = array('id' => $val['id'], 'mandatory' => 0, 'transparency' => ($user->id == $val['id'] ? $transparency : ''));
 			$i++;
 		}
 
@@ -1180,9 +1182,9 @@ $form = new Form($db);
 $formproject = new FormProjets($db);
 
 $arrayrecurrulefreq = array(
-	'no'=>$langs->trans("OnceOnly"),
-	'MONTHLY'=>$langs->trans("EveryMonth"),
-	'WEEKLY'=>$langs->trans("EveryWeek")
+	'no' => $langs->trans("OnceOnly"),
+	'MONTHLY' => $langs->trans("EveryMonth"),
+	'WEEKLY' => $langs->trans("EveryWeek")
 	// 'DAILY'=>$langs->trans("EveryDay")
 );
 
@@ -1386,12 +1388,12 @@ if ($action == 'create') {
 	print '</td></tr>';
 
 	$datep = ($datep ? $datep : (is_null($object->datep) ? '' : $object->datep));
-	if (GETPOST('datep', 'int', 1)) {
-		$datep = dol_stringtotime(GETPOST('datep', 'int', 1), 'tzuserrel');
+	if (GETPOSTINT('datep', 1)) {
+		$datep = dol_stringtotime(GETPOSTINT('datep', 1), 'tzuserrel');
 	}
 	$datef = ($datef ? $datef : $object->datef);
-	if (GETPOST('datef', 'int', 1)) {
-		$datef = dol_stringtotime(GETPOST('datef', 'int', 1), 'tzuserrel');
+	if (GETPOSTINT('datef', 1)) {
+		$datef = dol_stringtotime(GETPOSTINT('datef', 1), 'tzuserrel');
 	}
 	if (empty($datef) && !empty($datep)) {
 		if (GETPOST("actioncode", 'aZ09') == 'AC_RDV' || !getDolGlobalString('AGENDA_USE_EVENT_TYPE_DEFAULT')) {
@@ -1426,7 +1428,7 @@ if ($action == 'create') {
 	if (empty($donotclearsession)) {
 		$assignedtouser = GETPOST("assignedtouser") ? GETPOST("assignedtouser") : (!empty($object->userownerid) && $object->userownerid > 0 ? $object->userownerid : $user->id);
 		if ($assignedtouser) {
-			$listofuserid[$assignedtouser] = array('id'=>$assignedtouser, 'mandatory'=>0); // Owner first
+			$listofuserid[$assignedtouser] = array('id' => $assignedtouser, 'mandatory' => 0); // Owner first
 		}
 		//$listofuserid[$user->id] = array('id'=>$user->id, 'mandatory'=>0, 'transparency'=>(GETPOSTISSET('transparency') ? GETPOST('transparency', 'alpha') : 1)); // 1 by default at first init
 		$listofuserid[$assignedtouser]['transparency'] = (GETPOSTISSET('transparency') ? GETPOST('transparency', 'alpha') : 1); // 1 by default at first init
@@ -1473,7 +1475,7 @@ if ($action == 'create') {
 		if (empty($donotclearsession)) {
 			$assignedtoresource = GETPOST("assignedtoresource");
 			if ($assignedtoresource) {
-				$listofresourceid[$assignedtoresource] = array('id'=>$assignedtoresource, 'mandatory'=>0); // Owner first
+				$listofresourceid[$assignedtoresource] = array('id' => $assignedtoresource, 'mandatory' => 0); // Owner first
 			}
 			$_SESSION['assignedtoresource'] = json_encode($listofresourceid);
 		} else {
@@ -1494,7 +1496,7 @@ if ($action == 'create') {
 	// Status
 	print '<tr><td>'.$langs->trans("Status").' / '.$langs->trans("Percentage").'</td>';
 	print '<td>';
-	$percent = $complete !=='' ? $complete : -1;
+	$percent = $complete !== '' ? $complete : -1;
 	if (GETPOSTISSET('status')) {
 		$percent = GETPOST('status');
 	} elseif (GETPOSTISSET('percentage')) {
@@ -1543,7 +1545,7 @@ if ($action == 'create') {
 		if (GETPOSTINT('contactid')) {
 			$preselectedids[GETPOSTINT('contactid')] = GETPOSTINT('contactid');
 		}
-		if ($origin=='contact') {
+		if ($origin == 'contact') {
 			$preselectedids[GETPOSTINT('originid')] = GETPOSTINT('originid');
 		}
 		// select "all" or "none" contact by default
@@ -1970,12 +1972,12 @@ if ($id > 0) {
 		if (empty($donotclearsession)) {
 			if ($object->userownerid > 0) {
 				$listofuserid[$object->userownerid] = array(
-					'id'=>$object->userownerid,
-					'type'=>'user',
+					'id' => $object->userownerid,
+					'type' => 'user',
 					//'transparency'=>$object->userassigned[$user->id]['transparency'],
-					'transparency'=>$object->transparency, // Force transparency on ownerfrom event
-					'answer_status'=>$object->userassigned[$object->userownerid]['answer_status'],
-					'mandatory'=>$object->userassigned[$object->userownerid]['mandatory']
+					'transparency' => $object->transparency, // Force transparency on ownerfrom event
+					'answer_status' => $object->userassigned[$object->userownerid]['answer_status'],
+					'mandatory' => $object->userassigned[$object->userownerid]['mandatory']
 				);
 			}
 			if (!empty($object->userassigned)) {	// Now concat assigned users
@@ -2253,9 +2255,9 @@ if ($id > 0) {
 		$parameters = array();
 		$reshook = $hookmanager->executeHooks('formConfirm', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 		if (empty($reshook)) {
-			$formconfirm.=$hookmanager->resPrint;
+			$formconfirm .= $hookmanager->resPrint;
 		} elseif ($reshook > 0) {
-			$formconfirm=$hookmanager->resPrint;
+			$formconfirm = $hookmanager->resPrint;
 		}
 
 		// Print form confirm
@@ -2403,10 +2405,10 @@ if ($id > 0) {
 		if (empty($donotclearsession)) {
 			if ($object->userownerid > 0) {
 				$listofuserid[$object->userownerid] = array(
-					'id'=>$object->userownerid,
-					'transparency'=>$object->transparency, // Force transparency on owner from property of event
-					'answer_status'=>$object->userassigned[$object->userownerid]['answer_status'],
-					'mandatory'=>$object->userassigned[$object->userownerid]['mandatory']
+					'id' => $object->userownerid,
+					'transparency' => $object->transparency, // Force transparency on owner from property of event
+					'answer_status' => $object->userassigned[$object->userownerid]['answer_status'],
+					'mandatory' => $object->userassigned[$object->userownerid]['mandatory']
 				);
 			}
 			if (!empty($object->userassigned)) {	// Now concat assigned users

--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2015      Marcos García        <marcosgdf@gmail.com>
  * Copyright (C) 2017      Open-DSI             <support@open-dsi.fr>
  * Copyright (C) 2018-2021 Frédéric France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -55,10 +56,10 @@ $disabledefaultvalues = GETPOSTINT('disabledefaultvalues');
 
 $check_holiday = GETPOSTINT('check_holiday');
 $filter = GETPOST("search_filter", 'alpha', 3) ? GETPOST("search_filter", 'alpha', 3) : GETPOST("filter", 'alpha', 3);
-$filtert = GETPOST("search_filtert", "int", 3) ? GETPOST("search_filtert", "int", 3) : GETPOST("filtert", "int", 3);
-$usergroup = GETPOST("search_usergroup", "int", 3) ? GETPOST("search_usergroup", "int", 3) : GETPOST("usergroup", "int", 3);
+$filtert = GETPOSTINT("search_filtert", 3) ? GETPOSTINT("search_filtert", 3) : GETPOSTINT("filtert", 3);
+$usergroup = GETPOSTINT("search_usergroup", 3) ? GETPOSTINT("search_usergroup", 3) : GETPOSTINT("usergroup", 3);
 $showbirthday = empty($conf->use_javascript_ajax) ? GETPOSTINT("showbirthday") : 1;
-$search_categ_cus = GETPOST("search_categ_cus", "int", 3) ? GETPOST("search_categ_cus", "int", 3) : 0;
+$search_categ_cus = GETPOSTINT("search_categ_cus", 3) ? GETPOSTINT("search_categ_cus", 3) : 0;
 
 // If not choice done on calendar owner (like on left menu link "Agenda"), we filter on user.
 if (empty($filtert) && !getDolGlobalString('AGENDA_ALL_CALENDARS')) {
@@ -113,7 +114,7 @@ $year = GETPOSTINT("year") ? GETPOSTINT("year") : date("Y");
 $month = GETPOSTINT("month") ? GETPOSTINT("month") : date("m");
 $week = GETPOSTINT("week") ? GETPOSTINT("week") : date("W");
 $day = GETPOSTINT("day") ? GETPOSTINT("day") : date("d");
-$pid = GETPOST("search_projectid", "int", 3) ? GETPOST("search_projectid", "int", 3) : GETPOST("projectid", "int", 3);
+$pid = GETPOSTINT("search_projectid", 3) ? GETPOSTINT("search_projectid", 3) : GETPOSTINT("projectid", 3);
 $status = GETPOSTISSET("search_status") ? GETPOST("search_status", 'aZ09') : GETPOST("status", 'aZ09'); // status may be 0, 50, 100, 'todo', 'na' or -1
 $type = GETPOSTISSET("search_type") ? GETPOST("search_type", 'aZ09') : GETPOST("type", 'aZ09');
 $maxprint = GETPOSTISSET("maxprint") ? GETPOSTINT("maxprint") : $conf->global->AGENDA_MAX_EVENTS_DAY_VIEW;
@@ -523,7 +524,8 @@ $viewmode .= img_picto($langs->trans("ViewPerUser"), 'object_calendarperuser', '
 $viewmode .= '<span class="valignmiddle text-plus-circle btnTitle-label hideonsmartphone">'.$langs->trans("ViewPerUser").'</span></a>';
 
 // Add more views from hooks
-$parameters = array(); $object = null;
+$parameters = array();
+$object = null;
 $reshook = $hookmanager->executeHooks('addCalendarView', $parameters, $object, $action);
 if (empty($reshook)) {
 	$viewmode .= $hookmanager->resPrint;
@@ -550,7 +552,8 @@ if ($user->hasRight('agenda', 'myactions', 'create') || $user->hasRight('agenda'
 }
 
 // Define the legend/list of calendard to show
-$s = ''; $link = '';
+$s = '';
+$link = '';
 
 $showextcals = $listofextcals;
 $bookcalcalendars = array();
@@ -1455,7 +1458,8 @@ if (count($listofextcals)) {
 
 
 // Complete $eventarray with events coming from external module
-$parameters = array(); $object = null;
+$parameters = array();
+$object = null;
 $reshook = $hookmanager->executeHooks('getCalendarEvents', $parameters, $object, $action);
 if (!empty($hookmanager->resArray['eventarray'])) {
 	foreach ($hookmanager->resArray['eventarray'] as $keyDate => $events) {
@@ -1486,7 +1490,7 @@ if (!is_array($theme_datacolor)) {
 	$theme_datacolor = array(array(120, 130, 150), array(200, 160, 180), array(190, 190, 220));
 }
 
-$massactionbutton ='';
+$massactionbutton = '';
 
 print_barre_liste($langs->trans("Agenda"), $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, -1, 'object_action', 0, $nav.'<span class="marginleftonly"></span>'.$newcardbutton, '', $limit, 1, 0, 1, $viewmode);
 
@@ -1520,7 +1524,7 @@ if (empty($mode) || $mode == 'show_month') {      // View by month
 		print '  <td class="center bold uppercase tdfordaytitle'.($i == 0 ? ' borderleft' : '').'">';
 		$numdayinweek = (($i + (isset($conf->global->MAIN_START_WEEK) ? $conf->global->MAIN_START_WEEK : 1)) % 7);
 		if (!empty($conf->dol_optimize_smallscreen)) {
-			$labelshort = array(0=>'SundayMin', 1=>'MondayMin', 2=>'TuesdayMin', 3=>'WednesdayMin', 4=>'ThursdayMin', 5=>'FridayMin', 6=>'SaturdayMin');
+			$labelshort = array(0 => 'SundayMin', 1 => 'MondayMin', 2 => 'TuesdayMin', 3 => 'WednesdayMin', 4 => 'ThursdayMin', 5 => 'FridayMin', 6 => 'SaturdayMin');
 			print $langs->trans($labelshort[$numdayinweek]);
 		} else {
 			print $langs->trans("Day".$numdayinweek);

--- a/htdocs/comm/action/list.php
+++ b/htdocs/comm/action/list.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2017      Open-DSI             <support@open-dsi.fr>
  * Copyright (C) 2018-2021  Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2020		Tobias Sekan		<tobias.sekan@startmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,7 +58,7 @@ if (empty($mode) && preg_match('/show_/', $action)) {
 	$mode = $action;	// For backward compatibility
 }
 $resourceid = GETPOSTINT("search_resourceid") ? GETPOSTINT("search_resourceid") : GETPOSTINT("resourceid");
-$pid = GETPOST("search_projectid", 'int', 3) ? GETPOST("search_projectid", 'int', 3) : GETPOST("projectid", 'int', 3);
+$pid = GETPOSTINT("search_projectid", 3) ? GETPOSTINT("search_projectid", 3) : GETPOSTINT("projectid", 3);
 $search_status = (GETPOST("search_status", 'aZ09') != '') ? GETPOST("search_status", 'aZ09') : GETPOST("status", 'aZ09');
 $type = GETPOST('search_type', 'alphanohtml') ? GETPOST('search_type', 'alphanohtml') : GETPOST('type', 'alphanohtml');
 $year = GETPOSTINT("year");
@@ -93,10 +94,10 @@ if (empty($mode) && !GETPOSTISSET('mode')) {
 }
 
 $filter = GETPOST("search_filter", 'alpha', 3) ? GETPOST("search_filter", 'alpha', 3) : GETPOST("filter", 'alpha', 3);
-$filtert = GETPOST("search_filtert", "int", 3) ? GETPOST("search_filtert", "int", 3) : GETPOST("filtert", "int", 3);
-$usergroup = GETPOST("search_usergroup", "int", 3) ? GETPOST("search_usergroup", "int", 3) : GETPOST("usergroup", "int", 3);
+$filtert = GETPOSTINT("search_filtert", 3) ? GETPOSTINT("search_filtert", 3) : GETPOSTINT("filtert", 3);
+$usergroup = GETPOSTINT("search_usergroup", 3) ? GETPOSTINT("search_usergroup", 3) : GETPOSTINT("usergroup", 3);
 $showbirthday = empty($conf->use_javascript_ajax) ? (GETPOSTINT("search_showbirthday") ? GETPOSTINT("search_showbirthday") : GETPOSTINT("showbirthday")) : 1;
-$search_categ_cus = GETPOST("search_categ_cus", "int", 3) ? GETPOST("search_categ_cus", "int", 3) : 0;
+$search_categ_cus = GETPOSTINT("search_categ_cus", 3) ? GETPOSTINT("search_categ_cus", 3) : 0;
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
 $object = new ActionComm($db);
@@ -157,19 +158,19 @@ if (!$user->hasRight('agenda', 'allactions', 'read') || $filter == 'mine') {	// 
 }
 
 $arrayfields = array(
-	'a.id'=>array('label'=>"Ref", 'checked'=>1),
-	'owner'=>array('label'=>"Owner", 'checked'=>1),
-	'c.libelle'=>array('label'=>"Type", 'checked'=>1),
-	'a.label'=>array('label'=>"Title", 'checked'=>1),
-	'a.note'=>array('label'=>'Description', 'checked'=>0),
-	'a.datep'=>array('label'=>"DateStart", 'checked'=>1),
-	'a.datep2'=>array('label'=>"DateEnd", 'checked'=>1),
-	's.nom'=>array('label'=>"ThirdParty", 'checked'=>1),
-	'a.fk_contact'=>array('label'=>"Contact", 'checked'=>0),
-	'a.fk_element'=>array('label'=>"LinkedObject", 'checked'=>1, 'enabled'=>(getDolGlobalString('AGENDA_SHOW_LINKED_OBJECT'))),
-	'a.datec'=>array('label'=>'DateCreation', 'checked'=>0, 'position'=>510),
-	'a.tms'=>array('label'=>'DateModification', 'checked'=>0, 'position'=>520),
-	'a.percent'=>array('label'=>"Status", 'checked'=>1, 'position'=>1000)
+	'a.id' => array('label' => "Ref", 'checked' => 1),
+	'owner' => array('label' => "Owner", 'checked' => 1),
+	'c.libelle' => array('label' => "Type", 'checked' => 1),
+	'a.label' => array('label' => "Title", 'checked' => 1),
+	'a.note' => array('label' => 'Description', 'checked' => 0),
+	'a.datep' => array('label' => "DateStart", 'checked' => 1),
+	'a.datep2' => array('label' => "DateEnd", 'checked' => 1),
+	's.nom' => array('label' => "ThirdParty", 'checked' => 1),
+	'a.fk_contact' => array('label' => "Contact", 'checked' => 0),
+	'a.fk_element' => array('label' => "LinkedObject", 'checked' => 1, 'enabled' => (getDolGlobalString('AGENDA_SHOW_LINKED_OBJECT'))),
+	'a.datec' => array('label' => 'DateCreation', 'checked' => 0, 'position' => 510),
+	'a.tms' => array('label' => 'DateModification', 'checked' => 0, 'position' => 520),
+	'a.percent' => array('label' => "Status", 'checked' => 1, 'position' => 1000)
 );
 // Extra fields
 include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
@@ -204,7 +205,7 @@ if (GETPOST("viewcal") || GETPOST("viewweek") || GETPOST("viewday")) {
 	exit;
 }
 
-$parameters = array('id'=>$socid);
+$parameters = array('id' => $socid);
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
@@ -814,7 +815,7 @@ if (!empty($arrayfields['a.fk_element']['checked'])) {
 include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_input.tpl.php';
 
 // Fields from hook
-$parameters = array('arrayfields'=>$arrayfields);
+$parameters = array('arrayfields' => $arrayfields);
 $reshook = $hookmanager->executeHooks('printFieldListOption', $parameters); // Note that $action and $object may have been modified by hook
 print $hookmanager->resPrint;
 
@@ -892,7 +893,7 @@ if (!empty($arrayfields['a.fk_element']['checked'])) {
 // Extra fields
 include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_title.tpl.php';
 // Hook fields
-$parameters = array('arrayfields'=>$arrayfields, 'param'=>$param, 'sortfield'=>$sortfield, 'sortorder'=>$sortorder);
+$parameters = array('arrayfields' => $arrayfields, 'param' => $param, 'sortfield' => $sortfield, 'sortorder' => $sortorder);
 $reshook = $hookmanager->executeHooks('printFieldListTitle', $parameters); // Note that $action and $object may have been modified by hook
 print $hookmanager->resPrint;
 
@@ -1196,7 +1197,7 @@ while ($i < $imaxinloop) {
 	// Extra fields
 	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_print_fields.tpl.php';
 	// Fields from hook
-	$parameters = array('arrayfields'=>$arrayfields, 'obj'=>$obj, 'i'=>$i, 'totalarray'=>&$totalarray);
+	$parameters = array('arrayfields' => $arrayfields, 'obj' => $obj, 'i' => $i, 'totalarray' => &$totalarray);
 	$reshook = $hookmanager->executeHooks('printFieldListValue', $parameters); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 

--- a/htdocs/comm/action/pertype.php
+++ b/htdocs/comm/action/pertype.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2011      Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2014      Cedric GROSS         <c.gross@kreiz-it.fr>
  * Copyright (C) 2018-2019  Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,8 +50,8 @@ $action = GETPOST('action', 'aZ09');
 $disabledefaultvalues = GETPOSTINT('disabledefaultvalues');
 
 $filter = GETPOST("search_filter", 'alpha', 3) ? GETPOST("search_filter", 'alpha', 3) : GETPOST("filter", 'alpha', 3);
-$filtert = GETPOST("search_filtert", "int", 3) ? GETPOST("search_filtert", "int", 3) : GETPOST("filtert", "int", 3);
-$usergroup = GETPOST("search_usergroup", "int", 3) ? GETPOST("search_usergroup", "int", 3) : GETPOST("usergroup", "int", 3);
+$filtert = GETPOSTINT("search_filtert", 3) ? GETPOSTINT("search_filtert", 3) : GETPOSTINT("filtert", 3);
+$usergroup = GETPOSTINT("search_usergroup", 3) ? GETPOSTINT("search_usergroup", 3) : GETPOSTINT("usergroup", 3);
 //if (! ($usergroup > 0) && ! ($filtert > 0)) $filtert = $user->id;
 
 // $showbirthday = empty($conf->use_javascript_ajax)?GETPOST("showbirthday","int"):1;
@@ -105,7 +106,7 @@ $year = GETPOSTINT("year") ? GETPOSTINT("year") : date("Y");
 $month = GETPOSTINT("month") ? GETPOSTINT("month") : date("m");
 $week = GETPOSTINT("week") ? GETPOSTINT("week") : date("W");
 $day = GETPOSTINT("day") ? GETPOSTINT("day") : date("d");
-$pid = GETPOSTISSET("search_projectid") ? GETPOST("search_projectid", "int", 3) : GETPOST("projectid", "int", 3);
+$pid = GETPOSTISSET("search_projectid") ? GETPOSTINT("search_projectid", 3) : GETPOSTINT("projectid", 3);
 $status = GETPOSTISSET("search_status") ? GETPOST("search_status", 'aZ09') : GETPOST("status", 'aZ09');
 $type = GETPOSTISSET("search_type") ? GETPOST("search_type", 'alpha') : GETPOST("type", 'alpha');
 $maxprint = ((GETPOSTINT("maxprint") != '') ? GETPOSTINT("maxprint") : $conf->global->AGENDA_MAX_EVENTS_DAY_VIEW);
@@ -463,7 +464,8 @@ $viewmode .= '<span class="valignmiddle text-plus-circle btnTitle-label hideonsm
 $viewmode .= '<span class="marginrightonly"></span>';
 
 // Add more views from hooks
-$parameters = array(); $object = null;
+$parameters = array();
+$object = null;
 $reshook = $hookmanager->executeHooks('addCalendarView', $parameters, $object, $action);
 if (empty($reshook)) {
 	$viewmode .= $hookmanager->resPrint;

--- a/htdocs/comm/action/peruser.php
+++ b/htdocs/comm/action/peruser.php
@@ -7,6 +7,7 @@
  * Copyright (C) 2014      Cedric GROSS         <c.gross@kreiz-it.fr>
  * Copyright (C) 2018-2019  Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2023 Florian HENRY <florian.henry@scopen.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,8 +51,8 @@ $action = GETPOST('action', 'aZ09');
 $disabledefaultvalues = GETPOSTINT('disabledefaultvalues');
 
 $filter = GETPOST("search_filter", 'alpha', 3) ? GETPOST("search_filter", 'alpha', 3) : GETPOST("filter", 'alpha', 3);
-$filtert = GETPOST("search_filtert", "int", 3) ? GETPOST("search_filtert", "int", 3) : GETPOST("filtert", "int", 3);
-$usergroup = GETPOST("search_usergroup", "int", 3) ? GETPOST("search_usergroup", "int", 3) : GETPOST("usergroup", "int", 3);
+$filtert = GETPOSTINT("search_filtert", 3) ? GETPOSTINT("search_filtert", 3) : GETPOSTINT("filtert", 3);
+$usergroup = GETPOSTINT("search_usergroup", 3) ? GETPOSTINT("search_usergroup", 3) : GETPOSTINT("usergroup", 3);
 //if (! ($usergroup > 0) && ! ($filtert > 0)) $filtert = $user->id;
 //$showbirthday = empty($conf->use_javascript_ajax)?GETPOST("showbirthday","int"):1;
 $showbirthday = 0;
@@ -102,12 +103,12 @@ $year = GETPOSTINT("year") ? GETPOSTINT("year") : date("Y");
 $month = GETPOSTINT("month") ? GETPOSTINT("month") : date("m");
 $week = GETPOSTINT("week") ? GETPOSTINT("week") : date("W");
 $day = GETPOSTINT("day") ? GETPOSTINT("day") : date("d");
-$pid = GETPOSTISSET("search_projectid") ? GETPOST("search_projectid", "int", 3) : GETPOST("projectid", "int", 3);
+$pid = GETPOSTISSET("search_projectid") ? GETPOSTINT("search_projectid", 3) : GETPOSTINT("projectid", 3);
 $status = GETPOSTISSET("search_status") ? GETPOST("search_status", 'aZ09') : GETPOST("status", 'aZ09'); // status may be 0, 50, 100, 'todo', 'na' or -1
 $type = GETPOSTISSET("search_type") ? GETPOST("search_type", 'alpha') : GETPOST("type", 'alpha');
 $maxprint = ((GETPOSTINT("maxprint") != '') ? GETPOSTINT("maxprint") : $conf->global->AGENDA_MAX_EVENTS_DAY_VIEW);
 $optioncss = GETPOST('optioncss', 'aZ'); // Option for the css output (always '' except when 'print')
-$search_categ_cus = GETPOST("search_categ_cus", "int", 3) ? GETPOST("search_categ_cus", "int", 3) : 0;
+$search_categ_cus = GETPOSTINT("search_categ_cus", 3) ? GETPOSTINT("search_categ_cus", 3) : 0;
 // Set actioncode (this code must be same for setting actioncode into peruser, listacton and index)
 if (GETPOST('search_actioncode', 'array:aZ09')) {
 	$actioncode = GETPOST('search_actioncode', 'array:aZ09', 3);
@@ -466,7 +467,8 @@ $viewmode .= '<span class="valignmiddle text-plus-circle btnTitle-label hideonsm
 $viewmode .= '<span class="marginrightonly"></span>';
 
 // Add more views from hooks
-$parameters = array(); $object = null;
+$parameters = array();
+$object = null;
 $reshook = $hookmanager->executeHooks('addCalendarView', $parameters, $object, $action);
 if (empty($reshook)) {
 	$viewmode .= $hookmanager->resPrint;
@@ -938,7 +940,7 @@ while ($currentdaytoshow < $lastdaytoshow) {
 		if ($filtert > 0) {
 			$sql .= " AND u.rowid = ".((int) $filtert);
 		}
-		if ($usergroup > 0)	{
+		if ($usergroup > 0) {
 			$sql .= " AND ug.fk_usergroup = ".((int) $usergroup);
 		}
 		if ($user->socid > 0) {

--- a/htdocs/compta/bank/line.php
+++ b/htdocs/compta/bank/line.php
@@ -9,6 +9,7 @@
  * Copyright (C) 2016      Marcos García        <marcosgdf@gmail.com>
  * Copyright (C) 2018       Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2021       Gauthier VERDOL         <gauthier.verdol@atm-consulting.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -362,7 +363,7 @@ if ($result) {
 
 		print dol_get_fiche_head($head, 'bankline', $langs->trans('LineRecord'), 0, 'accountline', 0);
 
-		$linkback = '<a href="'.DOL_URL_ROOT.'/compta/bank/bankentries_list.php?restore_lastsearch_values=1'.(GETPOST('account', 'int', 1) ? '&id='.GETPOST('account', 'int', 1) : '').'">'.$langs->trans("BackToList").'</a>';
+		$linkback = '<a href="'.DOL_URL_ROOT.'/compta/bank/bankentries_list.php?restore_lastsearch_values=1'.(GETPOSTINT('account', 1) ? '&id='.GETPOSTINT('account', 1) : '').'">'.$langs->trans("BackToList").'</a>';
 
 
 		dol_banner_tab($bankline, 'rowid', $linkback);

--- a/htdocs/core/ajax/row.php
+++ b/htdocs/core/ajax/row.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010-2021 Regis Houssin       <regis.houssin@inodbox.com>
  * Copyright (C) 2017      Laurent Destailleur <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,7 +67,7 @@ print '<!-- Ajax page called with url '.dol_escape_htmltag($_SERVER["PHP_SELF"])
 
 // Registering the location of boxes
 if (GETPOST('roworder', 'alpha', 3) && GETPOST('table_element_line', 'aZ09', 3)
-	&& GETPOST('fk_element', 'aZ09', 3) && GETPOST('element_id', 'int', 3)) {
+	&& GETPOSTINT('fk_element', 3) && GETPOSTINT('element_id', 3)) {
 	$roworder = GETPOST('roworder', 'alpha', 3);
 	$table_element_line = GETPOST('table_element_line', 'aZ09', 3);
 	$fk_element = GETPOST('fk_element', 'aZ09', 3);
@@ -126,7 +127,7 @@ if (GETPOST('roworder', 'alpha', 3) && GETPOST('table_element_line', 'aZ09', 3)
 			$perm = 1;
 		}
 	}
-	$parameters = array('roworder'=> &$roworder, 'table_element_line' => &$table_element_line, 'fk_element' => &$fk_element, 'element_id' => &$element_id, 'perm' => &$perm);
+	$parameters = array('roworder' => &$roworder, 'table_element_line' => &$table_element_line, 'fk_element' => &$fk_element, 'element_id' => &$element_id, 'perm' => &$perm);
 	$row = new GenericObject($db);
 	$row->table_element_line = $table_element_line;
 	$row->fk_element = $fk_element;

--- a/htdocs/core/ajax/saveinplace.php
+++ b/htdocs/core/ajax/saveinplace.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2011-2012 Regis Houssin  <regis.houssin@inodbox.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -169,7 +170,7 @@ if (!empty($field) && !empty($element) && !empty($table_element) && !empty($fk_e
 				$return['error'] = $langs->trans('ErrorBadValue');
 			}
 		} elseif ($type == 'datepicker') {
-			$timestamp = GETPOST('timestamp', 'int', 2);
+			$timestamp = GETPOSTINT('timestamp', 2);
 			$format = 'date';
 			$newvalue = ($timestamp / 1000);
 		} elseif ($type == 'select') {

--- a/htdocs/core/ajax/ziptown.php
+++ b/htdocs/core/ajax/ziptown.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010      Regis Houssin       <regis.houssin@inodbox.com>
  * Copyright (C) 2011-2023 Laurent Destailleur <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -142,7 +143,7 @@ if (GETPOST('zipcode') || GETPOST('town')) {
 	top_httphead('text/html');
 
 	$formcompany = new FormCompany($db);
-	print $formcompany->select_state(GETPOST('selected', 'int', 1), GETPOST('country_codeid', 'int', 1), GETPOST('htmlname', 'alpha', 1), GETPOST('morecss', 'alpha', 1));
+	print $formcompany->select_state(GETPOSTINT('selected', 1), GETPOSTINT('country_codeid', 1), GETPOSTINT('htmlname', 1), GETPOSTINT('morecss', 1));
 }
 
 $db->close();

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8712,7 +8712,7 @@ abstract class CommonObject
 								}
 							}
 							$datekey = $keyprefix.'options_'.$key.$keysuffix;
-							$value = (GETPOSTISSET($datekey)) ? dol_mktime(12, 0, 0, GETPOST($datekey.'month', 'int', 3), GETPOST($datekey.'day', 'int', 3), GETPOST($datekey.'year', 'int', 3)) : $datenotinstring;
+							$value = (GETPOSTISSET($datekey)) ? dol_mktime(12, 0, 0, GETPOSTINT($datekey.'month', 3), GETPOSTINT($datekey.'day', 3), GETPOSTINT($datekey.'year', 3)) : $datenotinstring;
 						}
 						if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('datetime'))) {
 							$datenotinstring = null;
@@ -8723,7 +8723,7 @@ abstract class CommonObject
 								}
 							}
 							$timekey = $keyprefix.'options_'.$key.$keysuffix;
-							$value = (GETPOSTISSET($timekey)) ? dol_mktime(GETPOST($timekey.'hour', 'int', 3), GETPOST($timekey.'min', 'int', 3), GETPOST($timekey.'sec', 'int', 3), GETPOST($timekey.'month', 'int', 3), GETPOST($timekey.'day', 'int', 3), GETPOST($timekey.'year', 'int', 3), 'tzuserrel') : $datenotinstring;
+							$value = (GETPOSTISSET($timekey)) ? dol_mktime(GETPOSTINT($timekey.'hour', 3), GETPOSTINT($timekey.'min', 3), GETPOSTINT($timekey.'sec', 3), GETPOSTINT($timekey.'month', 3), GETPOSTINT($timekey.'day', 3), GETPOSTINT($timekey.'year', 3), 'tzuserrel') : $datenotinstring;
 						}
 						// Convert float submitted string into real php numeric (value in memory must be a php numeric)
 						if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('price', 'double'))) {

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -979,6 +979,7 @@ function GETPOST($paramname, $check = 'alphanohtml', $method = 0, $filter = null
  */
 function GETPOSTINT($paramname, $method = 0)
 {
+	// @phan-suppress-next-line GetPostShouldBeGetPostInt
 	return (int) GETPOST($paramname, 'int', $method, null, null, 0);
 }
 

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -746,16 +746,16 @@ if (!defined('NOLOGIN')) {
 		// It is not already authenticated and it requests the login / password
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/security2.lib.php';
 
-		$dol_dst_observed = GETPOST("dst_observed", 'int', 3);
-		$dol_dst_first = GETPOST("dst_first", 'int', 3);
-		$dol_dst_second = GETPOST("dst_second", 'int', 3);
-		$dol_screenwidth = GETPOST("screenwidth", 'int', 3);
-		$dol_screenheight = GETPOST("screenheight", 'int', 3);
-		$dol_hide_topmenu = GETPOST('dol_hide_topmenu', 'int', 3);
-		$dol_hide_leftmenu = GETPOST('dol_hide_leftmenu', 'int', 3);
-		$dol_optimize_smallscreen = GETPOST('dol_optimize_smallscreen', 'int', 3);
-		$dol_no_mouse_hover = GETPOST('dol_no_mouse_hover', 'int', 3);
-		$dol_use_jmobile = GETPOST('dol_use_jmobile', 'int', 3); // 0=default, 1=to say we use app from a webview app, 2=to say we use app from a webview app and keep ajax
+		$dol_dst_observed = GETPOSTINT("dst_observed", 3);
+		$dol_dst_first = GETPOSTINT("dst_first", 3);
+		$dol_dst_second = GETPOSTINT("dst_second", 3);
+		$dol_screenwidth = GETPOSTINT("screenwidth", 3);
+		$dol_screenheight = GETPOSTINT("screenheight", 3);
+		$dol_hide_topmenu = GETPOSTINT('dol_hide_topmenu', 3);
+		$dol_hide_leftmenu = GETPOSTINT('dol_hide_leftmenu', 3);
+		$dol_optimize_smallscreen = GETPOSTINT('dol_optimize_smallscreen', 3);
+		$dol_no_mouse_hover = GETPOSTINT('dol_no_mouse_hover', 3);
+		$dol_use_jmobile = GETPOSTINT('dol_use_jmobile', 3); // 0=default, 1=to say we use app from a webview app, 2=to say we use app from a webview app and keep ajax
 		//dol_syslog("POST key=".join(array_keys($_POST),',').' value='.join($_POST,','));
 
 		// If in demo mode, we check we go to home page through the public/demo/index.php page

--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -75,12 +75,12 @@ $file = GETPOST('file', 'alpha');
 $modulename = dol_sanitizeFileName(GETPOST('modulename', 'alpha'));
 $objectname = dol_sanitizeFileName(GETPOST('objectname', 'alpha'));
 $dicname = dol_sanitizeFileName(GETPOST('dicname', 'alpha'));
-$editorname= GETPOST('editorname', 'alpha');
-$editorurl= GETPOST('editorurl', 'alpha');
-$version= GETPOST('version', 'alpha');
-$family= GETPOST('family', 'alpha');
-$picto= GETPOST('idpicto', 'alpha');
-$idmodule= GETPOST('idmodule', 'alpha');
+$editorname = GETPOST('editorname', 'alpha');
+$editorurl = GETPOST('editorurl', 'alpha');
+$version = GETPOST('version', 'alpha');
+$family = GETPOST('family', 'alpha');
+$picto = GETPOST('idpicto', 'alpha');
+$idmodule = GETPOST('idmodule', 'alpha');
 
 // Security check
 if (!isModEnabled('modulebuilder')) {
@@ -168,11 +168,11 @@ foreach ($dirsrootforscan as $tmpdirread) {
 				}
 				if ($modulenamewithcase) {
 					$listofmodules[$dircustomcursor['name']] = array(
-						'modulenamewithcase'=>$modulenamewithcase,
-						'moduledescriptorrelpath'=> $moduledescriptorrelpath,
-						'moduledescriptorfullpath'=>$moduledescriptorfullpath,
-						'moduledescriptorrootpath'=>$tmpdirread,
-						'moduletype'=>$moduletype
+						'modulenamewithcase' => $modulenamewithcase,
+						'moduledescriptorrelpath' => $moduledescriptorrelpath,
+						'moduledescriptorfullpath' => $moduledescriptorfullpath,
+						'moduledescriptorrootpath' => $tmpdirread,
+						'moduletype' => $moduletype
 					);
 				}
 				//var_dump($listofmodules);
@@ -182,10 +182,10 @@ foreach ($dirsrootforscan as $tmpdirread) {
 
 	if ($forceddirread && empty($listofmodules)) {    // $forceddirread is 1 if we forced dir to read with dirins=... or with module=...@mydir
 		$listofmodules[strtolower($module)] = array(
-			'modulenamewithcase'=>$module,
-			'moduledescriptorrelpath'=> 'notyetimplemented',
-			'moduledescriptorfullpath'=> 'notyetimplemented',
-			'moduledescriptorrootpath'=> 'notyetimplemented',
+			'modulenamewithcase' => $module,
+			'moduledescriptorrelpath' => 'notyetimplemented',
+			'moduledescriptorfullpath' => 'notyetimplemented',
+			'moduledescriptorrootpath' => 'notyetimplemented',
 		);
 	}
 
@@ -231,8 +231,8 @@ if ($dirins && $action == 'initmodule' && $modulename) {
 		$destdir = $dirins.'/'.strtolower($modulename);
 
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename
 		);
 		$result = dolCopyDir($srcdir, $destdir, 0, 0, $arrayreplacement);
 		//dol_mkdir($destfile);
@@ -337,21 +337,21 @@ if ($dirins && $action == 'initmodule' && $modulename) {
 		foreach ($listofphpfilestoedit as $phpfileval) {
 			//var_dump($phpfileval['fullname']);
 			$arrayreplacement = array(
-				'mymodule'=>strtolower($modulename),
-				'MyModule'=>$modulename,
-				'MYMODULE'=>strtoupper($modulename),
-				'My module'=>$modulename,
-				'my module'=>$modulename,
-				'Mon module'=>$modulename,
-				'mon module'=>$modulename,
-				'htdocs/modulebuilder/template'=>strtolower($modulename),
-				'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : ''),
-				'Editor name'=>$editorname,
-				'https://www.example.com'=>$editorurl,
-				'$this->version = \'1.0\''=>'$this->version = \''.$version.'\'',
-				'$this->picto = \'generic\';'=>(empty($picto)) ? '$this->picto = \'generic\'' : '$this->picto = \''.$picto.'\';',
-				"modulefamily" =>$family,
-				'500000'=>$idmodule
+				'mymodule' => strtolower($modulename),
+				'MyModule' => $modulename,
+				'MYMODULE' => strtoupper($modulename),
+				'My module' => $modulename,
+				'my module' => $modulename,
+				'Mon module' => $modulename,
+				'mon module' => $modulename,
+				'htdocs/modulebuilder/template' => strtolower($modulename),
+				'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : ''),
+				'Editor name' => $editorname,
+				'https://www.example.com' => $editorurl,
+				'$this->version = \'1.0\'' => '$this->version = \''.$version.'\'',
+				'$this->picto = \'generic\';' => (empty($picto)) ? '$this->picto = \'generic\'' : '$this->picto = \''.$picto.'\';',
+				"modulefamily" => $family,
+				'500000' => $idmodule
 			);
 
 			if (getDolGlobalString('MODULEBUILDER_SPECIFIC_AUTHOR')) {
@@ -452,18 +452,18 @@ if ($dirins && in_array($action, array('initapi', 'initphpunit', 'initpagecontac
 	if ($result > 0) {
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'myobject'=>strtolower($objectname),
-			'MyObject'=>$objectname,
-			'MYOBJECT'=>strtoupper($objectname),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'myobject' => strtolower($objectname),
+			'MyObject' => $objectname,
+			'MYOBJECT' => strtoupper($objectname),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 		);
 
 		if (count($objects) > 1) {
@@ -509,19 +509,19 @@ if ($dirins && $action == 'initsqlextrafields' && !empty($module)) {
 
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'My Object'=>$objectname,
-			'MyObject'=>$objectname,
-			'my object'=>strtolower($objectname),
-			'myobject'=>strtolower($objectname),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'My Object' => $objectname,
+			'MyObject' => $objectname,
+			'my object' => strtolower($objectname),
+			'myobject' => strtolower($objectname),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 		);
 
 		dolReplaceInFile($destfile1, $arrayreplacement);
@@ -558,15 +558,15 @@ if ($dirins && $action == 'inithook' && !empty($module)) {
 
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 		);
 
 		dolReplaceInFile($destfile, $arrayreplacement);
@@ -592,15 +592,15 @@ if ($dirins && $action == 'inittrigger' && !empty($module)) {
 
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 		);
 
 		dolReplaceInFile($destfile, $arrayreplacement);
@@ -626,15 +626,15 @@ if ($dirins && $action == 'initwidget' && !empty($module)) {
 
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 		);
 
 		dolReplaceInFile($destfile, $arrayreplacement);
@@ -660,15 +660,15 @@ if ($dirins && $action == 'initemailing' && !empty($module)) {
 
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 		);
 
 		dolReplaceInFile($destfile, $arrayreplacement);
@@ -694,15 +694,15 @@ if ($dirins && $action == 'initcss' && !empty($module)) {
 
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : ''),
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : ''),
 		);
 
 		dolReplaceInFile($destfile, $arrayreplacement);
@@ -733,15 +733,15 @@ if ($dirins && $action == 'initjs' && !empty($module)) {
 
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 		);
 
 		dolReplaceInFile($destfile, $arrayreplacement);
@@ -772,20 +772,20 @@ if ($dirins && $action == 'initcli' && !empty($module)) {
 
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'__MYCOMPANY_NAME__'=>$mysoc->name,
-			'__KEYWORDS__'=>$modulename,
-			'__USER_FULLNAME__'=>$user->getFullName($langs),
-			'__USER_EMAIL__'=>$user->email,
-			'__YYYY-MM-DD__'=>dol_print_date($now, 'dayrfc'),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, 'dayrfc').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'__MYCOMPANY_NAME__' => $mysoc->name,
+			'__KEYWORDS__' => $modulename,
+			'__USER_FULLNAME__' => $user->getFullName($langs),
+			'__USER_EMAIL__' => $user->email,
+			'__YYYY-MM-DD__' => dol_print_date($now, 'dayrfc'),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, 'dayrfc').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 		);
 
 		dolReplaceInFile($destfile, $arrayreplacement);
@@ -812,20 +812,20 @@ if ($dirins && $action == 'initdoc' && !empty($module)) {
 
 		//var_dump($phpfileval['fullname']);
 		$arrayreplacement = array(
-			'mymodule'=>strtolower($modulename),
-			'MyModule'=>$modulename,
-			'MYMODULE'=>strtoupper($modulename),
-			'My module'=>$modulename,
-			'my module'=>$modulename,
-			'Mon module'=>$modulename,
-			'mon module'=>$modulename,
-			'htdocs/modulebuilder/template'=>strtolower($modulename),
-			'__MYCOMPANY_NAME__'=>$mysoc->name,
-			'__KEYWORDS__'=>$modulename,
-			'__USER_FULLNAME__'=>$user->getFullName($langs),
-			'__USER_EMAIL__'=>$user->email,
-			'__YYYY-MM-DD__'=>dol_print_date($now, 'dayrfc'),
-			'---Put here your own copyright and developer email---'=>dol_print_date($now, 'dayrfc').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+			'mymodule' => strtolower($modulename),
+			'MyModule' => $modulename,
+			'MYMODULE' => strtoupper($modulename),
+			'My module' => $modulename,
+			'my module' => $modulename,
+			'Mon module' => $modulename,
+			'mon module' => $modulename,
+			'htdocs/modulebuilder/template' => strtolower($modulename),
+			'__MYCOMPANY_NAME__' => $mysoc->name,
+			'__KEYWORDS__' => $modulename,
+			'__USER_FULLNAME__' => $user->getFullName($langs),
+			'__USER_EMAIL__' => $user->email,
+			'__YYYY-MM-DD__' => dol_print_date($now, 'dayrfc'),
+			'---Put here your own copyright and developer email---' => dol_print_date($now, 'dayrfc').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 		);
 
 		dolReplaceInFile($destfile, $arrayreplacement);
@@ -834,7 +834,7 @@ if ($dirins && $action == 'initdoc' && !empty($module)) {
 		$dirins = $listofmodules[strtolower($module)]['moduledescriptorrootpath'];
 		$destdir = $dirins.'/'.strtolower($module);
 		$objects = dolGetListOfObjectClasses($destdir);
-		foreach ($objects as $path=>$obj) {
+		foreach ($objects as $path => $obj) {
 			writePropsInAsciiDoc($path, $obj, $destfile);
 		}
 
@@ -915,7 +915,7 @@ if ($dirins && $action == 'addlanguage' && !empty($module)) {
 			$arrayofreplacement = array();
 			if (!dol_is_dir($srcfile) || !dol_is_file($srcfile)) {
 				$srcdir = DOL_DOCUMENT_ROOT.'/modulebuilder/template/langs/en_US';
-				$arrayofreplacement = array('mymodule'=>$modulelowercase);
+				$arrayofreplacement = array('mymodule' => $modulelowercase);
 			}
 			$result = dolCopyDir($srcdir, $destdir, 0, 0, $arrayofreplacement);
 		}
@@ -976,7 +976,7 @@ if ($dirins && $action == 'confirm_removefile' && !empty($module)) {
 			// Update descriptor file to comment file
 			if (in_array($tab, array('css', 'js'))) {
 				$srcfile = $dirins.'/'.strtolower($module).'/core/modules/mod'.$module.'.class.php';
-				$arrayreplacement = array('/^\s*\''.preg_quote('/'.$relativefilename, '/').'\',*/m'=>'                // \'/'.$relativefilename.'\',');
+				$arrayreplacement = array('/^\s*\''.preg_quote('/'.$relativefilename, '/').'\',*/m' => '                // \'/'.$relativefilename.'\',');
 				dolReplaceInFile($srcfile, $arrayreplacement, '', 0, 0, 1);
 			}
 
@@ -1290,21 +1290,21 @@ if ($dirins && $action == 'initobject' && $module && $objectname) {
 	if (!$error) {
 		// Copy some files
 		$filetogenerate = array(
-			'myobject_card.php'=>strtolower($objectname).'_card.php',
-			'myobject_note.php'=>strtolower($objectname).'_note.php',
-			'myobject_contact.php'=>strtolower($objectname).'_contact.php',
-			'myobject_document.php'=>strtolower($objectname).'_document.php',
-			'myobject_agenda.php'=>strtolower($objectname).'_agenda.php',
-			'myobject_list.php'=>strtolower($objectname).'_list.php',
-			'admin/myobject_extrafields.php'=>'admin/'.strtolower($objectname).'_extrafields.php',
-			'lib/mymodule_myobject.lib.php'=>'lib/'.strtolower($module).'_'.strtolower($objectname).'.lib.php',
+			'myobject_card.php' => strtolower($objectname).'_card.php',
+			'myobject_note.php' => strtolower($objectname).'_note.php',
+			'myobject_contact.php' => strtolower($objectname).'_contact.php',
+			'myobject_document.php' => strtolower($objectname).'_document.php',
+			'myobject_agenda.php' => strtolower($objectname).'_agenda.php',
+			'myobject_list.php' => strtolower($objectname).'_list.php',
+			'admin/myobject_extrafields.php' => 'admin/'.strtolower($objectname).'_extrafields.php',
+			'lib/mymodule_myobject.lib.php' => 'lib/'.strtolower($module).'_'.strtolower($objectname).'.lib.php',
 			//'test/phpunit/MyObjectTest.php'=>'test/phpunit/'.strtolower($objectname).'Test.php',
-			'sql/llx_mymodule_myobject.sql'=>'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'.sql',
-			'sql/llx_mymodule_myobject.key.sql'=>'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'.key.sql',
-			'sql/llx_mymodule_myobject_extrafields.sql'=>'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'_extrafields.sql',
-			'sql/llx_mymodule_myobject_extrafields.key.sql'=>'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'_extrafields.key.sql',
+			'sql/llx_mymodule_myobject.sql' => 'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'.sql',
+			'sql/llx_mymodule_myobject.key.sql' => 'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'.key.sql',
+			'sql/llx_mymodule_myobject_extrafields.sql' => 'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'_extrafields.sql',
+			'sql/llx_mymodule_myobject_extrafields.key.sql' => 'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'_extrafields.key.sql',
 			//'scripts/mymodule.php'=>'scripts/'.strtolower($objectname).'.php',
-			'class/myobject.class.php'=>'class/'.strtolower($objectname).'.class.php',
+			'class/myobject.class.php' => 'class/'.strtolower($objectname).'.class.php',
 			//'class/api_mymodule.class.php'=>'class/api_'.strtolower($module).'.class.php',
 		);
 
@@ -1312,9 +1312,9 @@ if ($dirins && $action == 'initobject' && $module && $objectname) {
 			dol_mkdir($destdir.'/core/modules/'.strtolower($module));
 
 			$filetogenerate += array(
-				'core/modules/mymodule/mod_myobject_advanced.php'=>'core/modules/'.strtolower($module).'/mod_'.strtolower($objectname).'_advanced.php',
-				'core/modules/mymodule/mod_myobject_standard.php'=>'core/modules/'.strtolower($module).'/mod_'.strtolower($objectname).'_standard.php',
-				'core/modules/mymodule/modules_myobject.php'=>'core/modules/'.strtolower($module).'/modules_'.strtolower($objectname).'.php',
+				'core/modules/mymodule/mod_myobject_advanced.php' => 'core/modules/'.strtolower($module).'/mod_'.strtolower($objectname).'_advanced.php',
+				'core/modules/mymodule/mod_myobject_standard.php' => 'core/modules/'.strtolower($module).'/mod_'.strtolower($objectname).'_standard.php',
+				'core/modules/mymodule/modules_myobject.php' => 'core/modules/'.strtolower($module).'/modules_'.strtolower($objectname).'.php',
 			);
 		}
 		if (GETPOST('includedocgeneration', 'aZ09')) {
@@ -1322,8 +1322,8 @@ if ($dirins && $action == 'initobject' && $module && $objectname) {
 			dol_mkdir($destdir.'/core/modules/'.strtolower($module).'/doc');
 
 			$filetogenerate += array(
-				'core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php'=>'core/modules/'.strtolower($module).'/doc/doc_generic_'.strtolower($objectname).'_odt.modules.php',
-				'core/modules/mymodule/doc/pdf_standard_myobject.modules.php'=>'core/modules/'.strtolower($module).'/doc/pdf_standard_'.strtolower($objectname).'.modules.php'
+				'core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php' => 'core/modules/'.strtolower($module).'/doc/doc_generic_'.strtolower($objectname).'_odt.modules.php',
+				'core/modules/mymodule/doc/pdf_standard_myobject.modules.php' => 'core/modules/'.strtolower($module).'/doc/pdf_standard_'.strtolower($objectname).'.modules.php'
 			);
 		}
 		if (GETPOST('generatepermissions', 'aZ09')) {
@@ -1341,7 +1341,7 @@ if ($dirins && $action == 'initobject' && $module && $objectname) {
 			}
 			$rights = $moduleobj->rights;
 			$moduledescriptorfile = $destdir.'/core/modules/mod'.$module.'.class.php';
-			$checkComment=checkExistComment($moduledescriptorfile, 1);
+			$checkComment = checkExistComment($moduledescriptorfile, 1);
 			if ($checkComment < 0) {
 				setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
 			} else {
@@ -1534,18 +1534,18 @@ if ($dirins && $action == 'initobject' && $module && $objectname) {
 
 			//var_dump($phpfileval['fullname']);
 			$arrayreplacement = array(
-				'mymodule'=>strtolower($module),
-				'MyModule'=>$module,
-				'MYMODULE'=>strtoupper($module),
-				'My module'=>$module,
-				'my module'=>$module,
-				'mon module'=>$module,
-				'Mon module'=>$module,
-				'htdocs/modulebuilder/template/'=>strtolower($modulename),
-				'myobject'=>strtolower($objectname),
-				'MyObject'=>$objectname,
+				'mymodule' => strtolower($module),
+				'MyModule' => $module,
+				'MYMODULE' => strtoupper($module),
+				'My module' => $module,
+				'my module' => $module,
+				'mon module' => $module,
+				'Mon module' => $module,
+				'htdocs/modulebuilder/template/' => strtolower($modulename),
+				'myobject' => strtolower($objectname),
+				'MyObject' => $objectname,
 				//'MYOBJECT'=>strtoupper($objectname),
-				'---Put here your own copyright and developer email---'=>dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
+				'---Put here your own copyright and developer email---' => dol_print_date($now, '%Y').' '.$user->getFullName($langs).($user->email ? ' <'.$user->email.'>' : '')
 			);
 
 			if (getDolGlobalString('MODULEBUILDER_SPECIFIC_AUTHOR')) {
@@ -1730,25 +1730,25 @@ if ($dirins && $action == 'addproperty' && empty($cancel) && !empty($module) && 
 
 		if (!$error && !GETPOST('regenerateclasssql') && !GETPOST('regeneratemissing')) {
 			$addfieldentry = array(
-				'name'=>GETPOST('propname', 'aZ09'),
-				'label'=>GETPOST('proplabel', 'alpha'),
-				'type'=>strtolower(GETPOST('proptype', 'alpha')),
-				'arrayofkeyval'=>GETPOST('proparrayofkeyval', 'alphawithlgt'), // Example json string '{"0":"Draft","1":"Active","-1":"Cancel"}'
-				'visible'=>GETPOST('propvisible', 'alphanohtml'),
-				'enabled'=>GETPOST('propenabled', 'alphanohtml'),
-				'position'=>GETPOSTINT('propposition'),
-				'notnull'=>GETPOSTINT('propnotnull'),
-				'index'=>GETPOSTINT('propindex'),
-				'foreignkey'=>GETPOST('propforeignkey', 'alpha'),
-				'searchall'=>GETPOSTINT('propsearchall'),
-				'isameasure'=>GETPOSTINT('propisameasure'),
-				'comment'=>GETPOST('propcomment', 'alpha'),
-				'help'=>GETPOST('prophelp', 'alpha'),
-				'css'=>GETPOST('propcss', 'alpha'),        // Can be 'maxwidth500 widthcentpercentminusxx' for example
-				'cssview'=>GETPOST('propcssview', 'alpha'),
-				'csslist'=>GETPOST('propcsslist', 'alpha'),
-				'default'=>GETPOST('propdefault', 'restricthtml'),
-				'noteditable'=>intval(GETPOSTINT('propnoteditable')),
+				'name' => GETPOST('propname', 'aZ09'),
+				'label' => GETPOST('proplabel', 'alpha'),
+				'type' => strtolower(GETPOST('proptype', 'alpha')),
+				'arrayofkeyval' => GETPOST('proparrayofkeyval', 'alphawithlgt'), // Example json string '{"0":"Draft","1":"Active","-1":"Cancel"}'
+				'visible' => GETPOST('propvisible', 'alphanohtml'),
+				'enabled' => GETPOST('propenabled', 'alphanohtml'),
+				'position' => GETPOSTINT('propposition'),
+				'notnull' => GETPOSTINT('propnotnull'),
+				'index' => GETPOSTINT('propindex'),
+				'foreignkey' => GETPOST('propforeignkey', 'alpha'),
+				'searchall' => GETPOSTINT('propsearchall'),
+				'isameasure' => GETPOSTINT('propisameasure'),
+				'comment' => GETPOST('propcomment', 'alpha'),
+				'help' => GETPOST('prophelp', 'alpha'),
+				'css' => GETPOST('propcss', 'alpha'),        // Can be 'maxwidth500 widthcentpercentminusxx' for example
+				'cssview' => GETPOST('propcssview', 'alpha'),
+				'csslist' => GETPOST('propcsslist', 'alpha'),
+				'default' => GETPOST('propdefault', 'restricthtml'),
+				'noteditable' => intval(GETPOSTINT('propnoteditable')),
 				//'alwayseditable'=>intval(GETPOST('propalwayseditable', 'int')),
 				'validate' => GETPOSTINT('propvalidate')
 			);
@@ -1927,27 +1927,27 @@ if ($dirins && $action == 'confirm_deleteobject' && $objectname) {
 
 		// Delete some files
 		$filetodelete = array(
-			'myobject_card.php'=>strtolower($objectname).'_card.php',
-			'myobject_note.php'=>strtolower($objectname).'_note.php',
-			'myobject_contact.php'=>strtolower($objectname).'_contact.php',
-			'myobject_document.php'=>strtolower($objectname).'_document.php',
-			'myobject_agenda.php'=>strtolower($objectname).'_agenda.php',
-			'myobject_list.php'=>strtolower($objectname).'_list.php',
-			'admin/myobject_extrafields.php'=>'admin/'.strtolower($objectname).'_extrafields.php',
-			'lib/mymodule_myobject.lib.php'=>'lib/'.strtolower($module).'_'.strtolower($objectname).'.lib.php',
-			'test/phpunit/MyObjectTest.php'=>'test/phpunit/'.strtolower($objectname).'Test.php',
-			'sql/llx_mymodule_myobject.sql'=>'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'.sql',
-			'sql/llx_mymodule_myobject_extrafields.sql'=>'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'_extrafields.sql',
-			'sql/llx_mymodule_myobject.key.sql'=>'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'.key.sql',
-			'sql/llx_mymodule_myobject_extrafields.key.sql'=>'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'_extrafields.key.sql',
-			'scripts/myobject.php'=>'scripts/'.strtolower($objectname).'.php',
-			'class/myobject.class.php'=>'class/'.strtolower($objectname).'.class.php',
-			'class/api_myobject.class.php'=>'class/api_'.strtolower($module).'.class.php',
-			'core/modules/mymodule/mod_myobject_advanced.php'=>'core/modules/'.strtolower($module).'/mod_'.strtolower($objectname).'_advanced.php',
-			'core/modules/mymodule/mod_myobject_standard.php'=>'core/modules/'.strtolower($module).'/mod_'.strtolower($objectname).'_standard.php',
-			'core/modules/mymodule/modules_myobject.php'=>'core/modules/'.strtolower($module).'/modules_'.strtolower($objectname).'.php',
-			'core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php'=>'core/modules/'.strtolower($module).'/doc/doc_generic_'.strtolower($objectname).'_odt.modules.php',
-			'core/modules/mymodule/doc/pdf_standard_myobject.modules.php'=>'core/modules/'.strtolower($module).'/doc/pdf_standard_'.strtolower($objectname).'.modules.php'
+			'myobject_card.php' => strtolower($objectname).'_card.php',
+			'myobject_note.php' => strtolower($objectname).'_note.php',
+			'myobject_contact.php' => strtolower($objectname).'_contact.php',
+			'myobject_document.php' => strtolower($objectname).'_document.php',
+			'myobject_agenda.php' => strtolower($objectname).'_agenda.php',
+			'myobject_list.php' => strtolower($objectname).'_list.php',
+			'admin/myobject_extrafields.php' => 'admin/'.strtolower($objectname).'_extrafields.php',
+			'lib/mymodule_myobject.lib.php' => 'lib/'.strtolower($module).'_'.strtolower($objectname).'.lib.php',
+			'test/phpunit/MyObjectTest.php' => 'test/phpunit/'.strtolower($objectname).'Test.php',
+			'sql/llx_mymodule_myobject.sql' => 'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'.sql',
+			'sql/llx_mymodule_myobject_extrafields.sql' => 'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'_extrafields.sql',
+			'sql/llx_mymodule_myobject.key.sql' => 'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'.key.sql',
+			'sql/llx_mymodule_myobject_extrafields.key.sql' => 'sql/llx_'.strtolower($module).'_'.strtolower($objectname).'_extrafields.key.sql',
+			'scripts/myobject.php' => 'scripts/'.strtolower($objectname).'.php',
+			'class/myobject.class.php' => 'class/'.strtolower($objectname).'.class.php',
+			'class/api_myobject.class.php' => 'class/api_'.strtolower($module).'.class.php',
+			'core/modules/mymodule/mod_myobject_advanced.php' => 'core/modules/'.strtolower($module).'/mod_'.strtolower($objectname).'_advanced.php',
+			'core/modules/mymodule/mod_myobject_standard.php' => 'core/modules/'.strtolower($module).'/mod_'.strtolower($objectname).'_standard.php',
+			'core/modules/mymodule/modules_myobject.php' => 'core/modules/'.strtolower($module).'/modules_'.strtolower($objectname).'.php',
+			'core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php' => 'core/modules/'.strtolower($module).'/doc/doc_generic_'.strtolower($objectname).'_odt.modules.php',
+			'core/modules/mymodule/doc/pdf_standard_myobject.modules.php' => 'core/modules/'.strtolower($module).'/doc/pdf_standard_'.strtolower($objectname).'.modules.php'
 		);
 
 		//menu for the object selected
@@ -2071,7 +2071,7 @@ if (($dirins && $action == 'confirm_deletedictionary' && $dicname) || ($dirins &
 	}
 
 	if (!empty(GETPOST('dictionnarykey'))) {
-		$newdicname = $dicts['tabname'][GETPOST('dictionnarykey')-1];
+		$newdicname = $dicts['tabname'][GETPOST('dictionnarykey') - 1];
 	}
 
 	//chercher la table dicname
@@ -2276,13 +2276,13 @@ if ($dirins && $action == 'addright' && !empty($module) && empty($cancel)) {
 
 	//check existing object permission
 	$counter = 0;
-	$permsForObject =array();
+	$permsForObject = array();
 	$permissions = $moduleobj->rights;
 	$allObject = array();
 
 	$countPerms = count($permissions);
 
-	for ($i =0; $i<$countPerms; $i++) {
+	for ($i = 0; $i < $countPerms; $i++) {
 		if ($permissions[$i][4] == $objectForPerms) {
 			$counter++;
 			if (count($permsForObject) < 3) {
@@ -2294,7 +2294,7 @@ if ($dirins && $action == 'addright' && !empty($module) && empty($cancel)) {
 
 	// check if label of object already exists
 	$countPermsObj = count($permsForObject);
-	for ($j = 0; $j<$countPermsObj; $j++) {
+	for ($j = 0; $j < $countPermsObj; $j++) {
 		if (in_array($crud, $permsForObject[$j])) {
 			$error++;
 			setEventMessages($langs->trans("ErrorExistingPermission", $langs->transnoentities($crud), $langs->transnoentities($objectForPerms)), null, 'errors');
@@ -2305,10 +2305,10 @@ if ($dirins && $action == 'addright' && !empty($module) && empty($cancel)) {
 		$key = $countPerms + 1;
 		//prepare right to add
 		$rightToAdd = [
-			0=> $id,
-			1=>$label,
-			4=>$objectForPerms,
-			5=>$crud
+			0 => $id,
+			1 => $label,
+			4 => $objectForPerms,
+			5 => $crud
 		];
 
 		if (isModEnabled(strtolower($module))) {
@@ -2340,7 +2340,7 @@ if ($dirins && $action == 'addright' && !empty($module) && empty($cancel)) {
 
 
 // Update permission
-if ($dirins && GETPOST('action') == 'update_right' && GETPOST('modifyright')&& empty($cancel)) {
+if ($dirins && GETPOST('action') == 'update_right' && GETPOST('modifyright') && empty($cancel)) {
 	$error = 0;
 	// load class and check if right exist
 	$pathtofile = $listofmodules[strtolower($module)]['moduledescriptorrelpath'];
@@ -2383,21 +2383,21 @@ if ($dirins && GETPOST('action') == 'update_right' && GETPOST('modifyright')&& e
 	}
 
 	$permissions = $moduleobj->rights;
-	$key =(int) GETPOST('counter')-1;
+	$key = (int) GETPOST('counter') - 1;
 	//get permission want to delete from permissions array
 	$x1 = $permissions[$key][1];
 	$x2 = $permissions[$key][4];
 	$x3 = $permissions[$key][5];
 	//check existing object permission
 	$counter = 0;
-	$permsForObject =array();
+	$permsForObject = array();
 	$permissions = $moduleobj->rights;
 	$firstRight = 0;
 	$existRight = 0;
 	$allObject = array();
 
 	$countPerms = count($permissions);
-	for ($i =0; $i<$countPerms; $i++) {
+	for ($i = 0; $i < $countPerms; $i++) {
 		if ($permissions[$i][4] == $objectForPerms) {
 			$counter++;
 			if (count($permsForObject) < 3) {
@@ -2409,7 +2409,7 @@ if ($dirins && GETPOST('action') == 'update_right' && GETPOST('modifyright')&& e
 
 	if ($label != $x1 && $crud != $x3) {
 		$countPermsObj = count($permsForObject);
-		for ($j = 0; $j<$countPermsObj; $j++) {
+		for ($j = 0; $j < $countPermsObj; $j++) {
 			if (in_array($label, $permsForObject[$j])) {
 				$error++;
 				setEventMessages($langs->trans("ErrorExistingPermission", $langs->transnoentities($label), $langs->transnoentities($objectForPerms)), null, 'errors');
@@ -2461,7 +2461,7 @@ if ($dirins && $action == 'confirm_deleteright' && !empty($module) && GETPOSTINT
 	}
 
 	$permissions = $moduleobj->rights;
-	$key = GETPOSTINT('permskey')-1;
+	$key = GETPOSTINT('permskey') - 1;
 
 	if (!$error) {
 		// check if module is enabled
@@ -2748,7 +2748,7 @@ if ($dirins && $action == 'addmenu' && empty($cancel)) {
 	$objects = dolGetListOfObjectClasses($destdir);
 
 	if (GETPOST('type', 'alpha') == 'left') {
-		if (empty(GETPOST('leftmenu')) && count($objects) >0) {
+		if (empty(GETPOST('leftmenu')) && count($objects) > 0) {
 			$error++;
 			setEventMessages($langs->trans("ErrorCoherenceMenu", $langs->transnoentities("leftmenu"), $langs->transnoentities("type")), null, 'errors');
 		}
@@ -2905,7 +2905,7 @@ if ($dirins && $action == "update_menu" && GETPOSTINT('menukey') && GETPOST('tab
 				if ($result < 0) {
 					setEventMessages($langs->trans('ErrorMenuExistValue'), null, 'errors');
 					//var_dump($_SESSION);exit;
-					header("Location: ".$_SERVER["PHP_SELF"].'?action=editmenu&token='.newToken().'&menukey='.urlencode($key+1).'&tab='.urlencode($tab).'&module='.urlencode($module).'&tabobj='.($key+1));
+					header("Location: ".$_SERVER["PHP_SELF"].'?action=editmenu&token='.newToken().'&menukey='.urlencode($key + 1).'&tab='.urlencode($tab).'&module='.urlencode($module).'&tabobj='.($key + 1));
 					exit;
 				}
 
@@ -4186,8 +4186,8 @@ if ($module == 'initmodule') {
 								print '<a class="reposition editfielda" href="'.$_SERVER['PHP_SELF'].'?tab='.urlencode($tab).'&tabobj='.$tabobj.'&module='.$module.($forceddirread ? '@'.$dirread : '').'&action=confirm_removefile&token='.newToken().'&file='.urlencode($pathtoapi).'">'.img_picto($langs->trans("Delete"), 'delete').'</a>';
 								print $form->textwithpicto('', $langs->trans("InfoForApiFile"), 1, 'warning');
 								print ' &nbsp; ';
-								// @phan-suppress-next-line ParamMatchRegexError
-								if (!isModEnabled($modulelowercase)) {	// If module is not activated
+								// Comparing to null (phan considers $modulelowercase can be null here)
+								if ($modulelowercase !== null && !isModEnabled($modulelowercase)) {	// If module is not activated
 									print '<a href="#" class="classfortooltip" target="apiexplorer" title="'.$langs->trans("ModuleMustBeEnabled", $module).'"><strike>'.$langs->trans("ApiExplorer").'</strike></a>';
 								} else {
 									print '<a href="'.DOL_URL_ROOT.'/api/index.php/explorer/" target="apiexplorer">'.$langs->trans("ApiExplorer").'</a>';
@@ -4799,14 +4799,14 @@ if ($module == 'initmodule') {
 						$i = 0;
 						$maxi = count($dicts['tabname']);
 						while ($i < $maxi) {
-							if ($action == 'editdict' && $i == GETPOSTINT('dictionnarykey')-1) {
+							if ($action == 'editdict' && $i == GETPOSTINT('dictionnarykey') - 1) {
 								print '<tr class="oddeven">';
 								print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 								print '<input type="hidden" name="token" value="'.newToken().'">';
 								print '<input type="hidden" name="tab" value="dictionaries">';
 								print '<input type="hidden" name="module" value="'.dol_escape_htmltag($module).'">';
 								print '<input type="hidden" name="action" value="updatedictionary">';
-								print '<input type="hidden" name="dictionnarykey" value="'.($i+1).'">';
+								print '<input type="hidden" name="dictionnarykey" value="'.($i + 1).'">';
 
 								print '<td class="tdsticky tdstickygray">';
 								print($i + 1);
@@ -4902,8 +4902,8 @@ if ($module == 'initmodule') {
 								print '</td>';
 
 								print '<td class="center minwidth75 tdstickyright tdstickyghostwhite">';
-								print '<a class="editfielda reposition marginleftonly marginrighttonly paddingright paddingleft" href="'.$_SERVER["PHP_SELF"].'?action=editdict&token='.newToken().'&dictionnarykey='.urlencode($i+1).'&tab='.urlencode($tab).'&module='.urlencode($module).'">'.img_edit().'</a>';
-								print '<a class="marginleftonly marginrighttonly paddingright paddingleft" href="'.$_SERVER["PHP_SELF"].'?action=deletedict&token='.newToken().'&dictionnarykey='.urlencode($i+1).'&tab='.urlencode($tab).'&module='.urlencode($module).'">'.img_delete().'</a>';
+								print '<a class="editfielda reposition marginleftonly marginrighttonly paddingright paddingleft" href="'.$_SERVER["PHP_SELF"].'?action=editdict&token='.newToken().'&dictionnarykey='.urlencode($i + 1).'&tab='.urlencode($tab).'&module='.urlencode($module).'">'.img_edit().'</a>';
+								print '<a class="marginleftonly marginrighttonly paddingright paddingleft" href="'.$_SERVER["PHP_SELF"].'?action=deletedict&token='.newToken().'&dictionnarykey='.urlencode($i + 1).'&tab='.urlencode($tab).'&module='.urlencode($module).'">'.img_delete().'</a>';
 								print '</td>';
 
 								print '</tr>';
@@ -5043,7 +5043,7 @@ if ($module == 'initmodule') {
 			$menus = $moduleobj->menu;
 
 			$permissions = $moduleobj->rights;
-			$crud = array('read'=>'CRUDRead', 'write'=>'CRUDCreateWrite', 'delete'=>'Delete');
+			$crud = array('read' => 'CRUDRead', 'write' => 'CRUDCreateWrite', 'delete' => 'Delete');
 
 			//grouped permissions
 			$groupedRights = array();
@@ -5118,7 +5118,7 @@ if ($module == 'initmodule') {
 				print_liste_field_titre("", $_SERVER["PHP_SELF"], '', "", $param, '', $sortfield, $sortorder, 'center ', $langs->trans(''));
 				print "</tr>\n";
 
-				$r = count($menus)+1;
+				$r = count($menus) + 1;
 				// for adding menu on module
 				print '<tr>';
 				print '<td class="center tdsticky tdstickygray"><input type="hidden" readonly class="center maxwidth50" name="propenabled" value="#"></td>';
@@ -5143,7 +5143,7 @@ if ($module == 'initmodule') {
 				print '<td class="left"><input id="url" type="text" class="left maxwidth100" name="url" value="'.dol_escape_htmltag(GETPOST('url', 'alpha')).'"></td>';
 				print '<td class="left"><input type="text" class="left maxwidth75" name="langs" value="'.strtolower($module).'@'.strtolower($module).'" readonly></td>';
 				// Position
-				print '<td class="center"><input type="text" class="center maxwidth50 tdstickygray" name="position" value="'.(1000+$r).'" readonly></td>';
+				print '<td class="center"><input type="text" class="center maxwidth50 tdstickygray" name="position" value="'.(1000 + $r).'" readonly></td>';
 				// Enabled
 				print '<td class="center">';
 				print '<input type="enabled" class="maxwidth125" value="'.dol_escape_htmltag(GETPOSTISSET('enabled') ? GETPOST('enabled') : 'isModEnabled(\''.$module.'\')').'">';
@@ -5375,7 +5375,7 @@ if ($module == 'initmodule') {
 							print '<td class="center minwidth75 tdstickyright tdstickyghostwhite">';
 							if ($menu['titre'] != 'Module'.$module.'Name') {
 								print '<a class="editfielda reposition marginleftonly marginrighttonly paddingright paddingleft" href="'.$_SERVER["PHP_SELF"].'?action=editmenu&token='.newToken().'&menukey='.urlencode($i).'&tab='.urlencode($tab).'&module='.urlencode($module).'&tabobj='.urlencode($tabobj).'">'.img_edit().'</a>';
-								print '<a class="marginleftonly marginrighttonly paddingright paddingleft" href="'.$_SERVER["PHP_SELF"].'?action=deletemenu&token='.newToken().'&menukey='.urlencode($i-1).'&tab='.urlencode($tab).'&module='.urlencode($module).'&tabobj='.urlencode($tabobj).'">'.img_delete().'</a>';
+								print '<a class="marginleftonly marginrighttonly paddingright paddingleft" href="'.$_SERVER["PHP_SELF"].'?action=deletemenu&token='.newToken().'&menukey='.urlencode($i - 1).'&tab='.urlencode($tab).'&module='.urlencode($module).'&tabobj='.urlencode($tabobj).'">'.img_delete().'</a>';
 							}
 							print '</td>';
 						}
@@ -5474,7 +5474,7 @@ if ($module == 'initmodule') {
 			$dir = $dirread.'/'.$modulelowercase.'/class';
 			$listofobject = dol_dir_list($dir, 'files', 0, '\.class\.php$');
 			$objects = array('myobject');
-			$reg =array();
+			$reg = array();
 			foreach ($listofobject as $fileobj) {
 				$tmpcontent = file_get_contents($fileobj['fullname']);
 				if (preg_match('/class\s+([^\s]*)\s+extends\s+CommonObject/ims', $tmpcontent, $reg)) {
@@ -5483,7 +5483,7 @@ if ($module == 'initmodule') {
 			}
 
 			// declared select list for actions and labels permissions
-			$crud = array('read'=>'CRUDRead', 'write'=>'CRUDCreateWrite', 'delete'=>'Delete');
+			$crud = array('read' => 'CRUDRead', 'write' => 'CRUDCreateWrite', 'delete' => 'Delete');
 			$labels = array("Read objects of ".$module, "Create/Update objects of ".$module, "Delete objects of ".$module);
 
 			$action = GETPOST('action', 'alpha');
@@ -5590,7 +5590,7 @@ if ($module == 'initmodule') {
 							print '<td>';
 							print '<select name="crud">';
 							print '<option value="'.dol_escape_htmltag($perm[5]).'">'.$langs->trans($perm[5]).'</option>';
-							foreach ($crud as $i=> $x) {
+							foreach ($crud as $i => $x) {
 								if ($perm[5] != $i) {
 									print '<option value="'.$i.'">'.$langs->trans(ucfirst($x)).'</option>';
 								}

--- a/htdocs/projet/activity/perday.php
+++ b/htdocs/projet/activity/perday.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2005-2010 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2010      François Legastelois <flegastelois@teclib.com>
  * Copyright (C) 2018      Frédéric France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,7 +51,7 @@ if ($mode == 'mine') {
 	$mine = 1;
 }
 
-$projectid = GETPOSTISSET("id") ? GETPOST("id", "int", 1) : GETPOSTINT("projectid");
+$projectid = GETPOSTISSET("id") ? GETPOSTINT("id", 1) : GETPOSTINT("projectid");
 
 $hookmanager->initHooks(array('timesheetperdaycard'));
 
@@ -124,9 +125,9 @@ $extrafields->fetch_name_optionals_label($object->table_element);
 
 // Definition of fields for list
 $arrayfields = array();
-$arrayfields['t.planned_workload'] = array('label'=>'PlannedWorkload', 'checked'=>1, 'enabled'=>1, 'position'=>0);
-$arrayfields['t.progress'] = array('label'=>'ProgressDeclared', 'checked'=>1, 'enabled'=>1, 'position'=>0);
-$arrayfields['timeconsumed'] = array('label'=>'TimeConsumed', 'checked'=>1, 'enabled'=>1, 'position'=>15);
+$arrayfields['t.planned_workload'] = array('label' => 'PlannedWorkload', 'checked' => 1, 'enabled' => 1, 'position' => 0);
+$arrayfields['t.progress'] = array('label' => 'ProgressDeclared', 'checked' => 1, 'enabled' => 1, 'position' => 0);
+$arrayfields['timeconsumed'] = array('label' => 'TimeConsumed', 'checked' => 1, 'enabled' => 1, 'position' => 15);
 /*$arrayfields=array(
  // Project
  'p.opp_amount'=>array('label'=>$langs->trans("OpportunityAmountShort"), 'checked'=>0, 'enabled'=>($conf->global->PROJECT_USE_OPPORTUNITIES?1:0), 'position'=>103),
@@ -140,7 +141,7 @@ $arrayfields['timeconsumed'] = array('label'=>'TimeConsumed', 'checked'=>1, 'ena
 if (!empty($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label']) > 0) {
 	foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $val) {
 		if (!empty($extrafields->attributes[$object->table_element]['list'][$key])) {
-			$arrayfields["efpt.".$key] = array('label'=>$extrafields->attributes[$object->table_element]['label'][$key], 'checked'=>(($extrafields->attributes[$object->table_element]['list'][$key] < 0) ? 0 : 1), 'position'=>$extrafields->attributes[$object->table_element]['pos'][$key], 'enabled'=>(abs((int) $extrafields->attributes[$object->table_element]['list'][$key]) != 3 && $extrafields->attributes[$object->table_element]['perms'][$key]));
+			$arrayfields["efpt.".$key] = array('label' => $extrafields->attributes[$object->table_element]['label'][$key], 'checked' => (($extrafields->attributes[$object->table_element]['list'][$key] < 0) ? 0 : 1), 'position' => $extrafields->attributes[$object->table_element]['pos'][$key], 'enabled' => (abs((int) $extrafields->attributes[$object->table_element]['list'][$key]) != 3 && $extrafields->attributes[$object->table_element]['perms'][$key]));
 		}
 	}
 }
@@ -645,7 +646,7 @@ $isavailable[$daytoparse] = $isavailablefordayanduser; // in projectLinesPerWeek
 
 $test = num_public_holiday($daytoparsegmt, $daytoparsegmt + 86400, $mysoc->country_code);
 if ($test) {
-	$isavailable[$daytoparse] = array('morning'=>false, 'afternoon'=>false, 'morning_reason'=>'public_holiday', 'afternoon_reason'=>'public_holiday');
+	$isavailable[$daytoparse] = array('morning' => false, 'afternoon' => false, 'morning_reason' => 'public_holiday', 'afternoon_reason' => 'public_holiday');
 }
 
 $tmparray = dol_getdate($daytoparse, true); // detail of current day

--- a/htdocs/projet/activity/permonth.php
+++ b/htdocs/projet/activity/permonth.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2004-2015 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2010 Regis Houssin        <regis.houssin@capnetworks.com>
  * Copyright (C) 2010      François Legastelois <flegastelois@teclib.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,7 +50,7 @@ if ($mode == 'mine') {
 	$mine = 1;
 }
 
-$projectid = GETPOSTISSET("id") ? GETPOST("id", "int", 1) : GETPOSTINT("projectid");
+$projectid = GETPOSTISSET("id") ? GETPOSTINT("id", 1) : GETPOSTINT("projectid");
 
 $hookmanager->initHooks(array('timesheetpermonthcard'));
 
@@ -125,9 +126,9 @@ $arrayfields = array();
  'p.budget_amount'=>array('label'=>$langs->trans("Budget"), 'checked'=>0, 'position'=>110),
  'p.usage_bill_time'=>array('label'=>$langs->trans("BillTimeShort"), 'checked'=>0, 'position'=>115),
  );*/
-$arrayfields['t.planned_workload'] = array('label'=>'PlannedWorkload', 'checked'=>1, 'enabled'=>1, 'position'=>5);
-$arrayfields['t.progress'] = array('label'=>'ProgressDeclared', 'checked'=>1, 'enabled'=>1, 'position'=>10);
-$arrayfields['timeconsumed'] = array('label'=>'TimeConsumed', 'checked'=>1, 'enabled'=>1, 'position'=>15);
+$arrayfields['t.planned_workload'] = array('label' => 'PlannedWorkload', 'checked' => 1, 'enabled' => 1, 'position' => 5);
+$arrayfields['t.progress'] = array('label' => 'ProgressDeclared', 'checked' => 1, 'enabled' => 1, 'position' => 10);
+$arrayfields['timeconsumed'] = array('label' => 'TimeConsumed', 'checked' => 1, 'enabled' => 1, 'position' => 15);
 /*foreach($object->fields as $key => $val)
  {
  // If $val['visible']==0, then we never show the field
@@ -138,7 +139,7 @@ $arrayfields['timeconsumed'] = array('label'=>'TimeConsumed', 'checked'=>1, 'ena
 if (!empty($extrafields->attributes['projet_task']['label']) && is_array($extrafields->attributes['projet_task']['label']) && count($extrafields->attributes['projet_task']['label']) > 0) {
 	foreach ($extrafields->attributes['projet_task']['label'] as $key => $val) {
 		if (!empty($extrafields->attributes['projet_task']['list'][$key])) {
-			$arrayfields["efpt.".$key] = array('label'=>$extrafields->attributes['projet_task']['label'][$key], 'checked'=>(($extrafields->attributes['projet_task']['list'][$key] < 0) ? 0 : 1), 'position'=>$extrafields->attributes['projet_task']['pos'][$key], 'enabled'=>(abs((int) $extrafields->attributes['projet_task']['list'][$key]) != 3 && $extrafields->attributes['projet_task']['perms'][$key]));
+			$arrayfields["efpt.".$key] = array('label' => $extrafields->attributes['projet_task']['label'][$key], 'checked' => (($extrafields->attributes['projet_task']['list'][$key] < 0) ? 0 : 1), 'position' => $extrafields->attributes['projet_task']['pos'][$key], 'enabled' => (abs((int) $extrafields->attributes['projet_task']['list'][$key]) != 3 && $extrafields->attributes['projet_task']['perms'][$key]));
 		}
 	}
 }

--- a/htdocs/projet/activity/perweek.php
+++ b/htdocs/projet/activity/perweek.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2005-2010 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2010      François Legastelois <flegastelois@teclib.com>
  * Copyright (C) 2018      Frédéric France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,7 +51,7 @@ if ($mode == 'mine') {
 	$mine = 1;
 }
 
-$projectid = GETPOSTISSET("id") ? GETPOST("id", "int", 1) : GETPOSTINT("projectid");
+$projectid = GETPOSTISSET("id") ? GETPOSTINT("id", 1) : GETPOSTINT("projectid");
 
 $hookmanager->initHooks(array('timesheetperweekcard'));
 
@@ -129,9 +130,9 @@ $arrayfields = array();
  'p.budget_amount'=>array('label'=>$langs->trans("Budget"), 'checked'=>0, 'position'=>110),
  'p.usage_bill_time'=>array('label'=>$langs->trans("BillTimeShort"), 'checked'=>0, 'position'=>115),
  );*/
-$arrayfields['t.planned_workload'] = array('label'=>'PlannedWorkload', 'checked'=>1, 'enabled'=>1, 'position'=>5);
-$arrayfields['t.progress'] = array('label'=>'ProgressDeclared', 'checked'=>1, 'enabled'=>1, 'position'=>10);
-$arrayfields['timeconsumed'] = array('label'=>'TimeConsumed', 'checked'=>1, 'enabled'=>1, 'position'=>15);
+$arrayfields['t.planned_workload'] = array('label' => 'PlannedWorkload', 'checked' => 1, 'enabled' => 1, 'position' => 5);
+$arrayfields['t.progress'] = array('label' => 'ProgressDeclared', 'checked' => 1, 'enabled' => 1, 'position' => 10);
+$arrayfields['timeconsumed'] = array('label' => 'TimeConsumed', 'checked' => 1, 'enabled' => 1, 'position' => 15);
 /*foreach($object->fields as $key => $val)
  {
  // If $val['visible']==0, then we never show the field
@@ -142,7 +143,7 @@ $arrayfields['timeconsumed'] = array('label'=>'TimeConsumed', 'checked'=>1, 'ena
 if (!empty($extrafields->attributes['projet_task']['label']) && is_array($extrafields->attributes['projet_task']['label']) && count($extrafields->attributes['projet_task']['label']) > 0) {
 	foreach ($extrafields->attributes['projet_task']['label'] as $key => $val) {
 		if (!empty($extrafields->attributes['projet_task']['list'][$key])) {
-			$arrayfields["efpt.".$key] = array('label'=>$extrafields->attributes['projet_task']['label'][$key], 'checked'=>(($extrafields->attributes['projet_task']['list'][$key] < 0) ? 0 : 1), 'position'=>$extrafields->attributes['projet_task']['pos'][$key], 'enabled'=>(abs((int) $extrafields->attributes['projet_task']['list'][$key]) != 3 && $extrafields->attributes['projet_task']['perms'][$key]));
+			$arrayfields["efpt.".$key] = array('label' => $extrafields->attributes['projet_task']['label'][$key], 'checked' => (($extrafields->attributes['projet_task']['list'][$key] < 0) ? 0 : 1), 'position' => $extrafields->attributes['projet_task']['pos'][$key], 'enabled' => (abs((int) $extrafields->attributes['projet_task']['list'][$key]) != 3 && $extrafields->attributes['projet_task']['perms'][$key]));
 		}
 	}
 }
@@ -536,7 +537,7 @@ for ($idw = 0; $idw < 7; $idw++) {
 
 	$test = num_public_holiday($dayinloopfromfirstdaytoshowgmt, $dayinloopfromfirstdaytoshowgmt + 86400, $mysoc->country_code);
 	if ($test) {
-		$isavailable[$dayinloopfromfirstdaytoshow] = array('morning'=>false, 'afternoon'=>false, 'morning_reason'=>'public_holiday', 'afternoon_reason'=>'public_holiday');
+		$isavailable[$dayinloopfromfirstdaytoshow] = array('morning' => false, 'afternoon' => false, 'morning_reason' => 'public_holiday', 'afternoon_reason' => 'public_holiday');
 	}
 }
 


### PR DESCRIPTION
# Qual: Enable detection of deprecated modulename & GETPOST(...,'int')

Enable phan rules to verify deprecated modulename usage and GETPOST(...,'int') usage in the code.

EDIT: this reveals a few cases that were not automatically replaced as one of the conditions for replacement was to have only 2 arguments to the GETPOST call.
EDIT2: I have updated the fixer to fix those cases - added to this PR.