### PR TITLE
NEW : Toggle Display of customer Invoices and Credit Notes on Payment Page

### DIFF
--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -65,6 +65,12 @@ $sortfield	= GETPOST('sortfield', 'aZ09comma');
 $sortorder	= GETPOST('sortorder', 'aZ09comma');
 $page = GETPOSTISSET('pageplusone') ? (GETPOSTINT('pageplusone') - 1) : GETPOSTINT("page");
 
+$displayAllInvoices = getDolGlobalInt('MAIN_PAIMENTS_SHOW_ALL_INVOICE_TYPES', 0);
+if (GETPOSTISSET('display-all-invoices')) {
+	$displayAllInvoices = GETPOSTINT('display-all-invoices');
+}
+
+
 $amounts = array();
 $amountsresttopay = array();
 $addwarning = 0;
@@ -474,7 +480,8 @@ if ($result >= 0) {
 
 		//Add js for AutoFill
 		print ' $(document).ready(function () {';
-		print ' 	$(".AutoFillAmount").on(\'click touchstart\', function(){
+			print ' 	$(".AutoFillAmount").on(\'click touchstart\', function(e){
+							e.preventDefault();
 							$("input[name="+$(this).data(\'rowname\')+"]").val($(this).data("value")).trigger("change");
 						});';
 		print '	});'."\n";
@@ -485,6 +492,7 @@ if ($result >= 0) {
 	print '<form id="payment_form" name="add_paiement" action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 	print '<input type="hidden" name="token" value="'.newToken().'">';
 	print '<input type="hidden" name="action" value="add_paiement">';
+		print '<input type="hidden" name="display-all-invoices" value="'.(int) $displayAllInvoices.'">';
 	print '<input type="hidden" name="facid" value="'.$facture->id.'">';
 	print '<input type="hidden" name="socid" value="'.$facture->socid.'">';
 	print '<input type="hidden" name="type" id="invoice_type" value="'.$facture->type.'">';
@@ -588,10 +596,13 @@ if ($result >= 0) {
 	}
 	$sql .= ") AND f.paye = 0";
 	$sql .= " AND f.fk_statut = 1"; // Statut=0 => not validated, Statut=2 => canceled
-	if ($facture->type != Facture::TYPE_CREDIT_NOTE) {
-		$sql .= " AND type IN (0,1,3,5)"; // Standard invoice, replacement, deposit, situation
-	} else {
-		$sql .= " AND type = 2"; // If paying back a credit note, we show all credit notes
+
+	if (!$displayAllInvoices) {
+		if ($facture->type != Facture::TYPE_CREDIT_NOTE) {
+			$sql .= " AND type IN (0,1,3,5)"; // Standard invoice, replacement, deposit, situation
+		} else {
+			$sql .= " AND type = 2"; // If paying back a credit note, we show all credit notes
+		}
 	}
 	if (!getDolGlobalInt('FACTURE_PAYMENTS_INVOICE_REQUESTED_SORT_FIRST')) {
 		// Sort invoices by date and serial number: the older one comes first
@@ -604,20 +615,21 @@ if ($result >= 0) {
 	$resql = $db->query($sql);
 	if ($resql) {
 		$num = $db->num_rows($resql);
+		$totalnboflines = $num = $db->num_rows($resql);
 		if ($num > 0) {
 			$arraytitle = $langs->trans('Invoice');
-			if ($facture->type == 2) {
+			if ($facture->type == Facture::TYPE_CREDIT_NOTE) {
 				$arraytitle = $langs->trans("CreditNotes");
 			}
 			$alreadypayedlabel = $langs->trans('Received');
 			$multicurrencyalreadypayedlabel = $langs->trans('MulticurrencyReceived');
-			if ($facture->type == 2) {
+			if ($facture->type == Facture::TYPE_CREDIT_NOTE) {
 				$alreadypayedlabel = $langs->trans("PaidBack");
 				$multicurrencyalreadypayedlabel = $langs->trans("MulticurrencyPaidBack");
 			}
 			$remaindertopay = $langs->trans('RemainderToTake');
 			$multicurrencyremaindertopay = $langs->trans('MulticurrencyRemainderToTake');
-			if ($facture->type == 2) {
+			if ($facture->type == Facture::TYPE_CREDIT_NOTE) {
 				$remaindertopay = $langs->trans("RemainderToPayBack");
 				$multicurrencyremaindertopay = $langs->trans("MulticurrencyRemainderToPayBack");
 			}
@@ -626,11 +638,36 @@ if ($result >= 0) {
 			//print '<tr><td colspan="3">';
 			print '<br>';
 
+			$moreHtmlRight = '';
+			if ($action=='create') {
+				$urlToggleDisplayMod = $_SERVER["PHP_SELF"].'?facid='.$facid.'&action='.$action.'&accountid='.$accountid.'&display-all-invoices=' . (intval(!$displayAllInvoices));
+
+				if (empty($displayAllInvoices)) {
+					$btnTitle = $langs->trans('DisplayOtherInvoicesToo');
+					if ($object->type != Facture::TYPE_CREDIT_NOTE) {
+						$btnTitle = $langs->trans('DisplayCreditNotesToo');
+					}
+				} else {
+					$btnTitle = $langs->trans('HideOtherInvoices');
+					if ($object->type != Facture::TYPE_CREDIT_NOTE) {
+						$btnTitle = $langs->trans('HideCreditNotes');
+					}
+				}
+
+				$btnIcon = empty($displayAllInvoices) ? 'fa fa-eye' : 'fa fa-eye-slash';
+				$moreHtmlRight.= dolGetButtonTitle($btnTitle, '', $btnIcon, $urlToggleDisplayMod);
+			}
+
+			print_barre_liste($langs->trans('Invoices'), 0, $_SERVER["PHP_SELF"], '', '', '', '', $num, $totalnboflines, 'bill', 0, $moreHtmlRight, '', 0, 0, 0, 1);
+
 			print '<div class="div-table-responsive-no-min">'; // You can use div-table-responsive-no-min if you don't need reserved height for your table
 			print '<table class="noborder centpercent">';
 
 			print '<tr class="liste_titre">';
 			print '<td>'.$arraytitle.'</td>';
+			if ($displayAllInvoices) {
+				print '<td>' . $langs->trans('Type') . '</td>';
+			}
 			print '<td class="center">'.$langs->trans('Date').'</td>';
 			print '<td class="center">'.$langs->trans('DateMaxPayment').'</td>';
 			if (isModEnabled('multicurrency')) {
@@ -661,7 +698,7 @@ if ($result >= 0) {
 				$objp = $db->fetch_object($resql);
 
 				$sign = 1;
-				if ($facture->type == Facture::TYPE_CREDIT_NOTE) {
+				if ($facture->type == Facture::TYPE_CREDIT_NOTE && !$displayAllInvoices) {
 					$sign = -1;
 				}
 
@@ -707,6 +744,18 @@ if ($result >= 0) {
 					print ' - '.$soc->getNomUrl(1).' ';
 				}
 				print "</td>\n";
+
+				// type
+				if ($displayAllInvoices) {
+					$typearray = [
+						Facture::TYPE_STANDARD => $langs->trans("InvoiceStandard"),
+						Facture::TYPE_REPLACEMENT => $langs->trans("InvoiceReplacement"),
+						Facture::TYPE_CREDIT_NOTE => $langs->trans("InvoiceAvoir"),
+						Facture::TYPE_DEPOSIT => $langs->trans("InvoiceDeposit"),
+					];
+					// Primary Secondary Success Danger Warning Info Light Dark status0 status1 status2 status3 status4 status5 status6 status7 status8 status9
+					print '<td class="center nowraponall">' . $typearray[$objp->type] . '</td>';
+				}
 
 				// Date
 				print '<td class="center">'.dol_print_date($db->jdate($objp->df), 'day')."</td>\n";
@@ -763,13 +812,21 @@ if ($result >= 0) {
 					// Add remind multicurrency amount
 					$namef = 'multicurrency_amount_'.$objp->facid;
 					$nameRemain = 'multicurrency_remain_'.$objp->facid;
+					$min = $max = '';
+					if ($displayAllInvoices) {
+						if ($objp->type == Facture::TYPE_CREDIT_NOTE) {
+							$max = ' max="0" ';
+						} else {
+							$min = ' min="0" ';
+						}
+					}
 
 					if ($objp->multicurrency_code && $objp->multicurrency_code != $conf->currency) {
 						if ($action != 'add_paiement') {
 							if (!empty($conf->use_javascript_ajax)) {
-								print img_picto("Auto fill", 'rightarrow', "class='AutoFillAmount' data-rowname='".$namef."' data-value='".($sign * (float) $multicurrency_remaintopay)."'");
+								print '<button class="btn-low-emphasis --btn-icon AutoFillAmount" data-rowname="'.$namef.'" data-value="'.($sign * (float) $multicurrency_remaintopay).'">'.img_picto("Auto fill", 'rightarrow');
 							}
-							print '<input type="text" class="maxwidth75 multicurrency_amount" name="'.$namef.'" value="'.(GETPOST($namef) != '0' ? GETPOST($namef) : '').'">';
+							print '<input '.$min.' '.$max.' type="number" step="any" size="8" class="multicurrency_amount" name="'.$namef.'" value="'.GETPOST($namef).'">';
 							print '<input type="hidden" class="multicurrency_remain" name="'.$nameRemain.'" value="'.$multicurrency_remaintopay.'">';
 						} else {
 							print '<input type="text" class="maxwidth75" name="'.$namef.'_disabled" value="'.(GETPOST($namef) != '0' ? GETPOST($namef) : '').'" disabled>';
@@ -827,11 +884,20 @@ if ($result >= 0) {
 				$namef = 'amount_'.$objp->facid;
 				$nameRemain = 'remain_'.$objp->facid;
 
+				$min = $max = '';
+				if ($displayAllInvoices) {
+					if ($objp->type == Facture::TYPE_CREDIT_NOTE) {
+						$max = ' max="0" ';
+					} else {
+						$min = ' min="0" ';
+					}
+				}
+
 				if ($action != 'add_paiement') {
 					if (!empty($conf->use_javascript_ajax)) {
-						print img_picto("Auto fill", 'rightarrow', "class='AutoFillAmount' data-rowname='".$namef."' data-value='".($sign * (float) $remaintopay)."'");
+						print '<button  class="btn-low-emphasis --btn-icon AutoFillAmount" data-rowname="'.$namef.'" data-value="'.($sign * (float) $remaintopay).'">'.img_picto("Auto fill", 'rightarrow').'</button>';
 					}
-					print '<input type="text" class="maxwidth75 amount" id="'.$namef.'" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">';
+					print '<input '.$max.' '.$min.' type="number" step="any" size="8" class="amount" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">'; // class is required to be used by javascript callForResult();
 					print '<input type="hidden" class="remain" name="'.$nameRemain.'" value="'.$remaintopay.'">';
 				} else {
 					print '<input type="text" class="maxwidth75" name="'.$namef.'_disabled" value="'.dol_escape_htmltag(GETPOST($namef)).'" disabled>';
@@ -861,9 +927,16 @@ if ($result >= 0) {
 			}
 
 			if ($i > 1) {
+				$colspan = 3;
+
+				// type
+				if ($displayAllInvoices) {
+					$colspan++;
+				}
+
 				// Print total
 				print '<tr class="liste_total">';
-				print '<td colspan="3" class="left">'.$langs->trans('TotalTTC').'</td>';
+				print '<td colspan="'.$colspan.'" class="left">'.$langs->trans('TotalTTC').'</td>';
 				if (isModEnabled('multicurrency')) {
 					print '<td></td>';
 					print '<td></td>';

--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -661,7 +661,8 @@ if ($result >= 0) {
 			print_barre_liste($langs->trans('Invoices'), 0, $_SERVER["PHP_SELF"], '', '', '', '', $num, $totalnboflines, 'bill', 0, $moreHtmlRight, '', 0, 0, 0, 1);
 
 			print '<div class="div-table-responsive-no-min">'; // You can use div-table-responsive-no-min if you don't need reserved height for your table
-			print '<table class="noborder centpercent">';
+			print '<table id="customer-invoices-paiments-list" class="noborder centpercent" data-display-all-invoices="' . (int) $displayAllInvoices . '" >';
+			print '<thead>';
 
 			print '<tr class="liste_titre">';
 			print '<td>'.$arraytitle.'</td>';
@@ -687,13 +688,14 @@ if ($result >= 0) {
 
 			print '<td align="right">&nbsp;</td>';
 			print "</tr>\n";
-
+			print '</thead>';
 			$total_ttc = 0;
 			$totalrecu = 0;
 			$totalrecucreditnote = 0;
 			$totalrecudeposits = 0;
 			$sign = 1;
 
+			print '<tbody>';
 			while ($i < $num) {
 				$objp = $db->fetch_object($resql);
 
@@ -736,7 +738,7 @@ if ($result >= 0) {
 				$tooltiponfullamount .= $langs->trans('AmountVAT') . ": " . price($objp->total_tva, 0, $langs, 0, -1, -1, $conf->currency) . "<br>";
 				$tooltiponfullamount .= $langs->trans('AmountTTC') . ": " . price($objp->total_ttc, 0, $langs, 0, -1, -1, $conf->currency) . "<br>";
 
-				print '<tr class="oddeven'.(($invoice->id == $facid) ? ' highlight' : '').'">';
+				print '<tr data-row-type="'.$objp->type.'" class="oddeven'.(($invoice->id == $facid) ? ' highlight' : '').'">';
 
 				print '<td class="nowraponall">';
 				print $invoice->getNomUrl(1, '');
@@ -925,6 +927,7 @@ if ($result >= 0) {
 				$totalrecudeposits += $deposits;
 				$i++;
 			}
+			print '</tbody>';
 
 			if ($i > 1) {
 				$colspan = 3;
@@ -935,6 +938,8 @@ if ($result >= 0) {
 				}
 
 				// Print total
+
+				print '<tfoot>';
 				print '<tr class="liste_total">';
 				print '<td colspan="'.$colspan.'" class="left">'.$langs->trans('TotalTTC').'</td>';
 				if (isModEnabled('multicurrency')) {
@@ -957,6 +962,7 @@ if ($result >= 0) {
 				print '<td class="right" id="result" style="font-weight: bold;"></td>'; // Autofilled
 				print '<td align="center">&nbsp;</td>';
 				print "</tr>\n";
+				print '</tfoot>';
 			}
 			print "</table>";
 			print "</div>\n";

--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -9067,6 +9067,11 @@ table.jPicker {
 	}
 }
 
+/** For toggle Display of customer/Supplyer Invoices and Credit Notes on Payment Page */
+:where(#fourn-invoices-paiments-list,#customer-invoices-paiments-list)[data-display-all-invoices="1"] tr[data-row-type="2"]{
+	font-weight: bold;
+}
+
 <?php
 if (getDolUserString('MAIN_OPTIMIZEFORTEXTBROWSER')) {
 	// Set a max height on multiselect when using multiselect


### PR DESCRIPTION
# New Toggle Display of customer Invoices and Credit Notes on Payment Page

see #33856



Toggle Display of Customer Invoices and Credit Notes on Payment Page

# Feature Description

This development introduces an enhancement to the customer payment page in Dolibarr, allowing users to toggle the visibility of invoice types (invoices and credit notes) based on the current context.

## More specifically:

- When viewing credit notes, a "view" (eye) button allows users to also display related invoices for the same supplier.
- Conversely, when viewing invoices, clicking the same button reveals the credit notes associated with that supplier.

## Purpose

The main goal of this feature is to facilitate global payments, especially in the context of direct debit payments.

With this enhancement, users can now see all relevant documents (invoices + credit notes) for a customer, allowing them to record a single, comprehensive payment and allocate amounts correctly.
