### PR TITLE
fix date start and date end in massaction

### DIFF
--- a/htdocs/mrp/mo_list.php
+++ b/htdocs/mrp/mo_list.php
@@ -255,15 +255,17 @@ if (empty($reshook)) {
 					if ($objMo->fetch($idMo)) {
 						if ($objMo->status == Mo::STATUS_DRAFT) {
 							if (!empty($changeDate)) {
-								if ($action == 'changedatestart_confirm') {			// Test on permission not required
-									if ($newDate < $objMo->date_end_planned) {
+								if ($action == 'changedatestart_confirm') {
+									// La date de début peut être définie SI (la date de fin est vide OU la nouvelle date est AVANT la date de fin existante).
+									if (empty($objMo->date_end_planned) || $newDate < $objMo->date_end_planned) {
 										$objMo->date_start_planned = $newDate;
 									} else {
 										setEventMessages($langs->trans('ErrorModifyMoDateStart', $objMo->ref), null, 'errors');
 										break;
 									}
-								} elseif ($action == 'changedateend_confirm') {		// Test on permission not required
-									if ($newDate > $objMo->date_start_planned) {
+								} elseif ($action == 'changedateend_confirm') {
+									// La date de fin peut être définie SI (la date de début est vide OU la nouvelle date est APRÈS la date de début existante).
+									if (empty($objMo->date_start_planned) || $newDate > $objMo->date_start_planned) {
 										$objMo->date_end_planned = $newDate;
 									} else {
 										setEventMessages($langs->trans('ErrorModifyMoDateEnd', $objMo->ref), null, 'errors');

--- a/htdocs/mrp/mo_list.php
+++ b/htdocs/mrp/mo_list.php
@@ -253,36 +253,32 @@ if (empty($reshook)) {
 			if (!empty($toselect)) {
 				foreach ($toselect as $key => $idMo) {
 					if ($objMo->fetch($idMo)) {
-						if ($objMo->status == Mo::STATUS_DRAFT) {
-							if (!empty($changeDate)) {
-								if ($action == 'changedatestart_confirm') {
-									// La date de début peut être définie SI (la date de fin est vide OU la nouvelle date est AVANT la date de fin existante).
-									if (empty($objMo->date_end_planned) || $newDate < $objMo->date_end_planned) {
-										$objMo->date_start_planned = $newDate;
-									} else {
-										setEventMessages($langs->trans('ErrorModifyMoDateStart', $objMo->ref), null, 'errors');
-										break;
-									}
-								} elseif ($action == 'changedateend_confirm') {
-									// La date de fin peut être définie SI (la date de début est vide OU la nouvelle date est APRÈS la date de début existante).
-									if (empty($objMo->date_start_planned) || $newDate > $objMo->date_start_planned) {
-										$objMo->date_end_planned = $newDate;
-									} else {
-										setEventMessages($langs->trans('ErrorModifyMoDateEnd', $objMo->ref), null, 'errors');
-										break;
-									}
-								}
-								if ($objMo->update($user)) {
-									setEventMessages($langs->trans('ModifyMoDate', $objMo->ref), null, 'mesgs');
+						if (!empty($changeDate)) {
+							if ($action == 'changedatestart_confirm') { 		// Test on permission
+								// The start date can be set IF (the end date is empty OR the new date is BEFORE the existing end date).
+								if (empty($objMo->date_end_planned) || $newDate < $objMo->date_end_planned) {
+									$objMo->date_start_planned = $newDate;
 								} else {
-									setEventMessages($langs->trans('ErrorModifyMoDate', $objMo->ref), null, 'errors');
+									setEventMessages($langs->trans('ErrorModifyMoDateStart', $objMo->ref), null, 'errors');
+									break;
 								}
+							} elseif ($action == 'changedateend_confirm') {
+								// The end date can be set IF (the start date is empty OR the new date is AFTER the existing start date).
+								if (empty($objMo->date_start_planned) || $newDate > $objMo->date_start_planned) {
+									$objMo->date_end_planned = $newDate;
+								} else {
+									setEventMessages($langs->trans('ErrorModifyMoDateEnd', $objMo->ref), null, 'errors');
+									break;
+								}
+							}
+							if ($objMo->update($user)) {
+								setEventMessages($langs->trans('ModifyMoDate', $objMo->ref), null, 'mesgs');
 							} else {
-								setEventMessages($langs->trans('ErrorEmptyChangeDate'), null, 'errors');
-								break;
+								setEventMessages($langs->trans('ErrorModifyMoDate', $objMo->ref), null, 'errors');
 							}
 						} else {
-							setEventMessages($langs->trans('ErrorObjectMustHaveStatusDraftToModifyDate', $objMo->ref), null, 'errors');
+							setEventMessages($langs->trans('ErrorEmptyChangeDate'), null, 'errors');
+							break;
 						}
 					}
 				}

--- a/htdocs/mrp/mo_list.php
+++ b/htdocs/mrp/mo_list.php
@@ -254,7 +254,7 @@ if (empty($reshook)) {
 				foreach ($toselect as $key => $idMo) {
 					if ($objMo->fetch($idMo)) {
 						if (!empty($changeDate)) {
-							if ($action == 'changedatestart_confirm') { 		// Test on permission
+							if ($action == 'changedatestart_confirm') { 		// Test on permission not required
 								// The start date can be set IF (the end date is empty OR the new date is BEFORE the existing end date).
 								if (empty($objMo->date_end_planned) || $newDate < $objMo->date_end_planned) {
 									$objMo->date_start_planned = $newDate;


### PR DESCRIPTION
# FIX|Fix #[*issue_number Short description*]
Bugfix: Robust Date Comparison for MO (Manufacturing Order) Planned Dates

Problem

The existing validation logic for modifying the planned start and end dates of a Manufacturing Order (MO) fails when one of the opposing dates is not yet defined (stored as an empty string "").

This issue is caused by PHP's loose comparison :

The positive timestamp $newDate is compared against the empty string "".

PHP implicitly converts "" to the integer 0.

The comparison (e.g., timestamp < 0) evaluates to FALSE, prematurely executing the error block (setEventMessages) and preventing the user from successfully setting the initial date.

Solution

The fix standardizes the object's date attributes ($objMo->date_end_planned, etc.) into reliable integer timestamps before performing validation.

We use is_numeric() to detect existing timestamps (positive integers).

We use strtotime() to safely convert empty strings ("" becomes 0) or date strings to integers.

The validation condition is updated to explicitly allow the modification if the opposing date is undefined (value $\le 0$ after conversion).