### PR TITLE
FIX compute pending amount on debit or credit request

### DIFF
--- a/htdocs/compta/facture/prelevement.php
+++ b/htdocs/compta/facture/prelevement.php
@@ -718,13 +718,14 @@ if ($object->id > 0) {
 	// For which amount ?
 
 	$sql = "SELECT SUM(pfd.amount) as amount";
-	$sql .= " FROM ".MAIN_DB_PREFIX."prelevement_demande as pfd";
+	$sql .= " FROM ".$db->prefix()."prelevement_demande as pfd";
+	$sql .= " LEFT JOIN ".$db->prefix()."prelevement_lignes as pl ON pfd.fk_prelevement_bons = pl.fk_prelevement_bons";
 	if ($type == 'bank-transfer') {
 		$sql .= " WHERE fk_facture_fourn = ".((int) $object->id);
 	} else {
 		$sql .= " WHERE fk_facture = ".((int) $object->id);
 	}
-	$sql .= " AND pfd.traite = 0";
+	$sql .= " AND (pl.statut IS NULL OR pl.statut = 0)";
 	$sql .= " AND pfd.type = 'ban'";
 
 	$resql = $db->query($sql);
@@ -752,7 +753,7 @@ if ($object->id > 0) {
 	}
 
 	// Add a transfer request
-	if ($object->statut > $object::STATUS_DRAFT && $object->paye == 0 && $num == 0) {
+	if ($object->statut > $object::STATUS_DRAFT && $object->paye == 0) {
 		if ($resteapayer > 0) {
 			if ($user_perms) {
 				$remaintopaylesspendingdebit = $resteapayer - $pending;
@@ -860,7 +861,7 @@ if ($object->id > 0) {
 	} else {
 		$sql .= " WHERE fk_facture = ".((int) $object->id);
 	}
-	$sql .= " AND pfd.traite = 0";
+	$sql .= " AND (pl.statut IS NULL OR pl.statut = 0)";
 	$sql .= " AND pfd.type = 'ban'";
 	$sql .= " ORDER BY pfd.date_demande DESC";
 


### PR DESCRIPTION
FIX compute pending amount on debit or credit request

On debit request the computed pending amount was incorrect.

**Before**
The calculation of the amount took into account unprocessed requests.
The "unprocessed" status (pdf.traite=0) is only when the request in not in the "llx_demande_lignes" table.
The debit request line is not created in database but some debit request are always in progress (status = 0).

**After**
The calculation of the amount took into account unprocessed and processed requests.
The "unprocessed" status in not the good way to take into account debit request are in progress : a line exist in "llx_demande_lignes" whose status is 0.
When the status is "2" (paid) or "3" (rejected), there is a payment in the linked invoice, so we don't need and the amount is removed from the calculation of remain to pay.

**=> This fix is also for customer credit requests**