### PR TITLE
FIX: categories protection limit

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -1159,7 +1159,8 @@ class Categorie extends CommonObject
 		}
 
 		$this->cats = array();
-
+		$nbcateg = 0;
+		
 		// Init this->motherof that is array(id_son=>id_parent, ...)
 		$this->load_motherof();
 		$current_lang = $langs->getDefaultLang();
@@ -1203,7 +1204,7 @@ class Categorie extends CommonObject
 		dol_syslog(get_class($this)."::get_full_arbo call to buildPathFromId", LOG_DEBUG);
 		foreach ($this->cats as $key => $val) {
 			//print 'key='.$key.'<br>'."\n";
-			$this->buildPathFromId($key, (!empty($nbcateg) ? $nbcateg : 0)); // Process a branch from the root category key (this category has no parent)
+			$this->buildPathFromId($key, $nbcateg); // Process a branch from the root category key (this category has no parent)
 		}
 
 		// Include or exclude leaf including $markafterid from tree

--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -11,7 +11,7 @@
  * Copyright (C) 2015       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2016       Charlie Benke           <charlie@patas-monkey.com>
  * Copyright (C) 2018-2023  Frédéric France         <frederic.france@netlogic.fr>
- * Copyright (C) 2023		Benjamin Falière		<benjamin.faliere@altairis.fr>
+ * Copyright (C) 2023-2024	Benjamin Falière		<benjamin.faliere@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1180,6 +1180,8 @@ class Categorie extends CommonObject
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$i = 0;
+			$nbcateg = $this->db->num_rows($resql);
+
 			while ($obj = $this->db->fetch_object($resql)) {
 				$this->cats[$obj->rowid]['rowid'] = $obj->rowid;
 				$this->cats[$obj->rowid]['id'] = $obj->rowid;
@@ -1201,7 +1203,7 @@ class Categorie extends CommonObject
 		dol_syslog(get_class($this)."::get_full_arbo call to buildPathFromId", LOG_DEBUG);
 		foreach ($this->cats as $key => $val) {
 			//print 'key='.$key.'<br>'."\n";
-			$this->buildPathFromId($key, 0); // Process a branch from the root category key (this category has no parent)
+			$this->buildPathFromId($key, (!empty($nbcateg) ? $nbcateg : 0)); // Process a branch from the root category key (this category has no parent)
 		}
 
 		// Include or exclude leaf including $markafterid from tree

--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -1160,7 +1160,7 @@ class Categorie extends CommonObject
 
 		$this->cats = array();
 		$nbcateg = 0;
-		
+
 		// Init this->motherof that is array(id_son=>id_parent, ...)
 		$this->load_motherof();
 		$current_lang = $langs->getDefaultLang();


### PR DESCRIPTION
Currently, when we list existing categories, it's limited to 1000 categories by default.

In some specific cases, we can encounter more categories, which generates an error.

Another way to keep protection but to allow more than 1000 categories is to count the number of categories and use it as a parameter for `buildPathFromId()`.