### PR TITLE
Update llx_societe.key.sql

### DIFF
--- a/htdocs/install/mysql/tables/llx_societe.key.sql
+++ b/htdocs/install/mysql/tables/llx_societe.key.sql
@@ -22,6 +22,7 @@ ALTER TABLE llx_societe ADD UNIQUE INDEX uk_societe_code_client(code_client, ent
 ALTER TABLE llx_societe ADD UNIQUE INDEX uk_societe_code_fournisseur(code_fournisseur, entity);
 
 ALTER TABLE llx_societe ADD UNIQUE INDEX uk_societe_barcode (barcode, fk_barcode_type, entity);
+ALTER TABLE llx_societe ADD UNIQUE INDEX uk_societe_nom(nom, entity);
 
 ALTER TABLE llx_societe ADD INDEX idx_societe_nom(nom);
 


### PR DESCRIPTION
# NEW|New [*Prevent duplicate third party names*]
[This pull request adds unique constraints to the llx_societe table to prevent duplicate entries for key fields such as the third party name (nom). In environments with inconsistent network quality, users have occasionally reported that multiple identical third parties can be registered due to retry attempts when the initial registration process is interrupted. even though there is a rollback in the code. 
Adding unique constraints on the nom field helps ensure that each third party is uniquely identifiable, thus reducing data redundancy and improving data integrity.

Changes

The following unique index have been added to the llx_societe table:

	•	uk_societe_nom (nom, entity): Prevents duplicate third party names within the same entity.

Benefits

	1.	Data Integrity: These constraint helps prevent accidental duplication, which is particularly helpful in high-traffic or unstable network environments.
	2.	Improved User Experience: Users will receive immediate feedback if a duplicate name is submitted, allowing for quick correction without having to manually clean up duplicates later.
	3.	Better Database Performance: By reducing duplicate data, we help optimize database queries and storage.]

this may need to be carefully check before mergin since it is only my idea and there may be a better solution without changing the database schema.

