### PR TITLE
Fix & enable PhanNoopProperty

### DIFF
--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -549,7 +549,7 @@ return [
 		// 'PhanSyntaxReturnValueInVoid',
 		// 'PhanTypeInstantiateTraitStaticOrSelf',
 		// 'PhanUndeclaredInvokeInCallable',
-		'PhanNoopProperty',
+		// 'PhanNoopProperty',
 		'PhanNoopVariable',
 		// 'PhanPluginPrintfUnusedArgument',
 		// 'PhanSyntaxReturnExpectedValue',

--- a/htdocs/compta/cashcontrol/cashcontrol_card.php
+++ b/htdocs/compta/cashcontrol/cashcontrol_card.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2015      Jean-François Ferry	<jfefe@aternatik.fr>
  * Copyright (C) 2016      Marcos García        <marcosgdf@gmail.com>
  * Copyright (C) 2018      Andreu Bisquerra		<jove@bisquerra.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -68,7 +69,7 @@ if ($contextpage == 'takepos') {
 	$_GET['optioncss'] = 'print';
 }
 
-$arrayofpaymentmode = array('cash'=>'Cash', 'cheque'=>'Cheque', 'card'=>'CreditCard');
+$arrayofpaymentmode = array('cash' => 'Cash', 'cheque' => 'Cheque', 'card' => 'CreditCard');
 
 $arrayofposavailable = array();
 if (isModEnabled('cashdesk')) {
@@ -180,7 +181,7 @@ if ($action == "start") {
 			$db->commit();
 			$action = "view";
 		} else {
-			$db->rollback;
+			$db->rollback();
 			$action = "view";
 		}
 	}

--- a/htdocs/fichinter/card-rec.php
+++ b/htdocs/fichinter/card-rec.php
@@ -10,6 +10,7 @@
  * Copyright (C) 2016-2018  Charlie Benke           <charlie@patas-monkey.com>
  * Copyright (C) 2018-2021  Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -730,9 +731,7 @@ if ($action == 'create') {
 				// Show product and description
 				if (isset($object->lines[$i]->product_type)) {
 					$type = $object->lines[$i]->product_type;
-				} else {
-					$object->lines[$i]->fk_product_type;
-				}
+				} // else { $object->lines[$i]->fk_product_type; }
 				// Try to enhance type detection using date_start and date_end for free lines when type
 				// was not saved.
 				if (!empty($objp->date_start)) {


### PR DESCRIPTION
# Fix & enable PhanNoopProperty

PhanNoopProperty reports about useless access to what looks to be properties.
The first commit fixes a ->rollback without parentheses to make it a function call.

I commented the property access in the 2nd commit, but that may not be the correct fix, please check.