### PR TITLE
Fix selectcontacts where GETPOST('socid') is empty

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -1188,7 +1188,7 @@ if ($action == 'create') {
 			$select_contact_default = -1; // select "none" by default
 		}
 		print img_picto('', 'contact', 'class="paddingrightonly"');
-		print $form->selectcontacts(GETPOSTISSET('socid') ? GETPOSTINT('socid') : $select_contact_default, $preselectedids, 'socpeopleassigned[]', 1, '', '', 0, 'minwidth300 quatrevingtpercent', false, 0, array(), false, 'multiple', 'contactid');
+		print $form->selectcontacts(GETPOSTISSET('socid') && !empty(GETPOST('socid')) ? GETPOSTINT('socid') : $select_contact_default, $preselectedids, 'socpeopleassigned[]', 1, '', '', 0, 'minwidth300 quatrevingtpercent', false, 0, array(), false, 'multiple', 'contactid');
 		print '</td></tr>';
 	}
 


### PR DESCRIPTION
When GETPOST('socid') is an empty string, all the contacts were loaded in $form->selectcontacts() even if MAIN_ACTIONCOM_CAN_ADD_ANY_CONTACT is not set to avoid to load all contacts.