### PR TITLE
FIX Update accounting.lib.php function getCurrentPeriodOfFiscalYear

### DIFF
--- a/htdocs/core/lib/accounting.lib.php
+++ b/htdocs/core/lib/accounting.lib.php
@@ -347,7 +347,7 @@ function getCurrentPeriodOfFiscalYear($db, $conf, $from_time = null)
 	if ($from_time === null) {
 		$from_time = $now;
 	}
-	$from_db_time = $db->idate($from_time);
+	$from_db_time = dol_print_date($from_time,"%Y-%m-%d");
 
 	$sql  = "SELECT date_start, date_end FROM ".$db->prefix()."accounting_fiscalyear";
 	$sql .= " WHERE date_start <= '".$db->escape($from_db_time)."' AND date_end >= '".$db->escape($from_db_time)."'";

--- a/htdocs/core/lib/accounting.lib.php
+++ b/htdocs/core/lib/accounting.lib.php
@@ -347,7 +347,7 @@ function getCurrentPeriodOfFiscalYear($db, $conf, $from_time = null)
 	if ($from_time === null) {
 		$from_time = $now;
 	}
-	$from_db_time = dol_print_date($from_time,"%Y-%m-%d");
+	$from_db_time = dol_print_date($from_time, "%Y-%m-%d");
 
 	$sql  = "SELECT date_start, date_end FROM ".$db->prefix()."accounting_fiscalyear";
 	$sql .= " WHERE date_start <= '".$db->escape($from_db_time)."' AND date_end >= '".$db->escape($from_db_time)."'";


### PR DESCRIPTION
When debugging Asset, I discovered that function getCurrentPeriodOfFiscalYear is generating a wrong SQL request when playing with boundaries of fiscal year. 
e.g FY2018 goes from 01/01/2018 up to 31/12/2018 
If you ran the function with searching the date 31/12/2018 the following SQL request was generated  =
SELECT date_start, date_end FROM llx_accounting_fiscalyear WHERE date_start <= '2018-12-31 12:00:00' AND date_end >= '2018-12-31 12:00:00' ORDER BY date_start DESC LIMIT 1  
WRONG SQL RESULT : 0 ROW due to $fromtime = 2018-12-31 12:00:00 

The reason is the fact that the time 12:00:00 is going over the limit of the day. 
Then the result returned by the main function is totally wrong (latest FY Dates available returned 2024-01-01 and 2024-12-31)

To avoid this behavior, we need to build the right $fromtime variable = 2018-12-31 with dol_print_date($from_time,"%Y-%m-%d") instead of $db->idate($from_time)
The SQL then becomes 
SELECT date_start, date_end FROM llx_accounting_fiscalyear WHERE date_start <= '2018-12-31' AND date_end >= '2018-12-31' ORDER BY date_start DESC LIMIT 1  
SQL RESULT : 1 row with the right Dates values returned by the function (2018-01-01  and 2018-12-31)

