### PR TITLE
Qual: Phan: Exclude htdocs/core/mymodule seen in cti.dolibarr.org

### DIFF
--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -317,6 +317,8 @@ return [
 	//'exclude_file_regex' => '@^vendor/.*/(tests?|Tests?)/@',
 	'exclude_file_regex' => '@^('  // @phpstan-ignore-line
 		.'dummy'  // @phpstan-ignore-line
+		// mymodule seen in cti, but not in git.
+		.'|htdocs/core/mymodule/.*'  // @phpstan-ignore-line
 		.'|htdocs/.*/canvas/.*/tpl/.*.tpl.php'  // @phpstan-ignore-line
 		.'|htdocs/modulebuilder/template/.*'  // @phpstan-ignore-line
 		// Included as stub (better analysis)
@@ -346,9 +348,9 @@ return [
 		'/^sanitizeVal$/' => [1, $sanitizeRegex,"UnknownSanitizeType"],
 		'/^checkVal$/' => [1, $sanitizeRegex,"UnknownCheckValSanitizeType"],
 		'/^\\\\ExtraFields::addExtraField$/' => [2, $extraFieldTypeRegex,"UnknownExtrafieldTypeBack"],
-		'/^dol_now$/' => [0, '{^(?:auto|gmt|tz(?:server|ref|user(?:rel)?))$}',"InvalidDolNowArgument"],  // '', 0, 1 match bool and int values
+		'/^dol_now$/' => [0, '{^(?:auto|gmt|tz(?:server|ref|user(?:rel)?))$}',"InvalidDolNowArgument"],
 		'/^dol_mktime$/' => [6, '{^(?:|0|1|auto|gmt|tz(?:server|ref|user(?:rel)?|,[+a-zA-Z-/]+))$}',"InvalidDolMktimeArgument"],  // '', 0, 1 match bool and int values
-		'/^dol_print_date$/' => [2, '{^(?:|0|1|auto|gmt|tz(?:server|user(?:rel)?))$}',"InvalidDolMktimeArgument"],
+		'/^dol_print_date$/' => [2, '{^(?:|0|1|auto|gmt|tz(?:server|user(?:rel)?))$}',"InvalidDolMktimeArgument"],  // '', 0, 1 match bool and int values
 		'/^GETPOSTFLOAT$/' => [1, '{^(?:|M[UTS]|C[UT]|\d+)$}',"InvalidGetPostFloatRounding"],
 		'/^price2num$/' => [1, '{^(?:|M[UTS]|C[UT]|\d+)$}',"InvalidPrice2NumRounding"],
 	],


### PR DESCRIPTION
# Qual: Phan: Exclude htdocs/core/mymodule seen in cti.dolibarr.org

`htdocs/core/mymodule` has notices on https://cti.dolibarr.org but it is not seen in git.

It would be a good idea to generate a module and include it in the static analysis on cti, but `htdocs/core/mymodule` is not up-to-date.

If such a generation is done, a better name could be used. For instance `generatedmymoduleforcti`.