### PR TITLE
Can't DELETE or CLONE various payment

### DIFF
--- a/htdocs/compta/bank/various_payment/card.php
+++ b/htdocs/compta/bank/various_payment/card.php
@@ -654,7 +654,7 @@ if ($id) {
 		print '<tr><td class="nowrap">';
 		print $form->editfieldkey('AccountAccounting', 'accountancy_code', $object->accountancy_code, $object, (!$alreadyaccounted && $permissiontoadd), 'string', '', 0);
 		print '</td><td>';
-		if ($action == 'editaccountancy_code' && (!$alreadyaccounted && $permissiontoadd)) {
+		if ($action == 'editaccountancy_code' || (!$alreadyaccounted && $permissiontoadd)) {
 			//print $form->editfieldval('AccountAccounting', 'accountancy_code', $object->accountancy_code, $object, (!$alreadyaccounted && $user->hasRight('banque', 'modifier')), 'string', '', 0);
 			print $formaccounting->formAccountingAccount($_SERVER['PHP_SELF'].'?id='.$object->id, $object->accountancy_code, 'accountancy_code', 0, 1, '', 1);
 		} else {


### PR DESCRIPTION
FIX | can't delete or clone a various payment

to reproduce the bug
1- create a new miscellaneous payment
2- go to the payment card
3- try to delete or clone

<img width="1417" alt="Screenshot 2024-12-26 at 8 18 27 PM" src="https://github.com/user-attachments/assets/a69bff4d-58ce-4850-a7c2-47aa891d5c5d" />
<img width="1419" alt="Screenshot 2024-12-26 at 8 18 08 PM" src="https://github.com/user-attachments/assets/64bbdaa0-956c-4b4d-b034-676f3222f653" />
