### PR TITLE
FIX Bug page_y url

### DIFF
--- a/htdocs/core/js/lib_foot.js.php
+++ b/htdocs/core/js/lib_foot.js.php
@@ -243,21 +243,27 @@ if ($conf->browser->layout != 'phone') {
 print "\n/* JS CODE TO ENABLE reposition management (does not work if a redirect is done after action of submission) */\n";
 print '
     jQuery(document).ready(function() {
-        page_y = getParameterByName("page_y", 0);
-        if (page_y == 0) page_y = jQuery("#page_y").text();
+		/* If page_y set, we set scrollbar with it */
+        page_y = getParameterByName("page_y", 0);				/* search in GET parameter */
+        if (page_y == 0) page_y = jQuery("#page_y").text();		/* search in POST parameter that is filed at bottom of page */
         if (page_y > 0) {
+			console.log("page_y found is "+page_y);
             jQuery("html, body").scrollTop(page_y);
         }
 
+		/* Set handler to add page_y param on output (click on href links or submit button) */
         jQuery(".reposition").click(function(event) {
             var page_y = jQuery(document).scrollTop();
             if (page_y > 0) {
                 if (this.href) {
+					console.log("We click on tag with .reposition class. this.ref was "+this.href);
                     var url = new URL(this.href, window.location.origin);
-                    url.searchParams.delete("page_y");
+                    url.searchParams.delete("page_y");		/* remove page_y param if already present */
                     url.searchParams.set("page_y", page_y);
                     this.href = url.toString();
+					console.log("We click on tag with .reposition class. this.ref is now "+this.href);
                 } else {
+					console.log("We click on tag with .reposition class but element is not an <a> html tag, so we try to update input form field with name=page_y with value "+page_y);
                     jQuery("input[type=hidden][name=page_y]").val(page_y);
                 }
             }

--- a/htdocs/core/js/lib_foot.js.php
+++ b/htdocs/core/js/lib_foot.js.php
@@ -242,38 +242,28 @@ if ($conf->browser->layout != 'phone') {
 // Code to manage reposition
 print "\n/* JS CODE TO ENABLE reposition management (does not work if a redirect is done after action of submission) */\n";
 print '
-	jQuery(document).ready(function() {
-				/* If page_y set, we set scrollbar with it */
-				page_y=getParameterByName(\'page_y\', 0);				/* search in GET parameter */
-				if (page_y == 0) page_y = jQuery("#page_y").text();		/* search in POST parameter that is filed at bottom of page */
-				if (page_y > 0)
-				{
-					console.log("page_y found is "+page_y);
-					$(\'html, body\').scrollTop(page_y);
-				}
+    jQuery(document).ready(function() {
+        page_y = getParameterByName("page_y", 0);
+        if (page_y == 0) page_y = jQuery("#page_y").text();
+        if (page_y > 0) {
+            jQuery("html, body").scrollTop(page_y);
+        }
 
-				/* Set handler to add page_y param on output (click on href links or submit button) */
-				jQuery(".reposition").click(function() {
-					var page_y = $(document).scrollTop();
-
-					if (page_y > 0)
-					{
-						if (this.href)
-						{
-							console.log("We click on tag with .reposition class. this.ref was "+this.href);
-							var hrefarray = this.href.split("#", 2);
-							hrefarray[0]=hrefarray[0].replace(/&page_y=(\d+)/, \'\');		/* remove page_y param if already present */
-							this.href=hrefarray[0]+\'&page_y=\'+page_y;
-							console.log("We click on tag with .reposition class. this.ref is now "+this.href);
-						}
-						else
-						{
-							console.log("We click on tag with .reposition class but element is not an <a> html tag, so we try to update input form field with name=page_y with value "+page_y);
-							jQuery("input[type=hidden][name=page_y]").val(page_y);
-						}
-					}
-				});
-	});'."\n";
+        jQuery(".reposition").click(function(event) {
+            var page_y = jQuery(document).scrollTop();
+            if (page_y > 0) {
+                if (this.href) {
+                    var url = new URL(this.href, window.location.origin);
+                    url.searchParams.delete("page_y");
+                    url.searchParams.set("page_y", page_y);
+                    this.href = url.toString();
+                } else {
+                    jQuery("input[type=hidden][name=page_y]").val(page_y);
+                }
+            }
+        });
+    });
+' . "\n";
 
 // Code to manage Copy To Clipboard click
 print "\n/* JS CODE TO ENABLE ClipBoard copy paste */\n";


### PR DESCRIPTION
# FIX
In some cases, 'reposition' modified the url by assigning variables other than page_y, for example :  https://XXX/ticket/card.php?id=2158&action=dellink&token=e88288a7e4488ebafb81a80fa5f58913&dellinkid=20308.60009765625.60009765625&page_y=2113.60009765625

Here, for example, we were unable to delete a linked element, which is logical when you see the contents of dellinkid