### PR TITLE
Fix set tiers as customer on online propal signature

### DIFF
--- a/htdocs/core/ajax/onlineSign.php
+++ b/htdocs/core/ajax/onlineSign.php
@@ -290,7 +290,7 @@ if ($action == "importSignature") {
 						} else {
 							$soc = new Societe($db);
 							$soc->id = $object->socid;
-							$result = $soc->set_as_client();
+							$result = $soc->setAsCustomer();
 							if ($result < 0) {
 								$error++;
 								$response = $db->lasterror();

--- a/htdocs/core/ajax/onlineSign.php
+++ b/htdocs/core/ajax/onlineSign.php
@@ -288,7 +288,15 @@ if ($action == "importSignature") {
 							$error++;
 							$response = "error in trigger " . $object->error;
 						} else {
-							$response = "success";
+							$soc = new Societe($db);
+							$soc->id = $object->socid;
+							$result = $soc->set_as_client();
+							if ($result < 0) {
+								$error++;
+								$response = $db->lasterror();
+							} else {
+								$response = "success";
+							}
 						}
 					} else {
 						$response = "success";


### PR DESCRIPTION
When a prospect signs an online propal, the tiers stays as prospect not customer.
This PR sets the tiers as customer when the propal is signed, the same way Propal::closeProposal() does.