### PR TITLE
Fix slow user card when many users in same group

### DIFF
--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -1940,7 +1940,7 @@ if ($action == 'create' || $action == 'adduserldap')
 					$exclude = array();
 
 					$usergroup = new UserGroup($db);
-					$groupslist = $usergroup->listGroupsForUser($object->id);
+					$groupslist = $usergroup->listGroupsForUser($object->id, false);
 
 					if (!empty($groupslist))
 					{


### PR DESCRIPTION
Fix slow user card when many users in same group
I disabled loading of all other users