### PR TITLE
allow updating invoice single Complementary Attribute

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -671,7 +671,12 @@ class Invoices extends DolibarrApi
 				$this->invoice->context['caller'] = $request_data['caller'];
 				continue;
 			}
-
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->invoice->array_options[$index] = $val;
+				}
+				continue;
+			}
 			$this->invoice->$field = $value;
 
 			// If cond reglement => update date lim reglement


### PR DESCRIPTION
NEW: Allow API change a invoice single Complementary Attribute
Previously to update a single Complementary Attribute for an invoice through the API one would have to include the full list of all complementary attributes in the array_options segment of the json, but with this change it is possible to only include those attributes one wants to change.