### PR TITLE
18.0 fix select type on ticket list

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -716,7 +716,7 @@ class FormTicket
 		$ticketstat->loadCacheTypesTickets();
 
 		print '<select id="select'.$htmlname.'" class="flat minwidth100'.($morecss ? ' '.$morecss : '').'" name="'.$htmlname.($multiselect?'[]':'').'"'.($multiselect?' multiple':'').'>';
-		if ($empty) {
+		if ($empty && !$multiselect) {
 			print '<option value="">&nbsp;</option>';
 		}
 
@@ -753,7 +753,7 @@ class FormTicket
 					print ' selected="selected"';
 				} elseif (in_array($id, $selected)) {
 					print ' selected="selected"';
-				} elseif ($arraytypes['use_default'] == "1" && empty($selected)) {
+				} elseif ($arraytypes['use_default'] == "1" && empty($selected) && !$multiselect) {
 					print ' selected="selected"';
 				}
 


### PR DESCRIPTION
# FIX Select type in ticket list

see issue https://github.com/Dolibarr/dolibarr/issues/31619 (issue mentions 20.0 ; I confirm on 18.0 and develop)

We have a problem on ticket type selection :
- on creation form, default value should be set and empty value should be forbidden.
- on ticket list search field, default value should not be set and empty value should be allowed. 

The function selectTypesTickets deals with many cases when `$selected` is empty :

- the field can be empty, and we don't want to select the default value (this is the **case in ticket list search field**, which is a multiselect)
- the field can be empty, and we want to select the default value (theoritical case, I will not deal with it)
- the field should not be empty, and we want to select the default value (this is the **case in ticket creation card**)
- the field should not be empty, and there is no default value (this **may be the case in ticket creation card**) -> this means the select will be selected on the first entry. The function should display an entry that is obviously wrong, like 'Please select type.'

To illustrate the problem on ticket list search field, when I load ticket/list.php (or do a search without setting the field for ticket type), the search field for type is set to default by DLB : 

![image](https://github.com/user-attachments/assets/f049b2aa-6111-4656-b759-432e59878e06)

This means that I have to remove this field each time I do a new search.

This PR :

- modifies selectTypesTickets to match these requirements
- changes the call to selectTypesTickets in creation form to forbid empty value.

As a consequence : 
- on ticket list, the search field for type remains empty
- on creation card, the default value is selected
- on creation card, **if there is no default value**, the value '-- Select type --' is the first of the list and is used.
![image](https://github.com/user-attachments/assets/a4433cc8-ea88-4a14-9ca2-e79379953d4a)
