### PR TITLE
FIX Extrafields always been delete and re insert for categories

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7029,7 +7029,7 @@ abstract class CommonObject
 
 			// Check if there is already a line for this object (in most cases, it is, but sometimes it is not, for example when extra field has been created after), so we must keep this overload)
 			$table_element = $this->table_element;
-			if ($table_element == 'categorie') {
+			if ($table_element == 'categorie') {	// TODO Rename table llx_categories_extrafields into llx_categorie_extrafields so we can remove this.
 				$table_element = 'categories'; // For compatibility
 			}
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7032,7 +7032,7 @@ abstract class CommonObject
 			if ($table_element == 'categorie') {
 				$table_element = 'categories'; // For compatibility
 			}
-			
+
 			$sql = "SELECT COUNT(rowid) as nb FROM ".$this->db->prefix().$table_element."_extrafields WHERE fk_object = ".((int) $this->id);
 			$resql = $this->db->query($sql);
 			if ($resql) {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7028,7 +7028,12 @@ abstract class CommonObject
 			$linealreadyfound = 0;
 
 			// Check if there is already a line for this object (in most cases, it is, but sometimes it is not, for example when extra field has been created after), so we must keep this overload)
-			$sql = "SELECT COUNT(rowid) as nb FROM ".$this->db->prefix().$this->table_element."_extrafields WHERE fk_object = ".((int) $this->id);
+			$table_element = $this->table_element;
+			if ($table_element == 'categorie') {
+				$table_element = 'categories'; // For compatibility
+			}
+			
+			$sql = "SELECT COUNT(rowid) as nb FROM ".$this->db->prefix().$table_element."_extrafields WHERE fk_object = ".((int) $this->id);
 			$resql = $this->db->query($sql);
 			if ($resql) {
 				$tmpobj = $this->db->fetch_object($resql);


### PR DESCRIPTION
To prevent the following issue: 
sql=SELECT COUNT(rowid) as nb FROM llx_categorie_extrafields WHERE fk_object = 842
ERR                      DoliDBMysqli::query Exception in query instead of returning an error: Table 'xxxxxxx.llx_categorie_extrafields' doesn't exist
ERR                      DoliDBMysqli::query SQL Error message: DB_ERROR_NOSUCHTABLE Table 'xxxxxxx.llx_categorie_extrafields' doesn't exist

As it done in line 6737, it's necessary to add a compatibility renaming of table_element for categories.
