### PR TITLE
FIX #36334 correct payment conditions in pdf invoice for member contribution 

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -2027,6 +2027,7 @@ class Adherent extends CommonObject
 				// Generate PDF (whatever is option MAIN_DISABLE_PDF_AUTOUPDATE) so we can include it into email
 				//if (!getDolGlobalString('MAIN_DISABLE_PDF_AUTOUPDATE'))
 
+				$invoice->fetch($invoice->id); // Reload invoice object data
 				$invoice->generateDocument($invoice->model_pdf, $outputlangs);
 			}
 		}


### PR DESCRIPTION
# FIX #36334 - correct payment conditions in pdf invoice for member contribution
When creating invoice pdf as an email attachment in the process of generating a new member contribution, the payment terms and payment method of a linked third party are transferred correctly.
Reloading invoice data before calling generateDocument of the pdf.