### PR TITLE
NEW Adds payment terms and procentual discount to the creation of an invoice from time entries in projects

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -419,8 +419,7 @@ if ($action == 'confirm_generateinvoice') {
 		$tmpproduct = new Product($db);
 		$fuser = new User($db);
 		$remiseproject = GETPOST('remiseproject', 'int');
-        $condidproject = GETPOST('condidproject', 'int');
-		
+		$condidproject = GETPOST('condidproject', 'int');		
 		$db->begin();
 		$idprod = GETPOSTINT('productid');
 		$generateinvoicemode = GETPOST('generateinvoicemode', 'alphanohtml');
@@ -551,7 +550,7 @@ if ($action == 'confirm_generateinvoice') {
 						}
 
 						// Add lines
-						$lineid = $tmpinvoice->addline($langs->trans("TimeSpentForInvoice", $username) . ' : ' . $qtyhourtext, $pu_htline, round($qtyhour / $prodDurationHours, 2), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0),$remiseproject);
+						$lineid = $tmpinvoice->addline($langs->trans("TimeSpentForInvoice", $username) . ' : ' . $qtyhourtext, $pu_htline, round($qtyhour / $prodDurationHours, 2), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0), $remiseproject);
 						if ($lineid < 0) {
 							$error++;
 							setEventMessages(null, $tmpinvoice->errors, 'errors');
@@ -650,7 +649,7 @@ if ($action == 'confirm_generateinvoice') {
 						}
 						$idprodline = $value['fk_product'];
 					}
-					$lineid = $tmpinvoice->addline($value['note'], $pu_htline, round($qtyhour / $prodDurationHours, 2), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0),$remiseproject);
+					$lineid = $tmpinvoice->addline($value['note'], $pu_htline, round($qtyhour / $prodDurationHours, 2), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0), $remiseproject);
 					if ($lineid < 0) {
 						$error++;
 						setEventMessages(null, $tmpinvoice->errors, 'errors');
@@ -1467,7 +1466,6 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 					print '</td>';
 					print '</tr>';
 				}
-
 				print '<tr>';
 				print '<td class="titlefield">';
 				print $langs->trans('InvoiceToUse');
@@ -1476,25 +1474,22 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 				print $form->selectInvoice($projectstatic->thirdparty->id, '', 'invoiceid', 24, 0, $langs->trans('NewInvoice'), 1, 0, 0, 'maxwidth500', '', 'all');
 				print '</td>';
 				print '</tr>';
-				
-                print '<tr>';
-                print '<td class="titlefield">';
+				print '<tr>';
+				print '<td class="titlefield">';
 				print $langs->trans("CustomerRelativeDiscount");
 				print '</td>';
-                print '<td>';
+				print '<td>';
 				print '<input type="text" size="5" name="remiseproject" value="'.$projectstatic->thirdparty->remise_percent.'">%';
 				print '</td>';
-                print '</tr>';
-                
+				print '</tr>';
 				print '<tr class="newinvoicedetail">';
-                print '<td class="titlefield">';
+				print '<td class="titlefield">';
 				print $langs->trans("PaymentConditions");
 				print '</td>';
-                print '<td>';
-				print $form->select_conditions_paiements($projectstatic->thirdparty->cond_reglement_id,'condidproject');
+				print '<td>';
+				print $form->select_conditions_paiements($projectstatic->thirdparty->cond_reglement_id, 'condidproject');
 				print '</td>';
