### PR TITLE
brute attempt at getting an event log for whenever a document was downloaded using the public hashp url

### DIFF
--- a/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
+++ b/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
@@ -87,6 +87,9 @@ class InterfaceActionsAuto extends DolibarrTriggers
 			return 0;
 		}
 
+		// 2024-11-30 by JonB: to get further I have configured this 'key' even though I had inserted it into llx_c_action_trigger
+		// configured in Home, Setup, Other Setup MAIN_AGENDA_ACTIONAUTO_ECMFILES_FETCH_HASHP = 1
+		// also INSERT INTO `llx_c_action_trigger` (`rowid`, `elementtype`, `code`, `contexts`, `label`, `description`, `rang`) VALUES (NULL, 'ecm', 'ECMFILES_FETCH_HASHP', '', 'Public file download', 'File downloaded using hashp value', '666');
 		$key = 'MAIN_AGENDA_ACTIONAUTO_'.$action;
 		//var_dump($action.' - '.$key.' - '.$conf->global->$key);exit;
 
@@ -230,6 +233,25 @@ class InterfaceActionsAuto extends DolibarrTriggers
 
 			// Parameters $object->sendtoid defined by caller
 			//$object->sendtoid = array();
+		} elseif ($action == 'ECMFILES_FETCH_HASHP') {
+			'@phan-var-force ECM $object';
+
+			$object->id = $object->src_object_id;
+			$object->element = $object->src_object_type;
+			$actionmsgStatic = "Public file download ".$object->filename;
+
+			if (empty($object->actionmsg2)) {
+				if (empty($object->context['actionmsg2'])) {
+					$object->actionmsg2 = $actionmsgStatic;
+				} else {
+					$object->actionmsg2 = $actionmsgStatic;
+				}
+			}
+			if (empty($object->actionmsg)) {
+				$object->actionmsg = $actionmsgStatic;
+			}
+
+			$object->sendtoid = array();
 		} elseif ($action == 'PROPAL_VALIDATE') {
 			'@phan-var-force Propal $object';
 			// Load translation files required by the page

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -532,6 +532,20 @@ class EcmFiles extends CommonObject
 
 			// $this->fetch_lines();
 
+			// Triggers
+			if (!$error && !$notrigger) {
+				// Call triggers
+				if (!empty($hashforshare)) {
+					$emptyUserObject = new user($this->db);
+					$result = $this->call_trigger(strtoupper(get_class($this)).'_FETCH_HASHP', $emptyUserObject);
+					// $this->call_trigger requires an User Object
+					if ($result < 0) {
+						$error++;
+					} //Do also here what you must do to rollback action if trigger fail
+				}
+				// End call triggers
+            }
+
 			$this->db->free($resql);
 
 			if ($numrows) {


### PR DESCRIPTION
brute attempt at getting an event log for whenever a document was downloaded using the public hashp url

We talked about it during international devcamp 2024 in Munich and it might not be the best idea to actually log this, because if someone downloads it 47238947213 then there could be a denial of service access to Dolibarr since Dolibarr might not like it has to load 47238947213 events on page load.


![image](https://github.com/user-attachments/assets/b14e4531-a0fe-40d7-9332-141d10be61ae)

I've decided to commit it anyway in case someone wanted to build upon it or search for words like the title above, but other than that I'll close the pull request.