### PR TITLE
fix(bookkeeping): doc_ref too long

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -232,6 +232,7 @@ class BookKeeping extends CommonObject
 		}
 		if (isset($this->doc_ref)) {
 			$this->doc_ref = trim($this->doc_ref);
+			$this->doc_ref = dol_trunc($this->doc_ref, 300); // We limit to 300 chars to avoid problems with too long ref in DB
 		}
 		if (isset($this->fk_doc)) {
 			$this->fk_doc = (int) $this->fk_doc;


### PR DESCRIPTION
# FIX|Fix doc_ref too long
doc_ref contains every ref of supplier invoice, even if there are thousands of entries. We need to trunc it to its column size.