### PR TITLE
Add phone info in form public/members/new.php

### DIFF
--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -907,15 +907,15 @@ if (getDolGlobalString('MEMBER_SKIP_TABLE') || getDolGlobalString('MEMBER_NEWFOR
 
 	// Pro phone
 	print '<tr><td>'.$langs->trans("PhonePro").'</td>';
-	print '<td>'.img_picto('', 'object_phoning', 'class="pictofixedwidth"').'<input type="text" name="phone" size="20" value="'.dol_escape_htmltag(GETPOSTISSET('phone')).'"></td></tr>';
+	print '<td>'.img_picto('', 'object_phoning', 'class="pictofixedwidth"').'<input type="text" name="phone" size="20" value="'.dol_escape_htmltag(GETPOST('phone')).'"></td></tr>';
 
 	// Personal phone
 	print '<tr><td>'.$langs->trans("PhonePerso").'</td>';
-	print '<td>'.img_picto('', 'object_phoning', 'class="pictofixedwidth"').'<input type="text" name="phone_perso" size="20" value="'.dol_escape_htmltag(GETPOSTISSET('phone_perso')).'"></td></tr>';
+	print '<td>'.img_picto('', 'object_phoning', 'class="pictofixedwidth"').'<input type="text" name="phone_perso" size="20" value="'.dol_escape_htmltag(GETPOST('phone_perso')).'"></td></tr>';
 
 	// Mobile phone
 	print '<tr><td>'.$langs->trans("PhoneMobile").'</td>';
-	print '<td>'.img_picto('', 'object_phoning_mobile', 'class="pictofixedwidth"').'<input type="text" name="phone_mobile" size="20" value="'.dol_escape_htmltag(GETPOSTISSET('phone_mobile')).'"></td></tr>';
+	print '<td>'.img_picto('', 'object_phoning_mobile', 'class="pictofixedwidth"').'<input type="text" name="phone_mobile" size="20" value="'.dol_escape_htmltag(GETPOST('phone_mobile')).'"></td></tr>';
 
 	// Birthday
 	print '<tr id="trbirth" class="trbirth"><td>'.$langs->trans("DateOfBirth").'</td><td>';

--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -419,6 +419,9 @@ if (empty($reshook) && $action == 'add') {	// Test on permission not required he
 		$adh->note_private = GETPOST('note_private');
 		$adh->morphy      = getDolGlobalString("MEMBER_NEWFORM_FORCEMORPHY", GETPOST('morphy'));
 		$adh->birth       = $birthday;
+		$adh->phone   = GETPOST('phone');
+		$adh->phone_perso = GETPOST('phone_perso');
+		$adh->phone_mobile= GETPOST('phone_mobile');
 
 		$adh->ip = getUserRemoteIP();
 
@@ -901,6 +904,18 @@ if (getDolGlobalString('MEMBER_SKIP_TABLE') || getDolGlobalString('MEMBER_NEWFOR
 		}
 		print '</td></tr>';
 	}
+
+	// Pro phone
+	print '<tr><td>'.$langs->trans("PhonePro").'</td>';
+	print '<td>'.img_picto('', 'object_phoning', 'class="pictofixedwidth"').'<input type="text" name="phone" size="20" value="'.dol_escape_htmltag(GETPOSTISSET('phone')).'"></td></tr>';
+
+	// Personal phone
+	print '<tr><td>'.$langs->trans("PhonePerso").'</td>';
+	print '<td>'.img_picto('', 'object_phoning', 'class="pictofixedwidth"').'<input type="text" name="phone_perso" size="20" value="'.dol_escape_htmltag(GETPOSTISSET('phone_perso')).'"></td></tr>';
+
+	// Mobile phone
+	print '<tr><td>'.$langs->trans("PhoneMobile").'</td>';
+	print '<td>'.img_picto('', 'object_phoning_mobile', 'class="pictofixedwidth"').'<input type="text" name="phone_mobile" size="20" value="'.dol_escape_htmltag(GETPOSTISSET('phone_mobile')).'"></td></tr>';
 
 	// Birthday
 	print '<tr id="trbirth" class="trbirth"><td>'.$langs->trans("DateOfBirth").'</td><td>';


### PR DESCRIPTION

# FIX #35050

This PR adds missing phone number fields to the public member registration form ([new.php](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) to match the functionality available in the admin member card form.

Problem
The public registration form was missing phone number input fields, preventing new members from providing their contact information during self-registration. This created an inconsistency with the admin interface where phone fields are available.
