### PR TITLE
Qual: detect malformed DOLAPIKEY when run.sh hurl tests

### DIFF
--- a/test/hurl/run.sh
+++ b/test/hurl/run.sh
@@ -233,9 +233,14 @@ get_dolibarr_api_key() {
 
 	# If key is already set, return it
 	if [ -n "${current_key}" ]; then
-		print_info "Using existing DOLAPIKEY."
-		echo "${current_key}"
-		return 0
+		if [[ "${DOLAPIKEY}" != *": "* ]]; then
+			print_error "Environment variable DOLAPIKEY has the wrong format: '${DOLAPIKEY}'"
+			print_error "should perhaps be: 'DOLAPIKEY: ${DOLAPIKEY}'"
+		else
+			print_info "Using existing DOLAPIKEY."
+			echo "${current_key}"
+			return 0
+		fi
 	fi
 
 	# Check if credentials are available
@@ -282,8 +287,8 @@ API_URL=${hostnport}/api/index.php
 
 DOLAPIKEY=$(get_dolibarr_api_key "${API_URL}" "${DOLAPIKEY}" "${DOLIUSERNAME}" "${DOLIPASSWORD}")
 
-if [[ -z ${DOLAPIKEY+x} ]]; then
-	print_info "DOLAPIKEY bash variable is unset, no API tests that require authentication"
+if [[ -z "${DOLAPIKEY}" ]]; then
+	print_info "DOLAPIKEY bash variable is unset/empty, no API tests that require authentication"
 else
 	# Build the find command for the API tests that do require authentication
 	find_args=("api/" "-type" "f" "-iwholename" "*/10*.hurl" "-not" "-iwholename" "*/00*.hurl")


### PR DESCRIPTION
# Qual: detect malformed DOLAPIKEY when run.sh hurl tests
This PR detects a malformed DOLAPIKEY environment variable as well as when none is set.

```
  549  test/hurl/run.sh 
  550  test/hurl/run.sh --apikey=************************
  552   DOLAPIKEY=************************ test/hurl/run.sh 
  553  test/hurl/run.sh --apikey=************************
  554   DOLAPIKEY='DOLAPIKEY: ************************' test/hurl/run.sh
  561   DOLAPIKEY='' test/hurl/run.sh
  567  test/hurl/run.sh --apikey='DOLAPIKEY: ************************'
```

`run.sh` no longer tries to run API tests requiring a key when
- key has the wrong format
- no/empty key and no login/password is available

And `run.sh` does run API tests requiring a key when
- key is supplied as just key
- key is supplied as the whole header to sent
- key is supplied using environment variable in the correct format

Empty variable results in
`INFO: DOLAPIKEY bash variable is unset/empty, no API tests that require authentication`

Wrong format variable results in
```
ERROR: Environment variable DOLAPIKEY has the wrong format: 'sdssd'
ERROR: should perhaps be: 'DOLAPIKEY: sdssd'
``´
