### PR TITLE
FIX Filter Warehouses (multicompany) for Product Stock tab  Limit Stock By Warehouses

### DIFF
--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1291,14 +1291,17 @@ if (!$variants || getDolGlobalString('VARIANT_ALLOW_STOCK_MOVEMENT_ON_VARIANT_PA
 
 		$pse = new ProductStockEntrepot($db);
 		$lines = $pse->fetchAll($id);
-		$visibleWarehouseEntities = explode(',', getEntity('stock')); //For MultiCompany compatibility
+
+		$visibleWarehouseEntities = explode(',', getEntity('stock')); 	// For MultiCompany compatibility
 
 		if (!empty($lines)) {
 			$var = false;
 			foreach ($lines as $line) {
 				$ent = new Entrepot($db);
 				$ent->fetch($line['fk_entrepot']);
-				if (in_array($ent->entity, $visibleWarehouseEntities)) { //Display only warehouses from our entity and entities sharing stock with actual entity
+				
+				if (!isModEnabled("multicompany") || in_array($ent->entity, $visibleWarehouseEntities)) {
+					// Display only warehouses from our entity and entities sharing stock with actual entity
 					print '<tr class="oddeven"><td>'.$ent->getNomUrl(3).'</td>';
 					print '<td class="right">'.$line['seuil_stock_alerte'].'</td>';
 					print '<td class="right">'.$line['desiredstock'].'</td>';

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1291,19 +1291,22 @@ if (!$variants || getDolGlobalString('VARIANT_ALLOW_STOCK_MOVEMENT_ON_VARIANT_PA
 
 		$pse = new ProductStockEntrepot($db);
 		$lines = $pse->fetchAll($id);
+		$visibleWarehouseEntities = explode(',', getEntity('stock')); //For MultiCompany compatibility
 
 		if (!empty($lines)) {
 			$var = false;
 			foreach ($lines as $line) {
 				$ent = new Entrepot($db);
 				$ent->fetch($line['fk_entrepot']);
-				print '<tr class="oddeven"><td>'.$ent->getNomUrl(3).'</td>';
-				print '<td class="right">'.$line['seuil_stock_alerte'].'</td>';
-				print '<td class="right">'.$line['desiredstock'].'</td>';
-				if ($user->hasRight('produit', 'creer')) {
-					print '<td class="right"><a href="'.$_SERVER['PHP_SELF'].'?id='.$id.'&fk_productstockwarehouse='.$line['id'].'&action=delete_productstockwarehouse&token='.newToken().'">'.img_delete().'</a></td>';
+				if (in_array($ent->entity, $visibleWarehouseEntities)) { //Display only warehouses from our entity and entities sharing stock with actual entity
+					print '<tr class="oddeven"><td>'.$ent->getNomUrl(3).'</td>';
+					print '<td class="right">'.$line['seuil_stock_alerte'].'</td>';
+					print '<td class="right">'.$line['desiredstock'].'</td>';
+					if ($user->hasRight('produit', 'creer')) {
+						print '<td class="right"><a href="'.$_SERVER['PHP_SELF'].'?id='.$id.'&fk_productstockwarehouse='.$line['id'].'&action=delete_productstockwarehouse&token='.newToken().'">'.img_delete().'</a></td>';
+					}
+					print '</tr>';
 				}
-				print '</tr>';
 			}
 		}
 


### PR DESCRIPTION
# FIX Filter Warehouses for stock limits (multicompany)

Table allowing to define stock limits by warehouses does not have to display all existing warehouses (because some of them may belong to other entites and may not be shared).
It is important, because if user has the right to create product, he/she has the right to delete those limits too.

Just added a check to ensure Entrepot->entity is in getEntity('stock')

BEFORE
![image](https://github.com/Dolibarr/dolibarr/assets/50403308/fd47148a-19d2-48da-87ab-a31a35aae9f1)

AFTER
![image](https://github.com/Dolibarr/dolibarr/assets/50403308/637476a1-66ed-42fd-ab75-c9cb20e11f42)

