### PR TITLE
Fix incorrect total discount (missing loop after GROUP BY query)

### DIFF
--- a/htdocs/comm/remx.php
+++ b/htdocs/comm/remx.php
@@ -372,7 +372,7 @@ if ($socid > 0) {
 		$sql .= " GROUP BY rc.fk_user";
 		$resql = $db->query($sql);
 		if ($resql) {
-			while($obj = $db->fetch_object($resql)) {
+			while ($obj = $db->fetch_object($resql)) {
 				$remise_all += (!empty($obj->amount) ? $obj->amount : 0);
 				if (!empty($obj->fk_user) && $obj->fk_user == $user->id) {
 					$remise_user += (!empty($obj->amount) ? $obj->amount : 0);

--- a/htdocs/comm/remx.php
+++ b/htdocs/comm/remx.php
@@ -372,10 +372,11 @@ if ($socid > 0) {
 		$sql .= " GROUP BY rc.fk_user";
 		$resql = $db->query($sql);
 		if ($resql) {
-			$obj = $db->fetch_object($resql);
-			$remise_all += (!empty($obj->amount) ? $obj->amount : 0);
-			if (!empty($obj->fk_user) && $obj->fk_user == $user->id) {
-				$remise_user += (!empty($obj->amount) ? $obj->amount : 0);
+			while($obj = $db->fetch_object($resql)) {
+				$remise_all += (!empty($obj->amount) ? $obj->amount : 0);
+				if (!empty($obj->fk_user) && $obj->fk_user == $user->id) {
+					$remise_user += (!empty($obj->amount) ? $obj->amount : 0);
+				}
 			}
 		} else {
 			dol_print_error($db);
@@ -401,10 +402,11 @@ if ($socid > 0) {
 		$sql .= " GROUP BY rc.fk_user";
 		$resql = $db->query($sql);
 		if ($resql) {
-			$obj = $db->fetch_object($resql);
-			$remise_all += (!empty($obj->amount) ? $obj->amount : 0);
-			if (!empty($obj->fk_user) && $obj->fk_user == $user->id) {
-				$remise_user += (!empty($obj->amount) ? $obj->amount : 0);
+			while ($obj = $db->fetch_object($resql)) {
+				$remise_all += (!empty($obj->amount) ? $obj->amount : 0);
+				if (!empty($obj->fk_user) && $obj->fk_user == $user->id) {
+					$remise_user += (!empty($obj->amount) ? $obj->amount : 0);
+				}
 			}
 		} else {
 			dol_print_error($db);


### PR DESCRIPTION
The code processing the return of the query listing the available discounts is missing the loop that allows the processing of every grouped line returned by the query.

Only the first line was processed. If multiple user created discount on the same third party, the result in /comm/remx.php was wrong, and only summing the discounts given by the first user.

To reproduce the bug, login as an user and create a discount on a third party (deposit or absolute), then disconnect and connect as another user. On the same third party, create another discount. The total displayed on /comm/remx.php is wrong.

<img width="1517" height="512" alt="image" src="https://github.com/user-attachments/assets/58ba82ea-1d51-4a21-a854-6cb500c26641" />
