### PR TITLE
NEW Make ticket linked files accessible from ticket public interface

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3478,6 +3478,7 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		if ($fuser->hasRight('ticket', $read)) {
 			$accessallowed = 1;
 		}
+		$email_split = explode('@', $_SESSION['email_customer']);
 		// include_once DOL_DOCUMENT_ROOT.'/ticket/class/ticket.class.php';
 		$sqlprotectagainstexternals = 'WITH tickets_roles (rowid) AS (SELECT rowid FROM '.MAIN_DB_PREFIX.'c_type_contact WHERE element = "ticket")';
 		$sqlprotectagainstexternals.= ' SELECT t.rowid, t.fk_soc FROM '.MAIN_DB_PREFIX.'ticket t';
@@ -3486,9 +3487,9 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		$sqlprotectagainstexternals.= ' LEFT JOIN tickets_roles tr ON tr.rowid = ec.fk_c_type_contact';
 		$sqlprotectagainstexternals.= ' WHERE t.ref LIKE "'.$db->sanitize($refname).'"';
 		$sqlprotectagainstexternals.= ' AND (';
-		$sqlprotectagainstexternals.= ' (tr.rowid IS NOT NULL AND c.email = "'.$db->escape($_SESSION['email_customer']).'")';
+		$sqlprotectagainstexternals.= ' (tr.rowid IS NOT NULL AND c.email = "'.$db->sanitize($email_split[0]).'@'.$db->sanitize($email_split[1]).'")';
 		if (isset($_SESSION['email_customer'])) {
-			$sqlprotectagainstexternals.= ' OR t.origin_email = "'.$db->escape($_SESSION['email_customer']).'"';
+			$sqlprotectagainstexternals.= ' OR t.origin_email = "'.$db->sanitize($email_split[0]).'@'.$db->sanitize($email_split[1]).'"';
 		}
 		$sqlprotectagainstexternals.= ')';
 		$original_file = $conf->ticket->multidir_output[$entity].'/'.$original_file;

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -14116,10 +14116,11 @@ function getActionCommEcmList($object)
 
 	$documents = array();
 
-	$sql = 'SELECT ecm.rowid as id, ecm.src_object_type, ecm.src_object_id, ecm.filepath, ecm.filename';
+	$sql = 'SELECT ecm.rowid as id, ecm.src_object_type, ecm.src_object_id, ecm.filepath, ecm.filename, ecm.agenda_id';
 	$sql .= ' FROM '.MAIN_DB_PREFIX.'ecm_files ecm';
 	$sql .= " WHERE ecm.filepath = 'agenda/".((int) $object->id)."'";
 	//$sql.= " ecm.src_object_type = '".$db->escape($object->element)."' AND ecm.src_object_id = ".((int) $object->id); // Old version didn't add object_type during upload
+	$sql.= ' OR ecm.agenda_id = '.(int) $object->id;
 	$sql .= ' ORDER BY ecm.position ASC';
 
 	$resql = $db->query($sql);
