### PR TITLE
Fix update order line

### DIFF
--- a/htdocs/commande/class/orderline.class.php
+++ b/htdocs/commande/class/orderline.class.php
@@ -589,6 +589,9 @@ class OrderLine extends CommonOrderLine
 		if (empty($this->remise_percent)) {
 			$this->remise_percent = 0;
 		}
+		if (empty($this->price)) {
+			$this->price = 0;
+		}
 		if (empty($this->remise)) {
 			$this->remise = 0;
 		}


### PR DESCRIPTION
NEW
Fix SQL update query in update() function, when doing an update and if the price field is empty invalid SQL is generated, add a check that sets price to 0 if empty leading to correct SQL statement being generated and executed

2025-09-12 01:18:36 DEBUG   120.157.238.154   91134     33   sql=UPDATE llx_commandedet SET description='Top of tag: Logo with \"YARRANDOO\" (see previous order)<br>\nLine 1 (35mm): {3586-3655}<br>\nLine 2 (10mm): 0427 603021' , label=null , vat_src_code='' , tva_tx=10 , localtax1_tx=0 , localtax2_tx=0 , localtax1_type='0' , localtax2_type='0' , qty=70 , ref_ext='' , subprice=0.85 , remise_percent=0 , price= , remise=0 , total_ht=59.5 , total_tva=5.95 , total_ttc=65.45 , total_localtax1=0 , total_localtax2=0 , fk_product_fournisseur_price=null , buy_price_ht='0.15' , info_bits=0 , special_code=0 , date_start=null , date_end=null , product_type=1 , fk_parent_line=null , fk_unit=NULL , multicurrency_subprice=0.85 , multicurrency_total_ht=59.5 , multicurrency_total_tva=5.95 , multicurrency_total_ttc=65.45 WHERE rowid = 9496

2025-09-12 01:18:36 ERR     120.157.238.154   91134     33   DoliDBMysqli::query Exception in query instead of returning an error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ' remise=0 , total_ht=59.5 , total_tva=5.95 , total_ttc=65.45 , total_localtax...' at line 1

2025-09-12 01:18:36 ERR     120.157.238.154   91134     33   DoliDBMysqli::query SQL Error message: DB_ERROR_SYNTAX You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ' remise=0 , total_ht=59.5 , total_tva=5.95 , total_ttc=65.45 , total_localtax...' at line 1 From /var/www/endurotags-cloud/dolibarr/htdocs/commande/class/orderline.class.php:671.
