### PR TITLE
chore: tell about delivery objecttype tabs

### DIFF
--- a/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
+++ b/htdocs/modulebuilder/template/core/modules/modMyModule.class.php
@@ -185,6 +185,7 @@ class modMyModule extends DolibarrModules
 		// 'categories_x'	  to add a tab in category view (replace 'x' by type of category (0=product, 1=supplier, 2=customer, 3=member)
 		// 'contact'          to add a tab in contact view
 		// 'contract'         to add a tab in contract view
+		// 'delivery'         to add a tab in delivery view
 		// 'group'            to add a tab in group view
 		// 'intervention'     to add a tab in intervention view
 		// 'invoice'          to add a tab in customer invoice view


### PR DESCRIPTION
I just needed to lookup the code to add a tab for `delivery` view, so I added it to the comment.

This probably should also be reflected on https://wiki.dolibarr.org/index.php?title=Tabs_system?!