### PR TITLE
FIX: Allow decimal qty reception

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3187,16 +3187,10 @@ class CommandeFournisseur extends CommonOrder
 				if ($qty < $this->line->packaging) {
 					$qty = $this->line->packaging;
 				} else {
-					// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
-					if (
-							!empty($this->line->packaging)
-							&& is_numeric($this->line->packaging)
-							&& (float) $this->line->packaging > 0
-							&& fmod((float) $qty, (float) $this->line->packaging) > 0
-						) {
-							$coeff = intval($qty / $this->line->packaging) + 1;
-							$qty = $this->line->packaging * $coeff;
-							setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
+					if (!empty($this->line->packaging) && ($qty % $this->line->packaging) > 0) {
+						$coeff = intval($qty / $this->line->packaging) + 1;
+						$qty = $this->line->packaging * $coeff;
+						setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
 					}
 				}
 			}

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3187,17 +3187,18 @@ class CommandeFournisseur extends CommonOrder
 				if ($qty < $this->line->packaging) {
 					$qty = $this->line->packaging;
 				} else {
-					// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
+				// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
 					if (
-						    !empty($this->line->packaging)
-						    && is_numeric($this->line->packaging)
-						    && (float)$this->line->packaging > 0
-						    && fmod((float)$qty, (float)$this->line->packaging) > 0
-						) {
-						    $coeff = intval($qty / $this->line->packaging) + 1;
-						    $qty = $this->line->packaging * $coeff;
-						    setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
-						}
+							!empty($this->line->packaging)
+							&& is_numeric($this->line->packaging)
+							&& (float) $this->line->packaging > 0
+							&& fmod((float) $qty, (float)$this->line->packaging) > 0
+						)
+					{
+							$coeff = intval($qty / $this->line->packaging) + 1;
+							$qty = $this->line->packaging * $coeff;
+							setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
+					}
 				}
 			}
 

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3187,14 +3187,13 @@ class CommandeFournisseur extends CommonOrder
 				if ($qty < $this->line->packaging) {
 					$qty = $this->line->packaging;
 				} else {
-				// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
+					// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
 					if (
 							!empty($this->line->packaging)
 							&& is_numeric($this->line->packaging)
 							&& (float) $this->line->packaging > 0
-							&& fmod((float) $qty, (float)$this->line->packaging) > 0
-						)
-					{
+							&& fmod((float) $qty, (float) $this->line->packaging) > 0
+						) {
 							$coeff = intval($qty / $this->line->packaging) + 1;
 							$qty = $this->line->packaging * $coeff;
 							setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -3187,11 +3187,17 @@ class CommandeFournisseur extends CommonOrder
 				if ($qty < $this->line->packaging) {
 					$qty = $this->line->packaging;
 				} else {
-					if (!empty($this->line->packaging) && ($qty % $this->line->packaging) > 0) {
-						$coeff = intval($qty / $this->line->packaging) + 1;
-						$qty = $this->line->packaging * $coeff;
-						setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
-					}
+					// Ensure packaging is numeric, positive, and use fmod instead of %, to prevent error with decimal packaging values (resulting in division by zero)
+					if (
+						    !empty($this->line->packaging)
+						    && is_numeric($this->line->packaging)
+						    && (float)$this->line->packaging > 0
+						    && fmod((float)$qty, (float)$this->line->packaging) > 0
+						) {
+						    $coeff = intval($qty / $this->line->packaging) + 1;
+						    $qty = $this->line->packaging * $coeff;
+						    setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
+						}
 				}
 			}
 

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -700,7 +700,7 @@ if (empty($reshook)) {
 
 					$line->id = $line_id;
 					$line->fk_entrepot = GETPOSTINT($stockLocation);
-					$line->qty = GETPOSTINT($qty);
+					$line->qty = price2num(GETPOST($qty, 'alpha'), 'MS');
 					$line->comment = GETPOST($comment, 'alpha');
 
 					if (isModEnabled('productbatch')) {
@@ -725,7 +725,7 @@ if (empty($reshook)) {
 				} else { // Product no predefined
 					$qty = "qtyl".$line_id;
 					$line->id = $line_id;
-					$line->qty = GETPOSTINT($qty);
+					$line->qty = price2num(GETPOST($qty, 'alpha'), 'MS');
 					$line->fk_entrepot = 0;
 					if ($line->update($user) < 0) {
 						setEventMessages($line->error, $line->errors, 'errors');

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -700,7 +700,7 @@ if (empty($reshook)) {
 
 					$line->id = $line_id;
 					$line->fk_entrepot = GETPOSTINT($stockLocation);
-					$line->qty = price2num(GETPOST($qty, 'alpha'), 'MS');
+					$line->qty = GETPOSTFLOAT($qty, 'MS');
 					$line->comment = GETPOST($comment, 'alpha');
 
 					if (isModEnabled('productbatch')) {
@@ -725,7 +725,7 @@ if (empty($reshook)) {
 				} else { // Product no predefined
 					$qty = "qtyl".$line_id;
 					$line->id = $line_id;
-					$line->qty = price2num(GETPOST($qty, 'alpha'), 'MS');
+					$line->qty = GETPOSTFLOAT($qty, 'MS');
 					$line->fk_entrepot = 0;
 					if ($line->update($user) < 0) {
 						setEventMessages($line->error, $line->errors, 'errors');


### PR DESCRIPTION
# NEW|New [*Allow decimal qty reception*]
*Some users would like to be able to enter received quantities with decimals, for example to indicate the exact weight. With price2num, it will be possible to manage the rounding policy using the appropriate constants.*

