### PR TITLE
on tasks status is statut

### DIFF
--- a/htdocs/core/ajax/objectonoff.php
+++ b/htdocs/core/ajax/objectonoff.php
@@ -77,7 +77,7 @@ if (!empty($user->socid)) {
 
 // We check permission.
 // Check is done on $user->rights->element->create or $user->rights->element->subelement->create (because $action = 'set')
-if (preg_match('/status$/', $field) || ($field == 'evenunsubscribe' && $object->table_element == 'mailing')) {
+if (preg_match('/statu[st]$/', $field) || ($field == 'evenunsubscribe' && $object->table_element == 'mailing')) {
 	restrictedArea($user, $object->module, $object, $object->table_element, $usesublevelpermission);
 } elseif ($element == 'product' && in_array($field, array('tosell', 'tobuy', 'tobatch'))) {	// Special case for products
 	restrictedArea($user, 'produit|service', $object, 'product&product', '', '', 'rowid');


### PR DESCRIPTION
yes i know statut & fk_statut are deprecated but there is a lot of case where statut is used, for example in tasks ... that PR will allow to use toggle on/off on tasks, good user ui/ux for that sort of situation

when all statut will be removed we could rollback that PR but for the moment i hope you will agree with that PR
