### PR TITLE
FIX re-create API temp dir after purging temp files

### DIFF
--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -58,6 +58,18 @@ class DolibarrApi
 
 		$this->db = $db;
 		$production_mode = (empty($conf->global->API_PRODUCTION_MODE) ? false : true);
+
+		if ($production_mode) {
+			// Create the directory Defaults::$cacheDirectory if it does not exist. If dir does not exist, using production_mode generates an error 500.
+			include_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+			if (!dol_is_dir(Defaults::$cacheDirectory)) {
+				dol_mkdir(Defaults::$cacheDirectory, DOL_DATA_ROOT);
+			}
+			if (getDolGlobalString('MAIN_API_DEBUG')) {
+				dol_syslog("Debug API construct::cacheDirectory=".Defaults::$cacheDirectory, LOG_DEBUG, 0, '_api');
+			}
+		}
+
 		$this->r = new Restler($production_mode, $refreshCache);
 
 		$urlwithouturlroot = preg_replace('/'.preg_quote(DOL_URL_ROOT, '/').'$/i', '', trim($dolibarr_main_url_root));

--- a/htdocs/core/class/utils.class.php
+++ b/htdocs/core/class/utils.class.php
@@ -168,8 +168,25 @@ class Utils
 		}
 
 		// Recreate temp dir that are not automatically recreated by core code for performance purpose, we need them
-		if (!empty($conf->api->enabled)) {
-			dol_mkdir($conf->api->dir_temp);
+		if (isModEnabled('api')) {
+			if (isModEnabled('multicompany')) {
+				global $mc;
+
+				if (is_object($mc)) {
+					$entitiesList = $mc->getEntitiesList();
+					foreach ($entitiesList as $entityId => $entity) {
+						if ($entityId > 1) {
+							$apiDir = DOL_DATA_ROOT.'/'.$entityId.'/api';
+							if (is_dir($apiDir)) { // only create API temp directory of entity (can create routes.php file from Restler API) if Restler API is enabled (API directory exists)
+								$apiTempDir = DOL_DATA_ROOT.'/'.$entityId.'/api/temp/';
+								dol_mkdir($apiTempDir);
+							}
+						}
+					}
+				}
+			}
+
+			dol_mkdir($conf->api->dir_temp); // create API temp directory for main entity (can create routes.php file from Restler API)
 		}
 		dol_mkdir($conf->user->dir_temp);
 

--- a/htdocs/core/class/utils.class.php
+++ b/htdocs/core/class/utils.class.php
@@ -169,24 +169,7 @@ class Utils
 
 		// Recreate temp dir that are not automatically recreated by core code for performance purpose, we need them
 		if (isModEnabled('api')) {
-			if (isModEnabled('multicompany')) {
-				global $mc;
-
-				if (is_object($mc)) {
-					$entitiesList = $mc->getEntitiesList();
-					foreach ($entitiesList as $entityId => $entity) {
-						if ($entityId > 1) {
-							$apiDir = DOL_DATA_ROOT.'/'.$entityId.'/api';
-							if (is_dir($apiDir)) { // only create API temp directory of entity (can create routes.php file from Restler API) if Restler API is enabled (API directory exists)
-								$apiTempDir = DOL_DATA_ROOT.'/'.$entityId.'/api/temp/';
-								dol_mkdir($apiTempDir);
-							}
-						}
-					}
-				}
-			}
-
-			dol_mkdir($conf->api->dir_temp); // create API temp directory for main entity (can create routes.php file from Restler API)
+			dol_mkdir($conf->api->dir_temp);
 		}
 		dol_mkdir($conf->user->dir_temp);
 


### PR DESCRIPTION
FIX re-create API temp dir after purging temp files

**Before**
When purge files is launched and Restler API is enabled and multicompany is enabled :
- API temp directory is deleted for all entities and only re-created for main entity [entity=1]
So when we try to create a third-party for an another entity, the request return a "Not allowed" response.
However the third-party is created and the result of request is not the "id" of created third-party.

The problem is the "routes.php" file for Restler API is not created for the entity (example : "2/api/temp" is not created for entity 2).

**To reproduce**
Enable multicompany and Rest API in entity 2.
Delete "2/api/temp" directory using purge files process or manually.

Try to create a third-party on entity 2.
curl --location --request POST 'DOLIBARR_URL/api/index.php/thirdparties' \
--header 'DOLAPIKEY: USER_API_KEY' \
--header 'DOLAPIENTITY: ENTITY' \
--header 'Content-Type: application/json' \
--data '{
  "entity": ENTITY,
  "name": "TEST Toto",
  "name_alias": "",
  "email": "test@test.test",
  "phone": "",
  "tva_assuj": "1",
  "tva_intra": "",
  "typent_id": "8",
  "lastname": "TEST",
  "firstname": "Toto",
  "address": "Rue du test",
  "zip": "00001",
  "town": "AIN",
  "country_id": "1",
  "country_code": "FR"
}'

**After**
The purge files re-create all API (if API is enabled and multicompany is enabled) temp directories after puging all temp directories and files.

So the "routes.php" file can be regenerated in API temp directory when we call the API with requests.

