### PR TITLE
FIX: substitutions THIRDPARTY_XXX are not available for actioncomm reminders

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -2341,6 +2341,7 @@ class ActionComm extends CommonObject
 
 					// Load event
 					$res = $this->fetch($actionCommReminder->fk_actioncomm);
+					if ($res > 0) $res = $this->fetch_thirdparty();
 					if ($res > 0) {
 						// PREPARE EMAIL
 						$errormesg = '';


### PR DESCRIPTION
FIX: substitutions THIRDPARTY_XXX are not available for actioncomm reminders

When creating an email template for actioncomm reminder, the substitutions for THIRDPARTY_XXX are not dealt with.
This PR simply calls Actioncomm::fetch_thirdparty() before managing substitutions.