### PR TITLE
fix date start and date end in massaction

### DIFF
--- a/htdocs/mrp/mo_list.php
+++ b/htdocs/mrp/mo_list.php
@@ -255,15 +255,17 @@ if (empty($reshook)) {
 					if ($objMo->fetch($idMo)) {
 						if ($objMo->status == Mo::STATUS_DRAFT) {
 							if (!empty($changeDate)) {
-								if ($action == 'changedatestart_confirm') {			// Test on permission not required
-									if ($newDate < $objMo->date_end_planned) {
+								if ($action == 'changedatestart_confirm') {
+									// La date de début peut être définie SI (la date de fin est vide OU la nouvelle date est AVANT la date de fin existante).
+									if (empty($objMo->date_end_planned) || $newDate < $objMo->date_end_planned) {
 										$objMo->date_start_planned = $newDate;
 									} else {
 										setEventMessages($langs->trans('ErrorModifyMoDateStart', $objMo->ref), null, 'errors');
 										break;
 									}
-								} elseif ($action == 'changedateend_confirm') {		// Test on permission not required
-									if ($newDate > $objMo->date_start_planned) {
+								} elseif ($action == 'changedateend_confirm') {
+									// La date de fin peut être définie SI (la date de début est vide OU la nouvelle date est APRÈS la date de début existante).
+									if (empty($objMo->date_start_planned) || $newDate > $objMo->date_start_planned) {
 										$objMo->date_end_planned = $newDate;
 									} else {
 										setEventMessages($langs->trans('ErrorModifyMoDateEnd', $objMo->ref), null, 'errors');


### PR DESCRIPTION
# FIX|Fix #[*issue_number Short description*]
Bugfix: Remove Status Check Restriction for MO Date Modification

Context

The current logic prevents bulk updates of Manufacturing Order (MO) dates by restricting date modifications to MOs that are only in the Draft status. However, this restriction is inconsistent with the behavior allowed when modifying dates individually on the MO card.

Problem

When a user accesses an individual MO card (e.g., an MO with status Finished or Closed), the system currently permits them to modify the planned start and end dates directly through the user interface.

In contrast, any attempt to modify these dates in bulk  is blocked by a status check that enforces status == Draft. This creates a logical inconsistency:

Individual Card: Modification is allowed, regardless of status.

Mass Update : Modification is blocked if status is not Draft.

Solution

The status check that prevents date modification on MOs not in Draft status is being removed from the core validation path.

Impact:

Consistency: The system's behavior will now be consistent: if a date can be modified on the MO card, it can also be modified via other update paths.

Flexibility: This restores flexibility for advanced users and integrations that need to adjust planned dates even when an MO is already validated or finished (e.g., for reporting or historical accuracy).
