### PR TITLE
BugFix Autocomplete under dialog box

### DIFF
--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -5124,6 +5124,9 @@ div#card-errors {
 .ui-dialog.ui-corner-all.ui-widget.ui-widget-content.ui-front.ui-draggable {
 	z-index: 1005 !important;		/* Default 101 with ui-jquery, top menu have a z-index of 1000 */
 }
+.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front {
+	z-index:1006 !important; /* To always be over the dialog box */
+}
 .ui-dialog.ui-widget.ui-widget-content {
 	border: 1px solid #e0e0e0;
 	border-radius: 6px;


### PR DESCRIPTION
# FIX|Fix #Autocomplete was under dialog box

If the Product module configuration is set to : trigger search with a minimum of character (can also be seen on thirdparty module), the autocomplete results were displayed under the dialog box under certain circumstances. (see Pics below)

Before : 
![DoliBug001](https://github.com/Dolibarr/dolibarr/assets/50403308/afc64050-f666-48e8-955f-f2f449d10f89)

After :
![DoliBug002](https://github.com/Dolibarr/dolibarr/assets/50403308/35d20b77-ee9b-4259-834b-47e72e82f5be)
