### PR TITLE
Fix undefined tag category array keys

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -173,7 +173,9 @@ class Categorie extends CommonObject
 		'project' => 'ProjectsCategoriesArea',
 		'warehouse' => 'StocksCategoriesArea',
 		'actioncomm' => 'ActioncommCategoriesArea',
-		'website_page' => 'WebsitePageCategoriesArea'
+		'website_page' => 'WebsitePageCategoriesArea',
+		'ticket' => 'TicketCategoriesArea',
+		'knowledgemanagement' => 'KnowledgemanagementCategoriesArea'
 	);
 
 	/**


### PR DESCRIPTION
# Fix undefined tag category array keys for ticket & knowledge management modules
Undefined array key "knowledgemanagement" (/var/www/dolibarr/21.0/htdocs/categories/viewcat.php:258)
Undefined array key "ticket" (/var/www/dolibarr/21.0/htdocs/categories/viewcat.php:258)


