### PR TITLE
Fix #31538 Addition to EPC-QR values ​​to correct remittance information

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -1690,6 +1690,7 @@ abstract class CommonInvoice extends CommonObject
 
 		// Add the amount and reference
 		$lines[] = 'EUR' . $totalTTCString; // Amount (optional)
+		$lines[] = ''; // Purpose (optional)
 		$lines[] = ''; // Payment reference (optional)
 		$lines[] = $this->ref; // Remittance Information (optional)
 


### PR DESCRIPTION
Correction of the value of the EPC QR code to ensure the correct sequence of information for a SEPA payment order. The value "Purpose" has been added.