### PR TITLE
Qual: Update PHP-CS-Fixer configuration and DolibarrModules class

### DIFF
--- a/dev/tools/php-cs-fixer/.php-cs-fixer.dist.php
+++ b/dev/tools/php-cs-fixer/.php-cs-fixer.dist.php
@@ -1,20 +1,22 @@
 <?php
+/* Copyright (C) 2025		MDW	<mdeweerd@users.noreply.github.com>
+ */
 
 /* PHP 7.0 */
 $finder = (new PhpCsFixer\Finder())
-->in(__DIR__)
-->exclude([
-	'core/includes',
-	'custom',
-	'documents',
-	'doctemplates',
-	'vendor',
-	'install/doctemplates',
-	'htdocs/custom',
-	'htdocs/includes',
-	'htdocs/install/doctemplates',
-])
-->notPath('vendor');
+	->in(__DIR__)
+	->exclude([
+		'core/includes',
+		'custom',
+		'documents',
+		'doctemplates',
+		'vendor',
+		'install/doctemplates',
+		'htdocs/custom',
+		'htdocs/includes',
+		'htdocs/install/doctemplates',
+	])
+	->notPath('vendor');
 
 
 /* PHP 7.4+ */
@@ -43,8 +45,11 @@ return (new PhpCsFixer\Config())
 		// So we use target PHP70 for the moment.
 		'@PHP70Migration' => true,
 		//'@PHP71Migration' => true,
-                // Avoid adding public to const (incompatible with PHP 7.0):
-                'visibility_required' => ['elements'=>['property', 'method']],
+				// Avoid adding public to const (incompatible with PHP 7.0):
+				'visibility_required' => ['elements' => ['property', 'method']],
+		// Replace deprecated 'visibility_required'
+		'modifier_keywords' => ['elements' => ['property', 'method']],
+
 
 		//'strict_param' => true,
 		//'array_syntax' => ['syntax' => 'short'],
@@ -59,5 +64,4 @@ return (new PhpCsFixer\Config())
 	->setIndent("\t")
 	// All files MUST use the Unix LF line ending only
 	// https://www.php-fig.org/psr/psr-12/#22-files
-	->setLineEnding("\n")
-;
+	->setLineEnding("\n");

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -139,16 +139,16 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	 */
 	public $rights_class;
 
-	public const URL_FOR_BLACKLISTED_MODULES = 'https://ping.dolibarr.org/modules-blacklist.txt';
+	const URL_FOR_BLACKLISTED_MODULES = 'https://ping.dolibarr.org/modules-blacklist.txt';
 
-	public const KEY_ID = 0;
-	public const KEY_LABEL = 1;
-	public const KEY_TYPE = 2;	// deprecated
-	public const KEY_DEFAULT = 3;
-	public const KEY_FIRST_LEVEL = 4;
-	public const KEY_SECOND_LEVEL = 5;
-	public const KEY_MODULE = 6;
-	public const KEY_ENABLED = 7;
+	const KEY_ID = 0;
+	const KEY_LABEL = 1;
+	const KEY_TYPE = 2;	// deprecated
+	const KEY_DEFAULT = 3;
+	const KEY_FIRST_LEVEL = 4;
+	const KEY_SECOND_LEVEL = 5;
+	const KEY_MODULE = 6;
+	const KEY_ENABLED = 7;
 
 	/**
 	 * @var array<array{commentgroup?:string,mainmenu:string,leftmenu:string,langs:string,enabled:int|string,target:string,titre:string,user:int,fk_menu:string,fk_parent:string,url:string,position:int,positionfull:int|string,perms:string,type:string}>|int<1,1> 	Module menu entries (1 means the menu entries are not declared into module descriptor but are hardcoded into menu manager)


### PR DESCRIPTION
# Qual: Update PHP-CS-Fixer configuration and DolibarrModules class

- Update PHP-CS-Fixer configuration to replace deprecated 'visibility_required' rule with 'modifier_keywords'
- Update DolibarrModules class to use const instead of public const for PHP 7.0 compatibility (revert recent change)