### PR TITLE
expensereportsjournal: fix empty IN () SQL request

### DIFF
--- a/htdocs/accountancy/journal/expensereportsjournal.php
+++ b/htdocs/accountancy/journal/expensereportsjournal.php
@@ -253,22 +253,24 @@ if ($result) {
 }
 
 // Load all unbound lines
-$sql = "SELECT fk_expensereport, COUNT(erd.rowid) as nb";
-$sql .= " FROM ".MAIN_DB_PREFIX."expensereport_det as erd";
-$sql .= " WHERE erd.fk_code_ventilation <= 0";
-$sql .= " AND erd.total_ttc <> 0";
-$sql .= " AND fk_expensereport IN (".$db->sanitize(implode(",", array_keys($taber))).")";
-$sql .= " GROUP BY fk_expensereport";
-$resql = $db->query($sql);
+if (!empty($taber)) {
+	$sql = "SELECT fk_expensereport, COUNT(erd.rowid) as nb";
+	$sql .= " FROM ".MAIN_DB_PREFIX."expensereport_det as erd";
+	$sql .= " WHERE erd.fk_code_ventilation <= 0";
+	$sql .= " AND erd.total_ttc <> 0";
+	$sql .= " AND fk_expensereport IN (".$db->sanitize(implode(",", array_keys($taber))).")";
+	$sql .= " GROUP BY fk_expensereport";
+	$resql = $db->query($sql);
 
-$num = $db->num_rows($resql);
-$i = 0;
-while ($i < $num) {
-	$obj = $db->fetch_object($resql);
-	if ($obj->nb > 0) {
-		$errorforinvoice[$obj->fk_expensereport] = 'somelinesarenotbound';
+	$num = $db->num_rows($resql);
+	$i = 0;
+	while ($i < $num) {
+		$obj = $db->fetch_object($resql);
+		if ($obj->nb > 0) {
+			$errorforinvoice[$obj->fk_expensereport] = 'somelinesarenotbound';
+		}
+		$i++;
 	}
-	$i++;
 }
 
 // Bookkeeping Write


### PR DESCRIPTION
# FIX expensereportsjournal: fix empty IN () SQL request, error with postgresql

`WHERE xx IN ()` is not allowed in PostgreSQL queries, and result in fatal errors.

We can check whether we have valid invoices before running the query, since the query will only check whether the invoices are complete or not.

It also fixes the following error on the development PHP output:

    Fatal error: Uncaught TypeError: pg_num_rows(): Argument #1 ($result)
    must be of type PgSql\Result, bool given in
    /var/www/html/core/db/pgsql.class.php:654 Stack trace: #0
    /var/www/html/core/db/pgsql.class.php(654): pg_num_rows(false) #1
    /var/www/html/accountancy/journal/expensereportsjournal.php(264):
    DoliDBPgsql->num_rows(false) #2 {main} thrown in
    /var/www/html/core/db/pgsql.class.php on line 654

References #32374.
