### PR TITLE
fix: multi filter journal in accountancy/bookkeeping/list.php and in export 

### DIFF
--- a/htdocs/accountancy/bookkeeping/list.php
+++ b/htdocs/accountancy/bookkeeping/list.php
@@ -676,7 +676,7 @@ if (count($filter) > 0) {
 		} elseif ($key == 't.reconciled_option') {
 			$sqlwhere[] = 't.lettering_code IS NULL';
 		} elseif ($key == 't.code_journal' && !empty($value)) {
-			$sqlwhere[] = natural_search("t.code_journal", join(',', $value), 3, 1);
+			$sqlwhere[] = natural_search("t.code_journal", join(',', $value), 4, 1);
 		} else {
 			$sqlwhere[] = natural_search($key, $value, 0, 1);
 		}

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1053,7 +1053,7 @@ class BookKeeping extends CommonObject
 					$sqlwhere[] = natural_search($key, $value, 1, 1);
 				} elseif ($key == 't.code_journal' && !empty($value)) {
 					if (is_array($value)) {
-						$sqlwhere[] = natural_search("t.code_journal", join(',', $value), 3, 1);
+						$sqlwhere[] = natural_search("t.code_journal", join(',', $value), 4, 1);
 					} else {
 						$sqlwhere[] = natural_search("t.code_journal", $value, 3, 1);
 					}


### PR DESCRIPTION
Actually if you set more than one journal in the filter like
![image](https://github.com/user-attachments/assets/86a6761f-d14b-40c0-9d57-ba7ae0671080)

the result SQL is 
AND (t.code_journal IN ('ACH') AND t.code_journal IN ('ODI') AND t.code_journal IN ('VEN')) 
So there is no result in this case 

instead of 

(((t.code_journal LIKE 'ACH,%' OR t.code_journal = 'ACH' OR t.code_journal LIKE '%,ACH' OR t.code_journal LIKE '%,ACH,%') OR (t.code_journal LIKE 'ODI,%' OR t.code_journal = 'ODI' OR t.code_journal LIKE '%,ODI' OR t.code_journal LIKE '%,ODI,%') OR (t.code_journal LIKE 'VEN,%' OR t.code_journal = 'VEN' OR t.code_journal LIKE '%,VEN' OR t.code_journal LIKE '%,VEN,%')))

The natural_search method parameters explain 
**4=value is a list of ID separated with comma (Example '2,7') to be used to search into a multiselect string '1,2,3,4'**