### PR TITLE
FIX or UPDATE Order Status linked with Invoice Billed status

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3706,9 +3706,21 @@ class Commande extends CommonOrder
 				$labelTooltip .= ' - '.$langs->transnoentitiesnoconv("DateDeliveryPlanned").dol_print_date($this->delivery_date, 'day').$billedtext;
 			}
 			$statusType = 'status4';
-		} elseif ($status == self::STATUS_CLOSED) {
+		} elseif ($status == self::STATUS_CLOSED && empty(getDolGlobalString('ORDER_STATUS_LINK_BILLED'))) {
 			$labelStatus = $langs->transnoentitiesnoconv('StatusOrderDelivered').$billedtext;
 			$labelStatusShort = $langs->transnoentitiesnoconv('StatusOrderDeliveredShort').$billedtext;
+			$statusType = 'status6';
+		} elseif ($status == self::STATUS_CLOSED && (!$billed && empty($conf->global->WORKFLOW_BILL_ON_SHIPMENT)) && (!empty(getDolGlobalString('ORDER_STATUS_LINK_BILLED')))) {
+			$labelStatus = $langs->transnoentitiesnoconv('StatusOrderToBill'); // translated into Delivered
+			$labelStatusShort = $langs->transnoentitiesnoconv('StatusOrderToBillShort'); // translated into Delivered
+			$statusType = 'status4';
+		} elseif ($status == self::STATUS_CLOSED && ($billed && empty($conf->global->WORKFLOW_BILL_ON_SHIPMENT)) && (!empty(getDolGlobalString('ORDER_STATUS_LINK_BILLED')))) {
+			$labelStatus = $langs->transnoentitiesnoconv('StatusOrderProcessed').$billedtext;
+			$labelStatusShort = $langs->transnoentitiesnoconv('StatusOrderProcessedShort').$billedtext;
+			$statusType = 'status6';
+		} elseif ($status == self::STATUS_CLOSED && (!empty($conf->global->WORKFLOW_BILL_ON_SHIPMENT)) && (!empty(getDolGlobalString('ORDER_STATUS_LINK_BILLED')))) {
+			$labelStatus = $langs->transnoentitiesnoconv('StatusOrderDelivered');
+			$labelStatusShort = $langs->transnoentitiesnoconv('StatusOrderDeliveredShort');
 			$statusType = 'status6';
 		} else {
 			$labelStatus = $langs->transnoentitiesnoconv('Unknown');


### PR DESCRIPTION
FIX or UPDATE commande.class.php Function LibStatut to revert previous link with OrderBilled status

For some reasons I could not find or understand, starting V19, the status displayed in order list or order card have been simplified creating confusion and less feature when working on mass order management for all our customers.
I added a CONST ORDER_STATUS_LINK_BILLED to included previous code status management back.
As a reminder a order that was shipped but not invoiced was Green and tag shipped. If Shipped and Invoiced an order was tagged Gray and Processed.
I put this behavior back starting V19 as it was already in code v18 and below.
