### PR TITLE
FIX : Not qualified lines for reception

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -756,7 +756,7 @@ class Reception extends CommonObject
 				// qty wished in order supplier (origin)
 				foreach ($this->commandeFournisseur->lines as $origin_line) {
 					// exclude lines not qualified for reception
-					if ((empty($conf->global->STOCK_SUPPORTS_SERVICES) && $origin_line->product_type == 1) || $origin_line->product_type > 1) {
+					if ((!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $origin_line->product_type > 0) || $origin_line->product_type > 1) {
 						continue;
 					}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -756,7 +756,7 @@ class Reception extends CommonObject
 				// qty wished in order supplier (origin)
 				foreach ($this->commandeFournisseur->lines as $origin_line) {
 					// exclude lines not qualified for reception
-					if (empty($conf->global->STOCK_SUPPORTS_SERVICES) && $origin_line->product_type > 0) {
+                    if ((empty($conf->global->STOCK_SUPPORTS_SERVICES) && $origin_line->product_type == 1) || $origin_line->product_type > 1) {
 						continue;
 					}
 

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -756,7 +756,7 @@ class Reception extends CommonObject
 				// qty wished in order supplier (origin)
 				foreach ($this->commandeFournisseur->lines as $origin_line) {
 					// exclude lines not qualified for reception
-                    if ((empty($conf->global->STOCK_SUPPORTS_SERVICES) && $origin_line->product_type == 1) || $origin_line->product_type > 1) {
+					if ((empty($conf->global->STOCK_SUPPORTS_SERVICES) && $origin_line->product_type == 1) || $origin_line->product_type > 1) {
 						continue;
 					}
 


### PR DESCRIPTION
Hello,

When validating a reception based on a supplier order with one line that has product_type = 9 (a title line in my Dolibarr), my supplier order status changes to "PARTIALLY RECEIVED" when validate the reception. However, it should change to "COMPLETELY RECEIVED". This issue arises due to the check performed with the "STOCK_SUPPORTS_SERVICES" configuration.

Currently, if the "STOCK_SUPPORTS_SERVICES" configuration is disabled and the line is not a product (as indicated by the product_type), then all lines that are not products are not considered qualified.

However, if the configuration is enabled, all types of lines are considered qualified. I believe that only product and service types should be qualified.

What do you think?