### PR TITLE
Update commonobject.class.php

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4239,9 +4239,9 @@ abstract class CommonObject
 		}
 
 		$sourceid = (!empty($sourceid) ? $sourceid : $this->id);
-		$sourcetype = (!empty($sourcetype) ? $sourcetype : $this->element);
+		$sourcetype = (!empty($sourcetype) ? $sourcetype : $this->getElementType());
 		$targetid = (!empty($targetid) ? $targetid : $this->id);
-		$targettype = (!empty($targettype) ? $targettype : $this->element);
+		$targettype = (!empty($targettype) ? $targettype : $this->getElementType());
 		$this->db->begin();
 		$error = 0;
 


### PR DESCRIPTION
FIX Changed sourcetype and targettype to use $this->getElementType() instead of $this->element

Changed sourcetype and targettype to use $this->getElementType() instead of $this->element to match how element links are created so that for custom modules the linked objects are displayed 


