### PR TITLE
FIX #30772 Accountancy document export - The project filter on expenses report don't work

### DIFF
--- a/htdocs/compta/accounting-files.php
+++ b/htdocs/compta/accounting-files.php
@@ -213,7 +213,7 @@ if (($action == 'searchfiles' || $action == 'dl')) {
 			// if project filter is used on an expense report,
 			// show only total_ht/total_tva/total_ttc of the line considered by the project
 			if (!empty($projectid)) {
-				$sql .= " SELECT t.rowid as id, t.entity, t.ref, t.paid, td.total_ht, td.total_ttc, td.total_tva as total_vat,";
+				$sql .= " SELECT t.rowid as id, t.entity, t.ref, t.paid, SUM(td.total_ht) as total_ht, SUM(td.total_ttc) as total_ttc, SUM(td.total_tva) as total_vat,";
 				$sql .= " 0 as localtax1, 0 as localtax2, 0 as revenuestamp,";
 				$sql .= " td.multicurrency_code as currency, t.fk_user_author as fk_soc, t.date_fin as date, t.date_fin as date_due, 'ExpenseReport' as item, CONCAT(CONCAT(u.lastname, ' '), u.firstname) as thirdparty_name, '' as thirdparty_code, c.code as country_code, '' as vatnum, " . PAY_DEBIT . " as sens";
 				$sql .= " FROM " . MAIN_DB_PREFIX . "expensereport as t";


### PR DESCRIPTION
Project filter is not considered for expenses report because this module work differently. Project is defined in line of the expenses report, not on the expenses report.

Example with an expense report with only 1 line affected to a project:

![image](https://github.com/user-attachments/assets/f7b6c66f-91b8-453b-b798-6da2c1873408)

Result with no project filter:

![image](https://github.com/user-attachments/assets/2a10198f-b662-4f58-88cb-16c8d2271908)

New result with a project filter defined: (Export show the result & only amount of the line is display)

![image](https://github.com/user-attachments/assets/8a235241-da81-4341-bb67-43bca3260101)


Work properly with several lines attached to a project:

![image](https://github.com/user-attachments/assets/c9bb1b34-64fd-4434-8b27-1ae9908edb4b)

![image](https://github.com/user-attachments/assets/9dea3450-4bb2-4131-ba4a-99622584c167)



