### PR TITLE
FIX: swiftmailer: correctly set errors-to header

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -577,7 +577,7 @@ class CMailFile
 
 			if (!empty($this->errors_to)) {
 				try {
-					$headers->addTextHeader('Errors-To', $this->getArrayAddress($this->errors_to));
+					$headers->addTextHeader('Errors-To', $this->getValidAddress($this->errors_to, 0));
 				} catch (Exception $e) {
 					$this->errors[] = $e->getMessage();
 				}
@@ -644,7 +644,6 @@ class CMailFile
 					$this->errors[] = $e->getMessage();
 				}
 			}
-			//if (!empty($this->errors_to)) $this->message->setErrorsTo($this->getArrayAddress($this->errors_to));
 			if (isset($this->deliveryreceipt) && $this->deliveryreceipt == 1) {
 				try {
 					$this->message->setReadReceiptTo($this->getArrayAddress($this->addr_from));


### PR DESCRIPTION
Swiftmailer's `addTextHeader` method does not handle array parameters like `setTo`, `setCC`, etc. So we format the `Errors-To` mail header as a `string` by hand.

This causes a fatal error in PHP8+

Fixes issue https://github.com/Dolibarr/dolibarr/issues/31741