### PR TITLE
FIX | Wrong syntax for LinkedIn social network link

### DIFF
--- a/htdocs/install/mysql/data/llx_c_socialnetworks.sql
+++ b/htdocs/install/mysql/data/llx_c_socialnetworks.sql
@@ -39,7 +39,7 @@ INSERT INTO llx_c_socialnetworks (entity, code, label, url, icon, active) VALUES
 INSERT INTO llx_c_socialnetworks (entity, code, label, url, icon, active) VALUES ( 1, 'github', 'GitHub', 'https://www.github.com/{socialid}', '', 0);
 INSERT INTO llx_c_socialnetworks (entity, code, label, url, icon, active) VALUES ( 1, 'googleplus', 'GooglePlus', 'https://www.googleplus.com/{socialid}', 'fa-google-plus', 0);
 INSERT INTO llx_c_socialnetworks (entity, code, label, url, icon, active) VALUES ( 1, 'instagram', 'Instagram', 'https://www.instagram.com/{socialid}', 'fa-instagram', 1);
-INSERT INTO llx_c_socialnetworks (entity, code, label, url, icon, active) VALUES ( 1, 'linkedin', 'LinkedIn', 'https://www.linkedin.com/{socialid}', 'fa-linkedin', 1);
+INSERT INTO llx_c_socialnetworks (entity, code, label, url, icon, active) VALUES ( 1, 'linkedin', 'LinkedIn', 'https://www.linkedin.com/in/{socialid}', 'fa-linkedin', 1);
 INSERT INTO llx_c_socialnetworks (entity, code, label, url, icon, active) VALUES ( 1, 'mastodon', 'Mastodon', '{socialid}', '', 0);
 INSERT INTO llx_c_socialnetworks (entity, code, label, url, icon, active) VALUES ( 1, 'meetup', 'Meetup', '{socialid}', 'fa-meetup', 0);
 INSERT INTO llx_c_socialnetworks (entity, code, label, url, icon, active) VALUES ( 1, 'periscope', 'Periscope', '{socialid}', '', 0);


### PR DESCRIPTION
Wrong link for LinkedIn social network
The defaut value for LinkedIn is https://www.linkedin.com/{socialid}
but following this syntax you will have an 404 error
eg 
https://www.linkedin.com/{socialid}
https://www.linkedin.com/laurent-destailleur

![Capture](https://github.com/Dolibarr/dolibarr/assets/24292300/08409f6f-803b-4ee4-94c9-7f2ad83d3930)

The right syntax is 
https://www.linkedin.com/in/{socialid}
https://www.linkedin.com/in/laurent-destailleur
![Capture2](https://github.com/Dolibarr/dolibarr/assets/24292300/aceed90b-99d2-4fe7-9d82-7ca042aed9f6)
