### PR TITLE
allow updating orders single Complementary Attribute

### DIFF
--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -652,7 +652,12 @@ class Orders extends DolibarrApi
 				$this->commande->context['caller'] = $request_data['caller'];
 				continue;
 			}
-
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->commande->array_options[$index] = $val;
+				}
+				continue;
+			}
 			$this->commande->$field = $value;
 		}
 


### PR DESCRIPTION
NEW: Allow API change a orders single Complementary Attribute
Previously to update a single Complementary Attribute for an order through the API one would have to include the full list of all complementary attributes in the array_options segment of the json, but with this change it is possible to only include the single attribute one wants to change.