### PR TITLE
FIX 17.0 API endpoints "PUT": prevent overwriting all extrafields if only some are supplied in the request

### DIFF
--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -348,6 +348,12 @@ class Members extends DolibarrApi
 					}
 				}
 			} else {
+				if ($field == 'array_options' && is_array($value)) {
+					foreach ($value as $index => $val) {
+						$member->array_options[$index] = $this->_checkValForAPI($field, $val, $member);
+					}
+					continue;
+				}
 				$member->$field = $value;
 			}
 		}

--- a/htdocs/adherents/class/api_memberstypes.class.php
+++ b/htdocs/adherents/class/api_memberstypes.class.php
@@ -193,6 +193,12 @@ class MembersTypes extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$membertype->array_options[$index] = $this->_checkValForAPI($field, $val, $membertype);
+				}
+				continue;
+			}
 			// Process the status separately because it must be updated using
 			// the validate(), resiliate() and exclude() methods of the class AdherentType.
 			$membertype->$field = $value;

--- a/htdocs/adherents/class/api_subscriptions.class.php
+++ b/htdocs/adherents/class/api_subscriptions.class.php
@@ -186,6 +186,12 @@ class Subscriptions extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$subscription->array_options[$index] = $this->_checkValForAPI($field, $val, $subscription);
+				}
+				continue;
+			}
 			$subscription->$field = $value;
 		}
 

--- a/htdocs/bom/class/api_boms.class.php
+++ b/htdocs/bom/class/api_boms.class.php
@@ -237,6 +237,12 @@ class Boms extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->bom->array_options[$index] = $this->_checkValForAPI($field, $val, $this->bom);
+				}
+				continue;
+			}
 			$this->bom->$field = $value;
 		}
 

--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -237,6 +237,12 @@ class Categories extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->category->array_options[$index] = $this->_checkValForAPI($field, $val, $this->category);
+				}
+				continue;
+			}
 			$this->category->$field = $value;
 		}
 

--- a/htdocs/comm/action/class/api_agendaevents.class.php
+++ b/htdocs/comm/action/class/api_agendaevents.class.php
@@ -270,6 +270,12 @@ class AgendaEvents extends DolibarrApi
 				continue;
 			}
 
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->actioncomm->array_options[$index] = $this->_checkValForAPI($field, $val, $this->actioncomm);
+				}
+				continue;
+			}
 			$this->actioncomm->$field = $this->_checkValForAPI($field, $value, $this->actioncomm);
 		}
 

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -696,6 +696,12 @@ class Proposals extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->propal->array_options[$index] = $this->_checkValForAPI($field, $val, $this->propal);
+				}
+				continue;
+			}
 			$this->propal->$field = $value;
 		}
 

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -652,6 +652,12 @@ class Orders extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->commande->array_options[$index] = $this->_checkValForAPI($field, $val, $this->commande);
+				}
+				continue;
+			}
 			$this->commande->$field = $value;
 		}
 

--- a/htdocs/compta/bank/class/api_bankaccounts.class.php
+++ b/htdocs/compta/bank/class/api_bankaccounts.class.php
@@ -332,6 +332,12 @@ class BankAccounts extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$account->array_options[$index] = $this->_checkValForAPI($field, $val, $account);
+				}
+				continue;
+			}
 			$account->$field = $this->_checkValForAPI($field, $value, $account);
 		}
 

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -627,6 +627,12 @@ class Invoices extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->invoice->array_options[$index] = $this->_checkValForAPI($field, $val, $this->invoice);
+				}
+				continue;
+			}
 			$this->invoice->$field = $value;
 		}
 

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -510,6 +510,12 @@ class Contracts extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->contract->array_options[$index] = $this->_checkValForAPI($field, $val, $this->contract);
+				}
+				continue;
+			}
 			$this->contract->$field = $value;
 		}
 

--- a/htdocs/don/class/api_donations.class.php
+++ b/htdocs/don/class/api_donations.class.php
@@ -231,6 +231,12 @@ class Donations extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->don->array_options[$index] = $this->_checkValForAPI($field, $val, $this->don);
+				}
+				continue;
+			}
 			$this->don->$field = $value;
 		}
 

--- a/htdocs/expedition/class/api_shipments.class.php
+++ b/htdocs/expedition/class/api_shipments.class.php
@@ -447,6 +447,12 @@ class Shipments extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->shipment->array_options[$index] = $this->_checkValForAPI($field, $val, $this->shipment);
+				}
+				continue;
+			}
 			$this->shipment->$field = $value;
 		}
 

--- a/htdocs/expensereport/class/api_expensereports.class.php
+++ b/htdocs/expensereport/class/api_expensereports.class.php
@@ -420,6 +420,12 @@ class ExpenseReports extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->expensereport->array_options[$index] = $this->_checkValForAPI($field, $val, $this->expensereport);
+				}
+				continue;
+			}
 			$this->expensereport->$field = $value;
 		}
 

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -263,6 +263,12 @@ class SupplierInvoices extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->invoice->array_options[$index] = $this->_checkValForAPI($field, $val, $this->invoice);
+				}
+				continue;
+			}
 			$this->invoice->$field = $value;
 		}
 

