### PR TITLE
FIX - Adding mapping to module rights

### DIFF
--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -718,6 +718,7 @@ class User extends CommonObject
 			'mo' => 'mrp',
 			'order' => 'commande',
 			'produit' => 'product',
+			'productlot' => 'produit',
 			'project' => 'projet',
 			'propale' => 'propal',
 			'shipping' => 'expedition',


### PR DESCRIPTION
# FIX - Adding mapping to module rights 
Actually its impossible to add linked event to product lot because rights "productlot" dosnt exist. I added a mapping for get "product" rights when "product lot" rights are used

