### PR TITLE
FIX backport Conflict with autoload to 18.0

### DIFF
--- a/htdocs/includes/restler/framework/Luracast/Restler/AutoLoader.php
+++ b/htdocs/includes/restler/framework/Luracast/Restler/AutoLoader.php
@@ -268,8 +268,8 @@ namespace Luracast\Restler {
 				return $this->loadThisLoader($className, $loader);
 			}
 			foreach ($loaders as $loader)
-			if (false !== $file = $this->loadThisLoader($className, $loader))
-				return $file;
+				if (false !== $file = $this->loadThisLoader($className, $loader))
+					return $file;
 
 			return false;
 		}
@@ -286,22 +286,51 @@ namespace Luracast\Restler {
 		private function loadThisLoader($className, $loader)
 		{
 			if (is_array($loader)
+				&& is_callable($loader)) {
+					$b = new $loader[0];
+					//avoid PHP Fatal error:  Uncaught Error: Access to undeclared static property: Composer\\Autoload\\ClassLoader::$loader
+					//in case of multiple autoloader systems
+					if (property_exists($b, $loader[1])) {
+						if (false !== $file = $b::$loader[1]($className)
+							&& $this->exists($className, $b::$loader[1])) {
+								return $file;
+							}
+					}
+				} elseif (is_callable($loader)
+					&& false !== $file = $loader($className)
+					&& $this->exists($className, $loader)) {
+						return $file;
+				}
+				return false;
+
+			/* other code tested to reduce autoload conflict
+			$s = '';
+			if (is_array($loader)
 			&& is_callable($loader)) {
+				// @CHANGE DOL avoid autoload conflict
+				if (!preg_match('/LuraCast/', get_class($loader[0]))) {
+					return false;
+				}
 				$b = new $loader[0];
-				//avoid PHP Fatal error:  Uncaught Error: Access to undeclared static property: Composer\\Autoload\\ClassLoader::$loader
+				// @CHANGE DOL avoid PHP Fatal error:  Uncaught Error: Access to undeclared static property: Composer\\Autoload\\ClassLoader::$loader
 				//in case of multiple autoloader systems
 				if (property_exists($b, $loader[1])) {
 					if (false !== $file = $b::$loader[1]($className)
-					&& $this->exists($className, $b::$loader[1])) {
-						return $file;
-					}
+						&& $this->exists($className, $b::$loader[1])) {
+							return $file;
+						}
 				}
-			} elseif (is_callable($loader)
-			&& false !== $file = $loader($className)
-				&& $this->exists($className, $loader)) {
-				return $file;
+			} elseif (is_callable($loader, false, $s)) {
+				// @CHANGE DOL avoid PHP infinite loop (detected when xdebug is on)
+				if ($s == 'Luracast\Restler\AutoLoader::__invoke') {
+					return false;
+				}
+				if (false !== ($file = $loader($className)) && $this->exists($className, $loader)) {
+					return $file;
+				}
 			}
 			return false;
+			*/
 		}
 
 		/**
@@ -417,7 +446,7 @@ namespace Luracast\Restler {
 			if (false !== $includeReference = $this->discover($className))
 			return $includeReference;
 
-			static::thereCanBeOnlyOne();
+			//static::thereCanBeOnlyOne();
 
 			if (false !== $includeReference = $this->loadAliases($className))
 			return $includeReference;
@@ -426,7 +455,7 @@ namespace Luracast\Restler {
 			return $includeReference;
 
 			if (false !== $includeReference = $this->loadLastResort($className))
-			return $includeReference;
+				return $includeReference;
 
 			static::seen($className, true);
 			return null;


### PR DESCRIPTION
Backport the fix of Restler autoload conflict to the 18.0
[original commit](https://github.com/Dolibarr/dolibarr/commit/0dcc75318bda2466f83da360d02062a3702a3b15)

## The problem
When using the API, if a module use composer is invoked, this will enter an infinite loop in the `AutoLoader.php`.
This can be a module API including its composer or a hook of a module using composer.

## To test this

### Module API example
1. Add a module that's use composer inside it's API file
2. Query the explorer
3. Wait for the API JSON fetch to fail

### Hook example
1. Add a module that's use composer and add a hook used by an API path (example FacturX)
4. Query an API path that's invoke the hook at some point (with FacturX its `POST /invoices/{id}/payment`)
5. Wait for PHP to run out of memory or timeout (if Xdebug is enabled it will stop and say it's an infinite loop)

## Remaining questions
I got some environments without the infinite loop, I wasn't able to find why
