### PR TITLE
FIX 17.0: follow-up of PR  #27008

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1895,7 +1895,7 @@ class FactureFournisseur extends CommonInvoice
 
 			// Set new ref and define current statut
 			if (!$error) {
-				$this->ref = $num;
+				$this->ref = $this->newref;
 				$this->statut = self::STATUS_VALIDATED;
 				//$this->date_validation=$now; this is stored into log table
 			}


### PR DESCRIPTION
# FIX $sInvoice->ref inconsistent with database value in some cases
This is the same problem as PR #27008: I had forgotten to also use `$this->newref` rather than `$num` to update `$this->ref` in that fix (because `$num` cannot be modified by trigger).

Here is a fictional example of the problem:
```php
$sInvoice->fetch($draftinvoiceid);
// $sInvoice->ref === '(PROV01234)'
$sInvoice->validate();
// Dolibar core first sets ref to 'SI_TEST_01'
// Let's say a module implementing BILL_SUPPLIER_VALIDATE then changes the ref to 'SI_TEST_02' and calls $object->update()

var_dump($sInvoice->ref); // expected: 'SI_TEST_02', got: 'SI_TEST_01'
```