### PR TITLE
FIX #33563 - Discount amount count twice when create a discount from deposit invoice

### DIFF
--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -541,7 +541,7 @@ class Paiement extends CommonObject
 										// Loop on each vat rate
 										$i = 0;
 										foreach ($invoice->lines as $line) {
-											if ($line->total_ht != 0) {    // no need to create discount if amount is null
+											if ($line->product_type != 9 && $line->total_ht != 0) {    // no need to create discount if amount is null or is special product
 												if (!array_key_exists($line->tva_tx, $amount_ht)) {
 													$amount_ht[$line->tva_tx] = 0.0;
 													$amount_tva[$line->tva_tx] = 0.0;


### PR DESCRIPTION
FIX #33563 - Discount amount count twice when create a discount from …