### PR TITLE
If the number of categories are smaller than the limit and the page is not 0, then we should not return anything

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -1118,7 +1118,11 @@ class Categorie extends CommonObject
 				dol_print_error($this->db);
 			}
 
-			if (($page * $limit) > (int) $nbtotalofrecords) {	// if total resultset is smaller then paging size (filtering), goto and load page 0
+			if (($limit >= (int) $nbtotalofrecords) && $page > 0) {
+				return [];
+			}
+
+			if (($page * $limit) >= (int) $nbtotalofrecords) {	// if total resultset is smaller or equal then paging size (filtering), goto and load page 0
 				$page = 0;
 				$offset = 0;
 			}


### PR DESCRIPTION
FIX #29425 29425 Category limits and page combinations should eventually end in []
If you happened to use a combination of limit which was bigger or equal to the number of categories, then consecutive pages would just return the results of page 0, which meant a non ending loop. This PR detects that and just returns []