### PR TITLE
FIX: product multiprices: fatal error on vat update on php 8.2

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2375,7 +2375,7 @@ class Product extends CommonObject
 				}
 			} else {
 				$price = (float) price2num($newprice, 'MU');
-				$price_ttc = ($newnpr != 1) ? price2num($newprice) * (1 + ($newvat / 100)) : $price;
+				$price_ttc = ($newnpr != 1) ? (float) price2num($newprice) * (1 + ($newvat / 100)) : $price;
 				$price_ttc = (float) price2num($price_ttc, 'MU');
 
 				if ($newminprice !== '' || $newminprice === 0) {


### PR DESCRIPTION
# CLOSE #34342: product multiprices: fatal error on vat update on php 8.2

```
( ! ) Fatal error: Uncaught TypeError: Unsupported operand types: string * float in /var/www/html/dolibarr/20.0/htdocs/product/class/product.class.php on line 2378
```
