### PR TITLE
Fix: Emailcollector, Html Email were registered with no body

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1800,7 +1800,7 @@ class EmailCollector extends CommonObject
 					if ($imapemail->hasHTMLBody()) {
 						$htmlmsg = $imapemail->getHTMLBody();
 					}
-					if ($imapemail->hasTextBody()) {
+					if ($imapemail->hasTextBody() && $imapemail->getTextBody() != "\n") {
 						$plainmsg = $imapemail->getTextBody();
 					}
 					if ($imapemail->hasAttachments()) {


### PR DESCRIPTION
Sometimes on email with HTML bodies,  `$imapemail->hasTextBody()` function from ` Webklex\PHPIMAP\Message` return true, because library creates a string with only a \n  inside `$imapemail->bodies['text']`. 
 =>  `$messagetext="\n"` instead of `$messagetext=$hmlmsg`;
