### PR TITLE
Qual: Correct typing hint for category type in setAsCategory.

### DIFF
--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -1479,8 +1479,8 @@ class FormSetupItem
 	 * Set type of input as a category selector
 	 * TODO add default value
 	 *
-	 * @param	int		$catType		Type of category ('customer', 'supplier', 'contact', 'product', 'member'). Old mode (0, 1, 2, ...) is deprecated.
-	 * @return self
+	 * @param	string	$catType		Type of category ('customer', 'supplier', 'contact', 'product', 'member'). Old mode (0, 1, 2, ...) is deprecated.
+	 * @return	self
 	 */
 	public function setAsCategory($catType)
 	{


### PR DESCRIPTION
# Qual: Correct typing hint for category type in setAsCategory

Type hint was int which is deprecated, so setting type hint to string which will help detect deprecated uses and not flag the correct uses