### PR TITLE
FIX data too long for column signature

### DIFF
--- a/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
+++ b/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
@@ -384,3 +384,4 @@ INSERT INTO llx_c_type_contact (element, source, code, libelle, active ) values 
 ALTER TABLE llx_facture_rec ADD COLUMN fk_societe_rib integer DEFAULT NULL;
 
 ALTER TABLE llx_facture ADD COLUMN is_also_delivery_note tinyint DEFAULT 0 NOT NULL;
+ALTER TABLE llx_user MODIFY COLUMN signature LONGTEXT;

--- a/htdocs/install/mysql/tables/llx_user.sql
+++ b/htdocs/install/mysql/tables/llx_user.sql
@@ -60,7 +60,7 @@ create table llx_user
   email               varchar(255),
   personal_email      varchar(255),
   email_oauth2        varchar(255),							  -- an email to validate OAuth2 authentication when email differs from the OAuth2 email
-  signature           text DEFAULT NULL,
+  signature           longtext DEFAULT NULL,
 
   socialnetworks      text DEFAULT NULL,                      -- json with socialnetworks
 


### PR DESCRIPTION
FIX data too long for column signature

Some users cannot add their signature banners correctly.
Error message: Data too long for column 'signature' at row 1

Changing TEXT to LONGTEXT for the signature field on llx_user table