### PR TITLE
Fix function call to display star extra fields by passing object as parameter

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1947,13 +1947,13 @@ class ExtraFields
 	/**
 	 * Return HTML string to put an output field into a page
 	 *
-	 * @param   string		$key            		Key of attribute
-	 * @param   string		$value          		Value to show
-	 * @param	string		$moreparam				To add more parameters on html input tag (only checkbox use html input for output rendering)
-	 * @param	string		$extrafieldsobjectkey	Required (for example $object->table_element).
-	 * @param 	Translate 	$outputlangs 			Output
-	 * @param	object		$object					The parent object of field to show
-	 * @return	string								Formatted value
+	 * @param   string			$key            		Key of attribute
+	 * @param   string			$value          		Value to show
+	 * @param	string			$moreparam				To add more parameters on html input tag (only checkbox use html input for output rendering)
+	 * @param	string			$extrafieldsobjectkey	Required (for example $object->table_element).
+	 * @param 	Translate|null 	$outputlangs 			Output
+	 * @param	object			$object					The parent object of field to show
+	 * @return	string									Formatted value
 	 */
 	public function showOutputField($key, $value, $moreparam = '', $extrafieldsobjectkey = '', $outputlangs = null, $object = null)
 	{

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -51,7 +51,7 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 					}
 				}
 
-				$valuetoshow = $extrafields->showOutputField($key, $value, '', $extrafieldsobjectkey);
+				$valuetoshow = $extrafields->showOutputField($key, $value, '', $extrafieldsobjectkey, null, $object);
 				$title = dol_string_nohtmltag($valuetoshow);
 
 				print '<td'.($cssclass ? ' class="'.$cssclass.'"' : '');	// TODO Add 'css' and 'cssview' and 'csslist' for extrafields and use here 'csslist'

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -51,7 +51,7 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 					}
 				}
 
-				$valuetoshow = $extrafields->showOutputField($key, $value, '', $extrafieldsobjectkey, null, $object);
+				$valuetoshow = $extrafields->showOutputField($key, $value, '', $extrafieldsobjectkey, '', $object);
 				$title = dol_string_nohtmltag($valuetoshow);
 
 				print '<td'.($cssclass ? ' class="'.$cssclass.'"' : '');	// TODO Add 'css' and 'cssview' and 'csslist' for extrafields and use here 'csslist'

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -51,7 +51,7 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 					}
 				}
 
-				$valuetoshow = $extrafields->showOutputField($key, $value, '', $extrafieldsobjectkey, '', $object);
+				$valuetoshow = $extrafields->showOutputField($key, $value, '', $extrafieldsobjectkey, null, $object);
 				$title = dol_string_nohtmltag($valuetoshow);
 
 				print '<td'.($cssclass ? ' class="'.$cssclass.'"' : '');	// TODO Add 'css' and 'cssview' and 'csslist' for extrafields and use here 'csslist'

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -256,7 +256,7 @@ if (empty($reshook) && !empty($object->table_element) && isset($extrafields->att
 				print '</form>';
 			} else {
 				//var_dump($tmpkeyextra.'-'.$value.'-'.$object->table_element);
-				print $extrafields->showOutputField($tmpkeyextra, $value, '', $object->table_element);
+				print $extrafields->showOutputField($tmpkeyextra, $value, '', $object->table_element, null, $object);
 			}
 
 			print '</td>';


### PR DESCRIPTION
Corrected the function call to display star extra fields by passing the relevant object as a parameter, ensuring proper rendering and functionality