### PR TITLE
Fix regression of #30398

### DIFF
--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -2215,7 +2215,7 @@ class BonPrelevement extends CommonObject
 			$XML_DEBITOR .= '					<FinInstnId>' . $CrLf;
 			if (getDolGlobalInt('WITHDRAWAL_WITHOUT_BIC')==0) {
 				$XML_DEBITOR .= '						<BIC>' . $row_bic . '</BIC>' . $CrLf;
-			}	
+			}
 			$XML_DEBITOR .= '					</FinInstnId>' . $CrLf;
 			$XML_DEBITOR .= '				</DbtrAgt>' . $CrLf;
 			$XML_DEBITOR .= '				<Dbtr>' . $CrLf;

--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -2211,13 +2211,13 @@ class BonPrelevement extends CommonObject
 			$XML_DEBITOR .= '						<AmdmntInd>false</AmdmntInd>' . $CrLf;
 			$XML_DEBITOR .= '					</MndtRltdInf>' . $CrLf;
 			$XML_DEBITOR .= '				</DrctDbtTx>' . $CrLf;
+			$XML_DEBITOR .= '				<DbtrAgt>' . $CrLf;
+			$XML_DEBITOR .= '					<FinInstnId>' . $CrLf;
 			if (getDolGlobalInt('WITHDRAWAL_WITHOUT_BIC')==0) {
-				$XML_DEBITOR .= '				<DbtrAgt>' . $CrLf;
-				$XML_DEBITOR .= '					<FinInstnId>' . $CrLf;
 				$XML_DEBITOR .= '						<BIC>' . $row_bic . '</BIC>' . $CrLf;
-				$XML_DEBITOR .= '					</FinInstnId>' . $CrLf;
-				$XML_DEBITOR .= '				</DbtrAgt>' . $CrLf;
-			}
+			}	
+			$XML_DEBITOR .= '					</FinInstnId>' . $CrLf;
+			$XML_DEBITOR .= '				</DbtrAgt>' . $CrLf;
 			$XML_DEBITOR .= '				<Dbtr>' . $CrLf;
 			$XML_DEBITOR .= '					<Nm>' . dolEscapeXML(strtoupper(dol_string_nospecial(dol_string_unaccent($row_nom), ' '))) . '</Nm>' . $CrLf;
 			$XML_DEBITOR .= '					<PstlAdr>' . $CrLf;


### PR DESCRIPTION
If no BIC is provided, only the BIC line must be omitted, not the surrounding block, even if it is empty.

