### PR TITLE
FIX#30491 token not set to launch cron task manually

### DIFF
--- a/htdocs/cron/list.php
+++ b/htdocs/cron/list.php
@@ -731,7 +731,7 @@ if ($num > 0) {
 		}
 		if ($user->hasRight('cron', 'execute')) {
 			if (!empty($obj->status)) {
-				print '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?id='.$obj->rowid.'&action=execute';
+				print '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?id='.$obj->rowid.'&action=execute&token='.newToken();
 				print(!getDolGlobalString('CRON_KEY') ? '' : '&securitykey=' . getDolGlobalString('CRON_KEY'));
 				print($sortfield ? '&sortfield='.$sortfield : '');
 				print($sortorder ? '&sortorder='.$sortorder : '');


### PR DESCRIPTION
add token into link to launch cron task manually (before pop up to confirm the execution) 
