### PR TITLE
Update contact.class.php

### DIFF
--- a/htdocs/contact/class/contact.class.php
+++ b/htdocs/contact/class/contact.class.php
@@ -1893,6 +1893,9 @@ class Contact extends CommonObject
 		} else {
 			if (count($this->roles) > 0) {
 				foreach ($this->roles as $keyRoles => $valRoles) {
+					if (empty($valRoles)) {
+						continue;
+					}
 					$idrole = 0;
 					if (is_array($valRoles)) {
 						$idrole = $valRoles['id'];


### PR DESCRIPTION
When creating a customer and a contact at the same time if in the third-party settings the default role assignment option is empty (not filled in) an SQL error occurs.