### PR TITLE
FIX: warning on invoice list when no extrafield

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -220,7 +220,7 @@ $extrafields = new ExtraFields($db);
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
 
-$search_array_options = $extrafields->getOptionalsFromPost($object->table_element, '', 'search_');
+$search_array_options = $extrafields->getOptionalsFromPost($object->table_element, '', 'search_') ?: [];
 
 // List of fields to search into when doing a "search in all"
 $fieldstosearchall = array(


### PR DESCRIPTION
Quick fix to  avoid the warning due to L800 foreach if there is no invoice extrafields.

The best fix would be to correct the return value of Extrafields::getOptionalsFromPost() so that the method no longer returns 0 but an empty array, but I don't know if this could cause problems elsewhere in the Dolibarr code.