### PR TITLE
NEW - Add a boolean for lines in api and $properties

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -69,17 +69,17 @@ class Invoices extends DolibarrApi
 	 *
 	 * @param	int		$id				ID of invoice
 	 * @param   int     $contact_list	0:Return array contains all properties, 1:Return array contains just id, -1: Do not return contacts/adddesses
-	 * @param 	string 	$properties Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @param 	bool 	$lines 		true or false to display or hide lines
+	 * @param 	string 	$properties 	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+	 * @param 	bool 	$withLines 		true or false to display or hide lines
 	 * @return	Object					Object with cleaned properties
 	 *
 	 * @throws	RestException
 	 */
-	public function get($id, $contact_list = 1, $properties = '', $lines = true)
+	public function get($id, $contact_list = 1, $properties = '', $withLines = true)
 	{
 		$invoice = $this->_fetch($id, '', '', $contact_list);
 
-		if ($lines == false) {
+		if (!$withLines) {
 			unset($invoice->lines);
 		}
 
@@ -195,7 +195,7 @@ class Invoices extends DolibarrApi
 	 * @param string    $properties	      	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool      $pagination_data  	If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0
 	 * @param int		$loadlinkedobjects	Load also linked object
-	 * @param bool $lines true or false to display or hide lines
+	 * @param bool 		$withLines 			true or false to display or hide lines
 	 * @return array                      	Array of invoice objects
 	 * @phan-return Facture[]|array{data:Facture[],pagination:array{total:int,page:int,page_count:int,limit:int}}
 	 * @phpstan-return Facture[]|array{data:Facture[],pagination:array{total:int,page:int,page_count:int,limit:int}}
@@ -203,7 +203,7 @@ class Invoices extends DolibarrApi
 	 * @throws RestException 404 Not found
 	 * @throws RestException 503 Error
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $status = '', $sqlfilters = '', $properties = '', $pagination_data = false, $loadlinkedobjects = 0, $lines = true)
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $status = '', $sqlfilters = '', $properties = '', $pagination_data = false, $loadlinkedobjects = 0, $withLines = true)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('facture', 'lire')) {
 			throw new RestException(403);
@@ -299,7 +299,7 @@ class Invoices extends DolibarrApi
 						$invoice_static->fetchObjectLinked();
 					}
 
