### PR TITLE
FIX product API PUT response (v21.0.2 + v22)

### DIFF
--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2019		Cedric Ancelin			<icedo.anc@gmail.com>
  * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2025		William Mead			<william@m34d.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -424,8 +425,10 @@ class Products extends DolibarrApi
 				if ($this->product->tva_npr != $oldproduct->tva_npr) {
 					$pricemodified = true;
 				}
-				if ($this->product->default_vat_code != $oldproduct->default_vat_code) {
-					$pricemodified = true;
+				if (!empty($this->product->default_vat_code)) {
+					if ($this->product->default_vat_code != $oldproduct->default_vat_code) {
+						$pricemodified = true;
+					}
 				}
 
 				if ($this->product->price_base_type == 'TTC') {


### PR DESCRIPTION
# FIX product API PUT response (v21.0.2 + v22)
In the case a product does not have a defined `default_vat_code` property the API PUT route generates the following PHP warning : 
```
PHP Warning:  Undefined property: stdClass::$default_vat_code in xxx/htdocs/product/class/api_products.class.php on line 427, referer https://xxx/api/index.php/explorer/
```
The product is still updated but this error generates an empty response from the API call which makes errors in third party software handling API calls. Example of bad response using Dolibarr Swagger UI:
<img width="1003" height="298" alt="Capture d’écran 2025-07-30 à 11 45 53" src="https://github.com/user-attachments/assets/67ffee78-ef36-4a28-9ff2-b4a3533c89c0" />

This fix adds a check on `default_vat_code` property in the product API `put` method