### PR TITLE
Fix Deposit percent on new propal not proposed and not saved

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1890,7 +1890,7 @@ if ($action == 'create') {
 	$currency_code = $conf->currency;
 
 	$cond_reglement_id = GETPOSTINT('cond_reglement_id');
-	$deposit_percent = GETPOST('cond_reglement_id_deposit_percent', 'alpha');
+	$deposit_percent = GETPOSTFLOAT('cond_reglement_id_deposit_percent');
 	$mode_reglement_id = GETPOSTINT('mode_reglement_id');
 	$fk_account = GETPOSTINT('fk_account');
 	$datepropal = (empty($datepropal) ? (!getDolGlobalString('MAIN_AUTOFILL_DATE_PROPOSAL') ? -1 : '') : $datepropal);


### PR DESCRIPTION
When deposit is activated, on new propal deposit percent is'nt proposed, and isn't saved in the propal, causing a display bug in pdf.

I just reported the same modif than in command

![Before fix ](https://github.com/user-attachments/assets/da78bba3-3f08-43ad-9049-062ac502ea11)

![After Fix](https://github.com/user-attachments/assets/ad90cfb9-9d9e-4a91-bec5-02678fe20978)



