### PR TITLE
Fix: Uniform `assign_values` method signatures

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -77,7 +77,7 @@ return [
         'htdocs/core/ajax/ajaxdirtree.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanUndeclaredGlobalVariable'],
         'htdocs/core/ajax/selectobject.php' => ['PhanTypeMismatchArgumentNullable'],
         'htdocs/core/class/CMailFile.class.php' => ['PhanTypeMismatchArgument'],
-        'htdocs/core/class/canvas.class.php' => ['PhanParamTooMany', 'PhanUndeclaredMethod'],
+        'htdocs/core/class/canvas.class.php' => ['PhanUndeclaredMethod'],
         'htdocs/core/class/ccountry.class.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/class/cgenericdic.class.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/class/commonobject.class.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanUndeclaredProperty'],

--- a/htdocs/adherents/canvas/actions_adherentcard_common.class.php
+++ b/htdocs/adherents/canvas/actions_adherentcard_common.class.php
@@ -93,11 +93,12 @@ abstract class ActionsAdherentCardCommon
 	/**
 	 *  Set content of ->tpl array, to use into template
 	 *
-	 *  @param	string		$action    Type of action
+	 *  @param	string		$action		Type of action
 	 *  @param	int			$id			Id
+	 * 	@param	string		$ref		Object ref (if id not provided) / Unused here
 	 *  @return	void
 	 */
-	public function assign_values(&$action, $id)
+	public function assign_values(&$action, $id, $ref = '')
 	{
 		// phpcs:enable
 		global $conf, $langs, $user, $canvas;

--- a/htdocs/adherents/canvas/default/actions_adherentcard_default.class.php
+++ b/htdocs/adherents/canvas/default/actions_adherentcard_default.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2011		Laurent Destailleur	<eldy@users.sourceforge.net>
  * Copyright (C) 2012-2018  Philippe Grand      <philippe.grand@atoo-net.com>
  * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -78,11 +79,12 @@ class ActionsAdherentCardDefault extends ActionsAdherentCardCommon
 	/**
 	 *  Assign custom values for canvas
 	 *
-	 *  @param	string		$action    	Type of action
-	 *  @param	int			$id				Id
+	 *  @param	string		$action		Type of action
+	 *  @param	int			$id			Id
+	 * 	@param	string		$ref		Object ref (if id not provided) / Unused here
 	 *  @return	void
 	 */
-	public function assign_values(&$action, $id)
+	public function assign_values(&$action, $id, $ref = '')
 	{
 		// phpcs:enable
 		global $conf, $db, $langs, $user;
@@ -90,7 +92,7 @@ class ActionsAdherentCardDefault extends ActionsAdherentCardCommon
 
 		$ret = $this->getObject($id);
 
-		parent::assign_values($action, $id);
+		parent::assign_values($action, $id, $ref);
 
 		$this->tpl['title'] = $this->getTitle($action);
 		$this->tpl['error'] = $this->error;

--- a/htdocs/contact/canvas/actions_contactcard_common.class.php
+++ b/htdocs/contact/canvas/actions_contactcard_common.class.php
@@ -102,11 +102,12 @@ abstract class ActionsContactCardCommon
 	/**
 	 *  Set content of ->tpl array, to use into template
 	 *
-	 *  @param	string		$action    Type of action
+	 *  @param	string		$action		Type of action
 	 *  @param	int			$id			Id
+	 * 	@param	string		$ref		Object ref (if id not provided) / Unused here
 	 *  @return	void
 	 */
-	public function assign_values(&$action, $id)
+	public function assign_values(&$action, $id, $ref = '')
 	{
 		// phpcs:enable
 		global $conf, $langs, $user, $canvas;

--- a/htdocs/contact/canvas/default/actions_contactcard_default.class.php
+++ b/htdocs/contact/canvas/default/actions_contactcard_default.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2010-2012	Regis Houssin		<regis.houssin@inodbox.com>
  * Copyright (C) 2011		Laurent Destailleur	<eldy@users.sourceforge.net>
+ * Copyright (C) 2025		MDW					<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -77,10 +78,11 @@ class ActionsContactCardDefault extends ActionsContactCardCommon
 	 *  Assign custom values for canvas
 	 *
 	 *  @param	string		$action    	Type of action
-	 *  @param	int			$id				Id
+	 *  @param	int			$id			Id
+	 * 	@param	string		$ref		Object ref (if id not provided) / Unused here
 	 *  @return	void
 	 */
-	public function assign_values(&$action, $id)
+	public function assign_values(&$action, $id, $ref = '')
 	{
 		// phpcs:enable
 		global $conf, $db, $langs, $user;
@@ -88,7 +90,7 @@ class ActionsContactCardDefault extends ActionsContactCardCommon
 
 		$ret = $this->getObject($id);
 
-		parent::assign_values($action, $id);
+		parent::assign_values($action, $id, $ref);
 
 		$this->tpl['title'] = $this->getTitle($action);
 		$this->tpl['error'] = $this->error;


### PR DESCRIPTION
# Fix: Uniform `assign_values` method signatures

`Canvas` is calling `assign_values` with three arguments, so all methods must have three arguments.

- Modified `actions_adherentcard_common.class.php` and `actions_contactcard_common.class.php` to add object reference parameter
- Updated `actions_adherentcard_default.class.php` and `actions_contactcard_default.class.php` to pass reference parameter to parent class
- Updated Phan baseline to reflect fix