### PR TITLE
NEW: constant PROJECT_ALWAYS_DISCARD_CLOSED_PROJECTS_IN_SELECT

### DIFF
--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -169,8 +169,7 @@ class FormProjets extends Form
 		if (getDolGlobalString('PROJECT_HIDE_UNSELECTABLES')) {
 			$hideunselectables = true;
 		}
-
-		if (getDolGlobalInt('MAIN_DISCARD_CLOSED_PROJECTS_IN_SELECT')) {
+		if (getDolGlobalInt('PROJECT_ALWAYS_DISCARD_CLOSED_PROJECTS_IN_SELECT')) {
 			$discard_closed = 1;
 		}
 

--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2018 Charlene Benke <charlie@patas-monkey.com>
  * Copyright (C) 2024		Frédéric France				<frederic.france@free.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024		Benjamin Falière			<benjamin.faliere@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -167,6 +168,10 @@ class FormProjets extends Form
 		$hideunselectables = false;
 		if (getDolGlobalString('PROJECT_HIDE_UNSELECTABLES')) {
 			$hideunselectables = true;
+		}
+
+		if (getDolGlobalInt('MAIN_DISCARD_CLOSED_PROJECTS_IN_SELECT')) {
+			$discard_closed = 1;
 		}
 
 		$projectsListId = false;


### PR DESCRIPTION
In all the select items to select a project, all the closed project are currently displayed.

I don't really see many cases where it can be necessary, so I think that we should be able to always hide all the projects already closed.

In that case, in `select_projects_list()`, I propose to add a constant that, if defined, would systematically define `$discard_closed` to 1. In many installation, with the increasing number of project over time, it can quickly become quite unmanageable.