### PR TITLE
Fix: Number of decimals for stock values ignores configuration

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3334,7 +3334,7 @@ class Form
 
 		if (isModEnabled('stock') && isset($objp->stock) && ($objp->fk_product_type == Product::TYPE_PRODUCT || getDolGlobalString('STOCK_SUPPORTS_SERVICES'))) {
 			if ($user->hasRight('stock', 'lire')) {
-				$opt .= ' - ' . $langs->trans("Stock") . ': ' . price2num($objp->stock, 'MS');
+				$opt .= ' - ' . $langs->trans("Stock") . ': ' . price(price2num($objp->stock, 'MS'), 0, $langs, 0, 0);
 
 				if ($objp->stock > 0) {
 					$outval .= ' - <span class="product_line_stock_ok">';

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3334,7 +3334,7 @@ class Form
 
 		if (isModEnabled('stock') && isset($objp->stock) && ($objp->fk_product_type == Product::TYPE_PRODUCT || getDolGlobalString('STOCK_SUPPORTS_SERVICES'))) {
 			if ($user->hasRight('stock', 'lire')) {
-				$opt .= ' - ' . $langs->trans("Stock") . ': ' . price(price2num($objp->stock, 'MS'));
+				$opt .= ' - ' . $langs->trans("Stock") . ': ' . price2num($objp->stock, 'MS');
 
 				if ($objp->stock > 0) {
 					$outval .= ' - <span class="product_line_stock_ok">';


### PR DESCRIPTION
In the select field for adding a new line for a proposal/invoice/... product as a line, the stock level is always shown with exactly two decimals. However, the number of decimals should be controlled by the existing global variable MAIN_MAX_DECIMALS_STOCK, but it is not taken into account:

<img width="481" alt="image" src="https://github.com/user-attachments/assets/dcc8706d-7af3-42c0-8e63-9996f8192c6d">



Building the stock level with the function price from the function price2num, which uses the configured number of decimals, always leads to exactly two decimals.


