### PR TITLE
fix(services-list): added missing hook printFieldListWhere

### DIFF
--- a/htdocs/contrat/services_list.php
+++ b/htdocs/contrat/services_list.php
@@ -348,6 +348,11 @@ if (!empty($filter_opcloture) && $filter_opcloture == ' BETWEEN ') {
 }
 // Add where from extra fields
 include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
+// Add where from hooks
+$parameters = array();
+$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+$sql .= $hookmanager->resPrint;
+
 $sql .= $db->order($sortfield, $sortorder);
 
 //print $sql;


### PR DESCRIPTION
# FIX|Fix missing hook printFieldListWhere
I've been added missing hook printFieldListWhere into services list that allows devs to edit the "Where" part in SQL request.