### PR TITLE
FIX : Fixes a bug where using a decimal value for packaging could cause a division by zero

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3187,17 +3187,18 @@ class CommandeFournisseur extends CommonOrder
 				if ($qty < $this->line->packaging) {
 					$qty = $this->line->packaging;
 				} else {
-					// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
+				// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
 					if (
-						    !empty($this->line->packaging)
-						    && is_numeric($this->line->packaging)
-						    && (float)$this->line->packaging > 0
-						    && fmod((float)$qty, (float)$this->line->packaging) > 0
-						) {
-						    $coeff = intval($qty / $this->line->packaging) + 1;
-						    $qty = $this->line->packaging * $coeff;
-						    setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
-						}
+							!empty($this->line->packaging)
+							&& is_numeric($this->line->packaging)
+							&& (float) $this->line->packaging > 0
+							&& fmod((float) $qty, (float)$this->line->packaging) > 0
+						)
+					{
+							$coeff = intval($qty / $this->line->packaging) + 1;
+							$qty = $this->line->packaging * $coeff;
+							setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
+					}
 				}
 			}
 

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3187,14 +3187,13 @@ class CommandeFournisseur extends CommonOrder
 				if ($qty < $this->line->packaging) {
 					$qty = $this->line->packaging;
 				} else {
-				// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
+					// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
 					if (
 							!empty($this->line->packaging)
 							&& is_numeric($this->line->packaging)
 							&& (float) $this->line->packaging > 0
-							&& fmod((float) $qty, (float)$this->line->packaging) > 0
-						)
-					{
+							&& fmod((float) $qty, (float) $this->line->packaging) > 0
+						) {
 							$coeff = intval($qty / $this->line->packaging) + 1;
 							$qty = $this->line->packaging * $coeff;
 							setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3187,11 +3187,17 @@ class CommandeFournisseur extends CommonOrder
 				if ($qty < $this->line->packaging) {
 					$qty = $this->line->packaging;
 				} else {
-					if (!empty($this->line->packaging) && ($qty % $this->line->packaging) > 0) {
-						$coeff = intval($qty / $this->line->packaging) + 1;
-						$qty = $this->line->packaging * $coeff;
-						setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
-					}
+					// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
+					if (
+						    !empty($this->line->packaging)
+						    && is_numeric($this->line->packaging)
+						    && (float)$this->line->packaging > 0
+						    && fmod((float)$qty, (float)$this->line->packaging) > 0
+						) {
+						    $coeff = intval($qty / $this->line->packaging) + 1;
+						    $qty = $this->line->packaging * $coeff;
+						    setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
+						}
 				}
 			}
 


### PR DESCRIPTION
# FIX|Fix #[*Fatal error with packaging decimal values*]
Fixes a bug where using a decimal value for packaging could cause a division by zero or a PHP error, because the % operator does not support decimal values. 
Now, the code checks that packaging is numeric and positive, and uses fmod() for compatibility with decimal values.

The error appear when update quantity in reception card with a decimal packaging.

This bug is also present in Dolibarr v21 and probably earlier versions.
If possible, please consider backporting this fix to the v21 branch and any other supported stable branches.

No related issue to my knowledge 



