### PR TITLE
Fix: Prevent warnings and fatal error in admin/mrp.php

### DIFF
--- a/htdocs/admin/mrp.php
+++ b/htdocs/admin/mrp.php
@@ -30,6 +30,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/pdf.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/mrp/class/mo.class.php';
 require_once DOL_DOCUMENT_ROOT.'/mrp/lib/mrp_mo.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/mrp/lib/mrp.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 
 /**
  * @var Conf $conf
@@ -397,7 +398,7 @@ foreach ($dirmodels as $reldir) {
 
 								// Default
 								print '<td class="center">';
-								if ($conf->global->MRP_MO_ADDON_PDF == $name) {
+								if (!empty($conf->global->MRP_MO_ADDON_PDF) && $conf->global->MRP_MO_ADDON_PDF == $name) {
 									print img_picto($langs->trans("Default"), 'on');
 								} else {
 									print '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?action=setdoc&token='.newToken().'&value='.urlencode($name).'&scan_dir='.urlencode($module->scandir).'&label='.urlencode($module->name).'" alt="'.$langs->trans("Default").'">'.img_picto($langs->trans("Disabled"), 'off').'</a>';

--- a/htdocs/admin/mrp.php
+++ b/htdocs/admin/mrp.php
@@ -398,7 +398,7 @@ foreach ($dirmodels as $reldir) {
 
 								// Default
 								print '<td class="center">';
-								if (!empty($conf->global->MRP_MO_ADDON_PDF) && $conf->global->MRP_MO_ADDON_PDF == $name) {
+								if (getDolGlobalString("MRP_MO_ADDON_PDF") == $name) {
 									print img_picto($langs->trans("Default"), 'on');
 								} else {
 									print '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?action=setdoc&token='.newToken().'&value='.urlencode($name).'&scan_dir='.urlencode($module->scandir).'&label='.urlencode($module->name).'" alt="'.$langs->trans("Default").'">'.img_picto($langs->trans("Disabled"), 'off').'</a>';


### PR DESCRIPTION
- Fixed "Undefined property: stdClass::$MRP_MO_ADDON_PDF" by checking existence with !empty().
- Fixed "Class 'Product' not found" by adding require_once for product.class.php.
- Improves stability and prevents unexpected crashes in MRP module.

❤️ @defrance