### PR TITLE
FIX Asset Module Update to use gmt (versus tz) everywhere to avoid time/calculation issues

### DIFF
--- a/htdocs/asset/card.php
+++ b/htdocs/asset/card.php
@@ -132,7 +132,7 @@ if (empty($reshook)) {
 
 	// Action dispose object
 	if ($action == 'confirm_disposal' && $confirm == 'yes' && $permissiontoadd) {
-		$object->disposal_date = dol_mktime(12, 0, 0, GETPOSTINT('disposal_datemonth'), GETPOSTINT('disposal_dateday'), GETPOSTINT('disposal_dateyear')); // for date without hour, we use gmt
+		$object->disposal_date = dol_mktime(0, 0, 0, GETPOSTINT('disposal_datemonth'), GETPOSTINT('disposal_dateday'), GETPOSTINT('disposal_dateyear'), 'gmt'); // for date without hour, we use gmt
 		$object->disposal_amount_ht = GETPOSTINT('disposal_amount');
 		$object->fk_disposal_type = GETPOSTINT('fk_disposal_type');
 		$disposal_invoice_id = GETPOSTINT('disposal_invoice_id');
@@ -273,7 +273,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		// Disposal
 		$langs->load('bills');
 
-		$disposal_date = dol_mktime(12, 0, 0, GETPOSTINT('disposal_datemonth'), GETPOSTINT('disposal_dateday'), GETPOSTINT('disposal_dateyear')); // for date without hour, we use gmt
+		$disposal_date = dol_mktime(0, 0, 0, GETPOSTINT('disposal_datemonth'), GETPOSTINT('disposal_dateday'), GETPOSTINT('disposal_dateyear'), 'gmt'); // for date without hour, we use gmt
 		$disposal_amount = GETPOSTINT('disposal_amount');
 		$fk_disposal_type = GETPOSTINT('fk_disposal_type');
 		$disposal_invoice_id = GETPOSTINT('disposal_invoice_id');

--- a/htdocs/asset/class/assetdepreciationoptions.class.php
+++ b/htdocs/asset/class/assetdepreciationoptions.class.php
@@ -262,7 +262,7 @@ class AssetDepreciationOptions extends CommonObject
 				if (in_array($field_info['type'], array('text', 'html'))) {
 					$value = GETPOST($html_name, 'restricthtml');
 				} elseif ($field_info['type'] == 'date') {
-					$value = dol_mktime(12, 0, 0, GETPOSTINT($html_name . 'month'), GETPOSTINT($html_name . 'day'), GETPOSTINT($html_name . 'year')); // for date without hour, we use gmt
+					$value = dol_mktime(0, 0, 0, GETPOSTINT($html_name . 'month'), GETPOSTINT($html_name . 'day'), GETPOSTINT($html_name . 'year'), 'gmt'); // for date without hour, we use gmt
 				} elseif ($field_info['type'] == 'datetime') {
 					$value = dol_mktime(GETPOSTINT($html_name . 'hour'), GETPOSTINT($html_name . 'min'), GETPOSTINT($html_name . 'sec'), GETPOSTINT($html_name . 'month'), GETPOSTINT($html_name . 'day'), GETPOSTINT($html_name . 'year'), 'tzuserrel');
 				} elseif ($field_info['type'] == 'duration') {


### PR DESCRIPTION
FIX Asset Module issue as already discussed longely in this closed PR:
https://github.com/Dolibarr/dolibarr/pull/31434

card.php and /class/assetdepreciationoptions.class.php

This fix is to avoid issue when using asset starting date that equal to either first or last day of fiscal year.

The solution is to get all the asset module using GMT (versus TZ) everywhere to avoid creating a new function to reset time as the following:
/**
 * Function to reset the time of a date to 00:00:00
 */
private function resetTimeToMidnight($date)
{
    if (!empty($date)) {
        // Assuming $date is a timestamp or string in format compatible with strtotime
        return dol_mktime(0, 0, 0, dol_print_date($date, '%m'), dol_print_date($date, '%d'), dol_print_date($date, '%Y'),'gmt');
    }
    return $date; // Return unchanged if date is empty or null
} 



