### PR TITLE
ODF : fix : escape specials chars in IF ELSE ENDIF $key

### DIFF
--- a/htdocs/includes/odtphp/Segment.php
+++ b/htdocs/includes/odtphp/Segment.php
@@ -117,14 +117,14 @@ class Segment implements IteratorAggregate, Countable
                 // Remove the IF tag
                 $this->xml = str_replace('[!-- IF '.$key.' --]', '', $this->xml);
                 // Remove everything between the ELSE tag (if it exists) and the ENDIF tag
-                $reg = '@(\[!--\sELSE\s' . preg_quote($key) . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key) . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+                $reg = '@(\[!--\sELSE\s' . preg_quote($key, '@') . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key, '@') . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
                 $this->xml = preg_replace($reg, '', $this->xml);
             }
             // Else the value is false, then two cases: no ELSE and we're done, or there is at least one place where there is an ELSE clause, then we replace it
             else
             {
                 // Find all conditional blocks for this variable: from IF to ELSE and to ENDIF
-                $reg = '@\[!--\sIF\s' . preg_quote($key) . '\s--\](.*)(\[!--\sELSE\s' . preg_quote($key) . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key) . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+                $reg = '@\[!--\sIF\s' . preg_quote($key, '@') . '\s--\](.*)(\[!--\sELSE\s' . preg_quote($key, '@') . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key, '@') . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
                 preg_match_all($reg, $this->xml, $matches, PREG_SET_ORDER);
                 foreach($matches as $match) { // For each match, if there is an ELSE clause, we replace the whole block by the value in the ELSE clause
                     if (!empty($match[3])) $this->xml = str_replace($match[0], $match[3], $this->xml);

--- a/htdocs/includes/odtphp/Segment.php
+++ b/htdocs/includes/odtphp/Segment.php
@@ -117,14 +117,14 @@ class Segment implements IteratorAggregate, Countable
                 // Remove the IF tag
                 $this->xml = str_replace('[!-- IF '.$key.' --]', '', $this->xml);
                 // Remove everything between the ELSE tag (if it exists) and the ENDIF tag
-                $reg = '@(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+                $reg = '@(\[!--\sELSE\s' . preg_quote($key) . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key) . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
                 $this->xml = preg_replace($reg, '', $this->xml);
             }
             // Else the value is false, then two cases: no ELSE and we're done, or there is at least one place where there is an ELSE clause, then we replace it
             else
             {
                 // Find all conditional blocks for this variable: from IF to ELSE and to ENDIF
-                $reg = '@\[!--\sIF\s' . $key . '\s--\](.*)(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+                $reg = '@\[!--\sIF\s' . preg_quote($key) . '\s--\](.*)(\[!--\sELSE\s' . preg_quote($key) . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key) . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
                 preg_match_all($reg, $this->xml, $matches, PREG_SET_ORDER);
                 foreach($matches as $match) { // For each match, if there is an ELSE clause, we replace the whole block by the value in the ELSE clause
                     if (!empty($match[3])) $this->xml = str_replace($match[0], $match[3], $this->xml);

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -565,7 +565,7 @@ IMG;
 				// Remove the IF tag
 				$this->contentXml = str_replace('[!-- IF '.$key.' --]', '', $this->contentXml);
 				// Remove everything between the ELSE tag (if it exists) and the ENDIF tag
-				$reg = '@(\[!--\sELSE\s' . preg_quote($key) . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key) . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+				$reg = '@(\[!--\sELSE\s' . preg_quote($key, '@') . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key, '@') . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
 				$this->contentXml = preg_replace($reg, '', $this->contentXml);
 				/*if ($sav != $this->contentXml)
 				{
@@ -579,7 +579,7 @@ IMG;
 			    //dol_syslog("Var ".$key." is not defined, we remove the IF, ELSE and ENDIF ");
 			    //$sav=$this->contentXml;
 				// Find all conditional blocks for this variable: from IF to ELSE and to ENDIF
-				$reg = '@\[!--\sIF\s' . preg_quote($key) . '\s--\](.*)(\[!--\sELSE\s' . preg_quote($key) . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key) . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+				$reg = '@\[!--\sIF\s' . preg_quote($key, '@') . '\s--\](.*)(\[!--\sELSE\s' . preg_quote($key, '@') . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key, '@') . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
 				preg_match_all($reg, $this->contentXml, $matches, PREG_SET_ORDER);
 				foreach($matches as $match) { // For each match, if there is an ELSE clause, we replace the whole block by the value in the ELSE clause
 					if (!empty($match[3])) $this->contentXml = str_replace($match[0], $match[3], $this->contentXml);

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -539,7 +539,7 @@ IMG;
 	private function _parse($type='content')
 	{
 	    // Search all tags fou into condition to complete $this->vars, so we will proceed all tests even if not defined
-	    $reg='@\[!--\sIF\s([{}a-zA-Z0-9\.\,_]+)\s--\]@smU';
+	    $reg='@\[!--\sIF\s([\[\]{}a-zA-Z0-9\.\,_]+)\s--\]@smU';
 		$matches = array();
 	    preg_match_all($reg, $this->contentXml, $matches, PREG_SET_ORDER);
 

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -540,6 +540,7 @@ IMG;
 	{
 	    // Search all tags fou into condition to complete $this->vars, so we will proceed all tests even if not defined
 	    $reg='@\[!--\sIF\s([{}a-zA-Z0-9\.\,_]+)\s--\]@smU';
+		$matches = array();
 	    preg_match_all($reg, $this->contentXml, $matches, PREG_SET_ORDER);
 
 	    //var_dump($this->vars);exit;
@@ -564,7 +565,7 @@ IMG;
 				// Remove the IF tag
 				$this->contentXml = str_replace('[!-- IF '.$key.' --]', '', $this->contentXml);
 				// Remove everything between the ELSE tag (if it exists) and the ENDIF tag
-				$reg = '@(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+				$reg = '@(\[!--\sELSE\s' . preg_quote($key) . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key) . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
 				$this->contentXml = preg_replace($reg, '', $this->contentXml);
 				/*if ($sav != $this->contentXml)
 				{
@@ -578,7 +579,7 @@ IMG;
 			    //dol_syslog("Var ".$key." is not defined, we remove the IF, ELSE and ENDIF ");
 			    //$sav=$this->contentXml;
 				// Find all conditional blocks for this variable: from IF to ELSE and to ENDIF
-				$reg = '@\[!--\sIF\s' . $key . '\s--\](.*)(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
+				$reg = '@\[!--\sIF\s' . preg_quote($key) . '\s--\](.*)(\[!--\sELSE\s' . preg_quote($key) . '\s--\](.*))?\[!--\sENDIF\s' . preg_quote($key) . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
 				preg_match_all($reg, $this->contentXml, $matches, PREG_SET_ORDER);
 				foreach($matches as $match) { // For each match, if there is an ELSE clause, we replace the whole block by the value in the ELSE clause
 					if (!empty($match[3])) $this->contentXml = str_replace($match[0], $match[3], $this->contentXml);


### PR DESCRIPTION
# FIX|Fix Use internal constants in ODT files

The [wiki](https://wiki.dolibarr.org/index.php?title=Create_an_ODT_or_ODS_document_template#Conditional_substitution) states that ODT substitution allows using internal constants :

> `{__[XXX]__} = Value of the constant XXX (into setup)`

However, this does not work since the chars `[` and `]` are special chars char used in PCRE expressions.

These keys should be escaped.

## Example

here, the ODT template : 

![image](https://github.com/user-attachments/assets/8b38dec0-1247-4de5-bfe7-fcb3004efa74)

MY_VERY_SPECIAL_CONST = 1

The generated ODT is as so : 

![image](https://github.com/user-attachments/assets/deae3c6d-8930-4be4-b788-f630df779ffb)

after applying the fix, the generated ODT is right:

![image](https://github.com/user-attachments/assets/07e8e533-ba56-42d2-9755-dac524b4c52d)


## Configuration

Bug observed on DLB14, DLB18, develop.

## Implementation

Note that the first IF is correctly deleted since the function used is str_replace. The ELSE and ENDIF are not deleted since they are searched using preg_replace function.

```php
odtphp/segment.php l.118
                // Remove the IF tag
                $this->xml = str_replace('[!-- IF '.$key.' --]', '', $this->xml);
                // Remove everything between the ELSE tag (if it exists) and the ENDIF tag
                $reg = '@(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
                $this->xml = preg_replace($reg, '', $this->xml);
```
At this stage, `$key == '[MY_VERY_SPECIAL_CONST]'` so the regex is not what we mean.

The implementation fixes this bug by applying `preg_quote($key)` when using `$key` in regex.


