### PR TITLE
#29026 [Form] fix: selectForForms issue for manage case where objectdesc don't need to reset

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8066,7 +8066,7 @@ class Form
 				if (array_key_exists($tmparray[1], $objectforfieldstmp->fields)) {
 					$objectdesc = $objectforfieldstmp->fields[$tmparray[1]]['type'];
 					$objectdesc = preg_replace('/^integer[^:]*:/', '', $objectdesc);
-				} elseif (empty($objectdesc)) {
+				} elseif (empty($objectdesc)) {	// For backward compatibility
 					$objectdesc = $objectdescorig;
 				}
 			}

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8066,6 +8066,8 @@ class Form
 				if (array_key_exists($tmparray[1], $objectforfieldstmp->fields)) {
 					$objectdesc = $objectforfieldstmp->fields[$tmparray[1]]['type'];
 					$objectdesc = preg_replace('/^integer[^:]*:/', '', $objectdesc);
+				} elseif (empty($objectdesc)) {
+					$objectdesc = $objectdescorig;
 				}
 			}
 		}


### PR DESCRIPTION
![image](https://github.com/Dolibarr/dolibarr/assets/52404047/f6a5364d-c3e9-4f72-862e-5b260e61590f)

In my case, I'm using the element_element table to add a link to the productlot table

In the code above, you can only link an object that has the link in its table, e.g. fk_productlot or with extrafields. However, these two cases only manage 1 - 1 cardinality, whereas with the element_element table you can manage 1 - N cardinality.


