### PR TITLE
NEW hidden conf for api contrat putLine endpoint to only return the line

### DIFF
--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -450,8 +450,81 @@ class Contracts extends DolibarrApi
 		);
 
 		if ($updateRes > 0) {
-			$result = $this->get($id);
-			unset($result->line);
+			if (getDolGlobalInt('API_CONTRAT_PUTLINE_OUTPUT_LINE_ONLY')) {
+				$result = $this->contractLine;
+				$result->fetch($id);
+				foreach ([
+					'array_languages',
+					'contacts_ids',
+					'linked_objects',
+					'linkedObjectsIds',
+					'canvas',
+					'user',
+					'origin',
+					'origin_id',
+					'ref_ext',
+					'status',
+					'country_id',
+					'country_code',
+					'state_id',
+					'region_id',
+					'barcode_type',
+					'barcode_type_coder',
+					'mode_reglement_id',
+					'cond_reglement_id',
+					'demand_reason_id',
+					'transport_mode_id',
+					'shipping_method_id',
+					'model_pdf',
+					'last_main_doc',
+					'fk_bank',
+					'fk_account',
+					'lines',
+					'name',
+					'firstname',
+					'lastname',
+					'date_creation',
+					'date_validation',
+					'date_modification',
+					'date_cloture',
+					'user_author',
+					'user_creation',
+					'user_creation_id',
+					'user_valid',
+					'user_validation',
+					'user_validation_id',
+					'fk_user_creat',
+					'fk_user_modif',
+					'specimen',
+					'fk_unit',
+					'date_debut_prevue',
+					'date_debut_reel',
+					'date_fin_prevue',
+					'date_fin_reel',
+					'weight',
+					'weight_units',
+					'width',
+					'width_units',
+					'length',
+					'length_units',
+					'surface',
+					'surface_units',
+					'volume',
+					'volume_units',
+					'multilangs',
+					'desc',
+					'product',
+					'fk_product_type',
+					'type',
+					'libelle'
+						 ] as $fieldToUnset) {
+					unset($result->{$fieldToUnset});
+				}
+			}
+			else {
+				$result = $this->get($id);
+				unset($result->line);
+			}
 			return $this->_cleanObjectDatas($result);
 		}
 

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -453,7 +453,7 @@ class Contracts extends DolibarrApi
 			if (getDolGlobalInt('API_CONTRAT_PUTLINE_OUTPUT_LINE_ONLY')) {
 				$result = $this->contractLine;
 				$result->fetch($id);
-				foreach ([
+				foreach (array(
 					'array_languages',
 					'contacts_ids',
 					'linked_objects',
@@ -517,11 +517,10 @@ class Contracts extends DolibarrApi
 					'fk_product_type',
 					'type',
 					'libelle'
-						 ] as $fieldToUnset) {
+						 ) as $fieldToUnset) {
 					unset($result->{$fieldToUnset});
 				}
-			}
-			else {
+			} else {
 				$result = $this->get($id);
 				unset($result->line);
 			}

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -451,13 +451,15 @@ class Contracts extends DolibarrApi
 
 		if ($updateRes > 0) {
 			if (getDolGlobalInt('API_CONTRAT_PUTLINE_OUTPUT_LINE_ONLY')) {
-				$result = $this->contractLine;
-				$result->fetch($id);
+				$result = new ContratLigne($this->db);
+				$result->fetch($lineid);
 				foreach (array(
 					'array_languages',
 					'contacts_ids',
 					'linked_objects',
 					'linkedObjectsIds',
+					'actiontypecode',
+					'module',
 					'canvas',
 					'user',
 					'origin',
@@ -474,6 +476,7 @@ class Contracts extends DolibarrApi
 					'cond_reglement_id',
 					'demand_reason_id',
 					'transport_mode_id',
+					'shipping_method',
 					'shipping_method_id',
 					'model_pdf',
 					'last_main_doc',
@@ -493,6 +496,12 @@ class Contracts extends DolibarrApi
 					'user_valid',
 					'user_validation',
 					'user_validation_id',
+					'user_modification',
+					'user_modification_id',
+					'cond_reglement_supplier_id',
+					'deposit_percent',
+					'retained_warranty_fk_cond_reglement',
+					'date_commande',
 					'fk_user_creat',
 					'fk_user_modif',
 					'specimen',
@@ -507,6 +516,8 @@ class Contracts extends DolibarrApi
 					'width_units',
 					'length',
 					'length_units',
+					'height',
+					'height_units',
 					'surface',
 					'surface_units',
 					'volume',
@@ -515,6 +526,8 @@ class Contracts extends DolibarrApi
 					'desc',
 					'product',
 					'fk_product_type',
+					'warehouse_id',
+					'totalpaid',
 					'type',
 					'libelle'
 						 ) as $fieldToUnset) {


### PR DESCRIPTION
# NEW hidden conf to enable sparse output for Contracts::putLine endpoint

When contracts have thousands of lines, the putLine endpoint becomes unwieldy because it returns the whole contract with every call, which is not a problem when you have smaller contracts.

This PR introduces a hidden conf to change this behavior and return only the modified line (and also remove attributes that are not set on the ContratLigne object when fetching it).

#### Off-topic
Unfortunately, I was unable to run the pre-commit hook because of unsatisfied dependencies; I am going to fix this, but I need to upgrade my distro first; in the meantime, I'm happy to fix problems with this PR manually.