### PR TITLE
Added new error message for CRON createRecurringInvoice

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -1395,6 +1395,7 @@ class FactureRec extends CommonInvoice
 					$nb_create++;
 					$this->output .= $langs->trans("InvoiceGeneratedFromTemplate", $facture->ref, $facturerec->ref)."\n";
 				} else {
+					$this->output .= $langs->trans("InvoiceGeneratedFromTemplateError", $facture->ref, $facturerec->ref, $this->error)."\n";
 					$this->db->rollback("createRecurringInvoices Process invoice template id=".$facturerec->id.", ref=".$facturerec->ref);
 				}
 

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -404,6 +404,7 @@ InvoiceAutoValidate=Validate invoices automatically
 GeneratedFromRecurringInvoice=Generated from template recurring invoice %s
 DateIsNotEnough=Date not reached yet
 InvoiceGeneratedFromTemplate=Invoice %s generated from recurring template invoice %s
+InvoiceGeneratedFromTemplateError=Error Invoice %s generated from recurring template invoice %s : %s
 GeneratedFromTemplate=Generated from template invoice %s
 WarningInvoiceDateInFuture=Warning, the invoice date is higher than current date
 WarningInvoiceDateTooFarInFuture=Warning, the invoice date is too far from current date


### PR DESCRIPTION
# FIX|Fix Missing error message
I've added a new error message for createRecurringInvoice cron with $this->error