### PR TITLE
Fix : Display supplier prices for shared products in multicompany context #35600

### DIFF
--- a/htdocs/fourn/product/list.php
+++ b/htdocs/fourn/product/list.php
@@ -169,7 +169,7 @@ $sql .= " FROM ".MAIN_DB_PREFIX."product as p";
 if ($catid) {
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."categorie_product as cp ON cp.fk_product = p.rowid";
 }
-$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product_fournisseur_price as ppf ON p.rowid = ppf.fk_product AND p.entity = ppf.entity";
+$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product_fournisseur_price as ppf ON p.rowid = ppf.fk_product AND ppf.entity IN (".getEntity('product_fournisseur_price').")";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON ppf.fk_soc = s.rowid AND s.entity IN (".getEntity('societe').")";
 $sql .= " WHERE p.entity IN (".getEntity('product').")";
 if ($sRefSupplier) {

--- a/htdocs/fourn/product/list.php
+++ b/htdocs/fourn/product/list.php
@@ -169,7 +169,7 @@ $sql .= " FROM ".MAIN_DB_PREFIX."product as p";
 if ($catid) {
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."categorie_product as cp ON cp.fk_product = p.rowid";
 }
-$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product_fournisseur_price as ppf ON p.rowid = ppf.fk_product AND ppf.entity IN (".getEntity('product_fournisseur_price').")";
+$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product_fournisseur_price as ppf ON p.rowid = ppf.fk_product AND ppf.entity IN (".getEntity('productsupplierprice').")";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON ppf.fk_soc = s.rowid AND s.entity IN (".getEntity('societe').")";
 $sql .= " WHERE p.entity IN (".getEntity('product').")";
 if ($sRefSupplier) {


### PR DESCRIPTION
# FIX|Fix #*Display supplier prices for shared products in multicompany context*

@eldy  , It is a backport from https://github.com/Dolibarr/dolibarr/pull/35600 

In a multi-company setup, the buying prices for shared products do not appear on the supplier's product list. The database query is too restrictive and fails to link a shared product to its price when they are located in different entities.

Solution
The solution is to make the database query more flexible. The query is modified to search for the price across all entities the user can access, instead of being limited to the product's original entity. This allows the shared product's price to be linked and displayed correctly.

