### PR TITLE
NEW : add closing date to refused propals

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -2629,7 +2629,10 @@ class Propal extends CommonObject
 		$newprivatenote = dol_concatdesc($this->note_private, $note);
 
 		$sql  = "UPDATE ".MAIN_DB_PREFIX."propal";
-		$sql .= " SET fk_statut = ".((int) $status).", note_private = '".$this->db->escape($newprivatenote)."', date_signature='".$this->db->idate($now)."', fk_user_signature=".$user->id;
+		$sql .= " SET fk_statut = ".((int) $status).", note_private = '".$this->db->escape($newprivatenote)."', date_signature='".$this->db->idate($now)."', fk_user_signature=".((int) $user->id);
+		if ($status == self::STATUS_NOTSIGNED) {
+			$sql .= ", date_cloture='".$this->db->idate($now)."', fk_user_cloture=".((int) $user->id);
+		}
 		$sql .= " WHERE rowid = ".((int) $this->id);
 
 		$resql = $this->db->query($sql);


### PR DESCRIPTION
This PR is in line with #29825 and add a closing date to unsigned propals. Apart from their status, they will be distinguishable by the dates :

- Signed propal : a sign date and no closing date
- Unsignedigned propal : no sign date and a closing date
- Billed propal : a sign date and a closing date
