### PR TITLE
FIX wrong message on update shipment

### DIFF
--- a/htdocs/expedition/dispatch.php
+++ b/htdocs/expedition/dispatch.php
@@ -357,7 +357,7 @@ if ($action == 'updatelines' && $usercancreate) {
 		setEventMessages($langs->trans("Error"), $errors, 'errors');
 	} else {
 		$db->commit();
-		setEventMessages($langs->trans("ReceptionUpdated"), null);
+		setEventMessages($langs->trans("ShipmentUpdated"), null);
 
 		header("Location: ".DOL_URL_ROOT.'/expedition/dispatch.php?id='.$object->id);
 		exit;

--- a/htdocs/langs/en_US/sendings.lang
+++ b/htdocs/langs/en_US/sendings.lang
@@ -66,6 +66,7 @@ NoLineGoOnTabToAddSome=No line, go on tab "%s" to add
 CreateInvoiceForThisCustomerFromSendings=Create Bills
 IfValidateInvoiceIsNoSendingStayUnbilled=If invoice validation is 'No', the sending will remain to status 'Unbilled' until the invoice is validated.
 OptionToSetSendingBilledNotEnabled=Option from module Workflow, to set sending to 'Billed' automatically when invoice is validated, is not enabled, so you will have to set the status of sendings to 'Billed' manually after the invoice has been generated.
+ShipmentUpdated=Shipment successfully updated
 
 # Sending methods
 # ModelDocument


### PR DESCRIPTION
FIX wrong message on update shipment
- the message when you update a dispatched shipment is "Reception successfully updated"

**After**
with this fix the message is now "Shipment successfully updated"