### PR TITLE
Qual: Exclude lessc.class.php from phpstan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,6 +25,7 @@ parameters:
 		- htdocs/support/*
 		analyse:
 		- htdocs/includes/*
+		- htdocs/core/class/lessc.class.php
 	checkAlwaysTrueCheckTypeFunctionCall: false
 	checkAlwaysTrueInstanceof: false
 	checkAlwaysTrueStrictComparison: false


### PR DESCRIPTION
# Qual: Exclude lessc.class.php from phpstan

'lessc' is considered an external analysis and can be excluded from analysis (>400 less phpstan notices).