### PR TITLE
Bug Fix: Livraison date not store when call funciton Livraison on htdocs/fourn/class/fournisseur.commande.class.php

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2697,6 +2697,7 @@ class CommandeFournisseur extends CommonOrder
 
 				$sql = "UPDATE ".$this->db->prefix()."commande_fournisseur";
 				$sql .= " SET fk_statut = ".((int) $statut);
+				$sql .= ",date_livraison = ".($date ? "'".$this->db->idate($date)."'" : 'null');
 				$sql .= " WHERE rowid = ".((int) $this->id);
 				$sql .= " AND fk_statut IN (".self::STATUS_ORDERSENT.",".self::STATUS_RECEIVED_PARTIALLY.")"; // Process running or Partially received
 


### PR DESCRIPTION
Currenty we have: public function Livraison($user, $date, $type, $comment) on "htdocs/fourn/class/fournisseur.commande.class.php"

https://github.com/Dolibarr/dolibarr/blob/1fb37db6f6005cd7c76abefcd7560eb05c671ca2/htdocs/fourn/class/fournisseur.commande.class.php#L2636

but $date is unused so we don't know when the good is full received, so this patch to fix it so we can have date livration data.
this will update field: llx_commande_fournisseur->date_livraison