### PR TITLE
FIX: ajax tooltip warnings

### DIFF
--- a/htdocs/core/class/timespent.class.php
+++ b/htdocs/core/class/timespent.class.php
@@ -716,7 +716,7 @@ class TimeSpent extends CommonObject
 		if (isset($this->status)) {
 			$datas['picto'] .= ' '.$this->getLibStatut(5);
 		}
-		$datas['ref'] .= '<br><b>'.$langs->trans('Ref').':</b> '.$this->ref;
+		$datas['ref'] = '<br><b>'.$langs->trans('Ref').':</b> '.$this->ref;
 
 		return $datas;
 	}

--- a/htdocs/webportal/class/webportalmember.class.php
+++ b/htdocs/webportal/class/webportalmember.class.php
@@ -233,7 +233,7 @@ class WebPortalMember extends Adherent
 		if (isset($this->status)) {
 			$datas['picto'] .= ' ' . $this->getLibStatut(5);
 		}
-		$datas['ref'] .= '<br><b>' . $langs->trans('Ref') . ':</b> ' . $this->ref;
+		$datas['ref'] = '<br><b>' . $langs->trans('Ref') . ':</b> ' . $this->ref;
 
 		return $datas;
 	}

--- a/htdocs/webportal/class/webportalorder.class.php
+++ b/htdocs/webportal/class/webportalorder.class.php
@@ -176,7 +176,7 @@ class WebPortalOrder extends Commande
 		$datas['picto'] = img_picto('', $this->picto) . ' <u>' . $langs->trans("WebPortalOrder") . '</u>';
 		$datas['picto'] .= ' ' . $this->getLibStatut(5);
 
-		$datas['ref'] .= '<br><b>' . $langs->trans('Ref') . ':</b> ' . $this->ref;
+		$datas['ref'] = '<br><b>' . $langs->trans('Ref') . ':</b> ' . $this->ref;
 
 		return $datas;
 	}

--- a/htdocs/webportal/class/webportalpartnership.class.php
+++ b/htdocs/webportal/class/webportalpartnership.class.php
@@ -202,7 +202,7 @@ class WebPortalPartnership extends Partnership
 		if (isset($this->status)) {
 			$datas['picto'] .= ' ' . $this->getLibStatut(5);
 		}
-		$datas['ref'] .= '<br><b>' . $langs->trans('Ref') . ':</b> ' . $this->ref;
+		$datas['ref'] = '<br><b>' . $langs->trans('Ref') . ':</b> ' . $this->ref;
 
 		return $datas;
 	}

--- a/htdocs/webportal/class/webportalpropal.class.php
+++ b/htdocs/webportal/class/webportalpropal.class.php
@@ -177,7 +177,7 @@ class WebPortalPropal extends Propal
 		if (isset($this->status)) {
 			$datas['picto'] .= ' ' . $this->getLibStatut(5);
 		}
-		$datas['ref'] .= '<br><b>' . $langs->trans('Ref') . ':</b> ' . $this->ref;
+		$datas['ref'] = '<br><b>' . $langs->trans('Ref') . ':</b> ' . $this->ref;
 
 		return $datas;
 	}


### PR DESCRIPTION
Fix warnings due to old ModuleBuilder generated code (concanetation operator used but $datas['ref'] does not exists).