### PR TITLE
FIX: add missing fields during install llx_accounting_system

### DIFF
--- a/htdocs/install/mysql/tables/llx_accounting_system.key.sql
+++ b/htdocs/install/mysql/tables/llx_accounting_system.key.sql
@@ -19,6 +19,7 @@
 
 
 ALTER TABLE llx_accounting_system ADD UNIQUE INDEX uk_accounting_system_pcg_version (pcg_version);
+ALTER TABLE llx_accounting_system ADD CONSTRAINT fk_accounting_system_fk_user_author    FOREIGN KEY (fk_user_author)    REFERENCES llx_user (rowid);
 
 -- This key is for another table but created here because must be done after foreign key index is created
 ALTER TABLE llx_accounting_account ADD CONSTRAINT fk_accounting_account_fk_pcg_version    FOREIGN KEY (fk_pcg_version)    REFERENCES llx_accounting_system (pcg_version);

--- a/htdocs/install/mysql/tables/llx_accounting_system.key.sql
+++ b/htdocs/install/mysql/tables/llx_accounting_system.key.sql
@@ -19,7 +19,6 @@
 
 
 ALTER TABLE llx_accounting_system ADD UNIQUE INDEX uk_accounting_system_pcg_version (pcg_version);
-ALTER TABLE llx_accounting_system ADD CONSTRAINT fk_accounting_system_fk_user_author    FOREIGN KEY (fk_user_author)    REFERENCES llx_user (rowid);
 
 -- This key is for another table but created here because must be done after foreign key index is created
 ALTER TABLE llx_accounting_account ADD CONSTRAINT fk_accounting_account_fk_pcg_version    FOREIGN KEY (fk_pcg_version)    REFERENCES llx_accounting_system (pcg_version);

--- a/htdocs/install/mysql/tables/llx_accounting_system.sql
+++ b/htdocs/install/mysql/tables/llx_accounting_system.sql
@@ -24,5 +24,7 @@ create table llx_accounting_system
   fk_country		integer,
   pcg_version       varchar(32)     NOT NULL,
   label             varchar(128)    NOT NULL,
-  active            smallint        DEFAULT 0
+  active            smallint        DEFAULT 0,
+  date_creation     datetime,
+  fk_user_author    integer
 )ENGINE=innodb;


### PR DESCRIPTION
# FIX: llx_accounting_system: add missing fields during install

The current code expects to be able to assign an author for the object and store the creation date.

@eldy Does it need some other changes for migration somehow?