### PR TITLE
FIX old copy not needed in supplier order create method

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1291,8 +1291,6 @@ class CommandeFournisseur extends CommonOrder
 	{
 		global $langs, $conf, $hookmanager;
 
-		$this->oldcopy = dol_clone($this, 2);
-
 		$this->db->begin();
 
 		$error = 0;
@@ -1324,7 +1322,7 @@ class CommandeFournisseur extends CommonOrder
 
 		// We set order into draft status
 		$this->brouillon = 1;
-		$this->statut = self::STATUS_DRAFT;
+		$this->statut = self::STATUS_DRAFT;	// deprecated
 		$this->status = self::STATUS_DRAFT;
 
 		$sql = "INSERT INTO ".MAIN_DB_PREFIX."commande_fournisseur (";
@@ -1414,8 +1412,6 @@ class CommandeFournisseur extends CommonOrder
 						);
 					if ($result < 0) {
 						dol_syslog(get_class($this)."::create ".$this->error, LOG_WARNING); // do not use dol_print_error here as it may be a functionnal error
-						$this->statut = $this->oldcopy->statut;
-						$this->status = $this->oldcopy->status;
 						$this->db->rollback();
 						return -1;
 					}
@@ -1469,8 +1465,6 @@ class CommandeFournisseur extends CommonOrder
 						// Call trigger
 						$result = $this->call_trigger('ORDER_SUPPLIER_CREATE', $user);
 						if ($result < 0) {
-							$this->statut = $this->oldcopy->statut;
-							$this->status = $this->oldcopy->status;
 							$this->db->rollback();
 							return -1;
 						}
@@ -1481,16 +1475,12 @@ class CommandeFournisseur extends CommonOrder
 					return $this->id;
 				} else {
 					$this->error = $this->db->lasterror();
-					$this->statut = $this->oldcopy->statut;
-					$this->status = $this->oldcopy->status;
 					$this->db->rollback();
 					return -2;
 				}
 			}
 		} else {
 			$this->error = $this->db->lasterror();
-			$this->statut = $this->oldcopy->statut;
-			$this->status = $this->oldcopy->status;
 			$this->db->rollback();
 			return -1;
 		}


### PR DESCRIPTION
FIX old copy not needed in supplier order create method
- see #31642
- only object status should be set