### PR TITLE
Fix typing for showOutputFieldForObject

### DIFF
--- a/htdocs/webportal/class/html.formwebportal.class.php
+++ b/htdocs/webportal/class/html.formwebportal.class.php
@@ -707,25 +707,25 @@ class FormWebPortal extends Form
 				$out = $this->inputType('number', $htmlName, dol_escape_htmltag($value), $htmlId, $morecss, $moreparam);
 				break;
 
-			case 'text' :
-			case 'html' :
+			case 'text':
+			case 'html':
 				$moreparam .= ($size > 0 ? ' maxlength="' . $size . '"' : '');
 				$out = $this->inputType('text', $htmlName, dol_escape_htmltag($value), $htmlId, $morecss, $moreparam);
 				break;
 
-			case 'email' :
+			case 'email':
 				$out = $this->inputType('email', $htmlName, dol_escape_htmltag($value), $htmlId, $morecss, $moreparam);
 				break;
 
-			case 'tel' :
+			case 'tel':
 				$out = $this->inputType('tel', $htmlName, dol_escape_htmltag($value), $htmlId, $morecss, $moreparam);
 				break;
 
-			case 'url' :
+			case 'url':
 				$out = $this->inputType('url', $htmlName, dol_escape_htmltag($value), $htmlId, $morecss, $moreparam);
 				break;
 
-			case 'price' :
+			case 'price':
 				if (!empty($value)) {
 					$value = price($value); // $value in memory is a php numeric, we format it into user number format.
 				}
@@ -733,18 +733,18 @@ class FormWebPortal extends Form
 				$out = $this->inputType('text', $htmlName, $value, $htmlId, $morecss, $moreparam, $addInputLabel);
 				break;
 
-			case 'double' :
+			case 'double':
 				if (!empty($value)) {
 					$value = price($value); // $value in memory is a php numeric, we format it into user number format.
 				}
 				$out = $this->inputType('text', $htmlName, $value, $htmlId, $morecss, $moreparam);
 				break;
 
-			case 'password' :
+			case 'password':
 				$out = $this->inputType('password', $htmlName, $value, $htmlId, $morecss, $moreparam);
 				break;
 
-			case 'radio' :
+			case 'radio':
 				foreach ($param['options'] as $keyopt => $valopt) {
 					$htmlId = $htmlName . '_' . $keyopt;
 					$htmlMoreParam = $moreparam . ($value == $keyopt ? ' checked' : '');
@@ -752,7 +752,7 @@ class FormWebPortal extends Form
 				}
 				break;
 
-			case 'select' :
+			case 'select':
 				$out = '<select class="' . $morecss . '" name="' . $htmlName . '" id="' . $htmlId . '"' . ($moreparam ? ' ' . $moreparam : '') . ' >';
 				if ($default == '' || $notNull != 1) {
 					$out .= '<option value="0">&nbsp;</option>';
@@ -771,7 +771,7 @@ class FormWebPortal extends Form
 				}
 				$out .= '</select>';
 				break;
-			case 'sellist' :
+			case 'sellist':
 				$out = '<select class="' . $morecss . '" name="' . $htmlName . '" id="' . $htmlId . '"' . ($moreparam ? ' ' . $moreparam : '') . '>';
 
 				$param_list = array_keys($param['options']);
@@ -923,7 +923,7 @@ class FormWebPortal extends Form
 				$out .= '</select>';
 				break;
 
-			case 'link' :
+			case 'link':
 				$param_list = array_keys($param['options']); // $param_list='ObjectName:classPath[:AddCreateButtonOrNot[:Filter[:Sortfield]]]'
 				$showempty = (($required && $default != '') ? 0 : 1);
 
@@ -931,7 +931,7 @@ class FormWebPortal extends Form
 
 				break;
 
-			default :
+			default:
 				if (!empty($hidden)) {
 					$out = $this->inputType('hidden', $htmlName, $value, $htmlId);
 				}
@@ -947,7 +947,7 @@ class FormWebPortal extends Form
 	 * @param CommonObject $object Common object
 	 * @param array $val Array of properties of field to show
 	 * @param string $key Key of attribute
-	 * @param string $value Preselected value to show (for date type it must be in timestamp format, for amount or price it must be a php numeric value)
+	 * @param string|string[] $value Preselected value to show (for date type it must be in timestamp format, for amount or price it must be a php numeric value)
 	 * @param string $moreparam To add more parameters on html input tag
 	 * @param string $keysuffix Prefix string to add into name and id of field (can be used to avoid duplicate names)
 	 * @param string $keyprefix Suffix string to add into name and id of field (can be used to avoid duplicate names)
@@ -1025,6 +1025,9 @@ class FormWebPortal extends Form
 		}
 
 		// Format output value differently according to properties of field
+		//
+		// First the cases that do not use $value from the arguments:
+		//
 		if (in_array($key, array('rowid', 'ref'))) {
 			if (property_exists($object, 'ref')) {
 				$value = $object->ref;
@@ -1035,6 +1038,20 @@ class FormWebPortal extends Form
 			}
 		} elseif ($key == 'status' && method_exists($object, 'getLibStatut')) {
 			$value = $object->getLibStatut(3);
+			//
+			// Then the cases where $value is an array
+			//
+		} elseif (is_array($value)) {
+			// Handle array early to get type identification solve for static
+			// analysis
+			if ($type == 'array') {
+				$value = implode('<br>', $value);
+			} else {
+				dol_syslog(__METHOD__ . 'ERROR unexpected type=$type for array value='.((string) json_encode($value)), LOG_ERR);
+			}
+			//
+			// Then the cases where $value is not an array (hence string)
+			//
 		} elseif ($type == 'date') {
 			if (!empty($value)) {
 				$value = dol_print_date($value, 'day');    // We suppose dates without time are always gmt (storage of course + output)
@@ -1304,8 +1321,6 @@ class FormWebPortal extends Form
 			}
 		} elseif ($type == 'password') {
 			$value = preg_replace('/./i', '*', $value);
-		} elseif ($type == 'array') {
-			$value = implode('<br>', $value);
 		} else {    // text|html|varchar
 			$value = dol_htmlentitiesbr($value);
 		}


### PR DESCRIPTION
# Fix typing for showOutputFieldForObject

Type hint that $value can also be a list of strings. Also updated the "else-if" sequence so that a static tool checker can still appropriately detect when $value is a string and when it is a list of strings so that it provides correct feedback. Added an error message to the syslog in case we got an array but not "array" as the value for "$type"