### PR TITLE
fix: get file link in invoice list with multicompany

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -2002,6 +2002,8 @@ if ($resql) {
 
 					$filename = dol_sanitizeFileName($obj->ref);
 					$filedir = $conf->facture->dir_output.'/'.dol_sanitizeFileName($obj->ref);
+					$filepath = $conf->invoice->multidir_output[$obj->entity] ?? $conf->invoice->dir_output;
+					$filedir = $filepath . '/' . $filename;
 					$urlsource = $_SERVER['PHP_SELF'].'?id='.$obj->id;
 					print $formfile->getDocumentsLink($facturestatic->element, $filename, $filedir);
 					print '</td>';


### PR DESCRIPTION
Get file link when an invoice was shared from another entity when using multicompany

Linked to fix #31930