### PR TITLE
New: Add quiet mode to hurl test runner

### DIFF
--- a/test/hurl/README.md
+++ b/test/hurl/README.md
@@ -134,13 +134,23 @@ This will exclude all tests that contain either `setup_modules` or `status` in t
 
 ### Verbose Output
 
-You can enable verbose output by providing the `--verbose` or `--very-verbose` option to the `run.sh` script. For example:
+You can enable verbose output by providing the `--verbose` (also `-v`) or `--very-verbose` option to the `run.sh` script. For example:
 
 ```bash
 ./run.sh --verbose setup_modules
 ```
 
 This will run all tests that contain `setup_modules` in their name with verbose output.
+
+### Quiet Output
+
+You can disable part of the informational output by providing the `--quiet` (also `-q`) option to the `run.sh` script. For example:
+
+```bash
+./run.sh --quiet setup_modules
+```
+
+This will run all tests that contain `setup_modules` in their name with info output disabled.
 
 ## Directory and file structure for hurl tests
 

--- a/test/hurl/run.sh
+++ b/test/hurl/run.sh
@@ -23,8 +23,9 @@ Options:
   --apikey=APIKEY      Specify the API key for API tests.
   --suburl=SUBURL      Specify the suburl of the Dolibarr server.
   --exclude=PATTERN    Exclude tests that match the specified pattern.
-  --verbose            Verbose hurl output
+  --verbose | -v       Verbose hurl output
   --very-verbose       Very verbose hurl output
+  --quiet | -q         Disable info output
   --help               Display this help message and exit.
 
 Test Filters:
@@ -42,15 +43,21 @@ Examples:
 EOHELP
 }
 
-# Github compatible messages
-print_error() { printf "::error::%s\n" "$*" >&2 ; }
-print_warning() { printf "::warning::%s\n" "$*" >&2 ; }
-print_info() { printf "::notice::%s\n" "$*" >&2 ; }
-
+if [[ -n "${GITHUB_WORKSPACE}" ]]; then
+	# Github compatible messages
+	print_error() { printf "::error::%s\n" "$*" >&2; }
+	print_warning() { if [[ "${QUIET}" = false ]]; then printf "::warning::%s\n" "$*" >&2 ; fi; }
+	print_info() { if [[ "${QUIET}" = false ]]; then printf "::notice::%s\n" "$*" >&2 ; fi; }
+else
+	print_error() { printf "ERROR: %s\n" "$*" >&2; }
+	print_warning() { if [[ "${QUIET}" = false ]]; then printf "WARNING: %s\n" "$*" >&2 ; fi; }
+	print_info() { if [[ "${QUIET}" = false ]]; then printf "INFO: %s\n" "$*" >&2 ; fi; }
+fi
 
 # Parse command-line arguments as test filters
 test_filters=()
 exclude_patterns=()
+QUIET=false
 
 for arg in "$@"; do
 	case "$arg" in
@@ -83,6 +90,9 @@ for arg in "$@"; do
 			;;
 		--very-verbose|--verbose|-v)
 			VERBOSE=${arg}
+			;;
+		--quiet|-q)
+			QUIET=true
 			;;
 		--help)
 			display_help


### PR DESCRIPTION
# New: Add quiet mode to hurl test runner

- Added `--quiet` or `-q` option to disable informational output
- Updated help message to include the new option
- Modified print functions to respect quiet mode