### PR TITLE
Add a parameter to dolCopyDir function to exclude copying archive files

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -877,7 +877,7 @@ function dol_copy($srcfile, $destfile, $newmask = '0', $overwriteifexists = 1, $
  * @param	array<string,string>	$arrayreplacement		Array to use to replace filenames with another one during the copy (works only on file names, not on directory names).
  * @param	int						$excludesubdir			0=Do not exclude subdirectories, 1=Exclude subdirectories, 2=Exclude subdirectories if name is not a 2 chars (used for country codes subdirectories).
  * @param	string[]				$excludefileext			Exclude some file extensions
- * @param	int						$excludearchivefiles	Exclude archive files that begin with v+timestamp (0 by default)
+ * @param	int						$excludearchivefiles	Exclude archive files that begin with v+timestamp or d+timestamp (0 by default)
  * @return	int												Return integer <0 if error, 0 if nothing done (all files already exists and overwriteifexists=0), >0 if OK
  * @see		dol_copy()
  */

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -945,7 +945,7 @@ function dolCopyDir($srcfile, $destfile, $newmask, $overwriteifexists, $arrayrep
 
 					if ($excludearchivefiles == 1) {
 						$extension = pathinfo($file, PATHINFO_EXTENSION);
-						if (preg_match('/^v\d+$/', $extension)) {
+						if (preg_match('/^[v|d]\d+$/', $extension)) {
 							continue;
 						}
 					}

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -870,17 +870,18 @@ function dol_copy($srcfile, $destfile, $newmask = '0', $overwriteifexists = 1, $
 /**
  * Copy a dir to another dir. This include recursive subdirectories.
  *
- * @param	string					$srcfile			Source file (a directory)
- * @param	string					$destfile			Destination file (a directory)
- * @param	string					$newmask			Mask for new file ('0' by default means getDolGlobalString('MAIN_UMASK')). Example: '0666'
- * @param 	int						$overwriteifexists	Overwrite file if exists (1 by default)
- * @param	array<string,string>	$arrayreplacement	Array to use to replace filenames with another one during the copy (works only on file names, not on directory names).
- * @param	int						$excludesubdir		0=Do not exclude subdirectories, 1=Exclude subdirectories, 2=Exclude subdirectories if name is not a 2 chars (used for country codes subdirectories).
- * @param	string[]				$excludefileext		Exclude some file extensions
- * @return	int											Return integer <0 if error, 0 if nothing done (all files already exists and overwriteifexists=0), >0 if OK
+ * @param	string					$srcfile				Source file (a directory)
+ * @param	string					$destfile				Destination file (a directory)
+ * @param	string					$newmask				Mask for new file ('0' by default means getDolGlobalString('MAIN_UMASK')). Example: '0666'
+ * @param 	int						$overwriteifexists		Overwrite file if exists (1 by default)
+ * @param	array<string,string>	$arrayreplacement		Array to use to replace filenames with another one during the copy (works only on file names, not on directory names).
+ * @param	int						$excludesubdir			0=Do not exclude subdirectories, 1=Exclude subdirectories, 2=Exclude subdirectories if name is not a 2 chars (used for country codes subdirectories).
+ * @param	string[]				$excludefileext			Exclude some file extensions
+ * @param	int						$excludearchivefiles	Exclude archive files that begin with v+timestamp (0 by default)
+ * @return	int												Return integer <0 if error, 0 if nothing done (all files already exists and overwriteifexists=0), >0 if OK
  * @see		dol_copy()
  */
-function dolCopyDir($srcfile, $destfile, $newmask, $overwriteifexists, $arrayreplacement = null, $excludesubdir = 0, $excludefileext = null)
+function dolCopyDir($srcfile, $destfile, $newmask, $overwriteifexists, $arrayreplacement = null, $excludesubdir = 0, $excludefileext = null, $excludearchivefiles = 0)
 {
 	$result = 0;
 
@@ -929,7 +930,7 @@ function dolCopyDir($srcfile, $destfile, $newmask, $overwriteifexists, $arrayrep
 							}
 						}
 						//var_dump("xxx dolCopyDir $srcfile/$file, $destfile/$file, $newmask, $overwriteifexists");
-						$tmpresult = dolCopyDir($srcfile."/".$file, $destfile."/".$newfile, $newmask, $overwriteifexists, $arrayreplacement, $excludesubdir, $excludefileext);
+						$tmpresult = dolCopyDir($srcfile."/".$file, $destfile."/".$newfile, $newmask, $overwriteifexists, $arrayreplacement, $excludesubdir, $excludefileext, $excludearchivefiles);
 					}
 				} else {
 					$newfile = $file;
@@ -938,6 +939,13 @@ function dolCopyDir($srcfile, $destfile, $newmask, $overwriteifexists, $arrayrep
 						$extension = pathinfo($file, PATHINFO_EXTENSION);
 						if (in_array($extension, $excludefileext)) {
 							//print "We exclude the file ".$file." because its extension is inside list ".join(', ', $excludefileext); exit;
+							continue;
+						}
+					}
+
+					if ($excludearchivefiles == 1) {
+						$extension = pathinfo($file, PATHINFO_EXTENSION);
+						if (preg_match('/^v\d+$/', $extension)) {
 							continue;
 						}
 					}

--- a/htdocs/website/class/website.class.php
+++ b/htdocs/website/class/website.class.php
@@ -986,7 +986,7 @@ class Website extends CommonObject
 		$destdir = $conf->website->dir_temp.'/'.$website->ref.'/containers';
 
 		dol_syslog("Copy pages from ".$srcdir." into ".$destdir);
-		dolCopyDir($srcdir, $destdir, 0, 1, $arrayreplacementinfilename, 2, array('old', 'back'));
+		dolCopyDir($srcdir, $destdir, 0, 1, $arrayreplacementinfilename, 2, array('old', 'back'), 1);
 
 		// Copy file README.md and LICENSE from directory containers into directory root
 		if (dol_is_file($conf->website->dir_temp.'/'.$website->ref.'/containers/README.md')) {


### PR DESCRIPTION
# Add a parameter to dolCopyDir function to exclude copying archive files
Add a parameter to dolCopyDir function to exclude copying archive files

