### PR TITLE
Fix:prevent handling update action by  generic include of actions_addupdatedelete.inc.php

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -282,10 +282,10 @@ if (empty($reshook)) {
 
 		if (! $error) {
 			$db->commit();
-			$action = '';
 		} else {
 			$db->rollback();
 		}
+		$action = '';
 	}
 
 	// Save quantity found during inventory (when we click on Save button on inventory page)

--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -282,6 +282,7 @@ if (empty($reshook)) {
 
 		if (! $error) {
 			$db->commit();
+			$action = '';
 		} else {
 			$db->rollback();
 		}


### PR DESCRIPTION
Fix:
To prevent the generic post-update action in inventories (/core/actions_addupdatedelete.inc.php) from handling the update action again, the $action variable must be unset after the first handling; otherwise, the $object fields will be overwritten with empty values.