### PR TITLE
fix: when create invoices from orders list, title and subtotal attribute is now copied

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -608,11 +608,9 @@ if (empty($reshook)) {
 							if ($result > 0) {
 								if (!empty($lines[$i]->extraparams)) {
 									$factureLine = new FactureLigne($db);
-									$res = $factureLine->fetch($result);
-									if ($res>0) {
-										$factureLine->extraparams = $lines[$i]->extraparams;
-										$factureLine->setExtraParameters();
-									}
+									$factureLine->id = $result;
+									$factureLine->extraparams = $lines[$i]->extraparams;
+									$factureLine->setExtraParameters();
 								}
 
 								$lineid = $result;

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -606,6 +606,15 @@ if (empty($reshook)) {
 								$lines[$i]->fk_unit
 							);
 							if ($result > 0) {
+								if (!empty($lines[$i]->extraparams)) {
+									$factureLine = new FactureLigne($db);
+									$res = $factureLine->fetch($result);
+									if ($res>0) {
+										$factureLine->extraparams = $lines[$i]->extraparams;
+										$factureLine->setExtraParameters();
+									}
+								}
+
 								$lineid = $result;
 							} else {
 								$lineid = 0;
@@ -621,7 +630,6 @@ if (empty($reshook)) {
 					}
 				}
 			}
-
 			if ($currentIndex <= getDolGlobalInt("MAXREFONDOC", 10)) {
 				$objecttmp->note_public = dol_concatdesc($objecttmp->note_public, $langs->transnoentities($cmd->ref).(empty($cmd->ref_client) ? '' : ' ('.$cmd->ref_client.')'));
 				$objecttmp->update($user);

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -630,6 +630,7 @@ if (empty($reshook)) {
 					}
 				}
 			}
+
 			if ($currentIndex <= getDolGlobalInt("MAXREFONDOC", 10)) {
 				$objecttmp->note_public = dol_concatdesc($objecttmp->note_public, $langs->transnoentities($cmd->ref).(empty($cmd->ref_client) ? '' : ' ('.$cmd->ref_client.')'));
 				$objecttmp->update($user);


### PR DESCRIPTION
With the mass action "Create Invoice from Orders" on orders list the attributes of title and sub total ("show unite price","show sub total",...)  are not copies on invoices lines

there was missing code  "setExtraParameters" in this case, the  "setExtraParameters" was correctly implemented in create invoice from order card

