### PR TITLE
FIX ci: Remove exit from SocieteTest, include company.lib in Societe.class.php which uses getCountry

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /* Copyright (C) 2002-2006	Rodolphe Quiedeville		<rodolphe@quiedeville.org>
  * Copyright (C) 2004-2021	Laurent Destailleur			<eldy@users.sourceforge.net>
  * Copyright (C) 2004		Eric Seigne					<eric.seigne@ryxeo.com>
@@ -20,7 +21,7 @@
  * Copyright (C) 2022		ButterflyOfFire				<butterflyoffire+dolibarr@protonmail.com>
  * Copyright (C) 2023-2024	Alexandre Janniaux			<alexandre.janniaux@gmail.com>
  * Copyright (C) 2024		William Mead				<william.mead@manchenumerique.fr>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,6 +46,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonincoterm.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonsocialnetworks.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonpeople.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/multicurrency/class/multicurrency.class.php';
 
 
@@ -3192,7 +3194,7 @@ class Societe extends CommonObject
 		if (empty($option) || preg_match('/customer/', $option)) {
 			if (($this->client == 1 || $this->client == 3) && !getDolGlobalString('SOCIETE_DISABLE_CUSTOMERS')) {
 				$s .= '<'.$tag.' class="customer-back" title="'.dolPrintHTMLForAttribute($langs->trans("Customer")).'"';
-				$s.= $tag == 'a' ? ' href="'.DOL_URL_ROOT.'/comm/card.php?socid='.$this->id.'"' : '';
+				$s .= $tag == 'a' ? ' href="'.DOL_URL_ROOT.'/comm/card.php?socid='.$this->id.'"' : '';
 				$s .= '>'.dol_substr($langs->trans("Customer"), 0, 1).'</'.$tag.'>';
 			}
 		}

--- a/test/phpunit/SocieteTest.php
+++ b/test/phpunit/SocieteTest.php
@@ -1,7 +1,9 @@
 <?php
+
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -100,7 +102,6 @@ class SocieteTest extends CommonClassTest
 		$localobject->country_code = 'ES';
 
 		$result = $localobject->create($user);
-		var_dump($localobject);exit;
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThanOrEqual($result, 0);


### PR DESCRIPTION
# FIX ci: Remove exit from SocieteTest, include company.lib in Societe.class.php which uses getCountry

Include company.lib.php in societe.class.php.
The SocieteTest.php test failed when run independently on windows.

The core reason for the failure is that SocieteTest.php had a call to `exit`.  So this is removed in this PR.

@eldy The windows test fail because it checks that PHPUNIT did not abnormally stop by checking the log for:
```bash
grep -qE "(OK .*[0-9]+ tests.*[0-9]+ assertions|Tests: [0-9]+)"
```

This is not done in travis, so the phpunit tests in travis are incomplete but this is not detected.

Up to another volunteer to update travis!