### PR TITLE
FIX : issue to get the right files exported in Quadratrus export.php

### DIFF
--- a/htdocs/accountancy/bookkeeping/export.php
+++ b/htdocs/accountancy/bookkeeping/export.php
@@ -1190,7 +1190,6 @@ while ($i < min($num, $limit)) {
 			require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 			$objectstatic = new Facture($db);
 			$objectstatic->fetch($line->fk_doc);
-			$modulepart = 'facture'; // or use $objectstatic->element
 
 			$filename = dol_sanitizeFileName($line->doc_ref);
 			$filedir = $conf->facture->dir_output.'/'.dol_sanitizeFileName($line->doc_ref);
@@ -1202,11 +1201,10 @@ while ($i < min($num, $limit)) {
 			require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
 			$objectstatic = new FactureFournisseur($db);
 			$objectstatic->fetch($line->fk_doc);
-			$modulepart = 'invoice_supplier'; // or use $objectstatic->element
 
 			$filename = dol_sanitizeFileName($line->doc_ref);
-			$filedir = $conf->fournisseur->facture->dir_output.'/'.get_exdir($line->fk_doc, 2, 0, 0, $objectstatic, $modulepart).dol_sanitizeFileName($line->doc_ref);
-			$subdir = get_exdir($objectstatic->id, 2, 0, 0, $objectstatic, $modulepart).dol_sanitizeFileName($line->doc_ref);
+			$filedir = $conf->fournisseur->facture->dir_output.'/'.get_exdir($line->fk_doc, 2, 0, 0, $objectstatic, $objectstatic->element).dol_sanitizeFileName($line->doc_ref);
+			$subdir = get_exdir($objectstatic->id, 2, 0, 0, $objectstatic, $objectstatic->element).dol_sanitizeFileName($line->doc_ref);
 			$documentlink = $formfile->getDocumentsLink($objectstatic->element, $subdir, $filedir);
 		} elseif ($line->doc_type == 'expense_report') {
 			$langs->loadLangs(array('trips'));
@@ -1214,7 +1212,6 @@ while ($i < min($num, $limit)) {
 			require_once DOL_DOCUMENT_ROOT.'/expensereport/class/expensereport.class.php';
 			$objectstatic = new ExpenseReport($db);
 			$objectstatic->fetch($line->fk_doc);
-			$modulepart = 'expensereport'; // or use $objectstatic->element
 
 			$filename = dol_sanitizeFileName($line->doc_ref);
 			$filedir = $conf->expensereport->dir_output.'/'.dol_sanitizeFileName($line->doc_ref);

--- a/htdocs/accountancy/bookkeeping/export.php
+++ b/htdocs/accountancy/bookkeeping/export.php
@@ -1190,7 +1190,7 @@ while ($i < min($num, $limit)) {
 			require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 			$objectstatic = new Facture($db);
 			$objectstatic->fetch($line->fk_doc);
-			//$modulepart = 'facture';
+			$modulepart = 'facture'; // or use $objectstatic->element
 
 			$filename = dol_sanitizeFileName($line->doc_ref);
 			$filedir = $conf->facture->dir_output.'/'.dol_sanitizeFileName($line->doc_ref);
@@ -1202,7 +1202,7 @@ while ($i < min($num, $limit)) {
 			require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
 			$objectstatic = new FactureFournisseur($db);
 			$objectstatic->fetch($line->fk_doc);
-			//$modulepart = 'invoice_supplier';
+			$modulepart = 'invoice_supplier'; // or use $objectstatic->element
 
 			$filename = dol_sanitizeFileName($line->doc_ref);
 			$filedir = $conf->fournisseur->facture->dir_output.'/'.get_exdir($line->fk_doc, 2, 0, 0, $objectstatic, $modulepart).dol_sanitizeFileName($line->doc_ref);
@@ -1214,7 +1214,7 @@ while ($i < min($num, $limit)) {
 			require_once DOL_DOCUMENT_ROOT.'/expensereport/class/expensereport.class.php';
 			$objectstatic = new ExpenseReport($db);
 			$objectstatic->fetch($line->fk_doc);
-			//$modulepart = 'expensereport';
+			$modulepart = 'expensereport'; // or use $objectstatic->element
 
 			$filename = dol_sanitizeFileName($line->doc_ref);
 			$filedir = $conf->expensereport->dir_output.'/'.dol_sanitizeFileName($line->doc_ref);


### PR DESCRIPTION
# FIX 
The export of files does not work correctly when using Accounting option export Quadratus with file export. The files are not attached to the zip until we uncomment the 3 lines of this PR.
