### PR TITLE
fix: with PRODUCT_USE_UNIT preset the unit in document

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -870,6 +870,11 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 							$('#date_start').attr('type', data.type);
 							$('#date_end').attr('type', data.type);
 
+							if(<?php echo getDolGlobalInt('PRODUCT_USE_UNITS'); ?>) {
+								console.log("objectline_create.tpl set content of units");
+								jQuery("#units").val(data.default_unit).change();
+							}
+
 							$('#date_start').removeAttr('mandatoryperiod');
 							$('#date_end').removeAttr('mandatoryperiod');
 							$('#date_start').attr('mandatoryperiod', data.mandatory_period);

--- a/htdocs/product/ajax/products.php
+++ b/htdocs/product/ajax/products.php
@@ -102,6 +102,7 @@ if ($action == 'fetch' && !empty($id)) {
 		$outref = $object->ref;
 		$outlabel = $object->label;
 		$outlabel_trans = '';
+		$default_unit = $object->fk_unit;
 		$outdesc = $object->description;
 		$outdesc_trans = '';
 		$outtype = $object->type;
@@ -294,7 +295,9 @@ if ($action == 'fetch' && !empty($id)) {
 			'qty' => $outqty,
 			'discount' => $outdiscount,
 			'mandatory_period' => $mandatory_period,
-			'array_options' => $object->array_options
+			'array_options' => $object->array_options,
+
+			'default_unit'=>$default_unit
 		);
 	}
 


### PR DESCRIPTION
# Instructions
- Set PRODUCT_USE_UNIT to 1
 - On a product set m2 as default unit

create a Proposal, select the product, the unit is not defaulted with the product unit selected

# PR Detail
Add default unit as data provided by htdocs/product/ajax/products.php

Use it in template htdocs/core/tpl/objectline_create.tpl.php if needed