### PR TITLE
Major break into 20.0 : revert to fetchAll signature

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1098,6 +1098,8 @@ class BookKeeping extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {	// deprecated, use $filter = USF syntax
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
+
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1050,6 +1050,11 @@ class BookKeeping extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		} else {
+			$filter = '';
+		}
 
 
 		dol_syslog(__METHOD__, LOG_DEBUG);

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1038,7 +1038,8 @@ class BookKeeping extends CommonObject
 	 * @param string 		$sortfield                      Sort field
 	 * @param int 			$limit                          Limit
 	 * @param int 			$offset                         Offset limit
-	 * @param string|array 	$filter                         Filter array
+	 * @param array			$filter       					Filter as an Universal Search string.
+	 * 														Example: $filter['uss'] =
 	 * @param string 		$filtermode                     Filter mode (AND or OR)
 	 * @param int           $showAlreadyExportMovements     Show movements when field 'date_export' is not empty (0:No / 1:Yes (Default))
 	 * @return int                                          Return integer <0 if KO, >0 if OK
@@ -1050,7 +1051,11 @@ class BookKeeping extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.reconciled_option'] = $search_not_reconciled
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 
 		dol_syslog(__METHOD__, LOG_DEBUG);

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1043,9 +1043,14 @@ class BookKeeping extends CommonObject
 	 * @param int           $showAlreadyExportMovements     Show movements when field 'date_export' is not empty (0:No / 1:Yes (Default))
 	 * @return int                                          Return integer <0 if KO, >0 if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND', $showAlreadyExportMovements = 1)
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND', $showAlreadyExportMovements = 1)
 	{
 		global $conf;
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
 

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1050,11 +1050,7 @@ class BookKeeping extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		if (isset($filter['uss'])) {
-			$filter = $filter['uss'];
-		} else {
-			$filter = '';
-		}
+		$filter = $filter['uss'] ?? "";
 
 
 		dol_syslog(__METHOD__, LOG_DEBUG);

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -398,6 +398,11 @@ class Asset extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		} else {
+			$filter = '';
+		}
 
 
 		$records = array();

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -386,14 +386,19 @@ class Asset extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+
 
 		$records = array();
 

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -398,11 +398,7 @@ class Asset extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		if (isset($filter['uss'])) {
-			$filter = $filter['uss'];
-		} else {
-			$filter = '';
-		}
+		$filter = $filter['uss'] ?? "";
 
 
 		$records = array();

--- a/htdocs/asset/class/assetmodel.class.php
+++ b/htdocs/asset/class/assetmodel.class.php
@@ -349,11 +349,7 @@ class AssetModel extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		if (isset($filter['uss'])) {
-			$filter = $filter['uss'];
-		} else {
-			$filter = '';
-		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/asset/class/assetmodel.class.php
+++ b/htdocs/asset/class/assetmodel.class.php
@@ -349,7 +349,11 @@ class AssetModel extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		} else {
+			$filter = '';
+		}
 
 		$records = array();
 
@@ -364,7 +368,7 @@ class AssetModel extends CommonObject
 
 		// Manage filter
 		$errormessage = '';
-		$sql .= forgeSQLFromUniversalSearchCriteria($filter, $errormessage);
+		$sql .= forgeSQLFromUniversalSearchCriteria($filter['uss'], $errormessage);
 		if ($errormessage) {
 			$this->errors[] = $errormessage;
 			dol_syslog(__METHOD__.' '.implode(',', $this->errors), LOG_ERR);

--- a/htdocs/asset/class/assetmodel.class.php
+++ b/htdocs/asset/class/assetmodel.class.php
@@ -337,14 +337,19 @@ class AssetModel extends CommonObject
 	 * @param  string      	$sortfield   	 Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+
 
 		$records = array();
 

--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1274,7 +1274,7 @@ class BOM extends CommonObject
 		$this->lines = array();
 
 		$objectline = new BOMLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_bom:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_bom:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->error = $objectline->error;

--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -483,13 +483,19 @@ class BOM extends CommonObject
 	 * @param  string      		$sortfield    Sort field
 	 * @param  int         		$limit        Limit
 	 * @param  int         		$offset       Offset
-	 * @param  string   		$filter       Filter USF
+	 * @param  array			$filter       Filter as an Universal Search string.
+	 * 										  Example: $filter['uss'] = ''
 	 * @param  string      		$filtermode   Filter mode (AND or OR)
 	 * @return array|int        			  int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 
@@ -1904,14 +1910,19 @@ class BOMLine extends CommonObjectLine
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string		$filtermode		No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/bookcal/class/availabilities.class.php
+++ b/htdocs/bookcal/class/availabilities.class.php
@@ -934,7 +934,7 @@ class Availabilities extends CommonObject
 		$this->lines = array();
 
 		$objectline = new AvailabilitiesLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_availabilities:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_availabilities:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->error = $objectline->error;

--- a/htdocs/bookcal/class/availabilities.class.php
+++ b/htdocs/bookcal/class/availabilities.class.php
@@ -380,14 +380,19 @@ class Availabilities extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/bookcal/class/calendar.class.php
+++ b/htdocs/bookcal/class/calendar.class.php
@@ -926,7 +926,7 @@ class Calendar extends CommonObject
 		$this->lines = array();
 
 		$objectline = new CalendarLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_calendar:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_calendar:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->setErrorsFromObject($objectline);

--- a/htdocs/bookcal/class/calendar.class.php
+++ b/htdocs/bookcal/class/calendar.class.php
@@ -340,14 +340,19 @@ class Calendar extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/core/class/cgenericdic.class.php
+++ b/htdocs/core/class/cgenericdic.class.php
@@ -225,13 +225,19 @@ class CGenericDic extends CommonDict
 	 * @param string 		$sortfield 		Sort field
 	 * @param int    		$limit     		Limit
 	 * @param int    		$offset    		offset limit
-	 * @param string|array  $filter    		filter USF
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =
 	 * @param string 		$filtermode 	filter mode (AND or OR)
 	 * @return int 							Return integer <0 if KO, >0 if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$fieldrowid = 'rowid';
 		$fieldlabel = 'label';

--- a/htdocs/core/class/cgenericdic.class.php
+++ b/htdocs/core/class/cgenericdic.class.php
@@ -237,7 +237,11 @@ class CGenericDic extends CommonDict
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$fieldrowid = 'rowid';
 		$fieldlabel = 'label';
@@ -257,6 +261,8 @@ class CGenericDic extends CommonDict
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
+
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/core/class/cleadstatus.class.php
+++ b/htdocs/core/class/cleadstatus.class.php
@@ -170,13 +170,19 @@ class CLeadStatus extends CommonDict
 	 * @param  string      $sortfield    Sort field
 	 * @param  int         $limit        Limit
 	 * @param  int         $offset       Offset
-	 * @param  string      $filter       Filter USF
+	 * @param  array	   $filter       Filter as an Universal Search string.
+	 * 									 Example: $filter['uss'] =
 	 * @param  string      $filtermode   Filter mode (AND or OR)
 	 * @return array|int                 int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";

--- a/htdocs/core/class/cleadstatus.class.php
+++ b/htdocs/core/class/cleadstatus.class.php
@@ -182,7 +182,11 @@ class CLeadStatus extends CommonDict
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";
@@ -196,6 +200,7 @@ class CLeadStatus extends CommonDict
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/core/class/commonobjectline.class.php
+++ b/htdocs/core/class/commonobjectline.class.php
@@ -260,13 +260,18 @@ abstract class CommonObjectLine extends CommonObject
 	 * @param  string      		$sortfield    	Sort field
 	 * @param  int         		$limit        	Limit the number of lines returned
 	 * @param  int         		$offset       	Offset
-	 * @param  string|array		$filter       	Filter as an Universal Search string.
-	 * 											Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array			$filter       	Filter as an Universal Search string.
+	 * 											Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      		$filtermode   	No more used
 	 * @return array|int        	         	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
+
 		return 0;
 	}
 }

