### PR TITLE
FIX: Add missing list value hook for appended column

### DIFF
--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -760,7 +760,7 @@ if ($action == 'create') {
 					print '<tr class="oddeven">';
 
 					$parameters = array('obj' => $objp, 'totalarray' => &$totalarray);
-					$reshook = $hookmanager->executeHooks('printFieldListValue', $parameters); // Note that $action and $object may have been modified by hook
+					$reshook = $hookmanager->executeHooks('printFieldPreListValue', $parameters); // Note that $action and $object may have been modified by hook
 					print $hookmanager->resPrint;
 
 					$productstatic->id = $objp->rowid;
@@ -842,6 +842,10 @@ if ($action == 'create') {
 						print $langs->trans("CorrectStock");
 						print "</a></td>";
 					}
+
+					$parameters = array('obj' => $objp, 'totalarray' => &$totalarray);
+					$reshook = $hookmanager->executeHooks('printFieldListValue', $parameters); // Note that $action and $object may have been modified by hook
+					print $hookmanager->resPrint;
 
 					print "</tr>";
 


### PR DESCRIPTION
In the warehouse stock list, there is a 'printFieldPreListTitle' hook to prepend a new column in the table list and a 'printFieldListTitle' hook to append a new column in the table list. However, the 'printFieldListValue' hook shall be renamed as 'printFieldPreListValue' to populate any pre-pended columns whereas the hook named 'printFieldListValue' shall be moved at the end of the table to be consistent and be able to populate the appended column.

