### PR TITLE
FIX #32347 Allow deactivation of document models on Donations module

### DIFF
--- a/htdocs/don/admin/donation.php
+++ b/htdocs/don/admin/donation.php
@@ -268,7 +268,7 @@ if (is_resource($handle)) {
 						print '</td>';
 					} else {
 						print "<td class=\"center\">\n";
-						print '<a href="'.$_SERVER["PHP_SELF"].'?action=setdoc&token='.newToken().'&value='.urlencode($name).'&scan_dir='.urlencode($module->scandir).'&label='.urlencode($module->name).'">'.img_picto($langs->trans("Enabled"), 'switch_on').'</a>';
+						print '<a href="'.$_SERVER["PHP_SELF"].'?action=del&token='.newToken().'&value='.urlencode($name).'&scan_dir='.urlencode($module->scandir).'&label='.urlencode($module->name).'">'.img_picto($langs->trans("Enabled"), 'switch_on').'</a>';
 						print '</td>';
 					}
 				} else {


### PR DESCRIPTION
# FIX #32347 Allow deactivation of document models on Donations module

The administration page for the donations module allows, like on other modules, to select the document models you want to offer for printing donations receipts. Unfortunately, it was impossible to deactivate a model once it had been activated, as a click on the "Activated" switch results in setting the corresponding model as default (thus keeping it activated).

The action to handle deactivation of the model was already there, just the link was wrong. This PR fixes the bug.

Impact found in v22 and develop. I suspect it happens also on v21 and v20 as the bug reports was initially on the v20. I can send a new PR based on v20 if you want. 