### PR TITLE
Fix: SQL compatibility, increase size for incoterms/code

### DIFF
--- a/htdocs/install/mysql/data/llx_c_incoterms.sql
+++ b/htdocs/install/mysql/data/llx_c_incoterms.sql
@@ -31,7 +31,6 @@
 --
 
 -- Incoterms officiels 2025 (CCI)
-ALTER TABLE llx_c_incoterms MODIFY code varchar(8) NOT NULL;
 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('EXW', 'Ex Works', 'Ex Works, au départ non chargé, non dédouané sortie d''usine (uniquement adapté aux flux domestiques, nationaux)', 1);
 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('FCA', 'Free Carrier', 'Free Carrier, marchandises dédouanées et chargées dans le pays de départ, chez le vendeur ou chez le commissionnaire de transport de l''acheteur', 1);
 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('FAS', 'Free Alongside Ship', 'Free Alongside Ship, sur le quai du port de départ', 1);

--- a/htdocs/install/mysql/data/llx_c_incoterms.sql
+++ b/htdocs/install/mysql/data/llx_c_incoterms.sql
@@ -31,6 +31,7 @@
 --
 
 -- Incoterms officiels 2025 (CCI)
+ALTER TABLE llx_c_incoterms MODIFY code varchar(8) NOT NULL;
 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('EXW', 'Ex Works', 'Ex Works, au départ non chargé, non dédouané sortie d''usine (uniquement adapté aux flux domestiques, nationaux)', 1);
 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('FCA', 'Free Carrier', 'Free Carrier, marchandises dédouanées et chargées dans le pays de départ, chez le vendeur ou chez le commissionnaire de transport de l''acheteur', 1);
 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('FAS', 'Free Alongside Ship', 'Free Alongside Ship, sur le quai du port de départ', 1);

--- a/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
+++ b/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
@@ -271,28 +271,39 @@ ALTER TABLE llx_blockedlog ADD COLUMN linktype varchar(16);
 ALTER TABLE llx_blockedlog ADD COLUMN vat double(24,8) DEFAULT NULL;
 
 
+WHERE code = 'CIP';
 -- Incoterms 2025 and specific terms
-
 -- DAT is replaced by DPU - but not deactivating for existing installations
 -- UPDATE llx_c_incoterms SET active = 0 WHERE code = 'DAT';
 
--- Add new 2025 Incoterms and specific terms
-INSERT INTO llx_c_incoterms (code, label, libelle, active)
-VALUES
-    ('DPU', 'Delivered at Place Unloaded', 'Delivered at Place Unloaded, marchandises déchargées et livrées au lieu de destination désigné (remplace DAT, élargit les lieux de livraison possibles)', 1),
-    ('DTP', 'Delivered at Terminal Paid', 'Delivered at Terminal Paid, marchandises livrées et dédouanées dans un terminal du pays de destination', 0),
-    ('DPP', 'Delivered at Place Paid', 'Delivered at Place Paid, marchandises livrées et dédouanées à une adresse précise du pays de destination', 0),
-    ('DTP(DHL)', 'Duties and Taxes Paid', 'Duties and Taxes Paid (service DHL) : l''expéditeur paie les droits de douane et taxes à l''importation (spécifique à DHL)', 0)
-ON CONFLICT (code) DO NOTHING;
+-- Add new 2025 Incoterms and specific terms when they do not exist
+ALTER TABLE llx_c_incoterms MODIFY code varchar(8) NOT NULL;
+
+-- For MySQL and MariaDB:
+-- VMYSQL5.7 INSERT IGNORE INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPU', 'Delivered at Place Unloaded', 'Delivered at Place Unloaded, marchandises déchargées et livrées au lieu de destination désigné (remplace DAT, élargit les lieux de livraison possibles)', 1);
+-- VMYSQL5.7 INSERT IGNORE INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP', 'Delivered at Terminal Paid', 'Delivered at Terminal Paid, marchandises livrées et dédouanées dans un terminal du pays de destination', 0);
+-- VMYSQL5.7 INSERT IGNORE INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPP', 'Delivered at Place Paid', 'Delivered at Place Paid, marchandises livrées et dédouanées à une adresse précise du pays de destination', 0);
+-- VMYSQL5.7 INSERT IGNORE INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP(DHL)', 'Duties and Taxes Paid', 'Duties and Taxes Paid (service DHL) : l''expéditeur paie les droits de douane et taxes à l''importation (spécifique à DHL)', 0);
+
+-- For PostgreSQL:
+-- VPGSQL9.5 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPU', 'Delivered at Place Unloaded', 'Delivered at Place Unloaded, marchandises déchargées et livrées au lieu de destination désigné (remplace DAT, élargit les lieux de livraison possibles)', 1) ON CONFLICT DO NOTHING;
+-- VPGSQL9.5 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP', 'Delivered at Terminal Paid', 'Delivered at Terminal Paid, marchandises livrées et dédouanées dans un terminal du pays de destination', 0) ON CONFLICT DO NOTHING;
+-- VPGSQL9.5 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPP', 'Delivered at Place Paid', 'Delivered at Place Paid, marchandises livrées et dédouanées à une adresse précise du pays de destination', 0) ON CONFLICT DO NOTHING;
+-- VPGSQL9.5 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP(DHL)', 'Duties and Taxes Paid', 'Duties and Taxes Paid (service DHL) : l''expéditeur paie les droits de douane et taxes à l''importation (spécifique à DHL)', 0) ON CONFLICT DO NOTHING;
+
+-- Update existing Incoterms descriptions
 UPDATE llx_c_incoterms
 SET libelle = 'Cost and Freight, chargé dans le bateau, livraison au port de départ, frais payés jusqu''au port d''arrivée, sans assurance pour le transport, non déchargé du navire à destination (les frais de déchargement sont inclus ou non au port d''arrivée)'
 WHERE code = 'CFR';
