### PR TITLE
Fix:  accountancy import for FEC files

### DIFF
--- a/htdocs/accountancy/class/accountancyimport.class.php
+++ b/htdocs/accountancy/class/accountancyimport.class.php
@@ -136,7 +136,7 @@ class AccountancyImport
 				$sens = 'C';
 			}
 
-			return "'" . $this->db->escape($sens) . "'";
+			return $sens;
 		}
 
 		return "''";


### PR DESCRIPTION
When importing FEC files the value for column sens is double escaped ( `'\'D\''`) even when the value is determined in the same method `computeDirection` which creates an error on the IMPORT query.

Removing the escape quotes the import can proceed successfully.


