### PR TITLE
NEW : Toggle Display of Supplier Invoices and Credit Notes on Payment Page

### DIFF
--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -76,6 +76,11 @@ $search_amount = GETPOST('search_amount', 'alpha'); // alpha because we must be 
 $search_company = GETPOST('search_company', 'alpha');
 $search_payment_num = GETPOST('search_payment_num', 'alpha');
 
+$displayAllInvoices = getDolGlobalInt('MAIN_PAIMENTS_SHOW_ALL_INVOICE_TYPES', 0);
+if (GETPOSTISSET('display-all-invoices')) {
+	$displayAllInvoices = GETPOSTINT('display-all-invoices');
+}
+
 $limit = GETPOSTINT('limit') ? GETPOST('limit') : $conf->liste_limit;
 $sortfield = GETPOST('sortfield', 'aZ09comma');
 $sortorder = GETPOST('sortorder', 'aZ09comma');
@@ -487,7 +492,8 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 
 				//Add js for AutoFill
 				print ' $(document).ready(function () {';
-				print ' 	$(".AutoFillAmount").on(\'click touchstart\', function(){
+				print ' 	$(".AutoFillAmount").on(\'click touchstart\', function(e){
+							e.preventDefault();
 							$("input[name="+$(this).data(\'rowname\')+"]").val($(this).data("value")).trigger("change");
 						});';
 				print '	});'."\n";
@@ -498,6 +504,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 			print '<form id="payment_form" name="addpaiement" action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 			print '<input type="hidden" name="token" value="'.newToken().'">';
 			print '<input type="hidden" name="action" value="add_paiement">';
+			print '<input type="hidden" name="display-all-invoices" value="'.(int) $displayAllInvoices.'">';
 			print '<input type="hidden" name="facid" value="'.$facid.'">';
 			print '<input type="hidden" name="ref_supplier" value="'.$obj->ref_supplier.'">';
 			print '<input type="hidden" name="socid" value="'.$obj->socid.'">';
@@ -560,11 +567,15 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 				$sql .= ' AND f.fk_soc = '.((int) $object->socid);
 				$sql .= ' AND f.paye = 0';
 				$sql .= ' AND f.fk_statut = 1'; // Status=0 => unvalidated, Status=2 => canceled
-				if ($object->type != FactureFournisseur::TYPE_CREDIT_NOTE) {
-					$sql .= ' AND f.type IN (0,1,3,5)'; // Standard invoice, replacement, deposit, situation
-				} else {
-					$sql .= ' AND f.type = 2'; // If paying back a credit note, we show all credit notes
+
+				if (!$displayAllInvoices) {
+					if ($object->type != FactureFournisseur::TYPE_CREDIT_NOTE) {
+						$sql .= ' AND f.type IN (0,1,3,5)'; // Standard invoice, replacement, deposit, situation
+					} else {
+						$sql .= ' AND f.type = 2'; // If paying back a credit note, we show all credit notes
+					}
 				}
+
 				// Group by because we have a total
 				$sql .= ' GROUP BY f.datef, f.ref, f.ref_supplier, f.rowid, f.type, f.total_ht, f.total_ttc,';
 				$sql .= ' f.multicurrency_code, f.multicurrency_tx, f.multicurrency_total_ht, f.multicurrency_total_tva, f.multicurrency_total_ttc,';
@@ -583,34 +594,62 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							//Add js for AutoFill
 							print "\n".'<script type="text/javascript">';
 							print ' $(document).ready(function () {';
-							print ' 	$(".AutoFillAmount").on(\'click touchstart\', function(){
+							print ' 	$(".AutoFillAmount").on(\'click touchstart\', function(e){
+											e.preventDefault();
 											$("input[name="+$(this).data(\'rowname\')+"]").val($(this).data("value"));
 										});';
 							print '	});'."\n";
 							print '	</script>'."\n";
 						}
 
