### PR TITLE
Fix extrafield filter for IN

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1433,7 +1433,7 @@ class ExtraFields
 						//var_dump($InfoFieldList[4].' -> '.$pos); var_dump($tmpafter);
 						$InfoFieldList[4] = $tmpbefore;
 						if ($tmpafter !== '') {
-							$InfoFieldList = array_merge($InfoFieldList, explode(':', $tmpafter));
+							$InfoFieldList[4] = implode(":", array_merge($InfoFieldList[4], explode(':', $tmpafter)));
 						}
 
 						// Fix better compatibility with some old extrafield syntax filter "(field=123)"

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1433,7 +1433,7 @@ class ExtraFields
 						//var_dump($InfoFieldList[4].' -> '.$pos); var_dump($tmpafter);
 						$InfoFieldList[4] = $tmpbefore;
 						if ($tmpafter !== '') {
-							$InfoFieldList[4] = implode(":", array_merge($InfoFieldList[4], explode(':', $tmpafter)));
+							$InfoFieldList[4] .= $tmpafter;
 						}
 
 						// Fix better compatibility with some old extrafield syntax filter "(field=123)"
@@ -1676,7 +1676,7 @@ class ExtraFields
 					//var_dump($InfoFieldList[4].' -> '.$pos); var_dump($tmpafter);
 					$InfoFieldList[4] = $tmpbefore;
 					if ($tmpafter !== '') {
-						$InfoFieldList = array_merge($InfoFieldList, explode(':', $tmpafter));
+						$InfoFieldList[4] .= $tmpafter;
 					}
 
 					// Fix better compatibility with some old extrafield syntax filter "(field=123)"


### PR DESCRIPTION
When using something like table:ref:rowid::season:IN:$SEL$ rowid FROM llx_season WHERE season_start => CURRENT_DATE AND AND season_end <= CURRENT_DATE as filter for extrafields the code is. not working properly. I think it's line 1361 in extrafields.class.php

# FIX #33153 