### PR TITLE
Fix #31015

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -1523,7 +1523,7 @@ class Invoices extends DolibarrApi
 
 		// Creation of payment line
 		$paymentobj = new Paiement($this->db);
-		$paymentobj->datepaye     = dol_stringtotime($datepaye);
+		$paymentobj->datepaye     = $datepaye;
 		$paymentobj->amounts      = $amounts; // Array with all payments dispatching with invoice id
 		$paymentobj->multicurrency_amounts = $multicurrency_amounts; // Array with all payments dispatching
 		$paymentobj->paiementid = $paymentid;


### PR DESCRIPTION
# FIX #31015

`datepaye` is already a timestamp as stated in the docblock, using `dol_stringtotime` will lead to an error
```@param string  $datepaye           {@from body}  Payment date        {@type timestamp}```
