### PR TITLE
Api member createSubscription, not all possible RestException numbers was mentioned

### DIFF
--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -655,6 +655,7 @@ class Members extends DolibarrApi
 	 *
 	 * @throws	RestException	403		Access denied
 	 * @throws	RestException	404		Member not found
+	 * @throws	RestException	422		Malformed data
 	 */
 	public function createSubscription($id, $start_date, $end_date, $amount, $label = '')
 	{


### PR DESCRIPTION
# Qual #35580 Add RestException 422
Api member createSubscription, not all possible RestException numbers was mentioned

Real bug fix seems done here https://github.com/Dolibarr/dolibarr/commit/73fe50af1042c97a255881639a4138c3182ddc4c by @ymollard 