### PR TITLE
FIX Avoid remove supplier order with dispateched lines

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2663,11 +2663,11 @@ if ($action == 'create') {
 						}
 						$dispachedLines = $object->getDispachedLines(1);
 						$nbDispachedLines = count($dispachedLines);
-						if($nbDispachedLines > 0){
+						if ($nbDispachedLines > 0) {
 							$hasreception = 1;
 						}
 					}
-					
+
 					if (in_array($object->statut, array(3, 4, 5))) {
 						if (isModEnabled("supplier_order") && $usercanreceive) {
 							print '<div class="inline-block divButAction"><a class="butAction" href="'.DOL_URL_ROOT.'/fourn/commande/dispatch.php?id='.$object->id.'">'.$labelofbutton.'</a></div>';

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2656,6 +2656,18 @@ if ($action == 'create') {
 						}
 					}
 
+					// To avoid delete order with dispatched lines
+					if (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER')) {
+						if (empty($object->lines)) {
+							$object->fetch_lines();
+						}
+						$dispachedLines = $object->getDispachedLines(1);
+						$nbDispachedLines = count($dispachedLines);
+						if($nbDispachedLines > 0){
+							$hasreception = 1;
+						}
+					}
+					
 					if (in_array($object->statut, array(3, 4, 5))) {
 						if (isModEnabled("supplier_order") && $usercanreceive) {
 							print '<div class="inline-block divButAction"><a class="butAction" href="'.DOL_URL_ROOT.'/fourn/commande/dispatch.php?id='.$object->id.'">'.$labelofbutton.'</a></div>';


### PR DESCRIPTION
# FIX Remove supplier order with dispateched lines

With STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER on Stock module configuation, any user can reopen a supplier order until it goes to draft status. 
And delete it. 
The dispatched lines are no longer shown on Reception tab with a non approved status.

If he removes the order, there is no way to delete the dispatched lines with the creation of the expected stock movement  