### PR TITLE
NEW: API GET projects by REF and by email_msgid

### DIFF
--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -77,7 +77,7 @@ class Projects extends DolibarrApi
 
 		$result = $this->project->fetch($id);
 		if (!$result) {
-			throw new RestException(404, 'Project not found');
+			throw new RestException(404, 'Project with supplied id not found');
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('project', $this->project->id)) {
@@ -88,7 +88,67 @@ class Projects extends DolibarrApi
 		return $this->_cleanObjectDatas($this->project);
 	}
 
+	/**
+	 * Get properties of a project object
+	 *
+	 * Return an array with project information
+	 *
+	 * @param	string	$ref			Ref of project
+	 * @return  Object					Object with cleaned properties
+	 *
+	 * @url GET ref/{ref}
+	 *
+	 * @throws	RestException
+	 */
+	public function getByRef($ref)
+	{
+		if (!DolibarrApiAccess::$user->hasRight('projet', 'lire')) {
+			throw new RestException(403);
+		}
 
+		$result = $this->project->fetch('',$ref);
+		if (!$result) {
+			throw new RestException(404, 'Project with supplied ref not found');
+		}
+
+		if (!DolibarrApi::_checkAccessToResource('project', $this->project->id)) {
+			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+		}
+
+		$this->project->fetchObjectLinked();
+		return $this->_cleanObjectDatas($this->project);
+	}
+
+	/**
+	 * Get properties of a project object
+	 *
+	 * Return an array with project information
+	 *
+	 * @param	string	$email_msgid	Email msgid of project
+	 * @return  Object					Object with cleaned properties
+	 *
+	 * @url GET email_msgid/{email_msgid}
+	 *
+	 * @throws	RestException
+	 */
+	public function getByMsgId($email_msgid)
+	{
+		if (!DolibarrApiAccess::$user->hasRight('projet', 'lire')) {
+			throw new RestException(403);
+		}
+
+		$result = $this->project->fetch('','','',$email_msgid);
+		if (!$result) {
+			throw new RestException(404, 'Project with supplied email_msgid not found');
+		}
+
+		if (!DolibarrApi::_checkAccessToResource('project', $this->project->id)) {
+			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+		}
+
+		$this->project->fetchObjectLinked();
+		return $this->_cleanObjectDatas($this->project);
+	}
 
 	/**
 	 * List projects

--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -106,7 +106,7 @@ class Projects extends DolibarrApi
 			throw new RestException(403);
 		}
 
-		$result = $this->project->fetch('',$ref);
+		$result = $this->project->fetch('', $ref);
 		if (!$result) {
 			throw new RestException(404, 'Project with supplied ref not found');
 		}
@@ -137,7 +137,7 @@ class Projects extends DolibarrApi
 			throw new RestException(403);
 		}
 
-		$result = $this->project->fetch('','','',$email_msgid);
+		$result = $this->project->fetch('', '', '', $email_msgid);
 		if (!$result) {
 			throw new RestException(404, 'Project with supplied email_msgid not found');
 		}


### PR DESCRIPTION
NEW: API GET projects by REF and by email_msgid
The API for Projects only had the possibility of using GET by id, but I needed REF for my own usage. I also created get by email_msgid because that seems to exist in the llx_projet table and in the fetch function for projects.

The fetch function for projects also listed an ext_ref which I initially also created an API GET for - but using it never failed when projects did not exist. Possibly because llx_projet table does not contain any ext_ref column. Removal of ext_ref will be supplied in a different pull request.