### PR TITLE
qual: phpstan for fournisseur.facture.class.php

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -200,15 +200,15 @@ class FactureFournisseur extends CommonInvoice
 	public $localtax1;
 	/** @var ?string */
 	public $localtax2;
-	/** @var float|int */
+	/** @var float */
 	public $total_ht;
-	/** @var float|int */
+	/** @var float */
 	public $total_tva;
-	/** @var float|int */
+	/** @var float */
 	public $total_localtax1;
-	/** @var float|int */
+	/** @var float */
 	public $total_localtax2;
-	/** @var float|int */
+	/** @var float */
 	public $total_ttc;
 
 	/**
@@ -1201,7 +1201,7 @@ class FactureFournisseur extends CommonInvoice
 			$this->statut = $this->status;
 		}
 		if (isset($this->author)) {  // TODO: user_creation_id?
-			$this->author = trim((string) $this->author);
+			$this->author = (int) $this->author;
 		}
 		if (isset($this->fk_user_valid)) {
 			$this->fk_user_valid = trim($this->fk_user_valid);


### PR DESCRIPTION
htdocs/fourn/class/fournisseur.facture.class.php	204	PHPDoc type float|int of property FactureFournisseur::$total_ht is not covariant with PHPDoc type float of overridden property CommonObject::$total_ht. 

htdocs/fourn/class/fournisseur.facture.class.php	206	PHPDoc type float|int of property FactureFournisseur::$total_tva is not covariant with PHPDoc type float of overridden property CommonObject::$total_tva. 

htdocs/fourn/class/fournisseur.facture.class.php	208	PHPDoc type float|int of property FactureFournisseur::$total_localtax1 is not covariant with PHPDoc type float of overridden property CommonObject::$total_localtax1. 

htdocs/fourn/class/fournisseur.facture.class.php	210	PHPDoc type float|int of property FactureFournisseur::$total_localtax2 is not covariant with PHPDoc type float of overridden property CommonObject::$total_localtax2. 

htdocs/fourn/class/fournisseur.facture.class.php	212	PHPDoc type float|int of property FactureFournisseur::$total_ttc is not covariant with PHPDoc type float of overridden property CommonObject::$total_ttc. 

htdocs/fourn/class/fournisseur.facture.class.php	1204	Property FactureFournisseur::$author (int) does not accept string.