### PR TITLE
Fix: replenish.php: no virtual stock shown for warehouses that have no physical stock

### DIFF
--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -35,6 +35,7 @@ StockMovementForId=Movement ID %d
 ListMouvementStockProject=List of stock movements associated to project
 StocksArea=Warehouses area
 AllWarehouses=All warehouses
+SelectedWarehouse=Selected warehouse
 IncludeEmptyDesiredStock=Include also negative stock with undefined desired stock
 IncludeAlsoDraftOrders=Include also draft orders
 Location=Location

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5830,6 +5830,22 @@ class Product extends CommonObject
 			}
 		}
 
+		if (! preg_match('/novirtual/', $option)) {
+			// initialize $this->stock_warehouse for all warehouses, even those with no current physical stock because
+			// they may still have a non-zero virtual stock
+			$sql = 'SELECT rowid FROM ' . $this->db->prefix() . 'entrepot WHERE entity IN (' . getEntity('stock') . ')';
+			$result = $this->db->query($sql);
+			if ($result) {
+				while ($obj = $this->db->fetch_object($result)) {
+					$stockWarehouse = $this->stock_warehouse[$obj->rowid] = new stdClass();
+					$stockWarehouse->id = 0;
+					$stockWarehouse->real = 0;
+					$stockWarehouse->virtual = 0;
+					$stockWarehouse->detail_batch = array();
+				}
+			}
+		}
+
 		$sql = "SELECT ps.rowid, ps.reel, ps.fk_entrepot";
 		$sql .= " FROM ".$this->db->prefix()."product_stock as ps";
 		$sql .= ", ".$this->db->prefix()."entrepot as w";

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5833,7 +5833,7 @@ class Product extends CommonObject
 		if (! preg_match('/novirtual/', $option)) {
 			// initialize $this->stock_warehouse for all warehouses, even those with no current physical stock because
 			// they may still have a non-zero virtual stock
-			$sql = 'SELECT rowid FROM ' . $this->db->prefix() . 'entrepot WHERE entity IN (' . getEntity('stock') . ')';
+			$sql = "SELECT rowid FROM " . $this->db->prefix() . "entrepot WHERE entity IN (" . getEntity('stock') . ")";
 			$result = $this->db->query($sql);
 			if ($result) {
 				while ($obj = $this->db->fetch_object($result)) {

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5830,19 +5830,19 @@ class Product extends CommonObject
 			}
 		}
 
-	// initialize $this->stock_warehouse for all warehouses, even those with no current physical stock because
-	// they may still have a non-zero virtual stock
-	$sql = "SELECT rowid FROM " . $this->db->prefix() . "entrepot WHERE entity IN (" . getEntity('stock') . ")";
-	$result = $this->db->query($sql);
-	if ($result) {
-		while ($obj = $this->db->fetch_object($result)) {
-			$stockWarehouse = $this->stock_warehouse[$obj->rowid] = new stdClass();
-			$stockWarehouse->id = 0;
-			$stockWarehouse->real = 0;
-			$stockWarehouse->virtual = 0;
-			$stockWarehouse->detail_batch = array();
+		// initialize $this->stock_warehouse for all warehouses, even those with no current physical stock because
+		// they may still have a non-zero virtual stock
+		$sql = "SELECT rowid FROM " . $this->db->prefix() . "entrepot WHERE entity IN (" . getEntity('stock') . ")";
+		$result = $this->db->query($sql);
+		if ($result) {
+			while ($obj = $this->db->fetch_object($result)) {
+				$stockWarehouse = $this->stock_warehouse[$obj->rowid] = new stdClass();
+				$stockWarehouse->id = 0;
+				$stockWarehouse->real = 0;
+				$stockWarehouse->virtual = 0;
+				$stockWarehouse->detail_batch = array();
+			}
 		}
-	}
 		$sql = "SELECT ps.rowid, ps.reel, ps.fk_entrepot";
 		$sql .= " FROM ".$this->db->prefix()."product_stock as ps";
 		$sql .= ", ".$this->db->prefix()."entrepot as w";

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5830,22 +5830,19 @@ class Product extends CommonObject
 			}
 		}
 
-		if (! preg_match('/novirtual/', $option)) {
-			// initialize $this->stock_warehouse for all warehouses, even those with no current physical stock because
-			// they may still have a non-zero virtual stock
-			$sql = "SELECT rowid FROM " . $this->db->prefix() . "entrepot WHERE entity IN (" . getEntity('stock') . ")";
-			$result = $this->db->query($sql);
-			if ($result) {
-				while ($obj = $this->db->fetch_object($result)) {
-					$stockWarehouse = $this->stock_warehouse[$obj->rowid] = new stdClass();
-					$stockWarehouse->id = 0;
-					$stockWarehouse->real = 0;
-					$stockWarehouse->virtual = 0;
-					$stockWarehouse->detail_batch = array();
-				}
-			}
+	// initialize $this->stock_warehouse for all warehouses, even those with no current physical stock because
+	// they may still have a non-zero virtual stock
+	$sql = "SELECT rowid FROM " . $this->db->prefix() . "entrepot WHERE entity IN (" . getEntity('stock') . ")";
+	$result = $this->db->query($sql);
+	if ($result) {
+		while ($obj = $this->db->fetch_object($result)) {
+			$stockWarehouse = $this->stock_warehouse[$obj->rowid] = new stdClass();
+			$stockWarehouse->id = 0;
+			$stockWarehouse->real = 0;
+			$stockWarehouse->virtual = 0;
+			$stockWarehouse->detail_batch = array();
 		}
-
+	}
 		$sql = "SELECT ps.rowid, ps.reel, ps.fk_entrepot";
 		$sql .= " FROM ".$this->db->prefix()."product_stock as ps";
 		$sql .= ", ".$this->db->prefix()."entrepot as w";

--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -716,7 +716,7 @@ if ($usevirtualstock == 0) {
 	$stocklabel = $langs->trans('PhysicalStock');
 }
 if (getDolGlobalString('STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE') && $fk_entrepot > 0) {
-	$stocklabelbis = $stocklabel.' (Selected warehouse)';
+	$stocklabelbis = $stocklabel.' ('.$langs->trans('SelectedWarehouse').')';
 	$stocklabel .= ' ('.$langs->trans("AllWarehouses").')';
 }
 $texte = $langs->trans('Replenishment');


### PR DESCRIPTION
## Issue

Currently, the replenish page can be filtered by warehouse. If you use this filter in the "virtual stock" mode, it shows a column with the virtual stock of every product for the selected warehouse.

However, when the product doesn't currently have any physical stock in that warehouse, the virtual stock is not computed even though it might be non-zero (for instance if the warehouse is the default warehouse for this product and there are supplier orders for that product, or if you allow negative stock and there are future shipments with lines referring to this warehouse and this product).

This is because `load_virtual_stock()` loops over keys of `$this->stock_warehouses` (an array indexed by warehouse), whose keys are initialized when computing the physical stock. Therefore, warehouses with no physical stock don't have a key in this array and are not considered for virtual stock computation.

## Proposed solution

This fix initializes the array `$this->stock_warehouses` with empty objects for every warehouse.

An alternative solution would be, in `load_virtual_stock()`, to loop over all warehouses instead of those listed as keys of `$this->stock_warehouses`. It would have a smaller memory footprint (no need to keep an array of mostly empty values for possibly thousands of warehouses) but this might be harder to read.