### PR TITLE
Fix : update line order with TTC price leads to bad unit price

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3182,7 +3182,8 @@ class Commande extends CommonOrder
 
 			// Anciens indicateurs: $price, $subprice (a ne plus utiliser)
 			$price = $pu_ht;
-			if ($price_base_type == 'TTC') {
+			// disabled, because $tabprice returns already the right prices, so subprice should always be equal to $pu_ht
+			if (false && $price_base_type == 'TTC') {
 				$subprice = $pu_ttc;
 			} else {
 				$subprice = $pu_ht;

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3182,8 +3182,7 @@ class Commande extends CommonOrder
 
 			// Anciens indicateurs: $price, $subprice (a ne plus utiliser)
 			$price = $pu_ht;
-			// disabled, because $tabprice returns already the right prices, so subprice should always be equal to $pu_ht
-			if (false && $price_base_type == 'TTC') {
+			if ($price_base_type == 'TTC') {
 				$subprice = $pu_ttc;
 			} else {
 				$subprice = $pu_ht;
@@ -3242,7 +3241,7 @@ class Commande extends CommonOrder
 			$this->line->localtax1_type = empty($localtaxes_type[0]) ? '' : $localtaxes_type[0];
 			$this->line->localtax2_type = empty($localtaxes_type[2]) ? '' : $localtaxes_type[2];
 			$this->line->remise_percent = $remise_percent;
-			$this->line->subprice       = $subprice;
+			$this->line->subprice       = $pu_ht;
 			$this->line->info_bits      = $info_bits;
 			$this->line->special_code   = $special_code;
 			$this->line->total_ht       = $total_ht;


### PR DESCRIPTION
# FIX
When updating an order line with a TTC price, the pu_ht is stored as TTC and the TTC has double TTC, and so, when creating and invoice, the prices are also different
So, I disabled the bad variable affectation.