### PR TITLE
Fix #33689 - missing rename

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -321,7 +321,7 @@ class Invoices extends DolibarrApi
 	/**
 	 * Create invoice object
 	 *
-	 * @param array $request_data   Request datas
+	 * @param array $request_data   Request data
 	 * @phan-param ?array<string,string> $request_data
 	 * @phpstan-param ?array<string,string> $request_data
 	 * @return int                  ID of invoice
@@ -331,8 +331,13 @@ class Invoices extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('facture', 'creer')) {
 			throw new RestException(403, "Insuffisant rights");
 		}
-		// Check mandatory fields
-		$request_data = $this->_validate($request_data);
+
+		if (!is_array($request_data)) {
+			$request_data = array();
+		}
+
+		// Check mandatory fields (not using output, only possible exception is important)
+		$this->_validate($request_data);
 
 		foreach ($request_data as $field => $value) {
 			if ($field === 'caller') {


### PR DESCRIPTION
# Fix #33689 - missing rename

Assignment to $result in code before fixing phan notice seem be an error, but in fact the assignment is useless and the code only expects a potential exception.