### PR TITLE
Fix: Use accessible path for CategorieTest

### DIFF
--- a/test/phpunit/CategorieTest.php
+++ b/test/phpunit/CategorieTest.php
@@ -214,7 +214,7 @@ class CategorieTest extends CommonClassTest
 		$this->assertLessThan($result, 0);
 		*/
 
-		$retarray = $localobject->liste_photos('/');
+		$retarray = $localobject->liste_photos(DOL_DATA_ROOT."/medias");
 		print __METHOD__." retarray size=".count($retarray)."\n";
 		$this->assertTrue(is_array($retarray));
 

--- a/test/phpunit/CategorieTest.php
+++ b/test/phpunit/CategorieTest.php
@@ -214,7 +214,7 @@ class CategorieTest extends CommonClassTest
 		$this->assertLessThan($result, 0);
 		*/
 
-		$retarray = $localobject->liste_photos(DOL_DATA_ROOT."/medias");
+		$retarray = $localobject->liste_photos(DOL_DATA_ROOT."/categorie");
 		print __METHOD__." retarray size=".count($retarray)."\n";
 		$this->assertTrue(is_array($retarray));
 


### PR DESCRIPTION
# Fix: Use accessible path for CategorieTest

The test was using '/' (root of the filesystem) which was outside the open_basedir paths.  Modified the path to the medias directory to allow the test to pass with open_basedir restriction in effect.
