### PR TITLE
FIX : remove useless condition to create credit on situation invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -4785,9 +4785,8 @@ else if ($id > 0 || ! empty($ref))
 				}
 			}
 
-			// For situation invoice with excess received
+			// For situation invoice
 			if ($object->statut > Facture::STATUS_DRAFT
-			    && ($object->total_ttc - $totalpaye - $totalcreditnotes - $totaldeposits) > 0
 			    && $user->rights->facture->creer
 			    && !$objectidnext
 			    && $object->is_last_in_cycle()


### PR DESCRIPTION
# FIX #35786 : wrong condition to allow the creation of credit invoices for situation invoices

The condition to allow creation of credit invoice only if excess payment was received is wrong, and (to my mind) useless.

I suggest to remove it.
If making this PR to 8.0 is too far behind, I will be glad to push to 14.0 or 18.0.

