### PR TITLE
NEW: Add prepare() method to DoliDB class (rebuild)

### DIFF
--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -24,7 +24,7 @@
  * \brief 		Class file to manage Dolibarr database access
  */
 
-require_once DOL_DOCUMENT_ROOT.'/core/db/Database.interface.php';
+require_once DOL_DOCUMENT_ROOT . '/core/db/Database.interface.php';
 
 
 /**
@@ -104,7 +104,7 @@ abstract class DoliDB implements Database
 	public function ifsql($test, $resok, $resko)
 	{
 		//return 'IF('.$test.','.$resok.','.$resko.')';		// Not sql standard
-		return '(CASE WHEN '.$test.' THEN '.$resok.' ELSE '.$resko.' END)';
+		return '(CASE WHEN ' . $test . ' THEN ' . $resok . ' ELSE ' . $resko . ' END)';
 	}
 
 	/**
@@ -115,7 +115,7 @@ abstract class DoliDB implements Database
 	 */
 	public function stddevpop($nameoffield)
 	{
-		return 'STDDEV_POP('.$nameoffield.')';
+		return 'STDDEV_POP(' . $nameoffield . ')';
 	}
 
 	/**
@@ -142,10 +142,10 @@ abstract class DoliDB implements Database
 	public function regexpsql($subject, $pattern, $sqlstring = 0)
 	{
 		if ($sqlstring) {
-			return "(". $subject ." REGEXP '" . $this->escape($pattern) . "')";
+			return "(" . $subject . " REGEXP '" . $this->escape($pattern) . "')";
 		}
 
-		return "('". $this->escape($subject) ."' REGEXP '" . $this->escape($pattern) . "')";
+		return "('" . $this->escape($subject) . "' REGEXP '" . $this->escape($pattern) . "')";
 	}
 
 
@@ -186,7 +186,7 @@ abstract class DoliDB implements Database
 	 */
 	public function sanitize($stringtosanitize, $allowsimplequote = 0, $allowsequals = 0, $allowsspace = 0, $allowschars = 1)
 	{
-		$result = preg_replace('/[^0-9_\-\.,'.($allowschars ? '\p{L}' : '').($allowsequals ? '=' : '').($allowsimplequote ? "\'" : '').($allowsspace ? ' ' : '').']/ui', '', $stringtosanitize);
+		$result = preg_replace('/[^0-9_\-\.,' . ($allowschars ? '\p{L}' : '') . ($allowsequals ? '=' : '') . ($allowsimplequote ? "\'" : '') . ($allowsspace ? ' ' : '') . ']/ui', '', $stringtosanitize);
 		//$result = preg_replace('/[^0-9_\-\.,'.($allowschars ? 'a-z' : '').($allowsequals ? '=' : '').($allowsimplequote ? "\'" : '').($allowsspace ? ' ' : '').']/i', '', $stringtosanitize);
 
 		if ($allowsimplequote == 1) {
@@ -196,7 +196,7 @@ abstract class DoliDB implements Database
 			foreach ($tmpchars as $tmpchar) {
 				$reg = array();
 				if (preg_match('/^\'(.*)\'$/', $tmpchar, $reg)) {
-					$newstringarray[] = "'".str_replace("'", "", $reg[1])."'";
+					$newstringarray[] = "'" . str_replace("'", "", $reg[1]) . "'";
 				} else {
 					$newstringarray[] = str_replace("'", "", $tmpchar);
 				}
@@ -219,7 +219,7 @@ abstract class DoliDB implements Database
 			$ret = $this->query("BEGIN");
 			if ($ret) {
 				$this->transaction_opened++;
-				dol_syslog("BEGIN Transaction".($textinlog ? ' '.$textinlog : ''), LOG_DEBUG);
+				dol_syslog("BEGIN Transaction" . ($textinlog ? ' ' . $textinlog : ''), LOG_DEBUG);
 				dol_syslog('', 0, 1);
 				return 1;
 			} else {
@@ -245,7 +245,7 @@ abstract class DoliDB implements Database
 			$ret = $this->query("COMMIT");
 			if ($ret) {
 				$this->transaction_opened = 0;
-				dol_syslog("COMMIT Transaction".($log ? ' '.$log : ''), LOG_DEBUG);
+				dol_syslog("COMMIT Transaction" . ($log ? ' ' . $log : ''), LOG_DEBUG);
 				return 1;
 			} else {
 				return 0;
@@ -268,7 +268,7 @@ abstract class DoliDB implements Database
 		if ($this->transaction_opened <= 1) {
 			$ret = $this->query("ROLLBACK");
 			$this->transaction_opened = 0;
-			dol_syslog("ROLLBACK Transaction".($log ? ' '.$log : ''), LOG_DEBUG);
+			dol_syslog("ROLLBACK Transaction" . ($log ? ' ' . $log : ''), LOG_DEBUG);
 			return $ret;
 		} else {
 			$this->transaction_opened--;
@@ -293,9 +293,9 @@ abstract class DoliDB implements Database
 			$limit = $conf->liste_limit;
 		}
 		if ($offset > 0) {
-			return " LIMIT ".((int) $offset).",".((int) $limit)." ";
+			return " LIMIT " . ((int) $offset) . "," . ((int) $limit) . " ";
 		} else {
-			return " LIMIT ".((int) $limit)." ";
+			return " LIMIT " . ((int) $limit) . " ";
 		}
 	}
 
@@ -353,7 +353,7 @@ abstract class DoliDB implements Database
 					$oldsortorder = 'DESC';
 					$return .= ' DESC';
 				} else {
-					$return .= ' '.($oldsortorder ? $oldsortorder : 'ASC');
+					$return .= ' ' . ($oldsortorder ? $oldsortorder : 'ASC');
 				}
 
 				$i++;
@@ -390,7 +390,7 @@ abstract class DoliDB implements Database
 			return '';
 		}
 		$string = preg_replace('/([^0-9])/i', '', $string);
-		$tmp = $string.'000000';
+		$tmp = $string . '000000';
 		$date = dol_mktime((int) substr($tmp, 8, 2), (int) substr($tmp, 10, 2), (int) substr($tmp, 12, 2), (int) substr($tmp, 4, 2), (int) substr($tmp, 6, 2), (int) substr($tmp, 0, 4), $gm);
 		return $date;
 	}
@@ -442,7 +442,7 @@ abstract class DoliDB implements Database
 	public function getRows($sql)
 	{
 		if (!preg_match('/LIMIT \d+(?:(?:,\ *\d*)|(?:\ +OFFSET\ +\d*))?\ *;?$/', $sql)) {
-			trigger_error(__CLASS__ .'::'.__FUNCTION__.'() query must have a LIMIT clause', E_USER_ERROR);
+			trigger_error(__CLASS__ . '::' . __FUNCTION__ . '() query must have a LIMIT clause', E_USER_ERROR);
 		}
 
 		$resql = $this->query($sql);
@@ -467,12 +467,11 @@ abstract class DoliDB implements Database
 	 *
 	 * @param string $sql SQL query to prepare
 	 * @return mixed Driver-specific prepared statement object or false on failure
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 */
 	public function prepare($sql)
 	{
 		$this->lasterror = 'prepare() not implemented for this driver.';
 		return false;
 	}
-
-
 }

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -470,7 +470,6 @@ abstract class DoliDB implements Database
 	 */
 	public function prepare($sql)
 	{
-
 		$sql;// Avoid "unused variable" warning
 		$this->lasterror = 'prepare() not implemented for this driver.';
 		return false;

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -470,7 +470,7 @@ abstract class DoliDB implements Database
 	 */
 	public function prepare($sql)
 	{
-		
+
 		$sql;// Avoid "unused variable" warning
 		$this->lasterror = 'prepare() not implemented for this driver.';
 		return false;

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -467,10 +467,11 @@ abstract class DoliDB implements Database
 	 *
 	 * @param string $sql SQL query to prepare
 	 * @return mixed Driver-specific prepared statement object or false on failure
-	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 */
 	public function prepare($sql)
 	{
+		
+		$sql;// Avoid "unused variable" warning
 		$this->lasterror = 'prepare() not implemented for this driver.';
 		return false;
 	}

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -459,4 +459,20 @@ abstract class DoliDB implements Database
 
 		return false;
 	}
+
+	/**
+	 * Prepare a SQL statement for execution
+	 *
+	 * This method must be implemented by subclasses.
+	 *
+	 * @param string $sql SQL query to prepare
+	 * @return mixed Driver-specific prepared statement object or false on failure
+	 */
+	public function prepare($sql)
+	{
+		$this->lasterror = 'prepare() not implemented for this driver.';
+		return false;
+	}
+
+
 }

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -470,6 +470,10 @@ abstract class DoliDB implements Database
 	 */
 	public function prepare($sql)
 	{
+<<<<<<< HEAD
+=======
+
+>>>>>>> 2adc4bf7134 (fix : whitespaces)
 		$sql;// Avoid "unused variable" warning
 		$this->lasterror = 'prepare() not implemented for this driver.';
 		return false;

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -467,7 +467,6 @@ abstract class DoliDB implements Database
 	 *
 	 * @param string $sql SQL query to prepare
 	 * @return mixed Driver-specific prepared statement object or false on failure
-	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 */
 	public function prepare($sql)
 	{

--- a/htdocs/core/db/DoliDB.class.php
+++ b/htdocs/core/db/DoliDB.class.php
@@ -467,6 +467,7 @@ abstract class DoliDB implements Database
 	 *
 	 * @param string $sql SQL query to prepare
 	 * @return mixed Driver-specific prepared statement object or false on failure
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 */
 	public function prepare($sql)
 	{

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -1331,7 +1331,6 @@ class DoliDBMysqli extends DoliDB
 		}
 	
 		$stmt = $this->db->prepare($sql);
-		
 		if ($stmt === false) {
 			$this->lasterror = $this->db->error;
 			$this->lastqueryerror = $sql;

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -1294,6 +1294,31 @@ class DoliDBMysqli extends DoliDB
 
 		return $result;
 	}
+
+	/**
+	 * Prepare a SQL statement for execution
+	 *
+	 * @param string $sql SQL query to prepare
+	 * @return false|mysqli_stmt
+	 */
+	public function prepare($sql)
+	{
+		if (!$this->connected) {
+			$this->lasterror = 'Not connected to database';
+			return false;
+		}
+	
+		$stmt = $this->db->prepare($sql);
+		
+		if ($stmt === false) {
+			$this->lasterror = $this->db->error;
+			$this->lastqueryerror = $sql;
+			return false;
+		}
+	
+		return $stmt;
+	}
+
 }
 
 if (class_exists('mysqli')) {

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -1307,14 +1307,13 @@ class DoliDBMysqli extends DoliDB
 			$this->lasterror = 'Not connected to database';
 			return false;
 		}
-	
 		$stmt = $this->db->prepare($sql);
 		if ($stmt === false) {
 			$this->lasterror = $this->db->error;
 			$this->lastqueryerror = $sql;
 			return false;
 		}
-	
+
 		return $stmt;
 	}
 }

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -1340,7 +1340,6 @@ class DoliDBMysqli extends DoliDB
 	
 		return $stmt;
 	}
