### PR TITLE
Fix bad sql in bookcal public page

### DIFF
--- a/htdocs/public/bookcal/index.php
+++ b/htdocs/public/bookcal/index.php
@@ -268,21 +268,6 @@ if ($action == 'add' ) {	// Test on permission not required here (anonymous acti
 			$error++;
 			$errmsg .= $actioncomm->error." ".implode(',', $actioncomm->errors);
 		}
-
-		if (!$error) {
-			$sql = "INSERT INTO ".MAIN_DB_PREFIX."actioncomm_resources";
-			$sql .= "(fk_actioncomm, element_type, fk_element, answer_status, mandatory, transparency";
-			$sql .= ") VALUES (";
-			$sql .= (int) $actioncomm->id;
-			$sql .= ", 'socpeople'";
-			$sql .= ", ". (int) $contact->id;
-			$sql .= ", 0, 0, 0)";
-			$resql = $db->query($sql);
-			if (!$resql) {
-				$error++;
-				$errmsg .= $db->lasterror();
-			}
-		}
 	}
 
 	if (!$error) {


### PR DESCRIPTION
Remove a SQL Request which always return an sql error because this request is already done in create of action comm So it always result in a duplicate key error in SQL