### PR TITLE
FIX: allow bookcal display on calendar list

### DIFF
--- a/htdocs/bookcal/availabilities_list.php
+++ b/htdocs/bookcal/availabilities_list.php
@@ -263,6 +263,9 @@ $sql = preg_replace('/,\s*$/', '', $sql);
 $sqlfields = $sql; // $sql fields to remove for count total
 
 $sql .= " FROM ".MAIN_DB_PREFIX.$object->table_element." as t";
+if ($object->ismultientitymanaged == 1  || $object->ismultientitymanaged != '') { // value is fk_bookcal_calendar@bookcal_calendar
+ 	$sql .= ", ".MAIN_DB_PREFIX."bookcal_calendar as bc";
+}
 //$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."anothertable as rc ON rc.parent = t.rowid";
 if (isset($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label'])) {
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX.$object->table_element."_extrafields as ef on (t.rowid = ef.fk_object)";
@@ -271,8 +274,9 @@ if (isset($extrafields->attributes[$object->table_element]['label']) && is_array
 $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
-if ($object->ismultientitymanaged == 1) {
-	$sql .= " WHERE t.entity IN (".getEntity($object->element, (GETPOSTINT('search_current_entity') ? 0 : 1)).")";
+if ($object->ismultientitymanaged == 1  || $object->ismultientitymanaged != '') { // value is fk_bookcal_calendar@bookcal_calendar
+    $sql .= " WHERE bc.rowid = t.fk_bookcal_calendar";
+    $sql .= " AND bc.entity IN (".getEntity($object->element, (GETPOSTINT('search_current_entity') ? 0 : 1)).")";
 } else {
 	$sql .= " WHERE 1 = 1";
 }

--- a/htdocs/bookcal/availabilities_list.php
+++ b/htdocs/bookcal/availabilities_list.php
@@ -276,7 +276,7 @@ $reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object
 $sql .= $hookmanager->resPrint;
 if ($object->ismultientitymanaged == 1  || $object->ismultientitymanaged != '') { // value is fk_bookcal_calendar@bookcal_calendar
 	$sql .= " WHERE bc.rowid = t.fk_bookcal_calendar";
-	$sql .= " AND bc.entity IN (".getEntity($object->element, (GETPOSTINT('search_current_entity') ? 0 : 1)).")";
+	$sql .= " AND bc.entity IN (".getEntity('calendar', (GETPOSTINT('search_current_entity') ? 0 : 1)).")";
 } else {
 	$sql .= " WHERE 1 = 1";
 }

--- a/htdocs/bookcal/availabilities_list.php
+++ b/htdocs/bookcal/availabilities_list.php
@@ -264,7 +264,7 @@ $sqlfields = $sql; // $sql fields to remove for count total
 
 $sql .= " FROM ".MAIN_DB_PREFIX.$object->table_element." as t";
 if ($object->ismultientitymanaged == 1  || $object->ismultientitymanaged != '') { // value is fk_bookcal_calendar@bookcal_calendar
- 	$sql .= ", ".MAIN_DB_PREFIX."bookcal_calendar as bc";
+	$sql .= ", ".MAIN_DB_PREFIX."bookcal_calendar as bc";
 }
 //$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."anothertable as rc ON rc.parent = t.rowid";
 if (isset($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label'])) {
@@ -275,8 +275,8 @@ $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
 if ($object->ismultientitymanaged == 1  || $object->ismultientitymanaged != '') { // value is fk_bookcal_calendar@bookcal_calendar
-    $sql .= " WHERE bc.rowid = t.fk_bookcal_calendar";
-    $sql .= " AND bc.entity IN (".getEntity($object->element, (GETPOSTINT('search_current_entity') ? 0 : 1)).")";
+	$sql .= " WHERE bc.rowid = t.fk_bookcal_calendar";
+	$sql .= " AND bc.entity IN (".getEntity($object->element, (GETPOSTINT('search_current_entity') ? 0 : 1)).")";
 } else {
 	$sql .= " WHERE 1 = 1";
 }

--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -71,10 +71,10 @@ $search_categ_cus = GETPOST("search_categ_cus", 'intcomma', 3) ? GETPOST("search
 
 // If not choice done on calendar owner (like on left menu link "Agenda"), we filter on user.
 if (empty($filtert) && !getDolGlobalString('AGENDA_ALL_CALENDARS')) {
-	$filtert = $user->id;
+	$filtert = "".$user->id;
 }
 //TODO :  debug : if filtert ON : no bookcal -> nothing is altering filtert ???
-$filtert=-1;
+$filtert="-1";
 
 $newparam = '';
 

--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -73,6 +73,8 @@ $search_categ_cus = GETPOST("search_categ_cus", 'intcomma', 3) ? GETPOST("search
 if (empty($filtert) && !getDolGlobalString('AGENDA_ALL_CALENDARS')) {
 	$filtert = $user->id;
 }
+//TODO :  debug : if filtert ON : no bookcal -> nothing is altering filtert ???
+$filtert=-1;
 
 $newparam = '';
 
@@ -599,6 +601,7 @@ if (isModEnabled("bookcal")) {
 	$sql .= " ON bc.rowid = ba.fk_bookcal_calendar";
 	$sql .= " WHERE bc.status = 1";
 	$sql .= " AND ba.status = 1";
+	$sql .= " AND bc.entity IN (".getEntity('agenda').")";
 	if (!empty($filtert) && $filtert != -1) {
 		$sql .= " AND bc.visibility = ".(int) $filtert ;
 	}


### PR DESCRIPTION
disable checks on "filtert" (default does not allow bookcal from other entities)
fix : add check on entites for bookcals

# FIX bookcal : FIX : check on entities + not displaying calendar if multicompany ON
In multicompany context, we have to check on entities so only display shared agenda/bookcal AND have to disable checks on "filtert" (default only allow bookcal from same user, but is not altered by bookcal)
