### PR TITLE
FIX #35154 - Massaction createbills in reception list don't mind about order and/or thirdparty currency

### DIFF
--- a/htdocs/langs/en_US/receptions.lang
+++ b/htdocs/langs/en_US/receptions.lang
@@ -54,3 +54,4 @@ RestoreWithCurrentQtySaved=Fill quantities with latest saved values
 ReceptionsRecorded=Receptions recorded
 ReceptionUpdated=Reception successfully updated
 ReceptionDistribution=Reception distribution
+ReceptionMustBeInTheSameCurrencyThanOther=Reception have to be int the same currency than the other

--- a/htdocs/langs/fr_FR/receptions.lang
+++ b/htdocs/langs/fr_FR/receptions.lang
@@ -56,3 +56,4 @@ RestoreWithCurrentQtySaved=Remplir les quantités avec les dernières valeurs en
 ReceptionsRecorded=Réceptions enregistrées
 ReceptionUpdated=Réception mise à jour avec succès
 ReceptionDistribution=Distribution de réception
+ReceptionMustBeInTheSameCurrencyThanOther=Cette Reception n'est pas dans la même devise que les autres

--- a/htdocs/reception/list.php
+++ b/htdocs/reception/list.php
@@ -265,6 +265,8 @@ if (empty($reshook)) {
 				$mode_reglement_id = 0;
 				$fk_account = 0;
 				$transport_mode_id = 0;
+				$mutlicurrency_code = null;
+
 				if (!empty($rcp->cond_reglement_id)) {
 					$cond_reglement_id = $rcp->cond_reglement_id;
 				}
@@ -277,11 +279,15 @@ if (empty($reshook)) {
 				if (!empty($rcp->transport_mode_id)) {
 					$transport_mode_id = $rcp->transport_mode_id;
 				}
+				if (!empty($rcp->multicurrency_code)) {
+					$multicurrency_code = $rcp->multicurrency_code;
+				}
 
 				if (empty($cond_reglement_id)
 					|| empty($mode_reglement_id)
 					|| empty($fk_account)
 					|| empty($transport_mode_id)
+					|| empty($multicurrency_code)
 				) {
 					if (!isset($rcp->supplier_order)) {
 						$rcp->fetch_origin();
@@ -302,6 +308,9 @@ if (empty($reshook)) {
 						if (empty($transport_mode_id) && !empty($supplierOrder->transport_mode_id)) {
 							$transport_mode_id = $supplierOrder->transport_mode_id;
 						}
+						if (empty($multicurrency_code) && !empty($supplierOrder->multicurrency_code)) {
+							$multicurrency_code = $supplierOrder->multicurrency_code;
+						}
 					}
 
 					// try get from third-party of reception
@@ -319,6 +328,9 @@ if (empty($reshook)) {
 						if (empty($transport_mode_id) && !empty($soc->transport_mode_id)) {
 							$transport_mode_id = $soc->transport_mode_id;
 						}
+						if (empty($multicurrency_code) && !empty($soc->multicurrency_code)) {
+							$multicurrency_code = $soc->multicurrency_code;
+						}
 					}
 				}
 
@@ -329,6 +341,7 @@ if (empty($reshook)) {
 				$objecttmp->mode_reglement_id = $mode_reglement_id;
 				$objecttmp->fk_account = $fk_account;
 				$objecttmp->transport_mode_id = $transport_mode_id;
+				$objecttmp->multicurrency_code = $multicurrency_code;
 
 				// if the VAT reverse-charge is activated by default in supplier card to resume the information
 				$objecttmp->vat_reverse_charge = $soc->vat_reverse_charge;
@@ -384,6 +397,13 @@ if (empty($reshook)) {
 			}
 
 			if ($objecttmp->id > 0) {
+				if (!isset($rcp->origin_object)) {
+					$rcp->fetch_origin();
+				}
+				if ($rcp->origin_object->multicurrency_code != $objecttmp->multicurrency_code) {
+					$errors[] = $rcp->ref." : ".$langs->trans("ReceptionMustBeInTheSameCurrencyThanOther");
+				}
+				
 				$res = $objecttmp->add_object_linked($objecttmp->origin, $id_reception);
 
 				if ($res == 0) {
@@ -492,7 +512,7 @@ if (empty($reshook)) {
 								array(),
 								null,
 								$lines[$i]->rowid,
-								0,
+								$lines[$i]->multicurrency_subprice,
 								$lines[$i]->ref_supplier
 							);
 


### PR DESCRIPTION
FIX #35154 - Massaction createbills in reception list don't mind about order and/or thirdparty currency

Check in the loop if all reception in a invoice are in the same currency and raise an error if not.
The error message is the translate key: ReceptionMustBeInTheSameCurrencyThanOther

