### PR TITLE
FIX delivery triggers and mail templates: correct inconsistencies in email triggers and templates`

### DIFF
--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -219,6 +219,7 @@ if (isModEnabled('invoice') && $user->hasRight('facture', 'lire')) {
 }
 if (isModEnabled("shipping")) {
 	$elementList['shipping_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendShipment'));
+	$elementList['delivery_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendDelivery'));
 }
 if (isModEnabled("reception")) {
 	$elementList['reception_send'] = img_picto('', 'dollyrevert', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendReception'));

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -219,7 +219,6 @@ if (isModEnabled('invoice') && $user->hasRight('facture', 'lire')) {
 }
 if (isModEnabled("shipping")) {
 	$elementList['shipping_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendShipment'));
-	$elementList['reception_send'] = img_picto('', 'dolly', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendReception'));
 }
 if (isModEnabled("reception")) {
 	$elementList['reception_send'] = img_picto('', 'dollyrevert', 'class="pictofixedwidth"').dol_escape_htmltag($langs->trans('MailToSendReception'));

--- a/htdocs/delivery/card.php
+++ b/htdocs/delivery/card.php
@@ -284,11 +284,11 @@ include DOL_DOCUMENT_ROOT.'/core/actions_printing.inc.php';
 
 // Actions to send emails
 
-$triggersendname = 'RECEPTION_SENTBYMAIL';
+$triggersendname = 'SHIPPING_SENTBYMAIL';
 $paramname = 'id';
-$autocopy = 'MAIN_MAIL_AUTOCOPY_RECEPTION_TO';
-$mode = 'emailfromreception';
-$trackid = 'bl' . $object->id;
+$autocopy = 'MAIN_MAIL_AUTOCOPY_SHIPMENT_TO';
+$mode = 'emailfromshipment';
+$trackid = 'shi' . $object->id;
 include DOL_DOCUMENT_ROOT . '/core/actions_sendmails.inc.php';
 
 
@@ -759,10 +759,10 @@ if ($action == 'create') {
 	}
 
 	// Presend form
-	$modelmail = 'reception_send';
-	$defaulttopic = 'SendReceptionRef';
-	$diroutput = $conf->expedition->dir_output.'/receipt';
-	$trackid = 'bl'.$object->id;
+	$modelmail = 'shipping_send';
+	$defaulttopic = 'SendShippingRef';
+	$diroutput = $conf->expedition->dir_output . '/sending';
+	$trackid = 'shi' . $object->id;
 
 	include DOL_DOCUMENT_ROOT.'/core/tpl/card_presend.tpl.php';
 }

--- a/htdocs/delivery/card.php
+++ b/htdocs/delivery/card.php
@@ -284,11 +284,11 @@ include DOL_DOCUMENT_ROOT.'/core/actions_printing.inc.php';
 
 // Actions to send emails
 
-$triggersendname = 'SHIPPING_SENTBYMAIL';
+$triggersendname = 'DELIVERY_SENTBYMAIL';
 $paramname = 'id';
-$autocopy = 'MAIN_MAIL_AUTOCOPY_SHIPMENT_TO';
-$mode = 'emailfromshipment';
-$trackid = 'shi' . $object->id;
+$autocopy = 'MAIN_MAIL_AUTOCOPY_DELIVERY_TO';
+$mode = 'emailfromdelivery';
+$trackid = 'del' . $object->id;
 include DOL_DOCUMENT_ROOT . '/core/actions_sendmails.inc.php';
 
 
@@ -759,10 +759,10 @@ if ($action == 'create') {
 	}
 
 	// Presend form
-	$modelmail = 'shipping_send';
-	$defaulttopic = 'SendShippingRef';
-	$diroutput = $conf->expedition->dir_output . '/sending';
-	$trackid = 'shi' . $object->id;
+	$modelmail = 'delivery_send';
+	$defaulttopic = 'SendDeliveryRef';
+	$diroutput = $conf->expedition->dir_output . '/receipt';
+	$trackid = 'del' . $object->id;
 
 	include DOL_DOCUMENT_ROOT.'/core/tpl/card_presend.tpl.php';
 }

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -2102,6 +2102,7 @@ MailToSendProposal=Customer proposals
 MailToSendOrder=Sales orders
 MailToSendInvoice=Customer invoices
 MailToSendShipment=Shipments
+MailToSendDelivery=Deliveries
 MailToSendIntervention=Interventions
 MailToSendSupplierRequestForQuotation=Quotation request
 MailToSendSupplierOrder=Purchase orders

--- a/htdocs/langs/en_US/sendings.lang
+++ b/htdocs/langs/en_US/sendings.lang
@@ -51,6 +51,7 @@ DateReceived=Date delivery received
 ClassifyReception=Classify Received
 SendShippingByEMail=Send shipment by email
 SendShippingRef=Submission of shipment %s
+SendDeliveryRef=Submission of delivery %s
 ActionsOnShipping=Events on shipment
 LinkToTrackYourPackage=Link to track your package
 ShipmentCreationIsDoneFromOrder=For the moment, creation of a new shipment is done from the Sales Order record.


### PR DESCRIPTION
# fix(delivery): correct inconsistencies in email triggers and templates

Reception is a supplier object, we use same template as shipping

- Adjusted email trigger names from `RECEPTION_*` to `SHIPPING_*`.
- Updated parameters and placeholders for shipment email tracking.
- Removed redundant `reception_send` entry in mail templates for shipping.


