### PR TITLE
fix: document.php set default entity value

### DIFF
--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -103,7 +103,7 @@ $original_file = GETPOST('file', 'alphanohtml');
 $hashp = GETPOST('hashp', 'aZ09');
 $modulepart = GETPOST('modulepart', 'alpha');
 $urlsource = GETPOST('urlsource', 'alpha');
-$entity = GETPOSTINT('entity');
+$entity = GETPOSTISSET('entity') ? GETPOSTINT('entity') : $conf->entity;
 
 // Security check
 if (empty($modulepart) && empty($hashp)) {


### PR DESCRIPTION
# FIX|Fix Wrong entity document.php
By default, entity 0 is taken if entity is not set in preview URL, we need to take current entity if no entity is set.
