### PR TITLE
# FIX|Fix # Special Character Not Allowed for Extrafields

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -10322,7 +10322,7 @@ function dol_eval($s, $returnvalue = 1, $hideerrors = 1, $onlysimplestring = '1'
 			// We must accept with 2: (($reloadedobj = new Task($db)) && ($reloadedobj->fetchNoCompute($object->id) > 0) && ($secondloadedobj = new Project($db)) && ($secondloadedobj->fetchNoCompute($reloadedobj->fk_project) > 0)) ? $secondloadedobj->ref : "Parent project not found"
 
 			// Check if there is dynamic call (first we check chars are all into use a whitelist chars)
-			$specialcharsallowed = '^$_+-.*>&|=!?():"\',/@';
+			$specialcharsallowed = '^$_+-.*><&|=!?():"\',/@';
 			if ($onlysimplestring == '2') {
 				$specialcharsallowed .= '[]';
 			}


### PR DESCRIPTION
# FIX|Fix # Special Character Not Allowed for Extrafields

I got this error message when I added this extrafield:

 **'Bad string syntax to evaluate (found chars that are not chars for a simple clean eval string): $object->array_options['options_anciennete'] % 72 <= 74 ? 'Yes' : 'No'** 

This is because the character '<' was not listed in the allowed special characters, so I added it


