### PR TITLE
FIX modification date from label in accounting bookkeeping list

### DIFF
--- a/htdocs/accountancy/bookkeeping/list.php
+++ b/htdocs/accountancy/bookkeeping/list.php
@@ -919,7 +919,7 @@ if (!empty($arrayfields['t.tms']['checked'])) {
 	print $form->selectDate($search_date_modification_start, 'search_date_modification_start', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans("From"));
 	print '</div>';
 	print '<div class="nowrap">';
-	print $form->selectDate($search_date_modification_end, 'search_date_modification_end', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans("From"));
+	print $form->selectDate($search_date_modification_end, 'search_date_modification_end', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans("to"));
 	print '</div>';
 	print '</td>';
 }


### PR DESCRIPTION
FIX modification date from label in accounting bookkeeping list

The modification date label is "From" instead of "to" for the end date filter :
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/e08168f4-5b1a-4c85-af64-eb193dff7f47)
