### PR TITLE
Fix 18.0 - Update VAT for Switzerland

### DIFF
--- a/htdocs/install/mysql/data/llx_c_tva.sql
+++ b/htdocs/install/mysql/data/llx_c_tva.sql
@@ -316,9 +316,9 @@ insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values ( 2
 
 -- SWITZERLAND (id country=6)
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (  61,   6,   '0','0','VAT rate 0',  1);
-insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (  62,   6, '3.7','0','VAT rate - reduced',1);
-insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (  63,   6, '2.5','0','VAT rate - super-reduced',1);
-insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (  64,   6, '7.7','0','VAT rate - standard',1);
+insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (  62,   6, '3.8','0','VAT rate - reduced',1);
+insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (  63,   6, '2.6','0','VAT rate - super-reduced',1);
+insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (  64,   6, '8.1','0','VAT rate - standard',1);
 
 -- SRI LANKA (id country=207)
 insert into llx_c_tva(rowid,fk_pays,taux,recuperableonly,note,active) values (2071, 207,   '0','0','VAT 0', 1);


### PR DESCRIPTION
VAT in Switzerland was increased on January 1, 2024.

See: https://www.estv.admin.ch/estv/fr/accueil/taxe-sur-la-valeur-ajoutee/taux-tva-suisse.html