### PR TITLE
FIX addline on an order. Wrong computation of $pu_ttc

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -867,7 +867,7 @@ if (empty($reshook)) {
 					}
 				}
 
-				$tmpvat = price2num(preg_replace('/\s*\(.*\)/', '', $tva_tx));
+				$tmpvat = floatval(price2num(preg_replace('/\s*\(.*\)/', '', $tva_tx))); // Use floatval() because we don't know which rounding to use
 				$tmpprodvat = price2num(preg_replace('/\s*\(.*\)/', '', $prod->tva_tx));
 
 				// Set unit price to use


### PR DESCRIPTION
# Fix #addline on an order

When adding a line on an order, $pu_ttc is not computed and creates a 500 error when $tva_tx is null. This is because price2num() returns '' when the passed value is null or '' and rounding is not set.
