### PR TITLE
FIX:  made invalid code shape error more user friendly

### DIFF
--- a/htdocs/barcode/printsheet.php
+++ b/htdocs/barcode/printsheet.php
@@ -255,10 +255,16 @@ if ($action == 'builddoc') {
 
 			if (!$mesg) {
 				$outputlangs = $langs;
+				$conf->global->TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = getDolGlobalInt('K_TCPDF_THROW_EXCEPTION_ERROR')!=1 ? 1 : getDolGlobalInt('K_TCPDF_THROW_EXCEPTION_ERROR');
+
 
 				// This generates and send PDF to output
 				// TODO Move
-				$result = doc_label_pdf_create($db, $arrayofrecords, $modellabel, $outputlangs, $diroutput, $template, dol_sanitizeFileName($outfile));
+				try {
+					$result = doc_label_pdf_create($db, $arrayofrecords, $modellabel, $outputlangs, $diroutput, $template, dol_sanitizeFileName($outfile));
+				} catch (Exception $e) {
+					$mesg = $langs->trans('ErrorInvalidCodeShape');
+				}
 			}
 		}
 

--- a/htdocs/barcode/printsheet.php
+++ b/htdocs/barcode/printsheet.php
@@ -255,7 +255,8 @@ if ($action == 'builddoc') {
 
 			if (!$mesg) {
 				$outputlangs = $langs;
-				$conf->global->TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = getDolGlobalInt('K_TCPDF_THROW_EXCEPTION_ERROR')!=1 ? 1 : getDolGlobalInt('K_TCPDF_THROW_EXCEPTION_ERROR');
+				$previousConf = getDolGlobalInt('TCPDF_THROW_ERRORS_INSTEAD_OF_DIE');
+				$conf->global->TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = 1;
 
 
 				// This generates and send PDF to output
@@ -263,8 +264,9 @@ if ($action == 'builddoc') {
 				try {
 					$result = doc_label_pdf_create($db, $arrayofrecords, $modellabel, $outputlangs, $diroutput, $template, dol_sanitizeFileName($outfile));
 				} catch (Exception $e) {
-					$mesg = $langs->trans('ErrorInvalidCodeShape');
+					$mesg = $langs->trans('ErrorGeneratingBarcode');
 				}
+				$conf->global->TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = $previousConf;
 			}
 		}
 

--- a/htdocs/barcode/printsheet.php
+++ b/htdocs/barcode/printsheet.php
@@ -231,7 +231,7 @@ if ($action == 'builddoc') {
 						'code'=>$code,
 						'encoding'=>$encoding,
 						'is2d'=>$is2d,
-						'photo'=>!empty($barcodeimage) ??  ''	// Photo must be a file that exists with format supported by TCPDF
+						'photo'=>$barcodeimage ??  ''	// Photo must be a file that exists with format supported by TCPDF
 					);
 				}
 			} else {

--- a/htdocs/barcode/printsheet.php
+++ b/htdocs/barcode/printsheet.php
@@ -231,7 +231,7 @@ if ($action == 'builddoc') {
 						'code'=>$code,
 						'encoding'=>$encoding,
 						'is2d'=>$is2d,
-						'photo'=>$barcodeimage	// Photo must be a file that exists with format supported by TCPDF
+						'photo'=>!empty($barcodeimage) ??  ''	// Photo must be a file that exists with format supported by TCPDF
 					);
 				}
 			} else {

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -304,6 +304,7 @@ ErrorValueCantBeNull=Value for <b>%s</b> can't be null
 ErrorDateOfMovementLowerThanDateOfFileTransmission=The date of the bank transaction can't be lower than the date of the file transmission
 ErrorTooMuchFileInForm=Too much files in form, the maximum number is %s file(s)
 ErrorSVGFilesNotAllowedAsLinksWithout=SVG files are not allowed as external links without option %s 
+ErrorInvalidCodeShape=Invalid code shape
 
 # Warnings
 WarningParamUploadMaxFileSizeHigherThanPostMaxSize=Your PHP parameter upload_max_filesize (%s) is higher than PHP parameter post_max_size (%s). This is not a consistent setup.

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -304,7 +304,7 @@ ErrorValueCantBeNull=Value for <b>%s</b> can't be null
 ErrorDateOfMovementLowerThanDateOfFileTransmission=The date of the bank transaction can't be lower than the date of the file transmission
 ErrorTooMuchFileInForm=Too much files in form, the maximum number is %s file(s)
 ErrorSVGFilesNotAllowedAsLinksWithout=SVG files are not allowed as external links without option %s 
-ErrorInvalidCodeShape=Invalid code shape
+ErrorGeneratingBarcode=Error while generating barcode (probably invalid code shape)
 
 # Warnings
 WarningParamUploadMaxFileSizeHigherThanPostMaxSize=Your PHP parameter upload_max_filesize (%s) is higher than PHP parameter post_max_size (%s). This is not a consistent setup.

--- a/htdocs/langs/fr_FR/errors.lang
+++ b/htdocs/langs/fr_FR/errors.lang
@@ -310,7 +310,7 @@ ErrorFieldExist=La valeur pour <b>%s</b> existe déjà
 ErrorEqualModule=Module invalide dans <b>%s</b>.
 ErrorFieldValue=La valeur pour <b>%s</b> est incorrecte
 ErrorCoherenceMenu=<b>%s</b> is required when <b>%s</b> is 'left'
-ErrorGeneratingBarcode=Error à la génération du code-barre (probablement une valeur invalide)
+ErrorGeneratingBarcode=Erreur à la génération du code-barre (probablement une valeur invalide)
 
 # Warnings
 WarningParamUploadMaxFileSizeHigherThanPostMaxSize=Votre paramètre PHP upload_max_filesize (%s) est supérieur au paramètre PHP post_max_size (%s). Ceci n'est pas une configuration cohérente.

--- a/htdocs/langs/fr_FR/errors.lang
+++ b/htdocs/langs/fr_FR/errors.lang
@@ -310,6 +310,7 @@ ErrorFieldExist=La valeur pour <b>%s</b> existe déjà
 ErrorEqualModule=Module invalide dans <b>%s</b>.
 ErrorFieldValue=La valeur pour <b>%s</b> est incorrecte
 ErrorCoherenceMenu=<b>%s</b> is required when <b>%s</b> is 'left'
+ErrorGeneratingBarcode=Error à la génération du code-barre (probablement une valeur invalide)
 
 # Warnings
 WarningParamUploadMaxFileSizeHigherThanPostMaxSize=Votre paramètre PHP upload_max_filesize (%s) est supérieur au paramètre PHP post_max_size (%s). Ceci n'est pas une configuration cohérente.


### PR DESCRIPTION
When a barcode had an invalid shape, the page would die, now we use the error, catch it and send a pop up the the user so that he is told about what could have caused this error.