### PR TITLE
FIX: notifications: correctly report email delivery errors

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -669,6 +669,12 @@ class Notify
 							'notification'
 						);
 
+						if (! empty($mailfile->error) || ! empty($mailfile->errors)) {
+							$this->error = $mailfile->error;
+							$this->errors = $mailfile->errors;
+							return -1;
+						}
+
 						if ($mailfile->sendfile()) {
 							if ($obj->type_target == 'touserid') {
 								$sql = "INSERT INTO ".$this->db->prefix()."notify (daten, fk_action, fk_soc, fk_user, type, objet_type, type_target, objet_id, email)";
@@ -932,6 +938,12 @@ class Notify
 						'',
 						'notification'
 					);
+
+					if (! empty($mailfile->error) || ! empty($mailfile->errors)) {
+						$this->error = $mailfile->error;
+						$this->errors = $mailfile->errors;
+						return -1;
+					}
 
 					if ($mailfile->sendfile()) {
 						$sql = "INSERT INTO ".$this->db->prefix()."notify (daten, fk_action, fk_soc, fk_contact, type, type_target, objet_type, objet_id, email)";

--- a/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
+++ b/htdocs/core/triggers/interface_50_modNotification_Notification.class.php
@@ -77,9 +77,13 @@ class InterfaceNotification extends DolibarrTriggers
 		dol_syslog("Trigger '".$this->name."' for action '".$action."' launched by ".__FILE__.". id=".$object->id);
 
 		$notify = new Notify($this->db);
-		$notify->send($action, $object);
+		$result = $notify->send($action, $object);
 
-		return 1;
+		if ($result < 0) {
+			$this->errors = array_merge($this->errors, empty($notify->error) ? array() : array($notify->error), empty($notify->errors) ? array() : $notify->errors);
+		}
+
+		return $result;
 	}
 
 


### PR DESCRIPTION
# FIX: notifications: correctly report email delivery errors

Errors coming from method `CMailFile::__construct()` and `Notify::send()` are not properly bubbled to their callers.