### PR TITLE
FIX: oauth: php 8 warnings

### DIFF
--- a/htdocs/includes/OAuth/Common/Http/Client/AbstractClient.php
+++ b/htdocs/includes/OAuth/Common/Http/Client/AbstractClient.php
@@ -59,15 +59,14 @@ abstract class AbstractClient implements ClientInterface
     /**
      * @param array $headers
      */
-    public function normalizeHeaders(&$headers)
+    public function normalizeHeaders($headers): void
     {
-        // Normalize headers
-        array_walk(
-            $headers,
-            function (&$val, &$key) {
-                $key = ucfirst(strtolower($key));
-                $val = ucfirst(strtolower($key)) . ': ' . $val;
-            }
-        );
+        $normalizeHeaders = [];
+        foreach ($headers as $key => $val) {
+            $val = ucfirst(strtolower($key)) . ': ' . $val;
+            $normalizeHeaders[$key] = $val;
+        }
+
+        return $normalizeHeaders;
     }
 }

--- a/htdocs/includes/OAuth/Common/Http/Client/AbstractClient.php
+++ b/htdocs/includes/OAuth/Common/Http/Client/AbstractClient.php
@@ -59,7 +59,7 @@ abstract class AbstractClient implements ClientInterface
     /**
      * @param array $headers
      */
-    public function normalizeHeaders($headers): void
+    public function normalizeHeaders($headers): array
     {
         $normalizeHeaders = [];
         foreach ($headers as $key => $val) {

--- a/htdocs/includes/OAuth/Common/Http/Client/CurlClient.php
+++ b/htdocs/includes/OAuth/Common/Http/Client/CurlClient.php
@@ -70,7 +70,7 @@ class CurlClient extends AbstractClient
         // Normalize method name
         $method = strtoupper($method);
 
-        $this->normalizeHeaders($extraHeaders);
+        $extraHeaders = $this->normalizeHeaders($extraHeaders);
 
         if ($method === 'GET' && !empty($requestBody)) {
             throw new \InvalidArgumentException('No body expected for "GET" request.');

--- a/htdocs/includes/OAuth/Common/Http/Client/StreamClient.php
+++ b/htdocs/includes/OAuth/Common/Http/Client/StreamClient.php
@@ -33,7 +33,7 @@ class StreamClient extends AbstractClient
         // Normalize method name
         $method = strtoupper($method);
 
-        $this->normalizeHeaders($extraHeaders);
+        $extraHeaders = $this->normalizeHeaders($extraHeaders);
 
         if ($method === 'GET' && !empty($requestBody)) {
             throw new \InvalidArgumentException('No body expected for "GET" request.');


### PR DESCRIPTION
# FIX: oauth: PHP 8 warnings

This is a backport of https://github.com/daviddesberg/PHPoAuthLib/commit/9edfb1d113964c3ad23f32a9eb781c42189d7136

The original error is caused by having variables by reference where not allowed anymore since PHP 8.0