### PR TITLE
Qual: ci 21.0 - Improve lang test + message in case of test exception

### DIFF
--- a/test/phpunit/CommonClassTest.class.php
+++ b/test/phpunit/CommonClassTest.class.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2018 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -167,6 +167,16 @@ abstract class CommonClassTest extends TestCase
 		// Use GitHub Action compatible group output (:warning: arguments not encoded)
 		print "##[group]$className::$failedTestMethod failed - $argsText.".PHP_EOL;
 		print "## ".get_class($t).": {$t->getMessage()}".PHP_EOL;
+
+		// Show some information about where it happened
+		foreach ($t->getTrace() as $idx => $trace) {
+			if (isset($trace['file'], $trace['line'])  // Only if we have a file name
+				&& !preg_match('/(?:\bphar\b|Framework)/', $trace['file']) // Only if it's not in phpunit
+			) {
+				print "## backtrace($idx): From {$trace['file']}:{$trace['line']}.".PHP_EOL;
+			}
+		}
+
 
 		if ($nbLinesToShow) {
 			$newLines = count($last_lines);

--- a/test/phpunit/LangTest.php
+++ b/test/phpunit/LangTest.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2013 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -194,14 +194,14 @@ class LangTest extends CommonClassTest
 
 		include_once DOL_DOCUMENT_ROOT.'/core/class/translate.class.php';
 
-
 		$prefix = __METHOD__."($code) ";
 		$tmplangs = new Translate('', $conf);
 		$langcode = $code;
 		$tmplangs->setDefaultLang($langcode);
 		$tmplangs->load("main");
 
-		print PHP_EOL.$prefix."Check language file".PHP_EOL;
+		print PHP_EOL.$prefix."Check language files".PHP_EOL;
+
 		$result = $tmplangs->transnoentitiesnoconv("FONTFORPDF");
 		print $prefix."FONTFORPDF=".$result.PHP_EOL;
 		$this->assertTrue(in_array($result, array('msungstdlight', 'stsongstdlight', 'helvetica', 'DejaVuSans', 'cid0jp', 'cid0kr', 'freemono', 'freeserif')), 'Error bad value '.$result.' for FONTFORPDF in main.lang file '.$code);
@@ -231,14 +231,14 @@ class LangTest extends CommonClassTest
 
 		unset($tmplangs);
 
-		print $prefix."Check some syntax rules in the language file".PHP_EOL;
+		print $prefix."Check syntax rules in the language files".PHP_EOL;
 		$filesarray2 = scandir(DOL_DOCUMENT_ROOT.'/langs/'.$code);
 		foreach ($filesarray2 as $key => $file) {
 			if (! preg_match('/\.lang$/', $file)) {
 				continue;
 			}
 
-			//print 'Check lang file '.$file.PHP_EOL;
+			//print $prefix.'Check lang file '.$file.PHP_EOL;
 			$filecontent = file_get_contents(DOL_DOCUMENT_ROOT.'/langs/'.$code.'/'.$file);
 
 			$result = preg_match('/=--$/m', $filecontent);	// A special % char we don't want. We want the common one.
@@ -260,7 +260,7 @@ class LangTest extends CommonClassTest
 			$reg = array();
 			$result = preg_match('/(.*)\'notranslate\'/im', $filecontent, $reg);	// A sequence of char we don't want
 			//print $prefix."Result for checking we don't have bad percent char = ".$result.PHP_EOL;
-			$this->assertTrue($result == 0, 'Found a sequence tag \'notranslate\' in the translation file '.$code.'/'.$file.' in line '.empty($reg[1]) ? '' : $reg[1]);
+			$this->assertTrue($result == 0, 'Found a sequence tag \'notranslate\' in the translation file '.$code.'/'.$file.' in line '.(empty($reg[1]) ? '' : $reg[1]));
 
 			if (!in_array($code, array('ar_SA'))) {
 				$reg = array();


### PR DESCRIPTION
# Qual: Improve lang test + message in case of test exception

This fixes the language test enabling the error message itself. I also improved the Exception handling so that a backtrace is shown to help find where it happened (here the error message was empty which was strange and made it harder to find - the (empty(val)?a:b) was lacking parentheses for proper concatenation