### PR TITLE
FIX : Position class select inactive users

### DIFF
--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -847,7 +847,7 @@ class Position extends CommonObject
 	 */
 	public function showInputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = 0, $nonewbutton = 0)
 	{
-		global $langs, $form;
+		global $langs, $form, $action;
 
 		if (!($form instanceof Form)) {
 			$form = new Form($this->db);
@@ -856,7 +856,7 @@ class Position extends CommonObject
 		if ($key == 'fk_user') {
 			$vacantId = $keyprefix.$key.'vacant'.$keysuffix;
 
-			$out = $form->select_dolusers($value, 'search_'.$key, 1, null, 0, '', '', '0', 0, 0, '', 0, '', (!empty($val['css']) ? $val['css'] : 'maxwidth100'));
+			$out = $form->select_dolusers($value, ($action == 'create' ? $key : 'search_'.$key), 1, null, 0, '', '', '0', 0, 0, '', 0, '', (!empty($val['css']) ? $val['css'] : 'maxwidth100'));
 
 			$out .= '<label class="nowrap position-fk-user classfortooltip" title="'.dol_escape_js($langs->trans('VacantCheckboxHelper')).'"><input type="checkbox" id="'.$vacantId.'" name="'.$vacantId.'">&nbsp;'.$langs->trans("Vacant").'</label>'; ?>
 			<script type="text/javascript">

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -849,7 +849,9 @@ class Position extends CommonObject
 	{
 		global $langs, $form;
 
-		$form ??= new Form($this->db);
+		if (empty($form)) {
+			$form = new Form($this->db);
+		}
 
 		if ($key == 'fk_user') {
 			$vacantId = $keyprefix.$key.'vacant'.$keysuffix;

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -856,8 +856,7 @@ class Position extends CommonObject
 		if ($key == 'fk_user') {
 			$vacantId = $keyprefix.$key.'vacant'.$keysuffix;
 
-			$action = GETPOST('action', 'alpha');
-			$out = $form->select_dolusers($value, ($action == 'create' ? $key : 'search_'.$key), 1, null, 0, '', '', '0', 0, 0, '', 0, '', (!empty($val['css']) ? $val['css'] : 'maxwidth100'));
+			$out = $form->select_dolusers($value, $keyprefix.$key.$keysuffix, 1, null, 0, '', '', '0', 0, 0, '', 0, '', (!empty($val['css']) ? $val['css'] : 'maxwidth100'));
 
 			$out .= '<label class="nowrap position-fk-user classfortooltip" title="'.dol_escape_js($langs->trans('VacantCheckboxHelper')).'"><input type="checkbox" id="'.$vacantId.'" name="'.$vacantId.'">&nbsp;'.$langs->trans("Vacant").'</label>'; ?>
 			<script type="text/javascript">

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -847,9 +847,9 @@ class Position extends CommonObject
 	 */
 	public function showInputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = 0, $nonewbutton = 0)
 	{
-		global $langs, $db, $form;
+		global $langs, $form;
 
-		$form ??= new Form($db);
+		$form ??= new Form($this->db);
 
 		if ($key == 'fk_user') {
 			$vacantId = $keyprefix.$key.'vacant'.$keysuffix;

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -849,7 +849,7 @@ class Position extends CommonObject
 	{
 		global $langs, $form;
 
-		if (empty($form)) {
+		if (!($form instanceof Form)) {
 			$form = new Form($this->db);
 		}
 

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -847,9 +847,9 @@ class Position extends CommonObject
 	 */
 	public function showInputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = 0, $nonewbutton = 0)
 	{
-		global $langs, $db;
+		global $langs, $db, $form;
 
-		$form = new Form($db);
+		$form ??= new Form($db);
 
 		if ($key == 'fk_user') {
 			$vacantId = $keyprefix.$key.'vacant'.$keysuffix;

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -97,7 +97,7 @@ class Position extends CommonObject
 		'date_creation' => array('type' => 'datetime', 'label' => 'DateCreation', 'enabled' => 1, 'position' => 500, 'notnull' => 1, 'visible' => -2,),
 		'tms' => array('type' => 'timestamp', 'label' => 'DateModification', 'enabled' => 1, 'position' => 501, 'notnull' => 0, 'visible' => -2,),
 		'fk_contrat' => array('type' => 'integer:Contrat:contrat/class/contrat.class.php', 'label' => 'fk_contrat', 'enabled' => 'isModEnabled("contract")', 'position' => 50, 'notnull' => 0, 'visible' => 0,),
-		'fk_user' => array('type' => 'integer:User:user/class/user.class.php:0:(t.statut:=:1)', 'label' => 'Employee', 'enabled' => 1, 'position' => 55, 'notnull' => 1, 'visible' => 1, 'default' => '0', 'picto' => 'user', 'css' => 'maxwidth300 widthcentpercentminusxx', 'csslist' => 'tdoverflowmax150'),
+		'fk_user' => array('type' => 'integer:User:user/class/user.class.php:0', 'label' => 'Employee', 'enabled' => 1, 'position' => 55, 'notnull' => 1, 'visible' => 1, 'default' => '0', 'picto' => 'user', 'css' => 'maxwidth300 widthcentpercentminusxx', 'csslist' => 'tdoverflowmax150'),
 		'fk_job' => array('type' => 'integer:Job:/hrm/class/job.class.php', 'label' => 'JobProfile', 'enabled' => 1, 'position' => 56, 'notnull' => 1, 'visible' => 1, 'picto' => 'jobprofile', 'css' => 'maxwidth300 widthcentpercentminusxx', 'csslist' => 'tdoverflowmax150'),
 		'date_start' => array('type' => 'date', 'label' => 'DateStart', 'enabled' => 1, 'position' => 101, 'notnull' => 1, 'visible' => 1,),
 		'date_end' => array('type' => 'date', 'label' => 'DateEnd', 'enabled' => 1, 'position' => 102, 'notnull' => 0, 'visible' => 1,),
@@ -847,12 +847,15 @@ class Position extends CommonObject
 	 */
 	public function showInputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = 0, $nonewbutton = 0)
 	{
-		global $langs;
+		global $langs, $db;
+
+		$form = new Form($db);
 
 		if ($key == 'fk_user') {
 			$vacantId = $keyprefix.$key.'vacant'.$keysuffix;
 
-			$out = parent::showInputField($val, $key, $value, $moreparam, $keysuffix, $keyprefix, $morecss);
+			$out = $form->select_dolusers($value, 'search_'.$key, 1, null, 0, '', '', '0', 0, 0, '', 0, '', (!empty($val['css']) ? $val['css'] : 'maxwidth100'));
+
 			$out .= '<label class="nowrap position-fk-user classfortooltip" title="'.dol_escape_js($langs->trans('VacantCheckboxHelper')).'"><input type="checkbox" id="'.$vacantId.'" name="'.$vacantId.'">&nbsp;'.$langs->trans("Vacant").'</label>'; ?>
 			<script type="text/javascript">
 				$(document).ready(function () {

--- a/htdocs/hrm/class/position.class.php
+++ b/htdocs/hrm/class/position.class.php
@@ -847,7 +847,7 @@ class Position extends CommonObject
 	 */
 	public function showInputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = 0, $nonewbutton = 0)
 	{
-		global $langs, $form, $action;
+		global $langs, $form;
 
 		if (!($form instanceof Form)) {
 			$form = new Form($this->db);
@@ -856,6 +856,7 @@ class Position extends CommonObject
 		if ($key == 'fk_user') {
 			$vacantId = $keyprefix.$key.'vacant'.$keysuffix;
 
+			$action = GETPOST('action', 'alpha');
 			$out = $form->select_dolusers($value, ($action == 'create' ? $key : 'search_'.$key), 1, null, 0, '', '', '0', 0, 0, '', 0, '', (!empty($val['css']) ? $val['css'] : 'maxwidth100'));
 
 			$out .= '<label class="nowrap position-fk-user classfortooltip" title="'.dol_escape_js($langs->trans('VacantCheckboxHelper')).'"><input type="checkbox" id="'.$vacantId.'" name="'.$vacantId.'">&nbsp;'.$langs->trans("Vacant").'</label>'; ?>


### PR DESCRIPTION
# FIX|Fix Position class select inactive users
Previously, it was possible to select inactive users from the position list.
A configuration option, USER_HIDE_INACTIVE_IN_COMBOBOX, exists and allows you to control whether inactive users are hidden or visible in dropdown menus. To ensure this configuration works as intended, I changed the select type to select_dolusers for the position_list, and removed the constraint from the fields.