### PR TITLE
NEW mass action line update margin and mark rate propal/commande/facture

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -989,6 +989,7 @@ if (empty($reshook)) {
 		$margin_rate = GETPOSTISSET('marginforalllines') ? GETPOST('marginforalllines', 'int') : '';
 		$mark_rate = GETPOSTISSET('markforalllines') ? GETPOST('markforalllines', 'int') : '';
 		foreach ($object->lines as &$line) {
+			$subprice_multicurrency = $line->subprice;
 			if (is_numeric($margin_rate) && $margin_rate > 0) {
 				$line->subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
 			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
@@ -1006,7 +1007,7 @@ if (empty($reshook)) {
 				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 			// Manage $line->subprice and $line->multicurrency_subprice
-			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $subprice_multicurrency;
 			// Update DB
 			$result = $object->updateline($line->id, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit, $multicurrency_subprice);
 			// Update $object with new margin info
@@ -1020,9 +1021,9 @@ if (empty($reshook)) {
 				$line->total_tva = $line->tva_tx * $line->qty * (float) $line->subprice;
 				$line->total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice;
 				// Manage $line->subprice and $line->multicurrency_subprice
-				$line->multicurrency_total_ht = $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
-				$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
-				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_ht = $line->qty * (float) $subprice_multicurrency * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $subprice_multicurrency * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $subprice_multicurrency* $line->multicurrency_subprice / $line->subprice;
 				// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
 				$line->multicurrency_subprice = $multicurrency_subprice;
 			}else{

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -990,11 +990,11 @@ if (empty($reshook)) {
 		foreach ($object->lines as &$line) {
 			$subprice_multicurrency = $line->subprice;
 			if (is_numeric($margin_rate) && $margin_rate > 0) {
-				$line->subprice = price2num($line->pa_ht * (1 + floatval($margin_rate) / 100), 'MU');
+				$line->subprice = floatval(price2num(floatval($line->pa_ht) * (1 + floatval($margin_rate) / 100), 'MU'));
 			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
-				$line->subprice = $line->pa_ht / (1 - (floatval($mark_rate) / 100));
+				$line->subprice = floatval($line->pa_ht / (1 - (floatval($mark_rate) / 100)));
 			} else {
-				$line->subprice = $line->pa_ht;
+				$line->subprice = floatval($line->pa_ht);
 			}
 			$prod = new Product($db);
 			$res = $prod->fetch($line->fk_product);

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -978,11 +978,10 @@ if (empty($reshook)) {
 			}
 			$result = $object->updateline($line->id, $line->subprice, $line->qty, $remise_percent, $tvatx, $line->localtax1_tx, $line->localtax2_tx, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->label, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit, $line->multicurrency_subprice);
 		}
-	} elseif (	$action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
+	} elseif ($action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
 				&& GETPOST('marginforalllines') !== '' && $usercancreate) ||
 				(GETPOST('submitforallmark', 'alpha')
 				&& GETPOST('markforalllines') !== '' && $usercancreate)) {
-
 		$outlangs = $langs;
 
 		// Define margin
@@ -991,9 +990,9 @@ if (empty($reshook)) {
 		foreach ($object->lines as &$line) {
 			$subprice_multicurrency = $line->subprice;
 			if (is_numeric($margin_rate) && $margin_rate > 0) {
-				$line->subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
+				$line->subprice = price2num($line->pa_ht * (1 + floatval($margin_rate) / 100), 'MU');
 			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
-				$line->subprice = $line->pa_ht / (1 - ($mark_rate / 100));
+				$line->subprice = $line->pa_ht / (1 - (floatval($mark_rate) / 100));
 			} else {
 				$line->subprice = $line->pa_ht;
 			}
@@ -1003,18 +1002,18 @@ if (empty($reshook)) {
 				$price_subprice  = price($line->subprice, 0, $outlangs, 1, -1, -1, 'auto');
 				$price_price_min = price($prod->price_min, 0, $outlangs, 1, -1, -1, 'auto');
 				setEventMessages($prod->ref.' - '.$prod->label.' ('.$price_subprice.' < '.$price_price_min.' '.strtolower($langs->trans("MinPrice")).')'."\n", null, 'warnings');
-			}else{
+			} else {
 				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 			// Manage $line->subprice and $line->multicurrency_subprice
 			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $subprice_multicurrency;
 			// Update DB
-			$result = $object->updateline($line->id, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit, $multicurrency_subprice);
+			$result = $object->updateline($line->id, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit, $multicurrency_subprice);
 			// Update $object with new margin info
-			if ($result > 0){
+			if ($result > 0) {
 				if (is_numeric($margin_rate) && empty($mark_rate)) {
 					$line->marge_tx = $margin_rate;
-				}elseif (is_numeric($mark_rate) && empty($margin_rate)) {
+				} elseif (is_numeric($mark_rate) && empty($margin_rate)) {
 					$line->marque_tx = $mark_rate;
 				}
 				$line->total_ht = $line->qty * (float) $line->subprice;
@@ -1026,7 +1025,7 @@ if (empty($reshook)) {
 				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $subprice_multicurrency* $line->multicurrency_subprice / $line->subprice;
 				// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
 				$line->multicurrency_subprice = $multicurrency_subprice;
-			}else{
+			} else {
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -987,7 +987,14 @@ if (empty($reshook)) {
 		$margin_rate = (GETPOST('marginforalllines') ? GETPOST('marginforalllines') : 0);
 		$mark_rate = (GETPOST('markforalllines') ? GETPOST('markforalllines') : 0);
 		foreach ($object->lines as &$line) {
-			$subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
+			if (GETPOST('marginforalllines') > 0){
+				$margin_rate = GETPOST('marginforalllines');
+				$subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
+			}elseif($mark_rate > 0) {
+				$margin_rate = price2num((( $line->total_ht - $line->pa_ht) / $line->pa_ht) *100, 'MU');
+				$subprice = $line->pa_ht / (1-(GETPOST('markforalllines') /100));
+			}
+
 			$prod = new Product($db);
 			$prod->fetch($line->fk_product);
 			if ($prod->price_min > $subprice) {

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -978,57 +978,56 @@ if (empty($reshook)) {
 			}
 			$result = $object->updateline($line->id, $line->subprice, $line->qty, $remise_percent, $tvatx, $line->localtax1_tx, $line->localtax2_tx, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->label, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit, $line->multicurrency_subprice);
 		}
-	} elseif ($action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
-		&& GETPOST('marginforalllines') !== '' && $usercancreate) ||
-		(GETPOST('submitforallmark', 'alpha')
-			&& GETPOST('markforalllines') !== '' && $usercancreate)
-	) {
-		// Define margin
-		$margin_rate = (GETPOST('marginforalllines') ? GETPOST('marginforalllines') : 0);
-		$mark_rate = (GETPOST('markforalllines') ? GETPOST('markforalllines') : 0);
-		foreach ($object->lines as &$line) {
-			if (GETPOST('marginforalllines') > 0){
-				$margin_rate = GETPOST('marginforalllines');
-				$subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
-			}elseif($mark_rate > 0) {
-				$margin_rate = price2num((( $line->total_ht - $line->pa_ht) / $line->pa_ht) *100, 'MU');
-				$subprice = $line->pa_ht / (1-(GETPOST('markforalllines') /100));
-			}
+	} elseif (	$action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
+				&& GETPOST('marginforalllines') !== '' && $usercancreate) ||
+				(GETPOST('submitforallmark', 'alpha')
+				&& GETPOST('markforalllines') !== '' && $usercancreate)) {
 
+		$outlangs = $langs;
+
+		// Define margin
+		$margin_rate = GETPOSTISSET('marginforalllines') ? GETPOST('marginforalllines', 'int') : '';
+		$mark_rate = GETPOSTISSET('markforalllines') ? GETPOST('markforalllines', 'int') : '';
+		foreach ($object->lines as &$line) {
+			if (is_numeric($margin_rate) && $margin_rate > 0) {
+				$line->subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
+			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
+				$line->subprice = $line->pa_ht / (1 - ($mark_rate / 100));
+			} else {
+				$line->subprice = $line->pa_ht;
+			}
 			$prod = new Product($db);
-			$prod->fetch($line->fk_product);
-			if ($prod->price_min > $subprice) {
-				$price_subprice  = price($subprice, 0, $outlangs, 1, -1, -1, 'auto');
+			$res = $prod->fetch($line->fk_product);
+			if ($res > 0 && $prod->price_min > $line->subprice) {
+				$price_subprice  = price($line->subprice, 0, $outlangs, 1, -1, -1, 'auto');
 				$price_price_min = price($prod->price_min, 0, $outlangs, 1, -1, -1, 'auto');
 				setEventMessages($prod->ref.' - '.$prod->label.' ('.$price_subprice.' < '.$price_price_min.' '.strtolower($langs->trans("MinPrice")).')'."\n", null, 'warnings');
+			}else{
+				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 			// Manage $line->subprice and $line->multicurrency_subprice
-			$multicurrency_subprice = (float) $subprice * $line->multicurrency_subprice / $line->subprice;
+			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
 			// Update DB
-			$result = $object->updateline($line->id, $subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->label, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit, $multicurrency_subprice);
+			$result = $object->updateline($line->id, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit, $multicurrency_subprice);
 			// Update $object with new margin info
-
-//			$T = getMarginInfos($subprice, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, $line->fk_fournprice, $line->pa_ht);
-//			var_dump($T);
-
-			$line->price = $subprice;
-			if (!empty(GETPOST('marginforalllines'))) {
-				$line->marge_tx = $margin_rate;
-				$line->marque_tx = $margin_rate * $line->pa_ht / (float) $subprice;
-			}else {
-				$line->marge_tx = 100 * ($line->total_ht - $line->pa_ht) / (float) $subprice;
-				$line->marque_tx = $mark_rate;
+			if ($result > 0){
+				if (is_numeric($margin_rate) && empty($mark_rate)) {
+					$line->marge_tx = $margin_rate;
+				}elseif (is_numeric($mark_rate) && empty($margin_rate)) {
+					$line->marque_tx = $mark_rate;
+				}
+				$line->total_ht = $line->qty * (float) $line->subprice;
+				$line->total_tva = $line->tva_tx * $line->qty * (float) $line->subprice;
+				$line->total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice;
+				// Manage $line->subprice and $line->multicurrency_subprice
+				$line->multicurrency_total_ht = $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
+				$line->multicurrency_subprice = $multicurrency_subprice;
+			}else{
+				setEventMessages($object->error, $object->errors, 'errors');
 			}
-			$line->total_ht = $line->qty * (float) $subprice;
-			$line->total_tva = $line->tva_tx * $line->qty * (float) $subprice;
-			$line->total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $subprice;
-			// Manage $line->subprice and $line->multicurrency_subprice
-			$line->multicurrency_total_ht = $line->qty * (float) $subprice * $line->multicurrency_subprice / $line->subprice;
-			$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $subprice * $line->multicurrency_subprice / $line->subprice;
-			$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $subprice * $line->multicurrency_subprice / $line->subprice;
-			// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
-			$line->subprice = $subprice;
-			$line->multicurrency_subprice = $multicurrency_subprice;
 		}
 	} elseif ($action == 'addline' && !GETPOST('submitforalllines', 'alpha') && !GETPOST('submitforallmargins', 'alpha') && $usercancreate) {		// Add line
 		// Set if we used free entry or predefined product

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -974,7 +974,6 @@ class Propal extends CommonObject
 			$this->line->multicurrency_total_ht 	= $multicurrency_total_ht;
 			$this->line->multicurrency_total_tva 	= $multicurrency_total_tva;
 			$this->line->multicurrency_total_ttc 	= $multicurrency_total_ttc;
-var_dump($pu_ht);
 			$result = $this->line->update($notrigger);
 			if ($result > 0) {
 				// Reorder if child line

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -931,7 +931,6 @@ class Propal extends CommonObject
 				$rangmax = $this->line_max($fk_parent_line);
 				$this->line->rang = $rangmax + 1;
 			}
-
 			$this->line->id = $rowid;
 			$this->line->label = $label;
 			$this->line->desc = $desc;
@@ -975,7 +974,7 @@ class Propal extends CommonObject
 			$this->line->multicurrency_total_ht 	= $multicurrency_total_ht;
 			$this->line->multicurrency_total_tva 	= $multicurrency_total_tva;
 			$this->line->multicurrency_total_ttc 	= $multicurrency_total_ttc;
-
+var_dump($pu_ht);
 			$result = $this->line->update($notrigger);
 			if ($result > 0) {
 				// Reorder if child line

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -688,6 +688,57 @@ if (empty($reshook)) {
 			}
 			$result = $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $remise_percent, $tvatx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->date_start, $line->date_end, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $line->fk_unit, $line->multicurrency_subprice);
 		}
+	}  elseif (	$action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
+				&& GETPOST('marginforalllines') !== '' && $usercancreate) ||
+				(GETPOST('submitforallmark', 'alpha')
+				&& GETPOST('markforalllines') !== '' && $usercancreate)) {
+		$outlangs = $langs;
+		// Define margin
+		$margin_rate = GETPOSTISSET('marginforalllines') ? GETPOST('marginforalllines', 'int') : '';
+		$mark_rate = GETPOSTISSET('markforalllines') ? GETPOST('markforalllines', 'int') : '';
+		foreach ($object->lines as &$line) {
+			if (is_numeric($margin_rate) && $margin_rate > 0) {
+				$line->subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
+			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
+				$line->subprice = $line->pa_ht / (1 - ($mark_rate / 100));
+			} else {
+				$line->subprice = $line->pa_ht;
+			}
+
+			$prod = new Product($db);
+			$res = $prod->fetch($line->fk_product);
+			if ($res > 0 && $prod->price_min > $line->subprice) {
+				$price_subprice  = price($line->subprice, 0, $outlangs, 1, -1, -1, 'auto');
+				$price_price_min = price($prod->price_min, 0, $outlangs, 1, -1, -1, 'auto');
+				setEventMessages($prod->ref.' - '.$prod->label.' ('.$price_subprice.' < '.$price_price_min.' '.strtolower($langs->trans("MinPrice")).')'."\n", null, 'warnings');
+			}else{
+				setEventMessages($prod->error, $prod->errors, 'errors');
+			}
+			// Manage $line->subprice and $line->multicurrency_subprice
+			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+			// Update DB
+			$result = $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, 'HT', $line->info_bits, $line->date_start, $line->date_end, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->fk_unit, $multicurrency_subprice);
+			// Update $object with new margin info
+			if ($result > 0) {
+				if (is_numeric($margin_rate) && empty($mark_rate)) {
+					$line->marge_tx = $margin_rate;
+				}elseif (is_numeric($mark_rate) && empty($margin_rate)) {
+					$line->marque_tx = $mark_rate;
+				}
+				$line->total_ht = $line->qty * (float) $line->subprice;
+				$line->total_tva = $line->tva_tx * $line->qty * (float) $line->subprice;
+				$line->total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice;
+				// Manage $line->subprice and $line->multicurrency_subprice
+				$line->multicurrency_total_ht = $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
+				$line->multicurrency_subprice = $multicurrency_subprice;
+			}else{
+				setEventMessages($object->error, $object->errors, 'errors');
+			}
+		}
+
 	} elseif ($action == 'addline' && !GETPOST('submitforalllines', 'alpha') && $usercancreate) {		// Add a new line
 		$langs->load('errors');
 		$error = 0;

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -697,6 +697,7 @@ if (empty($reshook)) {
 		$margin_rate = GETPOSTISSET('marginforalllines') ? GETPOST('marginforalllines', 'int') : '';
 		$mark_rate = GETPOSTISSET('markforalllines') ? GETPOST('markforalllines', 'int') : '';
 		foreach ($object->lines as &$line) {
+			$subprice_multicurrency = $line->subprice;
 			if (is_numeric($margin_rate) && $margin_rate > 0) {
 				$line->subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
 			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
@@ -715,7 +716,7 @@ if (empty($reshook)) {
 				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 			// Manage $line->subprice and $line->multicurrency_subprice
-			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $subprice_multicurrency;
 			// Update DB
 			$result = $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, 'HT', $line->info_bits, $line->date_start, $line->date_end, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->fk_unit, $multicurrency_subprice);
 			// Update $object with new margin info
@@ -729,9 +730,9 @@ if (empty($reshook)) {
 				$line->total_tva = $line->tva_tx * $line->qty * (float) $line->subprice;
 				$line->total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice;
 				// Manage $line->subprice and $line->multicurrency_subprice
-				$line->multicurrency_total_ht = $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
-				$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
-				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_ht = $line->qty * (float) $subprice_multicurrency* $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $subprice_multicurrency * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $subprice_multicurrency * $line->multicurrency_subprice / $line->subprice;
 				// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
 				$line->multicurrency_subprice = $multicurrency_subprice;
 			}else{

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -699,11 +699,11 @@ if (empty($reshook)) {
 		foreach ($object->lines as &$line) {
 			$subprice_multicurrency = $line->subprice;
 			if (is_numeric($margin_rate) && $margin_rate > 0) {
-				$line->subprice = price2num($line->pa_ht * (1 + floatval($margin_rate) / 100), 'MU');
+				$line->subprice = floatval(price2num(floatval($line->pa_ht) * (1 + floatval($margin_rate) / 100), 'MU'));
 			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
-				$line->subprice = $line->pa_ht / (1 - (floatval($mark_rate) / 100));
+				$line->subprice = floatval($line->pa_ht / (1 - (floatval($mark_rate) / 100)));
 			} else {
-				$line->subprice = $line->pa_ht;
+				$line->subprice = floatval($line->pa_ht);
 			}
 
 			$prod = new Product($db);

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -688,7 +688,7 @@ if (empty($reshook)) {
 			}
 			$result = $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $remise_percent, $tvatx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->date_start, $line->date_end, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $line->fk_unit, $line->multicurrency_subprice);
 		}
-	}  elseif (	$action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
+	} elseif (	$action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
 				&& GETPOST('marginforalllines') !== '' && $usercancreate) ||
 				(GETPOST('submitforallmark', 'alpha')
 				&& GETPOST('markforalllines') !== '' && $usercancreate)) {
@@ -699,9 +699,9 @@ if (empty($reshook)) {
 		foreach ($object->lines as &$line) {
 			$subprice_multicurrency = $line->subprice;
 			if (is_numeric($margin_rate) && $margin_rate > 0) {
-				$line->subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
+				$line->subprice = price2num($line->pa_ht * (1 + floatval($margin_rate) / 100), 'MU');
 			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
-				$line->subprice = $line->pa_ht / (1 - ($mark_rate / 100));
+				$line->subprice = $line->pa_ht / (1 - (floatval($mark_rate) / 100));
 			} else {
 				$line->subprice = $line->pa_ht;
 			}
@@ -712,13 +712,13 @@ if (empty($reshook)) {
 				$price_subprice  = price($line->subprice, 0, $outlangs, 1, -1, -1, 'auto');
 				$price_price_min = price($prod->price_min, 0, $outlangs, 1, -1, -1, 'auto');
 				setEventMessages($prod->ref.' - '.$prod->label.' ('.$price_subprice.' < '.$price_price_min.' '.strtolower($langs->trans("MinPrice")).')'."\n", null, 'warnings');
-			}else{
+			} else {
 				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 			// Manage $line->subprice and $line->multicurrency_subprice
 			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $subprice_multicurrency;
 			// Update DB
-			$result = $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, 'HT', $line->info_bits, $line->date_start, $line->date_end, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->fk_unit, $multicurrency_subprice);
+			$result = $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->date_start, $line->date_end, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->fk_unit, $multicurrency_subprice);
 			// Update $object with new margin info
 			if ($result > 0) {
 				if (is_numeric($margin_rate) && empty($mark_rate)) {

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -723,7 +723,7 @@ if (empty($reshook)) {
 			if ($result > 0) {
 				if (is_numeric($margin_rate) && empty($mark_rate)) {
 					$line->marge_tx = $margin_rate;
-				}elseif (is_numeric($mark_rate) && empty($margin_rate)) {
+				} elseif (is_numeric($mark_rate) && empty($margin_rate)) {
 					$line->marque_tx = $mark_rate;
 				}
 				$line->total_ht = $line->qty * (float) $line->subprice;
@@ -735,11 +735,10 @@ if (empty($reshook)) {
 				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $subprice_multicurrency * $line->multicurrency_subprice / $line->subprice;
 				// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
 				$line->multicurrency_subprice = $multicurrency_subprice;
-			}else{
+			} else {
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}
-
 	} elseif ($action == 'addline' && !GETPOST('submitforalllines', 'alpha') && $usercancreate) {		// Add a new line
 		$langs->load('errors');
 		$error = 0;

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2581,9 +2581,9 @@ if (empty($reshook)) {
 		foreach ($object->lines as &$line) {
 			$subprice_multicurrency = $line->subprice;
 			if (is_numeric($margin_rate) && $margin_rate > 0) {
-				$line->subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
+				$line->subprice = price2num(floatval($line->pa_ht) * (1 + floatval($margin_rate) / 100), 'MU');
 			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
-				$line->subprice = $line->pa_ht / (1 - ($mark_rate / 100));
+				$line->subprice = $line->pa_ht / (1 - (floatval($mark_rate) / 100));
 			} else {
 				$line->subprice = $line->pa_ht;
 			}
@@ -2600,7 +2600,7 @@ if (empty($reshook)) {
 			// Manage $line->subprice and $line->multicurrency_subprice
 			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $subprice_multicurrency;
 			// Update DB
-			$result = $object->updateline($line->id, $line->desc, $line->subprice,$line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit, $multicurrency_subprice);
+			$result = $object->updateline($line->id, $line->desc, $line->subprice,$line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit, $multicurrency_subprice);
 			// Update $object with new margin info
 			if ($result > 0) {
 				if (is_numeric($margin_rate) && empty($mark_rate)) {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2570,7 +2570,7 @@ if (empty($reshook)) {
 				$action = '';
 			}
 		}
-	}elseif ($action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
+	} elseif ($action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
 			&& GETPOST('marginforalllines') !== '' && $usercancreate) ||
 			(GETPOST('submitforallmark', 'alpha')
 			&& GETPOST('markforalllines') !== '' && $usercancreate)
@@ -2581,11 +2581,11 @@ if (empty($reshook)) {
 		foreach ($object->lines as &$line) {
 			$subprice_multicurrency = $line->subprice;
 			if (is_numeric($margin_rate) && $margin_rate > 0) {
-				$line->subprice = price2num(floatval($line->pa_ht) * (1 + floatval($margin_rate) / 100), 'MU');
+				$line->subprice = floatval(price2num(floatval($line->pa_ht) * (1 + floatval($margin_rate) / 100), 'MU'));
 			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
-				$line->subprice = $line->pa_ht / (1 - (floatval($mark_rate) / 100));
+				$line->subprice = floatval($line->pa_ht / (1 - (floatval($mark_rate) / 100)));
 			} else {
-				$line->subprice = $line->pa_ht;
+				$line->subprice = floatval($line->pa_ht);
 			}
 
 			$prod = new Product($db);
@@ -2594,18 +2594,18 @@ if (empty($reshook)) {
 				$price_subprice  = price($line->subprice, 0, $outlangs, 1, -1, -1, 'auto');
 				$price_price_min = price($prod->price_min, 0, $outlangs, 1, -1, -1, 'auto');
 				setEventMessages($prod->ref.' - '.$prod->label.' ('.$price_subprice.' < '.$price_price_min.' '.strtolower($langs->trans("MinPrice")).')'."\n", null, 'warnings');
-			}else{
+			} else {
 				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 			// Manage $line->subprice and $line->multicurrency_subprice
 			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $subprice_multicurrency;
 			// Update DB
-			$result = $object->updateline($line->id, $line->desc, $line->subprice,$line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit, $multicurrency_subprice);
+			$result = $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit, $multicurrency_subprice);
 			// Update $object with new margin info
 			if ($result > 0) {
 				if (is_numeric($margin_rate) && empty($mark_rate)) {
 					$line->marge_tx = $margin_rate;
-				}elseif (is_numeric($mark_rate) && empty($margin_rate)) {
+				} elseif (is_numeric($mark_rate) && empty($margin_rate)) {
 					$line->marque_tx = $mark_rate;
 				}
 				$line->total_ht = $line->qty * (float) $line->subprice;
@@ -2617,7 +2617,7 @@ if (empty($reshook)) {
 				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $subprice_multicurrency * $line->multicurrency_subprice / $line->subprice;
 				// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
 				$line->multicurrency_subprice = $multicurrency_subprice;
-			}else{
+			} else {
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2134,7 +2134,7 @@ if (empty($reshook)) {
 			}
 			$result = $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $remise_percent, $line->date_start, $line->date_end, $tvatx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit, $line->multicurrency_subprice);
 		}
-	} elseif ($action == 'addline' && !GETPOST('submitforalllines', 'alpha') && !GETPOST('submitforallmargins', 'alpha') && $usercancreate) {		// Add a new line
+	} elseif ($action == 'addline' && !GETPOST('submitforalllines', 'alpha') && !GETPOST('submitforallmargins', 'alpha') && !GETPOST('submitforallmark', 'alpha')) {		// Add a new line
 		$langs->load('errors');
 		$error = 0;
 
@@ -2568,6 +2568,56 @@ if (empty($reshook)) {
 				}
 
 				$action = '';
+			}
+		}
+	}elseif ($action == 'addline' && (GETPOST('submitforallmargins', 'alpha')
+			&& GETPOST('marginforalllines') !== '' && $usercancreate) ||
+			(GETPOST('submitforallmark', 'alpha')
+			&& GETPOST('markforalllines') !== '' && $usercancreate)
+	) {
+		$outlangs = $langs;
+		$margin_rate = GETPOSTISSET('marginforalllines') ? GETPOST('marginforalllines', 'int') : '';
+		$mark_rate = GETPOSTISSET('markforalllines') ? GETPOST('markforalllines', 'int') : '';
+		foreach ($object->lines as &$line) {
+			if (is_numeric($margin_rate) && $margin_rate > 0) {
+				$line->subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
+			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
+				$line->subprice = $line->pa_ht / (1 - ($mark_rate / 100));
+			} else {
+				$line->subprice = $line->pa_ht;
+			}
+
+			$prod = new Product($db);
+			$res = $prod->fetch($line->fk_product);
+			if ($res > 0 && $prod->price_min > $line->subprice) {
+				$price_subprice  = price($line->subprice, 0, $outlangs, 1, -1, -1, 'auto');
+				$price_price_min = price($prod->price_min, 0, $outlangs, 1, -1, -1, 'auto');
+				setEventMessages($prod->ref.' - '.$prod->label.' ('.$price_subprice.' < '.$price_price_min.' '.strtolower($langs->trans("MinPrice")).')'."\n", null, 'warnings');
+			}else{
+				setEventMessages($prod->error, $prod->errors, 'errors');
+			}
+			// Manage $line->subprice and $line->multicurrency_subprice
+			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+			// Update DB
+			$result = $object->updateline($line->id, $line->desc, $line->subprice,$line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit, $multicurrency_subprice);
+			// Update $object with new margin info
+			if ($result > 0) {
+				if (is_numeric($margin_rate) && empty($mark_rate)) {
+					$line->marge_tx = $margin_rate;
+				}elseif (is_numeric($mark_rate) && empty($margin_rate)) {
+					$line->marque_tx = $mark_rate;
+				}
+				$line->total_ht = $line->qty * (float) $line->subprice;
+				$line->total_tva = $line->tva_tx * $line->qty * (float) $line->subprice;
+				$line->total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice;
+				// Manage $line->subprice and $line->multicurrency_subprice
+				$line->multicurrency_total_ht = $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
+				$line->multicurrency_subprice = $multicurrency_subprice;
+			}else{
+				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}
 	} elseif ($action == 'updateline' && $usercancreate && !GETPOST('cancel', 'alpha')) {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2579,6 +2579,7 @@ if (empty($reshook)) {
 		$margin_rate = GETPOSTISSET('marginforalllines') ? GETPOST('marginforalllines', 'int') : '';
 		$mark_rate = GETPOSTISSET('markforalllines') ? GETPOST('markforalllines', 'int') : '';
 		foreach ($object->lines as &$line) {
+			$subprice_multicurrency = $line->subprice;
 			if (is_numeric($margin_rate) && $margin_rate > 0) {
 				$line->subprice = price2num($line->pa_ht * (1 + $margin_rate / 100), 'MU');
 			} elseif (is_numeric($mark_rate) && $mark_rate > 0) {
@@ -2597,7 +2598,7 @@ if (empty($reshook)) {
 				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 			// Manage $line->subprice and $line->multicurrency_subprice
-			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+			$multicurrency_subprice = (float) $line->subprice * $line->multicurrency_subprice / $subprice_multicurrency;
 			// Update DB
 			$result = $object->updateline($line->id, $line->desc, $line->subprice,$line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_rate, $line->localtax2_rate, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_ref, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit, $multicurrency_subprice);
 			// Update $object with new margin info
@@ -2611,9 +2612,9 @@ if (empty($reshook)) {
 				$line->total_tva = $line->tva_tx * $line->qty * (float) $line->subprice;
 				$line->total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice;
 				// Manage $line->subprice and $line->multicurrency_subprice
-				$line->multicurrency_total_ht = $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
-				$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
-				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $line->subprice * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_ht = $line->qty * (float) $subprice_multicurrency * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_tva = $line->tva_tx * $line->qty * (float) $subprice_multicurrency * $line->multicurrency_subprice / $line->subprice;
+				$line->multicurrency_total_ttc = (1 + $line->tva_tx) * $line->qty * (float) $subprice_multicurrency * $line->multicurrency_subprice / $line->subprice;
 				// Used previous $line->subprice and $line->multicurrency_subprice above, now they can be set to their new values
 				$line->multicurrency_subprice = $multicurrency_subprice;
 			}else{

--- a/htdocs/core/tpl/objectline_title.tpl.php
+++ b/htdocs/core/tpl/objectline_title.tpl.php
@@ -181,7 +181,7 @@ if ($usemargins && isModEnabled('margin') && empty($user->socid)) {
 	}
 	if (getDolGlobalString('DISPLAY_MARK_RATES') && $user->hasRight('margins', 'liretous')) {
 		print '<th class="linecolmargin2 margininfos right width75">'.$langs->trans('MarkRate');
-		if (in_array($object->element, array('propal', 'commande', 'facture')) && $object->status == $object::STATUS_DRAFT) {
+		if (in_array($object->element, array('propal', 'commande', 'facture')) && $object->status == get_class($object)::STATUS_DRAFT) {
 			print '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?mode=markforalllines&id='.$object->id.'">'.img_edit($langs->trans("UpdateForAllLines"), 0, 'class="clickmarkforalllines opacitymedium paddingleft cursorpointer"').'</a>';
 			if (GETPOST('mode', 'aZ09') == 'markforalllines') {
 				print '<div class="classmarkforalllines inline-block nowraponall">';

--- a/htdocs/core/tpl/objectline_title.tpl.php
+++ b/htdocs/core/tpl/objectline_title.tpl.php
@@ -180,7 +180,17 @@ if ($usemargins && isModEnabled('margin') && empty($user->socid)) {
 		print '</th>';
 	}
 	if (getDolGlobalString('DISPLAY_MARK_RATES') && $user->hasRight('margins', 'liretous')) {
-		print '<th class="linecolmargin2 margininfos right width75">'.$langs->trans('MarkRate').'</th>';
+		print '<th class="linecolmargin2 margininfos right width75">'.$langs->trans('MarkRate');
+		if (in_array($object->element, array('propal', 'commande', 'facture', 'supplier_proposal', 'order_supplier', 'invoice_supplier')) && $object->status == $object::STATUS_DRAFT) {
+			print '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?mode=markforalllines&id='.$object->id.'">'.img_edit($langs->trans("UpdateForAllLines"), 0, 'class="clickmarkforalllines opacitymedium paddingleft cursorpointer"').'</a>';
+			if (GETPOST('mode', 'aZ09') == 'markforalllines') {
+				print '<div class="classmarkforalllines inline-block nowraponall">';
+				print '<input type="number" name="markforalllines" min="0" max="999.9" value="20.0" step="0.1" class="width50"><label>%</label>';
+				print '<input class="inline-block button smallpaddingimp" type="submit" name="submitforallmark" value="'.$langs->trans("Update").'">';
+				print '</div>';
+			}
+		}
+		print '</th>';
 	}
 }
 

--- a/htdocs/core/tpl/objectline_title.tpl.php
+++ b/htdocs/core/tpl/objectline_title.tpl.php
@@ -181,7 +181,7 @@ if ($usemargins && isModEnabled('margin') && empty($user->socid)) {
 	}
 	if (getDolGlobalString('DISPLAY_MARK_RATES') && $user->hasRight('margins', 'liretous')) {
 		print '<th class="linecolmargin2 margininfos right width75">'.$langs->trans('MarkRate');
-		if (in_array($object->element, array('propal', 'commande', 'facture', 'supplier_proposal', 'order_supplier', 'invoice_supplier')) && $object->status == $object::STATUS_DRAFT) {
+		if (in_array($object->element, array('propal', 'commande', 'facture')) && $object->status == $object::STATUS_DRAFT) {
 			print '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?mode=markforalllines&id='.$object->id.'">'.img_edit($langs->trans("UpdateForAllLines"), 0, 'class="clickmarkforalllines opacitymedium paddingleft cursorpointer"').'</a>';
 			if (GETPOST('mode', 'aZ09') == 'markforalllines') {
 				print '<div class="classmarkforalllines inline-block nowraponall">';


### PR DESCRIPTION
# Instructions
On propal, orders, and invoices (client)
On line titles, I have added the ability to bulk edit
The margin rate and the brand rate (taux de marque)

# NEW|New [*update mass margin, brand rate*]
Now, bulk editing the margin and markup rates changes the unit price in the same way as editing a single line
I have added the mass action in the file "htdocs/core/tpl/objectline_title.tpl.php"
And in the card.php files for proposals, orders, and invoices, I have managed the unit price, the calculation of the margin and markup rates, as well as the handling of currency conversions.



