### PR TITLE
FIX 16.0 - $object->updateCommon($user) = loss of `fk_user_author`

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8859,9 +8859,13 @@ abstract class CommonObject
 	protected function setSaveQuery()
 	{
 		global $conf;
+		$fieldsToIgnore = array(
+			'fk_user_creat'
+		);
 
 		$queryarray = array();
 		foreach ($this->fields as $field => $info) {	// Loop on definition of fields
+			if (in_array($field, $fieldsToIgnore)) continue;
 			// Depending on field type ('datetime', ...)
 			if ($this->isDate($info)) {
 				if (empty($this->{$field})) {
@@ -9048,6 +9052,7 @@ abstract class CommonObject
 		}
 		if (array_key_exists('fk_user_creat', $fieldvalues) && !($fieldvalues['fk_user_creat'] > 0)) {
 			$fieldvalues['fk_user_creat'] = $user->id;
+			$this->user_creation_id = $user->id;
 		}
 		unset($fieldvalues['rowid']); // The field 'rowid' is reserved field name for autoincrement field so we don't need it into insert.
 		if (array_key_exists('ref', $fieldvalues)) {


### PR DESCRIPTION
# FIX fk_user_author lost when calling updateCommon()

When `createCommon()` is called, the database column `fk_user_author` is correctly set using `$user->id`, but the object's field in memory (which, unfortunately, is named differently, namely `user) does not reflect that and remains NULL.

When `updateCommon()` is called, it uses setSaveQuery(), which sets the database column `fk_user_author` to 0 because $this->fk_user_author isn't set. Even if `user_creation_id` were correctly set, the naming difference would still cause `fk_user_author` to be updated to 0.

Here is a minimalist reproduction case:
```php
<?php
chdir('{…}/dolibarr/htdocs');
include 'master.inc.php';
$user->fetch(1);
require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
$p = new Product($db);

$p->ref = 'test';
$p->type = 0;
$p->label = 'test';
$p->entity = 1;
$id = $p->create($user);

var_dump($p->user_creation_id); // Expected 1, Got NULL
$obj = $db->getRow('SELECT fk_user_author FROM llx_product WHERE rowid = '.$id);
var_dump($obj->fk_user_author); // Expected 1, Got 1
$res = $p->updateCommon($user);
$obj = $db->getRow('SELECT fk_user_author FROM llx_product WHERE rowid = '.$id);
var_dump($obj->fk_user_author); // Expected 1, Got 0
```

I am not sure that my fix is the right way of fixing the problem because I am not sure whether updateCommon() should or shouldn't modify fk_user_author if `user_creation_id` has been changed on the object. I assumed it should not be changed.

I also haven't investigated whether other fields with a naming difference between database column and the corresponding CommonObject field have a similar problem.