### PR TITLE
FIX #33226 Bad "Back" link for price expression editor

### DIFF
--- a/htdocs/product/price_suppliers.php
+++ b/htdocs/product/price_suppliers.php
@@ -679,7 +679,7 @@ if ($id > 0 || $ref) {
 							on_change();
 						}
 						function on_click() {
-							window.location = "'.DOL_URL_ROOT.'/product/dynamic_price/editor.php?id='.$id.'&tab=fournisseurs&eid=" + $("#eid").val();
+							window.location = "'.DOL_URL_ROOT.'/product/dynamic_price/editor.php?id='.$id.'&tab=price_suppliers&eid=" + $("#eid").val();
 						}
 						function on_change() {
 							if ($("#eid").val() == 0) {


### PR DESCRIPTION
# FIX|Fix #33226 Bad "Back" link for price expression editor

Fix dynamic price "back" link from price_suppliers tab