### PR TITLE
Qual: Add automatic_activation property (DolibarrModules)

### DIFF
--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -1629,7 +1629,7 @@ function activateModulesRequiredByCountry($country_code)
 
 						if ($modulequalified) {
 							// Load languages files of module
-							if (property_exists($objMod, 'automatic_activation') && isset($objMod->automatic_activation) && is_array($objMod->automatic_activation) && isset($objMod->automatic_activation[$country_code])) {
+							if (isset($objMod->automatic_activation[$country_code])) {
 								activateModule($modName);
 
 								setEventMessages($objMod->automatic_activation[$country_code], null, 'warnings');

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -139,16 +139,16 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	 */
 	public $rights_class;
 
-	const URL_FOR_BLACKLISTED_MODULES = 'https://ping.dolibarr.org/modules-blacklist.txt';
+	public const URL_FOR_BLACKLISTED_MODULES = 'https://ping.dolibarr.org/modules-blacklist.txt';
 
-	const KEY_ID = 0;
-	const KEY_LABEL = 1;
-	const KEY_TYPE = 2;	// deprecated
-	const KEY_DEFAULT = 3;
-	const KEY_FIRST_LEVEL = 4;
-	const KEY_SECOND_LEVEL = 5;
-	const KEY_MODULE = 6;
-	const KEY_ENABLED = 7;
+	public const KEY_ID = 0;
+	public const KEY_LABEL = 1;
+	public const KEY_TYPE = 2;	// deprecated
+	public const KEY_DEFAULT = 3;
+	public const KEY_FIRST_LEVEL = 4;
+	public const KEY_SECOND_LEVEL = 5;
+	public const KEY_MODULE = 6;
+	public const KEY_ENABLED = 7;
 
 	/**
 	 * @var array<array{commentgroup?:string,mainmenu:string,leftmenu:string,langs:string,enabled:int|string,target:string,titre:string,user:int,fk_menu:string,fk_parent:string,url:string,position:int,positionfull:int|string,perms:string,type:string}>|int<1,1> 	Module menu entries (1 means the menu entries are not declared into module descriptor but are hardcoded into menu manager)
@@ -399,6 +399,11 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	 * @var bool Module is disabled
 	 */
 	public $disabled;
+
+	/**
+	 * @var array<string,string>  Array ['<country_code>'=>'<translation_key_activation_reason>']
+	 */
+	public $automatic_activation = array();
 
 	/**
 	 * @var int Module is enabled globally (Multicompany support)


### PR DESCRIPTION
# Qual: Add automatic_activation property (DolibarrModules)

- Add `automatic_activation` property to store country-specific activation reasons
- Add public to class constants (PSR-2/php-cs-fixer)