### PR TITLE
FIX|Fix #31653: Events are hidden if the society module is not enabled

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -784,7 +784,7 @@ if ($pid) {
 }
 // If the internal user must only see his customers, force searching by him
 $search_sale = 0;
-if (!$user->hasRight('societe', 'client', 'voir')) {
+if (isModEnabled("societe") && !$user->hasRight('societe', 'client', 'voir')) {
 	$search_sale = $user->id;
 }
 // Search on sale representative

--- a/htdocs/comm/action/list.php
+++ b/htdocs/comm/action/list.php
@@ -500,7 +500,7 @@ if ($pid) {
 }
 // If the internal user must only see his customers, force searching by him
 $search_sale = 0;
-if (!$user->hasRight('societe', 'client', 'voir')) {
+if (isModEnabled("societe") && !$user->hasRight('societe', 'client', 'voir')) {
 	$search_sale = $user->id;
 }
 // Search on sale representative


### PR DESCRIPTION
# FIX|Fix [#31653: Events are hidden if the society module is not enabled](https://github.com/Dolibarr/dolibarr/issues/31653)

Checks if the society module is enabled before checking if the user has the right to see their events.