### PR TITLE
add param nocreateEcmFile

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1185,10 +1185,11 @@ class FormFile
 	 *  @param	 int			$addfilterfields	Add the line with filters
 	 *  @param	 int			$disablecrop		Disable crop feature on images (-1 = auto, prefer to set it explicitely to 0 or 1)
 	 *  @param	 string			$moreattrondiv		More attributes on the div for responsive. Example 'style="height:280px; overflow: auto;"'
+	 * 	@param	 int			$noCreateEcmFile	Manages ECM file creation
 	 * 	@return	 int								Return integer <0 if KO, nb of files shown if OK
 	 *  @see list_of_autoecmfiles()
 	 */
-	public function list_of_documents($filearray, $object, $modulepart, $param = '', $forcedownload = 0, $relativepath = '', $permonobject = 1, $useinecm = 0, $textifempty = '', $maxlength = 0, $title = '', $url = '', $showrelpart = 0, $permtoeditline = -1, $upload_dir = '', $sortfield = '', $sortorder = 'ASC', $disablemove = 1, $addfilterfields = 0, $disablecrop = -1, $moreattrondiv = '')
+	public function list_of_documents($filearray, $object, $modulepart, $param = '', $forcedownload = 0, $relativepath = '', $permonobject = 1, $useinecm = 0, $textifempty = '', $maxlength = 0, $title = '', $url = '', $showrelpart = 0, $permtoeditline = -1, $upload_dir = '', $sortfield = '', $sortorder = 'ASC', $disablemove = 1, $addfilterfields = 0, $disablecrop = -1, $moreattrondiv = '', $noCreateEcmFile = 0)
 	{
 		// phpcs:enable
 		global $user, $conf, $langs, $hookmanager, $form;
@@ -1314,7 +1315,7 @@ class FormFile
 
 			// Get list of files stored into database for same relative directory
 			if ($relativedir) {
-				completeFileArrayWithDatabaseInfo($filearray, $relativedir);
+				completeFileArrayWithDatabaseInfo($filearray, $relativedir, $noCreateEcmFile);
 
 				//var_dump($sortfield.' - '.$sortorder);
 				if ($sortfield && $sortorder) {	// If $sortfield is for example 'position_name', we will sort on the property 'position_name' (that is concat of position+name)

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -250,7 +250,6 @@ function dol_dir_list_in_database($path, $filter = "", $excludefilter = null, $s
 	} else {
 		$sql .= " AND filepath = '".$db->escape($path)."'";
 	}
-
 	$resql = $db->query($sql);
 	if ($resql) {
 		$file_list = array();
@@ -310,9 +309,10 @@ function dol_dir_list_in_database($path, $filter = "", $excludefilter = null, $s
  *
  * @param	array	$filearray			Array of files obtained using dol_dir_list
  * @param	string	$relativedir		Relative dir from DOL_DATA_ROOT
+ * @param	int		$noCreateEcmFile	Manages ECM file creation
  * @return	void
  */
-function completeFileArrayWithDatabaseInfo(&$filearray, $relativedir)
+function completeFileArrayWithDatabaseInfo(&$filearray, $relativedir, $noCreateEcmFile = 0)
 {
 	global $conf, $db, $user;
 
@@ -359,7 +359,6 @@ function completeFileArrayWithDatabaseInfo(&$filearray, $relativedir)
 				break;
 			}
 		}
-
 		if (!$found) {    // This happen in transition toward version 6, or if files were added manually into os dir.
 			$filearray[$key]['position'] = '999999'; // File not indexed are at end. So if we add a file, it will not replace an existing position
 			$filearray[$key]['cover'] = 0;
@@ -368,7 +367,7 @@ function completeFileArrayWithDatabaseInfo(&$filearray, $relativedir)
 
 			$rel_filename = preg_replace('/^'.preg_quote(DOL_DATA_ROOT, '/').'/', '', $filearray[$key]['fullname']);
 
-			if (!preg_match('/([\\/]temp[\\/]|[\\/]thumbs|\.meta$)/', $rel_filename)) {     // If not a tmp file
+			if (!preg_match('/([\\/]temp[\\/]|[\\/]thumbs|\.meta$)/', $rel_filename) && $noCreateEcmFile == 0) {     // If not a tmp file
 				dol_syslog("list_of_documents We found a file called '".$filearray[$key]['name']."' not indexed into database. We add it");
 				include_once DOL_DOCUMENT_ROOT.'/ecm/class/ecmfiles.class.php';
 				$ecmfile = new EcmFiles($db);

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -345,7 +345,6 @@ class EcmFiles extends CommonObject
 		$sql .= ')';
 
 		$this->db->begin();
-
 		$resql = $this->db->query($sql);
 		if (!$resql) {
 			$error++;


### PR DESCRIPTION
When the list_of_documents() method is called to display.
And one of the files has already been saved, we get a warning `DB_ERROR_RECORD_ALREADY_EXISTS `
With this additional` $noCreateEcmFile` parameter, we prevent the `$ecmfile->create() `of the `EcmFiles` object from being launched.