### PR TITLE
Fix: Gestion mémoire dans dol_htmlentitiesbr()

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8723,6 +8723,7 @@ function dol_htmlentitiesbr($stringtoencode, $nl2brmode = 0, $pagecodefrom = 'UT
 		$newstring = strtr($newstring, array('&' => '__PROTECTand__', '<' => '__PROTECTlt__', '>' => '__PROTECTgt__', '"' => '__PROTECTdquot__'));
 		$newstring = dol_htmlentities($newstring, ENT_COMPAT, $pagecodefrom); // Make entity encoding
 		$newstring = strtr($newstring, array('__PROTECTand__' => '&', '__PROTECTlt__' => '<', '__PROTECTgt__' => '>', '__PROTECTdquot__' => '"'));
+		
 	} else {
 		if ($removelasteolbr) {
 			$newstring = preg_replace('/(\r\n|\r|\n)$/i', '', $newstring); // Remove last \n (may remove several)


### PR DESCRIPTION
Cette PR corrige un problème de dépassement mémoire dans la fonction dol_htmlentitiesbr().
- Augmentation de la mémoire disponible.
- Vérification de la taille des entrées pour éviter une surcharge.
- Ajout d’un log pour détecter les chaînes trop longues.
@defrance 