### PR TITLE
Update Ticket card.php Issue #29757

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -212,7 +212,8 @@ if (empty($reshook)) {
 			$db->begin();
 
 			$getRef = GETPOST("ref", 'alphanohtml');
-			if ($object->fetch('', $getRef) > 0) {
+			$refcheck_object = new Ticket($db);
+			if ($refcheck_object->fetch('', $getRef) > 0) {
 				$object->ref = $object->getDefaultRef();
 				$object->track_id = null;
 				setEventMessage($langs->trans('TicketRefAlreadyUsed', $getRef, $object->ref));


### PR DESCRIPTION
Bug-Fix Issue #29757  Prevent the check for a duplicate ref from populating the new ticket object fields with values from the conflicting ticket.

# FIX|Fix #29757
In v18.0 the ticket form preemptively fills out a "Ref" in the create ticket form. If more than one user opens a new ticket form at the same time they have the same "Ref". When the forms are submitted, the later person's ticket inherits extra field values from the other person's ticket.

I have identified the problem in v18.0. The "$object" variable is used to set and save posted values. At the same time the "$object" variable is used to "fetch" data using the posted "ref" to check if the ref is already used. The "$object->fetch" call populates the object with data values for the ticket found. The extra field values from the ticket found overrides the extra field values submitted.