### PR TITLE
FIX : Add link to lines for a particular month in accountancy/expensereport/index.php

### DIFF
--- a/htdocs/accountancy/expensereport/index.php
+++ b/htdocs/accountancy/expensereport/index.php
@@ -347,7 +347,24 @@ for ($i = 1; $i <= 12; $i++) {
 	if ($j > 12) {
 		$j -= 12;
 	}
-	print '<td width="60" class="right">'.$langs->trans('MonthShort'.str_pad((string) $j, 2, '0', STR_PAD_LEFT)).'</td>';
+	$cursormonth = $j;
+	if ($cursormonth > 12) {
+		$cursormonth -= 12;
+	}
+	$cursoryear = ($cursormonth < getDolGlobalInt('SOCIETE_FISCAL_MONTH_START', 1)) ? $y + 1 : $y;
+	$tmp = dol_getdate(dol_get_last_day($cursoryear, $cursormonth, 'gmt'), false, 'gmt');
+
+	print '<td width="60" class="right">';
+	if (!empty($tmp['mday'])) {
+		$param = 'search_date_startday=1&search_date_startmonth='.$cursormonth.'&search_date_startyear='.$cursoryear;
+		$param .= '&search_date_endday='.$tmp['mday'].'&search_date_endmonth='.$tmp['mon'].'&search_date_endyear='.$tmp['year'];
+		print '<a href="'.DOL_URL_ROOT.'/accountancy/expensereport/lines.php?'.$param.'">';
+	}
+	print $langs->trans('MonthShort'.str_pad((string) $j, 2, '0', STR_PAD_LEFT));
+	if (!empty($tmp['mday'])) {
+		print '</a>';
+	}
+	print '</td>';
 }
 print '<td width="60" class="right"><b>'.$langs->trans("Total").'</b></td></tr>';
 


### PR DESCRIPTION
# Fix Link to accountancy expensereport lines

On accountancy/customer/index.php and accountancy/supplier/index.php, the header of the second table contains months. These months are links to the related /lines.php, with prefilled filters.
![customer_index](https://github.com/user-attachments/assets/d4bb4914-16b1-45a9-b613-27dc4d3e815a)


This is missing on accountancy/expensereport/index.php
![expensereport_index](https://github.com/user-attachments/assets/0687c9db-dfc8-4276-8457-18816711aa15)

This PR fixes this.

