### PR TITLE
Fix fatal error by validating array key type before using in empty()

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1239,6 +1239,9 @@ class ActionComm extends CommonObject
 					if (!is_array($val)) {	// For backward compatibility when val=id
 						$val = array('id' => $val);
 					}
+					if (!isset($val['id']) || !is_scalar($val['id'])) {
+						continue;
+					}
 					if (!empty($already_inserted[$val['id']])) {
 						continue;
 					}


### PR DESCRIPTION
# FIX|Fix fatal error by validating array key type before using in empty()
Fix fatal error caused by invalid array key in empty() check. Now ensures $val['id'] is set and scalar before usage.
