### PR TITLE
Pull request for Issue FIX|Fix #29031 18.0 - Restore last search values

### DIFF
--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -132,7 +132,7 @@ if (GETPOSTISARRAY('search_status')) {
 	$search_status = join(',', GETPOST('search_status', 'array:intcomma'));
 } else {
 	$search_status = (GETPOST('search_status', 'intcomma') != '' ? GETPOST('search_status', 'intcomma') : GETPOST('statut', 'intcomma'));
-    if ( is_array($search_status) ) $search_status = join(',', $search_status);
+	if ( is_array($search_status) ) $search_status = join(',', $search_status);
 }
 
 // Security check

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -132,6 +132,7 @@ if (GETPOSTISARRAY('search_status')) {
 	$search_status = join(',', GETPOST('search_status', 'array:intcomma'));
 } else {
 	$search_status = (GETPOST('search_status', 'intcomma') != '' ? GETPOST('search_status', 'intcomma') : GETPOST('statut', 'intcomma'));
+    if ( is_array($search_status) ) $search_status = join(',', $search_status);
 }
 
 // Security check


### PR DESCRIPTION
FIX|Fix #29031

The query building expects the variable $search_status to be a string, but the declaration when returning to the list using "restore_lastsearch_values" returns an array.

This change include a new line that converts this variable to a comma-separated string whenever it is an array to prevent the issue reported.

