### PR TITLE
FIX: advanced target emailling missing case

### DIFF
--- a/htdocs/comm/mailing/class/advtargetemailing.class.php
+++ b/htdocs/comm/mailing/class/advtargetemailing.class.php
@@ -641,6 +641,27 @@ class AdvanceTargetingMailing extends CommonObject
 						if ($arrayquery['options_'.$key] > 0) {
 							$sqlwhere[] = " (te.".$key." = ".((int) $arrayquery["options_".$key]).")";
 						}
+					} elseif ($extrafields->attributes[$elementtype]['type'][$key] == 'chkbxlst'
+						&& is_array($arrayquery['options_'.$key])) {
+						if (count($arrayquery['options_'.$key])) {
+							$i2 = 0;
+							$field = "te.".$key;
+							$sqlwhereselllist='';
+							foreach ($arrayquery['options_'.$key] as $data) {
+								$data = trim($data);
+								if ($data) {
+									$sqlwhereselllist .= ($i2 > 0 ? " OR (" : "(").$field." LIKE '".$this->db->escape($data).",%'";
+									$sqlwhereselllist .= ' OR '.$field." = '".$this->db->escape($data)."'";
+									$sqlwhereselllist .= ' OR '.$field." LIKE '%,".$this->db->escape($data)."'";
+									$sqlwhereselllist .= ' OR '.$field." LIKE '%,".$this->db->escape($data).",%'";
+									$sqlwhereselllist .= ')';
+									$i2++; // a criteria for 1 more field was added to string (we can add several criteria for the same field as it is a multiselect search criteria)
+								}
+							}
+							if (!empty($sqlwhereselllist)) {
+								$sqlwhere[] = "( ".$sqlwhereselllist." )";
+							}
+						}
 					} else {
 						if (is_array($arrayquery['options_'.$key])) {
 							$sqlwhere[] = " (te.".$key." IN (".$this->db->sanitize("'".implode("','", $arrayquery["options_".$key])."'", 1)."))";
@@ -784,6 +805,31 @@ class AdvanceTargetingMailing extends CommonObject
 								$sqlwhere[] = " (te.".$key." = ".((int) $arrayquery["options_".$key."_cnct"]).")";
 							}
 						}
