### PR TITLE
Coreenabled doesn't enable everything globally.

### DIFF
--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -2483,7 +2483,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 					}
 				}
 
-				$entity = $conf->entity; // Reset the current entity
+				$entity = ((!empty($this->always_enabled) || !empty($this->core_enabled)) ? 0 : $conf->entity); // Reset the current entity
 				$newvalue = $value;
 
 				// Serialize array parameters
@@ -2565,7 +2565,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 				if (is_array($value) && isset($value['entity'])) {
 					$entity = $value['entity'];
 				} else {
-					$entity = $conf->entity;
+					$entity = ((!empty($this->always_enabled) || !empty($this->core_enabled)) ? 0 : $conf->entity);
 				}
 
 				$sql = "DELETE FROM ".MAIN_DB_PREFIX."const";


### PR DESCRIPTION
# FIX|Fix [#34167](https://github.com/Dolibarr/dolibarr/issues/34167) - Enabling a "core_enabled" module inserts the "module parts" using the current entity

See [Dolibarr#34167](https://github.com/Dolibarr/dolibarr/issues/34167)