### PR TITLE
Qual: Fix & enable some low occurence notifications

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -17,15 +17,10 @@ return [
     // PhanTypeArraySuspiciousNull : 10+ occurrences
     // PhanTypeMismatchReturn : 10+ occurrences
     // PhanRedefineFunctionInternal : 6 occurrences
-    // PhanPluginUnsafeEval : 5 occurrences
-    // PhanParamSuspiciousOrder : 4 occurrences
     // PhanParamTooMany : 4 occurrences
-    // PhanPluginSuspiciousParamOrder : 4 occurrences
-    // PhanUndeclaredFunctionInCallable : 4 occurrences
     // PhanTypeMismatchPropertyProbablyReal : 2 occurrences
     // PhanAccessMethodProtected : 1 occurrence
     // PhanAccessPropertyStaticAsNonStatic : 1 occurrence
-    // PhanNoopArrayAccess : 1 occurrence
     // PhanNoopStringLiteral : 1 occurrence
     // PhanPluginAlwaysReturnFunction : 1 occurrence
 
@@ -48,14 +43,11 @@ return [
         'htdocs/compta/cashcontrol/cashcontrol_card.php' => ['PhanPluginDuplicateExpressionBinaryOp'],
         'htdocs/compta/prelevement/class/bonprelevement.class.php' => ['PhanParamTooMany'],
         'htdocs/compta/prelevement/create.php' => ['PhanPluginSuspiciousParamPosition'],
-        'htdocs/core/actions_massactions.inc.php' => ['PhanPluginSuspiciousParamOrder'],
         'htdocs/core/class/commondocgenerator.class.php' => ['PhanTypeArraySuspiciousNull'],
         'htdocs/core/class/commonobject.class.php' => ['PhanTypeMismatchReturnNullable'],
-        'htdocs/core/class/evalmath.class.php' => ['PhanPluginUnsafeEval'],
         'htdocs/core/class/extrafields.class.php' => ['PhanTypeMismatchReturnNullable'],
         'htdocs/core/class/html.form.class.php' => ['PhanPluginSuspiciousParamPosition'],
         'htdocs/core/class/html.formprojet.class.php' => ['PhanTypeMismatchReturnNullable'],
-        'htdocs/core/class/rssparser.class.php' => ['PhanUndeclaredFunctionInCallable'],
         'htdocs/core/class/smtps.class.php' => ['PhanTypeMismatchReturnNullable'],
         'htdocs/core/class/stats.class.php' => ['PhanTypeMismatchReturnNullable'],
         'htdocs/core/db/mysqli.class.php' => ['PhanParamSignatureMismatch'],
@@ -64,25 +56,20 @@ return [
         'htdocs/core/get_info.php' => ['PhanPluginSuspiciousParamPosition'],
         'htdocs/core/lib/date.lib.php' => ['PhanTypeMismatchReturnNullable'],
         'htdocs/core/lib/files.lib.php' => ['PhanPluginDuplicateExpressionBinaryOp'],
-        'htdocs/core/lib/functions.lib.php' => ['PhanParamTooMany', 'PhanPluginAlwaysReturnFunction', 'PhanPluginUnsafeEval', 'PhanRedefineFunctionInternal'],
+        'htdocs/core/lib/functions.lib.php' => ['PhanParamTooMany', 'PhanPluginAlwaysReturnFunction', 'PhanRedefineFunctionInternal'],
         'htdocs/core/lib/functions2.lib.php' => ['PhanTypeMismatchReturnNullable'],
         'htdocs/core/lib/pdf.lib.php' => ['PhanTypeMismatchReturnNullable'],
         'htdocs/core/lib/price.lib.php' => ['PhanPluginSuspiciousParamPosition'],
-        'htdocs/core/lib/usergroups.lib.php' => ['PhanNoopArrayAccess'],
         'htdocs/core/lib/website.lib.php' => ['PhanTypeMismatchReturnNullable'],
-        'htdocs/core/menus/standard/auguria_menu.php' => ['PhanParamSuspiciousOrder'],
-        'htdocs/core/menus/standard/eldy_menu.php' => ['PhanParamSuspiciousOrder'],
-        'htdocs/core/menus/standard/empty.php' => ['PhanParamSuspiciousOrder'],
         'htdocs/core/modules/DolibarrModules.class.php' => ['PhanTypeMismatchReturnNullable'],
         'htdocs/core/modules/movement/doc/pdf_standard.modules.php' => ['PhanPluginDuplicateExpressionBinaryOp'],
         'htdocs/core/modules/mrp/doc/pdf_vinci.modules.php' => ['PhanTypeArraySuspiciousNull'],
         'htdocs/core/modules/societe/modules_societe.class.php' => ['PhanTypeMismatchReturn'],
-        'htdocs/core/modules/syslog/mod_syslog_file.php' => ['PhanParamSignatureMismatch', 'PhanParamSuspiciousOrder'],
+        'htdocs/core/modules/syslog/mod_syslog_file.php' => ['PhanParamSignatureMismatch'],
         'htdocs/core/modules/syslog/mod_syslog_syslog.php' => ['PhanParamSignatureMismatch'],
         'htdocs/don/class/don.class.php' => ['PhanParamTooMany'],
         'htdocs/expedition/class/api_shipments.class.php' => ['PhanTypeMismatchReturn'],
         'htdocs/expensereport/class/api_expensereports.class.php' => ['PhanTypeMismatchReturn'],
-        'htdocs/fourn/class/api_supplier_invoices.class.php' => ['PhanPluginSuspiciousParamOrder'],
         'htdocs/fourn/class/fournisseur.commande.class.php' => ['PhanTypeMismatchReturn'],
         'htdocs/fourn/class/fournisseur.facture.class.php' => ['PhanTypeMismatchReturn'],
         'htdocs/intracommreport/list.php' => ['PhanAccessPropertyStaticAsNonStatic'],
@@ -93,9 +80,7 @@ return [
         'htdocs/projet/class/projectstats.class.php' => ['PhanTypeMismatchReturnNullable'],
         'htdocs/projet/class/task.class.php' => ['PhanTypeMismatchReturnNullable'],
         'htdocs/projet/tasks/list.php' => ['PhanTypeArraySuspiciousNull'],
-        'htdocs/public/opensurvey/index.php' => ['PhanPluginSuspiciousParamOrder'],
         'htdocs/public/payment/paymentok.php' => ['PhanPluginSuspiciousParamPosition'],
-        'htdocs/public/recruitment/index.php' => ['PhanPluginSuspiciousParamOrder'],
         'htdocs/societe/class/companybankaccount.class.php' => ['PhanParamSignatureMismatch'],
         'htdocs/stripe/admin/stripe.php' => ['PhanDeprecatedFunction'],
         'htdocs/stripe/class/actions_stripe.class.php' => ['PhanPluginSuspiciousParamPosition'],

--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -370,7 +370,7 @@ return [
 
 		'ConstantVariablePlugin', // Warns about values that are actually constant
 		//'HasPHPDocPlugin', // Requires PHPDoc
-		'InlineHTMLPlugin', // html in PHP file, or at end of file
+		// 'InlineHTMLPlugin', // html in PHP file, or at end of file
 		//'NonBoolBranchPlugin', // Requires test on bool, nont on ints
 		//'NonBoolInLogicalArithPlugin',
 		'NumericalComparisonPlugin',
@@ -471,7 +471,8 @@ return [
 
 		'PhanTypeExpectedObjectPropAccess',
 		'PhanTypeInvalidRightOperandOfNumericOp',
-		'PhanPluginInlineHTML',
+		// 'PhanPluginInlineHTML',
+		// 'PhanPluginInlineHTMLTrailing',
 		// 'PhanPluginUnknownFunctionReturnType',
 		// 'PhanPluginDescriptionlessCommentOnProtectedProperty',
 		'PhanPluginRedundantAssignmentInGlobalScope',
@@ -485,7 +486,6 @@ return [
 		// 'PhanTypeInvalidUnaryOperandIncOrDec',
 		// 'PhanPluginDescriptionlessCommentOnClass',
 		'PhanPluginEmptyStatementIf',
-		'PhanPluginInlineHTMLTrailing',
 		// 'PhanUndeclaredStaticMethod',
 		// 'PhanPluginDescriptionlessCommentOnPrivateMethod',
 		'PhanPluginPrintfIncompatibleArgumentType',
@@ -517,14 +517,14 @@ return [
 		// 'PhanTypeMismatchDeclaredParam',
 		// 'PhanCommentDuplicateMagicMethod',
 		// 'PhanParamSpecial1',
-		'PhanPluginInlineHTMLLeading',
+		// 'PhanPluginInlineHTMLLeading',
 		// 'PhanPluginUseReturnValueInternalKnown',
 		// 'PhanRedefinedInheritedInterface',
 		// 'PhanTypeComparisonToArray',
 		'PhanTypeConversionFromArray',
 		// 'PhanTypeInvalidLeftOperandOfIntegerOp',
 		// 'PhanTypeMismatchArgumentInternalProbablyReal',
-		'PhanTypeMismatchBitwiseBinaryOperands',
+		// 'PhanTypeMismatchBitwiseBinaryOperands',
 		'PhanTypeMismatchDimEmpty',
 		// 'PhanTypeSuspiciousEcho',
 		// 'PhanNoopBinaryOperator',

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1082,6 +1082,7 @@ if (!$error && ($massaction == 'delete' || ($action == 'delete' && $confirm == '
 
 			if ($objecttmp->element == 'societe') {
 				/** @var Societe $objecttmp */
+				'@phan-var-force Societe $objecttmp';
 				// TODO Change signature of delete for Societe
 				$result = $objecttmp->delete($objecttmp->id, $user, 1);
 			} else {

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -437,13 +437,17 @@ abstract class CommonInvoice extends CommonObject
 	/**
 	 *  Return list of payments
 	 *
+	 *  @see $error Empty string '' if no error.
+	 *
 	 *	@param		string	$filtertype		1 to filter on type of payment == 'PRE'
 	 *  @param      int     $multicurrency  Return multicurrency_amount instead of amount
-	 *  @return     array					Array with list of payments
+	 *  @return     array<array{amount:int|float,date:int,num:string,ref:string,ref_ext?:string,fk_bank_line?:int}>		 Array with list of payments
 	 */
 	public function getListOfPayments($filtertype = '', $multicurrency = 0)
 	{
 		$retarray = array();
+		// By default no error, list can be empty.
+		$this->error = '';
 
 		$table = 'paiement_facture';
 		$table2 = 'paiement';

--- a/htdocs/core/class/evalmath.class.php
+++ b/htdocs/core/class/evalmath.class.php
@@ -57,9 +57,6 @@
  *
  * AUTHOR INFORMATION
  * Copyright 2005, Miles Kaufmann.
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * LICENSE
  * Redistribution and use in source and binary forms, with or without
@@ -428,6 +425,7 @@ class EvalMath
 					if ($fnn == 'ln') {
 						$fnn = 'log';
 					}
+					// @phan-suppress-next-line PhanPluginUnsafeEval
 					eval('$stack->push('.$fnn.'($op1));'); // perfectly safe eval()
 				} elseif (array_key_exists($fnn, $this->f)) { // user function
 					// get args

--- a/htdocs/core/class/rssparser.class.php
+++ b/htdocs/core/class/rssparser.class.php
@@ -289,7 +289,9 @@ class RssParser
 					}
 
 					xml_set_object($xmlparser, $this);
+					// @phan-suppress-next-line PhanUndeclaredFunctionInCallable
 					xml_set_element_handler($xmlparser, 'feed_start_element', 'feed_end_element');
+					// @phan-suppress-next-line PhanUndeclaredFunctionInCallable
 					xml_set_character_data_handler($xmlparser, 'feed_cdata');
 
 					$status = xml_parse($xmlparser, $str, false);

--- a/htdocs/core/class/rssparser.class.php
+++ b/htdocs/core/class/rssparser.class.php
@@ -219,7 +219,7 @@ class RssParser
 		$newpathofdestfile = $cachedir.'/'.dol_hash($this->_urlRSS, 3); // Force md5 hash (does not contain special chars)
 		$newmask = '0644';
 
-		//dol_syslog("RssPArser::parser parse url=".$urlRSS." => cache file=".$newpathofdestfile);
+		//dol_syslog("RssParser::parser parse url=".$urlRSS." => cache file=".$newpathofdestfile);
 		$nowgmt = dol_now();
 
 		// Search into cache

--- a/htdocs/core/db/sqlite3.class.php
+++ b/htdocs/core/db/sqlite3.class.php
@@ -1442,7 +1442,7 @@ class DoliDBSqlite3 extends DoliDB
 	/**
 	 * calc_days_in_year
 	 *
-	 * @param 	string	$year		Year
+	 * @param 	int		$year		Year
 	 * @return	int					Nb of days in year
 	 */
 	private static function calc_days_in_year($year)

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9849,6 +9849,7 @@ function verifCond($strToEvaluate, $onlysimplestring = '1')
  * 										'2' (used for example for the compute property of extrafields)=Accept also '[]'
  * @return	mixed						Nothing or return result of eval
  * @see verifCond()
+ * @phan-suppress PhanPluginUnsafeEval
  */
 function dol_eval($s, $returnvalue = 1, $hideerrors = 1, $onlysimplestring = '1')
 {

--- a/htdocs/core/menus/standard/auguria_menu.php
+++ b/htdocs/core/menus/standard/auguria_menu.php
@@ -286,6 +286,7 @@ class MenuManager
 								$disabled = " vsmenudisabled";
 							}
 
+							// @phan-suppress-next-line PhanParamSuspiciousOrder
 							print str_pad('', $val2['level'] + 1);
 							print '<li class="lilevel'.($val2['level'] + 1);
 							if ($val2['level'] == 0) {

--- a/htdocs/core/menus/standard/eldy_menu.php
+++ b/htdocs/core/menus/standard/eldy_menu.php
@@ -293,6 +293,7 @@ class MenuManager
 								$disabled = " vsmenudisabled";
 							}
 
+							// @phan-suppress-next-line PhanParamSuspiciousOrder
 							print str_pad('', $val2['level'] + 1);
 							print '<li class="lilevel'.($val2['level'] + 1);
 							if ($val2['level'] == 0) {

--- a/htdocs/core/menus/standard/empty.php
+++ b/htdocs/core/menus/standard/empty.php
@@ -287,6 +287,7 @@ class MenuManager
 								$disabled = " vsmenudisabled";
 							}
 
+							// @phan-suppress-next-line PhanParamSuspiciousOrder
 							print str_pad('', $val2['level'] + 1);
 							print '<li class="lilevel'.($val2['level'] + 1);
 							if ($val2['level'] == 0) {

--- a/htdocs/core/modules/syslog/mod_syslog_file.php
+++ b/htdocs/core/modules/syslog/mod_syslog_file.php
@@ -179,6 +179,7 @@ class mod_syslog_file extends LogHandler implements LogHandlerInterface
 				$this->lastTime = $now;
 			}
 
+			// @phan-suppress-next-line PhanParamSuspiciousOrder
 			$message = dol_print_date(dol_now('gmt'), 'standard', 'gmt').$delay." ".sprintf("%-7s", $logLevels[$content['level']])." ".sprintf("%-15s", $content['ip'])." ".($this->ident > 0 ? str_pad('', $this->ident, ' ') : '').$content['message'];
 			fwrite($filefd, $message."\n");
 			fclose($filefd);

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016   Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2023	Joachim Kueter		    <git-jk@bloxera.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -387,7 +388,7 @@ class SupplierInvoices extends DolibarrApi
 		}
 
 		$result = $this->invoice->getListOfPayments();
-		if ($result < 0) {
+		if ($this->invoice->error !== '') {
 			throw new RestException(405, $this->invoice->error);
 		}
 

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -265,7 +265,7 @@ class SupplierInvoices extends DolibarrApi
 			$this->invoice->$field = $this->_checkValForAPI($field, $value, $this->invoice);
 		}
 
-		if ($this->invoice->update($id, DolibarrApiAccess::$user)) {
+		if ($this->invoice->update(DolibarrApiAccess::$user)) {
 			return $this->get($id);
 		}
 

--- a/htdocs/public/opensurvey/index.php
+++ b/htdocs/public/opensurvey/index.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2023       Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -169,7 +170,7 @@ if (getDolGlobalString('OPENSURVEY_IMAGE_PUBLIC_INTERFACE')) {
 }
 
 
-$results = $object->fetchAll($sortfield, $sortorder, 0, 0, '(status:=:1)');
+$results = $object->fetchAll($sortorder, $sortfield, 0, 0, '(status:=:1)');
 $now = dol_now();
 
 if (is_array($results)) {

--- a/htdocs/public/recruitment/index.php
+++ b/htdocs/public/recruitment/index.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2020       Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -170,7 +171,7 @@ if (getDolGlobalString('RECRUITMENT_IMAGE_PUBLIC_INTERFACE')) {
 }
 
 
-$results = $object->fetchAll($sortfield, $sortorder, 0, 0, '(status:=:1)');
+$results = $object->fetchAll($sortorder, $sortfield, 0, 0, '(status:=:1)');
 $now = dol_now();
 
 if (is_array($results)) {


### PR DESCRIPTION
# Qual: Fix & enable some low occurence notifications

Fix some of the Phan notifications that only have a few reports.

@eldy - I leave 2 case to your examinations:
- The proper replacement for a [NOOP array operation](https://github.com/Dolibarr/dolibarr/blob/aa7efa274eb364a19074826175b42a360db68ad3/htdocs/core/lib/usergroups.lib.php#L562);
- What to do with the missing function 'map_attrs'.  This seems to be something that is in AtomParser::map_attrs, but I do not see how that is loaded in Dolibarr.  Depending on your feedback I may need to include a stub for AtomParser so that the method is found, but then this needs to be included somehow.