### PR TITLE
FIX: FEC import

### DIFF
--- a/htdocs/accountancy/class/accountancyimport.class.php
+++ b/htdocs/accountancy/class/accountancyimport.class.php
@@ -113,12 +113,12 @@ class AccountancyImport
 
 
 	/**
-	 *  Compute direction
+	 * Compute direction
 	 *
 	 * @param   array       $arrayrecord        Array of read values: [fieldpos] => (['val']=>val, ['type']=>-1=null,0=blank,1=string), [fieldpos+1]...
 	 * @param   array       $listfields         Fields list to add
 	 * @param 	int			$record_key         Record key
-	 * @return  mixed							Value
+	 * @return  string							Value D or C or ""
 	 */
 	public function computeDirection(&$arrayrecord, $listfields, $record_key)
 	{
@@ -132,7 +132,7 @@ class AccountancyImport
 				$sens = 'C';
 			}
 
-			return $this->db->escape($sens);
+			return $sens;
 		}
 
 		return "";

--- a/htdocs/accountancy/class/accountancyimport.class.php
+++ b/htdocs/accountancy/class/accountancyimport.class.php
@@ -132,9 +132,9 @@ class AccountancyImport
 				$sens = 'C';
 			}
 
-			return "'" . $this->db->escape($sens) . "'";
+			return $this->db->escape($sens);
 		}
 
-		return "''";
+		return "";
 	}
 }


### PR DESCRIPTION
Actual Bug
![image](https://github.com/user-attachments/assets/7ee9e4e7-0b28-4988-8f44-292cdc147d7a)

Explanation : 
**sens** is a compute and hidden field define here
https://github.com/Dolibarr/dolibarr/blob/0578a5654f02c4e6d11218bb3821aa131df32d1a/htdocs/core/modules/modAccounting.class.php#L372
https://github.com/Dolibarr/dolibarr/blob/0578a5654f02c4e6d11218bb3821aa131df32d1a/htdocs/core/modules/modAccounting.class.php#L362

method **computeDirection** 
https://github.com/Dolibarr/dolibarr/blob/0578a5654f02c4e6d11218bb3821aa131df32d1a/htdocs/accountancy/class/accountancyimport.class.php#L135
return value can be 
`"'D'"` or `"'C'"` or `"''"`


but, when field is hidden (and not int or double) there is 
- in import_csv.modules.php
https://github.com/Dolibarr/dolibarr/blob/0578a5654f02c4e6d11218bb3821aa131df32d1a/htdocs/core/modules/import/import_csv.modules.php#L830
 - and import_xlsx.module.php
https://github.com/Dolibarr/dolibarr/blob/0578a5654f02c4e6d11218bb3821aa131df32d1a/htdocs/core/modules/import/import_xlsx.modules.php#L871

=> `$listvalues[] = "'".$this->db->escape($res)."'";`

the result  sql insert values for this field is `'\'D\''` or `'\'C\''` instead of `'D'` or `'C'`

