### PR TITLE
20.0 Fix MAIN_SEARCH_PRODUCT_BY_FOURN_REF conf

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2999,11 +2999,6 @@ class Form
 			$sql .= ' AND e.statut IN (' . $this->db->sanitize($this->db->escape(implode(',', $warehouseStatusArray))) . ')'; // Return line if product is inside the selected stock. If not, an empty line will be returned so we will count 0.
 		}
 
-		// include search in supplier ref
-		if (getDolGlobalString('MAIN_SEARCH_PRODUCT_BY_FOURN_REF')) {
-			$sql .= " LEFT JOIN " . $this->db->prefix() . "product_fournisseur_price as pfp ON p.rowid = pfp.fk_product";
-		}
-
 		//Price by customer
 		if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') && !empty($socid)) {
 			$sql .= " LEFT JOIN  " . $this->db->prefix() . "product_customer_price as pcp ON pcp.fk_soc=" . ((int) $socid) . " AND pcp.fk_product=p.rowid";
@@ -3064,6 +3059,8 @@ class Form
 		$sql .= $hookmanager->resPrint;
 		// Add criteria on ref/label
 		if ($filterkey != '') {
+			$sqlSupplierSearch= '';
+
 			$sql .= ' AND (';
 			$prefix = !getDolGlobalString('PRODUCT_DONOTSEARCH_ANYWHERE') ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
 			// For natural search
@@ -3089,8 +3086,11 @@ class Form
 						$sql .= " OR pl.description LIKE '" . $this->db->escape($prefix . $crit) . "%'";
 					}
 				}
+
+				// include search in supplier ref
 				if (getDolGlobalString('MAIN_SEARCH_PRODUCT_BY_FOURN_REF')) {
-					$sql .= " OR pfp.ref_fourn LIKE '" . $this->db->escape($prefix . $crit) . "%'";
+					$sqlSupplierSearch .= !empty($sqlSupplierSearch) ? ' OR ':'';
+					$sqlSupplierSearch .= " pfp.ref_fourn LIKE '" . $this->db->escape($prefix . $crit) . "%'";
 				}
 				$sql .= ")";
 				$i++;
@@ -3101,6 +3101,12 @@ class Form
 			if (isModEnabled('barcode')) {
 				$sql .= " OR p.barcode LIKE '" . $this->db->escape($prefix . $filterkey) . "%'";
 			}
+
+			// include search in supplier ref
+			if (getDolGlobalString('MAIN_SEARCH_PRODUCT_BY_FOURN_REF')) {
+				$sql .= ' OR EXISTS (SELECT pfp.fk_product FROM ' . $this->db->prefix() . 'product_fournisseur_price as pfp WHERE p.rowid = pfp.fk_product AND ('.$sqlSupplierSearch.') )';
+			}
+
 			$sql .= ')';
 		}
 		if (count($warehouseStatusArray)) {

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3104,7 +3104,10 @@ class Form
 
 			// include search in supplier ref
 			if (getDolGlobalString('MAIN_SEARCH_PRODUCT_BY_FOURN_REF')) {
-				$sql .= ' OR EXISTS (SELECT pfp.fk_product FROM ' . $this->db->prefix() . 'product_fournisseur_price as pfp WHERE p.rowid = pfp.fk_product AND ('.$sqlSupplierSearch.') )';
+				$sql .= " OR EXISTS (SELECT pfp.fk_product FROM " . $this->db->prefix() . "product_fournisseur_price as pfp WHERE p.rowid = pfp.fk_product";
+				$sql .= " AND (";
+				$sql .= $sqlSupplierSearch;
+				$sql .= "))";
 			}
 
 			$sql .= ')';


### PR DESCRIPTION
# Fix MAIN_SEARCH_PRODUCT_BY_FOURN_REF conf

In recent Dolibarr the sql query of function **select_produits_list method** in **html.form.class.php** does no more have a ```SELECT DISTINCT ``` but a simple ```SELECT``` so when we use hidden conf MAIN_SEARCH_PRODUCT_BY_FOURN_REF results are duplicated depending of number of suppliers prices.

This fix use EXISTS instead of join to create de SQL query.

Enjoy ;-)

see https://github.com/Dolibarr/dolibarr/pull/9857