### PR TITLE
17.0 fix translation pdf extrafields

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1294,7 +1294,7 @@ abstract class CommonDocGenerator
 		$extrafields = $this->extrafieldsCache;
 
 		$extrafieldOutputContent = '';
-		if (isset($object->array_options[$extrafieldOptionsKey])) $extrafieldOutputContent = $extrafields->showOutputField($extrafieldKey, $object->array_options[$extrafieldOptionsKey], '', $object->table_element);
+		if (isset($object->array_options[$extrafieldOptionsKey])) $extrafieldOutputContent = $extrafields->showOutputField($extrafieldKey, $object->array_options[$extrafieldOptionsKey], '', $object->table_element, $outputlangs);
 
 		// TODO : allow showOutputField to be pdf public friendly, ex: in a link to object, clean getNomUrl to remove link and images... like a getName methode ...
 		if ($extrafields->attributes[$object->table_element]['type'][$extrafieldKey] == 'link') {

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1727,11 +1727,12 @@ class ExtraFields
 							$translabel = '';
 							if (!empty($obj->$field_toshow)) {
 								$translabel = $outputlangs->trans($obj->$field_toshow);
-							}
-							if ($translabel != $obj->$field_toshow) {
-								$value .= dol_trunc($translabel, 24).' ';
-							} else {
-								$value .= $obj->$field_toshow.' ';
+
+								if ($translabel != $obj->$field_toshow) {
+									$value .= dol_trunc($translabel, 24) . ' ';
+								} else {
+									$value .= $obj->$field_toshow . ' ';
+								}
 							}
 						}
 					} else {

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1575,11 +1575,16 @@ class ExtraFields
 	 * @param   string	$value          		Value to show
 	 * @param	string	$moreparam				To add more parameters on html input tag (only checkbox use html input for output rendering)
 	 * @param	string	$extrafieldsobjectkey	Required (for example $object->table_element).
+	 * @param 	Translate $outputlangs 			Output language
 	 * @return	string							Formated value
 	 */
-	public function showOutputField($key, $value, $moreparam = '', $extrafieldsobjectkey = '')
+	public function showOutputField($key, $value, $moreparam = '', $extrafieldsobjectkey = '', $outputlangs = null)
 	{
 		global $conf, $langs;
+
+		if (is_null($outputlangs) || !is_object($outputlangs)) {
+			$outputlangs = $langs;
+		}
 
 		if (empty($extrafieldsobjectkey)) {
 			dol_syslog(get_class($this).'::showOutputField extrafieldsobjectkey required', LOG_ERR);
@@ -1624,7 +1629,7 @@ class ExtraFields
 				//$value=price($value);
 				$sizeparts = explode(",", $size);
 				$number_decimals = array_key_exists(1, $sizeparts) ? $sizeparts[1] : 0;
-				$value = price($value, 0, $langs, 0, 0, $number_decimals, '');
+				$value = price($value, 0, $outputlangs, 0, 0, $number_decimals, '');
 			}
 		} elseif ($type == 'boolean') {
 			$checked = '';
@@ -1643,7 +1648,7 @@ class ExtraFields
 		} elseif ($type == 'price') {
 			//$value = price($value, 0, $langs, 0, 0, -1, $conf->currency);
 			if ($value || $value == '0') {
-				$value = price($value, 0, $langs, 0, $conf->global->MAIN_MAX_DECIMALS_TOT, -1).' '.$langs->getCurrencySymbol($conf->currency);
+				$value = price($value, 0, $outputlangs, 0, $conf->global->MAIN_MAX_DECIMALS_TOT, -1).' '.$outputlangs->getCurrencySymbol($conf->currency);
 			}
 		} elseif ($type == 'pricecy') {
 			$currency = $conf->currency;
@@ -1654,7 +1659,7 @@ class ExtraFields
 				$value = $pricetmp[0];
 			}
 			if ($value || $value == '0') {
-				$value = price($value, 0, $langs, 0, $conf->global->MAIN_MAX_DECIMALS_TOT, -1, $currency);
+				$value = price($value, 0, $outputlangs, 0, $conf->global->MAIN_MAX_DECIMALS_TOT, -1, $currency);
 			}
 		} elseif ($type == 'select') {
 			$valstr = (!empty($param['options'][$value]) ? $param['options'][$value] : '');
@@ -1662,7 +1667,7 @@ class ExtraFields
 				$valstr = substr($valstr, 0, $pos);
 			}
 			if ($langfile && $valstr) {
-				$value = $langs->trans($valstr);
+				$value = $outputlangs->trans($valstr);
 			} else {
 				$value = $valstr;
 			}
