### PR TITLE
Fix 24338 In expense report list, all expense reports are a warning icon

### DIFF
--- a/htdocs/expensereport/list.php
+++ b/htdocs/expensereport/list.php
@@ -869,7 +869,7 @@ if ($num > 0) {
 				print '</td>';
 				// Warning late icon and note
 				print '<td class="nobordernopadding nowrap">';
-				if ($expensereportstatic->status == 2 && $expensereportstatic->hasDelay('toappove')) {
+				if ($expensereportstatic->status == 2 && $expensereportstatic->hasDelay('toapprove')) {
 					print img_warning($langs->trans("Late"));
 				}
 				if ($expensereportstatic->status == 5 && $expensereportstatic->hasDelay('topay')) {


### PR DESCRIPTION
FIX|Fix #24338 In expense report list, all expense reports are a warning icon
