### PR TITLE
NEW : Add pagination data to some api routes

### DIFF
--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -159,7 +159,7 @@ class Proposals extends DolibarrApi
 	 * @param string    $sqlfilters         Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'2016-01-01')"
 	 * @param string    $properties	        Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool      $pagination_data    If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
-     * @return  array                       Array of order objects
+	 * @return  array                       Array of order objects
 	 */
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
@@ -249,9 +249,9 @@ class Proposals extends DolibarrApi
 
 			$obj_ret['data'] = $tmp;
 			$obj_ret['pagination'] = [
-				'total' => (int)$total,
+				'total' => (int) $total,
 				'page' => $page, //count starts from 0
-				'page_count' => ceil((int)$total / $limit),
+				'page_count' => ceil((int) $total / $limit),
 				'limit' => $limit
 			];
 		}

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -158,7 +158,7 @@ class Proposals extends DolibarrApi
 	 * @param string	$thirdparty_ids		Thirdparty ids to filter commercial proposals (example '1' or '1,2,3') {@pattern /^[0-9,]*$/i}
 	 * @param string    $sqlfilters         Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'2016-01-01')"
 	 * @param string    $properties	        Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-     * @param bool      $pagination_data    If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+	 * @param bool      $pagination_data    If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
      * @return  array                       Array of order objects
 	 */
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false)
@@ -202,10 +202,10 @@ class Proposals extends DolibarrApi
 			}
 		}
 
-        //this query will return total proposals with the filters given
-        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+		//this query will return total proposals with the filters given
+		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
-        $sql .= $this->db->order($sortfield, $sortorder);
+		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -239,22 +239,22 @@ class Proposals extends DolibarrApi
 			throw new RestException(503, 'Error when retrieve propal list : '.$this->db->lasterror());
 		}
 
-        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
-        if ($pagination_data) {
-            $totalsResult = $this->db->query($sqlTotals);
-            $total = $this->db->fetch_object($totalsResult)->total;
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$totalsResult = $this->db->query($sqlTotals);
+			$total = $this->db->fetch_object($totalsResult)->total;
 
-            $tmp = $obj_ret;
-            $obj_ret = [];
+			$tmp = $obj_ret;
+			$obj_ret = [];
 
-            $obj_ret['data'] = $tmp;
-            $obj_ret['pagination'] = [
-                'total' => (int) $total,
-                'page' => $page, //count starts from 0
-                'page_count' => ceil((int) $total/$limit),
-                'limit' => $limit
-            ];
-        }
+			$obj_ret['data'] = $tmp;
+			$obj_ret['pagination'] = [
+				'total' => (int)$total,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int)$total / $limit),
+				'limit' => $limit
+			];
+		}
 
 		return $obj_ret;
 	}

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -157,10 +157,11 @@ class Proposals extends DolibarrApi
 	 * @param int		$page				Page number
 	 * @param string	$thirdparty_ids		Thirdparty ids to filter commercial proposals (example '1' or '1,2,3') {@pattern /^[0-9,]*$/i}
 	 * @param string    $sqlfilters         Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'2016-01-01')"
-	 * @param string    $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @return  array                       Array of order objects
+	 * @param string    $properties	        Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+     * @param bool      $pagination_data    If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+     * @return  array                       Array of order objects
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('propal', 'lire')) {
 			throw new RestException(403);
@@ -201,7 +202,10 @@ class Proposals extends DolibarrApi
 			}
 		}
 
-		$sql .= $this->db->order($sortfield, $sortorder);
+        //this query will return total proposals with the filters given
+        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+
+        $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -234,6 +238,23 @@ class Proposals extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve propal list : '.$this->db->lasterror());
 		}
+
+        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+        if ($pagination_data) {
+            $totalsResult = $this->db->query($sqlTotals);
+            $total = $this->db->fetch_object($totalsResult)->total;
+
+            $tmp = $obj_ret;
+            $obj_ret = [];
+
+            $obj_ret['data'] = $tmp;
+            $obj_ret['pagination'] = [
+                'total' => (int) $total,
+                'page' => $page, //count starts from 0
+                'page_count' => ceil((int) $total/$limit),
+                'limit' => $limit
+            ];
+        }
 
 		return $obj_ret;
 	}

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -158,7 +158,7 @@ class Orders extends DolibarrApi
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string           $sqlfilterlines      Other criteria to filter answers separated by a comma. Syntax example "(tl.fk_product:=:'17') and (tl.price:<:'250')"
 	 * @param string		   $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-     * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+	 * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
      * @return  array                               Array of order objects
 	 *
 	 * @throws RestException 404 Not found
@@ -215,8 +215,8 @@ class Orders extends DolibarrApi
 			}
 		}
 
-        //this query will return total orders with the filters given
-        $sqlTotals =  str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+		//this query will return total orders with the filters given
+		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
         $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
@@ -256,24 +256,24 @@ class Orders extends DolibarrApi
 			throw new RestException(503, 'Error when retrieve commande list : '.$this->db->lasterror());
 		}
 
