### PR TITLE
FIX #32072

### DIFF
--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -483,7 +483,12 @@ class Shipments extends DolibarrApi
 				$this->shipment->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
 				continue;
 			}
-
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->shipment->array_options[$index] = $this->_checkValForAPI($field, $val, $this->shipment);
+				}
+				continue;
+			}
 			$this->shipment->$field = $this->_checkValForAPI($field, $value, $this->shipment);
 		}
 

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1252,6 +1252,14 @@ class Expedition extends CommonObject
 			$this->errors[] = "Error ".$this->db->lasterror();
 		}
 
+		// Actions on extra fields
+		if (!$error) {
+			$result = $this->insertExtraFields();
+			if ($result < 0) {
+				$error++;
+			}
+		}
+
 		if (!$error && !$notrigger) {
 			// Call trigger
 			$result = $this->call_trigger('SHIPPING_MODIFY', $user);


### PR DESCRIPTION
# Fix #32072 PUT method doesn't change the value of the extra fields of the shipments module
The PUT method of the shipments module, did not handle the extra fields. I tried my best, and copied code from other modules.
After doing this, the API call worked on my instance.