### PR TITLE
FIX : BadFirstParameterForGETPOST because of $stockLocation in GETPOST

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -767,10 +767,9 @@ if (empty($reshook)) {
 						// line without lot
 						if ($lines[$i]->entrepot_id == 0) {
 							// single warehouse shipment line
-							$stockLocation = 0;
 							$qty = "qtyl".$line_id;
 							$line->id = $line_id;
-							$line->entrepot_id = GETPOST($stockLocation, 'int');
+							$line->entrepot_id = 0;
 							$line->qty = GETPOST($qty, 'int');
 							if ($line->update($user) < 0) {
 								setEventMessages($line->error, $line->errors, 'errors');

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -775,7 +775,6 @@ if (empty($reshook)) {
 								setEventMessages($line->error, $line->errors, 'errors');
 								$error++;
 							}
-							unset($_POST[$stockLocation]);
 							unset($_POST[$qty]);
 						} elseif ($lines[$i]->entrepot_id > 0) {
 							// single warehouse shipment line


### PR DESCRIPTION
# FIX|Fix #BadFirstParameterForGETPOST
When trying to edit a line of expedition, I had an error : Unknown column 'BadFirstParameterForGETPOST' in 'field list' - sql=UPDATE llx_expeditiondet SET fk_entrepot = BadFirstParameterForGETPOST , qty = 0 WHERE rowid = 4244"
Because $stockLocation in GETPOST was equal to 0