### PR TITLE
FIX late project search option

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -2266,6 +2266,7 @@ class Project extends CommonObject
 		$response->label = $langs->trans("OpenedProjects");
 		$response->labelShort = $langs->trans("Opened");
 		$response->url = DOL_URL_ROOT.'/projet/list.php?search_project_user=-1&search_status=1&mainmenu=project';
+		$response->url_late = DOL_URL_ROOT.'/projet/list.php?search_option=late&mainmenu=project';
 		$response->img = img_object('', "projectpub");
 		$response->nbtodo = 0;
 		$response->nbtodolate = 0;

--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -10,6 +10,7 @@
  * Copyright (C) 2023       Gauthier VERDOL         <gauthier.verdol@atm-consulting.fr>
  * Copyright (C) 2024		Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/projet/list.php
+++ b/htdocs/projet/list.php
@@ -11,6 +11,7 @@
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024		Benjamin Falière	<benjamin.faliere@altairis.fr>
+ * Copyright (C) 2024		William Mead		<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/projet/list.php
+++ b/htdocs/projet/list.php
@@ -192,6 +192,10 @@ if (GETPOSTISARRAY('search_status') || GETPOST('search_status_multiselect')) {
 	$search_status = (GETPOST('search_status', 'intcomma') != '' ? GETPOST('search_status', 'intcomma') : '0,1');
 }
 
+$search_option = GETPOST('search_option', 'alpha');
+if ($search_option == 'late') {
+	$search_status = '1';
+}
 // Initialize a technical object to manage hooks of page. Note that conf->hooks_modules contains an array of hook context
 $object = new Project($db);
 $hookmanager->initHooks(array('projectlist'));
@@ -352,6 +356,7 @@ if (empty($reshook)) {
 		$search_societe_alias = '';
 		$search_societe_country = '';
 		$search_status = -1;
+		$search_option = '';
 		$search_opp_status = -1;
 		$search_opp_amount = '';
 		$search_opp_percent = '';
@@ -637,6 +642,9 @@ if ($search_status != '' && $search_status != '-1') {
 	} else {
 		$sql .= " AND p.fk_statut IN (".$db->sanitize($db->escape($search_status)).")";
 	}
+}
+if ($search_option == 'late') {
+	$sql .= " AND p.datee < '".$db->idate(dol_now() - $conf->project->warning_delay)."'";
 }
 if ($search_opp_status) {
 	if (is_numeric($search_opp_status) && $search_opp_status > 0) {
@@ -1009,6 +1017,9 @@ if ($search_societe_country != '') {
 if ($search_status != '' && $search_status != '-1') {
 	$param .= "&search_status=".urlencode($search_status);
 }
+if ($search_option) {
+	$param .= "&search_option=".urlencode($search_option);
+}
 if ((is_numeric($search_opp_status) && $search_opp_status >= 0) || in_array($search_opp_status, array('all', 'openedopp', 'notopenedopp', 'none'))) {
 	$param .= '&search_opp_status='.urlencode($search_opp_status);
 }
@@ -1192,6 +1203,11 @@ if (getDolGlobalString('MAIN_SEARCH_CATEGORY_CUSTOMER_ON_PROJECT_LIST') && isMod
 	$formcategory = new FormCategory($db);
 	$moreforfilter .= $formcategory->getFilterBox(Categorie::TYPE_CUSTOMER, $searchCategoryCustomerList, 'minwidth300', $searchCategoryCustomerList ? $searchCategoryCustomerList : 0);
 }
+
+// alert on late date
+$moreforfilter .= '<div class="divsearchfield">';
+$moreforfilter .= $langs->trans('Alert').' <input type="checkbox" name="search_option" value="late"'.($search_option == 'late' ? ' checked' : '').'>';
+$moreforfilter .= '</div>';
 
 if (getDolGlobalInt('PROJECT_ENABLE_SUB_PROJECT')) {
 	//Checkbox for omitting child projects filter


### PR DESCRIPTION
# FIX late project search option
Like invoices #30670, the home page link to late projects does not work correctly. Currently the link will open the proejct list with all validated projects, the late alert duration is not used.
This PR adds a `search_option` post variable & `url_late` for the home page link as well as a alert checkbox on the project list.

![fix-late-project-list](https://github.com/user-attachments/assets/1e13232d-e972-45e5-a3e2-b2f5c05d0f08)
![fix-late-project-list-alert](https://github.com/user-attachments/assets/48d39d99-17b7-4e8b-b3fb-9268b3735f64)

Associated issues: #25963 #26056