### PR TITLE
Allow insertion of value equals to 0 with int type

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6780,7 +6780,7 @@ abstract class CommonObject
 					if (!is_numeric($value) && $value != '') {
 						$this->errors[] = $langs->trans("ExtraFieldHasWrongValue", $attributeLabel);
 						return -1;
-					} elseif ($value == '') {
+					} elseif ($value === '') {
 						$new_array_options[$key] = null;
 					}
 					break;


### PR DESCRIPTION
The issue is that right now we can't insert a value of 0 as an int extrafields (unless the filed is mandatory, wich is not always the case)

EDIT: You can upload a 0 value with the quick edit because it's casting the value as a string ('0'), but if you try to insertExtrafields from code with a (int) 0 it doesn't work
