### PR TITLE
 FIX the sum of warehouse totals

### DIFF
--- a/htdocs/product/stock/list.php
+++ b/htdocs/product/stock/list.php
@@ -624,7 +624,7 @@ if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 }
 print '</tr>'."\n";
 
-$totalarray = array();
+// $totalarray = array();  // Remove this line, because if the variable $totalarray is left active it is reset and does not correctly add up the totals in the warehouse list table.
 $totalarray['nbfield'] = 0;
 
 // Fields title label


### PR DESCRIPTION
Remove this line, since if the variable $totalarray is left active it is reset and does not correctly sum the totals in the warehouse list table

Preview before fixing the error
![image](https://github.com/user-attachments/assets/f2c24ecd-53d8-40b4-bba1-f648f3f32028)

Preview bug already fixed
![image](https://github.com/user-attachments/assets/ae20ac6f-a5b9-49ad-8149-1888b07de203)


