### PR TITLE
qual: fix PHAN warnings regarding undeclared CommonObject properties

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -864,6 +864,21 @@ abstract class CommonObject
 	 */
 	public $isextrafieldmanaged = 0;
 
+	/**
+	 * @var string		Image filename (full or relative path)
+	 */
+	public $photo
+
+	/**
+	 * @var int 		Image width in px
+	 */
+	public $imgWidth
+
+	/**
+	 * @var int 		Image height in px
+	 */
+	public $imgHeight
+
 
 	// No constructor as it is an abstract class
 
@@ -9293,7 +9308,7 @@ abstract class CommonObject
 	 * getDataToShowPhoto
 	 *
 	 * @param 	string	$modulepart		Module part
-	 * @param 	string	$imagesize		Image size
+	 * @param 	string	$imagesize		Image size ('', 'mini' or 'small')
 	 * @return	array{dir:string,file:string,originalfile:string,altfile:string,email:string,capture:string}	Array of data to show photo
 	 */
 	public function getDataToShowPhoto($modulepart, $imagesize)

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -867,17 +867,17 @@ abstract class CommonObject
 	/**
 	 * @var string		Image filename (full or relative path)
 	 */
-	public $photo
+	public $photo;
 
 	/**
 	 * @var int 		Image width in px
 	 */
-	public $imgWidth
+	public $imgWidth;
 
 	/**
 	 * @var int 		Image height in px
 	 */
-	public $imgHeight
+	public $imgHeight;
 
 
 	// No constructor as it is an abstract class

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -865,7 +865,7 @@ abstract class CommonObject
 	public $isextrafieldmanaged = 0;
 
 	/**
-	 * @var string		Image filename (full or relative path)
+	 * @var string|1	Image filename (full or relative path) or 1 (1 is only used in htdocs/contrat/index.php, which might be a mistake => check TODO)
 	 */
 	public $photo;
 


### PR DESCRIPTION
htdocs/core/class/commonobject.class.php	9505	UndefError PhanUndeclaredProperty Reference to undeclared property \CommonObject->imgWidth

htdocs/product/class/product.class.php	448	Plugin PhanPluginUnknownPropertyType Property \Product->imgWidth has an initial type that cannot be inferred

htdocs/core/class/commonobject.class.php	9505	UndefError PhanUndeclaredProperty Reference to undeclared property \CommonObject->imgHeight

htdocs/product/class/product.class.php	449	Plugin PhanPluginUnknownPropertyType Property \Product->imgHeight has an initial type that cannot be inferred

htdocs/core/class/commonobject.class.php	9312	UndefError PhanUndeclaredProperty Reference to undeclared property \CommonObject->photo

htdocs/core/class/commonobject.class.php	9313	UndefError PhanUndeclaredProperty Reference to undeclared property \CommonObject->photo

htdocs/core/class/commonobject.class.php	9315	UndefError PhanUndeclaredProperty Reference to undeclared property \CommonObject->photo

htdocs/core/class/commonobject.class.php	9317	UndefError PhanUndeclaredProperty Reference to undeclared property \CommonObject->photo

htdocs/core/class/commonobject.class.php	9319	UndefError PhanUndeclaredProperty Reference to undeclared property \CommonObject->photo

htdocs/core/class/commonobject.class.php	9321	UndefError PhanUndeclaredProperty Reference to undeclared property \CommonObject->photo