### PR TITLE
Fix $var |= ... ; into $var = || $var ; PhanTypeInvalidLeftOperandOfAdd

### DIFF
--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -495,7 +495,7 @@ return [
 		'PhanPossiblyNullTypeMismatchProperty',
 		'PhanRedefineClass',
 		'PhanRedefineFunction',
-		'PhanTypeInvalidLeftOperandOfBitwiseOp',
+		// 'PhanTypeInvalidLeftOperandOfBitwiseOp',
 		// 'PhanTypeMismatchDimAssignment',
 		// 'PhanPluginDescriptionlessCommentOnProtectedMethod',
 		// 'PhanPluginPrintfIncompatibleArgumentTypeWeak',

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -1548,7 +1548,7 @@ class Asset extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/asset/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = $mybool || (bool) @include_once $dir.$file;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -1548,7 +1548,7 @@ class Asset extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/asset/");
 
 				// Load file with numbering class (if found)
-				$mybool = $mybool || (bool) @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -875,7 +875,7 @@ class BOM extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/bom/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/bookcal/class/availabilities.class.php
+++ b/htdocs/bookcal/class/availabilities.class.php
@@ -975,7 +975,7 @@ class Availabilities extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/bookcal/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/bookcal/class/calendar.class.php
+++ b/htdocs/bookcal/class/calendar.class.php
@@ -964,7 +964,7 @@ class Calendar extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/bookcal/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -3615,7 +3615,7 @@ class Propal extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/propale/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if (!$mybool) {

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -416,7 +416,7 @@ class Commande extends CommonOrder
 				$dir = dol_buildpath($reldir."core/modules/commande/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4609,7 +4609,7 @@ class Facture extends CommonInvoice
 
 				// Load file with numbering class (if found)
 				if (is_file($dir.$file) && is_readable($dir.$file)) {
-					$mybool |= include_once $dir.$file;
+					$mybool = ((bool) include_once $dir.$file) || $mybool;
 				}
 			}
 
@@ -4624,7 +4624,7 @@ class Facture extends CommonInvoice
 
 					// Load file with numbering class (if found)
 					if (is_file($dir.$file) && is_readable($dir.$file)) {
-						$mybool |= include_once $dir.$file;
+						$mybool = (include_once $dir.$file) || $mybool;
 					}
 				}
 			}

--- a/htdocs/compta/paiement/cheque/class/remisecheque.class.php
+++ b/htdocs/compta/paiement/cheque/class/remisecheque.class.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2011-2016 Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2015      Marcos García        <marcosgdf@gmail.com>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -423,7 +424,7 @@ class RemiseCheque extends CommonObject
 
 				// Load file with numbering class (if found)
 				if (is_file($dir.$file) && is_readable($dir.$file)) {
-					$mybool |= include_once $dir.$file;
+					$mybool = (include_once $dir.$file) || $mybool;
 				}
 			}
 
@@ -438,7 +439,7 @@ class RemiseCheque extends CommonObject
 
 					// Load file with numbering class (if found)
 					if (is_file($dir.$file) && is_readable($dir.$file)) {
-						$mybool |= include_once $dir.$file;
+						$mybool = (include_once $dir.$file) || $mybool;
 					}
 				}
 			}

--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -13,6 +13,7 @@
  * Copyright (C) 2021       OpenDsi					<support@open-dsi.fr>
  * Copyright (C) 2023       Joachim Kueter			<git-jk@bloxera.com>
  * Copyright (C) 2023       Sylvain Legrand			<technique@infras.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -847,7 +848,7 @@ class Paiement extends CommonObject
 
 				// Add link to the Direct Debit if invoice refused ('InvoiceRefused') in bank_url
 				if (!$error && $label == '(InvoiceRefused)') {
-					$result=$acc->add_url_line(
+					$result = $acc->add_url_line(
 						$bank_line_id,
 						$this->id_prelevement,
 						DOL_URL_ROOT.'/compta/prelevement/card.php?id=',
@@ -1182,7 +1183,7 @@ class Paiement extends CommonObject
 
 				// Load file with numbering class (if found)
 				if (is_file($dir.$file) && is_readable($dir.$file)) {
-					$mybool |= include_once $dir.$file;
+					$mybool = (include_once $dir.$file) || $mybool;
 				}
 			}
 
@@ -1197,7 +1198,7 @@ class Paiement extends CommonObject
 
 					// Load file with numbering class (if found)
 					if (is_file($dir.$file) && is_readable($dir.$file)) {
-						$mybool |= include_once $dir.$file;
+						$mybool = (include_once $dir.$file) || $mybool;
 					}
 				}
 			}
