### PR TITLE
qual: phpdoc for ProductCombination.class.php

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -204,7 +204,8 @@ class ProductCombination
 			if ($fk_price_level > 0) {
 				$combination_price_levels[$fk_price_level] = ProductCombinationLevel::createFromParent($this->db, $this, $fk_price_level);
 			} else {
-				for ($i = 1; $i <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $i++) {
+				$produit_multiprices_limit = getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT');
+				for ($i = 1; $i <= $produit_multiprices_limit; $i++) {
 					$combination_price_levels[$i] = ProductCombinationLevel::createFromParent($this->db, $this, $i);
 				}
 			}
@@ -553,7 +554,8 @@ class ProductCombination
 
 			// MultiPrix
 			if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
-				for ($i = 1; $i <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $i++) {
+				$produit_multiprices_limit = getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT');
+				for ($i = 1; $i <= $produit_multiprices_limit; $i++) {
 					if ($parent->multiprices[$i] != '' || isset($this->combination_price_levels[$i]->variation_price)) {
 						$new_type = empty($parent->multiprices_base_type[$i]) ? 'HT' : $parent->multiprices_base_type[$i];
 						$new_min_price = $parent->multiprices_min[$i];
@@ -847,7 +849,8 @@ class ProductCombination
 
 				// Manage Price levels
 				if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
-					for ($i = 2; $i <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $i++) {
+					$produit_multiprices_limit = getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT');
+					for ($i = 2; $i <= $produit_multiprices_limit; $i++) {
 						$price_impact[$i] += (float) price2num($variations[$currcombattr][$currcombval]['price']);
 					}
 				}
@@ -875,7 +878,8 @@ class ProductCombination
 
 		// Init price level
 		if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
-			for ($i = 1; $i <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $i++) {
+			$produit_multiprices_limit = getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT');
+			for ($i = 1; $i <= $produit_multiprices_limit; $i++) {
 				$productCombinationLevel = new ProductCombinationLevel($this->db);
 				$productCombinationLevel->fk_product_attribute_combination = $newcomb->id;
 				$productCombinationLevel->fk_price_level = $i;

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -204,7 +204,7 @@ class ProductCombination
 			if ($fk_price_level > 0) {
 				$combination_price_levels[$fk_price_level] = ProductCombinationLevel::createFromParent($this->db, $this, $fk_price_level);
 			} else {
-				for ($i = 1; $i <= $conf->global->PRODUIT_MULTIPRICES_LIMIT; $i++) {
+				for ($i = 1; $i <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $i++) {
 					$combination_price_levels[$i] = ProductCombinationLevel::createFromParent($this->db, $this, $i);
 				}
 			}
@@ -553,7 +553,7 @@ class ProductCombination
 
 			// MultiPrix
 			if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
-				for ($i = 1; $i <= $conf->global->PRODUIT_MULTIPRICES_LIMIT; $i++) {
+				for ($i = 1; $i <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $i++) {
 					if ($parent->multiprices[$i] != '' || isset($this->combination_price_levels[$i]->variation_price)) {
 						$new_type = empty($parent->multiprices_base_type[$i]) ? 'HT' : $parent->multiprices_base_type[$i];
 						$new_min_price = $parent->multiprices_min[$i];
@@ -744,16 +744,16 @@ class ProductCombination
 	 * [...]
 	 * )
 	 *
-	 * @param User 				$user 			Object user
-	 * @param Product 			$product 		Parent product
-	 * @param array<int,int> 	$combinations 	Attribute and value combinations.
+	 * @param User                      $user                   User
+	 * @param Product                   $product                Parent Product
+	 * @param array<int,int>            $combinations           Attribute and value combinations.
 	 * @param array<int,array<int,array{weight:string|float,price:string|float}>> $variations 	Price and weight variations (example: $variations[fk_product_attribute][fk_product_attribute_value]['weight'])
-	 * @param bool|array 		$price_var_percent 	Is the price variation a relative variation?
-	 * @param bool|float 		$forced_pricevar 	If the price variation is forced
-	 * @param bool|float 		$forced_weightvar 	If the weight variation is forced
-	 * @param bool|string 		$forced_refvar 		If the reference is forced
-	 * @param string 	    	$ref_ext            External reference
-	 * @return int<-1,1>							Return integer <0 KO, >0 OK
+	 * @param bool                      $price_var_percent      Is the price variation value a relative variation (in %)?
+	 * @param false|float|float[]       $forced_pricevar        Value of the price variation if it is forced ; in currency or percent ; and an array if "PRODUIT_MULTIPRICES" is on.
+	 * @param false|float               $forced_weightvar       Value of the weight variation if it is forced
+	 * @param false|string              $forced_refvar          Value of the reference if it is forced
+	 * @param string                    $ref_ext                External reference
+	 * @return int<-1,1>                                        Return integer <0 KO, >0 OK
 	 */
 	public function createProductCombination(User $user, Product $product, array $combinations, array $variations, $price_var_percent = false, $forced_pricevar = false, $forced_weightvar = false, $forced_refvar = false, $ref_ext = '')
 	{
@@ -846,8 +846,8 @@ class ProductCombination
 				$price_impact[1] += (float) price2num($variations[$currcombattr][$currcombval]['price']);
 
 				// Manage Price levels
-				if ($conf->global->PRODUIT_MULTIPRICES) {
-					for ($i = 2; $i <= $conf->global->PRODUIT_MULTIPRICES_LIMIT; $i++) {
+				if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
+					for ($i = 2; $i <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $i++) {
 						$price_impact[$i] += (float) price2num($variations[$currcombattr][$currcombval]['price']);
 					}
 				}
@@ -874,8 +874,8 @@ class ProductCombination
 		$newcomb->variation_ref_ext = $this->db->escape($ref_ext);
 
 		// Init price level
-		if ($conf->global->PRODUIT_MULTIPRICES) {
-			for ($i = 1; $i <= $conf->global->PRODUIT_MULTIPRICES_LIMIT; $i++) {
+		if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
+			for ($i = 1; $i <= getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT'); $i++) {
 				$productCombinationLevel = new ProductCombinationLevel($this->db);
 				$productCombinationLevel->fk_product_attribute_combination = $newcomb->id;
 				$productCombinationLevel->fk_price_level = $i;
@@ -1300,7 +1300,7 @@ class ProductCombinationLevel
 
 		$sql = "DELETE FROM ".MAIN_DB_PREFIX.$this->table_element;
 		$sql .= " WHERE fk_product_attribute_combination = ".(int) $fk_product_attribute_combination;
-		$sql .= " AND fk_price_level > ".intval($conf->global->PRODUIT_MULTIPRICES_LIMIT);
+		$sql .= " AND fk_price_level > ".(int) getDolGlobalString('PRODUIT_MULTIPRICES_LIMIT');
 		$res = $this->db->query($sql);
 
 		return $res ? 1 : -1;

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -748,8 +748,8 @@ class ProductCombination
 	 * @param Product                   $product                Parent Product
 	 * @param array<int,int>            $combinations           Attribute and value combinations.
 	 * @param array<int,array<int,array{weight:string|float,price:string|float}>> $variations 	Price and weight variations (example: $variations[fk_product_attribute][fk_product_attribute_value]['weight'])
-	 * @param bool                      $price_var_percent      Is the price variation value a relative variation (in %)?
-	 * @param false|float|float[]       $forced_pricevar        Value of the price variation if it is forced ; in currency or percent ; and an array if "PRODUIT_MULTIPRICES" is on.
+	 * @param bool|bool[]               $price_var_percent      Is the price variation value a relative variation (in %)? (it is an array if global constant "PRODUIT_MULTIPRICES" is on)
+	 * @param false|float|float[]       $forced_pricevar        Value of the price variation if it is forced ; in currency or percent. (it is an array if global constant "PRODUIT_MULTIPRICES" is on)
 	 * @param false|float               $forced_weightvar       Value of the weight variation if it is forced
 	 * @param false|string              $forced_refvar          Value of the reference if it is forced
 	 * @param string                    $ref_ext                External reference

--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -40,8 +40,12 @@ $weight_impact = GETPOSTFLOAT('weight_impact', 2);
 $price_impact_percent = (bool) GETPOST('price_impact_percent');
 $price_impact = $price_impact_percent ? GETPOSTFLOAT('price_impact', 2) : GETPOSTFLOAT('price_impact', 'MU');
 
+// for PRODUIT_MULTIPRICES
 $level_price_impact = GETPOST('level_price_impact', 'array');
+$level_price_impact = array_map('price2num', $level_price_impact);
+$level_price_impact = array_map('floatval', $level_price_impact);
 $level_price_impact_percent = GETPOST('level_price_impact_percent', 'array');
+$level_price_impact_percent = array_map('boolval', $level_price_impact_percent);
 
 $form = new Form($db);
 
@@ -154,10 +158,7 @@ if (($action == 'add' || $action == 'create') && empty($massaction) && !GETPOST(
 		$weight_impact = price2num($weight_impact);
 		$price_impact = price2num($price_impact);
 
-		// for conf PRODUIT_MULTIPRICES
-		if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
-			$level_price_impact = array_map('price2num', $level_price_impact);
-		} else {
+		if (!getDolGlobalString('PRODUIT_MULTIPRICES')) {
 			$level_price_impact = array(1 => $price_impact);
 			$level_price_impact_percent = array(1 => $price_impact_percent);
 		}
@@ -280,15 +281,13 @@ if (($action == 'add' || $action == 'create') && empty($massaction) && !GETPOST(
 
 	// for conf PRODUIT_MULTIPRICES
 	if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
-		$level_price_impact = array_map('price2num', $level_price_impact);
-
-		$prodcomb->variation_price = (float) $level_price_impact[1];
-		$prodcomb->variation_price_percentage = (bool) $level_price_impact_percent[1];
+		$prodcomb->variation_price = $level_price_impact[1];
+		$prodcomb->variation_price_percentage = $level_price_impact_percent[1];
 	} else {
 		$level_price_impact = array(1 => $price_impact);
 		$level_price_impact_percent = array(1 => $price_impact_percent);
 
-		$prodcomb->variation_price = (float) $price_impact;
+		$prodcomb->variation_price = $price_impact;
 		$prodcomb->variation_price_percentage = $price_impact_percent;
 	}
 


### PR DESCRIPTION
use getDolGlobalString() 

and fix phan warning:

htdocs/variants/combinations.php	189	TypeError PhanTypeMismatchArgumentProbablyReal Argument 6 ($forced_pricevar) is $level_price_impact of type array{1:string}|string[] (real type ?array|?array{1:string}) but \ProductCombination::createProductCombination() takes bool|false|float (no real type) defined at htdocs/variants/class/ProductCombination.class.php:758 (the inferred real argument type has nothing in common with the parameter's phpdoc type)