### PR TITLE
FIX mod_facture_fournisseur_tulip::getExample & get_next_value if no object

### DIFF
--- a/htdocs/core/modules/supplier_invoice/mod_facture_fournisseur_tulip.php
+++ b/htdocs/core/modules/supplier_invoice/mod_facture_fournisseur_tulip.php
@@ -176,7 +176,7 @@ class mod_facture_fournisseur_tulip extends ModeleNumRefSuppliersInvoices
 		}
 
 		// Supplier invoices take invoice date instead of creation date for the mask
-		$numFinal = get_next_value($db, $mask, 'facture_fourn', 'ref', '', $objsoc, $object->date);
+		$numFinal = get_next_value($db, $mask, 'facture_fourn', 'ref', '', $objsoc, is_object($object) ?$object->date :'');
 
 		return  $numFinal;
 	}


### PR DESCRIPTION
Fix [#31287](https://github.com/Dolibarr/dolibarr/issues/31287)

Missing test of existing object