### PR TITLE
FIX: edit extrafield tpl card adherent is not correct

### DIFF
--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -1423,7 +1423,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 		print '</td></tr>';
 
 		// Other attributes. Fields from hook formObjectOptions and Extrafields.
-		include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_add.tpl.php';
+		include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_edit.tpl.php';
 
 		print '</table>';
 		print dol_get_fiche_end();


### PR DESCRIPTION
fix: edit extrafield tpl card adherent is not correct

Bug description
Create an extrafield "test" for member with visibility 4 (not on created form but available for update and list)
Create a member : extrafield is not displayed  : OK
member list : extrafield is available  : OK
Edit member :  extrafield is **not** displayed  : **KO**