### PR TITLE
FIX: update currency by selected supplier

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2716,7 +2716,11 @@ if ($action == 'create') {
 			print '<td>'.$form->editfieldkey('Currency', 'multicurrency_code', '', $object, 0).'</td>';
 			print '<td class="maxwidthonsmartphone">';
 			print img_picto('', 'currency', 'class="pictofixedwidth"');
-			print $form->selectMultiCurrency((GETPOSTISSET('multicurrency_code') ? GETPOST('multicurrency_code', 'alpha') : $currency_code), 'multicurrency_code');
+			$used_currency_code = $currency_code;
+			if (!GETPOST('changecompany')) {
+				$used_currency_code = GETPOSTISSET('multicurrency_code') ? GETPOST('multicurrency_code', 'alpha') : $currency_code;
+			}
+			print $form->selectMultiCurrency($used_currency_code, 'multicurrency_code');
 			print '</td></tr>';
 		}
 


### PR DESCRIPTION
# FIX In supplier invoice, update currency by the selected one

in the creation of a supplier invoice, when you select the supplier, the page reloads with the information but does not change the currency with it.

This behavior is annoying with multi-currencies.

However, having made the change, the page reload no longer takes the user's selection since it systematically takes that of the provider.

> Taked from branch 18
Old PR : https://github.com/Dolibarr/dolibarr/pull/27778
As mentioned, we should update currency when changing company, but only when company change with the 'changecompany' field