### PR TITLE
FIX invoices payments on multicurrencies being converted as int

### DIFF
--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -179,7 +179,7 @@ if (empty($reshook)) {
 					}
 				}
 
-				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => GETPOSTFLOAT($key));
+				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => GETPOST($key));
 			}
 		}
 

--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -179,7 +179,7 @@ if (empty($reshook)) {
 					}
 				}
 
-				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => GETPOSTINT($key));
+				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => GETPOSTFLOAT($key));
 			}
 		}
 


### PR DESCRIPTION
# FIX|Fix #[32605]
When doing a payment from a client in the currency of the invoice using an account in the same currency, amount is converted to int instead of being left as a float.
For example if payment is 15.99, is will save a payment of 15
Seems like bug has been introduced in Feb 27 2024.


# CLOSE|Close #[32605]
Replaced GETPOSTINT by GETPOSTFLOAT to allow floating decimals.