### PR TITLE
NEW: add contact list parameter to ticket API endpoints to control contact data retrieval

### DIFF
--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -67,16 +67,17 @@ class Tickets extends DolibarrApi
 	 *
 	 * Return an array with ticket information
 	 *
-	 * @param	int				$id			ID of ticket
-	 * @return  Object						Object with cleaned properties
+	 * @param	int				$id				ID of ticket
+	 * @param   int         	$contact_list	0: Returned array of contacts/addresses contains all properties, 1: Return array contains just id, -1: Do not return contacts/adddesses
+	 * @return  Object							Object with cleaned properties
 	 *
 	 * @throws RestException 401
 	 * @throws RestException 403
 	 * @throws RestException 404
 	 */
-	public function get($id)
+	public function get($id, $contact_list = 1)
 	{
-		return $this->getCommon($id, '', '');
+		return $this->getCommon($id, '', '', $contact_list);
 	}
 
 	/**
@@ -84,8 +85,9 @@ class Tickets extends DolibarrApi
 	 *
 	 * Return an array with ticket information
 	 *
-	 * @param	string			$track_id	Tracking ID of ticket
-	 * @return	array|mixed					Data without useless information
+	 * @param	string			$track_id		Tracking ID of ticket
+	 * @param   int         	$contact_list	0: Returned array of contacts/addresses contains all properties, 1: Return array contains just id, -1: Do not return contacts/adddesses
+	 * @return	array|mixed						Data without useless information
 	 *
 	 * @url GET track_id/{track_id}
 	 *
@@ -93,9 +95,9 @@ class Tickets extends DolibarrApi
 	 * @throws RestException	403
 	 * @throws RestException	404
 	 */
-	public function getByTrackId($track_id)
+	public function getByTrackId($track_id, $contact_list = 1)
 	{
-		return $this->getCommon(0, $track_id, '');
+		return $this->getCommon(0, $track_id, '', $contact_list);
 	}
 
 	/**
@@ -103,8 +105,9 @@ class Tickets extends DolibarrApi
 	 *
 	 * Return an array with ticket information
 	 *
-	 * @param	string			$ref		Reference for ticket
-	 * @return	array|mixed					Data without useless information
+	 * @param	string			$ref			Reference for ticket
+	 * @param   int         	$contact_list	0: Returned array of contacts/addresses contains all properties, 1: Return array contains just id, -1: Do not return contacts/adddesses
+	 * @return	array|mixed						Data without useless information
 	 *
 	 * @url GET ref/{ref}
 	 *
@@ -112,21 +115,22 @@ class Tickets extends DolibarrApi
 	 * @throws RestException 403
 	 * @throws RestException 404
 	 */
-	public function getByRef($ref)
+	public function getByRef($ref, $contact_list = 1)
 	{
-		return $this->getCommon(0, '', $ref);
+		return $this->getCommon(0, '', $ref, $contact_list);
 	}
 
 	/**
 	 * Get properties of a Ticket object
 	 * Return an array with ticket information
 	 *
-	 * @param	int				$id			ID of ticket
-	 * @param	string			$track_id	Tracking ID of ticket
-	 * @param	string			$ref		Reference for ticket
-	 * @return	array|mixed					Data without useless information
+	 * @param	int				$id				ID of ticket
+	 * @param	string			$track_id		Tracking ID of ticket
+	 * @param	string			$ref			Reference for ticket
+	 * @param   int         	$contact_list	0: Returned array of contacts/addresses contains all properties, 1: Return array contains just id, -1: Do not return contacts/adddesses
+	 * @return	array|mixed						Data without useless information
 	 */
