### PR TITLE
Auto-Generation of Lot/Serial Numbers in Manufacturing Orders and Reception Modules

### DIFF
--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1312,7 +1312,14 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 
 		$numFinal = $ref;
 	} elseif ($mode == 'next') {
-		$counter++;
+		//Begin Change: Accellier Ltd: If Increment in SN is required more than 1
+		//$counter++;
+		if (empty(getDolGlobalString('SN_ADVANCED_INCREMENT'))) {
+			$counter++;
+		} else {
+			$counter = $counter+getDolGlobalString('SN_ADVANCED_INCREMENT');
+		}
+		//End Change
 		$maskrefclient_counter = 0;
 
 		// If value for $counter has a length higher than $maskcounter chars

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -339,8 +339,43 @@ if (empty($reshook)) {
 							}
 							if (isModEnabled('productbatch') && $tmpproduct->status_batch && (!GETPOST('batchtoproduce-'.$line->id.'-'.$i))) {
 								$langs->load("errors");
-								setEventMessages($langs->trans("ErrorFieldRequiredForProduct", $langs->transnoentitiesnoconv("Batch"), $tmpproduct->ref), null, 'errors');
-								$error++;
+								//Begin Change: Accellier Ltd: Autogenerate Serial/Lot in MO
+								//setEventMessages($langs->trans("ErrorFieldRequiredForProduct", $langs->transnoentitiesnoconv("Batch"), $tmpproduct->ref), null, 'errors');
+								//$error++;
+								if ($tmpproduct->status_batch == 2) {
+									if ((getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_advanced') || (getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_standard')) {
+										$batch_autogen_module = getDolGlobalString('PRODUCTBATCH_SN_ADDON');
+										$batch_autogen_dirroot = DOL_DOCUMENT_ROOT.'/core/modules/product_batch/';
+										$batch_autogen_res = dol_include_once($batch_autogen_dirroot.$batch_autogen_module.'.php');
+										require_once $batch_autogen_dirroot.$batch_autogen_module.'.php';
+										$batch_autogen_mod = new $batch_autogen_module($db);
+										'@phan-var-force ModeleNumRefBatch $batch_autogen_mod';
+
+										$batch_autogen_object = new stdClass();
+										$batch_autogen_object->fk_product = $fk_product;
+										$batch = $batch_autogen_mod->getNextValue(null, $batch_autogen_object);
+										$_POST['batchtoproduce-'.$line->id.'-'.$i] = $batch;
+									}
+								} else if ($tmpproduct->status_batch == 1) {
+									if ((getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_advanced') || (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_standard')) {
+										$batch_autogen_module = getDolGlobalString('PRODUCTBATCH_LOT_ADDON');
+										$batch_autogen_dirroot = DOL_DOCUMENT_ROOT.'/core/modules/product_batch/';
+										$batch_autogen_res = dol_include_once($batch_autogen_dirroot.$batch_autogen_module.'.php');
+										require_once $batch_autogen_dirroot.$batch_autogen_module.'.php';
+										$batch_autogen_mod = new $batch_autogen_module($db);
+										'@phan-var-force ModeleNumRefBatch $batch_autogen_mod';
+
+										$batch_autogen_object = new stdClass();
+										$batch_autogen_object->fk_product = $fk_product;
+										$batch = $batch_autogen_mod->getNextValue(null, $batch_autogen_object);
+										$_POST['batchtoproduce-'.$line->id.'-'.$i] = $batch;
+									}
+								}
+								if (isModEnabled('productbatch') && $tmpproduct->status_batch && (!GETPOST('batchtoproduce-'.$line->id.'-'.$i))) {
+									setEventMessages($langs->trans("ErrorFieldRequiredForProduct", $langs->transnoentitiesnoconv("Batch"), $tmpproduct->ref), null, 'errors');
+									$error++;
+								}
+								//End Change
 							}
 						}
 

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -356,7 +356,7 @@ if (empty($reshook)) {
 										$batch = $batch_autogen_mod->getNextValue(null, $batch_autogen_object);
 										$_POST['batchtoproduce-'.$line->id.'-'.$i] = $batch;
 									}
