### PR TITLE
FIX intervention API add line duration v22+

### DIFF
--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -52,7 +52,7 @@ class Interventions extends DolibarrApi
 	public static $FIELDSLINE = array(
 		'description',
 		'date',
-		'duree',
+		'duration',
 	);
 
 	/**


### PR DESCRIPTION
# FIX intervention API add line duration v22+
With commit bea27b0b mandatory duration field in payload now needs to be `duration` instead of `duree`

