### PR TITLE
FIX #34046 No traceability when generating Intervention from Task Time

### DIFF
--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -1469,7 +1469,7 @@ class Fichinter extends CommonObject
 
 			if ($result >= 0) {
 				$this->db->commit();
-				return 1;
+				return $line->id;
 			} else {
 				$this->error = $this->db->error();
 				$this->db->rollback();

--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -2107,8 +2107,6 @@ class Task extends CommonObjectLine
 		$timespent->note = $this->timespent_note;
 		$timespent->invoice_id = $this->timespent_invoiceid;
 		$timespent->invoice_line_id = $this->timespent_invoicelineid;
-		$timespent->intervention_id = $this->intervention_id;
-		$timespent->intervention_line_id = $this->intervention_line_id;
 
 		dol_syslog(get_class($this)."::updateTimeSpent", LOG_DEBUG);
 		if ($timespent->update($user) > 0) {

--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -2107,6 +2107,8 @@ class Task extends CommonObjectLine
 		$timespent->note = $this->timespent_note;
 		$timespent->invoice_id = $this->timespent_invoiceid;
 		$timespent->invoice_line_id = $this->timespent_invoicelineid;
+		$timespent->intervention_id = $this->intervention_id;
+		$timespent->intervention_line_id = $this->intervention_line_id;
 
 		dol_syslog(get_class($this)."::updateTimeSpent", LOG_DEBUG);
 		if ($timespent->update($user) > 0) {

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -845,7 +845,7 @@ if ($action == 'confirm_generateinter') {
 				$arrayoftasks[$object->timespent_id]['timespent'] = $object->timespent_duration;
 				$arrayoftasks[$object->timespent_id]['totalvaluetodivideby3600'] = $object->timespent_duration * $object->timespent_thm;
 				$arrayoftasks[$object->timespent_id]['note'] = $object->timespent_note;
-				$arrayoftasks[$object->timespent_id]['date'] = date('Y-m-d H:i:s', $object->timespent_datehour);
+				$arrayoftasks[$object->timespent_id]['date'] = $object->timespent_datehour;
 			}
 
 			foreach ($arrayoftasks as $timespent_id => $value) {
@@ -857,6 +857,19 @@ if ($action == 'confirm_generateinter') {
 
 				// Add lines
 				$lineid = $tmpinter->addline($user, $tmpinter->id, $ftask->label . (!empty($value['note']) ? ' - ' . $value['note'] : ''), (int) $value['date'], $value['timespent']);
+
+				if ($lineid > 0) {
+					// Link timespent to intervention
+					//$object->fetchTimeSpent($timespent_id);
+					$object->timespent_id = $timespent_id;
+					$object->intervention_id = $tmpinter->id;
+					$object->intervention_line_id = $lineid;
+					$result = $object->updateTimeSpent($user);
+					if ($result < 0) {
+						$error++;
+						setEventMessages($object->error, $object->errors, 'errors');
+					}
+				}
 			}
 		}
 

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -860,7 +860,6 @@ if ($action == 'confirm_generateinter') {
 
 				if ($lineid > 0) {
 					// Link timespent to intervention
-					//$object->fetchTimeSpent($timespent_id);
 					$object->timespent_id = $timespent_id;
 					$object->intervention_id = $tmpinter->id;
 					$object->intervention_line_id = $lineid;

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -860,13 +860,14 @@ if ($action == 'confirm_generateinter') {
 
 				if ($lineid > 0) {
 					// Link timespent to intervention
-					$object->timespent_id = $timespent_id;
-					$object->intervention_id = $tmpinter->id;
-					$object->intervention_line_id = $lineid;
-					$result = $object->updateTimeSpent($user);
+					$timespent = new TimeSpent($db);
+					$timespent->fetch($timespent_id);
+					$timespent->intervention_id = $tmpinter->id;
+					$timespent->intervention_line_id = $lineid;
+					$result = $timespent->update($user);
 					if ($result < 0) {
 						$error++;
-						setEventMessages($object->error, $object->errors, 'errors');
+						setEventMessages($timespent->error, $timespent->errors, 'errors');
 					}
 				}
 			}


### PR DESCRIPTION
FIX #34046 

- Ensure that intervention_id and intervention_line_id fields are correctly populated in the element_time table.
- Correct the intervention line date when it is generated from task time entries.