### PR TITLE
fix: expedition set Draft do not reset display

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -163,6 +163,9 @@ if (empty($reshook)) {
 		$result = $object->setDraft($user, 0);
 		if ($result < 0) {
 			setEventMessages($object->error, $object->errors, 'errors');
+		} else {
+			header("Location: ".$_SERVER['PHP_SELF']."?id=".$object->id);
+			exit;
 		}
 	}
 	// Reopen
@@ -171,6 +174,9 @@ if (empty($reshook)) {
 		$result = $object->reOpen();
 		if ($result < 0) {
 			setEventMessages($object->error, $object->errors, 'errors');
+		} else {
+			header("Location: ".$_SERVER['PHP_SELF']."?id=".$object->id);
+			exit;
 		}
 	}
 


### PR DESCRIPTION
> How to reproduce Bug

Create a shipment from an Order
Validate a shipment
Click on Set To Draft ("Retour en brouillon")

Page is reloaded but status display is still Validate.

> Expected result

Page is reloaded and status is draft (as it is in DB).

