### PR TITLE
FIX : bad value for company ref crashes canvas feature

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -2069,7 +2069,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 				// Ref/ID
 				if (getDolGlobalString('MAIN_SHOW_TECHNICAL_ID')) {
 					print '<tr><td class="titlefieldcreate">'.$langs->trans("ID").'</td><td colspan="3">';
-					print $object->ref;
+					print $object->id;
 					print '</td></tr>';
 				}
 

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1934,7 +1934,7 @@ class Societe extends CommonObject
 				$this->entity       = $obj->entity;
 				$this->canvas = $obj->canvas;
 
-				$this->ref          = $obj->rowid;
+				$this->ref          = $obj->name;
 				$this->name = $obj->name;
 				$this->nom          = $obj->name; // deprecated
 				$this->name_alias = $obj->name_alias;


### PR DESCRIPTION
company ref was loaded with rowid that cause crashes in canvas assign_values (fetch was done on rowid=2 and name=2 for example). 
ref should be the company name like in the info() function