### PR TITLE
FIX #31643 Busy resources can be used by multiple events in the same time frame. 

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -479,10 +479,6 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 	}
 
 	// Checking resource availability if the config doesn't allow overlap
-	if (!empty($_SESSION['assignedtoresource']) && getDolGlobalString('RESOURCE_USED_IN_EVENT_CHECK')) {
-		$assigned_ressources = json_decode($_SESSION['assignedtoresource'], true);
-
-	// Checking resource availability if the config doesn't allow overlap
 	if (!$error && !empty($_SESSION['assignedtoresource']) && getDolGlobalString('RESOURCE_USED_IN_EVENT_CHECK')) {
 		$assigned_ressources = json_decode($_SESSION['assignedtoresource'], true);
 

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -479,7 +479,7 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 	}
 
 	// Checking resource availability if the config doesn't allow overlap
-	if (!$error && !empty($_SESSION['assignedtoresource']) && getDolGlobalString('RESOURCE_USED_IN_EVENT_CHECK')) {
+	if (!$error && !empty($_SESSION['assignedtoresource']) && json_decode($_SESSION['assignedtoresource'], true) && getDolGlobalString('RESOURCE_USED_IN_EVENT_CHECK')) {
 		$assigned_ressources = json_decode($_SESSION['assignedtoresource'], true);
 
 		// MODIFIED CODE FROM htdocs/resources/element_resources.php

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -493,7 +493,7 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 		}
 
 		//call to get_busy_resource_during in resource.lib.php
-		$busyResources = get_busy_resource_during($eventDateStart, $eventDateEnd, $assigned_ressources);
+		$busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, $assigned_ressources);
 
 		/// === false because it can return an empty array
 		if ($busyResources === false) {

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -493,7 +493,7 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 		}
 
 		//call to get_busy_resource_during in resource.lib.php
-		$busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, $assigned_ressources);
+		$busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, array_keys($assigned_ressources));
 
 		/// === false because it can return an empty array
 		if ($busyResources === false) {

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -497,18 +497,16 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 
 		/// === false because it can return an empty array
 		if ($busyResources === false) {
-			// an error occured in the sql
+			// an error occurred in the sql
 			$error++; $donotclearsession = 1; $action = 'create';
 			$object->error = $db->lasterror();
 			$object->errors[] = $object->error;
 			setEventMessages($object->error, $object->errors, 'errors');
-		}
-
-		else if (!empty($busyResources)){
+		} elseif (!empty($busyResources)) {
 			// Resource already in use
 			$error++; $donotclearsession = 1; $action = 'create';
 
-			$object->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
+			$object->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ' ;
 			foreach ($busyResources as $row) {
 				$object->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $row->r_ref, $row->ac_label.' ['.$row->ac_id.']');
 			}
@@ -567,11 +565,11 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 				if (!empty($_SESSION['assignedtoresource'])) {
 					$assignedtoresource = json_decode($_SESSION['assignedtoresource'], true);
 
-					foreach ($assignedtoresource as $resource_id => $resource){
+					foreach ($assignedtoresource as $resource_id => $resource) {
 						// hardcoding dolresource might be a problem later on
-						// add_element_resource(id, type, busy, mandatory) -> 1 on sucess or 0
-						if (!$object->add_element_resource($resource_id, "dolresource", 1, (int) $resource['mandatory'])){
-							dol_syslog("An Error occured in add_element_resource: '" . $object->error . "'", LOG_ERR);
+						// add_element_resource(id, type, busy, mandatory) -> 1 on success or 0
+						if (!$object->add_element_resource($resource_id, "dolresource", 1, (int) $resource['mandatory'])) {
+							dol_syslog("An Error occurred in add_element_resource: '" . $object->error . "'", LOG_ERR);
 						};
 					}
 				}

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -496,13 +496,7 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 		$busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, array_keys($assigned_ressources));
 
 		/// === false because it can return an empty array
-		if ($busyResources === false) {
-			// an error occurred in the sql
-			$error++; $donotclearsession = 1; $action = 'create';
-			$object->error = $db->lasterror();
-			$object->errors[] = $object->error;
-			setEventMessages($object->error, $object->errors, 'errors');
-		} elseif (!empty($busyResources)) {
+		if (!empty($busyResources)) {
 			// Resource already in use
 			$error++; $donotclearsession = 1; $action = 'create';
 

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -149,8 +149,10 @@ function resource_admin_prepare_head()
 
 function get_busy_resource_during($dateStart, $dateEnd, $resource_ids = array())
 {
-	// MODIFIED CODE FROM htdocs/resources/element_resources.php
+	// MODIFIED CODE FROM htdocs/resource/element_resources.php
 	global $db;
+
+	$SELECT_LIMIT = $db->sanitize($db->escape(getDolGlobalString("RESOURCE_SELECT_LIMIT", 100)));
 	if (!$db) {
 		// false to mimic what getRows returns
 		return false;
@@ -180,7 +182,7 @@ function get_busy_resource_during($dateStart, $dateEnd, $resource_ids = array())
 
 	// event date start before ac.datep and event date end after ac.datep2
 	$sql .= " OR (ac.datep >= '".$db->idate($dateStart). "' AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($dateEnd)."'))";
-	$sql .= ")";
+	$sql .= ") LIMIT " . $SELECT_LIMIT;
 
 	$result = $db->getRows($sql);
 	$db->free();

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -155,12 +155,12 @@ function resource_admin_prepare_head()
  * @param $resource_ids array
  * @return array|bool
  */
-function get_busy_resource_during(string $dateStart, string $dateEnd, $resource_ids = array())
+function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, $resource_ids = array())
 {
 	// MODIFIED CODE FROM htdocs/resource/element_resources.php
 	global $db;
 
-	$SELECT_LIMIT = $db->sanitize($db->escape(getDolGlobalString("RESOURCE_SELECT_LIMIT", 100)));
+	$SELECT_LIMIT = $db->plimit(getDolGlobalInt("RESOURCE_SELECT_LIMIT", 100));
 	if (!$db) {
 		// false to mimic what getRows returns
 		return false;
@@ -190,7 +190,7 @@ function get_busy_resource_during(string $dateStart, string $dateEnd, $resource_
 
 	// event date start before ac.datep and event date end after ac.datep2
 	$sql .= " OR (ac.datep >= '".$db->idate($dateStart). "' AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($dateEnd)."'))";
-	$sql .= ") LIMIT " . $SELECT_LIMIT;
+	$sql .= ") " . $SELECT_LIMIT;
 
 	$result = $db->getRows($sql);
 	$db->free();

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -175,10 +175,10 @@ function get_busy_resource_during($dateStart, $dateEnd, $resource_ids = array())
 	$sql .= " AND (";
 
 	// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-	$sql .= "(ac.datep <= '".$db->idate($dateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($dateStart)."'))";
+	$sql .= "(ac.datep <= '".$db->idate($dateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 > '".$db->idate($dateStart)."'))";
 
 	// event date end between ac.datep and ac.datep2
-	$sql .= " OR (ac.datep <= '".$db->idate($dateEnd)."' AND (ac.datep2 >= '".$db->idate($dateEnd)."'))";
+	$sql .= " OR (ac.datep < '".$db->idate($dateEnd)."' AND (ac.datep2 >= '".$db->idate($dateEnd)."'))";
 
 	// event date start before ac.datep and event date end after ac.datep2
 	$sql .= " OR (ac.datep >= '".$db->idate($dateStart). "' AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($dateEnd)."'))";

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -176,7 +176,7 @@ function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, $resource_
 		$escaped_ids = array_map(function (int $v) : string {
 			global $db;
 			return $db->sanitize($db->escape($v));
-		}, array_keys($resource_ids));
+		}, $resource_ids);
 		$sql .= " AND er.resource_id IN (". implode(", ", $escaped_ids) . ")";
 	}
 

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -147,6 +147,14 @@ function resource_admin_prepare_head()
 	return $head;
 }
 
+/**
+ * Returns the resources marked "busy" and assigned to an event during the specified time frame.
+ * You can specify an array of resources and the function will return the overlap of the two.
+ * @param $dateStart int|string Lower bound of the time frame.
+ * @param $dateEnd int|string
+ * @param $resource_ids array
+ * @return array|bool
+ */
 function get_busy_resource_during($dateStart, $dateEnd, $resource_ids = array())
 {
 	// MODIFIED CODE FROM htdocs/resource/element_resources.php

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -150,12 +150,12 @@ function resource_admin_prepare_head()
 /**
  * Returns the resources marked "busy" and assigned to an event during the specified time frame.
  * You can specify an array of resources and the function will return the overlap of the two.
- * @param $dateStart int|string Lower bound of the time frame.
- * @param $dateEnd int|string
+ * @param $dateStart string
+ * @param $dateEnd string
  * @param $resource_ids array
  * @return array|bool
  */
-function get_busy_resource_during($dateStart, $dateEnd, $resource_ids = array())
+function get_busy_resource_during(string $dateStart, string $dateEnd, $resource_ids = array()) : bool|array
 {
 	// MODIFIED CODE FROM htdocs/resource/element_resources.php
 	global $db;
@@ -173,7 +173,7 @@ function get_busy_resource_during($dateStart, $dateEnd, $resource_ids = array())
 	$sql .= " WHERE er.busy = 1";
 
 	if (!empty($resource_ids)) {
-		$escaped_ids = array_map(function ($v) {
+		$escaped_ids = array_map(function (int $v) : string {
 			global $db;
 			return $db->sanitize($db->escape($v));
 		}, array_keys($resource_ids));

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -155,7 +155,7 @@ function resource_admin_prepare_head()
  * @param $resource_ids array
  * @return array|bool
  */
-function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, $resource_ids = array())
+function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, array $resource_ids = array()) : mixed
 {
 	// MODIFIED CODE FROM htdocs/resource/element_resources.php
 	global $db;

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -155,7 +155,7 @@ function resource_admin_prepare_head()
  * @param $resource_ids array
  * @return array|bool
  */
-function get_busy_resource_during(string $dateStart, string $dateEnd, $resource_ids = array()): array
+function get_busy_resource_during(string $dateStart, string $dateEnd, $resource_ids = array())
 {
 	// MODIFIED CODE FROM htdocs/resource/element_resources.php
 	global $db;

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -155,7 +155,7 @@ function resource_admin_prepare_head()
  * @param $resource_ids array
  * @return array|bool
  */
-function get_busy_resource_during(string $dateStart, string $dateEnd, $resource_ids = array()) : bool|array
+function get_busy_resource_during(string $dateStart, string $dateEnd, $resource_ids = array()): array
 {
 	// MODIFIED CODE FROM htdocs/resource/element_resources.php
 	global $db;

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -155,16 +155,12 @@ function resource_admin_prepare_head()
  * @param $resource_ids array
  * @return array|bool
  */
-function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, array $resource_ids = array()) : mixed
+function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, array $resource_ids = array()) : array
 {
 	// MODIFIED CODE FROM htdocs/resource/element_resources.php
 	global $db;
 
 	$SELECT_LIMIT = $db->plimit(getDolGlobalInt("RESOURCE_SELECT_LIMIT", 100));
-	if (!$db) {
-		// false to mimic what getRows returns
-		return false;
-	}
 
 	$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
 	$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -150,10 +150,10 @@ function resource_admin_prepare_head()
 /**
  * Returns the resources marked "busy" and assigned to an event during the specified time frame.
  * You can specify an array of resources and the function will return the overlap of the two.
- * @param $dateStart string
- * @param $dateEnd string
- * @param $resource_ids array<int>
- * @return array
+ * @param string $dateStart
+ * @param string $dateEnd
+ * @param int[] $resource_ids
+ * @return array[]
  */
 function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, array $resource_ids = array()) : array
 {

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -153,7 +153,7 @@ function resource_admin_prepare_head()
  * @param string $dateStart the lower bound of the selector
  * @param string $dateEnd the upper bound of the selector
  * @param int[] $resource_ids the ids the request should filter by
- * @return array[]
+ * @return bool|object[]
  */
 function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, array $resource_ids = array()) : array
 {

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -150,9 +150,9 @@ function resource_admin_prepare_head()
 /**
  * Returns the resources marked "busy" and assigned to an event during the specified time frame.
  * You can specify an array of resources and the function will return the overlap of the two.
- * @param string $dateStart
- * @param string $dateEnd
- * @param int[] $resource_ids
+ * @param string $dateStart the lower bound of the selector
+ * @param string $dateEnd the upper bound of the selector
+ * @param int[] $resource_ids the ids the request should filter by
  * @return array[]
  */
 function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, array $resource_ids = array()) : array

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -152,8 +152,8 @@ function resource_admin_prepare_head()
  * You can specify an array of resources and the function will return the overlap of the two.
  * @param $dateStart string
  * @param $dateEnd string
- * @param $resource_ids array
- * @return array|bool
+ * @param $resource_ids array<int>
+ * @return array
  */
 function getBusyResourcesInPeriod(string $dateStart, string $dateEnd, array $resource_ids = array()) : array
 {

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -203,7 +203,7 @@ if (empty($reshook)) {
 
 				// removing the rows associated with our action id
 				$ac_id = (int) $object->element_id;
-				$busyResources = array_filter($_busyResources, function (Dolresource $row) : bool {
+				$busyResources = array_filter($_busyResources, function (StdClass $row) : bool {
 					global $ac_id;
 					return $row->ac_id != $ac_id;
 				});

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -136,7 +136,7 @@ if (empty($reshook)) {
 					$eventDateEnd   = dol_mktime(23, 59, 59, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
 				}
 
-				// Get the ressources busy during the period with the id "id"
+				// Get the resources busy during the period with the id "id"
 				$busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, array((int) $resource_id));
 
 				// sql error
@@ -190,7 +190,7 @@ if (empty($reshook)) {
 					$eventDateEnd   = dol_mktime(23, 59, 59, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
 				}
 
-				// Get the ressources busy during the period with the id "id"
+				// Get the resources busy during the period with the id "id"
 				$_busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, array((int) $resource_id));
 
 				// sql error

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -31,6 +31,7 @@ require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/resource/class/dolresource.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/resource.lib.php';
 if (isModEnabled('project')) {
 	require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 	require_once DOL_DOCUMENT_ROOT.'/core/class/html.formprojet.class.php';
@@ -129,53 +130,31 @@ if (empty($reshook)) {
 				$eventDateStart = $objstat->datep;
 				$eventDateEnd   = $objstat->datef;
 				$isFullDayEvent = $objstat->fulldayevent;
-				if (empty($eventDateEnd)) {
-					if ($isFullDayEvent) {
-						$eventDateStartArr = dol_getdate($eventDateStart);
-						$eventDateStart = dol_mktime(0, 0, 0, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
-						$eventDateEnd   = dol_mktime(23, 59, 59, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
-					}
+				if (empty($eventDateEnd) && $isFullDayEvent) {
+					$eventDateStartArr = dol_getdate($eventDateStart);
+					$eventDateStart = dol_mktime(0, 0, 0, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
+					$eventDateEnd   = dol_mktime(23, 59, 59, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
 				}
 
-				$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
-				$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = '".$db->escape($resource_type)."'";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$db->escape($objstat->element)."'";
-				$sql .= " WHERE er.resource_id = ".((int) $resource_id);
-				$sql .= " AND er.busy = 1";
-				$sql .= " AND (";
+				// Get the ressources busy during the period with the id "id"
+				$busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, array((int) $resource_id));
 
-				// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-				$sql .= " (ac.datep <= '".$db->idate($eventDateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateStart)."'))";
-				// event date end between ac.datep and ac.datep2
-				if (!empty($eventDateEnd)) {
-					$sql .= " OR (ac.datep <= '".$db->idate($eventDateEnd)."' AND (ac.datep2 >= '".$db->idate($eventDateEnd)."'))";
-				}
-				// event date start before ac.datep and event date end after ac.datep2
-				$sql .= " OR (";
-				$sql .= "ac.datep >= '".$db->idate($eventDateStart)."'";
-				if (!empty($eventDateEnd)) {
-					$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($eventDateEnd)."')";
-				}
-				$sql .= ")";
-
-				$sql .= ")";
-				$resql = $db->query($sql);
-				if (!$resql) {
+				// sql error
+				if ($busyResources === false) {
+					// an error occurred in the sql
 					$error++;
-					$objstat->error    = $db->lasterror();
+					$objstat->error = $db->lasterror();
 					$objstat->errors[] = $objstat->error;
-				} else {
-					if ($db->num_rows($resql) > 0) {
-						// Resource already in use
-						$error++;
-						$objstat->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
-						while ($obj = $db->fetch_object($resql)) {
-							$objstat->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
-						}
-						$objstat->errors[] = $objstat->error;
+				} elseif (!empty($busyResources)) {
+					// Resource already in use
+					$error++;
+
+					$objstat->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ' ;
+					foreach ($busyResources as $row) {
+						$objstat->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $row->r_ref, $row->ac_label.' ['.$row->ac_id.']');
 					}
-					$db->free($resql);
+
+					$objstat->errors[] = $objstat->error;
 				}
 			}
 

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -183,54 +183,41 @@ if (empty($reshook)) {
 				$eventDateStart = $object->objelement->datep;
 				$eventDateEnd   = $object->objelement->datef;
 				$isFullDayEvent = $objstat->fulldayevent;
-				if (empty($eventDateEnd)) {
-					if ($isFullDayEvent) {
-						$eventDateStartArr = dol_getdate($eventDateStart);
-						$eventDateStart = dol_mktime(0, 0, 0, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
-						$eventDateEnd   = dol_mktime(23, 59, 59, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
-					}
+
+				if (empty($eventDateEnd) && $isFullDayEvent) {
+					$eventDateStartArr = dol_getdate($eventDateStart);
+					$eventDateStart = dol_mktime(0, 0, 0, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
+					$eventDateEnd   = dol_mktime(23, 59, 59, $eventDateStartArr['mon'], $eventDateStartArr['mday'], $eventDateStartArr['year']);
 				}
 
-				$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
-				$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = '".$db->escape($object->resource_type)."'";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$db->escape($object->element_type)."'";
-				$sql .= " WHERE er.resource_id = ".((int) $object->resource_id);
-				$sql .= " AND ac.id <> ".((int) $object->element_id);
-				$sql .= " AND er.busy = 1";
-				$sql .= " AND (";
+				// Get the ressources busy during the period with the id "id"
+				$_busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, array((int) $resource_id));
 
-				// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-				$sql .= " (ac.datep <= '".$db->idate($eventDateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateStart)."'))";
-				// event date end between ac.datep and ac.datep2
-				if (!empty($eventDateEnd)) {
-					$sql .= " OR (ac.datep <= '".$db->idate($eventDateEnd)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateEnd)."'))";
-				}
-				// event date start before ac.datep and event date end after ac.datep2
-				$sql .= " OR (";
-				$sql .= "ac.datep >= '".$db->idate($eventDateStart)."'";
-				if (!empty($eventDateEnd)) {
-					$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($eventDateEnd)."')";
-				}
-				$sql .= ")";
-
-				$sql .= ")";
-				$resql = $db->query($sql);
-				if (!$resql) {
+				// sql error
+				if ($_busyResources === false) {
+					// an error occurred in the sql
 					$error++;
-					$object->error    = $db->lasterror();
+					$object->error = $db->lasterror();
 					$object->errors[] = $object->error;
-				} else {
-					if ($db->num_rows($resql) > 0) {
-						// Resource already in use
-						$error++;
-						$object->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
-						while ($obj = $db->fetch_object($resql)) {
-							$object->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
-						}
-						$object->errors[] = $objstat->error;
+				}
+
+				// removing the rows associated with our action id
+				$ac_id = (int) $object->element_id;
+				$busyResources = array_filter($_busyResources, function ($row) : bool {
+					global $ac_id;
+					return $row->ac_id != $ac_id;
+				});
+
+				if (!empty($busyResources)) {
+					// Resource already in use
+					$error++;
+
+					$object->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ' ;
+					foreach ($busyResources as $row) {
+						$object->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $row->r_ref, $row->ac_label.' ['.$row->ac_id.']');
 					}
-					$db->free($resql);
+
+					$object->errors[] = $object->error;
 				}
 			}
 

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -203,7 +203,7 @@ if (empty($reshook)) {
 
 				// removing the rows associated with our action id
 				$ac_id = (int) $object->element_id;
-				$busyResources = array_filter($_busyResources, function ($row) : bool {
+				$busyResources = array_filter($_busyResources, function (Dolresource $row) : bool {
 					global $ac_id;
 					return $row->ac_id != $ac_id;
 				});

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -139,13 +139,7 @@ if (empty($reshook)) {
 				// Get the resources busy during the period with the id "id"
 				$busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, array((int) $resource_id));
 
-				// sql error
-				if ($busyResources === false) {
-					// an error occurred in the sql
-					$error++;
-					$objstat->error = $db->lasterror();
-					$objstat->errors[] = $objstat->error;
-				} elseif (!empty($busyResources)) {
+				if (!empty($busyResources)) {
 					// Resource already in use
 					$error++;
 
@@ -192,14 +186,6 @@ if (empty($reshook)) {
 
 				// Get the resources busy during the period with the id "id"
 				$_busyResources = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, array((int) $resource_id));
-
-				// sql error
-				if ($_busyResources === false) {
-					// an error occurred in the sql
-					$error++;
-					$object->error = $db->lasterror();
-					$object->errors[] = $object->error;
-				}
 
 				// removing the rows associated with our action id
 				$ac_id = (int) $object->element_id;


### PR DESCRIPTION
# FIX [#31643 Busy resources can be used by multiple events in the same time frame. ](https://github.com/Dolibarr/dolibarr/issues/31643)

* Fixes resources not being taken into account when creating a new event from the event creation page.
* Fixes assigning busy resources to multiple events at the same time
