### PR TITLE
NEW: Add a new hook into CommonObject#commonReplaceThirdparty

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9253,6 +9253,21 @@ abstract class CommonObject
 	 */
 	public static function commonReplaceThirdparty(DoliDB $dbs, $origin_id, $dest_id, array $tables, $ignoreerrors = 0)
 	{
+		global $hookmanager;
+
+		$hookmanager->initHooks(array('commonobject'));
+		$parameters = array(
+			'origin_id' => $origin_id,
+			'dest_id' => $dest_id,
+			'tables' => $tables,
+		);
+		$reshook = $hookmanager->executeHooks('commonReplaceThirdparty', $parameters);
+		if ($reshook) {
+			return true; // replacement code
+		} elseif ($reshook < 0) {
+			return $ignoreerrors === 1; // failure
+		} // reshook = 0 => execute normal code
+
 		foreach ($tables as $table) {
 			$sql = 'UPDATE '.$dbs->prefix().$table.' SET fk_soc = '.((int) $dest_id).' WHERE fk_soc = '.((int) $origin_id);
 


### PR DESCRIPTION
Sometime it is useful to complete or override the existing commonReplaceThirdparty behaviour. This can be the case if we need to modify/delete database entries during the replacement and we need to do so during the transaction.

The existing replaceThirdparty hook does not work for such use cases because the previous database transaction (during which replaceThirdParty/commonReplaceThirdParty are executed) may fail. If it's the case then the whole database transaction is going for a rollback rendering any actions done in the existing replaceThirdparty hooks useless.