### PR TITLE
FIX: Error cannot add foreign key constraint on societe_commerciaux table

### DIFF
--- a/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
+++ b/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
@@ -337,6 +337,7 @@ ALTER TABLE llx_societe_commerciaux ADD COLUMN fk_c_type_contact_code varchar(32
 -- VMYSQL4.1 DROP INDEX uk_societe_commerciaux ON llx_societe_commerciaux;
 -- VPGSQL8.2 DROP INDEX uk_societe_commerciaux;
 ALTER TABLE llx_societe_commerciaux ADD UNIQUE INDEX uk_societe_commerciaux_c_type_contact (fk_soc, fk_user, fk_c_type_contact_code);
+ALTER TABLE llx_c_type_contact ADD INDEX idx_c_type_contact_code (code);
 ALTER TABLE llx_societe_commerciaux ADD CONSTRAINT fk_societe_commerciaux_fk_c_type_contact_code FOREIGN KEY (fk_c_type_contact_code)  REFERENCES llx_c_type_contact(code);
 ALTER TABLE llx_societe_commerciaux ADD CONSTRAINT fk_societe_commerciaux_fk_soc FOREIGN KEY (fk_soc)  REFERENCES llx_societe(rowid);
 ALTER TABLE llx_societe_commerciaux ADD CONSTRAINT fk_societe_commerciaux_fk_user FOREIGN KEY (fk_user)  REFERENCES llx_user(rowid);

--- a/htdocs/install/mysql/tables/llx_c_type_contact.key.sql
+++ b/htdocs/install/mysql/tables/llx_c_type_contact.key.sql
@@ -18,4 +18,4 @@
 
 
 ALTER TABLE llx_c_type_contact ADD UNIQUE INDEX uk_c_type_contact_id (element, source, code);
-
+ALTER TABLE llx_c_type_contact ADD INDEX idx_c_type_contact_code (code);


### PR DESCRIPTION
Fix the following error when running 19.0.0 > 20.0.0 update sql : 
DB_ERROR_CANNOT_ADD_FOREIGN_KEY_CONSTRAINT (Req 219): ALTER TABLE llx_societe_commerciaux ADD CONSTRAINT fk_societe_commerciaux_fk_c_type_contact_code FOREIGN KEY (fk_c_type_contact_code) REFERENCES llx_c_type_contact(code);
Cannot add foreign key constraint

(Tests performed with MySQL 5.7)