### PR TITLE
Replace js with css for third party types and membres

### DIFF
--- a/htdocs/accountancy/admin/subaccount.php
+++ b/htdocs/accountancy/admin/subaccount.php
@@ -498,7 +498,7 @@ if ($resql) {
 				$s .= '<a class="vendor-back" style="padding-left: 6px; padding-right: 6px" title="'.$langs->trans("Supplier").'" href="'.DOL_URL_ROOT.'/fourn/card.php?socid='.$obj->rowid.'">'.$langs->trans("Supplier").'</a>';
 			} elseif ($obj->type == 3) {
 				// User - Employee
-				$s .= '<a class="user-back" style="padding-left: 6px; padding-right: 6px" title="'.$langs->trans("Employee").'" href="'.DOL_URL_ROOT.'/user/card.php?id='.$obj->rowid.'">'.$langs->trans("Employee").'</a>';
+				$s .= '<a class="back user" style="padding-left: 6px; padding-right: 6px" title="'.$langs->trans("Employee").'" href="'.DOL_URL_ROOT.'/user/card.php?id='.$obj->rowid.'">'.$langs->trans("Employee").'</a>';
 			}
 			print $s;
 			print '</td>';

--- a/htdocs/adherents/card.php
+++ b/htdocs/adherents/card.php
@@ -1030,40 +1030,18 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 		print "</td>\n";
 
 		// Morphy
-		$morphys = array();
-		$morphys["phy"] = $langs->trans("Physical");
-		$morphys["mor"] = $langs->trans("Moral");
-		$checkednature = (GETPOSTISSET("morphy") ? GETPOST("morphy", 'alpha') : $object->morphy);
+		$checkedNature = (GETPOSTISSET("morphy") ? GETPOST("morphy", 'alpha') : $object->morphy);
 		print '<tr><td class="fieldrequired">'.$langs->trans("MemberNature")."</td><td>\n";
-		print '<span id="spannature1" class="nonature-back spannature paddinglarge marginrightonly"><label for="phisicalinput" class="valignmiddle">'.$morphys["phy"].'<input id="phisicalinput" class="flat checkforselect marginleftonly valignmiddle" type="radio" name="morphy" value="phy"'.($checkednature == "phy" ? ' checked="checked"' : '').'></label></span>';
-		print '<span id="spannature2" class="nonature-back spannature paddinglarge marginrightonly"><label for="moralinput" class="valignmiddle">'.$morphys["mor"].'<input id="moralinput" class="flat checkforselect marginleftonly valignmiddle" type="radio" name="morphy" value="mor"'.($checkednature == "mor" ? ' checked="checked"' : '').'></label></span>';
-
-		// Add js to manage the background of nature
-		if ($conf->use_javascript_ajax) {
-			print '<script>
-				function refreshNatureCss() {
-					jQuery(".spannature").each(function( index ) {
-						console.log(jQuery("#spannature"+(index+1)+" .checkforselect").is(":checked"));
-						if (jQuery("#spannature"+(index+1)+" .checkforselect").is(":checked")) {
-							if (index+1 == 1) {
-								jQuery("#spannature"+(index+1)).addClass("member-individual-back").removeClass("nonature-back");
-							}
-							if (index+1 == 2) {
-								jQuery("#spannature"+(index+1)).addClass("member-company-back").removeClass("nonature-back");
-							}
-						} else {
-							jQuery("#spannature"+(index+1)).removeClass("member-individual-back").removeClass("member-company-back").addClass("nonature-back");
-						}
-					});
-				}
-				jQuery(".spannature").click(function(){
-					console.log("We click on a nature");
-					refreshNatureCss();
-				});
-				refreshNatureCss();
-				</script>';
-		}
-
+		?>
+		<span class="nature paddinglarge marginrightonly">
+			<input type="radio" id="physical-input" name="morphy" value="phy" <?= $checkedNature == "phy" ? 'checked="checked"' : '' ?>>
+			<label for="physical-input"><?= $langs->trans("Physical") ?></label>
+		</span>
+		<span class="nature paddinglarge marginrightonly">
+			<input type="radio" id="moral-input" name="morphy" value="mor" <?= $checkedNature == "mor" ? 'checked="checked"' : '' ?>>
+			<label for="moral-input"><?= $langs->trans("Moral"); ?></label>
+		</span>
+		<?php
 		print "</td>\n";
 
 		// Company
