### PR TITLE
FIX: when INVOICE_USE_SITUATION === 2, some libs still use the old algorithms

### DIFF
--- a/htdocs/compta/facture/class/factureligne.class.php
+++ b/htdocs/compta/facture/class/factureligne.class.php
@@ -995,7 +995,12 @@ class FactureLigne extends CommonInvoiceLine
 			// state at the previous situation (if applicable).
 			$prevProgress = $this->get_prev_progress($this->fk_facture);
 
-			return ($this->situation_percent - $prevProgress) / 100;
+			if ($this->situation_percent == 0) {
+				// should not happen
+				return 0;
+			}
+
+			return ($this->situation_percent - $prevProgress) / $this->situation_percent;
 		}
 		// new mode (INVOICE_USE_SITUATION == 2):
 		// no ratio needed (data stored on line is already a delta)

--- a/htdocs/compta/facture/class/factureligne.class.php
+++ b/htdocs/compta/facture/class/factureligne.class.php
@@ -985,7 +985,7 @@ class FactureLigne extends CommonInvoiceLine
 	 * New mode = the values on the line already represent the delta between the previous
 	 * state and the current state, so we don't need a conversion (we return 1).
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public function getSituationRatio()
 	{

--- a/htdocs/compta/facture/class/factureligne.class.php
+++ b/htdocs/compta/facture/class/factureligne.class.php
@@ -973,4 +973,33 @@ class FactureLigne extends CommonInvoiceLine
 			return $cumulated_percent;
 		}
 	}
+
+	/**
+	 * Determines if we are using situation invoices.
+	 * If so, determines if we are using the new mode (2) or legacy mode (1).
+	 *
+	 * Legacy mode means invoice line fields store the state of the cycle at the current
+	 * situation (a cumulative value) rather than the delta between the previous situation
+	 * and the current one. In that case, we need a ratio to convert those values.
+	 *
+	 * New mode = the values on the line already represent the delta between the previous
+	 * state and the current state, so we don't need a conversion (we return 1).
+	 *
+	 * @return int
+	 */
+	public function getSituationRatio()
+	{
+		if (getDolGlobalInt('INVOICE_USE_SITUATION') === 1) {
+			// in legacy mode, the situation invoice line stores the (cumulative) state of the
+			// cycle at the current situation. To get the delta, we need to subtract the
+			// state at the previous situation (if applicable).
+			$prevProgress = $this->get_prev_progress($this->fk_facture);
+
+			return ($this->situation_percent - $prevProgress) / 100;
+		}
+		// new mode (INVOICE_USE_SITUATION == 2):
+		// no ratio needed (data stored on line is already a delta)
+		// or not a situation invoice: no ratio needed either
+		return 1;
+	}
 }

