### PR TITLE
Add clean conditions to show "create purchase order" button in sale order card

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -2952,7 +2952,7 @@ if ($action == 'create' && $usercancreate) {
 				// Create a purchase order
 				if (getDolGlobalInt('COMMANDE_DISABLE_ADD_PURCHASE_ORDER') == 0) {
 					$arrayforbutaction[] = array('lang'=>'orders', 'enabled'=>(isModEnabled("supplier_order") && $object->statut > Commande::STATUS_DRAFT && $object->getNbLinesProductOrServiceOnBuy(getDolGlobalInt('COMMANDE_ADD_PURCHASE_ORDER_IGNORE_FREE_PRODUCTS')) > 0), 'perm'=>$usercancreatepurchaseorder, 'label'=>'AddPurchaseOrder', 'url'=>'/fourn/commande/card.php?action=create&amp;origin='.$object->element.'&amp;originid='.$object->id);
-				}	
+				}
 				/*if (isModEnabled("supplier_order") && $object->statut > Commande::STATUS_DRAFT && $object->getNbOfServicesLines() > 0) {
 					if ($usercancreatepurchaseorder) { isModEnabled("supplier_order") && $object->statut > Commande::STATUS_DRAFT && $object->getNbOfServicesLines() > 0
 						print dolGetButtonAction('', $langs->trans('AddPurchaseOrder'), 'default', DOL_URL_ROOT.'/fourn/commande/card.php?action=create&amp;origin='.$object->element.'&amp;originid='.$object->id, '');

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -2949,11 +2949,12 @@ if ($action == 'create' && $usercancreate) {
 				}
 
 				$arrayforbutaction = array();
-
 				// Create a purchase order
-				$arrayforbutaction[] = array('lang'=>'orders', 'enabled'=>(isModEnabled("supplier_order") && $object->statut > Commande::STATUS_DRAFT && $object->getNbOfServicesLines() > 0), 'perm'=>$usercancreatepurchaseorder, 'label'=>'AddPurchaseOrder', 'url'=>'/fourn/commande/card.php?action=create&amp;origin='.$object->element.'&amp;originid='.$object->id);
+				if (empty(getDolGlobalInt('COMMANDE_DISABLE_ADD_PURCHASE_ORDER'))) {
+					$arrayforbutaction[] = array('lang'=>'orders', 'enabled'=>(isModEnabled("supplier_order") && $object->statut > Commande::STATUS_DRAFT && $object->getNbLinesProductOrServiceOnBuy(getDolGlobalInt('COMMANDE_ADD_PURCHASE_ORDER_IGNORE_FREE_PRODUCTS')) > 0), 'perm'=>$usercancreatepurchaseorder, 'label'=>'AddPurchaseOrder', 'url'=>'/fourn/commande/card.php?action=create&amp;origin='.$object->element.'&amp;originid='.$object->id);
+				}	
 				/*if (isModEnabled("supplier_order") && $object->statut > Commande::STATUS_DRAFT && $object->getNbOfServicesLines() > 0) {
-					if ($usercancreatepurchaseorder) {
+					if ($usercancreatepurchaseorder) { isModEnabled("supplier_order") && $object->statut > Commande::STATUS_DRAFT && $object->getNbOfServicesLines() > 0
 						print dolGetButtonAction('', $langs->trans('AddPurchaseOrder'), 'default', DOL_URL_ROOT.'/fourn/commande/card.php?action=create&amp;origin='.$object->element.'&amp;originid='.$object->id, '');
 					}
 				}*/

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -2950,7 +2950,7 @@ if ($action == 'create' && $usercancreate) {
 
 				$arrayforbutaction = array();
 				// Create a purchase order
-				if (empty(getDolGlobalInt('COMMANDE_DISABLE_ADD_PURCHASE_ORDER'))) {
+				if (getDolGlobalInt('COMMANDE_DISABLE_ADD_PURCHASE_ORDER') == 0) {
 					$arrayforbutaction[] = array('lang'=>'orders', 'enabled'=>(isModEnabled("supplier_order") && $object->statut > Commande::STATUS_DRAFT && $object->getNbLinesProductOrServiceOnBuy(getDolGlobalInt('COMMANDE_ADD_PURCHASE_ORDER_IGNORE_FREE_PRODUCTS')) > 0), 'perm'=>$usercancreatepurchaseorder, 'label'=>'AddPurchaseOrder', 'url'=>'/fourn/commande/card.php?action=create&amp;origin='.$object->element.'&amp;originid='.$object->id);
 				}	
 				/*if (isModEnabled("supplier_order") && $object->statut > Commande::STATUS_DRAFT && $object->getNbOfServicesLines() > 0) {

--- a/htdocs/core/class/commonorder.class.php
+++ b/htdocs/core/class/commonorder.class.php
@@ -90,7 +90,7 @@ abstract class CommonOrder extends CommonObject
 				}
 			}
 		}
-		
+		return $return;
 	}
 
 	/**

--- a/htdocs/core/class/commonorder.class.php
+++ b/htdocs/core/class/commonorder.class.php
@@ -70,13 +70,13 @@ abstract class CommonOrder extends CommonObject
 		$return .= '</div>';
 		return $return;
 	}
-	
+
 	/** return nb of fines of order where products or services that can be buyed
-	 * 
+	 *
 	 * @param	boolean		$ignoreFree		Ignore free lines
 	 * @return	int							number of products or services on buy in a command
 	 */
-	public function getNbLinesProductOrServiceOnBuy($ignoreFree = false) 
+	public function getNbLinesProductOrServiceOnBuy($ignoreFree = false)
 	{
 		require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 		$product = new Product($this->db);

--- a/htdocs/core/class/commonorder.class.php
+++ b/htdocs/core/class/commonorder.class.php
@@ -70,6 +70,28 @@ abstract class CommonOrder extends CommonObject
 		$return .= '</div>';
 		return $return;
 	}
+	
+	/** return nb of fines of order where products or services that can be buyed
+	 * 
+	 * @param	boolean		$ignoreFree		Ignore free lines
+	 * @return	int							number of products or services on buy in a command
+	 */
+	public function getNbLinesProductOrServiceOnBuy($ignoreFree = false) 
+	{
+		require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
+		$product = new Product($this->db);
+		$return = 0;
+		foreach ($this->lines as $line) {
+			if (empty($line->fk_product) && !$ignoreFree) {
+				$return ++;
+			} elseif ((int) $line->fk_product > 0) {
+				if ($product->fetch($line->fk_product) > 0) {
+					if ($product->status_buy) $return ++;
+				}
+			}
+		}
+		
+	}
 
 	/**
 	 * @var string code


### PR DESCRIPTION
# FIX #29782 option for creating purchase order from sales order, for some cases only

Now the button appears when

- const COMMANDE_DISABLE_ADD_PURCHASE_ORDER is empty
- order status is not draft
- user has right to create purchase order
- some products / services are on buy, or free if COMMANDE_ADD_PURCHASE_ORDER_IGNORE_FREE_PRODUCTS is empty