### PR TITLE
Fix #35354

### DIFF
--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -218,7 +218,7 @@ if (empty($reshook)) {
 					}
 				}
 
-				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => GETPOSTINT($key));
+				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => GETPOST($key));
 			}
 		}
 


### PR DESCRIPTION
Bug
Given: A supplier invoice in a foreign currency, amount has fractional part after decimal separator.

When entering a payment for this amount, just the integer part of this payment is getting recorded.