### PR TITLE
FIX virtual stock if const SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK is…

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5293,7 +5293,7 @@ class Product extends CommonObject
 		}
 		if (((!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || !empty($conf->supplier_order->enabled) || !empty($conf->supplier_invoice->enabled)) && empty($conf->reception->enabled)) {
 			// Case module reception is not used
-			$filterStatus = '4';
+			$filterStatus = empty($conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK) ? '4' : $conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK;
 			if (isset($includedraftpoforvirtual)) {
 				$filterStatus = '0,'.$filterStatus;
 			}
@@ -5305,7 +5305,7 @@ class Product extends CommonObject
 		}
 		if (((!empty($conf->fournisseur->enabled) && empty($conf->global->MAIN_USE_NEW_SUPPLIERMOD)) || !empty($conf->supplier_order->enabled) || !empty($conf->supplier_invoice->enabled)) && !empty($conf->reception->enabled)) {
 			// Case module reception is used
-			$filterStatus = '4';
+			$filterStatus = empty($conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK) ? '4' : $conf->global->SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK;
 			if (isset($includedraftpoforvirtual)) {
 				$filterStatus = '0,'.$filterStatus;
 			}


### PR DESCRIPTION
When using SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK const, the function load_virtual_stock (in product.class.php) has to used this CONST to calculate correctly the virtual stock.
Today the default value used is 4 for supplier orders or invoice. 
This has to be changed by using SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK
