### PR TITLE
FIX : contact type from custom module not showing

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1572,7 +1572,7 @@ abstract class CommonObject
 
 		$tab = array();
 
-		$sql = "SELECT DISTINCT tc.rowid, tc.code, tc.libelle as type_label, tc.position, tc.element";
+		$sql = "SELECT DISTINCT tc.rowid, tc.code, tc.libelle as type_label, tc.position, tc.element, tc.module";
 		$sql .= " FROM ".$this->db->prefix()."c_type_contact as tc";
 
 		$sqlWhere = array();
@@ -1609,7 +1609,7 @@ abstract class CommonObject
 				$langs->loadLangs(array("propal", "orders", "bills", "suppliers", "contracts", "supplier_proposal"));
 
 				while ($obj = $this->db->fetch_object($resql)) {
-					$modulename = $obj->element;
+					$modulename = $obj->module ?? $obj->element;
 					if (strpos($obj->element, 'project') !== false) {
 						$modulename = 'projet';
 					} elseif ($obj->element == 'contrat') {


### PR DESCRIPTION
Hello,

On my customer module i've added some contact types :

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/57ce9eea-5c3b-474d-b166-1e3d710d7819">

But i dont see them :

<img width="921" alt="image" src="https://github.com/user-attachments/assets/2bae65c9-f55e-4e80-89fa-c9bdfb2a810c">

And with my changes :

<img width="964" alt="image" src="https://github.com/user-attachments/assets/6970c37a-e44a-4bb6-ac1f-fb79bdf006c4">

