### PR TITLE
FIX : Missing objecttype filter for skill tab

### DIFF
--- a/htdocs/hrm/skill_tab.php
+++ b/htdocs/hrm/skill_tab.php
@@ -283,6 +283,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	$sql_skill .=" FROM ".MAIN_DB_PREFIX."hrm_skillrank AS sr";
 	$sql_skill .=" JOIN ".MAIN_DB_PREFIX."hrm_skill AS s ON sr.fk_skill = s.rowid";
 	$sql_skill .= " AND sr.fk_object = ".((int) $id);
+	$sql_skill .= " AND sr.objecttype = '".$db->escape($objecttype)."'";
 	$result = $db->query($sql_skill);
 	$numSkills = $db->num_rows($result);
 	for ($i=0; $i < $numSkills; $i++) {


### PR DESCRIPTION
Currently, if a skill is assigned to both a job and a user with the same ID, it appears twice in the skill tab. This fix ensures that the filtering correctly applies to the object type, preventing duplicate entries.

**Changes made:**
- Added a missing filter on objecttype in the SQL query to ensure that skills are correctly linked to their respective objects.