### PR TITLE
FIX: Mo::deleteLine() - stock movement correction

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -1,8 +1,9 @@
 <?php
-/* Copyright (C) 2017  Laurent Destailleur <eldy@users.sourceforge.net>
- * Copyright (C) 2020  Lenin Rivas		   <lenin@leninrivas.com>
- * Copyright (C) 2023-2024  Frédéric France     <frederic.france@free.fr>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2017		Laurent Destailleur		<eldy@users.sourceforge.net>
+ * Copyright (C) 2020		Lenin Rivas				<lenin@leninrivas.com>
+ * Copyright (C) 2023-2024  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2025		Noé Cendrier			<noe.cendrier@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -919,75 +920,74 @@ class Mo extends CommonObject
 
 		$this->db->begin();
 
-		if (!empty($arrayoflines)) {
-			// If there is child lines
+		if (!empty($fk_movement) || !empty($arrayoflines)) {
 			$stockmove = new MouvementStock($this->db);
 			$stockmove->setOrigin($this->element, $this->id);
+		}
 
-			if (!empty($fk_movement)) {
-				// The fk_movement was not recorded so we try to guess the product and quantity to restore.
-				$moline = new MoLine($this->db);
-				$TArrayMoLine = $moline->fetchAll('', '', 1, 0, '(fk_stock_movement:=:'.((int) $fk_movement).')');
-				$moline = array_shift($TArrayMoLine);
+		if (!empty($fk_movement)) {
+			// The fk_movement was not recorded so we try to guess the product and quantity to restore.
+			$moline = new MoLine($this->db);
+			$TArrayMoLine = $moline->fetchAll('', '', 1, 0, '(fk_stock_movement:=:'.((int) $fk_movement).')');
+			$moline = array_shift($TArrayMoLine);
 
-				$movement = new MouvementStock($this->db);
-				$movement->fetch($fk_movement);
-				$productstatic->fetch($movement->product_id);
-				$qtytoprocess = $movement->qty;
+			$movement = new MouvementStock($this->db);
+			$movement->fetch($fk_movement);
+			$productstatic->fetch($movement->product_id);
+			$qtytoprocess = $movement->qty;
+
+			// Reverse stock movement
+			$labelmovementCancel = $langs->trans("CancelProductionForRef", $productstatic->ref);
+			$codemovementCancel = $langs->trans("StockIncrease");
+
+			if (($qtytoprocess >= 0)) {
+				$idstockmove = $stockmove->reception($user, $movement->product_id, $movement->warehouse_id, $qtytoprocess, 0, $labelmovementCancel, '', '', $movement->batch, dol_now(), 0, $codemovementCancel);
+			} else {
+				$idstockmove = $stockmove->livraison($user, $movement->product_id, $movement->warehouse_id, $qtytoprocess, 0, $labelmovementCancel, dol_now(), '', '', $movement->batch, 0, $codemovementCancel);
+			}
+			if ($idstockmove < 0) {
+				$this->error++;
+				setEventMessages($stockmove->error, $stockmove->errors, 'errors');
+			} else {
+				$result = $moline->delete($user, $notrigger);
+			}
+		} elseif (!empty($arrayoflines)) {
+			// Loop on each child lines
+			foreach ($arrayoflines as $key => $arrayofline) {
+				$lineDetails = $arrayoflines[$key];
+				$productstatic->fetch($lineDetails['fk_product']);
+				$qtytoprocess = $lineDetails['qty'];
 
 				// Reverse stock movement
 				$labelmovementCancel = $langs->trans("CancelProductionForRef", $productstatic->ref);
 				$codemovementCancel = $langs->trans("StockIncrease");
 
-				if (($qtytoprocess >= 0)) {
-					$idstockmove = $stockmove->reception($user, $movement->product_id, $movement->warehouse_id, $qtytoprocess, 0, $labelmovementCancel, '', '', $movement->batch, dol_now(), 0, $codemovementCancel);
+
+				if ($qtytoprocess >= 0) {
+					$idstockmove = $stockmove->reception($user, $lineDetails['fk_product'], $lineDetails['fk_warehouse'], $qtytoprocess, 0, $labelmovementCancel, '', '', $lineDetails['batch'], dol_now(), 0, $codemovementCancel);
 				} else {
-					$idstockmove = $stockmove->livraison($user, $movement->product_id, $movement->warehouse_id, $qtytoprocess, 0, $labelmovementCancel, dol_now(), '', '', $movement->batch, 0, $codemovementCancel);
+					$idstockmove = $stockmove->livraison($user, $lineDetails['fk_product'], $lineDetails['fk_warehouse'], $qtytoprocess, 0, $labelmovementCancel, dol_now(), '', '', $lineDetails['batch'], 0, $codemovementCancel);
 				}
 				if ($idstockmove < 0) {
 					$this->error++;
 					setEventMessages($stockmove->error, $stockmove->errors, 'errors');
 				} else {
-					$result = $moline->delete($user, $notrigger);
-				}
-			} else {
-				// Loop on each child lines
-				foreach ($arrayoflines as $key => $arrayofline) {
-					$lineDetails = $arrayoflines[$key];
-					$productstatic->fetch($lineDetails['fk_product']);
-					$qtytoprocess = $lineDetails['qty'];
+					$moline = new MoLine($this->db);
+					$moline->fetch($lineDetails['rowid']);
 
-					// Reverse stock movement
-					$labelmovementCancel = $langs->trans("CancelProductionForRef", $productstatic->ref);
-					$codemovementCancel = $langs->trans("StockIncrease");
-
-
-					if ($qtytoprocess >= 0) {
-						$idstockmove = $stockmove->reception($user, $lineDetails['fk_product'], $lineDetails['fk_warehouse'], $qtytoprocess, 0, $labelmovementCancel, '', '', $lineDetails['batch'], dol_now(), 0, $codemovementCancel);
-					} else {
-						$idstockmove = $stockmove->livraison($user, $lineDetails['fk_product'], $lineDetails['fk_warehouse'], $qtytoprocess, 0, $labelmovementCancel, dol_now(), '', '', $lineDetails['batch'], 0, $codemovementCancel);
-					}
-					if ($idstockmove < 0) {
+					$resdel = $moline->delete($user, $notrigger);
+					if ($resdel < 0) {
 						$this->error++;
-						setEventMessages($stockmove->error, $stockmove->errors, 'errors');
-					} else {
-						$moline = new MoLine($this->db);
-						$moline->fetch($lineDetails['rowid']);
-
-						$resdel = $moline->delete($user, $notrigger);
-						if ($resdel < 0) {
-							$this->error++;
-							setEventMessages($moline->error, $moline->errors, 'errors');
-						}
+						setEventMessages($moline->error, $moline->errors, 'errors');
 					}
-				}
-
-				if (empty($this->error)) {
-					$result = $this->deleteLineCommon($user, $idline, $notrigger);
 				}
 			}
+
+			if (empty($this->error)) {
+				$result = $this->deleteLineCommon($user, $idline, $notrigger);
+			}
 		} else {
-			// No child lines
+			// No child lines and no associated movement
 			$result = $this->deleteLineCommon($user, $idline, $notrigger);
 		}
 

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -2,8 +2,9 @@
 /* Copyright (C) 2019-2020 	Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 		Christian Humpel     <christian.humpel@gmail.com>
  * Copyright (C) 2023 		Vincent de Grandpré  <vincent@de-grandpre.quebec>
- * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024       Frédéric France      <frederic.france@free.fr>
+ * Copyright (C) 2024		MDW					 <mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2025		Noé Cendrier		 <noe.cendrier@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1239,8 +1240,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 							print '</td>';
 						}
 
-						// Action delete line
-						if ($permissiontodelete) {
+						// Action delete line, if no consumption has occured for this product
+						if ($permissiontodelete && empty($arrayoflines)) {
 							$href = $_SERVER["PHP_SELF"] . '?id=' . ((int) $object->id) . '&action=deleteline&token=' . newToken() . '&lineid=' . ((int) $line->id);
 							print '<td class="center">';
 							print '<a class="reposition" href="' . $href . '">';


### PR DESCRIPTION
# FIX: Mo::deleteLine() - stock movement correction should not rely on linked lines

When we have to delete an MoLine from the mo_production page, we might remove a line with the `toconsume` role (which seems like a terrible idea to me), in which case we want to restock the `consumed` role lines which are linked. Hence the `$this->fetchLinesLinked`

But we can also remove a `consumed` role line (if we made an error in qty, typically)

<img width="899" height="115" alt="image" src="https://github.com/user-attachments/assets/19a6ddde-51e8-4d71-970e-16b8014136de" />

In which case, there are no line linked. Currently, that means there is no correcting stock movement generated, which is an obvious problem.

I deleted several `consumed` lines here

<img width="814" height="682" alt="image" src="https://github.com/user-attachments/assets/1308ad28-eaf1-45ca-b627-3dc3600cc20a" />

But before I made the modifications here proposed, no increasing stock movement where created, until after I changed the code

<img width="1587" height="535" alt="image" src="https://github.com/user-attachments/assets/ae7ec753-b7b2-4995-8046-0fe16b6b4dfd" />

As we can see, only two products out of eight were restocked.

