### PR TITLE
allow updating a single Complementary Attribute 

### DIFF
--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -697,7 +697,12 @@ class Proposals extends DolibarrApi
 				$this->propal->context['caller'] = $request_data['caller'];
 				continue;
 			}
-
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->propal->array_options[$index] = $val;
+				}
+				continue;
+			}
 			$this->propal->$field = $value;
 		}
 


### PR DESCRIPTION
NEW: Allow API change a proposals single Complementary Attribute 
Previously to update a single Complementary Attribute for a proposal through the API one would have to include the full list of all complementary attributes in the `array_options` segment of the json, but with this change it is possible to only include the single attribute one wants to change.