### PR TITLE
Backport from v20 missing executeHooks printFieldListFrom in product list page

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -484,6 +484,11 @@ if (!empty($conf->global->PRODUCT_USE_UNITS)) {
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_units cu ON cu.rowid = p.fk_unit";
 }
 
+// Add table from hooks
+$parameters = array();
+$reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+$sql .= $hookmanager->resPrint;
+
 $sql .= ' WHERE p.entity IN ('.getEntity('product').')';
 if ($sall) {
 	// Clean $fieldstosearchall


### PR DESCRIPTION
Backport from v20 missing executeHooks printFieldListFrom in  product list page
- see PR #29055