### PR TITLE
NEW Add option to open files in new tab

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -891,7 +891,7 @@ class FormFile
 						$out .= '<span class="spanoverflow">';
 					}
 					$out .= '<a class="documentdownload paddingright" ';
-					if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB')) {
+					if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB') && getDolGlobalString('MAIN_DISABLE_FORCE_SAVEAS')) {
 						print 'target="_blank" ';
 					}
 					print 'href="'.$documenturl.'?modulepart='.$modulepart.'&file='.urlencode($relativepath).($param ? '&'.$param : '').'"';
@@ -1134,7 +1134,7 @@ class FormFile
 
 				// Download
 				$tmpout .= '<li class="nowrap"><a class="pictopreview nowrap" ';
-				if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB')) {
+				if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB') && getDolGlobalString('MAIN_DISABLE_FORCE_SAVEAS')) {
 						$tmpout .= 'target="_blank" ';
 				}
 				$tmpout .= 'href="'.DOL_URL_ROOT.'/document.php?modulepart='.$modulepart.'&amp;entity='.$entity.'&amp;file='.urlencode($relativepath).'"';
@@ -1382,7 +1382,7 @@ class FormFile
 					// Show file name with link to download
 					//print "XX".$file['name'];	//$file['name'] must be utf8
 					print '<a class="paddingright valignmiddle" ';
-					if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB')) {
+					if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB') && getDolGlobalString('MAIN_DISABLE_FORCE_SAVEAS')) {
 						print 'target="_blank" ';
 					}
 					print 'href="'.DOL_URL_ROOT.'/document.php?modulepart='.$modulepart;
@@ -1962,7 +1962,7 @@ class FormFile
 				print '<td>';
 				//print "XX".$file['name']; //$file['name'] must be utf8
 				print '<a ';
-				if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB')) {
+				if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB') && getDolGlobalString('MAIN_DISABLE_FORCE_SAVEAS')) {
 					print 'target="_blank" ';
 				}
 				print 'href="'.DOL_URL_ROOT.'/document.php?modulepart='.urlencode($modulepart);

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -891,7 +891,7 @@ class FormFile
 						$out .= '<span class="spanoverflow">';
 					}
 					$out .= '<a class="documentdownload paddingright" ';
-					if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB') && getDolGlobalString('MAIN_DISABLE_FORCE_SAVEAS')) {
+					if (getDolGlobalInt('MAIN_DISABLE_FORCE_SAVEAS') == 2) {
 						$out .= 'target="_blank" ';
 					}
 					$out .= 'href="'.$documenturl.'?modulepart='.$modulepart.'&file='.urlencode($relativepath).($param ? '&'.$param : '').'"';
@@ -1134,7 +1134,7 @@ class FormFile
 
 				// Download
 				$tmpout .= '<li class="nowrap"><a class="pictopreview nowrap" ';
-				if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB') && getDolGlobalString('MAIN_DISABLE_FORCE_SAVEAS')) {
+				if (getDolGlobalInt('MAIN_DISABLE_FORCE_SAVEAS') == 2) {
 						$tmpout .= 'target="_blank" ';
 				}
 				$tmpout .= 'href="'.DOL_URL_ROOT.'/document.php?modulepart='.$modulepart.'&amp;entity='.$entity.'&amp;file='.urlencode($relativepath).'"';
@@ -1382,7 +1382,7 @@ class FormFile
 					// Show file name with link to download
 					//print "XX".$file['name'];	//$file['name'] must be utf8
 					print '<a class="paddingright valignmiddle" ';
-					if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB') && getDolGlobalString('MAIN_DISABLE_FORCE_SAVEAS')) {
+					if (getDolGlobalInt('MAIN_DISABLE_FORCE_SAVEAS') == 2) {
 						print 'target="_blank" ';
 					}
 					print 'href="'.DOL_URL_ROOT.'/document.php?modulepart='.$modulepart;
@@ -1962,7 +1962,7 @@ class FormFile
 				print '<td>';
 				//print "XX".$file['name']; //$file['name'] must be utf8
 				print '<a ';
-				if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB') && getDolGlobalString('MAIN_DISABLE_FORCE_SAVEAS')) {
+				if (getDolGlobalInt('MAIN_DISABLE_FORCE_SAVEAS') == 2) {
 					print 'target="_blank" ';
 				}
 				print 'href="'.DOL_URL_ROOT.'/document.php?modulepart='.urlencode($modulepart);

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -890,7 +890,11 @@ class FormFile
 					} else {
 						$out .= '<span class="spanoverflow">';
 					}
