### PR TITLE
Deposit not taken into account when displaying the amount of the supplier invoice.

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -159,10 +159,6 @@ abstract class CommonInvoice extends CommonObject
 	 */
 	public function getSumDepositsUsed($multicurrency = 0)
 	{
-		//if ($this->element == 'facture_fourn' || $this->element == 'invoice_supplier') {
-			// TODO
-		//	return 0.0;
-		//}
 
 		require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
 

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -159,10 +159,10 @@ abstract class CommonInvoice extends CommonObject
 	 */
 	public function getSumDepositsUsed($multicurrency = 0)
 	{
-		if ($this->element == 'facture_fourn' || $this->element == 'invoice_supplier') {
+		//if ($this->element == 'facture_fourn' || $this->element == 'invoice_supplier') {
 			// TODO
-			return 0.0;
-		}
+		//	return 0.0;
+		//}
 
 		require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
 


### PR DESCRIPTION
# FIX|Fix # Deposit not taken into account when displaying the amount of the supplier invoice.

When we create a deposit for a supplier invoice, it is not considered by the getSumDepositUsed function, which results in not updating the amount on the supplier invoice if we apply this account.


@eldy : Is there a particular rule that I might have missed or misunderstood for which this test is applied here? Or is this fix applicable for supplier invoices?
i'm aware of the presence in v19 of this update but i ask if we can set this part of code in v15.




