### PR TITLE
delete margin-top TCPDF <u>

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1449,7 +1449,11 @@ function pdf_writelinedesc(&$pdf, $object, $i, $outputlangs, $w, $h, $posx, $pos
 		$nbrep = 0;
 		$labelproductservice = preg_replace('/(<img[^>]*src=")([^"]*)(&amp;)([^"]*")/', '\1\2&\4', $labelproductservice, -1, $nbrep);
 
-		//var_dump($labelproductservice);exit;
+		if (getDolGlobalString('MARGIN_TOP_ZERO_UL')){
+			$pdf->setListIndentWidth(5);
+			$TMarginList = ['ul' => [['h'=>0.1, ],['h'=>0.1, ]], 'li' => [['h'=>0.1, ],],];
+			$pdf->setHtmlVSpace($TMarginList);
+		}
 
 		// Description
 		$pdf->writeHTMLCell($w, $h, $posx, $posy, $outputlangs->convToOutputCharset($labelproductservice), 0, 1, false, true, 'J', true);

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1449,7 +1449,7 @@ function pdf_writelinedesc(&$pdf, $object, $i, $outputlangs, $w, $h, $posx, $pos
 		$nbrep = 0;
 		$labelproductservice = preg_replace('/(<img[^>]*src=")([^"]*)(&amp;)([^"]*")/', '\1\2&\4', $labelproductservice, -1, $nbrep);
 
-		if (getDolGlobalString('MARGIN_TOP_ZERO_UL')){
+		if (getDolGlobalString('MARGIN_TOP_ZERO_UL')) {
 			$pdf->setListIndentWidth(5);
 			$TMarginList = ['ul' => [['h'=>0.1, ],['h'=>0.1, ]], 'li' => [['h'=>0.1, ],],];
 			$pdf->setHtmlVSpace($TMarginList);


### PR DESCRIPTION
# FIX|Fix #[*margin-top TCPDF *]
When you make a smart list in description line via CKeditor
```
<ul>
    <li>line1</li>
    <li>line2</li>
    <li>line3</li>
</ul>
```
On the `<ul>` tag a margin-top  is imposed
![image](https://github.com/Dolibarr/dolibarr/assets/146709163/e5134875-9e87-40c4-aaf0-95aefb2871d3)

We're losing space

$pdf->setListIndentWidth(5);
 gains left margin 

$TMarginList = ['ul' => [['h'=>0.1, ],['h'=>0.1, ]], 'li' => [['h'=>0.1, ],],];
$pdf->setHtmlVSpace($TMarginList);
We're keeping the` '<br>'  `generate by dol_concatdesc()
We remove the margin-top from <ul>


