### PR TITLE
Fix: In PHP 8 we need to return 0 instead of '' for integers

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1051,12 +1051,12 @@ function sanitizeVal($out = '', $check = 'alphanohtml', $filter = null, $options
 			break;
 		case 'int':    // Check param is a numeric value (integer but also float or hexadecimal)
 			if (!is_numeric($out)) {
-				$out = '';
+				$out = 0;
 			}
 			break;
 		case 'intcomma':
 			if (preg_match('/[^0-9,-]+/i', $out)) {
-				$out = '';
+				$out = 0;
 			}
 			break;
 		case 'san_alpha':


### PR DESCRIPTION
Fix: In PHP 8 ''<0 and is not converted to 0 so we should return 0 expressly for intreger values