### PR TITLE
FIX BankTransfer link in list.php

### DIFF
--- a/htdocs/compta/prelevement/list.php
+++ b/htdocs/compta/prelevement/list.php
@@ -417,7 +417,7 @@ while ($i < $imaxinloop) {
 		print '<td>';
 		print $line->LibStatut($obj->statut_ligne, 2);
 		print "&nbsp;";
-		print '<a href="'.DOL_URL_ROOT.'/compta/prelevement/line.php?id='.$obj->rowid_ligne.'">';
+		print '<a href="'.DOL_URL_ROOT.'/compta/prelevement/line.php?id='.$obj->rowid_ligne.($type == 'bank-transfer' ? '&type=bank-transfer' : '').'">';
 		print substr('000000'.$obj->rowid_ligne, -6);
 		print '</a></td>';
 


### PR DESCRIPTION
FIX BankTransfer link in list.php

This is to fix a wrong action link in list.php.
The link was sending to a WithDrawals screen creating confusion.

