### PR TITLE
FIX extra field list depend on parent list when editing a card

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7693,7 +7693,7 @@ abstract class CommonObject
 								    $("#"+child_list).hide();
 								//Show mother lists
 								} else if ($("#"+parent_list).val() != 0){
-								    $("#"+parent_list).show();
+								    showOptions'.$type.'(child_list, parent_list, orig_select[child_list]);
 								}
 								//Show the child list if the parent list value is selected
 								$("select[name=\""+parent_list+"\"]").click(function() {


### PR DESCRIPTION
FIX extra field list depend on parent list when editing a card

**To reproduce**
1.  create a select list extrafield on product card
<img width="694" height="719" alt="image" src="https://github.com/user-attachments/assets/e8519cf5-b17f-481d-ad8f-16379460b3c1" />

2. create a select list extrafield on product card depends on parent extrafield 
<img width="760" height="719" alt="image" src="https://github.com/user-attachments/assets/f0fa5ba0-f9c5-4518-aa9f-c7cc2afb2a37" />

The values are : 
10,Crème autres|options_listdep1:1
11,Crème 10%|options_listdep1:1
12,Crème 20%|options_listdep1:1
20,Bio|options_listdep1:2
30,Poudre|options_listdep1:3
31,Canne|options_listdep1:3

3. After creating a product, you edit it :
<img width="506" height="134" alt="image" src="https://github.com/user-attachments/assets/5756cfc7-02ca-4d3d-9cb9-4dad8c4a8e60" />

**4. You got all values in the child extra field** (not filtered with the parent list)
<img width="123" height="296" alt="image" src="https://github.com/user-attachments/assets/1d7b71ca-b999-4c81-a682-24bf52a8cf6a" />


**After fix**
The child list is filtered with the selected value of parent list on editing a card
<img width="127" height="206" alt="image" src="https://github.com/user-attachments/assets/99b130e0-c931-4d54-8fd1-147a89f39984" />
