### PR TITLE
FIX - Wrong Typing in DataBase

### DIFF
--- a/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
+++ b/htdocs/install/mysql/migration/18.0.0-19.0.0.sql
@@ -222,3 +222,5 @@ UPDATE llx_c_units SET scale = 1 WHERE code = 'S';
 UPDATE llx_c_tva SET taux = 3 WHERE fk_pays = 102 AND taux = 16;
 
 UPDATE llx_menu SET url = CONCAT(url, '&mode=init') WHERE fk_mainmenu = 'ticket' AND titre = 'NewTicket' AND url LIKE '/ticket/card.php?action=create%' AND url NOT LIKE '%mode=init%';
+
+ALTER TABLE llx_actioncomm MODIFY email_to TEXT, MODIFY email_tocc TEXT, MODIFY email_tobcc TEXT;

--- a/htdocs/install/mysql/tables/llx_actioncomm.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm.sql
@@ -63,9 +63,9 @@ create table llx_actioncomm
   email_msgid		varchar(255),					-- when event was an email, we store here the msgid
   email_from		varchar(255),					-- when event was an email, we store here the from
   email_sender		varchar(255),					-- when event was an email, we store here the sender
-  email_to			varchar(255),					-- when event was an email, we store here the email_to
-  email_tocc		varchar(255),					-- when event was an email, we store here the email_tocc
-  email_tobcc		varchar(255),					-- when event was an email, we store here the email_tobcc
+  email_to			TEXT,					-- when event was an email, we store here the email_to
+  email_tocc		TEXT,					-- when event was an email, we store here the email_tocc
+  email_tobcc		TEXT,					-- when event was an email, we store here the email_tobcc
   errors_to			varchar(255),					-- when event was an email, we store here the erros_to
   reply_to			varchar(255),					-- when event was an email, we store here the reply_to
   


### PR DESCRIPTION
# FIX - *Wrong Typing in DataBase*
To follow this hidden conf: 
“MAIL_MAX_NB_OF_RECIPIENTS_IN_SAME_EMAIL”
It is important to change the type of the email_to, email_tocc and email_tobcc columns. They must be changed from varchar(255) to TEXT. This change allows you to accommodate more data and avoids an event creation error when sending mail. Currently, it's possible to change the conf value to 100 (for example). The e-mail is sent to 100 people, but the event is not created because the type is not capable of handling that much data. 

