### PR TITLE
FIX Extend late search option for open and awaiting supplier orders

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3465,6 +3465,7 @@ class CommandeFournisseur extends CommonOrder
 				$response->label = $langs->trans("SuppliersOrdersAwaitingReception");
 				$response->labelShort = $langs->trans("AwaitingReception");
 				$response->url = DOL_URL_ROOT.'/fourn/commande/list.php?search_status=3,4&mainmenu=commercial&leftmenu=orders_suppliers';
+				$response->url_late = DOL_URL_ROOT.'/fourn/commande/list.php?mainmenu=commercial&leftmenu=orders_suppliers&search_option=recv_late';
 			}
 
 			while ($obj = $this->db->fetch_object($resql)) {

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -149,6 +149,9 @@ $search_option = GETPOST('search_option', 'alpha');
 if ($search_option == 'late') {
 	$search_status = '1,2';
 }
+if ($search_option == 'recv_late') {
+	$search_status = '3,4';
+}
 
 $diroutputmassaction = $conf->fournisseur->commande->dir_output.'/temp/massgeneration/'.$user->id;
 
@@ -1358,7 +1361,7 @@ if ($resql) {
 	}
 	// alert on late date
 	$moreforfilter .= '<div class="divsearchfield">';
-	$moreforfilter .= $langs->trans('Alert').' <input type="checkbox" name="search_option" value="late"'.($search_option == 'late' ? ' checked' : '').'>';
+	$moreforfilter .= $langs->trans('Alert').' <input type="checkbox" name="search_option" value="'.(($search_status == '3,4') ? 'recv_late' : 'late').'"'.((array_search($search_option,array('late','recv_late')) !== false) ? ' checked' : '').'>';
 	$moreforfilter .= '</div>';
 	$parameters = array();
 	$reshook = $hookmanager->executeHooks('printFieldPreListTitle', $parameters, $object, $action); // Note that $action and $object may have been modified by hook

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -1361,7 +1361,7 @@ if ($resql) {
 	}
 	// alert on late date
 	$moreforfilter .= '<div class="divsearchfield">';
-	$moreforfilter .= $langs->trans('Alert').' <input type="checkbox" name="search_option" value="'.(($search_status == '3,4') ? 'recv_late' : 'late').'"'.((array_search($search_option,array('late','recv_late')) !== false) ? ' checked' : '').'>';
+	$moreforfilter .= $langs->trans('Alert').' <input type="checkbox" name="search_option" value="'.(($search_status == '3,4') ? 'recv_late' : 'late').'"'.((array_search($search_option, array('late','recv_late')) !== false) ? ' checked' : '').'>';
 	$moreforfilter .= '</div>';
 	$parameters = array();
 	$reshook = $hookmanager->executeHooks('printFieldPreListTitle', $parameters, $object, $action); // Note that $action and $object may have been modified by hook


### PR DESCRIPTION
On Dolibarr main (dashboard) screen, a small dashboard box shows supplier orders on two lines:

* Open supplier orders / late open supplier orders
* Awaiting supplier orders / late awaiting supplier orders

If the user clicks on the "late awaiting supplier orders", he/she is lead to a supplier order list with pre-defined 'late' checkbox. However, checking this box implies a filter on this list to only show 'validated' and 'approved' late orders. This is not what is expected. The user cannot change the status filter to 'ordered' and 'partially received' and keep the 'late' checkbox on because the 'late' checkbox takes precedence and re-defines the status filter with 'validated' and 'approved'.

To kind of fix this, the late checkbox shall behave differently depending on the status filter, so that it shows either 'approved' and 'validated' late orders OR 'ordered' and 'partially received' by renaming the checkbox in the HTML form as either 'late' in the first case or 'recv_late' for the second case.
Therefore the url_late link in the dashboard box for awaiting case is redefined to point to the right result list.