### PR TITLE
Fix: Improve cache key generation for windows-ci

### DIFF
--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -1,41 +1,39 @@
 ---
 name: Win CI
+# yamllint disable-line rule:truthy
 on:
   push:
   pull_request:
   workflow_dispatch:
-
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+    }}
   cancel-in-progress: true
-
 env:
   PHPUNIT_LOG: phpunit_tests.log
   DOLIBARR_LOG: documents/dolibarr.log
   PHPSERVER_LOG: phpserver.log
-  PHPSERVER_DOMAIN_PORT: 127.0.0.1:8000 # could be 127.0.0.1:8000 if config modified
-  CACHE_KEY_PART: ${{ ( github.event_name == 'pull_request' ) && github.base_ref }}${{ ( github.event_name == 'pull_request' ) && '-' }}${{ github.head_ref }}
-  PHP_INI_SCAN_DIR: "C:\\myphpini"
+  PHPSERVER_DOMAIN_PORT: 127.0.0.1:8000  # could be 127.0.0.1:8000 if config modified
+  CACHE_KEY_PART: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}
+  PHP_INI_SCAN_DIR: C:\myphpini
   CKEY: win-ci-2
-
+  GITHUB_JSON: ${{ toJSON(github) }} # Helps in debugging Github Action
 jobs:
   win-test:
     strategy:
       matrix:
         os: [windows-latest]
         # php_version: [7.4, 8.0]  # Add more versions if needed
-        php_version: [7.4] # Add more versions if needed
+        php_version: [7.4]  # Add more versions if needed
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Setup MariaDB
         uses: ankane/setup-mariadb@v1
         with:
           # mariadb-version: ${{ matrix.mariadb-version }}
-          database: travis # Specify your database name
-
+          database: travis  # Specify your database name
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -60,13 +58,13 @@ jobs:
           path: |
             db_init.sql
             db_init.sql.md5
-          key: ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ env.CACHE_KEY_PART }}-${{ github.run_id }}
+          key: ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ env.CACHE_KEY_PART
+            }}-${{ github.run_id }}
           restore-keys: |
             ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ env.CACHE_KEY_PART }}-
             ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ github.head_ref }}-
             ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ github.base_ref }}-
             ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-
-
       - name: Create local php.ini
         shell: cmd
         if: false
@@ -91,7 +89,6 @@ jobs:
           SET PHP_INI_SCAN_DIR=
           ECHO "==== Verify it is used by PHP ==="
           php --ini
-
       - name: Run Bash script
         # Note this is bash (MSYS) on Windows
         shell: bash
@@ -106,7 +103,6 @@ jobs:
           ls -l
           echo "TEE=$(cygpath -w "$(which tee)")" >> "$GITHUB_ENV"
           echo "BASEDIR=$(realpath .)" >> "$GITHUB_ENV"
-
       - name: Start web server
         id: server
         if: false
@@ -115,7 +111,6 @@ jobs:
           Start-Process -FilePath "php.exe" -WindowStyle Hidden -ArgumentList "-S ${{ env.PHPSERVER_DOMAIN_PORT }} -t htdocs > ${{ env.PHPSERVER_LOG }}" -PassThru
           curl "http://${{ env.PHPSERVER_DOMAIN_PORT }}"
         shell: powershell
-
       - name: Run PHPUnit tests
         continue-on-error: true
         shell: cmd
@@ -148,13 +143,11 @@ jobs:
           REM 'DOSKEY' USED to recover error code (no pipefile equivalent in windows?)
           ( php "%PHPROOT%\phpunit" -d memory_limit=-1 -c %CD%\test\phpunit\phpunittest.xml "test\phpunit\AllTests.php" & call doskey /exename=err err=%%^^errorlevel%% ) | "${{ env.TEE }}" "${{ env.PHPUNIT_LOG }}"
           for /f "tokens=2 delims==" %%A in ('doskey /m:err') do EXIT /B %%A
-
       - name: Convert Raw Log to Annotations
         uses: mdeweerd/logToCheckStyle@v2024.2.9
         if: ${{ failure() }}
         with:
           in: ${{ env.PHPUNIT_LOG }}
-
       - name: Provide dolibarr and phpunit logs as artifact
         uses: actions/upload-artifact@v4
         if: ${{ ! cancelled() }}
@@ -169,7 +162,7 @@ jobs:
           retention-days: 2
 
       # Save cache
-      - name: "Save cache"
+      - name: Save cache
         uses: actions/cache/save@v4
         if: ${{ ! cancelled() }}
         with:


### PR DESCRIPTION
# Fix: Improve cache key generation for windows-ci

Caches did not restore as expected.  This change attemps to fix it.

Other changes are probably needed, but this should correct the key for pushes to the develop branch and improves the generation on push requests.