### PR TITLE
FIX : remove useless condition to create credit on situation invoice …

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5796,10 +5796,9 @@ if ($action == 'create') {
 				}
 			}
 
-			// For situation invoice with excess received
+			// For situation invoice
 			if ($object->statut > Facture::STATUS_DRAFT
 				&& $object->type == Facture::TYPE_SITUATION
-				&& ($object->total_ttc - $totalpaid - $totalcreditnotes - $totaldeposits) > 0
 				&& $usercancreate
 				&& !$objectidnext
 				&& $object->is_last_in_cycle()


### PR DESCRIPTION
# FIX #35786 : wrong condition to allow the creation of credit invoices for situation invoices

The condition to allow creation of credit invoice only if excess payment was received is wrong, and (to my mind) useless.

I suggest to remove it.


