### PR TITLE
QUAL: docker-dev: Improve docker-dev compose setup

### DIFF
--- a/dev/build/docker-dev/Dockerfile
+++ b/dev/build/docker-dev/Dockerfile
@@ -23,10 +23,11 @@ RUN apt-get update -y \
         msmtp \
         msmtp-mta \
         mailutils \
+        libpq-dev \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
+    && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql pgsql gd soap zip \
     && docker-php-ext-configure ldap \
     && docker-php-ext-install -j$(nproc) ldap && \
     mv ${PHP_INI_DIR}/php.ini-development ${PHP_INI_DIR}/php.ini

--- a/dev/build/docker-dev/Dockerfile
+++ b/dev/build/docker-dev/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update -y \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) calendar intl mysqli pdo_mysql gd soap zip \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-configure ldap \
     && docker-php-ext-install -j$(nproc) ldap && \
     mv ${PHP_INI_DIR}/php.ini-development ${PHP_INI_DIR}/php.ini
 

--- a/dev/build/docker-dev/README.md
+++ b/dev/build/docker-dev/README.md
@@ -1,8 +1,9 @@
 # How to use it ?
 
-The docker-compose.yml file is a sample of a config file to use to build and run Dolibarr in the current workspace with Docker.
-This docker image is intended for development usage.
-For production usage you should consider other contributor reference like https://hub.docker.com/r/dolibarr/dolibarr 
+The docker-compose.yml file is a sample of a config file to use to build and run
+Dolibarr in the current workspace with Docker. This docker image is intended for
+**development usage**. For production usage you should consider other
+contributor reference like https://hub.docker.com/r/dolibarr/dolibarr.
 
 Before build/run, define the variable HOST_USER_ID as following:
 
@@ -26,9 +27,11 @@ The URL to go to PhpMyAdmin is (login/password is root/root) :
 
         http://0.0.0.0:8080
 
-In Dolibarr configuration Email let PHP mail function, To see all mail send by Dolibarr go to maildev
+In Dolibarr configuration Email let PHP mail function, To see all mail send by
+Dolibarr go to maildev
 
         http://0.0.0.0:8081
 
-Setup the database connection during the installation process, please use mariadb (name of the database container) as database host.
-Setup documents folder, during the installation process, to /var/documents
+Setup the database connection during the installation process, please use
+mariadb (name of the database container) as database host. Setup documents
+folder, during the installation process, to /var/documents.

--- a/dev/build/docker-dev/README.md
+++ b/dev/build/docker-dev/README.md
@@ -13,11 +13,18 @@ Go in repository build/docker :
 
         cd dev/build/docker
 
-And then, you can run :
+And then, depending on whether you want to run with a MariaDB database or
+PostgreSQL database, you can run:
 
-        docker compose up
+        docker compose -f docker-compose.yml -f mariadb.yml up
+
+or
+
+        docker compose -f docker-compose.yml -f postgres.yml up
 
 This will run 4 containers Docker : Dolibarr, MariaDB, PhpMyAdmin and MailDev.
+In the case of PostgreSQL, only Dolibarr, MailDev and the PostgreSQL database
+will be running.
 
 The URL to go to the Dolibarr is :
 
@@ -33,5 +40,29 @@ Dolibarr go to maildev
         http://0.0.0.0:8081
 
 Setup the database connection during the installation process, please use
-mariadb (name of the database container) as database host. Setup documents
-folder, during the installation process, to /var/documents.
+mariadb or postgres (name of the database container) as database host.
+
+## Setup your custom modules
+
+You can setup your own modules from your development folder by using volume
+mounts and docker compose override. For instance for your module "yourmodule"
+located in `/path/to/your/module_folder`, you can edit `yourmodule.yml` and
+write:
+
+        ---
+        services:
+            web:
+                volumes:
+                    - /path/to/your/module_folder:/var/www/html/custom/yourmodule/
+
+This will add your module at runtime inside the dolibarr custom plugins and it
+will automatically be synced with your development environment.
+
+Then, you can start by extending one of the commands above, for instance for
+mariadb:
+
+        docker compose \
+            -f docker-compose.yml \
+            -f postgres.yml \
+            -f yourmodule.yml \
+            up

--- a/dev/build/docker-dev/README.md
+++ b/dev/build/docker-dev/README.md
@@ -15,7 +15,7 @@ Go in repository build/docker :
 
 And then, you can run :
 
-        docker-compose up
+        docker compose up
 
 This will run 4 containers Docker : Dolibarr, MariaDB, PhpMyAdmin and MailDev.
 

--- a/dev/build/docker-dev/docker-compose.yml
+++ b/dev/build/docker-dev/docker-compose.yml
@@ -1,5 +1,4 @@
-version: '3'
-
+---
 networks:
     internal-pod:
         internal: true

