### PR TITLE
FIX: try to fix v18 github action workflow

### DIFF
--- a/.github/workflows/pr-18.yaml
+++ b/.github/workflows/pr-18.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Assign reviewer
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         url: ${{ github.event.pull_request.html_url }}
       run: |
         gh pr edit "$url" --add-reviewer rycks

--- a/.github/workflows/pr-18.yaml
+++ b/.github/workflows/pr-18.yaml
@@ -17,38 +17,21 @@ jobs:
     #  GH_TOKENS: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ vars.PR18_APP_ID }}
+        private-key: ${{ secrets.PR18_SECRET_KEY }}
+
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    #- name: Install GitHub CLI
-    #  run: |
-    #    sudo apt update
-    #    sudo apt install gh -y
-
-    - name: Assign reviewer method 1
+    - name: Assign reviewer
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         url: ${{ github.event.pull_request.html_url }}
       run: |
-        gh pr edit "$url" --add-assignee rycks --add-reviewer rycks
-        gh pr merge "$url" --merge --auto
-      continue-on-error: true
+        gh pr edit "$url" --add-reviewer rycks
+        gh pr edit "$url" --add-reviewer lvessiller-opendsi
 
-    - name: Assign reviewer method 2
-      env:
-        #REVIEWER: "eldy,lvessiller-opendsi,rycks" # Remplacez par le nom d'utilisateur GitHub du reviewer
-        REVIEWER: "rycks" # Remplacez par le nom d'utilisateur GitHub du reviewer
-      run: |
-        echo "Run action by ${{ github.actor }}"        
-        echo "github.token=${{ github.token }}"
-        echo "secrets.GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
-        echo "GITHUB_EVENT_PATH=$GITHUB_EVENT_PATH"
-        echo Get the pr_number
-        pr_number=$(jq --raw-output .number < $GITHUB_EVENT_PATH)
-        echo "pr_number=$pr_number"
-        echo Authenticate login gh
-        gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-        gh auth setup-git
-        echo Set the reviewer
-        gh pr edit $pr_number --add-reviewer "$REVIEWER"
-      continue-on-error: true


### PR DESCRIPTION
# FIX: try to fix v18 github action workflow

About v18 LTS merge process, I could make it work on our fork on our organization, with the proposed changes.

This necessitates creating a GitHub app with several read/write accesses, action var `PR18_APP_ID`, action secret `PR18_SECRET_KEY`, and correctly installing the app.

*This is a tentative, I can't guarentee 100% that it will work (but it will difficultly be worse than before)*