### PR TITLE
FIX : Confusing behavior by add hidden conf MAIN_LIST_ORDER_LINK_DONT_U…

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -2212,7 +2212,15 @@ while ($i < $imaxinloop) {
 		// Ref
 		if (!empty($arrayfields['c.ref']['checked'])) {
 			print '<td class="nowraponall">';
-			print $generic_commande->getNomUrl(1, ($search_status != 2 ? 0 : $obj->fk_statut), 0, 0, 0, 1, 1);
+			$getNomUrlOption = $search_status != 2 ? 0 : $obj->fk_statut;
+			if (getDolGlobalInt('MAIN_LIST_ORDER_LINK_DONT_USE_STATUS')) {
+				// TODO : This hidden conf must be added to the user's individual conf.
+				//  The user must be able to manage this behavior to adapt it to his use of the software, because depending on the employee's workstation, his use differs.
+				//  This hidden configuration ensures that users are not confused by keeping the same behavior of click, whatever the current filter.
+				//  If the aim is to use a different url when the filter is applied via the link in the left-hand menu, then this detection should be adapted instead.
+				$getNomUrlOption = '';
+			}
+			print $generic_commande->getNomUrl(1, $getNomUrlOption, 0, 0, 0, 1, 1);
 
 			$filename = dol_sanitizeFileName($obj->ref);
 			$filedir = $conf->commande->multidir_output[$conf->entity].'/'.dol_sanitizeFileName($obj->ref);


### PR DESCRIPTION
# Fix
According to status the getNomUrl change destination tab in order card and it can be really confusing.
This hidden configuration ensures that users are not confused by keeping the same behavior of click, whatever the current filter.

TODO : If the aim is to use a different url when the filter is applied via the link in the left-hand menu, then this detection should be adapted instead.