### PR TITLE
FIX 17.0: unlink cloned invoice from model invoice

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1255,6 +1255,7 @@ class Facture extends CommonInvoice
 		$object->user_valid         = null; // deprecated
 		$object->fk_user_author     = $user->id;
 		$object->fk_user_valid      = null;
+		$object->fk_fac_rec_source  = null;
 		$object->fk_facture_source  = 0;
 		$object->date_creation      = '';
 		$object->date_modification = '';


### PR DESCRIPTION
# FIX: invoice clones should not be "generated from a model invoice"
Currently, when you clone an invoice that was generated from a model invoice, the clone is linked to the model too, which messes with the generation count and is not very logical, at least with the most common use cases we are aware of.

For instance, you clone FA12315, which was generated from MODEL_1234. As it currently stands in 17.0, you would have your clone (PROV1324124) "generated from MODEL_1234, which is not true, plus the number of invoices generated from the model would no longer match the field `nb_gen_done` , which might create bugs.