### PR TITLE
Fix & Enable PhanTypeInvalidPropertyName

### DIFF
--- a/dev/tools/codespell/codespell-dict.txt
+++ b/dev/tools/codespell/codespell-dict.txt
@@ -15,6 +15,7 @@ dolibar->dolibarr
 dolibarrr->dolibarr
 dollibar->dolibarr
 dollibarr->dolibarr
+extrafeild->extrafield
 thoose->those
 # fiche->card
 mot de passe->password

--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -483,7 +483,7 @@ return [
 		// 'PhanTypeInvalidRightOperandOfAdd',
 		// 'PhanPluginDescriptionlessCommentOnPrivateProperty',
 		// 'PhanUndeclaredVariableDim',  // Array initialisation on undeclared var: $abc['x']='ab'
-		'PhanTypeInvalidPropertyName',
+		// 'PhanTypeInvalidPropertyName',
 		'PhanPluginDuplicateCatchStatementBody',
 		'PhanPluginUndeclaredVariableIsset',
 		// 'PhanTypeInvalidUnaryOperandIncOrDec',

--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -270,7 +270,7 @@ return [
 		'langs' => '\Translate',
 		'leftmenu' => 'string',
 		'mainmenu' => 'string',
-		'menumanager' => 'string',
+		'menumanager' => '\MenuManager',
 		'mysoc' => '\Societe',
 		'nblines' => '\int',
 		'obj' => '\CommonObject',     // Deprecated

--- a/dev/tools/phan/config_extended.php
+++ b/dev/tools/phan/config_extended.php
@@ -210,7 +210,7 @@ return [
 		'dolibarr_main_data_root' => 'string',
 		'dolibarr_main_authentication' => 'string',
 		'dolibarr_main_demo' => 'string',
-		'menumanager' => 'string',
+		'menumanager' => '\MenuManager',
 		'errormsg' => 'string',
 		'form' => '\Form',
 		'object_rights' => 'int|stdClass',

--- a/htdocs/comm/mailing/class/html.formadvtargetemailing.class.php
+++ b/htdocs/comm/mailing/class/html.formadvtargetemailing.class.php
@@ -282,8 +282,8 @@ class FormAdvTargetEmailing extends Form
 	 * Return multiselect list of entities for extrafield type sellist
 	 *
 	 * @param string $htmlname control name
-	 * @param array $sqlqueryparam array
-	 * @param array $selected_array array
+	 * @param array<string,string> $sqlqueryparam array
+	 * @param string[] $selected_array array
 	 *
 	 *  @return	string HTML combo
 	 */

--- a/htdocs/comm/mailing/class/html.formadvtargetemailing.class.php
+++ b/htdocs/comm/mailing/class/html.formadvtargetemailing.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2014       Florian Henry           <florian.henry@open-concept.pro>
  * Copyright (C) 2019       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -278,7 +279,7 @@ class FormAdvTargetEmailing extends Form
 	}
 
 	/**
-	 * Return multiselect list of entities for extrafeild type sellist
+	 * Return multiselect list of entities for extrafield type sellist
 	 *
 	 * @param string $htmlname control name
 	 * @param array $sqlqueryparam array

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8786,8 +8786,8 @@ class Form
 	 * Show a multiselect form from an array. WARNING: Use this only for short lists.
 	 *
 	 * @param 	string 		$htmlname 		Name of select
-	 * @param 	array 		$array 			Array(key=>value) or Array(key=>array('id'=>key, 'label'=>value, 'color'=> , 'picto'=> , 'labelhtml'=> ))
-	 * @param 	array 		$selected 		Array of keys preselected
+	 * @param 	array<string,string|array{id:string,label:string,color:string,picto:string,labelhtml:string}>	$array 			Array(key=>value) or Array(key=>array('id'=>key, 'label'=>value, 'color'=> , 'picto'=> , 'labelhtml'=> ))
+	 * @param 	string[]	$selected 		Array of keys preselected
 	 * @param 	int 		$key_in_label 	1 to show key like in "[key] value"
 	 * @param 	int 		$value_as_key 	1 to use value as key
 	 * @param 	string 		$morecss 		Add more css style

--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -2778,9 +2778,9 @@ function migrate_project_task_actors($db, $langs, $conf)
  * @param	Translate	$langs			Object langs
  * @param	Conf		$conf			Object conf
  * @param	string		$table			Table name
- * @param	int			$fk_source		Id of element source
+ * @param	string		$fk_source		Id of element source (name of field)
  * @param	string		$sourcetype		Type of element source
- * @param	int			$fk_target		Id of element target
+ * @param	string		$fk_target		Id of element target
  * @param	string		$targettype		Type of element target
  * @return	void
  */

--- a/htdocs/reception/contact.php
+++ b/htdocs/reception/contact.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2005      Patrick Rouillon     <patrick@rouillon.net>
  * Copyright (C) 2005-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012 Regis Houssin        <regis.houssin@capnetworks.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/reception/dispatch.php
+++ b/htdocs/reception/dispatch.php
@@ -94,7 +94,7 @@ if ($id > 0 || !empty($ref)) {
 	if ($origin == 'order_supplier' && $object->origin_object->id && (isModEnabled("fournisseur") && !getDolGlobalString('MAIN_USE_NEW_SUPPLIERMOD') || isModEnabled("supplier_order"))) {
 		$origin_id = $object->origin_object->id;
 		$objectsrc = new CommandeFournisseur($db);
-		$objectsrc->fetch($object->origin_object->id);
+		$objectsrc->fetch($origin_id);
 	}
 }
 

--- a/htdocs/reception/document.php
+++ b/htdocs/reception/document.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2005-2012 Regis Houssin         <regis.houssin@inodbox.com>
  * Copyright (C) 2013      Cédric Salvador       <csalvador@gpcsolutions.fr>
  * Copyright (C) 2017      Ferran Marcet       	 <fmarcet@2byte.es>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/reception/note.php
+++ b/htdocs/reception/note.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2004-2008 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012  Regis Houssin        <regis.houssin@capnetworks.com>
  * Copyright (C) 2013 	   Florian Henry        <florian.henry@open-concept.pro>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -495,7 +495,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	}
 
 	// Personal email
-	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || $permissiontosimpleedit) {
+	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || ) {
 		print '<tr class="nowrap">';
 		print '<td>';
 		print $form->editfieldkey("UserPersonalEmail", 'personal_email', $object->personal_email, $object, $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write'));
@@ -506,7 +506,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	}
 
 	// Personal phone
-	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || $permissiontosimpleedit) {
+	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || ) {
 		print '<tr class="nowrap">';
 		print '<td>';
 		print $form->editfieldkey("UserPersonalMobile", 'personal_mobile', $object->personal_mobile, $object, $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write'));

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -495,7 +495,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	}
 
 	// Personal email
-	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || ) {
+	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || $permissiontosimpleedit) {
 		print '<tr class="nowrap">';
 		print '<td>';
 		print $form->editfieldkey("UserPersonalEmail", 'personal_email', $object->personal_email, $object, $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write'));
@@ -506,7 +506,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	}
 
 	// Personal phone
-	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || ) {
+	if ($user->hasRight('hrm', 'read_personal_information', 'read') || $user->hasRight('hrm', 'write_personal_information', 'write') || $permissiontosimpleedit) {
 		print '<tr class="nowrap">';
 		print '<td>';
 		print $form->editfieldkey("UserPersonalMobile", 'personal_mobile', $object->personal_mobile, $object, $user->hasRight('user', 'user', 'creer') || $user->hasRight('hrm', 'write_personal_information', 'write'));


### PR DESCRIPTION
# Fix & Enable PhanTypeInvalidPropertyName

This PR fixes several PhanTypeInvalidPropertyName occurences, except the follwoing.

## htdocs\comm\mailing\class\html.formadvtargetemailing.class.php

There is a test  `empty($InfoFieldList[1])` suggesting that this field can be empty, but it is then used untested as a property name - strange.

## pdf_ classes
The `$arrayidcontact = $object->$origin->getIdContact('external', 'SHIPPING');` assignments in the pdf_* classes were not fixed.
It seems that this assignment should be avoided: it seems to be done already once earlier in the method and IMHO the `$arrayidcontact` value should be reused as the first assignement qualifies that $object->$origin is an object, where the second assignement does not.
However, I prefer that a person with more dolibarr experience checks that out.

(Apart from the above, the PhanTypeInvalidPropertyName are fixed.