### PR TITLE
Fix : in messaging view, the event status was missing

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -15456,6 +15456,10 @@ function show_actions_messaging($conf, $langs, $db, $filterobj, $objcon = null, 
 			}
 			$out .= "</span></span>\n";
 
+			$out .= '<span class="time">';
+			$out .= $actionstatic->getLibStatut(2);
+			$out .= '</span>';
+
 			// Ref
 			$out .= '<h3 class="timeline-header">';
 


### PR DESCRIPTION
FIX #34308

![image](https://github.com/user-attachments/assets/cf4133ed-2ae9-4a67-8a9a-3ddc177e2a84)