### PR TITLE
restored value __REF__

### DIFF
--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -85,10 +85,8 @@ if ($action == 'presend') {
 	}
 
 	$topicmail = '';
-	if (empty($object->ref_client)) {
+	if (!empty($object->ref)) {
 		$topicmail = $outputlangs->trans($defaulttopic, '__REF__');
-	} elseif (!empty($object->ref_client)) {
-		$topicmail = $outputlangs->trans($defaulttopic, '__REF__ (__REF_CLIENT__)');
 	}
 
 	// Build document if it not exists


### PR DESCRIPTION
# Instructions
FIX To restore the value of the __REF__ key, the user can still use __REF_CLIENT__ in an email template.