### PR TITLE
Backport: fix intervention “Signed” confirmation when no status is selected

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2011-2020	Juanjo Menent				<jmenent@2byte.es>
  * Copyright (C) 2013		Florian Henry				<florian.henry@open-concept.pro>
  * Copyright (C) 2014-2018	Ferran Marcet				<fmarcet@2byte.es>
- * Copyright (C) 2014-2022	Charlene Benke				<charlene@patas-monkey.com>
+ * Copyright (C) 2014-2025	Charlene Benke				<charlene@patas-monkey.com>
  * Copyright (C) 2015-2016	Abbes Bahfir				<bafbes@gmail.com>
  * Copyright (C) 2018-2022	Philippe Grand				<philippe.grand@atoo-net.com>
  * Copyright (C) 2020-2024	Frédéric France				<frederic.france@free.fr>
@@ -13,6 +13,7 @@
  * Copyright (C) 2023-2024	William Mead				<william.mead@manchenumerique.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
+ * Copyright (C) 2024		Pierre Ardoin				<developpeur@lesmetiersdubatiment.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1224,6 +1225,7 @@ if ($action == 'create') {
 		$formquestion[] = [
 			'type' 		=> 'select',
 			'name' 		=> 'signed_status',
+			'select_show_empty' => 0,
 			'label'		=> '<span class="fieldrequired">'.$langs->trans('SignStatus').'</span>',
 			'values'	=> $object->getSignedStatusLocalisedArray()
 		];

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -13,7 +13,7 @@
  * Copyright (C) 2023-2024	William Mead				<william.mead@manchenumerique.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
- * Copyright (C) 2024		Pierre Ardoin				<developpeur@lesmetiersdubatiment.fr>
+ * Copyright (C) 2025		Pierre Ardoin				<developpeur@lesmetiersdubatiment.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Backport to the 21.x branch the fix already present in v22 so that the intervention “Signed” confirmation dialog always requires a sign status to be selected, preventing confirmations with an empty/undefined signed status.

This pull request backports to the 21.x branch a bug fix that is already present in v22 (see PR #34608 on develop).

On v21, when confirming an intervention as “Signed” from the intervention card, the confirmation dialog allows the user to validate the action even if no signed status is explicitly selected. Because the select field still exposes an empty choice, the intervention can end up confirmed as signed with an empty/undefined signed status, which leads to inconsistent data and behaviour.

The fix aligns v21 with v22 by:

Marking the “Sign status” field as required in the confirmation dialog.

Hiding the empty option in the signed status select so that the user must choose a valid status before confirming.

With this change, the user can no longer confirm the “Signed” action on an intervention without picking a proper signed status, and the behaviour of the intervention card in v21 becomes consistent with v22.
