### PR TITLE
[#29371] Fixed : Php wanring on separate type extra field update

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -650,6 +650,8 @@ class ExtraFields
 	{
 		global $action, $hookmanager;
 
+		$result = 0;
+
 		if ($elementtype == 'thirdparty') {
 			$elementtype = 'societe';
 		}


### PR DESCRIPTION
# FIX #29371 - Fixed Php warning on separate type extra field update

On separate type extra field update with PHP 8+, the result variable isn't set and returns a warning that can break the page. If we set it before, no warning way appear.


![Capture d’écran 2024-09-10 à 10 53 47](https://github.com/user-attachments/assets/bf801434-108d-43d9-a902-e07c7deba929)



