### PR TITLE
NEW hook allowing external modules to replace the behavior of fetchOb…

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4381,6 +4381,22 @@ abstract class CommonObject
 		$this->linkedObjectsIds = array();
 		$this->linkedObjects = array();
 
+		// Hook for allowing modules to completely alter the behavior of the method
+		$parameters = array(
+			'sourceid' => $sourceid,
+			'sourcetype' => $sourcetype,
+			'targetid' => $targetid,
+			'targettype' => $targettype,
+			'clause' => $clause,
+			'alsosametype' => $alsosametype,
+			'orderby' => $orderby,
+			'loadalsoobjects' => $loadalsoobjects
+		);
+		$reshook = $hookmanager->executeHooks('fetchObjectLinked', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+		if ($reshook > 0) {
+			return $reshook;
+		}
+
 		$justsource = false;
 		$justtarget = false;
 		$withtargettype = false;


### PR DESCRIPTION
# NEW Hook for fetchObjectLinked
As it stands, there is no obvious way for external modules to alter the fetching of linked object when it is performed by Dolibarr.

Our problem is with huge objects linked to many huge objects. The object's card calls `Form::showLinkedObjectBlock()`, which calls `$object->fetchObjectLinked()` (before the existing hook, so not modifiable) in order to perform `getNomUrl()` on each object.

When every object is big (many objects with many lines each), this easily exceeds performance limits.

With this hook, we can selectively choose to load less data / load it more effectively depending on the call context.

Note on design: I considered using the hookmanager's results array, but decided it was more convenient to let the implementer manipulate `$object->linkedObjectsIds`, `$object->linkedObjects` and `$object->linkedObjectsFullLoaded` directly, since those are public. 

[edit] *I just noticed that `linkedObjectsFullLoaded` is, in fact, private, so this will be a limitation of the hook.*

Note on overload: currently, the method `fetchObjectLinked` is very rarely overloaded in the core, but adding this hook means that 

Don't hesitate to give me feedback if you think this design was better.