### PR TITLE
Qual: Add dependencies between workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,16 @@
+# Workflow run order
+
+To reduce run minutes, the following order is put in place:
+
+On PR & Merge, always run:
+
+- pre-commit;
+- phan.
+
+When both succeed, start:
+
+- phpstan;
+- Windows-ci;
+- travis.
+
+See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: "CI"
+
+on: [push, pull_request]
+jobs:
+  pre-commit:
+    uses: ./.github/workflows/pre-commit.yml
+    secrets: inherit
+    with:
+      gh_event: ${{ github.event_name }}
+  phan:
+    uses: ./.github/workflows/phan.yml
+    secrets: inherit
+    with:
+      gh_event: ${{ github.event_name }}
+  phpstan:
+    uses: ./.github/workflows/phpstan.yml
+    secrets: inherit
+    needs: [pre-commit, phan]
+    with:
+      gh_event: ${{ github.event_name }}
+  windows-ci:
+    needs: [pre-commit, phan]
+    secrets: inherit
+    uses: ./.github/workflows/windows-ci.yml
+    with:
+      gh_event: ${{ github.event_name }}
+  gh-travis:  # Runs travis script on github runner (not on travis)
+    if: false
+    # needs: [pre-commit, phan]
+    # needs: [windows-ci]
+    secrets: inherit
+    uses: ./.github/workflows/gh-travis.yml
+    with:
+      gh_event: ${{ github.event_name }}
+
+
+# Note (not tested, from https://github.com/orgs/community/discussions/38361)
+# To cancel jobs if one failes, the following action may help
+#       - if: "failure()"
+#        uses: "andymckay/cancel-action@0.3"

--- a/.github/workflows/gh-travis.yml
+++ b/.github/workflows/gh-travis.yml
@@ -1,0 +1,49 @@
+---
+# This runs a travis script inside a github runner
+name: Travis
+# Controls when the workflow will run
+on:
+  # push:
+  # pull_request:
+  workflow_call:
+    inputs:
+      gh_event:
+        required: true
+        type: string
+  workflow_dispatch:
+
+concurrency:
+  group: travis-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+    }}
+  cancel-in-progress: true
+env:
+  gh_event: ${{ inputs.gh_event || github.event_name }}
+  GITHUB_JSON: ${{ toJSON(github) }}  # Helps in debugging Github Action
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job
+  gh-travis:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # matrix:
+      #   php-version:
+      #  # PHPStan requires PHP >= 7.2.
+      #    #- "7.2"
+      #    - "8.2"
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout travis file
+        uses: actions/checkout@v4
+      - name: Run .travis.yml build script
+        uses: ktomk/run-travis-yml@v1
+        with:
+          # run-job: travis  # name of a job in travis file
+          allow-failure: false
+          # file: .travis.yml
+          # steps: |  # Default: setup, before_install, install, before_script, script, after_script, before_deploy
+          #  install
+          #  script
+        # env:
+        #  TRAVIS_PHP_VERSION: ${{ matrix.php-version }}

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -1,16 +1,22 @@
 ---
 on:
-  pull_request:
-  push:
-  schedule:
-    # execute once a day, the 1st
-    - cron: 10 9 * * *
+  # pull_request:
+  # push:
+  # schedule:
+  #   # execute once a day, the 1st
+  #   - cron: 10 9 * * *
+  workflow_call:
+    inputs:
+      gh_event:
+        required: true
+        type: string
   workflow_dispatch:
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: phan-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 env:
-  # Do pull analysis on schedule or manual dispatch
+  gh_event: ${{ inputs.gh_event || github.event_name }}
   PHAN_CONFIG: >
     ${{
       ( github.event.schedule || github.event_name == 'workflow_dispatch' )
@@ -21,6 +27,7 @@ env:
   PHAN_MIN_PHP: 7.0
   PHAN_QUICK: ${{ github.event.schedule && '' || '--quick' }}
   GITHUB_JSON: ${{ toJSON(github) }} # Helps in debugging Github Action
+
 name: phan
 jobs:
   phan:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,16 +1,25 @@
+---
 # This is a basic workflow to check code with PHPSTAN tool
-
-name: "PHPStan"
-
+name: PHPStan
 # Controls when the workflow will run
-on: [push, pull_request]
-concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-    cancel-in-progress: true
+on:
+  # push:
+  # pull_request:
+  workflow_call:
+    inputs:
+      gh_event:
+        required: true
+        type: string
+  workflow_dispatch:
 
+concurrency:
+  group: stan-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+    }}
+  cancel-in-progress: true
 env:
