### PR TITLE
Fix Commercial index - Widget information are truncated

### DIFF
--- a/htdocs/comm/index.php
+++ b/htdocs/comm/index.php
@@ -194,8 +194,8 @@ if (isModEnabled("propal") && $user->hasRight("propal", "lire")) {
 				$companystatic->canvas = $obj->canvas;
 
 				print '<tr class="oddeven">';
-				print '<td class="nowraponall tdoverflowmax100">'.$propalstatic->getNomUrl(1).'</td>';
-				print '<td class="nowrap tdoverflowmax100">'.$companystatic->getNomUrl(1, 'customer').'</td>';
+				print '<td class="nobordernopadding nowraponall">'.$propalstatic->getNomUrl(1).'</td>';
+				print '<td class="nobordernopadding nowrap">'.$companystatic->getNomUrl(1, 'customer').'</td>';
 				print '<td class="nowrap right tdamount amount">'.price((getDolGlobalString('MAIN_DASHBOARD_USE_TOTAL_HT') ? $obj->total_ht : $obj->total_ttc)).'</td>';
 				print '</tr>';
 
@@ -291,8 +291,8 @@ if (isModEnabled('supplier_proposal') && $user->hasRight("supplier_proposal", "l
 				$companystatic->canvas = $obj->canvas;
 
 				print '<tr class="oddeven">';
-				print '<td class="nowraponall tdoverflowmax100">'.$supplierproposalstatic->getNomUrl(1).'</td>';
-				print '<td class="nowrap tdoverflowmax100">'.$companystatic->getNomUrl(1, 'supplier').'</td>';
+				print '<td class="nobordernopadding nowraponall">'.$supplierproposalstatic->getNomUrl(1).'</td>';
+				print '<td class="nobordernopadding nowrap">'.$companystatic->getNomUrl(1, 'supplier').'</td>';
 				print '<td class="nowrap right tdamount amount">'.price(getDolGlobalString('MAIN_DASHBOARD_USE_TOTAL_HT') ? $obj->total_ht : $obj->total_ttc).'</td>';
 				print '</tr>';
 


### PR DESCRIPTION
Regardless of window size, document references and labels are always truncated for draft objects.

Before:

![Capture d’écran du 2024-11-10 06-02-46](https://github.com/user-attachments/assets/ee4cd7cb-065a-4405-ba85-d1e6e81ec8c5)

After: (not the same data, just not truncated)

![image](https://github.com/user-attachments/assets/45087de8-dfe7-4adf-8d84-4da78383d51c)

