### PR TITLE
FIX: exclude lines with type 9 from qties calculation in receptions …

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -450,7 +450,8 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 					if (is_array($order->lines) && count($order->lines) > 0) {
 						foreach ($order->lines as $orderline) {
 							// Exclude lines not qualified for shipment, similar code is found into calcAndSetStatusDispatch() for vendors
-							if (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $orderline->product_type > 0) {
+							if ((!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $orderline->product_type > 0) ||
+								$orderline->product_type == 9) {
 								continue;
 							}
 							if (isset($qtyordred[$orderline->fk_product])) {
@@ -529,7 +530,8 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 					if (is_array($order->lines) && count($order->lines) > 0) {
 						foreach ($order->lines as $orderline) {
 							// Exclude lines not qualified for shipment, similar code is found into calcAndSetStatusDispatch() for vendors
-							if (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $orderline->product_type > 0) {
+							if ((!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $orderline->product_type > 0) ||
+								$orderline->product_type == 9) {
 								continue;
 							}
 							$qtyordred[$orderline->fk_product] += $orderline->qty;

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3745,7 +3745,8 @@ class CommandeFournisseur extends CommonOrder
 					}
 					foreach ($this->lines as $line) {
 						// Exclude lines not qualified for shipment, similar code is found into interface_20_modWrokflow for customers
-						if (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $line->product_type > 0) {
+						if ((!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $line->product_type > 0) ||
+							$line->product_type == 9) {
 							continue;
 						}
 						if (array_key_exists($line->fk_product, $qtywished)) {


### PR DESCRIPTION
Exclude lines with type 9 from qties calculation in reception /shipment workflow

How to reproduce the bug : 
- set the increase stock on reception validate
- set STOCK_SUPPORTS_SERVICES = 1
- Activate the Workflow module, with WORKFLOW_ORDER_CLASSIFY_RECEIVED_RECEPTION  = 1
- use a free text line module like Subtotal
-  Create a supplier order with a product line and a title line
- Create the reception from the order, validate the reception. The order won't be classified.