### PR TITLE
Regression : no more categ's path in categories multi select 

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8814,7 +8814,11 @@ class Form
 					$tmplabelhtml = '';
 					if (is_array($value) && array_key_exists('id', $value) && array_key_exists('label', $value)) {
 						$tmpkey = $value['id'];
-						$tmpvalue = empty($value['label']) ? '' : $value['label'];
+						if (!empty($value['fulllabel'])) { // for categories, this contains the path like catparent >> catchild 
+							$tmpvalue = $value['fulllabel'];
+						} else {
+							$tmpvalue = empty($value['label']) ? '' : $value['label'];
+						}
 						$tmpcolor = empty($value['color']) ? '' : $value['color'];
 						$tmppicto = empty($value['picto']) ? '' : $value['picto'];
 						$tmplabelhtml = empty($value['labelhtml']) ? '' : $value['labelhtml'];

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8814,7 +8814,7 @@ class Form
 					$tmplabelhtml = '';
 					if (is_array($value) && array_key_exists('id', $value) && array_key_exists('label', $value)) {
 						$tmpkey = $value['id'];
-						if (!empty($value['fulllabel'])) { // for categories, this contains the path like catparent >> catchild 
+						if (!empty($value['fulllabel'])) { // for categories, fulllabel key contains the path like catparent >> catchild
 							$tmpvalue = $value['fulllabel'];
 						} else {
 							$tmpvalue = empty($value['label']) ? '' : $value['label'];


### PR DESCRIPTION
Since at least v18, the path of cats (like catParent >> catChild) are no more displayed in categories select (for example used in list files)
In v16
![select in v16](https://github.com/Dolibarr/dolibarr/assets/5389628/c0779570-520e-49e7-bcce-d5e66bfc3156)

In V18
![select in v18](https://github.com/Dolibarr/dolibarr/assets/5389628/c2b7603d-1149-4ca7-859f-e565c7c577e8)

With this fix (in v19)
![select in v19 fixed](https://github.com/Dolibarr/dolibarr/assets/5389628/2c2bcbb8-0dc3-4214-b80d-d1b66116f2ff)

