### PR TITLE
FIX: social contribution payment: correct error reporting

### DIFF
--- a/htdocs/compta/paiement_charge.php
+++ b/htdocs/compta/paiement_charge.php
@@ -119,7 +119,7 @@ if ($action == 'add_payment') {
 
 			if (!$error) {
 				$result = $paiement->addPaymentToBank($user, 'payment_sc', '(SocialContributionPayment)', GETPOST('accountid', 'int'), '', '');
-				if ($result < 0) {
+				if ($result <= 0) {
 					$error++;
 					setEventMessages($paiement->error, $paiement->errors, 'errors');
 					$action = 'create';

--- a/htdocs/compta/paiement_charge.php
+++ b/htdocs/compta/paiement_charge.php
@@ -51,7 +51,7 @@ $charge = new ChargeSociales($db);
  * Actions
  */
 
-if ($action == 'add_payment' || ($action == 'confirm_paiement' && $confirm == 'yes')) {
+if ($action == 'add_payment') {
 	$error = 0;
 
 	if ($cancel) {
@@ -89,7 +89,7 @@ if ($action == 'add_payment' || ($action == 'confirm_paiement' && $confirm == 'y
 			}
 		}
 
-		if (count($amounts) <= 0) {
+		if (empty($amounts)) {
 			$error++;
 			setEventMessages($langs->trans("ErrorNoPaymentDefined"), null, 'errors');
 			$action = 'create';
@@ -119,9 +119,9 @@ if ($action == 'add_payment' || ($action == 'confirm_paiement' && $confirm == 'y
 
 			if (!$error) {
 				$result = $paiement->addPaymentToBank($user, 'payment_sc', '(SocialContributionPayment)', GETPOST('accountid', 'int'), '', '');
-				if (!($result > 0)) {
+				if ($result < 0) {
 					$error++;
-					setEventMessages($paiement->error, null, 'errors');
+					setEventMessages($paiement->error, $paiement->errors, 'errors');
 					$action = 'create';
 				}
 			}

--- a/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
+++ b/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
@@ -579,7 +579,6 @@ class PaymentSocialContribution extends CommonObject
 				$result = $this->update_fk_bank($bank_line_id);
 				if ($result <= 0) {
 					$error++;
-					dol_print_error($this->db);
 				}
 
 				// Add link 'payment', 'payment_supplier', 'payment_sc' in bank_url between payment and bank transaction
@@ -591,7 +590,7 @@ class PaymentSocialContribution extends CommonObject
 					$result = $acc->add_url_line($bank_line_id, $this->id, $url, '(paiement)', $mode);
 					if ($result <= 0) {
 						$error++;
-						dol_print_error($this->db);
+						$this->setErrorsFromObject($acc);
 					}
 				}
 
@@ -603,7 +602,8 @@ class PaymentSocialContribution extends CommonObject
 						$socialcontrib->fetch($key);
 						$result = $acc->add_url_line($bank_line_id, $socialcontrib->id, DOL_URL_ROOT.'/compta/charges.php?id=', $socialcontrib->type_label.(($socialcontrib->lib && $socialcontrib->lib != $socialcontrib->type_label) ? ' ('.$socialcontrib->lib.')' : ''), 'sc');
 						if ($result <= 0) {
-							dol_print_error($this->db);
+							$this->setErrorsFromObject($acc);
+							$error++;
 						}
 
 						if ($socialcontrib->fk_user) {
@@ -620,14 +620,14 @@ class PaymentSocialContribution extends CommonObject
 							);
 
 							if ($result <= 0) {
-								$this->error = $acc->error;
+								$this->setErrorsFromObject($acc);
 								$error++;
 							}
 						}
 					}
 				}
 			} else {
-				$this->error = $acc->error;
+				$this->setErrorsFromObject($acc);
 				$error++;
 			}
 		}


### PR DESCRIPTION
# FIX: social contribution payment: correct error reporting

When recording a payement of social contributions, error reporting can lead to misbehaviour because of calls to `dol_print_error()` (especially in REST API context), of by not filling errors from calls to methods of other objects.

Also, cleanup a condition on `$action` badly copy/pasted and some messy conditions.

