### PR TITLE
QUAL: (breaking) Stop using deprecated $statut, $fk_statut

### DIFF
--- a/dev/initdata/import-users.php
+++ b/dev/initdata/import-users.php
@@ -3,6 +3,7 @@
 /* Copyright (C) 2016 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2016 Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,27 +30,27 @@
 // Test si mode batch
 $sapi_type = php_sapi_name();
 $script_file = basename(__FILE__);
-$path=dirname(__FILE__).'/';
+$path = dirname(__FILE__).'/';
 if (substr($sapi_type, 0, 3) == 'cgi') {
 	echo "Error: You are using PHP for CGI. To execute ".$script_file." from command line, you must use PHP for CLI mode.\n";
 	exit;
 }
 
 // Recupere root dolibarr
-$path=preg_replace('/import-users.php/i', '', $_SERVER["PHP_SELF"]);
+$path = preg_replace('/import-users.php/i', '', $_SERVER["PHP_SELF"]);
 require $path."../../htdocs/master.inc.php";
 include_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
 include_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 
-$delimiter=',';
-$enclosure='"';
-$linelength=10000;
-$escape='/';
+$delimiter = ',';
+$enclosure = '"';
+$linelength = 10000;
+$escape = '/';
 
 // Global variables
-$version=DOL_VERSION;
-$confirmed=1;
-$error=0;
+$version = DOL_VERSION;
+$confirmed = 1;
+$error = 0;
 
 
 /*
@@ -79,7 +80,7 @@ if (! file_exists($filepath)) {
 	exit(-1);
 }
 
-$ret=$user->fetch('', 'admin');
+$ret = $user->fetch('', 'admin');
 if (! $ret > 0) {
 	print 'A user with login "admin" and all permissions must be created to use this script.'."\n";
 	exit;
@@ -109,11 +110,11 @@ if (! $fhandleerr) {
 
 $db->begin();
 
-$i=0;
-$nboflines=0;
-while ($fields=fgetcsv($fhandle, $linelength, $delimiter, $enclosure, $escape)) {
+$i = 0;
+$nboflines = 0;
+while ($fields = fgetcsv($fhandle, $linelength, $delimiter, $enclosure, $escape)) {
 	$i++;
-	$errorrecord=0;
+	$errorrecord = 0;
 
 	if ($startlinenb && $i < $startlinenb) {
 		continue;
@@ -127,20 +128,20 @@ while ($fields=fgetcsv($fhandle, $linelength, $delimiter, $enclosure, $escape)) 
 	$object = new User($db);
 	$object->status = 1;
 
-	$tmp=explode(' ', $fields[3], 2);
+	$tmp = explode(' ', $fields[3], 2);
 	$object->firstname = trim($tmp[0]);
 	$object->lastname = trim($tmp[1]);
 	if ($object->lastname) {
 		$object->login = strtolower(substr($object->firstname, 0, 1)) . strtolower(substr($object->lastname, 0));
 	} else {
-		$object->login=strtolower($object->firstname);
+		$object->login = strtolower($object->firstname);
 	}
-	$object->login=preg_replace('/ /', '', $object->login);
+	$object->login = preg_replace('/ /', '', $object->login);
 	$object->password = 'init';
 
 	print "Process line nb ".$i.", login ".$object->login;
 
-	$ret=$object->create($user);
+	$ret = $object->create($user);
 	if ($ret < 0) {
 		print " - Error in create result code = ".$ret." - ".$object->errorsToString();
 		$errorrecord++;

--- a/htdocs/accountancy/admin/fiscalyear.php
+++ b/htdocs/accountancy/admin/fiscalyear.php
@@ -1,6 +1,7 @@
 <?php
-/* Copyright (C) 2013-2024  Alexandre Spangaro  <aspangaro@easya.solutions>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+/* Copyright (C) 2013-2024	Alexandre Spangaro	<aspangaro@easya.solutions>
+ * Copyright (C) 2024		Frédéric France		<frederic.france@free.fr>
+ * Copyright (C) 2024		MDW					<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -162,7 +163,6 @@ if ($result) {
 			$fiscalyearstatic->id = $obj->rowid;
 			$fiscalyearstatic->date_start = $obj->date_start;
 			$fiscalyearstatic->date_end = $obj->date_end;
-			$fiscalyearstatic->statut = $obj->status;
 			$fiscalyearstatic->status = $obj->status;
 
 			print '<tr class="oddeven">';

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -2821,7 +2821,6 @@ class BookKeeping extends CommonObject
 		$error = 0;
 		$this->db->begin();
 
-		$fiscal_period->statut = Fiscalyear::STATUS_CLOSED;
 		$fiscal_period->status = Fiscalyear::STATUS_CLOSED; // Actually not used
 		$result = $fiscal_period->update($user);
 		if ($result < 0) {

--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -350,7 +350,6 @@ if (empty($reshook)) {
 			}
 
 			// Get status and public property
-			$object->statut = GETPOSTINT("statut");
 			$object->status = GETPOSTINT("statut");
 			$object->public = GETPOSTINT("public");
 

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -1628,7 +1628,7 @@ class Adherent extends CommonObject
 		require_once DOL_DOCUMENT_ROOT.'/partnership/class/partnership.class.php';
 
 
-		$this->partnerships[] = array();
+		$this->partnerships = array();
 
 		return 1;
 	}

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -391,7 +391,6 @@ class Adherent extends CommonObject
 	public function __construct($db)
 	{
 		$this->db = $db;
-		$this->statut = self::STATUS_DRAFT;
 		$this->status = self::STATUS_DRAFT;
 		// l'adherent n'est pas public par default
 		$this->public = 0;
@@ -814,7 +813,7 @@ class Adherent extends CommonObject
 		$sql .= ", note_public = ".($this->note_public ? "'".$this->db->escape($this->note_public)."'" : "null");
 		$sql .= ", photo = ".($this->photo ? "'".$this->db->escape($this->photo)."'" : "null");
 		$sql .= ", public = ".(int) $this->public;
-		$sql .= ", statut = ".(int) $this->statut;
+		$sql .= ", statut = ".(int) $this->status;
 		$sql .= ", default_lang = ".(!empty($this->default_lang) ? "'".$this->db->escape($this->default_lang)."'" : "null");
 		$sql .= ", fk_adherent_type = ".(int) $this->typeid;
 		$sql .= ", morphy = '".$this->db->escape($this->morphy)."'";
@@ -1499,7 +1498,6 @@ class Adherent extends CommonObject
 				$this->socialnetworks = ($obj->socialnetworks ? (array) json_decode($obj->socialnetworks, true) : array());
 
 				$this->photo = $obj->photo;
-				$this->statut = $obj->statut;
 				$this->status = $obj->statut;
 				$this->public = $obj->public;
 
@@ -2007,7 +2005,7 @@ class Adherent extends CommonObject
 		$now = dol_now();
 
 		// Check parameters
-		if ($this->statut == self::STATUS_VALIDATED) {
+		if ($this->status == self::STATUS_VALIDATED) {
 			dol_syslog(get_class($this)."::validate statut of member does not allow this", LOG_WARNING);
 			return 0;
 		}
@@ -2023,7 +2021,7 @@ class Adherent extends CommonObject
 		dol_syslog(get_class($this)."::validate", LOG_DEBUG);
 		$result = $this->db->query($sql);
 		if ($result) {
-			$this->statut = self::STATUS_VALIDATED;
+			$this->status = self::STATUS_VALIDATED;
 
 			// Call trigger
 			$result = $this->call_trigger('MEMBER_VALIDATE', $user);
@@ -2059,7 +2057,7 @@ class Adherent extends CommonObject
 		$error = 0;
 
 		// Check parameters
-		if ($this->statut == self::STATUS_RESILIATED) {
+		if ($this->status == self::STATUS_RESILIATED) {
 			dol_syslog(get_class($this)."::resiliate statut of member does not allow this", LOG_WARNING);
 			return 0;
 		}
@@ -2073,7 +2071,7 @@ class Adherent extends CommonObject
 
 		$result = $this->db->query($sql);
 		if ($result) {
-			$this->statut = self::STATUS_RESILIATED;
+			$this->status = self::STATUS_RESILIATED;
 
 			// Call trigger
 			$result = $this->call_trigger('MEMBER_RESILIATE', $user);
@@ -2107,7 +2105,7 @@ class Adherent extends CommonObject
 		$error = 0;
 
 		// Check parameters
-		if ($this->statut == self::STATUS_EXCLUDED) {
+		if ($this->status == self::STATUS_EXCLUDED) {
 			dol_syslog(get_class($this)."::resiliate statut of member does not allow this", LOG_WARNING);
 			return 0;
 		}
@@ -2121,7 +2119,7 @@ class Adherent extends CommonObject
 
 		$result = $this->db->query($sql);
 		if ($result) {
-			$this->statut = self::STATUS_EXCLUDED;
+			$this->status = self::STATUS_EXCLUDED;
 
 			// Call trigger
 			$result = $this->call_trigger('MEMBER_EXCLUDE', $user);
@@ -2411,7 +2409,7 @@ class Adherent extends CommonObject
 		}
 		if (($withpictoimg > -2 && $withpictoimg != 2) || $withpictoimg == -4) {
 			if (!getDolGlobalString('MAIN_OPTIMIZEFORTEXTBROWSER')) {
-				$result .= '<span class="nopadding valignmiddle'.((!isset($this->statut) || $this->statut) ? '' : ' strikefordisabled').
+				$result .= '<span class="nopadding valignmiddle'.((!isset($this->status) || $this->status) ? '' : ' strikefordisabled').
 				($morecss ? ' usertext'.$morecss : '').'">';
 			}
 			if ($mode == 'login') {
@@ -2458,7 +2456,7 @@ class Adherent extends CommonObject
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut($this->statut, $this->need_subscription, $this->datefin, $mode);
+		return $this->LibStatut($this->status, $this->need_subscription, $this->datefin, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -2613,7 +2611,7 @@ class Adherent extends CommonObject
 				$response->nbtodo++;
 
 				$adherentstatic->datefin = $this->db->jdate($obj->datefin);
-				$adherentstatic->statut = $obj->statut;
+				$adherentstatic->status = $obj->statut;
 
 				if ($adherentstatic->hasDelay()) {
 					$response->nbtodolate++;
@@ -2708,7 +2706,6 @@ class Adherent extends CommonObject
 		$this->birth = $now;
 		$this->photo = '';
 		$this->public = 1;
-		$this->statut = self::STATUS_DRAFT;
 		$this->status = self::STATUS_DRAFT;
 
 		$this->datefin = $now;
@@ -2857,8 +2854,8 @@ class Adherent extends CommonObject
 		if ($this->birth && getDolGlobalString('LDAP_MEMBER_FIELD_BIRTHDATE')) {
 			$info[getDolGlobalString('LDAP_MEMBER_FIELD_BIRTHDATE')] = dol_print_date($this->birth, 'dayhourldap');
 		}
-		if (isset($this->statut) && getDolGlobalString('LDAP_FIELD_MEMBER_STATUS')) {
-			$info[getDolGlobalString('LDAP_FIELD_MEMBER_STATUS')] = $this->statut;
+		if (isset($this->status) && getDolGlobalString('LDAP_FIELD_MEMBER_STATUS')) {
+			$info[getDolGlobalString('LDAP_FIELD_MEMBER_STATUS')] = $this->status;
 		}
 		if ($this->datefin && getDolGlobalString('LDAP_FIELD_MEMBER_END_LASTSUBSCRIPTION')) {
 			$info[getDolGlobalString('LDAP_FIELD_MEMBER_END_LASTSUBSCRIPTION')] = dol_print_date($this->datefin, 'dayhourldap');
@@ -3016,7 +3013,7 @@ class Adherent extends CommonObject
 		global $conf;
 
 		//Only valid members
-		if ($this->statut != self::STATUS_VALIDATED) {
+		if ($this->status != self::STATUS_VALIDATED) {
 			return false;
 		}
 		if (!$this->datefin) {

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -533,11 +533,11 @@ class Members extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of CommonObject
+	 * @template T of Object
 	 * @param   T	$object		Object to clean
-	 * @phan-param CommonObject	$object
+	 * @phan-param Object	$object
 	 * @return	T				Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -538,6 +538,7 @@ class Members extends DolibarrApi
 	 * @phan-param Object	$object
 	 * @return	T				Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -531,10 +531,13 @@ class Members extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object    	Object to clean
-	 * @return  Object    			Object with cleaned properties
+	 * @template T of CommonObject
+	 * @param   T	$object		Object to clean
+	 * @phan-param CommonObject	$object
+	 * @return	T				Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/adherents/class/subscription.class.php
+++ b/htdocs/adherents/class/subscription.class.php
@@ -440,7 +440,7 @@ class Subscription extends CommonObject
 		$langs->load("members");
 
 		$label = img_picto('', $this->picto).' <u class="paddingrightonly">'.$langs->trans("Subscription").'</u>';
-		/*if (isset($this->statut)) {
+		/*if (isset($this->status)) {
 			$label .= ' '.$this->getLibStatut(5);
 		}*/
 		$label .= '<br><b>'.$langs->trans('Ref').':</b> '.$this->ref;

