### PR TITLE
Fix: Update typing for qty as float

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -580,7 +580,7 @@ class BOM extends CommonObject
 	 *
 	 * @param	int		$fk_product				Id of product
 	 * @param	float	$qty					Quantity
-	 * @param	float	$qty_frozen				Frozen quantity
+	 * @param	int<0,1> $qty_frozen			If the qty is Frozen
 	 * @param 	int		$disable_stock_change	Disable stock change on using in MO
 	 * @param	float	$efficiency				Efficiency in MO
 	 * @param	int		$position				Position of BOM-Line in BOM-Lines


### PR DESCRIPTION
# Fix: Update typing for qty as float

Update the typing hints for qty to float (instead of int).
No functionnal issue was found in the review (i.e. conversion to int of qty) - the only outlier seems to be that qty is typed to int in a recruitement table which may need extra care.