### PR TITLE
FIX: product suplier tab: last modif date column was wrongly dependant of module barcode

### DIFF
--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -959,7 +959,7 @@ END;
 					'pfp.barcode'=>array('label'=>$langs->trans("BarcodeValue"), 'enabled' => isModEnabled('barcode'), 'checked'=>0, 'position'=>16),
 					'pfp.packaging'=>array('label'=>$langs->trans("PackagingForThisProduct"), 'enabled' => getDolGlobalInt('PRODUCT_USE_SUPPLIER_PACKAGING'), 'checked'=>0, 'position'=>17),
 					'pfp.status'=>array('label'=>$langs->trans("Status"), 'enabled' => 1, 'checked'=>0, 'position'=>40),
-					'pfp.tms'=>array('label'=>$langs->trans("DateModification"), 'enabled' => isModEnabled('barcode'), 'checked'=>1, 'position'=>50),
+					'pfp.tms'=>array('label'=>$langs->trans("DateModification"), 'enabled' => '1', 'checked'=>1, 'position'=>50),
 				);
 
 				// fetch optionals attributes and labels

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -959,7 +959,7 @@ END;
 					'pfp.barcode'=>array('label'=>$langs->trans("BarcodeValue"), 'enabled' => isModEnabled('barcode'), 'checked'=>0, 'position'=>16),
 					'pfp.packaging'=>array('label'=>$langs->trans("PackagingForThisProduct"), 'enabled' => getDolGlobalInt('PRODUCT_USE_SUPPLIER_PACKAGING'), 'checked'=>0, 'position'=>17),
 					'pfp.status'=>array('label'=>$langs->trans("Status"), 'enabled' => 1, 'checked'=>0, 'position'=>40),
-					'pfp.tms'=>array('label'=>$langs->trans("DateModification"), 'enabled' => '1', 'checked'=>1, 'position'=>50),
+					'pfp.tms'=>array('label'=>$langs->trans("DateModification"), 'enabled' => 1, 'checked'=>1, 'position'=>50),
 				);
 
 				// fetch optionals attributes and labels


### PR DESCRIPTION
# FIX: product suplier tab: last modif date column was wrongly dependant of module barcode

In product supplier list, since using column selector (see https://github.com/Dolibarr/dolibarr/commit/c6cb179447df6e8a964d3e0d476a1250c051e95d from v13 !), the `pfp.tms` column was only showed if the module barcode is enabled.