### PR TITLE
FIX: empty origin type passed to addline when creating invoices from …

### DIFF
--- a/htdocs/expedition/list.php
+++ b/htdocs/expedition/list.php
@@ -429,7 +429,7 @@ if (empty($reshook)) {
 								$product_type,
 								$rang,
 								$lines[$i]->special_code,
-								$objecttmp->origin,
+								$objecttmp->origin_type,
 								$lines[$i]->rowid,
 								$fk_parent_line,
 								$lines[$i]->fk_fournprice,


### PR DESCRIPTION
# FIX Parameter `$origin` passed to Facture::addline() is empty

Some external modules use the LINEBILL_INSERT trigger and want to fetch the invoice line's origin line, but they need to know what type of lines they are. For this, they use `$origin` + `$origin_id` (for instance, `'shipping'` + `19542`).

Unfortunately, on the shipment list, the mass action "Create Bills" seems to pass the wrong attribute (`origin` instead of `origin_type`) as the `$origin` parameter when calling Facture::addline().

This is my attempt to fix it.