### PR TITLE
FIX: Use highest VAT rate from dictionary when buyer's state/province…

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6996,7 +6996,7 @@ class Form
 		$sql .= " AND t.active > 0";
 		$sql .= " AND t.entity IN (".getEntity('c_tva').")";
 		$sql .= " AND c.code IN (" . $this->db->sanitize($country_code, 1) . ")";
-		$sql .= " ORDER BY t.code ASC, t.taux ASC, t.recuperableonly ASC";
+		$sql .= " ORDER BY t.code ASC, t.taux DESC, t.recuperableonly ASC";
 
 		$resql = $this->db->query($sql);
 		if ($resql) {


### PR DESCRIPTION
When the buyer's state or province has a VAT rule defined in the VAT rates dictionary, Dolibarr should apply the highest applicable rate as the default. This fix ensures that the correct VAT is selected in such cases.

