### PR TITLE
FIX $object not initialised in extrafields_list_print for propals

### DIFF
--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -1782,8 +1782,13 @@ while ($i < $imaxinloop) {
 		$param .= "&search_option=".urlencode($search_option);
 	}
 
-	$object->fetch($obj->rowid);
-	$object->fetch_optionals();
+	$object->id = $obj->rowid;
+	$object->ref = $obj->ref;
+	$object->ref_customer = $obj->ref_client;	
+	$object->note_public = $obj->note_public;	
+	$object->note_private = $obj->note_private;
+	$object->statut = $obj->status;	
+	$object->status = $obj->status;
 
 	$companystatic->id = $obj->socid;
 	$companystatic->name = $obj->name;

--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -572,6 +572,7 @@ if (isModEnabled('margin')) {
 $companystatic = new Societe($db);
 $projectstatic = new Project($db);
 $formcompany = new FormCompany($db);
+$userstatic = new User($db);
 
 $varpage = empty($contextpage) ? $_SERVER["PHP_SELF"] : $contextpage;
 $selectedfields = $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage); // This also change content of $arrayfields
@@ -890,9 +891,6 @@ if (!$resql) {
 	dol_print_error($db);
 	exit;
 }
-
-$object = new Propal($db);
-$userstatic = new User($db);
 
 if ($socid > 0) {
 	$soc = new Societe($db);

--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -1784,10 +1784,10 @@ while ($i < $imaxinloop) {
 
 	$object->id = $obj->rowid;
 	$object->ref = $obj->ref;
-	$object->ref_customer = $obj->ref_client;	
-	$object->note_public = $obj->note_public;	
+	$object->ref_customer = $obj->ref_client;
+	$object->note_public = $obj->note_public;
 	$object->note_private = $obj->note_private;
-	$object->statut = $obj->status;	
+	$object->statut = $obj->status;
 	$object->status = $obj->status;
 
 	$companystatic->id = $obj->socid;

--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -891,7 +891,7 @@ if (!$resql) {
 	exit;
 }
 
-$objectstatic = new Propal($db);
+$object = new Propal($db);
 $userstatic = new User($db);
 
 if ($socid > 0) {
@@ -1782,13 +1782,8 @@ while ($i < $imaxinloop) {
 		$param .= "&search_option=".urlencode($search_option);
 	}
 
-	$objectstatic->id = $obj->rowid;
-	$objectstatic->ref = $obj->ref;
-	$objectstatic->ref_customer = $obj->ref_client;
-	$objectstatic->note_public = $obj->note_public;
-	$objectstatic->note_private = $obj->note_private;
-	$objectstatic->statut = $obj->status;
-	$objectstatic->status = $obj->status;
+	$object->fetch($obj->rowid);
+	$object->fetch_optionals();
 
 	$companystatic->id = $obj->socid;
 	$companystatic->name = $obj->name;
@@ -1812,7 +1807,7 @@ while ($i < $imaxinloop) {
 	$multicurrency_totalInvoicedHT = 0;
 	$multicurrency_totalInvoicedTTC = 0;
 
-	$TInvoiceData = $objectstatic->InvoiceArrayList($obj->rowid);
+	$TInvoiceData = $object->InvoiceArrayList($object->id);
 
 	if (!empty($TInvoiceData)) {
 		foreach ($TInvoiceData as $invoiceData) {
@@ -1832,8 +1827,8 @@ while ($i < $imaxinloop) {
 
 	$marginInfo = array();
 	if ($with_margin_info) {
-		$objectstatic->fetch_lines();
-		$marginInfo = $formmargin->getMarginInfosArray($objectstatic);
+		$object->fetch_lines();
+		$marginInfo = $formmargin->getMarginInfosArray($object);
 		$total_ht += $obj->total_ht;
 		$total_margin += $marginInfo['total_margin'];
 	}
@@ -1844,16 +1839,16 @@ while ($i < $imaxinloop) {
 			print '<div class="box-flex-container kanban">';
 		}
 		// Output Kanban
-		$objectstatic->thirdparty = $companystatic;
+		$object->thirdparty = $companystatic;
 		$userstatic->fetch($obj->fk_user_author);
 		$arrayofparams = array('selected' => in_array($object->id, $arrayofselected), 'authorlink' => $userstatic->getNomUrl(-2), 'projectlink' => $projectstatic->getNomUrl(2));
-		print $objectstatic->getKanbanView('', $arrayofparams);
+		print $object->getKanbanView('', $arrayofparams);
 		if ($i == ($imaxinloop - 1)) {
 			print '</div>';
 			print '</td></tr>';
 		}
 	} else {
-		print '<tr data-rowid="'.$objectstatic->id.'" class="oddeven status'.$objectstatic->status.((getDolGlobalInt('MAIN_FINISHED_LINES_OPACITY') == 1 && $obj->status > 1) ? ' opacitymedium' : '').'">';
+		print '<tr data-rowid="'.$object->id.'" class="oddeven status'.$object->status.((getDolGlobalInt('MAIN_FINISHED_LINES_OPACITY') == 1 && $obj->status > 1) ? ' opacitymedium' : '').'">';
 
 		// Action column
 		if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
@@ -1877,7 +1872,7 @@ while ($i < $imaxinloop) {
 			print '<table class="nobordernopadding"><tr class="nocellnopadd">';
 			// Picto + Ref
 			print '<td class="nobordernopadding nowraponall">';
-			print $objectstatic->getNomUrl(1, '', '', 0, 1, (isset($conf->global->PROPAL_LIST_SHOW_NOTES) ? $conf->global->PROPAL_LIST_SHOW_NOTES : 1));
+			print $object->getNomUrl(1, '', '', 0, 1, (isset($conf->global->PROPAL_LIST_SHOW_NOTES) ? $conf->global->PROPAL_LIST_SHOW_NOTES : 1));
 			print '</td>';
 			// Warning
 			$warnornote = '';
@@ -1894,7 +1889,7 @@ while ($i < $imaxinloop) {
 			$filename = dol_sanitizeFileName($obj->ref);
 			$filedir = $conf->propal->multidir_output[$obj->propal_entity].'/'.dol_sanitizeFileName($obj->ref);
 			$urlsource = $_SERVER['PHP_SELF'].'?id='.$obj->rowid;
-			print $formfile->getDocumentsLink($objectstatic->element, $filename, $filedir);
+			print $formfile->getDocumentsLink($object->element, $filename, $filedir);
 			print '</td></tr></table>';
 
 			print "</td>\n";
@@ -2410,7 +2405,7 @@ while ($i < $imaxinloop) {
 
 		// Status
 		if (!empty($arrayfields['p.fk_statut']['checked'])) {
-			print '<td class="nowrap center">'.$objectstatic->getLibStatut(5).'</td>';
+			print '<td class="nowrap center">'.$object->getLibStatut(5).'</td>';
 			if (!$i) {
 				$totalarray['nbfield']++;
 			}

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -36,6 +36,8 @@ if (empty($extrafieldsobjectkey) && is_object($object)) {
 	$extrafieldsobjectkey = $object->table_element;
 }
 
+$object->fetch_optionals();
+
 // Loop to show all columns of extrafields from $obj, $extrafields and $db
 if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafieldsobjectkey])) {	// $extrafieldsobject is the $object->table_element like 'societe', 'socpeople', ...
 	if (array_key_exists('label', $extrafields->attributes[$extrafieldsobjectkey]) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label']) && count($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
@@ -69,7 +71,6 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 				}
 				// If field is a computed field, we make computation to get value
 				if ($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key]) {
-					$objectoffield = $object; // For compatibility with the computed formula
 					$value = dol_eval((string) $extrafields->attributes[$extrafieldsobjectkey]['computed'][$key], 1, 1, '2');
 					if (is_numeric(price2num($value)) && $extrafields->attributes[$extrafieldsobjectkey]['totalizable'][$key]) {
 						$obj->$tmpkey = price2num($value);

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -36,8 +36,6 @@ if (empty($extrafieldsobjectkey) && is_object($object)) {
 	$extrafieldsobjectkey = $object->table_element;
 }
 
-$object->fetch_optionals();
-
 // Loop to show all columns of extrafields from $obj, $extrafields and $db
 if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafieldsobjectkey])) {	// $extrafieldsobject is the $object->table_element like 'societe', 'socpeople', ...
 	if (array_key_exists('label', $extrafields->attributes[$extrafieldsobjectkey]) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label']) && count($extrafields->attributes[$extrafieldsobjectkey]['label'])) {

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -69,6 +69,7 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 				}
 				// If field is a computed field, we make computation to get value
 				if ($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key]) {
+					$objectoffield = $object; // For compatibility with the computed formula. $objectoffield is exported by dol_eval().
 					$value = dol_eval((string) $extrafields->attributes[$extrafieldsobjectkey]['computed'][$key], 1, 1, '2');
 					if (is_numeric(price2num($value)) && $extrafields->attributes[$extrafieldsobjectkey]['totalizable'][$key]) {
 						$obj->$tmpkey = price2num($value);


### PR DESCRIPTION
# FIX $object not initialised in extrafields_list_print for propals

`$object->id` or `$objectoffield->id` is not initialized in propals.

Removing $objectstatic, using $object populated from fetch instead.
Adding $object->fetch_optionals in extrafields_list_print_fields.tpl.php

See #33706  for more informations.