### PR TITLE
Fix: content-type haeder missing for webhook

### DIFF
--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -97,7 +97,7 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 
 				$jsonstr = json_encode($resobject);
 
-				$response = getURLContent($tmpobject->url, 'POST', $jsonstr, 1, array(), array('http', 'https'), 0, -1);
+				$response = getURLContent($tmpobject->url, 'POST', $jsonstr, 1, array('content-type:application/json'), array('http', 'https'), 0, -1);
 				if (empty($response['curl_error_no']) && $response['http_code'] >= 200 && $response['http_code'] < 300) {
 					$nbPosts++;
 				} else {


### PR DESCRIPTION
Data sent by webhooks is encoded in JSON and sent using the CURLOPT_POSTFIELDS function in cURL. However, the Content-Type header is not explicitly specified. By default, cURL automatically sets the Content-Type header to application/x-www-form-urlencoded, which can cause issues with certain applications. 
To avoid this, I explicitly set the Content-Type header to application/json. This ensures that the data is sent in the correct format and that applications receiving the data can process it correctly.