### PR TITLE
FIX: accountancy general ledger: last total not shown if last account group shown has only one entry

### DIFF
--- a/htdocs/accountancy/bookkeeping/listbyaccount.php
+++ b/htdocs/accountancy/bookkeeping/listbyaccount.php
@@ -932,6 +932,21 @@ $sous_total_credit = 0;
 $totalarray['val']['totaldebit'] = 0;
 $totalarray['val']['totalcredit'] = 0;
 
+$colspan = 0;			// colspan before field 'label of operation'
+$colspanend = 3;		// colspan after debit/credit
+if (!empty($arrayfields['t.piece_num']['checked'])) { $colspan++; }
+if (!empty($arrayfields['t.code_journal']['checked'])) { $colspan++; }
+if (!empty($arrayfields['t.doc_date']['checked'])) { $colspan++; }
+if (!empty($arrayfields['t.doc_ref']['checked'])) { $colspan++; }
+if (!empty($arrayfields['t.label_operation']['checked'])) { $colspan++; }
+if (!empty($arrayfields['t.date_export']['checked'])) { $colspanend++; }
+if (!empty($arrayfields['t.date_validated']['checked'])) { $colspanend++; }
+if (!empty($arrayfields['t.lettering_code']['checked'])) { $colspanend++; }
+if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
+	$colspan++;
+	$colspanend--;
+}
+
 while ($i < min($num, $limit)) {
 	$line = $object->lines[$i];
 
@@ -944,21 +959,6 @@ while ($i < min($num, $limit)) {
 		$accountg = length_accountg($line->numero_compte);
 	}
 	//if (empty($accountg)) $accountg = '-';
-
-	$colspan = 0;			// colspan before field 'label of operation'
-	$colspanend = 3;		// colspan after debit/credit
-	if (!empty($arrayfields['t.piece_num']['checked'])) { $colspan++; }
-	if (!empty($arrayfields['t.code_journal']['checked'])) { $colspan++; }
-	if (!empty($arrayfields['t.doc_date']['checked'])) { $colspan++; }
-	if (!empty($arrayfields['t.doc_ref']['checked'])) { $colspan++; }
-	if (!empty($arrayfields['t.label_operation']['checked'])) { $colspan++; }
-	if (!empty($arrayfields['t.date_export']['checked'])) { $colspanend++; }
-	if (!empty($arrayfields['t.date_validated']['checked'])) { $colspanend++; }
-	if (!empty($arrayfields['t.lettering_code']['checked'])) { $colspanend++; }
-	if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-		$colspan++;
-		$colspanend--;
-	}
 
 	// Is it a break ?
 	if ($accountg != $displayed_account_number || !isset($displayed_account_number)) {
@@ -1027,8 +1027,6 @@ while ($i < min($num, $limit)) {
 		//if (empty($displayed_account_number)) $displayed_account_number='-';
 		$sous_total_debit = 0;
 		$sous_total_credit = 0;
-
-		$colspan = 0;
 	}
 
 	print '<tr class="oddeven">';


### PR DESCRIPTION
# FIX: accountancy general ledger: last total not shown if last account group shown has only one entry

In general ledger page, when looping on each entry, (sub)total lines are shown when switching account groups. As this is done at the beginning of the loop, this operation is also done after the loop, if entries have been shown and if a `$colspan` has been calculated (see https://github.com/marc-dll/dolibarr/blob/ceed8a3ceb792d082e6d8f3568754a81f43cadb2/htdocs/accountancy/bookkeeping/listbyaccount.php#L1244).

However, this variable is reset to 0 every time a total is shown. Therefore if we don't go back to the beginning of the loop, in case the last entry is alone in its group, the totals are not shown.

I moved the `$colspan` calculation out of the loop as it is independant of what happens inside, with the added performance benefit of not calculating it at each iteration, and suppressed its reset.

