### PR TITLE
fix: add missing fetch_optionals() call on OrderLine fetch method

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4376,6 +4376,8 @@ class OrderLine extends CommonOrderLine
 			$this->multicurrency_total_tva	= $objp->multicurrency_total_tva;
 			$this->multicurrency_total_ttc	= $objp->multicurrency_total_ttc;
 
+			$this->fetch_optionals();
+
 			$this->db->free($result);
 
 			return 1;


### PR DESCRIPTION
like all other "line" class, the fetch method have to call the fetch_optionals to populate extrafields