### PR TITLE
add a check if tmparray is an array

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8067,7 +8067,7 @@ class Form
 					}
 				} else {
 					// For a property in ->fields
-					if (array_key_exists($tmparray[1], $objectforfieldstmp->fields)) {
+					if (is_array($tmparray) && array_key_exists($tmparray[1], $objectforfieldstmp->fields)) {
 						$objectdesc = $objectforfieldstmp->fields[$tmparray[1]]['type'];
 						$objectdesc = preg_replace('/^integer[^:]*:/', '', $objectdesc);
 					}


### PR DESCRIPTION
is some case we have a strange bug like that

PHP Warning:  Attempt to read property "fields" on int in htdocs/core/class/html.form.class.php on line 8066
PHP Fatal error:  Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in htdocs/core/class/html.form.class.php:8066