### PR TITLE
NEW: API set contact for any type in proposal, order or invoice dictionary (breaks API proposal)

### DIFF
--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -310,6 +310,7 @@ class Proposals extends DolibarrApi
 	 */
 	public function post($request_data = null)
 	{
+		global $conf;
 		if (!DolibarrApiAccess::$user->hasRight('propal', 'creer')) {
 			throw new RestException(403, "Insufficiant rights");
 		}
@@ -710,7 +711,7 @@ class Proposals extends DolibarrApi
 	 *
 	 * @param int    $id             Id of commercial proposal to update
 	 * @param int    $contactid      Id of external or internal contact to add
-	 * @param string $type           Type of the external contact (BILLING, SHIPPING, CUSTOMER), internal contact (SALESREPFOLL)
+	 * @param string $type           Type (code in dictionary) of the external contact (BILLING, SHIPPING, CUSTOMER), internal contact (SALESREPFOLL)
 	 * @param string $source         Source of the contact (usually either: internal, external)
 	 * @return array
 	 * @phan-return array{success:array{code:int,message:string}}
@@ -735,10 +736,10 @@ class Proposals extends DolibarrApi
 			throw new RestException(404, 'Proposal not found');
 		}
 
+		// test source
 		if (empty($source)) {
 			throw new RestException(400, 'Source can not be empty');
 		}
-
 		$sql_distinct_source = "SELECT DISTINCT source";
 		$sql_distinct_source .= " FROM ".MAIN_DB_PREFIX."c_type_contact";
 		$sql_distinct_source .= " WHERE element LIKE 'propal'";
@@ -748,7 +749,7 @@ class Proposals extends DolibarrApi
 		$source_array = array();
 
 		if ($source_result) {
-			$num = $this->db->num_rows($result);
+			$num = $this->db->num_rows($source_result);
 			$i = 0;
 			while ($i < $num) {
 				$obj = $this->db->fetch_object($source_result);
@@ -760,10 +761,41 @@ class Proposals extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving a list of propal contact sources: '.$this->db->lasterror());
 		}
-
 		if (!in_array($source, (array) $source_array, true)) {
 			throw new RestException(400, 'Source='.$source.' not found in dictionary with proposal contact types');
 		}
+
+		// test type
+		if (empty($type)) {
+			throw new RestException(400, 'type can not be empty');
+		}
+		// variable called type here, but code in dictionary and database
+		$sql_distinct_type = "SELECT DISTINCT code";
+		$sql_distinct_type .= " FROM ".MAIN_DB_PREFIX."c_type_contact";
+		$sql_distinct_type .= " WHERE element LIKE 'propal'";
+		$sql_distinct_type .= " AND source='".$this->db->escape($source)."'";
+		$sql_distinct_type .= " AND code is NOT NULL";
+		$sql_distinct_type .= " AND active != 0";
+		$type_result = $this->db->query($sql_distinct_type);
+		$type_array = array();
+
+		if ($type_result) {
+			$num = $this->db->num_rows($type_result);
+			$i = 0;
+			while ($i < $num) {
+				$obj = $this->db->fetch_object($type_result);
+				$type_kind = (string) $obj->source;
+				array_push($type_array, $type_kind);
+				dol_syslog("type_kind=".$type_kind);
+				$i++;
+			}
+		} else {
+			throw new RestException(503, 'Error when retrieving a list of propal contact types: '.$this->db->lasterror());
+		}
+		if (!in_array($source, (array) $type_array, true)) {
+			throw new RestException(400, 'Type='.$type.' not found in dictionary with proposal contact types');
+		}
+
 
 		if ($source == 'external' && !in_array($type, array('BILLING', 'SHIPPING', 'CUSTOMER'), true)) {
 			throw new RestException(500, 'Availables external types: BILLING, SHIPPING OR CUSTOMER');

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -136,7 +136,9 @@ class Proposals extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('propal', 'lire')) {
 			throw new RestException(403);
 		}
-
+		if ($id == 0) {
+			throw new RestException(400, 'No proposal with id=0 can exist');
+		}
 		$result = $this->propal->fetch($id, $ref, $ref_ext);
 		if (!$result) {
 			throw new RestException(404, 'Commercial Proposal not found');
@@ -319,6 +321,12 @@ class Proposals extends DolibarrApi
 				// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again with the caller
 				$this->propal->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
 				continue;
+			}
+			if ($field == 'id') {
+				throw new RestException(400, 'Creating with id field is forbidden');
+			}
+			if ($field == 'entity' && ((int) $value) != ((int) $conf->entity)) {
+				throw new RestException(403, 'Creating with entity='.((int) $value).' MUST be the same entity='.((int) $conf->entity).' as your API user/key belongs to');
 			}
 
 			$this->propal->$field = $this->_checkValForAPI($field, $value, $this->propal);
@@ -847,7 +855,9 @@ class Proposals extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('propal', 'creer')) {
 			throw new RestException(403);
 		}
-
+		if ($id == 0) {
+			throw new RestException(400, 'No proposal with id=0 can exist');
+		}
 		$result = $this->propal->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Proposal not found');
@@ -909,6 +919,10 @@ class Proposals extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('propal', 'supprimer')) {
 			throw new RestException(403);
 		}
+		if ($id == 0) {
+			throw new RestException(400, 'No proposal with id=0 can exist');
+		}
+
 		$result = $this->propal->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Commercial Proposal not found');

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -709,31 +709,26 @@ class Proposals extends DolibarrApi
 	 *
 	 * @since	10.0.0	Initial implementation
 	 *
