### PR TITLE
fix can't delete pdf if filename is not url encoded

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -4477,7 +4477,7 @@ if ($action == 'create') {
 		$file = GETPOST('file', 'alpha');
 
 		$formconfirm = $form->formconfirm(
-			$_SERVER["PHP_SELF"].'?facid='.$object->id.'&file='.$file,
+			$_SERVER["PHP_SELF"].'?facid='.$object->id.'&file='.urlencode($file),
 			$langs->trans('DeleteFileHeader'),
 			$langs->trans('DeleteFileText')."<br><br>".$file,
 			'remove_file',


### PR DESCRIPTION
if ref is like `#FA123456` we can't delete pdf