### PR TITLE
FIX : No order displayed in orders box

### DIFF
--- a/htdocs/core/boxes/box_commandes.php
+++ b/htdocs/core/boxes/box_commandes.php
@@ -121,7 +121,7 @@ class box_commandes extends ModeleBoxes
 			$result = $this->db->query($sql);
 			if ($result) {
 				$num = $this->db->num_rows($result);
-				
+
 				$line = 0;
 
 				while ($line < $num) {

--- a/htdocs/core/boxes/box_commandes.php
+++ b/htdocs/core/boxes/box_commandes.php
@@ -121,7 +121,7 @@ class box_commandes extends ModeleBoxes
 			$result = $this->db->query($sql);
 			if ($result) {
 				$num = $this->db->num_rows($result);
-				$num=0;
+				
 				$line = 0;
 
 				while ($line < $num) {


### PR DESCRIPTION
# FIX : No order displayed in orders box 
Remove the attribution to 0 for $num to avoid no orders displayed in the ordres box

