### PR TITLE
NEW : Adds some improvement for ODT Contracts

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -912,6 +912,9 @@ abstract class CommonDocGenerator
 			array('line_date_start', 'date_start', 'day', 'auto', null),
 			array('line_date_start_locale', 'date_start', 'day', 'tzserver', $outputlangs),
 			array('line_date_start_rfc', 'date_start', 'dayrfc', 'auto', null),
+			array('line_date_start_real', 'date_start_real', 'day', 'auto', null),
+			array('line_date_start_real_locale', 'date_start_real', 'day', 'tzserver', $outputlangs),
+			array('line_date_start_real_rfc', 'date_start_real', 'dayrfc', 'auto', null),
 			array('line_date_end', 'date_end', 'day', 'auto', null),
 			array('line_date_end_locale', 'date_end', 'day', 'tzserver', $outputlangs),
 			array('line_date_end_rfc', 'date_end', 'dayrfc', 'auto', null)

--- a/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
+++ b/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
@@ -233,7 +233,7 @@ class doc_generic_contract_odt extends ModelePDFContract
 		$outputlangs->charset_output = 'UTF-8';
 
 		// Load translation files required by page
-		$outputlangs->loadLangs(array("main", "dict", "companies", "bills"));
+		$outputlangs->loadLangs(array("main", "dict", "companies", "bills", "deliveries"));
 
 		if ($conf->contract->multidir_output[$object->entity]) {
 			// If $object is id instead of object


### PR DESCRIPTION
Commit : [916316f](https://github.com/Dolibarr/dolibarr/pull/31715/commits/916316f2efef0717c687bcab4d1adc11d22f4668) Adding three lines for having the "date_ouverture" substituted on ODT for contracts. 
{line_date_start_real}
{line_date_start_real_locale}
{line_date_start_real_rfc} 

Hope this is the right place to add those lines.

Commit : [b4c43fe](https://github.com/Dolibarr/dolibarr/pull/31715/commits/b4c43fe83fdbf8b291add3df83171bf66181fd0b) 
Add the deliveries langs for making key NameAndSignature substitued into Contracts ODT.
With php - strato template, it use ContactNameAndSignature but it don't print well on ODT "for %s, name and signature :"
![Signature Contracts](https://github.com/user-attachments/assets/8ca6ce06-d2d6-4cf2-9b21-e7cf013e7f8f)
