### PR TITLE
FIX: value mismatch when the entity of a FormSetupItem is not the current entity

### DIFF
--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -663,9 +663,7 @@ class FormSetupItem
 	 */
 	public function loadValueFromConf()
 	{
-		global $conf;
-		if (isset($conf->global->{$this->confKey})) {
-			$this->fieldValue = $conf->global->{$this->confKey};
+		if ($this->fieldValue = dolibarr_get_const($this->db, $this->confKey, $this->entity)) {
 			return true;
 		} else {
 			$this->fieldValue = null;


### PR DESCRIPTION
## Rationale
A FormSetupItem can have an `entity` that is different from `$conf->entity` (usually, when it is different, its value is `0` to make it a cross-entity conf). Currently, saving the conf is correctly implemented (saves to the specified entity), but loading the conf isn't (it takes the value from the current entity).

I made this fix weeks ago, while working on a feature that, ultimately, didn't require FormSetup at all, so I probably haven't tested it, or not extensively if I did.