### PR TITLE
# FIX|Fix - Update to the MRP Efficiency Loss Calculation

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -763,7 +763,10 @@ class Mo extends CommonObject
 							if ($line->qty_frozen) {
 								$moline->qty = $line->qty; // Qty to consume does not depends on quantity to produce
 							} else {
-								$moline->qty = (float) price2num(($line->qty / (!empty($bom->qty) ? $bom->qty : 1)) * $this->qty / (!empty($line->efficiency) ? $line->efficiency : 1), 'MS'); // Calculate with Qty to produce and  more presition
+								$efficiency = !empty($line->efficiency) ? $line->efficiency : 1;
+								$lossfactor = max(0, 2 - $efficiency); // Factor is 1 when efficiency is 1, >1 when efficiency <1
+								$qtyperbom = $line->qty / (!empty($bom->qty) ? $bom->qty : 1);
+								$moline->qty = (float) price2num($qtyperbom * $this->qty * $lossfactor, 'MS'); // Calculate with Qty to produce and more precision
 							}
 							if ($moline->qty <= 0) {
 								$error++;

--- a/htdocs/mrp/tpl/originproductline.tpl.php
+++ b/htdocs/mrp/tpl/originproductline.tpl.php
@@ -31,11 +31,9 @@ if (empty($form) || !is_object($form)) {
 	$form = new Form($db);
 }
 
-$qtytoconsumeforline = $this->tpl['qty'] / (!empty($this->tpl['efficiency']) ? $this->tpl['efficiency'] : 1);
-/*if ((empty($this->tpl['qty_frozen']) && $this->tpl['qty_bom'] > 1)) {
-	$qtytoconsumeforline = $qtytoconsumeforline / $this->tpl['qty_bom'];
-}*/
-$qtytoconsumeforline = price2num($qtytoconsumeforline, 'MS');
+$efficiency = !empty($this->tpl['efficiency']) ? $this->tpl['efficiency'] : 1;
+$lossfactor = max(0, 2 - $efficiency);
+$qtytoconsumeforline = price2num($this->tpl['qty'] * $lossfactor, 'MS');
 
 $tmpproduct = new Product($db);
 if ($line->fk_product > 0) {
@@ -67,7 +65,7 @@ if ($res) {
 }
 print '</td>';
 // Qty
-print '<td class="right">'.$this->tpl['qty'].(($this->tpl['efficiency'] > 0 && $this->tpl['efficiency'] < 1) ? ' / '.$form->textwithpicto($this->tpl['efficiency'], $langs->trans("ValueOfMeansLoss")).' = '.$qtytoconsumeforline : '').'</td>';
+print '<td class="right">'.$this->tpl['qty'].(($this->tpl['efficiency'] > 0 && $this->tpl['efficiency'] < 1) ? ' x (2 - '.$form->textwithpicto($this->tpl['efficiency'], $langs->trans("ValueOfMeansLoss")).') = '.$qtytoconsumeforline : '').'</td>';
 // Unit
 print '<td class="right">'.measuringUnitString($this->tpl['fk_unit'], '', '', 1).'</td>';
 // Stock


### PR DESCRIPTION
# FIX|Fix #*Update to the MRP Efficiency Loss Calculation*

**Explanation of the issue and the proposed fix**

In the MRP module, the current calculation of raw-material consumption when a production efficiency lower than 1 is defined uses the formula:
BOM_qty × quantity_to_produce / efficiency.
This implicitly interprets efficiency as output = input × efficiency, which generates non-rounded and unintuitive consumption values (e.g., 53,333.33 µL for a 10% loss). As a consequence, stock levels on consumed lots rarely reach zero, creating discrepancies and making inventory harder to manage.

In real manufacturing practice, users commonly interpret efficiency as a loss rate: an efficiency of 0.9 means a 10% loss, so the consumed quantity should increase by 10%. The correct expected formula is therefore:
BOM_qty × quantity_to_produce × (2 − efficiency)
For example, 48,000 µL × (2 − 0.9) = 52,800 µL, which accurately reflects a 10% loss added on top of the nominal required quantity.

The proposed patch replaces the division-based calculation with this loss-factor approach, resulting in more realistic consumption quantities and cleaner stock movements, avoiding artificial leftovers. The related UI display has also been updated to clearly show the new calculation logic to users.


