### PR TITLE
Fix Filter on search_project lost on next pages

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -769,6 +769,9 @@ if (empty($reshook)) {
 			if ($search_project_ref >= 0) {
 				$param .= "&search_project_ref=".urlencode($search_project_ref);
 			}
+			if ($search_project != '') {
+				$param .= "&search_project=".urlencode($search_project);
+			}
 			if ($search_billed != '') {
 				$param .= '&search_billed='.urlencode($search_billed);
 			}
@@ -1450,6 +1453,9 @@ if ($search_multicurrency_montant_ttc != '') {
 }
 if ($search_project_ref >= 0) {
 	$param .= "&search_project_ref=".urlencode($search_project_ref);
+}
+if ($search_project != '') {
+	$param .= "&search_project=".urlencode($search_project);
 }
 if ($search_town != '') {
 	$param .= '&search_town='.urlencode($search_town);


### PR DESCRIPTION
The filter on the p.title of the command list doesn't work if you switch result pages. It's simply not kept in the next page url.
