### PR TITLE
FIX hidden conf MAIN_DISABLE_ACCENT_INSENSITIVE_SEARCH does the opposite of what its name suggests

### DIFF
--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -501,7 +501,7 @@ function ajax_combobox($htmlname, $events = array(), $minLengthToAutocomplete = 
 	$msg = "\n".'<!-- JS CODE TO ENABLE '.$tmpplugin.' for id = '.$htmlname.' -->'."\n";
 	$msg .= "<script>\n";
 
-	if (getDolGlobalString('MAIN_DISABLE_ACCENT_INSENSITIVE_SEARCH')) {
+	if (!getDolGlobalString('MAIN_DISABLE_ACCENT_INSENSITIVE_SEARCH')) {
 		$msg .= '
 			// lowercase + remove accents
 			function normalizeString(str) {


### PR DESCRIPTION
# FIX
The PR #34933 is very useful, but there was a little mistake: the hidden conf's name is `DISABLE` but it actually *enables* the diacritic-insensitive search.

This fix just adds a `!` (that way, diacritic-insensitive search is the default, and setting the conf disables it).

### Possible alternative
An alternative would be to rename the conf:
- `MAIN_ENABLE_ACCENT_INSENSITIVE_SEARCH`
- or `MAIN_DISABLE_ACCENT_SENSITIVE_SEARCH` (but I find it less obvious)
