### PR TITLE
FIX getCurrentPeriodOfFiscalYear with wrong created period

### DIFF
--- a/htdocs/core/lib/accounting.lib.php
+++ b/htdocs/core/lib/accounting.lib.php
@@ -349,7 +349,7 @@ function getDefaultDatesForTransfer()
  * 	@param 	Conf		$conf				Config
  * 	@param 	?int 		$from_time			[=null] Get current time or set time to find fiscal period
  *	@param	'tzserver'|'gmt'	$gm			'gmt' => we return GMT timestamp (recommended), 'tzserver' => we return in the PHP server timezone
- * 	@param	int			$withenddateonly	Do not return period if and date is not defined
+ * 	@param	int			$withenddateonly	Do not return period if end date is not defined
  * 	@return array{date_start:int,date_end:int}	Period of fiscal year : [date_start, date_end]
  */
 function getCurrentPeriodOfFiscalYear($db, $conf, $from_time = null, $gm = 'tzserver', $withenddateonly = 1)
@@ -358,6 +358,8 @@ function getCurrentPeriodOfFiscalYear($db, $conf, $from_time = null, $gm = 'tzse
 	$now_arr = dol_getdate($now);
 	if ($from_time === null) {
 		$from_time = $now;
+	} else {
+		$now_arr = dol_getdate($from_time);
 	}
 
 	include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';


### PR DESCRIPTION
FIX function getCurrentPeriodOfFiscalYear

This one was returning the bad period when a FY period was not already defined. It was using the actual year instead of the year of $fromtime to return a created FY period.