-	 * @param int    $id             Id of commercial proposal to update
-	 * @param int    $contactid      Id of external or internal contact to add
-	 * @param string $type           Type (code in dictionary) of the external contact (BILLING, SHIPPING, CUSTOMER), internal contact (SALESREPFOLL)
-	 * @param string $source         Source of the contact (usually either: internal, external)
+	 * @param int    $id            Id of commercial proposal to update
+	 * @param int    $contactid     Id of contact to add
+	 * @param string $type          Type (code in dictionary) of the contact (BILLING, SHIPPING, CUSTOMER + possibly your own)
+	 * @param string $source		internal=Contact intern (llx_user), external=Contact extern (llx_socpeople)
+	 * @param int    $notrigger		0=Enable all triggers (default), 1=Disable all triggers
 	 * @return array
 	 * @phan-return array{success:array{code:int,message:string}}
 	 * @phpstan-return array{success:array{code:int,message:string}}
 	 *
-	 * @url	POST {id}/contact/{contactid}/{type}/{source}
+	 * @url	POST {id}/contact/{contactid}/{type}
 	 *
 	 * @throws RestException 400
 	 * @throws RestException 401
 	 * @throws RestException 404
 	 * @throws RestException 503
 	 */
-	public function postContact($id, $contactid, $type, $source = 'external')
+	public function postContact($id, $contactid, $type, $source = 'external', $notrigger = 0)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('propal', 'creer')) {
 			throw new RestException(403);
-		}
-
-		$result = $this->propal->fetch($id);
-
-		if (!$result) {
-			throw new RestException(404, 'Proposal not found');
 		}
 
 		// test source
@@ -762,7 +757,7 @@ class Proposals extends DolibarrApi
 			throw new RestException(503, 'Error when retrieving a list of propal contact sources: '.$this->db->lasterror());
 		}
 		if (!in_array($source, (array) $source_array, true)) {
-			throw new RestException(400, 'Source='.$source.' not found in dictionary with proposal contact types');
+			throw new RestException(400, 'Combo of Source='.$source.' and Type='.$type.' not found in dictionary with active proposal contact types');
 		}
 
 		// test type
@@ -794,14 +789,19 @@ class Proposals extends DolibarrApi
 			throw new RestException(503, 'Error when retrieving a list of propal contact types: '.$this->db->lasterror());
 		}
 		if (!in_array($type, (array) $type_array, true)) {
-			throw new RestException(400, 'Type='.$type.' not found in dictionary with active proposal contact types');
+			throw new RestException(400, 'Combo of Type='.$type.' and Source='.$source.' not found in dictionary with active proposal contact types');
 		}
 
