### PR TITLE
FIX #21294 Stock import sql query

### DIFF
--- a/htdocs/core/modules/modStock.class.php
+++ b/htdocs/core/modules/modStock.class.php
@@ -429,7 +429,7 @@ class modStock extends DolibarrModules
 		);
 		$this->import_updatekeys_array[$r] = array('ps.fk_product'=>'Product', 'ps.fk_entrepot'=>"Warehouse");
 		$this->import_run_sql_after_array[$r] = array(    // Because we may change data that are denormalized, we must update dernormalized data after.
-			'UPDATE '.MAIN_DB_PREFIX.'product as p SET p.stock = (SELECT SUM(ps.reel) FROM '.MAIN_DB_PREFIX.'product_stock ps WHERE ps.fk_product = p.rowid);'
+			'UPDATE '.MAIN_DB_PREFIX.'product as p SET stock = (SELECT SUM(ps.reel) FROM '.MAIN_DB_PREFIX.'product_stock ps WHERE ps.fk_product = p.rowid);'
 		);
 	}
 


### PR DESCRIPTION
# FIX #21294 Import stock fails

To respect the PostgreSQL update statement syntax, cf. https://www.postgresql.org/docs/17/sql-update.html

```
column_name
    The name of a column in the table named by table_name. The column name can
    be qualified with a subfield name or array subscript, if needed. Do not
    include the table's name in the specification of a target column — for
    example, UPDATE table_name SET table_name.col = 1 is invalid.
```