### PR TITLE
FIX 17.0: perweek.php resets task progress to 0% when:

### DIFF
--- a/htdocs/projet/activity/perweek.php
+++ b/htdocs/projet/activity/perweek.php
@@ -307,7 +307,7 @@ if ($action == 'addtime' && $user->rights->projet->lire && GETPOST('formfilterac
 				}
 			}
 
-			if (!$updateoftaskdone) {  // Check to update progress if no update were done on task.
+			if (!$updateoftaskdone && GETPOSTISSET($tmptaskid.'progress')) {  // Check to update progress if no update were done on task.
 				$object->fetch($taskid);
 				//var_dump($object->progress);
 				//var_dump(GETPOST($taskid . 'progress', 'int')); exit;

--- a/htdocs/projet/activity/perweek.php
+++ b/htdocs/projet/activity/perweek.php
@@ -307,7 +307,7 @@ if ($action == 'addtime' && $user->rights->projet->lire && GETPOST('formfilterac
 				}
 			}
 
-			if (!$updateoftaskdone && GETPOSTISSET($tmptaskid.'progress')) {  // Check to update progress if no update were done on task.
+			if (!$updateoftaskdone && GETPOSTISSET($taskid.'progress')) {  // Check to update progress if no update were done on task.
 				$object->fetch($taskid);
 				//var_dump($object->progress);
 				//var_dump(GETPOST($taskid . 'progress', 'int')); exit;


### PR DESCRIPTION
# FIX task progress mysteriously deleted

## Symptoms
One customer reported that task progress always got reset overnight. After investigating, we found that one user had hidden the "Declared real progress" column on the `perweek.php` page (a convenient matrix of form inputs used for time tracking on tasks). Every time that user used that form, the progress on all tasks with an empty time input got reset to 0%.

## Explanation
In `perweek.php`, when there is no progress data and no new time spent data for a task, there is a missing `GETPOSTISSET` test, which means the default value (0) will be set on the task progress before updating.

This fix just adds the test.