### PR TITLE
FIX show preview pdf list expensereport

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -2210,7 +2210,7 @@ if ($action == 'create') {
 										}
 									}
 
-									if (!$thumbshown && $fileinfo['extension'] == 'pdf' && !empty($filepdf)) {
+									if (!$thumbshown && $fileinfo['extension'] == 'pdf' && !empty($filepdf) && !empty($relativepath) && !empty($fileinfo['filename'])) {
 										$formFile = new FormFile($db);
 										$imgpreview = $formFile->showPreview([], $modulepart, $relativepath.'/'.$fileinfo['filename'].'.'.strtolower($fileinfo['extension']), 0);
 										print $imgpreview;

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -2210,7 +2210,11 @@ if ($action == 'create') {
 										}
 									}
 
-									if (!$thumbshown) {
+									if (!$thumbshown && $fileinfo['extension'] == 'pdf' && !empty($filepdf)) {
+										$formFile = new FormFile($db);
+										$imgpreview = $formFile->showPreview([], $modulepart, $relativepath.'/'.$fileinfo['filename'].'.'.strtolower($fileinfo['extension']), 0);
+										print $imgpreview;
+									} elseif (!$thumbshown) {
 										print img_mime($ecmfilesstatic->filename);
 									}
 								}


### PR DESCRIPTION
# Instructions
On a **note expense sheet**, under the list of uploaded documents, I have added a preview feature (fa-search-plus) for PDF documents.
Previously, we did not have access to PDF preview and only had an icon generated by img_mime().


# FIX|Fix #[*Adding PDF preview*]
The preview feature has been added only for uploaded files with a PDF extension. No changes have been made to the behavior of other files.

