### PR TITLE
FIX: product stock lists: prevent SQL error when filtering on physical stock

### DIFF
--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -292,8 +292,8 @@ if (!getDolGlobalString('PRODUCT_STOCK_LIST_SHOW_WITH_PRECALCULATED_DENORMALIZED
 		$sql_having .= " HAVING SUM(" . $db->ifsql('s.reel IS NULL', '0', 's.reel') . ") < p.seuil_stock_alerte";
 	}
 	if ($search_stock_physique != '') {
-		$natural_search_physique = natural_search('SUM_OF_REEL', $search_stock_physique, 1, 1);
-		$natural_search_physique = " " . substr(str_replace('SUM_OF_REEL', 'SUM(COALESCE(s.reel, 0))', $natural_search_physique), 1, -1); // remove first "(" and last ")" characters
+		$natural_search_physique = natural_search('__SUM_OF_REEL__', $search_stock_physique, 1, 1);
+		$natural_search_physique = " " . substr(str_replace('__SUM_OF_REEL__', 'SUM(COALESCE(s.reel, 0))', $natural_search_physique), 1, -1); // remove first "(" and last ")" characters
 		if (!empty($sql_having)) {
 			$sql_having .= " AND";
 		} else {

--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -155,7 +155,7 @@ $sql .= ' p.duration, p.tosell as statut, p.tobuy, p.seuil_stock_alerte, p.desir
 if (getDolGlobalString('PRODUCT_STOCK_LIST_SHOW_WITH_PRECALCULATED_DENORMALIZED_PHYSICAL_STOCK')) {
 	$sql .= ' p.stock as stock_physique';
 } else {
-	$sql .= ' SUM(COALESCE(s.reel)) as stock_physique';
+	$sql .= ' SUM(s.reel) as stock_physique';
 }
 if (getDolGlobalString('PRODUCT_USE_UNITS')) {
 	$sql .= ', u.short_label as unit_short';
@@ -292,8 +292,8 @@ if (!getDolGlobalString('PRODUCT_STOCK_LIST_SHOW_WITH_PRECALCULATED_DENORMALIZED
 		$sql_having .= " HAVING SUM(" . $db->ifsql('s.reel IS NULL', '0', 's.reel') . ") < p.seuil_stock_alerte";
 	}
 	if ($search_stock_physique != '') {
-		$natural_search_physique = natural_search('stock_physique', $search_stock_physique, 1, 1);
-		$natural_search_physique = " " . substr($natural_search_physique, 1, -1); // remove first "(" and last ")" characters
+		$natural_search_physique = natural_search('SUM_OF_REEL', $search_stock_physique, 1, 1);
+		$natural_search_physique = " " . substr(str_replace('SUM_OF_REEL', 'SUM(COALESCE(s.reel, 0))', $natural_search_physique), 1, -1); // remove first "(" and last ")" characters
 		if (!empty($sql_having)) {
 			$sql_having .= " AND";
 		} else {

--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -155,7 +155,7 @@ $sql .= ' p.duration, p.tosell as statut, p.tobuy, p.seuil_stock_alerte, p.desir
 if (getDolGlobalString('PRODUCT_STOCK_LIST_SHOW_WITH_PRECALCULATED_DENORMALIZED_PHYSICAL_STOCK')) {
 	$sql .= ' p.stock as stock_physique';
 } else {
-	$sql .= ' SUM(s.reel) as stock_physique';
+	$sql .= ' SUM(COALESCE(s.reel)) as stock_physique';
 }
 if (getDolGlobalString('PRODUCT_USE_UNITS')) {
 	$sql .= ', u.short_label as unit_short';
@@ -292,8 +292,7 @@ if (!getDolGlobalString('PRODUCT_STOCK_LIST_SHOW_WITH_PRECALCULATED_DENORMALIZED
 		$sql_having .= " HAVING SUM(" . $db->ifsql('s.reel IS NULL', '0', 's.reel') . ") < p.seuil_stock_alerte";
 	}
 	if ($search_stock_physique != '') {
-		//$natural_search_physique = natural_search('HAVING SUM(' . $db->ifsql('s.reel IS NULL', '0', 's.reel') . ')', $search_stock_physique, 1, 1);
-		$natural_search_physique = natural_search('SUM(' . $db->ifsql('s.reel IS NULL', '0', 's.reel') . ')', $search_stock_physique, 1, 1);
+		$natural_search_physique = natural_search('stock_physique', $search_stock_physique, 1, 1);
 		$natural_search_physique = " " . substr($natural_search_physique, 1, -1); // remove first "(" and last ")" characters
 		if (!empty($sql_having)) {
 			$sql_having .= " AND";

--- a/htdocs/product/reassortlot.php
+++ b/htdocs/product/reassortlot.php
@@ -255,7 +255,8 @@ $sql .= ' ps.fk_entrepot, ps.reel,';
 $sql .= ' e.ref as warehouse_ref, e.lieu as warehouse_lieu, e.fk_parent as warehouse_parent,';
 $sql .= ' pb.batch, pb.eatby as oldeatby, pb.sellby as oldsellby,';
 $sql .= ' pl.rowid as lotid, pl.eatby, pl.sellby,';
-$sql .= ' SUM(pb.qty) as stock_physique, COUNT(pb.rowid) as nbinbatchtable';
+$sql .= ' SUM(pb.qty) as stock_physique, COUNT(pb.rowid) as nbinbatchtable,';
+$sql .= ' SUM(COALESCE(pb.qty, ps.reel, 0)) AS search_physique';
 // Add fields from hooks
 $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters, $object); // Note that $action and $object may have been modified by hook
@@ -394,7 +395,7 @@ if ($search_toolowstock) {
 	$sql_having .= " HAVING SUM(".$db->ifsql('ps.reel IS NULL', '0', 'ps.reel').") < p.seuil_stock_alerte"; // Not used yet
 }
 if ($search_stock_physique != '') {
-	$natural_search_physique = natural_search('SUM(' . $db->ifsql('pb.qty IS NULL', $db->ifsql('ps.reel IS NULL', '0', 'ps.reel'), 'pb.qty') . ')', $search_stock_physique, 1, 1);
+	$natural_search_physique = natural_search('search_physique', $search_stock_physique, 1, 1);
 	$natural_search_physique = " " . substr($natural_search_physique, 1, -1); // remove first "(" and last ")" characters
 	if (!empty($sql_having)) {
 		$sql_having .= " AND";

--- a/htdocs/product/reassortlot.php
+++ b/htdocs/product/reassortlot.php
@@ -255,8 +255,7 @@ $sql .= ' ps.fk_entrepot, ps.reel,';
 $sql .= ' e.ref as warehouse_ref, e.lieu as warehouse_lieu, e.fk_parent as warehouse_parent,';
 $sql .= ' pb.batch, pb.eatby as oldeatby, pb.sellby as oldsellby,';
 $sql .= ' pl.rowid as lotid, pl.eatby, pl.sellby,';
-$sql .= ' SUM(pb.qty) as stock_physique, COUNT(pb.rowid) as nbinbatchtable,';
-$sql .= ' SUM(COALESCE(pb.qty, ps.reel, 0)) AS search_physique';
+$sql .= ' SUM(pb.qty) as stock_physique, COUNT(pb.rowid) as nbinbatchtable';
 // Add fields from hooks
 $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters, $object); // Note that $action and $object may have been modified by hook
@@ -395,8 +394,8 @@ if ($search_toolowstock) {
 	$sql_having .= " HAVING SUM(".$db->ifsql('ps.reel IS NULL', '0', 'ps.reel').") < p.seuil_stock_alerte"; // Not used yet
 }
 if ($search_stock_physique != '') {
-	$natural_search_physique = natural_search('search_physique', $search_stock_physique, 1, 1);
-	$natural_search_physique = " " . substr($natural_search_physique, 1, -1); // remove first "(" and last ")" characters
+	$natural_search_physique = natural_search('SEARCH_PHYSIQUE', $search_stock_physique, 1, 1);
+	$natural_search_physique = " " . substr(str_replace('SEARCH_PHYSIQUE', 'SUM(COALESCE(pb.qty, ps.reel, 0))', $natural_search_physique), 1, -1); // remove first "(" and last ")" characters
 	if (!empty($sql_having)) {
 		$sql_having .= " AND";
 	} else {

--- a/htdocs/product/reassortlot.php
+++ b/htdocs/product/reassortlot.php
@@ -394,8 +394,8 @@ if ($search_toolowstock) {
 	$sql_having .= " HAVING SUM(".$db->ifsql('ps.reel IS NULL', '0', 'ps.reel').") < p.seuil_stock_alerte"; // Not used yet
 }
 if ($search_stock_physique != '') {
-	$natural_search_physique = natural_search('SEARCH_PHYSIQUE', $search_stock_physique, 1, 1);
-	$natural_search_physique = " " . substr(str_replace('SEARCH_PHYSIQUE', 'SUM(COALESCE(pb.qty, ps.reel, 0))', $natural_search_physique), 1, -1); // remove first "(" and last ")" characters
+	$natural_search_physique = natural_search('__SEARCH_PHYSIQUE__', $search_stock_physique, 1, 1);
+	$natural_search_physique = " " . substr(str_replace('__SEARCH_PHYSIQUE__', 'SUM(COALESCE(pb.qty, ps.reel, 0))', $natural_search_physique), 1, -1); // remove first "(" and last ")" characters
 	if (!empty($sql_having)) {
 		$sql_having .= " AND";
 	} else {


### PR DESCRIPTION
# FIX: product stock lists: prevent SQL error when filtering on physical stock

Since v22, `natural_search()` sanitizes (with a call to `DoliDB::sanitize()`) the list of fields passed in the first argument.

Therefore, using SQL functions on those calls results in SQL errors.

```
Requête dernier accès en base en erreur: SELECT p.rowid, p.ref, p.label, p.barcode, p.price, p.price_ttc, p.price_base_type, p.entity, p.fk_product_type, p.tms as datem, p.duration, p.tosell as statut, p.tobuy, p.seuil_stock_alerte, p.desiredstock, SUM(s.reel) as stock_physique FROM llx_product as p LEFT JOIN llx_product_stock as s ON p.rowid = s.fk_product WHERE p.entity IN (1) AND EXISTS (SELECT e.rowid FROM llx_entrepot as e WHERE e.rowid = s.fk_entrepot AND e.entity IN (1)) AND p.fk_product_type <> '1' GROUP BY p.rowid, p.ref, p.label, p.barcode, p.price, p.price_ttc, p.price_base_type, p.entity, p.fk_product_type, p.tms, p.duration, p.tosell, p.tobuy, p.seuil_stock_alerte, p.desiredstock HAVING SUMCASEWHENs.reelISNULLTHEN0ELSEs.reelEND > 0 ORDER BY p.ref ASC LIMIT 26
Code retour dernier accès en base en erreur: DB_ERROR_NOSUCHFIELD
Information sur le dernier accès en base en erreur: Unknown column 'SUMCASEWHENs.reelISNULLTHEN0ELSEs.reelEND' in 'HAVING'
```

In the case we encountered, the error occurs on the `HAVING` part of the query, so I suggest moving calculations to the `SELECT` part, and only call `natural_search()` with the alias of such field.

Moreover, using `COALESCE()` is cleaner in this case, this function returns the first non-`NULL` argument it is given, so it simplifies those query elements.