### PR TITLE
New declare dictionaries more easily

### DIFF
--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -233,7 +233,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	/**
 	 * @var array dictionaries description
 	 */
-	public $dictionaries;
+	public $dictionaries = array();
 
 	/**
 	 * @var array tabs description
@@ -2631,5 +2631,32 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 			}
 		}
 		return 0;
+	}
+
+	/**
+	 * Helper method to declare dictionaries one at a time (rather than declaring dictionaries property by property).
+	 *
+	 * @param array $dictionaryArray Array describing one dictionary. Keys are:
+	 *                               'name',        table name (without prefix)
+	 *                               'lib',         dictionary label
+	 *                               'sql',         query for select
+	 *                               'sqlsort',     sort order
+	 *                               'field',       comma-separated list of fields to select
+	 *                               'fieldvalue',  list of columns used for editing existing rows
+	 *                               'fieldinsert', list of columns used for inserting new rows
+	 *                               'rowid',       name of the technical ID (primary key) column, usually 'rowid'
+	 *                               'cond',        condition for the dictionary to be shown / active
+	 *                               'help',        optional array of translation keys by column for tooltips
+	 *                               'fieldcheck'   (appears to be unused)
+	 * @param string $langs Optional translation file to include (appears to be unused)
+	 * @return void
+	 */
+	protected function declareNewDictionary($dictionaryArray, $langs = '')
+	{
+		$fields = array('name', 'lib', 'sql', 'sqlsort', 'field', 'fieldvalue', 'fieldinsert', 'rowid', 'cond', 'help', 'fieldcheck');
+		foreach ($fields as $field) {
+			$this->dictionaries['tab' . $field][] = $dictionaryArray[$field];
+		}
+		if ($langs && !in_array($langs, $this->dictionaries[$langs])) $this->dictionaries['langs'][] = $langs;
 	}
 }

--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -427,14 +427,14 @@ class modTicket extends DolibarrModules
 		}
 
 		$sql = array(
-			array("sql" => "insert into llx_c_type_contact(rowid, element, source, code, libelle, active ) values (110120, 'ticket',  'internal', 'SUPPORTTEC', 'Utilisateur assigné au ticket', 1);", "ignoreerror" => 1),
-			array("sql" => "insert into llx_c_type_contact(rowid, element, source, code, libelle, active ) values (110121, 'ticket',  'internal', 'CONTRIBUTOR', 'Intervenant', 1);", "ignoreerror" => 1),
-			array("sql" => "insert into llx_c_type_contact(rowid, element, source, code, libelle, active ) values (110122, 'ticket',  'external', 'SUPPORTCLI', 'Contact client suivi incident', 1);", "ignoreerror" => 1),
-			array("sql" => "insert into llx_c_type_contact(rowid, element, source, code, libelle, active ) values (110123, 'ticket',  'external', 'CONTRIBUTOR', 'Intervenant', 1);", "ignoreerror" => 1),
+			array("sql" => "insert into ".$this->db->prefix()."c_type_contact(rowid, element, source, code, libelle, active ) values (110120, 'ticket',  'internal', 'SUPPORTTEC', 'Utilisateur assigné au ticket', 1);", "ignoreerror" => 1),
+			array("sql" => "insert into ".$this->db->prefix()."c_type_contact(rowid, element, source, code, libelle, active ) values (110121, 'ticket',  'internal', 'CONTRIBUTOR', 'Intervenant', 1);", "ignoreerror" => 1),
+			array("sql" => "insert into ".$this->db->prefix()."c_type_contact(rowid, element, source, code, libelle, active ) values (110122, 'ticket',  'external', 'SUPPORTCLI', 'Contact client suivi incident', 1);", "ignoreerror" => 1),
+			array("sql" => "insert into ".$this->db->prefix()."c_type_contact(rowid, element, source, code, libelle, active ) values (110123, 'ticket',  'external', 'CONTRIBUTOR', 'Intervenant', 1);", "ignoreerror" => 1),
 			// remove old settings
-			"DELETE FROM ".MAIN_DB_PREFIX."document_model WHERE nom = 'TICKET_ADDON_PDF_ODT_PATH' AND type = 'ticket' AND entity = ".((int) $conf->entity),
+			"DELETE FROM ".$this->db->prefix()."document_model WHERE nom = 'TICKET_ADDON_PDF_ODT_PATH' AND type = 'ticket' AND entity = ".((int) $conf->entity),
 			// activate default odt templates
-			array("sql" => "INSERT INTO ".MAIN_DB_PREFIX."document_model (nom, type, libelle, entity, description) VALUES('generic_ticket_odt','ticket','ODT templates',".((int) $conf->entity).",'TICKET_ADDON_PDF_ODT_PATH');", "ignoreerror" => 1),
+			array("sql" => "INSERT INTO ".$this->db->prefix()."document_model (nom, type, libelle, entity, description) VALUES('generic_ticket_odt','ticket','ODT templates',".((int) $conf->entity).",'TICKET_ADDON_PDF_ODT_PATH');", "ignoreerror" => 1),
 		);
 
 		return $this->_init($sql, $options);

