### PR TITLE
Add class constants for types of discounts

### DIFF
--- a/htdocs/core/class/discount.class.php
+++ b/htdocs/core/class/discount.class.php
@@ -181,6 +181,12 @@ class DiscountAbsolute extends CommonObject
 	 */
 	public $type_invoice_supplier_source;
 
+	/* Customer Discount */
+	const TYPE_CUSTOMER = 0;
+
+	/* Supplier Discount */
+	const TYPE_SUPPLIER = 1;
+
 	/**
 	 *	Constructor
 	 *


### PR DESCRIPTION
# NEW class constants
This simply adds two constants, DiscountAbsolute::TYPE_CUSTOMER and DiscountAbsolute::TYPE_SUPPLIER.

This PR doesn't include the replacement of the int literals with the constants.
