### PR TITLE
Fix undefined task object

### DIFF
--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -934,7 +934,7 @@ function projectLinesa(&$inc, $parent, &$lines, &$level, $var, $showproject, &$t
 				// Extra fields
 				$extrafieldsobjectkey = $taskstatic->table_element;
 				$extrafieldsobjectprefix = 'efpt.';
-				$obj = $lines[$i]->obj;
+				$obj = $lines[$i];
 				include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_print_fields.tpl.php';
 				// Fields from hook
 				$parameters = array('arrayfields' => $arrayfields, 'obj' => $lines[$i]);


### PR DESCRIPTION
# Fix undefined task object
Undefined property: Task::$obj (/var/www/dolibarr/20.0/htdocs/core/lib/project.lib.php:937)
