### PR TITLE
feat(extrafields): add extrafields hook points for enhanced customization

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -82,6 +82,7 @@ class ExtraFields
 		'double' => 'Float',
 		'date' => 'Date',
 		'datetime' => 'DateAndTime',
+		'datetime' => 'DateAndTime',
 		'duration' => 'Duration',
 		//'datetimegmt'=>'DateAndTimeUTC',
 		'boolean' => 'Boolean',
@@ -166,6 +167,8 @@ class ExtraFields
 	 */
 	public function addExtraField($attrname, $label, $type, $pos, $size, $elementtype, $unique = 0, $required = 0, $default_value = '', $param = '', $alwayseditable = 0, $perms = '', $list = '-1', $help = '', $computed = '', $entity = '', $langfile = '', $enabled = '1', $totalizable = 0, $printable = 0, $moreparams = array(), $aiprompt = "")
 	{
+		global $hookmanager;
+		$hookmanager->initHooks('extrafieldsdao');
 		if (empty($attrname)) {
 			return -1;
 		}
@@ -207,6 +210,35 @@ class ExtraFields
 				|| ($type == 'separate' && $err2 == 'DB_ERROR_RECORD_ALREADY_EXISTS')) {
 				$this->error = '';
 				$this->errno = '0';
+				$parameters = ['result', $result,
+					'result2', $result2,
+					'attrname' => $attrname,
+					'label' => $label,
+					'type' => $type,
+					'pos' => $pos,
+					'size' => $size,
+					'elementtype' => $elementtype,
+					'unique' => $unique,
+					'required' => $required,
+					'default_value' => $default_value,
+					'param' => $param,
+					'alwayseditable' => $alwayseditable,
+					'perms' => $perms,
+					'list' => $list,
+					'help' => $help,
+					'computed' => $computed,
+					'entity' => $entity,
+					'langfile' => $langfile,
+					'enabled' => $enabled,
+					'totalizable' => $totalizable,
+					'printable' => $printable,
+					'moreparams' => $moreparams];
+				$reshook = $hookmanager->executeHooks('addExtraField', $parameters, $this); // Note that $action and $object may have been modified by some hooks
+
+				if ($reshook < 0) {
+					$this->error = $this->db->lasterror();
+					return -1;
+				}
 				return 1;
 			} else {
 				return -2;
@@ -773,7 +805,7 @@ class ExtraFields
 
 			if (is_object($hookmanager)) {
 				$hookmanager->initHooks(array('extrafieldsdao'));
-				$parameters = array('field_desc' => &$field_desc, 'table' => $table, 'attr_name' => $attrname, 'label' => $label, 'type' => $type, 'length' => $length, 'unique' => $unique, 'required' => $required, 'pos' => $pos, 'param' => $param, 'alwayseditable' => $alwayseditable, 'perms' => $perms, 'list' => $list, 'help' => $help, 'default' => $default, 'computed' => $computed, 'entity' => $entity, 'langfile' => $langfile, 'enabled' => $enabled, 'totalizable' => $totalizable, 'printable' => $printable);
+				$parameters = array('field_desc' => &$field_desc, 'table' => $table, 'attr_name' => $attrname, 'label' => $label, 'type' => $type, 'length' => $length, 'unique' => $unique, 'required' => $required, 'pos' => $pos, 'param' => $param, 'alwayseditable' => $alwayseditable, 'perms' => $perms, 'list' => $list, 'help' => $help, 'default' => $default, 'computed' => $computed, 'entity' => $entity, 'langfile' => $langfile, 'enabled' => $enabled, 'totalizable' => $totalizable, 'printable' => $printable, 'elementtype' => $elementtype);
 				$reshook = $hookmanager->executeHooks('updateExtrafields', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
 				if ($reshook < 0) {
@@ -807,6 +839,13 @@ class ExtraFields
 					 $this->error = $this->db->lasterror();
 					 return -1;
 					 }*/
+					$parameters = array('field_desc' => &$field_desc, 'table' => $table, 'attr_name' => $attrname, 'label' => $label, 'type' => $type, 'length' => $length, 'elementtype' => $elementtype, 'unique' => $unique, 'required' => $required, 'pos' => $pos, 'param' => $param, 'alwayseditable' => $alwayseditable, 'perms' => $perms, 'list' => $list, 'help' => $help, 'default' => $default, 'computed' => $computed, 'entity' => $entity, 'langfile' => $langfile, 'enabled' => $enabled, 'totalizable' => $totalizable, 'printable' => $printable);
+					$reshook = $hookmanager->executeHooks('afterUpdateExtraField', $parameters, $this); // Note that $action and $object may have been modified by some hooks
+					if ($reshook < 0) {
+						$this->error = $this->db->lasterror();
+
+						return -1;
+					}
 					return 1;
 				} else {
 					$this->error = $this->db->lasterror();
@@ -1035,24 +1074,24 @@ class ExtraFields
 		$array_name_label = array();
 
 		// We should not have several time this request. If we have, there is some optimization to do by calling a simple $extrafields->fetch_optionals() in top of code and not into subcode
-		$sql = "SELECT rowid, name, label, type, size, elementtype, fieldunique, fieldrequired, param, pos, alwayseditable, perms, langs, list, printable, totalizable, fielddefault, fieldcomputed, entity, enabled, help, aiprompt,";
-		$sql .= " css, cssview, csslist";
+		$sql = "SELECT e.rowid, e.name, e.label, e.type, e.size, e.elementtype, e.fieldunique, e.fieldrequired, e.param, e.pos, e.alwayseditable, e.perms, e.langs, e.list, e.printable, e.totalizable, e.fielddefault, e.fieldcomputed, e.entity, e.enabled, e.help, e.aiprompt,";
+		$sql .= " e.css, e.cssview, e.csslist";
 		$parameters = ['elementtype' => $elementtype, 'forceload' => $forceload, 'attrname' => $attrname];
 		$hookmanager->executeHooks('printExtrafieldsSelect', $parameters, $this, $action);
 		$sql .= $hookmanager->resPrint;
-		$sql .= " FROM ".$this->db->prefix()."extrafields";
+		$sql .= " FROM ".$this->db->prefix()."extrafields as e";
 		$hookmanager->executeHooks('printExtrafieldsFrom', $parameters, $this, $action);
 		$sql .= $hookmanager->resPrint;
 		//$sql.= " WHERE entity IN (0,".$conf->entity.")";    // Filter is done later
 		if ($elementtype && $elementtype != 'all') {
-			$sql .= " WHERE elementtype = '".$this->db->escape($elementtype)."'"; // Filed with object->table_element
+			$sql .= " WHERE e.elementtype = '".$this->db->escape($elementtype)."'"; // Filed with object->table_element
 		}
 		if ($attrname && $elementtype && $elementtype != 'all') {
-			$sql .= " AND name = '".$this->db->escape($attrname)."'";
+			$sql .= " AND e.name = '".$this->db->escape($attrname)."'";
 		}
 		$hookmanager->executeHooks('printExtrafieldsWhere', $parameters, $this, $action);
 		$sql .= $hookmanager->resPrint;
-		$sql .= " ORDER BY pos";
+		$sql .= " ORDER BY e.pos";
 
 		$resql = $this->db->query($sql);
 		if ($resql) {

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1011,7 +1011,8 @@ class ExtraFields
 	public function fetch_name_optionals_label($elementtype, $forceload = false, $attrname = '')
 	{
 		// phpcs:enable
-		global $conf;
+		global $conf, $hookmanager;
+		$hookmanager->initHooks(array('extrafieldsdao'));
 
 		if (empty($elementtype)) {
 			return array();
@@ -1036,7 +1037,12 @@ class ExtraFields
 		// We should not have several time this request. If we have, there is some optimization to do by calling a simple $extrafields->fetch_optionals() in top of code and not into subcode
 		$sql = "SELECT rowid, name, label, type, size, elementtype, fieldunique, fieldrequired, param, pos, alwayseditable, perms, langs, list, printable, totalizable, fielddefault, fieldcomputed, entity, enabled, help, aiprompt,";
 		$sql .= " css, cssview, csslist";
+		$parameters = ['elementtype' => $elementtype, 'forceload' => $forceload, 'attrname' => $attrname];
+		$hookmanager->executeHooks('printExtrafieldsSelect', $parameters, $this, $action);
+		$sql .= $hookmanager->resPrint;
 		$sql .= " FROM ".$this->db->prefix()."extrafields";
+		$hookmanager->executeHooks('printExtrafieldsFrom', $parameters, $this, $action);
+		$sql .= $hookmanager->resPrint;
 		//$sql.= " WHERE entity IN (0,".$conf->entity.")";    // Filter is done later
 		if ($elementtype && $elementtype != 'all') {
 			$sql .= " WHERE elementtype = '".$this->db->escape($elementtype)."'"; // Filed with object->table_element
@@ -1044,6 +1050,8 @@ class ExtraFields
 		if ($attrname && $elementtype && $elementtype != 'all') {
 			$sql .= " AND name = '".$this->db->escape($attrname)."'";
 		}
+		$hookmanager->executeHooks('printExtrafieldsWhere', $parameters, $this, $action);
+		$sql .= $hookmanager->resPrint;
 		$sql .= " ORDER BY pos";
 
 		$resql = $this->db->query($sql);
@@ -1088,7 +1096,11 @@ class ExtraFields
 					$this->attributes[$tab->elementtype]['css'][$tab->name] = $tab->css;
 					$this->attributes[$tab->elementtype]['cssview'][$tab->name] = $tab->cssview;
 					$this->attributes[$tab->elementtype]['csslist'][$tab->name] = $tab->csslist;
-
+					$parameters = array('tab' => $tab);
+					$reshook = $hookmanager->executeHooks('loadExtrafieldsAttributes', $parameters, $this, $action);
+					if ($reshook > 0) {
+						$this->attributes[$tab->elementtype] = $hookmanager->resArray[$tab->elementtype];
+					}
 					$this->attributes[$tab->elementtype]['loaded'] = 1;
 					$count++;
 				}

--- a/htdocs/core/tpl/admin_extrafields_add.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_add.tpl.php
@@ -282,6 +282,12 @@ print $formadmin->selectTypeOfFields('type', GETPOST('type', 'alpha'));
 	<!-- Multicompany entity -->
 	<tr><td><?php echo $langs->trans("AllEntities"); ?></td><td class="valeur"><input id="entitycurrentorall" type="checkbox" name="entitycurrentorall"<?php echo(GETPOST('entitycurrentorall', 'alpha') ? ' checked' : ''); ?>></td></tr>
 <?php } ?>
+
+<?php
+$parameters = [];
+$hookmanager->executeHooks('formObjectOptions', $parameters, $extrafields, $action); // Note that $action and $object may have been modified by hook
+print $hookmanager->resPrint;
+?>
 </table>
 
 <?php print dol_get_fiche_end(); ?>

--- a/htdocs/core/tpl/admin_extrafields_edit.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_edit.tpl.php
@@ -370,7 +370,11 @@ if (in_array($type, array_keys($typewecanchangeinto))) {
 	<?php echo dol_escape_htmltag((string) $enabled); ?>
 <?php } ?>
 </td></tr>
-
+<?php
+$parameters = [];
+$hookmanager->executeHooks('formObjectOptions', $parameters, $extrafields, $action); // Note that $action and $object may have been modified by hook
+print $hookmanager->resPrint;
+?>
 </table>
 
 <?php print dol_get_fiche_end(); ?>

--- a/htdocs/core/tpl/admin_extrafields_view.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_view.tpl.php
@@ -104,7 +104,7 @@ if (isModEnabled('multicompany')) {
 	print '<td class="center">'.$langs->trans("Entity").'</td>';
 }
 $parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListTitle', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+$reshook = $hookmanager->executeHooks('printFieldListTitle', $parameters, $extrafields, $action); // Note that $action and $object may have been modified by hook
 print $hookmanager->resPrint;
 // Action column
 if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {

--- a/htdocs/core/tpl/admin_extrafields_view.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_view.tpl.php
@@ -103,6 +103,9 @@ print '<td class="center">'.$form->textwithpicto($langs->trans("CssOnList"), $la
 if (isModEnabled('multicompany')) {
 	print '<td class="center">'.$langs->trans("Entity").'</td>';
 }
+$parameters = array();
+$reshook = $hookmanager->executeHooks('printFieldListTitle', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+print $hookmanager->resPrint;
 // Action column
 if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 	print '<td width="80">&nbsp;</td>';
@@ -196,6 +199,10 @@ if (isset($extrafields->attributes[$elementtype]['type']) && is_array($extrafiel
 			}
 			print '</td>';
 		}
+
+		$parameters = array('key' => $key, 'value' => $value);
+		$reshook = $hookmanager->executeHooks('printFieldListValue', $parameters, $extrafields, $action); // Note that $action and $object may have been modified by hook
+		print $hookmanager->resPrint;
 		// Actions
 		if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 			print '<td class="right nowraponall">';


### PR DESCRIPTION
# New add extrafields hook points for enhanced customization
    - Introduced multiple new hook points (`printFieldListTitle`, `printFieldListValue`, `formObjectOptions`, `loadExtrafieldsAttributes`, etc.) to allow enhanced customization and extension of extrafields functionalities.
    - Updated templates and extrafields class to execute hooks for additional flexibility in rendering and data manipulation.
    - Ensured backward compatibility with existing extrafields implementations.