### PR TITLE
Fix #30828 bad save of contract id in ticket card

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -698,7 +698,7 @@ class FormTicket
 			}
 		}
 
-		if ($subelement != 'contract') {
+		if ($subelement != 'contract' && $subelement != 'contrat') {
 			if (isModEnabled('contract') && !$this->ispublic) {
 				$langs->load('contracts');
 				$formcontract = new FormContract($this->db);

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -249,7 +249,7 @@ if (empty($reshook)) {
 			$object->fk_soc = GETPOSTINT('socid');
 			$fk_user_assign = GETPOSTINT('fk_user_assign');
 			$object->fk_project = GETPOSTINT('projectid');
-			$object->fk_contract = GETPOSTINT('fk_contract');
+			$object->fk_contract = GETPOSTISSET('contractid') ? GETPOSTINT('contractid') : GETPOSTINT('contratid');
 
 			if ($fk_user_assign > 0) {
 				$object->fk_user_assign = $fk_user_assign;


### PR DESCRIPTION
Fix a bad workflow when we create a ticket with url:
/ticket/card.php?action=create&socid=1&origin=contrat&originid=1

this create a double input display for contract
![Screenshot 2024-09-10 at 14-05-24 Créer ticket](https://github.com/user-attachments/assets/96b4539f-148c-445c-9acd-a9026ba29ced)
and then when we save it doesn't save the contractid

after it keep only 1 input and save the data
![Screenshot 2024-09-10 at 14-08-59 Créer ticket](https://github.com/user-attachments/assets/73e228df-838c-4bb7-b74a-edfd01b5479d)

