### PR TITLE
NEW Accountancy - Add hook on export filename

### DIFF
--- a/htdocs/accountancy/tpl/export_journal.tpl.php
+++ b/htdocs/accountancy/tpl/export_journal.tpl.php
@@ -98,7 +98,7 @@ if (is_object($hookmanager)) {
 	$parameters = array(
 		'type_export'       => $type_export ?? '',
 		'format'            => $format ?? '',
-		'format_code'       => isset($accountancyexport) && is_object($accountancyexport) && method_exists($accountancyexport, 'getFormatCode') ? $accountancyexport->getFormatCode($formatexportset) : '',
+		'format_code'       => $accountancyexport->getFormatCode($formatexportset),
 		'code'              => $code ?? '',
 		'prefix'            => $prefix ?? '',
 		'filename'          => $filename ?? '',
@@ -106,9 +106,9 @@ if (is_object($hookmanager)) {
 		'period_end'        => $endaccountingperiod ?? '',
 		'siren'             => $siren ?? '',
 		'ndate_in_filename' => $nodateexport ?? 0,
-		'now_datetime'      => $date_export ?? '',
+		'now_datetime'      => $date_export,
 		// Value by default
-		'defaultfilename'   => $completefilename ?? ''
+		'defaultfilename'   => $completefilename
 	);
 
 	// Hook called by modules: setExportFilename
@@ -116,8 +116,7 @@ if (is_object($hookmanager)) {
 	if ($reshook > 0) {
 		if (!empty($hookmanager->resArray['filename'])) {
 			$completefilename = $hookmanager->resArray['filename'];
-		} elseif (isset($hookmanager->resPrint) && $hookmanager->resPrint !== '') {
-			// Compatibility
+		} elseif ($hookmanager->resPrint !== '') {
 			$completefilename = $hookmanager->resPrint;
 		}
 	}

--- a/htdocs/accountancy/tpl/export_journal.tpl.php
+++ b/htdocs/accountancy/tpl/export_journal.tpl.php
@@ -1,10 +1,10 @@
 <?php
-/* Copyright (C) 2015-2024  Alexandre Spangaro	<alexandre@inovea-conseil.com>
- * Copyright (C) 2022  		Lionel Vessiller    <lvessiller@open-dsi.fr>
- * Copyright (C) 2016       Charlie Benke		<charlie@patas-monkey.com>
- * Copyright (C) 2022  		Progiseize         	<a.bisotti@progiseize.fr>
+/* Copyright (C) 2015-2025  Alexandre Spangaro			<alexandre@inovea-conseil.com>
+ * Copyright (C) 2022  		Lionel Vessiller			<lvessiller@open-dsi.fr>
+ * Copyright (C) 2016       Charlie Benke				<charlie@patas-monkey.com>
+ * Copyright (C) 2022  		Progiseize					<a.bisotti@progiseize.fr>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024       Frédéric France				<frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,6 +33,7 @@
 /**
  * @var Conf $conf
  * @var DoliDB $db
+ * @var HookManager $hookmanager
  * @var int $formatexportset
  * @var string $type_export
  * @var string $filename
@@ -87,6 +88,39 @@ if ((substr($accountancyexport->getFormatCode($formatexportset), 0, 3) == 'fec')
 	$completefilename = "XIMPORT.TXT";
 } else {
 	$completefilename = ($code ? $code."_" : "").($prefix ? $prefix."_" : "").$filename.($nodateexport ? "" : $date_export).".".$format;
+}
+
+// --- Hook: allow external modules to override export filename ---
+if (is_object($hookmanager)) {
+	// Dedicated context (non-blocking if other hooks are already initialized)
+	$hookmanager->initHooks(array('accountancyexportfilename'));
+
+	$parameters = array(
+		'type_export'       => $type_export ?? '',
+		'format'            => $format ?? '',
+		'format_code'       => isset($accountancyexport) && is_object($accountancyexport) && method_exists($accountancyexport, 'getFormatCode') ? $accountancyexport->getFormatCode($formatexportset) : '',
+		'code'              => $code ?? '',
+		'prefix'            => $prefix ?? '',
+		'filename'          => $filename ?? '',
+		'period_start'      => $startaccountingperiod ?? '',
+		'period_end'        => $endaccountingperiod ?? '',
+		'siren'             => $siren ?? '',
+		'ndate_in_filename' => $nodateexport ?? 0,
+		'now_datetime'      => $date_export ?? '',
+		// Value by default
+		'defaultfilename'   => $completefilename ?? ''
+	);
+
+	// Hook called by modules: setExportFilename
+	$reshook = $hookmanager->executeHooks('setExportFilename', $parameters, $accountancyexport, $action);
+	if ($reshook > 0) {
+		if (!empty($hookmanager->resArray['filename'])) {
+			$completefilename = $hookmanager->resArray['filename'];
+		} elseif (isset($hookmanager->resPrint) && $hookmanager->resPrint !== '') {
+			// Compatibility
+			$completefilename = $hookmanager->resPrint;
+		}
+	}
 }
 
 if (empty($downloadMode)) {


### PR DESCRIPTION
Add hook to manage filename on accountancy export.

Example for manage the general ledger (in CSV) filename in external module : 

```
public function setExportFilename($parameters, &$object, &$action, $hookmanager)
{
    if (!empty($parameters['type_export']) && $parameters['type_export'] === 'general_ledger'
        && !empty($parameters['format_code']) && $parameters['format_code'] === 'csv') {

        $periodEnd = !empty($parameters['period_end']) ? $parameters['period_end'] : '';
        $siren     = !empty($parameters['siren']) ? $parameters['siren'] : '';
        $filename  = 'MYMODULE_GL_' . $siren . '_' . $periodEnd . '.csv';

         $hookmanager->resArray['filename'] = $filename;
        return 1; // >0 => overloaded !
    }

    return 0; // no change
}
```