### PR TITLE
FIX adding tms and datec to email templates

### DIFF
--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -119,23 +119,33 @@ $hookmanager->initHooks(array('emailtemplates'));
 $tabname = array();
 $tabname[25] = MAIN_DB_PREFIX."c_email_templates";
 
+// Used by the GUI during creation so we don't ask the user to fill in tms and datec
+$tabfieldguicreate = array();
+$tabfieldguicreate[25] = "label,lang,type_template,fk_user,private,position,module,topic,joinfiles,defaultfortype,content";
+if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
+	$tabfieldguicreate[25] .= ',content_lines';
+}
+
 // Nom des champs en resultat de select pour affichage du dictionnaire
+// Names of fields in select results for dictionary display (AI translated)
 $tabfield = array();
-$tabfield[25] = "label,lang,type_template,fk_user,private,position,module,topic,joinfiles,defaultfortype,content";
+$tabfield[25] = "label,lang,type_template,fk_user,private,position,module,topic,joinfiles,defaultfortype,content,tms,datec";
 if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfield[25] .= ',content_lines';
 }
 
 // Nom des champs d'edition pour modification d'un enregistrement
+// Names of edit fields for modifying a record (AI translated)
 $tabfieldvalue = array();
-$tabfieldvalue[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content";
+$tabfieldvalue[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content,tms";
 if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfieldvalue[25] .= ',content_lines';
 }
 
 // Nom des champs dans la table pour insertion d'un enregistrement
+// Field names in the table for inserting a record (AI translated)
 $tabfieldinsert = array();
-$tabfieldinsert[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content";
+$tabfieldinsert[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content,tms,datec";
 if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfieldinsert[25] .= ',content_lines';
 }
@@ -338,14 +348,14 @@ if (empty($reshook)) {
 	if ((GETPOST('actionadd', 'alpha') && $permissiontoadd) || (GETPOST('actionmodify', 'alpha') && $permissiontoedit)) {
 		$listfield = explode(',', str_replace(' ', '', $tabfield[25]));
 		$listfieldinsert = explode(',', $tabfieldinsert[25]);
-		$listfieldmodify = explode(',', $tabfieldinsert[25]);
+		$listfieldmodify = explode(',', $tabfieldvalue[25]);
 		$listfieldvalue = explode(',', $tabfieldvalue[25]);
 
 		// Check that all fields are filled
 		$ok = 1;
 		foreach ($listfield as $f => $value) {
 			// Not mandatory fields
-			if (in_array($value, ['joinfiles', 'defaultfortype', 'content', 'content_lines', 'module'])) {
+			if (in_array($value, ['joinfiles', 'defaultfortype', 'content', 'content_lines', 'module', 'tms', 'datec'])) {
 				continue;
 			}
 
@@ -399,6 +409,8 @@ if (empty($reshook)) {
 
 			// List of values
 			$i = 0;
+			$now = dol_now();
+			$now_insert_timestamp = dol_print_date($now, 'standard');
 			foreach ($listfieldinsert as $f => $value) {
 				$keycode = isset($listfieldvalue[$i]) ? $listfieldvalue[$i] : "";
 				if ($value == 'lang') {
@@ -446,6 +458,12 @@ if (empty($reshook)) {
 				} else {
 					$sql .= "'".$db->escape(GETPOST($keycode, 'alphanohtml'))."'";
 				}
+				if ($value == 'tms') {
+					$_POST[$keycode] = $now_insert_timestamp;
+				}
+				if ($value == 'datec') {
+					$_POST[$keycode] = $now_insert_timestamp;
+				}
 				$i++;
 			}
 			$sql .= ", 1, 1)";
@@ -485,6 +503,8 @@ if (empty($reshook)) {
 				$sql = "UPDATE ".$tabname[25]." SET ";
 				// Modify value of fields
 				$i = 0;
+				$now = dol_now();
+				$now_update_timestamp = dol_print_date($now, 'standard');
 				foreach ($listfieldmodify as $field) {
 					if ($field == 'entity') {
 						// entity not present on listfieldmodify array
@@ -526,7 +546,9 @@ if (empty($reshook)) {
 					}
 					$sql .= $field."=";
 
-					if (GETPOST($keycode) == '' || (!in_array($keycode, array('langcode', 'position', 'private', 'defaultfortype')) && !GETPOST($keycode))) {
+					if ($keycode == 'tms') {
+						$sql .= '"'.$now_update_timestamp.'"';
+					} elseif (GETPOST($keycode) == '' || (!in_array($keycode, array('langcode', 'position', 'private', 'defaultfortype')) && !GETPOST($keycode))) {
 						$sql .= "null"; // langcode,... must be '' if not defined so the unique key that include lang will work
 					} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {
 						$sql .= "''"; // langcode must be '' if not defined so the unique key that include lang will work
@@ -631,7 +653,7 @@ if (!empty($user->admin) && (empty($_SESSION['leftmenu']) || $_SESSION['leftmenu
 $morejs = array();
 $morecss = array();
 
-$sql = "SELECT rowid as rowid, module, label, type_template, lang, fk_user, private, position, topic, email_from,joinfiles, defaultfortype, content_lines, content, enabled, active";
+$sql = "SELECT rowid as rowid, module, label, type_template, lang, fk_user, private, position, topic, email_from,joinfiles, defaultfortype, content_lines, content, enabled, active, tms, datec";
 $sql .= " FROM ".MAIN_DB_PREFIX."c_email_templates";
 $sql .= " WHERE entity IN (".getEntity('email_template').")";
 if (!$user->admin) {
@@ -756,18 +778,23 @@ if ($action == 'create') {
 	$obj->defaultfortype = GETPOST('defaultfortype') ? 1 : 0;
 	$obj->content = GETPOST('content', 'restricthtml');
 
+	$now_form_timestamp = dol_print_date($now, 'standard');
 	// Form to add a new line
-	print '<form action="'.$_SERVER['PHP_SELF'].'" method="POST">';
+	print '<form action="'.$_SERVER['PHP_SELF'].'" method="POST" id="create_c_email_template">';
 	print '<input type="hidden" name="token" value="'.newToken().'">';
 	print '<input type="hidden" name="action" value="add">';
 	print '<input type="hidden" name="from" value="'.dol_escape_htmltag(GETPOST('from', 'alpha')).'">';
 	print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
+	print '<input type="hidden" name="tms" value="'.$now_form_timestamp.'">';
+	print '<input type="hidden" name="datec" value="'.$now_form_timestamp.'">';
 
 	print '<div class="div-table-responsive-no-min">';
 	print '<table class="noborder centpercent">';
 
 	// Line to enter new values (title)
 	print '<tr class="liste_titre">';
+	// Only used during GUI creation
+	$fieldlist = explode(',', $tabfieldguicreate[25]);
 	foreach ($fieldlist as $field => $value) {
 		// Determine le nom du champ par rapport aux noms possibles
 		// dans les dictionnaires de donnees
@@ -843,7 +870,6 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('createEmailTemplateFieldlist', $parameters, $obj, $tmpaction); // Note that $action and $object may have been modified by some hooks
 	$error = $hookmanager->error;
 	$errors = $hookmanager->errors;
-
 
 	// Line to enter new values (input fields)
 	print '<tr class="oddeven">';
@@ -921,6 +947,8 @@ if ($action == 'create') {
 
 	print '<br><br><br>';
 }
+// back to viewing with tms and datec
+$fieldlist = explode(',', $tabfield[25]);
 
 // List of available record in database
 dol_syslog("htdocs/admin/dict", LOG_DEBUG);
@@ -932,7 +960,7 @@ if (!$resql) {
 
 $num = $db->num_rows($resql);
 
-print '<form action="'.$_SERVER['PHP_SELF'].'" method="POST">';
+print '<form action="'.$_SERVER['PHP_SELF'].'" method="POST" id="list_of_c_email_templates">';
 print '<input type="hidden" name="token" value="'.newToken().'">';
 print '<input type="hidden" name="from" value="'.dol_escape_htmltag(GETPOST('from', 'alpha')).'">';
 
@@ -1123,7 +1151,13 @@ if ($num) {
 				print '<tr class="nohover oddeven" id="rowid-'.$obj->rowid.'">';
 
 				$tmpaction = 'edit';
-				$parameters = array('fieldlist' => $fieldlist, 'tabname' => $tabname[25]);
+				if ($action == 'edit') {
+					// do not show tms and datec
+					$fieldlist = explode(',', $tabfieldguicreate[25]);
+					$parameters = array('fieldlist' => $fieldlist, 'tabname' => $tabname[25]);
+				} else {
+					$parameters = array('fieldlist' => $fieldlist, 'tabname' => $tabname[25]);
+				}
 				$reshook = $hookmanager->executeHooks('editEmailTemplateFieldlist', $parameters, $obj, $tmpaction); // Note that $action and $object may have been modified by some hooks
 				$error = $hookmanager->error;
 				$errors = $hookmanager->errors;

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -1099,6 +1099,12 @@ foreach ($fieldlist as $field => $value) {
 	if ($fieldlist[$field] == 'position') {
 		$css = 'center';
 	}
+	if ($fieldlist[$field] == 'tms') {
+		$valuetoshow = 'Modif. date';
+	}
+	if ($fieldlist[$field] == 'datec') {
+		$valuetoshow = 'Date creation';
+	}
 
 	if ($fieldlist[$field] == 'joinfiles') {
 		$valuetoshow = $langs->trans("FilesAttachedToEmail");

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -14,6 +14,7 @@
  * Copyright (C) 2018-2024  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		Vincent Maury			<vmaury@timgroup.fr>
+ * Copyright (C) 2025		Jon Bendtsen			<jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -119,17 +119,10 @@ $hookmanager->initHooks(array('emailtemplates'));
 $tabname = array();
 $tabname[25] = MAIN_DB_PREFIX."c_email_templates";
 
-// Used by the GUI during creation so we don't ask the user to fill in tms and datec
-$tabfieldguicreate = array();
-$tabfieldguicreate[25] = "label,lang,type_template,fk_user,private,position,module,topic,joinfiles,defaultfortype,content";
-if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
-	$tabfieldguicreate[25] .= ',content_lines';
-}
-
 // Nom des champs en resultat de select pour affichage du dictionnaire
 // Names of fields in select results for dictionary display (AI translated)
 $tabfield = array();
-$tabfield[25] = "label,lang,type_template,fk_user,private,position,module,topic,joinfiles,defaultfortype,content,tms,datec";
+$tabfield[25] = "label,lang,type_template,fk_user,private,position,module,topic,joinfiles,defaultfortype,content";
 if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfield[25] .= ',content_lines';
 }
@@ -137,7 +130,7 @@ if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 // Nom des champs d'edition pour modification d'un enregistrement
 // Names of edit fields for modifying a record (AI translated)
 $tabfieldvalue = array();
-$tabfieldvalue[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content,tms";
+$tabfieldvalue[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content";
 if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfieldvalue[25] .= ',content_lines';
 }
@@ -440,10 +433,10 @@ if (empty($reshook)) {
 				if ($i) {
 					$sql .= ", ";
 				}
-				if ($keycode == 'tms') {
+				if ($keycode == 'datec') {
 					$sql .= "'".$db->idate($now)."'";
-				} elseif ($keycode == 'datec') {
-					$sql .= "'".$db->idate($now)."'";
+				} elseif ($keycode == 'tms') {
+						$sql .= "'".$db->idate($now)."'";
 				} elseif (GETPOST($keycode) == '' && $keycode != 'langcode') {
 					$sql .= "null"; // langcode must be '' if not defined so the unique key that include lang will work
 				} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {
@@ -542,9 +535,7 @@ if (empty($reshook)) {
 					}
 					$sql .= $field."=";
 
-					if ($keycode == 'tms') {
-						$sql .= "'".$db->idate($now)."'";
-					} elseif (GETPOST($keycode) == '' || (!in_array($keycode, array('langcode', 'position', 'private', 'defaultfortype')) && !GETPOST($keycode))) {
+					if (GETPOST($keycode) == '' || (!in_array($keycode, array('langcode', 'position', 'private', 'defaultfortype')) && !GETPOST($keycode))) {
 						$sql .= "null"; // langcode,... must be '' if not defined so the unique key that include lang will work
 					} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {
 						$sql .= "''"; // langcode must be '' if not defined so the unique key that include lang will work
@@ -774,23 +765,19 @@ if ($action == 'create') {
 	$obj->defaultfortype = GETPOST('defaultfortype') ? 1 : 0;
 	$obj->content = GETPOST('content', 'restricthtml');
 
-	$now_form_timestamp = dol_print_date($now, 'standard');
 	// Form to add a new line
 	print '<form action="'.$_SERVER['PHP_SELF'].'" method="POST" id="create_c_email_template">';
 	print '<input type="hidden" name="token" value="'.newToken().'">';
 	print '<input type="hidden" name="action" value="add">';
 	print '<input type="hidden" name="from" value="'.dol_escape_htmltag(GETPOST('from', 'alpha')).'">';
 	print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
-	print '<input type="hidden" name="tms" value="'.$now_form_timestamp.'">';
-	print '<input type="hidden" name="datec" value="'.$now_form_timestamp.'">';
+	print '<input type="hidden" name="datec" value="'.$db->idate($now).'">';
 
 	print '<div class="div-table-responsive-no-min">';
 	print '<table class="noborder centpercent" id="table_create_c_email_template">';
 
 	// Line to enter new values (title)
 	print '<tr class="liste_titre">';
-	// Only used during GUI creation
-	$fieldlist = explode(',', $tabfieldguicreate[25]);
 	foreach ($fieldlist as $field => $value) {
 		// Determine le nom du champ par rapport aux noms possibles
 		// dans les dictionnaires de donnees
@@ -943,8 +930,6 @@ if ($action == 'create') {
 
 	print '<br><br><br>';
 }
-// back to viewing with tms and datec
-$fieldlist = explode(',', $tabfield[25]);
 
 // List of available record in database
 dol_syslog("htdocs/admin/dict", LOG_DEBUG);
@@ -1005,7 +990,7 @@ if ($num > $listlimit) {
 
 
 // Title line with search boxes
-print '<tr class="liste_titre">';
+print '<tr class="liste_titre" id="Title line with search boxes">';
 // Action column
 if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 	print '<td class="liste_titre center" width="64">';
@@ -1042,6 +1027,9 @@ foreach ($fieldlist as $field => $value) {
 }*/
 // Status
 print '<td></td>';
+// Have to expand the id="Title line with search boxes" with 2 extra fields because the line below id="Title of lines" are 2 fields longer
+print '<td></td>'; // tms / Modif. date
+print '<td></td>'; // datec / Date creation
 // Action column
 if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 	print '<td class="liste_titre center" width="64">';
@@ -1052,11 +1040,12 @@ if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 print '</tr>';
 
 // Title of lines
-print '<tr class="liste_titre">';
+print '<tr class="liste_titre" id="Title of lines">';
 // Action column
 if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 	print getTitleFieldOfList('');
 }
+array_push($fieldlist, "tms", "datec");
 foreach ($fieldlist as $field => $value) {
 	$showfield = 1; // By default
 	$css = "left";
@@ -1155,9 +1144,10 @@ if ($num) {
 				$tmpaction = 'edit';
 				if ($action == 'edit') {
 					// do not show tms and datec
-					$fieldlist = explode(',', $tabfieldguicreate[25]);
+					$fieldlist = explode(',', $tabfield[25]);
 					$parameters = array('fieldlist' => $fieldlist, 'tabname' => $tabname[25]);
 				} else {
+					array_push($fieldlist, "tms", "datec");
 					$parameters = array('fieldlist' => $fieldlist, 'tabname' => $tabname[25]);
 				}
 				$reshook = $hookmanager->executeHooks('editEmailTemplateFieldlist', $parameters, $obj, $tmpaction); // Note that $action and $object may have been modified by some hooks

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -494,7 +494,6 @@ if (empty($reshook)) {
 				$sql = "UPDATE ".$tabname[25]." SET ";
 				// Modify value of fields
 				$i = 0;
-				$now = dol_now();
 				foreach ($listfieldmodify as $field) {
 					if ($field == 'entity') {
 						// entity not present on listfieldmodify array
@@ -772,7 +771,6 @@ if ($action == 'create') {
 	print '<input type="hidden" name="action" value="add">';
 	print '<input type="hidden" name="from" value="'.dol_escape_htmltag(GETPOST('from', 'alpha')).'">';
 	print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
-	print '<input type="hidden" name="datec" value="'.$db->idate($now).'">';
 
 	print '<div class="div-table-responsive-no-min">';
 	print '<table class="noborder centpercent" id="table_create_c_email_template">';
@@ -854,6 +852,7 @@ if ($action == 'create') {
 	$reshook = $hookmanager->executeHooks('createEmailTemplateFieldlist', $parameters, $obj, $tmpaction); // Note that $action and $object may have been modified by some hooks
 	$error = $hookmanager->error;
 	$errors = $hookmanager->errors;
+
 
 	// Line to enter new values (input fields)
 	print '<tr class="oddeven">';
@@ -1148,7 +1147,6 @@ if ($num) {
 					$fieldlist = explode(',', $tabfield[25]);
 					$parameters = array('fieldlist' => $fieldlist, 'tabname' => $tabname[25]);
 				} else {
-					array_push($fieldlist, "tms", "datec");
 					$parameters = array('fieldlist' => $fieldlist, 'tabname' => $tabname[25]);
 				}
 				$reshook = $hookmanager->executeHooks('editEmailTemplateFieldlist', $parameters, $obj, $tmpaction); // Note that $action and $object may have been modified by some hooks

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -442,9 +442,9 @@ if (empty($reshook)) {
 					$sql .= ", ";
 				}
 				if ($keycode == 'tms') {
-					$sql .= '"'.$db->escape($now_insert_timestamp).'"';
+					$sql .= "'".$db->escape($now_insert_timestamp)."'";
 				} elseif ($keycode == 'datec') {
-					$sql .= '"'.$db->escape($now_insert_timestamp).'"';
+					$sql .= "'".$db->escape($now_insert_timestamp)."'";
 				} elseif (GETPOST($keycode) == '' && $keycode != 'langcode') {
 					$sql .= "null"; // langcode must be '' if not defined so the unique key that include lang will work
 				} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {
@@ -545,7 +545,7 @@ if (empty($reshook)) {
 					$sql .= $field."=";
 
 					if ($keycode == 'tms') {
-						$sql .= '"'.$db->escape($now_update_timestamp).'"';
+						$sql .= "'".$db->escape($now_update_timestamp)."'";
 					} elseif (GETPOST($keycode) == '' || (!in_array($keycode, array('langcode', 'position', 'private', 'defaultfortype')) && !GETPOST($keycode))) {
 						$sql .= "null"; // langcode,... must be '' if not defined so the unique key that include lang will work
 					} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -441,7 +441,11 @@ if (empty($reshook)) {
 				if ($i) {
 					$sql .= ", ";
 				}
-				if (GETPOST($keycode) == '' && $keycode != 'langcode') {
+				if ($keycode == 'tms') {
+					$sql .= '"'.$db->escape($now_insert_timestamp).'"';
+				} elseif ($keycode == 'datec') {
+					$sql .= '"'.$db->escape($now_insert_timestamp).'"';
+				} elseif (GETPOST($keycode) == '' && $keycode != 'langcode') {
 					$sql .= "null"; // langcode must be '' if not defined so the unique key that include lang will work
 				} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {
 					$sql .= "''"; // langcode must be '' if not defined so the unique key that include lang will work
@@ -457,12 +461,6 @@ if (empty($reshook)) {
 					$sql .= GETPOSTINT($keycode);
 				} else {
 					$sql .= "'".$db->escape(GETPOST($keycode, 'alphanohtml'))."'";
-				}
-				if ($value == 'tms') {
-					$_POST[$keycode] = $now_insert_timestamp;
-				}
-				if ($value == 'datec') {
-					$_POST[$keycode] = $now_insert_timestamp;
 				}
 				$i++;
 			}
@@ -547,7 +545,7 @@ if (empty($reshook)) {
 					$sql .= $field."=";
 
 					if ($keycode == 'tms') {
-						$sql .= '"'.$now_update_timestamp.'"';
+						$sql .= '"'.$db->escape($now_update_timestamp).'"';
 					} elseif (GETPOST($keycode) == '' || (!in_array($keycode, array('langcode', 'position', 'private', 'defaultfortype')) && !GETPOST($keycode))) {
 						$sql .= "null"; // langcode,... must be '' if not defined so the unique key that include lang will work
 					} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -410,7 +410,6 @@ if (empty($reshook)) {
 			// List of values
 			$i = 0;
 			$now = dol_now();
-			$now_insert_timestamp = dol_print_date($now, 'standard');
 			foreach ($listfieldinsert as $f => $value) {
 				$keycode = isset($listfieldvalue[$i]) ? $listfieldvalue[$i] : "";
 				if ($value == 'lang') {
@@ -442,9 +441,9 @@ if (empty($reshook)) {
 					$sql .= ", ";
 				}
 				if ($keycode == 'tms') {
-					$sql .= "'".$db->escape($now_insert_timestamp)."'";
+					$sql .= "'".$db->idate($now)."'";
 				} elseif ($keycode == 'datec') {
-					$sql .= "'".$db->escape($now_insert_timestamp)."'";
+					$sql .= "'".$db->idate($now)."'";
 				} elseif (GETPOST($keycode) == '' && $keycode != 'langcode') {
 					$sql .= "null"; // langcode must be '' if not defined so the unique key that include lang will work
 				} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {
@@ -502,7 +501,6 @@ if (empty($reshook)) {
 				// Modify value of fields
 				$i = 0;
 				$now = dol_now();
-				$now_update_timestamp = dol_print_date($now, 'standard');
 				foreach ($listfieldmodify as $field) {
 					if ($field == 'entity') {
 						// entity not present on listfieldmodify array
@@ -545,7 +543,7 @@ if (empty($reshook)) {
 					$sql .= $field."=";
 
 					if ($keycode == 'tms') {
-						$sql .= "'".$db->escape($now_update_timestamp)."'";
+						$sql .= "'".$db->idate($now)."'";
 					} elseif (GETPOST($keycode) == '' || (!in_array($keycode, array('langcode', 'position', 'private', 'defaultfortype')) && !GETPOST($keycode))) {
 						$sql .= "null"; // langcode,... must be '' if not defined so the unique key that include lang will work
 					} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -818,7 +818,7 @@ if ($action == 'create') {
 			$valuetoshow = $langs->trans("Code");
 		}
 		if ($fieldlist[$field] == 'label') {
-			$valuetoshow = $langs->trans("Code");
+			$valuetoshow = $langs->trans("Label");
 		}
 		if ($fieldlist[$field] == 'type_template') {
 			$valuetoshow = $langs->trans("TypeOfTemplate");
@@ -1087,7 +1087,7 @@ foreach ($fieldlist as $field => $value) {
 		$valuetoshow = $langs->trans("Type");
 	}
 	if ($fieldlist[$field] == 'libelle' || $fieldlist[$field] == 'label') {
-		$valuetoshow = $langs->trans("Code");
+		$valuetoshow = $langs->trans("Label");
 	}
 	if ($fieldlist[$field] == 'type_template') {
 		$css = 'center';

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -139,7 +139,7 @@ if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 // Nom des champs dans la table pour insertion d'un enregistrement
 // Field names in the table for inserting a record (AI translated)
 $tabfieldinsert = array();
-$tabfieldinsert[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content,tms,datec";
+$tabfieldinsert[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content,datec";
 if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfieldinsert[25] .= ',content_lines';
 }
@@ -436,8 +436,6 @@ if (empty($reshook)) {
 				}
 				if ($keycode == 'datec') {
 					$sql .= "'".$db->idate($now)."'";
-				} elseif ($keycode == 'tms') {
-						$sql .= "'".$db->idate($now)."'";
 				} elseif (GETPOST($keycode) == '' && $keycode != 'langcode') {
 					$sql .= "null"; // langcode must be '' if not defined so the unique key that include lang will work
 				} elseif (GETPOST($keycode) == '0' && $keycode == 'langcode') {

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -787,7 +787,7 @@ if ($action == 'create') {
 	print '<input type="hidden" name="datec" value="'.$now_form_timestamp.'">';
 
 	print '<div class="div-table-responsive-no-min">';
-	print '<table class="noborder centpercent">';
+	print '<table class="noborder centpercent" id="table_create_c_email_template">';
 
 	// Line to enter new values (title)
 	print '<tr class="liste_titre">';
@@ -963,7 +963,7 @@ print '<input type="hidden" name="token" value="'.newToken().'">';
 print '<input type="hidden" name="from" value="'.dol_escape_htmltag(GETPOST('from', 'alpha')).'">';
 
 print '<div class="div-table-responsive-no-min">';
-print '<table class="noborder centpercent">';
+print '<table class="noborder centpercent" id="table_list_of_c_email_templates">';
 
 $i = 0;
 

--- a/htdocs/api/class/api_emailtemplates.class.php
+++ b/htdocs/api/class/api_emailtemplates.class.php
@@ -323,6 +323,9 @@ class EmailTemplates extends DolibarrApi
 			if ($field == 'id') {
 				throw new RestException(400, 'Creating with id field is forbidden');
 			}
+			if ($field == 'tms') {
+				throw new RestException(400, 'Creating with tms field is forbidden');
+			}
 
 			$this->email_template->$field = $this->_checkValForAPI($field, $value, $this->email_template);
 		}
@@ -349,6 +352,7 @@ class EmailTemplates extends DolibarrApi
 	 *
 	 * @return	Object					Object with cleaned properties
 	 *
+	 * @throws	RestException 400
 	 * @throws	RestException 403
 	 * @throws	RestException 404
 	 * @throws	RestException 500
@@ -367,8 +371,12 @@ class EmailTemplates extends DolibarrApi
 
 		foreach ($request_data as $field => $value) {
 			if ($field == 'id') {
-				continue;
+				throw new RestException(400, 'Updating with id field is forbidden');
 			}
+			if ($field == 'datec') {
+				throw new RestException(400, 'Updating with datec field is forbidden');
+			}
+
 			if ($field === 'caller') {
 				// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again with the caller
 				$this->email_template->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
@@ -400,7 +408,7 @@ class EmailTemplates extends DolibarrApi
 	 *
 	 * @return	Object					Object with cleaned properties
 	 *
-	 * @throws	RestException 403
+	 * @throws	RestException 400
 	 * @throws	RestException 404
 	 * @throws	RestException 500
 	 */
@@ -419,8 +427,12 @@ class EmailTemplates extends DolibarrApi
 		$newlabel = $label;
 		foreach ($request_data as $field => $value) {
 			if ($field == 'id') {
-				continue;
+				throw new RestException(400, 'Updating with id field is forbidden');
 			}
+			if ($field == 'datec') {
+				throw new RestException(400, 'Updating with datec field is forbidden');
+			}
+
 			if ($field == 'label') {
 				$newlabel = $this->_checkValForAPI($field, $value, $this->email_template);
 			}

--- a/htdocs/core/class/cemailtemplate.class.php
+++ b/htdocs/core/class/cemailtemplate.class.php
@@ -79,7 +79,7 @@ class CEmailTemplate extends CommonObject
 	 */
 	public $type_template;
 	/**
-	 * @var string
+	 * @var int|string
 	 */
 	public $datec;
 	/**

--- a/htdocs/core/class/cemailtemplate.class.php
+++ b/htdocs/core/class/cemailtemplate.class.php
@@ -79,7 +79,7 @@ class CEmailTemplate extends CommonObject
 	 */
 	public $type_template;
 	/**
-	 * @var int|string
+	 * @var string
 	 */
 	public $datec;
 	/**
@@ -275,9 +275,9 @@ class CEmailTemplate extends CommonObject
 			$sql .= " '".((int) $this->fk_user)."',";
 		}
 		if (is_null($this->datec)) {
-			$sql .= " NULL,";
+			$sql .= " '".$this->db->idate($now)."',";
 		} else {
-			$sql .= " ".((int) $this->datec).",";
+			$sql .= " ".((string) $this->datec).",";
 		}
 		$sql .= " '".$this->db->escape($this->label)."',";
 		$sql .= " ".((int) $this->position).", ".((int) $this->defaultfortype).",";
@@ -372,7 +372,7 @@ class CEmailTemplate extends CommonObject
 		$sql .= " lang=".($this->lang ? "'".$this->db->escape($this->lang)."', " : 'NULL, ');
 		$sql .= " private=".((int) $this->private).",";
 		$sql .= " fk_user=".((int) $this->fk_user).",";
-		$sql .= " datec=".((int) $this->datec).",";
+		$sql .= " datec='".$this->db->idate($this->datec)."',";
 		$sql .= " label=".($this->label ? "'".$this->db->escape($this->label)."', " : 'NULL, ');
 		$sql .= " position=".((int) $this->position).",";
 		$sql .= " defaultfortype=".((int) $this->defaultfortype).",";
@@ -528,7 +528,7 @@ class CEmailTemplate extends CommonObject
 				$this->active = (int) $obj->active;
 				$this->content = (string) $obj->content;
 				$this->content_lines = (string) $obj->content_lines;
-				$this->datec = (int) $obj->datec;
+				$this->datec = $this->db->jdate($obj->datec);
 				$this->defaultfortype = (int) $obj->defaultfortype;
 				$this->email_from = (string) $obj->email_from;
 				$this->email_to = (string) $obj->email_to;
@@ -542,7 +542,7 @@ class CEmailTemplate extends CommonObject
 				$this->module = (string) $obj->module;
 				$this->position = (int) $obj->position;
 				$this->private = (int) $obj->private;
-				$this->tms = $obj->tms;
+				$this->tms = $this->db->jdate($obj->tms);
 				$this->topic = (string) $obj->topic;
 				$this->type_template = (string) $obj->type_template;
 

--- a/htdocs/core/class/cemailtemplate.class.php
+++ b/htdocs/core/class/cemailtemplate.class.php
@@ -372,7 +372,6 @@ class CEmailTemplate extends CommonObject
 		$sql .= " lang=".($this->lang ? "'".$this->db->escape($this->lang)."', " : 'NULL, ');
 		$sql .= " private=".((int) $this->private).",";
 		$sql .= " fk_user=".((int) $this->fk_user).",";
-		$sql .= " datec='".$this->db->idate($this->datec)."',";
 		$sql .= " label=".($this->label ? "'".$this->db->escape($this->label)."', " : 'NULL, ');
 		$sql .= " position=".((int) $this->position).",";
 		$sql .= " defaultfortype=".((int) $this->defaultfortype).",";

--- a/htdocs/core/class/cemailtemplate.class.php
+++ b/htdocs/core/class/cemailtemplate.class.php
@@ -277,7 +277,7 @@ class CEmailTemplate extends CommonObject
 		if (is_null($this->datec)) {
 			$sql .= " '".$this->db->idate($now)."',";
 		} else {
-			$sql .= " ".((string) $this->datec).",";
+			$sql .= " '".$this->db->idate($this->datec)."',";
 		}
 		$sql .= " '".$this->db->escape($this->label)."',";
 		$sql .= " ".((int) $this->position).", ".((int) $this->defaultfortype).",";

--- a/test/hurl/api/emailtemplates/10_emailtemplates.hurl
+++ b/test/hurl/api/emailtemplates/10_emailtemplates.hurl
@@ -65,6 +65,12 @@ POST http://{{hostnport}}/api/index.php/emailtemplates
 HTTP 400
 {"error":{"code":400,"message":"Bad Request: Creating with id field is forbidden"}}
 
+# POST No tms in post request data
+POST http://{{hostnport}}/api/index.php/emailtemplates
+{ "tms" : 42, "label" : "automatic test using 10_emailtemplates.hurl", "topic" : "automatic test using 10_emailtemplates.hurl", "type_template" : "all" }
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Creating with tms field is forbidden"}}
+
 # DELETE
 DELETE http://{{hostnport}}/api/index.php/emailtemplates/
 HTTP 405
@@ -96,3 +102,23 @@ GET http://{{hostnport}}/api/index.php/emailtemplates
 DOLAPIENTITY: 2
 HTTP 401
 {"error":{"code":401,"message":"Unauthorized: Error user not valid (not found with api key or bad status or bad validity dates) (conf->entity=2)"}}
+
+# GET id of first element
+GET http://{{hostnport}}/api/index.php/emailtemplates?limit=1&page=0
+HTTP 200
+[Asserts]
+jsonpath "$[0].id" exists
+[Captures]
+template-id: jsonpath "$[0]['id']"
+
+# PUT with an id
+PUT http://{{hostnport}}/api/index.php/emailtemplates/{{ template-id }}
+{ "id" : 42, "label" : "automatic test using 10_emailtemplates.hurl", "topic" : "automatic test using 10_emailtemplates.hurl", "type_template" : "all" }
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Updating with id field is forbidden"}}
+
+# PUT with an datec
+PUT http://{{hostnport}}/api/index.php/emailtemplates/{{ template-id }}
+{ "datec" : 42, "label" : "automatic test using 10_emailtemplates.hurl", "topic" : "automatic test using 10_emailtemplates.hurl", "type_template" : "all" }
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Updating with datec field is forbidden"}}


### PR DESCRIPTION
# FIX #32457 adding tms and datec to email templates
This PR adds tms and datec to email templates. It's added but not shown on creation and modify, where as it is shown when just listing email templates. The fields already existed in the database. A few more hurl tests are introduced to ensure that API post and create are not done with wrong fields.

This PR also adds id="" fields to the forms and the tables - so it easier to find them if you inspect the html.

This PR fixes #32457 but changing the `Code` column to  `Label` which matches what you get in the json using the API