### PR TITLE
FIX Empty child warehouse sql error

### DIFF
--- a/htdocs/product/inventory/class/inventory.class.php
+++ b/htdocs/product/inventory/class/inventory.class.php
@@ -297,7 +297,9 @@ class Inventory extends CommonObject
 				if (!empty($include_sub_warehouse) && getDolGlobalInt('INVENTORY_INCLUDE_SUB_WAREHOUSE')) {
 					$TChildWarehouses = array();
 					$this->getChildWarehouse($this->fk_warehouse, $TChildWarehouses);
-					$sql .= " OR ps.fk_entrepot IN (".$this->db->sanitize(implode(',', $TChildWarehouses)).")";
+					if (!empty($TChildWarehouses)){
+						$sql .= " OR ps.fk_entrepot IN (".$this->db->sanitize(implode(',', $TChildWarehouses)).")";
+					}
 				}
 				$sql .= ')';
 			}

--- a/htdocs/product/inventory/class/inventory.class.php
+++ b/htdocs/product/inventory/class/inventory.class.php
@@ -297,8 +297,8 @@ class Inventory extends CommonObject
 				if (!empty($include_sub_warehouse) && getDolGlobalInt('INVENTORY_INCLUDE_SUB_WAREHOUSE')) {
 					$TChildWarehouses = array();
 					$this->getChildWarehouse($this->fk_warehouse, $TChildWarehouses);
-					if (!empty($TChildWarehouses)){
-						$sql .= " OR ps.fk_entrepot IN (".$this->db->sanitize(implode(',', $TChildWarehouses)).")";
+					if (!empty($TChildWarehouses)) {
+						$sql .= " OR ps.fk_entrepot IN (" . $this->db->sanitize(implode(',', $TChildWarehouses)) . ")";
 					}
 				}
 				$sql .= ')';


### PR DESCRIPTION
# FIX - Empty Child Warehouse in inventory
*If the warehouse did not have a child warehouse, this created an sql error during inventory validation and validated the empty inventory.*