-
 }
 
 if (class_exists('mysqli')) {

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -1309,7 +1309,6 @@ class DoliDBMysqli extends DoliDB
 		}
 	
 		$stmt = $this->db->prepare($sql);
-		
 		if ($stmt === false) {
 			$this->lasterror = $this->db->error;
 			$this->lastqueryerror = $sql;

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -1316,6 +1316,31 @@ class DoliDBMysqli extends DoliDB
 
 		return $stmt;
 	}
+
+	/**
+	 * Prepare a SQL statement for execution
+	 *
+	 * @param string $sql SQL query to prepare
+	 * @return false|mysqli_stmt
+	 */
+	public function prepare($sql)
+	{
+		if (!$this->connected) {
+			$this->lasterror = 'Not connected to database';
+			return false;
+		}
+	
+		$stmt = $this->db->prepare($sql);
+		
+		if ($stmt === false) {
+			$this->lasterror = $this->db->error;
+			$this->lastqueryerror = $sql;
+			return false;
+		}
+	
+		return $stmt;
+	}
+
 }
 
 if (class_exists('mysqli')) {

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -1318,7 +1318,6 @@ class DoliDBMysqli extends DoliDB
 	
 		return $stmt;
 	}
-
 }
 
 if (class_exists('mysqli')) {

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -1307,6 +1307,7 @@ class DoliDBMysqli extends DoliDB
 			$this->lasterror = 'Not connected to database';
 			return false;
 		}
