### PR TITLE
Update ticket.class.php #28721  - Default for Ticket fk_statut in "up…

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1071,7 +1071,7 @@ class Ticket extends CommonObject
 		$sql .= " fk_user_assign=".(isset($this->fk_user_assign) ? $this->fk_user_assign : "null").",";
 		$sql .= " subject=".(isset($this->subject) ? "'".$this->db->escape($this->subject)."'" : "null").",";
 		$sql .= " message=".(isset($this->message) ? "'".$this->db->escape($this->message)."'" : "null").",";
-		$sql .= " fk_statut=".(isset($this->fk_statut) ? $this->fk_statut : "null").",";
+		$sql .= " fk_statut=".(isset($this->fk_statut) ? $this->fk_statut : "0").",";
 		$sql .= " resolution=".(isset($this->resolution) ? $this->resolution : "null").",";
 		$sql .= " progress=".(isset($this->progress) ? "'".$this->db->escape($this->progress)."'" : "null").",";
 		$sql .= " timing=".(isset($this->timing) ? "'".$this->db->escape($this->timing)."'" : "null").",";


### PR DESCRIPTION
…date" function

Correcting the default value for Ticket fk_statut to zero(0) instead of null based on the prescription derived from the create function.

# FIX|Fix [#28721](https://github.com/Dolibarr/dolibarr/issues/28721)
Fix where the update function sets Ticket.fk_statut to null which causes the status buttons to be unavailable.
The status badge shows "ErrorBadValueForParamNotAString"

