### PR TITLE
FIX Linked elements not up to date

### DIFF
--- a/htdocs/core/actions_dellink.inc.php
+++ b/htdocs/core/actions_dellink.inc.php
@@ -50,6 +50,7 @@ if ($action == 'addlink' && !empty($permissiondellink) && !$cancellink && $id > 
 	foreach ($addlinkids as $addlinkid) {
 		$result = $object->add_object_linked($addlink, $addlinkid);
 	}
+	$object->clearObjectLinkedCache();
 }
 
 // Link by reference
@@ -76,6 +77,7 @@ if ($action == 'addlinkbyref' && !empty($permissiondellink) && !$cancellink && $
 			setEventMessage($langs->trans('ErrorRecordNotFound'), 'errors');
 		}
 	}
+	$object->clearObjectLinkedCache();
 }
 
 // Delete link in table llx_element_element
@@ -84,6 +86,5 @@ if ($action == 'dellink' && !empty($permissiondellink) && !$cancellink && $delli
 	if ($result < 0) {
 		setEventMessages($object->error, $object->errors, 'errors');
 	}
+	$object->clearObjectLinkedCache();
 }
-
-$object->clearObjectLinkedCache();

--- a/htdocs/core/actions_dellink.inc.php
+++ b/htdocs/core/actions_dellink.inc.php
@@ -70,6 +70,7 @@ if ($action == 'addlinkbyref' && !empty($permissiondellink) && !$cancellink && $
 			if (isset($_POST['reftolinkto'])) {
 				unset($_POST['reftolinkto']);
 			}
+			$object->clearObjectLinkedCache();
 		} elseif ($ret < 0) {
 			setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
 		} else {
@@ -77,14 +78,13 @@ if ($action == 'addlinkbyref' && !empty($permissiondellink) && !$cancellink && $
 			setEventMessage($langs->trans('ErrorRecordNotFound'), 'errors');
 		}
 	}
-	$object->clearObjectLinkedCache();
 }
 
 // Delete link in table llx_element_element
 if ($action == 'dellink' && !empty($permissiondellink) && !$cancellink && $dellinkid > 0) {
 	$result = $object->deleteObjectLinked(0, '', 0, '', $dellinkid);
+	$object->clearObjectLinkedCache();
 	if ($result < 0) {
 		setEventMessages($object->error, $object->errors, 'errors');
 	}
-	$object->clearObjectLinkedCache();
 }

--- a/htdocs/core/actions_dellink.inc.php
+++ b/htdocs/core/actions_dellink.inc.php
@@ -85,3 +85,5 @@ if ($action == 'dellink' && !empty($permissiondellink) && !$cancellink && $delli
 		setEventMessages($object->error, $object->errors, 'errors');
 	}
 }
+
+$object->clearObjectLinkedCache();


### PR DESCRIPTION
# FIX
If you add a linked element, it won't appear without this correction, and if you delete an element, it won't disappear. You're forced to refresh the page to have the links updated, which is rather unpleasant.
