### PR TITLE
Handling of selected customer invoice to create a credit note if not in the list restricted by secret parameter

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5382,11 +5382,13 @@ class Facture extends CommonInvoice
 		if ($socid > 0) {
 			$sql .= " AND f.fk_soc = ".((int) $socid);
 		}
-		$sql .= " ORDER BY f.ref";
 
 		if (getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED') > 0) {
+			$sql .= " ORDER BY CASE WHEN f.rowid = '".$this->db->sanitize(GETPOST('fac_avoir'), 0, 0, 0, 0)."' THEN 0 ELSE 1 END, f.ref";
 			$sql .= " DESC"; //order by
 			$sql .= " LIMIT " . getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED');
+		} else {
+			$sql .= " ORDER BY f.ref";
 		}
 
 		dol_syslog(get_class($this)."::list_qualified_avoir_invoices", LOG_DEBUG);

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5384,8 +5384,8 @@ class Facture extends CommonInvoice
 		}
 
 		if (getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED') > 0) {
-			$sql .= " ORDER BY CASE WHEN f.rowid = '".$this->db->sanitize(GETPOST('fac_avoir'), 0, 0, 0, 0)."' THEN 0 ELSE 1 END, f.ref";
-			$sql .= " DESC"; //order by
+			$sql .= " ORDER BY CASE WHEN f.rowid = ".((int) GETPOST('fac_avoir'))."' THEN 0 ELSE 1 END, f.ref";
+			$sql .= " DESC";
 			$sql .= " LIMIT " . getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED');
 		} else {
 			$sql .= " ORDER BY f.ref";


### PR DESCRIPTION
# NEW|New Handling of selected customer invoice to create a credit note if not in the list restricted by secret parameter
Previously, the parameter LIST_OF_QUALIFIED_INVOCIES_LIMIT_DEFINED could limit the number of customer invoices shown in the dropdown when creating a credit note. In some cases—especially when using the "Create Credit Note" button from within an invoice—the original invoice was not included in the list due to this restriction.
With this update, the originating invoice will now always be included in the dropdown, regardless of the defined limit.