### PR TITLE
fix: avoid php8 warning/error on failed notification

### DIFF
--- a/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
+++ b/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
@@ -96,6 +96,9 @@ class InterfaceNotification extends DolibarrTriggers
 		$notify = new Notify($this->db);
 		$resultSend = $notify->send($action, $object);
 		if ($resultSend < 0) {
+			if (!isset($this->errors)) {
+				$this->errors = [];
+			}
 			$this->errors = array_merge($this->errors, $notify->errors);
 			return $resultSend;
 		}


### PR DESCRIPTION

 Warning: array_merge(): Expected parameter 1 to be an array, null given in /var/www/htdocs/core/triggers/interface_50_modNotification_Notification.class.php on line 99


 when notification failed