### PR TITLE
FIX 20.0 - PHP8 fatal when creating a reception unless corresponding PDF model is enabled

### DIFF
--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -947,7 +947,7 @@ if ($action == 'create') {
 			include_once DOL_DOCUMENT_ROOT.'/core/modules/reception/modules_reception.php';
 			$list = ModelePdfReception::liste_modeles($db);
 
-			if (count($list) > 1) {
+			if (is_array($list) && count($list) > 1) {
 				print "<tr><td>".$langs->trans("DefaultModel")."</td>";
 				print '<td colspan="3">';
 				print $form->selectarray('model', $list, $conf->global->RECEPTION_ADDON_PDF);


### PR DESCRIPTION
# FIX PHP8 fatal when creating a reception unless corresponding PDF model is enabled

A customer reported that, when they create a reception, they get a blank page. Analysis showed that there was a PHP8 Fatal Error (`count($list)` with `$list` being a non-array) because this customer disabled all PDF models for receptions.