### PR TITLE
NEW ModuleBuilder : fix type password and add genericpassword entry types

### DIFF
--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -1035,7 +1035,7 @@ class FormSetupItem
 	/**
 	 * generate input field for a password
 	 *
-	 * @param   [type]  $type  'dolibarr' (dolibarr password rules apply) or 'generic'
+	 * @param   string  $type  'dolibarr' (dolibarr password rules apply) or 'generic'
 	 *
 	 * @return  string
 	 */


### PR DESCRIPTION
# NEW add password to FormBuilder

That sort of field is missing with that great tool ... i've just added two sort of passwords : one with dolibarr rules and an other one for other external passwords (for example SMTP passwd entries).