### PR TITLE
FIX product API DELETE response (v21.0.2 + v22)

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2022   	Open-Dsi				<support@open-dsi.fr>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2025       William Mead            <william@m34d.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -479,9 +480,15 @@ class ProductCombination
 	 */
 	public function deleteByFkProductParent($user, $fk_product_parent)
 	{
+		$combinations = $this->fetchAllByFkProductParent($fk_product_parent);
+
+		if (!is_array($combinations)) { // No combinations found, return success
+			return 1;
+		}
+
 		$this->db->begin();
 
-		foreach ($this->fetchAllByFkProductParent($fk_product_parent) as $prodcomb) {
+		foreach ($combinations as $prodcomb) {
 			$prodstatic = new Product($this->db);
 
 			$res = $prodstatic->fetch($prodcomb->fk_product_child);


### PR DESCRIPTION
# FIX product API DELETE response (v21.0.2 + v22)
In the case a product does not have any product combinations the API DELETE route generates the following PHP warning :
```
PHP Warning:  foreach() argument must be of type array|object, int given in xxx/htdocs/variants/class/ProductCombination.class.php on line 484, referer https://xxx/api/index.php/explorer/
```
The product is still deleted but this error generates an empty response from the API call which makes errors in third party software handling API calls. Example of bad response using Dolibarr Swagger UI:
<img width="987" height="300" alt="Capture d’écran 2025-07-30 à 12 29 10" src="https://github.com/user-attachments/assets/73c68fb2-c410-457a-b128-52cf5b5bf901" />
This fix adds a check in `deleteByFkProductParent` method from `ProductCombination` class to make sure `foreach` is passed an array or returns if no combinations found.