### PR TITLE
FIX Accounting Closure Duplicates, Subledger accounts, Account Labels and more... Update bookkeeping.class.php

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -2798,10 +2798,10 @@ class BookKeeping extends CommonObject
 						$bookkeeping = new BookKeeping($this->db);
 						$bookkeeping->doc_date = $new_fiscal_period->date_start;
 						$bookkeeping->date_lim_reglement = '';
-						$bookkeeping->doc_ref = $new_fiscal_period->label;
+						$bookkeeping->doc_ref = $fiscal_period->label;
 						$bookkeeping->date_creation = $now;
 						$bookkeeping->doc_type = 'closure';
-						$bookkeeping->fk_doc = $new_fiscal_period->id;
+						$bookkeeping->fk_doc = $fiscal_period->id;
 						$bookkeeping->fk_docdet = 0; // Useless, can be several lines that are source of this record to add
 						$bookkeeping->thirdparty_code = '';
 

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2015-2022  Alexandre Spangaro  <aspangaro@open-dsi.fr>
  * Copyright (C) 2015-2020  Florian Henry       <florian.henry@open-concept.pro>
  * Copyright (C) 2018-2020  Frédéric France     <frederic.france@netlogic.fr>
+ * Copyright (C) 2024		Jose MARTINEZ	    <jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2748,9 +2749,9 @@ class BookKeeping extends CommonObject
 								$sql .= " LIMIT 1";
 								$result = $this->db->query($sql);
 								if (!$result) {
-    								$this->errors[] = 'Error: ' . $this->db->lasterror();
-    								dol_syslog(__METHOD__ . ' ' . join(',', $this->errors), LOG_ERR);
-    								$error++;
+									$this->errors[] = 'Error: ' . $this->db->lasterror();
+									dol_syslog(__METHOD__ . ' ' . join(',', $this->errors), LOG_ERR);
+									$error++;
 								}
 								$objtmp = $this->db->fetch_object($result);
 								$bookkeeping->subledger_label = $objtmp->subledger_label; // latest subledger label used
@@ -2810,9 +2811,9 @@ class BookKeeping extends CommonObject
 							$sql .= " LIMIT 1";
 							$result = $this->db->query($sql);
 							if (!$result) {
-    							$this->errors[] = 'Error: ' . $this->db->lasterror();
-    							dol_syslog(__METHOD__ . ' ' . join(',', $this->errors), LOG_ERR);
-    							$error++;
+								$this->errors[] = 'Error: ' . $this->db->lasterror();
+								dol_syslog(__METHOD__ . ' ' . join(',', $this->errors), LOG_ERR);
+								$error++;
 							}
 							$objtmp = $this->db->fetch_object($result);
 							$bookkeeping->subledger_label = $objtmp->subledger_label; // latest subledger label used

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -27,6 +27,7 @@
 
 // Class
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/commonobjectline.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/fiscalyear.class.php';
 require_once DOL_DOCUMENT_ROOT.'/accountancy/class/accountingjournal.class.php';
 require_once DOL_DOCUMENT_ROOT.'/accountancy/class/accountingaccount.class.php';
@@ -328,7 +329,7 @@ class BookKeeping extends CommonObject
 		$this->piece_num = 0;
 
 		// First check if line not yet already in bookkeeping.
-		// Note that we must include 'doc_type - fk_doc - numero_compte - label' to be sure to have unicity of line (because we may have several lines
+		// Note that we must include 'doc_type - fk_doc - numero_compte - label - subledger_account (if not empty)' to be sure to have unicity of line (because we may have several lines
 		// with same doc_type, fk_doc, numero_compte for 1 invoice line when using localtaxes with same account)
 		// WARNING: This is not reliable, label may have been modified. This is just a small protection.
 		// The page that make transfer make the test on couple (doc_type - fk_doc) only.
@@ -342,6 +343,9 @@ class BookKeeping extends CommonObject
 		}
 		$sql .= " AND numero_compte = '".$this->db->escape($this->numero_compte)."'";
 		$sql .= " AND label_operation = '".$this->db->escape($this->label_operation)."'";
+		if (!empty($this->subledger_account)) {
+			$sql .= " AND subledger_account = '".$this->db->escape($this->subledger_account)."'";
+		}
 		$sql .= " AND entity = ".$conf->entity; // Do not use getEntity for accounting features
 
 		$resql = $this->db->query($sql);


### PR DESCRIPTION
FIX I did further testing and investigation and I fixed the following issues that stop doing a full closure without duplicate lines generated by an unclean database :

    - different label_compte with same account number
    - removing label_compte is raising an issue and the code in the line around 2770 $bookkeeping->label_compte = $obj->label_compte;
    - different subledger_label with same subledger_account
    - empty versus null values for subledger_label and subledger_account
    - opening_balance is 0 as it creates a bookkeeping entry for now.  



See other comments here on this draft: https://github.com/Dolibarr/dolibarr/pull/30653
See also Fix required here : FIX - Update Accounting closure with missing too many A-Nouveau #30039)](https://github.com/Dolibarr/dolibarr/pull/30039)