### PR TITLE
FIX: use tax with code on supplier order line give tax code missing in supplier invoice

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2149,12 +2149,10 @@ class FactureFournisseur extends CommonInvoice
 			// Clean vat code
 			$reg = array();
 			$vat_src_code = '';
-			//var_dump($txtva);
 			if (preg_match('/\((.*)\)/', $txtva, $reg)) {
 				$vat_src_code = $reg[1];
 				$txtva = preg_replace('/\s*\(.*\)/', '', $txtva); // Remove code into vatrate.
 			}
-			//var_dump($fk_product,$vat_src_code,$txtva);
 
 			// Calcul du total TTC et de la TVA pour la ligne a partir de
 			// qty, pu, remise_percent et txtva

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2149,10 +2149,12 @@ class FactureFournisseur extends CommonInvoice
 			// Clean vat code
 			$reg = array();
 			$vat_src_code = '';
+			//var_dump($txtva);
 			if (preg_match('/\((.*)\)/', $txtva, $reg)) {
 				$vat_src_code = $reg[1];
 				$txtva = preg_replace('/\s*\(.*\)/', '', $txtva); // Remove code into vatrate.
 			}
+			//var_dump($fk_product,$vat_src_code,$txtva);
 
 			// Calcul du total TTC et de la TVA pour la ligne a partir de
 			// qty, pu, remise_percent et txtva

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -501,8 +501,6 @@ if (empty($reshook)) {
 							if (!empty($lines[$i]->vat_src_code) && !preg_match('/\(/', $tva_tx)) {
 								$tva_tx .= ' ('.$lines[$i]->vat_src_code.')';
 							}
-							//var_dump($lines[$i]->fk_product,$lines[$i]->tva_tx,$lines[$i]->vat_src_code,$tva_tx);
-
 
 							$result = $objecttmp->addline(
 								$desc,
@@ -546,7 +544,6 @@ if (empty($reshook)) {
 					}
 				}
 			}
-			//exit;
 
 			$cmd->classifyBilled($user); // TODO Move this in workflow like done for sales orders
 

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -496,10 +496,18 @@ if (empty($reshook)) {
 							if (($lines[$i]->product_type != 9 && empty($lines[$i]->fk_parent_line)) || $lines[$i]->product_type == 9) {
 								$fk_parent_line = 0;
 							}
+
+							$tva_tx = $lines[$i]->tva_tx;
+							if (!empty($lines[$i]->vat_src_code) && !preg_match('/\(/', $tva_tx)) {
+								$tva_tx .= ' ('.$lines[$i]->vat_src_code.')';
+							}
+							//var_dump($lines[$i]->fk_product,$lines[$i]->tva_tx,$lines[$i]->vat_src_code,$tva_tx);
+
+
 							$result = $objecttmp->addline(
 								$desc,
 								$lines[$i]->subprice,
-								$lines[$i]->tva_tx,
+								$tva_tx,
 								$lines[$i]->localtax1_tx,
 								$lines[$i]->localtax2_tx,
 								$lines[$i]->qty,
@@ -538,6 +546,7 @@ if (empty($reshook)) {
 					}
 				}
 			}
+			//exit;
 
 			$cmd->classifyBilled($user); // TODO Move this in workflow like done for sales orders
 

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -1255,6 +1255,11 @@ if (empty($reshook)) {
 									$date_end = $lines[$i]->date_end;
 								}
 
+								$tva_tx = $lines[$i]->tva_tx;
+								if (!empty($lines[$i]->vat_src_code) && !preg_match('/\(/', $tva_tx)) {
+									$tva_tx .= ' ('.$lines[$i]->vat_src_code.')';
+								}
+
 								// FIXME Missing special_code  into addline and updateline methods
 								$object->special_code = $lines[$i]->special_code;
 
@@ -1271,7 +1276,7 @@ if (empty($reshook)) {
 								$result = $object->addline(
 									$desc,
 									$pu,
-									$lines[$i]->tva_tx,
+									$tva_tx,
 									$lines[$i]->localtax1_tx,
 									$lines[$i]->localtax2_tx,
 									$lines[$i]->qty,


### PR DESCRIPTION
Actually

![image](https://github.com/user-attachments/assets/853a878e-d28f-47e3-b787-6f8c317ec067)
![image](https://github.com/user-attachments/assets/2ff108c4-e853-4ea2-9ceb-4c3f62245dfb)


Idem on create invoice from supplier order list

I report code use in customer invoice card
https://github.com/Dolibarr/dolibarr/blob/ac6c57e90e129bed83ca032165f0100a85f61f66/htdocs/compta/facture/card.php#L1740
