### PR TITLE
Fix css badge pill definition

### DIFF
--- a/htdocs/theme/eldy/badges.inc.php
+++ b/htdocs/theme/eldy/badges.inc.php
@@ -39,10 +39,17 @@ if (!defined('ISLOADEDBYSTEELSHEET')) {
 	}
 }
 
-.badge-pill, .tabs .badge {
+.tabs .badge {
 	padding-right: .5em;
 	padding-left: .5em;
 	border-radius: 0.25rem;
+}
+
+.badge-pill{
+	/* Use the .badge-pill modifier class to make badges more rounded (with a larger border-radius and additional horizontal padding). */
+	padding-right: .8em;
+	padding-left: 0.8em;
+	border-radius: 0.5rem;
 }
 
 .badge-dot {


### PR DESCRIPTION
# Fix css badge pill definition see #35763

Someone has changed the badge pill definition.

<img width="1378" height="941" alt="image" src="https://github.com/user-attachments/assets/4c8ec377-a080-4e5f-bc1d-6260598ddf85" />

