### PR TITLE
Qual - remove parameter not used in trans function of WebPortal

### DIFF
--- a/htdocs/public/webportal/webportal.main.inc.php
+++ b/htdocs/public/webportal/webportal.main.inc.php
@@ -213,7 +213,7 @@ if (!defined('WEBPORTAL_NOLOGIN') && !empty($context->controllerInstance->access
 
 			if ($user_id <= 0) {
 				$error++;
-				$error_msg = $langs->transnoentitiesnoconv('WebPortalSetupNotComplete', $user_id);
+				$error_msg = $langs->transnoentitiesnoconv('WebPortalSetupNotComplete');
 				dol_syslog($error_msg, LOG_WARNING);
 				$context->setEventMessages($error_msg, null, 'errors');
 			}


### PR DESCRIPTION
Qual - remove parameter not used in trans function of WebPortal

- "user_id" parameter is not used in translate of "WebPortalSetupNotComplete"