### PR TITLE
FIX: Disable commerce tab when only 'fournisseur:lire' permission is granted

### DIFF
--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -260,7 +260,6 @@ function print_eldy_menu($db, $atarget, $type_user, &$tabMenu, &$menu, $noout = 
 			$user->hasRight('propal', 'read')
 			|| $user->hasRight('commande', 'lire')
 			|| $user->hasRight('supplier_proposal', 'lire')
-			|| $user->hasRight('fournisseur', 'lire')
 			|| $user->hasRight('fournisseur', 'commande', 'lire')
 			|| $user->hasRight('supplier_order', 'lire')
 			|| $user->hasRight('contrat', 'lire')


### PR DESCRIPTION
### FIX: Disable commerce tab when only 'fournisseur:lire' permission is granted:
This fix updates the permission logic for the commerce tab.
Previously, internal users with only the fournisseur:lire permission could still access the commerce tab, which was not intended.
Now, the commerce tab is disabled unless additional permissions beyond fournisseur:lire are active.

Impact:
- Users with only fournisseur:lire will no longer see or access the commerce tab.
- No impact on users with other active permissions.