### PR TITLE
FIX: getEntity returns an invalid SQL string (e.g., '0,')

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -517,7 +517,6 @@ function getEntity($element, $shared = 1, $currentobject = null)
 			$element = 'supplier_invoice';
 			break; // "/fourn/class/fournisseur.facture.class.php"
 	}
-
 	if (is_object($mc)) {
 		$out = $mc->getEntity($element, $shared, $currentobject);
 	} else {
@@ -550,7 +549,9 @@ function getEntity($element, $shared = 1, $currentobject = null)
 			$out = $hookmanager->resPrint; // replace
 		}
 	}
-
+	if (substr(trim($out), -1) == ',') {
+		$out .= ((int) $conf->entity);
+	}
 	return $out;
 }
 


### PR DESCRIPTION

Context: This issue was identified on a fresh Dolibarr installation.

Problem: The getEntity('user') function can return a string ending with a comma (e.g., '0,').

When this value is used in an SQL IN() clause, such as in the loadStateBoard() method, the generated query (... WHERE u.entity IN ('0,')) is syntactically incorrect and fails.

Solution: A check has been added to the end of the getEntity() function:

If the $out string ends with a comma, the current entity ID ($conf->entity) is appended to it.

Example: '0,' becomes '0,1' (if $conf->entity = 1).

This ensures the function always returns a list that is syntactically valid for an SQL IN() clause.
