### PR TITLE
FIX attached files not sent in empty email

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -597,6 +597,9 @@ class CMailFile
 				$msg = $this->checkIfHTML($msg);		// This add a header and a body including custom CSS to the HTML content
 			}
 
+			if ($msg === '.') {
+				$msg = "\n.\n";
+			}
 			// Replace . alone on a new line with .. to avoid to have SMTP interpret this as end of message
 			$msg = preg_replace('/(\r|\n)\.(\r|\n)/ims', '\1..\2', $msg);
 


### PR DESCRIPTION
When we send an email with no text content, the msg text is set to  a single dot : '.' .
But the single dot does not pass this regex: 

$msg = preg_replace('/(\r|\n)\.(\r|\n)/ims', '\1..\2', $msg); in CMailFile.class.php line 602.

This regex converts a single dot alone in a line to two dots to avoid SMTP  interpret it as end of message.

So SMTP interpret it as end of message and truncate the mail content, any files attached won't be sent.