### PR TITLE
Fix listincsv on tab societe/price.php

### DIFF
--- a/htdocs/societe/price.php
+++ b/htdocs/societe/price.php
@@ -556,7 +556,7 @@ if (!empty($conf->global->PRODUIT_CUSTOMER_PRICES)) {
 		print '<input type="hidden" name="id" value="'.$object->id.'">';
 
 		print '<div class="div-table-responsive-no-min">';
-		print '<table class="noborder centpercent">';
+		print '<table class="noborder centpercent liste">';
 
 		print '<tr class="liste_titre">';
 		print '<td>'.$langs->trans("Ref").'</td>';


### PR DESCRIPTION
# Fix : coherent list on societe/price.php tab

Most (if not all) lists are in a table that has such attributes : `<table class="noborder centpercent liste">`.
The module ListInCSV uses the attribute 'list' to ad its export button.

This PR adds attr 'liste' on societe/price tab to allow listinCSV to execute there.




