### PR TITLE
FIX: filter agenda on user and ressource give SQL error

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -760,10 +760,7 @@ $reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters); // N
 $sql .= $hookmanager->resPrint;
 
 $sql .= ' FROM '.MAIN_DB_PREFIX.'c_actioncomm as ca, '.MAIN_DB_PREFIX."actioncomm as a";
-// We must filter on resource table
-if ($resourceid > 0) {
-	$sql .= ", ".MAIN_DB_PREFIX."element_resources as r";
-}
+
 // We must filter on assignment table
 if ($filtert > 0 || $usergroup > 0) {
 	$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm_resources as ar";
@@ -774,6 +771,10 @@ if ($filtert > 0 || $usergroup > 0) {
 	if ($usergroup > 0) {
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."usergroup_user as ugu ON ugu.fk_user = ar.fk_element AND ugu.fk_usergroup = ".((int) $usergroup);
 	}
+}
+// We must filter on resource table
+if ($resourceid > 0) {
+	$sql .= ", ".MAIN_DB_PREFIX."element_resources as r";
 }
 $sql .= ' WHERE a.fk_action = ca.id';
 $sql .= ' AND a.entity IN ('.getEntity('agenda').')';	// bookcal is a "virtual view" of agenda


### PR DESCRIPTION
On agenda filter on user (owner) and ressource

![image](https://github.com/user-attachments/assets/873ceb40-c135-476a-847c-8ee278b97c50)


Requête dernier accès en base en erreur: SELECT a.id, a.label, a.datep, a.datep2, a.percent, a.fk_user_author,a.fk_user_action, a.transparency, a.priority, a.fulldayevent, a.location, a.fk_soc, a.fk_contact, a.fk_project, a.fk_bookcal_calendar, a.fk_element, a.elementtype, ca.code as type_code, ca.libelle as type_label, ca.color as type_color, ca.type as type_type, ca.picto as type_picto FROM llx_c_actioncomm as ca, llx_actioncomm as a, llx_element_resources as r INNER JOIN llx_actioncomm_resources as ar ON ar.fk_actioncomm = a.id AND ar.element_type='user' AND ar.fk_element = 1 WHERE a.fk_action = ca.id AND a.entity IN (1) AND r.element_type = 'action' AND r.element_id = a.id AND r.resource_id = 2 AND ( (a.datep BETWEEN '2025-05-25 00:00:00' AND '2025-07-08 23:59:59') OR (a.datep2 BETWEEN '2025-05-25 00:00:00' AND '2025-07-08 23:59:59') OR (a.datep < '2025-05-25 00:00:00' AND a.datep2 > '2025-07-08 23:59:59')) AND (ar.fk_element = 1) ORDER BY datep ASC
Code retour dernier accès en base en erreur: DB_ERROR_NOSUCHFIELD
Information sur le dernier accès en base en erreur: Unknown column 'a.id' in 'ON'

"join" (with coma) on "llx_element_resources as r" have to be after  "INNER JOIN llx_actioncomm_resources as ar"


