### PR TITLE
NEW Add option to create simple shipment of non origin. SQL part

### DIFF
--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -287,4 +287,6 @@ ALTER TABLE llx_facture_fourn_rec ADD COLUMN usenewcurrencyrate integer DEFAULT 
 
 ALTER TABLE llx_don ADD COLUMN ip varchar(250);
 
+ALTER TABLE llx_expeditiondet ADD COLUMN description text AFTER fk_entrepot;
+
 INSERT INTO llx_c_type_container (code, label, active, module, position, typecontainer, entity) VALUES ('setup', 'Setup screen', 1, 'system', 500, 'library', __ENTITY__);

--- a/htdocs/install/mysql/tables/llx_expeditiondet.sql
+++ b/htdocs/install/mysql/tables/llx_expeditiondet.sql
@@ -31,6 +31,7 @@ create table llx_expeditiondet
   qty               real,              						    -- Quantity
   fk_unit           integer, 				                    -- ID of unit code
   fk_entrepot       integer,           						    -- Warehouse for departure of product
+  description		text,										-- Product description/label of non origin
   rang              integer  DEFAULT 0,							-- Position of line
   extraparams		varchar(255)				 				-- To save other parameters in json format
 )ENGINE=innodb;


### PR DESCRIPTION
related to #31652
According to mandate for e_reporting everything that exits business premises must be accompanied by a shipment sheet.
This applies to customers, suppliers or even internal movements(e.g. warehouse A to warehouse B, store A to store B etc.)

