### PR TITLE
fix(supplier_proposal): enforce class name in getElementProperties()

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13786,6 +13786,7 @@ function getElementProperties($elementType)
 		$classpath = 'supplier_proposal/class';
 		$module = 'supplier_proposal';
 		$classfile = 'supplier_proposal';
+		$classname = 'SupplierProposalLine';
 		$table_element = 'supplier_proposaldet';
 		$parent_element = 'supplier_proposal';
 	} elseif ($elementType == 'contract') {


### PR DESCRIPTION
# Fix #Enforce class name for Supplier Proposal object in getElementProperties()

In the getElementProperties() function in functions.lib.php, we do things to get all the properties of an element, based on its element_type. 
In the section below, we set module equal to element. For supplier_proposaldet, this will be supplier:
```php
if (preg_match('/^([^_]+)_([^_]+)/i', $element, $regs)) {	// 'myobject_mysubobject' with myobject=mymodule
		$module = $element = $regs[1];
		$subelement = $regs[2];
	}
```
So in the next block, where we define the class name, we replace “det” with “Line” on the element. But our element is currently Supplier, so the class name is still Supplier. Then, in the `fetchObjectByElement()` function, we can't find an object for SupplierProposalLine, since the previous function returns Supplier as the class name.

As this is already the case for other classes, I'll simply impose the class name for the Supplier Proposal object in the dedicated section.


