### PR TITLE
remove warning phpstan

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -121,12 +121,6 @@ class ActionComm extends CommonObject
 	public $label;
 
 	/**
-	 * @var string Agenda event label
-	 * @deprecated Use $label
-	 */
-	private $libelle;
-
-	/**
 	 * @var int Date creation record (datec)
 	 */
 	public $datec;


### PR DESCRIPTION
Property ActionComm::$libelle is unused.
Is it deliberate to keep this property depreciated?