### PR TITLE
FIX late customer orders are not shown on start page

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3698,8 +3698,7 @@ class Commande extends CommonOrder
 				$response->nbtodo++;
 				$response->total += $obj->total_ht;
 
-				$generic_commande->statut = $obj->fk_statut;
-				$generic_commande->date_commande = $this->db->jdate($obj->date_commande);
+				$generic_commande->status = $obj->fk_statut;
 				$generic_commande->date = $this->db->jdate($obj->date_commande);
 				$generic_commande->delivery_date = $this->db->jdate($obj->delivery_date);
 


### PR DESCRIPTION
# FIX late customer orders are not shown on start page
due to an mismatch of the used variable in hasDelay (status) and the setted variable (statut) the late orders where never shown in the start page as the count was always wrongly zero.