### PR TITLE
FIX - Display warnings invoice situation

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -118,7 +118,7 @@ if (getDolGlobalString('MAIN_MOTD')) {
  */
 
 // Specific warning to propose to upgrade invoice situation to progressive mode
-if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1 && (float) DOL_VERSION >= 22.0) {
 	$langs->loadLangs(array("admin"));
 	print info_admin($langs->trans("WarningExperimentalFeatureInvoiceSituationNeedToUpgradeToProgressiveMode", 'https://partners.dolibarr.org'));
 	//print "<br>";


### PR DESCRIPTION
# FIX - *Added condition warnings message *
Added condition on Dolibarr version for displaying an experimental warning message on invoices situations.
In versions prior to version 22, we do not need to see this message displayed because everything works fine with INVOICE_USE_SITUATION = 1. Starting with v22, this is where problems arise and it is necessary to set INVOICE_USE_SITUATION = 2 and execute 
