### PR TITLE
FIX : Use contract line for api contracts

### DIFF
--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -17,9 +17,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
- use Luracast\Restler\RestException;
+use Luracast\Restler\RestException;
 
- require_once DOL_DOCUMENT_ROOT.'/contrat/class/contrat.class.php';
+require_once DOL_DOCUMENT_ROOT.'/contrat/class/contrat.class.php';
 
 /**
  * API class for contracts
@@ -364,7 +364,7 @@ class Contracts extends DolibarrApi
 		$this->contractLine->info_bits = $request_data->info_bits;
 		$this->contractLine->fk_fournprice = $request_data->fk_fourn_price;
 		$this->contractLine->pa_ht = $request_data->pa_ht;
-		$this->contractLine->array_options = $request_data->array_options;
+		$this->contractLine->array_options = $request_data->array_options ?? $this->contractLine->array_options;
 		$this->contractLine->fk_unit = $request_data->fk_unit;
 
 		$updateRes = $this->contractLine->update(DolibarrApiAccess::$user);
@@ -502,7 +502,7 @@ class Contracts extends DolibarrApi
 		if ($updateRes > 0) {
 			return $this->get($id);
 		} else {
-			  throw new RestException(405, $this->contractLine->error);
+			throw new RestException(405, $this->contractLine->error);
 		}
 	}
 

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3349,7 +3349,9 @@ class ContratLigne extends CommonObjectLine
 		$sql .= " total_ttc = ".$this->total_ttc.",";
 		$sql .= " fk_product_fournisseur_price = ".(!empty($this->fk_fournprice) ? $this->fk_fournprice : "NULL").",";
 		$sql .= " buy_price_ht = '".price2num($this->pa_ht)."',";
-		$sql .= " info_bits = '".$this->db->escape($this->info_bits)."',";
+		if (!empty($this->info_bits)) {
+			$sql .= " info_bits = '".$this->db->escape($this->info_bits)."',";
+		}
 		$sql .= " fk_user_author = ".($this->fk_user_author >= 0 ? $this->fk_user_author : "NULL").",";
 		$sql .= " fk_user_ouverture = ".($this->fk_user_ouverture > 0 ? $this->fk_user_ouverture : "NULL").",";
 		$sql .= " fk_user_cloture = ".($this->fk_user_cloture > 0 ? $this->fk_user_cloture : "NULL").",";
@@ -3661,5 +3663,52 @@ class ContratLigne extends CommonObjectLine
 			$this->db->rollback();
 			return -1;
 		}
+	}
+
+	/**
+	 * 	Delete line in database
+	 *
+	 *  @param		User	$user		Object user
+	 *  @param		bool		$notrigger	Disable triggers
+	 *	@return		int					<0 if KO, >0 if OK
+	 */
+	public function delete($user, $notrigger = false)
+	{
+		$error = 0;
+
+		$this->db->begin();
+
+		if (!$notrigger) {
+			$result = $this->call_trigger('LINECONTRACT_DELETE', $user);
+			if ($result < 0) {
+				$error++;
+			}
+		}
+
+		if (!$error) {
+			$result = $this->deleteExtraFields();
+			if ($result < 0) {
+				$error++;
+			}
+		}
+
+		if (!$error) {
+			$sql = "DELETE FROM " . $this->db->prefix() . $this->table_element . " WHERE rowid=" . intval($this->id);
+
+			$res = $this->db->query($sql);
+			if (!$res) {
+				$error++;
+				$this->errors[] = $this->db->lasterror();
+			}
+		}
+
+		if ($error) {
+			$this->db->rollback();
+			return -1;
+		} else {
+			$this->db->commit();
+			return 1;
+		}
+
 	}
 }

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3709,6 +3709,5 @@ class ContratLigne extends CommonObjectLine
 			$this->db->commit();
 			return 1;
 		}
-
 	}
 }


### PR DESCRIPTION
Introduced a new ContratLigne instance ($contractLine) in the Contracts class to manage contract lines more efficiently.

Replaced direct calls to the contract object for contract line operations (addline, updateline, deleteline) with methods from ContratLigne (insert, update, delete, fetch, active_line, close_line).

Added new delete function in ContratLigne class