### PR TITLE
Reintroduce Conf/DeprecationHandler

### DIFF
--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -37,8 +37,8 @@ class Conf extends stdClass
 {
 	use DolDeprecationHandler;
 	/**
-	 * When true, indicates to the DeprecationHandler that this
-	 * class supports dynamic properties.
+	 * @var bool When true, indicates to the DeprecationHandler that this
+	 *           class supports dynamic properties.
 	 */
 	protected $enableDynamicProperties = true;
 
@@ -1219,14 +1219,14 @@ class Conf extends stdClass
 				$this->projet->task = new stdClass();
 				$this->projet->task->warning_delay = (getDolGlobalInt('MAIN_DELAY_TASKS_TODO', 7) * 86400);
 			}
-			if (isset($this->commande)) {
-				$this->warning_delays['order'] = getDolGlobalInt('MAIN_DELAY_ORDERS_TO_PROCESS', 2) * 86400;
-				$this->warning_delays['purchase_order'] = getDolGlobalInt('MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS', 7) * 86400;
-				$this->order->client = new stdClass();
-				$this->order->fournisseur = new stdClass();
-				$this->order->client->warning_delay = getDolGlobalInt('MAIN_DELAY_ORDERS_TO_PROCESS', 2) * 86400;
-				$this->order->fournisseur->warning_delay = getDolGlobalInt('MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS', 7) * 86400;
-			}
+			// if (isset($this->order)) {  // Always set through constructor
+			$this->warning_delays['order'] = getDolGlobalInt('MAIN_DELAY_ORDERS_TO_PROCESS', 2) * 86400;
+			$this->warning_delays['purchase_order'] = getDolGlobalInt('MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS', 7) * 86400;
+			$this->order->client = new stdClass();
+			$this->order->fournisseur = new stdClass();
+			$this->order->client->warning_delay = getDolGlobalInt('MAIN_DELAY_ORDERS_TO_PROCESS', 2) * 86400;
+			$this->order->fournisseur->warning_delay = getDolGlobalInt('MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS', 7) * 86400;
+			//}
 			if (isset($this->propal)) {
 				$this->warning_delays['proposal_close'] = getDolGlobalInt('MAIN_DELAY_PROPALS_TO_CLOSE') * 86400;
 				$this->warning_delays['proposal_invoice'] = getDolGlobalInt('MAIN_DELAY_PROPALS_TO_BILL') * 86400;
@@ -1245,7 +1245,6 @@ class Conf extends stdClass
 				$this->supplier_proposal->facturation->warning_delay = getDolGlobalInt('MAIN_DELAY_SUPPLIER_PROPALS_TO_BILL') * 86400;
 			}
 			if (isset($this->facture)) {
-<<<<<<< HEAD
 				$this->warning_delays['invoice'] = getDolGlobalInt('MAIN_DELAY_CUSTOMER_BILLS_UNPAYED') * 86400;
 				$this->warning_delays['supplier_invoice'] = getDolGlobalInt('MAIN_DELAY_SUPPLIER_BILLS_TO_PAY') * 86400;
 				$this->invoice->client = new stdClass();
@@ -1253,15 +1252,13 @@ class Conf extends stdClass
 				$this->invoice->client->warning_delay = getDolGlobalInt('MAIN_DELAY_CUSTOMER_BILLS_UNPAYED') * 86400;
 				$this->invoice->fournisseur->warning_delay = getDolGlobalInt('MAIN_DELAY_SUPPLIER_BILLS_TO_PAY') * 86400;
 			}
