### PR TITLE
FIX : move porpale ref pdf cornas

### DIFF
--- a/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
@@ -1321,6 +1321,7 @@ class pdf_cornas extends ModelePDFSuppliersOrders
 		$top_shift = 0;
 		// Show list of linked objects
 		$current_y = $pdf->getY();
+		$posx = $posx+10;
 		$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, 100, 3, 'R', $default_font_size);
 		if ($current_y < $pdf->getY()) {
 			$top_shift = $pdf->getY() - $current_y;


### PR DESCRIPTION
# FIX|Fix # move porpale ref pdf cornas
The reference of a commercial proposal was misaligned when I generated a PDF for a supplier order that was related to a commercial proposal.

