### PR TITLE
FIX: In shipment creation process, if product is not manage in stock, Dolibarr should not display a "low stock warning"

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1422,7 +1422,7 @@ if ($action == 'create') {
 
 					// Qty to ship
 					$quantityAsked = $line->qty;
-					if ($line->product_type == 1 && !getDolGlobalString('STOCK_SUPPORTS_SERVICES') && !getDolGlobalString('SHIPMENT_SUPPORTS_SERVICES')) {
+					if ($line->product_type == Product::TYPE_SERVICE && !getDolGlobalString('STOCK_SUPPORTS_SERVICES') && !getDolGlobalString('SHIPMENT_SUPPORTS_SERVICES')) {
 						$quantityToBeDelivered = 0;
 					} else {
 						if (is_numeric($quantityDelivered)) {
@@ -1931,7 +1931,7 @@ if ($action == 'create') {
 
 							print '<td class="left">';
 							if ($line->product_type == Product::TYPE_PRODUCT || getDolGlobalString('STOCK_SUPPORTS_SERVICES')) {
-								if ($warehouse_selected_id > 0) {
+								if ($warehouse_selected_id > 0 && $product->stockable_product == Product::ENABLED_STOCK) {
 									$warehouseObject = new Entrepot($db);
 									$warehouseObject->fetch($warehouse_selected_id);
 									print img_warning().' '.$langs->trans("NoProductToShipFoundIntoStock", $warehouseObject->label);

--- a/htdocs/expedition/shipment.php
+++ b/htdocs/expedition/shipment.php
@@ -802,7 +802,7 @@ if ($order_id > 0 || !empty($ref)) {
 
 					if ($objp->fk_product > 0 && ($type == Product::TYPE_PRODUCT || getDolGlobalString('STOCK_SUPPORTS_SERVICES')) && isModEnabled('stock')) {
 						print '<td class="center">';
-						if ($objp->stockable_product==Product::ENABLED_STOCK) {
+						if ($objp->stockable_product == Product::ENABLED_STOCK) {
 							print $product->stock_reel;
 							if ($product->stock_reel < $toBeShipped[$objp->fk_product]) {
 								print ' ' . img_warning($langs->trans("StockTooLow"));

--- a/htdocs/expedition/shipment.php
+++ b/htdocs/expedition/shipment.php
@@ -620,6 +620,7 @@ if ($order_id > 0 || !empty($ref)) {
 		$sql .= ' p.surface, p.surface_units, p.volume, p.volume_units';
 		$sql .= ', p.tobatch, p.tosell, p.tobuy, p.barcode';
 		$sql .= ', u.short_label as unit_order';
+		$sql .= ', p.stockable_product';
 		$sql .= " FROM ".MAIN_DB_PREFIX."commandedet as cd";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p ON cd.fk_product = p.rowid";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_units as u ON cd.fk_unit = u.rowid";
@@ -801,13 +802,17 @@ if ($order_id > 0 || !empty($ref)) {
 
 					if ($objp->fk_product > 0 && ($type == Product::TYPE_PRODUCT || getDolGlobalString('STOCK_SUPPORTS_SERVICES')) && isModEnabled('stock')) {
 						print '<td class="center">';
-						print $product->stock_reel;
-						if ($product->stock_reel < $toBeShipped[$objp->fk_product]) {
-							print ' '.img_warning($langs->trans("StockTooLow"));
-							if (getDolGlobalString('STOCK_CORRECT_STOCK_IN_SHIPMENT')) {
-								$nbPiece = $toBeShipped[$objp->fk_product] - $product->stock_reel;
-								print ' &nbsp; '.$langs->trans("GoTo").' <a href="'.DOL_URL_ROOT.'/product/stock/product.php?id='.((int) $product->id).'&action=correction&token='.newToken().'&nbpiece='.urlencode((string) ($nbPiece)).'&backtopage='.urlencode((string) ($_SERVER["PHP_SELF"].'?id='.((int) $object->id))).'">'.$langs->trans("CorrectStock").'</a>';
+						if ($objp->stockable_product==Product::ENABLED_STOCK) {
+							print $product->stock_reel;
+							if ($product->stock_reel < $toBeShipped[$objp->fk_product]) {
+								print ' ' . img_warning($langs->trans("StockTooLow"));
+								if (getDolGlobalString('STOCK_CORRECT_STOCK_IN_SHIPMENT')) {
+									$nbPiece = $toBeShipped[$objp->fk_product] - $product->stock_reel;
+									print ' &nbsp; ' . $langs->trans("GoTo") . ' <a href="' . DOL_URL_ROOT . '/product/stock/product.php?id=' . ((int) $product->id) . '&action=correction&token=' . newToken() . '&nbpiece=' . urlencode((string) ($nbPiece)) . '&backtopage=' . urlencode((string) ($_SERVER["PHP_SELF"] . '?id=' . ((int) $object->id))) . '">' . $langs->trans("CorrectStock") . '</a>';
+								}
 							}
+						} else {
+							print img_warning().' '.$langs->trans('StockDisabled');
 						}
 						print '</td>';
 					} elseif ($objp->fk_product > 0 && $type == Product::TYPE_SERVICE && getDolGlobalString('SHIPMENT_SUPPORTS_SERVICES') && isModEnabled('stock')) {


### PR DESCRIPTION

**Before :**
In Expedition tab of an order
<img width="1535" height="888" alt="image" src="https://github.com/user-attachments/assets/c9b5c72b-d874-4ac8-b689-0a05675ddba1" />

Then on create shipment card 
<img width="1600" height="717" alt="image" src="https://github.com/user-attachments/assets/4ddfa187-20a4-4090-9272-f7018eb13ba1" />




**after**
In Expedition tab of an order
<img width="1585" height="919" alt="image" src="https://github.com/user-attachments/assets/7d9d1816-af72-41f4-9d7a-14a90352f52a" />


Then on create shipment card 
<img width="1559" height="659" alt="image" src="https://github.com/user-attachments/assets/4b21c3e4-4ee1-4343-939c-9e39256ef948" />

