### PR TITLE
FIX #35181 Cancelled purchase orders now shown as such in Project Overview

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1272,7 +1272,7 @@ foreach ($listofreferent as $key => $value) {
 					if (!empty($element->close_code) && $element->close_code == 'replaced') {
 						$qualifiedfortotal = false; // Replacement invoice, do not include into total
 					}
-				} elseif ($key == 'order_supplier' && $element->status == 7) {
+				} elseif ($key == 'order_supplier' && ($element->status == 6 || $element->status == 7)) {
 					$qualifiedfortotal = false; // It makes no sense to include canceled orders in the total
 				}
 

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1277,7 +1277,7 @@ foreach ($listofreferent as $key => $value) {
 				}
 
 				if ($key == "order_supplier" && ($element->status == 6 || $element->status == 7)) {
-					print '<tr class="oddeven tr_canceled" style=display:none>';
+					print '<tr class="oddeven tr_canceled">';
 				} else {
 					print '<tr class="oddeven" >';
 				}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1276,7 +1276,7 @@ foreach ($listofreferent as $key => $value) {
 					$qualifiedfortotal = false; // It makes no sense to include canceled orders in the total
 				}
 
-				if ($key == "order_supplier" && $element->status == 7) {
+				if ($key == "order_supplier" && ($element->status == 6 || $element->status == 7)) {
 					print '<tr class="oddeven tr_canceled" style=display:none>';
 				} else {
 					print '<tr class="oddeven" >';


### PR DESCRIPTION
# FIX #35181 Cancelled purchase orders now shown as such in Project Overview

The "Project Overview" pages shows all related items (invoices, expense reports, etc) to a project. On the purchase orders sections, there is code that supposedly exclude cancelled orders from the total. But it doesn't happen for all cancelled order. Only the orders that are in status "Cancelled / Never received" (`status == 7`). "Regular" cancelled order (`status == 6`) were still used in the total, and didn't hide when clicking on the button "Cancelled shown".

This PR excludes all cancelled orders (`status` either 7 or 6) from the total, and also shows them all as crossed out. In addition, this PR displays by default the cancelled order, mostly because by default, the button on the right is labelled "Cancelled shown" (so the user would expect the cancelled orders to be shown by default).

BEFORE: cancelled purchase order is still counted in total and not crossed out
<img width="1270" height="266" alt="image" src="https://github.com/user-attachments/assets/7bf5858b-1bd6-4a54-b2a0-81d6300c54cc" />

AFTER: cancelled purchase order now crossed out and not used in total
<img width="1271" height="264" alt="image" src="https://github.com/user-attachments/assets/2d1fc1ec-8958-4476-966e-7e565f4251ed" />
