### PR TITLE
FIX: expensereport payment list: php warning

### DIFF
--- a/htdocs/expensereport/payment/list.php
+++ b/htdocs/expensereport/payment/list.php
@@ -50,6 +50,7 @@ $massaction = GETPOST('massaction', 'alpha');
 $optioncss = GETPOST('optioncss', 'alpha');
 $contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'vendorpaymentlist';
 $mode = GETPOST('mode', 'alpha');
+$toselect = GETPOSTISSET('toselect') ? GETPOST('toselect', 'array:int') : array();
 
 $socid = GETPOSTINT('socid');
 


### PR DESCRIPTION
# FIX: expensereport payment list: php warning

```
PHP Warning:  Undefined variable $toselect in /path/to/dolibarr/htdocs/expensereport/payment/list.php on line 295
```