### PR TITLE
FIX keep user who validate proposal on update

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -183,7 +183,6 @@ class Propal extends CommonObject
 	public $fin_validite;
 
 	public $user_author_id;
-	public $user_valid_id;
 	public $user_close_id;
 
 	/**
@@ -1369,7 +1368,7 @@ class Propal extends CommonObject
 
 		// Clear fields
 		$object->user_author = $user->id;
-		$object->user_valid = '';
+		$object->user_validation_id = 0;
 		$object->date = $now;
 		$object->datep = $now; // deprecated
 		$object->fin_validite = $object->date + ($object->duree_validite * 24 * 3600);
@@ -1554,7 +1553,7 @@ class Propal extends CommonObject
 				$this->extraparams = (array) json_decode($obj->extraparams, true);
 
 				$this->user_author_id = $obj->fk_user_author;
-				$this->user_valid_id = $obj->fk_user_valid;
+				$this->user_validation_id = $obj->fk_user_valid;
 				$this->user_close_id = $obj->fk_user_cloture;
 
 				//Incoterms
@@ -1656,7 +1655,7 @@ class Propal extends CommonObject
 		$sql .= " total_ttc=".(isset($this->total_ttc) ? $this->total_ttc : "null").",";
 		$sql .= " fk_statut=".(isset($this->statut) ? $this->statut : "null").",";
 		$sql .= " fk_user_author=".(isset($this->user_author_id) ? $this->user_author_id : "null").",";
-		$sql .= " fk_user_valid=".(isset($this->user_valid) ? $this->user_valid : "null").",";
+		$sql .= " fk_user_valid = ".(!empty($this->user_validation_id) ? (int) $this->user_validation_id : "null").",";
 		$sql .= " fk_projet=".(isset($this->fk_project) ? $this->fk_project : "null").",";
 		$sql .= " fk_cond_reglement=".(isset($this->cond_reglement_id) ? $this->cond_reglement_id : "null").",";
 		$sql .= " fk_mode_reglement=".(isset($this->mode_reglement_id) ? $this->mode_reglement_id : "null").",";
@@ -1942,7 +1941,7 @@ class Propal extends CommonObject
 			$this->ref = $num;
 			$this->brouillon = 0;
 			$this->statut = self::STATUS_VALIDATED;
-			$this->user_valid_id = $user->id;
+			$this->user_validation_id = $user->id;
 			$this->datev = $now;
 
 			$this->db->commit();
@@ -3199,9 +3198,7 @@ class Propal extends CommonObject
 				$this->user_creation = $cuser;
 
 				if ($obj->fk_user_valid) {
-					$vuser = new User($this->db);
-					$vuser->fetch($obj->fk_user_valid);
-					$this->user_validation = $vuser;
+					$this->user_validation_id = $obj->fk_user_valid;
 				}
 
 				if ($obj->fk_user_signature) {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -481,6 +481,11 @@ abstract class CommonObject
 	 */
 	public $date_modification; // Date last change (tms field)
 
+	/**
+	 * @var int|null		User id of validation
+	 */
+	public $user_validation_id;
+
 	public $next_prev_filter;
 
 	/**


### PR DESCRIPTION
FIX keep user who validate proposal on update :
- when you valid a proposal and you call update method of this proposal object, the user who validate is reset to NULL
- this is due of field "user_valid" is not in fetch method (it's the "user_valid_id" field)

So, to keep compatibility with develop, I rename "user_valid" to "user_validation_id".
I use the same "user_validation_id" in all methods of proposal object.
This attribute is defined in common object class.
