### PR TITLE
FIX ajaxik URL in ExpenseReport to load coef calculation

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -2615,7 +2615,7 @@ if ($action == 'create') {
                     let tva = jQuery("#vatrate").find(":selected").val();
                     let qty = jQuery(".input_qty").val();
 
-					let path = "'.DOL_DOCUMENT_ROOT.'/expensereport/ajax/ajaxik.php";
+					let path = "'.dol_buildpath("/expensereport/ajax/ajaxik.php", 1).'";
 					path += "?fk_c_exp_tax_cat="+tax_cat;
 					path += "&fk_expense="+'.((int) $object->id).';
                     path += "&vatrate="+tva;


### PR DESCRIPTION
# FIX #30917 load coef calculation in expense report

This patch fixes a regression in Dolibarr v19.0 and revert the line like it was in Dolibarr v18.0.