### PR TITLE
NEW: cash control: add hidden setting to show total including taxed in detail by vat rate

### DIFF
--- a/htdocs/compta/cashcontrol/report.php
+++ b/htdocs/compta/cashcontrol/report.php
@@ -452,8 +452,15 @@ if ($resql) {
 
 	if (!empty($totalvatperrate) && is_array($totalvatperrate)) {
 		print '<br><br><div class="small inline-block width100">'.$langs->trans("TotalHT").'</div><div class="small inline-block width100">'.$langs->trans("TotalVAT").'</div>';
+		if (getDolGlobalInt('TAKEPOS_CASHCONTROL_REPORT_SHOW_TOTAL_INCLUDING_TAXES_COLUMN', 0) != 0) {
+			print '<div class="small inline-block width100">'.$langs->trans("TotalTTC").'</div>';
+		}
 		foreach ($totalvatperrate as $keyrate => $valuerate) {
-			print '<br><div class="small">'.$langs->trans("VATRate").' '.vatrate($keyrate, true).' : <div class="inline-block amount width100">'.price($totalhtperrate[$keyrate] ?? 0).'</div><div class="inline-block amount width100">'.price($valuerate).'</div></div>';
+			print '<br><div class="small">'.$langs->trans("VATRate").' '.vatrate($keyrate, true).' : <div class="inline-block amount width100">'.price($totalhtperrate[$keyrate] ?? 0).'</div><div class="inline-block amount width100">'.price($valuerate).'</div>';
+			if (getDolGlobalInt('TAKEPOS_CASHCONTROL_REPORT_SHOW_TOTAL_INCLUDING_TAXES_COLUMN', 0) != 0) {
+				print '<div class="inline-block amount width100">'.price(($totalhtperrate[$keyrate] ?? 0) + $valuerate).'</div>';
+			}
+			print '</div>';
 		}
 	}
 


### PR DESCRIPTION
# NEW cash control: add hidden setting to show total including taxed in detail by vat rate

Add hidden setting `TAKEPOS_CASHCONTROL_REPORT_SHOW_TOTAL_INCLUDING_TAXES_COLUMN`.

In cash control ticket, in the end secton with the detail of each VAT rate, this toggles showing or not a column with the totals including taxes.

Disabled :
![Capture d’écran de 2025-02-20 14-19-52](https://github.com/user-attachments/assets/659b4d5b-5be8-4f58-a901-6b2367a48639)


Enabled :
![Capture d’écran de 2025-02-20 14-20-22](https://github.com/user-attachments/assets/e56f9661-507b-49af-86d6-bf753148b5f2)


