### PR TITLE
FIX: invoice export models are incorrect after 20.0 migration

### DIFF
--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -5075,9 +5075,9 @@ function migrate_contractdet_rank()
  */
 function migrate_invoice_export_models()
 {
-	global $db, $conf, $langs;
+	global $db, $langs;
 
-	$lock = $conf->export->dir_output.'/invoice_models_migrated.lock';
+	$lock = DOL_DATA_ROOT.'/invoice_models_migrated.lock';
 	$firstInstallVersion = getDolGlobalString('MAIN_VERSION_FIRST_INSTALL', DOL_VERSION);
 	$migrationNeeded = versioncompare(explode('.', $firstInstallVersion, 3), array(20, 0, -5)) < 0 && !file_exists($lock);
 

--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -509,6 +509,13 @@ if (!GETPOST('action', 'aZ09') || preg_match('/upgrade/i', GETPOST('action', 'aZ
 				migrate_contractdet_rank();
 			}
 			*/
+
+			// Scripts for 20.0
+			$afterversionarray = explode('.', '19.0.9');
+			$beforeversionarray = explode('.', '20.0.9');
+			if (versioncompare($versiontoarray, $afterversionarray) >= 0 && versioncompare($versiontoarray, $beforeversionarray) <= 0) {
+				migrate_invoice_export_models();
+			}
 		}
 
 
@@ -5059,4 +5066,80 @@ function migrate_contractdet_rank()
 	if (!$resultstring) {
 		print '<tr class="trforrunsql" style=""><td class="wordbreak" colspan="4">'.$langs->trans("NothingToDo")."</td></tr>\n";
 	}
+}
+
+/**
+ * Invoice exports been shifted (facture_1 => facture_0, facture_2 => facture_1) in version 20, shift export models accordingly
+ *
+ * @return  void
+ */
+function migrate_invoice_export_models()
+{
+	global $db, $conf, $langs;
+
+	$lock = $conf->export->dir_output.'/invoice_models_migrated.lock';
+	$firstInstallVersion = getDolGlobalString('MAIN_VERSION_FIRST_INSTALL', DOL_VERSION);
+	$migrationNeeded = versioncompare(explode('.', $firstInstallVersion, 3), array(20, 0, -5)) < 0 && !file_exists($lock);
+
+	if (! $migrationNeeded) {
+		touch($lock);
+		return;
+	}
+
+	print '<tr class="trforrunsql"><td colspan="4">';
+	print '<b>'.$langs->trans('InvoiceExportModelsMigration')."</b><br>\n";
+
+	$db->begin();
+
+	$sql1 = "
+		UPDATE ".$db->prefix()."export_model
+		SET type = 'facture_0'
+		WHERE type = 'facture_1'
+	";
+
+	$resql1 = $db->query($sql1);
+
+	if (! $resql1) {
+		dol_print_error($db);
+		$db->rollback();
+		print '</td></tr>';
+		return;
+	}
+
+	$modified1 = $db->affected_rows($resql1);
+
+	print str_repeat('.', $modified1);
+
+	$db->free($resql1);
+
+	$sql2 = "
+		UPDATE ".$db->prefix()."export_model
+		SET type = 'facture_1'
+		WHERE type = 'facture_2'
+	";
+
+	$resql2 = $db->query($sql2);
+
+	if (! $resql2) {
+		dol_print_error($db);
+		$db->rollback();
+		print '</td></tr>';
+		return;
+	}
+
+	$modified2 = $db->affected_rows($resql2);
+
+	print str_repeat('.', $modified2);
+
+	$db->free($resql2);
+
+	if (empty($modified1 + $modified2)) {
+		print $langs->trans('NothingToDo');
+	}
+
+	$db->commit();
+
+	touch($lock);
+
+	echo '</td></tr>';
 }

--- a/htdocs/langs/en_US/install.lang
+++ b/htdocs/langs/en_US/install.lang
@@ -217,3 +217,4 @@ FunctionTest=Function test
 NodoUpgradeAfterDB=No action requested by external modules after upgrade of database
 NodoUpgradeAfterFiles=No action requested by external modules after upgrade of files or directories
 MigrationContractLineRank=Migrate Contract Line to use Rank (and enable Reorder)
+InvoiceExportModelsMigration=Migrate invoice export models


### PR DESCRIPTION
# FIX: invoice export models are incorrect after 20.0 migration

Commit [#5a5c7d5](https://github.com/Dolibarr/dolibarr/commit/5a5c7d52282bd350493bd71fa71026403a234711) has shifted invoice export index for it to be zero-based, since Dolibarr 20.0.

As a consequence, export models are applied incorrectly because the field `type` has not been modified accordingly.

Since those models are always shared between all entities (`entity` field defaults to `0` and is never modified), the migration only has to be run once and for all, so we put a lock file inside data dir to mark that.