### PR TITLE
FIX: missing prospect/customer category translation

### DIFF
--- a/htdocs/langs/en_US/companies.lang
+++ b/htdocs/langs/en_US/companies.lang
@@ -256,6 +256,7 @@ VATIntraSyntaxIsValid=Syntax is valid
 VATPaymentFrequency=VAT payment frequency
 ProspectCustomer=Prospect / Customer
 Prospect=Prospect
+ProspectsOrCustomers=Prospects or customers
 CustomerCard=Customer Card
 Customer=Customer
 CustomerRelativeDiscount=Relative customer discount


### PR DESCRIPTION
# FIX: missing prospect/customer category translation

Only in 22.0+

<img width="1221" height="700" alt="Screenshot 2025-10-16 at 11-40-07 Tags_catégories" src="https://github.com/user-attachments/assets/5584d3b1-13ad-4dd4-a072-0dbae930e73b" />
