### PR TITLE
FIX Invoice Situation - Octopus - Shipping block overlap issue

### DIFF
--- a/htdocs/core/modules/facture/doc/pdf_octopus.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_octopus.modules.php
@@ -581,7 +581,12 @@ class pdf_octopus extends ModelePDFFactures
 				$nexY = $this->tab_top - 1;
 
 				// Specific stuff for situations invoices first page
-				$tab_top = 90;
+				if (getDolGlobalInt('INVOICE_SHOW_SHIPPING_ADDRESS')) {
+					$tab_top = 130;
+				} else {
+					$tab_top = 90;
+				}
+
 				$tab_height = 130;
 				$tab_height_newpage = 150;
 
@@ -2476,6 +2481,8 @@ class pdf_octopus extends ModelePDFFactures
 				}
 				if (!empty($carac_client_shipping)) {
 					$posy += $hautcadre;
+
+					$hautcadre -= 10;	// Height for the shipping address does not need to be as high as main box
 
 					// Show shipping frame
 					$pdf->SetXY($posx + 2, $posy - 5);


### PR DESCRIPTION
Overlap issue on octopus model

### Before

<img width="750" height="564" alt="Capture d’écran du 2025-11-06 06-04-31" src="https://github.com/user-attachments/assets/81fc0508-a93e-4cbe-b564-494334b9f291" />

### After

<img width="750" height="564" alt="Capture d’écran du 2025-11-06 06-22-16" src="https://github.com/user-attachments/assets/78e51233-9c6d-430f-ab06-c02a57ad6812" />

### And Without shipping address:

<img width="750" height="564" alt="image" src="https://github.com/user-attachments/assets/90f3e2bd-0b19-41be-b530-bd7800010a01" />
