### PR TITLE
FIX #32376: lettering: fix ifsql() called with invalid $check parameter

### DIFF
--- a/htdocs/accountancy/class/lettering.class.php
+++ b/htdocs/accountancy/class/lettering.class.php
@@ -781,12 +781,12 @@ class Lettering extends BookKeeping
 			} else {
 				$sql = "SELECT DISTINCT tl2.fk_link, tl2.fk_doc";
 				$sql .= " FROM (";
-				$sql .= "   SELECT DISTINCT " . $this->db->ifsql("tll." . $linked_info['fk_table_link_line_parent'],  "tll." . $linked_info['fk_table_link_line_parent'],  "tl." . $linked_info['fk_link']) . " AS fk_link, tl." . $linked_info['fk_doc'] . " AS fk_doc";
+				$sql .= "   SELECT DISTINCT " . $this->db->ifsql("tll." . $linked_info['fk_table_link_line_parent']." IS NOT NULL",  "tll." . $linked_info['fk_table_link_line_parent'],  "tl." . $linked_info['fk_link']) . " AS fk_link, tl." . $linked_info['fk_doc'] . " AS fk_doc";
 				$sql .= "   FROM " . MAIN_DB_PREFIX . $linked_info['table'] . " AS tl";
 				$sql .= "   LEFT JOIN " . MAIN_DB_PREFIX . $linked_info['table_link_line'] . " AS tll ON tll." . $linked_info['fk_table_link_line'] . " = tl." . $linked_info['fk_line_link'];
 				$sql .= ") AS tl";
 				$sql .= " LEFT JOIN (";
-				$sql .= "   SELECT DISTINCT " . $this->db->ifsql("tll." . $linked_info['fk_table_link_line_parent'],  "tll." . $linked_info['fk_table_link_line_parent'],  "tl." . $linked_info['fk_link']) . " AS fk_link, tl." . $linked_info['fk_doc'] . " AS fk_doc";
+				$sql .= "   SELECT DISTINCT " . $this->db->ifsql("tll." . $linked_info['fk_table_link_line_parent']." IS NOT NULL",  "tll." . $linked_info['fk_table_link_line_parent'],  "tl." . $linked_info['fk_link']) . " AS fk_link, tl." . $linked_info['fk_doc'] . " AS fk_doc";
 				$sql .= "   FROM " . MAIN_DB_PREFIX . $linked_info['table'] . " AS tl";
 				$sql .= "   LEFT JOIN " . MAIN_DB_PREFIX . $linked_info['table_link_line'] . " AS tll ON tll." . $linked_info['fk_table_link_line'] . " = tl." . $linked_info['fk_line_link'];
 				$sql .= ") AS tl2 ON tl2.fk_link = tl.fk_link";


### PR DESCRIPTION
# FIX #32376: lettering: fix ifsql() called with invalid $check parameter

The $check is supposed to be a check retuning a boolean. By being an `if (value)` check instead of being an `if (value IS NOT NULL)` check, postgresql complains the types are not correct:

        Error ERROR: 42804: argument of CASE/WHEN must be type boolean,
        not type integer LINE 1: ...k, tl2.fk_doc FROM ( SELECT DISTINCT
        (CASE WHEN tll.fk_fac... ^ LOCATION: coerce_to_boolean,
        parse_coerce.c:1176

Regression from commit cfc162a31d6f2a3570cacad3d3fef5cd8e756767.