### PR TITLE
FIX: product translation: redirect after successful action

### DIFF
--- a/htdocs/product/traduction.php
+++ b/htdocs/product/traduction.php
@@ -88,7 +88,8 @@ if (empty($reshook)) {
 		$object->fetch($id);
 		$object->delMultiLangs(GETPOST('langtodelete', 'alpha'), $user);
 		setEventMessages($langs->trans("RecordDeleted"), null, 'mesgs');
-		$action = '';
+		header('Location:'.$_SERVER['PHP_SELF'].'?id='.$id);
+		exit;
 	}
 
 	// Add translation
@@ -119,7 +120,8 @@ if (empty($reshook)) {
 		}
 
 		if ($result > 0) {
-			$action = '';
+			header('Location:'.$_SERVER['PHP_SELF'].'?id='.$id);
+			exit;
 		} else {
 			$action = 'add';
 			setEventMessages($object->error, $object->errors, 'errors');
@@ -148,7 +150,8 @@ if (empty($reshook)) {
 
 		$result = $object->setMultiLangs($user);
 		if ($result > 0) {
-			$action = '';
+			header('Location:'.$_SERVER['PHP_SELF'].'?id='.$id);
+			exit;
 		} else {
 			$action = 'edit';
 			setEventMessages($object->error, $object->errors, 'errors');
@@ -163,7 +166,8 @@ if (empty($reshook)) {
 
 		$result = $object->delMultiLangs($langtodelete, $user);
 		if ($result > 0) {
-			$action = '';
+			header('Location:'.$_SERVER['PHP_SELF'].'?id='.$id);
+			exit;
 		} else {
 			$action = 'edit';
 			setEventMessages($object->error, $object->errors, 'errors');


### PR DESCRIPTION
# FIX: product translation: redirect after successful action

The product translation page doesn't redirect after a successful action.

This leads to preventable errors (for example, triggering the sql injection protection) when printing the page or creating a bookmark at this point.

I therefore suggest reloading the page after a successful action.

