### PR TITLE
Fix: Add deprecated properties code_compta to remove some undefined properties warning

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -889,6 +889,13 @@ class Societe extends CommonObject
 	 */
 	public $bank_account;
 
+	/**
+	 * @deprecated
+	 * Accounting code for client
+	 * @var ?string
+	 */
+	public $code_compta;
+
 
 	const STATUS_CEASED = 0;
 	const STATUS_INACTIVITY = 1;


### PR DESCRIPTION
Add deprecated code_compta properties to avoid PHP 8+ "Undefined property" warnings.