-        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
-        if ($pagination_data) {
-            $totalsResult = $this->db->query($sqlTotals);
-            $total = $this->db->fetch_object($totalsResult)->total;
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$totalsResult = $this->db->query($sqlTotals);
+			$total = $this->db->fetch_object($totalsResult)->total;
 
-            $tmp = $obj_ret;
-            $obj_ret = [];
+			$tmp = $obj_ret;
+			$obj_ret = [];
 
-            $obj_ret['data'] = $tmp;
-            $obj_ret['pagination'] = [
-                'total' => (int) $total,
-                'page' => $page, //count starts from 0
-                'page_count' => ceil((int) $total/$limit),
-                'limit' => $limit
-            ];
-        }
+			$obj_ret['data'] = $tmp;
+			$obj_ret['pagination'] = [
+				'total' => (int)$total,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int)$total / $limit),
+				'limit' => $limit
+			];
+		}
 
-        return $obj_ret;
+		return $obj_ret;
 	}
 
 	/**

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -159,7 +159,7 @@ class Orders extends DolibarrApi
 	 * @param string           $sqlfilterlines      Other criteria to filter answers separated by a comma. Syntax example "(tl.fk_product:=:'17') and (tl.price:<:'250')"
 	 * @param string		   $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
-     * @return  array                               Array of order objects
+	 * @return  array                               Array of order objects
 	 *
 	 * @throws RestException 404 Not found
 	 * @throws RestException 503 Error
@@ -218,7 +218,7 @@ class Orders extends DolibarrApi
 		//this query will return total orders with the filters given
 		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
-        $sql .= $this->db->order($sortfield, $sortorder);
+		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -266,9 +266,9 @@ class Orders extends DolibarrApi
 
 			$obj_ret['data'] = $tmp;
 			$obj_ret['pagination'] = [
-				'total' => (int)$total,
+				'total' => (int) $total,
 				'page' => $page, //count starts from 0
-				'page_count' => ceil((int)$total / $limit),
+				'page_count' => ceil((int) $total / $limit),
 				'limit' => $limit
 			];
 		}

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -158,12 +158,13 @@ class Orders extends DolibarrApi
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string           $sqlfilterlines      Other criteria to filter answers separated by a comma. Syntax example "(tl.fk_product:=:'17') and (tl.price:<:'250')"
 	 * @param string		   $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @return  array                               Array of order objects
+     * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+     * @return  array                               Array of order objects
 	 *
 	 * @throws RestException 404 Not found
 	 * @throws RestException 503 Error
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $sqlfilterlines = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $sqlfilterlines = '', $properties = '', $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('commande', 'lire')) {
 			throw new RestException(403);
@@ -213,7 +214,11 @@ class Orders extends DolibarrApi
 				throw new RestException(400, 'Error when validating parameter sqlfilterlines -> '.$errormessage);
 			}
 		}
-		$sql .= $this->db->order($sortfield, $sortorder);
+
+        //this query will return total orders with the filters given
+        $sqlTotals =  str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+
+        $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -251,7 +256,24 @@ class Orders extends DolibarrApi
 			throw new RestException(503, 'Error when retrieve commande list : '.$this->db->lasterror());
 		}
 
-		return $obj_ret;
+        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+        if ($pagination_data) {
+            $totalsResult = $this->db->query($sqlTotals);
+            $total = $this->db->fetch_object($totalsResult)->total;
+
+            $tmp = $obj_ret;
+            $obj_ret = [];
+
+            $obj_ret['data'] = $tmp;
+            $obj_ret['pagination'] = [
+                'total' => (int) $total,
+                'page' => $page, //count starts from 0
+                'page_count' => ceil((int) $total/$limit),
+                'limit' => $limit
+            ];
+        }
+
+        return $obj_ret;
 	}
 
 	/**

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -180,7 +180,7 @@ class Invoices extends DolibarrApi
 	 * @param string    $sqlfilters       Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string    $properties	      Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0
-     * @return array                      Array of invoice objects
+	 * @return array                      Array of invoice objects
 	 *
 	 * @throws RestException 404 Not found
 	 * @throws RestException 503 Error
@@ -294,9 +294,9 @@ class Invoices extends DolibarrApi
 
 			$obj_ret['data'] = $tmp;
 			$obj_ret['pagination'] = [
-				'total' => (int)$total,
+				'total' => (int) $total,
 				'page' => $page, //count starts from 0
-				'page_count' => ceil((int)$total / $limit),
+				'page_count' => ceil((int) $total / $limit),
 				'limit' => $limit
 			];
 		}

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -179,7 +179,7 @@ class Invoices extends DolibarrApi
 	 * @param string	$status			  Filter by invoice status : draft | unpaid | paid | cancelled
 	 * @param string    $sqlfilters       Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string    $properties	      Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-     * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0
+	 * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0
      * @return array                      Array of invoice objects
 	 *
 	 * @throws RestException 404 Not found
@@ -239,8 +239,8 @@ class Invoices extends DolibarrApi
 			}
 		}
 
-        //this query will return total invoices with the filters given
-        $sqlTotals =  str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+		//this query will return total invoices with the filters given
+		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
 		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
@@ -284,22 +284,22 @@ class Invoices extends DolibarrApi
 			throw new RestException(503, 'Error when retrieve invoice list : '.$this->db->lasterror());
 		}
 
-        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
-        if ($pagination_data) {
-            $totalsResult = $this->db->query($sqlTotals);
-            $total = $this->db->fetch_object($totalsResult)->total;
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$totalsResult = $this->db->query($sqlTotals);
+			$total = $this->db->fetch_object($totalsResult)->total;
 
-            $tmp = $obj_ret;
-            $obj_ret = [];
+			$tmp = $obj_ret;
+			$obj_ret = [];
 
-            $obj_ret['data'] = $tmp;
-            $obj_ret['pagination'] = [
-                'total' => (int) $total,
-                'page' => $page, //count starts from 0
-                'page_count' => ceil((int) $total/$limit),
-                'limit' => $limit
-            ];
-        }
+			$obj_ret['data'] = $tmp;
+			$obj_ret['pagination'] = [
+				'total' => (int)$total,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int)$total / $limit),
+				'limit' => $limit
+			];
+		}
 
 		return $obj_ret;
 	}

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -178,13 +178,14 @@ class Invoices extends DolibarrApi
 	 * @param string	$thirdparty_ids	  Thirdparty ids to filter orders of (example '1' or '1,2,3') {@pattern /^[0-9,]*$/i}
 	 * @param string	$status			  Filter by invoice status : draft | unpaid | paid | cancelled
 	 * @param string    $sqlfilters       Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
-	 * @param string    $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @return array                      Array of invoice objects
+	 * @param string    $properties	      Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+     * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0
+     * @return array                      Array of invoice objects
 	 *
 	 * @throws RestException 404 Not found
 	 * @throws RestException 503 Error
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $status = '', $sqlfilters = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $status = '', $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('facture', 'lire')) {
 			throw new RestException(403);
@@ -238,6 +239,9 @@ class Invoices extends DolibarrApi
 			}
 		}
 
+        //this query will return total invoices with the filters given
+        $sqlTotals =  str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+
 		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
@@ -279,6 +283,23 @@ class Invoices extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve invoice list : '.$this->db->lasterror());
 		}
+
+        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+        if ($pagination_data) {
+            $totalsResult = $this->db->query($sqlTotals);
+            $total = $this->db->fetch_object($totalsResult)->total;
+
+            $tmp = $obj_ret;
+            $obj_ret = [];
+
+            $obj_ret['data'] = $tmp;
+            $obj_ret['pagination'] = [
+                'total' => (int) $total,
+                'page' => $page, //count starts from 0
+                'page_count' => ceil((int) $total/$limit),
+                'limit' => $limit
+            ];
+        }
 
 		return $obj_ret;
 	}

--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -96,7 +96,7 @@ class Shipments extends DolibarrApi
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string		   $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
-     * @return  array                               Array of shipment objects
+	 * @return  array                               Array of shipment objects
 	 *
 	 * @throws RestException
 	 */
