### PR TITLE
FIX : Can approuve holidays when negative balance

### DIFF
--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -706,13 +706,13 @@ if (empty($reshook)) {
 
 			if (!$error) {
 				$db->commit();
-
-				header('Location: '.$_SERVER["PHP_SELF"].'?id='.$object->id);
-				exit;
 			} else {
 				$db->rollback();
 				$action = '';
 			}
+
+			header('Location: '.$_SERVER["PHP_SELF"].'?id='.$object->id);
+			exit;
 		}
 	}
 

--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -898,13 +898,8 @@ class Holiday extends CommonObject
 		if ($checkBalance > 0) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
 
-			$startDdatetime = new DateTime("@$this->date_debut");
-			$endDatetime = new DateTime("@$this->date_fin");
-
-			$interval = $startDdatetime->diff($endDatetime);
-			$days = $interval->days;
-
-			if ($balance - $days < 0) {
+			$days = num_between_day($this->date_debut, $this->date_fin);
+			if ($balance - $days < 0 && !getDolGlobalString('HOLIDAY_ALLOW_NEGATIVE_BALANCE')) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}

--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -770,11 +770,11 @@ class Holiday extends CommonObject
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 		$error = 0;
 
+
 		$checkBalance = getDictionaryValue('c_holiday_types', 'block_if_negative', $this->fk_type, true);
 
 		if ($checkBalance > 0) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
-
 			if ($balance < 0) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
@@ -898,7 +898,13 @@ class Holiday extends CommonObject
 		if ($checkBalance > 0) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
 
-			if ($balance < 0) {
+			$startDdatetime = new DateTime("@$this->date_debut");
+			$endDatetime = new DateTime("@$this->date_fin");
+
+			$interval = $startDdatetime->diff($endDatetime);
+			$days = $interval->days;
+
+			if ($balance - $days < 0) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}


### PR DESCRIPTION
## FIX : Can approuve holidays when negative balance

Currently, it is possible to approve a leave request even if it causes the user's balance to go negative.
This should not be allowed.