### PR TITLE
FIX #33038 drag and drop files are not prefixed with object reference

### DIFF
--- a/htdocs/core/class/fileupload.class.php
+++ b/htdocs/core/class/fileupload.class.php
@@ -58,6 +58,7 @@ class FileUpload
 		$pathname = str_replace('/class', '', $element_prop['classpath']);
 		$filename = $element_prop['classfile'];
 		$dir_output = $element_prop['dir_output'];
+		$savingDocMask = '';
 
 		//print 'fileupload.class.php: element='.$element.' pathname='.$pathname.' filename='.$filename.' dir_output='.$dir_output."\n";
 
@@ -72,6 +73,11 @@ class FileUpload
 			$object = fetchObjectByElement($fk_element, $element);
 
 			$object_ref = dol_sanitizeFileName($object->ref);
+
+			// add object reference as file name prefix if const MAIN_DISABLE_SUGGEST_REF_AS_PREFIX is not enabled
+			if (!getDolGlobalInt('MAIN_DISABLE_SUGGEST_REF_AS_PREFIX')) {
+				$savingDocMask = $object_ref.'-__file__';
+			}
 
 			// Special cases to forge $object_ref used to forge $upload_dir
 			if ($element == 'invoice_supplier') {
@@ -98,6 +104,7 @@ class FileUpload
 			'script_url' => $_SERVER['PHP_SELF'],
 			'upload_dir' => $dir_output.'/'.$object_ref.'/',
 			'upload_url' => DOL_URL_ROOT.'/document.php?modulepart='.$element.'&attachment=1&file=/'.$object_ref.'/',
+			'saving_doc_mask' => $savingDocMask,
 			'param_name' => 'files',
 			// Set the following option to 'POST', if your server does not support
 			// DELETE requests. This is a parameter sent to the client:
@@ -417,6 +424,14 @@ class FileUpload
 
 		if ($validate) {
 			if (dol_mkdir($this->options['upload_dir']) >= 0) {
+				// add object reference as file name prefix if const MAIN_DISABLE_SUGGEST_REF_AS_PREFIX is not enabled
+				$fileNameWithoutExt = preg_replace('/\.[^\.]+$/', '', $file->name);
+				$savingDocMask = $this->options['saving_doc_mask'];
+				if ($savingDocMask && strpos($savingDocMask, $fileNameWithoutExt) !== 0) {
+					$fileNameWithPrefix = preg_replace('/__file__/', $file->name, $savingDocMask);
+					$file->name = $fileNameWithPrefix;
+				}
+
 				$file_path = $this->options['upload_dir'].$file->name;
 				$append_file = !$this->options['discard_aborted_uploads'] && is_file($file_path) && $file->size > filesize($file_path);
 


### PR DESCRIPTION
FIX #33038 drag and drop files are not prefixed with object reference