### PR TITLE
fix: load missing translation for extrafields in PDF

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1472,6 +1472,9 @@ abstract class CommonDocGenerator
 				$field = new stdClass();
 				$field->rank = intval($extrafields->attributes[$object->table_element]['pos'][$key]);
 				$field->content = $this->getExtrafieldContent($object, $key, $outputlangs);
+				if (isset($extrafields->attributes[$object->table_element]['langfile'][$key])) {
+					$outputlangs->load($extrafields->attributes[$object->table_element]['langfile'][$key]);
+				}
 				$field->label = $outputlangs->transnoentities($label);
 				$field->type = $extrafields->attributes[$object->table_element]['type'][$key];
 


### PR DESCRIPTION

--> How to reproduce
In a module monmondule
Create propaldet line extrafield with 
 - type : text
 - label : TransKeyExtraLabel 
 - visiblity: 1 
 - visilibity on PDF to 3 or 4
 - lang file monmodule@monmodule
 
Add a translation in monmodule/langs/xx_xx/monmodule.lang for
TransKeyExtraLabel=Information complémentaire

Create a propal, add a line, fill the extrafield with "some text"


Current : 
in PDF cyan line content is

**TransKeyExtraLabel** : some text

Wanted 

**Information complémentaire** : some text