### PR TITLE
fix: CronJob Property 'comment' do not exist replace by note_private

### DIFF
--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -1690,7 +1690,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 				$cronjob->command = $command;
 				$cronjob->params = $params;
 				$cronjob->md5params = $md5params;
-				$cronjob->comment = $comment;
+				$cronjob->note_private = $comment;
 				$cronjob->frequency = $frequency;
 				$cronjob->unitfrequency = $unitfrequency;
 				$cronjob->priority = $priority;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5af46ca3-1062-4cce-a483-a779d6fe30a9)


Should we change module template boilerplate and all core module cronjobs creation on activation to change array key name from "comment" to "note_private" to keep consistancy between declaration and field name ?
like in 
https://github.com/Dolibarr/dolibarr/blob/b2bad15a046d13594efd463fcf10fe899e2eb736/htdocs/core/modules/modAgenda.class.php#L125
or 
https://github.com/Dolibarr/dolibarr/blob/b2bad15a046d13594efd463fcf10fe899e2eb736/htdocs/modulebuilder/template/core/modules/modMyModule.class.php#L276