### PR TITLE
FIX: accountancy sales/purchases journal: sql error logged when no invoice in journal

### DIFF
--- a/htdocs/accountancy/journal/purchasesjournal.php
+++ b/htdocs/accountancy/journal/purchasesjournal.php
@@ -361,29 +361,32 @@ foreach ($tabfac as $key => $val) {		// Loop on each invoice
 }
 */
 // New way, single query, load all unbound lines
-$sql = "
-SELECT
-    fk_facture_fourn,
-    COUNT(fd.rowid) as nb
-FROM
-    llx_facture_fourn_det as fd
-WHERE
-    fd.product_type <= 2
-    AND fd.fk_code_ventilation <= 0
-    AND fd.total_ttc <> 0
-	AND fk_facture_fourn IN (".$db->sanitize(join(",", array_keys($tabfac))).")
-GROUP BY fk_facture_fourn
-";
-$resql = $db->query($sql);
 
-$num = $db->num_rows($resql);
-$i = 0;
-while ($i < $num) {
-	$obj = $db->fetch_object($resql);
-	if ($obj->nb > 0) {
-		$errorforinvoice[$obj->fk_facture_fourn] = 'somelinesarenotbound';
+if (!empty($tabfac)) {
+	$sql = "
+	SELECT
+		fk_facture_fourn,
+		COUNT(fd.rowid) as nb
+	FROM
+		llx_facture_fourn_det as fd
+	WHERE
+		fd.product_type <= 2
+		AND fd.fk_code_ventilation <= 0
+		AND fd.total_ttc <> 0
+		AND fk_facture_fourn IN (".$db->sanitize(join(",", array_keys($tabfac))).")
+	GROUP BY fk_facture_fourn
+	";
+	$resql = $db->query($sql);
+
+	$num = $db->num_rows($resql);
+	$i = 0;
+	while ($i < $num) {
+		$obj = $db->fetch_object($resql);
+		if ($obj->nb > 0) {
+			$errorforinvoice[$obj->fk_facture_fourn] = 'somelinesarenotbound';
+		}
+		$i++;
 	}
-	$i++;
 }
 //var_dump($errorforinvoice);exit;
 

--- a/htdocs/accountancy/journal/sellsjournal.php
+++ b/htdocs/accountancy/journal/sellsjournal.php
@@ -411,7 +411,7 @@ if (!empty($tabfac)) {
 		while ($i < $num) {
 			$obj = $db->fetch_object($resql);
 			if ($obj->nb > 0) {
-				$errorforinvoice[$obj->fk_facture_fourn] = 'somelinesarenotbound';
+				$errorforinvoice[$obj->fk_facture] = 'somelinesarenotbound';
 			}
 			$i++;
 		}

--- a/htdocs/accountancy/journal/sellsjournal.php
+++ b/htdocs/accountancy/journal/sellsjournal.php
@@ -390,29 +390,31 @@ foreach ($tabfac as $key => $val) {		// Loop on each invoice
 */
 // New way, single query, load all unbound lines
 
-$sql = "
-SELECT
-    fk_facture,
-    COUNT(fd.rowid) as nb
-FROM
-	".MAIN_DB_PREFIX."facturedet as fd
-WHERE
-    fd.product_type <= 2
-    AND fd.fk_code_ventilation <= 0
-    AND fd.total_ttc <> 0
-	AND fk_facture IN (".$db->sanitize(join(",", array_keys($tabfac))).")
-GROUP BY fk_facture
-";
-$resql = $db->query($sql);
-if ($resql) {
-	$num = $db->num_rows($resql);
-	$i = 0;
-	while ($i < $num) {
-		$obj = $db->fetch_object($resql);
-		if ($obj->nb > 0) {
-			$errorforinvoice[$obj->fk_facture_fourn] = 'somelinesarenotbound';
+if (!empty($tabfac)) {
+	$sql = "
+	SELECT
+		fk_facture,
+		COUNT(fd.rowid) as nb
+	FROM
+		".MAIN_DB_PREFIX."facturedet as fd
+	WHERE
+		fd.product_type <= 2
+		AND fd.fk_code_ventilation <= 0
+		AND fd.total_ttc <> 0
+		AND fk_facture IN (".$db->sanitize(join(",", array_keys($tabfac))).")
+	GROUP BY fk_facture
+	";
+	$resql = $db->query($sql);
+	if ($resql) {
+		$num = $db->num_rows($resql);
+		$i = 0;
+		while ($i < $num) {
+			$obj = $db->fetch_object($resql);
+			if ($obj->nb > 0) {
+				$errorforinvoice[$obj->fk_facture_fourn] = 'somelinesarenotbound';
+			}
+			$i++;
 		}
-		$i++;
 	}
 }
 //var_dump($errorforinvoice);exit;


### PR DESCRIPTION
# FIX: accountancy sales/purchases journal: sql error logged when no invoice in journal

In purchases and sales journal, when checking if some lines are not bound in the selected invoices, an SQL error occurs if no invoices are selected (this generates an SQL statement with `AND fk_facture IN ()`).

A simple check on array `$tabfac` being empty clears the error and has the added benefit of suppressing one superfluous SQL query.

And while fixing that, I discovered the check was not working for sales invoice as a copy/paste made in so that an incorrect sql result column was used (`$obj->fk_facture_fourn` instead of `$obj->fk_facture)`.