### PR TITLE
Fix for incorrect total time calculation in project overview tab

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1193,6 +1193,7 @@ foreach ($listofreferent as $key => $value) {
 			}
 
 			$num = count($elementarray);
+			$total_time = 0;
 			for ($i = 0; $i < $num; $i++) {
 				$tmp = explode('_', $elementarray[$i]);
 				$idofelement = $tmp[0];
@@ -1310,7 +1311,7 @@ foreach ($listofreferent as $key => $value) {
 				print "</td>\n";
 
 				// Date or TimeSpent
-				$date = ''; $total_time_by_line = null; $total_time = 0;
+				$date = ''; $total_time_by_line = null;
 				if ($tablename == 'expensereport_det') {
 					$date = $element->date; // No draft status on lines
 				} elseif ($tablename == 'stock_mouvement') {


### PR DESCRIPTION

# Fix for incorrect total time calculation in project overview tab
Hello everyone,

I have created a pull request to fix an issue in the project overview tab related to the calculation of total_time.

Previously, the total_time variable was declared inside a for loop, causing it to be reset to 0 at each iteration rather than accumulating the total across all rows. In my fix, I moved the declaration and initialization of total_time outside the loop to ensure the sum is correctly calculated for all lines.

This adjustment resolves the incorrect total displayed in the overview.

Feel free to review and provide feedback on the pull request. Looking forward to your input!

Best regards,