### PR TITLE
FIX: Need missing translation file in result index page of accountancy rapport

### DIFF
--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -43,7 +43,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
  */
 
 // Load translation files required by the page
-$langs->loadLangs(array('compta', 'bills', 'donation', 'salaries'));
+$langs->loadLangs(array('compta', 'bills', 'donation', 'accountancy', 'salaries'));
 
 $date_startday = GETPOSTINT('date_startday');
 $date_startmonth = GETPOSTINT('date_startmonth');


### PR DESCRIPTION
Need missing translation file in result index page of accountancy rapport