### PR TITLE
Uiux : new experiment ux intuitive select by ctrl and Shift keys

### DIFF
--- a/htdocs/admin/tools/ui/class/documentation.class.php
+++ b/htdocs/admin/tools/ui/class/documentation.class.php
@@ -237,6 +237,13 @@ class Documentation
 					'submenu' => array(),
 					'summary' => array(),
 				),
+
+				'ExperimentalUxIntuitiveSelect' => array(
+					'url' => dol_buildpath($this->baseUrl.'/experimental/experiments/intuitive-select/index.php', 1),
+					'icon' => 'fas fa-flask',
+					'submenu' => array(),
+					'summary' => array(),
+				),
 			)
 		);
 

--- a/htdocs/admin/tools/ui/content/tables.php
+++ b/htdocs/admin/tools/ui/content/tables.php
@@ -83,36 +83,42 @@ $documentation->showSidebar(); ?>
 				<div class="documentation-example">
 					<div class="div-table-responsive">
 						<table class="tagtable liste" id="we-recommend-always-adding-a-unique-identifier">
-							<tr class="liste_titre">
-								<th class="wrapcolumntitle left liste_titre" data-col="ProductRef" title="<?php echo dol_escape_htmltag($langs->trans('ProductRef')); ?>"><?php echo $langs->trans('ProductRef'); ?></th>
-								<th class="wrapcolumntitle center liste_titre" data-col="qty" title="<?php echo dol_escape_htmltag($langs->trans('Qty')); ?>"><?php echo $langs->trans('Qty'); ?></th>
-								<th class="wrapcolumntitle right liste_titre" data-col="amount-no-tax" title="<?php echo dol_escape_htmltag($langs->trans('AmountHT')); ?>"><?php echo $langs->trans('AmountHT'); ?></th>
-								<th class="wrapcolumntitle right liste_titre" data-col="total-no-tax" title="<?php echo dol_escape_htmltag($langs->trans('TotalHT')); ?>"><?php echo $langs->trans('TotalHT'); ?></th>
-							</tr>
-							<tr class="oddeven">
-								<td class="left" data-col="ProductRef" >My Product A</td>
-								<td class="center" data-col="qty" >13</td>
-								<td class="right amount" data-col="amount-no-tax" ><?php echo price(9.99, 0, '', 1, -1, -1, 'auto'); ?></td>
-								<td class="right amount" data-col="total-no-tax" ><?php echo price(129.87, 0, '', 1, -1, -1, 'auto'); ?></td>
-							</tr>
-							<tr class="oddeven">
-								<td class="left" data-col="ProductRef" >My Product B</td>
-								<td class="center" data-col="qty" >21</td>
-								<td class="right amount" data-col="amount-no-tax" ><?php echo price(13.37, 0, '', 1, -1, -1, 'auto'); ?></td>
-								<td class="right amount" data-col="total-no-tax" ><?php echo price(280.77, 0, '', 1, -1, -1, 'auto'); ?></td>
-							</tr>
-							<tr class="oddeven">
-								<td class="left" data-col="ProductRef" >My Product C</td>
-								<td class="center" data-col="qty" >7</td>
-								<td class="right amount" data-col="amount-no-tax" ><?php echo price(16.66, 0, '', 1, -1, -1, 'auto'); ?></td>
-								<td class="right amount" data-col="total-no-tax" ><?php echo price(116.62, 0, '', 1, -1, -1, 'auto'); ?></td>
-							</tr>
-							<tr class="liste_total">
-								<td class="left" data-col="ProductRef" >Total</td>
-								<td class="center" data-col="qty" >41</td>
-								<td class="right amount" data-col="amount-no-tax" >--</td>
-								<td class="right amount" data-col="total-no-tax" ><?php echo price(527.26, 0, '', 1, -1, -1, 'auto'); ?></td>
-							</tr>
+							<thead>
+								<tr class="liste_titre">
+									<th class="wrapcolumntitle left liste_titre" data-col="ProductRef" title="<?php echo dol_escape_htmltag($langs->trans('ProductRef')); ?>"><?php echo $langs->trans('ProductRef'); ?></th>
+									<th class="wrapcolumntitle center liste_titre" data-col="qty" title="<?php echo dol_escape_htmltag($langs->trans('Qty')); ?>"><?php echo $langs->trans('Qty'); ?></th>
+									<th class="wrapcolumntitle right liste_titre" data-col="amount-no-tax" title="<?php echo dol_escape_htmltag($langs->trans('AmountHT')); ?>"><?php echo $langs->trans('AmountHT'); ?></th>
+									<th class="wrapcolumntitle right liste_titre" data-col="total-no-tax" title="<?php echo dol_escape_htmltag($langs->trans('TotalHT')); ?>"><?php echo $langs->trans('TotalHT'); ?></th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr class="oddeven">
+									<td class="left" data-col="ProductRef" >My Product A</td>
+									<td class="center" data-col="qty" >13</td>
+									<td class="right amount" data-col="amount-no-tax" ><?php echo price(9.99, 0, '', 1, -1, -1, 'auto'); ?></td>
+									<td class="right amount" data-col="total-no-tax" ><?php echo price(129.87, 0, '', 1, -1, -1, 'auto'); ?></td>
+								</tr>
+								<tr class="oddeven">
+									<td class="left" data-col="ProductRef" >My Product B</td>
+									<td class="center" data-col="qty" >21</td>
+									<td class="right amount" data-col="amount-no-tax" ><?php echo price(13.37, 0, '', 1, -1, -1, 'auto'); ?></td>
+									<td class="right amount" data-col="total-no-tax" ><?php echo price(280.77, 0, '', 1, -1, -1, 'auto'); ?></td>
+								</tr>
+								<tr class="oddeven">
+									<td class="left" data-col="ProductRef" >My Product C</td>
+									<td class="center" data-col="qty" >7</td>
+									<td class="right amount" data-col="amount-no-tax" ><?php echo price(16.66, 0, '', 1, -1, -1, 'auto'); ?></td>
+									<td class="right amount" data-col="total-no-tax" ><?php echo price(116.62, 0, '', 1, -1, -1, 'auto'); ?></td>
+								</tr>
+							</tbody>
+							<tfoot>
+								<tr class="liste_total">
+									<td class="left" data-col="ProductRef" >Total</td>
+									<td class="center" data-col="qty" >41</td>
+									<td class="right amount" data-col="amount-no-tax" >--</td>
+									<td class="right amount" data-col="total-no-tax" ><?php echo price(527.26, 0, '', 1, -1, -1, 'auto'); ?></td>
+								</tr>
+							</tfoot>
 						</table>
 					</div>
 				</div>

