### PR TITLE
#29026 [Form] fix: selectForForms issue for manage case where objectdesc don't need to reset

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8067,10 +8067,15 @@ class Form
 					}
 				} else {
 					// For a property in ->fields
-					if (array_key_exists($tmparray[1], $objectforfieldstmp->fields)) {
+					if (array_key_exists($tmparray[1], $objectforfieldstmp->fields) && preg_match('/^integer[^:]*:/', $objectforfieldstmp->fields[$tmparray[1]]['type'])) {
 						$objectdesc = $objectforfieldstmp->fields[$tmparray[1]]['type'];
 						$objectdesc = preg_replace('/^integer[^:]*:/', '', $objectdesc);
 					}
+				}
+
+				// Reset $objectdesc to default value
+				if (empty($objectdesc)) {
+					$objectdesc = $objectdescorig;
 				}
 			}
 		}


### PR DESCRIPTION

Field from class we want use selectForForms functions
![image](https://github.com/user-attachments/assets/ca26adfa-ab5d-43b5-9bf2-af2cb67382b5)

Error occured because type integer not integer:Product......
![image](https://github.com/user-attachments/assets/decfbf4b-ee2a-4f71-bf4f-3901a1e1ba9f)

Fix with check and reset value
![image](https://github.com/user-attachments/assets/6634506f-62fe-4790-8484-512879fa295e)

Add preg_match for check before preg_replace
Add reset objectdesc to default value
