### PR TITLE
FIX: prevent crash for 0% rate loans on adding custom payments

### DIFF
--- a/htdocs/loan/class/loanschedule.class.php
+++ b/htdocs/loan/class/loanschedule.class.php
@@ -419,8 +419,12 @@ class LoanSchedule extends CommonObject
 	{
 		$result = '';
 
-		if (!empty($capital) && !empty($rate) && !empty($nbterm)) {
-			$result = ($capital * ($rate / 12)) / (1 - pow((1 + ($rate / 12)), ($nbterm * -1)));
+		if (!empty($capital) && !empty($nbterm)) {
+			if (!empty($rate)) {
+				$result = ($capital * ($rate / 12)) / (1 - pow((1 + ($rate / 12)), ($nbterm * -1)));
+			} else {
+				$result = $capital / $nbterm;
+			}
 		}
 
 		return $result;


### PR DESCRIPTION

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #30657
Adding payments for loans with 0% rate crashed. This change will add support for loans with 0% rate to fix the crash.

