### PR TITLE
FIX: Warning when getNomUrl is called before top_httphead

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -3095,8 +3095,6 @@ class Societe extends CommonObject
 		} else {
 			$label = implode($this->getTooltipContentArray($params));
 		}
-		print "\n";
-		//var_dump($label);exit;
 		$linkstart = '';
 		$linkend = '';
 


### PR DESCRIPTION
If Societe::getNomUrl() is called before top_httphead, this triggers a Cannot modify header warning

Example : on accountancy/journal/bankjournal.php page