### PR TITLE
NEW FY Changed Period handle in Module Asset

### DIFF
--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -1109,9 +1109,14 @@ class Asset extends CommonObject
 								}
 							}
 							$depreciation_ht = (float) price2num($period_amount * $nb_days / $nb_days_in_month, 'MT');
-						} else { // Annually
-							$nb_days = min($nb_days_in_year, num_between_day($begin_date, $end_date, 1));
-							$depreciation_ht = (float) price2num($period_amount * $nb_days / $nb_days_in_year, 'MT');
+						} else { // Annually, taking care for adjustments to shortened or extended periods (e.g., fiscal years of 9 or 15 months)					
+							$nb_days_real = num_between_day($begin_date, $end_date, 1);
+							if (($nb_days_real > 366) || (num_between_day($fiscal_period_start,$fiscal_period_end,1) < $nb_days_in_year)) { // FY Period changed
+								$nb_days = $nb_days_real;
+							} else {
+								$nb_days = min($nb_days_in_year, $nb_days_real);
+							}	
+							$depreciation_ht = (double) price2num($period_amount * $nb_days / $nb_days_in_year, 'MT');
 						}
 
 						if ($fiscal_period_start <= $depreciation_date_end && $depreciation_date_end <= $fiscal_period_end) { // last period
@@ -1130,12 +1135,13 @@ class Asset extends CommonObject
 
 					// Next fiscal period (+1 day/month/year)
 					$fiscal_period_start = dol_time_plus_duree($fiscal_period_end, 1, 'd');
+					$dates_fiscal_period = getCurrentPeriodOfFiscalYear($this->db, $conf, $fiscal_period_start,'gmt');
 					if ($fields['duration_type'] == 2) { // Daily
 						$fiscal_period_end = $fiscal_period_start;
 					} elseif ($fields['duration_type'] == 1) { // Monthly
 						$fiscal_period_end = dol_time_plus_duree(dol_time_plus_duree($fiscal_period_start, 1, 'm'), -1, 'd');
 					} else { // Annually
-						$fiscal_period_end = dol_time_plus_duree(dol_time_plus_duree($fiscal_period_start, 1, 'y'), -1, 'd');
+						$fiscal_period_end = $dates_fiscal_period['date_end'];
 					}
 					$last_period_date = $disposal_date !== "" && $disposal_date < $depreciation_date_end ? $disposal_date : $depreciation_date_end;
 				} while ($fiscal_period_start < $last_period_date);

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -1109,13 +1109,13 @@ class Asset extends CommonObject
 								}
 							}
 							$depreciation_ht = (float) price2num($period_amount * $nb_days / $nb_days_in_month, 'MT');
-						} else { // Annually, taking care for adjustments to shortened or extended periods (e.g., fiscal years of 9 or 15 months)					
+						} else { // Annually, taking care for adjustments to shortened or extended periods (e.g., fiscal years of 9 or 15 months)
 							$nb_days_real = num_between_day($begin_date, $end_date, 1);
-							if (($nb_days_real > 366) || (num_between_day($fiscal_period_start,$fiscal_period_end,1) < $nb_days_in_year)) { // FY Period changed
+							if (($nb_days_real > 366) || (num_between_day($fiscal_period_start, $fiscal_period_end, 1) < $nb_days_in_year)) { // FY Period changed
 								$nb_days = $nb_days_real;
 							} else {
 								$nb_days = min($nb_days_in_year, $nb_days_real);
-							}	
+							}
 							$depreciation_ht = (double) price2num($period_amount * $nb_days / $nb_days_in_year, 'MT');
 						}
 
@@ -1135,7 +1135,7 @@ class Asset extends CommonObject
 
 					// Next fiscal period (+1 day/month/year)
 					$fiscal_period_start = dol_time_plus_duree($fiscal_period_end, 1, 'd');
-					$dates_fiscal_period = getCurrentPeriodOfFiscalYear($this->db, $conf, $fiscal_period_start,'gmt');
+					$dates_fiscal_period = getCurrentPeriodOfFiscalYear($this->db, $conf, $fiscal_period_start, 'gmt');
 					if ($fields['duration_type'] == 2) { // Daily
 						$fiscal_period_end = $fiscal_period_start;
 					} elseif ($fields['duration_type'] == 1) { // Monthly


### PR DESCRIPTION
NEW This is the code modification to take in consideration any changed in fiscal year period adjustments to shortened or extended periods (e.g., fiscal years of 9 or 15 months).

The code modification is done in asset.class.php in function calculationDepreciation()
This has been tested with 200 Assets with Quadratus Comparison.

Here is the Fiscal Year periods with a sample with 15 months (Oct 2022- Dec 2023)
![image](https://github.com/user-attachments/assets/e8559cb5-ce26-4f2a-b957-630815953c1a)

Before changes in Asset Module:
![image](https://github.com/user-attachments/assets/e982d57c-2f91-45b4-8c44-5e0745feb646)

After changes:
![image](https://github.com/user-attachments/assets/cf3ec8cc-92d1-4bac-b9d7-d3ab54121246)

