### PR TITLE
FIX : constant PAYMENTBYBANKTRANSFER_ADDDAYS was never saved

### DIFF
--- a/htdocs/admin/paymentbybanktransfer.php
+++ b/htdocs/admin/paymentbybanktransfer.php
@@ -103,7 +103,9 @@ if ($action == "set") {
 		if (!($res > 0)) {
 			$error++;
 		}
-	} elseif (!$error) {
+	}
+
+	if (!$error) {
 		$db->commit();
 		setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
 	} else {


### PR DESCRIPTION
# FIX constant PAYMENTBYBANKTRANSFER_ADDDAYS was never saved

On page htdocs/admin/paymentbybanktransfer.php, it would be impossible to save a value for constant PAYMENTBYBANKTRANSFER_ADDDAYS. Moreover, if the user would set all values, none would be saved.

This is the case in DLB 14, 18 and develop, and probably versions between.

The $db->commit() was in a elseif() condition, and was never called when PAYMENTBYBANKTRANSFER_ADDDAYS const was set.

This PR fixes this.




