### PR TITLE
FIX: tcpdf: prevent error with 'data:' URLs

### DIFF
--- a/htdocs/includes/tecnickcom/tcpdf/tcpdf.php
+++ b/htdocs/includes/tecnickcom/tcpdf/tcpdf.php
@@ -19226,10 +19226,14 @@ class TCPDF
 					break;
 				}
 				$imgsrc = $tag['attribute']['src'];
+				$reg = array(); // @CHANGE DOL support 'data:' URLs (tcpdf backport https://github.com/tecnickcom/TCPDF/pull/552)
 				if ($imgsrc[0] === '@') {
 					// data stream
 					$imgsrc = '@'.base64_decode(substr($imgsrc, 1));
 					$type = '';
+				} elseif (preg_match('@^data:image/([^;]*);base64,(.*)@', $imgsrc, $reg)) { // @CHANGE DOL support 'data:' URLs (tcpdf backport https://github.com/tecnickcom/TCPDF/pull/552)
+					$imgsrc = '@'.base64_decode($reg[2]); // @CHANGE DOL support 'data:' URLs (tcpdf backport https://github.com/tecnickcom/TCPDF/pull/552)
+					$type = $reg[1]; // @CHANGE DOL support 'data:' URLs (tcpdf backport https://github.com/tecnickcom/TCPDF/pull/552)
 				} else {
 					// @CHANGE LDR Add support for src="file://..." links
 					if (strpos($imgsrc, 'file://') === 0) {


### PR DESCRIPTION
# FIX error when generating a document with a 'data:' URL

Since Dolibarr 19.0, `data:` streams are disabled for security reasons, and rightly so.

However, this generates an error when copy/pasting images in WYSIWYG fields (use case in document public notes) as the pasted data is inserted as `<img src="data:...">`.

![Capture d’écran de 2025-04-01 11-01-09](https://github.com/user-attachments/assets/e8932dc0-d9b1-46ff-908e-9536eb885512)

Fortunately, later TCPDF versions included a way to handle those URLs without the need of opening a stream. I therefore propose to backport the corresponding TCPDF PR (https://github.com/tecnickcom/TCPDF/pull/552) to fix the problem while keeping global use of data URLs disabled.

The modified lines have been tagged `@CHANGE` for clarity in case of a future bump of TCPDF version.