--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -134,38 +134,74 @@ class modTicket extends DolibarrModules
 			$conf->ticket = new stdClass();
 			$conf->ticket->enabled = 0;
 		}
-		$this->dictionaries = array(
-			'langs' => 'ticket',
-			'tabname' => array(
-				"c_ticket_type",
-				"c_ticket_severity",
-				"c_ticket_category",
-				"c_ticket_resolution"
-			),
-			'tablib' => array(
-				"TicketDictType",
-				"TicketDictSeverity",
-				"TicketDictCategory",
-				"TicketDictResolution"
-			),
-			'tabsql' => array(
-				'SELECT f.rowid as rowid, f.code, f.pos, f.label, f.active, f.use_default, f.entity FROM '.MAIN_DB_PREFIX.'c_ticket_type as f WHERE f.entity IN ('.getEntity('c_ticket_type').')',
-				'SELECT f.rowid as rowid, f.code, f.pos, f.label, f.active, f.use_default, f.entity FROM '.MAIN_DB_PREFIX.'c_ticket_severity as f WHERE f.entity IN ('.getEntity('c_ticket_severity').')',
-				'SELECT f.rowid as rowid, f.code, f.pos, f.label, f.active, f.use_default, f.public, f.fk_parent, f.entity FROM '.MAIN_DB_PREFIX.'c_ticket_category as f WHERE f.entity IN ('.getEntity('c_ticket_category').')',
-				'SELECT f.rowid as rowid, f.code, f.pos, f.label, f.active, f.use_default, f.entity FROM '.MAIN_DB_PREFIX.'c_ticket_resolution as f WHERE f.entity IN ('.getEntity('c_ticket_resolution').')'
-			),
-			'tabsqlsort' => array("pos ASC", "pos ASC", "pos ASC", "pos ASC"),
-			'tabfield' => array("code,label,pos,use_default", "code,label,pos,use_default", "code,label,pos,use_default,public,fk_parent", "code,label,pos,use_default"),
-			'tabfieldvalue' => array("code,label,pos,use_default", "code,label,pos,use_default", "code,label,pos,use_default,public,fk_parent", "code,label,pos,use_default"),
-			'tabfieldinsert' => array("code,label,pos,use_default,entity", "code,label,pos,use_default,entity", "code,label,pos,use_default,public,fk_parent,entity", "code,label,pos,use_default,entity"),
-			'tabrowid' => array("rowid", "rowid", "rowid", "rowid"),
-			'tabcond' => array(isModEnabled("ticket"), isModEnabled("ticket"), isModEnabled("ticket"), isModEnabled("ticket") && getDolGlobalString('TICKET_ENABLE_RESOLUTION')),
-			'tabhelp' => array(
-				array('code' => $langs->trans("EnterAnyCode"), 'use_default' => $langs->trans("Enter0or1")),
-				array('code' => $langs->trans("EnterAnyCode"), 'use_default' => $langs->trans("Enter0or1")),
-				array('code' => $langs->trans("EnterAnyCode"), 'use_default' => $langs->trans("Enter0or1"), 'public' => $langs->trans("Enter0or1").'<br>'.$langs->trans("TicketGroupIsPublicDesc"), 'fk_parent' => $langs->trans("IfThisCategoryIsChildOfAnother")),
-				array('code' => $langs->trans("EnterAnyCode"), 'use_default' => $langs->trans("Enter0or1"))
-			),
+
+		// Dictionary of ticket types
+		$this->declareNewDictionary(
+			array(
+				'name' => 'c_ticket_type',
+				'lib' => 'TicketDictType',
+				'sql' => 'SELECT f.rowid as rowid, f.code, f.pos, f.label, f.active, f.use_default, f.entity FROM '.$db->prefix().'c_ticket_type as f WHERE f.entity IN ('.getEntity('c_ticket_type').')',
+				'sqlsort' => 'pos ASC',
+				'field' => 'code,label,pos,use_default',
+				'fieldvalue' => 'code,label,pos,use_default',
+				'fieldinsert' => 'code,label,pos,use_default,entity',
+				'rowid' => 'rowid',
+				'cond' => isModEnabled('ticket'),
+				'help' => array('code' => $langs->trans('EnterAnyCode'), 'use_default' => $langs->trans('Enter0or1'))
+			)
+		);
+
+		// Dictionary of ticket severities
+		$this->declareNewDictionary(
+			array(
+				'name' => 'c_ticket_severity',
+				'lib' => 'TicketDictSeverity',
+				'sql' => 'SELECT f.rowid as rowid, f.code, f.pos, f.label, f.active, f.use_default, f.entity FROM '.$db->prefix().'c_ticket_severity as f WHERE f.entity IN ('.getEntity('c_ticket_severity').')',
+				'sqlsort' => 'pos ASC',
+				'field' => 'code,label,pos,use_default',
+				'fieldvalue' => 'code,label,pos,use_default',
+				'fieldinsert' => 'code,label,pos,use_default,entity',
+				'rowid' => 'rowid',
+				'cond' => isModEnabled('ticket'),
+				'help' => array('code' => $langs->trans('EnterAnyCode'), 'use_default' => $langs->trans('Enter0or1'))
+			)
+		);
+
+		// Dictionary of ticket categories
+		$this->declareNewDictionary(
+			array(
+				'name' => 'c_ticket_category',
+				'lib' => 'TicketDictCategory',
+				'sql' => 'SELECT f.rowid as rowid, f.code, f.pos, f.label, f.active, f.use_default, f.public, f.fk_parent, f.entity FROM '.$db->prefix().'c_ticket_category as f WHERE f.entity IN ('.getEntity('c_ticket_category').')',
+				'sqlsort' => 'pos ASC',
+				'field' => 'code,label,pos,use_default,public,fk_parent',
+				'fieldvalue' => 'code,label,pos,use_default,public,fk_parent',
+				'fieldinsert' => 'code,label,pos,use_default,public,fk_parent,entity',
+				'rowid' => 'rowid',
+				'cond' => isModEnabled('ticket'),
+				'help' => array(
+					'code' => $langs->trans('EnterAnyCode'),
+					'use_default' => $langs->trans('Enter0or1'),
+					'public' => $langs->trans('Enter0or1').'<br>'.$langs->trans('TicketGroupIsPublicDesc'),
+					'fk_parent' => $langs->trans('IfThisCategoryIsChildOfAnother')
+				)
+			)
+		);
+
+		// (apparently unused) Dictionary of ticket resolutions
+		$this->declareNewDictionary(
+			array(
+				'name' => 'c_ticket_resolution',
+				'lib' => 'TicketDictResolution',
+				'sql' => 'SELECT f.rowid as rowid, f.code, f.pos, f.label, f.active, f.use_default, f.entity FROM '.$db->prefix().'c_ticket_resolution as f WHERE f.entity IN ('.getEntity('c_ticket_resolution').')',
+				'sqlsort' => 'pos ASC',
+				'field' => 'code,label,pos,use_default',
+				'fieldvalue' => 'code,label,pos,use_default',
+				'fieldinsert' => 'code,label,pos,use_default,entity',
+				'rowid' => 'rowid',
+				'cond' => isModEnabled('ticket') && getDolGlobalString('TICKET_ENABLE_RESOLUTION'),
+				'help' => array('code' => $langs->trans('EnterAnyCode'), 'use_default' => $langs->trans('Enter0or1'))
+			)
 		);
 
 		// Boxes


### PR DESCRIPTION
# NEW make dictionary declaration easier
Currently, dictionaries are declared property by property. I find this somewhat cumbersome when there are more than 2 or 3… in one module we have 11 dictionaries and we have to count all the time to make sure we are not mixing up dictionaries with each other.

The new method I propose doesn't change the structure of the array `$objModule->dictionaries`. It doesn't force anyone to use it (dictionaries can be declared the current way), but simply adds an easier way to complete that array.

```php
// current method: concise but confusing
$this->dictionaries = [
  'tabname' => ['c_animal', 'c_vegetable'],
  'tabfield' => ['name,is_mammal,can_fly,can_swim,can_run,can_dig', 'name,nutritional_value,taste_ratings,min_usda_zone'],
  //etc. (imagine if there are 11 dictionaries instead of 2)
];

// new method: lengthier but way easier
$this->declareNewDictionary([
  'name' => 'c_animal',
  'field' => 'name,is_mammal,can_fly,can_swim,can_run,can_dig',
  //etc.
]);
$this->declareNewDictionary([
  'name' => 'c_vegetable',
  'field' => 'name,nutritional_value,taste_ratings,min_usda_zone',
  //etc.
]);
```

To illustrate further, I included in this PR the redefinition of the dictionaries for the Tickets module.

If this proves useful, I would also like to add similar helper methods for declaring imports and exports.