### PR TITLE
FIX : Default action type code when send mail.

### DIFF
--- a/htdocs/core/actions_sendmails.inc.php
+++ b/htdocs/core/actions_sendmails.inc.php
@@ -382,7 +382,7 @@ if (($action == 'send' || $action == 'relance') && !GETPOST('addfile') && !GETPO
 					// Initialisation of datas of object to call trigger
 					if (is_object($object)) {
 						if (empty($actiontypecode)) {
-							$actiontypecode = 'AC_OTH_AUTO'; // Event insert into agenda automatically
+							$actiontypecode = 'AC_EMAIL'; // Event insert into agenda automatically
 						}
 
 						$object->socid = $sendtosocid; // To link to a company


### PR DESCRIPTION
# FIX|Fix Default action type code when send mail. Changed from AC_OTH_AUTO to AC_EMAIL
By default, the action type code when you send an email is AC_OTH_AUTO. I think it is more relevant to set it to AC_EMAIL.