### PR TITLE
FIX allow double colon and string obfuscation in dol eval for computed extra fields

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9285,15 +9285,12 @@ function dol_eval($s, $returnvalue = 0, $hideerrors = 1, $onlysimplestring = '1'
 			return 'Bad string syntax to evaluate (value is Array) '.var_export($s, true);
 		}
 
-		// Disallow double colon
-		if (getDolGlobalString('MAIN_DISALLOW_DOUBLE_COLON_IN_DOL_EVAL')) {
-			if (strpos($s, '::') !== false) {
-				if ($returnvalue) {
-					return 'Bad string syntax to evaluate (double : char is forbidden): '.$s;
-				} else {
-					dol_syslog('Bad string syntax to evaluate (double : char is forbidden): '.$s);
-					return '';
-				}
+		if (!getDolGlobalString('MAIN_ALLOW_DOUBLE_COLON_IN_DOL_EVAL') && strpos($s, '::') !== false) {
+			if ($returnvalue) {
+				return 'Bad string syntax to evaluate (double : char is forbidden without setting MAIN_ALLOW_DOUBLE_COLON_IN_DOL_EVAL): '.$s;
+			} else {
+				dol_syslog('Bad string syntax to evaluate (double : char is forbidden without setting MAIN_ALLOW_DOUBLE_COLON_IN_DOL_EVAL): '.$s, LOG_WARNING);
+				return '';
 			}
 		}
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9284,14 +9284,19 @@ function dol_eval($s, $returnvalue = 0, $hideerrors = 1, $onlysimplestring = '1'
 		if (is_array($s) || $s === 'Array') {
 			return 'Bad string syntax to evaluate (value is Array) '.var_export($s, true);
 		}
-		if (strpos($s, '::') !== false) {
-			if ($returnvalue) {
-				return 'Bad string syntax to evaluate (double : char is forbidden): '.$s;
-			} else {
-				dol_syslog('Bad string syntax to evaluate (double : char is forbidden): '.$s);
-				return '';
+
+		// Disallow double colon
+		if (getDolGlobalString('MAIN_DISALLOW_DOUBLE_COLON_IN_DOL_EVAL')) {
+			if (strpos($s, '::') !== false) {
+				if ($returnvalue) {
+					return 'Bad string syntax to evaluate (double : char is forbidden): '.$s;
+				} else {
+					dol_syslog('Bad string syntax to evaluate (double : char is forbidden): '.$s);
+					return '';
+				}
 			}
 		}
+
 		if (strpos($s, '`') !== false) {
 			if ($returnvalue) {
 				return 'Bad string syntax to evaluate (backtick char is forbidden): '.$s;
@@ -9300,12 +9305,16 @@ function dol_eval($s, $returnvalue = 0, $hideerrors = 1, $onlysimplestring = '1'
 				return '';
 			}
 		}
-		if (preg_match('/[^0-9]+\.[^0-9]+/', $s)) {	// We refuse . if not between 2 numbers
-			if ($returnvalue) {
-				return 'Bad string syntax to evaluate (dot char is forbidden): '.$s;
-			} else {
-				dol_syslog('Bad string syntax to evaluate (dot char is forbidden): '.$s);
-				return '';
+
+		// Disallow also concat
+		if (getDolGlobalString('MAIN_DISALLOW_STRING_OBFUSCATION_IN_DOL_EVAL')) {
+			if (preg_match('/[^0-9]+\.[^0-9]+/', $s)) {    // We refuse . if not between 2 numbers
+				if ($returnvalue) {
+					return 'Bad string syntax to evaluate (dot char is forbidden): '.$s;
+				} else {
+					dol_syslog('Bad string syntax to evaluate (dot char is forbidden): '.$s);
+					return '';
+				}
 			}
 		}
 


### PR DESCRIPTION
FIX allow double colon and string obfuscation in dol eval for computed extra fields

**To reproduce**
- create a decimal (24,8) extra-field with computed value such as : 
dol_include_once('/MODULE/class/tools.class.php')?Tools::calculateWeight($object,isset($obj)?$obj:$objp):'Error'
- it uses a static method "Tools" of Tools class

Then when you want to update a field of the object card, you got an error on computed field because you got a bad value containing the error in a string : "Bad string syntax to evaluate (double : char is forbidden) ..."

**Backport**
The is a backport to allow to concat several point without decimal values in computed extra-field. The const "MAIN_DISALLOW_STRING_OBFUSCATION_IN_DOL_EVAL" was added in commit https://github.com/Dolibarr/dolibarr/commit/3edadbd8b82b175a3f5251102b42497bef8454df

**Add a const**
A const "MAIN_DISALLOW_DOUBLE_COLON_IN_DOL_EVAL" was added here, in order to allow call of static methods.
Otherwise you got an error when you want to update a field on object card.
I don't if it's the good way to by pass this check : https://github.com/Dolibarr/dolibarr/commit/e5fd841fe356d35a1121a16161e73ddcaf2e0595