### PR TITLE
FIX: resize iban column to support encryption

### DIFF
--- a/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
+++ b/htdocs/install/mysql/migration/20.0.0-21.0.0.sql
@@ -94,9 +94,8 @@ ALTER TABLE llx_product DROP FOREIGN KEY fk_product_default_warehouse;
 
 DROP TABLE llx_contratdet_log;
 
-ALTER TABLE llx_societe_rib MODIFY COLUMN iban_prefix varchar(80);
-ALTER TABLE llx_bank_account MODIFY COLUMN iban_prefix varchar(80);
-ALTER TABLE llx_user_rib MODIFY COLUMN iban_prefix varchar(80);
+ALTER TABLE llx_bank_account MODIFY COLUMN iban_prefix varchar(100);
+ALTER TABLE llx_user_rib MODIFY COLUMN iban_prefix varchar(100);
 
 ALTER TABLE llx_bom_bom ADD COLUMN last_main_doc varchar(255) AFTER model_pdf;
 

--- a/htdocs/install/mysql/tables/llx_bank_account.sql
+++ b/htdocs/install/mysql/tables/llx_bank_account.sql
@@ -39,7 +39,7 @@ create table llx_bank_account
   cle_rib					varchar(5),
   bic						varchar(11),                -- 11 according to ISO 9362
   bic_intermediate          varchar(11),                -- 11 according to ISO 9362. Same as bic but for intermediate bank
-  iban_prefix				varchar(80),				-- full iban. 34 according to ISO 13616 but we set 80 to allow to store it with encryption information
+  iban_prefix				varchar(100),				-- full iban. 34 according to ISO 13616 but we set 100 to allow to store it with encryption information
   country_iban				varchar(2),					-- deprecated
   cle_iban					varchar(2),
   domiciliation				varchar(255),

--- a/htdocs/install/mysql/tables/llx_user_rib.sql
+++ b/htdocs/install/mysql/tables/llx_user_rib.sql
@@ -31,7 +31,7 @@ create table llx_user_rib
   cle_rib           varchar(5),    -- key of bank account
   bic               varchar(11),   -- 11 according to ISO 9362
   bic_intermediate  varchar(11),   -- 11 according to ISO 9362. Same as bic but for intermediate bank
-  iban_prefix       varchar(80),   -- full iban. 34 according to ISO 13616 but we set 80 to allow to store it with encryption information
+  iban_prefix       varchar(100),   -- full iban. 34 according to ISO 13616 but we set 100 to allow to store it with encryption information
   domiciliation     varchar(255),
   proprio           varchar(60),
   owner_address     varchar(255),


### PR DESCRIPTION
# FIX: resize iban column to support encryption

IBAN column has been enlarged in 21 to 22 migration script to permit storing IBAN data with spaces, but reexcuting 20 to 21 migration scripts in case it has been modified, truncates it back to 80 characters.

So change also length in 20 to 21 migration script and table definititons. 

