### PR TITLE
FIX: SQL syntax error in DDLUpdateField

### DIFF
--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -1273,9 +1273,9 @@ class DoliDBPgsql extends DoliDB
 
 		if (isset($field_desc['default']) && $field_desc['default'] != '') {
 			if ($field_desc['type'] == 'double' || $field_desc['type'] == 'tinyint' || $field_desc['type'] == 'int') {
-				$sql .= " DEFAULT ".$this->escape($field_desc['default']);
+				$sql .= ", ALTER COLUMN ".$this->escape($field_name)." SET DEFAULT ".$this->escape($field_desc['default']);
 			} elseif ($field_desc['type'] != 'text') {
-				$sql .= " DEFAULT '".$this->escape($field_desc['default'])."'"; // Default not supported on text fields
+				$sql .= ", ALTER COLUMN ".$this->escape($field_name)." SET DEFAULT '"." DEFAULT '".$this->escape($field_desc['default'])."'"; // Default not supported on text fields
 			}
 		}
 

--- a/test/phpunit/DoliDBTest.php
+++ b/test/phpunit/DoliDBTest.php
@@ -160,7 +160,7 @@ class DoliDBTest extends PHPUnit\Framework\TestCase
 		print __METHOD__." result=".$result."\n";
 
 		// TODO Use $savtype and $savnull instead of hard coded
-		$field_desc = array('type'=>'varchar', 'value'=>'16', 'null'=>'NOT NULL');
+		$field_desc = array('type'=>'varchar', 'value'=>'16', 'null'=>'NOT NULL', 'default'=>'aaaabbbbccccdddd');
 
 		$result = $db->DDLUpdateField($db->prefix().'c_paper_format', 'code', $field_desc);
 		$this->assertEquals(1, $result);


### PR DESCRIPTION
# FIX: SQL syntax error in DDLUpdateField

In Dolibarr 18.0.5 with a Postgres database, I get an SQL syntax error when I try to modify the default value of a complementary attribute in the invoice module setup (`/compta/facture/admin/facture_cust_extrafields.php`). The query that fails is:

```sql
ALTER TABLE llx_facture_extrafields ALTER COLUMN annee_ca TYPE int DEFAULT 2024
```

The correct syntax for Postgres would be:

```sql
ALTER TABLE llx_facture_extrafields ALTER COLUMN annee_ca TYPE int, ALTER COLUMN annee_ca SET DEFAULT 2024
```

The problem was introduced by fc63599d, which updated `DDLUpdateField` to generate SQL with Postgres syntax, but forgot the case where `$field_desc['default']` is set (before that commit, `DDLUpdateField` used MySQL syntax, which was translated correctly by `convertSQLFromMysql`)