### PR TITLE
fix: remove SQL Error when tobill field is displayed in task list

### DIFF
--- a/htdocs/projet/tasks/list.php
+++ b/htdocs/projet/tasks/list.php
@@ -539,7 +539,7 @@ if (!empty($arrayfields['t.tobill']['checked']) || !empty($arrayfields['t.billed
 	$sql .= " GROUP BY p.rowid, p.ref, p.title, p.fk_statut, p.datee, p.fk_opp_status, p.public, p.fk_user_creat,";
 	$sql .= " s.nom, s.rowid,";
 	$sql .= " t.datec, t.dateo, t.datee, t.tms,";
-	$sql .= " t.rowid, t.ref, t.label, t.planned_workload, t.duration_effective, t.progress,t.budget_amount, t.fk_statut as status";
+	$sql .= " t.rowid, t.ref, t.label, t.planned_workload, t.duration_effective, t.progress,t.budget_amount, t.fk_statut";
 	// Add fields from extrafields
 	if (!empty($extrafields->attributes[$object->table_element]['label'])) {
 		foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $val) {


### PR DESCRIPTION
fix: #31359 

**GROUP BY** do not support **t.field as aliasname**

Requête dernier accès en base en erreur: SELECT DISTINCT p.rowid as projectid, p.ref as projectref, p.title as projecttitle, p.fk_statut as projectstatus, p.datee as projectdatee, p.fk_opp_status, p.public, p.fk_user_creat as projectusercreate, p.usage_bill_time, s.nom as name, s.name_alias as alias, s.rowid as socid, t.datec as date_creation, t.dateo as date_start, t.datee as date_end, t.tms as date_modification, t.rowid as id, t.ref, t.label, t.planned_workload, t.duration_effective, t.progress, t.fk_statut as status, t.description, t.fk_task_parent, t.budget_amount , SUM(tt.element_duration * (CASE WHEN invoice_id IS NULL THEN 1 ELSE 0 END)) as tobill, SUM(tt.element_duration * (CASE WHEN invoice_id IS NULL THEN 0 ELSE 1 END)) as billed FROM llx_projet as p LEFT JOIN llx_societe as s on p.fk_soc = s.rowid, llx_projet_task as t LEFT JOIN llx_element_time as tt ON (tt.fk_element = t.rowid AND tt.elementtype = 'task') WHERE t.fk_projet = p.rowid AND p.entity IN (1) AND p.fk_statut = 1 **GROUP BY** p.rowid, p.ref, p.title, p.fk_statut, p.datee, p.fk_opp_status, p.public, p.fk_user_creat, s.nom, s.rowid, t.datec, t.dateo, t.datee, t.tms, t.rowid, t.ref, t.label, t.planned_workload, t.duration_effective, t.progress,t.budget_amount, **t.fk_statut as status** ORDER BY p.ref DESC LIMIT 26
Code retour dernier accès en base en erreur: DB_ERROR_SYNTAX