### PR TITLE
FIX Treasury accountancy - Accounting errors for members

### DIFF
--- a/htdocs/accountancy/journal/treasuryjournal.php
+++ b/htdocs/accountancy/journal/treasuryjournal.php
@@ -4,11 +4,12 @@
  * Copyright (C) 2011       Juanjo Menent           <jmenent@2byte.es>
  * Copyright (C) 2012       Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2013       Christophe Battarel     <christophe.battarel@altairis.fr>
- * Copyright (C) 2013-2021  Alexandre Spangaro      <aspangaro@open-dsi.fr>
+ * Copyright (C) 2013-2025	Alexandre Spangaro		<alexandre@inovea-conseil.com>
  * Copyright (C) 2013-2014  Florian Henry           <florian.henry@open-concept.pro>
  * Copyright (C) 2013-2014  Olivier Geffroy         <jeff@jeffinfo.com>
  * Copyright (C) 2017-2025  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2018		Ferran Marcet		    <fmarcet@2byte.es>
+ * Copyright (C) 2025		Hannes Hieronimi		<hannes@innwerk.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -976,7 +977,7 @@ if ($resql) {
 				$sql .= " bu.fk_bank, bu.url_id AS bu_url_id, bu.type AS bu_type";
 				$sql .= " FROM ".$db->prefix()."subscription as su";
 				$sql .= " INNER JOIN ".$db->prefix()."adherent as adh ON adh.rowid = su.fk_adherent";
-				$sql .= " INNER JOIN ".$db->prefix()."bank_url as bu ON bu.url_id = su.rowid AND bu.type = '".$db->escape($type)."'";
+				$sql .= " INNER JOIN ".$db->prefix()."bank_url as bu ON bu.fk_bank = su.fk_bank AND bu.type = '".$db->escape($type)."'";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
 					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=su.rowid";
@@ -1004,7 +1005,7 @@ if ($resql) {
 						// Add object in payment
 						if (!isset($tabpay[$obj->fk_bank]['objects'][$object_key])) {
 							$tabpay[$obj->fk_bank]['objects'][$object_key] = array(
-								'amount' => -$obj->amount_payment,
+								'amount' => $obj->amount_payment,
 								'bu_url_id' => $obj->bu_url_id,
 							);
 						}


### PR DESCRIPTION
Copy of #34740 for CI problem integration

Need this PR #35098 for CI problem integration

FIX Treasury accountancy - Accounting errors for members
In the original plugin the https://github.com/Dolibarr/dolibarr/pull/33701 is based on, I discovered two errors while using the plugin. [I fixed them](https://gitlab.com/innwerk/treasuryaccounting) in the plugin source and figured there where not merged back into the upstream project.

---------------------------------------------------

1) SQL join condition for bank URL
The join condition for matching different tables used the wrong identifier. As the result, the wrong bank transactions were used in the accountancy.

2) swapped credit/debit in member case
A sign error switched credit/debit for member contributions.