### PR TITLE
FIX: backport - flip supplier proposal and orders to show up as negative in the project Profit overview

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -917,12 +917,18 @@ foreach ($listofreferent as $key => $value) {
 					$total_ttc_by_line = $element->total_ttc;
 				}
 
-				// Change sign of $total_ht_by_line and $total_ttc_by_line for some cases
+				// Change sign of $total_ht_by_line and $total_ttc_by_line for various payments
 				if ($tablename == 'payment_various') {
 					if ($element->sens == 1) {
 						$total_ht_by_line = -$total_ht_by_line;
 						$total_ttc_by_line = -$total_ttc_by_line;
 					}
+				}
+
+				// Change sign of $total_ht_by_line and $total_ttc_by_line for supplier proposal and supplier order
+				if ($tablename == 'commande_fournisseur' || $tablename == 'supplier_proposal') {
+					$total_ht_by_line = -$total_ht_by_line;
+					$total_ttc_by_line = -$total_ttc_by_line;
 				}
 
 				// Add total if we have to


### PR DESCRIPTION
FIX: backport - flip supplier proposal and orders to show up as negative in the project Profit overview
In the project overview, supplier proposals and orders was shown as positive, where as the supplier invoices was shown as negative. This backport MR fixes the presentation so they show up as negative.