### PR TITLE
FIX: API GET /members/types/{id} says it deletes member type #29421

### DIFF
--- a/htdocs/adherents/class/adherent_type.class.php
+++ b/htdocs/adherents/class/adherent_type.class.php
@@ -522,9 +522,10 @@ class AdherentType extends CommonObject
 
 				// fetch optionals attributes and labels
 				$this->fetch_optionals();
+				return $this->id;
+			} else {
+				return 0;
 			}
-
-			return 1;
 		} else {
 			$this->error = $this->db->lasterror();
 			return -1;

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -825,7 +825,7 @@ class Members extends DolibarrApi
 	 * @param int $id   member type ID
 	 * @return array
 	 *
-	 * @url GET /types/{id}
+	 * @url DELETE /types/{id}
 	 *
 	 * @throws	RestException	403		Access denied
 	 * @throws	RestException	404		No Member Type found
@@ -838,7 +838,7 @@ class Members extends DolibarrApi
 		}
 		$membertype = new AdherentType($this->db);
 		$result = $membertype->fetch($id);
-		if (!$result) {
+		if ($result < 1) {
 			throw new RestException(404, 'member type not found');
 		}
 


### PR DESCRIPTION
FIX: API GET /members/types/{id} says it deletes member type #29421
Fix also includes a fix for giving an error message when trying to delete a member type that does not exist.
