### PR TITLE
NEW: add const to not include default CSS in top_htmlhead with DISABLE_CSS_DEFAULT_THEME

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -2036,22 +2036,24 @@ function top_htmlhead($head, $title = '', $disablejs = 0, $disablehead = 0, $arr
 			print '<link rel="stylesheet" type="text/css" href="'.DOL_URL_ROOT.$fontawesome_directory.'/css/all.min.css'.($ext ? '?'.$ext : '').'">'."\n";
 		}
 
-		print '<!-- Includes CSS for Dolibarr theme -->'."\n";
-		// Output style sheets (optioncss='print' or ''). Note: $conf->css looks like '/theme/eldy/style.css.php'
-		$themepath = dol_buildpath($conf->css, 1);
-		$themesubdir = '';
-		if (!empty($conf->modules_parts['theme'])) {	// This slow down
-			foreach ($conf->modules_parts['theme'] as $reldir) {
-				if (file_exists(dol_buildpath($reldir.$conf->css, 0))) {
-					$themepath = dol_buildpath($reldir.$conf->css, 1);
-					$themesubdir = $reldir;
-					break;
+		if (!defined('DISABLE_CSS_DEFAULT_THEME')) {
+			print '<!-- Includes CSS for Dolibarr theme -->'."\n";
+			// Output style sheets (optioncss='print' or ''). Note: $conf->css looks like '/theme/eldy/style.css.php'
+			$themepath = dol_buildpath($conf->css, 1);
+			$themesubdir = '';
+			if (!empty($conf->modules_parts['theme'])) {	// This slow down
+				foreach ($conf->modules_parts['theme'] as $reldir) {
+					if (file_exists(dol_buildpath($reldir.$conf->css, 0))) {
+						$themepath = dol_buildpath($reldir.$conf->css, 1);
+						$themesubdir = $reldir;
+						break;
+					}
 				}
 			}
+
+			print '<link rel="stylesheet" type="text/css" href="' . $themepath . $themeparam . '">' . "\n";
 		}
 
-		//print 'themepath='.$themepath.' themeparam='.$themeparam;exit;
-		print '<link rel="stylesheet" type="text/css" href="'.$themepath.$themeparam.'">'."\n";
 		if (getDolGlobalString('MAIN_FIX_FLASH_ON_CHROME')) {
 			print '<!-- Includes CSS that does not exists as a workaround of flash bug of chrome -->'."\n".'<link rel="stylesheet" type="text/css" href="filethatdoesnotexiststosolvechromeflashbug">'."\n";
 		}

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -2036,21 +2036,21 @@ function top_htmlhead($head, $title = '', $disablejs = 0, $disablehead = 0, $arr
 			print '<link rel="stylesheet" type="text/css" href="'.DOL_URL_ROOT.$fontawesome_directory.'/css/all.min.css'.($ext ? '?'.$ext : '').'">'."\n";
 		}
 
-		if (!defined('DISABLE_CSS_DEFAULT_THEME')) {
-			print '<!-- Includes CSS for Dolibarr theme -->'."\n";
-			// Output style sheets (optioncss='print' or ''). Note: $conf->css looks like '/theme/eldy/style.css.php'
-			$themepath = dol_buildpath($conf->css, 1);
-			$themesubdir = '';
-			if (!empty($conf->modules_parts['theme'])) {	// This slow down
-				foreach ($conf->modules_parts['theme'] as $reldir) {
-					if (file_exists(dol_buildpath($reldir.$conf->css, 0))) {
-						$themepath = dol_buildpath($reldir.$conf->css, 1);
-						$themesubdir = $reldir;
-						break;
-					}
+		// Output style sheets (optioncss='print' or ''). Note: $conf->css looks like '/theme/eldy/style.css.php'
+		$themepath = dol_buildpath($conf->css, 1);
+		$themesubdir = '';
+		if (!empty($conf->modules_parts['theme'])) {	// This slow down
+			foreach ($conf->modules_parts['theme'] as $reldir) {
+				if (file_exists(dol_buildpath($reldir.$conf->css, 0))) {
+					$themepath = dol_buildpath($reldir.$conf->css, 1);
+					$themesubdir = $reldir;
+					break;
 				}
 			}
+		}
 
+		if (!defined('DISABLE_CSS_DEFAULT_THEME')) {
+			print '<!-- Includes CSS for Dolibarr theme -->'."\n";
 			print '<link rel="stylesheet" type="text/css" href="' . $themepath . $themeparam . '">' . "\n";
 		}
 


### PR DESCRIPTION
fix: #32971

When custom module add page, it would be nice to not always include defaulted "/theme/eldy/style.css.php" (not minified) 