### PR TITLE
FIX : close all services on contract will close all lines

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3761,15 +3761,13 @@ class ContratLigne extends CommonObjectLine
 
 		$error = 0;
 
-		// statut actif : 4
-
 		$this->db->begin();
 
 		$sql = "UPDATE ".MAIN_DB_PREFIX."contratdet SET statut = ".((int) ContratLigne::STATUS_CLOSED).",";
 		$sql .= " date_cloture = '".$this->db->idate($date_end_real)."',";
 		$sql .= " fk_user_cloture = ".((int) $user->id).",";
 		$sql .= " commentaire = '".$this->db->escape($comment)."'";
-		$sql .= " WHERE rowid = ".((int) $this->id)." AND statut = ".((int) ContratLigne::STATUS_OPEN);
+		$sql .= " WHERE rowid = ".((int) $this->id)." AND statut != ".((int) ContratLigne::STATUS_CLOSED);
 
 		$resql = $this->db->query($sql);
 		if ($resql) {

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3767,7 +3767,7 @@ class ContratLigne extends CommonObjectLine
 		$sql .= " date_cloture = '".$this->db->idate($date_end_real)."',";
 		$sql .= " fk_user_cloture = ".((int) $user->id).",";
 		$sql .= " commentaire = '".$this->db->escape($comment)."'";
-		$sql .= " WHERE rowid = ".((int) $this->id)." AND statut != ".((int) ContratLigne::STATUS_CLOSED);
+		$sql .= " WHERE rowid = ".((int) $this->id)." AND statut <> ".((int) ContratLigne::STATUS_CLOSED);
 
 		$resql = $this->db->query($sql);
 		if ($resql) {


### PR DESCRIPTION
On contracts with "inactive" lines, clic on "close all services" button do nothing on inactives lines ...

![image](https://github.com/user-attachments/assets/8d16f0a5-58d3-4082-9608-0e5cd6c92c99)


![image](https://github.com/user-attachments/assets/9d44d4d3-d3a5-40a4-8580-2dd540d7aeda)
