### PR TITLE
Sells do not need to be paid completely to be included in the cash control

### DIFF
--- a/htdocs/compta/cashcontrol/report.php
+++ b/htdocs/compta/cashcontrol/report.php
@@ -133,7 +133,7 @@ $sql .= " FROM ".MAIN_DB_PREFIX."paiement_facture as pf, ".MAIN_DB_PREFIX."factu
 $sql .= " WHERE pf.fk_facture = f.rowid AND p.rowid = pf.fk_paiement AND cp.id = p.fk_paiement AND p.fk_bank = b.rowid";
 $sql .= " AND f.module_source = '".$db->escape($posmodule)."'";
 $sql .= " AND f.pos_source = '".$db->escape($terminalid)."'";
-$sql .= " AND f.paye = 1";
+//$sql .= " AND f.paye = 1";
 $sql .= " AND p.entity = ".$conf->entity; // Never share entities for features related to accountancy
 /*if ($key == 'cash')       $sql.=" AND cp.code = 'LIQ'";
 elseif ($key == 'cheque') $sql.=" AND cp.code = 'CHQ'";


### PR DESCRIPTION
Sells do not need to be paid completely to be included in the cash control. So, the condition f.paye = 1 should not exist in the sql query