### PR TITLE
Update pgsql.class.php for deprecated parameters

### DIFF
--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -724,7 +724,7 @@ class DoliDBPgsql extends DoliDB
 	 */
 	public function escape($stringtoencode)
 	{
-		return pg_escape_string($stringtoencode);
+		return pg_escape_string($this->db, $stringtoencode);
 	}
 
 	/**


### PR DESCRIPTION
![image](https://github.com/Dolibarr/dolibarr/assets/3624836/0426a4f2-7ee1-49d6-8e50-c90ef2e73149)
https://www.php.net/manual/en/function.pg-escape-string.php