### PR TITLE
FIX : Correct rank when adding line on order

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1693,9 +1693,13 @@ class Commande extends CommonOrder
 				if (!empty($fk_parent_line)) {
 					$this->line_order(true, 'DESC');
 				} elseif ($ranktouse > 0 && $ranktouse <= count($this->lines)) { // Update all rank of all other lines
-					$linecount = count($this->lines);
-					for ($ii = $ranktouse; $ii <= $linecount; $ii++) {
-						$this->updateRangOfLine($this->lines[$ii - 1]->id, $ii + 1);
+					//TODO Réordonner le tableau this->lines en fonction du rang, il faut q'uen indice
+					foreach ($this->lines as $line) {
+						if ($line->rang >= $ranktouse) {
+							if (!empty($line->id)) {
+								$this->updateRangOfLine($line->id, $line->rang + 1);
+							}
+						}
 					}
 				}
 

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1693,7 +1693,6 @@ class Commande extends CommonOrder
 				if (!empty($fk_parent_line)) {
 					$this->line_order(true, 'DESC');
 				} elseif ($ranktouse > 0 && $ranktouse <= count($this->lines)) { // Update all rank of all other lines
-					//TODO Réordonner le tableau this->lines en fonction du rang, il faut q'uen indice
 					foreach ($this->lines as $line) {
 						if ($line->rang >= $ranktouse) {
 							if (!empty($line->id)) {


### PR DESCRIPTION
This PR addresses a critical bug in the rank update logic that occurs when a new item is inserted into a list.

The previous implementation used a `for` loop and assumed that the array index of an item corresponded to its rank (`$this->lines[$rank - 1]`). This assumption was unsafe, as the array is not guaranteed to be sorted by rank. This could lead to updating the wrong items, causing data inconsistency in the ranks.

### Changes Made

- Replaced the `for` loop with a `foreach` loop to iterate over the items.
- The logic now directly checks the `rank` property of each item (`$line->rank`) instead of relying on its array index.
- This ensures that only the correct items (those with a rank greater than or equal to the target rank) are updated.

The new implementation is more robust, predictable, and easier to understand.