### PR TITLE
FIX 17.0 fatal when updating recurring supplier invoice line with php8 ($remise_percent is '' instead of 0)

### DIFF
--- a/htdocs/fourn/facture/card-rec.php
+++ b/htdocs/fourn/facture/card-rec.php
@@ -778,7 +778,7 @@ if (empty($reshook)) {
 			$special_code = 3;
 		}
 
-		$remise_percent = price2num(GETPOST('remise_percent'), '', 2);
+		$remise_percent = price2num(GETPOST('remise_percent'), '', 2) ?: 0;
 
 		// Check minimum price
 		$productid = GETPOST('productid', 'int');


### PR DESCRIPTION
# FIX Fatal when updating line of recurring supplier invoice

When the HTTP param `remise_percent` is empty, `$remise_percent` is an empty string, which causes a Fatal Error when used in arithmetic operations.

