### PR TITLE
Fix: sort $aux_account after adding all items

### DIFF
--- a/htdocs/core/class/html.formaccounting.class.php
+++ b/htdocs/core/class/html.formaccounting.class.php
@@ -502,8 +502,6 @@ class FormAccounting extends Form
 				return -1;
 			}
 
-			ksort($aux_account);
-
 			$this->db->free($resql);
 
 			// Auxiliary user account
@@ -525,6 +523,8 @@ class FormAccounting extends Form
 				return -1;
 			}
 			$this->db->free($resql);
+
+			ksort($aux_account);
 
 			if ($usecache) {
 				$this->options_cache[$usecache] = $aux_account;


### PR DESCRIPTION
Currently, some items are added to $aux_account, then the array is sorted, then more items are added. In the end, the list visible in the UI is not sorted.

In our case, we see unsorted lists in `accountancy/bookkeeping/balance.php?type=sub`:

![dolibarr_sort_bug](https://github.com/user-attachments/assets/30ce8460-42f5-41a2-860b-605014cf5b3b)

This PR fixes the problem