### PR TITLE
FIX Accountancy - Printing the subsidiary ledger returns the general ledger

### DIFF
--- a/htdocs/accountancy/bookkeeping/listbyaccount.php
+++ b/htdocs/accountancy/bookkeeping/listbyaccount.php
@@ -463,11 +463,17 @@ if (empty($reshook)) {
 
 	// Actions
 	if ($action === 'exporttopdf' && $permissiontoadd) {
-		$object->fetchAllByAccount($sortorder, $sortfield, 0, 0, $filter);
+		if ($type == "sub") {
+			$object->fetchAllByAccount($sortorder, $sortfield, 0, 0, $filter, 'AND', 1);
+		} else {
+			$object->fetchAllByAccount($sortorder, $sortfield, 0, 0, $filter);
+		}
 		require_once DOL_DOCUMENT_ROOT . '/core/modules/accountancy/doc/pdf_ledger.modules.php';
 		$pdf = new pdf_ledger($db);
 		$pdf->fromDate = $search_date_start;
 		$pdf->toDate = $search_date_end;
+		$pdf->ledgerType = $type;
+
 		$result = $pdf->write_file($object, $langs);
 
 		if ($result < 0) {
@@ -895,7 +901,7 @@ if (empty($reshook)) {
 			$newcardbutton .= dolGetButtonTitle($langs->trans('GroupBySubAccountAccounting'), '', 'fa fa-align-left vmirror paddingleft imgforviewmode', DOL_URL_ROOT . '/accountancy/bookkeeping/listbyaccount.php?type=sub&' . $url_param, '', 1, array('morecss' => 'marginleftonly'));
 		}
 	}
-	$newcardbutton .= dolGetButtonTitle($langs->trans('ExportToPdf'), '', 'fa fa-file-pdf paddingleft', $_SERVER['PHP_SELF'] . '?action=exporttopdf&' . $url_param, '', 1, array('morecss' => 'marginleftonly'));
+	$newcardbutton .= dolGetButtonTitle($langs->trans('ExportToPdf'), '', 'fa fa-file-pdf paddingleft', $_SERVER['PHP_SELF'] . '?action=exporttopdf'.(!empty($type) ? '&type=sub' : '').'&' . $url_param, '', 1, array('morecss' => 'marginleftonly'));
 
 	$newcardbutton .= dolGetButtonTitleSeparator();
 

--- a/htdocs/core/modules/accountancy/doc/pdf_ledger.modules.php
+++ b/htdocs/core/modules/accountancy/doc/pdf_ledger.modules.php
@@ -786,7 +786,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 10,
 			'status' => (bool) getDolGlobalInt('PDF_ACCOUNTANCY_LEDGER_ADD_POSITION'),
 			'title' => [
-				'textkey' => '#', // use lang key is useful in somme case with module
+				'textkey' => '#', // use lang key is useful in some case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
@@ -804,7 +804,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 18, // only for desc
 			'status' => true,
 			'title' => [
-				'textkey' => 'Date', // use lang key is useful in somme case with module
+				'textkey' => 'Date', // use lang key is useful in some case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
@@ -822,7 +822,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 15,
 			'status' => true,
 			'title' => [
-				'textkey' => 'Journal', // use lang key is useful in somme case with module
+				'textkey' => 'Journal', // use lang key is useful in some case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
@@ -841,7 +841,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 15,
 			'status' => true,
 			'title' => [
-				'textkey' => 'Piece', // use lang key is useful in somme case with module
+				'textkey' => 'Piece', // use lang key is useful in some case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
@@ -860,7 +860,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => false,
 			'status' => true,
 			'title' => [
-				'textkey' => 'Label', // use lang key is useful in somme case with module
+				'textkey' => 'Label', // use lang key is useful in some case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
@@ -880,7 +880,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 14,
 			'status' => true,
 			'title' => [
-				'textkey' => 'Lettering', // use lang key is useful in somme case with module
+				'textkey' => 'Lettering', // use lang key is useful in some case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
@@ -899,7 +899,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 15,
 			'status' => true,
 			'title' => [
-				'textkey' => 'AccountingDebit', // use lang key is useful in somme case with module
+				'textkey' => 'AccountingDebit', // use lang key is useful in some case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
@@ -918,7 +918,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 15,
 			'status' => true,
 			'title' => array(
-				'textkey' => 'AccountingCredit', // use lang key is useful in somme case with module
+				'textkey' => 'AccountingCredit', // use lang key is useful in some case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
@@ -937,7 +937,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 20,
 			'status' => true,
 			'title' => [
-				'textkey' => 'Balance', // use lang key is useful in somme case with module
+				'textkey' => 'Balance', // use lang key is useful in some case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label

--- a/htdocs/core/modules/accountancy/doc/pdf_ledger.modules.php
+++ b/htdocs/core/modules/accountancy/doc/pdf_ledger.modules.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2023 		Charlene Benke				<charlene@patas-monkey.com>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024	    Nick Fragoulis
- * Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
+ * Copyright (C) 2024-2025	Alexandre Spangaro			<alexandre@inovea-conseil.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -71,6 +71,21 @@ class pdf_ledger extends ModelePdfAccountancy
 	 * @var string Version, possible values are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'''|'development'|'dolibarr'|'experimental'
 	 */
 	public $version = 'dolibarr';
+
+	/**
+	 * @var int $fromDate Start timestamp
+	 */
+	public $fromDate;
+
+	/**
+	 * @var int $toDate Start timestamp
+	 */
+	public $toDate;
+
+	/**
+	 * @var string $ledgerType Ledger type, default is empty for general ledger, or 'sub' for subsidiary ledger
+	 */
+	public $ledgerType;
 
 	/**
 	 *	Constructor
@@ -218,7 +233,11 @@ class pdf_ledger extends ModelePdfAccountancy
 		}
 
 		$pdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
-		$pdf->SetSubject($outputlangs->transnoentities("AccountancyLedger"));
+		if ($this->ledgerType == "sub") {
+			$pdf->SetSubject($outputlangs->transnoentities("BookkeepingSubAccount"));
+		} else {
+			$pdf->SetSubject($outputlangs->transnoentities("AccountancyLedger"));
+		}
 		$pdf->SetCreator("Dolibarr ".DOL_VERSION);
 		$pdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
 		$pdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref)." ".$outputlangs->transnoentities("AccountancyLedger"));
@@ -663,8 +682,12 @@ class pdf_ledger extends ModelePdfAccountancy
 		// Page title
 		$pdf->SetFont('', 'B', $default_font_size + 3);
 		$pdf->SetXY($posx - 2, $posy + 2);
-		$pdf->SetTextColor(0, 0, 60);
-		$title = $outputlangs->transnoentities("PdfLedgerTitle");
+		$pdf->SetTextColor(0, 0, 120);
+		if ($this->ledgerType == "sub") {
+			$title = $outputlangs->transnoentities("BookkeepingSubAccount");
+		} else {
+			$title = $outputlangs->transnoentities("PdfLedgerTitle");
+		}
 		$pdf->MultiCell($w / 3, 3, $title, 0, 'C');
 		$nexY = max($pdf->GetY(), $nexY);
 
@@ -844,7 +867,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 15,
 			'status' => true,
 			'title' => [
-				'textkey' => 'Debit', // use lang key is useful in somme case with module
+				'textkey' => 'AccountingDebit', // use lang key is useful in somme case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label
@@ -863,7 +886,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			'width' => 15,
 			'status' => true,
 			'title' => array(
-				'textkey' => 'Credit', // use lang key is useful in somme case with module
+				'textkey' => 'AccountingCredit', // use lang key is useful in somme case with module
 				'align' => 'C',
 				// 'textkey' => 'yourLangKey', // if there is no label, yourLangKey will be translated to replace label
 				// 'label' => ' ', // the final label

--- a/htdocs/core/modules/accountancy/doc/pdf_ledger.modules.php
+++ b/htdocs/core/modules/accountancy/doc/pdf_ledger.modules.php
@@ -303,37 +303,69 @@ class pdf_ledger extends ModelePdfAccountancy
 		$accountDebit = $accountCredit = $totalDebit = $totalCredit = 0;
 		for ($i = 0; $i < $nblines; $i++) {
 			// Show total line / title line when account has changed
-			if (empty($account) || $account != $object->lines[$i]->numero_compte) {
-				$accountingAccount = new AccountingAccount($this->db);
-				$accountingAccount->fetch(0, $object->lines[$i]->numero_compte);
+			if ($this->ledgerType == "sub") {
+				if (empty($account) || $account != $object->lines[$i]->subledger_account) {
+					// Add the subtotal line
+					if (!empty($account)) {
+						$this->addTotalLine(
+							$pdf,
+							$curY,
+							$nexY,
+							$default_font_size,
+							$langs->trans('Total'),
+							$tab_top_newpage,
+							$accountDebit,
+							$accountCredit
+						);
+					}
 
-				// Add the subtotal line
-				if (!empty($account)) {
-					$this->addTotalLine(
+					// Add the title line
+					$this->addTitleLine(
 						$pdf,
 						$curY,
 						$nexY,
 						$default_font_size,
-						$langs->trans('Total'),
-						$tab_top_newpage,
-						$accountDebit,
-						$accountCredit
+						'piece_num',
+						$langs->trans('SubledgerAccount') . ' ' . length_accounta($object->lines[$i]->subledger_account) . ' - ' . $object->lines[$i]->subledger_label,
+						$tab_top_newpage
 					);
+
+					$account = $object->lines[$i]->subledger_account;
+					$accountDebit = $accountCredit = 0;
 				}
+			} else {
+				if (empty($account) || $account != $object->lines[$i]->numero_compte) {
+					$accountingAccount = new AccountingAccount($this->db);
+					$accountingAccount->fetch(0, $object->lines[$i]->numero_compte);
 
-				// Add the title line
-				$this->addTitleLine(
-					$pdf,
-					$curY,
-					$nexY,
-					$default_font_size,
-					'piece_num',
-					$langs->trans('AccountAccountingShort') . ' ' . length_accountg($accountingAccount->ref) . ' - ' . $accountingAccount->label,
-					$tab_top_newpage
-				);
+					// Add the subtotal line
+					if (!empty($account)) {
+						$this->addTotalLine(
+							$pdf,
+							$curY,
+							$nexY,
+							$default_font_size,
+							$langs->trans('Total'),
+							$tab_top_newpage,
+							$accountDebit,
+							$accountCredit
+						);
+					}
 
-				$account = $object->lines[$i]->numero_compte;
-				$accountDebit = $accountCredit = 0;
+					// Add the title line
+					$this->addTitleLine(
+						$pdf,
+						$curY,
+						$nexY,
+						$default_font_size,
+						'piece_num',
+						$langs->trans('AccountAccountingShort') . ' ' . length_accountg($accountingAccount->ref) . ' - ' . $accountingAccount->label,
+						$tab_top_newpage
+					);
+
+					$account = $object->lines[$i]->numero_compte;
+					$accountDebit = $accountCredit = 0;
+				}
 			}
 
 			$accountDebit += $object->lines[$i]->debit;


### PR DESCRIPTION
When you try to print  subsidiary ledger, we return info of the general ledger.

Data:
<img width="1540" height="783" alt="image" src="https://github.com/user-attachments/assets/b50c012d-a215-4bd1-afee-230fd4111b28" />

Before: Launch printing from subsidiary ledger
<img width="1098" height="595" alt="image" src="https://github.com/user-attachments/assets/99ef9bfc-b6bb-4af9-a159-4756c8da0dd8" />

After:
<img width="1098" height="595" alt="image" src="https://github.com/user-attachments/assets/6b276f12-b617-42b2-b40c-1525cb0485f8" />
