### PR TITLE
NEW: Clickable links from PROFIT section #31748

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -869,6 +869,7 @@ if (isModEnabled('stock')) {
 	$langs->load('stocks');
 }
 
+print '<!-- Begin PROFIT table -->';
 print load_fiche_titre($langs->trans("Profit"), '', 'title_accountancy');
 
 print '<table class="noborder centpercent">';
@@ -1079,7 +1080,8 @@ foreach ($listofreferent as $key => $value) {
 
 			print '<tr class="oddeven">';
 			// Module
-			print '<td class="left">'.$name.'</td>';
+			print '<!-- // Module '.$name.' with tablename '.$tablename.' -->';
+			print '<td class="left"><a href="#table_'.$tablename.'">'.$name.'</a></td>';
 			// Nb
 			print '<td class="right">'.$i.'</td>';
 			// Amount HT
@@ -1148,6 +1150,7 @@ if ($total_revenue_ht) {
 }
 
 print "</table>";
+print '<!-- End PROFIT table -->';
 
 
 print '<br><br>';
@@ -1288,6 +1291,7 @@ foreach ($listofreferent as $key => $value) {
 						 </script></div>';
 		}
 
+		print '<a id="table_'.$tablename.'"></a>';
 		print load_fiche_titre($langs->trans($title), $addform, '');
 
 		print "\n".'<!-- Table for tablename = '.$tablename.' -->'."\n";


### PR DESCRIPTION
# NEW Clickable links from PROFIT section of Project down to details further down
This PR closes #31748 and it adds clickable links in the profit section in the top of the project overview page. A click on these links will jump further down the same page to the corresponding section, making it super easy to jump inside the page.

<img width="1443" height="486" alt="profit_section_with_links" src="https://github.com/user-attachments/assets/b5cdb4f6-7cac-4065-a6b7-c510bdfd53d6" />

clicking "vendor invoices" will jump to:
<img width="1444" height="493" alt="vendor_invoice_section" src="https://github.com/user-attachments/assets/64d644f2-a326-4e50-a09c-c67ccad637e4" />
