### PR TITLE
FIX : fk_product of inventory should take care of conf STOCK_SUPPORTS…

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -967,7 +967,9 @@ if ($object->status == $object::STATUS_DRAFT || $object->status == $object::STAT
 	print $formproduct->selectWarehouses((GETPOSTISSET('fk_warehouse') ? GETPOSTINT('fk_warehouse') : $object->fk_warehouse), 'fk_warehouse', 'warehouseopen', 1, 0, 0, '', 0, 0, array(), 'maxwidth300');
 	print '</td>';
 	print '<td>';
-	print $form->select_produits((GETPOSTISSET('fk_product') ? GETPOSTINT('fk_product') : $object->fk_product), 'fk_product', '', 0, 0, -1, 2, '', 0, null, 0, '1', 0, 'maxwidth300');
+	if (getDolGlobalString('STOCK_SUPPORTS_SERVICES')) $filtertype = '';
+	else $filtertype = 0;
+	print $form->select_produits((GETPOSTISSET('fk_product') ? GETPOSTINT('fk_product') : $object->fk_product), 'fk_product', $filtertype, 0, 0, -1, 2, '', 0, null, 0, '1', 0, 'maxwidth300');
 	print '</td>';
 	if (isModEnabled('productbatch')) {
 		print '<td>';

--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -967,8 +967,11 @@ if ($object->status == $object::STATUS_DRAFT || $object->status == $object::STAT
 	print $formproduct->selectWarehouses((GETPOSTISSET('fk_warehouse') ? GETPOSTINT('fk_warehouse') : $object->fk_warehouse), 'fk_warehouse', 'warehouseopen', 1, 0, 0, '', 0, 0, array(), 'maxwidth300');
 	print '</td>';
 	print '<td>';
-	if (getDolGlobalString('STOCK_SUPPORTS_SERVICES')) $filtertype = '';
-	else $filtertype = 0;
+	if (getDolGlobalString('STOCK_SUPPORTS_SERVICES')) {
+		$filtertype = '';
+	} else {
+		$filtertype = 0;
+	}
 	print $form->select_produits((GETPOSTISSET('fk_product') ? GETPOSTINT('fk_product') : $object->fk_product), 'fk_product', $filtertype, 0, 0, -1, 2, '', 0, null, 0, '1', 0, 'maxwidth300');
 	print '</td>';
 	if (isModEnabled('productbatch')) {


### PR DESCRIPTION
# FIX: Correct Visibility of Services Based on STOCK_SUPPORTS_SERVICES Configuration

Summary
This pull request addresses an issue with the handling of the fk_product field in the inventory section, specifically concerning the visibility of services based on the STOCK_SUPPORTS_SERVICES configuration setting.
Explanation
The modification ensures that services are only visible in the product selection dropdown when the STOCK_SUPPORTS_SERVICES global configuration is enabled.

Before: The filtertype parameter was always an empty string '', which meant that services could appear in the dropdown regardless of whether STOCK_SUPPORTS_SERVICES was enabled or not. This was problematic because it allowed users to see and potentially select services even if the configuration did not support them.

After: The filtertype parameter is now conditionally set based on the STOCK_SUPPORTS_SERVICES configuration. If the configuration is enabled, filtertype is set to an empty string '', which allows services to be displayed. If the configuration is not enabled, filtertype is set to 0, which hides services from the dropdown.

This update corrects the behavior by ensuring that services are only displayed in contexts where they are supported, thereby preventing users from selecting services when they are not configured to be available.

Impact
This change ensures that the product selection dropdown aligns with the STOCK_SUPPORTS_SERVICES configuration, improving both functionality and user experience by preventing the selection of unsupported services. It addresses the issue where services were visible and selectable even when the configuration did not allow for them.