### PR TITLE
FIX 17.0: ContratLigne::fetch() returns 1 even if the line doesn't exist

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3079,7 +3079,7 @@ class ContratLigne extends CommonObjectLine
 	 *
 	 *  @param	int		$id         Id object
 	 *  @param	string	$ref		Ref of contract line
-	 *  @return int         		<0 if KO, >0 if OK
+	 *  @return int         		<0 if KO, >0 if OK, 0 if not found
 	 */
 	public function fetch($id, $ref = '')
 	{
@@ -3200,6 +3200,9 @@ class ContratLigne extends CommonObjectLine
 				$this->rang = $obj->rang;
 
 				$this->fetch_optionals();
+			} else {
+				$this->db->free($resql);
+				return 0;
 			}
 
 			$this->db->free($resql);


### PR DESCRIPTION
# FIX return value for ContratLigne::fetch() when line not found
I just noticed that `ContratLigne::fetch()` returns 1 even when the line being fetched doesn't exist. This makes no sense to me and creates difficulty when debugging.

This bug is still present even in Dolibarr 21.0, though not in the same file, as the `ContratLigne` class was moved to its own file :+1:.

I'm not 100% sure about returning 0: maybe we could return -1 (I thought 0 was more in line with Dolibarr's usual convention).

I noticed it while debugging an API call to delete a contract line. The contract line doesn't exist, but the API returned a  405 (Method not allowed) error, which isn't very helpful in this case.