### PR TITLE
fix: missing error return on invoice created when lines array is filled

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -863,8 +863,8 @@ class Facture extends CommonInvoice
 						);
 
 						if ($result < 0) {
-							$this->error = $this->db->lasterror();
-							$this->errors = array_merge($this->errors, $newinvoiceline->errors);
+							$this->error = $newinvoiceline->error;
+							$this->errors = $newinvoiceline->errors;
 							$error++;
 							break;
 						}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -862,16 +862,17 @@ class Facture extends CommonInvoice
 							1
 						);
 
+						if ($result < 0) {
+							$this->error = $this->db->lasterror();
+							$this->errors = array_merge($this->errors, $newinvoiceline->errors);
+							$error++;
+							break;
+						}
+
 						// Defined the new fk_parent_line
 						if ($result > 0 && $newinvoiceline->product_type == 9) {
 							$fk_parent_line = $result;
 						}
-					}
-					if ($result < 0) {
-						$this->error = $newinvoiceline->error;
-						$this->errors = $newinvoiceline->errors;
-						$error++;
-						break;
 					}
 				}
 			} elseif (!$error && empty($this->fac_rec)) { 		// If this->lines is an array of invoice line arrays

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -864,7 +864,7 @@ class Facture extends CommonInvoice
 
 						if ($result < 0) {
 							$this->error = $newinvoiceline->error;
-							$this->errors = $newinvoiceline->errors;
+							$this->errors = array_merge($this->errors, $newinvoiceline->errors);
 							$error++;
 							break;
 						}


### PR DESCRIPTION
actually, 
the test 
`if ($result < 0) {`
is outside the loop of 
```
foreach ($this->lines as $i => $val) { 
...
$result  = $this->addline
...
}
```

So if one insert rows fails, the process continue and do not return the failed insert error, because may be next lines are added.


