### PR TITLE
NEW Constant to select if typent helps define whether the thirdparty is a company

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -4083,7 +4083,7 @@ class Societe extends CommonObject
 		} elseif (!empty($this->idprof1) || !empty($this->idprof2) || !empty($this->idprof3) || !empty($this->idprof4) || !empty($this->idprof5) || !empty($this->idprof6)) {
 			$isacompany = 1;
 		} else {
-			if (!empty($conf->global->DEFINE_CUSTOMERS_ARE_COMPANIES_BY_TYPE_COMPANY)) {
+			if (getDolGlobalString('DEFINE_CUSTOMERS_ARE_COMPANIES_BY_TYPE_COMPANY')) {
 				// TODO Add a field is_a_company into dictionary
 				if (preg_match('/^TE_PRIVATE/', $this->typent_code)) {
 					$isacompany = 0;

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -4082,12 +4082,16 @@ class Societe extends CommonObject
 			$isacompany = 1;
 		} elseif (!empty($this->idprof1) || !empty($this->idprof2) || !empty($this->idprof3) || !empty($this->idprof4) || !empty($this->idprof5) || !empty($this->idprof6)) {
 			$isacompany = 1;
-		} elseif (!empty($this->typent_code) && $this->typent_code != 'TE_UNKNOWN') {
-			// TODO Add a field is_a_company into dictionary
-			if (preg_match('/^TE_PRIVATE/', $this->typent_code)) {
-				$isacompany = 0;
+		} else {
+			if (!empty($conf->global->DEFINE_CUSTOMERS_ARE_COMPANIES_BY_TYPE_COMPANY)) {
+				// TODO Add a field is_a_company into dictionary
+				if (preg_match('/^TE_PRIVATE/', $this->typent_code)) {
+					$isacompany = 0;
+				} else {
+					$isacompany = 1;
+				}
 			} else {
-				$isacompany = 1;
+				$isacompany = 0;
 			}
 		}
 


### PR DESCRIPTION
When you create an european customer and if you define in type company it's a company... But the customer has not provided you with its intra-Community VAT number.

You need to apply normal VAT rate, no exemption because you have define it's a company in a simple list.

![image](https://github.com/Dolibarr/dolibarr/assets/2341395/26c1f40a-3b07-41d1-916d-5b198b923f0d)

I introduce a constant DEFINE_CUSTOMERS_ARE_COMPANIES_BY_TYPE_COMPANY to avoid this behavior
