### PR TITLE
qual: fix PHAN warnings for ProductCombination.class.php

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -747,7 +747,7 @@ class ProductCombination
 	 * @param User 				$user 			Object user
 	 * @param Product 			$product 		Parent product
 	 * @param array<int,int> 	$combinations 	Attribute and value combinations.
-	 * @param array<string,array<string,array{weight:string|float,price:string|float}>> $variations 	Price and weight variations
+	 * @param array<int,array<int,array{weight:string|float,price:string|float}>> $variations 	Price and weight variations (example: $variations[fk_product_attribute][fk_product_attribute_value]['weight'])
 	 * @param bool|array 		$price_var_percent 	Is the price variation a relative variation?
 	 * @param bool|float 		$forced_pricevar 	If the price variation is forced
 	 * @param bool|float 		$forced_weightvar 	If the weight variation is forced


### PR DESCRIPTION
htdocs/variants/class/ProductCombination.class.php	843	TypeError PhanTypeMismatchDimFetch When fetching an array index from a value of type array, found an array index of type int, but expected the index to be of type string

htdocs/variants/class/ProductCombination.class.php	843	TypeError PhanTypeMismatchDimFetch When fetching an array index from a value of type array, found an array index of type int, but expected the index to be of type string

htdocs/variants/class/ProductCombination.class.php	846	TypeError PhanTypeMismatchDimFetch When fetching an array index from a value of type array, found an array index of type int, but expected the index to be of type string

htdocs/variants/class/ProductCombination.class.php	846	TypeError PhanTypeMismatchDimFetch When fetching an array index from a value of type array, found an array index of type int, but expected the index to be of type string

htdocs/variants/class/ProductCombination.class.php	851	TypeError PhanTypeMismatchDimFetch When fetching an array index from a value of type array, found an array index of type int, but expected the index to be of type string

htdocs/variants/class/ProductCombination.class.php	851	TypeError PhanTypeMismatchDimFetch When fetching an array index from a value of type array, found an array index of type int, but expected the index to be of type string