### PR TITLE
FIX expense report API mandatory fields

### DIFF
--- a/htdocs/expensereport/class/api_expensereports.class.php
+++ b/htdocs/expensereport/class/api_expensereports.class.php
@@ -36,7 +36,9 @@ class ExpenseReports extends DolibarrApi
 	 * @var string[]	Mandatory fields, checked when create and update object
 	 */
 	public static $FIELDS = array(
-		'fk_user_author'
+		'fk_user_author',
+		'date_debut',
+		'date_fin',
 	);
 
 	/**


### PR DESCRIPTION
# FIX expense report API mandatory fields
Fix to give better feedback on necessary fields for POST expense report


