### PR TITLE
FIX:Error when getting product in category

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -958,7 +958,7 @@ class Categorie extends CommonObject
 						$obj->id = 0;
 						$obj->fetch($rec['fk_object']);
 						if ($obj->id > 0) {		// Failing fetch may happen for example when a category supplier was set and third party was moved as customer only. The object supplier can't be loaded.
-							$objs[] = $obj;
+							$objs[] = clone $obj;
 						}
 					}
 				}


### PR DESCRIPTION
When retrieving products by category, when adding the object, you must pass a clone of the "obj" rather than the "obj" itself. Otherwise, you will end up with an array containing only instances of the last product inserted.
Before
<img width="1600" height="788" alt="2025-11-17_14-10" src="https://github.com/user-attachments/assets/e082abc5-94d8-4ff8-a734-167bc5e6e237" />

After
<img width="1625" height="755" alt="image" src="https://github.com/user-attachments/assets/225a77eb-6d27-4838-9673-c598dc40075d" />
