### PR TITLE
FIX: flip supplier proposal and orders to show up as negative in the project Profit overview

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -948,12 +948,18 @@ foreach ($listofreferent as $key => $value) {
 					$total_ttc_by_line = $element->total_ttc;
 				}
 
-				// Change sign of $total_ht_by_line and $total_ttc_by_line for some cases
+				// Change sign of $total_ht_by_line and $total_ttc_by_line for various payments
 				if ($tablename == 'payment_various') {
 					if ($element->sens == 1) {
 						$total_ht_by_line = -$total_ht_by_line;
 						$total_ttc_by_line = -$total_ttc_by_line;
 					}
+				}
+
+				// Change sign of $total_ht_by_line and $total_ttc_by_line for supplier proposal and supplier order
+				if ($tablename == 'commande_fournisseur' || $tablename == 'supplier_proposal') {
+					$total_ht_by_line = -$total_ht_by_line;
+					$total_ttc_by_line = -$total_ttc_by_line;
 				}
 
 				// Add total if we have to


### PR DESCRIPTION
FIX: flip supplier proposal and orders to show up as negative in the project Profit overview
In the project overview, supplier proposals and orders was shown as positive, where as the supplier invoices was shown as negative. This MR fixes the presentation so they show up as negative.

![correct_supplier_proposals_orders_shown_as_negative_just_like_supplier_invoice_is_negative](https://github.com/user-attachments/assets/e52ba0d6-e47c-41a2-9e91-c2b23044d668)
![wrong_supplier_proposals_orders_shown_as_positive_where_as_invoice_is_negative](https://github.com/user-attachments/assets/ad8cdd22-02b2-4457-88f7-f771769de09a)
