### PR TITLE
Fix : sql filter for batch stats

### DIFF
--- a/htdocs/product/stock/class/productlot.class.php
+++ b/htdocs/product/stock/class/productlot.class.php
@@ -891,6 +891,7 @@ class Productlot extends CommonObject
 		}
 		$sql .= " WHERE cf.entity IN (".getEntity('expedition').")";
 		$sql .= " AND cfdi.batch = '".($this->db->escape($this->batch))."'";
+		$sql .= " AND cfdi.fk_product = " . (int) $this->fk_product;
 		if (!$user->hasRight('societe', 'client', 'voir')) {
 			$sql .= " AND cf.fk_soc = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 		}

--- a/htdocs/product/stock/stats/commande_fournisseur.php
+++ b/htdocs/product/stock/stats/commande_fournisseur.php
@@ -230,6 +230,7 @@ if ($id > 0 || !empty($ref)) {
 			}
 			$sql .= " WHERE cf.entity IN (".getEntity('product').")";
 			$sql .= " AND cfdi.batch = '".($db->escape($object->batch))."'";
+			$sql .= " AND cfdi.fk_product = " . (int) $object->fk_product;
 			if (!empty($search_month)) {
 				$sql .= ' AND MONTH(cf.date_commande) IN ('.$db->sanitize($search_month).')';
 			}


### PR DESCRIPTION
# Fix

In the "Referenced Objects" tab, the supplier order statistics are incorrect because they do not filter by product.
As a result, for a batch A of T-shirts, you also see the supplier orders for batch A of Tires, which is not correct.
