### PR TITLE
Fix: Email Collector subject/body exclusion filters not working

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1395,17 +1395,17 @@ class EmailCollector extends CommonObject
 					array_push($criteria, array($not."CC" => $rule['rulevalue']));
 				}
 				if ($rule['type'] == 'subject') {
-					if (strpos($rule['rulevalue'], '!') === 0) {
+					if ($not) {
 						//array_push($criteria, array("NOT SUBJECT" => $rule['rulevalue']));
-						$searchfilterexcludesubjectarray[] = preg_replace('/^!/', '', $rule['rulevalue']);
+						$searchfilterexcludesubjectarray[] = $rule['rulevalue'];
 					} else {
 						array_push($criteria, array("SUBJECT" => $rule['rulevalue']));
 					}
 				}
 				if ($rule['type'] == 'body') {
-					if (strpos($rule['rulevalue'], '!') === 0) {
+					if ($not) {
 						//array_push($criteria, array("NOT BODY" => $rule['rulevalue']));
-						$searchfilterexcludebodyarray[] = preg_replace('/^!/', '', $rule['rulevalue']);
+						$searchfilterexcludebodyarray[] = $rule['rulevalue'];
 					} else {
 						array_push($criteria, array("BODY" => $rule['rulevalue']));
 					}


### PR DESCRIPTION
## Problem

When using the Email Collector module, subject and body exclusion filters with syntax `![TAG]` (e.g., `![INV]`) never work. Emails are never excluded.

## Root cause

In `htdocs/emailcollector/class/emailcollector.class.php`, the `!` prefix is removed **before** being tested for exclusion:

**Lines 1369-1373** - The `!` is removed and `$not` is set:
```php
$not = '';
if (strpos($rule['rulevalue'], '!') === 0) {
    $not = 'NOT ';
    $rule['rulevalue'] = substr($rule['rulevalue'], 1);  // '!' removed here
}
```

**Lines 1398 and 1406** - The code tests for `!` again, but it was already removed:
```php
if (strpos($rule['rulevalue'], '!') === 0) {  // Always FALSE
    $searchfilterexcludesubjectarray[] = ...
}
```

## Fix

Use the `$not` variable (already correctly set) instead of re-testing for `!` on the modified `rulevalue`.

Also simplified the array assignment since `preg_replace` is no longer needed (the `!` was already stripped earlier).

## Testing

Tested on Dolibarr 20.x - exclusion filters now work correctly with `![TAG]` syntax.