### PR TITLE
NEW: redirect to expedition card if global search has unique result

### DIFF
--- a/htdocs/expedition/list.php
+++ b/htdocs/expedition/list.php
@@ -517,8 +517,8 @@ if (empty($reshook)) {
 			if ($limit > 0 && $limit != $conf->liste_limit) {
 				$param .= '&limit='.urlencode(strval($limit));
 			}
-			if ($sall) {
-				$param .= "&sall=".urlencode($sall);
+			if ($search_all) {
+				$param .= "&search_all=".urlencode($search_all);
 			}
 			if ($search_ref_exp) {
 				$param .= "&search_ref_exp=".urlencode($search_ref_exp);
@@ -642,7 +642,6 @@ $formcompany = new FormCompany($db);
 $shipment = new Expedition($db);
 
 $helpurl = 'EN:Module_Shipments|FR:Module_Exp&eacute;ditions|ES:M&oacute;dulo_Expediciones';
-llxHeader('', $langs->trans('ListOfSendings'), $helpurl);
 
 $sql = 'SELECT';
 if ($search_all || $search_user > 0) {
@@ -886,6 +885,16 @@ if (!$resql) {
 $num = $db->num_rows($resql);
 
 $arrayofselected = is_array($toselect) ? $toselect : array();
+
+// Redirect to expedition card if there is only one result for global search
+if ($num == 1 && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all) {
+	$obj = $db->fetch_object($resql);
+	$id = $obj->rowid;
+	header("Location: ".DOL_URL_ROOT.'/expedition/card.php?id='.$id);
+	exit;
+}
+
+llxHeader('', $langs->trans('ListOfSendings'), $helpurl);
 
 $expedition = new Expedition($db);
 


### PR DESCRIPTION
# NEW: redirect to expedition card if global search has unique result
Many global searches are redirected to object card instead of list when there is only one answer. This extends that behavior to Expedition

Before :

![image](https://github.com/Dolibarr/dolibarr/assets/81741011/77ec4c7f-a1ff-4d59-92c9-339956c565c9)

After : 

![image](https://github.com/Dolibarr/dolibarr/assets/81741011/dd34a13b-f02d-4335-8b74-95de225b71e9)
