### PR TITLE
Qual: Bump logToCheckStyle for better filename handling

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -106,7 +106,7 @@ jobs:
           ls -l ~/.cache/pre-commit/
 
       - name: Convert Raw Log to Annotations
-        uses: mdeweerd/logToCheckStyle@2024.3.2
+        uses: mdeweerd/logToCheckStyle@v2024.3.4
         if: ${{ failure() }}
         with:
           in: ${{ env.RAW_LOG }}

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -150,7 +150,7 @@ jobs:
           for /f "tokens=2 delims==" %%A in ('doskey /m:err') do EXIT /B %%A
 
       - name: Convert Raw Log to Annotations
-        uses: mdeweerd/logToCheckStyle@2024.3.2
+        uses: mdeweerd/logToCheckStyle@v2024.3.4
         if: ${{ failure() }}
         with:
           in: ${{ env.PHPUNIT_LOG }}


### PR DESCRIPTION
# Qual: Bump logToCheckStyle for better filename handling

Some notifications from the PHPCS step in pre-commit extracted too many characters for the filename in a specific case.
The update to logToCheckStyle fixes that.