### PR TITLE
FIX not redirect when error occurs on updating card

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -477,6 +477,7 @@ if (empty($reshook)) {
 
 					$action = 'view';
 				} else {
+					$error++;
 					setEventMessages($object->error, $object->errors, 'errors');
 					$action = 'edit';
 				}


### PR DESCRIPTION
FIX not redirect when error occurs on updating card
- if an error occurs when you update some information in a contact card, you are redirected in view mode of this contact card

This fix show an error message and keep the edit mode when an error occurs on updating a contact card.
