### PR TITLE
FIX: on change ref for bank account attachement are lost

### DIFF
--- a/htdocs/compta/bank/card.php
+++ b/htdocs/compta/bank/card.php
@@ -221,7 +221,7 @@ if (empty($reshook)) {
 		$object = new Account($db);
 		$object->fetch(GETPOST("id", 'int'));
 
-		$object->oldref=$object->ref;
+		$object->oldref = $object->ref;
 		$object->ref = dol_string_nospecial(trim(GETPOST('ref', 'alpha')));
 		$object->label = trim(GETPOST("label", 'alphanohtml'));
 		$object->courant = GETPOST("type");

--- a/htdocs/compta/bank/card.php
+++ b/htdocs/compta/bank/card.php
@@ -80,7 +80,6 @@ if (GETPOST("id", 'int') || GETPOST("ref")) {
 
 $result = restrictedArea($user, 'banque', $id, 'bank_account&bank_account', '', '', $fieldid);
 
-
 /*
  * Actions
  */
@@ -222,6 +221,7 @@ if (empty($reshook)) {
 		$object = new Account($db);
 		$object->fetch(GETPOST("id", 'int'));
 
+		$object->oldref=$object->ref;
 		$object->ref = dol_string_nospecial(trim(GETPOST('ref', 'alpha')));
 		$object->label = trim(GETPOST("label", 'alphanohtml'));
 		$object->courant = GETPOST("type");

--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -911,7 +911,7 @@ class Account extends CommonObject
 					$this->error = $this->db->lasterror();
 				}
 
-				// We rename directory ($this->ref = old ref, $num = new ref) in order not to lose the attachments
+				// We rename directory in order not to lose the attachments
 				$oldref = dol_sanitizeFileName($this->oldref);
 				$newref = dol_sanitizeFileName($this->ref);
 				$dirsource = $conf->bank->dir_output.'/'.$oldref;

--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -903,6 +903,14 @@ class Account extends CommonObject
 			}
 
 			if (!$error && !empty($this->oldref) && $this->oldref !== $this->ref) {
+				$sql = 'UPDATE '.MAIN_DB_PREFIX."ecm_files set filepath = 'bank/".$this->db->escape($this->ref)."'";
+				$sql .= " WHERE filepath = 'bank/".$this->db->escape($this->oldref)."' and src_object_type='bank_account' and entity = ".((int) $conf->entity);
+				$resql = $this->db->query($sql);
+				if (!$resql) {
+					$error++;
+					$this->error = $this->db->lasterror();
+				}
+
 				// We rename directory ($this->ref = old ref, $num = new ref) in order not to lose the attachments
 				$oldref = dol_sanitizeFileName($this->oldref);
 				$newref = dol_sanitizeFileName($this->ref);
@@ -912,8 +920,6 @@ class Account extends CommonObject
 					dol_syslog(get_class($this)."::update rename dir ".$dirsource." into ".$dirdest, LOG_DEBUG);
 					if (@rename($dirsource, $dirdest)) {
 						dol_syslog("Rename ok", LOG_DEBUG);
-					} else {
-						$error++;
 					}
 				}
 			}


### PR DESCRIPTION
When banck account change ref, the attachement folder is not rename so attachement are lost