### PR TITLE
Qual: Always run phpcs in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -67,13 +67,16 @@ jobs:
         uses: shivammathur/setup-php@v2
         # Install when we're going to run phpcs
         if: |
-          steps.changed-php.outputs.any_changed == 'true'
-          ||
+          ! cancelled() &&
           (
-            github.event_name == 'push'
-            && (
-                 github.event.ref == 'refs/heads/develop'
-               || endsWith(github.event.ref, '.0')
+            steps.changed-php.outputs.any_changed == 'true'
+            ||
+            (
+              github.event_name == 'push'
+              && (
+                   github.event.ref == 'refs/heads/develop'
+                 || endsWith(github.event.ref, '.0')
+              )
             )
           )
         with:
@@ -82,7 +85,7 @@ jobs:
           tools: phpcs
 
       - name: Run some pre-commit hooks on selected changed files only
-        if: steps.changed-php.outputs.any_changed == 'true'
+        if: "! cancelled() && steps.changed-php.outputs.any_changed == 'true'"
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-php.outputs.all_changed_files }}
         run: |

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -152,7 +152,7 @@ jobs:
           echo "PHPUNIT seems to have completed with a test result, reuse the exit code"
           for /f "tokens=2 delims==" %%A in ('doskey /m:err') do EXIT /B %%A
       - name: Convert Raw Log to Annotations
-        uses: mdeweerd/logToCheckStyle@v2024.2.9
+        uses: mdeweerd/logToCheckStyle@v2024.3.2
         if: ${{ failure() }}
         with:
           in: ${{ env.PHPUNIT_LOG }}


### PR DESCRIPTION
# Qual: Always run phpcs in pre-commit workflow

Developers are prioritizing the Travis Run because the pre-commit workflow only runs the phpcs checks if the other pre-commit checks did not fail. This modifies the action so that the phpcs checks are also run if the previous step failed.

That should help limit travis load and delays.