### PR TITLE
FIX: Replenishment lib class does not extract data from already received supplier orders

### DIFF
--- a/htdocs/product/stock/lib/replenishment.lib.php
+++ b/htdocs/product/stock/lib/replenishment.lib.php
@@ -39,7 +39,7 @@ function dolDispatchToDo($order_id)
 
 	// Count nb of quantity dispatched per product
 	$sql = 'SELECT fk_product, SUM(qty) as qtydispatched FROM '.MAIN_DB_PREFIX.'receptiondet_batch';
-	$sql .= ' WHERE fk_element = '.((int) $order_id);
+	$sql .= " WHERE fk_element = ".((int) $order_id)." AND element_type = 'supplier_order'";
 	$sql .= ' GROUP BY fk_product';
 	$sql .= ' ORDER by fk_product';
 	$resql = $db->query($sql);

--- a/htdocs/product/stock/lib/replenishment.lib.php
+++ b/htdocs/product/stock/lib/replenishment.lib.php
@@ -39,7 +39,7 @@ function dolDispatchToDo($order_id)
 
 	// Count nb of quantity dispatched per product
 	$sql = 'SELECT fk_product, SUM(qty) as qtydispatched FROM '.MAIN_DB_PREFIX.'receptiondet_batch';
-	$sql .= ' WHERE fk_commande = '.((int) $order_id);
+	$sql .= ' WHERE fk_element = '.((int) $order_id);
 	$sql .= ' GROUP BY fk_product';
 	$sql .= ' ORDER by fk_product';
 	$resql = $db->query($sql);
@@ -119,9 +119,9 @@ function ordered($product_id)
 	$sql .= ' '.MAIN_DB_PREFIX.'commande_fournisseurdet as cfd ';
 	$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'commande_fournisseur as cf';
 	$sql .= ' ON cfd.fk_commande = cf.rowid WHERE';
-	if ($conf->global->STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER) {
+	if (getDolGlobalString("STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER")) {
 		$sql .= ' cf.fk_statut < 3';
-	} elseif ($conf->global->STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER) {
+	} elseif getDolGlobalString("STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER")) {
 		$sql .= ' cf.fk_statut < 6 AND cf.rowid NOT IN '.dispatchedOrders();
 	} else {
 		$sql .= ' cf.fk_statut < 5';

--- a/htdocs/product/stock/lib/replenishment.lib.php
+++ b/htdocs/product/stock/lib/replenishment.lib.php
@@ -119,9 +119,9 @@ function ordered($product_id)
 	$sql .= ' '.MAIN_DB_PREFIX.'commande_fournisseurdet as cfd ';
 	$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'commande_fournisseur as cf';
 	$sql .= ' ON cfd.fk_commande = cf.rowid WHERE';
-	if (getDolGlobalString("STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER")) {
+	if (getDolGlobalInt("STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER")) {
 		$sql .= ' cf.fk_statut < 3';
-	} elseif (getDolGlobalString("STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER")) {
+	} elseif (getDolGlobalInt("STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER")) {
 		$sql .= ' cf.fk_statut < 6 AND cf.rowid NOT IN '.dispatchedOrders();
 	} else {
 		$sql .= ' cf.fk_statut < 5';

--- a/htdocs/product/stock/lib/replenishment.lib.php
+++ b/htdocs/product/stock/lib/replenishment.lib.php
@@ -121,7 +121,7 @@ function ordered($product_id)
 	$sql .= ' ON cfd.fk_commande = cf.rowid WHERE';
 	if (getDolGlobalString("STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER")) {
 		$sql .= ' cf.fk_statut < 3';
-	} elseif getDolGlobalString("STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER")) {
+	} elseif (getDolGlobalString("STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER")) {
 		$sql .= ' cf.fk_statut < 6 AND cf.rowid NOT IN '.dispatchedOrders();
 	} else {
 		$sql .= ' cf.fk_statut < 5';


### PR DESCRIPTION
In stock replenishment, the computation of supplier ordered products is not made as the column name in received orders is wrong. Therefore, the number of needed products is wrongly set to 0 with a total number of already ordered (and received) products displayed in the green box.
On the top of that the global variable `STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER` seems not to be defined and generates an error as it is accessed directly from the $conf array, rather than using the error free getDolGlobalString function.

* Fix wrong table column name from `fk_command` to `fk_element` for table receptiondet_batch
* use error free  getDolGlobalString to access global variable to replace $conf->global access.

