### PR TITLE
NEW add relation type on element_element

### DIFF
--- a/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
+++ b/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
@@ -303,3 +303,9 @@ ALTER TABLE llx_rights_def ADD COLUMN module_origin varchar(64) AFTER module;
 ALTER TABLE llx_rights_def ADD COLUMN enabled text NULL AFTER bydefault;
 
 DELETE FROM llx_c_action_trigger WHERE code = 'BILLREC_AUTOCREATEBILL';
+
+
+-- element_element, see https://github.com/Dolibarr/dolibarr/pull/29329
+
+ALTER TABLE element_element ADD COLUMN relationtype	varchar(64) DEFAULT NULL AFTER targettype;
+

--- a/htdocs/install/mysql/tables/llx_element_element.sql
+++ b/htdocs/install/mysql/tables/llx_element_element.sql
@@ -26,6 +26,6 @@ create table llx_element_element
   fk_source			integer NOT NULL,
   sourcetype		varchar(64) NOT NULL,
   fk_target			integer NOT NULL,
-  targettype		varchar(64) NOT NULL
+  targettype		varchar(64) NOT NULL,
+  relationtype		varchar(64) DEFAULT NULL
 ) ENGINE=innodb;
-


### PR DESCRIPTION
# datamodel evolution

That PR is the first step for a basic need : to be able to make links between elements like thirdparts - thirdparts with an information to complete the relation "what is the role provided".


## thirdparts - thirdparts relations

I have a lot of thirdparts in my dolibarr:

- A: a technical companie A for photocopier
- B: a technical companie B for photocopier
- C: a consultant C for training
- D: a consultant D for training
- .../...
- Z: my direct customer

i would make some links between customer and A and an other link between customer and D because wen Z call me i need to know who i have to call to make the intervention if the problem is with photocopier (A) or D if they need a new training ?

for the moment that is in textual notes (private) on thirdpart but we cannot make requests againts that ...

projects are an other solution, we could set up a project and make relations and roles on projects

but in a lot of situations that's just a link between thirdparts then if we could store "relation type" in element_element table we could use that table to make it

is that a good idea ? i hope, the good solution ? i hope too :)

## a little schema

![image](https://github.com/Dolibarr/dolibarr/assets/1468823/aac1d777-29e7-45be-aa13-d4998bb3f711)


Note: that's not only for thirdpart - thirdpart relations like in my example
