### PR TITLE
Qual: Disable PhanPluginDuplicateCatchStatementBody requires PHP7.1

### DIFF
--- a/dev/tools/phan/config_extended.php
+++ b/dev/tools/phan/config_extended.php
@@ -368,6 +368,7 @@ return [
 		'PhanPluginDuplicateConditionalTernaryDuplication',		// 2750+ occurrences
 		'PhanPluginDuplicateConditionalNullCoalescing',	// Not essential - 990+ occurrences
 		'PhanPluginRedundantAssignmentInGlobalScope',	// Not essential, a lot of false warning
+		'PhanPluginDuplicateCatchStatementBody',  // Requires PHP7.1 - 50+ occurrences
 	],
 	// You can put relative paths to internal stubs in this config option.
 	// Phan will continue using its detailed type annotations,


### PR DESCRIPTION
# Qual: Disable PhanPluginDuplicateCatchStatementBody which requires PHP7.1 for fix

To fix this PHP7.1 is required, so skipping the message in the extended report as well.
