### PR TITLE
qual: Variants - cleaner code and improved attributes readability

### DIFF
--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -928,8 +928,8 @@ if (!empty($id) || !empty($ref)) {
 
 				print '<td>'.$prodstatic->getNomUrl(1).'</td>';
 				print '<td>';
-				foreach($comb2val->fetchByFkCombination($currcomb->id) as $pc2v) {
-				    echo dol_htmlentities($pc2v).'<br>';
+				foreach ($comb2val->fetchByFkCombination($currcomb->id) as $pc2v) {
+					print dol_htmlentities($pc2v).'<br>';
 				}
 				print '</td>';
 				print '<td class="right">'.($currcomb->variation_price >= 0 ? '+' : '').price($currcomb->variation_price).($currcomb->variation_price_percentage ? ' %' : '').'</td>';

--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -928,14 +928,8 @@ if (!empty($id) || !empty($ref)) {
 
 				print '<td>'.$prodstatic->getNomUrl(1).'</td>';
 				print '<td>';
-				$productCombination2ValuePairs = $comb2val->fetchByFkCombination($currcomb->id);
-				$iMax = count($productCombination2ValuePairs);
-
-				for ($i = 0; $i < $iMax; $i++) {
-					echo dol_htmlentities($productCombination2ValuePairs[$i]);
-					if ($i !== ($iMax - 1)) {
-						echo ', ';
-					}
+				foreach($comb2val->fetchByFkCombination($currcomb->id) as $pc2v) {
+				    echo dol_htmlentities($pc2v).'<br>';
 				}
 				print '</td>';
 				print '<td class="right">'.($currcomb->variation_price >= 0 ? '+' : '').price($currcomb->variation_price).($currcomb->variation_price_percentage ? ' %' : '').'</td>';


### PR DESCRIPTION
Cleaner code and improved readability for the "Attributes" column (especially true with more than 3 attributes) and coherent with how attributes are shown elsewhere in Dolibarr (one per line).

Before:
![image](https://github.com/Dolibarr/dolibarr/assets/7697736/4bb39104-fbeb-43d1-b0a1-5e03e794035b)

After:
![image](https://github.com/Dolibarr/dolibarr/assets/7697736/da95f369-8f49-4295-96a1-cab594a7a7ef)
