### PR TITLE
Added one line to allow use of price_ttc in calculated extra fields (…

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -1628,7 +1628,8 @@ while ($i < $imaxinloop) {
 	}
 
 	$product_static->price = $obj->price;
-
+	$product_static->price_ttc = $obj->price_ttc; // Allows to use price_ttc in calculated extra fields (ex : price per kilo)
+	
 	$object = $product_static;
 
 	$usercancreadprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('product', 'product_advance', 'read_prices') : $user->hasRight('product', 'lire');

--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -1629,7 +1629,7 @@ while ($i < $imaxinloop) {
 
 	$product_static->price = $obj->price;
 	$product_static->price_ttc = $obj->price_ttc; // Allows to use price_ttc in calculated extra fields (ex : price per kilo)
-	
+
 	$object = $product_static;
 
 	$usercancreadprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('product', 'product_advance', 'read_prices') : $user->hasRight('product', 'lire');


### PR DESCRIPTION
# NEW [*Added one line to allow use of price_ttc in calculated extra fields (ex : price per kilo)*]
price_ttc sometimes needs to be used in extra fields to compute price ttc per kilo or per liter. 
Currently price_ttc does not compute in the product list, so price per kilo cannot compute either. 
This allows to add an extra field "Price TTC per kilo" like this : $object->price_ttc / $object->weight. 
$object->price_ttc will work because the added line puts price_ttc into $products_static, which is put in $object. 