### PR TITLE
Add includetimespent in index method for tasks

### DIFF
--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -103,9 +103,10 @@ class Tasks extends DolibarrApi
 	 * @param int			   $page				Page number
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string    $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+   * @param   int         $includetimespent       0=Return only task. 1=Include a summary of time spent, 2=Include details of time spent lines (2 is no implemented yet)
 	 * @return  array                               Array of project objects
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $sqlfilters = '', $properties = '')
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $sqlfilters = '', $properties = '', $includetimespent = 0)
 	{
 		global $db, $conf;
 
@@ -170,6 +171,13 @@ class Tasks extends DolibarrApi
 				$obj = $this->db->fetch_object($result);
 				$task_static = new Task($this->db);
 				if ($task_static->fetch($obj->rowid)) {
+          if ($includetimespent == 1) {
+            $timespent = $task_static->getSummaryOfTimeSpent(0);
+          }
+          if ($includetimespent == 2) {
+            // TODO
+            // Add class for timespent records and loop and fill $line->lines with records of timespent
+          }
 					$obj_ret[] = $this->_filterObjectProperties($this->_cleanObjectDatas($task_static), $properties);
 				}
 				$i++;


### PR DESCRIPTION
# NEW|New Add includetimespent in index method for tasks

There were no time spent option when using the /tasks endpoint. It is not possible to use the option 0 or 1.
I have tested it only on 14.0.5 because it is our actual instance.

Regards