### PR TITLE
FIX : cron tasks error email encoding

### DIFF
--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -1446,8 +1446,8 @@ class Cronjob extends CommonObject
 
 		if ($error && !empty($this->email_alert)) {
 			include_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
-			$subject = $langs->trans("ErrorInBatch", $this->label);
-			$msg = $langs->trans("ErrorInBatch", $this->label);
+			$subject = $langs->transnoentitiesnoconv("ErrorInBatch", $this->label);
+			$msg = $langs->transnoentitiesnoconv("ErrorInBatch", $this->label);
 			$from = getDolGlobalString('MAIN_MAIL_EMAIL_FROM');
 			$cmailfile = new CMailFile($subject, $this->email_alert, $from, $msg);
 			$result = $cmailfile->sendfile();	// Do not test result


### PR DESCRIPTION
How to reproduce : 
- Add your email in a cron task that will fail, execute the task.
- If text has special chars, will look like this : 
![image](https://github.com/user-attachments/assets/00380427-f93c-4f9f-846d-e1991a1ce274)

