### PR TITLE
fix translate with memcached and multilangs

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -31,7 +31,7 @@
 class Translate
 {
 	/**
-	 * @var string      Directory containing the /langs subdirectory
+	 * @var string[]      Directory containing the /langs subdirectory
 	 */
 	public $dir;
 
@@ -248,10 +248,12 @@ class Translate
 	 * 	@param	string	$forcelangdir				To force a different lang directory
 	 *  @param  int     $loadfromfileonly   		1=Do not load overwritten translation from file or old conf.
 	 *  @param  int     $forceloadifalreadynotfound	Force attempt to reload lang file if it was previously not found
+	 *  @param  array   $tabtranslatedomain			Store translations to be stored in cache
+	 *  @param  string  $langkey                    To create key for cachekey in recursivity
 	 *	@return	int									Return integer <0 if KO, 0 if already loaded or loading not required, >0 if OK
 	 *  @see loadLangs()
 	 */
-	public function load($domain, $alt = 0, $stopafterdirection = 0, $forcelangdir = '', $loadfromfileonly = 0, $forceloadifalreadynotfound = 0)
+	public function load($domain, $alt = 0, $stopafterdirection = 0, $forcelangdir = '', $loadfromfileonly = 0, $forceloadifalreadynotfound = 0, &$tabtranslatedomain = [], $langkey = '')
 	{
 		global $conf, $db;
 
@@ -294,6 +296,7 @@ class Translate
 
 		$fileread = 0;
 		$langofdir = (empty($forcelangdir) ? $this->defaultlang : $forcelangdir);
+		$langkey = (empty($langkey) ? $langofdir : $langkey);
 
 		// Redefine alt
 		$langarray = explode('_', $langofdir);
@@ -328,7 +331,7 @@ class Translate
 				$usecachekey = '';
 				// Using a memcached server
 				if (isModEnabled('memcached') && getDolGlobalString('MEMCACHED_SERVER')) {
-					$usecachekey = $newdomain . '_' . $langofdir . '_' . md5($file_lang); // Should not contains special chars
+					$usecachekey = $newdomain . '_' . $langkey . '_' . md5($file_lang); // Should not contains special chars
 				} elseif (getDolGlobalInt('MAIN_OPTIMIZE_SPEED') & 0x02) {
 					// Using cache with shmop. Speed gain: 40ms - Memory overusage: 200ko (Size of session cache file)
 					$usecachekey = $newdomain;
@@ -336,14 +339,10 @@ class Translate
 
 				if ($usecachekey) {
 					//dol_syslog('Translate::Load we will cache result into usecachekey '.$usecachekey);
-					//global $aaa; $aaa+=1;
-					//print $aaa." ".$usecachekey."\n";
 					require_once DOL_DOCUMENT_ROOT . '/core/lib/memory.lib.php';
 					$tmparray = dol_getcache($usecachekey);
 					if (is_array($tmparray) && count($tmparray)) {
 						$this->tab_translate += $tmparray; // Faster than array_merge($tmparray,$this->tab_translate). Note: If a value already exists into tab_translate, value into tmparaay is not added.
-						//print $newdomain."\n";
-						//var_dump($this->tab_translate);
 						if ($alt == 2) {
 							$fileread = 1;
 						}
@@ -354,7 +353,7 @@ class Translate
 				if (!$found) {
 					if ($fp = @fopen($file_lang, "rt")) {
 						if ($usecachekey) {
-							$tabtranslatedomain = array(); // To save lang content in cache
+							// $tabtranslatedomain = array(); // To save lang content in cache
 						}
 
 						/**
@@ -392,16 +391,6 @@ class Translate
 						fclose($fp);
 						$fileread = 1;
 
-						// TODO Move cache write out of loop on dirs
-						// To save lang content for usecachekey into cache
-						if ($usecachekey && count($tabtranslatedomain)) {
-							$ressetcache = dol_setcache($usecachekey, $tabtranslatedomain);
-							if ($ressetcache < 0) {
-								$error = 'Failed to set cache for usecachekey=' . $usecachekey . ' result=' . $ressetcache;
-								dol_syslog($error, LOG_ERR);
-							}
-						}
-
 						if (!getDolGlobalString('MAIN_FORCELANGDIR')) {
 							break; // Break loop on each root dir. If a module has forced dir, we do not stop loop.
 						}
@@ -421,7 +410,7 @@ class Translate
 			if ($langofdir == 'ar_AR') {
 				$langofdir = 'ar_SA'; // main parent for ar_EG is not 'ar_AR' but 'ar_SA'
 			}
-			$this->load($domain, $alt + 1, $stopafterdirection, $langofdir);
+			$this->load($domain, $alt + 1, $stopafterdirection, $langofdir, 0, 0, $tabtranslatedomain, $langkey);
 		}
 
 		// Now we complete with reference file (en_US)
@@ -429,7 +418,7 @@ class Translate
 			// This function MUST NOT contains call to syslog
 			//dol_syslog("Translate::Load loading alternate translation file (to complete ".$this->defaultlang."/".$newdomain.".lang file)", LOG_DEBUG);
 			$langofdir = 'en_US';
-			$this->load($domain, $alt + 1, $stopafterdirection, $langofdir);
+			$this->load($domain, $alt + 1, $stopafterdirection, $langofdir, 0, 0, $tabtranslatedomain, $langkey);
 		}
 
 		// We are in the pass of the reference file. No more files to scan to complete.
@@ -456,6 +445,15 @@ class Translate
 						$this->tab_translate[$tmparray2[0]] = $tmparray2[1];
 					}
 				}
+			}
+		}
+
+		// To save lang content for usecachekey into cache
+		if ($usecachekey && count($tabtranslatedomain)) {
+			$ressetcache = dol_setcache($usecachekey, $tabtranslatedomain);
+			if ($ressetcache < 0) {
+				$error = 'Failed to set cache for usecachekey=' . $usecachekey . ' result=' . $ressetcache;
+				dol_syslog($error, LOG_ERR);
 			}
 		}
 

--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -312,6 +312,7 @@ class Translate
 			return -1;
 		}
 
+		$usecachekey = '';
 		foreach ($this->dir as $searchdir) {
 			// Directory of translation files
 			$file_lang = $searchdir . ($modulename ? '/' . $modulename : '') . "/langs/" . $langofdir . "/" . $newdomain . ".lang";


### PR DESCRIPTION
using memcached with multilang give sometimes incomplete translations, when completing with en_US by example

![image](https://github.com/Dolibarr/dolibarr/assets/3624836/3bf4073e-f890-4b85-9bac-43b65d7ee006)
