### PR TITLE
Fix: The qty to be produced not added in virtual stock

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -3482,7 +3482,7 @@ class Product extends CommonObject
 		$sql .= " WHERE m.rowid = mp.fk_mo";
 		$sql .= " AND m.entity IN (".getEntity($forVirtualStock && getDolGlobalString('STOCK_CALCULATE_VIRTUAL_STOCK_TRANSVERSE_MODE') ? 'stock' : 'mrp').")";
 		$sql .= " AND mp.fk_product = ".((int) $this->id);
-		$sql .= " AND mp.disable_stock_change IN (0)";
+		$sql .= " AND (mp.disable_stock_change IN (0) OR mp.disable_stock_change IS NULL)";
 		if (!$user->hasRight('societe', 'client', 'voir') && !$socid && !$forVirtualStock) {
 			$sql .= " AND m.fk_soc = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 		}


### PR DESCRIPTION
The quantities pending production were not added to the virtual stock. The SQL indicated that the 'disable_stock_change' column must be 0, but in the case of the products to be produced this value is NULL, so they were not added.