### PR TITLE
fix: thirdparty substitutions var ignored on automatic event

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -1219,7 +1219,9 @@ class Notify
 				}
 				if (!empty($mailTemplateLabel) && is_object($emailTemplate) && $emailTemplate->id > 0) {
 					if (property_exists($object, 'thirdparty')) {
-						$object->fetch_thirdparty();
+						if (!($object->thirdparty instanceof Societe)) {
+							$object->fetch_thirdparty();
+						}
 
 						if ($object->thirdparty instanceof Societe && $object->thirdparty->default_lang && $object->thirdparty->default_lang != $langs->defaultlang) {
 							$outputlangs = new Translate('', $conf);

--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -1218,10 +1218,14 @@ class Notify
 					$emailTemplate = $formmail->getEMailTemplate($this->db, $object_type.'_send', $user, $outputlangs, 0, 1, $mailTemplateLabel);
 				}
 				if (!empty($mailTemplateLabel) && is_object($emailTemplate) && $emailTemplate->id > 0) {
-					if (property_exists($object, 'thirdparty') && $object->thirdparty instanceof Societe && $object->thirdparty->default_lang && $object->thirdparty->default_lang != $langs->defaultlang) {
-						$outputlangs = new Translate('', $conf);
-						$outputlangs->setDefaultLang($object->thirdparty->default_lang);
-						$outputlangs->loadLangs(array('main', 'other'));
+					if (property_exists($object, 'thirdparty')) {
+						$object->fetch_thirdparty();
+
+						if ($object->thirdparty instanceof Societe && $object->thirdparty->default_lang && $object->thirdparty->default_lang != $langs->defaultlang) {
+							$outputlangs = new Translate('', $conf);
+							$outputlangs->setDefaultLang($object->thirdparty->default_lang);
+							$outputlangs->loadLangs(array('main', 'other'));
+						}
 					}
 					$substitutionarray = getCommonSubstitutionArray($outputlangs, 0, null, $object);
 					complete_substitutions_array($substitutionarray, $outputlangs, $object);


### PR DESCRIPTION
# FIX|Fix #33295 Thirdparty variables substitution ignored
Thirdparty substitutions var ignored because thirdparty object has never been fetched on automatic event