### PR TITLE
fix: bad display Obj Ref product Reception

### DIFF
--- a/htdocs/product/stats/reception.php
+++ b/htdocs/product/stats/reception.php
@@ -99,7 +99,7 @@ if ($id > 0 || !empty($ref)) {
 		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 	}
 
-	llxHeader("", "", $langs->trans("CardProduct".$product->type), '', '', 0, 0, '', '', '', 'mod-product page-stats_reception');
+	llxHeader("", $langs->trans("CardProduct".$product->type), '', 0, 0, '', '', '', 'mod-product page-stats_reception');
 
 	if ($result > 0) {
 		$head = product_prepare_head($product);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/092aa080-88d2-4177-a96c-881a981f9f9b)


https://www.dolibarr.fr/forum/t/bug-page-objets-referents-des-produit/49235/5

https://www.dolibarr.fr/forum/t/cle-de-traduction-manquante-mod-product-page-stats-reception-affichee-dans-linterface/49399