--- a/htdocs/fourn/class/api_supplier_orders.class.php
+++ b/htdocs/fourn/class/api_supplier_orders.class.php
@@ -277,6 +277,12 @@ class SupplierOrders extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->order->array_options[$index] = $this->_checkValForAPI($field, $val, $this->order);
+				}
+				continue;
+			}
 			$this->order->$field = $value;
 		}
 

--- a/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
+++ b/htdocs/knowledgemanagement/class/api_knowledgemanagement.class.php
@@ -298,6 +298,12 @@ class KnowledgeManagement extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->knowledgerecord->array_options[$index] = $this->_checkValForAPI($field, $val, $this->knowledgerecord);
+				}
+				continue;
+			}
 			$this->knowledgerecord->$field = $this->_checkValForAPI($field, $value, $this->knowledgerecord);
 		}
 

--- a/htdocs/modulebuilder/template/class/api_mymodule.class.php
+++ b/htdocs/modulebuilder/template/class/api_mymodule.class.php
@@ -255,6 +255,12 @@ class MyModuleApi extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->myobject->array_options[$index] = $this->_checkValForAPI($field, $val, $this->myobject);
+				}
+				continue;
+			}
 			$this->myobject->$field = $this->_checkValForAPI($field, $value, $this->myobject);
 		}
 

--- a/htdocs/mrp/class/api_mos.class.php
+++ b/htdocs/mrp/class/api_mos.class.php
@@ -238,6 +238,12 @@ class Mos extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->mo->array_options[$index] = $this->_checkValForAPI($field, $val, $this->mo);
+				}
+				continue;
+			}
 			$this->mo->$field = $value;
 		}
 

--- a/htdocs/partnership/class/api_partnership.class.php
+++ b/htdocs/partnership/class/api_partnership.class.php
@@ -255,6 +255,12 @@ class PartnershipApi extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->partnership->array_options[$index] = $this->_checkValForAPI($field, $val, $this->partnership);
+				}
+				continue;
+			}
 			$this->partnership->$field = $this->_checkValForAPI($field, $value, $this->partnership);
 		}
 

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -361,6 +361,12 @@ class Products extends DolibarrApi
 			if ($field == 'stock_reel') {
 				throw new RestException(400, 'Stock reel cannot be updated here. Use the /stockmovements endpoint instead');
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->product->array_options[$index] = $this->_checkValForAPI($field, $val, $this->product);
+				}
+				continue;
+			}
 			$this->product->$field = $value;
 		}
 

--- a/htdocs/product/stock/class/api_warehouses.class.php
+++ b/htdocs/product/stock/class/api_warehouses.class.php
@@ -206,6 +206,12 @@ class Warehouses extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->warehouse->array_options[$index] = $this->_checkValForAPI($field, $val, $this->warehouse);
+				}
+				continue;
+			}
 			$this->warehouse->$field = $value;
 		}
 

--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -462,6 +462,12 @@ class Projects extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->project->array_options[$index] = $this->_checkValForAPI($field, $val, $this->project);
+				}
+				continue;
+			}
 			$this->project->$field = $value;
 		}
 

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -460,6 +460,12 @@ class Tasks extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->task->array_options[$index] = $this->_checkValForAPI($field, $val, $this->task);
+				}
+				continue;
+			}
 			$this->task->$field = $value;
 		}
 

--- a/htdocs/reception/class/api_receptions.class.php
+++ b/htdocs/reception/class/api_receptions.class.php
@@ -447,6 +447,12 @@ class Receptions extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->reception->array_options[$index] = $this->_checkValForAPI($field, $val, $this->reception);
+				}
+				continue;
+			}
 			$this->reception->$field = $value;
 		}
 

--- a/htdocs/societe/class/api_contacts.class.php
+++ b/htdocs/societe/class/api_contacts.class.php
@@ -330,6 +330,12 @@ class Contacts extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->contact->array_options[$index] = $this->_checkValForAPI($field, $val, $this->contact);
+				}
+				continue;
+			}
 			$this->contact->$field = $value;
 		}
 

--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -301,6 +301,12 @@ class Thirdparties extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->company->array_options[$index] = $this->_checkValForAPI($field, $val, $this->company);
+				}
+				continue;
+			}
 			$this->company->$field = $value;
 		}
 

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -381,6 +381,15 @@ class Tickets extends DolibarrApi
 		}
 
 		foreach ($request_data as $field => $value) {
+			if ($field == 'id') {
+				continue;
+			}
+			if ($field == 'array_options' && is_array($value)) {
+				foreach ($value as $index => $val) {
+					$this->ticket->array_options[$index] = $this->_checkValForAPI($field, $val, $this->ticket);
+				}
+				continue;
+			}
 			$this->ticket->$field = $value;
 		}
 

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -406,6 +406,12 @@ class Users extends DolibarrApi
 					throw new RestException(500, 'Error when updating status of user: '.$this->useraccount->error);
 				}
 			} else {
+				if ($field == 'array_options' && is_array($value)) {
+					foreach ($value as $index => $val) {
+						$this->useraccount->array_options[$index] = $this->_checkValForAPI($field, $val, $this->useraccount);
+					}
+					continue;
+				}
 				$this->useraccount->$field = $value;
 			}
 		}


### PR DESCRIPTION
Same as PR #29237, but for all objects with extrafields.

+security for Tickets API: disable updating rowid (same as with other APIs)

I didn't test it, confident because it is basically the same as PR #29237 but @eldy tell me if you want me to test it.