### PR TITLE
Qual: Fix phpstan by reverting config to 2.0

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none # disable xdebug, pcov
-          tools: phpstan, cs2pr
+          tools: phpstan:2.0, cs2pr
           extensions: calendar, json, imagick, gd, zip, mbstring, intl, opcache, imap,
             mysql, pgsql, sqlite3, ldap, xml, mcrypt
 


### PR DESCRIPTION
# Qual: Fix phpstan by reverting config to 2.0

Recent updated removed the ':2.0' modifier on the phpstan tool.
