### PR TITLE
FIX #32402 Social Contribution - Update - Drop the attached employee

### DIFF
--- a/htdocs/compta/sociales/card.php
+++ b/htdocs/compta/sociales/card.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2004-2020  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2013  Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2016-2018  Frédéric France         <frederic.france@netlogic.fr>
- * Copyright (C) 2017-2022  Alexandre Spangaro      <aspangaro@open-dsi.fr>
+ * Copyright (C) 2017-2024  Alexandre Spangaro      <alexandre@inovea-conseil.com>
  * Copyright (C) 2021       Gauthier VERDOL     	<gauthier.verdol@atm-consulting.fr>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -203,7 +203,7 @@ if (empty($reshook)) {
 			$object->periode = $dateperiod;
 			$object->period = $dateperiod;
 			$object->amount = $amount;
-			$object->fk_user			= $fk_user;
+			$object->fk_user = $fk_user;
 			$object->mode_reglement_id = GETPOSTINT('mode_reglement_id');
 			$object->fk_account = GETPOSTINT('fk_account');
 			$object->fk_project = GETPOSTINT('fk_project');
@@ -239,7 +239,7 @@ if (empty($reshook)) {
 			$object->periode = $dateperiod;
 			$object->period = $dateperiod;
 			$object->amount = $amount;
-			$object->fk_user = $fk_user;
+			// $object->fk_user = $fk_user;
 
 			$result = $object->update($user);
 			if ($result <= 0) {


### PR DESCRIPTION
Create a social contribution with an employee attached.

Update this social contribution & you dropped the employee attached. You need to redefined employee previously attached.

Solution : remove the fk_user update in the update action
The user can nevertheless be updated with the dedicated setfk_user

![image](https://github.com/user-attachments/assets/91afcfc8-71e2-44aa-8658-b5100295f962)

