### PR TITLE
NEW: generate renewal proposal for contracts

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -92,6 +92,7 @@ $action = GETPOST('action', 'aZ09');
 $cancel = GETPOST('cancel', 'alpha');
 $origin = GETPOST('origin', 'alpha');
 $originid = GETPOSTINT('originid');
+$renewal = GETPOST('renewal');	// for contract renewal
 $confirm = GETPOST('confirm', 'alpha');
 $backtopage = GETPOST('backtopage', 'alpha'); // Go back to a dedicated page
 $lineid = GETPOSTINT('lineid');
@@ -606,11 +607,14 @@ if (empty($reshook)) {
 						$element = $subelement = 'expedition';
 					}
 
-					$object->origin = $origin;
-					$object->origin_id = $originid;
+					// If this is a renewal proposal for a contract, we might choose to systematically create a new contract,
+					if (($origin != 'contrat' || $renewal != 'true') && !getDolGlobalInt('CONTRACT_NEW_CONTRACT_ON_RENEWAL')) {
+						$object->origin = $origin;
+						$object->origin_id = $originid;
 
-					// Possibility to add external linked objects with hooks
-					$object->linked_objects[$object->origin] = $object->origin_id;
+						// Possibility to add external linked objects with hooks
+						$object->linked_objects[$object->origin] = $object->origin_id;
+					}
 					if (GETPOSTISARRAY('other_linked_objects')) {
 						$object->linked_objects = array_merge($object->linked_objects, GETPOST('other_linked_objects', 'array:int'));
 					}
@@ -664,6 +668,15 @@ if (empty($reshook)) {
 								}
 								if ($lines[$i]->date_end) {
 									$date_end = $lines[$i]->date_end;
+								}
+
+								// For a contract renewal, we report duration, starting after the end of contract
+								if ($origin == 'contrat' && $renewal == 'true') {
+									if ($lines[$i]->date_start && $lines[$i]->date_end) {
+										$duration = $lines[$i]->date_end - $lines[$i]->date_start;
+										$date_start = $lines[$i]->date_end + 86400;
+										$date_end = $date_start + $duration;
+									}
 								}
 
 								// Reset fk_parent_line for no child products and special product
@@ -2326,6 +2339,9 @@ if ($action == 'create') {
 	if ($origin != 'project' && $originid) {
 		print '<input type="hidden" name="origin" value="' . $origin . '">';
 		print '<input type="hidden" name="originid" value="' . $originid . '">';
+		if ($origin == 'contrat' && !empty($renewal)) {
+			print '<input type="hidden" name="renewal" value="' . $renewal . '">';
+		}
 	} elseif ($origin == 'project' && !empty($projectid)) {
 		print '<input type="hidden" name="projectid" value="' . $projectid . '">';
 	}

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -2306,6 +2306,16 @@ if ($action == 'create') {
 						'enabled' => true,
 					);
 				}
+				if (isModEnabled('propal') && $object->status > 0 && $soc->client == 1) {
+					$arrayofcreatebutton[] = array(
+						'attr' => array('style' => 'text-align: left;'),
+						'url' => '/comm/propal/card.php?action=create&origin='.$object->element.'&originid='.$object->id.'&socid='.$object->thirdparty->id.'&renewal=true',
+						'label' => $langs->trans('AddRenewalProp'),
+						'lang' => 'propal',
+						'perm' => $user->hasRight('propale', 'creer') ? true : false,
+						'enabled' => true,
+					);
+				}
 				if (count($arrayofcreatebutton)) {
 					unset($params['attr']['title']);
 					print dolGetButtonAction('', $langs->trans("Create"), 'default', $arrayofcreatebutton, '', true, $params);

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -2278,6 +2278,16 @@ if ($action == 'create') {
 
 				// Create ... buttons
 				$arrayofcreatebutton = array();
+				if (isModEnabled('propal') && $object->status > 0 && $soc->client == 1) {
+					$arrayofcreatebutton[] = array(
+						'attr' => array('style' => 'text-align: left;'),
+						'url' => '/comm/propal/card.php?action=create&origin='.$object->element.'&originid='.$object->id.'&socid='.$object->thirdparty->id.'&renewal=true',
+						'label' => $langs->trans('AddProp'),
+						'lang' => 'propal',
+						'perm' => $user->hasRight('propale', 'creer') ? true : false,
+						'enabled' => true,
+					);
+				}
 				if (isModEnabled('order') && $object->status > 0 && $object->nbofservicesclosed < $nbofservices) {
 					$arrayofcreatebutton[] = array(
 						'url' => '/commande/card.php?action=create&token='.newToken().'&origin='.$object->element.'&originid='.$object->id.'&socid='.$object->thirdparty->id,
@@ -2303,16 +2313,6 @@ if ($action == 'create') {
 						'label' => $langs->trans('AddSupplierInvoice'),
 						'lang' => 'bills',
 						'perm' => $user->hasRight('fournisseur', 'facture', 'creer') ? true : false,
-						'enabled' => true,
-					);
-				}
-				if (isModEnabled('propal') && $object->status > 0 && $soc->client == 1) {
-					$arrayofcreatebutton[] = array(
-						'attr' => array('style' => 'text-align: left;'),
-						'url' => '/comm/propal/card.php?action=create&origin='.$object->element.'&originid='.$object->id.'&socid='.$object->thirdparty->id.'&renewal=true',
-						'label' => $langs->trans('AddRenewalProp'),
-						'lang' => 'propal',
-						'perm' => $user->hasRight('propale', 'creer') ? true : false,
 						'enabled' => true,
 					);
 				}

--- a/htdocs/langs/en_US/propal.lang
+++ b/htdocs/langs/en_US/propal.lang
@@ -14,6 +14,7 @@ DeleteProp=Delete commercial proposal
 ValidateProp=Validate commercial proposal
 CancelPropal=Cancel
 AddProp=Create proposal
+AddRenewalProp=Create renewal proposal
 ConfirmDeleteProp=Are you sure you want to delete this commercial proposal?
 ConfirmValidateProp=Are you sure you want to validate this commercial proposal under name <b>%s</b>?
 ConfirmCancelPropal=Are you sure you want to cancel commercial proposal <b>%s</b>?

--- a/htdocs/langs/fr_FR/propal.lang
+++ b/htdocs/langs/fr_FR/propal.lang
@@ -14,6 +14,7 @@ DeleteProp=Supprimer proposition
 ValidateProp=Valider proposition
 CancelPropal=Annuler
 AddProp=Créer une proposition
+AddRenewalProp=Créer une proposition de renouvellement
 ConfirmDeleteProp=Êtes-vous sûr de vouloir effacer cette proposition commerciale ?
 ConfirmValidateProp=Êtes-vous sûr de vouloir valider cette proposition commerciale sous la référence <b>%s</b> ?
 ConfirmCancelPropal=Êtes-vous sûr de vouloir annuler la proposition commerciale <b>%s</b>?


### PR DESCRIPTION
# NEW: generate renewal proposal for contracts
When we use contracts, we might want to renew and offer a new deal to our clients.

Here, we add a new create button for a new proposal for our clients:

<img width="1620" height="483" alt="image" src="https://github.com/user-attachments/assets/b1840ae7-85b1-4b7f-bbc9-661c8be237da" />

And, when we create the new proposal, the service(s) are renewed for the same amount of time, starting the day after the end of current contract:

<img width="1596" height="261" alt="image" src="https://github.com/user-attachments/assets/90e62ea3-1af8-4847-9f18-59b782f718e4" />
