### PR TITLE
Fix impossibility to validate objects

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1443,6 +1443,7 @@ function dol_include_once($relpath, $classname = '')
 function dol_buildpath($path, $type = 0, $returnemptyifnotfound = 0)
 {
 	global $conf;
+	require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 
 	$path = preg_replace('/^\//', '', $path);
 
@@ -1455,6 +1456,9 @@ function dol_buildpath($path, $type = 0, $returnemptyifnotfound = 0)
 				}
 				// if (@file_exists($dirroot.'/'.$path)) {
 				if (@file_exists($dirroot.'/'.$path)) {	// avoid [php:warn]
+					if (empty(dol_dir_list($dirroot.'/'.$path, "files"))) {
+						continue;
+					}
 					$res = $dirroot.'/'.$path;
 					return $res;
 				}


### PR DESCRIPTION
Fix a bug that make impossible to validate object when you have a core/module/<ObjectClass> directory in custom folder

To prevent this bug we try to find a file in the directory.

### Step to reproduce
We will try with invoice object but works on all objects

1.  set $dolibarr_main_document_root_alt = <pathtodolibarr>/custom
2.  create an empty directories with this patch  in custom directory: core/modules/facture

Now if you go in invoice configuration page there is no numbering files
If you try to create a new draft invoice and try to validate it. It create a fatal error. 
