### PR TITLE
NEW: login page: button to toggle the visibility of the password

### DIFF
--- a/htdocs/core/tpl/login.tpl.php
+++ b/htdocs/core/tpl/login.tpl.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024       Charlene Benke          <charlene@patas-monkey.com>
+ * Copyright (C) 2025       Marc de Lima Lucio      <marc-dll@user.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -298,14 +299,30 @@ if ($disablenofollow) {
 
 <!-- Password -->
 <div class="trinputlogin">
-<div class="tagtd nowraponall center valignmiddle tdinputlogin">
+<div class="tagtd nowraponall center valignmiddle tdinputlogin" id="tdpasswordlogin">
 	<?php if (getDolGlobalString('MAIN_OPTIMIZEFORTEXTBROWSER')) {
 		?><label for="password" class="hidden"><?php echo $langs->trans("Password"); ?></label><?php
 	} ?>
 <!--<span class="span-icon-password">-->
 <span class="fa fa-key"></span>
 <input type="password" id="password" maxlength="128" placeholder="<?php echo $langs->trans("Password"); ?>" name="password" class="flat input-icon-password minwidth150" value="<?php echo dol_escape_htmltag($password); ?>" tabindex="2" autocomplete="<?php echo !getDolGlobalString('MAIN_LOGIN_ENABLE_PASSWORD_AUTOCOMPLETE') ? 'off' : 'on'; ?>" />
+<a href id="togglepassword" tabindex="3"><span class="fa fa-eye"></span></a>
 </div></div>
+<script nonce="<?= getNonce() ?>">
+	$(document).ready(function () {
+		$('#togglepassword').on('click', function () {
+			const $passwordInput = $('#password');
+
+			if ($passwordInput.is('[type=password]')) {
+				$passwordInput.attr('type', 'text');
+			} else {
+				$passwordInput.attr('type', 'password');
+			}
+
+			return false; // This prevents the click from reloading the page
+		});
+	});
+</script>
 <?php } ?>
 
 

--- a/htdocs/core/tpl/login.tpl.php
+++ b/htdocs/core/tpl/login.tpl.php
@@ -308,7 +308,7 @@ if ($disablenofollow) {
 <input type="password" id="password" maxlength="128" placeholder="<?php echo $langs->trans("Password"); ?>" name="password" class="flat input-icon-password minwidth150" value="<?php echo dol_escape_htmltag($password); ?>" tabindex="2" autocomplete="<?php echo !getDolGlobalString('MAIN_LOGIN_ENABLE_PASSWORD_AUTOCOMPLETE') ? 'off' : 'on'; ?>" />
 <a href id="togglepassword" tabindex="3"><span class="fa fa-eye"></span></a>
 </div></div>
-<script nonce="<?= getNonce() ?>">
+<script nonce="<?php echo getNonce(); ?>">
 	$(document).ready(function () {
 		$('#togglepassword').on('click', function () {
 			const $passwordInput = $('#password');

--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2004-2024	Laurent Destailleur			<eldy@users.sourceforge.net>
  * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2025		Marc de Lima Lucio			<marc-dll@user.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -3414,6 +3415,20 @@ if (getDolGlobalString('MAIN_LOGIN_BACKGROUND')) {
 .login_table .tdinputlogin input#username, .login_table .tdinputlogin input#password, .login_table .tdinputlogin input#securitycode {
 	font-size: 1.1em;
 }
+/* Serve as reference for icon that toggles showing the password */
+.login_table #tdpasswordlogin {
+	position: relative;
+}
+.login_table #tdpasswordlogin #togglepassword {
+	position: absolute;
+	top: 10px;
+	right: 5px;
+}
+.login_table #tdpasswordlogin #togglepassword .fa {
+	padding: 0 3px;
+	width: auto;
+}
+
 /* For the static info message */
 .login_main_home {
 	word-break: break-word;

--- a/htdocs/theme/md/style.css.php
+++ b/htdocs/theme/md/style.css.php
@@ -9,6 +9,7 @@
  * Copyright (C) 2021-2023  Anthony Berton          <anthony.berton@bb2a.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Frédéric France				<frederic.france@free.fr>
+ * Copyright (C) 2025		Marc de Lima Lucio			<marc-dll@user.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -3479,6 +3480,19 @@ form#login {
 .login_table .tdinputlogin .fa {
 	padding-left: 10px;
 	width: 14px;
+}
+/* Serve as reference for icon that toggles showing the password */
+.login_table #tdpasswordlogin {
+	position: relative;
+}
+.login_table #tdpasswordlogin #togglepassword {
+	position: absolute;
+	top: 10px;
+	right: 5px;
+}
+.login_table #tdpasswordlogin #togglepassword .fa {
+	padding: 0 3px;
+	width: auto;
 }
 
 .login_main_home {


### PR DESCRIPTION
# NEW: login page: button to toggle the visibility of the password

As is more and more popular, I propose adding to the login page a button to toggle the visibility of the password.

With theme `eldy`:
![DolLoginLD](https://github.com/user-attachments/assets/d61ac2bf-fb89-45b3-b45d-3e8d5f204807)


With theme `md`:
![DolLoginMD](https://github.com/user-attachments/assets/3a299244-705e-4cd4-bf1d-bbb8860e5d65)


Keyboard navigation has been taken into account, we can go from the password to the button with the `Tab` key.
