### PR TITLE
Fix: Allow password reset link when CSRF protection is strict

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -337,7 +337,7 @@ if ((!defined('NOCSRFCHECK') && empty($dolibarr_nocsrfcheck) && getDolGlobalInt(
 	if ((GETPOSTISSET('massaction') || $tmpaction) && getDolGlobalInt('MAIN_SECURITY_CSRF_WITH_TOKEN') >= 3) {
 		// All GET actions (except the listed exceptions that are usually post for pre-actions and not real action) and mass actions are processed as sensitive.
 		// We exclude some action that are not sensitive so legitimate
-		if (GETPOSTISSET('massaction') || (strpos($tmpaction, 'display') !== 0 && !in_array($tmpaction, array('create', 'create2', 'createsite', 'createcard', 'edit', 'editcontract', 'editvalidator', 'file_manager', 'presend', 'presend_addmessage', 'preview', 'reconcile', 'specimen')))) {
+		if (GETPOSTISSET('massaction') || (strpos($tmpaction, 'display') !== 0 && !in_array($tmpaction, array('create', 'create2', 'createsite', 'createcard', 'edit', 'editcontract', 'editvalidator', 'file_manager', 'presend', 'presend_addmessage', 'preview', 'reconcile', 'specimen', 'validatenewpassword')))) {
 			$sensitiveget = true;
 		}
 	} elseif (getDolGlobalInt('MAIN_SECURITY_CSRF_WITH_TOKEN') >= 2) {

--- a/htdocs/user/passwordforgotten.php
+++ b/htdocs/user/passwordforgotten.php
@@ -26,7 +26,7 @@
  */
 
 define("NOLOGIN", 1); // This means this output page does not require to be logged.
-
+define("NOCSRFCHECK", 1);
 // Load Dolibarr environment
 require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';

--- a/htdocs/user/passwordforgotten.php
+++ b/htdocs/user/passwordforgotten.php
@@ -26,7 +26,7 @@
  */
 
 define("NOLOGIN", 1); // This means this output page does not require to be logged.
-define("NOCSRFCHECK", 1);
+
 // Load Dolibarr environment
 require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';


### PR DESCRIPTION
# Instructions

When MAIN_SECURITY_CSRF_WITH_TOKEN is set to 2 or 3 (checking GET requests), the validation link fails because:
The user comes from an email, so the request is a GET.
The user is not logged in yet, so there is no active session matching the browser context initially.
The URL generated in the email cannot contain a valid CSRF token.

# FIX|Fix 
Added define("NOCSRFCHECK", 1); in passwordforgotten.php before including main.inc.php. This explicitly tells the main controller to bypass the generic token check for this specific script.

This change is safe because passwordforgotten.php implements its own verification mechanism later in the code. It verifies the unique and time-sensitive passworduidhash passed in the URL. The generic CSRF token is redundant and technically impossible to provide in this specific "anonymous" workflow.

