### PR TITLE
DRAFT : Problem with HTML encoding on MultiSelectArrayWithCheckbox

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -9687,7 +9687,7 @@ class Form
 				// Note: $val['checked'] <> 0 means we must show the field into the combo list  @phan-suppress-next-line PhanTypePossiblyInvalidDimOffset
 				$listoffieldsforselection .= '<li><input type="checkbox" id="checkbox' . $key . '" value="' . $key . '"' . ((!array_key_exists('checked', $val) || empty($val['checked']) || $val['checked'] == '-1') ? '' : ' checked="checked"') . ' data-position="'.(empty($val['position']) ? '' : $val['position']).'" />';
 				$listoffieldsforselection .= '<label for="checkbox' . $key . '" class="paddingleft">';
-				$listoffieldsforselection .= dolPrintHTML(dol_string_nohtmltag($langs->trans($val['label'])));
+				$listoffieldsforselection .= dol_string_nohtmltag($langs->trans($val['label']));
 				$listoffieldsforselection .= '</label></li>';
 				$listcheckedstring .= (empty($val['checked']) ? '' : $key . ',');
 			}


### PR DESCRIPTION
There is a problem on Dolibarr 22.0-beta on MultiSelectArrayWithCheckbox. 
This is what i see : 
![image](https://github.com/user-attachments/assets/ad93e1be-ba76-4027-93b2-148119aa1cac)
So bad isn't it ? 
I saw some diff between Dolibarr 21.0 and Develop on function multiSelectArrayWithCheckbox in core/class/html.form.class.php 

Dolibarr 21 => `$listoffieldsforselection .= '<label for="checkbox' . $key . '">'.dol_string_nohtmltag($langs->trans($val['label'])) . '</label></li>';`

Dolibarr 22 =>` $listoffieldsforselection .= dolPrintHTML(dol_string_nohtmltag($langs->trans($val['label'])));
`
Function dolPrintHTML get inserted. 

When i go into the details of the function i get a diff in treatment on function dol_htmlwithnojs in core/lib/function.lib.php
the function preg_replace gave two different output between Dolibar 21 and 22: 

Dolibarr 21 $out
`"<?xml encoding="UTF-8"><div class="tricktoremove">R&eacute;f.</div>" `will become Réf. 

Dolibarr 22 $out 
`"<?xml encoding="UTF-8"><div class="tricktoremove">R&eacute;f.</div>" ` will become `"<!--?xml encoding="UTF-8"><div class="tricktoremove"-->R&eacute;f.</div>" 
`

If i remove the function dolPrintHTML in $listoffieldsforselection i got a correct printing.
![image](https://github.com/user-attachments/assets/ee6139ab-0bec-41bb-afbf-dc4322272bc5)

The problem seems to be into the function dol_htmlwithnojs but i am not skilled enought to find why.
If someone know the fix to that.
