### PR TITLE
Fix: 🛟 getrights must return a value

### DIFF
--- a/htdocs/user/class/usergroup.class.php
+++ b/htdocs/user/class/usergroup.class.php
@@ -577,7 +577,7 @@ class UserGroup extends CommonObject
 	 */
 	public function getrights($moduletag = '')
 	{
-		$this->loadRights($moduletag);
+		return $this->loadRights($moduletag);
 	}
 
 	/**


### PR DESCRIPTION
# Fix:getrights must return a value

The phan notice is all about the function not returning a value while it is said to return a value.
Added the missing 'return'