### PR TITLE
Fix default value on propal card

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -2492,7 +2492,7 @@ if ($action == 'create') {
 		}
 		print '</td><td class="valuefieldcreate">';
 		print img_picto('', 'clock', 'class="pictofixedwidth"');
-		$form->selectAvailabilityDelay((GETPOSTISSET('availability_id') ? GETPOSTINT('availability_id') : ''), 'availability_id', '', 1, 'maxwidth200 widthcentpercentminusx');
+		$form->selectAvailabilityDelay(GETPOSTINT('availability_id'), 'availability_id', '', 1, 'maxwidth200 widthcentpercentminusx');
 		print '</td></tr>';
 
 		// Delivery date (or manufacturing)


### PR DESCRIPTION
on à réparé le comportement de la variable "availability_id", lorsque il y a une valeur par défaut définit par un utilisateur dans la card de propal