### PR TITLE
Fix bug unit prefix on Unit field in product

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -6762,7 +6762,7 @@ class Product extends CommonObject
 			dol_syslog(get_class($this)."::getLabelOfUnit Error ".$this->error, LOG_ERR);
 			return -1;
 		} elseif ($this->db->num_rows($resql) > 0 && $res = $this->db->fetch_array($resql)) {
-			$label = ($label_type == 'short_label' ? $res[$label_type] : $res['code']);
+			$label =  $res[$label_type] ? $res[$label_type] : '';
 		}
 		$this->db->free($resql);
 

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -6762,7 +6762,7 @@ class Product extends CommonObject
 			dol_syslog(get_class($this)."::getLabelOfUnit Error ".$this->error, LOG_ERR);
 			return -1;
 		} elseif ($this->db->num_rows($resql) > 0 && $res = $this->db->fetch_array($resql)) {
-			$label = ($label_type == 'short_label' ? $res[$label_type] : 'unit'.$res['code']);
+			$label = ($label_type == 'short_label' ? $res[$label_type] : $res['code']);
 		}
 		$this->db->free($resql);
 


### PR DESCRIPTION
When we enable PRODUCT_USE_UNITS global setting, we allow to select unit on the product. but the problem when display data always have prefix 'unit', this patch will fix it.

<img width="835" height="470" alt="image" src="https://github.com/user-attachments/assets/3fda4335-357d-4f5f-bb5c-31433dc70991" />
