### PR TITLE
Product/Stock Hook formObjectOptions can replace

### DIFF
--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -812,7 +812,7 @@ if ($id > 0 || $ref) {
 					$result = $object->load_stats_sending(0, '2', 1, $filterShipmentStatus);
 					$helpondiff .= $langs->trans("ProductQtyInShipmentAlreadySent").': '.$object->stats_expedition['qty'];
 				}
-	
+
 				// Number of supplier order running
 				if (isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) {
 					if ($found) {

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -725,178 +725,179 @@ if ($id > 0 || $ref) {
 			$parameters = array();
 			$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 			print $hookmanager->resPrint;
-
-			print '</table>';
-
-			print '</div>';
-			print '<div class="fichehalfright"><div class="underbanner clearboth"></div>';
-
-			print '<table class="border tableforfield centpercent">';
-
-			// Stock alert threshold
-			print '<tr><td>'.$form->editfieldkey($form->textwithpicto($langs->trans("StockLimit"), $langs->trans("StockLimitDesc"), 1), 'seuil_stock_alerte', $object->seuil_stock_alerte, $object, $user->hasRight('produit', 'creer')).'</td><td>';
-			print $form->editfieldval("StockLimit", 'seuil_stock_alerte', $object->seuil_stock_alerte, $object, $user->hasRight('produit', 'creer'), 'string');
-			print '</td></tr>';
-
-			// Desired stock
-			print '<tr><td>'.$form->editfieldkey($form->textwithpicto($langs->trans("DesiredStock"), $langs->trans("DesiredStockDesc"), 1), 'desiredstock', $object->desiredstock, $object, $user->hasRight('produit', 'creer'));
-			print '</td><td>';
-			print $form->editfieldval("DesiredStock", 'desiredstock', $object->desiredstock, $object, $user->hasRight('produit', 'creer'), 'string');
-			print '</td></tr>';
-
-			// Real stock
-			$text_stock_options = $langs->trans("RealStockDesc").'<br>';
-			$text_stock_options .= $langs->trans("RealStockWillAutomaticallyWhen").'<br>';
-			$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_SHIPMENT') || getDolGlobalString('STOCK_CALCULATE_ON_SHIPMENT_CLOSE') ? '- '.$langs->trans("DeStockOnShipment").'<br>' : '');
-			$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_VALIDATE_ORDER') ? '- '.$langs->trans("DeStockOnValidateOrder").'<br>' : '');
-			$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_BILL') ? '- '.$langs->trans("DeStockOnBill").'<br>' : '');
-			$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_BILL') ? '- '.$langs->trans("ReStockOnBill").'<br>' : '');
-			$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER') ? '- '.$langs->trans("ReStockOnValidateOrder").'<br>' : '');
-			$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER') ? '- '.$langs->trans("ReStockOnDispatchOrder").'<br>' : '');
-			$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_RECEPTION') || getDolGlobalString('STOCK_CALCULATE_ON_RECEPTION_CLOSE') ? '- '.$langs->trans("StockOnReception").'<br>' : '');
-			$parameters = array();
-			$reshook = $hookmanager->executeHooks('physicalStockTextStockOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
-			if ($reshook > 0) {
-				$text_stock_options = $hookmanager->resPrint;
-			} elseif ($reshook == 0) {
-				$text_stock_options .= $hookmanager->resPrint;
-			} else {
-				setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
-			}
-
-			print '<tr><td>';
-			print $form->textwithpicto($langs->trans("PhysicalStock"), $text_stock_options, 1);
-			print '</td>';
-			print '<td>'.price2num($object->stock_reel, 'MS');
-			if ($object->seuil_stock_alerte != '' && ($object->stock_reel < $object->seuil_stock_alerte)) {
-				print ' '.img_warning($langs->trans("StockLowerThanLimit", $object->seuil_stock_alerte));
-			}
-
-			print ' &nbsp; &nbsp;<a href="'.DOL_URL_ROOT.'/product/stock/stockatdate.php?productid='.$object->id.'">'.$langs->trans("StockAtDate").'</a>';
-			print '</td>';
-			print '</tr>';
-
-			$stocktheo = price2num($object->stock_theorique, 'MS');
-
-			$found = 0;
-			$helpondiff = '<strong>'.$langs->trans("StockDiffPhysicTeoric").':</strong><br>';
-			// Number of sales orders running
-			if (isModEnabled('order')) {
-				if ($found) {
-					$helpondiff .= '<br>';
+			if(empty($reshook)){
+				print '</table>';
+	
+				print '</div>';
+				print '<div class="fichehalfright"><div class="underbanner clearboth"></div>';
+	
+				print '<table class="border tableforfield centpercent">';
+	
+				// Stock alert threshold
+				print '<tr><td>'.$form->editfieldkey($form->textwithpicto($langs->trans("StockLimit"), $langs->trans("StockLimitDesc"), 1), 'seuil_stock_alerte', $object->seuil_stock_alerte, $object, $user->hasRight('produit', 'creer')).'</td><td>';
+				print $form->editfieldval("StockLimit", 'seuil_stock_alerte', $object->seuil_stock_alerte, $object, $user->hasRight('produit', 'creer'), 'string');
+				print '</td></tr>';
+	
+				// Desired stock
+				print '<tr><td>'.$form->editfieldkey($form->textwithpicto($langs->trans("DesiredStock"), $langs->trans("DesiredStockDesc"), 1), 'desiredstock', $object->desiredstock, $object, $user->hasRight('produit', 'creer'));
+				print '</td><td>';
+				print $form->editfieldval("DesiredStock", 'desiredstock', $object->desiredstock, $object, $user->hasRight('produit', 'creer'), 'string');
+				print '</td></tr>';
+	
+				// Real stock
+				$text_stock_options = $langs->trans("RealStockDesc").'<br>';
+				$text_stock_options .= $langs->trans("RealStockWillAutomaticallyWhen").'<br>';
+				$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_SHIPMENT') || getDolGlobalString('STOCK_CALCULATE_ON_SHIPMENT_CLOSE') ? '- '.$langs->trans("DeStockOnShipment").'<br>' : '');
+				$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_VALIDATE_ORDER') ? '- '.$langs->trans("DeStockOnValidateOrder").'<br>' : '');
+				$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_BILL') ? '- '.$langs->trans("DeStockOnBill").'<br>' : '');
+				$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_BILL') ? '- '.$langs->trans("ReStockOnBill").'<br>' : '');
+				$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER') ? '- '.$langs->trans("ReStockOnValidateOrder").'<br>' : '');
+				$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER') ? '- '.$langs->trans("ReStockOnDispatchOrder").'<br>' : '');
+				$text_stock_options .= (getDolGlobalString('STOCK_CALCULATE_ON_RECEPTION') || getDolGlobalString('STOCK_CALCULATE_ON_RECEPTION_CLOSE') ? '- '.$langs->trans("StockOnReception").'<br>' : '');
+				$parameters = array();
+				$reshook = $hookmanager->executeHooks('physicalStockTextStockOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+				if ($reshook > 0) {
+					$text_stock_options = $hookmanager->resPrint;
+				} elseif ($reshook == 0) {
+					$text_stock_options .= $hookmanager->resPrint;
 				} else {
-					$found = 1;
+					setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 				}
-				$helpondiff .= $langs->trans("ProductQtyInCustomersOrdersRunning").': '.$object->stats_commande['qty'];
-				$result = $object->load_stats_commande(0, '0', 1);
-				if ($result < 0) {
-					dol_print_error($db, $object->error);
+	
+				print '<tr><td>';
+				print $form->textwithpicto($langs->trans("PhysicalStock"), $text_stock_options, 1);
+				print '</td>';
+				print '<td>'.price2num($object->stock_reel, 'MS');
+				if ($object->seuil_stock_alerte != '' && ($object->stock_reel < $object->seuil_stock_alerte)) {
+					print ' '.img_warning($langs->trans("StockLowerThanLimit", $object->seuil_stock_alerte));
 				}
-				$helpondiff .= ' <span class="opacitymedium">('.$langs->trans("ProductQtyInDraft").': '.$object->stats_commande['qty'].')</span>';
-			}
-
-			// Number of product from sales order already sent (partial shipping)
-			if (isModEnabled("shipping")) {
-				require_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php';
-				$filterShipmentStatus = '';
-				if (getDolGlobalString('STOCK_CALCULATE_ON_SHIPMENT')) {
-					$filterShipmentStatus = Expedition::STATUS_VALIDATED.','.Expedition::STATUS_CLOSED;
-				} elseif (getDolGlobalString('STOCK_CALCULATE_ON_SHIPMENT_CLOSE')) {
-					$filterShipmentStatus = Expedition::STATUS_CLOSED;
+	
+				print ' &nbsp; &nbsp;<a href="'.DOL_URL_ROOT.'/product/stock/stockatdate.php?productid='.$object->id.'">'.$langs->trans("StockAtDate").'</a>';
+				print '</td>';
+				print '</tr>';
+	
+				$stocktheo = price2num($object->stock_theorique, 'MS');
+	
+				$found = 0;
+				$helpondiff = '<strong>'.$langs->trans("StockDiffPhysicTeoric").':</strong><br>';
+				// Number of sales orders running
+				if (isModEnabled('order')) {
+					if ($found) {
+						$helpondiff .= '<br>';
+					} else {
+						$found = 1;
+					}
+					$helpondiff .= $langs->trans("ProductQtyInCustomersOrdersRunning").': '.$object->stats_commande['qty'];
+					$result = $object->load_stats_commande(0, '0', 1);
+					if ($result < 0) {
+						dol_print_error($db, $object->error);
+					}
+					$helpondiff .= ' <span class="opacitymedium">('.$langs->trans("ProductQtyInDraft").': '.$object->stats_commande['qty'].')</span>';
 				}
-				if ($found) {
-					$helpondiff .= '<br>';
+	
+				// Number of product from sales order already sent (partial shipping)
+				if (isModEnabled("shipping")) {
+					require_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php';
+					$filterShipmentStatus = '';
+					if (getDolGlobalString('STOCK_CALCULATE_ON_SHIPMENT')) {
+						$filterShipmentStatus = Expedition::STATUS_VALIDATED.','.Expedition::STATUS_CLOSED;
+					} elseif (getDolGlobalString('STOCK_CALCULATE_ON_SHIPMENT_CLOSE')) {
+						$filterShipmentStatus = Expedition::STATUS_CLOSED;
+					}
+					if ($found) {
+						$helpondiff .= '<br>';
+					} else {
+						$found = 1;
+					}
+					$result = $object->load_stats_sending(0, '2', 1, $filterShipmentStatus);
+					$helpondiff .= $langs->trans("ProductQtyInShipmentAlreadySent").': '.$object->stats_expedition['qty'];
+				}
+	
+				// Number of supplier order running
+				if (isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) {
+					if ($found) {
+						$helpondiff .= '<br>';
+					} else {
+						$found = 1;
+					}
+					$result = $object->load_stats_commande_fournisseur(0, '3,4', 1);
+					$helpondiff .= $langs->trans("ProductQtyInSuppliersOrdersRunning").': '.$object->stats_commande_fournisseur['qty'];
+					$result = $object->load_stats_commande_fournisseur(0, '0,1,2', 1);
+					if ($result < 0) {
+						dol_print_error($db, $object->error);
+					}
+					$helpondiff .= ' <span class="opacitymedium">('.$langs->trans("ProductQtyInDraftOrWaitingApproved").': '.$object->stats_commande_fournisseur['qty'].')</span>';
+				}
+	
+				// Number of product from supplier order already received (partial receipt)
+				if (isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) {
+					if ($found) {
+						$helpondiff .= '<br>';
+					} else {
+						$found = 1;
+					}
+					$helpondiff .= $langs->trans("ProductQtyInSuppliersShipmentAlreadyRecevied").': '.$object->stats_reception['qty'];
+				}
+	
+				// Number of product in production
+				if (isModEnabled('mrp')) {
+					if ($found) {
+						$helpondiff .= '<br>';
+					} else {
+						$found = 1;
+					}
+					$helpondiff .= $langs->trans("ProductQtyToConsumeByMO").': '.$object->stats_mrptoconsume['qty'].'<br>';
+					$helpondiff .= $langs->trans("ProductQtyToProduceByMO").': '.$object->stats_mrptoproduce['qty'];
+				}
+				$parameters = array('found' => &$found, 'id' => $object->id, 'includedraftpoforvirtual' => null);
+				$reshook = $hookmanager->executeHooks('virtualStockHelpOnDiff', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+				if ($reshook > 0) {
+					$helpondiff = $hookmanager->resPrint;
+				} elseif ($reshook == 0) {
+					$helpondiff .= $hookmanager->resPrint;
 				} else {
-					$found = 1;
+					setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 				}
-				$result = $object->load_stats_sending(0, '2', 1, $filterShipmentStatus);
-				$helpondiff .= $langs->trans("ProductQtyInShipmentAlreadySent").': '.$object->stats_expedition['qty'];
-			}
-
-			// Number of supplier order running
-			if (isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) {
-				if ($found) {
-					$helpondiff .= '<br>';
-				} else {
-					$found = 1;
+	
+	
+				// Calculating a theoretical value
+				print '<tr><td>';
+				print $form->textwithpicto($langs->trans("VirtualStock"), $langs->trans("VirtualStockDesc"));
+				print '</td>';
+				print "<td>";
+				//print (empty($stocktheo)?0:$stocktheo);
+				print $form->textwithpicto((empty($stocktheo) ? 0 : $stocktheo), $helpondiff);
+				if ($object->seuil_stock_alerte != '' && ($object->stock_theorique < $object->seuil_stock_alerte)) {
+					print ' '.img_warning($langs->trans("StockLowerThanLimit", $object->seuil_stock_alerte));
 				}
-				$result = $object->load_stats_commande_fournisseur(0, '3,4', 1);
-				$helpondiff .= $langs->trans("ProductQtyInSuppliersOrdersRunning").': '.$object->stats_commande_fournisseur['qty'];
-				$result = $object->load_stats_commande_fournisseur(0, '0,1,2', 1);
-				if ($result < 0) {
-					dol_print_error($db, $object->error);
+				print ' &nbsp; &nbsp;<a href="'.DOL_URL_ROOT.'/product/stock/stockatdate.php?mode=future&productid='.$object->id.'">'.$langs->trans("VirtualStockAtDate").'</a>';
+				print '</td>';
+				print '</tr>';
+	
+				// Last movement
+				if ($user->hasRight('stock', 'mouvement', 'lire')) {
+					$sql = "SELECT max(m.datem) as datem";
+					$sql .= " FROM ".MAIN_DB_PREFIX."stock_mouvement as m";
+					$sql .= " WHERE m.fk_product = ".((int) $object->id);
+					$resqlbis = $db->query($sql);
+					if ($resqlbis) {
+						$obj = $db->fetch_object($resqlbis);
+						$lastmovementdate = $db->jdate($obj->datem);
+					} else {
+						dol_print_error($db);
+					}
+					print '<tr><td class="tdtop">'.$langs->trans("LastMovement").'</td><td>';
+					if ($lastmovementdate) {
+						print dol_print_date($lastmovementdate, 'dayhour').' ';
+						print ' &nbsp; &nbsp; ';
+						print img_picto($langs->trans("StockMovement"), 'movement', 'class="pictofixedwidth"');
+						print '<a href="'.DOL_URL_ROOT.'/product/stock/movement_list.php?idproduct='.$object->id.'">'.$langs->trans("FullList").'</a>';
+					} else {
+						print img_picto($langs->trans("StockMovement"), 'movement', 'class="pictofixedwidth"');
+						print '<a href="'.DOL_URL_ROOT.'/product/stock/movement_list.php?idproduct='.$object->id.'">'.$langs->trans("None").'</a>';
+					}
+					print "</td></tr>";
 				}
-				$helpondiff .= ' <span class="opacitymedium">('.$langs->trans("ProductQtyInDraftOrWaitingApproved").': '.$object->stats_commande_fournisseur['qty'].')</span>';
-			}
-
-			// Number of product from supplier order already received (partial receipt)
-			if (isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) {
-				if ($found) {
-					$helpondiff .= '<br>';
-				} else {
-					$found = 1;
-				}
-				$helpondiff .= $langs->trans("ProductQtyInSuppliersShipmentAlreadyRecevied").': '.$object->stats_reception['qty'];
-			}
-
-			// Number of product in production
-			if (isModEnabled('mrp')) {
-				if ($found) {
-					$helpondiff .= '<br>';
-				} else {
-					$found = 1;
-				}
-				$helpondiff .= $langs->trans("ProductQtyToConsumeByMO").': '.$object->stats_mrptoconsume['qty'].'<br>';
-				$helpondiff .= $langs->trans("ProductQtyToProduceByMO").': '.$object->stats_mrptoproduce['qty'];
-			}
-			$parameters = array('found' => &$found, 'id' => $object->id, 'includedraftpoforvirtual' => null);
-			$reshook = $hookmanager->executeHooks('virtualStockHelpOnDiff', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
-			if ($reshook > 0) {
-				$helpondiff = $hookmanager->resPrint;
-			} elseif ($reshook == 0) {
-				$helpondiff .= $hookmanager->resPrint;
-			} else {
-				setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
-			}
-
-
-			// Calculating a theoretical value
-			print '<tr><td>';
-			print $form->textwithpicto($langs->trans("VirtualStock"), $langs->trans("VirtualStockDesc"));
-			print '</td>';
-			print "<td>";
-			//print (empty($stocktheo)?0:$stocktheo);
-			print $form->textwithpicto((empty($stocktheo) ? 0 : $stocktheo), $helpondiff);
-			if ($object->seuil_stock_alerte != '' && ($object->stock_theorique < $object->seuil_stock_alerte)) {
-				print ' '.img_warning($langs->trans("StockLowerThanLimit", $object->seuil_stock_alerte));
-			}
-			print ' &nbsp; &nbsp;<a href="'.DOL_URL_ROOT.'/product/stock/stockatdate.php?mode=future&productid='.$object->id.'">'.$langs->trans("VirtualStockAtDate").'</a>';
-			print '</td>';
-			print '</tr>';
-
-			// Last movement
-			if ($user->hasRight('stock', 'mouvement', 'lire')) {
-				$sql = "SELECT max(m.datem) as datem";
-				$sql .= " FROM ".MAIN_DB_PREFIX."stock_mouvement as m";
-				$sql .= " WHERE m.fk_product = ".((int) $object->id);
-				$resqlbis = $db->query($sql);
-				if ($resqlbis) {
-					$obj = $db->fetch_object($resqlbis);
-					$lastmovementdate = $db->jdate($obj->datem);
-				} else {
-					dol_print_error($db);
-				}
-				print '<tr><td class="tdtop">'.$langs->trans("LastMovement").'</td><td>';
-				if ($lastmovementdate) {
-					print dol_print_date($lastmovementdate, 'dayhour').' ';
-					print ' &nbsp; &nbsp; ';
-					print img_picto($langs->trans("StockMovement"), 'movement', 'class="pictofixedwidth"');
-					print '<a href="'.DOL_URL_ROOT.'/product/stock/movement_list.php?idproduct='.$object->id.'">'.$langs->trans("FullList").'</a>';
-				} else {
-					print img_picto($langs->trans("StockMovement"), 'movement', 'class="pictofixedwidth"');
-					print '<a href="'.DOL_URL_ROOT.'/product/stock/movement_list.php?idproduct='.$object->id.'">'.$langs->trans("None").'</a>';
-				}
-				print "</td></tr>";
 			}
 
 			print "</table>";

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -725,25 +725,25 @@ if ($id > 0 || $ref) {
 			$parameters = array();
 			$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 			print $hookmanager->resPrint;
-			if(empty($reshook)){
+			if (empty($reshook)) {
 				print '</table>';
-	
+
 				print '</div>';
 				print '<div class="fichehalfright"><div class="underbanner clearboth"></div>';
-	
+
 				print '<table class="border tableforfield centpercent">';
-	
+
 				// Stock alert threshold
 				print '<tr><td>'.$form->editfieldkey($form->textwithpicto($langs->trans("StockLimit"), $langs->trans("StockLimitDesc"), 1), 'seuil_stock_alerte', $object->seuil_stock_alerte, $object, $user->hasRight('produit', 'creer')).'</td><td>';
 				print $form->editfieldval("StockLimit", 'seuil_stock_alerte', $object->seuil_stock_alerte, $object, $user->hasRight('produit', 'creer'), 'string');
 				print '</td></tr>';
-	
+
 				// Desired stock
 				print '<tr><td>'.$form->editfieldkey($form->textwithpicto($langs->trans("DesiredStock"), $langs->trans("DesiredStockDesc"), 1), 'desiredstock', $object->desiredstock, $object, $user->hasRight('produit', 'creer'));
 				print '</td><td>';
 				print $form->editfieldval("DesiredStock", 'desiredstock', $object->desiredstock, $object, $user->hasRight('produit', 'creer'), 'string');
 				print '</td></tr>';
-	
+
 				// Real stock
 				$text_stock_options = $langs->trans("RealStockDesc").'<br>';
 				$text_stock_options .= $langs->trans("RealStockWillAutomaticallyWhen").'<br>';
@@ -763,7 +763,7 @@ if ($id > 0 || $ref) {
 				} else {
 					setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 				}
-	
+
 				print '<tr><td>';
 				print $form->textwithpicto($langs->trans("PhysicalStock"), $text_stock_options, 1);
 				print '</td>';
@@ -771,13 +771,13 @@ if ($id > 0 || $ref) {
 				if ($object->seuil_stock_alerte != '' && ($object->stock_reel < $object->seuil_stock_alerte)) {
 					print ' '.img_warning($langs->trans("StockLowerThanLimit", $object->seuil_stock_alerte));
 				}
-	
+
 				print ' &nbsp; &nbsp;<a href="'.DOL_URL_ROOT.'/product/stock/stockatdate.php?productid='.$object->id.'">'.$langs->trans("StockAtDate").'</a>';
 				print '</td>';
 				print '</tr>';
-	
+
 				$stocktheo = price2num($object->stock_theorique, 'MS');
-	
+
 				$found = 0;
 				$helpondiff = '<strong>'.$langs->trans("StockDiffPhysicTeoric").':</strong><br>';
 				// Number of sales orders running
@@ -794,7 +794,7 @@ if ($id > 0 || $ref) {
 					}
 					$helpondiff .= ' <span class="opacitymedium">('.$langs->trans("ProductQtyInDraft").': '.$object->stats_commande['qty'].')</span>';
 				}
-	
+
 				// Number of product from sales order already sent (partial shipping)
 				if (isModEnabled("shipping")) {
 					require_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php';
@@ -828,7 +828,7 @@ if ($id > 0 || $ref) {
 					}
 					$helpondiff .= ' <span class="opacitymedium">('.$langs->trans("ProductQtyInDraftOrWaitingApproved").': '.$object->stats_commande_fournisseur['qty'].')</span>';
 				}
-	
+
 				// Number of product from supplier order already received (partial receipt)
 				if (isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) {
 					if ($found) {
@@ -838,7 +838,7 @@ if ($id > 0 || $ref) {
 					}
 					$helpondiff .= $langs->trans("ProductQtyInSuppliersShipmentAlreadyRecevied").': '.$object->stats_reception['qty'];
 				}
-	
+
 				// Number of product in production
 				if (isModEnabled('mrp')) {
 					if ($found) {
@@ -858,8 +858,8 @@ if ($id > 0 || $ref) {
 				} else {
 					setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 				}
-	
-	
+
+
 				// Calculating a theoretical value
 				print '<tr><td>';
 				print $form->textwithpicto($langs->trans("VirtualStock"), $langs->trans("VirtualStockDesc"));
@@ -873,7 +873,7 @@ if ($id > 0 || $ref) {
 				print ' &nbsp; &nbsp;<a href="'.DOL_URL_ROOT.'/product/stock/stockatdate.php?mode=future&productid='.$object->id.'">'.$langs->trans("VirtualStockAtDate").'</a>';
 				print '</td>';
 				print '</tr>';
-	
+
 				// Last movement
 				if ($user->hasRight('stock', 'mouvement', 'lire')) {
 					$sql = "SELECT max(m.datem) as datem";


### PR DESCRIPTION
# NEW Hook formObjectOptions can replace in product/stock.php
This hook did not permit to replace the standard output. Just a check for the return value to give the possibility of replace the output text.
