### PR TITLE
FIX: box_actions.php still uses fk_user_done which no longer exists

### DIFF
--- a/htdocs/core/boxes/box_actions.php
+++ b/htdocs/core/boxes/box_actions.php
@@ -106,7 +106,7 @@ class box_actions extends ModeleBoxes
 				$sql .= " AND s.rowid = ".((int) $user->socid);
 			}
 			if (!$user->rights->agenda->allactions->read) {
-				$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id)." OR a.fk_user_done = ".((int) $user->id).")";
+				$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id).")";
 			}
 			$sql .= " ORDER BY a.datec DESC";
 			$sql .= $this->db->plimit($max, 0);


### PR DESCRIPTION
# FIX
I installed a brand new Dolibarr 20.0 and created an account with read permission on events, but not on other people's events. When I logged on with this user, I got SQL errors for the boxes 
- Oldest 3 events to do, not completed
- The next 3 upcoming events

I found that, only for unprivileged users, the column `fk_user_done` is still used in some queries. This column was removed in v14.0, hence the error.

## Important note
I am fixing it in v14.0 because this column was removed in this release, but in 14.0, the box `box_actions_future.php` didn't exist and, in v20.0, that box too references `fk_user_done` (and maybe in a few older versions as well), so it should also be fixed there.

