### PR TITLE
FIX Variable $includemonday missing

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -979,7 +979,7 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 				$jour_julien = unixtojd($timestampStart);
 				$jour_semaine = jddayofweek($jour_julien, 0);
 				//Monday (1), Friday (5), Saturday (6) and Sunday (0)
-				if ($includefriday) {					
+				if ($includefriday) {
 					if ($jour_semaine == 5) {
 						$ferie = true;
 					}

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -975,21 +975,27 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 
 		// If we have to include Friday, Saturday and Sunday
 		if (!$ferie) {
-			if ($includefriday || $includesaturday || $includesunday) {
+			if ($includefriday || $includesaturday || $includesunday || $includemonday) {
 				$jour_julien = unixtojd($timestampStart);
 				$jour_semaine = jddayofweek($jour_julien, 0);
-				if ($includefriday) {					//Friday (5), Saturday (6) and Sunday (0)
+				//Monday (1), Friday (5), Saturday (6) and Sunday (0)
+				if ($includefriday) {					
 					if ($jour_semaine == 5) {
 						$ferie = true;
 					}
 				}
-				if ($includesaturday) {					//Friday (5), Saturday (6) and Sunday (0)
+				if ($includesaturday) {	
 					if ($jour_semaine == 6) {
 						$ferie = true;
 					}
 				}
-				if ($includesunday) {					//Friday (5), Saturday (6) and Sunday (0)
+				if ($includesunday) {
 					if ($jour_semaine == 0) {
+						$ferie = true;
+					}
+				}
+				if ($includemonday) {
+					if ($jour_semaine == 1) {
 						$ferie = true;
 					}
 				}

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -984,7 +984,7 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 						$ferie = true;
 					}
 				}
-				if ($includesaturday) {	
+				if ($includesaturday) {
 					if ($jour_semaine == 6) {
 						$ferie = true;
 					}


### PR DESCRIPTION
Variable ```$includemonday``` missing in working/not working days
Related to https://www.dolibarr.fr/forum/t/erreur-sur-calcul-de-conges/48690
Tks for reading


