### PR TITLE
Fix: unit output (use_short_label)

### DIFF
--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1000,7 +1000,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 							}
 							$qtyhourforline = 0;
 							if ($line->fk_unit) {
-								$unitforline = measuringUnitString($line->fk_unit, '', '', 1);
+								$unitforline = measuringUnitString($line->fk_unit, '', '', 2);
 								$qtyhourforline = convertDurationtoHour($line->qty, $unitforline);
 							}
 
@@ -1612,7 +1612,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					print '<td class="right">'.$line->qty.'</td>';
 					// Unit
 					if (getDolGlobalInt('PRODUCT_USE_UNITS')) {
-						print '<td class="right">'.measuringUnitString($line->fk_unit, '', '', 1).'</td>';
+						print '<td class="right">'.measuringUnitString($line->fk_unit, '', '', 2).'</td>';
 					}
 					// Cost price
 					if ($permissiontoupdatecost) {


### PR DESCRIPTION
Now the same short Labels are used.

![image](https://github.com/user-attachments/assets/cd7df263-2eb9-4365-907c-52e94d502baa)

P.S. in transiflex no resources exist for ....Short, which is generated from 'measuringUnitString'.
