### PR TITLE
FIX : Missing hook in getElementProperties

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -12166,7 +12166,7 @@ function getElementProperties($element_type)
 		'dir_output' => $dir_output
 	);
 
-	$reshook = $hookmanager->executeHooks('changeElementProperties', $parameters);
+	$reshook = $hookmanager->executeHooks('getElementProperties', $parameters);
 	if ($reshook < 0) {
 		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 	} elseif ($reshook > 0) {

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -11872,7 +11872,7 @@ function dolGetButtonTitle($label, $helpText = '', $iconClass = 'fa fa-file', $u
  */
 function getElementProperties($element_type)
 {
-	global $conf;
+	global $conf, $hookmanager;
 
 	$regs = array();
 
@@ -12143,6 +12143,18 @@ function getElementProperties($element_type)
 	}
 	$dir_output .= $subdir;
 
+	$parameters = array(
+		'element_type' => $element_type,
+		'module' => $module,
+		'element' => $element,
+		'table_element' => $table_element,
+		'subelement' => $subelement,
+		'classpath' => $classpath,
+		'classfile' => $classfile,
+		'classname' => $classname,
+		'dir_output' => $dir_output
+	);
+
 	$element_properties = array(
 		'module' => $module,
 		'element' => $element,
@@ -12154,7 +12166,15 @@ function getElementProperties($element_type)
 		'dir_output' => $dir_output
 	);
 
-	//var_dump($element_properties);
+	$reshook = $hookmanager->executeHooks('changeElementProperties', $parameters);
+	if ($reshook < 0) {
+		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	} elseif ($reshook > 0) {
+		$element_properties = $hookmanager->resArray;
+	} elseif ($reshook == 0) {
+		$element_properties = array_merge($element_properties, $hookmanager->resArray);
+	}
+
 	return $element_properties;
 }
 


### PR DESCRIPTION
#FIX|Fix Missing hook in getElementProperties
I added the missing hook in getElementProperties to handle $element_properties array because of some errors for permissions