### PR TITLE
FIX: Add missing left join to filter by extrafields

### DIFF
--- a/htdocs/webportal/class/html.formwebportal.class.php
+++ b/htdocs/webportal/class/html.formwebportal.class.php
@@ -387,7 +387,6 @@ class FormWebPortal extends Form
 		$classpath = $InfoFieldList[1];
 		$filter = empty($InfoFieldList[3]) ? '' : $InfoFieldList[3];
 		$sortfield = empty($InfoFieldList[4]) ? '' : $InfoFieldList[4];
-
 		if (!empty($classpath)) {
 			dol_include_once($classpath);
 
@@ -490,6 +489,10 @@ class FormWebPortal extends Form
 				$tmparray = explode('@', $objecttmp->ismultientitymanaged);
 				$sql .= " INNER JOIN " . $this->db->prefix() . $tmparray[1] . " as parenttable ON parenttable.rowid = t." . $tmparray[0];
 			}
+		}
+
+		if (!empty($objecttmp->isextrafieldmanaged)) {
+			$sql .= " LEFT JOIN " . $this->db->prefix() . $this->db->sanitize($objecttmp->table_element) . "_extrafields as e ON t.rowid = e.fk_object";
 		}
 
 		// Add where from hooks


### PR DESCRIPTION
On the web portal pages, it was not possible to add a filter on extrafields.
I change the behavior to match standard html.form.class.php::selectForFormsList()