### PR TITLE
FIX: Resolve JS error on country change in public member form

### DIFF
--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -683,8 +683,8 @@ if (getDolGlobalString('MEMBER_SKIP_TABLE') || getDolGlobalString('MEMBER_NEWFOR
 		print "\n".'<script type="text/javascript">'."\n";
 		print 'jQuery(document).ready(function () {
 			jQuery("#selectcountry_id").change(function() {
-				document.formsoc.action.value="create";
-				document.formsoc.submit();
+				document.newmember.action.value="create";
+				document.newmember.submit();
 			});
 			function initfieldrequired() {
 				jQuery("#tdcompany").removeClass("fieldrequired");


### PR DESCRIPTION
# FIX : JS error on country change in public member form

On the public member subscription page http://localhost:8888/dolibarr/htdocs/public/members/new.php, changing the country dropdown triggers a form submission to reload the page (specifically to update the state/province list).

The JavaScript handler for the country change event was throwing the following error in the browser console:
Uncaught TypeError: Cannot read properties of undefined (reading 'action')

This occurred because the legacy DOM access method (document.newmember...) was failing to resolve the form object correctly in the current execution context. This prevented the form from reloading, making it impossible to select states/provinces for the chosen country.

### Solution
Updated the JavaScript code to use jQuery selectors to target the form and the action input. This is more robust and consistent with the rest of the file, ensuring the elements are correctly resolved before attempting to modify the value or submit the form.
<img width="1699" height="1098" alt="Capture d’écran 2025-11-26 à 00 46 13" src="https://github.com/user-attachments/assets/dd6ec1f7-7fd3-4146-8b4d-4ca26a48485f" />

