### PR TITLE
fix: forgeSQLFromUniversalSearchCriteria Filter error - Bad syntax of the search string: (te.client in (1,2,3)) in comm/card.php

### DIFF
--- a/htdocs/societe/class/client.class.php
+++ b/htdocs/societe/class/client.class.php
@@ -34,7 +34,7 @@ class Client extends Societe
 	/**
 	 * @var string Used to add a filter in Form::showrefnav method
 	 */
-	public $next_prev_filter = "te.client in (1,2,3)";
+	public $next_prev_filter = "(te.client:in:1,2,3)";
 
 	/**
 	 * @var array


### PR DESCRIPTION
On Form::showrefnav on Customer tab in comm/card.php the Client.next_prev_filter is not correctly formated in 20.0