### PR TITLE
Fix a problem when we have an extrafield on the contrat line

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1713,7 +1713,7 @@ if ($action == 'create') {
 						$line = new ContratLigne($db);
 						$line->id = $objp->rowid;
 						$line->fetch_optionals();
-						print $line->showOptionals($extrafields, 'view', array('class'=>'oddeven', 'style'=>$moreparam, 'colspan'=>$colspan), '', '', 1);
+						print $line->showOptionals($extrafields, 'view', array('class'=>'oddeven', 'style'=>$moreparam, 'colspan'=>$colspan, 'tdclass' => 'notitlefieldcreate'), '', '', 1);
 					}
 				} else {
 					// Line in mode update
@@ -1817,7 +1817,7 @@ if ($action == 'create') {
 						$line = new ContratLigne($db);
 						$line->id = $objp->rowid;
 						$line->fetch_optionals();
-						print $line->showOptionals($extrafields, 'edit', array('style'=>'class="oddeven"', 'colspan'=>$colspan), '', '', 1);
+						print $line->showOptionals($extrafields, 'edit', array('style'=>'class="oddeven"', 'colspan'=>$colspan, 'tdclass' => 'notitlefieldcreate'), '', '', 1);
 					}
 				}
 


### PR DESCRIPTION
# Fix

Actually, when we have en Extrafield on the contract line, the Label column width is modified by the class 'titlefieldcreate' added by showOptionals if no 'tdclass' is given.
To not change the width of the column I add a fictive class to prevent 'titlefieldcreate' to be added.

Without the Fix : 
![noFixBlur](https://github.com/user-attachments/assets/1c0bde3a-2d41-40ff-8ca3-c92f80dabbb9)

With the Fix : 
![FixBlur](https://github.com/user-attachments/assets/ffef4e8d-7ebc-4eb5-8022-1f7cb9aec713)