### PR TITLE
FIX: pgsql: error when calculating depreciations

### DIFF
--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -931,7 +931,7 @@ class Asset extends CommonObject
 				$sql = "DELETE FROM " . MAIN_DB_PREFIX . "asset_depreciation";
 				$sql .= " WHERE fk_asset = " . (int) $this->id;
 				$sql .= " AND depreciation_mode = '" . $this->db->escape($mode_key) . "'";
-				$sql .= " AND rowid NOT IN (SELECT fk_docdet FROM " . MAIN_DB_PREFIX . "accounting_bookkeeping WHERE doc_type = 'asset')";
+				$sql .= " AND NOT EXISTS (SELECT fk_docdet FROM " . MAIN_DB_PREFIX . "accounting_bookkeeping WHERE doc_type = 'asset' AND fk_docdet = " . $this->db->prefix(). "asset_depreciation.rowid)";
 				if ($last_depreciation_date !== "") {
 					$sql .= " AND ref != ''";
 				}

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -931,7 +931,7 @@ class Asset extends CommonObject
 				$sql = "DELETE FROM " . MAIN_DB_PREFIX . "asset_depreciation";
 				$sql .= " WHERE fk_asset = " . (int) $this->id;
 				$sql .= " AND depreciation_mode = '" . $this->db->escape($mode_key) . "'";
-				$sql .= " AND NOT EXISTS (SELECT fk_docdet FROM " . MAIN_DB_PREFIX . "accounting_bookkeeping WHERE doc_type = 'asset' AND fk_docdet = " . $this->db->prefix(). "asset_depreciation.rowid)";
+				$sql .= " AND NOT EXISTS (SELECT fk_docdet FROM " . MAIN_DB_PREFIX . "accounting_bookkeeping WHERE doc_type = 'asset' AND fk_docdet = " . MAIN_DB_PREFIX . "asset_depreciation.rowid)";
 				if ($last_depreciation_date !== "") {
 					$sql .= " AND ref != ''";
 				}

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -928,12 +928,13 @@ class Asset extends CommonObject
 				}
 
 				// Delete old lines
-				$sql = "DELETE " . MAIN_DB_PREFIX . "asset_depreciation FROM " . MAIN_DB_PREFIX . "asset_depreciation";
-				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "accounting_bookkeeping as ab ON ab.doc_type = 'asset' AND ab.fk_docdet = " . MAIN_DB_PREFIX . "asset_depreciation.rowid";
-				$sql .= " WHERE " . MAIN_DB_PREFIX . "asset_depreciation.fk_asset = " . (int) $this->id;
-				$sql .= " AND " . MAIN_DB_PREFIX . "asset_depreciation.depreciation_mode = '" . $this->db->escape($mode_key) . "'";
-				$sql .= " AND ab.fk_docdet IS NULL";
-				if ($last_depreciation_date !== "") $sql .= " AND " . MAIN_DB_PREFIX . "asset_depreciation.ref != ''";
+				$sql = "DELETE FROM " . MAIN_DB_PREFIX . "asset_depreciation";
+				$sql .= " WHERE fk_asset = " . (int) $this->id;
+				$sql .= " AND depreciation_mode = '" . $this->db->escape($mode_key) . "'";
+				$sql .= " AND rowid NOT IN (SELECT fk_docdet FROM " . MAIN_DB_PREFIX . "accounting_bookkeeping WHERE doc_type = 'asset')";
+				if ($last_depreciation_date !== "") {
+					$sql .= " AND ref != ''";
+				}
 				$resql = $this->db->query($sql);
 				if (!$resql) {
 					$this->errors[] = $langs->trans('AssetErrorClearDepreciationLines') . ': ' . $this->db->lasterror();


### PR DESCRIPTION
# FIX: pgsql: error when calculating depreciations

In calls to `Asset::calculationDepreciation()`, an SQL query uses a multi-table delete syntax not compatible with PostgreSQL (`DELETE t FROM t, t1`).

MariaDB, MySQL et PostgreSQL share a common syntax multi-table in `DELETE FROM t1 USING t2`, but details in referring to the the table with aliases prevent us from using them. Therefore, I propose using a subquery for now.