### PR TITLE
Update 19.0.0-20.0.0.sql

### DIFF
--- a/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
+++ b/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
@@ -407,6 +407,6 @@ UPDATE llx_c_units SET short_label = 'mn' WHERE short_label = 'i' AND code = 'MI
 
 -- missing entity field
 ALTER TABLE llx_c_holiday_types DROP INDEX uk_c_holiday_types;
-ALTER TABLE llx_socpeople ADD COLUMN entity	integer DEFAULT 1 NOT NULL AFTER rowid;
+ALTER TABLE llx_c_holiday_types ADD COLUMN entity	integer DEFAULT 1 NOT NULL AFTER rowid;
 ALTER TABLE llx_c_holiday_types ADD UNIQUE INDEX uk_c_holiday_types (entity, code);
 


### PR DESCRIPTION
table name error => index llx_c_holiday_types not created with  Erreur DB_ERROR_1072 (Req 265): ALTER TABLE llx_c_holiday_types ADD UNIQUE INDEX uk_c_holiday_types (entity, code); Key column 'entity' doesn't exist in table