### PR TITLE
Fix: Hide empty categories table

### DIFF
--- a/htdocs/categories/index.php
+++ b/htdocs/categories/index.php
@@ -130,7 +130,6 @@ if (empty($nosearch)) {
 			print '<table class="noborder centpercent">';
 			print '<tr class="liste_titre"><td colspan="2">'.$langs->trans("FoundCats").'</td></tr>';
 		}
-		
 		foreach ($cats as $cat) {
 			$categstatic->id = $cat->id;
 			$categstatic->ref = $cat->label;

--- a/htdocs/categories/index.php
+++ b/htdocs/categories/index.php
@@ -126,9 +126,11 @@ if (empty($nosearch)) {
 	if ($catname || $id > 0) {
 		$cats = $categstatic->rechercher($id, $catname, $typetext);
 
-		print '<table class="noborder centpercent">';
-		print '<tr class="liste_titre"><td colspan="2">'.$langs->trans("FoundCats").'</td></tr>';
-
+		if (count($cats) > 0) {
+			print '<table class="noborder centpercent">';
+			print '<tr class="liste_titre"><td colspan="2">'.$langs->trans("FoundCats").'</td></tr>';
+		}
+		
 		foreach ($cats as $cat) {
 			$categstatic->id = $cat->id;
 			$categstatic->ref = $cat->label;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/09da05f2-d5a4-42d8-adff-fa2ae66a6fc6)

Hide empty categories table when $cats < 0

@defrance 