### PR TITLE
FIX: dolPrintHTML double htmlentities

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -2082,7 +2082,7 @@ function dolPrintText($s)
  */
 function dolPrintHTML($s, $allowiframe = 0)
 {
-	return dol_escape_htmltag(dol_htmlwithnojs(dol_string_onlythesehtmltags(dol_htmlentitiesbr($s), 1, 1, 1, $allowiframe)), 1, 1, 'common', 0, 1);
+	return dol_escape_htmltag(dol_htmlwithnojs(dol_string_onlythesehtmltags(dol_htmlentitiesbr($s), 1, 1, 1, $allowiframe)), 1, 1, 'common', 0, 1, true);
 }
 
 /**
@@ -2160,10 +2160,11 @@ function dolPrintPassword($s)
  *  @param		string		$noescapetags			'' (escape all html tags) or 'common' (do not escape some common tags) or list of tags to not escape.
  *  @param		int			$escapeonlyhtmltags		1=Escape only html tags, not the special chars like accents.
  *  @param		int			$cleanalsojavascript	Clean also javascript. @TODO switch this option to 1 by default.
+ *  @param		bool		$nohtmlentities	    	If true, Bypass the htmlentities() call
  *  @return     string     				 			Escaped string
  *  @see		dol_string_nohtmltag(), dol_string_onlythesehtmltags(), dol_string_nospecial(), dol_string_unaccent(), dol_htmlentitiesbr()
  */
-function dol_escape_htmltag($stringtoescape, $keepb = 0, $keepn = 0, $noescapetags = '', $escapeonlyhtmltags = 0, $cleanalsojavascript = 0)
+function dol_escape_htmltag($stringtoescape, $keepb = 0, $keepn = 0, $noescapetags = '', $escapeonlyhtmltags = 0, $cleanalsojavascript = 0, $nohtmlentities = false)
 {
 	if ($noescapetags == 'common') {
 		$noescapetags = 'html,body,a,b,em,hr,i,u,ul,li,br,div,img,font,p,span,strong,table,tr,td,th,tbody,h1,h2,h3,h4,h5,h6,h7,h8,h9';
@@ -2260,7 +2261,7 @@ function dol_escape_htmltag($stringtoescape, $keepb = 0, $keepn = 0, $noescapeta
 		}
 
 		// Warning: htmlentities encode HTML tags like <abc> & into &amp; and more (but not &lt; &gt; &quotes; &apos; &#39; &amp; that remains untouched).
-		$result = htmlentities($tmp, ENT_COMPAT, 'UTF-8');
+		$result = $nohtmlentities ? $tmp : htmlentities($tmp, ENT_COMPAT, 'UTF-8');
 
 		//print $result;
 


### PR DESCRIPTION
Not sure this is the right way to fix the bug, dolPrintHTML() do not like ampersand because of double htmlentities (one in dol_escape_htmltag(), one in dol_htmlentitiesbr()). I add a optionnal $nohtmlentities parameter to the dol_escape_htmltag() function to bypass htmlentities() call.

Tested on export page.

Before : 
![image](https://github.com/user-attachments/assets/10bae8e0-1259-4c1f-932a-7f8536c6a95e)


After : 
![image](https://github.com/user-attachments/assets/d456f27c-4b64-427d-a0dd-4bdff810eb9e)
