### PR TITLE
FIX: migrate boolean fields

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9249,9 +9249,9 @@ abstract class CommonObject
 			return (int) $value;
 		} elseif ($fieldsentry['type'] == 'boolean') {
 			if ($value) {
-				return 'true';
+				return '1';
 			} else {
-				return 'false';
+				return '0';
 			}
 		} else {
 			return "'".$this->db->escape($value)."'";

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -410,7 +410,7 @@ class ExtraFields
 			$sql .= "'".$this->db->idate(dol_now())."',";
 			$sql .= " ".($enabled ? "'".$this->db->escape($enabled)."'" : "1").",";
 			$sql .= " ".($help ? "'".$this->db->escape($help)."'" : "null").",";
-			$sql .= " ".($totalizable ? 'TRUE' : 'FALSE').",";
+			$sql .= " ".($totalizable ? 1 : 0).",";
 			$sql .= " ".($css ? "'".$this->db->escape($css)."'" : "null").",";
 			$sql .= " ".($csslist ? "'".$this->db->escape($csslist)."'" : "null").",";
 			$sql .= " ".($cssview ? "'".$this->db->escape($cssview)."'" : "null");
@@ -793,7 +793,7 @@ class ExtraFields
 			$sql .= " '".$this->db->escape($params)."',";
 			$sql .= " '".$this->db->escape($list)."', ";
 			$sql .= " '".$this->db->escape($printable)."', ";
-			$sql .= " ".($totalizable ? 'TRUE' : 'FALSE').",";
+			$sql .= " ".($totalizable ? 1 : 0).",";
 			$sql .= " ".(($default != '') ? "'".$this->db->escape($default)."'" : "null").",";
 			$sql .= " ".($computed ? "'".$this->db->escape($computed)."'" : "null").",";
 			$sql .= " ".$user->id.",";

--- a/htdocs/core/lib/modulebuilder.lib.php
+++ b/htdocs/core/lib/modulebuilder.lib.php
@@ -336,6 +336,8 @@ function rebuildObjectSql($destdir, $module, $objectname, $newmask, $readdir = '
 				$type = 'double'; // html modulebuilder type is a text type in database
 			} elseif (in_array($type, array('link', 'sellist', 'duration'))) {
 				$type = 'integer';
+			} elseif ($type == 'boolean') {
+				$type = 'tinyint(1)';
 			}
 			$texttoinsert .= "\t".$key." ".$type;
 			if ($key == 'rowid') {

--- a/htdocs/core/lib/modulebuilder.lib.php
+++ b/htdocs/core/lib/modulebuilder.lib.php
@@ -337,7 +337,7 @@ function rebuildObjectSql($destdir, $module, $objectname, $newmask, $readdir = '
 			} elseif (in_array($type, array('link', 'sellist', 'duration'))) {
 				$type = 'integer';
 			} elseif ($type == 'boolean') {
-				$type = 'tinyint(1)';
+				$type = 'tinyint';
 			}
 			$texttoinsert .= "\t".$key." ".$type;
 			if ($key == 'rowid') {

--- a/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
+++ b/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
@@ -721,3 +721,8 @@ ALTER TABLE llx_user CHANGE COLUMN tms tms timestamp DEFAULT CURRENT_TIMESTAMP O
 ALTER TABLE llx_salary_extrafields CHANGE COLUMN tms tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
 -- 15.0 -> 16.0 rename llx_advtargetemailing to llx_mailing_advtarget
 ALTER TABLE llx_mailing_advtarget CHANGE COLUMN tms tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- migrate boolean fields
+
+-- VMYSQL4.1 ALTER TABLE llx_extrafields MODIFY COLUMN totalizable tinyint(1) DEFAULT 0;
+-- VPGSQL8.2 ALTER TABLE llx_extrafields ALTER COLUMN totalizable DROP DEFAULT, ALTER COLUMN totalizable TYPE smallint USING CASE totalizable WHEN 't' THEN 1 ELSE 0 END, ALTER COLUMN totalizable SET DEFAULT 0;

--- a/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
+++ b/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
@@ -724,5 +724,5 @@ ALTER TABLE llx_mailing_advtarget CHANGE COLUMN tms tms timestamp DEFAULT CURREN
 
 -- migrate boolean fields
 
--- VMYSQL4.1 ALTER TABLE llx_extrafields MODIFY COLUMN totalizable tinyint(1) DEFAULT 0;
+-- VMYSQL4.1 ALTER TABLE llx_extrafields MODIFY COLUMN totalizable tinyint DEFAULT 0;
 -- VPGSQL8.2 ALTER TABLE llx_extrafields ALTER COLUMN totalizable DROP DEFAULT, ALTER COLUMN totalizable TYPE smallint USING CASE totalizable WHEN 't' THEN 1 ELSE 0 END, ALTER COLUMN totalizable SET DEFAULT 0;

--- a/htdocs/install/mysql/tables/llx_extrafields.sql
+++ b/htdocs/install/mysql/tables/llx_extrafields.sql
@@ -37,7 +37,7 @@ create table llx_extrafields
 	param			text,										-- extra parameters to define possible values of field
 	list			varchar(255) DEFAULT '1',					-- visibility of field. 0=Never visible, 1=Visible on list and forms, 2=Visible on list only. Using a negative value means field is not shown by default on list but can be selected for viewing
 	printable		integer DEFAULT 0,					     	-- is the extrafield output on documents
-	totalizable		tinyint(1) DEFAULT 0,						-- is extrafield totalizable on list
+	totalizable		tinyint DEFAULT 0,							-- is extrafield totalizable on list
 	langs			varchar(64),								-- example: fileofmymodule@mymodule
 	help            text,                                       -- to store help tooltip
 	css             varchar(128),                               -- to store css on create/update forms

--- a/htdocs/install/mysql/tables/llx_extrafields.sql
+++ b/htdocs/install/mysql/tables/llx_extrafields.sql
@@ -37,7 +37,7 @@ create table llx_extrafields
 	param			text,										-- extra parameters to define possible values of field
 	list			varchar(255) DEFAULT '1',					-- visibility of field. 0=Never visible, 1=Visible on list and forms, 2=Visible on list only. Using a negative value means field is not shown by default on list but can be selected for viewing
 	printable		integer DEFAULT 0,					     	-- is the extrafield output on documents
-    totalizable     boolean DEFAULT FALSE,                      -- is extrafield totalizable on list
+	totalizable		tinyint(1) DEFAULT 0,						-- is extrafield totalizable on list
 	langs			varchar(64),								-- example: fileofmymodule@mymodule
 	help            text,                                       -- to store help tooltip
 	css             varchar(128),                               -- to store css on create/update forms


### PR DESCRIPTION
# FIX: migrate boolean fields

Objects with fields typed as `'boolean'` (checkboxes in modulebuilder-generated modules) are handled with database type `BOOLEAN`. This database type in not handled very well with the PHP PostgreSQL driver : `pg_fetch_*()` functions return `string` values `'t'` or `'f'` respectively for true or false, which are both 'truthy' values, so the checkboxes are always considered checked. Moreover, it complicates table create/update queries as we have to specifically pass `TRUE` or `FALSE` in SQL queries to have cross-compatible behaviour.

I therefore suggest migrating all those fields from `BOOLEAN` to `TINYINT` (which will be rewritten to `SMALLINT` in PostgreSQL), migrating existing fields (in v18, only field `totalizable` from table `llx_extrafields` is defined as such), and getting modulebuilder SQL-generation feature to output `SMALLINT` instead.

When this PR is merged, another will follow in v19 where more fields use the `BOOLEAN` database type.