### PR TITLE
Propal informations not updated after adding a line with MAIN_DISABLE_PDF_AUTOUPDATE set to 1

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1454,6 +1454,8 @@ if (empty($reshook)) {
 				if ($result > 0) {
 					$db->commit();
 
+					$ret = $object->fetch($id); // Reload to get new records
+
 					if (!getDolGlobalString('MAIN_DISABLE_PDF_AUTOUPDATE')) {
 						// Define output language
 						$outputlangs = $langs;
@@ -1462,7 +1464,7 @@ if (empty($reshook)) {
 							$newlang = (GETPOST('lang_id', 'aZ09') ? GETPOST('lang_id', 'aZ09') : $object->thirdparty->default_lang);
 							$outputlangs->setDefaultLang($newlang);
 						}
-						$ret = $object->fetch($id); // Reload to get new records
+
 						if ($ret > 0) {
 							$object->fetch_thirdparty();
 						}

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1455,6 +1455,9 @@ if (empty($reshook)) {
 					$db->commit();
 
 					$ret = $object->fetch($id); // Reload to get new records
+					if ($ret > 0) {
+						$object->fetch_thirdparty();
+					}
 
 					if (!getDolGlobalString('MAIN_DISABLE_PDF_AUTOUPDATE')) {
 						// Define output language
@@ -1463,10 +1466,6 @@ if (empty($reshook)) {
 							$outputlangs = new Translate("", $conf);
 							$newlang = (GETPOST('lang_id', 'aZ09') ? GETPOST('lang_id', 'aZ09') : $object->thirdparty->default_lang);
 							$outputlangs->setDefaultLang($newlang);
-						}
-
-						if ($ret > 0) {
-							$object->fetch_thirdparty();
 						}
 						$object->generateDocument($object->model_pdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
 					}


### PR DESCRIPTION
When a line is added to a Propal with the MAIN_DISABLE_PDF_AUTOUPDATE variable set to 1, the object is not reloaded, so the weight and amount are not updated when the Propal is displayed.

in commande/card.php,$ret = $object->fetch($object->id); is done outside the MAIN_DISABLE_PDF_AUTOUPDATE condition.