### PR TITLE
Fix function num_between_day in date.lib.php in Dev code v21

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -1024,7 +1024,7 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
  */
 function num_between_day($timestampStart, $timestampEnd, $lastday = 0)
 {
-	if ($timestampStart < $timestampEnd) {
+	if ($timestampStart <= $timestampEnd) {
 		if ($lastday == 1) {
 			$bit = 0;
 		} else {


### PR DESCRIPTION
When debugging Asset Module, I discovered that function num_between_day is returning 0 when $timestampStart equals (==) $timestampEnd and $lastday == 1 Normally it has to return
0 if $lastday = 0
1 if $lastday = 1
