### PR TITLE
Fix Problem with search engine and ckeditor config

### DIFF
--- a/htdocs/theme/eldy/ckeditor/config.js
+++ b/htdocs/theme/eldy/ckeditor/config.js
@@ -32,6 +32,7 @@ CKEDITOR.editorConfig = function( config )
 	//config.autoParagraph = false;
 	//config.removeFormatTags = 'b,big,code,del,dfn,em,font,i,ins,kbd';		// See also rules on this.dataProcessor.writer.setRules
 	//config.forcePasteAsPlainText = true;
+	config.entities_latin = false;
 
 	config.toolbar_Full =
 	[


### PR DESCRIPTION
# FIX #31231

A so-so fix that's change ckeditor conf so that it doesn't convert accentuated chars in html_entities but let them as is (in utf8)

May be it would be better change this in /htdocs/includes/ckeditor/ckeditor/build-config.js and re-build ckeditor but I dn't know how to ..