### PR TITLE
ADD(categories): missing translation

### DIFF
--- a/htdocs/langs/en_US/categories.lang
+++ b/htdocs/langs/en_US/categories.lang
@@ -104,3 +104,4 @@ CategorieListOfType=Categories (or tags) can be used to categorize the objects m
 NumberOfCategories=Number of tags/categories
 MyTag=My tag
 BackToCategoryTypes=Back to types of category
+ProspectsOrCustomers=Prospects or customers


### PR DESCRIPTION
Add missing translation for `categories/index.php` page.