--- a/htdocs/compta/journal/sellsjournal.php
+++ b/htdocs/compta/journal/sellsjournal.php
@@ -204,12 +204,22 @@ if ($result) {
 		$line->fetch($obj->id); // id of line
 		$prev_progress = 0;
 		if ($obj->situation_cycle_ref > 0) {	// It is a situation invoice
+			$prev_progress = $line->get_prev_progress($obj->rowid); // id on invoice
+			if (getDolGlobalInt('INVOICE_USE_SITUATION') === 1) {
+				// backward compat: old behavior => line's situation_percent was cumulative
+				// (it reflected the line's progress state, not the line progress delta)
+				$progressDelta = $obj->situation_percent - $prev_progress;
+				$progressState = $obj->situation_percent;
+			} else {
+				$progressDelta = $obj->situation_percent;
+				$progressState = $prev_progress + $progressDelta;
+			}
+
 			// Avoid divide by 0
-			if ($obj->situation_percent == 0) {
+			if ($progressState == 0) {
 				$situation_ratio = 0;
 			} else {
-				$prev_progress = $line->get_prev_progress($obj->rowid); // id on invoice
-				$situation_ratio = ($obj->situation_percent - $prev_progress) / $obj->situation_percent;
+				$situation_ratio = $progressDelta / $progressState;
 			}
 		} else {
 			$situation_ratio = 1;

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2413,7 +2413,7 @@ function pdf_getlineprogress($object, $i, $outputlangs, $hidedetails = 0, $hookm
 			// 2 = situation_percent is non-cumulative (delta of current situation)
 			// 1 = (old mode): situation_percent is cumulative (state at situation)
 			$isCumulative = getDolGlobalInt('INVOICE_USE_SITUATION') === 1;
-			$showDelta = (bool)getDolGlobalInt('SITUATION_DISPLAY_DIFF_ON_PDF');
+			$showDelta = (bool) getDolGlobalInt('SITUATION_DISPLAY_DIFF_ON_PDF');
 
 			if ($isCumulative xor $showDelta) {
 				// Either:

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2410,15 +2410,31 @@ function pdf_getlineprogress($object, $i, $outputlangs, $hidedetails = 0, $hookm
 			return '';
 		}
 		if (empty($hidedetails) || $hidedetails > 1) {
-			if (getDolGlobalString('SITUATION_DISPLAY_DIFF_ON_PDF')) {
+			// 2 = situation_percent is non-cumulative (delta of current situation)
+			// 1 = (old mode): situation_percent is cumulative (state at situation)
+			$isCumulative = getDolGlobalInt('INVOICE_USE_SITUATION') === 1;
+			$showDelta = (bool) getDolGlobalInt('SITUATION_DISPLAY_DIFF_ON_PDF');
+
+			if ($isCumulative xor $showDelta) {
+				// Either:
+				// - old mode and we want to show a total or
+				// - new mode and we want to show a delta
+				$result = $object->lines[$i]->situation_percent;
+			} else {
+				// Either:
+				// - old mode but we want to show a delta or
+				// - new mode but we want to show a total
 				$prev_progress = 0;
 				if (method_exists($object->lines[$i], 'get_prev_progress')) {
 					$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
 				}
-				$result = round($object->lines[$i]->situation_percent - $prev_progress, 1).'%';
-			} else {
-				$result = round($object->lines[$i]->situation_percent, 1).'%';
+				$result = $isCumulative ?
+					// old mode: we need to compute the delta (total - sum of previous)
+					$object->lines[$i]->situation_percent - $prev_progress :
+					// new mode: we need to compute the total (sum of previous + delta)
+					$prev_progress + $object->lines[$i]->situation_percent;
 			}
+			$result = round($result, 1).'%';
 		}
 	}
 	return $result;

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2451,7 +2451,7 @@ function pdf_getlineprogress($object, $i, $outputlangs, $hidedetails = 0, $hookm
  */
 function pdf_getlinetotalexcltax($object, $i, $outputlangs, $hidedetails = 0)
 {
-	global $conf, $hookmanager;
+	global $hookmanager;
 
 	$sign = 1;
 	if (isset($object->type) && $object->type == 2 && getDolGlobalString('INVOICE_POSITIVE_CREDIT_NOTE')) {
@@ -2480,17 +2480,9 @@ function pdf_getlinetotalexcltax($object, $i, $outputlangs, $hidedetails = 0)
 		} elseif (empty($hidedetails) || $hidedetails > 1) {
 			$total_ht = (isModEnabled("multicurrency") && $object->multicurrency_tx != 1 ? $object->lines[$i]->multicurrency_total_ht : $object->lines[$i]->total_ht);
 			if (!empty($object->lines[$i]->situation_percent) && $object->lines[$i]->situation_percent > 0) {
-				// TODO Remove this. The total should be saved correctly in database instead of being modified here.
-				$prev_progress = 0;
-				$progress = 1;
-				if (method_exists($object->lines[$i], 'get_prev_progress')) {
-					$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
-					$progress = ($object->lines[$i]->situation_percent - $prev_progress) / 100;
-				}
-				$result .= price($sign * ($total_ht / ($object->lines[$i]->situation_percent / 100)) * $progress, 0, $outputlangs);
-			} else {
-				$result .= price($sign * $total_ht, 0, $outputlangs);
+				$total_ht *= $object->lines[$i]->getSituationRatio();
 			}
+			$result .= price($sign * $total_ht, 0, $outputlangs);
 		}
 	}
 	return $result;
@@ -2536,17 +2528,9 @@ function pdf_getlinetotalwithtax($object, $i, $outputlangs, $hidedetails = 0)
 		} elseif (empty($hidedetails) || $hidedetails > 1) {
 			$total_ttc = (isModEnabled("multicurrency") && $object->multicurrency_tx != 1 ? $object->lines[$i]->multicurrency_total_ttc : $object->lines[$i]->total_ttc);
 			if (isset($object->lines[$i]->situation_percent) && $object->lines[$i]->situation_percent > 0) {
-				// TODO Remove this. The total should be saved correctly in database instead of being modified here.
-				$prev_progress = 0;
-				$progress = 1;
-				if (method_exists($object->lines[$i], 'get_prev_progress')) {
-					$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
-					$progress = ($object->lines[$i]->situation_percent - $prev_progress) / 100;
-				}
-				$result .= price($sign * ($total_ttc / ($object->lines[$i]->situation_percent / 100)) * $progress, 0, $outputlangs);
-			} else {
-				$result .= price($sign * $total_ttc, 0, $outputlangs);
+				$total_ttc *= $object->lines[$i]->getSituationRatio();
 			}
+			$result .= price($sign * $total_ttc, 0, $outputlangs);
 		}
 	}
 	return $result;

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2413,7 +2413,7 @@ function pdf_getlineprogress($object, $i, $outputlangs, $hidedetails = 0, $hookm
 			// 2 = situation_percent is non-cumulative (delta of current situation)
 			// 1 = (old mode): situation_percent is cumulative (state at situation)
 			$isCumulative = getDolGlobalInt('INVOICE_USE_SITUATION') === 1;
-			$showDelta = (bool) getDolGlobalInt('SITUATION_DISPLAY_DIFF_ON_PDF');
+			$showDelta = (bool)getDolGlobalInt('SITUATION_DISPLAY_DIFF_ON_PDF');
 
 			if ($isCumulative xor $showDelta) {
 				// Either:
@@ -2425,14 +2425,14 @@ function pdf_getlineprogress($object, $i, $outputlangs, $hidedetails = 0, $hookm
 				// - old mode but we want to show a delta or
 				// - new mode but we want to show a total
 				$prev_progress = 0;
-				 if (method_exists($object->lines[$i], 'get_prev_progress')) {
-					 $prev_progress = $object->lines[$i]->get_prev_progress($object->id);
-				 }
-				 $result = $isCumulative ?
-					 // old mode: we need to compute the delta (total - sum of previous)
-					 $object->lines[$i]->situation_percent - $prev_progress :
-					 // new mode: we need to compute the total (sum of previous + delta)
-					 $prev_progress + $object->lines[$i]->situation_percent;
+				if (method_exists($object->lines[$i], 'get_prev_progress')) {
+					$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
+				}
+				$result = $isCumulative ?
+					// old mode: we need to compute the delta (total - sum of previous)
+					$object->lines[$i]->situation_percent - $prev_progress :
+					// new mode: we need to compute the total (sum of previous + delta)
+					$prev_progress + $object->lines[$i]->situation_percent;
 			}
 			$result = round($result, 1).'%';
 		}

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2410,15 +2410,31 @@ function pdf_getlineprogress($object, $i, $outputlangs, $hidedetails = 0, $hookm
 			return '';
 		}
 		if (empty($hidedetails) || $hidedetails > 1) {
-			if (getDolGlobalString('SITUATION_DISPLAY_DIFF_ON_PDF')) {
-				$prev_progress = 0;
-				if (method_exists($object->lines[$i], 'get_prev_progress')) {
-					$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
-				}
-				$result = round($object->lines[$i]->situation_percent - $prev_progress, 1).'%';
+			// 2 = situation_percent is non-cumulative (delta of current situation)
+			// 1 = (old mode): situation_percent is cumulative (state at situation)
+			$isCumulative = getDolGlobalInt('INVOICE_USE_SITUATION') === 1;
+			$showDelta = (bool) getDolGlobalInt('SITUATION_DISPLAY_DIFF_ON_PDF');
+
+			if ($isCumulative xor $showDelta) {
+				// Either:
+				// - old mode and we want to show a total or
+				// - new mode and we want to show a delta
+				$result = $object->lines[$i]->situation_percent;
 			} else {
-				$result = round($object->lines[$i]->situation_percent, 1).'%';
+				// Either:
+				// - old mode but we want to show a delta or
+				// - new mode but we want to show a total
+				$prev_progress = 0;
+				 if (method_exists($object->lines[$i], 'get_prev_progress')) {
+					 $prev_progress = $object->lines[$i]->get_prev_progress($object->id);
+				 }
+				 $result = $isCumulative ?
+					 // old mode: we need to compute the delta (total - sum of previous)
+					 $object->lines[$i]->situation_percent - $prev_progress :
+					 // new mode: we need to compute the total (sum of previous + delta)
+					 $prev_progress + $object->lines[$i]->situation_percent;
 			}
+			$result = round($result, 1).'%';
 		}
 	}
 	return $result;


### PR DESCRIPTION
# FIX
## Background
I am not very familiar with situation invoices.

For reference: [GIFF Facture de situation (fr)](https://www.dolibarr.fr/forum/t/gif-facture-de-situation/41868/1)

In earlier Dolibarr versions, `INVOICE_USE_SITUATION` was functionally boolean (on/off). The column `llx_facturedet.situation_percent` contained a **state**: the overall percentage of progress for the line over the whole cycle.

Now situation invoices have been better integrated within Dolibarr's core, `INVOICE_USE_SITUATION` can have 3 values, depending on which the column `llx_facturedet.situation_percent` will represent different things:

| `INVOICE_USE_SITUATION` | `situation_percent` | Example / explanations |
| ---- | ---- | ---- |
| 0 | disabled | N/A |
| 1 = legacy mode | cumulative state of progress in % within the cycle | 80% = when that situation invoice was issued, the work was 80% complete |
| 2 = new mode | Δ<sub>progress</sub> in percentage points | 10% = between the previous situation and this situation, the work has progressed by 10% |

The same is true for other fields of the line (the amounts etc.).

## Rationale
The code was updated to accommodate for the new mode, but not everywhere. One of our customer found big errors (negative ratios leading to negative amounts) in the PDF generated using the new mode, because the legacy algorithm was used regardless of `INVOICE_USE_SITUATION`.

## This fix / caveat
As stated initially, I am not comfortable with situation invoicing. I looked for places in the code where the value of `INVOICE_USE_SITUATION` was not checked before performing the calculations and then attempted to fix them to the best of my knowledge, but, due to time constraints, I only tested the PDF fix using my customer's settings.

[edit]
I realized there were other functions forcing the legacy calculation mode, so I introduced a new `FactureLigne` method to get the progress ratio in one place rather than everywhere it is needed (it might be useful elsewhere as well).