-					if ($lines == false) {
+					if (!$withLines) {
 						unset($invoice_static->lines);
 					}
 

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -69,13 +69,21 @@ class Invoices extends DolibarrApi
 	 *
 	 * @param	int		$id				ID of invoice
 	 * @param   int     $contact_list	0:Return array contains all properties, 1:Return array contains just id, -1: Do not return contacts/adddesses
+	 * @param 	string 	$properties Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+	 * @param 	bool 	$lines 		true or false to display or hide lines
 	 * @return	Object					Object with cleaned properties
 	 *
 	 * @throws	RestException
 	 */
-	public function get($id, $contact_list = 1)
+	public function get($id, $contact_list = 1, $properties = '', $lines = true)
 	{
-		return $this->_fetch($id, '', '', $contact_list);
+		$invoice = $this->_fetch($id, '', '', $contact_list);
+
+		if ($lines == false) {
+			unset($invoice->lines);
+		}
+
+		return $this->_filterObjectProperties($invoice, $properties);
 	}
 
 	/**
@@ -187,6 +195,7 @@ class Invoices extends DolibarrApi
 	 * @param string    $properties	      	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool      $pagination_data  	If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0
 	 * @param int		$loadlinkedobjects	Load also linked object
+	 * @param bool $lines true or false to display or hide lines
 	 * @return array                      	Array of invoice objects
 	 * @phan-return Facture[]|array{data:Facture[],pagination:array{total:int,page:int,page_count:int,limit:int}}
 	 * @phpstan-return Facture[]|array{data:Facture[],pagination:array{total:int,page:int,page_count:int,limit:int}}
@@ -194,7 +203,7 @@ class Invoices extends DolibarrApi
 	 * @throws RestException 404 Not found
 	 * @throws RestException 503 Error
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $status = '', $sqlfilters = '', $properties = '', $pagination_data = false, $loadlinkedobjects = 0)
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $status = '', $sqlfilters = '', $properties = '', $pagination_data = false, $loadlinkedobjects = 0, $lines = true)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('facture', 'lire')) {
 			throw new RestException(403);
@@ -288,6 +297,10 @@ class Invoices extends DolibarrApi
 					if ($loadlinkedobjects) {
 						// retrieve linked objects
 						$invoice_static->fetchObjectLinked();
+					}
+
+					if ($lines == false) {
+						unset($invoice_static->lines);
 					}
 
 					// Add online_payment_url, copied from order

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -61,12 +61,12 @@ class Contracts extends DolibarrApi
 	 * Return an array with contract information
 	 *
 	 * @param   int         $id         ID of contract
-	 * @param 		string 		$properties Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
-	 * @param 		bool 		$lines 		true or false to display or hide lines
+	 * @param 	string 		$properties Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+	 * @param 	bool 		$withLines 	true or false to display or hide lines
 	 * @return  Object					Object with cleaned properties
 	 * @throws	RestException
 	 */
-	public function get($id, $properties = '', $lines = true)
+	public function get($id, $properties = '', $withLines = true)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('contrat', 'lire')) {
 			throw new RestException(403);
@@ -83,7 +83,7 @@ class Contracts extends DolibarrApi
 
 		$this->contract->fetchObjectLinked();
 
-		if ($lines == false) {
+		if (!$withLines) {
 			unset($this->contract->lines);
 		}
 
@@ -103,7 +103,7 @@ class Contracts extends DolibarrApi
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string		   $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
-	 * @param bool $lines true or false to display or hide lines
+	 * @param bool 			   $withLines 			true or false to display or hide lines
 	 * @return  array                               Array of order objects
 	 * @phan-return Contrat[]|array{data:Contrat[],pagination:array{total:int,page:int,page_count:int,limit:int}}
 	 * @phpstan-return Contrat[]|array{data:Contrat[],pagination:array{total:int,page:int,page_count:int,limit:int}}
@@ -111,7 +111,7 @@ class Contracts extends DolibarrApi
 	 * @throws RestException 404 Not found
 	 * @throws RestException 503 Error
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false, $lines = true)
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false, $withLines = true)
 	{
 		global $db, $conf;
 
@@ -177,7 +177,7 @@ class Contracts extends DolibarrApi
 				$obj = $this->db->fetch_object($result);
 				$contrat_static = new Contrat($this->db);
 				if ($contrat_static->fetch($obj->rowid)) {
-					if ($lines == false) {
+					if (!$withLines) {
 						unset($contrat_static->lines);
 					}
 					$obj_ret[] = $this->_filterObjectProperties($this->_cleanObjectDatas($contrat_static), $properties);

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -61,10 +61,12 @@ class Contracts extends DolibarrApi
 	 * Return an array with contract information
 	 *
 	 * @param   int         $id         ID of contract
+	 * @param 		string 		$properties Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+	 * @param 		bool 		$lines 		true or false to display or hide lines
 	 * @return  Object					Object with cleaned properties
 	 * @throws	RestException
 	 */
-	public function get($id)
+	public function get($id, $properties = '', $lines = true)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('contrat', 'lire')) {
 			throw new RestException(403);
@@ -80,7 +82,12 @@ class Contracts extends DolibarrApi
 		}
 
 		$this->contract->fetchObjectLinked();
-		return $this->_cleanObjectDatas($this->contract);
+
+		if ($lines == false) {
+			unset($this->contract->lines);
+		}
+
+		return $this->_filterObjectProperties($this->_cleanObjectDatas($this->contract), $properties);
 	}
 
 	/**
@@ -96,6 +103,7 @@ class Contracts extends DolibarrApi
 	 * @param string           $sqlfilters          Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 	 * @param string		   $properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
+	 * @param bool $lines true or false to display or hide lines
 	 * @return  array                               Array of order objects
 	 * @phan-return Contrat[]|array{data:Contrat[],pagination:array{total:int,page:int,page_count:int,limit:int}}
 	 * @phpstan-return Contrat[]|array{data:Contrat[],pagination:array{total:int,page:int,page_count:int,limit:int}}
@@ -103,7 +111,7 @@ class Contracts extends DolibarrApi
 	 * @throws RestException 404 Not found
 	 * @throws RestException 503 Error
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false)
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false, $lines = true)
 	{
 		global $db, $conf;
 
@@ -169,6 +177,9 @@ class Contracts extends DolibarrApi
 				$obj = $this->db->fetch_object($result);
 				$contrat_static = new Contrat($this->db);
 				if ($contrat_static->fetch($obj->rowid)) {
+					if ($lines == false) {
+						unset($contrat_static->lines);
+					}
 					$obj_ret[] = $this->_filterObjectProperties($this->_cleanObjectDatas($contrat_static), $properties);
 				}
 				$i++;


### PR DESCRIPTION
# NEW *Add a boolean for lines in api and $properties*
added $properties and the ability to choose whether or not $lines to include them in objects when using APIs
