### PR TITLE
FIX 16.0 - Notifications: configured e-mail templates not used if recipient is fixed e-mail address

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -847,12 +847,36 @@ class Notify
 					$mimefilename_list[] = $ref.".pdf";
 				}
 
-				$message = '';
-				$message .= $langs->transnoentities("YouReceiveMailBecauseOfNotification2", $application, $mysoc->name)."\n";
-				$message .= "\n";
-				$message .= $mesg;
+				// if an e-mail template is configured for this notification code (for instance
+				// 'SHIPPING_VALIDATE_TEMPLATE'), we fetch this template by its label. Otherwise, a default message
+				// content will be sent.
+				$mailTemplateLabel = isset($conf->global->{$notifcode.'_TEMPLATE'}) ? $conf->global->{$notifcode.'_TEMPLATE'} : '';
+				$emailTemplate = null;
+				if (!empty($mailTemplateLabel)) {
+					include_once DOL_DOCUMENT_ROOT.'/core/class/html.formmail.class.php';
+					$formmail = new FormMail($this->db);
+					$emailTemplate = $formmail->getEMailTemplate($this->db, $object_type.'_send', $user, $outputlangs, 0, 1, $labeltouse);
+				}
+				if (!empty($mailTemplateLabel) && is_object($emailTemplate) && $emailTemplate->id > 0) {
+					// Set output language
+					$outputlangs = $langs;
+					if ($obj->default_lang && $obj->default_lang != $langs->defaultlang) {
+						$outputlangs = new Translate('', $conf);
+						$outputlangs->setDefaultLang($obj->default_lang);
+						$outputlangs->loadLangs(array('main', 'other'));
+					}
+					$substitutionarray = getCommonSubstitutionArray($outputlangs, 0, null, $object);
+					complete_substitutions_array($substitutionarray, $outputlangs, $object);
+					$subject = make_substitutions($emailTemplate->topic, $substitutionarray, $outputlangs);
+					$message = make_substitutions($emailTemplate->content, $substitutionarray, $outputlangs);
+				} else {
+					$message = '';
+					$message .= $langs->transnoentities("YouReceiveMailBecauseOfNotification2", $application, $mysoc->name)."\n";
+					$message .= "\n";
+					$message .= $mesg;
 
-				$message = nl2br($message);
+					$message = nl2br($message);
+				}
 
 				// Replace keyword __SUPERVISOREMAIL__
 				if (preg_match('/__SUPERVISOREMAIL__/', $sendto)) {


### PR DESCRIPTION
# Issue description

When you configure the notification module, e-mail notifications can be sent:

1.  either to Users/Contacts (each user / contact can subscribe to specific notification types in the relevant tab of their User / Contact cards)

2. or to fixed e-mail addresses, configured directly in the admin page of the notification module

The admin page enables you to choose e-mail templates to use for specific notification types. When chosen, an e-mail template overrides the default message (based on translation keys).

The problem is that this override works for Users / Contacts (1) but not for fixed e-mail addresses (2), which always use a default message using hard-coded translation keys.

# This PR

This fix is mostly a copy/paste of what is done for Users/Contacts into the portion of code that sends notifications to fixed e-mail addresses. So this adds duplicated code and thus could benefit from some refactoring in later Dolibarr versions.