### PR TITLE
FIX: The select value is not only integer value so we accept string value for index into ajax_combobox() function

### DIFF
--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -517,7 +517,7 @@ function ajax_combobox($htmlname, $events = array(), $minLengthToAutocomplete = 
 	 					/* Code to add class of origin OPTION propagated to the new select2 <li> tag */
 						if (data.element) { $(container).addClass($(data.element).attr("class")); }
 						//console.log("data html is "+$(data.element).attr("data-html"));
-						if (data.id == '.((int) $idforemptyvalue).' && $(data.element).attr("data-html") == undefined) {
+						if (data.id == "'.dol_escape_js($idforemptyvalue, 2).'" && $(data.element).attr("data-html") == undefined) {
 							return \'&nbsp;\';
 						}
 						if ($(data.element).attr("data-html") != undefined) {
@@ -530,7 +530,7 @@ function ajax_combobox($htmlname, $events = array(), $minLengthToAutocomplete = 
 						return data.text;
 					},
 					templateSelection: function (selection) {		/* Format visible output of selected value */
-						if (selection.id == '.((int) $idforemptyvalue).') return \'<span class="placeholder">\'+selection.text+\'</span>\';
+						if (selection.id == "'.dol_escape_js($idforemptyvalue, 2).'") return \'<span class="placeholder">\'+selection.text+\'</span>\';
 						return selection.text;
 					},
 					escapeMarkup: function(markup) {


### PR DESCRIPTION
The select value is not only integer value so we accept string value for index into ajax_combobox() function

Example: If the empty value index is empty and we have a option with value index at 0 with a label, the label is set to empty