### PR TITLE
fix: INVOICE_USE_SITUATION=2, display progress more than 100% in culumated progression

### DIFF
--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -389,6 +389,9 @@ if (isset($this->situation_cycle_ref) && $this->situation_cycle_ref) {
 	if (getDolGlobalInt('INVOICE_USE_SITUATION') == 2) {
 		$previous_progress = $line->get_allprev_progress($object->id);
 		$current_progress = $previous_progress + floatval($line->situation_percent);
+		if ($current_progress > 100.0) {
+			$current_progress = 100.0;
+		}
 		print '<td class="linecolcycleref nowrap right">'.$current_progress.'%</td>';
 		$coldisplay++;
 		print '<td  class="nowrap right">'.$line->situation_percent.'%</td>';


### PR DESCRIPTION

Create first situation invoice with one line at 100% and another at 10% progress
Create second situation invoice the line with 100% from the first one is now displayed at 200% because we always display previous plus current in this display
![image](https://github.com/user-attachments/assets/90169bf5-7a61-4d48-9190-aeeff0761552)

This information is not use in calculation of amount, it's just a displayed strange information.
A % of progression should not be more than 100%, if there is a additionnal cost it have to be another lines