### PR TITLE
NEW: Support default values in extrafield definition for extrafields select list (n choices)

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9371,6 +9371,13 @@ abstract class CommonObject
 							}
 						}
 
+						if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('checkbox'))) {
+							if ($action == 'create') {
+								$value = (GETPOSTISSET($keyprefix.'options_'.$key.$keysuffix) || $value) ? $value : explode(',', $extrafields->attributes[$this->table_element]['default'][$key]);
+							}
+						}
+
+
 						$labeltoshow = $langs->trans($label);
 						$helptoshow = $langs->trans($extrafields->attributes[$this->table_element]['help'][$key]);
 						if ($display_type == 'card') {


### PR DESCRIPTION
# FIX : allow default value using checkbox extrafields

When using a checkbox extrafield, one have the ability to set default value(s) : 

![image](https://github.com/user-attachments/assets/736f10e2-6621-4c63-92d3-d5024ab5ebdb)

However, when going to the create form, the default values are not used : 
![image](https://github.com/user-attachments/assets/fd344c62-b722-4fad-8222-4c7df63f1a90)

This PR fixes this behavior and allows defaults values separated by a comma.

The default values are not used on edition form, only on creation form.