### PR TITLE
add exportFile parameter to accountancyexport hook

### DIFF
--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -541,7 +541,7 @@ class AccountancyExport
 				break;
 			default:
 				global $hookmanager;
-				$parameters = array('format' => $formatexportset);
+				$parameters = array('format' => $formatexportset, 'exportFile' => $exportFile);
 				// file contents will be created in the hooked function via print
 				$reshook = $hookmanager->executeHooks('export', $parameters, $TData);
 				if ($reshook != 1) {


### PR DESCRIPTION
NEW: add the exportFile parameter to the hook call in the accountancyExport.
Now the hook function can write to the file instead of just printing to the output.

