### PR TITLE
FIX MULTICOMPANY Error

### DIFF
--- a/htdocs/contact/project.php
+++ b/htdocs/contact/project.php
@@ -25,6 +25,7 @@
 
 // Load Dolibarr environment
 require '../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 
 /**


### PR DESCRIPTION
Without it, We have a "error 500" on this tab when Multicompany is active. Error exists on v21 and v22 at least.
