### PR TITLE
FIX: X button remove filter bug when using expeditions search all

### DIFF
--- a/htdocs/expedition/list.php
+++ b/htdocs/expedition/list.php
@@ -209,6 +209,7 @@ if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter.x'
 	$toselect = array();
 	$search_array_options = array();
 	$search_categ_cus = 0;
+	$search_all = '';
 }
 
 if (empty($reshook)) {


### PR DESCRIPTION
To reproduce the bug : 
1. Use the dolibarr search to search a shipment.
2. Once on the shipment list, click on the remove filters button (X). The search_all is not removed.