### PR TITLE
Fix undefined global variable user/card.php

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -918,7 +918,7 @@ return [
         'htdocs/ticket/list.php' => ['PhanTypeComparisonFromArray'],
         'htdocs/ticket/tpl/linkedobjectblock.tpl.php' => ['PhanUndeclaredProperty'],
         'htdocs/user/bank.php' => ['PhanPossiblyUndeclaredGlobalVariable', 'PhanUndeclaredGlobalVariable'],
-        'htdocs/user/card.php' => ['PhanTypeMismatchProperty', 'PhanUndeclaredGlobalVariable'],
+        'htdocs/user/card.php' => ['PhanTypeMismatchProperty'],
         'htdocs/user/class/api_users.class.php' => ['PhanTypeMismatchProperty'],
         'htdocs/user/class/user.class.php' => ['PhanUndeclaredProperty'],
         'htdocs/user/class/usergroup.class.php' => ['PhanPluginUnknownArrayMethodParamType', 'PhanPluginUnknownArrayMethodReturnType', 'PhanPluginUnknownPropertyType', 'PhanUndeclaredProperty'],

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -609,6 +609,7 @@ if (empty($reshook)) {
 						$dir = $conf->user->dir_output.'/'.get_exdir(0, 0, 0, 1, $object, 'user').'/photos';
 
 						dol_mkdir($dir);
+						$mesgs = null;
 
 						if (@is_dir($dir)) {
 							$newfile = $dir.'/'.dol_sanitizeFileName($_FILES['photo']['name']);
@@ -2964,7 +2965,15 @@ if ($action == 'create' || $action == 'adduserldap') {
 			$genallowed = $user->hasRight("user", "user", "read");
 			$delallowed = $user->hasRight("user", "user", "write");
 
-			print $formfile->showdocuments('user', $filename, $filedir, $urlsource, $genallowed, $delallowed, $object->model_pdf, 1, 0, 0, 28, 0, '', 0, '', !is_object($soc) || empty($soc->default_lang) ? '' : $soc->default_lang);
+
+			if ($object->socid) {
+				$societe = new Societe($db);
+				$societe->fetch($object->socid);
+			} else {
+				$societe = null;
+			}
+
+			print $formfile->showdocuments('user', $filename, $filedir, $urlsource, $genallowed, $delallowed, $object->model_pdf, 1, 0, 0, 28, 0, '', 0, '', !is_object($societe) || empty($societe->default_lang) ? '' : $societe->default_lang);
 			$somethingshown = $formfile->numoffiles;
 
 			// Show links to link elements


### PR DESCRIPTION
# Fix undefined global variable user/card.php

Fix a few issues, one of which noticed in V21 UI.

Also notified by phan:
```
htdocs\user\card.php:626 PhanUndeclaredGlobalVariable Global variable $mesgs is undeclared
htdocs\user\card.php:2967 PhanUndeclaredGlobalVariable Global variable $soc is undeclared
```

http://127.0.1.0/user/card.php?id=1

![image](https://github.com/user-attachments/assets/a2654a75-0395-4528-944f-bbd335bb89cb)
