### PR TITLE
New Hooks propals/orders

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -910,7 +910,6 @@ if ($object->id > 0) {
 
 		$resql = $db->query($sql);
 		if ($resql) {
-
 			$num = $db->num_rows($resql);
 			if ($num > 0) {
 				print '<div class="div-table-responsive-no-min">';
@@ -1018,7 +1017,6 @@ if ($object->id > 0) {
 
 		$resql = $db->query($sql);
 		if ($resql) {
-
 			$num = $db->num_rows($resql);
 			if ($num > 0) {
 				// Check if there are orders billable

--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -891,6 +891,7 @@ if ($object->id > 0) {
 	 * Latest proposals
 	 */
 	if (isModEnabled("propal") && $user->hasRight('propal', 'lire')) {
+		$propal_static = new Propal($db);
 		$langs->load("propal");
 
 		$sql = "SELECT s.nom, s.rowid, p.rowid as propalid, p.fk_projet, p.fk_statut, p.total_ht";
@@ -902,11 +903,14 @@ if ($object->id > 0) {
 		$sql .= " WHERE p.fk_soc = s.rowid AND p.fk_statut = c.id";
 		$sql .= " AND s.rowid = ".((int) $object->id);
 		$sql .= " AND p.entity IN (".getEntity('propal').")";
+		$parameters = array();
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $propal_static); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$sql .= " ORDER BY p.datep DESC";
 
 		$resql = $db->query($sql);
 		if ($resql) {
-			$propal_static = new Propal($db);
+
 
 			$num = $db->num_rows($resql);
 			if ($num > 0) {
@@ -996,6 +1000,7 @@ if ($object->id > 0) {
 	 * Latest orders
 	 */
 	if (isModEnabled('order') && $user->hasRight('commande', 'lire')) {
+		$commande_static = new Commande($db);
 		$sql = "SELECT s.nom, s.rowid";
 		$sql .= ", c.rowid as cid, c.entity, c.fk_projet, c.total_ht";
 		$sql .= ", c.total_tva";
@@ -1007,11 +1012,14 @@ if ($object->id > 0) {
 		$sql .= " WHERE c.fk_soc = s.rowid ";
 		$sql .= " AND s.rowid = ".((int) $object->id);
 		$sql .= " AND c.entity IN (".getEntity('commande').')';
+		$parameters = array();
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $commande_static); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$sql .= " ORDER BY c.date_commande DESC";
 
 		$resql = $db->query($sql);
 		if ($resql) {
-			$commande_static = new Commande($db);
+
 
 			$num = $db->num_rows($resql);
 			if ($num > 0) {

--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -911,7 +911,6 @@ if ($object->id > 0) {
 		$resql = $db->query($sql);
 		if ($resql) {
 
-
 			$num = $db->num_rows($resql);
 			if ($num > 0) {
 				print '<div class="div-table-responsive-no-min">';
@@ -1019,7 +1018,6 @@ if ($object->id > 0) {
 
 		$resql = $db->query($sql);
 		if ($resql) {
-
 
 			$num = $db->num_rows($resql);
 			if ($num > 0) {

--- a/htdocs/comm/index.php
+++ b/htdocs/comm/index.php
@@ -168,6 +168,10 @@ if (isModEnabled("propal") && $user->hasRight("propal", "lire") && is_object($pr
 	if ($socid) {
 		$sql .= " AND s.rowid = ".((int) $socid);
 	}
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $propalstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 
 	$resql = $db->query($sql);
 	if ($resql) {
@@ -269,7 +273,10 @@ if (isModEnabled('supplier_proposal') && $user->hasRight("supplier_proposal", "l
 	if ($socid) {
 		$sql .= " AND s.rowid = ".((int) $socid);
 	}
-
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $supplierproposalstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$resql = $db->query($sql);
 	if ($resql) {
 		$total = 0;
@@ -367,7 +374,10 @@ if (isModEnabled('order') && $user->hasRight('commande', 'lire') && is_object($o
 	if ($socid) {
 		$sql .= " AND c.fk_soc = ".((int) $socid);
 	}
-
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $orderstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$resql = $db->query($sql);
 	if ($resql) {
 		$total = 0;
@@ -469,7 +479,10 @@ if ((isModEnabled("fournisseur") && !getDolGlobalString('MAIN_USE_NEW_SUPPLIERMO
 	if ($socid) {
 		$sql .= " AND cf.fk_soc = ".((int) $socid);
 	}
-
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $supplierorderstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$resql = $db->query($sql);
 	if ($resql) {
 		$total = 0;
@@ -569,7 +582,10 @@ if (isModEnabled('intervention') && is_object($fichinterstatic)) {
 		$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 	}
 
-
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $fichinterstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$resql = $db->query($sql);
 	if ($resql) {
 		$num = $db->num_rows($resql);
@@ -742,12 +758,12 @@ if (isModEnabled("societe") && $user->hasRight('societe', 'lire')) {
  */
 
 if (isModEnabled('propal') && is_object($propalstatic)) {
-	$sql = "SELECT c.rowid, c.entity, c.ref, c.fk_statut as status, c.tms as datem,";
+	$sql = "SELECT p.rowid, p.entity, p.ref, p.fk_statut as status, p.tms as datem,";
 	$sql .= " s.nom as socname, s.rowid as socid, s.canvas, s.client, s.email, s.code_compta as code_compta_client";
-	$sql .= " FROM ".MAIN_DB_PREFIX."propal as c,";
+	$sql .= " FROM ".MAIN_DB_PREFIX."propal as p,";
 	$sql .= " ".MAIN_DB_PREFIX."societe as s";
-	$sql .= " WHERE c.entity IN (".getEntity($propalstatic->element).")";
-	$sql .= " AND c.fk_soc = s.rowid";
+	$sql .= " WHERE p.entity IN (".getEntity($propalstatic->element).")";
+	$sql .= " AND p.fk_soc = s.rowid";
 	// If the internal user must only see his customers, force searching by him
 	$search_sale = 0;
 	if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
@@ -756,16 +772,20 @@ if (isModEnabled('propal') && is_object($propalstatic)) {
 	// Search on sale representative
 	if ($search_sale && $search_sale != '-1') {
 		if ($search_sale == -2) {
-			$sql .= " AND NOT EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = c.fk_soc)";
+			$sql .= " AND NOT EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = p.fk_soc)";
 		} elseif ($search_sale > 0) {
-			$sql .= " AND EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = c.fk_soc AND sc.fk_user = ".((int) $search_sale).")";
+			$sql .= " AND EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = p.fk_soc AND sc.fk_user = ".((int) $search_sale).")";
 		}
 	}
 	// Search on socid
 	if ($socid) {
-		$sql .= " AND c.fk_soc = ".((int) $socid);
+		$sql .= " AND p.fk_soc = ".((int) $socid);
 	}
-	$sql .= " ORDER BY c.tms DESC";
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $propalstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
+	$sql .= " ORDER BY p.tms DESC";
 
 	$sql .= $db->plimit($max, 0);
 
@@ -857,6 +877,10 @@ if (isModEnabled('order')) {
 	if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
 		$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 	}
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $orderstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= " ORDER BY c.tms DESC";
 	$sql .= $db->plimit($max, 0);
 
@@ -1061,6 +1085,10 @@ if (isModEnabled('contract') && $user->hasRight("contrat", "lire") && 0) { // TO
 	if ($socid) {
 		$sql .= " AND s.rowid = ".((int) $socid);
 	}
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $staticcontrat); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= " ORDER BY c.tms DESC";
 	$sql .= $db->plimit($max + 1, 0);
 
@@ -1137,6 +1165,10 @@ if (isModEnabled("propal") && $user->hasRight("propal", "lire")) {
 	if ($socid) {
 		$sql .= " AND s.rowid = ".((int) $socid);
 	}
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $propalstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= " ORDER BY p.rowid DESC";
 
 	$resql = $db->query($sql);
@@ -1258,6 +1290,10 @@ if (isModEnabled('order') && $user->hasRight('commande', 'lire') && is_object($o
 	if ($socid) {
 		$sql .= " AND s.rowid = ".((int) $socid);
 	}
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $orderstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= " ORDER BY c.rowid DESC";
 
 	$resql = $db->query($sql);

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -187,6 +187,8 @@ class Proposals extends DolibarrApi
 	 */
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false, $loadlinkedobjects = 0)
 	{
+		global $hookmanager;
+		$hookmanager->initHooks(array('propalapi'));
 		if (!DolibarrApiAccess::$user->hasRight('propal', 'lire')) {
 			throw new RestException(403);
 		}
@@ -201,7 +203,16 @@ class Proposals extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir') && !$socids) {
 			$search_sale = DolibarrApiAccess::$user->id;
 		}
-
+		/**
+		 * TODO A VIRER CEST POUR TEST
+		 */
+		global $conf, $db, $mc;
+		$conf->entity = 2;
+		$conf->setValues($db);
+		$mc->setValues($conf);
+		/**
+		 * FIN
+		 */
 		$sql = "SELECT t.rowid";
 		$sql .= " FROM ".MAIN_DB_PREFIX."propal AS t";
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."societe AS s ON (s.rowid = t.fk_soc)";
@@ -218,6 +229,9 @@ class Proposals extends DolibarrApi
 				$sql .= " AND EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = t.fk_soc AND sc.fk_user = ".((int) $search_sale).")";
 			}
 		}
+		$parameters = array();
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $this->propal); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		// Add sql filters
 		if ($sqlfilters) {
 			$errormessage = '';

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -203,16 +203,6 @@ class Proposals extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir') && !$socids) {
 			$search_sale = DolibarrApiAccess::$user->id;
 		}
-		/**
-		 * TODO A VIRER CEST POUR TEST
-		 */
-		global $conf, $db, $mc;
-		$conf->entity = 2;
-		$conf->setValues($db);
-		$mc->setValues($conf);
-		/**
-		 * FIN
-		 */
 		$sql = "SELECT t.rowid";
 		$sql .= " FROM ".MAIN_DB_PREFIX."propal AS t";
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."societe AS s ON (s.rowid = t.fk_soc)";

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -188,7 +188,7 @@ class Proposals extends DolibarrApi
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $properties = '', $pagination_data = false, $loadlinkedobjects = 0)
 	{
 		global $hookmanager;
-		$hookmanager->initHooks(array('propalapi'));
+
 		if (!DolibarrApiAccess::$user->hasRight('propal', 'lire')) {
 			throw new RestException(403);
 		}

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -3500,7 +3500,7 @@ class Propal extends CommonObject
 	public function load_board($user, $mode)
 	{
 		// phpcs:enable
-		global $conf, $langs;
+		global $conf, $langs, $hookmanager;
 
 		$clause = " WHERE";
 
@@ -3529,6 +3529,10 @@ class Propal extends CommonObject
 		if ($user->socid) {
 			$sql .= " AND p.fk_soc = ".((int) $user->socid);
 		}
+		// Add where from hooks
+		$parameters = array('socid' => $user->socid);
+		$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 
 		$resql = $this->db->query($sql);
 		if ($resql) {

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -3691,7 +3691,7 @@ class Propal extends CommonObject
 	 */
 	public function loadStateBoard()
 	{
-		global $user;
+		global $user, $hookmanager;
 
 		$this->nb = array();
 		$clause = "WHERE";
@@ -3715,6 +3715,10 @@ class Propal extends CommonObject
 			}
 		}
 
+		// Add where from hooks
+		$parameters = array();
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			// This assignment in condition is not a bug. It allows walking the results.

--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -85,6 +85,7 @@ class PropaleStats extends Stats
 	 */
 	public function __construct($db, $socid = 0, $userid = 0, $mode = 'customer', $typentid = 0, $categid = 0)
 	{
+		global $hookmanager;
 		$this->db = $db;
 		$this->socid = ($socid > 0 ? $socid : 0);
 		$this->userid = $userid;
@@ -129,6 +130,10 @@ class PropaleStats extends Stats
 		if ($categid) {
 			$this->where .= ' AND EXISTS (SELECT rowid FROM '.MAIN_DB_PREFIX.'categorie_societe as cats WHERE cats.fk_soc = p.fk_soc AND cats.fk_categorie = '.((int) $categid).')';
 		}
+		// Add where from hooks
+		$parameters = array('socid' => $socid);
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $object); // Note that $action and $object may have been modified by hook
+		$this->where .= $hookmanager->resPrint;
 	}
 
 
@@ -153,7 +158,6 @@ class PropaleStats extends Stats
 		$sql .= " AND ".$this->where;
 		$sql .= " GROUP BY dm";
 		$sql .= $this->db->order('dm', 'DESC');
-
 		$res = $this->_getNbByMonth($year, $sql, $format);
 		return $res;
 	}

--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -90,7 +90,7 @@ class PropaleStats extends Stats
 		$this->socid = ($socid > 0 ? $socid : 0);
 		$this->userid = $userid;
 		$this->join = '';
-
+		$object = null;
 		if ($mode == 'customer') {
 			$object = new Propal($this->db);
 

--- a/htdocs/comm/propal/index.php
+++ b/htdocs/comm/propal/index.php
@@ -111,7 +111,10 @@ if (isModEnabled("propal")) {
 	if ($socid) {
 		$sql .= " AND p.fk_soc = ".((int) $socid);
 	}
-
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $propalstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$resql = $db->query($sql);
 	if ($resql) {
 		$num = $db->num_rows($resql);
@@ -171,12 +174,12 @@ print '<div class="fichetwothirdright">';
  * Last modified proposals
  */
 
-$sql = "SELECT c.rowid, c.entity, c.ref, c.total_ht, c.total_tva, c.total_ttc, c.fk_statut as status, date_cloture as datec, c.tms as datem,";
+$sql = "SELECT p.rowid, p.entity, p.ref, p.total_ht, p.total_tva, p.total_ttc, p.fk_statut as status, date_cloture as datec, p.tms as datem,";
 $sql .= " s.nom as socname, s.rowid as socid, s.canvas, s.client, s.email, s.code_compta as code_compta_client";
-$sql .= " FROM ".MAIN_DB_PREFIX."propal as c,";
+$sql .= " FROM ".MAIN_DB_PREFIX."propal as p,";
 $sql .= " ".MAIN_DB_PREFIX."societe as s";
-$sql .= " WHERE c.entity IN (".getEntity($propalstatic->element).")";
-$sql .= " AND c.fk_soc = s.rowid";
+$sql .= " WHERE p.entity IN (".getEntity($propalstatic->element).")";
+$sql .= " AND p.fk_soc = s.rowid";
 // If the internal user must only see his customers, force searching by him
 $search_sale = 0;
 if (!$user->hasRight('societe', 'client', 'voir')) {
@@ -185,16 +188,20 @@ if (!$user->hasRight('societe', 'client', 'voir')) {
 // Search on sale representative
 if ($search_sale && $search_sale != '-1') {
 	if ($search_sale == -2) {
-		$sql .= " AND NOT EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = c.fk_soc)";
+		$sql .= " AND NOT EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = p.fk_soc)";
 	} elseif ($search_sale > 0) {
-		$sql .= " AND EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = c.fk_soc AND sc.fk_user = ".((int) $search_sale).")";
+		$sql .= " AND EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = p.fk_soc AND sc.fk_user = ".((int) $search_sale).")";
 	}
 }
 // Search on socid
 if ($socid) {
-	$sql .= " AND c.fk_soc = ".((int) $socid);
+	$sql .= " AND p.fk_soc = ".((int) $socid);
 }
-$sql .= " ORDER BY c.tms DESC";
+// Add where from hooks
+$parameters = array('socid' => $user->socid);
+$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $propalstatic); // Note that $action and $object may have been modified by hook
+$sql .= $hookmanager->resPrint;
+$sql .= " ORDER BY p.tms DESC";
 
 $sql .= $db->plimit($max, 0);
 
@@ -289,6 +296,10 @@ if (isModEnabled("propal") && $user->hasRight('propal', 'lire')) {
 	if ($socid) {
 		$sql .= " AND p.fk_soc = ".((int) $socid);
 	}
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $propalstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= " ORDER BY p.rowid DESC";
 
 	$resql = $db->query($sql);

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -179,6 +179,8 @@ class Orders extends DolibarrApi
 	 */
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $sqlfilterlines = '', $properties = '', $pagination_data = false, $loadlinkedobjects = 0)
 	{
+		global $hookmanager;
+		$hookmanager->initHooks(array('orderapi'));
 		if (!DolibarrApiAccess::$user->hasRight('commande', 'lire')) {
 			throw new RestException(403);
 		}
@@ -210,6 +212,9 @@ class Orders extends DolibarrApi
 				$sql .= " AND EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = t.fk_soc AND sc.fk_user = ".((int) $search_sale).")";
 			}
 		}
+		$parameters = array();
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $this->commande); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		// Add sql filters
 		if ($sqlfilters) {
 			$errormessage = '';

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -180,7 +180,7 @@ class Orders extends DolibarrApi
 	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $thirdparty_ids = '', $sqlfilters = '', $sqlfilterlines = '', $properties = '', $pagination_data = false, $loadlinkedobjects = 0)
 	{
 		global $hookmanager;
-		$hookmanager->initHooks(array('orderapi'));
+
 		if (!DolibarrApiAccess::$user->hasRight('commande', 'lire')) {
 			throw new RestException(403);
 		}

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4153,21 +4153,24 @@ class Commande extends CommonOrder
 	 */
 	public function loadStateBoard()
 	{
-		global $user;
+		global $user, $hookmanager;
 
 		$this->nb = array();
 		$clause = "WHERE";
 
-		$sql = "SELECT count(co.rowid) as nb";
-		$sql .= " FROM ".MAIN_DB_PREFIX.$this->table_element." as co";
-		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON co.fk_soc = s.rowid";
+		$sql = "SELECT count(c.rowid) as nb";
+		$sql .= " FROM ".MAIN_DB_PREFIX.$this->table_element." as c";
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON c.fk_soc = s.rowid";
 		if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON s.rowid = sc.fk_soc";
 			$sql .= " WHERE sc.fk_user = ".((int) $user->id);
 			$clause = "AND";
 		}
-		$sql .= " ".$clause." co.entity IN (".getEntity('commande').")";
-
+		$sql .= " ".$clause." c.entity IN (".getEntity('commande').")";
+		// Add where from hooks
+		$parameters = array();
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			while ($obj = $this->db->fetch_object($resql)) {

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3627,7 +3627,7 @@ class Commande extends CommonOrder
 	public function load_board($user, $mode)
 	{
 		// phpcs:enable
-		global $conf, $langs;
+		global $conf, $langs, $hookmanager;
 
 		$clause = " WHERE";
 
@@ -3655,7 +3655,10 @@ class Commande extends CommonOrder
 		if ($user->socid) {
 			$sql .= " AND c.fk_soc = ".((int) $user->socid);
 		}
-
+		// Add where from hooks
+		$parameters = array('socid' => $user->socid);
+		$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$delay_warning = 0;

--- a/htdocs/commande/class/commandestats.class.php
+++ b/htdocs/commande/class/commandestats.class.php
@@ -107,6 +107,7 @@ class CommandeStats extends Stats
 		$this->userid = $userid;
 		$this->cachefilesuffix = $mode;
 		$this->join = '';
+		$object = null;
 
 		if ($mode == 'customer') {
 			$object = new Commande($this->db);

--- a/htdocs/commande/class/commandestats.class.php
+++ b/htdocs/commande/class/commandestats.class.php
@@ -100,6 +100,7 @@ class CommandeStats extends Stats
 	 */
 	public function __construct($db, $socid, $mode, $userid = 0, $typentid = 0, $categid = 0)
 	{
+		global $hookmanager;
 		$this->db = $db;
 
 		$this->socid = ($socid > 0 ? $socid : 0);
@@ -142,6 +143,10 @@ class CommandeStats extends Stats
 		if ($categid) {
 			$this->where .= ' AND EXISTS (SELECT rowid FROM '.$this->categ_link.' as cats WHERE cats.fk_soc = c.fk_soc AND cats.fk_categorie = '.((int) $categid).')';
 		}
+		// Add where from hooks
+		$parameters = array('socid' => $socid);
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $object); // Note that $action and $object may have been modified by hook
+		$this->where .= $hookmanager->resPrint;
 	}
 
 	/**

--- a/htdocs/commande/index.php
+++ b/htdocs/commande/index.php
@@ -117,7 +117,10 @@ if (isModEnabled('order')) {
 	if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
 		$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 	}
-
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $commandestatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$resql = $db->query($sql);
 	if ($resql) {
 		print '<div class="div-table-responsive-no-min">';
@@ -183,6 +186,10 @@ if ($socid) {
 if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
 	$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 }
+// Add where from hooks
+$parameters = array('socid' => $user->socid);
+$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $commandestatic); // Note that $action and $object may have been modified by hook
+$sql .= $hookmanager->resPrint;
 $sql .= " ORDER BY c.tms DESC";
 $sql .= $db->plimit($max, 0);
 
@@ -269,6 +276,10 @@ if (isModEnabled('order')) {
 	if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
 		$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 	}
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $commandestatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= " ORDER BY c.rowid DESC";
 
 	$resql = $db->query($sql);
@@ -358,6 +369,10 @@ if (isModEnabled('order')) {
 	if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
 		$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 	}
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $commandestatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= " ORDER BY c.rowid DESC";
 
 	$resql = $db->query($sql);

--- a/htdocs/commande/list_det.php
+++ b/htdocs/commande/list_det.php
@@ -659,7 +659,7 @@ include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 
 // Add where from hooks
 $parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters); // Note that $action and $object may have been modified by hook
+$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $object); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
 
 // Add HAVING from hooks

--- a/htdocs/contact/consumption.php
+++ b/htdocs/contact/consumption.php
@@ -365,6 +365,9 @@ if (!empty($sql_select)) {
 		}
 		$sql .= ")";
 	}
+	$parameters = array('type_element' => $type_element);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= $db->order($sortfield, $sortorder);
 	$resql = $db->query($sql);
 	$totalnboflines = $db->num_rows($resql);

--- a/htdocs/core/boxes/box_commandes.php
+++ b/htdocs/core/boxes/box_commandes.php
@@ -65,7 +65,7 @@ class box_commandes extends ModeleBoxes
 	 */
 	public function loadBox($max = 5)
 	{
-		global $user, $langs, $conf;
+		global $user, $langs, $conf, $hookmanager;
 		$langs->load('orders');
 
 		$this->max = $max;
@@ -108,9 +108,15 @@ class box_commandes extends ModeleBoxes
 			if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
 				$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 			}
-			if ($user->socid) {
-				$sql .= " AND s.rowid = ".((int) $user->socid);
+			// Add where from hooks
+			$parameters = array('socid' => $user->socid, 'boxcode' => $this->boxcode);
+			$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $commandestatic); // Note that $action and $object may have been modified by hook
+			if (empty($reshook)) {
+				if ($user->socid) {
+					$sql .= " AND s.rowid = " . ((int) $user->socid);
+				}
 			}
+			$sql .= $hookmanager->resPrint;
 			if (getDolGlobalString('MAIN_LASTBOX_ON_OBJECT_DATE')) {
 				$sql .= " ORDER BY c.date_commande DESC, c.ref DESC ";
 			} else {

--- a/htdocs/core/boxes/box_propales.php
+++ b/htdocs/core/boxes/box_propales.php
@@ -65,7 +65,7 @@ class box_propales extends ModeleBoxes
 	 */
 	public function loadBox($max = 5)
 	{
-		global $user, $langs, $conf;
+		global $user, $langs, $conf, $hookmanager;
 
 		$this->max = $max;
 
@@ -93,9 +93,15 @@ class box_propales extends ModeleBoxes
 			if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
 				$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 			}
-			if ($user->socid) {
-				$sql .= " AND s.rowid = ".((int) $user->socid);
+			// Add where from hooks
+			$parameters = array('socid' => $user->socid, 'boxcode' => $this->boxcode);
+			$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $propalstatic); // Note that $action and $object may have been modified by hook
+			if (empty($reshook)) {
+				if ($user->socid) {
+					$sql .= " AND s.rowid = " . ((int) $user->socid);
+				}
 			}
+			$sql .= $hookmanager->resPrint;
 			if (getDolGlobalString('MAIN_LASTBOX_ON_OBJECT_DATE')) {
 				$sql .= " ORDER BY p.datep DESC, p.ref DESC ";
 			} else {

--- a/htdocs/core/lib/order.lib.php
+++ b/htdocs/core/lib/order.lib.php
@@ -229,7 +229,7 @@ function order_admin_prepare_head()
  */
 function getCustomerOrderPieChart($socid = 0)
 {
-	global $conf, $db, $langs, $user;
+	global $conf, $db, $langs, $user, $hookmanager;
 
 	$result = '';
 
@@ -257,6 +257,10 @@ function getCustomerOrderPieChart($socid = 0)
 	if (empty($user->socid) && !$user->hasRight('societe', 'client', 'voir')) {
 		$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 	}
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $commandestatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= " GROUP BY c.fk_statut";
 
 	$resql = $db->query($sql);

--- a/htdocs/core/lib/propal.lib.php
+++ b/htdocs/core/lib/propal.lib.php
@@ -212,7 +212,7 @@ function propal_admin_prepare_head()
  */
 function getCustomerProposalPieChart($socid = 0)
 {
-	global $conf, $db, $langs, $user;
+	global $conf, $db, $langs, $user, $hookmanager;
 
 	$result = '';
 
@@ -239,6 +239,10 @@ function getCustomerProposalPieChart($socid = 0)
 		$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 	}
 	$sql .= " AND p.fk_statut IN (".$db->sanitize(implode(" ,", $listofstatus)).")";
+	// Add where from hooks
+	$parameters = array('socid' => $user->socid);
+	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $propalstatic); // Note that $action and $object may have been modified by hook
+	$sql .= $hookmanager->resPrint;
 	$sql .= " GROUP BY p.fk_statut";
 	$resql = $db->query($sql);
 	if ($resql) {

--- a/htdocs/core/modules/modCommande.class.php
+++ b/htdocs/core/modules/modCommande.class.php
@@ -48,7 +48,7 @@ class modCommande extends DolibarrModules
 	 */
 	public function __construct($db)
 	{
-		global $conf, $user;
+		global $conf, $user, $hookmanager;
 
 		$this->db = $db;
 		$this->numero = 25;
@@ -298,6 +298,9 @@ class modCommande extends DolibarrModules
 		if (!empty($user) && !$user->hasRight('societe', 'client', 'voir')) {
 			$this->export_sql_end[$r] .= ' AND sc.fk_user = '.(empty($user) ? 0 : $user->id);
 		}
+		$parameters = array();
+		$hookmanager->executeHooks('printExportWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$this->export_sql_end[$r] .= $hookmanager->resPrint;
 
 		// Imports
 		//--------

--- a/htdocs/core/modules/modPropale.class.php
+++ b/htdocs/core/modules/modPropale.class.php
@@ -44,7 +44,7 @@ class modPropale extends DolibarrModules
 	 */
 	public function __construct($db)
 	{
-		global $conf, $user;
+		global $conf, $user, $hookmanager;
 
 		$this->db = $db;
 		$this->numero = 20;
@@ -306,6 +306,9 @@ class modPropale extends DolibarrModules
 		if (!empty($user) && !$user->hasRight('societe', 'client', 'voir')) {
 			$this->export_sql_end[$r] .= ' AND sc.fk_user = '.(empty($user) ? 0 : $user->id);
 		}
+		$parameters = array();
+		$hookmanager->executeHooks('printExportWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$this->export_sql_end[$r] .= $hookmanager->resPrint;
 
 		// Imports
 		//--------

--- a/htdocs/expedition/index.php
+++ b/htdocs/expedition/index.php
@@ -231,6 +231,11 @@ if ($socid > 0) {
 if (!$user->hasRight('societe', 'client', 'voir')) {
 	$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 }
+
+$parameters = array();
+$reshook = $hookmanager->executeHooks('printFieldListWhereOpenedOrders', $parameters, $object); // Note that $action and $object may have been modified by hook
+$sql .= $hookmanager->resPrint;
+
 $sql .= " ORDER BY c.rowid ASC";
 
 $resql = $db->query($sql);

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -3507,7 +3507,10 @@ class Product extends CommonObject
 		if ($socid > 0) {
 			$sql .= " AND p.fk_soc = ".((int) $socid);
 		}
-
+		// Add where from hooks
+		$parameters = array('socid' => $socid, 'type_element' => 'propal');
+		$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$result = $this->db->query($sql);
 		if ($result) {
 			$obj = $this->db->fetch_object($result);
@@ -3616,6 +3619,7 @@ class Product extends CommonObject
 		// phpcs:enable
 		global $user, $hookmanager, $action;
 
+
 		$sql = "SELECT COUNT(DISTINCT c.fk_soc) as nb_customers, COUNT(DISTINCT c.rowid) as nb,";
 		$sql .= " COUNT(cd.rowid) as nb_rows, SUM(cd.qty) as qty";
 		$sql .= " FROM ".$this->db->prefix()."commandedet as cd";
@@ -3634,7 +3638,10 @@ class Product extends CommonObject
 		if ($filtrestatut != '') {
 			$sql .= " AND c.fk_statut IN (".$this->db->sanitize($filtrestatut).")";
 		}
-
+		// Add where from hooks
+		$parameters = array('socid' => $socid, 'type_element' => 'order');
+		$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$result = $this->db->query($sql);
 		if ($result) {
 			$obj = $this->db->fetch_object($result);
@@ -3687,7 +3694,10 @@ class Product extends CommonObject
 					$sql .= " JOIN ".$this->db->prefix()."commande as c ON el.fk_source = c.rowid";
 					$sql .= " WHERE c.fk_statut IN (".$this->db->sanitize($filtrestatut).") AND c.facture = 0 AND fd.fk_product = ".((int) $this->id);
 					$sql .= " AND EXISTS (SELECT cd.fk_product FROM ".$this->db->prefix()."commandedet as cd WHERE cd.fk_product = fd.fk_product AND cd.fk_commande = c.rowid)"; // We check that the product is in order lines
-
+					// Add where from hooks
+					$parameters = array('socid' => $socid, 'type_element' => 'order');
+					$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+					$sql .= $hookmanager->resPrint;
 					$resql = $this->db->query($sql);
 					if ($resql) {
 						while ($obj = $this->db->fetch_object($resql)) {
@@ -3720,6 +3730,10 @@ class Product extends CommonObject
 					$sql .= " AND EXISTS (SELECT cd.fk_product FROM ".$this->db->prefix()."commandedet as cd WHERE cd.fk_product = fd.fk_product AND cd.fk_commande = c.rowid)"; // We check that the product is in order lines
 
 					dol_syslog(__METHOD__.":: sql $sql", LOG_NOTICE);
+					// Add where from hooks
+					$parameters = array('socid' => $socid, 'type_element' => 'order');
+					$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+					$sql .= $hookmanager->resPrint;
 					$resql = $this->db->query($sql);
 					if ($resql) {
 						while ($obj = $this->db->fetch_object($resql)) {

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4629,7 +4629,7 @@ class Product extends CommonObject
 			$sql .= " AND p.fk_soc = ".((int) $socid);
 		}
 		$sql .= $morefilter;
-		$parameters = array('socid' => $user->socid, 'boxcode' => $this->boxcode);
+		$parameters = array('socid' => $user->socid);
 		$hookmanager->executeHooks('productGetNbPropal', $parameters, $this); // Note that $action and $object may have been modified by hook
 		$sql .= $hookmanager->resPrint;
 		$sql .= " GROUP BY date_format(p.datep,'%Y%m')";
@@ -4735,7 +4735,7 @@ class Product extends CommonObject
 			$sql .= " AND c.fk_soc = ".((int) $socid);
 		}
 		$sql .= $morefilter;
-		$parameters = array('socid' => $user->socid, 'boxcode' => $this->boxcode);
+		$parameters = array('socid' => $user->socid);
 		$hookmanager->executeHooks('productGetNbOrder', $parameters, $this); // Note that $action and $object may have been modified by hook
 		$sql .= $hookmanager->resPrint;
 		$sql .= " GROUP BY date_format(c.date_commande,'%Y%m')";

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4597,7 +4597,7 @@ class Product extends CommonObject
 	public function get_nb_propal($socid, $mode, $filteronproducttype = -1, $year = 0, $morefilter = '')
 	{
 		// phpcs:enable
-		global $user;
+		global $user, $hookmanager;
 
 		$sql = "SELECT sum(d.qty) as qty, date_format(p.datep, '%Y%m')";
 		if ($mode == 'bynumber') {
@@ -4629,9 +4629,11 @@ class Product extends CommonObject
 			$sql .= " AND p.fk_soc = ".((int) $socid);
 		}
 		$sql .= $morefilter;
+		$parameters = array('socid' => $user->socid, 'boxcode' => $this->boxcode);
+		$hookmanager->executeHooks('productGetNbPropal', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$sql .= " GROUP BY date_format(p.datep,'%Y%m')";
 		$sql .= " ORDER BY date_format(p.datep,'%Y%m') DESC";
-
 		return $this->_get_stats($sql, $mode, $year);
 	}
 
@@ -4701,7 +4703,7 @@ class Product extends CommonObject
 	public function get_nb_order($socid, $mode, $filteronproducttype = -1, $year = 0, $morefilter = '')
 	{
 		// phpcs:enable
-		global $user;
+		global $user, $hookmanager;
 
 		$sql = "SELECT sum(d.qty) as qty, date_format(c.date_commande, '%Y%m')";
 		if ($mode == 'bynumber') {
@@ -4733,6 +4735,9 @@ class Product extends CommonObject
 			$sql .= " AND c.fk_soc = ".((int) $socid);
 		}
 		$sql .= $morefilter;
+		$parameters = array('socid' => $user->socid, 'boxcode' => $this->boxcode);
+		$hookmanager->executeHooks('productGetNbOrder', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$sql .= " GROUP BY date_format(c.date_commande,'%Y%m')";
 		$sql .= " ORDER BY date_format(c.date_commande,'%Y%m') DESC";
 

--- a/htdocs/product/stats/commande.php
+++ b/htdocs/product/stats/commande.php
@@ -189,6 +189,10 @@ if ($id > 0 || !empty($ref)) {
 				$sql .= " AND c.fk_statut IN (".$db->sanitize($search_status).")";
 			}
 
+			// Add where from hooks
+			$parameters = array('socid' => $socid, 'type_element' => 'order');
+			$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $object); // Note that $action and $object may have been modified by hook
+			$sql .= $hookmanager->resPrint;
 			$sql .= $db->order($sortfield, $sortorder);
 
 			//Calcul total qty and amount for global if full scan list

--- a/htdocs/product/stats/propal.php
+++ b/htdocs/product/stats/propal.php
@@ -179,6 +179,10 @@ if ($id > 0 || !empty($ref)) {
 			if ($socid) {
 				$sql .= " AND p.fk_soc = ".((int) $socid);
 			}
+			// Add where from hooks
+			$parameters = array('socid' => $socid, 'type_element' => 'propal');
+			$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $object); // Note that $action and $object may have been modified by hook
+			$sql .= $hookmanager->resPrint;
 			$sql .= $db->order($sortfield, $sortorder);
 
 			// Calcul total qty and amount for global if full scan list

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -5164,6 +5164,7 @@ class Societe extends CommonObject
 	 */
 	public function getOutstandingProposals($mode = 'customer')
 	{
+		global $hookmanager;
 		$table = 'propal';
 		if ($mode == 'supplier') {
 			$table = 'supplier_proposal';
@@ -5178,6 +5179,11 @@ class Societe extends CommonObject
 		}
 
 		dol_syslog("getOutstandingProposals for fk_soc = ".((int) $this->id), LOG_DEBUG);
+
+		// Add where from hooks
+		$parameters = array('mode' => $mode, 'table' => $table);
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 
 		$resql = $this->db->query($sql);
 		if ($resql) {
@@ -5208,6 +5214,7 @@ class Societe extends CommonObject
 	 */
 	public function getOutstandingOrders($mode = 'customer')
 	{
+		global $hookmanager;
 		$table = 'commande';
 		if ($mode == 'supplier') {
 			$table = 'commande_fournisseur';
@@ -5222,6 +5229,10 @@ class Societe extends CommonObject
 		}
 
 		dol_syslog("getOutstandingOrders", LOG_DEBUG);
+		// Add where from hooks
+		$parameters = array('mode' => $mode, 'table' => $table);
+		$hookmanager->executeHooks('printFieldListWhere', $parameters, $this); // Note that $action and $object may have been modified by hook
+		$sql .= $hookmanager->resPrint;
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$outstandingOpened = 0;

--- a/htdocs/societe/consumption.php
+++ b/htdocs/societe/consumption.php
@@ -288,7 +288,7 @@ if ($type_element == 'propal') {
 	$tables_from = MAIN_DB_PREFIX."propal as c,".MAIN_DB_PREFIX."propaldet as d";
 	$where = " WHERE c.fk_soc = s.rowid AND s.rowid = ".((int) $socid);
 	$where .= " AND d.fk_propal = c.rowid";
-	$where .= " AND c.entity = ".$conf->entity;
+	$where .= " AND c.entity IN (".getEntity('propal').")";
 	$dateprint = 'c.datep';
 	$doc_number = 'c.ref';
 	$thirdTypeSelect = 'customer';
@@ -301,7 +301,7 @@ if ($type_element == 'order') {
 	$tables_from = MAIN_DB_PREFIX."commande as c,".MAIN_DB_PREFIX."commandedet as d";
 	$where = " WHERE c.fk_soc = s.rowid AND s.rowid = ".((int) $socid);
 	$where .= " AND d.fk_commande = c.rowid";
-	$where .= " AND c.entity = ".$conf->entity;
+	$where .= " AND c.entity IN (".getEntity('commande').")";
 	$dateprint = 'c.date_commande';
 	$doc_number = 'c.ref';
 	$thirdTypeSelect = 'customer';
@@ -439,7 +439,7 @@ if (!empty($sql_select)) {
 		$sql .= ")";
 	}
 
-	$parameters = array();
+	$parameters = array('type_element' => $type_element);
 	$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 	$sql .= $hookmanager->resPrint;
 


### PR DESCRIPTION
**PR Title:** `Feat: Add hooks for SQL list filtering (Propal, Order, etc.)`

## 💎 Context and Objective

This PR aims to add a series of new hooks throughout the Dolibarr core, mainly focused on proposals, orders, and product statistics.

The goal is to allow external modules (e.g., an entity/multicompany management module) to **inject custom `WHERE` conditions** into the SQL queries that generate lists, statistics, exports, and API responses.

Without these hooks, modules are forced to monkey-patch core files, which is a major source of technical debt and update conflicts.

## 🔬 Proposed Changes

This PR introduces new hook points in numerous files, including:

  * **Lists and Cards:** `htdocs/comm/card.php`, `htdocs/comm/index.php`, `htdocs/propal/index.php`, `htdocs/commande/index.php`, `htdocs/expedition/index.php`, etc.
  * **Classes (Stats, Boards):** `propal.class.php`, `commande.class.php`, `product.class.php`, `societe.class.php`, `propalestats.class.php`, `commandestats.class.php`.
  * **Boxes and Libs:** `core/boxes/box_commandes.php`, `core/boxes/box_propales.php`, `core/lib/order.lib.php`, `core/lib/propal.lib.php`.
  * **API:** `api_proposals.class.php`, `api_orders.class.php`.
  * **Exports:** `core/modules/modCommande.class.php`, `core/modules/modPropale.class.php`.

The main hook used is `printFieldListWhere`, which receives `$parameters` and `$object` to allow the module to determine the context.

-----

## 🤔 Open Question for @eldy

I have a major question about the **architectural approach** of this PR, and I would like your opinion before going further.

The `printFieldListWhere` hook is very **generic**. It is called from dozens of different places (a proposal list, a stats chart, a box, an API, etc.).

The consequence is that the module implementing this hook (e.g., `multicompany`) will have to contain a massive "God function" (`public function printFieldListWhere(...)`). This function will need to:

1.  Analyze the `$parameters` (e.g., `boxcode`, `type_element`) or the `$object->element` to guess *where* the hook is being called from.
2.  Contain a `switch` statement or a long series of `if/elseif` to return the correct SQL snippet (e.g., `AND (p.rowid ...)` or `AND (c.rowid ...)`).

**My question is:** Is this the validated way of doing things in Dolibarr?

I feel like we are only **moving the complexity from the Core to the Module**, not reducing it. The `multicompany` module (which will implement these hooks) will become very complex to maintain due to this manual routing.

### 💡 Alternative Suggestion

Wouldn't it be cleaner and more maintainable to have **more specific hooks**?

For example, instead of a generic `printFieldListWhere`:

  * In `htdocs/comm/index.php`, call `printFieldListWhere_commercialindex`
  * In `htdocs/core/boxes/box_commandes.php`, call `printFieldListWhere_boxcommandes`
  * In `htdocs/product/class/product.class.php` (for `load_stats_commande`), call `printFieldListWhere_productstatsorder`

This way, the module would implement small, atomic, and dedicated functions (SRP), making maintenance much simpler:

  * `public function printFieldListWhere_commercialindex(...)`
  * `public function printFieldListWhere_boxcommandes(...)`
  * `public function printFieldListWhere_productstatsorder(...)`
  
  I'm waiting for your suggestion

Thank you for your feedback on this approach. 