### PR TITLE
Fix card FactureFournisseur

### DIFF
--- a/htdocs/comm/remx.php
+++ b/htdocs/comm/remx.php
@@ -118,7 +118,9 @@ if ($action == 'confirm_split' && GETPOST("confirm", "alpha") == 'yes' && $permi
 		$newdiscount1->fk_user = $discount->fk_user;
 		$newdiscount2->fk_user = $discount->fk_user;
 		$newdiscount1->fk_soc = $discount->fk_soc;
+		$newdiscount1->socid = $discount->socid;
 		$newdiscount2->fk_soc = $discount->fk_soc;
+		$newdiscount2->socid = $discount->socid;
 		$newdiscount1->discount_type = $discount->discount_type;
 		$newdiscount2->discount_type = $discount->discount_type;
 		$newdiscount1->datec = $discount->datec;

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -439,6 +439,7 @@ if (empty($reshook)) {
 							// Negative line, we create a discount line
 							$discount = new DiscountAbsolute($db);
 							$discount->fk_soc = $objecttmp->socid;
+							$discount->socid = $objecttmp->socid;
 							$discount->amount_ht = abs($lines[$i]->total_ht);
 							$discount->amount_tva = abs($lines[$i]->total_tva);
 							$discount->amount_ttc = abs($lines[$i]->total_ttc);

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -910,6 +910,7 @@ if (empty($reshook)) {
 				setEventMessages($langs->trans('CantConvertToReducAnInvoiceOfThisType'), null, 'errors');
 			}
 			$discount->fk_soc = $object->socid;
+			$discount->socid = $object->socid;
 			$discount->fk_facture_source = $object->id;
 
 			$error = 0;
@@ -1740,6 +1741,7 @@ if (empty($reshook)) {
 
 										$discount = new DiscountAbsolute($db);
 										$discount->fk_soc = $object->socid;
+										$discount->socid = $object->socid;
 										$discount->amount_ht = abs($lines[$i]->total_ht);
 										$discount->amount_tva = abs($lines[$i]->total_tva);
 										$discount->amount_ttc = abs($lines[$i]->total_ttc);

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -1197,6 +1197,7 @@ class Invoices extends DolibarrApi
 			}
 
 			$discount->fk_soc = $this->invoice->socid;
+			$discount->socid = $this->invoice->socid;
 			$discount->fk_facture_source = $this->invoice->id;
 
 			$error = 0;

--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -471,6 +471,7 @@ class Paiement extends CommonObject
 									if (empty($discount->id)) {	// If the invoice was not yet converted into a discount (this may have been done manually before we come here)
 										$discount->description = '(DEPOSIT)';
 										$discount->fk_soc = $invoice->socid;
+										$discount->socid = $invoice->socid;
 										$discount->fk_facture_source = $invoice->id;
 
 										// Loop on each vat rate

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -175,7 +175,7 @@ abstract class CommonObject
 	private $linkedObjectsFullLoaded = array();
 
 	/**
-	 * @var CommonObject	To store a cloned copy of the object before editing it (to keep track of its former properties)
+	 * @var static	To store a cloned copy of the object before editing it (to keep track of its former properties)
 	 */
 	public $oldcopy;
 
@@ -5372,6 +5372,7 @@ abstract class CommonObject
 			$discount = new DiscountAbsolute($this->db);
 			if (property_exists($this, 'socid')) {
 				$discount->fk_soc = $this->socid;
+				$discount->socid = $this->socid;
 			}
 			$this->tpl['label'] .= $discount->getNomUrl(0, 'discount');
 		} elseif (!empty($line->fk_product)) {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4099,15 +4099,15 @@ abstract class CommonObject
 	 *  - source id+type + target type -> will get list of targets of the type linked to source
 	 *  - target id+type + source type -> will get list of sources of the type linked to target
 	 *
-	 *	@param	int			$sourceid			Object source id (if not defined, $this->id)
+	 *	@param	?int		$sourceid			Object source id (if not defined, $this->id)
 	 *	@param  string		$sourcetype			Object source type (if not defined, $this->element)
-	 *	@param  int			$targetid			Object target id (if not defined, $this->id)
+	 *	@param  ?int		$targetid			Object target id (if not defined, $this->id)
 	 *	@param  string		$targettype			Object target type (if not defined, $this->element)
 	 *	@param  string		$clause				'OR' or 'AND' clause used when both source id and target id are provided
-	 *  @param  int			$alsosametype		0=Return only links to object that differs from source type. 1=Include also link to objects of same type.
+	 *  @param  int<0,1>	$alsosametype		0=Return only links to object that differs from source type. 1=Include also link to objects of same type.
 	 *  @param  string		$orderby			SQL 'ORDER BY' clause
-	 *  @param	int|string	$loadalsoobjects	Load also the array $this->linkedObjects. Use 0 to not load (increase performances), Use 1 to load all, Use value of type ('facture', 'facturerec', ...) to load only a type of object.
-	 *	@return int								Return integer <0 if KO, >0 if OK
+	 *  @param	int<0,1>|string	$loadalsoobjects	Load also the array $this->linkedObjects. Use 0 to not load (increase performances), Use 1 to load all, Use value of type ('facture', 'facturerec', ...) to load only a type of object.
+	 *	@return int<-1,1>						Return integer <0 if KO, >0 if OK
 	 *  @see	add_object_linked(), updateObjectLinked(), deleteObjectLinked()
 	 */
 	public function fetchObjectLinked($sourceid = null, $sourcetype = '', $targetid = null, $targettype = '', $clause = 'OR', $alsosametype = 1, $orderby = 'sourcetype', $loadalsoobjects = 1)

--- a/htdocs/core/class/discount.class.php
+++ b/htdocs/core/class/discount.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2004-2018 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2024      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +34,7 @@ class DiscountAbsolute extends CommonObject
 {
 	/**
 	 * @var int 	Thirdparty ID
-	 * @deprecated
+	 * @deprecated  Use socid instead.
 	 */
 	public $fk_soc;
 	/**
@@ -171,6 +172,7 @@ class DiscountAbsolute extends CommonObject
 
 				$this->id = $obj->rowid;
 				$this->fk_soc = $obj->fk_soc;
+				$this->socid = $obj->fk_soc;
 				$this->discount_type = $obj->discount_type;
 
 				$this->total_ht = $obj->amount_ht;
@@ -275,7 +277,7 @@ class DiscountAbsolute extends CommonObject
 		$sql .= " multicurrency_amount_ht, multicurrency_amount_tva, multicurrency_amount_ttc,";
 		$sql .= " fk_facture_source, fk_invoice_supplier_source";
 		$sql .= ")";
-		$sql .= " VALUES (".$conf->entity.", '".$this->db->idate($this->datec != '' ? $this->datec : dol_now())."', ".((int) $this->fk_soc).", ".(empty($this->discount_type) ? 0 : intval($this->discount_type)).", ".((int) $userid).", '".$this->db->escape($this->description)."',";
+		$sql .= " VALUES (".$conf->entity.", '".$this->db->idate($this->datec != '' ? $this->datec : dol_now())."', ".((int) $this->socid).", ".(empty($this->discount_type) ? 0 : intval($this->discount_type)).", ".((int) $userid).", '".$this->db->escape($this->description)."',";
 		$sql .= " ".price2num($this->amount_ht).", ".price2num($this->amount_tva).", ".price2num($this->amount_ttc).", ".price2num($this->tva_tx).", '".$this->db->escape($this->vat_src_code)."',";
 		$sql .= " ".price2num($this->multicurrency_amount_ht).", ".price2num($this->multicurrency_amount_tva).", ".price2num($this->multicurrency_amount_ttc).", ";
 		$sql .= " ".($this->fk_facture_source ? ((int) $this->fk_facture_source) : "null").",";
@@ -709,7 +711,7 @@ class DiscountAbsolute extends CommonObject
 		}
 		if ($option == 'discount') {
 			$label = $langs->trans("Discount");
-			$link = '<a href="'.DOL_URL_ROOT.'/comm/remx.php?id='.$this->fk_soc.'" title="'.dol_escape_htmltag($label, 1).'" class="classfortooltip">';
+			$link = '<a href="'.DOL_URL_ROOT.'/comm/remx.php?id='.$this->socid.'" title="'.dol_escape_htmltag($label, 1).'" class="classfortooltip">';
 			$linkend = '</a>';
 			$ref = $langs->trans("Discount");
 			$picto = 'generic';

--- a/htdocs/core/class/discount.class.php
+++ b/htdocs/core/class/discount.class.php
@@ -42,6 +42,9 @@ class DiscountAbsolute extends CommonObject
 	 */
 	public $socid;
 
+	/**
+	 * @var int<0,1>
+	 */
 	public $discount_type; // 0 => customer discount, 1 => supplier discount
 
 	public $total_ht;
@@ -132,7 +135,7 @@ class DiscountAbsolute extends CommonObject
 	 *  @param      int		$rowid       					id discount to load
 	 *  @param      int		$fk_facture_source				fk_facture_source
 	 *  @param		int		$fk_invoice_supplier_source		fk_invoice_supplier_source
-	 *	@return		int										Return integer <0 if KO, =0 if not found, >0 if OK
+	 *	@return		int<-1,1>								Return integer <0 if KO, =0 if not found, >0 if OK
 	 */
 	public function fetch($rowid, $fk_facture_source = 0, $fk_invoice_supplier_source = 0)
 	{
@@ -225,7 +228,7 @@ class DiscountAbsolute extends CommonObject
 	 *      Create a discount into database
 	 *
 	 *      @param      User	$user       User that create
-	 *      @return     int         		Return integer <0 if KO, >0 if OK
+	 *      @return     int<-1,1>      		Return integer <0 if KO, >0 if OK
 	 */
 	public function create($user)
 	{
@@ -299,8 +302,8 @@ class DiscountAbsolute extends CommonObject
 	/**
 	 *  Delete object in database. If fk_facture_source is defined, we delete all family with same fk_facture_source. If not, only with id is removed
 	 *
-	 *  @param      User    $user       Object of user asking to delete
-	 *  @return     int                 Return integer <0 if KO, >0 if OK
+	 *  @param	User	$user		Object of user asking to delete
+	 *  @return	int<-1,1>			Return integer <0 if KO, >0 if OK
 	 */
 	public function delete($user)
 	{
@@ -424,7 +427,7 @@ class DiscountAbsolute extends CommonObject
 	 *
 	 *	@param		int		$rowidline		Invoice line id (To use discount into invoice lines)
 	 *	@param		int		$rowidinvoice	Invoice id (To use discount as a credit note to reduce payment of invoice)
-	 *	@return		int						Return integer <0 if KO, >0 if OK
+	 *	@return		int<-1,1>				Return integer <0 if KO, >0 if OK
 	 */
 	public function link_to_invoice($rowidline, $rowidinvoice)
 	{
@@ -480,7 +483,7 @@ class DiscountAbsolute extends CommonObject
 	 *	Link the discount to a particular invoice line or a particular invoice.
 	 *	Do not call this if discount is linked to a reconcialiated invoice
 	 *
-	 *	@return		int							Return integer <0 if KO, >0 if OK
+	 *	@return		int<-1,1>					Return integer <0 if KO, >0 if OK
 	 */
 	public function unlink_invoice()
 	{
@@ -507,13 +510,13 @@ class DiscountAbsolute extends CommonObject
 	/**
 	 *  Return amount (with tax) of discounts currently available for a company, user or other criteria
 	 *
-	 *	@param		Societe		$company		Object third party for filter
-	 *	@param		User		$user			Filtre sur un user auteur des remises
+	 *	@param		?Societe	$company		Object third party for filter
+	 *	@param		?User		$user			Filtre sur un user auteur des remises
 	 * 	@param		string		$filter			Filter other. Warning: Do not use a user input value here.
-	 * 	@param		int			$maxvalue		Filter on max value for discount
-	 *  @param      int			$discount_type  0 => customer discount, 1 => supplier discount
-	 *  @param      int			$multicurrency  Return multicurrency_amount instead of amount
-	 * 	@return		int						Return integer <0 if KO, amount otherwise
+	 * 	@param		int|float	$maxvalue		Filter on max value for discount
+	 *  @param      int<0,1>	$discount_type  0 => customer discount, 1 => supplier discount
+	 *  @param      int<0,1>	$multicurrency  Return multicurrency_amount instead of amount
+	 * 	@return		int<-1,-1>|float			Return integer <0 if KO, amount otherwise
 	 */
 	public function getAvailableDiscounts($company = null, $user = null, $filter = '', $maxvalue = 0, $discount_type = 0, $multicurrency = 0)
 	{
@@ -566,8 +569,8 @@ class DiscountAbsolute extends CommonObject
 	 *  Should always be empty, except if option FACTURE_DEPOSITS_ARE_JUST_PAYMENTS or FACTURE_SUPPLIER_DEPOSITS_ARE_JUST_PAYMENTS is on (not recommended).
 	 *
 	 *	@param		CommonInvoice	$invoice		Object invoice (customer of supplier)
-	 *  @param 		int 		    $multicurrency 	1=Return multicurrency_amount instead of amount. TODO Add a mode multicurrency = -1 to return array with amount + multicurrency amount
-	 *	@return		int				     			Return integer <0 if KO, Sum of credit notes and deposits amount otherwise
+	 *  @param 		int<-1,1>	    $multicurrency 	1=Return multicurrency_amount instead of amount. TODO Add a mode multicurrency = -1 to return array with amount + multicurrency amount
+	 *	@return		int<-1,-1>|float     			Return integer <0 if KO, Sum of credit notes and deposits amount otherwise
 	 */
 	public function getSumDepositsUsed($invoice, $multicurrency = 0)
 	{
@@ -607,7 +610,7 @@ class DiscountAbsolute extends CommonObject
 	 *  Return amount (with tax) of all credit notes invoices + excess received used by invoice as a payment
 	 *
 	 *	@param      CommonInvoice	  $invoice	    	Object invoice
-	 *	@param      int			      $multicurrency	1=Return multicurrency_amount instead of amount. TODO Add a mode multicurrency = -1 to return array with amount + multicurrency amount
+	 *	@param      int<-1,1>	      $multicurrency	1=Return multicurrency_amount instead of amount. TODO Add a mode multicurrency = -1 to return array with amount + multicurrency amount
 	 *	@return     int					        		Return integer <0 if KO, Sum of credit notes and excess received amount otherwise
 	 */
 	public function getSumCreditNotesUsed($invoice, $multicurrency = 0)
@@ -647,7 +650,7 @@ class DiscountAbsolute extends CommonObject
 	 *    	Return amount (with tax) of all converted amount for this credit note
 	 *
 	 *	@param		CommonInvoice	  $invoice	    	Object invoice
-	 *	@param		int			      $multicurrency	Return multicurrency_amount instead of amount. TODO Add a mode multicurrency = -1 to return array with amount + multicurrency amount
+	 *	@param		int<-1,1>	      $multicurrency	Return multicurrency_amount instead of amount. TODO Add a mode multicurrency = -1 to return array with amount + multicurrency amount
 	 *	@return		int					        		Return integer <0 if KO, Sum of credit notes and deposits amount otherwise
 	 */
 	public function getSumFromThisCreditNotesNotUsed($invoice, $multicurrency = 0)
@@ -685,9 +688,9 @@ class DiscountAbsolute extends CommonObject
 	/**
 	 *  Return clickable ref of object (with picto or not)
 	 *
-	 *  @param		int		$withpicto		0=No picto, 1=Include picto into link, 2=Picto only
-	 *  @param		string	$option			Where to link to ('invoice' or 'discount')
-	 *  @return		string					String with URL
+	 *  @param	int<0,1>	$withpicto		0=No picto, 1=Include picto into link, 2=Picto only
+	 *  @param	string		$option			Where to link to ('invoice' or 'discount')
+	 *  @return	string						String with URL
 	 */
 	public function getNomUrl($withpicto, $option = 'invoice')
 	{
@@ -734,7 +737,7 @@ class DiscountAbsolute extends CommonObject
 	 *  Used to build previews or test instances.
 	 *	id must be 0 if object instance is a specimen.
 	 *
-	 *  @return	int
+	 *  @return	int<0,1>
 	 */
 	public function initAsSpecimen()
 	{

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -178,7 +178,7 @@ class FactureFournisseur extends CommonInvoice
 
 	/**
 	 * @var double $amount
-	 * @deprecated
+	 * @deprecated See $total_ttc, $total_ht, $total_tva
 	 */
 	public $amount = 0;
 	/**
@@ -558,7 +558,7 @@ class FactureFournisseur extends CommonInvoice
 		$sql .= ", '".$this->db->escape($this->ref_ext)."'";
 		$sql .= ", ".((int) $conf->entity);
 		$sql .= ", '".$this->db->escape($this->type)."'";
-		$sql .= ", ".($this->subtype ? "'".$this->db->escape($this->subtype)."'" : "null");
+		$sql .= ", ".((int) $this->subtype);
 		$sql .= ", '".$this->db->escape(isset($this->label) ? $this->label : (isset($this->libelle) ? $this->libelle : ''))."'";
 		$sql .= ", ".((int) $this->socid);
 		$sql .= ", '".$this->db->idate($now)."'";
@@ -927,7 +927,7 @@ class FactureFournisseur extends CommonInvoice
 				$this->ref_ext			    = $obj->ref_ext;
 				$this->entity				= $obj->entity;
 				$this->type					= empty($obj->type) ? self::TYPE_STANDARD : $obj->type;
-				$this->subtype				= $obj->subtype;
+				$this->subtype				= (int) $obj->subtype;
 				$this->socid				= $obj->fk_soc;
 				$this->datec				= $this->db->jdate($obj->datec);
 				$this->date					= $this->db->jdate($obj->datef);
@@ -1231,7 +1231,7 @@ class FactureFournisseur extends CommonInvoice
 		$sql .= " ref_ext=".(isset($this->ref_ext) ? "'".$this->db->escape($this->ref_ext)."'" : "null").",";
 		$sql .= " entity=".(isset($this->entity) ? ((int) $this->entity) : "null").",";
 		$sql .= " type=".(isset($this->type) ? ((int) $this->type) : "null").",";
-		$sql .= " subtype=".(isset($this->subtype) ? $this->db->escape($this->subtype) : "null").",";
+		$sql .= " subtype=".((int) $this->subtype).",";
 		$sql .= " fk_soc=".(isset($this->socid) ? ((int) $this->socid) : "null").",";
 		$sql .= " datec=".(dol_strlen($this->datec) != 0 ? "'".$this->db->idate($this->datec)."'" : 'null').",";
 		$sql .= " datef=".(dol_strlen($this->date) != 0 ? "'".$this->db->idate($this->date)."'" : 'null').",";

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -460,6 +460,7 @@ if (empty($reshook)) {
 							// Negative line, we create a discount line
 							$discount = new DiscountAbsolute($db);
 							$discount->fk_soc = $objecttmp->socid;
+							$discount->socid = $objecttmp->socid;
 							$discount->amount_ht = abs($lines[$i]->total_ht);
 							$discount->amount_tva = abs($lines[$i]->total_tva);
 							$discount->amount_ttc = abs($lines[$i]->total_ttc);

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -647,6 +647,7 @@ if (empty($reshook)) {
 			}
 			$discount->discount_type = 1; // Supplier discount
 			$discount->fk_soc = $object->socid;
+			$discount->socid = $object->socid;
 			$discount->fk_invoice_supplier_source = $object->id;
 
 			$error = 0;

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -118,7 +118,7 @@ if (!empty($user->socid)) {
 	$socid = $user->socid;
 }
 
-$isdraft = (($object->statut == FactureFournisseur::STATUS_DRAFT) ? 1 : 0);
+$isdraft = (($object->status == FactureFournisseur::STATUS_DRAFT) ? 1 : 0);
 $result = restrictedArea($user, 'fournisseur', $id, 'facture_fourn', 'facture', 'fk_soc', 'rowid', $isdraft);
 
 // Common permissions
@@ -190,6 +190,7 @@ if (empty($reshook)) {
 	// Action clone object
 	if ($action == 'confirm_clone' && $confirm == 'yes' && $permissiontoadd) {
 		$objectutil = dol_clone($object, 1); // To avoid to denaturate loaded object when setting some properties for clone. We use native clone to keep this->db valid.
+		'@phan-var-force FactureFournisseur $objectutil';  // Same object type for cloned object
 
 		if (GETPOST('newsupplierref', 'alphanohtml')) {
 			$objectutil->ref_supplier = GETPOST('newsupplierref', 'alphanohtml');
@@ -592,7 +593,7 @@ if (empty($reshook)) {
 		if ($object->type == FactureFournisseur::TYPE_DEPOSIT && empty($discountcheck->id)) {
 			$canconvert = 1; // we can convert deposit into discount if deposit is paid (completely, partially or not at all) and not already converted (see real condition into condition used to show button converttoreduc)
 		}
-		if (($object->type == FactureFournisseur::TYPE_CREDIT_NOTE || $object->type == FactureFournisseur::TYPE_STANDARD) && $object->paye == 0 && empty($discountcheck->id)) {
+		if (($object->type == FactureFournisseur::TYPE_CREDIT_NOTE || $object->type == FactureFournisseur::TYPE_STANDARD) && $object->paid == 0 && empty($discountcheck->id)) {
 			$canconvert = 1; // we can convert credit note into discount if credit note is not refunded completely and not already converted and amount of payment is 0 (see also the real condition used as the condition to show button converttoreduc)
 		}
 		if ($canconvert) {
@@ -616,6 +617,12 @@ if (empty($reshook)) {
 					$i++;
 				}
 			}
+			'@phan-var-force array<string,float> $amount_ht
+			 @phan-var-force array<string,float> $amount_tva
+			 @phan-var-force array<string,float> $amount_ttc
+			 @phan-var-force array<string,float> $multicurrency_amount_ht
+			 @phan-var-force array<string,float> $multicurrency_amount_tva
+			 @phan-var-force array<string,float> $multicurrency_amount_ttc';
 
 			// If some payments were already done, we change the amount to pay using same prorate
 			if (getDolGlobalString('SUPPLIER_INVOICE_ALLOW_REUSE_OF_CREDIT_WHEN_PARTIALLY_REFUNDED') && $object->type == FactureFournisseur::TYPE_CREDIT_NOTE) {
@@ -713,7 +720,7 @@ if (empty($reshook)) {
 						$tva_tx = preg_replace('/\s*\(.*\)/', '', $tva_tx); // Remove code into vatrate.
 					}
 
-					$discount->tva_tx = abs($tva_tx);
+					$discount->tva_tx = abs((float) $tva_tx);
 					$discount->vat_src_code = $vat_src_code;
 
 					$result = $discount->create($user);
@@ -745,7 +752,7 @@ if (empty($reshook)) {
 	} elseif ($action == 'confirm_delete_paiement' && $confirm == 'yes' && $usercancreate) {
 		// Delete payment
 		$object->fetch($id);
-		if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0) {
+		if ($object->status == FactureFournisseur::STATUS_VALIDATED && $object->paid == 0) {
 			$paiementfourn = new PaiementFourn($db);
 			$result = $paiementfourn->fetch(GETPOST('paiement_id'));
 			if ($result > 0) {
@@ -769,6 +776,7 @@ if (empty($reshook)) {
 		$db->begin();
 
 		$error = 0;
+		$tmpproject = 0;  // Ensure a value
 
 		// Fill array 'array_options' with data from add form
 		$ret = $extrafields->setOptionalsFromPost(null, $object);
@@ -814,8 +822,8 @@ if (empty($reshook)) {
 				$object->ref = GETPOST('ref', 'alphanohtml');
 				$object->ref_supplier = GETPOST('ref_supplier', 'alpha');
 				$object->socid = GETPOSTINT('socid');
-				$object->libelle = GETPOST('label', 'alphanohtml');	// deprecated
 				$object->label = GETPOST('label', 'alphanohtml');
+				$object->libelle = $object->label;	// deprecated
 				$object->date = $dateinvoice;
 				$object->date_echeance = $datedue;
 				$object->note_public = GETPOST('note_public', 'restricthtml');
@@ -888,8 +896,8 @@ if (empty($reshook)) {
 				$object->ref_supplier       = GETPOST('ref_supplier', 'alphanohtml');
 				$object->subtype            = GETPOST('subtype', 'alphanohtml');
 				$object->socid				= GETPOSTINT('socid');
-				$object->libelle            = GETPOST('label', 'alphanohtml');
 				$object->label				= GETPOST('label', 'alphanohtml');
+				$object->libelle            = $object->label;  // Deprecated
 				$object->date               = $dateinvoice;
 				$object->date_echeance      = $datedue;
 				$object->note_public        = GETPOST('note_public', 'restricthtml');
@@ -959,7 +967,7 @@ if (empty($reshook)) {
 						$totaldeposits = $facture_source->getSumDepositsUsed();
 						$remain_to_pay = abs($facture_source->total_ttc - $totalpaid - $totalcreditnotes - $totaldeposits);
 						$desc = $langs->trans('invoiceAvoirLineWithPaymentRestAmount');
-						$retAddLine = $object->addline($desc, $remain_to_pay, 0, 0, 0, 1, 0, 0, '', '', 0, '', 'TTC');
+						$retAddLine = $object->addline($desc, $remain_to_pay, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 'TTC');
 
 						if ($retAddLine < 0) {
 							$error++;
@@ -988,7 +996,7 @@ if (empty($reshook)) {
 			if (!$error) {
 				$object->socid              = GETPOSTINT('socid');
 				$object->type               = GETPOST('type', 'alphanohtml');
-				$object->subtype            = GETPOST('subtype', 'alphanohtml');
+				$object->subtype            = GETPOSTINT('subtype');
 				$object->ref                = GETPOST('ref', 'alphanohtml');
 				$object->date               = $dateinvoice;
 				$object->note_public        = trim(GETPOST('note_public', 'restricthtml'));
@@ -999,7 +1007,7 @@ if (empty($reshook)) {
 				$object->cond_reglement_id	= (GETPOSTINT('type') == 3 ? 1 : GETPOST('cond_reglement_id'));
 				$object->mode_reglement_id	= GETPOSTINT('mode_reglement_id');
 				$object->fk_account         = GETPOSTINT('fk_account');
-				$object->amount             = price2num(GETPOST('amount'));
+				$object->amount             = (float) price2num(GETPOST('amount'));  // FIXME: FactureFournisseur::$amount is deprecated and not used?
 				//$object->remise_absolue		= price2num(GETPOST('remise_absolue'), 'MU');
 				//$object->remise_percent		= price2num(GETPOST('remise_percent'), '', 2);
 				$object->fk_incoterms       = GETPOSTINT('incoterm_id');
@@ -1054,12 +1062,12 @@ if (empty($reshook)) {
 				// Creation invoice
 				$object->socid				= GETPOSTINT('socid');
 				$object->type				= GETPOST('type', 'alphanohtml');
-				$object->subtype            = GETPOST('subtype', 'alphanohtml');
+				$object->subtype            = GETPOSTINT('subtype');
 				$object->ref				= GETPOST('ref', 'alphanohtml');
 				$object->ref_supplier		= GETPOST('ref_supplier', 'alphanohtml');
 				$object->socid				= GETPOSTINT('socid');
-				$object->libelle			= GETPOST('label', 'alphanohtml');	// deprecated
 				$object->label				= GETPOST('label', 'alphanohtml');
+				$object->libelle			= $object->label;	// deprecated
 				$object->date				= $dateinvoice;
 				$object->date_echeance		= $datedue;
 				$object->note_public		= GETPOST('note_public', 'restricthtml');
@@ -1073,7 +1081,7 @@ if (empty($reshook)) {
 				$object->location_incoterms	= GETPOST('location_incoterms', 'alpha');
 				$object->multicurrency_code	= GETPOST('multicurrency_code', 'alpha');
 				$object->multicurrency_tx	= GETPOSTINT('originmulticurrency_tx');
-				$object->transport_mode_id	= GETPOST('transport_mode_id');
+				$object->transport_mode_id	= GETPOSTINT('transport_mode_id');
 
 				// Auto calculation of date due if not filled by user
 				if (empty($object->date_echeance)) {
@@ -1172,6 +1180,7 @@ if (empty($reshook)) {
 									}
 									$TTotalByTva[$line->tva_tx] += $line->total_ttc;
 								}
+								'@phan-var-force array<string,float> $TTotalByTva';
 
 								$amount_ttc_diff = 0.;
 								foreach ($TTotalByTva as $tva => &$total) {
@@ -1209,6 +1218,7 @@ if (empty($reshook)) {
 									} else {
 										setEventMessages($srcobject->error, $srcobject->errors, 'errors');
 										$error++;
+										$amountdeposit[0] = 0;
 									}
 								}
 
@@ -1250,7 +1260,7 @@ if (empty($reshook)) {
 									0, // product_type
 									1,
 									0,
-									0,
+									array(), // array_options
 									null,
 									$object->origin,
 									0,
@@ -1283,7 +1293,7 @@ if (empty($reshook)) {
 									0,
 									$object->lines[0]->date_start,
 									$object->lines[0]->date_end,
-									0,
+									array(),  // array_options
 									0,
 									0,
 									'',
@@ -1303,7 +1313,7 @@ if (empty($reshook)) {
 									continue; // Skip unselected lines
 								}
 
-								$desc = ($lines[$i]->desc ? $lines[$i]->desc : $lines[$i]->libelle);
+								$desc = ($lines[$i]->desc ? $lines[$i]->desc : $lines[$i]->product_label);
 								$product_type = ($lines[$i]->product_type ? $lines[$i]->product_type : 0);
 
 								// Extrafields
@@ -1879,7 +1889,7 @@ if (empty($reshook)) {
 
 		if (!$ventilExportCompta) {
 			// We verify that no payment was done
-			if ($resteapayer == price2num($object->total_ttc, 'MT', 1) && $object->statut == FactureFournisseur::STATUS_VALIDATED) {
+			if ($resteapayer == price2num($object->total_ttc, 'MT', 1) && $object->status == FactureFournisseur::STATUS_VALIDATED) {
 				$idwarehouse = GETPOST('idwarehouse');
 
 				$object->fetch_thirdparty();
@@ -1932,8 +1942,8 @@ if (empty($reshook)) {
 	} elseif ($action == 'reopen' && $usercancreate) {
 		// Set invoice to validated/unpaid status
 		$result = $object->fetch($id);
-		if ($object->statut == FactureFournisseur::STATUS_CLOSED
-		|| ($object->statut == FactureFournisseur::STATUS_ABANDONED && $object->close_code != 'replaced')) {
+		if ($object->status == FactureFournisseur::STATUS_CLOSED
+		|| ($object->status == FactureFournisseur::STATUS_ABANDONED && $object->close_code != 'replaced')) {
 			$result = $object->setUnpaid($user);
 			if ($result > 0) {
 				header('Location: '.$_SERVER["PHP_SELF"].'?id='.$id);
@@ -2063,6 +2073,7 @@ llxHeader('', $title, $help_url);
 // Mode creation
 if ($action == 'create') {
 	$facturestatic = new FactureFournisseur($db);
+	$selectedLines = array();  // Ensure initialised
 
 	print load_fiche_titre($langs->trans('NewSupplierInvoice'), '', 'supplier_invoice');
 
@@ -2290,12 +2301,12 @@ if ($action == 'create') {
 		print '<td>';
 
 		if (!empty($societe->id) && $societe->id > 0 && ($fac_recid <= 0 || !empty($invoice_predefined->frequency))) {
-			$absolute_discount = $societe->getAvailableDiscounts('', '', 0, 1);
+			$absolute_discount = $societe->getAvailableDiscounts(null, '', 0, 1);
 			print $societe->getNomUrl(1, 'supplier');
 			print '<input type="hidden" name="socid" value="'.$societe->id.'">';
 		} else {
 			$filter = '((s.fournisseur:=:1) AND (s.status:=:1))';
-			print img_picto('', 'company', 'class="pictofixedwidth"').$form->select_company(empty($societe->id) ? 0 : $societe->id, 'socid', $filter, 'SelectThirdParty', 1, 0, null, 0, 'minwidth175 widthcentpercentminusxx maxwidth500');
+			print img_picto('', 'company', 'class="pictofixedwidth"').$form->select_company(empty($societe->id) ? 0 : $societe->id, 'socid', $filter, 'SelectThirdParty', 1, 0, array(), 0, 'minwidth175 widthcentpercentminusxx maxwidth500');
 			// reload page to retrieve supplier information
 			if (!getDolGlobalString('RELOAD_PAGE_ON_SUPPLIER_CHANGE_DISABLED')) {
 				print '<script type="text/javascript">
@@ -2542,8 +2553,10 @@ if ($action == 'create') {
 					foreach ($facids as $key => $valarray) {
 						$newinvoice_static->id = $key;
 						$newinvoice_static->ref = $valarray ['ref'];
+						$newinvoice_static->status = $valarray ['status'];
 						$newinvoice_static->statut = $valarray ['status'];
 						$newinvoice_static->type = $valarray ['type'];
+						$newinvoice_static->paid = $valarray ['paye'];
 						$newinvoice_static->paye = $valarray ['paye'];
 
 						$optionsav .= '<option value="'.$key.'"';
@@ -2804,9 +2817,10 @@ if ($action == 'create') {
 			}
 			print '<tr><td>'.$txt.'</td><td>'.$objectsrc->getNomUrl(1);
 			// We check if Origin document (id and type is known) has already at least one invoice attached to it
-			$objectsrc->fetchObjectLinked($originid, $origin, '', 'invoice_supplier');
+			$objectsrc->fetchObjectLinked($originid, $origin, null, 'invoice_supplier');
 
 			$invoice_supplier = $objectsrc->linkedObjects['invoice_supplier'];
+			'@phan-var-force null|FactureFournisseur[] $invoice_supplier';
 
 			// count function need a array as argument (Note: the array must implement Countable too)
 			if (is_array($invoice_supplier)) {
@@ -2920,7 +2934,7 @@ if ($action == 'create') {
 			}
 		}
 
-		if ($object->paye) {
+		if ($object->paid) {
 			$resteapayer = 0;
 		}
 		$resteapayeraffiche = $resteapayer;
@@ -2933,8 +2947,8 @@ if ($action == 'create') {
 			$filtercreditnote = "fk_invoice_supplier_source IS NOT NULL AND (description NOT LIKE '(DEPOSIT)%' OR description LIKE '(EXCESS PAID)%')";
 		}
 
-		$absolute_discount = $societe->getAvailableDiscounts('', $filterabsolutediscount, 0, 1);
-		$absolute_creditnote = $societe->getAvailableDiscounts('', $filtercreditnote, 0, 1);
+		$absolute_discount = $societe->getAvailableDiscounts(null, $filterabsolutediscount, 0, 1);
+		$absolute_creditnote = $societe->getAvailableDiscounts(null, $filtercreditnote, 0, 1);
 		$absolute_discount = price2num($absolute_discount, 'MT');
 		$absolute_creditnote = price2num($absolute_creditnote, 'MT');
 
@@ -3333,8 +3347,8 @@ if ($action == 'create') {
 			print '<td>'.$form->editfieldval("Label", 'label', $object->label, $object, $usercancreate).'</td>';
 			print '</tr>';
 
-			//$form_permission = ($object->statut < FactureFournisseur::STATUS_CLOSED) && $usercancreate && ($object->getSommePaiement() <= 0);
-			$form_permission = ($object->statut < FactureFournisseur::STATUS_CLOSED) && $usercancreate;
+			//$form_permission = ($object->status < FactureFournisseur::STATUS_CLOSED) && $usercancreate && ($object->getSommePaiement() <= 0);
+			$form_permission = ($object->status < FactureFournisseur::STATUS_CLOSED) && $usercancreate;
 
 			// Date
 			print '<tr><td>';
@@ -3398,7 +3412,7 @@ if ($action == 'create') {
 				print '<table class="nobordernopadding" width="100%"><tr><td>';
 				print $form->editfieldkey('Currency', 'multicurrency_code', '', $object, 0);
 				print '</td>';
-				if ($action != 'editmulticurrencycode' && $object->statut == $object::STATUS_DRAFT) {
+				if ($action != 'editmulticurrencycode' && $object->status == $object::STATUS_DRAFT) {
 					print '<td class="right"><a class="editfielda" href="'.$_SERVER["PHP_SELF"].'?action=editmulticurrencycode&token='.newToken().'&id='.$object->id.'">'.img_edit($langs->transnoentitiesnoconv('SetMultiCurrencyCode'), 1).'</a></td>';
 				}
 				print '</tr></table>';
@@ -3417,7 +3431,7 @@ if ($action == 'create') {
 					print '<table class="nobordernopadding centpercent"><tr><td>';
 					print $form->editfieldkey('CurrencyRate', 'multicurrency_tx', '', $object, 0);
 					print '</td>';
-					if ($action != 'editmulticurrencyrate' && $object->statut == $object::STATUS_DRAFT && $object->multicurrency_code && $object->multicurrency_code != $conf->currency) {
+					if ($action != 'editmulticurrencyrate' && $object->status == $object::STATUS_DRAFT && $object->multicurrency_code && $object->multicurrency_code != $conf->currency) {
 						print '<td class="right"><a class="editfielda" href="'.$_SERVER["PHP_SELF"].'?action=editmulticurrencyrate&token='.newToken().'&id='.$object->id.'">'.img_edit($langs->transnoentitiesnoconv('SetMultiCurrencyCode'), 1).'</a></td>';
 					}
 					print '</tr></table>';
@@ -3429,7 +3443,7 @@ if ($action == 'create') {
 						$form->form_multicurrency_rate($_SERVER['PHP_SELF'].'?id='.$object->id, $object->multicurrency_tx, 'multicurrency_tx', $object->multicurrency_code);
 					} else {
 						$form->form_multicurrency_rate($_SERVER['PHP_SELF'].'?id='.$object->id, $object->multicurrency_tx, 'none', $object->multicurrency_code);
-						if ($object->statut == $object::STATUS_DRAFT && $object->multicurrency_code && $object->multicurrency_code != $conf->currency) {
+						if ($object->status == $object::STATUS_DRAFT && $object->multicurrency_code && $object->multicurrency_code != $conf->currency) {
 							print '<div class="inline-block"> &nbsp; &nbsp; &nbsp; &nbsp; ';
 							print '<a href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=actualizemulticurrencyrate">'.$langs->trans("ActualizeCurrency").'</a>';
 							print '</div>';
@@ -3685,7 +3699,7 @@ if ($action == 'create') {
 						print $paymentstatic->getNomUrl(1);
 						print '</td>';
 						print '<td>'.dol_print_date($db->jdate($objp->dp), 'day').'</td>';
-						$s = $form->form_modes_reglement(null, $objp->payment_type, 'none', '', 1, 0, '', 1).' '.$objp->num_payment;
+						$s = $form->form_modes_reglement('', $objp->payment_type, 'none', '', 1, 0, '', 1).' '.$objp->num_payment;
 						print '<td class="tdoverflowmax125" title="'.dol_escape_htmltag($s).'">';
 						print $s;
 						print '</td>';
@@ -3711,7 +3725,7 @@ if ($action == 'create') {
 						}
 						print '<td class="right">'.price($sign * $objp->amount).'</td>';
 						print '<td class="center">';
-						if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0 && $user->socid == 0) {
+						if ($object->status == FactureFournisseur::STATUS_VALIDATED && $object->paid == 0 && $user->socid == 0) {
 							print '<a href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=deletepayment&token='.newToken().'&paiement_id='.$objp->rowid.'">';
 							print img_delete();
 							print '</a>';
@@ -3726,7 +3740,7 @@ if ($action == 'create') {
 				}
 
 				/*
-				if ($object->paye == 0)
+				if ($object->paid == 0)
 				{
 					print '<tr><td colspan="'.$nbcols.'" class="right">'.$langs->trans('AlreadyPaid').' :</td><td class="right">'.price($totalpaid).'</td><td></td></tr>';
 					print '<tr><td colspan="'.$nbcols.'" class="right">'.$langs->trans("Billed").' :</td><td class="right">'.price($object->total_ttc).'</td><td></td></tr>';
@@ -3804,7 +3818,7 @@ if ($action == 'create') {
 				}
 
 				// Paye partiellement 'escompte'
-				if (($object->statut == FactureFournisseur::STATUS_CLOSED || $object->statut == FactureFournisseur::STATUS_ABANDONED) && $object->close_code == 'discount_vat') {
+				if (($object->status == FactureFournisseur::STATUS_CLOSED || $object->status == FactureFournisseur::STATUS_ABANDONED) && $object->close_code == 'discount_vat') {
 					print '<tr><td colspan="'.$nbcols.'" class="right nowrap">';
 					print '<span class="opacitymedium">';
 					print $form->textwithpicto($langs->trans("Discount"), $langs->trans("HelpEscompte"), - 1);
@@ -3814,7 +3828,7 @@ if ($action == 'create') {
 					$cssforamountpaymentcomplete = 'amountpaymentneutral';
 				}
 				// Paye partiellement ou Abandon 'badsupplier'
-				if (($object->statut == FactureFournisseur::STATUS_CLOSED || $object->statut == FactureFournisseur::STATUS_ABANDONED) && $object->close_code == 'badsupplier') {
+				if (($object->status == FactureFournisseur::STATUS_CLOSED || $object->status == FactureFournisseur::STATUS_ABANDONED) && $object->close_code == 'badsupplier') {
 					print '<tr><td colspan="'.$nbcols.'" class="right nowrap">';
 					print '<span class="opacitymedium">';
 					print $form->textwithpicto($langs->trans("Abandoned"), $langs->trans("HelpAbandonBadCustomer"), - 1);
@@ -3824,7 +3838,7 @@ if ($action == 'create') {
 					$cssforamountpaymentcomplete = 'amountpaymentneutral';
 				}
 				// Paye partiellement ou Abandon 'product_returned'
-				if (($object->statut == FactureFournisseur::STATUS_CLOSED || $object->statut == FactureFournisseur::STATUS_ABANDONED) && $object->close_code == 'product_returned') {
+				if (($object->status == FactureFournisseur::STATUS_CLOSED || $object->status == FactureFournisseur::STATUS_ABANDONED) && $object->close_code == 'product_returned') {
 					print '<tr><td colspan="'.$nbcols.'" class="right nowrap">';
 					print '<span class="opacitymedium">';
 					print $form->textwithpicto($langs->trans("ProductReturned"), $langs->trans("HelpAbandonProductReturned"), - 1);
@@ -3834,7 +3848,7 @@ if ($action == 'create') {
 					$cssforamountpaymentcomplete = 'amountpaymentneutral';
 				}
 				// Paye partiellement ou Abandon 'abandon'
-				if (($object->statut == FactureFournisseur::STATUS_CLOSED || $object->statut == FactureFournisseur::STATUS_ABANDONED) && $object->close_code == 'abandon') {
+				if (($object->status == FactureFournisseur::STATUS_CLOSED || $object->status == FactureFournisseur::STATUS_ABANDONED) && $object->close_code == 'abandon') {
 					print '<tr><td colspan="'.$nbcols.'" class="right nowrap">';
 					$text = $langs->trans("HelpAbandonOther");
 					if ($object->close_note) {
@@ -3954,7 +3968,7 @@ if ($action == 'create') {
 			print '<input type="hidden" name="socid" value="'.$societe->id.'">';
 			print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
 
-			if (!empty($conf->use_javascript_ajax) && $object->statut == FactureFournisseur::STATUS_DRAFT) {
+			if (!empty($conf->use_javascript_ajax) && $object->status == FactureFournisseur::STATUS_DRAFT) {
 				include DOL_DOCUMENT_ROOT.'/core/tpl/ajaxrow.tpl.php';
 			}
 
@@ -3979,7 +3993,7 @@ if ($action == 'create') {
 			$num = count($object->lines);
 
 			// Form to add new line
-			if ($object->statut == FactureFournisseur::STATUS_DRAFT && $usercancreate) {
+			if ($object->status == FactureFournisseur::STATUS_DRAFT && $usercancreate) {
 				if ($action != 'editline') {
 					// Add free products/services
 
@@ -4014,7 +4028,7 @@ if ($action == 'create') {
 			// modified by hook
 			if (empty($reshook)) {
 				// Modify a validated invoice with no payments
-				if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $action != 'confirm_edit' && $object->getSommePaiement() == 0 && $usercancreate) {
+				if ($object->status == FactureFournisseur::STATUS_VALIDATED && $action != 'confirm_edit' && $object->getSommePaiement() == 0 && $usercancreate) {
 					// We check if lines of invoice are not already transferred into accountancy
 					$ventilExportCompta = $object->getVentilExportCompta(); // Should be 0 since the sum of payments are zero. But we keep the protection.
 
@@ -4032,7 +4046,7 @@ if ($action == 'create') {
 				if (($object->type == FactureFournisseur::TYPE_STANDARD || $object->type == FactureFournisseur::TYPE_REPLACEMENT
 					|| ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE && empty($discount->id))
 					|| ($object->type == FactureFournisseur::TYPE_DEPOSIT && empty($discount->id)))
-					&& ($object->statut == FactureFournisseur::STATUS_CLOSED || $object->statut == FactureFournisseur::STATUS_ABANDONED)) {				// A paid invoice (partially or completely)
+					&& ($object->status == FactureFournisseur::STATUS_CLOSED || $object->status == FactureFournisseur::STATUS_ABANDONED)) {				// A paid invoice (partially or completely)
 					if (!$objectidnext && $object->close_code != 'replaced' && $usercancreate) {	// Not replaced by another invoice
 						print '<a class="butAction'.($conf->use_javascript_ajax ? ' reposition' : '').'" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=reopen&token='.newToken().'">'.$langs->trans('ReOpen').'</a>';
 					} else {
@@ -4045,7 +4059,7 @@ if ($action == 'create') {
 				}
 
 				// Validate
-				if ($action != 'confirm_edit' && $object->statut == FactureFournisseur::STATUS_DRAFT) {
+				if ($action != 'confirm_edit' && $object->status == FactureFournisseur::STATUS_DRAFT) {
 					if (count($object->lines)) {
 						if ($usercanvalidate) {
 							print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=valid"';
@@ -4059,7 +4073,7 @@ if ($action == 'create') {
 
 				// Send by mail
 				if (empty($user->socid)) {
-					if (($object->statut == FactureFournisseur::STATUS_VALIDATED || $object->statut == FactureFournisseur::STATUS_CLOSED)) {
+					if (($object->status == FactureFournisseur::STATUS_VALIDATED || $object->status == FactureFournisseur::STATUS_CLOSED)) {
 						if ($usercansend) {
 							print '<a class="butAction" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=presend&mode=init#formmailbeforetitle">'.$langs->trans('SendMail').'</a>';
 						} else {
@@ -4069,14 +4083,14 @@ if ($action == 'create') {
 				}
 
 				// Create payment
-				if ($object->type != FactureFournisseur::TYPE_CREDIT_NOTE && $object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0) {
+				if ($object->type != FactureFournisseur::TYPE_CREDIT_NOTE && $object->status == FactureFournisseur::STATUS_VALIDATED && $object->paid == 0) {
 					print '<a class="butAction'.($conf->use_javascript_ajax ? ' reposition' : '').'" href="'.DOL_URL_ROOT.'/fourn/facture/paiement.php?facid='.$object->id.'&amp;action=create'.($object->fk_account > 0 ? '&amp;accountid='.$object->fk_account : '').'">'.$langs->trans('DoPayment').'</a>'; // must use facid because id is for payment id not invoice
 				}
 
 				// Reverse back money or convert to reduction
 				if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE || $object->type == FactureFournisseur::TYPE_DEPOSIT || $object->type == FactureFournisseur::TYPE_STANDARD) {
 					// For credit note only
-					if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE && $object->statut == 1 && $object->paye == 0) {
+					if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE && $object->status == 1 && $object->paid == 0) {
 						if ($resteapayer == 0) {
 							print '<span class="butActionRefused classfortooltip" title="'.$langs->trans("DisabledBecauseRemainderToPayIsZero").'">'.$langs->trans('DoPaymentBack').'</span>';
 						} else {
@@ -4085,23 +4099,23 @@ if ($action == 'create') {
 					}
 
 					// For standard invoice with excess paid
-					if ($object->type == FactureFournisseur::TYPE_STANDARD && empty($object->paye) && ($object->total_ttc - $totalpaid - $totalcreditnotes - $totaldeposits) < 0 && $usercancreate && empty($discount->id)) {
+					if ($object->type == FactureFournisseur::TYPE_STANDARD && empty($object->paid) && ($object->total_ttc - $totalpaid - $totalcreditnotes - $totaldeposits) < 0 && $usercancreate && empty($discount->id)) {
 						print '<a class="butAction'.($conf->use_javascript_ajax ? ' reposition' : '').'" href="'.$_SERVER["PHP_SELF"].'?facid='.$object->id.'&amp;action=converttoreduc">'.$langs->trans('ConvertExcessPaidToReduc').'</a>';
 					}
 					// For credit note
-					if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE && $object->statut == 1 && $object->paye == 0 && $usercancreate
+					if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE && $object->status == 1 && $object->paid == 0 && $usercancreate
 						&& (getDolGlobalString('SUPPLIER_INVOICE_ALLOW_REUSE_OF_CREDIT_WHEN_PARTIALLY_REFUNDED') || $object->getSommePaiement() == 0)
 					) {
 						print '<a class="butAction'.($conf->use_javascript_ajax ? ' reposition' : '').'" href="'.$_SERVER["PHP_SELF"].'?facid='.$object->id.'&amp;action=converttoreduc" title="'.dol_escape_htmltag($langs->trans("ConfirmConvertToReducSupplier2")).'">'.$langs->trans('ConvertToReduc').'</a>';
 					}
 					// For deposit invoice
-					if ($object->type == FactureFournisseur::TYPE_DEPOSIT && $usercancreate && $object->statut > 0 && empty($discount->id)) {
+					if ($object->type == FactureFournisseur::TYPE_DEPOSIT && $usercancreate && $object->status > 0 && empty($discount->id)) {
 						print '<a class="butAction'.($conf->use_javascript_ajax ? ' reposition' : '').'" href="'.$_SERVER["PHP_SELF"].'?facid='.$object->id.'&amp;action=converttoreduc">'.$langs->trans('ConvertToReduc').'</a>';
 					}
 				}
 
 				// Classify paid
-				if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0 && (
+				if ($object->status == FactureFournisseur::STATUS_VALIDATED && $object->paid == 0 && (
 					($object->type != FactureFournisseur::TYPE_CREDIT_NOTE && $object->type != FactureFournisseur::TYPE_DEPOSIT && ($resteapayer <= 0 || (getDolGlobalString('SUPPLIER_INVOICE_CAN_SET_PAID_EVEN_IF_PARTIALLY_PAID') && $object->total_ttc == $resteapayer))) ||
 						($object->type == FactureFournisseur::TYPE_CREDIT_NOTE && $resteapayer >= 0) ||
 						($object->type == FactureFournisseur::TYPE_DEPOSIT && $object->total_ttc > 0 && ($resteapayer == 0 || (getDolGlobalString('SUPPLIER_INVOICE_CAN_SET_PAID_EVEN_IF_PARTIALLY_PAID') && $object->total_ttc == $resteapayer)))
@@ -4111,7 +4125,7 @@ if ($action == 'create') {
 				}
 
 				// Classify 'closed not completely paid' (possible if validated and not yet filed paid)
-				if ($object->statut == FactureFournisseur::STATUS_VALIDATED && $object->paye == 0 && $resteapayer > 0 && (!getDolGlobalString('SUPPLIER_INVOICE_CAN_SET_PAID_EVEN_IF_PARTIALLY_PAID') || $object->total_ttc != $resteapayer)) {
+				if ($object->status == FactureFournisseur::STATUS_VALIDATED && $object->paid == 0 && $resteapayer > 0 && (!getDolGlobalString('SUPPLIER_INVOICE_CAN_SET_PAID_EVEN_IF_PARTIALLY_PAID') || $object->total_ttc != $resteapayer)) {
 					if ($totalpaid > 0 || $totalcreditnotes > 0) {
 						// If one payment or one credit note was linked to this invoice
 						print '<a class="butAction'.($conf->use_javascript_ajax ? ' reposition' : '').'" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&amp;action=paid">'.$langs->trans('ClassifyPaidPartially').'</a>';
@@ -4129,7 +4143,7 @@ if ($action == 'create') {
 				}*/
 
 				// Create a credit note
-				if (($object->type == FactureFournisseur::TYPE_STANDARD || $object->type == FactureFournisseur::TYPE_DEPOSIT) && $object->statut > 0 && $usercancreate) {
+				if (($object->type == FactureFournisseur::TYPE_STANDARD || $object->type == FactureFournisseur::TYPE_DEPOSIT) && $object->status > 0 && $usercancreate) {
 					if (!$objectidnext) {
 						print '<a class="butAction" href="'.$_SERVER['PHP_SELF'].'?socid='.$object->socid.'&amp;fac_avoir='.$object->id.'&amp;action=create&amp;type=2'.($object->fk_project > 0 ? '&amp;projectid='.$object->fk_project : '').'">'.$langs->trans("CreateCreditNote").'</a>';
 					}
@@ -4141,7 +4155,7 @@ if ($action == 'create') {
 				}
 
 				// Clone as predefined / Create template
-				if (($object->type ==  FactureFournisseur::TYPE_STANDARD || $object->type == FactureFournisseur::TYPE_DEPOSIT) && $object->statut == 0 && $usercancreate) {
+				if (($object->type ==  FactureFournisseur::TYPE_STANDARD || $object->type == FactureFournisseur::TYPE_DEPOSIT) && $object->status == 0 && $usercancreate) {
 					if (!$objectidnext && count($object->lines) > 0) {
 						print '<a class="butAction" href="'.DOL_URL_ROOT.'/fourn/facture/card-rec.php?facid='.$object->id.'&amp;action=create">'.$langs->trans("ChangeIntoRepeatableInvoice").'</a>';
 					}
@@ -4190,7 +4204,7 @@ if ($action == 'create') {
 					$somethingshown = $formfile->numoffiles;
 
 					// Show links to link elements
-					$linktoelem = $form->showLinkToObjectBlock($object, null, array('invoice_supplier'));
+					$linktoelem = $form->showLinkToObjectBlock($object, array(), array('invoice_supplier'));
 					$somethingshown = $form->showLinkedObjectBlock($object, $linktoelem);
 
 					print '</div><div class="fichehalfright">';

--- a/htdocs/reception/list.php
+++ b/htdocs/reception/list.php
@@ -410,6 +410,7 @@ if (empty($reshook)) {
 							// Negative line, we create a discount line
 							$discount = new DiscountAbsolute($db);
 							$discount->fk_soc = $objecttmp->socid;
+							$discount->socid = $objecttmp->socid;
 							$discount->amount_ht = abs($lines[$i]->total_ht);
 							$discount->amount_tva = abs($lines[$i]->total_tva);
 							$discount->amount_ttc = abs($lines[$i]->total_ttc);

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -2498,7 +2498,7 @@ class Societe extends CommonObject
 	/**
 	 * 	Returns amount of included taxes of the current discounts/credits available from the company
 	 *
-	 *	@param	User	$user			Filter on a user author of discounts
+	 *	@param	?User	$user			Filter on a user author of discounts
 	 * 	@param	string	$filter			Other filter
 	 * 	@param	integer	$maxvalue		Filter on max value for discount
 	 * 	@param	int		$discount_type	0 => customer discount, 1 => supplier discount

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -2464,6 +2464,7 @@ class Societe extends CommonObject
 
 			$discount = new DiscountAbsolute($this->db);
 			$discount->fk_soc = $this->id;
+			$discount->socid = $this->id;
 
 			$discount->discount_type = $discount_type;
 


### PR DESCRIPTION
# Fix card FactureFournisseur

Fix several phan notices for card.php for FactureFournisseur

(builds on deprecation fix for DiscountAbsolute).

@eldy 

### Issue 1
Phan reveals that the following line is curently a bug:
https://github.com/Dolibarr/dolibarr/blob/f61bd8c347e8acfd19c7745a5b5148b2aab42140/htdocs/fourn/facture/card.php#L837

\FactureFournisseur::createFromCurrent does not exist, \Facture::createFromCurrent does exist.
There are multiple solutions:
- Suppress this functionnality from fourn/facture/card
- Duplicate createFromCurrent in FactureFournisseur
- Move createFromCurrent to the CommonInvoice class (and ensure compatibility for child classes).

### Issue 2

'$i' is used two times outside the foreach loop and marked as possibly undeclared:

https://github.com/Dolibarr/dolibarr/blob/f61bd8c347e8acfd19c7745a5b5148b2aab42140/htdocs/fourn/facture/card.php#L1247

### Issue 3
special_code does not exist on FactureFournisseur:
https://github.com/Dolibarr/dolibarr/blob/f61bd8c347e8acfd19c7745a5b5148b2aab42140/htdocs/fourn/facture/card.php#L1331