### PR TITLE
FIX: missing formObjectOptions hook on payment card

### DIFF
--- a/htdocs/compta/paiement/card.php
+++ b/htdocs/compta/paiement/card.php
@@ -470,6 +470,11 @@ if (!empty($object->ext_payment_id)) {
 	print '</td></tr>';
 }
 
+// Other attributes
+$parameters = array();
+$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+print $hookmanager->resPrint;
+
 print '</table>';
 
 print '</div>';


### PR DESCRIPTION
Add the formObjectOptions hook to allow external modules to add informations on the payment card.