--- a/htdocs/adherents/partnership.php
+++ b/htdocs/adherents/partnership.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2021		NextGestion					<contact@nextgestion.com>
  * Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -272,12 +273,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		} else {
 			if (!$adht->subscription) {
 				print $langs->trans("SubscriptionNotRecorded");
-				if ($fadherent->statut > 0) {
+				if ($fadherent->status > 0) {
 					print " ".img_warning($langs->trans("Late")); // Display a delay picto only if it is not a draft and is not canceled
 				}
 			} else {
 				print $langs->trans("SubscriptionNotReceived");
-				if ($fadherent->statut > 0) {
+				if ($fadherent->status > 0) {
 					print " ".img_warning($langs->trans("Late")); // Display a delay picto only if it is not a draft and is not canceled
 				}
 			}

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -559,12 +559,12 @@ if ($object->datefin) {
 		print $langs->trans("SubscriptionNotNeeded");
 	} elseif (!$adht->subscription) {
 		print $langs->trans("SubscriptionNotRecorded");
-		if (Adherent::STATUS_VALIDATED == $object->statut) {
+		if (Adherent::STATUS_VALIDATED == $object->status) {
 			print " ".img_warning($langs->trans("Late")); // displays delay Pictogram only if not a draft, not excluded and not resiliated
 		}
 	} else {
 		print $langs->trans("SubscriptionNotReceived");
-		if (Adherent::STATUS_VALIDATED == $object->statut) {
+		if (Adherent::STATUS_VALIDATED == $object->status) {
 			print " ".img_warning($langs->trans("Late")); // displays delay Pictogram only if not a draft, not excluded and not resiliated
 		}
 	}

--- a/htdocs/adherents/subscription/list.php
+++ b/htdocs/adherents/subscription/list.php
@@ -623,7 +623,6 @@ while ($i < $imaxinloop) {
 	$adherent->firstname = $obj->firstname;
 	$adherent->ref = $obj->rowid;
 	$adherent->id = $obj->rowid;
-	$adherent->statut = $obj->status;
 	$adherent->status = $obj->status;
 	$adherent->login = $obj->login;
 	$adherent->photo = $obj->photo;

--- a/htdocs/adherents/type.php
+++ b/htdocs/adherents/type.php
@@ -876,7 +876,6 @@ if ($rowid > 0) {
 				$adh->firstname = $objp->firstname;
 				$adh->datefin = $datefin;
 				$adh->need_subscription = $objp->subscription;
-				$adh->statut = $objp->status;
 				$adh->status = $objp->status;
 				$adh->email = $objp->email;
 				$adh->photo = $objp->photo;

--- a/htdocs/admin/emailcollector_card.php
+++ b/htdocs/admin/emailcollector_card.php
@@ -106,7 +106,7 @@ include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'inclu
 // Security check - Protection if external user
 //if ($user->socid > 0) accessforbidden();
 //if ($user->socid > 0) $socid = $user->socid;
-//$isdraft = (($object->statut == MyObject::STATUS_DRAFT) ? 1 : 0);
+//$isdraft = (($object->status == MyObject::STATUS_DRAFT) ? 1 : 0);
 //$result = restrictedArea($user, 'mymodule', $object->id, '', '', 'fk_soc', 'rowid', $isdraft);
 
 $permissionnote = $user->admin; // Used by the include of actions_setnotes.inc.php

--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -129,9 +129,10 @@ class DolibarrApi
 	/**
 	 * Filter properties that will be returned on object
 	 *
-	 * @param   Object  $object			Object to clean
-	 * @param   String  $properties		Comma separated list of properties names
-	 * @return	Object					Object with cleaned properties
+	 * @template T of object
+	 * @param   T		$object			Object to clean
+	 * @param   string  $properties		Comma separated list of properties names
+	 * @return	T						Object with cleaned properties
 	 */
 	protected function _filterObjectProperties($object, $properties)
 	{
@@ -187,7 +188,7 @@ class DolibarrApi
 	protected function _cleanObjectDatas($object)
 	{
 		// phpcs:enable
-		// Remove $db object property for object
+		// Remove $db object property from object
 		unset($object->db);
 		unset($object->isextrafieldmanaged);
 		unset($object->ismultientitymanaged);
@@ -216,11 +217,11 @@ class DolibarrApi
 
 		unset($object->mode_reglement);		// We use mode_reglement_id now
 		unset($object->cond_reglement);		// We use cond_reglement_id now
-		unset($object->note);				// We use note_public or note_private now
+		// unset($object->note);				// We use note_public or note_private now - disabled now because unsetting note unsets note_private.
 		unset($object->contact);			// We use contact_id now
 		unset($object->thirdparty);			// We use thirdparty_id or fk_soc or socid now
 
-		unset($object->projet); // Should be fk_project
+		// unset($object->projet); // Should be fk_project // already unset by next line
 		unset($object->project); // Should be fk_project
 		unset($object->fk_projet); // Should be fk_project
 		unset($object->author); // Should be fk_user_author
@@ -238,7 +239,7 @@ class DolibarrApi
 		unset($object->name_bis);
 		unset($object->newref);
 		unset($object->oldref);
-		unset($object->alreadypaid);
+		// unset($object->alreadypaid);  // Disable unset because it also unsets totalpaid
 		unset($object->openid);
 		unset($object->fk_bank);
 		unset($object->showphoto_on_popup);

--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -131,10 +131,10 @@ class DolibarrApi
 	 *
 	 * @template T of object
 	 * @param   T		$object			Object to clean
-	 * @phan-param CommonObject		$object
+	 * @phan-param Object		$object
 	 * @param   string  $properties		Comma separated list of properties names
 	 * @return	T						Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _filterObjectProperties($object, $properties)
 	{

--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -131,8 +131,10 @@ class DolibarrApi
 	 *
 	 * @template T of object
 	 * @param   T		$object			Object to clean
+	 * @phan-param CommonObject		$object
 	 * @param   string  $properties		Comma separated list of properties names
 	 * @return	T						Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _filterObjectProperties($object, $properties)
 	{

--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -135,6 +135,7 @@ class DolibarrApi
 	 * @param   string  $properties		Comma separated list of properties names
 	 * @return	T						Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _filterObjectProperties($object, $properties)
 	{

--- a/htdocs/api/class/api_access.class.php
+++ b/htdocs/api/class/api_access.class.php
@@ -176,7 +176,7 @@ class DolibarrApiAccess implements iAuthenticate
 			}
 
 			// Check if user status is enabled
-			if ($fuser->statut != $fuser::STATUS_ENABLED) {
+			if ($fuser->status != $fuser::STATUS_ENABLED) {
 				// Status is disabled
 				dol_syslog("functions_isallowed::check_user_api_key Authentication KO for '".$login."': The user has been disabled", LOG_NOTICE);
 				sleep(1); // Anti brute force protection. Must be same delay when user and password are not valid.

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -800,11 +800,11 @@ class Setup extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of CommonObject
+	 * @template T of Object
 	 * @param   T	$object		Object to clean
-	 * @phan-param CommonObject	$object
+	 * @phan-param Object	$object
 	 * @return	T				Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -798,10 +798,13 @@ class Setup extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param 	Object    $object    	Object to clean
-	 * @return 	Object 					Object with cleaned properties
+	 * @template T of CommonObject
+	 * @param   T	$object		Object to clean
+	 * @phan-param CommonObject	$object
+	 * @return	T				Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -805,6 +805,7 @@ class Setup extends DolibarrApi
 	 * @phan-param Object	$object
 	 * @return	T				Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/bom/bom_net_needs.php
+++ b/htdocs/bom/bom_net_needs.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2017-2020  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2019-2024  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -135,7 +136,7 @@ $form = new Form($db);
 $formfile = new FormFile($db);
 
 $title = $langs->trans('BOM');
-$help_url ='EN:Module_BOM';
+$help_url = 'EN:Module_BOM';
 
 llxHeader('', $title, $help_url, '', 0, 0, '', '', '', 'mod-bom page-net_needs');
 
@@ -258,6 +259,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	print '</thead>';
 	print '<tbody>';
 	if (count($TChildBom) > 0) {
+		'@phan-var-force array<int,array{bom:BOM,parentid:int,level:int,qty:float,product:array<int,array{level:int,qty:float}>}> $TChildBom';
 		if ($action == 'treeview') {
 			foreach ($TChildBom as $fk_bom => $TProduct) {
 				$repeatChar = '&emsp;';

--- a/htdocs/bom/class/api_boms.class.php
+++ b/htdocs/bom/class/api_boms.class.php
@@ -502,7 +502,9 @@ class Boms extends DolibarrApi
 	 *
 	 * @template T of CommonObject
 	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
 	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/bom/class/api_boms.class.php
+++ b/htdocs/bom/class/api_boms.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2019 Maxime Kohlhaas <maxime@atm-consulting.fr>
  * Copyright (C) 2020-2024  Frédéric France		<frederic.france@free.fr>
  * Copyright (C) 2022		Christian Humpel		<christian.humpel@live.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -499,8 +500,9 @@ class Boms extends DolibarrApi
 	/**
 	 * Clean sensible object datas
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of CommonObject
+	 * @param   T  $object     Object to clean
+	 * @return  T              Object with cleaned properties
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -514,7 +516,7 @@ class Boms extends DolibarrApi
 		unset($object->lastname);
 		unset($object->firstname);
 		unset($object->civility_id);
-		unset($object->statut);
+		unset($object->status);
 		unset($object->state);
 		unset($object->state_id);
 		unset($object->state_code);

--- a/htdocs/bom/class/api_boms.class.php
+++ b/htdocs/bom/class/api_boms.class.php
@@ -500,11 +500,11 @@ class Boms extends DolibarrApi
 	/**
 	 * Clean sensible object datas
 	 *
-	 * @template T of CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/bom/class/api_boms.class.php
+++ b/htdocs/bom/class/api_boms.class.php
@@ -505,6 +505,7 @@ class Boms extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -599,7 +599,7 @@ class BOM extends CommonObject
 		$logtext .= ", fk_bom_child=$fk_bom_child, import_key=$import_key";
 		dol_syslog(get_class($this).$logtext, LOG_DEBUG);
 
-		if ($this->statut == self::STATUS_DRAFT) {
+		if ($this->status == self::STATUS_DRAFT) {
 			include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
 
 			// Clean parameters
@@ -707,7 +707,7 @@ class BOM extends CommonObject
 		$logtext .= ", import_key=$import_key";
 		dol_syslog(get_class($this).$logtext, LOG_DEBUG);
 
-		if ($this->statut == self::STATUS_DRAFT) {
+		if ($this->status == self::STATUS_DRAFT) {
 			include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
 
 			// Clean parameters

--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -680,9 +680,9 @@ class Categories extends DolibarrApi
 	 *
 	 * @template T of \Categorie
 	 * @param   T  $object		Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T     			Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -680,7 +680,9 @@ class Categories extends DolibarrApi
 	 *
 	 * @template T of \Categorie
 	 * @param   T  $object		Object to clean
+	 * @phan-param CommonObject  $object
 	 * @return  T     			Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -683,6 +683,7 @@ class Categories extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T     			Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2015       Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2024       Jose MARTINEZ			<jose.martinez@pichinov.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -677,8 +678,9 @@ class Categories extends DolibarrApi
 	/**
 	 * Clean sensible object datas
 	 *
-	 * @param   Categorie  $object  Object to clean
-	 * @return  Object     			Object with cleaned properties
+	 * @template T of \Categorie
+	 * @param   T  $object		Object to clean
+	 * @return  T     			Object with cleaned properties
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -725,7 +727,7 @@ class Categories extends DolibarrApi
 		unset($object->fk_account);
 		unset($object->fk_project);
 		unset($object->note);
-		unset($object->statut);
+		unset($object->status);
 
 		return $object;
 	}

--- a/htdocs/comm/action/class/api_agendaevents.class.php
+++ b/htdocs/comm/action/class/api_agendaevents.class.php
@@ -364,11 +364,11 @@ class AgendaEvents extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/comm/action/class/api_agendaevents.class.php
+++ b/htdocs/comm/action/class/api_agendaevents.class.php
@@ -364,8 +364,9 @@ class AgendaEvents extends DolibarrApi
 	/**
 	 * Clean sensible object datas
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @return  T              Object with cleaned properties
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -384,7 +385,7 @@ class AgendaEvents extends DolibarrApi
 		unset($object->origin);
 		unset($object->origin_id);
 		unset($object->ref_ext);
-		unset($object->statut);
+		unset($object->status);
 		unset($object->state_code);
 		unset($object->state_id);
 		unset($object->state);

--- a/htdocs/comm/action/class/api_agendaevents.class.php
+++ b/htdocs/comm/action/class/api_agendaevents.class.php
@@ -369,6 +369,7 @@ class AgendaEvents extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/comm/action/class/api_agendaevents.class.php
+++ b/htdocs/comm/action/class/api_agendaevents.class.php
@@ -362,11 +362,13 @@ class AgendaEvents extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
 	 * @template T of \CommonObject
 	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
 	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -1238,7 +1238,6 @@ if ($object->id > 0) {
 				$contrat->ref_customer = $objp->refcus;
 				$contrat->ref_supplier = $objp->refsup;
 				$contrat->fk_project = $objp->fk_projet;
-				$contrat->statut = $objp->contract_status;
 				$contrat->status = $objp->contract_status;
 				$contrat->last_main_doc = $objp->last_main_doc;
 				$contrat->model_pdf = $objp->model_pdf;
@@ -1246,7 +1245,7 @@ if ($object->id > 0) {
 
 				$late = '';
 				foreach ($contrat->lines as $line) {
-					if ($contrat->status == Contrat::STATUS_VALIDATED && $line->statut == ContratLigne::STATUS_OPEN) {
+					if ($contrat->status == Contrat::STATUS_VALIDATED && $line->status == ContratLigne::STATUS_OPEN) {
 						if (((!empty($line->date_end) ? $line->date_end : 0) + $conf->contrat->services->expires->warning_delay) < $now) {
 							$late = img_warning($langs->trans("Late"));
 						}
@@ -1351,7 +1350,6 @@ if ($object->id > 0) {
 
 				$fichinter_static->id = $objp->id;
 				$fichinter_static->ref = $objp->ref;
-				$fichinter_static->statut = $objp->fk_statut;
 				$fichinter_static->fk_project = $objp->fk_projet;
 
 				print '<tr class="oddeven">';
@@ -1575,7 +1573,6 @@ if ($object->id > 0) {
 				$facturestatic->total_ht = $objp->total_ht;
 				$facturestatic->total_tva = $objp->total_tva;
 				$facturestatic->total_ttc = $objp->total_ttc;
-				$facturestatic->statut = $objp->status;
 				$facturestatic->status = $objp->status;
 				$facturestatic->paye = $objp->paye;
 				$facturestatic->alreadypaid = $objp->am;

--- a/htdocs/comm/index.php
+++ b/htdocs/comm/index.php
@@ -196,7 +196,6 @@ if (isModEnabled("propal") && $user->hasRight("propal", "lire") && is_object($pr
 				$propalstatic->total_ht = $obj->total_ht;
 				$propalstatic->total_tva = $obj->total_tva;
 				$propalstatic->total_ttc = $obj->total_ttc;
-				$propalstatic->statut = $obj->status;
 				$propalstatic->status = $obj->status;
 
 				$companystatic->id = $obj->socid;
@@ -295,7 +294,6 @@ if (isModEnabled('supplier_proposal') && $user->hasRight("supplier_proposal", "l
 				$supplierproposalstatic->total_ht = $obj->total_ht;
 				$supplierproposalstatic->total_tva = $obj->total_tva;
 				$supplierproposalstatic->total_ttc = $obj->total_ttc;
-				$supplierproposalstatic->statut = $obj->status;
 				$supplierproposalstatic->status = $obj->status;
 
 				$companystatic->id = $obj->socid;
@@ -395,7 +393,6 @@ if (isModEnabled('order') && $user->hasRight('commande', 'lire') && is_object($o
 				$orderstatic->total_ht = $obj->total_ht;
 				$orderstatic->total_tva = $obj->total_tva;
 				$orderstatic->total_ttc = $obj->total_ttc;
-				$orderstatic->statut = $obj->status;
 				$orderstatic->status = $obj->status;
 
 				$companystatic->id = $obj->socid;
@@ -497,7 +494,6 @@ if ((isModEnabled("fournisseur") && !getDolGlobalString('MAIN_USE_NEW_SUPPLIERMO
 				$supplierorderstatic->total_ht = $obj->total_ht;
 				$supplierorderstatic->total_tva = $obj->total_tva;
 				$supplierorderstatic->total_ttc = $obj->total_ttc;
-				$supplierorderstatic->statut = $obj->status;
 				$supplierorderstatic->status = $obj->status;
 
 				$companystatic->id = $obj->socid;
@@ -586,7 +582,6 @@ if (isModEnabled('intervention') && is_object($fichinterstatic)) {
 
 				$fichinterstatic->id = $obj->rowid;
 				$fichinterstatic->ref = $obj->ref;
-				$fichinterstatic->statut = $obj->fk_statut;
 				$fichinterstatic->status = $obj->fk_statut;
 
 				$companystatic->id = $obj->socid;

--- a/htdocs/comm/mailing/class/mailing.class.php
+++ b/htdocs/comm/mailing/class/mailing.class.php
@@ -1,9 +1,9 @@
 <?php
-/* Copyright (C) 2005      Rodolphe Quiedeville <rodolphe@quiedeville.org>
- * Copyright (C) 2005-2016 Laurent Destailleur  <eldy@users.sourceforge.net>
- * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
- * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2005		Rodolphe Quiedeville	<rodolphe@quiedeville.org>
+ * Copyright (C) 2005-2016	Laurent Destailleur		<eldy@users.sourceforge.net>
+ * Copyright (C) 2005-2009	Regis Houssin			<regis.houssin@inodbox.com>
+ * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -87,12 +87,6 @@ class Mailing extends CommonObject
 	 * @var string background image
 	 */
 	public $bgimage;
-
-	/**
-	 * @var int status
-	 * @deprecated Use $status
-	 */
-	public $statut; // Status 0=Draft, 1=Validated, 2=Sent partially, 3=Sent completely
 
 	/**
 	 * @var int status
@@ -370,7 +364,6 @@ class Mailing extends CommonObject
 				$this->title = $obj->title;
 				$this->messtype = $obj->messtype;
 
-				$this->statut = $obj->status;	// deprecated
 				$this->status = $obj->status;
 
 				$this->nbemail = $obj->nbemail;
@@ -438,7 +431,6 @@ class Mailing extends CommonObject
 		$object->fetch($fromid);
 		$object->id = 0;
 		$object->status = 0;
-		$object->statut = 0;
 
 		// Clear fields
 		$object->title = $langs->trans("CopyOf").' '.$object->title.' '.dol_print_date(dol_now());

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -1007,10 +1007,13 @@ class Proposals extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -1014,6 +1014,7 @@ class Proposals extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -1009,11 +1009,11 @@ class Proposals extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -125,14 +125,6 @@ class Propal extends CommonObject
 	/**
 	 * Status of the quote
 	 * @var int
-	 * @deprecated Try to use $status now
-	 * @see Propal::STATUS_DRAFT, Propal::STATUS_VALIDATED, Propal::STATUS_SIGNED, Propal::STATUS_NOTSIGNED, Propal::STATUS_BILLED, Propal::STATUS_CANCELED
-	 */
-	public $statut;
-
-	/**
-	 * Status of the quote
-	 * @var int
 	 * @see Propal::STATUS_DRAFT, Propal::STATUS_VALIDATED, Propal::STATUS_SIGNED, Propal::STATUS_NOTSIGNED, Propal::STATUS_BILLED, Propal::STATUS_CANCELED
 	 */
 	public $status;

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2015   	Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016		Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1114,10 +1115,13 @@ class Orders extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object			Object to clean
-	 * @return  Object					Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -1137,8 +1141,8 @@ class Orders extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param   array           $data   Array with data to verify
-	 * @return  array
+	 * @param   array<string,mixed>		$data   Array with data to verify
+	 * @return  array<string,mixed>
 	 * @throws  RestException
 	 */
 	private function _validate($data)

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -1122,6 +1122,7 @@ class Orders extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -1117,11 +1117,11 @@ class Orders extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -114,7 +114,7 @@ class Commande extends CommonOrder
 	 * Status of the order
 	 * @var int
 	 */
-	public $statut;
+	public $status;
 
 	/**
 	 * @var int Status Billed or not
@@ -3393,7 +3393,7 @@ class Commande extends CommonOrder
 		$sql .= " localtax2=".(isset($this->total_localtax2) ? $this->total_localtax2 : "null").",";
 		$sql .= " total_ht=".(isset($this->total_ht) ? $this->total_ht : "null").",";
 		$sql .= " total_ttc=".(isset($this->total_ttc) ? $this->total_ttc : "null").",";
-		$sql .= " fk_statut=".(isset($this->statut) ? $this->statut : "null").",";
+		$sql .= " fk_statut=".(isset($this->status) ? (int) $this->status : "null").",";
 		$sql .= " fk_user_modif=".(isset($user->id) ? $user->id : "null").",";
 		$sql .= " fk_user_valid=".((isset($this->user_validation_id) && $this->user_validation_id > 0) ? $this->user_validation_id : "null").",";
 		$sql .= " fk_projet=".(isset($this->fk_project) ? $this->fk_project : "null").",";
@@ -3657,7 +3657,7 @@ class Commande extends CommonOrder
 				$response->nbtodo++;
 				$response->total += $obj->total_ht;
 
-				$generic_commande->statut = $obj->fk_statut;
+				$generic_commande->status = $obj->fk_statut;
 				$generic_commande->date_commande = $this->db->jdate($obj->date_commande);
 				$generic_commande->date = $this->db->jdate($obj->date_commande);
 				$generic_commande->delivery_date = $this->db->jdate($obj->delivery_date);

--- a/htdocs/compta/bank/class/api_bankaccounts.class.php
+++ b/htdocs/compta/bank/class/api_bankaccounts.class.php
@@ -411,11 +411,11 @@ class BankAccounts extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/compta/bank/class/api_bankaccounts.class.php
+++ b/htdocs/compta/bank/class/api_bankaccounts.class.php
@@ -409,10 +409,13 @@ class BankAccounts extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/compta/bank/class/api_bankaccounts.class.php
+++ b/htdocs/compta/bank/class/api_bankaccounts.class.php
@@ -416,6 +416,7 @@ class BankAccounts extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/compta/deplacement/class/deplacement.class.php
+++ b/htdocs/compta/deplacement/class/deplacement.class.php
@@ -103,7 +103,7 @@ class Deplacement extends CommonObject
 	/**
 	 * @var int Status 0=draft, 1=validated, 2=Refunded
 	 */
-	public $statut;
+	public $status;
 	/**
 	 * @var array<string,string>  (Encoded as JSON in database)
 	 */
@@ -248,7 +248,7 @@ class Deplacement extends CommonObject
 		$sql .= " SET km = ".((float) $this->km); // This is a distance or amount
 		$sql .= " , dated = '".$this->db->idate($this->date)."'";
 		$sql .= " , type = '".$this->db->escape($this->type)."'";
-		$sql .= " , fk_statut = '".$this->db->escape($this->statut)."'";
+		$sql .= " , fk_statut = '".$this->db->escape($this->status)."'";
 		$sql .= " , fk_user = ".((int) $this->fk_user);
 		$sql .= " , fk_user_modif = ".((int) $user->id);
 		$sql .= " , fk_soc = ".($this->socid > 0 ? $this->socid : 'null');
@@ -299,7 +299,7 @@ class Deplacement extends CommonObject
 			$this->socid		= $obj->fk_soc;
 			$this->km = $obj->km;
 			$this->type			= $obj->type;
-			$this->statut	    = $obj->fk_statut;
+			$this->status	    = $obj->fk_statut;
 			$this->note_private = $obj->note_private;
 			$this->note_public	= $obj->note_public;
 			$this->fk_project	= $obj->fk_project;
@@ -348,7 +348,7 @@ class Deplacement extends CommonObject
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut($this->statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -1889,11 +1889,11 @@ class Invoices extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanTemplateObjectDatas($object)
 	{

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -1887,17 +1887,20 @@ class Invoices extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanTemplateObjectDatas($object)
 	{
 		// phpcs:enable
 		$object = parent::_cleanObjectDatas($object);
 
-		unset($object->note);
+		// unset($object->note);   // Removed unset because this also unsets note_private
 		unset($object->address);
 		unset($object->barcode_type);
 		unset($object->barcode_type_code);

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -1894,6 +1894,7 @@ class Invoices extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanTemplateObjectDatas($object)
 	{

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2237,7 +2237,7 @@ class Facture extends CommonInvoice
 				$this->total_localtax2		= $obj->localtax2;
 				$this->total_ttc			= $obj->total_ttc;
 				$this->revenuestamp         = $obj->revenuestamp;
-				$this->paye                 = $obj->paye;
+				$this->paid                 = $obj->paye;
 				$this->close_code			= $obj->close_code;
 				$this->close_note			= $obj->close_note;
 
@@ -2563,7 +2563,7 @@ class Facture extends CommonInvoice
 		$sql .= " datef=".(strval($this->date) != '' ? "'".$this->db->idate($this->date)."'" : 'null').",";
 		$sql .= " date_pointoftax=".(strval($this->date_pointoftax) != '' ? "'".$this->db->idate($this->date_pointoftax)."'" : 'null').",";
 		$sql .= " date_valid=".(strval($this->date_validation) != '' ? "'".$this->db->idate($this->date_validation)."'" : 'null').",";
-		$sql .= " paye=".(isset($this->paye) ? $this->db->escape($this->paye) : 0).",";
+		$sql .= " paye=".(isset($this->paid) ? (int) $this->paid : 0).",";
 		$sql .= " close_code=".(isset($this->close_code) ? "'".$this->db->escape($this->close_code)."'" : "null").",";
 		$sql .= " close_note=".(isset($this->close_note) ? "'".$this->db->escape($this->close_note)."'" : "null").",";
 		$sql .= " total_tva=".(isset($this->total_tva) ? (float) $this->total_tva : "null").",";
@@ -2935,9 +2935,9 @@ class Facture extends CommonInvoice
 
 					// On efface le repertoire de pdf provisoire
 					$ref = dol_sanitizeFileName($this->ref);
-					if ($conf->facture->dir_output && !empty($this->ref)) {
-						$dir = $conf->facture->dir_output."/".$ref;
-						$file = $conf->facture->dir_output."/".$ref."/".$ref.".pdf";
+					if ($conf->invoice->dir_output && !empty($this->ref)) {
+						$dir = $conf->invoice->dir_output."/".$ref;
+						$file = $conf->invoice->dir_output."/".$ref."/".$ref.".pdf";
 						if (file_exists($file)) {	// We must delete all files before deleting directory
 							$ret = dol_delete_preview($this);
 
@@ -2982,7 +2982,7 @@ class Facture extends CommonInvoice
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
-	 *  Tag the invoice as paid completely (if close_code is filled) => this->fk_statut=2, this->paye=1
+	 *  Tag the invoice as paid completely (if close_code is filled) => this->fk_statut=2, this->paid=1
 	 *  or partially (if close_code filled) + appel trigger BILL_PAYED => this->fk_statut=2, this->paye stay 0
 	 *
 	 *	@deprecated
@@ -3001,8 +3001,8 @@ class Facture extends CommonInvoice
 
 	/**
 	 *  Tag the invoice as :
-	 *  - paid completely (if close_code is not filled) => this->fk_statut=2, this->paye=1
-	 *  - or partially (if close_code filled) + appel trigger BILL_PAYED => this->fk_statut=2, this->paye stay 0
+	 *  - paid completely (if close_code is not filled) => this->fk_statut=2, this->paid=1
+	 *  - or partially (if close_code filled) + appel trigger BILL_PAYED => this->fk_statut=2, this->paid stay 0
 	 *
 	 *  @param	User	$user      	Object user that modify
 	 *	@param  string	$close_code	Code set when forcing to set the invoice as fully paid while in practice it is incomplete (because of a discount (fr:escompte) for instance)
@@ -3013,7 +3013,7 @@ class Facture extends CommonInvoice
 	{
 		$error = 0;
 
-		if ($this->paye != 1) {
+		if ($this->paid != 1) {
 			$this->db->begin();
 
 			$now = dol_now();
@@ -3600,15 +3600,15 @@ class Facture extends CommonInvoice
 					// We rename directory ($this->ref = old ref, $num = new ref) in order not to lose the attachments
 					$oldref = dol_sanitizeFileName($this->ref);
 					$newref = dol_sanitizeFileName($num);
-					$dirsource = $conf->facture->dir_output.'/'.$oldref;
-					$dirdest = $conf->facture->dir_output.'/'.$newref;
+					$dirsource = $conf->invoice->dir_output.'/'.$oldref;
+					$dirdest = $conf->invoice->dir_output.'/'.$newref;
 					if (!$error && file_exists($dirsource)) {
 						dol_syslog(get_class($this)."::validate rename dir ".$dirsource." into ".$dirdest);
 
 						if (@rename($dirsource, $dirdest)) {
 							dol_syslog("Rename ok");
 							// Rename docs starting with $oldref with $newref
-							$listoffiles = dol_dir_list($conf->facture->dir_output.'/'.$newref, 'files', 1, '^'.preg_quote($oldref, '/'));
+							$listoffiles = dol_dir_list($conf->invoice->dir_output.'/'.$newref, 'files', 1, '^'.preg_quote($oldref, '/'));
 							foreach ($listoffiles as $fileentry) {
 								$dirsource = $fileentry['name'];
 								$dirdest = preg_replace('/^'.preg_quote($oldref, '/').'/', $newref, $dirsource);
@@ -5036,7 +5036,7 @@ class Facture extends CommonInvoice
 			$now = dol_now();
 
 			$response = new WorkboardResponse();
-			$response->warning_delay = $conf->facture->client->warning_delay / 60 / 60 / 24;
+			$response->warning_delay = $conf->invoice->client->warning_delay / 60 / 60 / 24;
 			$response->label = $langs->trans("CustomerBillsUnpaid");
 			$response->labelShort = $langs->trans("Unpaid");
 			$response->url = DOL_URL_ROOT.'/compta/facture/list.php?search_status=1&mainmenu=billing&leftmenu=customers_bills';
@@ -5145,7 +5145,6 @@ class Facture extends CommonInvoice
 
 		$this->note_public = 'This is a comment (public)';
 		$this->note_private = 'This is a comment (private)';
-		$this->note = 'This is a comment (private)';
 
 		$this->fk_user_author = $user->id;
 
@@ -5533,15 +5532,15 @@ class Facture extends CommonInvoice
 			return false;
 		}
 
-		$hasDelay = $this->date_lim_reglement < ($now - $conf->facture->client->warning_delay);
+		$hasDelay = $this->date_lim_reglement < ($now - $conf->invoice->client->warning_delay);
 		if ($hasDelay && !empty($this->retained_warranty) && !empty($this->retained_warranty_date_limit)) {
 			$totalpaid = $this->getSommePaiement();
 			$totalpaid = (float) $totalpaid;
 			$RetainedWarrantyAmount = $this->getRetainedWarrantyAmount();
 			if ($totalpaid >= 0 && $RetainedWarrantyAmount >= 0) {
-				if (($totalpaid < $this->total_ttc - $RetainedWarrantyAmount) && $this->date_lim_reglement < ($now - $conf->facture->client->warning_delay)) {
+				if (($totalpaid < $this->total_ttc - $RetainedWarrantyAmount) && $this->date_lim_reglement < ($now - $conf->invoice->client->warning_delay)) {
 					$hasDelay = 1;
-				} elseif ($totalpaid < $this->total_ttc && $this->retained_warranty_date_limit < ($now - $conf->facture->client->warning_delay)) {
+				} elseif ($totalpaid < $this->total_ttc && $this->retained_warranty_date_limit < ($now - $conf->invoice->client->warning_delay)) {
 					$hasDelay = 1;
 				} else {
 					$hasDelay = 0;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -169,11 +169,11 @@ class Facture extends CommonInvoice
 	public $resteapayer;
 
 	/**
-	 *
 	 * @var int<0,1> 1 if invoice paid COMPLETELY, 0 otherwise
-	 * @deprecated * Use statut and close_code)
+	 *
+	 * @deprecated Use $status and close_code
 	 */
-	public $paye;
+	public $paid;
 
 	/**
 	 * @var string key of module source when invoice generated from a dedicated module ('cashdesk', 'takepos', ...)
@@ -500,7 +500,6 @@ class Facture extends CommonInvoice
 			$this->mode_reglement_id = 0;
 		}
 		$this->status = self::STATUS_DRAFT;
-		$this->statut = self::STATUS_DRAFT;	// deprecated
 
 		if (!empty($this->multicurrency_code)) {
 			// Multicurrency (test on $this->multicurrency_tx because we should take the default rate of multicurrency_code only if not using original rate)
@@ -613,7 +612,6 @@ class Facture extends CommonInvoice
 				$this->mode_reglement_id = 0;
 			}
 			$this->status = self::STATUS_DRAFT;
-			$this->statut = self::STATUS_DRAFT;	// deprecated
 
 			$this->linked_objects = $_facrec->linkedObjectsIds;
 			// We do not add link to template invoice or next invoice will be linked to all generated invoices
@@ -1292,7 +1290,6 @@ class Facture extends CommonInvoice
 		}
 
 		$object->id = 0;
-		$object->statut = self::STATUS_DRAFT;
 		$object->status = self::STATUS_DRAFT;
 
 		// Clear fields
@@ -2250,7 +2247,6 @@ class Facture extends CommonInvoice
 				$this->fk_project = $obj->fk_project;
 				$this->project = null; // Clear if another value was already set by fetch_projet
 
-				$this->statut = $obj->status;	// deprecated
 				$this->status = $obj->status;
 
 				$this->date_lim_reglement = $this->db->jdate($obj->dlr);
@@ -3634,7 +3630,6 @@ class Facture extends CommonInvoice
 			// Set new ref and define current status
 			if (!$error) {
 				$this->ref = $num;
-				$this->statut = self::STATUS_VALIDATED;	// deprecated
 				$this->status = self::STATUS_VALIDATED;
 				$this->date_validation = $now;
 				$i = 0;
@@ -3788,16 +3783,14 @@ class Facture extends CommonInvoice
 			}
 
 			if ($error == 0) {
-				$old_statut = $this->status;
-				$this->statut = self::STATUS_DRAFT;	// deprecated
+				$old_status = $this->status;
 				$this->status = self::STATUS_DRAFT;
 
 				// Call trigger
 				$result = $this->call_trigger('BILL_UNVALIDATE', $user);
 				if ($result < 0) {
 					$error++;
-					$this->statut = $old_statut; // deprecated
-					$this->status = $old_statut;
+					$this->status = $old_status;
 				}
 				// End call triggers
 			} else {
@@ -4362,7 +4355,7 @@ class Facture extends CommonInvoice
 				return -1;
 			}
 		} else {
-			$this->error = "Invoice statut makes operation forbidden";
+			$this->error = "Invoice status makes operation forbidden";
 			return -2;
 		}
 	}
@@ -5053,7 +5046,6 @@ class Facture extends CommonInvoice
 
 			while ($obj = $this->db->fetch_object($resql)) {
 				$generic_facture->date_lim_reglement = $this->db->jdate($obj->datefin);
-				$generic_facture->statut = $obj->status;
 				$generic_facture->status = $obj->status;
 
 				$response->nbtodo++;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2260,7 +2260,6 @@ class Facture extends CommonInvoice
 				$this->fk_account = ($obj->fk_account > 0) ? $obj->fk_account : null;
 				$this->fk_facture_source	= $obj->fk_facture_source;
 				$this->fk_fac_rec_source	= $obj->fk_fac_rec_source;
-				$this->note = $obj->note_private; // deprecated
 				$this->note_private = $obj->note_private;
 				$this->note_public			= $obj->note_public;
 				$this->user_creation_id     = $obj->fk_user_author;
@@ -2528,11 +2527,8 @@ class Facture extends CommonInvoice
 		if (isset($this->close_note)) {
 			$this->close_note = trim($this->close_note);
 		}
-		if (isset($this->note) || isset($this->note_private)) {
-			$this->note = (isset($this->note) ? trim($this->note) : trim($this->note_private)); // deprecated
-		}
-		if (isset($this->note) || isset($this->note_private)) {
-			$this->note_private = (isset($this->note_private) ? trim($this->note_private) : trim($this->note));
+		if (isset($this->note_private)) {
+			$this->note_private = trim($this->note_private);
 		}
 		if (isset($this->note_public)) {
 			$this->note_public = trim($this->note_public);

--- a/htdocs/compta/index.php
+++ b/htdocs/compta/index.php
@@ -362,7 +362,6 @@ if ((isModEnabled('fournisseur') && !getDolGlobalString('MAIN_USE_NEW_SUPPLIERMO
 				$facstatic->total_ttc = $obj->total_ttc;
 				$facstatic->statut = $obj->status;
 				$facstatic->status = $obj->status;
-				$facstatic->paye = $obj->paye;
 				$facstatic->paid = $obj->paye;
 				$facstatic->type = $obj->type;
 				$facstatic->ref_supplier = $obj->ref_supplier;

--- a/htdocs/compta/paymentbybanktransfer/index.php
+++ b/htdocs/compta/paymentbybanktransfer/index.php
@@ -168,7 +168,6 @@ if (isModEnabled('supplier_invoice')) {
 				$invoicestatic->ref = $obj->ref;
 				$invoicestatic->status = $obj->fk_statut;
 				$invoicestatic->statut = $obj->fk_statut;	// For backward compatibility
-				$invoicestatic->paye = $obj->paye;
 				$invoicestatic->paid = $obj->paye;
 				$invoicestatic->type = $obj->type;
 				$invoicestatic->date = $db->jdate($obj->datef);

--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -228,12 +228,6 @@ class BonPrelevement extends CommonObject
 	 * @var float
 	 */
 	public $amount;
-
-	/**
-	 * @var int	Status
-	 * @deprecated Use $status
-	 */
-	public $statut;
 	/**
 	 * @var int	Status
 	 */
@@ -523,7 +517,6 @@ class BonPrelevement extends CommonObject
 				if (empty($this->status)) {		// Value is sometimes null in database
 					$this->status = 0;
 				}
-				$this->statut         = $this->status; // For backward compatibility
 
 				$this->fetched = 1;
 
@@ -752,7 +745,6 @@ class BonPrelevement extends CommonObject
 			// End of procedure
 			if ($error == 0) {
 				$this->date_credit = $date;		// date credit or debit
-				$this->statut = self::STATUS_CREDITED;
 				$this->status = self::STATUS_CREDITED;
 
 				$this->db->commit();
@@ -808,7 +800,6 @@ class BonPrelevement extends CommonObject
 
 			if ($error == 0) {
 				$this->date_trans = $date;
-				$this->statut = self::STATUS_TRANSFERED;
 				$this->status = self::STATUS_TRANSFERED;
 				$this->user_trans = $user->id;
 
@@ -2795,7 +2786,7 @@ class BonPrelevement extends CommonObject
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut($this->statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/compta/prelevement/class/ligneprelevement.class.php
+++ b/htdocs/compta/prelevement/class/ligneprelevement.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2010-2011 Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2015      Marcos García        <marcosgdf@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,7 +50,7 @@ class LignePrelevement
 	/**
 	 * @var int Status of the line
 	 */
-	public $statut;
+	public $status;
 
 	/**
 	 * @var string Ref of bon
@@ -122,7 +123,7 @@ class LignePrelevement
 				$this->id              = $obj->rowid;
 				$this->amount          = $obj->amount;
 				$this->socid           = $obj->fk_soc;
-				$this->statut          = $obj->statut;
+				$this->status          = $obj->statut;
 				$this->bon_ref         = $obj->ref;
 				$this->bon_rowid       = $obj->bon_rowid;
 			} else {
@@ -148,7 +149,7 @@ class LignePrelevement
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut($this->statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/compta/prelevement/line.php
+++ b/htdocs/compta/prelevement/line.php
@@ -186,9 +186,9 @@ if ($id) {
 
 		print '<tr><td>'.$langs->trans("Amount").'</td><td><span class="amount">'.price($lipre->amount).'</span></td></tr>';
 
-		print '<tr><td>'.$langs->trans("Status").'</td><td>'.$lipre->LibStatut($lipre->statut, 1).'</td></tr>';
+		print '<tr><td>'.$langs->trans("Status").'</td><td>'.$lipre->LibStatut($lipre->status, 1).'</td></tr>';
 
-		if ($lipre->statut == 3) {
+		if ($lipre->status == 3) {
 			$rej = new RejetPrelevement($db, $user, $type);
 			$resf = $rej->fetch($lipre->id);
 			if ($resf == 0) {
@@ -275,8 +275,8 @@ if ($id) {
 	print '<div class="tabsAction">';
 
 	if ($action == '') {
-		if (is_object($bon) && $bon->statut == BonPrelevement::STATUS_CREDITED) {
-			if ($lipre->statut == 2) {
+		if (is_object($bon) && $bon->status == BonPrelevement::STATUS_CREDITED) {
+			if ($lipre->status == 2) {
 				if ($user->hasRight('prelevement', 'bons', 'credit')) {
 					print '<a class="butActionDelete" href="line.php?action=rejet&type='.$type.'&id='.$lipre->id.'">'.$langs->trans("StandingOrderReject").'</a>';
 				} else {

--- a/htdocs/compta/sociales/class/chargesociales.class.php
+++ b/htdocs/compta/sociales/class/chargesociales.class.php
@@ -99,8 +99,7 @@ class ChargeSociales extends CommonObject
 	/**
 	 * @var int<0,1>
 	 */
-	public $paye;
-
+	public $paid;
 	/**
 	 * @deprecated Use $period
 	 * @var int|string
@@ -178,6 +177,18 @@ class ChargeSociales extends CommonObject
 	 */
 	const STATUS_PAID = 1;
 
+
+	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>  Old property to new property mapping
+	 */
+	protected function deprecatedProperties()
+	{
+		return array(
+			'paye' => 'paid',
+		) + parent::deprecatedProperties();
+	}
 
 	/**
 	 * Constructor

--- a/htdocs/contact/class/contact.class.php
+++ b/htdocs/contact/class/contact.class.php
@@ -226,7 +226,7 @@ class Contact extends CommonObject
 	/**
 	 * @var int  Status 0=inactive, 1=active
 	 */
-	public $statut;
+	public $status;
 
 	/**
 	 * @var string
@@ -382,7 +382,7 @@ class Contact extends CommonObject
 	public function __construct($db)
 	{
 		$this->db = $db;
-		$this->statut = 1; // By default, status is enabled
+		$this->status = 1; // By default, status is enabled
 		$this->ismultientitymanaged = 1;
 		$this->isextrafieldmanaged = 1;
 
@@ -501,8 +501,8 @@ class Contact extends CommonObject
 		if (empty($this->priv)) {
 			$this->priv = 0;
 		}
-		if (empty($this->statut)) {
-			$this->statut = 0; // This is to convert '' into '0' to avoid bad sql request
+		if (empty($this->status)) {
+			$this->status = 0; // This is to convert '' into '0' to avoid bad sql request
 		}
 
 		// setEntity will set entity with the right value if empty or change it for the right value if multicompany module is active
@@ -536,7 +536,7 @@ class Contact extends CommonObject
 		$sql .= " ".($user->id > 0 ? ((int) $user->id) : "null").",";
 		$sql .= " ".((int) $this->priv).",";
 		$sql .= " 0,";
-		$sql .= " ".((int) $this->statut).",";
+		$sql .= " ".((int) $this->status).",";
 		$sql .= " ".(!empty($this->canvas) ? "'".$this->db->escape($this->canvas)."'" : "null").",";
 		$sql .= " ".((int) $this->entity).",";
 		$sql .= "'".$this->db->escape($this->ref_ext)."',";
@@ -625,8 +625,8 @@ class Contact extends CommonObject
 		$this->zip = (empty($this->zip) ? '' : trim($this->zip));
 		$this->town = (empty($this->town) ? '' : trim($this->town));
 		$this->country_id = (empty($this->country_id) || $this->country_id < 0) ? 0 : $this->country_id;
-		if (empty($this->statut)) {
-			$this->statut = 0;
+		if (empty($this->status)) {
+			$this->status = 0;
 		}
 		if (empty($this->civility_code) && !is_numeric($this->civility_id)) {
 			$this->civility_code = $this->civility_id; // For backward compatibility
@@ -667,7 +667,7 @@ class Contact extends CommonObject
 		if (isset($this->stcomm_id)) {
 			$sql .= ", fk_stcommcontact = ".($this->stcomm_id > 0 || $this->stcomm_id == -1 ? $this->stcomm_id : "0");
 		}
-		$sql .= ", statut = ".((int) $this->statut);
+		$sql .= ", statut = ".((int) $this->status);
 		$sql .= ", fk_user_modif=".($user->id > 0 ? "'".$this->db->escape($user->id)."'" : "NULL");
 		$sql .= ", default_lang=".($this->default_lang ? "'".$this->db->escape($this->default_lang)."'" : "NULL");
 		$sql .= ", entity = ".((int) $this->entity);
@@ -1097,7 +1097,7 @@ class Contact extends CommonObject
 				$this->socid		= $obj->fk_soc;		// Both fk_soc and socid are used
 				$this->socname		= $obj->socname;
 				$this->poste		= $obj->poste;
-				$this->statut		= $obj->statut;
+				$this->status		= $obj->statut;
 
 				$this->fk_prospectlevel = $obj->fk_prospectlevel;
 
@@ -1648,7 +1648,7 @@ class Contact extends CommonObject
 	 */
 	public function getLibStatut($mode)
 	{
-		return $this->LibStatut($this->statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -1755,7 +1755,7 @@ class Contact extends CommonObject
 		$this->note_private = 'This is a comment (private)';
 
 		$this->socid = $socid;
-		$this->statut = 1;
+		$this->status = 1;
 
 		return 1;
 	}
@@ -1773,17 +1773,17 @@ class Contact extends CommonObject
 		$error = 0;
 
 		// Check parameters
-		if ($this->statut == $status) {
+		if ($this->status == $status) {
 			return 0;
 		} else {
-			$this->statut = $status;
+			$this->status = $status;
 		}
 
 		$this->db->begin();
 
 		// User disable
 		$sql = "UPDATE ".MAIN_DB_PREFIX."socpeople";
-		$sql .= " SET statut = ".((int) $this->statut);
+		$sql .= " SET statut = ".((int) $this->status);
 		$sql .= ", fk_user_modif = ".((int) $user->id);
 		$sql .= " WHERE rowid = ".((int) $this->id);
 		$result = $this->db->query($sql);

--- a/htdocs/contact/consumption.php
+++ b/htdocs/contact/consumption.php
@@ -479,14 +479,13 @@ if ($sql_select && $documentstatic !== null) {
 		$documentstatic->type = $objp->doc_type;
 
 		$documentstatic->fk_statut = $objp->status;
-		$documentstatic->statut = $objp->status;
 		$documentstatic->status = $objp->status;
 
 		$documentstatic->paye = $objp->paid;
 		$documentstatic->paid = $objp->paid;
 
 		if (is_object($documentstaticline)) {
-			$documentstaticline->statut = $objp->status;
+			$documentstaticline->status = $objp->status;
 		}
 
 		print '<tr class="oddeven">';

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -675,11 +675,11 @@ class Contracts extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2015		Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016		Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2018-2024  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,9 +18,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
- use Luracast\Restler\RestException;
+use Luracast\Restler\RestException;
 
- require_once DOL_DOCUMENT_ROOT.'/contrat/class/contrat.class.php';
+require_once DOL_DOCUMENT_ROOT.'/contrat/class/contrat.class.php';
 
 /**
  * API class for contracts
@@ -672,10 +673,13 @@ class Contracts extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -680,6 +680,7 @@ class Contracts extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -128,12 +128,6 @@ class Contrat extends CommonObject
 	public $societe;
 
 	/**
-	 * Status of the contract
-	 * @var int
-	 * @deprecated
-	 */
-	public $statut = 0;
-	/**
 	 * Status of the contract (0=Draft, 1=Validated)
 	 * @var int
 	 */
@@ -430,7 +424,7 @@ class Contrat extends CommonObject
 
 		foreach ($this->lines as $contratline) {
 			// Open lines not already open
-			if ($contratline->statut != ContratLigne::STATUS_OPEN) {
+			if ($contratline->status != ContratLigne::STATUS_OPEN) {
 				$contratline->context = $this->context;
 
 				$result = $contratline->active_line($user, $date_start, !empty($date_end) ? $date_end : -1, $comment);	// This call trigger LINECONTRACT_ACTIVATE
@@ -443,7 +437,7 @@ class Contrat extends CommonObject
 			}
 		}
 
-		if (!$error && $this->statut == 0) {
+		if (!$error && $this->status == 0) {
 			$result = $this->validate($user, '', $notrigger);
 			if ($result < 0) {
 				$error++;
@@ -481,11 +475,11 @@ class Contrat extends CommonObject
 
 		foreach ($this->lines as $contratline) {
 			// Close lines not already closed
-			if ($contratline->statut != ContratLigne::STATUS_CLOSED) {
+			if ($contratline->status != ContratLigne::STATUS_CLOSED) {
 				$contratline->date_end_real = $now;
 				$contratline->date_cloture = $now;	// For backward compatibility
 				$contratline->user_closing_id = $user->id;
-				$contratline->statut = ContratLigne::STATUS_CLOSED;
+				$contratline->status = ContratLigne::STATUS_CLOSED;
 
 				$result = $contratline->close_line($user, $now, $comment, $notrigger);
 
@@ -498,7 +492,7 @@ class Contrat extends CommonObject
 			}
 		}
 
-		if (!$error && $this->statut == 0) {
+		if (!$error && $this->status == 0) {
 			$result = $this->validate($user, '', $notrigger);
 			if ($result < 0) {
 				$error++;
@@ -623,7 +617,6 @@ class Contrat extends CommonObject
 			if (!$error) {
 				$this->ref = $num;
 				$this->status = self::STATUS_VALIDATED;
-				$this->statut = self::STATUS_VALIDATED;	// deprecated
 				$this->date_validation = $now;
 			}
 		} else {
@@ -683,7 +676,6 @@ class Contrat extends CommonObject
 
 		// Set new ref and define current status
 		if (!$error) {
-			$this->statut = self::STATUS_DRAFT;
 			$this->status = self::STATUS_DRAFT;
 			$this->date_validation = $now;
 		}
@@ -756,7 +748,6 @@ class Contrat extends CommonObject
 					$this->ref_supplier = $obj->ref_supplier;
 					$this->ref_ext = $obj->ref_ext;
 					$this->entity = $obj->entity;
-					$this->statut = $obj->status;
 					$this->status = $obj->status;
 					$this->signed_status = $obj->signed_status;
 
@@ -898,7 +889,6 @@ class Contrat extends CommonObject
 				$line->localtax1_type	= $objp->localtax1_type;
 				$line->localtax2_type	= $objp->localtax2_type;
 				$line->subprice			= $objp->subprice;
-				$line->statut = $objp->status;
 				$line->status = $objp->status;
 				$line->remise_percent	= $objp->remise_percent;
 				$line->price_ht			= $objp->price_ht;
@@ -967,16 +957,16 @@ class Contrat extends CommonObject
 				//dol_syslog("1 ".$line->desc);
 				//dol_syslog("2 ".$line->product_desc);
 
-				if ($line->statut == ContratLigne::STATUS_INITIAL) {
+				if ($line->status == ContratLigne::STATUS_INITIAL) {
 					$this->nbofserviceswait++;
 				}
-				if ($line->statut == ContratLigne::STATUS_OPEN && (empty($line->date_end) || $line->date_end >= $now)) {
+				if ($line->status == ContratLigne::STATUS_OPEN && (empty($line->date_end) || $line->date_end >= $now)) {
 					$this->nbofservicesopened++;
 				}
-				if ($line->statut == ContratLigne::STATUS_OPEN && (!empty($line->date_end) && $line->date_end < $now)) {
+				if ($line->status == ContratLigne::STATUS_OPEN && (!empty($line->date_end) && $line->date_end < $now)) {
 					$this->nbofservicesexpired++;
 				}
-				if ($line->statut == ContratLigne::STATUS_CLOSED) {
+				if ($line->status == ContratLigne::STATUS_CLOSED) {
 					$this->nbofservicesclosed++;
 				}
 
@@ -1363,9 +1353,6 @@ class Contrat extends CommonObject
 		if (isset($this->entity)) {
 			$this->entity = (int) $this->entity;
 		}
-		if (isset($this->statut)) {
-			$this->statut = (int) $this->statut;
-		}
 		if (isset($this->status)) {
 			$this->status = (int) $this->status;
 		}
@@ -1399,7 +1386,7 @@ class Contrat extends CommonObject
 		$sql .= " ref_ext=".(isset($this->ref_ext) ? "'".$this->db->escape($this->ref_ext)."'" : "null").",";
 		$sql .= " entity=".((int) $conf->entity).",";
 		$sql .= " date_contrat=".(dol_strlen($this->date_contrat) != 0 ? "'".$this->db->idate($this->date_contrat)."'" : 'null').",";
-		$sql .= " statut=".(isset($this->statut) ? $this->statut : (isset($this->status) ? $this->status : "null")).",";
+		$sql .= " statut=".(isset($this->status) ? (int) $this->status : "null").",";
 		$sql .= " fk_soc=".($this->socid > 0 ? $this->socid : "null").",";
 		$sql .= " fk_projet=".($this->fk_project > 0 ? $this->fk_project : "null").",";
 		$sql .= " fk_commercial_signature=".(isset($this->fk_commercial_signature) ? $this->fk_commercial_signature : "null").",";
@@ -1485,7 +1472,7 @@ class Contrat extends CommonObject
 			return -1;
 		}
 
-		if ($this->statut >= 0) {
+		if ($this->status >= 0) {
 			// Clean parameters
 			$pu_ht = price2num($pu_ht);
 			$pu_ttc = price2num($pu_ttc);
@@ -1885,7 +1872,7 @@ class Contrat extends CommonObject
 	{
 		$error = 0;
 
-		if ($this->statut >= 0) {
+		if ($this->status >= 0) {
 			// Call trigger
 			$this->context['line_id'] = $idline;
 			$result = $this->call_trigger('LINECONTRACT_DELETE', $user);
@@ -1946,7 +1933,7 @@ class Contrat extends CommonObject
 		dol_syslog(__METHOD__." is deprecated", LOG_WARNING);
 
 		// If draft, we keep it (should not happen)
-		if ($this->statut == 0) {
+		if ($this->status == 0) {
 			return 1;
 		}
 
@@ -1971,7 +1958,7 @@ class Contrat extends CommonObject
 	 */
 	public function getLibStatut($mode)
 	{
-		return $this->LibStatut($this->statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -2051,7 +2038,7 @@ class Contrat extends CommonObject
 		if ($user->hasRight('contrat', 'lire')) {
 			$datas['picto'] = img_picto('', $this->picto).' <u class="paddingrightonly">'.$langs->trans("Contract").'</u>';
 			/* Status of a contract is status of all services, so disabled
-			if (isset($this->statut)) {
+			if (isset($this->status)) {
 				$label .= ' '.$this->getLibStatut(5);
 			}*/
 			$datas['ref'] = '<br><b>'.$langs->trans('Ref').':</b> '.($this->ref ? $this->ref : $this->id);
@@ -2637,7 +2624,7 @@ class Contrat extends CommonObject
 		$objsoc->fetch($clonedObj->socid);
 
 		// Clean data
-		$clonedObj->statut = 0;
+		$clonedObj->status = 0;
 		// Clean extrafields
 		if (is_array($clonedObj->array_options) && count($clonedObj->array_options) > 0) {
 			$extrafields->fetch_name_optionals_label($this->table_element);
@@ -2810,7 +2797,7 @@ class Contrat extends CommonObject
 
 						$someinvoicenotpaid = 0;
 						foreach ($object->linkedObjects['facture'] as $idinvoice => $invoice) {
-							if ($invoice->statut == Facture::STATUS_DRAFT) {
+							if ($invoice->status == Facture::STATUS_DRAFT) {
 								continue;
 							}	// Draft invoice are not invoice not paid
 

--- a/htdocs/core/boxes/box_factures_fourn_imp.php
+++ b/htdocs/core/boxes/box_factures_fourn_imp.php
@@ -141,7 +141,6 @@ class box_factures_fourn_imp extends ModeleBoxes
 
 					//$alreadypaid = $facturestatic->getSommePaiement();
 
-					$facturestatic->paye = $objp->paye;
 					$facturestatic->paid = $objp->paye;
 					$facturestatic->alreadypaid = $objp->am;
 					$facturestatic->totalpaid = $objp->am;

--- a/htdocs/core/boxes/box_last_ticket.php
+++ b/htdocs/core/boxes/box_last_ticket.php
@@ -117,7 +117,6 @@ class box_last_ticket extends ModeleBoxes
 					$ticket->id = $objp->id;
 					$ticket->track_id = $objp->track_id;
 					$ticket->ref = $objp->ref;
-					$ticket->fk_statut = $objp->status;
 					$ticket->status = $objp->status;
 					$ticket->subject = $objp->subject;
 					if ($objp->fk_soc > 0) {

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -64,9 +64,9 @@ abstract class CommonInvoice extends CommonObject
 	public $socid;
 
 	/**
-	 * @var int<0,1>
+	 * @var int<0,1> 1 if the invoice is fully paid.
 	 */
-	public $paye;
+	public $paid;
 
 	/**
 	 * Invoice date (date)
@@ -269,6 +269,19 @@ abstract class CommonInvoice extends CommonObject
 	 * - CLOSECODE_REPLACED
 	 */
 	const STATUS_ABANDONED = 3;
+
+
+	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>  Deprecated to replacement mapping
+	 */
+	protected function deprecatedProperties()
+	{
+		return array(
+			'paye' => 'paid',
+		) + parent::deprecatedProperties();
+	}
 
 
 
@@ -903,7 +916,7 @@ abstract class CommonInvoice extends CommonObject
 	 */
 	public function getLibStatut($mode = 0, $alreadypaid = -1)
 	{
-		return $this->LibStatut($this->paye, $this->status, $mode, $alreadypaid, $this->type, $this->nbofopendirectdebitorcredittransfer);
+		return $this->LibStatut($this->paid, $this->status, $mode, $alreadypaid, $this->type);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -1106,7 +1119,7 @@ abstract class CommonInvoice extends CommonObject
 
 		dol_syslog(get_class($this)."::demande_prelevement", LOG_DEBUG);
 
-		if ($this->status > self::STATUS_DRAFT && $this->paye == 0) {
+		if ($this->status > self::STATUS_DRAFT && $this->paid == 0) {
 			require_once DOL_DOCUMENT_ROOT.'/societe/class/companybankaccount.class.php';
 			$bac = new CompanyBankAccount($this->db);
 			$bac->fetch($ribId, '', $this->socid);
@@ -1210,7 +1223,7 @@ abstract class CommonInvoice extends CommonObject
 			}
 		} else {
 			$this->error = "Status of invoice does not allow this";
-			dol_syslog(get_class($this)."::demandeprelevement ".$this->error." $this->status, $this->paye, $this->mode_reglement_id");
+			dol_syslog(get_class($this)."::demandeprelevement ".$this->error." $this->status, $this->paid, $this->mode_reglement_id");
 			return -3;
 		}
 	}
@@ -1267,7 +1280,7 @@ abstract class CommonInvoice extends CommonObject
 
 		dol_syslog(get_class($this)."::makeStripeSepaRequest start did=".$did." type=".$type." service=".$service." sourcetype=".$sourcetype." forcestripe=".$forcestripe, LOG_DEBUG);
 
-		if ($this->status > self::STATUS_DRAFT && $this->paye == 0) {
+		if ($this->status > self::STATUS_DRAFT && $this->paid == 0) {
 			// Get the default payment mode for BAN payment of the third party
 			require_once DOL_DOCUMENT_ROOT.'/societe/class/companybankaccount.class.php';
 			$bac = new CompanyBankAccount($this->db);	// Table societe_rib
@@ -1771,7 +1784,7 @@ abstract class CommonInvoice extends CommonObject
 			}
 		} else {
 			$this->error = "Status of invoice does not allow this";
-			dol_syslog(get_class($this)."::makeStripeSepaRequest ".$this->error." ".$this->status." ,".$this->paye.", ".$this->mode_reglement_id, LOG_WARNING);
+			dol_syslog(get_class($this)."::makeStripeSepaRequest ".$this->error." ".$this->status." ,".$this->paid.", ".$this->mode_reglement_id, LOG_WARNING);
 			return -3;
 		}
 	}

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -475,13 +475,13 @@ abstract class CommonObject
 	 * @deprecated  Use $cond_reglement_id instead - Kept for compatibility
 	 * @see $cond_reglement_id
 	 *
-	 * Note: cond_reglement can not be aliased to cond_reglement!!!
+	 * Note: cond_reglement_id can not be aliased to cond_reglement!!!
 	 */
 	private $cond_reglement;  // Private to call DolDeprecationHandler
 	/**
 	 * @var int|string Internal to detect deprecated access
 	 */
-	protected $depr_cond_reglement;  // Internal value for deprecation
+	protected $depr_cond_reglement;  // Internal value to detect deprecation
 
 	/**
 	 * @var int 		Delivery address ID
@@ -879,14 +879,16 @@ abstract class CommonObject
 	{
 		return array(
 			'alreadypaid' => 'totalpaid',
-			'cond_reglement' => 'depr_cond_reglement',
-			//'note' => 'note_private',		// Some classes needs ->note and others need ->note_public/private so we can't manage deprecation for this field with dolDeprecationHandler
+			'cond_reglement' => 'depr_cond_reglement',  // Map to internal value
+			//'note' => 'note_private',		// Some classes need ->note and others need ->note_public/private so we can't manage deprecation for this field with dolDeprecationHandler
+			'modelpdf' => 'model_pdf',
 			'commandeFournisseur' => 'origin_object',
 			'expedition' => 'origin_object',
 			'fk_project' => 'fk_project',
 			'livraison' => 'origin_object',
 			'projet' => 'project',
 			'statut' => 'status',
+			'rowid' => 'id',
 		);
 	}
 
@@ -11059,9 +11061,6 @@ abstract class CommonObject
 
 			if (!$error) {
 				$this->status = $status;
-				if (property_exists($this, 'statut')) {	// For backward compatibility
-					$this->statut = $status;
-				}
 				$this->db->commit();
 				return 1;
 			} else {

--- a/htdocs/core/class/fiscalyear.class.php
+++ b/htdocs/core/class/fiscalyear.class.php
@@ -89,13 +89,6 @@ class Fiscalyear extends CommonObject
 
 	/**
 	 * @var int status 0=open, 1=closed
-	 * @deprecated
-	 * @see $status
-	 */
-	public $statut;
-
-	/**
-	 * @var int status 0=open, 1=closed
 	 */
 	public $status;
 

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1529,7 +1529,7 @@ function show_contacts($conf, $langs, $db, $object, $backtopage = '', $showuserl
 
 			$contactstatic->id = $obj->rowid;
 			$contactstatic->ref = $obj->rowid;
-			$contactstatic->statut = $obj->statut;
+			$contactstatic->status = $obj->statut;
 			$contactstatic->lastname = $obj->lastname;
 			$contactstatic->firstname = $obj->firstname;
 			$contactstatic->civility_id = $obj->civility_id;

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3139,7 +3139,7 @@ function dol_banner_tab($object, $paramid, $morehtml = '', $shownav = 1, $fieldi
 		}
 		$morehtmlstatus .= $tmptxt;
 	} elseif ($object->element == 'contrat' || $object->element == 'contract') {
-		if ($object->statut == 0) {
+		if ($object->status == 0) {
 			$morehtmlstatus .= $object->getLibStatut(5);
 		} else {
 			$morehtmlstatus .= $object->getLibStatut(4);
@@ -3152,14 +3152,11 @@ function dol_banner_tab($object, $paramid, $morehtml = '', $shownav = 1, $fieldi
 			$morehtmlstatus .= $object->getLibStatut(5);
 		}
 	} elseif ($object->element == 'project_task') {
-		$object->fk_statut = 1;
 		$object->status = 1;
 		if ($object->progress > 0) {
-			$object->fk_statut = 2;
 			$object->status = 2;
 		}
 		if ($object->progress >= 100) {
-			$object->fk_statut = 3;
 			$object->status = 3;
 		}
 		$tmptxt = $object->getLibStatut(5);

--- a/htdocs/core/lib/invoice.lib.php
+++ b/htdocs/core/lib/invoice.lib.php
@@ -654,8 +654,8 @@ function getCustomerInvoiceDraftTable($maxCount = 500, $socid = 0)
 					$tmpinvoice->total_tva = $obj->total_tva;
 					$tmpinvoice->total_ttc = $obj->total_ttc;
 					$tmpinvoice->ref_client = $obj->ref_client;
-					$tmpinvoice->statut = $obj->status;
-					$tmpinvoice->paye = $obj->paye;
+					$tmpinvoice->status = $obj->status;
+					$tmpinvoice->paid = $obj->paye;
 
 					$companystatic->id = $obj->socid;
 					$companystatic->name = $obj->name;
@@ -787,9 +787,7 @@ function getDraftSupplierTable($maxCount = 500, $socid = 0)
 					$facturesupplierstatic->total_ttc = $obj->total_ttc;
 					$facturesupplierstatic->ref_supplier = $obj->ref_supplier;
 					$facturesupplierstatic->type = $obj->type;
-					$facturesupplierstatic->statut = $obj->status;
 					$facturesupplierstatic->status = $obj->status;
-					$facturesupplierstatic->paye = $obj->paye;
 					$facturesupplierstatic->paid = $obj->paye;
 
 					$companystatic->id = $obj->socid;
@@ -903,8 +901,7 @@ function getCustomerInvoiceLatestEditTable($maxCount = 5, $socid = 0)
 
 		$objectstatic->id = $obj->rowid;
 		$objectstatic->ref = $obj->ref;
-		$objectstatic->paye = $obj->paye;
-		$objectstatic->statut = $obj->status;
+		$objectstatic->paid = $obj->paye;
 		$objectstatic->status = $obj->status;
 		$objectstatic->total_ht = $obj->total_ht;
 		$objectstatic->total_tva = $obj->total_tva;
@@ -1016,9 +1013,7 @@ function getPurchaseInvoiceLatestEditTable($maxCount = 5, $socid = 0)
 
 		$objectstatic->id = $obj->rowid;
 		$objectstatic->ref = $obj->ref;
-		$objectstatic->paye = $obj->paye;
 		$objectstatic->paid = $obj->paye;
-		$objectstatic->statut = $obj->status;
 		$objectstatic->status = $obj->status;
 		$objectstatic->total_ht = $obj->total_ht;
 		$objectstatic->total_tva = $obj->total_tva;
@@ -1160,8 +1155,8 @@ function getCustomerInvoiceUnpaidOpenTable($maxCount = 500, $socid = 0)
 					$tmpinvoice->total_tva = $obj->total_tva;
 					$tmpinvoice->total_ttc = $obj->total_ttc;
 					$tmpinvoice->type = $obj->type;
-					$tmpinvoice->statut = $obj->status;
-					$tmpinvoice->paye = $obj->paye;
+					$tmpinvoice->status = $obj->status;
+					$tmpinvoice->paid = $obj->paye;
 					$tmpinvoice->date_lim_reglement = $db->jdate($obj->datelimite);
 
 					$societestatic->id = $obj->socid;
@@ -1348,10 +1343,8 @@ function getPurchaseInvoiceUnpaidOpenTable($maxCount = 500, $socid = 0)
 					$facstatic->total_ht = $obj->total_ht;
 					$facstatic->total_tva = $obj->total_tva;
 					$facstatic->total_ttc = $obj->total_ttc;
-					$facstatic->statut = $obj->status;
 					$facstatic->status = $obj->status;
 					$facstatic->paid = $obj->paye;
-					$facstatic->paye = $obj->paye;
 
 					$societestatic->id = $obj->socid;
 					$societestatic->name = $obj->name;

--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -1246,7 +1246,7 @@ function projectLinesPerAction(&$inc, $parent, $fuser, $lines, &$level, &$projec
 			$projectstatic->public = $lines[$i]->public;
 			$projectstatic->status = $lines[$i]->project->status;
 
-			$taskstatic->id = $lines[$i]->fk_statut;
+			$taskstatic->id = $lines[$i]->status;
 			$taskstatic->ref = ($lines[$i]->task_ref ? $lines[$i]->task_ref : $lines[$i]->task_id);
 			$taskstatic->label = $lines[$i]->task_label;
 			$taskstatic->date_start = $lines[$i]->date_start;

--- a/htdocs/core/modules/expensereport/doc/pdf_standard_expensereport.modules.php
+++ b/htdocs/core/modules/expensereport/doc/pdf_standard_expensereport.modules.php
@@ -654,7 +654,7 @@ class pdf_standard_expensereport extends ModeleExpenseReport
 		*/
 
 		// Draft watermark
-		if ($object->fk_statut == 0 && getDolGlobalString('EXPENSEREPORT_DRAFT_WATERMARK')) {
+		if ($object->status == 0 && getDolGlobalString('EXPENSEREPORT_DRAFT_WATERMARK')) {
 			pdf_watermark($pdf, $outputlangs, $this->page_hauteur, $this->page_largeur, 'mm', $conf->global->EXPENSEREPORT_DRAFT_WATERMARK);
 		}
 
@@ -812,7 +812,7 @@ class pdf_standard_expensereport extends ModeleExpenseReport
 				$pdf->MultiCell(96, 4, $outputlangs->transnoentities("DateCreation")." : ".dol_print_date($object->date_create, "day", false, $outputlangs), 0, 'L');
 			}
 
-			if ($object->fk_statut == 99) {
+			if ($object->status == 99) {
 				if ($object->fk_user_refuse > 0) {
 					$userfee = new User($this->db);
 					$userfee->fetch($object->fk_user_refuse);
@@ -826,7 +826,7 @@ class pdf_standard_expensereport extends ModeleExpenseReport
 					$pdf->SetXY($posx + 2, $posy);
 					$pdf->MultiCell(96, 4, $outputlangs->transnoentities("DATE_REFUS")." : ".dol_print_date($object->date_refuse, "day", false, $outputlangs), 0, 'L');
 				}
-			} elseif ($object->fk_statut == 4) {
+			} elseif ($object->status == 4) {
 				if ($object->fk_user_cancel > 0) {
 					$userfee = new User($this->db);
 					$userfee->fetch($object->fk_user_cancel);
@@ -853,7 +853,7 @@ class pdf_standard_expensereport extends ModeleExpenseReport
 				}
 			}
 
-			if ($object->fk_statut == 6) {
+			if ($object->status == 6) {
 				if ($object->fk_user_paid > 0) {
 					$userfee = new User($this->db);
 					$userfee->fetch($object->fk_user_paid);

--- a/htdocs/don/class/api_donations.class.php
+++ b/htdocs/don/class/api_donations.class.php
@@ -368,6 +368,7 @@ class Donations extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/don/class/api_donations.class.php
+++ b/htdocs/don/class/api_donations.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2019       Thibault FOUCART        <support@ptibogxiv.net>
  * Copyright (C) 2019       Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -360,17 +361,20 @@ class Donations extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
 		// phpcs:enable
 		$object = parent::_cleanObjectDatas($object);
 
-		unset($object->note);
+		// unset($object->note);  // Not unsetting note as this also unsets note_private
 		unset($object->address);
 		unset($object->barcode_type);
 		unset($object->barcode_type_code);

--- a/htdocs/don/class/api_donations.class.php
+++ b/htdocs/don/class/api_donations.class.php
@@ -363,11 +363,11 @@ class Donations extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -714,6 +714,7 @@ class Shipments extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2015       Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016       Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,9 +17,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
- use Luracast\Restler\RestException;
+use Luracast\Restler\RestException;
 
- require_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php';
+require_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php';
 
 /**
  * API class for shipments
@@ -706,10 +707,13 @@ class Shipments extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -720,7 +724,7 @@ class Shipments extends DolibarrApi
 
 		unset($object->thirdparty); // id already returned
 
-		unset($object->note);
+		// unset($object->note);  // Not unsetting note as this also unsets note_private
 		unset($object->address);
 		unset($object->barcode_type);
 		unset($object->barcode_type_code);
@@ -753,8 +757,8 @@ class Shipments extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param   array           $data   Array with data to verify
-	 * @return  array
+	 * @param   array<string,mixed>	$data   Array with data to verify
+	 * @return  array<string,mixed>
 	 * @throws  RestException
 	 */
 	private function _validate($data)

--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -709,11 +709,11 @@ class Shipments extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/expensereport/class/api_expensereports.class.php
+++ b/htdocs/expensereport/class/api_expensereports.class.php
@@ -742,11 +742,11 @@ class ExpenseReports extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/expensereport/class/api_expensereports.class.php
+++ b/htdocs/expensereport/class/api_expensereports.class.php
@@ -747,6 +747,7 @@ class ExpenseReports extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/expensereport/class/api_expensereports.class.php
+++ b/htdocs/expensereport/class/api_expensereports.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016   Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2020-2024  Frédéric France		<frederic.france@free.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -739,10 +740,13 @@ class ExpenseReports extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -786,7 +790,7 @@ class ExpenseReports extends DolibarrApi
 		unset($object->country_id);
 		unset($object->country_code);
 
-		unset($object->note); // We already use note_public and note_pricate
+		// unset($object->note); // We already use note_public and note_private // stop unsetting as this unsets note_private as well
 
 		return $object;
 	}
@@ -794,8 +798,8 @@ class ExpenseReports extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param   array           $data   Array with data to verify
-	 * @return  array
+	 * @param   array<string,mixed>	$data   Array with data to verify
+	 * @return  array<string,mixed>
 	 * @throws  RestException
 	 */
 	private function _validate($data)

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -1566,7 +1566,6 @@ class ExpenseReport extends CommonObject
 			$sql .= " fk_user_approve = NULL";
 			$sql .= " WHERE rowid = ".((int) $this->id);
 			if ($this->db->query($sql)) {
-				$this->fk_statut = 99; // deprecated
 				$this->status = 99;
 				$this->fk_user_refuse = $fuser->id;
 				$this->detail_refuse = $details;

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -111,7 +111,7 @@ class ExpenseReport extends CommonObject
 	 * @var int		Status
 	 * @deprecated Use $status
 	 */
-	public $fk_statut;
+	private $fk_statut;
 
 	/**
 	 * @var int ID
@@ -291,6 +291,7 @@ class ExpenseReport extends CommonObject
 	 */
 	const STATUS_REFUSED = 99;
 
+
 	public $fields = array(
 		'rowid' => array('type' => 'integer', 'label' => 'ID', 'enabled' => 1, 'visible' => -1, 'notnull' => 1, 'position' => 10),
 		'ref' => array('type' => 'varchar(50)', 'label' => 'Ref', 'enabled' => 1, 'visible' => -1, 'notnull' => 1, 'showoncombobox' => 1, 'position' => 15),
@@ -336,6 +337,19 @@ class ExpenseReport extends CommonObject
 		'model_pdf' => array('type' => 'varchar(255)', 'label' => 'Model pdf', 'enabled' => 1, 'visible' => 0, 'position' => 1010),
 		'fk_statut' => array('type' => 'integer', 'label' => 'Fk statut', 'enabled' => 1, 'visible' => -1, 'notnull' => 1, 'position' => 500),
 	);
+
+	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>  Old property to new property mapping
+	 */
+	protected function deprecatedProperties()
+	{
+		return array(
+			'fk_statut' => 'status',
+		) + parent::deprecatedProperties();
+	}
+
 
 	/**
 	 *  Constructor
@@ -419,7 +433,7 @@ class ExpenseReport extends CommonObject
 		$sql .= ", ".($this->fk_user_validator > 0 ? ((int) $this->fk_user_validator) : "null");
 		$sql .= ", ".($this->fk_user_approve > 0 ? ((int) $this->fk_user_approve) : "null");
 		$sql .= ", ".($this->fk_user_modif > 0 ? ((int) $this->fk_user_modif) : "null");
-		$sql .= ", ".($this->fk_statut > 1 ? ((int) $this->fk_statut) : 0);
+		$sql .= ", ".($this->status > 1 ? ((int) $this->status) : 0);
 		$sql .= ", ".($this->modepaymentid ? ((int) $this->modepaymentid) : "null");
 		$sql .= ", 0";
 		$sql .= ", ".($this->note_public ? "'".$this->db->escape($this->note_public)."'" : "null");
@@ -556,7 +570,6 @@ class ExpenseReport extends CommonObject
 		$this->id = 0;
 		$this->ref = '';
 		$this->status = 0;
-		$this->fk_statut = 0; // deprecated
 
 		// Clear fields
 		$this->fk_user_creat = $user->id;
@@ -632,7 +645,7 @@ class ExpenseReport extends CommonObject
 		$sql .= " , fk_user_valid = ".($this->fk_user_valid > 0 ? $this->fk_user_valid : "null");
 		$sql .= " , fk_user_approve = ".($this->fk_user_approve > 0 ? $this->fk_user_approve : "null");
 		$sql .= " , fk_user_modif = ".((int) $user->id);
-		$sql .= " , fk_statut = ".($this->fk_statut >= 0 ? $this->fk_statut : '0');
+		$sql .= " , fk_statut = ".($this->status >= 0 ? (int) $this->status : '0');
 		$sql .= " , fk_c_paiement = ".($this->fk_c_paiement > 0 ? $this->fk_c_paiement : "null");
 		$sql .= " , note_public = ".(!empty($this->note_public) ? "'".$this->db->escape($this->note_public)."'" : "''");
 		$sql .= " , note_private = ".(!empty($this->note_private) ? "'".$this->db->escape($this->note_private)."'" : "''");
@@ -753,7 +766,6 @@ class ExpenseReport extends CommonObject
 				}
 				$this->user_validator_infos = dolGetFirstLastname($user_approver->firstname, $user_approver->lastname);
 
-				$this->fk_statut                = $obj->status; // deprecated
 				$this->status                   = $obj->status;
 				$this->fk_c_paiement            = $obj->fk_c_paiement;
 				$this->paid                     = $obj->paid;

--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -434,11 +434,11 @@ class Interventions extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016	Laurent Destailleur		<eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -431,10 +432,13 @@ class Interventions extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -450,8 +454,8 @@ class Interventions extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param array $data   Data to validate
-	 * @return array
+	 * @param array<string,mixed> $data   Data to validate
+	 * @return array<string,mixed>
 	 *
 	 * @throws RestException
 	 */

--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -439,6 +439,7 @@ class Interventions extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -146,7 +146,7 @@ class Fichinter extends CommonObject
 	/**
 	 * @var int status
 	 */
-	public $statut = 0; // 0=draft, 1=validated, 2=invoiced, 3=Terminate
+	public $status = 0; // 0=draft, 1=validated, 2=invoiced, 3=Terminate
 
 	/**
 	 * @var string description
@@ -340,8 +340,8 @@ class Fichinter extends CommonObject
 		$sql .= ", '".$this->db->escape($this->model_pdf)."'";
 		$sql .= ", ".($this->fk_project ? ((int) $this->fk_project) : 0);
 		$sql .= ", ".($this->fk_contrat ? ((int) $this->fk_contrat) : 0);
-		$sql .= ", ".((int) $this->statut);
-		$sql .= ", ".($this->signed_status);
+		$sql .= ", ".((int) $this->status);
+		$sql .= ", ".((int) $this->signed_status);
 		$sql .= ", ".($this->note_private ? "'".$this->db->escape($this->note_private)."'" : "null");
 		$sql .= ", ".($this->note_public ? "'".$this->db->escape($this->note_public)."'" : "null");
 		$sql .= ")";
@@ -501,7 +501,6 @@ class Fichinter extends CommonObject
 				$this->description  = $obj->description;
 				$this->socid        = $obj->fk_soc;
 				$this->status       = $obj->status;
-				$this->statut       = $obj->status;	// deprecated
 				$this->signed_status = $obj->signed_status;
 				$this->duration     = $obj->duree;
 				$this->datec        = $this->db->jdate($obj->datec);
@@ -555,7 +554,7 @@ class Fichinter extends CommonObject
 		$error = 0;
 
 		// Protection
-		if ($this->statut <= self::STATUS_DRAFT) {
+		if ($this->status <= self::STATUS_DRAFT) {
 			return 0;
 		}
 
@@ -580,7 +579,7 @@ class Fichinter extends CommonObject
 			}
 
 			if (!$error) {
-				$this->statut = self::STATUS_DRAFT;
+				$this->status = self::STATUS_DRAFT;
 				$this->db->commit();
 				return 1;
 			} else {
@@ -698,7 +697,6 @@ class Fichinter extends CommonObject
 			if (!$error) {
 				$this->ref = $num;
 				$this->status = self::STATUS_VALIDATED;
-				$this->statut = self::STATUS_VALIDATED;	// deprecated
 				$this->date_validation = $now;
 				$this->db->commit();
 				return 1;
@@ -725,7 +723,7 @@ class Fichinter extends CommonObject
 
 		$error = 0;
 
-		if ($this->statut == self::STATUS_CLOSED) {
+		if ($this->status == self::STATUS_CLOSED) {
 			return 0;
 		} else {
 			$this->db->begin();
@@ -751,7 +749,7 @@ class Fichinter extends CommonObject
 				}
 
 				if (!$error) {
-					$this->statut = self::STATUS_CLOSED;
+					$this->status = self::STATUS_CLOSED;
 					$this->db->commit();
 					return 1;
 				} else {
@@ -828,7 +826,7 @@ class Fichinter extends CommonObject
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut((isset($this->statut) ? $this->statut : $this->status), $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -1334,7 +1332,6 @@ class Fichinter extends CommonObject
 		$this->id = 0;
 		$this->ref = '';
 		$this->status = self::STATUS_DRAFT;
-		$this->statut = self::STATUS_DRAFT;	//  deprecated
 
 		// Clear fields
 		$this->user_author_id     = $user->id;

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -747,11 +747,11 @@ class SupplierInvoices extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -745,10 +745,13 @@ class SupplierInvoices extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -767,8 +770,8 @@ class SupplierInvoices extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param array $data   Datas to validate
-	 * @return array
+	 * @param array<string,mixed>	$data   Datas to validate
+	 * @return array<string,mixed>
 	 *
 	 * @throws RestException
 	 */

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -752,6 +752,7 @@ class SupplierInvoices extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/fourn/class/api_supplier_orders.class.php
+++ b/htdocs/fourn/class/api_supplier_orders.class.php
@@ -747,6 +747,7 @@ class SupplierOrders extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/fourn/class/api_supplier_orders.class.php
+++ b/htdocs/fourn/class/api_supplier_orders.class.php
@@ -742,11 +742,11 @@ class SupplierOrders extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/fourn/class/api_supplier_orders.class.php
+++ b/htdocs/fourn/class/api_supplier_orders.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016   Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -699,9 +700,9 @@ class SupplierOrders extends DolibarrApi
 		}
 
 		foreach ($lines as $line) {
-			$lineObj =(object) $line;
+			$lineObj = (object) $line;
 
-			$result=$this->order->dispatchProduct(
+			$result = $this->order->dispatchProduct(
 				DolibarrApiAccess::$user,
 				$lineObj->fk_product,
 				$lineObj->qty,
@@ -739,10 +740,13 @@ class SupplierOrders extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -761,8 +765,8 @@ class SupplierOrders extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param array $data   Datas to validate
-	 * @return array
+	 * @param array<string,mixed> $data   Datas to validate
+	 * @return array<string,mixed>
 	 *
 	 * @throws RestException
 	 */

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -119,7 +119,7 @@ class CommandeFournisseur extends CommonOrder
 	 * @deprecated see $status
 	 * @see $status
 	 */
-	public $statut; // 0=Draft -> 1=Validated -> 2=Approved -> 3=Ordered/Process running -> 4=Received partially -> 5=Received totally -> (reopen) 4=Received partially
+	public $status; // 0=Draft -> 1=Validated -> 2=Approved -> 3=Ordered/Process running -> 4=Received partially -> 5=Received totally -> (reopen) 4=Received partially
 	//                                                                                          -> 7=Canceled/Never received -> (reopen) 3=Process running
 	//									                            -> 6=Canceled -> (reopen) 2=Approved
 	//  		                                      -> 9=Refused  -> (reopen) 1=Validated
@@ -546,7 +546,6 @@ class CommandeFournisseur extends CommonOrder
 			$this->ref_supplier = $obj->ref_supplier;
 			$this->socid = $obj->fk_soc;
 			$this->fourn_id = $obj->fk_soc;
-			$this->statut = $obj->status;	// deprecated
 			$this->status = $obj->status;
 			$this->billed = $obj->billed;
 			$this->user_author_id = $obj->user_author_id;
@@ -868,7 +867,6 @@ class CommandeFournisseur extends CommonOrder
 			if (!$error) {
 				$result = 1;
 				$this->status = self::STATUS_VALIDATED;
-				$this->statut = self::STATUS_VALIDATED;	// deprecated
 				$this->ref = $num;
 			}
 
@@ -1372,9 +1370,9 @@ class CommandeFournisseur extends CommonOrder
 					$this->ref = $this->newref;
 
 					if ($movetoapprovestatus) {
-						$this->statut = self::STATUS_ACCEPTED;
+						$this->status = self::STATUS_ACCEPTED;
 					} else {
-						$this->statut = self::STATUS_VALIDATED;
+						$this->status = self::STATUS_VALIDATED;
 					}
 					if (empty($secondlevel)) {	// standard or first level approval
 						$this->date_approve = $now;
@@ -1531,7 +1529,7 @@ class CommandeFournisseur extends CommonOrder
 
 			dol_syslog(get_class($this)."::commande", LOG_DEBUG);
 			if ($this->db->query($sql)) {
-				$this->statut = self::STATUS_ORDERSENT;
+				$this->status = self::STATUS_ORDERSENT;
 				$this->methode_commande_id = $methode;
 				$this->date_commande = $date;
 				$this->context = array('comments' => $comment);
@@ -1604,8 +1602,7 @@ class CommandeFournisseur extends CommonOrder
 		}
 		$this->entity = setEntity($this);
 
-		// We set order into draft status
-		$this->statut = self::STATUS_DRAFT;	// deprecated
+		// Set the order status to DRAFT
 		$this->status = self::STATUS_DRAFT;
 
 		$sql = "INSERT INTO ".$this->db->prefix()."commande_fournisseur (";
@@ -1827,7 +1824,7 @@ class CommandeFournisseur extends CommonOrder
 		$sql .= " localtax2=".(isset($this->total_localtax2) ? $this->total_localtax2 : "null").",";
 		$sql .= " total_ht=".(isset($this->total_ht) ? $this->total_ht : "null").",";
 		$sql .= " total_ttc=".(isset($this->total_ttc) ? $this->total_ttc : "null").",";
-		$sql .= " fk_statut=".(isset($this->statut) ? $this->statut : "null").",";
+		$sql .= " fk_statut=".(isset($this->status) ? (int) $this->status : "null").",";
 		$sql .= " fk_user_author=".(isset($this->user_author_id) ? $this->user_author_id : "null").",";
 		$sql .= " fk_user_valid=".(isset($this->user_validation_id) && $this->user_validation_id > 0 ? $this->user_validation_id : "null").",";
 		$sql .= " fk_projet=".(isset($this->fk_project) ? $this->fk_project : "null").",";
@@ -1923,7 +1920,7 @@ class CommandeFournisseur extends CommonOrder
 		}
 
 		$this->id = 0;
-		$this->statut = self::STATUS_DRAFT;
+		$this->status = self::STATUS_DRAFT;
 
 		// Clear fields
 		$this->user_author_id     = $user->id;
@@ -2007,7 +2004,7 @@ class CommandeFournisseur extends CommonOrder
 		dol_syslog(get_class($this)."::addline $desc, $pu_ht, $qty, $txtva, $txlocaltax1, $txlocaltax2, $fk_product, $fk_prod_fourn_price, $ref_supplier, $remise_percent, $price_base_type, $pu_ttc, $type, $info_bits, $notrigger, $date_start, $date_end, $fk_unit, $pu_ht_devise, $origin, $origin_id");
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
 
-		if ($this->statut == self::STATUS_DRAFT) {
+		if ($this->status == self::STATUS_DRAFT) {
 			include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
 
 			// Clean parameters
@@ -2312,7 +2309,7 @@ class CommandeFournisseur extends CommonOrder
 
 		$inventorycode = dol_print_date(dol_now(), 'dayhourlog');
 
-		if (($this->statut == self::STATUS_ORDERSENT || $this->statut == self::STATUS_RECEIVED_PARTIALLY || $this->statut == self::STATUS_RECEIVED_COMPLETELY)) {
+		if (($this->status == self::STATUS_ORDERSENT || $this->status == self::STATUS_RECEIVED_PARTIALLY || $this->status == self::STATUS_RECEIVED_COMPLETELY)) {
 			$this->db->begin();
 
 			$sql = "INSERT INTO ".$this->db->prefix()."receptiondet_batch";
@@ -2386,7 +2383,7 @@ class CommandeFournisseur extends CommonOrder
 	{
 		global $user;
 
-		if ($this->statut == 0) {
+		if ($this->status == 0) {
 			$line = new CommandeFournisseurLigne($this->db);
 
 			if ($line->fetch($idline) <= 0) {
@@ -2447,7 +2444,7 @@ class CommandeFournisseur extends CommonOrder
 		$this->fetchObjectLinked(null, 'order_supplier');
 		if (!empty($this->linkedObjects) && array_key_exists('reception', $this->linkedObjects)) {
 			foreach ($this->linkedObjects['reception'] as $element) {
-				if ($element->statut >= 0) {
+				if ($element->status >= 0) {
 					$this->errors[] = $langs->trans('ReceptionExist');
 					$error++;
 					break;
@@ -2679,8 +2676,8 @@ class CommandeFournisseur extends CommonOrder
 				$resql = $this->db->query($sql);
 				if ($resql) {
 					$result = 1;
-					$old_statut = $this->statut;
-					$this->statut = $statut;
+					$old_statut = $this->status;
+					$this->status = $statut;
 					$this->context['actionmsg2'] = $comment;
 
 					// Call trigger
@@ -2693,7 +2690,7 @@ class CommandeFournisseur extends CommonOrder
 					if (empty($error)) {
 						$this->db->commit();
 					} else {
-						$this->statut = $old_statut;
+						$this->status = $old_statut;
 						$this->db->rollback();
 						$this->error = $this->db->lasterror();
 						$result = -1;
@@ -2931,7 +2928,7 @@ class CommandeFournisseur extends CommonOrder
 		}
 
 		if (!$error) {
-			$this->statut = $status;
+			$this->status = $status;
 			$this->db->commit();
 			return 1;
 		} else {
@@ -2971,7 +2968,7 @@ class CommandeFournisseur extends CommonOrder
 
 		$error = 0;
 
-		if ($this->statut == self::STATUS_DRAFT) {
+		if ($this->status == self::STATUS_DRAFT) {
 			// Clean parameters
 			if (empty($qty)) {
 				$qty = 0;
@@ -3192,7 +3189,6 @@ class CommandeFournisseur extends CommonOrder
 		$this->multicurrency_tx = 1;
 		$this->multicurrency_code = $conf->currency;
 
-		$this->statut = 0;
 		$this->status = 0;
 
 		// Lines
@@ -3354,7 +3350,7 @@ class CommandeFournisseur extends CommonOrder
 			while ($obj = $this->db->fetch_object($resql)) {
 				$commandestatic->delivery_date = $this->db->jdate($obj->delivery_date);
 				$commandestatic->date_commande = $this->db->jdate($obj->date_commande);
-				$commandestatic->statut = $obj->fk_statut;
+				$commandestatic->status = $obj->fk_statut;
 
 				$response->nbtodo++;
 				$response->total += $obj->total_ht;
@@ -3535,7 +3531,7 @@ class CommandeFournisseur extends CommonOrder
 	{
 		global $conf;
 
-		if ($this->statut == self::STATUS_ORDERSENT || $this->statut == self::STATUS_RECEIVED_PARTIALLY) {
+		if ($this->status == self::STATUS_ORDERSENT || $this->status == self::STATUS_RECEIVED_PARTIALLY) {
 			$now = dol_now();
 			if (!empty($this->delivery_date)) {
 				$date_to_test = $this->delivery_date;
@@ -3549,7 +3545,7 @@ class CommandeFournisseur extends CommonOrder
 			$now = dol_now();
 			$date_to_test = $this->date_commande;
 
-			return ($this->statut > 0 && $this->statut < 5) && $date_to_test && $date_to_test < ($now - $conf->commande->fournisseur->warning_delay);
+			return ($this->status > 0 && $this->status < 5) && $date_to_test && $date_to_test < ($now - $conf->commande->fournisseur->warning_delay);
 		}
 	}
 
@@ -3568,7 +3564,7 @@ class CommandeFournisseur extends CommonOrder
 
 		$text = '';
 
-		if ($this->statut == self::STATUS_ORDERSENT || $this->statut == self::STATUS_RECEIVED_PARTIALLY) {
+		if ($this->status == self::STATUS_ORDERSENT || $this->status == self::STATUS_RECEIVED_PARTIALLY) {
 			if (!empty($this->delivery_date)) {
 				$text = $langs->trans("DeliveryDate").' '.dol_print_date($this->delivery_date, 'day');
 			} else {

--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1417,7 +1417,6 @@ class FactureFournisseurRec extends CommonInvoice
 
 					$new_fac_fourn->type = self::TYPE_STANDARD;
 					$new_fac_fourn->subtype = $facturerec->subtype;
-					$new_fac_fourn->statut = self::STATUS_DRAFT;	// deprecated
 					$new_fac_fourn->status = self::STATUS_DRAFT;
 					$new_fac_fourn->date = empty($facturerec->date_when) ? $now : $facturerec->date_when; // We could also use dol_now here but we prefer date_when so invoice has real date when we would like even if we generate later.
 					$new_fac_fourn->socid = $facturerec->socid;

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -123,14 +123,6 @@ class FactureFournisseur extends CommonInvoice
 	/**
 	 * Supplier invoice status
 	 * @var int
-	 * @deprecated
-	 * @see $status
-	 */
-	public $statut;
-
-	/**
-	 * Supplier invoice status
-	 * @var int
 	 * @see FactureFournisseur::STATUS_DRAFT, FactureFournisseur::STATUS_VALIDATED, FactureFournisseur::STATUS_PAID, FactureFournisseur::STATUS_ABANDONED
 	 */
 	public $status;
@@ -141,14 +133,15 @@ class FactureFournisseur extends CommonInvoice
 	 * @deprecated
 	 * @see $status
 	 */
-	public $fk_statut;
+	private $fk_statut;
 
 	/**
 	 * Set to 1 if the invoice is completely paid, otherwise is 0
 	 * @var int<0,1>
 	 * @deprecated Use $paid
 	 */
-	public $paye;
+	private $paye;
+
 	/**
 	 * Set to 1 if the invoice is completely paid, otherwise is 0
 	 * @var int<0,1>
@@ -377,6 +370,18 @@ class FactureFournisseur extends CommonInvoice
 	const CLOSECODE_REPLACED = 'replaced';
 
 	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>
+	 */
+	protected function deprecatedProperties()
+	{
+		return array(
+			'fk_statut' => 'status',
+		) + parent::deprecatedProperties();
+	}
+
+	/**
 	 *	Constructor
 	 *
 	 *  @param		DoliDB		$db      Database handler
@@ -485,7 +490,6 @@ class FactureFournisseur extends CommonInvoice
 				$this->mode_reglement_id = 0;
 			}
 			$this->status = self::STATUS_DRAFT;
-			$this->statut = self::STATUS_DRAFT;	// deprecated
 
 			$this->linked_objects = $_facrec->linkedObjectsIds;
 			// We do not add link to template invoice or next invoice will be linked to all generated invoices
@@ -959,7 +963,6 @@ class FactureFournisseur extends CommonInvoice
 				$this->tms                  = $this->db->jdate($obj->tms);
 				$this->libelle              = $obj->label; // deprecated
 				$this->label				= $obj->label;
-				$this->paye					= $obj->paye;
 				$this->paid					= $obj->paye;
 				$this->close_code			= $obj->close_code;
 				$this->close_note			= $obj->close_note;
@@ -969,8 +972,6 @@ class FactureFournisseur extends CommonInvoice
 				$this->total_tva			= $obj->total_tva;
 				$this->total_ttc			= $obj->total_ttc;
 				$this->status				= $obj->status;
-				$this->statut				= $obj->status;	// For backward compatibility
-				$this->fk_statut			= $obj->status;	// For backward compatibility
 				$this->user_creation_id     = $obj->fk_user_author;
 				$this->author				= $obj->fk_user_author;	// deprecated
 				$this->user_validation_id   = $obj->fk_user_valid;
@@ -1181,11 +1182,7 @@ class FactureFournisseur extends CommonInvoice
 			$this->label = trim($this->label);
 		}
 		if (isset($this->paid)) {
-			$this->paid = (int) (bool) $this->paye;
-			$this->paye = $this->paid;
-		} elseif (isset($this->paye)) {
-			$this->paid = (int) (bool) $this->paye;
-			$this->paye = $this->paid;
+			$this->paid = (int) (bool) $this->paid;
 		}
 		if (isset($this->close_code)) {
 			$this->close_code = trim($this->close_code);
@@ -1210,10 +1207,6 @@ class FactureFournisseur extends CommonInvoice
 		}
 		if (isset($this->status)) {
 			$this->status = (int) $this->status;
-			$this->statut = $this->status;
-		} elseif (isset($this->statut)) {
-			$this->status = (int) $this->statut;
-			$this->statut = $this->status;
 		}
 		if (isset($this->author)) {  // TODO: user_creation_id?
 			$this->author = (int) $this->author;
@@ -1275,7 +1268,7 @@ class FactureFournisseur extends CommonInvoice
 		$sql .= " total_ht=".(isset($this->total_ht) ? ((float) $this->total_ht) : "null").",";
 		$sql .= " total_tva=".(isset($this->total_tva) ? ((float) $this->total_tva) : "null").",";
 		$sql .= " total_ttc=".(isset($this->total_ttc) ? ((float) $this->total_ttc) : "null").",";
-		$sql .= " fk_statut=".(isset($this->status) ? ((int) $this->status) : (isset($this->statut) ? ((int) $this->statut) : "null")).",";
+		$sql .= " fk_statut=".(isset($this->status) ? (int) $this->status : "null").",";
 		$sql .= " fk_user_author=".(isset($this->author) ? ((int) $this->author) : "null").",";
 		$sql .= " fk_user_valid=".(isset($this->fk_user_valid) ? ((int) $this->fk_user_valid) : "null").",";
 		$sql .= " fk_facture_source=".($this->fk_facture_source ? ((int) $this->fk_facture_source) : "null").",";
@@ -1966,7 +1959,6 @@ class FactureFournisseur extends CommonInvoice
 			// Set new ref and define current status
 			if (!$error) {
 				$this->ref = $this->newref;
-				$this->statut = self::STATUS_VALIDATED;
 				$this->status = self::STATUS_VALIDATED;
 				//$this->date_validation=$now; this is stored into log table
 			}
@@ -2742,7 +2734,6 @@ class FactureFournisseur extends CommonInvoice
 
 			while ($obj = $this->db->fetch_object($resql)) {
 				$facturestatic->date_echeance = $this->db->jdate($obj->datefin);
-				$facturestatic->statut = $obj->status;	// For backward compatibility
 				$facturestatic->status = $obj->status;
 
 				$response->nbtodo++;
@@ -3177,7 +3168,6 @@ class FactureFournisseur extends CommonInvoice
 		// Load source object
 		$object->fetch($fromid);
 		$object->id = 0;
-		$object->statut = self::STATUS_DRAFT;	// For backward compatibility
 		$object->status = self::STATUS_DRAFT;
 
 		$object->fetch_thirdparty(); // We need it to recalculate VAT localtaxes according to main sale taxes and vendor
@@ -3331,7 +3321,7 @@ class FactureFournisseur extends CommonInvoice
 			return false;
 		}
 
-		$status = isset($this->status) ? $this->status : $this->statut;
+		$status = $this->status;
 
 		return ($status == self::STATUS_VALIDATED) && ($this->date_echeance < ($now - $conf->facture->fournisseur->warning_delay));
 	}

--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -57,7 +57,7 @@ class PaiementFourn extends Paiement
 	/**
 	 * @var int	Status of payment. 0 = unvalidated; 1 = validated
 	 */
-	public $statut;
+	public $status; //Status of payment. 0 = unvalidated; 1 = validated
 	// fk_paiement dans llx_paiement est l'id du type de paiement (7 pour CHQ, ...)
 	// fk_paiement dans llx_paiement_facture est le rowid du paiement
 
@@ -145,7 +145,7 @@ class PaiementFourn extends Paiement
 				$this->type_code            = $obj->payment_code;
 				$this->type_label           = $obj->payment_type;
 				$this->fk_paiement           = $obj->fk_paiement;
-				$this->statut               = $obj->statut;
+				$this->status               = $obj->statut;
 
 				$error = 1;
 			} else {
@@ -610,7 +610,7 @@ class PaiementFourn extends Paiement
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut($this->statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2609,10 +2609,8 @@ if ($action == 'create') {
 						$newinvoice_static->id = $key;
 						$newinvoice_static->ref = $valarray ['ref'];
 						$newinvoice_static->status = $valarray ['status'];
-						$newinvoice_static->statut = $valarray ['status'];
 						$newinvoice_static->type = $valarray ['type'];
 						$newinvoice_static->paid = $valarray ['paye'];
-						$newinvoice_static->paye = $valarray ['paye'];
 
 						$optionsav .= '<option value="'.$key.'"';
 						if ($key == GETPOSTINT('fac_avoir')) {

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -1629,7 +1629,6 @@ while ($i < $imaxinloop) {
 
 	$facturestatic->alreadypaid = ($paiement ? $paiement : 0);
 
-	$facturestatic->paye = $obj->paye;
 	$facturestatic->paid = $obj->paye;
 
 	$facturestatic->date = $db->jdate($obj->datef);

--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -95,12 +95,6 @@ class Holiday extends CommonObject
 	public $halfday = '';
 
 	/**
-	 * @var int Status 1=draft, 2=validated, 3=approved, 4 canceled, 5 refused
-	 * @deprecated
-	 */
-	public $statut = 0;
-
-	/**
 	 * @var int 	ID of user that must approve. Real user for approval is fk_user_valid (old version) or fk_user_approve (new versions)
 	 */
 	public $fk_validator;

--- a/htdocs/hrm/core/tpl/objectline_view.tpl.php
+++ b/htdocs/hrm/core/tpl/objectline_view.tpl.php
@@ -54,6 +54,8 @@ if (empty($object) || !is_object($object)) {
 	exit(1);
 }
 
+'@phan-var-force CommonObject $this';
+
 global $mysoc;
 global $forceall, $senderissupplier, $inputalsopricewithtax, $outputalsopricetotalwithtax;
 

--- a/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
+++ b/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2021 SuperAdmin <test@dolibarr.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -269,7 +270,7 @@ class KnowledgeManagement extends DolibarrApi
 		// Clean data
 		// $this->knowledgerecord->abc = sanitizeVal($this->knowledgerecord->abc, 'alphanohtml');
 
-		if ($this->knowledgerecord->create(DolibarrApiAccess::$user)<0) {
+		if ($this->knowledgerecord->create(DolibarrApiAccess::$user) < 0) {
 			throw new RestException(500, "Error creating KnowledgeRecord", array_merge(array($this->knowledgerecord->error), $this->knowledgerecord->errors));
 		}
 		return $this->knowledgerecord->id;
@@ -363,10 +364,13 @@ class KnowledgeManagement extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -427,8 +431,8 @@ class KnowledgeManagement extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param	array		$data   Array of data to validate
-	 * @return	array
+	 * @param	array<string,mixed>		$data   Array of data to validate
+	 * @return	array<string,mixed>
 	 *
 	 * @throws	RestException
 	 */

--- a/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
+++ b/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
@@ -366,11 +366,11 @@ class KnowledgeManagement extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
+++ b/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
@@ -371,6 +371,7 @@ class KnowledgeManagement extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/mrp/class/api_mos.class.php
+++ b/htdocs/mrp/class/api_mos.class.php
@@ -901,6 +901,7 @@ class Mos extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/mrp/class/api_mos.class.php
+++ b/htdocs/mrp/class/api_mos.class.php
@@ -894,10 +894,13 @@ class Mos extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object			Object to clean
-	 * @return  Object					Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -957,8 +960,8 @@ class Mos extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param	array		$data   Array of data to validate
-	 * @return	array
+	 * @param	array<string,mixed>		$data   Array of data to validate
+	 * @return	array<string,mixed>
 	 *
 	 * @throws	RestException
 	 */

--- a/htdocs/mrp/class/api_mos.class.php
+++ b/htdocs/mrp/class/api_mos.class.php
@@ -896,11 +896,11 @@ class Mos extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/multicurrency/class/api_multicurrencies.class.php
+++ b/htdocs/multicurrency/class/api_multicurrencies.class.php
@@ -357,6 +357,7 @@ class MultiCurrencies extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/multicurrency/class/api_multicurrencies.class.php
+++ b/htdocs/multicurrency/class/api_multicurrencies.class.php
@@ -352,11 +352,11 @@ class MultiCurrencies extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/multicurrency/class/api_multicurrencies.class.php
+++ b/htdocs/multicurrency/class/api_multicurrencies.class.php
@@ -1,6 +1,6 @@
 <?php
-/* Copyright (C) 2022   J-F Bouculat     <jfbouculat@gmail.com>
- * Copyright (C) 2024		MDW					<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2022		J-F Bouculat	<jfbouculat@gmail.com>
+ * Copyright (C) 2024		MDW				<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -350,10 +350,13 @@ class MultiCurrencies extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   MultiCurrency	$object		Object to clean
-	 * @return  Object						Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -379,12 +382,14 @@ class MultiCurrencies extends DolibarrApi
 	 * Clean sensible MultiCurrencyRate object datas
 	 *
 	 * @param   MultiCurrency	$object     Object to clean
-	 * @return  Object						Object with cleaned properties
+	 * @return  MultiCurrency				Object with cleaned properties
 	 */
 	protected function _cleanObjectDatasRate($object)
 	{
 		// phpcs:enable
 		$object = parent::_cleanObjectDatas($object);
+
+		'@phan-var-force MultiCurrency $object';
 
 		// Clear all fields out of interest
 		foreach ($object as $key => $value) {

--- a/htdocs/partnership/class/api_partnerships.class.php
+++ b/htdocs/partnership/class/api_partnerships.class.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -208,7 +209,7 @@ class Partnerships extends DolibarrApi
 		// Clean data
 		// $this->partnership->abc = sanitizeVal($this->partnership->abc, 'alphanohtml');
 
-		if ($this->partnership->create(DolibarrApiAccess::$user)<0) {
+		if ($this->partnership->create(DolibarrApiAccess::$user) < 0) {
 			throw new RestException(500, "Error creating Partnership", array_merge(array($this->partnership->error), $this->partnership->errors));
 		}
 		return $this->partnership->id;
@@ -302,10 +303,13 @@ class Partnerships extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -366,8 +370,8 @@ class Partnerships extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param	array		$data   Array of data to validate
-	 * @return	array
+	 * @param	array<string,mixed>		$data   Array of data to validate
+	 * @return	array<string,mixed>
 	 *
 	 * @throws	RestException
 	 */

--- a/htdocs/partnership/class/api_partnerships.class.php
+++ b/htdocs/partnership/class/api_partnerships.class.php
@@ -310,6 +310,7 @@ class Partnerships extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/partnership/class/api_partnerships.class.php
+++ b/htdocs/partnership/class/api_partnerships.class.php
@@ -305,11 +305,11 @@ class Partnerships extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -2030,6 +2030,7 @@ class Products extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -2025,11 +2025,11 @@ class Products extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -2023,10 +2023,13 @@ class Products extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -2091,8 +2094,8 @@ class Products extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param  array $data Datas to validate
-	 * @return array
+	 * @param  array<string,mixed> $data Datas to validate
+	 * @return array<string,mixed>
 	 * @throws RestException
 	 */
 	private function _validate($data)

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2979,7 +2979,6 @@ class Product extends CommonObject
 				$this->url = $obj->url;
 				$this->note_public = $obj->note_public;
 				$this->note_private = $obj->note_private;
-				$this->note = $obj->note_private; // deprecated
 
 				$this->type = $obj->fk_product_type;
 				$this->price_label = $obj->price_label;

--- a/htdocs/product/stock/class/api_stockmovements.class.php
+++ b/htdocs/product/stock/class/api_stockmovements.class.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2016   Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -279,10 +280,13 @@ class StockMovements extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   MouvementStock $object     Object to clean
-	 * @return  Object                     Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -337,8 +341,8 @@ class StockMovements extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param array|null    $data    Data to validate
-	 * @return array
+	 * @param ?array<string,mixed>    $data    Data to validate
+	 * @return array<string,mixed>
 	 *
 	 * @throws RestException
 	 */

--- a/htdocs/product/stock/class/api_stockmovements.class.php
+++ b/htdocs/product/stock/class/api_stockmovements.class.php
@@ -282,11 +282,11 @@ class StockMovements extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/product/stock/class/api_stockmovements.class.php
+++ b/htdocs/product/stock/class/api_stockmovements.class.php
@@ -287,6 +287,7 @@ class StockMovements extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/product/stock/class/api_warehouses.class.php
+++ b/htdocs/product/stock/class/api_warehouses.class.php
@@ -270,6 +270,7 @@ class Warehouses extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/product/stock/class/api_warehouses.class.php
+++ b/htdocs/product/stock/class/api_warehouses.class.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2016   Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,10 +16,10 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
- use Luracast\Restler\RestException;
+use Luracast\Restler\RestException;
 
- require_once DOL_DOCUMENT_ROOT.'/product/stock/class/entrepot.class.php';
- require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/stock/class/entrepot.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 
 /**
  * API class for warehouses
@@ -262,10 +263,13 @@ class Warehouses extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Entrepot  $object   Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -282,8 +286,8 @@ class Warehouses extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param array|null    $data    Data to validate
-	 * @return array
+	 * @param ?array<string,mixed>    $data    Data to validate
+	 * @return array<string,mixed>
 	 *
 	 * @throws RestException
 	 */

--- a/htdocs/product/stock/class/api_warehouses.class.php
+++ b/htdocs/product/stock/class/api_warehouses.class.php
@@ -265,11 +265,11 @@ class Warehouses extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/product/stock/class/entrepot.class.php
+++ b/htdocs/product/stock/class/entrepot.class.php
@@ -68,11 +68,6 @@ class Entrepot extends CommonObject
 	public $description;
 
 	/**
-	 * @var int
-	 */
-	public $statut;
-
-	/**
 	 * @var string Place
 	 */
 	public $lieu;
@@ -357,7 +352,7 @@ class Entrepot extends CommonObject
 		$sql .= ", fk_parent = ".(($this->fk_parent > 0) ? $this->fk_parent : "NULL");
 		$sql .= ", fk_project = ".(($this->fk_project > 0) ? $this->fk_project : "NULL");
 		$sql .= ", description = '".$this->db->escape($this->description)."'";
-		$sql .= ", statut = ".((int) $this->statut);
+		$sql .= ", statut = ".((int) $this->status);
 		$sql .= ", lieu = '".$this->db->escape($this->lieu)."'";
 		$sql .= ", address = '".$this->db->escape($this->address)."'";
 		$sql .= ", zip = '".$this->db->escape($this->zip)."'";
@@ -541,7 +536,7 @@ class Entrepot extends CommonObject
 				$this->ref            = $obj->label;
 				$this->label          = $obj->label;
 				$this->description    = $obj->description;
-				$this->statut         = $obj->statut;
+				$this->status         = $obj->statut;
 				$this->lieu           = $obj->lieu;
 				$this->address        = $obj->address;
 				$this->zip            = $obj->zip;
@@ -724,7 +719,7 @@ class Entrepot extends CommonObject
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut($this->statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -773,7 +768,7 @@ class Entrepot extends CommonObject
 			return ['optimize' => $langs->trans("Warehouse")];
 		}
 		$datas['picto'] = img_picto('', $this->picto).' <u class="paddingrightonly">'.$langs->trans("Warehouse").'</u>';
-		if (!empty($this->statut)) {
+		if (!empty($this->status)) {
 			$datas['picto'] .= ' '.$this->getLibStatut(5);
 		}
 		$datas['ref'] = '<br><b>'.$langs->trans('Ref').':</b> '.(empty($this->ref) ? $this->label : $this->ref);
@@ -897,7 +892,7 @@ class Entrepot extends CommonObject
 		$this->id = 0;
 		$this->label = 'WAREHOUSE SPECIMEN';
 		$this->description = 'WAREHOUSE SPECIMEN '.dol_print_date($now, 'dayhourlog');
-		$this->statut = 1;
+		$this->status = 1;
 		$this->specimen = 1;
 
 		$this->lieu = 'Location test';

--- a/htdocs/projet/activity/index.php
+++ b/htdocs/projet/activity/index.php
@@ -511,7 +511,6 @@ if (!getDolGlobalString('PROJECT_HIDE_TASKS') && getDolGlobalString('PROJECT_SHO
 
 			$taskstatic->projectstatus = $obj->projectstatus;
 			$taskstatic->progress = $obj->progress;
-			$taskstatic->fk_statut = $obj->status;
 			$taskstatic->status = $obj->status;
 			$taskstatic->date_start = $db->jdate($obj->date_start);
 			$taskstatic->date_end = $db->jdate($obj->date_end);

--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -747,11 +747,11 @@ class Projects extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -752,6 +752,7 @@ class Projects extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -745,10 +745,13 @@ class Projects extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -688,6 +688,7 @@ class Tasks extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -683,11 +683,11 @@ class Tasks extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -680,10 +681,13 @@ class Tasks extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -731,8 +735,8 @@ class Tasks extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param   array           $data   Array with data to verify
-	 * @return  array
+	 * @param   array<string,mixed>	$data   Array with data to verify
+	 * @return  array<string,mixed>
 	 * @throws  RestException
 	 */
 	private function _validate($data)

--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -206,12 +206,6 @@ class Project extends CommonObject
 	public $max_attendees;
 
 	/**
-	 * @var int status
-	 * @deprecated Use $status
-	 */
-	public $statut; // 0=draft, 1=opened, 2=closed
-
-	/**
 	 * @var int opportunity status
 	 */
 	public $opp_status; // opportunity status, into table llx_c_lead_status
@@ -784,7 +778,6 @@ class Project extends CommonObject
 				$this->user_modification_id = $obj->fk_user_modif;
 				$this->user_closing_id = $obj->fk_user_close;
 				$this->public = $obj->public;
-				$this->statut = $obj->status; // deprecated
 				$this->status = $obj->status;
 				$this->opp_status = $obj->fk_opp_status;
 				$this->opp_amount	= $obj->opp_amount;
@@ -1254,7 +1247,6 @@ class Project extends CommonObject
 			}
 
 			if (!$error) {
-				$this->statut = 1;
 				$this->status = 1;
 				$this->db->commit();
 				return 1;
@@ -1306,7 +1298,7 @@ class Project extends CommonObject
 				// End call triggers
 
 				if (!$error) {
-					$this->status = 2;
+					$this->status = self::STATUS_CLOSED;
 					$this->db->commit();
 					return 1;
 				} else {
@@ -1333,7 +1325,7 @@ class Project extends CommonObject
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut(isset($this->status) ? $this->status : $this->statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -2327,7 +2319,6 @@ class Project extends CommonObject
 			while ($obj = $this->db->fetch_object($resql)) {
 				$response->nbtodo++;
 
-				$project_static->statut = $obj->status;
 				$project_static->status = $obj->status;
 				$project_static->opp_status = $obj->fk_opp_status;
 				$project_static->date_end = $this->db->jdate($obj->datee);

--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -134,7 +134,7 @@ class Task extends CommonObjectLine
 	 * @deprecated use status instead
 	 * @see $status
 	 */
-	public $fk_statut;
+	private $fk_statut;
 
 	/**
 	 * @var int ID
@@ -372,6 +372,18 @@ class Task extends CommonObjectLine
 	 */
 	const STATUS_CANCELED = 9;
 
+	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>
+	 */
+	protected function deprecatedProperties()
+	{
+		return array(
+			'fk_statut' => 'status',
+		) + parent::deprecatedProperties();
+	}
+
 
 	/**
 	 *  Constructor
@@ -565,7 +577,6 @@ class Task extends CommonObjectLine
 				$this->date_end = $this->db->jdate($obj->date_end);
 				$this->fk_user_creat		= $obj->fk_user_creat;
 				$this->fk_user_valid		= $obj->fk_user_valid;
-				$this->fk_statut		    = $obj->status;
 				$this->status			    = $obj->status;
 				$this->progress				= $obj->progress;
 				$this->budget_amount		= $obj->budget_amount;
@@ -1332,7 +1343,6 @@ class Task extends CommonObjectLine
 					}
 
 					$tasks[$i]->progress		= $obj->progress;
-					$tasks[$i]->fk_statut		= $obj->status;
 					$tasks[$i]->status 		    = $obj->status;
 					$tasks[$i]->public = $obj->public;
 					$tasks[$i]->date_start = $this->db->jdate($obj->date_start);
@@ -2613,7 +2623,6 @@ class Task extends CommonObjectLine
 
 				$task_static->projectstatus = $obj->projectstatus;
 				$task_static->progress = $obj->progress;
-				$task_static->fk_statut = $obj->status;
 				$task_static->status = $obj->status;
 				$task_static->date_start = $this->db->jdate($obj->date_start);
 				$task_static->date_end = $this->db->jdate($obj->date_end);

--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -1,8 +1,7 @@
 <?php
-/* Copyright (C) 2024		MDW	<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2013-2016	Jean-François FERRY			<jfefe@aternatik.fr>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
- */
-/*  Copyright (C) 2013-2016    Jean-François FERRY    <jfefe@aternatik.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -712,7 +711,7 @@ if ($action == "view_ticketlist") {
 						}
 					}
 
-					// Statut
+					// Status
 					if (!empty($arrayfields['t.fk_statut']['checked'])) {
 						print '<td class="nowraponall">';
 						$object->status = $obj->fk_statut;

--- a/htdocs/public/ticket/view.php
+++ b/htdocs/public/ticket/view.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2013-2016  Jean-François FERRY     <hello@librethic.io>
  * Copyright (C) 2018-2024	Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2023		Benjamin Falière		<benjamin.faliere@altairis.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -404,7 +405,7 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 			$baseurl = getDolGlobalString('TICKET_URL_PUBLIC_INTERFACE', DOL_URL_ROOT.'/public/ticket/');
 
 			$formticket->param = array('track_id' => $object->dao->track_id, 'fk_user_create' => '-1',
-									   'returnurl' => $baseurl.'view.php'.(!empty($entity) && isModEnabled('multicompany')?'?entity='.$entity:''));
+									   'returnurl' => $baseurl.'view.php'.(!empty($entity) && isModEnabled('multicompany') ? '?entity='.$entity : ''));
 
 			$formticket->withfile = 2;
 			$formticket->withcancel = 1;
@@ -415,7 +416,7 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 		if ($action != 'presend') {
 			$baseurl = getDolGlobalString('TICKET_URL_PUBLIC_INTERFACE', DOL_URL_ROOT.'/public/ticket/');
 
-			print '<form method="POST" id="form_view_ticket_list" name="form_view_ticket_list" action="'.$baseurl.'list.php'.(!empty($entity) && isModEnabled('multicompany')?'?entity='.$entity:'').'">';
+			print '<form method="POST" id="form_view_ticket_list" name="form_view_ticket_list" action="'.$baseurl.'list.php'.(!empty($entity) && isModEnabled('multicompany') ? '?entity='.$entity : '').'">';
 			print '<input type="hidden" name="token" value="'.newToken().'">';
 			print '<input type="hidden" name="action" value="view_ticketlist">';
 			print '<input type="hidden" name="track_id" value="'.$object->dao->track_id.'">';
@@ -428,12 +429,12 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 			// List ticket
 			print '<div class="inline-block divButAction"><a class="left" style="padding-right: 50px" href="javascript:$(\'#form_view_ticket_list\').submit();">'.$langs->trans('ViewMyTicketList').'</a></div>';
 
-			if ($object->dao->fk_statut < Ticket::STATUS_CLOSED) {
+			if ($object->dao->status < Ticket::STATUS_CLOSED) {
 				// New message
 				print '<div class="inline-block divButAction"><a class="butAction" href="'.$_SERVER['PHP_SELF'].'?action=presend&mode=init&track_id='.$object->dao->track_id.(!empty($entity) && isModEnabled('multicompany') ? '&entity='.$entity : '').'&token='.newToken().'">'.$langs->trans('TicketAddMessage').'</a></div>';
 
 				// Close ticket
-				if ($object->dao->fk_statut >= Ticket::STATUS_NOT_READ && $object->dao->fk_statut < Ticket::STATUS_CLOSED) {
+				if ($object->dao->status >= Ticket::STATUS_NOT_READ && $object->dao->status < Ticket::STATUS_CLOSED) {
 					print '<div class="inline-block divButAction"><a class="butAction" href="'.$_SERVER['PHP_SELF'].'?action=close&track_id='.$object->dao->track_id.(!empty($entity) && isModEnabled('multicompany') ? '&entity='.$entity : '').'&token='.newToken().'">'.$langs->trans('CloseTicket').'</a></div>';
 				}
 			}

--- a/htdocs/reception/class/api_receptions.class.php
+++ b/htdocs/reception/class/api_receptions.class.php
@@ -714,10 +714,13 @@ class Receptions extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/reception/class/api_receptions.class.php
+++ b/htdocs/reception/class/api_receptions.class.php
@@ -716,11 +716,11 @@ class Receptions extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/reception/class/api_receptions.class.php
+++ b/htdocs/reception/class/api_receptions.class.php
@@ -721,6 +721,7 @@ class Receptions extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/recruitment/class/api_recruitments.class.php
+++ b/htdocs/recruitment/class/api_recruitments.class.php
@@ -618,11 +618,11 @@ class Recruitments extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/recruitment/class/api_recruitments.class.php
+++ b/htdocs/recruitment/class/api_recruitments.class.php
@@ -616,10 +616,13 @@ class Recruitments extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/recruitment/class/api_recruitments.class.php
+++ b/htdocs/recruitment/class/api_recruitments.class.php
@@ -623,6 +623,7 @@ class Recruitments extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -207,7 +207,7 @@ if ($action == 'setfk_user' && $permissiontoadd) {
 
 if ($action == 'reopen' && $permissiontoadd) {
 	$result = $object->fetch($id);
-	if ($object->paye) {
+	if ($object->paid) {
 		$result = $object->set_unpaid($user);
 		if ($result > 0) {
 			header('Location: '.$_SERVER["PHP_SELF"].'?id='.$id);
@@ -409,7 +409,7 @@ if ($action == 'confirm_clone' && $confirm == 'yes' && $permissiontoadd) {
 	$object->fetch($id);
 
 	if ($object->id > 0) {
-		$object->paye = 0;
+		$object->paid = 0;
 		$object->id = 0;
 		$object->ref = '';
 

--- a/htdocs/salaries/class/api_salaries.class.php
+++ b/htdocs/salaries/class/api_salaries.class.php
@@ -1,6 +1,7 @@
 <?php
 /*
  * Copyright (C) 2023 Marc Chenebaux <marc.chenebaux@maj44.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +34,7 @@ class Salaries extends DolibarrApi
 	/**
 	 * @var array $FIELDS Mandatory fields, checked when creating an object
 	 */
-	static $FIELDS = array(
+	public static $FIELDS = array(
 		'fk_user',
 		'label',
 		'amount',
@@ -42,7 +43,7 @@ class Salaries extends DolibarrApi
 	/**
 	 * array $FIELDS Mandatory fields, checked when creating an object
 	 */
-	static $FIELDSPAYMENT = array(
+	public static $FIELDSPAYMENT = array(
 		"paiementtype",
 		'datepaye',
 		'chid',
@@ -444,7 +445,9 @@ class Salaries extends DolibarrApi
 	{
 		$paymentsalary = array();
 		$fields = Salaries::$FIELDSPAYMENT;
-		if (isModEnabled("bank")) array_push($fields, "accountid");
+		if (isModEnabled("bank")) {
+			array_push($fields, "accountid");
+		}
 		foreach ($fields as $field) {
 			if (!isset($data[$field])) {
 				throw new RestException(400, "$field field missing");
@@ -456,10 +459,13 @@ class Salaries extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/salaries/class/api_salaries.class.php
+++ b/htdocs/salaries/class/api_salaries.class.php
@@ -466,6 +466,7 @@ class Salaries extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/salaries/class/api_salaries.class.php
+++ b/htdocs/salaries/class/api_salaries.class.php
@@ -461,11 +461,11 @@ class Salaries extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/salaries/class/salary.class.php
+++ b/htdocs/salaries/class/salary.class.php
@@ -149,7 +149,7 @@ class Salary extends CommonObject
 	 * @var int<0,1> 1 if salary paid COMPLETELY, 0 otherwise (do not use it anymore, use statut and close_code)
 	 * @deprecated Use $status and $close_code
 	 */
-	public $paye;
+	public $paid;
 
 	const STATUS_UNPAID = 0;
 	const STATUS_PAID = 1;
@@ -185,6 +185,18 @@ class Salary extends CommonObject
 		'note_public' => array('type' => 'text', 'label' => 'NotePublic', 'enabled' => 1, 'visible' => 0, 'position' => 220),
 	);
 
+
+	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>  Old property to new property mapping
+	 */
+	protected function deprecatedProperties()
+	{
+		return array(
+			'paye' => 'paid',
+		) + parent::deprecatedProperties();
+	}
 
 	/**
 	 *	Constructor
@@ -333,7 +345,7 @@ class Salary extends CommonObject
 				$this->note				= $obj->note_private;
 				$this->note_private		= $obj->note_private;
 				$this->note_public		= $obj->note_public;
-				$this->paye 			= $obj->paye;
+				$this->paid 			= $obj->paye;
 				$this->status 			= $obj->paye;
 				$this->fk_bank          = $obj->fk_bank;
 				$this->fk_user_author   = $obj->fk_user_author;

--- a/htdocs/salaries/list.php
+++ b/htdocs/salaries/list.php
@@ -794,7 +794,6 @@ while ($i < $imaxinloop) {
 	$userstatic->login = $obj->login;
 	$userstatic->email = $obj->email;
 	$userstatic->socid = $obj->fk_soc;
-	$userstatic->statut = $obj->status;		// deprecated
 	$userstatic->status = $obj->status;
 	$userstatic->photo = $obj->photo;
 

--- a/htdocs/salaries/virement_request.php
+++ b/htdocs/salaries/virement_request.php
@@ -475,7 +475,7 @@ $sql .= " ORDER BY pfd.date_demande DESC";
 $resql = $db->query($sql);
 
 $hadRequest = $db->num_rows($resql);
-if ($object->paye == 0 && $hadRequest == 0) {
+if ($object->paid == 0 && $hadRequest == 0) {
 	if ($resteapayer > 0) {
 		if ($user_perms) {
 			print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'">';
@@ -512,7 +512,7 @@ if ($object->paye == 0 && $hadRequest == 0) {
 	}
 } else {
 	if ($hadRequest == 0) {
-		if ($object->paye > 0) {
+		if ($object->paid > 0) {
 			print '<a class="butActionRefused classfortooltip" href="#" title="'.dol_escape_htmltag($langs->trans("AlreadyPaid")).'">'.$buttonlabel.'</a>';
 		} else {
 			print '<a class="butActionRefused classfortooltip" href="#" title="'.dol_escape_htmltag($langs->trans("Draft")).'">'.$buttonlabel.'</a>';
@@ -571,7 +571,6 @@ if ($resql) {
 			$tmpuser->email = $obj->email;
 			$tmpuser->lastname = $obj->lastname;
 			$tmpuser->firstname = $obj->firstname;
-			$tmpuser->statut = $obj->user_status;
 			$tmpuser->status = $obj->user_status;
 
 			print '<tr class="oddeven">';
@@ -607,7 +606,6 @@ if ($resql) {
 				$withdrawreceipt->date_trans = $db->jdate($obj->date_trans);
 				$withdrawreceipt->date_credit = $db->jdate($obj->date_credit);
 				$withdrawreceipt->date_creation = $db->jdate($obj->datec);
-				$withdrawreceipt->statut = $obj->status;
 				$withdrawreceipt->status = $obj->status;
 				$withdrawreceipt->amount = $obj->pb_amount;
 				//$withdrawreceipt->credite = $db->jdate($obj->credite);
@@ -688,7 +686,6 @@ if ($resql) {
 			$tmpuser->email = $obj->email;
 			$tmpuser->lastname = $obj->lastname;
 			$tmpuser->firstname = $obj->firstname;
-			$tmpuser->statut = $obj->user_status;
 			$tmpuser->status = $obj->user_status;
 
 			print '<tr class="oddeven">';
@@ -721,7 +718,6 @@ if ($resql) {
 				$withdrawreceipt->date_trans = $db->jdate($obj->date_trans);
 				$withdrawreceipt->date_credit = $db->jdate($obj->date_credit);
 				$withdrawreceipt->date_creation = $db->jdate($obj->datec);
-				$withdrawreceipt->statut = $obj->status;
 				$withdrawreceipt->status = $obj->status;
 				$withdrawreceipt->fk_bank_account = $obj->fk_bank_account;
 				$withdrawreceipt->amount = $obj->pb_amount;

--- a/htdocs/societe/class/api_contacts.class.php
+++ b/htdocs/societe/class/api_contacts.class.php
@@ -620,11 +620,11 @@ class Contacts extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/societe/class/api_contacts.class.php
+++ b/htdocs/societe/class/api_contacts.class.php
@@ -618,10 +618,13 @@ class Contacts extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -644,8 +647,8 @@ class Contacts extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param   string[]|null     $data   Data to validate
-	 * @return  string[]
+	 * @param   ?array<string,mixed>     $data   Data to validate
+	 * @return  array<string,mixed>
 	 * @throws  RestException
 	 */
 	private function _validate($data)

--- a/htdocs/societe/class/api_contacts.class.php
+++ b/htdocs/societe/class/api_contacts.class.php
@@ -625,6 +625,7 @@ class Contacts extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -2080,11 +2080,11 @@ class Thirdparties extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -2078,10 +2078,13 @@ class Thirdparties extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object				Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -2120,8 +2123,8 @@ class Thirdparties extends DolibarrApi
 	/**
 	 * Validate fields before create or update object
 	 *
-	 * @param array $data   Datas to validate
-	 * @return array
+	 * @param array<string,mixed>	$data   Data to validate
+	 * @return array<string,mixed>
 	 *
 	 * @throws RestException
 	 */

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -2085,6 +2085,7 @@ class Thirdparties extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
+++ b/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
@@ -343,6 +343,7 @@ class SupplierProposals extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
+++ b/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
@@ -338,11 +338,11 @@ class SupplierProposals extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
+++ b/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016   Laurent Destailleur     <eldy@users.sourceforge.net>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -335,10 +336,13 @@ class SupplierProposals extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -113,11 +113,6 @@ class SupplierProposal extends CommonObject
 	 */
 	public $ref_supplier; //Reference saisie lors de l'ajout d'une ligne à la demande
 
-	/**
-	 * @var int
-	 * @deprecated
-	 */
-	public $statut; // 0 (draft), 1 (validated), 2 (signed), 3 (not signed), 4 (processed/billed)
 
 	/**
 	 * @var int|string Date of proposal
@@ -489,7 +484,7 @@ class SupplierProposal extends CommonObject
 			return -1;
 		}
 
-		if ($this->statut == self::STATUS_DRAFT) {
+		if ($this->status == self::STATUS_DRAFT) {
 			$this->db->begin();
 
 			if ($fk_product > 0) {
@@ -892,7 +887,7 @@ class SupplierProposal extends CommonObject
 	{
 		global $user;
 
-		if ($this->statut == 0) {
+		if ($this->status == 0) {
 			$line = new SupplierProposalLine($this->db);
 
 			// For triggers
@@ -1180,7 +1175,7 @@ class SupplierProposal extends CommonObject
 		}
 
 		$this->id = 0;
-		$this->statut = 0;
+		$this->status = 0;
 
 		if (!getDolGlobalString('SUPPLIER_PROPOSAL_ADDON') || !is_readable(DOL_DOCUMENT_ROOT."/core/modules/supplier_proposal/" . getDolGlobalString('SUPPLIER_PROPOSAL_ADDON').".php")) {
 			$this->error = 'ErrorSetupNotComplete';
@@ -1291,7 +1286,6 @@ class SupplierProposal extends CommonObject
 				$this->note                 = $obj->note_private; // TODO deprecated
 				$this->note_private         = $obj->note_private;
 				$this->note_public          = $obj->note_public;
-				$this->statut               = (int) $obj->fk_statut;
 				$this->status               = (int) $obj->fk_statut;
 				$this->datec                = $this->db->jdate($obj->datec); // TODO deprecated
 				$this->datev                = $this->db->jdate($obj->datev); // TODO deprecated
@@ -1529,7 +1523,6 @@ class SupplierProposal extends CommonObject
 				}
 
 				$this->ref = $num;
-				$this->statut = self::STATUS_VALIDATED;
 				$this->status = self::STATUS_VALIDATED;
 				$this->user_validation_id = $user->id;
 				$this->datev = $now;
@@ -1671,11 +1664,11 @@ class SupplierProposal extends CommonObject
 	{
 		global $langs, $conf;
 
-		$this->statut = $statut;
+		$this->status = $statut;
 		$error = 0;
 
 		$sql = "UPDATE ".MAIN_DB_PREFIX."supplier_proposal";
-		$sql .= " SET fk_statut = ".((int) $this->statut).",";
+		$sql .= " SET fk_statut = ".((int) $this->status).",";
 		if (!empty($note)) {
 			$sql .= " note_private = '".$this->db->escape($note)."',";
 		}
@@ -1732,7 +1725,7 @@ class SupplierProposal extends CommonObject
 		$hidedetails = 0;
 		$hidedesc = 0;
 		$hideref = 0;
-		$this->statut = $status;
+		$this->status = $status;
 		$error = 0;
 		$now = dol_now();
 
@@ -1933,7 +1926,7 @@ class SupplierProposal extends CommonObject
 
 		$error = 0;
 
-		if ($this->statut == self::STATUS_DRAFT) {
+		if ($this->status == self::STATUS_DRAFT) {
 			dol_syslog(get_class($this)."::setDraft already draft status", LOG_WARNING);
 			return 0;
 		}
@@ -1957,7 +1950,6 @@ class SupplierProposal extends CommonObject
 
 			if (!$error) {
 				$this->status = self::STATUS_DRAFT;
-				$this->statut = self::STATUS_DRAFT;	// deprecated
 				$this->db->commit();
 				return 1;
 			} else {
@@ -2202,7 +2194,7 @@ class SupplierProposal extends CommonObject
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut((isset($this->statut) ? $this->statut : $this->status), $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -1,8 +1,8 @@
 <?php
-/* Copyright (C) 2013-2015 Jean-François FERRY <hello@librethic.io>
- * Copyright (C) 2016      Christophe Battarel <christophe@altairis.fr>
- * Copyright (C) 2024      Destailleur Laurent <eldy@users.sourceforge.net>
- * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+/* Copyright (C) 2013-2015	Jean-François FERRY	<hello@librethic.io>
+ * Copyright (C) 2016		Christophe Battarel	<christophe@altairis.fr>
+ * Copyright (C) 2024		Destailleur Laurent	<eldy@users.sourceforge.net>
+ * Copyright (C) 2024		Frédéric France		<frederic.france@free.fr>
  * Copyright (C) 2024		MDW					<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -147,7 +147,7 @@ class ActionsTicket extends CommonHookActions
 	public function getLibStatut($mode = 0)
 	{
 		$this->getInstanceDao();
-		$this->dao->fk_statut = $this->fk_statut;
+		$this->dao->status = $this->fk_statut;
 		return $this->dao->getLibStatut($mode);
 	}
 

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -489,11 +489,11 @@ class Tickets extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 *
 	 * @todo use an array for properties to clean
 	 *

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -494,6 +494,7 @@ class Tickets extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 *
 	 * @todo use an array for properties to clean
 	 *

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -487,10 +487,13 @@ class Tickets extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 *
 	 * @todo use an array for properties to clean
 	 *

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -124,7 +124,7 @@ class Ticket extends CommonObject
 	 * @deprecated use status
 	 * @see $status
 	 */
-	public $fk_statut;
+	private $fk_statut;
 
 	/**
 	 * @var int Ticket status
@@ -332,6 +332,18 @@ class Ticket extends CommonObject
 	);
 	// END MODULEBUILDER PROPERTIES
 
+
+	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>
+	 */
+	protected function deprecatedProperties()
+	{
+		return array(
+			'fk_statut' => 'status',
+		) + parent::deprecatedProperties();
+	}
 
 	/**
 	 *  Constructor
@@ -558,7 +570,7 @@ class Ticket extends CommonObject
 			$sql .= " ".(!isDolTms($this->email_date) ? 'NULL' : "'".$this->db->idate($this->email_date)."'").",";
 			$sql .= " ".(!isset($this->subject) ? 'NULL' : "'".$this->db->escape($this->subject)."'").",";
 			$sql .= " ".(!isset($this->message) ? 'NULL' : "'".$this->db->escape($this->message)."'").",";
-			$sql .= " ".(!isset($this->status) ? '0' : ((int) $this->status)).",";
+			$sql .= " ".(!isset($this->status) ? '0' : (int) $this->status).",";
 			$sql .= " ".(!isset($this->resolution) ? 'NULL' : ((int) $this->resolution)).",";
 			$sql .= " ".(!isset($this->progress) ? '0' : ((int) $this->progress)).",";
 			$sql .= " ".(!isset($this->timing) ? 'NULL' : "'".$this->db->escape($this->timing)."'").",";
@@ -747,7 +759,6 @@ class Ticket extends CommonObject
 				$this->ip = $obj->ip;
 
 				$this->status = $obj->status;
-				$this->fk_statut = $this->status; // For backward compatibility
 
 				$this->resolution = $obj->resolution;
 				$this->progress = $obj->progress;
@@ -942,7 +953,6 @@ class Ticket extends CommonObject
 
 					$line->subject = $obj->subject;
 					$line->message = $obj->message;
-					$line->fk_statut = $obj->status;
 					$line->status = $obj->status;
 					$line->resolution = $obj->resolution;
 					$line->progress = $obj->progress;
@@ -1266,7 +1276,6 @@ class Ticket extends CommonObject
 
 		// Clear fields
 		$object->id = 0;
-		$object->statut = 0;
 		$object->status = 0;
 
 		// Create clone
@@ -1868,7 +1877,7 @@ class Ticket extends CommonObject
 			if (!empty($contacts)) {
 				// Ensure that contact is active and select first active contact
 				foreach ($contacts as $contact) {
-					if ((int) $contact->statut == 1) {
+					if ((int) $contact->status == 1) {
 						$actioncomm->contact_id = $contact->id;
 						break;
 					}
@@ -2017,14 +2026,14 @@ class Ticket extends CommonObject
 						foreach ($this->linkedObjectsIds['fichinter'] as $fichinter_id) {
 							$fichinter = new Fichinter($this->db);
 							$fichinter->fetch($fichinter_id);
-							if ($fichinter->statut == 0) {
+							if ($fichinter->status == 0) {
 								$result = $fichinter->setValid($user);
 								if (!$result) {
 									$this->errors[] = $fichinter->error;
 									$error++;
 								}
 							}
-							if ($fichinter->statut < 3) {
+							if ($fichinter->status < 3) {
 								$result = $fichinter->setStatut(3);
 								if (!$result) {
 									$this->errors[] = $fichinter->error;

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -1038,7 +1038,6 @@ while ($i < $imaxinloop) {
 	// Store properties in $object
 	$object->setVarsFromFetchObj($obj);
 	$object->type_code = $obj->type_code;
-	$object->status = $object->fk_statut; // because field name is fk_statut
 
 	if ($mode == 'kanban') {
 		if ($i == 0) {

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -383,7 +383,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	print '<table class="border centpercent tableforfield">';
 
 	print '<tr><td class="titlefieldmiddle">'.$langs->trans("Login").'</td>';
-	if (!empty($object->ldap_sid) && $object->statut == 0) {
+	if (!empty($object->ldap_sid) && $object->status == 0) {
 		print '<td class="error">';
 		print $langs->trans("LoginAccountDisableInDolibarr");
 		print '</td>';
@@ -687,7 +687,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 				$salary->label = $objp->label;
 				$salary->datesp = $db->jdate($objp->datesp);
 				$salary->dateep = $db->jdate($objp->dateep);
-				$salary->paye = $objp->paye;
+				$salary->paid = $objp->paye;
 				$salary->amount = $objp->amount;
 
 				$payment_salary->id = !empty($objp->rowid) ? $objp->rowid : 0;
@@ -747,7 +747,6 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 				$holiday->ref = $objp->rowid;
 
 				$holiday->fk_type = $objp->fk_type;
-				$holiday->statut = $objp->status;
 				$holiday->status = $objp->status;
 
 				$nbopenedday = num_open_day($db->jdate($objp->date_debut, 'gmt'), $db->jdate($objp->date_fin, 'gmt'), 0, 1, $objp->halfday);

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -737,6 +737,7 @@ class Users extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -732,11 +732,11 @@ class Users extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -660,7 +660,7 @@ class Users extends DolibarrApi
 	}
 
 	/**
-	 * Get properties of an group object
+	 * Get properties of a group object
 	 *
 	 * Return an array with group information
 	 *
@@ -730,10 +730,13 @@ class Users extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object	$object		Object to clean
-	 * @return  Object				Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	protected function _cleanObjectDatas($object)
 	{

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -77,13 +77,6 @@ class User extends CommonObject
 
 	/**
 	 * @var int
-	 * @deprecated Use $status
-	 * @see $status
-	 */
-	public $statut;
-
-	/**
-	 * @var int
 	 */
 	public $status;
 
@@ -691,7 +684,6 @@ class User extends CommonObject
 				$this->note_public = $obj->note_public;
 				$this->note_private = $obj->note_private;
 
-				$this->statut		= $obj->status;			// deprecated
 				$this->status		= $obj->status;
 
 				$this->photo		= $obj->photo;
@@ -1577,8 +1569,8 @@ class User extends CommonObject
 		$error = 0;
 
 		// Check parameters
-		if (isset($this->statut)) {
-			if ($this->statut == $status) {
+		if (isset($this->status)) {
+			if ($this->status == $status) {
 				return 0;
 			}
 		} elseif (isset($this->status) && $this->status == $status) {
@@ -1613,7 +1605,6 @@ class User extends CommonObject
 			return -$error;
 		} else {
 			$this->status = $status;
-			$this->statut = $status;
 			$this->db->commit();
 			return 1;
 		}
@@ -1822,7 +1813,7 @@ class User extends CommonObject
 				$entrepot->label = $langs->trans("PersonalStock", $this->getFullName($langs));
 				$entrepot->libelle = $entrepot->label; // For backward compatibility
 				$entrepot->description = $langs->trans("ThisWarehouseIsPersonalStock", $this->getFullName($langs));
-				$entrepot->statut = 1;
+				$entrepot->status = 1;
 				$entrepot->country_id = $mysoc->country_id;
 
 				$warehouseid = $entrepot->create($user);
@@ -3290,7 +3281,7 @@ class User extends CommonObject
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut(isset($this->statut) ? (int) $this->statut : (int) $this->status, $mode);
+		return $this->LibStatut((int) $this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -3631,7 +3622,6 @@ class User extends CommonObject
 		$this->iplastlogin = '127.0.0.1';
 		$this->datepreviouslogin = $now;
 		$this->ippreviouslogin = '127.0.0.1';
-		$this->statut = 1;		// deprecated
 		$this->status = 1;
 
 		$this->entity = 1;

--- a/htdocs/webportal/class/webportalinvoice.class.php
+++ b/htdocs/webportal/class/webportalinvoice.class.php
@@ -124,10 +124,6 @@ class WebPortalInvoice extends Facture
 	//public $multicurrency_total_ht;
 	//public $multicurrency_total_tva;
 	//public $multicurrency_total_ttc;
-
-	/*
-	 * @var int status
-	 */
 	//public $fk_statut; // Managed in parent
 	// END MODULEBUILDER PROPERTIES
 
@@ -311,7 +307,7 @@ class WebPortalInvoice extends Facture
 	 */
 	public function getLabelStatus($mode = 0)
 	{
-		return $this->LibStatut($this->paye, $this->status, $mode, -1, $this->type);
+		return $this->LibStatut($this->paid, $this->status, $mode, -1, $this->type);
 	}
 
 	/**
@@ -323,7 +319,7 @@ class WebPortalInvoice extends Facture
 	 */
 	public function getLibStatut($mode = 0, $alreadypaid = -1)
 	{
-		return $this->LibStatut($this->paye, $this->status, $mode, $alreadypaid, $this->type);
+		return $this->LibStatut($this->paid, $this->status, $mode, $alreadypaid, $this->type);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -331,7 +327,7 @@ class WebPortalInvoice extends Facture
 	/**
 	 *  Return label of a status
 	 *
-	 * @param	int			$paye			Status field paye
+	 * @param	int			$paid			Status field paid
 	 * @param	int			$status			Id status
 	 * @param	int<0,6>	$mode 			0=long label, 1=short label, 2=Picto + short label, 3=Picto, 4=Picto + long label, 5=short label + picto, 6=long label + picto
 	 * @param	int 		$alreadypaid	0=No payment already done, >0=Some payments were already done
@@ -339,9 +335,9 @@ class WebPortalInvoice extends Facture
 	 * @param	int			$nbofopendirectdebitorcredittransfer	Nb of open direct debit or credit transfer
 	 * @return  string	Label of status
 	 */
-	public function LibStatut($paye, $status, $mode = 0, $alreadypaid = -1, $type = -1, $nbofopendirectdebitorcredittransfer = 0)
+	public function LibStatut($paid, $status, $mode = 0, $alreadypaid = -1, $type = -1, $nbofopendirectdebitorcredittransfer = 0)
 	{
 		// phpcs:enable
-		return $this->getInvoiceStatic()->LibStatut($paye, $status, $mode, $alreadypaid, $type, $nbofopendirectdebitorcredittransfer);
+		return $this->getInvoiceStatic()->LibStatut($paid, $status, $mode, $alreadypaid, $type, $nbofopendirectdebitorcredittransfer);
 	}
 }

--- a/htdocs/webportal/class/webportalinvoice.class.php
+++ b/htdocs/webportal/class/webportalinvoice.class.php
@@ -125,10 +125,10 @@ class WebPortalInvoice extends Facture
 	//public $multicurrency_total_tva;
 	//public $multicurrency_total_ttc;
 
-	/**
+	/*
 	 * @var int status
 	 */
-	public $fk_statut;
+	//public $fk_statut; // Managed in parent
 	// END MODULEBUILDER PROPERTIES
 
 
@@ -311,7 +311,7 @@ class WebPortalInvoice extends Facture
 	 */
 	public function getLabelStatus($mode = 0)
 	{
-		return $this->LibStatut($this->paye, $this->fk_statut, $mode, -1, $this->type);
+		return $this->LibStatut($this->paye, $this->status, $mode, -1, $this->type);
 	}
 
 	/**
@@ -323,7 +323,7 @@ class WebPortalInvoice extends Facture
 	 */
 	public function getLibStatut($mode = 0, $alreadypaid = -1)
 	{
-		return $this->LibStatut($this->paye, $this->fk_statut, $mode, $alreadypaid, $this->type);
+		return $this->LibStatut($this->paye, $this->status, $mode, $alreadypaid, $this->type);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/webportal/class/webportalorder.class.php
+++ b/htdocs/webportal/class/webportalorder.class.php
@@ -121,10 +121,10 @@ class WebPortalOrder extends Commande
 	//public $multicurrency_total_tva;
 	//public $multicurrency_total_ttc;
 
-	/**
+	/*
 	 * @var int status
 	 */
-	public $fk_statut;
+	//public $fk_statut; // Managed in parent
 	// END MODULEBUILDER PROPERTIES
 
 
@@ -306,7 +306,7 @@ class WebPortalOrder extends Commande
 	 */
 	public function getLabelStatus($mode = 0)
 	{
-		return $this->LibStatut($this->fk_statut, $this->billed, $mode);
+		return $this->LibStatut($this->status, $this->billed, $mode);
 	}
 
 	/**
@@ -317,7 +317,7 @@ class WebPortalOrder extends Commande
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut($this->fk_statut, $this->billed, $mode);
+		return $this->LibStatut($this->status, $this->billed, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/webportal/class/webportalorder.class.php
+++ b/htdocs/webportal/class/webportalorder.class.php
@@ -120,10 +120,6 @@ class WebPortalOrder extends Commande
 	//public $multicurrency_total_ht;
 	//public $multicurrency_total_tva;
 	//public $multicurrency_total_ttc;
-
-	/*
-	 * @var int status
-	 */
 	//public $fk_statut; // Managed in parent
 	// END MODULEBUILDER PROPERTIES
 

--- a/htdocs/webportal/class/webportalpropal.class.php
+++ b/htdocs/webportal/class/webportalpropal.class.php
@@ -121,10 +121,10 @@ class WebPortalPropal extends Propal
 	//public $multicurrency_total_tva;
 	//public $multicurrency_total_ttc;
 
-	/**
+	/*
 	 * @var int status
 	 */
-	public $fk_statut;
+	//public $fk_statut; // Managed in parent
 	// END MODULEBUILDER PROPERTIES
 
 
@@ -301,7 +301,7 @@ class WebPortalPropal extends Propal
 	 */
 	public function getLabelStatus($mode = 0)
 	{
-		return $this->LibStatut($this->fk_statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	/**
@@ -312,7 +312,7 @@ class WebPortalPropal extends Propal
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut($this->fk_statut, $mode);
+		return $this->LibStatut($this->status, $mode);
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/webportal/class/webportalpropal.class.php
+++ b/htdocs/webportal/class/webportalpropal.class.php
@@ -120,10 +120,6 @@ class WebPortalPropal extends Propal
 	//public $multicurrency_total_ht;
 	//public $multicurrency_total_tva;
 	//public $multicurrency_total_ttc;
-
-	/*
-	 * @var int status
-	 */
 	//public $fk_statut; // Managed in parent
 	// END MODULEBUILDER PROPERTIES
 

--- a/htdocs/workstation/workstation_list.php
+++ b/htdocs/workstation/workstation_list.php
@@ -1,5 +1,4 @@
 <?php
-
 /* Copyright (C) 2007-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2020      Gauthier VERDOL <gauthier.verdol@atm-consulting.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>

--- a/htdocs/zapier/class/api_zapier.class.php
+++ b/htdocs/zapier/class/api_zapier.class.php
@@ -297,10 +297,13 @@ class Zapier extends DolibarrApi
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**
-	 * Clean sensible object datas
+	 * Clean sensitive data from object
 	 *
-	 * @param   Object  $object     Object to clean
-	 * @return  Object              Object with cleaned properties
+	 * @template T of \CommonObject
+	 * @param   T  $object     Object to clean
+	 * @phan-param CommonObject  $object
+	 * @return  T              Object with cleaned properties
+	 * @phan-return CommonObject
 	 */
 	public function _cleanObjectDatas($object)
 	{

--- a/htdocs/zapier/class/api_zapier.class.php
+++ b/htdocs/zapier/class/api_zapier.class.php
@@ -304,6 +304,7 @@ class Zapier extends DolibarrApi
 	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
 	 * @phan-return Object
+	 * @suppress PhanTemplateTypeNotUsedInFunctionReturn
 	 */
 	public function _cleanObjectDatas($object)
 	{

--- a/htdocs/zapier/class/api_zapier.class.php
+++ b/htdocs/zapier/class/api_zapier.class.php
@@ -299,11 +299,11 @@ class Zapier extends DolibarrApi
 	/**
 	 * Clean sensitive data from object
 	 *
-	 * @template T of \CommonObject
+	 * @template T of Object
 	 * @param   T  $object     Object to clean
-	 * @phan-param CommonObject  $object
+	 * @phan-param Object  $object
 	 * @return  T              Object with cleaned properties
-	 * @phan-return CommonObject
+	 * @phan-return Object
 	 */
 	public function _cleanObjectDatas($object)
 	{

--- a/test/phpunit/RestAPIContactTest.php
+++ b/test/phpunit/RestAPIContactTest.php
@@ -70,7 +70,7 @@ class RestAPIContactTest extends AbstractRestAPITest
 		$this->assertEquals($result['curl_error_no'], '');
 		$object = json_decode($result['content'], true);
 		$this->assertNotNull($object, "Parsing of json result must not be null");
-		$this->assertEquals(1, $object['statut']);
+		$this->assertEquals(1, $object['statut'] ?? $object['status']);
 	}
 
 	/**

--- a/test/phpunit/RestAPIUserTest.php
+++ b/test/phpunit/RestAPIUserTest.php
@@ -71,7 +71,7 @@ class RestAPIUserTest extends AbstractRestAPITest
 		$this->assertEquals('', $result['curl_error_no'], "$test should have no error");
 		$object = json_decode($result['content'], true);
 		$this->assertNotNull($object, "$test Parsing of JSON result must not be null");
-		$this->assertEquals(1, $object['statut']);
+		$this->assertEquals(1, $object['statut'] ?? $object['status']);
 
 		return $object['id'];
 	}


### PR DESCRIPTION
# QUAL: (breaking)  Stop using deprecated $statut, $fk_statut

This change is a breaking change because 'statut' is replaced with 'status' in the API replies.

Remove/replace usages of $statut and $fk_status properties.
Update the DolDeprecationHandler configuration (extra definition in classes that introduced fk_statut).

(Assignments to the deprecated identifiers are no longer needed as the DeprecatonHandler will access the new attribute when the deprecated name is accessed.


> This change is a breaking change because 'statut' is replaced with 'status' in the API replies.

@eldy Do you want to maintain 'statut' in the replies alongside 'status' or make this a hard change with the APIs.