### PR TITLE
FIX selectcontact is loading all contacts when update event

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -1670,7 +1670,12 @@ if ($id > 0) {
 			// related contact
 			print '<tr><td>'.$langs->trans("ActionOnContact").'</td><td>';
 			print '<div class="maxwidth200onsmartphone">';
-			print img_picto('', 'contact', 'class="paddingrightonly"').$form->selectcontacts($object->socid, array_keys($object->socpeopleassigned), 'socpeopleassigned[]', 1, '', '', 1, 'quatrevingtpercent', false, 0, 0, array(), 'multiple', 'contactid');
+			if (getDolGlobalInt('MAIN_ACTIONCOM_CAN_ADD_ANY_CONTACT')) {
+				$select_contact_default = 0; // select "all" contacts by default : avoid to use it if there is a lot of contacts
+			} else {
+				$select_contact_default = -1; // select "none" by default
+			}
+			print img_picto('', 'contact', 'class="paddingrightonly"').$form->selectcontacts(!empty($object->socid) ? $object->socid : $select_contact_default, array_keys($object->socpeopleassigned), 'socpeopleassigned[]', 1, '', '', 1, 'quatrevingtpercent', false, 0, 0, array(), 'multiple', 'contactid');
 			print '</div>';
 			print '</td>';
 			print '</tr>';


### PR DESCRIPTION
Same fix as here: https://github.com/Dolibarr/dolibarr/pull/32600
But for update event.

When an event has no company linked, selectcontacts was loading all contacts even if MAIN_ACTIONCOM_CAN_ADD_ANY_CONTACT is not set