### PR TITLE
Fix extrafield in Salary

### DIFF
--- a/htdocs/salaries/list.php
+++ b/htdocs/salaries/list.php
@@ -407,6 +407,12 @@ $sql .= " GROUP BY u.rowid, u.lastname, u.firstname, u.login, u.email, u.admin, 
 $sql .= " s.rowid, s.fk_account, s.paye, s.fk_user, s.amount, s.salary, s.label, s.datesp, s.dateep, s.fk_typepayment, s.fk_bank,";
 $sql .= " ba.rowid, ba.ref, ba.number, ba.account_number, ba.fk_accountancy_journal, ba.label, ba.iban_prefix, ba.bic, ba.currency_code, ba.clos,";
 $sql .= " pst.code";
+// Add fields from extrafields
+if (!empty($extrafields->attributes[$object->table_element]['label'])) {
+	foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $val) {
+		$sql .= ($extrafields->attributes[$object->table_element]['type'][$key] != 'separate' ? ", ef.".$key : '');
+	}
+}
 
 // Count total nb of records
 $nbtotalofrecords = '';


### PR DESCRIPTION
# FIX extrafield in Salary

```
DoliDBPgsql::query SQL Error message: ERROR:  42803: column "ef.xxx" must appear in the GROUP BY clause or be used in an aggregate function
```