### PR TITLE
fix delete file from task tab

### DIFF
--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -205,7 +205,15 @@ if ($action == 'remove_file' && $user->rights->projet->creer) {
 
 	$langs->load("other");
 	$upload_dir = $conf->project->dir_output;
-	$file = $upload_dir.'/'.dol_sanitizeFileName(GETPOST('file'));
+	//in case of a task filename is like PJ2211-0001%2FTK2211-0001%2FTK2211-0001_task.odt
+	//then dol_sanitizeFileName will convert it to PJ2211-0001_FTK2211-0001_FTK2211-0001_task.odt
+	//and that file does not exists so can't be deleted
+	$sanitizedFileName = dol_sanitizeFileName(GETPOST('file'));
+	$nameWithUnderscore = "_".$object->ref."_";
+	if (strpos($sanitizedFileName, $nameWithUnderscore)) {
+		$sanitizedFileName = str_replace($nameWithUnderscore, "/".$object->ref."/", $sanitizedFileName);
+	}
+	$file = $upload_dir.'/'.$sanitizedFileName;
 
 	$ret = dol_delete_file($file);
 	if ($ret) {


### PR DESCRIPTION
On task tab there is the list of linked files:

![image](https://github.com/user-attachments/assets/da72f961-841a-4313-872f-8de5cd5e7172)

the trash icon have that sort of url

/projet/tasks/task.php?id=1&action=remove_file&token=xxx&file=PJ2211-0001%2FTK2211-0001%2FTK2211-0001_tache_modele-02.odt&entity=1

then the source code will sanitize file name and replace %2 with underscore and the consequence is delete can't be done but the success message is displayed !

![image](https://github.com/user-attachments/assets/db832324-c34a-4221-8168-38d0e4042189)

this PR will fix that bug