### PR TITLE
Fix #34182 regression on api thridp#34182arty fetch

### DIFF
--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -2390,7 +2390,7 @@ class Thirdparties extends DolibarrApi
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.'. No read permission on thirdparties.');
 		}
 
-		if ($rowid == 0) {
+		if ($rowid == 0 && !is_null($rowid)) {
 			$result = $this->company->initAsSpecimen();
 		} else {
 			$result = $this->company->fetch($rowid, $ref, $ref_ext, $barcode, $idprof1, $idprof2, $idprof3, $idprof4, $idprof5, $idprof6, $email, $ref_alias);


### PR DESCRIPTION
Prevent a regression on api thirdparty fetch which doesn't use rowid like email or barcode