### PR TITLE
fix: SQL Error on replannish

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -365,7 +365,7 @@ $sql .= ' FROM ' . MAIN_DB_PREFIX . 'product as p';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'product_stock as s ON p.rowid = s.fk_product';
 $sql .= ' AND s.fk_entrepot  IN (' . $db->sanitize($list_warehouse) . ')';
 
-$list_warehouse_selected = ($fk_entrepot < 0) ? '0' : $fk_entrepot;
+$list_warehouse_selected = ($fk_entrepot < 0 || empty($fk_entrepot)) ? '0' : $fk_entrepot;
 $sql .= ' AND s.fk_entrepot  IN (' . $db->sanitize($list_warehouse_selected) . ')';
 
 


### PR DESCRIPTION
since 
https://github.com/Dolibarr/dolibarr/commit/31ce8f826b4d58f76cf0e2db0943150f2c4d5bf2


Code retour dernier accès en base en erreur: DB_ERROR_SYNTAX
Information sur le dernier accès en base en erreur: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ') WHERE p.entity IN (1) AND p.tobuy = 1 GROUP BY p.rowid, p.ref, p.label, p.d...' at line 1


result SQL is something like 

ON p.rowid = s.fk_product AND s.fk_entrepot IN (15, 16, 18) AND s.fk_entrepot IN ()