### PR TITLE
FIX: we should ensure Commande::$lines array contains OrderLine objects

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1068,10 +1068,15 @@ class Commande extends CommonOrder
 				for ($i = 0; $i < $num; $i++) {
 					$line = $this->lines[$i];
 
-					// Test and convert into object this->lines[$i]. When coming from REST API, we may still have an array
+					// Test and convert into OrderLine object this->lines[$i]. When coming from REST API, we may still have an array
 					//if (! is_object($line)) $line=json_decode(json_encode($line), false);  // convert recursively array into object.
 					if (!is_object($line)) {
-						$line = (object) $line;
+						$lineobj = new OrderLine($this->db);
+						foreach ($line as $key => $val) {
+							$lineobj->$key = $val;
+						}
+						$line = $lineobj;
+						$this->lines[$i] = $line;
 					}
 
 					// Reset fk_parent_line for no child products and special product


### PR DESCRIPTION
# FIX: we should ensure Commande::$lines array contains OrderLine objects

Right now, when an order is created from the REST API, the lines array contains arrays with data. The present code permits the order lines registration, but if we need to address in the ORDER_CREATE trigger, the order generation will fail.

I suggest we make those arrays proper OrderLine objects in the Commande object.
