### PR TITLE
FIX : Mass file area rights with "objects"

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3564,9 +3564,19 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 				dol_print_error(null, 'Error call dol_check_secure_access_document with not supported value for modulepart parameter ('.$modulepart.')');
 				exit;
 			}
-			if ($fuser->hasRight($tmpmodule, $lire) || preg_match('/^specimen/i', $original_file)) {
-				$accessallowed = 1;
-			}
+
+            // Check fuser->rights->modulepart->myobject->read and fuser->rights->modulepart->read
+            $partsofdirinoriginalfile = explode('/', $original_file);
+            if (!empty($partsofdirinoriginalfile[1])) {	// If original_file is xxx/filename (xxx is a part we will use)
+                $partofdirinoriginalfile = $partsofdirinoriginalfile[0];
+                if ($partofdirinoriginalfile && ($fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'lire') || $fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'read'))) {
+                    $accessallowed = 1;
+                }
+            }
+            if ($fuser->hasRight($tmpmodule, $lire) || $fuser->hasRight($tmpmodule, $read)) {
+                $accessallowed = 1;
+            }
+
 			$original_file = $conf->$tmpmodule->dir_output.'/temp/massgeneration/'.$user->id.'/'.$original_file;
 		} else {
 			if (empty($conf->$modulepart->dir_output)) {	// modulepart not supported

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3565,17 +3565,17 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 				exit;
 			}
 
-            // Check fuser->rights->modulepart->myobject->read and fuser->rights->modulepart->read
-            $partsofdirinoriginalfile = explode('/', $original_file);
-            if (!empty($partsofdirinoriginalfile[1])) {	// If original_file is xxx/filename (xxx is a part we will use)
-                $partofdirinoriginalfile = $partsofdirinoriginalfile[0];
-                if (($partofdirinoriginalfile && ($fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'lire') || $fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'read'))) || preg_match('/^specimen/i', $original_file)) {
-                    $accessallowed = 1;
-                }
-            }
-            if (($fuser->hasRight($tmpmodule, $lire) || $fuser->hasRight($tmpmodule, $read)) || preg_match('/^specimen/i', $original_file)) {
-                $accessallowed = 1;
-            }
+			// Check fuser->rights->modulepart->myobject->read and fuser->rights->modulepart->read
+			$partsofdirinoriginalfile = explode('/', $original_file);
+			if (!empty($partsofdirinoriginalfile[1])) {    // If original_file is xxx/filename (xxx is a part we will use)
+				$partofdirinoriginalfile = $partsofdirinoriginalfile[0];
+				if (($partofdirinoriginalfile && ($fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'lire') || $fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'read'))) || preg_match('/^specimen/i', $original_file)) {
+					$accessallowed = 1;
+				}
+			}
+			if (($fuser->hasRight($tmpmodule, $lire) || $fuser->hasRight($tmpmodule, $read)) || preg_match('/^specimen/i', $original_file)) {
+				$accessallowed = 1;
+			}
 
 			$original_file = $conf->$tmpmodule->dir_output.'/temp/massgeneration/'.$user->id.'/'.$original_file;
 		} else {

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3569,11 +3569,11 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
             $partsofdirinoriginalfile = explode('/', $original_file);
             if (!empty($partsofdirinoriginalfile[1])) {	// If original_file is xxx/filename (xxx is a part we will use)
                 $partofdirinoriginalfile = $partsofdirinoriginalfile[0];
-                if ($partofdirinoriginalfile && ($fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'lire') || $fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'read'))) {
+                if (($partofdirinoriginalfile && ($fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'lire') || $fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'read'))) || preg_match('/^specimen/i', $original_file)) {
                     $accessallowed = 1;
                 }
             }
-            if ($fuser->hasRight($tmpmodule, $lire) || $fuser->hasRight($tmpmodule, $read)) {
+            if (($fuser->hasRight($tmpmodule, $lire) || $fuser->hasRight($tmpmodule, $read)) || || preg_match('/^specimen/i', $original_file)) {
                 $accessallowed = 1;
             }
 

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3569,11 +3569,11 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 			$partsofdirinoriginalfile = explode('/', $original_file);
 			if (!empty($partsofdirinoriginalfile[1])) {    // If original_file is xxx/filename (xxx is a part we will use)
 				$partofdirinoriginalfile = $partsofdirinoriginalfile[0];
-				if (($partofdirinoriginalfile && ($fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'lire') || $fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'read'))) || preg_match('/^specimen/i', $original_file)) {
+				if (($partofdirinoriginalfile &&  $fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'read')) || preg_match('/^specimen/i', $original_file)) {
 					$accessallowed = 1;
 				}
 			}
-			if (($fuser->hasRight($tmpmodule, $lire) || $fuser->hasRight($tmpmodule, $read)) || preg_match('/^specimen/i', $original_file)) {
+			if ($fuser->hasRight($tmpmodule, $read) || preg_match('/^specimen/i', $original_file)) {
 				$accessallowed = 1;
 			}
 

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3573,7 +3573,7 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
                     $accessallowed = 1;
                 }
             }
-            if (($fuser->hasRight($tmpmodule, $lire) || $fuser->hasRight($tmpmodule, $read)) || || preg_match('/^specimen/i', $original_file)) {
+            if (($fuser->hasRight($tmpmodule, $lire) || $fuser->hasRight($tmpmodule, $read)) || preg_match('/^specimen/i', $original_file)) {
                 $accessallowed = 1;
             }
 

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3569,7 +3569,7 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 			$partsofdirinoriginalfile = explode('/', $original_file);
 			if (!empty($partsofdirinoriginalfile[1])) {    // If original_file is xxx/filename (xxx is a part we will use)
 				$partofdirinoriginalfile = $partsofdirinoriginalfile[0];
-				if (($partofdirinoriginalfile &&  $fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'read')) || preg_match('/^specimen/i', $original_file)) {
+				if (($partofdirinoriginalfile && $fuser->hasRight($tmpmodule, $partofdirinoriginalfile, 'read')) || preg_match('/^specimen/i', $original_file)) {
 					$accessallowed = 1;
 				}
 			}


### PR DESCRIPTION
Hello,

In my module, the right to view an object is defined as follows:

`$user->rights->mymodule->myobject->read`

However, the current code does not handle "myobject" properly; it only checks the `$lire` variable instead of `$read`.

So, I simply copied and pasted the code below from the else block.