### PR TITLE
fix: with MAIN_MAIL_ADD_INLINE_IMAGES_IF_IN_MEDIAS and multicompany image are not find on send mail

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -270,7 +270,7 @@ class CMailFile
 				// This convert an embedd file with src="/viewimage.php?modulepart... into a cid link
 				// TODO Exclude viewimage used for the read tracker ?
 				$dolibarr_main_data_root_images=$dolibarr_main_data_root;
-				if ($conf->entity!==1) {
+				if ((int)$conf->entity!==1) {
 					$dolibarr_main_data_root_images.='/'.$conf->entity.'/';
 				}
 				$findimg = $this->findHtmlImages($dolibarr_main_data_root_images.'/medias');


### PR DESCRIPTION

Following #34894, missing catch to (int) for $conf->entity. Seems to not always be an int (but can be string)....

