### PR TITLE
FIX can validate shipment without stock movement

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2295,7 +2295,11 @@ class Expedition extends CommonObject
 			$error ++;
 		}
 
-		return $error;
+		if (!$error) {
+			return 1;
+		} else {
+			return -1;
+		}
 	}
 
 	/**


### PR DESCRIPTION
FIX can validate shipment without stock movement even if :
- stock movements are created on validate shipment
- the return of manageStockMvtOnEvt() method was wrong (always 0 or positive when errors occured)


**Before**
- you can validate an shipment without stock movement (even if the product was manged for stock)

**After**
- with this fix, you can't validate a shipment if stock is not enough (with negative stock not enabled)