### PR TITLE
Update recap-fourn.php

### DIFF
--- a/htdocs/fourn/recap-fourn.php
+++ b/htdocs/fourn/recap-fourn.php
@@ -107,6 +107,7 @@ if ($socid > 0) {
 		print '<td class="right">' . $langs->trans("Author") . '</td>';
 		print '</tr>';
 
+		/** @var array<array{fk_facture?:int,fk_paiement?:int,date:int|string,datefieldforsort:string,link:string,status:string,amount:float,balance?:float,author:string}> $TData */
 		$TData = array();
 
 		$sql = "SELECT s.nom, s.rowid as socid, f.ref_supplier, f.total_ttc, f.datef as df,";

--- a/htdocs/fourn/recap-fourn.php
+++ b/htdocs/fourn/recap-fourn.php
@@ -96,9 +96,15 @@ if ($socid > 0) {
 		// Invoice list
 		print load_fiche_titre($langs->trans("SupplierPreview"));
 
+		// Add parameter for sorting
+		$param = '';
+		if ($socid > 0) {
+			$param .= '&socid=' . $socid;
+		}
+
 		print '<table class="noborder tagtable liste centpercent">';
 		print '<tr class="liste_titre">';
-		print_liste_field_titre($langs->trans("Date"), $_SERVER["PHP_SELF"], "f.datef", "", "", 'align="center" class="nowrap"', $sortfield, $sortorder);
+		print_liste_field_titre($langs->trans("Date"), $_SERVER["PHP_SELF"], "f.datef", "", $param, 'align="center" class="nowrap"', $sortfield, $sortorder);
 		print '<td>' . $langs->trans("Element") . '</td>';
 		print '<td>' . $langs->trans("Status") . '</td>';
 		print '<td class="right">' . $langs->trans("Debit") . '</td>';

--- a/htdocs/fourn/recap-fourn.php
+++ b/htdocs/fourn/recap-fourn.php
@@ -27,8 +27,9 @@
 
 // Load Dolibarr environment
 require '../main.inc.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.facture.class.php';
+require_once DOL_DOCUMENT_ROOT . '/fourn/class/paiementfourn.class.php';
 
 /**
  * @var Conf $conf
@@ -48,9 +49,26 @@ if ($user->socid > 0) {
 	$socid = $user->socid;
 }
 
-
 // Initialize a technical object to manage hooks of page. Note that conf->hooks_modules contains an array of hook context
 $hookmanager->initHooks(array('supplierbalencelist', 'globalcard'));
+
+// Load variable for pagination
+$limit = GETPOSTINT('limit') ? GETPOSTINT('limit') : $conf->liste_limit;
+$sortfield = GETPOST('sortfield', 'aZ09comma');
+$sortorder = GETPOST('sortorder', 'aZ09comma');
+$page = GETPOSTISSET('pageplusone') ? (GETPOSTINT('pageplusone') - 1) : GETPOSTINT("page");
+if (empty($page) || $page == -1) {
+	$page = 0;
+}     // If $page is not defined, or '' or -1
+$offset = $limit * $page;
+$pageprev = $page - 1;
+$pagenext = $page + 1;
+if (!$sortfield) {
+	$sortfield = "f.datef,f.rowid"; // Set here default search field
+}
+if (!$sortorder) {
+	$sortorder = "DESC";
+}
 
 /*
  * View
@@ -79,35 +97,30 @@ if ($socid > 0) {
 		print load_fiche_titre($langs->trans("SupplierPreview"));
 
 		print '<table class="noborder tagtable liste centpercent">';
+		print '<tr class="liste_titre">';
+		print_liste_field_titre($langs->trans("Date"), $_SERVER["PHP_SELF"], "f.datef", "", "", 'align="center" class="nowrap"', $sortfield, $sortorder);
+		print '<td>' . $langs->trans("Element") . '</td>';
+		print '<td>' . $langs->trans("Status") . '</td>';
+		print '<td class="right">' . $langs->trans("Debit") . '</td>';
+		print '<td class="right">' . $langs->trans("Credit") . '</td>';
+		print '<td class="right">' . $langs->trans("Balance") . '</td>';
+		print '<td class="right">' . $langs->trans("Author") . '</td>';
+		print '</tr>';
 
-		$sql = "SELECT s.nom, s.rowid as socid, f.ref_supplier, f.datef as df,";
+		$TData = array();
+
+		$sql = "SELECT s.nom, s.rowid as socid, f.ref_supplier, f.total_ttc, f.datef as df,";
 		$sql .= " f.paye as paye, f.fk_statut as statut, f.rowid as facid,";
 		$sql .= " u.login, u.rowid as userid";
-		$sql .= " FROM ".MAIN_DB_PREFIX."societe as s,".MAIN_DB_PREFIX."facture_fourn as f,".MAIN_DB_PREFIX."user as u";
-		$sql .= " WHERE f.fk_soc = s.rowid AND s.rowid = ".((int) $societe->id);
-		$sql .= " AND f.entity IN (".getEntity("facture_fourn").")"; // Recognition of the entity attributed to this invoice for Multicompany
+		$sql .= " FROM " . MAIN_DB_PREFIX . "societe as s," . MAIN_DB_PREFIX . "facture_fourn as f," . MAIN_DB_PREFIX . "user as u";
+		$sql .= " WHERE f.fk_soc = s.rowid AND s.rowid = " . ((int) $societe->id);
+		$sql .= " AND f.entity IN (" . getEntity("facture_fourn") . ")"; // Recognition of the entity attributed to this invoice for Multicompany
 		$sql .= " AND f.fk_user_valid = u.rowid";
-		$sql .= " ORDER BY f.datef DESC";
+		$sql .= $db->order($sortfield, $sortorder);
 
 		$resql = $db->query($sql);
 		if ($resql) {
 			$num = $db->num_rows($resql);
-
-			print '<tr class="liste_titre">';
-			print '<td width="100" class="center">'.$langs->trans("Date").'</td>';
-			print '<td>&nbsp;</td>';
-			print '<td>'.$langs->trans("Status").'</td>';
-			print '<td class="right">'.$langs->trans("Debit").'</td>';
-			print '<td class="right">'.$langs->trans("Credit").'</td>';
-			print '<td class="right">'.$langs->trans("Balance").'</td>';
-			print '<td>&nbsp;</td>';
-			print '</tr>';
-
-			if ($num <= 0) {
-				print '<tr><td colspan="7"><span class="opacitymedium">'.$langs->trans("NoInvoice").'</span></td></tr>';
-			}
-
-			$solde = 0;
 
 			// Boucle sur chaque facture
 			for ($i = 0; $i < $num; $i++) {
@@ -116,36 +129,35 @@ if ($socid > 0) {
 				$fac = new FactureFournisseur($db);
 				$ret = $fac->fetch($objf->facid);
 				if ($ret < 0) {
-					print $fac->error."<br>";
+					print $fac->error . "<br>";
 					continue;
 				}
 				$totalpaid = $fac->getSommePaiement();
 
-				print '<tr class="oddeven">';
+				$userstatic->id = $objf->userid;
+				$userstatic->login = $objf->login;
 
-				print '<td class="center">'.dol_print_date($fac->date)."</td>\n";
-				print "<td><a href=\"facture/card.php?facid=$fac->id\">".img_object($langs->trans("ShowBill"), "bill")." ".$fac->ref."</a></td>\n";
+				$values = array(
+					'fk_facture' => $objf->facid,
+					'date' => $fac->date,
+					'datefieldforsort' => $fac->date . '-' . $fac->ref,
+					'link' => $fac->getNomUrl(1),
+					'status' => $fac->getLibStatut(2, $totalpaid),
+					'amount' => $fac->total_ttc,
+					'author' => $userstatic->getLoginUrl(1)
+				);
 
-				print '<td class="left">'.$fac->getLibStatut(2, $totalpaid).'</td>';
-				print '<td class="right">'.price($fac->total_ttc)."</td>\n";
-				$solde += $fac->total_ttc;
-
-				print '<td class="right">&nbsp;</td>';
-				print '<td class="right">'.price($solde)."</td>\n";
-
-				// Author
-				print '<td class="nowrap" width="50"><a href="'.DOL_URL_ROOT.'/user/card.php?id='.$objf->userid.'">'.img_object($langs->trans("ShowUser"), 'user').' '.$objf->login.'</a></td>';
-
-				print "</tr>\n";
+				$TData[] = $values;
 
 				// Payments
 				$sql = "SELECT p.rowid, p.datep as dp, pf.amount, p.statut,";
 				$sql .= " p.fk_user_author, u.login, u.rowid as userid";
-				$sql .= " FROM ".MAIN_DB_PREFIX."paiementfourn_facturefourn as pf,";
-				$sql .= " ".MAIN_DB_PREFIX."paiementfourn as p";
-				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."user as u ON p.fk_user_author = u.rowid";
+				$sql .= " FROM " . MAIN_DB_PREFIX . "paiementfourn_facturefourn as pf,";
+				$sql .= " " . MAIN_DB_PREFIX . "paiementfourn as p";
+				$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "user as u ON p.fk_user_author = u.rowid";
 				$sql .= " WHERE pf.fk_paiementfourn = p.rowid";
-				$sql .= " AND pf.fk_facturefourn = ".((int) $fac->id);
+				$sql .= " AND pf.fk_facturefourn = " . ((int) $fac->id);
+				$sql .= " ORDER BY p.datep ASC, p.rowid ASC";
 
 				$resqlp = $db->query($sql);
 				if ($resqlp) {
@@ -154,22 +166,24 @@ if ($socid > 0) {
 
 					while ($j < $nump) {
 						$objp = $db->fetch_object($resqlp);
-						//
-						print '<tr class="oddeven">';
-						print '<td class="center">'.dol_print_date($db->jdate($objp->dp))."</td>\n";
-						print '<td>';
-						print '&nbsp; &nbsp; &nbsp; '; // Decalage
-						print '<a href="paiement/card.php?id='.$objp->rowid.'">'.img_object($langs->trans("ShowPayment"), "payment").' '.$langs->trans("Payment").' '.$objp->rowid.'</td>';
-						print "<td>&nbsp;</td>\n";
-						print "<td>&nbsp;</td>\n";
-						print '<td class="right">'.price($objp->amount).'</td>';
-						$solde -= $objp->amount;
-						print '<td class="right">'.price($solde)."</td>\n";
 
-						// Auteur
-						print '<td class="nowrap" width="50"><a href="'.DOL_URL_ROOT.'/user/card.php?id='.$objp->userid.'">'.img_object($langs->trans("ShowUser"), 'user').' '.$objp->login.'</a></td>';
+						$paymentstatic = new PaiementFourn($db);
+						$paymentstatic->id = $objp->rowid;
 
-						print '</tr>';
+						$userstatic->id = $objp->userid;
+						$userstatic->login = $objp->login;
+
+						$values = array(
+							'fk_paiement' => $objp->rowid,
+							'date' => $db->jdate($objp->dp),
+							'datefieldforsort' => $db->jdate($objp->dp) . '-' . $fac->ref,
+							'link' => $langs->trans("Payment") . ' ' . $paymentstatic->getNomUrl(1),
+							'status' => '',
+							'amount' => -$objp->amount,
+							'author' => $userstatic->getLoginUrl(1)
+						);
+
+						$TData[] = $values;
 
 						$j++;
 					}
@@ -181,6 +195,78 @@ if ($socid > 0) {
 			}
 		} else {
 			dol_print_error($db);
+		}
+
+		if (empty($TData)) {
+			print '<tr class="oddeven"><td colspan="7"><span class="opacitymedium">' . $langs->trans("NoInvoice") . '</span></td></tr>';
+		} else {
+			// Sort array by date ASC to calculate balance
+			$TData = dol_sort_array($TData, 'datefieldforsort', 'ASC');
+
+			// Balance calculation
+			$balance = 0;
+			foreach (array_keys($TData) as $key) {
+				$balance += $TData[$key]['amount'];
+				if (!array_key_exists('balance', $TData[$key])) {
+					$TData[$key]['balance'] = 0;
+				}
+				$TData[$key]['balance'] += $balance;
+			}
+
+			// Resorte array to have elements on the required $sortorder
+			$TData = dol_sort_array($TData, 'datefieldforsort', $sortorder);
+
+			$totalDebit = 0;
+			$totalCredit = 0;
+
+			// Display array
+			foreach ($TData as $data) {
+				$html_class = '';
+				if (!empty($data['fk_facture'])) {
+					$html_class = 'facid-' . $data['fk_facture'];
+				} elseif (!empty($data['fk_paiement'])) {
+					$html_class = 'payid-' . $data['fk_paiement'];
+				}
+
+				print '<tr class="oddeven ' . $html_class . '">';
+
+				$datedetail = dol_print_date($data['date'], 'dayhour');
+				if (!empty($data['fk_facture'])) {
+					$datedetail = dol_print_date($data['date'], 'day');
+				}
+				print '<td class="center" title="' . dol_escape_htmltag($datedetail) . '">';
+				print dol_print_date($data['date'], 'day');
+				print "</td>\n";
+
+				print '<td>' . $data['link'] . "</td>\n";
+
+				print '<td class="left">' . $data['status'] . '</td>';
+
+				print '<td class="right">' . (($data['amount'] > 0) ? price(abs($data['amount'])) : '') . "</td>\n";
+
+				$totalDebit += ($data['amount'] > 0) ? abs($data['amount']) : 0;
+
+				print '<td class="right">' . (($data['amount'] > 0) ? '' : price(abs($data['amount']))) . "</td>\n";
+				$totalCredit += ($data['amount'] > 0) ? 0 : abs($data['amount']);
+
+				// Balance
+				print '<td class="right"><span class="amount">' . price($data['balance']) . "</span></td>\n";
+
+				// Author
+				print '<td class="nowrap right">';
+				print $data['author'];
+				print '</td>';
+
+				print "</tr>\n";
+			}
+
+			print '<tr class="liste_total">';
+			print '<td colspan="3">&nbsp;</td>';
+			print '<td class="right">' . price($totalDebit) . '</td>';
+			print '<td class="right">' . price($totalCredit) . '</td>';
+			print '<td class="right">' . price(price2num($totalDebit - $totalCredit, 'MT')) . '</td>';
+			print '<td></td>';
+			print "</tr>\n";
 		}
 
 		print "</table>";

--- a/htdocs/fourn/recap-fourn.php
+++ b/htdocs/fourn/recap-fourn.php
@@ -104,7 +104,7 @@ if ($socid > 0) {
 
 		print '<table class="noborder tagtable liste centpercent">';
 		print '<tr class="liste_titre">';
-		print_liste_field_titre($langs->trans("Date"), $_SERVER["PHP_SELF"], "f.datef", "", $param, 'align="center" class="nowrap"', $sortfield, $sortorder);
+		print_liste_field_titre("Date", $_SERVER["PHP_SELF"], "f.datef", "", $param, 'align="center" class="nowrap"', $sortfield, $sortorder);
 		print '<td>' . $langs->trans("Element") . '</td>';
 		print '<td>' . $langs->trans("Status") . '</td>';
 		print '<td class="right">' . $langs->trans("Debit") . '</td>';

--- a/htdocs/fourn/recap-fourn.php
+++ b/htdocs/fourn/recap-fourn.php
@@ -113,7 +113,7 @@ if ($socid > 0) {
 		print '<td class="right">' . $langs->trans("Author") . '</td>';
 		print '</tr>';
 
-		/** @var array<array{fk_facture?:int,fk_paiement?:int,date:int|string,datefieldforsort:string,link:string,status:string,amount:float,balance?:float,author:string}> $TData */
+		/** @var array<string|int,mixed> $TData */
 		$TData = array();
 
 		$sql = "SELECT s.nom, s.rowid as socid, f.ref_supplier, f.total_ttc, f.datef as df,";


### PR DESCRIPTION
The key improvement is that now the balance calculation works correctly with descending order of movements. The balance will show the most recent transaction with the cumulative total of all transactions, and older transactions will show their respective balances as of that time. This implementation now matches the behavior of compta\recap-compta.php where the balance is calculated from bottom to top when the movements are displayed in descending order.



