### PR TITLE
FIX| Human readable statement descriptor for Stripe SEPA Direct Debit

### DIFF
--- a/htdocs/stripe/class/stripe.class.php
+++ b/htdocs/stripe/class/stripe.class.php
@@ -461,7 +461,7 @@ class Stripe extends CommonObject
 			$descriptor = dol_trunc($tag, 10, 'right', 'UTF-8', 1);
 			if (getDolGlobalInt('STRIPE_SEPA_DIRECT_DEBIT')) {
 				$paymentmethodtypes[] = "sepa_debit"; //&& ($object->thirdparty->isInEEC())
-				//$descriptor = preg_replace('/ref=[^:=]+/', '', $descriptor);	// Clean ref
+				if (is_object($object) && $object->ref) { $descriptor = $object->ref; }	// Expose ref in descriptor statement
 			}
 			if (getDolGlobalInt('STRIPE_KLARNA')) {
 				$paymentmethodtypes[] = "klarna";


### PR DESCRIPTION
Use reference of the object (Orders, Invoice) for the statement descriptor. 
Insted of the truncated $FULLTAG at first 10 character, does not allow the customer to identify the nature of the direct debit

Utilise la référence de objet ( commande, facture) dans libellé de relevé bancaire. Car la le $fulltag tronqué a 10 caractère ne permet pas au client d'identifié la nature du prélèvement.
