### PR TITLE
Fix: Cope with undefined country key in search array.

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -700,7 +700,7 @@ return [
         'htdocs/partnership/core/modules/partnership/mod_partnership_advanced.php' => ['PhanUndeclaredProperty'],
         'htdocs/partnership/lib/partnership.lib.php' => ['PhanPluginUnknownArrayFunctionReturnType'],
         'htdocs/partnership/partnership_card.php' => ['PhanUndeclaredGlobalVariable'],
-        'htdocs/partnership/partnership_list.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredProperty'],
+        'htdocs/partnership/partnership_list.php' => ['PhanUndeclaredProperty'],
         'htdocs/paypal/lib/paypal.lib.php' => ['PhanPluginUnknownArrayFunctionReturnType'],
         'htdocs/printing/index.php' => ['PhanUndeclaredProperty'],
         'htdocs/printing/lib/printing.lib.php' => ['PhanPluginUnknownArrayFunctionReturnType'],

--- a/htdocs/partnership/partnership_list.php
+++ b/htdocs/partnership/partnership_list.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2007-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2021		NextGestion			<contact@nextgestion.com>
  * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -790,9 +791,9 @@ foreach ($all_fields_list as $key => $val) {
 		} elseif ($key == 'lang') {
 			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
 			$formadmin = new FormAdmin($db);
-			print $formadmin->select_language($search[$key], 'search_lang', 0, null, 1, 0, 0, 'minwidth100imp maxwidth125', 2);
+			print $formadmin->select_language($search[$key], 'search_lang', 0, array(), 1, 0, 0, 'minwidth100imp maxwidth125', 2);
 		} elseif ($key == 'country') {
-			print $form->select_country($search[$key], 'search_country', '', 0, 'minwidth100imp maxwidth100');
+			print $form->select_country(in_array($key, $search) ? $search[$key] : 0, 'search_country', '', 0, 'minwidth100imp maxwidth100');
 		} else {
 			print '<input type="text" class="flat maxwidth75" name="search_'.$key.'" value="'.dol_escape_htmltag(isset($search[$key]) ? $search[$key] : '').'">';
 		}


### PR DESCRIPTION
# Fix: Cope with undefined country key in search array

Fix:
```
htdocs\partnership\partnership_list.php:533 PhanUndeclaredProperty Reference to undeclared property \Partnership->login
htdocs\partnership\partnership_list.php:793 PhanTypeMismatchArgumentProbablyReal Argument 4 ($filter) is null of type null but \FormAdmin::select_language() takes array|string[] (no real type) defined at htdocs\core\class\html.formadmin.class.php:74 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
```

http://127.0.1.0/partnership/partnership_list.php?idmenu=108562&mainmenu=companies&leftmenu=

![image](https://github.com/user-attachments/assets/2ebcd202-3d16-4302-a76f-a83d29290fba)
