### PR TITLE
Fix: Prevent negative payment amount in EPC-QR Code

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -1669,6 +1669,9 @@ abstract class CommonInvoice extends CommonObject
 			$amount_to_pay = $this->total_ttc;
 		}
 
+		// Prevent negative values (e.g. overpayments)
+		$amount_to_pay = max(0, $amount_to_pay);
+
 		// Ensure numeric formatting for EPC QR code
 		$amount_to_pay = price2num($amount_to_pay, 'MT');
 


### PR DESCRIPTION
# Fix - Prevent negative payment amount in EPC-QR Code
Under certain conditions – for example, if an invoice has already been overpaid – the value for "remaining unpaid" amount is negative. A SEPA transfer must not contain a negative payment amount.