### PR TITLE
NEW: Automatically release docker image for each GitHub release

### DIFF
--- a/.github/workflows/ci-on-release.yml
+++ b/.github/workflows/ci-on-release.yml
@@ -1,0 +1,22 @@
+name: "CI-RELEASE"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-docker:
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_DOCKER_ID }}
+          private-key: ${{ secrets.RELEASE_DOCKER_SECRET }}
+
+      - uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: Dolibarr/dolibarr-docker
+          event-type: new-release
+          client-payload: '{"version": "${{ github.event.release.tag_name }}"}'


### PR DESCRIPTION
This PR allow to automatically create a Docker release each time a GitHub release is made. This allow the end users to automatically enjoy the version without having to wait for the weekly build or for a manual workflow.

See: 
- https://github.com/Dolibarr/dolibarr-docker/issues/93
- https://github.com/Dolibarr/dolibarr-docker/pull/94

---

**Note**: This PR will need for us to setup a PAT with `workflow` rights in order to trigger the workflow in dolibarr/dolibarr-docker. It should be indicated in a secret `WORKFLOW_TOKEN`