### PR TITLE
FIX: Update document.php

### DIFF
--- a/htdocs/resource/document.php
+++ b/htdocs/resource/document.php
@@ -84,7 +84,7 @@ $object = new Dolresource($db);
 // Load object
 include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'include', not 'include_once'.
 
-$upload_dir = $conf->resource->dir_output.'/'.dol_sanitizeFileName($object->ref);
+$upload_dir = $conf->resource->dir_output.'/'.dol_sanitizeFileName($object->id);
 $modulepart = 'resource';
 
 $result = restrictedArea($user, 'resource', $object->id, 'resource');


### PR DESCRIPTION
In the Resources module, uploaded files are stored in folders with the resource reference instead of its ID, which causes all documents to disappear when the  reference is changed.

This fix need a script to rename folders.
