### PR TITLE
Fix: Prevent invalid foreach() on extrafields label in product/price.php

### DIFF
--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -1539,7 +1539,7 @@ if (getDolGlobalString('PRODUIT_MULTIPRICES') || getDolGlobalString('PRODUIT_CUS
 
 	// Extrafields
 	$extrafields->fetch_name_optionals_label("product");
-	$extralabels = !empty($extrafields->attributes["product"]['label']) ? $extrafields->attributes["product"]['label'] : '';
+	$extralabels = !empty($extrafields->attributes["product"]['label']) ? $extrafields->attributes["product"]['label'] : [];
 	$extrafield_values = $extrafields->getOptionalsFromPost("product");
 	$sql  = "SELECT";
 	$sql .= " fk_object";


### PR DESCRIPTION
- Ensured $extralabels is always an array before looping to prevent warnings.
- Fixes "foreach() argument must be of type array|string given" error.
- Improves stability when handling extrafields.

❤️ @defrance