### PR TITLE
FIX: accountancy lettering: php8.1 warning

### DIFF
--- a/htdocs/accountancy/class/lettering.class.php
+++ b/htdocs/accountancy/class/lettering.class.php
@@ -574,7 +574,7 @@ class Lettering extends BookKeeping
 
 		$grouped_lines = array();
 		foreach (self::$doc_type_infos as $doc_type => $doc_type_info) {
-			if (!is_array($bookkeeping_lines_by_type[$doc_type])) {
+			if (empty($bookkeeping_lines_by_type[$doc_type]) || !is_array($bookkeeping_lines_by_type[$doc_type])) {
 				continue;
 			}
 


### PR DESCRIPTION
# FIX: accountancy lettering: php8.1 warning

```
PHP Warning:  Undefined array key "supplier_invoice" in /path/to/dolibarr/htdocs/accountancy/class/lettering.class.php on line 589
PHP Warning:  Undefined array key "customer_invoice" in /path/to/dolibarr/htdocs/accountancy/class/lettering.class.php on line 589
```