-			if (isset($this->contrat)) {
-				$this->warning_delays['contract_inactive'] = getDolGlobalInt('MAIN_DELAY_NOT_ACTIVATED_SERVICES') * 86400;
-				$this->warning_delays['contract_expired'] = getDolGlobalInt('MAIN_DELAY_RUNNING_SERVICES') * 86400;
-				$this->contract->services = new stdClass();
-				$this->contract->services->inactifs = new stdClass();
-				$this->contract->services->expires = new stdClass();
-				$this->contract->services->inactifs->warning_delay = getDolGlobalInt('MAIN_DELAY_NOT_ACTIVATED_SERVICES') * 86400;
-				$this->contract->services->expires->warning_delay = getDolGlobalInt('MAIN_DELAY_RUNNING_SERVICES') * 86400;
-			}
+			$this->warning_delays['contract_inactive'] = getDolGlobalInt('MAIN_DELAY_NOT_ACTIVATED_SERVICES') * 86400;
+			$this->warning_delays['contract_expired'] = getDolGlobalInt('MAIN_DELAY_RUNNING_SERVICES') * 86400;
+			$this->contract->services = new stdClass();
+			$this->contract->services->inactifs = new stdClass();
+			$this->contract->services->expires = new stdClass();
+			$this->contract->services->inactifs->warning_delay = getDolGlobalInt('MAIN_DELAY_NOT_ACTIVATED_SERVICES') * 86400;
+			$this->contract->services->expires->warning_delay = getDolGlobalInt('MAIN_DELAY_RUNNING_SERVICES') * 86400;
 
 			$this->warning_delays['bank_cheque_to_conciliate'] = getDolGlobalInt('MAIN_DELAY_TRANSACTIONS_TO_CONCILIATE') * 86400;
 			$this->warning_delays['bank_cheque_to_be_deposited'] = getDolGlobalInt('MAIN_DELAY_CHEQUES_TO_DEPOSIT') * 86400;
@@ -1271,7 +1268,6 @@ class Conf extends stdClass
 			$this->bank->cheque	= new stdClass();
 			$this->bank->rappro->warning_delay = getDolGlobalInt('MAIN_DELAY_TRANSACTIONS_TO_CONCILIATE') * 86400;
 			$this->bank->cheque->warning_delay = getDolGlobalInt('MAIN_DELAY_CHEQUES_TO_DEPOSIT') * 86400;
