### PR TITLE
FIX 19.0 - attachments upload dir for invoices not always determined accurately

### DIFF
--- a/htdocs/compta/facture/document.php
+++ b/htdocs/compta/facture/document.php
@@ -68,9 +68,9 @@ if (!$sortfield) {
 }
 
 $object = new Facture($db);
-if ($object->fetch($id, $ref)) {
+if ($object->fetch($id, $ref) > 0) {
 	$object->fetch_thirdparty();
-	$upload_dir = $conf->facture->dir_output."/".dol_sanitizeFileName($object->ref);
+	$upload_dir = $conf->facture->multidir_output[$object->entity].'/'.dol_sanitizeFileName($object->ref);
 }
 
 $permissiontoadd = $user->hasRight('facture', 'creer');
@@ -118,7 +118,6 @@ if ($id > 0 || !empty($ref)) {
 	if ($object->fetch($id, $ref) > 0) {
 		$object->fetch_thirdparty();
 
-		$upload_dir = $conf->facture->multidir_output[$object->entity].'/'.dol_sanitizeFileName($object->ref);
 
 		$head = facture_prepare_head($object);
 		print dol_get_fiche_head($head, 'documents', $langs->trans('InvoiceCustomer'), -1, 'bill');

--- a/htdocs/core/lib/invoice.lib.php
+++ b/htdocs/core/lib/invoice.lib.php
@@ -108,6 +108,9 @@ function facture_prepare_head($object)
 	require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 	require_once DOL_DOCUMENT_ROOT.'/core/class/link.class.php';
 	$upload_dir = $conf->facture->dir_output."/".dol_sanitizeFileName($object->ref);
+	if (!empty($conf->facture->multidir_output[$object->entity])) {
+		$upload_dir = $conf->facture->multidir_output[$object->entity]."/".dol_sanitizeFileName($object->ref);
+	}
 	$nbFiles = count(dol_dir_list($upload_dir, 'files', 0, '', '(\.meta|_preview.*\.png)$'));
 	$nbLinks = Link::count($db, $object->element, $object->id);
 	$head[$h][0] = DOL_URL_ROOT.'/compta/facture/document.php?id='.$object->id;


### PR DESCRIPTION
# FIX wrong directory for upload
## Scenario

- I am connected on the main entity (1).
- I go to the card of an invoice from entity 3.
- I generate the PDF → all is well: the PDF file is in `documents/3/facture/…`
- I go to the attachments tab and upload a file → the file is not displayed; it is uploaded to `documents/facture/…`

## This fix
The fix just moves up the assignment of `$upload_dir` and also fixes the number badge on the tab label.