### PR TITLE
FIX|Fix #Hide mandatory DLC/DLUO options when disabled in product configuration

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1330,6 +1330,18 @@ if (isModEnabled('accounting')) {
 $sellOrEatByMandatoryList = null;
 if (isModEnabled('productbatch')) {
 	$sellOrEatByMandatoryList = Product::getSellOrEatByMandatoryList();
+	foreach ($sellOrEatByMandatoryList as $key => $label) {
+		$remove = false;
+		if (getDolGlobalString('PRODUCT_DISABLE_SELLBY') && (stripos($label, $langs->trans('SellByDate')) !== false)) {
+			$remove = true;
+		}
+		if (getDolGlobalString('PRODUCT_DISABLE_EATBY') && (stripos($label, $langs->trans('EatByDate')) !== false )) {
+			$remove = true;
+		}
+		if ($remove) {
+			unset($sellOrEatByMandatoryList[$key]);
+		}
+	}
 }
 
 $title = $langs->trans('ProductServiceCard');

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1337,12 +1337,10 @@ if (isModEnabled('productbatch')) {
 	if ($disableSellBy) {
 		unset($sellOrEatByMandatoryList[Product::SELL_OR_EAT_BY_MANDATORY_ID_SELL_BY]);
 		unset($sellOrEatByMandatoryList[Product::SELL_OR_EAT_BY_MANDATORY_ID_SELL_AND_EAT]);
-
 	}
 	if ($disableEatBy) {
 		unset($sellOrEatByMandatoryList[Product::SELL_OR_EAT_BY_MANDATORY_ID_EAT_BY]);
 		unset($sellOrEatByMandatoryList[Product::SELL_OR_EAT_BY_MANDATORY_ID_SELL_AND_EAT]);
-
 	}
 }
 

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1330,17 +1330,19 @@ if (isModEnabled('accounting')) {
 $sellOrEatByMandatoryList = null;
 if (isModEnabled('productbatch')) {
 	$sellOrEatByMandatoryList = Product::getSellOrEatByMandatoryList();
-	foreach ($sellOrEatByMandatoryList as $key => $label) {
-		$remove = false;
-		if (getDolGlobalString('PRODUCT_DISABLE_SELLBY') && (stripos($label, $langs->trans('SellByDate')) !== false)) {
-			$remove = true;
-		}
-		if (getDolGlobalString('PRODUCT_DISABLE_EATBY') && (stripos($label, $langs->trans('EatByDate')) !== false )) {
-			$remove = true;
-		}
-		if ($remove) {
-			unset($sellOrEatByMandatoryList[$key]);
-		}
+
+	$disableSellBy = getDolGlobalString('PRODUCT_DISABLE_SELLBY');
+	$disableEatBy  = getDolGlobalString('PRODUCT_DISABLE_EATBY');
+
+	if ($disableSellBy) {
+		unset($sellOrEatByMandatoryList[Product::SELL_OR_EAT_BY_MANDATORY_ID_SELL_BY]);
+		unset($sellOrEatByMandatoryList[Product::SELL_OR_EAT_BY_MANDATORY_ID_SELL_AND_EAT]);
+
+	}
+	if ($disableEatBy) {
+		unset($sellOrEatByMandatoryList[Product::SELL_OR_EAT_BY_MANDATORY_ID_EAT_BY]);
+		unset($sellOrEatByMandatoryList[Product::SELL_OR_EAT_BY_MANDATORY_ID_SELL_AND_EAT]);
+
 	}
 }
 


### PR DESCRIPTION
# FIX|Fix #Hide mandatory DLC/DLUO options when disabled in product configuration

When one or both of the global configurations PRODUCT_DISABLE_SELLBY (for DLC) and PRODUCT_DISABLE_EATBY (for DMD/DLUO) are enabled, the corresponding options are now hidden from the "mandatory DLC/DLUO" dropdown in the product creation and modification forms. This fix ensures that users can no longer select a value that has been globally disabled, which prevents any potential configuration inconsistencies. The select list is now dynamically filtered to only show options that are relevant according to the current global settings.

