### PR TITLE
fix: buyer and sellers in supplier invoice and supplier order list are not corectly defined

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2144,7 +2144,7 @@ class FactureFournisseur extends CommonInvoice
 				$pu = 0;
 			}
 
-			$localtaxes_type = getLocalTaxesFromRate($txtva, 0, $mysoc, $mysoc);
+			$localtaxes_type = getLocalTaxesFromRate($txtva, 0, $mysoc, $this->thirdparty);
 
 			// Clean vat code
 			$reg = array();

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2144,7 +2144,7 @@ class FactureFournisseur extends CommonInvoice
 				$pu = 0;
 			}
 
-			$localtaxes_type = getLocalTaxesFromRate($txtva, 0, $mysoc, $this->thirdparty);
+			$localtaxes_type = getLocalTaxesFromRate($txtva, 0, $mysoc, $mysoc);
 
 			// Clean vat code
 			$reg = array();

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -391,6 +391,7 @@ if (empty($reshook)) {
 					$societe = new Societe($db);
 					$societe->fetch($cmd->socid);
 					$objecttmp->vat_reverse_charge = $societe->vat_reverse_charge;
+					$objecttmp->thirdparty = $societe;
 				}
 				$objecttmp->socid = $cmd->socid;
 				$objecttmp->type = $objecttmp::TYPE_STANDARD;


### PR DESCRIPTION
In supplier invoice addline method 
we use wrongly  $this->thirdparty as buyer insted of $mysoc
and in 
calcul_price_total in case of create supplier invoice from supplier order list $this->thirdparty is never defined