### PR TITLE
Fix: Ctrl+Click on checkbox did not preserve multi-selection behavior

### DIFF
--- a/htdocs/admin/tools/ui/experimental/experiments/intuitive-select/index.php
+++ b/htdocs/admin/tools/ui/experimental/experiments/intuitive-select/index.php
@@ -313,6 +313,9 @@ $form = new Form($db);
 					}
 				</style>
 				<script nonce="<?php echo getNonce(); ?>" >
+					/**
+					 * TODO : when include this code in core of Dolibarr, add it to a js file note directly in page
+					 * */
 					$(function() {
 
 						/**
@@ -342,6 +345,25 @@ $form = new Form($db);
 							if (e.ctrlKey) {
 								e.stopPropagation();
 							}
+						});
+
+						$(document).on("mousedown click", ".row-with-select input.checkforselect", function (e) {
+							// Prevents automatic change of “checked”
+							e.preventDefault();
+							e.stopPropagation(); // parent click trigger will be done below
+
+							let parentRow = $(this).closest(".row-with-select");
+
+							// this part of code prevent weird behavior when user (ctrl or maj) + click directly on checkbox
+							// We simulate a click on the parent line
+							parentRow.trigger({
+								type: "click",
+								ctrlKey: !e.shiftKey, // simulate ctrlKey click will automatically prop activate the checkbox with parent event but not if shift key is pressed.
+								metaKey: !e.shiftKey, // simulate metaKey click will automatically prop activate the checkbox with parent event but not if shift key is pressed.
+								shiftKey: e.shiftKey,
+								originalEvent: e
+							});
+
 						});
 
 						$(document).on("click", ".row-with-select", function (e) {


### PR DESCRIPTION
See #33566 , #34807

# In english
#### Bug usage case

When users wanted to select multiple rows with **Ctrl+Click** (or **Cmd+Click** on macOS), the behavior worked correctly if they clicked on the **row** itself.

⚠️ However, if they clicked directly on the **checkbox (`.checkforselect`) while holding Ctrl/Cmd**, the checkbox would briefly toggle and then instantly revert to its previous state.

This created an **inconsistent user experience**: the same gesture (Ctrl+Click) had different outcomes depending on whether the user clicked on the row or on the checkbox.

#### Fix

* Intercepted `Ctrl+Click` and `Shift+Click` events on checkboxes.
* Simulated a click on the parent row so that checkbox clicks behave the same as row clicks.
* Ensured consistent selection logic:

  * **Normal Click** → toggles checkbox normally.
  * **Ctrl/Cmd+Click** → adds/removes row from the multi-selection.
  * **Shift+Click** → selects a range between the last clicked row and the current one.

This brings the UX in line with standard multi-selection patterns (Windows Explorer, macOS Finder, Gmail, etc.).

# En francais

#### Cas d’usage du bug

Lorsqu’un utilisateur voulait sélectionner plusieurs lignes avec **Ctrl + Click**, le comportement était correct quand il cliquait directement sur la **ligne**.

⚠️ Mais si l’utilisateur cliquait **directement sur la case à cocher (`.checkforselect`) en maintenant Ctrl**, la checkbox se cochait/décochait brièvement puis revenait immédiatement à son état initial.

* Cela créait une **incohérence d’expérience utilisateur** : le même geste (Ctrl+Click) ne donnait pas le même résultat selon qu’on clique sur la ligne ou sur la case.
* Impossible donc d’utiliser les cases à cocher pour faire une multisélection comme dans un explorateur de fichiers classique (Windows, macOS, Gmail, etc.).

---

### ✅ Après correction

* **Ctrl/Cmd+Click sur la case** = même comportement que sur la ligne (ajoute/retire la ligne de la sélection multiple).
* **Shift+Click sur la case** = sélection d’une plage entre la dernière ligne sélectionnée et la ligne actuelle.
* **Click normal sur la case** = coche/décoche naturellement, sans altérer la logique de sélection multiple.


