### PR TITLE
Member Contributions: using note_public since note_private is not working

### DIFF
--- a/htdocs/adherents/subscription/card.php
+++ b/htdocs/adherents/subscription/card.php
@@ -238,7 +238,7 @@ if ($user->hasRight('adherent', 'cotisation', 'creer') && $action == 'edit') {
 	// Label
 	print '<tr><td>'.$langs->trans("Label").'</td>';
 	print '<td class="valeur">';
-	print '<input type="text" class="flat" name="note" value="'.$object->note_private.'"></td></tr>';
+	print '<input type="text" class="flat" name="note" value="'.$object->note_public.'"></td></tr>';
 
 	// Bank line
 	if (isModEnabled("bank") && (getDolGlobalString('ADHERENT_BANK_USE') || $object->fk_bank)) {
@@ -334,7 +334,7 @@ if ($rowid && $action != 'edit') {
 	print '<tr><td>'.$langs->trans("Amount").'</td><td class="valeur"><span class="amount">'.price($object->amount).'</span></td></tr>';
 
 	// Label
-	print '<tr><td>'.$langs->trans("Label").'</td><td class="valeur sensiblehtmlcontent">'.dol_string_onlythesehtmltags(dol_htmlentitiesbr($object->note_private)).'</td></tr>';
+	print '<tr><td>'.$langs->trans("Label").'</td><td class="valeur sensiblehtmlcontent">'.dol_string_onlythesehtmltags(dol_htmlentitiesbr($object->note_public)).'</td></tr>';
 
 	// Bank line
 	if (isModEnabled("bank") && (getDolGlobalString('ADHERENT_BANK_USE') || $object->fk_bank)) {


### PR DESCRIPTION
# Fix #28582 Using note_public as Contribution label
On the card showing the details of a membership contribution the label field appeared empty, while it was showing in the list.php. This commit will make the Label field use the note_public rather than note_private.