### PR TITLE
allow user self + useradministrator to modify a users bank account

### DIFF
--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -282,7 +282,7 @@ llxHeader('', $title, $help_url);
 
 $head = user_prepare_head($object);
 
-if ($id && $bankid && $action == 'edit' && !$cancel && $permissiontoaddbankaccount)) {
+if ($id && $bankid && $action == 'edit' && !$cancel && $permissiontoaddbankaccount) {
 	if ($conf->use_javascript_ajax) {
 		print "\n<script>";
 		print 'jQuery(document).ready(function () {
@@ -303,7 +303,7 @@ if ($id && $bankid && $action == 'edit' && !$cancel && $permissiontoaddbankaccou
 	print '<input type="hidden" name="id" value="'.GETPOSTINT("id").'">';
 	print '<input type="hidden" name="bankid" value="'.$bankid.'">';
 }
-if ($id && $action == 'create' && !$cancel && $permissiontoaddbankaccount)) {
+if ($id && $action == 'create' && !$cancel && $permissiontoaddbankaccount) {
 	if ($conf->use_javascript_ajax) {
 		print "\n<script>";
 		print 'jQuery(document).ready(function () {

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -85,13 +85,13 @@ if (empty($account->userid)) {
 }
 
 // Define value to know what current user can do on users
-$selfpermission = ( $user->id == $id && $user->hasRight('user', 'self', 'creer'));
+$selfpermission = ($user->id == $id && $user->hasRight('user', 'self', 'creer'));
 $canadduser = (!empty($user->admin) || $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write') );
 $canreaduser = (!empty($user->admin) || $user->hasRight('user', 'user', 'lire') || $user->hasRight('hrm', 'read_personal_information', 'read') );
 $permissiontoaddbankaccount = ($user->hasRight('salaries', 'write') || $user->hasRight('hrm', 'employee', 'write') || $user->hasRight('user', 'user', 'creer') || $selfpermission);
 $permissiontoreadhr = $user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write');
 $permissiontowritehr = $user->hasRight('hrm', 'write_personal_information', 'write');
-$permissiontosimpleedit = ( $selfpermission || $canadduser );
+$permissiontosimpleedit = ($selfpermission || $canadduser);
 
 // Ok if user->hasRight('salaries', 'readall') or user->hasRight('hrm', 'read')
 //$result = restrictedArea($user, 'salaries|hrm', $object->id, 'user&user', $feature2);
@@ -495,7 +495,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	}
 
 	// Personal email
-	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || $permissiontosimpleedit) {
+	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || ) {
 		print '<tr class="nowrap">';
 		print '<td>';
 		print $form->editfieldkey("UserPersonalEmail", 'personal_email', $object->personal_email, $object, $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write'));
@@ -506,7 +506,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	}
 
 	// Personal phone
-	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || $permissiontosimpleedit) {
+	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || ) {
 		print '<tr class="nowrap">';
 		print '<td>';
 		print $form->editfieldkey("UserPersonalMobile", 'personal_mobile', $object->personal_mobile, $object, $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write'));

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -85,8 +85,8 @@ if (empty($account->userid)) {
 }
 
 // Define value to know what current user can do on users
-$canadduser = (!empty($user->admin) || $user->hasRight('user', 'user', 'creer') || $user->rights->hrm->write_personal_information->write);
-$canreaduser = (!empty($user->admin) || $user->rights->user->user->lire || $user->rights->hrm->read_personal_information->read);
+$canadduser = (!empty($user->admin) || $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write') );
+$canreaduser = (!empty($user->admin) || $user->hasRight('user', 'user', 'lire') || $user->hasRight('hrm', 'read_personal_information', 'read') );
 $permissiontoaddbankaccount = ($user->hasRight('salaries', 'write') || $user->hasRight('hrm', 'employee', 'write') || $user->hasRight('user', 'user', 'creer') || $user->hasRight('user', 'self', 'creer'));
 $permissiontoreadhr = $user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write');
 $permissiontowritehr = $user->hasRight('hrm', 'write_personal_information', 'write');

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -282,7 +282,7 @@ llxHeader('', $title, $help_url);
 
 $head = user_prepare_head($object);
 
-if ($id && $bankid && $action == 'edit' && ($user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write'))) {
+if ($id && $bankid && $action == 'edit' && !$cancel && $permissiontoaddbankaccount)) {
 	if ($conf->use_javascript_ajax) {
 		print "\n<script>";
 		print 'jQuery(document).ready(function () {
@@ -303,7 +303,7 @@ if ($id && $bankid && $action == 'edit' && ($user->hasRight('user', 'user', 'cre
 	print '<input type="hidden" name="id" value="'.GETPOSTINT("id").'">';
 	print '<input type="hidden" name="bankid" value="'.$bankid.'">';
 }
-if ($id && $action == 'create' && $user->hasRight('user', 'user', 'creer')) {
+if ($id && $action == 'create' && !$cancel && $permissiontoaddbankaccount)) {
 	if ($conf->use_javascript_ajax) {
 		print "\n<script>";
 		print 'jQuery(document).ready(function () {

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -87,7 +87,7 @@ if (empty($account->userid)) {
 // Define value to know what current user can do on users
 $canadduser = (!empty($user->admin) || $user->hasRight('user', 'user', 'creer') || $user->rights->hrm->write_personal_information->write);
 $canreaduser = (!empty($user->admin) || $user->rights->user->user->lire || $user->rights->hrm->read_personal_information->read);
-$permissiontoaddbankaccount = ($user->hasRight('salaries', 'write') || $user->hasRight('hrm', 'employee', 'write') || $user->hasRight('user', 'creer'));
+$permissiontoaddbankaccount = ($user->hasRight('salaries', 'write') || $user->hasRight('hrm', 'employee', 'write') || $user->hasRight('user', 'user', 'creer') || $user->hasRight('user', 'self', 'creer'));
 $permissiontoreadhr = $user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write');
 $permissiontowritehr = $user->hasRight('hrm', 'write_personal_information', 'write');
 

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -85,19 +85,21 @@ if (empty($account->userid)) {
 }
 
 // Define value to know what current user can do on users
+$selfpermission = ( $user->id == $id && $user->hasRight('user', 'self', 'creer'));
 $canadduser = (!empty($user->admin) || $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write') );
 $canreaduser = (!empty($user->admin) || $user->hasRight('user', 'user', 'lire') || $user->hasRight('hrm', 'read_personal_information', 'read') );
-$permissiontoaddbankaccount = ($user->hasRight('salaries', 'write') || $user->hasRight('hrm', 'employee', 'write') || $user->hasRight('user', 'user', 'creer') || $user->hasRight('user', 'self', 'creer'));
+$permissiontoaddbankaccount = ($user->hasRight('salaries', 'write') || $user->hasRight('hrm', 'employee', 'write') || $user->hasRight('user', 'user', 'creer') || $selfpermission);
 $permissiontoreadhr = $user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write');
 $permissiontowritehr = $user->hasRight('hrm', 'write_personal_information', 'write');
+$permissiontosimpleedit = ( $selfpermission || $canadduser );
 
-// Ok if user->hasRight('salaries', 'read') or user->hasRight('hrm', 'read')
+// Ok if user->hasRight('salaries', 'readall') or user->hasRight('hrm', 'read')
 //$result = restrictedArea($user, 'salaries|hrm', $object->id, 'user&user', $feature2);
 $ok = false;
 if ($user->id == $id) {
 	$ok = true; // A user can always read its own card
 }
-if ($user->hasRight('salaries', 'read')) {
+if ($user->hasRight('salaries', 'readall')) {
 	$ok = true;
 }
 if ($user->hasRight('hrm', 'read')) {
@@ -201,7 +203,7 @@ if ($action == 'setbirth' && $canadduser && !$cancel) {
 }
 
 // update personal email
-if ($action == 'setpersonal_email' && $canadduser && !$cancel) {
+if ($action == 'setpersonal_email' && $permissiontosimpleedit && !$cancel) {
 	$object->personal_email = (string) GETPOST('personal_email', 'alphanohtml');
 	$result = $object->update($user);
 	if ($result < 0) {
@@ -210,7 +212,7 @@ if ($action == 'setpersonal_email' && $canadduser && !$cancel) {
 }
 
 // update personal mobile
-if ($action == 'setpersonal_mobile' && $canadduser && !$cancel) {
+if ($action == 'setpersonal_mobile' && $permissiontosimpleedit && !$cancel) {
 	$object->personal_mobile = (string) GETPOST('personal_mobile', 'alphanohtml');
 	$result = $object->update($user);
 	if ($result < 0) {
@@ -493,7 +495,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	}
 
 	// Personal email
-	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write')) {
+	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || $permissiontosimpleedit) {
 		print '<tr class="nowrap">';
 		print '<td>';
 		print $form->editfieldkey("UserPersonalEmail", 'personal_email', $object->personal_email, $object, $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write'));
@@ -504,7 +506,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	}
 
 	// Personal phone
-	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write')) {
+	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || $permissiontosimpleedit) {
 		print '<tr class="nowrap">';
 		print '<td>';
 		print $form->editfieldkey("UserPersonalMobile", 'personal_mobile', $object->personal_mobile, $object, $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write'));
@@ -895,7 +897,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 }
 
 // Edit
-if ($id && ($action == 'edit' || $action == 'create') && $user->hasRight('user', 'user', 'creer')) {
+if ($id && ($action == 'edit' || $action == 'create') && $permissiontoaddbankaccount) {
 	$title = $langs->trans("User");
 	print dol_get_fiche_head($head, 'bank', $title, 0, 'user');
 
@@ -1030,11 +1032,11 @@ if ($id && ($action == 'edit' || $action == 'create') && $user->hasRight('user',
 	print $form->buttonsSaveCancel($action == 'create' ? "Create" : "Modify");
 }
 
-if ($id && $action == 'edit' && $user->hasRight('user', 'user', 'creer')) {
+if ($id && $action == 'edit' && $permissiontoaddbankaccount) {
 	print '</form>';
 }
 
-if ($id && $action == 'create' && $user->hasRight('user', 'user', 'creer')) {
+if ($id && $action == 'create' && $permissiontoaddbankaccount) {
 	print '</form>';
 }
 


### PR DESCRIPTION
FIX #27028 allow user self + useradministrator to modify a users bank/email/phone information
Both user and a useradministrator can now add, edit and delete a users bank account.
Still only one bank account is possible. 
User can now no longer visit /user/bank.php?id= with any user ID and view their bank account details.
User can now change their own email and phone information.
