### PR TITLE
FIX right to modify a product price by customer

### DIFF
--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -2736,8 +2736,8 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 
 				// Todo Edit or delete button
 				// Action
-				if ($user->hasRight('produit', 'supprimer') || $user->hasRight('service', 'supprimer')) {
-					print '<td class="right nowraponall">';
+				print '<td class="right nowraponall">';
+				if ($user->hasRight('produit', 'creer') || $user->hasRight('service', 'creer')) {
 					print '<a href="'.$_SERVER["PHP_SELF"].'?action=showlog_customer_price&token='.newToken().'&id='.$object->id.'&socid='.$line->fk_soc.'">';
 					print img_info($langs->trans('PriceByCustomerLog'));
 					print '</a>';
@@ -2746,11 +2746,13 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 					print img_edit('default', 0, 'style="vertical-align: middle;"');
 					print '</a>';
 					print ' ';
+				}
+				if ($user->hasRight('produit', 'supprimer') || $user->hasRight('service', 'supprimer')) {
 					print '<a class="marginleftonly" href="'.$_SERVER["PHP_SELF"].'?action=delete_customer_price&token='.newToken().'&id='.$object->id.'&lineid='.$line->id.'">';
 					print img_delete('default', 'style="vertical-align: middle;"');
 					print '</a>';
-					print '</td>';
 				}
+				print '</td>';
 
 				print "</tr>\n";
 			}


### PR DESCRIPTION

# FIX right to modify a product price by customer : correctly display the button.

IF the user has the right to create/modify a product, they have the right to add a product price by customer (if parameter is set). BUT they don't have the right to edit the product price by customer (the 'edit') button is not displayed.

This commit fixes this.

___

to reproduce : 

- on product setup page, setup for price rules : different price for each customer
- make sure your user has the right to create/edit a product, but not the right to delete a product
- go to page product/price.php of a product, create a price for a customer

expected display (pencil to edit and no bin to delete) : 
<img width="325" height="96" alt="image" src="https://github.com/user-attachments/assets/d0be2a37-05c7-4fcc-bd27-21344da77b45" />

available display (no pencil to edit, no bin. Even the `<td>` is missing.): 
<img width="368" height="84" alt="Capture d’écran_2025-09-08_14-58-38" src="https://github.com/user-attachments/assets/63b0c216-47a1-4556-bc7d-4e9dd240c548" />




