### PR TITLE
(Re)store mariadb setup executable from/to cache

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -70,6 +70,7 @@ jobs:
           path: |
             ./db_init.sql
             ./db_init.sql.md5
+            ./.cache/mariadb
           key: ${{ env.KEY_ROOT }}-${{ env.HASH }}-${{ env.CACHE_KEY_PART }}-${{ github.run_id }}
           restore-keys: |
             ${{ env.KEY_ROOT }}-${{ env.HASH }}-${{ env.CACHE_KEY_PART }}-
@@ -189,3 +190,4 @@ jobs:
           path: |
             ./db_init.sql
             ./db_init.sql.md5
+            ./.cache/mariadb


### PR DESCRIPTION
# (Re)store mariadb setup executable from/to cache

After adding cachability for setup-mariadb on the fork of that action, use the feature