### PR TITLE
FIX search status in tasks

### DIFF
--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -330,8 +330,8 @@ if (!empty($search_progresscalc)) {
 	$morewherefilterarray[] = '(planned_workload IS NULL OR planned_workload = 0 OR '.natural_search('ROUND(100 * duration_effective / planned_workload, 2)', $search_progresscalc, 1, 1).')';
 	//natural_search('round(100 * $line->duration_effective / $line->planned_workload,2)', $filterprogresscalc, 1, 1).' {return 1;} else {return 0;}';
 }
-if ($search_status > -1) {
-	$morewherefilterarray[] = " t.fk_statut = ".$search_status;
+if ($search_status > -1 && $search_status != '') {
+	$morewherefilterarray[] = " t.fk_statut = ".((int) $search_status);
 }
 if ($search_task_budget_amount) {
 	$morewherefilterarray[] = natural_search('t.budget_amount', $search_task_budget_amount, 1, 1);


### PR DESCRIPTION
FIX search status in tasks
- if you go on tasks tab of project, you got a SQL error (on develop only) : 

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'GROUP BY p.rowid, p.ref, p.title, p.public, p.fk_statut, p.usage_bill_time, t.da' at line 1
