### PR TITLE
FIX: find and send invoice attachment in sendEmailsRemindersOnInvoiceDueDate

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5602,9 +5602,9 @@ class Facture extends CommonInvoice
 							$joinFileName = [];
 							$joinFileMime = [];
 							if ($arraymessage->joinfiles == 1 && !empty($tmpinvoice->last_main_doc)) {
-								$joinFile[] = DOL_DATA_ROOT.$tmpinvoice->last_main_doc;
+								$joinFile[] = DOL_DATA_ROOT.'/'.$tmpinvoice->last_main_doc;
 								$joinFileName[] = basename($tmpinvoice->last_main_doc);
-								$joinFileMime[] = dol_mimetype(DOL_DATA_ROOT.$tmpinvoice->last_main_doc);
+								$joinFileMime[] = dol_mimetype(DOL_DATA_ROOT.'/'.$tmpinvoice->last_main_doc);
 							}
 
 							// Mail Creation


### PR DESCRIPTION
Fix find correct last_main_doc in sendEmailsRemindersOnInvoiceDueDate

Actual dolibarr_cron.log : 

```
CMailFile::sendfile: mail end error=Unable to open file for reading [/home/XXXX/dolibarr/documentsfacture/FA00001/FA00001.pdf]
Cronjob::run_jobs END result=1 error= : NOMCONTACT <emailcontact@xxxx.xx>
```
There is a missing "/" in path `/home/XXXX/dolibarr/documentsfacture/`
instead of `/home/XXXX/dolibarr/documents/facture/`


DOL_DATA_ROOT do not have last / by default, and last_main_doc not have first /

Every where in htdocs/core/tpl/card_presend.tpl.php where file is search there is 
$diroutput.'/'.$ref