### PR TITLE
FIX #35655 Check if API user has rights to see all thirdparties

### DIFF
--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -218,6 +218,13 @@ class Contracts extends DolibarrApi
 		if ($thirdparty_result < 1) {
 			throw new RestException(404, 'Thirdparty with id='.$socid.' not found or not allowed');
 		}
+		if (!DolibarrApi::_checkAccessToResource('societe', $thirdpartytmp->id)) {
+			throw new RestException(404, 'Thirdparty with id='.$thirdpartytmp->id.' not found or not allowed');
+		}
+
+		dol_syslog("socid=".$socid);
+		dol_syslog("thirdparty_result=".$thirdparty_result);
+		dol_syslog("thirdpartytmp->id=".$thirdpartytmp->id);
 
 		// Check mandatory fields
 		$result = $this->_validate($request_data);

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -21,6 +21,7 @@
 use Luracast\Restler\RestException;
 
 require_once DOL_DOCUMENT_ROOT.'/contrat/class/contrat.class.php';
+require_once DOL_DOCUMENT_ROOT.'/societe/class/api_thirdparties.class.php';
 
 /**
  * API class for contracts
@@ -208,11 +209,15 @@ class Contracts extends DolibarrApi
 	public function post($request_data = null)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('contrat', 'creer')) {
-			throw new RestException(403, "Insufficient rights");
+			throw new RestException(403, "Missing permission: Create/modify contracts/subscriptions");
 		}
-		if (!DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir')) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.'. No read permission on all thirdparties.');
-		}
+
+		$socid = (int) $request_data['socid'];
+		$thirdparties = new Thirdparties($this->db);
+		$thirdparty_result = $thirdparties->get((int) $socid);
+		// if there is no such thirdparty, then $thirdparties->get((int) $socid); returns 404 "Not Found: Thirdparty not found"
+		// if this user does not have access to this thirdparty, then $thirdparties->get((int) $socid); returns 403 Forbidden: Access not allowed for login ***** on this thirdparty"
+
 		// Check mandatory fields
 		$result = $this->_validate($request_data);
 
@@ -681,6 +686,7 @@ class Contracts extends DolibarrApi
 			throw new RestException(404, 'Contrat not found');
 		}
 
+		$socid = $this->contract->socid;
 		$deny_access = true;
 		$why_deny_access = '';
 		if (DolibarrApiAccess::$user->hasRight('societe', 'lire')) {
@@ -688,10 +694,10 @@ class Contracts extends DolibarrApi
 				$deny_access = false;
 			} else {
 				$why_deny_access = 'Extend access to all third parties';
-				if (DolibarrApi::_checkAccessToResource('societe', $this->contract->socid)) {
+				if (DolibarrApi::_checkAccessToResource('societe', $socid)) {
 					$deny_access = false;
 				} else {
-					$why_deny_access = $why_deny_access.' and NOT sales representative for this thirdparty='.$this->contract->socid;
+					$why_deny_access = $why_deny_access.' and NOT sales representative for this thirdparty='.$socid;
 				}
 			}
 		} else {

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -159,7 +159,6 @@ class Contracts extends DolibarrApi
 			$sql .= $this->db->plimit($limit + 1, $offset);
 		}
 
-		dol_syslog("API Rest request");
 		$result = $this->db->query($sql);
 
 		if ($result) {
@@ -221,10 +220,6 @@ class Contracts extends DolibarrApi
 		if (!DolibarrApi::_checkAccessToResource('societe', $thirdpartytmp->id)) {
 			throw new RestException(404, 'Thirdparty with id='.$thirdpartytmp->id.' not found or not allowed');
 		}
-
-		dol_syslog("socid=".$socid);
-		dol_syslog("thirdparty_result=".$thirdparty_result);
-		dol_syslog("thirdpartytmp->id=".$thirdpartytmp->id);
 
 		// Check mandatory fields
 		$result = $this->_validate($request_data);
@@ -316,7 +311,6 @@ class Contracts extends DolibarrApi
 			$sql .= $this->db->plimit($limit + 1, $offset);
 		}
 
-		dol_syslog("API Rest request");
 		$result = $this->db->query($sql);
 		if ($result) {
 			$num = $this->db->num_rows($result);

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -211,7 +211,7 @@ class Contracts extends DolibarrApi
 			throw new RestException(403, "Insufficient rights");
 		}
 		if (!DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir')) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.'. No read permission on thirdparties.');
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.'. No read permission on all thirdparties.');
 		}
 		// Check mandatory fields
 		$result = $this->_validate($request_data);
@@ -677,7 +677,7 @@ class Contracts extends DolibarrApi
 			throw new RestException(403);
 		}
 		if (!DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir')) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.'. No read permission on thirdparties.');
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.'. No read permission on all thirdparties.');
 		}
 		$result = $this->contract->fetch($id);
 		if (!$result) {

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -213,7 +213,7 @@ class Contracts extends DolibarrApi
 		}
 
 		$socid = (int) $request_data['socid'];
-		$thirdparties = new Thirdparties($this->db);
+		$thirdparties = new Thirdparties();
 		$thirdparty_result = $thirdparties->get((int) $socid);
 		// if there is no such thirdparty, then $thirdparties->get((int) $socid); returns 404 "Not Found: Thirdparty not found"
 		// if this user does not have access to this thirdparty, then $thirdparties->get((int) $socid); returns 403 Forbidden: Access not allowed for login ***** on this thirdparty"

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -21,7 +21,7 @@
 use Luracast\Restler\RestException;
 
 require_once DOL_DOCUMENT_ROOT.'/contrat/class/contrat.class.php';
-require_once DOL_DOCUMENT_ROOT.'/societe/class/api_thirdparties.class.php';
+require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
 
 /**
  * API class for contracts
@@ -77,7 +77,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$this->contract->fetchObjectLinked();
@@ -213,10 +213,11 @@ class Contracts extends DolibarrApi
 		}
 
 		$socid = (int) $request_data['socid'];
-		$thirdparties = new Thirdparties();
-		$thirdparty_result = $thirdparties->get((int) $socid);
-		// if there is no such thirdparty, then $thirdparties->get((int) $socid); returns 404 "Not Found: Thirdparty not found"
-		// if this user does not have access to this thirdparty, then $thirdparties->get((int) $socid); returns 403 Forbidden: Access not allowed for login ***** on this thirdparty"
+		$thirdpartytmp = new Societe($this->db);
+		$thirdparty_result = $thirdpartytmp->fetch($socid);
+		if ($thirdparty_result < 1) {
+			throw new RestException(404, 'Thirdparty with id='.$socid.' not found or not allowed');
+		}
 
 		// Check mandatory fields
 		$result = $this->_validate($request_data);
@@ -276,7 +277,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$obj_ret = [];
@@ -368,7 +369,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$request_data = (object) $request_data;
@@ -428,7 +429,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$request_data = (object) $request_data;
@@ -576,7 +577,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$updateRes = $this->contract->active_line(DolibarrApiAccess::$user, $lineid, (int) $datestart, $dateend, $comment);
@@ -614,7 +615,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$updateRes = $this->contract->close_line(DolibarrApiAccess::$user, $lineid, (int) $datestart, $comment);
@@ -654,7 +655,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		// TODO Check the lineid $lineid is a line of object
@@ -687,13 +688,20 @@ class Contracts extends DolibarrApi
 		}
 
 		$old_socid = $this->contract->socid;
-		$thirdparties = new Thirdparties();
-		$thirdparty_result = $thirdparties->get((int) $old_socid);
-		// if there is no such thirdparty, then $thirdparties->get((int) $old_socid); returns 404 "Not Found: Thirdparty not found"
-		// if this user does not have access to this thirdparty, then $thirdparties->get((int) $old_socid); returns 403 Forbidden: Access not allowed for login ***** on this thirdparty"
+		$oldthirdpartytmp = new Societe($this->db);
+		$old_thirdparty_result = $oldthirdpartytmp->fetch($old_socid);
+		if ($old_thirdparty_result < 1) {
+			throw new RestException(404, 'Thirdparty with id='.$old_socid.' not found or not allowed');
+		}
+		$new_socid = (int) $request_data['socid'];
+		$newthirdpartytmp = new Societe($this->db);
+		$new_thirdparty_result = $newthirdpartytmp->fetch($new_socid);
+		if ($new_thirdparty_result < 1) {
+			throw new RestException(404, 'Thirdparty with id='.$new_socid.' not found or not allowed');
+		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 		foreach ($request_data as $field => $value) {
 			if ($field == 'id') {
@@ -712,13 +720,11 @@ class Contracts extends DolibarrApi
 			}
 
 			if ($field == 'socid') {
-				$new_socid = (int) $request_data['socid'];
-				$thirdparties = new Thirdparties();
-				$thirdparty_result = $thirdparties->get((int) $new_socid);
-				// if there is no such thirdparty, then $thirdparties->get((int) $old_socid); returns 404 "Not Found: Thirdparty not found"
-				// if this user does not have access to this thirdparty, then $thirdparties->get((int) $old_socid); returns 403 Forbidden: Access not allowed for login ***** on this thirdparty"
-				if ($thirdparty_result->id != $new_socid) {
-					throw new RestException(404, 'New thirdparty with id='.$new_socid.' not found OR this user/api key does not have access to the new thirdparty');
+				$new_socid = (int) $value;
+				$loopthirdpartytmp = new Societe($this->db);
+				$new_thirdparty_result = $loopthirdpartytmp->fetch($new_socid);
+				if ($new_thirdparty_result < 1) {
+					throw new RestException(404, 'Thirdparty with id='.$new_socid.' not found or not allowed');
 				}
 			}
 
@@ -744,7 +750,7 @@ class Contracts extends DolibarrApi
 	public function delete($id)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('contrat', 'supprimer')) {
-			throw new RestException(403);
+			throw new RestException(403, 'Missing permission: Delete contracts/subscriptions');
 		}
 		$result = $this->contract->fetch($id);
 		if (!$result) {
@@ -752,7 +758,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		if (!$this->contract->delete(DolibarrApiAccess::$user)) {
@@ -797,7 +803,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$result = $this->contract->validate(DolibarrApiAccess::$user, '', $notrigger);
@@ -846,7 +852,7 @@ class Contracts extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(403, 'Access to this contract is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$result = $this->contract->closeAll(DolibarrApiAccess::$user, $notrigger);

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -700,11 +700,8 @@ class Contracts extends DolibarrApi
 		if ($old_thirdparty_result < 1) {
 			throw new RestException(404, 'Thirdparty with id='.$old_socid.' not found or not allowed');
 		}
-		$new_socid = (int) $request_data['socid'];
-		$newthirdpartytmp = new Societe($this->db);
-		$new_thirdparty_result = $newthirdpartytmp->fetch($new_socid);
-		if ($new_thirdparty_result < 1) {
-			throw new RestException(404, 'Thirdparty with id='.$new_socid.' not found or not allowed');
+		if (!DolibarrApi::_checkAccessToResource('societe', $old_socid)) {
+			throw new RestException(403, 'Access to old thirdparty='.$old_socid.' is not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
@@ -732,6 +729,9 @@ class Contracts extends DolibarrApi
 				$new_thirdparty_result = $loopthirdpartytmp->fetch($new_socid);
 				if ($new_thirdparty_result < 1) {
 					throw new RestException(404, 'Thirdparty with id='.$new_socid.' not found or not allowed');
+				}
+				if (!DolibarrApi::_checkAccessToResource('societe', $new_socid)) {
+					throw new RestException(403, 'Access to new thirdparty='.$new_socid.' is not allowed for login '.DolibarrApiAccess::$user->login);
 				}
 			}
 

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -210,6 +210,9 @@ class Contracts extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('contrat', 'creer')) {
 			throw new RestException(403, "Insufficient rights");
 		}
+		if (!DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir')) {
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.'. No read permission on thirdparties.');
+		}
 		// Check mandatory fields
 		$result = $this->_validate($request_data);
 
@@ -673,7 +676,9 @@ class Contracts extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('contrat', 'creer')) {
 			throw new RestException(403);
 		}
-
+		if (!DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir')) {
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.'. No read permission on thirdparties.');
+		}
 		$result = $this->contract->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Contrat not found');

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -686,26 +686,11 @@ class Contracts extends DolibarrApi
 			throw new RestException(404, 'Contrat not found');
 		}
 
-		$socid = $this->contract->socid;
-		$deny_access = true;
-		$why_deny_access = '';
-		if (DolibarrApiAccess::$user->hasRight('societe', 'lire')) {
-			if (DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir')) {
-				$deny_access = false;
-			} else {
-				$why_deny_access = 'Extend access to all third parties';
-				if (DolibarrApi::_checkAccessToResource('societe', $socid)) {
-					$deny_access = false;
-				} else {
-					$why_deny_access = $why_deny_access.' and NOT sales representative for this thirdparty='.$socid;
-				}
-			}
-		} else {
-			$why_deny_access = 'Read third parties linked to user';
-		}
-		if ($deny_access) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.' - missing permissions: '.$why_deny_access);
-		}
+		$old_socid = $this->contract->socid;
+		$thirdparties = new Thirdparties();
+		$thirdparty_result = $thirdparties->get((int) $old_socid);
+		// if there is no such thirdparty, then $thirdparties->get((int) $old_socid); returns 404 "Not Found: Thirdparty not found"
+		// if this user does not have access to this thirdparty, then $thirdparties->get((int) $old_socid); returns 403 Forbidden: Access not allowed for login ***** on this thirdparty"
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
@@ -724,6 +709,17 @@ class Contracts extends DolibarrApi
 					$this->contract->array_options[$index] = $this->_checkValForAPI($field, $val, $this->contract);
 				}
 				continue;
+			}
+
+			if ($field == 'socid') {
+				$new_socid = (int) $request_data['socid'];
+				$thirdparties = new Thirdparties();
+				$thirdparty_result = $thirdparties->get((int) $new_socid);
+				// if there is no such thirdparty, then $thirdparties->get((int) $old_socid); returns 404 "Not Found: Thirdparty not found"
+				// if this user does not have access to this thirdparty, then $thirdparties->get((int) $old_socid); returns 403 Forbidden: Access not allowed for login ***** on this thirdparty"
+				if ($thirdparty_result->id != $new_socid) {
+					throw new RestException(404, 'New thirdparty with id='.$new_socid.' not found OR this user/api key does not have access to the new thirdparty');
+				}
 			}
 
 			$this->contract->$field = $this->_checkValForAPI($field, $value, $this->contract);

--- a/htdocs/contrat/class/api_contracts.class.php
+++ b/htdocs/contrat/class/api_contracts.class.php
@@ -676,12 +676,29 @@ class Contracts extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('contrat', 'creer')) {
 			throw new RestException(403);
 		}
-		if (!DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir')) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.'. No read permission on all thirdparties.');
-		}
 		$result = $this->contract->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Contrat not found');
+		}
+
+		$deny_access = true;
+		$why_deny_access = '';
+		if (DolibarrApiAccess::$user->hasRight('societe', 'lire')) {
+			if (DolibarrApiAccess::$user->hasRight('societe', 'client', 'voir')) {
+				$deny_access = false;
+			} else {
+				$why_deny_access = 'Extend access to all third parties';
+				if (DolibarrApi::_checkAccessToResource('societe', $this->contract->socid)) {
+					$deny_access = false;
+				} else {
+					$why_deny_access = $why_deny_access.' and NOT sales representative for this thirdparty='.$this->contract->socid;
+				}
+			}
+		} else {
+			$why_deny_access = 'Read third parties linked to user';
+		}
+		if ($deny_access) {
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login.' - missing permissions: '.$why_deny_access);
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('contrat', $this->contract->id)) {


### PR DESCRIPTION
# FIX #35655 Check if API user has rights to see all thirdparties
This PR is a fix for #35655, checking if the api user/key has access to the thirdparty used in the contract