### PR TITLE
FIX: wrong llxHeader on "related items" tab for product card

### DIFF
--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -152,7 +152,7 @@ if ($id > 0 || !empty($ref)) {
 		$helpurl = 'EN:Module_Services_En|FR:Module_Services|ES:M&oacute;dulo_Servicios';
 	}
 
-	llxHeader('', $title, $helpurl, '', '', 0, 0, '', '', '', 'mod-product page-stats_facture');
+	llxHeader('', $title, $helpurl, '', 0, 0, '', '', '', 'mod-product page-stats_facture');
 
 	if ($result > 0) {
 		$head = product_prepare_head($product);


### PR DESCRIPTION
# FIX
`llxHeader` has many parameters. In this instance, the intent was to set the parameter `$morecssonbody` (the 10th). It came out as the 11th (one extra parameter was added mistakenly).