### PR TITLE
Qual: Fix caching for windows workflow

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -65,8 +65,8 @@ jobs:
           # See https://github.com/actions/cache/issues/1275#issuecomment-1925217178
           enableCrossOsArchive: true 
           path: |
-            db_init.sql
-            db_init.sql.md5
+            ./db_init.sql
+            ./db_init.sql.md5
           key: ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ env.CACHE_KEY_PART
             }}-${{ github.run_id }}
           restore-keys: |
@@ -183,4 +183,6 @@ jobs:
           # See https://github.com/actions/cache/issues/1275#issuecomment-1925217178
           enableCrossOsArchive: true 
           key: ${{ steps.cache.outputs.cache-primary-key }}
-          path: db_init.*
+          path: |
+            ./db_init.sql
+            ./db_init.sql.md5

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -61,19 +61,22 @@ jobs:
       - name: Restore cache
         id: cache
         uses: actions/cache/restore@v4
+        env:
+          HASH: ${{ hashFiles('htdocs/install/**') }}
+          KEY_ROOT: ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}
         with:
           # See https://github.com/actions/cache/issues/1275#issuecomment-1925217178
           enableCrossOsArchive: true 
           path: |
             ./db_init.sql
             ./db_init.sql.md5
-          key: ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ env.CACHE_KEY_PART
-            }}-${{ github.run_id }}
+          key: ${{ env.KEY_ROOT }}-${{ env.HASH }}-${{ env.CACHE_KEY_PART }}-${{ github.run_id }}
           restore-keys: |
-            ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ env.CACHE_KEY_PART }}-
-            ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ github.head_ref }}-
-            ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-${{ github.base_ref }}-
-            ${{ matrix.os }}-${{ env.ckey }}-${{ matrix.php_version }}-
+            ${{ env.KEY_ROOT }}-${{ env.HASH }}-${{ env.CACHE_KEY_PART }}-
+            ${{ env.KEY_ROOT }}-${{ env.HASH }}-${{ github.head_ref }}-
+            ${{ env.KEY_ROOT }}-${{ env.HASH }}-${{ github.base_ref }}-
+            ${{ env.KEY_ROOT }}-${{ env.HASH }}-
+            ${{ env.KEY_ROOT }}-
 
       - name: Create local php.ini with open_basedir restrictions
         shell: cmd


### PR DESCRIPTION
# Qual: Fix caching for windows workflow

actions/cache/v3 and v4 do not work on windows, but there are new suggestions to try to make it work.
The main approach is to prefix the cached paths with './' and have exactly the same content for 'path:'.
See https://github.com/actions/cache/issues/1361#issuecomment-2015044001

Success: the cache was successfully restored in this PR after pushing the rebased branch - about 4 minutes gained for the windows action!