### PR TITLE
FIX_DUPLICATE_ORDERBY_CONTRACTS_LIST

### DIFF
--- a/htdocs/contrat/services_list.php
+++ b/htdocs/contrat/services_list.php
@@ -381,10 +381,6 @@ $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
 
-$sql .= $db->order($sortfield, $sortorder);
-
-//print $sql;
-
 // Count total nb of records
 $nbtotalofrecords = '';
 if (!getDolGlobalInt('MAIN_DISABLE_FULL_SCANLIST')) {


### PR DESCRIPTION
# FIX|Fix #[*issue_number Short description*]
The Issue
This PR fixes a fatal SQL error (DB_ERROR_SYNTAX) on the contract services list page. The error occurred whenever a user tried to sort a column from contract box in dashboard.

The Solution
The root cause was a duplicate ORDER BY clause being added to the SQL query.

This fix removes the first, premature addition of the clause. The ORDER BY is now correctly applied only once, just before the LIMIT clause for pagination.



