### PR TITLE
FIX: Email template fetching

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -2439,7 +2439,7 @@ class ModelMail extends CommonObject
 		//$result = $this->fetchCommon($id, $ref, '', $noextrafields);
 		$this->fetchCommon($id, '', (empty($ref) ? '' : " AND t.label = '".$this->db->escape($ref)."'"), $noextrafields);
 
-        if ($result > 0 && !empty($this->table_element_line) && empty($nolines)) {
+		if ($result > 0 && !empty($this->table_element_line) && empty($nolines)) {
 			$this->fetchLines($noextrafields);
 		}
 		return $result;

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -2437,13 +2437,9 @@ class ModelMail extends CommonObject
 	{
 		// The table llx_c_email_templates has no field ref. The field ref was named "label" instead. So we change the call to fetchCommon.
 		//$result = $this->fetchCommon($id, $ref, '', $noextrafields);
-		if (!empty($ref)) {
-			$result = $this->fetchCommon($id, null, " AND t.label = '".$this->db->escape($ref)."'", $noextrafields);
-		} else {
-			$result = $this->fetchCommon($id, null, '', $noextrafields);
-		}
+		$this->fetchCommon($id, '', (empty($ref) ? '' : " AND t.label = '".$this->db->escape($ref)."'"), $noextrafields);
 
-		if ($result > 0 && !empty($this->table_element_line) && empty($nolines)) {
+        if ($result > 0 && !empty($this->table_element_line) && empty($nolines)) {
 			$this->fetchLines($noextrafields);
 		}
 		return $result;

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -2437,7 +2437,11 @@ class ModelMail extends CommonObject
 	{
 		// The table llx_c_email_templates has no field ref. The field ref was named "label" instead. So we change the call to fetchCommon.
 		//$result = $this->fetchCommon($id, $ref, '', $noextrafields);
-		$result = $this->fetchCommon($id, '', " AND t.label = '".$this->db->escape($ref)."'", $noextrafields);
+		if (!empty($ref)) {
+			$result = $this->fetchCommon($id, null, " AND t.label = '".$this->db->escape($ref)."'", $noextrafields);
+		} else {
+			$result = $this->fetchCommon($id, null, '', $noextrafields);
+		}
 
 		if ($result > 0 && !empty($this->table_element_line) && empty($nolines)) {
 			$this->fetchLines($noextrafields);


### PR DESCRIPTION
When ref was not given in this fetch function, fetch sql request was:
 ```SQL
SELECT t.rowid,t.module,t.type_template,t.lang,t.private,t.fk_user,t.datec,t.tms,t.label,t.position,t.active,t.topic,t.content,t.content_lines,t.enabled,t.joinfiles,t.email_from,t.email_to,t.email_tocc,t.email_tobcc,t.defaultfortype 
FROM llx_c_email_templates as t 
WHERE t.rowid = XXX AND t.label = '' ;
```
The label condition was therefore blocking