### PR TITLE
FIX Update date.lib.php Function num_between_day 

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -852,7 +852,7 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
  */
 function num_between_day($timestampStart, $timestampEnd, $lastday = 0)
 {
-	if ($timestampStart < $timestampEnd)
+	if ($timestampStart <= $timestampEnd)
 	{
 		if ($lastday == 1)
 		{

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -852,14 +852,10 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
  */
 function num_between_day($timestampStart, $timestampEnd, $lastday = 0)
 {
-	if ($timestampStart <= $timestampEnd)
-	{
-		if ($lastday == 1)
-		{
+	if ($timestampStart <= $timestampEnd) {
+		if ($lastday == 1) {
 			$bit = 0;
-		}
-		else
-		{
+		} else {
 			$bit = 1;
 		}
 		$nbjours = (int) floor(($timestampEnd - $timestampStart) / (60 * 60 * 24)) + 1 - $bit;


### PR DESCRIPTION
FIX - When debugging Asset Module, I discovered that function num_between_day is returning nothing when  $timestampStart equals (==) $timestampEnd
Normally it has to return 
0 if $lastday = 0
1 if $lastday = 1

