### PR TITLE
init array_options in current object   if we don't have record for it

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6388,7 +6388,7 @@ abstract class CommonObject
 				} else {
 					/**
 					We are in a situation where the current object has no values in its extra fields.
-					We want to initialize all the values to empty so that the array_option is accessible in other contexts (especially in document generation).
+					We want to initialize all the values to null so that the array_option is accessible in other contexts (especially in document generation).
 					 **/
 					if (is_array($extrafields->attributes[$this->table_element]['label'])) {
 						foreach ($extrafields->attributes[$this->table_element]['label'] as $key => $val) {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6392,7 +6392,7 @@ abstract class CommonObject
 					 **/
 					if (is_array($extrafields->attributes[$this->table_element]['label'])) {
 						foreach ($extrafields->attributes[$this->table_element]['label'] as $key => $val) {
-							$this->array_options['options_' . $key] = '';
+							$this->array_options['options_' . $key] = null;
 						}
 					}
 				}

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6385,7 +6385,7 @@ abstract class CommonObject
 							}
 						}
 					}
-				}else{
+				} else {
 					/**
 					We are in a situation where the current object has no values in its extra fields.
 					We want to initialize all the values to empty so that the array_option is accessible in other contexts (especially in document generation).

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6385,6 +6385,16 @@ abstract class CommonObject
 							}
 						}
 					}
+				}else{
+					/**
+					We are in a situation where the current object has no values in its extra fields.
+					We want to initialize all the values to empty so that the array_option is accessible in other contexts (especially in document generation).
+					 **/
+					if (is_array($extrafields->attributes[$this->table_element]['label'])) {
+						foreach ($extrafields->attributes[$this->table_element]['label'] as $key => $val) {
+							$this->array_options['options_' . $key] = '';
+						}
+					}
 				}
 
 				// If field is a computed field, value must become result of compute (regardless of whether a row exists


### PR DESCRIPTION
# NEW|New 
We are in a situation where the current object has no values in its extra fields.
We want to initialize all the values to null so that the array_option is accessible in other contexts (especially in document generation).
