### PR TITLE
FIX api orders : forward database error on failure (backport commit d9e81cb)

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1156,7 +1156,7 @@ class Commande extends CommonOrder
 				}
 			}
 		} else {
-			dol_print_error($this->db);
+			$this->error = $this->db->lasterror();
 			$this->db->rollback();
 			return -1;
 		}


### PR DESCRIPTION
FIX api orders : forward database error on failure (backpot commit d9e81cb)

For example when we use the API orders with wrong socid value :  no error is shwon and.
The code response is : 0
The headers responses is : 
`{
  "error": "no response from server"
}`


**With this fix** : 
The error message is understandable for human.

Response code is : 500
Response body : 

`{
  "error": {
    "0": "Cannot add or update a child row: a foreign key constraint fails (`llx_commande`, CONSTRAINT `fk_commande_fk_soc` FOREIGN KEY (`fk_soc`) REFERENCES `llx_societe` (`rowid`))",
    "code": 500,
    "message": "Internal Server Error: Error creating order"
  },
  "debug": {
    "source": "api_orders.class.php:273 at call stage",
    "stages": {
      "success": [
        "get",
        "route",
        "negotiate",
        "authenticate",
        "validate"
      ],
      "failure": [
        "call",
        "message"
      ]
    }
  }
}`

