### PR TITLE
FIX: BIC requirement is now checked separately from IBAN

### DIFF
--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -1747,7 +1747,7 @@ class Account extends CommonObject
 	}
 
 	/**
-	 * Return 1 if IBAN / BIC is mandatory (otherwise option)
+	 * Return 1 if IBAN is mandatory (otherwise option)
 	 *
 	 * @return		int        1 = mandatory / 0 = Not mandatory
 	 */
@@ -1799,6 +1799,37 @@ class Account extends CommonObject
 
 		if (in_array($country_code, $country_code_in_EEC)) {
 			return 1; // France, Spain, ...
+		}
+		return 0;
+	}
+
+	/**
+	 * Return 1 if BIC is mandatory (otherwise option)
+	 *
+	 * @return		int        1 = mandatory / 0 = Not mandatory
+	 */
+	public function needBIC()
+	{
+		if (getDolGlobalString('MAIN_IBAN_IS_NEVER_MANDATORY')) {
+			return 0;
+		}
+
+		$country_code = $this->getCountryCode();
+
+		$country_code_in_EEC = array(
+			'AD', // Andorra
+			'BH', // Bahrein
+			'DK', // Denmark
+			'FR', // France
+			'GH', // Ghana
+			'HU', // Hungary
+			'JP', // Japan
+			'LV', // Latvia
+			'SE', // Sweden
+		);
+
+		if (in_array($country_code, $country_code_in_EEC)) {
+			return 1; // Andorra, Bahrein, ...
 		}
 		return 0;
 	}

--- a/htdocs/societe/paymentmodes.php
+++ b/htdocs/societe/paymentmodes.php
@@ -158,6 +158,8 @@ if (empty($reshook)) {
 				$action = 'edit';
 				$error++;
 			}
+		}
+		if ($companybankaccount->needBIC() == 1) {
 			if (!GETPOST('bic') && (getDolGlobalInt('WITHDRAWAL_WITHOUT_BIC') == 0)) {
 				setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("BIC")), null, 'errors');
 				$action = 'edit';
@@ -341,6 +343,8 @@ if (empty($reshook)) {
 					$action = 'create';
 					$error++;
 				}
+			}
+			if ($companybankaccount->needBIC() == 1) {
 				if (!GETPOST('bic') && (getDolGlobalInt('WITHDRAWAL_WITHOUT_BIC') == 0)) {
 					setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("BIC")), null, 'errors');
 					$action = 'create';
@@ -2015,7 +2019,7 @@ if ($socid && $action == 'edit' && $permissiontoaddupdatepaymentinformation) {
 			$name = 'bic';
 			$size = 12;
 			$content = $bankaccount->bic;
-			if ($bankaccount->needIBAN() && (getDolGlobalInt('WITHDRAWAL_WITHOUT_BIC') == 0)) {
+			if ($bankaccount->needBIC() && (getDolGlobalInt('WITHDRAWAL_WITHOUT_BIC') == 0)) {
 				$require = true;
 			}
 			$tooltip = $langs->trans("Example").': LIABLT2XXXX';
@@ -2187,7 +2191,7 @@ if ($socid && $action == 'create' && $permissiontoaddupdatepaymentinformation) {
 			$name = 'bic';
 			$size = 12;
 			$content = $companybankaccount->bic;
-			if ($companybankaccount->needIBAN() && (getDolGlobalInt('WITHDRAWAL_WITHOUT_BIC') == 0)) {
+			if ($companybankaccount->needBIC() && (getDolGlobalInt('WITHDRAWAL_WITHOUT_BIC') == 0)) {
 				$require = true;
 			}
 			$tooltip = $langs->trans("Example").': LIABLT2XXXX';


### PR DESCRIPTION
# FIX|BIC requirement is now checked separately from IBAN

Currently, the same function is used top check is an IBAN is required and if a BIC is required:
![image](https://github.com/user-attachments/assets/0db1a31f-cbff-4574-986b-7b119f1d1f7f)

The needIBAN() function checks if the country is among a list of countries to decide if the field IBAN can be left blank or not.

I've added a needBIC() function which works the same way but for BIC/SWIFT since the list of countries where the BIC is mandatory is different than for IBAN (ex: Belgium requires an IBAN but not a BIC)
I've based the list on these sources:
https://www.westernunion.com/fr/fr/swift-bic-codes.html
https://qonto.com/fr/swift-codes
![image](https://github.com/user-attachments/assets/2cfc2c62-4c5f-42d9-9e4f-ad7b423247b2)
![image](https://github.com/user-attachments/assets/9350008e-5109-48c3-a370-aeb89f196aaa)

HOWEVER: I still added France to the list so in order to change as little as possible the way it has been working in dolibarr, even if technically BIC isn't mandatory in France.
![image](https://github.com/user-attachments/assets/e48e3876-2226-49d6-b7a4-52188ef5f81f)
