### PR TITLE
FIX: langs overwrite

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,7 @@ FIX: #24265 regression cannot see all product on takepos (#28753)
 FIX: #26015
 FIX: #28205
 FIX: #28251 Fixing subpermission name on api_multicurrencies.class.php (#28252)
-FIX: #28347 FIX: occured#28962 FIX: #29224  FIX: #29035  (#29303)
+FIX: #28347 FIX: occurred#28962 FIX: #29224  FIX: #29035  (#29303)
 FIX: #28369
 FIX: #28429
 FIX: #28491 (#28522)

--- a/htdocs/core/class/commonnumrefgenerator.class.php
+++ b/htdocs/core/class/commonnumrefgenerator.class.php
@@ -93,7 +93,6 @@ abstract class CommonNumRefGenerator
 	 */
 	public function info($langs)
 	{
-		global $langs;
 		return $langs->trans("NoDescription");
 	}
 


### PR DESCRIPTION
In this function, the value of `$langs` passed as a parameter was overwriten by the global value.