-
 			if (isset($this->expensereport)) {
 				$this->warning_delays['expensereport_approve'] = getDolGlobalInt('MAIN_DELAY_EXPENSEREPORTS') * 86400;
 				$this->warning_delays['expense_report_payment'] = getDolGlobalInt('MIN_DELAY_EXPENSEREPORTS_TO_PAY') * 86400;

--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -32,7 +32,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/doldeprecationhandler.class.php';
 
 /**
  *  Class to stock current configuration
- *
  */
 class Conf extends stdClass
 {
@@ -251,7 +250,7 @@ class Conf extends stdClass
 	public $fournisseur;
 
 	/**
-	 * @var stdClass
+	 * @var stdClass	Product
 	 */
 	public $product;
 
@@ -282,20 +281,8 @@ class Conf extends stdClass
 
 	/**
 	 * @var stdClass
-	 * @deprecated Use $order
-	 */
-	public $commande;
-
-	/**
-	 * @var stdClass
 	 */
 	public $order;
-
-	/**
-	 * @var stdClass
-	 * @deprecated Use $invoice
-	 */
-	public $facture;
 
 	/**
 	 * @var stdClass
@@ -309,14 +296,9 @@ class Conf extends stdClass
 
 	/**
 	 * @var stdClass
-	 * @deprecated Use $member
-	 */
-	public $adherent;
-
-	/**
-	 * @var stdClass
 	 */
 	public $member;
+
 
 	/**
 	 * @var stdClass
@@ -349,34 +331,6 @@ class Conf extends stdClass
 	public $api;
 
 	/**
-	 * @var stdClass
-	 */
-	public $bank;
-
-	/**
-	 * @var stdClass
-	 */
-	public $notification;
-
-	/**
-	 * @var stdClass
-	 */
-	public $expensereport;
-
-	/**
-	 * @var stdClass
-	 */
-	public $productbatch;
-
-	/**
-	 * @var stdClass
-	 * @deprecated      Use $project
-	 * @see $project
-	 */
-	private $projet;
-
-
-	/**
 	 * @var ?stdClass
 	 */
 	public $project;
@@ -405,34 +359,6 @@ class Conf extends stdClass
 	 * @var ?stdClass
 	 */
 	public $mrp;
-
-	/**
-	 * @var stdClass
-	 * @deprecated      Use $category
-	 * @see $category
-	 */
-	private $categorie;
-
-	/**
-	 * @var stdClass
-	 * @deprecated      Use $supplier_proposal
-	 * @see $supplier_proposal
-	 */
-	private $supplierproposal;
-
-	/**
-	 * @var stdClass
-	 * @deprecated      Use $delivery_note
-	 * @see $delivery_note
-	 */
-	private $expedition;
-
-	/**
-	 * @var stdClass
-	 * @deprecated      Use $bank
-	 * @see $bank
-	 */
-	private $banque;
 
 	/**
 	 * Constructor

--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -813,9 +813,17 @@ class Conf extends stdClass
 			$rootfortemp = empty($this->global->MAIN_TEMP_DIR) ? $rootfordata : $this->global->MAIN_TEMP_DIR;
 
 			// Define default dir_output and dir_temp for directories of modules
-			foreach ($this->modules as $module) {
+			// By default use the old names.
+			foreach (array_keys(MODULE_MAPPING) + $this->modules as $module) {
+				if (!empty($this->$module->dir_output)) {
+					continue;
+				}
 				//var_dump($module);
 				// For multicompany sharings
+				if (empty($this->$module)) {
+					$this->$module = new stdClass();
+				}
+
 				$this->$module->multidir_output = array($this->entity => $rootfordata."/".$module);
 				$this->$module->multidir_temp = array($this->entity => $rootfortemp."/".$module."/temp");
 				// For backward compatibility

--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -21,6 +21,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+require_once DOL_DOCUMENT_ROOT.'/core/class/doldeprecationhandler.class.php';
+
 /**
  *	\file       	htdocs/core/class/conf.class.php
  *	\ingroup		core
@@ -30,9 +32,17 @@
 
 /**
  *  Class to stock current configuration
+ *
  */
 class Conf extends stdClass
 {
+	use DolDeprecationHandler;
+	/**
+	 * When true, indicates to the DeprecationHandler that this
+	 * class supports dynamic properties.
+	 */
+	protected $enableDynamicProperties = true;
+
 	/**
 	 * @var Object 		Associative array with properties found in conf file
 	 */
@@ -113,7 +123,6 @@ class Conf extends stdClass
 	 * @var string Used to store current menu handler
 	 */
 	public $standard_menu;
-
 	/**
 	 * @var array<string,string>  List of activated modules
 	 */
@@ -242,26 +251,14 @@ class Conf extends stdClass
 	public $fournisseur;
 
 	/**
-	 * @var stdClass	Product
+	 * @var stdClass
 	 */
 	public $product;
-
-	/**
-	 * @var stdClass
-	 * @deprecated Use product
-	 */
-	public $produit;
 
 	/**
 	 * @var stdClass  	service
 	 */
 	public $service;
-
-	/**
-	 * @var stdClass
-	 * @deprecated Use contract
-	 */
-	public $contrat;
 
 	/**
 	 * @var stdClass Contract
@@ -285,7 +282,7 @@ class Conf extends stdClass
 
 	/**
 	 * @var stdClass
-	 * @deprecated Use order
+	 * @deprecated Use $order
 	 */
 	public $commande;
 
@@ -296,7 +293,7 @@ class Conf extends stdClass
 
 	/**
 	 * @var stdClass
-	 * @deprecated Use invoice
+	 * @deprecated Use $invoice
 	 */
 	public $facture;
 
@@ -312,7 +309,7 @@ class Conf extends stdClass
 
 	/**
 	 * @var stdClass
-	 * @deprecated Use member
+	 * @deprecated Use $member
 	 */
 	public $adherent;
 
@@ -352,10 +349,32 @@ class Conf extends stdClass
 	public $api;
 
 	/**
-	 * @var ?stdClass
-	 * @deprecated Use project
+	 * @var stdClass
 	 */
-	public $projet;
+	public $bank;
+
+	/**
+	 * @var stdClass
+	 */
+	public $notification;
+
+	/**
+	 * @var stdClass
+	 */
+	public $expensereport;
+
+	/**
+	 * @var stdClass
+	 */
+	public $productbatch;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $project
+	 * @see $project
+	 */
+	private $projet;
+
 
 	/**
 	 * @var ?stdClass
@@ -386,6 +405,34 @@ class Conf extends stdClass
 	 * @var ?stdClass
 	 */
 	public $mrp;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $category
+	 * @see $category
+	 */
+	private $categorie;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $supplier_proposal
+	 * @see $supplier_proposal
+	 */
+	private $supplierproposal;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $delivery_note
+	 * @see $delivery_note
+	 */
+	private $expedition;
+
+	/**
+	 * @var stdClass
+	 * @deprecated      Use $bank
+	 * @see $bank
+	 */
+	private $banque;
 
 	/**
 	 * Constructor
@@ -439,20 +486,45 @@ class Conf extends stdClass
 		$this->fournisseur = new stdClass();
 		$this->product = new stdClass();
 		$this->service = new stdClass();
-		$this->contrat = new stdClass();
+		$this->contract = new stdClass();
 		$this->actions = new stdClass();
 		$this->agenda = new stdClass();
-		$this->commande = new stdClass();
+		$this->order = new stdClass();
 		$this->propal = new stdClass();
-		$this->facture = new stdClass();
+		$this->invoice = new stdClass();
 		$this->user	= new stdClass();
-		$this->adherent = new stdClass();
+		$this->member = new stdClass();
 		$this->bank = new stdClass();
 		$this->mailing = new stdClass();
 		$this->notification = new stdClass();
 		$this->expensereport = new stdClass();
 		$this->productbatch = new stdClass();
 		$this->api = new stdClass();
+	}
+
+	/**
+	 * Provide list of deprecated properties and replacements
+	 *
+	 * @return array<string,string>
+	 */
+	protected function deprecatedProperties()
+	{
+		return MODULE_MAPPING
+		+ array(
+			// Previously detected module names, already in mapping
+			//'adherent' => 'member',
+			//'banque' => 'bank',
+			//'categorie' => 'category',
+			//'commande' => 'order',
+			//'contrat' => 'contract',
+			//'expedition' => 'delivery_note',
+			//'facture' => 'invoice',
+			//'projet' => 'project',
+
+			// Other, not deprecated module names
+			'produit' => 'product',
+			'supplierproposal' => 'supplier_proposal',
+		);
 	}
 
 
@@ -510,14 +582,14 @@ class Conf extends stdClass
 		$this->compta = new stdClass();
 		$this->product = new stdClass();
 		$this->service = new stdClass();
-		$this->contrat = new stdClass();
+		$this->contract = new stdClass();
 		$this->actions = new stdClass();
 		$this->agenda = new stdClass();
-		$this->commande = new stdClass();
+		$this->order = new stdClass();
 		$this->propal = new stdClass();
-		$this->facture = new stdClass();
+		$this->invoice = new stdClass();
 		$this->user	= new stdClass();
-		$this->adherent = new stdClass();
+		$this->member = new stdClass();
 		$this->bank = new stdClass();
 		$this->notification = new stdClass();
 		$this->expensereport = new stdClass();
@@ -624,12 +696,6 @@ class Conf extends stdClass
 							} elseif (preg_match('/^MAIN_MODULE_([0-9A-Z_]+)$/i', $key, $reg)) {
 								// If this is a module constant (must be at end)
 								$modulename = strtolower($reg[1]);
-								if ($modulename == 'propale') {
-									$modulename = 'propal';
-								}
-								if ($modulename == 'supplierproposal') {
-									$modulename = 'supplier_proposal';
-								}
 								$this->modules[$modulename] = $modulename; // Add this module in list of enabled modules
 
 								// deprecated in php 8.2
@@ -640,7 +706,6 @@ class Conf extends stdClass
 								$this->$modulename->enabled = true;	// TODO Remove this
 
 								// Duplicate entry with the new name
-								/*
 								$mapping = $this->deprecatedProperties();
 								if (array_key_exists($modulename, $mapping)) {
 									$newmodulename = $mapping[$modulename];
@@ -651,7 +716,6 @@ class Conf extends stdClass
 									}
 									$this->$newmodulename->enabled = true;	// TODO Remove this
 								}
-								*/
 							}
 						}
 					}
