### PR TITLE
fix(user): wrong assigned user on agenda, and wrong backtopage

### DIFF
--- a/htdocs/user/agenda.php
+++ b/htdocs/user/agenda.php
@@ -164,7 +164,7 @@ $out = '';
 $permok = $user->hasRight('agenda', 'myactions', 'create');
 if ((!empty($objUser->id) || !empty($objcon->id)) && $permok) {
 	if (is_object($objUser) && get_class($objUser) == 'User') {
-		$out .= '&amp;originid='.$objUser->id.($objUser->id > 0 ? '&amp;userid='.$objUser->id : '').'&amp;backtopage='.urlencode($_SERVER['PHP_SELF'].($objUser->id > 0 ? '?userid='.$objUser->id : ''));
+		$out .= '&amp;originid='.$objUser->id.($objUser->id > 0 ? '&amp;assignedtouser='.$objUser->id : '').'&amp;backtopage='.urlencode($_SERVER['PHP_SELF'].($objUser->id > 0 ? '?id='.$objUser->id : ''));
 	}
 	$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '');
 	$out .= '&amp;datep='.dol_print_date(dol_now(), 'dayhourlog', 'tzuserrel');


### PR DESCRIPTION
# FIX|Fix wrong assigned user on agenda, and wrong backtopage
The correct backtopage param is "id" and not "userid". Same for assigning a user, it's assignedtouser not userid