### PR TITLE
FIX force rounding mode 0 for expense report

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3855,6 +3855,12 @@ abstract class CommonObject
 			$fieldup = 'pu_ht';
 		}
 		if ($this->element == 'expensereport') {
+			// force rounding mode to 1
+			// otherwise when you set MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND to 1
+			// you have 2 lines with same TTC amounts (6,2 Unit price TTC and VAT rate 20%)
+			// on the first line you got 5,17 on HT total
+			// when you got 5,16 on HT total and 1,04 on VAT total to get 6,20 on TTT total (see #30051)
+			$forcedroundingmode = '0';
 			$fieldup = 'value_unit';
 			$base_price_type = 'TTC';
 		}


### PR DESCRIPTION
FIX force rounding mode 0 for expense report

See PR https://github.com/Dolibarr/dolibarr/pull/30051

- it's better to force rounding mode to 0 for expense report than having different HT total amounts for same lines with same TTC unit price