### PR TITLE
NEW Accountancy - Add general account on thirdparty - SQL Part

### DIFF
--- a/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
+++ b/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
@@ -136,3 +136,15 @@ ALTER TABLE llx_recruitment_recruitmentcandidature MODIFY fk_user_creat integer 
 
 ALTER TABLE llx_ecm_files ADD COLUMN agenda_id integer;
 
+-- Add accountancy code general on user / customer / supplier subledger
+ALTER TABLE llx_user ADD COLUMN accountancy_code_user_general varchar(32) DEFAULT NULL AFTER fk_barcode_type;
+ALTER TABLE llx_societe ADD COLUMN accountancy_code_customer_general varchar(32) DEFAULT NULL AFTER code_fournisseur;
+ALTER TABLE llx_societe ADD COLUMN accountancy_code_supplier_general varchar(32) DEFAULT NULL AFTER code_compta;
+ALTER TABLE llx_societe_perentity ADD COLUMN accountancy_code_customer_general varchar(32) DEFAULT NULL AFTER entity;
+ALTER TABLE llx_societe_perentity ADD COLUMN accountancy_code_supplier_general varchar(32) DEFAULT NULL AFTER accountancy_code_customer;
+
+-- Uniformize length of accountancy account
+ALTER TABLE llx_societe MODIFY COLUMN code_compta varchar(32);
+ALTER TABLE llx_societe MODIFY COLUMN code_compta_fournisseur varchar(32);
+ALTER TABLE llx_societe_perentity MODIFY COLUMN accountancy_code_customer varchar(32);
+ALTER TABLE llx_societe_perentity MODIFY COLUMN accountancy_code_supplier varchar(32);

--- a/htdocs/install/mysql/tables/llx_societe.sql
+++ b/htdocs/install/mysql/tables/llx_societe.sql
@@ -38,8 +38,12 @@ create table llx_societe
 
   code_client              varchar(24),                         		-- code client
   code_fournisseur         varchar(24),                         		-- code fournisseur
-  code_compta              varchar(24),                         		-- customer accountancy auxiliary account
-  code_compta_fournisseur  varchar(24),                         		-- supplier accountancy auxiliary account
+
+  accountancy_code_customer_general	varchar(32) DEFAULT NULL,			-- customer accountancy general account
+  code_compta              			varchar(32),                        -- customer accountancy auxiliary account
+  accountancy_code_supplier_general varchar(32) DEFAULT NULL,			-- supplier accountancy general account
+  code_compta_fournisseur  			varchar(32),                        -- supplier accountancy auxiliary account
+
   address                  varchar(255),                        		-- company address
   zip                      varchar(25),                         		-- zipcode
   town                     varchar(50),                         		-- town

--- a/htdocs/install/mysql/tables/llx_societe_perentity-multicompany.sql
+++ b/htdocs/install/mysql/tables/llx_societe_perentity-multicompany.sql
@@ -19,12 +19,14 @@
 
 create table llx_societe_perentity
 (
-  	rowid						integer AUTO_INCREMENT PRIMARY KEY,
-  	fk_soc						integer,
-  	entity						integer DEFAULT 1 NOT NULL,             -- multi company id
-  	accountancy_code_customer	varchar(24),                         	-- customer accountancy auxiliary account
-  	accountancy_code_supplier	varchar(24),                         	-- supplier accountancy auxiliary account
-  	accountancy_code_sell		varchar(32),                            -- Selling accountancy code
-  	accountancy_code_buy		varchar(32),                            -- Buying accountancy code
-	vat_reverse_charge			tinyint DEFAULT 0						-- VAT reverse charge
+  	rowid								integer AUTO_INCREMENT PRIMARY KEY,
+  	fk_soc								integer,
+  	entity								integer DEFAULT 1 NOT NULL,             -- multi company id
+	accountancy_code_customer_general	varchar(32) DEFAULT NULL,				-- customer accountancy general account
+  	accountancy_code_customer			varchar(32),                         	-- customer accountancy auxiliary account
+	accountancy_code_supplier_general	varchar(32) DEFAULT NULL,				-- supplier accountancy general account
+  	accountancy_code_supplier			varchar(32),                         	-- supplier accountancy auxiliary account
+  	accountancy_code_sell				varchar(32),                            -- Selling accountancy code
+  	accountancy_code_buy				varchar(32),                            -- Buying accountancy code
+	vat_reverse_charge					tinyint DEFAULT 0						-- VAT reverse charge
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_user.sql
+++ b/htdocs/install/mysql/tables/llx_user.sql
@@ -1,7 +1,8 @@
 -- ============================================================================
--- Copyright (C) 2001-2003 Rodolphe Quiedeville <rodolphe@quiedeville.org>
--- Copyright (C) 2006-2013 Laurent Destailleur  <eldy@users.sourceforge.net>
--- Copyright (C) 2007-2013 Regis Houssin        <regis.houssin@inodbox.com>
+-- Copyright (C) 2001-2003	Rodolphe Quiedeville		<rodolphe@quiedeville.org>
+-- Copyright (C) 2006-2013	Laurent Destailleur			<eldy@users.sourceforge.net>
+-- Copyright (C) 2007-2013	Regis Houssin				<regis.houssin@inodbox.com>
+-- Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -98,7 +99,10 @@ create table llx_user
   color                   varchar(6),
   barcode                 varchar(255)  DEFAULT NULL,
   fk_barcode_type         integer       DEFAULT 0,
-  accountancy_code        varchar(32) NULL,
+
+  accountancy_code_user_general	varchar(32) DEFAULT NULL,
+  accountancy_code				varchar(32) NULL,
+
   nb_holiday              integer       DEFAULT 0,
   thm                     double(24,8),
   tjm                     double(24,8),


### PR DESCRIPTION
Prepare evolution of accountancy.

With the capacity of define general account + auxiliary account on thirdparty & user, we can respond to different problems.

If the general account are not defined in thirdparty / user, we will use the default general account manage in accountancy module 

For example : 
- SCOPs, where a customer must be classified in a general account and a member-customer in another general account.

- For users, it is necessary to classify employees and managers differently via a general account.