### PR TITLE
fetchObjectByElement could return int error code

### DIFF
--- a/htdocs/core/ajax/ajaxtooltip.php
+++ b/htdocs/core/ajax/ajaxtooltip.php
@@ -52,7 +52,7 @@ if (GETPOSTISSET('option')) {
 
 // Load object according to $element
 $object = fetchObjectByElement($id, $objecttype);
-if (empty($object->element)) {
+if (is_numeric($object) || empty($object->element)) {
 	httponly_accessforbidden('Failed to get object with fetchObjectByElement(id='.$id.', objecttype='.$objecttype.')');
 }
 

--- a/htdocs/core/ajax/extraparams.php
+++ b/htdocs/core/ajax/extraparams.php
@@ -46,7 +46,9 @@ $type = GETPOST('type', 'alpha');
 
 // Load object according to $id and $element
 $object = fetchObjectByElement($id, $element);
-
+if (is_numeric($object) || empty($object->element)) {
+	httponly_accessforbidden('Failed to get object with fetchObjectByElement(id='.$id.', objecttype='.$objecttype.')');
+}
 $module = $object->module;
 $element = $object->element;
 $usesublevelpermission = ($module != $element ? $element : '');

--- a/htdocs/core/ajax/fileupload.php
+++ b/htdocs/core/ajax/fileupload.php
@@ -45,6 +45,9 @@ $elementupload = $element;
 
 // Load object according to $id and $element
 $object = fetchObjectByElement($id, $element);
+if (is_numeric($object) || empty($object->element)) {
+	httponly_accessforbidden('Failed to get object with fetchObjectByElement(id='.$id.', objecttype='.$objecttype.')');
+}
 
 $module = $object->module;
 $element = $object->element;

--- a/htdocs/core/ajax/loadinplace.php
+++ b/htdocs/core/ajax/loadinplace.php
@@ -45,6 +45,9 @@ $id = $fk_element;
 
 // Load object according to $id and $element
 $object = fetchObjectByElement($id, $element);
+if (is_numeric($object) || empty($object->element)) {
+	httponly_accessforbidden('Failed to get object with fetchObjectByElement(id='.$id.', objecttype='.$objecttype.')');
+}
 
 $module = $object->module;
 $element = $object->element;

--- a/htdocs/core/ajax/objectonoff.php
+++ b/htdocs/core/ajax/objectonoff.php
@@ -52,7 +52,7 @@ $format = 'int';
 
 // Load object according to $id and $element
 $object = fetchObjectByElement($id, $element);
-if (!is_object($object)) {
+if (is_numeric($object) || empty($object->element)) {
 	httponly_accessforbidden("Bad value for combination of parameters element/field: Object not found.");	// This includes the exit.
 }
 

--- a/htdocs/core/ajax/saveinplace.php
+++ b/htdocs/core/ajax/saveinplace.php
@@ -57,6 +57,9 @@ savemethodname:
 
 // Load object according to $id and $element
 $object = fetchObjectByElement($id, $element);
+if (is_numeric($object) || empty($object->element)) {
+	httponly_accessforbidden('Failed to get object with fetchObjectByElement(id='.$id.', objecttype='.$objecttype.')');
+}
 
 $module = $object->module;
 $element = $object->element;

--- a/htdocs/core/class/fileupload.class.php
+++ b/htdocs/core/class/fileupload.class.php
@@ -70,6 +70,10 @@ class FileUpload
 		if ($pathname !== null && $filename !== null) {
 			// Get object from its id and type
 			$object = fetchObjectByElement($fk_element, $element);
+			if (is_numeric($object) || empty($object->element)) {
+				//fatal ? at least dolibarr log
+				dol_syslog("Failed to get object with fetchObjectByElement", LOG_ERR);
+			}
 
 			$object_ref = dol_sanitizeFileName($object->ref);
 

--- a/htdocs/core/tpl/resource_view.tpl.php
+++ b/htdocs/core/tpl/resource_view.tpl.php
@@ -30,6 +30,10 @@ print '<input type="hidden" name="resource_type" value="'.$resource_type.'" />';
 if ((array) $linked_resources && count($linked_resources) > 0) {
 	foreach ($linked_resources as $linked_resource) {
 		$object_resource = fetchObjectByElement($linked_resource['resource_id'], $linked_resource['resource_type']);
+		if (is_numeric($object_resource) || empty($object_resource->element)) {
+			//fatal ? at least dolibarr log
+			dol_syslog("Failed to get object with fetchObjectByElement", LOG_ERR);
+		}
 
 		//$element_id = $linked_resource['rowid'];
 

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -120,6 +120,10 @@ if (empty($reshook)) {
 			$action = '';
 		} else {
 			$objstat = fetchObjectByElement($element_id, $element, $element_ref);
+			if (is_numeric($objstat) || empty($objstat->element)) {
+				//fatal ? at least dolibarr log
+				dol_syslog("Failed to get object with fetchObjectByElement", LOG_ERR);
+			}
 			$objstat->element = $element; // For externals module, we need to keep @xx
 
 			// TODO : add this check at update_linked_resource and when modifying event start or end date


### PR DESCRIPTION
There is a lot of case in dolibarr code where there is no tests on values returned by fetchObjectByElement function.

That function COULD return an object (most of the time when there is no problem) but sometimes it's 0 or -1 (for example) then we don't have to use properties on it !