### PR TITLE
Fix : SQL order on extrafields type chkbxlst (multiselectarray)

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1512,6 +1512,8 @@ class ExtraFields
 					// print $sql;
 
 					$sql .= $sqlwhere;
+					$sql .= ' ORDER BY '.implode(', ', $fields_label);
+
 					dol_syslog(get_class($this).'::showInputField type=chkbxlst', LOG_DEBUG);
 					$resql = $this->db->query($sql);
 					if ($resql) {


### PR DESCRIPTION

On create view extrafields type chkbxlst (multiselectarray) is filter by id 
![image](https://github.com/user-attachments/assets/f108f9e8-97b5-4aa7-b51a-c867b23ec414)

On view extrafields type chkbxlst (multiselectarray) is filter by label
![image](https://github.com/user-attachments/assets/4bf8e415-64a2-4f9b-b16f-383653a4582e)

Extrafields configuration
![image](https://github.com/user-attachments/assets/482836da-71da-413a-9b9c-55fcf66754b0)


