### PR TITLE
Fix #36019 : bank account count was wrong on thirdparty card

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -216,7 +216,7 @@ function societe_prepare_head(Societe $object)
 		$sql .= " FROM ".MAIN_DB_PREFIX."societe_rib as n";
 		$sql .= " WHERE n.fk_soc = ".((int) $object->id);
 		if (!isModEnabled('stripe')) {
-			$sql .= " AND n.stripe_card_ref IS NULL";
+			$sql .= " AND (n.stripe_card_ref IS NULL OR n.stripe_card_ref ='')";
 		} else {
 			$sql .= " AND (n.stripe_card_ref IS NULL OR (n.stripe_card_ref IS NOT NULL AND n.status = ".((int) $servicestatus)."))";
 		}


### PR DESCRIPTION
@eldy is this the right way to fix it ? Or should we force the stripe_card_ref to be null on UI creation instead of empty ?