### PR TITLE
FIX Change date accountancy elements makes changes on many entities

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1614,6 +1614,7 @@ class BookKeeping extends CommonObject
 	 */
 	public function updateByMvt($piece_num = '', $field = '', $value = '', $mode = '')
 	{
+		global $conf;
 		$error = 0;
 
 		$sql_filter = $this->getCanModifyBookkeepingSQL();
@@ -1626,6 +1627,7 @@ class BookKeeping extends CommonObject
 		$sql = "UPDATE ".$this->db->prefix().$this->table_element.$mode;
 		$sql .= " SET ".$this->db->sanitize($field)." = ".(is_numeric($value) ? ((float) $value) : "'".$this->db->escape($value)."'");
 		$sql .= " WHERE piece_num = ".((int) $piece_num);
+		$sql .= " AND entity = " . ((int) $conf->entity);
 		$sql .= $sql_filter;
 
 		$resql = $this->db->query($sql);


### PR DESCRIPTION
# FIX Change date accountancy elements makes changes on many entities

This bug occurs when multicurrency module is activated and there are many entities with accountancy module activated.

When updating the date of a bookkeeping element(page accountancy/bookkeeping/card.php), if another element has the same piece_num in other entities, date is updated on both elements.

This PR fixes this behavior.

