### PR TITLE
FIX: prelevement order list: handle case of use by banktransfer module

### DIFF
--- a/htdocs/compta/prelevement/orders_list.php
+++ b/htdocs/compta/prelevement/orders_list.php
@@ -152,7 +152,11 @@ if (($massaction == "delete" || ($action == 'delete' && $confirm == 'yes')) && $
 }
 $objectclass = 'BonPrelevement';
 $objectlabel = 'BonPrelevement';
-$uploaddir = $conf->prelevement->dir_output;
+if ($type == 'bank-transfer') {
+	$uploaddir = $conf->paymentbybanktransfer->dir_output;
+} else {
+	$uploaddir = $conf->prelevement->dir_output;
+}
 include DOL_DOCUMENT_ROOT.'/core/actions_massactions.inc.php';
 
 /*


### PR DESCRIPTION
# FIX: prelevement order list: handle case of use by banktransfer module

The list of prelevement orders is also used by the banktransfert module. In the latter case, it fails if the prelevement module is disabled as it tries to use its document directory to handle massactions.

This happens since Dolibarr 19.0, when mass-action handling in this page has begun using factorized code.