### PR TITLE
Fix transfert stock float number

### DIFF
--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -344,7 +344,7 @@ if ($action == "transfert_stock" && !$cancel && $usercanupdatestock) {
 		$error++;
 		$action = 'transfert';
 	}
-	if (!GETPOSTINT("nbpiece")) {
+	if (!GETPOST("nbpiece")) {
 		setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("NumberOfUnit")), null, 'errors');
 		$error++;
 		$action = 'transfert';


### PR DESCRIPTION
I have copy @eldy fix for stock correction and apply it to stock transfert
if you type 0.545 as number of pieces to transfert, Dolibarr trigger error " Error Field Required"   

and $nbpiece is filter in next lines with :
```php
$nbpiece = price2num(GETPOST("nbpiece", 'alphanohtml'));
```