### PR TITLE
Fix #30447 Mysql error sorting contract services

### DIFF
--- a/htdocs/contrat/services_list.php
+++ b/htdocs/contrat/services_list.php
@@ -78,7 +78,7 @@ $contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'co
 $opouvertureprevuemonth = GETPOST('opouvertureprevuemonth');
 $opouvertureprevueday = GETPOST('opouvertureprevueday');
 $opouvertureprevueyear = GETPOST('opouvertureprevueyear');
-$filter_opouvertureprevue = GETPOST('filter_opouvertureprevue','alphalgt');
+$filter_opouvertureprevue = GETPOST('filter_opouvertureprevue', 'alphalgt');
 
 $op1month = GETPOST('op1month', 'int');
 $op1day = GETPOST('op1day', 'int');

--- a/htdocs/contrat/services_list.php
+++ b/htdocs/contrat/services_list.php
@@ -78,22 +78,22 @@ $contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'co
 $opouvertureprevuemonth = GETPOST('opouvertureprevuemonth');
 $opouvertureprevueday = GETPOST('opouvertureprevueday');
 $opouvertureprevueyear = GETPOST('opouvertureprevueyear');
-$filter_opouvertureprevue = GETPOST('filter_opouvertureprevue');
+$filter_opouvertureprevue = GETPOST('filter_opouvertureprevue','alphalgt');
 
 $op1month = GETPOST('op1month', 'int');
 $op1day = GETPOST('op1day', 'int');
 $op1year = GETPOST('op1year', 'int');
-$filter_op1 = GETPOST('filter_op1', 'alpha');
+$filter_op1 = GETPOST('filter_op1', 'alphalgt');
 
 $op2month = GETPOST('op2month', 'int');
 $op2day = GETPOST('op2day', 'int');
 $op2year = GETPOST('op2year', 'int');
-$filter_op2 = GETPOST('filter_op2', 'alpha');
+$filter_op2 = GETPOST('filter_op2', 'alphalgt');
 
 $opcloturemonth = GETPOST('opcloturemonth', 'int');
 $opclotureday = GETPOST('opclotureday', 'int');
 $opclotureyear = GETPOST('opclotureyear', 'int');
-$filter_opcloture = GETPOST('filter_opcloture', 'alpha');
+$filter_opcloture = GETPOST('filter_opcloture', 'alphalgt');
 
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context


### PR DESCRIPTION
Step to reproduce:

- Fill one of the date filters on contrat/service_list.php 
- Click on search button
- Sort by any other column then date filters
This create a mysql error

To prevent this we use 'alphalgt' on getpost to prevent spaces around the value in **filter_opouvertureprevue** for exemple to be removed a create an error.