### PR TITLE
FIX: sql error when upgrading to 22 if session table is already in use

### DIFF
--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -199,7 +199,7 @@ UPDATE llx_product_customer_price_log SET date_begin = datec WHERE date_begin IS
 ALTER TABLE llx_accounting_bookkeeping ADD COLUMN ref VARCHAR(30) AFTER rowid;
 ALTER TABLE llx_accounting_bookkeeping_tmp ADD COLUMN ref VARCHAR(30) AFTER rowid;
 
-ALTER TABLE llx_session ADD COLUMN date_creation datetime NOT NULL AFTER session_variable;
+ALTER TABLE llx_session ADD COLUMN date_creation datetime NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER session_variable;
 
 ALTER TABLE llx_accounting_account ADD COLUMN centralized tinyint DEFAULT 0 NOT NULL AFTER active;
 UPDATE llx_accounting_account as acc SET acc.centralized = 1 WHERE acc.account_number in (SELECT value  FROM llx_const WHERE name IN (__ENCRYPT('ACCOUNTING_ACCOUNT_CUSTOMER')__,__ENCRYPT('ACCOUNTING_ACCOUNT_SUPPLIER')__,__ENCRYPT('SALARIES_ACCOUNTING_ACCOUNT_PAYMENT')__,__ENCRYPT('ACCOUNTING_ACCOUNT_EXPENSEREPORT')__));

--- a/htdocs/install/mysql/tables/llx_session-disabled.sql
+++ b/htdocs/install/mysql/tables/llx_session-disabled.sql
@@ -21,7 +21,7 @@ create table llx_session
 (
   session_id varchar(50) PRIMARY KEY,
   session_variable text,
-  date_creation datetime NOT NULL,
+  date_creation datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   last_accessed datetime NOT NULL,
   fk_user integer NOT NULL,
   remote_ip varchar(64) NULL,


### PR DESCRIPTION
If upgrading Dolibarr from a previous version, and sessions are already stored in db, an error will occurs : 

![image](https://github.com/user-attachments/assets/bf20a14a-49c2-4aa9-b2e2-f65b0ff25d2e)
