### PR TITLE
FIX - Default Workstation on bom

### DIFF
--- a/htdocs/bom/ajax/ajax.php
+++ b/htdocs/bom/ajax/ajax.php
@@ -53,7 +53,7 @@ $idproduct = GETPOST('idproduct', 'int');
  * View
  */
 
-top_httphead();
+top_httphead('application/json');
 
 if ($action == 'getDurationUnitByProduct' && $user->hasRight('product', 'lire')) {
 	$product = new Product($db);
@@ -63,5 +63,26 @@ if ($action == 'getDurationUnitByProduct' && $user->hasRight('product', 'lire'))
 	$fk_unit = $cUnit->getUnitFromCode($product->duration_unit, 'short_label', 'time');
 
 	echo json_encode($fk_unit);
+	exit();
+}
+
+if ($action == 'getWorkstationByProduct' && $user->hasRight('product', 'lire')) {
+	$product = new Product($db);
+	$res = $product->fetch($idproduct);
+
+	$result = array();
+
+	if ($res < 0) {
+		$error = 'SQL ERROR';
+	} elseif ($res == 0) {
+		$error = 'NOT FOUND';
+	} else {
+		$error = null;
+		$result['defaultWk']=$product->fk_default_workstation;
+	}
+
+	$result['error']=$error;
+
+	echo json_encode($result);
 	exit();
 }

--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -792,7 +792,7 @@ class BOM extends CommonObject
 					$line->array_options[$key] = $array_options[$key];
 				}
 			}
-			if ($fk_default_workstation > 0 && $line->fk_default_workstation != $fk_default_workstation) {
+			if ($fk_default_workstation >= 0 && $line->fk_default_workstation != $fk_default_workstation) {
 				$line->fk_default_workstation = $fk_default_workstation;
 			}
 

--- a/htdocs/bom/tpl/objectline_create.tpl.php
+++ b/htdocs/bom/tpl/objectline_create.tpl.php
@@ -185,7 +185,7 @@ if ($filtertype != 1) {
 
 	$coldisplay++;
 	print '<td class="bordertop nobottom nowrap linecolworkstation right">';
-	print '&nbsp;';
+	print $formproduct->selectWorkstations('', 'idworkstations', 1);
 	print '</td>';
 
 	$coldisplay++;
@@ -235,13 +235,26 @@ jQuery(document).ready(function() {
 				,type: 'POST'
 				,data: {
 					'action': 'getDurationUnitByProduct'
+					,'token' : "<?php echo newToken() ?>"
 					,'idproduct' : idproduct
 				}
 			}).done(function(data) {
 
 				console.log(data);
-				var data = JSON.parse(data);
 				$("#fk_unit").val(data).change();
+			});
+
+			$.ajax({
+				url : "<?php echo dol_buildpath('/bom/ajax/ajax.php', 1); ?>"
+				,type: 'POST'
+				,data: {
+					'action': 'getWorkstationByProduct'
+					,'token' :  "<?php echo newToken() ?>"
+					,'idproduct' : idproduct
+				}
+			}).done(function(data) {
+				$('#idworkstations').val(data.defaultWk).select2();
+
 			});
 	});
 	<?php } ?>


### PR DESCRIPTION
# FIX *Default workstation on bom*

In the services of a BOM, when adding a line, dynamic management of workstations by default depending on the selected service. When modifying, possibility of emptying the default workstation field.

This Fix must also be in 19.0 here is the old PR towards develop :
https://github.com/Dolibarr/dolibarr/pull/27729