### PR TITLE
Ticket : don't autofill search field for ticket type on multiselect

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -716,7 +716,7 @@ class FormTicket
 		$ticketstat->loadCacheTypesTickets();
 
 		print '<select id="select'.$htmlname.'" class="flat minwidth100'.($morecss ? ' '.$morecss : '').'" name="'.$htmlname.($multiselect?'[]':'').'"'.($multiselect?' multiple':'').'>';
-		if ($empty) {
+		if ($empty && !$multiselect) {
 			print '<option value="">&nbsp;</option>';
 		}
 
@@ -753,7 +753,7 @@ class FormTicket
 					print ' selected="selected"';
 				} elseif (in_array($id, $selected)) {
 					print ' selected="selected"';
-				} elseif ($arraytypes['use_default'] == "1" && empty($selected)) {
+				} elseif ($arraytypes['use_default'] == "1" && empty($selected) && !$multiselect) {
 					print ' selected="selected"';
 				}
 


### PR DESCRIPTION
# FIX Select type on ticket list
 See issue https://github.com/Dolibarr/dolibarr/issues/31619

Problem 1 : when going to the ticket list, the search field for ticket type is filled with the default value, even if we do not want it. So we have to remove it manually for each search.
![image](https://github.com/user-attachments/assets/c0608213-0acb-41b7-bf4a-09305def3a5c)

Problem 2 : the empty value is available for the multiselect. Is should not be (moreover, it triggers an SQL error when chosen).
![image](https://github.com/user-attachments/assets/031e8cf8-a245-4361-a0d8-7a8be9fe79e2)

This PR fixes both problems.


