### PR TITLE
FIX ODT substitution when many HTML tags in string

### DIFF
--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -46,8 +46,8 @@ class Odf
 	public $userdefined=array();
 
 	const PIXEL_TO_CM = 0.026458333;
-	const FIND_TAGS_REGEX = '/<([A-Za-z0-9]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/>)|(?:>(.*)<\/\1>))/s';
-	const FIND_ENCODED_TAGS_REGEX = '/&lt;([A-Za-z]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/&gt;)|(?:&gt;(.*)&lt;\/\1&gt;))/';
+	const FIND_TAGS_REGEX = '/<([A-Za-z0-9]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/>)|(?:>([^(<\1>)]*)<\/\1>))/s';
+	const FIND_ENCODED_TAGS_REGEX = '/&lt;([A-Za-z]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/&gt;)|(?:&gt;([^(&lt;\1&gt;)]*)&lt;\/\1&gt;))/';
 
 
 	/**

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -46,8 +46,8 @@ class Odf
 	public $userdefined=array();
 
 	const PIXEL_TO_CM = 0.026458333;
-	const FIND_TAGS_REGEX = '/<([A-Za-z0-9]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/>)|(?:>([^(<\1>)]*)<\/\1>))/s';
-	const FIND_ENCODED_TAGS_REGEX = '/&lt;([A-Za-z]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/&gt;)|(?:&gt;([^(&lt;\1&gt;)]*)&lt;\/\1&gt;))/';
+	const FIND_TAGS_REGEX = '/<([A-Za-z0-9]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/>)|(?:>(((?!<\1>).)*)<\/\1>))/s';
+	const FIND_ENCODED_TAGS_REGEX = '/&lt;([A-Za-z]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/&gt;)|(?:&gt;(((?!&lt;\1&gt;).)*)&lt;\/\1&gt;))/';
 
 
 	/**

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -46,8 +46,8 @@ class Odf
 	public $userdefined=array();
 
 	const PIXEL_TO_CM = 0.026458333;
-	const FIND_TAGS_REGEX = '/<([A-Za-z0-9]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/>)|(?:>(((?!<\1>).)*)<\/\1>))/s';
-	const FIND_ENCODED_TAGS_REGEX = '/&lt;([A-Za-z]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/&gt;)|(?:&gt;(((?!&lt;\1&gt;).)*)&lt;\/\1&gt;))/';
+	const FIND_TAGS_REGEX = '/<([A-Za-z0-9]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/>)|(?:>(((?!<\1(\s.*)?>).)*)<\/\1>))/s';
+	const FIND_ENCODED_TAGS_REGEX = '/&lt;([A-Za-z]+)(?:\s([A-Za-z]+(?:\-[A-Za-z]+)?(?:=(?:".*?")|(?:[0-9]+))))*(?:(?:\s\/&gt;)|(?:&gt;(((?!&lt;\1(\s.*)?&gt;).)*)&lt;\/\1&gt;))/';
 
 
 	/**

--- a/test/phpunit/ODFTest.php
+++ b/test/phpunit/ODFTest.php
@@ -296,33 +296,39 @@ class ODFTest extends PHPUnit\Framework\TestCase
 				'charset' => null,
 				'expected' => utf8_encode('text with <text:span text:style-name="boldText">intricated<text:span text:style-name="underlineText">tags</text:span></text:span>'),
 			],
+			24 => [
+				'to_convert' => "text with <strong>two</strong> (strong) <strong>tags</strong>",
+				'encode' => true,
+				'charset' => null,
+				'expected' => utf8_encode('text with <text:span text:style-name="boldText">two</text:span> (strong) <text:span text:style-name="boldText">tags</text:span>'),
+			],
 
 			// One can also pass html-encoded string to the method
-			24 => [
+			25 => [
 				'to_convert' => 'One&amp;two',
 				'encode' => true,
 				'charset' => null,
 				'expected' => 'One&amp;two',
 			],
-			25 => [
+			26 => [
 				'to_convert' => "text with &lt;strong&gt;strong, &lt;/strong&gt;&lt;em&gt;emphasis&lt;/em&gt; and &lt;u&gt;underlined&lt;/u&gt; words with &lt;i&gt;it@lic sp&amp;ciàlchärs éè l'&lt;/i&gt;",
 				'encode' => false,
 				'charset' => 'UTF-8',
 				'expected' => 'text with <text:span text:style-name="boldText">strong, </text:span><text:span text:style-name="italicText">emphasis</text:span> and <text:span text:style-name="underlineText">underlined</text:span> words with <text:span text:style-name="italicText">it@lic sp&ciàlchärs éè l\'</text:span>',
 			],
-			26 => [
+			27 => [
 				'to_convert' => "text with &lt;strong&gt;strong, &lt;/strong&gt;&lt;em&gt;emphasis&lt;/em&gt; and &lt;u&gt;underlined&lt;/u&gt; words with &lt;i&gt;it@lic sp&amp;ciàlchärs éè l'&lt;/i&gt;",
 				'encode' => true,
 				'charset' => 'UTF-8',
 				'expected' => 'text with <text:span text:style-name="boldText">strong, </text:span><text:span text:style-name="italicText">emphasis</text:span> and <text:span text:style-name="underlineText">underlined</text:span> words with <text:span text:style-name="italicText">it@lic sp&amp;ciàlchärs éè l&apos;</text:span>',
 			],
-			27 => [
+			28 => [
 				'to_convert' => "text with &lt;strong&gt;strong, &lt;/strong&gt;&lt;em&gt;emphasis&lt;/em&gt; and &lt;u&gt;underlined&lt;/u&gt; words with &lt;i&gt;it@lic sp&amp;ciàlchärs éè l'&lt;/i&gt;",
 				'encode' => false,
 				'charset' => null,
 				'expected' => utf8_encode('text with <text:span text:style-name="boldText">strong, </text:span><text:span text:style-name="italicText">emphasis</text:span> and <text:span text:style-name="underlineText">underlined</text:span> words with <text:span text:style-name="italicText">it@lic sp&ciàlchärs éè l\'</text:span>'),
 			],
-			28 => [
+			29 => [
 				'to_convert' => "text with &lt;strong&gt;strong, &lt;/strong&gt;&lt;em&gt;emphasis&lt;/em&gt; and &lt;u&gt;underlined&lt;/u&gt; words with &lt;i&gt;it@lic sp&amp;ciàlchärs éè l'&lt;/i&gt;",
 				'encode' => true,
 				'charset' => null,
@@ -341,20 +347,20 @@ class ODFTest extends PHPUnit\Framework\TestCase
 			// Following tests reflect the current behavior. They may evolve if the method behavior changes.
 
 			// The method removes hyperlinks and tags that are not dealt with.
-			29 => [
+			30 => [
 				'to_convert' => '123 <a href="/test.php">trucmachin > truc < troc > trac</a>bla bla',
 				'encode' => true,
 				'charset' => null,
 				'expected' => "123 trucmachin &gt; truc &lt; troc &gt; tracbla bla",
 			],
-			30 => [
+			31 => [
 				'to_convert' => '123 <h3>Title</h3> bla',
 				'encode' => true,
 				'charset' => null,
 				'expected' => "123 Title bla",
 			],
 			// HTML should not take \n into account, but only <br />.
-			31 => [
+			32 => [
 				'to_convert' => "text with <strong>strong text </strong>, a line\nbreak and <u>underlined</u> words with <i>it@lic sp&ciàlchärs éè l'</i>",
 				'encode' => false,
 				'charset' => 'UTF-8',

--- a/test/phpunit/ODFTest.php
+++ b/test/phpunit/ODFTest.php
@@ -377,7 +377,7 @@ class ODFTest extends PHPUnit\Framework\TestCase
 			} else {
 				$res = $odf->convertVarToOdf($case['to_convert'], $case['encode']);
 			}
-			$this->assertEquals($res, $case['expected']);
+			$this->assertEquals($case['expected'], $res);
 		}
 
 		print __METHOD__." result=".$result."\n";

--- a/test/phpunit/ODFTest.php
+++ b/test/phpunit/ODFTest.php
@@ -302,33 +302,39 @@ class ODFTest extends PHPUnit\Framework\TestCase
 				'charset' => null,
 				'expected' => utf8_encode('text with <text:span text:style-name="boldText">two</text:span> (strong) <text:span text:style-name="boldText">tags</text:span>'),
 			],
+			25 => [
+				'to_convert' => "text with <strong class=\"whatever\">two</strong> (strong) <strong class=\"the weather\">tags and <u>intricated</u> underline </strong>",
+				'encode' => true,
+				'charset' => null,
+				'expected' => utf8_encode('text with <text:span text:style-name="boldText">two</text:span> (strong) <text:span text:style-name="boldText">tags and <text:span text:style-name="underlineText">intricated</text:span> underline </text:span>'),
+			],
 
 			// One can also pass html-encoded string to the method
-			25 => [
+			26 => [
 				'to_convert' => 'One&amp;two',
 				'encode' => true,
 				'charset' => null,
 				'expected' => 'One&amp;two',
 			],
-			26 => [
+			27 => [
 				'to_convert' => "text with &lt;strong&gt;strong, &lt;/strong&gt;&lt;em&gt;emphasis&lt;/em&gt; and &lt;u&gt;underlined&lt;/u&gt; words with &lt;i&gt;it@lic sp&amp;ciàlchärs éè l'&lt;/i&gt;",
 				'encode' => false,
 				'charset' => 'UTF-8',
 				'expected' => 'text with <text:span text:style-name="boldText">strong, </text:span><text:span text:style-name="italicText">emphasis</text:span> and <text:span text:style-name="underlineText">underlined</text:span> words with <text:span text:style-name="italicText">it@lic sp&ciàlchärs éè l\'</text:span>',
 			],
-			27 => [
+			28 => [
 				'to_convert' => "text with &lt;strong&gt;strong, &lt;/strong&gt;&lt;em&gt;emphasis&lt;/em&gt; and &lt;u&gt;underlined&lt;/u&gt; words with &lt;i&gt;it@lic sp&amp;ciàlchärs éè l'&lt;/i&gt;",
 				'encode' => true,
 				'charset' => 'UTF-8',
 				'expected' => 'text with <text:span text:style-name="boldText">strong, </text:span><text:span text:style-name="italicText">emphasis</text:span> and <text:span text:style-name="underlineText">underlined</text:span> words with <text:span text:style-name="italicText">it@lic sp&amp;ciàlchärs éè l&apos;</text:span>',
 			],
-			28 => [
+			29 => [
 				'to_convert' => "text with &lt;strong&gt;strong, &lt;/strong&gt;&lt;em&gt;emphasis&lt;/em&gt; and &lt;u&gt;underlined&lt;/u&gt; words with &lt;i&gt;it@lic sp&amp;ciàlchärs éè l'&lt;/i&gt;",
 				'encode' => false,
 				'charset' => null,
 				'expected' => utf8_encode('text with <text:span text:style-name="boldText">strong, </text:span><text:span text:style-name="italicText">emphasis</text:span> and <text:span text:style-name="underlineText">underlined</text:span> words with <text:span text:style-name="italicText">it@lic sp&ciàlchärs éè l\'</text:span>'),
 			],
-			29 => [
+			30 => [
 				'to_convert' => "text with &lt;strong&gt;strong, &lt;/strong&gt;&lt;em&gt;emphasis&lt;/em&gt; and &lt;u&gt;underlined&lt;/u&gt; words with &lt;i&gt;it@lic sp&amp;ciàlchärs éè l'&lt;/i&gt;",
 				'encode' => true,
 				'charset' => null,
@@ -347,20 +353,20 @@ class ODFTest extends PHPUnit\Framework\TestCase
 			// Following tests reflect the current behavior. They may evolve if the method behavior changes.
 
 			// The method removes hyperlinks and tags that are not dealt with.
-			30 => [
+			31 => [
 				'to_convert' => '123 <a href="/test.php">trucmachin > truc < troc > trac</a>bla bla',
 				'encode' => true,
 				'charset' => null,
 				'expected' => "123 trucmachin &gt; truc &lt; troc &gt; tracbla bla",
 			],
-			31 => [
+			32 => [
 				'to_convert' => '123 <h3>Title</h3> bla',
 				'encode' => true,
 				'charset' => null,
 				'expected' => "123 Title bla",
 			],
 			// HTML should not take \n into account, but only <br />.
-			32 => [
+			33 => [
 				'to_convert' => "text with <strong>strong text </strong>, a line\nbreak and <u>underlined</u> words with <i>it@lic sp&ciàlchärs éè l'</i>",
 				'encode' => false,
 				'charset' => 'UTF-8',


### PR DESCRIPTION
# FIX ODT substitution : if a string contains many times the same HTML tag, only the first opening tag and the last closing tag are used.

## To reproduce : 

- create a translation string containing two times the same HTML tag, : `I <b>contain</b> two <b>bold</b> tags`
![two_strong_tags_string](https://github.com/user-attachments/assets/941f9ded-9235-40ef-9d64-ca39c688ca9a)

- create an ODT template with this translation string and upload it for any object
![two_strong_tags_tempalte](https://github.com/user-attachments/assets/91434bad-1c05-43e0-b236-5d4677698d5b)

- generate the ODT
- see that the string is incorrectly rendered
![two_strong_tags_result](https://github.com/user-attachments/assets/27159bcd-3d14-48c9-9ef0-add9988d05d7)

This PR fixes this behavior and adds a test to lock the correct behavior.

As a side enhancement, the PR reverses the orders of parameters in test assertEquals() method since they were not in the right order.




