### PR TITLE
FIX #30520 Creator user data displayed in the form after an error in the user creation form

### DIFF
--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -75,7 +75,7 @@ $group = GETPOSTINT("group", 3);
 $cancel		= GETPOST('cancel', 'alpha');
 $contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'useracard'; // To manage different context of search
 
-if (empty($id) && $action != 'create') {
+if (empty($id) && $action != 'add' && $action != 'create') {
 	$id = $user->id;
 }
 


### PR DESCRIPTION
# FIX #30520 Creator user data displayed in the form after an error in the user creation form
