### PR TITLE
FIX : display error when loan can't be deleted

### DIFF
--- a/htdocs/loan/card.php
+++ b/htdocs/loan/card.php
@@ -82,7 +82,7 @@ if (empty($reshook)) {
 		if ($result > 0) {
 			setEventMessages($langs->trans('LoanPaid'), null, 'mesgs');
 		} else {
-			setEventMessages($loan->error, null, 'errors');
+			setEventMessages($object->error, $object->errors, 'errors');
 		}
 	}
 
@@ -95,7 +95,7 @@ if (empty($reshook)) {
 			header("Location: list.php");
 			exit;
 		} else {
-			setEventMessages($loan->error, null, 'errors');
+			setEventMessages($object->error, $object->errors, 'errors');
 		}
 	}
 

--- a/htdocs/loan/class/loan.class.php
+++ b/htdocs/loan/class/loan.class.php
@@ -308,6 +308,7 @@ class Loan extends CommonObject
 				$accountline->fetch($line_url['fk_bank']);
 				$result = $accountline->delete_urls($user);
 				if ($result < 0) {
+					$this->errors = array_merge($this->errors, [$accountline->error], $accountline->errors);
 					$error++;
 				}
 			}


### PR DESCRIPTION
# FIX On loan, if a payment bank line is conciliated, the loan can't be deleted but there is no error.

Bug seen on DLB 18 and develop. I guess it is also buggy inbetween.

On loan, if a payment bank line is conciliated, the loan can't be deleted.
This is good, but the user should receive an error.

To reproduce :
-  Module loan must be activated 
- a bank account should exist
- create a loan (htdocs/loan/list.php)
- create a payment for this loan
- navigate to the bank line related to the payment
- Reconciliate the bank line by entering any account statement.
- now try to delete the loan :
    - the loan is not deleted
    - you don't get any error

This PR makes the error visible in the webUI.