### PR TITLE
Fix str_replace expects string argument

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -12846,7 +12846,7 @@ function forgeSQLFromUniversalSearchCriteria($filter, &$errorstr = '', $noand = 
 		$ret = str_replace('__NOW__', $db->idate(dol_now()), $ret);
 	}
 	if (is_object($user)) {
-		$ret = str_replace('__USER_ID__', (int) $user->id, $ret);
+		$ret = str_replace('__USER_ID__', (string) (int) $user->id, $ret);
 	}
 
 	return $ret;


### PR DESCRIPTION
# Fix str_replace expects string argument

Fix PhanTypeMismatchArgumentInternal: Argument 2 ($replace) is (int)($user-&gt;id) of type int but \str_replace() takes array|string