### PR TITLE
Problem in Gantt view. Tasks in project

### DIFF
--- a/htdocs/projet/ganttchart.inc.php
+++ b/htdocs/projet/ganttchart.inc.php
@@ -140,8 +140,8 @@ if (g.getDivId() != null)
 			'task_alternate_id' => (int) -$t['task_project_id'],
 			'task_name' => $projecttmp->ref.' '.$projecttmp->title,
 			'task_resources' => '',
-			'task_start_date' => 0,
-			'task_end_date' => 0,
+			'task_start_date' => $projecttmp->date_start,
+			'task_end_date' => $projecttmp->date_end,
 			'task_is_group' => 1, 'task_position' => 0, 'task_css' => 'ggroupblack', 'task_milestone' => 0, 'task_parent' => 0, 'task_parent_alternate_id' => 0,
 			'note' => '',
 			'task_planned_workload' => 0

--- a/htdocs/projet/ganttview.php
+++ b/htdocs/projet/ganttview.php
@@ -204,7 +204,7 @@ if (($id > 0 && is_numeric($id)) || !empty($ref)) {
 	print '</td></tr>';
 
 	// Date start - end project
-	print '<tr><td>'.$langs->trans("Dates").'</td><td>';
+	print '<tr><td>'.$langs->trans("DateStart").' - '.$langs->trans("DateEnd").'</td><td>';
 	$start = dol_print_date($object->date_start, 'day');
 	print($start ? $start : '?');
 	$end = dol_print_date($object->date_end, 'day');


### PR DESCRIPTION
Fixes #35411

# FIX|Fix #35411 Project dates display incorrectly in Gantt view and translation issues

## Issues Fixed

### 1. Project Dates Displaying as 01/01/70
**Problem**: In the Gantt view ([/projet/ganttview.php](cci:7://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/projet/ganttview.php:0:0-0:0)), project dates were showing as "01/01/70" instead of the actual project dates (e.g., "09/28/2025 - 10/15/2025").

**Root Cause**: In [htdocs/projet/ganttchart.inc.php](cci:7://file:///c:/Users/cehoj/OneDrive/Documentos/www/dolibarr/htdocs/projet/ganttchart.inc.php:0:0-0:0) lines 143-144, the project start and end dates were hardcoded to `0`, which represents the Unix epoch (January 1, 1970).

**Solution**: Changed the hardcoded values to use the actual project dates from the fetched project object:
```php
// Before:
'task_start_date' => 0,
'task_end_date' => 0,

// After:
'task_start_date' => $projecttmp->date_start,
'task_end_date' => $projecttmp->date_end,