### PR TITLE
Fix #29292

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13591,7 +13591,7 @@ function dolForgeCriteriaCallback($matches)
 	if (empty($matches[1])) {
 		return '';
 	}
-	$tmp = explode(':', $matches[1]);
+	$tmp = explode(':', $matches[1], 3);
 	if (count($tmp) < 3) {
 		return '';
 	}

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -98,6 +98,16 @@ $resultboxes = FormOther::getBoxesArea($user, "0"); // Load $resultboxes (select
 
 print load_fiche_titre('&nbsp;', $resultboxes['selectboxlist'], '', 0, '', 'titleforhome');
 
+if (DOL_VERSION  != $conf->global->MAIN_VERSION_LAST_UPGRADE) {
+	$langs->loadLangs(['admin']);
+	print "\n<!-- Start of warning text -->\n";
+	print '<div class="warning">';
+	print img_warning('') . ' ';
+	print $langs->trans("RunningUpdateProcessMayBeRequired", DOL_VERSION, getDolGlobalString('MAIN_VERSION_LAST_UPGRADE'));
+	print '</div>';
+	print "\n<!-- End of warning text -->\n";
+}
+
 if (getDolGlobalString('MAIN_MOTD')) {
 	$conf->global->MAIN_MOTD = preg_replace('/<br(\s[\sa-zA-Z_="]*)?\/?>/i', '<br>', getDolGlobalString('MAIN_MOTD'));
 	if (getDolGlobalString('MAIN_MOTD')) {

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -98,16 +98,6 @@ $resultboxes = FormOther::getBoxesArea($user, "0"); // Load $resultboxes (select
 
 print load_fiche_titre('&nbsp;', $resultboxes['selectboxlist'], '', 0, '', 'titleforhome');
 
-if (DOL_VERSION  != $conf->global->MAIN_VERSION_LAST_UPGRADE) {
-	$langs->loadLangs(['admin']);
-	print "\n<!-- Start of warning text -->\n";
-	print '<div class="warning">';
-	print img_warning('') . ' ';
-	print $langs->trans("RunningUpdateProcessMayBeRequired", DOL_VERSION, getDolGlobalString('MAIN_VERSION_LAST_UPGRADE'));
-	print '</div>';
-	print "\n<!-- End of warning text -->\n";
-}
-
 if (getDolGlobalString('MAIN_MOTD')) {
 	$conf->global->MAIN_MOTD = preg_replace('/<br(\s[\sa-zA-Z_="]*)?\/?>/i', '<br>', getDolGlobalString('MAIN_MOTD'));
 	if (getDolGlobalString('MAIN_MOTD')) {

--- a/test/phpunit/FunctionsLibTest.php
+++ b/test/phpunit/FunctionsLibTest.php
@@ -239,7 +239,7 @@ class FunctionsLibTest extends CommonClassTest
 		// A real search string
 		$filter = "(t.ref:like:'SO-%') or (t.date_creation:<:'20160101') or (t.date_creation:<:'2016-01-01 12:30:00') or (t.nature:is:NULL)";
 		$sql = forgeSQLFromUniversalSearchCriteria($filter);
-		$this->assertEquals(" AND ((t.ref LIKE 'SO-%') or (t.date_creation < '20160101') or (t.date_creation < 0) or (t.nature IS NULL))", $sql);
+		$this->assertEquals(" AND ((t.ref LIKE 'SO-%') or (t.date_creation < '20160101') or (t.date_creation < '2016-01-01 12:30:00') or (t.nature IS NULL))", $sql);
 
 		// A real search string
 		$filter = "(t.fieldstring:=:'aaa ttt')";


### PR DESCRIPTION
# FIX #29292
Allowing colon char `":"` in sqlfilters is done by limiting results from explode