### PR TITLE
FIX 21.0: $height and $width can be ints, but also 'auto'

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5898,13 +5898,6 @@ class Form
 
 			$postconfirmas = 'GET';
 
-			if ($height !== 'auto') {
-				$height = (int) $height;
-			}
-			if ($width !== 'auto') {
-				$width = (int) $width;
-			}
-
 			$formconfirm .= '
                     resizable: false,
 					height: \'' . dol_escape_js($height) . '\',

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5898,10 +5898,14 @@ class Form
 
 			$postconfirmas = 'GET';
 
+			if ($height !== 'auto') $height = (int) $height;
+			if ($width !== 'auto') $width = (int) $width;
+
+
 			$formconfirm .= '
                     resizable: false,
-                    height: \'' . ((int) $height) . '\',
-                    width: \'' . ((int) $width) . '\',
+                    height: '.json_encode($height).',
+                    width: '.json_encode($width).',
                     modal: true,
                     closeOnEscape: false,
                     buttons: {

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5898,14 +5898,17 @@ class Form
 
 			$postconfirmas = 'GET';
 
-			if ($height !== 'auto') $height = (int) $height;
-			if ($width !== 'auto') $width = (int) $width;
-
+			if ($height !== 'auto') {
+				$height = (int) $height;
+			}
+			if ($width !== 'auto') {
+				$width = (int) $width;
+			}
 
 			$formconfirm .= '
                     resizable: false,
-                    height: '.json_encode($height).',
-                    width: '.json_encode($width).',
+					height: \'' . dol_escape_js($height) . '\',
+                    width: \'' . dol_escape_js($width) . '\',
                     modal: true,
                     closeOnEscape: false,
                     buttons: {


### PR DESCRIPTION
# FIX
Formconfirm dialogs take a `$height` argument. Before v21.0, the value `auto` was accepted (and frequently used in external modules), but in v21.0, a typecast to int was introduced, which turns `auto` into `0` and makes some of the dialogs unusable.
