### PR TITLE
FIX: warnings when printing start/end date on line tpl

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -754,8 +754,8 @@ class FactureFournisseurRec extends CommonInvoice
 				$line->total_localtax2          = $objp->total_localtax2;
 				$line->total_ttc                = $objp->total_ttc;
 				$line->product_type             = $objp->product_type;
-				$line->date_start               = $objp->date_start;
-				$line->date_end                 = $objp->date_end;
+				$line->date_start               = $this->db->jdate($objp->date_start);
+				$line->date_end                 = $this->db->jdate($objp->date_end);
 				$line->info_bits                = $objp->info_bits	;
 				$line->special_code             = $objp->special_code;
 				$line->rang                     = $objp->rang;
@@ -2122,8 +2122,8 @@ class FactureFournisseurLigneRec extends CommonObjectLine
 			$this->total_localtax2          = $objp->total_localtax2;
 			$this->total_ttc                = $objp->total_ttc;
 			$this->product_type             = $objp->product_type;
-			$this->date_start               = $objp->date_start;
-			$this->date_end                 = $objp->date_end;
+			$this->date_start               = $this->db->jdate($objp->date_start);
+			$this->date_end                 = $this->db->jdate($objp->date_end);
 			$this->info_bits                = $objp->info_bits;
 			$this->special_code             = $objp->special_code;
 			$this->rang                     = $objp->rang;

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1072,8 +1072,8 @@ class FactureFournisseur extends CommonInvoice
 					$line->id = $obj->rowid;
 					$line->rowid = $obj->rowid;
 					$line->description = $obj->description;
-					$line->date_start = $obj->date_start;
-					$line->date_end = $obj->date_end;
+					$line->date_start = $this->db->jdate($obj->date_start);
+					$line->date_end = $this->db->jdate($obj->date_end);
 
 					$line->product_ref = $obj->product_ref;
 					$line->ref = $obj->product_ref;
@@ -3657,8 +3657,8 @@ class SupplierInvoiceLine extends CommonObjectLine
 		$this->rowid = $obj->rowid;
 		$this->fk_facture_fourn = $obj->fk_facture_fourn;
 		$this->description		= $obj->description;
-		$this->date_start = $obj->date_start;
-		$this->date_end = $obj->date_end;
+		$this->date_start = $this->db->jdate($obj->date_start);
+		$this->date_end = $this->db->jdate($obj->date_end);
 		$this->product_ref		= $obj->product_ref;
 		$this->ref_supplier		= $obj->ref_supplier;
 		$this->product_desc		= $obj->product_desc;


### PR DESCRIPTION
# FIX: warnings when printing start/end date on line tpl

Some supplier classes don't use `DoliDB::jdate()` after fetching lines from database, like it is done elsewhere. This causes numerous warnings that flood the `dolibarr.log` file, as `dol_print_date()` (called by get_date_range() inside the lines templates) deprecates being called with `YYYY-MM-DD (HH:MM:SS)` values.
