### PR TITLE
fix: if MAXREFONDOC is set to -1 should do not output Orders in Invoice public note

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -453,7 +453,7 @@ if (empty($reshook)) {
 					$objecttmp->ref_client = $cmd->ref_client;
 				}
 
-				if (empty($objecttmp->note_public)) {
+				if (empty($objecttmp->note_public) && getDolGlobalInt("MAXREFONDOC", 10)>0) {
 					$objecttmp->note_public =  $langs->transnoentities("Orders");
 				}
 


### PR DESCRIPTION
Create invoices from orders list (with max action)

Actually on each lines in the invoices the source Order Ref is added in description.

So there is no need to add bulk source orders ref in invoice public note, but it is a standard feature.

It's possible to not populate invoice public note source ORders Ref with constant MAXREFONDOC set to -1

https://github.com/Dolibarr/dolibarr/blob/75438c60c76ed65c6c546b01f239566d9425478f/htdocs/commande/list.php#L625

But there is still label "Order" in the invoices public note in this case. There is no need