### PR TITLE
Fix drop down ergonomy and feedback

### DIFF
--- a/htdocs/core/js/lib_head.js.php
+++ b/htdocs/core/js/lib_head.js.php
@@ -1324,7 +1324,7 @@ jQuery(document).ready(function() {
 	jQuery(".butAction.dropdown-toggle").on("click", function(event) {
 		console.log("Click on .butAction.dropdown-toggle");
 		var parentholder = jQuery(".butAction.dropdown-toggle").closest(".dropdown");
-			 var offset = parentholder.offset();
+		var offset = parentholder.offset();
 		var widthdocument = $(document).width();
 		var left = offset.left;
 		var right = widthdocument - offset.left - parentholder.width();
@@ -1335,6 +1335,18 @@ jQuery(document).ready(function() {
 		}
 		parentholder.toggleClass("open");
 		parentholder.children(".dropdown-content").css({"right": right+"px", "left": "auto"});
+	});
+
+	// Close drop down
+	jQuery(document).on("click", function(event) {
+		// search if click was outside drop down
+		if (!$(event.target).closest('.butAction.dropdown-toggle').length) {
+			let parentholder = jQuery(".butAction.dropdown-toggle").closest(".dropdown.open");
+			if(parentholder){
+				// Hide the menus.
+				parentholder.removeClass("open");
+			}
+		}
 	});
 });
 

--- a/htdocs/theme/eldy/btn.inc.php
+++ b/htdocs/theme/eldy/btn.inc.php
@@ -137,9 +137,10 @@ span.butActionNewRefused>span.fa, span.butActionNewRefused>span.fa:hover
 	box-shadow: none; webkit-box-shadow: none;
 }
 
-.butAction:hover   {
-	-webkit-box-shadow: 0px 0px 6px 1px rgba(50, 50, 50, 0.4), 0px 0px 0px rgba(60,60,60,0.1);
-	box-shadow: 0px 0px 6px 1px rgba(50, 50, 50, 0.4), 0px 0px 0px rgba(60,60,60,0.1);
+.butAction:hover, .dropdown-holder.open > .butAction   {
+	/** TODO use css var with hsl from --colortextlink to allow create darken or lighten color */
+	-webkit-box-shadow: 5px 5px 0px rgba(0,0,0,0.1), inset 0px 0px 200px rgba(0,0,0,0.3); /* fix hover feedback : use "inset" background to easily darken background */
+	box-shadow: 5px 5px 0px rgba(0,0,0,0.1), inset 0px 0px 200px rgba(0,0,0,0.3); /* fix hover feedback : use "inset" background to easily darken background */
 }
 .butActionNew:hover   {
 	text-decoration: underline;

--- a/htdocs/theme/eldy/dropdown.inc.php
+++ b/htdocs/theme/eldy/dropdown.inc.php
@@ -538,7 +538,9 @@ dropdown-holder {
 	right:10px;	/* will be set with js */
 	background: #fff;
 	border: 1px solid #bbb;
-	text-align: <?php echo $left; ?>
+	text-align: <?php echo $left; ?>;
+	-webkit-box-shadow: 5px 5px 0px rgba(0,0,0,0.1);
+	box-shadow: 5px 5px 0px rgba(0,0,0,0.1);
 }
 
 .dropdown-content a {
@@ -566,6 +568,20 @@ dropdown-holder {
 	display: block;
 }
 
+/** dropdown arrow used to clearly identify parent button of dropdown*/
+.dropdown-holder.open .dropdown-content::before {
+	--triangleBorderSize : 5px;
+	position: absolute;
+	content: "";
+	top: calc(var(--triangleBorderSize) * -1);
+	right: 12px;
+	width: 0px;
+	height: 0px;
+	border-style: solid;
+	border-width: 0 var(--triangleBorderSize) var(--triangleBorderSize) var(--triangleBorderSize);
+	border-color: transparent transparent #ffff transparent;
+	transform: rotate(0deg);
+}
 
 
 /* smartphone */


### PR DESCRIPTION
# Instructions
On dropdown action buttons, we're currently have to re-click on the button to close the dropdown; it's not possible to simply click outside the dropdown. This creates frustration and errors in clicking on the right button, as the button in use is not sufficiently identifiable.

I know that the active button can be identified by the little chevron, but it's no use. My testers almost all made the mistake of clicking on send mail at least once instead of clicking on create again to close dropdown.


# FIX

- Add js to dectect a click outside the dropdown to close it.
- modify css to simplify identification of active button and provide clear feedback on hover too
   _note : I had to revise the shadows of the box because with the darkening of the background on hovering, the external shadows gave a slobbery look._    


BEFORE 
![image](https://github.com/user-attachments/assets/4d455160-eeb7-484e-b705-d351d2c3bb3d)

AFTER
![image](https://github.com/user-attachments/assets/6e3ea5ed-e64e-44d3-ad0c-c0deb1d79160)



BEFORE
![image](https://github.com/user-attachments/assets/cdf65ce7-4815-487e-ba80-9d8b43061e96)

AFTER
![image](https://github.com/user-attachments/assets/14e008dd-b320-4b13-990b-daa7923b70f1)