--- a/htdocs/core/class/cproductnature.class.php
+++ b/htdocs/core/class/cproductnature.class.php
@@ -156,13 +156,19 @@ class CProductNature extends CommonDict
 	 * @param  string      $sortfield    Sort field
 	 * @param  int         $limit        Limit
 	 * @param  int         $offset       Offset
-	 * @param  string      $filter       Filter USF
+	 * @param  array		$filter      Filter as an Universal Search string.
+	 * 									 Example: $filter['uss'] =
 	 * @param  string      $filtermode   Filter mode (AND or OR)
 	 * @return array|int                 int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";

--- a/htdocs/core/class/cproductnature.class.php
+++ b/htdocs/core/class/cproductnature.class.php
@@ -168,7 +168,11 @@ class CProductNature extends CommonDict
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";
@@ -180,6 +184,7 @@ class CProductNature extends CommonDict
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/core/class/ctyperesource.class.php
+++ b/htdocs/core/class/ctyperesource.class.php
@@ -199,13 +199,19 @@ class Ctyperesource extends CommonDict
 	 * @param string 		$sortfield 		Sort field
 	 * @param int    		$limit     		Limit
 	 * @param int    		$offset    		Offset limit
-	 * @param string|array  $filter    		filter array
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =
 	 * @param string 		$filtermode 	filter mode (AND or OR)
 	 * @return int 							Return integer <0 if KO, >0 if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";

--- a/htdocs/core/class/ctyperesource.class.php
+++ b/htdocs/core/class/ctyperesource.class.php
@@ -211,7 +211,11 @@ class Ctyperesource extends CommonDict
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";
@@ -223,6 +227,7 @@ class Ctyperesource extends CommonDict
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/core/class/cunits.class.php
+++ b/htdocs/core/class/cunits.class.php
@@ -212,13 +212,19 @@ class CUnits extends CommonDict
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	Limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string|array $filter       	Filter USF
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =
 	 * @param  string      	$filtermode   	Filter mode (AND or OR)
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";

--- a/htdocs/core/class/cunits.class.php
+++ b/htdocs/core/class/cunits.class.php
@@ -224,7 +224,11 @@ class CUnits extends CommonDict
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";
@@ -240,6 +244,7 @@ class CUnits extends CommonDict
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/core/class/defaultvalues.class.php
+++ b/htdocs/core/class/defaultvalues.class.php
@@ -252,7 +252,11 @@ class DefaultValues extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like 't.page' => 'comm/action/card.php'
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$records = array();
 

--- a/htdocs/core/class/defaultvalues.class.php
+++ b/htdocs/core/class/defaultvalues.class.php
@@ -240,14 +240,19 @@ class DefaultValues extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string|array	$filter       	Filter as an Universal Search string or Array (array use is deprecated)
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/core/class/defaultvalues.class.php
+++ b/htdocs/core/class/defaultvalues.class.php
@@ -267,6 +267,7 @@ class DefaultValues extends CommonObject
 
 		// Deprecated. For compatibility.
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/core/class/timespent.class.php
+++ b/htdocs/core/class/timespent.class.php
@@ -318,14 +318,19 @@ class TimeSpent extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		global $conf;
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
 

