### PR TITLE
Fix warning when creating a reception

### DIFF
--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -1246,7 +1246,7 @@ if ($action == 'create') {
 
 				// Qty already received
 				print '<td class="center">';
-				$quantityDelivered = $objectsrc->receptions[$line->id];
+				$quantityDelivered = $objectsrc->receptions[$line->id] ?? 0;
 				if (! array_key_exists($line->id, $arrayofpurchaselinealreadyoutput)) {	// Add test to avoid to show qty twice
 					print $quantityDelivered;
 				}


### PR DESCRIPTION
This should fix warnings appearing when creating a reception and no quantity received. I made the easiest fix, maybe this is not the best way, keep me in touch if changes needed.
![Capture d’écran du 2025-04-08 09-38-01](https://github.com/user-attachments/assets/c63d0ff9-fcd9-40ee-9af4-80d515f867ab)
