### PR TITLE
FIX Bad GETPOSTINT for document preview

### DIFF
--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -103,7 +103,7 @@ $original_file = GETPOST('file', 'alphanohtml');
 $hashp = GETPOST('hashp', 'aZ09');
 $modulepart = GETPOST('modulepart', 'alpha');
 $urlsource = GETPOST('urlsource', 'alpha');
-$entity = GETPOSTINT('entity', $conf->entity);
+$entity = GETPOSTINT('entity');
 
 // Security check
 if (empty($modulepart) && empty($hashp)) {


### PR DESCRIPTION
# FIX - Misuse GETPOSTINT param 
There was a misuse of the second parameter of a GETPOSTINT, here you put $conf->entity as the second parameter, which changed the method used depending on the entity you were on. which made 


