### PR TITLE
FIX date_echeance of supplier invoices not updated

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -389,9 +389,8 @@ if (empty($reshook)) {
 		}
 
 		if (!$error) {
-			$old_date_echeance = $object->date_echeance;
 			$new_date_echeance = $object->calculate_date_lim_reglement();
-			if ($new_date_echeance > $old_date_echeance) {
+			if ($new_date_echeance) {
 				$object->date_echeance = $new_date_echeance;
 			}
 			if ($object->date_echeance < $object->date) {
@@ -455,7 +454,7 @@ if (empty($reshook)) {
 
 		$object->date = $newdate;
 		$date_echence_calc = $object->calculate_date_lim_reglement();
-		if (!empty($object->date_echeance) && $object->date_echeance < $date_echence_calc) {
+		if (!empty($object->date_echeance)) {
 			$object->date_echeance = $date_echence_calc;
 		}
 		if ($object->date_echeance && $object->date_echeance < $object->date) {


### PR DESCRIPTION
FIX update date_echeance of supplier invoices when we update invoice date in the past

When we update the date of supplier invoices in the past, the date_echeance was not updated if the new calculated date_echeance is before the current date_echeance. The same goes if we update the payment term of supplier invoice, the date echeance is not updated if the new calculated date_echeance is before the current date_echeance. With this PR, when we update the supplier invoice date or payment term, the date_echeance is updated even if the new calculated date_echeance is before the current date_echeance.
