### PR TITLE
FIX Asset Module Update depreciation_options_edit.tpl.php

### DIFF
--- a/htdocs/asset/tpl/depreciation_options_edit.tpl.php
+++ b/htdocs/asset/tpl/depreciation_options_edit.tpl.php
@@ -1,6 +1,7 @@
 <?php
-/* Copyright (C) 2021  Open-Dsi  <support@open-dsi.fr>
+/* Copyright (C) 2021  		Open-Dsi  				<support@open-dsi.fr>
  * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024		José					<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -137,7 +138,7 @@ if (empty($reshook)) {
 				}
 				$value = GETPOSTISSET($html_name) ? GETPOST($html_name, $check) : $assetdepreciationoptions->$field_key;
 			} elseif ($field_info['type'] == 'price') {
-				$value = GETPOSTISSET($html_name) ? price2num(GETPOST($html_name)) : ($assetdepreciationoptions->$field_key ? price2num($assetdepreciationoptions->$field_key) : (!empty($field_info['default']) ? $field_info['default'] : 0));
+				$value = GETPOSTISSET($html_name) ? price2num(GETPOST($html_name)) : ($assetdepreciationoptions->$field_key ? price2num($assetdepreciationoptions->$field_key) : (!empty($field_info['default']) ? dol_eval($field_info['default'], 1) : 0));
 			} elseif ($field_key == 'lang') {
 				$value = GETPOSTISSET($html_name) ? GETPOST($html_name, 'aZ09') : $assetdepreciationoptions->lang;
 			} else {


### PR DESCRIPTION
The AssetDepreciationOptionAmountBaseDepreciationHT (Base Amortissable) and 2 others fields AssetDepreciationOptionAmountBaseDeductibleHT, AssetDepreciationOptionTotalAmountLastDepreciationHT did not get their default value executed when using the following TPL: asset/tpl/depreciation_options_edit.tpl.php

Here is the issue:
![image](https://github.com/user-attachments/assets/283eee0d-5c4b-496f-a909-6109211479a2)
 
After fix applied:
![image](https://github.com/user-attachments/assets/56e8b8bd-c410-43da-bf30-af4daf7850c4)

The function dol_eval($field_info['default'], 1) was missing.