### PR TITLE
Fix php8 change, '' != 0 since php8

### DIFF
--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -258,7 +258,7 @@ if ($action == 'dispatch' && $permissiontoreceive) {
 			}
 
 			// We ask to move a qty
-			if (GETPOST($qty) != 0) {
+			if (!empty(GETPOST($qty)) && GETPOST($qty) != 0) {
 				if (!(GETPOST($ent, 'int') > 0)) {
 					dol_syslog('No dispatch for line '.$key.' as no warehouse was chosen.');
 					$text = $langs->transnoentities('Warehouse').', '.$langs->transnoentities('Line').' '.($numline);

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -258,7 +258,7 @@ if ($action == 'dispatch' && $permissiontoreceive) {
 			}
 
 			// We ask to move a qty
-			if (!empty(GETPOST($qty)) && GETPOST($qty) != 0) {
+			if ((float) GETPOST($qty) != 0) {
 				if (!(GETPOST($ent, 'int') > 0)) {
 					dol_syslog('No dispatch for line '.$key.' as no warehouse was chosen.');
 					$text = $langs->transnoentities('Warehouse').', '.$langs->transnoentities('Line').' '.($numline);


### PR DESCRIPTION
# Fix

Since PHP8 '' != 0 which change the behavior on dispatch.

Pre PHP8 when you don't fill a quantity it was accepted as 0 and don't check if a warehouse is set

On develop, you use a new function GETPOSTFLOAT which use (float) price2num GETPOST and since there is a cast to float, the empty string become a 0, it has the same reaction as pre PHP8

But here on dolibarr V18, there is no GETPOSTFLOAT or anything to change the empty string to 0, and it goes inside the "if" and return an error if a warehouse is not set

To prevent this change of behavior, I just added a check !empty(GETPOST($qty))