### PR TITLE
Fix: Modify module mapping principle

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -206,25 +206,40 @@ function getDolUserInt($key, $default = 0, $tmpuser = null)
 	return (int) (empty($tmpuser->conf->$key) ? $default : $tmpuser->conf->$key);
 }
 
+
+/**
+ * This mapping defines the conversion to the current internal
+ * names from the alternative allowed names (including effectively deprecated
+ * and future new names (not yet used as internal names).
+ *
+ * This allows to map any temporary or future name to the effective internal name.
+ *
+ * The value is typically the name of module's root directory.
+ */
 define(
-	'DEPRECATED_MODULE_MAPPING',
+	'MODULE_MAPPING',
 	array(
-		'actioncomm' => 'agenda',
-		'adherent' => 'member',
-		'adherent_type' => 'member_type',
-		'banque' => 'bank',
-		'categorie' => 'category',
-		'commande' => 'order',
-		'contrat' => 'contract',
-		'entrepot' => 'stock',
-		'expedition' => 'delivery_note',
-		'facture' => 'invoice',
-		'ficheinter' => 'intervention',
-		'product_fournisseur_price' => 'productsupplierprice',
-		'product_price' => 'productprice',
-		'projet'  => 'project',
-		'propale' => 'propal',
-		'socpeople' => 'contact',
+		// Map deprecated names to internal names
+		'adherent' => 'member',  // Has new directory
+		'member_type' => 'adherent_type',   // No directory, but file called adherent_type
+		'banque' => 'bank',   // Has new directory
+		'contrat' => 'contract', // Has new directory
+		'entrepot' => 'stock',   // Has new directory
+		'projet'  => 'project', // Has new directory
+
+		'actioncomm' => 'agenda',  // NO module directory (public dir agenda)
+		'product_price' => 'productprice', // NO directory
+		'product_fournisseur_price' => 'productsupplierprice', // NO directory
+
+		// Map future names to current internal names
+		'category' => 'categorie', // Has old directory
+		'order' => 'commande',    // Has old directory
+		'shipping' => 'expedition', // Has old directory
+		'invoice' => 'facture', // Has old directory
+		'intervention' => 'fichinter', // Has old directory
+		'ficheinter' => 'fichinter',  // Backup for 'fichinter'
+		'propal' => 'propale', // Has old directory
+		'contact' => 'socpeople', // Has old directory
 	)
 );
 
@@ -239,8 +254,8 @@ function isModEnabled($module)
 	global $conf;
 
 	// Fix old names (map to new names)
-	$arrayconv = DEPRECATED_MODULE_MAPPING;
-	$arrayconvbis = array_flip(DEPRECATED_MODULE_MAPPING);
+	$arrayconv = MODULE_MAPPING;
+	$arrayconvbis = array_flip(MODULE_MAPPING);
 
 	if (!getDolGlobalString('MAIN_USE_NEW_SUPPLIERMOD')) {
 		// Special cases: both use the same module.

--- a/htdocs/core/modules/import/modules_import.php
+++ b/htdocs/core/modules/import/modules_import.php
@@ -119,7 +119,7 @@ class ModeleImports
 	/**
 	 * @var	array	Element mapping from table name
 	 */
-	public static $mapTableToElement = DEPRECATED_MODULE_MAPPING;
+	public static $mapTableToElement = MODULE_MAPPING;
 
 	/**
 	 *  Constructor

--- a/test/phpunit/CodingPhpTest.php
+++ b/test/phpunit/CodingPhpTest.php
@@ -695,15 +695,16 @@ class CodingPhpTest extends CommonClassTest
 	 */
 	private function assertModuleIsOk($module_name, $message = '')
 	{
-		if (isset(self::DEPRECATED_MODULE_MAPPING[$module_name])) {
-			$new_name = self::DEPRECATED_MODULE_MAPPING[$module_name];
+		if (isset(self::EFFECTIVE_DEPRECATED_MODULE_MAPPING[$module_name])) {
+			$new_name = self::EFFECTIVE_DEPRECATED_MODULE_MAPPING[$module_name];
 			print("\033[31mDeprecated module name, use '$new_name':\033[0m$message".PHP_EOL);
 
 			//trigger_error("Deprecated module name, use '$new_name': $message", E_USER_NOTICE);
 			//trigger_error("Deprecated module name, use '$new_name': $message", E_USER_DEPRECATED);
 		} else {
 			$this->assertTrue(
-				array_key_exists($module_name, self::VALID_MODULE_MAPPING),
+				array_key_exists($module_name, self::VALID_MODULE_MAPPING)
+				|| array_key_exists($module_name, self::DEPRECATED_MODULE_MAPPIG),
 				"Unknown module: $message"
 			);
 		}

--- a/test/phpunit/CommonClassTest.class.php
+++ b/test/phpunit/CommonClassTest.class.php
@@ -39,7 +39,6 @@ $conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 
 use PHPUnit\Framework\TestCase;
 
-
 /**
  * Class for PHPUnit tests
  *
@@ -204,12 +203,22 @@ abstract class CommonClassTest extends TestCase
 		'entrepot' => 'stock',
 		'expedition' => 'delivery_note',
 		'facture' => 'invoice',
-		'ficheinter' => 'intervention',
+		'fichinter' => 'intervention',
 		'product_fournisseur_price' => 'productsupplierprice',
 		'product_price' => 'productprice',
 		'projet'  => 'project',
 		'propale' => 'propal',
 		'socpeople' => 'contact',
+	);
+
+	const EFFECTIVE_DEPRECATED_MODULE_MAPPING = array(
+		'adherent' => 'member',
+		'adherent_type' => 'member_type',
+		'banque' => 'bank',
+		'contrat' => 'contract',
+		'entrepot' => 'stock',
+		'ficheinter' => 'fichinter',
+		'projet'  => 'project',
 	);
 
 	/**


### PR DESCRIPTION
My changes "conflict" with other integrated at the same time.

I changed the principle of the mapping: map used names to internal names, regardless of deprecation.

I've also updated the CodingPhp test to check only the really deprecated modules.

Another PR is under preparation to revert the module names and the phan checks to not report on them.