### PR TITLE
Fix ticket category html form warnings

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -7710,7 +7710,7 @@ class Form
 
 			if (!$forcecombo) {
 				include_once DOL_DOCUMENT_ROOT . '/core/lib/ajax.lib.php';
-				$out .= ajax_combobox($htmlname, $events, $conf->global->TICKET_USE_SEARCH_TO_SELECT);
+				$out .= ajax_combobox($htmlname, $events, getDolGlobalString('TICKET_USE_SEARCH_TO_SELECT'));
 			}
 
 			$out .= '<select class="flat' . ($morecss ? ' ' . $morecss : '') . '" name="' . $htmlname . '" id="' . $htmlname . '">';
@@ -7783,7 +7783,6 @@ class Form
 
 		$outkey = $objp->rowid;
 		$outref = $objp->ref;
-		$outtype = $objp->fk_product_type;
 
 		$opt = '<option value="' . $objp->rowid . '"';
 		$opt .= ($objp->rowid == $selected) ? ' selected' : '';

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -24,6 +24,7 @@
  * Copyright (C) 2023		Joachim Kueter			<git-jk@bloxera.com>
  * Copyright (C) 2023		Nick Fragoulis
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
# Fix ticket category html form warnings
Warnings on viewing `htdocs/categories/viewcat.php` for ticket category
```
Undefined property: stdClass::$TICKET_USE_SEARCH_TO_SELECT (/var/www/dolibarr/21.0/htdocs/core/class/html.form.class.php:7713)
Undefined property: stdClass::$fk_product_type (/var/www/dolibarr/21.0/htdocs/core/class/html.form.class.php:7786)
```


