### PR TITLE
FIX 16.0: extrafield of type link to category causes SQL error in selectForFormsList()

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -7698,7 +7698,7 @@ class Form
 			if ($tmpfieldstoshow) {
 				$fieldstoshow = $tmpfieldstoshow;
 			}
-		} else if ($objecttmp === 'categorie') {
+		} else if ($objecttmp->element === 'category') {
 			$fieldstoshow = 't.label';
 		} else {
 			// For backward compatibility

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -7698,6 +7698,8 @@ class Form
 			if ($tmpfieldstoshow) {
 				$fieldstoshow = $tmpfieldstoshow;
 			}
+		} else if ($objecttmp === 'categorie') {
+			$fieldstoshow = 't.label';
 		} else {
 			// For backward compatibility
 			$objecttmp->fields['ref'] = array('type'=>'varchar(30)', 'label'=>'Ref', 'showoncombobox'=>1);


### PR DESCRIPTION
# FIX link-to-category extrafield causes SQL error
## How to reproduce?
In Dolibarr 17, 18 or 19:

1. Enable modules: project and categories.
2. Navigate to the setup page of the Projects / Opportunities module
3. Create an extrafield of type "link to an object" with value: `Categorie:categories/class/categorie.class.php`
4. Navigate to the list of projects

→ there is a non-blocking SQL error when displaying the filter for the column of the extrafield: 
```
Unknown column 't.ref' in 'SELECT'
```

## Versions of Dolibarr
The bug is present in Dolibarr 17 to 19. [edit] maybe in Dolibarr 16 too but I didn't test my fix there

In Dolibarr 20 and higher, the Categorie class has a `fields` property that is properly set up, which fixes this problem in a much cleaner way, so no need keep this fix in v20 and higher.

## This fix
This just checks whether the object element is `categorie` and, if so, forces `label` instead of `ref` as the field to select.
