### PR TITLE
Create a shipment without documents

### DIFF
--- a/htdocs/install/mysql/tables/llx_expeditiondet.sql
+++ b/htdocs/install/mysql/tables/llx_expeditiondet.sql
@@ -23,7 +23,7 @@ create table llx_expeditiondet
 (
   rowid             integer AUTO_INCREMENT PRIMARY KEY,
   fk_expedition     integer NOT NULL,
-  fk_origin_line    integer,           -- should be renamed into fk_elementdet. The ID of line of source object (proposal, sale order)
+  fk_elementdet    integer,           -- should be renamed into fk_elementdet. The ID of line of source object (proposal, sale order)
   element_type   	varchar(50) DEFAULT 'order' NOT NULL,
   fk_entrepot       integer,           -- Entrepot de depart du produit
   qty               real,              -- Quantity

--- a/htdocs/install/mysql/tables/llx_expeditiondet.sql
+++ b/htdocs/install/mysql/tables/llx_expeditiondet.sql
@@ -23,7 +23,7 @@ create table llx_expeditiondet
 (
   rowid             integer AUTO_INCREMENT PRIMARY KEY,
   fk_expedition     integer NOT NULL,
-  fk_elementdet    integer,           -- should be renamed into fk_elementdet. The ID of line of source object (proposal, sale order)
+  fk_elementdet    integer,           -- The ID of line of source object (proposal, sale order)
   element_type   	varchar(50) DEFAULT 'order' NOT NULL,
   fk_entrepot       integer,           -- Entrepot de depart du produit
   qty               real,              -- Quantity

--- a/htdocs/install/mysql/tables/llx_expeditiondet.sql
+++ b/htdocs/install/mysql/tables/llx_expeditiondet.sql
@@ -23,7 +23,7 @@ create table llx_expeditiondet
 (
   rowid             integer AUTO_INCREMENT PRIMARY KEY,
   fk_expedition     integer NOT NULL,
-  fk_origin_line    integer,           -- The ID of line of source object (proposal, sale order)
+  fk_origin_line    integer,           -- The ID of line of source object (proposal, sale order). TODO should be renamed into fk_elementdet in SQL files and code in same PR.
   element_type   	varchar(50) DEFAULT 'order' NOT NULL,
   fk_entrepot       integer,           -- Entrepot de depart du produit
   qty               real,              -- Quantity

--- a/htdocs/install/mysql/tables/llx_expeditiondet.sql
+++ b/htdocs/install/mysql/tables/llx_expeditiondet.sql
@@ -23,7 +23,7 @@ create table llx_expeditiondet
 (
   rowid             integer AUTO_INCREMENT PRIMARY KEY,
   fk_expedition     integer NOT NULL,
-  fk_elementdet    integer,           -- The ID of line of source object (proposal, sale order)
+  fk_origin_line    integer,           -- The ID of line of source object (proposal, sale order)
   element_type   	varchar(50) DEFAULT 'order' NOT NULL,
   fk_entrepot       integer,           -- Entrepot de depart du produit
   qty               real,              -- Quantity

--- a/htdocs/install/mysql/tables/llx_expeditiondet.sql
+++ b/htdocs/install/mysql/tables/llx_expeditiondet.sql
@@ -24,6 +24,7 @@ create table llx_expeditiondet
   rowid             integer AUTO_INCREMENT PRIMARY KEY,
   fk_expedition     integer NOT NULL,
   fk_origin_line    integer,           -- should be renamed into fk_elementdet. The ID of line of source object (proposal, sale order)
+  element_type   	varchar(50) DEFAULT 'order' NOT NULL,
   fk_entrepot       integer,           -- Entrepot de depart du produit
   qty               real,              -- Quantity
   rang              integer  DEFAULT 0


### PR DESCRIPTION
# NEW [Possibility of creating a shipment without documents or from all documents (genericity)]
At the moment, there's a big restriction on shipping: you can only ship from a propal or an order. Sometimes, however, we just need to make an internal transfer, or we don't yet have the customer order.
I therefore propose to make this form active:
expedition/card.php?action=create
from expedition -> create without having to go through a document by setting product as origin.
I'd have to rework the shipping page, but this would allow you to either directly retrieve a product, or retrieve the line from a document.
So here's my first proposal along these lines: record the origin of the shipment: propal or order for the moment, and we can imagine product in the future, for example for a shipment without documents.

