### PR TITLE
build debian package on bookworm

### DIFF
--- a/build/makepack-dolibarr.pl
+++ b/build/makepack-dolibarr.pl
@@ -4,7 +4,7 @@
 # \brief        Dolibarr package builder (tgz, zip, rpm, deb, exe, aps)
 # \author       (c)2004-2020 Laurent Destailleur  <eldy@users.sourceforge.net>
 #
-# This is list of constant you can set to have generated packages moved into a specific dir: 
+# This is list of constant you can set to have generated packages moved into a specific dir:
 #DESTIBETARC='/media/HDDATA1_LD/Mes Sites/Web/Dolibarr/dolibarr.org/files/lastbuild'
 #DESTISTABLE='/media/HDDATA1_LD/Mes Sites/Web/Dolibarr/dolibarr.org/files/stable'
 #DESTIMODULES='/media/HDDATA1_LD/Mes Sites/Web/Admin1/wwwroot/files/modules'
@@ -35,7 +35,7 @@ $PUBLISHSTABLE="$ENV{'DESTISFLOGIN'}\@frs.sourceforge.net:/home/frs/project/doli
 "RPM_FEDORA"=>"rpmbuild",
 "RPM_MANDRIVA"=>"rpmbuild",
 "RPM_OPENSUSE"=>"rpmbuild",
-"DEB"=>"dpkg dpatch",
+"DEB"=>"dpkg",
 "FLATPACK"=>"flatpack",
 "EXEDOLIWAMP"=>"ISCC.exe",
 "SNAPSHOT"=>"tar"
@@ -128,7 +128,7 @@ if (! $TEMP || ! -d $TEMP) {
 	print "$PROG.$Extension aborted.\n";
 	sleep 2;
 	exit 2;
-} 
+}
 $BUILDROOT="$TEMP/buildroot";
 
 
@@ -171,7 +171,7 @@ $newbuild = $BUILD;
 $newbuild =~ s/(dev|alpha)/1/gi;                # dev
 $newbuild =~ s/beta(.?)/2/gi;                   # beta    			(we want beta1, beta2, betax to be same package name)
 $newbuild =~ s/rc(.?)/3/gi;                     # rc				(we want rc1, rc2, rcx to be same package name)
-if ($newbuild !~ /-/) { $newbuild.='-4'; }      # finale is same than rc. 
+if ($newbuild !~ /-/) { $newbuild.='-4'; }      # finale is same than rc.
 # now newbuild is 0-1 or 0-4 for example. Note that for native package (see debian/source/format), we should not use a dash part but to get a better version management
 $build = $newbuild;
 $build =~ s/-.*$//g;
@@ -189,8 +189,8 @@ for (0..@ARGV-1) {
 	if ($ARGV[$_] =~ /^-*target=(\w+)/i)   { $target=$1; $batch=1; }
 	if ($ARGV[$_] =~ /^-*desti=(.+)/i)     { $DESTI=$1; }
 	if ($ARGV[$_] =~ /^-*prefix=(.+)/i)    {
-		$PREFIX=$1; 
-		$FILENAMESNAPSHOT.="-".$PREFIX; 
+		$PREFIX=$1;
+		$FILENAMESNAPSHOT.="-".$PREFIX;
 	}
 }
 if ($ENV{"DESTIBETARC"} && $BUILD =~ /[a-z]/i)   { $DESTI = $ENV{"DESTIBETARC"}; }	# Force output dir if env DESTIBETARC is defined
