### PR TITLE
 FIX public ticket layout for Safari on macOS

### DIFF
--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -518,7 +518,7 @@ $arrayofcss = array(getDolGlobalString('TICKET_URL_PUBLIC_INTERFACE', '/public/t
 llxHeaderTicket($langs->trans("CreateTicket"), "", 0, 0, $arrayofjs, $arrayofcss);
 
 
-print '<div class="ticketpublicarea ticketlargemargin centpercent">';
+print '<div class="ticketpublicarea ticketlargemargin">';
 
 if ($action != "infos_success") {
 	$formticket->withfromsocid = isset($socid) ? $socid : $user->socid;

--- a/htdocs/public/ticket/index.php
+++ b/htdocs/public/ticket/index.php
@@ -86,7 +86,7 @@ $arrayofcss = array(getDolGlobalString('TICKET_URL_PUBLIC_INTERFACE', '/public/t
 
 llxHeaderTicket($langs->trans('Tickets'), "", 0, 0, $arrayofjs, $arrayofcss);
 
-print '<div class="ticketpublicarea ticketlargemargin centpercent">';
+print '<div class="ticketpublicarea ticketlargemargin">';
 
 print '<p style="text-align: center">'.(getDolGlobalString("TICKET_PUBLIC_TEXT_HOME", '<span class="opacitymedium">'.$langs->trans("TicketPublicDesc")).'</span></p>').'</p>';
 print '<br>';

--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -197,7 +197,7 @@ if ($action == "view_ticketlist") {
 
 
 if ($action == "view_ticketlist") {
-	print '<div class="ticketpublicarealist ticketlargemargin centpercent">';
+	print '<div class="ticketpublicarealist ticketlargemargin">';
 
 	print '<br>';
 	if ($display_ticket_list) {
@@ -746,7 +746,7 @@ if ($action == "view_ticketlist") {
 
 	print '</div>';
 } else {
-	print '<div class="ticketpublicarea ticketlargemargin centpercent">';
+	print '<div class="ticketpublicarea ticketlargemargin">';
 
 	print '<p class="center opacitymedium">'.$langs->trans("TicketPublicMsgViewLogIn").'</p>';
 	print '<br>';

--- a/htdocs/public/ticket/view.php
+++ b/htdocs/public/ticket/view.php
@@ -245,7 +245,7 @@ llxHeaderTicket($langs->trans("Tickets"), "", 0, 0, $arrayofjs, $arrayofcss);
 if ($action == "view_ticket" || $action == "presend" || $action == "close" || $action == "confirm_public_close") {
 	if ($display_ticket) {
 		print '<!-- public view ticket -->';
-		print '<div class="ticketpublicarea ticketlargemargin centpercent">';
+		print '<div class="ticketpublicarea ticketlargemargin">';
 
 		// Confirmation close
 		if ($action == 'close') {
@@ -445,7 +445,7 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 		print '<br>';
 	} else {
 		print '<!-- public view ticket -->';
-		print '<div class="ticketpublicarea ticketlargemargin centpercent">';
+		print '<div class="ticketpublicarea ticketlargemargin">';
 
 		print '<div class="error">Not Allowed<br><a href="'.$_SERVER['PHP_SELF'].'?track_id='.$object->dao->track_id.(!empty($entity) && isModEnabled('multicompany') ? '?entity='.$entity : '').'" rel="nofollow noopener">'.$langs->trans('Back').'</a></div>';
 
@@ -453,7 +453,7 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 	}
 } else {
 	print '<!-- public view ticket -->';
-	print '<div class="ticketpublicarea ticketlargemargin centpercent">';
+	print '<div class="ticketpublicarea ticketlargemargin">';
 
 	print '<div class="center opacitymedium margintoponly marginbottomonly ticketlargemargin">'.$langs->trans("TicketPublicMsgViewLogIn").'</div>';
 


### PR DESCRIPTION
# FIX public ticket layout for Safari on macOS
On Safari 18.3.1 (macOS Sequoia) and also older Safari 15.6.1 (macOS Catalina) the public ticket layouts stretch out to the right, this adds a horizontal scroll and in some cases makes it difficult to use.

![Bug Safari ticket public index 2025-04-04](https://github.com/user-attachments/assets/eba24296-6aee-443b-90c0-ef9555d95026)
![Bug Safari ticket public create 2025-04-04](https://github.com/user-attachments/assets/ad8abfd4-f7fd-41a9-adfb-606671928cef)
![Bug Safari ticket public view 2025-04-04](https://github.com/user-attachments/assets/4bbebdec-c99d-4729-a686-b2c41d992ff9)

This fix removes the redundant `centpercent` class on the div using `ticketpublicarea` class. The `centpercent` class is already set on the parent div using the `publicnewticketform2` class, (`llxHeaderTicket`function). 

I have tested on Firefox and Edge/Chrome and haven't seen any regressions from this change.