### PR TITLE
FIX executeHooks $object default value

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -153,7 +153,7 @@ class HookManager
 	 *                                      All types can also return some values into an array ->results that will be finaly merged into this->resArray for caller.
 	 *                                      $this->error or this->errors are also defined by class called by this function if error.
 	 */
-	public function executeHooks($method, $parameters = array(), &$object = '', &$action = '')
+	public function executeHooks($method, $parameters = array(), &$object = null, &$action = '')
 	{
 		if (!is_array($this->hooks) || empty($this->hooks)) {
 			return 0; // No hook available, do nothing.


### PR DESCRIPTION
Change $object parameter default value from '' to null to fix issue when using type declarations in custom hooks.

Mirrored change from commit 0453b3e.