### PR TITLE
FIX: event info tab: php 8.1 warning

### DIFF
--- a/htdocs/comm/action/info.php
+++ b/htdocs/comm/action/info.php
@@ -53,8 +53,6 @@ if ($user->socid && $socid) {
 	$result = restrictedArea($user, 'societe', $socid);
 }
 
-$usercancreate = $user->hasRight('agenda', 'allactions', 'create') || (($object->authorid == $user->id || $object->userownerid == $user->id) && $user->hasRight('agenda', 'myactions', 'create'));
-
 
 /*
  * View
@@ -68,6 +66,8 @@ llxHeader('', $langs->trans("Agenda"), $help_url);
 $object = new ActionComm($db);
 $object->fetch($id);
 $object->info($object->id);
+
+$usercancreate = $user->hasRight('agenda', 'allactions', 'create') || (($object->authorid == $user->id || $object->userownerid == $user->id) && $user->hasRight('agenda', 'myactions', 'create'));
 
 $head = actions_prepare_head($object);
 print dol_get_fiche_head($head, 'info', $langs->trans("Action"), -1, 'action');

--- a/htdocs/comm/action/info.php
+++ b/htdocs/comm/action/info.php
@@ -53,6 +53,11 @@ if ($user->socid && $socid) {
 	$result = restrictedArea($user, 'societe', $socid);
 }
 
+$object = new ActionComm($db);
+$object->fetch($id);
+
+$usercancreate = $user->hasRight('agenda', 'allactions', 'create') || (($object->authorid == $user->id || $object->userownerid == $user->id) && $user->hasRight('agenda', 'myactions', 'create'));
+
 
 /*
  * View
@@ -63,11 +68,7 @@ $form = new Form($db);
 $help_url = 'EN:Module_Agenda_En|FR:Module_Agenda|ES:M&omodulodulo_Agenda|DE:Modul_Terminplanung';
 llxHeader('', $langs->trans("Agenda"), $help_url);
 
-$object = new ActionComm($db);
-$object->fetch($id);
 $object->info($object->id);
-
-$usercancreate = $user->hasRight('agenda', 'allactions', 'create') || (($object->authorid == $user->id || $object->userownerid == $user->id) && $user->hasRight('agenda', 'myactions', 'create'));
 
 $head = actions_prepare_head($object);
 print dol_get_fiche_head($head, 'info', $langs->trans("Action"), -1, 'action');


### PR DESCRIPTION
# FIX: event info tab: php 8.1 warnings

`$usercancreate` is declared bebore `$object` but uses it

```
PHP Warning:  Attempt to read property "authorid" on null in /path/to/dolibarr/htdocs/comm/action/info.php on line 56
PHP Warning:  Attempt to read property "userownerid" on null in /path/to/dolibarr/htdocs/comm/action/info.php on line 56
```

Triggered only when the user doesn't have the right `$user->hasRight('agenda', 'allactions', 'create')`
