### PR TITLE
Remove db attributes from webhook body

### DIFF
--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -119,7 +119,7 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 				if (property_exists($resobject->object, 'errors')) {
 					unset($resobject->object->errors);
 				}
-				if(property_exists($resobject->object, 'db')) {
+				if (property_exists($resobject->object, 'db')) {
 					unset($resobject->object->db);
 				}
 				if (property_exists($resobject->object, 'linkedObjects')) {

--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -124,7 +124,7 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 				}
 				if (property_exists($resobject->object, 'linkedObjects')) {
 					foreach ($resobject->object->linkedObjects as $key => $linkedObject) {
-						foreach ($linkedObject as $k => $obj) {
+						foreach ($linkedObject as $obj) {
 							if (property_exists($obj, 'db')) {
 								unset($obj->db);
 							}

--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -119,6 +119,18 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 				if (property_exists($resobject->object, 'errors')) {
 					unset($resobject->object->errors);
 				}
+				if(property_exists($resobject->object, 'db')) {
+					unset($resobject->object->db);
+				}
+				if (property_exists($resobject->object, 'linkedObjects')) {
+					foreach ($resobject->object->linkedObjects as $key => $linkedObject) {
+						foreach ($linkedObject as $k => $obj) {
+							if (property_exists($obj, 'db')) {
+								unset($obj->db);
+							}
+						}
+					}
+				}
 
 				$jsonstr = json_encode($resobject);
 


### PR DESCRIPTION
# FIX|Fix #[*35818 Webhook body too long*]
Remove db attributes from objects being serialized to body of webhooks