### PR TITLE
Fix paymentok to make custom module payment method possible

### DIFF
--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -134,16 +134,7 @@ if ($ws) {
 	dol_syslog("Paymentok.php page is invoked from a website with ref ".$ws.". It performs actions and then redirects back to this website. A page with ref paymentok must be created for this website.", LOG_DEBUG, 0, '_payment');
 }
 
-$validpaymentmethod = array();
-if (isModEnabled('paypal')) {
-	$validpaymentmethod['paypal'] = 'paypal';
-}
-if (isModEnabled('paybox')) {
-	$validpaymentmethod['paybox'] = 'paybox';
-}
-if (isModEnabled('stripe')) {
-	$validpaymentmethod['stripe'] = 'stripe';
-}
+$validpaymentmethod = getValidOnlinePaymentMethods($paymentmethod);
 
 // Security check
 if (empty($validpaymentmethod)) {


### PR DESCRIPTION
When we were paying with a payment method from a custom module the message 
No valid payment mode was sent

Because the payment method wasn't set in payment method So now we use the function to have this payment method in $validpaymentmethod