### PR TITLE
Qual deprecated user done

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,9 @@ The following changes may create regressions for some external modules, but were
 * The signature for all ->delete() method has been modified to match the modulebuilder template (so first paramis now always $user), except
   the delete for thirdparty (still accept the id of thirdparty to delete as first parameter). Will probably be modified into another version.
 * Route for API /thirdparties/gateways has been renamed into /thirdparties/accounts
+* The $userdoneid in actioncomm class is deprecated. Please use $userownerid instead.
+* The field fk_user_done in actioncomm table is deprecated. Please use fk_user_action instead.
+* The AGENDA_ENABLE_DONEBY hidden option is deprecated.
 
 
 ***** ChangeLog for 19.0.1 compared to 19.0.0 *****

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -426,12 +426,6 @@ if (empty($reshook) && $action == 'add') {
 		}
 	}
 
-	if (!$error && getDolGlobalString('AGENDA_ENABLE_DONEBY')) {
-		if (GETPOST("doneby") > 0) {
-			$object->userdoneid = GETPOSTINT("doneby");
-		}
-	}
-
 	$object->note_private = trim(GETPOST("note", "restricthtml"));
 
 	if (GETPOSTISSET("contactid")) {
@@ -877,12 +871,6 @@ if (empty($reshook) && $action == 'update') {
 		$object->transparency = $transparency; // We set transparency on event (even if we can also store it on each user, standard says this property is for event)
 		// TODO store also transparency on owner user
 
-		if (getDolGlobalString('AGENDA_ENABLE_DONEBY')) {
-			if (GETPOST("doneby")) {
-				$object->userdoneid = GETPOSTINT("doneby");
-			}
-		}
-
 		// Check parameters
 		if (GETPOSTISSET('actioncode') && !GETPOST('actioncode', 'aZ09')) {	// actioncode is '0'
 			$error++;
@@ -1230,16 +1218,6 @@ if ($action == 'create') {
                         setdatefields();
                     });
 
-                    $("#selectcomplete").change(function() {
-						console.log("we change the complete status - set the doneby");
-                        if ($("#selectcomplete").val() == 100) {
-                            if ($("#doneby").val() <= 0) $("#doneby").val(\''.((int) $user->id).'\');
-                        }
-                        if ($("#selectcomplete").val() == 0) {
-                            $("#doneby").val(-1);
-                        }
-                    });
-
                     $("#actioncode").change(function() {
                         if ($("#actioncode").val() == \'AC_RDV\') $("#dateend").addClass("fieldrequired");
                         else $("#dateend").removeClass("fieldrequired");
@@ -1443,13 +1421,6 @@ if ($action == 'create') {
 	print $form->select_dolusers_forevent(($action == 'create' ? 'add' : 'update'), 'assignedtouser', 1, '', 0, '', '', 0, 0, 0, 'AND u.statut != 0', 1, $listofuserid, $listofcontactid, $listofotherid);
 	print '</div>';
 	print '</td></tr>';
-
-	// Done by
-	if (getDolGlobalString('AGENDA_ENABLE_DONEBY')) {
-		print '<tr><td class="nowrap">'.$langs->trans("ActionDoneBy").'</td><td>';
-		print $form->select_dolusers(GETPOSTISSET("doneby") ? GETPOSTINT("doneby") : (!empty($object->userdoneid) && $percent == 100 ? $object->userdoneid : 0), 'doneby', 1);
-		print '</td></tr>';
-	}
 
 	// Location
 	if (!getDolGlobalString('AGENDA_DISABLE_LOCATION')) {
@@ -1995,13 +1966,6 @@ if ($id > 0) {
 		}*/
 		print '</td></tr>';
 
-		// Realised by
-		if (getDolGlobalString('AGENDA_ENABLE_DONEBY')) {
-			print '<tr><td class="nowrap">'.$langs->trans("ActionDoneBy").'</td><td colspan="3">';
-			print $form->select_dolusers($object->userdoneid > 0 ? $object->userdoneid : -1, 'doneby', 1);
-			print '</td></tr>';
-		}
-
 		// Location
 		if (!getDolGlobalString('AGENDA_DISABLE_LOCATION')) {
 			print '<tr><td>'.$langs->trans("Location").'</td><td colspan="3"><input type="text" name="location" class="minwidth300 maxwidth150onsmartphone" value="'.$object->location.'"></td></tr>';
@@ -2426,17 +2390,6 @@ if ($id > 0) {
 		}
 		*/
 		print '	</td></tr>';
-
-		// Done by
-		if (getDolGlobalString('AGENDA_ENABLE_DONEBY')) {
-			print '<tr><td class="nowrap">'.$langs->trans("ActionDoneBy").'</td><td>';
-			if ($object->userdoneid > 0) {
-				$tmpuser = new User($db);
-				$tmpuser->fetch($object->userdoneid);
-				print $tmpuser->getNomUrl(1);
-			}
-			print '</td></tr>';
-		}
 
 		// Categories
 		if (isModEnabled('category')) {

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -242,6 +242,7 @@ class ActionComm extends CommonObject
 
 	/**
 	 * @var int 	Id of user that has done the event. Used only if AGENDA_ENABLE_DONEBY is set.
+	 * @deprecated	Use $userownerid instead
 	 */
 	public $userdoneid;
 

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -241,12 +241,6 @@ class ActionComm extends CommonObject
 	public $userownerid;
 
 	/**
-	 * @var int 	Id of user that has done the event. Used only if AGENDA_ENABLE_DONEBY is set.
-	 * @deprecated	Use $userownerid instead
-	 */
-	public $userdoneid;
-
-	/**
 	 * @var int[] Array of contact ids
 	 */
 	public $socpeopleassigned = array();
@@ -494,7 +488,6 @@ class ActionComm extends CommonObject
 		}
 
 		$userownerid = $this->userownerid;
-		$userdoneid = $this->userdoneid;
 
 		// Be sure assigned user is defined as an array of array('id'=>,'mandatory'=>,...).
 		if (empty($this->userassigned) || count($this->userassigned) == 0 || !is_array($this->userassigned)) {
@@ -544,7 +537,6 @@ class ActionComm extends CommonObject
 		$sql .= "fk_contact,";
 		$sql .= "fk_user_author,";
 		$sql .= "fk_user_action,";
-		$sql .= "fk_user_done,";
 		$sql .= "label,percent,priority,fulldayevent,location,";
 		$sql .= "transparency,";
 		$sql .= "fk_element,";
@@ -583,7 +575,6 @@ class ActionComm extends CommonObject
 		$sql .= ((isset($this->contact_id) && $this->contact_id > 0) ? ((int) $this->contact_id) : "null").", "; // deprecated, use ->socpeopleassigned
 		$sql .= (isset($user->id) && $user->id > 0 ? $user->id : "null").", ";
 		$sql .= ($userownerid > 0 ? $userownerid : "null").", ";
-		$sql .= ($userdoneid > 0 ? $userdoneid : "null").", ";
 		$sql .= "'".$this->db->escape($this->label)."', ";
 		$sql .= "'".$this->db->escape($this->percentage)."', ";
 		$sql .= "'".$this->db->escape($this->priority)."', ";
@@ -812,7 +803,7 @@ class ActionComm extends CommonObject
 		$sql .= " a.fk_soc,";
 		$sql .= " a.fk_project,";
 		$sql .= " a.fk_user_author, a.fk_user_mod,";
-		$sql .= " a.fk_user_action, a.fk_user_done,";
+		$sql .= " a.fk_user_action,";
 		$sql .= " a.fk_contact, a.percent as percentage,";
 		$sql .= " a.fk_element as elementid, a.elementtype,";
 		$sql .= " a.priority, a.fulldayevent, a.location, a.transparency,";
@@ -1162,16 +1153,9 @@ class ActionComm extends CommonObject
 			$this->fk_project = 0;
 		}
 
-		// Check parameters
-		if ($this->percentage == 0 && $this->userdoneid > 0) {
-			$this->error = "ErrorCantSaveADoneUserWithZeroPercentage";
-			return -1;
-		}
-
 		$socid = (($this->socid > 0) ? $this->socid : 0);
 		$contactid = (($this->contact_id > 0) ? $this->contact_id : 0);
 		$userownerid = ($this->userownerid ? $this->userownerid : 0);
-		$userdoneid = ($this->userdoneid ? $this->userdoneid : 0);
 
 		// If a type_id is set, we must also have the type_code set
 		if ($this->type_id > 0) {
@@ -1209,7 +1193,6 @@ class ActionComm extends CommonObject
 		$sql .= ", transparency = '".$this->db->escape($this->transparency)."'";
 		$sql .= ", fk_user_mod = ".((int) $user->id);
 		$sql .= ", fk_user_action = ".($userownerid > 0 ? ((int) $userownerid) : "null");
-		$sql .= ", fk_user_done = ".($userdoneid > 0 ? ((int) $userdoneid) : "null");
 		if (!empty($this->fk_element)) {
 			$sql .= ", fk_element=".($this->fk_element ? ((int) $this->fk_element) : "null");
 		}
@@ -1432,7 +1415,7 @@ class ActionComm extends CommonObject
 		}
 		$sql .= " AND a.entity IN (".getEntity('agenda').")";
 		if (!$user->hasRight('agenda', 'allactions', 'read')) {
-			$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id)." OR a.fk_user_done = ".((int) $user->id);
+			$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id);
 			$sql .= " OR ar.fk_element = ".((int) $user->id);
 			$sql .= ")";
 		}
@@ -2004,7 +1987,6 @@ class ActionComm extends CommonObject
 		$buildfile = true;
 		$login = '';
 		$logina = '';
-		$logind = '';
 		$logint = '';
 		$eventorganization = '';
 
@@ -2354,9 +2336,6 @@ class ActionComm extends CommonObject
 			}
 			if ($logint) {
 				$more = $langs->transnoentities("ActionsToDoBy").' '.$logint;
-			}
-			if ($logind) {
-				$more = $langs->transnoentities("ActionsDoneBy").' '.$logind;
 			}
 			if ($eventorganization) {
 				$langs->load("eventorganization");

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -6,7 +6,8 @@
  * Copyright (C) 2015	    Marcos García		    <marcosgdf@gmail.com>
  * Copyright (C) 2018	    Nicolas ZABOURI	        <info@inovea-conseil.com>
  * Copyright (C) 2018-2024  Frédéric France         <frederic.france@free.fr>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/install/mysql/tables/llx_actioncomm.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm.sql
@@ -17,7 +17,7 @@
 -- along with this program. If not, see <https://www.gnu.org/licenses/>.
 --
 --
--- Table of events and actions (past and to do). 
+-- Table of events and actions (past and to do).
 -- This is also the table to track events on other Dolibarr objects.
 -- ========================================================================
 
@@ -31,7 +31,7 @@ create table llx_actioncomm
   datep2			datetime,						-- date end
 
   fk_action			integer,						-- type of action (optional link with id in llx_c_actioncomm or null)
-  code				varchar(50) NULL,				-- code of action for automatic action ('AC_OTH_AUTO' for automatic actions, 'AC_EMAILIN_AUTO' for email input, 'AC_xxx' for manual action...) 
+  code				varchar(50) NULL,				-- code of action for automatic action ('AC_OTH_AUTO' for automatic actions, 'AC_EMAILIN_AUTO' for email input, 'AC_xxx' for manual action...)
 
   datec				datetime,						-- date creation
   tms				timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,						-- last modification date
@@ -43,7 +43,6 @@ create table llx_actioncomm
   fk_contact		integer,
   fk_parent			integer NOT NULL default 0,
   fk_user_action	integer,						-- user id of owner of action (note that users assigned to event are stored into table 'actioncomm_resources')
-  fk_user_done		integer,						-- user id of user that has made action (deprecated)
 
   transparency      integer,						-- transparency (ical standard). used to say if user assigned to event are busy or not by event. This field may be deprecated if we want to store transparency for each assigned user, moved into table llx_actioncomm_resources.
 
@@ -56,9 +55,9 @@ create table llx_actioncomm
 
   label				varchar(255) NOT NULL,			-- label/title of event or topic of email
   note				mediumtext,						-- private note of event or content of email
-  
+
   calling_duration  integer,                        -- when event is a phone call, duration of phone call
-  
+
   email_subject		varchar(255),					-- when event was an email, we store here the subject. content is stored into note.
   email_msgid		varchar(255),					-- when event was an email, we store here the msgid
   email_from		varchar(255),					-- when event was an email, we store here the from
@@ -68,7 +67,7 @@ create table llx_actioncomm
   email_tobcc		varchar(255),					-- when event was an email, we store here the email_tobcc
   errors_to			varchar(255),					-- when event was an email, we store here the erros_to
   reply_to			varchar(255),					-- when event was an email, we store here the reply_to
-  
+
   recurid           varchar(128),                   -- used to store event id to link each other all the repeating event record. It can be the 'iCalUID' as in RFC5545 (an id similar for all the same serie)
   recurrule         varchar(128),					-- contains string with ical format recurring rule like 'FREQ=MONTHLY;INTERVAL=2;BYMONTHDAY=19' or 'FREQ=WEEKLY;BYDAY=MO'
   recurdateend      datetime,						-- no more recurring event after this date


### PR DESCRIPTION
# QUAL deprecated user done
This PR removes the hidden `AGENDA_ENABLE_DONEBY` option which relies on `$userdoneid` & `fk_user_done`.

The removal of this was previously examined in 2015 #2899
In the `actioncomm` table `fk_user_done` is marked as deprecated

Currently, `fk_user_action` seems to be widely used.
