### PR TITLE
fix: remove php warning

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -3786,7 +3786,7 @@ if (!function_exists("llxFooter")) {
 						$url_for_ping = getDolGlobalString('MAIN_URL_FOR_PING', "https://ping.dolibarr.org/");
 						// Try to guess the distrib used
 						$distrib = 'standard';
-						if ($_SERVER["SERVER_ADMIN"] == 'doliwamp@localhost') {
+						if (isset($_SERVER["SERVER_ADMIN"]) && $_SERVER["SERVER_ADMIN"] == 'doliwamp@localhost') {
 							$distrib = 'doliwamp';
 						}
 						if (!empty($dolibarr_distrib)) {


### PR DESCRIPTION
After migration from 17.0, the first time there is a warning
![image](https://github.com/user-attachments/assets/1dd8d681-d512-4cb7-a476-c13df79c7a47)
