### PR TITLE
Fix : Correction of Margin Rate and Mark-up Rate Calculation

### DIFF
--- a/htdocs/margin/productMargins.php
+++ b/htdocs/margin/productMargins.php
@@ -300,12 +300,24 @@ if ($result) {
 			$pv = $objp->selling_price;
 			$marge = $objp->marge;
 
-			if ($marge < 0) {
-				$marginRate = ($pa != 0) ? -1 * (100 * $marge / $pa) : '';
-				$markRate = ($pv != 0) ? -1 * (100 * $marge / $pv) : '';
+			if ($pa != 0) {
+				$marginRate = (100 * $marge / $pa);
+				// We invert the sign if the margin is negative, regardless of the sign of the purchase price
+				if ($marge < 0) {
+					$marginRate = -$marginRate;
+				}
 			} else {
-				$marginRate = ($pa != 0) ? (100 * $marge / $pa) : '';
-				$markRate = ($pv != 0) ? (100 * $marge / $pv) : '';
+				$marginRate = '';
+			}
+
+			if ($pv != 0) {
+				$markRate = (100 * $marge / $pv);
+				// We invert the sign if the margin is negative, as in the original logic
+				if ($marge < 0) {
+					$markRate = -$markRate;
+				}
+			} else {
+				$markRate = '';
 			}
 
 			print '<tr class="oddeven">';


### PR DESCRIPTION
# FIX|Fix  Correction of Margin Rate and Mark-up Rate Calculation

Description:

This pull request corrects the calculation of the margin rate and mark-up rate to properly handle cases where the margin is negative, while maintaining the expected behavior for both positive and negative purchase prices.

Initial Problem:
The original formula incorrectly inverted the sign of the margin rate in certain cases, particularly when the purchase price was positive and the margin was negative.

Modification:
The logic has been adjusted to invert the sign of the rate only when the margin is negative, regardless of the sign of the purchase price.

Examples of cases handled:

1. Positive purchase price, negative margin:
   Purchase Price: €13,734.14
   Margin: -€3,229.14
   Old result: -23.51% (incorrect)
   New result: 23.51% (correct)

2. Negative purchase price, negative margin:
   Purchase Price: -€6,938.40
   Margin: -€1,321.60
   Old result: -19.05% (correct)
   New result: -19.05% (maintained correct)

This modification ensures that:
- The margin rate is always positive when the margin is negative, regardless of the sign of the purchase price.
- The behavior remains unchanged for cases where the purchase price is negative.
- The same logic is applied to the mark-up rate calculation to maintain consistency.

