### PR TITLE
FIX Societe - Problem of date on outstanding opened late

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -4875,10 +4875,12 @@ class Societe extends CommonObject
 		 $alreadypayed=price2num($paiement + $creditnotes + $deposits,'MT');
 		 $remaintopay=price2num($invoice->total_ttc - $paiement - $creditnotes - $deposits,'MT');
 		 */
+		$today = dol_get_first_hour(dol_now('tzuser')); // Returns today at 00:00 in the user's time zone
+
 		$sql = "SELECT rowid, ref, total_ht, total_ttc, paye, type, fk_statut as status, close_code FROM ".MAIN_DB_PREFIX.$table." as f";
 		$sql .= " WHERE fk_soc = ".((int) $this->id);
 		if (!empty($late)) {
-			$sql .= " AND date_lim_reglement < '".$this->db->idate(dol_now())."'";
+			$sql .= " AND date_lim_reglement < '".$this->db->idate($today)."'";
 		}
 		if ($mode == 'supplier') {
 			$sql .= " AND entity IN (".getEntity('facture_fourn').")";


### PR DESCRIPTION
The invoice payment deadline is recorded as 0 hours 0 minutes 0 seconds in database, so when compared with dol_now, the problem arises that the invoice is considered overdue as soon as it is past 00:00:01 a.m.:  

$sql .= “ AND date_lim_reglement < ‘”.$this->db->idate(dol_now()).“’”;

However, an invoice will not be due until 11:59:59 p.m., so my fix proposes comparing one day with another, ignoring the hours, minutes, and seconds by forcing dol_now to 12:00:00 a.m. as well.

Example : An invoice with a payment deadline of September 9, 2025 (today) will appear as overdue at 00:00:01, when in reality it will be overdue the following day, or at least at 11:59:59 p.m.  