### PR TITLE
fix fatale error Update card.php v20.0.2 regress

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1263,7 +1263,7 @@ if (empty($reshook)) {
 					}
 					if (!empty($newlang)) {
 						$outputlangs = new Translate("", $conf);
-						$outputlangs->setDefaultLang($newlang);
+						$outputlangs->setDefaultLang($newlang->defaultlang);
 					}
 
 					$object->generateDocument($object->model_pdf, $outputlangs, $hidedetails, $hidedesc, $hideref);

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1249,24 +1249,38 @@ if (empty($reshook)) {
 			if ($result > 0) {
 				$ret = $object->fetch($object->id); // Reload to get new records
 
-				if (!getDolGlobalString('MAIN_DISABLE_PDF_AUTOUPDATE')) {
-					// Define output language
+				if (! getDolGlobalString('MAIN_DISABLE_PDF_AUTOUPDATE')) {
+					// Langue de sortie par défaut : objet $langs (instance de Translate)
 					$outputlangs = $langs;
-					$newlang = GETPOST('lang_id', 'alpha');
+
+					// Récupère un code langue via GETPOST ou profil utilisateur
+					$newlang = GETPOST('lang_id', 'alpha'); // ex. "fr_FR"
 					if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-						$tmpuser = new User($db);
-						$tmpuser->fetch($object->fk_user_author);
-						$newlang = $tmpuser->lang;
-					}
-					if (empty($newlang)) {
-						$newlang = $langs->defaultlang;
-					}
-					if (!empty($newlang)) {
-						$outputlangs = new Translate("", $conf);
-						$outputlangs->setDefaultLang($newlang->defaultlang);
+						$user = new User($db);
+						if ($user->fetch($object->fk_user_author) > 0) {
+							$newlang = $user->lang;         // ex. "en_US"
+						}
 					}
 
-					$object->generateDocument($object->model_pdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
+					// Si toujours vide, on prend la langue par défaut de la conf
+					if (empty($newlang)) {
+						$newlang = $conf->global->MAIN_LANG_DEFAULT; // chaîne, ex. "fr_FR"
+					}
+
+					// Enfin, on force la langue de $outputlangs
+					if (! empty($newlang) && is_string($newlang)) {
+						$outputlangs = new Translate("", $conf);
+						$outputlangs->setDefaultLang($newlang);
+					}
+
+					// Génération du PDF
+					$object->generateDocument(
+						$object->model_pdf,
+						$outputlangs,
+						$hidedetails,
+						$hidedesc,
+						$hideref
+					);
 				}
 
 				unset($qty);


### PR DESCRIPTION

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[Fix erreur fatale 500 php > 8 avec $langpart = explode("_", $codetouse);]
[Fix fatale error in php > 8  


Fix erreur fatale 500 php > 8 avec $langpart = explode("_", $codetouse); deuxième argument de explode()) n’est pas une chaîne de caractères, mais un objet Translate. À partir de PHP 8, explode() ne tolère plus qu’on lui passe autre chose qu’une string Correction d'une erreur fatale 500 php > 8 avec $langpart = explosive("_", $codetouse); Le deuxième argument de burst()) n’est pas une chaîne de caractères, mais un objet Translate. À partir de PHP 8, explosive() ne tolère plus qu'on lui passe autre chose qu'une string]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# UIUX|Uiux [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

