### PR TITLE
FIX: actions_addUpdateDelete password checked

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -256,7 +256,11 @@ if ($action == 'update' && !empty($permissiontoadd)) {
 				$value = implode(',', $values_arr);
 			}
 		} elseif ($object->fields[$key]['type'] === 'password') {
-			$value = GETPOST($key, 'none');
+			/*
+			 * GETPOST with check 'None' is unauthorized
+			 * Bypass: check 'Cutom' with filter FILTER_UNSAFE_RAW which does nothing
+			 */
+			$value = GETPOST($key, 'custom', 0, FILTER_UNSAFE_RAW, 0);
 		} else {
 			if ($key == 'lang') {
 				$value = GETPOST($key, 'aZ09');

--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -255,6 +255,8 @@ if ($action == 'update' && !empty($permissiontoadd)) {
 			if (!empty($values_arr)) {
 				$value = implode(',', $values_arr);
 			}
+		} elseif ($object->fields[$key]['type'] === 'password') {
+			$value = GETPOST($key, 'none');
 		} else {
 			if ($key == 'lang') {
 				$value = GETPOST($key, 'aZ09');


### PR DESCRIPTION
# FIX: actions_addUpdateDelete password check

Fields of type 'password' was checked by default with 'alphanohtml' which erase special chars.
Password with special chars was saved with wrong value.