### PR TITLE
FIX: PUT /thirdparties/{id} and PUT /contacts/{id} should throw exception if update returns < 0 + other issues

### DIFF
--- a/htdocs/societe/class/api_contacts.class.php
+++ b/htdocs/societe/class/api_contacts.class.php
@@ -65,7 +65,7 @@ class Contacts extends DolibarrApi
 	 * @param 	int    $id                  ID of contact
 	 * @param   int    $includecount        Count and return also number of elements the contact is used as a link for
 	 * @param   int    $includeroles        Includes roles of the contact
-	 * @return 	array|mixed data without useless information
+	 * @return 	object data without useless information
 	 *
 	 * @throws 	RestException
 	 */
@@ -304,9 +304,12 @@ class Contacts extends DolibarrApi
 	/**
 	 * Update contact
 	 *
-	 * @param int   $id             Id of contact to update
-	 * @param array $request_data   Datas
-	 * @return int
+	 * @param int $id Id of contact to update
+	 * @param array $request_data Datas
+	 * @return object  Representation of the Contact
+	 * @throws RestException 401
+	 * @throws RestException 404
+	 * @throws RestException 500
 	 */
 	public function put($id, $request_data = null)
 	{
@@ -334,11 +337,11 @@ class Contacts extends DolibarrApi
 			$this->contact->setNoEmail($this->contact->no_email);
 		}
 
-		if ($this->contact->update($id, DolibarrApiAccess::$user, 1, 'update')) {
+		if ($this->contact->update($id, DolibarrApiAccess::$user, 0, 'update') > 0) {
 			return $this->get($id);
+		} else {
+			throw new RestException(500, $this->contact->error);
 		}
-
-		return false;
 	}
 
 	/**

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -68,7 +68,7 @@ class Thirdparties extends DolibarrApi
 	 * Return an array with thirdparty informations
 	 *
 	 * @param 	int 	$id Id of third party to load
-	 * @return 	array|mixed Cleaned Societe object
+	 * @return 	object Cleaned Societe object
 	 *
 	 * @throws 	RestException
 	 */
@@ -277,7 +277,10 @@ class Thirdparties extends DolibarrApi
 	 *
 	 * @param int   $id             Id of thirdparty to update
 	 * @param array $request_data   Datas
-	 * @return array|mixed|boolean
+	 * @return object
+	 * @throws RestException 401
+	 * @throws RestException 404
+	 * @throws RestException 500
 	 */
 	public function put($id, $request_data = null)
 	{
@@ -305,11 +308,11 @@ class Thirdparties extends DolibarrApi
 			$this->company->setNoEmail($this->company->no_email);
 		}
 
-		if ($this->company->update($id, DolibarrApiAccess::$user, 1, '', '', 'update', 1)) {
+		if ($this->company->update($id, DolibarrApiAccess::$user, 1, '', '', 'update', 1) > 0) {
 			return $this->get($id);
+		} else {
+			throw new RestException(500, $this->company->error);
 		}
-
-		return false;
 	}
 
 	/**
@@ -1790,7 +1793,7 @@ class Thirdparties extends DolibarrApi
 	 * Clean sensible object datas
 	 *
 	 * @param   Object  $object     Object to clean
-	 * @return  array|mixed         Object with cleaned properties
+	 * @return  object         Object with cleaned properties
 	 */
 	protected function _cleanObjectDatas($object)
 	{
@@ -1873,7 +1876,7 @@ class Thirdparties extends DolibarrApi
 	 * @param    string	$idprof6		Prof id 6 of third party (Warning, this can return several records)
 	 * @param    string	$email   		Email of third party (Warning, this can return several records)
 	 * @param    string	$ref_alias  Name_alias of third party (Warning, this can return several records)
-	 * @return array|mixed cleaned Societe object
+	 * @return object cleaned Societe object
 	 *
 	 * @throws RestException
 	 */


### PR DESCRIPTION
# FIX #29594
Now I really think setting the `notrigger` param to 1 when calling `Contact::update` was just a copy/paste mistake (because it makes sense for the 3rd param of `Societe::update` to be 1 since this parameter is `call_trigger` and does the opposite of `notrigger`).

I also include in this PR a missing 500 throw when the endpoint fails to update the object (both Contact and Societe) + some minor PHPDoc inaccuracies.

@eldy I know you usually don't want to change REST API behaviour in released versions of Dolibarr even when the behaviour is arguably wrong, so if you feel that this change is significant enough, feel free to change the target branch to `develop`.

