### PR TITLE
FIX  #29029 Impossible to delete an order line

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4445,7 +4445,7 @@ class OrderLine extends CommonOrderLine
 
 			dol_syslog("OrderLine::delete", LOG_DEBUG);
 			$resql = $this->db->query($sql);
-			if ($resql) {
+			if (!$resql) {
 				$this->error = $this->db->lasterror();
 				$error++;
 			}


### PR DESCRIPTION
FIX #29029  Impossible to delete a line because the code lead to add an error if the request is valid therefore leading to a rollback of the request
