### PR TITLE
FIX: data validation of is_numeric for subscription start_date API

### DIFF
--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -661,8 +661,8 @@ class Members extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('adherent', 'cotisation', 'creer')) {
 			throw new RestException(403);
 		}
-		if (is_numeric($start_date) || !is_numeric($end_date) || !is_numeric($amount)) {
-			throw new RestException(422, 'Malformed data');
+		if (!is_numeric($start_date) || !is_numeric($end_date) || !is_numeric($amount)) {
+			throw new RestException(422, 'Malformed data: subscription start or end date, or subscription amount, is not numeric');
 		}
 
 		$member = new Adherent($this->db);


### PR DESCRIPTION
# FIX Membership API: Bugfix data validation of is_numeric for subscription start_date
Start date and end dates both are expected to be numeric timestamps, data validation is wrong