### PR TITLE
Fix/130/remove dol syslog throws

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1658,8 +1658,11 @@ function dol_syslog($message, $level = LOG_INFO, $ident = 0, $suffixinfilename =
 	if (!empty($message)) {
 		// Test log level
 		$logLevels = array(LOG_EMERG=>'EMERG', LOG_ALERT=>'ALERT', LOG_CRIT=>'CRITICAL', LOG_ERR=>'ERR', LOG_WARNING=>'WARN', LOG_NOTICE=>'NOTICE', LOG_INFO=>'INFO', LOG_DEBUG=>'DEBUG');
+		$defaultLogLevel = getDolGlobalInt('DEFAULT_SYSLOG_LEVEL', $logLevels[LOG_ERR]);
+
 		if (!array_key_exists($level, $logLevels)) {
-			throw new Exception('Incorrect log level');
+			dol_syslog('The given log level does not correspond to any of the available levels: '.$level, LOG_ERR);
+			$level = $defaultLogLevel;
 		}
 		if ($level > $conf->global->SYSLOG_LEVEL) {
 			return;

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1627,7 +1627,7 @@ function dol_ucwords($string, $encoding = "UTF-8")
  */
 function dol_syslog($message, $level = LOG_INFO, $ident = 0, $suffixinfilename = '', $restricttologhandler = '', $logcontext = null)
 {
-	global $conf, $user, $debugbar;
+	global $conf, $user, $debugbar, $langs;
 
 	// If syslog module enabled
 	if (empty($conf->syslog->enabled)) {
@@ -1658,11 +1658,10 @@ function dol_syslog($message, $level = LOG_INFO, $ident = 0, $suffixinfilename =
 	if (!empty($message)) {
 		// Test log level
 		$logLevels = array(LOG_EMERG=>'EMERG', LOG_ALERT=>'ALERT', LOG_CRIT=>'CRITICAL', LOG_ERR=>'ERR', LOG_WARNING=>'WARN', LOG_NOTICE=>'NOTICE', LOG_INFO=>'INFO', LOG_DEBUG=>'DEBUG');
-		$defaultLogLevel = getDolGlobalInt('DEFAULT_SYSLOG_LEVEL', $logLevels[LOG_ERR]);
 
 		if (!array_key_exists($level, $logLevels)) {
-			dol_syslog('The given log level does not correspond to any of the available levels: '.$level, LOG_ERR);
-			$level = $defaultLogLevel;
+			dol_syslog($langs->trans('ErrorBadLogLevel', $level), LOG_ERR);
+			$level = getDolGlobalInt('DEFAULT_SYSLOG_LEVEL', $logLevels[LOG_ERR]);
 		}
 		if ($level > $conf->global->SYSLOG_LEVEL) {
 			return;

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -155,6 +155,7 @@ ErrorPHPNeedModule=Error, your PHP must have module <b>%s</b> installed to use t
 ErrorOpenIDSetupNotComplete=You setup Dolibarr config file to allow OpenID authentication, but URL of OpenID service is not defined into constant %s
 ErrorWarehouseMustDiffers=Source and target warehouses must differs
 ErrorBadFormat=Bad format!
+ErrorBadLogLevel=The given log level does not correspond to any of the available levels: %s
 ErrorMemberNotLinkedToAThirpartyLinkOrCreateFirst=Error, this member is not yet linked to any third party. Link member to an existing third party or create a new third party before creating subscription with invoice.
 ErrorThereIsSomeDeliveries=Error, there is some deliveries linked to this shipment. Deletion refused.
 ErrorCantDeletePaymentReconciliated=Can't delete a payment that had generated a bank entry that was reconciled


### PR DESCRIPTION
# Qual | Dol_Syslog must not throws error 

Currently, the dol_syslog function can throw errors if the provided log level is invalid. Since this function is itself called in case of an error to populate error and debug logs, it should not be capable of raising errors, as this could lead to blocking situations.

I have therefore modified the behavior of the throw to retrieve a default log level from the database via the `ErrorBadLogLevel` configuration if it exists, or use the `LOG_ERR` level otherwise.

This way, the log can still be displayed, and the user will be informed that the initial log level is incorrect through a recursive call to the function itself to convey this information.


