### PR TITLE
FIX: restricted os commands: don't permit restore commands at install

### DIFF
--- a/htdocs/admin/system/security.php
+++ b/htdocs/admin/system/security.php
@@ -279,7 +279,7 @@ if (empty($dolibarr_main_restrict_os_commands)) {
 } else {
 	print $dolibarr_main_restrict_os_commands;
 }
-print ' <span class="opacitymedium">('.$langs->trans("RecommendedValueIs", 'mysqldump, mysql, pg_dump, pgrestore').')</span>';
+print ' <span class="opacitymedium">('.$langs->trans("RecommendedValueIs", 'mysqldump, pg_dump').')</span>';
 print '<br>';
 
 if (empty($conf->global->SECURITY_DISABLE_TEST_ON_OBFUSCATED_CONF)) {

--- a/htdocs/conf/conf.php.example
+++ b/htdocs/conf/conf.php.example
@@ -253,11 +253,11 @@ $dolibarr_main_prod='1';
 // $dolibarr_main_restrict_os_commands
 // To restrict commands you can execute by the backup feature, enter allowed command here.
 // Note: If you can, defining permission on OS linux (using SELinux for example) may be a better choice.
-// Default value: 'mysqldump, mysql, pg_dump, pgrestore'
+// Default value: 'mysqldump, pg_dump'
 // Examples:
 // $dolibarr_main_restrict_os_commands='mysqldump, /usr/local/bin/otherdumptool';
 //
-$dolibarr_main_restrict_os_commands='mysqldump, mysql, pg_dump, pgrestore';
+$dolibarr_main_restrict_os_commands='mysqldump, pg_dump';
 
 // $dolibarr_main_restrict_ip
 // To restrict access to backoffice to some ip addresses only. Use a comma to separate values.

--- a/htdocs/install/step1.php
+++ b/htdocs/install/step1.php
@@ -908,7 +908,7 @@ function write_conf_file($conffile)
 		fputs($fp, '$dolibarr_main_force_https=\''.$main_force_https.'\';');
 		fputs($fp, "\n");
 
-		fputs($fp, '$dolibarr_main_restrict_os_commands=\'mysqldump, mysql, pg_dump, pgrestore\';');
+		fputs($fp, '$dolibarr_main_restrict_os_commands=\'mysqldump, pg_dump\';');
 		fputs($fp, "\n");
 
 		fputs($fp, '$dolibarr_nocsrfcheck=\'0\';');


### PR DESCRIPTION
Hi @eldy

I noticed the name of the PostgreSQL restore command was wrong in the restricted access to OS commands (`pgrestore` instead of the correct `pg_restore`), so I wanted to propose changing it.

But when digging on the implications of the fix, I saw that anyway : 
- the recommended PostgreSQL tool to restore a dump is the `psql` command (see `pgsql::getPathOfRestore()`)
- the restore page never actually lanches the restore command, whatever the database type.

So I'm proposing a better fix that simply doesn't allow restore commands by default.

Would you be open to even further restrict those commands at installation depending on the database type (only `mysqldump` command for MySQL/MariaFB, only `psql` for PostgreSQL, or empty otherwise) ?

