### PR TITLE
FIX: dol_escape_htmltag in extrafields_view

### DIFF
--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -259,7 +259,7 @@ if (empty($reshook) && !empty($object->table_element) && isset($extrafields->att
 			} else {
 				//var_dump($tmpkeyextra.'-'.$value.'-'.$object->table_element);
 				print $extrafields->showOutputField($tmpkeyextra, $value, '', $object->table_element);
-				print '<input type="hidden" value="' . $value . '" name="options_' . $tmpkeyextra . '" id="options_' . $tmpkeyextra . '"/>'; // it's needed when to get parent value when extra-field list depend on parent extra-field list
+				print '<input type="hidden" value="' . dol_escape_htmltag($value) . '" name="options_' . dol_escape_htmltag($tmpkeyextra) . '" id="options_' . dol_escape_htmltag($tmpkeyextra) . '"/>'; // it's needed when to get parent value when extra-field list depend on parent extra-field list
 			}
 
 			print '</td>';


### PR DESCRIPTION
# FIX: Use dol_escape_htmltag() in extrafields_view

$value may contain double quotes or other HTML special characters which can break input fields by closing the value attribute prematurely and corrupt the DOM display. 

Fix: escape $value using dol_escape_htmltag() to ensure safe HTML output.