### PR TITLE
FIX fatal valid recep

### DIFF
--- a/htdocs/delivery/class/delivery.class.php
+++ b/htdocs/delivery/class/delivery.class.php
@@ -422,7 +422,7 @@ class Delivery extends CommonObject
 					$soc->fetch($this->socid);
 
 					if (preg_match('/^[\(]?PROV/i', $this->ref) || empty($this->ref)) { // empty should not happened, but when it occurs, the test save life
-						$numref = $objMod->delivery_get_num($soc, $this);
+						$numref = $objMod->getNextValue($soc, $this);
 					} else {
 						$numref = $this->ref;
 					}


### PR DESCRIPTION
# Instructions
Fatal error when validating receipt 

# FIX|Fix #[*Error Fatal *]
`Fatal error: Uncaught Error: Call to undefined method mod_delivery_jade::delivery_get_num()`
The delivery_get_num() method has been removed from the mod_delivery_jade.
This generates a fatal error
I replaced it with ->getNextValue()