### PR TITLE
FIX : Correct Operator GETPOST for search Categories in Thirdparty list

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -119,8 +119,8 @@ $search_categ_sup = GETPOSTINT("search_categ_sup");
 $searchCategoryCustomerOperator = GETPOSTINT('search_category_customer_operator');
 $searchCategorySupplierOperator = GETPOSTINT('search_category_supplier_operator');
 if (GETPOSTISSET('formfilteraction')) {
-	$searchCategoryCustomerOperator = GETPOST('search_category_customer_operator');
-	$searchCategorySupplierOperator = GETPOST('search_category_supplier_operator');
+	$searchCategoryCustomerOperator = GETPOSTINT('search_category_customer_operator');
+	$searchCategorySupplierOperator = GETPOSTINT('search_category_supplier_operator');
 } elseif (getDolGlobalString('MAIN_SEARCH_CAT_OR_BY_DEFAULT')) {
 	$searchCategoryCustomerOperator = getDolGlobalString('MAIN_SEARCH_CAT_OR_BY_DEFAULT');
 	$searchCategorySupplierOperator = getDolGlobalString('MAIN_SEARCH_CAT_OR_BY_DEFAULT');


### PR DESCRIPTION
There is a small mistake on the Operator 'OR' in thirdparty list on Tags/Category searches 
Oddly, the first PR is correct https://github.com/Dolibarr/dolibarr/pull/28335/files 
But later : 
```
if (GETPOSTISSET('formfilteraction')) {
	$searchCategoryCustomerOperator = GETPOSTINT('search_category_customer_operator');
	$searchCategorySupplierOperator = GETPOSTINT('search_category_supplier_operator');
	
```
Get changed by : 
```
if (GETPOSTISSET('formfilteraction')) {
	$searchCategoryCustomerOperator = GETPOST('search_category_customer_operator');
	$searchCategorySupplierOperator = GETPOST('search_category_supplier_operator');
```

On this PR https://github.com/Dolibarr/dolibarr/commit/1b09d9abf614b69e4cbb32f886517284c11892cf

This is incorrect because : 
 GETPOST('search_category_customer_operator') = '' 
 where as 
 GETPOSTINT('search_category_customer_operator') = 0 (int) 

Later during the execution of the request we have : 
`if ($searchCategoryCustomerOperator == 0) {`
Meaning WRONG if $searchCategoryCustomerOperator = '' but TRUE when $searchCategoryCustomerOperator = 0

This PR gets back to the initial version of the code.