### PR TITLE
FIX #34678 Expense Reports now don't use VAT when Organization don't use Sales tax

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -2634,7 +2634,7 @@ if ($action == 'create') {
 					// If option to have no default VAT on expense report is on, we force MAIN_VAT_DEFAULT_IF_AUTODETECT_FAILS
 					$conf->global->MAIN_VAT_DEFAULT_IF_AUTODETECT_FAILS = 'none';
 				}
-				print $form->load_tva('vatrate', (!empty($vatrate) ? $vatrate : $defaultvat), null, null, 0, 0, '', false, 1);
+				print $form->load_tva('vatrate', (!empty($vatrate) ? $vatrate : $defaultvat), $mysoc, null, 0, 0, '', false, 1);
 				print '</td>';
 
 				// Unit price net


### PR DESCRIPTION
# FIX #34678 Expense Reports now don't use VAT when Organization don't use Sales tax

`htdocs/expensereport/card.php` uses the function `load_tva()` twice in the file: 
- first when editing an already-existing line;
- second when adding a new line in the expense report.

The second one, as reported in #34678, displays all VAT rates even if the organization set in Dolibarr doesn't use Sales taxes. The problem becomes even more obvious where you try editing the line you just added: there, the VAT rates are not displayed, and if you entered one at the beginning, now you are losing the information.

I found out that the call to `load_tva()` doesn't use the same parameters in the two cases. On the correct one, `$mysoc` is used to fill in the `$societe_acheteuse` parameter, whereas `null` is passed in the buggy case. Passing `$mysoc` makes `load_tva()` not displaying any VAT rates as intended.

Bug was reproduced on 21, 22, and develop. I haven't checked on older versions.


