### PR TITLE
Fix #29900 - Show option values when in array_options of object

### DIFF
--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -36,7 +36,8 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 				} elseif (in_array($extrafields->attributes[$extrafieldsobjectkey]['type'][$key], array('int'))) {
 					$value = (!empty($obj->$tmpkey) || $obj->$tmpkey === '0'  ? $obj->$tmpkey : '');
 				} else {
-					$value = (isset($obj->$tmpkey) ? $obj->$tmpkey : 
+					// The key may be in $obj->array_options if not in $obj
+					$value = (isset($obj->$tmpkey) ? $obj->$tmpkey :
 						(isset($obj->array_options[$tmpkey]) ? $obj->array_options[$tmpkey] : '') );
 				}
 				// If field is a computed field, we make computation to get value

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -36,7 +36,8 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 				} elseif (in_array($extrafields->attributes[$extrafieldsobjectkey]['type'][$key], array('int'))) {
 					$value = (!empty($obj->$tmpkey) || $obj->$tmpkey === '0'  ? $obj->$tmpkey : '');
 				} else {
-					$value = (isset($obj->$tmpkey) ? $obj->$tmpkey : '');
+					$value = (isset($obj->$tmpkey) ? $obj->$tmpkey : 
+						(isset($obj->array_options[$tmpkey]) ? $obj->array_options[$tmpkey] : '') );
 				}
 				// If field is a computed field, we make computation to get value
 				if ($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key]) {
@@ -45,7 +46,6 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 					if (is_numeric(price2num($value)) && $extrafields->attributes[$extrafieldsobjectkey]['totalizable'][$key]) {
 						$obj->$tmpkey = price2num($value);
 					}
-					//var_dump($value);
 				}
 
 				$valuetoshow = $extrafields->showOutputField($key, $value, '', $extrafieldsobjectkey);


### PR DESCRIPTION
# FIX|Fix #[*29900_Billing status not checked on Project's Task tab List of Tasks when Billing is True*]
[*Sometimes, extrafields are stored in array_options attribute of objects when rendering (i.e. task options_invoiceable) and need to be looked for to show value in list row*