### PR TITLE
Fix impossibility to validate objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Follow these step-by-step instructions to seamlessly upgrade Dolibarr to the lat
 
 See the [ChangeLog](https://github.com/Dolibarr/dolibarr/blob/develop/ChangeLog) file.
 
+Adding new templates must be done by adding files into a module directory. Adding files into custom with same path of the core without having using a module is now forbidden
 
 ## FEATURES
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1569,7 +1569,7 @@ function dol_buildpath($path, $type = 0, $returnemptyifnotfound = 0)
 				}
 				// if (@file_exists($dirroot.'/'.$path)) {
 				if (@file_exists($dirroot . '/' . $path)) {	// avoid [php:warn]
-					if ($key != 'main' && preg_match('/^core\//', $path)) {	// When searching into an alternative custom path, we don't wan't path like 'core/...' because path should be 'modulename/core/...'
+					if ($key != 'main' && preg_match('/^core\//', $path)) {	// When searching into an alternative custom path, we don't want path like 'core/...' because path should be 'modulename/core/...'
 						continue;
 					}
 					$res = $dirroot . '/' . $path;

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1569,6 +1569,9 @@ function dol_buildpath($path, $type = 0, $returnemptyifnotfound = 0)
 				}
 				// if (@file_exists($dirroot.'/'.$path)) {
 				if (@file_exists($dirroot . '/' . $path)) {	// avoid [php:warn]
+					if ($key != 'main' && preg_match('/^core\//', $path)) {	// When searching into an alternative custom path, we don't wan't path like 'core/...' because path should be 'modulename/core/...'
+						continue;
+					}
 					$res = $dirroot . '/' . $path;
 					return $res;
 				}


### PR DESCRIPTION


Fix a bug that make impossible to validate object when you have a core/module/ directory in custom folder

To prevent this bug we try to find a file in the directory.
### Step to reproduce

We will try with invoice object but works on all objects

1. set $dolibarr_main_document_root_alt = /custom
2. create an empty directories with this patch in custom directory: core/modules/facture

Now if you go in invoice configuration page there is no numbering files
If you try to create a new draft invoice and try to validate it. It create a fatal error.
