### PR TITLE
FIX select list for contacts with very long third party names

### DIFF
--- a/htdocs/core/tpl/contacts.tpl.php
+++ b/htdocs/core/tpl/contacts.tpl.php
@@ -143,7 +143,7 @@ if ($permission) {
 		<div class="tagtd nowrap noborderbottom">
 			<?php
 			$selectedCompany = GETPOSTISSET("newcompany") ? GETPOST("newcompany", 'int') : (empty($object->socid) ?  0 : $object->socid);
-			$selectedCompany = $formcompany->selectCompaniesForNewContact($object, 'id', $selectedCompany, 'newcompany', '', 0, '', 'minwidth300imp');	// This also print the select component
+			$selectedCompany = $formcompany->selectCompaniesForNewContact($object, 'id', $selectedCompany, 'newcompany', '', 0, '', 'minwidth300imp maxwidth400 widthcentpercentminusx');	// This also print the select component
 			?>
 		</div>
 		<div class="tagtd noborderbottom minwidth500imp">


### PR DESCRIPTION
# FIX select list for contacts with very long third party names
In some cases when third party name is very long the other columns are squashed, especially contact role. This is visible on contacts tab for propals, orders, etc. This fix is a backport from v20.