### PR TITLE
always have 2 digits after decimal seperator, to avoid the server side…

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -729,7 +729,7 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 				price = ((bpjs / (1 - ratejs / 100)) / (1 - remisejs / 100));
 		}
 
-		$("input[name='price_ht']:first").val(price);	// TODO Must use a function like php price to have here a formatted value
+		$("input[name='price_ht']:first").val(price.toFixed(2));	// TODO Must use a function like php price to have here a formatted value
 
 		return true;
 	}

--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -559,7 +559,7 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 			else if (npRate == "np_markRate")
 				price = ((bpjs / (1 - ratejs / 100)) / (1 - remisejs / 100));
 		}
-		$("input[name='price_ht']:first").val(price);	// TODO Must use a function like php price to have here a formatted value
+		$("input[name='price_ht']:first").val(price.toFixed(2));	// TODO Must use a function like php price to have here a formatted value
 
 		return true;
 	}


### PR DESCRIPTION
… confusing deciamal with thousand seperators
# FIX
at least in german language, if the calculated price has 3 digits after the decimal point, server side thinks it's a thousand seperator and the price is off by factor 1000.

As the server side seems to cap at 2 digits precision anyway, this patch cuts off at 2 digits already, avoiding confusion.