### PR TITLE
fix: commande buy price not calculated (set to 0), at least in some cases

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4465,7 +4465,7 @@ class OrderLine extends CommonOrderLine
 	{
 		$error = 0;
 
-		$pa_ht_isemptystring = (empty($this->pa_ht) && $this->pa_ht == ''); // If true, we can use a default value. If this->pa_ht = '0', we must use '0'.
+		$pa_ht_isemptystring = (empty($this->pa_ht) && ($this->pa_ht == '' || $this->pa_ht === 0.0)); // If true, we can use a default value. If this->pa_ht = '0', we must use '0'.
 
 		dol_syslog(get_class($this)."::insert rang=".$this->rang);
 


### PR DESCRIPTION
# FIX|Fix commande buy price not calculated (set to 0), at least in some cases


Instead of `''`, `pa_ht` will be `0.0` by default as of Dolibarr 20.  
This lead to [$pa_ht_isemptystring](https://github.com/Dolibarr/dolibarr/blob/20.0/htdocs/commande/class/commande.class.php#L4468) being `FALSE` but for the very same data in Dolibarr 19 it was `TRUE`.  
This now prevented [defineBuyPrice](https://github.com/Dolibarr/dolibarr/blob/20.0/htdocs/commande/class/commande.class.php#L4518) to be called for calculating `pa_ht`.

Some context:
I'm migrating data to Dolibarr to (some day) start using it in production. So I do use the API. I migrated hundret's of items already. I just do it every now and then while directly improving quality of my book-keeping (which was a mess since I didn't know this wonderfull project exists).

Two days ago I migrated to Dolibarr 20 and today I recognized that on sales orders I have "0" as "costs", instead of (as before) the correct calculated value.

When searching for existing issues I saw #32429. Not sure if my change fixes this as well, since I don't know if this person also uses API or UI.

I haven't seen an issue when creating sales orders with UI yet, calculation worked there.