### PR TITLE
Update tax.lib.php

### DIFF
--- a/htdocs/core/lib/tax.lib.php
+++ b/htdocs/core/lib/tax.lib.php
@@ -1177,6 +1177,7 @@ function tax_by_rate($type, $db, $y, $q, $date_start, $date_end, $modetax, $dire
 		if (!empty($conf->global->MAIN_NOT_INCLUDE_ZERO_VAT_IN_REPORTS)) {
 			$sql .= " AND (d.".$f_rate." <> 0 OR d.total_tva <> 0)";
 		}
+		$sql .= " GROUP BY d.rowid";
 		$sql .= " ORDER BY e.rowid";
 
 		if (!$sql) {


### PR DESCRIPTION
When expensereport for a month and for a tax rate contains more than 1 line (n lines), the tax report contains n identical lines and total are impacted with those n values.
In this exemple ER2409-0045 contains 7 different payments (2 payments with 20% tva, 2 payments with 10% tva and 3 payments with 5.5% tva -> the picture).
The lines are copied 7 times for the same value in the report.

![Capture d'écran 2024-11-21 152725](https://github.com/user-attachments/assets/a5dd1a49-b3a8-4f61-a760-3e7e607519aa)

Add GROUP BY in SELECT sql request solve the problem.

Francis