### PR TITLE
Fix: don stats: SQL query was not formatted correctly due to double quotes

### DIFF
--- a/htdocs/don/class/donstats.class.php
+++ b/htdocs/don/class/donstats.class.php
@@ -111,7 +111,7 @@ class DonationStats extends Stats
 		}
 
 		if ($typentid) {
-			$this->join .= " LEFT JOIN '.MAIN_DB_PREFIX.'societe as s ON s.rowid = d.fk_soc";
+			$this->join .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON s.rowid = d.fk_soc";
 			$this->where .= " AND s.fk_typent = ".((int) $typentid);
 		}
 	}


### PR DESCRIPTION
Fix: don statistics : SQL query was not formatted correctly due to double quotes when filter with entity

@defrance 