### PR TITLE
Fix setup color in display mode

### DIFF
--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -1317,12 +1317,21 @@ class FormSetupItem
 	public function generateOutputFieldColor()
 	{
 		global $langs;
+		$out = '';
 		$this->fieldAttr['disabled'] = null;
 		$color = colorArrayToHex(colorStringToArray($this->fieldValue, array()), '');
-		if ($color) {
-			return '<input type="text" class="colorthumb" disabled="disabled" style="padding: 1px; margin-top: 0; margin-bottom: 0; background-color: #'.$color.'" value="'.$color.'">';
+		$useDefaultColor = false;
+		if (!$color && !empty($this->defaultFieldValue)) {
+			$color = $this->defaultFieldValue;
+			$useDefaultColor = true;
 		}
-		return $langs->trans("Default");
+		if ($color) {
+			$out.= '<input type="color" class="colorthumb" disabled="disabled" style="padding: 1px; margin-top: 0; margin-bottom: 0; " value="#'.$color.'">';
+		}
+
+		if ($useDefaultColor) $out.= ' '.$langs->trans("Default");
+
+		return $out;
 	}
 	/**
 	 * generateInputFieldColor

--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -1329,7 +1329,11 @@ class FormSetupItem
 			$out.= '<input type="color" class="colorthumb" disabled="disabled" style="padding: 1px; margin-top: 0; margin-bottom: 0; " value="#'.$color.'">';
 		}
 
-		if ($useDefaultColor) $out.= ' '.$langs->trans("Default");
+		if ($useDefaultColor) {
+			$out.= ' '.$langs->trans("Default");
+		} else {
+			$out.= ' #'.$color;
+		}
 
 		return $out;
 	}


### PR DESCRIPTION
# FIX setup color in display mode

color item display is broken 

this patch restore old V16 display method but using V20 type of color data.

## Before patch 
![image](https://github.com/user-attachments/assets/de0bfa5d-962e-4af2-90be-80d07cac3145)
![image](https://github.com/user-attachments/assets/2f6cad74-2328-4b13-8197-35692251f3cc)


## After patch
![image](https://github.com/user-attachments/assets/af3c0e0a-9e58-4ba2-9240-e6715644debe)
![image](https://github.com/user-attachments/assets/13f4ecaa-ce14-4c43-ba1c-3f98ca1cc312)
