### PR TITLE
FIX Missing trigger on situation invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2050,7 +2050,7 @@ if (empty($reshook)) {
 					$extrafields->fetch_name_optionals_label($nextSituationInvoice->table_element);
 					$ret = $extrafields->setOptionalsFromPost(null, $nextSituationInvoice);
 					if ($ret > 0) {
-						$nextSituationInvoice->insertExtraFields();
+						$nextSituationInvoice->insertExtraFields('BILL_CREATE');
 					}
 
 					// Hooks


### PR DESCRIPTION
# FIX | Missing trigger on invoice situation creation
Missing trigger on invoice situation creation for allow action on extrafields

