### PR TITLE
Fix deposit from element with discount

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1508,7 +1508,7 @@ if (empty($reshook)) {
 
 								$TTotalByTva = array();
 								foreach ($srcobject->lines as &$line) {
-									if (!empty($line->special_code)) {
+									if (!empty($line->special_code) && empty($line->info_bits)) {
 										continue;
 									}
 									$TTotalByTva[$line->tva_tx] += $line->total_ttc;


### PR DESCRIPTION
When you create a deposit (amount type) from an element with more than one VAT rate and a discount line the calculation doesn't take in account the discount line.