### PR TITLE
FIX Invoice unpaid widget - SQL error on group by with constant MAIN_COMPANY_PERENTITY_SHARED

### DIFF
--- a/htdocs/core/boxes/box_factures_imp.php
+++ b/htdocs/core/boxes/box_factures_imp.php
@@ -1,8 +1,9 @@
 <?php
-/* Copyright (C) 2003-2007 Rodolphe Quiedeville <rodolphe@quiedeville.org>
- * Copyright (C) 2004-2007 Laurent Destailleur  <eldy@users.sourceforge.net>
- * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
- * Copyright (C) 2015-2019 Frederic France      <frederic.france@netlogic.fr>
+/* Copyright (C) 2003-2007	Rodolphe Quiedeville		<rodolphe@quiedeville.org>
+ * Copyright (C) 2004-2007	Laurent Destailleur			<eldy@users.sourceforge.net>
+ * Copyright (C) 2005-2009	Regis Houssin				<regis.houssin@inodbox.com>
+ * Copyright (C) 2015-2019	Frederic France				<frederic.france@netlogic.fr>
+ * Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -126,7 +127,7 @@ class box_factures_imp extends ModeleBoxes
 			}
 			$sql3 = " GROUP BY s.rowid, s.nom, s.name_alias, s.code_client, s.client, s.logo, s.email, s.entity, s.tva_intra, s.siren, s.siret, s.ape, s.idprof4, s.idprof5, s.idprof6,";
 			if (getDolGlobalString('MAIN_COMPANY_PERENTITY_SHARED')) {
-				$sql3 .= " spe.accountancy_code_customer as code_compta,";
+				$sql3 .= " spe.accountancy_code_customer,";
 			} else {
 				$sql3 .= " s.code_compta,";
 			}


### PR DESCRIPTION
Constant MAIN_COMPANY_PERENTITY_SHARED

Remove "as..." in GROUP BY

![image](https://github.com/user-attachments/assets/89b7b843-37bf-4d3a-a111-5d3fc4f77fa1)

`ERR DoliDBMysqli::query SQL Error query: SELECT s.rowid as socid, s.nom as name, s.name_alias, s.code_client, s.client, spe.accountancy_code_customer as code_compta, s.logo, s.email, s.entity, s.tva_intra, s.siren as idprof1, s.siret as idprof2, s.ape as idprof3, s.idprof4, s.idprof5, s.idprof6, f.ref, f.date_lim_reglement as datelimite, f.type, f.datef as date, f.total_ht, f.total_tva, f.total_ttc, f.paye, f.fk_statut as status, f.rowid as facid, SUM(pf.amount) as am FROM llx_societe as s LEFT JOIN llx_societe_perentity as spe ON spe.fk_soc = s.rowid AND spe.entity = 2, llx_facture as f LEFT JOIN llx_paiement_facture as pf ON f.rowid = pf.fk_facture WHERE f.fk_soc = s.rowid AND f.entity IN (2) AND f.paye = 0 AND fk_statut = 1 GROUP BY s.rowid, s.nom, s.name_alias, s.code_client, s.client, s.logo, s.email, s.entity, s.tva_intra, s.siren, s.siret, s.ape, s.idprof4, s.idprof5, s.idprof6, spe.accountancy_code_customer as code_compta, f.rowid, f.ref, f.date_lim_reglement, f.type, f.datef, f.total_ht, f.total_tva, f.total_ttc, f.paye, f.fk_statut ORDER BY datelimite ASC, f.ref ASC  LIMIT 6`

`ERR DoliDBMysqli::query SQL Error message: DB_ERROR_SYNTAX You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'as code_compta, f.rowid, f.ref, f.date_lim_reglement, f.type, f.datef, f.tota...' at line 1`