### PR TITLE
Fix & enable PhanTypeInvalidUnaryOperandIncOrDec

### DIFF
--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -482,7 +482,7 @@ return [
 		'PhanTypeInvalidPropertyName',
 		'PhanPluginDuplicateCatchStatementBody',
 		'PhanPluginUndeclaredVariableIsset',
-		'PhanTypeInvalidUnaryOperandIncOrDec',
+		// 'PhanTypeInvalidUnaryOperandIncOrDec',
 		// 'PhanPluginDescriptionlessCommentOnClass',
 		'PhanPluginEmptyStatementIf',
 		'PhanPluginInlineHTMLTrailing',

--- a/htdocs/barcode/printsheet.php
+++ b/htdocs/barcode/printsheet.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2003	   Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (C) 2003	   Jean-Louis Bergamo	<jlb@j1b.org>
  * Copyright (C) 2006-2017 Laurent Destailleur	<eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -252,8 +253,6 @@ if (empty($reshook)) {
 					$error++;
 				}
 			}
-
-			$i++;
 
 			// Build and output PDF
 			if (!$error && $mode == 'label') {

--- a/htdocs/compta/cashcontrol/report.php
+++ b/htdocs/compta/cashcontrol/report.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2016       Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2017       Alexandre Spangaro   <aspangaro@open-dsi.fr>
  * Copyright (C) 2018       Andreu Bisquerra	 <jove@bisquerra.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,13 +60,13 @@ $sortorder = 'ASC';
 $sortfield = 'b.datev,b.dateo,b.rowid';
 
 $arrayfields = array(
-	'b.rowid'=>array('label'=>$langs->trans("Ref"), 'checked'=>1),
-	'b.dateo'=>array('label'=>$langs->trans("DateOperationShort"), 'checked'=>1),
-	'b.num_chq'=>array('label'=>$langs->trans("Number"), 'checked'=>1),
-	'ba.ref'=>array('label'=>$langs->trans("BankAccount"), 'checked'=>1),
-	'cp.code'=>array('label'=>$langs->trans("PaymentMode"), 'checked'=>1),
-	'b.debit'=>array('label'=>$langs->trans("Debit"), 'checked'=>1, 'position'=>600),
-	'b.credit'=>array('label'=>$langs->trans("Credit"), 'checked'=>1, 'position'=>605),
+	'b.rowid' => array('label' => $langs->trans("Ref"), 'checked' => 1),
+	'b.dateo' => array('label' => $langs->trans("DateOperationShort"), 'checked' => 1),
+	'b.num_chq' => array('label' => $langs->trans("Number"), 'checked' => 1),
+	'ba.ref' => array('label' => $langs->trans("BankAccount"), 'checked' => 1),
+	'cp.code' => array('label' => $langs->trans("PaymentMode"), 'checked' => 1),
+	'b.debit' => array('label' => $langs->trans("Debit"), 'checked' => 1, 'position' => 600),
+	'b.credit' => array('label' => $langs->trans("Credit"), 'checked' => 1, 'position' => 605),
 );
 
 $syear  = $object->year_close;
@@ -209,7 +210,7 @@ if ($resql) {
 	$transactionspertype = array();
 	$amountpertype = array();
 
-	$totalarray = array();
+	$totalarray = array('nbfield' => 0,'pos' => array());
 	while ($i < $num) {
 		$objp = $db->fetch_object($resql);
 

--- a/htdocs/compta/cashcontrol/report.php
+++ b/htdocs/compta/cashcontrol/report.php
@@ -210,7 +210,7 @@ if ($resql) {
 	$transactionspertype = array();
 	$amountpertype = array();
 
-	$totalarray = array('nbfield' => 0,'pos' => array());
+	$totalarray = array('nbfield' => 0, 'pos' => array());
 	while ($i < $num) {
 		$objp = $db->fetch_object($resql);
 

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1040,6 +1040,7 @@ if (!$error && ($massaction == 'delete' || ($action == 'delete' && $confirm == '
 
 	$objecttmp = new $objectclass($db);
 	$nbok = 0;
+	$nbignored = 0;
 	$TMsg = array();
 
 	//$toselect could contain duplicate entries, cf https://github.com/Dolibarr/dolibarr/issues/26244
@@ -1200,6 +1201,7 @@ if (!$error && $massaction == 'generate_doc' && $permissiontoread) {
 }
 
 if (!$error && ($action == 'affecttag' && $confirm == 'yes') && $permissiontoadd) {
+	$nbok = 0;
 	$db->begin();
 
 	$affecttag_type = GETPOST('affecttag_type', 'alpha');
@@ -1221,7 +1223,6 @@ if (!$error && ($action == 'affecttag' && $confirm == 'yes') && $permissiontoadd
 		}
 
 		//For each valid categ type set common categ
-		$nbok = 0;
 		if (!empty($to_affecttag_type_array)) {
 			foreach ($to_affecttag_type_array as $categ_type) {
 				$contcats = GETPOST('contcats_' . $categ_type, 'array');
@@ -1256,6 +1257,7 @@ if (!$error && ($action == 'affecttag' && $confirm == 'yes') && $permissiontoadd
 }
 
 if (!$error && ($action == 'updateprice' && $confirm == 'yes') && $permissiontoadd) {
+	$nbok = 0;
 	$db->begin();
 	if (GETPOSTISSET('pricerate')) {
 		$pricepercentage = GETPOSTINT('pricerate');
@@ -1300,6 +1302,7 @@ if (!$error && ($action == 'updateprice' && $confirm == 'yes') && $permissiontoa
 }
 
 if (!$error && ($action == 'setsupervisor' && $confirm == 'yes') && $permissiontoadd) {
+	$nbok = 0;
 	$db->begin();
 	$supervisortoset = GETPOST('supervisortoset');
 	if (!empty($supervisortoset)) {
@@ -1335,6 +1338,7 @@ if (!$error && ($action == 'setsupervisor' && $confirm == 'yes') && $permissiont
 }
 
 if (!$error && ($action == 'affectuser' && $confirm == 'yes') && $permissiontoadd) {
+	$nbok = 0;
 	$db->begin();
 
 	$usertoaffect = GETPOST('usertoaffect');

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -2230,7 +2230,6 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon = null, $nopr
 			}
 
 			$out .= "</tr>\n";
-			$i++;
 		}
 		if (empty($histo)) {
 			$colspan = 9;

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13804,8 +13804,6 @@ function show_actions_messaging($conf, $langs, $db, $filterobj, $objcon = null, 
 
 			$out .= '</li>';
 			$out .= '<!-- END timeline item -->';
-
-			$i++;
 		}
 
 		$out .= "</ul>\n";

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -3363,7 +3363,7 @@ class EmailCollector extends CommonObject
 				if (empty($mode) && empty($error)) {
 					$res = imap_mail_move($connection, $imapemail, $targetdir, CP_UID);
 					if ($res == false) {
-						$errorforemail++;
+						// $errorforemail++;  // Not in loop, not needed, not initialised
 						$this->error = imap_last_error();
 						$this->errors[] = $this->error;
 

--- a/htdocs/product/popuprop.php
+++ b/htdocs/product/popuprop.php
@@ -260,7 +260,6 @@ if ($mode && $mode != '-1') {
 		print '<td>'.dol_escape_htmltag($vals['label']).'</td>';
 		print '<td class="right">'.$vals['nbline'].'</td>';
 		print "</tr>\n";
-		$i++;
 	}
 } else {
 	print '<tr><td colspan="4"><span class="opacitymedium">'.$langs->trans("SelectTheTypeOfObjectToAnalyze").'</span></td></tr>';

--- a/htdocs/product/stock/movement_card.php
+++ b/htdocs/product/stock/movement_card.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2015		Juanjo Menent			<jmenent@2byte.es>
  * Copyright (C) 2018		Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2019       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -249,6 +250,7 @@ if ($action == "correct_stock") {
 
 // Transfer stock from a warehouse to another warehouse
 if ($action == "transfert_stock" && !$cancel) {
+	$error = 0;
 	$product = new Product($db);
 	if (!empty($product_id)) {
 		$result = $product->fetch($product_id);

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -429,6 +429,7 @@ if ($action == "correct_stock") {
 
 // Transfer stock from a warehouse to another warehouse
 if ($action == "transfert_stock" && !$cancel) {
+	$error = 0;
 	$product = new Product($db);
 	if (!empty($product_id)) {
 		$result = $product->fetch($product_id);

--- a/htdocs/reception/dispatch.php
+++ b/htdocs/reception/dispatch.php
@@ -9,6 +9,7 @@
  * Copyright (C) 2017-2022 Ferran Marcet        <fmarcet@2byte.es>
  * Copyright (C) 2018-2022 Frédéric France      <frederic.france@netlogic.fr>
  * Copyright (C) 2019-2020 Christophe Battarel	<christophe@altairis.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -304,6 +305,7 @@ $supplierorderdispatch = new CommandeFournisseurDispatch($db);
 $title = $object->ref." - ".$langs->trans('ReceptionDistribution');
 $help_url = 'EN:Module_Suppliers_Orders|FR:CommandeFournisseur|ES:Módulo_Pedidos_a_proveedores';
 $morejs = array('/fourn/js/lib_dispatch.js.php');
+$numline = 0;
 
 llxHeader('', $title, $help_url, '', 0, 0, $morejs);
 

--- a/htdocs/societe/admin/societe.php
+++ b/htdocs/societe/admin/societe.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2005-2011  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012  Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2011-2012  Juanjo Menent           <jmenent@2byte.es>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -735,7 +736,6 @@ foreach ($profid as $key => $val) {
 
 		print "</tr>\n";
 	}
-	$i++;
 }
 
 // VAT ID

--- a/htdocs/website/index.php
+++ b/htdocs/website/index.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2016-2023 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2020 	   Nicolas ZABOURI		<info@inovea-conseil.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -747,6 +748,8 @@ if ($action == 'addsite' && $usercanedit) {
 	}
 }
 
+'@phan-var-force int $error';
+
 // Add page/container
 if ($action == 'addcontainer' && $usercanedit) {
 	dol_mkdir($pathofwebsite);
@@ -761,6 +764,7 @@ if ($action == 'addcontainer' && $usercanedit) {
 		$grabimagesinto = GETPOST('grabimagesinto', 'alpha');
 
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/geturl.lib.php';
+		// The include seems to break typing on variables
 
 		if (empty($urltograb)) {
 			$error++;


### PR DESCRIPTION
# Fix & enable PhanTypeInvalidUnaryOperandIncOrDec

This fixes ($var++) where $var was not clearly defined as an int.
In some cases these were stray $i++ occurences, in most cases an initialisation was needed, and in one case the reason is not clear (website/index.php where $error was initialised but still deemed to not be an int later).

All PhanTypeInvalidUnaryOperandIncOrDec cases are fixed, so this notification does not need suppression.