### PR TITLE
FIX: product variants copy: also copy multiprice variations

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -950,8 +950,8 @@ class ProductCombination
 				$variations[$tmp_pc2v->fk_prod_attr] = $tmp_pc2v->fk_prod_attr_val;
 			}
 
-            $variation_price_percentage = $combination->variation_price_percentage;
-            $variation_price = $combination->variation_price;
+			$variation_price_percentage = $combination->variation_price_percentage;
+			$variation_price = $combination->variation_price;
 
 			if (getDolGlobalInt('PRODUIT_MULTIPRICES') && getDolGlobalInt('PRODUIT_MULTIPRICES_LIMIT') > 1) {
 				$variation_price_percentage = [ ];

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -753,7 +753,7 @@ class ProductCombination
 		}
 
 		if (!is_array($price_var_percent)) {
-			$price_var_percent = array(1 => (float) $price_var_percent);
+			$price_var_percent = array(1 => (bool) $price_var_percent);
 		}
 
 		$newcomb = new ProductCombination($this->db);
@@ -840,7 +840,7 @@ class ProductCombination
 				$productCombinationLevel->fk_product_attribute_combination = $newcomb->id;
 				$productCombinationLevel->fk_price_level = $i;
 				$productCombinationLevel->variation_price = $price_impact[$i];
-				$productCombinationLevel->variation_price_percentage = (empty($price_var_percent[$i]) ? false : $price_var_percent[$i]);
+				$productCombinationLevel->variation_price_percentage = $price_var_percent[$i];
 
 				$newcomb->combination_price_levels[$i] = $productCombinationLevel;
 			}


### PR DESCRIPTION
When conjointly using product variants et multiple price levels, when copying variants from a product A to a product B, the multiprice impact was not copied

Original product variant :
![Capture d’écran de 2025-01-07 17-14-02](https://github.com/user-attachments/assets/8f847b44-a397-473a-9c8b-1cafef5e4c18)

Copied product variant :
![Capture d’écran de 2025-01-07 17-14-05](https://github.com/user-attachments/assets/0a75f927-4933-4b5f-9217-5f9ebfb83a38)