@@ -1352,7 +1353,7 @@ class Paiement extends CommonObject
 		$result .= $linkend;
 		global $action;
 		$hookmanager->initHooks(array($this->element . 'dao'));
-		$parameters = array('id'=>$this->id, 'getnomurl' => &$result);
+		$parameters = array('id' => $this->id, 'getnomurl' => &$result);
 		$reshook = $hookmanager->executeHooks('getNomUrl', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 		if ($reshook > 0) {
 			$result = $hookmanager->resPrint;

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -337,7 +337,7 @@ class Contrat extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/contract/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if (!$mybool) {

--- a/htdocs/core/class/timespent.class.php
+++ b/htdocs/core/class/timespent.class.php
@@ -951,7 +951,7 @@ class TimeSpent extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/timespent/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -969,7 +969,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/eventorganization/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -306,7 +306,7 @@ class Expedition extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/expedition/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if (!$mybool) {

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -1729,7 +1729,7 @@ class ExpenseReport extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/expensereport/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -200,17 +200,17 @@ class Fichinter extends CommonObject
 	/*
 	 * Signed by sender
 	 */
-	CONST STATUS_SIGNED_SENDER   = 1;
+	const STATUS_SIGNED_SENDER   = 1;
 
 	/*
 	 * Signed by receiver
 	 */
-	CONST STATUS_SIGNED_RECEIVER = 2;
+	const STATUS_SIGNED_RECEIVER = 2;
 
 	/*
 	 * Signed by all
 	 */
-	CONST STATUS_SIGNED_ALL      = 9; // To handle future kind of signature (ex: tripartite contract)
+	const STATUS_SIGNED_ALL      = 9; // To handle future kind of signature (ex: tripartite contract)
 
 	/**
 	 * Date delivery
@@ -1010,7 +1010,7 @@ class Fichinter extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/fichinter/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1129,7 +1129,7 @@ class CommandeFournisseur extends CommonOrder
 				$dir = dol_buildpath($reldir."core/modules/supplier_order/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2963,7 +2963,7 @@ class FactureFournisseur extends CommonInvoice
 			$dir = dol_buildpath($reldir."core/modules/supplier_invoice/");
 
 			// Load file with numbering class (if found)
-			$mybool |= @include_once $dir.$file;
+			$mybool = ((bool) @include_once $dir.$file) || $mybool;
 		}
 
 		if ($mybool === false) {

--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -10,6 +10,7 @@
  * Copyright (C) 2023      Joachim Kueter		  <git-jk@bloxera.com>
  * Copyright (C) 2023      Sylvain Legrand		  <technique@infras.fr>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -279,9 +280,9 @@ class PaiementFourn extends Paiement
 							// If we want to closed paid invoices
 							if ($closepaidinvoices) {
 								$paiement = $invoice->getSommePaiement();
-								$creditnotes=$invoice->getSumCreditNotesUsed();
+								$creditnotes = $invoice->getSumCreditNotesUsed();
 								//$creditnotes = 0;
-								$deposits=$invoice->getSumDepositsUsed();
+								$deposits = $invoice->getSumDepositsUsed();
 								//$deposits = 0;
 								$alreadypayed = price2num($paiement + $creditnotes + $deposits, 'MT');
 								$remaintopay = price2num($invoice->total_ttc - $paiement - $creditnotes - $deposits, 'MT');
@@ -712,7 +713,7 @@ class PaiementFourn extends Paiement
 
 		global $action;
 		$hookmanager->initHooks(array($this->element . 'dao'));
-		$parameters = array('id'=>$this->id, 'getnomurl' => &$result);
+		$parameters = array('id' => $this->id, 'getnomurl' => &$result);
 		$reshook = $hookmanager->executeHooks('getNomUrl', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 		if ($reshook > 0) {
 			$result = $hookmanager->resPrint;
@@ -783,7 +784,7 @@ class PaiementFourn extends Paiement
 
 				// Load file with numbering class (if found)
 				if (is_file($dir.$file) && is_readable($dir.$file)) {
-					$mybool |= include_once $dir.$file;
+					$mybool = (include_once $dir.$file) || $mybool;
 				}
 			}
 
@@ -798,7 +799,7 @@ class PaiementFourn extends Paiement
 
 					// Load file with numbering class (if found)
 					if (is_file($dir.$file) && is_readable($dir.$file)) {
-						$mybool |= include_once $dir.$file;
+						$mybool = (include_once $dir.$file) || $mybool;
 					}
 				}
 			}

--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -232,7 +232,7 @@ class Holiday extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/holiday/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/hrm/class/evaluation.class.php
+++ b/htdocs/hrm/class/evaluation.class.php
@@ -952,7 +952,7 @@ class Evaluation extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/hrm/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/hrm/class/evaluationdet.class.php
+++ b/htdocs/hrm/class/evaluationdet.class.php
@@ -922,7 +922,7 @@ class EvaluationLine extends CommonObjectLine
 				$dir = dol_buildpath($reldir."core/modules/hrm/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/hrm/class/job.class.php
+++ b/htdocs/hrm/class/job.class.php
@@ -961,7 +961,7 @@ class Job extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/hrm/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -1001,7 +1001,7 @@ class Position extends CommonObject
 				$dir = dol_buildpath($reldir . "core/modules/hrm/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir . $file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/hrm/class/skill.class.php
+++ b/htdocs/hrm/class/skill.class.php
@@ -1001,7 +1001,7 @@ class Skill extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/hrm/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/hrm/class/skilldet.class.php
+++ b/htdocs/hrm/class/skilldet.class.php
@@ -889,7 +889,7 @@ class Skilldet extends CommonObjectLine
 				$dir = dol_buildpath($reldir."core/modules/hrm/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/hrm/class/skillrank.class.php
+++ b/htdocs/hrm/class/skillrank.class.php
@@ -965,7 +965,7 @@ class SkillRank extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/hrm/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/knowledgemanagement/class/knowledgerecord.class.php
+++ b/htdocs/knowledgemanagement/class/knowledgerecord.class.php
@@ -1027,7 +1027,7 @@ class KnowledgeRecord extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/knowledgemanagement/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -1020,7 +1020,7 @@ class Mo extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/mrp/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/partnership/class/partnership.class.php
+++ b/htdocs/partnership/class/partnership.class.php
@@ -1230,7 +1230,7 @@ class Partnership extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/partnership/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/product/class/productfournisseurprice.class.php
+++ b/htdocs/product/class/productfournisseurprice.class.php
@@ -824,7 +824,7 @@ class ProductFournisseurPrice extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/buypricehistory/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
+++ b/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
@@ -975,7 +975,7 @@ class StockTransfer extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/stocktransfer/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/product/stock/stocktransfer/class/stocktransferline.class.php
+++ b/htdocs/product/stock/stocktransfer/class/stocktransferline.class.php
@@ -939,7 +939,7 @@ class StockTransferLine extends CommonObjectLine
 				$dir = dol_buildpath($reldir."core/modules/stocktransfer/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -180,7 +180,7 @@ class Reception extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/reception/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if (!$mybool) {

--- a/htdocs/recruitment/class/recruitmentcandidature.class.php
+++ b/htdocs/recruitment/class/recruitmentcandidature.class.php
@@ -953,7 +953,7 @@ class RecruitmentCandidature extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/recruitment/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/recruitment/class/recruitmentjobposition.class.php
+++ b/htdocs/recruitment/class/recruitmentjobposition.class.php
@@ -1010,7 +1010,7 @@ class RecruitmentJobPosition extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/recruitment/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if ($mybool === false) {

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -2429,7 +2429,7 @@ class SupplierProposal extends CommonObject
 				$dir = dol_buildpath($reldir."core/modules/supplier_proposal/");
 
 				// Load file with numbering class (if found)
-				$mybool |= @include_once $dir.$file;
+				$mybool = ((bool) @include_once $dir.$file) || $mybool;
 			}
 
 			if (!$mybool) {

--- a/htdocs/webhook/class/target.class.php
+++ b/htdocs/webhook/class/target.class.php
@@ -901,7 +901,7 @@ class Target extends CommonObject
 			$dir = dol_buildpath($reldir."core/modules/webhook/");
 
 			// Load file with numbering class (if found)
-			$mybool |= @include_once $dir.$file;
+			$mybool = ((bool) @include_once $dir.$file) || $mybool;
 		}
 
 		if ($mybool === false) {

--- a/htdocs/workstation/class/workstation.class.php
+++ b/htdocs/workstation/class/workstation.class.php
@@ -878,7 +878,7 @@ class Workstation extends CommonObject
 
 				// Load file with numbering class (if found)
 				if (file_exists($dir.$file)) {
-					$mybool |= @include_once $dir.$file;
+					$mybool = ((bool) @include_once $dir.$file) || $mybool;
 				}
 			}
 


### PR DESCRIPTION
# Fix $var |= ... ; into $var =  || $var ;   PhanTypeInvalidLeftOperandOfAdd

|= is a binary operation, change in to boolean op.
|= always evaluates the expression the bitwise and is performed with, so need to use || $var.

All occurences are for the same use case where a loop tries to include the available files on the list.
