### PR TITLE
Fix : expense report reapproval email, wrong date format + missing param

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -502,8 +502,7 @@ if (empty($reshook)) {
 				// CONTENT
 				$link = $urlwithroot.'/expensereport/card.php?id='.$object->id;
 				$link = '<a href="'.$link.'">'.$link.'</a>';
-				$dateRefusEx = explode(" ", $object->date_refuse);
-				$message = $langs->transnoentities("ExpenseReportWaitingForReApprovalMessage", $dateRefusEx[0], $object->detail_refuse, $expediteur->getFullName($langs), $link);
+				$message = $langs->transnoentities("ExpenseReportWaitingForReApprovalMessage", dol_print_date($object->date_refuse, 'day'), $object->detail_refuse, $expediteur->getFullName($langs), get_date_range($object->date_debut, $object->date_fin, '', $langs), $link);
 
 				// Rebuild pdf
 				/*


### PR DESCRIPTION
When sending an expense report for **_re_**approval (after refuse), the email sent contains a wrong date format and the "period" parameter is missing in the message

![image](https://github.com/Dolibarr/dolibarr/assets/2097773/de10d92b-7f75-4df7-8f58-1d60f38c6372)
