### PR TITLE
Fix wrong bank journal when using FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS

### DIFF
--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -158,6 +158,7 @@ if ($in_bookkeeping == 'already') {
 if ($in_bookkeeping == 'notyet') {
 	$sql .= " AND (b.rowid NOT IN (SELECT fk_doc FROM ".MAIN_DB_PREFIX."accounting_bookkeeping as ab  WHERE ab.doc_type='bank') )";
 }
+$sql .= " GROUP BY b.rowid";
 $sql .= " ORDER BY b.datev";
 //print $sql;
 
@@ -356,7 +357,7 @@ if ($result) {
 					$paymentsupplierstatic->ref = $links[$key]['url_id'];
 					$tabpay[$obj->rowid]["lib"] .= ' '.$paymentsupplierstatic->getNomUrl(2);
 					$tabpay[$obj->rowid]["paymentsupplierid"] = $paymentsupplierstatic->id;
-				} elseif ($links[$key]['type'] == 'company') {
+				} elseif ($links[$key]['type'] == 'company' && $links[$key]['url_id'] == $obj->socid) {
 					$societestatic->id = $links[$key]['url_id'];
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];


### PR DESCRIPTION
When we use this optiion "FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS" if the same payment groups the invoices of several subsidiaries (same parent company) thanks to this option, the transfer of the bank journal becomes crazy! The amount proposed for the bank's accounting account is equal to the amount paid multiplied by the number of subsidiaries included. The amount proposed for the subsidiaries' accounting account is equal to the amount paid multiplied by the number of subsidiaries included and by the number of different invoices for each subsidiary.

This patch is very partial, it only allows to quickly unblock the blockage observed by proposing the transfer to accounting of the correct amounts for the bank account and the subsidiary having carried out the monetary flow.

A resumption of this option is necessary to make it usable in compliance with the accounting rules!