### PR TITLE
Fix Excel Export of zero values

### DIFF
--- a/htdocs/core/modules/export/export_excel2007.modules.php
+++ b/htdocs/core/modules/export/export_excel2007.modules.php
@@ -336,9 +336,9 @@ class ExportExcel2007 extends ModeleExports
 				continue;
 			}
 
-			$newvalue = !empty($objp->$alias) ? $objp->$alias : '';
+			// $newvalue = !empty($objp->$alias) ? $objp->$alias : '';
 
-			$newvalue = $this->excel_clean($newvalue);
+			$newvalue = $this->excel_clean($objp->$alias);
 			$typefield = isset($array_types[$code]) ? $array_types[$code] : '';
 
 			if (preg_match('/^Select:/i', $typefield) && $typefield = substr($typefield, 7)) {

--- a/htdocs/core/modules/export/export_excel2007.modules.php
+++ b/htdocs/core/modules/export/export_excel2007.modules.php
@@ -336,9 +336,9 @@ class ExportExcel2007 extends ModeleExports
 				continue;
 			}
 
-			// $newvalue = !empty($objp->$alias) ? $objp->$alias : '';
+			$newvalue = (!empty($objp->$alias) || (is_numeric($objp->alias))) ? $objp->$alias : '';
 
-			$newvalue = $this->excel_clean($objp->$alias);
+			$newvalue = $this->excel_clean($newvalue);
 			$typefield = isset($array_types[$code]) ? $array_types[$code] : '';
 
 			if (preg_match('/^Select:/i', $typefield) && $typefield = substr($typefield, 7)) {


### PR DESCRIPTION
# FIX Excel Export for zero values

When exporting a using Excel file format, if an exported value is zero, the corresponding cell in the exported excel file will be empty. This creates a problem when exporting flag type of value (ex. customer type 0 or 1) and trying to import the resulting Excel file back which will emit the 'no default value for field xyz' error message and force the user to edit the Excel file to set these empty cells with a value of 0.