### PR TITLE
NEW Better object examples for webhook test

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -12744,6 +12744,13 @@ function getElementProperties($elementType)
 		$classname = 'Ccountry';
 		$table_element = 'c_country';
 		$subelement = '';
+	} elseif ($elementType == 'knowledgerecord') {
+		$module = '';
+		$classpath = 'knowledgemanagement/class';
+		$classfile = 'knowledgerecord';
+		$classname = 'KnowledgeRecord';
+		$table_element = 'knowledgemanagement_knowledgerecord';
+		$subelement = '';
 	}
 
 	if (empty($classfile)) {

--- a/htdocs/webhook/target_card.php
+++ b/htdocs/webhook/target_card.php
@@ -602,7 +602,7 @@ if ($action == "test") {
 			$.ajax({
 				method: \'GET\',
 				url:  \''.DOL_URL_ROOT.'/webhook/ajax/webhook.php\',
-				data: { action: "getjsonformtrigger", triggercode: triggercode },
+				data: { action: "getjsonformtrigger", triggercode: triggercode , token:"'.currentToken().'"},
 				success: function(response) {
 					obj = JSON.stringify(response);
 					$("#jsondata").val(obj);


### PR DESCRIPTION
- Add knowledgerecord to element type list in getElementProperties
- Implement function findobjecttosend in ajax/webhook.php so it Find and init a specimen for the given object type
