### PR TITLE
FIX: double space file bug when using dolibarr import

### DIFF
--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -238,7 +238,7 @@ if ($step == 3 && $datatoimport) {
 		dol_mkdir($conf->import->dir_temp);
 		$nowyearmonth = dol_print_date(dol_now(), '%Y%m%d%H%M%S');
 
-		$fullpath = $conf->import->dir_temp."/".$nowyearmonth.'-'.$_FILES['userfile']['name'];
+		$fullpath = $conf->import->dir_temp."/".$nowyearmonth.'-'.dol_string_nohtmltag(dol_sanitizeFileName($_FILES['userfile']['name']));
 		if (dol_move_uploaded_file($_FILES['userfile']['tmp_name'], $fullpath, 1) > 0) {
 			dol_syslog("File ".$fullpath." was added for import");
 		} else {


### PR DESCRIPTION
The old double space in filename bug still present when adding a file for import : 
The file can't be removed from the import files list, and trying to use the file will throw a 500 error on import step 4 page. 