### PR TITLE
FIX: Sanitize JS string fort alert()

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -597,7 +597,7 @@ function CloseBill() {
 	if (!empty($conf->global->TAKEPOS_FORBID_SALES_TO_DEFAULT_CUSTOMER)) {
 		echo "customerAnchorTag = document.querySelector('a[id=\"customer\"]'); ";
 		echo "if (customerAnchorTag && customerAnchorTag.innerText.trim() === '".$langs->trans("Customer")."') { ";
-		echo "alert('".$langs->trans("NoClientErrorMessage")."'); ";
+		echo "alert('".dol_escape_js($langs->trans("NoClientErrorMessage"))."'); ";
 		echo "return; } \n";
 	}
 	?>


### PR DESCRIPTION
# FIX: Sanitize JS string fort alert()

Currently this bug prevents TakePOS to start when the translated string contains `'`

Not ideal way to sanitize though, since HTML entities are also converted by this function. So alert shows `Veuillez s&eacute;lectionner un client d'abord`.