### PR TITLE
FIX: pgsql: case sensitivity in select queries

### DIFF
--- a/htdocs/core/boxes/box_activity.php
+++ b/htdocs/core/boxes/box_activity.php
@@ -111,7 +111,7 @@ class box_activity extends ModeleBoxes
 
 			$data = array();
 
-			$sql = "SELECT p.fk_statut, SUM(p.total_ttc) as Mnttot, COUNT(*) as nb";
+			$sql = "SELECT p.fk_statut, SUM(p.total_ttc) as mnttot, COUNT(*) as nb";
 			$sql .= " FROM (".MAIN_DB_PREFIX."societe as s, ".MAIN_DB_PREFIX."propal as p";
 			if (empty($user->rights->societe->client->voir) && !$user->socid) {
 				$sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -171,7 +171,7 @@ class box_activity extends ModeleBoxes
 
 					$this->info_box_contents[$line][3] = array(
 						'td' => 'class="nowraponall right amount"',
-						'text' => price($data[$j]->Mnttot, 1, $langs, 0, 0, -1, $conf->currency),
+						'text' => price($data[$j]->mnttot, 1, $langs, 0, 0, -1, $conf->currency),
 					);
 					$this->info_box_contents[$line][4] = array(
 						'td' => 'class="right" width="18"',
@@ -200,7 +200,7 @@ class box_activity extends ModeleBoxes
 
 			$data = array();
 
-			$sql = "SELECT c.fk_statut, sum(c.total_ttc) as Mnttot, count(*) as nb";
+			$sql = "SELECT c.fk_statut, sum(c.total_ttc) as mnttot, count(*) as nb";
 			$sql .= " FROM (".MAIN_DB_PREFIX."societe as s, ".MAIN_DB_PREFIX."commande as c";
 			if (empty($user->rights->societe->client->voir) && !$user->socid) {
 				$sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -257,7 +257,7 @@ class box_activity extends ModeleBoxes
 
 					$this->info_box_contents[$line][3] = array(
 						'td' => 'class="nowraponall right amount"',
-						'text' => price($data[$j]->Mnttot, 1, $langs, 0, 0, -1, $conf->currency),
+						'text' => price($data[$j]->mnttot, 1, $langs, 0, 0, -1, $conf->currency),
 					);
 					$this->info_box_contents[$line][4] = array(
 						'td' => 'class="right" width="18"',
@@ -285,7 +285,7 @@ class box_activity extends ModeleBoxes
 
 			// part 1
 			$data = array();
-			$sql = "SELECT f.fk_statut, SUM(f.total_ttc) as Mnttot, COUNT(*) as nb";
+			$sql = "SELECT f.fk_statut, SUM(f.total_ttc) as mnttot, COUNT(*) as nb";
 			$sql .= " FROM (".MAIN_DB_PREFIX."societe as s,".MAIN_DB_PREFIX."facture as f";
 			if (empty($user->rights->societe->client->voir) && !$user->socid) {
 				$sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
@@ -342,7 +342,7 @@ class box_activity extends ModeleBoxes
 
 					$this->info_box_contents[$line][3] = array(
 						'td' => 'class="nowraponall right amount"',
-						'text' => price($data[$j]->Mnttot, 1, $langs, 0, 0, -1, $conf->currency)
+						'text' => price($data[$j]->mnttot, 1, $langs, 0, 0, -1, $conf->currency)
 					);
 
 					// We add only for the current year
@@ -366,7 +366,7 @@ class box_activity extends ModeleBoxes
 
 			// part 2
 			$data = array();
-			$sql = "SELECT f.fk_statut, SUM(f.total_ttc) as Mnttot, COUNT(*) as nb";
+			$sql = "SELECT f.fk_statut, SUM(f.total_ttc) as mnttot, COUNT(*) as nb";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s,".MAIN_DB_PREFIX."facture as f";
 			$sql .= " WHERE f.entity IN (".getEntity('invoice').')';
 			$sql .= " AND f.fk_soc = s.rowid";
@@ -415,7 +415,7 @@ class box_activity extends ModeleBoxes
 					$totalnb += $data[$j]->nb;
 					$this->info_box_contents[$line][3] = array(
 						'td' => 'class="nowraponall right amount"',
-						'text' => price($data[$j]->Mnttot, 1, $langs, 0, 0, -1, $conf->currency),
+						'text' => price($data[$j]->mnttot, 1, $langs, 0, 0, -1, $conf->currency),
 					);
 					$this->info_box_contents[$line][4] = array(
 						'td' => 'class="right" width="18"',

--- a/htdocs/core/boxes/box_validated_projects.php
+++ b/htdocs/core/boxes/box_validated_projects.php
@@ -180,7 +180,7 @@ class box_validated_projects extends ModeleBoxes
 
 					$this->info_box_contents[$i][] = array(
 						'td' => 'class="center"',
-						'text' => $objp->startDate,
+						'text' => $objp->startdate,
 					);
 
 					$this->info_box_contents[$i][] = array(

--- a/htdocs/product/index.php
+++ b/htdocs/product/index.php
@@ -453,7 +453,7 @@ function activitytrim($product_type)
 	$yearofbegindate = date('Y', dol_time_plus_duree(time(), -3, "y"));
 
 	// breakdown by quarter
-	$sql = "SELECT DATE_FORMAT(p.datep,'%Y') as annee, DATE_FORMAT(p.datep,'%m') as mois, SUM(fd.total_ht) as Mnttot";
+	$sql = "SELECT DATE_FORMAT(p.datep,'%Y') as annee, DATE_FORMAT(p.datep,'%m') as mois, SUM(fd.total_ht) as mnttot";
 	$sql .= " FROM ".MAIN_DB_PREFIX."facture as f, ".MAIN_DB_PREFIX."facturedet as fd";
 	$sql .= " , ".MAIN_DB_PREFIX."paiement as p,".MAIN_DB_PREFIX."paiement_facture as pf";
 	$sql .= " WHERE f.entity IN (".getEntity('invoice').")";
@@ -515,19 +515,19 @@ function activitytrim($product_type)
 			}
 
 			if ($objp->mois == "01" || $objp->mois == "02" || $objp->mois == "03") {
-				$trim1 += $objp->Mnttot;
+				$trim1 += $objp->mnttot;
 			}
 
 			if ($objp->mois == "04" || $objp->mois == "05" || $objp->mois == "06") {
-				$trim2 += $objp->Mnttot;
+				$trim2 += $objp->mnttot;
 			}
 
 			if ($objp->mois == "07" || $objp->mois == "08" || $objp->mois == "09") {
-				$trim3 += $objp->Mnttot;
+				$trim3 += $objp->mnttot;
 			}
 
 			if ($objp->mois == "10" || $objp->mois == "11" || $objp->mois == "12") {
-				$trim4 += $objp->Mnttot;
+				$trim4 += $objp->mnttot;
 			}
 
 			$i++;


### PR DESCRIPTION
# FIX: pgsql: case sensitivity in select queries

When selecting fields with uppercase characters, the PHP PostgreSQL driver puts them in lowercase with fetching an object. As a consequence, we have to prohibit uppercase letters in fields names and aliases.

This causes PHP warnings and incorrect results.