### PR TITLE
Fix VAT-Inclusive Price Recording Issue in Order Line Editing

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3231,7 +3231,7 @@ class Commande extends CommonOrder
 			$this->line->localtax1_type = empty($localtaxes_type[0]) ? '' : $localtaxes_type[0];
 			$this->line->localtax2_type = empty($localtaxes_type[2]) ? '' : $localtaxes_type[2];
 			$this->line->remise_percent = $remise_percent;
-			$this->line->subprice       = $subprice;
+			$this->line->subprice       = $pu_ht;
 			$this->line->info_bits      = $info_bits;
 			$this->line->special_code   = $special_code;
 			$this->line->total_ht       = $total_ht;


### PR DESCRIPTION
Description:
This pull request fixes a bug related to modifying order line prices . When a user only changes the tax-inclusive price and saves the order line, the price is incorrectly saved as a tax-exclusive price.

Changes Made:
I edited a variable and that fixed the issue, but I'm wondering if this is the right way to patch it.



I saw that this condition was deprecated so I took the liberty of not using the $subprice variable and passing the $pu_ht variable instead of $subprice.
![image](https://github.com/Dolibarr/dolibarr/assets/81382225/62c401eb-bfcb-4de9-93a5-a20c6672f885)
If my fix is accepted he will want me to remove the condition because the $subprice variable is not used.


There is also this line which is deprecated. I tried to uncomment it and it had no negative effect so I wonder what this property is for? 
![image](https://github.com/Dolibarr/dolibarr/assets/81382225/38ada42b-7475-4eb3-b12b-7007dad6616a)
It may be time to remove the line if it does not impact the application.



Problem Solved:
This fix resolves the issue where the edited VAT-inclusive price was saved as the VAT-exclusive. It ensures that users can modify and save the VAT-inclusive

Testing:
Manually tested by editing order lines to verify that the VAT-inclusive price is correctly recorded.

References:
Fixes the bug described in issue https://github.com/Dolibarr/dolibarr/issues/29771 .