### PR TITLE
FIX : Hide number beside select contract & added langs to translate c…

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -654,10 +654,11 @@ class FormTicket
 
 		if ($subelement != 'contract') {
 			if (isModEnabled('contract') && !$this->ispublic) {
+				$langs->load('contracts');
 				$formcontract = new FormContract($this->db);
 				print '<tr><td><label for="contract"><span class="">'.$langs->trans("Contract").'</span></label></td><td>';
 				print img_picto('', 'contract');
-				print $formcontract->select_contract(-1, GETPOST('contactid', 'int'), 'contractid', 0, 1, 1);
+				$formcontract->select_contract(-1, GETPOST('contactid', 'int'), 'contractid', 0, 1, 1);
 				print '</td></tr>';
 			}
 		}

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -658,7 +658,7 @@ class FormTicket
 				$formcontract = new FormContract($this->db);
 				print '<tr><td><label for="contract"><span class="">'.$langs->trans("Contract").'</span></label></td><td>';
 				print img_picto('', 'contract');
-				$formcontract->select_contract(-1, GETPOST('contactid', 'int'), 'contractid', 0, 1, 1);
+				print $formcontract->select_contract(-1, GETPOST('contactid', 'int'), 'contractid', 0, 1, 1, 1);
 				print '</td></tr>';
 			}
 		}


### PR DESCRIPTION
# FIX|Fix Hide number beside select contract & added langs to translate contract
I removed the print before select_contract that hide the return number of the function.
I added the contracts langs to translate contract.