### PR TITLE
FIX php8: Fatal when empty $tmpvat is an empty string

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -860,7 +860,7 @@ if (empty($reshook)) {
 					}
 				}
 
-				$tmpvat = price2num(preg_replace('/\s*\(.*\)/', '', $tva_tx));
+				$tmpvat = price2num(preg_replace('/\s*\(.*\)/', '', $tva_tx)) ?: 0;
 				$tmpprodvat = price2num(preg_replace('/\s*\(.*\)/', '', $prod->tva_tx));
 
 				// Set unit price to use


### PR DESCRIPTION
# Issue description
PHP8 throws a TypeError when an empty string is used in basic arithmetic operations, where PHP7 would only issue a warning and silently convert to 0.

In some cases, `$tva_tx` is an empty string (I don't remember the precise context as it happened to a client several weeks ago).
This results in `$tmptva` being also an empty string and causes a fatal error.
