### PR TITLE
Fix: Skip UtilsTest on windows where ls is not available

### DIFF
--- a/test/phpunit/CommonClassTest.class.php
+++ b/test/phpunit/CommonClassTest.class.php
@@ -418,4 +418,22 @@ abstract class CommonClassTest extends TestCase
 			$this->assertFileDoesNotExist($file, $message);
 		}
 	}
+
+
+	/**
+	 * Skip test if test is not running on "Unix"
+	 *
+	 * @param string $message Message to indicate which test requires "Unix"
+	 *
+	 * @return bool True if this is not *nix, and fake assert generated
+	 */
+	protected function fakeAssertIfNotUnix($message)
+	{
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+			$this->assertTrue(true, "Dummy test to not mark the test as risky");
+			// $this->markTestSkipped("PHPUNIT is running on windows.  $message");
+			return true;
+		}
+		return false;
+	}
 }

--- a/test/phpunit/UtilsTest.php
+++ b/test/phpunit/UtilsTest.php
@@ -55,6 +55,11 @@ class UtilsTest extends CommonClassTest
 	 */
 	public function testExecuteCLI()
 	{
+		// Needs ls. Skip test if not running on *nix system.
+		if ($this->fakeAssertIfNotUnix(__METHOD__." only works on *nix")) {
+			return;
+		}
+
 		global $conf,$user,$langs,$db;
 		$conf = $this->savconf;
 		$user = $this->savuser;


### PR DESCRIPTION
# Fix: Skip UtilsTest on windows where ls is not available

The test in question uses 'ls' which is not available on windows. This change limits the execution to non windows systems.