### PR TITLE
Fix Tests for compatibility with deprecations

### DIFF
--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2020		Frédéric France		<frederic.france@netlogic.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -107,16 +108,41 @@ class DolibarrApi
 	 */
 	protected function _filterObjectProperties($object, $properties)
 	{
+		// phpcs:enable
 		// If properties is empty, we return all properties
 		if (empty($properties)) {
 			return $object;
 		}
-		// Else we filter properties
+
+		// Copy of exploded array for efficiency
+		$arr_properties = explode(',', $properties);
+		$magic_properties = array();
+		$real_properties = get_object_vars($object);
+
+		// Unsetting real properties may unset magic properties.
+		// We keep a copy of the requested magic properties
+		foreach ($arr_properties as $key) {
+			if (!array_key_exists($key, $real_properties)) {
+				// Not a real property,
+				// check if $key is a magic property (we want to keep '$obj->$key')
+				if (property_exists($object, $key) && isset($object->$key)) {
+					$magic_properties[$key] = $object->$key;
+				}
+			}
+		}
+
+		// Filter real properties (may indirectly unset magic properties)
 		foreach (get_object_vars($object) as $key => $value) {
-			if (!in_array($key, explode(',', $properties))) {
+			if (!in_array($key, $arr_properties)) {
 				unset($object->$key);
 			}
 		}
+
+		// Restore the magic properties
+		foreach ($magic_properties as $key => $value) {
+			$object->$key = $value;
+		}
+
 		return $object;
 	}
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1368,6 +1368,41 @@ function dol_buildpath($path, $type = 0, $returnemptyifnotfound = 0)
 }
 
 /**
+ *	Get properties for an object - including magic properties when requested
+ *
+ *	Only returns properties that exist
+ *
+ *	@param	object		$obj		Object to get properties from
+ *	@param	string[]	$properties	Optional list of properties to get.
+ *  								When empty, only gets public properties.
+ *	@return array<string,mixed>		Hash for retrieved values (key=name)
+ */
+function dol_get_object_properties($obj, $properties = [])
+{
+	// Get real properties using get_object_vars() if $properties is empty
+	if (empty($properties)) {
+		return get_object_vars($obj);
+	}
+
+	$existingProperties = [];
+	$realProperties = get_object_vars($obj);
+
+	// Get the real or magic property values
+	foreach ($properties as $property) {
+		if (array_key_exists($property, $realProperties)) {
+			// Real property, add the value
+			$existingProperties[$property] = $obj->{$property};
+		} elseif (property_exists($obj, $property)) {
+			// Magic property
+			$existingProperties[$property] = $obj->{$property};
+		}
+	}
+
+	return $existingProperties;
+}
+
+
+/**
  *	Create a clone of instance of object (new instance with same value for each properties)
  *  With native = 0: Property that are reference are different memory area in the new object (full isolation clone). This means $this->db of new object may not be valid.
  *  With native = 1: Use PHP clone. Property that are reference are same pointer. This means $this->db of new object is still valid but point to same this->db than original object.

--- a/test/phpunit/FactureRecTest.php
+++ b/test/phpunit/FactureRecTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2013 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -116,39 +117,5 @@ class FactureRecTest extends CommonClassTest
 	{
 		$localobject->note_private = 'New note';
 		//$localobject->note='New note after update';
-	}
-
-	/**
-	 * Compare all public properties values of 2 objects
-	 *
-	 * @param 	Object		$oA						Object operand 1
-	 * @param 	Object		$oB						Object operand 2
-	 * @param	boolean		$ignoretype				False will not report diff if type of value differs
-	 * @param	array		$fieldstoignorearray	Array of fields to ignore in diff
-	 * @return	array								Array with differences
-	 */
-	public function objCompare($oA, $oB, $ignoretype = true, $fieldstoignorearray = array('id'))
-	{
-		$retAr = array();
-
-		if (get_class($oA) !== get_class($oB)) {
-			$retAr[] = "Supplied objects are not of same class.";
-		} else {
-			$oVarsA = get_object_vars($oA);
-			$oVarsB = get_object_vars($oB);
-			$aKeys = array_keys($oVarsA);
-			foreach ($aKeys as $sKey) {
-				if (in_array($sKey, $fieldstoignorearray)) {
-					continue;
-				}
-				if (! $ignoretype && ($oVarsA[$sKey] !== $oVarsB[$sKey])) {
-					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
-				}
-				if ($ignoretype && ($oVarsA[$sKey] != $oVarsB[$sKey])) {
-					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
-				}
-			}
-		}
-		return $retAr;
 	}
 }

