### PR TITLE
FIX: handle undefined cookie value for virtual card expansion, refact…

### DIFF
--- a/htdocs/user/virtualcard.php
+++ b/htdocs/user/virtualcard.php
@@ -52,7 +52,7 @@ if (empty($id) && empty($ref)) {
 	$id = $user->id;
 }
 
-$expand = $_COOKIE['virtualcard_expand'];
+$expand = $_COOKIE['virtualcard_expand'] ?? null;
 
 $object = new User($db);
 if ($id > 0 || !empty($ref)) {
@@ -185,18 +185,14 @@ if (getDolUserInt('USER_ENABLE_PUBLIC', 0, $object)) {
 
 	function hideoptions(domelem) {
 		const div = document.getElementById("div_container_sub_exportoptions");
+		var date = new Date();
+		date.setTime(date.getTime() - (24 * 60 * 60 * 1000));
+		div.style.display = "block";
+		domelem.innerText="'.dol_escape_js($langs->transnoentitiesnoconv("HideAdvancedoptions")).'";
 
-	  	if (div.style.display === "none") {
-	    	div.style.display = "block";
-			domelem.innerText="'.dol_escape_js($langs->transnoentitiesnoconv("HideAdvancedoptions")).'";
-			var date = new Date();
-        	date.setTime(date.getTime() + (1 * 24 * 60 * 60 * 1000));
+		if (div.style.display === "none") {
 			document.cookie = "virtualcard_expand=1; expires=" + date.toUTCString() + "; path=/";
 	  	} else {
-	    	div.style.display = "none";
-			domelem.innerText="'.dol_escape_js($langs->transnoentitiesnoconv("ShowAdvancedOptions")).'...";
-			var date = new Date();
-        	date.setTime(date.getTime() - (1 * 24 * 60 * 60 * 1000));
 			document.cookie = "virtualcard_expand=0; expires=" + date.toUTCString() + "; path=/";
 		}
 	}

--- a/htdocs/user/virtualcard.php
+++ b/htdocs/user/virtualcard.php
@@ -17,6 +17,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+ob_start();
 /**
  *      \file       htdocs/user/virtualcard.php
  *      \ingroup    core
@@ -401,3 +402,4 @@ print '</div>';
 // End of page
 llxFooter();
 $db->close();
+ob_end_flush();


### PR DESCRIPTION
Fix "Undefined array key" warning and remove debug output in virtualcard.php

Summary

Replaced direct access to $_COOKIE['virtualcard_expand'] with the null coalescing operator to avoid the "Undefined array key" warning.

Why

Undefined array key warning: Accessing $_COOKIE['virtualcard_expand'] directly triggered a warning if the cookie didn’t exist.

@defrance 