### PR TITLE
NEW #33506 Add a constant to apply a ratio to resize images in ODT templates

### DIFF
--- a/htdocs/core/modules/asset/doc/doc_generic_asset_odt.modules.php
+++ b/htdocs/core/modules/asset/doc/doc_generic_asset_odt.modules.php
@@ -380,12 +380,19 @@ class doc_generic_asset_odt extends ModelePDFAsset
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) {
 							// Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/asset/doc/doc_generic_asset_odt.modules.php
+++ b/htdocs/core/modules/asset/doc/doc_generic_asset_odt.modules.php
@@ -382,7 +382,7 @@ class doc_generic_asset_odt extends ModelePDFAsset
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/asset/doc/doc_generic_asset_odt.modules.php
+++ b/htdocs/core/modules/asset/doc/doc_generic_asset_odt.modules.php
@@ -382,7 +382,7 @@ class doc_generic_asset_odt extends ModelePDFAsset
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
+++ b/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
@@ -378,11 +378,18 @@ class doc_generic_bom_odt extends ModelePDFBom
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
+++ b/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
@@ -380,7 +380,7 @@ class doc_generic_bom_odt extends ModelePDFBom
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
+++ b/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
@@ -380,7 +380,7 @@ class doc_generic_bom_odt extends ModelePDFBom
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -401,7 +401,7 @@ class doc_generic_order_odt extends ModelePDFCommandes
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -399,11 +399,18 @@ class doc_generic_order_odt extends ModelePDFCommandes
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -401,7 +401,7 @@ class doc_generic_order_odt extends ModelePDFCommandes
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
+++ b/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
@@ -389,13 +389,19 @@ class doc_generic_contract_odt extends ModelePDFContract
 				// Call the ODTSubstitution hook
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
 
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) {
 							// Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
+++ b/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
@@ -391,7 +391,7 @@ class doc_generic_contract_odt extends ModelePDFContract
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
+++ b/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
@@ -391,7 +391,7 @@ class doc_generic_contract_odt extends ModelePDFContract
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -372,6 +372,13 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 					dol_syslog($e->getMessage(), LOG_INFO);
 				}
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				// Make substitutions into odt of user info
 				$tmparray = $this->get_substitutionarray_user($user, $outputlangs);
 				foreach ($tmparray as $key => $value) {
@@ -379,7 +386,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 						if (preg_match('/logo$/', $key)) { // Image
 							//var_dump($value);exit;
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}
@@ -397,7 +404,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 						if (preg_match('/logo$/', $key)) {	// Image
 							//var_dump($value);exit;
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}
@@ -419,7 +426,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 					try {
 						if (preg_match('/logo$/', $key)) {	// Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}
@@ -437,7 +444,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 						try {
 							if (preg_match('/logo$/', $key)) {	// Image
 								if (file_exists($value)) {
-									$odfHandler->setImage($key, $value);
+									$odfHandler->setImage($key, $value, $ratio);
 								} else {
 									$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 								}
@@ -464,7 +471,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 						if (preg_match('/logo$/', $key)) {
 							// Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -374,7 +374,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -374,7 +374,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -453,12 +453,20 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
+				//var_dump($tmparray); exit;
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							//var_dump($value);exit;
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -455,7 +455,7 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -455,7 +455,7 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
+++ b/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
@@ -351,12 +351,20 @@ class doc_generic_member_odt extends ModelePDFMember
 					'substitutionarray' => &$tmparray
 				);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) {
 							// Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
+++ b/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
@@ -354,7 +354,7 @@ class doc_generic_member_odt extends ModelePDFMember
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
+++ b/htdocs/core/modules/member/doc/doc_generic_member_odt.class.php
@@ -354,7 +354,7 @@ class doc_generic_member_odt extends ModelePDFMember
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
+++ b/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
@@ -380,7 +380,7 @@ class doc_generic_mo_odt extends ModelePDFMo
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
+++ b/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
@@ -378,12 +378,19 @@ class doc_generic_mo_odt extends ModelePDFMo
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) {
 							// Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
+++ b/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
@@ -380,7 +380,7 @@ class doc_generic_mo_odt extends ModelePDFMo
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
+++ b/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
@@ -390,11 +390,18 @@ class doc_generic_product_odt extends ModelePDFProduct
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
+++ b/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
@@ -392,7 +392,7 @@ class doc_generic_product_odt extends ModelePDFProduct
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
+++ b/htdocs/core/modules/product/doc/doc_generic_product_odt.modules.php
@@ -392,7 +392,7 @@ class doc_generic_product_odt extends ModelePDFProduct
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
+++ b/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
@@ -653,7 +653,7 @@ class doc_generic_project_odt extends ModelePDFProjects
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
+++ b/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
@@ -651,11 +651,18 @@ class doc_generic_project_odt extends ModelePDFProjects
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
+++ b/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
@@ -653,7 +653,7 @@ class doc_generic_project_odt extends ModelePDFProjects
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/project/task/doc/doc_generic_task_odt.modules.php
+++ b/htdocs/core/modules/project/task/doc/doc_generic_task_odt.modules.php
@@ -592,7 +592,7 @@ class doc_generic_task_odt extends ModelePDFTask
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/project/task/doc/doc_generic_task_odt.modules.php
+++ b/htdocs/core/modules/project/task/doc/doc_generic_task_odt.modules.php
@@ -590,11 +590,18 @@ class doc_generic_task_odt extends ModelePDFTask
 				$tmparray = array_merge($substitutionarray, $array_object_from_properties, $array_user, $array_soc, $array_thirdparty, $array_objet, $array_other);
 				complete_substitutions_array($tmparray, $outputlangs, $object);
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/project/task/doc/doc_generic_task_odt.modules.php
+++ b/htdocs/core/modules/project/task/doc/doc_generic_task_odt.modules.php
@@ -592,7 +592,7 @@ class doc_generic_task_odt extends ModelePDFTask
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -436,11 +436,18 @@ class doc_generic_proposal_odt extends ModelePDFPropales
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -438,7 +438,7 @@ class doc_generic_proposal_odt extends ModelePDFPropales
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
+++ b/htdocs/core/modules/propale/doc/doc_generic_proposal_odt.modules.php
@@ -438,7 +438,7 @@ class doc_generic_proposal_odt extends ModelePDFPropales
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
+++ b/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
@@ -385,11 +385,19 @@ class doc_generic_reception_odt extends ModelePdfReception
 				// Call the ODTSubstitution hook
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
+++ b/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
@@ -388,7 +388,7 @@ class doc_generic_reception_odt extends ModelePdfReception
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
+++ b/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
@@ -388,7 +388,7 @@ class doc_generic_reception_odt extends ModelePdfReception
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
+++ b/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
@@ -384,12 +384,19 @@ class doc_generic_odt extends ModeleThirdPartyDoc
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				// Replace variables into document
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) {	// Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
+++ b/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
@@ -386,7 +386,7 @@ class doc_generic_odt extends ModeleThirdPartyDoc
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
+++ b/htdocs/core/modules/societe/doc/doc_generic_odt.modules.php
@@ -386,7 +386,7 @@ class doc_generic_odt extends ModeleThirdPartyDoc
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/stock/doc/doc_generic_stock_odt.modules.php
+++ b/htdocs/core/modules/stock/doc/doc_generic_stock_odt.modules.php
@@ -388,11 +388,18 @@ class doc_generic_stock_odt extends ModelePDFStock
 				$parameters = array('file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/stock/doc/doc_generic_stock_odt.modules.php
+++ b/htdocs/core/modules/stock/doc/doc_generic_stock_odt.modules.php
@@ -390,7 +390,7 @@ class doc_generic_stock_odt extends ModelePDFStock
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/stock/doc/doc_generic_stock_odt.modules.php
+++ b/htdocs/core/modules/stock/doc/doc_generic_stock_odt.modules.php
@@ -390,7 +390,7 @@ class doc_generic_stock_odt extends ModelePDFStock
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/supplier_invoice/doc/doc_generic_supplier_invoice_odt.modules.php
+++ b/htdocs/core/modules/supplier_invoice/doc/doc_generic_supplier_invoice_odt.modules.php
@@ -390,11 +390,18 @@ class doc_generic_supplier_invoice_odt extends ModelePDFSuppliersInvoices
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/supplier_invoice/doc/doc_generic_supplier_invoice_odt.modules.php
+++ b/htdocs/core/modules/supplier_invoice/doc/doc_generic_supplier_invoice_odt.modules.php
@@ -392,7 +392,7 @@ class doc_generic_supplier_invoice_odt extends ModelePDFSuppliersInvoices
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/supplier_invoice/doc/doc_generic_supplier_invoice_odt.modules.php
+++ b/htdocs/core/modules/supplier_invoice/doc/doc_generic_supplier_invoice_odt.modules.php
@@ -392,7 +392,7 @@ class doc_generic_supplier_invoice_odt extends ModelePDFSuppliersInvoices
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
@@ -385,11 +385,18 @@ class doc_generic_supplier_order_odt extends ModelePDFSuppliersOrders
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
@@ -387,7 +387,7 @@ class doc_generic_supplier_order_odt extends ModelePDFSuppliersOrders
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/doc_generic_supplier_order_odt.modules.php
@@ -387,7 +387,7 @@ class doc_generic_supplier_order_odt extends ModelePDFSuppliersOrders
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
@@ -414,11 +414,18 @@ class doc_generic_supplier_proposal_odt extends ModelePDFSupplierProposal
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
@@ -416,7 +416,7 @@ class doc_generic_supplier_proposal_odt extends ModelePDFSupplierProposal
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/doc_generic_supplier_proposal_odt.modules.php
@@ -416,7 +416,7 @@ class doc_generic_supplier_proposal_odt extends ModelePDFSupplierProposal
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
+++ b/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
@@ -346,11 +346,19 @@ class doc_generic_ticket_odt extends ModelePDFTicket
 				// Call the ODTSubstitution hook
 				$parameters = array('file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
+++ b/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
@@ -349,7 +349,7 @@ class doc_generic_ticket_odt extends ModelePDFTicket
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
+++ b/htdocs/core/modules/ticket/doc/doc_generic_ticket_odt.modules.php
@@ -349,7 +349,7 @@ class doc_generic_ticket_odt extends ModelePDFTicket
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
+++ b/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
@@ -377,11 +377,19 @@ class doc_generic_user_odt extends ModelePDFUser
 				// Call the ODTSubstitution hook
 				$parameters = array('file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
+++ b/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
@@ -380,7 +380,7 @@ class doc_generic_user_odt extends ModelePDFUser
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
+++ b/htdocs/core/modules/user/doc/doc_generic_user_odt.modules.php
@@ -380,7 +380,7 @@ class doc_generic_user_odt extends ModelePDFUser
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
+++ b/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
@@ -412,11 +412,19 @@ class doc_generic_usergroup_odt extends ModelePDFUserGroup
 				// Call the ODTSubstitution hook
 				$parameters = array('file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) { // Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
+++ b/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
@@ -415,7 +415,7 @@ class doc_generic_usergroup_odt extends ModelePDFUserGroup
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
+++ b/htdocs/core/modules/usergroup/doc/doc_generic_usergroup_odt.modules.php
@@ -415,7 +415,7 @@ class doc_generic_usergroup_odt extends ModelePDFUserGroup
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/includes/odtphp/Segment.php
+++ b/htdocs/includes/odtphp/Segment.php
@@ -260,7 +260,7 @@ class Segment implements IteratorAggregate, Countable
 	 * @throws OdfException
 	 * @return Segment
 	 */
-	public function setImage($key, $value, $ratio=1)
+	public function setImage($key, $value, float $ratio=1)
 	{
 		$filename = strtok(strrchr($value, '/'), '/.');
 		$file = substr(strrchr($value, '/'), 1);

--- a/htdocs/includes/odtphp/Segment.php
+++ b/htdocs/includes/odtphp/Segment.php
@@ -257,6 +257,7 @@ class Segment implements IteratorAggregate, Countable
 	 *
 	 * @param string $key name of the variable within the template
 	 * @param string $value path to the picture
+	 * @param float $ratio   Ratio for image
 	 * @throws OdfException
 	 * @return Segment
 	 */

--- a/htdocs/includes/odtphp/Segment.php
+++ b/htdocs/includes/odtphp/Segment.php
@@ -260,7 +260,7 @@ class Segment implements IteratorAggregate, Countable
 	 * @throws OdfException
 	 * @return Segment
 	 */
-	public function setImage($key, $value)
+	public function setImage($key, $value, $ratio=1)
 	{
 		$filename = strtok(strrchr($value, '/'), '/.');
 		$file = substr(strrchr($value, '/'), 1);
@@ -270,8 +270,8 @@ class Segment implements IteratorAggregate, Countable
 		}
 		// Set the width and height of the page
 		list ($width, $height) = $size;
-		$width *= Odf::PIXEL_TO_CM;
-		$height *= Odf::PIXEL_TO_CM;
+		$width *= Odf::PIXEL_TO_CM * $ratio;
+		$height *= Odf::PIXEL_TO_CM * $ratio;
 		// Fix local-aware issues (eg: 12,10 -> 12.10)
 		$width = sprintf("%F", $width);
 		$height = sprintf("%F", $height);

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -530,7 +530,7 @@ class Odf
 	 * @throws OdfException
 	 * @return odf
 	 */
-	public function setImage($key, $value, $ratio=1)
+	public function setImage($key, $value, float $ratio=1)
 	{
 		$filename = strtok(strrchr($value, '/'), '/.');
 		$file = substr(strrchr($value, '/'), 1);

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -527,6 +527,7 @@ class Odf
 	 *
 	 * @param string $key name of the variable within the template
 	 * @param string $value path to the picture
+	 * @param float $ratio   Ratio for image
 	 * @throws OdfException
 	 * @return odf
 	 */

--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -530,7 +530,7 @@ class Odf
 	 * @throws OdfException
 	 * @return odf
 	 */
-	public function setImage($key, $value)
+	public function setImage($key, $value, $ratio=1)
 	{
 		$filename = strtok(strrchr($value, '/'), '/.');
 		$file = substr(strrchr($value, '/'), 1);
@@ -539,8 +539,8 @@ class Odf
 			throw new OdfException("Invalid image");
 		}
 		list ($width, $height) = $size;
-		$width *= self::PIXEL_TO_CM;
-		$height *= self::PIXEL_TO_CM;
+		$width *= self::PIXEL_TO_CM * $ratio;
+		$height *= self::PIXEL_TO_CM * $ratio;
 		$xml = <<<IMG
 			<draw:frame draw:style-name="fr1" draw:name="$filename" text:anchor-type="aschar" svg:width="{$width}cm" svg:height="{$height}cm" draw:z-index="3"><draw:image xlink:href="Pictures/$file" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad"/></draw:frame>
 IMG;

--- a/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
@@ -417,7 +417,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
@@ -417,7 +417,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
@@ -415,12 +415,19 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) {
 							// Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/recruitment/core/modules/recruitment/doc/doc_generic_recruitmentjobposition_odt.modules.php
+++ b/htdocs/recruitment/core/modules/recruitment/doc/doc_generic_recruitmentjobposition_odt.modules.php
@@ -408,12 +408,19 @@ class doc_generic_recruitmentjobposition_odt extends ModelePDFRecruitmentJobPosi
 				$parameters = array('odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray);
 				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
+				// retrieve the constant to apply a ratio for image size or set the ratio to 1
+				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
+					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+				} else {
+					$ratio = 1;
+				}
+
 				foreach ($tmparray as $key => $value) {
 					try {
 						if (preg_match('/logo$/', $key)) {
 							// Image
 							if (file_exists($value)) {
-								$odfHandler->setImage($key, $value);
+								$odfHandler->setImage($key, $value, $ratio);
 							} else {
 								$odfHandler->setVars($key, 'ErrorFileNotFound', true, 'UTF-8');
 							}

--- a/htdocs/recruitment/core/modules/recruitment/doc/doc_generic_recruitmentjobposition_odt.modules.php
+++ b/htdocs/recruitment/core/modules/recruitment/doc/doc_generic_recruitmentjobposition_odt.modules.php
@@ -410,7 +410,7 @@ class doc_generic_recruitmentjobposition_odt extends ModelePDFRecruitmentJobPosi
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
+					$ratio = floatval(getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}

--- a/htdocs/recruitment/core/modules/recruitment/doc/doc_generic_recruitmentjobposition_odt.modules.php
+++ b/htdocs/recruitment/core/modules/recruitment/doc/doc_generic_recruitmentjobposition_odt.modules.php
@@ -410,7 +410,7 @@ class doc_generic_recruitmentjobposition_odt extends ModelePDFRecruitmentJobPosi
 
 				// retrieve the constant to apply a ratio for image size or set the ratio to 1
 				if (getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO')) {
-					$ratio = getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO') * 1;
+					$ratio = floatval( getDolGlobalString('MAIN_DOC_ODT_IMAGE_RATIO'));
 				} else {
 					$ratio = 1;
 				}


### PR DESCRIPTION
Added a new Dolibarr constant MAIN_DOC_ODT_IMAGE_RATIO.
This constant holds a number that is multiplied when computing the size of images in ODT templates.
All doc_generic_*_odt_modules.php files have been updated to call the setImage Method with a new parameter $ratio.
The method setImage in the file odt.php and segment.php has been modified to have a new parameter $ratio and use it to compute the image size