### PR TITLE
Update tool versions in .pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: (?x)^( htdocs/includes/ckeditor/.*|(\.(?!github/workflows)[^/]*/.*))$
 repos:
   # Several miscellaneous checks and fix (on yaml files, end of files fix)
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       # This hook tests the name of the branch and return an error if the name is
       #  'develop' or an official version 'x.y'
@@ -60,13 +60,13 @@ repos:
 
   # Gitleaks is a SAST tool for detecting and preventing hardcoded secrets like passwords, api keys, and tokens in git repos
   - repo: https://github.com/gitleaks/gitleaks.git
-    rev: v8.16.1
+    rev: v8.24.0
     hooks:
       - id: gitleaks
 
   # Check github actions
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.3
+    rev: v1.7.7
     hooks:
       - id: actionlint
 
@@ -168,7 +168,7 @@ repos:
 
   # Prettier (format code, only for non common files)
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
+    rev: v3.1.0
     hooks:
       - id: prettier
         stages: [manual]
@@ -191,7 +191,7 @@ repos:
 
   # Check format of yaml files
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.36.2
     hooks:
       - id: yamllint
         args:
@@ -251,7 +251,7 @@ repos:
 
   # Check sql file syntax
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 3.1.0
+    rev: 3.3.1
     hooks:
       - id: sqlfluff-lint
         stages: [pre-commit, manual]  # manual needed for ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ processes = -1
 #verbose = 1
 #exclude_rules = "LT01,CP01,RF04"
 # RF04 | Keywords should not be used as identifiers. (rowid, login, position, ...)
-exclude_rules = "LT01,LT02,LT05,LT12,LT13,CP01,CP02,CP04,CP05,RF04"
+exclude_rules = "LT01,LT02,LT05,LT12,LT13,LT14,CP01,CP02,CP04,CP05,RF04"
 dialect = "mysql"
 # Default byte limit is 20000, must set limit - some files are too big.
 large_file_skip_byte_limit = 100000


### PR DESCRIPTION
# Update tool versions in .pre-commit-config

Update tool versions for pre-commit.
codespell is updated in #33493 .
Prettier was upgraded to 3.1.0 - higher versions are not compatible with the normal pre-commit workflow apparently.