### PR TITLE
Fix: PhanTypeMismatchDeclaredParamNullable & enable detection

### DIFF
--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -475,7 +475,7 @@ return [
 		// 'PhanPluginUnknownFunctionReturnType',
 		// 'PhanPluginDescriptionlessCommentOnProtectedProperty',
 		'PhanPluginRedundantAssignmentInGlobalScope',
-		'PhanTypeMismatchDeclaredParamNullable',
+		// 'PhanTypeMismatchDeclaredParamNullable',
 		'PhanTypeInvalidRightOperandOfAdd',
 		// 'PhanPluginDescriptionlessCommentOnPrivateProperty',
 		// 'PhanUndeclaredVariableDim',  // Array initialisation on undeclared var: $abc['x']='ab'

--- a/htdocs/core/lib/bank.lib.php
+++ b/htdocs/core/lib/bank.lib.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2016		Juanjo Menent   	<jmenent@2byte.es>
  * Copyright (C) 2019	   Nicolas ZABOURI     <info@inovea-conseil.com>
  * Copyright (C) 2021		Ferran Marcet		<fmarcet@2byte.es>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -228,8 +229,8 @@ function account_statement_prepare_head($object, $num)
 /**
  * Prepare array with list of tabs
  *
- * @param   Object	$object		Object related to tabs
- * @return  array				Array of tabs to shoc
+ * @param   CommonObject	$object		Object related to tabs
+ * @return  array						Array of tabs to shoc
  */
 function various_payment_prepare_head($object)
 {
@@ -275,8 +276,8 @@ function various_payment_prepare_head($object)
 /**
  *      Check SWIFT information for a bank account
  *
- *      @param  Account     $account    A bank account (used to get BIC/SWIFT)
- *      @param	string		$swift		Swift value (used to get BIC/SWIFT, param $account non used if provided)
+ *      @param  ?Account	$account    A bank account (used to get BIC/SWIFT)
+ *      @param	?string		$swift		Swift value (used to get BIC/SWIFT, param $account non used if provided)
  *      @return boolean                 True if information are valid, false otherwise
  */
 function checkSwiftForAccount(Account $account = null, $swift = null)
@@ -296,8 +297,8 @@ function checkSwiftForAccount(Account $account = null, $swift = null)
 /**
  *      Check IBAN number information for a bank account.
  *
- *      @param  Account     $account    	A bank account
- *      @param	string		$ibantocheck	Bank account number (used to get BAN, $account not used if provided)
+ *      @param  ?Account	$account    	A bank account
+ *      @param	?string		$ibantocheck	Bank account number (used to get BAN, $account not used if provided)
  *      @return boolean                 	True if information are valid, false otherwise
  */
 function checkIbanForAccount(Account $account = null, $ibantocheck = null)

--- a/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
+++ b/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2011		Fabrice CHERRIER
  * Copyright (C) 2013		Cédric Salvador				<csalvador@gpcsolutions.fr>
  * Copyright (C) 2015       Marcos García               <marcosgdf@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -449,7 +450,7 @@ class pdf_soleil extends ModelePDFFicheinter
 	 *   @param		Translate	$outputlangs	Langs object
 	 *   @param		int			$hidetop		Hide top bar of array
 	 *   @param		int			$hidebottom		Hide bottom bar of array
-	 *   @param		Fichinter	$object			FichInter Object
+	 *   @param		?Fichinter	$object			FichInter Object
 	 *   @return	void
 	 */
 	protected function _tableau(&$pdf, $tab_top, $tab_height, $nexY, $outputlangs, $hidetop = 0, $hidebottom = 0, FichInter $object = null)


### PR DESCRIPTION
# Fix: PhanTypeMismatchDeclaredParamNullable & enable detection

The few cases with PhanTypeMismatchDeclaredParamNullable  are fixed, and detection can be enabled.