### PR TITLE
qual: phan for accountingaccount.class.php

### DIFF
--- a/htdocs/accountancy/class/accountingaccount.class.php
+++ b/htdocs/accountancy/class/accountingaccount.class.php
@@ -174,7 +174,7 @@ class AccountingAccount extends CommonObject
 	 * Load record in memory
 	 *
 	 * @param 	int       		$rowid 				    	Id
-	 * @param 	string 	       	$account_number 	        Account number
+	 * @param 	string|null    	$account_number 	        Account number
 	 * @param 	int|boolean    	$limittocurrentchart     	1 or true=Load record only if it is into current active chart of account
 	 * @param   string         	$limittoachartaccount    	'ABC'=Load record only if it is into chart account with code 'ABC' (better and faster than previous parameter if you have chart of account code).
 	 * @return 	int                                     	Return integer <0 if KO, 0 if not found, Id of record if OK and found


### PR DESCRIPTION
htdocs/accountancy/admin/productaccount.php	196	TypeError PhanTypeMismatchArgumentProbablyReal Argument 2 ($account_number) is null of type null but \AccountingAccount::fetch() takes string (no real type) defined at htdocs/accountancy/class/accountingaccount.class.php:182 (the inferred real argument type has nothing in common with the parameter's phpdoc type)