### PR TITLE
FIX add token in link validate and clone  button uri generate an error wi…

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2560,7 +2560,7 @@ if ($action == 'create') {
 
 						print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=valid&token='.newToken().'">';
 						print $tmpbuttonlabel;
-						print '</a>';.
+						print '</a>';
 					}
 				}
 				// Create event

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2558,9 +2558,9 @@ if ($action == 'create') {
 							$tmpbuttonlabel = $langs->trans("ValidateAndApprove");
 						}
 
-						print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=valid">';
+						print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=valid&token='.newToken().'">';
 						print $tmpbuttonlabel;
-						print '</a>';
+						print '</a>';.
 					}
 				}
 				// Create event
@@ -2717,7 +2717,7 @@ if ($action == 'create') {
 
 				// Clone
 				if ($usercancreate) {
-					print '<a class="butAction" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&amp;socid='.$object->socid.'&amp;action=clone&amp;object=order">'.$langs->trans("ToClone").'</a>';
+					print '<a class="butAction" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&amp;socid='.$object->socid.'&amp;action=clone&amp;object=order&token='.newToken().'">'.$langs->trans("ToClone").'</a>';
 				}
 
 				// Cancel


### PR DESCRIPTION
# FIX|Fix

Description:
This pull request addresses an issue where generating the URI for the validate and clone buttons produces an error when the MAIN_SECURITY_CSRF_WITH_TOKEN constant is set to 3. To resolve this, a token is added to the link for these buttons.

Changes Made:
Added token to the URI for the validate button.
Added token to the URI for the clone button.
Ensured compatibility with MAIN_SECURITY_CSRF_WITH_TOKEN set to 3.

Reason for Changes:
When MAIN_SECURITY_CSRF_WITH_TOKEN is set to 3, it enhances security by requiring a CSRF token in the links. Without including this token, the generation of the validate and clone button URIs results in errors. This update ensures that the URIs include the necessary tokens, thereby preventing these errors and maintaining the intended security level.

Testing:
Verified that the validate button works correctly with the token included in the URI.
Verified that the clone button works correctly with the token included in the URI.
Tested with MAIN_SECURITY_CSRF_WITH_TOKEN set to various levels to ensure compatibility.
