### PR TITLE
FIX|Fix # Create event from productlot

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -362,6 +362,8 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 		$object->fulldayevent = ($fulldayevent ? 1 : 0);
 		$object->location = GETPOST("location", 'alphanohtml');
 		$object->label = GETPOST('label', 'alphanohtml');
+		$object->fk_element = $originid;
+		$object->elementtype= $origin;
 
 		if (GETPOST("elementtype", 'alpha')) {
 			$elProp = getElementProperties(GETPOST("elementtype", 'alpha'));
@@ -1260,6 +1262,9 @@ if ($action == 'create') {
 	print '<input type="hidden" name="action" value="add">';
 	print '<input type="hidden" name="donotclearsession" value="1">';
 	print '<input type="hidden" name="page_y" value="">';
+	print '<input type="hidden" name="origin" value="'.$origin.'">';
+	print '<input type="hidden" name="originid" value="'.$originid.'">';
+
 	if ($backtopage) {
 		print '<input type="hidden" name="backtopage" value="'.($backtopage != '1' ? $backtopage : '').'">';
 	}


### PR DESCRIPTION
When I tried to create an event from a productlot, the event was created but the origin and origin ID were missing.
So I fixed it, and now, when you create an event from a product lot, it shows the linked event on the productlot card.