@@ -1721,13 +1726,12 @@ class ExtraFields
 						foreach ($fields_label as $field_toshow) {
 							$translabel = '';
 							if (!empty($obj->$field_toshow)) {
-								$translabel = $langs->trans($obj->$field_toshow);
-
-								if ($translabel != $obj->$field_toshow) {
-									$value .= dol_trunc($translabel, 24).' ';
-								} else {
-									$value .= $obj->$field_toshow.' ';
-								}
+								$translabel = $outputlangs->trans($obj->$field_toshow);
+							}
+							if ($translabel != $obj->$field_toshow) {
+								$value .= dol_trunc($translabel, 24).' ';
+							} else {
+								$value .= $obj->$field_toshow.' ';
 							}
 						}
 					} else {
@@ -1735,7 +1739,7 @@ class ExtraFields
 						$tmppropname = $InfoFieldList[1];
 						//$obj->$tmppropname = '';
 						if (!empty(isset($obj->$tmppropname) ? $obj->$tmppropname : '')) {
-							$translabel = $langs->trans($obj->$tmppropname);
+							$translabel = $outputlangs->trans($obj->$tmppropname);
 						}
 						if ($translabel != (isset($obj->$tmppropname) ? $obj->$tmppropname : '')) {
 							$value = dol_trunc($translabel, 18);
@@ -1764,10 +1768,10 @@ class ExtraFields
 			}
 		} elseif ($type == 'radio') {
 			if (!isset($param['options'][$value])) {
-				$langs->load('errors');
-				$value = $langs->trans('ErrorNoValueForRadioType');
+				$outputlangs->load('errors');
+				$value = $outputlangs->trans('ErrorNoValueForRadioType');
 			} else {
-				$value = $langs->trans($param['options'][$value]);
+				$value = $outputlangs->trans($param['options'][$value]);
 			}
 		} elseif ($type == 'checkbox') {
 			$value_arr = explode(',', $value);
@@ -1831,7 +1835,7 @@ class ExtraFields
 								foreach ($fields_label as $field_toshow) {
 									$translabel = '';
 									if (!empty($obj->$field_toshow)) {
-										$translabel = $langs->trans($obj->$field_toshow);
+										$translabel = $outputlangs->trans($obj->$field_toshow);
 									}
 									if ($translabel != $field_toshow) {
 										$label .= ' '.dol_trunc($translabel, 18);
@@ -1844,7 +1848,7 @@ class ExtraFields
 							} else {
 								$translabel = '';
 								if (!empty($obj->{$InfoFieldList[1]})) {
-									$translabel = $langs->trans($obj->{$InfoFieldList[1]});
+									$translabel = $outputlangs->trans($obj->{$InfoFieldList[1]});
 								}
 								if ($translabel != $obj->{$InfoFieldList[1]}) {
 									$toprint[] = '<li class="select2-search-choice-dolibarr noborderoncategories" style="background: #bbb">'.dol_trunc($translabel, 18).'</li>';


### PR DESCRIPTION
# FIX|Fix #

Value of extrafield in PDF doesn't manage several langs because showOutPutFields() and  getExtrafieldContent() are used. 
getExtrafieldContent() and showOutPutField()  don't manage $outpulangs

