### PR TITLE
allow updating members single Complementary Attribute

### DIFF
--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -349,7 +349,12 @@ class Members extends DolibarrApi
 				$member->context['caller'] = $request_data['caller'];
 				continue;
 			}
-
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$member->array_options[$index] = $val;
+				}
+				continue;
+			}
 			// Process the status separately because it must be updated using
 			// the validate(), resiliate() and exclude() methods of the class Adherent.
 			if ($field == 'statut') {


### PR DESCRIPTION
NEW: Allow API change a members single Complementary Attribute
Previously to update a single Complementary Attribute for a member through the API one would have to include the full list of all complementary attributes in the array_options segment of the json, but with this change it is possible to only include the single attribute one wants to change.