### PR TITLE
FIX: wrong wording when user has no right to transfer stock

### DIFF
--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -945,7 +945,7 @@ if (empty($reshook)) {
 				print '<a class="butActionRefused classfortooltip" href="#" title="'.$langs->trans("ActionAvailableOnVariantProductOnly").'">'.$langs->trans("TransferStock").'</a>';
 			}
 		} else {
-			print '<a class="butActionRefused classfortooltip" href="#" title="'.$langs->trans("NotEnoughPermissions").'">'.$langs->trans("CorrectStock").'</a>';
+			print '<a class="butActionRefused classfortooltip" href="#" title="'.$langs->trans("NotEnoughPermissions").'">'.$langs->trans("TransferStock").'</a>';
 		}
 
 		if ($user->hasRight('stock', 'mouvement', 'creer')) {


### PR DESCRIPTION
"Correct Stock" is used for both disabled buttons : 

![image](https://github.com/user-attachments/assets/56e50909-592b-4891-aaff-8ae590d3f093)
