### PR TITLE
FIX: migration file Update 21.0.0-22.0.0.sql syntax error

### DIFF
--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -184,8 +184,8 @@ ALTER TABLE llx_product_customer_price ADD COLUMN discount_percent real DEFAULT 
 ALTER TABLE llx_product_customer_price_log ADD COLUMN date_begin date AFTER ref_customer;
 ALTER TABLE llx_product_customer_price_log ADD COLUMN date_end date AFTER date_begin;
 ALTER TABLE llx_product_customer_price_log ADD COLUMN discount_percent real DEFAULT 0 AFTER localtax2_type;
-ALTER TABLE llx_product_customer_price DROP CONSTRAINT fk_product_customer_price_fk_product;
-ALTER TABLE llx_product_customer_price DROP CONSTRAINT fk_product_customer_price_fk_soc;
+ALTER TABLE llx_product_customer_price DROP FOREIGN KEY fk_product_customer_price_fk_product;
+ALTER TABLE llx_product_customer_price DROP FOREIGN KEY fk_product_customer_price_fk_soc;
 ALTER TABLE llx_product_customer_price DROP INDEX uk_customer_price_fk_product_fk_soc;
 ALTER TABLE llx_product_customer_price ADD UNIQUE INDEX uk_customer_price_fk_product_fk_soc (fk_product, fk_soc, date_begin);
 ALTER TABLE llx_product_customer_price ADD CONSTRAINT fk_product_customer_price_fk_product FOREIGN KEY (fk_product) REFERENCES llx_product(rowid);

--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -186,6 +186,8 @@ ALTER TABLE llx_product_customer_price_log ADD COLUMN date_end date AFTER date_b
 ALTER TABLE llx_product_customer_price_log ADD COLUMN discount_percent real DEFAULT 0 AFTER localtax2_type;
 ALTER TABLE llx_product_customer_price DROP FOREIGN KEY fk_product_customer_price_fk_product;
 ALTER TABLE llx_product_customer_price DROP FOREIGN KEY fk_product_customer_price_fk_soc;
+ALTER TABLE llx_product_customer_price DROP FOREIGN KEY fk_customer_price_fk_product;
+ALTER TABLE llx_product_customer_price DROP FOREIGN KEY fk_customer_price_fk_soc;
 ALTER TABLE llx_product_customer_price DROP INDEX uk_customer_price_fk_product_fk_soc;
 ALTER TABLE llx_product_customer_price ADD UNIQUE INDEX uk_customer_price_fk_product_fk_soc (fk_product, fk_soc, date_begin);
 ALTER TABLE llx_product_customer_price ADD CONSTRAINT fk_product_customer_price_fk_product FOREIGN KEY (fk_product) REFERENCES llx_product(rowid);


### PR DESCRIPTION
Fix the following DB errors when updating : 
DB_ERROR_SYNTAX (Req 70): ALTER TABLE llx_product_customer_price DROP CONSTRAINT fk_product_customer_price_fk_product; DB_ERROR_SYNTAX (Req 71): ALTER TABLE llx_product_customer_price DROP CONSTRAINT fk_product_customer_price_fk_soc;
