### PR TITLE
PERF: hidden var to limit list of invoices for credit note list

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5244,6 +5244,11 @@ class Facture extends CommonInvoice
 		}
 		$sql .= " ORDER BY f.ref";
 
+		if (getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED', 0) > 0) {
+			$sql .= " DESC"; //order by
+			$sql .= " LIMIT " . getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED');
+		}
+
 		dol_syslog(get_class($this)."::list_qualified_avoir_invoices", LOG_DEBUG);
 		$resql = $this->db->query($sql);
 		if ($resql) {

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5244,7 +5244,7 @@ class Facture extends CommonInvoice
 		}
 		$sql .= " ORDER BY f.ref";
 
-		if (getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED', 0) > 0) {
+		if (getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED') > 0) {
 			$sql .= " DESC"; //order by
 			$sql .= " LIMIT " . getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED');
 		}


### PR DESCRIPTION
That problem happens on race condition : you ave one customer with lot of invoices (easy with takepos and a lot of sells). For example 40.000 invoices.
Clic on make a credit note when a customer comes back ... your dolibarr url will become https://dolibarr/compta/facture/card.php?socid=xx&fac_avoir=193503&action=create

and takes 20 seconds (ore more, it depends on your browser) ... yes because html page could be +10Mbyte and 40.000 lines of entries like

```
<option value="193511" data-select2-id="46">XXXXX2504-41805 (Payée)</option>
```

so this PR add a hidden setup option to be able to limit that list ...