### PR TITLE
PERF: remove useless calls to count() in core classes, tpls and modulebuilder template

### DIFF
--- a/htdocs/core/class/cgenericdic.class.php
+++ b/htdocs/core/class/cgenericdic.class.php
@@ -255,13 +255,11 @@ class CGenericDic
 
 		// Manage filter
 		$sqlwhere = array();
-		if (count($filter) > 0) {
-			foreach ($filter as $key => $value) {
-				$sqlwhere[] = $key." LIKE '%".$this->db->escape($value)."%'";
-			}
+		foreach ($filter as $key => $value) {
+			$sqlwhere[] = $key." LIKE '%".$this->db->escape($value)."%'";
 		}
 
-		if (count($sqlwhere) > 0) {
+		if (!empty($sqlwhere)) {
 			$sql .= " WHERE ".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
 		}
 		if (!empty($sortfield)) {

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -169,7 +169,7 @@ abstract class CommonDocGenerator
 			'myuser_gender'=>$user->gender,
 		);
 		// Retrieve extrafields
-		if (is_array($user->array_options) && count($user->array_options)) {
+		if (is_array($user->array_options) && !empty($user->array_options)) {
 			$array_user = $this->fill_substitutionarray_with_extrafields($user, $array_user, $extrafields, 'myuser', $outputlangs);
 		}
 		return $array_user;
@@ -215,7 +215,7 @@ abstract class CommonDocGenerator
 			'mymember_birth' => dol_print_date($member->birth, 'day', 'tzuser'),
 		);
 		// Retrieve extrafields
-		if (is_array($member->array_options) && count($member->array_options)) {
+		if (is_array($member->array_options) && !empty($member->array_options)) {
 			$array_member = $this->fill_substitutionarray_with_extrafields($member, $array_member, $extrafields, 'mymember', $outputlangs);
 		}
 		return $array_member;
@@ -338,7 +338,7 @@ abstract class CommonDocGenerator
 		);
 
 		// Retrieve extrafields
-		if (is_array($object->array_options) && count($object->array_options)) {
+		if (is_array($object->array_options) && !empty($object->array_options)) {
 			$object->fetch_optionals();
 
 			$array_thirdparty = $this->fill_substitutionarray_with_extrafields($object, $array_thirdparty, $extrafields, $array_key, $outputlangs);
@@ -397,7 +397,7 @@ abstract class CommonDocGenerator
 		);
 
 		// Retrieve extrafields
-		if (is_array($object->array_options) && count($object->array_options)) {
+		if (is_array($object->array_options) && !empty($object->array_options)) {
 			$object->fetch_optionals();
 
 			$array_contact = $this->fill_substitutionarray_with_extrafields($object, $array_contact, $extrafields, $array_key, $outputlangs);
@@ -592,7 +592,7 @@ abstract class CommonDocGenerator
 		}
 
 		// Add vat by rates
-		if (is_array($object->lines) && count($object->lines) > 0) {
+		if (is_array($object->lines) && !empty($object->lines)) {
 			$totalUp = 0;
 			// Set substitution keys for different VAT rates
 			foreach ($object->lines as $line) {
@@ -632,7 +632,7 @@ abstract class CommonDocGenerator
 		}
 
 		// Retrieve extrafields
-		if (is_array($object->array_options) && count($object->array_options)) {
+		if (is_array($object->array_options) && !empty($object->array_options)) {
 			$object->fetch_optionals();
 
 			$resarray = $this->fill_substitutionarray_with_extrafields($object, $resarray, $extrafields, $array_key, $outputlangs);
@@ -819,7 +819,7 @@ abstract class CommonDocGenerator
 		}
 
 		// Retrieve extrafields
-		if (is_array($object->array_options) && count($object->array_options)) {
+		if (is_array($object->array_options) && !empty($object->array_options)) {
 			$object->fetch_optionals();
 
 			$array_shipment = $this->fill_substitutionarray_with_extrafields($object, $array_shipment, $extrafields, $array_key, $outputlangs);
@@ -1488,6 +1488,8 @@ abstract class CommonDocGenerator
 		}
 
 		if (!empty($fields)) {
+			$fieldsCount = count($fields);
+
 			// Sort extrafields by rank
 			uasort($fields, function ($a, $b) {
 				return  ($a->rank > $b->rank) ? 1 : -1;
@@ -1500,7 +1502,7 @@ abstract class CommonDocGenerator
 			if ($params['display'] == 'auto') {
 				$lastNnumbItems = 0;
 				foreach ($params['auto'] as $display => $numbItems) {
-					if ($lastNnumbItems <= $numbItems && count($fields) > $numbItems) {
+					if ($lastNnumbItems <= $numbItems && $fieldsCount > $numbItems) {
 						$lastNnumbItems = $numbItems;
 						$params['display'] = $display;
 					}

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1505,7 +1505,7 @@ abstract class CommonObject
 			$sqlWhere[] = " tc.code='".$this->db->escape($code)."'";
 		}
 
-		if (count($sqlWhere) > 0) {
+		if (!empty($sqlWhere)) {
 			$sql .= " WHERE ".implode(' AND ', $sqlWhere);
 		}
 
@@ -4570,7 +4570,7 @@ abstract class CommonObject
 		}
 
 		// Check parameters
-		if (!isset($this->childtables) || !is_array($this->childtables) || count($this->childtables) == 0) {
+		if (empty($this->childtables) || !is_array($this->childtables)) {
 			dol_print_error('Called isObjectUsed on a class with property this->childtables not defined');
 			return -1;
 		}
@@ -5517,17 +5517,15 @@ abstract class CommonObject
 					}
 					if (is_dir($tmpdir)) {
 						$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.od(s|t)$', '', 'name', SORT_ASC, 0);
-						if (count($tmpfiles)) {
+						if (!empty($tmpfiles)) {
 							$listoffiles = array_merge($listoffiles, $tmpfiles);
 						}
 					}
 				}
 
-				if (count($listoffiles)) {
-					foreach ($listoffiles as $record) {
-						$srctemplatepath = $record['fullname'];
-						break;
-					}
+				foreach ($listoffiles as $record) {
+					$srctemplatepath = $record['fullname'];
+					break;
 				}
 			}
 
@@ -6087,7 +6085,7 @@ abstract class CommonObject
 		}
 
 		// Request to get complementary values
-		if (is_array($optionsArray) && count($optionsArray) > 0) {
+		if (is_array($optionsArray) && !empty($optionsArray)) {
 			$sql = "SELECT rowid";
 			foreach ($optionsArray as $name => $label) {
 				if (empty($extrafields->attributes[$this->table_element]['type'][$name]) || $extrafields->attributes[$this->table_element]['type'][$name] != 'separate') {
@@ -7082,20 +7080,20 @@ abstract class CommonObject
 				// 6 : ids categories list separated by comma for category root
 				$keyList = (empty($InfoFieldList[2]) ? 'rowid' : $InfoFieldList[2].' as rowid');
 
-				if (count($InfoFieldList) > 4 && !empty($InfoFieldList[4])) {
+				if (!empty($InfoFieldList[4])) {
 					if (strpos($InfoFieldList[4], 'extra.') !== false) {
 						$keyList = 'main.'.$InfoFieldList[2].' as rowid';
 					} else {
 						$keyList = $InfoFieldList[2].' as rowid';
 					}
 				}
-				if (count($InfoFieldList) > 3 && !empty($InfoFieldList[3])) {
+				if (!empty($InfoFieldList[3])) {
 					list($parentName, $parentField) = explode('|', $InfoFieldList[3]);
 					$keyList .= ', '.$parentField;
 				}
 
 				$filter_categorie = false;
-				if (count($InfoFieldList) > 5) {
+				if (!empty($InfoFieldList[5])) {
 					if ($InfoFieldList[0] == 'categorie') {
 						$filter_categorie = true;
 					}
@@ -7156,7 +7154,7 @@ abstract class CommonObject
 							// Several field into label (eq table:code|libelle:rowid)
 							$notrans = false;
 							$fields_label = explode('|', $InfoFieldList[1]);
-							if (count($fields_label) > 1) {
+							if (!empty($fields_label[1])) {
 								$notrans = true;
 								foreach ($fields_label as $field_toshow) {
 									$labeltoshow .= $obj->$field_toshow . ' ';
@@ -7254,11 +7252,11 @@ abstract class CommonObject
 				// 6 : ids categories list separated by comma for category root
 				$keyList = (empty($InfoFieldList[2]) ? 'rowid' : $InfoFieldList[2].' as rowid');
 
-				if (count($InfoFieldList) > 3 && !empty($InfoFieldList[3])) {
+				if (!empty($InfoFieldList[3])) {
 					list ($parentName, $parentField) = explode('|', $InfoFieldList[3]);
 					$keyList .= ', '.$parentField;
 				}
-				if (count($InfoFieldList) > 4 && !empty($InfoFieldList[4])) {
+				if (!empty($InfoFieldList[4])) {
 					if (strpos($InfoFieldList[4], 'extra.') !== false) {
 						$keyList = 'main.'.$InfoFieldList[2].' as rowid';
 					} else {
@@ -7267,7 +7265,7 @@ abstract class CommonObject
 				}
 
 				$filter_categorie = false;
-				if (count($InfoFieldList) > 5) {
+				if (!empty($InfoFieldList[5])) {
 					if ($InfoFieldList[0] == 'categorie') {
 						$filter_categorie = true;
 					}
@@ -7329,7 +7327,7 @@ abstract class CommonObject
 							$notrans = false;
 							// Several field into label (eq table:code|libelle:rowid)
 							$fields_label = explode('|', $InfoFieldList[1]);
-							if (count($fields_label) > 1) {
+							if (!empty($fields_label[1])) {
 								$notrans = true;
 								foreach ($fields_label as $field_toshow) {
 									$labeltoshow .= $obj->$field_toshow . ' ';
@@ -7648,7 +7646,7 @@ abstract class CommonObject
 			$selectkey = "rowid";
 			$keyList = 'rowid';
 
-			if (count($InfoFieldList) > 4 && !empty($InfoFieldList[4])) {
+			if (!empty($InfoFieldList[4])) {
 				$selectkey = $InfoFieldList[2];
 				$keyList = $InfoFieldList[2].' as rowid';
 			}
@@ -7660,7 +7658,7 @@ abstract class CommonObject
 			}
 
 			$filter_categorie = false;
-			if (count($InfoFieldList) > 5) {
+			if (!empty($InfoFieldList[5])) {
 				if ($InfoFieldList[0] == 'categorie') {
 					$filter_categorie = true;
 				}
@@ -7693,7 +7691,7 @@ abstract class CommonObject
 						// Several field into label (eq table:code|libelle:rowid)
 						$fields_label = explode('|', $InfoFieldList[1]);
 
-						if (is_array($fields_label) && count($fields_label) > 1) {
+						if (is_array($fields_label) && !empty($fields_label[1])) {
 							foreach ($fields_label as $field_toshow) {
 								$translabel = '';
 								if (!empty($obj->$field_toshow)) {
@@ -7738,9 +7736,9 @@ abstract class CommonObject
 		} elseif ($type == 'checkbox') {
 			$value_arr = explode(',', $value);
 			$value = '';
-			if (is_array($value_arr) && count($value_arr) > 0) {
+			if (!empty($value_arr)) {
 				$toprint = array();
-				foreach ($value_arr as $keyval => $valueval) {
+				foreach ($value_arr as $valueval) {
 					$toprint[] = '<li class="select2-search-choice-dolibarr noborderoncategories" style="background: #bbb">'.$param['options'][$valueval].'</li>';
 				}
 				$value = '<div class="select2-container-multi-dolibarr" style="width: 90%;"><ul class="select2-choices-dolibarr">'.implode(' ', $toprint).'</ul></div>';
@@ -7754,7 +7752,7 @@ abstract class CommonObject
 			$selectkey = "rowid";
 			$keyList = 'rowid';
 
-			if (count($InfoFieldList) >= 3) {
+			if (!empty($InfoFieldList[2])) {
 				$selectkey = $InfoFieldList[2];
 				$keyList = $InfoFieldList[2].' as rowid';
 			}
@@ -7766,7 +7764,7 @@ abstract class CommonObject
 			}
 
 			$filter_categorie = false;
-			if (count($InfoFieldList) > 5) {
+			if (!empty($InfoFieldList[5])) {
 				if ($InfoFieldList[0] == 'categorie') {
 					$filter_categorie = true;
 				}
@@ -7790,7 +7788,7 @@ abstract class CommonObject
 						// Several field into label (eq table:code|libelle:rowid)
 						$fields_label = explode('|', $InfoFieldList[1]);
 						if (is_array($value_arr) && in_array($obj->rowid, $value_arr)) {
-							if (is_array($fields_label) && count($fields_label) > 1) {
+							if (is_array($fields_label) && !empty($fields_label[1])) {
 								foreach ($fields_label as $field_toshow) {
 									$translabel = '';
 									if (!empty($obj->$field_toshow)) {
@@ -8110,7 +8108,7 @@ abstract class CommonObject
 			$value_arr = array_map(array($this->db, 'escape'), $value_arr);
 
 			$selectkey = "rowid";
-			if (count($InfoFieldList) > 4 && !empty($InfoFieldList[4])) {
+			if (!empty($InfoFieldList[4])) {
 				$selectkey = $InfoFieldList[2];
 			}
 
@@ -8167,7 +8165,7 @@ abstract class CommonObject
 		$reshook = $hookmanager->executeHooks('showOptionals', $parameters, $this, $action); // Note that $action and $object may have been modified by hook
 
 		if (empty($reshook)) {
-			if (is_array($extrafields->attributes[$this->table_element]) && key_exists('label', $extrafields->attributes[$this->table_element]) && is_array($extrafields->attributes[$this->table_element]['label']) && count($extrafields->attributes[$this->table_element]['label']) > 0) {
+			if (!empty($extrafields->attributes[$this->table_element]['label']) && is_array($extrafields->attributes[$this->table_element]['label'])) {
 				$out .= "\n";
 				$out .= '<!-- commonobject:showOptionals --> ';
 				$out .= "\n";
@@ -8228,7 +8226,7 @@ abstract class CommonObject
 					}
 
 					$colspan = 0;
-					if (is_array($params) && count($params) > 0 && $display_type=='card') {
+					if (is_array($params) && !empty($params) && $display_type == 'card') {
 						if (array_key_exists('cols', $params)) {
 							$colspan = $params['cols'];
 						} elseif (array_key_exists('colspan', $params)) {	// For backward compatibility. Use cols instead now.
@@ -8280,7 +8278,7 @@ abstract class CommonObject
 						if (!empty($extrafield_param) && is_array($extrafield_param)) {
 							$extrafield_param_list = array_keys($extrafield_param['options']);
 
-							if (count($extrafield_param_list) > 0) {
+							if (!empty($extrafield_param_list)) {
 								$extrafield_collapse_display_value = intval($extrafield_param_list[0]);
 
 								if ($extrafield_collapse_display_value == 1 || $extrafield_collapse_display_value == 2) {
@@ -8300,7 +8298,7 @@ abstract class CommonObject
 
 						$class = (!empty($extrafields->attributes[$this->table_element]['hidden'][$key]) ? 'hideobject ' : '');
 						$csstyle = '';
-						if (is_array($params) && count($params) > 0) {
+						if (is_array($params) && !empty($params)) {
 							if (array_key_exists('class', $params)) {
 								$class .= $params['class'].' ';
 							}
@@ -8747,7 +8745,7 @@ abstract class CommonObject
 
 		completeFileArrayWithDatabaseInfo($filearray, $relativedir);
 
-		if (count($filearray)) {
+		if (!empty($filearray)) {
 			if ($sortfield && $sortorder) {
 				$filearray = dol_sort_array($filearray, $sortfield, $sortorder);
 			}
@@ -9386,15 +9384,12 @@ abstract class CommonObject
 		}
 
 		// Create lines
-		if (!empty($this->table_element_line) && !empty($this->fk_element)) {
-			$num = (is_array($this->lines) ? count($this->lines) : 0);
-			for ($i = 0; $i < $num; $i++) {
-				$line = $this->lines[$i];
-
+		if (!empty($this->table_element_line) && !empty($this->fk_element) && !empty($this->lines) && is_array($this->lines)) {
+			foreach ($this->lines as $line) {
 				$keyforparent = $this->fk_element;
 				$line->$keyforparent = $this->id;
 
-				// Test and convert into object this->lines[$i]. When coming from REST API, we may still have an array
+				// Test and convert into object $line. When coming from REST API, we may still have an array
 				//if (! is_object($line)) $line=json_decode(json_encode($line), false);  // convert recursively array into object.
 				if (!is_object($line)) {
 					$line = (object) $line;
@@ -9688,7 +9683,7 @@ abstract class CommonObject
 		if (is_array($this->childtablesoncascade) && !empty($this->childtablesoncascade)) {
 			foreach ($this->childtablesoncascade as $table) {
 				$deleteFromObject = explode(':', $table);
-				if (count($deleteFromObject) >= 2) {
+				if (!empty($deleteFromObject[1])) {
 					$className = str_replace('@', '', $deleteFromObject[0]);
 					$filePath = $deleteFromObject[1];
 					$columnName = $deleteFromObject[2];
@@ -9808,18 +9803,18 @@ abstract class CommonObject
 
 			// Manage filters
 			$sqlwhere = array();
-			if (count($filter) > 0) {
-				foreach ($filter as $key => $value) {
-					if ($key == 'customsql') {
-						$sqlwhere[] = $value;
-					} elseif (strpos($value, '%') === false) {
-						$sqlwhere[] = $key." IN (".$this->db->sanitize($this->db->escape($value)).")";
-					} else {
-						$sqlwhere[] = $key." LIKE '%".$this->db->escape($value)."%'";
-					}
+
+			foreach ($filter as $key => $value) {
+				if ($key == 'customsql') {
+					$sqlwhere[] = $value;
+				} elseif (strpos($value, '%') === false) {
+					$sqlwhere[] = $key." IN (".$this->db->sanitize($this->db->escape($value)).")";
+				} else {
+					$sqlwhere[] = $key." LIKE '%".$this->db->escape($value)."%'";
 				}
 			}
-			if (count($sqlwhere) > 0) {
+
+			if (!empty($sqlwhere)) {
 				$sql .= " AND (".implode(" ".$filtermode." ", $sqlwhere).")";
 			}
 

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -352,10 +352,10 @@ class ExtraFields
 		}
 
 		if (!empty($attrname) && preg_match("/^\w[a-zA-Z0-9-_]*$/", $attrname) && !is_numeric($attrname)) {
-			if (is_array($param) && count($param) > 0) {
+			if (is_array($param) && !empty($param)) {
 				$params = serialize($param);
-			} elseif (strlen($param) > 0) {
-				$params = trim($param);
+			} elseif (!empty($param)) {
+				$params = trim((string) $param);
 			} else {
 				$params = '';
 			}
@@ -725,12 +725,12 @@ class ExtraFields
 		if (isset($attrname) && $attrname != '' && preg_match("/^\w[a-zA-Z0-9-_]*$/", $attrname)) {
 			$this->db->begin();
 
-			if (is_array($param) && count($param) > 0) {
+			if (is_array($param) && !empty($param)) {
 				$params = serialize($param);
 			} elseif (is_array($param)) {
 				$params = '';
-			} elseif (strlen($param) > 0) {
-				$params = trim($param);
+			} elseif (!empty($param)) {
+				$params = trim((string) $param);
 			} else {
 				$params = '';
 			}
@@ -1197,20 +1197,20 @@ class ExtraFields
 				$keyList = (empty($InfoFieldList[2]) ? 'rowid' : $InfoFieldList[2].' as rowid');
 
 
-				if (count($InfoFieldList) > 4 && !empty($InfoFieldList[4])) {
+				if (!empty($InfoFieldList[4])) {
 					if (strpos($InfoFieldList[4], 'extra.') !== false) {
 						$keyList = 'main.'.$InfoFieldList[2].' as rowid';
 					} else {
 						$keyList = $InfoFieldList[2].' as rowid';
 					}
 				}
-				if (count($InfoFieldList) > 3 && !empty($InfoFieldList[3])) {
+				if (!empty($InfoFieldList[3])) {
 					list($parentName, $parentField) = explode('|', $InfoFieldList[3]);
 					$keyList .= ', '.$parentField;
 				}
 
 				$filter_categorie = false;
-				if (count($InfoFieldList) > 5) {
+				if (!empty($InfoFieldList[5])) {
 					if ($InfoFieldList[0] == 'categorie') {
 						$filter_categorie = true;
 					}
@@ -1367,11 +1367,11 @@ class ExtraFields
 				// 6 : ids categories list separated by comma for category root
 				$keyList = (empty($InfoFieldList[2]) ? 'rowid' : $InfoFieldList[2].' as rowid');
 
-				if (count($InfoFieldList) > 3 && !empty($InfoFieldList[3])) {
+				if (!empty($InfoFieldList[3])) {
 					list ($parentName, $parentField) = explode('|', $InfoFieldList[3]);
 					$keyList .= ', '.$parentField;
 				}
-				if (count($InfoFieldList) > 4 && !empty($InfoFieldList[4])) {
+				if (!empty($InfoFieldList[4])) {
 					if (strpos($InfoFieldList[4], 'extra.') !== false) {
 						$keyList = 'main.'.$InfoFieldList[2].' as rowid';
 					} else {
@@ -1380,7 +1380,7 @@ class ExtraFields
 				}
 
 				$filter_categorie = false;
-				if (count($InfoFieldList) > 5) {
+				if (!empty($InfoFieldList[5])) {
 					if ($InfoFieldList[0] == 'categorie') {
 						$filter_categorie = true;
 					}
@@ -1690,7 +1690,7 @@ class ExtraFields
 			$selectkey = "rowid";
 			$keyList = 'rowid';
 
-			if (count($InfoFieldList) >= 3) {
+			if (!empty($InfoFieldList[2])) {
 				$selectkey = $InfoFieldList[2];
 				$keyList = $InfoFieldList[2].' as rowid';
 			}
@@ -1702,7 +1702,7 @@ class ExtraFields
 			}
 
 			$filter_categorie = false;
-			if (count($InfoFieldList) > 5) {
+			if (!empty($InfoFieldList[5])) {
 				if ($InfoFieldList[0] == 'categorie') {
 					$filter_categorie = true;
 				}
@@ -1807,7 +1807,7 @@ class ExtraFields
 			$selectkey = "rowid";
 			$keyList = 'rowid';
 
-			if (count($InfoFieldList) >= 3) {
+			if (!empty($InfoFieldList[2])) {
 				$selectkey = $InfoFieldList[2];
 				$keyList = $InfoFieldList[2].' as rowid';
 			}
@@ -1819,7 +1819,7 @@ class ExtraFields
 			}
 
 			$filter_categorie = false;
-			if (count($InfoFieldList) > 5) {
+			if (!empty($InfoFieldList[5])) {
 				if ($InfoFieldList[0] == 'categorie') {
 					$filter_categorie = true;
 				}
@@ -2000,7 +2000,7 @@ class ExtraFields
 		// Set $extrafield_collapse_display_value (do we have to collapse/expand the group after the separator)
 		$extrafield_collapse_display_value = -1;
 		$expand_display = false;
-		if (is_array($extrafield_param_list) && count($extrafield_param_list) > 0) {
+		if (is_array($extrafield_param_list) && !empty($extrafield_param_list)) {
 			$extrafield_collapse_display_value = intval($extrafield_param_list[0]);
 			$expand_display = ((isset($_COOKIE['DOLCOLLAPSE_'.$object->table_element.'_extrafields_'.$key]) || GETPOST('ignorecollapsesetup', 'int')) ? (empty($_COOKIE['DOLCOLLAPSE_'.$object->table_element.'_extrafields_'.$key]) ? false : true) : ($extrafield_collapse_display_value == 2 ? false : true));
 		}

--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -128,7 +128,7 @@ class HookManager
 			}
 		}
 		// Log the init of hook but only for hooks thare are declared to be managed
-		if (count($arraytolog) > 0) {
+		if (!empty($arraytolog)) {
 			dol_syslog(get_class($this)."::initHooks Loading hooks: ".join(', ', $arraytolog), LOG_DEBUG);
 		}
 
@@ -255,7 +255,7 @@ class HookManager
 						$resactiontmp = $actionclassinstance->$method($parameters, $object, $action, $this); // $object and $action can be changed by method ($object->id during creation for example or $action to go back to other action for example)
 						$resaction += $resactiontmp;
 
-						if ($resactiontmp < 0 || !empty($actionclassinstance->error) || (!empty($actionclassinstance->errors) && count($actionclassinstance->errors) > 0)) {
+						if ($resactiontmp < 0 || !empty($actionclassinstance->error) || !empty($actionclassinstance->errors)) {
 							$error++;
 							$this->error = $actionclassinstance->error;
 							$this->errors = array_merge($this->errors, (array) $actionclassinstance->errors);

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -424,7 +424,7 @@ class Form
 			$arrayoflangcode[] = $conf->global->PDF_USE_ALSO_LANGUAGE_CODE;
 		}
 
-		if (is_array($arrayoflangcode) && count($arrayoflangcode)) {
+		if (is_array($arrayoflangcode) && !empty($arrayoflangcode)) {
 			if (!is_object($extralanguages)) {
 				include_once DOL_DOCUMENT_ROOT . '/core/class/extralanguages.class.php';
 				$extralanguages = new ExtraLanguages($this->db);
@@ -827,7 +827,7 @@ class Form
 		$parameters = array();
 		$reshook = $hookmanager->executeHooks('addMoreMassActions', $parameters); // Note that $action and $object may have been modified by hook
 		// check if there is a mass action
-		if (count($arrayofaction) == 0 && empty($hookmanager->resPrint)) {
+		if (empty($arrayofaction) && empty($hookmanager->resPrint)) {
 			return;
 		}
 		if (empty($reshook)) {
@@ -999,7 +999,7 @@ class Form
 					if (empty($row['rowid'])) {
 						continue;
 					}
-					if (is_array($exclude_country_code) && count($exclude_country_code) && in_array($row['code_iso'], $exclude_country_code)) {
+					if (is_array($exclude_country_code) && !empty($exclude_country_code) && in_array($row['code_iso'], $exclude_country_code)) {
 						continue; // exclude some countries
 					}
 
@@ -1209,8 +1209,7 @@ class Form
 		// phpcs:enable
 		global $langs;
 
-		$num = count($this->cache_types_fees);
-		if ($num > 0) {
+		if (!empty($this->cache_types_fees)) {
 			return 0; // Cache already loaded
 		}
 
@@ -1474,7 +1473,7 @@ class Form
 			// For natural search
 			$scrit = explode(' ', $filterkey);
 			$i = 0;
-			if (count($scrit) > 1) {
+			if (!empty($scrit[1])) {
 				$sql .= "(";
 			}
 			foreach ($scrit as $crit) {
@@ -1484,7 +1483,7 @@ class Form
 				$sql .= "(s.nom LIKE '" . $this->db->escape($prefix . $crit) . "%')";
 				$i++;
 			}
-			if (count($scrit) > 1) {
+			if (!empty($scrit[1])) {
 				$sql .= ")";
 			}
 			if (isModEnabled('barcode')) {
@@ -1872,10 +1871,10 @@ class Form
 					if ($obj->statut == 1) {
 						if ($htmlname != 'none') {
 							$disabled = 0;
-							if (is_array($exclude) && count($exclude) && in_array($obj->rowid, $exclude)) {
+							if (is_array($exclude) && !empty($exclude) && in_array($obj->rowid, $exclude)) {
 								$disabled = 1;
 							}
-							if (is_array($limitto) && count($limitto) && !in_array($obj->rowid, $limitto)) {
+							if (is_array($limitto) && !empty($limitto) && !in_array($obj->rowid, $limitto)) {
 								$disabled = 1;
 							}
 							if (!empty($selected) && in_array($obj->rowid, $selected)) {
@@ -2131,7 +2130,7 @@ class Form
 					$userstatic->admin = $obj->admin;
 
 					$disableline = '';
-					if (is_array($enableonly) && count($enableonly) && !in_array($obj->rowid, $enableonly)) {
+					if (is_array($enableonly) && !empty($enableonly) && !in_array($obj->rowid, $enableonly)) {
 						$disableline = ($enableonlytext ? $enableonlytext : '1');
 					}
 
@@ -2309,7 +2308,7 @@ class Form
 			}
 			// Show my availability
 			if ($showproperties) {
-				if ($ownerid == $value['id'] && is_array($listofuserid) && count($listofuserid) && in_array($ownerid, array_keys($listofuserid))) {
+				if ($ownerid == $value['id'] && is_array($listofuserid) && !empty($listofuserid) && in_array($ownerid, array_keys($listofuserid))) {
 					$out .= '<div class="myavailability inline-block">';
 					$out .= '<span class="hideonsmartphone">&nbsp;-&nbsp;<span class="opacitymedium">' . $langs->trans("Availability") . ':</span>  </span><input id="transparency" class="paddingrightonly" ' . ($action == 'view' ? 'disabled' : '') . ' type="checkbox" name="transparency"' . ($listofuserid[$ownerid]['transparency'] ? ' checked' : '') . '><label for="transparency">' . $langs->trans("Busy") . '</label>';
 					$out .= '</div>';
@@ -2639,7 +2638,7 @@ class Form
 		}
 
 		$selectFields = " p.rowid, p.ref, p.label, p.description, p.barcode, p.fk_country, p.fk_product_type, p.price, p.price_ttc, p.price_base_type, p.tva_tx, p.default_vat_code, p.duration, p.fk_price_expression";
-		if (count($warehouseStatusArray)) {
+		if (!empty($warehouseStatusArray)) {
 			$selectFieldsGrouped = ", sum(" . $this->db->ifsql("e.statut IS NULL", "0", "ps.reel") . ") as stock"; // e.statut is null if there is no record in stock
 		} else {
 			$selectFieldsGrouped = ", " . $this->db->ifsql("p.stock IS NULL", 0, "p.stock") . " AS stock";
@@ -2707,7 +2706,7 @@ class Form
 		$reshook = $hookmanager->executeHooks('selectProductsListFrom', $parameters); // Note that $action and $object may have been modified by hook
 		$sql .= $hookmanager->resPrint;
 
-		if (count($warehouseStatusArray)) {
+		if (!empty($warehouseStatusArray)) {
 			$sql .= " LEFT JOIN " . $this->db->prefix() . "product_stock as ps on ps.fk_product = p.rowid";
 			$sql .= " LEFT JOIN " . $this->db->prefix() . "entrepot as e on ps.fk_entrepot = e.rowid AND e.entity IN (" . getEntity('stock') . ")";
 			$sql .= ' AND e.statut IN (' . $this->db->sanitize($this->db->escape(implode(',', $warehouseStatusArray))) . ')'; // Return line if product is inside the selected stock. If not, an empty line will be returned so we will count 0.
@@ -2783,7 +2782,7 @@ class Form
 			// For natural search
 			$scrit = explode(' ', $filterkey);
 			$i = 0;
-			if (count($scrit) > 1) {
+			if (!empty($scrit[1])) {
 				$sql .= "(";
 			}
 			foreach ($scrit as $crit) {
@@ -2809,7 +2808,7 @@ class Form
 				$sql .= ")";
 				$i++;
 			}
-			if (count($scrit) > 1) {
+			if (!empty($scrit[1])) {
 				$sql .= ")";
 			}
 			if (isModEnabled('barcode')) {
@@ -2817,7 +2816,7 @@ class Form
 			}
 			$sql .= ')';
 		}
-		if (count($warehouseStatusArray)) {
+		if (!empty($warehouseStatusArray)) {
 			$sql .= " GROUP BY " . $selectFields;
 		}
 
@@ -3429,7 +3428,7 @@ class Form
 			// For natural search
 			$scrit = explode(' ', $filterkey);
 			$i = 0;
-			if (count($scrit) > 1) {
+			if (!empty($scrit[1])) {
 				$sql .= "(";
 			}
 			foreach ($scrit as $crit) {
@@ -3443,7 +3442,7 @@ class Form
 				$sql .= ")";
 				$i++;
 			}
-			if (count($scrit) > 1) {
+			if (!empty($scrit[1])) {
 				$sql .= ")";
 			}
 			if (isModEnabled('barcode')) {
@@ -3958,8 +3957,7 @@ class Form
 		// phpcs:enable
 		global $langs;
 
-		$num = count($this->cache_conditions_paiements);
-		if ($num > 0) {
+		if (!empty($this->cache_conditions_paiements)) {
 			return 0; // Cache already loaded
 		}
 
@@ -4007,8 +4005,8 @@ class Form
 		// phpcs:enable
 		global $langs;
 
-		$num = count($this->cache_availability);    // TODO Use $conf->cache['availability'] instead of $this->cache_availability
-		if ($num > 0) {
+		// TODO Use $conf->cache['availability'] instead of $this->cache_availability
+		if (!empty($this->cache_availability)) {
 			return 0; // Cache already loaded
 		}
 
@@ -4091,8 +4089,8 @@ class Form
 	{
 		global $langs;
 
-		$num = count($this->cache_demand_reason);    // TODO Use $conf->cache['input_reason'] instead of $this->cache_demand_reason
-		if ($num > 0) {
+		// TODO Use $conf->cache['input_reason'] instead of $this->cache_demand_reason
+		if (!empty($this->cache_demand_reason)) {
 			return 0; // Cache already loaded
 		}
 
@@ -4188,9 +4186,9 @@ class Form
 		// phpcs:enable
 		global $langs;
 
-		$num = count($this->cache_types_paiements);        // TODO Use $conf->cache['payment_mode'] instead of $this->cache_types_paiements
-		if ($num > 0) {
-			return $num; // Cache already loaded
+		// TODO Use $conf->cache['payment_mode'] instead of $this->cache_types_paiements
+		if (!empty($this->cache_types_paiements)) {
+			return count($this->cache_types_paiements); // Cache already loaded
 		}
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
@@ -4399,7 +4397,7 @@ class Form
 			}
 
 			// On passe si on a demande de filtrer sur des modes de paiments particuliers
-			if (count($filterarray) && !in_array($arraytypes['type'], $filterarray)) {
+			if (!empty($filterarray) && !in_array($arraytypes['type'], $filterarray)) {
 				continue;
 			}
 
@@ -4500,9 +4498,9 @@ class Form
 		// phpcs:enable
 		global $langs;
 
-		$num = count($this->cache_transport_mode);        // TODO Use $conf->cache['payment_mode'] instead of $this->cache_transport_mode
-		if ($num > 0) {
-			return $num; // Cache already loaded
+		// TODO Use $conf->cache['payment_mode'] instead of $this->cache_transport_mode
+		if (!empty($this->cache_transport_mode)) {
+			return count($this->cache_transport_mode); // Cache already loaded
 		}
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
@@ -5064,7 +5062,7 @@ class Form
 
 		$output = '<select class="flat' . ($morecss ? ' ' . $morecss : '') . '" name="' . $htmlname . '" id="' . $htmlname . '">';
 		if (is_array($cate_arbo)) {
-			if (!count($cate_arbo)) {
+			if (empty($cate_arbo)) {
 				$output .= '<option value="-1" disabled>' . $langs->trans("NoCategoriesDefined") . '</option>';
 			} else {
 				$output .= '<option value="-1">&nbsp;</option>';
@@ -5165,8 +5163,9 @@ class Form
 		// Set height automatically if not defined
 		if (empty($height)) {
 			$height = 220;
-			if (is_array($formquestion) && count($formquestion) > 2) {
-				$height += ((count($formquestion) - 2) * 24);
+			$formquestioncount = is_array($formquestion) ? count($formquestion) : 0;
+			if ($formquestioncount > 2) {
+				$height += ($formquestioncount - 2) * 24;
 			}
 		}
 
@@ -6268,7 +6267,7 @@ class Form
 		if (!in_array($conf->currency, $TCurrency) && !$excludeConfCurrency) {
 			$TCurrency[$conf->currency] = $conf->currency;
 		}
-		if (count($TCurrency) > 0) {
+		if (!empty($TCurrency)) {
 			foreach ($langs->cache_currencies as $code_iso => $currency) {
 				if (isset($TCurrency[$code_iso])) {
 					if (!empty($selected) && $selected == $code_iso) {
@@ -6306,9 +6305,8 @@ class Form
 		// phpcs:enable
 		global $langs, $user;
 
-		$num = count($this->cache_vatrates);
-		if ($num > 0) {
-			return $num; // Cache already loaded
+		if (!empty($this->cache_vatrates)) {
+			return count($this->cache_vatrates); // Cache already loaded
 		}
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
@@ -7338,15 +7336,18 @@ class Form
 			$prefix = empty($conf->global->TICKET_DONOTSEARCH_ANYWHERE) ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
 			// For natural search
 			$scrit = explode(' ', $filterkey);
-			$i = 0;
-			if (count($scrit) > 1) $sql .= "(";
-			foreach ($scrit as $crit) {
-				if ($i > 0) $sql .= " AND ";
-				$sql .= "(p.ref LIKE '" . $this->db->escape($prefix . $crit) . "%' OR p.subject LIKE '" . $this->db->escape($prefix . $crit) . "%'";
-				$sql .= ")";
-				$i++;
+			if (!empty($scrit[1])) {
+				$sql .= "(";
 			}
-			if (count($scrit) > 1) $sql .= ")";
+			foreach ($scrit as $i => $crit) {
+				if ($i > 0) {
+					$sql .= " AND ";
+				}
+				$sql .= "(p.ref LIKE '" . $this->db->escape($prefix . $crit) . "%' OR p.subject LIKE '" . $this->db->escape($prefix . $crit) . "%')";
+			}
+			if (!empty($scrit[1])) {
+				$sql .= ")";
+			}
 			$sql .= ')';
 		}
 
@@ -7544,15 +7545,18 @@ class Form
 			$prefix = empty($conf->global->TICKET_DONOTSEARCH_ANYWHERE) ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
 			// For natural search
 			$scrit = explode(' ', $filterkey);
-			$i = 0;
-			if (count($scrit) > 1) $sql .= "(";
-			foreach ($scrit as $crit) {
-				if ($i > 0) $sql .= " AND ";
-				$sql .= "p.ref LIKE '" . $this->db->escape($prefix . $crit) . "%'";
-				$sql .= "";
-				$i++;
+			if (!empty($scrit[1])) {
+				$sql .= "(";
 			}
-			if (count($scrit) > 1) $sql .= ")";
+			foreach ($scrit as $i => $crit) {
+				if ($i > 0) {
+					$sql .= " AND ";
+				}
+				$sql .= "p.ref LIKE '" . $this->db->escape($prefix . $crit) . "%'";
+			}
+			if (!empty($scrit[1])) {
+				$sql .= ")";
+			}
 			$sql .= ')';
 		}
 
@@ -7759,15 +7763,19 @@ class Form
 			$prefix = empty($conf->global->MEMBER_DONOTSEARCH_ANYWHERE) ? '%' : ''; // Can use index if PRODUCT_DONOTSEARCH_ANYWHERE is on
 			// For natural search
 			$scrit = explode(' ', $filterkey);
-			$i = 0;
-			if (count($scrit) > 1) $sql .= "(";
-			foreach ($scrit as $crit) {
-				if ($i > 0) $sql .= " AND ";
+			if (!empty($scrit[1])) {
+				$sql .= "(";
+			}
+			foreach ($scrit as $i => $crit) {
+				if ($i > 0) {
+					$sql .= " AND ";
+				}
 				$sql .= "(p.firstname LIKE '" . $this->db->escape($prefix . $crit) . "%'";
 				$sql .= " OR p.lastname LIKE '" . $this->db->escape($prefix . $crit) . "%')";
-				$i++;
 			}
-			if (count($scrit) > 1) $sql .= ")";
+			if (!empty($scrit[1])) {
+				$sql .= ")";
+			}
 			$sql .= ')';
 		}
 		if ($status != -1) {
@@ -9141,11 +9149,11 @@ class Form
 		}
 
 		if (empty($reshook)) {
-			if (is_array($hookmanager->resArray) && count($hookmanager->resArray)) {
+			if (is_array($hookmanager->resArray) && !empty($hookmanager->resArray)) {
 				$possiblelinks = array_merge($possiblelinks, $hookmanager->resArray);
 			}
 		} elseif ($reshook > 0) {
-			if (is_array($hookmanager->resArray) && count($hookmanager->resArray)) {
+			if (is_array($hookmanager->resArray) && !empty($hookmanager->resArray)) {
 				$possiblelinks = $hookmanager->resArray;
 			}
 		}
@@ -9520,7 +9528,7 @@ class Form
 				$arrayoflangcode[] = $conf->global->PDF_USE_ALSO_LANGUAGE_CODE;
 			}
 
-			if (is_array($arrayoflangcode) && count($arrayoflangcode)) {
+			if (is_array($arrayoflangcode) && !empty($arrayoflangcode)) {
 				if (!is_object($extralanguages)) {
 					include_once DOL_DOCUMENT_ROOT . '/core/class/extralanguages.class.php';
 					$extralanguages = new ExtraLanguages($this->db);
@@ -9903,7 +9911,7 @@ class Form
 				while ($i < $num) {
 					$obj = $this->db->fetch_object($resql);
 					$disableline = 0;
-					if (is_array($enableonly) && count($enableonly) && !in_array($obj->rowid, $enableonly)) {
+					if (is_array($enableonly) && !empty($enableonly) && !in_array($obj->rowid, $enableonly)) {
 						$disableline = 1;
 					}
 

--- a/htdocs/core/class/utils.class.php
+++ b/htdocs/core/class/utils.class.php
@@ -137,7 +137,7 @@ class Utils
 				}
 			}
 
-			if (is_array($filesarray) && count($filesarray)) {
+			if (is_array($filesarray) && !empty($filesarray)) {
 				foreach ($filesarray as $key => $value) {
 					//print "x ".$filesarray[$key]['fullname']."-".$filesarray[$key]['type']."<br>\n";
 					if ($filesarray[$key]['type'] == 'dir') {
@@ -747,7 +747,7 @@ class Utils
 		}
 
 		// Update with result
-		if (is_array($output_arr) && count($output_arr) > 0) {
+		if (is_array($output_arr) && !empty($output_arr)) {
 			foreach ($output_arr as $val) {
 				$output .= $val.($execmethod == 2 ? '' : "\n");
 			}
@@ -798,7 +798,7 @@ class Utils
 		}
 
 		$arrayversion = explode('.', $moduleobj->version, 3);
-		if (count($arrayversion)) {
+		if (!empty($arrayversion)) {
 			$FILENAMEASCII = strtolower($module).'.asciidoc';
 			$FILENAMEDOC = strtolower($module).'.html';
 			$FILENAMEDOCPDF = strtolower($module).'.pdf';
@@ -1190,22 +1190,21 @@ class Utils
 				while ($row = $db->fetch_row($result)) {
 					// For each row of data we print a line of INSERT
 					fwrite($handle, "INSERT ".$delayed.$ignore."INTO ".$table." VALUES (");
-					$columns = count($row);
-					for ($j = 0; $j < $columns; $j++) {
+					foreach ($row as &$column) {
 						// Processing each columns of the row to ensure that we correctly save the value (eg: add quotes for string - in fact we add quotes for everything, it's easier)
-						if ($row[$j] == null && !is_string($row[$j])) {
+						if ($column === null) {
 							// IMPORTANT: if the field is NULL we set it NULL
-							$row[$j] = 'NULL';
-						} elseif (is_string($row[$j]) && $row[$j] == '') {
+							$column = 'NULL';
+						} elseif ($column === '') {
 							// if it's an empty string, we set it as an empty string
-							$row[$j] = "''";
-						} elseif (is_numeric($row[$j]) && !strcmp($row[$j], $row[$j] + 0)) { // test if it's a numeric type and the numeric version ($nb+0) == string version (eg: if we have 01, it's probably not a number but rather a string, else it would not have any leading 0)
+							$column = "''";
+						} elseif (is_numeric($column) && !strcmp($column, $column + 0)) { // test if it's a numeric type and the numeric version ($nb+0) == string version (eg: if we have 01, it's probably not a number but rather a string, else it would not have any leading 0)
 							// if it's a number, we return it as-is
-							//	                    $row[$j] = $row[$j];
+							//	                    $column = $column;
 						} else { // else for all other cases we escape the value and put quotes around
-							$row[$j] = addslashes($row[$j]);
-							$row[$j] = preg_replace("#\n#", "\\n", $row[$j]);
-							$row[$j] = "'".$row[$j]."'";
+							$column = addslashes($column);
+							$column = preg_replace("#\n#", "\\n", $column);
+							$column = "'".$column."'";
 						}
 					}
 					fwrite($handle, implode(',', $row).");\n");

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1675,22 +1675,18 @@ function dol_escape_htmltag($stringtoescape, $keepb = 0, $keepn = 0, $noescapeta
 		if ($noescapetags) {
 			$tmparrayoftags = explode(',', $noescapetags);
 		}
-		if (count($tmparrayoftags)) {
-			foreach ($tmparrayoftags as $tagtoreplace) {
-				$tmp = str_ireplace('<'.$tagtoreplace.'>', '__BEGINTAGTOREPLACE'.$tagtoreplace.'__', $tmp);
-				$tmp = str_ireplace('</'.$tagtoreplace.'>', '__ENDTAGTOREPLACE'.$tagtoreplace.'__', $tmp);
-				$tmp = str_ireplace('<'.$tagtoreplace.' />', '__BEGINENDTAGTOREPLACE'.$tagtoreplace.'__', $tmp);
-			}
+		foreach ($tmparrayoftags as $tagtoreplace) {
+			$tmp = str_ireplace('<'.$tagtoreplace.'>', '__BEGINTAGTOREPLACE'.$tagtoreplace.'__', $tmp);
+			$tmp = str_ireplace('</'.$tagtoreplace.'>', '__ENDTAGTOREPLACE'.$tagtoreplace.'__', $tmp);
+			$tmp = str_ireplace('<'.$tagtoreplace.' />', '__BEGINENDTAGTOREPLACE'.$tagtoreplace.'__', $tmp);
 		}
 
 		$result = htmlentities($tmp, ENT_COMPAT, 'UTF-8');
 
-		if (count($tmparrayoftags)) {
-			foreach ($tmparrayoftags as $tagtoreplace) {
-				$result = str_ireplace('__BEGINTAGTOREPLACE'.$tagtoreplace.'__', '<'.$tagtoreplace.'>', $result);
-				$result = str_ireplace('__ENDTAGTOREPLACE'.$tagtoreplace.'__', '</'.$tagtoreplace.'>', $result);
-				$result = str_ireplace('__BEGINENDTAGTOREPLACE'.$tagtoreplace.'__', '<'.$tagtoreplace.' />', $result);
-			}
+		foreach ($tmparrayoftags as $tagtoreplace) {
+			$result = str_ireplace('__BEGINTAGTOREPLACE'.$tagtoreplace.'__', '<'.$tagtoreplace.'>', $result);
+			$result = str_ireplace('__ENDTAGTOREPLACE'.$tagtoreplace.'__', '</'.$tagtoreplace.'>', $result);
+			$result = str_ireplace('__BEGINENDTAGTOREPLACE'.$tagtoreplace.'__', '<'.$tagtoreplace.' />', $result);
 		}
 
 		return $result;
@@ -2066,10 +2062,7 @@ function dol_get_fiche_head($links = array(), $active = '', $title = '', $notab 
 	// Define max of key (max may be higher than sizeof because of hole due to module disabling some tabs).
 	$maxkey = -1;
 	if (is_array($links) && !empty($links)) {
-		$keys = array_keys($links);
-		if (count($keys)) {
-			$maxkey = max($keys);
-		}
+		$maxkey = max(array_keys($links));
 	}
 
 	// Show tabs
@@ -4000,14 +3993,12 @@ function isValidMXRecord($domain)
 			$mxhosts = array();
 			$weight = array();
 			getmxrr(idn_to_ascii($domain), $mxhosts, $weight);
-			if (count($mxhosts) > 1) {
-				return 1;
-			}
-			if (count($mxhosts) == 1 && !empty($mxhosts[0])) {
-				return 1;
+
+			if (empty($mxhosts) || empty($mxhosts[0])) {
+				return 0;
 			}
 
-			return 0;
+			return 1;
 		}
 	}
 
@@ -5332,7 +5323,7 @@ function dol_print_error_email($prefixcode, $errormessage = '', $errormessages =
 	if ($errormessage) {
 		print '<br><br>'.$errormessage;
 	}
-	if (is_array($errormessages) && count($errormessages)) {
+	if (is_array($errormessages)) {
 		foreach ($errormessages as $mesgtoshow) {
 			print '<br><br>'.$mesgtoshow;
 		}
@@ -7020,12 +7011,11 @@ function dol_mkdir($dir, $dataroot = '', $newmask = '')
 	}
 
 	$cdir = explode("/", $dir);
-	$num = count($cdir);
-	for ($i = 0; $i < $num; $i++) {
+	foreach ($cdir as $i => $d) {
 		if ($i > 0) {
-			$ccdir .= '/'.$cdir[$i];
+			$ccdir .= '/'.$d;
 		} else {
-			$ccdir .= $cdir[$i];
+			$ccdir .= $d;
 		}
 		$regs = array();
 		if (preg_match("/^.:$/", $ccdir, $regs)) {
@@ -8184,7 +8174,7 @@ function getCommonSubstitutionArray($outputlangs, $onlykey = 0, $exclude = null,
 				$extrafields->fetch_name_optionals_label($object->table_element, true);
 
 				if ($object->fetch_optionals() > 0) {
-					if (is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label']) > 0) {
+					if (!empty($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label'])) {
 						foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $label) {
 							if ($extrafields->attributes[$object->table_element]['type'][$key] == 'date') {
 								$substitutionarray['__EXTRAFIELD_'.strtoupper($key).'__'] = dol_print_date($object->array_options['options_'.$key], 'day');
@@ -8819,7 +8809,6 @@ function get_htmloutput_mesg($mesgstring = '', $mesgarray = '', $style = 'ok', $
 {
 	global $conf, $langs;
 
-	$ret = 0;
 	$return = '';
 	$out = '';
 	$divstart = $divend = '';
@@ -8830,20 +8819,18 @@ function get_htmloutput_mesg($mesgstring = '', $mesgarray = '', $style = 'ok', $
 		$divend = '</div>';
 	}
 
-	if ((is_array($mesgarray) && count($mesgarray)) || $mesgstring) {
+	if ((is_array($mesgarray) && !empty($mesgarray)) || $mesgstring) {
 		$langs->load("errors");
 		$out .= $divstart;
-		if (is_array($mesgarray) && count($mesgarray)) {
-			foreach ($mesgarray as $message) {
-				$ret++;
-				$out .= $langs->trans($message);
-				if ($ret < count($mesgarray)) {
+		if (is_array($mesgarray) && !empty($mesgarray)) {
+			foreach ($mesgarray as $i => $message) {
+				if ($i > 0) {
 					$out .= "<br>\n";
 				}
+				$out .= $langs->trans($message);
 			}
 		}
 		if ($mesgstring) {
-			$ret++;
 			$out .= $langs->trans($mesgstring);
 		}
 		$out .= $divend;
@@ -8904,7 +8891,7 @@ function get_htmloutput_errors($mesgstring = '', $mesgarray = array(), $keepembe
  */
 function dol_htmloutput_mesg($mesgstring = '', $mesgarray = array(), $style = 'ok', $keepembedded = 0)
 {
-	if (empty($mesgstring) && (!is_array($mesgarray) || count($mesgarray) == 0)) {
+	if (empty($mesgstring) && (!is_array($mesgarray) || empty($mesgarray))) {
 		return;
 	}
 
@@ -8995,8 +8982,7 @@ function dol_sort_array(&$array, $index, $order = 'asc', $natsort = 0, $case_sen
 	$order = strtolower($order);
 
 	if (is_array($array)) {
-		$sizearray = count($array);
-		if ($sizearray > 0) {
+		if (!empty($array)) {
 			$temp = array();
 			foreach (array_keys($array) as $key) {
 				if (is_object($array[$key])) {
@@ -9696,10 +9682,11 @@ function complete_head_from_modules($conf, $langs, $object, &$head, &$h, $type, 
 	if (isset($conf->modules_parts['tabs'][$type]) && is_array($conf->modules_parts['tabs'][$type])) {
 		foreach ($conf->modules_parts['tabs'][$type] as $value) {
 			$values = explode(':', $value);
+			$valuesCount = count($values);
 
 			$reg = array();
 			if ($mode == 'add' && !preg_match('/^\-/', $values[1])) {
-				if (count($values) == 6) {
+				if ($valuesCount == 6) {
 					// new declaration with permissions:
 					// $value='objecttype:+tabname1:Title1:langfile@mymodule:$user->rights->mymodule->read:/mymodule/mynewtab1.php?id=__ID__'
 					// $value='objecttype:+tabname1:Title1,class,pathfile,method:langfile@mymodule:$user->rights->mymodule->read:/mymodule/mynewtab1.php?id=__ID__'
@@ -9753,7 +9740,7 @@ function complete_head_from_modules($conf, $langs, $object, &$head, &$h, $type, 
 						$head[$h][2] = str_replace('+', '', $values[1]);
 						$h++;
 					}
-				} elseif (count($values) == 5) {       // case deprecated
+				} elseif ($valuesCount == 5) {       // case deprecated
 					dol_syslog('Passing 5 values in tabs module_parts is deprecated. Please update to 6 with permissions.', LOG_WARNING);
 
 					if ($values[0] != $type) {
@@ -10010,7 +9997,7 @@ function printCommonFooter($zone = 'private')
 			print '<!-- Output debugbar data -->'."\n";
 			$renderer = $debugbar->getRenderer();
 			print $debugbar->getRenderer()->render();
-		} elseif (count($conf->logbuffer)) {    // If there is some logs in buffer to show
+		} elseif (!empty($conf->logbuffer)) {    // If there is some logs in buffer to show
 			print "\n";
 			print "<!-- Start of log output\n";
 			//print '<div class="hidden">'."\n";
@@ -10183,7 +10170,7 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 				$i2++; // a criteria for 1 more field was added to string
 			} elseif ($mode == 3 || $mode == -3) {
 				$tmparray = explode(',', $crit);
-				if (count($tmparray)) {
+				if (!empty($tmparray)) {
 					$listofcodes = '';
 					foreach ($tmparray as $val) {
 						$val = trim($val);
@@ -10200,7 +10187,7 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 				}
 			} elseif ($mode == 4) {
 				$tmparray = explode(',', $crit);
-				if (count($tmparray)) {
+				if (!empty($tmparray)) {
 					$listofcodes = '';
 					foreach ($tmparray as $val) {
 						$val = trim($val);
@@ -10917,7 +10904,7 @@ function colorIsLight($stringcolor)
 	if (!empty($stringcolor)) {
 		$res = 0;
 		$tmp = explode(',', $stringcolor);
-		if (count($tmp) > 1) {   // This is a comma RGB ('255','255','255')
+		if (isset($tmp[2])) {   // This is a comma RGB ('255','255','255')
 			$r = $tmp[0];
 			$g = $tmp[1];
 			$b = $tmp[2];
@@ -12114,7 +12101,7 @@ function dolForgeDummyCriteriaCallback($matches)
 		return '';
 	}
 	$tmp = explode(':', $matches[1]);
-	if (count($tmp) < 3) {
+	if (!isset($tmp[2])) {
 		return '';
 	}
 
@@ -12138,7 +12125,7 @@ function dolForgeCriteriaCallback($matches)
 		return '';
 	}
 	$tmp = explode(':', $matches[1]);
-	if (count($tmp) < 3) {
+	if (!isset($tmp[2])) {
 		return '';
 	}
 
@@ -12833,7 +12820,7 @@ function show_actions_messaging($conf, $langs, $db, $filterobj, $objcon = '', $n
 			$footer = '';
 
 			// Contact for this action
-			if (isset($histo[$key]['socpeopleassigned']) && is_array($histo[$key]['socpeopleassigned']) && count($histo[$key]['socpeopleassigned']) > 0) {
+			if (!empty($histo[$key]['socpeopleassigned']) && is_array($histo[$key]['socpeopleassigned'])) {
 				$contactList = '';
 				foreach ($histo[$key]['socpeopleassigned'] as $cid => $Tab) {
 					$contact = new Contact($db);

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -6328,11 +6328,7 @@ function isOnlyOneLocalTax($local)
 
 	$valors = explode(":", $tax);
 
-	if (count($valors) > 1) {
-		return false;
-	} else {
-		return true;
-	}
+	return !array_key_exists(1, $valors);
 }
 
 /**

--- a/htdocs/core/tpl/admin_extrafields_view.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_view.tpl.php
@@ -85,7 +85,7 @@ if (isModEnabled('multicompany')) {
 print '<td width="80">&nbsp;</td>';
 print "</tr>\n";
 
-if (isset($extrafields->attributes[$elementtype]['type']) && is_array($extrafields->attributes[$elementtype]['type']) && count($extrafields->attributes[$elementtype]['type'])) {
+if (!empty($extrafields->attributes[$elementtype]['type']) && is_array($extrafields->attributes[$elementtype]['type'])) {
 	foreach ($extrafields->attributes[$elementtype]['type'] as $key => $value) {
 		/*if (! dol_eval($extrafields->attributes[$elementtype]['enabled'][$key], 1, 1, '1')) {
 			// TODO Uncomment this to exclude extrafields of modules not enabled. Add a link to "Show extrafields disabled"

--- a/htdocs/core/tpl/advtarget.tpl.php
+++ b/htdocs/core/tpl/advtarget.tpl.php
@@ -278,7 +278,7 @@ if (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED)) {
 	foreach ($extrafields->attributes[$elementtype]['label'] as $key => $val) {
 		if ($key != 'ts_nameextra' && $key != 'ts_payeur') {
 			print '<tr><td>'.$extrafields->attributes[$elementtype]['label'][$key];
-			if (!empty($array_query['options_'.$key]) || (is_array($array_query['options_'.$key]) && count($array_query['options_'.$key]) > 0)) {
+			if (!empty($array_query['options_'.$key])) {
 				print img_picto($langs->trans('AdvTgtUse'), 'ok.png@advtargetemailing');
 			}
 			print '</td><td>';
@@ -477,7 +477,7 @@ if (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED)) {
 	if (!empty($extrafields->attributes[$elementtype]['label'])) {
 		foreach ($extrafields->attributes[$elementtype]['label'] as $key => $val) {
 			print '<tr><td>'.$extrafields->attributes[$elementtype]['label'][$key];
-			if ($array_query['options_'.$key.'_cnct'] != '' || (is_array($array_query['options_'.$key.'_cnct']) && count($array_query['options_'.$key.'_cnct']) > 0)) {
+			if ($array_query['options_'.$key.'_cnct'] != '' || (is_array($array_query['options_'.$key.'_cnct']) && !empty($array_query['options_'.$key.'_cnct']))) {
 				print img_picto($langs->trans('AdvTgtUse'), 'ok.png@advtargetemailing');
 			}
 			print '</td><td>';

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -222,14 +222,14 @@ if ($action == 'presend') {
 		$fuserdest = new User($db);
 
 		$result = $fuserdest->fetchAll('ASC', 't.lastname', 0, 0, array('customsql'=>"t.statut=1 AND t.employee=1 AND t.email IS NOT NULL AND t.email <> ''"), 'AND', true);
-		if ($result > 0 && is_array($fuserdest->users) && count($fuserdest->users) > 0) {
+		if ($result > 0 && is_array($fuserdest->users) && !empty($fuserdest->users)) {
 			foreach ($fuserdest->users as $uuserdest) {
 				$listeuser[$uuserdest->id] = $uuserdest->user_get_property($uuserdest->id, 'email');
 			}
 		} elseif ($result < 0) {
 			setEventMessages(null, $fuserdest->errors, 'errors');
 		}
-		if (count($listeuser) > 0) {
+		if (!empty($listeuser)) {
 			$formmail->withtouser = $listeuser;
 			$formmail->withtoccuser = $listeuser;
 		}
@@ -333,7 +333,7 @@ if ($action == 'presend') {
 	$contactarr = array();
 	$contactarr = $tmpobject->liste_contact(-1, 'external', 0, '', 1);
 
-	if (is_array($contactarr) && count($contactarr) > 0) {
+	if (is_array($contactarr) && !empty($contactarr)) {
 		require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 		require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
 		$contactstatic = new Contact($db);

--- a/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_array_fields.tpl.php
@@ -14,7 +14,7 @@ if (empty($extrafieldsobjectkey) && is_object($object)) {
 
 // Loop to show all columns of extrafields from $obj, $extrafields and $db
 if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table_element like 'societe', 'socpeople', ...
-	if (isset($extrafields->attributes[$extrafieldsobjectkey]['label']) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label']) && count($extrafields->attributes[$extrafieldsobjectkey]['label']) > 0) {
+	if (!empty($extrafields->attributes[$extrafieldsobjectkey]['label']) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
 		if (empty($extrafieldsobjectprefix)) {
 			$extrafieldsobjectprefix = 'ef.';
 		}

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -12,7 +12,7 @@ if (empty($extrafieldsobjectkey) && is_object($object)) {
 
 // Loop to show all columns of extrafields from $obj, $extrafields and $db
 if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafieldsobjectkey])) {	// $extrafieldsobject is the $object->table_element like 'societe', 'socpeople', ...
-	if (key_exists('label', $extrafields->attributes[$extrafieldsobjectkey]) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label']) && count($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
+	if (!empty($extrafields->attributes[$extrafieldsobjectkey]['label']) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
 		if (empty($extrafieldsobjectprefix)) {
 			$extrafieldsobjectprefix = 'ef.';
 		}

--- a/htdocs/core/tpl/extrafields_list_search_input.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_input.tpl.php
@@ -14,7 +14,7 @@ if (empty($extrafieldsobjectkey) && is_object($object)) {
 
 // Loop to show all columns of extrafields for the search title line
 if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table_element like 'societe', 'socpeople', ...
-	if (!empty($extrafields->attributes[$extrafieldsobjectkey]['label']) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label']) && count($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
+	if (!empty($extrafields->attributes[$extrafieldsobjectkey]['label']) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
 		if (empty($extrafieldsobjectprefix)) {
 			$extrafieldsobjectprefix = 'ef.';
 		}

--- a/htdocs/core/tpl/extrafields_list_search_title.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_title.tpl.php
@@ -15,7 +15,7 @@ if (!isset($disablesortlink)) {
 
 // Loop to show all columns of extrafields for the title line
 if (!empty($extrafieldsobjectkey)) {	// $extrafieldsobject is the $object->table_element like 'societe', 'socpeople', ...
-	if (!empty($extrafields->attributes[$extrafieldsobjectkey]['label']) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label']) && count($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
+	if (!empty($extrafields->attributes[$extrafieldsobjectkey]['label']) && is_array($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
 		if (empty($extrafieldsobjectprefix)) {
 			$extrafieldsobjectprefix = 'ef.';
 		}

--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -102,7 +102,7 @@ if (!empty($extrafields)) {
 	}
 }
 print "<!-- BEGIN PHP TEMPLATE objectline_create.tpl.php -->\n";
-$nolinesbefore = (count($this->lines) == 0 || $forcetoshowtitlelines);
+$nolinesbefore = (empty($this->lines) || $forcetoshowtitlelines);
 if ($nolinesbefore) {
 	?>
 	<tr class="liste_titre<?php echo (($nolinesbefore || $object->element == 'contrat') ? '' : ' liste_titre_add_') ?> nodrag nodrop">

--- a/htdocs/core/tpl/resource_view.tpl.php
+++ b/htdocs/core/tpl/resource_view.tpl.php
@@ -27,7 +27,7 @@ print '<input type="hidden" name="id" value="'.$element_id.'" />';
 print '<input type="hidden" name="action" value="update_linked_resource" />';
 print '<input type="hidden" name="resource_type" value="'.$resource_type.'" />';
 
-if ((array) $linked_resources && count($linked_resources) > 0) {
+if ((array) $linked_resources && !empty($linked_resources)) {
 	foreach ($linked_resources as $linked_resource) {
 		$object_resource = fetchObjectByElement($linked_resource['resource_id'], $linked_resource['resource_type']);
 

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -646,7 +646,7 @@ if (!empty($_SESSION["disablemodules"])) {
 
 // Set current modulepart
 $modulepart = explode("/", $_SERVER["PHP_SELF"]);
-if (is_array($modulepart) && count($modulepart) > 0) {
+if (is_array($modulepart) && !empty($modulepart)) {
 	foreach ($conf->modules as $module) {
 		if (in_array($module, $modulepart)) {
 			$modulepart = $module;
@@ -683,7 +683,7 @@ if (!defined('NOLOGIN')) {
 	$authmode = explode(',', $dolibarr_main_authentication);
 
 	// No authentication mode
-	if (!count($authmode)) {
+	if (empty($authmode)) {
 		$langs->load('main');
 		dol_print_error('', $langs->trans("ErrorConfigParameterNotDefined", 'dolibarr_main_authentication'));
 		exit;
@@ -958,7 +958,7 @@ if (!defined('NOLOGIN')) {
 			if (GETPOST('lang', 'aZ09')) {
 				$paramsurl[] = 'lang='.GETPOST('lang', 'aZ09');
 			}
-			header('Location: '.DOL_URL_ROOT.'/index.php'.(count($paramsurl) ? '?'.implode('&', $paramsurl) : ''));
+			header('Location: '.DOL_URL_ROOT.'/index.php'.(!empty($paramsurl) ? '?'.implode('&', $paramsurl) : ''));
 			exit;
 		} else {
 			// User is loaded, we may need to change language for him according to its choice
@@ -1042,8 +1042,8 @@ if (!defined('NOLOGIN')) {
 			if (GETPOST('lang', 'aZ09')) {
 				$paramsurl[] = 'lang='.GETPOST('lang', 'aZ09');
 			}
-							header('Location: '.DOL_URL_ROOT.'/index.php'.(count($paramsurl) ? '?'.implode('&', $paramsurl) : ''));
-							exit;
+			header('Location: '.DOL_URL_ROOT.'/index.php'.(!empty($paramsurl) ? '?'.implode('&', $paramsurl) : ''));
+			exit;
 		} else {
 			// Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
 			$hookmanager->initHooks(array('main'));
@@ -3533,7 +3533,7 @@ if (!function_exists("llxFooter")) {
 			// Clean and save data
 			foreach ($user->lastsearch_values_tmp as $key => $val) {
 				unset($_SESSION['lastsearch_values_tmp_'.$key]); // Clean array to rebuild it just after
-				if (count($val) && empty($_POST['button_removefilter']) && empty($_POST['button_removefilter_x'])) {
+				if (!empty($val) && empty($_POST['button_removefilter']) && empty($_POST['button_removefilter_x'])) {
 					if (empty($val['sortfield'])) {
 						unset($val['sortfield']);
 					}

--- a/htdocs/modulebuilder/template/admin/setup.php
+++ b/htdocs/modulebuilder/template/admin/setup.php
@@ -80,7 +80,6 @@ $type = 'myobject';
 
 
 $error = 0;
-$setupnotempty = 0;
 
 // Set this to 1 to use the factory to manage constants. Warning, the generated module will be compatible with version v15+ only
 $useFormSetup = 1;
@@ -158,9 +157,6 @@ $item->helpText = $langs->transnoentities('AnHelpMessage');
 //$item->fieldOverride = false; // set this var to override field output will override $fieldInputOverride and $fieldOutputOverride too
 //$item->fieldInputOverride = false; // set this var to override field input
 //$item->fieldOutputOverride = false; // set this var to override field output
-
-
-$setupnotempty += count($formSetup->items);
 
 
 $dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
@@ -318,6 +314,7 @@ $myTmpObjects = array();
 // TODO Scan list of objects
 $myTmpObjects['myobject'] = array('label'=>'MyObject', 'includerefgeneration'=>0, 'includedocgeneration'=>0, 'class'=>'MyObject');
 
+$setupnotempty = 0;
 
 foreach ($myTmpObjects as $myTmpObjectKey => $myTmpObjectArray) {
 	if ($myTmpObjectArray['includerefgeneration']) {

--- a/htdocs/modulebuilder/template/class/actions_mymodule.class.php
+++ b/htdocs/modulebuilder/template/class/actions_mymodule.class.php
@@ -332,7 +332,6 @@ class ActionsMyModule
 		} elseif ($parameters['mode'] == 'add') {
 			$langs->load('mymodule@mymodule');
 			// used when we want to add some tabs
-			$counter = count($parameters['head']);
 			$element = $parameters['object']->element;
 			$id = $parameters['object']->id;
 			// verifier le type d'onglet comme member_stats où ça ne doit pas apparaitre
@@ -340,15 +339,19 @@ class ActionsMyModule
 			if (in_array($element, ['context1', 'context2'])) {
 				$datacount = 0;
 
-				$parameters['head'][$counter][0] = dol_buildpath('/mymodule/mymodule_tab.php', 1) . '?id=' . $id . '&amp;module='.$element;
-				$parameters['head'][$counter][1] = $langs->trans('MyModuleTab');
+				$entry = array(
+					dol_buildpath('/mymodule/mymodule_tab.php', 1) . '?id=' . $id . '&amp;module='.$element,
+					$langs->trans('MyModuleTab'),
+					'mymoduleemails'
+				);
+
 				if ($datacount > 0) {
-					$parameters['head'][$counter][1] .= '<span class="badge marginleftonlyshort">' . $datacount . '</span>';
+					$entry[1] .= '<span class="badge marginleftonlyshort">' . $datacount . '</span>';
 				}
-				$parameters['head'][$counter][2] = 'mymoduleemails';
-				$counter++;
+
+				$parameters['head'][] = $entry;
 			}
-			if ($counter > 0 && (int) DOL_VERSION < 14) {
+			if (!empty($parameters['head']) && (int) DOL_VERSION < 14) {
 				$this->results = $parameters['head'];
 				// return 1 to replace standard code
 				return 1;

--- a/htdocs/modulebuilder/template/class/api_mymodule.class.php
+++ b/htdocs/modulebuilder/template/class/api_mymodule.class.php
@@ -189,7 +189,7 @@ class MyModuleApi extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving myobject list: '.$this->db->lasterror());
 		}
-		if (!count($obj_ret)) {
+		if (empty($obj_ret)) {
 			throw new RestException(404, 'No myobject found');
 		}
 		return $obj_ret;
@@ -390,13 +390,12 @@ class MyModuleApi extends DolibarrApi
 		*/
 
 		// If object has lines, remove $db property
-		if (isset($object->lines) && is_array($object->lines) && count($object->lines) > 0) {
-			$nboflines = count($object->lines);
-			for ($i = 0; $i < $nboflines; $i++) {
-				$this->_cleanObjectDatas($object->lines[$i]);
+		if (!empty($object->lines) && is_array($object->lines)) {
+			foreach ($object->lines as $line) {
+				$this->_cleanObjectDatas($line);
 
-				unset($object->lines[$i]->lines);
-				unset($object->lines[$i]->note);
+				unset($line->lines);
+				unset($line->note);
 			}
 		}
 

--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -351,7 +351,7 @@ class MyObject extends CommonObject
 		}
 		// ...
 		// Clear extrafields that are unique
-		if (is_array($object->array_options) && count($object->array_options) > 0) {
+		if (is_array($object->array_options) && !empty($object->array_options)) {
 			$extrafields->fetch_name_optionals_label($this->table_element);
 			foreach ($object->array_options as $key => $option) {
 				$shortkey = preg_replace('/options_/', '', $key);
@@ -456,22 +456,20 @@ class MyObject extends CommonObject
 		}
 		// Manage filter
 		$sqlwhere = array();
-		if (count($filter) > 0) {
-			foreach ($filter as $key => $value) {
-				if ($key == 't.rowid') {
-					$sqlwhere[] = $key." = ".((int) $value);
-				} elseif (in_array($this->fields[$key]['type'], array('date', 'datetime', 'timestamp'))) {
-					$sqlwhere[] = $key." = '".$this->db->idate($value)."'";
-				} elseif ($key == 'customsql') {
-					$sqlwhere[] = $value;
-				} elseif (strpos($value, '%') === false) {
-					$sqlwhere[] = $key." IN (".$this->db->sanitize($this->db->escape($value)).")";
-				} else {
-					$sqlwhere[] = $key." LIKE '%".$this->db->escapeforlike($this->db->escape($value))."%'";
-				}
+		foreach ($filter as $key => $value) {
+			if ($key == 't.rowid') {
+				$sqlwhere[] = $key." = ".((int) $value);
+			} elseif (in_array($this->fields[$key]['type'], array('date', 'datetime', 'timestamp'))) {
+				$sqlwhere[] = $key." = '".$this->db->idate($value)."'";
+			} elseif ($key == 'customsql') {
+				$sqlwhere[] = $value;
+			} elseif (strpos($value, '%') === false) {
+				$sqlwhere[] = $key." IN (".$this->db->sanitize($this->db->escape($value)).")";
+			} else {
+				$sqlwhere[] = $key." LIKE '%".$this->db->escapeforlike($this->db->escape($value))."%'";
 			}
 		}
-		if (count($sqlwhere) > 0) {
+		if (!empty($sqlwhere)) {
 			$sql .= " AND (".implode(" ".$filtermode." ", $sqlwhere).")";
 		}
 

--- a/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/doc/doc_generic_myobject_odt.modules.php
@@ -142,7 +142,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
 			} else {
 				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(ods|odt)');
-				if (count($tmpfiles)) {
+				if (!empty($tmpfiles)) {
 					$listoffiles = array_merge($listoffiles, $tmpfiles);
 				}
 			}
@@ -166,7 +166,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 		if (getDolGlobalString('MYMODULE_MYOBJECT_ADDON_PDF_ODT_PATH')) {
 			$texte .= $langs->trans("NumberOfModelFilesFound").': <b>';
 			//$texte.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$texte .= count($listoffiles);
+			$texte .= $nbofiles;
 			//$texte.=$nbofiles?'</a>':'';
 			$texte .= '</b>';
 		}
@@ -313,7 +313,7 @@ class doc_generic_myobject_odt extends ModelePDFMyObject
 				// If CUSTOMER contact defined on object, we use it
 				$usecontact = false;
 				$arrayidcontact = $object->getIdContact('external', 'CUSTOMER');
-				if (count($arrayidcontact) > 0) {
+				if (!empty($arrayidcontact)) {
 					$usecontact = true;
 					$result = $object->fetch_contact($arrayidcontact[0]);
 				}

--- a/htdocs/modulebuilder/template/core/modules/mymodule/doc/pdf_standard_myobject.modules.php
+++ b/htdocs/modulebuilder/template/core/modules/mymodule/doc/pdf_standard_myobject.modules.php
@@ -1013,7 +1013,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 		// Get contact
 		if (getDolGlobalInt('DOC_SHOW_FIRST_SALES_REP')) {
 			$arrayidcontact = $object->getIdContact('internal', 'SALESREPFOLL');
-			if (count($arrayidcontact) > 0) {
+			if (!empty($arrayidcontact)) {
 				$usertmp = new User($this->db);
 				$usertmp->fetch($arrayidcontact[0]);
 				$posy += 4;
@@ -1073,7 +1073,7 @@ class pdf_standard_myobject extends ModelePDFMyObject
 			// If BILLING contact defined on invoice, we use it
 			$usecontact = false;
 			$arrayidcontact = $object->getIdContact('external', 'BILLING');
-			if (count($arrayidcontact) > 0) {
+			if (!empty($arrayidcontact)) {
 				$usecontact = true;
 				$result = $object->fetch_contact($arrayidcontact[0]);
 			}

--- a/htdocs/modulebuilder/template/core/tpl/linkedobjectblock_myobject.tpl.php
+++ b/htdocs/modulebuilder/template/core/tpl/linkedobjectblock_myobject.tpl.php
@@ -35,11 +35,12 @@ $linkedObjectBlock = $GLOBALS['linkedObjectBlock'];
 $langs->load("mymodule");
 
 $total = 0; $ilink = 0;
+$linkedObjectBlockCount = count($linkedObjectBlock);
 foreach ($linkedObjectBlock as $key => $objectlink) {
 	$ilink++;
 
 	$trclass = 'oddeven';
-	if ($ilink == count($linkedObjectBlock) && empty($noMoreLinkedObjectBlockAfter) && count($linkedObjectBlock) <= 1) {
+	if ($ilink == $linkedObjectBlockCount && empty($noMoreLinkedObjectBlockAfter) && $linkedObjectBlockCount <= 1) {
 		$trclass .= ' liste_sub_total';
 	}
 	?>

--- a/htdocs/modulebuilder/template/myobject_agenda.php
+++ b/htdocs/modulebuilder/template/myobject_agenda.php
@@ -91,7 +91,7 @@ $backtopage = GETPOST('backtopage', 'alpha');
 
 if (GETPOST('actioncode', 'array')) {
 	$actioncode = GETPOST('actioncode', 'array', 3);
-	if (!count($actioncode)) {
+	if (empty($actioncode)) {
 		$actioncode = '0';
 	}
 } else {

--- a/htdocs/modulebuilder/template/myobject_card.php
+++ b/htdocs/modulebuilder/template/myobject_card.php
@@ -533,7 +533,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			// Validate
 			if ($object->status == $object::STATUS_DRAFT) {
-				if (empty($object->table_element_line) || (is_array($object->lines) && count($object->lines) > 0)) {
+				if (empty($object->table_element_line) || (is_array($object->lines) && !empty($object->lines))) {
 					print dolGetButtonAction('', $langs->trans('Validate'), 'default', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=confirm_validate&confirm=yes&token='.newToken(), '', $permissiontoadd);
 				} else {
 					$langs->load("errors");

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -296,7 +296,7 @@ $sqlfields = $sql; // $sql fields to remove for count total
 
 $sql .= " FROM ".MAIN_DB_PREFIX.$object->table_element." as t";
 //$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."anothertable as rc ON rc.parent = t.rowid";
-if (isset($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label'])) {
+if (!empty($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label'])) {
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX.$object->table_element."_extrafields as ef on (t.rowid = ef.fk_object)";
 }
 // Add table from hooks
@@ -555,7 +555,7 @@ if (!empty($moreforfilter)) {
 
 $varpage = empty($contextpage) ? $_SERVER["PHP_SELF"] : $contextpage;
 $selectedfields = ($mode != 'kanban' ? $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage, getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN', '')) : ''); // This also change content of $arrayfields
-$selectedfields .= (count($arrayofmassactions) ? $form->showCheckAddButtons('checkforselect', 1) : '');
+$selectedfields .= (!empty($arrayofmassactions) ? $form->showCheckAddButtons('checkforselect', 1) : '');
 
 print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
 print '<table class="tagtable nobottomiftotal liste'.($moreforfilter ? " listwithfilterbefore" : "").'">'."\n";
@@ -671,7 +671,7 @@ print '</tr>'."\n";
 
 // Detect if we need a fetch on each output line
 $needToFetchEachLine = 0;
-if (isset($extrafields->attributes[$object->table_element]['computed']) && is_array($extrafields->attributes[$object->table_element]['computed']) && count($extrafields->attributes[$object->table_element]['computed']) > 0) {
+if (!empty($extrafields->attributes[$object->table_element]['computed']) && is_array($extrafields->attributes[$object->table_element]['computed'])) {
 	foreach ($extrafields->attributes[$object->table_element]['computed'] as $key => $val) {
 		if (!is_null($val) && preg_match('/\$object/', $val)) {
 			$needToFetchEachLine++; // There is at least one compute field that use $object

--- a/scripts/cron/cron_run_jobs.php
+++ b/scripts/cron/cron_run_jobs.php
@@ -185,11 +185,10 @@ if ($result < 0) {
 
 // TODO Duplicate code. This sequence of code must be shared with code into public/cron/cron_run_jobs.php php page.
 
-$nbofjobs = count($object->lines);
 $nbofjobslaunchedok = 0;
 $nbofjobslaunchedko = 0;
 
-if (is_array($object->lines) && (count($object->lines) > 0)) {
+if (is_array($object->lines) && !empty($object->lines)) {
 	$savconf = dol_clone($conf);
 
 	// Loop over job


### PR DESCRIPTION
# PERF: remove useless calls to count() in core classes, tpls and modulebuilder template

Dolibarr is filled with calls to function `count()` whose result is simply compared to 0 (to see if the passed `array` is empty or not) or below a certain value. This loses a lot of time because under the hood, time is spent needlessly to really return the number of elements.

I searched for any call to count in main core Dolibarr classes, tpls, and in the modulebuilder template, and replaced those calls (mostly using `empty()` or replacing `for` with `foreach`) where necessary.


