### PR TITLE
FIX multicurrency syncRates disable condition

### DIFF
--- a/htdocs/multicurrency/class/multicurrency.class.php
+++ b/htdocs/multicurrency/class/multicurrency.class.php
@@ -648,7 +648,7 @@ class MultiCurrency extends CommonObject
 	{
 		global $conf, $db, $langs;
 
-		if (!getDolGlobalString('MULTICURRENCY_DISABLE_SYNC_CURRENCYLAYER')) {
+		if (getDolGlobalString('MULTICURRENCY_DISABLE_SYNC_CURRENCYLAYER')) {
 			if ($mode == "cron") {
 				$this->output = $langs->trans('Use of API for currency update is disabled by option MULTICURRENCY_DISABLE_SYNC_CURRENCYLAYER');
 			} else {


### PR DESCRIPTION
# FIX multicurrency syncRates disable condition  
The condition to disable currency synchronization seems to have been reversed.  
Currently, it is necessary to set `MULTICURRENCY_DISABLE_SYNC_CURRENCYLAYER` to `1` for synchronization to work. However, this also has the effect of hiding the API configuration menu.