### PR TITLE
FIX: fixed search filter for projects resetting when set to empty

### DIFF
--- a/htdocs/projet/list.php
+++ b/htdocs/projet/list.php
@@ -183,7 +183,7 @@ if (isModEnabled('categorie')) {
 	$search_category_array = GETPOST("search_category_".Categorie::TYPE_PROJECT."_list", "array");
 }
 
-if (GETPOSTISARRAY('search_status')) {
+if (GETPOSTISARRAY('search_status') || GETPOST('search_status_multiselect')) {
 	$search_status = join(',', GETPOST('search_status', 'array:intcomma'));
 } else {
 	$search_status = (GETPOST('search_status', 'intcomma') != '' ? GETPOST('search_status', 'intcomma') : '0,1');


### PR DESCRIPTION
# FIX|Fixed search filter for projects resetting when set to empty

When you cleared the status filters, they would just reappear since the page was reloaded. This fixes it.
![image](https://github.com/user-attachments/assets/d2aec012-1e7e-4dba-a512-7d1c0386a77a)

