### PR TITLE
Qual: Improve type hints and cache arrays in html.form.class.php

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -74,18 +74,25 @@ class Form
 	/** @var array<string,int> */
 	public $result;
 
-	/** @var int 	Number of line returned by method to generate combo select */
+	/** @var int 	Number of lines returned by method to generate combo select */
 	public $num;
 
 	// Cache arrays
+	/** @var array<string,array{id:int,code:string,label:string,type:int,entity:int,active:int}> */
 	public $cache_types_paiements = array();
+	/** @var array<string,array{code:string,label:string,deposit_percent:string,entity:int}> */
 	public $cache_conditions_paiements = array();
+	/** @var array<int,array{rowid:int,code:string,label:string,active:int}> */
 	public $cache_transport_mode = array();
 	/** @var array<int,array{code:string,label:string,position:int}> */
 	public $cache_availability = array();
+	/** @var array<int,array{id:int,code:string,label:string}> */
 	public $cache_demand_reason = array();
+	/** @var array<string,string> */
 	public $cache_types_fees = array();
+	/** @var array<int,array{rowid:int,type_vat:int,code:string,txtva:string,nprtva:int,localtax1:string|float|null,localtax1_type:string,localtax2:string|float|null,localtax2_type:string,label:string,labelallrates:string,labelpositiverates:string}> */
 	public $cache_vatrates = array();
+	/** @var array<int,array{rowid:int,code:string,label:string}> */
 	public $cache_invoice_subtype = array();
 	/** @var array<string,string> */
 	public $cache_rule_for_lines_dates = array();
@@ -4755,7 +4762,7 @@ class Form
 					$label = $langs->trans($obj->code); // So translation key SRC_XXX will work
 				}
 
-				$tmparray[$obj->rowid]['id'] = $obj->rowid;
+				$tmparray[$obj->rowid]['id'] = (int) $obj->rowid;
 				$tmparray[$obj->rowid]['code'] = $obj->code;
 				$tmparray[$obj->rowid]['label'] = $label;
 				$i++;
@@ -7300,7 +7307,7 @@ class Form
 					$obj = $this->db->fetch_object($resql);
 
 					$tmparray = array();
-					$tmparray['rowid']			= $obj->rowid;
+					$tmparray['rowid']			= (int) $obj->rowid;
 					$tmparray['type_vat']		= ($obj->type_vat <= 0 ? 0 : $obj->type_vat);	// Some version have type_vat corrupted with value -1
 					$tmparray['code']			= $obj->code;
 					$tmparray['txtva']			= $obj->taux;

--- a/htdocs/core/modules/dons/html_cerfafr.modules.php
+++ b/htdocs/core/modules/dons/html_cerfafr.modules.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2012       Marcos García           <marcosgdf@gmail.com>
  * Copyright (C) 2014-2020  Alexandre Spangaro		<aspangaro@open-dsi.fr>
  * Copyright (C) 2015  		Benoit Bruchard			<benoitb21@gmail.com>
- * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -172,7 +172,7 @@ class html_cerfafr extends ModeleDon
 				$form = str_replace('__DONATOR_ADDRESS__', $don->address, $form);
 				$form = str_replace('__DONATOR_ZIP__', $don->zip, $form);
 				$form = str_replace('__DONATOR_TOWN__', $don->town, $form);
-				$form = str_replace('__PAYMENTMODE_LIB__ ', $paymentmode, $form);
+				$form = str_replace('__PAYMENTMODE_LIB__ ', (string) $paymentmode, $form);
 				$form = str_replace('__NOW__', dol_print_date($now, 'day', false, $outputlangs), $form);
 				$form = str_replace('__DonationRef__', $outputlangs->trans("DonationRef"), $form);
 				$form = str_replace('__DonationTitle__', $outputlangs->trans("DonationTitle"), $form);

--- a/htdocs/core/modules/dons/html_generic.modules.php
+++ b/htdocs/core/modules/dons/html_generic.modules.php
@@ -6,7 +6,7 @@
  * Copyright (C) 2014-2020  Alexandre Spangaro		<aspangaro@open-dsi.fr>
  * Copyright (C) 2015  		Benoit Bruchard			<benoitb21@gmail.com>
  * Copyright (C) 2015  		Benjamin Neumann <btdn@sigsoft.org>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -97,7 +97,7 @@ class html_generic extends ModeleDon
 		$formclass->load_cache_types_paiements();
 
 		if ($don->mode_reglement_id) {
-			$paymentmode = $formclass->cache_types_paiements[$don->mode_reglement_id]['label'];
+			$paymentmode = (string) $formclass->cache_types_paiements[$don->mode_reglement_id]['label'];
 		} else {
 			$paymentmode = '';
 		}


### PR DESCRIPTION
# Qual: Improve type hints and cache arrays in html.form.class.php

- Added detailed type hints for cache arrays
- Fixed a typo in the comment for the 'num' property
- Ensured consistent type casting for integer values in cache arrays

(fixes phpstan notices)