### PR TITLE
FIX: ticket module - use random_int() for secure ID generation instea…

### DIFF
--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -217,18 +217,27 @@ function showDirectPublicLink($object)
 }
 
 /**
- *  Generate a random id
+ * Generate a random id
  *
- *  @param  int 	$car 	Length of string to generate key
- *  @return string
+ * @param  int     $car   Length of string to generate key
+ * @return string
  */
 function generate_random_id($car = 16)
 {
 	$string = "";
 	$chaine = "abcdefghijklmnopqrstuvwxyz123456789";
-	mt_srand((int) ((float) microtime() * 1000000));
+	$max = strlen($chaine) - 1;
+
 	for ($i = 0; $i < $car; $i++) {
-		$string .= $chaine[mt_rand() % strlen($chaine)];
+		try {
+			// Cela ne dépend PAS de microtime() et ne nécessite pas de srand/seed.
+			$key = random_int(0, $max);
+		} catch (\Exception $e) {
+			// Fallback de secours extrême si la source d'entropie système est illisible
+			// On laisse PHP gérer le seeding automatiquement ici (plus de mt_srand manuel)
+			$key = mt_rand(0, $max);
+		}
+		$string .= $chaine[$key];
 	}
 	return $string;
 }

--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -230,11 +230,9 @@ function generate_random_id($car = 16)
 
 	for ($i = 0; $i < $car; $i++) {
 		try {
-			// Cela ne dépend PAS de microtime() et ne nécessite pas de srand/seed.
 			$key = random_int(0, $max);
 		} catch (\Exception $e) {
-			// Fallback de secours extrême si la source d'entropie système est illisible
-			// On laisse PHP gérer le seeding automatiquement ici (plus de mt_srand manuel)
+			// Fallback. We let PHP makes the seed automatically (no manual mt_srand)
 			$key = mt_rand(0, $max);
 		}
 		$string .= $chaine[$key];


### PR DESCRIPTION
# FIX Secure random ID generation in Ticket module (remove microtime dependency)

## Problem
The function `generate_random_id` in `ticket.lib.php` was manually seeding the random number generator using `mt_srand((int)((float)microtime()*1000000));`.
If `microtime()` fails or returns a constant value (e.g. server clock issue), the seed becomes predictable, and the generated ID is always the same. Furthermore, manual seeding of `mt_rand` is discouraged in modern PHP versions.

## Solution
I have refactored the function to use `random_int()`, which is a Cryptographically Secure Pseudo-Random Number Generator (CSPRNG).

## Changes
- Removed dependency on `microtime()`.
- Removed manual `mt_srand()` call.
- Implemented `random_int($min, $max)` for secure generation.
- Added a fallback to `mt_rand()` (with automatic PHP seeding) inside a try/catch block for robustness.
- Removed the modulo operator logic in favor of direct index selection to avoid potential modulo bias.

## Verification
Tested locally:
- IDs are correctly generated.
- Forcing `mt_srand(0)` before the call does not affect the output anymore (the function is now stateless).


# CLOSE Secure random ID generation in Ticket module