### PR TITLE
FIX : FATAL ERROR abusively triggered due to incomplete regex

### DIFF
--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -421,7 +421,7 @@ abstract class DoliDB implements Database
 	 */
 	public function getRows($sql)
 	{
-		if (!preg_match('/LIMIT \d+,?\d*\ *;?$/', $sql)) {
+		if (!preg_match('/LIMIT \d+(?:(?:,\ *\d*)|(?:\ +OFFSET\ +\d*))?\ *;?$/', $sql)) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.'() query must have a LIMIT clause', E_USER_ERROR);
 		}
 

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -421,7 +421,7 @@ abstract class DoliDB implements Database
 	 */
 	public function getRows($sql)
 	{
-		if (!preg_match('/LIMIT \d+$/', $sql)) {
+		if (!preg_match('/LIMIT \d+,?\d*\ *;?$/', $sql)) {
 			trigger_error(__CLASS__ .'::'.__FUNCTION__.'() query must have a LIMIT clause', E_USER_ERROR);
 		}
 


### PR DESCRIPTION
# FIX 
FATAL ERROR abusively triggered due to incomplete regex


`SELECT [...] WHERE [...] LIMIT 50`  **OK**
`SELECT [...] WHERE [...] LIMIT 50  ` **FAIL**
`SELECT [...] WHERE [...] LIMIT 50 ;` **FAIL**
`SELECT [...] WHERE [...] LIMIT 25,50;` **FAIL**
`SELECT [...] WHERE [...] LIMIT 25,50` **FAIL**


After:

`SELECT [...] WHERE [...] LIMIT 50`  **OK** 
`SELECT [...] WHERE [...] LIMIT 50  ` **OK** 
`SELECT [...] WHERE [...] LIMIT 50 ;` **OK** 
`SELECT [...] WHERE [...] LIMIT 25,50;` **OK** 
`SELECT [...] WHERE [...] LIMIT 25,50` **OK** 
`SELECT [...] WHERE [...] LIMIT` **FAIL** 
`SELECT [...] WHERE [...] `  **FAIL**