@@ -144,7 +144,7 @@ class Shipments extends DolibarrApi
 		//this query will return total shipments with the filters given
 		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
-        $sql .= $this->db->order($sortfield, $sortorder);
+		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -183,9 +183,9 @@ class Shipments extends DolibarrApi
 
 			$obj_ret['data'] = $tmp;
 			$obj_ret['pagination'] = [
-				'total' => (int)$total,
+				'total' => (int) $total,
 				'page' => $page, //count starts from 0
-				'page_count' => ceil((int)$total / $limit),
+				'page_count' => ceil((int) $total / $limit),
 				'limit' => $limit
 			];
 		}

--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -95,7 +95,7 @@ class Shipments extends DolibarrApi
 	 * @param string		   $thirdparty_ids		Thirdparty ids to filter shipments of (example '1' or '1,2,3') {@pattern /^[0-9,]*$/i}
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string		   $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-     * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+	 * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
      * @return  array                               Array of shipment objects
 	 *
 	 * @throws RestException
@@ -141,8 +141,8 @@ class Shipments extends DolibarrApi
 			}
 		}
 
-        //this query will return total shipments with the filters given
-        $sqlTotals =  str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+		//this query will return total shipments with the filters given
+		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
         $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
@@ -173,22 +173,22 @@ class Shipments extends DolibarrApi
 			throw new RestException(503, 'Error when retrieve commande list : '.$this->db->lasterror());
 		}
 
-        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
-        if ($pagination_data) {
-            $totalsResult = $this->db->query($sqlTotals);
-            $total = $this->db->fetch_object($totalsResult)->total;
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$totalsResult = $this->db->query($sqlTotals);
+			$total = $this->db->fetch_object($totalsResult)->total;
 
-            $tmp = $obj_ret;
-            $obj_ret = [];
+			$tmp = $obj_ret;
+			$obj_ret = [];
 
-            $obj_ret['data'] = $tmp;
-            $obj_ret['pagination'] = [
-                'total' => (int) $total,
-                'page' => $page, //count starts from 0
-                'page_count' => ceil((int) $total/$limit),
-                'limit' => $limit
-            ];
-        }
+			$obj_ret['data'] = $tmp;
+			$obj_ret['pagination'] = [
+				'total' => (int)$total,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int)$total / $limit),
+				'limit' => $limit
+			];
+		}
 
 		return $obj_ret;
 	}

