### PR TITLE
NEW: Allow multiple extrafields deletion

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -622,7 +622,7 @@ class ExtraFields
 			if (!empty($elementtype)) {
 				$sql .= " AND elementtype = '".$this->db->escape($elementtype)."'";
 			}
-			
+
 			dol_syslog(get_class($this)."::delete_label", LOG_DEBUG);
 			$resql = $this->db->query($sql);
 			if ($resql) {

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -619,8 +619,10 @@ class ExtraFields
 			$sql = "DELETE FROM ".$this->db->prefix()."extrafields";
 			$sql .= " WHERE name = '".$this->db->escape($attrname)."'";
 			$sql .= " AND entity IN  (0,".$conf->entity.')';
-			$sql .= " AND elementtype = '".$this->db->escape($elementtype)."'";
-
+			if (!empty($elementtype)) {
+				$sql .= " AND elementtype = '".$this->db->escape($elementtype)."'";
+			}
+			
 			dol_syslog(get_class($this)."::delete_label", LOG_DEBUG);
 			$resql = $this->db->query($sql);
 			if ($resql) {


### PR DESCRIPTION
If no element type parameter is given to the delete_label function, all occurences of the same extra field name are deleted at once. This simplifies the de-installation of a module that would have created multiple extra fields accros several element types.
