### PR TITLE
FIX: Special code is now transmitted by args only in order supplier In 17.0

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1344,8 +1344,6 @@ if (empty($reshook)) {
 									$tva_tx = get_default_tva($soc, $mysoc, $lines[$i]->fk_product, $product_fourn_price_id);
 								}
 
-								$object->special_code = $lines[$i]->special_code;
-
 								$result = $object->addline(
 									$desc,
 									$lines[$i]->subprice,
@@ -1368,7 +1366,9 @@ if (empty($reshook)) {
 									$lines[$i]->fk_unit,
 									0,
 									$element,
-									!empty($lines[$i]->id) ? $lines[$i]->id : $lines[$i]->rowid
+									!empty($lines[$i]->id) ? $lines[$i]->id : $lines[$i]->rowid,
+									-1,
+									$lines[$i]->special_code
 								);
 
 								if ($result < 0) {


### PR DESCRIPTION
As the original commit in https://github.com/Dolibarr/dolibarr/pull/28051 was done in 17.0
The fix https://github.com/Dolibarr/dolibarr/pull/28546 should  also be done in 17.0 also 