### PR TITLE
fix: PHP Fatal error when llx_const SOCIETE_ADDRESSES_MANAGEMENT=1

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -3319,11 +3319,6 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 				if (empty($conf->global->SOCIETE_DISABLE_CONTACTS)) {
 					$result = show_contacts($conf, $langs, $db, $object, $_SERVER["PHP_SELF"].'?socid='.$object->id);
 				}
-
-				// Addresses list
-				if (!empty($conf->global->SOCIETE_ADDRESSES_MANAGEMENT)) {
-					$result = show_addresses($conf, $langs, $db, $object, $_SERVER["PHP_SELF"].'?socid='.$object->id);
-				}
 			}
 		}
 


### PR DESCRIPTION
fix: when option SOCIETE_ADDRESSES_MANAGEMENT is set then in htdocs/societe/card.php "PHP Fatal error:  Uncaught Error: Call to undefined function show_addresses() in htdocs/societe/card.php:3325

this method have been remove from dolibarr since .. I don't know I check to 10.0 branch and this method do not exists

this part of code in societe/card.php have been remove in next branch
