### PR TITLE
FIX: categories: sql error in link extrafields targettings categories

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -9138,7 +9138,11 @@ class Form
 		// Search data
 		$sql = "SELECT t.rowid, " . $fieldstoshow . " FROM " . $this->db->prefix() . $this->db->sanitize($objecttmp->table_element) . " as t";
 		if (!empty($objecttmp->isextrafieldmanaged)) {
-			$sql .= " LEFT JOIN " . $this->db->prefix() . $this->db->sanitize($objecttmp->table_element) . "_extrafields as e ON t.rowid = e.fk_object";
+			$extrafieldTable = $objecttmp->table_element;
+			if ($extrafieldTable == 'categorie') {
+				$extrafieldTable = 'categories'; // For compatibility
+			}
+			$sql .= " LEFT JOIN " . $this->db->prefix() . $this->db->sanitize($extrafieldTable) . "_extrafields as e ON t.rowid = e.fk_object";
 		}
 		if (!empty($objecttmp->parent_element)) {	// If parent_element is defined
 			$parent_properties = getElementProperties($objecttmp->parent_element);


### PR DESCRIPTION
# FIX: categories: sql error in link extrafields targettings categories

Category objects have been recently tagged as handling extrafields. Where most existing code seemed to correctly handle this case, the method `Form::selectForFormsList()` did not, it caused the following when having a link extrafield targetting a category :

```
Requête dernier accès en base en erreur: SELECT t.rowid, t.label FROM llx_categorie as t LEFT JOIN llx_categorie_extrafields as e ON t.rowid = e.fk_object WHERE 1=1 AND t.entity IN (1) AND (((t.type = 6) and (t.fk_parent = 61))) ORDER BY t.label ASC
Code retour dernier accès en base en erreur: DB_ERROR_NOSUCHTABLE
Information sur le dernier accès en base en erreur: Table 'dolibarr_220.llx_categorie_extrafields' doesn't exist
```