### PR TITLE
Fix: 3 modules where list.php redirected to /mymodule/myobject_card.php

### DIFF
--- a/htdocs/comm/mailing/list.php
+++ b/htdocs/comm/mailing/list.php
@@ -265,7 +265,7 @@ $num = $db->num_rows($resql);
 if ($num == 1 && getDolGlobalString('MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE') && $search_all && !$page) {
 	$obj = $db->fetch_object($resql);
 	$id = $obj->rowid;
-	header("Location: ".dol_buildpath('/mymodule/myobject_card.php', 1).'?id='.$id);
+	header("Location: ".dol_buildpath('/comm/mailing/card.php', 1).'?id='.((int) $id));
 	exit;
 }
 

--- a/htdocs/don/list.php
+++ b/htdocs/don/list.php
@@ -319,7 +319,7 @@ $num = $db->num_rows($resql);
 if ($num == 1 && getDolGlobalInt('MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE') && $search_all && !$page) {
 	$obj = $db->fetch_object($resql);
 	$id = $obj->rowid;
-	header("Location: ".dol_buildpath('/mymodule/myobject_card.php', 1).'?id='.((int) $id));
+	header("Location: ".dol_buildpath('/don/card.php', 1).'?id='.((int) $id));
 	exit;
 }
 

--- a/htdocs/loan/list.php
+++ b/htdocs/loan/list.php
@@ -222,7 +222,7 @@ $num = $db->num_rows($resql);
 if ($num == 1 && getDolGlobalInt('MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE') && $search_all && !$page) {
 	$obj = $db->fetch_object($resql);
 	$id = $obj->rowid;
-	header("Location: ".dol_buildpath('/mymodule/myobject_card.php', 1).'?id='.((int) $id));
+	header("Location: ".dol_buildpath('/loan/card.php', 1).'?id='.((int) $id));
 	exit;
 }
 

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -198,20 +198,6 @@ if ($reshook < 0) {
 }
 
 if (empty($reshook)) {
-	/*
-	$backurlforlist = DOL_URL_ROOT.'/reception/list.php';
-
-	if (empty($backtopage) || ($cancel && empty($id))) {
-		if (empty($backtopage) || ($cancel && strpos($backtopage, '__ID__'))) {
-			 if (empty($id) && (($action != 'add' && $action != 'create') || $cancel)) {
-				 $backtopage = $backurlforlist;
-			 } else {
-				 $backtopage = dol_buildpath('/mymodule/myobject_card.php', 1).'?id='.((!empty($id) && $id > 0) ? $id : '__ID__');
-			 }
-		}
-	}
-	*/
-
 	if ($cancel) {
 		if (!empty($backtopageforcancel)) {
 			header("Location: ".$backtopageforcancel);

--- a/htdocs/ticket/class/cticketcategory.class.php
+++ b/htdocs/ticket/class/cticketcategory.class.php
@@ -480,7 +480,6 @@ class CTicketCategory extends CommonObject
 		*/
 		$label = '';
 
-		//$url = dol_buildpath('/mymodule/myobject_card.php', 1).'?id='.$this->id;
 		$url = '';
 
 		if ($option != 'nolink') {


### PR DESCRIPTION
# Fix 3 modules where list.php redirected to /mymodule/myobject_card.php
This PR is a fix of mainly mass mailing where if you searched for something and there was only one result it would jump to /mymodule/myobject_card.php which is obviously wrong.

I searched for /mymodule/myobject_card.php and found a few more places in

- htdocs/don/list.php
- htdocs/loan/list.php

I changed those to their respectively new cards - even though nothing happened, it seems like direct jump only works for mass mailings? Either way /mymodule/myobject_card.php is obviously wrong so I committed them anyway.

Then there were 2 more mentions of  /mymodule/myobject_card.php  but these were already commented out - so removing those should not matter at all, and it's more of a principle

- htdocs/reception/card.php
- htdocs/ticket/class/cticketcategory.class.php