--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -241,7 +241,7 @@ function project_prepare_head(Project $project, $moreparam = '')
 		} else {
 			require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorbooth.class.php';
 			$conforbooth = new ConferenceOrBooth($db);
-			$result = $conforbooth->fetchAll('', '', 0, 0, '(t.fk_project:=:'.((int) $project->id).")");
+			$result = $conforbooth->fetchAll('', '', 0, 0, ['uss' => '(t.fk_project:=:'.((int) $project->id).')']);
 			//,
 			if (!is_array($result) && $result < 0) {
 				setEventMessages($conforbooth->error, $conforbooth->errors, 'errors');
@@ -257,7 +257,7 @@ function project_prepare_head(Project $project, $moreparam = '')
 		} else {
 			require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorboothattendee.class.php';
 			$conforboothattendee = new ConferenceOrBoothAttendee($db);
-			$result = $conforboothattendee->fetchAll('', '', 0, 0, '(t.fk_project:=:'.((int) $project->id).')');
+			$result = $conforboothattendee->fetchAll('', '', 0, 0, ['uss' => '(t.fk_project:=:'.((int) $project->id).')']);
 
 			if (!is_array($result) && $result < 0) {
 				setEventMessages($conforboothattendee->error, $conforboothattendee->errors, 'errors');

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -229,7 +229,7 @@ if ($action == 'presend') {
 	if (getDolGlobalString('MAIN_MAIL_ENABLED_USER_DEST_SELECT')) {
 		$listeuser = array();
 		$fuserdest = new User($db);
-		$result = $fuserdest->fetchAll('ASC', 't.lastname', 0, 0, "(t.statut:=:1) AND (t.employee:=:1) AND (t.email:isnot:NULL) AND (t.email:!=:'')", 'AND', true);
+		$result = $fuserdest->fetchAll('ASC', 't.lastname', 0, 0, ['uss' => "(t.statut:=:1) AND (t.employee:=:1) AND (t.email:isnot:NULL) AND (t.email:!=:'')"], 'AND', true);
 		if ($result > 0 && is_array($fuserdest->users) && count($fuserdest->users) > 0) {
 			foreach ($fuserdest->users as $uuserdest) {
 				$listeuser[$uuserdest->id] = $uuserdest->user_get_property($uuserdest->id, 'email');

--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -519,13 +519,19 @@ class Cronjob extends CommonObject
 	 * @param	int				$limit			Limit page
 	 * @param	int				$offset			Offset ppage
 	 * @param	int				$status			Display active or not
-	 * @param	string|array	$filter			Filter USF.
+	 * @param  array			$filter       	Filter as an Universal Search string.
+	 * 											Example: $filter['uss'] =
 	 * @param	int				$processing		Processing or not (-1=all, 0=not in progress, 1=in progress)
 	 * @return	int								if KO: <0 || if OK: >0
 	 */
-	public function fetchAll(string $sortorder = 'DESC', string $sortfield = 't.rowid', int $limit = 0, int $offset = 0, int $status = 1, $filter = '', int $processing = -1)
+	public function fetchAll(string $sortorder = 'DESC', string $sortfield = 't.rowid', int $limit = 0, int $offset = 0, int $status = 1, array $filter = array(), int $processing = -1)
 	{
 		$this->lines = array();
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";

--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -531,7 +531,11 @@ class Cronjob extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";
@@ -581,6 +585,7 @@ class Cronjob extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {
 					if ($key == 't.rowid') {

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -535,13 +535,19 @@ class EcmFiles extends CommonObject
 	 * @param 	string 			$sortfield 		Sort field
 	 * @param 	int    			$limit     		Limit
 	 * @param 	int    			$offset    		Offset limit
-	 * @param 	string|array  	$filter    		filter array
+	 * @param  array			$filter       	Filter as an Universal Search string.
+	 * 											Example: $filter['uss'] =
 	 * @param 	string 			$filtermode 	filter mode (AND or OR)
 	 * @return 	int 							Return integer <0 if KO, >0 if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$sql = 'SELECT';
 		$sql .= ' t.rowid,';

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -547,7 +547,11 @@ class EcmFiles extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like 't.src_object_type' => $objectType
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$sql = 'SELECT';
 		$sql .= ' t.rowid,';

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -579,6 +579,7 @@ class EcmFiles extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/eventorganization/class/conferenceorbooth.class.php
+++ b/htdocs/eventorganization/class/conferenceorbooth.class.php
@@ -273,17 +273,22 @@ class ConferenceOrBooth extends ActionComm
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		//TODO set percent according status
 		global $conf;
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -398,14 +398,19 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/eventorganization/lib/eventorganization_conferenceorbooth.lib.php
+++ b/htdocs/eventorganization/lib/eventorganization_conferenceorbooth.lib.php
@@ -141,7 +141,7 @@ function conferenceorboothProjectPrepareHead($object)
 	} else {
 		require_once DOL_DOCUMENT_ROOT . '/eventorganization/class/conferenceorbooth.class.php';
 		$conforbooth = new ConferenceOrBooth($db);
-		$result = $conforbooth->fetchAll('', '', 0, 0, '(t.fk_project:=:' . ((int) $object->id) . ')');
+		$result = $conforbooth->fetchAll('', '', 0, 0, ['uss' => '(t.fk_project:=:' . ((int) $object->id) . ')']);
 		if (!is_array($result) && $result < 0) {
 			setEventMessages($conforbooth->error, $conforbooth->errors, 'errors');
 		} else {
@@ -167,7 +167,7 @@ function conferenceorboothProjectPrepareHead($object)
 	} else {
 		require_once DOL_DOCUMENT_ROOT . '/eventorganization/class/conferenceorboothattendee.class.php';
 		$attendees = new ConferenceOrBoothAttendee($db);
-		$result = $attendees->fetchAll('', '', 0, 0, '(t.fk_project:=:' . ((int) $object->id) . ')');
+		$result = $attendees->fetchAll('', '', 0, 0, ['uss' => '(t.fk_project:=:' . ((int) $object->id) . ')']);
 		if (!is_array($result) && $result < 0) {
 			setEventMessages($attendees->error, $attendees->errors, 'errors');
 		} else {

--- a/htdocs/hrm/class/evaluation.class.php
+++ b/htdocs/hrm/class/evaluation.class.php
@@ -224,7 +224,7 @@ class Evaluation extends CommonObject
 		if ($resultcreate > 0) {
 			require_once DOL_DOCUMENT_ROOT . '/hrm/class/skillrank.class.php';
 			$skillRank = new SkillRank($this->db);
-			$TRequiredRanks = $skillRank->fetchAll('ASC', 't.rowid', 0, 0, '(fk_object:=:'.((int) $this->fk_job).") AND (objecttype:=:'job')");
+			$TRequiredRanks = $skillRank->fetchAll('ASC', 't.rowid', 0, 0, ['uss' => '(fk_object:=:'.((int) $this->fk_job).") AND (objecttype:=:'job')"]);
 
 			if (is_array($TRequiredRanks) && !empty($TRequiredRanks)) {
 				$this->lines = array();
@@ -912,7 +912,7 @@ class Evaluation extends CommonObject
 		$this->lines = array();
 
 		$objectline = new EvaluationLine($this->db);
-		$result = $objectline->fetchAll('ASC', '', 0, 0, '(fk_evaluation:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', '', 0, 0, ['uss' => '(fk_evaluation:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->setErrorsFromObject($objectline);

--- a/htdocs/hrm/class/evaluation.class.php
+++ b/htdocs/hrm/class/evaluation.class.php
@@ -381,14 +381,19 @@ class Evaluation extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/hrm/class/evaluationdet.class.php
+++ b/htdocs/hrm/class/evaluationdet.class.php
@@ -892,7 +892,7 @@ class EvaluationLine extends CommonObjectLine
 		$this->lines = array();
 
 		$objectline = new EvaluationLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_evaluationdet:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_evaluationdet:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->setErrorsFromObject($objectline);

--- a/htdocs/hrm/class/evaluationdet.class.php
+++ b/htdocs/hrm/class/evaluationdet.class.php
@@ -357,16 +357,21 @@ class EvaluationLine extends CommonObjectLine
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		global $conf;
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/hrm/class/job.class.php
+++ b/htdocs/hrm/class/job.class.php
@@ -352,14 +352,19 @@ class Job extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/hrm/class/job.class.php
+++ b/htdocs/hrm/class/job.class.php
@@ -921,7 +921,7 @@ class Job extends CommonObject
 		$this->lines = array();
 
 		$objectline = new JobLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_job:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_job:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->setErrorsFromObject($objectline);

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -961,7 +961,7 @@ class Position extends CommonObject
 		$this->lines = array();
 
 		$objectline = new PositionLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_position:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_position:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->setErrorsFromObject($objectline);
@@ -1037,7 +1037,7 @@ class Position extends CommonObject
 	{
 		$TPosition = array();
 
-		$TPosition = $this->fetchAll('ASC', 't.rowid', 0, 0, '(fk_user:=:'.((int) $userid).')');
+		$TPosition = $this->fetchAll('ASC', 't.rowid', 0, 0, ['uss' => '(fk_user:=:'.((int) $userid).')']);
 
 		return $TPosition;
 	}

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -359,14 +359,19 @@ class Position extends CommonObject
 	 * @param 	string 		$sortfield 		Sort field
 	 * @param 	int 		$limit 			limit
 	 * @param 	int 		$offset 		Offset
-	 * @param  	string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  	string      $filtermode   	No more used
 	 * @return 	array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/hrm/class/skill.class.php
+++ b/htdocs/hrm/class/skill.class.php
@@ -400,7 +400,7 @@ class Skill extends CommonObject
 		$this->lines = array();
 		require_once __DIR__ . '/skilldet.class.php';
 		$skilldet = new Skilldet($this->db);
-		$this->lines = $skilldet->fetchAll('ASC', '', 0, 0, '(fk_skill:=:'.$this->id.')');
+		$this->lines = $skilldet->fetchAll('ASC', '', 0, 0, ['uss' => '(fk_skill:=:'.$this->id.')']);
 
 		if (is_array($this->lines)) {
 			return (count($this->lines) > 0) ? $this->lines : array();
@@ -961,7 +961,7 @@ class Skill extends CommonObject
 		$this->lines = array();
 
 		$objectline = new Skilldet($this->db);
-		$result = $objectline->fetchAll('ASC', 'rankorder', 0, 0, '(fk_skill:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'rankorder', 0, 0, ['uss' => '(fk_skill:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->setErrorsFromObject($objectline);

--- a/htdocs/hrm/class/skill.class.php
+++ b/htdocs/hrm/class/skill.class.php
@@ -419,14 +419,19 @@ class Skill extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/hrm/class/skilldet.class.php
+++ b/htdocs/hrm/class/skilldet.class.php
@@ -351,14 +351,19 @@ class Skilldet extends CommonObjectLine
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/hrm/class/skillrank.class.php
+++ b/htdocs/hrm/class/skillrank.class.php
@@ -392,14 +392,19 @@ class SkillRank extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset      	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/hrm/class/skillrank.class.php
+++ b/htdocs/hrm/class/skillrank.class.php
@@ -211,7 +211,7 @@ class SkillRank extends CommonObject
 	{
 		global $langs;
 
-		$filter = '(fk_object:=:'.((int) $this->fk_object).") AND (objecttype:=:'".$this->db->escape($this->objecttype)."') AND (fk_skill:=:".((int) $this->fk_skill).")";
+		$filter = ['uss' => '(fk_object:=:'.((int) $this->fk_object).") AND (objecttype:=:'".$this->db->escape($this->objecttype)."') AND (fk_skill:=:".((int) $this->fk_skill).")"];
 
 		$alreadyLinked = $this->fetchAll('ASC', 'rowid', 0, 0, $filter);
 		if (!empty($alreadyLinked)) {
@@ -921,7 +921,7 @@ class SkillRank extends CommonObject
 
 		/*
 		$objectline = new SkillRankLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_skillrank:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_skillrank:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->error = $objectline->error;

--- a/htdocs/hrm/evaluation_card.php
+++ b/htdocs/hrm/evaluation_card.php
@@ -169,7 +169,7 @@ if (empty($reshook)) {
 	if ($action == 'close') {
 		// save evaldet lines to user;
 		$sk = new SkillRank($db);
-		$SkillrecordsForActiveUser = $sk->fetchAll('ASC', 'fk_skill', 0, 0, "(fk_object:=:".((int) $object->fk_user).") AND (objecttype:=:'".$db->escape(SkillRank::SKILLRANK_TYPE_USER)."')", 'AND');
+		$SkillrecordsForActiveUser = $sk->fetchAll('ASC', 'fk_skill', 0, 0, ['uss' => "(fk_object:=:".((int) $object->fk_user).") AND (objecttype:=:'".$db->escape(SkillRank::SKILLRANK_TYPE_USER)."')"], 'AND');
 
 		$errors = 0;
 		// we go through the evaldets of the eval

--- a/htdocs/hrm/lib/hrm_skillrank.lib.php
+++ b/htdocs/hrm/lib/hrm_skillrank.lib.php
@@ -113,7 +113,7 @@ function displayRankInfos($selected_rank, $fk_skill, $inputname = 'TNote', $mode
 
 	// On charge les différentes notes possibles pour la compétence $fk_skill
 	$skilldet = new Skilldet($db);
-	$Lines = $skilldet->fetchAll('ASC', 'rankorder', 0, 0, '(fk_skill:=:'.((int) $fk_skill).')');
+	$Lines = $skilldet->fetchAll('ASC', 'rankorder', 0, 0, ['uss' => '(fk_skill:=:'.((int) $fk_skill).')']);
 
 	if (!is_array($Lines) && $Lines<0) {
 		setEventMessages($skilldet->error, $skilldet->errors, 'errors');

--- a/htdocs/hrm/skill_tab.php
+++ b/htdocs/hrm/skill_tab.php
@@ -161,7 +161,7 @@ if (empty($reshook)) {
 	} elseif ($action == 'saveSkill') {
 		if (!empty($TNote)) {
 			foreach ($TNote as $skillId => $rank) {
-				$TSkills = $skill->fetchAll('ASC', 't.rowid', 0, 0, '(fk_object:=:'.((int) $id).") AND (objecttype:=:'".$db->escape($objecttype)."') AND (fk_skill:=:".((int) $skillId).')');
+				$TSkills = $skill->fetchAll('ASC', 't.rowid', 0, 0, ['uss' => '(fk_object:=:'.((int) $id).") AND (objecttype:=:'".$db->escape($objecttype)."') AND (fk_skill:=:".((int) $skillId).')']);
 				if (is_array($TSkills) && !empty($TSkills)) {
 					foreach ($TSkills as $tmpObj) {
 						$tmpObj->rankorder = $rank;

--- a/htdocs/knowledgemanagement/class/knowledgerecord.class.php
+++ b/htdocs/knowledgemanagement/class/knowledgerecord.class.php
@@ -372,7 +372,11 @@ class KnowledgeRecord extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$records = array();
 
@@ -387,6 +391,8 @@ class KnowledgeRecord extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
+
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/knowledgemanagement/class/knowledgerecord.class.php
+++ b/htdocs/knowledgemanagement/class/knowledgerecord.class.php
@@ -360,13 +360,19 @@ class KnowledgeRecord extends CommonObject
 	 * @param  string      		$sortfield    	Sort field
 	 * @param  int        		$limit        	Limit
 	 * @param  int         		$offset       	Offset
-	 * @param  string|array     $filter       	Filter USF.
+	 * @param  array			$filter       	Filter as an Universal Search string.
+	 * 											Example: $filter['uss'] =
 	 * @param  string      		$filtermode   	Filter mode (AND or OR)
 	 * @return array|int                 		int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/knowledgemanagement/class/knowledgerecord.class.php
+++ b/htdocs/knowledgemanagement/class/knowledgerecord.class.php
@@ -981,7 +981,7 @@ class KnowledgeRecord extends CommonObject
 		$this->lines = array();
 
 		$objectline = new KnowledgeRecordLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_knowledgerecord:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_knowledgerecord:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->error = $objectline->error;

--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -433,14 +433,19 @@ class MyObject extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	Limit the number of lines returned
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 1000, $offset = 0, string $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 1000, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -1089,7 +1089,7 @@ class MyObject extends CommonObject
 		$this->lines = array();
 
 		$objectline = new MyObjectLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_myobject:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_myobject:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->setErrorsFromObject($objectline);

--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -483,13 +483,19 @@ class Mo extends CommonObject
 	 * @param  string      		$sortfield    	Sort field
 	 * @param  int         		$limit        	Limit
 	 * @param  int         		$offset       	Offset
-	 * @param  string|array     $filter       	Filter USF.
+	 * @param  array			$filter       	Filter as an Universal Search string.
+	 * 											Example: $filter['uss'] =
 	 * @param  string      		$filtermode   	Filter mode (AND or OR)
 	 * @return array|int                 		int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 
@@ -2190,13 +2196,19 @@ class MoLine extends CommonObjectLine
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string|array $filter       	Filter array. Example array('field'=>'valueforlike', 'customurl'=>...)
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =
 	 * @param  string      	$filtermode   	Filter mode (AND or OR)
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -931,7 +931,7 @@ class Mo extends CommonObject
 			if (!empty($fk_movement)) {
 				// The fk_movement was not recorded so we try to guess the product and quantity to restore.
 				$moline = new MoLine($this->db);
-				$TArrayMoLine = $moline->fetchAll('', '', 1, 0, '(fk_stock_movement:=:'.((int) $fk_movement).')');
+				$TArrayMoLine = $moline->fetchAll('', '', 1, 0, ['uss' => '(fk_stock_movement:=:'.((int) $fk_movement).')']);
 				$moline = array_shift($TArrayMoLine);
 
 				$movement = new MouvementStock($this->db);
@@ -1637,7 +1637,7 @@ class Mo extends CommonObject
 		if (!empty($rolefilter)) {
 			$filter .= " AND (role:=:'".$this->db->escape($rolefilter)."')";
 		}
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, $filter);
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => $filter]);
 
 		if (is_numeric($result)) {
 			$this->error = $objectline->error;

--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -495,7 +495,11 @@ class Mo extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$records = array();
 
@@ -510,6 +514,7 @@ class Mo extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/opensurvey/class/opensurveysondage.class.php
+++ b/htdocs/opensurvey/class/opensurveysondage.class.php
@@ -808,14 +808,19 @@ class Opensurveysondage extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/partnership/class/partnership.class.php
+++ b/htdocs/partnership/class/partnership.class.php
@@ -433,7 +433,11 @@ class Partnership extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$records = array();
 
@@ -448,6 +452,8 @@ class Partnership extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
+
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/partnership/class/partnership.class.php
+++ b/htdocs/partnership/class/partnership.class.php
@@ -421,13 +421,19 @@ class Partnership extends CommonObject
 	 * @param  string      		$sortfield    	Sort field
 	 * @param  int         		$limit        	Limit
 	 * @param  int         		$offset       	Offset page
-	 * @param  string|array     $filter       	Filter USF.
+	 * @param  array			$filter       	Filter as an Universal Search string.
+	 * 											Example: $filter['uss'] =
 	 * @param  string      		$filtermode   	Filter mode (AND or OR)
 	 * @return array|int                 		int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/partnership/class/partnership.class.php
+++ b/htdocs/partnership/class/partnership.class.php
@@ -1190,7 +1190,7 @@ class Partnership extends CommonObject
 		$this->lines = array();
 
 		$objectline = new PartnershipLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_partnership:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_partnership:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->error = $objectline->error;

--- a/htdocs/partnership/class/partnership_type.class.php
+++ b/htdocs/partnership/class/partnership_type.class.php
@@ -152,16 +152,21 @@ class PartnershipType extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		global $conf;
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1078,7 +1078,7 @@ if (empty($reshook)) {
 
 				$filter = array('t.fk_product' => $object->id, 't.fk_soc' => $soc->id);
 
-				$result = $prodcustprice->fetchAll('', '', 0, 0, $filter);
+				$result = $prodcustprice->fetchAll('', '', 0, 0, ['uss' => $filter]);
 				if ($result) {
 					if (count($prodcustprice->lines) > 0) {
 						$pu_ht = price($prodcustprice->lines [0]->price);

--- a/htdocs/product/class/productcustomerprice.class.php
+++ b/htdocs/product/class/productcustomerprice.class.php
@@ -442,6 +442,7 @@ class ProductCustomerPrice extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {
 					if (strpos($key, 'date')) {				// To allow $filter['YEAR(s.dated)']=>$year

--- a/htdocs/product/class/productcustomerprice.class.php
+++ b/htdocs/product/class/productcustomerprice.class.php
@@ -383,12 +383,19 @@ class ProductCustomerPrice extends CommonObject
 	 * @param 	string 			$sortfield 	Sort field
 	 * @param 	int 			$limit 		Limit page
 	 * @param 	int 			$offset 	offset
-	 * @param 	string|array 	$filter 	Filter USF.
+	 * @param  array			$filter     Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =
 	 * @return 	int 						Return integer <0 if KO, >0 if OK
 	 * @since dolibarr v17
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array())
 	{
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
+
 		if (empty($sortfield)) {
 			$sortfield = "t.rowid";
 		}

--- a/htdocs/product/class/productcustomerprice.class.php
+++ b/htdocs/product/class/productcustomerprice.class.php
@@ -394,7 +394,11 @@ class ProductCustomerPrice extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like 't.fk_product' => $prod->id
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		if (empty($sortfield)) {
 			$sortfield = "t.rowid";

--- a/htdocs/product/class/productfournisseurprice.class.php
+++ b/htdocs/product/class/productfournisseurprice.class.php
@@ -327,7 +327,11 @@ class ProductFournisseurPrice extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$records = array();
 
@@ -342,6 +346,7 @@ class ProductFournisseurPrice extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/product/class/productfournisseurprice.class.php
+++ b/htdocs/product/class/productfournisseurprice.class.php
@@ -315,13 +315,19 @@ class ProductFournisseurPrice extends CommonObject
 	 * @param  string      		$sortfield    	Sort field
 	 * @param  int         		$limit        	Limit
 	 * @param  int         		$offset       	Offset
-	 * @param  string|array     $filter       	Filter USF.
+	 * @param  array			$filter       	Filter as an Universal Search string.
+	 * 											Example: $filter['uss'] =
 	 * @param  string      		$filtermode   	Filter mode (AND or OR)
 	 * @return array|int                 		int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/product/stock/class/productstockentrepot.class.php
+++ b/htdocs/product/stock/class/productstockentrepot.class.php
@@ -235,13 +235,19 @@ class ProductStockEntrepot extends CommonObject
 	 * @param string 		$sortfield  	Sort field
 	 * @param int    		$limit      	Limit
 	 * @param int    		$offset     	Offset limit
-	 * @param string|array  $filter     	Filter USF.
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =
 	 * @param string 		$filtermode 	Filter mode (AND or OR)
 	 * @return int|array 					Return integer <0 if KO, array if OK
 	 */
-	public function fetchAll($fk_product = 0, $fk_entrepot = 0, $sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($fk_product = 0, $fk_entrepot = 0, $sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";

--- a/htdocs/product/stock/class/productstockentrepot.class.php
+++ b/htdocs/product/stock/class/productstockentrepot.class.php
@@ -247,7 +247,11 @@ class ProductStockEntrepot extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";
@@ -262,6 +266,7 @@ class ProductStockEntrepot extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
+++ b/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
@@ -414,14 +414,19 @@ class StockTransfer extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
+++ b/htdocs/product/stock/stocktransfer/class/stocktransfer.class.php
@@ -944,7 +944,7 @@ class StockTransfer extends CommonObject
 		$this->lines = array();
 
 		$objectline = new StockTransferLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'rang', 0, 0, "(fk_stocktransfer:=:".((int) $this->id).")");
+		$result = $objectline->fetchAll('ASC', 'rang', 0, 0, ['uss' => "(fk_stocktransfer:=:".((int) $this->id).")"]);
 
 		if (is_numeric($result)) {
 			$this->error = $objectline->error;

--- a/htdocs/product/stock/stocktransfer/class/stocktransferline.class.php
+++ b/htdocs/product/stock/stocktransfer/class/stocktransferline.class.php
@@ -299,14 +299,19 @@ class StockTransferLine extends CommonObjectLine
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =  '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/product/stock/stocktransfer/stocktransfer_card.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_card.php
@@ -200,7 +200,7 @@ if (empty($reshook)) {
 
 		if (empty($error)) {
 			$line = new StockTransferLine($db);
-			$records = $line->fetchAll('', '', 0, 0, '(fk_stocktransfer:=:'.((int) $id).') AND (fk_product:=:'.((int) $fk_product).') AND (fk_warehouse_source:=:'.((int) $fk_warehouse_source).') AND (fk_warehouse_destination:=:'.((int) $fk_warehouse_destination).') AND ('.(empty($batch) ? "(batch:=:'') OR (batch:IS:NULL)" : "batch:=:'".$db->escape($batch)."'").')');
+			$records = $line->fetchAll('', '', 0, 0, ['uss' => '(fk_stocktransfer:=:'.((int) $id).') AND (fk_product:=:'.((int) $fk_product).') AND (fk_warehouse_source:=:'.((int) $fk_warehouse_source).') AND (fk_warehouse_destination:=:'.((int) $fk_warehouse_destination).') AND ('.(empty($batch) ? "(batch:=:'') OR (batch:IS:NULL)" : "batch:=:'".$db->escape($batch)."'").')']);
 			if (!empty($records[key($records)])) {
 				$line = $records[key($records)];
 			}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -993,7 +993,7 @@ print '</tr>';
 if ($object->usage_organize_event) {
 	require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorboothattendee.class.php';
 	$conforboothattendee = new ConferenceOrBoothAttendee($db);
-	$result = $conforboothattendee->fetchAll('', '', 0, 0, '(t.fk_project:=:'.((int) $object->id).') AND (t.status:=:'.ConferenceOrBoothAttendee::STATUS_VALIDATED.')');
+	$result = $conforboothattendee->fetchAll('', '', 0, 0, ['uss' => '(t.fk_project:=:'.((int) $object->id).') AND (t.status:=:'.ConferenceOrBoothAttendee::STATUS_VALIDATED.')']);
 
 	if (!is_array($result) && $result < 0) {
 		setEventMessages($conforboothattendee->error, $conforboothattendee->errors, 'errors');

--- a/htdocs/public/bookcal/index.php
+++ b/htdocs/public/bookcal/index.php
@@ -427,7 +427,7 @@ if ($action == 'afteradd') {
 		// Load into an array all days with availabilities of the calendar for the current month $todayarray['mon'] and $todayarray['year']
 		$arrayofavailabledays = array();
 
-		$arrayofavailabilities = $availability->fetchAll('', '', 0, 0, '(status:=:1) AND (fk_bookcal_calendar:=:'.((int) $id).')');
+		$arrayofavailabilities = $availability->fetchAll('', '', 0, 0, ['uss' => '(status:=:1) AND (fk_bookcal_calendar:=:'.((int) $id).')']);
 		if ($arrayofavailabilities < 0) {
 			setEventMessages($availability->error, $availability->errors, 'errors');
 		} else {

--- a/htdocs/public/eventorganization/attendee_new.php
+++ b/htdocs/public/eventorganization/attendee_new.php
@@ -276,7 +276,7 @@ if (empty($reshook) && $action == 'add' && (!empty($conference->id) && $conferen
 		}
 
 		// Check if there is already an attendee into table eventorganization_conferenceorboothattendee for same event (or conference/booth)
-		$resultfetchconfattendee = $confattendee->fetchAll('', '', 0, 0, $filter);
+		$resultfetchconfattendee = $confattendee->fetchAll('', '', 0, 0, ['uss' => $filter]);
 
 		if (is_array($resultfetchconfattendee) && count($resultfetchconfattendee) > 0) {
 			// Found confattendee

--- a/htdocs/public/opensurvey/index.php
+++ b/htdocs/public/opensurvey/index.php
@@ -170,7 +170,7 @@ if (getDolGlobalString('OPENSURVEY_IMAGE_PUBLIC_INTERFACE')) {
 }
 
 
-$results = $object->fetchAll($sortorder, $sortfield, 0, 0, '(status:=:1)');
+$results = $object->fetchAll($sortorder, $sortfield, 0, 0, ['uss' => '(status:=:1)']);
 $now = dol_now();
 
 if (is_array($results)) {

--- a/htdocs/public/partnership/new.php
+++ b/htdocs/public/partnership/new.php
@@ -598,7 +598,7 @@ jQuery(document).ready(function () {
 
 // Type
 $partnershiptype = new PartnershipType($db);
-$listofpartnershipobj = $partnershiptype->fetchAll('', '', 1000, 0, '(active:=:1)');
+$listofpartnershipobj = $partnershiptype->fetchAll('', '', 1000, 0, ['uss' => '(active:=:1)']);
 $listofpartnership = array();
 foreach ($listofpartnershipobj as $partnershipobj) {
 	$listofpartnership[$partnershipobj->id] = $partnershipobj->label;

--- a/htdocs/public/recruitment/index.php
+++ b/htdocs/public/recruitment/index.php
@@ -171,7 +171,7 @@ if (getDolGlobalString('RECRUITMENT_IMAGE_PUBLIC_INTERFACE')) {
 }
 
 
-$results = $object->fetchAll($sortorder, $sortfield, 0, 0, '(status:=:1)');
+$results = $object->fetchAll($sortorder, $sortfield, 0, 0, ['uss' => '(status:=:1)']);
 $now = dol_now();
 
 if (is_array($results)) {

--- a/htdocs/reception/class/receptionlinebatch.class.php
+++ b/htdocs/reception/class/receptionlinebatch.class.php
@@ -668,13 +668,19 @@ class ReceptionLineBatch extends CommonObjectLine
 	 * @param string 		$sortfield 		Sort field
 	 * @param int    		$limit     		limit
 	 * @param int    		$offset    		offset limit
-	 * @param string|array  $filter    		filter array
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =
 	 * @param string 		$filtermode 	filter mode (AND or OR)
 	 * @return 								int Return integer <0 if KO, >0 if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";

--- a/htdocs/reception/class/receptionlinebatch.class.php
+++ b/htdocs/reception/class/receptionlinebatch.class.php
@@ -680,7 +680,11 @@ class ReceptionLineBatch extends CommonObjectLine
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$sql = "SELECT";
 		$sql .= " t.rowid,";
@@ -701,6 +705,7 @@ class ReceptionLineBatch extends CommonObjectLine
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/recruitment/class/recruitmentcandidature.class.php
+++ b/htdocs/recruitment/class/recruitmentcandidature.class.php
@@ -353,14 +353,19 @@ class RecruitmentCandidature extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/recruitment/class/recruitmentcandidature.class.php
+++ b/htdocs/recruitment/class/recruitmentcandidature.class.php
@@ -912,7 +912,7 @@ class RecruitmentCandidature extends CommonObject
 		$this->lines = array();
 
 		$objectline = new RecruitmentCandidatureLine($this->db);
-		$result = $objectline->fetchAll('ASC', 'position', 0, 0, '(fk_recruitmentcandidature:=:'.((int) $this->id).')');
+		$result = $objectline->fetchAll('ASC', 'position', 0, 0, ['uss' => '(fk_recruitmentcandidature:=:'.((int) $this->id).')']);
 
 		if (is_numeric($result)) {
 			$this->error = $objectline->error;

--- a/htdocs/recruitment/class/recruitmentjobposition.class.php
+++ b/htdocs/recruitment/class/recruitmentjobposition.class.php
@@ -380,14 +380,19 @@ class RecruitmentJobPosition extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =  '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/resource/class/dolresource.class.php
+++ b/htdocs/resource/class/dolresource.class.php
@@ -615,7 +615,11 @@ class Dolresource extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 		$extrafields = new ExtraFields($this->db);
@@ -651,6 +655,7 @@ class Dolresource extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			foreach ($filter as $key => $value) {
 				if (strpos($key, 'date')) {
 					$sql .= " AND ".$this->db->sanitize($key)." = '".$this->db->idate($value)."'";

--- a/htdocs/resource/class/dolresource.class.php
+++ b/htdocs/resource/class/dolresource.class.php
@@ -605,11 +605,18 @@ class Dolresource extends CommonObject
 	 * @param	string			$sortfield		Sort field
 	 * @param	int				$limit			Limit page
 	 * @param	int				$offset			Offset page
-	 * @param	string|array	$filter			Filter USF.
+	 * @param	array			$filter       	Filter as an Universal Search string.
+	 * 											Example: $filter['uss'] =
 	 * @return	int								If KO: <0 || if OK number of lines loaded
 	 */
-	public function fetchAll(string $sortorder, string $sortfield, int $limit, int $offset, $filter = '')
+	public function fetchAll(string $sortorder, string $sortfield, int $limit, int $offset, array $filter = array())
 	{
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
+
 		require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 		$extrafields = new ExtraFields($this->db);
 

--- a/htdocs/ticket/class/cticketcategory.class.php
+++ b/htdocs/ticket/class/cticketcategory.class.php
@@ -351,14 +351,19 @@ class CTicketCategory extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -798,12 +798,18 @@ class Ticket extends CommonObject
 	 * @param  int    		$limit     	Limit
 	 * @param  int    		$offset    	Offset page
 	 * @param  int    		$arch      	Archive or not (not used)
-	 * @param  string|array $filter    	Filter for query
+	 * @param  array		$filter    	Filter as an Universal Search string.
+	 * 									Example: $filter['uss'] =
 	 * @return int 						Return integer <0 if KO, >0 if OK
 	 */
-	public function fetchAll($user, $sortorder = 'ASC', $sortfield = 't.datec', $limit = 0, $offset = 0, $arch = 0, $filter = '')
+	public function fetchAll($user, $sortorder = 'ASC', $sortfield = 't.datec', $limit = 0, $offset = 0, $arch = 0, array $filter = array())
 	{
 		global $langs, $extrafields;
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		// fetch optionals attributes and labels
 		$extrafields->fetch_name_optionals_label($this->table_element);

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -867,6 +867,7 @@ class Ticket extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			foreach ($filter as $key => $value) {
 				if (strpos($key, 'date')) { // To allow $filter['YEAR(s.dated)']=>$year
 					$sql .= " AND ".$this->db->sanitize($key)." = '".$this->db->escape($value)."'";

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -809,7 +809,11 @@ class Ticket extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like 't.fk_contract' => $this->id
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		// fetch optionals attributes and labels
 		$extrafields->fetch_name_optionals_label($this->table_element);

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -4086,15 +4086,20 @@ class User extends CommonObject
 	 *  @param	string		$sortfield		sort field
 	 *  @param	int			$limit			limit page
 	 *  @param	int			$offset			page
-	 * 	@param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * 	@param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] =  '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * 	@param  string      $filtermode   	No more used
 	 *  @param  bool        $entityfilter	Activate entity filter
 	 *  @return int							Return integer <0 if KO, >0 if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND', $entityfilter = false)
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND', $entityfilter = false)
 	{
 		global $conf, $user;
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$sql = "SELECT t.rowid";
 		$sql .= ' FROM '.$this->db->prefix().$this->table_element.' as t ';

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -726,7 +726,7 @@ class User extends CommonObject
 			require_once DOL_DOCUMENT_ROOT.'/core/class/defaultvalues.class.php';
 
 			$defaultValues = new DefaultValues($this->db);
-			$result = $defaultValues->fetchAll('', '', 0, 0, '(t.user_id:in:0,'.$this->id.') AND (entity:in:'.(isset($this->entity) ? $this->entity : $conf->entity).','.$conf->entity.')');	// User 0 (all) + me (if defined)
+			$result = $defaultValues->fetchAll('', '', 0, 0, ['uss' => '(t.user_id:in:0,'.$this->id.') AND (entity:in:'.(isset($this->entity) ? $this->entity : $conf->entity).','.$conf->entity.')']);	// User 0 (all) + me (if defined)
 			//$result = $defaultValues->fetchAll('', '', 0, 0, array('t.user_id'=>array(0, $this->id), 'entity'=>array((isset($this->entity) ? $this->entity : $conf->entity), $conf->entity)));	// User 0 (all) + me (if defined)
 
 			if (!is_array($result) && $result < 0) {

--- a/htdocs/webhook/class/target.class.php
+++ b/htdocs/webhook/class/target.class.php
@@ -388,14 +388,19 @@ class Target extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/website/class/website.class.php
+++ b/htdocs/website/class/website.class.php
@@ -377,13 +377,19 @@ class Website extends CommonObject
 	 * @param 	string 			$sortfield 		Sort field
 	 * @param 	int    			$limit     		limit
 	 * @param 	int    			$offset    		offset limit
-	 * @param 	string|array	$filter    		filter array
+	 * @param	array			$filter       	Filter as an Universal Search string.
+	 * 											Example: $filter['uss'] =
 	 * @param 	string 			$filtermode 	filter mode (AND or OR)
 	 * @return 	array|int       	          	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/website/class/website.class.php
+++ b/htdocs/website/class/website.class.php
@@ -389,7 +389,11 @@ class Website extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$records = array();
 
@@ -412,6 +416,7 @@ class Website extends CommonObject
 
 		// Manage filter
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 			if (count($filter) > 0) {
 				foreach ($filter as $key => $value) {

--- a/htdocs/website/class/websitepage.class.php
+++ b/htdocs/website/class/websitepage.class.php
@@ -368,14 +368,19 @@ class WebsitePage extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string|array	$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return WebSitePage[]|int<-1,-1>    	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($websiteid, $sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($websiteid, $sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/website/class/websitepage.class.php
+++ b/htdocs/website/class/websitepage.class.php
@@ -380,7 +380,11 @@ class WebsitePage extends CommonObject
 		if (isset($filter['customsql'])) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
 		}
-		$filter = $filter['uss'] ?? "";
+		//some part of dolibarr main code use $filter as array like $filter['t.xxxx'] =
+		//then we use "universal search string only if exists"
+		if (isset($filter['uss'])) {
+			$filter = $filter['uss'];
+		}
 
 		$records = array();
 
@@ -414,6 +418,7 @@ class WebsitePage extends CommonObject
 
 		// Deprecated. If we receive an array, we use it. Prefer using the USF syntax.
 		if (is_array($filter)) {
+			dol_syslog(__METHOD__ . "Using deprecated filter with old array data, please update to Universal Search string syntax", LOG_NOTICE);
 			$sqlwhere = array();
 
 			if (count($filter) > 0) {

--- a/htdocs/workstation/class/workstation.class.php
+++ b/htdocs/workstation/class/workstation.class.php
@@ -414,14 +414,19 @@ class Workstation extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit        	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 

--- a/htdocs/zapier/class/hook.class.php
+++ b/htdocs/zapier/class/hook.class.php
@@ -386,16 +386,21 @@ class Hook extends CommonObject
 	 * @param  string      	$sortfield    	Sort field
 	 * @param  int         	$limit       	limit
 	 * @param  int         	$offset       	Offset
-	 * @param  string		$filter       	Filter as an Universal Search string.
-	 * 										Example: '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
+	 * @param  array		$filter       	Filter as an Universal Search string.
+	 * 										Example: $filter['uss'] = '((client:=:1) OR ((client:>=:2) AND (client:<=:3))) AND (client:!=:8) AND (nom:like:'a%')'
 	 * @param  string      	$filtermode   	No more used
 	 * @return array|int                 	int <0 if KO, array of pages if OK
 	 */
-	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, $filter = '', $filtermode = 'AND')
+	public function fetchAll($sortorder = '', $sortfield = '', $limit = 0, $offset = 0, array $filter = array(), $filtermode = 'AND')
 	{
 		global $conf;
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		if (isset($filter['customsql'])) {
+			trigger_error(__CLASS__ .'::'.__FUNCTION__.' customsql in filter is now forbidden, please use $filter["uss"]="xx:yy:zz" with Universal Search String instead', E_USER_ERROR);
+		}
+		$filter = $filter['uss'] ?? "";
 
 		$records = array();
 


### PR DESCRIPTION
There is a major code break in dolibarr 20.0 with a incredible function signature change ... fetchAll switch from array to string argument for $filter which cause major breaks into all dolibarr ecosystem

That PR is a work in progress to open exchanges about that problem and don't waist my time if you refuse that PR but please consider it.

The original change was done without PR and with no review.

This PR is a solution which cause no break down with all other tools.

More details on french forum if needed: https://www.dolibarr.fr/forum/t/question-ouverte-sur-le-dev-du-coeur-de-dolibarr/46868