-						print '<div class="div-table-responsive-no-min">';
-						print '<table class="tagtable liste'.($moreforfilter ? " listwithfilterbefore" : "").'">'."\n";
+						$moreHtmlRight = '';
+						if ($action=='create') {
+							$urlToggleDisplayMod = $_SERVER["PHP_SELF"].'?facid='.$facid.'&action='.$action.'&accountid='.$accountid.'&display-all-invoices=' . (intval(!$displayAllInvoices));
 
-						print '<tr class="liste_titre">';
-						print '<td>'.$langs->trans('Invoice').'</td>';
-						print '<td>'.$langs->trans('RefSupplier').'</td>';
-						print '<td class="center">'.$langs->trans('Date').'</td>';
-						print '<td class="center">'.$langs->trans('DateMaxPayment').'</td>';
-						if (isModEnabled("multicurrency")) {
-							print '<td>'.$langs->trans('Currency').'</td>';
-							print '<td class="right">'.$langs->trans('MulticurrencyAmountTTC').'</td>';
-							print '<td class="right">'.$langs->trans('MulticurrencyAlreadyPaid').'</td>';
-							print '<td class="right">'.$langs->trans('MulticurrencyRemainderToPay').'</td>';
-							print '<td class="center">'.$langs->trans('MulticurrencyPaymentAmount').'</td>';
+							if (empty($displayAllInvoices)) {
+								$btnTitle = $langs->trans('DisplayOtherInvoicesToo');
+								if ($object->type != FactureFournisseur::TYPE_CREDIT_NOTE) {
+									$btnTitle = $langs->trans('DisplayCreditNotesToo');
+								}
+							} else {
+								$btnTitle = $langs->trans('HideOtherInvoices');
+								if ($object->type != FactureFournisseur::TYPE_CREDIT_NOTE) {
+									$btnTitle = $langs->trans('HideCreditNotes');
+								}
+							}
+
+							$btnIcon = empty($displayAllInvoices) ? 'fa fa-eye' : 'fa fa-eye-slash';
+							$moreHtmlRight.= dolGetButtonTitle($btnTitle, '', $btnIcon, $urlToggleDisplayMod);
 						}
-						print '<td class="right">'.$langs->trans('AmountTTC').'</td>';
-						print '<td class="right">'.$langs->trans('AlreadyPaid').'</td>';
-						print '<td class="right">'.$langs->trans('RemainderToPay').'</td>';
-						print '<td class="center">'.$langs->trans('PaymentAmount').'</td>';
-						print '</tr>';
 
+						print_barre_liste($langs->trans('Invoices'), 0, $_SERVER["PHP_SELF"], [], '', '', '', $num, $num, 'bill', 0, $moreHtmlRight, '', 0, 0, 0, 1);
+
+
+						print '<div class="div-table-responsive-no-min">';
+						print '<table  id="fourn-invoices-paiments-list" class="tagtable liste">'."\n";
+						print '<thead>';
+						print '<tr class="liste_titre">';
+						print '<th>'.$langs->trans('Invoice').'</th>';
+						print '<th>'.$langs->trans('RefSupplier').'</th>';
+						if ($displayAllInvoices) {
+							print '<td>' . $langs->trans('Type') . '</td>';
+						}
+						print '<th class="center">'.$langs->trans('Date').'</th>';
+						print '<th class="center">'.$langs->trans('DateMaxPayment').'</th>';
+						if (isModEnabled("multicurrency")) {
+							print '<th>'.$langs->trans('Currency').'</th>';
+							print '<th class="right">'.$langs->trans('MulticurrencyAmountTTC').'</th>';
+							print '<th class="right">'.$langs->trans('MulticurrencyAlreadyPaid').'</th>';
+							print '<th class="right">'.$langs->trans('MulticurrencyRemainderToPay').'</th>';
+							print '<th class="center">'.$langs->trans('MulticurrencyPaymentAmount').'</th>';
+						}
+						print '<th class="right">'.$langs->trans('AmountTTC').'</th>';
+						print '<th class="right">'.$langs->trans('AlreadyPaid').'</th>';
+						print '<th class="right">'.$langs->trans('RemainderToPay').'</th>';
+						print '<th class="center">'.$langs->trans('PaymentAmount').'</th>';
+						print '</tr>';
+						print '</thead>';
+						print '<tbody>';
 						$total = 0;
 						$total_ttc = 0;
 						$totalrecu = 0;
@@ -620,7 +659,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							$objp = $db->fetch_object($resql);
 
 							$sign = 1;
-							if ($objp->type == FactureFournisseur::TYPE_CREDIT_NOTE) {
+							if ($objp->type == FactureFournisseur::TYPE_CREDIT_NOTE && !$displayAllInvoices) {
 								$sign = -1;
 							}
 
@@ -649,27 +688,39 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 								$multicurrency_remaintopay = price2num($invoice->multicurrency_total_ttc - $multicurrency_payment - $multicurrency_creditnotes - $multicurrency_deposits, 'MT');
 							}
 
-							print '<tr class="oddeven'.(($invoice->id == $facid) ? ' highlight' : '').'">';
+							print '<tr data-row-type="'.$objp->type.'" class="oddeven'.(($invoice->id == $facid) ? ' highlight' : '').'">';
 
 							// Ref
-							print '<td class="nowraponall">';
+							print '<td data-col="object-name" class="nowraponall">';
 							print $invoicesupplierstatic->getNomUrl(1);
 							print '</td>';
 
 							// Ref supplier
-							print '<td>'.$objp->ref_supplier.'</td>';
+							print '<td data-col="ref-supplier" >'.$objp->ref_supplier.'</td>';
+
+							// type
+							if ($displayAllInvoices) {
+								$typearray = [
+									FactureFournisseur::TYPE_STANDARD => $langs->trans("InvoiceStandard"),
+									FactureFournisseur::TYPE_REPLACEMENT => $langs->trans("InvoiceReplacement"),
+									FactureFournisseur::TYPE_CREDIT_NOTE => $langs->trans("InvoiceAvoir"),
+									FactureFournisseur::TYPE_DEPOSIT => $langs->trans("InvoiceDeposit"),
+								];
+								// Primary Secondary Success Danger Warning Info Light Dark status0 status1 status2 status3 status4 status5 status6 status7 status8 status9
+								print '<td class="center nowraponall">' . $typearray[$objp->type] . '</td>';
+							}
 
 							// Date
 							if ($objp->df > 0) {
-								print '<td class="center nowraponall">';
+								print '<td data-col="datef" data-col-value="'.$db->jdate($objp->df).'" class="center nowraponall">';
 								print dol_print_date($db->jdate($objp->df), 'day').'</td>';
 							} else {
-								print '<td class="center"><b>!!!</b></td>';
+								print '<td data-col="datef" data-col-value="" class="center"><b>!!!</b></td>';
 							}
 
 							// Date Max Payment
 							if ($objp->dlr > 0) {
-								print '<td class="center nowraponall">';
+								print '<td data-col="dater" data-col-value="'.$db->jdate($objp->dlr).'" class="center nowraponall">';
 								print dol_print_date($db->jdate($objp->dlr), 'day');
 
 								if ($invoice->hasDelay()) {
@@ -678,21 +729,21 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 
 								print '</td>';
 							} else {
-								print '<td class="center"><b>--</b></td>';
+								print '<td data-col="dater" data-col-value="" class="center"><b>--</b></td>';
 							}
 
 							// Multicurrency
 							if (isModEnabled("multicurrency")) {
 								// Currency
-								print '<td class="center">'.$objp->multicurrency_code."</td>\n";
+								print '<td data-col="multicurrency-code" class="center">'.$objp->multicurrency_code."</td>\n";
 
-								print '<td class="right">';
+								print '<td data-col="multicurrency-total-ttc" class="right">';
 								if ($objp->multicurrency_code && $objp->multicurrency_code != $conf->currency) {
 									print price($objp->multicurrency_total_ttc);
 								}
 								print '</td>';
 
-								print '<td class="right">';
+								print '<td data-col="multicurrency-payment" class="right">';
 								if ($objp->multicurrency_code && $objp->multicurrency_code != $conf->currency) {
 									print price($sign * $multicurrency_payment);
 									if ($multicurrency_creditnotes) {
@@ -704,23 +755,33 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 								}
 								print '</td>';
 
-								print '<td class="right">';
+								print '<td data-col="remain-to-pay" class="right">';
 								if ($objp->multicurrency_code && $objp->multicurrency_code != $conf->currency) {
 									print price($sign * (float) $multicurrency_remaintopay);
 								}
 								print '</td>';
 
-								print '<td class="right">';
+								print '<td data-col="remain-to-pay-multicurrency-amount" class="right">';
 								// Add remind multicurrency amount
 								$namef = 'multicurrency_amount_'.$objp->facid;
 								$nameRemain = 'multicurrency_remain_'.$objp->facid;
+
+								$min = $max = '';
+								if ($displayAllInvoices) {
+									if ($objp->type == FactureFournisseur::TYPE_CREDIT_NOTE) {
+										$max = ' max="0" ';
+									} else {
+										$min = ' min="0" ';
+									}
+								}
+
 								if ($objp->multicurrency_code && $objp->multicurrency_code != $conf->currency) {
 									if ($action != 'add_paiement') {
 										if (!empty($conf->use_javascript_ajax)) {
-											print img_picto("Auto fill", 'rightarrow', "class='AutoFillAmount' data-rowname='".$namef."' data-value='".($sign * (float) $multicurrency_remaintopay)."'");
+											print '<button class="btn-low-emphasis --btn-icon AutoFillAmount" data-rowname="'.$namef.'" data-value="'.($sign * (float) $multicurrency_remaintopay).'">'.img_picto("Auto fill", 'rightarrow');
 										}
 										print '<input type=hidden class="multicurrency_remain" name="'.$nameRemain.'" value="'.$multicurrency_remaintopay.'">';
-										print '<input type="text" size="8" class="multicurrency_amount" name="'.$namef.'" value="'.GETPOST($namef).'">';
+										print '<input '.$min.' '.$max.' type="number" step="any" size="8" class="multicurrency_amount" name="'.$namef.'" value="'.GETPOST($namef).'">';
 									} else {
 										print '<input type="text" size="8" name="'.$namef.'_disabled" value="'.GETPOST($namef).'" disabled>';
 										print '<input type="hidden" name="'.$namef.'" value="'.GETPOST($namef).'">';
@@ -772,12 +833,21 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							$namef = 'amount_'.$objp->facid;
 							$nameRemain = 'remain_'.$objp->facid;
 
+							$min = $max = '';
+							if ($displayAllInvoices) {
+								if ($objp->type == FactureFournisseur::TYPE_CREDIT_NOTE) {
+									$max = ' max="0" ';
+								} else {
+									$min = ' min="0" ';
+								}
+							}
+
 							if ($action != 'add_paiement') {
 								if (!empty($conf->use_javascript_ajax)) {
-									print img_picto("Auto fill", 'rightarrow', "class='AutoFillAmount' data-rowname='".$namef."' data-value='".($sign * (float) $remaintopay)."'");
+									print '<button  class="btn-low-emphasis --btn-icon AutoFillAmount" data-rowname="'.$namef.'" data-value="'.($sign * (float) $remaintopay).'">'.img_picto("Auto fill", 'rightarrow').'</button>';
 								}
 								print '<input type="hidden" class="remain" name="'.$nameRemain.'" value="'.$remaintopay.'">';
-								print '<input type="text" size="8" class="amount" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">'; // class is required to be used by javascript callForResult();
+								print '<input '.$max.' '.$min.' type="number" step="any" size="8" class="amount" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">'; // class is required to be used by javascript callForResult();
 							} else {
 								print '<input type="text" size="8" name="'.$namef.'_disabled" value="'.dol_escape_htmltag(GETPOST($namef)).'" disabled>';
 								print '<input type="hidden" class="amount" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">'; // class is required to be used by javascript callForResult();
@@ -792,10 +862,20 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							$totalrecudeposits += $deposits;
 							$i++;
 						}
+						print '</tbody>';
+
 						if ($i > 1) {
+							print '<tfoot>';
 							// Print total
 							print '<tr class="liste_total">';
-							print '<td colspan="4" class="left">'.$langs->trans('TotalTTC').':</td>';
+							$colspan = 4;
+
+							// type
+							if ($displayAllInvoices) {
+								$colspan++;
+							}
+
+							print '<td colspan="'.$colspan.'" class="left">'.$langs->trans('TotalTTC').':</td>';
 							if (isModEnabled("multicurrency")) {
 								print '<td>&nbsp;</td>';
 								print '<td>&nbsp;</td>';
@@ -815,6 +895,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							print '<td class="right"><b>'.price((float) price2num($total_ttc - $totalrecu - $totalrecucreditnote - $totalrecudeposits, 'MT')).'</b></td>';
 							print '<td class="center" id="result" style="font-weight: bold;"></td>'; // Autofilled
 							print "</tr>\n";
+							print '</tfoot>';
 						}
 						print "</table>\n";
 

--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -622,7 +622,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							$moreHtmlRight.= dolGetButtonTitle($btnTitle, '', $btnIcon, $urlToggleDisplayMod);
 						}
 
-						print_barre_liste($langs->trans('Invoices'), 0, $_SERVER["PHP_SELF"], [], '', '', '', $num, $num, 'bill', 0, $moreHtmlRight, '', 0, 0, 0, 1);
+						print_barre_liste($langs->trans('Invoices'), 0, $_SERVER["PHP_SELF"], '', '', '', '', $num, $num, 'bill', 0, $moreHtmlRight, '', 0, 0, 0, 1);
 
 
 						print '<div class="div-table-responsive-no-min">';

--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -626,7 +626,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 
 
 						print '<div class="div-table-responsive-no-min">';
-						print '<table  id="fourn-invoices-paiments-list" class="tagtable liste">'."\n";
+						print '<table  id="fourn-invoices-paiments-list" data-display-all-invoices="' . (int) $displayAllInvoices . '" class="tagtable liste" >'."\n";
 						print '<thead>';
 						print '<tr class="liste_titre">';
 						print '<th>'.$langs->trans('Invoice').'</th>';

--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -418,7 +418,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 	}
 	$resql = $db->query($sql);
 	if ($resql) {
-		$num = $db->num_rows($resql);
+		$totalnboflines = $num = $db->num_rows($resql);
 		if ($num) {
 			$obj = $db->fetch_object($resql);
 			$total = $obj->total;
@@ -622,7 +622,7 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							$moreHtmlRight.= dolGetButtonTitle($btnTitle, '', $btnIcon, $urlToggleDisplayMod);
 						}
 
-						print_barre_liste($langs->trans('Invoices'), 0, $_SERVER["PHP_SELF"], '', '', '', '', $num, $num, 'bill', 0, $moreHtmlRight, '', 0, 0, 0, 1);
+						print_barre_liste($langs->trans('Invoices'), 0, $_SERVER["PHP_SELF"], '', '', '', '', $num, $totalnboflines, 'bill', 0, $moreHtmlRight, '', 0, 0, 0, 1);
 
 
 						print '<div class="div-table-responsive-no-min">';

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -468,6 +468,11 @@ ValidateGeneratedDeposit=Validate the generated deposit
 DepositGenerated=Deposit generated
 ErrorCanOnlyAutomaticallyGenerateADepositFromProposalOrOrder=You can only automatically generate a deposit from a proposal or an order
 ErrorPaymentConditionsNotEligibleToDepositCreation=The chose payment conditions are not eligible for automatic deposit generation
+# Paiement page
+DisplayOtherInvoicesToo = Display other invoices too
+DisplayCreditNotesToo = Display credit notes too
+HideOtherInvoices = Hide other invoices
+HideCreditNotes = Hide credit notes
 # PaymentType
 PaymentTypeVIR=Bank transfer
 PaymentTypeShortVIR=Bank transfer


### PR DESCRIPTION
# NEW

Toggle Display of Supplier Invoices and Credit Notes on Payment Page

# Feature Description

This development introduces an enhancement to the supplier payment page in Dolibarr, allowing users to toggle the visibility of invoice types (invoices and credit notes) based on the current context.

## More specifically:

- When viewing credit notes, a "view" (eye) button allows users to also display related invoices for the same supplier.
- Conversely, when viewing invoices, clicking the same button reveals the credit notes associated with that supplier.

## Purpose

The main goal of this feature is to facilitate global payments, especially in the context of direct debit payments initiated by suppliers.

**In these scenarios:**

- **Suppliers often perform a single debit transaction that covers both invoices and credit notes.**
- The payment details are usually not itemized, making it difficult to allocate the payment correctly, so considering credit notes as refund is more accurate.
- With this enhancement, users can now see all relevant documents (invoices + credit notes) for a supplier, allowing them to record a single, comprehensive payment and allocate amounts correctly.


# notes
This CSS helps visually differentiate credit notes from invoices in the 'display all' view. It could be greate to include this css too?
```css
  #fourn-invoices-paiments-list[data-display-all-invoices="1"] tr[data-row-type="2"]{
    font-weight: bold;
 }
```