### PR TITLE
FIX: expense report card: do not show bank account if user cannot see them

### DIFF
--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1929,7 +1929,7 @@ if ($action == 'create') {
 			print '</tr>';
 
 			// List of payments already done
-			$canSeeBankAccount = isModEnabled('banque') && $user->hasRight('banque', 'lire');
+			$canSeeBankAccount = isModEnabled('bank') && $user->hasRight('banque', 'lire');
 			$nbcols = 3;
 			$nbrows = 0;
 			if ($canSeeBankAccount) {

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1929,9 +1929,10 @@ if ($action == 'create') {
 			print '</tr>';
 
 			// List of payments already done
+			$canSeeBankAccount = isModEnabled('banque') && $user->hasRight('banque', 'lire');
 			$nbcols = 3;
 			$nbrows = 0;
-			if (isModEnabled("banque")) {
+			if ($canSeeBankAccount) {
 				$nbrows++;
 				$nbcols++;
 			}
@@ -1942,7 +1943,7 @@ if ($action == 'create') {
 			print '<td class="liste_titre">'.$langs->trans('Payments').'</td>';
 			print '<td class="liste_titre">'.$langs->trans('Date').'</td>';
 			print '<td class="liste_titre">'.$langs->trans('Type').'</td>';
-			if (isModEnabled("banque")) {
+			if ($canSeeBankAccount) {
 				print '<td class="liste_titre right">'.$langs->trans('BankAccount').'</td>';
 			}
 			print '<td class="liste_titre right">'.$langs->trans('Amount').'</td>';
@@ -1984,7 +1985,7 @@ if ($action == 'create') {
 					$labeltype = $langs->trans("PaymentType".$objp->payment_code) != ("PaymentType".$objp->payment_code) ? $langs->trans("PaymentType".$objp->payment_code) : $objp->payment_type;
 					print "<td>".$labeltype.' '.$objp->num_payment."</td>\n";
 					// Bank account
-					if (isModEnabled("banque")) {
+					if ($canSeeBankAccount) {
 						$bankaccountstatic->id = $objp->baid;
 						$bankaccountstatic->ref = $objp->baref;
 						$bankaccountstatic->label = $objp->baref;


### PR DESCRIPTION
# FIX: expense report card: do not show bank account if user cannot see them

A user that has no rights on the bank module can see bank account ref + popin in the expense report card where a payment has been created.