### PR TITLE
FIX :  Deduplicate ticket dictionary joins to prevent row multiplication

### DIFF
--- a/htdocs/core/boxes/box_last_modified_ticket.php
+++ b/htdocs/core/boxes/box_last_modified_ticket.php
@@ -3,7 +3,8 @@
  * Copyright (C) 2013-2016  Jean-François FERRY     <hello@librethic.io>
  *               2016       Christophe Battarel     <christophe@altairis.fr>
  * Copyright (C) 2019-2021  Frédéric France         <frederic.france@netlogic.fr>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2025		Pierre Ardoin			<developpeur@lesmetiersdubatiment.fr>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -79,13 +80,15 @@ class box_last_modified_ticket extends ModeleBoxes
 		);
 
 		if ($user->hasRight('ticket', 'read')) {
-			$sql = "SELECT t.rowid as id, t.ref, t.track_id, t.fk_soc, t.fk_user_create, t.fk_user_assign, t.subject, t.message, t.fk_statut as status, t.type_code, t.category_code, t.severity_code, t.datec, t.tms as datem, t.date_read, t.date_close, t.origin_email ";
-			$sql .= ", type.label as type_label, category.label as category_label, severity.label as severity_label";
+			$sql = "SELECT t.rowid as id, t.ref, t.track_id, t.fk_soc, t.fk_user_create, t.fk_user_assign, t.subject, t.message, t.fk_statut as status";
+			$sql .= ", t.type_code, t.category_code, t.severity_code, t.datec, GREATEST(t.tms, tef.tms) as datem, t.date_read, t.date_close, t.origin_email ";
+			$sql .= ", ty.label as type_label, cat.label as category_label, sev.label as severity_label";
 			$sql .= ", s.nom as company_name, s.email as socemail, s.client, s.fournisseur";
 			$sql .= " FROM ".MAIN_DB_PREFIX."ticket as t";
-			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_ticket_type as type ON type.code=t.type_code";
-			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_ticket_category as category ON category.code=t.category_code";
-			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_ticket_severity as severity ON severity.code=t.severity_code";
+			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."ticket_extrafields as tef ON tef.fk_object=t.rowid";
+			$sql .= " LEFT JOIN ( SELECT code, MIN(label) AS label FROM ".MAIN_DB_PREFIX."c_ticket_type WHERE active = 1 GROUP BY code )  as ty ON ty.code=t.type_code";
+            $sql .= " LEFT JOIN ( SELECT code, MIN(label) AS label FROM ".MAIN_DB_PREFIX."c_ticket_category WHERE active = 1 GROUP BY code ) as cat ON cat.code=t.category_code";
+        	$sql .= " LEFT JOIN ( SELECT code, MIN(label) AS label FROM ".MAIN_DB_PREFIX."c_ticket_severity WHERE active = 1 GROUP BY code ) as sev ON sev.code=t.severity_code";
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON s.rowid=t.fk_soc";
 
 			$sql .= " WHERE t.entity IN (".getEntity('ticket').')';


### PR DESCRIPTION
Problem: LEFT JOIN on llx_c_ticket_type, llx_c_ticket_category, and llx_c_ticket_severity multiplied rows when multiple records shared the same code.

Changes:
- Replace direct joins with aggregated subqueries deduplicated by code (MIN(label)), filtered on active = 1.
- Remove duplicate aliases in the SELECT.
- Keep ordering and pagination intact.