### PR TITLE
FIX #35147 SQL Error on Beluga Export when ExpenseReport is enabled

### DIFF
--- a/htdocs/core/modules/project/doc/pdf_beluga.modules.php
+++ b/htdocs/core/modules/project/doc/pdf_beluga.modules.php
@@ -428,7 +428,7 @@ class pdf_beluga extends ModelePDFProjects
 						'table' => 'expensereport',
 						'datefieldname' => 'date_debut',
 						'margin' => 'minus',
-						'disableamount' => 1,
+						'disableamount' => 0,
 						'test' => isModEnabled('expensereport') && $user->hasRight('expensereport', 'lire'),
 						'lang' => 'trip'),
 					'agenda' => array(
@@ -643,6 +643,9 @@ class pdf_beluga extends ModelePDFProjects
 									}
 									if (empty($date)) {
 										$date = $element->datev; // Intervention card
+									}
+									if (empty($date)) {
+										$date = $element->date_debut; // Expense report
 									}
 								}
 

--- a/htdocs/core/modules/project/doc/pdf_beluga.modules.php
+++ b/htdocs/core/modules/project/doc/pdf_beluga.modules.php
@@ -465,7 +465,7 @@ class pdf_beluga extends ModelePDFProjects
 					}
 
 					//var_dump("$key, $tablename, $datefieldname, $dates, $datee");
-					$elementarray = $object->get_element_list($key, $tablename, $datefieldname, null, null, $projectField);
+					$elementarray = $object->get_element_list($key, $tablename, $datefieldname, 0, 0, $projectField);
 
 					$num = count($elementarray);
 					if ($num >= 0) {

--- a/htdocs/core/modules/project/doc/pdf_beluga.modules.php
+++ b/htdocs/core/modules/project/doc/pdf_beluga.modules.php
@@ -465,7 +465,7 @@ class pdf_beluga extends ModelePDFProjects
 					}
 
 					//var_dump("$key, $tablename, $datefieldname, $dates, $datee");
-					$elementarray = $object->get_element_list($key, $tablename, $datefieldname, 0, 0, $projectField);
+					$elementarray = $object->get_element_list($key, $tablename, $datefieldname, null, null, $projectField);
 
 					$num = count($elementarray);
 					if ($num >= 0) {

--- a/htdocs/core/modules/project/doc/pdf_beluga.modules.php
+++ b/htdocs/core/modules/project/doc/pdf_beluga.modules.php
@@ -426,7 +426,7 @@ class pdf_beluga extends ModelePDFProjects
 						'title' => "ListExpenseReportsAssociatedProject",
 						'class' => 'ExpenseReport',
 						'table' => 'expensereport',
-						'datefieldname' => 'dated',
+						'datefieldname' => 'date_debut',
 						'margin' => 'minus',
 						'disableamount' => 1,
 						'test' => isModEnabled('expensereport') && $user->hasRight('expensereport', 'lire'),


### PR DESCRIPTION
# FIX #35147 SQL Error on Beluga Export when ExpenseReport is enabled

Fixed a SQL error on printing a Beluga export when expensereport module is enabled. This was due to `datefieldname` referencing an unknown `dated` column, instead of `date_debut`.

Also, on v21, I couldn't ever get any line displayed for any referenced object (propal, invoice, expense report, etc). This was due to `0` being sent to  `get_element_list()`, causing the SQL filter to look like `dated BETWEEN '1970-01-01' AND '1970-01-01'`, thus giving 0 results. Passing `null` instead removes completely the date filter and allows lines to be displayed correctly.

Added bonus, that could be removed if we consider it inappropriate to put on an already-released version: Columns Date and Amount are now filled in for Expense report lines (both were not shown before)


