### PR TITLE
fix(mail): lot of 0 after amount of total_ht and total_ttc

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9344,6 +9344,7 @@ function getCommonSubstitutionArray($outputlangs, $onlykey = 0, $exclude = null,
 
 		// For backward compatibility
 		if ($onlykey != 2) {
+			if (is_object($object)) $object->update_price();
 			$substitutionarray['__TOTAL_TTC__']    = is_object($object) ? $object->total_ttc : '';
 			$substitutionarray['__TOTAL_HT__']     = is_object($object) ? $object->total_ht : '';
 			$substitutionarray['__TOTAL_VAT__']    = is_object($object) ? (isset($object->total_vat) ? $object->total_vat : $object->total_tva) : '';


### PR DESCRIPTION
# FIX|Fix lot of 0 after amount of total_ht and total_ttc
I've added update_price before substitution because there was a lot of 0 after the price in the email.