### PR TITLE
FIX: online propal sign: double header with logo when custom logo set

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -2666,14 +2666,22 @@ function addMailingEventTypeSQL($actioncode, $objcon, $filterobj)
  * @param   Translate	$langs			Output language
  * @return	void
  */
-function htmlPrintOnlineHeader($mysoc, $langs)
+function htmlPrintOnlineHeader($mysoc, $langs, $suffix = '')
 {
 	global $conf;
 
 	// Define urllogo
 	$urllogo = DOL_URL_ROOT.'/theme/common/login_logo.png';
+	$suffix = GETPOST("suffix", 'aZ09');
 
-	if (!empty($mysoc->logo_small) && is_readable($conf->mycompany->dir_output.'/logos/thumbs/'.$mysoc->logo_small)) {
+	$customLogoWithSuffix = getDolGlobalString('ONLINE_SIGN_LOGO_'.$suffix);
+	$customLogo = getDolGlobalString('ONLINE_SIGN_LOGO');
+
+	if (!empty($customLogoWithSuffix) && is_readable($conf->mycompany->dir_output.'/logos/thumbs/'.$customLogoWithSuffix)) {
+		$urllogo = DOL_URL_ROOT.'/viewimage.php?cache=1&amp;modulepart=mycompany&amp;file='.urlencode('logos/thumbs/'.$customLogoWithSuffix);
+	} elseif (!empty($customLogo) && is_readable($conf->mycompany->dir_output.'/logos/thumbs/'.$customLogo)) {
+		$urllogo = DOL_URL_ROOT.'/viewimage.php?cache=1&amp;modulepart=mycompany&amp;file='.urlencode('logos/thumbs/'.$customLogo);
+	} elseif (!empty($mysoc->logo_small) && is_readable($conf->mycompany->dir_output.'/logos/thumbs/'.$mysoc->logo_small)) {
 		$urllogo = DOL_URL_ROOT.'/viewimage.php?cache=1&amp;modulepart=mycompany&amp;file='.urlencode('logos/thumbs/'.$mysoc->logo_small);
 	} elseif (!empty($mysoc->logo) && is_readable($conf->mycompany->dir_output.'/logos/'.$mysoc->logo)) {
 		$urllogo = DOL_URL_ROOT.'/viewimage.php?cache=1&amp;modulepart=mycompany&amp;file='.urlencode('logos/'.$mysoc->logo);

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -2664,6 +2664,7 @@ function addMailingEventTypeSQL($actioncode, $objcon, $filterobj)
  *
  * @param   Societe		$mysoc			Third party
  * @param   Translate	$langs			Output language
+ * @param	string		$suffix			Suffix
  * @return	void
  */
 function htmlPrintOnlineHeader($mysoc, $langs, $suffix = '')

--- a/htdocs/public/onlinesign/newonlinesign.php
+++ b/htdocs/public/onlinesign/newonlinesign.php
@@ -247,7 +247,7 @@ $title = $langs->trans("OnlineSignature");
 $replacemainarea = (empty($conf->dol_hide_leftmenu) ? '<div>' : '').'<div>';
 llxHeader($head, $title, '', '', 0, 0, '', '', '', 'onlinepaymentbody', $replacemainarea, 1);
 
-htmlPrintOnlineHeader($mysoc, $langs);
+htmlPrintOnlineHeader($mysoc, $langs, $suffix);
 
 if ($action == 'refusepropal') {
 	print $form->formconfirm($_SERVER["PHP_SELF"].'?ref='.urlencode($ref).'&securekey='.urlencode($SECUREKEY).(isModEnabled('multicompany') ? '&entity='.$entity : ''), $langs->trans('RefusePropal'), $langs->trans('ConfirmRefusePropal', $object->ref), 'confirm_refusepropal', '', '', 1);
@@ -280,39 +280,6 @@ print '<!-- Form to sign -->'."\n";
 
 print '<table id="dolpublictable" summary="Payment form" class="center">'."\n";
 
-// Show logo (search order: logo defined by ONLINE_SIGN_LOGO_suffix, then ONLINE_SIGN_LOGO_, then small company logo, large company logo, theme logo, common logo)
-// Define logo and logosmall
-$logosmall = $mysoc->logo_small;
-$logo = $mysoc->logo;
-$paramlogo = 'ONLINE_SIGN_LOGO_'.$suffix;
-if (getDolGlobalString($paramlogo)) {
-	$logosmall = getDolGlobalString($paramlogo);
-} elseif (getDolGlobalString('ONLINE_SIGN_LOGO')) {
-	$logosmall = getDolGlobalString('ONLINE_SIGN_LOGO');
-}
-//print '<!-- Show logo (logosmall='.$logosmall.' logo='.$logo.') -->'."\n";
-// Define urllogo
-$urllogo = '';
-$urllogofull = '';
-if (!empty($logosmall) && is_readable($conf->mycompany->dir_output.'/logos/thumbs/'.$logosmall)) {
-	$urllogo = DOL_URL_ROOT.'/viewimage.php?modulepart=mycompany&amp;entity='.$conf->entity.'&amp;file='.urlencode('logos/thumbs/'.$logosmall);
-	$urllogofull = $dolibarr_main_url_root.'/viewimage.php?modulepart=mycompany&entity='.$conf->entity.'&file='.urlencode('logos/thumbs/'.$logosmall);
-} elseif (!empty($logo) && is_readable($conf->mycompany->dir_output.'/logos/'.$logo)) {
-	$urllogo = DOL_URL_ROOT.'/viewimage.php?modulepart=mycompany&amp;entity='.$conf->entity.'&amp;file='.urlencode('logos/'.$logo);
-	$urllogofull = $dolibarr_main_url_root.'/viewimage.php?modulepart=mycompany&entity='.$conf->entity.'&file='.urlencode('logos/'.$logo);
-}
-// Output html code for logo
-if ($urllogo) {
-	print '<div class="backgreypublicpayment">';
-	print '<div class="logopublicpayment">';
-	print '<img id="dolpaymentlogo" src="'.$urllogo.'"';
-	print '>';
-	print '</div>';
-	if (!getDolGlobalString('MAIN_HIDE_POWERED_BY')) {
-		print '<div class="poweredbypublicpayment opacitymedium right"><a class="poweredbyhref" href="https://www.dolibarr.org?utm_medium=website&utm_source=poweredby" target="dolibarr" rel="noopener">'.$langs->trans("PoweredBy").'<br><img class="poweredbyimg" src="'.DOL_URL_ROOT.'/theme/dolibarr_logo.svg" width="80px"></a></div>';
-	}
-	print '</div>';
-}
 if ($source == 'proposal' && getDolGlobalString('PROPOSAL_IMAGE_PUBLIC_SIGN')) {
 	print '<div class="backimagepublicproposalsign">';
 	print '<img id="idPROPOSAL_IMAGE_PUBLIC_INTERFACE" src="' . getDolGlobalString('PROPOSAL_IMAGE_PUBLIC_SIGN').'">';


### PR DESCRIPTION
# CLOSE #34075: online propal sign: double header with logo when custom logo set

On public proposal online sign public paage, with hidden confs `ONLINE_SIGN_LOGO` or `ONLINE_SIGN_LOGO_*`, the header is printed twice.

Header handling has been factored out in v21, we just move the handling of those special cases in the function in which header in now generated.