### PR TITLE
FIX: asset: could not select invoice in disposal pop-in

### DIFF
--- a/htdocs/asset/card.php
+++ b/htdocs/asset/card.php
@@ -271,9 +271,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		$disposal_type_form = $object->showInputField(null, 'fk_disposal_type', $fk_disposal_type, '', '', '', 0);
 		$object->fields['fk_disposal_type']['visible'] = -2;
 
-		$object->fields['disposal_invoice_id'] = array('type' => 'integer:Facture:compta/facture/class/facture.class.php::entity IN (__SHARED_ENTITIES__)', 'enabled' => '1', 'notnull' => 1, 'visible' => 1, 'index' => 1, 'validate' => '1',);
-		$disposal_invoice_form = $object->showInputField(null, 'disposal_invoice_id', $disposal_invoice_id, '', '', '', 0);
-		unset($object->fields['disposal_invoice_id']);
+		$disposal_invoice_form = $form->selectForForms('Facture:compta/facture/class/facture.class.php::(entity:IN:__SHARED_ENTITIES__)', 'disposal_invoice_id', $disposal_invoice_id);
 
 		// Create an array for form
 		$formquestion = array(


### PR DESCRIPTION
# FIX: asset: could not select invoice in disposal pop-in

When disposing of an asset, the combobox to select a customer invoice cannot be displayed :
* simulating a field by editing `$fields` does not work as the object is instantiated from scratch in `CommonObject`
* the universal filter syntax is not correct anymore anyway

To fix that, instead of simulating a field to generate the combo, we make the corresponding call in `Form` class, with the correct universal filter.

This bugfix is valid up to `develop` branch.