### PR TITLE
fix: cookie JS creation missing defaut attribute SameSite

### DIFF
--- a/htdocs/core/ajax/row.php
+++ b/htdocs/core/ajax/row.php
@@ -76,7 +76,6 @@ print '<!-- Ajax page called with url '.dol_escape_htmltag($_SERVER["PHP_SELF"])
 // Registering the location of boxes
 if (GETPOST('roworder', 'alpha', 3) && GETPOST('table_element_line', 'aZ09', 3)
 	&& GETPOST('fk_element', 'aZ09', 3) && GETPOSTINT('element_id', 3)) {
-
 	// Make test on permission
 	$perm = 0;
 	if ($table_element_line == 'propaldet' && $user->hasRight('propal', 'creer')) {

--- a/htdocs/core/boxes/box_task.php
+++ b/htdocs/core/boxes/box_task.php
@@ -124,7 +124,7 @@ class box_task extends ModeleBoxes
 						});
 						</script>';
 				// set cookie by js
-				$boxcontent .= '<script nonce="'.getNonce().'">date = new Date(); date.setTime(date.getTime()+(30*86400000)); document.cookie = "'.$cookie_name.'='.$filterValue.'; expires= " + date.toGMTString() + "; path=/ "; </script>';
+				$boxcontent .= '<script nonce="'.getNonce().'">date = new Date(); date.setTime(date.getTime()+(30*86400000)); document.cookie = "'.$cookie_name.'='.$filterValue.'; expires= " + date.toGMTString() + "; path=/ ; SameSite=Lax"; </script>';
 			}
 			$this->info_box_contents[0][] = array(
 				'tr' => 'class="nohover showiffilter'.$this->boxcode.' hideobject"',

--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -1078,7 +1078,7 @@ class FormSetupItem
 			$max = $genhandler->length2;
 		}
 		$out = '<input required="required" type="password" class="flat" id="'.$this->confKey.'" name="'.$this->confKey.'" value="'.(GETPOST($this->confKey, 'alpha') ? GETPOST($this->confKey, 'alpha') : $this->fieldValue).'"';
-		if ($min){
+		if ($min) {
 			$out .= ' minlength="' . $min . '"';
 		}
 		if ($max) {

--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -16,9 +16,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
-
-
 /**
  * This class help you create setup render
  */

--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -17,6 +17,8 @@
  */
 
 
+
+
 /**
  * This class help you create setup render
  */
@@ -1078,7 +1080,7 @@ class FormSetupItem
 			$max = $genhandler->length2;
 		}
 		$out = '<input required="required" type="password" class="flat" id="'.$this->confKey.'" name="'.$this->confKey.'" value="'.(GETPOST($this->confKey, 'alpha') ? GETPOST($this->confKey, 'alpha') : $this->fieldValue).'"';
-		if ($min){
+		if ($min) {
 			$out .= ' minlength="' . $min . '"';
 		}
 		if ($max) {


### PR DESCRIPTION
![image](https://github.com/Dolibarr/dolibarr/assets/1050053/db98a078-fc8a-428c-9574-52f43cfff972)


Le cookie « DOLUSERCOOKIE_boxfilter_task » n’a pas de valeur d’attribut « SameSite » appropriée. Bientôt, les cookies dont l’attribut « SameSite » est manquant ou défini avec une valeur invalide seront traités comme « Lax ». Cela signifie que le cookie ne sera plus envoyé dans des contextes tiers. Si votre application dépend de la disponibilité de ce cookie dans de tels contextes, veuillez lui ajouter l’attribut « SameSite=None ». Pour en savoir plus sur l’attribut « SameSite », consultez https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite