### PR TITLE
Fix creation of individual function when CONTACTS_DEFAULT_ROLES is not defined

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1117,7 +1117,9 @@ class Societe extends CommonObject
 		$contact->town              = $this->town;
 		$this->setUpperOrLowerCase();
 		$contact->phone_pro         = $this->phone;
-		$contact->roles				= explode(',', getDolGlobalString('CONTACTS_DEFAULT_ROLES'));
+		if (getDolGlobalString('CONTACTS_DEFAULT_ROLES')) {
+			$contact->roles			= explode(',', getDolGlobalString('CONTACTS_DEFAULT_ROLES'));
+		}
 
 		$contactId = $contact->create($user, $notrigger);
 		if ($contactId < 0) {


### PR DESCRIPTION
# Fix
This PR fixes the issue where not defined CONTACTS_DEFAULT_ROLES causes an error because $contact->roles is null


