### PR TITLE
QUAL Use DOL_DATA_ROOT instead of DOL_DOCUMENT_ROOT

### DIFF
--- a/htdocs/takepos/send.php
+++ b/htdocs/takepos/send.php
@@ -81,7 +81,7 @@ if ($action == "send") {
 	$msg = "<html>".$arraydefaultmessage->content."<br>".$receipt."</html>";
 	$sendto = $email;
 	$from = $mysoc->email;
-	$mail = new CMailFile($subject, $sendto, $from, $msg, array(), array(), array(), '', '', 0, 1, '', '', '', '', '', '', DOL_DOCUMENT_ROOT.'/documents/takepos/temp');
+	$mail = new CMailFile($subject, $sendto, $from, $msg, array(), array(), array(), '', '', 0, 1, '', '', '', '', '', '', DOL_DATA_ROOT.'/documents/takepos/temp');
 	if ($mail->error || !empty($mail->errors)) {
 		setEventMessages($mail->error, $mail->errors, 'errors');
 	} else {


### PR DESCRIPTION
#QUAL  Use DOL_DATA_ROOT instead of DOL_DOCUMENT_ROOT for upload_dir_tmp in CMailFile

# Instructions
Prevent the writing of  temporary image files in the htdocs directory when sending email with embedded picture from TakePos.