-								} else if ($tmpproduct->status_batch == 1) {
+								} elseif ($tmpproduct->status_batch == 1) {
 									if ((getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_advanced') || (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_standard')) {
 										$batch_autogen_module = getDolGlobalString('PRODUCTBATCH_LOT_ADDON');
 										$batch_autogen_dirroot = DOL_DOCUMENT_ROOT.'/core/modules/product_batch/';

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -939,17 +939,25 @@ class Reception extends CommonObject
 							}
 							if ($lastKey >= 0) {
 								$lastvalue = $this->lines[$lastKey]->batch;
-								$batch = $lastvalue;
+								$lastbatch = $lastvalue;
 								if (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_advanced') {
 									$mask = getDolGlobalString('LOT_ADVANCED_MASK');
 									if (preg_match('/\{(0+)([@\+][0-9\-\+\=]+)?([@\+][0-9\-\+\=]+)?\}/i', $mask, $reg)) {
 										$maskcounter = $reg[1];
 										$maskcounter_start = strpos(str_replace("}","",str_replace("{","",$mask)),$maskcounter);
 										$maskcounter_len = strlen($maskcounter);
-										$batch_pre = substr($batch, 0, $maskcounter_start);
-										$batch_suf = substr($batch, $maskcounter_len+$maskcounter_start);
-										$batch_counter = substr($batch,$maskcounter_start,$maskcounter_len);
-										$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+1)).$batch_suf;
+										$batch_pre = substr($lastbatch, 0, $maskcounter_start);
+										$batch_suf = substr($lastbatch, $maskcounter_len+$maskcounter_start);
+										$batch_counter = substr($lastbatch,$maskcounter_start,$maskcounter_len);
+										if (($batch_pre == $lastbatch) || empty($batch_counter)){
+											$batch = $batch;
+										} else {
+											if (empty(getDolGlobalString('SN_ADVANCED_INCREMENT'))) {
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+1)).$batch_suf;
+											} else {
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+getDolGlobalString('SN_ADVANCED_INCREMENT'))).$batch_suf;
+											}
+										}
 									}
 								} else if (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_standard') {
 									$batch_array = explode('-', $batch);

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -861,8 +861,113 @@ class Reception extends CommonObject
 		if (isModEnabled('productbatch')) {
 			$langs->load("errors");
 			if (!empty($product->status_batch) && empty($batch)) {
-				$this->error = $langs->trans('ErrorProductNeedBatchNumber', $product->ref);
-				return -1;
+				//Begin Change: Accellier Ltd.: Auto Generation of Serial/Lot Number
+				//$this->error = $langs->trans('ErrorProductNeedBatchNumber', $product->ref);
+				//return -1;
+				if ($product->status_batch == 2) {
+					if ((getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_advanced') || (getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_standard')) {
+						$batch_autogen_module = getDolGlobalString('PRODUCTBATCH_SN_ADDON');
+						$batch_autogen_dirroot = '/core/modules/product_batch/';
+						$batch_autogen_res = dol_include_once($batch_autogen_dirroot.$batch_autogen_module.'.php');
+						$batch_autogen_mod = new $batch_autogen_module($this->db);
+						'@phan-var-force ModeleNumRefBatch $batch_autogen_mod';
+
+						$batch_autogen_object = new stdClass();
+						$batch_autogen_object->fk_product = $fk_product;
+						$batch = $batch_autogen_mod->getNextValue(null, $batch_autogen_object);
+						if (!(empty($this->lines))) {
+							$lastKey = '';
+							foreach ($this->lines as $key=>$linevalue) {
+								$last_product = new Product($this->db);
+								$last_product->fetch($linevalue->fk_product);
+								if ($last_product->status_batch == 2) {
+									$lastKey = $key;
+								}
+							}
+							if ($lastKey >= 0) {
+								$lastvalue = $this->lines[$lastKey]->batch;
+								$lastbatch = $lastvalue;
+								if (getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_advanced') {
+									$mask = getDolGlobalString('SN_ADVANCED_MASK');
+									if (preg_match('/\{(0+)([@\+][0-9\-\+\=]+)?([@\+][0-9\-\+\=]+)?\}/i', $mask, $reg)) {
+										$maskcounter = $reg[1];
+										$maskcounter_start = strpos(str_replace("}","",str_replace("{","",$mask)),$maskcounter);
+										$maskcounter_len = strlen($maskcounter);
+										$batch_pre = substr($lastbatch, 0, $maskcounter_start);
+										$batch_suf = substr($lastbatch, $maskcounter_len+$maskcounter_start);
+										$batch_counter = substr($lastbatch,$maskcounter_start,$maskcounter_len);
+										if (($batch_pre == $lastbatch) || empty($batch_counter)){
+											$batch = $batch;
+										} else {
+											if (empty(getDolGlobalString('SN_ADVANCED_INCREMENT'))) {
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+1)).$batch_suf;
+											} else {
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+getDolGlobalString('SN_ADVANCED_INCREMENT'))).$batch_suf;
+											}
+										}
+									}
+								} else if (getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_standard') {
+									$batch_array = explode('-', $lastbatch);
+									$batch_array[1] = $batch_array[1]+1;
+									if ($batch_array[1] < 9999) {
+										$batch_array[1] = sprintf("%04d", $batch_array[1]);
+									}
+									$batch = implode('-',$batch_array);
+								}
+							}
+						}
+					}
+				} else if ($product->status_batch == 1) {
+					if ((getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_advanced') || (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_standard')) {
+						$batch_autogen_module = getDolGlobalString('PRODUCTBATCH_LOT_ADDON');
+						$batch_autogen_dirroot = '/core/modules/product_batch/';
+						$batch_autogen_res = dol_include_once($batch_autogen_dirroot.$batch_autogen_module.'.php');
+						$batch_autogen_mod = new $batch_autogen_module($this->db);
+						'@phan-var-force ModeleNumRefBatch $batch_autogen_mod';
+
+						$batch_autogen_object = new stdClass();
+						$batch_autogen_object->fk_product = $fk_product;
+						$batch = $batch_autogen_mod->getNextValue(null, $batch_autogen_object);
+						if (!(empty($this->lines))) {
+							$lastKey = '';
+							foreach ($this->lines as $key=>$linevalue) {
+								$last_product = new Product($this->db);
+								$last_product->fetch($linevalue->fk_product);
+								if ($last_product->status_batch == 1) {
+									$lastKey = $key;
+								}
+							}
+							if ($lastKey >= 0) {
+								$lastvalue = $this->lines[$lastKey]->batch;
+								$batch = $lastvalue;
+								if (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_advanced') {
+									$mask = getDolGlobalString('LOT_ADVANCED_MASK');
+									if (preg_match('/\{(0+)([@\+][0-9\-\+\=]+)?([@\+][0-9\-\+\=]+)?\}/i', $mask, $reg)) {
+										$maskcounter = $reg[1];
+										$maskcounter_start = strpos(str_replace("}","",str_replace("{","",$mask)),$maskcounter);
+										$maskcounter_len = strlen($maskcounter);
+										$batch_pre = substr($batch, 0, $maskcounter_start);
+										$batch_suf = substr($batch, $maskcounter_len+$maskcounter_start);
+										$batch_counter = substr($batch,$maskcounter_start,$maskcounter_len);
+										$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+1)).$batch_suf;
+									}
+								} else if (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_standard') {
+									$batch_array = explode('-', $batch);
+									$batch_array[1] = $batch_array[1]+1;
+									if ($batch_array[1] < 9999) {
+										$batch_array[1] = sprintf("%04d", $batch_array[1]);
+									}
+									$batch = implode('-',$batch_array);
+								}
+							}
+						}
+					}
+				}
+				if (empty($batch)) {
+					$this->error = $langs->trans('ErrorProductNeedBatchNumber', $product->ref);
+					return -1;
+				}
+				//End Change
 			} elseif (empty($product->status_batch) && !empty($batch)) {
 				$this->error = $langs->trans('ErrorProductDoesNotNeedBatchNumber', $product->ref);
 				return -1;

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -906,7 +906,7 @@ class Reception extends CommonObject
 											}
 										}
 									}
