### PR TITLE
Uiux : Data for invoices & Orders status badges

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3757,6 +3757,12 @@ class Commande extends CommonOrder
 
 		$labelTooltip = '';
 
+		$paramsBadge = array('badgeParams' => array('attr' => array(
+			'data-status-element' => $this->element,
+			'data-billed' => (int) $billed,
+			'data-status' => (int) $status
+		)));
+
 		if ($status == self::STATUS_CANCELED) {
 			$labelStatus = $langs->transnoentitiesnoconv('StatusOrderCanceled');
 			$labelStatusShort = $langs->transnoentitiesnoconv('StatusOrderCanceledShort');
@@ -3788,11 +3794,14 @@ class Commande extends CommonOrder
 			$mode = 0;
 		}
 
+		$paramsBadge['tooltip'] = $labelTooltip;
+
 		$parameters = array(
 			'status'          => $status,
 			'mode'            => $mode,
 			'billed'          => $billed,
-			'donotshowbilled' => $donotshowbilled
+			'donotshowbilled' => $donotshowbilled,
+			'paramsBadge'	  =>& $paramsBadge
 		);
 
 		$reshook = $hookmanager->executeHooks('LibStatut', $parameters, $this); // Note that $action and $object may have been modified by hook
@@ -3801,7 +3810,7 @@ class Commande extends CommonOrder
 			return $hookmanager->resPrint;
 		}
 
-		return dolGetStatus($labelStatus, $labelStatusShort, '', $statusType, $mode, '', array('tooltip' => $labelTooltip));
+		return dolGetStatus($labelStatus, $labelStatusShort, '', $statusType, $mode, '', $paramsBadge);
 	}
 
 	/**

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -1022,7 +1022,7 @@ abstract class CommonInvoice extends CommonObject
 			}
 		}
 
-		$paramsButton = array('badgeParams' => array('attr' => array(
+		$paramsBadge = array('badgeParams' => array('attr' => array(
 			'data-status-element' => $this->element,
 			'data-already-paid' => $alreadypaid > 0 ? 1 : 0,
 			'data-status' => (int) $status
@@ -1034,7 +1034,7 @@ abstract class CommonInvoice extends CommonObject
 			'paye'        => $paye,
 			'alreadypaid' => $alreadypaid,
 			'type'        => $type,
-			'paramsButton'=>& $paramsButton
+			'paramsBadge'=>& $paramsBadge
 		);
 
 		$reshook = $hookmanager->executeHooks('LibStatut', $parameters, $this); // Note that $action and $object may have been modified by hook
@@ -1059,7 +1059,7 @@ abstract class CommonInvoice extends CommonObject
 			}
 
 			//$paramsbutton = array('badgeParams' => array('attr' => array('title' => 'rrrr')));
-			$paramsButton['badgeParams' ]['attr']['title'] = $titlestringtoshow;
+			$paramsBadge['badgeParams' ]['attr']['title'] = $titlestringtoshow;
 		}
 
 		/*
@@ -1072,7 +1072,7 @@ abstract class CommonInvoice extends CommonObject
 			$statusType = 'status8';
 		}
 
-		$statusbadge = dolGetStatus($labelStatus, $labelStatusShort, '', $statusType, $mode, '', $paramsButton);
+		$statusbadge = dolGetStatus($labelStatus, $labelStatusShort, '', $statusType, $mode, '', $paramsBadge);
 
 		return $statusbadge;
 	}

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -1022,12 +1022,19 @@ abstract class CommonInvoice extends CommonObject
 			}
 		}
 
+		$paramsButton = array('badgeParams' => array('attr' => array(
+			'data-status-element' => $this->element,
+			'data-already-paid' => $alreadypaid > 0 ? 1 : 0,
+			'data-status' => (int) $status
+		)));
+
 		$parameters = array(
 			'status'      => $status,
 			'mode'        => $mode,
 			'paye'        => $paye,
 			'alreadypaid' => $alreadypaid,
-			'type'        => $type
+			'type'        => $type,
+			'paramsButton'=>& $paramsButton
 		);
 
 		$reshook = $hookmanager->executeHooks('LibStatut', $parameters, $this); // Note that $action and $object may have been modified by hook
@@ -1052,9 +1059,7 @@ abstract class CommonInvoice extends CommonObject
 			}
 
 			//$paramsbutton = array('badgeParams' => array('attr' => array('title' => 'rrrr')));
-			$paramsbutton = array('badgeParams' => array('attr' => array('title' => $titlestringtoshow)));
-		} else {
-			$paramsbutton = array();
+			$paramsButton['badgeParams' ]['attr']['title'] = $titlestringtoshow;
 		}
 
 		/*
@@ -1067,7 +1072,7 @@ abstract class CommonInvoice extends CommonObject
 			$statusType = 'status8';
 		}
 
-		$statusbadge = dolGetStatus($labelStatus, $labelStatusShort, '', $statusType, $mode, '', $paramsbutton);
+		$statusbadge = dolGetStatus($labelStatus, $labelStatusShort, '', $statusType, $mode, '', $paramsButton);
 
 		return $statusbadge;
 	}

--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -1004,6 +1004,12 @@ class MyObject extends CommonObject
 			return '';
 		}
 
+		$paramsBadge = array('badgeParams' => array('attr' => array(
+			'data-status-element' => $this->element,
+			'data-status' => (int) $status
+		)));
+
+
 		if (empty($this->labelStatus) || empty($this->labelStatusShort)) {
 			global $langs;
 			//$langs->load("mymodule@mymodule");
@@ -1021,7 +1027,7 @@ class MyObject extends CommonObject
 			$statusType = 'status6';
 		}
 
-		return dolGetStatus($this->labelStatus[$status], $this->labelStatusShort[$status], '', $statusType, $mode);
+		return dolGetStatus($this->labelStatus[$status], $this->labelStatusShort[$status], '', $statusType, $mode, '', $paramsBadge);
 	}
 
 	/**


### PR DESCRIPTION
# Uiux 
Add dom info in status badges for invoices & Orders

This will help refine the WebPortal status color definitions so that each color can better match the message or alert you want to display to the end user.