### PR TITLE
FIX : Tmparray string not array

### DIFF
--- a/htdocs/core/tpl/document_actions_post_headers.tpl.php
+++ b/htdocs/core/tpl/document_actions_post_headers.tpl.php
@@ -152,8 +152,13 @@ $tmparray = $formfile->form_attach_new_file(
 	2
 );
 
-$formToUploadAFile = $tmparray['formToUploadAFile'];
-$formToAddALink = $tmparray['formToAddALink'];
+$formToUploadAFile = '';
+$formToAddALink = '';
+
+if (is_array($tmparray) && !empty($tmparray)) {
+	$formToUploadAFile = $tmparray['formToUploadAFile'];
+	$formToAddALink = $tmparray['formToAddALink'];
+}
 
 
 // List of document


### PR DESCRIPTION
# FIX|Fix Fatal error tmparray string not array
In document_actions_post_headers.tpl.php, fatal error because form_attach_new_file returns string so tmparray is not an array