### PR TITLE
set deposit percent to zero on change

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4332,7 +4332,7 @@ class Form
 							if (depositPercent.length > 0) {
 								$("#' . $htmlname . '_deposit_percent_container").show().find("#' . $htmlname . '_deposit_percent").val(depositPercent);
 							} else {
-								$("#' . $htmlname . '_deposit_percent_container").hide();
+								$("#' . $htmlname . '_deposit_percent_container").hide().find("#' . $htmlname . '_deposit_percent").val(0);
 							}
 
 							return true;


### PR DESCRIPTION
if you set a deposit percent value it store that value into database -> ok

but after that if you change the condition to something else the deposit percent value is not removed because javascript hide the field and let the value unchanged

for example:

first set 30% deposit on order : ok

![image](https://github.com/user-attachments/assets/60523db5-9288-404b-b746-e4bb6a95cfc4)

and after that change to something else -> post value is unchanged and database field is not updated !

![2025-02-14_09-28](https://github.com/user-attachments/assets/9858e233-b1ff-41e8-9413-6d4688e3528f)

serverside paymenterms is called with a deposit value set to old "30" ... 

![image](https://github.com/user-attachments/assets/737700ef-ce59-4906-ac7c-bd3806f29fca)
