### PR TITLE
Modification of the family VARCHAR field to VARCHAR(64), causing the failure of module re-activation.

### DIFF
--- a/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
+++ b/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
@@ -205,7 +205,7 @@ DELETE FROM llx_user_rights WHERE fk_id IN (SELECT id FROM llx_rights_def WHERE 
 DELETE FROM llx_usergroup_rights WHERE fk_id IN (SELECT id FROM llx_rights_def WHERE module = 'eventorganization');
 DELETE FROM llx_rights_def WHERE module = 'eventorganization';
 
-ALTER TABLE llx_rights_def ADD COLUMN family VARCHAR(16) AFTER module_position;
+ALTER TABLE llx_rights_def ADD COLUMN family VARCHAR(64) AFTER module_position;
 
 -- Reorder some permission
 UPDATE llx_rights_def SET module_position = 64 WHERE module = 'intracommreport' AND module_position <> 64;

--- a/htdocs/install/mysql/tables/llx_rights_def.sql
+++ b/htdocs/install/mysql/tables/llx_rights_def.sql
@@ -25,7 +25,7 @@ create table llx_rights_def
   module			varchar(64),
   module_origin		varchar(64),				-- if the permission is for a module but provided by another module, we add here the name of the module that provides the permission
   module_position	integer DEFAULT 0 NOT NULL,
-  family            varchar(16) NULL,
+  family            varchar(64) NULL,
   family_position	integer DEFAULT 0 NOT NULL,
   perms				varchar(50),
   subperms			varchar(50),


### PR DESCRIPTION
# FIX|Fix #[*issue_number Short description*]
This PR updates the length of the family field in the database from a standard VARCHAR to VARCHAR(64). This change is required to ensure consistency and data integrity when using longer family names.

Issue

After applying this modification, we observed that changing the field length caused module re-activation to fail. This behavior was due to inconsistencies between the updated schema and internal module dependencies/validations.
