### PR TITLE
Add mp4 and webm to file previews

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13431,7 +13431,7 @@ function dolIsAllowedForPreview($file)
 	}
 
 	// Check mime types
-	$mime_preview = array('bmp', 'jpeg', 'png', 'gif', 'tiff', 'pdf', 'plain', 'css', 'webp');
+	$mime_preview = array('bmp', 'jpeg', 'png', 'gif', 'tiff', 'pdf', 'plain', 'css', 'webp', 'webm', 'mp4');
 	if (getDolGlobalString('MAIN_ALLOW_SVG_FILES_AS_IMAGES')) {
 		$mime_preview[] = 'svg+xml';
 	}


### PR DESCRIPTION
So simple to do ... (I supposed it's because the JS preview still takes charge of this formats)

Tested on firefox and chromium

The small magnifying glass is displayed
<img width="5277" height="217" alt="Screenshot 2025-09-26 at 10-56-52 Produit Tes - Fichiers joints" src="https://github.com/user-attachments/assets/ba3d382b-8023-434b-a319-56987f8595ad" />

When clicking on it, the video player is displayed in the popin

<img width="5148" height="1728" alt="Screenshot 2025-09-26 at 10-57-16 Produit Tes - Fichiers joints" src="https://github.com/user-attachments/assets/baafec9d-e0e0-4cec-bd33-3e37f88cc252" />

