### PR TITLE
FIX#29958 - Evaluation of the enablement condition of an extrafield to add it to list of fields

### DIFF
--- a/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
@@ -25,7 +25,12 @@ if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table
 			$extrafieldsobjectprefix = 'ef.';
 		}
 		foreach ($extrafields->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
-			if (!empty($extrafields->attributes[$extrafieldsobjectkey]['list'][$key])) {
+			$enabled = true;
+			if(!empty($extrafields->attributes[$extrafieldsobjectkey]['enabled'][$key])) {
+				// An enablemend condition exists, it is evaluated.
+				$enabled = dol_eval($extrafields->attributes[$extrafieldsobjectkey]['enabled'][$key], 1);
+			}
+			if (!empty($extrafields->attributes[$extrafieldsobjectkey]['list'][$key]) && $enabled ) {
 				$arrayfields[$extrafieldsobjectprefix.$key] = array(
 					'label'    => $extrafields->attributes[$extrafieldsobjectkey]['label'][$key],
 					'type'     => $extrafields->attributes[$extrafieldsobjectkey]['type'][$key],

--- a/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
@@ -27,7 +27,7 @@ if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table
 		foreach ($extrafields->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
 			$enabled = true;
 			if (!empty($extrafields->attributes[$extrafieldsobjectkey]['enabled'][$key])) {
-				// An enablemend condition exists, it is evaluated.
+				// An enablement condition exist, it is evaluated.
 				$enabled = dol_eval($extrafields->attributes[$extrafieldsobjectkey]['enabled'][$key], 1);
 			}
 			if (!empty($extrafields->attributes[$extrafieldsobjectkey]['list'][$key]) && $enabled ) {

--- a/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
@@ -26,7 +26,7 @@ if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table
 		}
 		foreach ($extrafields->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
 			$enabled = true;
-			if(!empty($extrafields->attributes[$extrafieldsobjectkey]['enabled'][$key])) {
+			if (!empty($extrafields->attributes[$extrafieldsobjectkey]['enabled'][$key])) {
 				// An enablemend condition exists, it is evaluated.
 				$enabled = dol_eval($extrafields->attributes[$extrafieldsobjectkey]['enabled'][$key], 1);
 			}


### PR DESCRIPTION
# FIX|Fix #29958 
When there in an enablement condition for an extrafield in database, it is evaluated when constructing the list of extrafields to put in the array elements to show.

After:
![Capture d’écran du 2024-06-09 11-43-04](https://github.com/Dolibarr/dolibarr/assets/3855975/0e2d98ff-8043-45e3-88e3-a7dc576c6a6c)

Before: 
![Capture d’écran du 2024-06-09 11-40-35](https://github.com/Dolibarr/dolibarr/assets/3855975/53d2922d-9500-4a07-b2e6-66e88194d119)
![Capture d’écran du 2024-06-09 11-41-54](https://github.com/Dolibarr/dolibarr/assets/3855975/c7e94422-aaaa-4ede-a7bf-f3fcdfb67cb1)
