### PR TITLE
FIX: my previous fix was incompatible with Thomas' fix from PR#35590

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -452,7 +452,7 @@ if (empty($reshook)) {
 	if (($action == "confirm_close" || $action == "confirm_abandon") && GETPOST('confirm', 'alpha') == 'yes' && $permissiontoadd) {
 		$object->fetch(GETPOSTINT('id'), '', GETPOST('track_id', 'alpha'));
 		if (GETPOSTISSET('contactid')) {
-			$object->context['contactid'] = GETPOSTINT('contactid');
+			$object->context['contact_id'] = GETPOSTINT('contactid');
 		}
 
 		if ($object->close($user, ($action == "confirm_abandon" ? 1 : 0))) {


### PR DESCRIPTION
# FIX ticket closed e-mail still not sent

Our client didn't have the most recent 21.0, so I based my previous fix on their version, which didn't have the code from PR #35590 (which renames the array key `contactid` to `contact_id`).

To be clear: there is no problem with PR #35590, but I based my fix on older code.