### PR TITLE
Fix #29115 API PUT call issue (product extra fields)

### DIFF
--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -368,7 +368,12 @@ class Products extends DolibarrApi
 				$this->product->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
 				continue;
 			}
-
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->product->array_options[$index] = $val;
+				}
+				continue;
+			}
 			$this->product->$field = $this->_checkValForAPI($field, $value, $this->product);
 		}
 

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -370,7 +370,7 @@ class Products extends DolibarrApi
 			}
 			if ($field == 'array_options' && is_array($value)) {
 				foreach ($value as $index => $val) {
-					$this->product->array_options[$index] = $val;
+					$this->product->array_options[$index] = $this->_checkValForAPI($field, $val, $this->product);
 				}
 				continue;
 			}


### PR DESCRIPTION
FIX #29115 API PUT call issue (product extra fields)
Allow API Put call to update just a single extra field / complementary attribute / array_options / options_ field without having to supply all the other extra fields which previously would be reset to null.

This commit should close #29115