### PR TITLE
FIX Accountancy - General setup - Missing form on UpdateMask

### DIFF
--- a/htdocs/accountancy/admin/index.php
+++ b/htdocs/accountancy/admin/index.php
@@ -692,12 +692,17 @@ foreach ($arrayofmodules as $module) {
 }
 print '</table>';
 print '</div>';
-
+print '</form>';
 
 // Show advanced options
 print '<br><br>';
 
 // Advanced params
+print '<form action="'.$_SERVER["PHP_SELF"].'" method="post">';
+print '<input type="hidden" name="token" value="'.newToken().'">';
+print '<input type="hidden" name="action" value="update2">';
+print '<input type="hidden" name="page_y" value="">';
+
 print '<div class="div-table-responsive-no-min">';
 print '<table class="noborder centpercent">';
 print '<tr class="liste_titre">';


### PR DESCRIPTION
Since the numbering module was added, a form "updateMask" is automatically inserted, which prevents other options from being saved. Need to close form et re-open a new one for save the others options.