### PR TITLE
fix(services-list): search thirdparty by name

### DIFF
--- a/htdocs/contrat/services_list.php
+++ b/htdocs/contrat/services_list.php
@@ -281,7 +281,7 @@ if ($filter == "notexpired") {
 	$sql .= " AND cd.date_fin_validite >= '".$db->idate($now)."'";
 }
 if ($search_name) {
-	$sql .= natural_search("c.ref", $search_name);
+	$sql .= natural_search("s.nom", $search_name);
 }
 if ($search_contract) {
 	$sql .= natural_search("c.ref", $search_contract);


### PR DESCRIPTION
# FIX|Fix search thirdparty by name
Before, it was not possible to search thirdparty by name in service list because it was searching on c.ref instead of s.nom.