### PR TITLE
NEW Const ASSET_ROUND_INTEGER_NUMBER_UPWARDS for ASSET Module. Compatibily to migrate from other accounting solutions.

### DIFF
--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -1113,7 +1113,12 @@ class Asset extends CommonObject
 							$nb_days = min($nb_days_in_year, num_between_day($begin_date, $end_date, 1));
 							$depreciation_ht = (float) price2num($period_amount * $nb_days / $nb_days_in_year, 'MT');
 						}
-
+						if (getDolGlobalInt('ASSET_ROUND_INTEGER_NUMBER_UPWARDS') == 1){
+							if ($idx_loop < $max_loop) { // avoid last depreciation value
+								$depreciation_ht = ceil($depreciation_ht);
+							}
+						}
+						
 						if ($fiscal_period_start <= $depreciation_date_end && $depreciation_date_end <= $fiscal_period_end) { // last period
 							$depreciation_ht = (float) price2num($depreciation_amount - (float) $cumulative_depreciation_ht, 'MT');
 							$cumulative_depreciation_ht = $depreciation_amount;

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -1113,12 +1113,12 @@ class Asset extends CommonObject
 							$nb_days = min($nb_days_in_year, num_between_day($begin_date, $end_date, 1));
 							$depreciation_ht = (float) price2num($period_amount * $nb_days / $nb_days_in_year, 'MT');
 						}
-						if (getDolGlobalInt('ASSET_ROUND_INTEGER_NUMBER_UPWARDS') == 1){
+						if (getDolGlobalInt('ASSET_ROUND_INTEGER_NUMBER_UPWARDS') == 1) {
 							if ($idx_loop < $max_loop) { // avoid last depreciation value
 								$depreciation_ht = ceil($depreciation_ht);
 							}
 						}
-						
+
 						if ($fiscal_period_start <= $depreciation_date_end && $depreciation_date_end <= $fiscal_period_end) { // last period
 							$depreciation_ht = (float) price2num($depreciation_amount - (float) $cumulative_depreciation_ht, 'MT');
 							$cumulative_depreciation_ht = $depreciation_amount;


### PR DESCRIPTION
NEW CONST ASSET_ROUND_INTEGER_NUMBER_UPWARDS

During several months, we worked with 3 accounting experts in migrating from Quadratus to Dolibarr several assets.(more than 200). We compared all of them to get same result in Dolibarr. This has been helping us to check, clean and validate all calculations issues. Other PRs will be submitted.

During this test we discovered also that Quadratus has an option per Company to round upwards all the calculated depreciation asset values (less the last one). With this CONST and the code attach we get same result than Quadratus. 
This is really helpful to migration and also clarity in the lines.  
The code that has been updated is in asset.class.php function calculationDepreciation() 
Const ASSET_ROUND_INTEGER_NUMBER_UPWARDS Asset Values are upwarded

Let me know if this could be added in the core or if we need to create a hook for external modules.

Here is without the const:
![image](https://github.com/user-attachments/assets/6398382d-c40d-460a-aee9-bad5d339e06d)

and with :
![image](https://github.com/user-attachments/assets/2a1f288c-8bdb-4070-ac57-0c1bcdeb6c60)