+<<<<<<< HEAD
 		$stmt = $this->db->prepare($sql);
 		if ($stmt === false) {
 			$this->lasterror = $this->db->error;
@@ -1330,13 +1331,15 @@ class DoliDBMysqli extends DoliDB
 			return false;
 		}
 	
+=======
+>>>>>>> 2adc4bf7134 (fix : whitespaces)
 		$stmt = $this->db->prepare($sql);
 		if ($stmt === false) {
 			$this->lasterror = $this->db->error;
 			$this->lastqueryerror = $sql;
 			return false;
 		}
-	
+
 		return $stmt;
 	}
 }

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -1531,5 +1531,4 @@ class DoliDBPgsql extends DoliDB
 
 		return $stmtname; // We just return the name of the prepared statement
 	}
-
 }

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -1512,4 +1512,24 @@ class DoliDBPgsql extends DoliDB
 
 		return array();
 	}
+
+	/**
+	 * Prepare a SQL statement for execution (PostgreSQL prepared statement)
+	 *
+	 * @param string $sql The SQL query to prepare
+	 * @return string|false The name of the prepared statement on success, or false on failure
+	 */
+	public function prepare($sql)
+	{
+		$stmtname = uniqid('dolipgstmt_'); // Generate a unique identifier for the statement
+
+		$result = pg_prepare($this->db, $stmtname, $sql);
+		if (!$result) {
+			$this->lasterror = pg_last_error($this->db);
+			return false;
+		}
+
+		return $stmtname; // We just return the name of the prepared statement
+	}
+
 }


