### PR TITLE
NEW Allow omission of ODT template name when generating ODT and PDF (global string MAIN_ODT_AS_PDF_OMIT_TEMPLATE_NAME)

### DIFF
--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -270,7 +270,11 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 				$newfiletmp = preg_replace('/template_/i', '', $newfiletmp);
 				$newfiletmp = preg_replace('/modele_/i', '', $newfiletmp);
 
-				$newfiletmp = $objectref . '_' . $newfiletmp;
+				if (getDolGlobalString('MAIN_ODT_AS_PDF_OMIT_TEMPLATE_NAME')) {
+					$newfiletmp = $objectref;
+				} else {
+					$newfiletmp = $objectref . '_' . $newfiletmp;
+				}
 
 				// Get extension (ods or odt)
 				$newfileformat = substr($newfile, strrpos($newfile, '.') + 1);


### PR DESCRIPTION
Presently, Invoice PDF/ODT is generated with template name just before file extension. This creates an issue where Mass Actions is also unable to perform Send By Email, or PDF Merge. This pull request is inspired by this forum post:

https://www.dolibarr.org/forum/t/how-to-remove-omit-odt-templete-name-from-auto-document-generated/22735

