### PR TITLE
FIX supplier price duplicate entry on update supplier product ref

### DIFF
--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -181,6 +181,7 @@ if (empty($reshook)) {
 	}
 
 	if ($action == 'save_price') {
+		$ref_fourn_price_id = GETPOSTINT('ref_fourn_price_id');
 		$id_fourn = GETPOST("id_fourn");
 		if (empty($id_fourn)) {
 			$id_fourn = GETPOST("search_id_fourn");
@@ -265,15 +266,18 @@ if (empty($reshook)) {
 		if (!$error) {
 			$db->begin();
 
-			if (!$error) {
+			if (empty($ref_fourn_price_id)) {
 				$ret = $object->add_fournisseur($user, $id_fourn, $ref_fourn_old, $quantity); // This insert record with no value for price. Values are update later with update_buyprice
 				if ($ret == -3) {
 					$error++;
 
-					$object->fetch($object->product_id_already_linked);
-					$productLink = $object->getNomUrl(1, 'supplier');
+					$tmpobject = new Product($db);
+					$tmpobject->fetch($object->product_id_already_linked);
+					$productLink = $tmpobject->getNomUrl(1, 'supplier');
 
-					setEventMessages($langs->trans("ReferenceSupplierIsAlreadyAssociatedWithAProduct", $productLink), null, 'errors');
+					$texttoshow = $langs->trans("ReferenceSupplierIsAlreadyAssociatedWithAProduct", '{s1}');
+					$texttoshow = str_replace('{s1}', $productLink, $texttoshow);
+					setEventMessages($texttoshow, null, 'errors');
 				} elseif ($ret < 0) {
 					$error++;
 					setEventMessages($object->error, $object->errors, 'errors');
@@ -283,7 +287,7 @@ if (empty($reshook)) {
 			if (!$error) {
 				$supplier = new Fournisseur($db);
 				$result = $supplier->fetch($id_fourn);
-				if (GETPOSTISSET('ref_fourn_price_id')) {
+				if ($ref_fourn_price_id > 0) {
 					$object->fetch_product_fournisseur_price(GETPOST('ref_fourn_price_id', 'int'));
 				}
 				$extralabels = $extrafields->fetch_name_optionals_label("product_fournisseur_price");

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -288,7 +288,7 @@ if (empty($reshook)) {
 				$supplier = new Fournisseur($db);
 				$result = $supplier->fetch($id_fourn);
 				if ($ref_fourn_price_id > 0) {
-					$object->fetch_product_fournisseur_price(GETPOST('ref_fourn_price_id', 'int'));
+					$object->fetch_product_fournisseur_price($ref_fourn_price_id);
 				}
 				$extralabels = $extrafields->fetch_name_optionals_label("product_fournisseur_price");
 				$extrafield_values = $extrafields->getOptionalsFromPost("product_fournisseur_price");


### PR DESCRIPTION
FIX supplier price duplicate entry on update supplier product ref
- when you edit an existing supplier price and when you update en empty supplier product reference with a new one, you got a duplicate entry SQL error

**To reproduce**
You have this product supplier price : 
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/e953acb0-2353-4831-9992-706f7f12d1b4)

You edit this supplier price and set a new product supplier reference : "PROD1FOURN1"

Then when you save this product supplier price, you got this error : 
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/2bd4b5f5-bb93-42bc-8baa-bed6eb794fd5)

**Remarks**
This fix is only for products with no supplier reference : the supplier reference of product is empty in database.
The field of "ref_fourn" is not mandatory in database and can be NULL.
So you can have a database with this case.

And for an update you don't need to use 'add_fournisseur()" method because you know the rowid of "product_supplier_price" table. And no need to check if the unique key for supplier reference already exist : it will be return by the SQL server such as "mysql".