### PR TITLE
FIX accountancy closure: if subledger_label is not found, accountancy is never closed.

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -2822,7 +2822,7 @@ class BookKeeping extends CommonObject
 								$error++;
 							}
 							$objtmp = $this->db->fetch_object($result);
-							$bookkeeping->subledger_label = $objtmp->subledger_label; // latest subledger label used
+							$bookkeeping->subledger_label = $objtmp->subledger_label ?? null; // latest subledger label used
 						} else {
 							$bookkeeping->subledger_account = null;
 							$bookkeeping->subledger_label = null;


### PR DESCRIPTION
# FIX : accountancy closure would not be closed if a subledger label is missing

In Bookkeeping::closeFiscalPeriod, if we search for a subledger label that does not exist, the SQL query returns empty data. But `$result` evaluates to true.
As a consequence, $objtmp->subledger_label does not exist and PHP8.2 throws an error.

