### PR TITLE
allow spaces on natural search

### DIFF
--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -121,24 +121,17 @@ abstract class DoliDB implements Database
 	}
 
 	/**
-	 * Sanitize a string for SQL forging
-	 *
-	 * @param   string 	$stringtosanitize 	String to escape
-	 * @param   int		$allowsimplequote 	1=Allow simple quotes in string. When string is used as a list of SQL string ('aa', 'bb', ...)
-	 * @param   int		$allowspaces 		1=Allow spaces in string. When string is a sentense or a composed word
-	 * @return  string                      String escaped
-	 */
-	public function sanitize($stringtosanitize, $allowsimplequote = 0, $allowspaces = 0)
+		 * Sanitize a string for SQL forging
+		 *
+		 * @param   string 	$stringtosanitize 	String to escape
+		 * @param   int		$allowsimplequote 	1=Allow simple quotes in string. When string is used as a list of SQL string ('aa', 'bb', ...)
+		 * @param	int		$allowsequals		1=Allow equals sign
+		 * @param	int		$allowsspace		1=Allow space char
+		 * @return  string                      String escaped
+		 */
+	public function sanitize($stringtosanitize, $allowsimplequote = 0, $allowsequals = 0, $allowsspace = 0)
 	{
-		$regex = "^a-z0-9_\-\.,";
-		if ($allowspaces) {
-			$regex .= " ";
-		}
-		if ($allowsimplequote) {
-			$regex .= "\'";
-		}
-
-		return preg_replace('/[' . $regex . ']/i', '', $stringtosanitize);
+		return preg_replace('/[^a-z0-9_\-\.,'.($allowsequals ? '=' : '').($allowsimplequote ? "\'" : '').($allowsspace ? ' ' : '').']/i', '', $stringtosanitize);
 	}
 
 	/**

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -125,15 +125,20 @@ abstract class DoliDB implements Database
 	 *
 	 * @param   string 	$stringtosanitize 	String to escape
 	 * @param   int		$allowsimplequote 	1=Allow simple quotes in string. When string is used as a list of SQL string ('aa', 'bb', ...)
+	 * @param   int		$allowspaces 		1=Allow spaces in string. When string is a sentense or a composed word
 	 * @return  string                      String escaped
 	 */
-	public function sanitize($stringtosanitize, $allowsimplequote = 0)
+	public function sanitize($stringtosanitize, $allowsimplequote = 0, $allowspaces = 0)
 	{
-		if ($allowsimplequote) {
-			return preg_replace('/[^a-z0-9_\-\.,\']/i', '', $stringtosanitize);
-		} else {
-			return preg_replace('/[^a-z0-9_\-\.,]/i', '', $stringtosanitize);
+		$regex = "^a-z0-9_\-\.,";
+		if ($allowspaces) {
+			$regex .= " ";
 		}
+		if ($allowsimplequote) {
+			$regex .= "\'";
+		}
+
+		return preg_replace('/[' . $regex . ']/i', '', $stringtosanitize);
 	}
 
 	/**

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9022,7 +9022,12 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 
 	$value = preg_replace('/\s*\|\s*/', '|', $value);
 
-	$crits = explode(' ', $value);
+	//natural mode search type 3 allow spaces into search ...
+	if ($mode == 3 || $mode == -3) {
+		$crits = explode(',', $value);
+	} else {
+		$crits = explode(' ', $value);
+	}
 	$res = '';
 	if (!is_array($fields)) {
 		$fields = array($fields);
@@ -9072,7 +9077,8 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 							$listofcodes .= "'".$db->escape($val)."'";
 						}
 					}
-					$newres .= ($i2 > 0 ? ' OR ' : '').$field." ".($mode == -3 ? 'NOT ' : '')."IN (".$db->sanitize($listofcodes, 1).")";
+					//note: db->sanitize remove spaces ...
+					$newres .= ($i2 > 0 ? ' OR ' : '').$field." ".($mode == -3 ? 'NOT ' : '')."IN (".$db->sanitize($listofcodes, 1, 1).")";
 					$i2++; // a criteria was added to string
 				}
 				if ($mode == -3) {

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9077,7 +9077,6 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 							$listofcodes .= "'".$db->escape($val)."'";
 						}
 					}
-					//note: db->sanitize remove spaces ...
 					$newres .= ($i2 > 0 ? ' OR ' : '').$field." ".($mode == -3 ? 'NOT ' : '')."IN (".$db->sanitize($listofcodes, 1, 1).")";
 					$i2++; // a criteria was added to string
 				}

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9077,7 +9077,7 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 							$listofcodes .= "'".$db->escape($val)."'";
 						}
 					}
-					$newres .= ($i2 > 0 ? ' OR ' : '').$field." ".($mode == -3 ? 'NOT ' : '')."IN (".$db->sanitize($listofcodes, 1, 1).")";
+					$newres .= ($i2 > 0 ? ' OR ' : '').$field." ".($mode == -3 ? 'NOT ' : '')."IN (".$db->sanitize($listofcodes, 1, 0, 1).")";
 					$i2++; // a criteria was added to string
 				}
 				if ($mode == -3) {


### PR DESCRIPTION
Origin of the bug is a bank journal with spaces like that:

![image](https://github.com/user-attachments/assets/5d63c319-c7cb-44e8-a28f-0633b5666bc5)

Then that journal code is displayed into filters and list with empty filter displays lines 

![image](https://github.com/user-attachments/assets/d06e7aa9-e5f4-4b82-bb2e-c8a02a41cd27)

But as soon as i choose that journal and apply filter, list remains empty

and debug log display this SQL request 

```
sql=SELECT COUNT(*) as nbtotalofrecords FROM llx_accounting_bookkeeping as t WHERE t.entity IN (1) AND (t.code_journal IN ('ENC') AND t.code_journal IN ('SGAPSO'))
```

That's because of the use of natural_search on t.code_journal