### PR TITLE
Fix spelling (using beta codespell)

### DIFF
--- a/dev/setup/pre-commit/README.md
+++ b/dev/setup/pre-commit/README.md
@@ -85,7 +85,7 @@ export SKIP=no-commit-to-branch   # In your .bashrc or session.
 There is much more you can do with pre-commit, check out its
 [documentation](https://pre-commit.com).
 
-Now your commit is less likely to fail in the Continuous Intagration (CI) run
+Now your commit is less likely to fail in the Continuous Integration (CI) run
 on github.\
 CI also runs pre-commit to help maintain code quality.
 

--- a/dev/tools/codespell/codespell-ignore.txt
+++ b/dev/tools/codespell/codespell-ignore.txt
@@ -27,6 +27,8 @@ thead
 ue
 whitelist
 ws
+# Thirdparty should be Third party or Third-party but ignoring it because it's omnipresent
+thirdparty
 # Code string
 ect
 tempdate

--- a/htdocs/api/class/api_login.class.php
+++ b/htdocs/api/class/api_login.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016	Laurent Destailleur		<eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,7 +50,7 @@ class Login
 	 * Login
 	 *
 	 * Request the API token for a couple username / password.
-	 * WARNING: You should NEVER use this API, like you should never use the similare API that uses the POST method. This will expose your password.
+	 * WARNING: You should NEVER use this API, like you should never use the similar API that uses the POST method. This will expose your password.
 	 * To use the APIs, you should instead set an API token to the user you want to allow to use API (This API token called DOLAPIKEY can be found/set on the user page) and use this token as credential for any API call.
 	 * From the API explorer, you can enter directly the "DOLAPIKEY" into the field at the top right of the page to get access to any allowed APIs.
 	 *
@@ -73,7 +74,7 @@ class Login
 	 * Login
 	 *
 	 * Request the API token for a couple username / password.
-	 * WARNING: You should NEVER use this API, like you should never use the similare API that uses the POST method. This will expose your password.
+	 * WARNING: You should NEVER use this API, like you should never use the similar API that uses the POST method. This will expose your password.
 	 * To use the APIs, you should instead set an API token to the user you want to allow to use API (This API token called DOLAPIKEY can be found/set on the user page) and use this token as credential for any API call.
 	 * From the API explorer, you can enter directly the "DOLAPIKEY" into the field at the top right of the page to get access to any allowed APIs.
 	 *

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1445,7 +1445,7 @@ function dol_sanitizeFileName($str, $newstr = '_', $unaccent = 1)
 
 
 /**
- *	Clean a string to use it as a path name. Similare to dol_sanitizeFileName but accept / and \ chars.
+ *	Clean a string to use it as a path name. Similar to dol_sanitizeFileName but accept / and \ chars.
  *  Replace also '--' and ' -' strings, they are used for parameters separation (Note: ' - ' is allowed).
  *
  *	@param	string	$str            String to clean
@@ -7928,7 +7928,7 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 
 			// We replace chars from a/A to z/Z encoded with numeric HTML entities with the real char so we won't loose the chars at the next step (preg_replace).
 			// No need to use a loop here, this step is not to sanitize (this is done at next step, this is to try to save chars, even if they are
-			// using a non coventionnel way to be encoded, to not have them sanitized just after)
+			// using a non conventionnel way to be encoded, to not have them sanitized just after)
 			$out = preg_replace_callback(
 				'/&#(x?[0-9][0-9a-f]+;?)/i',
 				/**

--- a/htdocs/societe/paymentmodes.php
+++ b/htdocs/societe/paymentmodes.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2017       Ferran Marcet        <fmarcet@2byte.es>
  * Copyright (C) 2018-2023  Thibault FOUCART     <support@ptibogxiv.net>
  * Copyright (C) 2021       Alexandre Spangaro   <aspangaro@open-dsi.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1974,7 +1975,7 @@ if ($socid && $action == 'edit' && $permissiontoaddupdatepaymentinformation) {
 
 	// Show fields of bank account
 	$bankaccount = $companybankaccount;
-	// Code here is similare than into bank.php for users
+	// Code here is similar as in bank.php for users
 	foreach ($bankaccount->getFieldsToShow(1) as $val) {
 		$require = false;
 		$tooltip = '';

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -7,6 +7,7 @@
  * Copyright (C) 2015-2016  Marcos García        <marcosgdf@gmail.com>
  * Copyright (C) 2015       Alexandre Spangaro   <aspangaro@open-dsi.fr>
  * Copyright (C) 2021       Gauthier VERDOL      <gauthier.verdol@atm-consulting.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -957,7 +958,7 @@ if ($id && ($action == 'edit' || $action == 'create') && $user->hasRight('user',
 
 	// Show fields of bank account
 	$bankaccount = $account;
-	// Code here is similare than into paymentmodes.php for third-parties
+	// Code here is similar as in paymentmodes.php for third-parties
 	foreach ($bankaccount->getFieldsToShow(1) as $val) {
 		$require = false;
 		$tooltip = '';

--- a/test/phpunit/CommonClassTest.class.php
+++ b/test/phpunit/CommonClassTest.class.php
@@ -23,7 +23,7 @@
  *      \file       test/phpunit/CommonClassTest.php
  *      \ingroup    test
  *      \brief      PHPUnit test
- *      \remarks    Class that extends all PHPunit tests. To share similare code between each test.
+ *      \remarks    Class that extends all PHPunit tests. To share similar code between each test.
  */
 
 // Workaround for false security issue with main.inc.php on Windows in tests:


### PR DESCRIPTION
# Fix spelling (using beta codespell

New spelling fixes - ignoring thirdparty which should be either third-party or third party.
