### PR TITLE
[FIX] Remove xdebug_print_function_stack() call to suppress verbose XDebug output in non-production environments

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -166,7 +166,7 @@ function dol_time_plus_duree($time, $duration_value, $duration_unit, $ruleforend
 	if (getDolGlobalString('MAIN_DATE_IN_MEMORY_ARE_GMT')) {
 		$date->setTimezone(new DateTimeZone('UTC'));
 	}
-	$date->setTimestamp($time);
+	$date->setTimestamp((int)$time);
 	$interval = new DateInterval($deltastring);
 
 	if ($sub) {

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -166,7 +166,7 @@ function dol_time_plus_duree($time, $duration_value, $duration_unit, $ruleforend
 	if (getDolGlobalString('MAIN_DATE_IN_MEMORY_ARE_GMT')) {
 		$date->setTimezone(new DateTimeZone('UTC'));
 	}
-	$date->setTimestamp((int)$time);
+	$date->setTimestamp($time);
 	$interval = new DateInterval($deltastring);
 
 	if ($sub) {

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -6193,14 +6193,19 @@ function dol_print_error($db = null, $error = '', $errors = null)
 			$syslog .= ", msg=".$msg;
 		}
 	}
-	if (empty($dolibarr_main_prod) && $_SERVER['DOCUMENT_ROOT'] && function_exists('xdebug_print_function_stack') && function_exists('xdebug_call_file')) {
-		xdebug_print_function_stack();
-		$out .= '<b>XDebug information:</b>'."<br>\n";
-		$out .= 'File: '.xdebug_call_file()."<br>\n";
-		$out .= 'Line: '.xdebug_call_line()."<br>\n";
-		$out .= 'Function: '.xdebug_call_function()."<br>\n";
-		$out .= "<br>\n";
+	if (empty($dolibarr_main_prod)
+		&& !empty($_SERVER['DOCUMENT_ROOT'])
+		&& function_exists('xdebug_call_file')
+		&& function_exists('xdebug_call_line')
+		&& function_exists('xdebug_call_function')) {
+
+		$out .= '<b>XDebug information:</b><br>' . "\n";
+		$out .= 'File: ' . xdebug_call_file() . '<br>' . "\n";
+		$out .= 'Line: ' . xdebug_call_line() . '<br>' . "\n";
+		$out .= 'Function: ' . xdebug_call_function() . '<br>' . "\n";
+		$out .= '<br>' . "\n";
 	}
+
 
 	// Return a http header with error code if possible
 	if (!headers_sent()) {

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -6193,19 +6193,6 @@ function dol_print_error($db = null, $error = '', $errors = null)
 			$syslog .= ", msg=".$msg;
 		}
 	}
-	if (empty($dolibarr_main_prod)
-		&& !empty($_SERVER['DOCUMENT_ROOT'])
-		&& function_exists('xdebug_call_file')
-		&& function_exists('xdebug_call_line')
-		&& function_exists('xdebug_call_function')) {
-
-		$out .= '<b>XDebug information:</b><br>' . "\n";
-		$out .= 'File: ' . xdebug_call_file() . '<br>' . "\n";
-		$out .= 'Line: ' . xdebug_call_line() . '<br>' . "\n";
-		$out .= 'Function: ' . xdebug_call_function() . '<br>' . "\n";
-		$out .= '<br>' . "\n";
-	}
-
 
 	// Return a http header with error code if possible
 	if (!headers_sent()) {

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -6193,6 +6193,18 @@ function dol_print_error($db = null, $error = '', $errors = null)
 			$syslog .= ", msg=".$msg;
 		}
 	}
+	if (empty($dolibarr_main_prod)
+    	&& !empty($_SERVER['DOCUMENT_ROOT'])
+		&& function_exists('xdebug_call_file')
+		&& function_exists('xdebug_call_line')
+		&& function_exists('xdebug_call_function')) {
+		$out .= '<b>XDebug information:</b><br>' . "\n";
+		$out .= 'File: ' . xdebug_call_file() . '<br>' . "\n";
+		$out .= 'Line: ' . xdebug_call_line() . '<br>' . "\n";
+		$out .= 'Function: ' . xdebug_call_function() . '<br>' . "\n";
+		$out .= "<br>\n";
+	}
+
 
 	// Return a http header with error code if possible
 	if (!headers_sent()) {


### PR DESCRIPTION
Removes the verbose xdebug_print_function_stack() call in non-production environments. Now, only targeted debug info (file, line, function) is output when applicable.
@defrance 