### PR TITLE
fix: missing token on delete line on MO

### DIFF
--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1644,6 +1644,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 							$href = $_SERVER["PHP_SELF"];
 							$href .= '?id='.$object->id;
 							$href .= '&action=deleteline';
+							$href .= '&token='.newToken();
 							$href .= '&lineid='.$line->id;
 							print '<td class="center">';
 							print '<a class="reposition" href="'.$href.'">';


### PR DESCRIPTION
Missing token on delete line in MO

![image](https://github.com/user-attachments/assets/a50f372a-51f7-4112-a6c6-afa20cd16b7c)
