### PR TITLE
FIX do not force rowid to int

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8369,7 +8369,7 @@ abstract class CommonObject
 									$isDependList = 1;
 								}
 
-								$data[(int) $obj->rowid] = $labeltoshow;
+								$data[$obj->rowid] = $labeltoshow;
 							}
 
 							$i++;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8369,7 +8369,7 @@ abstract class CommonObject
 									$isDependList = 1;
 								}
 
-								$data[$obj->rowid] = $labeltoshow;
+								$data[$obj->rowid] = $labeltoshow;	// Warning: $obj->rowid is an alias and can be an int, but also a string ref.
 							}
 
 							$i++;


### PR DESCRIPTION
FIX When string is field (e.g. ref) is used instead of rowid in checkboxlist, we can't force rowid to be int. Was changed in line 8801 commit [c62e015410e489b63bf3bdd58dfd93f38214e5f1](https://github.com/Dolibarr/dolibarr/commit/c62e015410e489b63bf3bdd58dfd93f38214e5f1#diff-cf800c5395ad947cf09307e873b8450cea7733e464cf7c9b553f03b7781fa4b8)
