### PR TITLE
Fix: Propagate errors when closing linked shipments

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -211,6 +211,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 					if (price2num($totalonlinkedelements, 'MT') == price2num($object->total_ht, 'MT')) {
 						foreach ($object->linkedObjects['shipping'] as $element) {
 							$ret = $element->setClosed();
+							$this->errors = $element->errors;
 							if ($ret < 0) {
 								return (int) $ret;
 							}


### PR DESCRIPTION
# FIX|Fix # add error to object 
Previously, the function correctly returned the error code, but $this->errors (the error array of the main object, e.g., the invoice) was not updated. The end-user would see a generic failure message without knowing why closing the shipment failed (e.g., "Invalid status," "Stock not sufficient," etc.).



