### PR TITLE
qual: phpstan for TraceableDB.php

### DIFF
--- a/htdocs/debugbar/class/TraceableDB.php
+++ b/htdocs/debugbar/class/TraceableDB.php
@@ -40,7 +40,7 @@ class TraceableDB extends DoliDB
 	 */
 	public $queries;
 	/**
-	 * @var int Request start time
+	 * @var float Request start time
 	 */
 	protected $startTime;
 	/**


### PR DESCRIPTION
htdocs/debugbar/class/TraceableDB.php	362	Property TraceableDB::$startTime (int) does not accept float.