### PR TITLE
Fix board info box list links menus

### DIFF
--- a/htdocs/core/boxes/box_clients.php
+++ b/htdocs/core/boxes/box_clients.php
@@ -77,7 +77,7 @@ class box_clients extends ModeleBoxes
 		$thirdpartystatic = new Client($this->db);
 
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxTitleLastModifiedCustomers", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/societe/list.php?type=c&sortfield=s.tms&sortorder=DESC"><span class="badge">...</span></a>',
+			'text' => $langs->trans("BoxTitleLastModifiedCustomers", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/societe/list.php?mainmenu=companies&leftmenu=customers&type=c&sortfield=s.tms&sortorder=DESC"><span class="badge">...</span></a>',
 		);
 
 		if ($user->hasRight('societe', 'lire')) {

--- a/htdocs/core/boxes/box_commandes.php
+++ b/htdocs/core/boxes/box_commandes.php
@@ -75,7 +75,7 @@ class box_commandes extends ModeleBoxes
 
 		$text = $langs->trans("BoxTitleLast".(getDolGlobalString('MAIN_LASTBOX_ON_OBJECT_DATE') ? "" : "Modified")."CustomerOrders", $max);
 		$this->info_box_head = array(
-			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/commande/list.php?sortfield=c.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/commande/list.php?mainmenu=commercial&leftmenu=orders&sortfield=c.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('commande', 'lire')) {

--- a/htdocs/core/boxes/box_contacts.php
+++ b/htdocs/core/boxes/box_contacts.php
@@ -74,7 +74,7 @@ class box_contacts extends ModeleBoxes
 		$societestatic = new Societe($this->db);
 
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxTitleLastModifiedContacts", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/contact/list.php?sortfield=p.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => $langs->trans("BoxTitleLastModifiedContacts", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/contact/list.php?mainmenu=companies&leftmenu=contactssortfield=p.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('societe', 'lire') && $user->hasRight('societe', 'contact', 'lire')) {

--- a/htdocs/core/boxes/box_contracts.php
+++ b/htdocs/core/boxes/box_contracts.php
@@ -67,7 +67,7 @@ class box_contracts extends ModeleBoxes
 		include_once DOL_DOCUMENT_ROOT.'/contrat/class/contrat.class.php';
 
 		$this->info_box_head = array(
-			'text' => '<span class="valignmiddle">'.$langs->trans("BoxTitleLastContracts", $max).'</span><a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/contrat/list.php?sortfield=c.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => '<span class="valignmiddle">'.$langs->trans("BoxTitleLastContracts", $max).'</span><a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/contrat/list.php?mainmenu=commercial&leftmenu=contracts&sortfield=c.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('contrat', 'lire')) {

--- a/htdocs/core/boxes/box_factures.php
+++ b/htdocs/core/boxes/box_factures.php
@@ -73,7 +73,7 @@ class box_factures extends ModeleBoxes
 
 		$text = $langs->trans("BoxTitleLast".(getDolGlobalString('MAIN_LASTBOX_ON_OBJECT_DATE') ? "" : "Modified")."CustomerBills", $max);
 		$this->info_box_head = array(
-			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/compta/facture/list.php?sortfield=f.tms&sortorder=DESC"><span class="badge">...</span></a>',
+			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/compta/facture/list.php?mainmenu=billing&leftmenu=custommers_billssortfield=f.tms&sortorder=DESC"><span class="badge">...</span></a>',
 			'limit' => dol_strlen($text)
 		);
 

--- a/htdocs/core/boxes/box_factures.php
+++ b/htdocs/core/boxes/box_factures.php
@@ -73,8 +73,7 @@ class box_factures extends ModeleBoxes
 
 		$text = $langs->trans("BoxTitleLast".(getDolGlobalString('MAIN_LASTBOX_ON_OBJECT_DATE') ? "" : "Modified")."CustomerBills", $max);
 		$this->info_box_head = array(
-			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/compta/facture/list.php?mainmenu=billing&leftmenu=custommers_billssortfield=f.tms&sortorder=DESC"><span class="badge">...</span></a>',
-			'limit' => dol_strlen($text)
+			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/compta/facture/list.php?mainmenu=billing&leftmenu=custommers_billssortfield=f.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('facture', 'lire')) {

--- a/htdocs/core/boxes/box_factures.php
+++ b/htdocs/core/boxes/box_factures.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2015      Frederic France      <frederic.france@free.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024		William Mead	<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/core/boxes/box_factures_fourn.php
+++ b/htdocs/core/boxes/box_factures_fourn.php
@@ -72,7 +72,7 @@ class box_factures_fourn extends ModeleBoxes
 
 		$text = $langs->trans("BoxTitleLast".(getDolGlobalString('MAIN_LASTBOX_ON_OBJECT_DATE') ? "" : "Modified")."SupplierBills", $max);
 		$this->info_box_head = array(
-			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/fourn/facture/list.php?sortfield=f.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/fourn/facture/list.php?mainmenu=billing&leftmenu=supplier_bills&sortfield=f.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('fournisseur', 'facture', 'lire')) {

--- a/htdocs/core/boxes/box_factures_fourn_imp.php
+++ b/htdocs/core/boxes/box_factures_fourn_imp.php
@@ -74,7 +74,7 @@ class box_factures_fourn_imp extends ModeleBoxes
 
 		$textHead = $langs->trans("BoxTitleOldestUnpaidSupplierBills");
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxTitleOldestUnpaidSupplierBills", $this->max).'<a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/fourn/facture/list.php?search_status=1&sortfield=f.date_lim_reglement,f.ref&sortorder=ASC,ASC"><span class="badge">...</span></a>',
+			'text' => $langs->trans("BoxTitleOldestUnpaidSupplierBills", $this->max).'<a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/fourn/facture/list.php?mainmenu=billing&leftmenu=supplier_bills&search_status=1&sortfield=f.date_lim_reglement,f.ref&sortorder=ASC,ASC"><span class="badge">...</span></a>',
 			'limit' => dol_strlen($textHead)
 		);
 

--- a/htdocs/core/boxes/box_factures_imp.php
+++ b/htdocs/core/boxes/box_factures_imp.php
@@ -78,7 +78,7 @@ class box_factures_imp extends ModeleBoxes
 		$textHead = $langs->trans("BoxTitleOldestUnpaidCustomerBills");
 		$this->info_box_head = array(
 			'text' => $langs->trans("BoxTitleOldestUnpaidCustomerBills", $this->max).'<a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/compta/facture/list.php?mainmenu=billing&leftmenu=customer_bills&search_status=1&sortfield=f.date_lim_reglement,f.ref&sortorder=ASC,ASC"><span class="badge">...</span></a>',
-			'limit' => dol_strlen($textHead));
+		);
 
 		if ($user->hasRight('facture', 'lire')) {
 			$sql1 = "SELECT s.rowid as socid, s.nom as name, s.name_alias, s.code_client, s.client";

--- a/htdocs/core/boxes/box_factures_imp.php
+++ b/htdocs/core/boxes/box_factures_imp.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2015-2019 Frederic France      <frederic.france@netlogic.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024		William Mead	<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/core/boxes/box_factures_imp.php
+++ b/htdocs/core/boxes/box_factures_imp.php
@@ -77,7 +77,7 @@ class box_factures_imp extends ModeleBoxes
 
 		$textHead = $langs->trans("BoxTitleOldestUnpaidCustomerBills");
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxTitleOldestUnpaidCustomerBills", $this->max).'<a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/compta/facture/list.php?search_status=1&sortfield=f.date_lim_reglement,f.ref&sortorder=ASC,ASC"><span class="badge">...</span></a>',
+			'text' => $langs->trans("BoxTitleOldestUnpaidCustomerBills", $this->max).'<a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/compta/facture/list.php?mainmenu=billing&leftmenu=customer_bills&search_status=1&sortfield=f.date_lim_reglement,f.ref&sortorder=ASC,ASC"><span class="badge">...</span></a>',
 			'limit' => dol_strlen($textHead));
 
 		if ($user->hasRight('facture', 'lire')) {

--- a/htdocs/core/boxes/box_ficheinter.php
+++ b/htdocs/core/boxes/box_ficheinter.php
@@ -69,7 +69,7 @@ class box_ficheinter extends ModeleBoxes
 		$thirdpartystatic = new Societe($this->db);
 
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxTitleLastFicheInter", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/fichinter/list.php?sortfield=f.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => $langs->trans("BoxTitleLastFicheInter", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/fichinter/list.php?mainmenu=commercial&leftmenu=fichinter&sortfield=f.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('ficheinter', 'lire')) {

--- a/htdocs/core/boxes/box_fournisseurs.php
+++ b/htdocs/core/boxes/box_fournisseurs.php
@@ -70,7 +70,7 @@ class box_fournisseurs extends ModeleBoxes
 		$thirdpartystatic = new Fournisseur($this->db);
 
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxTitleLastModifiedSuppliers", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/societe/list.php?type=f&sortfield=s.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => $langs->trans("BoxTitleLastModifiedSuppliers", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/societe/list.php?mainmenu=companies&leftmenu=suppliers&type=f&sortfield=s.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('societe', 'lire')) {

--- a/htdocs/core/boxes/box_last_modified_ticket.php
+++ b/htdocs/core/boxes/box_last_modified_ticket.php
@@ -66,7 +66,7 @@ class box_last_modified_ticket extends ModeleBoxes
 
 		$text = $langs->trans("BoxLastModifiedTicketDescription", $max);
 		$this->info_box_head = array(
-			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/ticket/list.php?sortfield=t.tms&sortorder=DESC"><span class="badge">...</span></a>',
+			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/ticket/list.php?mainmenu=ticket&leftmenu=ticket&sortfield=t.tms&sortorder=DESC"><span class="badge">...</span></a>',
 			'limit' => dol_strlen($text)
 		);
 

--- a/htdocs/core/boxes/box_last_ticket.php
+++ b/htdocs/core/boxes/box_last_ticket.php
@@ -66,7 +66,7 @@ class box_last_ticket extends ModeleBoxes
 
 		$text = $langs->trans("BoxLastTicketDescription", $max);
 		$this->info_box_head = array(
-			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/ticket/list.php?sortfield=t.datec&sortorder=DESC"><span class="badge">...</span></a>',
+			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/ticket/list.php?mainmenu=ticket&leftmenu=ticket&sortfield=t.datec&sortorder=DESC"><span class="badge">...</span></a>',
 			'limit' => dol_strlen($text),
 		);
 

--- a/htdocs/core/boxes/box_produits.php
+++ b/htdocs/core/boxes/box_produits.php
@@ -73,7 +73,7 @@ class box_produits extends ModeleBoxes
 		$productstatic = new Product($this->db);
 
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxTitleLastProducts", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/product/list.php?sortfield=p.tms&sortorder=DESC"><span class="badge">...</span></a>',
+			'text' => $langs->trans("BoxTitleLastProducts", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/product/list.php?mainmenu=products&leftmenu=product&sortfield=p.tms&sortorder=DESC"><span class="badge">...</span></a>',
 		);
 
 		if ($user->hasRight('produit', 'lire') || $user->hasRight('service', 'lire')) {

--- a/htdocs/core/boxes/box_propales.php
+++ b/htdocs/core/boxes/box_propales.php
@@ -73,7 +73,7 @@ class box_propales extends ModeleBoxes
 
 		$text = $langs->trans("BoxTitleLast".(getDolGlobalString('MAIN_LASTBOX_ON_OBJECT_DATE') ? "" : "Modified")."Propals", $max);
 		$this->info_box_head = array(
-			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/comm/propal/list.php?sortfield=p.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/comm/propal/list.php?mainmenu=commercial&leftmenu=propals&sortfield=p.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('propal', 'lire')) {

--- a/htdocs/core/boxes/box_prospect.php
+++ b/htdocs/core/boxes/box_prospect.php
@@ -77,7 +77,7 @@ class box_prospect extends ModeleBoxes
 		$thirdpartystatic = new Client($this->db);
 
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxTitleLastModifiedProspects", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/societe/list.php?type=p&sortfield=s.tms&sortorder=DESC"><span class="badge">...</span></a>',
+			'text' => $langs->trans("BoxTitleLastModifiedProspects", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/societe/list.php?mainmenu=companies&leftmenu=prospects&type=p&sortfield=s.tms&sortorder=DESC"><span class="badge">...</span></a>',
 		);
 
 		if ($user->hasRight('societe', 'lire')) {

--- a/htdocs/core/boxes/box_services_contracts.php
+++ b/htdocs/core/boxes/box_services_contracts.php
@@ -70,7 +70,7 @@ class box_services_contracts extends ModeleBoxes
 		$form = new Form($this->db);
 
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxLastProductsInContract", $max).'<a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/contrat/list.php?sortfield=c.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => $langs->trans("BoxLastProductsInContract", $max).'<a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/contrat/list.php?mainmenu=commercial&leftmenu=contracts&sortfield=c.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('service', 'lire') && $user->hasRight('contrat', 'lire')) {

--- a/htdocs/core/boxes/box_services_expired.php
+++ b/htdocs/core/boxes/box_services_expired.php
@@ -66,7 +66,9 @@ class box_services_expired extends ModeleBoxes
 
 		$now = dol_now();
 
-		$this->info_box_head = array('text' => $langs->trans("BoxLastExpiredServices", $max));
+		$this->info_box_head = array(
+			'text' => $langs->trans("BoxLastExpiredServices", $max).'<a class="paddingleft valignmiddle" href="'.DOL_URL_ROOT.'/contrat/services_list.php?mainmenu=commercial&leftmenu=contracts&search_status=4%26filter=expired&sortfield=cd.date_fin_validite&sortorder=DESC"><span class="badge">...</span></a>'
+		);
 
 		if ($user->hasRight('contrat', 'lire')) {
 			// Select contracts with at least one expired service

--- a/htdocs/core/boxes/box_services_expired.php
+++ b/htdocs/core/boxes/box_services_expired.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2011 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024		William Mead	<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/core/boxes/box_shipments.php
+++ b/htdocs/core/boxes/box_shipments.php
@@ -75,7 +75,7 @@ class box_shipments extends ModeleBoxes
 		$societestatic = new Societe($this->db);
 
 		$this->info_box_head = array(
-			'text' => $langs->trans("BoxTitleLastCustomerShipments", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/expedition/list.php?sortfield=e.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => $langs->trans("BoxTitleLastCustomerShipments", $max).'<a class="paddingleft" href="'.DOL_URL_ROOT.'/expedition/list.php?mainmenu=products&leftmenu=sendings&sortfield=e.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('expedition', 'lire')) {

--- a/htdocs/core/boxes/box_supplier_orders.php
+++ b/htdocs/core/boxes/box_supplier_orders.php
@@ -71,7 +71,7 @@ class box_supplier_orders extends ModeleBoxes
 
 		$text = $langs->trans("BoxTitleLatest".(getDolGlobalString('MAIN_LASTBOX_ON_OBJECT_DATE') ? "" : "Modified")."SupplierOrders", $max);
 		$this->info_box_head = array(
-			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/fourn/commande/list.php?sortfield=cf.tms&sortorder=DESC"><span class="badge">...</span></a>'
+			'text' => $text.'<a class="paddingleft" href="'.DOL_URL_ROOT.'/fourn/commande/list.php?mainmenu=commercial&leftmenu=orders_suppliers&sortfield=cf.tms&sortorder=DESC"><span class="badge">...</span></a>'
 		);
 
 		if ($user->hasRight('fournisseur', 'commande', 'lire')) {


### PR DESCRIPTION
# Fix board info box list links menus
This PR fixes the main & left menus shown when opening the info boxes links on home page board. Currently when opening each list from the badge on board info boxes will leave the main & left menus as default (home). The benefit for end user is improved navigation experience.


