### PR TITLE
 NEW Supplier order - Introduce constant ORDER_SUPPLIER_METHOD_BY_DEFAULT to define order method

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2790,7 +2790,7 @@ if ($action == 'create') {
 
 			// Force mandatory order method
 			print '<tr><td class="fieldrequired">'.$langs->trans("OrderMode").'</td><td>';
-			$methodecommande = GETPOSTISSET("methodecommande", "alpha") ? GETPOST('methodecommande', 'alpha') : getDolGlobalString('ORDER_SUPPLIER_METHOD_BY_DEFAULT');
+			$methodecommande = GETPOSTISSET("methodecommande") ? GETPOST('methodecommande', 'alpha') : getDolGlobalString('ORDER_SUPPLIER_METHOD_BY_DEFAULT');
 			$formorder->selectInputMethod($methodecommande, "methodecommande", 1);
 			print '</td></tr>';
 

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2790,7 +2790,8 @@ if ($action == 'create') {
 
 			// Force mandatory order method
 			print '<tr><td class="fieldrequired">'.$langs->trans("OrderMode").'</td><td>';
-			$formorder->selectInputMethod(GETPOST('methodecommande'), "methodecommande", 1);
+			$methodecommande = GETPOSTISSET("methodecommande", "alpha") ? GETPOST('methodecommande', 'alpha') : getDolGlobalString('ORDER_SUPPLIER_METHOD_BY_DEFAULT');
+			$formorder->selectInputMethod($methodecommande, "methodecommande", 1);
 			print '</td></tr>';
 
 			print '<tr><td>'.$langs->trans("Comment").'</td><td><input class="quatrevingtpercent" type="text" name="comment" value="'.GETPOST('comment').'"></td></tr>';


### PR DESCRIPTION
# NEW introduce const ORDER_SUPPLIER_METHOD_BY_DEFAULT on supplier order card

On supplier order, there is a select with the order method. There is no way to set a default order method.
However, users may want to have a default method if they always send the order in a certain way.

This PR introduces constant ORDER_SUPPLIER_METHOD_BY_DEFAULT to solve this case.

The value for ORDER_SUPPLIER_METHOD_BY_DEFAULT must be the ID of the method to use in the dict of order methods.


