### PR TITLE
Fix: Ignore errors (related to open_basedir restrictions

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -586,11 +586,7 @@ function dol_compare_file($a, $b)
 function dol_is_dir($folder)
 {
 	$newfolder = dol_osencode($folder);
-	if (is_dir($newfolder)) {
-		return true;
-	} else {
-		return false;
-	}
+	return (bool) @is_dir($newfolder);
 }
 
 /**
@@ -616,7 +612,7 @@ function dol_is_dir_empty($dir)
 function dol_is_file($pathoffile)
 {
 	$newpathoffile = dol_osencode($pathoffile);
-	return is_file($newpathoffile);
+	return (bool) @is_file($newpathoffile);
 }
 
 /**
@@ -885,7 +881,7 @@ function dol_copy($srcfile, $destfile, $newmask = '0', $overwriteifexists = 1, $
 		dol_syslog("files.lib.php::dol_copy failed Permission denied to overwrite target file", LOG_WARNING);
 		return -1;
 	}
-	if (!is_writable($newdirdestfile)) {
+	if (!(bool) @is_writable($newdirdestfile)) {
 		dol_syslog("files.lib.php::dol_copy failed Permission denied to write into target directory ".$newdirdestfile, LOG_WARNING);
 		return -2;
 	}


### PR DESCRIPTION
# Fix: Ignore errors (related to open_basedir restrictions

Used '@' on specific checks on the file system that failed with open_basedir restrictions.  With these changes several phpunit tests now pass with open_basedir restriction in effect