### PR TITLE
natural sort of result

### DIFF
--- a/htdocs/core/class/html.formcompany.class.php
+++ b/htdocs/core/class/html.formcompany.class.php
@@ -130,6 +130,8 @@ class FormCompany extends Form
 			}
 			$this->db->free($resql);
 		}
+		//return natural sorted list
+		natsort($effs);
 		return $effs;
 	}
 


### PR DESCRIPTION
That's just for users :-) 

By default there is a entry for 1 to 5 people ... but that's really different a company with only one people (single) to more than 1 ... Then for example add a new entry in dictionary with 

EF1 / single-people active

and all drow down list will display 1 at the end, due to sort on id

This PR makes a natural sort on result, then "1" will be at the right place