### PR TITLE
New box comm card

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -1210,7 +1210,9 @@ if ($object->id > 0) {
 				// print $formfile->getDocumentsLink($contrat->element, $filename, $filedir);
 				print $late;
 				print "</td>\n";
-				print '<td class="nowrap">'.dol_trunc($objp->refsup, 12)."</td>\n";
+				print '<td class="nowrap">';
+				print dol_trunc(strtolower(get_class($object)) == strtolower(Client::class) ?  $objp->refcus : $objp->refsup, 12);
+				print "</td>\n";
 				//print '<td class="right" width="80px"><span title="'.$langs->trans("DateCreation").'">'.dol_print_date($db->jdate($objp->dc), 'day')."</span></td>\n";
 				print '<td class="right" width="80px"><span title="'.$langs->trans("DateContract").'">'.dol_print_date($db->jdate($objp->dcon), 'day')."</span></td>\n";
 				print '<td width="20">&nbsp;</td>';
@@ -1422,7 +1424,7 @@ if ($object->id > 0) {
 	 *   Latest invoices
 	 */
 	if (isModEnabled('invoice') && $user->hasRight('facture', 'lire')) {
-		$sql = 'SELECT f.rowid as facid, f.ref, f.type';
+		$sql = 'SELECT f.rowid as facid, f.ref, f.type, f.ref_client';
 		$sql .= ', f.total_ht';
 		$sql .= ', f.total_tva';
 		$sql .= ', f.total_ttc';
@@ -1452,6 +1454,9 @@ if ($object->id > 0) {
 				if (getDolGlobalString('MAIN_SHOW_PRICE_WITH_TAX_IN_SUMMARIES')) {
 					$colspan++;
 				}
+				if (getDolGlobalString('MAIN_SHOW_REF_CUSTOMER_INVOICES')) {
+					$colspan++;
+				}
 				print '<td colspan="'.$colspan.'">';
 				print '<table class="centpercent nobordernopadding"><tr><td>'.$langs->trans("LastCustomersBills", ($num <= $MAXLIST ? "" : $MAXLIST)).'</td><td class="right"><a class="notasortlink" href="'.DOL_URL_ROOT.'/compta/facture/list.php?socid='.$object->id.'"><span class="hideonsmartphone">'.$langs->trans("AllBills").'</span><span class="badge marginleftonlyshort">'.$num.'</span></a></td>';
 				print '<td width="20px" class="right"><a href="'.DOL_URL_ROOT.'/compta/facture/stats/index.php?socid='.$object->id.'">'.img_picto($langs->trans("Statistics"), 'stats').'</a></td>';
@@ -1466,6 +1471,7 @@ if ($object->id > 0) {
 
 				$facturestatic->id = $objp->facid;
 				$facturestatic->ref = $objp->ref;
+				$facturestatic->ref_client = $objp->ref_client;
 				$facturestatic->type = $objp->type;
 				$facturestatic->total_ht = $objp->total_ht;
 				$facturestatic->total_tva = $objp->total_tva;
@@ -1511,6 +1517,11 @@ if ($object->id > 0) {
 				// $urlsource = '/compta/facture/card.php?id='.$objp->cid;
 				//print $formfile->getDocumentsLink($facturestatic->element, $filename, $filedir);
 				print '</td>';
+				if (getDolGlobalString('MAIN_SHOW_REF_CUSTOMER_INVOICES')) {
+					print '<td class="left nowraponall">';
+					print $objp->ref_client;
+					print '</td>';
+				}
 				if ($objp->df > 0) {
 					print '<td width="80px" title="'.dol_escape_htmltag($langs->trans('DateInvoice')).'">'.dol_print_date($db->jdate($objp->df), 'day').'</td>';
 				} else {
@@ -1521,6 +1532,7 @@ if ($object->id > 0) {
 				} else {
 					print '<td><b>!!!</b></td>';
 				}
+
 				print '<td class="right nowraponall">';
 				print price($objp->total_ht);
 				print '</td>';

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -701,8 +701,6 @@ $resHook = $hookmanager->executeHooks('completeListOfReferent', $parameters, $ob
 
 if (!empty($hookmanager->resArray)) {
 	$listofreferent = array_merge($listofreferent, $hookmanager->resArray);
-}elseif ($resHook > 0 && !empty($hookmanager->resPrint)) {
-	$listofreferent = $hookmanager->resPrint;
 }
 
 if ($action == "addelement") {

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -701,6 +701,8 @@ $resHook = $hookmanager->executeHooks('completeListOfReferent', $parameters, $ob
 
 if (!empty($hookmanager->resArray)) {
 	$listofreferent = array_merge($listofreferent, $hookmanager->resArray);
+}elseif ($resHook > 0 && !empty($hookmanager->resPrint)) {
+	$listofreferent = $hookmanager->resPrint;
 }
 
 if ($action == "addelement") {


### PR DESCRIPTION
# Instructions

The modifications are valid on the comm/card.php page
On the client tab of the third party.
They concern the boxes "Les derniers contrats" and "Les dernières factures client"

# NEW|New [*change col box*]

    BOX "Les derniers contrats" 
Before, it was always the supplier reference displayed. 
I added the possibility to display the customer reference in the box when we are on this page and my object is "Client". If it is not, the supplier reference is displayed.

    BOX "Les derrières factures client" 
Before, there was no column with the customer reference.
Via a hidden configuration, I added the possibility to add a column with the customer reference of the invoice.