### PR TITLE
FIX The "AfterImportInsert" hook is not triggered during the simulation. (20) #33260

### DIFF
--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -1910,6 +1910,14 @@ if ($step == 5 && $datatoimport) {
 					if (!count($obj->errors) && !count($obj->warnings)) {
 						$nbok++;
 					}
+
+				}
+
+				$reshook = $hookmanager->executeHooks('AfterImportInsert', $parameters);
+				if ($reshook < 0) {
+					$arrayoferrors[$sourcelinenb][] = [
+						'lib' => implode("<br>", array_merge([$hookmanager->error], $hookmanager->errors))
+					];
 				}
 			}
 			// Close file

--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -1910,7 +1910,6 @@ if ($step == 5 && $datatoimport) {
 					if (!count($obj->errors) && !count($obj->warnings)) {
 						$nbok++;
 					}
-
 				}
 
 				$reshook = $hookmanager->executeHooks('AfterImportInsert', $parameters);


### PR DESCRIPTION
Fixes [this issue](https://github.com/Dolibarr/dolibarr/issues/33260)

The code was copied from the sixth step of the import.