### PR TITLE
Remove obsolete check for MAIN_MODULE_OPENIDCONNECT during login

### DIFF
--- a/htdocs/core/login/functions_openid_connect.php
+++ b/htdocs/core/login/functions_openid_connect.php
@@ -42,7 +42,7 @@ function check_user_password_openid_connect($usertotest, $passwordtotest, $entit
 {
 	global $db;
 
-	if (getDolGlobalInt('MAIN_MODULE_OPENIDCONNECT', 0) <= 0) {
+	if (getDolGlobalInt('MAIN_AUTHENTICATION_OIDC_ON', 0) <= 0) {
 		$_SESSION["dol_loginmesg"] = "OpenID Connect is disabled";
 		dol_syslog("functions_openid_connect::check_user_password_openid_connect Module disabled");
 		return false;

--- a/htdocs/core/tpl/login.tpl.php
+++ b/htdocs/core/tpl/login.tpl.php
@@ -173,7 +173,7 @@ if (getDolGlobalString('MAIN_OPTIMIZEFORTEXTBROWSER')) {
 }
 
 // If OpenID Connect is set as an authentication
-if (getDolGlobalInt('MAIN_MODULE_OPENIDCONNECT', 0) > 0 && isset($conf->file->main_authentication) && preg_match('/openid_connect/', $conf->file->main_authentication)) {
+if (getDolGlobalInt('MAIN_AUTHENTICATION_OIDC_ON', 0) > 0 && isset($conf->file->main_authentication) && preg_match('/openid_connect/', $conf->file->main_authentication)) {
 	// Set a cookie to transfer rollback page information
 	$prefix = dol_getprefix('');
 	if (empty($_COOKIE["DOL_rollback_url_$prefix"])) {
@@ -445,7 +445,7 @@ if ($forgetpasslink || $helpcenterlink) {
 	echo '</div>';
 }
 
-if (getDolGlobalInt('MAIN_MODULE_OPENIDCONNECT', 0) > 0 && isset($conf->file->main_authentication) && preg_match('/openid/', $conf->file->main_authentication)) {
+if (getDolGlobalInt('MAIN_AUTHENTICATION_OIDC_ON', 0) > 0 && isset($conf->file->main_authentication) && preg_match('/openid/', $conf->file->main_authentication)) {
 	dol_include_once('/core/lib/openid_connect.lib.php');
 	$langs->load("users");
 

--- a/htdocs/user/logout.php
+++ b/htdocs/user/logout.php
@@ -108,7 +108,7 @@ if (GETPOST('dol_use_jmobile')) {
 }
 
 // Logout openid_connect sessions using OIDC logout URL if defined
-if (getDolGlobalInt('MAIN_MODULE_OPENIDCONNECT', 0) > 0 && !empty($_SESSION['OPENID_CONNECT']) && getDolGlobalString("MAIN_AUTHENTICATION_OIDC_LOGOUT_URL")) {
+if (getDolGlobalInt('MAIN_AUTHENTICATION_OIDC_ON', 0) > 0 && !empty($_SESSION['OPENID_CONNECT']) && getDolGlobalString("MAIN_AUTHENTICATION_OIDC_LOGOUT_URL")) {
 	// We need the full URL
 	if (strpos($url, '/') === 0) {
 		$url = DOL_MAIN_URL_ROOT . $url;


### PR DESCRIPTION
# FIX #36048 replace var MAIN_MODULE_OPENIDCONNECT with MAIN_AUTHENTICATION_OIDC_ON because openid_connect is integrated into the core
This PR is an attempt to fix #36048, which happens when you set 
```
$dolibarr_main_authentication='openid_connect,dolibarr';
```
and have configured the openid_connect settings in `/admin/openid_connect.php`
