### PR TITLE
Fix trigger call on shipping creation for orders

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -810,7 +810,15 @@ class Expedition extends CommonObject
 		}
 
 		// Change status of order to "shipment in process"
-		$ret = $this->setStatut(Commande::STATUS_SHIPMENTONPROCESS, $this->origin_id, $this->origin);
+		$triggerKey = 'SHIPPING_'; // Because when the trigger is fired the object is a shipping and not the real target object, so I add a prefix like SHIPPING_ to avoid confusion
+		if ($this->origin == 'commande') {
+			$triggerKey.= 'ORDER_SHIPMENTONPROCESS';
+		} else {
+			$triggerKey.= strtoupper($this->origin).'_SHIPMENTONPROCESS';
+		}
+
+		// TODO : load the origin object to trigger the right setStatus according to origin object
+		$ret = $this->setStatut(Commande::STATUS_SHIPMENTONPROCESS, $this->origin_id, $this->origin, $triggerKey);
 		if (!$ret) {
 			$error++;
 		}


### PR DESCRIPTION
# Instructions
When an Expedition object is validated, a setStatut is triggered on the origin object. However, the call is unusual because it uses $this, which refers to the Expedition object itself, and calls $this->setStatut. The problem is that no triggers are fired within the setStatut method because $triggerKey is empty.

# Fix
add a $triggerKey 
add a todo for futur fix in develop branch

