### PR TITLE
Fix #34593

### DIFF
--- a/htdocs/core/triggers/dolibarrtriggers.class.php
+++ b/htdocs/core/triggers/dolibarrtriggers.class.php
@@ -168,7 +168,7 @@ abstract class DolibarrTriggers
 	 */
 	public function setErrorsFromObject(CommonObject $object)
 	{
-		$this->errors = $this->errors ?? [];
+		isset($this->errors) ?: $this->errors = [];
 
 		if (!empty($object->error)) {
 			$this->errors = array_merge($this->errors, array($object->error));

--- a/htdocs/core/triggers/dolibarrtriggers.class.php
+++ b/htdocs/core/triggers/dolibarrtriggers.class.php
@@ -168,8 +168,6 @@ abstract class DolibarrTriggers
 	 */
 	public function setErrorsFromObject(CommonObject $object)
 	{
-		isset($this->errors) ?: $this->errors = [];
-
 		if (!empty($object->error)) {
 			$this->errors = array_merge($this->errors, array($object->error));
 		}

--- a/htdocs/core/triggers/dolibarrtriggers.class.php
+++ b/htdocs/core/triggers/dolibarrtriggers.class.php
@@ -169,7 +169,7 @@ abstract class DolibarrTriggers
 	public function setErrorsFromObject(CommonObject $object)
 	{
 		$this->errors = $this->errors ?? [];
-		
+
 		if (!empty($object->error)) {
 			$this->errors = array_merge($this->errors, array($object->error));
 		}

--- a/htdocs/core/triggers/dolibarrtriggers.class.php
+++ b/htdocs/core/triggers/dolibarrtriggers.class.php
@@ -168,6 +168,8 @@ abstract class DolibarrTriggers
 	 */
 	public function setErrorsFromObject(CommonObject $object)
 	{
+		$this->errors = $this->errors ?? [];
+		
 		if (!empty($object->error)) {
 			$this->errors = array_merge($this->errors, array($object->error));
 		}

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -49,6 +49,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 		$this->description = "Triggers of this module allows to manage workflows";
 		$this->version = self::VERSIONS['prod'];
 		$this->picto = 'technic';
+		$this->errors = [];
 	}
 
 	/**


### PR DESCRIPTION
FIX #34593
In some cases $this->errors is NULL. With PHP 7 this generated a PHP warning. Since PHP 8 it creates a fatal error

