### PR TITLE
Update commande.class.php trigger name correction according to standard

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2985,7 +2985,7 @@ class Commande extends CommonOrder
 
 			if (!$notrigger && empty($error)) {
 				// Call trigger
-				$result = $this->call_trigger('ORDER_CLASSIFY_BILLED', $user);
+				$result = $this->call_trigger('ORDER_BILLED', $user);
 				if ($result < 0) {
 					$error++;
 				}
@@ -3035,7 +3035,7 @@ class Commande extends CommonOrder
 
 			if (!$notrigger && empty($error)) {
 				// Call trigger
-				$result = $this->call_trigger('ORDER_CLASSIFY_UNBILLED', $user);
+				$result = $this->call_trigger('ORDER_UNBILLED', $user);
 				if ($result < 0) {
 					$error++;
 				}


### PR DESCRIPTION
# QUAL [Correction of trigger names]
ORDER_CLASSIFY_BILLED becomes ORDER_BILLED
ORDER_CLASSIFY_UNBILLED becomes ORDER_UNBILLED
following the module_action standard


