### PR TITLE
FIX link to list to view overdue invoices

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5042,7 +5042,7 @@ class Facture extends CommonInvoice
 
 				if ($generic_facture->hasDelay()) {
 					$response->nbtodolate++;
-					$response->url_late = DOL_URL_ROOT.'/compta/facture/list.php?search_option=late&mainmenu=billing&leftmenu=customers_bills';
+					$response->url_late = DOL_URL_ROOT.'/compta/facture/list.php?search_late=late&mainmenu=billing&leftmenu=customers_bills';
 				}
 			}
 


### PR DESCRIPTION
# FIX link to list to view overdue invoices

On the dashboard, when you clicked on the little overdue invoices badge, you were taken to the list of invoices with no filter.