### PR TITLE
FIX: Make html form warehouse select filter between closed and opened work if const ENTREPOT_EXTRA_STATUS not set

### DIFF
--- a/htdocs/product/class/html.formproduct.class.php
+++ b/htdocs/product/class/html.formproduct.class.php
@@ -298,7 +298,7 @@ class FormProduct
 		dol_syslog(get_class($this)."::selectWarehouses " . (is_array($selected) ? 'selected is array' : $selected) . ", $htmlname, $filterstatus, $empty, $disabled, $fk_product, $empty_label, $showstock, $forcecombo, $morecss", LOG_DEBUG);
 
 		$out = '';
-		if ((!getDolGlobalString('ENTREPOT_EXTRA_STATUS') && ($filterstatus==="warehouseinternal")) {
+		if ((!getDolGlobalString('ENTREPOT_EXTRA_STATUS')) && ($filterstatus==="warehouseinternal")) {
 			$filterstatus = '';
 		}
 		if (!empty($fk_product) && $fk_product > 0) {

--- a/htdocs/product/class/html.formproduct.class.php
+++ b/htdocs/product/class/html.formproduct.class.php
@@ -298,7 +298,7 @@ class FormProduct
 		dol_syslog(get_class($this)."::selectWarehouses " . (is_array($selected) ? 'selected is array' : $selected) . ", $htmlname, $filterstatus, $empty, $disabled, $fk_product, $empty_label, $showstock, $forcecombo, $morecss", LOG_DEBUG);
 
 		$out = '';
-		if (!getDolGlobalString('ENTREPOT_EXTRA_STATUS')) {
+		if ((!getDolGlobalString('ENTREPOT_EXTRA_STATUS') && ($filterstatus==="warehouseinternal")) {
 			$filterstatus = '';
 		}
 		if (!empty($fk_product) && $fk_product > 0) {


### PR DESCRIPTION
Fix filter status variable that is reset if global constant ENTREPOT_EXTRA_STATUS is not set. 
This prevents the form warehouse list to display only opened or closed warehouse if the global const is not set.
