### PR TITLE
FIX: Sort Stock To Date on PMP

### DIFF
--- a/htdocs/product/stock/stockatdate.php
+++ b/htdocs/product/stock/stockatdate.php
@@ -497,7 +497,7 @@ if ($mode == 'future') {
 	print_liste_field_titre('VirtualStock', $_SERVER["PHP_SELF"], '', $param, '', '', $sortfield, $sortorder, 'right ', 'VirtualStockDesc');
 } else {
 	print_liste_field_titre($stocklabel, $_SERVER["PHP_SELF"], '', $param, '', '', $sortfield, $sortorder, 'right ');
-	print_liste_field_titre("EstimatedStockValue", $_SERVER["PHP_SELF"], "estimatedvalue", '', $param, '', $sortfield, $sortorder, 'right ', $langs->trans("AtDate"), 1);
+	print_liste_field_titre("EstimatedStockValue", $_SERVER["PHP_SELF"], "currentvalue", '', $param, '', $sortfield, $sortorder, 'right ', $langs->trans("AtDate"), 1);
 	print_liste_field_titre("EstimatedStockValueSell", $_SERVER["PHP_SELF"], "", '', $param, '', $sortfield, $sortorder, 'right ', $langs->trans("AtDate"), 1);
 	print_liste_field_titre('', $_SERVER["PHP_SELF"]);
 	print_liste_field_titre('CurrentStock', $_SERVER["PHP_SELF"], $fieldtosortcurrentstock, $param, '', '', $sortfield, $sortorder, 'right ');


### PR DESCRIPTION
Since this PR 
https://github.com/Dolibarr/dolibarr/pull/26481/files
"estimatedvalue" is no more use in SQL, the SQL aliase in now change to "currentvalue"

The field to srot on have to be change is the same way, or :
![image](https://github.com/user-attachments/assets/d1d1e99f-5550-4f82-bf50-80504b9ad972)
 
