### PR TITLE
Fix : resource list was inaccessible if only one resource

### DIFF
--- a/htdocs/resource/list.php
+++ b/htdocs/resource/list.php
@@ -85,6 +85,8 @@ if (empty($sortfield)) {
 	$sortfield = "t.ref";
 }
 
+$search_all = trim(GETPOST('search_all', 'alphanohtml'));
+
 // Load variable for pagination
 $limit	= GETPOSTINT('limit') ? GETPOSTINT('limit') : $conf->liste_limit;
 
@@ -349,7 +351,7 @@ if (!$resql) {
 $num = $db->num_rows($resql);
 
 // Direct jump if only one record found
-if ($num == 1 && getDolGlobalString('MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE') && !$page) {
+if ($num == 1 && getDolGlobalString('MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE') && $search_all && !$page) {
 	$obj = $db->fetch_object($resql);
 	$id = $obj->rowid;
 	header("Location: ".dol_buildpath('/resource/card.php', 1).'?id='.$id);


### PR DESCRIPTION
Due to the MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE setup, the list of resources was directly redirecting on the card when there was only one resource in the database. The global search for resources doesn't exist yet and this option is properly used when a search returns only one result