### PR TITLE
FIX - useless product fetch on invoice create

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -979,13 +979,13 @@ class Facture extends CommonInvoice
 			 */
 			if (!$error && $this->fac_rec > 0) {
 				foreach ($_facrec->lines as $i => $val) {
+					// For line from template invoice, we use data from template invoice
+					/*
 					if ($_facrec->lines[$i]->fk_product) {
 						$prod = new Product($this->db);
 						$res = $prod->fetch($_facrec->lines[$i]->fk_product);
 					}
 
-					// For line from template invoice, we use data from template invoice
-					/*
 					$tva_tx = get_default_tva($mysoc,$soc,$prod->id);
 					$tva_npr = get_default_npr($mysoc,$soc,$prod->id);
 					if (empty($tva_tx)) $tva_npr=0;


### PR DESCRIPTION
# FIX - useless product fetch on invoice create
For performance reasons, it's important to remove this prod->fetch because it doesn't need to be done here. The data management of this fetch was removed a while ago. 