--- a/htdocs/admin/tools/ui/content/tables.php
+++ b/htdocs/admin/tools/ui/content/tables.php
@@ -69,6 +69,7 @@ $documentation->showSidebar(); ?>
 
 			<h1 class="documentation-title"><?php echo $langs->trans('DocTableTitle'); ?></h1>
 			<p class="documentation-text"><?php echo $langs->trans('DocTableMainDescription'); ?></p>
+			<p class="documentation-text"><?php echo $langs->trans('DocTableMainDescriptionNote'); ?></p>
 
 			<!-- Summary -->
 			<?php $documentation->showSummary(); ?>
@@ -81,7 +82,7 @@ $documentation->showSidebar(); ?>
 				<p class="documentation-text"><?php echo $langs->trans('DocTableBasicDescription'); ?></p>
 				<div class="documentation-example">
 					<div class="div-table-responsive">
-						<table class="tagtable liste">
+						<table class="tagtable liste" id="we-recommend-always-adding-a-unique-identifier">
 							<tr class="liste_titre">
 								<th class="wrapcolumntitle left liste_titre" title="<?php echo $langs->trans('ProductRef'); ?>"><?php echo $langs->trans('ProductRef'); ?></th>
 								<th class="wrapcolumntitle center liste_titre" title="<?php echo $langs->trans('Qty'); ?>"><?php echo $langs->trans('Qty'); ?></th>
