### PR TITLE
Qual: FactureTest - use assertions rather than dying in the setup.

### DIFF
--- a/test/phpunit/FactureTest.php
+++ b/test/phpunit/FactureTest.php
@@ -56,20 +56,9 @@ class FactureTest extends CommonClassTest
 	 */
 	public static function setUpBeforeClass(): void
 	{
-		global $conf,$user,$langs,$db;
-
-		if (!isModEnabled('facture')) {
-			print __METHOD__." module customer invoice must be enabled.\n";
-			die(1);
-		}
-		if (isModEnabled('ecotaxdeee')) {
-			print __METHOD__." ecotaxdeee module must not be enabled.\n";
-			die(1);
-		}
-
-		$db->begin(); // This is to have all actions inside a transaction even if test launched without suite.
-
-		print __METHOD__."\n";
+		self::assertTrue(isModEnabled('facture'), " module customer invoice must be enabled");
+		self::assertFalse(isModEnabled('ecotaxdeee'), " module customer invoice must be enabled");
+		parent::setUpBeforeClass();
 	}
 
 


### PR DESCRIPTION
# Qual: FactureTest - use assertions rather than dying in the setup.

The 'die()' instructions have been replaced - not all tests should fail because the preconditions for a test case are not met.