+
 UPDATE llx_c_incoterms
 SET libelle = 'Cost, Insurance and Freight, chargé sur le bateau, frais jusqu''au port d''arrivée, avec l''assurance marchandise transportée souscrite par le vendeur pour le compte de l''acheteur (couverture standard, 10% de la valeur commerciale)'
 WHERE code = 'CIF';
+
 UPDATE llx_c_incoterms
 SET libelle = 'Carriage and Insurance Paid to, idem CPT, avec assurance marchandise transportée souscrite par le vendeur pour le compte de l''acheteur (couverture tous risques)'
 WHERE code = 'CIP';
+
 
 
 -- Fix a wrong migration script

--- a/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
+++ b/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
@@ -271,7 +271,6 @@ ALTER TABLE llx_blockedlog ADD COLUMN linktype varchar(16);
 ALTER TABLE llx_blockedlog ADD COLUMN vat double(24,8) DEFAULT NULL;
 
 
-WHERE code = 'CIP';
 -- Incoterms 2025 and specific terms
 -- DAT is replaced by DPU - but not deactivating for existing installations
 -- UPDATE llx_c_incoterms SET active = 0 WHERE code = 'DAT';
@@ -280,16 +279,10 @@ WHERE code = 'CIP';
 ALTER TABLE llx_c_incoterms MODIFY code varchar(8) NOT NULL;
 
 -- For MySQL and MariaDB:
--- VMYSQL5.7 INSERT IGNORE INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPU', 'Delivered at Place Unloaded', 'Delivered at Place Unloaded, marchandises déchargées et livrées au lieu de destination désigné (remplace DAT, élargit les lieux de livraison possibles)', 1);
--- VMYSQL5.7 INSERT IGNORE INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP', 'Delivered at Terminal Paid', 'Delivered at Terminal Paid, marchandises livrées et dédouanées dans un terminal du pays de destination', 0);
--- VMYSQL5.7 INSERT IGNORE INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPP', 'Delivered at Place Paid', 'Delivered at Place Paid, marchandises livrées et dédouanées à une adresse précise du pays de destination', 0);
--- VMYSQL5.7 INSERT IGNORE INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP(DHL)', 'Duties and Taxes Paid', 'Duties and Taxes Paid (service DHL) : l''expéditeur paie les droits de douane et taxes à l''importation (spécifique à DHL)', 0);
-
--- For PostgreSQL:
--- VPGSQL9.5 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPU', 'Delivered at Place Unloaded', 'Delivered at Place Unloaded, marchandises déchargées et livrées au lieu de destination désigné (remplace DAT, élargit les lieux de livraison possibles)', 1) ON CONFLICT DO NOTHING;
--- VPGSQL9.5 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP', 'Delivered at Terminal Paid', 'Delivered at Terminal Paid, marchandises livrées et dédouanées dans un terminal du pays de destination', 0) ON CONFLICT DO NOTHING;
--- VPGSQL9.5 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPP', 'Delivered at Place Paid', 'Delivered at Place Paid, marchandises livrées et dédouanées à une adresse précise du pays de destination', 0) ON CONFLICT DO NOTHING;
--- VPGSQL9.5 INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP(DHL)', 'Duties and Taxes Paid', 'Duties and Taxes Paid (service DHL) : l''expéditeur paie les droits de douane et taxes à l''importation (spécifique à DHL)', 0) ON CONFLICT DO NOTHING;
+INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPU', 'Delivered at Place Unloaded', 'Delivered at Place Unloaded, marchandises déchargées et livrées au lieu de destination désigné (remplace DAT, élargit les lieux de livraison possibles)', 1);
+INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP', 'Delivered at Terminal Paid', 'Delivered at Terminal Paid, marchandises livrées et dédouanées dans un terminal du pays de destination', 0);
+INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DPP', 'Delivered at Place Paid', 'Delivered at Place Paid, marchandises livrées et dédouanées à une adresse précise du pays de destination', 0);
+INSERT INTO llx_c_incoterms (code, label, libelle, active) VALUES ('DTP(DHL)', 'Duties and Taxes Paid', 'Duties and Taxes Paid (service DHL) : l''expéditeur paie les droits de douane et taxes à l''importation (spécifique à DHL)', 0);
 
 -- Update existing Incoterms descriptions
 UPDATE llx_c_incoterms

--- a/htdocs/install/mysql/tables/llx_c_incoterms.sql
+++ b/htdocs/install/mysql/tables/llx_c_incoterms.sql
@@ -19,9 +19,8 @@
 
 CREATE TABLE llx_c_incoterms (
   rowid integer AUTO_INCREMENT PRIMARY KEY,
-  code varchar(3) NOT NULL,
+  code varchar(8) NOT NULL,
   label varchar(100),
   libelle varchar(255) NOT NULL,
   active tinyint DEFAULT 1  NOT NULL
 ) ENGINE=innodb;
-


### PR DESCRIPTION
# Fix: SQL compatibility, increase size for incoterms/code
    
- Modify llx_c_incoterms table to increase code field length
- Use `INSERT IGNORE` or `ON CONFLICT` depending on db type