### PR TITLE
FIX: projects: go back to edit view after cloning

### DIFF
--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -499,7 +499,7 @@ if (empty($reshook)) {
 			$newobject->fetch_optionals();
 			$newobject->fetch_thirdparty(); // Load new object
 			$object = $newobject;
-			$action = 'view';
+			$action = 'edit';
 			$comefromclone = true;
 
 			setEventMessages($langs->trans("ProjectCreatedInDolibarr", $newobject->ref), "", 'mesgs');

--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -496,14 +496,11 @@ if (empty($reshook)) {
 			// Load new object
 			$newobject = new Project($db);
 			$newobject->fetch($result);
-			$newobject->fetch_optionals();
-			$newobject->fetch_thirdparty(); // Load new object
-			$object = $newobject;
-			$action = 'edit';
-			$comefromclone = true;
 
 			setEventMessages($langs->trans("ProjectCreatedInDolibarr", $newobject->ref), "", 'mesgs');
-			//var_dump($newobject); exit;
+
+			header('Location: '.$_SERVER['PHP_SELF'].'?id='.$result.'&action=edit&comefromclone=1');
+			exit;
 		}
 	}
 


### PR DESCRIPTION
# FIX: projects: go back to edit view after cloning

Since commit https://github.com/Dolibarr/dolibarr/commit/ea7e7456a5884471c13e1c0c2c9b538bc84969f0, the screen we go back to after cloning a project is the project visualization.

This is impractical, this makes to user do many inputs if they want to edit the cloned project, which is the majoritary use case (to remove the prefix "Copy of", etc.). It is even more notable when we clone a closed project, as we must put it back to draft or validated before modifying it.

As changing back the original line doesn't work (I guess because the `edit` action is handled after `confirm_clone`), I propose making a redirection to the edit view.
