### PR TITLE
FIX add a control before difining "DOL_DOCUMENT_ROOT" in filefunc.php

### DIFF
--- a/htdocs/filefunc.inc.php
+++ b/htdocs/filefunc.inc.php
@@ -176,7 +176,9 @@ if (empty($dolibarr_strict_mode)) {
 	$dolibarr_strict_mode = 0; // For debug in php strict mode
 }
 
-define('DOL_DOCUMENT_ROOT', $dolibarr_main_document_root); // Filesystem core php (htdocs)
+if (!defined('DOL_DOCUMENT_ROOT')) {
+	define('DOL_DOCUMENT_ROOT', $dolibarr_main_document_root); // Filesystem core php (htdocs)
+}
 
 // Security: CSRF protection
 // This test check if referrer ($_SERVER['HTTP_REFERER']) is same web site than Dolibarr ($_SERVER['HTTP_HOST'])


### PR DESCRIPTION
# FIX add a control before difining "DOL_DOCUMENT_ROOT" in filefunc.php

 It may generate errors otherwise on module activation.

'PHP Warning:  Constant DOL_DOCUMENT_ROOT already defined in /var/www/dolitest/htdocs/[filefunc.inc](http://filefunc.inc/).php on line 245'
