### PR TITLE
Fix & enable PhanPluginDuplicateExpressionAssignment

### DIFF
--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -410,8 +410,7 @@ return [
 		'PhanDeprecatedProperty',
 		'PhanDeprecatedFunction',
 		//'PhanCompatibleNegativeStringOffset',
-		// Dolibarr has quite a few strange noop assignments like $abc=$abc;
-		'PhanPluginDuplicateExpressionAssignment',
+		// 'PhanPluginDuplicateExpressionAssignment',
 		// Nulls are likely mostly false positives
 		'PhanPluginConstantVariableNull',
 		'PhanTypeObjectUnsetDeclaredProperty',
@@ -601,7 +600,7 @@ return [
 		'PhanUndeclaredClassMethod',
 		'PhanUndeclaredMethod',
 		'PhanTypeMismatchArgumentProbablyReal',
-		'PhanPluginDuplicateExpressionAssignmentOperation',
+		'PhanPluginDuplicateExpressionAssignmentOperation',  // Suggestions for optimisation
 		'PhanTypeMismatchPropertyDefault',
 		// 'PhanPluginAlwaysReturnMethod',
 		// 'PhanPluginMissingReturnMethod',

--- a/htdocs/adherents/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/adherents/tpl/linkedobjectblock.tpl.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2010-2011	Regis Houssin <regis.houssin@inodbox.com>
  * Copyright (C) 2013		Juanjo Menent <jmenent@2byte.es>
  * Copyright (C) 2014       Marcos García <marcosgdf@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,7 +41,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	echo '<td class="center">'.dol_print_date($objectlink->dateh, 'day').'</td>';
 	echo '<td class="right">';
 	if ($user->hasRight('adherent', 'lire')) {
-		$total = $total + $objectlink->amount;
+		$total += $objectlink->amount;
 		echo price($objectlink->amount);
 	}
 	echo '</td>';

--- a/htdocs/admin/modules.php
+++ b/htdocs/admin/modules.php
@@ -9,6 +9,7 @@
  * Copyright (C) 2015		Raphaël Doursenaud		<rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2018		Nicolas ZABOURI 		<info@inovea-conseil.com>
  * Copyright (C) 2021-2023  Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1253,36 +1254,36 @@ if ($mode == 'deploy') {
 			$maxphp = @ini_get('upload_max_filesize'); // In unknown
 			if (preg_match('/k$/i', $maxphp)) {
 				$maxphp = preg_replace('/k$/i', '', $maxphp);
-				$maxphp = $maxphp * 1;
+				$maxphp *= 1;
 			}
 			if (preg_match('/m$/i', $maxphp)) {
 				$maxphp = preg_replace('/m$/i', '', $maxphp);
-				$maxphp = $maxphp * 1024;
+				$maxphp *= 1024;
 			}
 			if (preg_match('/g$/i', $maxphp)) {
 				$maxphp = preg_replace('/g$/i', '', $maxphp);
-				$maxphp = $maxphp * 1024 * 1024;
+				$maxphp *= 1024 * 1024;
 			}
 			if (preg_match('/t$/i', $maxphp)) {
 				$maxphp = preg_replace('/t$/i', '', $maxphp);
-				$maxphp = $maxphp * 1024 * 1024 * 1024;
+				$maxphp *= 1024 * 1024 * 1024;
 			}
 			$maxphp2 = @ini_get('post_max_size'); // In unknown
 			if (preg_match('/k$/i', $maxphp2)) {
 				$maxphp2 = preg_replace('/k$/i', '', $maxphp2);
-				$maxphp2 = $maxphp2 * 1;
+				$maxphp2 *= 1;
 			}
 			if (preg_match('/m$/i', $maxphp2)) {
 				$maxphp2 = preg_replace('/m$/i', '', $maxphp2);
-				$maxphp2 = $maxphp2 * 1024;
+				$maxphp2 *= 1024;
 			}
 			if (preg_match('/g$/i', $maxphp2)) {
 				$maxphp2 = preg_replace('/g$/i', '', $maxphp2);
-				$maxphp2 = $maxphp2 * 1024 * 1024;
+				$maxphp2 *= 1024 * 1024;
 			}
 			if (preg_match('/t$/i', $maxphp2)) {
 				$maxphp2 = preg_replace('/t$/i', '', $maxphp2);
-				$maxphp2 = $maxphp2 * 1024 * 1024 * 1024;
+				$maxphp2 *= 1024 * 1024 * 1024;
 			}
 			// Now $max and $maxphp and $maxphp2 are in Kb
 			$maxmin = $max;

--- a/htdocs/admin/system/filecheck.php
+++ b/htdocs/admin/system/filecheck.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2007-2012  Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2015-2019  Frederic France         <frederic.france@netlogic.fr>
  * Copyright (C) 2017       Nicolas ZABOURI         <info@inovea-conseil.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -83,7 +84,7 @@ $xmlshortfile = dol_sanitizeFileName(GETPOST('xmlshortfile', 'alpha') ? GETPOST(
 
 $xmlfile = DOL_DOCUMENT_ROOT.'/install/'.$xmlshortfile;
 if (!preg_match('/\.zip$/i', $xmlfile) && dol_is_file($xmlfile.'.zip')) {
-	$xmlfile = $xmlfile.'.zip';
+	$xmlfile .= '.zip';
 }
 
 // Remote file to compare to
@@ -183,7 +184,7 @@ if (GETPOST('target') == 'remote') {
 			libxml_disable_entity_loader(true);
 		}
 
-		$xml = simplexml_load_string($xmlfile, 'SimpleXMLElement', LIBXML_NOCDATA|LIBXML_NONET);
+		$xml = simplexml_load_string($xmlfile, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_NONET);
 	} else {
 		$errormsg = $langs->trans('XmlNotFound').': '.$xmlremote.' - '.$xmlarray['http_code'].(($xmlarray['http_code'] == 400 && $xmlarray['content']) ? ' '.$xmlarray['content'] : '').' '.$xmlarray['curl_error_no'].' '.$xmlarray['curl_error_msg'];
 		setEventMessages($errormsg, null, 'errors');
@@ -259,7 +260,7 @@ if (empty($error) && !empty($xml)) {
 			$tmprelativefilename = preg_replace('/^'.preg_quote(DOL_DOCUMENT_ROOT, '/').'/', '', $valfile['fullname']);
 			if (!in_array($tmprelativefilename, $file_list['insignature'])) {
 				$md5newfile = @md5_file($valfile['fullname']); // Can fails if we don't have permission to open/read file
-				$file_list['added'][] = array('filename'=>$tmprelativefilename, 'md5'=>$md5newfile);
+				$file_list['added'][] = array('filename' => $tmprelativefilename, 'md5' => $md5newfile);
 			}
 		}
 

--- a/htdocs/admin/system/phpinfo.php
+++ b/htdocs/admin/system/phpinfo.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2005-2012	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2016       Juanjo Menent			<jmenent@2byte.es>
  * Copyright (C) 2020       Tobias Sekan			<tobias.sekan@startmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,36 +54,36 @@ if (isset($title)) {
 $maxphp = @ini_get('upload_max_filesize'); // In unknown
 if (preg_match('/k$/i', $maxphp)) {
 	$maxphp = preg_replace('/k$/i', '', $maxphp);
-	$maxphp = $maxphp * 1;
+	$maxphp *= 1;
 }
 if (preg_match('/m$/i', $maxphp)) {
 	$maxphp = preg_replace('/m$/i', '', $maxphp);
-	$maxphp = $maxphp * 1024;
+	$maxphp *= 1024;
 }
 if (preg_match('/g$/i', $maxphp)) {
 	$maxphp = preg_replace('/g$/i', '', $maxphp);
-	$maxphp = $maxphp * 1024 * 1024;
+	$maxphp *= 1024 * 1024;
 }
 if (preg_match('/t$/i', $maxphp)) {
 	$maxphp = preg_replace('/t$/i', '', $maxphp);
-	$maxphp = $maxphp * 1024 * 1024 * 1024;
+	$maxphp *= 1024 * 1024 * 1024;
 }
 $maxphp2 = @ini_get('post_max_size'); // In unknown
 if (preg_match('/k$/i', $maxphp2)) {
 	$maxphp2 = preg_replace('/k$/i', '', $maxphp2);
-	$maxphp2 = $maxphp2 * 1;
+	$maxphp2 *= 1;
 }
 if (preg_match('/m$/i', $maxphp2)) {
 	$maxphp2 = preg_replace('/m$/i', '', $maxphp2);
-	$maxphp2 = $maxphp2 * 1024;
+	$maxphp2 *= 1024;
 }
 if (preg_match('/g$/i', $maxphp2)) {
 	$maxphp2 = preg_replace('/g$/i', '', $maxphp2);
-	$maxphp2 = $maxphp2 * 1024 * 1024;
+	$maxphp2 *= 1024 * 1024;
 }
 if (preg_match('/t$/i', $maxphp2)) {
 	$maxphp2 = preg_replace('/t$/i', '', $maxphp2);
-	$maxphp2 = $maxphp2 * 1024 * 1024 * 1024;
+	$maxphp2 *= 1024 * 1024 * 1024;
 }
 if ($maxphp > 0 && $maxphp2 > 0 && $maxphp > $maxphp2) {
 	$langs->load("errors");

--- a/htdocs/compta/bank/various_payment/card.php
+++ b/htdocs/compta/bank/various_payment/card.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2018-2024  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2023       Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2023       Joachim Kueter     		<git-jk@bloxera.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -286,9 +287,7 @@ if ($action == 'confirm_clone' && $confirm == 'yes' && $permissiontoadd) {
 
 		if (GETPOSTISSET("clone_sens")) {
 			$object->sens = GETPOSTINT("clone_sens");
-		} else {
-			$object->sens = $object->sens;
-		}
+		} // else { $object->sens = $object->sens; }
 
 		if (GETPOSTISSET("clone_amount")) {
 			$object->amount = GETPOSTFLOAT("clone_amount");

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1274,7 +1274,7 @@ if (empty($reshook)) {
 							$line->fk_parent_line = $fk_parent_line;
 
 							$line->subprice = -$line->subprice; // invert price for object
-							$line->pa_ht = $line->pa_ht; // we chose to have buy/cost price always positive, so no revert of sign here
+							// $line->pa_ht = $line->pa_ht; // we chose to have buy/cost price always positive, so no revert of sign here
 							$line->total_ht = -$line->total_ht;
 							$line->total_tva = -$line->total_tva;
 							$line->total_ttc = -$line->total_ttc;

--- a/htdocs/compta/sociales/class/chargesociales.class.php
+++ b/htdocs/compta/sociales/class/chargesociales.class.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2016-2024  Frédéric France      <frederic.france@free.fr>
  * Copyright (C) 2017      Alexandre Spangaro	<aspangaro@open-dsi.fr>
  * Copyright (C) 2021      Gauthier VERDOL		<gauthier.verdol@atm-consulting.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -192,7 +193,7 @@ class ChargeSociales extends CommonObject
 				$this->paye = $obj->paye;
 				$this->periode = $this->db->jdate($obj->period);
 				$this->period = $this->db->jdate($obj->period);
-				$this->import_key = $this->import_key;
+				$this->import_key = $obj->import_key;
 
 				$this->db->free($resql);
 
@@ -653,7 +654,7 @@ class ChargeSociales extends CommonObject
 		$result .= $linkend;
 		global $action;
 		$hookmanager->initHooks(array($this->element . 'dao'));
-		$parameters = array('id'=>$this->id, 'getnomurl' => &$result);
+		$parameters = array('id' => $this->id, 'getnomurl' => &$result);
 		$reshook = $hookmanager->executeHooks('getNomUrl', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 		if ($reshook > 0) {
 			$result = $hookmanager->resPrint;

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -764,7 +764,7 @@ if (empty($reshook)) {
 			$fk_unit = GETPOST('unit', 'alpha');
 
 			// update price_ht with discount
-			// TODO Use object->updateline instead objedtline->update
+			// TODO Use object->updateline instead objectline->update
 
 			$price_ht =  price2num(GETPOST('elprice'), 'MU');
 			$remise_percent = price2num(GETPOST('elremise_percent'), '', 2);
@@ -789,7 +789,7 @@ if (empty($reshook)) {
 			$objectline->user_closing_id = $user->id;
 			//$objectline->fk_fournprice = $fk_fournprice;
 			$objectline->pa_ht = $pa_ht;
-			$objectline->rang = $objectline->rang;
+			// $objectline->rang = $objectline->rang;
 
 			if ($fk_unit > 0) {
 				$objectline->fk_unit = GETPOST('unit');

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3467,19 +3467,6 @@ class ContratLigne extends CommonObjectLine
 		if (empty($this->remise_percent)) {
 			$this->remise_percent = 0;
 		}
-		// For backward compatibility
-		if (empty($this->date_start)) {
-			$this->date_start = $this->date_start;
-		}
-		if (empty($this->date_start_real)) {
-			$this->date_start_real = $this->date_start_real;
-		}
-		if (empty($this->date_end)) {
-			$this->date_end = $this->date_end;
-		}
-		if (empty($this->date_end_real)) {
-			$this->date_end_real = $this->date_end_real;
-		}
 
 		// Calcul du total TTC et de la TVA pour la ligne a partir de
 		// qty, pu, remise_percent et txtva

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -11,6 +11,7 @@
  * Copyright (C) 2017       Nicolas ZABOURI         <info@inovea-conseil.com>
  * Copyright (C) 2018-2022  Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2022 		Antonin MARCHAL         <antonin@letempledujeu.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1310,7 +1311,6 @@ class ExtraFields
 							} else {
 								$labeltoshow = $obj->{$InfoFieldList[1]};
 							}
-							$labeltoshow = $labeltoshow;
 
 							if ($value == $obj->rowid) {
 								if (!$notrans) {

--- a/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
+++ b/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
@@ -9,6 +9,7 @@
  * Copyright (C) 2023		William Mead			<william.mead@manchenumerique.fr>
  * Copyright (C) 2023       Christian Foellmann     <christian@foellmann.de>
  * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -172,7 +173,7 @@ class InterfaceActionsAuto extends DolibarrTriggers
 			}
 
 			$object->sendtoid = array($object->id => $object->id);
-			$object->socid = $object->socid;
+			// $object->socid = $object->socid;
 		} elseif ($action == 'CONTACT_MODIFY') {
 			// Load translation files required by the page
 			$langs->loadLangs(array("agenda", "other", "companies"));
@@ -189,7 +190,7 @@ class InterfaceActionsAuto extends DolibarrTriggers
 			}
 
 			$object->sendtoid = array($object->id => $object->id);
-			$object->socid = $object->socid;
+			// $object->socid = $object->socid;
 		} elseif ($action == 'CONTRACT_VALIDATE') {
 			// Load translation files required by the page
 			$langs->loadLangs(array("agenda", "other", "contracts"));

--- a/htdocs/salaries/document.php
+++ b/htdocs/salaries/document.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2013       Cédric Salvador         <csalvador@gpcsolutions.fr>
  * Copyright (C) 2015-2023  Alexandre Spangaro      <aspangaro@easya.solutions>
  * Copyright (C) 2021       Gauthier VERDOL         <gauthier.verdol@atm-consulting.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -238,7 +239,7 @@ if ($object->id) {
 	print dol_get_fiche_end();
 
 	$modulepart = 'salaries';
-	$permissiontoadd = $permissiontoadd;
+	// $permissiontoadd = $permissiontoadd;
 	$param = '&id='.$object->id;
 	include DOL_DOCUMENT_ROOT.'/core/tpl/document_actions_post_headers.tpl.php';
 } else {

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2019   Cedric Ancelin          <icedo.anc@gmail.com>
  * Copyright (C) 2020-2024  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2023       Alexandre Janniaux  <alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1306,7 +1307,7 @@ class Thirdparties extends DolibarrApi
 		$this->company->setDocModel(DolibarrApiAccess::$user, $model);
 
 		$this->company->fk_bank = $this->company->fk_account;
-		$this->company->fk_account = $this->company->fk_account;
+		// $this->company->fk_account = $this->company->fk_account;
 
 		$outputlangs = $langs;
 		$newlang = '';

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -447,7 +447,7 @@ if (empty($reshook)) {
 			$line->fk_parent_line = $fk_parent_line;
 
 			$line->subprice = -$line->subprice; // invert price for object
-			$line->pa_ht = $line->pa_ht; // we chose to have the buy/cost price always positive, so no inversion of the sign here
+			// $line->pa_ht = $line->pa_ht; // we chose to have the buy/cost price always positive, so no inversion of the sign here
 			$line->total_ht = -$line->total_ht;
 			$line->total_tva = -$line->total_tva;
 			$line->total_ttc = -$line->total_ttc;


### PR DESCRIPTION
# Fix & enable PhanPluginDuplicateExpressionAssignment

Most of the time these are '$a = $a' that seem to be useless assignments, except for 'documentation'.  In some cases this may be due to removal of deprecated properties.

In the first commit this seems to be a mistake and I modified the assignment.

I suggest an attentive review to ensure that none of the deleted/commented cases were in fact forgotten updates to the assignments.

Some changes are optimisations because I filtered on PhanPluginDuplicateExpressionAssignment which got me the PhanPluginDuplicateExpressionAssignmentOperation cases as well that are in fact optimisations.  As I fixed some of those, I kept them in the PR.
