### PR TITLE
FIX: if filter is set on export for Duree type filed, then there is SQL error

### DIFF
--- a/htdocs/exports/class/export.class.php
+++ b/htdocs/exports/class/export.class.php
@@ -354,7 +354,6 @@ class Export
 				}
 				break;
 			case 'Duree':
-				break;
 			case 'Numeric':
 				// if there is a signe +
 				if (strpos($ValueField, "+") > 0) {
@@ -575,7 +574,6 @@ class Export
 				$szMsg = $langs->trans('ExportDateFilter');
 				break;
 			case 'Duree':
-				break;
 			case 'Numeric':
 				$szMsg = $langs->trans('ExportNumericFilter');
 				break;


### PR DESCRIPTION
In Export module, for example Agenda or Task, is you set a filter on Duration type field the result is an SQL error.

SELECT DISTINCT 
p.ref as p_ref
FROM llx_actioncomm as ac
LEFT JOIN llx_actioncomm_extrafields as extra ON ac.id = extra.fk_object
LEFT JOIN llx_c_actioncomm as cac on ac.fk_action = cac.id
LEFT JOIN llx_socpeople as sp on ac.fk_contact = sp.rowid
LEFT JOIN llx_societe as s on ac.fk_soc = s.rowid
LEFT JOIN llx_user as uc ON ac.fk_user_author = uc.rowid
LEFT JOIN llx_c_country as co on s.fk_pays = co.rowid
LEFT JOIN llx_projet as p ON p.rowid = ac.fk_project
WHERE ac.entity IN (2, 3, 4, 5, 6, 7, 8, 9, 10, 1)
AND ac.entity IN (2, 3, 4, 5, 6, 7, 8, 9, 10, 1)
**AND**
ORDER BY ac.datep



At least it have to be considered as a numeric