### PR TITLE
Fix #32365 Warning: Attempt to read property datepaye on string

### DIFF
--- a/htdocs/core/modules/supplier_payment/mod_supplier_payment_brodator.php
+++ b/htdocs/core/modules/supplier_payment/mod_supplier_payment_brodator.php
@@ -139,7 +139,7 @@ class mod_supplier_payment_brodator extends ModeleNumRefSupplierPayments
 			return 0;
 		}
 
-		$numFinal = get_next_value($db, $mask, 'paiementfourn', 'ref', '', $objsoc, $object->datepaye);
+		$numFinal = get_next_value($db, $mask, 'paiementfourn', 'ref', '', $objsoc, is_object($object) ?$object->datepaye :'');
 
 		return  $numFinal;
 	}


### PR DESCRIPTION
Fix the warning Warning: Attempt to read property datepaye on string that can be seen on the provider module configuration.