### PR TITLE
bookkeeping: listbyaccount: fix $num_rows warning

### DIFF
--- a/htdocs/accountancy/bookkeeping/listbyaccount.php
+++ b/htdocs/accountancy/bookkeeping/listbyaccount.php
@@ -157,7 +157,7 @@ if (empty($search_date_start) && empty($search_date_end) && !GETPOSTISSET('searc
 	$sql .= $db->plimit(1);
 	$res = $db->query($sql);
 
-	if ($res->num_rows > 0) {
+	if ($res !== false && $db->num_rows($res) > 0) {
 		$fiscalYear = $db->fetch_object($res);
 		$search_date_start = strtotime($fiscalYear->date_start);
 		$search_date_end = strtotime($fiscalYear->date_end);


### PR DESCRIPTION
# FIX bookkeeping: listbyaccount: fix $num_rows warning on postgresql

Fix the following warning:

	Warning: Undefined property: PgSql\Result::$num_rows in
	/var/www/html/accountancy/bookkeeping/listbyaccount.php on line 160

The warning is happening when listing the operations after the accounting setup is done but no accounts for bank nor operations are created.