### PR TITLE
Correction for the generation of the bankjournal for a paiement for different third parties

### DIFF
--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -298,9 +298,6 @@ if ($result) {
 		// Set accountancy code for thirdparty (example: '411CU...' or '411' if no subledger account defined on customer)
 		$compta_soc = 'NotDefined';
 		$accountancy_code_general = 'NotDefined';
-
-		$socid = $obj->socid;	// the socid concerned by the current row
-
 		if ($lineisapurchase > 0) {
 			$accountancy_code_general = (!empty($obj->accountancy_code_supplier_general) && $obj->accountancy_code_supplier_general != '-1') ? $obj->accountancy_code_supplier_general : $account_supplier;
 			$compta_soc = (($obj->code_compta_fournisseur != "") ? $obj->code_compta_fournisseur : $account_supplier);
@@ -365,9 +362,10 @@ if ($result) {
 			$amounttouse = $obj->amount_main_currency;
 		}
 
-		// in case of paiement multi-third parties ( one payments for different third parties bills with same parent company)
-		// because in this case $obj-amount = the total of the paiement and not the paiement for each company part
-		if ($lineisapurchase == 1 || $lineisasale == 1) {
+		// in case option FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS is on, payment could be for more than one third-partie
+		// so we have to find wich part of the payment is affected to each third-parties
+		// (because in this case $obj-amount = the total of the paiement and not the paiement for each third-parties)
+		if (getDolGlobalString('FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS') && ($lineisapurchase == 1 || $lineisasale == 1) ) {
 			if ($lineisapurchase == 1) {
 				$sqlamount = "SELECT SUM(pf.amount) as amount";
 				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
@@ -454,11 +452,18 @@ if ($result) {
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];
 					$tabpay[$obj->rowid]["soclib"] = $societestatic->getNomUrl(1, '', 30);
-					if ($compta_soc && $socid == $links[$key]['url_id']) {	// we have to add $amoutouse only if the line $links[$key] correspond to socid
-						if (empty($tabtp[$obj->rowid][$compta_soc])) {
-							$tabtp[$obj->rowid][$compta_soc] = $amounttouse;
-						} else {
-							$tabtp[$obj->rowid][$compta_soc] += $amounttouse;
+					if ($compta_soc) {	
+						// because we are in 2 loop (loop on the line from the sql queries and loop on $links)
+						// and in case of option FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS is on,
+						// we will pass here n times for each payment line
+						// so we have to add $amoutouse only if the line $links[$key] correspond to the payment line we are in used ( socid correspondinf at the payment line $links)
+						// if FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS is off we add $amounttouse
+						if (!getDolGlobalString('FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS') || $obj->socid == $links[$key]['url_id']){
+							if (empty($tabtp[$obj->rowid][$compta_soc])) {
+								$tabtp[$obj->rowid][$compta_soc] = $amounttouse;
+							} else {
+								$tabtp[$obj->rowid][$compta_soc] += $amounttouse;
+							}
 						}
 					}
 				} elseif ($links[$key]['type'] == 'user') {

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -452,7 +452,7 @@ if ($result) {
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];
 					$tabpay[$obj->rowid]["soclib"] = $societestatic->getNomUrl(1, '', 30);
-					if ($compta_soc) {	
+					if ($compta_soc) {
 						// because we are in 2 loop (loop on the line from the sql queries and loop on $links)
 						// and in case of option FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS is on,
 						// we will pass here n times for each payment line

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -363,7 +363,7 @@ if ($result) {
 		}
 
 		// in case option FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS is on, payment could be for more than one third-partie
-		// so we have to find wich part of the payment is affected to each third-parties
+		// so we have to find which part of the payment is affected to each third-parties
 		// (because in this case $obj-amount = the total of the paiement and not the paiement for each third-parties)
 		if (getDolGlobalString('FACTURE_PAYMENTS_ON_DIFFERENT_THIRDPARTIES_BILLS') && ($lineisapurchase == 1 || $lineisasale == 1) ) {
 			if ($lineisapurchase == 1) {

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -298,9 +298,6 @@ if ($result) {
 		// Set accountancy code for thirdparty (example: '411CU...' or '411' if no subledger account defined on customer)
 		$compta_soc = 'NotDefined';
 		$accountancy_code_general = 'NotDefined';
-
-		$socid = $obj->socid;	// the socid concerned by the current row
-
 		if ($lineisapurchase > 0) {
 			$accountancy_code_general = (!empty($obj->accountancy_code_supplier_general) && $obj->accountancy_code_supplier_general != '-1') ? $obj->accountancy_code_supplier_general : $account_supplier;
 			$compta_soc = (($obj->code_compta_fournisseur != "") ? $obj->code_compta_fournisseur : $account_supplier);
@@ -363,30 +360,6 @@ if ($result) {
 		if (!empty($obj->amount_main_currency)) {
 			// If $obj->amount_main_currency is set, it means that $obj->amount is not in same currency, we must use $obj->amount_main_currency
 			$amounttouse = $obj->amount_main_currency;
-		}
-
-		// in case of paiement multi-third parties ( one payments for different third parties bills with same parent company)
-		// because in this case $obj-amount = the total of the paiement and not the paiement for each company part
-		if ($lineisapurchase == 1) {
-			$sqlamount = "SELECT SUM(pf.amount) as amount";
-			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
-			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
-			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
-			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
-		}
-		if ($lineisasale == 1 ) {
-			$sqlamount = "SELECT SUM(pf.amount) as amount";
-			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
-			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
-			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
-			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
-		}
-		if ($lineisapurchase == 1 || $lineisasale == 1) {
-			$resultamount = $db->query($sqlamount);
-			$objamount = $db->fetch_object($resultamount);
-			if (!empty($objamount->amount)) $amounttouse = $objamount->amount;
 		}
 
 		// get_url may return -1 which is not traversable
@@ -453,7 +426,7 @@ if ($result) {
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];
 					$tabpay[$obj->rowid]["soclib"] = $societestatic->getNomUrl(1, '', 30);
-					if ($compta_soc && $socid == $links[$key]['url_id']) {	// we have to add $amoutouse only if the line $links[$key] correspond to socid
+					if ($compta_soc) {
 						if (empty($tabtp[$obj->rowid][$compta_soc])) {
 							$tabtp[$obj->rowid][$compta_soc] = $amounttouse;
 						} else {

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -373,8 +373,8 @@ if ($result) {
 				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
 				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
 				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
-				$sqlamount .= " WHERE p.fk_bank = " . ((int) $obj->rowid);
-				$sqlamount .= " AND f.fk_soc = " . ((int) $obj->socid);
+				$sqlamount .= " WHERE p.fk_bank = ".((int) $obj->rowid);
+				$sqlamount .= " AND f.fk_soc = ".((int) $obj->socid);
 			} else {
 				$sqlamount = "SELECT SUM(pf.amount) as amount";
 				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
@@ -384,8 +384,10 @@ if ($result) {
 				$sqlamount .= " AND f.fk_soc = ".((int) $obj->socid);
 			}
 			$resultamount = $db->query($sqlamount);
-			$objamount = $db->fetch_object($resultamount);
-			if (!empty($objamount->amount)) $amounttouse = $objamount->amount;
+			if ($resultamount) {
+				$objamount = $db->fetch_object($resultamount);
+				if (!empty($objamount->amount)) $amounttouse = $objamount->amount;
+			}
 		}
 
 		// get_url may return -1 which is not traversable

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -298,6 +298,7 @@ if ($result) {
 		// Set accountancy code for thirdparty (example: '411CU...' or '411' if no subledger account defined on customer)
 		$compta_soc = 'NotDefined';
 		$accountancy_code_general = 'NotDefined';
+		$socid = $obj->socid;
 		if ($lineisapurchase > 0) {
 			$accountancy_code_general = (!empty($obj->accountancy_code_supplier_general) && $obj->accountancy_code_supplier_general != '-1') ? $obj->accountancy_code_supplier_general : $account_supplier;
 			$compta_soc = (($obj->code_compta_fournisseur != "") ? $obj->code_compta_fournisseur : $account_supplier);
@@ -360,6 +361,31 @@ if ($result) {
 		if (!empty($obj->amount_main_currency)) {
 			// If $obj->amount_main_currency is set, it means that $obj->amount is not in same currency, we must use $obj->amount_main_currency
 			$amounttouse = $obj->amount_main_currency;
+		}
+
+		// in case of paiement multi-third parties ( one payments for different third parties bills with same parent company)
+		// 		because in this case $obj->amount = the total of the paiement and not the paiement for each company part
+		// 		and we need only the part for each company
+		if( $lineisapurchase == 1) {
+			$sqlamount = "SELECT SUM(pf.amount) as amount";
+			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
+			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
+			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
+			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
+			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+		}
+		if( $lineisasale == 1 ) {
+			$sqlamount = "SELECT SUM(pf.amount) as amount";
+			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
+			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
+			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
+			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
+			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+		}
+		if( $lineisapurchase == 1 || $lineisasale == 1) {
+			$resultamount = $db->query($sqlamount);
+			$objamount = $db->fetch_object($resultamount);
+			if( ! empty($objamount->amount)) $amounttouse = $objamount->amount;
 		}
 
 		// get_url may return -1 which is not traversable
@@ -426,7 +452,9 @@ if ($result) {
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];
 					$tabpay[$obj->rowid]["soclib"] = $societestatic->getNomUrl(1, '', 30);
-					if ($compta_soc) {
+					if ($compta_soc  && $socid == $links[$key]['url_id'] ) {	// we have to add only if $compta_soc is defined AND if $links[$key]['url_id'] is equal to socid 
+																				// (if not we will add $amounttouse as many times as there are third parties involved in the payment and this for each line. 
+																				// That is to say that if there are 2 third parties, we will double the amount compared to what we should find, triple it if there are 3 third parties...)
 						if (empty($tabtp[$obj->rowid][$compta_soc])) {
 							$tabtp[$obj->rowid][$compta_soc] = $amounttouse;
 						} else {

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -298,6 +298,9 @@ if ($result) {
 		// Set accountancy code for thirdparty (example: '411CU...' or '411' if no subledger account defined on customer)
 		$compta_soc = 'NotDefined';
 		$accountancy_code_general = 'NotDefined';
+
+		$socid = $obj->socid;	// the socid concerned by the current row
+
 		if ($lineisapurchase > 0) {
 			$accountancy_code_general = (!empty($obj->accountancy_code_supplier_general) && $obj->accountancy_code_supplier_general != '-1') ? $obj->accountancy_code_supplier_general : $account_supplier;
 			$compta_soc = (($obj->code_compta_fournisseur != "") ? $obj->code_compta_fournisseur : $account_supplier);
@@ -360,6 +363,30 @@ if ($result) {
 		if (!empty($obj->amount_main_currency)) {
 			// If $obj->amount_main_currency is set, it means that $obj->amount is not in same currency, we must use $obj->amount_main_currency
 			$amounttouse = $obj->amount_main_currency;
+		}
+
+		// in case of paiement multi-third parties ( one payments for different third parties bills with same parent company)
+		// because in this case $obj-amount = the total of the paiement and not the paiement for each company part
+		if ($lineisapurchase == 1 || $lineisasale == 1) {
+			if ($lineisapurchase == 1) {
+				$sqlamount = "SELECT SUM(pf.amount) as amount";
+				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
+				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
+				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
+				$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
+				$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+			}
+			if ($lineisasale == 1 ) {
+				$sqlamount = "SELECT SUM(pf.amount) as amount";
+				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
+				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
+				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
+				$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
+				$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+			}
+			$resultamount = $db->query($sqlamount);
+			$objamount = $db->fetch_object($resultamount);
+			if (!empty($objamount->amount)) $amounttouse = $objamount->amount;
 		}
 
 		// get_url may return -1 which is not traversable
@@ -426,7 +453,7 @@ if ($result) {
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];
 					$tabpay[$obj->rowid]["soclib"] = $societestatic->getNomUrl(1, '', 30);
-					if ($compta_soc) {
+					if ($compta_soc && $socid == $links[$key]['url_id']) {	// we have to add $amoutouse only if the line $links[$key] correspond to socid
 						if (empty($tabtp[$obj->rowid][$compta_soc])) {
 							$tabtp[$obj->rowid][$compta_soc] = $amounttouse;
 						} else {

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -375,8 +375,7 @@ if ($result) {
 				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
 				$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
 				$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
-			}
-			if ($lineisasale == 1 ) {
+			} else {
 				$sqlamount = "SELECT SUM(pf.amount) as amount";
 				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
 				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -374,14 +374,14 @@ if ($result) {
 				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
 				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
 				$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-				$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+				$sqlamount .= " AND f.fk_soc =".((int) $obj->socid);
 			} else {
 				$sqlamount = "SELECT SUM(pf.amount) as amount";
 				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
 				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
 				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
 				$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-				$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+				$sqlamount .= " AND f.fk_soc =".((int) $obj->socid);
 			}
 			$resultamount = $db->query($sqlamount);
 			$objamount = $db->fetch_object($resultamount);

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -373,15 +373,15 @@ if ($result) {
 				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
 				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
 				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
-				$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-				$sqlamount .= " AND f.fk_soc =".((int) $obj->socid);
+				$sqlamount .= " WHERE p.fk_bank = ".((int)$obj->rowid);
+				$sqlamount .= " AND f.fk_soc = ".((int) $obj->socid);
 			} else {
 				$sqlamount = "SELECT SUM(pf.amount) as amount";
 				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
 				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
 				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
-				$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-				$sqlamount .= " AND f.fk_soc =".((int) $obj->socid);
+				$sqlamount .= " WHERE p.fk_bank = ".((int)$obj->rowid);
+				$sqlamount .= " AND f.fk_soc = ".((int) $obj->socid);
 			}
 			$resultamount = $db->query($sqlamount);
 			$objamount = $db->fetch_object($resultamount);

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -373,14 +373,14 @@ if ($result) {
 				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
 				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
 				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
-				$sqlamount .= " WHERE p.fk_bank = ".((int)$obj->rowid);
-				$sqlamount .= " AND f.fk_soc = ".((int) $obj->socid);
+				$sqlamount .= " WHERE p.fk_bank = " . ((int) $obj->rowid);
+				$sqlamount .= " AND f.fk_soc = " . ((int) $obj->socid);
 			} else {
 				$sqlamount = "SELECT SUM(pf.amount) as amount";
 				$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
 				$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
 				$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
-				$sqlamount .= " WHERE p.fk_bank = ".((int)$obj->rowid);
+				$sqlamount .= " WHERE p.fk_bank = ".((int) $obj->rowid);
 				$sqlamount .= " AND f.fk_soc = ".((int) $obj->socid);
 			}
 			$resultamount = $db->query($sqlamount);

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -298,7 +298,6 @@ if ($result) {
 		// Set accountancy code for thirdparty (example: '411CU...' or '411' if no subledger account defined on customer)
 		$compta_soc = 'NotDefined';
 		$accountancy_code_general = 'NotDefined';
-		$socid = $obj->socid;
 		if ($lineisapurchase > 0) {
 			$accountancy_code_general = (!empty($obj->accountancy_code_supplier_general) && $obj->accountancy_code_supplier_general != '-1') ? $obj->accountancy_code_supplier_general : $account_supplier;
 			$compta_soc = (($obj->code_compta_fournisseur != "") ? $obj->code_compta_fournisseur : $account_supplier);
@@ -361,31 +360,6 @@ if ($result) {
 		if (!empty($obj->amount_main_currency)) {
 			// If $obj->amount_main_currency is set, it means that $obj->amount is not in same currency, we must use $obj->amount_main_currency
 			$amounttouse = $obj->amount_main_currency;
-		}
-
-		// in case of paiement multi-third parties ( one payments for different third parties bills with same parent company)
-		// 		because in this case $obj->amount = the total of the paiement and not the paiement for each company part
-		// 		and we need only the part for each company
-		if( $lineisapurchase == 1) {
-			$sqlamount = "SELECT SUM(pf.amount) as amount";
-			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
-			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
-			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
-			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
-		}
-		if( $lineisasale == 1 ) {
-			$sqlamount = "SELECT SUM(pf.amount) as amount";
-			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
-			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
-			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
-			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
-		}
-		if( $lineisapurchase == 1 || $lineisasale == 1) {
-			$resultamount = $db->query($sqlamount);
-			$objamount = $db->fetch_object($resultamount);
-			if( ! empty($objamount->amount)) $amounttouse = $objamount->amount;
 		}
 
 		// get_url may return -1 which is not traversable
@@ -452,9 +426,7 @@ if ($result) {
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];
 					$tabpay[$obj->rowid]["soclib"] = $societestatic->getNomUrl(1, '', 30);
-					if ($compta_soc  && $socid == $links[$key]['url_id'] ) {	// we have to add only if $compta_soc is defined AND if $links[$key]['url_id'] is equal to socid 
-																				// (if not we will add $amounttouse as many times as there are third parties involved in the payment and this for each line. 
-																				// That is to say that if there are 2 third parties, we will double the amount compared to what we should find, triple it if there are 3 third parties...)
+					if ($compta_soc) {
 						if (empty($tabtp[$obj->rowid][$compta_soc])) {
 							$tabtp[$obj->rowid][$compta_soc] = $amounttouse;
 						} else {

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -298,9 +298,6 @@ if ($result) {
 		// Set accountancy code for thirdparty (example: '411CU...' or '411' if no subledger account defined on customer)
 		$compta_soc = 'NotDefined';
 		$accountancy_code_general = 'NotDefined';
-
-		$socid = $obj->socid;	// the socid concerned by the current row
-		
 		if ($lineisapurchase > 0) {
 			$accountancy_code_general = (!empty($obj->accountancy_code_supplier_general) && $obj->accountancy_code_supplier_general != '-1') ? $obj->accountancy_code_supplier_general : $account_supplier;
 			$compta_soc = (($obj->code_compta_fournisseur != "") ? $obj->code_compta_fournisseur : $account_supplier);
@@ -363,30 +360,6 @@ if ($result) {
 		if (!empty($obj->amount_main_currency)) {
 			// If $obj->amount_main_currency is set, it means that $obj->amount is not in same currency, we must use $obj->amount_main_currency
 			$amounttouse = $obj->amount_main_currency;
-		}
-
-		// in case of paiement multi-third parties ( one payments for different third parties bills with same parent company)
-		// because in this case $obj-amount = the total of the paiement and not the paiement for each company part
-		if ($lineisapurchase == 1) {
-			$sqlamount = "SELECT SUM(pf.amount) as amount";
-			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
-			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
-			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
-			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
-		}
-		if ($lineisasale == 1 ) {
-			$sqlamount = "SELECT SUM(pf.amount) as amount";
-			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
-			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
-			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
-			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
-			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
-		}
-		if ($lineisapurchase == 1 || $lineisasale == 1) {
-			$resultamount = $db->query($sqlamount);
-			$objamount = $db->fetch_object($resultamount);
-			if( ! empty($objamount->amount)) $amounttouse = $objamount->amount;
 		}
 
 		// get_url may return -1 which is not traversable
@@ -453,7 +426,7 @@ if ($result) {
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];
 					$tabpay[$obj->rowid]["soclib"] = $societestatic->getNomUrl(1, '', 30);
-					if ($compta_soc && $socid == $links[$key]['url_id']) {	// we have to add $amoutouse only if the line $links[$key] correspond to socid
+					if ($compta_soc) {
 						if (empty($tabtp[$obj->rowid][$compta_soc])) {
 							$tabtp[$obj->rowid][$compta_soc] = $amounttouse;
 						} else {

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -298,6 +298,9 @@ if ($result) {
 		// Set accountancy code for thirdparty (example: '411CU...' or '411' if no subledger account defined on customer)
 		$compta_soc = 'NotDefined';
 		$accountancy_code_general = 'NotDefined';
+
+		$socid = $obj->socid;	// the socid concerned by the current row
+
 		if ($lineisapurchase > 0) {
 			$accountancy_code_general = (!empty($obj->accountancy_code_supplier_general) && $obj->accountancy_code_supplier_general != '-1') ? $obj->accountancy_code_supplier_general : $account_supplier;
 			$compta_soc = (($obj->code_compta_fournisseur != "") ? $obj->code_compta_fournisseur : $account_supplier);
@@ -360,6 +363,30 @@ if ($result) {
 		if (!empty($obj->amount_main_currency)) {
 			// If $obj->amount_main_currency is set, it means that $obj->amount is not in same currency, we must use $obj->amount_main_currency
 			$amounttouse = $obj->amount_main_currency;
+		}
+
+		// in case of paiement multi-third parties ( one payments for different third parties bills with same parent company)
+		// because in this case $obj-amount = the total of the paiement and not the paiement for each company part
+		if ($lineisapurchase == 1) {
+			$sqlamount = "SELECT SUM(pf.amount) as amount";
+			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
+			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
+			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
+			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
+			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+		}
+		if ($lineisasale == 1 ) {
+			$sqlamount = "SELECT SUM(pf.amount) as amount";
+			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
+			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
+			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
+			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
+			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+		}
+		if ($lineisapurchase == 1 || $lineisasale == 1) {
+			$resultamount = $db->query($sqlamount);
+			$objamount = $db->fetch_object($resultamount);
+			if (!empty($objamount->amount)) $amounttouse = $objamount->amount;
 		}
 
 		// get_url may return -1 which is not traversable
@@ -426,7 +453,7 @@ if ($result) {
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];
 					$tabpay[$obj->rowid]["soclib"] = $societestatic->getNomUrl(1, '', 30);
-					if ($compta_soc) {
+					if ($compta_soc && $socid == $links[$key]['url_id']) {	// we have to add $amoutouse only if the line $links[$key] correspond to socid
 						if (empty($tabtp[$obj->rowid][$compta_soc])) {
 							$tabtp[$obj->rowid][$compta_soc] = $amounttouse;
 						} else {

--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -298,6 +298,9 @@ if ($result) {
 		// Set accountancy code for thirdparty (example: '411CU...' or '411' if no subledger account defined on customer)
 		$compta_soc = 'NotDefined';
 		$accountancy_code_general = 'NotDefined';
+
+		$socid = $obj->socid;	// the socid concerned by the current row
+		
 		if ($lineisapurchase > 0) {
 			$accountancy_code_general = (!empty($obj->accountancy_code_supplier_general) && $obj->accountancy_code_supplier_general != '-1') ? $obj->accountancy_code_supplier_general : $account_supplier;
 			$compta_soc = (($obj->code_compta_fournisseur != "") ? $obj->code_compta_fournisseur : $account_supplier);
@@ -360,6 +363,30 @@ if ($result) {
 		if (!empty($obj->amount_main_currency)) {
 			// If $obj->amount_main_currency is set, it means that $obj->amount is not in same currency, we must use $obj->amount_main_currency
 			$amounttouse = $obj->amount_main_currency;
+		}
+
+		// in case of paiement multi-third parties ( one payments for different third parties bills with same parent company)
+		// because in this case $obj-amount = the total of the paiement and not the paiement for each company part
+		if ($lineisapurchase == 1) {
+			$sqlamount = "SELECT SUM(pf.amount) as amount";
+			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiementfounr_facturefourn AS pf";
+			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiementfourn AS p ON pf.fk_paiementfourn = p.rowid";
+			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facturefourn = f.rowid";
+			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
+			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+		}
+		if ($lineisasale == 1 ) {
+			$sqlamount = "SELECT SUM(pf.amount) as amount";
+			$sqlamount .= " FROM ".MAIN_DB_PREFIX."paiement_facture AS pf";
+			$sqlamount .= " INNER JOIN ".MAIN_DB_PREFIX."paiement AS p ON pf.fk_paiement = p.rowid";
+			$sqlamount .= " RIGHT JOIN ".MAIN_DB_PREFIX."facture AS f ON pf.fk_facture = f.rowid";
+			$sqlamount .= " WHERE p.fk_bank = '" . $obj->rowid . "'";
+			$sqlamount .= " AND f.fk_soc ='" . $obj->socid . "'";
+		}
+		if ($lineisapurchase == 1 || $lineisasale == 1) {
+			$resultamount = $db->query($sqlamount);
+			$objamount = $db->fetch_object($resultamount);
+			if( ! empty($objamount->amount)) $amounttouse = $objamount->amount;
 		}
 
 		// get_url may return -1 which is not traversable
@@ -426,7 +453,7 @@ if ($result) {
 					$societestatic->name = $links[$key]['label'];
 					$societestatic->email = $tabcompany[$obj->rowid]['email'];
 					$tabpay[$obj->rowid]["soclib"] = $societestatic->getNomUrl(1, '', 30);
-					if ($compta_soc) {
+					if ($compta_soc && $socid == $links[$key]['url_id']) {	// we have to add $amoutouse only if the line $links[$key] correspond to socid
 						if (empty($tabtp[$obj->rowid][$compta_soc])) {
 							$tabtp[$obj->rowid][$compta_soc] = $amounttouse;
 						} else {


### PR DESCRIPTION
In the case of use the option  "Allow payments on different third parties bills but same parent company", a payment can concern different third parties.
In this case, the actual bank journal generation is wrong because the total amount for the payment is used for each line. So if there is 2 lines, the payment line is doubled and each company line is quadrupled. If the payment concern 3 third parties, the payment line is tripled....

I've made a bug issue about it : https://github.com/Dolibarr/dolibarr/issues/34755

I propose here a correction for the amount of each line. The titled of each line should be also corrected but I didn't already do it