### PR TITLE
18.0 create SOURCES dir if not exists

### DIFF
--- a/build/makepack-dolibarr.pl
+++ b/build/makepack-dolibarr.pl
@@ -831,6 +831,7 @@ if ($nboftargetok) {
 			print "Compress $FILENAMETGZ2 into $FILENAMETGZ2.tgz...\n";
 			$ret=`tar --exclude-from "$SOURCE/build/tgz/tar_exclude.txt" --directory "$BUILDROOT" -czvf "$BUILDROOT/$FILENAMETGZ2.tgz" $FILENAMETGZ2`;
 
+			if (! -d $RPMDIR . '/SOURCES') { mkdir($RPMDIR . '/SOURCES'); }
 			print "Move $BUILDROOT/$FILENAMETGZ2.tgz to $RPMDIR/SOURCES/$FILENAMETGZ2.tgz\n";
 			$cmd="mv $BUILDROOT/$FILENAMETGZ2.tgz $RPMDIR/SOURCES/$FILENAMETGZ2.tgz";
 			$ret=`$cmd`;

--- a/build/makepack-howto.txt
+++ b/build/makepack-howto.txt
@@ -6,7 +6,7 @@ of Dolibarr. There is a chapter for BETA version and a chapter for RELEASE versi
 ***** Prerequisites For Linux *****
 
 Prerequisites to build tgz, debian and rpm packages:
-> apt-get install perl tar dpkg dpatch p7zip-full rpm zip php-cli
+> apt-get install perl tar dpkg p7zip-full rpm zip php-cli debhelper po-debconf
 
 Prerequisites to build autoexe DoliWamp package from Linux (solution seems broken since Ubuntu 20.04):
 > apt-get install wine q4wine
@@ -14,11 +14,11 @@ Prerequisites to build autoexe DoliWamp package from Linux (solution seems broke
 > Install InnoSetup
    For example by running isetup-5.5.8.exe (https://www.jrsoftware.org)  https://files.jrsoftware.org/is/5/
 > Install WampServer into "C:\wamp64" to have Apache, PHP and MariaDB
-   For example by running wampserver3.2.6_x64.exe (https://www.wampserver.com). 
+   For example by running wampserver3.2.6_x64.exe (https://www.wampserver.com).
    See file build/exe/doliwamp.iss to know the doliwamp version currently setup.
 > Add path to ISCC into PATH windows var:
   Launch wine cmd, then regedit and add entry int HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment\PATH
-> To build manually the .exe from Windows (running from makepack-dolibarr.pl script is however recommanded), 
+> To build manually the .exe from Windows (running from makepack-dolibarr.pl script is however recommanded),
   open file build/exe/doliwamp.iss and click on button "Compile".
   The .exe file will be build into directory build.
 
@@ -31,8 +31,8 @@ Prerequisites to build autoexe DoliWamp package from Windows:
 > Install isetup-5.5.8.exe (https://www.jrsoftware.org)
 > Install WampServer-3.2.*-64.exe (Apache 2.4.51, PHP 7.3.33, MariaDB 10.6.5 for example. Version must match the values found into doliwamp.iss)
 > Install GIT for Windows (https://git-scm.com/ => You must choose option "Add Git bash profile", "Git commit as-is")
-> Install Dolibarr current version:   
-  git clone https://github.com/dolibarr/dolibarr  or  git clone --branch X.Y https://github.com/dolibarr/dolibarr  
+> Install Dolibarr current version:
+  git clone https://github.com/dolibarr/dolibarr  or  git clone --branch X.Y https://github.com/dolibarr/dolibarr
 
 > Add the path of PHP (C:\wamp64\bin\php\php7.3.33) and InnoSetup (C:\Program Files (x86)\Inno Setup 5) into the %PATH% of Windows.
 
@@ -43,11 +43,11 @@ Prerequisites to build autoexe DoliWamp package from Windows:
 
 
 ***** Actions to do a BETA *****
-This files describe steps made by Dolibarr packaging team to make a 
+This files describe steps made by Dolibarr packaging team to make a
 beta version of Dolibarr, step by step.
 
 - Check all files are commited.
-- Update version/info in ChangeLog, for this you can: 
+- Update version/info in ChangeLog, for this you can:
 To generate a changelog of a major new version x.y.0 (from a repo on branch develop), you can do "cd ~/git/dolibarr; git log `diff -u <(git rev-list --first-parent x.(y-1).0)  <(git rev-list --first-parent develop) | sed -ne 's/^ //p' | head -1`.. --no-merges --pretty=short --oneline | sed -e "s/^[0-9a-z]* //" | grep -e '^FIX\|NEW' | sort -u | sed 's/FIXED:/FIX:/g' | sed 's/FIXED :/FIX:/g' | sed 's/FIX :/FIX:/g' | sed 's/FIX /FIX: /g' | sed 's/NEW :/NEW:/g' | sed 's/NEW /NEW: /g' > /tmp/aaa"
 To generate a changelog of a major new version x.y.0 (from a repo on branch x.y repo), you can do "cd ~/git/dolibarr_x.y; git log `diff -u <(git rev-list --first-parent x.(y-1).0)  <(git rev-list --first-parent x.y.0) | sed -ne 's/^ //p' | head -1`.. --no-merges --pretty=short --oneline | sed -e "s/^[0-9a-z]* //" | grep -e '^FIX\|NEW' | sort -u | sed 's/FIXED:/FIX:/g' | sed 's/FIXED :/FIX:/g' | sed 's/FIX :/FIX:/g' | sed 's/FIX /FIX: /g' | sed 's/NEW :/NEW:/g' | sed 's/NEW /NEW: /g' > /tmp/aaa"
 To generate a changelog of a maintenance version x.y.z, you can do "cd ~/git/dolibarr_x.y; git log x.y.z-1.. --no-merges --pretty=short --oneline | sed -e "s/^[0-9a-z]* //" | grep -e '^FIX\|NEW' | sort -u | sed 's/FIXED:/FIX:/g' | sed 's/FIXED :/FIX:/g' | sed 's/FIX :/FIX:/g' | sed 's/FIX /FIX: /g' | sed 's/NEW :/NEW:/g' | sed 's/NEW /NEW: /g' > /tmp/aaa"
@@ -67,7 +67,7 @@ Recopy the content of the output file into the file ChangeLog.
 
 
 ***** Actions to do a RELEASE *****
-This files describe steps made by Dolibarr packaging team to make a 
+This files describe steps made by Dolibarr packaging team to make a
 complete release of Dolibarr, step by step.
 
 - Check all files are commited.
@@ -84,9 +84,9 @@ Recopy the content of the output file into the file ChangeLog.
 
 - Check content of built packages.
 
-- Run makepack-dolibarr.pl again with option to publish files on 
+- Run makepack-dolibarr.pl again with option to publish files on
   dolibarr foundation server (Dir /home/dolibarr/wwwroot/files/stable on www.dolibarr.org).
-- Run makepack-dolibarr.pl again with option to publish files on 
+- Run makepack-dolibarr.pl again with option to publish files on
   sourceforge. This will also add official tag.
 - Edit symbolic links in directory "/home/dolibarr/wwwroot/files/stable/xxx"
   on server to point to new files (used by some web sites).


### PR DESCRIPTION
On @lvessiller-opendsi  setup rpmbuild/SOURCES directory does not exists and makepack.pl fails due to that