### PR TITLE
FIX: PHP 8 Error 500

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2375,7 +2375,7 @@ class Product extends CommonObject
 				}
 			} else {
 				$price = (float) price2num($newprice, 'MU');
-				$price_ttc = ($newnpr != 1) ? $newprice * (1 + ($newvat / 100)) : $price;
+				$price_ttc = ($newnpr != 1) ? (float) price2num($newprice) * (1 + ($newvat / 100)) : $price;
 				$price_ttc = (float) price2num($price_ttc, 'MU');
 
 				if ($newminprice !== '' || $newminprice === 0) {

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2375,7 +2375,7 @@ class Product extends CommonObject
 				}
 			} else {
 				$price = (float) price2num($newprice, 'MU');
-				$price_ttc = ($newnpr != 1) ? price2num($newprice) * (1 + ($newvat / 100)) : $price;
+				$price_ttc = ($newnpr != 1) ? $newprice * (1 + ($newvat / 100)) : $price;
 				$price_ttc = (float) price2num($price_ttc, 'MU');
 
 				if ($newminprice !== '' || $newminprice === 0) {


### PR DESCRIPTION
# FIX: PHP 8 Error 500
PHP 8 does not approve of multiplying numbers and strings, and price2num does return a string. This avoids that

![image](https://github.com/user-attachments/assets/9fccba3c-0bc0-462a-8216-c6e4ed0b8404)
