### PR TITLE
Fix: Cache issue in windows-ci - add enableCrossOsArchive

### DIFF
--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -55,6 +55,8 @@ jobs:
         id: cache
         uses: actions/cache/restore@v4
         with:
+          # See https://github.com/actions/cache/issues/1275#issuecomment-1925217178
+          enableCrossOsArchive: true 
           path: |
             db_init.sql
             db_init.sql.md5
@@ -166,5 +168,7 @@ jobs:
         uses: actions/cache/save@v4
         if: ${{ ! cancelled() }}
         with:
+          # See https://github.com/actions/cache/issues/1275#issuecomment-1925217178
+          enableCrossOsArchive: true 
           key: ${{ steps.cache.outputs.cache-primary-key }}
           path: db_init.*


### PR DESCRIPTION
# Fix: Cache issue in windows-ci - add enableCrossOsArchive

There is an issue in actions/cache on windows and adding 'enableCrossOsArchive: true' should fix it according to
https://github.com/actions/cache/issues/1275#issuecomment-1925217178