### PR TITLE
NEW Can force_install_dolibarrpassword for automatic installation

### DIFF
--- a/htdocs/install/install.forced.docker.php
+++ b/htdocs/install/install.forced.docker.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2016       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
- * Copyright (C) 2024       Yann Le Doaré      <services@linuxconsole.org>
+ * Copyright (C) 2024       Yann Le Doaré      		<services@linuxconsole.org>
+ * Copyright (C) 2025       Charlene Benke      	<charlene@patas-monkey.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,6 +67,9 @@ $force_install_databaserootpass = getenv('DOLI_ROOT_PASSWORD', true) ?: getenv('
 
 /** @var string $force_install_dolibarrlogin		Dolibarr super-administrator username */
 $force_install_dolibarrlogin = 'admin';
+
+/** @var string $force_install_dolibarrpassword		Dolibarr super-administrator password */
+$force_install_dolibarrpassword = '';
 
 /** @var bool $force_install_lockinstall			Force install locking */
 $force_install_lockinstall = true;

--- a/htdocs/install/install.forced.sample.php
+++ b/htdocs/install/install.forced.sample.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2016       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
+ * Copyright (C) 2025       Charlene Benke      	<charlene@patas-monkey.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,6 +66,9 @@ $force_install_databaserootpass = '';
 
 /** @var string $force_install_dolibarrlogin		Dolibarr super-administrator username */
 $force_install_dolibarrlogin = 'admin';
+
+/** @var string $force_install_dolibarrpassword		Dolibarr super-administrator password */
+$force_install_dolibarrpassword = '';
 
 /** @var bool $force_install_lockinstall			Force install locking */
 $force_install_lockinstall = true;

--- a/htdocs/install/step4.php
+++ b/htdocs/install/step4.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2004       Sebastien DiCintio      <sdicintio@ressource-toi.org>
  * Copyright (C) 2004-2008  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2015-2016  Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
+ * Copyright (C) 2025		Charlene Benke      	<charlene@patas-monkey.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,9 +83,9 @@ if ($db->ok) {
 	print '<tr><td><label for="login">'.$langs->trans("Login").' :</label></td><td>';
 	print '<input id="login" name="login" type="text" value="'.(GETPOSTISSET("login") ? GETPOST("login", 'alpha') : (isset($force_install_dolibarrlogin) ? $force_install_dolibarrlogin : '')).'"'.(@$force_install_noedit == 2 && $force_install_dolibarrlogin !== null ? ' disabled' : '').' autofocus></td></tr>';
 	print '<tr><td><label for="pass">'.$langs->trans("Password").' :</label></td><td>';
-	print '<input type="password" id="pass" name="pass" autocomplete="new-password" minlength="8"></td></tr>';
+	print '<input type="password" id="pass" name="pass" autocomplete="new-password" minlength="8" value="'. (isset($force_install_dolibarrpassword) ? $force_install_dolibarrpassword : '').'"'.(@$force_install_noedit == 2 && $force_install_dolibarrpassword !== null ? ' disabled' : '').'></td></tr>';
 	print '<tr><td><label for="pass_verif">'.$langs->trans("PasswordRetype").' :</label></td><td>';
-	print '<input type="password" id="pass_verif" name="pass_verif" autocomplete="new-password" minlength="8"></td></tr>';
+	print '<input type="password" id="pass_verif" name="pass_verif" autocomplete="new-password" minlength="8" value="'.(isset($force_install_dolibarrpassword) ? $force_install_dolibarrpassword : '').'"'.(@$force_install_noedit == 2 && $force_install_dolibarrpassword !== null ? ' disabled' : '').'></td></tr>';
 	print '</table>';
 
 	if (GETPOSTINT("error") == 1) {


### PR DESCRIPTION
The goal is to automate the installation process using an empty database so that table creation can also be tested.
Setting the password allows for complete automation of the installation.