### PR TITLE
FIX#31237

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -2136,7 +2136,12 @@ class Societe extends CommonObject
 		$tmpthirdparty = new Societe($this->db);
 		$result = $tmpthirdparty->fetch($rowid, $ref, $ref_ext, $barcode, $idprof1, $idprof2, $idprof3, $idprof4, $idprof5, $idprof6, $email, $ref_alias, $is_client, $is_supplier);
 
-		return $result;
+		//If the row is found by previous operation return it
+		if ($result == 1) {
+			return $tmpthirdparty->id;
+		} else {
+			return $result;
+		}
 	}
 
 	/**


### PR DESCRIPTION
# FIX|Fix #31237 
[*Long description*]

Wrong third-party linking by Emailcollector class has been fixed more accurate way.
