### PR TITLE
FIX: TakePos sometimes thirdpartyid = undefined

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -334,7 +334,7 @@ function LoadProducts(position, issubcat) {
 
 	// Get socid
 	let socid = jQuery('#thirdpartyid').val();
-	if ((socid === undefined || socid === "") && parseInt("<?= $socid ?>") > 0) {
+	if ((socid === undefined || socid === "") && parseInt("<?php echo $socid ?>") > 0) {
 		socid = parseInt("<?= $socid ?>");
 	}
 
@@ -449,7 +449,7 @@ function MoreProducts(moreorless) {
 
 	// Get socid
 	let socid = jQuery('#thirdpartyid').val();
-	if ((socid === undefined || socid === "") && parseInt("<?= $socid ?>") > 0) {
+	if ((socid === undefined || socid === "") && parseInt("<?php echo $socid ?>") > 0) {
 		socid = parseInt("<?= $socid ?>");
 	}
 
@@ -681,7 +681,7 @@ function Search2(keyCodeForEnter, moreorless) {
 
 			// Only show products for sale (tosell=1)
 			let socid = jQuery('#thirdpartyid').val();
-			if ((socid === undefined || socid === "") && parseInt("<?= $socid ?>") > 0) {
+			if ((socid === undefined || socid === "") && parseInt("<?php echo $socid ?>") > 0) {
 				socid = parseInt("<?= $socid ?>");
 			}
 

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -93,6 +93,8 @@ if ($conf->browser->layout == 'phone') {
 $MAXCATEG = (empty($conf->global->TAKEPOS_NB_MAXCATEG) ? $maxcategbydefaultforthisdevice : $conf->global->TAKEPOS_NB_MAXCATEG);
 $MAXPRODUCT = (empty($conf->global->TAKEPOS_NB_MAXPRODUCT) ? $maxproductbydefaultforthisdevice : $conf->global->TAKEPOS_NB_MAXPRODUCT);
 
+$term = empty($_SESSION['takeposterminal']) ? 1 : $_SESSION['takeposterminal'];
+$socid = getDolGlobalString('CASHDESK_ID_THIRDPARTY' . $term);
 /*
  $constforcompanyid = 'CASHDESK_ID_THIRDPARTY'.$_SESSION["takeposterminal"];
  $soc = new Societe($db);
@@ -329,8 +331,15 @@ function LoadProducts(position, issubcat) {
 	if (maxproduct >= 1) {
 		limit = maxproduct-1;
 	}
+
+	// Get socid
+	let socid = jQuery('#thirdpartyid').val();
+	if ((socid === undefined || socid === "") && parseInt("<?= $socid ?>") > 0) {
+		socid = parseInt("<?= $socid ?>");
+	}
+
 	// Only show products for sale (tosell=1)
-	$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=getProducts&token=<?php echo newToken();?>&thirdpartyid=' + jQuery('#thirdpartyid').val() + '&category='+currentcat+'&tosell=1&limit='+limit+'&offset=0', function(data) {
+	$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=getProducts&token=<?php echo newToken();?>&thirdpartyid=' + socid + '&category='+currentcat+'&tosell=1&limit='+limit+'&offset=0', function(data) {
 		console.log("Call ajax.php (in LoadProducts) to get Products of category "+currentcat+" then loop on result to fill image thumbs");
 		console.log(data);
 		while (ishow < maxproduct) {
@@ -437,8 +446,15 @@ function MoreProducts(moreorless) {
 		limit = maxproduct-1;
 	}
 	var offset = <?php echo ($MAXPRODUCT - 2); ?> * pageproducts;
+
+	// Get socid
+	let socid = jQuery('#thirdpartyid').val();
+	if ((socid === undefined || socid === "") && parseInt("<?= $socid ?>") > 0) {
+		socid = parseInt("<?= $socid ?>");
+	}
+
 	// Only show products for sale (tosell=1)
-	$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=getProducts&token=<?php echo newToken();?>&thirdpartyid=' + jQuery('#thirdpartyid').val() + '&category='+currentcat+'&tosell=1&limit='+limit+'&offset='+offset, function(data) {
+	$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=getProducts&token=<?php echo newToken();?>&thirdpartyid=' + socid + '&category='+currentcat+'&tosell=1&limit='+limit+'&offset='+offset, function(data) {
 		console.log("Call ajax.php (in MoreProducts) to get Products of category "+currentcat);
 
 		if (typeof (data[0]) == "undefined" && moreorless=="more"){ // Return if no more pages
@@ -662,7 +678,14 @@ function Search2(keyCodeForEnter, moreorless) {
 			pageproducts = 0;
 			jQuery(".wrapper2 .catwatermark").hide();
 			var nbsearchresults = 0;
-			$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=search&token=<?php echo newToken();?>&term=' + search_term + '&thirdpartyid=' + jQuery('#thirdpartyid').val() + '&search_start=' + search_start + '&search_limit=' + search_limit, function (data) {
+
+			// Only show products for sale (tosell=1)
+			let socid = jQuery('#thirdpartyid').val();
+			if ((socid === undefined || socid === "") && parseInt("<?= $socid ?>") > 0) {
+				socid = parseInt("<?= $socid ?>");
+			}
+
+			$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=search&token=<?php echo newToken();?>&term=' + search_term + '&thirdpartyid=' + socid + '&search_start=' + search_start + '&search_limit=' + search_limit, function (data) {
 				for (i = 0; i < <?php echo $MAXPRODUCT ?>; i++) {
 					if (typeof (data[i]) == "undefined") {
 						$("#prowatermark" + i).html("");

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -94,7 +94,7 @@ $MAXCATEG = (empty($conf->global->TAKEPOS_NB_MAXCATEG) ? $maxcategbydefaultforth
 $MAXPRODUCT = (empty($conf->global->TAKEPOS_NB_MAXPRODUCT) ? $maxproductbydefaultforthisdevice : $conf->global->TAKEPOS_NB_MAXPRODUCT);
 
 $term = empty($_SESSION['takeposterminal']) ? 1 : $_SESSION['takeposterminal'];
-$socid = getDolGlobalString('CASHDESK_ID_THIRDPARTY' . $term);
+$socid = getDolGlobalInt('CASHDESK_ID_THIRDPARTY' . $term);
 /*
  $constforcompanyid = 'CASHDESK_ID_THIRDPARTY'.$_SESSION["takeposterminal"];
  $soc = new Societe($db);

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -334,8 +334,8 @@ function LoadProducts(position, issubcat) {
 
 	// Get socid
 	let socid = jQuery('#thirdpartyid').val();
-	if ((socid === undefined || socid === "") && parseInt("<?php echo $socid ?>") > 0) {
-		socid = parseInt("<?= $socid ?>");
+	if ((socid === undefined || socid === "") && parseInt("<?php echo dol_escape_js($socid) ?>") > 0) {
+		socid = parseInt("<?php echo dol_escape_js($socid); ?>");
 	}
 
 	// Only show products for sale (tosell=1)
@@ -449,8 +449,8 @@ function MoreProducts(moreorless) {
 
 	// Get socid
 	let socid = jQuery('#thirdpartyid').val();
-	if ((socid === undefined || socid === "") && parseInt("<?php echo $socid ?>") > 0) {
-		socid = parseInt("<?= $socid ?>");
+	if ((socid === undefined || socid === "") && parseInt("<?php echo dol_escape_js($socid) ?>") > 0) {
+		socid = parseInt("<?php echo dol_escape_js($socid); ?>");
 	}
 
 	// Only show products for sale (tosell=1)
@@ -681,8 +681,8 @@ function Search2(keyCodeForEnter, moreorless) {
 
 			// Only show products for sale (tosell=1)
 			let socid = jQuery('#thirdpartyid').val();
-			if ((socid === undefined || socid === "") && parseInt("<?php echo $socid ?>") > 0) {
-				socid = parseInt("<?= $socid ?>");
+			if ((socid === undefined || socid === "") && parseInt("<?php echo dol_escape_js($socid) ?>") > 0) {
+				socid = parseInt("<?php echo dol_escape_js($socid); ?>");
 			}
 
 			$.getJSON('<?php echo DOL_URL_ROOT ?>/takepos/ajax/ajax.php?action=search&token=<?php echo newToken();?>&term=' + search_term + '&thirdpartyid=' + socid + '&search_start=' + search_start + '&search_limit=' + search_limit, function (data) {


### PR DESCRIPTION
Linked to [36341](https://github.com/Dolibarr/dolibarr/pull/36341)
Sometimes jQuery('#thirdpartyid').val() is undefined because the input is described in takepos/invoice.php. 
But it needs to be defined before, to prevent wrong price to be fetched in case of multilevel prices. 
