### PR TITLE
Qual: Phan/apstats should not be using the standard baseline

### DIFF
--- a/dev/tools/apstats.php
+++ b/dev/tools/apstats.php
@@ -95,7 +95,15 @@ while ($i < $argc) {
 	$i++;
 }
 
-if (!is_readable("{$path}phan/config.php")) {
+
+// Configuration is required, otherwise phan is disabled.
+$PHAN_CONFIG = "{$path}phan/config_extended.php";
+// BASELINE is ignored if it does not exist
+$PHAN_BASELINE = "{$path}phan/baseline_extended.txt";
+$PHAN_MIN_PHP = "7.0";
+$PHAN_MEMORY_OPT = "--memory-limit 5G";
+
+if (!is_readable($PHAN_CONFIG)) {
 	print "Skipping phan - configuration not found\n";
 	// Disable phan while not integrated yet
 	$dir_phan = 'disabled';
@@ -139,15 +147,15 @@ if ($dirphpstan != 'disabled') {
 $output_phan_json = array();
 $res_exec_phan = 0;
 if ($dir_phan != 'disabled') {
+	if (is_readable($PHAN_BASELINE)) {
+		$PHAN_BASELINE_OPT = "-B '${PHAN_BASELINE}'";
+	} else {
+		$PHAN_BASELINE_OPT = '';
+	}
 	// Get technical debt (phan)
-	$PHAN_CONFIG = "dev/tools/phan/config_extended.php";
-	$PHAN_BASELINE = "dev/tools/phan/baseline.txt";
-	$PHAN_MIN_PHP = "7.0";
-	$PHAN_MEMORY_OPT = "--memory-limit 5G";
-
 	$commandcheck
 		= ($dir_phan ? $dir_phan.DIRECTORY_SEPARATOR : '')
-		  ."phan --output-mode json $PHAN_MEMORY_OPT -k $PHAN_CONFIG -B $PHAN_BASELINE --analyze-twice --minimum-target-php-version $PHAN_MIN_PHP";
+		  ."phan --output-mode json $PHAN_MEMORY_OPT -k '$PHAN_CONFIG' $PHAN_BASELINE_OPT --analyze-twice --minimum-target-php-version $PHAN_MIN_PHP";
 	print 'Execute Phan to get the technical debt: '.$commandcheck."\n";
 	exec($commandcheck, $output_phan_json, $res_exec_phan);
 }

--- a/dev/tools/phan/baseline_extended.txt
+++ b/dev/tools/phan/baseline_extended.txt
@@ -1,0 +1,22 @@
+<?php
+/**
+ * /!\ DO NOT generate this baseline - it should only suppress notices
+ * that are to be excluded from the technical debt and that can
+ * not be excluded using other methods.
+ * The 'internal' PhanUndeclaredConstant is such a case.
+ *
+ * When Phan is invoked with --load-baseline=path/to/baseline.php,
+ * The pre-existing issues listed in this file won't be emitted.
+ *
+ * This file can be updated by invoking Phan with --save-baseline=path/to/baseline.php
+ * (can be combined with --load-baseline)
+ */
+return [
+
+    // Currently, file_suppressions and directory_suppressions are the only supported suppressions
+    'file_suppressions' => [
+        'internal' => ['PhanUndeclaredConstant'],
+    ],
+    // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
+    // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
+];


### PR DESCRIPTION
# Qual: Phan/apstats should not be using the standard baseline

Fix to get apstats reporting on the technical debt.  The 'baseline.txt' is for the ci regression.  The code is changed to allow a 'baseline_extended.txt' which should not be generated, only hand-crafted