### PR TITLE
Fix : Display error message when impossible to create user from contact

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -184,6 +184,9 @@ if (empty($reshook)) {
 				$errors = $nuser->errors;
 				$db->rollback();
 			}
+			if ($error) {
+				setEventMessage($langs->trans('ImpossibleToCreateUserFromContact').' : '.$nuser->errorsToString(), 'errors');
+			}
 		} else {
 			$error = $object->error;
 			$errors = $object->errors;

--- a/htdocs/langs/en_US/companies.lang
+++ b/htdocs/langs/en_US/companies.lang
@@ -475,3 +475,4 @@ SocialNetworksBusiness=Social networks for company
 ErrorCommercialNotAllowedForThirdparty=The user %s has not the permission to see all thirdparties and is not an allowed sale representative of the company.
 EnablePublicCompanyPages=Enable the public contact page
 PublicInterfaceCompanyDesc=This option offer a public page to offer an online contact form to allow any anonymous visitor to send you a message (creating also a thirdparty and/or contact, automatically).
+ImpossibleToCreateUserFromContact=Impossible to create user from this contact

--- a/htdocs/langs/fr_FR/companies.lang
+++ b/htdocs/langs/fr_FR/companies.lang
@@ -473,3 +473,4 @@ NewSocNameForClone=Nouveau nom société
 ConfirmCloneThirdparties=Êtes-vous sûr de vouloir cloner <b>%s</b> société ?
 SocialNetworksBusiness=Réseaux sociaux de la société
 ErrorCommercialNotAllowedForThirdparty=Le utilisateur %s n'a pas l'autorisation de voir tous les tiers et n'est pas un représentant commercial autorisé du société.
+ImpossibleToCreateUserFromContact=Impossible de créer l'utilisateur à partir ce ce contact


### PR DESCRIPTION
Before this fix, if you try to create a user from a company contact and the're an error (existing same login and/or same mail in user table), we go back to the contact card, nothing happens and no message is displayed.
Now the right message is displayed
<img width="3946" height="1122" alt="Snapshot_2025-10-17_12-15-13" src="https://github.com/user-attachments/assets/0a38624d-238c-451c-86d5-88b8b9c03386" />
