### PR TITLE
return resprint hook

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -701,6 +701,8 @@ $resHook = $hookmanager->executeHooks('completeListOfReferent', $parameters, $ob
 
 if (!empty($hookmanager->resArray)) {
 	$listofreferent = array_merge($listofreferent, $hookmanager->resArray);
+} elseif ($resHook > 0 && !empty($hookmanager->resPrint)) {
+	$listofreferent = $hookmanager->resPrint;
 }
 
 if ($action == "addelement") {


### PR DESCRIPTION
I need to add a related objectives table, the current hook return only allows me to add at the end of the page, I kept this possibility.
I have implemented the ability to completely modify the order of the array that I store in $hookmanager->resPrint.

