### PR TITLE
FIX: api_thirdparties: fix num_rows typo

### DIFF
--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -1865,7 +1865,7 @@ class Thirdparties extends DolibarrApi
 		$result = $this->db->query($sql);
 
 		// We do not found an existing SocieteAccount entity for this fk_soc and site ; we then create a new one.
-		if ($result && $this->db->num_rows == 0) {
+		if ($result && $this->db->num_rows($result) == 0) {
 			if (!isset($request_data['key_account'])) {
 				throw new RestException(422, 'Unprocessable Entity: You must pass the key_account attribute in your request data !');
 			}


### PR DESCRIPTION
# FIX: api_thirdparties: fix num_rows typo

$res->num_rows will not work on PostgreSQL. $db->num_rows() must be used instead to execute the correct procedure depending on the database backend.

But the call was not written properly and both were mixed up in commit 25741a618ebc162af25ede4936b8087f580e85bf which used $db->num_rows, and then fixed in 72c443868c235c31cb192c1202d277b6df4cd380 which used $db->num_rows($result) where suited, except this location.