### PR TITLE
Missing hook PrintFieldListFrom on actions list

### DIFF
--- a/htdocs/comm/action/list.php
+++ b/htdocs/comm/action/list.php
@@ -454,6 +454,12 @@ if ($filtert > 0 || $usergroup > 0) {
 if ($usergroup > 0) {
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."usergroup_user as ugu ON ugu.fk_user = ar.fk_element";
 }
+
+// Add table from hooks
+$parameters = array();
+$reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+$sql .= $hookmanager->resPrint;
+
 $sql .= " WHERE c.id = a.fk_action";
 $sql .= ' AND a.entity IN ('.getEntity('agenda').')';
 // Condition on actioncode


### PR DESCRIPTION
# Fix : missing hool PrintFieldListFrom on actions list
 The hook PrintFieldListFrom exists on most lists, but not on comm/actions/list.php.

This PR adds it.
