### PR TITLE
Exit code must be negative then external scripts can detect an error

### DIFF
--- a/htdocs/master.inc.php
+++ b/htdocs/master.inc.php
@@ -161,7 +161,7 @@ if (!defined('NOREQUIREDB')) {
 			exit;
 		}
 		dol_print_error($db, "host=".$conf->db->host.", port=".$conf->db->port.", user=".$conf->db->user.", databasename=".$conf->db->name.", ".$db->error);
-		exit;
+		exit(-1);
 	}
 }
 

--- a/htdocs/master.inc.php
+++ b/htdocs/master.inc.php
@@ -158,10 +158,10 @@ if (!defined('NOREQUIREDB')) {
 				print "SorryWebsiteIsCurrentlyOffLine";
 			}
 			print '</div>';
-			exit;
+			exit(1);
 		}
 		dol_print_error($db, "host=".$conf->db->host.", port=".$conf->db->port.", user=".$conf->db->user.", databasename=".$conf->db->name.", ".$db->error);
-		exit(-1);
+		exit(1);
 	}
 }
 


### PR DESCRIPTION
Hello,

I made a script but i can't detect an error with database connexion without a negative exit code.
Exit code should be negative.

Thank you.