### PR TITLE
Fix :  Knowledge not listed in category management

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -14012,7 +14012,7 @@ function getElementProperties($elementType)
 		$table_element = 'ecmfiles';
 		$subelement = '';
 	} elseif ($elementType == 'knowledgerecord' || $elementType == 'knowledgemanagement') {
-		$module = '';
+		$module = 'knowledgemanagement';
 		$classpath = 'knowledgemanagement/class';
 		$classfile = 'knowledgerecord';
 		$classname = 'KnowledgeRecord';


### PR DESCRIPTION
Even if knowledge management module is activated, it's not listed in categories management 

![Before](https://github.com/user-attachments/assets/8647328f-9a34-421e-8d1b-99c6be15f116)

after this small correction

![After correction jpg](https://github.com/user-attachments/assets/ea2cfa80-1e57-4c65-a52a-09bbc9abdd03)