-					$out .= '<a class="documentdownload paddingright" href="'.$documenturl.'?modulepart='.$modulepart.'&file='.urlencode($relativepath).($param ? '&'.$param : '').'"';
+					$out .= '<a class="documentdownload paddingright" ';
+					if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB')) {
+						print 'target="_blank" ';
+					}
+					print 'href="'.$documenturl.'?modulepart='.$modulepart.'&file='.urlencode($relativepath).($param ? '&'.$param : '').'"';
 
 					$mime = dol_mimetype($relativepath, '', 0);
 					if (preg_match('/text/', $mime)) {
@@ -1081,8 +1085,8 @@ class FormFile
 		$out .= '<!-- html.formfile::getDocumentsLink -->'."\n";
 		if (!empty($file_list)) {
 			$out = '<dl class="dropdown inline-block">
-    			<dt><a data-ajax="false" href="#" onClick="return false;">'.img_picto('', 'listlight', '', 0, 0, 0, '', $morecss).'</a></dt>
-    			<dd><div class="multichoicedoc" style="position:absolute;left:100px;" ><ul class="ulselectedfields">';
+				<dt><a data-ajax="false" href="#" onClick="return false;">'.img_picto('', 'listlight', '', 0, 0, 0, '', $morecss).'</a></dt>
+				<dd><div class="multichoicedoc" style="position:absolute;left:100px;" ><ul class="ulselectedfields">';
 			$tmpout = '';
 
 			// Loop on each file found
@@ -1129,7 +1133,11 @@ class FormFile
 				}
 
 				// Download
-				$tmpout .= '<li class="nowrap"><a class="pictopreview nowrap" href="'.DOL_URL_ROOT.'/document.php?modulepart='.$modulepart.'&amp;entity='.$entity.'&amp;file='.urlencode($relativepath).'"';
+				$tmpout .= '<li class="nowrap"><a class="pictopreview nowrap" ';
+				if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB')) {
+						$tmpout .= 'target="_blank" ';
+				}
+				$tmpout .= 'href="'.DOL_URL_ROOT.'/document.php?modulepart='.$modulepart.'&amp;entity='.$entity.'&amp;file='.urlencode($relativepath).'"';
 				$mime = dol_mimetype($relativepath, '', 0);
 				if (preg_match('/text/', $mime)) {
 					$tmpout .= ' target="_blank" rel="noopener noreferrer"';
@@ -1141,7 +1149,7 @@ class FormFile
 			}
 			$out .= $tmpout;
 			$out .= '</ul></div></dd>
-    			</dl>';
+				</dl>';
 
 			if (!$found) {
 				$out = '';
@@ -1373,7 +1381,11 @@ class FormFile
 
 					// Show file name with link to download
 					//print "XX".$file['name'];	//$file['name'] must be utf8
-					print '<a class="paddingright valignmiddle" href="'.DOL_URL_ROOT.'/document.php?modulepart='.$modulepart;
+					print '<a class="paddingright valignmiddle" ';
+					if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB')) {
+						print 'target="_blank" ';
+					}
+					print 'href="'.DOL_URL_ROOT.'/document.php?modulepart='.$modulepart;
 					if ($forcedownload) {
 						print '&attachment=1';
 					}
@@ -1949,7 +1961,11 @@ class FormFile
 				// Check if document source has external module part, if it the case use it for module part on document.php
 				print '<td>';
 				//print "XX".$file['name']; //$file['name'] must be utf8
-				print '<a href="'.DOL_URL_ROOT.'/document.php?modulepart='.urlencode($modulepart);
+				print '<a ';
+				if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB')) {
+					print 'target="_blank" ';
+				}
+				print 'href="'.DOL_URL_ROOT.'/document.php?modulepart='.urlencode($modulepart);
 				if ($forcedownload) {
 					print '&attachment=1';
 				}

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -892,9 +892,9 @@ class FormFile
 					}
 					$out .= '<a class="documentdownload paddingright" ';
 					if (getDolGlobalString('MAIN_FILES_OPEN_NEWTAB') && getDolGlobalString('MAIN_DISABLE_FORCE_SAVEAS')) {
-						print 'target="_blank" ';
+						$out .= 'target="_blank" ';
 					}
-					print 'href="'.$documenturl.'?modulepart='.$modulepart.'&file='.urlencode($relativepath).($param ? '&'.$param : '').'"';
+					$out .= 'href="'.$documenturl.'?modulepart='.$modulepart.'&file='.urlencode($relativepath).($param ? '&'.$param : '').'"';
 
 					$mime = dol_mimetype($relativepath, '', 0);
 					if (preg_match('/text/', $mime)) {


### PR DESCRIPTION
This is a feature that is recurringly requested along with the modification of "MAIN_DISABLE_FORCE_SAVEAS"

See for exemple : 
https://www.dolibarr.org/forum/t/option-to-open-pdf-in-new-window/8389
https://www.dolibarr.org/forum/t/open-links-in-new-tab/14791
https://www.dolibarr.fr/forum/t/ouverture-des-pdf-dans-une-nouvelle-page/30766
https://www.dolibarr.fr/forum/t/pdf-dans-une-autre-fenetre/8058
https://www.dolibarr.fr/forum/t/ouverture-des-pdf/9447

In this PR, it is adding the option "MAIN_FILES_OPEN_NEWTAB" to open most files inside a newtab if it is not empty.

I will update the wiki once/if this PR is merge.

I suggest is to make this behavior as defaut, as it is the main behavior of all the main tools on the web. 
In compensation, we could have an option "MAIN_FILES_OPEN_SAMETAB".
But it require consent from the experts who prefer otherwise, because the consensus will be status quo.