### PR TITLE
FIX encoding issues with underscores in mb_convert_encoding functiona…

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -868,11 +868,13 @@ class EmailCollector extends CommonObject
 		if (function_exists('mb_convert_encoding')) {
 			// change spaces by entropy because mb_convert fail with spaces
 			$str = preg_replace("/ /", "xxxSPACExxx", $str);		// the replacement string must be valid in utf7 so _ can't be used
+			$str = preg_replace("/_/", "xxxUNDERSCORExxx", $str); // encode underscore to avoid encoding issues with mb_convert
 			$str = preg_replace("/\[Gmail\]/", "xxxGMAILxxx", $str);	// the replacement string must be valid in utf7 so _ can't be used
 			// if mb_convert work
 			if ($str = mb_convert_encoding($str, "UTF-7")) {
 				// change characters
 				$str = preg_replace("/\+A/", "&A", $str);
+				$str = preg_replace("/xxxUNDERSCORExxx/", "_", $str);
 				// change to spaces again
 				$str = preg_replace("/xxxSPACExxx/", " ", $str);
 				// change to [Gmail] again


### PR DESCRIPTION
This fix improves the UTF-7 encoding used to access IMAP folders, especially those containing underscores (_) in their names.

📌 Issue encountered
When an IMAP folder (e.g., a custom Gmail label like tickets_todo) contains an underscore (_), the current encoding using mb_convert_encoding(..., 'UTF-7') silently fails or returns an incorrect name. As a result, Dolibarr's email collector is unable to access the affected folder properly.

✅ Proposed solution
A temporary replacement is introduced, replacing underscores with a placeholder (xxxUNDERSCORExxx) before encoding, then restoring the original character after encoding. This approach follows the same logic already applied to spaces and [Gmail].
