### PR TITLE
qual: phpstan for htdocs/expedition/class/expedition.class.php

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1242,7 +1242,7 @@ class Expedition extends CommonObject
 
 					$mouvS = new MouvementStock($this->db);
 					// we do not log origin because it will be deleted
-					$mouvS->origin = null;
+					$mouvS->origin = '';
 					// get lot/serial
 					$lotArray = null;
 					if (isModEnabled('productbatch')) {
@@ -1435,7 +1435,7 @@ class Expedition extends CommonObject
 
 					$mouvS = new MouvementStock($this->db);
 					// we do not log origin because it will be deleted
-					$mouvS->origin = null;
+					$mouvS->origin = '';
 					// get lot/serial
 					$lotArray = $shipmentlinebatch->fetchAll($obj->expeditiondet_id);
 					if (!is_array($lotArray)) {


### PR DESCRIPTION
htdocs/expedition/class/expedition.class.php	1245	Property CommonObject::$origin (CommonObject|string) does not accept null. 

htdocs/expedition/class/expedition.class.php	1438	Property CommonObject::$origin (CommonObject|string) does not accept null.