### PR TITLE
Error urlencode(): Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_param.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_param.tpl.php
@@ -55,7 +55,7 @@ if (!empty($search_array_options) && is_array($search_array_options)) {	// $extr
 			$param .= '&'.$search_options_pattern.$tmpkey.'_endmin='.dol_print_date($val['end'], '%M');
 			$val = '';
 		}
-		if ($val !== '') {
+		if ($val !== '' && $val !== null && $val !== []) {
 			if (is_array($val)) {
 				foreach ($val as $val2) {
 					$param .= '&'.$search_options_pattern.$tmpkey.'[]='.urlencode($val2);


### PR DESCRIPTION
FIX #33863 urlencode(): Passing null to parameter #1 ($string) of type string is deprecated
To fix issue #33863 we must filter void values: ''(empty string), [](empty array) and null; leting pass '0', 0, false and letting pass whatever else