@@ -884,12 +948,12 @@ class Conf extends stdClass
 			$this->productbatch->multidir_output = array($this->entity => $rootfordata."/productlot");
 			$this->productbatch->multidir_temp = array($this->entity => $rootfortemp."/productlot/temp");
 
-			// Module contrat
-			$this->contrat->multidir_output = array($this->entity => $rootfordata."/contract");
-			$this->contrat->multidir_temp = array($this->entity => $rootfortemp."/contract/temp");
+			// Module contract
+			$this->contract->multidir_output = array($this->entity => $rootfordata."/contract");
+			$this->contract->multidir_temp = array($this->entity => $rootfortemp."/contract/temp");
 			// For backward compatibility
-			$this->contrat->dir_output = $rootfordata."/contract";
-			$this->contrat->dir_temp = $rootfortemp."/contract/temp";
+			$this->contract->dir_output = $rootfordata."/contract";
+			$this->contract->dir_temp = $rootfortemp."/contract/temp";
 
 			// Module bank
 			$this->bank->multidir_output = array($this->entity => $rootfordata."/bank");
@@ -1207,14 +1271,14 @@ class Conf extends stdClass
 			// Avoid strict errors. TODO: Replace conf->xxx->warning_delay with a property conf->warning_delays['xxx']
 			if (isset($this->agenda)) {
 				$this->warning_delays['subscription'] = getDolGlobalInt('MAIN_DELAY_MEMBERS') * 86400;
-				$this->adherent->subscription = new stdClass();
-				$this->adherent->subscription->warning_delay = getDolGlobalInt('MAIN_DELAY_MEMBERS') * 86400;
+				$this->member->subscription = new stdClass();
+				$this->member->subscription->warning_delay = getDolGlobalInt('MAIN_DELAY_MEMBERS') * 86400;
 			}
 			if (isset($this->agenda)) {
 				$this->warning_delays['agenda'] = getDolGlobalInt('MAIN_DELAY_ACTIONS_TODO', 7) * 86400;
 				$this->agenda->warning_delay = getDolGlobalInt('MAIN_DELAY_ACTIONS_TODO', 7) * 86400;
 			}
