### PR TITLE
fix: on edit line contrat, if failed at the end, stay on edit mode

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -802,6 +802,8 @@ if (empty($reshook)) {
 			$result = $objectline->update($user);
 			if ($result < 0) {
 				$error++;
+				$action = 'editline';
+				$_GET['rowid'] = GETPOST('elrowid');
 				setEventMessages($objectline->error, $objectline->errors, 'errors');
 			}
 		}


### PR DESCRIPTION


If update failed for whatever error, it should stay on edit mode as it is done on first date check

As it is done in 
https://github.com/Dolibarr/dolibarr/blob/29dd8ade0164640289b69ef46d4b7e310c9289d3/htdocs/contrat/card.php#L697