### PR TITLE
Fix #17816 match compta/paiement.php payment method for credit note ivoices for  /invoices/paymentsdistributed  API

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -1568,13 +1568,13 @@ class Invoices extends DolibarrApi
 				$amount = price2num($amountarray["multicurrency_amount"], 'MT');
 			}
 
-			if ($amount > $remainstopay && !$accepthigherpayment) {
+			if (abs($amount) > abs($remainstopay) && !$accepthigherpayment) {
 				$this->db->rollback();
 				throw new RestException(400, 'Payment amount on invoice ID '.$id.' ('.$amount.') is higher than remain to pay ('.$remainstopay.')');
 			}
 
 			if ($this->invoice->type == Facture::TYPE_CREDIT_NOTE) {
-				$amount = -$amount;
+				$amount = - abs($amount);
 			}
 
 			if ($is_multicurrency) {


### PR DESCRIPTION
Fix a bug with Credit note on invoice payment distibuted API function

Credit Notes have a negative total amount. Submitting payments using API function addPaymentDistributed in api_invoices.class.php fail with error 'Payment amount on invoice [...] ('...') is higher than remain to pay ('...').
This is an API-only issue: using the regular Dolibarr payment page works as expected.
So we do the same has in compta/paiement.php