### PR TITLE
qual: fix phpstan for Property Object::$oldcopy (static) in empty() is not falsy.

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1193,7 +1193,7 @@ class ActionComm extends CommonObject
 		}
 
 		$code = $this->code;
-		if (empty($code) || (!empty($this->oldcopy) && $this->oldcopy->type_code != $this->type_code)) {	// If code unknown or if we change the type, we reset $code too
+		if (empty($code) || (($this->oldcopy !== null) && ($this->oldcopy->type_code != $this->type_code))) {	// If code unknown or if we change the type, we reset $code too
 			$code = $this->type_code;
 		}
 

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3542,7 +3542,7 @@ class ContratLigne extends CommonObjectLine
 		}
 
 		// $this->oldcopy should have been set by the caller of update (here properties were already modified)
-		if (empty($this->oldcopy)) {
+		if ($this->oldcopy === null) {
 			dol_syslog("this->oldcopy should have been set by the caller of update (here properties were already modified)", LOG_WARNING);
 			$this->oldcopy = dol_clone($this, 2);
 		}

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1185,7 +1185,7 @@ class Product extends CommonObject
 
 		if ($result >= 0) {
 			// $this->oldcopy should have been set by the caller of update (here properties were already modified)
-			if (empty($this->oldcopy)) {
+			if ($this->oldcopy === null) {
 				$this->oldcopy = dol_clone($this, 1);
 			}
 			// Test if batch management is activated on existing product

--- a/htdocs/product/stock/class/productlot.class.php
+++ b/htdocs/product/stock/class/productlot.class.php
@@ -559,7 +559,7 @@ class Productlot extends CommonObject
 		}
 
 		// $this->oldcopy should have been set by the caller of update (here properties were already modified)
-		if (empty($this->oldcopy)) {
+		if ($this->oldcopy === null) {
 			$this->oldcopy = dol_clone($this, 2);
 		}
 

--- a/htdocs/resource/class/dolresource.class.php
+++ b/htdocs/resource/class/dolresource.class.php
@@ -385,7 +385,7 @@ class Dolresource extends CommonObject
 		}
 
 		// $this->oldcopy should have been set by the caller of update (here properties were already modified)
-		if (empty($this->oldcopy)) {
+		if ($this->oldcopy === null) {
 			$this->oldcopy = dol_clone($this, 2);
 		}
 

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -2062,7 +2062,7 @@ class User extends CommonObject
 		$this->db->begin();
 
 		// Check if login already exists in same entity or into entity 0.
-		if (!empty($this->oldcopy) && $this->oldcopy->login != $this->login) {
+		if (($this->oldcopy !== null) && ($this->oldcopy->login != $this->login)) {
 			$sqltochecklogin = "SELECT COUNT(*) as nb FROM ".$this->db->prefix()."user WHERE entity IN (".$this->db->sanitize((int) $this->entity).", 0) AND login = '".$this->db->escape($this->login)."'";
 			$resqltochecklogin = $this->db->query($sqltochecklogin);
 			if ($resqltochecklogin) {
@@ -2076,7 +2076,7 @@ class User extends CommonObject
 				}
 			}
 		}
-		if (!empty($this->oldcopy) && !empty($this->email) && $this->oldcopy->email != $this->email) {
+		if (($this->oldcopy !== null) && !empty($this->email) && ($this->oldcopy->email != $this->email)) {
 			$sqltochecklogin = "SELECT COUNT(*) as nb FROM ".$this->db->prefix()."user WHERE entity IN (".$this->db->sanitize((int) $this->entity).", 0) AND email = '".$this->db->escape($this->email)."'";
 			$resqltochecklogin = $this->db->query($sqltochecklogin);
 			if ($resqltochecklogin) {
@@ -3346,7 +3346,7 @@ class User extends CommonObject
 
 				// Check if it is the LDAP key and if its value has been changed
 				if (getDolGlobalString('LDAP_KEY_USERS') && $conf->global->LDAP_KEY_USERS == getDolGlobalString($constname)) {
-					if (!empty($this->oldcopy) && $this->$varname != $this->oldcopy->$varname) {
+					if (($this->oldcopy !== null) && ($this->$varname != $this->oldcopy->$varname)) {
 						$keymodified = true; // For check if LDAP key has been modified
 					}
 				}


### PR DESCRIPTION
htdocs/comm/action/class/actioncomm.class.php	1196	Property CommonObject::$oldcopy (static(ActionComm)) in empty() is not falsy.

htdocs/contrat/class/contrat.class.php	3545	Property CommonObject::$oldcopy (static(ContratLigne)) in empty() is not falsy.

htdocs/product/class/product.class.php	1188	Property Product::$oldcopy (static(Product)) in empty() is not falsy.

htdocs/product/stock/class/productlot.class.php	562	Property CommonObject::$oldcopy (static(Productlot)) in empty() is not falsy.

htdocs/resource/class/dolresource.class.php	388	Property Dolresource::$oldcopy (static(Dolresource)) in empty() is not falsy.

htdocs/user/class/user.class.php	2065	Property User::$oldcopy (static(User)) in empty() is not falsy.
htdocs/user/class/user.class.php	2079	Property User::$oldcopy (static(User)) in empty() is not falsy.
htdocs/user/class/user.class.php	3349	Property User::$oldcopy (static(User)) in empty() is not falsy.