### PR TITLE
fix: remove unused variable $show_files

### DIFF
--- a/htdocs/reception/list.php
+++ b/htdocs/reception/list.php
@@ -1458,7 +1458,7 @@ print '</form>';
 $db->free($resql);
 
 $hidegeneratedfilelistifempty = 1;
-if ($massaction == 'builddoc' || $action == 'remove_file' || $show_files) {
+if ($massaction == 'builddoc' || $action == 'remove_file') {
 	$hidegeneratedfilelistifempty = 0;
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cf0fca4e-a2a8-4184-a455-e0cffb811462)

remove unused and undefined variable $show_files

@defrance 