### PR TITLE
Fix: Uncaught Error: Class 'Facture' not found in API GET thirdparties invoices for credit/replacement

### DIFF
--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -1027,6 +1027,7 @@ class Thirdparties extends DolibarrApi
 		 throw new RestException(404, 'Thirdparty not found');
 		 }*/
 
+		require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 		$invoice = new Facture($this->db);
 		$result = $invoice->list_replacable_invoices($id);
 		if ($result < 0) {
@@ -1070,6 +1071,7 @@ class Thirdparties extends DolibarrApi
 		 throw new RestException(404, 'Thirdparty not found');
 		 }*/
 
+		require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 		$invoice = new Facture($this->db);
 		$result = $invoice->list_qualified_avoir_invoices($id);
 		if ($result < 0) {


### PR DESCRIPTION
Fix: API GET thirdparties invoices for credit/replacement failed with: Uncaught Error: Class 'Facture' not found
This pull request just require_once the needed Facture class, but while developing this I was wondering why our builder friend 'Phan' did not discover mistakes like this? Maybe there are similar errors elsewhere in the code?