### PR TITLE
fix: removed useless redefined var in cabyprodserv

### DIFF
--- a/htdocs/compta/stats/cabyprodserv.php
+++ b/htdocs/compta/stats/cabyprodserv.php
@@ -296,12 +296,6 @@ if ($date_end == dol_time_plus_duree($date_start, 1, 'y') - 1) {
 	$periodlink = '';
 }
 
-$builddate = 0;
-$calcmode = '';
-$name = '';
-$period = '';
-$periodlink = '';
-
 report_header($name, $namelink, $period, $periodlink, $description, $builddate, $exportlink, $tableparams, $calcmode);
 
 if (isModEnabled('accounting') && $modecompta != 'BOOKKEEPING') {


### PR DESCRIPTION
# FIX|Fix Removed useless redefined var in cabyprodserv
These vars are already defined. Moreover, they erase the existing name, period, etc.