### PR TITLE
FIX Accountancy - Missing subledger information on mass cloning

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -3601,7 +3601,7 @@ class BookKeeping extends CommonObject
 						if ($bookKeeping->fetch($toselectid)) {
 							$code_journal = getDolGlobalString('ACCOUNTING_CLONING_ENABLE_INPUT_JOURNAL') ? $code_journal : $bookKeeping->code_journal;
 							$journal_label = getDolGlobalString('ACCOUNTING_CLONING_ENABLE_INPUT_JOURNAL') ? $accountingJournal->label : $bookKeeping->journal_label;
-							$sql = "SELECT piece_num, label_operation, numero_compte, label_compte, doc_type, code_journal, fk_user_author, doc_ref, fk_doc, fk_docdet, debit, credit, journal_label, sens, montant ";
+							$sql = "SELECT piece_num, label_operation, numero_compte, label_compte, subledger_account, subledger_label, doc_type, code_journal, fk_user_author, doc_ref, fk_doc, fk_docdet, debit, credit, journal_label, sens, montant ";
 							$sql .= "FROM " . MAIN_DB_PREFIX . "accounting_bookkeeping WHERE rowid = " . ((int) $toselectid);
 
 							$resql = $this->db->query($sql);
@@ -3610,11 +3610,12 @@ class BookKeeping extends CommonObject
 									$docRef = $langs->trans("CloneOf", $obj->doc_ref);
 
 									$sql_insert = "INSERT INTO ".$this->db->prefix()."accounting_bookkeeping";
-									$sql_insert .= " (piece_num, label_operation, numero_compte, label_compte, doc_type, code_journal, doc_date,";
+									$sql_insert .= " (piece_num, label_operation, numero_compte, label_compte, subledger_account, subledger_label, doc_type, code_journal, doc_date,";
 									$sql_insert .= " fk_user_author, doc_ref, fk_doc, fk_docdet, debit, credit, journal_label, sens, montant";
 									$sql_insert .= ")";
 									$sql_insert .= " VALUES (" . ((int) $pieceNumNext) . ", '" . $this->db->escape($obj->label_operation) . "', '" . $this->db->escape($obj->numero_compte) . "',";
-									$sql_insert .= " '" . $this->db->escape($obj->label_compte) . "', '" . $this->db->escape($obj->doc_type) . "', '" . $this->db->escape($code_journal) . "', '" . $this->db->idate($docdate)."',";
+									$sql_insert .= " '" . $this->db->escape($obj->label_compte) . "', '" . $this->db->escape($obj->subledger_account) . "', '" . $this->db->escape($obj->subledger_label) . "',";
+									$sql_insert .= " '" . $this->db->escape($obj->doc_type) . "', '" . $this->db->escape($code_journal) . "', '" . $this->db->idate($docdate)."',";
 									$sql_insert .= " '" . $this->db->escape($obj->fk_user_author) . "', '" . $this->db->escape($docRef) . "', " . ((int) $obj->fk_doc) . ", " . ((int) $obj->fk_docdet) . ",";
 									$sql_insert .= " " . (float) $obj->debit . ", " . (float) $obj->credit . ", '" . $this->db->escape($journal_label) . "', '" . $this->db->escape($obj->sens) . "', " . (float) $obj->montant;
 									$sql_insert .= ")";

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -3547,7 +3547,7 @@ class BookKeeping extends CommonObject
 	 */
 	public function newCloneMass($toselect, $code_journal, $docdate)
 	{
-		global $langs;
+		global $langs, $user;
 
 		$error = 0;
 		$this->db->begin();
@@ -3608,6 +3608,7 @@ class BookKeeping extends CommonObject
 							if ($resql) {
 								while ($obj = $this->db->fetch_object($resql)) {
 									$docRef = $langs->trans("CloneOf", $obj->doc_ref);
+									$fk_user_author = $user->id;
 
 									$sql_insert = "INSERT INTO ".$this->db->prefix()."accounting_bookkeeping (";
 									$sql_insert .= " piece_num";
@@ -3616,14 +3617,14 @@ class BookKeeping extends CommonObject
 									$sql_insert .= ", label_compte";
 									$sql_insert .= ", subledger_account";
 									$sql_insert .= ", subledger_label";
-									//$sql_insert .= ", doc_type";
+									$sql_insert .= ", doc_type";
 									$sql_insert .= ", code_journal";
 									$sql_insert .= ", doc_date";
 									$sql_insert .= ", date_creation";
 									$sql_insert .= ", fk_user_author";
 									$sql_insert .= ", doc_ref";
-									//$sql_insert .= ", fk_doc";
-									//$sql_insert .= ", fk_docdet";
+									$sql_insert .= ", fk_doc";
+									$sql_insert .= ", fk_docdet";
 									$sql_insert .= ", debit";
 									$sql_insert .= ", credit";
 									$sql_insert .= ", journal_label";
@@ -3631,20 +3632,20 @@ class BookKeeping extends CommonObject
 									$sql_insert .= ", montant";
 									$sql_insert .= ")";
 									$sql_insert .= " VALUES (";
-									$sql_insert .= " ((int) $pieceNumNext)";
+									$sql_insert .=  $pieceNumNext;
 									$sql_insert .= ", '" . $this->db->escape($obj->label_operation) . "'";
 									$sql_insert .= ", '" . $this->db->escape($obj->numero_compte) . "'";
 									$sql_insert .= ", '" . $this->db->escape($obj->label_compte) . "'";
 									$sql_insert .= ", '" . $this->db->escape($obj->subledger_account) . "'";
 									$sql_insert .= ", '" . $this->db->escape($obj->subledger_label) . "'";
-									//$sql_insert .= ", '" . $this->db->escape($obj->doc_type) . "'";
+									$sql_insert .= ", ''";
 									$sql_insert .= ", '" . $this->db->escape($code_journal) . "'";
 									$sql_insert .= ", '" . $this->db->idate($docdate)."'";
 									$sql_insert .= ", '" . $this->db->idate($now)."'";
-									$sql_insert .= ", '" . $this->db->escape($obj->fk_user_author) . "'";
+									$sql_insert .= ", '" . $this->db->escape($fk_user_author) . "'";
 									$sql_insert .= ", '" . $this->db->escape($docRef) . "'";
-									//$sql_insert .= ", " . ((int) $obj->fk_doc);
-									//$sql_insert .= ", " . ((int) $obj->fk_docdet);
+									$sql_insert .= ", '0'";
+									$sql_insert .= ", '0'";
 									$sql_insert .= ", " . (float) $obj->debit;
 									$sql_insert .= ", " . (float) $obj->credit;
 									$sql_insert .= ", '" . $this->db->escape($journal_label) . "'";

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -3601,23 +3601,55 @@ class BookKeeping extends CommonObject
 						if ($bookKeeping->fetch($toselectid)) {
 							$code_journal = getDolGlobalString('ACCOUNTING_CLONING_ENABLE_INPUT_JOURNAL') ? $code_journal : $bookKeeping->code_journal;
 							$journal_label = getDolGlobalString('ACCOUNTING_CLONING_ENABLE_INPUT_JOURNAL') ? $accountingJournal->label : $bookKeeping->journal_label;
-							$sql = "SELECT piece_num, label_operation, numero_compte, label_compte, subledger_account, subledger_label, doc_type, code_journal, fk_user_author, doc_ref, fk_doc, fk_docdet, debit, credit, journal_label, sens, montant ";
-							$sql .= "FROM " . MAIN_DB_PREFIX . "accounting_bookkeeping WHERE rowid = " . ((int) $toselectid);
+							$sql = "SELECT piece_num, label_operation, numero_compte, label_compte, subledger_account, subledger_label, doc_type, code_journal, fk_user_author, doc_ref, fk_doc, fk_docdet, debit, credit, journal_label, sens, montant";
+							$sql .= " FROM ".$this->db->prefix()."accounting_bookkeeping WHERE rowid = " . ((int) $toselectid);
 
 							$resql = $this->db->query($sql);
 							if ($resql) {
 								while ($obj = $this->db->fetch_object($resql)) {
 									$docRef = $langs->trans("CloneOf", $obj->doc_ref);
 
-									$sql_insert = "INSERT INTO ".$this->db->prefix()."accounting_bookkeeping";
-									$sql_insert .= " (piece_num, label_operation, numero_compte, label_compte, subledger_account, subledger_label, doc_type, code_journal, doc_date,";
-									$sql_insert .= " fk_user_author, doc_ref, fk_doc, fk_docdet, debit, credit, journal_label, sens, montant";
+									$sql_insert = "INSERT INTO ".$this->db->prefix()."accounting_bookkeeping (";
+									$sql_insert .= " piece_num";
+									$sql_insert .= ", label_operation";
+									$sql_insert .= ", numero_compte";
+									$sql_insert .= ", label_compte";
+									$sql_insert .= ", subledger_account";
+									$sql_insert .= ", subledger_label";
+									//$sql_insert .= ", doc_type";
+									$sql_insert .= ", code_journal";
+									$sql_insert .= ", doc_date";
+									$sql_insert .= ", date_creation";
+									$sql_insert .= ", fk_user_author";
+									$sql_insert .= ", doc_ref";
+									//$sql_insert .= ", fk_doc";
+									//$sql_insert .= ", fk_docdet";
+									$sql_insert .= ", debit";
+									$sql_insert .= ", credit";
+									$sql_insert .= ", journal_label";
+									$sql_insert .= ", sens";
+									$sql_insert .= ", montant";
 									$sql_insert .= ")";
-									$sql_insert .= " VALUES (" . ((int) $pieceNumNext) . ", '" . $this->db->escape($obj->label_operation) . "', '" . $this->db->escape($obj->numero_compte) . "',";
-									$sql_insert .= " '" . $this->db->escape($obj->label_compte) . "', '" . $this->db->escape($obj->subledger_account) . "', '" . $this->db->escape($obj->subledger_label) . "',";
-									$sql_insert .= " '" . $this->db->escape($obj->doc_type) . "', '" . $this->db->escape($code_journal) . "', '" . $this->db->idate($docdate)."',";
-									$sql_insert .= " '" . $this->db->escape($obj->fk_user_author) . "', '" . $this->db->escape($docRef) . "', " . ((int) $obj->fk_doc) . ", " . ((int) $obj->fk_docdet) . ",";
-									$sql_insert .= " " . (float) $obj->debit . ", " . (float) $obj->credit . ", '" . $this->db->escape($journal_label) . "', '" . $this->db->escape($obj->sens) . "', " . (float) $obj->montant;
+									$sql_insert .= " VALUES (";
+									$sql_insert .= " ((int) $pieceNumNext)";
+									$sql_insert .= ", '" . $this->db->escape($obj->label_operation) . "'";
+									$sql_insert .= ", '" . $this->db->escape($obj->numero_compte) . "'";
+									$sql_insert .= ", '" . $this->db->escape($obj->label_compte) . "'";
+									$sql_insert .= ", '" . $this->db->escape($obj->subledger_account) . "'";
+									$sql_insert .= ", '" . $this->db->escape($obj->subledger_label) . "'";
+									//$sql_insert .= ", '" . $this->db->escape($obj->doc_type) . "'";
+									$sql_insert .= ", '" . $this->db->escape($code_journal) . "'";
+									$sql_insert .= ", '" . $this->db->idate($docdate)."'";
+									$sql_insert .= ", '" . $this->db->idate($now)."'";
+									$sql_insert .= ", '" . $this->db->escape($obj->fk_user_author) . "'";
+									$sql_insert .= ", '" . $this->db->escape($docRef) . "'";
+									//$sql_insert .= ", " . ((int) $obj->fk_doc);
+									//$sql_insert .= ", " . ((int) $obj->fk_docdet);
+									$sql_insert .= ", " . (float) $obj->debit;
+									$sql_insert .= ", " . (float) $obj->credit;
+									$sql_insert .= ", '" . $this->db->escape($journal_label) . "'";
+									$sql_insert .= ", '" . $this->db->escape($obj->sens) . "'";
+									$sql_insert .= ", " . (float) $obj->montant;
 									$sql_insert .= ")";
 
 									$resqlInsert = $this->db->query($sql_insert);

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -3608,7 +3608,6 @@ class BookKeeping extends CommonObject
 							if ($resql) {
 								while ($obj = $this->db->fetch_object($resql)) {
 									$docRef = $langs->trans("CloneOf", $obj->doc_ref);
-									$fk_user_author = $user->id;
 
 									$sql_insert = "INSERT INTO ".$this->db->prefix()."accounting_bookkeeping (";
 									$sql_insert .= " piece_num";
@@ -3642,7 +3641,7 @@ class BookKeeping extends CommonObject
 									$sql_insert .= ", '" . $this->db->escape($code_journal) . "'";
 									$sql_insert .= ", '" . $this->db->idate($docdate)."'";
 									$sql_insert .= ", '" . $this->db->idate($now)."'";
-									$sql_insert .= ", '" . $this->db->escape($fk_user_author) . "'";
+									$sql_insert .= ", ".($user->id > 0 ? ((int) $user->id) : "NULL");
 									$sql_insert .= ", '" . $this->db->escape($docRef) . "'";
 									$sql_insert .= ", '0'";
 									$sql_insert .= ", '0'";

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -3643,8 +3643,8 @@ class BookKeeping extends CommonObject
 									$sql_insert .= ", '" . $this->db->idate($now)."'";
 									$sql_insert .= ", ".($user->id > 0 ? ((int) $user->id) : "NULL");
 									$sql_insert .= ", '" . $this->db->escape($docRef) . "'";
-									$sql_insert .= ", '0'";
-									$sql_insert .= ", '0'";
+									$sql_insert .= ", 0";
+									$sql_insert .= ", 0";
 									$sql_insert .= ", " . (float) $obj->debit;
 									$sql_insert .= ", " . (float) $obj->credit;
 									$sql_insert .= ", '" . $this->db->escape($journal_label) . "'";


### PR DESCRIPTION
Finally, I clear some problem on cloning operation:
- Add subledger information
- Add date_creation information
- Return the real user who are clone
- Clean fk_doc, fk_docdet & doc_type. Cloning return an manuel operation not linked to a dolibarr document like invoice, etc otherwise it will be hell trying to find a document that is in accounting or not