### PR TITLE
FIX show and download attached files on ticket card

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1356,6 +1356,12 @@ class FormFile
 			$i = 0;
 			$nboflines = 0;
 			$lastrowid = 0;
+			$parametersByDefault = array(
+				'modulepart'=> $modulepart,
+				'relativepath'=> $relativepath,
+				'permtoedit' => $permtoeditline,
+				'permonobject' => $permonobject,
+			);
 			foreach ($filearray as $key => $file) {      // filearray must be only files here
 				if ($file['name'] != '.' && $file['name'] != '..' && !preg_match('/\.meta$/i', $file['name'])) {
 					if (array_key_exists('rowid', $filearray[$key]) && $filearray[$key]['rowid'] > 0) {
@@ -1363,8 +1369,13 @@ class FormFile
 					}
 					//var_dump($filearray[$key]);
 
-					// Note: for supplier invoice, $modulepart may be already 'facture_fournisseur' and $relativepath may be already '6/1/SI2210-0013/'
+					// get specific parameters from file attributes if set or get default ones
+					$modulepart = ($file['modulepart'] ?? $parametersByDefault['modulepart']);
+					$relativepath = ($file['relativepath'] ?? $parametersByDefault['relativepath']);
+					$permtoeditline = ($file['permtoedit'] ?? $parametersByDefault['permtoedit']);
+					$permonobject = ($file['permonobject'] ?? $parametersByDefault['permonobject']);
 
+					// Note: for supplier invoice, $modulepart may be already 'facture_fournisseur' and $relativepath may be already '6/1/SI2210-0013/'
 					if (empty($relativepath) || empty($modulepart)) {
 						$filepath = $file['level1name'].'/'.$file['name'];
 					} else {

--- a/htdocs/ticket/document.php
+++ b/htdocs/ticket/document.php
@@ -222,6 +222,13 @@ if ($object->id) {
 			$upload_msg_dir = $conf->agenda->dir_output.'/'.$db->fetch_row($resql)[0];
 			$file_msg = dol_dir_list($upload_msg_dir, "files", 0, '', '\.meta$', $sortfield, (strtolower($sortorder) == 'desc' ? SORT_DESC : SORT_ASC), 1);
 			if (count($file_msg)) {
+				// add specific module part and user rights for delete
+				foreach ($file_msg as $key => $file) {
+					$file_msg[$key]['modulepart'] = 'actions';
+					$file_msg[$key]['relativepath'] = $file['level1name'].'/'; // directory without file name
+					$file_msg[$key]['permtoedit'] = 0;
+					$file_msg[$key]['permonobject'] = 0;
+				}
 				$file_msg_array = array_merge($file_msg, $file_msg_array);
 			}
 		}


### PR DESCRIPTION
FIX show and download attached files on ticket card

**To reproduce**
- go on the ticket card and add a message private message or send an email with an attached file.
- you got the error message : "The file doesn't exist" when you want to preview of download the file from "document" card

Futhermore, edit and delete files doesn't work due to the wrong module part passed into list of documents method.
The module part is "actions" for the attached files in a message sent by mail.
The module part "ticket" is correct when you join a file from the ticket card.

**The fix**
SoI decided to set more information in files array : 
- modulepart
- relativepath
- permtoedit
- permonobject
In the case of an attached file in an event, the module part is "actions" (not "ticket") and I prevent the user from edit / delete theses files directly from the ticket card. He can do it from the linked event.

**Test**
I also tested the attached files in public interface and it works fine for me.
And a test was also realized on attached files on supplier invoice card with specific relative path. 
