### PR TITLE
feat(invoice-rec): new rule_for_lines_dates field - DB

### DIFF
--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -161,3 +161,5 @@ CREATE TABLE llx_bank_record_link
 
 ALTER TABLE llx_bank_record_link ADD CONSTRAINT fk_bank_record_bank_record FOREIGN KEY (fk_bank_record) REFERENCES llx_bank_record (rowid);
 ALTER TABLE llx_bank_record_link ADD CONSTRAINT fk_bank_import_bank_import FOREIGN KEY (fk_bank_import) REFERENCES llx_bank_import (rowid);
+
+ALTER TABLE llx_facture_rec ADD COLUMN rule_for_lines_dates varchar(255) DEFAULT 'prepaid';

--- a/htdocs/install/mysql/tables/llx_facture_rec.sql
+++ b/htdocs/install/mysql/tables/llx_facture_rec.sql
@@ -65,9 +65,10 @@ create table llx_facture_rec
   multicurrency_total_tva   double(24,8) DEFAULT 0,
   multicurrency_total_ttc   double(24,8) DEFAULT 0,
 
-  usenewprice        integer DEFAULT 0,			-- update invoice with current price of product instead of recorded price
-  frequency          integer,						-- frequency (for example: 3 for every 3 month)
-  unit_frequency     varchar(2) DEFAULT 'm',		-- 'm' for month (date_when must be a day <= 28), 'y' for year, ...
+  usenewprice        	integer DEFAULT 0,			-- update invoice with current price of product instead of recorded price
+  frequency          	integer,						-- frequency (for example: 3 for every 3 month)
+  unit_frequency     	varchar(2) DEFAULT 'm',		-- 'm' for month (date_when must be a day <= 28), 'y' for year, ...
+  rule_for_lines_dates	varchar(255) DEFAULT 'prepaid',
 
   date_when          datetime DEFAULT NULL,		-- date for next gen (when an invoice is generated, this field must be updated with next date)
   date_last_gen      datetime DEFAULT NULL,		-- date for last gen (date with last successfull generation of invoice)


### PR DESCRIPTION
# NEW|New rule_for_lines_dates field on invoice rec
I have introduced a new field called billing_term to the model, with two possible values: postpaid or prepaid. By default, models are set to prepaid, meaning that invoice lines will reflect the dates of the current billing period when the invoice is generated. If the billing_term is set to postpaid, the invoice lines will instead correspond to the previous billing period. For instance, in a monthly billing cycle, a prepaid invoice for January would reflect January's dates, while a postpaid invoice generated in January would reflect December's dates. Similarly, for a quarterly cycle, a postpaid invoice generated for Q2 would cover the dates for Q1.

This differs from the fk_cond_reglement field, which governs the payment terms, such as whether payment is due upon receipt, within 30 days end-of-month, or within 10 days. While billing_term determines the period referenced in the invoice lines (current or prior), fk_cond_reglement defines when payment is expected, addressing distinct parts of the invoicing process.

Use Case Example: Consider a subscription service. For a prepaid model, the customer is billed at the start of January for services to be delivered in January. In contrast, for a postpaid model, the customer is billed at the start of January for services delivered in December. This allows flexibility in how the company aligns its invoicing practices with its operational or contractual obligations.

First PR : https://github.com/Dolibarr/dolibarr/pull/32129