### PR TITLE
Fix: 🚑 Update PHPDoc for new showLinkToObjectBlock return value

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -9536,8 +9536,8 @@ class Form
 	 * @param 	CommonObject 	$object 			Object we want to show links to
 	 * @param 	string[] 		$restrictlinksto 	Restrict links to some elements, for example array('order') or array('supplier_order'). null or array() if no restriction.
 	 * @param 	string[] 		$excludelinksto 	Do not show links of this type, for example array('order') or array('supplier_order'). null or array() if no exclusion.
-	 * @param	int				$nooutput			1=Return array with content instead of printing it.
-	 * @return  string                              HTML block
+	 * @param	int<0,1>		$nooutput			1=Return array with content instead of printing it.
+	 * @return	array{linktoelem:string,htmltoenteralink:string}|string	HTML block
 	 */
 	public function showLinkToObjectBlock($object, $restrictlinksto = array(), $excludelinksto = array(), $nooutput = 0)
 	{


### PR DESCRIPTION
# Fix: Update PHPDoc for new showLinkToObjectBlock return value

This fixes the ci notice on the develop branch