@@ -117,7 +118,7 @@ $documentation->showSidebar(); ?>
 				</div>
 				<?php
 				$lines = array(
-					'<table class="tagtable liste">',
+					'<table class="tagtable liste" id="we-recommend-always-adding-a-unique-identifier" >',
 					'',
 					'	<!-- Table header -->',
 					'	<tr class="liste_titre">',
@@ -235,7 +236,7 @@ $documentation->showSidebar(); ?>
 					'	<input type="hidden" name="action" value="ACTION_VALUE">',
 					'	<!-- other hidden fields like sortfield, sortorder, page, ... -->',
 					'	',
-					'	<table class="tagtable liste">',
+					'	<table class="tagtable liste" id="we-recommend-always-adding-a-unique-identifier">',
 					'	',
 					'		<!-- Filters row -->',
 					'		<tr class="liste_titre_filter">',
@@ -366,7 +367,7 @@ $documentation->showSidebar(); ?>
 					'		</select>',
 					'	</div>',
 					'</div>',
-					'<table class="tagtable liste listwithfilterbefore">',
+					'<table class="tagtable liste listwithfilterbefore" id="we-recommend-always-adding-a-unique-identifier">',
 					'	<!-- Filters row -->',
 					'	<!-- Table header -->',
 					'	<!-- Data lines -->',

--- a/htdocs/admin/tools/ui/content/tables.php
+++ b/htdocs/admin/tools/ui/content/tables.php
@@ -84,34 +84,34 @@ $documentation->showSidebar(); ?>
 					<div class="div-table-responsive">
 						<table class="tagtable liste" id="we-recommend-always-adding-a-unique-identifier">
 							<tr class="liste_titre">
-								<th class="wrapcolumntitle left liste_titre" title="<?php echo $langs->trans('ProductRef'); ?>"><?php echo $langs->trans('ProductRef'); ?></th>
-								<th class="wrapcolumntitle center liste_titre" title="<?php echo $langs->trans('Qty'); ?>"><?php echo $langs->trans('Qty'); ?></th>
-								<th class="wrapcolumntitle right liste_titre" title="<?php echo $langs->trans('AmountHT'); ?>"><?php echo $langs->trans('AmountHT'); ?></th>
-								<th class="wrapcolumntitle right liste_titre" title="<?php echo $langs->trans('TotalHT'); ?>"><?php echo $langs->trans('TotalHT'); ?></th>
+								<th class="wrapcolumntitle left liste_titre" data-col="ProductRef" title="<?php echo dol_escape_htmltag($langs->trans('ProductRef')); ?>"><?php echo $langs->trans('ProductRef'); ?></th>
+								<th class="wrapcolumntitle center liste_titre" data-col="qty" title="<?php echo dol_escape_htmltag($langs->trans('Qty')); ?>"><?php echo $langs->trans('Qty'); ?></th>
+								<th class="wrapcolumntitle right liste_titre" data-col="amount-no-tax" title="<?php echo dol_escape_htmltag($langs->trans('AmountHT')); ?>"><?php echo $langs->trans('AmountHT'); ?></th>
+								<th class="wrapcolumntitle right liste_titre" data-col="total-no-tax" title="<?php echo dol_escape_htmltag($langs->trans('TotalHT')); ?>"><?php echo $langs->trans('TotalHT'); ?></th>
 							</tr>
 							<tr class="oddeven">
-								<td class="left">My Product A</td>
-								<td class="center">13</td>
-								<td class="right amount"><?php echo price(9.99, 0, '', 1, -1, -1, 'auto'); ?></td>
-								<td class="right amount"><?php echo price(129.87, 0, '', 1, -1, -1, 'auto'); ?></td>
+								<td class="left" data-col="ProductRef" >My Product A</td>
+								<td class="center" data-col="qty" >13</td>
+								<td class="right amount" data-col="amount-no-tax" ><?php echo price(9.99, 0, '', 1, -1, -1, 'auto'); ?></td>
+								<td class="right amount" data-col="total-no-tax" ><?php echo price(129.87, 0, '', 1, -1, -1, 'auto'); ?></td>
 							</tr>
 							<tr class="oddeven">
-								<td class="left">My Product B</td>
-								<td class="center">21</td>
-								<td class="right amount"><?php echo price(13.37, 0, '', 1, -1, -1, 'auto'); ?></td>
-								<td class="right amount"><?php echo price(280.77, 0, '', 1, -1, -1, 'auto'); ?></td>
+								<td class="left" data-col="ProductRef" >My Product B</td>
+								<td class="center" data-col="qty" >21</td>
+								<td class="right amount" data-col="amount-no-tax" ><?php echo price(13.37, 0, '', 1, -1, -1, 'auto'); ?></td>
+								<td class="right amount" data-col="total-no-tax" ><?php echo price(280.77, 0, '', 1, -1, -1, 'auto'); ?></td>
 							</tr>
 							<tr class="oddeven">
-								<td class="left">My Product C</td>
-								<td class="center">7</td>
-								<td class="right amount"><?php echo price(16.66, 0, '', 1, -1, -1, 'auto'); ?></td>
-								<td class="right amount"><?php echo price(116.62, 0, '', 1, -1, -1, 'auto'); ?></td>
+								<td class="left" data-col="ProductRef" >My Product C</td>
+								<td class="center" data-col="qty" >7</td>
+								<td class="right amount" data-col="amount-no-tax" ><?php echo price(16.66, 0, '', 1, -1, -1, 'auto'); ?></td>
+								<td class="right amount" data-col="total-no-tax" ><?php echo price(116.62, 0, '', 1, -1, -1, 'auto'); ?></td>
 							</tr>
 							<tr class="liste_total">
-								<td class="left">Total</td>
-								<td class="center">41</td>
-								<td class="right amount">--</td>
-								<td class="right amount"><?php echo price(527.26, 0, '', 1, -1, -1, 'auto'); ?></td>
+								<td class="left" data-col="ProductRef" >Total</td>
+								<td class="center" data-col="qty" >41</td>
+								<td class="right amount" data-col="amount-no-tax" >--</td>
+								<td class="right amount" data-col="total-no-tax" ><?php echo price(527.26, 0, '', 1, -1, -1, 'auto'); ?></td>
 							</tr>
 						</table>
 					</div>
@@ -121,38 +121,44 @@ $documentation->showSidebar(); ?>
 					'<table class="tagtable liste" id="we-recommend-always-adding-a-unique-identifier" >',
 					'',
 					'	<!-- Table header -->',
-					'	<tr class="liste_titre">',
-					'		<th class="wrapcolumntitle left liste_titre" title="First Name">First Name</th>',
-					'		<th class="wrapcolumntitle left liste_titre" title="Last Name">Last Name</th>',
-					'		<th class="wrapcolumntitle center liste_titre" title="Age">Age</th>',
-					'		<th class="wrapcolumntitle right liste_titre" title="Country">Country</th>',
-					'	</tr>',
+					'	<thead>',
+					'		<tr class="liste_titre">',
+					'			<th class="wrapcolumntitle left liste_titre" data-col="ProductRef" title="<?php echo dol_escape_htmltag($langs->trans(\'ProductRef\')); ?>"><?php echo $langs->trans(\'ProductRef\'); ?></th>',
+					'			<th class="wrapcolumntitle left liste_titre" data-col="qty" title="<?php echo dol_escape_htmltag($langs->trans(\'Qty\')); ?>"><?php echo $langs->trans(\'Qty\'); ?></th>',
+					'			<th class="wrapcolumntitle center liste_titre" data-col="amount-no-tax" title="<?php echo dol_escape_htmltag($langs->trans(\'AmountHT\')); ?>"><?php echo $langs->trans(\'AmountHT\'); ?></th>',
+					'			<th class="wrapcolumntitle right liste_titre" data-col="total-no-tax" title="<?php echo dol_escape_htmltag($langs->trans(\'TotalHT\')); ?>"><?php echo $langs->trans(\'TotalHT\'); ?></th>',
+					'		</tr>',
+					'	</thead>',
 					'',
-					'	<!-- Data lines -->',
-					'	<tr class="oddeven">',
-					'		<td class="left">My Product A</td>',
-					'		<td class="left">13</td>',
-					'		<td class="center amount">9,99 &euro;</td>',
-					'		<td class="right amount">129,87 &euro;</td>',
-					'	</tr>',
-					'	<tr class="oddeven">',
-					'		<td class="left">My Product B</td>',
-					'		<td class="left">21</td>',
-					'		<td class="center amount">13,37 &euro;</td>',
-					'		<td class="right amount">280,77 &euro;</td>',
-					'	</tr>',
+					'	<tbody>',
+					'		<!-- Data lines -->',
+					'		<tr class="oddeven">',
+					'			<td class="left" data-col="ProductRef" >My Product A</td>',
+					'			<td class="left" data-col="qty" >13</td>',
+					'			<td class="center amount" data-col="amount-no-tax" >9,99 &euro;</td>',
+					'			<td class="right amount" data-col="total-no-tax" >129,87 &euro;</td>',
+					'		</tr>',
+					'		<tr class="oddeven">',
+					'			<td class="left" data-col="ProductRef" >My Product B</td>',
+					'			<td class="left" data-col="qty" >21</td>',
+					'			<td class="center amount" data-col="amount-no-tax" >13,37 &euro;</td>',
+					'			<td class="right amount" data-col="total-no-tax" >280,77 &euro;</td>',
+					'		</tr>',
+					'	</tbody>',
 					'',
 					'	<!-- Total -->',
-					'	<tr class="liste_total">',
-					'		<td class="left">Total</td>',
-					'		<td class="left">58</td>',
-					'		<td class="center amount">--</td>',
-					'		<td class="right amount">1178,87 &euro;</td>',
-					'	</tr>',
+					'	<tfoot>',
+					'		<tr class="liste_total">',
+					'			<td class="left" data-col="ProductRef" >Total</td>',
+					'			<td class="left" data-col="qty" >58</td>',
+					'			<td class="center amount" data-col="amount-no-tax" >--</td>',
+					'			<td class="right amount" data-col="total-no-tax" >1178,87 &euro;</td>',
+					'		</tr>',
+					'	</tfoot>',
 					'',
 					'</table>',
 				);
