### PR TITLE
Reviving some old PR with API get, activate and disable modules

### DIFF
--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -2974,8 +2974,8 @@ class Setup extends DolibarrApi
 						if (class_exists($modName)) {
 							$objMod = new $modName($db);
 							$moduleName = strtoupper(preg_replace('/^mod/i', '', get_class($objMod)));
-							$publisher = dol_escape_htmltag($objMod->getPublisher());
-							$external = ($objMod->isCoreOrExternalModule() == 'external');
+							$publisher = dol_escape_htmltag((string) $objMod->getPublisher());
+							$external = ((string) $objMod->isCoreOrExternalModule() == 'external');
 							$active = getDolGlobalString('MAIN_MODULE_'.$moduleName);
 							$version = $objMod->version;
 							if ($status != 'all') {

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -33,6 +33,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/cregion.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/ccountry.class.php';
 require_once DOL_DOCUMENT_ROOT.'/hrm/class/establishment.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/modules/DolibarrModules.class.php';
 
 /**
  * API class for dictionaries
@@ -2952,6 +2953,7 @@ class Setup extends DolibarrApi
 	public function getModulesList($status = "active", $origin = 'all')
 	{
 		global $db;
+		$moduleObject = new DolibarrModules($this->db);
 
 		if (!DolibarrApiAccess::$user->admin
 			&& (!getDolGlobalString('API_LOGINS_ALLOWED_FOR_GET_MODULES') || DolibarrApiAccess::$user->login != getDolGlobalString('API_LOGINS_ALLOWED_FOR_GET_MODULES'))) {
@@ -2974,8 +2976,8 @@ class Setup extends DolibarrApi
 						if (class_exists($modName)) {
 							$objMod = new $modName($db);
 							$moduleName = strtoupper(preg_replace('/^mod/i', '', get_class($objMod)));
-							$publisher = dol_escape_htmltag((string) $objMod->getPublisher());
-							$external = ((string) $objMod->isCoreOrExternalModule() == 'external');
+							$publisher = dol_escape_htmltag((string) $moduleObject->getPublisher());
+							$external = ((string) $moduleObject->isCoreOrExternalModule() == 'external');
 							$active = getDolGlobalString('MAIN_MODULE_'.$moduleName);
 							$version = $objMod->version;
 							if ($status != 'all') {

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -2935,7 +2935,7 @@ class Setup extends DolibarrApi
 
 		sort($conf->modules);
 
-		return $this->_cleanObjectDatas($conf->modules);
+		return $conf->modules;
 	}
 
 	/**

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -32,6 +32,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/cstate.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/cregion.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/ccountry.class.php';
 require_once DOL_DOCUMENT_ROOT.'/hrm/class/establishment.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 
 /**
  * API class for dictionaries
@@ -2911,18 +2912,20 @@ class Setup extends DolibarrApi
 		return array('resultcode' => $resultcode, 'resultcomment' => $resultcomment, 'expectedchecksum' => $outexpectedchecksum, 'currentchecksum' => $outcurrentchecksum, 'out' => $out);
 	}
 
-
 	/**
 	 * Get list of enabled modules
 	 *
 	 * @url	GET /modules
 	 *
-	 * @return  array<string,string>	Array of modules
+	 * @return  array Data without useless information
+	 * @phan-return array<string,string>
+	 * @phpstan-return array<string,string>
 	 *
 	 * @throws RestException 403 Forbidden
 	 */
 	public function getModules()
 	{
+		dol_syslog("Setup::getModules is DEPRECATED, use /api/index.php/setup/modules/status", LOG_INFO);
 		global $conf;
 
 		if (!DolibarrApiAccess::$user->admin
@@ -2932,7 +2935,155 @@ class Setup extends DolibarrApi
 
 		sort($conf->modules);
 
-		//return $this->_cleanObjectDatas($conf->modules);
-		return $conf->modules;
+		return $this->_cleanObjectDatas($conf->modules);
+	}
+
+	/**
+	 * Get list of modules with status and origin
+	 *
+	 * @url	GET /modules/status/{origin}
+	 *
+	 * @param	string			$status	"all", "active", "disabled"
+	 * @param	string			$origin	Origin of the module (all, core, external)
+	 * @return  array|mixed Data without useless information
+	 *
+	 * @throws RestException 403 Forbidden
+	 */
+	public function getModulesList($status = "active", $origin = 'all')
+	{
+		global $db;
+
+		if (!DolibarrApiAccess::$user->admin
+			&& (!getDolGlobalString('API_LOGINS_ALLOWED_FOR_GET_MODULES') || DolibarrApiAccess::$user->login != getDolGlobalString('API_LOGINS_ALLOWED_FOR_GET_MODULES'))) {
+			throw new RestException(403, 'Error API open to admin users only or to the users with logins defined into constant API_LOGINS_ALLOWED_FOR_GET_MODULES');
+		}
+
+		$filename = array();
+		$modulesdir = dolGetModulesDirs();
+		foreach ($modulesdir as $dir) {
+			// Load modules attributes in arrays (name, numero, orders) from dir directory
+			//print $dir."\n<br>";
+			dol_syslog("Scan directory ".$dir." for module descriptor files (modXXX.class.php)");
+			$handle = @opendir($dir);
+			if (is_resource($handle)) {
+				while (($file = readdir($handle)) !== false) {
+					//print "$i ".$file."\n<br>";
+					if (is_readable($dir.$file) && substr($file, 0, 3) == 'mod' && substr($file, dol_strlen($file) - 10) == '.class.php') {
+						$modName = substr($file, 0, dol_strlen($file) - 10);
+						include_once $dir.$file; // A class already exists in a different file will send a non catchable fatal error.
+						if (class_exists($modName)) {
+							$objMod = new $modName($db);
+							$moduleName = strtoupper(preg_replace('/^mod/i', '', get_class($objMod)));
+							$publisher = dol_escape_htmltag($objMod->getPublisher());
+							$external = ($objMod->isCoreOrExternalModule() == 'external');
+							$active = getDolGlobalString('MAIN_MODULE_'.$moduleName);
+							$version = $objMod->version;
+							if ($status != 'all') {
+								if ($status == 'active' && $active == "") {
+									continue;
+								} elseif ($status == 'disabled' && $active == 1) {
+									continue;
+								}
+							}
+							if ($origin != 'all') {
+								if ($origin == 'external' && !$external) {
+									continue;
+								} elseif ($origin == 'core' && $external) {
+									continue;
+								}
+							}
+
+							$filename[$moduleName] = array(
+								'modName' => $modName,
+								'origin' => $external ? 'external' : 'core',
+								'active' => $active,
+								'publisher' => $publisher,
+								'version' => $version
+							);
+						}
+					}
+				}
+			}
+		}
+		return $this->_cleanObjectDatas($filename);
+	}
+
+	/**
+	 * PUT enable module
+	 *
+	 * @url	PUT /modules/{modulename}/enable
+	 *
+	 * @param	string			$modulename name of the module
+	 * @return  array|mixed		Data without useless information
+	 *
+	 * @throws RestException 403 Forbidden
+	 * @throws RestException 404 Not found
+	 */
+	public function enableModules($modulename)
+	{
+		return $this->_moduleOnOff($modulename, $state = true);
+	}
+	/**
+	 * PUT enable module
+	 *
+	 * @url	PUT /modules/{modulename}/disable
+	 *
+	 * @param	string			$modulename name of the module
+	 * @return  array|mixed		Data without useless information
+	 *
+	 * @throws RestException 403 Forbidden
+	 * @throws RestException 404 Not found
+	 */
+	public function disableModules($modulename)
+	{
+		return $this->_moduleOnOff($modulename, $state = false);
+	}
+
+	/**
+	 * switch moduleOnOff
+	 *
+	 * @param	string			$modulename name of the module
+	 * @param	bool			$state false means off, true means on
+	 * @return  array|mixed		Data without useless information
+	 *
+	 * @throws RestException 403 Forbidden
+	 * @throws RestException 404 Not found
+	 */
+	private function _moduleOnOff($modulename, $state = false)
+	{
+		global $db;
+
+		if (!DolibarrApiAccess::$user->admin
+			&& (!getDolGlobalString('API_LOGINS_ALLOWED_FOR_GET_MODULES') || DolibarrApiAccess::$user->login != getDolGlobalString('API_LOGINS_ALLOWED_FOR_GET_MODULES'))) {
+			throw new RestException(403, 'Error API open to admin users only or to the users with logins defined into constant API_LOGINS_ALLOWED_FOR_GET_MODULES');
+		}
+
+		$modulesdir = dolGetModulesDirs();
+		foreach ($modulesdir as $dir) {
+			$handle = @opendir($dir);
+			if (is_resource($handle)) {
+				while (($file = readdir($handle)) !== false) {
+					if (is_readable($dir.$file) && substr($file, 0, 3) == 'mod' && substr($file, dol_strlen($file) - 10) == '.class.php') {
+						// print $modulename. "==".substr($file, 0, dol_strlen($file) - 10)."\n";
+						if ($modulename == substr($file, 0, dol_strlen($file) - 10)) {
+							$modName = substr($file, 0, dol_strlen($file) - 10);
+							include_once $dir.$file; // A class already exists in a different file will send a non catchable fatal error.
+							if (class_exists($modName)) {
+								$objMod = new $modName($db);
+								//$name = strtoupper(preg_replace('/^mod/i', '', get_class($objMod)));
+								if ($state) {
+									activateModule($modulename);
+									return array('result' => 'success', 'message' => 'Module '.$this->db->escape($modulename).' activated');
+								} else {
+									unActivateModule($modulename);
+									return array('result' => 'success', 'message' => 'Module '.$this->db->escape($modulename).' deactivated');
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		throw new RestException(404, 'Module '.$this->db->escape($modulename).' not found');
 	}
 }

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -3005,7 +3005,7 @@ class Setup extends DolibarrApi
 				}
 			}
 		}
-		return $this->_cleanObjectDatas($filename);
+		return $filename;
 	}
 
 	/**

--- a/test/hurl/api/setup/10_setup_modules.hurl
+++ b/test/hurl/api/setup/10_setup_modules.hurl
@@ -1,5 +1,65 @@
-# Check status
+# Check module list
 GET http://{{hostnport}}/api/index.php/setup/modules
 HTTP 200
 [Asserts]
 jsonpath "$" count > 2
+
+# Get all states for all modules
+GET http://{{hostnport}}/api/index.php/setup/modules/status/all?status=all
+HTTP 200
+[Captures]
+workflow_active: jsonpath "$['WORKFLOW']['active']"
+[Asserts]
+jsonpath "$.WORKFLOW.modName" == "modWorkflow"
+jsonpath "$.WORKFLOW.origin" == "core"
+jsonpath "$.WORKFLOW.active" matches /^\d{1}$/
+jsonpath "$.WORKFLOW.publisher" == ""
+jsonpath "$.WORKFLOW.version" == "dolibarr"
+
+# Get active all modules
+GET http://{{hostnport}}/api/index.php/setup/modules/status/all?status=active
+HTTP 200
+[Asserts]
+jsonpath "$.*" count > 2
+
+# Get disabled for all modules
+GET http://{{hostnport}}/api/index.php/setup/modules/status/all?status=disabled
+HTTP 200
+[Asserts]
+jsonpath "$.*" count > 2
+
+# Get all states for all modules
+GET http://{{hostnport}}/api/index.php/setup/modules/status/core?status=all
+HTTP 200
+[Asserts]
+jsonpath "$.*" count > 2
+
+# Get active all modules
+GET http://{{hostnport}}/api/index.php/setup/modules/status/core?status=active
+HTTP 200
+[Asserts]
+jsonpath "$.*" count > 2
+
+# Get disabled for all modules
+GET http://{{hostnport}}/api/index.php/setup/modules/status/core?status=disabled
+HTTP 200
+[Asserts]
+jsonpath "$.*" count > 2
+
+# Get all states for all modules
+GET http://{{hostnport}}/api/index.php/setup/modules/status/external?status=all
+HTTP 200
+[Asserts]
+jsonpath "$.*" count >= 0
+
+# Get active all modules
+GET http://{{hostnport}}/api/index.php/setup/modules/status/external?status=active
+HTTP 200
+[Asserts]
+jsonpath "$.*" count >= 0
+
+# Get disabled for all modules
+GET http://{{hostnport}}/api/index.php/setup/modules/status/external?status=disabled
+HTTP 200
+[Asserts]
+jsonpath "$.*" count >=0

--- a/test/hurl/api/setup/10_setup_modules.hurl
+++ b/test/hurl/api/setup/10_setup_modules.hurl
@@ -63,3 +63,22 @@ GET http://{{hostnport}}/api/index.php/setup/modules/status/external?status=disa
 HTTP 200
 [Asserts]
 jsonpath "$.*" count >=0
+
+PUT http://{{hostnport}}/api/index.php/setup/modules/foobar/disable
+HTTP 404
+{"error":{"code":404,"message":"Not Found: Module foobar not found"}}
+
+PUT http://{{hostnport}}/api/index.php/setup/modules/foobar/enable
+HTTP 404
+{"error":{"code":404,"message":"Not Found: Module foobar not found"}}
+
+# GET modules DOLAPIENTITY: 1
+GET http://{{hostnport}}/api/index.php/setup/modules/status/all?status=all
+DOLAPIENTITY: 1
+HTTP 200
+
+# GET modules DOLAPIENTITY: 2
+GET http://{{hostnport}}/api/index.php/setup/modules/status/all?status=all
+DOLAPIENTITY: 2
+HTTP 401
+{"error":{"code":401,"message":"Unauthorized: Error user not valid (not found with api key or bad status or bad validity dates) (conf->entity=2)"}}


### PR DESCRIPTION
# NEW API setup to get, activate and disable modules
This PR adds API endpoints to get, activate and disable modules. Original work made by @defrance in spring 2025. Revived and polished by @JonBendtsen. Also deprecates Jon's simple list of modules. As well as adding some hurl tests.