### PR TITLE
FIX: purge files cron: php 8.1 warnings when rest module enabled

### DIFF
--- a/htdocs/core/class/conf.class.php
+++ b/htdocs/core/class/conf.class.php
@@ -161,6 +161,7 @@ class Conf
 		$this->mailing = new stdClass();
 		$this->expensereport	= new stdClass();
 		$this->productbatch		= new stdClass();
+		$this->api = new stdClass();
 	}
 
 	/**

--- a/htdocs/core/class/utils.class.php
+++ b/htdocs/core/class/utils.class.php
@@ -133,7 +133,13 @@ class Utils
 
 						$result = dol_delete_dir_recursive($filesarray[$key]['fullname'], $startcount, 1, 0, $tmpcountdeleted);
 
-						if (!in_array($filesarray[$key]['fullname'], array($conf->api->dir_temp, $conf->user->dir_temp))) {		// The 2 directories $conf->api->dir_temp and $conf->user->dir_temp are recreated at end, so we do not count them
+						$recreatedDirs = array($conf->user->dir_temp);
+
+						if (isModEnabled('api')) {
+							$recreatedDirs[] = $conf->api->dir_temp;
+						}
+
+						if (!in_array($filesarray[$key]['fullname'], $recreatedDirs)) {		// The 2 directories $conf->api->dir_temp and $conf->user->dir_temp are recreated at end, so we do not count them
 							$count += $result;
 							$countdeleted += $tmpcountdeleted;
 						}


### PR DESCRIPTION
```
PHP Warning:  Undefined property: Conf::$api in /htdocs/core/class/utils.class.php on line 136
PHP Warning:  Attempt to read property "dir_temp" on null in /htdocs/core/class/utils.class.php on line 136
```