### PR TITLE
Fix #35241: extrafields are not tranfered from order to shipping and cannot be edited at creation time

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1202,13 +1202,17 @@ if ($action == 'create') {
 				print "</td></tr>\n";
 			}
 
-			// Other attributes. Fields from hook formObjectOptions and Extrafields.
-			// $objectsrc is Commande|Facture
-			$objectsav = $object;	// Because Expedition is $expe and not $object that is wrongly a duplicate of $objectsrc.
-			$object = $expe;
-			$parameters = array('objectsrc' => isset($objectsrc) ? $objectsrc : '', 'cols' => '3', 'socid' => $socid);
-			include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_view.tpl.php';
-			$object = $objectsav;
+			$parameters = array('objectsrc' => isset($objectsrc) ? $objectsrc : '', 'colspan' => ' colspan="3"', 'cols' => '3', 'socid' => $socid);
+			$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $expe, $action); // Note that $action and $object may have been modified by hook
+			print $hookmanager->resPrint;
+
+			if (empty($reshook)) {
+				// copy from order
+				if ($object->fetch_optionals() > 0) {
+					$expe->array_options = array_merge($expe->array_options, $object->array_options);
+				}
+				print $expe->showOptionals($extrafields, 'edit', $parameters);
+			}
 
 			print "</table>";
 


### PR DESCRIPTION
FIX #35241 extrafields are not tranfered from order to shipping at creation and cannot be edited at creation time

If there are the same extrafields in the customer order and the shipping, then the extrafields where not transfered to the order. Additionally extrafields could be edited on shipping creation time. This leads to a lock in case the extrafields is mandatory or could only be set on creation time. The main issue was, that the newly used template extrafields_view.tpl.php doesn't support the use case for creation as it needs an object id to work correctly. 