### PR TITLE
FIX extra-field list depend on parent extra-field list on direct edit

### DIFF
--- a/htdocs/core/js/lib_head.js.php
+++ b/htdocs/core/js/lib_head.js.php
@@ -1173,4 +1173,39 @@ $(document).ready(function() {
 	}
 });
 
+
+// Code to manage the js for combo list with dependencies (called by extrafields_view.tpl.php)
+function showOptions(child_list, parent_list) {
+	var parentInput = $("select[name="+parent_list+"]");
+	if (parentInput.length === 0) { // when parent extra-field is in view mode and the child is edited directly on card (on line edit)
+		parentInput = $("input[name="+parent_list+"]");
+	}
+	if (parentInput.length > 0) {
+		var val = parentInput.val();
+		var parentVal = parent_list + ":" + val;
+		if (val > 0) {
+			$("select[name=\""+child_list+"\"] option[parent]").prop("disabled", true).hide(); // hide not work with select2 element so disabled it
+			$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").prop('disabled', false).show(); // show not work with select2 element so enabled it
+		} else {
+			$("select[name=\""+child_list+"\"] option").prop("disabled", false).show(); // show not work with select2 element so enabled it
+		}
+	}
+}
+function setListDependencies() {
+	console.log("setListDependencies");
+	jQuery("select option[parent]").parent().each(function() {
+		var child_list = $(this).attr("name");
+		var parent = $(this).find("option[parent]:first").attr("parent");
+		var infos = parent.split(":");
+		var parent_list = infos[0];
+		showOptions(child_list, parent_list);
+
+		/* Activate the handler to call showOptions on each future change */
+		$("select[name=\""+parent_list+"\"]").change(function() {
+			showOptions(child_list, parent_list);
+		});
+	});
+}
+
+
 // End of lib_head.js.php

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -257,6 +257,7 @@ if (empty($reshook) && isset($extrafields->attributes[$object->table_element]['l
 			} else {
 				//var_dump($tmpkeyextra.'-'.$value.'-'.$object->table_element);
 				print $extrafields->showOutputField($tmpkeyextra, $value, '', $object->table_element);
+				print '<input type="hidden" value="' . $value . '" name="options_' . $tmpkeyextra . '" id="options_' . $tmpkeyextra . '"/>'; // it's needed when to get parent value when extra-field list depend on parent extra-field list
 			}
 
 			print '</td>';
@@ -271,31 +272,6 @@ if (empty($reshook) && isset($extrafields->attributes[$object->table_element]['l
 		print '
 				<script>
 				    jQuery(document).ready(function() {
-				    	function showOptions(child_list, parent_list)
-				    	{
-				    		var val = $("select[name="+parent_list+"]").val();
-				    		var parentVal = parent_list + ":" + val;
-							if(val > 0) {
-					    		$("select[name=\""+child_list+"\"] option[parent]").hide();
-					    		$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
-							} else {
-								$("select[name=\""+child_list+"\"] option").show();
-							}
-				    	}
-						function setListDependencies() {
-					    	jQuery("select option[parent]").parent().each(function() {
-					    		var child_list = $(this).attr("name");
-								var parent = $(this).find("option[parent]:first").attr("parent");
-								var infos = parent.split(":");
-								var parent_list = infos[0];
-								showOptions(child_list, parent_list);
-
-								/* Activate the handler to call showOptions on each future change */
-								$("select[name=\""+parent_list+"\"]").change(function() {
-									showOptions(child_list, parent_list);
-								});
-					    	});
-						}
 						setListDependencies();
 				    });
 				</script>'."\n";


### PR DESCRIPTION
FIX extra-field list depend on parent extra-field list on direct edit
- it's similar of PR #35165 but when you edit a field directly from card (live edit)
- for exemple when theses extrafields are always editables and you are on proposal card

**Before**
<img width="517" height="381" alt="image" src="https://github.com/user-attachments/assets/2dd0bb64-616d-46d8-a68a-d240a2763b2d" />

**After**
<img width="515" height="373" alt="image" src="https://github.com/user-attachments/assets/eff0b91b-d79e-4647-923d-ac9b2baa187f" />

I only disabled options because if we hide it doesn't work with jQuery Select2 plugin
