### PR TITLE
FIX: pgsql: cast string_agg arguments

### DIFF
--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -167,6 +167,7 @@ class DoliDBPgsql extends DoliDB
 			$line = preg_replace('/GROUP_CONCAT/i', 'STRING_AGG', $line);
 			$line = preg_replace('/ SEPARATOR/i', ',', $line);
 			$line = preg_replace('/STRING_AGG\(([^,\)]+)\)/i', 'STRING_AGG(\\1, \',\')', $line);
+			$line = preg_replace('/STRING_AGG\(([^,]+),([^\)]+)\)/i', 'STRING_AGG(\\1::TEXT, \\2::TEXT)', $line);
 			//print $line."\n";
 
 			if ($type == 'auto') {

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -167,7 +167,7 @@ class DoliDBPgsql extends DoliDB
 			$line = preg_replace('/GROUP_CONCAT/i', 'STRING_AGG', $line);
 			$line = preg_replace('/ SEPARATOR/i', ',', $line);
 			$line = preg_replace('/STRING_AGG\(([^,\)]+)\)/i', 'STRING_AGG(\\1, \',\')', $line);
-			$line = preg_replace('/STRING_AGG\(([^,]+),([^\)]+)\)/i', 'STRING_AGG(\\1::TEXT, \\2::TEXT)', $line);
+			$line = preg_replace('/STRING_AGG\(([^,]+),([^\)]+)\)/i', 'STRING_AGG(\\1::TEXT,\\2::TEXT)', $line);
 			//print $line."\n";
 
 			if ($type == 'auto') {

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -305,10 +305,10 @@ $positiverates = '';
 if (price2num($line->tva_tx)) {
 	$positiverates .= ($positiverates ? '/' : '').price2num($line->tva_tx);
 }
-if (price2num($line->total_localtax1)) {
+if (price2num($line->localtax1_tx)) {
 	$positiverates .= ($positiverates ? '/' : '').price2num($line->localtax1_tx);
 }
-if (price2num($line->total_localtax2)) {
+if (price2num($line->localtax2_tx)) {
 	$positiverates .= ($positiverates ? '/' : '').price2num($line->localtax2_tx);
 }
 if (empty($positiverates)) {

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -959,7 +959,7 @@ END;
 					'pfp.barcode'=>array('label'=>$langs->trans("BarcodeValue"), 'enabled' => isModEnabled('barcode'), 'checked'=>0, 'position'=>16),
 					'pfp.packaging'=>array('label'=>$langs->trans("PackagingForThisProduct"), 'enabled' => getDolGlobalInt('PRODUCT_USE_SUPPLIER_PACKAGING'), 'checked'=>0, 'position'=>17),
 					'pfp.status'=>array('label'=>$langs->trans("Status"), 'enabled' => 1, 'checked'=>0, 'position'=>40),
-					'pfp.tms'=>array('label'=>$langs->trans("DateModification"), 'enabled' => isModEnabled('barcode'), 'checked'=>1, 'position'=>50),
+					'pfp.tms'=>array('label'=>$langs->trans("DateModification"), 'enabled' => 1, 'checked'=>1, 'position'=>50),
 				);
 
 				// fetch optionals attributes and labels

--- a/test/phpunit/PgsqlTest.php
+++ b/test/phpunit/PgsqlTest.php
@@ -189,13 +189,13 @@ class PgsqlTest extends PHPUnit\Framework\TestCase
 		$sql="SELECT a.b, GROUP_CONCAT(a.c) FROM table GROUP BY a.b";
 		$result=DoliDBPgsql::convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
-		$this->assertEquals($result, "SELECT a.b, STRING_AGG(a.c, ',') FROM table GROUP BY a.b", 'Test GROUP_CONCAT (without SEPARATOR)');
+		$this->assertEquals($result, "SELECT a.b, STRING_AGG(a.c::TEXT, ','::TEXT) FROM table GROUP BY a.b", 'Test GROUP_CONCAT (without SEPARATOR)');
 
 		// Test GROUP_CONCAT (with SEPARATOR)
 		$sql="SELECT a.b, GROUP_CONCAT(a.c SEPARATOR ',') FROM table GROUP BY a.b";
 		$result=DoliDBPgsql::convertSQLFromMysql($sql);
 		print __METHOD__." result=".$result."\n";
-		$this->assertEquals($result, "SELECT a.b, STRING_AGG(a.c, ',') FROM table GROUP BY a.b", 'Test GROUP_CONCAT (with SEPARATOR)');
+		$this->assertEquals($result, "SELECT a.b, STRING_AGG(a.c::TEXT, ','::TEXT) FROM table GROUP BY a.b", 'Test GROUP_CONCAT (with SEPARATOR)');
 
 		return $result;
 	}


### PR DESCRIPTION
# FIX: pgsql: cast string_agg arguments

When converting MySQL/MariaDB `GROUP_CONCAT` calls to PostgreSQL `STRING_AGG`, an error occurs because of incorrect argument types (the literal `','` that is added if no `SEPARATOR` is given in the original call is of type `unknown`, for example).

`STRING_AGG` takes either `(TEXT, TEXT)` or `(BYTEA, BYTEA)` arguments (see https://www.postgresql.org/docs/12/functions-aggregate.html), therefore, I propose casting to `TEXT`.


