### PR TITLE
FIX issue #29101 in mails_templates.php

### DIFF
--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -1041,7 +1041,7 @@ foreach ($fieldlist as $field => $value) {
 		}
 		$sortfieldtouse = ($sortable ? $fieldlist[$field] : '');
 		if ($sortfieldtouse == 'type_template') {
-			$sortfieldtouse .= 'type_template,lang,position,label';
+			$sortfieldtouse .= ',lang,position,label';
 		}
 		print getTitleFieldOfList($valuetoshow, 0, $_SERVER["PHP_SELF"], $sortfieldtouse, ($page ? 'page='.$page.'&' : ''), $param, '', $sortfield, $sortorder, $css.' ');
 	}


### PR DESCRIPTION
FIX #29101 Sort by email template fails with DB_ERROR_NOSUCHFIELD
Fix for issue #29101,  Sort by email template fails with DB_ERROR_NOSUCHFIELD  Unknown column 'type_templatetype_template' in 'order clause' 