+					} elseif ($extrafields->attributes[$elementtype]['type'][$key] == 'link') {
+						if ($arrayquery['options_'.$key."_cnct"] > 0) {
+							$sqlwhere[]= " (te.".$key." = ".((int) $arrayquery["options_".$key."_cnct"]).")";
+						}
+					} elseif ($extrafields->attributes[$elementtype]['type'][$key] == 'chkbxlst'
+						&& is_array($arrayquery['options_'.$key.'_cnct'])) {
+						if (count($arrayquery['options_'.$key.'_cnct'])) {
+							$i2 = 0;
+							$field = "te.".$key;
+							$sqlwhereselllist='';
+							foreach ($arrayquery['options_'.$key.'_cnct'] as $data) {
+								$data = trim($data);
+								if ($data) {
+									$sqlwhereselllist .= ($i2 > 0 ? " OR (" : "(").$field." LIKE '".$this->db->escape($data).",%'";
+									$sqlwhereselllist .= ' OR '.$field." = '".$this->db->escape($data)."'";
+									$sqlwhereselllist .= ' OR '.$field." LIKE '%,".$this->db->escape($data)."'";
+									$sqlwhereselllist .= ' OR '.$field." LIKE '%,".$this->db->escape($data).",%'";
+									$sqlwhereselllist .= ')';
+									$i2++; // a criteria for 1 more field was added to string (we can add several criteria for the same field as it is a multiselect search criteria)
+								}
+							}
+							if (!empty($sqlwhereselllist)) {
+								$sqlwhere[] = "( ".$sqlwhereselllist." )";
+							}
+						}
 					} else {
 						if (is_array($arrayquery['options_'.$key.'_cnct'])) {
 							$sqlwhere[] = " (te.".$key." IN (".$this->db->sanitize("'".implode("','", $arrayquery["options_".$key."_cnct"])."'", 1)."))";
@@ -887,6 +933,31 @@ class AdvanceTargetingMailing extends CommonObject
 							} elseif ($extrafields->attributes[$elementtype]['type'][$key] == 'boolean') {
 								if ($arrayquery['options_'.$key] != '') {
 									$sqlwhere[] = " (tse.".$key." = ".((int) $arrayquery["options_".$key]).")";
+								}
+							} elseif ($extrafields->attributes[$elementtype]['type'][$key] == 'link') {
+								if ($arrayquery['options_'.$key] > 0) {
+									$sqlwhere[]= " (te.".$key." = ".((int) $arrayquery["options_".$key]).")";
+								}
+							} elseif ($extrafields->attributes[$elementtype]['type'][$key] == 'chkbxlst'
+								&& is_array($arrayquery['options_'.$key])) {
+								if (count($arrayquery['options_'.$key])) {
+									$i2 = 0;
+									$field = "tse.".$key;
+									$sqlwhereselllist='';
+									foreach ($arrayquery['options_'.$key] as $data) {
+										$data = trim($data);
+										if ($data) {
+											$sqlwhereselllist  .= ($i2 > 0 ? " OR (" : "(").$field." LIKE '".$this->db->escape($data).",%'";
+											$sqlwhereselllist  .= ' OR '.$field." = '".$this->db->escape($data)."'";
+											$sqlwhereselllist  .= ' OR '.$field." LIKE '%,".$this->db->escape($data)."'";
+											$sqlwhereselllist  .= ' OR '.$field." LIKE '%,".$this->db->escape($data).",%'";
+											$sqlwhereselllist  .= ')';
+											$i2++; // a criteria for 1 more field was added to string (we can add several criteria for the same field as it is a multiselect search criteria)
+										}
+									}
+									if (!empty($sqlwhereselllist)) {
+										$sqlwhere[] = "( ".$sqlwhereselllist." )";
+									}
 								}
 							} else {
 								if (is_array($arrayquery['options_'.$key])) {

--- a/htdocs/comm/mailing/class/advtargetemailing.class.php
+++ b/htdocs/comm/mailing/class/advtargetemailing.class.php
@@ -646,15 +646,15 @@ class AdvanceTargetingMailing extends CommonObject
 						if (count($arrayquery['options_'.$key])) {
 							$i2 = 0;
 							$field = "te.".$key;
-							$sqlwhereselllist='';
+							$sqlwhereselllist="";
 							foreach ($arrayquery['options_'.$key] as $data) {
 								$data = trim($data);
 								if ($data) {
 									$sqlwhereselllist .= ($i2 > 0 ? " OR (" : "(").$field." LIKE '".$this->db->escape($data).",%'";
-									$sqlwhereselllist .= ' OR '.$field." = '".$this->db->escape($data)."'";
-									$sqlwhereselllist .= ' OR '.$field." LIKE '%,".$this->db->escape($data)."'";
-									$sqlwhereselllist .= ' OR '.$field." LIKE '%,".$this->db->escape($data).",%'";
-									$sqlwhereselllist .= ')';
+									$sqlwhereselllist .= " OR ".$field." = '".$this->db->escape($data)."'";
+									$sqlwhereselllist .= " OR ".$field." LIKE '%,".$this->db->escape($data)."'";
+									$sqlwhereselllist .= " OR ".$field." LIKE '%,".$this->db->escape($data).",%'";
+									$sqlwhereselllist .= ")";
 									$i2++; // a criteria for 1 more field was added to string (we can add several criteria for the same field as it is a multiselect search criteria)
 								}
 							}
@@ -814,15 +814,15 @@ class AdvanceTargetingMailing extends CommonObject
 						if (count($arrayquery['options_'.$key.'_cnct'])) {
 							$i2 = 0;
 							$field = "te.".$key;
-							$sqlwhereselllist='';
+							$sqlwhereselllist="";
 							foreach ($arrayquery['options_'.$key.'_cnct'] as $data) {
 								$data = trim($data);
 								if ($data) {
 									$sqlwhereselllist .= ($i2 > 0 ? " OR (" : "(").$field." LIKE '".$this->db->escape($data).",%'";
-									$sqlwhereselllist .= ' OR '.$field." = '".$this->db->escape($data)."'";
-									$sqlwhereselllist .= ' OR '.$field." LIKE '%,".$this->db->escape($data)."'";
-									$sqlwhereselllist .= ' OR '.$field." LIKE '%,".$this->db->escape($data).",%'";
-									$sqlwhereselllist .= ')';
+									$sqlwhereselllist .= " OR ".$field." = '".$this->db->escape($data)."'";
+									$sqlwhereselllist .= " OR ".$field." LIKE '%,".$this->db->escape($data)."'";
+									$sqlwhereselllist .= " OR ".$field." LIKE '%,".$this->db->escape($data).",%'";
+									$sqlwhereselllist .= ")";
 									$i2++; // a criteria for 1 more field was added to string (we can add several criteria for the same field as it is a multiselect search criteria)
 								}
 							}
@@ -943,15 +943,15 @@ class AdvanceTargetingMailing extends CommonObject
 								if (count($arrayquery['options_'.$key])) {
 									$i2 = 0;
 									$field = "tse.".$key;
-									$sqlwhereselllist='';
+									$sqlwhereselllist="";
 									foreach ($arrayquery['options_'.$key] as $data) {
 										$data = trim($data);
 										if ($data) {
 											$sqlwhereselllist  .= ($i2 > 0 ? " OR (" : "(").$field." LIKE '".$this->db->escape($data).",%'";
-											$sqlwhereselllist  .= ' OR '.$field." = '".$this->db->escape($data)."'";
-											$sqlwhereselllist  .= ' OR '.$field." LIKE '%,".$this->db->escape($data)."'";
-											$sqlwhereselllist  .= ' OR '.$field." LIKE '%,".$this->db->escape($data).",%'";
-											$sqlwhereselllist  .= ')';
+											$sqlwhereselllist  .= " OR ".$field." = '".$this->db->escape($data)."'";
+											$sqlwhereselllist  .= " OR ".$field." LIKE '%,".$this->db->escape($data)."'";
+											$sqlwhereselllist  .= " OR ".$field." LIKE '%,".$this->db->escape($data).",%'";
+											$sqlwhereselllist  .= ")";
 											$i2++; // a criteria for 1 more field was added to string (we can add several criteria for the same field as it is a multiselect search criteria)
 										}
 									}


### PR DESCRIPTION
On Advance target emailing page on Emailing
When filter is done on extrafield type chkbxlst the SQL query wasn't correct

Data in extrafield "extrafield_chkbxlst" stored like 
17,2,26,1,25

Previous SQL
  AND (te.extrafield_chkbxlst IN ('2', '26', '25'))

Expected SQL :
((te.extrafield_chkbxlst LIKE '2,%' OR te.extrafield_chkbxlst = '2' OR te.extrafield_chkbxlst LIKE '%,2' OR
        te.extrafield_chkbxlst LIKE '%,2,%') OR
       (te.extrafield_chkbxlst LIKE '26,%' OR te.extrafield_chkbxlst = '26' OR te.extrafield_chkbxlst LIKE '%,26' OR
        te.extrafield_chkbxlst LIKE '%,26,%') OR
       (te.extrafield_chkbxlst LIKE '25,%' OR te.extrafield_chkbxlst = '25' OR te.extrafield_chkbxlst LIKE '%,25' OR
        te.extrafield_chkbxlst LIKE '%,25,%'))


