### PR TITLE
FIX|Fix # fatal when u try to add a newline on expensereport object 

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1250,7 +1250,7 @@ if (empty($reshook)) {
 						$newlang = $user->lang;
 					}
 					if (empty($newlang)) {
-						$newlang = $langs;
+						$newlang = $langs->defaultlang;
 					}
 					if (!empty($newlang)) {
 						$outputlangs = new Translate("", $conf);


### PR DESCRIPTION
# FIX|Fix #Fatal on addLine on Expensereport

I noticed that when I tried to add a new line to an Expense Report object, a fatal error was triggered. After investigation, I found that this issue was linked to the "expensereport" module, specifically to the way the "newlangs" field was handled.

Instead of assigning a language code as a string (such as "fr_FR"), the code was setting "newlangs" to a Translate object. Later, when the Translate class tried to use the explode function on this field, it expected a string but received an object, which caused the fatal error.


