### PR TITLE
qual fix PHAN warning when using $product->fetch($id) with $id not being an integer

### DIFF
--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -490,7 +490,7 @@ class Categories extends DolibarrApi
 			throw new RestException(400, "this type is not recognized yet.");
 		}
 
-		$result = $object->fetch('', $object_ref);
+		$result = $object->fetch(0, $object_ref);
 		if ($result > 0) {
 			$result = $this->category->add_type($object, $type);
 			if ($result < 0) {

--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -650,7 +650,7 @@ class Categories extends DolibarrApi
 			throw new RestException(400, "this type is not recognized yet.");
 		}
 
-		$result = $object->fetch('', (string) $object_ref);
+		$result = $object->fetch(0, (string) $object_ref);
 		if ($result > 0) {
 			$result = $this->category->del_type($object, $type);
 			if ($result < 0) {

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -1759,7 +1759,7 @@ class Products extends DolibarrApi
 			throw new RestException(403);
 		}
 
-		$result = $this->product->fetch('', $ref);
+		$result = $this->product->fetch(0, $ref);
 		if (!$result) {
 			throw new RestException(404, 'Product not found');
 		}

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -1881,7 +1881,7 @@ class Products extends DolibarrApi
 			}
 		}
 
-		$result = $this->product->fetch('', trim($ref));
+		$result = $this->product->fetch(0, trim($ref));
 		if (!$result) {
 			throw new RestException(404, 'Product not found');
 		}

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -770,7 +770,7 @@ class ProductCombination
 
 		if (!empty($forced_refvar) && $forced_refvar != $product->ref) {
 			$existingProduct = new Product($this->db);
-			$result = $existingProduct->fetch('', $forced_refvar);
+			$result = $existingProduct->fetch(0, $forced_refvar);
 			if ($result > 0) {
 				$newproduct = $existingProduct;
 			} else {

--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -375,7 +375,7 @@ if ($action === 'confirm_deletecombination') {
 	//Check destination product
 	$dest_product = GETPOST('dest_product');
 
-	if ($prodstatic->fetch('', $dest_product) > 0) {
+	if ($prodstatic->fetch(0, $dest_product) > 0) {
 		//To prevent from copying to the same product
 		if ($prodstatic->ref != $object->ref) {
 			if ($prodcomb->copyAll($user, $object->id, $prodstatic) > 0) {


### PR DESCRIPTION
htdocs/categories/class/api_categories.class.php	493	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($id) is '' of type '' but \Product::fetch() takes int (no real type) defined at htdocs/product/class/product.class.php:2540 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/categories/class/api_categories.class.php	653	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($id) is '' of type '' but \Product::fetch() takes int (no real type) defined at htdocs/product/class/product.class.php:2540 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/product/class/api_products.class.php	1762	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($id) is '' of type '' but \Product::fetch() takes int (no real type) defined at htdocs/product/class/product.class.php:2540 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
htdocs/product/class/api_products.class.php	1884	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($id) is '' of type '' but \Product::fetch() takes int (no real type) defined at htdocs/product/class/product.class.php:2540 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/variants/class/ProductCombination.class.php	773	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($id) is '' of type '' but \Product::fetch() takes int (no real type) defined at htdocs/product/class/product.class.php:2540 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

htdocs/variants/combinations.php	378	TypeError PhanTypeMismatchArgumentProbablyReal Argument 1 ($id) is '' of type '' but \Product::fetch() takes int (no real type) defined at htdocs/product/class/product.class.php:2540 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
S