### PR TITLE
Fix: Avoid undefined array key warning in form setup

### DIFF
--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -329,7 +329,7 @@ class FormSetup
 			$this->setupNotEmpty++;
 			$out .= '<tr class="'.$trClass.'">';
 
-			$out .= '<td class="col-setup-title'.($item->fieldParams['isMandatory'] ? ' fieldrequired' : '').'">';
+			$out .= '<td class="col-setup-title'.(!empty($item->fieldParams['isMandatory']) ? ' fieldrequired' : '').'">';
 			$out .= '<span id="helplink'.$item->confKey.'" class="spanforparamtooltip">';
 			$out .= $this->form->textwithpicto($item->getNameText(), $item->getHelpText(), 1, 'info', '', 0, 3, 'tootips'.$item->confKey);
 			$out .= '</span>';


### PR DESCRIPTION
- Added a check to ensure 'isMandatory' exists in $item->fieldParams before accessing it.
- Prevents "Undefined array key" warning in html.formsetup.class.php.
- Improved robustness by using !empty() to handle missing or false values safely.

❤️ @defrance