### PR TITLE
FIX fatal error on loading pictures in attached documents of an event

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -841,9 +841,6 @@ class ActionComm extends CommonObject
 				$this->type_color = $obj->type_color;
 				$this->type_picto = $obj->type_picto;
 				$this->type       = $obj->type_type;
-				/*$transcode = $langs->trans("Action".$obj->type_code);
-				$this->type       = (($transcode != "Action".$obj->type_code) ? $transcode : $obj->type_label); */
-				$transcode = $langs->trans("Action".$obj->type_code.'Short');
 
 				$this->code = $obj->code;
 				$this->label = $obj->label;


### PR DESCRIPTION
FIX fatal error on loading pictures in attached documents of an event
- a fatal error occurs when the source file of the picture is loading
- the variable "langs" is not set and you got the fatal error : "Call to a member function trans() on null"
- so the picture is not loaded

**Before**
- attach a picture on an event and you won't see the preview of it :
![image](https://github.com/user-attachments/assets/84201ad8-4028-4858-b35c-143acd147620)


**After**
- you see again the preview of the picture : 
![image](https://github.com/user-attachments/assets/3d8bbb5e-94a2-47eb-86fd-5991a93ef5b0)

I removed the comment lines and the unused local variable "transcode"
