### PR TITLE
Affchage des paiements divers et des prêts dans le tableau résultat / Exercice du module comptabilité

### DIFF
--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -831,7 +831,7 @@ if (getDolGlobalString('ACCOUNTING_REPORTS_INCLUDE_VARPAY') && isModEnabled("ban
 		$num = $db->num_rows($result);
 		$i = 0;
 		if ($num) {
-			while ($i < $num) {				
+			while ($i < $num) {
 				$obj = $db->fetch_object($result);
 
 				if (!isset($decaiss[$obj->dm])) {

--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -813,7 +813,7 @@ if (isModEnabled('don') && ($modecompta == 'CREANCES-DETTES' || $modecompta == "
  * Various Payments
  */
 
- if (getDolGlobalString('ACCOUNTING_REPORTS_INCLUDE_VARPAY') && isModEnabled("bank") && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES")) {
+if (getDolGlobalString('ACCOUNTING_REPORTS_INCLUDE_VARPAY') && isModEnabled("bank") && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES")) {
 	// decaiss
 
 	$sql = "SELECT date_format(p.datep, '%Y-%m') AS dm, SUM(p.amount) AS amount FROM ".MAIN_DB_PREFIX."payment_various as p";
@@ -831,8 +831,7 @@ if (isModEnabled('don') && ($modecompta == 'CREANCES-DETTES' || $modecompta == "
 		$num = $db->num_rows($result);
 		$i = 0;
 		if ($num) {
-			while ($i < $num) {
-
+			while ($i < $num) {				
 				$obj = $db->fetch_object($result);
 
 				if (!isset($decaiss[$obj->dm])) {

--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -813,7 +813,7 @@ if (isModEnabled('don') && ($modecompta == 'CREANCES-DETTES' || $modecompta == "
  * Various Payments
  */
 
-if (getDolGlobalString('ACCOUNTING_REPORTS_INCLUDE_VARPAY') && isModEnabled("bank") && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES")) {
+ if (getDolGlobalString('ACCOUNTING_REPORTS_INCLUDE_VARPAY') && isModEnabled("bank") && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES")) {
 	// decaiss
 
 	$sql = "SELECT date_format(p.datep, '%Y-%m') AS dm, SUM(p.amount) AS amount FROM ".MAIN_DB_PREFIX."payment_various as p";
@@ -824,6 +824,7 @@ if (getDolGlobalString('ACCOUNTING_REPORTS_INCLUDE_VARPAY') && isModEnabled("ban
 	}
 	$sql .= ' GROUP BY dm';
 
+
 	dol_syslog("get various payments");
 	$result = $db->query($sql);
 	if ($result) {
@@ -831,13 +832,19 @@ if (getDolGlobalString('ACCOUNTING_REPORTS_INCLUDE_VARPAY') && isModEnabled("ban
 		$i = 0;
 		if ($num) {
 			while ($i < $num) {
+
 				$obj = $db->fetch_object($result);
+
+				if (!isset($decaiss[$obj->dm])) {
+					$decaiss[$obj->dm] = 0;
+				}
+				$decaiss[$obj->dm] += $obj->amount;
+
 				if (!isset($decaiss_ttc[$obj->dm])) {
 					$decaiss_ttc[$obj->dm] = 0;
 				}
-				if (isset($obj->amount)) {
-					$decaiss_ttc[$obj->dm] += $obj->amount;
-				}
+				$decaiss_ttc[$obj->dm] += $obj->amount;
+
 				$i++;
 			}
 		}
@@ -863,12 +870,17 @@ if (getDolGlobalString('ACCOUNTING_REPORTS_INCLUDE_VARPAY') && isModEnabled("ban
 		if ($num) {
 			while ($i < $num) {
 				$obj = $db->fetch_object($result);
+
+				if (!isset($encaiss[$obj->dm])) {
+					$encaiss[$obj->dm] = 0;
+				}
+				$encaiss[$obj->dm] += $obj->amount;
+
 				if (!isset($encaiss_ttc[$obj->dm])) {
 					$encaiss_ttc[$obj->dm] = 0;
 				}
-				if (isset($obj->amount)) {
-					$encaiss_ttc[$obj->dm] += $obj->amount;
-				}
+				$encaiss_ttc[$obj->dm] += $obj->amount;
+
 				$i++;
 			}
 		}
@@ -902,12 +914,17 @@ if (getDolGlobalString('ACCOUNTING_REPORTS_INCLUDE_LOAN') && isModEnabled('loan'
 		if ($num) {
 			while ($i < $num) {
 				$obj = $db->fetch_object($result);
+
+				if (!isset($decaiss[$obj->dm])) {
+					$decaiss[$obj->dm] = 0;
+				}
+				$decaiss[$obj->dm] += $obj->amount;
+
 				if (!isset($decaiss_ttc[$obj->dm])) {
 					$decaiss_ttc[$obj->dm] = 0;
 				}
-				if (isset($obj->amount)) {
-					$decaiss_ttc[$obj->dm] += $obj->amount;
-				}
+				$decaiss_ttc[$obj->dm] += $obj->amount;
+
 				$i++;
 			}
 		}


### PR DESCRIPTION
# Description
Cette mise à jour permet d'afficher les paiements divers et les prêts dans le tableau Résultat / Exercice du module comptabilité.

# Modifications apportées
Ajout du total ht des paiements divers (payment_various) en mode créances-dettes et recettes-dépenses.
Ajout du total ht  des paiements de prêts (payment_loan) en mode créances-dettes et recettes-dépenses.
Affichage des montants dans les colonnes correspondantes du tableau des résultats comptables.

# Code ajouté
Ajout des montants ht dans la catégorie des décaissements.

# Pré-requis
Le module Comptabilité avancée doit être activé.
Les variables globales suivantes doivent être activées :
ACCOUNTING_REPORTS_INCLUDE_VARPAY
et /ou
ACCOUNTING_REPORTS_INCLUDE_LOAN
Les modules Banque (bank) et/ou Prêts (loan) doivent être activés.

# Impact
Permet une meilleure visualisation des flux financiers réels, en incluant les paiements divers et les remboursements de prêts.
Offre une vision plus complète du résultat comptable.


![image](https://github.com/user-attachments/assets/18e6337d-7678-438f-87bf-5f2843954403)
![image](https://github.com/user-attachments/assets/d1946e3a-2381-4075-b6ad-6aa16e5904ac)
