### PR TITLE
correction of the line organization in the cloned order

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1706,7 +1706,6 @@ class Commande extends CommonOrder
 
 				if ($result > 0) {
 					$this->db->commit();
-					$this->lines[] = $this->line;
 					return $this->line->id;
 				} else {
 					$this->db->rollback();


### PR DESCRIPTION
# FIX|Fix #[*issue_number Short description*]
when an order is cloned, the lines are disordered in the cloned object


