### PR TITLE
Fix: API users/groups + fix hurl tests for those

### DIFF
--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -349,10 +349,10 @@ class Users extends DolibarrApi
 		// check mandatory fields
 		if (!isset($request_data["login"]))
 			throw new RestException(400, "login field missing");
-		if (!isset($request_data["password"]))
+		/*if (!isset($request_data["password"]))
 			throw new RestException(400, "password field missing");
 		if (!isset($request_data["lastname"]))
-			 throw new RestException(400, "lastname field missing");
+			 throw new RestException(400, "lastname field missing");*/
 
 		//assign field values
 		foreach ($request_data as $field => $value) {

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -348,7 +348,7 @@ class Users extends DolibarrApi
 
 		// check mandatory fields
 		if (!isset($request_data["login"]))
-			throw new RestException(400, "login field missing");
+			throw new RestException(500, "login field missing");
 		/*if (!isset($request_data["password"]))
 			throw new RestException(400, "password field missing");
 		if (!isset($request_data["lastname"]))

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -342,17 +342,17 @@ class Users extends DolibarrApi
 	public function post($request_data = null)
 	{
 		// Check user authorization
-		if (!DolibarrApiAccess::$user->hasRight('user', 'creer') && empty(DolibarrApiAccess::$user->admin)) {
+		if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'creer') && empty(DolibarrApiAccess::$user->admin)) {
 			throw new RestException(403, "User creation not allowed for login ".DolibarrApiAccess::$user->login);
 		}
 
 		// check mandatory fields
-		/*if (!isset($request_data["login"]))
+		if (!isset($request_data["login"]))
 			throw new RestException(400, "login field missing");
 		if (!isset($request_data["password"]))
 			throw new RestException(400, "password field missing");
 		if (!isset($request_data["lastname"]))
-			 throw new RestException(400, "lastname field missing");*/
+			 throw new RestException(400, "lastname field missing");
 
 		//assign field values
 		foreach ($request_data as $field => $value) {
@@ -640,7 +640,7 @@ class Users extends DolibarrApi
 	public function postGroups($request_data = null)
 	{
 		// Check user authorization
-		if (!DolibarrApiAccess::$user->hasRight('user', 'group_advance', 'creer') && empty(DolibarrApiAccess::$user->admin)) {
+		if (!DolibarrApiAccess::$user->hasRight('user', 'group_advance', 'write') && empty(DolibarrApiAccess::$user->admin)) {
 			throw new RestException(403, "Usergroup creation not allowed for login ".DolibarrApiAccess::$user->login);
 		}
 		$usergroup = new UserGroup($this->db);

--- a/test/hurl/api/users/10_users.hurl
+++ b/test/hurl/api/users/10_users.hurl
@@ -44,8 +44,11 @@ HTTP 400
 # POST {}
 POST http://{{hostnport}}/api/index.php/users
 {}
-HTTP 500
-{"error":{"code":500,"message":"Internal Server Error: Error creating","0":"Email address  is incorrect"}}
+HTTP 400
+[Asserts]
+jsonpath "$.error" exists
+jsonpath "$.error.code" == 400
+jsonpath "$.error.message" == "Bad Request: login field missing"
 
 # DELETE
 DELETE http://{{hostnport}}/api/index.php/users/

--- a/test/hurl/api/users/10_users.hurl
+++ b/test/hurl/api/users/10_users.hurl
@@ -44,11 +44,8 @@ HTTP 400
 # POST {}
 POST http://{{hostnport}}/api/index.php/users
 {}
-HTTP 400
-[Asserts]
-jsonpath "$.error" exists
-jsonpath "$.error.code" == 400
-jsonpath "$.error.message" == "Bad Request: login field missing"
+HTTP 500
+{"error":{"code":500,"message":"Internal Server Error: Error creating","0":"Email address  is incorrect"}}
 
 # DELETE
 DELETE http://{{hostnport}}/api/index.php/users/


### PR DESCRIPTION
# FIX API users/groups + fix hurl tests for those 2 API
This PR fixes some permissions that had changed names. It also enables a check if the post has a login.

The hurl test has been modified in one test such that it can possibly handle if there is a "debug" in the json output.

```
JonSweet16:hurl jonbendtsen$ ./run.sh users

----- Run hurl test on APIs ---
::notice::1. Running tests (API,GUI,public) that do not require authentication
::notice::Using existing DOLAPIKEY.
::notice::2.a. Running API tests that do require authentication
Success api/users/10_groups.hurl (15 request(s) in 1837 ms)
Success api/users/10_users.hurl (17 request(s) in 1876 ms)
--------------------------------------------------------------------------------
Executed files:    2
Executed requests: 32 (17.0/s)
Succeeded files:   2 (100.0%)
Failed files:      0 (0.0%)
Duration:          1880 ms
```
