### PR TITLE
fix: return line id created by insert line Propal class

### DIFF
--- a/htdocs/comm/propal/class/propaleligne.class.php
+++ b/htdocs/comm/propal/class/propaleligne.class.php
@@ -611,7 +611,7 @@ class PropaleLigne extends CommonObjectLine
 			}
 
 			$this->db->commit();
-			return 1;
+			return (int) $this->id;
 		} else {
 			$this->error = $this->db->error()." sql=".$sql;
 			$this->db->rollback();

--- a/htdocs/comm/propal/class/propaleligne.class.php
+++ b/htdocs/comm/propal/class/propaleligne.class.php
@@ -591,13 +591,10 @@ class PropaleLigne extends CommonObjectLine
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$this->rowid = $this->db->last_insert_id(MAIN_DB_PREFIX.'propaldet');
-
-			if (!$error) {
-				$this->id = $this->rowid;
-				$result = $this->insertExtraFields();
-				if ($result < 0) {
-					$error++;
-				}
+			$this->id = $this->rowid;
+			$result = $this->insertExtraFields();
+			if ($result < 0) {
+				$error++;
 			}
 
 			if (!$error && !$notrigger) {


### PR DESCRIPTION
As in all others "Line" insert methods, Dolibarr should return the new rowid created.
I also remove the test on !empty($error) because $error is never modified before this line