### PR TITLE
FIX : Ergonomic fail

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13338,8 +13338,8 @@ function show_actions_messaging($conf, $langs, $db, $filterobj, $objcon = '', $n
 				&& $actionstatic->code != 'AC_TICKET_CREATE'
 				&& $actionstatic->code != 'AC_TICKET_MODIFY'
 			) {
-				$out .= '<div class="timeline-body classfortooltip" title="'.dol_escape_htmltag(dol_htmlwithnojs(dol_string_onlythesehtmltags(dol_htmlentitiesbr($histo[$key]['message']), 1, 1, 1)), 1, 1).'">';
-				$out .= dolGetFirstLineOfText($histo[$key]['message'], 3);
+				$out .= '<div class="timeline-body" >';
+				$out .= $histo[$key]['message'];
 				$out .= '</div>';
 			}
 


### PR DESCRIPTION
The road to hell is paved with good intentions :-) 

The show_actions_messaging in dialog version display behavior have change introducing bad user expérience reported by all employee from ATM after V19 Update.

Read message history is became more difficult.
And in some cases, we've even experienced a lack of understanding between users in the ticket messaging system. Because in, the users doesn't saw the 3 little dots.

Remember the function of message view (1) is to allow user to read an history fill like a chat or forum, if the user need a list he can use the list view (2)
![image](https://github.com/Dolibarr/dolibarr/assets/29435477/3e269416-16d1-4389-ada5-001ff85bfdd7)


# FIX

- [x] 1 - First step backward to origin display  
  Done by this pull request

- [x] 2 - Create a new PR to introduce a mor #29373e ergonomic read more behavior, (with configuration for user préférences).  
   see  #29373


![image](https://github.com/Dolibarr/dolibarr/assets/29435477/b6bee584-f620-4a06-8478-41893060a97a)

![image](https://github.com/Dolibarr/dolibarr/assets/29435477/75817b4a-2a88-4c87-9a18-cc19267d2bad)

