### PR TITLE
FIX: add payment to bank

### DIFF
--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -426,8 +426,8 @@ class Paiement extends CommonObject
 			}
 		}
 
-		$totalamount = (float) price2num($totalamount);
-		$totalamount_converted = (float) price2num($totalamount_converted);
+		$totalamount = (float) price2num($totalamount, 'MT');
+		$totalamount_converted = (float) price2num($totalamount_converted, 'MT');
 
 		// Check parameters
 		if (empty($totalamount) && empty($atleastonepaymentnotnull)) {	 // We accept negative amounts for withdraw reject but not empty arrays


### PR DESCRIPTION
If total amount and total converted amount not rounded on same way we have error: 'Payment in same currency than company but this->amount != this->multicurrency_amount';

