### PR TITLE
add warning in Changelog for const STOCK_ALLOW_NEGATIVE_TRANSFER

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ The following changes may create regressions for some external modules, but were
 * The directory /build has been moved into /dev/build.
 * The use of GETPOST function is not allowed inside extrafields conditions or any strings that contains dynamic code evaluated with dol_eval()
 * The deprecated variable $trigger_name (duplicate of variable $triggersendname) has been removed. You must use $triggersendname everywhere now.
+* The behavior of constant STOCK_ALLOW_NEGATIVE_TRANSFER has been reversed. It has been renamed to STOCK_DISALLOW_NEGATIVE_TRANSFER.
 
 
 ***** ChangeLog for 21.0.0 compared to 20.0 *****


### PR DESCRIPTION
# Qual #Add warning in changelog for change in const STOCK_ALLOW_NEGATIVE_TRANSFER

https://github.com/Dolibarr/dolibarr/pull/33444 has been integrated into core (at commit 051a902f1f3).

But the initial PR received a useful message that was not considered : add warning in the changelog.
This is what this PR does.

