### PR TITLE
FIX: partial result on timespent list

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -1616,7 +1616,7 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 			$sql .= " AND pt.fk_projet IN (" . $db->sanitize($projectidforalltimes) . ")";
 		} elseif (!empty($allprojectforuser)) {
 			// Limit on on user
-			if (empty($search_user)) {
+			if (empty($search_user) && !empty($arrayfields['author']['checked'])) {
 				$search_user = $user->id;
 			}
 			if ($search_user > 0) {


### PR DESCRIPTION
If the column `author` isn't checked, there is only a partial answer while only the current user is selected by default and can't be changed. I propose to fix this by removing this filter if the column isn't checked.