### PR TITLE
FIX|Fix # issue when you approve holidays from massaction 

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1631,6 +1631,8 @@ if (!$error && ($massaction == 'approveleave' || ($action == 'approveleave' && $
 
 				$objecttmp->date_valid = dol_now();
 				$objecttmp->fk_user_valid = $user->id;
+				$objecttmp->date_approval = dol_now();
+				$objecttmp->fk_user_approve = $user->id;
 				$objecttmp->status = Holiday::STATUS_APPROVED;
 				$objecttmp->statut = $objecttmp->status;	// deprecated
 


### PR DESCRIPTION
I noticed that when you try to approve a holiday using the mass action, the approval date is not set on the object.
To fix this, you need to set the approvalDate property to the current date before calling the approve method.