### PR TITLE
fix: php warning for status field in list of purchase orders

### DIFF
--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -1774,7 +1774,7 @@ if ($resql) {
 		$objectstatic->note_public = $obj->note_public;
 		$objectstatic->note_private = $obj->note_private;
 		$objectstatic->statut = $obj->fk_statut;
-		$objectstatic->status = $obj->fk_status;
+		$objectstatic->status = $obj->fk_statut;
 
 		if ($mode == 'kanban') {
 			if ($i == 0) {


### PR DESCRIPTION
Fix this php warning that made this page confusing.
![Capture d’écran du 2025-04-28 16-08-50](https://github.com/user-attachments/assets/e67d2952-c90f-4788-81f6-bdb3901177bf)
