### PR TITLE
fix: fix download and preview for thirdparty document tab (backport fix PR #34833)

### DIFF
--- a/htdocs/societe/document.php
+++ b/htdocs/societe/document.php
@@ -183,10 +183,11 @@ print '</div>';
 
 print dol_get_fiche_end();
 
-$modulepart = 'societe';
+$modulepart = 'company';
 $permissiontoadd = $user->hasRight('societe', 'creer');
 $permtoedit = $user->hasRight('societe', 'creer');
 $param = '&id='.$object->id;
+$relativepathwithnofile = $object->id . '/';
 include DOL_DOCUMENT_ROOT.'/core/tpl/document_actions_post_headers.tpl.php';
 
 // End of page


### PR DESCRIPTION
Fix issue : https://github.com/Dolibarr/dolibarr/issues/34815 but also in 20.0
With the same code as in PR https://github.com/Dolibarr/dolibarr/pull/34833 merged in 21.0