### PR TITLE
FIX: warehouse list: broken status filter

### DIFF
--- a/htdocs/product/stock/list.php
+++ b/htdocs/product/stock/list.php
@@ -246,17 +246,17 @@ if ($separatedPMP) {
 }
 $sql .= " WHERE t.entity IN (".getEntity('stock').")";
 foreach ($search as $key => $val) {
-	if (array_key_exists($key, $object->fields)) {
-		$class_key = $key;
-		if ($class_key == 'status') {
-			$class_key = 'statut'; // remove this after refactoring entrepot.class property statut to status
-		}
+	$class_key = $key;
+	if ($class_key == 'status') {
+		$class_key = 'statut'; // remove this after refactoring entrepot.class property statut to status
+	}
+	if (array_key_exists($class_key, $object->fields)) {
 		if (($key == 'status' && $search[$key] == -1) || $key == 'entity') {
 			continue;
 		}
-		$mode_search = (($object->isInt($object->fields[$key]) || $object->isFloat($object->fields[$key])) ? 1 : 0);
-		if ((strpos($object->fields[$key]['type'], 'integer:') === 0) || (strpos($object->fields[$key]['type'], 'sellist:') === 0) || !empty($object->fields[$key]['arrayofkeyval'])) {
-			if ($search[$key] == '-1' || ($search[$key] === '0' && (empty($object->fields[$key]['arrayofkeyval']) || !array_key_exists('0', $object->fields[$key]['arrayofkeyval'])))) {
+		$mode_search = (($object->isInt($object->fields[$class_key]) || $object->isFloat($object->fields[$class_key])) ? 1 : 0);
+		if ((strpos($object->fields[$class_key]['type'], 'integer:') === 0) || (strpos($object->fields[$class_key]['type'], 'sellist:') === 0) || !empty($object->fields[$class_key]['arrayofkeyval'])) {
+			if ($search[$key] == '-1' || ($search[$key] === '0' && (empty($object->fields[$class_key]['arrayofkeyval']) || !array_key_exists('0', $object->fields[$class_key]['arrayofkeyval'])))) {
 				$search[$key] = '';
 			}
 			$mode_search = 2;


### PR DESCRIPTION
# FIX: warehouse list: broken status filter

Due to an oversight, the status filter on the warehouse list was not working.

The field inside the class is called `statut` but the filter is named `status`. It seems there are plans to rename it but for now, we just have to treat this special case correctly.