### PR TITLE
FIX: status ticket update for new message

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -458,7 +458,7 @@ if (empty($reshook)) {
 	// Action to add a message (private or not, with email or not).
 	// This may also send an email (concatenated with email_intro and email footer if checkbox was selected)
 	if ($action == 'add_message' && GETPOSTISSET('btn_add_message') && $permissiontoread) {
-		$ret = $object->newMessage($user, $action, (GETPOST('private_message', 'alpha') == "on" ? 1 : 0), 0);
+		$ret = $object->newMessage($user, $action, GETPOSTINT('private_message'), 0);
 
 		if ($ret > 0) {
 			if (!empty($backtopage)) {


### PR DESCRIPTION
# FIX: status ticket update for new message
There is a parameter in Ticket module that allows to set a status when we send a message from ticket. However, this shouldn’t apply when said message is private.
The current test to determine whether our message is private… is always false, because the private message option is a checkbox, an not a text content. This should fix the issue.