### PR TITLE
fix: php 8 warning on expense report validation when multi-lang 

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -403,6 +403,8 @@ if (empty($reshook)) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
 				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
+					$user = new User($db);
+					$user->fetch($object->fk_user_author);
 					$newlang = $user->lang;
 				}
 				if (!empty($newlang)) {
@@ -520,7 +522,9 @@ if (empty($reshook)) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
 				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-					$newlang = $object->thirdparty->default_lang;
+					$user = new User($db);
+					$user->fetch($object->fk_user_author);
+					$newlang = $user->lang;
 				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
@@ -632,6 +636,8 @@ if (empty($reshook)) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
 				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
+					$user = new User($db);
+					$user->fetch($object->fk_user_author);
 					$newlang = $user->lang;
 				}
 				if (!empty($newlang)) {
@@ -748,7 +754,9 @@ if (empty($reshook)) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
 				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-					$newlang = $object->thirdparty->default_lang;
+					$user = new User($db);
+					$user->fetch($object->fk_user_author);
+					$newlang = $user->lang;
 				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
@@ -864,7 +872,9 @@ if (empty($reshook)) {
 							$newlang = GETPOST('lang_id', 'aZ09');
 						}
 						if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-							$newlang = $object->thirdparty->default_lang;
+							$user = new User($db);
+							$user->fetch($object->fk_user_author);
+							$newlang = $user->lang;
 						}
 						if (!empty($newlang)) {
 							$outputlangs = new Translate("", $conf);
@@ -978,6 +988,8 @@ if (empty($reshook)) {
 						$newlang = GETPOST('lang_id', 'aZ09');
 					}
 					if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
+						$user = new User($db);
+						$user->fetch($object->fk_user_author);
 						$newlang = $user->lang;
 					}
 					if (!empty($newlang)) {
@@ -1017,7 +1029,9 @@ if (empty($reshook)) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
 				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-					$newlang = $object->thirdparty->default_lang;
+					$user = new User($db);
+					$user->fetch($object->fk_user_author);
+					$newlang = $user->lang;
 				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
@@ -1046,7 +1060,9 @@ if (empty($reshook)) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
 				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-					$newlang = $object->thirdparty->default_lang;
+					$user = new User($db);
+					$user->fetch($object->fk_user_author);
+					$newlang = $user->lang;
 				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
@@ -1277,7 +1293,9 @@ if (empty($reshook)) {
 						$newlang = GETPOST('lang_id', 'aZ09');
 					}
 					if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-						$newlang = $object->thirdparty->default_lang;
+						$user = new User($db);
+						$user->fetch($object->fk_user_author);
+						$newlang = $user->lang;
 					}
 					if (!empty($newlang)) {
 						$outputlangs = new Translate("", $conf);
@@ -1374,7 +1392,9 @@ if (empty($reshook)) {
 							$newlang = GETPOST('lang_id', 'aZ09');
 						}
 						if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-							$newlang = $object->thirdparty->default_lang;
+							$user = new User($db);
+							$user->fetch($object->fk_user_author);
+							$newlang = $user->lang;
 						}
 						if (!empty($newlang)) {
 							$outputlangs = new Translate("", $conf);

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -407,6 +407,9 @@ if (empty($reshook)) {
 					$user->fetch($object->fk_user_author);
 					$newlang = $user->lang;
 				}
+				if (empty($newlang)) {
+					$newlang = $langs;
+				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
 					$outputlangs->setDefaultLang($newlang);
@@ -526,6 +529,9 @@ if (empty($reshook)) {
 					$user->fetch($object->fk_user_author);
 					$newlang = $user->lang;
 				}
+				if (empty($newlang)) {
+					$newlang = $langs;
+				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
 					$outputlangs->setDefaultLang($newlang);
@@ -639,6 +645,9 @@ if (empty($reshook)) {
 					$user = new User($db);
 					$user->fetch($object->fk_user_author);
 					$newlang = $user->lang;
+				}
+				if (empty($newlang)) {
+					$newlang = $langs;
 				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
@@ -758,6 +767,9 @@ if (empty($reshook)) {
 					$user->fetch($object->fk_user_author);
 					$newlang = $user->lang;
 				}
+				if (empty($newlang)) {
+					$newlang = $langs;
+				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
 					$outputlangs->setDefaultLang($newlang);
@@ -876,6 +888,9 @@ if (empty($reshook)) {
 							$user->fetch($object->fk_user_author);
 							$newlang = $user->lang;
 						}
+						if (empty($newlang)) {
+							$newlang = $langs;
+						}
 						if (!empty($newlang)) {
 							$outputlangs = new Translate("", $conf);
 							$outputlangs->setDefaultLang($newlang);
@@ -992,6 +1007,9 @@ if (empty($reshook)) {
 						$user->fetch($object->fk_user_author);
 						$newlang = $user->lang;
 					}
+					if (empty($newlang)) {
+						$newlang = $langs;
+					}
 					if (!empty($newlang)) {
 						$outputlangs = new Translate("", $conf);
 						$outputlangs->setDefaultLang($newlang);
@@ -1033,6 +1051,9 @@ if (empty($reshook)) {
 					$user->fetch($object->fk_user_author);
 					$newlang = $user->lang;
 				}
+				if (empty($newlang)) {
+					$newlang = $langs;
+				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
 					$outputlangs->setDefaultLang($newlang);
@@ -1063,6 +1084,9 @@ if (empty($reshook)) {
 					$user = new User($db);
 					$user->fetch($object->fk_user_author);
 					$newlang = $user->lang;
+				}
+				if (empty($newlang)) {
+					$newlang = $langs;
 				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
@@ -1242,6 +1266,9 @@ if (empty($reshook)) {
 						$user->fetch($object->fk_user_author);
 						$newlang = $user->lang;
 					}
+					if (empty($newlang)) {
+						$newlang = $langs;
+					}
 					if (!empty($newlang)) {
 						$outputlangs = new Translate("", $conf);
 						$outputlangs->setDefaultLang($newlang);
@@ -1296,6 +1323,12 @@ if (empty($reshook)) {
 						$user = new User($db);
 						$user->fetch($object->fk_user_author);
 						$newlang = $user->lang;
+					}
+					if (empty($newlang)) {
+						$newlang = $langs;
+					}
+					if (empty($newlang)) {
+						$newlang = $langs;
 					}
 					if (!empty($newlang)) {
 						$outputlangs = new Translate("", $conf);
@@ -1395,6 +1428,9 @@ if (empty($reshook)) {
 							$user = new User($db);
 							$user->fetch($object->fk_user_author);
 							$newlang = $user->lang;
+						}
+						if (empty($newlang)) {
+							$newlang = $langs;
 						}
 						if (!empty($newlang)) {
 							$outputlangs = new Translate("", $conf);

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -403,7 +403,7 @@ if (empty($reshook)) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
 				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-					$newlang = $object->thirdparty->default_lang;
+					$newlang = $user->lang;
 				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
@@ -632,7 +632,7 @@ if (empty($reshook)) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
 				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-					$newlang = $object->thirdparty->default_lang;
+					$newlang = $user->lang;
 				}
 				if (!empty($newlang)) {
 					$outputlangs = new Translate("", $conf);
@@ -978,7 +978,7 @@ if (empty($reshook)) {
 						$newlang = GETPOST('lang_id', 'aZ09');
 					}
 					if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-						$newlang = $object->thirdparty->default_lang;
+						$newlang = $user->lang;
 					}
 					if (!empty($newlang)) {
 						$outputlangs = new Translate("", $conf);


### PR DESCRIPTION
On Expense Report there is no $object->thirdparty. 

In case of multi-lang Dolibarr set up, the default lang should be user creation lang of display langs ones



