### PR TITLE
FIX: use suspended status in FactureFournisseurRec::updateline()

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1186,7 +1186,7 @@ class FactureFournisseurRec extends CommonInvoice
 			return -1;
 		}
 
-		if ($this->status == self::STATUS_SUSPENDED) {
+		if ($this->suspended == self::STATUS_SUSPENDED) {
 			// Clean parameters
 			$fk_product = empty($fk_product) ? 0 : $fk_product;
 			$label = empty($label) ? '' : $label;


### PR DESCRIPTION
# FIX: Recurring supplier invoice line update does not work because wrong property is checked (since V19)
When editing a line of a recurring supplier invoice (FactureFournisseurRec),
the update is not executed. The method updateline() always returns 0,
so the SQL UPDATE is never performed.

## Root cause:
The method checks $this->status == self::STATUS_SUSPENDED.
For recurring supplier invoices, $this->status is not populated (it is always null).
The real field used to store the suspended flag of the template is $this->suspended.
So the condition is never true, and the function exits with return 0;.

## Solution
Replace the wrong property in FactureFournisseurRec::updateline():

- if ($this->status == self::STATUS_SUSPENDED) {
+ if ($this->suspended == self::STATUS_SUSPENDED) {