### PR TITLE
FIX: doubled display of Product Stokable checkbox when STOCK_SUPPORTS_SERVICES on service card in edit mode

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -2340,12 +2340,6 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 					print '</label>';
 
 					print '</td></tr>';
-
-					if (isModEnabled('stock') && getDolGlobalString('STOCK_SUPPORTS_SERVICES')) {
-						print '<tr><td>' . $langs->trans("StockableProduct") . '</td>';
-						$checked = $object->stockable_product == 1 ? "checked" : "";
-						print '<td><input type="checkbox" id="stockable_product" name="stockable_product" ' . $checked . ' /></td></tr>';
-					}
 				} else {
 					if (!getDolGlobalString('PRODUCT_DISABLE_NATURE')) {
 						// Nature


### PR DESCRIPTION
How to reproduce :
In stock module settings set Use stock for services

Go to a service card, edit it, the checkbox is displayed two times :

There is no need to print HTML for this field here L.2343 because just before
https://github.com/Dolibarr/dolibarr/blob/3cc6f830d27e8a7128e08c24b776cedea84cee90/htdocs/product/card.php#L2279
the condition is `isProduct **OR** STOCK_SUPPORTS_SERVICES` is already OK



Before:
<img width="815" height="654" alt="image" src="https://github.com/user-attachments/assets/12a2f8ea-f9b6-4aaa-b090-f4f8175b5ed3" />

After:
<img width="651" height="626" alt="image" src="https://github.com/user-attachments/assets/da419ad6-4a57-41d7-a7c5-cbefec4e4839" />

