### PR TITLE
FIX Select correct approver when making a leave request for someone else

### DIFF
--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -1164,6 +1164,12 @@ if ((empty($id) && empty($ref)) || $action == 'create' || $action == 'add') {
 			// Defined default approver (the forced approved of user or the supervisor if no forced value defined)
 			// Note: This use will be set only if the deinfed approvr has permission to approve so is inside include_users
 			$defaultselectuser = (empty($user->fk_user_holiday_validator) ? $user->fk_user : $user->fk_user_holiday_validator);
+			if ($fuserid != $user->id) {
+				$target = new User($db);
+				$target->fetch($fuserid);
+				$defaultselectuser = (empty($target->fk_user_holiday_validator) ? $target->fk_user : $target->fk_user_holiday_validator);
+			}
+
 			if (getDolGlobalString('HOLIDAY_DEFAULT_VALIDATOR')) {
 				$defaultselectuser = getDolGlobalString('HOLIDAY_DEFAULT_VALIDATOR'); // Can force default approver
 			}

--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -1161,13 +1161,13 @@ if ((empty($id) && empty($ref)) || $action == 'create' || $action == 'add') {
 		if (empty($include_users)) {
 			print img_warning().' '.$langs->trans("NobodyHasPermissionToValidateHolidays");
 		} else {
-			// Defined default approver (the forced approved of user or the supervisor if no forced value defined)
-			// Note: This use will be set only if the deinfed approvr has permission to approve so is inside include_users
+			// Defined default approver (the forced approver of edited user or the supervisor of user if no forced value defined)
+			// Note: This user will be set only if the defined approver has permission to approve so is inside include_users
 			$defaultselectuser = (empty($user->fk_user_holiday_validator) ? $user->fk_user : $user->fk_user_holiday_validator);
 			if ($fuserid != $user->id) {
-				$target = new User($db);
-				$target->fetch($fuserid);
-				$defaultselectuser = (empty($target->fk_user_holiday_validator) ? $target->fk_user : $target->fk_user_holiday_validator);
+				$fuser = new User($db);
+				$fuser->fetch($fuserid);
+				$defaultselectuser = (empty($fuser->fk_user_holiday_validator) ? $fuser->fk_user : $fuser->fk_user_holiday_validator);
 			}
 
 			if (getDolGlobalString('HOLIDAY_DEFAULT_VALIDATOR')) {


### PR DESCRIPTION
# FIX Select correct approver when making a leave request for someone else

As long as you have the correct permissions, you can create a leave request for a colleague. You can go to `/htdocs/holiday/list.php?id={id_colleague}`, and there will be a button there, "Make a leave request". You are then redirected to the "new leave request" form, with the colleague preselected as user. The problem is, your own supervisor is also preselected, not theirs. It could lead to a leave request sent to the wrong approver. 

This PR fixes the problem by looking if we are in this case, and if yes, select the colleague's supervisor (or the designated approver) instead of the connected user's supervisor.

Steps to reproduce:

Given the following hierachy:
<img width="319" height="179" alt="image" src="https://github.com/user-attachments/assets/fc629d04-bc39-4308-a1ab-9045a123fb70" />

BEFORE: 
When I create a leave request for my colleague, it's my own supervisor that is selected by default
<img width="629" height="350" alt="image" src="https://github.com/user-attachments/assets/d43250ea-6419-4c23-a9dd-bdd8fbb5e35a" />

AFTER:
Now, their supervisor is selected by default, even if it's not my supervisor
<img width="618" height="421" alt="image" src="https://github.com/user-attachments/assets/e4ad130c-8aa5-4904-9fd8-edddde8056f1" />
