### PR TITLE
FIX : Avoid duplicates in insertions 

### DIFF
--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -788,19 +788,22 @@ class ImportCsv extends ModeleImports
 						if (!preg_match('/^'.preg_quote($alias, '/').'\./', $tmpkey)) {
 							continue; // Not a field of current table
 						}
-						if ($tmpval == 'user->id') {
-							$listfields[] = preg_replace('/^'.preg_quote($alias, '/').'\./', '', $tmpkey);
+						$keyfield = preg_replace('/^'.preg_quote($alias, '/').'\./', '', $tmpkey);
+						// avoid duplicates in insert
+						if (in_array($keyfield, $listfields)) {
+							continue;
+						} elseif ($tmpval == 'user->id') {
+							$listfields[] = $keyfield;
 							$listvalues[] = ((int) $user->id);
 						} elseif (preg_match('/^lastrowid-/', $tmpval)) {
 							$tmp = explode('-', $tmpval);
 							$lastinsertid = (isset($last_insert_id_array[$tmp[1]])) ? $last_insert_id_array[$tmp[1]] : 0;
-							$keyfield = preg_replace('/^'.preg_quote($alias, '/').'\./', '', $tmpkey);
 							$listfields[] = $keyfield;
 							$listvalues[] = (int) $lastinsertid;
 							//print $tmpkey."-".$tmpval."-".$listfields."-".$listvalues."<br>";exit;
 						} elseif (preg_match('/^const-/', $tmpval)) {
 							$tmp = explode('-', $tmpval, 2);
-							$listfields[] = preg_replace('/^'.preg_quote($alias, '/').'\./', '', $tmpkey);
+							$listfields[] = $keyfield;
 							$listvalues[] = "'".$this->db->escape($tmp[1])."'";
 						} elseif (preg_match('/^rule-/', $tmpval)) {
 							$fieldname = $tmpkey;

--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -785,10 +785,10 @@ class ImportCsv extends ModeleImports
 				if (!empty($listfields) && is_array($objimport->array_import_fieldshidden[0])) {
 					// Loop on each hidden fields to add them into listfields/listvalues
 					foreach ($objimport->array_import_fieldshidden[0] as $tmpkey => $tmpval) {
-						if (!preg_match('/^'.preg_quote($alias, '/').'\./', $tmpkey)) {
+						if (!preg_match('/^' . preg_quote($alias, '/') . '\./', $tmpkey)) {
 							continue; // Not a field of current table
 						}
-						$keyfield = preg_replace('/^'.preg_quote($alias, '/').'\./', '', $tmpkey);
+						$keyfield = preg_replace('/^' . preg_quote($alias, '/') . '\./', '', $tmpkey);
 						// avoid duplicates in insert
 						if (in_array($keyfield, $listfields)) {
 							continue;

--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -789,7 +789,7 @@ class ImportCsv extends ModeleImports
 							continue; // Not a field of current table
 						}
 						$keyfield = preg_replace('/^' . preg_quote($alias, '/') . '\./', '', $tmpkey);
-						
+
 						if (in_array($keyfield, $listfields)) {		// avoid duplicates in insert
 							continue;
 						} elseif ($tmpval == 'user->id') {

--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -789,8 +789,8 @@ class ImportCsv extends ModeleImports
 							continue; // Not a field of current table
 						}
 						$keyfield = preg_replace('/^' . preg_quote($alias, '/') . '\./', '', $tmpkey);
-						// avoid duplicates in insert
-						if (in_array($keyfield, $listfields)) {
+						
+						if (in_array($keyfield, $listfields)) {		// avoid duplicates in insert
 							continue;
 						} elseif ($tmpval == 'user->id') {
 							$listfields[] = $keyfield;

--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -832,22 +832,25 @@ class ImportXlsx extends ModeleImports
 				if (!empty($listfields) && is_array($objimport->array_import_fieldshidden[0])) {
 					// Loop on each hidden fields to add them into listfields/listvalues
 					foreach ($objimport->array_import_fieldshidden[0] as $key => $val) {
-						if (!preg_match('/^'.preg_quote($alias, '/').'\./', $key)) {
+						if (!preg_match('/^' . preg_quote($alias, '/') . '\./', $key)) {
 							continue; // Not a field of current table
 						}
-						if ($val == 'user->id') {
-							$listfields[] = preg_replace('/^' . preg_quote($alias, '/') . '\./', '', $key);
+						$keyfield = preg_replace('/^' . preg_quote($alias, '/') . '\./', '', $tmpkey);
+						// avoid duplicates in insert
+						if (in_array($keyfield, $listfields)) {
+							continue;
+						} elseif ($val == 'user->id') {
+							$listfields[] = $keyfield;
 							$listvalues[] = ((int) $user->id);
 						} elseif (preg_match('/^lastrowid-/', $val)) {
 							$tmp = explode('-', $val);
 							$lastinsertid = (isset($last_insert_id_array[$tmp[1]])) ? $last_insert_id_array[$tmp[1]] : 0;
-							$keyfield = preg_replace('/^' . preg_quote($alias, '/') . '\./', '', $key);
 							$listfields[] = $keyfield;
 							$listvalues[] = (int) $lastinsertid;
 							//print $key."-".$val."-".$listfields."-".$listvalues."<br>";exit;
 						} elseif (preg_match('/^const-/', $val)) {
 							$tmp = explode('-', $val, 2);
-							$listfields[] = preg_replace('/^' . preg_quote($alias, '/') . '\./', '', $key);
+							$listfields[] = $keyfield;
 							$listvalues[] = "'".$this->db->escape($tmp[1])."'";
 						} elseif (preg_match('/^rule-/', $val)) {
 							$fieldname = $key;

--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -835,9 +835,9 @@ class ImportXlsx extends ModeleImports
 						if (!preg_match('/^' . preg_quote($alias, '/') . '\./', $key)) {
 							continue; // Not a field of current table
 						}
-						$keyfield = preg_replace('/^' . preg_quote($alias, '/') . '\./', '', $tmpkey);
-						// avoid duplicates in insert
-						if (in_array($keyfield, $listfields)) {
+						$keyfield = preg_replace('/^' . preg_quote($alias, '/') . '\./', '', $key);
+						
+						if (in_array($keyfield, $listfields)) {	// avoid duplicates in insert
 							continue;
 						} elseif ($val == 'user->id') {
 							$listfields[] = $keyfield;


### PR DESCRIPTION
If someone used fieldshidden_array to instanciate default values, there was an error  because field was found twice in the sql insert statement