### PR TITLE
FIX: no emails sent when closing a ticket

### DIFF
--- a/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
+++ b/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
@@ -304,7 +304,7 @@ class InterfaceTicketEmail extends DolibarrTriggers
 						// Refuse email if not
 						$contactObj = new Contact($this->db);
 						$res = $contactObj->fetch($contactid);
-						if (! in_array($contactObj, $linked_contacts)) {
+						if (! in_array($contactObj->id, array_column($linked_contacts, 'id'))) {
 							$error_msg = $langs->trans('Error'). ': ';
 							$error_msg .= $langs->transnoentities('TicketWrongContact');
 							setEventMessages($error_msg, [], 'errors');

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -451,6 +451,9 @@ if (empty($reshook)) {
 
 	if (($action == "confirm_close" || $action == "confirm_abandon") && GETPOST('confirm', 'alpha') == 'yes' && $permissiontoadd) {
 		$object->fetch(GETPOSTINT('id'), '', GETPOST('track_id', 'alpha'));
+		if (GETPOSTISSET('contactid')) {
+			$object->context['contactid'] = GETPOSTINT('contactid');
+		}
 
 		if ($object->close($user, ($action == "confirm_abandon" ? 1 : 0))) {
 			setEventMessages($langs->trans('TicketMarkedAsClosed'), null, 'mesgs');


### PR DESCRIPTION
# FIX: when a ticket is closed, no e-mail is sent to contacts despite settings

Maybe this is a regression: `$object->context['contactid']` was no longer set when closing a ticket from the web interface (I didn't try it via other methods).

In addition, there was a wrong `in_array` (the searched item is an object, but the items in the array are arrays).

I didn't check if the problem started in 21.0 or if it was already present in older versions.