### PR TITLE
fix #28374 : tosell is not used anymore on products, use status

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -233,7 +233,7 @@ if (empty($reshook)) {
 							$line->fetch_product();
 						}
 						if (is_object($line->product) && $line->product->id > 0) {
-							if (empty($line->product->tosell)) {
+							if (empty($line->product->status)) {
 								$warningMsgLineList[$line->id] = $langs->trans('WarningLineProductNotToSell', $line->product->ref);
 							}
 						}

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -203,7 +203,7 @@ if (empty($reshook)) {
 							$line->fetch_product();
 						}
 						if (is_object($line->product) && $line->product->id > 0) {
-							if (empty($line->product->tosell)) {
+							if (empty($line->product->status)) {
 								$warningMsgLineList[$line->id] = $langs->trans('WarningLineProductNotToSell', $line->product->ref);
 							}
 						}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -234,7 +234,7 @@ if (empty($reshook)) {
 						$line->fetch_product();
 					}
 					if (is_object($line->product) && $line->product->id > 0) {
-						if (empty($line->product->tosell)) {
+						if (empty($line->product->status)) {
 							$warningMsgLineList[$line->id] = $langs->trans('WarningLineProductNotToSell', $line->product->ref);
 						}
 					}


### PR DESCRIPTION
Fix #28374 : tosell is not used anymore on products, use status

#2874 would display a warning on each object cloning. We want the warning only the product is not to sell.