### PR TITLE
FIX: User need perm. 'extended to all third objects' to read own event #34852

### DIFF
--- a/htdocs/comm/action/list.php
+++ b/htdocs/comm/action/list.php
@@ -513,7 +513,7 @@ if ($search_sale && $search_sale != '-1') {
 	if ($search_sale == -2) {
 		$sql .= " AND NOT EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = a.fk_soc)";
 	} elseif ($search_sale > 0) {
-		$sql .= " AND EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = a.fk_soc AND sc.fk_user = ".((int) $search_sale).")";
+		$sql .= " AND EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE a.fk_soc IS NULL OR ( sc.fk_soc = a.fk_soc AND sc.fk_user = ".((int) $search_sale)."))";
 	}
 }
 // Search on socid


### PR DESCRIPTION
# FIX User need perm. 'extended to all third objects' to read own event
This PR is a partial fix to #34852 by including agenda events which does not have any thirdparty assigned.

The user can still see the thirdparty in the card view if they know the direct link. Perhaps this should be fixed