### PR TITLE
fix: On Clone Invoice, ref_customer is not clean

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1294,6 +1294,7 @@ class Facture extends CommonInvoice
 		$object->date_modification = '';
 		$object->date_validation    = '';
 		$object->ref_client         = '';
+		$object->ref_customer         = '';
 		$object->close_code         = '';
 		$object->close_note         = '';
 		if (getDolGlobalInt('MAIN_DONT_KEEP_NOTE_ON_CLONING') == 1) {


### PR DESCRIPTION
On Clone Invoice "Réf Client" is cleaned, but "ref_client" is not the correct attribute name, ref_customer is the correct one