### PR TITLE
FIX #35011 Computed extrafield on tasks list now display correct values

### DIFF
--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -600,6 +600,7 @@ function projectLinesa(&$inc, $parent, &$lines, &$level, $var, $showproject, &$t
 {
 	global $user, $langs, $conf, $db, $hookmanager;
 	global $projectstatic, $taskstatic, $extrafields;
+	global $objectoffield;
 
 	$lastprojectid = 0;
 
@@ -936,6 +937,7 @@ function projectLinesa(&$inc, $parent, &$lines, &$level, $var, $showproject, &$t
 				$extrafieldsobjectkey = $taskstatic->table_element;
 				$extrafieldsobjectprefix = 'efpt.';
 				$obj = $lines[$i];
+				$object = $lines[$i];
 				include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_print_fields.tpl.php';
 				// Fields from hook
 				$parameters = array('arrayfields' => $arrayfields, 'obj' => $lines[$i]);


### PR DESCRIPTION
# FIX #35011 Computed extrafield on tasks list now display correct values

Two seemingly unrelated changes were necessary to fix the bug described in the issue.

The functions assigns value to `$obj` on line 976, but doesn't assign value to `$object`. But it's `$object` that is then assigned to `$objectoffield` in line 75 of `extrafields_list_print_fields.tpl.php`. `$objectoffield` is the recommended value to use for computed extrafields, according to the docs. First fix was to add this assignment. I let the assignment to `$obj` because it's also used for other kinds of extrafields in the included tpl file.

But assigning `$object` is not enough, because `$objectoffield` at this moment is not grabbed from the global scope, so the value stays local and `dol_eval()` doesn't find it. So it also needs to grab the variable from the global scope to affect it correctly. Hence the call to `global $objectoffield` added at the beginning of the function.

The changed function, `projectLinesa()` is called only twice in the project: by itself recursively to go through all subtasks, and on the page where I detected the bug initially, `tasks.php`, so the impact should be minimal.

Bug is also present on V21, V22, and V23-alpha. Let me know if I should send several PR for those versions (CONTRIBUTING.md is a little vague on this point). Be advised, my simple fix seems to work on branch V22, but it seems it wasn't enough to fix the problem in V23, I haven't figured out why though.