### PR TITLE
FIX #28533 and #28581 v3 Mo::deleteLine removes the "main" MoLine if consumed line is delete

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -1241,7 +1241,7 @@ class Mo extends CommonObject
 				if (!$error) {
 					$tmpline = new MoLine($this->db);
 					$tmpline->fetch($line['rowid']);
-					$result = $tmpline->cancelConsumedOrProduced($user,$notrigger);
+					$result = $tmpline->cancelConsumedOrProduced($user, $notrigger);
 					if ($result < 0) {
 						$error++;
 						$this->setErrorsFromObject($tmpline);
@@ -1257,7 +1257,7 @@ class Mo extends CommonObject
 				if (!$error) {
 					$tmpline = new MoLine($this->db);
 					$tmpline->fetch($line['rowid']);
-					$result = $tmpline->cancelConsumedOrProduced($user,$notrigger);
+					$result = $tmpline->cancelConsumedOrProduced($user, $notrigger);
 					if ($result < 0) {
 						$error++;
 						$this->setErrorsFromObject($tmpline);
@@ -2181,7 +2181,7 @@ class MoLine extends CommonObjectLine
 			$lines = $this->fetchLinesLinked();
 			foreach ($lines as $line) {
 				if (!$error) {
-					$result = $line->delete($user,$notrigger);
+					$result = $line->delete($user, $notrigger);
 					if ($result < 0) {
 						$error++;
 					}
@@ -2212,7 +2212,7 @@ class MoLine extends CommonObjectLine
 	 *
 	 * @return 	array             	Array of lines
 	 */
-	function fetchLinesLinked()
+	private function fetchLinesLinked()
 	{
 		$mostatic = new MoLine($this->db);
 		$resarray = $mostatic->fetchAll(filter:array('fk_mrp_production' => $this->id));
@@ -2241,7 +2241,7 @@ class MoLine extends CommonObjectLine
 			$lines = $this->fetchLinesLinked();
 			foreach ($lines as $line) {
 				if (!$error) {
-					$result = $line->cancelConsumedOrProduced($user,$notrigger);
+					$result = $line->cancelConsumedOrProduced($user, $notrigger);
 					if ($result < 0) {
 						$this->error++;
 					}


### PR DESCRIPTION
To fix this Issue #28533, some changes are required.
Thru this Bugfix the Issue #28581 also fixed.
To understand it better, i make a few pictures:
![image](https://github.com/Dolibarr/dolibarr/assets/78662388/08f14d60-dbc1-4016-be3e-ccee7b4f40ac)
![image](https://github.com/Dolibarr/dolibarr/assets/78662388/43290147-ab85-49d8-bccd-be92e9e6c656)
![image](https://github.com/Dolibarr/dolibarr/assets/78662388/79999acc-f746-48c0-b957-db48eb9e3cef)
![image](https://github.com/Dolibarr/dolibarr/assets/78662388/c53e6ee1-2b0f-4602-9c75-b88ecd1fedd0)

I hope this work is now successful *pfffff* .
Best regards
Christian