### PR TITLE
Fix ci: travis - Better test if phpunit completed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -528,12 +528,11 @@ script:
 
   - |
     echo "Unit testing"
-    # Ensure we catch errors with -e. Set this to +e instead of -e if you want to go to the end to see dolibarr.log file.
-    set -e
-    phpunit -d memory_limit=-1 -c test/phpunit/phpunittest.xml test/phpunit/AllTests.php
-    phpunitresult=$?
+    # Execute phpunit, check its exit status and that the phpunit output shows a test summary
+    phpunit -d memory_limit=-1 -c test/phpunit/phpunittest.xml test/phpunit/AllTests.php | tee /dev/tty | grep -qE "(OK .*[0-9]+ tests.*[0-9]+ assertions|Tests: [0-9]+)" ; phpunitresult=$((PIPESTATUS[0]?PIPESTATUS[0]:PIPESTATUS[2]))
     echo "Phpunit return code = $phpunitresult"
-    set +e
+    # Comment next line if you want to go to the end to see the dolibarr.log file.
+    [ $phpunitresult == 0 ] || exit $phpunitresult
     echo
 
 after_script:

--- a/test/phpunit/SocieteTest.php
+++ b/test/phpunit/SocieteTest.php
@@ -1,6 +1,9 @@
 <?php
+
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
+ * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,9 +47,9 @@ $conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 /**
  * Class for PHPUnit tests
  *
- * @backupGlobals disabled
+ * @backupGlobals          disabled
  * @backupStaticAttributes enabled
- * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ * @remarks                backupGlobals must be disabled to have db,conf,user and lang not erased.
  */
 class SocieteTest extends CommonClassTest
 {
@@ -74,7 +77,7 @@ class SocieteTest extends CommonClassTest
 			die(1);
 		}
 
-		$db->begin();	// This is to have all actions inside a transaction even if test launched without suite.
+		$db->begin();    // This is to have all actions inside a transaction even if test launched without suite.
 
 		print __METHOD__."\n";
 	}
@@ -99,7 +102,6 @@ class SocieteTest extends CommonClassTest
 		$localobject->country_code = 'ES';
 
 		$result = $localobject->create($user);
-		var_dump($localobject);exit;
 
 		print __METHOD__." result=".$result."\n";
 		$this->assertLessThanOrEqual($result, 0);
@@ -110,10 +112,10 @@ class SocieteTest extends CommonClassTest
 	/**
 	 * testSocieteFetch
 	 *
-	 * @param   int     $id             Company id
-	 * @return  Societe $localobject    Company
+	 * @param  int $id Company id
+	 * @return Societe $localobject    Company
 	 *
-	 * @depends	testSocieteCreate
+	 * @depends testSocieteCreate
 	 * The depends says test is run only if previous is ok
 	 */
 	public function testSocieteFetch($id)
@@ -139,9 +141,9 @@ class SocieteTest extends CommonClassTest
 	/**
 	 * testSocieteUpdate
 	 *
-	 * @param   Societe $localobject    Company
-	 * @return  Societe $localobject    Company
-	*
+	 * @param  Societe $localobject Company
+	 * @return Societe $localobject    Company
+	 *
 	 * @depends testSocieteFetch
 	 * The depends says test is run only if previous is ok
 	 */
@@ -211,8 +213,8 @@ class SocieteTest extends CommonClassTest
 	/**
 	 * testIdProfCheck
 	 *
-	 * @param   Societe $localobject    Company
-	 * @return  Societe $localobject    Company
+	 * @param  Societe $localobject Company
+	 * @return Societe $localobject    Company
 	 *
 	 * @depends testSocieteUpdate
 	 * The depends says test is run only if previous is ok
@@ -266,8 +268,8 @@ class SocieteTest extends CommonClassTest
 	/**
 	 * testSocieteOther
 	 *
-	 * @param   Societe $localobject    Company
-	 * @return  int     $id             Id of company
+	 * @param  Societe $localobject Company
+	 * @return int     $id             Id of company
 	 *
 	 * @depends testIdProfCheck
 	 * The depends says test is run only if previous is ok
@@ -326,8 +328,8 @@ class SocieteTest extends CommonClassTest
 	/**
 	 * testGetOutstandingBills
 	 *
-	 * @param   int     $id     Id of company
-	 * @return  int
+	 * @param  int $id Id of company
+	 * @return int
 	 *
 	 * @depends testSocieteOther
 	 * The depends says test is run only if previous is ok
@@ -355,8 +357,8 @@ class SocieteTest extends CommonClassTest
 	/**
 	 * testSocieteDelete
 	 *
-	 * @param   int     $id     Id of company
-	 * @return  int
+	 * @param  int $id Id of company
+	 * @return int
 	 *
 	 * @depends testGetOutstandingBills
 	 * The depends says test is run only if previous is ok
@@ -383,7 +385,7 @@ class SocieteTest extends CommonClassTest
 	/**
 	 * testSocieteGetFullAddress
 	 *
-	 * @return  int     $id             Id of company
+	 * @return int     $id             Id of company
 	 */
 	public function testSocieteGetFullAddress()
 	{


### PR DESCRIPTION
# Fix ci: travis - Better test if phpunit completed

Backport travis-ci fix to check phpunit result.

First commit: show error because of 'exit' in SecurityTest.php

2nd commit: backport of fix on SecurityTest.php to clear errored travis build.