### PR TITLE
[fix] Product_type line empty create sql error

### DIFF
--- a/htdocs/comm/propal/class/propaleligne.class.php
+++ b/htdocs/comm/propal/class/propaleligne.class.php
@@ -534,7 +534,7 @@ class PropaleLigne extends CommonObjectLine
 		}
 
 		// Check parameters
-		if ($this->product_type < 0) {
+		if ($this->product_type < 0 || empty($this->product_type)) {
 			return -1;
 		}
 

--- a/htdocs/comm/propal/class/propaleligne.class.php
+++ b/htdocs/comm/propal/class/propaleligne.class.php
@@ -534,7 +534,7 @@ class PropaleLigne extends CommonObjectLine
 		}
 
 		// Check parameters
-		if ($this->product_type < 0 || empty($this->product_type)) {
+		if ((int) $this->product_type < 0) {
 			return -1;
 		}
 

--- a/htdocs/comm/propal/class/propaleligne.class.php
+++ b/htdocs/comm/propal/class/propaleligne.class.php
@@ -534,7 +534,7 @@ class PropaleLigne extends CommonObjectLine
 		}
 
 		// Check parameters
-		if ((int) $this->product_type < 0) {
+		if ($this->product_type < 0) {
 			return -1;
 		}
 
@@ -555,7 +555,7 @@ class PropaleLigne extends CommonObjectLine
 		$sql .= " ".(!empty($this->label) ? "'".$this->db->escape($this->label)."'" : "null").",";
 		$sql .= " '".$this->db->escape($this->desc)."',";
 		$sql .= " ".($this->fk_product ? "'".$this->db->escape((string) $this->fk_product)."'" : "null").",";
-		$sql .= " '".$this->db->escape((string) $this->product_type)."',";
+		$sql .= " '".$this->db->escape((int) $this->product_type)."',";
 		$sql .= " ".($this->fk_remise_except ? "'".$this->db->escape((string) $this->fk_remise_except)."'" : "null").",";
 		$sql .= " ".price2num($this->qty, 'MS').",";
 		$sql .= " ".(empty($this->vat_src_code) ? "''" : "'".$this->db->escape($this->vat_src_code)."'").",";

--- a/htdocs/commande/class/orderline.class.php
+++ b/htdocs/commande/class/orderline.class.php
@@ -410,7 +410,7 @@ class OrderLine extends CommonOrderLine
 		}
 
 		// Check parameters
-		if ($this->product_type < 0) {
+		if ($this->product_type < 0 || empty($this->product_type)) {
 			return -1;
 		}
 

--- a/htdocs/compta/facture/class/factureligne.class.php
+++ b/htdocs/compta/facture/class/factureligne.class.php
@@ -394,7 +394,7 @@ class FactureLigne extends CommonInvoiceLine
 		}
 
 		// Check parameters
-		if ($this->product_type < 0) {
+		if ($this->product_type < 0 || empty($this->product_type)) {
 			$this->error = 'ErrorProductTypeMustBe0orMore';
 			return -1;
 		}
@@ -616,7 +616,7 @@ class FactureLigne extends CommonInvoiceLine
 		}
 
 		// Check parameters
-		if ($this->product_type < 0) {
+		if ($this->product_type < 0 || empty($this->product_type)) {
 			return -1;
 		}
 


### PR DESCRIPTION
When we add a free line without selecting the type, we get an SQL error because $line->product_type is a string when it's empty, whereas in the database, product_type is an integer.

Since the code doesn't enter the condition, it doesn't return -1, which causes a major SQL error.

My pull request was intended to prevent this by checking if it's empty.