### PR TITLE
Fix paymentko to make custom module payment method possible

### DIFF
--- a/htdocs/public/payment/paymentko.php
+++ b/htdocs/public/payment/paymentko.php
@@ -103,17 +103,7 @@ if ($ws) {
 }
 
 
-$validpaymentmethod = array();
-if (isModEnabled('paypal')) {
-	$validpaymentmethod['paypal'] = 'paypal';
-}
-if (isModEnabled('paybox')) {
-	$validpaymentmethod['paybox'] = 'paybox';
-}
-if (isModEnabled('stripe')) {
-	$validpaymentmethod['stripe'] = 'stripe';
-}
-
+$validpaymentmethod = getValidOnlinePaymentMethods($paymentmethod);
 
 // Security check
 if (empty($validpaymentmethod)) {


### PR DESCRIPTION

When we were paying with a payment method from a custom module the message
No valid payment mode was sent

Because the payment method wasn't set in payment method So now we use the function to have this payment method in $validpaymentmethod