### PR TITLE
Update adherent.class.php

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -3102,6 +3102,7 @@ class Adherent extends CommonObject
 
 			$sql = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'adherent';
 			$sql .= " WHERE entity = ".((int) $conf->entity); // Do not use getEntity('adherent').")" here, we want the batch to be on its entity only;
+			$sql .= " AND statut = 1";
 			$sql .= " AND datefin = '".$this->db->idate($datetosearchfor)."'";
 			//$sql .= " LIMIT 10000";
 


### PR DESCRIPTION
Hi there! 
I propose this little modification, done on 18.0:
To not send the Email to cancelled members. They already asked not to be members anymore. Sending reminders can be exhausting.

`$sql .= " WHERE entity = ".((int) $conf->entity); // Do not use getEntity('adherent').")" here, we want the batch to be on its entity only;
$sql .= " AND statut = 1";
$sql .= " AND datefin = '".$this->db->idate($datetosearchfor)."'";`