### PR TITLE
FIX: search and add extrafields to tasks when conf disabled

### DIFF
--- a/htdocs/core/ajax/selectsearchbox.php
+++ b/htdocs/core/ajax/selectsearchbox.php
@@ -92,7 +92,7 @@ if (isModEnabled('mrp') && $user->hasRight('mrp', 'read') && empty($conf->global
 if (isModEnabled('project') && empty($conf->global->MAIN_SEARCHFORM_PROJECT_DISABLED) && $user->hasRight('projet', 'lire')) {
 	$arrayresult['searchintoprojects'] = array('position'=>40, 'shortcut'=>'Q', 'img'=>'object_project', 'label'=>$langs->trans("SearchIntoProjects", $search_boxvalue), 'text'=>img_picto('', 'object_project', 'class="pictofixedwidth"').' '.$langs->trans("SearchIntoProjects", $search_boxvalue), 'url'=>DOL_URL_ROOT.'/projet/list.php'.($search_boxvalue ? '?search_all='.urlencode($search_boxvalue) : ''));
 }
-if (isModEnabled('project') && empty($conf->global->MAIN_SEARCHFORM_TASK_DISABLED) && $user->hasRight('projet', 'lire')) {
+if (isModEnabled('project') && empty($conf->global->MAIN_SEARCHFORM_TASK_DISABLED) && empty($conf->global->PROJECT_HIDE_TASKS) && $user->hasRight('projet', 'lire')) {
 	$arrayresult['searchintotasks'] = array('position'=>45, 'img'=>'object_projecttask', 'label'=>$langs->trans("SearchIntoTasks", $search_boxvalue), 'text'=>img_picto('', 'object_projecttask', 'class="pictofixedwidth"').' '.$langs->trans("SearchIntoTasks", $search_boxvalue), 'url'=>DOL_URL_ROOT.'/projet/tasks/list.php'.($search_boxvalue ? '?search_all='.urlencode($search_boxvalue) : ''));
 }
 

--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -529,14 +529,16 @@ function project_admin_prepare_head()
 	$head[$h][2] = 'attributes';
 	$h++;
 
-	$head[$h][0] = DOL_URL_ROOT.'/projet/admin/project_task_extrafields.php';
-	$head[$h][1] = $langs->trans("ExtraFieldsProjectTask");
-	$nbExtrafields = $extrafields->attributes['projet_task']['count'];
-	if ($nbExtrafields > 0) {
-		$head[$h][1] .= '<span class="badge marginleftonlyshort">'.$nbExtrafields.'</span>';
+	if (empty($conf->global->PROJECT_HIDE_TASKS)) {
+		$head[$h][0] = DOL_URL_ROOT . '/projet/admin/project_task_extrafields.php';
+		$head[$h][1] = $langs->trans("ExtraFieldsProjectTask");
+		$nbExtrafields = $extrafields->attributes['projet_task']['count'];
+		if ($nbExtrafields > 0) {
+			$head[$h][1] .= '<span class="badge marginleftonlyshort">' . $nbExtrafields . '</span>';
+		}
+		$head[$h][2] = 'attributes_task';
+		$h++;
 	}
-	$head[$h][2] = 'attributes_task';
-	$h++;
 
 	if (!empty($conf->global->PROJECT_USE_OPPORTUNITIES)) {
 		$langs->load("members");


### PR DESCRIPTION
Fixing the ability to search tasks in the left menu or to add extra fields in the project module configuration even if they were disabled.