### PR DESCRIPTION
### Summary

This PR introduces support for prepared SQL statements across Dolibarr's database abstraction layer.

A `prepare($sql)` method is added to the `DoliDB` base class, and implemented specifically for MySQLi and PostgreSQL drivers.

---

### Implementation details

- Adds a `prepare($sql)` method in `DoliDB`, acting as an interface.
- Concrete implementations provided in:
  - `DoliDBMysqli` using `bind_param()` and `get_result()`
  - `DoliDBPgsql` using `pg_prepare()` and `pg_execute()`
- The base method in `DoliDB` returns `false` with a default error message if not implemented.

Error messages are handled via `$this->lasterror` in case of failure.

---

### Usage example — MySQLi

```php
global $db;

$sql = "SELECT rowid, login, lastname, firstname FROM " . MAIN_DB_PREFIX . "user WHERE rowid = ?";

// Prepare the statement
$stmt = $db->prepare($sql);

if ($stmt === false) {
    echo "Prepare error: " . $db->lasterror;
    exit;
}

$rowid = 1;
$stmt->bind_param("i", $rowid); // 'i' stands for integer

// Execute
if (!$stmt->execute()) {
    echo "Execution error: " . $stmt->error;
    exit;
}

// Fetch result
$result = $stmt->get_result();
if ($result && $result->num_rows > 0) {
    $user = $result->fetch_assoc();
    var_dump($user);
} else {
    echo "No user found.";
}

$stmt->close();
```

---

### Usage example — PostgreSQL
```php
global $db;

$sql = "SELECT rowid, login, lastname, firstname FROM " . MAIN_DB_PREFIX . "user WHERE rowid = $1";

// Prepare
$stmtName = "get_user_by_rowid";
$result = $db->prepare($sql, $stmtName); // Custom wrapper for pg_prepare()

if ($result === false) {
    echo "Prepare error: " . $db->lasterror;
    exit;
}

// Execute with parameters
$rowid = 1;
$res = $db->execute($stmtName, array($rowid)); // Wrapper for pg_execute()

if ($res && pg_num_rows($res) > 0) {
    $user = pg_fetch_assoc($res);
    var_dump($user);
} else {
    echo "No user found.";
}
```
