### PR TITLE
fix #30800 bad GetUrlContent with no hearders for webhook

### DIFF
--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -120,7 +120,12 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 
 				$jsonstr = json_encode($resobject);
 
-				$response = getURLContent($tmpobject->url, 'POST', $jsonstr, 1, array(), array('http', 'https'), 0, -1);
+				$headers = array(
+					'Content-Type: application/json',
+					'Accept: application/json'
+				);
+
+				$response = getURLContent($tmpobject->url, 'POST', $jsonstr, 1, $headers, array('http', 'https'), 2, -1);
 				if (empty($response['curl_error_no']) && $response['http_code'] >= 200 && $response['http_code'] < 300) {
 					$nbPosts++;
 				} else {


### PR DESCRIPTION
Fix a bad way to send data to an url to GetURLContent by adding hearders and matching develop way 

The actual way to send data create a bad parse of the data in the website that receive the data