-                print '</tr>';
-                
+				print '</tr>';                
 				/*print '<tr>';
 				 print '<td>';
 				 print $langs->trans('ValidateInvoices');

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -1489,7 +1489,7 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 				print '<td>';
 				print $form->getSelectConditionsPaiements($projectstatic->thirdparty->cond_reglement_id, 'condidproject');
 				print '</td>';
-				print '</tr>';                
+				print '</tr>';
 				/*print '<tr>';
 				 print '<td>';
 				 print $langs->trans('ValidateInvoices');

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -418,7 +418,9 @@ if ($action == 'confirm_generateinvoice') {
 		$tmptimespent = new Task($db);
 		$tmpproduct = new Product($db);
 		$fuser = new User($db);
-
+		$remiseproject = GETPOST('remiseproject', 'int');
+        $condidproject = GETPOST('condidproject', 'int');
+		
 		$db->begin();
 		$idprod = GETPOSTINT('productid');
 		$generateinvoicemode = GETPOST('generateinvoicemode', 'alphanohtml');
@@ -458,7 +460,7 @@ if ($action == 'confirm_generateinvoice') {
 		$tmpinvoice->socid = $projectstatic->thirdparty->id;
 		$tmpinvoice->date = dol_mktime(GETPOSTINT('rehour'), GETPOSTINT('remin'), GETPOSTINT('resec'), GETPOSTINT('remonth'), GETPOSTINT('reday'), GETPOSTINT('reyear'));
 		$tmpinvoice->fk_project = $projectstatic->id;
-		$tmpinvoice->cond_reglement_id = $projectstatic->thirdparty->cond_reglement_id;
+		$tmpinvoice->cond_reglement_id = $condidproject;
 		$tmpinvoice->mode_reglement_id = $projectstatic->thirdparty->mode_reglement_id;
 		$tmpinvoice->fk_account = $projectstatic->thirdparty->fk_account;
 
@@ -549,7 +551,7 @@ if ($action == 'confirm_generateinvoice') {
 						}
 
 						// Add lines
-						$lineid = $tmpinvoice->addline($langs->trans("TimeSpentForInvoice", $username) . ' : ' . $qtyhourtext, $pu_htline, round($qtyhour / $prodDurationHours, 2), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0));
+						$lineid = $tmpinvoice->addline($langs->trans("TimeSpentForInvoice", $username) . ' : ' . $qtyhourtext, $pu_htline, round($qtyhour / $prodDurationHours, 2), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0),$remiseproject);
 						if ($lineid < 0) {
 							$error++;
 							setEventMessages(null, $tmpinvoice->errors, 'errors');
@@ -648,7 +650,7 @@ if ($action == 'confirm_generateinvoice') {
 						}
 						$idprodline = $value['fk_product'];
 					}
-					$lineid = $tmpinvoice->addline($value['note'], $pu_htline, round($qtyhour / $prodDurationHours, 2), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0));
+					$lineid = $tmpinvoice->addline($value['note'], $pu_htline, round($qtyhour / $prodDurationHours, 2), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0),$remiseproject);
 					if ($lineid < 0) {
 						$error++;
 						setEventMessages(null, $tmpinvoice->errors, 'errors');
@@ -746,7 +748,7 @@ if ($action == 'confirm_generateinvoice') {
 						$date_start = '';
 						$date_end = '';
 						$lineName = $ftask->ref . ' - ' . $ftask->label;
-						$lineid = $tmpinvoice->addline($lineName, $pu_ht_for_task, price2num($qtyhour / $prodDurationHours, 'MS'), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0), 0, $date_start, $date_end, 0, 0, '', 'HT', 0, 1, -1, 0, '', 0, 0, null, $pa_ht);
+						$lineid = $tmpinvoice->addline($lineName, $pu_ht_for_task, price2num($qtyhour / $prodDurationHours, 'MS'), $txtvaline, $localtax1line, $localtax2line, ($idprodline > 0 ? $idprodline : 0), $remiseproject, $date_start, $date_end, 0, 0, '', 'HT', 0, 1, -1, 0, '', 0, 0, null, $pa_ht);
 						if ($lineid < 0) {
 							$error++;
 							setEventMessages($tmpinvoice->error, $tmpinvoice->errors, 'errors');
@@ -1474,6 +1476,25 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 				print $form->selectInvoice($projectstatic->thirdparty->id, '', 'invoiceid', 24, 0, $langs->trans('NewInvoice'), 1, 0, 0, 'maxwidth500', '', 'all');
 				print '</td>';
 				print '</tr>';
+				
+                print '<tr>';
+                print '<td class="titlefield">';
+				print $langs->trans("CustomerRelativeDiscount");
+				print '</td>';
+                print '<td>';
+				print '<input type="text" size="5" name="remiseproject" value="'.$projectstatic->thirdparty->remise_percent.'">%';
+				print '</td>';
+                print '</tr>';
+                
+				print '<tr class="newinvoicedetail">';
+                print '<td class="titlefield">';
+				print $langs->trans("PaymentConditions");
+				print '</td>';
+                print '<td>';
+				print $form->select_conditions_paiements($projectstatic->thirdparty->cond_reglement_id,'condidproject');
+				print '</td>';
+                print '</tr>';
+                
 				/*print '<tr>';
 				 print '<td>';
 				 print $langs->trans('ValidateInvoices');

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -418,7 +418,7 @@ if ($action == 'confirm_generateinvoice') {
 		$tmptimespent = new Task($db);
 		$tmpproduct = new Product($db);
 		$fuser = new User($db);
-		$remiseproject = price2num(GETPOST('remiseproject', 'int'));
+		$remiseproject = price2num(GETPOST('remiseprojet', 'alphanohtml'));
 		$condidproject = GETPOSTINT('condidproject');
 		$db->begin();
 		$idprod = GETPOSTINT('productid');

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -418,8 +418,8 @@ if ($action == 'confirm_generateinvoice') {
 		$tmptimespent = new Task($db);
 		$tmpproduct = new Product($db);
 		$fuser = new User($db);
-		$remiseproject = GETPOST('remiseproject', 'int');
-		$condidproject = GETPOST('condidproject', 'int');
+		$remiseproject = price2num(GETPOST('remiseproject', 'int'));
+		$condidproject = GETPOSTINT('condidproject');
 		$db->begin();
 		$idprod = GETPOSTINT('productid');
 		$generateinvoicemode = GETPOST('generateinvoicemode', 'alphanohtml');

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -419,7 +419,7 @@ if ($action == 'confirm_generateinvoice') {
 		$tmpproduct = new Product($db);
 		$fuser = new User($db);
 		$remiseproject = GETPOST('remiseproject', 'int');
-		$condidproject = GETPOST('condidproject', 'int');		
+		$condidproject = GETPOST('condidproject', 'int');
 		$db->begin();
 		$idprod = GETPOSTINT('productid');
 		$generateinvoicemode = GETPOST('generateinvoicemode', 'alphanohtml');
@@ -1487,7 +1487,7 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 				print $langs->trans("PaymentConditions");
 				print '</td>';
 				print '<td>';
-				print $form->select_conditions_paiements($projectstatic->thirdparty->cond_reglement_id, 'condidproject');
+				print $form->getSelectConditionsPaiements($projectstatic->thirdparty->cond_reglement_id, 'condidproject');
 				print '</td>';
 				print '</tr>';                
 				/*print '<tr>';


### PR DESCRIPTION
# NEW Adds payment terms and procentual discount to the creation of an invoice from time entries in projects

when an invoice is created from time entries in projects, a payment term is only transferred if the customer has a customer-specific payment term. If the customer does not have this, the invoice is created without a payment term.
This code inserts two additional lines in the pre-diagram for invoice creation. These lines show the payment terms and the percentage discount - pre-filled with the customer's values if available otherwise the first payment term and 0% discount.
It is possible to customize the values here. The invoice is then created with the specified payment terms and each invoice line with the specified percentage discount.
If an existing invoice is selected instead of a new one, the line for the payment term is hidden.

![Greenshot 2024-05-15 16 37 30](https://github.com/Dolibarr/dolibarr/assets/48153507/36e73c3d-b153-4a38-adf9-d40229e41dac)
