### PR TITLE
Use bank account owner name (if set) instead of company

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -1680,7 +1680,11 @@ abstract class CommonInvoice extends CommonObject
 		if ($this->fk_account > 0) {
 			$bankAccount->fetch($this->fk_account);
 			$lines[] = $bankAccount->bic; //BIC (required)
-			$lines[] = $mysoc->name; //Name (required)
+			if ($bankAccount->owner_name) {
+			    $lines[] = $bankAccount->owner_name; //Owner of bank account, if present (required)
+			} else {
+			    $lines[] = $mysoc->name; //Use company name instead (required)
+		        }
 			$lines[] = $bankAccount->iban; //IBAN (required)
 		} else {
 			$lines[] = ""; //BIC (required)


### PR DESCRIPTION
NEW #31284 buildEPCQrCodeString: Use owner_name of bank account instead of company