### PR TITLE
Remain to pay in multicurrency

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -291,7 +291,12 @@ abstract class CommonInvoice extends CommonObject
 		$alreadypaid += $this->getSumDepositsUsed($multicurrency);
 		$alreadypaid += $this->getSumCreditNotesUsed($multicurrency);
 
-		$remaintopay = price2num($this->total_ttc - $alreadypaid, 'MT');
+		if((int) $multicurrency > 0){
+			$totalamount = $this->multicurrency_total_ttc;
+		} else {
+			$totalamount = $this->total_ttc;
+		}
+		$remaintopay = price2num($totalamount - $alreadypaid, 'MT');
 		if ($this->status == self::STATUS_CLOSED && $this->close_code == 'discount_vat') {		// If invoice closed with discount for anticipated payment
 			$remaintopay = 0.0;
 		}

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -291,7 +291,7 @@ abstract class CommonInvoice extends CommonObject
 		$alreadypaid += $this->getSumDepositsUsed($multicurrency);
 		$alreadypaid += $this->getSumCreditNotesUsed($multicurrency);
 
-		if((int) $multicurrency > 0){
+		if ((int) $multicurrency > 0) {
 			$totalamount = $this->multicurrency_total_ttc;
 		} else {
 			$totalamount = $this->total_ttc;


### PR DESCRIPTION
If I want to have the remainder to pay in foreign currency, I must deduct it from the amount in multicurrency, not the amount in conf->currency.

Current behavior with conf->currency EUR:
If I make an invoice in CHF of 940 CHF - 1000 EUR  (1 EUR = 0.94 CHF)
II make a payment of 470 CHF, which is equivalent to 500 EUR.

```
// Get Remain to pay in conf currency
$remaintopayConf = $object->getRemainToPay(0); // Remain to pay = 1000 EUR - 500 EUR = 500 EUR ( It works ! )
// Get Remain to pay in forein currency
$remaintopayMulti = $object->getRemainToPay(1); // Remain to pay = 1000 EUR - 470 CHF = 530 CHF ? (Does not work)
```
Total 1000 EUR should be total of multicurrency amount (940 CHF):
940 CHF - 470 CHF = 470 CHF
