### PR TITLE
FIX : Extrafield following between rec invoice and classic invoice

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -1338,6 +1338,14 @@ class FactureRec extends CommonInvoice
 						$facture->multicurrency_tx = $facturerec->multicurrency_tx;
 					}
 
+					if (isset($facture->array_options) && isset($facturerec->array_options)) {
+						foreach ($facturerec->array_options as $key => $value) {
+							if (isset($facture->array_options[$key])) {
+								$facture->array_options[$key] = $value;
+							}
+						}
+					}
+
 					$invoiceidgenerated = $facture->create($user);
 					if ($invoiceidgenerated <= 0) {
 						$this->errors = $facture->errors;


### PR DESCRIPTION
# FIX|Fix Extrafield following
As it has been already done for propal and order, I added the same process for model invoice and classic invoice