### PR TITLE
FIX : Scale for the "second" unit

### DIFF
--- a/htdocs/install/mysql/data/llx_c_units.sql
+++ b/htdocs/install/mysql/data/llx_c_units.sql
@@ -54,7 +54,7 @@ INSERT INTO llx_c_units (code, sortorder, scale, label, short_label, unit_type, 
 INSERT INTO llx_c_units (code, sortorder, scale, label, short_label, unit_type, active) VALUES ('P',  '500', '0','Piece','p', 'qty', 1);
 INSERT INTO llx_c_units (code, sortorder, scale, label, short_label, unit_type, active) VALUES ('SET','510', '0','Set','set', 'qty', 1);
 
-INSERT INTO llx_c_units (code, sortorder, scale, label, short_label, unit_type, active) VALUES ('S', '600',       '0','second','s', 'time', 1);
+INSERT INTO llx_c_units (code, sortorder, scale, label, short_label, unit_type, active) VALUES ('S', '600',       '1','second','s', 'time', 1);
 INSERT INTO llx_c_units (code, sortorder, scale, label, short_label, unit_type, active) VALUES ('MI','610',      '60','minute','i', 'time', 1);
 INSERT INTO llx_c_units (code, sortorder, scale, label, short_label, unit_type, active) VALUES ('H', '620',    '3600','hour','h', 'time', 1);
 INSERT INTO llx_c_units (code, sortorder, scale, label, short_label, unit_type, active) VALUES ('D', '630',   '86400','day','d', 'time', 1);

--- a/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
+++ b/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
@@ -1,0 +1,1 @@
+UPDATE llx_c_units SET scale = 1 WHERE code = "S";

--- a/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
+++ b/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
@@ -1,1 +1,1 @@
-UPDATE llx_c_units SET scale = 1 WHERE code = "S";
+UPDATE llx_c_units SET scale = 1 WHERE code = 'S';


### PR DESCRIPTION
## FIX : Scale for the "second" unit


I can't do operations/conversion with seconds because the system constantly returns 0 to me
I think the error comes from the fact that the seconds scale should be 1 and not 0

![image](https://github.com/Dolibarr/dolibarr/assets/67913809/6768ab6f-d265-4aeb-a767-c9061d2a716b)

![image](https://github.com/Dolibarr/dolibarr/assets/67913809/0156d748-33f0-4618-9ac4-b602388df8c3)


Maybe there is a better solution than this?