### PR TITLE
FIX: Always re-instantiate object when doing mass PDF generation

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1183,7 +1183,7 @@ if (!$error && $massaction == 'generate_doc' && $permissiontoread) {
 				$nbok++;
 			}
 
-            unset($objecttmp);
+			unset($objecttmp);
 		} else {
 			setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
 			$error++;

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1133,9 +1133,9 @@ if (!$error && ($massaction == 'delete' || ($action == 'delete' && $confirm == '
 // @todo : propose model selection
 if (!$error && $massaction == 'generate_doc' && $permissiontoread) {
 	$db->begin();
-	$objecttmp = new $objectclass($db);
 	$nbok = 0;
 	foreach ($toselect as $toselectid) {
+		$objecttmp = new $objectclass($db);
 		$result = $objecttmp->fetch($toselectid);
 		if ($result > 0) {
 			$outputlangs = $langs;

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1182,6 +1182,8 @@ if (!$error && $massaction == 'generate_doc' && $permissiontoread) {
 			} else {
 				$nbok++;
 			}
+
+            unset($objecttmp);
 		} else {
 			setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
 			$error++;


### PR DESCRIPTION
Sometime when mass generating PDFs some strange bugs can happen because the object being rendered as PDF are not always "clean".

For example this happen in supplier invoice because in the method fetch (https://github.com/Dolibarr/dolibarr/blob/2f351ae4dc80c5e899333be26a633f5e1c67843f/htdocs/fourn/class/fournisseur.facture.class.php#L863C9-L863C24) we only reset "basic" properties and not the **thirdparty** property. Therefore if a module use the **thirdparty** magic property and does not reload it manually by calling **fetch_thirdparty** then we may end up with information from the first generated invoice where the thirdparty was initially loaded.

I think it would be cleaner to just reallocate the object each time before the PDF generation occurs to ensure up-to-date information. The impact caused by reallocating the object every-time in the loop would be less problematic than the current situation.

What do you think?