### PR TITLE
FIX: accountancy: warning when account not found in plan

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -2147,7 +2147,7 @@ class BookKeeping extends CommonObject
 		dol_syslog(get_class($this)."::select_account", LOG_DEBUG);
 		$resql = $this->db->query($sql);
 		if ($resql) {
-			$obj = '';
+			$obj = (object) array('label' => '');
 			if ($this->db->num_rows($resql)) {
 				$obj = $this->db->fetch_object($resql);
 			}


### PR DESCRIPTION
# FIX: accountancy: warning when account not found in plan

```
( ! ) Warning: Attempt to read property "label" on string in
htdocs/accountancy/class/bookkeeping.class.php on line 2334
```