### PR TITLE
Qual: Exclude some tests from windows-ci until fixed

### DIFF
--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -114,7 +114,7 @@ jobs:
           curl "http://${{ env.PHPSERVER_DOMAIN_PORT }}"
         shell: powershell
       - name: Run PHPUnit tests
-        continue-on-error: true
+        # continue-on-error: true
         shell: cmd
         # setting up php.ini, starting the php server are currently in this step
         run: |-
@@ -143,7 +143,7 @@ jobs:
           cat htdocs/conf/conf.php
           curl "http://${{ env.PHPSERVER_DOMAIN_PORT }}"
           REM 'DOSKEY' USED to recover error code (no pipefile equivalent in windows?)
-          ( php "%PHPROOT%\phpunit" -d memory_limit=-1 -c %CD%\test\phpunit\phpunittest.xml "test\phpunit\AllTests.php" & call doskey /exename=err err=%%^^errorlevel%% ) | "${{ env.TEE }}" "${{ env.PHPUNIT_LOG }}"
+          ( php "%PHPROOT%\phpunit" -d memory_limit=-1 -c %CD%\test\phpunit\phpunittest.xml "test\phpunit\AllTests.php" --exclude-group WindowsWaitingForFix & call doskey /exename=err err=%%^^errorlevel%% ) | "${{ env.TEE }}" "${{ env.PHPUNIT_LOG }}"
           for /f "tokens=2 delims==" %%A in ('doskey /m:err') do EXIT /B %%A
       - name: Convert Raw Log to Annotations
         uses: mdeweerd/logToCheckStyle@v2024.2.9

--- a/test/phpunit/FilesLibTest.php
+++ b/test/phpunit/FilesLibTest.php
@@ -247,6 +247,7 @@ class FilesLibTest extends CommonClassTest
 	 * testDolCopyMoveDelete
 	 *
 	 * @return	void
+	 * @group WindowsWaitingForFix
 	 */
 	public function testDolCopyMoveDelete()
 	{
@@ -490,6 +491,7 @@ class FilesLibTest extends CommonClassTest
 	 * testDolDirMove
 	 *
 	 * @return void
+	 * @group WindowsWaitingForFix
 	 */
 	public function testDolDirMove()
 	{


### PR DESCRIPTION
# Qual: Exclude some tests from windows-ci until fixed

Until #28598 and #28264 find some way to the develop branch, this update will skip the tests that currently fail on windows so that the results of other tests have an effect on the CI status and github annotations