### PR TITLE
Fix: Use reception email templates for receptions

### DIFF
--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -2271,7 +2271,7 @@ if ($action == 'create') {
 	}
 
 	// Presend form
-	$modelmail = 'shipping_send';
+	$modelmail = 'reception_send';
 	$defaulttopic = 'SendReceptionRef';
 	$diroutput = $conf->reception->dir_output;
 	$trackid = 'rec'.$object->id;


### PR DESCRIPTION
# Fix Use reception email templates for receptions

Clicking send via email in a reception card queries the database for email templates `WHERE type_template = 'shipping_send'`

#### Log line before change

```
2025-09-11 13:34:19 DEBUG   10.21.16.4 [via 10.25.10.130]  291213     33 sql=SELECT rowid, module, label, topic, content, content_lines, lang, fk_user, private, position FROM llx_c_email_templates WHERE type_template IN ('shipping_send', 'all') AND entity IN (0,1) AND (private = 0 OR fk_user = 12) AND active = 1 ORDER BY position ASC, lang ASC, label ASC
```

When creating an email template and selecting Reception in the template type dropdown, the template is added to the `llx_c_email_templates` table with `type_template='reception_send'`

#### Log line for modifying the email template

```
2025-09-11 14:19:45 DEBUG   10.21.16.4 [via 10.25.10.130]  282075     33 sql=UPDATE llx_c_email_templates SET label='Wareneingang an Bestellungs Author', lang=null, type_template='reception_send', fk_user= 12, private=0, position=1, topic='Neuer Wareneingang', email_from='noreply@example.com', joinfiles=null, defaultfortype=0, content='Wareneingang für Bestellung abc', entity='1' WHERE rowid = 24

```

This PR changes the `$modelmail` variable in `htdocs/reception/card.php l. 2274` to `'reception_send'` resulting in the correct sql query for the email templates.

#### Log line after change

```
2025-09-11 14:17:50 DEBUG   10.21.16.4 [via 10.25.10.130]  257438     33 sql=SELECT rowid, module, label, topic, content, content_lines, lang, fk_user, private, position FROM llx_c_email_templates WHERE type_template IN ('reception_send', 'all') AND entity IN (0,1) AND (private = 0 OR fk_user = 12) AND active = 1 ORDER BY position ASC, lang ASC, label ASC

```
