### PR TITLE
# FIX|Fix #32292 

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -119,7 +119,7 @@ $search_accountancy_code_buy_intra = GETPOST("search_accountancy_code_buy_intra"
 $search_accountancy_code_buy_export = GETPOST("search_accountancy_code_buy_export", 'alpha');
 $search_import_key = GETPOST("search_import_key", 'alpha');
 $search_finished = GETPOST("search_finished");
-$search_units = GETPOST('search_units', 'alpha');
+$search_units = GETPOST('search_units', 'int');
 $type = GETPOST("type", 'alpha');
 
 // Show/hide child product variants


### PR DESCRIPTION
# FIX|Fix #32292 
When viewing the product list and searching by any of the available criteria (category, reference, label, etc) no results appear after clicking the search button (magnifying glass). However, after then clicking the change view buttons, the results show up normally. For subsequent searches I must change the keyword, click the search button (no results), and then click the view (list or tile) button to be presented with the search results.

in the httdocs/product/list.php on line 122
$search_units = GETPOST('search_units', 'alpha');
must be replaced by
$search_units = GETPOST('search_units', 'int');
