### PR TITLE
fix: .pre-commit-config.yaml Expected one of [...] push but got: 'pre-commit'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: end-of-file-fixer
       # Check that there are no completely merged file conflicts
       - id: check-merge-conflict
-        stages: [pre-commit, pre-rebase, pre-commit, pre-merge-commit]
+        stages: [merge-commit]
       # Check that files with shebangs have the executable bit set (in git)
       - id: check-executables-have-shebangs
       # Check that shell files are executables
@@ -239,7 +239,7 @@ repos:
     rev: 3.0.4
     hooks:
       - id: sqlfluff-lint
-        stages: [pre-commit, manual]  # manual needed for ci
+        stages: [commit, manual]  # manual needed for ci
         exclude: (?x)^
           (htdocs/includes/.*
           |htdocs/install/doctemplates/websites/.*_template

--- a/htdocs/core/ajax/row.php
+++ b/htdocs/core/ajax/row.php
@@ -76,7 +76,6 @@ print '<!-- Ajax page called with url '.dol_escape_htmltag($_SERVER["PHP_SELF"])
 // Registering the location of boxes
 if (GETPOST('roworder', 'alpha', 3) && GETPOST('table_element_line', 'aZ09', 3)
 	&& GETPOST('fk_element', 'aZ09', 3) && GETPOSTINT('element_id', 3)) {
-
 	// Make test on permission
 	$perm = 0;
 	if ($table_element_line == 'propaldet' && $user->hasRight('propal', 'creer')) {

--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -1078,7 +1078,7 @@ class FormSetupItem
 			$max = $genhandler->length2;
 		}
 		$out = '<input required="required" type="password" class="flat" id="'.$this->confKey.'" name="'.$this->confKey.'" value="'.(GETPOST($this->confKey, 'alpha') ? GETPOST($this->confKey, 'alpha') : $this->fieldValue).'"';
-		if ($min){
+		if ($min) {
 			$out .= ' minlength="' . $min . '"';
 		}
 		if ($max) {


### PR DESCRIPTION
log of pre-commit.log

An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
==> At Config()
==> At key: repos
==> At Repository(repo='https://github.com/sqlfluff/sqlfluff')
==> At key: hooks
==> At Hook(id='sqlfluff-lint')
==> At key: stages
==> At index 0
=====> Expected one of commit, commit-msg, manual, merge-commit, post-checkout, post-commit, post-merge, post-rewrite, prepare-commit-msg, push but got: 'pre-commit'