--- a/dev/build/docker-dev/docker-compose.yml
+++ b/dev/build/docker-dev/docker-compose.yml
@@ -37,8 +37,8 @@ services:
             PHP_INI_DATE_TIMEZONE: $PHP_INI_DATE_TIMEZONE
             PHP_INI_MEMORY_LIMIT: $PHP_INI_MEMORY_LIMIT
         volumes:
-            - ../../htdocs:/var/www/html/
-            - ../../documents:/var/documents
+            - ../../../htdocs:/var/www/html/
+            - ../../../documents:/var/www/documents
         ports:
             - "80:80"
             - "9000:9000"

--- a/dev/build/docker-dev/docker-compose.yml
+++ b/dev/build/docker-dev/docker-compose.yml
@@ -16,19 +16,6 @@ services:
         networks:
             - internal-pod
             - external-pod
-
-    phpmyadmin:
-        image: phpmyadmin/phpmyadmin
-        environment:
-            PMA_HOST: mariadb
-        depends_on:
-            - mariadb
-        ports:
-            - "8080:80"
-        networks:
-            - internal-pod
-            - external-pod
-
     web:
         build: .
         environment:
@@ -42,7 +29,6 @@ services:
             - "80:80"
             - "9000:9000"
         depends_on:
-            - mariadb
             - mail
         networks:
             - internal-pod

--- a/dev/build/docker-dev/docker-run.sh
+++ b/dev/build/docker-dev/docker-run.sh
@@ -2,18 +2,13 @@
 # Script used by the Dockerfile.
 # See README.md to know how to create a Dolibarr env with docker
 
+if [ "${HOST_USER_ID}" == "" ]; then
+	echo "Define HOST_USER_ID to your user ID before starting"
+	exit 1
+fi
+
 usermod -u "${HOST_USER_ID}" www-data
 groupmod -g "${HOST_USER_ID}" www-data
-
-chgrp -hR www-data /var/www/html
-chmod g+rwx /var/www/html/conf
-
-if [ ! -d /var/documents ]; then
-	echo "[docker-run] => create volume directory /var/documents ..."
-	mkdir -p /var/documents
-fi
-echo "[docker-run] => Set Permission to www-data for /var/documents"
-chown -R www-data:www-data /var/documents
 
 echo "[docker-run] => update '${PHP_INI_DIR}/conf.d/dolibarr-php.ini'"
 cat <<EOF > "${PHP_INI_DIR}/conf.d/dolibarr-php.ini"

--- a/dev/build/docker-dev/docker-run.sh
+++ b/dev/build/docker-dev/docker-run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Script used by the Dockerfile.
 # See README.md to know how to create a Dolibarr env with docker
+set -ex
 
 if [ "${HOST_USER_ID}" == "" ]; then
 	echo "Define HOST_USER_ID to your user ID before starting"
@@ -14,6 +15,7 @@ echo "[docker-run] => update '${PHP_INI_DIR}/conf.d/dolibarr-php.ini'"
 cat <<EOF > "${PHP_INI_DIR}/conf.d/dolibarr-php.ini"
 date.timezone = ${PHP_INI_DATE_TIMEZONE:-UTC}
 memory_limit = ${PHP_INI_MEMORY_LIMIT:-256M}
+display_errors = Off
 EOF
 
 exec apache2-foreground

--- a/dev/build/docker-dev/mariadb.yml
+++ b/dev/build/docker-dev/mariadb.yml
@@ -1,0 +1,34 @@
+---
+networks:
+    internal-pod:
+        internal: true
+    external-pod:
+        internal: false
+
+services:
+    mariadb:
+        image: mariadb:latest
+        environment:
+            MYSQL_ROOT_PASSWORD: rootpassfordev
+            MYSQL_DATABASE: dolibarr
+        ports:
+            - "3306:3306"
+        networks:
+            - internal-pod
+            - external-pod
+    web:
+        depends_on:
+            - mariadb
+    phpmyadmin:
+        image: phpmyadmin/phpmyadmin
+        environment:
+            PMA_HOST: mariadb
+        depends_on:
+            - mariadb
+        ports:
+            - "8080:80"
+        networks:
+            - internal-pod
+            - external-pod
+
+

--- a/dev/build/docker-dev/postgres.yml
+++ b/dev/build/docker-dev/postgres.yml
@@ -1,0 +1,18 @@
+---
+networks:
+    internal-pod:
+        internal: true
+    external-pod:
+        internal: false
+
+services:
+    postgres:
+        image: postgres:latest
+        environment:
+            POSTGRES_PASSWORD: rootpassfordev
+        networks:
+            - internal-pod
+            - external-pod
+    web:
+        depends_on:
+            - postgres


### PR DESCRIPTION
# QUAL docker-dev: improve docker-dev compose setup

This MR fixes the paths for the current docker-dev compose manifest as well as documenting and adding new ways to run the setup with postgresql or with custom modules.