### PR TITLE
Fix extrafield filter with $SEL$ ... IN ...  statement

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1433,7 +1433,7 @@ class ExtraFields
 						//var_dump($InfoFieldList[4].' -> '.$pos); var_dump($tmpafter);
 						$InfoFieldList[4] = $tmpbefore;
 						if ($tmpafter !== '') {
-							$InfoFieldList = array_merge($InfoFieldList, explode(':', $tmpafter));
+							$InfoFieldList[4] = implode(":", array_merge($InfoFieldList[4], explode(':', $tmpafter)));
 						}
 
 						// Fix better compatibility with some old extrafield syntax filter "(field=123)"

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1433,7 +1433,7 @@ class ExtraFields
 						//var_dump($InfoFieldList[4].' -> '.$pos); var_dump($tmpafter);
 						$InfoFieldList[4] = $tmpbefore;
 						if ($tmpafter !== '') {
-							$InfoFieldList[4] .= $tmpafter;
+							$InfoFieldList[4] = implode(":", array_merge([$InfoFieldList[4]], explode(':', $tmpafter)));
 						}
 
 						// Fix better compatibility with some old extrafield syntax filter "(field=123)"
@@ -1676,7 +1676,7 @@ class ExtraFields
 					//var_dump($InfoFieldList[4].' -> '.$pos); var_dump($tmpafter);
 					$InfoFieldList[4] = $tmpbefore;
 					if ($tmpafter !== '') {
-						$InfoFieldList[4] .= $tmpafter;
+						$InfoFieldList[4] = implode(":", array_merge([$InfoFieldList[4]], explode(':', $tmpafter)));
 					}
 
 					// Fix better compatibility with some old extrafield syntax filter "(field=123)"

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1433,7 +1433,7 @@ class ExtraFields
 						//var_dump($InfoFieldList[4].' -> '.$pos); var_dump($tmpafter);
 						$InfoFieldList[4] = $tmpbefore;
 						if ($tmpafter !== '') {
-							$InfoFieldList[4] = implode(":", array_merge($InfoFieldList[4], explode(':', $tmpafter)));
+							$InfoFieldList[4] .= $tmpafter;
 						}
 
 						// Fix better compatibility with some old extrafield syntax filter "(field=123)"
@@ -1676,7 +1676,7 @@ class ExtraFields
 					//var_dump($InfoFieldList[4].' -> '.$pos); var_dump($tmpafter);
 					$InfoFieldList[4] = $tmpbefore;
 					if ($tmpafter !== '') {
-						$InfoFieldList = array_merge($InfoFieldList, explode(':', $tmpafter));
+						$InfoFieldList[4] .= $tmpafter;
 					}
 
 					// Fix better compatibility with some old extrafield syntax filter "(field=123)"

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -183,9 +183,9 @@ abstract class DoliDB implements Database
 	 * @param	int		$allowschars		1=Allow a-z chars
 	 * @return  string                      String escaped
 	 */
-	public function sanitize($stringtosanitize, $allowsimplequote = 0, $allowsequals = 0, $allowsspace = 0, $allowschars = 1)
+	public function sanitize($stringtosanitize, $allowsimplequote = 0, $allowsequals = 0, $allowsspace = 0, $allowschars = 1, $allowsarrows = 0)
 	{
-		return preg_replace('/[^0-9_\-\.,'.($allowschars ? 'a-z' : '').($allowsequals ? '=' : '').($allowsimplequote ? "\'" : '').($allowsspace ? ' ' : '').']/i', '', $stringtosanitize);
+		return preg_replace('/[^0-9_\-\.,'.($allowschars ? 'a-z' : '').($allowsequals ? '=' : '').($allowsarrows ? '<>' : '').($allowsimplequote ? "\'" : '').($allowsspace ? ' ' : '').']/i', '', $stringtosanitize);
 	}
 
 	/**

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -14182,9 +14182,9 @@ function dolForgeSQLCriteriaCallback($matches)
 		foreach ($tmpelemarray as $tmpkey => $tmpelem) {
 			$reg = array();
 			if (preg_match('/^\'(.*)\'$/', $tmpelem, $reg)) {
-				$tmpelemarray[$tmpkey] = "'".$db->escape($db->sanitize($reg[1], 1, 1, 1))."'";
+				$tmpelemarray[$tmpkey] = "'".$db->escape($db->sanitize($reg[1], 1, 1, 1, 1))."'";
 			} else {
-				$tmpelemarray[$tmpkey] = $db->escape($db->sanitize($tmpelem, 1, 1, 1));
+				$tmpelemarray[$tmpkey] = $db->escape($db->sanitize($tmpelem, 1, 1, 1, 1));
 			}
 		}
 		$tmpescaped2 .= implode(',', $tmpelemarray);


### PR DESCRIPTION
When using something like table:ref:rowid::season:IN:$SEL$ rowid FROM llx_season WHERE season_start => CURRENT_DATE AND AND season_end <= CURRENT_DATE as filter for extrafields the code is. not working properly. I think it's line 1361 in extrafields.class.php


# FIX #33153 