--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -95,11 +95,12 @@ class Shipments extends DolibarrApi
 	 * @param string		   $thirdparty_ids		Thirdparty ids to filter shipments of (example '1' or '1,2,3') {@pattern /^[0-9,]*$/i}
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string		   $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @return  array                               Array of shipment objects
+     * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+     * @return  array                               Array of shipment objects
 	 *
 	 * @throws RestException
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('expedition', 'lire')) {
 			throw new RestException(403);
@@ -140,7 +141,10 @@ class Shipments extends DolibarrApi
 			}
 		}
 
-		$sql .= $this->db->order($sortfield, $sortorder);
+        //this query will return total shipments with the filters given
+        $sqlTotals =  str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+
+        $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -168,6 +172,23 @@ class Shipments extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve commande list : '.$this->db->lasterror());
 		}
+
+        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+        if ($pagination_data) {
+            $totalsResult = $this->db->query($sqlTotals);
+            $total = $this->db->fetch_object($totalsResult)->total;
+
+            $tmp = $obj_ret;
+            $obj_ret = [];
+
+            $obj_ret['data'] = $tmp;
+            $obj_ret['pagination'] = [
+                'total' => (int) $total,
+                'page' => $page, //count starts from 0
+                'page_count' => ceil((int) $total/$limit),
+                'limit' => $limit
+            ];
+        }
 
 		return $obj_ret;
 	}

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -98,11 +98,12 @@ class SupplierInvoices extends DolibarrApi
 	 * @param string	$status			  Filter by invoice status : draft | unpaid | paid | cancelled
 	 * @param string    $sqlfilters       Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'20160101')"
 	 * @param string    $properties		  Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @return array                      Array of invoice objects
+     * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+     * @return array                      Array of invoice objects
 	 *
 	 * @throws RestException
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $status = '', $sqlfilters = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $status = '', $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight("fournisseur", "facture", "lire")) {
 			throw new RestException(403);
@@ -156,7 +157,10 @@ class SupplierInvoices extends DolibarrApi
 			}
 		}
 
-		$sql .= $this->db->order($sortfield, $sortorder);
+        //this query will return total supplier invoices with the filters given
+        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+
+        $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -182,6 +186,23 @@ class SupplierInvoices extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve supplier invoice list : ' . $this->db->lasterror());
 		}
+
+        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+        if ($pagination_data) {
+            $totalsResult = $this->db->query($sqlTotals);
+            $total = $this->db->fetch_object($totalsResult)->total;
+
+            $tmp = $obj_ret;
+            $obj_ret = [];
+
+            $obj_ret['data'] = $tmp;
+            $obj_ret['pagination'] = [
+                'total' => (int) $total,
+                'page' => $page, //count starts from 0
+                'page_count' => ceil((int) $total/$limit),
+                'limit' => $limit
+            ];
+        }
 
 		return $obj_ret;
 	}

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -98,7 +98,7 @@ class SupplierInvoices extends DolibarrApi
 	 * @param string	$status			  Filter by invoice status : draft | unpaid | paid | cancelled
 	 * @param string    $sqlfilters       Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'20160101')"
 	 * @param string    $properties		  Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-     * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+	 * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
      * @return array                      Array of invoice objects
 	 *
 	 * @throws RestException
@@ -157,8 +157,8 @@ class SupplierInvoices extends DolibarrApi
 			}
 		}
 
-        //this query will return total supplier invoices with the filters given
-        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+		//this query will return total supplier invoices with the filters given
+		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
         $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
@@ -187,22 +187,22 @@ class SupplierInvoices extends DolibarrApi
 			throw new RestException(503, 'Error when retrieve supplier invoice list : ' . $this->db->lasterror());
 		}
 
-        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
-        if ($pagination_data) {
-            $totalsResult = $this->db->query($sqlTotals);
-            $total = $this->db->fetch_object($totalsResult)->total;
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$totalsResult = $this->db->query($sqlTotals);
+			$total = $this->db->fetch_object($totalsResult)->total;
 
-            $tmp = $obj_ret;
-            $obj_ret = [];
+			$tmp = $obj_ret;
+			$obj_ret = [];
 
-            $obj_ret['data'] = $tmp;
-            $obj_ret['pagination'] = [
-                'total' => (int) $total,
-                'page' => $page, //count starts from 0
-                'page_count' => ceil((int) $total/$limit),
-                'limit' => $limit
-            ];
-        }
+			$obj_ret['data'] = $tmp;
+			$obj_ret['pagination'] = [
+				'total' => (int)$total,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int)$total / $limit),
+				'limit' => $limit
+			];
+		}
 
 		return $obj_ret;
 	}

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -99,7 +99,7 @@ class SupplierInvoices extends DolibarrApi
 	 * @param string    $sqlfilters       Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'20160101')"
 	 * @param string    $properties		  Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
