### PR TITLE
fix: incorrect string value when emoji in body

### DIFF
--- a/htdocs/comm/mailing/class/mailing.class.php
+++ b/htdocs/comm/mailing/class/mailing.class.php
@@ -327,6 +327,7 @@ class Mailing extends CommonObject
 		$sql .= " WHERE rowid = ".(int) $this->id;
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
+		$this->db->query("SET NAMES 'utf8mb4'");
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			if (!$error && !$notrigger) {


### PR DESCRIPTION
# FIX|Fix incorrect string value when emoji in body
I add a SET NAMES request set to utf8mb4 because when a message has emoji, it throws a sql error incorrect string value