### PR TITLE
NEW : Apply THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_(ORDER|INVOICE) when changing thirdparty on a creation page

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9418,6 +9418,16 @@ abstract class CommonObject
 							}
 						}
 
+						// Expected behavior : if THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_XXX is set, when we change company,
+						// Then we use the extrafields of the object (they are filled in the card when constant THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_XXX is set)
+						$force_values_on_change_company = (
+							($this->element == 'facture' && getDolGlobalInt('THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_INVOICE'))
+							|| ($this->element == 'commande' && getDolGlobalInt('THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_ORDER'))
+						);
+						if ($force_values_on_change_company && GETPOSTINT('changecompany')) {
+							$value = $this->array_options['options_'.$key] ?? $value;
+						}
+
 						// Convert date into timestamp format (value in memory must be a timestamp)
 						if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('date'))) {
 							$datenotinstring = null;


### PR DESCRIPTION
# NEW : Apply THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_(ORDER|INVOICE) when changing thirdparty on a creation page

Hidden constants THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_(ORDER|INVOICE) apply when creating an object from the thirdparty page. I think they should apply also when changing the thirdparty on an (order|invoice) creation card.

see issue https://github.com/Dolibarr/dolibarr/issues/33953


