### PR TITLE
FIX: Error mesg show untranslated extrafield name

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -833,7 +833,7 @@ class ExtraFields
 	public function fetch_name_optionals_label($elementtype, $forceload = false)
 	{
 		// phpcs:enable
-		global $conf;
+		global $conf, $langs;
 
 		if (empty($elementtype)) {
 			return array();
@@ -883,7 +883,7 @@ class ExtraFields
 					}
 
 					$this->attributes[$tab->elementtype]['type'][$tab->name] = $tab->type;
-					$this->attributes[$tab->elementtype]['label'][$tab->name] = $tab->label;
+					$this->attributes[$tab->elementtype]['label'][$tab->name] = $langs->transnoentities($tab->label);
 					$this->attributes[$tab->elementtype]['size'][$tab->name] = $tab->size;
 					$this->attributes[$tab->elementtype]['elementtype'][$tab->name] = $tab->elementtype;
 					$this->attributes[$tab->elementtype]['default'][$tab->name] = $tab->fielddefault;


### PR DESCRIPTION
Before
![image](https://github.com/Dolibarr/dolibarr/assets/58433943/fa037238-1cfd-488d-9576-b325f37d8a06)


After
![image](https://github.com/Dolibarr/dolibarr/assets/58433943/ca64e5f8-c05c-414f-98b3-7d78ed0cff83)


