### PR TITLE
#29103 Fix error in export part of the builder module

### DIFF
--- a/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
+++ b/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
@@ -409,7 +409,7 @@ class modMyModule extends DolibarrModules
 		//$this->export_help_array[$r] = array('t.field'=>'FieldDescHelp');
 		$this->export_sql_start[$r]='SELECT DISTINCT ';
 		$this->export_sql_end[$r]  =' FROM '.MAIN_DB_PREFIX.'mymodule_myobject as t';
-		//$this->export_sql_end[$r]  =' LEFT JOIN '.MAIN_DB_PREFIX.'mymodule_myobject_line as tl ON tl.fk_myobject = t.rowid';
+		//$this->export_sql_end[$r]  .=' LEFT JOIN '.MAIN_DB_PREFIX.'mymodule_myobject_line as tl ON tl.fk_myobject = t.rowid';
 		$this->export_sql_end[$r] .=' WHERE 1 = 1';
 		$this->export_sql_end[$r] .=' AND t.entity IN ('.getEntity('myobject').')';
 		$r++; */


### PR DESCRIPTION
# Fix #29103 Fix error in export part of the builder module
In the builder module, suggestions are offered by default. Just remove the comments for this to work.

Except for this line:
//$this->export_sql_end[$r] =' LEFT JOIN '.MAIN_DB_PREFIX.'competence_line as tl ON tl.fk_competence = t.rowid';

A "point" is missing before the "equal":
//$this->export_sql_end[$r] .=' LEFT JOIN '.MAIN_DB_PREFIX.'competence_line as tl ON tl.fk_competence = t.rowid';

The problem is the overwriting of part of the query, if we want to couple other tables.
