### PR TITLE
fix: manage error in Notification trigger

### DIFF
--- a/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
+++ b/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
@@ -96,7 +96,7 @@ class InterfaceNotification extends DolibarrTriggers
 		$notify = new Notify($this->db);
 		$resultSend = $notify->send($action, $object);
 		if ($resultSend < 0) {
-			$this->errors=array_merge($this->errors, $notify->errors);
+			$this->errors = array_merge($this->errors, $notify->errors);
 			return $resultSend;
 		}
 

--- a/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
+++ b/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
@@ -94,7 +94,11 @@ class InterfaceNotification extends DolibarrTriggers
 		dol_syslog("Trigger '".$this->name."' for action '".$action."' launched by ".__FILE__.". id=".$object->id);
 
 		$notify = new Notify($this->db);
-		$notify->send($action, $object);
+		$resultSend = $notify->send($action, $object);
+		if ($resultSend<0) {
+			$this->errors=array_merge($this->errors, $notify->errors);
+			return $resultSend;
+		}
 
 		return 1;
 	}

--- a/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
+++ b/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
@@ -95,7 +95,7 @@ class InterfaceNotification extends DolibarrTriggers
 
 		$notify = new Notify($this->db);
 		$resultSend = $notify->send($action, $object);
-		if ($resultSend<0) {
+		if ($resultSend < 0) {
 			$this->errors=array_merge($this->errors, $notify->errors);
 			return $resultSend;
 		}


### PR DESCRIPTION
Actually if the triggers Notification fail to send mail the process to not manage errors.
It would be better to catch the error
