### PR TITLE
Update ticket.class.php Bug-fix  Issue #31206

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1575,6 +1575,8 @@ class Ticket extends CommonObject
 			$this->oldcopy = dol_clone($this);
 
 			$this->db->begin();
+			$oldStatus = $this->fk_statut;
+			$this->fk_statut = Ticket::STATUS_READ;
 
 			$sql = "UPDATE ".MAIN_DB_PREFIX."ticket";
 			$sql .= " SET fk_statut = ".Ticket::STATUS_READ.", date_read = '".$this->db->idate(dol_now())."'";
@@ -1583,13 +1585,14 @@ class Ticket extends CommonObject
 			dol_syslog(get_class($this)."::markAsRead");
 			$resql = $this->db->query($sql);
 			if ($resql) {
-				$this->actionmsg = $langs->trans('TicketLogMesgReadBy', $this->ref, $user->getFullName($langs));
-				$this->actionmsg2 = $langs->trans('TicketLogMesgReadBy', $this->ref, $user->getFullName($langs));
+				$this->context['actionmsg'] = $langs->trans('TicketLogMesgReadBy', $this->ref, $user->getFullName($langs));
+				$this->context['actionmsg2'] = $langs->trans('TicketLogMesgReadBy', $this->ref, $user->getFullName($langs));
 
-				if (!$error && !$notrigger) {
+				if (!$notrigger) {
 					// Call trigger
 					$result = $this->call_trigger('TICKET_MODIFY', $user);
 					if ($result < 0) {
+						$this->fk_statut = $oldStatus;
 						$error++;
 					}
 					// End call triggers
@@ -1599,12 +1602,14 @@ class Ticket extends CommonObject
 					$this->db->commit();
 					return 1;
 				} else {
+					$this->fk_statut = $oldStatus;
 					$this->db->rollback();
-					$this->error = join(',', $this->errors);
+					$this->error = implode(',', $this->errors);
 					dol_syslog(get_class($this)."::markAsRead ".$this->error, LOG_ERR);
 					return -1;
 				}
 			} else {
+				$this->fk_statut = $oldStatus;
 				$this->db->rollback();
 				$this->error = $this->db->lasterror();
 				dol_syslog(get_class($this)."::markAsRead ".$this->error, LOG_ERR);


### PR DESCRIPTION
Fix Issue #31206 for the v.18 branch because unrelated tests failing on develop branch.
Fix Issue #31206  

Sets the object's  "fk_statut" to Ticket::STATUS_READ. In the event of rollback reverts the object's "fk_statut" to its old value.

### NOTE:  I need this fix to be applied to v18.x if and when approved.