### PR TITLE
fix: negative quantity in reception are allowed and must be managed on revert stock mvt

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1977,10 +1977,6 @@ class Reception extends CommonObject
 
 						$qty = $obj->qty;
 
-
-						if ($qty <= 0) {
-							continue;
-						}
 						dol_syslog(get_class($this)."::reopen reception movement index ".$i." ed.rowid=".$obj->rowid." edb.rowid=".$obj->edbrowid);
 
 						//var_dump($this->lines[$i]);


### PR DESCRIPTION
If you input a reception fourn with negative quantity (it's possible) when validated the stock quantity is reduced, but when return in draft the stock is not incremented.

The result is always reduced quantity on Validation, never re-stock on revert to Draft