### PR TITLE
qual: phan for htdocs/core/lib/functions.lib.php

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9288,7 +9288,7 @@ function setEventMessage($mesgs, $style = 'mesgs', $noduplicate = 0)
  *	Set event messages in dol_events session object. Will be output by calling dol_htmloutput_events.
  *  Note: Calling dol_htmloutput_events is done into pages by standard llxFooter() function.
  *
- *	@param	string		$mesg			Message string
+ *	@param	string|null	$mesg			Message string
  *	@param	array|null	$mesgs			Message array
  *  @param  string		$style      	Which style to use ('mesgs' by default, 'warnings', 'errors')
  *  @param	string		$messagekey		A key to be used to allow the feature "Never show this message again"


### PR DESCRIPTION
68 entries for "Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299"

Examples (first 10):

htdocs/accountancy/admin/categories.php	155	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/accountancy/admin/categories.php	189	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/accountancy/bookkeeping/card.php	778	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/admin/eventorganization.php	341	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/admin/hrm.php	596	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/admin/hrm.php	603	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/admin/hrm.php	627	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/admin/knowledgemanagement.php	293	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/admin/knowledgemanagement.php	300	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/admin/multicurrency.php	115	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($mesg) is null of type null but \setEventMessages() takes string (no real type) defined at htdocs/core/lib/functions.lib.php:9299 (the inferred real argument type has nothing in common with the parameter's phpdoc type)