### PR TITLE
Fix: Use a stable windows version to avoid mariadb download issue

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -29,7 +29,11 @@ jobs:
   win-test:
     strategy:
       matrix:
-        os: [windows-latest]
+        config:
+          # - {os: windows-latest}
+          # - {os: windows-latest, r: '4.1'}
+          # Fixed version to avoid mariadb installation issue
+          - {os: windows-latest, r: '4.2'}
         # php_version: [7.4, 8.0]  # Add more versions if needed
         php_version: [7.4]  # Add more versions if needed
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# Fix: Use a stable windows version to avoid mariadb download issue

From the https://github.com/ankane/setup-mariadb/issues/15 issue it seems that older windows version have not issue downloading the mariadb installation file.