### PR TITLE
Fixes for PhanPluginUnknownObjectMethodCall

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -24,6 +24,7 @@ return [
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
+        'htdocs/adherents/admin/member.php' => ['PhanParamTooMany'],
         'htdocs/adherents/type.php' => ['PhanPluginDuplicateExpressionBinaryOp'],
         'htdocs/admin/receiptprinter.php' => ['PhanRedefineFunctionInternal'],
         'htdocs/api/class/api_documents.class.php' => ['PhanPluginDuplicateExpressionBinaryOp'],

--- a/dev/tools/phan/stubs/multicompany.php
+++ b/dev/tools/phan/stubs/multicompany.php
@@ -1,5 +1,7 @@
 <?php
 /* Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ *
+ * Note: in this context Entity == Company.
  */
 class ActionsMulticompany
 {
@@ -9,12 +11,83 @@ class ActionsMulticompany
 	public function __construct($db)
 	{
 	}
-	/** @ver string */
+	/** @var string */
 	public $id;
-	/** @ver string */
+	/** @var string */
 	public $label;
 	/** @var array{stock:string[],referent:string} */
 	public $sharings;
-	/** @ver DoliDB */
+	/** @var DoliDB */
 	public $db;
+
+	/**
+	 * @param string $login
+	 * @param bool $bool1
+	 * @param bool $bool2
+	 * @return array<int,string>
+	 */
+	public function getEntitiesList($login = '', $bool1 = false, $bool2 = false)
+	{
+	}
+
+	/**
+	 * @param string $entity
+	 * @return void
+	 */
+	public function getInfo($entity)
+	{
+	}
+
+	/**
+	 * @param int $id
+	 * @param string $key
+	 * @param string $param_str
+	 * @param bool $bool1
+	 * @param bool $bool2
+	 * @param bool $bool3
+	 * @param bool $bool4
+	 * @param bool $bool5
+	 * @return string */
+	public function select_entities($id, $key = '', $param_str = '', $bool1 = false, $bool2 = false, $bool3 = false, $bool4 = false, $bool5 = false)
+	{
+	}
+
+	/**
+	 * @param Conf $conf
+	 * @return void
+	 */
+	public function setValues($conf)
+	{
+	}
+	/**
+	 * @param string $element
+	 * @param int<0,1> $shared
+	 * @param ?CommonObject $currentobject
+	 * @return string
+	 */
+	public function getEntity($element, $shared = 1, $currentobject = 0)
+	{
+	}
+	/**
+	 * @param CommonObject $currentobject
+	 * @return int
+	 */
+	public function setEntity($currentobject)
+	{
+	}
+	/**
+	 * @param int $entityid
+	 * @return int<-1,0>
+	 */
+	public function switchEntity($entityid)
+	{
+	}
+	/**
+	 * @param int $id
+	 * @param string $entitytotest
+	 * @return int
+	 */
+	public function checkRight($id, $entitytotest)
+	{
+	}
 }

--- a/htdocs/adherents/admin/member.php
+++ b/htdocs/adherents/admin/member.php
@@ -10,6 +10,7 @@
  * Copyright (C) 2015      Jean-François Ferry  <jfefe@aternatik.fr>
  * Copyright (C) 2020-2021 Frédéric France      <frederic.france@netlogic.fr>
  * Copyright (C) 2023		Waël Almoman		<info@almoman.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -286,6 +287,7 @@ foreach ($dirModMember as $dirroot) {
 }
 
 $arrayofmodules = dol_sort_array($arrayofmodules, 'position');
+'@phan-var-force array<string,ModeleNumRefMembers> $arrayofmodules';
 
 foreach ($arrayofmodules as $file => $modCodeMember) {
 	print '<tr class="oddeven">'."\n";

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -674,6 +674,7 @@ class Adherent extends CommonObject
 						require_once $modfile;
 						$modname = getDolGlobalString('MEMBER_CODEMEMBER_ADDON');
 						$modCodeMember = new $modname();
+						'@phan-var-force ModeleNumRefMembers $modCodeMember';
 						$this->ref = $modCodeMember->getNextValue($mysoc, $this);
 					} catch (Exception $e) {
 						dol_syslog($e->getMessage(), LOG_ERR);

--- a/htdocs/admin/agenda_other.php
+++ b/htdocs/admin/agenda_other.php
@@ -137,6 +137,7 @@ if ($action == 'set') {
 		require_once $file;
 
 		$module = new $classname($db, $commande);
+		'@phan-var-force pdf_standard_actions $module';
 
 		if ($module->write_file($commande, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=action&file=SPECIMEN.pdf");

--- a/htdocs/admin/agenda_reminder.php
+++ b/htdocs/admin/agenda_reminder.php
@@ -100,6 +100,7 @@ if ($action == 'set') {
 		require_once $file;
 
 		$module = new $classname($db, $commande);
+		'@phan-var-force pdf_standard_actions $module';
 
 		if ($module->write_file($commande, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=action&file=SPECIMEN.pdf");

--- a/htdocs/admin/bank.php
+++ b/htdocs/admin/bank.php
@@ -145,6 +145,7 @@ if ($action == 'specimen') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force ModeleBankAccountDoc $module';
 
 		if ($module->write_file($object, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=bank&file=SPECIMEN.pdf");

--- a/htdocs/admin/barcode.php
+++ b/htdocs/admin/barcode.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2004-2015	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2005-2012	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2011-2013	Juanjo Menent			<jmenent@2byte.es>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -189,7 +190,7 @@ foreach ($dirbarcode as $reldir) {
 		}
 	}
 }
-
+'@phan-var-force array<string,ModeleBarCode> $barcodelist';
 
 
 // Select barcode numbering module
@@ -224,6 +225,7 @@ if (isModEnabled('product')) {
 					}
 
 					$modBarCode = new $file();
+					'@phan-var-force ModeleNumRefBarCode $modBarCode';
 
 					print '<tr class="oddeven">';
 					print '<td>'.(isset($modBarCode->name) ? $modBarCode->name : $modBarCode->nom)."</td><td>\n";

--- a/htdocs/admin/bom.php
+++ b/htdocs/admin/bom.php
@@ -90,6 +90,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force ModelePDFBom $module';
 
 		if ($module->write_file($bom, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=bom&file=SPECIMEN.pdf");

--- a/htdocs/admin/chequereceipts.php
+++ b/htdocs/admin/chequereceipts.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2010-2016  Juanjo Menent	       <jmenent@2byte.es>
  * Copyright (C) 2013-2018  Philippe Grand             <philippe.grand@atoo-net.com>
  * Copyright (C) 2015       Jean-François Ferry         <jfefe@aternatik.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -151,6 +152,7 @@ foreach ($dirmodels as $reldir) {
 						require_once $dir.$filebis;
 
 						$module = new $classname($db);
+						'@phan-var-force ModeleNumRefChequeReceipts $module';
 
 						// Show modules according to features level
 						if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {

--- a/htdocs/admin/commande.php
+++ b/htdocs/admin/commande.php
@@ -100,6 +100,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force ModelePDFCommandes $module';
 
 		if ($module->write_file($commande, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=commande&file=SPECIMEN.pdf");

--- a/htdocs/admin/contract.php
+++ b/htdocs/admin/contract.php
@@ -96,6 +96,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force ModelePDFContract $module';
 
 		if ($module->write_file($contract, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=contract&file=SPECIMEN.pdf");

--- a/htdocs/admin/delivery.php
+++ b/htdocs/admin/delivery.php
@@ -145,6 +145,7 @@ if ($action == 'specimen') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force ModelePDFDeliveryOrder $module';
 
 		if ($module->write_file($sending, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=delivery&file=SPECIMEN.pdf");

--- a/htdocs/admin/expedition.php
+++ b/htdocs/admin/expedition.php
@@ -116,6 +116,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force ModelePdfExpedition $module';
 
 		if ($module->write_file($exp, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=expedition&file=SPECIMEN.pdf");

--- a/htdocs/admin/expensereport.php
+++ b/htdocs/admin/expensereport.php
@@ -97,6 +97,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force ModeleExpenseReport $module';
 
 		if ($module->write_file($expensespecimen, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=expensereport&file=SPECIMEN.pdf");

--- a/htdocs/admin/fichinter.php
+++ b/htdocs/admin/fichinter.php
@@ -96,6 +96,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force ModelePDFFicheinter $module';
 
 		if ($module->write_file($inter, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=ficheinter&file=SPECIMEN.pdf");

--- a/htdocs/admin/holiday.php
+++ b/htdocs/admin/holiday.php
@@ -96,6 +96,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($holiday, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=holiday&file=SPECIMEN.pdf");

--- a/htdocs/admin/hrm.php
+++ b/htdocs/admin/hrm.php
@@ -140,6 +140,7 @@ if ($action == 'update') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($tmpobject, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=".strtolower($tmpobjectkey)."&file=SPECIMEN.pdf");

--- a/htdocs/admin/invoice.php
+++ b/htdocs/admin/invoice.php
@@ -113,6 +113,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($facture, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=facture&file=SPECIMEN.pdf");

--- a/htdocs/admin/knowledgemanagement.php
+++ b/htdocs/admin/knowledgemanagement.php
@@ -123,6 +123,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $className($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($tmpobject, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=".strtolower($tmpobjectkey)."&file=SPECIMEN.pdf");

--- a/htdocs/admin/modules.php
+++ b/htdocs/admin/modules.php
@@ -864,6 +864,7 @@ if ($mode == 'common' || $mode == 'commonkanban') {
 			if (!empty($objMod->disabled)) {
 				$codeenabledisable .= $langs->trans("Disabled");
 			} elseif (!empty($objMod->always_enabled) || ((isModEnabled('multicompany') && $objMod->core_enabled) && ($user->entity || $conf->entity != 1))) {
+				// @phan-suppress-next-line PhanUndeclaredMethodCall
 				if (method_exists($objMod, 'alreadyUsed') && $objMod->alreadyUsed()) {
 					$codeenabledisable .= $langs->trans("Used");
 				} else {
@@ -874,6 +875,7 @@ if ($mode == 'common' || $mode == 'commonkanban') {
 					$disableSetup++;
 				}
 			} else {
+				// @phan-suppress-next-line PhanUndeclaredMethodCall
 				if (!empty($objMod->warnings_unactivation[$mysoc->country_code]) && method_exists($objMod, 'alreadyUsed') && $objMod->alreadyUsed()) {
 					$codeenabledisable .= '<a class="reposition valignmiddle" href="'.$_SERVER["PHP_SELF"].'?id='.$objMod->numero.'&amp;token='.newToken().'&amp;module_position='.$module_position.'&amp;action=reset_confirm&amp;confirm_message_code='.urlencode($objMod->warnings_unactivation[$mysoc->country_code]).'&amp;value='.$modName.'&amp;mode='.$mode.$param.'">';
 					$codeenabledisable .= img_picto($langs->trans("Activated").($warningstring ? ' '.$warningstring : ''), 'switch_on');

--- a/htdocs/admin/mrp.php
+++ b/htdocs/admin/mrp.php
@@ -91,6 +91,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($mo, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=mrp&file=SPECIMEN.pdf");

--- a/htdocs/admin/payment.php
+++ b/htdocs/admin/payment.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2015  Juanjo Menent				<jmenent@2byte.es>
  * Copyright (C) 2020  Maxime DEMAREST              <maxime@indelog.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -154,6 +155,7 @@ foreach ($dirmodels as $reldir) {
 						require_once $dir.$filebis;
 
 						$module = new $classname($db);
+						'@phan-var-force ModeleNumRefPayments $module';
 
 						// Show modules according to features level
 						if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {

--- a/htdocs/admin/propal.php
+++ b/htdocs/admin/propal.php
@@ -96,6 +96,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($propal, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=propal&file=SPECIMEN.pdf");

--- a/htdocs/admin/reception_setup.php
+++ b/htdocs/admin/reception_setup.php
@@ -119,6 +119,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($exp, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=reception&file=SPECIMEN.pdf");

--- a/htdocs/admin/security.php
+++ b/htdocs/admin/security.php
@@ -207,6 +207,7 @@ if (is_resource($handle)) {
 			require_once $dir.'/'.$file;
 
 			$obj = new $classname($db, $conf, $langs, $user);
+			'@phan-var-force ModeleGenPassword $obj';
 			$arrayhandler[$obj->id] = $obj;
 			$i++;
 		}

--- a/htdocs/admin/stock.php
+++ b/htdocs/admin/stock.php
@@ -123,6 +123,7 @@ if ($action == 'specimen') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($object, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=stock&file=SPECIMEN.pdf");
@@ -585,6 +586,7 @@ foreach ($dirmodels as $reldir) {
 
 							require_once $dir.'/'.$file;
 							$module = new $classname($db);
+							'@phan-var-force ModelePDFStock $module';
 
 							$modulequalified = 1;
 							if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {

--- a/htdocs/admin/stocktransfer.php
+++ b/htdocs/admin/stocktransfer.php
@@ -105,6 +105,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($tmpobject, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=".strtolower($tmpobjectkey)."&file=SPECIMEN.pdf");

--- a/htdocs/admin/supplier_invoice.php
+++ b/htdocs/admin/supplier_invoice.php
@@ -116,6 +116,7 @@ if ($action == 'specimen') {  // For invoices
 		require_once $file;
 
 		$module = new $classname($db, $facture);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($facture, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=facture_fournisseur&file=SPECIMEN.pdf");

--- a/htdocs/admin/supplier_order.php
+++ b/htdocs/admin/supplier_order.php
@@ -106,6 +106,7 @@ if ($action == 'specimen') {  // For orders
 		require_once $file;
 
 		$module = new $classname($db, $commande);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($commande, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=commande_fournisseur&file=SPECIMEN.pdf");

--- a/htdocs/admin/supplier_payment.php
+++ b/htdocs/admin/supplier_payment.php
@@ -117,6 +117,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($paiementFourn, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=supplier_payment&file=SPECIMEN.pdf");

--- a/htdocs/admin/supplier_proposal.php
+++ b/htdocs/admin/supplier_proposal.php
@@ -95,6 +95,7 @@ if ($action == 'specimen') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($supplier_proposal, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=supplier_proposal&file=SPECIMEN.pdf");
@@ -261,6 +262,7 @@ foreach ($dirmodels as $reldir) {
 					require_once $dir.'/'.$file.'.php';
 
 					$module = new $file();
+					'@phan-var-force ModeleNumRefSupplierProposal $module';
 
 					// Show modules according to features level
 					if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {
@@ -393,6 +395,7 @@ foreach ($dirmodels as $reldir) {
 
 							require_once $dir.'/'.$file;
 							$module = new $classname($db);
+							'@phan-var-force CommonDocGenerator $module';
 
 							$modulequalified = 1;
 							if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {

--- a/htdocs/admin/syslog.php
+++ b/htdocs/admin/syslog.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2007      Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (C) 2013	   Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -63,6 +64,7 @@ foreach ($dirsyslogs as $reldir) {
 					require_once $newdir.$file.'.php';
 
 					$module = new $file();
+					'@phan-var-force LogHandler $module';
 
 					// Show modules according to features level
 					if ($module->getVersion() == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {
@@ -96,6 +98,7 @@ if ($action == 'set') {
 	foreach ($syslogModules as $syslogHandler) {
 		if (in_array($syslogHandler, $syslogModules)) {
 			$module = new $syslogHandler();
+			'@phan-var-force LogHandler $module';
 
 			if (in_array($syslogHandler, $selectedModules)) {
 				$newActiveModules[] = $syslogHandler;
@@ -118,6 +121,7 @@ if ($action == 'set') {
 	// Check configuration
 	foreach ($activeModules as $modulename) {
 		$module = new $modulename();
+		'@phan-var-force LogHandler $module';
 		$res = $module->checkConfiguration();
 		if (!$res) {
 			$error++;
@@ -210,6 +214,7 @@ print "</tr>\n";
 
 foreach ($syslogModules as $moduleName) {
 	$module = new $moduleName();
+	'@phan-var-force LogHandler $module';
 
 	$moduleactive = (int) $module->isActive();
 	//print $moduleName." = ".$moduleactive." - ".$module->getName()." ".($moduleactive == -1)."<br>\n";

--- a/htdocs/admin/system/modules.php
+++ b/htdocs/admin/system/modules.php
@@ -115,6 +115,7 @@ foreach ($modulesdir as $dir) {
 						if (class_exists($modName)) {
 							try {
 								$objMod = new $modName($db);
+								'@phan-var-force DolibarrModules $objMod';
 
 								$modules[$objMod->numero] = $objMod;
 								$modules_files[$objMod->numero] = $file;
@@ -132,6 +133,7 @@ foreach ($modulesdir as $dir) {
 		closedir($handle);
 	}
 }
+'@phan-var-force array<string,DolibarrModules> $modules';
 
 // create pre-filtered list for modules
 foreach ($modules as $key => $module) {

--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2016       Christophe Battarel <christophe@altairis.fr>
  * Copyright (C) 2022-2023  Udo Tamm            <dev@dolibit.de>
  * Copyright (C) 2023       Alexandre Spangaro  <aspangaro@easya.solutions>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -289,6 +290,7 @@ foreach ($dirmodels as $reldir) {
 					include_once $dir.'/'.$file.'.php';
 
 					$module = new $file();
+					'@phan-var-force ModeleNumRefTicket $module';
 
 					// Show modules according to features level
 					if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {
@@ -423,6 +425,7 @@ foreach ($dirmodels as $reldir) {
 
 							require_once $dir.'/'.$file;
 							$module = new $classname($db);
+							'@phan-var-force CommonDocGenerator $module';
 
 							$modulequalified = 1;
 							if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {

--- a/htdocs/admin/user.php
+++ b/htdocs/admin/user.php
@@ -7,6 +7,7 @@
  * Copyright (C) 2005-2011	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2015		Juanjo Menent			<jmenent@2byte.es>
  * Copyright (C) 2020       Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -246,6 +247,7 @@ foreach ($dirmodels as $reldir) {
 
 							require_once $dir.'/'.$file;
 							$module = new $classname($db);
+							'@phan-var-force CommonDocGenerator $module';
 
 							$modulequalified = 1;
 							if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {

--- a/htdocs/admin/usergroup.php
+++ b/htdocs/admin/usergroup.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2004		Benoit Mortier			<benoit.mortier@opensides.be>
  * Copyright (C) 2005-2011	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2015		Juanjo Menent			<jmenent@2byte.es>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -169,6 +170,7 @@ foreach ($dirmodels as $reldir) {
 
 							require_once $dir.'/'.$file;
 							$module = new $classname($db);
+							'@phan-var-force CommonDocGenerator $module';
 
 							$modulequalified = 1;
 							if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {

--- a/htdocs/admin/workstation.php
+++ b/htdocs/admin/workstation.php
@@ -107,6 +107,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($tmpobject, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=".strtolower($tmpobjectkey)."&file=SPECIMEN.pdf");
@@ -260,6 +261,7 @@ foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 							require_once $dir.'/'.$file.'.php';
 
 							$module = new $file($db);
+							'@phan-var-force CommonNumRefGenerator $module';
 
 							// Show modules according to features level
 							if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {
@@ -399,6 +401,7 @@ foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 
 									require_once $dir.'/'.$file;
 									$module = new $classname($db);
+									'@phan-var-force CommonDocGenerator $module';
 
 									$modulequalified = 1;
 									if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {

--- a/htdocs/asset/admin/setup.php
+++ b/htdocs/asset/admin/setup.php
@@ -119,6 +119,7 @@ if ($action == 'updateMask') {
 		require_once $file;
 
 		$module = new $classname($db);
+		'@phan-var-force CommonDocGenerator $module';
 
 		if ($module->write_file($tmpobject, $langs) > 0) {
 			header("Location: ".DOL_URL_ROOT."/document.php?modulepart=".strtolower($tmpobjectkey)."&file=SPECIMEN.pdf");
@@ -232,6 +233,7 @@ foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 							require_once $dir.'/'.$file.'.php';
 
 							$module = new $file($db);
+							'@phan-var-force CommonNumRefGenerator $module';
 
 							// Show modules according to features level
 							if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {
@@ -371,6 +373,7 @@ foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 
 									require_once $dir.'/'.$file;
 									$module = new $classname($db);
+									'@phan-var-force CommonDocGenerator $module';
 
 									$modulequalified = 1;
 									if ($module->version == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {

--- a/htdocs/barcode/codeinit.php
+++ b/htdocs/barcode/codeinit.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2014-2022 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2018  	   Ferran Marcet 		<fmarcet@2byte.es>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -86,6 +87,7 @@ if (getDolGlobalString('BARCODE_THIRDPARTY_ADDON_NUM')) {
 					}
 
 					$modBarCodeThirdparty = new $file();
+					'@phan-var-force ModeleNumRefBarCode $module';
 					break;
 				}
 			}
@@ -190,6 +192,7 @@ if (getDolGlobalString('BARCODE_PRODUCT_ADDON_NUM')) {
 						}
 
 						$modBarCodeProduct = new $file();
+						'@phan-var-force ModeleNumRefBarCode $module';
 						break;
 					}
 				}

--- a/htdocs/barcode/printsheet.php
+++ b/htdocs/barcode/printsheet.php
@@ -179,6 +179,7 @@ if (empty($reshook)) {
 			// Load barcode class for generating barcode image
 			$classname = "mod".ucfirst($generator);
 			$module = new $classname($db);
+			'@phan-var-force ModeleBarCode $module';
 			if ($generator != 'tcpdfbarcode') {
 				// May be phpbarcode
 				$template = 'standardlabel';

--- a/htdocs/blockedlog/class/blockedlog.class.php
+++ b/htdocs/blockedlog/class/blockedlog.class.php
@@ -371,13 +371,13 @@ class BlockedLog
 	}
 
 	/**
-	 *      Populate properties of log from object data
+	 *	Populate properties of log from object data
 	 *
-	 *      @param		Object		$object     object to store
-	 *      @param		string		$action     action
-	 *      @param		string		$amounts    amounts
-	 *      @param		User		$fuser		User object (forced)
-	 *      @return		int						>0 if OK, <0 if KO
+	 *	@param	CommonObject	$object		object to store
+	 *	@param	string			$action		action
+	 *	@param	string			$amounts	amounts
+	 *	@param	?User			$fuser		User object (forced)
+	 *	@return	int							>0 if OK, <0 if KO
 	 */
 	public function setObjectData(&$object, $action, $amounts, $fuser = null)
 	{

--- a/htdocs/categories/viewcat.php
+++ b/htdocs/categories/viewcat.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2015       Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2020		Tobias Sekan		<tobias.sekan@startmail.com>
  * Copyright (C) 2020		Josep Lluís Amador  <joseplluis@lliuretic.cat>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -506,6 +507,7 @@ if ($type == Categorie::TYPE_PRODUCT) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var Product[] $prods */
+			'@phan-var-force Product[] $prods';
 			// Form to add record into the category
 			$showclassifyform = 1;
 			if ($showclassifyform) {
@@ -593,6 +595,7 @@ if ($type == Categorie::TYPE_CUSTOMER) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var Societe[] $socs */
+			'@phan-var-force Societe[] $socs';
 			// Form to add record into a category
 			$showclassifyform = 1;
 			if ($showclassifyform) {
@@ -679,6 +682,7 @@ if ($type == Categorie::TYPE_SUPPLIER) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var Fournisseur[] $socs */
+			'@phan-var-force Fournisseur[] $socs';
 			// Form to add record into a category
 			$showclassifyform = 1;
 			if ($showclassifyform) {
@@ -768,6 +772,7 @@ if ($type == Categorie::TYPE_MEMBER) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var Adherent[] $members */
+			'@phan-var-force Adherent[] $members';
 			// Form to add record into a category
 			$showclassifyform = 1;
 			if ($showclassifyform) {
@@ -856,6 +861,7 @@ if ($type == Categorie::TYPE_CONTACT) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var Contact[] $contacts */
+			'@phan-var-force Contact[] $contacts';
 			// Form to add record into a category
 			$showclassifyform = 1;
 			if ($showclassifyform) {
@@ -949,6 +955,7 @@ if ($type == Categorie::TYPE_ACCOUNT) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var Account[] $accounts */
+			'@phan-var-force Account[] $accounts';
 			// Form to add record into a category
 			$showclassifyform = 1;
 			if ($showclassifyform) {
@@ -1038,6 +1045,7 @@ if ($type == Categorie::TYPE_PROJECT) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var Project $object */
+			'@phan-var-force Project $object';
 			// Form to add record into a category
 			$showclassifyform = 1;
 			if ($showclassifyform) {
@@ -1125,6 +1133,7 @@ if ($type == Categorie::TYPE_USER) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var User[] $users */
+			'@phan-var-force User[] $users';
 			// Form to add record into a category
 			$showclassifyform = 1;
 			if ($showclassifyform) {
@@ -1211,6 +1220,7 @@ if ($type == Categorie::TYPE_WAREHOUSE) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var Entrepot[] $objects */
+			'@phan-var-force Entrepot[] $objects';
 			print '<form method="post" action="'.$_SERVER["PHP_SELF"].'">';
 			print '<input type="hidden" name="token" value="'.newToken().'">';
 			print '<input type="hidden" name="typeid" value="'.$typeid.'">';
@@ -1278,6 +1288,7 @@ if ($type == Categorie::TYPE_TICKET) {
 			dol_print_error($db, $object->error, $object->errors);
 		} else {
 			/** @var Ticket[] $tickets */
+			'@phan-var-force Ticket[] $tickets';
 			// Form to add record into a category
 			$showclassifyform = 1;
 			if ($showclassifyform) {

--- a/htdocs/comm/mailing/index.php
+++ b/htdocs/comm/mailing/index.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2005-2009 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2010      Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2019      Nicolas ZABOURI      <info@inovea-conseil.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -101,6 +102,7 @@ if (is_resource($handle)) {
 				$classname = "mailing_".$modulename;
 				require_once $file;
 				$mailmodule = new $classname($db);
+				'@phan-var-force MailingTargets $mailmodule';
 
 				$qualified = 1;
 				foreach ($mailmodule->require_module as $key) {

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4635,6 +4635,7 @@ class Facture extends CommonInvoice
 			}
 
 			$obj = new $classname();
+			'@phan-var-force CommonNumRefGenerator $obj';
 
 			$numref = $obj->getNextValue($soc, $this, $mode);
 

--- a/htdocs/compta/paiement/cheque/class/remisecheque.class.php
+++ b/htdocs/compta/paiement/cheque/class/remisecheque.class.php
@@ -450,6 +450,7 @@ class RemiseCheque extends CommonObject
 			}
 
 			$obj = new $classname();
+			'@phan-var-force CommonNumRefGenerator $obj';
 			$numref = "";
 			$numref = $obj->getNextValue($mysoc, $this);
 
@@ -590,6 +591,7 @@ class RemiseCheque extends CommonObject
 
 			$classname = 'BordereauCheque'.ucfirst($model);
 			$docmodel = new $classname($this->db);
+			'@phan-var-force CommonDocGenerator $module';
 
 			$sql = "SELECT b.banque, b.emetteur, b.amount, b.num_chq";
 			$sql .= " FROM ".MAIN_DB_PREFIX."bank as b";

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -346,6 +346,7 @@ class Contrat extends CommonObject
 			}
 
 			$obj = new $classname();
+			'@phan-var-force CommonNumRefGenerator $obj';
 			$numref = $obj->getNextValue($soc, $this);
 
 			if ($numref != "") {
@@ -1064,6 +1065,7 @@ class Contrat extends CommonObject
 			$result = dol_include_once('/core/modules/contract/'.$module.'.php');
 			if ($result > 0) {
 				$modCodeContract = new $module();
+				'@phan-var-force CommonNumRefGenerator $modCodeContrat';
 
 				if (!empty($modCodeContract->code_auto)) {
 					// Force the ref to a draft value if numbering module is an automatic numbering
@@ -2686,6 +2688,7 @@ class Contrat extends CommonObject
 		require_once DOL_DOCUMENT_ROOT."/core/modules/contract/" . getDolGlobalString('CONTRACT_ADDON').'.php';
 		$obj = getDolGlobalString('CONTRACT_ADDON');
 		$modContract = new $obj();
+		'@phan-var-force CommonNumRefGenerator $modContrat';
 		$clonedObj->ref = $modContract->getNextValue($objsoc, $clonedObj);
 
 		// get extrafields so they will be clone

--- a/htdocs/core/actions_printing.inc.php
+++ b/htdocs/core/actions_printing.inc.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2014-2016 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2014-2018 Frederic France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,6 +48,7 @@ if ($action == 'print_file' && $user->hasRight('printing', 'read')) {
 			require_once $classfile;
 			$classname = 'printing_'.$driver;
 			$printer = new $classname($db);
+			'@phan-var-force PrintingDriver $printer';
 			$langs->load($printer::LANGFILE);
 			//print '<pre>'.print_r($printer, true).'</pre>';
 

--- a/htdocs/core/boxes/box_dolibarr_state_board.php
+++ b/htdocs/core/boxes/box_dolibarr_state_board.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2004-2010 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2015-2024 Frederic France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -69,7 +70,7 @@ class box_dolibarr_state_board extends ModeleBoxes
 			$hookmanager->initHooks(array('index'));
 			$object = new stdClass();
 			$action = '';
-			$parameters =array();
+			$parameters = array();
 			$hookmanager->executeHooks('addStatisticLine', $parameters, $object, $action);
 			$boxstatItems = array();
 			$boxstatFromHook = '';
@@ -254,6 +255,7 @@ class box_dolibarr_state_board extends ModeleBoxes
 
 						$board = new $class($this->db);
 						if (method_exists($board, 'load_state_board')) {
+							// @phan-suppress-next-line PhanUndeclaredMethod  (Legacy, not present in core).
 							$board->load_state_board();
 						} elseif (method_exists($board, 'loadStateBoard')) {
 							$board->loadStateBoard();

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -336,10 +336,10 @@ function getDoliDBInstance($type, $host, $user, $pass, $name, $port)
  *									'contract', 'tax', 'expensereport', 'holiday', 'multicurrency', 'project',
  *									'email_template', 'event', 'donation'
  *									'c_paiement', 'c_payment_term', ...
- * 	@param	int		$shared			0=Return id of current entity only,
+ * 	@param	int<0,1>	$shared		0=Return id of current entity only,
  * 									1=Return id of current entity + shared entities (default)
- *  @param	object	$currentobject	Current object if needed
- * 	@return	mixed					Entity id(s) to use ( eg. entity IN ('.getEntity(elementname).')' )
+ *  @param	?CommonObject			$currentobject	Current object if needed
+ * 	@return	string					Entity id(s) to use ( eg. entity IN ('.getEntity(elementname).')' )
  */
 function getEntity($element, $shared = 1, $currentobject = null)
 {
@@ -401,8 +401,8 @@ function getEntity($element, $shared = 1, $currentobject = null)
 /**
  * 	Set entity id to use when to create an object
  *
- * 	@param	object	$currentobject	Current object
- * 	@return	mixed					Entity id to use ( eg. entity = '.setEntity($object) )
+ * 	@param	CommonObject	$currentobject	Current object
+ * 	@return	int								Entity id to use ( eg. entity = '.setEntity($object) )
  */
 function setEntity($currentobject)
 {

--- a/htdocs/core/modules/bank/doc/pdf_sepamandate.modules.php
+++ b/htdocs/core/modules/bank/doc/pdf_sepamandate.modules.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2016 Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2020 Josep Lluís Amador  <joseplluis@lliuretic.cat>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -115,7 +116,7 @@ class pdf_sepamandate extends ModeleBankAccountDoc
 	/**
 	 *  Function to create pdf of company bank account sepa mandate
 	 *
-	 *	@param	CompanyBankAccount	$object   		    Object bank account to generate document for
+	 *	@param	Account				$object				CompanyBankAccount bank account to generate document for
 	 *	@param	Translate			$outputlangs	    Lang output object
 	 *  @param	string				$srctemplatepath	Full path of source filename for generator using a template file
 	 *  @param	int					$hidedetails		Do not show line details (not used for this template)
@@ -128,6 +129,11 @@ class pdf_sepamandate extends ModeleBankAccountDoc
 	{
 		// phpcs:enable
 		global $conf, $hookmanager, $langs, $user, $mysoc;
+
+		if (!$object instanceof CompanyBankAccount) {
+			dol_syslog(get_class($this)."::write_file object is of type ".get_class($object)." which is not expected", LOG_ERR);
+			return -1;
+		}
 
 		if (!is_object($outputlangs)) {
 			$outputlangs = $langs;

--- a/htdocs/core/modules/bank/modules_bank.php
+++ b/htdocs/core/modules/bank/modules_bank.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010-2014	Regis Houssin	<regis.houssin@inodbox.com>
  * Copyright (C) 2014       Marcos García   <marcosgdf@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,4 +51,15 @@ abstract class ModeleBankAccountDoc extends CommonDocGenerator
 
 		return $list;
 	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *	Write the document to disk
+	 *
+	 *	@param	Account		$object   		Object Account to generate
+	 *	@param	Translate	$outputlangs	Lang output object
+	 *	@return	int         				1 if OK, <=0 if KO
+	 */
+	abstract public function write_file($object, $outputlangs);
+	// phpcs:enable
 }

--- a/htdocs/core/modules/printing/modules_printing.php
+++ b/htdocs/core/modules/printing/modules_printing.php
@@ -1,6 +1,7 @@
 <?php
 /*
  * Copyright (C) 2014-2023 Frederic France      <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +32,9 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
  */
 class PrintingDriver
 {
+	/** Force subclass to implement LANGFILE */
+	const LANGFILE = self::LANGFILE;
+
 	/**
 	 * @var DoliDB Database handler.
 	 */
@@ -70,8 +74,8 @@ class PrintingDriver
 	 *  Return list of printing driver
 	 *
 	 *  @param  DoliDB  $db                 Database handler
-	 *  @param  integer  $maxfilenamelength  Max length of value to show
-	 *  @return array                       List of drivers
+	 *  @param  int		$maxfilenamelength	Max length of value to show
+	 *  @return array<string,string>		List of drivers
 	 */
 	public static function listDrivers($db, $maxfilenamelength = 0)
 	{

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -777,6 +777,7 @@ class Product extends CommonObject
 				}
 				dol_include_once('/core/modules/product/'.$module.'.php');
 				$modCodeProduct = new $module();
+				'@phan-var-force ModeleProductCode $modCodeProduct';
 				if (!empty($modCodeProduct->code_auto)) {
 					$this->ref = $modCodeProduct->getNextValue($this, $this->type);
 				}
@@ -1048,6 +1049,7 @@ class Product extends CommonObject
 			}
 
 			$mod = new $module();
+			'@phan-var-force ModeleNumRefBarCode $mod';
 
 			dol_syslog(get_class($this)."::check_barcode value=".$valuetotest." type=".$typefortest." module=".$module);
 			$result = $mod->verif($this->db, $valuetotest, $this, 0, $typefortest);
@@ -6358,6 +6360,7 @@ class Product extends CommonObject
 			}
 			$var = getDolGlobalString('BARCODE_PRODUCT_ADDON_NUM');
 			$mod = new $var();
+			'@phan-var-force ModeleNumRefBarCode $module';
 
 			$result = $mod->getNextValue($object, $type);
 

--- a/htdocs/public/payment/paymentko.php
+++ b/htdocs/public/payment/paymentko.php
@@ -46,6 +46,8 @@ if (is_numeric($entity)) {
 	define("DOLENTITY", $entity);
 }
 
+'@phan-var-force CommonObject $object';
+
 // Load Dolibarr environment
 require '../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';


### PR DESCRIPTION
# Fixes for PhanPluginUnknownObjectMethodCall

This fixes several PhanPluginUnknownObjectMethodCall notices which transform most of the time ito a PhanUndeclaredMethod because the parent class does not declare the abstract method that is supposed to be available on the child classes (write_file, getNextValue, getExample, ... .

The issue for  member.php is real - the related getToolTip method only takes 2 arguments
```
PhanParamTooMany: Call with 3 arg(s) to \ModeleNumRefMembers::getToolTip(\Translate $langs, \Societe $soc) which only takes 2 arg(s) defined at htdocs/core/modules/member/modules_member.class.php:74
```

@eldy: you know that in the CTI log there are notifications for htdocs/custom/mymodule which are not part of this repository?!