### PR TITLE
Fix (ecm): support for custom entity in file operations

### DIFF
--- a/htdocs/core/actions_linkedfiles.inc.php
+++ b/htdocs/core/actions_linkedfiles.inc.php
@@ -290,7 +290,7 @@ if ($action == 'confirm_deletefile' && $confirm == 'yes' && !empty($permissionto
 						$langs->load("errors"); // lang must be loaded because we can't rely on loading during output, we need var substitution to be done now.
 						setEventMessages($langs->trans("ErrorFilenameCantStartWithDot", $filenameto), null, 'errors');
 					} elseif (!file_exists($destpath)) {
-						$result = dol_move($srcpath, $destpath);
+						$result = dol_move($srcpath, $destpath,'0',1,0,1,[],$object->entity ?? 0);
 						if ($result) {
 							// Define if we have to generate thumbs or not
 							$generatethumbs = 1;

--- a/htdocs/core/actions_linkedfiles.inc.php
+++ b/htdocs/core/actions_linkedfiles.inc.php
@@ -290,7 +290,7 @@ if ($action == 'confirm_deletefile' && $confirm == 'yes' && !empty($permissionto
 						$langs->load("errors"); // lang must be loaded because we can't rely on loading during output, we need var substitution to be done now.
 						setEventMessages($langs->trans("ErrorFilenameCantStartWithDot", $filenameto), null, 'errors');
 					} elseif (!file_exists($destpath)) {
-						$result = dol_move($srcpath, $destpath,'0',1,0,1,[],$object->entity ?? 0);
+						$result = dol_move($srcpath, $destpath, '0', 1, 0, 1, [], $object->entity ?? 0);
 						if ($result) {
 							// Define if we have to generate thumbs or not
 							$generatethumbs = 1;

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -1028,11 +1028,12 @@ function dolCopyDir($srcfile, $destfile, $newmask, $overwriteifexists, $arrayrep
  * @param   int<0,1>	$overwriteifexists  Overwrite file if exists (1 by default)
  * @param   int<0,1>	$testvirus          Do an antivirus test. Move is canceled if a virus is found.
  * @param	int<0,1>	$indexdatabase		Index new file into database.
- * @param	array<string,mixed>	$moreinfo			Array with more information to set in index table
+ * @param	array<string,mixed>	$moreinfo   Array with more information to set in index table
+ * @param	int			$entity				Entity
  * @return  boolean 		            True if OK, false if KO
  * @see dol_move_uploaded_file()
  */
-function dol_move($srcfile, $destfile, $newmask = '0', $overwriteifexists = 1, $testvirus = 0, $indexdatabase = 1, $moreinfo = array())
+function dol_move($srcfile, $destfile, $newmask = '0', $overwriteifexists = 1, $testvirus = 0, $indexdatabase = 1, $moreinfo = array(), $entity = 0)
 {
 	global $user, $db;
 	$result = false;
@@ -1106,13 +1107,13 @@ function dol_move($srcfile, $destfile, $newmask = '0', $overwriteifexists = 1, $
 				include_once DOL_DOCUMENT_ROOT.'/ecm/class/ecmfiles.class.php';
 
 				$ecmfiletarget = new EcmFiles($db);
-				$resultecmtarget = $ecmfiletarget->fetch(0, '', $rel_filetorenameafter);
+				$resultecmtarget = $ecmfiletarget->fetch(0, '', $rel_filetorenameafter,'','','',0,$entity);
 				if ($resultecmtarget > 0) {   // An entry for target name already exists for target, we delete it, a new one will be created.
 					$ecmfiletarget->delete($user);
 				}
 
 				$ecmfile = new EcmFiles($db);
-				$resultecm = $ecmfile->fetch(0, '', $rel_filetorenamebefore);
+				$resultecm = $ecmfile->fetch(0, '', $rel_filetorenamebefore,'','','',0,$entity);
 				if ($resultecm > 0) {   // If an entry was found for src file, we use it to move entry
 					$filename = basename($rel_filetorenameafter);
 					$rel_dir = dirname($rel_filetorenameafter);
@@ -1165,6 +1166,9 @@ function dol_move($srcfile, $destfile, $newmask = '0', $overwriteifexists = 1, $
 					}
 					if (!empty($moreinfo) && !empty($moreinfo['cover'])) {
 						$ecmfile->cover = $moreinfo['cover'];
+					}
+					if(!empty($entity)) {
+						$ecmfile->entity = $entity;
 					}
 
 					$resultecm = $ecmfile->create($user);
@@ -1585,7 +1589,7 @@ function dol_delete_file($file, $disableglob = 0, $nophperrors = 0, $nohook = 0,
 								dol_syslog("Try to remove also entries in database for full relative path = ".$rel_filetodelete, LOG_DEBUG);
 								include_once DOL_DOCUMENT_ROOT.'/ecm/class/ecmfiles.class.php';
 								$ecmfile = new EcmFiles($db);
-								$result = $ecmfile->fetch(0, '', $rel_filetodelete);
+								$result = $ecmfile->fetch(0, '', $rel_filetodelete, '', '', '', 0, $object->entity ?? 0);
 								if ($result >= 0 && $ecmfile->id > 0) {
 									$result = $ecmfile->delete($user);
 								}
@@ -2038,7 +2042,7 @@ function dol_add_file_process($upload_dir, $allowoverwrite = 0, $updatesessionor
 
 						// If we allow overwrite, we may need to also overwrite index, so we delete index first so insert can work
 						if ($allowoverwrite) {
-							deleteFilesIntoDatabaseIndex($upload_dir, basename($destfile).($resupload == 2 ? '.noexe' : ''), '');
+							deleteFilesIntoDatabaseIndex($upload_dir, basename($destfile).($resupload == 2 ? '.noexe' : ''), '', $object);
 						}
 
 						$result = addFileIntoDatabaseIndex($upload_dir, basename($destfile).($resupload == 2 ? '.noexe' : ''), $TFile['name'][$i], 'uploaded', $sharefile, $object, $forceFullTextIndexation);
@@ -2208,6 +2212,9 @@ function addFileIntoDatabaseIndex($dir, $file, $fullpathorig = '', $mode = 'uplo
 			if (isset($object->src_object_keywords)) {
 				$ecmfile->keywords = $object->src_object_keywords;
 			}
+			if(isset($object->entity)) {
+				$ecmfile->entity = $object->entity;
+			}
 		}
 
 		if (getDolGlobalString('MAIN_FORCE_SHARING_ON_ANY_UPLOADED_FILE')) {
@@ -2322,9 +2329,10 @@ function addFileIntoDatabaseIndex($dir, $file, $fullpathorig = '', $mode = 'uplo
  *  @param      string	$dir			Directory name (full real path without ending /)
  *  @param		string	$file			File name
  *  @param		string	$mode			How file was created ('uploaded', 'generated', ...)
+ *  @param		Object	$object			object used for entity
  *	@return		int						Return integer <0 if KO, 0 if nothing done, >0 if OK
  */
-function deleteFilesIntoDatabaseIndex($dir, $file, $mode = 'uploaded')
+function deleteFilesIntoDatabaseIndex($dir, $file, $mode = 'uploaded', $object = null)
 {
 	global $conf, $db;
 
@@ -2348,7 +2356,11 @@ function deleteFilesIntoDatabaseIndex($dir, $file, $mode = 'uploaded')
 
 		if (!$error) {
 			$sql = 'DELETE FROM '.MAIN_DB_PREFIX.'ecm_files';
-			$sql .= ' WHERE entity = '.((int) $conf->entity);
+			if(isset($object->entity)) {
+				$sql .= ' WHERE entity = ' . ((int) $object->entity);
+			} else {
+				$sql .= ' WHERE entity = ' . ((int) $conf->entity);
+			}
 			$sql .= " AND filepath = '".$db->escape($rel_dir)."'";
 			if ($file) {
 				$sql .= " AND filename = '".$db->escape($file)."'";

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -1107,13 +1107,13 @@ function dol_move($srcfile, $destfile, $newmask = '0', $overwriteifexists = 1, $
 				include_once DOL_DOCUMENT_ROOT.'/ecm/class/ecmfiles.class.php';
 
 				$ecmfiletarget = new EcmFiles($db);
-				$resultecmtarget = $ecmfiletarget->fetch(0, '', $rel_filetorenameafter,'','','',0,$entity);
+				$resultecmtarget = $ecmfiletarget->fetch(0, '', $rel_filetorenameafter, '', '', '', 0, $entity);
 				if ($resultecmtarget > 0) {   // An entry for target name already exists for target, we delete it, a new one will be created.
 					$ecmfiletarget->delete($user);
 				}
 
 				$ecmfile = new EcmFiles($db);
-				$resultecm = $ecmfile->fetch(0, '', $rel_filetorenamebefore,'','','',0,$entity);
+				$resultecm = $ecmfile->fetch(0, '', $rel_filetorenamebefore, '', '', '', 0, $entity);
 				if ($resultecm > 0) {   // If an entry was found for src file, we use it to move entry
 					$filename = basename($rel_filetorenameafter);
 					$rel_dir = dirname($rel_filetorenameafter);
@@ -1167,7 +1167,7 @@ function dol_move($srcfile, $destfile, $newmask = '0', $overwriteifexists = 1, $
 					if (!empty($moreinfo) && !empty($moreinfo['cover'])) {
 						$ecmfile->cover = $moreinfo['cover'];
 					}
-					if(!empty($entity)) {
+					if (! empty($entity)) {
 						$ecmfile->entity = $entity;
 					}
 
@@ -2212,7 +2212,7 @@ function addFileIntoDatabaseIndex($dir, $file, $fullpathorig = '', $mode = 'uplo
 			if (isset($object->src_object_keywords)) {
 				$ecmfile->keywords = $object->src_object_keywords;
 			}
-			if(isset($object->entity)) {
+			if (isset($object->entity)) {
 				$ecmfile->entity = $object->entity;
 			}
 		}
@@ -2356,7 +2356,7 @@ function deleteFilesIntoDatabaseIndex($dir, $file, $mode = 'uploaded', $object =
 
 		if (!$error) {
 			$sql = 'DELETE FROM '.MAIN_DB_PREFIX.'ecm_files';
-			if(isset($object->entity)) {
+			if (isset($object->entity)) {
 				$sql .= ' WHERE entity = ' . ((int) $object->entity);
 			} else {
 				$sql .= ' WHERE entity = ' . ((int) $conf->entity);

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -408,9 +408,10 @@ class EcmFiles extends CommonObject
 	 * @param  string $hashforshare    	Hash of file sharing, or 'shared'
 	 * @param  string $src_object_type 	src_object_type to search (value of object->table_element)
 	 * @param  int    $src_object_id 	src_object_id to search
+	 * @param  int    $entity 	        entity
 	 * @return int                 	   	Return integer <0 if KO, 0 if not found, >0 if OK
 	 */
-	public function fetch($id, $ref = '', $relativepath = '', $hashoffile = '', $hashforshare = '', $src_object_type = '', $src_object_id = 0)
+	public function fetch($id, $ref = '', $relativepath = '', $hashoffile = '', $hashforshare = '', $src_object_type = '', $src_object_id = 0, $entity = 0)
 	{
 		global $conf;
 
@@ -457,17 +458,29 @@ class EcmFiles extends CommonObject
 			if ($filename != '*') {
 				$sql .= " AND t.filename = '".$this->db->escape($filename)."'";
 			}
-			$sql .= " AND t.entity = ".$conf->entity; // unique key include the entity so each company has its own index
+			if(!empty($entity)) {
+				$sql .= " AND t.entity = " . $entity;
+			} else {
+				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
+			}
 			$filterfound++;
 		}
 		if (!empty($ref)) {		// hash of file path
 			$sql .= " AND t.ref = '".$this->db->escape($ref)."'";
-			$sql .= " AND t.entity = ".$conf->entity; // unique key include the entity so each company has its own index
+			if(!empty($entity)) {
+				$sql .= " AND t.entity = " . $entity;
+			} else {
+				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
+			}
 			$filterfound++;
 		}
 		if (!empty($hashoffile)) {	// hash of content
 			$sql .= " AND t.label = '".$this->db->escape($hashoffile)."'";
-			$sql .= " AND t.entity = ".$conf->entity; // unique key include the entity so each company has its own index
+			if(!empty($entity)) {
+				$sql .= " AND t.entity = " . $entity;
+			} else {
+				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
+			}
 			$filterfound++;
 		}
 		if (!empty($hashforshare)) {
@@ -481,7 +494,11 @@ class EcmFiles extends CommonObject
 		}
 		if ($src_object_type && $src_object_id) {
 			$sql .= " AND t.src_object_type = '".$this->db->escape($src_object_type)."' AND t.src_object_id = ".((int) $src_object_id);
-			$sql .= " AND t.entity = ".((int) $conf->entity);
+			if(!empty($entity)) {
+				$sql .= " AND t.entity = " . $entity;
+			} else {
+				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
+			}
 			$filterfound++;
 		}
 		if ($id > 0 || empty($filterfound)) {
@@ -766,7 +783,6 @@ class EcmFiles extends CommonObject
 		$sql .= ' src_object_id = '.($this->src_object_id > 0 ? $this->src_object_id : "null").',';
 		$sql .= ' src_object_type = '.(isset($this->src_object_type) ? "'".$this->db->escape($this->src_object_type)."'" : "null");
 		$sql .= ' WHERE rowid='.((int) $this->id);
-
 		$this->db->begin();
 
 		$resql = $this->db->query($sql);

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -458,7 +458,7 @@ class EcmFiles extends CommonObject
 			if ($filename != '*') {
 				$sql .= " AND t.filename = '".$this->db->escape($filename)."'";
 			}
-			if(!empty($entity)) {
+			if (! empty($entity)) {
 				$sql .= " AND t.entity = " . $entity;
 			} else {
 				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
@@ -467,7 +467,7 @@ class EcmFiles extends CommonObject
 		}
 		if (!empty($ref)) {		// hash of file path
 			$sql .= " AND t.ref = '".$this->db->escape($ref)."'";
-			if(!empty($entity)) {
+			if (! empty($entity)) {
 				$sql .= " AND t.entity = " . $entity;
 			} else {
 				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
@@ -476,7 +476,7 @@ class EcmFiles extends CommonObject
 		}
 		if (!empty($hashoffile)) {	// hash of content
 			$sql .= " AND t.label = '".$this->db->escape($hashoffile)."'";
-			if(!empty($entity)) {
+			if (! empty($entity)) {
 				$sql .= " AND t.entity = " . $entity;
 			} else {
 				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
@@ -494,7 +494,7 @@ class EcmFiles extends CommonObject
 		}
 		if ($src_object_type && $src_object_id) {
 			$sql .= " AND t.src_object_type = '".$this->db->escape($src_object_type)."' AND t.src_object_id = ".((int) $src_object_id);
-			if(!empty($entity)) {
+			if (! empty($entity)) {
 				$sql .= " AND t.entity = " . $entity;
 			} else {
 				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -459,7 +459,7 @@ class EcmFiles extends CommonObject
 				$sql .= " AND t.filename = '".$this->db->escape($filename)."'";
 			}
 			if (! empty($entity)) {
-				$sql .= " AND t.entity = " . $entity;
+				$sql .= " AND t.entity = " . (int) $entity;
 			} else {
 				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
 			}
@@ -468,7 +468,7 @@ class EcmFiles extends CommonObject
 		if (!empty($ref)) {		// hash of file path
 			$sql .= " AND t.ref = '".$this->db->escape($ref)."'";
 			if (! empty($entity)) {
-				$sql .= " AND t.entity = " . $entity;
+				$sql .= " AND t.entity = " . (int) $entity;
 			} else {
 				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
 			}
@@ -477,7 +477,7 @@ class EcmFiles extends CommonObject
 		if (!empty($hashoffile)) {	// hash of content
 			$sql .= " AND t.label = '".$this->db->escape($hashoffile)."'";
 			if (! empty($entity)) {
-				$sql .= " AND t.entity = " . $entity;
+				$sql .= " AND t.entity = " . (int) $entity;
 			} else {
 				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
 			}
@@ -495,7 +495,7 @@ class EcmFiles extends CommonObject
 		if ($src_object_type && $src_object_id) {
 			$sql .= " AND t.src_object_type = '".$this->db->escape($src_object_type)."' AND t.src_object_id = ".((int) $src_object_id);
 			if (! empty($entity)) {
-				$sql .= " AND t.entity = " . $entity;
+				$sql .= " AND t.entity = " . (int) $entity;
 			} else {
 				$sql .= " AND t.entity = " . $conf->entity; // unique key include the entity so each company has its own index
 			}

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -783,7 +783,7 @@ if (empty($reshook)) {
 								if (getDolGlobalString('THIRDPARTY_LOGO_ALLOW_EXTERNAL_DOWNLOAD')) {
 									require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 									// the dir dirname($newfile) is directory of logo, so we should have only one file at once into index, so we delete indexes for the dir
-									deleteFilesIntoDatabaseIndex(dirname($newfile), '', '');
+									deleteFilesIntoDatabaseIndex(dirname($newfile), '', '', $object);
 									// now we index the uploaded logo file
 									addFileIntoDatabaseIndex(dirname($newfile), basename($newfile), '', 'uploaded', 1);
 								}


### PR DESCRIPTION
# Fix ECM  add support for custom entity in file operations

This commit addresses missing support for specifying custom entity values during file operations, ensuring proper handling of multi-entity configurations.

The current implementation has an issue where adding an attachment from entity 1 to a product created on entity 2 results in the file being indexed under entity 1. This inconsistency leads to warnings and data integrity problems.

Changes in this PR:

    Adds an entity parameter to the fetch method of EcmFiles and ensures proper filtering based on the provided entity.

    Modifies dol_move, deleteFilesIntoDatabaseIndex, and other file-related functions to properly support the entity parameter.

    Ensures correct entity propagation in operations like file indexing, renaming, and deletion.

This change resolves the existing warnings and addresses the core inconsistency issue, significantly improving flexibility and correctness in multi-entity setups. The codebase is now more robust and aligns with expected behavior for shared resources across different entities.