+		// tests done, let's get it
+		$result = $this->propal->fetch($id);
+		if (!$result) {
+			throw new RestException(404, 'Proposal not found');
+		}
 		if (!DolibarrApi::_checkAccessToResource('propal', $this->propal->id)) {
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
-		$result = $this->propal->add_contact($contactid, $type, $source);
+		$result = $this->propal->add_contact($contactid, $type, $source, $notrigger);
 
 		if ($result == 0) {
 			throw new RestException(400, 'Already exists: Contact='.$contactid.' is already linked to the proposal='.$id.' as source='.$source.' and type='.$type);

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -703,15 +703,17 @@ class Proposals extends DolibarrApi
 	 * @param int    $id             Id of commercial proposal to update
 	 * @param int    $contactid      Id of external or internal contact to add
 	 * @param string $type           Type of the external contact (BILLING, SHIPPING, CUSTOMER), internal contact (SALESREPFOLL)
-	 * @param string $source         Source of the contact (internal, external)
+	 * @param string $source         Source of the contact (usually either: internal, external)
 	 * @return array
 	 * @phan-return array{success:array{code:int,message:string}}
 	 * @phpstan-return array{success:array{code:int,message:string}}
 	 *
 	 * @url	POST {id}/contact/{contactid}/{type}/{source}
 	 *
+	 * @throws RestException 400
 	 * @throws RestException 401
 	 * @throws RestException 404
+	 * @throws RestException 503
 	 */
 	public function postContact($id, $contactid, $type, $source = 'external')
 	{
@@ -725,8 +727,34 @@ class Proposals extends DolibarrApi
 			throw new RestException(404, 'Proposal not found');
 		}
 
-		if (!in_array($source, array('internal', 'external'), true)) {
-			throw new RestException(500, 'Availables sources: internal OR external');
+		if (empty($source)) {
+			throw new RestException(400, 'Source can not be empty');
+		}
+
+		$sql_distinct_source = "SELECT DISTINCT source";
+		$sql_distinct_source .= " FROM ".MAIN_DB_PREFIX."c_type_contact";
+		$sql_distinct_source .= " WHERE element LIKE 'propal'";
+		$sql_distinct_source .= " AND source is NOT NULL";
+		$sql_distinct_source .= " AND active != 0";
+		$source_result = $this->db->query($sql_distinct_source);
+		$source_array = array();
+
+		if ($source_result) {
+			$num = $this->db->num_rows($result);
+			$i = 0;
+			while ($i < $num) {
+				$obj = $this->db->fetch_object($source_result);
+				$source_kind = (string) $obj->source;
+				array_push($source_array, $source_kind);
+				dol_syslog("source_kind=".$source_kind);
+				$i++;
+			}
+		} else {
+			throw new RestException(503, 'Error when retrieving a list of propal contact sources: '.$this->db->lasterror());
+		}
+
+		if (!in_array($source, (array) $source_array, true)) {
+			throw new RestException(400, 'Source='.$source.' not found in dictionary with proposal contact types');
 		}
 
 		if ($source == 'external' && !in_array($type, array('BILLING', 'SHIPPING', 'CUSTOMER'), true)) {

--- a/htdocs/comm/propal/class/api_proposals.class.php
+++ b/htdocs/comm/propal/class/api_proposals.class.php
@@ -784,7 +784,8 @@ class Proposals extends DolibarrApi
 			$i = 0;
 			while ($i < $num) {
 				$obj = $this->db->fetch_object($type_result);
-				$type_kind = (string) $obj->source;
+				// variable called type here, but code in dictionary and database
+				$type_kind = (string) $obj->code;
 				array_push($type_array, $type_kind);
 				dol_syslog("type_kind=".$type_kind);
 				$i++;
@@ -792,17 +793,8 @@ class Proposals extends DolibarrApi
 		} else {
 			throw new RestException(503, 'Error when retrieving a list of propal contact types: '.$this->db->lasterror());
 		}
-		if (!in_array($source, (array) $type_array, true)) {
-			throw new RestException(400, 'Type='.$type.' not found in dictionary with proposal contact types');
-		}
-
-
-		if ($source == 'external' && !in_array($type, array('BILLING', 'SHIPPING', 'CUSTOMER'), true)) {
-			throw new RestException(500, 'Availables external types: BILLING, SHIPPING OR CUSTOMER');
-		}
-
-		if ($source == 'internal' && !in_array($type, array('SALESREPFOLL'), true)) {
-			throw new RestException(500, 'Availables internal types: SALESREPFOLL');
+		if (!in_array($type, (array) $type_array, true)) {
+			throw new RestException(400, 'Type='.$type.' not found in dictionary with active proposal contact types');
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('propal', $this->propal->id)) {
@@ -811,6 +803,24 @@ class Proposals extends DolibarrApi
 
 		$result = $this->propal->add_contact($contactid, $type, $source);
 
+		if ($result == 0) {
+			throw new RestException(400, 'Already exists: Contact='.$contactid.' is already linked to the proposal='.$id.' as source='.$source.' and type='.$type);
+		} elseif ($result == -1) {
+			throw new RestException(400, 'Wrong contact='.$contactid);
+		} elseif ($result == -2) {
+			throw new RestException(400, 'Wrong type='.$type);
+		} elseif ($result == -3) {
+			throw new RestException(400, 'Not allowed contacts');
+		} elseif ($result == -4) {
+			throw new RestException(400, 'ErrorCommercialNotAllowedForThirdparty');
+		} elseif ($result == -5) {
+			throw new RestException(400, 'Trigger failed');
+		} elseif ($result == -6) {
+			throw new RestException(400, 'DB_ERROR_RECORD_ALREADY_EXISTS');
+		} elseif ($result == -7) {
+			throw new RestException(400, 'Some other error');
+		}
+
 		if (!$result) {
 			throw new RestException(500, 'Error when added the contact');
 		}
@@ -818,7 +828,7 @@ class Proposals extends DolibarrApi
 		return array(
 			'success' => array(
 				'code' => 200,
-				'message' => 'Contact linked to the proposal'
+				'message' => 'Contact='.$contactid.' linked to the proposal='.$id.' as '.$source.' '.$type
 			)
 		);
 	}

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -315,6 +315,7 @@ class Orders extends DolibarrApi
 	 */
 	public function post($request_data = null)
 	{
+		global $conf;
 		if (!DolibarrApiAccess::$user->hasRight('commande', 'creer')) {
 			throw new RestException(403, "Insufficiant rights");
 		}

--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -124,7 +124,9 @@ class Orders extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('commande', 'lire')) {
 			throw new RestException(403);
 		}
-
+		if ($id == 0) {
+			throw new RestException(400, 'No order with id=0 can exist');
+		}
 		$result = $this->commande->fetch($id, $ref, $ref_ext);
 		if (!$result) {
 			throw new RestException(404, 'Order not found');
@@ -324,6 +326,12 @@ class Orders extends DolibarrApi
 				// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again with the caller
 				$this->commande->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
 				continue;
+			}
+			if ($field == 'id') {
+				throw new RestException(400, 'Creating with id field is forbidden');
+			}
+			if ($field == 'entity' && ((int) $value) != ((int) $conf->entity)) {
+				throw new RestException(403, 'Creating with entity='.((int) $value).' MUST be the same entity='.((int) $conf->entity).' as your API user/key belongs to');
 			}
 
 			$this->commande->$field = $this->_checkValForAPI($field, $value, $this->commande);
@@ -622,19 +630,21 @@ class Orders extends DolibarrApi
 	/**
 	 * Add a contact type of given order
 	 *
-	 * @param int    $id             Id of order to update
-	 * @param int    $contactid      Id of contact to add
-	 * @param string $type           Type of the contact (BILLING, SHIPPING, CUSTOMER)
-	 * @param   string  $source		 external=Contact extern (llx_socpeople), internal=Contact intern (llx_user)
-	 * @param   int     $notrigger   Disable all triggers
+	 * @param int    $id            Id of order to update
+	 * @param int    $contactid     Id of contact to add
+	 * @param string $type          Type (code in dictionary) of the contact (BILLING, SHIPPING, CUSTOMER + possibly your own)
+	 * @param string $source		internal=Contact intern (llx_user), external=Contact extern (llx_socpeople)
+	 * @param int    $notrigger		0=Enable all triggers (default), 1=Disable all triggers
 	 * @return array
 	 * @phan-return array{success:array{code:int,message:string}}
 	 * @phpstan-return array{success:array{code:int,message:string}}
 	 *
 	 * @url	POST {id}/contact/{contactid}/{type}
 	 *
+	 * @throws RestException 400
 	 * @throws RestException 401
 	 * @throws RestException 404
+	 * @throws RestException 503
 	 */
 	public function postContact($id, $contactid, $type, $source = "external", $notrigger = 0)
 	{
@@ -642,29 +652,100 @@ class Orders extends DolibarrApi
 			throw new RestException(403);
 		}
 
+		// test source
+		if (empty($source)) {
+			throw new RestException(400, 'Source can not be empty');
+		}
+		$sql_distinct_source = "SELECT DISTINCT source";
+		$sql_distinct_source .= " FROM ".MAIN_DB_PREFIX."c_type_contact";
+		$sql_distinct_source .= " WHERE element LIKE 'commande'";
+		$sql_distinct_source .= " AND source is NOT NULL";
+		$sql_distinct_source .= " AND active != 0";
+		$source_result = $this->db->query($sql_distinct_source);
+		$source_array = array();
+
+		if ($source_result) {
+			$num = $this->db->num_rows($source_result);
+			$i = 0;
+			while ($i < $num) {
+				$obj = $this->db->fetch_object($source_result);
+				$source_kind = (string) $obj->source;
+				array_push($source_array, $source_kind);
+				dol_syslog("source_kind=".$source_kind);
+				$i++;
+			}
+		} else {
+			throw new RestException(503, 'Error when retrieving a list of order contact sources: '.$this->db->lasterror());
+		}
+		if (!in_array($source, (array) $source_array, true)) {
+			throw new RestException(400, 'Combo of Source='.$source.' and Type='.$type.' not found in dictionary with active order contact types');
+		}
+
+		// test type
+		if (empty($type)) {
+			throw new RestException(400, 'type can not be empty');
+		}
+		// variable called type here, but code in dictionary and database
+		$sql_distinct_type = "SELECT DISTINCT code";
+		$sql_distinct_type .= " FROM ".MAIN_DB_PREFIX."c_type_contact";
+		$sql_distinct_type .= " WHERE element LIKE 'commande'";
+		$sql_distinct_type .= " AND source='".$this->db->escape($source)."'";
+		$sql_distinct_type .= " AND code is NOT NULL";
+		$sql_distinct_type .= " AND active != 0";
+		$type_result = $this->db->query($sql_distinct_type);
+		$type_array = array();
+
+		if ($type_result) {
+			$num = $this->db->num_rows($type_result);
+			$i = 0;
+			while ($i < $num) {
+				$obj = $this->db->fetch_object($type_result);
+				// variable called type here, but code in dictionary and database
+				$type_kind = (string) $obj->code;
+				array_push($type_array, $type_kind);
+				dol_syslog("type_kind=".$type_kind);
+				$i++;
+			}
+		} else {
+			throw new RestException(503, 'Error when retrieving a list of order contact types: '.$this->db->lasterror());
+		}
+		if (!in_array($type, (array) $type_array, true)) {
+			throw new RestException(400, 'Combo of Type='.$type.' and Source='.$source.' not found in dictionary with active order contact types');
+		}
+
+		// tests done, let's get it
 		$result = $this->commande->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Order not found');
 		}
-
 		if (!DolibarrApi::_checkAccessToResource('commande', $this->commande->id)) {
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$result = $this->commande->add_contact($contactid, $type, $source, $notrigger);
 
-		if ($result < 0) {
-			throw new RestException(500, 'Error when added the contact');
-		}
-
 		if ($result == 0) {
-			throw new RestException(304, 'contact already added');
+			throw new RestException(400, 'Already exists: Contact='.$contactid.' is already linked to the order='.$id.' as source='.$source.' and type='.$type);
+		} elseif ($result == -1) {
+			throw new RestException(400, 'Wrong contact='.$contactid);
+		} elseif ($result == -2) {
+			throw new RestException(400, 'Wrong type='.$type);
+		} elseif ($result == -3) {
+			throw new RestException(400, 'Not allowed contacts');
+		} elseif ($result == -4) {
+			throw new RestException(400, 'ErrorCommercialNotAllowedForThirdparty');
+		} elseif ($result == -5) {
+			throw new RestException(400, 'Trigger failed');
+		} elseif ($result == -6) {
+			throw new RestException(400, 'DB_ERROR_RECORD_ALREADY_EXISTS');
+		} elseif ($result == -7) {
+			throw new RestException(400, 'Some other error');
 		}
 
 		return array(
 			'success' => array(
 				'code' => 200,
-				'message' => 'Contact linked to the order'
+				'message' => 'Contact='.$contactid.' linked to the order='.$id.' as '.$source.' '.$type
 			)
 		);
 	}
@@ -736,7 +817,9 @@ class Orders extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('commande', 'creer')) {
 			throw new RestException(403);
 		}
-
+		if ($id == 0) {
+			throw new RestException(400, 'No order with id=0 can exist');
+		}
 		$result = $this->commande->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Order not found');
@@ -790,6 +873,9 @@ class Orders extends DolibarrApi
 	{
 		if (!DolibarrApiAccess::$user->hasRight('commande', 'supprimer')) {
 			throw new RestException(403);
+		}
+		if ($id == 0) {
+			throw new RestException(400, 'No order with id=0 can exist');
 		}
 		$result = $this->commande->fetch($id);
 		if (!$result) {

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -141,7 +141,9 @@ class Invoices extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('facture', 'lire')) {
 			throw new RestException(403);
 		}
-
+		if ($id == 0) {
+			throw new RestException(400, 'No invoice with id=0 can exist');
+		}
 		$result = $this->invoice->fetch($id, $ref, $ref_ext);
 		if (!$result) {
 			throw new RestException(404, 'Invoice not found');
@@ -364,6 +366,12 @@ class Invoices extends DolibarrApi
 				$this->invoice->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
 				continue;
 			}
+			if ($field == 'id') {
+				throw new RestException(400, 'Creating with id field is forbidden');
+			}
+			if ($field == 'entity' && ((int) $value) != ((int) $conf->entity)) {
+				throw new RestException(403, 'Creating with entity='.((int) $value).' MUST be the same entity='.((int) $conf->entity).' as your API user/key belongs to');
+			}
 
 			$this->invoice->$field = $this->_checkValForAPI($field, $value, $this->invoice);
 		}
@@ -580,12 +588,12 @@ class Invoices extends DolibarrApi
 	/**
 	 * Add a contact type of given invoice
 	 *
-	 * @param	int    $id             Id of invoice to update
-	 * @param	int    $contactid      Id of contact to add
-	 * @param	string $type           Type of the contact (BILLING, SHIPPING, CUSTOMER)
-	 * @param   string  $source		   external=Contact extern (llx_socpeople), internal=Contact intern (llx_user)
-	 * @param   int     $notrigger     Disable all triggers
-	 * @return	array
+	 * @param int    $id            Id of invoice to update
+	 * @param int    $contactid     Id of contact to add
+	 * @param string $type          Type (code in dictionary) of the contact (BILLING, SHIPPING, CUSTOMER + possibly your own)
+	 * @param string $source		internal=Contact intern (llx_user), external=Contact extern (llx_socpeople)
+	 * @param int    $notrigger		0=Enable all triggers (default), 1=Disable all triggers
+	 * @return array
 	 * @phan-return array{success:array{code:int,message:string}}
 	 * @phpstan-return array{success:array{code:int,message:string}}
 	 *
@@ -600,21 +608,95 @@ class Invoices extends DolibarrApi
 			throw new RestException(403);
 		}
 
-		$result = $this->invoice->fetch($id);
+		// test source
+		if (empty($source)) {
+			throw new RestException(400, 'Source can not be empty');
+		}
+		$sql_distinct_source = "SELECT DISTINCT source";
+		$sql_distinct_source .= " FROM ".MAIN_DB_PREFIX."c_type_contact";
+		$sql_distinct_source .= " WHERE element LIKE 'facture'";
+		$sql_distinct_source .= " AND source is NOT NULL";
+		$sql_distinct_source .= " AND active != 0";
+		$source_result = $this->db->query($sql_distinct_source);
+		$source_array = array();
 
+		if ($source_result) {
+			$num = $this->db->num_rows($source_result);
+			$i = 0;
+			while ($i < $num) {
+				$obj = $this->db->fetch_object($source_result);
+				$source_kind = (string) $obj->source;
+				array_push($source_array, $source_kind);
+				dol_syslog("source_kind=".$source_kind);
+				$i++;
+			}
+		} else {
+			throw new RestException(503, 'Error when retrieving a list of invoice contact sources: '.$this->db->lasterror());
+		}
+		if (!in_array($source, (array) $source_array, true)) {
+			throw new RestException(400, 'Combo of Source='.$source.' and Type='.$type.' not found in dictionary with active invoice contact types');
+		}
+
+		// test type
+		if (empty($type)) {
+			throw new RestException(400, 'type can not be empty');
+		}
+		// variable called type here, but code in dictionary and database
+		$sql_distinct_type = "SELECT DISTINCT code";
+		$sql_distinct_type .= " FROM ".MAIN_DB_PREFIX."c_type_contact";
+		$sql_distinct_type .= " WHERE element LIKE 'facture'";
+		$sql_distinct_type .= " AND source='".$this->db->escape($source)."'";
+		$sql_distinct_type .= " AND code is NOT NULL";
+		$sql_distinct_type .= " AND active != 0";
+		$type_result = $this->db->query($sql_distinct_type);
+		$type_array = array();
+
+		if ($type_result) {
+			$num = $this->db->num_rows($type_result);
+			$i = 0;
+			while ($i < $num) {
+				$obj = $this->db->fetch_object($type_result);
+				// variable called type here, but code in dictionary and database
+				$type_kind = (string) $obj->code;
+				array_push($type_array, $type_kind);
+				dol_syslog("type_kind=".$type_kind);
+				$i++;
+			}
+		} else {
+			throw new RestException(503, 'Error when retrieving a list of invoice contact types: '.$this->db->lasterror());
+		}
+		if (!in_array($type, (array) $type_array, true)) {
+			throw new RestException(400, 'Combo of Type='.$type.' and Source='.$source.' not found in dictionary with active invoice contact types');
+		}
+
+		// tests done, let's get it
+		$result = $this->invoice->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Invoice not found');
 		}
-
-		if (!in_array($type, array('BILLING', 'SHIPPING', 'CUSTOMER'), true)) {
-			throw new RestException(500, 'Availables types: BILLING, SHIPPING OR CUSTOMER');
-		}
-
 		if (!DolibarrApi::_checkAccessToResource('invoice', $this->invoice->id)) {
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
 		$result = $this->invoice->add_contact($contactid, $type, $source, $notrigger);
+
+		if ($result == 0) {
+			throw new RestException(400, 'Already exists: Contact='.$contactid.' is already linked to the invoice='.$id.' as source='.$source.' and type='.$type);
+		} elseif ($result == -1) {
+			throw new RestException(400, 'Wrong contact='.$contactid);
+		} elseif ($result == -2) {
+			throw new RestException(400, 'Wrong type='.$type);
+		} elseif ($result == -3) {
+			throw new RestException(400, 'Not allowed contacts');
+		} elseif ($result == -4) {
+			throw new RestException(400, 'ErrorCommercialNotAllowedForThirdparty');
+		} elseif ($result == -5) {
+			throw new RestException(400, 'Trigger failed');
+		} elseif ($result == -6) {
+			throw new RestException(400, 'DB_ERROR_RECORD_ALREADY_EXISTS');
+		} elseif ($result == -7) {
+			throw new RestException(400, 'Some other error');
+		}
 
 		if (!$result) {
 			throw new RestException(500, 'Error when added the contact');
@@ -623,7 +705,7 @@ class Invoices extends DolibarrApi
 		return array(
 			'success' => array(
 				'code' => 200,
-				'message' => 'Contact linked to the invoice'
+				'message' => 'Contact='.$contactid.' linked to the invoice='.$id.' as '.$source.' '.$type
 			)
 		);
 	}
@@ -766,7 +848,9 @@ class Invoices extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('facture', 'creer')) {
 			throw new RestException(403);
 		}
-
+		if ($id == 0) {
+			throw new RestException(400, 'No invoice with id=0 can exist');
+		}
 		$result = $this->invoice->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Invoice not found');
@@ -826,6 +910,9 @@ class Invoices extends DolibarrApi
 	{
 		if (!DolibarrApiAccess::$user->hasRight('facture', 'supprimer')) {
 			throw new RestException(403);
+		}
+		if ($id == 0) {
+			throw new RestException(400, 'No invoice with id=0 can exist');
 		}
 		$result = $this->invoice->fetch($id);
 		if (!$result) {

--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -349,6 +349,7 @@ class Invoices extends DolibarrApi
 	 */
 	public function post($request_data = null)
 	{
+		global $conf;
 		if (!DolibarrApiAccess::$user->hasRight('facture', 'creer')) {
 			throw new RestException(403, "Insufficiant rights");
 		}

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1296,7 +1296,7 @@ abstract class CommonObject
 					$langs->load("companies");
 					$this->error = $langs->trans("ErrorCommercialNotAllowedForThirdparty", $user->id);
 					dol_syslog(get_class($this)."::add_contact ".$this->error, LOG_ERR);
-					return -3;
+					return -4;
 				}
 			}
 		}
@@ -1357,7 +1357,7 @@ abstract class CommonObject
 					$result = $this->call_trigger($triggerPrefix.'_ADD_CONTACT', $user);
 					if ($result < 0) {
 						$this->db->rollback();
-						return -1;
+						return -5;
 					}
 				}
 
