### PR TITLE
add user_author in create recurrence invoice

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -1333,6 +1333,7 @@ class FactureRec extends CommonInvoice
 					$facture->brouillon = 1;
 					$facture->statut = self::STATUS_DRAFT;
 					$facture->status = self::STATUS_DRAFT;
+					$facture->fk_user_author = $facture->user_author = $facturerec->user_author;
 					$facture->date = (empty($facturerec->date_when) ? $now : $facturerec->date_when); // We could also use dol_now here but we prefer date_when so invoice has real date when we would like even if we generate later.
 					$facture->socid = $facturerec->socid;
 					if (!empty($facturerec->fk_multicurrency)) {

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -1333,7 +1333,7 @@ class FactureRec extends CommonInvoice
 					$facture->brouillon = 1;
 					$facture->statut = self::STATUS_DRAFT;
 					$facture->status = self::STATUS_DRAFT;
-					$facture->fk_user_author = $facture->user_author = $facturerec->user_author;
+					$facture->fk_user_author = $user->id;
 					$facture->date = (empty($facturerec->date_when) ? $now : $facturerec->date_when); // We could also use dol_now here but we prefer date_when so invoice has real date when we would like even if we generate later.
 					$facture->socid = $facturerec->socid;
 					if (!empty($facturerec->fk_multicurrency)) {


### PR DESCRIPTION
Fix: Carry over author ID from recurring invoice template in createRecurringInvoices method

## Problem Description
In the `createRecurringInvoices` method of the `facture-rec` class, when creating an invoice from a recurring invoice template, the author's ID was not properly carried over to the new invoice. This could lead to a loss of information about the invoice's origin and complicate user action tracking.

## Proposed Solution
This PR fixes the issue by ensuring that the author ID from the recurring invoice template is correctly copied to the `fk_user_author` field of the new invoice during its creation in the `createRecurringInvoices` method.

