### PR TITLE
FIX : Row size of role contact in thirdparty

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1467,7 +1467,7 @@ function show_contacts($conf, $langs, $db, $object, $backtopage = '', $showuserl
 
 			// Role
 			if (!empty($arrayfields['sc.role']['checked'])) {
-				print '<td>';
+				print '<td class="tdoverflowmax150">';
 				print $formcompany->showRoles("roles", $contactstatic, 'view');
 				print '</td>';
 			}


### PR DESCRIPTION
# FIX|Fix Row size of role contact in thirdparty
Added class tdoverflowmax150 to the td for role contact in thirdparty. It takes too much space and hide name of contacts.