### PR TITLE
FIX - Correction of new hook PR

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -2573,7 +2573,7 @@ if ($resql) {
 					if ($reshook == 1) {
 						// for add information
 						$text_info .= $hookmanager->resPrint;
-					} elseif ($reshook == 0) {
+					} elseif ($reshook == 2) {
 						// for replace information
 						$text_info = $hookmanager->resPrint;
 					} elseif ($reshook == -1) {


### PR DESCRIPTION
# FIX - *Correction of new hook PR*
This PR corrects the [PR for adding a new hook](https://github.com/Dolibarr/dolibarr/pull/31315). I made the mistake of setting the text_info replacement to $reshook == 0, which is the default value for reshook, which always replaced the given with empty when the hook was not in use. 






