### PR TITLE
Fix : require_once functions2.lib.php in mod_bookkeeping_argon.php

### DIFF
--- a/htdocs/core/modules/accountancy/mod_bookkeeping_argon.php
+++ b/htdocs/core/modules/accountancy/mod_bookkeeping_argon.php
@@ -22,6 +22,7 @@
  *  \ingroup    accountancy
  *  \brief      File of class to manage Bookkeeping numbering rules Argon
  */
+require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/modules/accountancy/modules_accountancy.php';
 
 /**


### PR DESCRIPTION
# Fix bookkeeping_argon might cause an error

mod_bookkeeping_argon.php uses function get_next_value(), which is defined in functions2.lib.php.

This causes an error 500 in at least one case: when saving bookkeeping on page `accountancy/journal/sellsjournal.php`.

This PR adds the missing include.

