### PR TITLE
FIX ticket list : type_code multiselect search can be an empty value.…

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9875,8 +9875,10 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 							$listofcodes .= "'".$db->escape($val)."'";
 						}
 					}
-					$newres .= ($i2 > 0 ? ' OR ' : '').$field." ".($mode == -3 ? 'NOT ' : '')."IN (".$db->sanitize($listofcodes, 1).")";
-					$i2++; // a criteria for 1 more field was added to string
+					if ($val) {
+						$newres .= ($i2 > 0 ? ' OR ' : '').$field." ".($mode == -3 ? 'NOT ' : '')."IN (".$db->sanitize($listofcodes, 1).")";
+						$i2++; // a criteria for 1 more field was added to string
+					}
 				}
 				if ($mode == -3) {
 					$newres .= ' OR '.$field.' IS NULL';
@@ -9962,7 +9964,10 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 		}
 		$i1++;
 	}
-	$res = ($nofirstand ? "" : " AND ")."(".$res.")";
+
+	if ($res !== '') {
+		$res = ($nofirstand ? "" : " AND ")."(".$res.")";
+	}
 
 	return $res;
 }

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -402,6 +402,12 @@ foreach ($search as $key => $val) {
 		continue;
 	} elseif ($key == 'type_code') {
 		$newarrayoftypecodes = is_array($search[$key]) ? $search[$key] : (!empty($search[$key]) ? explode(',', $search[$key]) : array());
+		$newarrayoftypecodes = array_filter(
+			$newarrayoftypecodes,
+			function ($var) {
+				return !(empty($var) && $var !== '0');
+			}
+		);
 		if (count($newarrayoftypecodes)) {
 			$sql .= natural_search($key, join(',', $newarrayoftypecodes), 3);
 		}
@@ -836,7 +842,7 @@ foreach ($object->fields as $key => $val) {
 			print '</td>';
 		} elseif ($key == 'type_code') {
 			print '<td class="liste_titre'.($cssforfield ? ' '.$cssforfield : '').'">';
-			$formTicket->selectTypesTickets(dol_escape_htmltag(empty($search[$key]) ? '' : $search[$key]), 'search_'.$key.'', '', 2, 0, 1, 0, (!empty($val['css']) ? $val['css'] : 'maxwidth150'), 1);
+			$formTicket->selectTypesTickets(dol_escape_htmltag(empty($search[$key]) ? '' : $search[$key]), 'search_'.$key.'', '', 2, 1, 1, 0, (!empty($val['css']) ? $val['css'] : 'maxwidth150'), 1);
 			print '</td>';
 		} elseif ($key == 'category_code') {
 			print '<td class="liste_titre'.($cssforfield ? ' '.$cssforfield : '').'">';

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -836,7 +836,7 @@ foreach ($object->fields as $key => $val) {
 			print '</td>';
 		} elseif ($key == 'type_code') {
 			print '<td class="liste_titre'.($cssforfield ? ' '.$cssforfield : '').'">';
-			$formTicket->selectTypesTickets(dol_escape_htmltag(empty($search[$key]) ? '' : $search[$key]), 'search_'.$key.'', '', 2, 1, 1, 0, (!empty($val['css']) ? $val['css'] : 'maxwidth150'), 1);
+			$formTicket->selectTypesTickets(dol_escape_htmltag(empty($search[$key]) ? '' : $search[$key]), 'search_'.$key.'', '', 2, 0, 1, 0, (!empty($val['css']) ? $val['css'] : 'maxwidth150'), 1);
 			print '</td>';
 		} elseif ($key == 'category_code') {
 			print '<td class="liste_titre'.($cssforfield ? ' '.$cssforfield : '').'">';

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -402,12 +402,6 @@ foreach ($search as $key => $val) {
 		continue;
 	} elseif ($key == 'type_code') {
 		$newarrayoftypecodes = is_array($search[$key]) ? $search[$key] : (!empty($search[$key]) ? explode(',', $search[$key]) : array());
-		$newarrayoftypecodes = array_filter(
-			$newarrayoftypecodes,
-			function ($var) {
-				return !(empty($var) && $var !== '0');
-			}
-		);
 		if (count($newarrayoftypecodes)) {
 			$sql .= natural_search($key, join(',', $newarrayoftypecodes), 3);
 		}
@@ -842,7 +836,7 @@ foreach ($object->fields as $key => $val) {
 			print '</td>';
 		} elseif ($key == 'type_code') {
 			print '<td class="liste_titre'.($cssforfield ? ' '.$cssforfield : '').'">';
-			$formTicket->selectTypesTickets(dol_escape_htmltag(empty($search[$key]) ? '' : $search[$key]), 'search_'.$key.'', '', 2, 1, 1, 0, (!empty($val['css']) ? $val['css'] : 'maxwidth150'), 1);
+			$formTicket->selectTypesTickets(dol_escape_htmltag(empty($search[$key]) ? '' : $search[$key]), 'search_'.$key.'', '', 2, 0, 1, 0, (!empty($val['css']) ? $val['css'] : 'maxwidth150'), 1);
 			print '</td>';
 		} elseif ($key == 'category_code') {
 			print '<td class="liste_titre'.($cssforfield ? ' '.$cssforfield : '').'">';

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -836,7 +836,7 @@ foreach ($object->fields as $key => $val) {
 			print '</td>';
 		} elseif ($key == 'type_code') {
 			print '<td class="liste_titre'.($cssforfield ? ' '.$cssforfield : '').'">';
-			$formTicket->selectTypesTickets(dol_escape_htmltag(empty($search[$key]) ? '' : $search[$key]), 'search_'.$key.'', '', 2, 0, 1, 0, (!empty($val['css']) ? $val['css'] : 'maxwidth150'), 1);
+			$formTicket->selectTypesTickets(dol_escape_htmltag(empty($search[$key]) ? '' : $search[$key]), 'search_'.$key.'', '', 2, 1, 1, 0, (!empty($val['css']) ? $val['css'] : 'maxwidth150'), 1);
 			print '</td>';
 		} elseif ($key == 'category_code') {
 			print '<td class="liste_titre'.($cssforfield ? ' '.$cssforfield : '').'">';


### PR DESCRIPTION
# Fix multiselect on ticket list would allow empty value for type_code

On ticket list, the search for type_code is a multiselect. It can receive an empty value that would mean 'type_code is not set'.
Since type_code is a mandatory value, a search on value 'is not set' should not be allowed.

![Capture d’écran_2024-11-06_11-49-56](https://github.com/user-attachments/assets/cef52523-d75d-442b-896e-155162c13852)



