### PR TITLE
Qual: PhanCompatibleNegativeStringOffset must be suppressed

### DIFF
--- a/htdocs/core/lib/json.lib.php
+++ b/htdocs/core/lib/json.lib.php
@@ -267,6 +267,7 @@ function dol_json_decode($json, $assoc = false)
 		} else {
 			$out .= $json[$i];
 		}
+		// @phan-suppress-next-line PhanCompatibleNegativeStringOffset
 		if ($i >= 1 && $json[$i] == '"' && $json[$i - 1] != "\\") {
 			$comment = !$comment;
 		}


### PR DESCRIPTION
# Qual: PhanCompatibleNegativeStringOffset must be suppressed

Apparently the PhanCompatibleNegativeStringOffset notice can not be avoided through the '>=1' condition hint, so suppress it explicitly