-				echo $documentation->showCode($lines); ?>
+				echo $documentation->showCode($lines, 'php'); ?>
 			</div>
 
 			<!-- Table with filters -->

--- a/htdocs/admin/tools/ui/experimental/experiments/intuitive-select/index.php
+++ b/htdocs/admin/tools/ui/experimental/experiments/intuitive-select/index.php
@@ -1,0 +1,395 @@
+<?php
+/*
+ * Copyright (C) 2024 Anthony Damhet <a.damhet@progiseize.fr>
+ * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Load Dolibarr environment
+require '../../../../../../main.inc.php';
+
+/**
+ * @var DoliDB      $db
+ * @var HookManager $hookmanager
+ * @var Translate   $langs
+ * @var User        $user
+ */
+
+// Protection if external user
+if ($user->socid > 0) {
+	accessforbidden();
+}
+
+// Includes
+require_once DOL_DOCUMENT_ROOT . '/admin/tools/ui/class/documentation.class.php';
+
+// Load documentation translations
+$langs->load('uxdocumentation');
+
+//
+$documentation = new Documentation($db);
+$group = 'ExperimentalUx';
+$experimentName = 'ExperimentalUxIntuitiveSelect';
+
+$experimentAssetsPath = $documentation->baseUrl . '/experimental/experiments/intuitive-select/assets/';
+$js = [
+	'/includes/ace/src/ace.js',
+	'/includes/ace/src/ext-statusbar.js',
+	'/includes/ace/src/ext-language_tools.js',
+];
+$css = [
+//	$experimentAssetsPath . '-01.css'
+];
+
+// Output html head + body - Param is Title
+$documentation->docHeader($langs->trans($experimentName, $group), $js, $css);
+
+// Set view for menu and breadcrumb
+$documentation->view = [$group, $experimentName];
+
+// Output sidebar
+$documentation->showSidebar();
+$form = new Form($db);
+
+?>
+
+<div class="doc-wrapper">
+
+	<?php $documentation->showBreadCrumb(); ?>
+
+	<div class="doc-content-wrapper">
+
+		<h1 class="documentation-title"><?php echo $langs->trans($experimentName); ?></h1>
+
+		<?php $documentation->showSummary(); ?>
+
+		<div class="documentation-section" >
+			<h2 class="documentation-title" >Select table lines by <kbd>Ctrl</kbd> + <kbd>Click</kbd>  (Experimental)</h2>
+
+
+			<h2>Description</h2>
+			<p>
+				This feature allows users to <strong>select</strong> or <strong>deselect</strong> table rows (<code>&lt;tr&gt;</code>) in an HTML table:
+			</p>
+			<ul>
+				<li>Holding down <strong>Ctrl</strong> (or <strong>Cmd</strong> on Mac) allows users to add or remove individual rows from the selection.</li>
+				<li>Holding down <strong>Shift</strong> allows users to <strong>select a range</strong> of rows between the last selected row and the clicked row.</li>
+			</ul>
+
+			<h2>Detailed Behavior</h2>
+			<table border="1" cellpadding="6" cellspacing="0">
+				<thead>
+				<tr>
+					<th>User Action</th>
+					<th>Expected Result</th>
+				</tr>
+				</thead>
+				<tbody>
+				<tr>
+					<td>Ctrl + Click on a row</td>
+					<td>Toggles selection of the clicked row (add/remove).</td>
+				</tr>
+				<tr>
+					<td>Shift + Click on a row</td>
+					<td>Selects all rows between the last selected and clicked row.</td>
+				</tr>
+				</tbody>
+			</table>
+
+			<h2>HTML Requirements</h2>
+			<p>
+				The table should follow a standard structure with <code>&lt;thead&gt;</code> and <code>&lt;tbody&gt;</code> elements,
+				and each <code>&lt;tr&gt;</code> must be selectable by applying <code>.row-with-select</code> CSS class and have checkbox with <code>.checkforselect</code> class
+			</p>
+
+			<h2>Key Notes</h2>
+			<ul>
+				<li>The script supports <strong>Cmd</strong> key (for Mac users) as an alternative to <strong>Ctrl</strong>.</li>
+				<li>When Shift-clicking without a previously selected row, selection will not start.</li>
+				<li>When user start selection, the css rules will remove text selection possibility.</li>
+				<li>When the user double-clicks, the selection functionality is reactivated, but the reference to the last selected row is cleared, thus disabling the <code>Shift + Click</code> range selection behavior.</li>
+			</ul>
+
+
+			<div class="documentation-example">
+				<div class="div-table-responsive">
+					<table class="tagtable liste listwithfilterbefore table-with-select" id="try-line-ctrl-click-feature">
+						<thead>
+							<tr class="liste_titre_filter">
+								<td class="liste_titre center maxwidthsearch">
+									<div class="nowraponall">
+										<button type="submit" class="liste_titre button_search reposition" name="button_search_x" value="x">
+											<span class="fas fa-search"></span>
+										</button>
+										<button type="submit" class="liste_titre button_removefilter reposition" name="button_removefilter_x" value="x">
+											<span class="fas fa-times"></span>
+										</button>
+									</div>
+								</td>
+								<td><input class="flat" type="text" name="search_firstname" value=""></td>
+								<td><input class="flat" type="text" name="search_lasttname" value=""></td>
+								<td class="center"><input class="maxwidth50 flat" type="text" name="search_age" value=""></td>
+								<td class="right"><input class="flat" type="text" name="search_country" value=""></td>
+							</tr>
+							<tr class="liste_titre">
+								<th>
+									<dl class="dropdown" style="opacity: 0.5;">
+										<dt><span class="fas fa-list" style=""></span></dt>
+										<dd class="dropdowndd">
+											<div class="multiselectcheckboxselectedfields">
+												<ul class="selectedfieldsleft"></ul>
+											</div>
+										</dd>
+									</dl>
+									<div class="inline-block checkallactions">
+										<input type="checkbox" id="checkforselects" name="checkforselects" class="checkallactions" >
+										<script nonce="<?php echo getNonce(); ?>" >
+											// TODO : Dolibarr use this kind of script inclusion for toggle checkboxes : we need to add a more global js method
+											$(document).ready(function() {
+												$("#checkforselects").click(function() {
+													if($(this).is(':checked')){
+														console.log("We check all checkforselect and trigger the change method");
+														$(".checkforselect").prop('checked', true).trigger('change');
+													}
+													else
+													{
+														console.log("We uncheck all");
+														$(".checkforselect").prop('checked', false).trigger('change');
+													}
+													if (typeof initCheckForSelect == 'function') { initCheckForSelect(0, "massaction", "checkforselect"); } else { console.log("No function initCheckForSelect found. Call won't be done."); }         });
+												$(".checkforselect").change(function() {
+													// TODO : change this by a simple css rule
+													$(this).closest("tr").toggleClass("highlight", this.checked);
+												});
+											});
+										</script>
+									</div>
+								</th>
+								<th class="wrapcolumntitle left liste_titre" title="First Name">First Name</th>
+								<th class="wrapcolumntitle left liste_titre" title="Last Name">Last Name</th>
+								<th class="wrapcolumntitle center liste_titre" title="Age">Age</th>
+								<th class="wrapcolumntitle right liste_titre" title="Country">Country</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr class="oddeven row-with-select" >
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">John</td>
+								<td class="left">Doe</td>
+								<td class="center">37</td>
+								<td class="right">U.S.A</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Jack</td>
+								<td class="left">Sparrow</td>
+								<td class="center">29</td>
+								<td class="right">Caribbean</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Sacha</td>
+								<td class="left">Ketchum</td>
+								<td class="center">16</td>
+								<td class="right">Kanto</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Albert</td>
+								<td class="left">Einstein</td>
+								<td class="center">72</td>
+								<td class="right">Germany</td>
+							</tr>
+							<tr class="oddeven row-with-select" >
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">John</td>
+								<td class="left">Doe</td>
+								<td class="center">37</td>
+								<td class="right">U.S.A</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Jack</td>
+								<td class="left">Sparrow</td>
+								<td class="center">29</td>
+								<td class="right">Caribbean</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Sacha</td>
+								<td class="left">Ketchum</td>
+								<td class="center">16</td>
+								<td class="right">Kanto</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Albert</td>
+								<td class="left">Einstein</td>
+								<td class="center">72</td>
+								<td class="right">Germany</td>
+							</tr>
+							<tr class="oddeven row-with-select" >
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">John</td>
+								<td class="left">Doe</td>
+								<td class="center">37</td>
+								<td class="right">U.S.A</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Jack</td>
+								<td class="left">Sparrow</td>
+								<td class="center">29</td>
+								<td class="right">Caribbean</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Sacha</td>
+								<td class="left">Ketchum</td>
+								<td class="center">16</td>
+								<td class="right">Kanto</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Albert</td>
+								<td class="left">Einstein</td>
+								<td class="center">72</td>
+								<td class="right">Germany</td>
+							</tr>
+							<tr class="oddeven row-with-select" >
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">John</td>
+								<td class="left">Doe</td>
+								<td class="center">37</td>
+								<td class="right">U.S.A</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Jack</td>
+								<td class="left">Sparrow</td>
+								<td class="center">29</td>
+								<td class="right">Caribbean</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Sacha</td>
+								<td class="left">Ketchum</td>
+								<td class="center">16</td>
+								<td class="right">Kanto</td>
+							</tr>
+							<tr class="oddeven row-with-select">
+								<td><input class="checkforselect" type="checkbox" name="" value="" ></td>
+								<td class="left">Albert</td>
+								<td class="left">Einstein</td>
+								<td class="center">72</td>
+								<td class="right">Germany</td>
+							</tr>
+						</tbody>
+					</table>
+
+				</div>
+				<style>
+					/* Remove text selection */
+					.row-with-select[data-is-last-changed] * {
+						-webkit-touch-callout: none; /* iOS Safari */
+						-webkit-user-select: none; /* Safari */
+						-khtml-user-select: none; /* Konqueror HTML */
+						-moz-user-select: none; /* Old versions of Firefox */
+						-ms-user-select: none; /* Internet Explorer/Edge */
+						user-select: none; /* Non-prefixed version, currently
+								  supported by Chrome, Edge, Opera and Firefox */
+					}
+				</style>
+				<script nonce="<?php echo getNonce(); ?>" >
+					$(function() {
+
+						/**
+						 * @param {jQuery}  el
+						 * @param {Integer}  status
+						 */
+						let setLastClickedRowStatus = function (el, status = 1){
+							$('.row-with-select').attr('data-is-last-changed', 0);
+							el.attr('data-is-last-changed', status === 0 ? 0 : 1);
+						}
+
+						/**
+						 * Remove data-is-last-changed on double click
+						 * Because if data-is-last-changed is present the user can't select text
+						 */
+						$(document).on("dblclick", ".row-with-select", function(e) {
+							$('.row-with-select[data-is-last-changed]').removeAttr( 'data-is-last-changed' );
+						});
+
+						/**
+						 * DISABLE on click a and button
+						 * Because Ctrl + Click on link is also used for open ion a new tab
+						 * we need to block select tool
+						 */
+						$(document).on("click", ".row-with-select a, .row-with-select button", function (e) {
+							// we need to block select tool
+							if (e.ctrlKey) {
+								e.stopPropagation();
+							}
+						});
+
+						$(document).on("click", ".row-with-select", function (e) {
+							let checkBox = $(this).find('.checkforselect');
+							let nextCheckStatus = !checkBox.is(':checked')
+
+							if (e.ctrlKey || e.metaKey) {
+								// Add line to selection
+								if(checkBox){
+									checkBox.prop('checked', nextCheckStatus).trigger('change');
+								}
+								setLastClickedRowStatus($(this), 1);
+							}
+
+							if (e.shiftKey) {
+								let lastLastChanged = $(this).closest('table').find('.row-with-select[data-is-last-changed="1"]');
+
+								if(lastLastChanged.length>0){
+									// Add all lines to selection betwin last selected line
+									if($(this).index() === lastLastChanged.index()) {
+										return null;
+									}
+
+									if($(this).index() < lastLastChanged.index()) {
+										$(this).nextUntil(lastLastChanged, ".row-with-select" ).find('.checkforselect').prop('checked', nextCheckStatus).trigger('change');
+									}else{
+										lastLastChanged.nextUntil($(this), ".row-with-select" ).find('.checkforselect').prop('checked', nextCheckStatus).trigger('change');
+									}
+
+
+									lastLastChanged.find('.checkforselect').prop('checked', nextCheckStatus).trigger('change');
+									checkBox.prop('checked', nextCheckStatus).trigger('change');
+
+									setLastClickedRowStatus($(this), 1);
+								}
+							}
+						});
+					});
+
+				</script>
+			</div>
+		</div>
+
+
+	</div>
+
+</div>
+<?php
+// Output close body + html
+$documentation->docFooter();
+?>

