### PR TITLE
FIX : If the global INVOICE_CAN_NEVER_BE_EDITED disabled the action 'modify' of a invoice, we test in the point of entry of the action and not after we make many useless tests

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -749,7 +749,7 @@ if (empty($reshook)) {
 				}
 			}
 		}
-	} elseif ($action == 'confirm_modif' && $usercanunvalidate) {
+	} elseif ($action == 'confirm_modif' && $usercanunvalidate && !getDolGlobalString('INVOICE_CAN_NEVER_BE_EDITED')) {
 		// Go back to draft status (unvalidate)
 		$idwarehouse = GETPOSTINT('idwarehouse');
 
@@ -766,7 +766,7 @@ if (empty($reshook)) {
 			}
 
 			if ($qualified_for_stock_change) {
-				if (!$idwarehouse || $idwarehouse == - 1) {
+				if (!$idwarehouse || $idwarehouse == -1) {
 					$error++;
 					setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv("Warehouse")), null, 'errors');
 					$action = '';
@@ -778,8 +778,8 @@ if (empty($reshook)) {
 			// We check if invoice has payments
 			$totalpaid = 0;
 			$sql = 'SELECT pf.amount';
-			$sql .= ' FROM '.MAIN_DB_PREFIX.'paiement_facture as pf';
-			$sql .= ' WHERE pf.fk_facture = '.((int) $object->id);
+			$sql .= ' FROM ' . MAIN_DB_PREFIX . 'paiement_facture as pf';
+			$sql .= ' WHERE pf.fk_facture = ' . ((int) $object->id);
 
 			$result = $db->query($sql);
 			if ($result) {
@@ -801,36 +801,35 @@ if (empty($reshook)) {
 			$ventilExportCompta = $object->getVentilExportCompta();
 
 			// We check if no payment has been made
-			if (!getDolGlobalString('INVOICE_CAN_NEVER_BE_EDITED')) {
-				if ($ventilExportCompta == 0) {
-					if (getDolGlobalString('INVOICE_CAN_BE_EDITED_EVEN_IF_PAYMENT_DONE') || ($resteapayer == $object->total_ttc && empty($object->paye))) {
-						$result = $object->setDraft($user, $idwarehouse);
-						if ($result < 0) {
-							setEventMessages($object->error, $object->errors, 'errors');
-						}
+			if ($ventilExportCompta == 0) {
+				if (getDolGlobalString('INVOICE_CAN_BE_EDITED_EVEN_IF_PAYMENT_DONE') || ($resteapayer == $object->total_ttc && empty($object->paye))) {
+					$result = $object->setDraft($user, $idwarehouse);
+					if ($result < 0) {
+						setEventMessages($object->error, $object->errors, 'errors');
+					}
 
-						// Define output language
-						if (!getDolGlobalString('MAIN_DISABLE_PDF_AUTOUPDATE')) {
-							$outputlangs = $langs;
-							$newlang = '';
-							if (getDolGlobalInt('MAIN_MULTILANGS') /* && empty($newlang) */ && GETPOST('lang_id', 'aZ09')) {
-								$newlang = GETPOST('lang_id', 'aZ09');
-							}
-							if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-								$newlang = $object->thirdparty->default_lang;
-							}
-							if (!empty($newlang)) {
-								$outputlangs = new Translate("", $conf);
-								$outputlangs->setDefaultLang($newlang);
-								$outputlangs->load('products');
-							}
-							$model = $object->model_pdf;
-							$ret = $object->fetch($id); // Reload to get new records
-
-							$object->generateDocument($model, $outputlangs, $hidedetails, $hidedesc, $hideref);
+					// Define output language
+					if (!getDolGlobalString('MAIN_DISABLE_PDF_AUTOUPDATE')) {
+						$outputlangs = $langs;
+						$newlang = '';
+						if (getDolGlobalInt('MAIN_MULTILANGS') /* && empty($newlang) */ && GETPOST('lang_id', 'aZ09')) {
+							$newlang = GETPOST('lang_id', 'aZ09');
 						}
+						if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
+							$newlang = $object->thirdparty->default_lang;
+						}
+						if (!empty($newlang)) {
+							$outputlangs = new Translate("", $conf);
+							$outputlangs->setDefaultLang($newlang);
+							$outputlangs->load('products');
+						}
+						$model = $object->model_pdf;
+						$ret = $object->fetch($id); // Reload to get new records
+
+						$object->generateDocument($model, $outputlangs, $hidedetails, $hidedesc, $hideref);
 					}
 				}
+
 			}
 		}
 	} elseif ($action == 'confirm_paid' && $confirm == 'yes' && $usercanissuepayment) {
@@ -5892,28 +5891,26 @@ if ($action == 'create') {
 				)
 			);
 			// Edit a validated invoice without any payment and not transferred to accounting
-			if ($object->status == Facture::STATUS_VALIDATED) {
+			if ($object->status == Facture::STATUS_VALIDATED && !getDolGlobalString('INVOICE_CAN_NEVER_BE_EDITED')) {
 				// We check if lines of invoice are not already transferred into accountancy
 				$ventilExportCompta = $object->getVentilExportCompta();
 
-				if (!getDolGlobalString('INVOICE_CAN_NEVER_BE_EDITED')) {
-					if ($ventilExportCompta == 0) {
-						if (getDolGlobalString('INVOICE_CAN_BE_EDITED_EVEN_IF_PAYMENT_DONE') || ($resteapayer == price2num($object->total_ttc, 'MT', 1) && empty($object->paye))) {
-							if (!$objectidnext && $object->is_last_in_cycle()) {
-								if ($usercanunvalidate) {
-									unset($params['attr']['title']);
-									print dolGetButtonAction($langs->trans('Modify'), '', 'default', $_SERVER['PHP_SELF'] . '?facid=' . $object->id . '&action=modif&token=' . newToken(), '', true, $params);
-								} else {
-									$params['attr']['title'] = $langs->trans('NotEnoughPermissions');
-									print dolGetButtonAction($langs->trans('Modify'), '', 'default', $_SERVER['PHP_SELF'] . '?facid=' . $object->id . '&action=modif&token=' . newToken(), '', false, $params);
-								}
-							} elseif (!$object->is_last_in_cycle()) {
-								$params['attr']['title'] = $langs->trans('NotLastInCycle');
-								print dolGetButtonAction($langs->trans('Modify'), '', 'default', '#', '', false, $params);
+				if ($ventilExportCompta == 0) {
+					if (getDolGlobalString('INVOICE_CAN_BE_EDITED_EVEN_IF_PAYMENT_DONE') || ($resteapayer == price2num($object->total_ttc, 'MT', 1) && empty($object->paye))) {
+						if (!$objectidnext && $object->is_last_in_cycle()) {
+							if ($usercanunvalidate) {
+								unset($params['attr']['title']);
+								print dolGetButtonAction($langs->trans('Modify'), '', 'default', $_SERVER['PHP_SELF'] . '?facid=' . $object->id . '&action=modif&token=' . newToken(), '', true, $params);
 							} else {
-								$params['attr']['title'] = $langs->trans('DisabledBecauseReplacedInvoice');
-								print dolGetButtonAction($langs->trans('Modify'), '', 'default', '#', '', false, $params);
+								$params['attr']['title'] = $langs->trans('NotEnoughPermissions');
+								print dolGetButtonAction($langs->trans('Modify'), '', 'default', $_SERVER['PHP_SELF'] . '?facid=' . $object->id . '&action=modif&token=' . newToken(), '', false, $params);
 							}
+						} elseif (!$object->is_last_in_cycle()) {
+							$params['attr']['title'] = $langs->trans('NotLastInCycle');
+							print dolGetButtonAction($langs->trans('Modify'), '', 'default', '#', '', false, $params);
+						} else {
+							$params['attr']['title'] = $langs->trans('DisabledBecauseReplacedInvoice');
+							print dolGetButtonAction($langs->trans('Modify'), '', 'default', '#', '', false, $params);
 						}
 					}
 				} else {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -829,7 +829,6 @@ if (empty($reshook)) {
 						$object->generateDocument($model, $outputlangs, $hidedetails, $hidedesc, $hideref);
 					}
 				}
-
 			}
 		}
 	} elseif ($action == 'confirm_paid' && $confirm == 'yes' && $usercanissuepayment) {


### PR DESCRIPTION
If the global INVOICE_CAN_NEVER_BE_EDITED disabled the action 'modify' of a invoice, we test in the point of entry of the action and not after we make many useless tests