### PR TITLE
FIX: Initialize $groupby to avoid PHPStan warning

### DIFF
--- a/htdocs/hrm/job_list.php
+++ b/htdocs/hrm/job_list.php
@@ -400,6 +400,7 @@ llxHeader('', $title, $help_url, '', 0, 0, $morejs, $morecss, '', 'mod-hrm page-
 $arrayofselected = is_array($toselect) ? $toselect : array();
 
 $param = '';
+$groupby = '';
 if (!empty($mode)) {
 	$param .= '&mode='.urlencode($mode);
 }


### PR DESCRIPTION
### FIX

**Short description:**
Fix PHPStan warning about uninitialized `$groupby` variable

**Long description:**
PHPStan detected an issue where the variable `$groupby` in [`htdocs/hrm/job_list.php`](htdocs/hrm/job_list.php#L415) at line 415 might be used before being initialized.

This commit explicitly initializes `$groupby` to an empty string (`''`) to ensure proper definition and avoid potential runtime warnings or errors.
