### PR TITLE
Fix modulebuilder backward compatibility.

### DIFF
--- a/htdocs/modulebuilder/template/myobject_card.php
+++ b/htdocs/modulebuilder/template/myobject_card.php
@@ -629,12 +629,15 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 		// Show links to link elements
 		$tmparray = $form->showLinkToObjectBlock($object, array(), array('myobject'), 1);
-		$linktoelem = $tmparray['linktoelem'];
-		$htmltoenteralink = $tmparray['htmltoenteralink'];
-		print $htmltoenteralink;
-
-		$somethingshown = $form->showLinkedObjectBlock($object, $linktoelem);
-
+		if (is_array($tmparray)) {
+			$linktoelem = $tmparray['linktoelem'];
+			$htmltoenteralink = $tmparray['htmltoenteralink'];
+			print $htmltoenteralink;
+			$somethingshown = $form->showLinkedObjectBlock($object, $linktoelem);
+		} else {
+			// backward compatibility
+			$somethingshown = $form->showLinkedObjectBlock($object, $tmparray);
+		}
 
 		print '</div><div class="fichehalfright">';
 


### PR DESCRIPTION
To have a V21 build module also working on v20

~~On second thought, the return string to array change in V21 will cause trouble running v20- build modules on v21+.~~

@eldy Forgot to remove the nooutput parameter for testing.

Working on other backward compatibility solution. 
 
