### PR TITLE
fix: avoid duplicate lines in inventory

### DIFF
--- a/htdocs/product/inventory/class/inventory.class.php
+++ b/htdocs/product/inventory/class/inventory.class.php
@@ -274,7 +274,7 @@ class Inventory extends CommonObject
 			// Scan existing stock to prefill the inventory
 			$sql = "SELECT ps.rowid, ps.fk_entrepot as fk_warehouse, ps.fk_product, ps.reel,";
 			if (isModEnabled('productbatch')) {
-				$sql .= " pb.batch as batch, pb.qty as qty,";
+				$sql .= " COALESCE(pb.batch, '') as batch, pb.qty as qty,";
 			} else {
 				$sql .= " '' as batch, 0 as qty,";
 			}


### PR DESCRIPTION
# Fix Avoid line duplicates in inventories

On inventories, when the batch module is enabled, one can create duplicate lines for products that don't need batch number.

![image](https://github.com/user-attachments/assets/ca442fff-f47c-453f-87a2-3f68d347f026)

The reason is that, for these products, the batch is saved as NULL in fk_inventorydet on inventory validation. But the UK constraint (fk_inventory, fk_warehouse, fk_product, batch) will allow duplicates lines if batch is NULL.

Bug exists on V20  and develop. 

This PR fixes this by saving batch = '' when batch is NULL (not defined) when the inventory is validated.

note - Bug also exists before V20, even when batch module is not enabled. So the fix is different prior to V20.

