### PR TITLE
FIX float posted quantities on dispatch shipment

### DIFF
--- a/htdocs/expedition/dispatch.php
+++ b/htdocs/expedition/dispatch.php
@@ -902,7 +902,7 @@ if ($object->id > 0 || !empty($object->ref)) {
 								// Qty to dispatch
 								print '<td class="right nowraponall">';
 								print '<a href="" id="reset'.$suffix.'" class="resetline">'.img_picto($langs->trans("Reset"), 'eraser', 'class="pictofixedwidth opacitymedium"').'</a>';
-								$suggestedvalue = (GETPOSTISSET('qty'.$suffix) ? GETPOSTINT('qty'.$suffix) : $objd->qty);
+								$suggestedvalue = (GETPOSTISSET('qty'.$suffix) ? GETPOSTFLOAT('qty'.$suffix) : $objd->qty);
 								//var_dump($suggestedvalue);exit;
 								print '<input id="qty'.$suffix.'" onchange="onChangeDispatchLineQty($(this))" name="qty'.$suffix.'" data-type="'.$type.'" data-index="'.$i.'" class="width50 right qtydispatchinput" value="'.$suggestedvalue.'" data-expected="'.$objd->qty.'">';
 								print '</td>';


### PR DESCRIPTION
FIX float posted quantities on dispatch shipment
- on dispatch tab of shipment card the quantities posted using "int" and not "float"

![image](https://github.com/user-attachments/assets/eae55c02-1f3e-4b9c-887c-41db61d22678)

- so when an error occurs, the quantity in the form is set to int value and not show the previous value (float)
![image](https://github.com/user-attachments/assets/7bb8345f-3d1f-47e3-bc7b-5899ec2ccc48)

