### PR TITLE
LDAP fixes for php8.1+

### DIFF
--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -307,7 +307,12 @@ class Ldap
 					if ($ldapdebug) {
 						dol_syslog(get_class($this)."::connect_bind serverPing true, we try ldap_connect to ".$host);
 					}
-					$this->connection = ldap_connect($host, $this->serverPort);
+					if (strnatcmp(phpversion(), '8.3.0') >= 0) {
+						$uri = $host.':'.$this->serverPort;
+						$this->connection = ldap_connect($uri);
+					} else {
+						$this->connection = ldap_connect($host, $this->serverPort);
+					}
 				} else {
 					if (preg_match('/^ldaps/i', $host)) {
 						// With host = ldaps://server, the serverPing to ssl://server sometimes fails, even if the ldap_connect succeed, so
@@ -315,7 +320,12 @@ class Ldap
 						if ($ldapdebug) {
 							dol_syslog(get_class($this)."::connect_bind serverPing false, we try ldap_connect to ".$host);
 						}
-						$this->connection = ldap_connect($host, $this->serverPort);
+						if (strnatcmp(phpversion(), '8.3.0') >= 0) {
+							$uri = $host.':'.$this->serverPort;
+							$this->connection = ldap_connect($uri);
+						} else {
+							$this->connection = ldap_connect($host, $this->serverPort);
+						}
 					} else {
 						continue;
 					}
@@ -463,14 +473,26 @@ class Ldap
 	/**
 	 * Unbind of LDAP server (close connection).
 	 *
-	 * @return	boolean					true or false
-	 * @see close()
+	 * @return		boolean		true or false
+	 * @see	close()
 	 */
 	public function unbind()
 	{
 		$this->result = true;
-		if (is_resource($this->connection) || is_object($this->connection)) {
-			$this->result = @ldap_unbind($this->connection);
+		if (strnatcmp(phpversion(), '8.1.0') >= 0) {
+			if (is_object($this->connection)) {
+				try {
+					$this->result = ldap_unbind($this->connection);
+				} catch (Throwable $exception) {
+					$this->error = 'Failed to unbind LDAP connection: '.$exception;
+					$this->result = false;
+					dol_syslog(get_class($this).'::unbind - '.$this->error, LOG_WARNING);
+				}
+			}
+		} else {
+			if (is_resource($this->connection)) {
+				$this->result = @ldap_unbind($this->connection);
+			}
 		}
 		if ($this->result) {
 			return true;

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -307,7 +307,7 @@ class Ldap
 					if ($ldapdebug) {
 						dol_syslog(get_class($this)."::connect_bind serverPing true, we try ldap_connect to ".$host);
 					}
-					if (strnatcmp(phpversion(), '8.3.0') >= 0) {
+					if (version_compare(PHP_VERSION, '8.3.0', '>=')) {
 						$uri = $host.':'.$this->serverPort;
 						$this->connection = ldap_connect($uri);
 					} else {
@@ -320,7 +320,7 @@ class Ldap
 						if ($ldapdebug) {
 							dol_syslog(get_class($this)."::connect_bind serverPing false, we try ldap_connect to ".$host);
 						}
-						if (strnatcmp(phpversion(), '8.3.0') >= 0) {
+						if (version_compare(PHP_VERSION, '8.3.0', '>=')) {
 							$uri = $host.':'.$this->serverPort;
 							$this->connection = ldap_connect($uri);
 						} else {
@@ -479,7 +479,7 @@ class Ldap
 	public function unbind()
 	{
 		$this->result = true;
-		if (strnatcmp(phpversion(), '8.1.0') >= 0) {
+		if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
 			if (is_object($this->connection)) {
 				try {
 					$this->result = ldap_unbind($this->connection);

--- a/htdocs/core/login/functions_ldap.php
+++ b/htdocs/core/login/functions_ldap.php
@@ -246,13 +246,15 @@ function check_user_password_ldap($usertotest, $passwordtotest, $entitytotest)
 			 ** 53 - Account inactive (manually locked out by administrator)
 			 */
 			dol_syslog("functions_ldap::check_user_password_ldap Authentication KO failed to connect to LDAP for '".$usertotest."'", LOG_NOTICE);
-			if ($ldapdebug) {
-				if ($ldap->connection != false) {
-					if (is_resource($ldap->connection) || is_object($ldap->connection)) {    // If connection ok but bind ko
-						$ldap->ldapErrorCode = ldap_errno($ldap->connection);
-						$ldap->ldapErrorText = ldap_error($ldap->connection);
-						dol_syslog("functions_ldap::check_user_password_ldap ".$ldap->ldapErrorCode." ".$ldap->ldapErrorText);
-					}
+			if (is_resource($ldap->connection) || is_object($ldap->connection)) {    // If connection ok but bind ko
+				try {
+					$ldap->ldapErrorCode = ldap_errno($ldap->connection);
+					$ldap->ldapErrorText = ldap_error($ldap->connection);
+					dol_syslog("functions_ldap::check_user_password_ldap ".$ldap->ldapErrorCode." ".$ldap->ldapErrorText);
+				} catch (Throwable $exception) {
+					$ldap->ldapErrorCode = '';
+					$ldap->ldapErrorText = '';
+					dol_syslog('functions_ldap::check_user_password_ldap '.$exception, LOG_WARNING);
 				}
 			}
 			sleep(1); // Anti brut force protection. Must be same delay when user and password are not valid.

--- a/htdocs/core/login/functions_ldap.php
+++ b/htdocs/core/login/functions_ldap.php
@@ -247,10 +247,12 @@ function check_user_password_ldap($usertotest, $passwordtotest, $entitytotest)
 			 */
 			dol_syslog("functions_ldap::check_user_password_ldap Authentication KO failed to connect to LDAP for '".$usertotest."'", LOG_NOTICE);
 			if ($ldapdebug) {
-				if ($ldap->connection !== false || is_resource($ldap->connection) || is_object($ldap->connection)) {    // If connection ok but bind ko
-					$ldap->ldapErrorCode = ldap_errno($ldap->connection);
-					$ldap->ldapErrorText = ldap_error($ldap->connection);
-					dol_syslog("functions_ldap::check_user_password_ldap ".$ldap->ldapErrorCode." ".$ldap->ldapErrorText);
+				if ($ldap->connection != false) {
+					if (is_resource($ldap->connection) || is_object($ldap->connection)) {    // If connection ok but bind ko
+						$ldap->ldapErrorCode = ldap_errno($ldap->connection);
+						$ldap->ldapErrorText = ldap_error($ldap->connection);
+						dol_syslog("functions_ldap::check_user_password_ldap ".$ldap->ldapErrorCode." ".$ldap->ldapErrorText);
+					}
 				}
 			}
 			sleep(1); // Anti brut force protection. Must be same delay when user and password are not valid.
@@ -258,9 +260,7 @@ function check_user_password_ldap($usertotest, $passwordtotest, $entitytotest)
 			$langs->loadLangs(array('main', 'other', 'errors'));
 			$_SESSION["dol_loginmesg"] = ($ldap->error ? $ldap->error : $langs->transnoentitiesnoconv("ErrorBadLoginPassword"));
 		}
-		if ($ldap->connection !== false) {
-			$ldap->unbind();
-		}
+		$ldap->unbind();
 	}
 
 	return $login;

--- a/htdocs/core/login/functions_ldap.php
+++ b/htdocs/core/login/functions_ldap.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2007-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2008-2021 Regis Houssin        <regis.houssin@inodbox.com>
+ * Copyright (C) 2024		William Mead		<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -245,19 +246,21 @@ function check_user_password_ldap($usertotest, $passwordtotest, $entitytotest)
 			 ** 53 - Account inactive (manually locked out by administrator)
 			 */
 			dol_syslog("functions_ldap::check_user_password_ldap Authentication KO failed to connect to LDAP for '".$usertotest."'", LOG_NOTICE);
-			if (is_resource($ldap->connection) || is_object($ldap->connection)) {    // If connection ok but bind ko
-				$ldap->ldapErrorCode = ldap_errno($ldap->connection);
-				$ldap->ldapErrorText = ldap_error($ldap->connection);
-				dol_syslog("functions_ldap::check_user_password_ldap ".$ldap->ldapErrorCode." ".$ldap->ldapErrorText);
+			if ($ldapdebug) {
+				if ($ldap->connection !== false || is_resource($ldap->connection) || is_object($ldap->connection)) {    // If connection ok but bind ko
+					$ldap->ldapErrorCode = ldap_errno($ldap->connection);
+					$ldap->ldapErrorText = ldap_error($ldap->connection);
+					dol_syslog("functions_ldap::check_user_password_ldap ".$ldap->ldapErrorCode." ".$ldap->ldapErrorText);
+				}
 			}
 			sleep(1); // Anti brut force protection. Must be same delay when user and password are not valid.
-
 			// Load translation files required by the page
 			$langs->loadLangs(array('main', 'other', 'errors'));
 			$_SESSION["dol_loginmesg"] = ($ldap->error ? $ldap->error : $langs->transnoentitiesnoconv("ErrorBadLoginPassword"));
 		}
-
-		$ldap->unbind();
+		if ($ldap->connection !== false) {
+			$ldap->unbind();
+		}
 	}
 
 	return $login;


### PR DESCRIPTION
# LDAP fixes for php8.1+
This is a quick fix for #30669, #30588 & #25975

Even if `ldap_unbind` errors are silenced with @ they seem to be throwing fatal errors with PHP 8.1+ This seems to be linked to the change of ldap resource to class instance.

This PR :
- Improves error management for ldap class `unbind` method for PHP 8.1+
- Improves ldap class `connect_bind` method for PHP 8.3+
- ~~Only shows ldap error code & text if ldap debug is actif. This might be better for security reasons also.~~

Linked research on this:
- https://www.php.net/manual/en/function.ldap-connect.php
- https://www.php.net/manual/en/function.ldap-unbind.php
- https://php.watch/versions/8.1/LDAP-resource