### PR TITLE
Fix type casting for TVA tax in addline method

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -679,7 +679,7 @@ if (empty($reshook)) {
 					$desc,
 					(float) $pu_ht,
 					(float) $qty,
-					(float) $tva_tx,
+					$tva_tx,
 					$localtax1_tx,
 					$localtax2_tx,
 					$idprod,


### PR DESCRIPTION
tva_tx should not be casting to float

FIX #35829 
similar issues #35829 #35831 