### PR TITLE
NEW : display product and qty in stock_movement table in project overview

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1149,6 +1149,11 @@ foreach ($listofreferent as $key => $value) {
 		print '<td style="width: 24px"></td>';
 		// Ref
 		print '<td'.(($tablename != 'actioncomm' && $tablename != 'projet_task') ? ' style="width: 200px"' : '').'>'.$langs->trans("Ref").'</td>';
+		// Product and qty on stock_movement
+		if ('MouvementStock' == $classname) {
+			print '<td style="width: 200px">'.$langs->trans("Product").'</td>';
+			print '<td style="width: 50px">'.$langs->trans("Qty").'</td>';
+		}
 		// Date
 		print '<td'.(($tablename != 'actioncomm' && $tablename != 'projet_task') ? ' style="width: 200px"' : '').' class="center">';
 		if (in_array($tablename, array('projet_task'))) {
@@ -1335,7 +1340,13 @@ foreach ($listofreferent as $key => $value) {
 					}
 				}
 				print "</td>\n";
-
+				// Product and qty on stock movement
+				if ('MouvementStock' == $classname) {
+					$mvsProd = new Product($element->db);
+					$mvsProd->fetch($element->product_id);
+					print '<td>'.$mvsProd->getNomUrl(1).'</td>';
+					print '<td>'.$element->qty.'</td>';
+				}
 				// Date or TimeSpent
 				$date = '';
 				$total_time_by_line = null;


### PR DESCRIPTION
NEW : in project overview, stock movement section, we only see stock movement ref, but not the product and not the quantity moved
This PR add this fields
![mvtstock090424](https://github.com/Dolibarr/dolibarr/assets/5389628/f62e100e-9b28-4b93-9010-89c5f3063b44)
