### PR TITLE
Use NDF_CC_EMAILS on ndf approval

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -683,7 +683,7 @@ if (empty($reshook)) {
 				}
 				*/
 
-				$mailfile = new CMailFile($subject, $emailTo, $emailFrom, $message, $filedir, $mimetype, $filename, '', '', 0, -1);
+				$mailfile = new CMailFile($subject, $emailTo, $emailFrom, $message, $filedir, $mimetype, $filename, $emailCC, '', 0, -1);
 
 				if ($mailfile) {
 					// SEND


### PR DESCRIPTION
The variable $emailCC isn't used on the instanciation of Cmail class, it should be.

