### PR TITLE
FIX : Missing translation for en-US in user page

### DIFF
--- a/htdocs/langs/en_US/users.lang
+++ b/htdocs/langs/en_US/users.lang
@@ -144,3 +144,5 @@ CloneCategoriesUser=Clone the user's categories
 ConfirmUserClone=Are you sure you want to clone the user: <b>%s</b>?
 NewEmailUserClone=Email address of the new user
 SocialNetworksUser=Social networks for user
+ShowAsConversation=Show as conversation list
+MessageListViewType=Show as table list


### PR DESCRIPTION
FIX : Added two missing translation keys for a user's page.
![image](https://github.com/user-attachments/assets/f4f8c307-9cc2-440d-969a-f0062c807912)
![image](https://github.com/user-attachments/assets/978898ef-51dd-417b-ab1b-472b98b294a5)