### PR TITLE
Fix prevent batch shipment for same product

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -268,6 +268,8 @@ if (empty($reshook)) {
 		$num = count($objectsrc->lines);
 		$totalqty = 0;
 
+		$product_batch_used = array();
+
 		for ($i = 0; $i < $num; $i++) {
 			$idl = "idl".$i;
 

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -305,11 +305,16 @@ if (empty($reshook)) {
 						//var_dump($sub_qty[$j]['id_batch']);
 
 						//var_dump($qty);var_dump($batch);var_dump($sub_qty[$j]['q']);var_dump($sub_qty[$j]['id_batch']);
-						if ($is_batch_or_serial==2 && $sub_qty[$j]['q']>1) {
+						if ($is_batch_or_serial==2 && ($sub_qty[$j]['q']>1 || ($sub_qty[$j]['q']>0 && in_array($sub_qty[$j]['id_batch'], $product_batch_used)))) {
 							setEventMessages($langs->trans("TooManyQtyForSerialNumber", $product->ref, ''), null, 'errors');
 							$totalqty=0;
 							break 2;
 						}
+
+						if ($is_batch_or_serial==2 && $sub_qty[$j]['q']>0) {
+							$product_batch_used[$j] = $sub_qty[$j]['id_batch']; // we stock the batch id to test if the same serial is shipped on another line for the same product
+						}
+
 						$j++;
 						$batch = "batchl".$i."_".$j;
 						$qty = "qtyl".$i.'_'.$j;


### PR DESCRIPTION
# FIX|Fix #[*Revent batch shipment for same product*]
When we have several time the same product in an order (in two different line for exemple) and this product uses unique serial number, there is no restriction to ship the same batch number in the two different lines for the same product. We shouldn't be able to ship the same serial number on two different lines for the same product. 

For information, for now, the restriction is only on a quantity more than 1 for a unique line.