### PR TITLE
fix: PHP warning in mail and card presend

### DIFF
--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -73,7 +73,6 @@ $optioncss = GETPOST('optioncss', 'alpha');
 $backtopage = GETPOST('backtopage');
 $contextpage = GETPOST('contextpage', 'aZ09');
 
-$id = $rowid = (GETPOSTINT('id') ? GETPOSTINT('id') : GETPOSTINT('rowid'));
 $search_label = GETPOST('search_label', 'alphanohtml'); // Must allow value like 'Abc Def' or '(MyTemplateName)'
 $search_type_template = GETPOST('search_type_template', 'alpha');
 $search_lang = GETPOST('search_lang', 'alpha');
@@ -1158,8 +1157,7 @@ if ($num) {
 					$fieldsforcontent[] = 'content_lines';
 				}
 
-				$tabname=isset($tabname[$id]) ? $tabname[$id] :'';
-				$parameters = array('fieldsforcontent' => &$fieldsforcontent, 'tabname' => $tabname);
+				$parameters = array('fieldsforcontent' => &$fieldsforcontent, 'tabname' => $tabname[25] ?? '');
 				$hookmanager->executeHooks('editEmailTemplateFieldsForContent', $parameters, $obj, $tmpaction); // Note that $action and $object may have been modified by some hooks
 
 				foreach ($fieldsforcontent as $tmpfieldlist) {

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -1157,7 +1157,7 @@ if ($num) {
 					$fieldsforcontent[] = 'content_lines';
 				}
 
-				$parameters = array('fieldsforcontent' => &$fieldsforcontent, 'tabname' => $tabname[25] ?? '');
+				$parameters = array('fieldsforcontent' => &$fieldsforcontent, 'tabname' => $tabname[25]);
 				$hookmanager->executeHooks('editEmailTemplateFieldsForContent', $parameters, $obj, $tmpaction); // Note that $action and $object may have been modified by some hooks
 
 				foreach ($fieldsforcontent as $tmpfieldlist) {

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -73,6 +73,7 @@ $optioncss = GETPOST('optioncss', 'alpha');
 $backtopage = GETPOST('backtopage');
 $contextpage = GETPOST('contextpage', 'aZ09');
 
+$rowid = (GETPOSTINT('id') ? GETPOSTINT('id') : GETPOSTINT('rowid'));
 $search_label = GETPOST('search_label', 'alphanohtml'); // Must allow value like 'Abc Def' or '(MyTemplateName)'
 $search_type_template = GETPOST('search_type_template', 'alpha');
 $search_lang = GETPOST('search_lang', 'alpha');

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -52,6 +52,7 @@ if (empty($conf) || !is_object($conf)) {
 }
 
 $fileparams = array();
+$file = null;
 
 if ($action == 'presend') {
 	$langs->load("mails");


### PR DESCRIPTION
Fixed some warnings
One in `htdocs/core/tpl/card_presend.tpl.php:433` where in some cases $file was not defined
The other one in `htdocs/admin/mails_templates.php :1161` where I replaced the $id by hardcoded 25 to avoid undefined array key warning
I also removed the $id variable as it was no longer used