### PR TITLE
Update text extrafields in contract lines when value is empty

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2555,7 +2555,7 @@ class ExtraFields
 					}
 					$value_key = dol_htmlcleanlastbr(GETPOST($keysuffix."options_".$key.$keyprefix, 'restricthtml'));
 				} else {
-					if (!GETPOST($keysuffix."options_".$key.$keyprefix)) {
+					if (!GETPOSTISSET($keysuffix."options_".$key.$keyprefix)) {
 						continue; // Value was not provided, we should not set it.
 					}
 					$value_key = GETPOST($keysuffix."options_".$key.$keyprefix);


### PR DESCRIPTION
# FIX

I found an issue when trying to update text extrafields in contract lines with an empty value.

getOptionalsFromPost in extrafields.class.php only returns text extrafields when the value is not empty. So you can never full clear textboxes that previously had text in them.

Instead of actually trying to retrieve the value, just checking if it is set (like for the other cases above) should be enough.