### PR TITLE
NEW Add contacts and addresses to templace invoices / factures recurrentes with MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -718,6 +718,7 @@ if ($id == DICT_TYPE_CONTACT) {
 		'commande' => img_picto('', 'order', 'class="pictofixedwidth"').$langs->trans('Order'),
 		'shipping' => img_picto('', 'dolly', 'class="pictofixedwidth"') . $langs->trans('Shipment'),
 		'facture' => img_picto('', 'bill', 'class="pictofixedwidth"').$langs->trans('Bill'),
+		'facturerec' => img_picto('', 'bill', 'class="pictofixedwidth"').$langs->trans('RecurringInvoiceTemplate'),
 		'fichinter' => img_picto('', 'intervention', 'class="pictofixedwidth"').$langs->trans('InterventionCard'),
 		'contrat' => img_picto('', 'contract', 'class="pictofixedwidth"').$langs->trans('Contract'),
 		'ticket' => img_picto('', 'ticket', 'class="pictofixedwidth"').$langs->trans('Ticket'),

--- a/htdocs/compta/facture/card-rec.php
+++ b/htdocs/compta/facture/card-rec.php
@@ -312,6 +312,8 @@ if (empty($reshook)) {
 			$oldinvoice->fetch(GETPOSTINT('facid'));
 
 			$onlylines = GETPOST('toselect', 'array');
+			$object->origin = 'facture';
+			$object->origin_id = $oldinvoice->id;
 
 			$result = $object->create($user, $oldinvoice->id, 0, $onlylines);
 			if ($result > 0) {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1439,6 +1439,8 @@ if (empty($reshook)) {
 
 				// Source facture
 				$object->fac_rec = GETPOSTINT('fac_rec');
+				$object->origin = 'facturerec';
+				$object->origin_id = $object->fac_rec;
 
 				$id = $object->create($user); // This include recopy of links from recurring invoice and recurring invoice lines
 			}

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -526,6 +526,24 @@ class FactureRec extends CommonInvoice
 					}
 				}
 
+				// Propagate contacts
+				if (!$error && $this->id && getDolGlobalString('MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN') && !empty($this->origin) && !empty($this->origin_id)) {   // Get contact from origin object
+					$originforcontact = $this->origin;
+					$originidforcontact = $this->origin_id;
+					$sqlcontact = "SELECT ctc.code, ctc.source, ec.fk_socpeople FROM ".MAIN_DB_PREFIX."element_contact as ec, ".MAIN_DB_PREFIX."c_type_contact as ctc";
+					$sqlcontact .= " WHERE element_id = ".((int) $originidforcontact)." AND ec.fk_c_type_contact = ctc.rowid AND ctc.element = '".$this->db->escape($originforcontact)."'";
+
+					$resqlcontact = $this->db->query($sqlcontact);
+					if ($resqlcontact) {
+						while ($objcontact = $this->db->fetch_object($resqlcontact)) {
+							//print $objcontact->code.'-'.$objcontact->source.'-'.$objcontact->fk_socpeople."\n";
+							$this->add_contact($objcontact->fk_socpeople, $objcontact->code, $objcontact->source); // May failed because of duplicate key or because code of contact type does not exists for new object
+						}
+					} else {
+						dol_print_error($resqlcontact);
+					}
+				}
+
 				if (!$error) {
 					$result = $this->insertExtraFields();
 					if ($result < 0) {
@@ -893,7 +911,7 @@ class FactureRec extends CommonInvoice
 		$sqlef = "DELETE FROM $ef WHERE fk_object IN (SELECT rowid FROM ".$main." WHERE fk_facture = ".((int) $rowid).")";
 		$sql = "DELETE FROM ".MAIN_DB_PREFIX."facturedet_rec WHERE fk_facture = ".((int) $rowid);
 
-		if ($this->db->query($sqlef) && $this->db->query($sql)) {
+		if ($this->db->query($sqlef) && $this->db->query($sql) && $this->delete_linked_contact() >= 0) {
 			$sql = "DELETE FROM ".MAIN_DB_PREFIX."facture_rec WHERE rowid = ".((int) $rowid);
 			dol_syslog($sql);
 			if ($this->db->query($sql)) {

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -526,23 +526,24 @@ class FactureRec extends CommonInvoice
 					}
 				}
 
-				// Propagate contacts
-				if (!$error && $this->id && getDolGlobalString('MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN') && !empty($this->origin) && !empty($this->origin_id)) {   // Get contact from origin object
-					$originforcontact = $this->origin;
-					$originidforcontact = $this->origin_id;
-					$sqlcontact = "SELECT ctc.code, ctc.source, ec.fk_socpeople FROM ".MAIN_DB_PREFIX."element_contact as ec, ".MAIN_DB_PREFIX."c_type_contact as ctc";
-					$sqlcontact .= " WHERE element_id = ".((int) $originidforcontact)." AND ec.fk_c_type_contact = ctc.rowid AND ctc.element = '".$this->db->escape($originforcontact)."'";
+			// Propagate contacts
+			if (!$error && $this->id && getDolGlobalString('MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN') && !empty($this->origin) && !empty($this->origin_id)) {   // Get contact from origin object
+				$originforcontact = $this->origin;
+				$originidforcontact = $this->origin_id;
+				
+				$sqlcontact = "SELECT ctc.code, ctc.source, ec.fk_socpeople FROM ".MAIN_DB_PREFIX."element_contact as ec, ".MAIN_DB_PREFIX."c_type_contact as ctc";
+				$sqlcontact .= " WHERE element_id = ".((int) $originidforcontact)." AND ec.fk_c_type_contact = ctc.rowid AND ctc.element = '".$this->db->escape($originforcontact)."'";
 
-					$resqlcontact = $this->db->query($sqlcontact);
-					if ($resqlcontact) {
-						while ($objcontact = $this->db->fetch_object($resqlcontact)) {
-							//print $objcontact->code.'-'.$objcontact->source.'-'.$objcontact->fk_socpeople."\n";
-							$this->add_contact($objcontact->fk_socpeople, $objcontact->code, $objcontact->source); // May failed because of duplicate key or because code of contact type does not exists for new object
-						}
-					} else {
-						dol_print_error($resqlcontact);
+				$resqlcontact = $this->db->query($sqlcontact);
+				if ($resqlcontact) {
+					while ($objcontact = $this->db->fetch_object($resqlcontact)) {
+						//print $objcontact->code.'-'.$objcontact->source.'-'.$objcontact->fk_socpeople."\n";
+						$this->add_contact($objcontact->fk_socpeople, $objcontact->code, $objcontact->source); // May failed because of duplicate key or because code of contact type does not exists for new object
 					}
+				} else {
+					dol_print_error($this->db);
 				}
+			}
 
 				if (!$error) {
 					$result = $this->insertExtraFields();

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -530,7 +530,7 @@ class FactureRec extends CommonInvoice
 				if (!$error && $this->id && getDolGlobalString('MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN') && !empty($this->origin) && !empty($this->origin_id)) {   // Get contact from origin object
 					$originforcontact = $this->origin;
 					$originidforcontact = $this->origin_id;
-					
+
 					$sqlcontact = "SELECT ctc.code, ctc.source, ec.fk_socpeople FROM ".MAIN_DB_PREFIX."element_contact as ec, ".MAIN_DB_PREFIX."c_type_contact as ctc";
 					$sqlcontact .= " WHERE element_id = ".((int) $originidforcontact)." AND ec.fk_c_type_contact = ctc.rowid AND ctc.element = '".$this->db->escape($originforcontact)."'";
 

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -526,24 +526,24 @@ class FactureRec extends CommonInvoice
 					}
 				}
 
-			// Propagate contacts
-			if (!$error && $this->id && getDolGlobalString('MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN') && !empty($this->origin) && !empty($this->origin_id)) {   // Get contact from origin object
-				$originforcontact = $this->origin;
-				$originidforcontact = $this->origin_id;
-				
-				$sqlcontact = "SELECT ctc.code, ctc.source, ec.fk_socpeople FROM ".MAIN_DB_PREFIX."element_contact as ec, ".MAIN_DB_PREFIX."c_type_contact as ctc";
-				$sqlcontact .= " WHERE element_id = ".((int) $originidforcontact)." AND ec.fk_c_type_contact = ctc.rowid AND ctc.element = '".$this->db->escape($originforcontact)."'";
+				// Propagate contacts
+				if (!$error && $this->id && getDolGlobalString('MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN') && !empty($this->origin) && !empty($this->origin_id)) {   // Get contact from origin object
+					$originforcontact = $this->origin;
+					$originidforcontact = $this->origin_id;
+					
+					$sqlcontact = "SELECT ctc.code, ctc.source, ec.fk_socpeople FROM ".MAIN_DB_PREFIX."element_contact as ec, ".MAIN_DB_PREFIX."c_type_contact as ctc";
+					$sqlcontact .= " WHERE element_id = ".((int) $originidforcontact)." AND ec.fk_c_type_contact = ctc.rowid AND ctc.element = '".$this->db->escape($originforcontact)."'";
 
-				$resqlcontact = $this->db->query($sqlcontact);
-				if ($resqlcontact) {
-					while ($objcontact = $this->db->fetch_object($resqlcontact)) {
-						//print $objcontact->code.'-'.$objcontact->source.'-'.$objcontact->fk_socpeople."\n";
-						$this->add_contact($objcontact->fk_socpeople, $objcontact->code, $objcontact->source); // May failed because of duplicate key or because code of contact type does not exists for new object
+					$resqlcontact = $this->db->query($sqlcontact);
+					if ($resqlcontact) {
+						while ($objcontact = $this->db->fetch_object($resqlcontact)) {
+							//print $objcontact->code.'-'.$objcontact->source.'-'.$objcontact->fk_socpeople."\n";
+							$this->add_contact($objcontact->fk_socpeople, $objcontact->code, $objcontact->source); // May failed because of duplicate key or because code of contact type does not exists for new object
+						}
+					} else {
+						dol_print_error($this->db);
 					}
-				} else {
-					dol_print_error($this->db);
 				}
-			}
 
 				if (!$error) {
 					$result = $this->insertExtraFields();

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -633,8 +633,9 @@ class Facture extends CommonInvoice
 			$this->statut = self::STATUS_DRAFT;	// deprecated
 
 			$this->linked_objects = $_facrec->linkedObjectsIds;
-			// We do not add link to template invoice or next invoice will be linked to all generated invoices
-			//$this->linked_objects['facturerec'][0] = $this->fac_rec;
+			// If we do not remove factures, all generated invoices will be linked together
+			unset($this->linked_objects['facture']);
+			$this->linked_objects['facturerec'][0] = $this->fac_rec;
 
 			// For recurring invoices, update date and number of last generation of recurring template invoice, before inserting new invoice
 			if ($_facrec->frequency > 0) {

--- a/htdocs/compta/facture/contact.php
+++ b/htdocs/compta/facture/contact.php
@@ -35,6 +35,7 @@ require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/invoice.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
+require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture-rec.class.php';
 if (isModEnabled('project')) {
 	require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 }
@@ -55,13 +56,18 @@ $ref    = GETPOST('ref', 'alpha');
 $lineid = GETPOSTINT('lineid');
 $socid  = GETPOSTINT('socid');
 $action = GETPOST('action', 'aZ09');
+$object_rec   = GETPOSTINT('object_rec');
 
 // Security check
 if ($user->socid) {
 	$socid = $user->socid;
 }
 
-$object = new Facture($db);
+if ($object_rec) {
+	$object = new FactureRec($db);
+} else {
+	$object = new Facture($db);
+}
 // Load object
 if ($id > 0 || !empty($ref)) {
 	$ret = $object->fetch($id, $ref, '', 0, getDolGlobalBool('INVOICE_USE_SITUATION'));
@@ -112,7 +118,7 @@ if (empty($reshook)) {
 		$result = $object->delete_contact($lineid);
 
 		if ($result >= 0) {
-			header("Location: ".$_SERVER['PHP_SELF']."?id=".$object->id);
+			header("Location: ".$_SERVER['PHP_SELF']."?id=".$object->id.($object_rec ? '&object_rec=1': '') );
 			exit;
 		} else {
 			dol_print_error($db);
@@ -144,7 +150,11 @@ if ($id > 0 || !empty($ref)) {
 	if ($object->fetch($id, $ref) > 0) {
 		$object->fetch_thirdparty();
 
-		$head = facture_prepare_head($object);
+		if ($object_rec) {
+			$head = invoice_rec_prepare_head($object);
+		} else {
+			$head = facture_prepare_head($object);
+		}
 
 		$totalpaid = $object->getSommePaiement();
 
@@ -164,20 +174,12 @@ if ($id > 0 || !empty($ref)) {
 		if (isModEnabled('project')) {
 			$langs->load("projects");
 			$morehtmlref .= '<br>';
-			if (0) {
-				$morehtmlref .= img_picto($langs->trans("Project"), 'project', 'class="pictofixedwidth"');
-				if ($action != 'classify') {
-					$morehtmlref .= '<a class="editfielda" href="'.$_SERVER['PHP_SELF'].'?action=classify&token='.newToken().'&id='.$object->id.'">'.img_edit($langs->transnoentitiesnoconv('SetProject')).'</a> ';
-				}
-				$morehtmlref .= $form->form_project($_SERVER['PHP_SELF'].'?id='.$object->id, $object->socid, (string) $object->fk_project, ($action == 'classify' ? 'projectid' : 'none'), 0, 0, 0, 1, '', 'maxwidth300');
-			} else {
-				if (!empty($object->fk_project)) {
-					$proj = new Project($db);
-					$proj->fetch($object->fk_project);
-					$morehtmlref .= $proj->getNomUrl(1);
-					if ($proj->title) {
-						$morehtmlref .= '<span class="opacitymedium"> - '.dol_escape_htmltag($proj->title).'</span>';
-					}
+			if (!empty($object->fk_project)) {
+				$proj = new Project($db);
+				$proj->fetch($object->fk_project);
+				$morehtmlref .= $proj->getNomUrl(1);
+				if ($proj->title) {
+					$morehtmlref .= '<span class="opacitymedium"> - '.dol_escape_htmltag($proj->title).'</span>';
 				}
 			}
 		}

--- a/htdocs/compta/facture/contact.php
+++ b/htdocs/compta/facture/contact.php
@@ -70,7 +70,11 @@ if ($object_rec) {
 }
 // Load object
 if ($id > 0 || !empty($ref)) {
-	$ret = $object->fetch($id, $ref, '', 0, getDolGlobalBool('INVOICE_USE_SITUATION'));
+	if ($object_rec) {
+		$ret = $object->fetch($id, $ref);
+	} else {
+		$ret = $object->fetch($id, $ref, '', 0, getDolGlobalBool('INVOICE_USE_SITUATION'));
+	}
 }
 // Initialize a technical object to manage hooks of page. Note that conf->hooks_modules contains an array of hook context
 $hookmanager->initHooks(array('invoicecontactcard', 'globalcard'));

--- a/htdocs/compta/facture/contact.php
+++ b/htdocs/compta/facture/contact.php
@@ -118,7 +118,7 @@ if (empty($reshook)) {
 		$result = $object->delete_contact($lineid);
 
 		if ($result >= 0) {
-			header("Location: ".$_SERVER['PHP_SELF']."?id=".$object->id.($object_rec ? '&object_rec=1': '') );
+			header("Location: ".$_SERVER['PHP_SELF']."?id=".$object->id.($object_rec ? '&object_rec=1': ''));
 			exit;
 		} else {
 			dol_print_error($db);

--- a/htdocs/core/lib/invoice.lib.php
+++ b/htdocs/core/lib/invoice.lib.php
@@ -262,6 +262,17 @@ function invoice_rec_prepare_head($object)
 	$head[$h][2] = 'card';
 	$h++;
 
+	if (!getDolGlobalString('MAIN_DISABLE_CONTACTS_TAB')) {
+		$nbContact = count($object->liste_contact(-1, 'internal')) + count($object->liste_contact(-1, 'external'));
+		$head[$h][0] = DOL_URL_ROOT.'/compta/facture/contact.php?id='.urlencode((string) ($object->id)).'&object_rec=1';
+		$head[$h][1] = $langs->trans('ContactsAddresses');
+		if ($nbContact > 0) {
+			$head[$h][1] .= '<span class="badge marginleftonlyshort">'.$nbContact.'</span>';
+		}
+		$head[$h][2] = 'contact';
+		$h++;
+	}
+
 	$head[$h][0] = DOL_URL_ROOT . '/compta/facture/list.php?search_fk_fac_rec_source=' . $object->id;
 	$head[$h][1] = $langs->trans('InvoicesGeneratedFromRec');
 	//count facture rec

--- a/htdocs/core/tpl/contacts.tpl.php
+++ b/htdocs/core/tpl/contacts.tpl.php
@@ -121,6 +121,9 @@ if ($permission) {
 	if (empty($hideaddcontactforuser)) {
 		?>
 	<form class="tagtr impair nohover" action="<?php echo $_SERVER["PHP_SELF"].'?id='.$object->id; ?>" method="POST">
+		<?php if ($object_rec) { ?>
+			<input type="hidden" name='object_rec' value='1' />
+		<?php } ?>
 		<input type="hidden" name="token" value="<?php echo newToken(); ?>" />
 		<input type="hidden" name="id" value="<?php echo $object->id; ?>" />
 		<input type="hidden" name="action" value="addcontact" />
@@ -170,6 +173,9 @@ if ($permission) {
 		?>
 
 	<form class="tagtr pair nohover" action="<?php echo $_SERVER["PHP_SELF"].'?id='.$object->id; ?>" method="POST">
+		<?php if ($object_rec) { ?>
+			<input type="hidden" name='object_rec' value='1' />
+		<?php } ?>
 		<input type="hidden" name="token" value="<?php echo newToken(); ?>" />
 		<input type="hidden" name="id" value="<?php echo $object->id; ?>" />
 		<input type="hidden" name="action" value="addcontact" />
@@ -321,11 +327,14 @@ $arrayfields = array(
 );
 
 $param = 'id='.$object->id.'&mainmenu=home';
-
+$param .= ($object_rec ? '&object_rec=1': '');
 
 // Show list of contact links
 
 print '<form method="POST" id="searchFormList" action="'.$_SERVER["PHP_SELF"].'">';
+if ($object_rec) {
+	print '<input type="hidden" name="object_rec" value="1" />';
+}
 print '<input type="hidden" name="token" value="'.newToken().'">';
 print '<input type="hidden" name="formfilteraction" id="formfilteraction" value="list">';
 print '<input type="hidden" name="action" value="list">';
@@ -366,6 +375,7 @@ foreach ($list as $entry) {
 		$href .= '?id='.((int) $object->id);
 		$href .= '&action=deletecontact&token='.newToken();
 		$href .= '&lineid='.((int) $entry->id);
+		$href .= ($object_rec ? '&object_rec=1': '');
 
 		print '<td class="center">';
 		print '<a href="'.$href.'">';

--- a/htdocs/core/tpl/contacts.tpl.php
+++ b/htdocs/core/tpl/contacts.tpl.php
@@ -34,6 +34,7 @@
  * @var Translate $langs
  * @var User $user
  * @var ?string $permission
+ * @var ?int $object_rec
  */
 '
 @phan-var-force ?CommonObject $object

--- a/htdocs/core/tpl/contacts.tpl.php
+++ b/htdocs/core/tpl/contacts.tpl.php
@@ -40,6 +40,7 @@
 @phan-var-force ?CommonObject $object
 @phan-var-force ?CommonObject $objectsrc
 @phan-var-force ?string $permission
+@phan-var-force ?int $object_rec
 ';
 
 // Protection to avoid direct call of template

--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -246,3 +246,9 @@ ALTER TABLE llx_contratdet DROP COLUMN remise;
 ALTER TABLE llx_extrafields ADD COLUMN aiprompt text;
 
 ALTER TABLE llx_menu ADD COLUMN showtopmenuinframe integer DEFAULT 0;
+
+-- Add contacts to reccurent / templates invoices / factures
+INSERT INTO llx_c_type_contact (element, source, code, libelle, active, module, position)
+SELECT 'facturerec', source, code, libelle, active, module, position
+FROM llx_c_type_contact
+WHERE element = 'facture';


### PR DESCRIPTION
# NEW Add contacts and addresses to templace invoices / factures recurrentes
With this PR, it will allow to add contacts and addresses to recurring invoices / templates invoices / facture-rec

On invoice generation, contacts will be propagated, only with the use of the MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN constant.
Need to discuss about the point of having MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN for invoice-rec. If we set contacts in invoice-rec, it is not for the template but for the generated invoices. So we might want to have it by default, without this const.

We have the problematic about the duplication of entering twice the Dict->Contact Type, one for invoice and one for invoice-rec.
I didn't found any automation allowing to enter it only once. I don't think that it is really a problem for users willing to use this functionnality to think to enter a new type both in invoice and invoice-rec. It is only once in many days, and if it is not working, it will think of that or quickly find the solution in a forum post / wiki / other.
Automation of that could come in the future.

This propagation is working ( from template to invoice ) and ( from invoice to template )

This PR add the link between generated invoices and their template, without the link to the other generated invoices.

I took the liberty to remove a `if (0) {...}` block that was lurking since v17