### PR TITLE
fix warning with pgsql DoliDB.class.php

### DIFF
--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -181,8 +181,10 @@ abstract class DoliDB implements Database
 				$this->transaction_opened++;
 				dol_syslog("BEGIN Transaction".($textinlog ? ' '.$textinlog : ''), LOG_DEBUG);
 				dol_syslog('', 0, 1);
+				return 1;
+			} else {
+				return 0;
 			}
-			return $ret;
 		} else {
 			$this->transaction_opened++;
 			dol_syslog('', 0, 1);


### PR DESCRIPTION
use same code than in ->commit()

![image](https://github.com/Dolibarr/dolibarr/assets/3624836/6733564a-8df3-47f1-a2d6-07d8314b8928)

the problem is the int cast in v20
![image](https://github.com/Dolibarr/dolibarr/assets/3624836/38a8002c-1b75-4090-b36b-d8abae9e4693)