@@ -14839,10 +14840,21 @@ function show_actions_messaging($conf, $langs, $db, $filterobj, $objcon = null, 
 
 					$filePath = DOL_DATA_ROOT.'/'.$doc->filepath.'/'.$doc->filename;
 					$mime = dol_mimetype($filePath);
-					$file = $actionstatic->id.'/'.$doc->filename;
-					$thumb = $actionstatic->id.'/thumbs/'.substr($doc->filename, 0, strrpos($doc->filename, '.')).'_mini'.substr($doc->filename, strrpos($doc->filename, '.'));
-					$doclink = dol_buildpath('document.php', 1).'?modulepart=actions&attachment=0&file='.urlencode($file).'&entity='.$conf->entity;
-					$viewlink = dol_buildpath('viewimage.php', 1).'?modulepart=actions&file='.urlencode($thumb).'&entity='.$conf->entity;
+					if (empty($doc->agenda_id)) {
+						$dir_ref = $actionstatic->id;
+						$modulepart = 'actions';
+					} else {
+						$split_dir = explode('/', $doc->filepath);
+						$modulepart = array_shift($split_dir);
+						$dir_ref = implode('/', $split_dir);
+					}
+
+					$file = $dir_ref.'/'.$doc->filename;
+					$thumb = $dir_ref.'/thumbs/'.substr($doc->filename, 0, strrpos($doc->filename, '.')).'_mini'.substr($doc->filename, strrpos($doc->filename, '.'));
+					$doclink = dol_buildpath('document.php', 1).'?modulepart='.$modulepart.'&attachment=0&file='.urlencode($file).'&entity='.$conf->entity;
+					$viewlink = dol_buildpath('viewimage.php', 1).'?modulepart='.$modulepart.'&file='.urlencode($thumb).'&entity='.$conf->entity;
+
+
 
 					$mimeAttr = ' mime="'.$mime.'" ';
 					$class = '';

--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -63,7 +63,17 @@ if (isset($_GET["hashp"]) && !defined("NOLOGIN")) {
 }
 // Some value of modulepart can be used to get resources that are public so no login are required.
 // Keep $_GET here, GETPOST is not available yet
-if (isset($_GET["modulepart"]) && in_array($_GET["modulepart"], ['medias', 'ticket'])) {
+if ((isset($_GET["modulepart"]) && $_GET["modulepart"] == 'medias')) {
+	if (!defined("NOLOGIN")) {
+		define("NOLOGIN", 1);
+	}
+	if (!defined("NOCSRFCHECK")) {
+		define("NOCSRFCHECK", 1); // We accept to go on this page from external web site.
+	}
+	if (!defined("NOIPCHECK")) {
+		define("NOIPCHECK", 1); // Do not check IP defined into conf $dolibarr_main_restrict_ip
+	}
+} elseif (isset($_GET["modulepart"]) && $_GET["modulepart"] == 'ticket' && strpos($_SERVER['HTTP_REFERER'], 'public/ticket') !== false) {
 	if (!defined("NOLOGIN")) {
 		define("NOLOGIN", 1);
 	}

--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -266,7 +266,7 @@ if (!empty($hashp)) {
 				}
 			}
 		}
-	} else if ($modulepart == 'ticket' && !getDolGlobalString('TICKET_EMAIL_MUST_EXISTS')) {
+	} elseif ($modulepart == 'ticket' && !getDolGlobalString('TICKET_EMAIL_MUST_EXISTS')) {
 		if ($sqlprotectagainstexternals) {
 			$resql = $db->query($sqlprotectagainstexternals);
 			if ($resql) {

--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -75,6 +75,22 @@ if ((isset($_GET["modulepart"]) && $_GET["modulepart"] == 'medias')) {
 	}
 }
 
+// Deactivate checks for documents when coming from ticket public interface.
+if (
+	isset($_GET["modulepart"])
+	&& $_GET["modulepart"] == 'ticket'
+	) {
+	if (!defined("NOLOGIN")) {
+		define("NOLOGIN", 1);
+	}
+	if (!defined("NOCSRFCHECK")) {
+		define("NOCSRFCHECK", 1); // We accept to go on this page from external web site.
+	}
+	if (!defined("NOIPCHECK")) {
+		define("NOIPCHECK", 1); // Do not check IP defined into conf $dolibarr_main_restrict_ip
+	}
+}
+
 /**
  * Header empty
  *
@@ -263,6 +279,16 @@ if (!empty($hashp)) {
 						break;
 					}
 					$i++;
+				}
+			}
+		}
+	} else if ($modulepart == 'ticket' && !getDolGlobalString('TICKET_EMAIL_MUST_EXISTS')) {
+		if ($sqlprotectagainstexternals) {
+			$resql = $db->query($sqlprotectagainstexternals);
+			if ($resql) {
+				$num = $db->num_rows($resql);
+				if ($num > 0) {
+					$accessallowed = 1;
 				}
 			}
 		}

--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -63,23 +63,7 @@ if (isset($_GET["hashp"]) && !defined("NOLOGIN")) {
 }
 // Some value of modulepart can be used to get resources that are public so no login are required.
 // Keep $_GET here, GETPOST is not available yet
-if ((isset($_GET["modulepart"]) && $_GET["modulepart"] == 'medias')) {
-	if (!defined("NOLOGIN")) {
-		define("NOLOGIN", 1);
-	}
-	if (!defined("NOCSRFCHECK")) {
-		define("NOCSRFCHECK", 1); // We accept to go on this page from external web site.
-	}
-	if (!defined("NOIPCHECK")) {
-		define("NOIPCHECK", 1); // Do not check IP defined into conf $dolibarr_main_restrict_ip
-	}
-}
-
-// Deactivate checks for documents when coming from ticket public interface.
-if (
-	isset($_GET["modulepart"])
-	&& $_GET["modulepart"] == 'ticket'
-	) {
+if (isset($_GET["modulepart"]) && in_array($_GET["modulepart"], ['medias', 'ticket'])) {
 	if (!defined("NOLOGIN")) {
 		define("NOLOGIN", 1);
 	}

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -158,6 +158,11 @@ class EcmFiles extends CommonObject
 	public $src_object_id;
 
 	/**
+	 * @var int ID of linked agenda event
+	 */
+	public $agenda_id;
+
+	/**
 	 * @var int section_id		ID of section = ID of EcmDirectory, directory of manual ECM (not stored into database)
 	 */
 	public $section_id;
@@ -307,7 +312,7 @@ class EcmFiles extends CommonObject
 			$this->entity = $conf->entity;
 		}
 		// Put here code to add control on parameters values
-		if (isset($this->agenda_id)) {
+		if (!empty($this->agenda_id)) {
 			$this->agenda_id = (int) $this->agenda_id;
 		}
 
@@ -361,7 +366,7 @@ class EcmFiles extends CommonObject
 		$sql .= ' '.(!isset($this->acl) ? 'NULL' : "'".$this->db->escape($this->acl)."'").',';
 		$sql .= ' '.(!isset($this->src_object_type) ? 'NULL' : "'".$this->db->escape($this->src_object_type)."'").',';
 		$sql .= ' '.(!isset($this->src_object_id) ? 'NULL' : $this->src_object_id).',';
-		$sql .= ' '.(!isset($this->agenda_id) ? 'NULL' : (int) $this->agenda_id);
+		$sql .= ' '.(empty($this->agenda_id) ? 'NULL' : (int) $this->agenda_id);
 		$sql .= ')';
 
 		$this->db->begin();
@@ -750,7 +755,7 @@ class EcmFiles extends CommonObject
 
 		// Check parameters
 		// Put here code to add a control on parameters values
-		if (isset($this->agenda_id)) {
+		if (!empty($this->agenda_id)) {
 			$this->agenda_id = (int) $this->agenda_id;
 		}
 

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -187,6 +187,7 @@ class EcmFiles extends CommonObject
 		'note_public' => array('type' => 'text', 'label' => 'NotePublic', 'enabled' => 1, 'visible' => 0, 'position' => 155),
 		'note_private' => array('type' => 'text', 'label' => 'NotePrivate', 'enabled' => 1, 'visible' => 0, 'position' => 160),
 		'acl' => array('type' => 'text', 'label' => 'NotePrivate', 'enabled' => 1, 'visible' => 0, 'position' => 160, 'comment' => "for future permission 'per file'"),
+		'agenda_id' => array('type' => 'integer', 'label' => 'IdAgenda', 'enabled' => 1, 'visible' => 0, 'position' => 180, 'comment' => "Link to an actioncomm"),
 	);
 
 
@@ -306,6 +307,9 @@ class EcmFiles extends CommonObject
 			$this->entity = $conf->entity;
 		}
 		// Put here code to add control on parameters values
+		if (isset($this->agenda_id)) {
+			$this->agenda_id = (int) $this->agenda_id;
+		}
 
 		// Insert request
 		$sql = 'INSERT INTO '.MAIN_DB_PREFIX.$this->table_element.'(';
@@ -331,7 +335,8 @@ class EcmFiles extends CommonObject
 		$sql .= 'fk_user_m,';
 		$sql .= 'acl,';
 		$sql .= 'src_object_type,';
-		$sql .= 'src_object_id';
+		$sql .= 'src_object_id,';
+		$sql .= 'agenda_id';
 		$sql .= ') VALUES (';
 		$sql .= " '".$this->db->escape($this->ref)."', ";
 		$sql .= ' '.(!isset($this->label) ? 'NULL' : "'".$this->db->escape($this->label)."'").',';
@@ -355,7 +360,8 @@ class EcmFiles extends CommonObject
 		$sql .= ' '.(!isset($this->fk_user_m) ? 'NULL' : $this->fk_user_m).',';
 		$sql .= ' '.(!isset($this->acl) ? 'NULL' : "'".$this->db->escape($this->acl)."'").',';
 		$sql .= ' '.(!isset($this->src_object_type) ? 'NULL' : "'".$this->db->escape($this->src_object_type)."'").',';
-		$sql .= ' '.(!isset($this->src_object_id) ? 'NULL' : $this->src_object_id);
+		$sql .= ' '.(!isset($this->src_object_id) ? 'NULL' : $this->src_object_id).',';
+		$sql .= ' '.(!isset($this->agenda_id) ? 'NULL' : (int) $this->agenda_id);
 		$sql .= ')';
 
 		$this->db->begin();
@@ -442,7 +448,8 @@ class EcmFiles extends CommonObject
 		$sql .= ' t.note_public,';
 		$sql .= " t.acl,";
 		$sql .= " t.src_object_type,";
-		$sql .= " t.src_object_id";
+		$sql .= " t.src_object_id,";
+		$sql .= " t.agenda_id";
 		$sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element.' as t';
 		$sql .= ' WHERE 1 = 1';
 		/* Fetching this table depends on filepath+filename, it must not depends on entity because filesystem on disk does not know what is Dolibarr entities
@@ -524,6 +531,7 @@ class EcmFiles extends CommonObject
 				$this->acl = $obj->acl;
 				$this->src_object_type = $obj->src_object_type;
 				$this->src_object_id = $obj->src_object_id;
+				$this->agenda_id = $obj->agenda_id;
 			}
 
 			// Retrieve all extrafields for ecm_files
@@ -585,7 +593,8 @@ class EcmFiles extends CommonObject
 		$sql .= " t.fk_user_m,";
 		$sql .= " t.acl,";
 		$sql .= " t.src_object_type,";
-		$sql .= " t.src_object_id";
+		$sql .= " t.src_object_id,";
+		$sql .= " t.agenda_id";
 		$sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element.' as t';
 		$sql .= ' WHERE 1 = 1';
 
@@ -661,6 +670,7 @@ class EcmFiles extends CommonObject
 				$line->acl = $obj->acl;
 				$line->src_object_type = $obj->src_object_type;
 				$line->src_object_id = $obj->src_object_id;
+				$line->agenda_id = $obj->agenda_id;
 				$this->lines[] = $line;
 			}
 			$this->db->free($resql);
@@ -740,6 +750,9 @@ class EcmFiles extends CommonObject
 
 		// Check parameters
 		// Put here code to add a control on parameters values
+		if (isset($this->agenda_id)) {
+			$this->agenda_id = (int) $this->agenda_id;
+		}
 
 		// Update request
 		$sql = 'UPDATE '.MAIN_DB_PREFIX.$this->table_element.' SET';
@@ -764,7 +777,8 @@ class EcmFiles extends CommonObject
 		$sql .= ' fk_user_m = '.($this->fk_user_m > 0 ? $this->fk_user_m : $user->id).',';
 		$sql .= ' acl = '.(isset($this->acl) ? "'".$this->db->escape($this->acl)."'" : "null").',';
 		$sql .= ' src_object_id = '.($this->src_object_id > 0 ? $this->src_object_id : "null").',';
-		$sql .= ' src_object_type = '.(isset($this->src_object_type) ? "'".$this->db->escape($this->src_object_type)."'" : "null");
+		$sql .= ' src_object_type = '.(isset($this->src_object_type) ? "'".$this->db->escape($this->src_object_type)."'" : "null").',';
+		$sql .= ' agenda_id = '.($this->agenda_id > 0 ? (int) $this->agenda_id : null);
 		$sql .= ' WHERE rowid='.((int) $this->id);
 
 		$this->db->begin();

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -370,9 +370,8 @@ class ActionsTicket extends CommonHookActions
 								$footer .= ' data-filename="'.dol_escape_htmltag($doc->filename).'" ';
 								$footer .= '>';
 
-								$mime = dol_mimetype($filePath);
 								if (empty($doc->agenda_id)) {
-									$dir_ref = $actionstatic->id;
+									$dir_ref = $arraymsgs['id'];
 									$modulepart = 'actions';
 								} else {
 									$split_dir = explode('/', $doc->filepath);
@@ -380,9 +379,13 @@ class ActionsTicket extends CommonHookActions
 									$dir_ref = implode('/', $split_dir);
 								}
 								$filePath = DOL_DATA_ROOT.'/'.$doc->filepath.'/'.$doc->filename;
+								$file_relative_path = $dir_ref.'/'.$doc->filename;
 								$mime = dol_mimetype($filePath);
-								$thumb = $dir_ref.'/thumbs/'.substr($doc->filename, 0, strrpos($doc->filename, '.')).'_mini'.substr($doc->filename, strrpos($doc->filename, '.'));
-								$doclink = DOL_URL_ROOT.'/document.php?hashp='.urlencode($doc->share);
+								if (!empty($doc->share)) {
+									$doclink = DOL_URL_ROOT.'/document.php?hashp='.urlencode($doc->share);
+								} elseif ($doc->src_object_type == 'ticket') {
+									$doclink = dol_buildpath('document.php', 1).'?modulepart='.$modulepart.'&attachment=0&file='.urlencode($file_relative_path).'&entity='.getentity('ticket', 0);
+								}
 
 								$mimeAttr = ' mime="'.$mime.'" ';
 								$class = '';

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -343,7 +343,7 @@ class ActionsTicket extends CommonHookActions
 
 					$documents = array();
 
-					$sql = 'SELECT ecm.rowid as id, ecm.src_object_type, ecm.src_object_id';
+					$sql = 'SELECT ecm.rowid as id, ecm.src_object_type, ecm.src_object_id, ecm.agenda_id';
 					$sql .= ', ecm.filepath, ecm.filename, ecm.share';
 					$sql .= ' FROM '.MAIN_DB_PREFIX.'ecm_files ecm';
 					$sql .= " WHERE ecm.filepath = 'agenda/".(int) $arraymsgs['id']."'";
@@ -362,7 +362,7 @@ class ActionsTicket extends CommonHookActions
 						$isshared = 0;
 						$footer = '<div class="timeline-documents-container">';
 						foreach ($documents as $doc) {
-							if (!empty($doc->share)) {
+							if (!empty($doc->share) || ($doc->src_object_type == 'ticket')) {
 								$isshared = 1;
 								$footer .= '<span id="document_'.$doc->id.'" class="timeline-documents" ';
 								$footer .= ' data-id="'.$doc->id.'" ';
@@ -370,9 +370,18 @@ class ActionsTicket extends CommonHookActions
 								$footer .= ' data-filename="'.dol_escape_htmltag($doc->filename).'" ';
 								$footer .= '>';
 
+								$mime = dol_mimetype($filePath);
+								if (empty($doc->agenda_id)) {
+									$dir_ref = $actionstatic->id;
+									$modulepart = 'actions';
+								} else {
+									$split_dir = explode('/', $doc->filepath);
+									$modulepart = array_shift($split_dir);
+									$dir_ref = implode('/', $split_dir);
+								}
 								$filePath = DOL_DATA_ROOT.'/'.$doc->filepath.'/'.$doc->filename;
 								$mime = dol_mimetype($filePath);
-								$thumb = $arraymsgs['id'].'/thumbs/'.substr($doc->filename, 0, strrpos($doc->filename, '.')).'_mini'.substr($doc->filename, strrpos($doc->filename, '.'));
+								$thumb = $dir_ref.'/thumbs/'.substr($doc->filename, 0, strrpos($doc->filename, '.')).'_mini'.substr($doc->filename, strrpos($doc->filename, '.'));
 								$doclink = DOL_URL_ROOT.'/document.php?hashp='.urlencode($doc->share);
 
 								$mimeAttr = ' mime="'.$mime.'" ';

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -346,7 +346,8 @@ class ActionsTicket extends CommonHookActions
 					$sql = 'SELECT ecm.rowid as id, ecm.src_object_type, ecm.src_object_id';
 					$sql .= ', ecm.filepath, ecm.filename, ecm.share';
 					$sql .= ' FROM '.MAIN_DB_PREFIX.'ecm_files ecm';
-					$sql .= " WHERE ecm.filepath = 'agenda/".$arraymsgs['id']."'";
+					$sql .= " WHERE ecm.filepath = 'agenda/".(int) $arraymsgs['id']."'";
+					$sql .= " OR (ecm.agenda_id = ".(int) $arraymsgs['id']." AND ecm.src_object_type = 'ticket' AND ecm.src_object_id = ".(int) $this->dao->id.")";
 					$sql .= ' ORDER BY ecm.position ASC';
 
 					$resql = $this->db->query($sql);

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -381,10 +381,11 @@ class ActionsTicket extends CommonHookActions
 								$filePath = DOL_DATA_ROOT.'/'.$doc->filepath.'/'.$doc->filename;
 								$file_relative_path = $dir_ref.'/'.$doc->filename;
 								$mime = dol_mimetype($filePath);
+								$doclink = '';
 								if (!empty($doc->share)) {
 									$doclink = DOL_URL_ROOT.'/document.php?hashp='.urlencode($doc->share);
 								} elseif ($doc->src_object_type == 'ticket') {
-									$doclink = dol_buildpath('document.php', 1).'?modulepart='.$modulepart.'&attachment=0&file='.urlencode($file_relative_path).'&entity='.getentity('ticket', 0);
+									$doclink = dol_buildpath('document.php', 1).'?modulepart='.$modulepart.'&attachment=0&file='.urlencode($file_relative_path).'&entity='.getEntity('ticket', 0);
 								}
 
 								$mimeAttr = ' mime="'.$mime.'" ';

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1904,7 +1904,7 @@ class Ticket extends CommonObject
 					//if (dol_mkdir($destdir) >= 0) {
 					//require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 					//dol_move($filespath, $destfile);	// Disabled, a file for a ticket should be stored into ticket directory. It generates big trouble.
-					if (in_array($actioncomm->code, array('TICKET_MSG', 'TICKET_MSG_SENTBYMAIL'))) {
+					if (in_array($actioncomm->code, array('TICKET_MSG', 'TICKET_MSG_SENTBYMAIL', 'TICKET_MSG_PRIVATE'))) {
 						$ecmfile = new EcmFiles($this->db);
 						$destdir = preg_replace('/^'.preg_quote(DOL_DATA_ROOT, '/').'/', '', $destdir);
 						$destdir = preg_replace('/[\\/]$/', '', $destdir);
@@ -1913,11 +1913,7 @@ class Ticket extends CommonObject
 						$result = $ecmfile->fetch(0, '', $destdir.'/'.$attachedfiles['names'][$key]);
 
 						// TODO We must add a column into ecm_files table agenda_id to store the ID of event.
-						// $ecmfile->agenda_id = $actionid;
-
-						// Disabled, serious security hole. A file published into the ERP should not become public for everybody.
-						//require_once DOL_DOCUMENT_ROOT.'/core/lib/security2.lib.php';
-						//$ecmfile->share = getRandomPassword(true);
+						$ecmfile->agenda_id = $actionid;
 
 						if ($result > 0) {
 							$result = $ecmfile->update($user);


### PR DESCRIPTION
# NEW Make ticket linked files accessible from ticket public interface

This PR should be merged after #32325.

It makes documents accessible on ticket public interface, linked to the message they originate from.

view of public interface (preview works)

![Capture d’écran_2024-12-17_11-59-17](https://github.com/user-attachments/assets/c686b12f-0107-4a94-bc91-c5a62ae333c8)




