### PR TITLE
FIX: migration: 19.0→20.0: rename llx_commande_fournisseur_dispatch sequence #31228

### DIFF
--- a/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
+++ b/htdocs/install/mysql/migration/19.0.0-20.0.0.sql
@@ -244,6 +244,9 @@ ALTER TABLE llx_knowledgemanagement_knowledgerecord MODIFY COLUMN answer longtex
 ALTER TABLE llx_commande_fournisseur_dispatch_extrafields RENAME TO llx_receptiondet_batch_extrafields;
 ALTER TABLE llx_commande_fournisseur_dispatch RENAME TO llx_receptiondet_batch;
 
+-- VPGSQL8.2 ALTER SEQUENCE llx_commande_fournisseur_dispatch_extrafields_rowid_seq RENAME TO llx_receptiondet_batch_extrafields_rowid_seq;
+-- VPGSQL8.2 ALTER SEQUENCE llx_commande_fournisseur_dispatch_rowid_seq RENAME TO llx_receptiondet_batch_rowid_seq;
+
 -- Rename const to add customer categories on not customer/prospect third-party if enabled
 UPDATE llx_const SET name = 'THIRDPARTY_CAN_HAVE_CUSTOMER_CATEGORY_EVEN_IF_NOT_CUSTOMER_PROSPECT' WHERE name = 'THIRDPARTY_CAN_HAVE_CATEGORY_EVEN_IF_NOT_CUSTOMER_PROSPECT_SUPPLIER';
 


### PR DESCRIPTION
# FIX migration: 19.0→20.0: rename llx_commande_fournisseur_dispatch sequence #31228

Fix an issue after upgrading to 20.0.x with the backend saying that the sequences llx_expeditiondet_batch_rowid_seq doesn't exist.

The table was somehow renamed, and migration fixed for PostgreSQL in the following commits:

- 3670ba75ba4f1172ea50c1f266af78e141402965: rename the table to match the intent of the table.
- 9913778da0cd573c2f95718c4cb7a8370503918a: using VPGSQL comments to use a different RENAME function for PostgreSQL.
- d73d27466bbd4a8592173d683f95fb861e8e63c7: Using RENAME TO which is compatible with both PostgreSQL and MySQL.

But the sequence was still a leftover after those migrations.

Co-authored-by: Alexis Thietard
Co-authored-by: Geoffrey Mellar

Fixes #31228

Should be applied to develop branch afterwards.