### PR TITLE
FIX : when creating a ticken on backend and adding a linked file, the 'notify thirdparty at creation' chackbox disappears.

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -734,7 +734,7 @@ class FormTicket
 			}
 
 			// Notify thirdparty at creation
-			if (empty($this->ispublic) && $action == 'create') {
+			if (empty($this->ispublic) && ($action == 'create' || $action == 'presend')) {
 				print '<tr><td><label for="notify_tiers_at_create">'.$langs->trans("TicketNotifyTiersAtCreation").'</label></td><td>';
 				print '<input type="checkbox" id="notify_tiers_at_create" name="notify_tiers_at_create"'.($this->withnotifytiersatcreate ? ' checked="checked"' : '').'>';
 				print '</td></tr>';


### PR DESCRIPTION
FIX : when creating a ticket on backend and adding a linked file, the 'notify thirdparty at creation' chackbox disappears.