-     * @return array                      Array of invoice objects
+	 * @return array                      Array of invoice objects
 	 *
 	 * @throws RestException
 	 */
@@ -160,7 +160,7 @@ class SupplierInvoices extends DolibarrApi
 		//this query will return total supplier invoices with the filters given
 		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
-        $sql .= $this->db->order($sortfield, $sortorder);
+		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -197,9 +197,9 @@ class SupplierInvoices extends DolibarrApi
 
 			$obj_ret['data'] = $tmp;
 			$obj_ret['pagination'] = [
-				'total' => (int)$total,
+				'total' => (int) $total,
 				'page' => $page, //count starts from 0
-				'page_count' => ceil((int)$total / $limit),
+				'page_count' => ceil((int) $total / $limit),
 				'limit' => $limit
 			];
 		}

--- a/htdocs/fourn/class/api_supplier_orders.class.php
+++ b/htdocs/fourn/class/api_supplier_orders.class.php
@@ -95,7 +95,7 @@ class SupplierOrders extends DolibarrApi
 	 * @param string    $sqlfilters       Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'20160101')"
 	 * @param string    $sqlfilterlines   Other criteria to filter answers separated by a comma. Syntax example "(tl.fk_product:=:'17') and (tl.price:<:'250')"
 	 * @param string    $properties		  Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-     * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+	 * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
      * @return array                      Array of order objects
 	 *
 	 * @throws RestException
@@ -182,8 +182,8 @@ class SupplierOrders extends DolibarrApi
 			}
 		}
 
-        //this query will return total supplier orders with the filters given
-        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+		//this query will return total supplier orders with the filters given
+		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
         $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
@@ -212,22 +212,22 @@ class SupplierOrders extends DolibarrApi
 			throw new RestException(503, 'Error when retrieve supplier order list : '.$this->db->lasterror());
 		}
 
-        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
-        if ($pagination_data) {
-            $totalsResult = $this->db->query($sqlTotals);
-            $total = $this->db->fetch_object($totalsResult)->total;
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$totalsResult = $this->db->query($sqlTotals);
+			$total = $this->db->fetch_object($totalsResult)->total;
 
-            $tmp = $obj_ret;
-            $obj_ret = [];
+			$tmp = $obj_ret;
+			$obj_ret = [];
 
-            $obj_ret['data'] = $tmp;
-            $obj_ret['pagination'] = [
-                'total' => (int) $total,
-                'page' => $page, //count starts from 0
-                'page_count' => ceil((int) $total/$limit),
-                'limit' => $limit
-            ];
-        }
+			$obj_ret['data'] = $tmp;
+			$obj_ret['pagination'] = [
+				'total' => (int)$total,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int)$total / $limit),
+				'limit' => $limit
+			];
+		}
 
         return $obj_ret;
 	}

--- a/htdocs/fourn/class/api_supplier_orders.class.php
+++ b/htdocs/fourn/class/api_supplier_orders.class.php
@@ -96,11 +96,11 @@ class SupplierOrders extends DolibarrApi
 	 * @param string    $sqlfilterlines   Other criteria to filter answers separated by a comma. Syntax example "(tl.fk_product:=:'17') and (tl.price:<:'250')"
 	 * @param string    $properties		  Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
-     * @return array                      Array of order objects
+	 * @return array                      Array of order objects
 	 *
 	 * @throws RestException
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $product_ids = '', $status = '', $sqlfilters = '', $sqlfilterlines = '', $properties = '',  $pagination_data = false)
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $product_ids = '', $status = '', $sqlfilters = '', $sqlfilterlines = '', $properties = '', $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight("fournisseur", "commande", "lire")) {
 			throw new RestException(403);
@@ -185,7 +185,7 @@ class SupplierOrders extends DolibarrApi
 		//this query will return total supplier orders with the filters given
 		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
-        $sql .= $this->db->order($sortfield, $sortorder);
+		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -222,14 +222,14 @@ class SupplierOrders extends DolibarrApi
 
 			$obj_ret['data'] = $tmp;
 			$obj_ret['pagination'] = [
-				'total' => (int)$total,
+				'total' => (int) $total,
 				'page' => $page, //count starts from 0
-				'page_count' => ceil((int)$total / $limit),
+				'page_count' => ceil((int) $total / $limit),
 				'limit' => $limit
 			];
 		}
 
