### PR TITLE
FIX: no longer create payment if invoices can't be linked

### DIFF
--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -899,6 +899,7 @@ class Paiement extends CommonObject
 									'company'
 								);
 								if ($result <= 0) {
+									$error++;
 									dol_syslog(get_class($this).'::addPaymentToBank '.$this->db->lasterror());
 								}
 								$linkaddedforthirdparty[$fac->thirdparty->id] = $fac->thirdparty->id; // Mark as done for this thirdparty
@@ -917,6 +918,7 @@ class Paiement extends CommonObject
 									'company'
 								);
 								if ($result <= 0) {
+									$error++;
 									dol_syslog(get_class($this).'::addPaymentToBank '.$this->db->lasterror());
 								}
 								$linkaddedforthirdparty[$fac->thirdparty->id] = $fac->thirdparty->id; // Mark as done for this thirdparty


### PR DESCRIPTION
# FIX no longer create payment if invoices can't be linked
Je ne suis pas sûr que ce soit un bug très courant, vu la criticité que cela amène.

J'ai eu quelques cas où l'enregistrement du paiement n'a pas réussi à relier et classer correctement les factures comme payées.
Cependant le paiement s'est quand même enregistré.

Cela a créé une vraie galère pour réussir à rattraper le coup.

Pour éviter que le paiement ne s'enregistre s'il n'arrive pas à lier les factures, je propose cette PR.

Je n'imagine pas une situation où cette PR pose un problème bloquant.
Si le paiement ne valide pas correctement les factures, c'est qu'il y a un problème préalable à régler.
A mon avis, il vaut mieux empêcher le paiement de s'enregistrer pour régler le problème plutôt que d'enregistrer le paiement et de devoir régler le problème ensuite.


