### PR TITLE
FIX custom CSS for WebPortal

### DIFF
--- a/htdocs/public/webportal/css/themes/custom.css.php
+++ b/htdocs/public/webportal/css/themes/custom.css.php
@@ -45,6 +45,9 @@ if (!defined('NOREQUIREAJAX')) {
 
 session_cache_limiter('public');
 
+if (!defined('MAIN_INC_REL_DIR')) {
+	define('MAIN_INC_REL_DIR', '../../');
+}
 require_once __DIR__.'/../../webportal.main.inc.php';
 dol_include_once('/webportal/class/webPortalTheme.class.php');
 

--- a/htdocs/public/webportal/webportal.main.inc.php
+++ b/htdocs/public/webportal/webportal.main.inc.php
@@ -76,8 +76,11 @@ if (!function_exists('dol_getprefix')) {
 	}
 }
 
-
-include '../../main.inc.php';
+$relDir = '';
+if (defined('MAIN_INC_REL_DIR')) {
+	$relDir = MAIN_INC_REL_DIR;
+}
+include $relDir.'../../main.inc.php';
 
 require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
 require_once DOL_DOCUMENT_ROOT . '/societe/class/societeaccount.class.php';


### PR DESCRIPTION
FIX custom CSS for WebPortal
- apply the custom CSS

**To reproduce**
- go on "CSS setup" of WebPortal
![image](https://github.com/user-attachments/assets/5bb79854-2c51-4ea0-b144-6b3e1cd45e1e)

- try to add this CSS code
```
.home-links-card {
    background-color: #ffdddd;
}
```

- try to access to WebPortal and you haven't got this custom CSS

**After**
![image](https://github.com/user-attachments/assets/28ae2515-7830-4978-9ed2-8b2180ec08a8)
