### PR TITLE
Fix fatal (PHP8.X) type issue with abs, and amend dol_eval return type

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8300,7 +8300,12 @@ abstract class CommonObject
 			$value = '<span class="opacitymedium">'.$langs->trans("Encrypted").'</span>';
 			//$value = preg_replace('/./i', '*', $value);
 		} elseif ($type == 'array') {
-			$value = implode('<br>', $value);
+			if (is_array($value)) {
+				$value = implode('<br>', $value);
+			} else {
+				dol_syslog(__METHOD__.' Expected array from dol_eval, but got '.gettype($value), LOG_ERR);
+				return 'Error unexpected result from code evaluation';
+			}
 		} else {	// text|html|varchar
 			$value = dol_htmlentitiesbr($value);
 		}

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9925,7 +9925,7 @@ function verifCond($strToEvaluate, $onlysimplestring = '1')
  * @param	string	$onlysimplestring	'0' (deprecated, do not use it anymore)=Accept all chars,
  * 										'1' (most common use)=Accept only simple string with char 'a-z0-9\s^$_+-.*>&|=!?():"\',/@';',
  * 										'2' (used for example for the compute property of extrafields)=Accept also '[]'
- * @return	mixed						Nothing or return result of eval
+ * @return	void|string					Nothing or return result of eval (even if type can be int, it is safer to assume string and find all potential typing issues as abs(dol_eval(...)).
  * @see verifCond()
  * @phan-suppress PhanPluginUnsafeEval
  */

--- a/htdocs/projet/list.php
+++ b/htdocs/projet/list.php
@@ -226,7 +226,7 @@ $arrayfields = array();
 foreach ($object->fields as $key => $val) {
 	// If $val['visible']==0, then we never show the field
 	if (!empty($val['visible'])) {
-		$visible = dol_eval($val['visible'], 1, 1, '1');
+		$visible = (int) dol_eval($val['visible'], 1, 1, '1');
 		$arrayfields['p.'.$key] = array(
 			'label' => $val['label'],
 			'checked' => (($visible < 0) ? 0 : 1),


### PR DESCRIPTION
# Fix fatal (PHP8.X) type issue with abs, and amend dol_eval return type

I got the following message:
`Fatal error: Uncaught TypeError: abs(): Argument #1 ($num) must be of type int|float, string given in D:\mdeweerd\workspace\dolibarr\htdocs\projet\list.php on line 233`

I examined the phan report and there was no mention of this because dol_eval was said to return mixed.

In order to detect such cases, I amended the dol_eval return type to ensure to find most of the locations where a cast is needed.

This resulted in the detection of a possible exception in showOutputField  Which already lead to the protection of the outcome of dol_eval in showOutputField when it's expected to be an array.