### PR TITLE
Fix #34315 API get stockmovements sqlfilter - Unknown column 't.product_id'

### DIFF
--- a/htdocs/multicurrency/class/api_multicurrencies.class.php
+++ b/htdocs/multicurrency/class/api_multicurrencies.class.php
@@ -48,7 +48,7 @@ class MultiCurrencies extends DolibarrApi
 	 * @param string	$sortorder		Sort order
 	 * @param int		$limit			Limit for list
 	 * @param int	    $page			Page number
-	 * @param string    $sqlfilters		Other criteria to filter answers separated by a comma. Syntax example "(t.product_id:=:1) and (t.date_creation:<:'20160101')"
+	 * @param string    $sqlfilters		Other criteria to filter answers separated by a comma. Syntax example "(t.rowid:=:1) and (t.date_creation:<:'20160101')"
 	 * @param string    $properties		Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @return array					Array of warehouse objects
 	 * @phan-return MultiCurrency[]

--- a/htdocs/product/stock/class/api_stockmovements.class.php
+++ b/htdocs/product/stock/class/api_stockmovements.class.php
@@ -89,7 +89,7 @@ class StockMovements extends DolibarrApi
 	 * @param string	$sortorder	Sort order
 	 * @param int		$limit		Limit for list
 	 * @param int		$page		Page number
-	 * @param string    $sqlfilters Other criteria to filter answers separated by a comma. Syntax example "(t.product_id:=:1) and (t.date_creation:<:'20160101')"
+	 * @param string    $sqlfilters Other criteria to filter answers separated by a comma. Syntax example "(t.rowid:=:1) and (t.date_creation:<:'20160101')"
 	 * @param string    $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @return array                Array of warehouse objects
 	 * @phan-return MouvementStock[]


### PR DESCRIPTION
# FIX #34315 
The examples of sql filters were wrong, tested with t.rowid:=:xxx is ok

