### PR TITLE
fix: better inner join than comma for hook printFieldListFrom after

### DIFF
--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -77,6 +77,9 @@ $mode 		= GETPOST('mode', 'alpha');
 // Search Fields
 $search_all = trim((GETPOST('search_all', 'alphanohtml') != '') ? GETPOST('search_all', 'alphanohtml') : GETPOST('sall', 'alphanohtml'));
 $search_user 	= GETPOSTINT('search_user');
+if ($search_user==-1) {
+	$search_user=0;
+}
 $search_sale 	= GETPOSTINT('search_sale');
 $search_ref 	= GETPOST('sf_ref') ? GETPOST('sf_ref', 'alpha') : GETPOST('search_ref', 'alpha');
 $search_refcustomer = GETPOST('search_refcustomer', 'alpha');
@@ -587,7 +590,7 @@ $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as country on (country.rowid = s
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_typent as typent on (typent.id = s.fk_typent)";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_departements as state on (state.rowid = s.fk_departement)";
 
-$sql .= ', '.MAIN_DB_PREFIX.'propal as p';
+$sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'propal as p ON p.fk_soc = s.rowid';
 if (!empty($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label'])) {
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX.$object->table_element."_extrafields as ef on (p.rowid = ef.fk_object)";
 }
@@ -598,8 +601,10 @@ $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'user as u ON p.fk_user_author = u.rowid';
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."projet as pr ON pr.rowid = p.fk_projet";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_availability as ava on (ava.rowid = p.fk_availability)";
 if ($search_user > 0) {
-	$sql .= ", ".MAIN_DB_PREFIX."element_contact as c";
-	$sql .= ", ".MAIN_DB_PREFIX."c_type_contact as tc";
+	$sql .= " INNER JOIN ".MAIN_DB_PREFIX."element_contact as c";
+	$sql .= " ON  c.element_id = p.rowid AND c.fk_socpeople = ".((int) $search_user);
+	$sql .= " INNER JOIN  ".MAIN_DB_PREFIX."c_type_contact as tc";
+	$sql .= " ON c.fk_c_type_contact = tc.rowid AND tc.element='propal' AND tc.source='internal'";
 }
 
 // Add table from hooks
@@ -607,8 +612,8 @@ $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
 
-$sql .= ' WHERE p.fk_soc = s.rowid';
-$sql .= ' AND p.entity IN ('.getEntity('propal').')';
+$sql .= ' WHERE';
+$sql .= ' p.entity IN ('.getEntity('propal').')';
 if ($search_town) {
 	$sql .= natural_search('s.town', $search_town);
 }
@@ -717,9 +722,6 @@ if ($search_date_delivery_start) {
 }
 if ($search_date_delivery_end) {
 	$sql .= " AND p.date_livraison <= '".$db->idate($search_date_delivery_end)."'";
-}
-if ($search_user > 0) {
-	$sql .= " AND c.fk_c_type_contact = tc.rowid AND tc.element='propal' AND tc.source='internal' AND c.element_id = p.rowid AND c.fk_socpeople = ".((int) $search_user);
 }
 if ($search_date_signature_start) {
 	$sql .= " AND p.date_signature >= '".$db->idate($search_date_signature_start)."'";
@@ -1147,7 +1149,7 @@ if ($search_date_signature_endyear) {
 	if ($user->hasRight('user', 'user', 'lire')) {
 		$moreforfilter .= '<div class="divsearchfield">';
 		$tmptitle = $langs->trans('LinkedToSpecificUsers');
-		$moreforfilter .= img_picto($tmptitle, 'user', 'class="pictofixedwidth"').$form->select_dolusers($search_user, 'search_user', $tmptitle, '', 0, '', '', 0, 0, 0, '', 0, '', 'maxwidth250 widthcentpercentminusx');
+		$moreforfilter .= img_picto($tmptitle, 'user', 'class="pictofixedwidth"').$form->select_dolusers((empty($search_user)?-2:0), 'search_user', $tmptitle, '', 0, '', '', 0, 0, 0, '', 0, '', 'maxwidth250 widthcentpercentminusx');
 		$moreforfilter .= '</div>';
 	}
 	// If the user can view products

--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -77,9 +77,7 @@ $mode 		= GETPOST('mode', 'alpha');
 // Search Fields
 $search_all = trim((GETPOST('search_all', 'alphanohtml') != '') ? GETPOST('search_all', 'alphanohtml') : GETPOST('sall', 'alphanohtml'));
 $search_user 	= GETPOSTINT('search_user');
-if ($search_user==-1) {
-	$search_user=0;
-}
+if ($search_user==-1) $search_user=0;
 $search_sale 	= GETPOSTINT('search_sale');
 $search_ref 	= GETPOST('sf_ref') ? GETPOST('sf_ref', 'alpha') : GETPOST('search_ref', 'alpha');
 $search_refcustomer = GETPOST('search_refcustomer', 'alpha');


### PR DESCRIPTION
better to use INNER JOIN than comma and where for join

fix also regression because
 $search_user 	= GETPOSTINT('search_user'); // this return 0
instead of 
$search_user 	= GETPOST('search_user','int'); // this can return an empty string

in 

$moreforfilter .= img_picto($tmptitle, 'user', 'class="pictofixedwidth"').$form->select_dolusers($search_user, 'search_user', $tmptitle, '', 0, '', '', 0, 0, 0, '', 0, '', 'maxwidth250 widthcentpercentminusx');

is $search_user=0 it will preselect current user connected but the filter in SQL is not apply, it's just display, so give false information about filtered lines 

$moreforfilter .= img_picto($tmptitle, 'user', 'class="pictofixedwidth"').$form->select_dolusers((empty($search_user)?-2:0), 'search_user', $tmptitle, '', 0, '', '', 0, 0, 0, '', 0, '', 'maxwidth250 widthcentpercentminusx');

Will send -2 if not set
