### PR TITLE
Fix bad use of getDolGlobalInt to get a string in ticket.class.php

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -2995,7 +2995,7 @@ class Ticket extends CommonObject
 
 								$sendtocc = array();
 								if (getDolGlobalString("TICKET_SEND_INTERNAL_CC")) {
-									$sendtocc = explode(',', getDolGlobalInt("TICKET_SEND_INTERNAL_CC"));
+									$sendtocc = explode(',', getDolGlobalString("TICKET_SEND_INTERNAL_CC"));
 								}
 
 								// Don't try to send email when no recipient

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -2994,8 +2994,8 @@ class Ticket extends CommonObject
 								}
 
 								$sendtocc = array();
-								if (getDolGlobalInt("TICKET_SEND_INTERNAL_CC")) {
-									$sendtocc = explode(',', getDolGlobalString("TICKET_SEND_INTERNAL_CC"));
+								if (getDolGlobalString("TICKET_SEND_INTERNAL_CC")) {
+									$sendtocc = explode(',', getDolGlobalInt("TICKET_SEND_INTERNAL_CC"));
 								}
 
 								// Don't try to send email when no recipient


### PR DESCRIPTION
Fix usage of GetDolGlobalInt to get a string for sending email ticket with a CC 