### PR TITLE
FIX: bookkeeping/export error when not reconciled option is checked (no customsql !)

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1153,6 +1153,8 @@ class BookKeeping extends CommonObject
 						} else {
 							$sqlwhere[] = natural_search("t.code_journal", $value, 3, 1);
 						}
+					} elseif ($key == 't.reconciled_option') {
+						$sqlwhere[] = 't.lettering_code IS NULL';
 					} else {
 						$sqlwhere[] = natural_search($key, $value, 0, 1);
 					}


### PR DESCRIPTION
How to reproduce the bug :

Activate lettering feature (Accountancy Configuration)
Go to Accountancy > Export Accountancy (accountancy/bookkeeping/export.php)
Check Not reconciled option and refresh your list
Export to file => the following error will occur