### PR TITLE
Fix #30695

### DIFF
--- a/htdocs/admin/system/security.php
+++ b/htdocs/admin/system/security.php
@@ -149,7 +149,7 @@ print "<br>\n";
 $todisabletext = '';
 $i = 0;
 foreach ($arrayoffunctionstodisable as $functiontodisable) {
-	if (! in_array($functiontodisable, $arrayoffunctionsdisabled)) {
+	if (\function_exists($functiontodisable)) {
 		if ($i > 0) {
 			$todisabletext .= ', ';
 		}
@@ -164,7 +164,7 @@ if ($todisabletext) {
 $todisabletext = '';
 $i = 0;
 foreach ($arrayoffunctionstodisable2 as $functiontodisable) {
-	if (! in_array($functiontodisable, $arrayoffunctionsdisabled)) {
+	if (\function_exists($functiontodisable)) {
 		if ($i > 0) {
 			$todisabletext .= ', ';
 		}
@@ -176,8 +176,7 @@ if ($todisabletext) {
 	print img_picto('', 'warning', 'class="pictofixedwidth"').$langs->trans("IfCLINotRequiredYouShouldDisablePHPFunctions").': '.$todisabletext;
 	print '<br>';
 }
-
-if (in_array($functiontokeep, $arrayoffunctionsdisabled)) {
+if (!\function_exists($functiontokeep)) {
 	print img_picto($langs->trans("PHPFunctionsRequiredForCLI"), 'warning', 'class="pictofixedwidth"');
 } else {
 	print img_picto('', 'tick', 'class="pictofixedwidth"');


### PR DESCRIPTION
# FIX #30695
To avoid incorrect detection of disabled php functions, we use php native `function_exists`.

