### PR TITLE
FIX: pos: invoice date incorrectly set beacause of timezome mismatches

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -473,7 +473,7 @@ if (empty($reshook)) {
 	// If we add a line and no invoice yet, we create the invoice
 	if (($action == "addline" || $action == "freezone") && $placeid == 0) {
 		$invoice->socid = getDolGlobalString($constforcompanyid);
-		$invoice->date = dol_now('tzuserrel');		// We use the local date, only the day will be saved.
+		$invoice->date = dol_now();		// Invoice::create() needs a GMT timestamp
 		$invoice->module_source = 'takepos';
 		$invoice->pos_source =  isset($_SESSION["takeposterminal"]) ? $_SESSION["takeposterminal"] : '' ;
 		$invoice->entity = !empty($_SESSION["takeposinvoiceentity"]) ? $_SESSION["takeposinvoiceentity"] : $conf->entity;


### PR DESCRIPTION
This reverts commit 36e91da that does not seem to work.

Tickets created from 10 PM French time (during DST) have their date set to the next day.

The server date and timezones are correctly set.