### PR TITLE
FIX: actions_addUpdateDelete password check

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -255,6 +255,8 @@ if ($action == 'update' && !empty($permissiontoadd)) {
 			if (!empty($values_arr)) {
 				$value = implode(',', $values_arr);
 			}
+		} elseif ($object->fields[$key]['type'] === 'password') {
+			$value = GETPOST($key, 'none');
 		} else {
 			if ($key == 'lang') {
 				$value = GETPOST($key, 'aZ09');


### PR DESCRIPTION
# FIX: actions_addUpdateDelete password check

Fields of type 'password' was checked by default with 'alphanohtml' which erase special chars.
Password with special chars was saved with wrong value.