-								} else if (getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_standard') {
+								} elseif (getDolGlobalString('PRODUCTBATCH_SN_ADDON') == 'mod_sn_standard') {
 									$batch_array = explode('-', $lastbatch);
 									$batch_array[1] = $batch_array[1]+1;
 									if ($batch_array[1] < 9999) {
@@ -917,7 +917,7 @@ class Reception extends CommonObject
 							}
 						}
 					}
-				} else if ($product->status_batch == 1) {
+				} elseif ($product->status_batch == 1) {
 					if ((getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_advanced') || (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_standard')) {
 						$batch_autogen_module = getDolGlobalString('PRODUCTBATCH_LOT_ADDON');
 						$batch_autogen_dirroot = '/core/modules/product_batch/';
@@ -959,7 +959,7 @@ class Reception extends CommonObject
 											}
 										}
 									}
-								} else if (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_standard') {
+								} elseif (getDolGlobalString('PRODUCTBATCH_LOT_ADDON') == 'mod_lot_standard') {
 									$batch_array = explode('-', $batch);
 									$batch_array[1] = $batch_array[1]+1;
 									if ($batch_array[1] < 9999) {

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -891,18 +891,18 @@ class Reception extends CommonObject
 									$mask = getDolGlobalString('SN_ADVANCED_MASK');
 									if (preg_match('/\{(0+)([@\+][0-9\-\+\=]+)?([@\+][0-9\-\+\=]+)?\}/i', $mask, $reg)) {
 										$maskcounter = $reg[1];
-										$maskcounter_start = strpos(str_replace("}","",str_replace("{","",$mask)),$maskcounter);
+										$maskcounter_start = strpos(str_replace("}", "", str_replace("{", "", $mask)), $maskcounter);
 										$maskcounter_len = strlen($maskcounter);
 										$batch_pre = substr($lastbatch, 0, $maskcounter_start);
 										$batch_suf = substr($lastbatch, $maskcounter_len+$maskcounter_start);
-										$batch_counter = substr($lastbatch,$maskcounter_start,$maskcounter_len);
+										$batch_counter = substr($lastbatch, $maskcounter_start, $maskcounter_len);
 										if (($batch_pre == $lastbatch) || empty($batch_counter)){
 											$batch = $batch;
 										} else {
 											if (empty(getDolGlobalString('SN_ADVANCED_INCREMENT'))) {
-												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+1)).$batch_suf;
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d", ($batch_counter+1)).$batch_suf;
 											} else {
-												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+getDolGlobalString('SN_ADVANCED_INCREMENT'))).$batch_suf;
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d", ($batch_counter+getDolGlobalString('SN_ADVANCED_INCREMENT'))).$batch_suf;
 											}
 										}
 									}
