### PR TITLE
Fix [2...] rounding param bug

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -6148,7 +6148,7 @@ function price($amount, $form = 0, $outlangs = '', $trunc = 1, $rounding = -1, $
 	}
 
 	// Format number
-	$output = number_format($amount, $nbdecimal, $dec, $thousand);
+	$output = number_format((float) $amount, (int) $nbdecimal, $dec, $thousand);
 	if ($form) {
 		$output = preg_replace('/\s/', '&nbsp;', $output);
 		$output = preg_replace('/\'/', '&#039;', $output);


### PR DESCRIPTION
# FIX 
If in precision you choose the special value "2..." you can have some fatal errors that freeze product list and product page

This bug exists at least in V18, v19, v20 and develop branch
![Screenshot 2024-08-26 at 11-39-42 Produits](https://github.com/user-attachments/assets/3fea2f4c-9a6a-4c67-a668-a673b9544fbe)



