### PR TITLE
height tabs

### DIFF
--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -3945,6 +3945,7 @@ div.tabs {
 	/*padding-left: 6px;
 	padding-right: 6px;*/
 	clear:both;
+	/* height: 100%; Disabled for fix #33965 */
 }
 div.tabsElem {
 	margin-top: 1px;

--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -3945,7 +3945,6 @@ div.tabs {
 	/*padding-left: 6px;
 	padding-right: 6px;*/
 	clear:both;
-	height:100%;
 }
 div.tabsElem {
 	margin-top: 1px;


### PR DESCRIPTION
I tried to remove this line on my Dolibarr and it didn't make any difference, it doesn't seem useful.
What's more, it causes a bug on some pages (notably the supplier price) where the tabs take up the whole page (100%) and the banner comes underneath but you can't even see it without scrolling.