### PR TITLE
Qual: phpstan api_*/Ignore 'no value type specified in iterable type …

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -114,7 +114,8 @@ parameters:
 		- '#Call to function array_key_exists.. with .error. .* will always evaluate to false.#'
 		- '#function dolGetButtonAction expects array\{confirm\?: array.*confirm: true} given.#'
 		- '#(?:make_substitutions expects array<string, string>,) string given\.#'
-		- '# (DolibarrApiAccess|Documents|Login|Setup|Status|Boms|Categories|ExpenseReports|Interventions|AgendaEvents|Proposals|Orders|BankAccounts|Invoices|Contracts|Donations|Shipments|SupplierInvoices|SupplierOrders|KnowledgeManagement|Mos|MultiCurrencies|Partnerships|Products|Tasks|Warehouses|Tickets|Workstation|WorkstationResource|WorkstationUserGroup|Zapier)::.* no value type specified in iterable type array\.#'
+		- '#Method (?:(?:(?:(?:AgendaEve|BankAccou)nt|Bom|C(?:ategorie|ont(?:r?act))|Do(?:cument|libarrApiAcces|nation)|ExpenseReport|In(?:tervention|voice))s|KnowledgeManagement|Login|M(?:(?:ultiCurrencie|o)s)|(?:Order|P(?:artnership|ro(?:duct|posal))|Salarie)s|S(?:etup|(?:hipment|t(?:atu|ockMovement)|upplier(?:Invoice|Order|Proposal))s)|T(?:(?:ask|hirdpartie|icket)s)|W(?:arehouses|ebhook|orkstations)|Zapier)::.*) no value type specified in iterable type array#'
+		- '#Property (?:(?:(?:(?:AgendaEven|Cont(?:r?ac))t|Do(?:libarrApiAcces|nation)|ExpenseReport|In(?:tervention|voice)|Order|Pro(?:duct|posal)|S(?:alarie|(?:hip|tockMove)ment|upplier(?:Invoice|Order|Proposal))|T(?:ask|hirdpartie|icket)|Warehouse)s|Webhook|Zapier)::.*) no value type specified in iterable type array#'
 		- '#Property RemiseCheque::\$account_id \(int\) does not accept string\.#'
 		- '#Property Contact::\$roles \(array<int, array\{id: int, socid: int, element: string, source: string, code: string, label: string\}>\) does not accept non-empty-array<int, string>\.#'
 


### PR DESCRIPTION
…array'

# Qual: phpstan api_*/Ignore 'no value type specified in iterable type array'

This phpstan notice seems to be manually added as an exception and creates conflicts when merging.

So this updates phpstan.neon.dist for all these notices in the api_* files.