--- a/htdocs/langs/en_US/uxdocumentation.lang
+++ b/htdocs/langs/en_US/uxdocumentation.lang
@@ -50,6 +50,7 @@ DocButtonSubmenuDescription=Fill the $url parameter with an array of url in orde
 #Tables
 DocTableTitle=Tables
 DocTableMainDescription=Documentation and examples for tables.
+DocTableMainDescriptionNote=<b>Note:</b> we recommend always adding a unique “id” identifier to the table, which will enable integrators to easily interact with css and/or js.
 DocTableBasic=Basic usage
 DocTableBasicDescription=Here is a template for creating a basic data table.
 DocTableWithFilters=Filters row

--- a/htdocs/langs/en_US/uxdocumentation.lang
+++ b/htdocs/langs/en_US/uxdocumentation.lang
@@ -164,4 +164,5 @@ ExperimentalUxContributionEnd = This structure ensures a clear and modular organ
 # Start experiements menu title
 ExperimentalUxFreezeTooltip = Tooltip freeze
 ExperimentalUxInputAjaxFeedback = Input feedback
+ExperimentalUxIntuitiveSelect = Intuitive table lines selection
 # End experiements manu tyile


### PR DESCRIPTION
# UIUX new experiment ux intuitive select by ctrl and Shift keys