@@ -912,7 +912,7 @@ class Reception extends CommonObject
 									if ($batch_array[1] < 9999) {
 										$batch_array[1] = sprintf("%04d", $batch_array[1]);
 									}
-									$batch = implode('-',$batch_array);
+									$batch = implode('-', $batch_array);
 								}
 							}
 						}
@@ -944,18 +944,18 @@ class Reception extends CommonObject
 									$mask = getDolGlobalString('LOT_ADVANCED_MASK');
 									if (preg_match('/\{(0+)([@\+][0-9\-\+\=]+)?([@\+][0-9\-\+\=]+)?\}/i', $mask, $reg)) {
 										$maskcounter = $reg[1];
-										$maskcounter_start = strpos(str_replace("}","",str_replace("{","",$mask)),$maskcounter);
+										$maskcounter_start = strpos(str_replace("}", "", str_replace("{", "", $mask)), $maskcounter);
 										$maskcounter_len = strlen($maskcounter);
 										$batch_pre = substr($lastbatch, 0, $maskcounter_start);
 										$batch_suf = substr($lastbatch, $maskcounter_len+$maskcounter_start);
-										$batch_counter = substr($lastbatch,$maskcounter_start,$maskcounter_len);
+										$batch_counter = substr($lastbatch, $maskcounter_start, $maskcounter_len);
 										if (($batch_pre == $lastbatch) || empty($batch_counter)){
 											$batch = $batch;
 										} else {
 											if (empty(getDolGlobalString('SN_ADVANCED_INCREMENT'))) {
-												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+1)).$batch_suf;
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d", ($batch_counter+1)).$batch_suf;
 											} else {
-												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d",($batch_counter+getDolGlobalString('SN_ADVANCED_INCREMENT'))).$batch_suf;
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d", ($batch_counter+getDolGlobalString('SN_ADVANCED_INCREMENT'))).$batch_suf;
 											}
 										}
 									}
@@ -965,7 +965,7 @@ class Reception extends CommonObject
 									if ($batch_array[1] < 9999) {
 										$batch_array[1] = sprintf("%04d", $batch_array[1]);
 									}
-									$batch = implode('-',$batch_array);
+									$batch = implode('-', $batch_array);
 								}
 							}
 						}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -953,9 +953,9 @@ class Reception extends CommonObject
 											$batch = $batch;
 										} else {
 											if (empty(getDolGlobalString('SN_ADVANCED_INCREMENT'))) {
-												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d", ($batch_counter+1)).$batch_suf;
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d", ($batch_counter+1)) . $batch_suf;
 											} else {
-												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d", ($batch_counter+getDolGlobalString('SN_ADVANCED_INCREMENT'))).$batch_suf;
+												$batch = $batch_pre.sprintf("%0".$maskcounter_len."d", ($batch_counter+getDolGlobalString('SN_ADVANCED_INCREMENT'))) . $batch_suf;
 											}
 										}
 									}


### PR DESCRIPTION
*Currently, users must manually input Lot/Serial numbers for products during Manufacturing Orders or Reception processes. This can be time-consuming, especially in large-scale operations or scenarios where unique Lot/Serial tracking is critical for compliance or inventory management.*

When the Sr.no/lot no. Auto generation enabled, if the user leaves the Lot/Serial number field blank, Dolibarr should automatically generate a unique identifier based on a pre-defined format or sequence .

# Expected Benefits:
Improved efficiency by reducing manual data entry during Manufacturing and Reception processes.
