### PR TITLE
FIX: background color for enabled modules

### DIFF
--- a/htdocs/theme/md/style.css.php
+++ b/htdocs/theme/md/style.css.php
@@ -354,7 +354,7 @@ print '*/'."\n";
 	--amountremaintopaybackcolor:none;
 	--productlinestockod: #002200;
 	--productlinestocktoolow: #884400;
-	--infoboxmoduleenabledbgcolor : linear-gradient(0.4turn, #2b2d2f, #2b2d2f, #2b2d2f, #e4efe8);
+	--infoboxmoduleenabledbgcolor : linear-gradient(0.4turn, #fff, #fff, #fff, #e4efe8);
 	--tablevalidbgcolor: rgb(252, 248, 227);
 	--butactionbg : #<?php print $butactionbg; ?>;
 	--textbutaction : #<?php print $textbutaction; ?>;


### PR DESCRIPTION
FIX: in modules configuration list with theme md, the info box linear gradient background make active modules unreadable. So I took linear gradient from eldy theme.

before:

![image](https://github.com/Dolibarr/dolibarr/assets/81741011/2cbbf74e-7ec3-4a25-b8b5-7166168325d5)

after:

![image](https://github.com/Dolibarr/dolibarr/assets/81741011/cdaa29b9-d1b3-4dd8-b507-d19c12f3c4f4)
