### PR TITLE
FIX: Fix download shared document between shared entity

### DIFF
--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -201,6 +201,12 @@ if (!empty($hashp)) {
 			$original_file = (($tmp[1] ? $tmp[1].'/' : '').$ecmfile->filename); // this is relative to module dir
 		}
 		$entity = $ecmfile->entity;
+		if (isModEnabled('multicompany') && !empty($ecmfile->src_object_type) && $ecmfile->src_object_id > 0) {
+			$object = fetchObjectByElement($ecmfile->src_object_id, $ecmfile->src_object_type);
+			if (is_object($object) && $object->id > 0) {
+				$entity = $object->entity;
+			}
+		}
 		if ($entity != $conf->entity) {
 			$conf->entity = $entity;
 			$conf->setValues($db);


### PR DESCRIPTION
Fix download shared document when for exemple
the thirdparty is shared between entity 1 and 2
and we create the thirdpaty on entity 1 but generate and share a document from entity 2

Dolibarr try to download the file on entity 2 but it's created on entity 1 (the entity where the thirdparty is created)
