### PR TITLE
Fix history tooltip display

### DIFF
--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -1346,7 +1346,7 @@ class ProductFournisseur extends Product
 			$label .= '<br><b>'.$langs->trans('ProductAccountancyBuyExportCode').':</b> '.length_accountg($this->accountancy_code_buy_export);
 		}
 
-		$logPrices = $this->listProductFournisseurPriceLog($this->product_fourn_price_id, 'pfpl.datec', 'DESC'); // set sort order here
+		$logPrices = $this->listProductFournisseurPriceLog($this->product_fourn_price_id, 'pfpl.datec', 'DESC', getDolGlobalInt('MAIN_TOOLTIP_PRICELOG_HISTORY_LIMIT', 10)); // set sort order here
 		if (is_array($logPrices) && count($logPrices) > 0) {
 			$label .= '<br><br>';
 			$label .= '<u>'.$langs->trans("History").'</u>';


### PR DESCRIPTION
# Fix 

The getNomUrl function of Supplier.product.class.php  add price history in tooltip but without limit. 
limit set as 10 for default because more the tooltip make a page overflow  