### PR TITLE
fix:  FATAL ERROR (php 8, invoice situation=2) Invoice line Save after edit (even if invoice is STANDARD)

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2742,7 +2742,7 @@ if (empty($reshook)) {
 		// Invoice situation
 		if (getDolGlobalInt('INVOICE_USE_SITUATION') == 2) {
 			$previousprogress = $line->get_allprev_progress($line->fk_facture);
-			$fullprogress = price2num(GETPOST('progress', 'alpha'));
+			$fullprogress = price2num(GETPOST('progress', 'alpha'), 'MU');
 
 			if ($fullprogress < $previousprogress) {
 				$error++;

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2742,7 +2742,7 @@ if (empty($reshook)) {
 		// Invoice situation
 		if (getDolGlobalInt('INVOICE_USE_SITUATION') == 2) {
 			$previousprogress = $line->get_allprev_progress($line->fk_facture);
-			$fullprogress = price2num(GETPOST('progress', 'alpha'), 'MU');
+			$fullprogress = price2num(GETPOST('progress', 'alpha'), 2);
 
 			if ($fullprogress < $previousprogress) {
 				$error++;


### PR DESCRIPTION
On standard invoice

Edit invoice lline on std invoice trigger Fatal Error if INVOICE_USE_SITUATION=2 (as the invoice is not a situation invoice)

as $fullprogress = price2num() return '' 

![image](https://github.com/user-attachments/assets/f32857c3-2487-41b7-b3e4-cc13f55b574c)

![image](https://github.com/user-attachments/assets/924c6daf-9ad8-44e4-9a35-6f7d5c488f47)

