### PR TITLE
[FIX] Remove xdebug_print_function_stack() call to suppress verbose X…

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -6193,14 +6193,19 @@ function dol_print_error($db = null, $error = '', $errors = null)
 			$syslog .= ", msg=".$msg;
 		}
 	}
-	if (empty($dolibarr_main_prod) && $_SERVER['DOCUMENT_ROOT'] && function_exists('xdebug_print_function_stack') && function_exists('xdebug_call_file')) {
-		xdebug_print_function_stack();
-		$out .= '<b>XDebug information:</b>'."<br>\n";
-		$out .= 'File: '.xdebug_call_file()."<br>\n";
-		$out .= 'Line: '.xdebug_call_line()."<br>\n";
-		$out .= 'Function: '.xdebug_call_function()."<br>\n";
-		$out .= "<br>\n";
+	if (empty($dolibarr_main_prod)
+		&& !empty($_SERVER['DOCUMENT_ROOT'])
+		&& function_exists('xdebug_call_file')
+		&& function_exists('xdebug_call_line')
+		&& function_exists('xdebug_call_function')) {
+
+		$out .= '<b>XDebug information:</b><br>' . "\n";
+		$out .= 'File: ' . xdebug_call_file() . '<br>' . "\n";
+		$out .= 'Line: ' . xdebug_call_line() . '<br>' . "\n";
+		$out .= 'Function: ' . xdebug_call_function() . '<br>' . "\n";
+		$out .= '<br>' . "\n";
 	}
+
 
 	// Return a http header with error code if possible
 	if (!headers_sent()) {


### PR DESCRIPTION
…Debug output in non-production environments

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

