### PR TITLE
fix: bad selected log level if set to 4 - warning

### DIFF
--- a/htdocs/admin/syslog.php
+++ b/htdocs/admin/syslog.php
@@ -315,14 +315,14 @@ print "</tr>\n";
 
 print '<tr class="oddeven"><td>'.$langs->trans("SyslogLevel").'</td>';
 print '<td colspan="2"><select class="flat minwidth400" id="level" name="level" '.$optionmc.'>';
-print '<option value="'.LOG_EMERG.'" '.($conf->global->SYSLOG_LEVEL == LOG_EMERG ? 'SELECTED' : '').'>LOG_EMERG ('.LOG_EMERG.')</option>';
-print '<option value="'.LOG_ALERT.'" '.($conf->global->SYSLOG_LEVEL == LOG_ALERT ? 'SELECTED' : '').'>LOG_ALERT ('.LOG_ALERT.')</option>';
-print '<option value="'.LOG_CRIT.'" '.($conf->global->SYSLOG_LEVEL == LOG_CRIT ? 'SELECTED' : '').'>LOG_CRIT ('.LOG_CRIT.')</option>';
-print '<option value="'.LOG_ERR.'" '.($conf->global->SYSLOG_LEVEL == LOG_ERR ? 'SELECTED' : '').'>LOG_ERR ('.LOG_ERR.')</option>';
-print '<option value="'.LOG_WARNING.'" '.($conf->global->SYSLOG_LEVEL == LOG_WARNING ? 'SELECTED' : '').'">LOG_WARNING ('.LOG_WARNING.')</option>';
-print '<option value="'.LOG_NOTICE.'" '.($conf->global->SYSLOG_LEVEL == LOG_NOTICE ? 'SELECTED' : '').' data-html="'.dol_escape_htmltag('LOG_NOTICE ('.LOG_NOTICE.') - <span class="opacitymedium">'.$langs->trans("RecommendedForProduction").'</span>').'">LOG_NOTICE ('.LOG_NOTICE.')</option>';
-print '<option value="'.LOG_INFO.'" '.($conf->global->SYSLOG_LEVEL == LOG_INFO ? 'SELECTED' : '').'>LOG_INFO ('.LOG_INFO.')</option>';
-print '<option value="'.LOG_DEBUG.'" '.($conf->global->SYSLOG_LEVEL >= LOG_DEBUG ? 'SELECTED' : '').' data-html="'.dol_escape_htmltag('LOG_DEBUG ('.LOG_DEBUG.') - <span class="opacitymedium">'.$langs->trans("RecommendedForDebug").'</span>').'">LOG_DEBUG ('.LOG_DEBUG.')</option>';
+print '<option value="'.LOG_EMERG.'" '.($conf->global->SYSLOG_LEVEL == LOG_EMERG ? 'selected' : '').'>LOG_EMERG ('.LOG_EMERG.')</option>';
+print '<option value="'.LOG_ALERT.'" '.($conf->global->SYSLOG_LEVEL == LOG_ALERT ? 'selected' : '').'>LOG_ALERT ('.LOG_ALERT.')</option>';
+print '<option value="'.LOG_CRIT.'" '.($conf->global->SYSLOG_LEVEL == LOG_CRIT ? 'selected' : '').'>LOG_CRIT ('.LOG_CRIT.')</option>';
+print '<option value="'.LOG_ERR.'" '.($conf->global->SYSLOG_LEVEL == LOG_ERR ? 'selected' : '').'>LOG_ERR ('.LOG_ERR.')</option>';
+print '<option value="'.LOG_WARNING.'" '.($conf->global->SYSLOG_LEVEL == LOG_WARNING ? 'selected' : '').'>LOG_WARNING ('.LOG_WARNING.')</option>';
+print '<option value="'.LOG_NOTICE.'" '.($conf->global->SYSLOG_LEVEL == LOG_NOTICE ? 'selected' : '').' data-html="'.dol_escape_htmltag('LOG_NOTICE ('.LOG_NOTICE.') - <span class="opacitymedium">'.$langs->trans("RecommendedForProduction").'</span>').'">LOG_NOTICE ('.LOG_NOTICE.')</option>';
+print '<option value="'.LOG_INFO.'" '.($conf->global->SYSLOG_LEVEL == LOG_INFO ? 'selected' : '').'>LOG_INFO ('.LOG_INFO.')</option>';
+print '<option value="'.LOG_DEBUG.'" '.($conf->global->SYSLOG_LEVEL >= LOG_DEBUG ? 'selected' : '').' data-html="'.dol_escape_htmltag('LOG_DEBUG ('.LOG_DEBUG.') - <span class="opacitymedium">'.$langs->trans("RecommendedForDebug").'</span>').'">LOG_DEBUG ('.LOG_DEBUG.')</option>';
 print '</select>';
 
 print ajax_combobox("level");


### PR DESCRIPTION
**Bug Reproducibility**
In Debug Logs module set log to 4 : WARNING

Result => Log level selected in select is 0  : Emergency 

In llx_const the value is correctly set to 4

**Cause of this "bad" selected option** 
<img width="1038" height="929" alt="image" src="https://github.com/user-attachments/assets/ca4a6103-33a5-42f4-9254-2f5e317d4742" />

There is a double quote in the "selected" option 

`<option value="4" selected"="">LOG_WARNING (4)</option>`

selected **"** =""

I've also set "selected" in lowercase according to HTML5 specification



