### PR TITLE
Fix : Rounding order calculate cost bom

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1455,10 +1455,10 @@ class BOM extends CommonObject
 								$line->unit_cost = 0;
 							}
 						} else {
-							$line->unit_cost = (float) price2num($unit_cost);
+							$line->unit_cost = (float) $unit_cost;
 						}
 
-						$line->total_cost = (float) price2num($line->qty * $line->unit_cost, 'MT');
+						$line->total_cost = (float) $line->qty * $line->unit_cost;
 
 						$this->total_cost += $line->total_cost;
 					} else {
@@ -1467,7 +1467,7 @@ class BOM extends CommonObject
 						if ($res > 0) {
 							$bom_child->calculateCosts();
 							$line->childBom[] = $bom_child;
-							$this->total_cost += (float) price2num($bom_child->total_cost * $line->qty, 'MT');
+							$this->total_cost += (float) $bom_child->total_cost * $line->qty;
 							$this->total_cost += $line->total_cost;
 						} else {
 							$this->error = $bom_child->error;
@@ -1488,7 +1488,7 @@ class BOM extends CommonObject
 						$res = $workstation->fetch($line->fk_default_workstation);
 
 						if ($res > 0) {
-							$line->total_cost = (float) price2num($qtyhourforline * ($workstation->thm_operator_estimated + $workstation->thm_machine_estimated), 'MT');
+							$line->total_cost = (float) $qtyhourforline * ($workstation->thm_operator_estimated + $workstation->thm_machine_estimated);
 						} else {
 							$this->error = $workstation->error;
 							return -3;
@@ -1502,9 +1502,9 @@ class BOM extends CommonObject
 						}
 
 						if ($qtyhourservice) {
-							$line->total_cost = (float) price2num($qtyhourforline / $qtyhourservice * $tmpproduct->cost_price, 'MT');
+							$line->total_cost = (float) $qtyhourforline / $qtyhourservice * $tmpproduct->cost_price;
 						} else {
-							$line->total_cost = (float) price2num($line->qty * $tmpproduct->cost_price, 'MT');
+							$line->total_cost = (float) $line->qty * $tmpproduct->cost_price;
 						}
 					}
 


### PR DESCRIPTION
# FIX|Fix #Rounding order calculate cost bom

Context: The Problem
I noticed that the calculateCosts() method for Bill of Materials (BOM) was producing an estimated cost that was often inaccurate.

The reason for this inaccuracy was that the calculation applied rounding (using price2num) at every single step: for each product line, each service, and each sub-BOM. The accumulation of these rounding operations at each stage resulted in a final total_cost that was merely a vague estimate rather than a precise value.

The Solution
This fix addresses the issue by removing the intermediate rounding during the calculation process.

The calls to price2num have been removed from the calculateCosts method. All calculations are now performed using their full floating-point precision, and the sum is aggregated without losing accuracy along the way. Rounding should only occur when the final value is displayed to the user, not during the calculation itself.

Impact of this Fix
Main Benefit: The estimated cost calculated for a BOM is now significantly more accurate and reliable.

Side Effect: As a direct consequence, the "Total Cost" column for individual product and service lines within a BOM will now display the true, unrounded value. For example, instead of seeing a rounded cost like $10.55, you will see the exact value used in the calculation, such as $10.548975. This is the correct behavior as it reflects the actual data being used to compute the final, more precise total cost.

<img width="188" height="190" alt="image" src="https://github.com/user-attachments/assets/1bc5a928-c853-4eba-98cd-026fb0ee64dd" />
