### PR TITLE
FIX link type extrafield on warehouse not working

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -11923,7 +11923,8 @@ function getElementProperties($element_type)
 	} elseif ($element_type == 'inventory') {
 		$module = 'product';
 		$classpath = 'product/inventory/class';
-	} elseif ($element_type == 'stock') {
+	} elseif ($element_type == 'stock' || $element_type == 'entrepot') {
+		$module = 'stock';
 		$classpath = 'product/stock/class';
 		$classfile = 'entrepot';
 		$classname = 'Entrepot';


### PR DESCRIPTION
FIX #28524 fixing extrafield (link type) for warehouse object 


