### PR TITLE
NEW : add new permissions to read supplier prices

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -159,6 +159,14 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][4] = 'ignore_price_min_advance';
 		$r++;
 
+		$this->rights[$r][0] = 40; // id de la permission
+		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
+		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][4] = 'product_advance';
+		$this->rights[$r][5] = 'read_supplier_prices';
+		$r++;
+
 		// Menus
 		//-------
 

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -159,7 +159,7 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][4] = 'ignore_price_min_advance';
 		$r++;
 
-		$this->rights[$r][0] = 40; // id de la permission
+		$this->rights[$r][0] = 37; // id de la permission
 		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // La permission est-elle une permission par default

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -138,6 +138,14 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][5] = 'read_prices';
 		$r++;
 
+		$this->rights[$r][0] = 35; // id de la permission
+		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
+		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][4] = 'product_advance';
+		$this->rights[$r][5] = 'read_supplier_prices';
+		$r++;
+		
 		$this->rights[$r][0] = 34; // id de la permission
 		$this->rights[$r][1] = 'Delete products'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
@@ -157,14 +165,6 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][2] = 'r';
 		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'ignore_price_min_advance';
-		$r++;
-
-		$this->rights[$r][0] = 37; // id de la permission
-		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
-		$this->rights[$r][4] = 'product_advance';
-		$this->rights[$r][5] = 'read_supplier_prices';
 		$r++;
 
 		// Menus

--- a/htdocs/core/modules/modService.class.php
+++ b/htdocs/core/modules/modService.class.php
@@ -110,6 +110,14 @@ class modService extends DolibarrModules
 		$this->rights[$r][5] = 'read_prices';
 		$r++;
 
+		$this->rights[$r][0] = 535; // id de la permission
+		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
+		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][4] = 'product_advance';
+		$this->rights[$r][5] = 'read_supplier_prices';
+		$r++;
+		
 		$this->rights[$r][0] = 534; // id de la permission
 		$this->rights[$r][1] = 'Delete les services'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
@@ -122,14 +130,6 @@ class modService extends DolibarrModules
 		$this->rights[$r][2] = 'r';
 		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'export';
-		$r++;
-
-		$this->rights[$r][0] = 539; // id de la permission
-		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
-		$this->rights[$r][4] = 'product_advance';
-		$this->rights[$r][5] = 'read_supplier_prices';
 		$r++;
 
 		// Menus

--- a/htdocs/core/modules/modService.class.php
+++ b/htdocs/core/modules/modService.class.php
@@ -124,6 +124,14 @@ class modService extends DolibarrModules
 		$this->rights[$r][4] = 'export';
 		$r++;
 
+		$this->rights[$r][0] = 539; // id de la permission
+		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
+		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][4] = 'product_advance';
+		$this->rights[$r][5] = 'read_supplier_prices';
+		$r++;
+
 		// Menus
 		//-------
 		$this->menu = 1; // This module add menu entries. They are coded into menu manager.


### PR DESCRIPTION
Some companies dont want some collaborators to read supplier prices but to be allowed to see customer prices.
@eldy do you think we replace the current read_prices permission by a read_supplier_prices and a read_customer_prices ?
or do we only add this new read_supplier_prices permission ?