### PR TITLE
Support of PATCH / PATCHALREADYFORMATED HTTP methods in getURLContent() #35212

### DIFF
--- a/htdocs/core/lib/geturl.lib.php
+++ b/htdocs/core/lib/geturl.lib.php
@@ -30,7 +30,7 @@
  * - common local lookup ips like 127.*.*.* are automatically added
  *
  * @param	string	  $url 				    URL to call.
- * @param	string    $postorget		    'POST', 'GET', 'HEAD', 'PUT', 'PUTALREADYFORMATED', 'POSTALREADYFORMATED', 'DELETE'
+ * @param	string    $postorget		    'POST', 'GET', 'HEAD', 'PUT', 'PATCH', 'PUTALREADYFORMATED', 'POSTALREADYFORMATED', 'PATCHALREADYFORMATED', 'DELETE'
  * @param	string    $param			    Parameters of URL (x=value1&y=value2) or may be a formatted content with $postorget='PUTALREADYFORMATED'
  * @param	integer   $followlocation		0=Do not follow, 1=Follow location.
  * @param	string[]  $addheaders			Array of string to add into header. Example: ('Accept: application/xrds+xml', ....)
@@ -144,6 +144,19 @@ function getURLContent($url, $postorget = 'GET', $param = '', $followlocation = 
 	} elseif ($postorget == 'PUTALREADYFORMATED') {
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT'); // HTTP request is 'PUT'
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $param); // param = content of post, like a xml string
+	} elseif ($postorget == 'PATCH') {
+		$array_param = null;
+		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH'); // RFC 5789
+		if (!is_array($param)) {
+			parse_str($param, $array_param);
+		} else {
+			dol_syslog("parameter param must be a string", LOG_WARNING);
+			$array_param = $param;
+		}
+		curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($array_param));
+	} elseif ($postorget == 'PATCHALREADYFORMATED') {
+		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH'); // RFC 5789
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $param);
 	} elseif ($postorget == 'HEAD') {
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'HEAD'); // HTTP request is 'HEAD'
 		curl_setopt($ch, CURLOPT_NOBODY, true);


### PR DESCRIPTION
# NEW|New Support of PATCH
As described in issue #35212, support has been added for the PATCH to the `geturl.lib.php`, in version 20.0, I believe it must be cast to the newer versions (a.k.a 21, 22, and demo 23), as well as previous versions might also benefit from it.
