### PR TITLE
test status contact

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -213,7 +213,7 @@ class Notify
 
 		if (!$error) {
 			if ($socid >= 0 && in_array('thirdparty', $scope)) {
-				$sql = "SELECT a.code, c.email, c.rowid , c.statut";
+				$sql = "SELECT a.code, c.email, c.rowid, c.statut as status";
 				$sql .= " FROM ".$this->db->prefix()."notify_def as n,";
 				$sql .= " ".$this->db->prefix()."socpeople as c,";
 
@@ -237,7 +237,7 @@ class Notify
 					while ($i < $num) {
 						$obj = $this->db->fetch_object($resql);
 						// we want to notify only if contact is enable
-						if ($obj && $obj->statut ==  1) {
+						if ($obj && $obj->status ==  1) {
 							$newval2 = trim($obj->email);
 							$isvalid = isValidEmail($newval2);
 							if (empty($resarray[$newval2])) {

--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -213,9 +213,10 @@ class Notify
 
 		if (!$error) {
 			if ($socid >= 0 && in_array('thirdparty', $scope)) {
-				$sql = "SELECT a.code, c.email, c.rowid";
+				$sql = "SELECT a.code, c.email, c.rowid , c.statut";
 				$sql .= " FROM ".$this->db->prefix()."notify_def as n,";
 				$sql .= " ".$this->db->prefix()."socpeople as c,";
+
 				$sql .= " ".$this->db->prefix()."c_action_trigger as a,";
 				$sql .= " ".$this->db->prefix()."societe as s";
 				$sql .= " WHERE n.fk_contact = c.rowid";
@@ -235,7 +236,8 @@ class Notify
 					$i = 0;
 					while ($i < $num) {
 						$obj = $this->db->fetch_object($resql);
-						if ($obj) {
+						// we want to notify only if contact is enable
+						if ($obj && $obj->statut ==  1) {
 							$newval2 = trim($obj->email);
 							$isvalid = isValidEmail($newval2);
 							if (empty($resarray[$newval2])) {


### PR DESCRIPTION
# FIX|Fix 

Problem
The notification module allows associating a third party's contact with an event of different types, provided that the contact is active. However, if this contact is deactivated later, the notification remains active, which can lead to inconsistencies.

Modification Made
I have modified the notification module to check the status of the contact before each notification is sent. If the contact is deactivated, the notification is then deactivated, thus avoiding sending notifications to inactive contacts.

Alternative Solution
Another option would be to delete the entry from the ll_notif_def table at the time the contact is deactivated. However, this seems a bit overkill as a solution.

