### PR TITLE
FIX updateTotal timesheet.js

### DIFF
--- a/htdocs/core/js/timesheet.js
+++ b/htdocs/core/js/timesheet.js
@@ -1,6 +1,6 @@
 /* Copyright (C) 2014      delcroip            <delcroip@gmail.com>
  * Copyright (C) 2015-2017 Laurent Destailleur <eldy@users.sourceforge.net>
- * Copyright (C) 2021      Josep Lluís Amador  <joseplluis@lliuretic.cat>
+ * Copyright (C) 2021-2024 Josep Lluís Amador  <joseplluis@lliuretic.cat>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -144,9 +144,10 @@ function updateTotal(days,mode)
                 }
                 if (result >= 0)
                 {
-                	nbextradays = nbextradays + Math.floor((total.getHours()+taskTime.getHours() + result*24) / 24);
+                	nbextrahour = Math.floor((total.getMinutes()+taskTime.getMinutes()) / 60);
+                	nbextradays = nbextradays + Math.floor((total.getHours()+taskTime.getHours() + nbextrahour + result*24) / 24);
                 	//console.log("i="+i+" result="+result);
-			    	total.setHours(total.getHours()+taskTime.getHours());
+                	total.setHours(total.getHours()+taskTime.getHours());
                 	total.setMinutes(total.getMinutes()+taskTime.getMinutes());
             		//console.log("i="+i+" nbextradays cumul="+nbextradays+" h="+total.getHours()+" "+taskTime.getHours());
                 }
@@ -170,7 +171,8 @@ function updateTotal(days,mode)
                 }
                 if (result >= 0)
                 {
-                	nbextradays = nbextradays + Math.floor((total.getHours()+taskTime.getHours() + result*24) / 24);
+			nbextrahour = Math.floor((total.getMinutes()+taskTime.getMinutes()) / 60);
+                	nbextradays = nbextradays + Math.floor((total.getHours()+taskTime.getHours() + nbextrahour + result*24) / 24);
                 	//console.log("i="+i+" result="+result);
                 	total.setHours(total.getHours()+taskTime.getHours());
                 	total.setMinutes(total.getMinutes()+taskTime.getMinutes());


### PR DESCRIPTION
FIX updateTotal timesheet.js
In some cases, calculation of nbextradays in total is wrong, because the extra hours accumulated by the current task minutes are not considered

For example, if the accumulated hours are 22:30, and the next task to be added is 1:30h, the new extra day would not be computed in total.