### PR TITLE
NEW: added column default_rib in llx_user_rib

### DIFF
--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -1057,7 +1057,7 @@ class BonPrelevement extends CommonObject
 				$sql .= " FROM " . MAIN_DB_PREFIX . "salary as f";
 				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "prelevement_demande as pd ON f.rowid = pd.fk_salary";
 				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "user as s ON s.rowid = f.fk_user";
-				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "user_rib as sr ON s.rowid = sr.fk_user AND sr.default_rib = 1";
+				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "user_rib as sr ON s.rowid = sr.fk_user"; // TODO Add AND sr.default_rib = 1 here. UPDATE 5 sep 2024: the column has been created in llx_user_rib and default to 0
 			}
 			if ($sourcetype != 'salary') {
 				if ($type != 'bank-transfer') {

--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -1057,7 +1057,7 @@ class BonPrelevement extends CommonObject
 				$sql .= " FROM " . MAIN_DB_PREFIX . "salary as f";
 				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "prelevement_demande as pd ON f.rowid = pd.fk_salary";
 				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "user as s ON s.rowid = f.fk_user";
-				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "user_rib as sr ON s.rowid = sr.fk_user";	// TODO Add AND sr.default_rib = 1 here
+				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "user_rib as sr ON s.rowid = sr.fk_user AND sr.default_rib = 1";
 			}
 			if ($sourcetype != 'salary') {
 				if ($type != 'bank-transfer') {

--- a/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
+++ b/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
@@ -87,6 +87,7 @@ ALTER TABLE llx_c_hrm_public_holiday ADD UNIQUE INDEX uk_c_hrm_public_holiday(en
 ALTER TABLE llx_c_hrm_public_holiday ADD UNIQUE INDEX uk_c_hrm_public_holiday2(entity, fk_country, dayrule, day, month, year);
 
 ALTER TABLE llx_societe_account ADD COLUMN date_last_reset_password datetime after date_previous_login;
+ALTER TABLE llx_user_rib ADD COLUMN default_rib smallint NOT NULL DEFAULT 1;
 
 -- Rename of bank table
 ALTER TABLE llx_bank_categ RENAME TO llx_category_bank;		-- TODO Move content into llx_categorie instead of renaming it

--- a/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
+++ b/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
@@ -87,7 +87,7 @@ ALTER TABLE llx_c_hrm_public_holiday ADD UNIQUE INDEX uk_c_hrm_public_holiday(en
 ALTER TABLE llx_c_hrm_public_holiday ADD UNIQUE INDEX uk_c_hrm_public_holiday2(entity, fk_country, dayrule, day, month, year);
 
 ALTER TABLE llx_societe_account ADD COLUMN date_last_reset_password datetime after date_previous_login;
-ALTER TABLE llx_user_rib ADD COLUMN default_rib smallint NOT NULL DEFAULT 1;
+ALTER TABLE llx_user_rib ADD COLUMN default_rib smallint NOT NULL DEFAULT 0;
 
 -- Rename of bank table
 ALTER TABLE llx_bank_categ RENAME TO llx_category_bank;		-- TODO Move content into llx_categorie instead of renaming it

--- a/htdocs/install/mysql/tables/llx_user_rib.sql
+++ b/htdocs/install/mysql/tables/llx_user_rib.sql
@@ -37,5 +37,6 @@ create table llx_user_rib
   owner_address     varchar(255),
   state_id          integer,
   fk_country        integer,
-  currency_code     varchar(3)
+  currency_code     varchar(3),
+  default_rib       smallint(6) DEFAULT 1 NOT NULL
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_user_rib.sql
+++ b/htdocs/install/mysql/tables/llx_user_rib.sql
@@ -38,5 +38,5 @@ create table llx_user_rib
   state_id          integer,
   fk_country        integer,
   currency_code     varchar(3),
-  default_rib       smallint(6) DEFAULT 1 NOT NULL
+  default_rib       smallint(6) DEFAULT 0 NOT NULL
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_user_rib.sql
+++ b/htdocs/install/mysql/tables/llx_user_rib.sql
@@ -38,5 +38,5 @@ create table llx_user_rib
   state_id          integer,
   fk_country        integer,
   currency_code     varchar(3),
-  default_rib       smallint(6) DEFAULT 0 NOT NULL
+  default_rib       smallint DEFAULT 0 NOT NULL
 )ENGINE=innodb;


### PR DESCRIPTION
# NEW|New column default_rib in llx_user_rib as requested in a TODO

In htdocs/compta/prelevement/class/bonprelevement.class.php, a TODO requested the following (see image):
![image](https://github.com/user-attachments/assets/b03cd190-3e3b-4ac3-8145-8f2946ccdc59)

In order to do that, we need to add a "default_rib" column to llx_user.

THIS COLUMN IS DEFAULTED AS 1 TO ALLOW RETROCOMPATIBILITY. The column isn't used yet so  it was set to default at 1 to make sure the newly added condition doesn't mess with existing processes.

This PR is made to prepare a future PR for this feature request about RIB : https://github.com/Dolibarr/dolibarr/issues/30810

