### PR TITLE
Show only open projects on short list

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -245,7 +245,7 @@ function dolDecrypt($chain, $key = '')
  * 										Use 'md5' if hash is not needed for security purpose. For security need, prefer 'auto'.
  * 	@param 		int 		$nosalt		Do not include any salt
  *  @param		int			$mode		0=Return encoded password, 1=Return array with encoding password + encoding algorithm
- * 	@return		string|array<pass_encrypted:string,pass_encoding:string>			Hash of string or array with pass_encrypted and pass_encoding
+ * 	@return		string|array(pass_encrypted:string,pass_encoding:string)			Hash of string or array with pass_encrypted and pass_encoding
  *  @see getRandomPassword(), dol_verifyHash()
  */
 function dol_hash($chain, $type = '0', $nosalt = 0, $mode = 0)

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -245,7 +245,7 @@ function dolDecrypt($chain, $key = '')
  * 										Use 'md5' if hash is not needed for security purpose. For security need, prefer 'auto'.
  * 	@param 		int 		$nosalt		Do not include any salt
  *  @param		int			$mode		0=Return encoded password, 1=Return array with encoding password + encoding algorithm
- * 	@return		string|array(pass_encrypted:string,pass_encoding:string)			Hash of string or array with pass_encrypted and pass_encoding
+ * 	@return		string|array<pass_encrypted:string,pass_encoding:string>			Hash of string or array with pass_encrypted and pass_encoding
  *  @see getRandomPassword(), dol_verifyHash()
  */
 function dol_hash($chain, $type = '0', $nosalt = 0, $mode = 0)

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -312,3 +312,6 @@ TaskMergeSuccess=Tasks have been merged
 ErrorTaskIdIsMandatory=Error: Task id is mandatory
 ErrorsTaskMerge=An error occurred while merging tasks
 Billable = Billable
+PROJECT_SHOW_ONLY_VALIDATED_ON_LATEST_UPDATE_help=By default dolibarr displays all projects (draft, closed, open) on project index page ("latest projects short list"). With that option dolibarr will display only validated projects to make a more concise list.
+PROJECT_SHOW_ONLY_VALIDATED_ON_LATEST_UPDATE=Display only validated projects on short list
+

--- a/htdocs/projet/admin/project.php
+++ b/htdocs/projet/admin/project.php
@@ -872,6 +872,16 @@ print ajax_constantonoff('PROJECT_DISPLAY_LINKED_BY_CONTACT');
 print '</td>';
 print '</tr>';
 
+
+print '<tr class="oddeven">';
+print '<td class="left">';
+print $form->textwithpicto($langs->transnoentities('PROJECT_SHOW_ONLY_VALIDATED_ON_LATEST_UPDATE'), $langs->transnoentities('PROJECT_SHOW_ONLY_VALIDATED_ON_LATEST_UPDATE_help'));
+print '</td>';
+print '<td class="right" colspan="2">';
+print ajax_constantonoff('PROJECT_SHOW_ONLY_VALIDATED_ON_LATEST_UPDATE');
+print '</td>';
+print '</tr>';
+
 print '</table>';
 print '</div>';
 

--- a/htdocs/projet/index.php
+++ b/htdocs/projet/index.php
@@ -247,6 +247,10 @@ if ($mine || !$user->hasRight('projet', 'all', 'lire')) {
 if ($socid) {
 	$sql .= " AND (p.fk_soc IS NULL OR p.fk_soc = 0 OR p.fk_soc = ".((int) $socid).")";
 }
+if (getDolGlobalInt('PROJECT_SHOW_ONLY_VALIDATED_ON_LATEST_UPDATE', 0) == 1) {
+	$sql .= " AND p.fk_statut=" . (int) Project::STATUS_VALIDATED;
+}
+
 $sql .= " ORDER BY p.tms DESC";
 $sql .= $db->plimit($max, 0);
 


### PR DESCRIPTION
With a standard dolibarr setup here is what you can see:

![image](https://github.com/user-attachments/assets/7c209062-b3f8-4bfc-bff1-526c421e7b86)

most of them are not valided ... that PR add an option to make that result:

![image](https://github.com/user-attachments/assets/da8f7a4a-cac8-4ff2-aabd-ee21b81d022d)
