### PR TITLE
FIX: social charges accountancy: link with employee should be ignored

### DIFF
--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -314,7 +314,9 @@ if ($result) {
 			}
 			// Now loop on each link of record in bank (code similar to bankentries_list.php)
 			foreach ($links as $key => $val) {
-				if ($links[$key]['type'] == 'user' && !$is_sc) continue;
+				if ($links[$key]['type'] == 'user' && $is_sc) {
+					continue;
+				}
 				if (in_array($links[$key]['type'], array('sc', 'payment_sc', 'payment', 'payment_supplier', 'payment_vat', 'payment_expensereport', 'banktransfert', 'payment_donation', 'member', 'payment_loan', 'payment_salary', 'payment_various'))) {
 					// So we excluded 'company' and 'user' here. We want only payment lines
 


### PR DESCRIPTION
Social charges payment bank url is both linked with the social charge itself and with the user.

The link with the user should be ignored as the payment of social charges is not made to the employee but to a public establishment.

This causes an imbalance as it makes two debit counterparts, one with the social charge type accountancy code and the other with the employee accountancy code.

This bug is still present in develop.