### PR TITLE
Fix Wrong header Errors-To

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -687,7 +687,7 @@ class CMailFile
 
 			if (!empty($this->errors_to)) {
 				try {
-					$headers->addTextHeader('Errors-To', $this->getArrayAddress($this->errors_to));
+					$headers->addMailboxHeader('Errors-To', $this->getArrayAddress($this->errors_to));
 				} catch (Exception $e) {
 					$this->errors[] = $e->getMessage();
 				}


### PR DESCRIPTION
### FIX
In Dolibar v19.0.2
```
PHP Fatal error:  Uncaught TypeError: preg_split(): Argument #2 ($subject) must be of type string, array given in /htdocs/includes/swiftmailer/lib/classes/Swift/Mime/Headers/AbstractHeader.php:312
```