-        return $obj_ret;
+		return $obj_ret;
 	}
 
 	/**

--- a/htdocs/fourn/class/api_supplier_orders.class.php
+++ b/htdocs/fourn/class/api_supplier_orders.class.php
@@ -95,11 +95,12 @@ class SupplierOrders extends DolibarrApi
 	 * @param string    $sqlfilters       Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'20160101')"
 	 * @param string    $sqlfilterlines   Other criteria to filter answers separated by a comma. Syntax example "(tl.fk_product:=:'17') and (tl.price:<:'250')"
 	 * @param string    $properties		  Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @return array                      Array of order objects
+     * @param bool      $pagination_data  If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+     * @return array                      Array of order objects
 	 *
 	 * @throws RestException
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $product_ids = '', $status = '', $sqlfilters = '', $sqlfilterlines = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $product_ids = '', $status = '', $sqlfilters = '', $sqlfilterlines = '', $properties = '',  $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight("fournisseur", "commande", "lire")) {
 			throw new RestException(403);
@@ -181,7 +182,10 @@ class SupplierOrders extends DolibarrApi
 			}
 		}
 
-		$sql .= $this->db->order($sortfield, $sortorder);
+        //this query will return total supplier orders with the filters given
+        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+
+        $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -208,7 +212,24 @@ class SupplierOrders extends DolibarrApi
 			throw new RestException(503, 'Error when retrieve supplier order list : '.$this->db->lasterror());
 		}
 
-		return $obj_ret;
+        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+        if ($pagination_data) {
+            $totalsResult = $this->db->query($sqlTotals);
+            $total = $this->db->fetch_object($totalsResult)->total;
+
+            $tmp = $obj_ret;
+            $obj_ret = [];
+
+            $obj_ret['data'] = $tmp;
+            $obj_ret['pagination'] = [
+                'total' => (int) $total,
+                'page' => $page, //count starts from 0
+                'page_count' => ceil((int) $total/$limit),
+                'limit' => $limit
+            ];
+        }
+
+        return $obj_ret;
 	}
 
 	/**

--- a/htdocs/reception/class/api_receptions.class.php
+++ b/htdocs/reception/class/api_receptions.class.php
@@ -96,7 +96,7 @@ class Receptions extends DolibarrApi
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string           $properties	        Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
-     * @return  array                               Array of reception objects
+	 * @return  array                               Array of reception objects
 	 *
 	 * @throws RestException
 	 */
@@ -183,9 +183,9 @@ class Receptions extends DolibarrApi
 
 			$obj_ret['data'] = $tmp;
 			$obj_ret['pagination'] = [
-				'total' => (int)$total,
+				'total' => (int) $total,
 				'page' => $page, //count starts from 0
-				'page_count' => ceil((int)$total / $limit),
+				'page_count' => ceil((int) $total / $limit),
 				'limit' => $limit
 			];
 		}

--- a/htdocs/reception/class/api_receptions.class.php
+++ b/htdocs/reception/class/api_receptions.class.php
@@ -95,7 +95,7 @@ class Receptions extends DolibarrApi
 	 * @param string		   $thirdparty_ids		Thirdparty ids to filter receptions of (example '1' or '1,2,3') {@pattern /^[0-9,]*$/i}
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string           $properties	        Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-     * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+	 * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
      * @return  array                               Array of reception objects
 	 *
 	 * @throws RestException
@@ -141,8 +141,8 @@ class Receptions extends DolibarrApi
 			}
 		}
 
-        //this query will return total receptions with the filters given
-        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+		//this query will return total receptions with the filters given
+		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
 		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
@@ -173,22 +173,22 @@ class Receptions extends DolibarrApi
 			throw new RestException(503, 'Error when retrieve commande list : '.$this->db->lasterror());
 		}
 
-        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
-        if ($pagination_data) {
-            $totalsResult = $this->db->query($sqlTotals);
-            $total = $this->db->fetch_object($totalsResult)->total;
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$totalsResult = $this->db->query($sqlTotals);
+			$total = $this->db->fetch_object($totalsResult)->total;
 
-            $tmp = $obj_ret;
-            $obj_ret = [];
+			$tmp = $obj_ret;
+			$obj_ret = [];
 
-            $obj_ret['data'] = $tmp;
-            $obj_ret['pagination'] = [
-                'total' => (int) $total,
-                'page' => $page, //count starts from 0
-                'page_count' => ceil((int) $total/$limit),
-                'limit' => $limit
-            ];
-        }
+			$obj_ret['data'] = $tmp;
+			$obj_ret['pagination'] = [
+				'total' => (int)$total,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int)$total / $limit),
+				'limit' => $limit
+			];
+		}
 
 		return $obj_ret;
 	}

--- a/htdocs/reception/class/api_receptions.class.php
+++ b/htdocs/reception/class/api_receptions.class.php
@@ -94,12 +94,13 @@ class Receptions extends DolibarrApi
 	 * @param int			   $page				Page number
 	 * @param string		   $thirdparty_ids		Thirdparty ids to filter receptions of (example '1' or '1,2,3') {@pattern /^[0-9,]*$/i}
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
-	 * @param string    $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @return  array                               Array of reception objects
+	 * @param string           $properties	        Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+     * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+     * @return  array                               Array of reception objects
 	 *
 	 * @throws RestException
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('reception', 'lire')) {
 			throw new RestException(403);
@@ -140,6 +141,9 @@ class Receptions extends DolibarrApi
 			}
 		}
 
+        //this query will return total receptions with the filters given
+        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+
 		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
@@ -168,6 +172,23 @@ class Receptions extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieve commande list : '.$this->db->lasterror());
 		}
