### PR TITLE
FIX Change date accountancy elements makes changes on many entities

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1399,6 +1399,7 @@ class BookKeeping extends CommonObject
 	 */
 	public function updateByMvt($piece_num = '', $field = '', $value = '', $mode = '')
 	{
+		global $conf;
 		$error = 0;
 
 		$this->db->begin();
@@ -1406,6 +1407,7 @@ class BookKeeping extends CommonObject
 		$sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element.$mode;
 		$sql .= " SET ".$field." = ".(is_numeric($value) ? ((float) $value) : "'".$this->db->escape($value)."'");
 		$sql .= " WHERE piece_num = ".((int) $piece_num);
+		$sql .= " AND entity = " . ((int) $conf->entity);
 
 		$resql = $this->db->query($sql);
 


### PR DESCRIPTION
# FIX Change date accountancy elements makes changes on many entities

This bug occurs when multicurrency module is activated and there are many entities with accountancy module activated.

When updating the date of a bookkeeping element(page accountancy/bookkeeping/card.php), if another element has the same piece_num in other entities, date is updated on both elements.

This PR fixes this behavior.