### PR TITLE
FIX #32178: repair.php: fix missing 'as' with Postgres

### DIFF
--- a/htdocs/install/mysql/migration/repair.sql
+++ b/htdocs/install/mysql/migration/repair.sql
@@ -410,7 +410,7 @@ drop table tmp_c_shipment_mode;
 
 -- Restore id of user on link for payment of expense report
 drop table tmp_bank_url_expense_user;
-create table tmp_bank_url_expense_user (select e.fk_user_author, bu2.fk_bank from llx_expensereport as e, llx_bank_url as bu2 where bu2.url_id = e.rowid and bu2.type = 'payment_expensereport');
+create table tmp_bank_url_expense_user as (select e.fk_user_author, bu2.fk_bank from llx_expensereport as e, llx_bank_url as bu2 where bu2.url_id = e.rowid and bu2.type = 'payment_expensereport');
 update llx_bank_url as bu set url_id = (select e.fk_user_author from tmp_bank_url_expense_user as e where e.fk_bank = bu.fk_bank) where (bu.url_id = 0 OR bu.url_id IS NULL) and bu.type ='user';
 drop table tmp_bank_url_expense_user;
 


### PR DESCRIPTION
# FIX #32178 repair.php: fix missing 'as' with Postgres

Fix the following SQL error when executing the repair script on 19.0.x and above.

        Error DB_ERROR_SYNTAX (Req 159): create table tmp_bank_url_expense_user (select e.fk_user_author, bu2.fk_bank from llx_expensereport as e, llx_bank_url as bu2 where bu2.url_id = e.rowid and bu2.type = 'payment_expensereport');
        ERROR: 42601: syntax error at or near "select" LINE 1: create table tmp_bank_url_expense_user (select e.fk_user_aut... ^ LOCATION: scanner_yyerror, scan.l:1145