### PR TITLE
fix multicurrency on supplier invoices

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3540,11 +3540,17 @@ abstract class CommonObject
 			}
 
 			// Clean total
-			$this->total_ht = (float) price2num($this->total_ht);
-			$this->total_tva = (float) price2num($this->total_tva);
+			if (isModEnabled('multicurrency') && !empty($multicurrency_tx) && $multicurrency_tx != 1) {
+				$this->total_ht  = (float) price2num($this->multicurrency_total_ht  / $multicurrency_tx);
+				$this->total_tva = (float) price2num($this->multicurrency_total_tva / $multicurrency_tx);
+				$this->total_ttc = (float) price2num($this->multicurrency_total_ttc / $multicurrency_tx);
+			} else {
+				$this->total_ht  = (float) price2num($this->total_ht);
+				$this->total_tva = (float) price2num($this->total_tva);
+				$this->total_ttc = (float) price2num($this->total_ttc);
+			}
 			$this->total_localtax1 = (float) price2num($this->total_localtax1);
 			$this->total_localtax2 = (float) price2num($this->total_localtax2);
-			$this->total_ttc = (float) price2num($this->total_ttc);
 
 			$this->db->free($resql);
 


### PR DESCRIPTION
# FIX multicurrency total is wrong on invoices

If a currency (ex. USD) invoice contains many lines, the main (ex. EUR) price may be wrong.
This is due to EUR total being sum of EUR price for each line. This bug exists at least from 14.0 to develop.

This PR makes the EUR total be computed from the USD price. 

example wrong (140/1.1 = 127.272727 => 127.27)
![multicur-KO](https://github.com/user-attachments/assets/cc5dd305-b99d-4003-ba1a-64a8d35c5b3e)

example right
![multicur-OK](https://github.com/user-attachments/assets/d544dc77-fcb5-4886-b0db-5a8b9832c516)
