### PR TITLE
NEW: setDefaultLangs('auto') now check mysoc and conf

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -93,7 +93,7 @@ class Translate
 		if ($srclang == 'auto') {
 			if (!empty($mysoc->defaultlang)) {
 				$srclang = $mysoc->defaultlang;
-			} else if (!empty(getDolGlobalString('MAIN_LANG_DEFAULT', 'auto'))) {
+			} else {
 				$srclang = getDolGlobalString('MAIN_LANG_DEFAULT', 'auto');
 			}
 		}

--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -70,7 +70,7 @@ class Translate
 	 */
 	public function setDefaultLang($srclang = 'en_US')
 	{
-		global $conf;
+		global $conf, $mysoc;
 
 		//dol_syslog(get_class($this)."::setDefaultLang srclang=".$srclang,LOG_DEBUG);
 
@@ -89,6 +89,14 @@ class Translate
 		}
 
 		$this->origlang = $srclang;
+
+		if ($srclang == 'auto') {
+			if (!empty($mysoc->defaultlang)) {
+				$srclang = $mysoc->defaultlang;
+			} else if (!empty(getDolGlobalString('MAIN_LANG_DEFAULT', 'auto'))) {
+				$srclang = getDolGlobalString('MAIN_LANG_DEFAULT', 'auto');
+			}
+		}
 
 		if (empty($srclang) || $srclang == 'auto') {
 			// $_SERVER['HTTP_ACCEPT_LANGUAGE'] can be 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7,it;q=0.6' but can contains also malicious content


### PR DESCRIPTION
# NEW|New setDefaultLangs now checks MAIN_LANG_DEFAULT and mysoc lang if 'auto'

Currently, setDefaultLangs with 'auto' argument sets the lang to the server's. 
I've added so that it will beforehand check if $mysoc->defaultlang is defined and if yes it will take its lang,
otherwise if 'MAIN_LANG_DEFAULT' is defined it takes its lang.

Otherwise it does the same thing as before (server's lang).
