### PR TITLE
FIX 18.0: `GETPOSTDATE()` and `buildParamDate()` assumed wrong HTTP param names

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -12996,8 +12996,8 @@ function GETPOSTDATE($prefix, $hourTime = '', $gm = 'auto')
 {
 	if ($hourTime === 'getpost') {
 		$hour   = GETPOSTINT($prefix . 'hour');
-		$minute = GETPOSTINT($prefix . 'minute');
-		$second = GETPOSTINT($prefix . 'second');
+		$minute = GETPOSTINT($prefix . 'min');
+		$second = GETPOSTINT($prefix . 'sec');
 	} elseif (preg_match('/^(\d\d):(\d\d):(\d\d)$/', $hourTime, $m)) {
 		$hour   = intval($m[1]);
 		$minute = intval($m[2]);
@@ -13034,8 +13034,8 @@ function buildParamDate($prefix, $timestamp = null, $hourTime = '', $gm = 'auto'
 	if ($hourTime === 'getpost' || ($timestamp !== null && dol_print_date($timestamp, '%H:%M:%S') !== '00:00:00')) {
 		$TParam = array_merge($TParam, array(
 			$prefix . 'hour'   => intval(dol_print_date($timestamp, '%H')),
-			$prefix . 'minute' => intval(dol_print_date($timestamp, '%M')),
-			$prefix . 'second' => intval(dol_print_date($timestamp, '%S'))
+			$prefix . 'min' => intval(dol_print_date($timestamp, '%M')),
+			$prefix . 'sec' => intval(dol_print_date($timestamp, '%S'))
 		));
 	}
 


### PR DESCRIPTION
# FIX
When I introduced `GETPOSTDATE` three years ago (#23483), I didn't use the correct http parameter names for minutes and seconds. Usage of the function doesn't seem to have spread much since, but I recently had to use GETPOSTDATE to get a timestamp from a form that did use time of day information. I then noticed that minutes and seconds were set to 0 instead of what was actually sent.