### PR TITLE
NEW: consider document lines in element properties

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -12149,6 +12149,17 @@ function getElementProperties($elementType)
 		$subelement = $regs[2];
 	}
 
+	// Object lines will use parent classpath and module ref
+	if (substr($element_type, -3) == 'det') {
+		$module = preg_replace('/det$/', '', $element);
+		$subelement = preg_replace('/det$/', '', $subelement);
+		$classpath = $module.'/class';
+		$classfile = $module;
+		$classname = preg_replace('/det$/', 'Line', $element);
+		if (in_array($module, array('expedition', 'propale', 'facture', 'contrat', 'fichinter', 'commandefournisseur'))) {
+			$classname = preg_replace('/det$/', 'Ligne', $element);
+		}
+	}
 	// For compatibility and to work with non standard path
 	if ($elementType == "action") {
 		$classpath = 'comm/action/class';

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -12150,7 +12150,7 @@ function getElementProperties($elementType)
 	}
 
 	// Object lines will use parent classpath and module ref
-	if (substr($element_type, -3) == 'det') {
+	if (substr($elementType, -3) == 'det') {
 		$module = preg_replace('/det$/', '', $element);
 		$subelement = preg_replace('/det$/', '', $subelement);
 		$classpath = $module.'/class';


### PR DESCRIPTION
# NEW consider document lines in element properties
The getElementProperties() function does not get element properties for CommonObjectLine elements. I think it should.