### PR TITLE
Qual: Fix argument mismatch for form_attach_new_file

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -55,7 +55,6 @@ return [
         'htdocs/admin/dict.php' => ['PhanRedefineFunction'],
         'htdocs/admin/fckeditor.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'htdocs/admin/mails_templates.php' => ['PhanRedefineFunction'],
-        'htdocs/admin/security_file.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'htdocs/api/class/api_access.class.php' => ['PhanPluginUnknownArrayMethodParamType', 'PhanUndeclaredProperty'],
         'htdocs/api/class/api_documents.class.php' => ['PhanPluginDuplicateExpressionBinaryOp', 'PhanPluginUnknownArrayMethodReturnType', 'PhanPossiblyUndeclaredVariable'],
         'htdocs/api/class/api_login.class.php' => ['PhanPluginUnknownArrayMethodReturnType'],

--- a/htdocs/admin/security_file.php
+++ b/htdocs/admin/security_file.php
@@ -221,7 +221,7 @@ print '</form>';
 // Form to test upload
 print '<br>';
 $formfile = new FormFile($db);
-$formfile->form_attach_new_file($_SERVER['PHP_SELF'], $langs->trans("FormToTestFileUploadForm"), 0, 0, 1, 50, '', '', 1, '', 0);
+$formfile->form_attach_new_file($_SERVER['PHP_SELF'], $langs->trans("FormToTestFileUploadForm"), 0, 0, 1, 50, null, '', 1, '', 0);
 
 // List of document
 $filearray = dol_dir_list($upload_dir, "files", 0, '', '', $sortfield, $sortorder == 'desc' ? SORT_DESC : SORT_ASC, 1);


### PR DESCRIPTION
# Qual: Fix argument mismatch for form_attach_new_file

Use null instead of '' to match the argument type for form_attach_new_file.