### PR TITLE
Fix WAF alert ModSecurity: Access denied with code 403 (phase 4).

### DIFF
--- a/htdocs/core/lib/security2.lib.php
+++ b/htdocs/core/lib/security2.lib.php
@@ -608,7 +608,7 @@ function showEyeForField($htmlname, $htmlnameofinput)
 {
 	return '<!-- code to manage the eye hide/show -->
 <span id="'.$htmlname.'" tabindex="-1"><span class="fa fa-eye"></span></span>
-<script nonce="<?php echo getNonce(); ?>">
+<script nonce="'.getNonce().'">
 	$(document).ready(function () {
 		$(\'#'.$htmlname.'\').on(\'click\', function (e) {
 			e.preventDefault();


### PR DESCRIPTION
# Instructions

# FIX
If you use WAF and mod security for the V22 server, this triggers a 403 error during front-end connection.

This is because WAF detects direct exposure of PHP.