--- a/test/phpunit/FactureTest.php
+++ b/test/phpunit/FactureTest.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2010 Laurent Destailleur   <eldy@users.sourceforge.net>
  * Copyright (C) 2018 Frédéric France       <frederic.france@netlogic.fr>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -155,7 +156,7 @@ class FactureTest extends CommonClassTest
 
 		$this->assertLessThan($result, 0);
 
-		// Test everything are still same than specimen
+		// Test everything is still the same as specimen
 		$newlocalobject = new Facture($db);
 		$newlocalobject->initAsSpecimen();
 		$this->changeProperties($newlocalobject);
@@ -168,6 +169,7 @@ class FactureTest extends CommonClassTest
 			$localobject,
 			$newlocalobject,
 			true,
+			// Not comparing:
 			array(
 				'newref','oldref','id','lines','client','thirdparty','brouillon','user_creation_id','date_creation','date_validation','datem','date_modification',
 				'ref','statut','status','paye','specimen','ref','actiontypecode','actionmsg2','actionmsg','mode_reglement','cond_reglement',
@@ -280,39 +282,5 @@ class FactureTest extends CommonClassTest
 	{
 		$localobject->note_private = 'New note';
 		//$localobject->note='New note after update';
-	}
-
-	/**
-	 * Compare all public properties values of 2 objects
-	 *
-	 * @param   Object $oA                      Object operand 1
-	 * @param   Object $oB                      Object operand 2
-	 * @param   boolean $ignoretype             False will not report diff if type of value differs
-	 * @param   array $fieldstoignorearray      Array of fields to ignore in diff
-	 * @return  array                           Array with differences
-	 */
-	public function objCompare($oA, $oB, $ignoretype = true, $fieldstoignorearray = array('id'))
-	{
-		$retAr = array();
-
-		if (get_class($oA) !== get_class($oB)) {
-			$retAr[] = "Supplied objects are not of same class.";
-		} else {
-			$oVarsA = get_object_vars($oA);
-			$oVarsB = get_object_vars($oB);
-			$aKeys = array_keys($oVarsA);
-			foreach ($aKeys as $sKey) {
-				if (in_array($sKey, $fieldstoignorearray)) {
-					continue;
-				}
-				if (! $ignoretype && ($oVarsA[$sKey] !== $oVarsB[$sKey])) {
-					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
-				}
-				if ($ignoretype && ($oVarsA[$sKey] != $oVarsB[$sKey])) {
-					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
-				}
-			}
-		}
-		return $retAr;
 	}
 }

--- a/test/phpunit/InventoryTest.php
+++ b/test/phpunit/InventoryTest.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2010 Laurent Destailleur   <eldy@users.sourceforge.net>
  * Copyright (C) 2018 Frédéric France       <frederic.france@netlogic.fr>
  * Copyright (C) 2023 Alexandre Janniaux    <alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -266,39 +267,5 @@ class InventoryTest extends CommonClassTest
 		$this->assertLessThan($result, 0);
 
 		return $result;
