### PR TITLE
FIX: objects lists from a thirdparty do not keep socid when using a mass action

### DIFF
--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -33,6 +33,10 @@
 // $withmaindocfilemail
 '@phan-var-force CommonObject $objecttmp';
 
+if (!empty($socid)) {
+	print '<input type="hidden" name="socid" value="'.$socid.'">';
+}
+
 if (!empty($sall) || !empty($search_all)) {
 	$search_all = empty($sall) ? $search_all : $sall;
 


### PR DESCRIPTION
 When a list page has been reached from a thirdparty card, using a mass action lose the socid param.