### PR TITLE
18 fix default autoselect mailto

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -1048,7 +1048,7 @@ class FormMail extends Form
 	 */
 	public function getHtmlForTo()
 	{
-		global $langs, $form;
+		global $langs, $form, $object;
 		$out = '<tr><td class="fieldrequired">';
 		if ($this->withtofree) {
 			$out .= $form->textwithpicto($langs->trans("MailTo"), $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients"));
@@ -1104,9 +1104,16 @@ class FormMail extends Form
 					}
 
 					//if empty, search if one of them is default contact for that type of document ?
-					//first step: default role on thirdpart, next (an priority) will be on document
-					$element = substr($this->param["models"],0,strpos($this->param["models"],'_'));
+					//first step: default role on object
 					if(empty($withtoselected)) {
+						$withtoselected = $object->getIdContact('external',null);
+					}
+					//then default role on thirdpart
+					if(empty($withtoselected)) {
+						$element = $object->element;
+						if(empty($element)) {
+							$element = substr($this->param["models"],0,strpos($this->param["models"],'_'));
+						}
 						require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 						$contact = new Contact($this->db);
 						foreach($this->withto as $key => $value) {

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -1102,20 +1102,20 @@ class FormMail extends Form
 					if (empty($withtoselected) && count($tmparray) == 1 && GETPOST('action', 'aZ09') == 'presend') {
 						$withtoselected = array_keys($tmparray);
 					}
-				}
 
-				//if empty, search if one of them is default contact for that type of document ?
-				//first step: default role on thirdpart, next (an priority) will be on document
-				$element = substr($this->param["models"],0,strpos($this->param["models"],'_'));
-				if(empty($withtoselected)) {
-					require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
-					$contact = new Contact($this->db);
-					foreach($this->withto as $key => $value) {
-						if($contact->fetch($key,null,'','',1)) {
-							foreach($contact->roles as $roleid => $role) {
-								//TODO: how to find current needed role for that mail ? && $role['code'] == 'BILLING') {
-								if($role['element'] == $element) {
-									$withtoselected[] = $key;
+					//if empty, search if one of them is default contact for that type of document ?
+					//first step: default role on thirdpart, next (an priority) will be on document
+					$element = substr($this->param["models"],0,strpos($this->param["models"],'_'));
+					if(empty($withtoselected)) {
+						require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
+						$contact = new Contact($this->db);
+						foreach($this->withto as $key => $value) {
+							if($contact->fetch($key,null,'','',1)) {
+								foreach($contact->roles as $roleid => $role) {
+									//TODO: how to find current needed role for that mail ? && $role['code'] == 'BILLING') {
+									if($role['element'] == $element) {
+										$withtoselected[] = $key;
+									}
 								}
 							}
 						}

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -7,6 +7,7 @@
  * Copyright (C) 2018-2022	Frédéric France			<frederic.france@netlogic.fr>
  * Copyright (C) 2022		Charlene Benke			<charlene@patas-monkey.com>
  * Copyright (C) 2023		Anthony Berton			<anthony.berton@bb2a.fr>
+ * Copyright (C) 2024		Éric Seigne				<eric.seigne@cap-rel.fr>
  *
  *
  * This program is free software; you can redistribute it and/or modify

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -1079,6 +1079,7 @@ class FormMail extends Form
 				$out .= (!is_array($this->withto) && !is_numeric($this->withto)) ? $this->withto : "";
 			}
 		} else {
+			// print "<p>" . json_encode($this) . "</p>";exit;
 			// The free input of email
 			if (!empty($this->withtofree)) {
 				$out .= '<input class="minwidth200" id="sendto" name="sendto" value="'.(($this->withtofree && !is_numeric($this->withtofree)) ? $this->withtofree : (!is_array($this->withto) && !is_numeric($this->withto) ? (GETPOSTISSET("sendto") ? GETPOST("sendto") : $this->withto) : "")).'" />';
@@ -1099,6 +1100,24 @@ class FormMail extends Form
 				if (!getDolGlobalInt('MAIN_MAIL_NO_WITH_TO_SELECTED')) {
 					if (empty($withtoselected) && count($tmparray) == 1 && GETPOST('action', 'aZ09') == 'presend') {
 						$withtoselected = array_keys($tmparray);
+					}
+				}
+
+				//if empty, search if one of them is default contact for that type of document ?
+				//first step: default role on thirdpart, next (an priority) will be on document
+				$element = substr($this->param["models"],0,strpos($this->param["models"],'_'));
+				if(empty($withtoselected)) {
+					require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
+					$contact = new Contact($this->db);
+					foreach($this->withto as $key => $value) {
+						if($contact->fetch($key,null,'','',1)) {
+							foreach($contact->roles as $roleid => $role) {
+								//TODO: how to find current needed role for that mail ? && $role['code'] == 'BILLING') {
+								if($role['element'] == $element) {
+									$withtoselected[] = $key;
+								}
+							}
+						}
 					}
 				}
 

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -1080,7 +1080,6 @@ class FormMail extends Form
 				$out .= (!is_array($this->withto) && !is_numeric($this->withto)) ? $this->withto : "";
 			}
 		} else {
-			// print "<p>" . json_encode($this) . "</p>";exit;
 			// The free input of email
 			if (!empty($this->withtofree)) {
 				$out .= '<input class="minwidth200" id="sendto" name="sendto" value="'.(($this->withtofree && !is_numeric($this->withtofree)) ? $this->withtofree : (!is_array($this->withto) && !is_numeric($this->withto) ? (GETPOSTISSET("sendto") ? GETPOST("sendto") : $this->withto) : "")).'" />';

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -1104,23 +1104,22 @@ class FormMail extends Form
 					}
 
 					//if empty, search if one of them is default contact for that type of document ?
-					//first step: default role on object
-					if(empty($withtoselected)) {
-						$withtoselected = $object->getIdContact('external',null);
+					//first step: default role on object, then if empty switch back on default role on thirdpart
+					if (empty($withtoselected)) {
+						$withtoselected = $object->getIdContact('external', null);
 					}
-					//then default role on thirdpart
-					if(empty($withtoselected)) {
+					if (empty($withtoselected)) {
 						$element = $object->element;
-						if(empty($element)) {
-							$element = substr($this->param["models"],0,strpos($this->param["models"],'_'));
+						if (empty($element)) {
+							$element = substr($this->param["models"], 0, strpos($this->param["models"], '_'));
 						}
 						require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 						$contact = new Contact($this->db);
-						foreach($this->withto as $key => $value) {
-							if($contact->fetch($key,null,'','',1)) {
-								foreach($contact->roles as $roleid => $role) {
+						foreach ($this->withto as $key => $value) {
+							if ($contact->fetch($key, null, '', '', 1)) {
+								foreach ($contact->roles as $roleid => $role) {
 									//TODO: how to find current needed role for that mail ? && $role['code'] == 'BILLING') {
-									if($role['element'] == $element) {
+									if ($role['element'] == $element) {
 										$withtoselected[] = $key;
 									}
 								}


### PR DESCRIPTION
# Fix default contact is not used on mail action

That bug is far away ... but that is really a bug : for example on an invoice if you add somebody as "billing contact" then clic on "send invoice by mail" that contact is not pre-selected !

Same problem if there is no contact linked to that invoice, default contact on thirdpart for invoices are not pre-selected too ... 

More details on french forum : 
https://www.dolibarr.fr/forum/t/selection-automatique-du-contact-mail-probleme-recurrent/45657
