### PR TITLE
fix: missing classfile for facturerec getElementProperties

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13290,6 +13290,7 @@ function getElementProperties($elementType)
 		$parent_element = 'facture';
 	} elseif ($elementType == 'facturerec') {
 		$classpath = 'compta/facture/class';
+		$classfile = 'facture-rec';
 		$module = 'facture';
 		$classname = 'FactureRec';
 	} elseif ($elementType == 'commande' || $elementType == 'order') {


### PR DESCRIPTION
# FIX|Fix missing classfile for facturerec getElementProperties
I've added class file var for facturerec because it's specific