@@ -1293,13 +1271,19 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 		print "</td></tr>";
 
 		// Morphy
-		$morphys["phy"] = $langs->trans("Physical");
-		$morphys["mor"] = $langs->trans("Moral");
-		$checkednature = (GETPOSTISSET("morphy") ? GETPOST("morphy", 'alpha') : $object->morphy);
-		print '<tr><td><span class="fieldrequired">'.$langs->trans("MemberNature").'</span></td><td>';
-		print '<span id="spannature1" class="member-individual-back spannature paddinglarge marginrightonly"><label for="phisicalinput" class="valignmiddle">'.$morphys["phy"].'<input id="phisicalinput" class="flat checkforselect marginleftonly valignmiddle" type="radio" name="morphy" value="phy"'.($checkednature == "phy" ? ' checked="checked"' : '').'></label></span>';
-		print '<span id="spannature1" class="member-company-back spannature paddinglarge marginrightonly"><label for="moralinput" class="valignmiddle">'.$morphys["mor"].'<input id="moralinput" class="flat checkforselect marginleftonly valignmiddle" type="radio" name="morphy" value="mor"'.($checkednature == "mor" ? ' checked="checked"' : '').'></label></span>';
-		print "</td></tr>";
+		$checkedNature = (GETPOSTISSET("morphy") ? GETPOST("morphy", 'alpha') : $object->morphy);
+		print '<tr><td class="fieldrequired">'.$langs->trans("MemberNature")."</td><td>\n";
+		?>
+		<span class="back nature paddinglarge marginrightonly">
+			<input type="radio" id="physical-input" name="morphy" value="phy" <?= $checkedNature == "phy" ? 'checked="checked"' : '' ?>>
+			<label for="physical-input"><?= $langs->trans("Physical") ?></label>
+		</span>
+		<span class="back nature paddinglarge marginrightonly">
+			<input type="radio" id="moral-input" name="morphy" value="mor" <?= $checkedNature == "mor" ? 'checked="checked"' : '' ?>>
+			<label for="moral-input"><?= $langs->trans("Moral"); ?></label>
+		</span>
+		<?php
+		print "</td></tr>\n";
 
 		// Company
 		print '<tr><td id="tdcompany">'.$langs->trans("Company").'</td><td><input type="text" name="societe" class="minwidth300" maxlength="128" value="'.(GETPOSTISSET("societe") ? GETPOST("societe", 'alphanohtml', 2) : $object->company).'"></td></tr>';

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -587,7 +587,7 @@ class Adherent extends CommonObject
 						$labeltoshow = dol_strtoupper(dolGetFirstLetters($labeltoshowp, 2));
 					}
 				}
-				$s .= '<span class="member-individual-back paddingleftimp paddingrightimp" title="'.$langs->trans("Physical").'">'.$labeltoshow.'</span>';
+				$s .= '<span class="back physical paddingleftimp paddingrightimp" title="'.$langs->trans("Physical").'">'.$labeltoshow.'</span>';
 			}
 			if ($morphy == 'mor') {
 				$labeltoshow = $labeltoshowm;
@@ -597,7 +597,7 @@ class Adherent extends CommonObject
 						$labeltoshow = dol_strtoupper(dolGetFirstLetters($labeltoshowm, 2));
 					}
 				}
