### PR TITLE
FIX: if you call fetchLines several times, your $object->lines contains duplicates

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9297,6 +9297,7 @@ abstract class CommonObject
 		if ($resql) {
 			$num_rows = $this->db->num_rows($resql);
 			$i = 0;
+			$this->lines = array();
 			while ($i < $num_rows) {
 				$obj = $this->db->fetch_object($resql);
 				if ($obj) {


### PR DESCRIPTION
# FIX fetchLines

Currently, if you call `$object->fetchLine()` twice on an object, you get two copies of every line in $object->lines.

I couldn't find a reason to keep the previously fetched lines in `$this->lines`, but I'm not seeing the big picture so maybe this isn't the right fix.

