### PR TITLE
FIX 17.0 SQL errors in Facture::update()

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1238,7 +1238,7 @@ class Facture extends CommonInvoice
 				$object->socid = $objsoc->id;
 				$object->cond_reglement_id	= (!empty($objsoc->cond_reglement_id) ? $objsoc->cond_reglement_id : 0);
 				$object->mode_reglement_id	= (!empty($objsoc->mode_reglement_id) ? $objsoc->mode_reglement_id : 0);
-				$object->fk_project = '';
+				$object->fk_project = null;
 				$object->fk_delivery_address = '';
 			}
 
@@ -1255,7 +1255,7 @@ class Facture extends CommonInvoice
 		$object->user_valid         = null; // deprecated
 		$object->fk_user_author     = $user->id;
 		$object->fk_user_valid      = null;
-		$object->fk_facture_source  = 0;
+		$object->fk_facture_source  = null;
 		$object->date_creation      = '';
 		$object->date_modification = '';
 		$object->date_validation    = '';


### PR DESCRIPTION
# FIX 17.0 SQL errors in Facture::update()

## Summary
When emptying a field, it is better to use `null` rather than empty strings or zeroes: `update()` always handles `null` well, while other empty values can cause bugs.

## Long story
We wanted to implement [this fix](https://github.com/Dolibarr/dolibarr/pull/34777) as a trigger in our client-specific module, so we used a trigger (`billCreate`) for this.

```php
public function billCreate(string $action, Facture $invoice, User $user, Translate $langs, Conf $conf): int
{
if ($invoice->context['createfromclone'] === 'createfromclone') {
	$invoice->fk_fac_rec_source = null;
	if ($invoice->update($user) < 0) {
		setEventMessages($invoice->error, $invoice->errors, 'errors');
		return -1;
	}
}
 // [………]
```

We noticed there were syntax errors and foreign key constraint errors because `createFromClone()` and `update()` don't work well together:
- `createFromClone()` assigns `''` to `fk_projet` instead of `null`
- `createFromClone()` assigns `0` to `fk_facture_source` instead of `null`
- `update()` only checks for set values, not empty values, so since both values are set (though empty), they are concatenated using `$db->escape()`.
- the generated SQL can look like this:

```sql
UPDATE llx_facture SET […] fk_facture_source=0, fk_projet=, […] WHERE rowid=[…]
```