### PR TITLE
fix(services-list): added missing hook printFieldListSearchParam in services list

### DIFF
--- a/htdocs/contrat/services_list.php
+++ b/htdocs/contrat/services_list.php
@@ -442,6 +442,10 @@ if ($optioncss != '') {
 }
 // Add $param from extra fields
 include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_param.tpl.php';
+// Add $param from hooks
+$parameters = array();
+$reshook = $hookmanager->executeHooks('printFieldListSearchParam', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+$param .= $hookmanager->resPrint;
 
 // List of mass actions available
 $arrayofmassactions = array(


### PR DESCRIPTION
# FIX|Fix added missing hook printFieldListSearchParam
I've been added printFieldListSearchParam hook to allow devs to edit $param in services list