### PR TITLE
PHP warning on updating html type extrafield

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -591,6 +591,7 @@ class ExtraFields
 				$lengthdb = '255';
 			} elseif ($type == 'html') {
 				$typedb = 'text';
+				$lengthdb = $length;
 			} elseif ($type == 'link') {
 				$typedb = 'int';
 				$lengthdb = '11';


### PR DESCRIPTION
# FIX #29229 
PHP Wraning undefined variable $lengthdb in /core/class/extrafields.class.php on line 604

# CLOSE #29229 
PHP Wraning undefined variable $lengthdb in /core/class/extrafields.class.php on line 604
