### PR TITLE
NEW Show cron last result and output in info

### DIFF
--- a/htdocs/cron/info.php
+++ b/htdocs/cron/info.php
@@ -78,7 +78,10 @@ print '<br>';
 
 print '<table width="100%"><tr><td>';
 dol_print_object_info($object);
-print '</td></tr></table>';
+print '</td></tr>';
+print '<tr><td>'.$langs->trans('CronLastResult').' : '.$object->lastresult.'</td></tr>';
+print '<tr><td>'.$langs->trans('CronLastOutput').' : '.$object->lastoutput.'</td></tr>';
+print '</table>';
 print '</div>';
 
 llxFooter();

--- a/htdocs/cron/info.php
+++ b/htdocs/cron/info.php
@@ -79,8 +79,8 @@ print '<br>';
 print '<table width="100%"><tr><td>';
 dol_print_object_info($object);
 print '</td></tr>';
-print '<tr><td>'.$langs->trans('CronLastResult').' : '.$object->lastresult.'</td></tr>';
-print '<tr><td>'.$langs->trans('CronLastOutput').' : '.$object->lastoutput.'</td></tr>';
+print '<tr><td>'.$langs->trans('CronLastResult').' : '.dolPrintHTML($object->lastresult).'</td></tr>';
+print '<tr><td>'.$langs->trans('CronLastOutput').' : '.dolPrintHTML($object->lastoutput).'</td></tr>';
 print '</table>';
 print '</div>';
 


### PR DESCRIPTION
#NEW From now, last output and last result of a cron are only displayed in cron's list, and output isn't very convenient to read

This PR adds last output and last result in cron's info page
<img width="5453" height="966" alt="image" src="https://github.com/user-attachments/assets/93a05402-85e4-4ee1-91b4-d3d9327eb2a7" />
