### PR TITLE
FIX: accountancy expensereport journal: php 8.1 warning

### DIFF
--- a/htdocs/accountancy/journal/expensereportsjournal.php
+++ b/htdocs/accountancy/journal/expensereportsjournal.php
@@ -238,7 +238,7 @@ if ($action == 'writebookkeeping' && !$error) {
 		$db->begin();
 
 		// Error if some lines are not binded/ready to be journalized
-		if ($errorforinvoice[$key] == 'somelinesarenotbound') {
+		if (!empty($errorforinvoice[$key]) && $errorforinvoice[$key] == 'somelinesarenotbound') {
 			$error++;
 			$errorforline++;
 			setEventMessages($langs->trans('ErrorInvoiceContainsLinesNotYetBounded', $val['ref']), null, 'errors');


### PR DESCRIPTION
# FIX: accountancy expensereport journal: php 8.1 warning

```
PHP Warning:  Undefined array key 409 in /path/to/dolibarr/htdocs/accountancy/journal/expensereportsjournal.php on line 673
```