+
+        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+        if ($pagination_data) {
+            $totalsResult = $this->db->query($sqlTotals);
+            $total = $this->db->fetch_object($totalsResult)->total;
+
+            $tmp = $obj_ret;
+            $obj_ret = [];
+
+            $obj_ret['data'] = $tmp;
+            $obj_ret['pagination'] = [
+                'total' => (int) $total,
+                'page' => $page, //count starts from 0
+                'page_count' => ceil((int) $total/$limit),
+                'limit' => $limit
+            ];
+        }
 
 		return $obj_ret;
 	}

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -130,10 +130,11 @@ class Thirdparties extends DolibarrApi
 	 *								Set to 4 to show only suppliers
 	 * @param	int		$category   Use this param to filter list by category
 	 * @param   string  $sqlfilters Other criteria to filter answers separated by a comma. Syntax example "((t.nom:like:'TheCompany%') or (t.name_alias:like:'TheCompany%')) and (t.datec:<:'20160101')"
-	 * @param string    $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @return  array               Array of thirdparty objects
+	 * @param   string  $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+     * @param bool $pagination_data If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+     * @return  array               Array of thirdparty objects
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
 		$obj_ret = array();
 
@@ -203,7 +204,10 @@ class Thirdparties extends DolibarrApi
 			}
 		}
 
-		$sql .= $this->db->order($sortfield, $sortorder);
+        //this query will return total thirdparties with the filters given
+        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+
+        $sql .= $this->db->order($sortfield, $sortorder);
 
 		if ($limit) {
 			if ($page < 0) {
@@ -236,7 +240,25 @@ class Thirdparties extends DolibarrApi
 		if (!count($obj_ret)) {
 			throw new RestException(404, 'Thirdparties not found');
 		}
-		return $obj_ret;
+
+        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+        if ($pagination_data) {
+            $totalsResult = $this->db->query($sqlTotals);
+            $total = $this->db->fetch_object($totalsResult)->total;
+
+            $tmp = $obj_ret;
+            $obj_ret = [];
+
+            $obj_ret['data'] = $tmp;
+            $obj_ret['pagination'] = [
+                'total' => (int) $total,
+                'page' => $page, //count starts from 0
+                'page_count' => ceil((int) $total/$limit),
+                'limit' => $limit
+            ];
+        }
+
+        return $obj_ret;
 	}
 
 	/**

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -132,7 +132,7 @@ class Thirdparties extends DolibarrApi
 	 * @param   string  $sqlfilters Other criteria to filter answers separated by a comma. Syntax example "((t.nom:like:'TheCompany%') or (t.name_alias:like:'TheCompany%')) and (t.datec:<:'20160101')"
 	 * @param   string  $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool $pagination_data If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
-     * @return  array               Array of thirdparty objects
+	 * @return  array               Array of thirdparty objects
 	 */
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
@@ -250,14 +250,14 @@ class Thirdparties extends DolibarrApi
 
 			$obj_ret['data'] = $tmp;
 			$obj_ret['pagination'] = [
-				'total' => (int)$total,
+				'total' => (int) $total,
 				'page' => $page, //count starts from 0
-				'page_count' => ceil((int)$total / $limit),
+				'page_count' => ceil((int) $total / $limit),
 				'limit' => $limit
 			];
 		}
 
-        return $obj_ret;
+		return $obj_ret;
 	}
 
 	/**

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -131,7 +131,7 @@ class Thirdparties extends DolibarrApi
 	 * @param	int		$category   Use this param to filter list by category
 	 * @param   string  $sqlfilters Other criteria to filter answers separated by a comma. Syntax example "((t.nom:like:'TheCompany%') or (t.name_alias:like:'TheCompany%')) and (t.datec:<:'20160101')"
 	 * @param   string  $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-     * @param bool $pagination_data If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+	 * @param bool $pagination_data If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
      * @return  array               Array of thirdparty objects
 	 */
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $mode = 0, $category = 0, $sqlfilters = '', $properties = '', $pagination_data = false)
@@ -204,11 +204,10 @@ class Thirdparties extends DolibarrApi
 			}
 		}
 
-        //this query will return total thirdparties with the filters given
-        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+		//this query will return total thirdparties with the filters given
+		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
-        $sql .= $this->db->order($sortfield, $sortorder);
-
+		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -241,22 +240,22 @@ class Thirdparties extends DolibarrApi
 			throw new RestException(404, 'Thirdparties not found');
 		}
 
-        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
-        if ($pagination_data) {
-            $totalsResult = $this->db->query($sqlTotals);
-            $total = $this->db->fetch_object($totalsResult)->total;
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$totalsResult = $this->db->query($sqlTotals);
+			$total = $this->db->fetch_object($totalsResult)->total;
 
-            $tmp = $obj_ret;
-            $obj_ret = [];
+			$tmp = $obj_ret;
+			$obj_ret = [];
 
-            $obj_ret['data'] = $tmp;
-            $obj_ret['pagination'] = [
-                'total' => (int) $total,
-                'page' => $page, //count starts from 0
-                'page_count' => ceil((int) $total/$limit),
-                'limit' => $limit
-            ];
-        }
+			$obj_ret['data'] = $tmp;
+			$obj_ret['pagination'] = [
+				'total' => (int)$total,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int)$total / $limit),
+				'limit' => $limit
+			];
+		}
 
         return $obj_ret;
 	}

