### PR TITLE
FIX: customer prices multiprices

### DIFF
--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -526,7 +526,7 @@ if (empty($reshook)) {
 						$db->free($resql);
 					}
 					if (!empty($lineid->rowid)) {
-						if (!empty($price_extralabels) && is_array($price_extralabels)) {
+						if (!empty($price_extralabels)) {
 							foreach ($price_extralabels as $code => $label) {
 								$code_array = GETPOST($code, 'array');
 								$object->array_options['options_'.$code] = $code_array[$key];

--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -526,16 +526,14 @@ if (empty($reshook)) {
 						$db->free($resql);
 					}
 					if (!empty($lineid->rowid)) {
-						if (!empty($price_extralabels)) {
-							foreach ($price_extralabels as $code => $label) {
-								$code_array = GETPOST($code, 'array');
-								$object->array_options['options_'.$code] = $code_array[$key];
-							}
-							// We need to force table to update product_price and not product extrafields
-							$object->id = $lineid->rowid;
-							$object->table_element = 'product_price';
-							$result = $object->insertExtraFields();
+						foreach ($price_extralabels as $code => $label) {
+							$code_array = GETPOST($code, 'array');
+							$object->array_options['options_'.$code] = $code_array[$key];
 						}
+						// We need to force table to update product_price and not product extrafields
+						$object->id = $lineid->rowid;
+						$object->table_element = 'product_price';
+						$result = $object->insertExtraFields();
 						// Back to product table
 						$object->id = $id;
 						$object->table_element = 'product';

--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -2361,6 +2361,8 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 		print '<table class="liste centpercent">'."\n";
 
 		if (count($prodcustprice->lines) > 0 || $search_soc) {
+			$extrafields->fetch_name_optionals_label("product_customer_price");
+			$custom_price_extralabels = !empty($extrafields->attributes["product_customer_price"]['label']) ? $extrafields->attributes["product_customer_price"]['label'] : '';
 			if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES_AND_MULTIPRICES')) {
 				$colspan = 10;
 			} else {
@@ -2369,8 +2371,8 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 			if ($mysoc->localtax1_assuj == "1" || $mysoc->localtax2_assuj == "1") {
 				$colspan++;
 			}
-			if (!empty($price_extralabels) && is_array($price_extralabels)) {
-				$colspan += count($price_extralabels);
+			if (!empty($custom_price_extralabels) && is_array($custom_price_extralabels)) {
+				$colspan += count($custom_price_extralabels);
 			}
 
 			print '<tr class="liste_titre">';


### PR DESCRIPTION
# FIX: customer prices multiprices
Don't display or update the extrafields of the product sheet on the selling prices tab.

Product extrafield
![image](https://github.com/user-attachments/assets/45f2cc5f-41f9-4cf0-b458-4210238031f6)

 Product extrafield on selling prices, before
![image](https://github.com/user-attachments/assets/cbd5a945-e8c3-4db8-9131-6583ab2e861d)

 And not product extrafield on selling prices, after
![image](https://github.com/user-attachments/assets/380e1464-36ab-4bcf-9842-9e1b43efa2bf)

Correction on the update of price level extrafields and correction on the customer price table for the display of extrafields columns.

Before
![image](https://github.com/user-attachments/assets/d15791dd-26e9-46d4-b319-27e3f5c5a6a2)

After
![image](https://github.com/user-attachments/assets/e0208623-dd84-4a8b-b44c-1cb178230f1d)
