### PR TITLE
FIX element must be visible to set focus on select input when using mandatory default values

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9935,7 +9935,9 @@ function printCommonFooter($zone = 'private')
 								print 'jQuery("input[name=\''.$paramkey.'\']").prop(\'required\',true);'."\n";
 								print 'jQuery("textarea[name=\''.$paramkey.'\']").prop(\'required\',true);'."\n";
 								print '// required on a select works only if key is "", so we add the required attributes but also we reset the key -1 or 0 to an empty string'."\n";
-								print 'jQuery("select[name=\''.$paramkey.'\']").prop(\'required\',true);'."\n";
+								print 'if (jQuery("select[name=\''.$paramkey.'\']").is(\':visible\')===true) {'."\n";
+								print 'jQuery("select[name=\''.$paramkey.'\']").prop(\'required\',true);'."\n"; // can set focus only if this element is visible
+								print '}'."\n";
 								print 'jQuery("select[name=\''.$paramkey.'\'] option[value=\'-1\']").prop(\'value\', \'\');'."\n";
 								print 'jQuery("select[name=\''.$paramkey.'\'] option[value=\'0\']").prop(\'value\', \'\');'."\n";
 


### PR DESCRIPTION
FIX element must be visible to set focus on select input when using mandatory default values

**To reproduce**
- add a mandatory value in form of company card : 
![image](https://github.com/user-attachments/assets/03d7453e-3d35-4e9a-bf41-6618fce96895)
- then try to create a new supplier from third-party menu :
- when you click on create button, nothing happens and in the console you can see this error message : 
**Le contrôle de formulaire avec name=‘custcats[]’ ne peut recevoir le focus.**

**Fix**
- the property required is only set to true when the select input is visible to avoid this previous error
