### PR TITLE
FIX #31890 store empty line extrafields

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -11,6 +11,7 @@
  * Copyright (C) 2017       Nicolas ZABOURI         <info@inovea-conseil.com>
  * Copyright (C) 2018-2022  Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2022 		Antonin MARCHAL         <antonin@letempledujeu.fr>
+ * Copyright (C) 2024		Joachim Kueter			<git-jk@bloxera.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2415,10 +2416,13 @@ class ExtraFields
 					}
 					$value_key = dol_htmlcleanlastbr(GETPOST($keysuffix."options_".$key.$keyprefix, 'restricthtml'));
 				} else {
-					if (!GETPOST($keysuffix."options_".$key.$keyprefix)) {
+					if (!GETPOSTISSET($keysuffix."options_".$key.$keyprefix)) {
 						continue; // Value was not provided, we should not set it.
 					}
 					$value_key = GETPOST($keysuffix."options_".$key.$keyprefix);
+    				if ($value_key === '') {
+        				$value_key = null;
+    				}
 				}
 
 				$array_options[$keysuffix."options_".$key] = $value_key; // No keyprefix here. keyprefix is used only for read.

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2420,9 +2420,9 @@ class ExtraFields
 						continue; // Value was not provided, we should not set it.
 					}
 					$value_key = GETPOST($keysuffix."options_".$key.$keyprefix);
-    				if ($value_key === '') {
-        				$value_key = null;
-    				}
+					if ($value_key === '') {
+						$value_key = null;
+					}
 				}
 
 				$array_options[$keysuffix."options_".$key] = $value_key; // No keyprefix here. keyprefix is used only for read.


### PR DESCRIPTION
If a line extrafield had originally some contents, after deleting it and submitting it as empty, the extrafield was not stored but the original contents kept

The issue was detected in offer lines, but it appears in lines of all business elements (orders, invoices etc.) This fix corrects the root cause of the issue for all occurrences. (Note: the original pull request #32148 to only fix offers was closed.)