### PR TITLE
FIX: reloading supplier proposal page whenselecting company is not working

### DIFF
--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -1277,14 +1277,14 @@ if ($action == 'create') {
 			$filter = '((s.fournisseur:=:1) AND (s.status:=:1))';
 			print img_picto('', 'company', 'class="pictofixedwidth"').$form->select_company((empty($socid) ? '' : $socid), 'socid', $filter, 'SelectThirdParty', 1, 0, null, 0, 'minwidth175 maxwidth500 widthcentpercentminusxx');
 			// reload page to retrieve customer information
-			if (getDolGlobalString('RELOAD_PAGE_ON_SUPPLIER_CHANGE')) {
+			if (!getDolGlobalString('RELOAD_PAGE_ON_SUPPLIER_CHANGE_DISABLED')) {
 				print '<script>
 				$(document).ready(function() {
 					$("#socid").change(function() {
 						console.log("We have changed the company - Reload page");
 						// reload page
 						$("input[name=action]").val("create");
-						$("form[name=add]").submit();
+						$("form[name=addprop]").submit();
 					});
 				});
 				</script>';


### PR DESCRIPTION
the form selector has been fixed, and the const name has been changed, same one used on fourn/commande/card.php and fourn/facture/card.php (so the feature is enabled by default) 