-	}
-
-	/**
-	 * Compare all public properties values of 2 objects
-	 *
-	 * @param   Object $oA                      Object operand 1
-	 * @param   Object $oB                      Object operand 2
-	 * @param   boolean $ignoretype             False will not report diff if type of value differs
-	 * @param   array $fieldstoignorearray      Array of fields to ignore in diff
-	 * @return  array                           Array with differences
-	 */
-	public function objCompare($oA, $oB, $ignoretype = true, $fieldstoignorearray = array('id'))
-	{
-		$retAr = array();
-
-		if (get_class($oA) !== get_class($oB)) {
-			$retAr[] = "Supplied objects are not of same class.";
-		} else {
-			$oVarsA = get_object_vars($oA);
-			$oVarsB = get_object_vars($oB);
-			$aKeys = array_keys($oVarsA);
-			foreach ($aKeys as $sKey) {
-				if (in_array($sKey, $fieldstoignorearray)) {
-					continue;
-				}
-				if (! $ignoretype && ($oVarsA[$sKey] !== $oVarsB[$sKey])) {
-					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
-				}
-				if ($ignoretype && ($oVarsA[$sKey] != $oVarsB[$sKey])) {
-					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
-				}
-			}
-		}
-		return $retAr;
 	}
 }

--- a/test/phpunit/UserTest.php
+++ b/test/phpunit/UserTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010-2015 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -402,39 +403,5 @@ class UserTest extends CommonClassTest
 	public function changeProperties(&$localobject)
 	{
 		$localobject->note_private = 'New note after update';
-	}
-
-	/**
-	 * Compare all public properties values of 2 objects
-	 *
-	 * @param   Object      $oA                     Object operand 1
-	 * @param   Object      $oB                     Object operand 2
-	 * @param   boolean     $ignoretype             False will not report diff if type of value differs
-	 * @param   array       $fieldstoignorearray    Array of fields to ignore in diff
-	 * @return  array                               Array with differences
-	 */
-	public function objCompare($oA, $oB, $ignoretype = true, $fieldstoignorearray = array('id'))
-	{
-		$retAr = array();
-
-		if (get_class($oA) !== get_class($oB)) {
-			$retAr[] = "Supplied objects are not of same class.";
-		} else {
-			$oVarsA = get_object_vars($oA);
-			$oVarsB = get_object_vars($oB);
-			$aKeys = array_keys($oVarsA);
-			foreach ($aKeys as $sKey) {
-				if (in_array($sKey, $fieldstoignorearray)) {
-					continue;
-				}
-				if (! $ignoretype && ($oVarsA[$sKey] !== $oVarsB[$sKey])) {
-					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
-				}
-				if ($ignoretype && ($oVarsA[$sKey] != $oVarsB[$sKey])) {
-					$retAr[] = $sKey.' : '.(is_object($oVarsA[$sKey]) ? get_class($oVarsA[$sKey]) : $oVarsA[$sKey]).' <> '.(is_object($oVarsB[$sKey]) ? get_class($oVarsB[$sKey]) : $oVarsB[$sKey]);
-				}
-			}
-		}
-		return $retAr;
 	}
 }


### PR DESCRIPTION
# Fix Tests for compatibility with deprecations

After simplifying the code using the DolDeprecationHandler features, some tests failed.

The reason is that they exclude deprecated property names from comparisons, but not the new property names.

`objCompare` was updated and refactored so that it uses the `deprecatedProperties` information to update the exclusion list.  That way the tests can still use the old property names which is good for testing backward compatibility.

## Refactor objCompare:

- Move to CommonClassTest;
- Report class name for mismatched property;
- Cope with dolDeprecated property aliases (test may exclude deprecated name, also exclude new name).

## New: dol_get_object_properties to get real and magic props

This method will get an array with real and magic properties from an object (if $properties is provided).
I expected to need this in the tests.  While it is not needed and the method is created, I suggest to leave it as it can be used to get selected properties from an object into an array.

## Cope with magic and real properties aliases in _filterObjectProperties

While looking on the code for the use of get_object_vars, I noticed that the _filterObjectProperties could unset properties by mistake - for instance the arguments suggets to keep 'statut' which is a magic property.  That would unset 'status' which implies that 'statut' is also unset.
A method was added to be sure to restore the values of magic properties that should be kept.

At the same time the method was slightly optimised by not exploding the properties string each time.

These updates are needed for #29145 .

