### PR TITLE
Qual: Ignore htdocs/custom/mymodule in cti/apstats

### DIFF
--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -318,7 +318,7 @@ return [
 	'exclude_file_regex' => '@^('  // @phpstan-ignore-line
 		.'dummy'  // @phpstan-ignore-line
 		// mymodule seen in cti, but not in git.
-		.'|htdocs/core/mymodule/.*'  // @phpstan-ignore-line
+		.'|htdocs/custom/mymodule/.*'  // @phpstan-ignore-line
 		.'|htdocs/.*/canvas/.*/tpl/.*.tpl.php'  // @phpstan-ignore-line
 		.'|htdocs/modulebuilder/template/.*'  // @phpstan-ignore-line
 		// Included as stub (better analysis)


### PR DESCRIPTION
# Qual: Ignore htdocs/custom/mymodule in cti/apstats

Fix #30551 where '../core/...' was added instead of '.../custom/...'.