### PR TITLE
FIX: last arg is for showempty, not for a translation / label ...

### DIFF
--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -786,7 +786,7 @@ class FormSetupItem
 
 		$tmp = explode(':', $this->type);
 		$out= img_picto('', 'category', 'class="pictofixedwidth"');
-		$out.= $formother->select_categories($tmp[1],  $this->fieldValue, $this->confKey, 0, $this->langs->trans('CustomersProspectsCategoriesShort'));
+		$out.= $formother->select_categories($tmp[1],  $this->fieldValue, $this->confKey, 0, 1);
 		return $out;
 	}
 


### PR DESCRIPTION
That function is

```
public function select_categories($type, $selected = 0, $htmlname = 'search_categ', $nocateg = 0, $showempty = 1, $morecss = '')
```

Then i don't know why showempty was set from a translation ... 