### PR TITLE
NEW: API GET projects by REF_EXT

### DIFF
--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -124,6 +124,37 @@ class Projects extends DolibarrApi
 	 *
 	 * Return an array with project information
 	 *
+	 * @param	string	$ref_ext			Ref_Ext of project
+	 * @return  Object					Object with cleaned properties
+	 *
+	 * @url GET ref_ext/{ref_ext}
+	 *
+	 * @throws	RestException
+	 */
+	public function getByRefExt($ref_ext)
+	{
+		if (!DolibarrApiAccess::$user->hasRight('projet', 'lire')) {
+			throw new RestException(403);
+		}
+
+		$result = $this->project->fetch('', $ref_ext);
+		if (!$result) {
+			throw new RestException(404, 'Project with supplied ref_ext not found');
+		}
+
+		if (!DolibarrApi::_checkAccessToResource('project', $this->project->id)) {
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+		}
+
+		$this->project->fetchObjectLinked();
+		return $this->_cleanObjectDatas($this->project);
+	}
+
+	/**
+	 * Get properties of a project object
+	 *
+	 * Return an array with project information
+	 *
 	 * @param	string	$email_msgid	Email msgid of project
 	 * @return  Object					Object with cleaned properties
 	 *

--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -137,7 +137,7 @@ class Projects extends DolibarrApi
 			throw new RestException(403);
 		}
 
-		$result = $this->project->fetch('', $ref_ext);
+		$result = $this->project->fetch('', '', $ref_ext);
 		if (!$result) {
 			throw new RestException(404, 'Project with supplied ref_ext not found');
 		}


### PR DESCRIPTION
NEW: API GET projects by REF_EXT
The fetch function for projects also listed an ext_ref so this is the last missing project getby... API function. 

NOT tested to the same standard as I did with #29186 - because my Dolibarr llx_projet table still has no ref_ext column , see #29185.

However, I do not get any errors running it, and I did try adding an ext_ref using the API, which initially looked promising, but reloading once again showed null in ref_ext.

Further more the code in this commit is a carbon copy of `public function getByRef($ref)` where I just did a search for `ref` and replaced it with `ref_ext` so I feel confident enough that it should work as well as getByRef.