### PR TITLE
fix: display of chkbxlst in edit with SQL filter

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7953,9 +7953,9 @@ abstract class CommonObject
 						if (strpos($InfoFieldList[4], 'extra') !== false) {
 							$sql .= ' as main, ' . $this->db->sanitize($this->db->prefix() . $InfoFieldList[0]) . '_extrafields as extra';
 							$sqlwhere .= " WHERE extra.fk_object = main." . $this->db->sanitize($InfoFieldList[2]);
-							$sqlwhere .= " AND " . $InfoFieldList[4];
+							$sqlwhere .= " AND " . forgeSQLFromUniversalSearchCriteria($InfoFieldList[4], $errstr, 1);
 						} else {
-							$sqlwhere .= " WHERE " . $InfoFieldList[4];
+							$sqlwhere .= " WHERE " . forgeSQLFromUniversalSearchCriteria($InfoFieldList[4], $errstr, 1);
 						}
 					} else {
 						$sqlwhere .= ' WHERE 1=1';


### PR DESCRIPTION
From 20.0 
 with  object field definition like 
```
public $fields = array(
      'fieldname' => array(
			      'type' => 'chkbxlst:tablesource:displayedcolumn:rowid::(active=1)',
			      'label' => 'DimensionsPneumatiques',
			      'enabled' => 1,
			      'visible' => '1',
			      'position' => 240,
		      ),
      );
```
the $InfoFieldList[4] is rewrite with (active:=:1) on line https://github.com/Dolibarr/dolibarr/blob/cd69b8deb1635594925c2fc47b8c2243bd58974d/htdocs/core/class/commonobject.class.php#L7892
like it is done for selllist (https://github.com/Dolibarr/dolibarr/blob/cd69b8deb1635594925c2fc47b8c2243bd58974d/htdocs/core/class/commonobject.class.php#L7660)

but the SQL request WHERE clause do not use forgeSQLFromUniversalSearchCriteria like it is done in selllist field type
https://github.com/Dolibarr/dolibarr/blob/cd69b8deb1635594925c2fc47b8c2243bd58974d/htdocs/core/class/commonobject.class.php#L7721

**Result SQL error** 
Error in request SELECT rowid as rowid, label FROM llx_tablesource WHERE **(active:=:1)** You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ':=:1)' at line 1. Check setup of extra parameters.
