### PR TITLE
FIX #33148 - partial payments are taken into account in EPC QR codes

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -1660,8 +1660,17 @@ abstract class CommonInvoice extends CommonObject
 	{
 		global $mysoc;
 
-		// Convert total_ttc to a string with 2 decimal places
-		$totalTTCString = number_format($this->total_ttc, 2, '.', '');
+		// Get the amount to pay
+		if (method_exists($this, 'getRemainToPay')) {
+			// Get remaining amount to pay
+			$amount_to_pay = $this->getRemainToPay();
+		} else {
+			// Use Total amount with taxes
+			$amount_to_pay = $this->total_ttc;
+		}
+
+		// Ensure numeric formatting for EPC QR code
+		$amount_to_pay = price2num($amount_to_pay, 'MT');
 
 		// Initialize an array to hold the lines of the QR code
 		$lines = array();
@@ -1689,7 +1698,7 @@ abstract class CommonInvoice extends CommonObject
 		}
 
 		// Add the amount and reference
-		$lines[] = 'EUR' . $totalTTCString; // Amount (optional)
+		$lines[] = 'EUR' . $amount_to_pay; // Amount (optional)
 		$lines[] = ''; // Purpose (optional)
 		$lines[] = ''; // Payment reference (optional)
 		$lines[] = $this->ref; // Remittance Information (optional)


### PR DESCRIPTION
# FIX #33148 - partial payments are taken into account in EPC QR codes
When generating EPC QR codes on an invoice, any partial payments already made are taken into account. The remaining balance (the value of "Remaining unpaid") is then entered as the amount in the EPC QR code.