### PR TITLE
Bug in tva.lib.php when using FACTURE_DEPOSITS_ARE_JUST_PAYMENTS hidden feature and vat setup on payment date

### DIFF
--- a/htdocs/core/lib/tax.lib.php
+++ b/htdocs/core/lib/tax.lib.php
@@ -438,19 +438,7 @@ function tax_by_thirdparty($type, $db, $y, $date_start, $date_end, $modetax, $di
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p on d.fk_product = p.rowid";
 		$sql .= " WHERE f.entity IN (".getEntity($invoicetable).")";
 		$sql .= " AND f.fk_statut in (1,2)"; // Paid (partially or completely)
-		if ($direction == 'buy') {
-			if (getDolGlobalString('FACTURE_SUPPLIER_DEPOSITS_ARE_JUST_PAYMENTS')) {
-				$sql .= " AND f.type IN (0,1,2,5)";
-			} else {
-				$sql .= " AND f.type IN (0,1,2,3,5)";
-			}
-		} else {
-			if (getDolGlobalString('FACTURE_DEPOSITS_ARE_JUST_PAYMENTS')) {
-				$sql .= " AND f.type IN (0,1,2,5)";
-			} else {
-				$sql .= " AND f.type IN (0,1,2,3,5)";
-			}
-		}
+		$sql .= " AND f.type IN (0,1,2,3,5)";
 		$sql .= " AND f.rowid = d.".$fk_facture;
 		$sql .= " AND s.rowid = f.fk_soc";
 		$sql .= " AND pf.".$fk_facture2." = f.rowid";
@@ -825,19 +813,7 @@ function tax_by_rate($type, $db, $y, $q, $date_start, $date_end, $modetax, $dire
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p on d.fk_product = p.rowid";
 		$sql .= " WHERE f.entity IN (".getEntity($invoicetable).")";
 		$sql .= " AND f.fk_statut in (1,2)"; // Paid (partially or completely)
-		if ($direction == 'buy') {
-			if (getDolGlobalString('FACTURE_SUPPLIER_DEPOSITS_ARE_JUST_PAYMENTS')) {
-				$sql .= " AND f.type IN (0,1,2,5)";
-			} else {
-				$sql .= " AND f.type IN (0,1,2,3,5)";
-			}
-		} else {
-			if (getDolGlobalString('FACTURE_DEPOSITS_ARE_JUST_PAYMENTS')) {
-				$sql .= " AND f.type IN (0,1,2,5)";
-			} else {
-				$sql .= " AND f.type IN (0,1,2,3,5)";
-			}
-		}
+		$sql .= " AND f.type IN (0,1,2,3,5)";
 		if ($y && $m) {
 			$sql .= " AND pa.datep >= '".$db->idate(dol_get_first_day($y, $m, false))."'";
 			$sql .= " AND pa.datep <= '".$db->idate(dol_get_last_day($y, $m, false))."'";
@@ -1026,19 +1002,7 @@ function tax_by_rate($type, $db, $y, $q, $date_start, $date_end, $modetax, $dire
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p on d.fk_product = p.rowid";
 		$sql .= " WHERE f.entity IN (".getEntity($invoicetable).")";
 		$sql .= " AND f.fk_statut in (1,2)"; // Paid (partially or completely)
-		if ($direction == 'buy') {
-			if (getDolGlobalString('FACTURE_SUPPLIER_DEPOSITS_ARE_JUST_PAYMENTS')) {
-				$sql .= " AND f.type IN (0,1,2,5)";
-			} else {
-				$sql .= " AND f.type IN (0,1,2,3,5)";
-			}
-		} else {
-			if (getDolGlobalString('FACTURE_DEPOSITS_ARE_JUST_PAYMENTS')) {
-				$sql .= " AND f.type IN (0,1,2,5)";
-			} else {
-				$sql .= " AND f.type IN (0,1,2,3,5)";
-			}
-		}
+		$sql .= " AND f.type IN (0,1,2,3,5)";
 		if ($y && $m) {
 			$sql .= " AND pa.datep >= '".$db->idate(dol_get_first_day($y, $m, false))."'";
 			$sql .= " AND pa.datep <= '".$db->idate(dol_get_last_day($y, $m, false))."'";


### PR DESCRIPTION
**How to reproduce the bug :**
- on the VAT admin setup page, use the following setup (or test with the standard setup and a service) :  
![image](https://github.com/user-attachments/assets/99deb800-fc08-4ca7-a74c-812843b19100)

- set the misc param FACTURE_DEPOSITS_ARE_JUST_PAYMENTS to 1
- Create an order with a 20% vat product
![image](https://github.com/user-attachments/assets/104b474f-fd71-48bc-a491-baf2f292f21e)

- Create a deposit invoice from the order
- Add a payment on the deposit invoice
- Create the order invoice, and pay this invoice using the deposit invoice. A discount is created.
- Apply the discount on the invoice
![image](https://github.com/user-attachments/assets/ccc719e0-57ba-4704-936f-3fdeaa6be6e3)
![image](https://github.com/user-attachments/assets/8a044fb6-3f5c-4b4a-9a4b-af7d014155ab)

- Go to /compta/tva/quadri_detail.php page, filter on the current date : 
![image](https://github.com/user-attachments/assets/ec9f9fcd-6869-4e85-a8f5-9a03294b69b2)

Our deposit vat should be visible.