-	private function getCommon($id = 0, $track_id = '', $ref = '')
+	private function getCommon($id = 0, $track_id = '', $ref = '', $contact_list = 1)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('ticket', 'read')) {
 			throw new RestException(403);
@@ -184,6 +188,19 @@ class Tickets extends DolibarrApi
 		if (!DolibarrApi::_checkAccessToResource('ticket', $this->ticket->id)) {
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
+
+		if ($contact_list > -1) {
+			// Add external contacts ids
+			$tmparray = $this->ticket->liste_contact(-1, 'external', $contact_list);
+			if (is_array($tmparray)) {
+				$this->ticket->contacts_ids = $tmparray;
+			}
+			$tmparray = $this->ticket->liste_contact(-1, 'internal', $contact_list);
+			if (is_array($tmparray)) {
+				$this->ticket->contacts_ids_internal = $tmparray;
+			}
+		}
+
 		return $this->_cleanObjectDatas($this->ticket);
 	}
 
@@ -198,14 +215,15 @@ class Tickets extends DolibarrApi
 	 * @param int		$limit		Limit for list
 	 * @param int		$page		Page number
 	 * @param string	$sqlfilters Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101') and (t.fk_statut:=:1)"
-	 * @param string    $properties	Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+	 * @param string    $properties		Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
+	 * @param int		$loadcontacts		Load also contacts/addresses (0=No, 1=Yes)
 	 * @param bool             $pagination_data     If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
 	 *
 	 * @return array Array of ticket objects
 	 * @phan-return Ticket[]|array{data:Ticket[],pagination:array{total:int,page:int,page_count:int,limit:int}}
 	 * @phpstan-return Ticket[]|array{data:Ticket[],pagination:array{total:int,page:int,page_count:int,limit:int}}
 	 */
-	public function index($socid = 0, $sortfield = "t.rowid", $sortorder = "ASC", $limit = 100, $page = 0, $sqlfilters = '', $properties = '', $pagination_data = false)
+	public function index($socid = 0, $sortfield = "t.rowid", $sortorder = "ASC", $limit = 100, $page = 0, $sqlfilters = '', $properties = '', $loadcontacts = 0, $pagination_data = false)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('ticket', 'read')) {
 			throw new RestException(403);
@@ -274,6 +292,19 @@ class Tickets extends DolibarrApi
 						$userStatic->fetch($ticket_static->fk_user_assign);
 						$ticket_static->fk_user_assign_string = $userStatic->firstname.' '.$userStatic->lastname;
 					}
+
+					if ($loadcontacts) {
+						// Add external contacts ids
+						$tmparray = $ticket_static->liste_contact(-1, 'external', 1);
+						if (is_array($tmparray)) {
+							$ticket_static->contacts_ids = $tmparray;
+						}
+						$tmparray = $ticket_static->liste_contact(-1, 'internal', 1);
+						if (is_array($tmparray)) {
+							$ticket_static->contacts_ids_internal = $tmparray;
+						}
+					}
+
 					$obj_ret[] = $this->_filterObjectProperties($this->_cleanObjectDatas($ticket_static), $properties);
 				}
 				$i++;


### PR DESCRIPTION
# FIX|Fix API tickets contacts_ids and contacts_ids_internal always return null
The tickets API was returning null for `contacts_ids` and `contacts_ids_internal` in both single ticket and list endpoints, even when contacts were properly associated with the tickets.

**Root cause:** Unlike other Dolibarr APIs (orders, interventions, etc.), the tickets API was missing contact loading functionality entirely in both [getCommon()](cci:1://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/ticket/class/api_tickets.class.php:122:1-204:2) and [index()](cci:1://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/commande/class/api_orders.class.php:157:1-296:2) methods.

**Solution:** Added comprehensive contact loading functionality following Dolibarr's established patterns:

**Single ticket endpoints ([get](cci:1://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/commande/class/api_orders.class.php:56:1-70:2), [getByTrackId](cci:1://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/ticket/class/api_tickets.class.php:82:1-100:2), [getByRef](cci:1://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/commande/class/api_orders.class.php:72:1-88:2)):**
- Added optional `$contact_list` parameter (default: 1 = load contacts)
- Implemented contact loading in [getCommon()](cci:1://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/ticket/class/api_tickets.class.php:122:1-204:2) method:
  - External contacts via [liste_contact(-1, 'external', $contact_list)](cci:1://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/core/class/commonobject.class.php:1513:1-1630:2)
  - Internal contacts via [liste_contact(-1, 'internal', $contact_list)](cci:1://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/core/class/commonobject.class.php:1513:1-1630:2)

**List tickets endpoint ([index](cci:1://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/commande/class/api_orders.class.php:157:1-296:2)):**
- Added optional `$loadcontacts` parameter (default: 0 = don't load contacts for performance)
- Implemented conditional contact loading to avoid performance issues with large lists
- Only loads contacts when explicitly requested via `loadcontacts=1`

**Files changed:**
- [htdocs/ticket/class/api_tickets.class.php](cci:7://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/ticket/class/api_tickets.class.php:0:0-0:0)

**API Usage:**
- Single ticket with contacts (default): `GET /tickets/{id}`
- Single ticket without contacts: `GET /tickets/{id}?contact_list=-1`
- List tickets without contacts (default): `GET /tickets`
- List tickets with contacts: `GET /tickets?loadcontacts=1`

**Testing:**
- Verified that single ticket endpoints now return populated `contacts_ids` and `contacts_ids_internal`
- Confirmed that list endpoint performance is maintained by default (no contacts loaded)
- Validated that `loadcontacts=1` parameter correctly loads contacts in list queries
- No breaking changes to existing API behavior

This fix ensures consistency with other Dolibarr APIs while maintaining optimal performance for large ticket lists.