### PR TITLE
FIX(propal): Incorrect HT/TTC recalculation when editing proposal lines #36514

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -19,6 +19,7 @@
  * Copyright (C) 2023		William Mead				<william.mead@manchenumerique.fr>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
+ * Copyright (C) 2025		Benjamin Falière			<benjamin@faliere.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1932,6 +1933,12 @@ if (empty($reshook)) {
 
 			$type = $product->type;
 			$price_base_type = $product->price_base_type;
+
+			// If base type TTc, we change pu value to define the TTC one
+			if ($price_base_type == 'TTC') {
+				$pu = $pu_ttc;
+			}
+
 			$label = ((GETPOST('update_label') && GETPOST('product_label')) ? GETPOST('product_label') : '');
 
 			$price_min = $product->price_min;


### PR DESCRIPTION
Related to https://github.com/Dolibarr/dolibarr/issues/36514

When we edit a line in propal, even if price base type was defined to TTC, we used the ht value to update it. The ht value bacame the TTC one after editing.