### PR TITLE
Fix: DeprecationHandler, correct isset(), ignore false phpstan positive

### DIFF
--- a/htdocs/core/class/doldeprecationhandler.class.php
+++ b/htdocs/core/class/doldeprecationhandler.class.php
@@ -1,5 +1,5 @@
 <?php
-/* Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -142,7 +142,7 @@ trait DolDeprecationHandler
 			if ($this->isDeprecatedReportingEnabled()) {
 				trigger_error($msg, E_USER_DEPRECATED);
 			}
-			return isset($newProperty);
+			return isset($this->$newProperty);
 		} elseif ($this->isDynamicPropertiesEnabled()) {
 			return isset($this->$name);
 		}
@@ -203,7 +203,7 @@ trait DolDeprecationHandler
 	{
 		// By default, if enableDynamicProperties is set, use that value.
 
-		if (property_exists($this, 'enableDynamicProperties')) {
+		if (property_exists($this, 'enableDynamicProperties')) { // @phpstan-ignore-line
 			// If the property exists, then we use it.
 			return (bool) $this->enableDynamicProperties;
 		}

--- a/test/phpunit/DolDeprecationHandlerTest.php
+++ b/test/phpunit/DolDeprecationHandlerTest.php
@@ -1,5 +1,5 @@
 <?php
-/* Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -71,6 +71,12 @@ class DolDeprecationHandlerTest extends CommonClassTest
 		print __METHOD__."\n";
 		$this->handler = new class () {
 			use DolDeprecationHandler;
+
+			/**
+			 * @var bool Configuration enabling throwing exceptions
+			 *           for deprecated access.
+			 */
+			private $enableDeprecatedReporting = true;
 
 			/**
 			 * @var string Private var to check that magic
@@ -256,7 +262,15 @@ class DolDeprecationHandlerTest extends CommonClassTest
 	 */
 	public function testDeprecatedPropertyUnset()
 	{
-		$this->handler->newProperty = "TestUnset";
+		// Initially the new property should be unset
+		$this->assertFalse(isset($this->handler->newProperty));
+
+		// Then we set the new property, so it should be set
+		$this->handler->newProperty = "ValueIsSet";
+		$this->assertTrue(isset($this->handler->newProperty));
+
+		// Then we set the new property using the old name,
+		// so it should be unset.
 		unset($this->handler->oldProperty);
 		$this->assertFalse(isset($this->handler->newProperty));
 	}
@@ -288,7 +302,7 @@ class DolDeprecationHandlerTest extends CommonClassTest
 		$this->expectExceptionMessage("Undefined property 'privateVarShouldTrigger'");
 		$this->handler->privateVarShouldTrigger;
 
-		$this->expectExceptionMessage("Accessing deprecated property 'privateDeprecated'. Use 'newProperty' instead.");
+		$this->expectExceptionMessage("Accessing deprecated property 'privateDeprecated'");
 		$this->handler->privateDeprecated;
 
 		// Restore error_reporting


### PR DESCRIPTION
# Fix: DeprecationHandler, correct isset(), ignore false phpstan positive

When the old property name is used, the 'isset' result was not tested on the property.

Also ignore a false positive from phpstan