### PR TITLE
Bad variable used in updateExtrafield when used by categories

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7045,9 +7045,9 @@ abstract class CommonObject
 			//var_dump('linealreadyfound='.$linealreadyfound.' sql='.$sql); exit;
 			if ($linealreadyfound) {
 				if ($this->array_options["options_".$key] === null) {
-					$sql = "UPDATE ".$this->db->prefix().$this->table_element."_extrafields SET ".$key." = null";
+					$sql = "UPDATE ".$this->db->prefix().$table_element."_extrafields SET ".$key." = null";
 				} else {
-					$sql = "UPDATE ".$this->db->prefix().$this->table_element."_extrafields SET ".$key." = '".$this->db->escape($new_array_options["options_".$key])."'";
+					$sql = "UPDATE ".$this->db->prefix().$table_element."_extrafields SET ".$key." = '".$this->db->escape($new_array_options["options_".$key])."'";
 				}
 				$sql .= " WHERE fk_object = ".((int) $this->id);
 


### PR DESCRIPTION
At line 7031 to 7034, there is a buffer variables to store the table_element and modify the value if $this->table_element is categorie.
A line 7036, this variable is used :
`SELECT COUNT(rowid) as nb FROM ".$this->db->prefix().$table_element."_extrafields WHERE fk_object = ".((int) $this->id)
`

But at lines 7048 and 7050, the $this->table_element is used. 

So when you modify a extrafield on a category, you have those message:
```
sql=UPDATE llx_categorie_extrafields SET syncmagento_category_needupdate = null WHERE fk_object = 1714
DoliDBMysqli::query Exception in query instead of returning an error: Table '2cvp.llx_categorie_extrafields' doesn't exist
DoliDBMysqli::query SQL Error message: DB_ERROR_NOSUCHTABLE Table '2cvp.llx_categorie_extrafields' doesn't exist

```

