### PR TITLE
TakePos Once payment is complet, a click on a product should start a new sale

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -527,6 +527,10 @@ function MoreProducts(moreorless) {
 
 function ClickProduct(position, qty = 1) {
 	console.log("ClickProduct at position"+position);
+	if ($('#invoiceid').val() == "") {
+		invoiceid = $('#invoiceid').val();
+		Refresh();
+	}
 	$('#proimg'+position).animate({opacity: '0.5'}, 1);
 	$('#proimg'+position).animate({opacity: '1'}, 100);
 	if ($('#prodiv'+position).data('iscat')==1){
@@ -1015,6 +1019,7 @@ function ModalBox(ModalID)
 function DirectPayment(){
 	console.log("DirectPayment");
 	$("#poslines").load("invoice.php?place="+place+"&action=valid&token=<?php echo newToken(); ?>&pay=LIQ", function() {
+		$('#invoiceid').val("");
 	});
 }
 

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -352,6 +352,7 @@ if (!getDolGlobalInt("TAKEPOS_NUMPAD")) {
 		parent.$("#poslines").load("invoice.php?place=<?php echo $place; ?>&action=valid&token=<?php echo newToken(); ?>&pay="+payment+"&amount="+amountpayed+"&excess="+excess+"&invoiceid="+invoiceid+"&accountid="+accountid, function() {
 			if (amountpayed > <?php echo $remaintopay; ?> || amountpayed == <?php echo $remaintopay; ?> || amountpayed==0 ) {
 				console.log("Close popup");
+				parent.$('#invoiceid').val("");
 				parent.$.colorbox.close();
 			}
 			else {


### PR DESCRIPTION
# New Start a new sale on click product on TakePOS

We upgraded a customer from Dolibarr 17.x to 20.x and they add an issue : on Dolibarr 17.x on TakePOS when we click on a product after a sale is complete it tries to update the sell instead of creating a new one.

This patchs allows to start a new sell by clicking a product
