### PR TITLE
FIX: asset depreciation: division by zero

### DIFF
--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -999,7 +999,7 @@ class Asset extends CommonObject
 				//-----------------------------------------------------
 				$nb_days_in_year = !empty($conf->global->ASSET_DEPRECIATION_DURATION_PER_YEAR) ? $conf->global->ASSET_DEPRECIATION_DURATION_PER_YEAR : 365;
 				$nb_days_in_month = !empty($conf->global->ASSET_DEPRECIATION_DURATION_PER_MONTH) ? $conf->global->ASSET_DEPRECIATION_DURATION_PER_MONTH : 30;
-				$period_amount = (double) price2num($depreciation_period_amount / $fields['duration'], 'MT');
+				$period_amount = (float) ($fields['duration'] > 0 ? price2num($depreciation_period_amount / $fields['duration'], 'MT') : 0);
 				$first_period_found = false;
 				$first_period_date = isset($begin_period) && $begin_period > $fiscal_period_start ? $begin_period : $fiscal_period_start;
 


### PR DESCRIPTION
# FIX: asset depreciation: division by zero

Depreciation duration is set to 0 when some types of depreciation are disabled. This causes a division by 0 when calculating depreciation entries (which is fatal error in PHP 8+).