### PR TITLE
Fix: Remove extra space in translation key

### DIFF
--- a/htdocs/blockedlog/class/authority.class.php
+++ b/htdocs/blockedlog/class/authority.class.php
@@ -316,7 +316,7 @@ class BlockedLogAuthority
 				if ($res['content'] === 'blockalreadyadded' || $res['content'] === 'blockadded') {
 					$block->setCertified();
 				} else {
-					$this->error = $langs->trans('ImpossibleToContactAuthority ', $url);
+					$this->error = $langs->trans('ImpossibleToContactAuthority', $url);
 					return -1;
 				}
 			}


### PR DESCRIPTION
# Fix: Remove extra space in translation key

Fix the extra space in the key 'ImpossibleToContactAuthority' when calling trans.