### PR TITLE
fix(facture): when updating, subtype should not be trimmed as it is a…

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2451,9 +2451,6 @@ class Facture extends CommonInvoice
 		if (empty($this->type)) {
 			$this->type = self::TYPE_STANDARD;
 		}
-		if (isset($this->subtype)) {
-			$this->subtype = trim($this->subtype);
-		}
 		if (isset($this->ref)) {
 			$this->ref = trim($this->ref);
 		}


### PR DESCRIPTION
# FIX|Fix Update facture SQL Error
When updating an invoice, the subtype should not be trimmed as it's an int, not a string. So, there is a SQL error with subtype.