### PR TITLE
FIX | Thirdparty sales representative status in list view

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -1827,6 +1827,7 @@ while ($i < $imaxinloop) {
 					$userstatic->user_mobile = $val['user_mobile'];
 					$userstatic->job = $val['job'];
 					$userstatic->gender = $val['gender'];
+					$userstatic->statut = $val['statut'];
 					print ($nbofsalesrepresentative < 2) ? $userstatic->getNomUrl(-1, '', 0, 0, 12) : $userstatic->getNomUrl(-2);
 					$j++;
 					if ($j < $nbofsalesrepresentative) {


### PR DESCRIPTION
FIX|Fix [Thirdparty sales representative status in LIST VIEW] 

[third party sales representative user status in LIST view is marked as DISABLED when hovering over the sales representative, even though the user is ENABLED]
this pull request fixes this.


<img width="776" alt="Screenshot 2024-10-16 at 6 36 09 PM" src="https://github.com/user-attachments/assets/aaaa8c47-ebd9-4d69-9c99-dfc0c3da05f8">