### PR TITLE
FIX(orderlist): Double hook execution

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -14,6 +14,7 @@
  * Copyright (C) 2021-2024 	Anthony Berton			<anthony.berton@bb2a.fr>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Noé Cendrier			<noe.cendrier@altairis.fr>
+ * Copyright (C) 2024		Benjamin Falière		<benjamin.faliere@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1527,9 +1528,6 @@ if (empty($reshook)) {
 if (!empty($moreforfilter)) {
 	print '<div class="liste_titre liste_titre_bydiv centpercent">';
 	print $moreforfilter;
-	$parameters = array();
-	$reshook = $hookmanager->executeHooks('printFieldPreListTitle', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
-	print $hookmanager->resPrint;
 	print '</div>';
 }
 


### PR DESCRIPTION
Hook printFieldPreListTitle was executed twice if `$moreforfilter` was set by the first execution.