### PR TITLE
fix: remove list mass action update price when price mode is not uniq price

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -829,7 +829,7 @@ $arrayofmassactions = array(
 	//'presend'=>img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
 );
 if ($user->hasRight($rightskey, 'creer')) {
-	if (getDolGlobalString('PRODUCT_PRICE_UNIQ')) {
+	if (getDolGlobalString('PRODUCT_PRICE_UNIQ') || getDolGlobalString('PRODUIT_CUSTOMER_PRICES')) {
 		$arrayofmassactions['preupdateprice'] = img_picto('', 'edit', 'class="pictofixedwidth"').$langs->trans("UpdatePrice");
 	}
 

--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -829,7 +829,10 @@ $arrayofmassactions = array(
 	//'presend'=>img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
 );
 if ($user->hasRight($rightskey, 'creer')) {
-	$arrayofmassactions['preupdateprice'] = img_picto('', 'edit', 'class="pictofixedwidth"').$langs->trans("UpdatePrice");
+	if (getDolGlobalString('PRODUCT_PRICE_UNIQ')) {
+		$arrayofmassactions['preupdateprice'] = img_picto('', 'edit', 'class="pictofixedwidth"').$langs->trans("UpdatePrice");
+	}
+
 	$arrayofmassactions['switchonsalestatus'] = img_picto('', 'stop-circle', 'class="pictofixedwidth"').$langs->trans("SwitchOnSaleStatus");
 	$arrayofmassactions['switchonpurchasestatus'] = img_picto('', 'stop-circle', 'class="pictofixedwidth"').$langs->trans("SwitchOnPurchaseStatus");
 }


### PR DESCRIPTION
Product mass action update price have no impact if price rule is not uniq (or price by customer because base price always exists).
For exemple pricerule with multiprice level cannot be manage with this feature (acutally)
It will be a new feature to ask on witch lelvel(s) we want to apply the price variation