### PR TITLE
UPDATE: Doliwamp to PHP V7.4

### DIFF
--- a/build/exe/doliwamp/Languages/MyCatalan.isl
+++ b/build/exe/doliwamp/Languages/MyCatalan.isl
@@ -43,5 +43,5 @@ DoliWampWillStartApacheMysql=L'instal·lador DoliWamp intentarà iniciar o reini
 OldVersionFoundAndMoveInNew=S'ha trobat una versió antiga de base de dades i ha estat moguda per a ser utilitzada per la nova versió de Dolibarr
 OldVersionFoundButFailedToMoveInNew=S'ha trobat una versió antiga de base de dades, però no es pot moure per a ser utilitzada per la nova versió de Dolibarr
 
-DLLMissing=La teva instal·lació windows no té el component "Microsoft Visual C++ Redistributable for Visual Studio 2015". Instal·la primer la versió de 32-bit (vcredist_x86.exe) (pots trobar-la a https://www.microsoft.com/en-us/download/) i reiniciar després la instal·lació/actualització de DoliWamp.
+DLLMissing=La teva instal·lació windows no té el component "Microsoft Visual C++ Redistributable for Visual Studio 2017". Instal·la primer la versió de 32-bit (vcredist_x86.exe) (pots trobar-la a https://www.microsoft.com/en-us/download/) i reiniciar després la instal·lació/actualització de DoliWamp.
 ContinueAnyway=Continua igualment (el procés d'instal·lació podria fallar sense aquest prerequisit)

--- a/build/exe/doliwamp/Languages/MyEnglish.isl
+++ b/build/exe/doliwamp/Languages/MyEnglish.isl
@@ -44,5 +44,5 @@ DoliWampWillStartApacheMysql=DoliWamp installer will now start or restart Apache
 OldVersionFoundAndMoveInNew=An old database version has been found and moved to be used by the new Dolibarr version
 OldVersionFoundButFailedToMoveInNew=An old database version has been found but could not be moved to be used with the new Dolibarr version
 
-DLLMissing=Your Windows installation is missing The "Microsoft Visual C++ Redistributable for Visual Studio 2015" component. Please install the 32-bit version (vcredist_x86.exe) first (you can find it at https://www.microsoft.com/en-us/download/) and restart DoliWamp installation/upgrade after.
+DLLMissing=Your Windows installation is missing The "Microsoft Visual C++ Redistributable for Visual Studio 2017" component. Please install the 32-bit version (vcredist_x86.exe) first (you can find it at https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170) and restart DoliWamp installation/upgrade after.
 ContinueAnyway=Continue anyway (install process may fail without this prerequisite)

--- a/build/exe/doliwamp/Languages/MyFrench.isl
+++ b/build/exe/doliwamp/Languages/MyFrench.isl
@@ -2,47 +2,47 @@
 [CustomMessages]
 
 NameAndVersion=%1 version %2
-AdditionalIcons=Icônes supplémentaires :
-CreateDesktopIcon=Créer une icône sur le &Bureau
-CreateQuickLaunchIcon=Créer une icône dans la barre de &Lancement rapide
+AdditionalIcons=IcÃ´nes supplÃ©mentaires :
+CreateDesktopIcon=CrÃ©er une icÃ´ne sur le &Bureau
+CreateQuickLaunchIcon=CrÃ©er une icÃ´ne dans la barre de &Lancement rapide
 ProgramOnTheWeb=Page d'accueil de %1
-UninstallProgram=Désinstaller %1
-LaunchProgram=Exécuter %1
+UninstallProgram=DÃ©sinstaller %1
+LaunchProgram=ExÃ©cuter %1
 AssocFileExtension=&Associer %1 avec l'extension de fichier %2
 AssocingFileExtension=Associe %1 avec l'extension de fichier %2...
 
-YouWillInstallDoliWamp=Vous allez installer DoliWamp sur votre ordinateur (donc Dolibarr + tous ses composants prérequis comme Apache, Mysql et PHP).
-ThisAssistantInstallOrUpgrade=AVERTISSEMENT: L'utilisation d'un ERP CRM installé sur un ordinateur local peut être dangereuse: si votre ordinateur tombe en panne, vous pouvez perdre toutes vos données. Faites-le si vous êtes prêt à gérer les sauvegardes vous-même sérieusement. Sinon, utilisez plutôt une installation en Saas (voir https://saas.dolibarr.org).
-IfYouHaveTechnicalKnowledge=De plus, si vous avez des compétences techniques et envisagez de partager votre Apache, Mysql et PHP avec d''autres applications que Dolibarr, vous ne devriez pas utiliser cet assistant mais faire plutôt une installation manuelle de Dolibarr sur un serveur existant équipé de Apache, Mysql et PHP.
-ButIfYouLook=Mais si vous recherchez une installation clé en main automatisée sur une poste local, vous êtes sur la bonne voie...
-DoYouWantToStart=Voulez-vous démarrer le processus d'installation ?
+YouWillInstallDoliWamp=Vous allez installer DoliWamp sur votre ordinateur (donc Dolibarr + tous ses composants prÃ©requis comme Apache, Mysql et PHP).
+ThisAssistantInstallOrUpgrade=AVERTISSEMENT: L'utilisation d'un ERP CRM installÃ© sur un ordinateur local peut Ãªtre dangereuse: si votre ordinateur tombe en panne, vous pouvez perdre toutes vos donnÃ©es. Faites-le si vous Ãªtes prÃªt Ã  gÃ©rer les sauvegardes vous-mÃªme sÃ©rieusement. Sinon, utilisez plutÃ´t une installation en Saas (voir https://saas.dolibarr.org).
+IfYouHaveTechnicalKnowledge=De plus, si vous avez des compÃ©tences techniques et envisagez de partager votre Apache, Mysql et PHP avec d''autres applications que Dolibarr, vous ne devriez pas utiliser cet assistant mais faire plutÃ´t une installation manuelle de Dolibarr sur un serveur existant Ã©quipÃ© de Apache, Mysql et PHP.
+ButIfYouLook=Mais si vous recherchez une installation clÃ© en main automatisÃ©e sur une poste local, vous Ãªtes sur la bonne voie...
+DoYouWantToStart=Voulez-vous dÃ©marrer le processus d'installation ?
 
-TechnicalParameters=Paramètres techniques
-IfFirstInstall=S'il s'agit de la première installation, merci de spécifier ces quelques paramètres techniques. Si vous ne les comprennez pas, êtes non sûr, ou procédez à une mise à jour, laissez les champs avec les valeurs proposées par défaut.
+TechnicalParameters=ParamÃ¨tres techniques
+IfFirstInstall=S'il s'agit de la premiÃ¨re installation, merci de spÃ©cifier ces quelques paramÃ¨tres techniques. Si vous ne les comprennez pas, Ãªtes non sÃ»r, ou procÃ©dez Ã  une mise Ã  jour, laissez les champs avec les valeurs proposÃ©es par dÃ©faut.
 
 
 ; WARNING !!! STRINGS FOR THIS 4 STRINGS MUST BE LOWER THAN 70 CHARACTERS
-SMTPServer=Serveur SMTP (le votre ou de votre FAI, première installation uniquement):
-ApachePort=Port Apache (première installation uniquement, le choix standard est 80):
-MySqlPort=Port Mysql (première installation uniquement, le choix standard est 3306):
-MySqlPassword=Mot de passe serveur+base MySql de root (première installation uniquement):
+SMTPServer=Serveur SMTP (le votre ou de votre FAI, premiÃ¨re installation uniquement):
+ApachePort=Port Apache (premiÃ¨re installation uniquement, le choix standard est 80):
+MySqlPort=Port Mysql (premiÃ¨re installation uniquement, le choix standard est 3306):
+MySqlPassword=Mot de passe serveur+base MySql de root (premiÃ¨re installation uniquement):
 
-FailedToDeleteLock=Echec de la suppression du fichier %1/www/dolibarr/install.lock. Vous pouvez ignorer l'avertissement mais il est possible que vous deviez le supprimer manuellement plus tard. Dans ce cas, cela vous sera signalé. Cliquez sur OK pour continuer...
+FailedToDeleteLock=Echec de la suppression du fichier %1/www/dolibarr/install.lock. Vous pouvez ignorer l'avertissement mais il est possible que vous deviez le supprimer manuellement plus tard. Dans ce cas, cela vous sera signalÃ©. Cliquez sur OK pour continuer...
 
-PortAlreadyInUse=Le port %1 semble déjà utilisé. Il est recommandé d'annuler pour revenir en arrière et spécifier une autre valeur pour le port %2. Annuler le choix et choisir une autre valeur ?
+PortAlreadyInUse=Le port %1 semble dÃ©jÃ  utilisÃ©. Il est recommandÃ© d'annuler pour revenir en arriÃ¨re et spÃ©cifier une autre valeur pour le port %2. Annuler le choix et choisir une autre valeur ?
 
-FirefoxDetected=Firefox a été détecté sur votre ordinateur. Voulez-vous en faire votre navigateur par défaut pour Dolibarr ?
-ChromeDetected=Chrome a été détecté sur votre ordinateur. Voulez-vous en faire votre navigateur par défaut pour Dolibarr ?
-ChooseDefaultBrowser=Merci de choisir votre navigateur par défaut (iexplore.exe, firefox.exe, chrome.exe, MicrosoftEdge.exe...). Si vous n'êtes pas sûr, cliquez simplement sur Ouvrir :
+FirefoxDetected=Firefox a Ã©tÃ© dÃ©tectÃ© sur votre ordinateur. Voulez-vous en faire votre navigateur par dÃ©faut pour Dolibarr ?
+ChromeDetected=Chrome a Ã©tÃ© dÃ©tectÃ© sur votre ordinateur. Voulez-vous en faire votre navigateur par dÃ©faut pour Dolibarr ?
+ChooseDefaultBrowser=Merci de choisir votre navigateur par dÃ©faut (iexplore.exe, firefox.exe, chrome.exe, MicrosoftEdge.exe...). Si vous n'Ãªtes pas sÃ»r, cliquez simplement sur Ouvrir :
 
 LaunchNow=Lancer Dolibarr maintenant
 
-ProgramHasBeenRemoved=Les fichiers du programme Dolibarr ont été supprimés. Toutefois, tous vos fichiers de données sont toujours dans le répertoire %1. Vous devez supprimer ce répertoire manuellement pour avoir une désinstallation complète.
+ProgramHasBeenRemoved=Les fichiers du programme Dolibarr ont Ã©tÃ© supprimÃ©s. Toutefois, tous vos fichiers de donnÃ©es sont toujours dans le rÃ©pertoire %1. Vous devez supprimer ce rÃ©pertoire manuellement pour avoir une dÃ©sinstallation complÃ¨te.
 
-DoliWampWillStartApacheMysql=L'installeur DoliWamp va maintenant démarrer ou redémarrer Apache et Mysql, ceci peut durer de quelques secondes à une minute après cette confirmation. Démarrer l'installation ou mise à jour du serveur web et base de données requis par Dolibarr ?
+DoliWampWillStartApacheMysql=L'installeur DoliWamp va maintenant dÃ©marrer ou redÃ©marrer Apache et Mysql, ceci peut durer de quelques secondes Ã  une minute aprÃ¨s cette confirmation. DÃ©marrer l'installation ou mise Ã  jour du serveur web et base de donnÃ©es requis par Dolibarr ?
 
-OldVersionFoundAndMoveInNew=Une ancienne version de base a été trouvée et déplacée pour fonctionner avec la nouvelle version de Dolibarr.
-OldVersionFoundButFailedToMoveInNew=Une ancienne version de base a été trouvée mais ne peut être déplacée pour être utilisée avec la nouvelle version de Dolibarr.
+OldVersionFoundAndMoveInNew=Une ancienne version de base a Ã©tÃ© trouvÃ©e et dÃ©placÃ©e pour fonctionner avec la nouvelle version de Dolibarr.
+OldVersionFoundButFailedToMoveInNew=Une ancienne version de base a Ã©tÃ© trouvÃ©e mais ne peut Ãªtre dÃ©placÃ©e pour Ãªtre utilisÃ©e avec la nouvelle version de Dolibarr.
 
-DLLMissing=L'installation de votre Windows est incomplète. Il manque le composant "Micrsoft Visual C++ Redistributable for Visual Studio 2015". Installer la version 32-bit (vcredist_x86.exe) d'abord (vous pourrez le trouver à https://www.microsoft.com/fr-fr/download/) puis relancer l'installation de DoliWamp après.
-ContinueAnyway=Continuer malgré tout (le process d'installaton échouera)
+DLLMissing=L'installation de votre Windows est incomplÃ¨te. Il manque le composant "Micrsoft Visual C++ Redistributable for Visual Studio 2017". Installer la version 32-bit (vcredist_x86.exe) d'abord (vous pourrez le trouver Ã  https://www.microsoft.com/fr-fr/download/) puis relancer l'installation de DoliWamp aprÃ¨s.
+ContinueAnyway=Continuer malgrÃ© tout (le process d'installaton Ã©chouera)

--- a/build/exe/doliwamp/Languages/MyGerman.isl
+++ b/build/exe/doliwamp/Languages/MyGerman.isl
@@ -43,5 +43,5 @@ DoliWampWillStartApacheMysql=Die DoliWamp-Installation wird nun starten oder Apa
 OldVersionFoundAndMoveInNew=Eine alte Datenbankversion wurde gefunden und verschoben, um von der neuen Dolibarr-Version verwendet zu werden.
 OldVersionFoundButFailedToMoveInNew=Eine alte Datenbankversion wurde gefunden, konnte jedoch nicht verschoben werden, um mit der neuen Dolibarr-Version verwendet zu werden.
 
-DLLMissing=Your Windows installation is missing The "Micrsoft Visual C++ Redistributable for Visual Studio 2015" component. Please install the 32-bit version (vcredist_x86.exe) first (you can find it at https://www.microsoft.com/en-us/download/) and restart DoliWamp installation/upgrade after.
+DLLMissing=Your Windows installation is missing The "Micrsoft Visual C++ Redistributable for Visual Studio 2017" component. Please install the 32-bit version (vcredist_x86.exe) first (you can find it at https://www.microsoft.com/en-us/download/) and restart DoliWamp installation/upgrade after.
 ContinueAnyway=Fahren Sie trotzdem fort (der Installationsvorgang kann ohne diese Voraussetzung fehlschlagen).

--- a/build/exe/doliwamp/Languages/MySpanish.isl
+++ b/build/exe/doliwamp/Languages/MySpanish.isl
@@ -43,5 +43,5 @@ DoliWampWillStartApacheMysql=El instalador DoliWamp intentará iniciar o reinici
 OldVersionFoundAndMoveInNew=Se ha encontrado una versión antigua de base de datos y ha sido movida para ser utilizada por la nueva versión de Dolibarr
 OldVersionFoundButFailedToMoveInNew=Se ha encontrado una versión antigua de base de datos, pero no se pudo mover para ser utilizada por la nueva versión de Dolibarr
  	  	 
-DLLMissing=Su instalación Windows no tiene el componente "Microsoft Visual C++ Redistributable for Visual Studio 2015". Instale primero la versión de 32-bit (vcredist_x86.exe) (puedes encontrarlo en https://www.microsoft.com/en-us/download/) y reiniciar después la instalación/actualización de DoliWamp.
+DLLMissing=Su instalación Windows no tiene el componente "Microsoft Visual C++ Redistributable for Visual Studio 2017". Instale primero la versión de 32-bit (vcredist_x86.exe) (puedes encontrarlo en https://www.microsoft.com/en-us/download/) y reiniciar después la instalación/actualización de DoliWamp.
 ContinueAnyway=Continua igualmente (el proceso de instalación podría fallar sin este prerequisito)

--- a/build/exe/doliwamp/doliwamp.iss
+++ b/build/exe/doliwamp/doliwamp.iss
@@ -100,9 +100,9 @@ Source: "build\exe\doliwamp\UsedPort.exe"; DestDir: "{app}\"; Flags: ignoreversi
 
 ; Apache, Php, Mysql
 ; Put here path of Wampserver applications
-; Value OK: apache 2.4.51, php 7.3.33, mariadb10.6.5 (wampserver3.2.6_x64.exe)
+; Value OK: apache 2.4.51, php 7.4.26, mariadb10.6.5 (wampserver3.2.6_x64.exe)
 Source: "C:\wamp64\bin\apache\apache2.4.51\*.*"; DestDir: "{app}\bin\apache\apache2.4.51"; Flags: ignoreversion recursesubdirs; Excludes: "php.ini,httpd.conf,wampserver.conf,*.log,*_log"
-Source: "C:\wamp64\bin\php\php7.3.33\*.*"; DestDir: "{app}\bin\php\php7.3.33"; Flags: ignoreversion recursesubdirs; Excludes: "php.ini,phpForApache.ini,wampserver.conf,*.log,*_log"
+Source: "C:\wamp64\bin\php\php7.4.26\*.*"; DestDir: "{app}\bin\php\php7.4.26"; Flags: ignoreversion recursesubdirs; Excludes: "php.ini,phpForApache.ini,wampserver.conf,*.log,*_log"
 Source: "C:\wamp64\bin\mariadb\mariadb10.6.5\*.*"; DestDir: "{app}\bin\mariadb\mariadb10.6.5"; Flags: ignoreversion recursesubdirs; Excludes: "my.ini,data\*,wampserver.conf,*.log,*_log,MySQLInstanceConfig.exe"
 
 ; Mysql data files (does not overwrite if exists)
@@ -121,7 +121,7 @@ Source: "build\exe\doliwamp\dolibarr.conf.install"; DestDir: "{app}\alias"; Flag
 Source: "build\exe\doliwamp\httpd.conf.install"; DestDir: "{app}\bin\apache\apache2.4.51\conf"; Flags: ignoreversion;
 Source: "build\exe\doliwamp\my.ini.install"; DestDir: "{app}\bin\mysql\mysql5.0.45"; Flags: ignoreversion;
 Source: "build\exe\doliwamp\my.ini.install"; DestDir: "{app}\bin\mariadb\mariadb10.6.5"; Flags: ignoreversion;
-Source: "build\exe\doliwamp\php.ini.install"; DestDir: "{app}\bin\php\php7.3.33"; Flags: ignoreversion;
+Source: "build\exe\doliwamp\php.ini.install"; DestDir: "{app}\bin\php\php7.4.26"; Flags: ignoreversion;
 Source: "build\exe\doliwamp\index.php.install"; DestDir: "{app}\www"; Flags: ignoreversion;
 Source: "build\exe\doliwamp\install.forced.php.install"; DestDir: "{app}\www\dolibarr\htdocs\install"; Flags: ignoreversion;
 Source: "build\exe\doliwamp\openssl.conf"; DestDir: "{app}"; Flags: ignoreversion;
@@ -228,7 +228,7 @@ begin
 
   //version des applis, a modifier pour chaque version de WampServer 2
   apacheVersion := '2.4.51';
-  phpVersion := '7.3.33' ;
+  phpVersion := '7.4.26' ;
   mysqlVersion := '10.6.5';
 
   smtpServer := 'localhost';

--- a/build/makepack-howto.txt
+++ b/build/makepack-howto.txt
@@ -30,7 +30,7 @@ Prerequisites to build autoexe DoliWamp package from Windows:
 > Install Perl for Windows (https://strawberryperl.com/)
 > Install isetup-5.5.8.exe (https://www.jrsoftware.org)
 > Install Microsoft Visual C++ Redistributable 2017 (https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170)
-> Install WampServer-3.2.*-64.exe (Apache 2.4.51, PHP 7.3.33, MariaDB 10.6.5 for example. Version must match the values found into doliwamp.iss)
+> Install WampServer-3.2.6-64.exe (Apache 2.4.51, PHP 7.4.26, MariaDB 10.6.5 for example. Version must match the values found into doliwamp.iss)
 > Install GIT for Windows (https://git-scm.com/ => You must choose option "Add Git bash profile", "Git commit as-is")
 > Install Dolibarr current version:   
   git clone https://github.com/dolibarr/dolibarr  or  git clone --branch X.Y https://github.com/dolibarr/dolibarr  

--- a/build/makepack-howto.txt
+++ b/build/makepack-howto.txt
@@ -29,12 +29,13 @@ Prerequisites to build autoexe DoliWamp package from Windows:
 
 > Install Perl for Windows (https://strawberryperl.com/)
 > Install isetup-5.5.8.exe (https://www.jrsoftware.org)
+> Install Microsoft Visual C++ Redistributable 2017 (https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170)
 > Install WampServer-3.2.*-64.exe (Apache 2.4.51, PHP 7.3.33, MariaDB 10.6.5 for example. Version must match the values found into doliwamp.iss)
 > Install GIT for Windows (https://git-scm.com/ => You must choose option "Add Git bash profile", "Git commit as-is")
 > Install Dolibarr current version:   
   git clone https://github.com/dolibarr/dolibarr  or  git clone --branch X.Y https://github.com/dolibarr/dolibarr  
 
-> Add the path of PHP (C:\wamp64\bin\php\php7.3.33) and InnoSetup (C:\Program Files (x86)\Inno Setup 5) into the %PATH% of Windows.
+> Add the path of PHP (C:\wamp64\bin\php\php7.4.26) and InnoSetup (C:\Program Files (x86)\Inno Setup 5) into the %PATH% of Windows.
 
 > Create a config file c:\dolibarr\dolibarr\htdocs\conf\conf.php with content
   <?php


### PR DESCRIPTION
UPDATE Doliwamp to PHP V7.4.

Warning : You need to update the Micrsoft Visual C++ Redistributable for Visual Studio from 2015 to at least 2017