### PR TITLE
FIX create invoice from order using API and multi-entity

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1836,9 +1836,11 @@ class Commande extends CommonOrder
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_availability as ca ON c.fk_availability = ca.rowid';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_input_reason as dr ON c.fk_input_reason = dr.rowid';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_incoterms as i ON c.fk_incoterms = i.rowid';
-		$sql .= " WHERE c.entity IN (".getEntity('commande').")"; // it's a security for API invoices create invoice from order (POST /createfromorder/{orderid})
+
 		if ($id) {
-			$sql .= " AND c.rowid=".((int) $id);
+			$sql .= " WHERE c.rowid=".((int) $id);
+		} else {
+			$sql .= " WHERE c.entity IN (".getEntity('commande').")"; // Dont't use entity if you use rowid
 		}
 
 		if ($ref) {

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1836,11 +1836,9 @@ class Commande extends CommonOrder
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_availability as ca ON c.fk_availability = ca.rowid';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_input_reason as dr ON c.fk_input_reason = dr.rowid';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_incoterms as i ON c.fk_incoterms = i.rowid';
-
+		$sql .= " WHERE c.entity IN (".getEntity('commande').")"; // it's a security for API invoices create invoice from order (POST /createfromorder/{orderid})
 		if ($id) {
-			$sql .= " WHERE c.rowid=".((int) $id);
-		} else {
-			$sql .= " WHERE c.entity IN (".getEntity('commande').")"; // Dont't use entity if you use rowid
+			$sql .= " AND c.rowid=".((int) $id);
 		}
 
 		if ($ref) {

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -334,7 +334,7 @@ class Invoices extends DolibarrApi
 			throw new RestException(400, 'Order ID is mandatory');
 		}
 		if (!DolibarrApi::_checkAccessToResource('commande', $orderid)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access not allowed on order for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$order = new Commande($this->db);

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -315,6 +315,7 @@ class Invoices extends DolibarrApi
 	  * @return int
 	  * @throws RestException 400
 	  * @throws RestException 401
+	  * @throws RestException 403		Access not allowed for login
 	  * @throws RestException 404
 	  * @throws RestException 405
 	  */
@@ -331,6 +332,9 @@ class Invoices extends DolibarrApi
 		}
 		if (empty($orderid)) {
 			throw new RestException(400, 'Order ID is mandatory');
+		}
+		if (!DolibarrApi::_checkAccessToResource('commande', $orderid)) {
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$order = new Commande($this->db);


### PR DESCRIPTION
FIX create invoice from order using API and multi-entity

**To reproduce**
Create an invoice from API : 
- all users belong to entity 1 with MULTICOMPANY_TRANSVERSE_MODE enabled
- create an order on entity 1: id =ORDER_ID_ENTITY_1
- try to create an invoice from this order and using DOLAPIENTITY = 2 to create on entity 2
`curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'DOLAPIKEY:  YOUR_AP_KEY' 'URL_DOLIBARR/api/index.php/invoices/createfromorder/ORDER_ID_ENTITY_1' --header 'HTTP_DOLAPIENTITY: 2'`

**Result**
{
  "error": {
    "code": 405,
    "message": "Method Not Allowed"
  }
}

**Expected result**
{
  "error": {
    "code": 404,
    "message": "Not Found: Order not found"
  }
- the order is not found in entity 2 because the request orderid belong to entity 1 and orders are not share between entities 1 and 2