-				$s .= '<span class="member-company-back paddingleftimp paddingrightimp" title="'.$langs->trans("Moral").'">'.$labeltoshow.'</span>';
+				$s .= '<span class="back moral paddingleftimp paddingrightimp" title="'.$langs->trans("Moral").'">'.$labeltoshow.'</span>';
 			}
 		} else {
 			if ($morphy == 'phy') {

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1493,7 +1493,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 			if (!getDolGlobalString('SOCIETE_DISABLE_PROSPECTS')) {
 				?>
-				<span class="nature paddinglarge marginrightonly">
+				<span class="back nature paddinglarge marginrightonly">
 					<input type="checkbox" id="prospect-input" name="prospect" value="2" <?= $selectedProspect ? 'checked="checked"' : '' ?>>
 					<label for="prospect-input"><?= $langs->trans("Prospect") ?></label>
 				</span>
@@ -1502,7 +1502,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 			if (!getDolGlobalString('SOCIETE_DISABLE_CUSTOMERS')) {
 				?>
-				<span class="nature paddinglarge marginrightonly">
+				<span class="back nature paddinglarge marginrightonly">
 					<input type="checkbox" id="customer-input" name="customer" value="1" <?= $selectedCustomer ? 'checked="checked"' : '' ?>>
 					<label for="customer-input"><?= $langs->trans("Customer") ?></label>
 				</span>
@@ -1514,7 +1514,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 				// Supplier
 				$selected = (GETPOSTISSET('supplier') ? GETPOSTINT('supplier') : $object->fournisseur);
 				?>
-				<span class="nature paddinglarge marginrightonly">
+				<span class="back nature paddinglarge marginrightonly">
 						<input type="checkbox" id="supplier-input" name="supplier" value="1" <?= $selected ? 'checked="checked"' : '' ?>>
 						<label for="supplier-input"><?= $langs->trans("Vendor") ?></label>
 					</span>
@@ -2306,7 +2306,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 				if (!getDolGlobalString('SOCIETE_DISABLE_PROSPECTS')) {
 					?>
-					<span class="nature paddinglarge marginrightonly">
+					<span class="back nature paddinglarge marginrightonly">
 						<input type="checkbox" id="prospect-input" name="prospect" value="2" <?= $selectedProspect ? 'checked="checked"' : '' ?>>
 						<label for="prospect-input"><?= $langs->trans("Prospect") ?></label>
 					</span>
@@ -2315,7 +2315,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 				if (!getDolGlobalString('SOCIETE_DISABLE_CUSTOMERS')) {
 					?>
-					<span class="nature paddinglarge marginrightonly">
+					<span class="back nature paddinglarge marginrightonly">
 						<input type="checkbox" id="customer-input" name="customer" value="1" <?= $selectedCustomer ? 'checked="checked"' : '' ?>>
 						<label for="customer-input"><?= $langs->trans("Customer") ?></label>
 					</span>
@@ -2326,7 +2326,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 					// Supplier
 					$selected = (GETPOSTISSET('supplier') ? GETPOSTINT('supplier') : $object->fournisseur);
 					?>
-					<span class="nature paddinglarge marginrightonly">
+					<span class="back nature paddinglarge marginrightonly">
 						<input type="checkbox" id="supplier-input" name="supplier" value="1" <?= $selected ? 'checked="checked"' : '' ?>>
 						<label for="supplier-input"><?= $langs->trans("Vendor") ?></label>
 					</span>

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1466,25 +1466,25 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 			// Prospect/Customer/Supplier
 			$selected = $object->client;
-			$selectedcustomer = 0;
-			$selectedprospect = 0;
+			$selectedCustomer = 0;
+			$selectedProspect = 0;
 			switch ($selected) {
 				case 1:
-					$selectedcustomer = 1;
+					$selectedCustomer = 1;
 					break;
 				case 2:
-					$selectedprospect = 1;
+					$selectedProspect = 1;
 					break;
 				case 3:
-					$selectedprospect = 1;
-					$selectedcustomer = 1;
+					$selectedProspect = 1;
+					$selectedCustomer = 1;
 					break;
 				default:
 					break;
 			}
 
-			$selectedprospect = (GETPOSTISSET('prospect') ? GETPOSTINT('prospect') : $selectedprospect);
-			$selectedcustomer = (GETPOSTISSET('customer') ? GETPOSTINT('customer') : $selectedcustomer);
+			$selectedProspect = (GETPOSTISSET('prospect') ? GETPOSTINT('prospect') : $selectedProspect);
+			$selectedCustomer = (GETPOSTISSET('customer') ? GETPOSTINT('customer') : $selectedCustomer);
 			print '<tr class="marginbottomlarge height50">';
 			if ($conf->browser->layout != 'phone') {
 				print '<td class="titlefieldcreate">'.$form->editfieldkey('', 'customerprospect', '', $object, 0, 'string', '', 0).'</td>';
@@ -1492,60 +1492,33 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 			print '<td class="maxwidthonsmartphone"'.($conf->browser->layout != 'phone' ? 'colspan="3"' : 'colspan="2"').'>';
 
 			if (!getDolGlobalString('SOCIETE_DISABLE_PROSPECTS')) {
-				print '<span id="spannature1" class="spannature prospect-back paddinglarge marginrightonly"><label for="prospectinput" class="valignmiddle">'.$langs->trans("Prospect").'<input id="prospectinput" class="flat checkforselect marginleftonly valignmiddle" type="checkbox" name="prospect" value="2"'.($selectedprospect ? ' checked="checked"' : '').'></label></span>';
+				?>
+				<span class="nature paddinglarge marginrightonly">
+					<input type="checkbox" id="prospect-input" name="prospect" value="2" <?= $selectedProspect ? 'checked="checked"' : '' ?>>
+					<label for="prospect-input"><?= $langs->trans("Prospect") ?></label>
+				</span>
+				<?php
 			}
 
 			if (!getDolGlobalString('SOCIETE_DISABLE_CUSTOMERS')) {
-				print '<span id="spannature2" class="spannature customer-back paddinglarge marginrightonly"><label for="customerinput" class="valignmiddle">'.$langs->trans("Customer").'<input id="customerinput" class="flat checkforselect marginleftonly valignmiddle" type="checkbox" name="customer" value="1"'.($selectedcustomer ? ' checked="checked"' : '').'></label></span>';
+				?>
+				<span class="nature paddinglarge marginrightonly">
+					<input type="checkbox" id="customer-input" name="customer" value="1" <?= $selectedCustomer ? 'checked="checked"' : '' ?>>
+					<label for="customer-input"><?= $langs->trans("Customer") ?></label>
+				</span>
+				<?php
 			}
 
 			if ((isModEnabled("fournisseur") && $user->hasRight('fournisseur', 'lire') && !getDolGlobalString('MAIN_USE_NEW_SUPPLIERMOD')) || (isModEnabled("supplier_order") && $user->hasRight('supplier_order', 'lire')) || (isModEnabled("supplier_invoice") && $user->hasRight('supplier_invoice', 'lire'))
 				|| (isModEnabled('supplier_proposal') && $user->hasRight('supplier_proposal', 'lire'))) {
 				// Supplier
 				$selected = (GETPOSTISSET('supplier') ? GETPOSTINT('supplier') : $object->fournisseur);
-				print '<span id="spannature3" class="spannature vendor-back paddinglarge marginrightonly"><label for="supplierinput" class="valignmiddle">'.$langs->trans("Vendor").'<input id="supplierinput" class="flat checkforselect marginleftonly valignmiddle" type="checkbox" name="supplier" value="1"'.($selected ? ' checked="checked"' : '').'></label></span>';
-			}
-			// Add js to manage the background of nature
-			if ($conf->use_javascript_ajax) {
-				print '<script>
-				function refreshNatureCss() {
-					jQuery(".spannature").each(function( index ) {
-						id = $(this).attr("id").split("spannature")[1];
-						console.log(jQuery("#spannature"+(id)+" .checkforselect").is(":checked"));
-						if (jQuery("#spannature"+(id)+" .checkforselect").is(":checked")) {
-							if (id == 1) {
-								jQuery("#spannature"+(id)).addClass("prospect-back").removeClass("nonature-back");
-							}
-							if (id == 2) {
-								jQuery("#spannature"+(id)).addClass("customer-back").removeClass("nonature-back");
-							}
-							if (id == 3) {
-								jQuery("#spannature"+(id)).addClass("vendor-back").removeClass("nonature-back");
-							}
-						} else {
-							jQuery("#spannature"+(id)).removeClass("prospect-back").removeClass("customer-back").removeClass("vendor-back").addClass("nonature-back");
-						}
-					});
-				}
-
-				function manageprospectcustomer(element) {
-					console.log("We uncheck unwanted values on a nature");
-					id = $(element).attr("id").split("spannature")[1];
-					if ( id == 1){
-						$("#spannature2 .checkforselect").prop("checked", false);
-					}
-					if ( id == 2){
-						$("#spannature1 .checkforselect").prop("checked", false);
-					}
-				}
-
-				jQuery(".spannature").click(function(){
-					console.log("We click on a nature");
-					'.(getDolGlobalString('SOCIETE_DISABLE_PROSPECTSCUSTOMERS') ? 'manageprospectcustomer($(this));' : '').'
-					refreshNatureCss();
-				});
-				refreshNatureCss();
-				</script>';
+				?>
+				<span class="nature paddinglarge marginrightonly">
+						<input type="checkbox" id="supplier-input" name="supplier" value="1" <?= $selected ? 'checked="checked"' : '' ?>>
+						<label for="supplier-input"><?= $langs->trans("Vendor") ?></label>
+					</span>
+				<?php
 			}
 			print '</td>';
 			print '</tr>';
@@ -2308,85 +2281,58 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 				// Prospect/Customer/Supplier
 				$selected = $object->client;
-				$selectedcustomer = 0;
-				$selectedprospect = 0;
+				$selectedCustomer = 0;
+				$selectedProspect = 0;
 				switch ($selected) {
 					case 1:
-						$selectedcustomer = 1;
+						$selectedCustomer = 1;
 						break;
 					case 2:
-						$selectedprospect = 1;
+						$selectedProspect = 1;
 						break;
 					case 3:
-						$selectedprospect = 1;
-						$selectedcustomer = 1;
+						$selectedProspect = 1;
+						$selectedCustomer = 1;
 						break;
 					default:
 						break;
 				}
 
 				// Nature of thirdparty
-				$selectedprospect = (GETPOSTISSET('prospect') ? GETPOSTINT('prospect') : $selectedprospect);
-				$selectedcustomer = (GETPOSTISSET('customer') ? GETPOSTINT('customer') : $selectedcustomer);
+				$selectedProspect = (GETPOSTISSET('prospect') ? GETPOSTINT('prospect') : $selectedProspect);
+				$selectedCustomer = (GETPOSTISSET('customer') ? GETPOSTINT('customer') : $selectedCustomer);
 				print '<tr class="marginbottomlarge height50"><td class="titlefieldcreate">'.$form->editfieldkey('', 'customerprospect', '', $object, 0, 'string', '', 0).'</td>';
 				print '<td class="maxwidthonsmartphone" colspan="3">';
 
 				if (!getDolGlobalString('SOCIETE_DISABLE_PROSPECTS')) {
-					print '<span id="spannature1" class="spannature prospect-back paddinglarge marginrightonly"><label for="prospectinput" class="valignmiddle">'.$langs->trans("Prospect").'<input id="prospectinput" class="flat checkforselect marginleftonly valignmiddle" type="checkbox" name="prospect" value="2"'.($selectedprospect ? ' checked="checked"' : '').'></label></span>';
+					?>
+					<span class="nature paddinglarge marginrightonly">
+						<input type="checkbox" id="prospect-input" name="prospect" value="2" <?= $selectedProspect ? 'checked="checked"' : '' ?>>
+						<label for="prospect-input"><?= $langs->trans("Prospect") ?></label>
+					</span>
+					<?php
 				}
 
 				if (!getDolGlobalString('SOCIETE_DISABLE_CUSTOMERS')) {
-					print '<span id="spannature2" class="spannature customer-back paddinglarge marginrightonly"><label for="customerinput" class="valignmiddle">'.$langs->trans("Customer").'<input id="customerinput" class="flat checkforselect marginleftonly valignmiddle" type="checkbox" name="customer" value="1"'.($selectedcustomer ? ' checked="checked"' : '').'></label></span>';
+					?>
+					<span class="nature paddinglarge marginrightonly">
+						<input type="checkbox" id="customer-input" name="customer" value="1" <?= $selectedCustomer ? 'checked="checked"' : '' ?>>
+						<label for="customer-input"><?= $langs->trans("Customer") ?></label>
+					</span>
+					<?php
 				}
 				if ((isModEnabled("fournisseur") && $user->hasRight('fournisseur', 'lire') && !getDolGlobalString('MAIN_USE_NEW_SUPPLIERMOD')) || (isModEnabled("supplier_order") && $user->hasRight('supplier_order', 'lire')) || (isModEnabled("supplier_invoice") && $user->hasRight('supplier_invoice', 'lire'))
 					|| (isModEnabled('supplier_proposal') && $user->hasRight('supplier_proposal', 'lire'))) {
 					// Supplier
 					$selected = (GETPOSTISSET('supplier') ? GETPOSTINT('supplier') : $object->fournisseur);
-					print '<span id="spannature3" class="spannature vendor-back paddinglarge marginrightonly"><label for="supplierinput" class="valignmiddle">'.$langs->trans("Vendor").'<input id="supplierinput" class="flat checkforselect marginleftonly valignmiddle" type="checkbox" name="supplier" value="1"'.($selected ? ' checked="checked"' : '').'></label></span>';
+					?>
+					<span class="nature paddinglarge marginrightonly">
+						<input type="checkbox" id="supplier-input" name="supplier" value="1" <?= $selected ? 'checked="checked"' : '' ?>>
+						<label for="supplier-input"><?= $langs->trans("Vendor") ?></label>
+					</span>
+					<?php
 				}
 
-				// Add js to manage the background of nature
-				if ($conf->use_javascript_ajax) {
-					print '<script>
-						function refreshNatureCss() {
-							jQuery(".spannature").each(function( index ) {
-								id = $(this).attr("id").split("spannature")[1];
-								console.log(jQuery("#spannature"+(id)+" .checkforselect").is(":checked"));
-								if (jQuery("#spannature"+(id)+" .checkforselect").is(":checked")) {
-									if (id == 1) {
-										jQuery("#spannature"+(id)).addClass("prospect-back").removeClass("nonature-back");
-									}
-									if (id == 2) {
-										jQuery("#spannature"+(id)).addClass("customer-back").removeClass("nonature-back");
-									}
-									if (id == 3) {
-										jQuery("#spannature"+(id)).addClass("vendor-back").removeClass("nonature-back");
-									}
-								} else {
-									jQuery("#spannature"+(id)).removeClass("prospect-back").removeClass("customer-back").removeClass("vendor-back").addClass("nonature-back");
-								}
-							})
-						}
-
-						function manageprospectcustomer(element) {
-							console.log("We uncheck unwanted values on a nature");
-							id = $(element).attr("id").split("spannature")[1];
-							if ( id == 1){
-								$("#spannature2 .checkforselect").prop("checked", false);
-							}
-							if ( id == 2){
-								$("#spannature1 .checkforselect").prop("checked", false);
-							}
-						}
-
-						jQuery(".spannature").click(function(){
-							console.log("We click on a nature");
-							'.(getDolGlobalString('SOCIETE_DISABLE_PROSPECTSCUSTOMERS') ? 'manageprospectcustomer($(this));' : '').'
-							refreshNatureCss();
-						});
-						refreshNatureCss();
-						</script>';
-				}
 				print '</td>';
 				print '</tr>';
 				print '<tr><td>'.$form->editfieldkey('CustomerCode', 'customer_code', '', $object, 0).'</td><td>';

--- a/htdocs/theme/eldy/info-box.inc.php
+++ b/htdocs/theme/eldy/info-box.inc.php
@@ -346,36 +346,32 @@ if (GETPOSTISSET('THEME_SATURATE_RATIO')) {
 	<?php } ?>
 }
 
-.nonature-back {
-	background-color: #EEE;
-	padding: 2px;
-	margin: 2px;
+.nature label {
+	background: #EEE;
+	color: #000;
+	padding: 5px 10px;
 	border-radius: 3px;
+	cursor: pointer;
 }
-.prospect-back {
-	background-color: #a7c5b0 !important;
-	color: #FFF !important;
-	padding: 2px;
-	margin: 2px;
-	border-radius: 3px;
+.nature input[type="checkbox"] {
+	display: none;
 }
-.customer-back {
-	background-color: #55955d !important;
-	color: #FFF !important;
-	padding: 2px;
-	margin: 2px;
-	border-radius: 3px;
+
+.nature input:checked + label {
+	color: #fff;
 }
-.vendor-back {
-	background-color: #599caf !important;
-	color: #FFF !important;
-	padding: 2px;
-	margin: 2px;
-	border-radius: 3px;
+.nature input#prospect-input:checked + label {
+	background: #a7c5b0;
+}
+.nature input#customer-input:checked + label {
+	background: #65953d;
+}
+.nature input#supplier-input:checked + label {
+	background: #599caf;
 }
 .user-back {
-	background-color: #79633f !important;
-	color: #FFF !important;
+	background-color: #79633f;
+	color: #FFF;
 	padding: 2px;
 	margin: 2px;
 	border-radius: 3px;

--- a/htdocs/theme/eldy/info-box.inc.php
+++ b/htdocs/theme/eldy/info-box.inc.php
@@ -346,14 +346,20 @@ if (GETPOSTISSET('THEME_SATURATE_RATIO')) {
 	<?php } ?>
 }
 
+.back {
+	padding: 2px;
+	margin: 2px;
+	border-radius: 3px;
+}
 .nature label {
 	background: #EEE;
 	color: #000;
 	padding: 5px 10px;
-	border-radius: 3px;
 	cursor: pointer;
+	border-radius: 3px;
 }
-.nature input[type="checkbox"] {
+.nature input[type="checkbox"],
+.nature input[type="radio"] {
 	display: none;
 }
 
@@ -369,28 +375,18 @@ if (GETPOSTISSET('THEME_SATURATE_RATIO')) {
 .nature input#supplier-input:checked + label {
 	background: #599caf;
 }
-.user-back {
+.nature input#physical-input:checked + label,
+.nature input#moral-input:checked + label,
+.physical,
+.moral {
+	background: #599caf;
+	white-space: nowrap;
+	color: #fff;
+}
+
+.user {
 	background-color: #79633f;
 	color: #FFF;
-	padding: 2px;
-	margin: 2px;
-	border-radius: 3px;
-}
-.member-company-back {
-	padding: 2px;
-	margin: 2px;
-	background-color: #e4e4e4;
-	color: #666;
-	border-radius: 3px;
-	white-space: nowrap;
-}
-.member-individual-back {
-	padding: 2px;
-	margin: 2px;
-	background-color: #e4e4e4;
-	color: #666;
-	border-radius: 3px;
-	white-space: nowrap;
 }
 
 

--- a/htdocs/theme/md/info-box.inc.php
+++ b/htdocs/theme/md/info-box.inc.php
@@ -40,14 +40,20 @@ if (GETPOSTISSET('THEME_SATURATE_RATIO')) {
 
 ?>
 
+.back {
+	padding: 2px;
+	margin: 2px;
+	border-radius: 3px;
+}
 .nature label {
 	background: #EEE;
 	color: #000;
 	padding: 5px 10px;
-	border-radius: 3px;
 	cursor: pointer;
+	border-radius: 3px;
 }
-.nature input[type="checkbox"] {
+.nature input[type="checkbox"],
+.nature input[type="radio"] {
 	display: none;
 }
 
@@ -63,28 +69,18 @@ if (GETPOSTISSET('THEME_SATURATE_RATIO')) {
 .nature input#supplier-input:checked + label {
 	background: #599caf;
 }
-.user-back {
+.nature input#physical-input:checked + label,
+.nature input#moral-input:checked + label,
+.physical,
+.moral {
+	background: #599caf;
+	white-space: nowrap;
+	color: #fff;
+}
+
+.user {
 	background-color: #79633f;
 	color: #FFF;
-	padding: 2px;
-	margin: 2px;
-	border-radius: 3px;
-}
-.member-company-back {
-	padding: 2px;
-	margin: 2px;
-	background-color: #e4e4e4;
-	color: #666;
-	border-radius: 3px;
-	white-space: nowrap;
-}
-.member-individual-back {
-	padding: 2px;
-	margin: 2px;
-	background-color: #e4e4e4;
-	color: #666;
-	border-radius: 3px;
-	white-space: nowrap;
 }
 
 .bg-infobox-project{

--- a/htdocs/theme/md/info-box.inc.php
+++ b/htdocs/theme/md/info-box.inc.php
@@ -40,36 +40,32 @@ if (GETPOSTISSET('THEME_SATURATE_RATIO')) {
 
 ?>
 
-.nonature-back {
-	background-color: #EEE;
-	padding: 2px;
-	margin: 2px;
+.nature label {
+	background: #EEE;
+	color: #000;
+	padding: 5px 10px;
 	border-radius: 3px;
+	cursor: pointer;
 }
-.prospect-back {
-	background-color: #a7c5b0 !important;
-	color: #FFF !important;
-	padding: 2px;
-	margin: 2px;
-	border-radius: 3px;
+.nature input[type="checkbox"] {
+	display: none;
 }
-.customer-back {
-	background-color: #65953d !important;
-	color: #FFF !important;
-	padding: 2px;
-	margin: 2px;
-	border-radius: 3px;
+
+.nature input:checked + label {
+	color: #fff;
 }
-.vendor-back {
-	background-color: #599caf !important;
-	color: #FFF !important;
-	padding: 2px;
-	margin: 2px;
-	border-radius: 3px;
+.nature input#prospect-input:checked + label {
+	background: #a7c5b0;
+}
+.nature input#customer-input:checked + label {
+	background: #65953d;
+}
+.nature input#supplier-input:checked + label {
+	background: #599caf;
 }
 .user-back {
-	background-color: #79633f !important;
-	color: #FFF !important;
+	background-color: #79633f;
+	color: #FFF;
 	padding: 2px;
 	margin: 2px;
 	border-radius: 3px;


### PR DESCRIPTION
# Qual #[*Remove JS to add styles on third parties and membres types*]
As CSS is powerful, we should not use JS to add or remove styles according to a checked value of an input.
In this way, I removed JQuery scripts in third parties and members page, to replace it with some CSS.

The only difference is that I hid the default checkox, since the button colours are significant enough, and it gives a more modern look

![image](https://github.com/user-attachments/assets/74fa879d-5ab5-4fa1-ba4f-8d726845b8ba)
