### PR TITLE
Fix bad sql whe exporting salaries

### DIFF
--- a/htdocs/core/modules/modSalaries.class.php
+++ b/htdocs/core/modules/modSalaries.class.php
@@ -158,7 +158,8 @@ class modSalaries extends DolibarrModules
 
 		$this->export_sql_start[$r] = 'SELECT DISTINCT ';
 		$this->export_sql_end[$r]  = ' FROM '.MAIN_DB_PREFIX.'user as u';
-		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'payment_salary as p ON p.fk_user = u.rowid';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'salary as s ON s.fk_user = u.rowid';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'payment_salary as p ON p.fk_salary = s.rowid';
 		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_paiement as cp ON p.fk_typepayment = cp.id';
 		$this->export_sql_end[$r] .= ' AND u.entity IN ('.getEntity('user').')';
 	}


### PR DESCRIPTION
Fix a bad SQL request that link payment_salary to user with a field empty most of the time
Which result on bad values exported

Fix -> join payment_salary <> salary <> user in the SQL request