### PR TITLE
fix: cast timestamp to int

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -166,7 +166,7 @@ function dol_time_plus_duree($time, $duration_value, $duration_unit, $ruleforend
 	if (getDolGlobalString('MAIN_DATE_IN_MEMORY_ARE_GMT')) {
 		$date->setTimezone(new DateTimeZone('UTC'));
 	}
-	$date->setTimestamp($time);
+	$date->setTimestamp((int) $time);
 	$interval = new DateInterval($deltastring);
 
 	if ($sub) {


### PR DESCRIPTION
Ensure that $time is cast to an integer before calling DateTime::setTimestamp to avoid a TypeError.
@defrance 
Sorry @frederic34 i was sleeping on my keyboard lol. 
