### PR TITLE
FIX: cash control report: php warning

### DIFF
--- a/htdocs/compta/cashcontrol/report.php
+++ b/htdocs/compta/cashcontrol/report.php
@@ -253,7 +253,7 @@ if ($resql) {
 
 		// Date ope
 		print '<td class="nowrap left">';
-		print '<span id="dateoperation_'.$objp->rowid.'">'.dol_print_date($db->jdate($objp->do), "day")."</span>";
+		print '<span id="dateoperation_'.$objp->facid.'">'.dol_print_date($db->jdate($objp->do), "day")."</span>";
 		print "</td>\n";
 		if (!$i) {
 			$totalarray['nbfield']++;


### PR DESCRIPTION
# FIX: cash control report: php warning

Bad use of an SQL result object that triggers a PHP warning (and prevents external modules from identifying operation date if needed)