### PR TITLE
Add quote arround value in extra field sql where

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13756,7 +13756,7 @@ function dolForgeCriteriaCallback($matches)
 		} elseif (is_numeric((string) $tmpescaped)) {	// it can be a float with a .
 			$tmpescaped = (float) $tmpescaped;
 		} else {
-			$tmpescaped = preg_replace('/[^a-z0-9_]/i', '', $tmpescaped);	// it can be a name of field or a substitution variable like '__NOW__'
+			$tmpescaped = "'".preg_replace('/[^a-z0-9_]/i', '', $tmpescaped)."'";	// it can be a name of field or a substitution variable like '__NOW__'
 		}
 	}
 


### PR DESCRIPTION
# Fix - Set extra field search value as string in dolForgeCriteriaCallback
Between 20.0.2 and 20.0.5 a new bug appears on the extra fields. String value for direct search are not parse as string, so SQL throws an error.