-			if (isset($this->projet)) {
+			if (isset($this->project)) {
 				$this->warning_delays['project'] = (getDolGlobalInt('MAIN_DELAY_PROJECT_TO_CLOSE', 7) * 86400);
 				$this->warning_delays['task'] = (getDolGlobalInt('MAIN_DELAY_TASKS_TODO', 7) * 86400);
 				$this->projet->warning_delay = (getDolGlobalInt('MAIN_DELAY_PROJECT_TO_CLOSE', 7) * 86400);
@@ -1224,10 +1288,10 @@ class Conf extends stdClass
 			if (isset($this->commande)) {
 				$this->warning_delays['order'] = getDolGlobalInt('MAIN_DELAY_ORDERS_TO_PROCESS', 2) * 86400;
 				$this->warning_delays['purchase_order'] = getDolGlobalInt('MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS', 7) * 86400;
-				$this->commande->client = new stdClass();
-				$this->commande->fournisseur = new stdClass();
-				$this->commande->client->warning_delay = getDolGlobalInt('MAIN_DELAY_ORDERS_TO_PROCESS', 2) * 86400;
-				$this->commande->fournisseur->warning_delay = getDolGlobalInt('MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS', 7) * 86400;
+				$this->order->client = new stdClass();
+				$this->order->fournisseur = new stdClass();
+				$this->order->client->warning_delay = getDolGlobalInt('MAIN_DELAY_ORDERS_TO_PROCESS', 2) * 86400;
+				$this->order->fournisseur->warning_delay = getDolGlobalInt('MAIN_DELAY_SUPPLIER_ORDERS_TO_PROCESS', 7) * 86400;
 			}
 			if (isset($this->propal)) {
 				$this->warning_delays['proposal_close'] = getDolGlobalInt('MAIN_DELAY_PROPALS_TO_CLOSE') * 86400;
@@ -1247,21 +1311,22 @@ class Conf extends stdClass
 				$this->supplier_proposal->facturation->warning_delay = getDolGlobalInt('MAIN_DELAY_SUPPLIER_PROPALS_TO_BILL') * 86400;
 			}
 			if (isset($this->facture)) {
+<<<<<<< HEAD
 				$this->warning_delays['invoice'] = getDolGlobalInt('MAIN_DELAY_CUSTOMER_BILLS_UNPAYED') * 86400;
 				$this->warning_delays['supplier_invoice'] = getDolGlobalInt('MAIN_DELAY_SUPPLIER_BILLS_TO_PAY') * 86400;
-				$this->facture->client = new stdClass();
-				$this->facture->fournisseur = new stdClass();
-				$this->facture->client->warning_delay = getDolGlobalInt('MAIN_DELAY_CUSTOMER_BILLS_UNPAYED') * 86400;
-				$this->facture->fournisseur->warning_delay = getDolGlobalInt('MAIN_DELAY_SUPPLIER_BILLS_TO_PAY') * 86400;
+				$this->invoice->client = new stdClass();
+				$this->invoice->fournisseur = new stdClass();
+				$this->invoice->client->warning_delay = getDolGlobalInt('MAIN_DELAY_CUSTOMER_BILLS_UNPAYED') * 86400;
+				$this->invoice->fournisseur->warning_delay = getDolGlobalInt('MAIN_DELAY_SUPPLIER_BILLS_TO_PAY') * 86400;
 			}
 			if (isset($this->contrat)) {
 				$this->warning_delays['contract_inactive'] = getDolGlobalInt('MAIN_DELAY_NOT_ACTIVATED_SERVICES') * 86400;
 				$this->warning_delays['contract_expired'] = getDolGlobalInt('MAIN_DELAY_RUNNING_SERVICES') * 86400;
-				$this->contrat->services = new stdClass();
-				$this->contrat->services->inactifs = new stdClass();
-				$this->contrat->services->expires = new stdClass();
-				$this->contrat->services->inactifs->warning_delay = getDolGlobalInt('MAIN_DELAY_NOT_ACTIVATED_SERVICES') * 86400;
-				$this->contrat->services->expires->warning_delay = getDolGlobalInt('MAIN_DELAY_RUNNING_SERVICES') * 86400;
+				$this->contract->services = new stdClass();
+				$this->contract->services->inactifs = new stdClass();
+				$this->contract->services->expires = new stdClass();
+				$this->contract->services->inactifs->warning_delay = getDolGlobalInt('MAIN_DELAY_NOT_ACTIVATED_SERVICES') * 86400;
+				$this->contract->services->expires->warning_delay = getDolGlobalInt('MAIN_DELAY_RUNNING_SERVICES') * 86400;
 			}
 
 			$this->warning_delays['bank_cheque_to_conciliate'] = getDolGlobalInt('MAIN_DELAY_TRANSACTIONS_TO_CONCILIATE') * 86400;
@@ -1404,37 +1469,6 @@ class Conf extends stdClass
 				$this->tzuserinputkey = $this->global->MAIN_TZUSERINPUTKEY;	// 'tzserver' or 'tzuserrel'
 			}
 
-			// Simple deprecation management. We do not use DolDeprecationHandlet for $conf.
-
-			// product is new use
-			if (isset($this->product)) {
-				// For backward compatibility
-				$this->produit = $this->product;
-			}
-			// invoice is new use, facture is old use still initialised
-			if (isset($this->facture)) {
-				$this->invoice = $this->facture;
-			}
-			// order is new use, commande is old use still initialised
-			if (isset($this->commande)) {
-				$this->order = $this->commande;
-			}
-			// contract is new use, contrat is old use still initialised
-			if (isset($this->contrat)) {
-				$this->contract = $this->contrat;
-			}
-			// category is new use, categorie is old use still initialised
-			if (isset($this->categorie)) {
-				$this->category = $this->categorie;
-			}
-			// project is new use, projet is old use still initialised
-			if (isset($this->projet) && !isset($this->project)) {
-				$this->project = $this->projet;
-			}
-			// member is new use, adherent is old use still initialised
-			if (isset($this->adherent) && !isset($this->member)) {
-				$this->member = $this->adherent;
-			}
 
 			// Object $mc
 			if (!defined('NOREQUIREMC') && isModEnabled('multicompany')) {

--- a/test/phpunit/AllTests.php
+++ b/test/phpunit/AllTests.php
@@ -87,6 +87,8 @@ class AllTests
 		//$suite->addTestSuite('CoreTest');
 		require_once dirname(__FILE__).'/AdminLibTest.php';
 		$suite->addTestSuite('AdminLibTest');
+		require_once dirname(__FILE__).'/ConfTest.php';
+		$suite->addTestSuite('ConfTest');
 		require_once dirname(__FILE__).'/CompanyLibTest.php';
 		$suite->addTestSuite('CompanyLibTest');
 		require_once dirname(__FILE__).'/DateLibTest.php';

--- a/test/phpunit/ConfTest.php
+++ b/test/phpunit/ConfTest.php
@@ -1,0 +1,91 @@
+<?php
+/* Copyright (C) 2013 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/FactureRecTest.php
+ *		\ingroup    test
+ *      \brief      PHPUnit test
+ *		\remarks	To run this script as CLI:  phpunit filename.php
+ */
+
+global $conf,$user,$langs,$db;
+//define('TEST_DB_FORCE_TYPE','mysql');	// This is to force using mysql driver
+//require_once 'PHPUnit/Autoload.php';
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	$user->getrights();
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class ConfTest extends CommonClassTest
+{
+	/**
+	 * Provider for moduleMap test.
+	 *
+	 * TODO: extend to help test expected dir_output path which depends
+	 * on module name, so extra list is needed
+	 *
+	 * @return array<string,array{0:string,1:string}>
+	 */
+	public function moduleMapProvider()
+	{
+		$tests = [];
+		foreach (self::DEPRECATED_MODULE_MAPPING as $old => $new) {
+			$tests[$old] = [$old, $new];
+		}
+		return $tests;
+	}
+
+	/**
+	 * testModulePaths
+	 *
+	 * @dataProvider moduleMapProvider
+	 *
+	 * @param string $old Module
+	 * @param string $new New Module
+	 * @return void
+	 */
+	public function testModulePaths($old, $new)
+	{
+		global $conf,$user,$langs,$db;
+
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		print "DIR_OUTPUT for $old is {$conf->$old->dir_output}".PHP_EOL;
+		print "DIR_OUTPUT for $new is {$conf->$new->dir_output}".PHP_EOL;
+		$this->assertEquals($conf->$old->dir_output, $conf->$new->dir_output, "Old and new dir_output must be equal");
+		$this->assertEquals($conf->$old->dir_output, $conf->$new->dir_output, "Old and new dir_output must be equal");
+	}
+}

--- a/test/phpunit/CoreTest.php
+++ b/test/phpunit/CoreTest.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010-2013 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -74,11 +75,35 @@ if (! defined("NOLOGIN")) {
 class CoreTest extends CommonClassTest
 {
 	/**
+	 * DataProvider for detectURLROOT test
+	 *
+	 * @return array<string,array{0:int}>
+	 */
+	public function detectUrlRootDataProvider()
+	{
+		global $dolibarr_main_document_root;
+		$tests = [
+			'/var/www/dolibarrnew' => [1],
+			'/var/www/aaa/htdocs' => [2],
+			'/home/ldestailleur/git/dolibarr/htdocs' => [3],
+			'/var/www/dolibarr' => [4],
+			'http://localhost/dolibarralias' => [5],
+		];
+		if (array_key_exists($dolibarr_main_document_root, $tests)) {
+			return [$dolibarr_main_document_root, $tests[$dolibarr_main_document_root]];
+		}
+		return [0 => [0]];
+	}
+
+	/**
 	 * testDetectURLROOT
 	 *
+	 * @dataProvider detectUrlRootDataProvider
+	 *
+	 * @param int $testtodo Test to do
 	 * @return	void
 	 */
-	public function testDetectURLROOT()
+	public function testDetectURLROOT($testtodo)
 	{
 		global $dolibarr_main_prod;
 
@@ -91,8 +116,6 @@ class CoreTest extends CommonClassTest
 		global $dolibarr_main_db_port;
 		global $dolibarr_main_db_type;
 		global $dolibarr_main_db_prefix;
-
-		$testtodo = 0;
 
 		// Case 1:
 		// Test for subdir dolibarrnew (that point to htdocs) in root directory /var/www


### PR DESCRIPTION
@eldy 
What is the issue?

IMHO, a test case should demonstrate the issue so that the real cause can be determined.

From reading the code I can only see the following as a possible cause, and an overlooked deprecation mapping (I could not find any):

https://github.com/Dolibarr/dolibarr/blob/56f9ec41c025c8f34cde2d5b6c5af08c7d525842/htdocs/core/class/conf.class.php#L570-L572

Possibly $mapping should be restricted to MODULE_MAPPING and not the entire deprecation list.