-  CACHE_KEY_PART: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}
-  GITHUB_JSON: ${{ toJSON(github) }} # Helps in debugging Github Action
+  gh_event: ${{ inputs.gh_event || github.event_name }}
+  CACHE_KEY_PART: ${{ ( inputs.gh_event == 'pull_request' || github.event_name == 'pull_request' ) && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}
+  GITHUB_JSON: ${{ toJSON(github) }}  # Helps in debugging Github Action
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job
@@ -23,7 +32,7 @@ jobs:
         php-version:
           # PHPStan requires PHP >= 7.2.
           #- "7.2"
-          - "8.2"
+          - '8.2'
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -34,9 +43,10 @@ jobs:
         id: setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "${{ matrix.php-version }}"
+          php-version: ${{ matrix.php-version }}
           tools: phpstan, cs2pr
-          extensions: calendar, json, imagick, gd, zip, mbstring, intl, opcache, imap, mysql, pgsql, sqlite3, ldap, xml, mcrypt
+          extensions: calendar, json, imagick, gd, zip, mbstring, intl, opcache, imap,
+            mysql, pgsql, sqlite3, ldap, xml, mcrypt
 
       # Restore old cache
       - name: Restore phpstan cache
@@ -44,7 +54,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ./.github/tmp
-          key: phpstan-cache-${{ matrix.php-version }}-${{ env.CACHE_KEY_PART }}-${{ github.run_id }}
+          key: phpstan-cache-${{ matrix.php-version }}-${{ env.CACHE_KEY_PART }}-${{
+            github.run_id }}
           restore-keys: |
             phpstan-cache-${{ matrix.php-version }}-${{ env.CACHE_KEY_PART }}-
             phpstan-cache-${{ matrix.php-version }}-${{ github.head_ref }}-
@@ -61,12 +72,13 @@ jobs:
         # continue-on-error: true
 
       # Save cache
-      - name: "Save phpstan cache"
+      - name: Save phpstan cache
         uses: actions/cache/save@v4
         if: ${{ success() || ( ! cancelled() && steps.cache.outputs.cache-hit != 'true' ) }}
         with:
           path: ./.github/tmp
-          key: phpstan-cache-${{ matrix.php-version }}-${{ env.CACHE_KEY_PART }}-${{ github.run_id }}
+          key: phpstan-cache-${{ matrix.php-version }}-${{ env.CACHE_KEY_PART }}-${{
+            github.run_id }}
       - name: Provide phpstan log as artifact
         uses: actions/upload-artifact@v4
         if: ${{ always() }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,8 +1,17 @@
 ---
 name: pre-commit
 on:
-  pull_request:
-  push:
+  # pull_request:
+  # push:
+  workflow_call:
+    inputs:
+      gh_event:
+        required: true
+        type: string
+  workflow_dispatch:
+
+env:
+  gh_event: ${{ inputs.gh_event || github.event_name }}
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -20,7 +29,7 @@ jobs:
       - name: Get all changed php files (if PR)
         id: changed-php
         uses: tj-actions/changed-files@v43
-        if: github.event_name == 'pull_request'
+        if: env.gh_event == 'pull_request'
         with:
           files: |
             **.php
@@ -58,7 +67,7 @@ jobs:
       # - name: Get all changed php files (if PR)
       #   id: changed-php
       #   uses: tj-actions/changed-files@v43
-      #   if: github.event_name == 'pull_request'
+      #   if: env.gh_event == 'pull_request'
       #   with:
       #     files: |
       #        **.php
@@ -72,7 +81,7 @@ jobs:
             steps.changed-php.outputs.any_changed == 'true'
             ||
             (
-              github.event_name == 'push'
+              env.gh_event == 'push'
               && (
                    github.event.ref == 'refs/heads/develop'
                  || endsWith(github.event.ref, '.0')
@@ -94,7 +103,7 @@ jobs:
 
       - name: Run some pre-commit hooks on all files on push to "main" branches
         if: |
-          github.event_name == 'push'
+          env.gh_event == 'push'
           && (
                github.event.ref == 'refs/heads/develop'
              || endsWith(github.event.ref, '.0')

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -2,19 +2,26 @@
 name: Win CI
 # yamllint disable-line rule:truthy
 on:
-  push:
-  pull_request:
+  # push:
+  # pull_request:
+  workflow_call:
+    inputs:
+      gh_event:
+        required: true
+        type: string
   workflow_dispatch:
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+  group: win-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
     }}
   cancel-in-progress: true
 env:
+  gh_event: ${{ inputs.gh_event || github.event_name }}
   PHPUNIT_LOG: phpunit_tests.log
   DOLIBARR_LOG: documents/dolibarr.log
   PHPSERVER_LOG: phpserver.log
   PHPSERVER_DOMAIN_PORT: 127.0.0.1:8000  # could be 127.0.0.1:8000 if config modified
-  CACHE_KEY_PART: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}
+  CACHE_KEY_PART: ${{ ( inputs.gh_event == 'pull_request' || github.event_name == 'pull_request' ) && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}
   PHP_INI_SCAN_DIR: C:\myphpini
   CKEY: win-ci-2
   GITHUB_JSON: ${{ toJSON(github) }} # Helps in debugging Github Action


### PR DESCRIPTION
# Qual: Add dependencies between workflows

Run costly workflows only after a few workflows succeed (pre-commit, phan).


@eldy 
Here you have it!  Dependencies between workflows.

In practice it has to be one workflow, but I created 'ci.yml' to refer to the others.

ci.yml defines the dependencies as well.

gh-travis.yml tries to run the job on a github runner - it starts but fails at the point where it touches a file:
```
: touch(): Unable to create file /home/runner/.config/composer/config.json because Permission denied
```

Maybe you know why - I disable it for now.