### PR TITLE
qual: phan for htdocs/core/lib/ajax.lib.php

### DIFF
--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -628,19 +628,19 @@ function ajax_event($htmlname, $events)
 /**
  * 	On/off button for constant
  *
- * 	@param	string	$code					Name of constant
- * 	@param	array	$input					Array of complementary actions to do if success ("disabled"|"enabled'|'set'|'del') => CSS element to switch, 'alert' => message to show, ... Example: array('disabled'=>array(0=>'cssid'))
- * 	@param	int		$entity					Entity. Current entity is used if null.
- *  @param	int		$revertonoff			1=Revert on/off
- *  @param	int		$strict					Use only "disabled" with delConstant and "enabled" with setConstant
- *  @param	int		$forcereload			Force to reload page if we click/change value (this is supported only when there is no 'alert' option in input)
- *  @param	int		$marginleftonlyshort	1 = Add a short left margin on picto, 2 = Add a larger left margin on picto, 0 = No left margin.
- *  @param	int		$forcenoajax			1 = Force to use a ahref link instead of ajax code.
- *  @param	int		$setzeroinsteadofdel	1 = Set constantto '0' instead of deleting it
- *  @param	string	$suffix					Suffix to use on the name of the switch_on picto. Example: '', '_red'
- *  @param	string	$mode					Add parameter &mode= to the href link (Used for href link)
- *  @param	string	$morecss				More CSS
- * 	@return	string
+ * 	@param  string      $code                   Name of constant
+ * 	@param  array       $input                  Array of complementary actions to do if success ("disabled"|"enabled'|'set'|'del') => CSS element to switch, 'alert' => message to show, ... Example: array('disabled'=>array(0=>'cssid'))
+ * 	@param  int|null    $entity                 Entity. Current entity is used if null.
+ *  @param  int         $revertonoff            1=Revert on/off
+ *  @param  int	        $strict                 Use only "disabled" with delConstant and "enabled" with setConstant
+ *  @param  int         $forcereload            Force to reload page if we click/change value (this is supported only when there is no 'alert' option in input)
+ *  @param  int         $marginleftonlyshort    1 = Add a short left margin on picto, 2 = Add a larger left margin on picto, 0 = No left margin.
+ *  @param  int	        $forcenoajax            1 = Force to use a ahref link instead of ajax code.
+ *  @param  int         $setzeroinsteadofdel    1 = Set constantto '0' instead of deleting it
+ *  @param  string      $suffix                 Suffix to use on the name of the switch_on picto. Example: '', '_red'
+ *  @param  string      $mode                   Add parameter &mode= to the href link (Used for href link)
+ *  @param  string      $morecss                More CSS
+ * 	@return string
  */
 function ajax_constantonoff($code, $input = array(), $entity = null, $revertonoff = 0, $strict = 0, $forcereload = 0, $marginleftonlyshort = 2, $forcenoajax = 0, $setzeroinsteadofdel = 0, $suffix = '', $mode = '', $morecss = 'inline-block')
 {


### PR DESCRIPTION
29 entries for:

Argument 3 ($entity) is null of type null but \ajax_constantonoff() takes int (no real type) defined at htdocs/core/lib/ajax.lib.php:645