### PR TITLE
htdocs/conf/.htaccess should use apache 2.4 syntax

### DIFF
--- a/htdocs/conf/.htaccess
+++ b/htdocs/conf/.htaccess
@@ -1,2 +1,1 @@
-Order deny,allow
-Deny from all
+Require host localhost


### PR DESCRIPTION
# NEW|New [*htdocs/conf/.htaccess should use apache 2.4 syntax*]
[*most modern OS already use apache 2.4 and the mixing of 2.2 and 2.4 syntax is known to cause problems.So, just use 2.4 syntax here*]
