### PR TITLE
FIX: accountancy: bad filter on custom account groups

### DIFF
--- a/htdocs/accountancy/bookkeeping/export.php
+++ b/htdocs/accountancy/bookkeeping/export.php
@@ -348,7 +348,7 @@ if (empty($reshook)) {
 		$listofaccountsforgroup2 = array();
 		if (is_array($listofaccountsforgroup)) {
 			foreach ($listofaccountsforgroup as $tmpval) {
-				$listofaccountsforgroup2[] = "'".$db->escape($tmpval['id'])."'";
+				$listofaccountsforgroup2[] = "'".$db->escape($tmpval['account_number'])."'";
 			}
 		}
 		$filter['t.search_accounting_code_in'] = join(',', $listofaccountsforgroup2);

--- a/htdocs/accountancy/bookkeeping/list.php
+++ b/htdocs/accountancy/bookkeeping/list.php
@@ -332,7 +332,7 @@ if (empty($reshook)) {
 		$listofaccountsforgroup2 = array();
 		if (is_array($listofaccountsforgroup)) {
 			foreach ($listofaccountsforgroup as $tmpval) {
-				$listofaccountsforgroup2[] = "'".$db->escape($tmpval['id'])."'";
+				$listofaccountsforgroup2[] = "'".$db->escape($tmpval['account_number'])."'";
 			}
 		}
 		$filter['t.search_accounting_code_in'] = join(',', $listofaccountsforgroup2);

--- a/htdocs/accountancy/bookkeeping/listbyaccount.php
+++ b/htdocs/accountancy/bookkeeping/listbyaccount.php
@@ -291,7 +291,7 @@ if (empty($reshook)) {
 		$listofaccountsforgroup2 = array();
 		if (is_array($listofaccountsforgroup)) {
 			foreach ($listofaccountsforgroup as $tmpval) {
-				$listofaccountsforgroup2[] = "'".$db->escape($tmpval['id'])."'";
+				$listofaccountsforgroup2[] = "'".$db->escape($tmpval['account_number'])."'";
 			}
 		}
 		$filter['t.search_accounting_code_in'] = join(',', $listofaccountsforgroup2);


### PR DESCRIPTION
# FIX: accountancy: bad filter on custom account groups

The filter `t.search_accounting_code_in` of `BookKeeping::fetchAllByAccount()` needs an account number (see https://github.com/Dolibarr/dolibarr/blob/18.0/htdocs/accountancy/class/bookkeeping.class.php#L906) but is given an account id.


