### PR TITLE
Fix - Task event linked from task and event

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -444,7 +444,7 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 
 			$object->fk_element = $taskid;
 			$object->elementid = $taskid;
-			$object->elementtype = 'task';
+			$object->elementtype = 'project_task';
 		}
 
 		$object->datep = $datep;
@@ -963,7 +963,7 @@ if (empty($reshook) && $action == 'update' && $usercancreate) {
 
 			$object->fk_element = $taskid;
 			$object->elementid = $taskid;
-			$object->elementtype = 'task';
+			$object->elementtype = 'project_task';
 		}
 
 		$object->note_private = trim(GETPOST("note", "restricthtml"));
@@ -1803,7 +1803,7 @@ if ($action == 'create') {
 		}
 		//var_dump('origin='.$origin.' originid='.$originid.' hasPermissionOnLinkedObject='.$hasPermissionOnLinkedObject);
 
-		if (! in_array($origin, array('societe', 'project', 'task', 'user'))) {
+		if (! in_array($origin, array('societe', 'project', 'project_task', 'user'))) {
 			// We do not use link for object that already contains a hard coded field to make links with agenda events
 			print '<tr><td class="titlefieldcreate">'.$langs->trans("LinkedObject").'</td>';
 			print '<td colspan="3">';
@@ -2321,7 +2321,7 @@ if ($id > 0 && $action != 'create') {
 			print '<tr>';
 			print '<td>'.$langs->trans("LinkedObject").'</td>';
 
-			if ($object->elementtype == 'task' && isModEnabled('project')) {
+			if ($object->elementtype == 'project_task' && isModEnabled('project')) {
 				print '<td id="project-task-input-container" >';
 
 				$urloption = '?action=create&donotclearsession=1'; // we use create not edit for more flexibility

--- a/htdocs/core/class/html.formactions.class.php
+++ b/htdocs/core/class/html.formactions.class.php
@@ -198,7 +198,7 @@ class FormActions
 				$projectid = $object->id;
 			}
 			$taskid = 0;
-			if ($typeelement == 'task') {
+			if ($typeelement == 'project_task') {
 				$taskid = $object->id;
 			}
 

--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -2146,7 +2146,7 @@ function dolGetElementUrl($objectid, $objecttype, $withpicto = 0, $option = '')
 		$langs->load('projects');
 		$classpath = 'projet/class';
 		$module = 'projet';
-	} elseif ($objecttype == 'task') {
+	} elseif ($objecttype == 'project_task') {
 		$langs->load('projects');
 		$classpath = 'projet/class';
 		$module = 'projet';


### PR DESCRIPTION
NEW This patch fixes task events so that they are correctly displayed in the task event list and that in the event the Linked Object refers back to the task.

The issue was that the elementtype value in the database was being referenced as both 'project_task' and 'task' by different parts of code

The only thing that this patch does not fix is that in the database table actioncomm the value in elementtype is both 'project_task' and 'task'. This patch should also update the database to rename 'task' to 'project_task' but I am not sure how to do this as part of the patch