### PR TITLE
FIX: when qty is not an integer, apply price()

### DIFF
--- a/htdocs/compta/stats/cabyprodserv.php
+++ b/htdocs/compta/stats/cabyprodserv.php
@@ -425,7 +425,7 @@ print_liste_field_titre(
 
 			// Quantity
 			print '<td class="right">';
-			print $qty[$key] == round($qty[$key]) ? $qty[$key] : price($qty[$key]);
+			print price($qty[$key], 1, $langs, 0, 0);
 			print '</td>';
 
 			// Percent;

--- a/htdocs/compta/stats/cabyprodserv.php
+++ b/htdocs/compta/stats/cabyprodserv.php
@@ -425,7 +425,7 @@ print_liste_field_titre(
 
 			// Quantity
 			print '<td class="right">';
-			print $qty[$key];
+			print $qty[$key] == round($qty[$key]) ? $qty[$key] : price($qty[$key]);
 			print '</td>';
 
 			// Percent;


### PR DESCRIPTION
# FIX: weird qty shown

## Issue
Currently, the report `cabyprodserv.php` displays the quantity column as is:
```php
print $qty[$key];
```

Some companies use non-integer quantities.
Due to the non-infinite precision of binary representation and arithmetic, floats can sometimes be counter-intuitive.
```php
> ini_set('precision', -1);
> echo 0.1 + 0.2;
0.30000000000000004
```

One of our customers has this problem (weird quantities such as 7.600000000000001 appear on screen). Using `price()` when the number has non-zero decimals seems to work and enables the customer to better control how the decimals are displayed.