### PR TITLE
FIX: mandatory extrafelds on lines are not checked

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -4443,8 +4443,17 @@ class PropaleLigne extends CommonObjectLine
 				// End call triggers
 			}
 
-			$this->db->commit();
-			return 1;
+			if (!$error) {
+				$this->db->commit();
+				return $this->id;
+			}
+
+			foreach ($this->errors as $errmsg) {
+				dol_syslog(get_class($this)."::insert ".$errmsg, LOG_ERR);
+				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+			}
+			$this->db->rollback();
+			return -1 * $error;
 		} else {
 			$this->error = $this->db->error()." sql=".$sql;
 			$this->db->rollback();
@@ -4650,8 +4659,17 @@ class PropaleLigne extends CommonObjectLine
 				// End call triggers
 			}
 
-			$this->db->commit();
-			return 1;
+			if (!$error) {
+				$this->db->commit();
+				return 1;
+			}
+
+			foreach ($this->errors as $errmsg) {
+				dol_syslog(get_class($this)."::update ".$errmsg, LOG_ERR);
+				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+			}
+			$this->db->rollback();
+			return -1 * $error;
 		} else {
 			$this->error = $this->db->error();
 			$this->db->rollback();

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -4445,7 +4445,7 @@ class PropaleLigne extends CommonObjectLine
 
 			if (!$error) {
 				$this->db->commit();
-				return $this->id;
+				return 1;
 			}
 
 			foreach ($this->errors as $errmsg) {

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -6409,7 +6409,7 @@ class FactureLigne extends CommonInvoiceLine
 
 			// If fk_remise_except is defined, the discount is linked to the invoice
 			// which flags it as "consumed".
-			if ($this->fk_remise_except) {
+			if ($this->fk_remise_except && empty($error)) {
 				$discount = new DiscountAbsolute($this->db);
 				$result = $discount->fetch($this->fk_remise_except);
 				if ($result >= 0) {
@@ -6446,7 +6446,7 @@ class FactureLigne extends CommonInvoiceLine
 				}
 			}
 
-			if (!$notrigger) {
+			if (!$notrigger && empty($error)) {
 				// Call trigger
 				$result = $this->call_trigger('LINEBILL_INSERT', $user);
 				if ($result < 0) {
@@ -6456,8 +6456,17 @@ class FactureLigne extends CommonInvoiceLine
 				// End call triggers
 			}
 
-			$this->db->commit();
-			return $this->id;
+			if (!$error) {
+				$this->db->commit();
+				return $this->id;
+			}
+
+			foreach ($this->errors as $errmsg) {
+				dol_syslog(get_class($this)."::insert ".$errmsg, LOG_ERR);
+				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+			}
+			$this->db->rollback();
+			return -1 * $error;
 		} else {
 			$this->error = $this->db->lasterror();
 			$this->db->rollback();
@@ -6628,8 +6637,18 @@ class FactureLigne extends CommonInvoiceLine
 				}
 				// End call triggers
 			}
-			$this->db->commit();
-			return 1;
+
+			if (!$error) {
+				$this->db->commit();
+				return 1;
+			}
+
+			foreach ($this->errors as $errmsg) {
+				dol_syslog(get_class($this)."::update ".$errmsg, LOG_ERR);
+				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+			}
+			$this->db->rollback();
+			return -1 * $error;
 		} else {
 			$this->error = $this->db->error();
 			$this->db->rollback();

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3026,6 +3026,8 @@ class CommandeFournisseur extends CommonOrder
 				$this->db->commit();
 				return $result;
 			} else {
+				$this->errors[] = $this->line->error;
+				$this->errors = array_merge($this->errors, $this->line->errors);
 				$this->error = $this->db->lasterror();
 				$this->db->rollback();
 				return -1;

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2439,6 +2439,7 @@ class FactureFournisseur extends CommonInvoice
 
 		if ($res < 1) {
 			$this->errors[] = $line->error;
+			$this->errors = array_merge($this->errors, $line->errors);
 		} else {
 			// Update total price into invoice record
 			$res = $this->update_price('1', 'auto', 0, $this->thirdparty);
@@ -4093,8 +4094,18 @@ class SupplierInvoiceLine extends CommonObjectLine
 				// End call triggers
 			}
 
-			$this->db->commit();
-			return $this->id;
+			if (!$error) {
+				$this->db->commit();
+				return $this->id;
+			}
+
+			foreach ($this->errors as $errmsg) {
+				dol_syslog(get_class($this)."::insert ".$errmsg, LOG_ERR);
+				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+			}
+
+			$this->db->rollback();
+			return -1 * $error;
 		} else {
 			$this->error = $this->db->error();
 			$this->db->rollback();


### PR DESCRIPTION
If you set **mandatory** extrafields on lines of 

- Propal
- Invoice
- Supllier Order
- Supplier Invoice 

then Dolibarr let users add the line (or update) the line without error (or without displaying error message) when the extrafield is empty

On Order Lines, it is actually the only case where this is correctly managed

I've used the code of OrderLine->update and OrderLine->insert to apply the same check and rerror return and displayed on Propal Line, Invoice Line, Supplier Order line, Supplier Invoice line