### PR TITLE
Add link to doc and fix doc

### DIFF
--- a/htdocs/admin/tools/ui/components/icons.php
+++ b/htdocs/admin/tools/ui/components/icons.php
@@ -83,7 +83,7 @@ $documentation->showSidebar(); ?>
 				}
 				?>
 
-				<h2 class="documentation-title"><?php echo $langs->trans('DocIconsList'); ?></h2>
+				<h2 class="documentation-title"><?php echo $langs->trans('DocIconsListImgPicto'); ?></h2>
 				<?php /* <p class="documentation-text"><?php echo $langs->trans('DocDocIconsListDescription'); ?></p>*/ ?>
 				<div class="documentation-example">
 					<div class="documentation-fontawesome-icon-list">
@@ -100,7 +100,7 @@ $documentation->showSidebar(); ?>
 										<div class="info-box-lines">
 											<div class="info-box-line spanoverflow nowrap">
 												<div class="inline-block nowraponall">
-													<div class="documentation-code"><pre>'.dol_htmlentities('img_picto(\''.$labelAlt.'\', '.$iconName.')').'</pre></div>
+													<div class="documentation-code"><pre>'.dol_htmlentities('img_picto(\''.$labelAlt.'\', \''.$iconName.'\')').'</pre></div>
 												</div>
 											</div>
 										</div><!-- /.info-box-lines -->
@@ -133,7 +133,7 @@ $documentation->showSidebar(); ?>
 				}
 				?>
 
-				<h2 class="documentation-title"><?php echo $langs->trans('DocIconsList'); ?></h2>
+				<h2 class="documentation-title"><?php echo $langs->trans('DocIconsListFontAwesome'); ?></h2>
 				<?php /* <p class="documentation-text"><?php echo $langs->trans('DocDocIconsListDescription'); ?></p>*/ ?>
 				<div class="documentation-example">
 

--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -836,6 +836,11 @@ function ihm_prepare_head()
 	$head[$h][2] = 'css';
 	$h++;
 
+	$head[$h][0] = DOL_URL_ROOT."/admin/tools/ui/components/index.php";
+	$head[$h][1] = $langs->trans("UxComponentsDoc").' '.img_picto('', 'external-link-square-alt');
+	$head[$h][2] = 'css';
+	$h++;
+
 	complete_head_from_modules($conf, $langs, null, $head, $h, 'ihm_admin');
 
 	complete_head_from_modules($conf, $langs, null, $head, $h, 'ihm_admin', 'remove');

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -2644,3 +2644,4 @@ itemFound=%s Items found
 SearchStringMinLength=Search string must be at least 2 characters
 RefWebsite=Website reference
 FileToConcatToGeneratedPDF=File to concat to the generated PDF
+UxComponentsDoc=UX Components Doc

--- a/htdocs/langs/en_US/uxdocumentation.lang
+++ b/htdocs/langs/en_US/uxdocumentation.lang
@@ -82,7 +82,9 @@ DocButtonIconsForTitle = Buttons for list title
 
 # Fontawesome icons
 DocIconsTitle = Icons used by Dolibarr
-DocIconsList = List of usable icons with img_picto function
+DocIconsList = List of usable icons
+DocIconsListImgPicto = List of usable icons with img_picto function
+DocIconsListFontAwesome = List of usable icons with Font Awesome
 DocIconsMainDescription = Dolibarr use a part of fontawesome 5 icons
 DocIconsFontAwesomeList = List of usable fontawesome icons
 


### PR DESCRIPTION
# Fix
Lang key font icon doc and missing quote in generated exemple.


# CLOSE #32066
Add a link to doc in admin display section : 
![image](https://github.com/user-attachments/assets/275d53b0-b6bf-4f4e-8bb9-2823d5f1f4c3)

Note : I use an "external" icon to indicate that clicking on the menu will completely change the page.