### PR TITLE
Add isextrafieldmanaged property to salary class

### DIFF
--- a/htdocs/salaries/class/salary.class.php
+++ b/htdocs/salaries/class/salary.class.php
@@ -197,6 +197,7 @@ class Salary extends CommonObject
 		$this->db = $db;
 		$this->element = 'salary';
 		$this->table_element = 'salary';
+		$this->isextrafieldmanaged = 1;
 
 		$this->fields['ref_ext']['visible'] = getDolGlobalInt('MAIN_LIST_SHOW_REF_EXT');
 	}


### PR DESCRIPTION
FIX #36046 Extrafield's data for Salary was not deleted when Salary is deleted
Enabling extrafieldmanaged property to enable deletion of records from the llx_salay_extrafields table when delete a salary

