### PR TITLE
qual: phpstan for htdocs/loan/class/loan.class.php

### DIFF
--- a/htdocs/loan/class/loan.class.php
+++ b/htdocs/loan/class/loan.class.php
@@ -108,7 +108,7 @@ class Loan extends CommonObject
 	public $fk_project;
 
 	/**
-	 * @var int totalpaid
+	 * @var float totalpaid
 	 */
 	public $totalpaid;
 


### PR DESCRIPTION
htdocs/loan/class/loan.class.php	113	PHPDoc type int of property Loan::$totalpaid is not covariant with PHPDoc type float of overridden property CommonObject::$totalpaid.