### PR TITLE
Ignore .htaccess files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ phpstan_custom.neon
 /.php-cs-fixer.cache
 /.php_cs.cache
 /.cache
+
+# ignore .htaccess files
+.htaccess


### PR DESCRIPTION
If the Dolibarr installation is accessible after an HTTP Auth via .htaccess files, we must add a .htaccess files in the /htdocs/public directory to disable the HTTP Auth on public pages.
This kind of file is currently not ignored by git