### PR TITLE
FIX|Fix # issue when you try to attach of file on form ticket

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -189,7 +189,7 @@ if (empty($reshook)) {
 		$action = 'view';
 	}
 
-	if (($action == 'add' || ($action == 'update' && $object->status < Ticket::STATUS_CLOSED)) && $permissiontoadd) {
+	if (($action == 'add' && GETPOST('save', 'alpha') || ($action == 'update' && $object->status < Ticket::STATUS_CLOSED)) && $permissiontoadd) {
 		$ifErrorAction = $action == 'add' ? 'create' : 'edit';
 		if ($action == 'add') $object->track_id = null;
 		$error = 0;


### PR DESCRIPTION
I’ve noticed an issue starting from Dolibarr version 20: when trying to attach a file during ticket creation, clicking the "Attach File" button unexpectedly creates the ticket instead, without attaching the file.

To resolve this, a condition should be added to distinguish whether the "Attach File" button or the "Create Ticket" button was clicked. This way, the system can correctly handle file attachments when the appropriate button is used, and only create the ticket when intended.