@@ -209,7 +209,7 @@ print "Target directory (DESTI) : $DESTI\n";
 # Choose package targets
 #-----------------------
 if ($target) {
-	if ($target eq "ALL") { 
+	if ($target eq "ALL") {
 		foreach my $key (@LISTETARGET) {
 			if ($key ne 'SNAPSHOT' && $key ne 'SF' && $key ne 'ASSO') { $CHOOSEDTARGET{$key}=1; }
 		}
@@ -235,10 +235,10 @@ else {
 		printf(" %2d - %-14s  (%s)\n",$cpt,"ASSO (publish)","Need ".$REQUIREMENTPUBLISH{"ASSO"});
 		$cpt=99;
 		printf(" %2d - %-14s  (%s)\n",$cpt,"SF (publish)","Need ".$REQUIREMENTPUBLISH{"SF"});
-	
+
 		# Ask which target to build
 		print "Choose one target number or several separated with space (0 - ".$cpt."): ";
-		$NUM_SCRIPT=<STDIN>; 
+		$NUM_SCRIPT=<STDIN>;
 		chomp($NUM_SCRIPT);
 		if ($NUM_SCRIPT !~ /^[0-9\s]+$/)
 		{
@@ -285,11 +285,11 @@ foreach my $target (sort keys %CHOOSEDTARGET) {
 			print "Error: You asked creation of several rpms. Because all rpm have same name, you must defined an environment variable DESTI to tell packager where it can create subdirs for each generated package.\n";
 			exit;
 		}
-		$atleastonerpm=1;			
-	} 
-	foreach my $req (split(/[,\s]/,$REQUIREMENTTARGET{$target})) 
+		$atleastonerpm=1;
+	}
+	foreach my $req (split(/[,\s]/,$REQUIREMENTTARGET{$target}))
 	{
-		# Test    
+		# Test
 		print "Test requirement for target $target: Search '$req'... ";
 		$newreq=$req; $newparam='';
 		if ($newreq eq 'zip') { $newparam.='-h'; }
@@ -298,12 +298,12 @@ foreach my $target (sort keys %CHOOSEDTARGET) {
 		print "Test command ".$cmd."... ";
 		$ret=`$cmd`;
 		$coderetour=$?; $coderetour2=$coderetour>>8;
-		if ($coderetour != 0 && (($coderetour2 == 1 && $OS =~ /windows/ && $ret !~ /Usage/i) || ($coderetour2 == 127 && $OS !~ /windows/)) && $PROGPATH) { 
+		if ($coderetour != 0 && (($coderetour2 == 1 && $OS =~ /windows/ && $ret !~ /Usage/i) || ($coderetour2 == 127 && $OS !~ /windows/)) && $PROGPATH) {
 			# Not found error, we try in PROGPATH
 			$ret=`"$PROGPATH/$ALTERNATEPATH{$req}/$req\" 2>&1`;
 			$coderetour=$?; $coderetour2=$coderetour>>8;
 			$REQUIREMENTTARGET{$target}="$PROGPATH/$ALTERNATEPATH{$req}/$req";
-		} 
+		}
 
 		if ($coderetour != 0 && (($coderetour2 == 1 && $OS =~ /windows/ && $ret !~ /Usage/i) || ($coderetour2 == 127 && $OS !~ /windows/))) {
 			# Not found error
@@ -332,7 +332,7 @@ $nbofpublishneedchangelog=0;
 foreach my $target (sort keys %CHOOSEDTARGET) {
 	if ($target eq '-CHKSUM') { $nbofpublishneedchangelog++; }
 	if ($CHOOSEDTARGET{$target} < 0) { next; }
-	if ($target ne 'EXE' && $target ne 'EXEDOLIWAMP' && $target ne '-CHKSUM') 
+	if ($target ne 'EXE' && $target ne 'EXEDOLIWAMP' && $target ne '-CHKSUM')
 	{
 		$nboftargetneedbuildroot++;
 	}
@@ -396,10 +396,10 @@ if ($nboftargetok) {
 		print "Go to directory $SOURCE\n";
 		$olddir=getcwd();
 		chdir("$SOURCE");
-		
+
 		print "Clean $SOURCE/htdocs/includes/autoload.php\n";
 		$ret=`rm -f  $SOURCE/htdocs/includes/autoload.php`;
-		
+
 		$ret=`git ls-files . --exclude-standard --others`;
 		if ($ret)
 		{
@@ -408,7 +408,7 @@ if ($nboftargetok) {
 				print "Canceled.\n";
 				exit;
 		}
-		
+
 	   	print 'Create xml check file with md5 checksum with command php '.$SOURCE.'/build/generate_filelist_xml.php release='.$MAJOR.'.'.$MINOR.'.'.$BUILD."\n";
 	  	$ret=`php $SOURCE/build/generate_filelist_xml.php release=$MAJOR.$MINOR.$BUILD`;
 	  	print $ret."\n";
@@ -426,13 +426,13 @@ if ($nboftargetok) {
 		print "Go to directory $SOURCE\n";
 		$olddir=getcwd();
 		chdir("$SOURCE");
-		
+
 		print 'Run git tag -a -m "'.$MAJOR.'.'.$MINOR.'.'.$BUILD.'" "'.$MAJOR.'.'.$MINOR.'.'.$BUILD.'"'."\n";
 		$ret=`git tag -a -m "$MAJOR.$MINOR.$BUILD" "$MAJOR.$MINOR.$BUILD" 2>&1`;
 		if ($ret =~ /(already exists|existe déjà)/)
 		{
 			print "WARNING: Tag ".$MAJOR.'.'.$MINOR.'.'.$BUILD." already exists. Overwrite (y/N) ? ";
-			$QUESTIONOVERWRITETAG=<STDIN>; 
+			$QUESTIONOVERWRITETAG=<STDIN>;
 			chomp($QUESTIONOVERWRITETAG);
 			if ($QUESTIONOVERWRITETAG =~ /(o|y)/)
 			{
@@ -451,7 +451,7 @@ if ($nboftargetok) {
 		}
 		chdir("$olddir");
 	}
-	
+
 	# Update buildroot if required
 	#-----------------------------
 	if ($nboftargetneedbuildroot)
@@ -461,7 +461,7 @@ if ($nboftargetok) {
 
 			print "Delete directory $BUILDROOT\n";
 			$ret=`rm -fr "$BUILDROOT"`;
-		
+
 			mkdir "$BUILDROOT";
 			mkdir "$BUILDROOT/$PROJECT";
 			print "Copy $SOURCE into $BUILDROOT/$PROJECT\n";
@@ -487,7 +487,7 @@ if ($nboftargetok) {
 		$ret=`rm -f  $BUILDROOT/$PROJECT/phpstan.neon`;
 		$ret=`rm -f  $BUILDROOT/$PROJECT/pom.xml`;
 		$ret=`rm -f  $BUILDROOT/$PROJECT/README-*.md`;
-		
+
 		$ret=`rm -fr $BUILDROOT/$PROJECT/build/html`;
 		$ret=`rm -f  $BUILDROOT/$PROJECT/build/Doli*-*`;
 		$ret=`rm -f  $BUILDROOT/$PROJECT/build/dolibarr_*.deb`;
@@ -554,20 +554,20 @@ if ($nboftargetok) {
 		$ret=`rm -f  $BUILDROOT/$PROJECT/doc/images/dolibarr_screenshot11.png`;
 		$ret=`rm -f  $BUILDROOT/$PROJECT/doc/images/dolibarr_screenshot12.png`;
 
-		# Security to avoid to package data files 
+		# Security to avoid to package data files
         print "Remove documents dir\n";
 		$ret=`rm -fr $BUILDROOT/$PROJECT/document`;
 		$ret=`rm -fr $BUILDROOT/$PROJECT/documents`;
 		$ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/document`;
 		$ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/documents`;
-        
+
         print "Remove subdir of custom dir\n";
    	    print "find $BUILDROOT/$PROJECT/htdocs/custom/* -type d -exec rm -fr {} \\;\n";
    	    $ret=`find $BUILDROOT/$PROJECT/htdocs/custom/* -type d -exec rm -fr {} \\; >/dev/null 2>&1`;	# For custom we want to remove all subdirs but not files
    	    print "find $BUILDROOT/$PROJECT/htdocs/custom/* -type l -exec rm -fr {} \\;\n";
    	    $ret=`find $BUILDROOT/$PROJECT/htdocs/custom/* -type l -exec rm -fr {} \\; >/dev/null 2>&1`;	# For custom we want to remove all subdirs, even symbolic links, but not files
 
-		# Removed known external modules to avoid any error when packaging from env where external modules are tested 
+		# Removed known external modules to avoid any error when packaging from env where external modules are tested
 		$ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/abricot*`;
 		$ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/accountingexport*`;
 		$ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/allscreens*`;
@@ -592,15 +592,15 @@ if ($nboftargetok) {
 		$ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/timesheet*`;
 		$ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/webmail*`;
 		$ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/theme/common/fontawesome-5/svgs`;
-		
+
 		# Removed other test files
 	    $ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/public/test`;
 	    $ret=`rm -fr $BUILDROOT/$PROJECT/test`;
 	    $ret=`rm -fr $BUILDROOT/$PROJECT/Thumbs.db $BUILDROOT/$PROJECT/*/Thumbs.db $BUILDROOT/$PROJECT/*/*/Thumbs.db $BUILDROOT/$PROJECT/*/*/*/Thumbs.db $BUILDROOT/$PROJECT/*/*/*/*/Thumbs.db`;
 	    $ret=`rm -f  $BUILDROOT/$PROJECT/.cvsignore $BUILDROOT/$PROJECT/*/.cvsignore $BUILDROOT/$PROJECT/*/*/.cvsignore $BUILDROOT/$PROJECT/*/*/*/.cvsignore $BUILDROOT/$PROJECT/*/*/*/*/.cvsignore $BUILDROOT/$PROJECT/*/*/*/*/*/.cvsignore $BUILDROOT/$PROJECT/*/*/*/*/*/*/.cvsignore`;
 	    $ret=`rm -f  $BUILDROOT/$PROJECT/.gitignore $BUILDROOT/$PROJECT/*/.gitignore $BUILDROOT/$PROJECT/*/*/.gitignore $BUILDROOT/$PROJECT/*/*/*/.gitignore $BUILDROOT/$PROJECT/*/*/*/*/.gitignore $BUILDROOT/$PROJECT/*/*/*/*/*/.gitignore $BUILDROOT/$PROJECT/*/*/*/*/*/*/.gitignore`;
-		
-		# Removed files installed by the awful composer   	    
+
+		# Removed files installed by the awful composer
    	    $ret=`rm -f  $BUILDROOT/$PROJECT/htdocs/includes/geoip/sample*.*`;
         $ret=`rm -f  $BUILDROOT/$PROJECT/htdocs/includes/bin`;
         $ret=`rm -fr $BUILDROOT/$PROJECT/htdocs/includes/ckeditor/ckeditor/adapters`;		# Keep this removal in case we embed libraries
@@ -639,14 +639,14 @@ if ($nboftargetok) {
 
 	# Build package for each target
 	#------------------------------
-	foreach my $target (sort keys %CHOOSEDTARGET) 
+	foreach my $target (sort keys %CHOOSEDTARGET)
 	{
 		if ($CHOOSEDTARGET{$target} < 0) { next; }
 		if ($target eq '-CHKSUM') { next; }
-		
+
 		print "\nBuild package for target $target\n";
 
-		if ($target eq 'SNAPSHOT') 
+		if ($target eq 'SNAPSHOT')
 		{
 			$NEWDESTI=$DESTI;
 
@@ -670,13 +670,13 @@ if ($nboftargetok) {
 			next;
 		}
 
-		if ($target eq 'TGZ') 
+		if ($target eq 'TGZ')
 		{
 			$NEWDESTI=$DESTI;
 			if ($NEWDESTI =~ /stable/)
 			{
 				mkdir($DESTI.'/standard');
-				if (-d $DESTI.'/standard') { $NEWDESTI=$DESTI.'/standard'; } 
+				if (-d $DESTI.'/standard') { $NEWDESTI=$DESTI.'/standard'; }
 			}
 
 			print "Remove target $FILENAMETGZ.tgz...\n";
@@ -690,7 +690,7 @@ if ($nboftargetok) {
 
 			$ret=`rm -fr $BUILDROOT/$FILENAMETGZ/build/exe`;
 			$ret=`rm -fr $BUILDROOT/$FILENAMETGZ/htdocs/includes/ckeditor/_source`;	# We can't remove it with exclude file, we need it for some tarball packages
-			
+
 			print "Compress $FILENAMETGZ into $FILENAMETGZ.tgz...\n";
 			$cmd="tar --exclude-vcs --exclude-from \"$BUILDROOT/$PROJECT/build/tgz/tar_exclude.txt\" --directory \"$BUILDROOT\" --mode=go-w --group=500 --owner=500 -czvf \"$BUILDROOT/$FILENAMETGZ.tgz\" $FILENAMETGZ";
 			print "$cmd\n";
@@ -702,14 +702,14 @@ if ($nboftargetok) {
 			next;
 		}
 
-		if ($target eq 'XZ') 
+		if ($target eq 'XZ')
 		{
 			$NEWDESTI=$DESTI;
 			if ($NEWDESTI =~ /stable/)
 			{
 				mkdir($DESTI.'/standard');
 				if (-d $DESTI.'/standard') { $NEWDESTI=$DESTI.'/standard'; }
-			} 
+			}
 
 			print "Remove target $FILENAMEXZ.xz...\n";
 			unlink("$NEWDESTI/$FILENAMEXZ.xz");
@@ -722,7 +722,7 @@ if ($nboftargetok) {
 
 			$ret=`rm -fr $BUILDROOT/$FILENAMEXZ/build/exe`;
 			$ret=`rm -fr $BUILDROOT/$FILENAMEXZ/htdocs/includes/ckeditor/_source`;	# We can't remove it with exclude file, we need it for some tarball packages
-			
+
 			print "Compress $FILENAMEXZ into $FILENAMEXZ.xz...\n";
 
 			print "Go to directory $BUILDROOT\n";
@@ -738,15 +738,15 @@ if ($nboftargetok) {
 			$ret=`mv "$BUILDROOT/$FILENAMEXZ.xz" "$NEWDESTI/$FILENAMEXZ.xz"`;
 			next;
 		}
-		
-		if ($target eq 'ZIP') 
+
+		if ($target eq 'ZIP')
 		{
 			$NEWDESTI=$DESTI;
 			if ($NEWDESTI =~ /stable/)
 			{
 				mkdir($DESTI.'/standard');
 				if (-d $DESTI.'/standard') { $NEWDESTI=$DESTI.'/standard'; }
-			} 
+			}
 
 			print "Remove target $FILENAMEZIP.zip...\n";
 			unlink("$NEWDESTI/$FILENAMEZIP.zip");
@@ -769,14 +769,14 @@ if ($nboftargetok) {
 			print $cmd."\n";
 			$ret= `$cmd`;
 			chdir("$olddir");
-						
+
 			# Move to final dir
 			print "Move $FILENAMEZIP.zip to $NEWDESTI/$FILENAMEZIP.zip\n";
 			$ret=`mv "$BUILDROOT/$FILENAMEZIP.zip" "$NEWDESTI/$FILENAMEZIP.zip"`;
 			next;
 		}
-	
-		if ($target =~ /RPM/)	                 # Linux only 
+
+		if ($target =~ /RPM/)	                 # Linux only
 		{
 			$NEWDESTI=$DESTI;
 			$subdir="package_rpm_generic";
@@ -787,7 +787,7 @@ if ($nboftargetok) {
 			{
 				mkdir($DESTI.'/'.$subdir);
 				if (-d $DESTI.'/'.$subdir) { $NEWDESTI=$DESTI.'/'.$subdir; }
-			} 
+			}
 
 			if ($RPMDIR eq "") { $RPMDIR=$ENV{'HOME'}."/rpmbuild"; }
 
@@ -800,7 +800,7 @@ if ($nboftargetok) {
 
 			print "Create directory $BUILDROOT/$FILENAMETGZ2\n";
 			$ret=`rm -fr $BUILDROOT/$FILENAMETGZ2`;
-			
+
 			print "Copy $BUILDROOT/$PROJECT to $BUILDROOT/$FILENAMETGZ2\n";
 			$cmd="cp -pr '$BUILDROOT/$PROJECT' '$BUILDROOT/$FILENAMETGZ2'";
 			$ret=`$cmd`;
@@ -826,7 +826,7 @@ if ($nboftargetok) {
 			if ($target =~ /FEDO/i) { $BUILDFICSRC="${FILENAME}_fedora.spec"; }
 			if ($target =~ /MAND/i) { $BUILDFICSRC="${FILENAME}_mandriva.spec"; }
 			if ($target =~ /OPEN/i) { $BUILDFICSRC="${FILENAME}_opensuse.spec"; }
-			
+
 			use Date::Language;
 			$lang=Date::Language->new('English');
 			$datestring = $lang->time2str("%a %b %e %Y", time);
@@ -844,7 +844,7 @@ if ($nboftargetok) {
 			}
 			close SPECFROM;
 			close SPECTO;
-	
+
 			print "Copy patch file to $RPMDIR/SOURCES\n";
 			$ret=`cp "$SOURCE/build/rpm/dolibarr-forrpm.patch" "$RPMDIR/SOURCES"`;
 			$ret=`chmod 644 $RPMDIR/SOURCES/dolibarr-forrpm.patch`;
@@ -866,14 +866,14 @@ if ($nboftargetok) {
 			next;
 		}
 
-		if ($target eq 'DEB') 
+		if ($target eq 'DEB')
 		{
 			$NEWDESTI=$DESTI;
 			if ($NEWDESTI =~ /stable/)
 			{
 				mkdir($DESTI.'/package_debian-ubuntu');
 				if (-d $DESTI.'/package_debian-ubuntu') { $NEWDESTI=$DESTI.'/package_debian-ubuntu'; }
-			} 
+			}
 
 			$olddir=getcwd();
 
@@ -954,13 +954,18 @@ if ($nboftargetok) {
 			$ret=`rm -fr $BUILDROOT/$PROJECT.tmp/htdocs/includes/jquery/plugins/select2/LICENSE`;
 			$ret=`rm -fr $BUILDROOT/$PROJECT.tmp/htdocs/includes/mike42/escpos-php/LICENSE.md`;
 			$ret=`rm -fr $BUILDROOT/$PROJECT.tmp/htdocs/includes/mobiledetect/mobiledetectlib/LICENSE.txt`;
-			
+
 			# Removed files we don't need (already removed)
 			#$ret=`rm -fr $BUILDROOT/$PROJECT.tmp/htdocs/includes/ckeditor/ckeditor/_source`;
-			
+			$ret=`rm -fr $BUILDROOT/$PROJECT.tmp/.codeclimate.yml`;
+			$ret=`rm -fr $BUILDROOT/$PROJECT.tmp/.pre-commit-config.yaml`;
+			$ret=`rm -fr $BUILDROOT/$PROJECT.tmp/.vscode`;
+			$ret=`find $BUILDROOT/$PROJECT.tmp/ -type f -name '.editorconfig' -exec rm {} \\;`;
+			$ret=`find $BUILDROOT/$PROJECT.tmp/ -type f -name '.travis.yml' -exec rm {} \\;`;
+
 			# Rename upstream changelog to match debian rules
 			$ret=`mv $BUILDROOT/$PROJECT.tmp/ChangeLog $BUILDROOT/$PROJECT.tmp/changelog`;
-			
+
 			# Prepare source package (init debian dir)
 			print "Create directory $BUILDROOT/$PROJECT.tmp/debian\n";
 			$ret=`mkdir "$BUILDROOT/$PROJECT.tmp/debian"`;
@@ -998,7 +1003,7 @@ if ($nboftargetok) {
 			$ret=`cp -f  "$SOURCE/build/debian/dolibarr.postrm"         "$BUILDROOT/$PROJECT.tmp/debian"`;
 			$ret=`cp -f  "$SOURCE/build/debian/dolibarr.templates"      "$BUILDROOT/$PROJECT.tmp/debian"`;
 			$ret=`cp -f  "$SOURCE/build/debian/install.forced.php.install"      "$BUILDROOT/$PROJECT.tmp/debian"`;
-			
+
 			# Set owners and permissions
 			#print "Set owners on files/dir\n";
 			#$ret=`chown -R root.root $BUILDROOT/$PROJECT.tmp`;
@@ -1029,8 +1034,8 @@ if ($nboftargetok) {
 			$ret=`$cmd`;
 			$cmd="find $BUILDROOT/$PROJECT.tmp/scripts -name '*.sh' -type f -exec chmod 755 {} \\; ";
 			$ret=`$cmd`;
-			
-		
+
+
 			print "Rename directory $BUILDROOT/$PROJECT.tmp into $BUILDROOT/$PROJECT-$MAJOR.$MINOR.$build\n";
 			$cmd="mv $BUILDROOT/$PROJECT.tmp $BUILDROOT/$PROJECT-$MAJOR.$MINOR.$build";
 			$ret=`$cmd`;
@@ -1038,14 +1043,14 @@ if ($nboftargetok) {
 
 			print "Go into directory $BUILDROOT\n";
 			chdir("$BUILDROOT");
-			
+
 			# We need a tarball to be able to build "quilt" debian package (not required for native but we need patch so it is not a native)
 			print "Compress $BUILDROOT/$PROJECT-$MAJOR.$MINOR.$build into $BUILDROOT/$FILENAMEDEBNATIVE.orig.tar.gz...\n";
 			$cmd="tar --exclude-vcs --exclude-from \"$BUILDROOT/$PROJECT/build/tgz/tar_exclude.txt\" --directory \"$BUILDROOT\" --mode=go-w --group=500 --owner=500 -czvf \"$BUILDROOT/$FILENAMEDEBNATIVE.orig.tar.gz\" $PROJECT-$MAJOR.$MINOR.$build";
 			print $cmd."\n";
 			$ret=`$cmd`;
 
-			# Creation of source package          
+			# Creation of source package
 			print "Go into directory $BUILDROOT/$PROJECT-$MAJOR.$MINOR.$build\n";
 			chdir("$BUILDROOT/$PROJECT-$MAJOR.$MINOR.$build");
 			#$cmd="dpkg-source -b $BUILDROOT/$PROJECT-$MAJOR.$MINOR.$build";
@@ -1064,12 +1069,12 @@ if ($nboftargetok) {
 			$ret=`mv $BUILDROOT/*_all.deb "$NEWDESTI/"`;
 			$ret=`mv $BUILDROOT/*.dsc "$NEWDESTI/"`;
 			$ret=`mv $BUILDROOT/*.orig.tar.gz "$NEWDESTI/"`;
-			#$ret=`mv $BUILDROOT/*.debian.tar.xz "$NEWDESTI/"`;		# xz file is generated when build/debian/sources/option 
+			#$ret=`mv $BUILDROOT/*.debian.tar.xz "$NEWDESTI/"`;		# xz file is generated when build/debian/sources/option
 			$ret=`mv $BUILDROOT/*.debian.tar.gz "$NEWDESTI/"`;
 			$ret=`mv $BUILDROOT/*.changes "$NEWDESTI/"`;
 			next;
 		}
-		
+
 		if ($target eq 'EXEDOLIWAMP')
 		{
 			$NEWDESTI=$DESTI;
@@ -1077,22 +1082,22 @@ if ($nboftargetok) {
 			{
 				mkdir($DESTI.'/package_windows');
 				if (-d $DESTI.'/package_windows') { $NEWDESTI=$DESTI.'/package_windows'; }
-			} 
+			}
 
      		print "Remove target $NEWDESTI/$FILENAMEEXEDOLIWAMP.exe...\n";
     		unlink "$NEWDESTI/$FILENAMEEXEDOLIWAMP.exe";
- 
+
  			if ($OS eq 'windows') {
  				print "Check that ISCC.exe is in your PATH.\n";
 			} else {
  				print "Check that in your Wine setup, you have created a Z: drive that point to your / directory.\n";
 			}
-			
+
  			$SOURCEBACK=$SOURCE;
  			$SOURCEBACK =~ s/\//\\/g;
 
     		print "Prepare file \"$SOURCEBACK\\build\\exe\\doliwamp\\doliwamp.tmp.iss\" from \"$SOURCEBACK\\build\\exe\\doliwamp\\doliwamp.iss\"\n";
-    		
+
     		#$ret=`cat "$SOURCE/build/exe/doliwamp/doliwamp.iss" | sed -e 's/__FILENAMEEXEDOLIWAMP__/$FILENAMEEXEDOLIWAMP/g' > "$SOURCE/build/exe/doliwamp/doliwamp.tmp.iss"`;
     		open(IN, '<' . $SOURCE."/build/exe/doliwamp/doliwamp.iss") or die $!;
 			open(OUT, '>' . "$SOURCE/build/exe/doliwamp/doliwamp.tmp.iss") or die $!;
@@ -1105,7 +1110,7 @@ if ($nboftargetok) {
 			close(OUT);
 
     		print "Compil exe $FILENAMEEXEDOLIWAMP.exe file from iss file \"$SOURCEBACK\\build\\exe\\doliwamp\\doliwamp.tmp.iss\" on OS $OS\n";
-    		
+
  			if ($OS eq 'windows') {
 	    		$cmd= "ISCC.exe \"$SOURCEBACK\\build\\exe\\doliwamp\\doliwamp.tmp.iss\"";
 	    	} else {
@@ -1119,26 +1124,26 @@ if ($nboftargetok) {
 			print "Move \"$SOURCE\\build\\$FILENAMEEXEDOLIWAMP.exe\" to $NEWDESTI/$FILENAMEEXEDOLIWAMP.exe\n";
     		rename("$SOURCE/build/$FILENAMEEXEDOLIWAMP.exe","$NEWDESTI/$FILENAMEEXEDOLIWAMP.exe");
             print "Move $SOURCE/build/$FILENAMEEXEDOLIWAMP.exe to $NEWDESTI/$FILENAMEEXEDOLIWAMP.exe\n";
-            
+
             use File::Copy;
 
             #$ret=`mv "$SOURCE/build/$FILENAMEEXEDOLIWAMP.exe" "$NEWDESTI/$FILENAMEEXEDOLIWAMP.exe"`;
             $ret=move("$SOURCE/build/$FILENAMEEXEDOLIWAMP.exe", "$NEWDESTI/$FILENAMEEXEDOLIWAMP.exe");
-            
+
             print "Remove tmp file $SOURCE/build/exe/doliwamp/doliwamp.tmp.iss\n";
             #$ret=`rm "$SOURCE/build/exe/doliwamp/doliwamp.tmp.iss"`;
             $ret=unlink("$SOURCE/build/exe/doliwamp/doliwamp.tmp.iss");
-            
+
     		next;
     	}
     }
 
 	# Publish package for each target
 	#--------------------------------
-	foreach my $target (sort keys %CHOOSEDPUBLISH) 
+	foreach my $target (sort keys %CHOOSEDPUBLISH)
 	{
 		if ($CHOOSEDPUBLISH{$target} < 0) { next; }
-	
+
 		print "\nList of files to publish (BUILD=$BUILD)\n";
 		%filestoscansf=(
 			"$DESTI/signatures/filelist-$MAJOR.$MINOR.$BUILD.xml"=>'none',				# none means it won't be published on SF
@@ -1196,26 +1201,26 @@ if ($nboftargetok) {
 			print "\n";
 		}
 
-		if ($target eq 'SF' || $target eq 'ASSO') 
+		if ($target eq 'SF' || $target eq 'ASSO')
 		{
 			print "\n";
-			
+
 			if ($target eq 'SF') { $PUBLISH = $PUBLISHSTABLE; }
 			if ($target eq 'ASSO' && $BUILD =~ /[a-z]/i)   { $PUBLISH = $PUBLISHBETARC.'/lastbuild'; }
 			if ($target eq 'ASSO' && $BUILD =~ /^[0-9]+$/) { $PUBLISH = $PUBLISHBETARC.'/stable'; }
-			
+
 			$NEWPUBLISH=$PUBLISH;
 			print "Publish to target $NEWPUBLISH. Click enter or CTRL+C...\n";
 
 			# Ask which target to build
-			$NUM_SCRIPT=<STDIN>; 
+			$NUM_SCRIPT=<STDIN>;
 			chomp($NUM_SCRIPT);
 
 			print "Create empty dir /tmp/emptydir. We need it to create target dir using rsync.\n";
 			$ret=`mkdir -p "/tmp/emptydir/"`;
-			
+
 			%filestoscan=%filestoscansf;
-			
+
 			foreach my $file (sort keys %filestoscan)
 			{
 				$found=0;
@@ -1225,30 +1230,30 @@ if ($nboftargetok) {
 	    		if ($target eq 'SF') {
 	    			if ($filestoscan{$file} eq 'none') {
 	    				next;
-	    			} 
+	    			}
 	    			$destFolder="$NEWPUBLISH/$filestoscan{$file}/".$MAJOR.'.'.$MINOR.'.'.$BUILD;
 	    		}
 	    		elsif ($target eq 'ASSO' and $NEWPUBLISH =~ /stable/) {
 	    			$destFolder="$NEWPUBLISH/$filestoscanstableasso{$file}";
-	    		} 
+	    		}
 	    		elsif ($target eq 'ASSO' and $NEWPUBLISH !~ /stable/) {
 	    			$destFolder="$NEWPUBLISH";
-	    		} 
+	    		}
 	    		else	# No more used
 	    		{
 	    			$dirnameonly=$file;
-	    			$dirnameonly =~ s/.*\/([^\/]+)\/[^\/]+$/$1/;  
+	    			$dirnameonly =~ s/.*\/([^\/]+)\/[^\/]+$/$1/;
 	    			$filenameonly=$file;
-	    			$filenameonly =~ s/.*\/[^\/]+\/([^\/])+$/$1/;  
+	    			$filenameonly =~ s/.*\/[^\/]+\/([^\/])+$/$1/;
 	    			$destFolder="$NEWPUBLISH/$dirnameonly";
 	    		}
 
 				print "\n";
 	    		print "Publish file ".$file." to ".$destFolder."\n";
 
-				# mkdir	   
+				# mkdir
 				#my $ssh = Net::SSH::Perl->new("frs.sourceforge.net");
-				#$ssh->login("$user","$pass"); 		
+				#$ssh->login("$user","$pass");
 				#use String::ShellQuote qw( shell_quote );
 				#$ssh->cmd('mkdir '.shell_quote($destFolder).' && exit');
 
@@ -1257,20 +1262,20 @@ if ($nboftargetok) {
 				#$sftp->mkdir($destFolder)
 
 				#$command="ssh eldy,dolibarr\@frs.sourceforge.net mkdir -p \"$destFolder\"";
-				#print "$command\n";	
+				#print "$command\n";
 				#my $ret=`$command 2>&1`;
 
 				$command="rsync -s -e 'ssh' --recursive /tmp/emptydir/ \"".$destFolder."\"";
-				print "$command\n";	
+				print "$command\n";
 				my $ret=`$command 2>&1`;
 
 				$command="rsync -s -e 'ssh' \"$file\" \"".$destFolder."\"";
-				print "$command\n";	
+				print "$command\n";
 				my $ret2=`$command 2>&1`;
 				print "$ret2\n";
 			}
 		}
-	}    
+	}
 }
 
 print "\n----- Summary -----\n";


### PR DESCRIPTION
dpatch is not presend in bookworm and was deprecated some years ago :)
by chance we don't need it to build debian package so i just remove depatch from prereq tests command and add some exclude files like others then debian package is build successfull