### PR TITLE
FIX: VAT may be wrong when supplier is not subject to VAT

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -1101,7 +1101,7 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 			<?php else : ?>
 				var tva_tx = parseFloat($('option:selected', this).attr('data-tvatx')); 					// When select is done from HTML select
 				if (isNaN(tva_tx)) { tva_tx = parseFloat(jQuery('#idprodfournprice').attr('data-tvatx'));}	// When select is done from HTML input with ajax autocomplete
-	
+
 				var default_vat_code = $('option:selected', this).attr('data-default-vat-code');							 					// When select is done from HTML select
 				if (typeof default_vat_code === 'undefined') { default_vat_code = jQuery('#idprodfournprice').attr('data-default-vat-code');}	// When select is done from HTML input with ajax autocomplete
 			<?php endif; ?>

--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -1095,11 +1095,16 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 			var discount = parseFloat($('option:selected', this).attr('data-discount'));
 			if (isNaN(discount)) { discount = parseFloat(jQuery('#idprodfournprice').attr('data-discount'));}
 
-			var tva_tx = parseFloat($('option:selected', this).attr('data-tvatx')); 					// When select is done from HTML select
-			if (isNaN(tva_tx)) { tva_tx = parseFloat(jQuery('#idprodfournprice').attr('data-tvatx'));}	// When select is done from HTML input with ajax autocomplete
-
-			var default_vat_code = $('option:selected', this).attr('data-default-vat-code');							 					// When select is done from HTML select
-			if (typeof default_vat_code === 'undefined') { default_vat_code = jQuery('#idprodfournprice').attr('data-default-vat-code');}	// When select is done from HTML input with ajax autocomplete
+			<?php if (($object->element == 'supplier_proposal' || $object->element == 'order_supplier' || $object->element == 'invoice_supplier' || $object->element == 'invoice_supplier_rec') && !$seller->tva_assuj) : ?>
+				var tva_tx = .0;
+				var default_vat_code = null;
+			<?php else : ?>
+				var tva_tx = parseFloat($('option:selected', this).attr('data-tvatx')); 					// When select is done from HTML select
+				if (isNaN(tva_tx)) { tva_tx = parseFloat(jQuery('#idprodfournprice').attr('data-tvatx'));}	// When select is done from HTML input with ajax autocomplete
+	
+				var default_vat_code = $('option:selected', this).attr('data-default-vat-code');							 					// When select is done from HTML select
+				if (typeof default_vat_code === 'undefined') { default_vat_code = jQuery('#idprodfournprice').attr('data-default-vat-code');}	// When select is done from HTML input with ajax autocomplete
+			<?php endif; ?>
 
 			var stringforvatrateselection = tva_tx;
 			if (typeof default_vat_code != 'undefined' && default_vat_code != null && default_vat_code != '') {


### PR DESCRIPTION
When selecting a product on a supplier object (proposal, order, invoice), if the supplier is not subject to VAT,  display is ok (VAT 
 = 0%), but the hidden input may be not !