### PR TITLE
FIX: manufacturing orders: missing extraparams field

### DIFF
--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -290,3 +290,5 @@ ALTER TABLE llx_don ADD COLUMN ip varchar(250);
 ALTER TABLE llx_expeditiondet ADD COLUMN description text AFTER fk_entrepot;
 
 INSERT INTO llx_c_type_container (code, label, active, module, position, typecontainer, entity) VALUES ('setup', 'Setup screen', 1, 'system', 500, 'library', __ENTITY__);
+
+ALTER TABLE llx_mrp_mo ADD COLUMN extraparams varchar(255) DEFAULT NULL;

--- a/htdocs/install/mysql/tables/llx_mrp_mo-mrp.sql
+++ b/htdocs/install/mysql/tables/llx_mrp_mo-mrp.sql
@@ -41,6 +41,7 @@ CREATE TABLE llx_mrp_mo(
 	fk_bom integer,
 	fk_project integer,
 	last_main_doc varchar(255),
-    fk_parent_line integer
+	fk_parent_line integer,
+	extraparams varchar(255) DEFAULT NULL
     -- END MODULEBUILDER FIELDS
 ) ENGINE=innodb;


### PR DESCRIPTION
# FIX: manufacturing orders: missing extraparams field

```
2025-06-13 09:56:43 ERR     [...]  DoliDBMysqli::query Exception in query instead of returning an error: Unknown column 'extraparams' in 'SET'
2025-06-13 09:56:43 ERR     [...]  DoliDBMysqli::query SQL Error query: UPDATE llx_mrp_mo SET extraparams = null WHERE rowid = 256
2025-06-13 09:56:43 ERR     [...]  DoliDBMysqli::query SQL Error message: DB_ERROR_NOSUCHFIELD Unknown column 'extraparams' in 'SET' From /path/to/dolibarr/htdocs/core/class/commonobject.class.php:5180.
```

