### PR TITLE
fix: VAT is already calculted if not post

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -1647,14 +1647,6 @@ if (empty($reshook)) {
 
 				$ref_supplier = $productsupplier->ref_supplier;
 
-				$tva_tx = get_default_tva($object->thirdparty, $mysoc, $productsupplier->id, GETPOST('idprodfournprice', 'alpha'));
-				$tva_npr = get_default_npr($object->thirdparty, $mysoc, $productsupplier->id, GETPOST('idprodfournprice', 'alpha'));
-				if (empty($tva_tx)) {
-					$tva_npr = 0;
-				}
-				$localtax1_tx = get_localtax($tva_tx, 1, $mysoc, $object->thirdparty, $tva_npr);
-				$localtax2_tx = get_localtax($tva_tx, 2, $mysoc, $object->thirdparty, $tva_npr);
-
 				if (empty($pu)) {
 					$pu = 0; // If pu is '' or null, we force to have a numeric value
 				}


### PR DESCRIPTION
On supplier Invoice, from france to france, select a product or service, TVA select is set to 20%, if you change the default vat from 20% to 10 %,  add line => it's set to 20% on the added line.

It should keep the 10% VAT

the $tva_tx is actually set twice.

One time correctly
https://github.com/Dolibarr/dolibarr/blob/892d9cc8658e0868fef6b75c5aebc63689143399/htdocs/fourn/facture/card.php#L1618

and just after force again without control
I remove the last part as it's already done L1618

