### PR TITLE
New col showuserlogin contact

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1226,6 +1226,7 @@ function show_contacts($conf, $langs, $db, $object, $backtopage = '', $showuserl
 		'sc.role' => array('label' => "ContactByDefaultFor", 'checked' => 1, 'position' => 40),
 		't.birthday' => array('label' => "Birthday", 'checked' => 0, 'position' => 45),
 		't.statut' => array('label' => "Status", 'checked' => 1, 'position' => 50, 'class' => 'center'),
+		'u.user'=>array('label'=>"DolibarrLogin", 'checked'=>1, 'position'=>50, 'class'=>'center'),
 	);
 	// Extra fields
 	if (!empty($extrafields->attributes[$contactstatic->table_element]['label']) && is_array($extrafields->attributes[$contactstatic->table_element]['label']) && count($extrafields->attributes[$contactstatic->table_element]['label'])) {

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -701,6 +701,8 @@ $resHook = $hookmanager->executeHooks('completeListOfReferent', $parameters, $ob
 
 if (!empty($hookmanager->resArray)) {
 	$listofreferent = array_merge($listofreferent, $hookmanager->resArray);
+}elseif ($resHook > 0 && !empty($hookmanager->resPrint)) {
+	$listofreferent = $hookmanager->resPrint;
 }
 
 if ($action == "addelement") {

--- a/htdocs/societe/contact.php
+++ b/htdocs/societe/contact.php
@@ -66,11 +66,12 @@ $errors = array();
 
 
 // Get parameters
-$action		= (GETPOST('action', 'aZ09') ? GETPOST('action', 'aZ09') : 'view');
-$cancel 	= GETPOST('cancel', 'alpha');
-$backtopage = GETPOST('backtopage', 'alpha');
-$confirm 	= GETPOST('confirm');
-$socid 		= GETPOSTINT('socid') ? GETPOSTINT('socid') : GETPOSTINT('id');
+$action			= (GETPOST('action', 'aZ09') ? GETPOST('action', 'aZ09') : 'view');
+$cancel 		= GETPOST('cancel', 'alpha');
+$backtopage 	= GETPOST('backtopage', 'alpha');
+$confirm 		= GETPOST('confirm');
+$socid 			= GETPOSTINT('socid') ? GETPOSTINT('socid') : GETPOSTINT('id');
+$selectedfields = GETPOST('selectedfields', 'alpha');
 
 if ($user->socid) {
 	$socid = $user->socid;
@@ -206,7 +207,8 @@ print '<br>';
 if ($action != 'presend') {
 	// Contacts list
 	if (!getDolGlobalString('SOCIETE_DISABLE_CONTACTS')) {
-		$result = show_contacts($conf, $langs, $db, $object, $_SERVER["PHP_SELF"].'?socid='.$object->id, 1);
+		$showuserlogin = in_array('u.user', explode(',', $selectedfields )) ? 1 : 0;
+		$result = show_contacts($conf, $langs, $db, $object, $_SERVER["PHP_SELF"].'?socid='.$object->id, $showuserlogin);
 	}
 }
 if ($action == 'delete') {


### PR DESCRIPTION
# FIX|Fix #[*COL DolibarrLogin in burger contact.php *]
On the contact.php page, the 'DolibarrLogin' column was mandatory.
I have integrated it into the burger menu so that the user can choose to display it or not.
