### PR TITLE
Fix error sortorder on product variant

### DIFF
--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1349,7 +1349,7 @@ if (!$variants || getDolGlobalString('VARIANT_ALLOW_STOCK_MOVEMENT_ON_VARIANT_PA
 	// load variants
 	$title = $langs->trans("ProductCombinations");
 
-	print_barre_liste($title, 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, '', 0);
+	print_barre_liste($title, 0, $_SERVER["PHP_SELF"], '', '', '', '', 0);
 
 	print '<div class="div-table-responsive">'; ?>
 	<table class="liste">


### PR DESCRIPTION
Bug fix error on product variant list:
Warning: Undefined variable $sortfield in \htdocs\product\stock\product.php on line 1352
Warning: Undefined variable $sortorder in \htdocs\product\stock\product.php on line 1352