### PR TITLE
Define CommonObject relation in CommonObjectLine classes

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1671,6 +1671,16 @@ class BOMLine extends CommonObjectLine
 	public $table_element = 'bom_bomline';
 
 	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'bom';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_bom';
+
+	/**
 	 * @var string String with name of icon for bomline. Must be the part after the 'object_' into object_bomline.png
 	 */
 	public $picto = 'bomline';

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -3975,6 +3975,16 @@ class PropaleLigne extends CommonObjectLine
 	 */
 	public $table_element = 'propaldet';
 
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'propal';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_propal';
+
 	public $oldline;
 
 	// From llx_propaldet

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -2143,6 +2143,16 @@ class FactureLigneRec extends CommonInvoiceLine
 	 */
 	public $table_element = 'facturedet_rec';
 
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'facturerec';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_facture';
+
 	//! From llx_facturedet_rec
 	//! Id facture
 	public $fk_facture;

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3010,6 +3010,16 @@ class ContratLigne extends CommonObjectLine
 	public $table_element = 'contratdet';
 
 	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'contrat';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_contrat';
+
+	/**
 	 * @var string 	Name to use for 'features' parameter to check module permissions user->rights->feature with restrictedArea().
 	 * 				Undefined means same value than $element. Can be use to force a check on another element for example for class of line, we mention here the parent element.
 	 */

--- a/htdocs/core/class/commonobjectline.class.php
+++ b/htdocs/core/class/commonobjectline.class.php
@@ -34,6 +34,16 @@
 abstract class CommonObjectLine extends CommonObject
 {
 	/**
+	 * @var string ID to identify parent CommonObject type (element name)
+	 */
+	public $parent_element = '';
+
+	/**
+	 * @var string Attribute related to parent CommonObject rowid (many2one)
+	 */
+	public $fk_parent_attribute = '';
+
+	/**
 	 * Id of the line
 	 * @var int
 	 */

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2656,6 +2656,15 @@ class ExpeditionLigne extends CommonObjectLine
 	 */
 	public $table_element = 'expeditiondet';
 
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'expedition';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_expedition';
 
 	/**
 	 * Id of the line. Duplicate of $id.

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3741,6 +3741,16 @@ class CommandeFournisseurLigne extends CommonOrderLine
 	 */
 	public $table_element = 'commande_fournisseurdet';
 
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'commande_fournisseur';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_commande_fournisseur';
+
 	public $oldline;
 
 	/**

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -3733,6 +3733,16 @@ class SupplierInvoiceLine extends CommonObjectLine
 	public $table_element = 'facture_fourn_det';
 
 	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'facture_fourn';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_facture_fourn';
+
+	/**
 	 * @var static
 	 */
 	public $oldline;

--- a/htdocs/hrm/class/evaluationdet.class.php
+++ b/htdocs/hrm/class/evaluationdet.class.php
@@ -53,6 +53,16 @@ class EvaluationLine extends CommonObjectLine
 	public $table_element = 'hrm_evaluationdet';
 
 	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'hrm_evaluation';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_evaluation';
+
+	/**
 	 * @var string String with name of icon for evaluationdet. Must be the part after the 'object_' into object_evaluationdet.png
 	 */
 	public $picto = 'evaluationdet@hrm';

--- a/htdocs/hrm/class/skilldet.class.php
+++ b/htdocs/hrm/class/skilldet.class.php
@@ -51,6 +51,16 @@ class Skilldet extends CommonObjectLine
 	public $table_element = 'hrm_skilldet';
 
 	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'skill';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_skill';
+
+	/**
 	 * @var string String with name of icon for skilldet. Must be the part after the 'object_' into object_skilldet.png
 	 */
 	public $picto = 'skilldet@hrm';

--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -1251,6 +1251,18 @@ class MyObjectLine extends CommonObjectLine
 	// We should have a field rowid, fk_myobject and position
 
 	/**
+	 * To overload
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = '';
+
+	/**
+	 * To overload
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = '';
+
+	/**
 	 * Constructor
 	 *
 	 * @param DoliDB $db Database handler

--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -2002,6 +2002,16 @@ class MoLine extends CommonObjectLine
 	public $table_element = 'mrp_production';
 
 	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'mo';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_mo';
+
+	/**
 	 *  'type' field format:
 	 *  	'integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter[:Sortfield]]]',
 	 *  	'select' (list of values are in 'options'. for integer list of values are in 'arrayofkeyval'),

--- a/htdocs/product/inventory/class/inventory.class.php
+++ b/htdocs/product/inventory/class/inventory.class.php
@@ -801,6 +801,16 @@ class InventoryLine extends CommonObjectLine
 	public $table_element = 'inventorydet';
 
 	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'inventory';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_inventory';
+
+	/**
 	 * @var string String with name of icon for inventory
 	 */
 	public $picto = 'stock';

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -2815,6 +2815,16 @@ class SupplierProposalLine extends CommonObjectLine
 	 */
 	public $table_element = 'supplier_proposaldet';
 
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $parent_element = 'supplier_proposal';
+
+	/**
+	 * @see CommonObjectLine
+	 */
+	public $fk_parent_attribute = 'fk_supplier_proposal';
+
 	public $oldline;
 
 	/**


### PR DESCRIPTION
# FIX-NEW
Add new information in CommonObjectLine objects to describe relation with parent commonObject (relation many2one) and so prepare another PR to fix ajax resquests on those objects (#29941), and, in a third time, fix/add the ability to use a CommonObjectLine in an extrafield as a link (#29957).
