### PR TITLE
FIX: extrafields of type "int" not displayed on `projet/tasks.php`

### DIFF
--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -56,7 +56,7 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 					}
 					$value = $datenotinstring;
 				} elseif (in_array($extrafields->attributes[$extrafieldsobjectkey]['type'][$key], array('int'))) {
-					$value = (!empty($obj->$tmpkey) || $obj->$tmpkey === '0'  ? $obj->$tmpkey : '');
+					$value = $obj->$tmpkey ?? (isset($obj->array_options[$tmpkey]) ? $obj->array_options[$tmpkey] : null) ?? '';
 				} else {
 					// The key may be in $obj->array_options if not in $obj
 					$value = (isset($obj->$tmpkey) ? $obj->$tmpkey :
@@ -71,7 +71,7 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 					}
 				}
 
-				$valuetoshow = $extrafields->showOutputField($key, $value, '', $extrafieldsobjectkey, null, $object);
+				$valuetoshow = $extrafields->showOutputField($key, $value, '', $extrafieldsobjectkey, null, $object ?? null);
 				$title = dol_string_nohtmltag($valuetoshow);
 
 				print '<td'.($cssclass ? ' class="'.$cssclass.'"' : '');	// TODO Add 'css' and 'cssview' and 'csslist' for extrafields and use here 'csslist'


### PR DESCRIPTION
# FIX: extrafields of type "int" not displayed in `projet/tasks.php`

<img width="410" height="338" alt="image" src="https://github.com/user-attachments/assets/604789da-eb60-4bbb-9078-36944c639e97" />

A nice-to-have would also be for extrafield columns to be sortable (our "priority" extrafield is less useful if tasks can't be sorted by it).

Note: this only happens on `projet/tasks.php`: if you go to the list of tasks (`projet/tasks/list.php`), the extrafield column is displayed correctly and is sortable / filterable.