### PR TITLE
feat: add entity in custom translation with multicompany

### DIFF
--- a/htdocs/admin/translation.php
+++ b/htdocs/admin/translation.php
@@ -59,6 +59,7 @@ if ($mode == 'searchkey') {
 	$transvalue = GETPOST('transvalue', 'restricthtml');
 }
 
+$entity = $conf->entity;
 if (isModEnabled('multicompany') && !$user->entity) {
 	$entity = GETPOST('entity', 'int');
 }

--- a/htdocs/admin/translation.php
+++ b/htdocs/admin/translation.php
@@ -59,6 +59,10 @@ if ($mode == 'searchkey') {
 	$transvalue = GETPOST('transvalue', 'restricthtml');
 }
 
+if (isModEnabled('multicompany') && !$user->entity) {
+	$entity = GETPOST('entity', 'int');
+}
+
 // Load variable for pagination
 $limit = GETPOSTINT('limit') ? GETPOSTINT('limit') : $conf->liste_limit;
 $sortfield = GETPOST('sortfield', 'aZ09comma');
@@ -128,10 +132,19 @@ if ($action == 'update') {
 		setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("NewTranslationStringToShow")), null, 'errors');
 		$error++;
 	}
+	if ($entity == '') {
+		setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("Entity")), null, 'errors');
+		$error++;
+	}
 	if (!$error) {
 		$db->begin();
 
-		$sql = "UPDATE ".MAIN_DB_PREFIX."overwrite_trans set transkey = '".$db->escape($transkey)."', transvalue = '".$db->escape($transvalue)."' WHERE rowid = ".(GETPOSTINT('rowid'));
+		$sql = "UPDATE " . MAIN_DB_PREFIX . "overwrite_trans set transkey = '" . $db->escape(
+				$transkey
+			) . "', transvalue = '" . $db->escape($transvalue) . "', entity = '" . $db->escape(
+				$entity
+			) . "' WHERE rowid = " . ((int) GETPOST('rowid', 'int'));
+
 		$result = $db->query($sql);
 		if ($result) {
 			$db->commit();
@@ -368,7 +381,9 @@ if ($mode == 'overwrite') {
 	print_liste_field_titre("Language_en_US_es_MX_etc", $_SERVER["PHP_SELF"], 'lang,transkey', '', $param, '', $sortfield, $sortorder);
 	print_liste_field_titre("TranslationKey", $_SERVER["PHP_SELF"], 'transkey', '', $param, '', $sortfield, $sortorder);
 	print_liste_field_titre("NewTranslationStringToShow", $_SERVER["PHP_SELF"], 'transvalue', '', $param, '', $sortfield, $sortorder);
-	//if (isModEnabled('multicompany') && !$user->entity) print_liste_field_titre("Entity", $_SERVER["PHP_SELF"], 'entity,transkey', '', $param, '', $sortfield, $sortorder);
+	if (isModEnabled('multicompany') && !$user->entity) {
+		print_liste_field_titre("Entity", $_SERVER["PHP_SELF"], 'Entity', '', $param, '', $sortfield, $sortorder);
+	}
 	print '<td align="center"></td>';
 	print "</tr>\n";
 
@@ -376,20 +391,35 @@ if ($mode == 'overwrite') {
 	// Line to add new record
 	print "\n";
 
-	print '<tr class="oddeven"><td>';
+	print '<tr class="oddeven">';
+
+	// Lang
+	print '<td>';
 	print $formadmin->select_language(GETPOST('langcode'), 'langcode', 0, array(), 1, 0, $disablededit ? 1 : 0, 'maxwidth250', 1);
 	print '</td>'."\n";
+
+	// Trans key
 	print '<td>';
 	print '<input type="text" class="flat maxwidthonsmartphone"'.$disablededit.' name="transkey" id="transkey" value="'.(!empty($transkey) ? $transkey : "").'">';
-	print '</td><td>';
+	print '</td>';
+
+	// Value
+	print '<td>';
 	print '<input type="text" class="quatrevingtpercent"'.$disablededit.' name="transvalue" id="transvalue" value="'.(!empty($transvalue) ? $transvalue : "").'">';
 	print '</td>';
+
+	// Multi company
+	if (isModEnabled('multicompany') && !$user->entity) {
+		print '<td>';
+		print '<input type="text" class="quatrevingtpercent"' . $disablededit . ' name="entity" id="entity" value="' . (!empty($entity) ? $entity : "") . '">';
+		print '</td>';
+	}
+
 	print '<td class="center">';
 	print '<input type="hidden" name="entity" value="'.$conf->entity.'">';
 	print '<input type="submit" class="button"'.$disabled.' value="'.$langs->trans("Add").'" name="add" title="'.dol_escape_htmltag($langs->trans("YouMustEnableTranslationOverwriteBefore")).'">';
 	print "</td>\n";
 	print '</tr>';
-
 
 	// Show constants
 	$sql = "SELECT rowid, entity, lang, transkey, transvalue";
@@ -411,7 +441,10 @@ if ($mode == 'overwrite') {
 
 			print '<tr class="oddeven">';
 
+			// Lang
 			print '<td>'.dol_escape_htmltag($obj->lang).'</td>'."\n";
+
+			// Trans key
 			print '<td>';
 			if ($action == 'edit' && $obj->rowid == GETPOSTINT('rowid')) {
 				print '<input type="text" class="quatrevingtpercent" name="transkey" value="'.dol_escape_htmltag($obj->transkey).'">';
@@ -440,6 +473,19 @@ if ($mode == 'overwrite') {
 				print '</span>';
 			}
 			print '</td>';
+
+			// Entity limit to superadmin
+			if (isModEnabled('multicompany') && empty($user->entity)) {
+				print '<td>';
+				if ($action == 'edit' && $obj->rowid == GETPOSTINT('rowid')) {
+					print '<input type="text" class="flat" size="1" name="entity" value="' . ((int) $obj->entity) . '">';
+				} else {
+					print dol_escape_htmltag($obj->entity);
+				}
+				print '</td>';
+			} else {
+				print '<input type="hidden" name="const[' . $i . '][entity]" value="' . ((int) $obj->entity) . '">';
+			}
 
 			print '<td class="center">';
 			if ($action == 'edit' && $obj->rowid == GETPOSTINT('rowid')) {


### PR DESCRIPTION
Allow setting entity to apply custom translation when multicompany is enabled.

## With multiompany 
### View
![image](https://github.com/user-attachments/assets/1d212281-bd36-40b5-ba07-29f14ddaa9bf)

### Edit
![image](https://github.com/user-attachments/assets/932845df-9abb-4dd2-8aa1-52cd236dc422)

## Without Multicompany
![image](https://github.com/user-attachments/assets/7807dbf4-cf7d-4e26-8914-ff769682a9cc)
