### PR TITLE
pre-commit : change regex for hook no-commit-to-branch to block only `18.0`, not `18.0_branch_description`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     rev: v4.5.0
     hooks:
       - id: no-commit-to-branch
-        args: [--branch, develop, --pattern, \d+.0]
+        args: [--branch, develop, --pattern, \d+.0$]
       - id: check-yaml
         args: [--unsafe]
       - id: check-json


### PR DESCRIPTION
# Fix pre-commit : change regex for hook no-commit-to-branch to allow descriptions on branch name

The pre-commit hook `no-commit-to-branch` forbids any branch name that begins with `18.0` (or any digit followed by `.0`). I regularly name branches after the target branch, with a description : `18.0_fix_XXX`. These patterns are forbidden, and I don't see any reason for this.

This PR blocks commits only if they are target to a stable branch, but allows patterns with target branch + a description. It keeps blocking commits to branch develop.


