### PR TITLE
Qual/Fix: remove entity=2 hurl test which doesn't work

### DIFF
--- a/test/hurl/api/setup/10_setup_modules.hurl
+++ b/test/hurl/api/setup/10_setup_modules.hurl
@@ -76,9 +76,3 @@ HTTP 404
 GET http://{{hostnport}}/api/index.php/setup/modules/status/all?status=all
 DOLAPIENTITY: 1
 HTTP 200
-
-# GET modules DOLAPIENTITY: 2
-GET http://{{hostnport}}/api/index.php/setup/modules/status/all?status=all
-DOLAPIENTITY: 2
-HTTP 401
-{"error":{"code":401,"message":"Unauthorized: Error user not valid (not found with api key or bad status or bad validity dates) (conf->entity=2)"}}


### PR DESCRIPTION
# Qual/Fix: remove entity=2 hurl test which doesn't work

This PR removes the entity=2 which does not work when getting a list of modules - probably all modules are enabled for all customers?

IF multicompany mode allows for different companies having different modules enabled, then I wish that YOU would help me get a test for the entity IN htdocs/api/class/api_setup.class.php

```
JonSweet16:hurl jonbendtsen$ ./run.sh module

----- Run hurl test on APIs ---
::notice::1. Running tests (API,GUI,public) that do not require authentication ::notice::Using existing DOLAPIKEY.
::notice::2.a. Running API tests that do require authentication Success api/setup/10_setup_modules.hurl (13 request(s) in 2547 ms) --------------------------------------------------------------------------------
Executed files:    1
Executed requests: 13 (5.1/s)
Succeeded files:   1 (100.0%)
Failed files:      0 (0.0%)
Duration:          2548 ms
```