### PR TITLE
QUAL Support user-based holiday calculation in num_open_day

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1742,7 +1742,7 @@ if (!$error && ($massaction == 'approveleave' || ($action == 'approveleave' && $
 				// If no SQL error, we redirect to the request form
 				if (!$error) {
 					// Calculate number of days consumed
-					$nbopenedday = num_open_day($objecttmp->date_debut_gmt, $objecttmp->date_fin_gmt, 0, 1, $objecttmp->halfday);
+					$nbopenedday = num_open_day($objecttmp->date_debut_gmt, $objecttmp->date_fin_gmt, 0, 1, $objecttmp->halfday, '', $objecttmp->fk_user);
 					$soldeActuel = $objecttmp->getCpforUser($objecttmp->fk_user, $objecttmp->fk_type);
 					$newSolde = ($soldeActuel - $nbopenedday);
 

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -1311,12 +1311,30 @@ function num_between_day($timestampStart, $timestampEnd, $lastday = 0)
  *	@param		int			$lastday            We include last day, 0: no, 1:yes
  *  @param		int			$halfday			Tag to define half day when holiday start and end
  *  @param      string		$country_code       Country code (company country code if not defined)
+ *  @param      int			$fk_user       		ID of the user for whom we are calculating
  *	@return    	int|string						Number of days or hours or string if error
  *  @seealso num_between_day(), num_public_holiday()
  */
-function num_open_day($timestampStart, $timestampEnd, $inhour = 0, $lastday = 0, $halfday = 0, $country_code = '')
+function num_open_day($timestampStart, $timestampEnd, $inhour = 0, $lastday = 0, $halfday = 0, $country_code = '', $fk_user = null)
 {
-	global $langs, $mysoc;
+	global $langs, $mysoc, $db;
+        if(!empty($fk_user)){
+            $userObj = new User($db);
+            $result = $userObj->fetch($fk_user);
+            if($result > 0 && !empty($userObj->country_id)){
+                $sql = 'SELECT code FROM '.MAIN_DB_PREFIX.'c_country as c';
+                $sql .= ' WHERE c.rowid = '.(int) $userObj->country_id;
+                $resql = $db->query($sql);
+                if ($resql) {
+                        $obj = $db->fetch_object($resql);
+                        if ($obj) {
+                            $country_code = $obj->code;
+                        }
+                } else {
+                    dol_syslog("Error finding country for user: ".$fk_user);
+                }
+            }
+        }
 
 	if (empty($country_code)) {
 		$country_code = $mysoc->country_code;

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -1318,23 +1318,23 @@ function num_between_day($timestampStart, $timestampEnd, $lastday = 0)
 function num_open_day($timestampStart, $timestampEnd, $inhour = 0, $lastday = 0, $halfday = 0, $country_code = '', $fk_user = null)
 {
 	global $langs, $mysoc, $db;
-        if(!empty($fk_user)){
-            $userObj = new User($db);
-            $result = $userObj->fetch($fk_user);
-            if($result > 0 && !empty($userObj->country_id)){
-                $sql = 'SELECT code FROM '.MAIN_DB_PREFIX.'c_country as c';
-                $sql .= ' WHERE c.rowid = '.(int) $userObj->country_id;
-                $resql = $db->query($sql);
-                if ($resql) {
-                        $obj = $db->fetch_object($resql);
-                        if ($obj) {
-                            $country_code = $obj->code;
-                        }
-                } else {
-                    dol_syslog("Error finding country for user: ".$fk_user);
-                }
-            }
-        }
+	if (!empty($fk_user)) {
+		$userObj = new User($db);
+		$result = $userObj->fetch($fk_user);
+		if ($result > 0 && !empty($userObj->country_id)) {
+			$sql = 'SELECT code FROM '.MAIN_DB_PREFIX.'c_country as c';
+			$sql .= ' WHERE c.rowid = '.(int) $userObj->country_id;
+			$resql = $db->query($sql);
+			if ($resql) {
+				$obj = $db->fetch_object($resql);
+				if ($obj) {
+					$country_code = $obj->code;
+				}
+			} else {
+				dol_syslog("Error finding country for user: ".$fk_user);
+			}
+		}
+	}
 
 	if (empty($country_code)) {
 		$country_code = $mysoc->country_code;

--- a/htdocs/exports/class/export.class.php
+++ b/htdocs/exports/class/export.class.php
@@ -783,7 +783,7 @@ class Export
 								include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 								//$alias=$this->array_export_alias[$indice][$key];
 								$alias = str_replace(array('.', '-', '(', ')'), '_', $key);
-								$obj->$alias = num_open_day(dol_stringtotime($obj->d_date_debut, 1), dol_stringtotime($obj->d_date_fin, 1), 0, 1, $obj->d_halfday, $mysoc->country_code);
+								$obj->$alias = num_open_day(dol_stringtotime($obj->d_date_debut, 1), dol_stringtotime($obj->d_date_fin, 1), 0, 1, $obj->d_halfday, $mysoc->country_code, $obj->d_fk_user);
 							} elseif (is_string($item) && $item == 'getRemainToPay') {
 								// Operation INVOICEREMAINTOPAY
 								//$alias=$this->array_export_alias[$indice][$key];

--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -260,7 +260,7 @@ if (empty($reshook)) {
 		}
 
 		// If there is no Business Days within request
-		$nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday);
+		$nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday, '', $fuserid);
 		if ($nbopenedday < 0.5) {
 			setEventMessages($langs->trans("ErrorDureeCP"), null, 'errors'); // No working day
 			$error++;
@@ -402,7 +402,7 @@ if (empty($reshook)) {
 				}
 
 				// If there is no Business Days within request
-				$nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday);
+				$nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday, '', $object->fk_user);
 				if ($nbopenedday < 0.5) {
 					setEventMessages($langs->trans('ErrorDureeCP'), null, 'warnings');
 					$error++;
@@ -531,7 +531,7 @@ if (empty($reshook)) {
 
 				// option to notify the validator if the balance is less than the request
 				if (!getDolGlobalString('HOLIDAY_HIDE_APPROVER_ABOUT_NEGATIVE_BALANCE')) {
-					$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday);
+					$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, '', $object->fk_user);
 
 					if ($nbopenedday > $object->getCPforUser($object->fk_user, $object->fk_type)) {
 						$message .= "<p>".$langs->transnoentities("HolidaysToValidateAlertSolde")."</p>\n";
@@ -643,7 +643,7 @@ if (empty($reshook)) {
 			// If no SQL error, we redirect to the request form
 			if (!$error && empty($decrease)) {
 				// Calculate number of days consumed
-				$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday);
+				$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, '', $object->fk_user);
 				$soldeActuel = $object->getCpforUser($object->fk_user, $object->fk_type);
 				$newSolde = ($soldeActuel - $nbopenedday);
 				$label = $object->ref.' - '.$langs->transnoentitiesnoconv("HolidayConsumption");
@@ -886,7 +886,7 @@ if (empty($reshook)) {
 				}
 
 				// Calculate number of days consumed
-				$nbopenedday = num_open_day($startDate, $endDate, 0, 1, $object->halfday);
+				$nbopenedday = num_open_day($startDate, $endDate, 0, 1, $object->halfday, '', $object->fk_user);
 
 				$soldeActuel = $object->getCpforUser($object->fk_user, $object->fk_type);
 				$newSolde = ($soldeActuel + $nbopenedday);
@@ -1415,7 +1415,7 @@ if ((empty($id) && empty($ref)) || $action == 'create' || $action == 'add') {
 				print $form->textwithpicto($langs->trans('NbUseDaysCP'), $htmlhelp);
 				print '</td>';
 				print '<td>';
-				print num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday);
+				print num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, '', $object->fk_user);
 				print '</td>';
 				print '</tr>';
 

--- a/htdocs/holiday/card_group.php
+++ b/htdocs/holiday/card_group.php
@@ -285,83 +285,81 @@ if (empty($reshook)) {
 					$TusersToProcess[$u] = $u;
 				}
 			}
-                        // Chek if there is any user with no working days
-                        foreach ($TusersToProcess as $u) {
-                            $nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday, '', $u);
-                            if ($nbopenedday < 0.5) {
-                                    setEventMessages($langs->trans("ErrorDureeCP", $u), null, 'errors'); // No working day
-                                    $error++;
-                                    $action = 'create';
-                            }
-                        }
-                        if(!$error){
-                            
-                        
-                            foreach ($TusersToProcess as $u) {
-                                    // Check if there is already holiday for this period pour chaque user
-                                    $verifCP = $object->verifDateHolidayCP($u, $date_debut, $date_fin, $halfday);
-                                    if (!$verifCP) {
-                                            //setEventMessages($langs->trans("alreadyCPexist"), null, 'errors');
+			// Check if there is any user with no working days
+			foreach ($TusersToProcess as $u) {
+				$nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday, '', $u);
+				if ($nbopenedday < 0.5) {
+					setEventMessages($langs->trans("ErrorDureeCP", $u), null, 'errors'); // No working day
+					$error++;
+					$action = 'create';
+				}
+			}
+			if (!$error) {
+				foreach ($TusersToProcess as $u) {
+					// Check if there is already holiday for this period pour chaque user
+					$verifCP = $object->verifDateHolidayCP($u, $date_debut, $date_fin, $halfday);
+					if (!$verifCP) {
+						//setEventMessages($langs->trans("alreadyCPexist"), null, 'errors');
 
-                                            $userError = new User($db);
-                                            $result = $userError->fetch($u);
+						$userError = new User($db);
+						$result = $userError->fetch($u);
 
-                                            if ($result) {
-                                                    setEventMessages($langs->trans("UseralreadyCPexist", $userError->firstname . ' '. $userError->lastname), null, 'errors');
-                                            } else {
-                                                    setEventMessages($langs->trans("ErrorUserFetch", $u), null, 'errors');
-                                            }
+						if ($result) {
+							setEventMessages($langs->trans("UseralreadyCPexist", $userError->firstname . ' '. $userError->lastname), null, 'errors');
+						} else {
+							setEventMessages($langs->trans("ErrorUserFetch", $u), null, 'errors');
+						}
 
-                                            $error++;
-                                            $action = 'create';
-                                    }
-                            }
+						$error++;
+						$action = 'create';
+					}
+				}
 
-                            if (!$error) {
-                                    $db->begin();
-                                    // non errors we can insert all
-                                    foreach ($TusersToProcess as $u) {
-                                            $object = new Holiday($db);
-                                            $object->fk_user = $u;
-                                            $object->description = $description;
-                                            $object->fk_validator = $approverid;
-                                            $object->fk_type = $type;
-                                            $object->date_debut = $date_debut;
-                                            $object->date_fin = $date_fin;
-                                            $object->halfday = $halfday;
+				if (!$error) {
+					$db->begin();
+					// non errors we can insert all
+					foreach ($TusersToProcess as $u) {
+						$object = new Holiday($db);
+						$object->fk_user = $u;
+						$object->description = $description;
+						$object->fk_validator = $approverid;
+						$object->fk_type = $type;
+						$object->date_debut = $date_debut;
+						$object->date_fin = $date_fin;
+						$object->halfday = $halfday;
 
-                                            $result = $object->create($user);
+						$result = $object->create($user);
 
-                                            if ($result <= 0) {
-                                                    setEventMessages($object->error, $object->errors, 'errors');
-                                                    $error++;
-                                            } else {
-                                                    //@TODO changer le nom si validated
-                                                    if ($autoValidation) {
-                                                            $htemp = new Holiday($db);
-                                                            $htemp->fetch($result);
+						if ($result <= 0) {
+							setEventMessages($object->error, $object->errors, 'errors');
+							$error++;
+						} else {
+							//@TODO changer le nom si validated
+							if ($autoValidation) {
+								$htemp = new Holiday($db);
+								$htemp->fetch($result);
 
-                                                            $htemp->status = Holiday::STATUS_VALIDATED;
-                                                            $resultValidated = $htemp->update($approverid);
+								$htemp->status = Holiday::STATUS_VALIDATED;
+								$resultValidated = $htemp->update($approverid);
 
-                                                            if ($resultValidated < 0) {
-                                                                    setEventMessages($object->error, $object->errors, 'errors');
-                                                                    $error++;
-                                                            }
-                                                            // we can auto send mail if we are in auto validation behavior
+								if ($resultValidated < 0) {
+									setEventMessages($object->error, $object->errors, 'errors');
+									$error++;
+								}
+								// we can auto send mail if we are in auto validation behavior
 
-                                                            if ($AutoSendMail && !$error) {
-                                                                    // send a mail to the user
-                                                                    $returnSendMail = sendMail($result, $permissiontoadd, $now, $autoValidation);
-                                                                    if (!empty($returnSendMail->msg)) {
-                                                                            setEventMessage($returnSendMail->msg, $returnSendMail->style);
-                                                                    }
-                                                            }
-                                                    }
-                                            }
-                                    }
-                            }
-                        }
+								if ($AutoSendMail && !$error) {
+									// send a mail to the user
+									$returnSendMail = sendMail($result, $permissiontoadd, $now, $autoValidation);
+									if (!empty($returnSendMail->msg)) {
+										setEventMessage($returnSendMail->msg, $returnSendMail->style);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
 			// If no SQL error we redirect to the request card
 			if (!$error) {
 				$db->commit();

--- a/htdocs/holiday/card_group.php
+++ b/htdocs/holiday/card_group.php
@@ -285,70 +285,83 @@ if (empty($reshook)) {
 					$TusersToProcess[$u] = $u;
 				}
 			}
-			foreach ($TusersToProcess as $u) {
-				// Check if there is already holiday for this period pour chaque user
-				$verifCP = $object->verifDateHolidayCP($u, $date_debut, $date_fin, $halfday);
-				if (!$verifCP) {
-					//setEventMessages($langs->trans("alreadyCPexist"), null, 'errors');
+                        // Chek if there is any user with no working days
+                        foreach ($TusersToProcess as $u) {
+                            $nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday, '', $u);
+                            if ($nbopenedday < 0.5) {
+                                    setEventMessages($langs->trans("ErrorDureeCP", $u), null, 'errors'); // No working day
+                                    $error++;
+                                    $action = 'create';
+                            }
+                        }
+                        if(!$error){
+                            
+                        
+                            foreach ($TusersToProcess as $u) {
+                                    // Check if there is already holiday for this period pour chaque user
+                                    $verifCP = $object->verifDateHolidayCP($u, $date_debut, $date_fin, $halfday);
+                                    if (!$verifCP) {
+                                            //setEventMessages($langs->trans("alreadyCPexist"), null, 'errors');
 
-					$userError = new User($db);
-					$result = $userError->fetch($u);
+                                            $userError = new User($db);
+                                            $result = $userError->fetch($u);
 
-					if ($result) {
-						setEventMessages($langs->trans("UseralreadyCPexist", $userError->firstname . ' '. $userError->lastname), null, 'errors');
-					} else {
-						setEventMessages($langs->trans("ErrorUserFetch", $u), null, 'errors');
-					}
+                                            if ($result) {
+                                                    setEventMessages($langs->trans("UseralreadyCPexist", $userError->firstname . ' '. $userError->lastname), null, 'errors');
+                                            } else {
+                                                    setEventMessages($langs->trans("ErrorUserFetch", $u), null, 'errors');
+                                            }
 
-					$error++;
-					$action = 'create';
-				}
-			}
+                                            $error++;
+                                            $action = 'create';
+                                    }
+                            }
 
-			if (!$error) {
-				$db->begin();
-				// non errors we can insert all
-				foreach ($TusersToProcess as $u) {
-					$object = new Holiday($db);
-					$object->fk_user = $u;
-					$object->description = $description;
-					$object->fk_validator = $approverid;
-					$object->fk_type = $type;
-					$object->date_debut = $date_debut;
-					$object->date_fin = $date_fin;
-					$object->halfday = $halfday;
+                            if (!$error) {
+                                    $db->begin();
+                                    // non errors we can insert all
+                                    foreach ($TusersToProcess as $u) {
+                                            $object = new Holiday($db);
+                                            $object->fk_user = $u;
+                                            $object->description = $description;
+                                            $object->fk_validator = $approverid;
+                                            $object->fk_type = $type;
+                                            $object->date_debut = $date_debut;
+                                            $object->date_fin = $date_fin;
+                                            $object->halfday = $halfday;
 
-					$result = $object->create($user);
+                                            $result = $object->create($user);
 
-					if ($result <= 0) {
-						setEventMessages($object->error, $object->errors, 'errors');
-						$error++;
-					} else {
-						//@TODO changer le nom si validated
-						if ($autoValidation) {
-							$htemp = new Holiday($db);
-							$htemp->fetch($result);
+                                            if ($result <= 0) {
+                                                    setEventMessages($object->error, $object->errors, 'errors');
+                                                    $error++;
+                                            } else {
+                                                    //@TODO changer le nom si validated
+                                                    if ($autoValidation) {
+                                                            $htemp = new Holiday($db);
+                                                            $htemp->fetch($result);
 
-							$htemp->status = Holiday::STATUS_VALIDATED;
-							$resultValidated = $htemp->update($approverid);
+                                                            $htemp->status = Holiday::STATUS_VALIDATED;
+                                                            $resultValidated = $htemp->update($approverid);
 
-							if ($resultValidated < 0) {
-								setEventMessages($object->error, $object->errors, 'errors');
-								$error++;
-							}
-							// we can auto send mail if we are in auto validation behavior
+                                                            if ($resultValidated < 0) {
+                                                                    setEventMessages($object->error, $object->errors, 'errors');
+                                                                    $error++;
+                                                            }
+                                                            // we can auto send mail if we are in auto validation behavior
 
-							if ($AutoSendMail && !$error) {
-								// send a mail to the user
-								$returnSendMail = sendMail($result, $permissiontoadd, $now, $autoValidation);
-								if (!empty($returnSendMail->msg)) {
-									setEventMessage($returnSendMail->msg, $returnSendMail->style);
-								}
-							}
-						}
-					}
-				}
-			}
+                                                            if ($AutoSendMail && !$error) {
+                                                                    // send a mail to the user
+                                                                    $returnSendMail = sendMail($result, $permissiontoadd, $now, $autoValidation);
+                                                                    if (!empty($returnSendMail->msg)) {
+                                                                            setEventMessage($returnSendMail->msg, $returnSendMail->style);
+                                                                    }
+                                                            }
+                                                    }
+                                            }
+                                    }
+                            }
+                        }
 			// If no SQL error we redirect to the request card
 			if (!$error) {
 				$db->commit();
@@ -758,7 +771,7 @@ function sendMail($id, $cancreate, $now, $autoValidation)
 
 				// option to notify the validator if the balance is less than the request
 				if (!getDolGlobalString('HOLIDAY_HIDE_APPROVER_ABOUT_NEGATIVE_BALANCE')) {
-					$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday);
+					$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, '', $object->fk_validator);
 
 					if ($nbopenedday > $object->getCPforUser($object->fk_user, $object->fk_type)) {
 						$message .= "<p>".$langs->transnoentities("HolidaysToValidateAlertSolde")."</p>\n";

--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -1759,7 +1759,7 @@ class Holiday extends CommonObject
 							$endDate = $endOfMonth;
 						}
 
-						$nbDaysToDeduct = (int) num_open_day($startDate, $endDate, 0, 1, $obj['halfday']);
+						$nbDaysToDeduct = (int) num_open_day($startDate, $endDate, 0, 1, $obj['halfday'], '', $obj['fk_user']);
 
 						if ($nbDaysToDeduct <= 0) {
 							continue;

--- a/htdocs/holiday/document.php
+++ b/htdocs/holiday/document.php
@@ -228,7 +228,7 @@ if ($object->id) {
 	}
 	print $form->textwithpicto($langs->trans('NbUseDaysCP'), $htmlhelp);
 	print '</td>';
-	print '<td>'.num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday).'</td>';
+	print '<td>'.num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, '', $object->fk_user).'</td>';
 	print '</tr>';
 
 	if ($object->status == Holiday::STATUS_REFUSED) {

--- a/htdocs/holiday/list.php
+++ b/htdocs/holiday/list.php
@@ -875,7 +875,7 @@ if ($id && !$user->hasRight('holiday', 'readall') && !in_array($id, $childids)) 
 		$starthalfday = ($obj->halfday == -1 || $obj->halfday == 2) ? 'afternoon' : 'morning';
 		$endhalfday = ($obj->halfday == 1 || $obj->halfday == 2) ? 'morning' : 'afternoon';
 
-		$nbopenedday = num_open_day($db->jdate($obj->date_debut, 1), $db->jdate($obj->date_fin, 1), 0, 1, $obj->halfday);	// user jdate(..., 1) because num_open_day need UTC dates
+		$nbopenedday = num_open_day($db->jdate($obj->date_debut, 1), $db->jdate($obj->date_fin, 1), 0, 1, $obj->halfday, '', $obj->fk_user);	// user jdate(..., 1) because num_open_day need UTC dates
 		$totalduration += $nbopenedday;
 
 		if ($mode == 'kanban') {

--- a/htdocs/holiday/month_report.php
+++ b/htdocs/holiday/month_report.php
@@ -459,7 +459,7 @@ if ($num == 0) {
 		}
 
 		if (!empty($arrayfields['used_days']['checked'])) {
-			print '<td class="right">'.num_open_day($date_start, $date_end, 0, 1, $obj->halfday).'</td>';
+			print '<td class="right">'.num_open_day($date_start, $date_end, 0, 1, $obj->halfday, '', $obj->fk_user).'</td>';
 		}
 
 		if (!empty($arrayfields['date_start_month']['checked'])) {
@@ -475,7 +475,7 @@ if ($num == 0) {
 		}
 
 		if (!empty($arrayfields['used_days_month']['checked'])) {
-			print '<td class="right">'.num_open_day($date_start_inmonth, $date_end_inmonth, 0, 1, $halfdayinmonth).'</td>';
+			print '<td class="right">'.num_open_day($date_start_inmonth, $date_end_inmonth, 0, 1, $halfdayinmonth, '', $obj->fk_user).'</td>';
 		}
 		if (!empty($arrayfields['cp.description']['checked'])) {
 			print '<td class="maxwidth300 small">';

--- a/htdocs/projet/activity/permonth.php
+++ b/htdocs/projet/activity/permonth.php
@@ -773,7 +773,7 @@ if (count($tasksarray) > 0) {
 			$startweekholiday = (int) (($h["date_debut"] <= $weekstart) ? $weekstart : $h["date_debut"]);
 			$endweekholiday = (int) (($h["date_fin"] >= $weekend) ? $weekend : $h["date_fin"]);
 			$halfdays = (int) $h["halfday"];
-			$nbdays = num_open_day($startweekholiday, $endweekholiday, 0, 1, $halfdays);
+			$nbdays = num_open_day($startweekholiday, $endweekholiday, 0, 1, $halfdays, $h["fk_user"]);
 
 			$THolidays[$weekNb]["ids"][] = $h->rowid;
 			$THolidays[$weekNb]["days"] += $nbdays;

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -764,7 +764,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 				$holiday->statut = $objp->status;
 				$holiday->status = $objp->status;
 
-				$nbopenedday = num_open_day($db->jdate($objp->date_debut, 'gmt'), $db->jdate($objp->date_fin, 'gmt'), 0, 1, $objp->halfday);
+				$nbopenedday = num_open_day($db->jdate($objp->date_debut, 'gmt'), $db->jdate($objp->date_fin, 'gmt'), 0, 1, $objp->halfday, '', $object->id);
 
 				print '<tr class="oddeven">';
 				print '<td class="nowraponall">';


### PR DESCRIPTION
# QUAL|Qual Extended num_open_day() function to support user-specific calculations

Extended the `num_open_day()` function to accept an optional `$fk_user` parameter, enabling user-specific open day calculation logic based on individual user calendars and country codes.

## Changes made:
- Modified `num_open_day()` function signature to accept `$fk_user` parameter
- Updated `actions_massactions.inc.php` to propagate user ID when approving leave requests
- Improved leave balance computation accuracy for users with distinct calendars or country configurations

## Benefits:
- More accurate leave balance calculations for multi-user environments
- Better support for organizations with users in different countries or with custom calendars
- Maintains backward compatibility with existing code that doesn't specify a user

This enhancement improves the precision of holiday/leave management calculations, particularly important for organizations with diverse user configurations.