### PR TITLE
FIX issue on action set condition in particular when you set a deposi…

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1613,9 +1613,9 @@ if (empty($reshook)) {
 		$result = $object->set_demand_reason($user, GETPOST('demand_reason_id', 'int'));
 	} elseif ($action == 'setconditions' && $usercancreate) {
 		// Terms of payment
-		$sql = 'SELECT code ';
-		$sql .= 'FROM ' . $db->prefix() . 'c_payment_term ';
-		$sql .= 'WHERE rowid = ' . (GETPOST('cond_reglement_id', 'int'));
+		$sql = "SELECT code ";
+		$sql .= "FROM " . $db->prefix() . "c_payment_term";
+		$sql .= " WHERE rowid = " . ((int) GETPOST('cond_reglement_id', 'int'));
 		$result = $db->query($sql);
 		if ($result) {
 			$obj = $db->fetch_object($result);

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1614,14 +1614,14 @@ if (empty($reshook)) {
 	} elseif ($action == 'setconditions' && $usercancreate) {
 		// Terms of payment
 		$sql = 'SELECT code ';
-		$sql .= 'FROM '.$db->prefix().'c_payment_term ';
-		$sql .= 'WHERE rowid = '.(GETPOST('cond_reglement_id', 'int'));
+		$sql .= 'FROM ' . $db->prefix() . 'c_payment_term ';
+		$sql .= 'WHERE rowid = ' . (GETPOST('cond_reglement_id', 'int'));
 		$result = $db->query($sql);
-		if ($result){
+		if ($result) {
 			$obj = $db->fetch_object($result);
-			if ($obj->code == 'DEP30PCTDEL'){
+			if ($obj->code == 'DEP30PCTDEL') {
 				$result = $object->setPaymentTerms(GETPOST('cond_reglement_id', 'int'), GETPOST('cond_reglement_id_deposit_percent', 'alpha'));
-			}else{
+			} else {
 				$object->deposit_percent = 0;
 				$object->update($user);
 				$result = $object->setPaymentTerms(GETPOST('cond_reglement_id', 'int'), $object->deposit_percent);

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1957,7 +1957,7 @@ if ($action == 'create') {
 	// at last resort we take the payment term id which may be filled by default values set (if not getpostisset)
 	print $form->getSelectConditionsPaiements($cond_reglement_id, 'cond_reglement_id', 1, 1, 0, '', $deposit_percent);
 	print '</td></tr>';
-//
+
 	// Mode of payment
 	print '<tr class="field_mode_reglement_id"><td class="titlefieldcreate">'.$langs->trans('PaymentMode').'</td><td class="valuefieldcreate">';
 	print img_picto('', 'bank', 'class="pictofixedwidth"');


### PR DESCRIPTION
# FIX|Fix # Change payment term from deposit to an other payment term

When creating a commercial proposal and setting an advance payment condition, and then wanting to change to a condition such as payment upon receipt, the item along with the proposal still displays the amount of the initial advance next to the new payment condition. Moreover, it was not set to zero during this change.
I have therefore modified it so that if the payment condition is an advance, it retains the current default behavior. However, if the payment method was initially set to an advance on the commercial proposal and then changed to another payment condition, the deposit percentage value is updated in the database so that it is not considered in the commercial proposal.