@@ -1367,11 +1367,11 @@ abstract class CommonObject
 				if ($this->db->errno() == 'DB_ERROR_RECORD_ALREADY_EXISTS') {
 					$this->error = $this->db->errno();
 					$this->db->rollback();
-					return -2;
+					return -6;
 				} else {
 					$this->error = $this->db->lasterror();
 					$this->db->rollback();
-					return -1;
+					return -7;
 				}
 			}
 		} else {

--- a/test/hurl/api/comm/propal/10_propal.hurl
+++ b/test/hurl/api/comm/propal/10_propal.hurl
@@ -1,0 +1,89 @@
+# GET proposals
+GET http://{{hostnport}}/api/index.php/proposals
+HTTP 200
+
+# GET sorted proposals
+GET http://{{hostnport}}/api/index.php/proposals?sortfield=t.rowid&sortorder=ASC
+HTTP 200
+
+# GET sorted proposals
+GET http://{{hostnport}}/api/index.php/proposals?sortfield=t.rowid&sortorder=DSC
+HTTP 200
+
+# GET with limit and page
+GET http://{{hostnport}}/api/index.php/proposals?limit=100&page=1
+HTTP 200
+
+# GET with fk_user
+GET http://{{hostnport}}/api/index.php/proposals?fk_user=0
+HTTP 200
+
+# GET with properties=id%2Cstatus
+GET http://{{hostnport}}/api/index.php/proposals?properties=id%2Cstatus
+HTTP 200
+
+# GET with pagination_data=false
+GET http://{{hostnport}}/api/index.php/proposals?pagination_data=false
+HTTP 200
+
+# GET with pagination_data=true
+GET http://{{hostnport}}/api/index.php/proposals?pagination_data=true
+HTTP 200
+[Asserts]
+jsonpath "$.data" exists
+jsonpath "$.pagination.total" >= 0
+jsonpath "$.pagination.page" >= 0
+jsonpath "$.pagination.page_count" >= 0
+jsonpath "$.pagination.limit" == 100
+
+# GET proposal with ID 0 - which should not exist
+GET http://{{hostnport}}/api/index.php/proposals/0
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: No proposal with id=0 can exist"}}
+
+# POST {}
+POST http://{{hostnport}}/api/index.php/proposals
+{}
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: socid field missing"}}
+
+# POST topic required
+POST http://{{hostnport}}/api/index.php/proposals
+{ "socid" : "22"}
+HTTP 500
+{"error":{"code":500,"message":"Internal Server Error: Error creating order","0":"Date of proposal is required"}}
+# this output should be adjusted for the real output when the check is done for required fields
+
+# DELETE
+DELETE http://{{hostnport}}/api/index.php/proposals/
+HTTP 405
+
+# DELETE proposal with ID 0 - which should not exist
+DELETE http://{{hostnport}}/api/index.php/proposals/0
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: No proposal with id=0 can exist"}}
+
+# PUT
+PUT http://{{hostnport}}/api/index.php/proposals/
+{}
+HTTP 405
+
+# PUT
+PUT http://{{hostnport}}/api/index.php/proposals/0
+{}
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: No proposal with id=0 can exist"}}
+
+
+
+# GET proposals DOLAPIENTITY: 1
+GET http://{{hostnport}}/api/index.php/proposals
+DOLAPIENTITY: 1
+HTTP 200
+
+# GET proposals DOLAPIENTITY: 2
+GET http://{{hostnport}}/api/index.php/proposals
+DOLAPIENTITY: 2
+HTTP 403
+{"error":{"code":403,"message":"Forbidden"}}
+

--- a/test/hurl/api/comm/propal/10_propal.hurl
+++ b/test/hurl/api/comm/propal/10_propal.hurl
@@ -95,16 +95,19 @@ proposal_id: jsonpath "$[0]['id']"
 proposal_socid: jsonpath "$[0]['socid']"
 
 # POST random type and source
-POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a/random_source_989100dd0af388a9
+POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a
+{ "source" : "random_source_989100dd0af388a9" }
 HTTP 400
-{"error":{"code":400,"message":"Bad Request: Source=random_source_989100dd0af388a9 not found in dictionary with proposal contact types"}}
+{"error":{"code":400,"message":"Bad Request: Combo of Source=random_source_989100dd0af388a9 and Type=random_type_65f0be7e9d538a6a not found in dictionary with active proposal contact types"}}
 
 # POST internal source and "random" type
-POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a/internal
+POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a
+{ "source" : "internal" }
 HTTP 400
-{"error":{"code":400,"message":"Bad Request: Type=random_type_65f0be7e9d538a6a not found in dictionary with active proposal contact types"}}
+{"error":{"code":400,"message":"Bad Request: Combo of Type=random_type_65f0be7e9d538a6a and Source=internal not found in dictionary with active proposal contact types"}}
 
 # POST external source and "random" type
-POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a/external
+POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a
+{ "source" : "external" }
 HTTP 400
-{"error":{"code":400,"message":"Bad Request: Type=random_type_65f0be7e9d538a6a not found in dictionary with active proposal contact types"}}
+{"error":{"code":400,"message":"Bad Request: Combo of Type=random_type_65f0be7e9d538a6a and Source=external not found in dictionary with active proposal contact types"}}

--- a/test/hurl/api/comm/propal/10_propal.hurl
+++ b/test/hurl/api/comm/propal/10_propal.hurl
@@ -102,9 +102,9 @@ HTTP 400
 # POST internal source and "random" type
 POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a/internal
 HTTP 400
-{"error":{"code":400,"message":"Bad Request: Type=random_type_65f0be7e9d538a6a not found in dictionary with proposal contact types"}}
+{"error":{"code":400,"message":"Bad Request: Type=random_type_65f0be7e9d538a6a not found in dictionary with active proposal contact types"}}
 
 # POST external source and "random" type
 POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a/external
 HTTP 400
-{"error":{"code":400,"message":"Bad Request: Type=random_type_65f0be7e9d538a6a not found in dictionary with proposal contact types"}}
+{"error":{"code":400,"message":"Bad Request: Type=random_type_65f0be7e9d538a6a not found in dictionary with active proposal contact types"}}

--- a/test/hurl/api/comm/propal/10_propal.hurl
+++ b/test/hurl/api/comm/propal/10_propal.hurl
@@ -87,3 +87,24 @@ DOLAPIENTITY: 2
 HTTP 403
 {"error":{"code":403,"message":"Forbidden"}}
 
+# Capture a proposal ID number
+GET http://{{hostnport}}/api/index.php/proposals?limit=1
+HTTP 200
+[Captures]
+proposal_id: jsonpath "$[0]['id']"
+proposal_socid: jsonpath "$[0]['socid']"
+
+# POST random type and source
+POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a/random_source_989100dd0af388a9
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Source=random_source_989100dd0af388a9 not found in dictionary with proposal contact types"}}
+
+# POST internal source and "random" type
+POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a/internal
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Type=random_type_65f0be7e9d538a6a not found in dictionary with proposal contact types"}}
+
+# POST external source and "random" type
+POST http://{{hostnport}}/api/index.php/proposals/{{ proposal_id }}/contact/{{ proposal_socid }}/random_type_65f0be7e9d538a6a/external
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Type=random_type_65f0be7e9d538a6a not found in dictionary with proposal contact types"}}

--- a/test/hurl/api/commande/10_commande.hurl
+++ b/test/hurl/api/commande/10_commande.hurl
@@ -1,0 +1,113 @@
+# GET orders
+GET http://{{hostnport}}/api/index.php/orders
+HTTP 200
+
+# GET sorted orders
+GET http://{{hostnport}}/api/index.php/orders?sortfield=t.rowid&sortorder=ASC
+HTTP 200
+
+# GET sorted orders
+GET http://{{hostnport}}/api/index.php/orders?sortfield=t.rowid&sortorder=DSC
+HTTP 200
+
+# GET with limit and page
+GET http://{{hostnport}}/api/index.php/orders?limit=100&page=1
+HTTP 200
+
+# GET with fk_user
+GET http://{{hostnport}}/api/index.php/orders?fk_user=0
+HTTP 200
+
+# GET with properties=id%2Cstatus
+GET http://{{hostnport}}/api/index.php/orders?properties=id%2Cstatus
+HTTP 200
+
+# GET with pagination_data=false
+GET http://{{hostnport}}/api/index.php/orders?pagination_data=false
+HTTP 200
+
+# GET with pagination_data=true
+GET http://{{hostnport}}/api/index.php/orders?pagination_data=true
+HTTP 200
+[Asserts]
+jsonpath "$.data" exists
+jsonpath "$.pagination.total" >= 0
+jsonpath "$.pagination.page" >= 0
+jsonpath "$.pagination.page_count" >= 0
+jsonpath "$.pagination.limit" == 100
+
+# GET order with ID 0 - which should not exist
+GET http://{{hostnport}}/api/index.php/orders/0
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: No order with id=0 can exist"}}
+
+# POST {}
+POST http://{{hostnport}}/api/index.php/orders
+{}
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: socid field missing"}}
+
+# POST topic required
+POST http://{{hostnport}}/api/index.php/orders
+{ "socid" : "22"}
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: date field missing"}}
+# this output should be adjusted for the real output when the check is done for required fields
+
+# DELETE
+DELETE http://{{hostnport}}/api/index.php/orders/
+HTTP 405
+
+# DELETE order with ID 0 - which should not exist
+DELETE http://{{hostnport}}/api/index.php/orders/0
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: No order with id=0 can exist"}}
+
+# PUT
+PUT http://{{hostnport}}/api/index.php/orders/
+{}
+HTTP 405
+
+# PUT
+PUT http://{{hostnport}}/api/index.php/orders/0
+{}
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: No order with id=0 can exist"}}
+
+
+
+# GET orders DOLAPIENTITY: 1
+GET http://{{hostnport}}/api/index.php/orders
+DOLAPIENTITY: 1
+HTTP 200
+
+# GET orders DOLAPIENTITY: 2
+GET http://{{hostnport}}/api/index.php/orders
+DOLAPIENTITY: 2
+HTTP 403
+{"error":{"code":403,"message":"Forbidden"}}
+
+# Capture a order ID number
+GET http://{{hostnport}}/api/index.php/orders?limit=1
+HTTP 200
+[Captures]
+order_id: jsonpath "$[0]['id']"
+order_socid: jsonpath "$[0]['socid']"
+
+# POST random type and source
+POST http://{{hostnport}}/api/index.php/orders/{{ order_id }}/contact/{{ order_socid }}/random_type_65f0be7e9d538a6a
+{ "source" : "random_source_989100dd0af388a9" }
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Combo of Source=random_source_989100dd0af388a9 and Type=random_type_65f0be7e9d538a6a not found in dictionary with active order contact types"}}
+
+# POST internal source and "random" type
+POST http://{{hostnport}}/api/index.php/orders/{{ order_id }}/contact/{{ order_socid }}/random_type_65f0be7e9d538a6a
+{ "source" : "internal" }
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Combo of Type=random_type_65f0be7e9d538a6a and Source=internal not found in dictionary with active order contact types"}}
+
+# POST external source and "random" type
+POST http://{{hostnport}}/api/index.php/orders/{{ order_id }}/contact/{{ order_socid }}/random_type_65f0be7e9d538a6a
+{ "source" : "external" }
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Combo of Type=random_type_65f0be7e9d538a6a and Source=external not found in dictionary with active order contact types"}}

--- a/test/hurl/api/compta/facture/10_facture.hurl
+++ b/test/hurl/api/compta/facture/10_facture.hurl
@@ -1,0 +1,106 @@
+# GET invoices
+GET http://{{hostnport}}/api/index.php/invoices
+HTTP 200
+
+# GET sorted invoices
+GET http://{{hostnport}}/api/index.php/invoices?sortfield=t.rowid&sortorder=ASC
+HTTP 200
+
+# GET sorted invoices
+GET http://{{hostnport}}/api/index.php/invoices?sortfield=t.rowid&sortorder=DSC
+HTTP 200
+
+# GET with limit and page
+GET http://{{hostnport}}/api/index.php/invoices?limit=100&page=1
+HTTP 200
+
+# GET with fk_user
+GET http://{{hostnport}}/api/index.php/invoices?fk_user=0
+HTTP 200
+
+# GET with properties=id%2Cstatus
+GET http://{{hostnport}}/api/index.php/invoices?properties=id%2Cstatus
+HTTP 200
+
+# GET with pagination_data=false
+GET http://{{hostnport}}/api/index.php/invoices?pagination_data=false
+HTTP 200
+
+# GET with pagination_data=true
+GET http://{{hostnport}}/api/index.php/invoices?pagination_data=true
+HTTP 200
+[Asserts]
+jsonpath "$.data" exists
+jsonpath "$.pagination.total" >= 0
+jsonpath "$.pagination.page" >= 0
+jsonpath "$.pagination.page_count" >= 0
+jsonpath "$.pagination.limit" == 100
+
+# GET invoice with ID 0 - which should not exist
+GET http://{{hostnport}}/api/index.php/invoices/0
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: No invoice with id=0 can exist"}}
+
+# POST {}
+POST http://{{hostnport}}/api/index.php/invoices
+{}
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: socid field missing"}}
+
+# DELETE
+DELETE http://{{hostnport}}/api/index.php/invoices/
+HTTP 405
+
+# DELETE invoice with ID 0 - which should not exist
+DELETE http://{{hostnport}}/api/index.php/invoices/0
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: No invoice with id=0 can exist"}}
+
+# PUT
+PUT http://{{hostnport}}/api/index.php/invoices/
+{}
+HTTP 405
+
+# PUT
+PUT http://{{hostnport}}/api/index.php/invoices/0
+{}
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: No invoice with id=0 can exist"}}
+
+
+
+# GET invoices DOLAPIENTITY: 1
+GET http://{{hostnport}}/api/index.php/invoices
+DOLAPIENTITY: 1
+HTTP 200
+
+# GET invoices DOLAPIENTITY: 2
+GET http://{{hostnport}}/api/index.php/invoices
+DOLAPIENTITY: 2
+HTTP 403
+{"error":{"code":403,"message":"Forbidden"}}
+
+# Capture a invoice ID number
+GET http://{{hostnport}}/api/index.php/invoices?limit=1
+HTTP 200
+[Captures]
+invoice_id: jsonpath "$[0]['id']"
+invoice_socid: jsonpath "$[0]['socid']"
+
+# POST random type and source
+POST http://{{hostnport}}/api/index.php/invoices/{{ invoice_id }}/contact/{{ invoice_socid }}/random_type_65f0be7e9d538a6a
+{ "source" : "random_source_989100dd0af388a9" }
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Combo of Source=random_source_989100dd0af388a9 and Type=random_type_65f0be7e9d538a6a not found in dictionary with active invoice contact types"}}
+
+# POST internal source and "random" type
+POST http://{{hostnport}}/api/index.php/invoices/{{ invoice_id }}/contact/{{ invoice_socid }}/random_type_65f0be7e9d538a6a
+{ "source" : "internal" }
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Combo of Type=random_type_65f0be7e9d538a6a and Source=internal not found in dictionary with active invoice contact types"}}
+
+# POST external source and "random" type
+POST http://{{hostnport}}/api/index.php/invoices/{{ invoice_id }}/contact/{{ invoice_socid }}/random_type_65f0be7e9d538a6a
+{ "source" : "external" }
+HTTP 400
+{"error":{"code":400,"message":"Bad Request: Combo of Type=random_type_65f0be7e9d538a6a and Source=external not found in dictionary with active invoice contact types"}}


### PR DESCRIPTION
# NEW #30485 API set contact for any type in proposal, order or invoice dictionary (breaks API proposal)
This PR introduces the possibility to set a proposal, order or invoice contact to any type and source defined in the respective contact dictionary. This PR closes #30485.

# breaking change
This PR introduces a breaking change in the proposal API to make it just like the order and invoice API when it comes to adding contacts. The old url endpoint will now give a 404 Not Found

# Hurl tests
This PR adds extensive hurl testing for API end points for proposals, orders and invoices

