### PR TITLE
fix: hidden option MAIN_KEEP_REF_CUSTOMER_ON_CLONING always win on pr…

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1415,7 +1415,9 @@ class Propal extends CommonObject
 			}
 
 			// reset ref_client
-			$object->ref_client = '';
+			if (empty($conf->global->MAIN_KEEP_REF_CUSTOMER_ON_CLONING)) {
+				$object->ref_client = '';
+			}
 
 			// TODO Change product price if multi-prices
 		} else {

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1415,7 +1415,7 @@ class Propal extends CommonObject
 			}
 
 			// reset ref_client
-			if (empty($conf->global->MAIN_KEEP_REF_CUSTOMER_ON_CLONING)) {
+			if (!getDolGlobalString('MAIN_KEEP_REF_CUSTOMER_ON_CLONING')) {
 				$object->ref_client = '';
 			}
 


### PR DESCRIPTION
There is an hidden option MAIN_KEEP_REF_CUSTOMER_ON_CLONING
when cloning a propal, if this option is set, even if it's a clone for another customer the hidden option must be used