### PR TITLE
Update oldcopy in task

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -587,6 +587,7 @@ class Task extends CommonObjectLine
 			$this->db->free($resql);
 
 			if ($num_rows) {
+				$this->oldcopy = clone $this;
 				return 1;
 			} else {
 				return 0;


### PR DESCRIPTION
FIX #31985 oldcopy not set

Example of updating oldcopy when fetching task object.

It would be very usefull to update oldcopy for all objects

