### PR TITLE
New : Introduce const THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_SUPPLIER_ORDER

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1911,6 +1911,15 @@ if ($action == 'create') {
 		print $hookmanager->resPrint;
 
 		if (empty($reshook)) {
+			if (getDolGlobalString('THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_SUPPLIER_ORDER') && !empty($societe->id)) {
+				// copy from thirdparty
+				$tpExtrafields = new ExtraFields($db);
+				$tpExtrafieldLabels = $tpExtrafields->fetch_name_optionals_label($societe->table_element);
+				if ($societe->fetch_optionals() > 0) {
+					$object->array_options = array_merge($object->array_options, $societe->array_options);
+				}
+			}
+
 			print $object->showOptionals($extrafields, 'create');
 		}
 


### PR DESCRIPTION
# NEW Allow Extrafields to be propagated from a thirdparty to a supplier order

Introduce constant `THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_SUPPLIER_ORDER` that has the same behavior as `THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_INVOICE` and `THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_ORDER`.

If the supplier and the supplier order have an extrafield that carries the same code, the value of the supplier extrafield is pre-filled on the supplier order creation form.

This only takes effect when creating the supplier order from the "supplier" tab of a thirdparty, not when setting a thirdparty from a supplier order card with `$action == 'create'`



