### PR TITLE
Update html.formmargin.class.php

### DIFF
--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -99,7 +99,7 @@ class FormMargin
 				$line->pa_ht = $line->subprice * (1 - ($line->remise_percent / 100));
 			}
 
-			$pv = $line->total_ht;
+			$pv = (float)$line->total_ht;
 
 			// $line->pa_ht is always positive in database, so we guess the correct sign
 

--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -99,7 +99,7 @@ class FormMargin
 				$line->pa_ht = $line->subprice * (1 - ($line->remise_percent / 100));
 			}
 
-			$pv = (float)$line->total_ht;
+			$pv = (float) $line->total_ht;
 
 			// $line->pa_ht is always positive in database, so we guess the correct sign
 


### PR DESCRIPTION
Under PHP 8 , can't add string and float on following lines. So i propose to convert to avoid errors

But i don't understand why database double(24,8) are fetched as string 