### PR TITLE
FIX|Fix  - Duplicate bommline when i refresh my page

### DIFF
--- a/htdocs/bom/bom_card.php
+++ b/htdocs/bom/bom_card.php
@@ -253,7 +253,7 @@ if (empty($reshook)) {
 			$object->calculateCosts();
 
 			header('Location: '.$_SERVER['PHP_SELF'].'?id='.$object->id);
-			exit();
+			exit;
 		}
 	}
 
@@ -312,7 +312,7 @@ if (empty($reshook)) {
 			$object->calculateCosts();
 
 			header('Location: '.$_SERVER['PHP_SELF'].'?id='.$object->id);
-			exit();
+			exit;
 		}
 	}
 }

--- a/htdocs/bom/bom_card.php
+++ b/htdocs/bom/bom_card.php
@@ -251,6 +251,9 @@ if (empty($reshook)) {
 			$object->fetchLines();
 
 			$object->calculateCosts();
+
+			header('Location: '.$_SERVER['PHP_SELF'].'?id='.$object->id);
+			exit();
 		}
 	}
 
@@ -307,6 +310,9 @@ if (empty($reshook)) {
 			$object->fetchLines();
 
 			$object->calculateCosts();
+
+			header('Location: '.$_SERVER['PHP_SELF'].'?id='.$object->id);
+			exit();
 		}
 	}
 }


### PR DESCRIPTION
# FIX|Fix #Duplicate BOMLine when i refresh BOM page


I noticed that when you add a BOM line to a BOM, and then refresh the page, the line you just added is duplicated.
To fix this and secure this type of operation, I added this code

