### PR TITLE
FIX|Fix # Change Class Name of Mark Rates on Objectlines_view tpl

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -155,7 +155,7 @@ if ($nolinesbefore) {
 					echo '<td class="margininfos linecolmargin2 right"><span class="np_marginRate">'.$langs->trans('MarginRate').'</span></td>';
 				}
 				if (!empty($conf->global->DISPLAY_MARK_RATES)) {
-					echo '<td class="margininfos linecolmargin2 right"><span class="np_markRate">'.$langs->trans('MarkRate').'</span></td>';
+					echo '<td class="margininfos linecolmark1 right"><span class="np_markRate">'.$langs->trans('MarkRate').'</span></td>';
 				}
 			}
 		}

--- a/htdocs/core/tpl/objectline_title.tpl.php
+++ b/htdocs/core/tpl/objectline_title.tpl.php
@@ -144,7 +144,7 @@ if ($usemargins && !empty($conf->margin->enabled) && empty($user->socid)) {
 		print '<td class="linecolmargin2 margininfos right" style="width: 50px">'.$langs->trans('MarginRate').'</td>';
 	}
 	if (!empty($conf->global->DISPLAY_MARK_RATES) && $user->rights->margins->liretous) {
-		print '<td class="linecolmargin2 margininfos right" style="width: 50px">'.$langs->trans('MarkRate').'</td>';
+		print '<td class="linecolmark1 margininfos right" style="width: 50px">'.$langs->trans('MarkRate').'</td>';
 	}
 }
 

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -372,7 +372,7 @@ if ($usemargins && !empty($conf->margin->enabled) && empty($user->socid)) {
 		<td class="linecolmargin2 nowrap margininfos right"><?php $coldisplay++; ?><?php print (($line->pa_ht == 0) ? 'n/a' : price(price2num($line->marge_tx, 'MT')).'%'); ?></td>
 	<?php }
 	if (!empty($conf->global->DISPLAY_MARK_RATES) && $user->rights->margins->liretous) {?>
-		<td class="linecolmargin2 nowrap margininfos right"><?php $coldisplay++; ?><?php print price(price2num($line->marque_tx, 'MT')).'%'; ?></td>
+		<td class="linecolmark1 nowrap margininfos right"><?php $coldisplay++; ?><?php print price(price2num($line->marque_tx, 'MT')).'%'; ?></td>
 	<?php }
 }
 


### PR DESCRIPTION
# FIX|Fix # class name of MarginRate <td> tag 
I noticed that when I added Margin rates and Mark rates on a proposal, both td tags had the same class name, which is incorrect. The td tag for Margin had the class name linecolmargin2, which is correct, but the td tag for Mark rates also had linecolmargin2, which is incorrect and should be linecolmark1
