### PR TITLE
Fix: Error in the treatment of the date and the name of the variable

### DIFF
--- a/htdocs/product/class/productbatch.class.php
+++ b/htdocs/product/class/productbatch.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2007-2023 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2013-2014 Cedric GROSS         <c.gross@kreiz-it.fr>
+ * Copyright (C) 2024      Ferran Marcet        <fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -519,7 +520,7 @@ class Productbatch extends CommonObject
 				$tmp->import_key = $obj->import_key;
 
 				if (getDolGlobalString('SHIPPING_DISPLAY_STOCK_ENTRY_DATE')) {
-					$tmp->context['stock_date_entry'] = $obj->date_entree;
+					$tmp->context['stock_entry_date'] = $dbs->jdate($obj->date_entree);
 				}
 
 				if ($fk_product > 0) {


### PR DESCRIPTION
A jdate() was missing to convert the date to an integer after fetch. And the name of the variable did not correspond to the name it was intended to be used with.