### PR TITLE
Fix: hooks are not initiated if Hookmanager exists.

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -3528,8 +3528,8 @@ class EmailCollector extends CommonObject
 							if (!is_object($hookmanager)) {
 								include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
 								$hookmanager = new HookManager($this->db);
-								$hookmanager->initHooks(['emailcolector']);
 							}
+							$hookmanager->initHooks(['emailcolector']);
 
 							$parameters = array(
 								'connection' =>  $connection,


### PR DESCRIPTION
FIX: hooks are not initated and therefore not called, if the Hookmanager already exists
