### PR TITLE
exclude escpos-php/doc from filelist_xml

### DIFF
--- a/build/generate_filelist_xml.php
+++ b/build/generate_filelist_xml.php
@@ -172,7 +172,7 @@ $files = new RegexIterator($iterator1, '#^(?:[A-Z]:)?(?:/(?!(?:'.($includecustom
 */
 // Define qualified files (must be same than into generate_filelist_xml.php and in api_setup.class.php)
 $regextoinclude = '\.(php|php3|php4|php5|phtml|phps|phar|inc|css|scss|html|xml|js|json|tpl|jpg|jpeg|png|gif|ico|sql|lang|txt|yml|bak|md|mp3|mp4|wav|mkv|z|gz|zip|rar|tar|less|svg|eot|woff|woff2|ttf|manifest)$';
-$regextoexclude = '('.($includecustom?'':'custom|').'documents|conf|install|dejavu-fonts-ttf-.*|public\/test|sabre\/sabre\/.*\/tests|Shared\/PCLZip|nusoap\/lib\/Mail|php\/example|php\/test|geoip\/sample.*\.php|ckeditor\/samples|ckeditor\/adapters)$';  // Exclude dirs
+$regextoexclude = '('.($includecustom?'':'custom|').'documents|escpos-php\/doc|conf|install|dejavu-fonts-ttf-.*|public\/test|sabre\/sabre\/.*\/tests|Shared\/PCLZip|nusoap\/lib\/Mail|php\/example|php\/test|geoip\/sample.*\.php|ckeditor\/samples|ckeditor\/adapters)$';  // Exclude dirs
 $files = dol_dir_list(DOL_DOCUMENT_ROOT, 'files', 1, $regextoinclude, $regextoexclude, 'fullname');
 
 $dir='';


### PR DESCRIPTION
sorry for that PR on 18.0 branch but here is the result of integrity test of 18.0.8

<img width="1508" height="1668" alt="image" src="https://github.com/user-attachments/assets/7b2e3493-aaca-4625-97f4-bd555c060c05" />

/includes/mike42/escpos-php/doc/FAQ.md is missing because of the main pl script who makes a rm -rf of that directory ... but the file is included into the php script who make integrity list so i have to make a choice