### PR TITLE
Fix 35142

### DIFF
--- a/htdocs/core/ajax/objectonoff.php
+++ b/htdocs/core/ajax/objectonoff.php
@@ -122,6 +122,9 @@ if (($action == 'set') && !empty($id)) {	// Test on permission already done in h
 	if ($triggerkey == 'PRODUCT_UPDATE') {
 		$triggerkey = 'PRODUCT_MODIFY';
 	}
+    if ($triggerkey == 'PRODUCT_MODIFY') {
+        unset($object->module);
+    }
 
 	$result = $object->setValueFrom($field, $value, $object->table_element, $id, $format, '', $user, $triggerkey);
 


### PR DESCRIPTION
# FIX #35142 
[Setting product on/off sell or on/off buy with small buttons top right of the card doesn't create an event in product card]

This solution works, but I don't know if it's the good approach to solve the bug ....