### PR TITLE
FIX: TakePOS Missing Thirdparty Id when getting more products

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -438,7 +438,7 @@ function MoreProducts(moreorless) {
 	}
 	var offset = <?php echo ($MAXPRODUCT - 2); ?> * pageproducts;
 	// Only show products for sale (tosell=1)
-	$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=getProducts&token=<?php echo newToken();?>&category='+currentcat+'&tosell=1&limit='+limit+'&offset='+offset, function(data) {
+	$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=getProducts&token=<?php echo newToken();?>&thirdpartyid=' + jQuery('#thirdpartyid').val() + '&category='+currentcat+'&tosell=1&limit='+limit+'&offset='+offset, function(data) {
 		console.log("Call ajax.php (in MoreProducts) to get Products of category "+currentcat);
 
 		if (typeof (data[0]) == "undefined" && moreorless=="more"){ // Return if no more pages


### PR DESCRIPTION
In the TakePos menu, when product prices were configured by third parties, thirdparty id was not sent when clicking on the plus or minus arrows for fetching products price by ajax, unlike at the page loading or when selecting thirdparty. 