This feature allows users to **select** or **deselect** table rows (`<tr>`) in an HTML table:

*   Holding down **Ctrl** (or **Cmd** on Mac) allows users to add or remove individual rows from the selection.
*   Holding down **Shift** allows users to **select a range** of rows between the last selected row and the clicked row.

Detailed Behavior
-----------------

| User Action            | Expected Result                                             |
|------------------------|-------------------------------------------------------------|
| Ctrl + Click on a row  | Toggles selection of the clicked row (add/remove).          |
| Shift + Click on a row | Selects all rows between the last selected and clicked row. |


HTML Requirements
-----------------

The table should follow a standard structure with `<thead>` and `<tbody>` elements, and each `<tr>` must be selectable by applying `.row-with-select` CSS class and have checkbox with `.checkforselect` class

Key Notes
---------

*   The script supports **Cmd** key (for Mac users) as an alternative to **Ctrl**.
*   When Shift-clicking without a previously selected row, selection will not start.
*   When user start selection, the css rules will remove text selection possibility.
*   When the user double-clicks, the selection functionality is reactivated, but the reference to the last selected row is cleared, thus disabling the `Shift + Click` range selection behavior.


NOTE ABOUT THIS VIDEO: Apologies, my cursor is not visible. However, when I press the Ctrl key (without clicking), a purple effect appears, this effect comes from my Linux system, not from Dolibarr.

https://github.com/user-attachments/assets/b793ba72-de24-4bc0-a186-b05aeb18f0a7


