### PR TITLE
FIX : attached file on first page load

### DIFF
--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -264,7 +264,7 @@ class modTicket extends DolibarrModules
 			'type' => 'left',
 			'titre' => 'NewTicket',
 			'mainmenu' => 'ticket',
-			'url' => '/ticket/card.php?action=create',
+			'url' => '/ticket/card.php?action=create&mode=init',
 			'langs' => 'ticket',
 			'position' => 102,
 			'enabled' => 'isModEnabled("ticket")',

--- a/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
+++ b/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
@@ -220,3 +220,5 @@ UPDATE llx_c_type_contact SET element = 'stocktransfer' WHERE element = 'StockTr
 UPDATE llx_c_units SET scale = 1 WHERE code = 'S';
 
 UPDATE llx_c_tva SET taux = 3, note = 'Νήσων υπερμειωμένος Φ.Π.Α.' WHERE fk_pays = 102 AND taux = 16;
+
+UPDATE llx_menu SET url = CONCAT(url, '&mode=init') WHERE fk_mainmenu = 'ticket' AND titre = 'NewTicket'AND url LIKE '/ticket/card.php?action=create%';

--- a/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
+++ b/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
@@ -221,4 +221,4 @@ UPDATE llx_c_units SET scale = 1 WHERE code = 'S';
 
 UPDATE llx_c_tva SET taux = 3, note = 'Νήσων υπερμειωμένος Φ.Π.Α.' WHERE fk_pays = 102 AND taux = 16;
 
-UPDATE llx_menu SET url = CONCAT(url, '&mode=init') WHERE fk_mainmenu = 'ticket' AND titre = 'NewTicket'AND url LIKE '/ticket/card.php?action=create%';
+UPDATE llx_menu SET url = CONCAT(url, '&mode=init') WHERE fk_mainmenu = 'ticket' AND titre = 'NewTicket' AND url LIKE '/ticket/card.php?action=create%' AND url NOT LIKE '%mode=init%';

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -738,7 +738,21 @@ llxHeader('', $title, $help_url);
 
 if ($action == 'create' || $action == 'presend') {
 	$formticket = new FormTicket($db);
+	if (!GETPOSTISSET('token')){
+		// we are on create mode for the first time
+		//  we need to remove any attached files in session
+		if (!empty($_SESSION["listofpaths"])) {
+			unset($_SESSION["listofpaths"]);
+		}
 
+		if (!empty($_SESSION["listofnames"])) {
+			unset($_SESSION["listofnames"]);
+		}
+
+		if (!empty($_SESSION["listofmimes"])) {
+			unset($_SESSION["listofmimes"]);
+		}
+	}
 	print load_fiche_titre($langs->trans('NewTicket'), '', 'ticket');
 
 	$formticket->trackid = '';		// TODO Use a unique key 'tic' to avoid conflict in upload file feature

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -738,21 +738,7 @@ llxHeader('', $title, $help_url);
 
 if ($action == 'create' || $action == 'presend') {
 	$formticket = new FormTicket($db);
-	if (!GETPOSTISSET('token')) {
-		// we are on create mode for the first time
-		//  we need to remove any attached files in session
-		if (!empty($_SESSION["listofpaths"])) {
-			unset($_SESSION["listofpaths"]);
-		}
 
-		if (!empty($_SESSION["listofnames"])) {
-			unset($_SESSION["listofnames"]);
-		}
-
-		if (!empty($_SESSION["listofmimes"])) {
-			unset($_SESSION["listofmimes"]);
-		}
-	}
 	print load_fiche_titre($langs->trans('NewTicket'), '', 'ticket');
 
 	$formticket->trackid = '';		// TODO Use a unique key 'tic' to avoid conflict in upload file feature
@@ -769,6 +755,10 @@ if ($action == 'create' || $action == 'presend') {
 
 	$formticket->withcancel = 1;
 
+	// Init list of files
+	if (GETPOST("mode", "aZ09") == 'init') {
+		$formticket->clear_attached_files();
+	}
 	$formticket->showForm(1, 'create', 0, null, $action);
 	/*} elseif ($action == 'edit' && $user->rights->ticket->write && $object->status < Ticket::STATUS_CLOSED) {
 	$formticket = new FormTicket($db);

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -738,7 +738,7 @@ llxHeader('', $title, $help_url);
 
 if ($action == 'create' || $action == 'presend') {
 	$formticket = new FormTicket($db);
-	if (!GETPOSTISSET('token')){
+	if (!GETPOSTISSET('token')) {
 		// we are on create mode for the first time
 		//  we need to remove any attached files in session
 		if (!empty($_SESSION["listofpaths"])) {


### PR DESCRIPTION
## Bug Description

When creating a new ticket, if the user adds an attachment without creating the ticket, leaves the page, and then returns to the ticket creation page, the previously added attachment is still present. This behavior is undesirable as it can lead to confusion for the user and potentially result in the addition of irrelevant attachments to a new ticket.

## Proposed Solution

To resolve this issue, we will check if the page is loaded for the first time by testing for the presence of a token in the $_POST. If this is the case, we will clean up the temporary attachments associated with the user's session.
