### PR TITLE
FIX max file size to download not needed for WebPortal

### DIFF
--- a/htdocs/webportal/controllers/document.controller.class.php
+++ b/htdocs/webportal/controllers/document.controller.class.php
@@ -212,15 +212,6 @@ class DocumentController extends Controller
 			exit;
 		}
 
-		$fileSize = dol_filesize($fullpath_original_file); // the returned value is in byte
-		$fileSizeMaxDefault = 20 * 1024 * 1024; // 20 Mo by default
-		$fileSizeMax = getDolGlobalInt('MAIN_SECURITY_MAXFILESIZE_DOWNLOADED', $fileSizeMaxDefault);
-		if ($fileSize > $fileSizeMax) {
-			dol_syslog('ErrorFileSizeTooLarge: ' . $fileSize);
-			print 'ErrorFileSizeTooLarge: ' . $fileSize . ' (max ' . $fileSizeMax . ')';
-			exit;
-		}
-
 		// Hooks
 		$hookmanager->initHooks(array('document'));
 		$parameters = array('ecmfile' => $ecmfile, 'modulepart' => $modulepart, 'original_file' => $original_file,


### PR DESCRIPTION
FIX max file size to download not needed for WebPortal
- the file size in not for downloading PDF documents (no limit)

With this FIX it's the same behavior when you download PDF documents from the back office. 