### PR TITLE
fix : #29372 month_report is accessible even without the readall permission

### DIFF
--- a/htdocs/holiday/month_report.php
+++ b/htdocs/holiday/month_report.php
@@ -43,7 +43,7 @@ if ($user->socid > 0) {	// Protection if external user
 	//$socid = $user->socid;
 	accessforbidden();
 }
-$result = restrictedArea($user, 'holiday', $id, '');
+$result = restrictedArea($user, 'holiday', $id, '', 'readall');
 
 $action      = GETPOST('action', 'aZ09') ?GETPOST('action', 'aZ09') : 'view';
 $massaction  = GETPOST('massaction', 'alpha');


### PR DESCRIPTION
# FIX #29372
The user have access to the month_report.php without permissions (Have to type the URI)

# CLOSE #29372
