### PR TITLE
FIX 21: HTML Markup no longer allowed in $title parameter of print_barre_liste

### DIFF
--- a/htdocs/langs/en_US/companies.lang
+++ b/htdocs/langs/en_US/companies.lang
@@ -463,3 +463,4 @@ AADEWebserviceCredentials=AADE Webservice Credentials
 ThirdPartyMustBeACustomerToCreateBANOnStripe=The third-party must be a customer to allow the creation of its bank info on Stripe side
 NewSocNameForClone=New company name
 ConfirmCloneThirdparties=Are you sure that you want to clone <b>%s</b> company ?
+SelectElementType=[please select the type of element below]

--- a/htdocs/societe/consumption.php
+++ b/htdocs/societe/consumption.php
@@ -476,8 +476,8 @@ if ($sql_select) {
 	if ($optioncss) {
 		$param .= '&optioncss='.urlencode($optioncss);
 	}
-
-	print_barre_liste($langs->trans('ProductsIntoElements').' '.$typeElementString.' '.$button, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', $num, $totalnboflines, '', 0, '', '', $limit);
+	print_barre_liste($langs->trans('ProductsIntoElements', $langs->trans($elementTypeArray[GETPOST('type_element')] ?? 'SelectElementType')), $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', $num, $totalnboflines, '', 0, '', '', $limit);
+	print $typeElementString.' '.$button;
 
 	print '<div class="div-table-responsive-no-min">';
 	print '<table class="liste centpercent">'."\n";
@@ -746,7 +746,8 @@ if ($sql_select) {
 	}
 	$db->free($resql);
 } elseif (empty($type_element) || $type_element == -1) {
-	print_barre_liste($langs->trans('ProductsIntoElements').' '.$typeElementString.' '.$button, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', (!empty($num) ? $num : 0), '', '');
+	print_barre_liste($langs->trans('ProductsIntoElements', $langs->trans($elementTypeArray[GETPOST('type_element')] ?? 'SelectElementType')), $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', (!empty($num) ? $num : 0), '', '');
+	print $typeElementString.' '.$button;
 
 	print '<table class="liste centpercent">'."\n";
 	// Titles with sort buttons
@@ -762,7 +763,8 @@ if ($sql_select) {
 
 	print "</table>";
 } else {
-	print_barre_liste($langs->trans('ProductsIntoElements').' '.$typeElementString.' '.$button, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', $num, '', '');
+	print_barre_liste($langs->trans('ProductsIntoElements', $langs->trans($elementTypeArray[GETPOST('type_element')] ?? 'SelectElementType')), $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', $num, '', '');
+	print ' '.$typeElementString.' '.$button;
 
 	print '<table class="liste centpercent">'."\n";
 


### PR DESCRIPTION
# FIX
In Dolibarr 21, when you go to a company's Related Items tab, you get this:
![image](https://github.com/user-attachments/assets/d02f6342-123d-47c9-9257-3c394b487398)

After my PR it would look like this:
![image](https://github.com/user-attachments/assets/6b111402-5e4e-4747-b468-f4701f527ee5)
