### PR TITLE
FIX: contact/address title is always "New Contact/Address" even if the contact/address already exists

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -585,7 +585,9 @@ if (!empty($conf->global->MAIN_HTML_TITLE) && preg_match('/contactnameonly/', $c
 	$title = $object->lastname;
 }
 $help_url = 'EN:Module_Third_Parties|FR:Module_Tiers|ES:Empresas';
-$title = (!empty($conf->global->SOCIETE_ADDRESSES_MANAGEMENT) ? $langs->trans("NewContact") : $langs->trans("NewContactAddress"));
+if (empty($object->id)) {
+    $title = (!empty($conf->global->SOCIETE_ADDRESSES_MANAGEMENT) ? $langs->trans("NewContact") : $langs->trans("NewContactAddress"));
+}
 
 llxHeader('', $title, $help_url);
 


### PR DESCRIPTION
# minor FIX (wrong tab title)

The title of the tab/window is always "New Contact/Address" even when the contact is not new.
