### PR TITLE
FIX select on ticket list for fields group and severity (issue #31619)

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -391,12 +391,12 @@ class FormTicket
 		if ($public) {
 			$filter = '(public:=:1)';
 		}
-		$this->selectGroupTickets($category_code, 'category_code', $filter, 2, 1, 0, 0, 'minwidth200 maxwidth500');
+		$this->selectGroupTickets($category_code, 'category_code', $filter, 2, 0, 0, 0, 'minwidth200 maxwidth500');
 		print '</td></tr>';
 
 		// Severity => Priority
 		print '<tr><td><span class="fieldrequired"><label for="selectseverity_code">'.$langs->trans("TicketSeverity").'</span></label></td><td>';
-		$this->selectSeveritiesTickets($severity_code, 'severity_code', '', 2, 1, 0, 0, 'minwidth200 maxwidth500');
+		$this->selectSeveritiesTickets($severity_code, 'severity_code', '', 2, 0, 0, 0, 'minwidth200 maxwidth500');
 		print '</td></tr>';
 
 		if (isModEnabled('knowledgemanagement')) {
@@ -885,6 +885,8 @@ class FormTicket
 			print '<select id="select'.$htmlname.'" class="flat minwidth100'.($morecss ? ' '.$morecss : '').'" name="'.$htmlname.'">';
 			if ($empty) {
 				print '<option value="">&nbsp;</option>';
+			} else {
+				print '<option value="">--&nbsp;'.$langs->trans('TicketSelectGroup').'&nbsp;--</option>';
 			}
 
 			if (is_array($ticketstat->cache_category_tickets) && count($ticketstat->cache_category_tickets)) {
@@ -929,9 +931,9 @@ class FormTicket
 						print ' selected="selected"';
 					} elseif (isset($selected) && $selected == $id) {
 						print ' selected="selected"';
-					} elseif ($arraycategories['use_default'] == "1" && empty($selected)) {
+					} elseif ($arraycategories['use_default'] == "1" && empty($selected) && !$empty) {
 						print ' selected="selected"';
-					} elseif (count($ticketstat->cache_category_tickets) == 1) {	// If only 1 choice, we autoselect it
+					} elseif (count($ticketstat->cache_category_tickets) == 1 && !$empty) {	// If only 1 choice, we autoselect it
 						print ' selected="selected"';
 					}
 
@@ -1238,6 +1240,8 @@ class FormTicket
 		print '<select id="select'.$htmlname.'" class="flat minwidth100'.($morecss ? ' '.$morecss : '').'" name="'.$htmlname.'">';
 		if ($empty) {
 			print '<option value="">&nbsp;</option>';
+		} else {
+			print '<option value="">--&nbsp;'.$langs->trans('TicketSelectSeverity').'&nbsp;--</option>';
 		}
 
 		if (is_array($conf->cache['severity_tickets']) && count($conf->cache['severity_tickets'])) {
@@ -1273,7 +1277,7 @@ class FormTicket
 					print ' selected="selected"';
 				} elseif (isset($selected) && $selected == $id) {
 					print ' selected="selected"';
-				} elseif ($arrayseverities['use_default'] == "1" && empty($selected)) {
+				} elseif ($arrayseverities['use_default'] == "1" && empty($selected) && !$empty) {
 					print ' selected="selected"';
 				}
 

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -152,6 +152,8 @@ ShowAsConversation=Show as conversation list
 MessageListViewType=Show as table list
 ConfirmMassTicketClosingSendEmail=Automatically send emails when closing tickets
 ConfirmMassTicketClosingSendEmailQuestion=Do you want to notify thirdparties when closing these tickets ?
+TicketSelectGroup=Select group
+TicketSelectSeverity=Select severity
 # Ticket card
 Ticket=Ticket
 TicketCard=Ticket card


### PR DESCRIPTION
# FIX select group and severity search fields on ticket list

issue #31619 (indicates 20.0, but I encountered it also on develop)
see also PR #32120 , which is similar but for ticket type, and brings more details.

group and severity must be set when creating/updating a ticket, and have a default value.
However, on search fields, we don't want to set the default value.

This PR sets the default value only if `$empty` is not set.
These are the changes brought by this PR : 

- when $empty is set (case search lists), the empty value is selected
- when $empty value is not set, the default value is selected. If there is no default value, an obviously wrong value ('Select group', 'Select severity') is used.

if no default value : 
![image](https://github.com/user-attachments/assets/b1a3ba24-4527-4091-bc45-23f999bda740)
