### PR TITLE
FIX: do not forget extrafields for BOM in export lines

### DIFF
--- a/htdocs/core/modules/modBom.class.php
+++ b/htdocs/core/modules/modBom.class.php
@@ -301,6 +301,7 @@ class modBom extends DolibarrModules
 		$this->export_sql_end[$r]  = ' FROM '.MAIN_DB_PREFIX.'bom_bom as t';
 		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'bom_bom_extrafields as extra on (t.rowid = extra.fk_object)';
 		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'bom_bomline as tl ON tl.fk_bom = t.rowid';
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'bom_bomline_extrafields as extraline ON tl.rowid = extraline.fk_object';
 		$this->export_sql_end[$r] .= ' WHERE 1 = 1';
 		$this->export_sql_end[$r] .= ' AND t.entity IN ('.getEntity('bom').')';
 		$r++;


### PR DESCRIPTION
FIX: do not forget extrafields for BOM in export lines
In the current state we have a delicate message if we dared to create an extrafield in the BOM lines
```
Unknown column 'extraline.commentaire' in 'field list' - sql=SELECT DISTINCT t.rowid as t_rowid, t.ref as t_ref, t.label as t_label, t.bomtype as t_bomtype, t.fk_product as t_fk_product, t.description as t_description, t.qty as t_qty, t.duration as t_duration, t.fk_warehouse as t_fk_warehouse, t.note_public as t_note_public, t.note_private as t_note_private, t.date_creation as t_date_creation, t.tms as t_tms, t.date_valid as t_date_valid, t.fk_user_creat as t_fk_user_creat, t.fk_user_modif as t_fk_user_modif, t.fk_user_valid as t_fk_user_valid, t.import_key as t_import_key, t.model_pdf as t_model_pdf, t.status as t_status, tl.rowid as tl_rowid, tl.fk_product as tl_fk_product, tl.fk_bom_child as tl_fk_bom_child, tl.description as tl_description, tl.qty as tl_qty, tl.qty_frozen as tl_qty_frozen, tl.disable_stock_change as tl_disable_stock_change, tl.efficiency as tl_efficiency, tl.fk_unit as tl_fk_unit, tl.position as tl_position, tl.import_key as tl_import_key, tl.fk_default_workstation as tl_fk_default_workstation, extraline.commentaire as extraline_commentaire FROM llx_bom_bom as t LEFT JOIN llx_bom_bom_extrafields as extra on (t.rowid = extra.fk_object) LEFT JOIN llx_bom_bomline as tl ON tl.fk_bom = t.rowid WHERE 1 = 1 AND t.entity IN (1) 
```
This fixes that