### PR TITLE
FIX : Perf for bom select

### DIFF
--- a/htdocs/admin/bom.php
+++ b/htdocs/admin/bom.php
@@ -171,7 +171,7 @@ if ($action == 'updateMask') {
 	} else {
 		setEventMessages($langs->trans("Error"), null, 'errors');
 	}
-}elseif ($action == 'updateoptions') {
+} elseif ($action == 'updateoptions') {
 	if (GETPOST('BOM_USE_SEARCH_TO_SELECT')) {
 		$bomsearch = GETPOST('activate_BOM_USE_SEARCH_TO_SELECT', 'alpha');
 		if (dolibarr_set_const($db, "BOM_USE_SEARCH_TO_SELECT", $bomsearch, 'chaine', 0, '', $conf->entity)) {

--- a/htdocs/admin/bom.php
+++ b/htdocs/admin/bom.php
@@ -171,6 +171,13 @@ if ($action == 'updateMask') {
 	} else {
 		setEventMessages($langs->trans("Error"), null, 'errors');
 	}
+}elseif ($action == 'updateoptions') {
+	if (GETPOST('BOM_USE_SEARCH_TO_SELECT')) {
+		$bomsearch = GETPOST('activate_BOM_USE_SEARCH_TO_SELECT', 'alpha');
+		if (dolibarr_set_const($db, "BOM_USE_SEARCH_TO_SELECT", $bomsearch, 'chaine', 0, '', $conf->entity)) {
+			$conf->global->BOM_USE_SEARCH_TO_SELECT = $bomsearch;
+		}
+	}
 }
 
 
@@ -463,6 +470,31 @@ print '<td class="center" width="60"></td>';
 print "<td>&nbsp;</td>\n";
 print "</tr>\n";
 
+
+print '<tr class="oddeven">';
+print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
+print '<input type="hidden" name="token" value="'.newToken().'">';
+print '<input type="hidden" name="action" value="updateoptions">';
+print '<td>'.$langs->trans("UseSearchToSelectBom").'</td>';
+if (!$conf->use_javascript_ajax) {
+	print '<td></td>';
+	print '<td class="nowrap right">';
+	print $langs->trans("NotAvailableWhenAjaxDisabled");
+	print "</td>";
+} else {
+	print '<td class="right">';
+	$arrval = array('0' => $langs->trans("No"),
+		'1' => $langs->trans("Yes").' ('.$langs->trans("NumberOfKeyToSearch", 1).')',
+		'2' => $langs->trans("Yes").' ('.$langs->trans("NumberOfKeyToSearch", 2).')',
+		'3' => $langs->trans("Yes").' ('.$langs->trans("NumberOfKeyToSearch", 3).')',
+	);
+	print $form->selectarray("activate_BOM_USE_SEARCH_TO_SELECT", $arrval, getDolGlobalString("BOM_USE_SEARCH_TO_SELECT")).'</td>';
+	print '<td class="right"><input type="submit" class="button small reposition" name="BOM_USE_SEARCH_TO_SELECT" value="'.$langs->trans("Modify").'">';
+	print "</td>";
+}
+print '</form>';
+print '</tr>';
+
 $substitutionarray = pdf_getSubstitutionArray($langs, null, null, 2);
 $substitutionarray['__(AnyTranslationKey)__'] = $langs->trans("Translation");
 $htmltext = '<i>'.$langs->trans("AvailableVariables").':<br>';
@@ -506,6 +538,8 @@ print '</form>';
 print '</table>';
 print '</div>';
 print '<br>';
+
+
 
 
 // End of page

--- a/htdocs/admin/system/perf.php
+++ b/htdocs/admin/system/perf.php
@@ -37,7 +37,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
  */
 
 // Load translation files required by the page
-$langs->loadLangs(array("install", "other", "admin", "products"));
+$langs->loadLangs(array("install", "other", "admin", "products", "mrp"));
 
 if (!$user->admin) {
 	accessforbidden();
@@ -610,6 +610,27 @@ if ($resql) {
 		}
 	} else {
 		print img_picto('', 'tick.png', 'class="pictofixedwidth"').' '.$langs->trans("NbOfObjectIsLowerThanNoPb", $nb, $langs->transnoentitiesnoconv("Projects"));
+	}
+	print '<br>';
+	$db->free($resql);
+}
+// Bom combo list
+$sql = "SELECT COUNT(*) as nb";
+$sql .= " FROM ".MAIN_DB_PREFIX."bom_bom as s";
+$resql = $db->query($sql);
+if ($resql) {
+	$limitforoptim = 5000;
+	$num = $db->num_rows($resql);
+	$obj = $db->fetch_object($resql);
+	$nb = $obj->nb;
+	if ($nb > $limitforoptim) {
+		if (!getDolGlobalString('BOM_USE_SEARCH_TO_SELECT')) {
+			print img_picto('', 'warning.png', 'class="pictofixedwidth"').' '.$langs->trans("YouHaveXObjectUseComboOptim", $nb, $langs->transnoentitiesnoconv("Bom"), 'BOM_USE_SEARCH_TO_SELECT');
+		} else {
+			print img_picto('', 'tick.png', 'class="pictofixedwidth"').' '.$langs->trans("YouHaveXObjectAndSearchOptimOn", $nb, $langs->transnoentitiesnoconv("Bom"), 'BOM_USE_SEARCH_TO_SELECT', getDolGlobalString('BOM_USE_SEARCH_TO_SELECT'));
+		}
+	} else {
+		print img_picto('', 'tick.png', 'class="pictofixedwidth"').' '.$langs->trans("NbOfObjectIsLowerThanNoPb", $nb, $langs->transnoentitiesnoconv("Bom"));
 	}
 	print '<br>';
 	$db->free($resql);

--- a/htdocs/admin/system/perf.php
+++ b/htdocs/admin/system/perf.php
@@ -616,7 +616,7 @@ if ($resql) {
 }
 // Bom combo list
 $sql = "SELECT COUNT(*) as nb";
-$sql .= " FROM ".MAIN_DB_PREFIX."bom_bom as s";
+$sql .= " FROM ".$db->prefix()."bom_bom as s";
 $resql = $db->query($sql);
 if ($resql) {
 	$limitforoptim = 5000;

--- a/htdocs/core/ajax/selectobject.php
+++ b/htdocs/core/ajax/selectobject.php
@@ -147,7 +147,8 @@ if ($usesublevelpermission && !isset($user->rights->$module->$element)) {	// The
 $searchkey = (($id && GETPOST((string) $id, 'alpha')) ? GETPOST((string) $id, 'alpha') : (($htmlname && GETPOST($htmlname, 'alpha')) ? GETPOST($htmlname, 'alpha') : ''));
 
 // Add a security test to avoid to get content of all tables
-if ($objecttmp !== null && !empty($objecttmp->module)) {
+$allowModules = ['bom'];
+if ($objecttmp !== null && !empty($objecttmp->module) && !in_array($objecttmp->module, $allowModules)) {
 	restrictedArea($user, $objecttmp->module, $id, $objecttmp->table_element, $objecttmp->element);
 } else {
 	restrictedArea($user, $objecttmp !== null ? $objecttmp->element : '', $id);

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2989,7 +2989,7 @@ class Form
 		if (!$forcecombo) {
 			include_once DOL_DOCUMENT_ROOT . '/core/lib/ajax.lib.php';
 			$events = array();
-			$out .= ajax_combobox($htmlname, $events, getDolGlobalInt("PRODUIT_USE_SEARCH_TO_SELECT"));
+			$out .= ajax_combobox($htmlname, $events, getDolGlobalInt("BOM_USE_SEARCH_TO_SELECT"));
 		}
 
 		$out .= '<select class="flat' . ($morecss ? ' ' . $morecss : '') . '" name="' . $htmlname . '" id="' . $htmlname . '">';
@@ -9013,6 +9013,7 @@ class Form
 		if ($prefixforautocompletemode == 'product') {
 			$prefixforautocompletemode = 'produit';
 		}
+
 		$confkeyforautocompletemode = strtoupper($prefixforautocompletemode) . '_USE_SEARCH_TO_SELECT'; // For example COMPANY_USE_SEARCH_TO_SELECT
 
 		dol_syslog(get_class($this) . "::selectForForms filter=" . $filter, LOG_DEBUG);

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -1288,7 +1288,6 @@ function accessforbidden($message = '', $printheader = 1, $printfooter = 1, $sho
 {
 	global $conf, $db, $user, $langs, $hookmanager;
 	global $action, $object;
-	debug_print_backtrace();exit;
 
 	if (!is_object($langs)) {
 		include_once DOL_DOCUMENT_ROOT.'/core/class/translate.class.php';

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -1288,6 +1288,7 @@ function accessforbidden($message = '', $printheader = 1, $printfooter = 1, $sho
 {
 	global $conf, $db, $user, $langs, $hookmanager;
 	global $action, $object;
+	debug_print_backtrace();exit;
 
 	if (!is_object($langs)) {
 		include_once DOL_DOCUMENT_ROOT.'/core/class/translate.class.php';

--- a/htdocs/langs/en_US/mrp.lang
+++ b/htdocs/langs/en_US/mrp.lang
@@ -169,3 +169,4 @@ ErrorModifyMoDateStart = You must choose a start date earlier than the current s
 ErrorModifyMoDateEnd = You must choose an end date later than the start date. %s
 ErrorCancelMo=Error updating cancellation
 ErrorModifyMoDate=Error updating date modification
+UseSearchToSelectBom=Wait until a key is pressed before loading content of Boms combo list.<br>This may improve performance if you have a large number of projects, but it is less convenient.

--- a/htdocs/langs/fr_FR/mrp.lang
+++ b/htdocs/langs/fr_FR/mrp.lang
@@ -169,3 +169,4 @@ ErrorModifyMoDateStart = Vous devez choisir une date de début antérieure à la
 ErrorModifyMoDateEnd = Vous devez choisir une date de fin postérieure à la date de début. %s
 ErrorCancelMo=Erreur lors de la mise à jour de l'annulation
 ErrorModifyMoDate=Erreur lors de la mise à jour de la modification de la date
+UseSearchToSelectBom=Attendre que vous ayez appuyé sur une touche avant de charger le contenu de la liste déroulante des nomenclatures (Cela peut augmenter les performances si vous avez un grand nombre de nomenclatures, mais cela est moins convivial)


### PR DESCRIPTION
## FIX BOM combo list performance and correct product selector regression

Hello,

This pull request addresses the performance issues in the Bill of Materials (BOM) dropdown lists by implementing a search-on-type feature. This new version has been updated to fix all the critical issues raised in the previous review.

Objective:

    To improve UI performance on instances with a large number of BOMs by adding a lazy-loading mechanism to the BOM selection dropdown.

    This is controlled by a new global constant: BOM_USE_SEARCH_TO_SELECT.