### PR TITLE
NEW API call to re-generate a users password.

### DIFF
--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -472,7 +472,7 @@ class Users extends DolibarrApi
 		// I do not like that the first parameter has to be an empty string :-()
 		// in user/card.php it is called like this setPassword($user, '')
 		// and my development server does not actually send email, so I can't really test this
-		$newpassword = $this->useraccount->setPassword($user, '');	// This will generate a new password
+		$newpassword = $this->useraccount->setPassword(global $user, '');	// This will generate a new password
 		if (is_int($newpassword) && $newpassword < 0) {
 			throw new RestException(520, 'ErrorFailedToSetNewPassword'.$this->useraccount->error);
 		} else {
@@ -480,7 +480,7 @@ class Users extends DolibarrApi
 			if ($send_password) {
 				// I do not like that the first parameter has to be an empty string :-(
 				// in user/card.php it is called like this send_password($user, $newpassword)
-				if ($this->useraccount->send_password($user, $newpassword) > 0) {
+				if ($this->useraccount->send_password(global $user, $newpassword) > 0) {
 					return 2;
 				} else {
 					throw new RestException(530, 'ErrorFailedSendingNewPassword'.$this->useraccount->error);

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -447,6 +447,7 @@ class Users extends DolibarrApi
 	public function setPassword($id, $send_password = 0, $entity = 1)
 	{
 		global $conf;
+		global $user;
 
 		if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'creer') && empty(DolibarrApiAccess::$user->admin)) {
 			throw new RestException(403, "setPassword on user not allowed");
@@ -472,7 +473,7 @@ class Users extends DolibarrApi
 		// I do not like that the first parameter has to be an empty string :-()
 		// in user/card.php it is called like this setPassword($user, '')
 		// and my development server does not actually send email, so I can't really test this
-		$newpassword = $this->useraccount->setPassword(global $user, '');	// This will generate a new password
+		$newpassword = $this->useraccount->setPassword($user, '');	// This will generate a new password
 		if (is_int($newpassword) && $newpassword < 0) {
 			throw new RestException(520, 'ErrorFailedToSetNewPassword'.$this->useraccount->error);
 		} else {
@@ -480,7 +481,7 @@ class Users extends DolibarrApi
 			if ($send_password) {
 				// I do not like that the first parameter has to be an empty string :-(
 				// in user/card.php it is called like this send_password($user, $newpassword)
-				if ($this->useraccount->send_password(global $user, $newpassword) > 0) {
+				if ($this->useraccount->send_password($user, $newpassword) > 0) {
 					return 2;
 				} else {
 					throw new RestException(530, 'ErrorFailedSendingNewPassword'.$this->useraccount->error);

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -434,7 +434,7 @@ class Users extends DolibarrApi
 	 * Update a users password
 	 *
 	 * @param   int     $id        User ID
-	 * @param	int		$send_password		Set this to 1 to have thenew password sent to the user
+	 * @param	bool	$send_password		Only if set to true, the new password will send to the user
 	 * @param   int     $entity    Entity ID (valid only for superadmin in multicompany transverse mode)
 	 * @return  int                1 if password changed, 2 if password changed and sent
 	 *
@@ -444,10 +444,9 @@ class Users extends DolibarrApi
 	 *
 	 * @url	GET {id}/setPassword
 	 */
-	public function setPassword($id, $send_password = 0, $entity = 1)
+	public function setPassword($id, $send_password = FALSE, $entity = 1)
 	{
 		global $conf;
-		global $user;
 
 		if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'creer') && empty(DolibarrApiAccess::$user->admin)) {
 			throw new RestException(403, "setPassword on user not allowed");
@@ -470,13 +469,13 @@ class Users extends DolibarrApi
 			$entity = (DolibarrApiAccess::$user->entity > 0 ? DolibarrApiAccess::$user->entity : $conf->entity);
 		}
 
-		$newpassword = $this->useraccount->setPassword($user, '');	// This will generate a new password
+		$newpassword = $this->useraccount->setPassword($this->useraccount, '');	// This will generate a new password
 		if (is_int($newpassword) && $newpassword < 0) {
 			throw new RestException(500, 'ErrorFailedToSetNewPassword'.$this->useraccount->error);
 		} else {
 			// Success
 			if ($send_password) {
-				if ($this->useraccount->send_password($user, $newpassword) > 0) {
+				if ($this->useraccount->send_password($this->useraccount, $newpassword) > 0) {
 					return 2;
 				} else {
 					throw new RestException(500, 'ErrorFailedSendingNewPassword'.$this->useraccount->error);

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -470,18 +470,13 @@ class Users extends DolibarrApi
 			$entity = (DolibarrApiAccess::$user->entity > 0 ? DolibarrApiAccess::$user->entity : $conf->entity);
 		}
 
-		// I do not like that the first parameter has to be an empty string :-()
-		// in user/card.php it is called like this setPassword($user, '')
-		// and my development server does not actually send email, so I can't really test this
 		$newpassword = $this->useraccount->setPassword($user, '');	// This will generate a new password
 		if (is_int($newpassword) && $newpassword < 0) {
 			throw new RestException(500, 'ErrorFailedToSetNewPassword'.$this->useraccount->error);
 		} else {
 			// Success
 			if ($send_password) {
-				// I do not like that the first parameter has to be an empty string :-(
-				// in user/card.php it is called like this send_password($user, $newpassword)
-				if ($this->useraccount->send_password( $user, $newpassword) > 0) {
+				if ($this->useraccount->send_password($user, $newpassword) > 0) {
 					return 2;
 				} else {
 					throw new RestException(500, 'ErrorFailedSendingNewPassword'.$this->useraccount->error);

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -435,6 +435,7 @@ class Users extends DolibarrApi
 	 *
 	 * @param   int     $id        User ID
 	 * @param	int		$send_password		Set this to 1 to have thenew password sent to the user
+	 * @param   int     $entity    Entity ID (valid only for superadmin in multicompany transverse mode)
 	 * @return  int                1 if password changed, 2 if password changed and sent
 	 *
 	 * @throws RestException 403 Not allowed

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -472,7 +472,7 @@ class Users extends DolibarrApi
 		// I do not like that the first parameter has to be an empty string :-()
 		// in user/card.php it is called like this setPassword($user, '')
 		// and my development server does not actually send email, so I can't really test this
-		$newpassword = $this->useraccount->setPassword('', '');	// This will generate a new password
+		$newpassword = $this->useraccount->setPassword($user, '');	// This will generate a new password
 		if (is_int($newpassword) && $newpassword < 0) {
 			throw new RestException(520, 'ErrorFailedToSetNewPassword'.$this->useraccount->error);
 		} else {
@@ -480,7 +480,7 @@ class Users extends DolibarrApi
 			if ($send_password) {
 				// I do not like that the first parameter has to be an empty string :-(
 				// in user/card.php it is called like this send_password($user, $newpassword)
-				if ($this->useraccount->send_password('', $newpassword) > 0) {
+				if ($this->useraccount->send_password($user, $newpassword) > 0) {
 					return 2;
 				} else {
 					throw new RestException(530, 'ErrorFailedSendingNewPassword'.$this->useraccount->error);

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -444,7 +444,7 @@ class Users extends DolibarrApi
 	 *
 	 * @url	GET {id}/setPassword
 	 */
-	public function setPassword($id, $send_password = FALSE, $entity = 1)
+	public function setPassword($id, $send_password = false, $entity = 1)
 	{
 		global $conf;
 

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -475,16 +475,16 @@ class Users extends DolibarrApi
 		// and my development server does not actually send email, so I can't really test this
 		$newpassword = $this->useraccount->setPassword($user, '');	// This will generate a new password
 		if (is_int($newpassword) && $newpassword < 0) {
-			throw new RestException(520, 'ErrorFailedToSetNewPassword'.$this->useraccount->error);
+			throw new RestException(500, 'ErrorFailedToSetNewPassword'.$this->useraccount->error);
 		} else {
 			// Success
 			if ($send_password) {
 				// I do not like that the first parameter has to be an empty string :-(
 				// in user/card.php it is called like this send_password($user, $newpassword)
-				if ($this->useraccount->send_password($user, $newpassword) > 0) {
+				if ($this->useraccount->send_password( $user, $newpassword) > 0) {
 					return 2;
 				} else {
-					throw new RestException(530, 'ErrorFailedSendingNewPassword'.$this->useraccount->error);
+					throw new RestException(500, 'ErrorFailedSendingNewPassword'.$this->useraccount->error);
 				}
 			} else {
 				return 1;


### PR DESCRIPTION
# NEW API call to re-generate a users password 
Adds a API endpoint GET /users/{user}/setPassword with option for sending the new password to user.
Partial fix of #30482.