### PR TITLE
fix: On Supplier Order create, if insertExtrafield failed, Dolibarr do not return error and continue

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1610,8 +1610,13 @@ class CommandeFournisseur extends CommonOrder
 						// End call triggers
 					}
 
-					$this->db->commit();
-					return $this->id;
+					if (!$error) {
+						$this->db->commit();
+						return $this->id;
+					} else {
+						$this->db->rollback();
+						return -4;
+					}
 				} else {
 					$this->error = $this->db->lasterror();
 					$this->db->rollback();


### PR DESCRIPTION
if 
$result = $this->insertExtraFields();
failed
for exemple mandatory extrafield value
the process continue and the Supplier order is created

theses changes are the exact same code as in facture.Calss.php (function create())
