### PR TITLE
FIX: notification email not sent

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -649,7 +649,7 @@ class Notify
 		if (getDolGlobalString('MAIN_APPLICATION_TITLE')) {
 			$application = getDolGlobalString('MAIN_APPLICATION_TITLE');
 		}
-		$from = getDolGlobalString('NOTIFICATION_EMAIL_FROM');
+		$from = getDolGlobalString('NOTIFICATION_EMAIL_FROM', getDolGlobalString('MAIN_MAIL_EMAIL_FROM'));
 		$object_type = '';
 		$link = '';
 		$num = 0;


### PR DESCRIPTION
# FIX: notification email not sent

When from_value of notification configuration was empty, it didn't take the one from main email configuration and email was not sent.