### PR TITLE
new: add fitid column in llx_bank_import

### DIFF
--- a/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
+++ b/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
@@ -104,4 +104,6 @@ ALTER TABLE llx_subscription ADD INDEX idx_subscription_fk_adherent (fk_adherent
 ALTER TABLE llx_subscription ADD INDEX idx_subscription_fk_bank (fk_bank);
 ALTER TABLE llx_subscription ADD INDEX idx_subscription_dateadh (dateadh);
 
+ALTER TABLE llx_bank_import ADD COLUMN fitid varchar(255) NULL after id_account; -- OFX Financial Institution Transaction ID "FITID"
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_bank_import-bank.sql
+++ b/htdocs/install/mysql/tables/llx_bank_import-bank.sql
@@ -23,6 +23,7 @@ CREATE TABLE llx_bank_import
 (
   rowid                 integer         AUTO_INCREMENT PRIMARY KEY,
   id_account			integer			NOT NULL,              	-- bank account ID in Dolibarr
+  fitid					varchar(255)	NULL,              		-- OFX Financial Institution Transaction ID "FITID"
   record_type 			varchar(64)   	NULL,                  	-- OFX Type of transaction: DIRECTDEBIT, XFER, OTHER or code/type of operation
   label         		varchar(255)  	NOT NULL,               -- label of operation
   record_type_origin  	varchar(255)  	NOT NULL,               -- operation code/type origin


### PR DESCRIPTION
close : #35127 

In OFX Specification :
 https://financialdataexchange.org/common/Uploaded%20files/OFX%20files/OFX%20Banking%20Specification%20v2.3.pdf (page 84)

 the unique identifier of a transaction is <FITID>

For now, only add this column, no constraint unique or index, because only export in OFX or CMI give this information