### PR TITLE
QUAL Hide errors counter

### DIFF
--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -1247,7 +1247,6 @@ if ((empty($id) && empty($ref)) || $action == 'create' || $action == 'add') {
 } else {
 	if ($error && $action != 'edit') {
 		print '<div class="tabBar">';
-		print $error;
 		print '<br><br><input type="button" value="'.$langs->trans("ReturnCP").'" class="button" onclick="history.go(-1)" />';
 		print '</div>';
 	} else {


### PR DESCRIPTION
# QUAL
It seems unnecessary to display the error counter, as the errors themselves are already displayed via notification.