### PR TITLE
FIX - Substitution error in ticket emails in the subject

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1492,7 +1492,7 @@ class FormTicket
 			// Subject/topic
 			$topic = "";
 			foreach ($formmail->lines_model as $line) {
-				if ($this->param['models_id'] == $line->id) {
+				if (!empty($this->substit) && $this->param['models_id'] == $line->id) {
 					$topic = make_substitutions($line->topic, $this->substit);
 					break;
 				}

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1493,7 +1493,7 @@ class FormTicket
 			$topic = "";
 			foreach ($formmail->lines_model as $line) {
 				if ($this->param['models_id'] == $line->id) {
-					$topic = $line->topic;
+					$topic = make_substitutions($line->topic, $this->substit);
 					break;
 				}
 			}


### PR DESCRIPTION
# FIX - *Substitution error in ticket emails in the subject*
*When applying an email template to a ticket email. Keys are not substituted in the subject.*
