### PR TITLE
FIX : On ticket creation from backend, thirdparty is never notified.

### DIFF
--- a/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
+++ b/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
@@ -211,7 +211,7 @@ class InterfaceTicketEmail extends DolibarrTriggers
 
 					// if contact selected send to email's contact else send to email's thirdparty
 
-					$contactid = empty($object->context['contactid']) ? 0 : $object->context['contactid'];
+					$contactid = empty($object->context['contact_id']) ? 0 : $object->context['contact_id'];
 					$res = 0;
 
 					if (!empty($contactid)) {
@@ -271,7 +271,7 @@ class InterfaceTicketEmail extends DolibarrTriggers
 						$linked_contacts[]['email'] = $object->thirdparty->email;
 					}
 
-					$contactid = empty($object->context['contactid']) ? 0 : $object->context['contactid'];
+					$contactid = empty($object->context['contact_id']) ? 0 : $object->context['contact_id'];
 					$res = 0;
 
 					if ($contactid > 0) {

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -265,7 +265,7 @@ if (empty($reshook)) {
 				$object->origin_email = null;
 				$notifyTiers = GETPOST("notify_tiers_at_create", 'alpha');
 				$object->notify_tiers_at_create = empty($notifyTiers) ? 0 : 1;
-				$object->context['contact_id'] = GETPOSTINT('contact_id');
+				$object->context['contact_id'] = GETPOSTINT('contactid');
 				$id = $object->create($user);
 			} else {
 				$id = $object->update($user);
@@ -455,7 +455,7 @@ if (empty($reshook)) {
 	if ($action == "confirm_public_close" && GETPOST('confirm', 'alpha') == 'yes' && $permissiontoadd) {
 		$object->fetch(GETPOSTINT('id'), '', GETPOST('track_id', 'alpha'));
 		if ($_SESSION['email_customer'] == $object->origin_email || $_SESSION['email_customer'] == $object->thirdparty->email) {
-			$object->context['contact_id'] = GETPOSTINT('contact_id');
+			$object->context['contact_id'] = GETPOSTINT('contactid');
 
 			$object->close($user);
 


### PR DESCRIPTION
# FIX : On ticket creation from backend, thirdparty is never notified.

On branch 20.0 up to develop

To reproduce : 
- ensure TICKET_DISABLE_ALL_MAILS is not on
- navigate to ticket creation page (backend page, not public page)
- tick 'notify thirdparty at creation'
- create the ticket
- no mail is sent to customer

This is due to 

- the fact that the information is stored in `$_POST['contactid']` and not `$_POST['contact_id']` (see `FormTicket::showForm()`)
- the fact that it is stored in `$object->context['contact_id']` in ticket/card.php, not `$object->context['contactid']`


