### PR TITLE
# NEW| Added a configuration option for the propagation to variants

### DIFF
--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -432,3 +432,4 @@ ConfirmEditExtrafield = Select the extrafield you want modify
 ConfirmEditExtrafieldQuestion = Are you sure you want to modify this extrafield?
 ModifyValueExtrafields = Modify value of an extrafield
 OrProductsWithCategories=Or products with tags/categories
+AlwaysPropagateToVariants = Always propagate the modifications to the variants

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -432,3 +432,4 @@ ConfirmEditExtrafield = Sélectionnez l'extrafield que vous souhaitez modifier
 ConfirmEditExtrafieldQuestion = Voulez-vous vraiment modifier cet extrafield ?
 ModifyValueExtrafields = Modifier la valeur d'un extrafield
 OrProductsWithCategories=Ou des produits avec des tags/catégories
+AlwaysPropagateToVariants = Toujours propager les modifications aux variantes

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1348,7 +1348,7 @@ class Product extends CommonObject
 				}
 
 				if (!$error) {
-					if (isModEnabled('variants')) {
+					if (isModEnabled('variants') && getDolGlobalString('PRODUIT_ATTRIBUTES_PROPAGATE', 1)) {
 						include_once DOL_DOCUMENT_ROOT.'/variants/class/ProductCombination.class.php';
 
 						$comb = new ProductCombination($this->db);

--- a/htdocs/variants/admin/admin.php
+++ b/htdocs/variants/admin/admin.php
@@ -50,6 +50,11 @@ if ($action) {
 		$error++;
 	}
 
+	if (!dolibarr_set_const($db, 'PRODUIT_ATTRIBUTES_PROPAGATE', GETPOST('PRODUIT_ATTRIBUTES_PROPAGATE'), 'chaine', 0, '', $conf->entity)) {
+		setEventMessages($langs->trans('CoreErrorMessage'), null, 'errors');
+		$error++;
+	}
+
 	if (!$error) {
 		setEventMessages($langs->trans('RecordSaved'), null, 'mesgs');
 	}
@@ -82,6 +87,10 @@ if (isset($conf->global->PRODUIT_ATTRIBUTES_SEPARATOR)) {
 	$separator = "_";
 }
 print '<td class="right"><input size="3" type="text" class="flat" name="PRODUIT_ATTRIBUTES_SEPARATOR" value="'.$separator.'"></td></tr>';
+
+
+print '<tr class="oddeven"><td>'.$langs->trans('AlwaysPropagateToVariants').'</td>';
+print '<td>'. $form->selectyesno("PRODUIT_ATTRIBUTES_PROPAGATE", getDolGlobalString('PRODUIT_ATTRIBUTES_PROPAGATE', '1'), 1).'</td></tr>';
 
 print '</table>';
 


### PR DESCRIPTION
The propagation of modifications to variant products is automatic, but there are legit cases where you don't want to propagation to occur.
> Example: The status of a parent product should be "not for sale" while the variants are "for sale"

This adds an option in the configuration of the module to prevent the propagation from occurring.