### PR TITLE
Fix: BOM columns if "Stock management supports Services" is active

### DIFF
--- a/htdocs/bom/tpl/objectline_create.tpl.php
+++ b/htdocs/bom/tpl/objectline_create.tpl.php
@@ -47,11 +47,6 @@ if (empty($forceall)) {
 if (empty($filtertype)) {
 	$filtertype = 0;
 }
-// TODO: This can't work $object->element is always 'bom' and getDolGlobalString('STOCK_SUPPORT_SERVICES') are incorrect, 'STOCK_SUPPORTS_SERVICES' is right.
-// $filtertype with value -1 is not supported in the further course.
-if (!empty($object->element) && $object->element == 'contrat' && !getDolGlobalString('STOCK_SUPPORT_SERVICES')) {
-	$filtertype = -1;
-}
 
 $formproduct = new FormProduct($object->db);
 
@@ -76,23 +71,33 @@ if ($nolinesbefore) {
 	print '</td>';
 	print '<td class="linecolqty right">'.$langs->trans('Qty').'</td>';
 
-	if ($filtertype != 1) {
+	if ($filtertype != 1) { // Product
 		if (getDolGlobalInt('PRODUCT_USE_UNITS')) {
 			print '<td class="linecoluseunit left">';
 			print '<span id="title_units">';
 			print $langs->trans('Unit');
 			print '</span></td>';
 		}
-		print '<td class="linecolqtyfrozen right">' . $form->textwithpicto($langs->trans('QtyFrozen'), $langs->trans("QuantityConsumedInvariable")) . '</td>';
-		print '<td class="linecoldisablestockchange right">' . $form->textwithpicto($langs->trans('DisableStockChange'), $langs->trans('DisableStockChangeHelp')) . '</td>';
-		print '<td class="linecollost right">' . $form->textwithpicto($langs->trans('ManufacturingEfficiency'), $langs->trans('ValueOfMeansLoss')) . '</td>';
-	} else {
+	} else { // Service
 		print '<td class="linecolunit right">' . $form->textwithpicto($langs->trans('Unit'), '').'</td>';
-		if (isModEnabled('workstation')) {
-			print '<td class="linecolworkstation right">' .  $form->textwithpicto($langs->trans('Workstation'), '') . '</td>';
-		}
-		print '<td class="linecoltotalcost right">' .  $form->textwithpicto($langs->trans('TotalCost'), '') . '</td>';
 	}
+	if ($filtertype != 1 || getDolGlobalString('STOCK_SUPPORTS_SERVICES')) { // Product or stock support for Services is active
+		// Qty frozen
+		print '<td class="linecolqtyfrozen right">' . $form->textwithpicto($langs->trans('QtyFrozen'), $langs->trans("QuantityConsumedInvariable")) . '</td>';
+
+		// Disable stock change
+		print '<td class="linecoldisablestockchange right">' . $form->textwithpicto($langs->trans('DisableStockChange'), $langs->trans('DisableStockChangeHelp')) . '</td>';
+
+		// Efficiency
+		print '<td class="linecollost right">' . $form->textwithpicto($langs->trans('ManufacturingEfficiency'), $langs->trans('ValueOfMeansLoss')) . '</td>';
+	}
+
+	// Service and workstations are active
+	if ($filtertype == 1 && isModEnabled('workstation')) {
+		print '<td class="linecolworkstation right">' .  $form->textwithpicto($langs->trans('Workstation'), '') . '</td>';
+	}
+	// Cost
+	print '<td class="linecoltotalcost right">' .  $form->textwithpicto($langs->trans('TotalCost'), '') . '</td>';
 
 	print '<td class="linecoledit" colspan="' . $colspan . '">&nbsp;</td>';
 	print '</tr>';
@@ -154,7 +159,9 @@ print '</td>';
 if ($filtertype != 1) { // Product
 	if (getDolGlobalInt('PRODUCT_USE_UNITS')) {
 		$coldisplay++;
-		print '<td class="nobottom linecoluseunit left">';
+		print '<td class="bordertop nobottom nowrap linecoluseunit left">';
+		// TODO: integrate selection for Units by creating (similar as by Service)
+		// print  $formproduct->selectMeasuringUnits("fk_unit", "", $fk_unit_default, 0, 0);
 		print '</td>';
 	}
 } else { // Service

--- a/htdocs/bom/tpl/objectline_create.tpl.php
+++ b/htdocs/bom/tpl/objectline_create.tpl.php
@@ -47,6 +47,8 @@ if (empty($forceall)) {
 if (empty($filtertype)) {
 	$filtertype = 0;
 }
+// TODO: This can't work $object->element is always 'bom' and getDolGlobalString('STOCK_SUPPORT_SERVICES') are incorrect, 'STOCK_SUPPORTS_SERVICES' is right.
+// $filtertype with value -1 is not supported in the further course.
 if (!empty($object->element) && $object->element == 'contrat' && !getDolGlobalString('STOCK_SUPPORT_SERVICES')) {
 	$filtertype = -1;
 }
@@ -149,32 +151,13 @@ $coldisplay++;
 print '<td class="bordertop nobottom linecolqty right"><input type="text" size="2" name="qty" id="qty" class="flat right" value="'.(GETPOSTISSET("qty") ? GETPOST("qty", 'alpha', 2) : 1).'">';
 print '</td>';
 
-if ($filtertype != 1) {
+if ($filtertype != 1) { // Product
 	if (getDolGlobalInt('PRODUCT_USE_UNITS')) {
 		$coldisplay++;
 		print '<td class="nobottom linecoluseunit left">';
 		print '</td>';
 	}
-
-	$coldisplay++;
-	print '<td class="bordertop nobottom linecolqtyfrozen right"><input type="checkbox" name="qty_frozen" id="qty_frozen" class="flat right" value="1"' . (GETPOST("qty_frozen", 'alpha') ? ' checked="checked"' : '') . '>';
-	print '</td>';
-
-
-	$coldisplay++;
-	print '<td class="bordertop nobottom linecoldisablestockchange right"><input type="checkbox" name="disable_stock_change" id="disable_stock_change" class="flat right" value="1"' . (GETPOST("disable_stock_change", 'alpha') ? ' checked="checked"' : '') . '">';
-	print '</td>';
-
-	$coldisplay++;
-	print '<td class="bordertop nobottom nowrap linecollost right">';
-	print '<input type="text" size="2" name="efficiency" id="efficiency" class="flat right" value="' . ((GETPOSTISSET("efficiency") && $action == 'addline') ? GETPOST("efficiency", 'alpha') : 1) . '">';
-	print '</td>';
-
-	$coldisplay++;
-	print '<td class="bordertop nobottom nowrap linecolcost right">';
-	print '&nbsp;';
-	print '</td>';
-} else {
+} else { // Service
 	$coldisplay++;
 	require_once DOL_DOCUMENT_ROOT.'/core/class/cunits.class.php';
 	$cUnit = new CUnits($this->db);
@@ -182,23 +165,44 @@ if ($filtertype != 1) {
 	print '<td class="bordertop nobottom nowrap linecolunit right">';
 	print  $formproduct->selectMeasuringUnits("fk_unit", "time", $fk_unit_default, 0, 0);
 	print '</td>';
+}
+if ($filtertype != 1 || getDolGlobalString('STOCK_SUPPORTS_SERVICES')) { // Product or stock support for Services is active
+	// Qty frozen
+	$coldisplay++;
+	print '<td class="bordertop nobottom linecolqtyfrozen right"><input type="checkbox" name="qty_frozen" id="qty_frozen" class="flat right" value="1"' . (GETPOST("qty_frozen", 'alpha') ? ' checked="checked"' : '') . '>';
+	print '</td>';
 
+	// Disable stock change
+	$coldisplay++;
+	print '<td class="bordertop nobottom linecoldisablestockchange right"><input type="checkbox" name="disable_stock_change" id="disable_stock_change" class="flat right" value="1"' . (GETPOST("disable_stock_change", 'alpha') ? ' checked="checked"' : '') . '">';
+	print '</td>';
+
+	// Efficiency
+	$coldisplay++;
+	print '<td class="bordertop nobottom nowrap linecollost right">';
+	print '<input type="text" size="2" name="efficiency" id="efficiency" class="flat right" value="' . ((GETPOSTISSET("efficiency") && $action == 'addline') ? GETPOST("efficiency", 'alpha') : 1) . '">';
+	print '</td>';
+}
+
+// Service and workstations are active
+if ($filtertype == 1 && isModEnabled('workstation')) {
 	$coldisplay++;
 	print '<td class="bordertop nobottom nowrap linecolworkstation right">';
 	print $formproduct->selectWorkstations('', 'idworkstations', 1);
 	print '</td>';
-
-	$coldisplay++;
-	print '<td class="bordertop nobottom nowrap linecolcost right">';
-	print '&nbsp;';
-	print '</td>';
 }
 
-	$coldisplay += $colspan;
-	print '<td class="bordertop nobottom linecoledit center valignmiddle" colspan="' . $colspan . '">';
-	print '<input type="submit" class="button button-add" name="addline" id="addline" value="' . $langs->trans('Add') . '">';
-	print '</td>';
-	print '</tr>';
+// Cost
+$coldisplay++;
+print '<td class="bordertop nobottom nowrap linecolcost right">';
+print '&nbsp;';
+print '</td>';
+
+$coldisplay += $colspan;
+print '<td class="bordertop nobottom linecoledit center valignmiddle" colspan="' . $colspan . '">';
+print '<input type="submit" class="button button-add" name="addline" id="addline" value="' . $langs->trans('Add') . '">';
+print '</td>';
+print '</tr>';
 
 ?>
 

--- a/htdocs/bom/tpl/objectline_edit.tpl.php
+++ b/htdocs/bom/tpl/objectline_edit.tpl.php
@@ -127,44 +127,48 @@ if (($line->info_bits & 2) != 2) {
 }
 print '</td>';
 
-if ($filtertype != 1) {
+if ($filtertype != 1) { // Product
 	if (getDolGlobalInt('PRODUCT_USE_UNITS')) {
 		$coldisplay++;
 		print '<td class="nobottom nowrap linecolunit right">';
 		print  $formproduct->selectMeasuringUnits("fk_unit", '', (($line->fk_unit) ? $line->fk_unit : ''), 0, 0);
 		print '</td>';
 	}
-
-	$coldisplay++;
-	print '<td class="nobottom linecolqtyfrozen right"><input type="checkbox" name="qty_frozen" id="qty_frozen" class="flat right" value="1"' . (GETPOSTISSET("qty_frozen") ? (GETPOST('qty_frozen', 'int') ? ' checked="checked"' : '') : ($line->qty_frozen ? ' checked="checked"' : '')) . '>';
-	print '</td>';
-
-	$coldisplay++;
-	print '<td class="nobottom linecoldisablestockchange right"><input type="checkbox" name="disable_stock_change" id="disable_stock_change" class="flat right" value="1"' . (GETPOSTISSET('disablestockchange') ? (GETPOST("disable_stock_change", 'int') ? ' checked="checked"' : '') : ($line->disable_stock_change ? ' checked="checked"' : '')) . '">';
-	print '</td>';
-
-	$coldisplay++;
-	print '<td class="nobottom nowrap linecollost right">';
-	print '<input type="text" size="2" name="efficiency" id="efficiency" class="flat right" value="' . $line->efficiency . '"></td>';
-
-	$coldisplay++;
-	print '<td class="nobottom nowrap linecolcostprice right">';
-	print '</td>';
-} else {
+} else { // Service
 	$coldisplay++;
 	print '<td class="nobottom nowrap linecolunit right">';
 	print  $formproduct->selectMeasuringUnits("fk_unit", "time", ($line->fk_unit) ? $line->fk_unit : '', 0, 0);
 	print '</td>';
+}
+if ($filtertype != 1 || getDolGlobalString('STOCK_SUPPORTS_SERVICES')) { // Product or stock support for Services is active
+	// Qty frozen
+	$coldisplay++;
+	print '<td class="nobottom linecolqtyfrozen right"><input type="checkbox" name="qty_frozen" id="qty_frozen" class="flat right" value="1"' . (GETPOSTISSET("qty_frozen") ? (GETPOST('qty_frozen', 'int') ? ' checked="checked"' : '') : ($line->qty_frozen ? ' checked="checked"' : '')) . '>';
+	print '</td>';
 
+	// Disable stock change
+	$coldisplay++;
+	print '<td class="nobottom linecoldisablestockchange right"><input type="checkbox" name="disable_stock_change" id="disable_stock_change" class="flat right" value="1"' . (GETPOSTISSET('disablestockchange') ? (GETPOST("disable_stock_change", 'int') ? ' checked="checked"' : '') : ($line->disable_stock_change ? ' checked="checked"' : '')) . '">';
+	print '</td>';
+
+	// Efficiency
+	$coldisplay++;
+	print '<td class="nobottom nowrap linecollost right">';
+	print '<input type="text" size="2" name="efficiency" id="efficiency" class="flat right" value="' . $line->efficiency . '"></td>';
+}
+
+// Service and workstations are active
+if ($filtertype == 1 && isModEnabled('workstation')) {
 	$coldisplay++;
 	print '<td class="nobottom nowrap linecolworkstation right">';
 	print $formproduct->selectWorkstations($line->fk_default_workstation, 'idworkstations', 1);
 	print '</td>';
-
-	$coldisplay++;
-	print '<td class="nobottom nowrap linecolcostprice right">';
-	print '</td>';
 }
+
+// Cost
+$coldisplay++;
+print '<td class="nobottom nowrap linecolcostprice right">';
+print '</td>';
 
 $coldisplay += $colspan;
 print '<td class="nobottom linecoledit center valignmiddle" colspan="'.$colspan.'">';

--- a/htdocs/bom/tpl/objectline_title.tpl.php
+++ b/htdocs/bom/tpl/objectline_title.tpl.php
@@ -68,11 +68,14 @@ print '</td>';
 // Qty
 print '<td class="linecolqty right">'.$form->textwithpicto($langs->trans('Qty'), ($filtertype != 1) ? $langs->trans("QtyRequiredIfNoLoss") : '').'</td>';
 
-if ($filtertype != 1) {
+if ($filtertype != 1) { // Product
 	if (getDolGlobalInt('PRODUCT_USE_UNITS')) {
 		print '<td class="linecoluseunit left">' . $langs->trans('Unit') . '</td>';
 	}
-
+} else { // Service
+	print '<td class="linecolunit right">' . $form->textwithpicto($langs->trans('Unit'), '').'</td>';
+}
+if ($filtertype != 1 || getDolGlobalString('STOCK_SUPPORTS_SERVICES')) { // Product or stock support for Services is active
 	// Qty frozen
 	print '<td class="linecolqtyfrozen right">' . $form->textwithpicto($langs->trans('QtyFrozen'), $langs->trans("QuantityConsumedInvariable")) . '</td>';
 
@@ -81,22 +84,15 @@ if ($filtertype != 1) {
 
 	// Efficiency
 	print '<td class="linecolefficiency right">' . $form->textwithpicto($langs->trans('ManufacturingEfficiency'), $langs->trans('ValueOfMeansLoss')) . '</td>';
-
-	// Cost
-	print '<td class="linecolcost right">'.$form->textwithpicto($langs->trans("TotalCost"), $langs->trans("BOMTotalCost")).'</td>';
-} else {
-	print '<td class="linecolunit right">' . $form->textwithpicto($langs->trans('Unit'), '').'</td>';
-
-	if (isModEnabled('workstation')) {
-		print '<td class="linecolworkstation right">' .  $form->textwithpicto($langs->trans('DefaultWorkstation'), '') . '</td>';
-	}
-
-	// Cost
-	print '<td class="linecolcost right">'.$form->textwithpicto($langs->trans("TotalCost"), $langs->trans("BOMTotalCostService")).'</td>';
 }
 
+// Service and workstations are active
+if ($filtertype == 1 && isModEnabled('workstation')) {
+	print '<td class="linecolworkstation right">' .  $form->textwithpicto($langs->trans('DefaultWorkstation'), '') . '</td>';
+}
 
-
+// Cost
+print '<td class="linecolcost right">'.$form->textwithpicto($langs->trans("TotalCost"), $langs->trans("BOMTotalCostService")).'</td>';
 
 print '<td class="linecoledit"></td>'; // No width to allow autodim
 

--- a/htdocs/bom/tpl/objectline_view.tpl.php
+++ b/htdocs/bom/tpl/objectline_view.tpl.php
@@ -130,7 +130,7 @@ $coldisplay++;
 echo price($line->qty, 0, '', 0, 0); // Yes, it is a quantity, not a price, but we just want the formating role of function price
 print '</td>';
 
-if ($filtertype != 1) {
+if ($filtertype != 1) { // Product
 	if (getDolGlobalInt('PRODUCT_USE_UNITS')) {
 		print '<td class="linecoluseunit nowrap left">';
 		$label = measuringUnitString($line->fk_unit, '', '', 1);
@@ -139,21 +139,7 @@ if ($filtertype != 1) {
 		}
 		print '</td>';
 	}
-
-	print '<td class="linecolqtyfrozen nowrap right">';
-	$coldisplay++;
-	echo $line->qty_frozen ? yn($line->qty_frozen) : '';
-	print '</td>';
-	print '<td class="linecoldisablestockchange nowrap right">';
-	$coldisplay++;
-	echo $line->disable_stock_change ? yn($line->disable_stock_change) : ''; // Yes, it is a quantity, not a price, but we just want the formating role of function price
-	print '</td>';
-
-	print '<td class="linecolefficiency nowrap right">';
-	$coldisplay++;
-	echo $line->efficiency;
-	print '</td>';
-} else {
+} else { // Service
 	// Unit
 	print '<td class="linecolunit nowrap right">';
 	$coldisplay++;
@@ -166,19 +152,38 @@ if ($filtertype != 1) {
 	}
 
 	print '</td>';
+}
+if ($filtertype != 1 || getDolGlobalString('STOCK_SUPPORTS_SERVICES')) { // Product or stock support for Services is active
+	// Qty frozen
+	print '<td class="linecolqtyfrozen nowrap right">';
+	$coldisplay++;
+	echo $line->qty_frozen ? yn($line->qty_frozen) : '';
+	print '</td>';
+	print '<td class="linecoldisablestockchange nowrap right">';
 
-	// Work station
-	if (isModEnabled('workstation')) {
-		$workstation = new Workstation($object->db);
-		$res = $workstation->fetch($line->fk_default_workstation);
+	// Disable stock change
+	$coldisplay++;
+	echo $line->disable_stock_change ? yn($line->disable_stock_change) : ''; // Yes, it is a quantity, not a price, but we just want the formating role of function price
+	print '</td>';
 
-		print '<td class="linecolworkstation nowrap right">';
-		$coldisplay++;
-		if ($res > 0) {
-			echo $workstation->getNomUrl(1);
-		}
-		print '</td>';
+	// Efficiency
+	print '<td class="linecolefficiency nowrap right">';
+	$coldisplay++;
+	echo $line->efficiency;
+	print '</td>';
+}
+
+// Service and workstations are active
+if ($filtertype == 1 && isModEnabled('workstation')) {
+	$workstation = new Workstation($object->db);
+	$res = $workstation->fetch($line->fk_default_workstation);
+
+	print '<td class="linecolworkstation nowrap right">';
+	$coldisplay++;
+	if ($res > 0) {
+		echo $workstation->getNomUrl(1);
 	}
+	print '</td>';
 }
 
 // Cost


### PR DESCRIPTION
Fix #30187.
Now the Columns: Frozen Qty, Stock change disabled and Manufacturing efficiency shows if the option "Stock management supports Services" is active.
![image](https://github.com/Dolibarr/dolibarr/assets/78662388/de2e2ba3-d9f6-483e-a0b3-6ad451e1b543)
