### PR TITLE
Set import_key in import when update record

### DIFF
--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -963,7 +963,7 @@ class ImportCsv extends ModeleImports
 								foreach ($data as $key => $val) {
 									$set[] = $key." = ".$val;
 								}
-								$sqlstart .= " SET ".implode(', ', $set);
+								$sqlstart .= " SET ".implode(', ', $set).", import_key = '".$this->db->escape($importid)."'";
 
 								if (empty($keyfield)) {
 									$keyfield = 'rowid';

--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -1006,7 +1006,7 @@ class ImportXlsx extends ModeleImports
 								foreach ($data as $key => $val) {
 									$set[] = $key." = ".$val;
 								}
-								$sqlstart .= " SET " . implode(', ', $set);
+								$sqlstart .= " SET " . implode(', ', $set) . ", import_key = '" . $this->db->escape($importid) . "'";
 
 								if (empty($keyfield)) {
 									$keyfield = 'rowid';


### PR DESCRIPTION
The Import_key field is missing in imported records when they are updated.
This missing information is essential to execute hooks on the latest imported records.