### PR TITLE
FIX: All contacts were loaded even if no thirdparty was selected

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -2067,7 +2067,30 @@ if ($id > 0) {
 			// related contact
 			print '<tr><td>'.$langs->trans("ActionOnContact").'</td><td>';
 			print '<div class="maxwidth200onsmartphone">';
-			print img_picto('', 'contact', 'class="paddingrightonly"').$form->selectcontacts(!getDolGlobalString('MAIN_ACTIONCOM_CAN_ADD_ANY_CONTACT') ? $object->socid : 0, array_keys($object->socpeopleassigned), 'socpeopleassigned[]', 1, '', '', 1, 'minwidth300 widthcentpercentminusx', false, 0, 0, array(), 'multiple', 'contactid');
+
+			$searchSocid = $object->socid > 0 ? $object->socid : -1;
+			if ($searchSocid <= 0 && getDolGlobalString('MAIN_ACTIONCOM_CAN_ADD_ANY_CONTACT')) {
+				$searchSocid = 0;
+			}
+
+			print img_picto('', 'contact', 'class="paddingrightonly"');
+			print $form->selectcontacts(
+				$searchSocid,
+				array_keys($object->socpeopleassigned),
+				'socpeopleassigned[]',
+				1,
+				'',
+				'',
+				1,
+				'minwidth300 widthcentpercentminusx',
+				false,
+				0,
+				0,
+				array(),
+				'multiple',
+				'contactid'
+			);
+
 			print '</div>';
 			print '</td>';
 			print '</tr>';

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -2068,10 +2068,7 @@ if ($id > 0) {
 			print '<tr><td>'.$langs->trans("ActionOnContact").'</td><td>';
 			print '<div class="maxwidth200onsmartphone">';
 
-			$searchSocid = $object->socid > 0 ? $object->socid : -1;
-			if ($searchSocid <= 0 && getDolGlobalString('MAIN_ACTIONCOM_CAN_ADD_ANY_CONTACT')) {
-				$searchSocid = 0;
-			}
+			$searchSocid = ($object->socid > 0) ? $object->socid : (getDolGlobalString('MAIN_ACTIONCOM_CAN_ADD_ANY_CONTACT') ? 0 : -1);
 
 			print img_picto('', 'contact', 'class="paddingrightonly"');
 			print $form->selectcontacts(


### PR DESCRIPTION
This bug is only problematic with a huge amount of contacts. 

It only append on an existing actioncomm with no contact or thirdparty attributed. When the user chose to modify it, all the contacts were loaded into the contact selector, resulting in a very slow-loading or even broken page.

I decided to do as it is now on actioncomm creation: the thirdparty needs to be selected before contact. 

This behavior can be deactivated with conf `MAIN_ACTIONCOM_CAN_ADD_ANY_CONTACT`