### PR TITLE
NEW add settodraft to the supplier invoice API

### DIFF
--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -425,7 +425,6 @@ class SupplierInvoices extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight("fournisseur", "facture", "creer")) {
 			throw new RestException(403);
 		}
-		
 		$result = $this->invoice->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Invoice not found');
@@ -455,7 +454,6 @@ class SupplierInvoices extends DolibarrApi
 		return $this->_cleanObjectDatas($this->invoice);
 	}
 
-	
 	/**
 	 * Get list of payments of a given supplier invoice
 	 *

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -406,6 +406,57 @@ class SupplierInvoices extends DolibarrApi
 	}
 
 	/**
+	 * Sets an invoice as draft
+	 *
+	 * @param   int     $id             Id of supplier invoice
+	 * @param   int     $idwarehouse    Warehouse ID
+	 * @param   int     $notrigger      1=Does not execute triggers, 0= execute triggers
+	 * @return  Object                  Object with cleaned properties
+	 *
+	 * @url POST    {id}/settodraft
+	 *
+	 * @throws RestException 304
+	 * @throws RestException 403
+	 * @throws RestException 404
+	 * @throws RestException 500 System error
+	 */
+	public function settodraft($id, $idwarehouse = -1, $notrigger = 0)
+	{
+		if (!DolibarrApiAccess::$user->hasRight("fournisseur", "facture", "creer")) {
+			throw new RestException(403);
+		}
+		
+		$result = $this->invoice->fetch($id);
+		if (!$result) {
+			throw new RestException(404, 'Invoice not found');
+		}
+
+		if (!DolibarrApi::_checkAccessToResource('fournisseur', $id, 'facture_fourn', 'facture')) {
+			throw new RestException(403, 'Access not allowed for login ' . DolibarrApiAccess::$user->login);
+		}
+
+		$result = $this->invoice->setDraft(DolibarrApiAccess::$user, $idwarehouse, $notrigger);
+		if ($result == 0) {
+			throw new RestException(304, 'Nothing done.');
+		}
+		if ($result < 0) {
+			throw new RestException(500, 'Error : ' . $this->invoice->error);
+		}
+
+		$result = $this->invoice->fetch($id);
+		if (!$result) {
+			throw new RestException(404, 'Invoice not found');
+		}
+
+		if (!DolibarrApi::_checkAccessToResource('fournisseur', $id, 'facture_fourn', 'facture')) {
+			throw new RestException(403, 'Access not allowed for login ' . DolibarrApiAccess::$user->login);
+		}
+
+		return $this->_cleanObjectDatas($this->invoice);
+	}
+
+	
+	/**
 	 * Get list of payments of a given supplier invoice
 	 *
 	 * @param int   $id             Id of SupplierInvoice


### PR DESCRIPTION
Similar to client invoices, I've introduced a new endpoint that allows setting a supplier invoice to draft.
