### PR TITLE
NEW Accountancy - Add possibility for specific format FEC to sort with the fec name

### DIFF
--- a/htdocs/accountancy/tpl/export_journal.tpl.php
+++ b/htdocs/accountancy/tpl/export_journal.tpl.php
@@ -1,5 +1,5 @@
 <?php
-/* Copyright (C) 2015-2022  Alexandre Spangaro	<aspangaro@open-dsi.fr>
+/* Copyright (C) 2015-2024  Alexandre Spangaro	<alexandre@inovea-conseil.com>
  * Copyright (C) 2022  		Lionel Vessiller    <lvessiller@open-dsi.fr>
  * Copyright (C) 2016       Charlie Benke		<charlie@patas-monkey.com>
  * Copyright (C) 2022  		Progiseize         	<a.bisotti@progiseize.fr>
@@ -44,8 +44,7 @@ include_once DOL_DOCUMENT_ROOT.'/accountancy/class/accountancyexport.class.php';
 $accountancyexport = new AccountancyExport($db);
 
 // Specific filename for FEC model export into the general ledger
-if (($accountancyexport->getFormatCode($formatexportset) == 'fec' || $accountancyexport->getFormatCode($formatexportset) == 'fec2')
-	&& $type_export == "general_ledger") {
+if ((substr($accountancyexport->getFormatCode($formatexportset), 0, 3) == 'fec') && $type_export == "general_ledger") {
 	// FEC format is defined here: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000027804775&cidTexte=LEGITEXT000006069583&dateTexte=20130802&oldAction=rechCodeArticle
 	if (empty($search_date_end)) {
 		// TODO Get the max date into bookkeeping table


### PR DESCRIPTION
With a module, if you add a specific model "fec3", the generated file cannot take the specific naming of the FEC file.

With this modification, we detect the first 3 letters "fec" to generate output name. No longer hardcoded fec1/fec2