### PR TITLE
FIX|Fix # Ticket module: display issue with HTML links in header/footer configuration

### DIFF
--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -231,7 +231,7 @@ if ($action == 'updateMask') {
 		$error++;
 	}
 
-	$mail_signature = GETPOST('TICKET_MESSAGE_MAIL_SIGNATURE', 'restricthtml');
+	$mail_signature = htmlspecialchars_decode(GETPOST('TICKET_MESSAGE_MAIL_SIGNATURE', 'restricthtml'));
 	$signature_description = "Signature of ticket replies sent from Dolibarr";
 	if (!empty($mail_signature)) {
 		$res = dolibarr_set_const($db, 'TICKET_MESSAGE_MAIL_SIGNATURE', $mail_signature, 'chaine', 0, $signature_description, $conf->entity);

--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -220,7 +220,7 @@ if ($action == 'updateMask') {
 		$error++;
 	}
 
-	$mail_intro = GETPOST('TICKET_MESSAGE_MAIL_INTRO', 'restricthtml');
+	$mail_intro = htmlspecialchars_decode(GETPOST('TICKET_MESSAGE_MAIL_INTRO', 'restricthtml'));
 	$mail_intro_description = "Introduction text of ticket replies sent from Dolibarr";
 	if (!empty($mail_intro)) {
 		$res = dolibarr_set_const($db, 'TICKET_MESSAGE_MAIL_INTRO', $mail_intro, 'chaine', 0, $mail_intro_description, $conf->entity);

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1835,13 +1835,13 @@ class FormTicket
 			}
 			if (getDolGlobalString('TICKET_MESSAGE_MAIL_INTRO')) {
 				$mail_intro = make_substitutions(getDolGlobalString('TICKET_MESSAGE_MAIL_INTRO'), $this->substit);
-				print '<input type="hidden" name="mail_intro" value="'.$mail_intro.'">';
+				print '<input type="hidden" name="mail_intro" value="'.htmlspecialchars($mail_intro, ENT_QUOTES).'">';
 				$texttooltip .= '<br><u>'.$langs->trans("TicketMessageMailIntro").'</u><br>'.$mail_intro;
 			}
 			if (getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE')) {
 				$mail_signature = make_substitutions(getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE'), $this->substit);
 				print '<input type="hidden" name="mail_signature" value="'.htmlspecialchars($mail_signature, ENT_QUOTES) .'">';
-				$texttooltip .= '<br><br><u>'.$langs->trans("TicketMessageMailFooter").'</u><br>'.htmlspecialchars($mail_signature, ENT_QUOTES);
+				$texttooltip .= '<br><br><u>'.$langs->trans("TicketMessageMailFooter").'</u><br>'.$mail_signature;
 			}
 			print $form->textwithpicto('', $texttooltip, 1, 'help');
 		}

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1840,8 +1840,8 @@ class FormTicket
 			}
 			if (getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE')) {
 				$mail_signature = make_substitutions(getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE'), $this->substit);
-				print '<input type="hidden" name="mail_signature" value="'.$mail_signature.'">';
-				$texttooltip .= '<br><br><u>'.$langs->trans("TicketMessageMailFooter").'</u><br>'.$mail_signature;
+				print '<input type="hidden" name="mail_signature" value="'.htmlspecialchars($mail_signature, ENT_QUOTES) .'">';
+				$texttooltip .= '<br><br><u>'.$langs->trans("TicketMessageMailFooter").'</u><br>'.htmlspecialchars($mail_signature, ENT_QUOTES);
 			}
 			print $form->textwithpicto('', $texttooltip, 1, 'help');
 		}


### PR DESCRIPTION
Problem encountered (Ticket module)

In the ticket module, when HTML links are used in the message header or footer configuration fields, a display issue occurs for private messages and for email sending above the ticket form.

If these fields contain an HTML link, and the value is injected into a `<input type="hidden">`, the presence of the HTML tag breaks the markup: everything after the link is incorrectly displayed above the form, resulting in misplaced content and incorrect rendering (truncated links, shifted display, broken HTML structure, etc.).


Solution implemented

The implemented solution is to properly decode HTML entities (using ) when retrieving the signature from the hidden input in the ticket module.

This now allows the original HTML content (including links) to be correctly rendered in both forms and emails, without disrupting the page’s structure or display `htmlspecialchars_decode`
