### PR TITLE
Fix: php warning 8.2 property undefined

### DIFF
--- a/htdocs/admin/holiday.php
+++ b/htdocs/admin/holiday.php
@@ -214,7 +214,7 @@ foreach ($dirmodels as $reldir) {
 					}
 
 					if ($module->isEnabled()) {
-						print '<tr class="oddeven"><td>'.$module->nom."</td><td>\n";
+						print '<tr class="oddeven"><td>'.$module->name."</td><td>\n";
 						print $module->info($langs);
 						print '</td>';
 


### PR DESCRIPTION
Corrects the php warning "$module->nom undefined