### PR TITLE
Error "StripeCusNotFound" page payment

### DIFF
--- a/htdocs/stripe/class/stripe.class.php
+++ b/htdocs/stripe/class/stripe.class.php
@@ -263,14 +263,14 @@ class Stripe extends CommonObject
 							$isineec = isInEEC($object);
 							if ($object->country_code && $isineec) {
 								//$taxids = $customer->allTaxIds($customer);
-								$customer->createTaxId($customer, array('type' => 'eu_vat', 'value' => $vatcleaned));
+								$customer->createTaxId($customer->id, array('type' => 'eu_vat', 'value' => $vatcleaned));
 							}
 						}
 					}
 
 					// Create customer in Dolibarr
 					$sql = "INSERT INTO ".MAIN_DB_PREFIX."societe_account (fk_soc, login, key_account, site, site_account, status, entity, date_creation, fk_user_creat)";
-					$sql .= " VALUES (".((int) $object->id).", '', '".$this->db->escape($customer)."', 'stripe', '".$this->db->escape($stripearrayofkeysbyenv[$status]['publishable_key'])."', ".((int) $status).", ".((int) $conf->entity).", '".$this->db->idate(dol_now())."', ".((int) $user->id).")";
+					$sql .= " VALUES (".((int) $object->id).", '', '".$this->db->escape($customer->id)."', 'stripe', '".$this->db->escape($stripearrayofkeysbyenv[$status]['publishable_key'])."', ".((int) $status).", ".((int) $conf->entity).", '".$this->db->idate(dol_now())."', ".((int) $user->id).")";
 					$resql = $this->db->query($sql);
 					if (!$resql) {
 						$this->error = $this->db->lasterror();


### PR DESCRIPTION
# Instructions
change in parameters of :
createTaxId()
$this->db->escape()

![image](https://github.com/user-attachments/assets/b6b3bf85-a5e0-4630-8057-c5360d5beb1d)

# FIX|Fix #[code erreur "StripeCusNotFound]
Insertion of the Stripe Customer ID in the societe_account table failed with the error :
This problem was due to the fact that the variable $customer was used directly instead of $customer->id in the SQL query. This resulted in the insertion of an integer object instead of a string.

Without this change the payment is blocked

