### PR TITLE
qual: phpdoc for htdocs/core/db/mysqli.class.php

### DIFF
--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -232,12 +232,12 @@ class DoliDBMysqli extends DoliDB
 	/**
 	 * Connect to server
 	 *
-	 * @param   string  $host 	Database server host
-	 * @param   string  $login 	Login
-	 * @param   string  $passwd Password
-	 * @param   string  $name 	Name of database (not used for mysql, used for pgsql)
-	 * @param   integer $port 	Port of database server
-	 * @return  mysqli|null		Database access object
+	 * @param   string          $host           Database server host
+	 * @param   string          $login          Login
+	 * @param   string          $passwd         Password
+	 * @param   string          $name           Name of database (not used for mysql, used for pgsql)
+	 * @param   integer         $port           Port of database server
+	 * @return  mysqli|mysqliDoli|false         Database access object
 	 * @see close()
 	 */
 	public function connect($host, $login, $passwd, $name, $port = 0)


### PR DESCRIPTION
PHPDoc update to reflect what the code does today.

This update however doesn't solve this PHPStan warning: 
htdocs/core/db/mysqli.class.php	243	Return type (mysqli|null) of method DoliDBMysqli::connect() should be compatible with return type (resource) of method Database::connect()