### PR TITLE
FIX : PAIEMENT Wrong field displayed for DateChequeReceived

### DIFF
--- a/htdocs/compta/paiement/cheque/card.php
+++ b/htdocs/compta/paiement/cheque/card.php
@@ -544,7 +544,7 @@ if ($action == 'new') {
 		if (count($lines[$bid])) {
 			foreach ($lines[$bid] as $lid => $value) {
 				print '<tr class="oddeven">';
-				print '<td>'.dol_print_date($value["date"], 'day').'</td>';
+				print '<td>'.dol_print_date($value["paymentdate"], 'day').'</td>';
 				print '<td>'.$value["numero"]."</td>\n";
 				print '<td>'.$value["emetteur"]."</td>\n";
 				print '<td>'.$value["banque"]."</td>\n";


### PR DESCRIPTION
FIX

On compta/paiement/cheque/card.php - New Deposit slip page
There is a mismatch on the date you are looking for Checks Deposit and the date you see in the list.

By reading the code line 444 to 464 You can see that $search_date_start has something to deal with date (of the payment).
Whereas in line 547, the part where the list is built, the $value["date"] refers to Creation date (of the payment) (cf line 471) which is not the same.

My fix try to apply the "right" date on the list.
I mean right because we need to use the date of the payment and not its creation date.
We can create a payment the 2nd of Febrary, but we want to deposit the check on the 2nd of march.
In order to make a deposit slip at the good date, we need to use the date of the payment, not the creation date.
