### PR TITLE
New Add a workflow to let @lvessiller-opendsi and @rycks merge 18.0 PR by accepting reviews

### DIFF
--- a/.github/workflows/pr-18.yaml
+++ b/.github/workflows/pr-18.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   run:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
       - name: Create PR review request
         env:

--- a/.github/workflows/pr-18.yaml
+++ b/.github/workflows/pr-18.yaml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - "18.0"
+
+jobs:
+  run:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Create PR review request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          url: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$url" --add-assignee lvessiller-opendsi,rycks --add-reviewer lvessiller-opendsi,rycks
+          gh pr merge "$url" --merge --auto


### PR DESCRIPTION
The workflow only run on PR targeting the `18.0` branch, it adds @lvessiller-opendsi and @rycks as assignee and reviewer.

Combine with the ruleset below and allowing auto merge on this repo, the PR will auto merge once all requirements are met.

This ruleset make two approved review a requirement for all PR on 18.0 (excepted for repo admin) :
```yaml
{
  "id": 2630207,
  "name": "18",
  "target": "branch",
  "source_type": "Repository",
  "source": "fcharlaix-opendsi/dolibarr",
  "enforcement": "active",
  "conditions": {
    "ref_name": {
      "exclude": [],
      "include": [
        "refs/heads/18.0"
      ]
    }
  },
  "rules": [
    {
      "type": "deletion"
    },
    {
      "type": "non_fast_forward"
    },
    {
      "type": "pull_request",
      "parameters": {
        "required_approving_review_count": 2,
        "dismiss_stale_reviews_on_push": true,
        "require_code_owner_review": false,
        "require_last_push_approval": false,
        "required_review_thread_resolution": true,
        "automatic_copilot_code_review_enabled": false
      }
    }
  ],
  "bypass_actors": [
    {
      "actor_id": 5,
      "actor_type": "RepositoryRole",
      "bypass_mode": "always"
    }
  ]
}
```