### PR TITLE
Qual: 🛟 Fix CI Issues ($db to $this->db / LDAP typing / Win-ci cache md5sum)

### DIFF
--- a/dev/setup/phpunit/setup_conf.sh
+++ b/dev/setup/phpunit/setup_conf.sh
@@ -129,6 +129,14 @@ if [ "$DB" = 'mysql' ] || [ "$DB" = 'mariadb' ] || [ "$DB" = 'postgresql' ]; the
 	${SUDO} "${MYSQL}" -u "$DB_ROOT" -h 127.0.0.1 $PASS_OPT -e 'FLUSH PRIVILEGES;'
 
 	sum=$(find "${TRAVIS_BUILD_DIR}/htdocs/install" -type f -exec md5sum {} + | LC_ALL=C sort | md5sum)
+	cnt=$(find "${TRAVIS_BUILD_DIR}/htdocs/install" -type f -exec md5sum {} + | wc)
+	echo "OLDSUM $sum COUNT:$cnt"
+
+	# shellcheck disable=2046
+	sum=$(md5sum $(find "${TRAVIS_BUILD_DIR}/htdocs/install" -type f) | LC_ALL=C sort | md5sum)
+	# shellcheck disable=2046
+	cnt=$(md5sum $(find "${TRAVIS_BUILD_DIR}/htdocs/install" -type f) | wc)
+	echo "NEWSUM $sum COUNT:$cnt"
 	load_cache=0
 	if [ -r "$DB_CACHE_FILE".md5 ] && [ -r "$DB_CACHE_FILE" ] && [ -x "$(which "${MYSQLDUMP}")" ] ; then
 		cache_sum="$(<"$DB_CACHE_FILE".md5)"

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2005-2021	Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2006-2021	Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2024		William Mead		<william.mead@manchenumerique.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -539,6 +540,7 @@ class Ldap
 			}
 		} else {
 			if (is_resource($this->connection)) {
+				// @phan-suppress-next-line PhanTypeMismatchArgumentInternalReal
 				$this->result = @ldap_unbind($this->connection);
 			}
 		}

--- a/htdocs/core/login/functions_ldap.php
+++ b/htdocs/core/login/functions_ldap.php
@@ -255,7 +255,7 @@ function check_user_password_ldap($usertotest, $passwordtotest, $entitytotest)
 					$ldap->ldapErrorText = ldap_error($ldap->connection);
 					dol_syslog("functions_ldap::check_user_password_ldap ".$ldap->ldapErrorCode." ".$ldap->ldapErrorText);
 				} catch (Throwable $exception) {
-					$ldap->ldapErrorCode = '';
+					$ldap->ldapErrorCode = 0;
 					$ldap->ldapErrorText = '';
 					dol_syslog('functions_ldap::check_user_password_ldap '.$exception, LOG_WARNING);
 				}

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -233,7 +233,7 @@ class Ticket extends CommonObject
 	public $email_msgid;
 
 	/**
-	 * @var string 	Email Date
+	 * @var null|int|'' 	Email Date
 	 */
 	public $email_date;
 

--- a/htdocs/website/class/websitepage.class.php
+++ b/htdocs/website/class/websitepage.class.php
@@ -707,7 +707,7 @@ class WebsitePage extends CommonObject
 
 		if ($istranslation) {
 			if (is_null($website)) {
-				$website = new Website($db);
+				$website = new Website($this->db);
 			}
 			$website->fetch($object->fk_website);
 


### PR DESCRIPTION
# Qual: 🛟 Fix CI Issues ($db to $this->db / LDAP typing / Win-ci cache md5sum)

- $db was undeclared, use $this->db.
- Also some typing with LDAP (initialize/reset error number, ignore notice wrt 'resource')
- Update the type of email_date for tickets;
- Correct md5sum calculation for reusing sql cache (work around issue with `find` command and environment limit on windows).