### PR TITLE
SEC: security access permissions are NOT checked on HRM evaluation cards

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -447,6 +447,10 @@ function restrictedArea(User $user, $features, $object = 0, $tableandshare = '',
 		$tableandshare = 'paiementcharge';
 		$parentfortableentity = 'fk_charge@chargesociales';
 	}
+	if ($features == 'evaluation') {
+		$features = 'hrm';
+		$feature2 = 'evaluation';
+	}
 
 	//print $features.' - '.$tableandshare.' - '.$feature2.' - '.$dbt_select."\n";
 
@@ -908,7 +912,7 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 		$checkparentsoc = array('agenda', 'contact', 'contrat'); // Test on entity + link to third party on field $dbt_keyfield. Allowed if link is empty (Ex: contacts...).
 		$checkproject = array('projet', 'project'); // Test for project object
 		$checktask = array('projet_task'); // Test for task object
-		$checkhierarchy = array('expensereport', 'holiday');	// check permission among the hierarchy of user
+		$checkhierarchy = array('expensereport', 'holiday', 'hrm');	// check permission among the hierarchy of user
 		$checkuser = array('bookmark');	// check permission among the fk_user (must be myself or null)
 		$nocheck = array('barcode', 'stock'); // No test
 
@@ -1134,6 +1138,20 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 						return false;
 					}
 				}
+			}
+			if ($feature == 'hrm' && in_array('evaluation', $feature2)) {
+				$useridtocheck = $object->fk_user;
+
+				if ($user->hasRight('hrm', 'evaluation', 'readall')) {
+					// the user can view evaluations for anyone
+					return true;
+				}
+				if (!$user->hasRight('hrm', 'evaluation', 'read')) {
+					// the user can't view any evaluations
+					return false;
+				}
+				// the user can only their own evaluations or their subordinates'
+				return in_array($useridtocheck, $childids);
 			}
 		}
 

--- a/htdocs/hrm/evaluation_card.php
+++ b/htdocs/hrm/evaluation_card.php
@@ -92,8 +92,8 @@ $upload_dir = $conf->hrm->multidir_output[isset($object->entity) ? $object->enti
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();
 //if ($user->socid > 0) $socid = $user->socid;
-//$isdraft = (($object->status == $object::STATUS_DRAFT) ? 1 : 0);
-//restrictedArea($user, $object->element, $object->id, $object->table_element, '', 'fk_soc', 'rowid', $isdraft);
+$isdraft = ($object->status == Evaluation::STATUS_DRAFT) ? 1 : 0;
+restrictedArea($user, $object->element, $object, $object->table_element, '', 'fk_soc', 'rowid', $isdraft);
 if (!isModEnabled("hrm")) {
 	accessforbidden();
 }


### PR DESCRIPTION
# FIX permission check on HRM evaluation card

Currently, permissions are not checked at all on the card (contrary to the list). This is serious as it can undermine confidence in data privacy.

Permissions involved:
- hrm->evaluation->readall: user can view anyone's evaluations
- hrm->evaluation->read: user can only view their or their subordinates' evaluations

@eldy the functions involved in `security.lib.php` are pretty complex and there are some parameters whose role remains obscure to me, but I tried to fix the bug with the least possible amount of refactoring. Don't hesitate to tell me if I should do it differently.