### PR TITLE
FIX: access problem when label is used with next/prev

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2254,7 +2254,7 @@ abstract class CommonObject
 	public function getLineIdByLabel($label)
 	{
 		$sql = "SELECT rowid FROM ".$this->db->prefix().$this->table_element;
-		$sql .= " WHERE label = '" . $label . "'";
+		$sql .= " WHERE label = '" . $this->db->escape($label) . "'";
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$row = $this->db->fetch_row($resql);

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2251,9 +2251,9 @@ abstract class CommonObject
 	 * @param string $label The label of the element.
 	 * @return int Returns an integer: 0 if KO, > 0 if OK.
 	 */
-	public function getLineIdByLabel($label)
+	public function getCategorieLineIdByLabel($label)
 	{
-		$sql = "SELECT rowid FROM ".$this->db->prefix().$this->table_element;
+		$sql = "SELECT rowid FROM ".$this->db->prefix()."categorie";
 		$sql .= " WHERE label = '" . $this->db->escape($label) . "'";
 		$resql = $this->db->query($sql);
 		if ($resql) {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -2246,6 +2246,25 @@ abstract class CommonObject
 	}
 
 	/**
+	 * Retrieve the rowid of an element based on its label.
+	 *
+	 * @param string $label The label of the element.
+	 * @return int Returns an integer: 0 if KO, > 0 if OK.
+	 */
+	public function getLineIdByLabel($label)
+	{
+		$sql = "SELECT rowid FROM ".$this->db->prefix().$this->table_element;
+		$sql .= " WHERE label = '" . $label . "'";
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			$row = $this->db->fetch_row($resql);
+			return (!empty($row[0]) ? $row[0] : 0);
+		}
+
+		return 0;
+	}
+
+	/**
 	 *	Setter generic. Update a specific field into database.
 	 *  Warning: Trigger is run only if param trigkey is provided.
 	 *

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -10755,8 +10755,8 @@ class Form
 		if ($shownav) {
 			//print "paramid=$paramid,morehtml=$morehtml,shownav=$shownav,$fieldid,$fieldref,$morehtmlref,$moreparam";
 			$object->load_previous_next_ref((isset($object->next_prev_filter) ? $object->next_prev_filter : ''), $fieldid, $nodbprefix);
-			$id_preview = isset($object->ref_previous) && $object->getLineIdByLabel($object->ref_previous) ? "id=".$object->getLineIdByLabel($object->ref_previous) : "";
-			$id_next = isset($object->ref_next) &&  $object->getLineIdByLabel($object->ref_next) ? "id=".$object->getLineIdByLabel($object->ref_next) : "";
+			$id_preview = isset($object->ref_previous) && $object->getCategorieLineIdByLabel($object->ref_previous) ? "id=".$object->getCategorieLineIdByLabel($object->ref_previous) : "";
+			$id_next = isset($object->ref_next) &&  $object->getCategorieLineIdByLabel($object->ref_next) ? "id=".$object->getCategorieLineIdByLabel($object->ref_next) : "";
 
 			$navurl = $_SERVER["PHP_SELF"];
 			// Special case for project/task page

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -10755,6 +10755,8 @@ class Form
 		if ($shownav) {
 			//print "paramid=$paramid,morehtml=$morehtml,shownav=$shownav,$fieldid,$fieldref,$morehtmlref,$moreparam";
 			$object->load_previous_next_ref((isset($object->next_prev_filter) ? $object->next_prev_filter : ''), $fieldid, $nodbprefix);
+			$id_preview = isset($object->ref_previous) && $object->getLineIdByLabel($object->ref_previous) ? "id=".$object->getLineIdByLabel($object->ref_previous) : "";
+			$id_next = isset($object->ref_next) &&  $object->getLineIdByLabel($object->ref_next) ? "id=".$object->getLineIdByLabel($object->ref_next) : "";
 
 			$navurl = $_SERVER["PHP_SELF"];
 			// Special case for project/task page
@@ -10776,8 +10778,8 @@ class Form
 				$stringforfirstkey .= ' CTL +';
 			}
 
-			$previous_ref = $object->ref_previous ? '<a accesskey="p" alt="'.dol_escape_htmltag($langs->trans("Previous")).'" title="' . $stringforfirstkey . ' p" class="classfortooltip reposition" href="' . $navurl . '?' . $paramid . '=' . urlencode($object->ref_previous) . $moreparam . '"><i class="fa fa-chevron-left"></i></a>' : '<span class="inactive"><i class="fa fa-chevron-left opacitymedium"></i></span>';
-			$next_ref = $object->ref_next ? '<a accesskey="n" alt="'.dol_escape_htmltag($langs->trans("Next")).'" title="' . $stringforfirstkey . ' n" class="classfortooltip reposition" href="' . $navurl . '?' . $paramid . '=' . urlencode($object->ref_next) . $moreparam . '"><i class="fa fa-chevron-right"></i></a>' : '<span class="inactive"><i class="fa fa-chevron-right opacitymedium"></i></span>';
+			$previous_ref = $object->ref_previous ? '<a accesskey="p" alt="'.dol_escape_htmltag($langs->trans("Previous")).'" title="' . $stringforfirstkey . ' p" class="classfortooltip reposition" href="' . $navurl . '?' . $id_preview . '&' . $paramid . '=' . urlencode($object->ref_previous) . $moreparam . '"><i class="fa fa-chevron-left"></i></a>' : '<span class="inactive"><i class="fa fa-chevron-left opacitymedium"></i></span>';
+			$next_ref = $object->ref_next ? '<a accesskey="n" alt="'.dol_escape_htmltag($langs->trans("Next")).'" title="' . $stringforfirstkey . ' n" class="classfortooltip reposition" href="' . $navurl . '?' . $id_next . '&' . $paramid . '=' . urlencode($object->ref_next) . $moreparam . '"><i class="fa fa-chevron-right"></i></a>' : '<span class="inactive"><i class="fa fa-chevron-right opacitymedium"></i></span>';
 		}
 
 		//print "xx".$previous_ref."x".$next_ref;


### PR DESCRIPTION
In the following line, restrictedArea is called with the $id parameter:

[dolibarr/htdocs/categories/viewcat.php](https://github.com/Dolibarr/dolibarr/blob/8c94c2f98cbb881914923b28db57a35cf20926e3/htdocs/categories/viewcat.php#L73)

Line 73

 $result = restrictedArea($user, 'categorie', $id, '&category'); 

But as you can see [here](https://github.com/Dolibarr/dolibarr/blob/8c94c2f98cbb881914923b28db57a35cf20926e3/htdocs/categories/viewcat.php#L67), sometimes we don't get $id but $label instead (for example from the [previous/next links](https://github.com/Dolibarr/dolibarr/blob/8c94c2f98cbb881914923b28db57a35cf20926e3/htdocs/categories/viewcat.php#L266))

Here is the link to the issue: https://github.com/Dolibarr/dolibarr/issues/20240