### PR TITLE
Fix #33951 Non-blocking minimum sale price in the proposals

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1924,6 +1924,7 @@ if (empty($reshook)) {
 			$res = $product->fetch($productid);
 
 			$type = $product->type;
+			$$price_base_type = $product->price_base_type;
 			$label = ((GETPOST('update_label') && GETPOST('product_label')) ? GETPOST('product_label') : '');
 
 			$price_min = $product->price_min;


### PR DESCRIPTION
#33951 Non-blocking minimum sale price in the proposals  

# FIX|Fix #33951 Non-blocking minimum sale price in the proposals
the price base type was not in the $price_base_type variable and therefore none of the checks were done so it was possible to have a price below the min price

