### PR TITLE
NEW Add a warning if invoice payment is Credit Transfer on newpayment.php

### DIFF
--- a/htdocs/langs/en_US/other.lang
+++ b/htdocs/langs/en_US/other.lang
@@ -349,3 +349,4 @@ EmailContent=Email content
 Pre-Prompt=Pre-prompt
 Post-Prompt=Post-prompt
 AIProcessingPleaseWait=AI (%s) is processing your request, please wait...
+PayOfBankTransferInvoice=This invoice has Bank Transfer as payment method.<br>Please verify that a payment isn't already done or is pending.

--- a/htdocs/langs/en_US/other.lang
+++ b/htdocs/langs/en_US/other.lang
@@ -349,4 +349,4 @@ EmailContent=Email content
 Pre-Prompt=Pre-prompt
 Post-Prompt=Post-prompt
 AIProcessingPleaseWait=AI (%s) is processing your request, please wait...
-PayOfBankTransferInvoice=This invoice has Bank Transfer as payment method.<br>Please verify that a payment isn't already done or is pending.
+PayOfBankTransferInvoice=You will make an online payment for this invoice. However, this invoice has been set up to be paid in "Bank Transfer" mode, so to avoid paying twice, please verify that no current bank transfer has already been initiated before continuing.

--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -1268,7 +1268,7 @@ if ($source == 'invoice') {
 	print '<input type="hidden" name="tag" value="'.(empty($tag) ? '' : $tag).'">';
 	print '<input type="hidden" name="fulltag" value="'.$fulltag.'">';
 	print '</td></tr>'."\n";
-	if ($form->cache_types_paiements[$invoice->mode_reglement_id]["code"] == "VIR") {
+	if ($invoice->mode_reglement_id > 0 && $form->cache_types_paiements[$invoice->mode_reglement_id]["code"] == "VIR") {
 		print '<tr class="CTableRow2 center"><td class="CTableRow2" colspan="2">';
 		print '<div class="warning">';
 		print $langs->trans("PayOfBankTransferInvoice");

--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -1172,6 +1172,7 @@ if ($source == 'order') {
 if ($source == 'invoice') {
 	$found = true;
 	$langs->load("bills");
+	$form->load_cache_types_paiements();
 
 	require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 
@@ -1267,6 +1268,13 @@ if ($source == 'invoice') {
 	print '<input type="hidden" name="tag" value="'.(empty($tag) ? '' : $tag).'">';
 	print '<input type="hidden" name="fulltag" value="'.$fulltag.'">';
 	print '</td></tr>'."\n";
+	if ($form->cache_types_paiements[$invoice->mode_reglement_id]["code"] == "VIR") {
+		print '<tr class="CTableRow2 center"><td class="CTableRow2" colspan="2">';
+		print '<div class="warning">';
+		print $langs->trans("PayOfBankTransferInvoice");
+		print '</div>';
+		print '</td></tr>'."\n";
+	}
 
 	// Shipping address
 	$shipToName = $invoice->thirdparty->name;


### PR DESCRIPTION
Add a warning on public/newpayment.php page warn users that the invoice is set to Bank transfer payment method so they don't pay it twice