### PR TITLE
fix: get file link in invoice list with multicompany

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -2146,7 +2146,8 @@ if ($num > 0) {
 				}
 
 				$filename = dol_sanitizeFileName($obj->ref);
-				$filedir = $conf->facture->dir_output.'/'.dol_sanitizeFileName($obj->ref);
+				$filepath = $conf->invoice->multidir_output[$obj->entity] ?? $conf->invoice->dir_output;
+				$filedir = $filepath.'/'.$filename;
 				$urlsource = $_SERVER['PHP_SELF'].'?id='.$obj->id;
 				print $formfile->getDocumentsLink($facturestatic->element, $filename, $filedir);
 				print '</td>';


### PR DESCRIPTION
Get file link when an invoice was shared from another entity when using multicompany
![image](https://github.com/user-attachments/assets/54271cc2-a27b-4b2d-b714-a2b87ac38f6f)
