### PR TITLE
FIX #34857 Structured communication number checksum is now always correct

### DIFF
--- a/htdocs/core/lib/functions_be.lib.php
+++ b/htdocs/core/lib/functions_be.lib.php
@@ -64,7 +64,7 @@ function dolBECalculateStructuredCommunication($invoice_number, $invoice_type)
 	$controlKey = ($mod97 === 0) ? 97 : $mod97;
 
 	// Add the check digit at the end of the reference
-	$invoice_number .= sprintf("%02d",$controlKey);
+	$invoice_number .= sprintf("%02d", $controlKey);
 
 	// Format reference as XXX/XXXX/XXXXX
 	$part1 = '+++'.substr($invoice_number, 0, 3);

--- a/htdocs/core/lib/functions_be.lib.php
+++ b/htdocs/core/lib/functions_be.lib.php
@@ -64,7 +64,7 @@ function dolBECalculateStructuredCommunication($invoice_number, $invoice_type)
 	$controlKey = ($mod97 === 0) ? 97 : $mod97;
 
 	// Add the check digit at the end of the reference
-	$invoice_number .= $controlKey;
+	$invoice_number .= sprintf("%02d",$controlKey);
 
 	// Format reference as XXX/XXXX/XXXXX
 	$part1 = '+++'.substr($invoice_number, 0, 3);

--- a/test/phpunit/FunctionsBELibTest.php
+++ b/test/phpunit/FunctionsBELibTest.php
@@ -1,0 +1,63 @@
+<?php
+/* Copyright (C) 2010-2014 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2015	   Juanjo Menent		<jmenent@2byte.es>
+ * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/FunctionsLibTest.php
+ *		\ingroup    test
+ *      \brief      PHPUnit test
+ *		\remarks	To run this script as CLI:  phpunit filename.php
+ */
+
+global $conf,$user,$langs,$db,$mysoc;
+//define('TEST_DB_FORCE_TYPE','mysql');	// This is to force using mysql driver
+//require_once 'PHPUnit/Autoload.php';
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+require_once dirname(__FILE__).'/../../htdocs/core/lib/functions_be.lib.php';
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class FunctionsBELibTest extends CommonClassTest
+{
+
+	/**
+	 * testDolNow
+	 *
+	 * @return	void
+	 */
+	public function testdolBECalculateStructuredCommunication()
+	{
+        // Basic test
+        $this->assertEquals(dolBECalculateStructuredCommunication('00000000', '99'), '+++000/0000/00097+++');
+
+        // Test given in issue
+		$this->assertEquals(dolBECalculateStructuredCommunication('it-comp-25057', '0'), '+++200/0025/05702+++');
+
+        // Random test
+        $this->assertEquals(dolBECalculateStructuredCommunication('FA3698-5455', '0'), '+++203/6985/45505+++');
+	}
+
+}

--- a/test/phpunit/FunctionsBELibTest.php
+++ b/test/phpunit/FunctionsBELibTest.php
@@ -50,14 +50,14 @@ class FunctionsBELibTest extends CommonClassTest
 	 */
 	public function testdolBECalculateStructuredCommunication()
 	{
-        // Basic test
-        $this->assertEquals(dolBECalculateStructuredCommunication('00000000', '99'), '+++000/0000/00097+++');
+		// Basic test
+		$this->assertEquals(dolBECalculateStructuredCommunication('00000000', '99'), '+++000/0000/00097+++');
 
-        // Test given in issue
+		// Test given in issue
 		$this->assertEquals(dolBECalculateStructuredCommunication('it-comp-25057', '0'), '+++200/0025/05702+++');
 
-        // Random test
-        $this->assertEquals(dolBECalculateStructuredCommunication('FA3698-5455', '0'), '+++203/6985/45505+++');
+		// Random test
+		$this->assertEquals(dolBECalculateStructuredCommunication('FA3698-5455', '0'), '+++203/6985/45505+++');
 	}
 
 }

--- a/test/phpunit/FunctionsBELibTest.php
+++ b/test/phpunit/FunctionsBELibTest.php
@@ -59,5 +59,4 @@ class FunctionsBELibTest extends CommonClassTest
 		// Random test
 		$this->assertEquals(dolBECalculateStructuredCommunication('FA3698-5455', '0'), '+++203/6985/45505+++');
 	}
-
 }


### PR DESCRIPTION
FIX #34857 Structured communication number checksum is now always correct

This is a PR to merge the fix proposed by @vlandru in #34857. Upon verification and reproduction on my side, I could confirm the code is bad when the result of the modulo operation is less than 10. Adding the `sprintf()` makes sure the result number is always two digits long.

I also created a phpunit test file to make sure the bug can be caught earlier next time. As the 21.0 branch is supposedly frozen, I don't know if that's the good thing to do. Let me know if you want me to do another PR to add the unit test file only in develop.