--- a/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
+++ b/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
@@ -217,7 +217,7 @@ class SupplierProposals extends DolibarrApi
 	 * @param string	$thirdparty_ids		Thirdparty ids to filter supplier proposals (example '1' or '1,2,3') {@pattern /^[0-9,]*$/i}
 	 * @param string    $sqlfilters         Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'20160101')"
 	 * @param string    $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-     * @param bool      $pagination_data    If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+	 * @param bool      $pagination_data    If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
      * @return  array                       Array of order objects
 	 */
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false)
@@ -261,8 +261,8 @@ class SupplierProposals extends DolibarrApi
 			}
 		}
 
-        //this query will return total supplier proposals with the filters given
-        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+		//this query will return total supplier proposals with the filters given
+		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
         $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
@@ -292,22 +292,22 @@ class SupplierProposals extends DolibarrApi
 			throw new RestException(503, 'Error when retrieving supplier proposal list : '.$this->db->lasterror());
 		}
 
-        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
-        if ($pagination_data) {
-            $totalsResult = $this->db->query($sqlTotals);
-            $total = $this->db->fetch_object($totalsResult)->total;
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$totalsResult = $this->db->query($sqlTotals);
+			$total = $this->db->fetch_object($totalsResult)->total;
 
-            $tmp = $obj_ret;
-            $obj_ret = [];
+			$tmp = $obj_ret;
+			$obj_ret = [];
 
-            $obj_ret['data'] = $tmp;
-            $obj_ret['pagination'] = [
-                'total' => (int) $total,
-                'page' => $page, //count starts from 0
-                'page_count' => ceil((int) $total/$limit),
-                'limit' => $limit
-            ];
-        }
+			$obj_ret['data'] = $tmp;
+			$obj_ret['pagination'] = [
+				'total' => (int)$total,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int)$total / $limit),
+				'limit' => $limit
+			];
+		}
 
 		return $obj_ret;
 	}

--- a/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
+++ b/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
@@ -218,7 +218,7 @@ class SupplierProposals extends DolibarrApi
 	 * @param string    $sqlfilters         Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'20160101')"
 	 * @param string    $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool      $pagination_data    If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
-     * @return  array                       Array of order objects
+	 * @return  array                       Array of order objects
 	 */
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
@@ -264,7 +264,7 @@ class SupplierProposals extends DolibarrApi
 		//this query will return total supplier proposals with the filters given
 		$sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
 
-        $sql .= $this->db->order($sortfield, $sortorder);
+		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -302,9 +302,9 @@ class SupplierProposals extends DolibarrApi
 
 			$obj_ret['data'] = $tmp;
 			$obj_ret['pagination'] = [
-				'total' => (int)$total,
+				'total' => (int) $total,
 				'page' => $page, //count starts from 0
-				'page_count' => ceil((int)$total / $limit),
+				'page_count' => ceil((int) $total / $limit),
 				'limit' => $limit
 			];
 		}

--- a/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
+++ b/htdocs/supplier_proposal/class/api_supplier_proposals.class.php
@@ -217,9 +217,10 @@ class SupplierProposals extends DolibarrApi
 	 * @param string	$thirdparty_ids		Thirdparty ids to filter supplier proposals (example '1' or '1,2,3') {@pattern /^[0-9,]*$/i}
 	 * @param string    $sqlfilters         Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.datec:<:'20160101')"
 	 * @param string    $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @return  array                       Array of order objects
+     * @param bool      $pagination_data    If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+     * @return  array                       Array of order objects
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('supplier_proposal', 'lire')) {
 			throw new RestException(403);
@@ -260,7 +261,10 @@ class SupplierProposals extends DolibarrApi
 			}
 		}
 
-		$sql .= $this->db->order($sortfield, $sortorder);
+        //this query will return total supplier proposals with the filters given
+        $sqlTotals = str_replace('SELECT t.rowid', 'SELECT count(t.rowid) as total', $sql);
+
+        $sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
 			if ($page < 0) {
 				$page = 0;
@@ -287,6 +291,23 @@ class SupplierProposals extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving supplier proposal list : '.$this->db->lasterror());
 		}
+
+        //if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+        if ($pagination_data) {
+            $totalsResult = $this->db->query($sqlTotals);
+            $total = $this->db->fetch_object($totalsResult)->total;
+
+            $tmp = $obj_ret;
+            $obj_ret = [];
+
+            $obj_ret['data'] = $tmp;
+            $obj_ret['pagination'] = [
+                'total' => (int) $total,
+                'page' => $page, //count starts from 0
+                'page_count' => ceil((int) $total/$limit),
+                'limit' => $limit
+            ];
+        }
 
 		return $obj_ret;
 	}


### PR DESCRIPTION
Hello,

Based on [my issue](https://github.com/Dolibarr/dolibarr/issues/29402),

When using the product API, I noticed there is pagination data that can be useful for other endpoints. Therefore, I added it by simply copying and pasting the code already implemented in the product API [here](https://github.com/Dolibarr/dolibarr/pull/17485).

Would you prefer if we implemented a new function in the DolibarrApi class instead?