### PR TITLE
FIX: in shippement creation with SHIPMENT_SUPPORTS_SERVICES and/or STOCK_DISALLOW_NEGATIVE_TRANSFER and/or stockable_product there are inconsistancies

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1677,6 +1677,7 @@ if ($action == 'create') {
 								}
 
 								$tmpwarehouseObject->fetch($warehouse_id);
+
 								if ($stock_warehouse->real > 0 || !getDolGlobalInt('STOCK_DISALLOW_NEGATIVE_TRANSFER')) {
 									$stock = + $stock_warehouse->real; // Convert it to number
 									$deliverableQty = min($quantityToBeDelivered, $stock);
@@ -1909,7 +1910,7 @@ if ($action == 'create') {
 									$disabled = '';
 								}
 								print '<input class="qtyl right" name="qtyl'.$indiceAsked.'_'.$subj.'" id="qtyl'.$indiceAsked.'_'.$subj.'" type="text" size="4" value="0"'.($disabled ? ' '.$disabled : '').'> ';
-								if (empty($disabled) && !getDolGlobalInt('STOCK_DISALLOW_NEGATIVE_TRANSFER')) {
+								if (empty($disabled) && (!getDolGlobalInt('STOCK_DISALLOW_NEGATIVE_TRANSFER') || $product->stockable_product == Product::DISABLED_STOCK)) {
 									print '<input name="ent1' . $indiceAsked . '_' . $subj . '" type="hidden" value="' . $warehouse_selected_id . '">';
 								}
 							} elseif ($line->product_type == Product::TYPE_SERVICE && getDolGlobalString('SHIPMENT_SUPPORTS_SERVICES')) {
@@ -1921,7 +1922,7 @@ if ($action == 'create') {
 									$disabled = 'disabled="disabled"';
 								}
 								print '<input class="qtyl right" name="qtyl'.$indiceAsked.'_'.$subj.'" id="qtyl'.$indiceAsked.'_'.$subj.'" type="text" size="4" value="'.$quantityToBeDelivered.'"'.($disabled ? ' '.$disabled : '').'> ';
-								if (empty($disabled) && !getDolGlobalInt('STOCK_DISALLOW_NEGATIVE_TRANSFER')) {
+								if (empty($disabled)) {
 									print '<input name="ent1' . $indiceAsked . '_' . $subj . '" type="hidden" value="' . $warehouse_selected_id . '">';
 								}
 							} else {

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1677,7 +1677,6 @@ if ($action == 'create') {
 								}
 
 								$tmpwarehouseObject->fetch($warehouse_id);
-
 								if ($stock_warehouse->real > 0 || !getDolGlobalInt('STOCK_DISALLOW_NEGATIVE_TRANSFER')) {
 									$stock = + $stock_warehouse->real; // Convert it to number
 									$deliverableQty = min($quantityToBeDelivered, $stock);


### PR DESCRIPTION
Functional wish : 
From an order, we create the exact same shipment, even if there are services and product not managed in stock, but we want to be sure for "stocked product" that there is enough stock qty


Stock Settings
 Do not allow negative stock = 1
 SHIPMENT_SUPPORTS_SERVICES = 1
 STOCK_SUPPORTS_SERVICES = 0

Create en order with :
 - a product A1 managed in stock (qty 1) (and there is enough to stock  qty in a warehouse to ship 1 unit)
 - 1 service S1 (qty 1)
 - a product A2 not managed in stock (qty 1)

Create a shipment
**Actual result** : Shipment only get A1 line
**Expected Result** : Shipment have to be populated with A1, S1, and A2

With Do not allow negative stock =  0 ("allow negative stock")
**Actual result** : Shipment get all order lines : A1, S1, and A2

But we don't want to allow negative stock for products that are managed in stock.
So the shipment created should be the same with "allow negative stock" or not  for services or products that aren't managed in stock





