### PR TITLE
new fetch() for classes Fournisseur and Client

### DIFF
--- a/htdocs/fourn/class/fournisseur.class.php
+++ b/htdocs/fourn/class/fournisseur.class.php
@@ -49,6 +49,29 @@ class Fournisseur extends Societe
 		$this->fournisseur = 1;
 	}
 
+	/**
+	 *    Load a third party from database into memory
+	 *
+	 *    @param	int		$rowid			Id of third party to load
+	 *    @param    string	$ref			Reference of third party, name (Warning, this can return several records)
+	 *    @param    string	$ref_ext       	External reference of third party (Warning, this information is a free field not provided by Dolibarr)
+	 *    @param    string	$barcode       	Barcode of third party to load
+	 *    @param    string	$idprof1		Prof id 1 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof2		Prof id 2 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof3		Prof id 3 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof4		Prof id 4 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof5		Prof id 5 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof6		Prof id 6 of third party (Warning, this can return several records)
+	 *    @param    string	$email   		Email of third party (Warning, this can return several records)
+	 *    @param    string	$ref_alias 		Name_alias of third party (Warning, this can return several records)
+	 * 	  @param	bool	$is_client		Is the thirdparty a client ?
+	 *    @param	bool	$is_supplier	Is the thirdparty a supplier ?
+	 *    @return   int						>0 if OK, <0 if KO or if two records found for same ref or idprof, 0 if not found.
+	 */
+	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $is_client = false, $is_supplier = true)
+	{
+		return parent::fetch($rowid, $ref, $ref_ext, $barcode, $idprof1, $idprof2, $idprof3, $idprof4, $idprof5, $idprof6, $email, $ref_alias, $is_client, $is_supplier);
+	}
 
 	/**
 	 * Return nb of orders

--- a/htdocs/societe/class/client.class.php
+++ b/htdocs/societe/class/client.class.php
@@ -48,6 +48,32 @@ class Client extends Societe
 		$this->fournisseur = 0;
 	}
 
+
+	/**
+	 *    Load a third party from database into memory
+	 *
+	 *    @param	int		$rowid			Id of third party to load
+	 *    @param    string	$ref			Reference of third party, name (Warning, this can return several records)
+	 *    @param    string	$ref_ext       	External reference of third party (Warning, this information is a free field not provided by Dolibarr)
+	 *    @param    string	$barcode       	Barcode of third party to load
+	 *    @param    string	$idprof1		Prof id 1 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof2		Prof id 2 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof3		Prof id 3 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof4		Prof id 4 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof5		Prof id 5 of third party (Warning, this can return several records)
+	 *    @param    string	$idprof6		Prof id 6 of third party (Warning, this can return several records)
+	 *    @param    string	$email   		Email of third party (Warning, this can return several records)
+	 *    @param    string	$ref_alias 		Name_alias of third party (Warning, this can return several records)
+	 * 	  @param	bool	$is_client		Is the thirdparty a client ?
+	 *    @param	bool	$is_supplier	Is the thirdparty a supplier ?
+	 *    @return   int						>0 if OK, <0 if KO or if two records found for same ref or idprof, 0 if not found.
+	 */
+	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $is_client = true, $is_supplier = false)
+	{
+		return parent::fetch($rowid, $ref, $ref_ext, $barcode, $idprof1, $idprof2, $idprof3, $idprof4, $idprof5, $idprof6, $email, $ref_alias, $is_client, $is_supplier);
+	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *  Load indicators into this->nb for board
 	 *

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1801,7 +1801,7 @@ class Societe extends CommonObject
 	 *    @param	bool	$is_supplier	Is the thirdparty a supplier ?
 	 *    @return   int						>0 if OK, <0 if KO or if two records found for same ref or idprof, 0 if not found.
 	 */
-	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $is_client = true, $is_supplier = true)
+	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $is_client = false, $is_supplier = false)
 	{
 		global $langs;
 		global $conf;
@@ -1873,11 +1873,13 @@ class Societe extends CommonObject
 		$sql .= ' WHERE s.entity IN ('.getEntity($this->element).')';
 
 		// Filter on client or supplier, for Client::fetch() and Fournisseur::fetch()
-		if ($is_client && !$is_supplier) {
+		if ($is_client && $is_supplier) {
+			$sql .= ' AND s.client > 0 AND s.fournisseur > 0';
+		} elseif ($is_client && !$is_supplier) {
 			$sql .= ' AND s.client > 0 AND s.fournisseur <= 0';
 		} elseif ($is_supplier && !$is_client) {
 			$sql .= ' AND s.fournisseur > 0 AND s.client <= 0';
-		} // else, nothing special (the thirdparty can be client and/or supplier)
+		} // if both false, no test (the thirdparty can be client and/or supplier)
 
 		if ($rowid) {
 			$sql .= ' AND s.rowid = '.((int) $rowid);

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1873,12 +1873,11 @@ class Societe extends CommonObject
 		$sql .= ' WHERE s.entity IN ('.getEntity($this->element).')';
 
 		// Filter on client or supplier, for Client::fetch() and Fournisseur::fetch()
-		if ($is_client && $is_supplier) {
-			$sql .= ' AND s.client > 0 AND s.fournisseur > 0';
-		} elseif ($is_client && !$is_supplier) {
-			$sql .= ' AND s.client > 0 AND s.fournisseur <= 0';
-		} elseif ($is_supplier && !$is_client) {
-			$sql .= ' AND s.fournisseur > 0 AND s.client <= 0';
+		if ($is_client) {
+			$sql .= ' AND s.client > 0';
+		}
+		if ($is_supplier) {
+			$sql .= ' AND s.fournisseur > 0';
 		} // if both false, no test (the thirdparty can be client and/or supplier)
 
 		if ($rowid) {

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1797,9 +1797,11 @@ class Societe extends CommonObject
 	 *    @param    string	$idprof6		Prof id 6 of third party (Warning, this can return several records)
 	 *    @param    string	$email   		Email of third party (Warning, this can return several records)
 	 *    @param    string	$ref_alias 		Name_alias of third party (Warning, this can return several records)
+	 * 	  @param	bool	$is_client		Is the thirdparty a client ?
+	 *    @param	bool	$is_supplier	Is the thirdparty a supplier ?
 	 *    @return   int						>0 if OK, <0 if KO or if two records found for same ref or idprof, 0 if not found.
 	 */
-	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '')
+	public function fetch($rowid, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $is_client = true, $is_supplier = true)
 	{
 		global $langs;
 		global $conf;
@@ -1869,6 +1871,14 @@ class Societe extends CommonObject
 			$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'societe_remise_supplier as sr2 ON sr2.rowid = (SELECT MAX(rowid) FROM '.MAIN_DB_PREFIX.'societe_remise_supplier WHERE fk_soc = s.rowid AND entity IN ('.getEntity('discount').'))';
 		}
 		$sql .= ' WHERE s.entity IN ('.getEntity($this->element).')';
+
+		// Filter on client or supplier, for Client::fetch() and Fournisseur::fetch()
+		if ($is_client && !$is_supplier) {
+			$sql .= ' AND s.client > 0 AND s.fournisseur <= 0';
+		} elseif ($is_supplier && !$is_client) {
+			$sql .= ' AND s.fournisseur > 0 AND s.client <= 0';
+		} // else, nothing special (the thirdparty can be client and/or supplier)
+
 		if ($rowid) {
 			$sql .= ' AND s.rowid = '.((int) $rowid);
 		}


### PR DESCRIPTION
# NEW fetch() method for Fournisseur() and Client() classes

When instanciating a Fournisseur() or a Client(), then running a fetch(), we use the parent Societe::fetch() method.
For this reason, we get a Societe object which might be a Client when we are looking for a Fournisseur.

This PR:
- adds parameters is_client and is_supplier to Societe::fetch(). Both are false by default, which means nothing will be added to WHERE ...
- if both is_client and is_supplier are true, then WHERE will look for Thirdparties that are both client and supplier.
- introduces Fournisseur::fetch() and Client::fetch() which call Societe::fetch() with correct is_client and is_supplier parameters



