### PR TITLE
fix: add rounding for multicurrency unit price

### DIFF
--- a/htdocs/core/lib/price.lib.php
+++ b/htdocs/core/lib/price.lib.php
@@ -174,7 +174,7 @@ function calcul_price_total($qty, $pu, $remise_percent_ligne, $txtva, $uselocalt
 	// pu calculation from pu_devise if pu empty
 	if (empty($pu) && !empty($pu_devise)) {
 		if (!empty($multicurrency_tx)) {
-			$pu = price2num($pu_devise / $multicurrency_tx, 'MT');
+			$pu = price2num($pu_devise / $multicurrency_tx, 'MU');
 		} else {
 			dol_syslog('Price.lib::calcul_price_total function called with bad parameters combination (multicurrency_tx empty when pu_devise not) ', LOG_ERR);
 			return array();

--- a/htdocs/core/lib/price.lib.php
+++ b/htdocs/core/lib/price.lib.php
@@ -174,7 +174,7 @@ function calcul_price_total($qty, $pu, $remise_percent_ligne, $txtva, $uselocalt
 	// pu calculation from pu_devise if pu empty
 	if (empty($pu) && !empty($pu_devise)) {
 		if (!empty($multicurrency_tx)) {
-			$pu = $pu_devise / $multicurrency_tx;
+			$pu = price2num($pu_devise / $multicurrency_tx, 'MT');
 		} else {
 			dol_syslog('Price.lib::calcul_price_total function called with bad parameters combination (multicurrency_tx empty when pu_devise not) ', LOG_ERR);
 			return array();
@@ -408,7 +408,7 @@ function calcul_price_total($qty, $pu, $remise_percent_ligne, $txtva, $uselocalt
 		}
 
 		// Recall function using the multicurrency price as reference price. We must set param $multicurrency_tx to 1 to avoid infinite loop.
-		$newresult = calcul_price_total($qty, $pu_devise, $remise_percent_ligne, $txtva, $uselocaltax1_rate, $uselocaltax2_rate, $remise_percent_global, $price_base_type, $info_bits, $type, $seller, $localtaxes_array, $progress, 1, 0, '');
+		$newresult = calcul_price_total($qty, '', $remise_percent_ligne, $txtva, $uselocaltax1_rate, $uselocaltax2_rate, $remise_percent_global, $price_base_type, $info_bits, $type, $seller, $localtaxes_array, $progress, 1, $pu_devise, '');
 
 		if ($multicurrency_code) {
 			// Restore setup of currency accurency

--- a/htdocs/core/lib/price.lib.php
+++ b/htdocs/core/lib/price.lib.php
@@ -85,7 +85,7 @@
  * 						25=multicurrency_total_tax1 for total_ht
  *                      26=multicurrency_total_tax2 for total_ht
  */
-function calcul_price_total($qty, $pu = 0, $remise_percent_ligne, $txtva, $uselocaltax1_rate, $uselocaltax2_rate, $remise_percent_global, $price_base_type, $info_bits, $type, $seller = '', $localtaxes_array = [], $progress = 100, $multicurrency_tx = 1, $pu_devise = 0, $multicurrency_code = '')
+function calcul_price_total($qty, $pu, $remise_percent_ligne, $txtva, $uselocaltax1_rate, $uselocaltax2_rate, $remise_percent_global, $price_base_type, $info_bits, $type, $seller = '', $localtaxes_array = [], $progress = 100, $multicurrency_tx = 1, $pu_devise = 0, $multicurrency_code = '')
 {
 	global $conf, $mysoc, $db;
 
@@ -172,7 +172,7 @@ function calcul_price_total($qty, $pu = 0, $remise_percent_ligne, $txtva, $uselo
 	}
 
 	// pu calculation from pu_devise if pu empty
-	if (!$pu && $pu_devise) {
+	if (empty($pu) && !empty($pu_devise)) {
 		if (!empty($multicurrency_tx)) {
 			$pu = price2num($pu_devise / $multicurrency_tx, 'MT');
 		} else {
@@ -180,7 +180,9 @@ function calcul_price_total($qty, $pu = 0, $remise_percent_ligne, $txtva, $uselo
 			return array();
 		}
 	}
-
+	if ($pu === '') {
+		$pu = 0;
+	}
 	// pu_devise calculation from pu
 	if (empty($pu_devise) && !empty($multicurrency_tx)) {
 		if (is_numeric($pu) && is_numeric($multicurrency_tx)) {

--- a/htdocs/core/lib/price.lib.php
+++ b/htdocs/core/lib/price.lib.php
@@ -85,7 +85,7 @@
  * 						25=multicurrency_total_tax1 for total_ht
  *                      26=multicurrency_total_tax2 for total_ht
  */
-function calcul_price_total($qty, $pu, $remise_percent_ligne, $txtva, $uselocaltax1_rate, $uselocaltax2_rate, $remise_percent_global, $price_base_type, $info_bits, $type, $seller = '', $localtaxes_array = [], $progress = 100, $multicurrency_tx = 1, $pu_devise = 0, $multicurrency_code = '')
+function calcul_price_total($qty, $pu = 0, $remise_percent_ligne, $txtva, $uselocaltax1_rate, $uselocaltax2_rate, $remise_percent_global, $price_base_type, $info_bits, $type, $seller = '', $localtaxes_array = [], $progress = 100, $multicurrency_tx = 1, $pu_devise = 0, $multicurrency_code = '')
 {
 	global $conf, $mysoc, $db;
 
@@ -172,7 +172,7 @@ function calcul_price_total($qty, $pu, $remise_percent_ligne, $txtva, $uselocalt
 	}
 
 	// pu calculation from pu_devise if pu empty
-	if (empty($pu) && !empty($pu_devise)) {
+	if (!$pu && $pu_devise) {
 		if (!empty($multicurrency_tx)) {
 			$pu = price2num($pu_devise / $multicurrency_tx, 'MT');
 		} else {
@@ -180,9 +180,7 @@ function calcul_price_total($qty, $pu, $remise_percent_ligne, $txtva, $uselocalt
 			return array();
 		}
 	}
-	if ($pu === '') {
-		$pu = 0;
-	}
+
 	// pu_devise calculation from pu
 	if (empty($pu_devise) && !empty($multicurrency_tx)) {
 		if (is_numeric($pu) && is_numeric($multicurrency_tx)) {
@@ -408,7 +406,7 @@ function calcul_price_total($qty, $pu, $remise_percent_ligne, $txtva, $uselocalt
 		}
 
 		// Recall function using the multicurrency price as reference price. We must set param $multicurrency_tx to 1 to avoid infinite loop.
-		$newresult = calcul_price_total($qty, '', $remise_percent_ligne, $txtva, $uselocaltax1_rate, $uselocaltax2_rate, $remise_percent_global, $price_base_type, $info_bits, $type, $seller, $localtaxes_array, $progress, 1, $pu_devise, '');
+		$newresult = calcul_price_total($qty, 0, $remise_percent_ligne, $txtva, $uselocaltax1_rate, $uselocaltax2_rate, $remise_percent_global, $price_base_type, $info_bits, $type, $seller, $localtaxes_array, $progress, 1, $pu_devise, '');
 
 		if ($multicurrency_code) {
 			// Restore setup of currency accurency

--- a/test/phpunit/PricesTest.php
+++ b/test/phpunit/PricesTest.php
@@ -89,7 +89,7 @@ class PricesTest extends CommonClassTest
 		$result1 = calcul_price_total(2, 8.56, 0, 10, 0, 0, 0, 'HT', 0, 0, '', '', 100, 1.09205);
 		print __METHOD__." result1=".join(', ', $result1)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
-		$this->assertEquals(array(17.12, 1.71, 18.83, 8.56, 0.856, 9.416, 17.12, 1.71, 18.83, 0, 0, 0, 0, 0, 0, 0, 18.7, 1.87, 20.57, 9.34795, 0.93479, 10.28274, 18.7, 1.87, 20.57, 0, 0), $result1, 'Test1b FR');
+		$this->assertEquals(array(17.12, 1.71, 18.83, 8.56, 0.856, 9.416, 17.12, 1.71, 18.83, 0, 0, 0, 0, 0, 0, 0, 18.7, 1.87, 20.57, 9.35, 0.935, 10.285, 18.7, 1.87, 20.57, 0, 0), $result1, 'Test1b FR');
 
 		// qty=2, unit_price=0, discount_line=0, vat_rate=10, price_base_type='HT', multicurrency_tx=1.09205 (method we provide value), pu_ht_devise=100
 		$mysoc->country_code = 'FR';

--- a/test/phpunit/PricesTest.php
+++ b/test/phpunit/PricesTest.php
@@ -97,7 +97,7 @@ class PricesTest extends CommonClassTest
 		$result1 = calcul_price_total(2, 0, 0, 10, 0, 0, 0, 'HT', 0, 0, '', '', 100, 1.09205, 20);
 		print __METHOD__." result1=".join(', ', $result1)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
-		$this->assertEquals(array(36.63, 3.66, 40.29, 18.31418, 1.83142, 20.1456, 36.63, 3.66, 40.29, 0, 0, 0, 0, 0, 0, 0, 40, 4, 44, 20, 2, 22, 40, 4, 44, 0, 0), $result1, 'Test1c FR');
+		$this->assertEquals(array(36.62, 3.66, 40.28, 18.31, 1.831, 20.141, 36.62, 3.66, 40.28, 0, 0, 0, 0, 0, 0, 0, 40, 4, 44, 20, 2, 22, 40, 4, 44, 0, 0), $result1, 'Test1c FR');
 
 		/*
 		 *  Country Spain

--- a/test/phpunit/PricesTest.php
+++ b/test/phpunit/PricesTest.php
@@ -89,7 +89,7 @@ class PricesTest extends CommonClassTest
 		$result1 = calcul_price_total(2, 8.56, 0, 10, 0, 0, 0, 'HT', 0, 0, '', '', 100, 1.09205);
 		print __METHOD__." result1=".join(', ', $result1)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
-		$this->assertEquals(array(17.12, 1.71, 18.83, 8.56, 0.856, 9.416, 17.12, 1.71, 18.83, 0, 0, 0, 0, 0, 0, 0, 18.7, 1.87, 20.57, 9.34795, 0.93479, 10.28274, 18.7, 1.87, 20.57, 0, 0), $result1, 'Test1b FR');
+		$this->assertEquals(array(17.12, 1.71, 18.83, 8.56, 0.856, 9.416, 17.12, 1.71, 18.83, 0, 0, 0, 0, 0, 0, 0, 18.7, 1.87, 20.57, 9.34795, 0.9348, 10.28275, 18.7, 1.87, 20.57, 0, 0), $result1, 'Test1b FR');
 
 		// qty=2, unit_price=0, discount_line=0, vat_rate=10, price_base_type='HT', multicurrency_tx=1.09205 (method we provide value), pu_ht_devise=100
 		$mysoc->country_code = 'FR';

--- a/test/phpunit/PricesTest.php
+++ b/test/phpunit/PricesTest.php
@@ -89,7 +89,7 @@ class PricesTest extends CommonClassTest
 		$result1 = calcul_price_total(2, 8.56, 0, 10, 0, 0, 0, 'HT', 0, 0, '', '', 100, 1.09205);
 		print __METHOD__." result1=".join(', ', $result1)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
-		$this->assertEquals(array(17.12, 1.71, 18.83, 8.56, 0.856, 9.416, 17.12, 1.71, 18.83, 0, 0, 0, 0, 0, 0, 0, 18.7, 1.87, 20.57, 9.35, 0.935, 10.285, 18.7, 1.87, 20.57, 0, 0), $result1, 'Test1b FR');
+		$this->assertEquals(array(17.12, 1.71, 18.83, 8.56, 0.856, 9.416, 17.12, 1.71, 18.83, 0, 0, 0, 0, 0, 0, 0, 18.7, 1.87, 20.57, 9.34795, 0.93479, 10.28274, 18.7, 1.87, 20.57, 0, 0), $result1, 'Test1b FR');
 
 		// qty=2, unit_price=0, discount_line=0, vat_rate=10, price_base_type='HT', multicurrency_tx=1.09205 (method we provide value), pu_ht_devise=100
 		$mysoc->country_code = 'FR';
@@ -97,7 +97,7 @@ class PricesTest extends CommonClassTest
 		$result1 = calcul_price_total(2, 0, 0, 10, 0, 0, 0, 'HT', 0, 0, '', '', 100, 1.09205, 20);
 		print __METHOD__." result1=".join(', ', $result1)."\n";
 		// result[0,1,2,3,4,5,6,7,8]	(total_ht, total_vat, total_ttc, pu_ht, pu_tva, pu_ttc, total_ht_without_discount, total_vat_without_discount, total_ttc_without_discount)
-		$this->assertEquals(array(36.62, 3.66, 40.28, 18.31, 1.831, 20.141, 36.62, 3.66, 40.28, 0, 0, 0, 0, 0, 0, 0, 40, 4, 44, 20, 2, 22, 40, 4, 44, 0, 0), $result1, 'Test1c FR');
+		$this->assertEquals(array(36.63, 3.66, 40.29, 18.31418, 1.83142, 20.1456, 36.63, 3.66, 40.29, 0, 0, 0, 0, 0, 0, 0, 40, 4, 44, 20, 2, 22, 40, 4, 44, 0, 0), $result1, 'Test1c FR');
 
 		/*
 		 *  Country Spain


### PR DESCRIPTION
In **Dolibarr**, when using **foreign currencies**, the wrong value was used for the unit price. Instead of using the correctly rounded value for the unit price, `$pu_devise` (the foreign currency value) was directly used as `$pu`. This resulted in the **unit price being stored in the database with more than two decimal places** and displayed incorrectly in documents like PDFs, leading to inconsistent price representations.

### Cause

The issue was caused by using **`$pu_devise`** (unit price in foreign currency) as the value for **`$pu`** (unit price), without applying the necessary rounding to two decimal places. As a result, the unit price for foreign currencies was not correctly rounded or stored.

### Solution

I modified the code so that:
- **`$pu`** is now passed as **`0`** when calling **`calcul_price_total()`** for foreign currencies.
- **`$pu_devise`** is now passed instead of **`0`** when calling **`calcul_price_total()`** for foreign currencies.
- This ensures that the correct unit price calculation logic is triggered.

### Impact

This fix ensures that:
- Unit prices for foreign currencies, are **stored in the database with two decimal places**, bringing consistency across the system.