### PR TITLE
fix: migrate reflot folder with new rowid as folder storage

### DIFF
--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -514,8 +514,14 @@ if (!GETPOST('action', 'aZ09') || preg_match('/upgrade/i', GETPOST('action', 'aZ
 			*/
 
 			// Scripts for 20.0
-			$afterversionarray = explode('.', '19.0.9');
+			/*$afterversionarray = explode('.', '19.0.9');
 			$beforeversionarray = explode('.', '20.0.9');
+			if (versioncompare($versiontoarray, $afterversionarray) >= 0 && versioncompare($versiontoarray, $beforeversionarray) <= 0) {
+			}*/
+
+			// Scripts for 21.0
+			$afterversionarray = explode('.', '20.0.9');
+			$beforeversionarray = explode('.', '21.0.9');
 			if (versioncompare($versiontoarray, $afterversionarray) >= 0 && versioncompare($versiontoarray, $beforeversionarray) <= 0) {
 				migrate_productlot_path();
 			}


### PR DESCRIPTION
As https://github.com/Dolibarr/dolibarr/pull/29859 was merged, in develop and was writing when 20.0 was still develop branch the migration script have to be adapted