### PR TITLE
Fix : Add 'printFieldListGroupBy' hook to stockatdate.php for module flexibility

### DIFF
--- a/htdocs/product/stock/stockatdate.php
+++ b/htdocs/product/stock/stockatdate.php
@@ -287,7 +287,7 @@ if (!empty($search_fk_warehouse)) {
 }
 // Add fields from hooks
 $parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters); // Note that $action and $object may have been modified by hook
+$reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
 
 $sql .= ' FROM '.MAIN_DB_PREFIX.'product as p';
@@ -296,7 +296,7 @@ if (!empty($search_fk_warehouse)) {
 }
 // Add fields from hooks
 $parameters = array();
-$reshook = $hookmanager->executeHooks('printFieldListJoin', $parameters); // Note that $action and $object may have been modified by hook
+$reshook = $hookmanager->executeHooks('printFieldListJoin', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
 $sql .= ' WHERE p.entity IN ('.getEntity('product').')';
 if ($productid > 0) {
@@ -319,7 +319,7 @@ $sqlGroupBy = ' GROUP BY p.rowid, p.ref, p.label, p.description, p.price, p.pmp,
 $sqlGroupBy .= ' p.tms, p.duration, p.tobuy, p.stock';
 
 $parameters = array('sqlGroupBy' => $sqlGroupBy);
-$reshook = $hookmanager->executeHooks('printFieldListGroupBy', $parameters); // Note that $action and $object may have been modified by hook
+$reshook = $hookmanager->executeHooks('printFieldListGroupBy', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 
 if ($reshook == 0) {
 	// Allows the hook to add things (old behavior)

--- a/htdocs/product/stock/stockatdate.php
+++ b/htdocs/product/stock/stockatdate.php
@@ -314,8 +314,24 @@ if ($search_ref) {
 if ($search_nom) {
 	$sql .= natural_search('p.label', $search_nom);
 }
-$sql .= ' GROUP BY p.rowid, p.ref, p.label, p.description, p.price, p.pmp, p.price_ttc, p.price_base_type, p.fk_product_type, p.desiredstock, p.seuil_stock_alerte,';
-$sql .= ' p.tms, p.duration, p.tobuy, p.stock';
+
+$sqlGroupBy = ' GROUP BY p.rowid, p.ref, p.label, p.description, p.price, p.pmp, p.price_ttc, p.price_base_type, p.fk_product_type, p.desiredstock, p.seuil_stock_alerte,';
+$sqlGroupBy .= ' p.tms, p.duration, p.tobuy, p.stock';
+
+$parameters = array('sqlGroupBy' => $sqlGroupBy);
+$reshook = $hookmanager->executeHooks('printFieldListGroupBy', $parameters); // Note that $action and $object may have been modified by hook
+
+if ($reshook == 0) {
+	// Allows the hook to add things (old behavior)
+	$sql .= $hookmanager->resPrint;
+	// Allows the hook to REPLACE the clause (new behavior)
+	if (!empty($hookmanager->resArray['sqlGroupBy'])) {
+		$sqlGroupBy = $hookmanager->resArray['sqlGroupBy'];
+	}
+}
+
+$sql .= $sqlGroupBy;
+
 // Add where from hooks
 $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters); // Note that $action and $object may have been modified by hook


### PR DESCRIPTION
# FIX|Fix #*Add 'printFieldListGroupBy' hook to stockatdate.php for module flexibility*

This PR is a follow-up to the discussion in #35895.

**Context:**
The original PR #35895 tried to fix an incorrect WAP (PMP) calculation in the "Stock at date" report for modules that manage WAP per entity (like Multicompany). The feedback was to use hooks instead of modifying the core query.

**Problem:**
After analysis, the existing hooks are insufficient. The `printFieldListWhere` hook is executed *after* the `GROUP BY` clause is already added to the query. This makes it impossible to correctly modify the grouping logic (e.g., to add `ppe.pmp` for per-entity WAP) without using a fragile `str_replace` hack.

**Solution:**
This PR introduces a new, flexible hook named `printFieldListGroupBy`.

* It is placed just *before* the `GROUP BY` clause is added.
* It passes the default `GROUP BY` string as a variable (`$sqlGroupBy`) in the `$parameters` array.
* It allows modules to cleanly **replace** this clause by setting `$this->resArray['sqlGroupBy']`.

This provides the necessary hook for modules to integrate properly and fixes the underlying issue from #35895 in a clean, robust, and future-proof way.

