### PR TITLE
NEW: declare extrafields as a property in module descriptor

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -137,9 +137,10 @@ class ExtraFields
 	 *  @param	int				$totalizable		Is a measure. Must show a total on lists
 	 *  @param  int             $printable          Is extrafield displayed on PDF
 	 *  @param	array			$moreparams			More parameters. Example: array('css'=>, 'csslist'=>Css on list, 'cssview'=>...)
+	 *  @param	string			$module				Module responsible for the extrafield
 	 *  @return int      							Return integer <=0 if KO, >0 if OK
 	 */
-	public function addExtraField($attrname, $label, $type, $pos, $size, $elementtype, $unique = 0, $required = 0, $default_value = '', $param = '', $alwayseditable = 0, $perms = '', $list = '-1', $help = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $printable = 0, $moreparams = array())
+	public function addExtraField($attrname, $label, $type, $pos, $size, $elementtype, $unique = 0, $required = 0, $default_value = '', $param = '', $alwayseditable = 0, $perms = '', $list = '-1', $help = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $printable = 0, $moreparams = array(), $module = null)
 	{
 		if (empty($attrname)) {
 			return -1;
@@ -169,7 +170,7 @@ class ExtraFields
 		$err1 = $this->errno;
 		if ($result > 0 || $err1 == 'DB_ERROR_COLUMN_ALREADY_EXISTS' || $type == 'separate') {
 			// Add declaration of field into table
-			$result2 = $this->create_label($attrname, $label, $type, $pos, $size, $elementtype, $unique, $required, $param, $alwayseditable, $perms, $list, $help, $default_value, $computed, $entity, $langfile, $enabled, $totalizable, $printable, $moreparams);
+			$result2 = $this->create_label($attrname, $label, $type, $pos, $size, $elementtype, $unique, $required, $param, $alwayseditable, $perms, $list, $help, $default_value, $computed, $entity, $langfile, $enabled, $totalizable, $printable, $moreparams, $module);
 			$err2 = $this->errno;
 			if ($result2 > 0 || ($err1 == 'DB_ERROR_COLUMN_ALREADY_EXISTS' && $err2 == 'DB_ERROR_RECORD_ALREADY_EXISTS')) {
 				$this->error = '';
@@ -387,10 +388,11 @@ class ExtraFields
 	 *  @param	int				$totalizable	Is a measure. Must show a total on lists
 	 *  @param  int             $printable      Is extrafield displayed on PDF
 	 *  @param	array			$moreparams		More parameters. Example: array('css'=>, 'csslist'=>, 'cssview'=>...)
+	 *  @param	string			$module			Module responsible for the extrafield
 	 *  @return	int								Return integer <=0 if KO, >0 if OK
 	 *  @throws Exception
 	 */
-	private function create_label($attrname, $label = '', $type = '', $pos = 0, $size = '', $elementtype = '', $unique = 0, $required = 0, $param = '', $alwayseditable = 0, $perms = '', $list = '-1', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $printable = 0, $moreparams = array())
+	private function create_label($attrname, $label = '', $type = '', $pos = 0, $size = '', $elementtype = '', $unique = 0, $required = 0, $param = '', $alwayseditable = 0, $perms = '', $list = '-1', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $printable = 0, $moreparams = array(), $module = null)
 	{
 		// phpcs:enable
 		global $conf, $user;
@@ -438,6 +440,10 @@ class ExtraFields
 			$cssview = $moreparams['cssview'];
 		}
 
+		if (empty($module)) {
+			$module = null;
+		}
+
 		if (!empty($attrname) && preg_match("/^\w[a-zA-Z0-9-_]*$/", $attrname) && !is_numeric($attrname)) {
 			if (is_array($param) && count($param) > 0) {
 				$params = serialize($param);
@@ -473,7 +479,8 @@ class ExtraFields
 			$sql .= " totalizable,";
 			$sql .= " css,";
 			$sql .= " csslist,";
-			$sql .= " cssview";
+			$sql .= " cssview,";
+			$sql .= " module";
 			$sql .= " )";
 			$sql .= " VALUES('".$this->db->escape($attrname)."',";
 			$sql .= " '".$this->db->escape($label)."',";
@@ -500,7 +507,8 @@ class ExtraFields
 			$sql .= " ".($totalizable ? 'TRUE' : 'FALSE').",";
 			$sql .= " ".($css ? "'".$this->db->escape($css)."'" : "null").",";
 			$sql .= " ".($csslist ? "'".$this->db->escape($csslist)."'" : "null").",";
-			$sql .= " ".($cssview ? "'".$this->db->escape($cssview)."'" : "null");
+			$sql .= " ".($cssview ? "'".$this->db->escape($cssview)."'" : "null").",";
+			$sql .= " ".($module ? "'".$this->db->escape($module)."'" : "null");
 			$sql .= ')';
 
 			if ($this->db->query($sql)) {
@@ -636,10 +644,11 @@ class ExtraFields
 	 *  @param  int     $totalizable        Is extrafield totalizable on list
 	 *  @param  int     $printable        	Is extrafield displayed on PDF
 	 *  @param	array	$moreparams			More parameters. Example: array('css'=>, 'csslist'=>, 'cssview'=>...)
+	 *  @param	string	$module				Module responsible for the extrafield
 	 * 	@return	int							>0 if OK, <=0 if KO
 	 *  @throws Exception
 	 */
-	public function update($attrname, $label, $type, $length, $elementtype, $unique = 0, $required = 0, $pos = 0, $param = array(), $alwayseditable = 0, $perms = '', $list = '', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $printable = 0, $moreparams = array())
+	public function update($attrname, $label, $type, $length, $elementtype, $unique = 0, $required = 0, $pos = 0, $param = array(), $alwayseditable = 0, $perms = '', $list = '', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $printable = 0, $moreparams = array(), $module = null)
 	{
 		global $action, $hookmanager;
 
@@ -722,7 +731,7 @@ class ExtraFields
 			if ($result > 0 || $type == 'separate') {
 				if ($label) {
 					dol_syslog(get_class($this).'::update_label', LOG_DEBUG);
-					$result = $this->update_label($attrname, $label, $type, $length, $elementtype, $unique, $required, $pos, $param, $alwayseditable, $perms, $list, $help, $default, $computed, $entity, $langfile, $enabled, $totalizable, $printable, $moreparams);
+					$result = $this->update_label($attrname, $label, $type, $length, $elementtype, $unique, $required, $pos, $param, $alwayseditable, $perms, $list, $help, $default, $computed, $entity, $langfile, $enabled, $totalizable, $printable, $moreparams, $module);
 				}
 				if ($result > 0) {
 					$sql = '';
@@ -779,10 +788,11 @@ class ExtraFields
 	 *  @param  int     $totalizable        Is extrafield totalizable on list
 	 *  @param  int     $printable        	Is extrafield displayed on PDF
 	 *  @param	array	$moreparams			More parameters. Example: array('css'=>, 'csslist'=>, 'cssview'=>...)
+	 *  @param	string	$module				Module responsible for the extrafield
 	 *  @return	int							Return integer <=0 if KO, >0 if OK
 	 *  @throws Exception
 	 */
-	private function update_label($attrname, $label, $type, $size, $elementtype, $unique = 0, $required = 0, $pos = 0, $param = array(), $alwayseditable = 0, $perms = '', $list = '0', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $printable = 0, $moreparams = array())
+	private function update_label($attrname, $label, $type, $size, $elementtype, $unique = 0, $required = 0, $pos = 0, $param = array(), $alwayseditable = 0, $perms = '', $list = '0', $help = '', $default = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $printable = 0, $moreparams = array(), $module = null)
 	{
 		// phpcs:enable
 		global $conf, $user;
@@ -826,6 +836,10 @@ class ExtraFields
 		$cssview = '';
 		if (!empty($moreparams) && !empty($moreparams['cssview'])) {
 			$cssview = $moreparams['cssview'];
+		}
+
+		if (empty($module)) {
+			$module = null;
 		}
 
 		if (isset($attrname) && $attrname != '' && preg_match("/^\w[a-zA-Z0-9-_]*$/", $attrname)) {
@@ -882,7 +896,8 @@ class ExtraFields
 			$sql .= " help,";
 			$sql .= " css,";
 			$sql .= " csslist,";
-			$sql .= " cssview";
+			$sql .= " cssview,";
+			$sql .= " module";
 			$sql .= ") VALUES (";
 			$sql .= "'".$this->db->escape($attrname)."',";
 			$sql .= " ".($entity === '' ? $conf->entity : $entity).",";
@@ -909,7 +924,8 @@ class ExtraFields
 			$sql .= " ".($help ? "'".$this->db->escape($help)."'" : "null").",";
 			$sql .= " ".($css ? "'".$this->db->escape($css)."'" : "null").",";
 			$sql .= " ".($csslist ? "'".$this->db->escape($csslist)."'" : "null").",";
-			$sql .= " ".($cssview ? "'".$this->db->escape($cssview)."'" : "null");
+			$sql .= " ".($cssview ? "'".$this->db->escape($cssview)."'" : "null").",";
+			$sql .= " ".($module ? "'".$this->db->escape($module)."'" : "null");
 			$sql .= ")";
 
 			$resql2 = $this->db->query($sql);

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -664,6 +664,10 @@ class ExtraFields
 			$table = 'categories_extrafields';
 		}
 
+		if ($type == 'separator') {
+			$type = 'separate';
+		}
+
 		if (isset($attrname) && $attrname != '' && preg_match("/^\w[a-zA-Z0-9-_]*$/", $attrname)) {
 			if ($type == 'boolean') {
 				$typedb = 'int';

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -2558,6 +2558,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 					array_key_exists('totalizable', $extrafield) ? $extrafield['totalizable'] : 0,
 					array_key_exists('printable', $extrafield) ? $extrafield['printable'] : 0,
 					array_key_exists('moreparams', $extrafield) ? $extrafield['moreparams'] : array(),
+					$this->rights_class,
 				);
 			} else {
 				$result = $extrafields->addExtraField(
@@ -2582,6 +2583,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 					array_key_exists('totalizable', $extrafield) ? $extrafield['totalizable'] : 0,
 					array_key_exists('printable', $extrafield) ? $extrafield['printable'] : 0,
 					array_key_exists('moreparams', $extrafield) ? $extrafield['moreparams'] : array(),
+					$this->rights_class,
 				);
 			}
 

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -138,6 +138,11 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	 */
 	public $rights_class;
 
+	/**
+	 * @var array Module extrafields
+	 */
+	public $extrafields = array();
+
 	const KEY_ID = 0;
 	const KEY_LABEL = 1;
 	const KEY_TYPE = 2;	// deprecated
@@ -481,6 +486,10 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 		// Insert specific menus entries into database
 		if (!$err) {
 			$err += $this->insert_menus();
+		}
+
+		if (!$err) {
+			$err += $this->insertExtrafields();
 		}
 
 		// Create module's directories
@@ -2486,6 +2495,111 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 		return $err;
 	}
 
+	/**
+	 * Creates or updates extrafields handled by the module
+	 */
+	protected function insertExtrafields(): int
+	{
+		require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
+
+		$extrafields = new ExtraFields($this->db);
+
+		foreach ($this->extrafields as $extrafield) {
+			if (! array_key_exists('size', $extrafield)) {
+				$extrafield['size'] = 0;
+			}
+
+			if (! array_key_exists('pos', $extrafield)) {
+				$extrafield['pos'] = 0;
+			}
+
+			if (array_key_exists('default_value', $extrafield)) {
+				$extrafield['default'] = $extrafield['default_value'];
+			}
+
+			if (
+				! array_key_exists('attrname', $extrafield)
+				|| ! array_key_exists('label', $extrafield)
+				|| ! array_key_exists('type', $extrafield)
+				|| ! array_key_exists('elementtype', $extrafield)
+			) {
+				continue;
+			}
+
+			$extrafield['length'] = $extrafield['size'];
+
+			$attrname = $extrafield['attrname'];
+			$elementtype = $extrafield['elementtype'];
+
+			if (! array_key_exists($elementtype, $extrafields->attributes)) {
+				$extrafields->fetch_name_optionals_label($elementtype);
+			}
+			// Update extrafield if it exists
+			if (isset($extrafields->attributes[$elementtype]['type'][$attrname])) {
+				$result = $extrafields->update(
+					$attrname,
+					$extrafield['label'],
+					$extrafield['type'],
+					$extrafield['size'],
+					$elementtype,
+					array_key_exists('unique', $extrafield) ? $extrafield['unique'] : 0,
+					array_key_exists('required', $extrafield) ? $extrafield['required'] : 0,
+					$extrafield['pos'],
+					array_key_exists('param', $extrafield) ? $extrafield['param'] : array(),
+					array_key_exists('alwayseditable', $extrafield) ? $extrafield['alwayseditable'] : 0,
+					array_key_exists('perms', $extrafield) ? $extrafield['perms'] : '',
+					array_key_exists('list', $extrafield) ? $extrafield['list'] : '',
+					array_key_exists('help', $extrafield) ? $extrafield['help'] : '',
+					array_key_exists('default_value', $extrafield) ? $extrafield['default_value'] : '',
+					array_key_exists('computed', $extrafield) ? $extrafield['computed'] : '',
+					array_key_exists('entity', $extrafield) ? $extrafield['entity'] : '',
+					array_key_exists('langfile', $extrafield) ? $extrafield['langfile'] : '',
+					array_key_exists('enabled', $extrafield) ? $extrafield['enabled'] : '1',
+					array_key_exists('totalizable', $extrafield) ? $extrafield['totalizable'] : 0,
+					array_key_exists('printable', $extrafield) ? $extrafield['printable'] : 0,
+					array_key_exists('moreparams', $extrafield) ? $extrafield['moreparams'] : array(),
+				);
+			} else {
+				$result = $extrafields->addExtraField(
+					$attrname,
+					$extrafield['label'],
+					$extrafield['type'],
+					$extrafield['pos'],
+					$extrafield['size'],
+					$elementtype,
+					array_key_exists('unique', $extrafield) ? $extrafield['unique'] : 0,
+					array_key_exists('required', $extrafield) ? $extrafield['required'] : 0,
+					array_key_exists('default_value', $extrafield) ? $extrafield['default_value'] : '',
+					array_key_exists('param', $extrafield) ? $extrafield['param'] : '',
+					array_key_exists('alwayseditable', $extrafield) ? $extrafield['alwayseditable'] : 0,
+					array_key_exists('perms', $extrafield) ? $extrafield['perms'] : '',
+					array_key_exists('list', $extrafield) ? $extrafield['list'] : '-1',
+					array_key_exists('help', $extrafield) ? $extrafield['help'] : '',
+					array_key_exists('computed', $extrafield) ? $extrafield['computed'] : '',
+					array_key_exists('entity', $extrafield) ? $extrafield['entity'] : '',
+					array_key_exists('langfile', $extrafield) ? $extrafield['langfile'] : '',
+					array_key_exists('enabled', $extrafield) ? $extrafield['enabled'] : '1',
+					array_key_exists('totalizable', $extrafield) ? $extrafield['totalizable'] : 0,
+					array_key_exists('printable', $extrafield) ? $extrafield['printable'] : 0,
+					array_key_exists('moreparams', $extrafield) ? $extrafield['moreparams'] : array(),
+				);
+			}
+
+			if ($result < 0) {
+				if (empty($this->error) && ! empty($extrafields->error)) {
+					$this->error = $extrafields->error;
+				}
+
+				if (empty($this->errors) && ! empty($extrafields->error)) {
+					$this->errors = $extrafields->errors;
+				}
+
+				return 1;
+			}
+		}
+
+		return 0;
+	}
 	/**
 	 * Function called when module is enabled.
 	 * The init function adds tabs, constants, boxes, permissions and menus (defined in constructor) into Dolibarr database.

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -2537,9 +2537,18 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 			$attrname = $extrafield['attrname'];
 			$elementtype = $extrafield['elementtype'];
 
+			if ($elementtype == 'thirdparty') {
+				$elementtype = 'societe';
+			} elseif ($elementtype == 'contact') {
+				$elementtype = 'socpeople';
+			} elseif ($elementtype == 'order_supplier') {
+				$elementtype = 'commande_fournisseur';
+			}
+
 			if (! array_key_exists($elementtype, $extrafields->attributes)) {
 				$extrafields->fetch_name_optionals_label($elementtype);
 			}
+
 			// Update extrafield if it exists
 			if (isset($extrafields->attributes[$elementtype]['type'][$attrname])) {
 				$result = $extrafields->update(

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -2503,6 +2503,8 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 
 	/**
 	 * Creates or updates extrafields handled by the module
+	 *
+	 * @return int Error count (0 if OK)
 	 */
 	protected function insertExtrafields(): int
 	{

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -488,6 +488,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 			$err += $this->insert_menus();
 		}
 
+		// Insert extrafields
 		if (!$err) {
 			$err += $this->insertExtrafields();
 		}
@@ -600,6 +601,11 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 		// Remove module's menus (entries in llx_menu)
 		if (!$err) {
 			$err += $this->delete_menus();
+		}
+
+		// Disable extrafields managed by the module
+		if (!$err) {
+			$err += $this->deleteExtrafields();
 		}
 
 		// Remove module's directories
@@ -2602,6 +2608,26 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 
 		return 0;
 	}
+
+	/**
+	 * Disable extrafields managed by the module
+	 *
+	 * @return int Error count (0 if OK)
+	 */
+	protected function deleteExtrafields(): int
+	{
+		$sql = 'UPDATE '.$this->db->prefix().'extrafields SET enabled = 0 WHERE module = "'.$this->db->escape($this->rights_class).'"';
+
+		$resql = $this->db->query($sql);
+
+		if (!$resql) {
+			$this->error = $this->db->lasterror();
+			return 1;
+		}
+
+		return 0;
+	}
+
 	/**
 	 * Function called when module is enabled.
 	 * The init function adds tabs, constants, boxes, permissions and menus (defined in constructor) into Dolibarr database.

--- a/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
+++ b/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
@@ -388,3 +388,6 @@ ALTER TABLE llx_chargesociales ADD INDEX idx_chargesociales_fk_user (fk_user);
 
 -- table paiementcharge indexes
 ALTER TABLE llx_paiementcharge ADD INDEX idx_paiementcharge_fk_charge (fk_charge);
+
+ALTER TABLE llx_extrafields ADD module VARCHAR(255) AFTER csslist;
+

--- a/htdocs/install/mysql/tables/llx_extrafields.sql
+++ b/htdocs/install/mysql/tables/llx_extrafields.sql
@@ -43,6 +43,7 @@ create table llx_extrafields
 	css             varchar(128),                               -- to store css on create/update forms
 	cssview         varchar(128),                               -- to store css on view form
 	csslist         varchar(128),                               -- to store css on list
+	module			varchar(255),								-- module responsible for the extrafield
 	fk_user_author	integer,									-- user making creation
 	fk_user_modif	integer,	                                -- user making last change
 	datec			datetime,									-- date de creation

--- a/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
+++ b/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
@@ -450,6 +450,62 @@ class modMyModule extends DolibarrModules
 		$this->import_run_sql_after_array[$r] = array();
 		$r++; */
 		/* END MODULEBUILDER IMPORT MYOBJECT */
+
+		$this->extrafields = array();
+		/* `attrname`, `label`, `type` and `elementtype` are required. @see ExtraFields::addExtraField() for supported indices.
+		$this->extrafields[] = array(
+			'attrname' => 'mymodule_separator1',
+			'label' => 'Separator 1',
+			'type' => 'separator',
+			'elementtype' => 'thirdparty',
+			'pos' => 1,
+			'langfile' => 'mymodule@mymodule',
+		);
+		$this->extrafields[] = array(
+			'attrname' => 'mymodule_myattr1',
+			'label' => 'New Attr 1 label',
+			'type' => 'boolean',
+			'elementtype' => 'thirdparty',
+			'pos' => 1,
+			'langfile' => 'mymodule@mymodule',
+		);
+		$this->extrafields[] = array(
+			'attrname' => 'mymodule_myattr2',
+			'label' => 'New Attr 2 label',
+			'type' => 'varchar',
+			'size' => 10,
+			'elementtype' => 'projet',
+			'pos' => 1,
+			'langfile' => 'mymodule@mymodule',
+		);
+		$this->extrafields[] = array(
+			'attrname' => 'mymodule_myattr3',
+			'label' => 'New Attr 3 label',
+			'type' => 'varchar',
+			'size' => 10,
+			'elementtype' => 'bank_account',
+			'pos' => 1,
+			'langfile' => 'mymodule@mymodule',
+		);
+		$this->extrafields[] = array(
+			'attrname' => 'mymodule_myattr4',
+			'label' => 'New Attr 4 label',
+			'type' => 'select',
+			'param' => array('options' => array('code1' => 'Val1', 'code2' => 'Val2', 'code3' => 'Val3')),
+			'size' => 3,
+			'elementtype' => 'thirdparty',
+			'pos' => 1,
+			'langfile' => 'mymodule@mymodule',
+		);
+		$this->extrafields[] = array(
+			'attrname' => 'mymodule_myattr5',
+			'label' => 'New Attr 5 label',
+			'type' => 'text',
+			'elementtype' => 'user',
+			'pos' => 1,
+			'langfile' => 'mymodule@mymodule',
+		);
+		 */
 	}
 
 	/**
@@ -469,16 +525,6 @@ class modMyModule extends DolibarrModules
 		if ($result < 0) {
 			return -1; // Do not activate module if error 'not allowed' returned when loading module SQL queries (the _load_table run sql with run_sql with the error allowed parameter set to 'default')
 		}
-
-		// Create extrafields during init
-		//include_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
-		//$extrafields = new ExtraFields($this->db);
-		//$result0=$extrafields->addExtraField('mymodule_separator1', "Separator 1", 'separator', 1,  0, 'thirdparty',   0, 0, '', array('options'=>array(1=>1)), 1, '', 1, 0, '', '', 'mymodule@mymodule', 'isModEnabled("mymodule")');
-		//$result1=$extrafields->addExtraField('mymodule_myattr1', "New Attr 1 label", 'boolean', 1,  3, 'thirdparty',   0, 0, '', '', 1, '', -1, 0, '', '', 'mymodule@mymodule', 'isModEnabled("mymodule")');
-		//$result2=$extrafields->addExtraField('mymodule_myattr2', "New Attr 2 label", 'varchar', 1, 10, 'project',      0, 0, '', '', 1, '', -1, 0, '', '', 'mymodule@mymodule', 'isModEnabled("mymodule")');
-		//$result3=$extrafields->addExtraField('mymodule_myattr3', "New Attr 3 label", 'varchar', 1, 10, 'bank_account', 0, 0, '', '', 1, '', -1, 0, '', '', 'mymodule@mymodule', 'isModEnabled("mymodule")');
-		//$result4=$extrafields->addExtraField('mymodule_myattr4', "New Attr 4 label", 'select',  1,  3, 'thirdparty',   0, 1, '', array('options'=>array('code1'=>'Val1','code2'=>'Val2','code3'=>'Val3')), 1,'', -1, 0, '', '', 'mymodule@mymodule', 'isModEnabled("mymodule")');
-		//$result5=$extrafields->addExtraField('mymodule_myattr5', "New Attr 5 label", 'text',    1, 10, 'user',         0, 0, '', '', 1, '', -1, 0, '', '', 'mymodule@mymodule', 'isModEnabled("mymodule")');
 
 		// Permissions
 		$this->remove($options);


### PR DESCRIPTION
Bonus features over calling `ExtraFields::addExtraField()` :
- handle updating extrafields definitition if it already exists
- disable extrafields linked to the module
- add to module builder template