### PR TITLE
FIX delete file with mask

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -1588,7 +1588,7 @@ function dol_delete_file($file, $disableglob = 0, $nophperrors = 0, $nohook = 0,
 					}
 				}
 			} else {
-				$ok = false; // to avoid false positive
+				$ok = true;
 				dol_syslog("No files to delete found", LOG_DEBUG);
 			}
 		} else {


### PR DESCRIPTION
FIX delete file with mask
- I have an error when I want to upgrade the new version of Dolibarr (develop only)
![image](https://github.com/user-attachments/assets/1e7004ce-8e5e-4ed3-ac12-07a3081eeeac)

If we check the upgrade2.php script at line 4123, we see the script has a mask to delete several files :
- /includes/nusoap/lib/class.*

And the function "dol_delete_file()" can have several files as mask in the first parameter (see in "files.lib.php")

I don't know if it's the good way to fix it but I wonder why if no files found there is an error on line 1591 of "file.lib.php" : 
```
$ok = false; // to avoid false positive
dol_syslog("No files to delete found", LOG_DEBUG);
```

and the syslog in not a Warning or Error.
