### PR TITLE
FIX #32791 When updating task details, keep original fields when they are not shown in the task table

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1417,9 +1417,9 @@ class Task extends CommonObjectLine
 	/**
 	 *  Add time spent
 	 *
-	 *  @param	User	$user           User object
-	 *  @param  int		$notrigger	    0=launch triggers after, 1=disable triggers
-	 *  @return	int                     Return integer <=0 if KO, >0 if OK
+	 *  @param	User		$user		User object
+	 *  @param	int<0,1>	$notrigger	0=launch triggers after, 1=disable triggers
+	 *  @return	int				Return integer <=0 if KO, >0 if OK
 	 */
 	public function addTimeSpent($user, $notrigger = 0)
 	{

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -331,23 +331,42 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 		} else {
 			$object->fetch($id, $ref);
 
-			$object->timespent_id = GETPOSTINT("lineid");
+			// Define the array mapping object fields to GETPOSTINT keys
+			$intFields = array(
+				'timespent_id' => 'lineid',
+				'timespent_old_duration' => 'old_duration',
+				'timespent_duration_hour' => 'new_durationhour',
+				'timespent_duration_min' => 'new_durationmin',
+				'timelinehour' => 'timelinehour',
+				'timelinemin' => 'timelinemin',
+				'timelinemonth' => 'timelinemonth',
+				'timelineday' => 'timelineday',
+				'timelineyear' => 'timelineyear',
+				'timespent_fk_user' => 'userid_line',
+				'timespent_fk_product' => 'fk_product',
+				'timespent_invoiceid' => 'invoiceid',
+				'timespent_invoicelineid' => 'invoicelineid'
+			);
+
+			// Loop over the array and set the object properties for integer fields
+			foreach ($intFields as $objectField => $getpostKey) {
+				if (GETPOSTISSET($getpostKey)) {
+					$object->$objectField = GETPOSTINT($getpostKey);
+				}
+			}
+
 			$object->timespent_note = GETPOST("timespent_note_line", "alphanohtml");
-			$object->timespent_old_duration = GETPOSTINT("old_duration");
-			$object->timespent_duration = GETPOSTINT("new_durationhour") * 60 * 60; // We store duration in seconds
-			$object->timespent_duration += (GETPOSTINT("new_durationmin") ? GETPOSTINT('new_durationmin') : 0) * 60; // We store duration in seconds
+
+			$object->timespent_duration = $object->timespent_duration_hour * 60 * 60; // We store duration in seconds
+			$object->timespent_duration += $object->timespent_duration_min * 60; // We store duration in seconds
+
 			if (GETPOST("timelinehour") != '' && GETPOST("timelinehour") >= 0) {    // If hour was entered
-				$object->timespent_date = dol_mktime(GETPOSTINT("timelinehour"), GETPOSTINT("timelinemin"), 0, GETPOSTINT("timelinemonth"), GETPOSTINT("timelineday"), GETPOSTINT("timelineyear"));
+				$object->timespent_date = dol_mktime($object->timelinehour, $object->timelinemin, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
 				$object->timespent_withhour = 1;
 			} else {
-				$object->timespent_date = dol_mktime(12, 0, 0, GETPOSTINT("timelinemonth"), GETPOSTINT("timelineday"), GETPOSTINT("timelineyear"));
+				$object->timespent_date = dol_mktime(12, 0, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
 				$object->timespent_withhour = 0;
 			}
-			$object->timespent_fk_user = GETPOSTINT("userid_line");
-			$object->timespent_fk_product = GETPOSTINT("fk_product");
-			$object->timespent_invoiceid = GETPOSTINT("invoiceid");
-			$object->timespent_invoicelineid = GETPOSTINT("invoicelineid");
-			$result = 0;
 
 			if (in_array($object->timespent_fk_user, $childids) || $user->hasRight('projet', 'all', 'creer')) {
 				$result = $object->updateTimeSpent($user);

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -360,10 +360,12 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 			$object->timespent_duration = $object->timespent_duration_hour * 60 * 60; // We store duration in seconds
 			$object->timespent_duration += $object->timespent_duration_min * 60; // We store duration in seconds
 
-			if (GETPOST("timelinehour") != '' && GETPOST("timelinehour") >= 0) {    // If hour was entered
+			if ((string) GETPOST("timelinehour") != '' && $object->timelinehour >= 0) {
+				// Time of day was entered (could be midnight as well)
 				$object->timespent_date = dol_mktime($object->timelinehour, $object->timelinemin, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
 				$object->timespent_withhour = 1;
 			} else {
+				// No time of day, use midnight to compute the date value
 				$object->timespent_date = dol_mktime(12, 0, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
 				$object->timespent_withhour = 0;
 			}

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -270,6 +270,7 @@ if ($action == 'addtimespent' && $user->hasRight('projet', 'time')) {
 
 if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $user->hasRight('projet', 'lire')) {
 	$error = 0;
+	$db->begin();
 
 	if (!GETPOST("new_durationhour") && !GETPOST("new_durationmin")) {
 		setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv("Duration")), null, 'errors');
@@ -301,10 +302,21 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 				$object->timespent_date = dol_mktime(12, 0, 0, GETPOST("timelinemonth"), GETPOST("timelineday"), GETPOST("timelineyear"));
 				$object->timespent_withhour = 0;
 			}
-			$object->timespent_fk_user = GETPOSTINT("userid_line");
-			$object->timespent_fk_product = GETPOSTINT("fk_product");
-			$object->timespent_invoiceid = GETPOSTINT("invoiceid");
-			$object->timespent_invoicelineid = GETPOSTINT("invoicelineid");
+
+			// Use fields from existing record or from post (if provided)
+			if (GETPOST("userid_line") != '') {
+				$object->timespent_fk_user = GETPOSTINT("userid_line");
+			}
+			if (GETPOST("fk_product") != '') {
+				$object->timespent_fk_product = GETPOSTINT("fk_product");
+			}
+			if (GETPOST("invoiceid") != '') {
+				$object->timespent_invoiceid = GETPOSTINT("invoiceid");
+			}
+			if (GETPOST("invoicelineid") != '') {
+				$object->timespent_invoicelineid = GETPOSTINT("invoicelineid");
+			}
+
 
 			$result = 0;
 			if (in_array($object->timespent_fk_user, $childids) || $user->hasRight('projet', 'all', 'creer')) {
@@ -350,6 +362,11 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 		}
 	} else {
 		$action = '';
+	}
+	if ($error == 0) {
+		$db->commit();
+	} else {
+		$db->rollback();
 	}
 }
 

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -292,13 +292,15 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 			'timespent_fk_user' => 'userid_line',
 			'timespent_fk_product' => 'fk_product',
 			'timespent_invoiceid' => 'invoiceid',
-			'timespent_invoicelineid' => 'invoicelineid'
+			'timespent_invoicelineid' => 'invoicelineid',
 		);
 
 		if (GETPOSTINT('taskid') != $id) {        // GETPOST('taskid') is id of new task
+			// Changing the task this item is linked to.
 			$id_temp = GETPOSTINT('taskid'); // should not overwrite $id
 
 			$object->fetchTimeSpent(GETPOSTINT('lineid'));
+
 
 			$result = 0;
 			if (in_array($object->timespent_fk_user, $childids) || $user->hasRight('projet', 'all', 'creer')) {
@@ -310,6 +312,7 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 			$Add1OrUpdate0 = 1;
 		} else {
 			$object->fetch($id, $ref);
+			$object->fetchTimeSpent(GETPOSTINT('lineid'));
 			$Add1OrUpdate0 = 0;
 		}
 
@@ -328,13 +331,14 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 		if ((string) GETPOST("timelinehour") != '' && $object->timelinehour >= 0) {
 			// Time of day was entered (could be midnight as well)
 			$object->timespent_date = dol_mktime($object->timelinehour, $object->timelinemin, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
+			$object->timespent_datehour = $object->timespent_date;
 			$object->timespent_withhour = 1;
 		} else {
 			// No time of day, use midnight to compute the date value
 			$object->timespent_date = dol_mktime(12, 0, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
+			$object->timespent_datehour = null;
 			$object->timespent_withhour = 0;
 		}
-
 
 		// Add or update record.
 		if (in_array($object->timespent_fk_user, $childids) || $user->hasRight('projet', 'all', 'creer')) {
@@ -666,7 +670,6 @@ if ($action == 'confirm_generateinvoice') {
 						$error++;
 						setEventMessages(null, $tmpinvoice->errors, 'errors');
 					}
-					//var_dump($lineid);exit;
 
 					// Update lineid into line of timespent
 					$sql = 'UPDATE '.MAIN_DB_PREFIX.'element_time SET invoice_line_id = '.((int) $lineid).', invoice_id = '.((int) $tmpinvoice->id);
@@ -2134,6 +2137,7 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 				print '<td class="center nowraponall">';
 				if (($action == 'editline' || $action == 'splitline') && GETPOSTINT('lineid') == $task_time->rowid) {
 					print '<input type="hidden" name="lineid" value="' . GETPOSTINT('lineid') . '">';
+					print '<input type="hidden" name="id" value="' . $task_time->fk_element . '">';
 					print '<input type="submit" class="button buttongen smallpaddingimp margintoponlyshort marginbottomonlyshort button-save" name="save" value="'.$langs->trans("Save").'">';
 					print '<br>';
 					print '<input type="submit" class="button buttongen smallpaddingimp margintoponlyshort marginbottomonlyshort button-cancel" name="cancel" value="'.$langs->trans("Cancel").'">';

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -295,9 +295,12 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 			'timespent_invoicelineid' => 'invoicelineid',
 		);
 
-		if (GETPOSTINT('taskid') != $id) {        // GETPOST('taskid') is id of new task
+		$taskid = GETPOSTINT('taskid');
+		if ((GETPOSTISSET('old_taskid') && (GETPOSTINT('old_taskid') != $taskId)) // Task was updated based on old_taskid field.
+		   || (($id > 0) && ($newTaskId != $id))  // Task was selected on page
+		) {
 			// Changing the task this item is linked to.
-			$id_temp = GETPOSTINT('taskid'); // should not overwrite $id
+			$id_temp = $taskid; // should not overwrite $id
 
 			$object->fetchTimeSpent(GETPOSTINT('lineid'));
 
@@ -2137,7 +2140,7 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 				print '<td class="center nowraponall">';
 				if (($action == 'editline' || $action == 'splitline') && GETPOSTINT('lineid') == $task_time->rowid) {
 					print '<input type="hidden" name="lineid" value="' . GETPOSTINT('lineid') . '">';
-					print '<input type="hidden" name="id" value="' . $task_time->fk_element . '">';
+					print '<input type="hidden" name="old_taskid" value="' . $task_time->fk_element . '">';
 					print '<input type="submit" class="button buttongen smallpaddingimp margintoponlyshort marginbottomonlyshort button-save" name="save" value="'.$langs->trans("Save").'">';
 					print '<br>';
 					print '<input type="submit" class="button buttongen smallpaddingimp margintoponlyshort marginbottomonlyshort button-cancel" name="cancel" value="'.$langs->trans("Cancel").'">';

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -278,9 +278,25 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 	}
 
 	if (!$error) {
+		// Define the array mapping object fields to GETPOSTINT keys
+		$intFields = array(
+			'timespent_id' => 'lineid',
+			'timespent_old_duration' => 'old_duration',
+			'timespent_duration_hour' => 'new_durationhour',
+			'timespent_duration_min' => 'new_durationmin',
+			'timelinehour' => 'timelinehour',
+			'timelinemin' => 'timelinemin',
+			'timelinemonth' => 'timelinemonth',
+			'timelineday' => 'timelineday',
+			'timelineyear' => 'timelineyear',
+			'timespent_fk_user' => 'userid_line',
+			'timespent_fk_product' => 'fk_product',
+			'timespent_invoiceid' => 'invoiceid',
+			'timespent_invoicelineid' => 'invoicelineid'
+		);
+
 		if (GETPOSTINT('taskid') != $id) {        // GETPOST('taskid') is id of new task
 			$id_temp = GETPOSTINT('taskid'); // should not overwrite $id
-
 
 			$object->fetchTimeSpent(GETPOSTINT('lineid'));
 
@@ -290,95 +306,48 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 			}
 
 			$object->fetch($id_temp, $ref);
-
-			$object->timespent_note = GETPOST("timespent_note_line", "alphanohtml");
-			$object->timespent_old_duration = GETPOSTINT("old_duration");
-			$object->timespent_duration = GETPOSTINT("new_durationhour") * 60 * 60; // We store duration in seconds
-			$object->timespent_duration += (GETPOSTINT("new_durationmin") ? GETPOSTINT('new_durationmin') : 0) * 60; // We store duration in seconds
-			if (GETPOST("timelinehour") != '' && GETPOST("timelinehour") >= 0) {    // If hour was entered
-				$object->timespent_date = dol_mktime(GETPOST("timelinehour"), GETPOST("timelinemin"), 0, GETPOST("timelinemonth"), GETPOST("timelineday"), GETPOST("timelineyear"));
-				$object->timespent_withhour = 1;
-			} else {
-				$object->timespent_date = dol_mktime(12, 0, 0, GETPOST("timelinemonth"), GETPOST("timelineday"), GETPOST("timelineyear"));
-				$object->timespent_withhour = 0;
-			}
-
-			// Use fields from existing record or from post (if provided)
-			if (GETPOST("userid_line") != '') {
-				$object->timespent_fk_user = GETPOSTINT("userid_line");
-			}
-			if (GETPOST("fk_product") != '') {
-				$object->timespent_fk_product = GETPOSTINT("fk_product");
-			}
-			if (GETPOST("invoiceid") != '') {
-				$object->timespent_invoiceid = GETPOSTINT("invoiceid");
-			}
-			if (GETPOST("invoicelineid") != '') {
-				$object->timespent_invoicelineid = GETPOSTINT("invoicelineid");
-			}
-
-
-			$result = 0;
-			if (in_array($object->timespent_fk_user, $childids) || $user->hasRight('projet', 'all', 'creer')) {
-				$result = $object->addTimeSpent($user);
-				if ($result >= 0) {
-					setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
-				} else {
-					setEventMessages($langs->trans($object->error), null, 'errors');
-					$error++;
-				}
-			}
+			unset($intFields['timespent_id']); // Do not use this field.
+			$Add1OrUpdate0 = 1;
 		} else {
 			$object->fetch($id, $ref);
+			$Add1OrUpdate0 = 0;
+		}
 
-			// Define the array mapping object fields to GETPOSTINT keys
-			$intFields = array(
-				'timespent_id' => 'lineid',
-				'timespent_old_duration' => 'old_duration',
-				'timespent_duration_hour' => 'new_durationhour',
-				'timespent_duration_min' => 'new_durationmin',
-				'timelinehour' => 'timelinehour',
-				'timelinemin' => 'timelinemin',
-				'timelinemonth' => 'timelinemonth',
-				'timelineday' => 'timelineday',
-				'timelineyear' => 'timelineyear',
-				'timespent_fk_user' => 'userid_line',
-				'timespent_fk_product' => 'fk_product',
-				'timespent_invoiceid' => 'invoiceid',
-				'timespent_invoicelineid' => 'invoicelineid'
-			);
-
-			// Loop over the array and set the object properties for integer fields
-			foreach ($intFields as $objectField => $getpostKey) {
-				if (GETPOSTISSET($getpostKey)) {
-					$object->$objectField = GETPOSTINT($getpostKey);
-				}
+		// Loop over the array and set the object properties for integer fields
+		foreach ($intFields as $objectField => $getpostKey) {
+			if (GETPOSTISSET($getpostKey)) {
+				$object->$objectField = GETPOSTINT($getpostKey);
 			}
+		}
 
-			$object->timespent_note = GETPOST("timespent_note_line", "alphanohtml");
+		// Update other, more complex fields
+		$object->timespent_note = GETPOST("timespent_note_line", "alphanohtml");
+		$object->timespent_duration = $object->timespent_duration_hour * 60 * 60; // We store duration in seconds
+		$object->timespent_duration += $object->timespent_duration_min * 60; // We store duration in seconds
 
-			$object->timespent_duration = $object->timespent_duration_hour * 60 * 60; // We store duration in seconds
-			$object->timespent_duration += $object->timespent_duration_min * 60; // We store duration in seconds
+		if ((string) GETPOST("timelinehour") != '' && $object->timelinehour >= 0) {
+			// Time of day was entered (could be midnight as well)
+			$object->timespent_date = dol_mktime($object->timelinehour, $object->timelinemin, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
+			$object->timespent_withhour = 1;
+		} else {
+			// No time of day, use midnight to compute the date value
+			$object->timespent_date = dol_mktime(12, 0, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
+			$object->timespent_withhour = 0;
+		}
 
-			if ((string) GETPOST("timelinehour") != '' && $object->timelinehour >= 0) {
-				// Time of day was entered (could be midnight as well)
-				$object->timespent_date = dol_mktime($object->timelinehour, $object->timelinemin, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
-				$object->timespent_withhour = 1;
+
+		// Add or update record.
+		if (in_array($object->timespent_fk_user, $childids) || $user->hasRight('projet', 'all', 'creer')) {
+			if ($Add1OrUpdate0 == 1) {
+				$result = $object->addTimeSpent($user);
 			} else {
-				// No time of day, use midnight to compute the date value
-				$object->timespent_date = dol_mktime(12, 0, 0, $object->timelinemonth, $object->timelineday, $object->timelineyear);
-				$object->timespent_withhour = 0;
-			}
-
-			if (in_array($object->timespent_fk_user, $childids) || $user->hasRight('projet', 'all', 'creer')) {
 				$result = $object->updateTimeSpent($user);
-
-				if ($result >= 0) {
-					setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
-				} else {
-					setEventMessages($langs->trans($object->error), null, 'errors');
-					$error++;
-				}
+			}
+			if ($result >= 0) {
+				setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
+			} else {
+				setEventMessages($langs->trans($object->error), null, 'errors');
+				$error++;
 			}
 		}
 	} else {


### PR DESCRIPTION
# FIX #32791 When updating task details, keep original fields when they are not shown in the task table

This fixes lost user and THM when updating task time, and other lost fields.

The task time was assigned the user '0' when updating, which resulted in an error where a NULL object was used.
This resulted in a partially replaced record with no user and empty THM.

The correction adds the use of a DB transaction to avoid inconsistency in case of an error.
The correction uses the fields from the original record if no new fields are provided in the POST arguments