### PR TITLE
Fix setup default value

### DIFF
--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -615,7 +615,7 @@ class FormSetupItem
 	/** @var string $picto */
 	public $picto = '';
 
-	/** @var string $fieldValue */
+	/** @var string|null $fieldValue */
 	public $fieldValue;
 
 	/** @var string $defaultFieldValue */

--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -700,10 +700,10 @@ class FormSetupItem
 	{
 		global $conf;
 		if (isset($conf->global->{$this->confKey})) {
-			$this->fieldValue = getDolGlobalString($this->confKey);
+			$this->fieldValue = getDolGlobalString($this->confKey, null);
 			return true;
 		} else {
-			$this->fieldValue = '';
+			$this->fieldValue = null;
 			return false;
 		}
 	}


### PR DESCRIPTION
# Instructions
on setup page when set a setup item default value it doesn't work

```php
$item = $formSetup->newItem('IMPFOURNPRICE_MIN_EVOL_ACCEPTED');
$item->defaultFieldValue = 0;
```

# Fix 
by setting null it allow this part of code to work 
`htdocs/core/class/html.formsetup.class.php` Line 874
```php
		// Set default value
		if (is_null($this->fieldValue)) {
			$this->fieldValue = $this->defaultFieldValue;
		}

```