### PR TITLE
FIX : fix restrictedArea on selectobject for a third-party modules

### DIFF
--- a/htdocs/core/ajax/selectobject.php
+++ b/htdocs/core/ajax/selectobject.php
@@ -84,7 +84,11 @@ if (!is_object($objecttmp)) {
 $searchkey = (($id && GETPOST($id, 'alpha')) ? GETPOST($id, 'alpha') : (($htmlname && GETPOST($htmlname, 'alpha')) ? GETPOST($htmlname, 'alpha') : ''));
 
 // Add a security test to avoid to get content of all tables
-restrictedArea($user, $objecttmp->element, $id);
+if (!empty($objecttmp->module)) {
+    restrictedArea($user, $objecttmp->module, $id, $objecttmp->table_element, $objecttmp->element);
+}else {
+    restrictedArea($user, $objecttmp->element, $id);
+}
 
 $arrayresult = $form->selectForFormsList($objecttmp, $htmlname, '', 0, $searchkey, '', '', '', 0, 1);
 


### PR DESCRIPTION
Hello,

I was trying to add some extra fields from my custom module to the proposal object. However, with the configuration "OBJECTNAME_USE_SEARCH_TO_SELECT" (to make asynchronous calls instead of displaying a list), the input wasn't working with the objects from my module.

This issue is caused by the restrictedArea() function, where the necessary parameters were not being sent.

BEFORE : 
<img width="498" alt="image" src="https://github.com/Dolibarr/dolibarr/assets/85104766/929df8a6-d57e-4a71-aa22-6fa3c7f7c287">
<img width="466" alt="image" src="https://github.com/Dolibarr/dolibarr/assets/85104766/14bf899b-f56c-4c6f-8487-4f2f18b9bd54">

NOW :
<img width="445" alt="image" src="https://github.com/Dolibarr/dolibarr/assets/85104766/b68b44a3-28d0-484b-9221-26a51b07d471">

I tested with some objects who got $module defined or not