### PR TITLE
[UIUX] Displaying the label instead of the id for the fiscal year

### DIFF
--- a/htdocs/accountancy/admin/fiscalyear_card.php
+++ b/htdocs/accountancy/admin/fiscalyear_card.php
@@ -334,13 +334,19 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	// ------------------------------------------------------------
 	$linkback = '<a href="'.DOL_URL_ROOT.'/accountancy/admin/fiscalyear.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 
-	dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref', $morehtmlref);
+	dol_banner_tab($object, 'label', $linkback, 1, 'label', 'label', $morehtmlref);
 
 
 	print '<div class="fichecenter">';
 	print '<div class="fichehalfleft">';
 	print '<div class="underbanner clearboth"></div>';
 	print '<table class="border centpercent tableforfield">'."\n";
+
+	// Id
+	print "<tr>";
+	print '<td class="titlefield">'.$langs->trans("Id").'</td><td>';
+	print $object->id;
+	print '</td></tr>';
 
 	// Label
 	print '<tr><td class="tdtop">';


### PR DESCRIPTION
# UIUX| #34138  Display fiscal year label instead of ID in Accounting module
This Pull Request addresses a user experience issue within the Accounting module where the Fiscal Year was being displayed using its internal database ID, which is not user-friendly.
