### PR TITLE
FIX 20.0 ajax_constantonoff + FormSetup were ignoring custom css class

### DIFF
--- a/htdocs/core/class/html.formsetup.class.php
+++ b/htdocs/core/class/html.formsetup.class.php
@@ -899,9 +899,9 @@ class FormSetupItem
 			$out .=  $this->generateInputFieldColor();
 		} elseif ($this->type == 'yesno') {
 			if (!empty($conf->use_javascript_ajax)) {
-				$out .= ajax_constantonoff($this->confKey);
+				$out .= ajax_constantonoff($this->confKey, array(), null, 0, 0, 0, 2, 0, 0, '', '', $this->cssClass);
 			} else {
-				$out .= $this->form->selectyesno($this->confKey, $this->fieldValue, 1);
+				$out .= $this->form->selectyesno($this->confKey, $this->fieldValue, 1, false, 0, 0, $this->cssClass);
 			}
 		} elseif (preg_match('/emailtemplate:/', $this->type)) {
 			$out .= $this->generateInputFieldEmailTemplate();
@@ -1212,7 +1212,7 @@ class FormSetupItem
 			$out .=  $this->generateOutputFieldColor();
 		} elseif ($this->type == 'yesno') {
 			if (!empty($conf->use_javascript_ajax)) {
-				$out .= ajax_constantonoff($this->confKey, array(), $this->entity); // TODO possibility to add $input parameter
+				$out .= ajax_constantonoff($this->confKey, array(), $this->entity, 0, 0, 0, 2, 0, 0, '', '', $this->cssClass); // TODO possibility to add $input parameter
 			} else {
 				if ($this->fieldValue == 1) {
 					$out .= $langs->trans('yes');

--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -697,8 +697,8 @@ function ajax_constantonoff($code, $input = array(), $entity = null, $revertonof
 		</script>'."\n";
 
 		$out .= '<div id="confirm_'.$code.'" title="" style="display: none;"></div>';
-		$out .= '<span id="set_'.$code.'" class="valignmiddle inline-block linkobject '.(!empty($conf->global->$code) ? 'hideobject' : '').'">'.($revertonoff ? img_picto($langs->trans("Enabled"), 'switch_on', '', false, 0, 0, '', '', $marginleftonlyshort) : img_picto($langs->trans("Disabled"), 'switch_off', '', false, 0, 0, '', '', $marginleftonlyshort)).'</span>';
-		$out .= '<span id="del_'.$code.'" class="valignmiddle inline-block linkobject '.(!empty($conf->global->$code) ? '' : 'hideobject').'">'.($revertonoff ? img_picto($langs->trans("Disabled"), 'switch_off'.$suffix, '', false, 0, 0, '', '', $marginleftonlyshort) : img_picto($langs->trans("Enabled"), 'switch_on'.$suffix, '', false, 0, 0, '', '', $marginleftonlyshort)).'</span>';
+		$out .= '<span id="set_'.$code.'" class="valignmiddle inline-block linkobject '.(!empty($conf->global->$code) ? 'hideobject' : '').' '.$morecss.'">'.($revertonoff ? img_picto($langs->trans("Enabled"), 'switch_on', '', false, 0, 0, '', '', $marginleftonlyshort) : img_picto($langs->trans("Disabled"), 'switch_off', '', false, 0, 0, '', '', $marginleftonlyshort)).'</span>';
+		$out .= '<span id="del_'.$code.'" class="valignmiddle inline-block linkobject '.(!empty($conf->global->$code) ? '' : 'hideobject').' '.$morecss.'">'.($revertonoff ? img_picto($langs->trans("Disabled"), 'switch_off'.$suffix, '', false, 0, 0, '', '', $marginleftonlyshort) : img_picto($langs->trans("Enabled"), 'switch_on'.$suffix, '', false, 0, 0, '', '', $marginleftonlyshort)).'</span>';
 		$out .= "\n";
 	}
 


### PR DESCRIPTION
# FIX custom css class ignored in FormSetup for yes/no params

I was trying to add custom classes to a bunch of on/off buttons on a setup page (with the aim of selectively hiding some options when the "parent" option is disabled).

```php
$formSetup->newItem('PARENT_OPTION')->setAsYesNo();

// those two options should only be visible if the parent option is enabled.
$formSetup->newItem('CHILD_OPTION')->setAsYesNo()->cssClass = '--depends_PARENT_OPTION';
$formSetup->newItem('OTHER_CHILD_OPTION')->setAsYesNo()->cssClass = '--depends_PARENT_OPTION';
```

The CSS part is a bit ugly in v20.0 because of the way I have to check whether the const is on or off.
```css
table:has(#del_PARENT_OPTION[style*="display: none"]) tr:has(.--depends_PARENT_OPTION) {
    display: none;
}
```

But I found out that the custom css class wasn't put on the form element for yes/no inputs.

Side note: in future versions, it would be fantastic if the `ajax_constantonoff()` widget could wrap its elements in a div or span with a class indicating its state (`--on` for enabled, no class or `--off` for disabled).