### PR TITLE
Qual: Cleanup dev/tools/github_commits_byversion.sh

### DIFF
--- a/dev/tools/github_commits_byversion.sh
+++ b/dev/tools/github_commits_byversion.sh
@@ -1,25 +1,64 @@
 #!/bin/bash
-#
-# Count number of commits per user and per versions (using date for version detection)
-#
-# shellcheck disable=1113,2002,2006,2086,2164,2219
+# Copyright (C) 2024		MDW	<mdeweerd@users.noreply.github.com>
 
-Releases=("3.9" "4.0" "5.0" "6.0" "7.0" "8.0" "9.0" "10.0" "11.0" "12.0" "13.0" "14.0" "15.0" "16.0" "17.0" "18.0" "19.0" "20.0" "develop")
-let "counter = 0"
+#
+# Count number of commits per user and per version (using date for version detection)
+#
+#
+#
 
 echo "Copy script into /tmp/github_commits_byversion.sh"
-cp $0 /tmp/github_commits_perversion.sh
+cp "$0" /tmp/github_commits_perversion.sh
 
-echo "Delete /tmp/git"
-rm -fr /tmp/git
-echo "Create and go into /tmp/git"
-mkdir /tmp/git
-cd /tmp/git
-git clone https://github.com/Dolibarr/dolibarr.git
+TEMP_DIR=/tmp/git
+DOL_GIT="$TEMP_DIR/dolibarr"
+if ! git rev-parse ; then
+	echo "Delete $TEMP_DIR"
+	rm -fr "$TEMP_DIR"
+	echo "Create '$TEMP_DIR' and cd to it"
+	mkdir "$TEMP_DIR"
+	cd "$TEMP_DIR" || exit
+	git clone https://github.com/Dolibarr/dolibarr.git
+	cd "${DOL_GIT}" || exit
+else
+	if [ -r "${DOL_GIT}" ] ; then
+		git worktree remove "${DOL_GIT}"
+		rm -rf "${DOL_GIT}" >& /dev/null
+	fi
+	git worktree add --force "${DOL_GIT}" develop
+	cd "$DOL_GIT" || exit
+	git pull
+fi
 
-cd /tmp/git/dolibarr
+
+# Determine release to check
+Releases=("3.9" "4.0" "5.0" "6.0" "7.0" "8.0" "9.0" "10.0" "11.0" "12.0" "13.0" "14.0" "15.0" "16.0" "17.0" "18.0" "19.0" "20.0")
+target_version=$(sed -n "s/.*define('DOL_VERSION',[[:space:]]*'\\([0-9]*\\.[0-9]*\\).*/\\1/p" htdocs/filefunc.inc.php)
+
+# Default target version in case getting it from filefunc.inc failed
+target_version=${target_version:=20.0}
+
+# Setup loop to append required versions
+target_major=${target_version%%.*}
+last_major=${Releases%%.*}
+
+# Add versions up to target_version
+while (( last_major < target_major )); do
+	((last_major++))
+	tag="${last_major}.0"
+	if git rev-parse --verify "origin/$tag" >&/dev/null ; then
+		Releases+=("$tag")
+	fi
+done
+
+# Always end with develop
+Releases+=("develop")
+
+
+# Now proceed with generating the report for branches in ${Releases[@]}
 
 firstline=1
+((counter = 0))
 for i in "${Releases[@]}"
 do
 	if [ $firstline -eq 1 ]; then
@@ -31,21 +70,28 @@ do
 	echo "=== Version $i (counter $counter):"
 	echo "Get common commit ID between origin/${Releases[counter]} and origin/${Releases[counter+1]}"
 	echo "git merge-base origin/${Releases[counter]} origin/${Releases[counter+1]}"
-	commitidcommon=`git merge-base origin/${Releases[counter]} origin/${Releases[counter+1]}`
+	commitidcommon=$(git merge-base "origin/${Releases[counter]}" "origin/${Releases[counter+1]}")
 	echo "Found commitid=$commitidcommon"
 
-	echo "Checkout into version $i"
-	git checkout $i
+	echo "Checkout version $i"
+	git checkout --ignore-other-worktrees "$i"
 	#git shortlog -s -n  --after=YYYY-MM-DD --before=YYYY-MM-DD | tr '[:lower:]' '[:upper:]' > /tmp/github_commits_perversion.txt
-	git shortlog -s -n $commitidcommon..  | iconv -f UTF-8 -t ASCII//TRANSLIT | tr '[:lower:]' '[:upper:]' > /tmp/github_commits_perversion.txt
+	git shortlog --encoding=utf-8 -s -n "$commitidcommon.."  | iconv -f UTF-8 -t ASCII//TRANSLIT | tr '[:lower:]' '[:upper:]' > /tmp/github_commits_perversion.txt
 	#cat /tmp/github_commits_perversion.txt
 	echo "Total for version $i:"
 	echo -n "- Nb of commits: "
-	git log $commitidcommon.. --pretty=oneline | tr '[:lower:]' '[:upper:]' > /tmp/github_commits_perversion2.txt
-	cat /tmp/github_commits_perversion2.txt | wc -l
+	git log "$commitidcommon.." --pretty=oneline | tr '[:lower:]' '[:upper:]' > /tmp/github_commits_perversion2.txt
+	wc -l < /tmp/github_commits_perversion2.txt
 	echo -n "- Nb of different authors: "
 	awk ' { print $2 } ' < /tmp/github_commits_perversion.txt | sort -u | wc -l
 	echo "======================="
 	echo
-	let "counter +=1"
+	((counter++))
 done
+
+# Clean up git directory if it is a worktree
+if [ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] ; then
+	cd "$TEMP_DIR" || exit
+	git -C "$DOL_GIT" worktree remove "$DOL_GIT"
+fi
+exit


### PR DESCRIPTION
# Qual: Cleanup dev/tools/github_commits_byversion.sh

- Get the maximum version from htdocs/filefunc.inc.php;
- Avoid fetching the repository by using a worktree;
- Fix shellcheck notices.