### PR TITLE
QUAL: github pull request template: add warning about target branch in case of bugfix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@
 *Please:*
 - *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
 - *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
+- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
 - *replace the bracket enclosed texts with meaningful information*
 
 


### PR DESCRIPTION
# QUAL: github pull request template: add warning about target branch in case of bugfix

Targetting the oldest version when submitting a bugfix is part of Dolibarr's developper guidelines. Despite this, we still get a lot of fixes submitted (and then merged) in branche `develop` while the bug is also present in stable versions.

I therefore suggest making a special case about this part of the guidelines sot that it is clearer for contributors, by adding this requirement to the GitHub pull request template with more emphasis on it.

