### PR TITLE
FIX: stock control condition in reception delete

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1060,7 +1060,7 @@ class Reception extends CommonObject
 		$this->db->begin();
 
 		// Stock control
-		if (isModEnabled('stock') && !getDolGlobalInt('STOCK_CALCULATE_ON_RECEPTION') && $this->statut > 0) {
+		if (isModEnabled('stock') && ((getDolGlobalInt('STOCK_CALCULATE_ON_RECEPTION') && $this->status > self::STATUS_DRAFT) || (getDolGlobalInt('STOCK_CALCULATE_ON_RECEPTION_CLOSE') && $this->status == self::STATUS_CLOSED))) {
 			require_once DOL_DOCUMENT_ROOT."/product/stock/class/mouvementstock.class.php";
 
 			$langs->load("agenda");


### PR DESCRIPTION
# FIX: stock control condition in reception delete
With the current condition, we would only reverse the reception stock movements if stock was calculated on reception closing. With this condition, we ensure that we consider the decreasing stock movements both when an increasing stock movement was set on validation or closing.