### PR TITLE
Apply dol-20.0 solution (cherry pick of #4a3edf9)

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -2519,81 +2519,86 @@ class ActionComm extends CommonObject
 
 					// Load event
 					$res = $this->fetch($actionCommReminder->fk_actioncomm);
-					if ($res > 0) $res = $this->fetch_thirdparty();
 					if ($res > 0) {
-						// PREPARE EMAIL
-						$errormesg = '';
+						$res2 = $this->fetch_thirdparty();
+						if ($res2 >= 0) {
+							// PREPARE EMAIL
+							$errormesg = '';
 
-						// Make substitution in email content
-						$substitutionarray = getCommonSubstitutionArray($langs, 0, '', $this);
+							// Make substitution in email content
+							$substitutionarray = getCommonSubstitutionArray($langs, 0, null, $this);
 
-						complete_substitutions_array($substitutionarray, $langs, $this);
+							complete_substitutions_array($substitutionarray, $langs, $this);
 
-						// Content
-						$sendContent = make_substitutions($langs->trans($arraymessage->content), $substitutionarray);
+							// Content
+							$sendContent = make_substitutions($langs->trans($arraymessage->content), $substitutionarray);
 
-						//Topic
-						$sendTopic = (!empty($arraymessage->topic)) ? $arraymessage->topic : html_entity_decode($langs->transnoentities('EventReminder'));
+							//Topic
+							$sendTopic = (!empty($arraymessage->topic)) ? $arraymessage->topic : html_entity_decode($langs->transnoentities('EventReminder'));
 
-						// Recipient
-						$recipient = new User($this->db);
-						$res = $recipient->fetch($actionCommReminder->fk_user);
-						if ($res > 0) {
-							if (!empty($recipient->email)) {
-								$to = $recipient->email;
+							// Recipient
+							$recipient = new User($this->db);
+							$res = $recipient->fetch($actionCommReminder->fk_user);
+							if ($res > 0) {
+								if (!empty($recipient->email)) {
+									$to = $recipient->email;
+								} else {
+									$errormesg = "Failed to send remind to user id=".$actionCommReminder->fk_user.". No email defined for user.";
+									$error++;
+								}
 							} else {
-								$errormesg = "Failed to send remind to user id=".$actionCommReminder->fk_user.". No email defined for user.";
+								$errormesg = "Failed to load recipient with user id=".$actionCommReminder->fk_user;
 								$error++;
+							}
+
+							// Sender
+							$from = getDolGlobalString('MAIN_MAIL_EMAIL_FROM');
+							if (empty($from)) {
+								$errormesg = "Failed to get sender into global setup MAIN_MAIL_EMAIL_FROM";
+								$error++;
+							}
+
+							if (!$error) {
+								// Errors Recipient
+								$errors_to = getDolGlobalString('MAIN_MAIL_ERRORS_TO');
+
+								// Mail Creation
+								$cMailFile = new CMailFile($sendTopic, $to, $from, $sendContent, array(), array(), array(), '', "", 0, 1, $errors_to, '', '', '', '', '');
+
+								// Sending Mail
+								if ($cMailFile->sendfile()) {
+									$nbMailSend++;
+								} else {
+									$errormesg = 'Failed to send email to: '.$to.' '.$cMailFile->error.implode(',', $cMailFile->errors);
+									$error++;
+								}
+							}
+
+							if (!$error) {
+								$actionCommReminder->status = $actionCommReminder::STATUS_DONE;
+
+								$res = $actionCommReminder->update($user);
+								if ($res < 0) {
+									$errorsMsg[] = "Failed to update status to done of ActionComm Reminder";
+									$error++;
+									break; // This is to avoid to have this error on all the selected email. If we fails here for one record, it may fails for others. We must solve first.
+								}
+							} else {
+								$actionCommReminder->status = $actionCommReminder::STATUS_ERROR;
+								$actionCommReminder->lasterror = dol_trunc($errormesg, 128, 'right', 'UTF-8', 1);
+
+								$res = $actionCommReminder->update($user);
+								if ($res < 0) {
+									$errorsMsg[] = "Failed to update status to error of ActionComm Reminder";
+									$error++;
+									break; // This is to avoid to have this error on all the selected email. If we fails here for one record, it may fails for others. We must solve first.
+								} else {
+									$errorsMsg[] = $errormesg;
+								}
 							}
 						} else {
-							$errormesg = "Failed to load recipient with user id=".$actionCommReminder->fk_user;
+							$errorsMsg[] = 'Failed to fetch record thirdparty on actioncomm with ID = '.$actionCommReminder->fk_actioncomm;
 							$error++;
-						}
-
-						// Sender
-						$from = getDolGlobalString('MAIN_MAIL_EMAIL_FROM');
-						if (empty($from)) {
-							$errormesg = "Failed to get sender into global setup MAIN_MAIL_EMAIL_FROM";
-							$error++;
-						}
-
-						if (!$error) {
-							// Errors Recipient
-							$errors_to = getDolGlobalString('MAIN_MAIL_ERRORS_TO');
-
-							// Mail Creation
-							$cMailFile = new CMailFile($sendTopic, $to, $from, $sendContent, array(), array(), array(), '', "", 0, 1, $errors_to, '', '', '', '', '');
-
-							// Sending Mail
-							if ($cMailFile->sendfile()) {
-								$nbMailSend++;
-							} else {
-								$errormesg = 'Failed to send email to: '.$to.' '.$cMailFile->error.join(',', $cMailFile->errors);
-								$error++;
-							}
-						}
-
-						if (!$error) {
-							$actionCommReminder->status = $actionCommReminder::STATUS_DONE;
-
-							$res = $actionCommReminder->update($user);
-							if ($res < 0) {
-								$errorsMsg[] = "Failed to update status to done of ActionComm Reminder";
-								$error++;
-								break; // This is to avoid to have this error on all the selected email. If we fails here for one record, it may fails for others. We must solve first.
-							}
-						} else {
-							$actionCommReminder->status = $actionCommReminder::STATUS_ERROR;
-							$actionCommReminder->lasterror = dol_trunc($errormesg, 128, 'right', 'UTF-8', 1);
-
-							$res = $actionCommReminder->update($user);
-							if ($res < 0) {
-								$errorsMsg[] = "Failed to update status to error of ActionComm Reminder";
-								$error++;
-								break; // This is to avoid to have this error on all the selected email. If we fails here for one record, it may fails for others. We must solve first.
-							} else {
-								$errorsMsg[] = $errormesg;
-							}
 						}
 					} else {
 						$errorsMsg[] = 'Failed to fetch record actioncomm with ID = '.$actionCommReminder->fk_actioncomm;


### PR DESCRIPTION
Original commit and fix message #4a3edf9 says "STOCK_ALLOW_NEGATIVE_TRANSFER on" ... but in 18.0 "my" problem is with email notification linked from calendar : cron task is blocked in the past due to non-thirdparty linked events like that:

![image](https://github.com/user-attachments/assets/5420c9db-18c9-4178-99e3-59df22f96db3)


and when i try to start cron the error message is

![image](https://github.com/user-attachments/assets/30ffd2a8-0657-4415-bb2f-2ca01da94c18)

if i add a thirdpart to that event everything is ok ... so that patch fix also that bug :)