### PR TITLE
FIX: online signature partly fails if commercial proposal numbering contains a mask that’s includes a space (#28608) 

### DIFF
--- a/htdocs/core/lib/payments.lib.php
+++ b/htdocs/core/lib/payments.lib.php
@@ -242,7 +242,6 @@ function getOnlinePaymentUrl($mode, $type, $ref = '', $amount = 0, $freetag = 'y
 {
 	global $conf, $dolibarr_main_url_root;
 
-	$ref = str_replace(' ', '', $ref);
 	$out = '';
 
 	// Define $urlwithroot

--- a/htdocs/core/lib/signature.lib.php
+++ b/htdocs/core/lib/signature.lib.php
@@ -74,7 +74,6 @@ function getOnlineSignatureUrl($mode, $type, $ref = '', $localorexternal = 1, $o
 		}
 	}
 
-	$ref = str_replace(' ', '', $ref);
 	$out = '';
 
 	// Define $urlwithroot


### PR DESCRIPTION
FIX #28608 : online signature with space in ref
If Commercial proposal numbering contains a mask that’s includes a space, that will affect the result of the online signature form. When generating the online signature form, the code in signature.lib.php line 77, will remove any existing space in the Commercial proposal numbering. The result is that the online signature form will miss data in field “Third-party” and “Amount”.

@JonBendtsen also mentioned that  the same issue also appears in core/lib/payments.lib.php:	$ref = str_replace(' ', '', $ref);