### PR TITLE
FIX project: contact type for project creator

### DIFF
--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -132,6 +132,7 @@ AlsoCloseAProjectTooltip=Keep it open if you still need to follow production tas
 ReOpenAProject=Open project
 ConfirmReOpenAProject=Are you sure you want to re-open this project?
 ProjectContact=Contacts of project
+ProjectContactTypeManager=Contact type of project manager
 TaskContact=Task contacts
 ActionsOnProject=Events on project
 YouAreNotContactOfProject=You are not a contact of this private project

--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -237,11 +237,11 @@ if (empty($reshook)) {
 
 			$result = $object->create($user);
 			if (!$error && $result > 0) {
-				// Add myself as project leader
-				$typeofcontact = 'PROJECTLEADER';
+				// Add myself as Owner Contact Selected in the form
+				$typeofcontact = GETPOST('typeofcontact');
 				$result = $object->add_contact($user->id, $typeofcontact, 'internal');
 
-				// -3 means type not found (PROJECTLEADER renamed, de-activated or deleted), so don't prevent creation if it has been the case
+				// -3 means type not found (renamed, de-activated or deleted), so don't prevent creation if it has been the case
 				if ($result == -3) {
 					setEventMessage('ErrorPROJECTLEADERRoleMissingRestoreIt', 'errors');
 					$error++;
@@ -850,6 +850,14 @@ if ($action == 'create' && $user->hasRight('projet', 'creer')) {
 		print img_picto('', 'category', 'class="pictofixedwidth"').$form->multiselectarray('categories', $cate_arbo, $arrayselected, '', 0, 'quatrevingtpercent widthcentpercentminusx', 0, 0);
 		print "</td></tr>";
 	}
+
+	// Selection of Owner contact type
+	print '<tr><td class="tdtop">'.$langs->trans("ProjectContactTypeManager").'</td>';
+	print '<td>';
+	$contactList = $object->liste_type_contact('internal', 'position', 1);
+	$owner_contact = GETPOST('typeofcontact') ? GETPOST('owner_contact') : 'PROJECTLEADER';
+	print $form->selectarray('typeofcontact', $contactList, $owner_contact, 0, 0, 0, '', 0, 0, 0, '', '', 1);
+	print '</td></tr>';
 
 	// Other options
 	$parameters = array();


### PR DESCRIPTION
# FIX project: ability to select contact type for project creator

Currently, when we create a project, the user who creates it is automatically assigned as a contact with type "PROJECTLEADER".

In this PR, I make sure that the user can choose their type with a default selection of "PROJECTLEADER"