### PR TITLE
FIX: In the caluculation of the structured communication, the modulo must have 2 digits

### DIFF
--- a/htdocs/core/lib/functions_be.lib.php
+++ b/htdocs/core/lib/functions_be.lib.php
@@ -61,7 +61,7 @@ function dolBECalculateStructuredCommunication($invoice_number, $invoice_type)
 	// Calculate module97
 	$invoice_number = $invoice_type.$invoice_number;
 	$mod97 = intval($invoice_number) % 97;
-	$controlKey = ($mod97 === 0) ? 97 : $mod97;
+	$controlKey = ($mod97 === 0) ? 97 : str_pad($mod97, 2, '0', STR_PAD_LEFT);
 
 	// Add the check digit at the end of the reference
 	$invoice_number .= $controlKey;


### PR DESCRIPTION
In the caluculation of the structured communication, the modulo must have 2 digits

+++3digits/4digits/5digits+++
+++202/5030/01408+++ and not +++202/5030/0148+++