### PR TITLE
NEW Parent project column in list of projects

### DIFF
--- a/htdocs/projet/list.php
+++ b/htdocs/projet/list.php
@@ -119,7 +119,8 @@ $search_opp_status = GETPOST("search_opp_status", 'alpha');
 $search_opp_percent = GETPOST("search_opp_percent", 'alpha');
 $search_opp_amount = GETPOST("search_opp_amount", 'alpha');
 $search_budget_amount = GETPOST("search_budget_amount", 'alpha');
-$search_parent = GETPOST('search_parent', 'alpha');
+$search_parent_ref = GETPOST('search_parent_ref', 'alpha');
+$search_parent_label = GETPOST('search_parent_label', 'alpha');
 $search_public = GETPOST("search_public", 'intcomma');
 $search_project_user = GETPOSTINT('search_project_user');
 $search_project_contact = GETPOSTINT('search_project_contact');
@@ -412,7 +413,8 @@ if (empty($reshook)) {
 		$search_opp_amount = '';
 		$search_opp_percent = '';
 		$search_budget_amount = '';
-		$search_parent = '';
+		$search_parent_ref = '';
+		$search_parent_label = '';
 		$search_public = "";
 		$search_sale = "";
 		$search_project_user = '';
@@ -649,8 +651,11 @@ if ($search_ref) {
 if ($search_label) {
 	$sql .= natural_search('p.title', $search_label);
 }
-if ($search_parent) {
-	$sql .= natural_search('pa.ref', $search_parent);
+if ($search_parent_ref) {
+	$sql .= natural_search('pa.ref', $search_parent_ref);
+}
+if ($search_parent_label) {
+	$sql .= natural_search('pa.title', $search_parent_label);
 }
 if (empty($arrayfields['s.name_alias']['checked']) && $search_societe) {
 	$sql .= natural_search(array("s.nom", "s.name_alias"), $search_societe);
@@ -955,8 +960,11 @@ if ($groupby != '') {
 	$param .= '&groupby='.urlencode($groupby);
 }
 
-if ($search_parent != '') {
-	$param .= '&search_parent='.urlencode($search_parent);
+if ($search_parent_ref != '') {
+	$param .= '&search_parent_ref='.urlencode($search_parent_ref);
+}
+if ($search_parent_label != '') {
+	$param .= '&search_parent_label='.urlencode($search_parent_label);
 }
 
 if ($socid) {
@@ -1357,8 +1365,15 @@ if (!empty($arrayfields['p.title']['checked'])) {
 
 // Parent project
 if (!empty($arrayfields['p.fk_project']['checked'])) {
-	print '<td class="liste_titre" id="search_parent">';
-	print '<input type="text" class="flat width75" name="search_parent" value="'.dol_escape_htmltag($search_parent).'">';
+	print '<td class="liste_titre" id="parent_project">';
+	print '<div class="nowrap">';
+	$ref_placeholder = $langs->trans('Ref');
+	print '<input id="search_parent_ref" placeholder="'.$ref_placeholder.'" type="text" class="flat width75" name="search_parent_ref" value="'.dol_escape_htmltag($search_parent_ref).'">';
+	print '</div>';
+	print '<div class="nowrap">';
+	$label_placeholder = $langs->trans('Label');
+	print '<input id="search_parent_label" placeholder="'.$label_placeholder.'" type="text" class="flat width75" name="search_parent_label" value="'.dol_escape_htmltag($search_parent_label).'">';
+	print '</div>';
 	print '</td>';
 }
 

--- a/htdocs/projet/list.php
+++ b/htdocs/projet/list.php
@@ -12,6 +12,7 @@
  * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024		Benjamin Falière	<benjamin.faliere@altairis.fr>
  * Copyright (C) 2024		William Mead		<william.mead@manchenumerique.fr>
+ * Copyright (C) 2025		Jon Bendtsen            <jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -118,6 +119,7 @@ $search_opp_status = GETPOST("search_opp_status", 'alpha');
 $search_opp_percent = GETPOST("search_opp_percent", 'alpha');
 $search_opp_amount = GETPOST("search_opp_amount", 'alpha');
 $search_budget_amount = GETPOST("search_budget_amount", 'alpha');
+$search_parent = GETPOST('search_parent', 'alpha');
 $search_public = GETPOST("search_public", 'intcomma');
 $search_project_user = GETPOSTINT('search_project_user');
 $search_project_contact = GETPOSTINT('search_project_contact');
@@ -290,7 +292,6 @@ if (GETPOST('search_usage_event_organization')) {
 		$arrayfields['p.usage_organize_event']['checked'] = '1';
 	}
 }
-$arrayfields['p.fk_project']['enabled'] = '0';
 
 // Force this field to be visible
 if ($contextpage == 'lead') {
@@ -411,6 +412,7 @@ if (empty($reshook)) {
 		$search_opp_amount = '';
 		$search_opp_percent = '';
 		$search_budget_amount = '';
+		$search_parent = '';
 		$search_public = "";
 		$search_sale = "";
 		$search_project_user = '';
@@ -586,7 +588,7 @@ $selectedfields = $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfi
 // Build and execute select
 // --------------------------------------------------------------------
 $sql = "SELECT";
-$sql .= " p.rowid as id, p.ref, p.title, p.fk_statut as status, cls.position, ";
+$sql .= " p.rowid as id, p.ref, p.title, p.fk_statut as status, cls.position, p.fk_project, ";
 $sql .= $db->ifsql("p.fk_opp_status IS NULL", "0", "p.fk_opp_status")." as fk_opp_status, p.public, p.fk_user_creat,";
 $sql .= " p.datec as date_creation, p.dateo as date_start, p.datee as date_end, p.opp_amount, p.opp_percent, (p.opp_amount * p.opp_percent / 100) as opp_weighted_amount, p.tms as date_modification, p.budget_amount,";
 $sql .= " p.usage_opportunity, p.usage_task, p.usage_bill_time, p.usage_organize_event,";
@@ -618,6 +620,7 @@ $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s on p.fk_soc = s.rowid";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_country as country on country.rowid = s.fk_pays";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_lead_status as cls on p.fk_opp_status = cls.rowid";
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'user AS u ON p.fk_user_creat = u.rowid';
+$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.$object->table_element.' AS pa ON p.fk_project = pa.rowid';
 // We'll need this table joined to the select in order to filter by sale
 // No check is done on company permission because readability is managed by public status of project and assignment.
 //if ($search_sale > 0 || (! $user->rights->societe->client->voir && ! $socid)) $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON sc.fk_soc = s.rowid";
@@ -645,6 +648,9 @@ if ($search_ref) {
 }
 if ($search_label) {
 	$sql .= natural_search('p.title', $search_label);
+}
+if ($search_parent) {
+	$sql .= natural_search('pa.ref', $search_parent);
 }
 if (empty($arrayfields['s.name_alias']['checked']) && $search_societe) {
 	$sql .= natural_search(array("s.nom", "s.name_alias"), $search_societe);
@@ -947,6 +953,10 @@ if ($search_entity != '') {
 }
 if ($groupby != '') {
 	$param .= '&groupby='.urlencode($groupby);
+}
+
+if ($search_parent != '') {
+	$param .= '&search_parent='.urlencode($search_parent);
 }
 
 if ($socid) {
@@ -1319,34 +1329,42 @@ print '<table class="tagtable nobottomiftotal liste'.($moreforfilter ? " listwit
 // Fields title search
 // --------------------------------------------------------------------
 print '<tr class="liste_titre_filter">';
-// Action column
+// Action column left
 if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-	print '<td class="liste_titre maxwidthsearch">';
+	print '<td class="liste_titre maxwidthsearch" id="action_column_left">';
 	$searchpicto = $form->showFilterButtons('left');
 	print $searchpicto;
 	print '</td>';
 }
 // Project ID
 if (!empty($arrayfields['p.rowid']['checked'])) {
-	print '<td class="liste_titre">';
+	print '<td class="liste_titre" id="search_id">';
 	print '<input type="text" class="flat width50" name="search_id" value="'.dol_escape_htmltag($search_id).'">';
 	print '</td>';
 }
 // Project ref
 if (!empty($arrayfields['p.ref']['checked'])) {
-	print '<td class="liste_titre">';
+	print '<td class="liste_titre" id="search_ref">';
 	print '<input type="text" class="flat width75" name="search_ref" value="'.dol_escape_htmltag($search_ref).'">';
 	print '</td>';
 }
 // Project label
 if (!empty($arrayfields['p.title']['checked'])) {
-	print '<td class="liste_titre">';
+	print '<td class="liste_titre" id="search_label">';
 	print '<input type="text" class="flat width100" name="search_label" value="'.dol_escape_htmltag($search_label).'">';
 	print '</td>';
 }
+
+// Parent project
+if (!empty($arrayfields['p.fk_project']['checked'])) {
+	print '<td class="liste_titre" id="search_parent">';
+	print '<input type="text" class="flat width75" name="search_parent" value="'.dol_escape_htmltag($search_parent).'">';
+	print '</td>';
+}
+
 // Third party
 if (!empty($arrayfields['s.nom']['checked'])) {
-	print '<td class="liste_titre">';
+	print '<td class="liste_titre" id="search_societe">';
 	if ($socid > 0) {
 		$tmpthirdparty = new Societe($db);
 		$tmpthirdparty->fetch($socid);
@@ -1358,7 +1376,7 @@ if (!empty($arrayfields['s.nom']['checked'])) {
 
 // Alias
 if (!empty($arrayfields['s.name_alias']['checked'])) {
-	print '<td class="liste_titre">';
+	print '<td class="liste_titre" id="search_societe_alias">';
 	if ($socid > 0) {
 		$tmpthirdparty = new Societe($db);
 		$tmpthirdparty->fetch($socid);
@@ -1370,30 +1388,30 @@ if (!empty($arrayfields['s.name_alias']['checked'])) {
 
 // Ref customer
 if (!empty($arrayfields['s.code_client']['checked'])) {
-	print '<td class="liste_titre">';
+	print '<td class="liste_titre" id="search_societe_ref_customer">';
 	print '<input type="text" class="flat width75" name="search_societe_ref_customer" value="'.dol_escape_htmltag($search_societe_ref_customer).'">';
 	print '</td>';
 }
 // Ref supplier
 if (!empty($arrayfields['s.code_fournisseur']['checked'])) {
-	print '<td class="liste_titre">';
+	print '<td class="liste_titre" id="search_societe_ref_supplier">';
 	print '<input type="text" class="flat width75" name="search_societe_ref_supplier" value="'.dol_escape_htmltag($search_societe_ref_supplier).'">';
 	print '</td>';
 }
 
 // Country of thirdparty
 if (!empty($arrayfields['co.country_code']['checked'])) {
-	print '<td class="liste_titre">';
+	print '<td class="liste_titre" id="search_societe_country">';
 	print '<input type="text" class="flat width50" name="search_societe_country" value="'.dol_escape_htmltag($search_societe_country).'">';
 	print '</td>';
 }
 // Sale representative
 if (!empty($arrayfields['commercial']['checked'])) {
-	print '<td class="liste_titre">&nbsp;</td>';
+	print '<td class="liste_titre" id="sale_representative">&nbsp;</td>';
 }
 // Start date
 if (!empty($arrayfields['p.dateo']['checked'])) {
-	print '<td class="liste_titre center">';
+	print '<td class="liste_titre center" id="search_date_start">';
 	print '<div class="nowrapfordate">';
 	print $form->selectDate($search_date_start_start ? $search_date_start_start : -1, 'search_date_start_start', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
 	print '</div>';
@@ -1404,7 +1422,7 @@ if (!empty($arrayfields['p.dateo']['checked'])) {
 }
 // End date
 if (!empty($arrayfields['p.datee']['checked'])) {
-	print '<td class="liste_titre center">';
+	print '<td class="liste_titre center" id="search_date_end">';
 	print '<div class="nowrapfordate">';
 	print $form->selectDate($search_date_end_start ? $search_date_end_start : -1, 'search_date_end_start', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
 	print '</div>';
@@ -1431,12 +1449,12 @@ if (!empty($arrayfields['p.fk_opp_status']['checked'])) {
 	print '</td>';
 }
 if (!empty($arrayfields['p.opp_amount']['checked'])) {
-	print '<td class="liste_titre nowrap right">';
+	print '<td class="liste_titre nowrap right" id="search_opp_amount">';
 	print '<input type="text" class="flat" name="search_opp_amount" size="3" value="'.$search_opp_amount.'">';
 	print '</td>';
 }
 if (!empty($arrayfields['p.opp_percent']['checked'])) {
-	print '<td class="liste_titre nowrap right">';
+	print '<td class="liste_titre nowrap right" id="search_opp_percent">';
 	print '<input type="text" class="flat" name="search_opp_percent" size="2" value="'.$search_opp_percent.'">';
 	print '</td>';
 }
@@ -1445,7 +1463,7 @@ if (!empty($arrayfields['opp_weighted_amount']['checked'])) {
 	print '</td>';
 }
 if (!empty($arrayfields['p.budget_amount']['checked'])) {
-	print '<td class="liste_titre nowrap right">';
+	print '<td class="liste_titre nowrap right" id="search_budget_amount">';
 	print '<input type="text" class="flat" name="search_budget_amount" size="4" value="'.$search_budget_amount.'">';
 	print '</td>';
 }
@@ -1481,18 +1499,18 @@ if (!empty($arrayfields['p.accept_booth_suggestions']['checked'])) {
 	print '</td>';
 }
 if (!empty($arrayfields['p.price_registration']['checked'])) {
-	print '<td class="liste_titre nowrap right">';
+	print '<td class="liste_titre nowrap right" id="search_price_registration">';
 	print '<input type="text" class="flat" name="search_price_registration" size="4" value="'.dol_escape_htmltag($search_price_registration).'">';
 	print '</td>';
 }
 if (!empty($arrayfields['p.price_booth']['checked'])) {
-	print '<td class="liste_titre nowrap right">';
+	print '<td class="liste_titre nowrap right" id="search_price_booth">';
 	print '<input type="text" class="flat" name="search_price_booth" size="4" value="'.dol_escape_htmltag($search_price_booth).'">';
 	print '</td>';
 }
 if (!empty($arrayfields['u.login']['checked'])) {
 	// Author
-	print '<td class="liste_titre" align="center">';
+	print '<td class="liste_titre" align="center" id="search_login">';
 	print '<input class="flat" size="4" type="text" name="search_login" value="'.dol_escape_htmltag($search_login).'">';
 	print '</td>';
 }
@@ -1505,7 +1523,7 @@ $reshook = $hookmanager->executeHooks('printFieldListOption', $parameters); // N
 print $hookmanager->resPrint;
 // Creation date
 if (!empty($arrayfields['p.datec']['checked'])) {
-	print '<td class="liste_titre center">';
+	print '<td class="liste_titre center" id="search_date_creation">';
 	print '<div class="nowrapfordate">';
 	print $form->selectDate($search_date_creation_start ? $search_date_creation_start : -1, 'search_date_creation_start', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
 	print '</div>';
@@ -1516,7 +1534,7 @@ if (!empty($arrayfields['p.datec']['checked'])) {
 }
 // Modification date
 if (!empty($arrayfields['p.tms']['checked'])) {
-	print '<td class="liste_titre center">';
+	print '<td class="liste_titre center" id="search_date_modif">';
 	print '<div class="nowrapfordate">';
 	print $form->selectDate($search_date_modif_start ? $search_date_modif_start : -1, 'search_date_modif_start', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans('From'));
 	print '</div>';
@@ -1532,18 +1550,19 @@ if (!empty($arrayfields['p.email_msgid']['checked'])) {
 }
 if (!empty($arrayfields['p.import_key']['checked'])) {
 	// Import key
-	print '<td class="liste_titre">';
+	print '<td class="liste_titre" id="search_import_key">';
 	print '<input class="flat width75" type="text" name="search_import_key" value="'.dol_escape_htmltag($search_import_key).'">';
 	print '</td>';
 }
+// Status - if you insert id here it doesn't work the way it should - so we don't
 if (!empty($arrayfields['p.fk_statut']['checked'])) {
 	print '<td class="liste_titre center parentonrightofpage">';
 	$formproject->selectProjectsStatus($search_status, 1, 'search_status');
 	print '</td>';
 }
-// Action column
+// Action column right
 if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-	print '<td class="liste_titre maxwidthsearch">';
+	print '<td class="liste_titre maxwidthsearch" id="action_column_right">';
 	$searchpicto = $form->showFilterButtons();
 	print $searchpicto;
 	print '</td>';
@@ -1570,6 +1589,10 @@ if (!empty($arrayfields['p.ref']['checked'])) {
 }
 if (!empty($arrayfields['p.title']['checked'])) {
 	print_liste_field_titre($arrayfields['p.title']['label'], $_SERVER["PHP_SELF"], "p.title", "", $param, "", $sortfield, $sortorder);
+	$totalarray['nbfield']++;
+}
+if (!empty($arrayfields['p.fk_project']['checked'])) {
+	print_liste_field_titre($arrayfields['p.fk_project']['label'], $_SERVER["PHP_SELF"], "p.fk_project", "", $param, "", $sortfield, $sortorder);
 	$totalarray['nbfield']++;
 }
 if (!empty($arrayfields['s.nom']['checked'])) {
@@ -1738,6 +1761,7 @@ while ($i < $imaxinloop) {
 	$object->id = $obj->id;
 	$object->ref = $obj->ref;
 	$object->title = $obj->title;
+	$object->fk_project = $obj->fk_project;
 	$object->fk_opp_status = $obj->fk_opp_status;
 	$object->user_author_id = $obj->fk_user_creat;
 	$object->date_creation = $db->jdate($obj->date_creation);
@@ -2006,6 +2030,31 @@ while ($i < $imaxinloop) {
 				$totalarray['nbfield']++;
 			}
 		}
+		// Parent Project
+		if (!empty($arrayfields['p.fk_project']['checked'])) {
+			print '<td class="nowraponall">';
+			if ($object->fk_project) {
+				$parent_object = new Project($db);
+				$parent_result = $parent_object->fetch($object->fk_project);
+				if ($parent_result > 0) {
+					$accessallowed = checkUserAccessToObject($user, array('projet'), $parent_object, 'projet&project', '', '', 'rowid', '');
+					if ($accessallowed) {
+						print $parent_object->getNomUrl(-1);
+					} else {
+						$parent_url = DOL_URL_ROOT.'/projet/card.php?id='.$object->fk_project;
+						print '<a href="'.$parent_url.'"><del title="You do not have access to see parent project">ACCESS DENIED!</del></a>';
+					}
+				} else {
+					print ((int) $object->fk_project);
+				}
+			}
+
+			print '</td>';
+			if (!$i) {
+				$totalarray['nbfield']++;
+			}
+		}
+
 		// Company
 		if (!empty($arrayfields['s.nom']['checked'])) {
 			print '<td class="tdoverflowmax125">';

--- a/htdocs/projet/list.php
+++ b/htdocs/projet/list.php
@@ -2057,7 +2057,11 @@ while ($i < $imaxinloop) {
 						print $parent_object->getNomUrl(-1);
 					} else {
 						$parent_url = DOL_URL_ROOT.'/projet/card.php?id='.$object->fk_project;
-						print '<a href="'.$parent_url.'"><del title="You do not have access to see parent project">ACCESS DENIED!</del></a>';
+						print '<a href="'.$parent_url.'">';
+						print img_picto('', 'warning', 'class="pictofixedwidth error"');
+						print '<del title="You do not have access to see parent project">ACCESS DENIED!</del>';
+						print img_picto('', 'warning', 'class="pictofixedwidth error"');
+						print '</a>';
 					}
 				} else {
 					print ((int) $object->fk_project);


### PR DESCRIPTION
# NEW Parent project column in list of projects
This PR adds the possibility of showing a parent column in the list of projects as well as making it searchable on both ref and label among parent project. If you don't have access to the parent project it will write that in the column rather than revealing the parent project ref.

This PR has also introduced a lot of id="search_..." on all the other columns to make it easier to identify the columns when you use the browsers inspect function.