### PR TITLE
Fix : cron job user rights force reload

### DIFF
--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -210,7 +210,7 @@ if (is_array($object->lines) && (count($object->lines) > 0)) {
 						exit(-1);
 					}
 				}
-				$user->getrights();
+				$user->getrights('', 1); // We force rights reload to have the correct permissions for user in the entity we just switched in
 			}
 
 			// Reload langs


### PR DESCRIPTION
The script to run Dolibarr cron jobs switch between entities if necessary. It also reloads the user and its permissions. But the "forcereload" parameter was not set in the call to the getRights function, so rights were never really reloaded...