### PR TITLE
fix: fetch action linked object

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3832,7 +3832,7 @@ abstract class CommonObject
 			$num = $this->db->num_rows($resql);
 			$i = 0;
 			while ($i < $num) {
-				$obj = $this->db->fetch_object($resql);
+                $obj = $this->db->fetch_object($resql);
 				if ($justsource || $justtarget) {
 					if ($justsource) {
 						$this->linkedObjectsIds[$obj->targettype][$obj->rowid] = $obj->fk_target;
@@ -3892,8 +3892,12 @@ abstract class CommonObject
 						$classpath = 'adherents/class';
 						$module = 'adherent';
 					} elseif ($objecttype == 'contact') {
-						 $module = 'societe';
-					}
+                        $module = 'societe';
+                    } elseif ($objecttype == 'action') {
+                        $module = 'agenda';
+                        $subelement = 'actionComm';
+                    }
+
 					// Set classfile
 					$classfile = strtolower($subelement);
 					$classname = ucfirst($subelement);


### PR DESCRIPTION
When trying to fetch linked object from action object. Nothing were returned because module name was wrong (it is modAgenda instead of modAction) and class name was wrong (it is ActionComm instead of Action).