### PR TITLE
Qual: DENY access to Thirdparty when module is enabled, but no permissions at all

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -1052,6 +1052,9 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 				if ($user->socid != $objectid) {
 					return false;
 				}
+			} elseif (isModEnabled('societe') && !($user->hasRight('societe', 'lire') && !$user->hasRight('societe', 'client', 'voir'))) {
+				dol_syslog("security.lib.php::checkUserAccessToObject True: (isModEnabled('societe') && !(user->hasRight('societe', 'lire') && !user->hasRight('societe', 'client', 'voir')))", LOG_DEBUG);
+				return false;
 			} elseif (isModEnabled("societe") && ($user->hasRight('societe', 'lire') && !$user->hasRight('societe', 'client', 'voir'))) {
 				// If internal user: Check permission for internal users that are restricted on their objects
 				$sql = "SELECT COUNT(sc.fk_soc) as nb";

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -1266,7 +1266,7 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 			}
 		}
 	}
-	
+
 	dol_syslog("security.lib.php::checkUserAccessToObject::return True", LOG_DEBUG);
 	return true;
 }

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -937,7 +937,6 @@ function restrictedArea(User $user, $features, $object = 0, $tableandshare = '',
  */
 function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tableandshare = '', $feature2 = '', $dbt_keyfield = '', $dbt_select = 'rowid', $parenttableforentity = '')
 {
-	dol_syslog("security.lib.php::checkUserAccessToObject::begin", LOG_DEBUG);
 	global $db, $conf;
 
 	if (is_object($object)) {
@@ -1240,7 +1239,7 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 					// the user can't view any evaluations
 					return false;
 				}
-				// the user can only their own evaluations or their subordinates'
+				// the user can only see their own evaluations or their subordinates'
 				return in_array($useridtocheck, $childids);
 			}
 		}
@@ -1267,6 +1266,7 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 			}
 		}
 	}
+	
 	dol_syslog("security.lib.php::checkUserAccessToObject::return True", LOG_DEBUG);
 	return true;
 }

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -937,6 +937,7 @@ function restrictedArea(User $user, $features, $object = 0, $tableandshare = '',
  */
 function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tableandshare = '', $feature2 = '', $dbt_keyfield = '', $dbt_select = 'rowid', $parenttableforentity = '')
 {
+	dol_syslog("security.lib.php::checkUserAccessToObject::begin", LOG_DEBUG);
 	global $db, $conf;
 
 	if (is_object($object)) {
@@ -1052,8 +1053,8 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 				if ($user->socid != $objectid) {
 					return false;
 				}
-			} elseif (isModEnabled('societe') && !($user->hasRight('societe', 'lire') && !$user->hasRight('societe', 'client', 'voir'))) {
-				dol_syslog("security.lib.php::checkUserAccessToObject True: (isModEnabled('societe') && !(user->hasRight('societe', 'lire') && !user->hasRight('societe', 'client', 'voir')))", LOG_DEBUG);
+			} elseif (isModEnabled('societe') && !$user->hasRight('societe', 'lire') && !$user->hasRight('societe', 'client', 'voir')) {
+				dol_syslog("security.lib.php::checkUserAccessToObject Deny access due: (isModEnabled('societe') && !user->hasRight('societe', 'lire') && !user->hasRight('societe', 'client', 'voir'))", LOG_DEBUG);
 				return false;
 			} elseif (isModEnabled("societe") && ($user->hasRight('societe', 'lire') && !$user->hasRight('societe', 'client', 'voir'))) {
 				// If internal user: Check permission for internal users that are restricted on their objects
@@ -1261,12 +1262,12 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 					return false;
 				}
 			} else {
-				dol_syslog("Bad forged sql in checkUserAccessToObject", LOG_WARNING);
+				dol_syslog("Bad forged sql in security.lib.php::checkUserAccessToObject", LOG_WARNING);
 				return false;
 			}
 		}
 	}
-
+	dol_syslog("security.lib.php::checkUserAccessToObject::return True", LOG_DEBUG);
 	return true;
 }
 


### PR DESCRIPTION
# QUAL DENY access to Thirdparty when module is enabled, but no permissions at all
This PR will catch the hopefully rare case where the Thirdparty module has been enabled but no permissions of any kind has been granted on Thirdparties.

This PR was discovered during exploration of this bug 35655 in this MR #36024
