### PR TITLE
add env var for non-origin repository

### DIFF
--- a/build/makepack-dolibarr.pl
+++ b/build/makepack-dolibarr.pl
@@ -21,6 +21,9 @@ $PROJECT="dolibarr";
 $PUBLISHBETARC="$ENV{'DESTIASSOLOGIN'}\@vmprod1.dolibarr.org:/home/dolibarr/asso.dolibarr.org/dolibarr_documents/website/www.dolibarr.org/files";
 $PUBLISHSTABLE="$ENV{'DESTISFLOGIN'}\@frs.sourceforge.net:/home/frs/project/dolibarr";
 
+# due to implicit origin on git commands, example
+# implicit origin, lionel upstream, eric dolibarr
+$GITREMOTENAME="$ENV{'GITREMOTENAME'}";
 #@LISTETARGET=("TGZ","ZIP","RPM_GENERIC","RPM_FEDORA","RPM_MANDRIVA","RPM_OPENSUSE","DEB","EXEDOLIWAMP","SNAPSHOT");   # Possible packages
 @LISTETARGET=("TGZ","ZIP","RPM_GENERIC","RPM_FEDORA","RPM_MANDRIVA","RPM_OPENSUSE","DEB","EXEDOLIWAMP","SNAPSHOT");   # Possible packages
 %REQUIREMENTPUBLISH=(
@@ -97,6 +100,13 @@ if (! -d $ENV{"DESTIBETARC"} || ! -d $ENV{"DESTISTABLE"})
 	exit 1;
 }
 
+if (! $ENV{"GITREMOTENAME"})
+{
+	print "Error: environment variable  GITREMOTENAME does not exist.\n";
+	print "$PROG.$Extension aborted.\n";
+	sleep 2;
+	exit 1;
+}
 # Detect OS type
 # --------------
 if ("$^O" =~ /linux/i || (-d "/etc" && -d "/var" && "$^O" !~ /cygwin/i)) { $OS='linux'; $CR=''; }
@@ -442,15 +452,15 @@ if ($nboftargetok) {
 			{
 				print 'Run git tag -a -f -m "'.$MAJOR.'.'.$MINOR.'.'.$BUILD.'" "'.$MAJOR.'.'.$MINOR.'.'.$BUILD.'"'."\n";
 				$ret=`git tag -a -f -m "$MAJOR.$MINOR.$BUILD" "$MAJOR.$MINOR.$BUILD"`;
-				print 'Run git push -f --tags'."\n";
-				$ret=`git push -f --tags`;
+				print 'Run git push $GITREMOTENAME -f --tags'."\n";
+				$ret=`git push $GITREMOTENAME -f --tags`;
 				#$ret=`git push -f origin "$MAJOR.$MINOR.$BUILD"`;
 			}
 		}
 		else
 		{
-			print 'Run git push --tags'."\n";
-			$ret=`git push --tags`;
+			print 'Run git push $GITREMOTENAME --tags'."\n";
+			$ret=`git push $GITREMOTENAME --tags`;
 			#$ret=`git push origin "$MAJOR.$MINOR.$BUILD"`;
 		}
 		chdir("$olddir");


### PR DESCRIPTION
As @lvessiller-opendsi and me do not have https://github.com/Dolibarr/dolibarr as origin remote on our systems this PR add a new ENV var request : GITREMOTENAME to push tags on right remote repository