### PR TITLE
fix : 19.0 fix inconsistent link validation

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8497,7 +8497,7 @@ abstract class CommonObject
 			if (!$validate->isFetchable($fieldValue, $classname, $classpath)) {
 				$lastIsFetchableError = $validate->error;
 
-				// from V19 of Dolibarr, In some cases link use element instead of class example project_task
+				// from V19 of Dolibarr, In some cases link use element instead of class, example project_task
 				if ($validate->isFetchableElement($fieldValue, $classname)) {
 					return true;
 				}

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8495,7 +8495,14 @@ abstract class CommonObject
 			$classname = $InfoFieldList[0];
 			$classpath = $InfoFieldList[1];
 			if (!$validate->isFetchable($fieldValue, $classname, $classpath)) {
-				$this->setFieldError($fieldKey, $validate->error);
+				$lastIsFetchableError = $validate->error;
+
+				// from V19 of Dolibarr, In some cases link use element instead of class exemple project_task
+				if ($validate->isFetchableElement($fieldValue, $classname)) {
+					return true;
+				}
+
+				$this->setFieldError($fieldKey, $lastIsFetchableError);
 				return false;
 			} else {
 				return true;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8497,7 +8497,7 @@ abstract class CommonObject
 			if (!$validate->isFetchable($fieldValue, $classname, $classpath)) {
 				$lastIsFetchableError = $validate->error;
 
-				// from V19 of Dolibarr, In some cases link use element instead of class exemple project_task
+				// from V19 of Dolibarr, In some cases link use element instead of class example project_task
 				if ($validate->isFetchableElement($fieldValue, $classname)) {
 					return true;
 				}

--- a/htdocs/core/class/validate.class.php
+++ b/htdocs/core/class/validate.class.php
@@ -335,4 +335,19 @@ class Validate
 		}
 		return false;
 	}
+
+	/**
+	 * Check for all values in db for an element
+	 * @see self::isFetchable()
+	 *
+	 * @param integer  $id of element
+	 * @param string $element_type the element type
+	 * @return boolean Validity is ok or not
+	 * @throws Exception
+	 */
+	public function isFetchableElement($id, $element_type)
+	{
+		$elementProperty = getElementProperties($element_type);
+		return $this->isFetchable($id, $elementProperty['classname'], $elementProperty['classpath'].'/'.$elementProperty['classfile'].'.class.php');
+	}
 }

--- a/htdocs/core/class/validate.class.php
+++ b/htdocs/core/class/validate.class.php
@@ -347,6 +347,7 @@ class Validate
 	 */
 	public function isFetchableElement($id, $element_type)
 	{
+		// TODO use newObjectByElement() introduce in V20 by PR #30036 for better errors management
 		$elementProperty = getElementProperties($element_type);
 		return $this->isFetchable($id, $elementProperty['classname'], $elementProperty['classpath'].'/'.$elementProperty['classfile'].'.class.php');
 	}


### PR DESCRIPTION
# Instructions

Using fields like integer:project_task:projet/class/task.class.php:1 is not valide for validation fields

in V19 the definition of field using link has changed


integer:ClassName:ClassFilePath => (Class name oriented)
could by 
integer:ElementType:ClassFilePath => (Element type oriented)

exemple 

integer:Task:projet/class/task.class.php:1
become 
integer:project_task:projet/class/task.class.php:1


so this change create a lot of errors, and I found a new one with validation of fields

# Fix validation check for "Element type oriented"

kind of same problems linked's to #30036
