### PR TITLE
FIX : WebPortal responsive menu dropdown

### DIFF
--- a/htdocs/public/webportal/css/nav.css
+++ b/htdocs/public/webportal/css/nav.css
@@ -13,11 +13,15 @@ nav a:is([aria-current], :hover, :active, :focus), [role=link]:is([aria-current]
 }
 
 nav  a:focus, nav  [role=link]:focus {
-	--background-color: hsla(274, 97%, 59%, 0.125);
+	--background-color: var(--primary-focus);
 }
 
 .top-nav-icon{
 	max-height: 24px;
+}
+
+.top-nav-icon.menu-icon-dropdown{
+	margin-top: 2px; /* small visual fix */
 }
 
 a:hover .top-nav-icon{
@@ -27,4 +31,102 @@ a:hover .top-nav-icon{
 /* Used to pull primary menu on left */
 .primary-top-nav .logout {
 	margin-left: auto;
+}
+
+nav details.dropdown>summary+ul {
+	width: auto;
+}
+nav details.dropdown>summary+ul li{
+	padding: 0.3em;
+}
+nav details.dropdown>summary+ul li a {
+	padding: calc(var(--nav-element-spacing-vertical)/2) calc(var(--nav-element-spacing-horizontal)/2);
+	margin: 0;
+}
+nav details.dropdown[open]>summary+ul {
+	width: auto;
+}
+nav details.dropdown[open]>summary {
+	--form-element-active-background-color: var(--primary-focus);
+}
+
+
+body > nav {
+	--nav-link-spacing-vertical: 1rem;
+	-webkit-backdrop-filter: saturate(180%) blur(10px);
+	z-index: 99;
+	position: fixed;
+	top: 0;
+	right: 0;
+	left: 0;
+	backdrop-filter: blur(60px) ;
+	background-color: var(--nav-background-color);
+	box-shadow: 0px 1px 0 var(--nav-border-color);
+}
+
+nav.primary-top-nav ul:first-of-type {
+	clear: both;
+	min-width: 100px;
+}
+
+.primary-top-nav{
+	--border-radius: 0;
+}
+
+ul.brand {
+	max-width:	80px;
+}
+nav.primary-top-nav ul:first-of-type {
+	margin-left: unset !important;
+}
+
+ul.menu-entries li {
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+nav .menu-entries-alt {
+	display: none;
+}
+
+.menu-entries-alt details.dropdown[open]>summary {
+	--form-element-active-background-color: var(--primary-focus);
+}
+.menu-entries-alt details.dropdown.main-nav-dropdown>summary {
+	border-radius: 100%;
+	aspect-ratio: 1/1;
+	text-align: center;
+
+	height: calc(var(--line-height) - var(--nav-link-spacing-vertical) *2);
+	margin-top: calc(var(--nav-link-spacing-vertical) / 2);
+	padding: calc(var(--nav-link-spacing-vertical) / 2);
+}
+.menu-entries-alt details.dropdown.main-nav-dropdown>summary:after {
+	content: none;
+}
+
+nav li:has(details.dropdown) {
+	padding: 0;
+}
+
+nav details.dropdown>summary:not([role]) {
+	border: none;
+}
+
+/* Responsive for tabs and smartphone */
+@media (max-width: 900px) {
+	.nav-link .user-account-name {
+		display: none;
+	}
+
+	nav .brand li.brand {
+		padding-left: 0px;
+	}
+	nav .menu-entries li {
+		display: none;
+	}
+	nav .menu-entries-alt {
+		display: block;
+	}
 }

--- a/htdocs/public/webportal/css/pico.css.php
+++ b/htdocs/public/webportal/css/pico.css.php
@@ -2105,6 +2105,178 @@ details[open] > summary::after {
 	background-position: left center;
 }
 
+
+
+details.dropdown {
+	position: relative;
+	border-bottom: none
+}
+
+details.dropdown>a:after,details.dropdown>button:after,details.dropdown>summary:after {
+	display: block;
+	width: 1rem;
+	height: calc(1rem * var(--line-height,1.5));
+	margin-inline-start:.25rem;float: right;
+	transform: rotate(0) translate(.2rem);
+	background-image: var(--icon-chevron);
+	background-position: right center;
+	background-size: 1rem auto;
+	background-repeat: no-repeat;
+	content: ""
+}
+
+nav details.dropdown {
+	margin-bottom: 0
+}
+
+details.dropdown>summary:not([role]) {
+	height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) * 2 + var(--border-width) * 2);
+	padding: var(--form-element-spacing-vertical) var(--form-element-spacing-horizontal);
+	border: var(--border-width) solid var(--form-element-border-color);
+	border-radius: var(--border-radius);
+	background-color: var(--form-element-background-color);
+	color: var(--form-element-placeholder-color);
+	line-height: inherit;
+	cursor: pointer;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	user-select: none;
+	transition: background-color var(--transition),border-color var(--transition),color var(--transition),box-shadow var(--transition)
+}
+
+details.dropdown>summary:not([role]):active,details.dropdown>summary:not([role]):focus {
+	border-color: var(--form-element-active-border-color);
+	background-color: var(--form-element-active-background-color)
+}
+
+details.dropdown>summary:not([role]):focus {
+	box-shadow: 0 0 0 var(--outline-width) var(--form-element-focus-color)
+}
+
+details.dropdown>summary:not([role]):focus-visible {
+	outline: 0
+}
+
+details.dropdown>summary:not([role])[aria-invalid=false] {
+	--form-element-border-color: var(--form-element-valid-border-color);
+	--form-element-active-border-color: var(--form-element-valid-focus-color);
+	--form-element-focus-color: var(--form-element-valid-focus-color)
+}
+
+details.dropdown>summary:not([role])[aria-invalid=true] {
+	--form-element-border-color: var(--form-element-invalid-border-color);
+	--form-element-active-border-color: var(--form-element-invalid-focus-color);
+	--form-element-focus-color: var(--form-element-invalid-focus-color)
+}
+
+nav details.dropdown {
+	display: inline;
+	margin: calc(var(--nav-element-spacing-vertical) * -1) 0
+}
+
+nav details.dropdown>summary:after {
+	transform: rotate(0) translate(0)
+}
+
+nav details.dropdown>summary:not([role]) {
+	height: calc(1rem * var(--line-height) + var(--nav-link-spacing-vertical) * 2);
+	padding: calc(var(--nav-link-spacing-vertical) - var(--border-width) * 2) var(--nav-link-spacing-horizontal)
+}
+
+nav details.dropdown>summary:not([role]):focus-visible {
+	box-shadow: 0 0 0 var(--outline-width) var(--primary-focus)
+}
+
+details.dropdown>summary+ul {
+	display: flex;
+	z-index: 99;
+	position: absolute;
+	left: 0;
+	flex-direction: column;
+	width: 100%;
+	min-width: -moz-fit-content;
+	min-width: fit-content;
+	margin: 0;
+	margin-top: var(--outline-width);
+	padding: 0;
+	border: var(--border-width) solid var(--dropdown-border-color);
+	border-radius: var(--border-radius);
+	background-color: var(--dropdown-background-color);
+	box-shadow: var(--dropdown-box-shadow);
+	color: var(--dropdown-color);
+	white-space: nowrap;
+	opacity: 0;
+	transition: opacity var(--transition),transform 0s ease-in-out 1s
+}
+
+details.dropdown>summary+ul[dir=rtl] {
+	right: 0;
+	left: auto
+}
+
+:where(details.dropdown>summary+ul li) {
+	width: 100%;
+	margin-bottom: 0;
+	padding: calc(var(--form-element-spacing-vertical) * .5) var(--form-element-spacing-horizontal);
+	list-style: none
+}
+
+details.dropdown>summary+ul li:first-of-type {
+	margin-top: calc(var(--form-element-spacing-vertical) * .5)
+}
+
+details.dropdown>summary+ul li:last-of-type {
+	margin-bottom: calc(var(--form-element-spacing-vertical) * .5)
+}
+
+details.dropdown>summary+ul li a {
+	display: block;
+	margin: calc(var(--form-element-spacing-vertical) * -.5) calc(var(--form-element-spacing-horizontal) * -1);
+	padding: calc(var(--form-element-spacing-vertical) * .5) var(--form-element-spacing-horizontal);
+	overflow: hidden;
+	border-radius: 0;
+	color: var(--dropdown-color);
+	text-decoration: none;
+	text-overflow: ellipsis
+}
+
+details.dropdown>summary+ul li a:active,details.dropdown>summary+ul li a:focus,details.dropdown>summary+ul li a:focus-visible,details.dropdown>summary+ul li a:hover,details.dropdown>summary+ul li a[aria-current]:not([aria-current=false]) {
+	background-color: var(--dropdown-hover-background-color)
+}
+
+details.dropdown>summary+ul li label {
+	width: 100%
+}
+
+details.dropdown>summary+ul li:has(label):hover {
+	background-color: var(--dropdown-hover-background-color)
+}
+
+details.dropdown[open]>summary {
+	margin-bottom: 0
+}
+
+details.dropdown[open]>summary+ul {
+	transform: scaleY(1);
+	opacity: 1;
+	transition: opacity var(--transition),transform 0s ease-in-out 0s
+}
+
+details.dropdown[open]>summary:before {
+	display: block;
+	z-index: 1;
+	position: fixed;
+	width: 100vw;
+	height: 100vh;
+	inset: 0;
+	background: 0 0;
+	content: "";
+	cursor: default
+}
+
+label>details.dropdown {
+	margin-top: calc(var(--spacing) * .25)
+}
 /**
  * Card (<article>)
  */

--- a/htdocs/public/webportal/css/style.css.php
+++ b/htdocs/public/webportal/css/style.css.php
@@ -104,65 +104,9 @@ This file can overwrite default pico css
  */
 
 
-/**
- * Navs
- */
-
-body > nav {
-  --nav-link-spacing-vertical: 1rem;
-  -webkit-backdrop-filter: saturate(180%) blur(10px);
-  z-index: 99;
-  position: fixed;
-  top: 0;
-  right: 0;
-  left: 0;
-  backdrop-filter: blur(60px) ;
-  background-color: var(--nav-background-color);
-  box-shadow: 0px 1px 0 var(--nav-border-color);
-}
-
-nav.primary-top-nav ul:first-of-type {
-	clear: both;
-	min-width: 100px;
-}
-
-.primary-top-nav{
-  --border-radius: 0;
-}
-
-ul.brand {
-	max-width:	80px;
-}
-nav.primary-top-nav ul:first-of-type {
-	margin-left: unset !important;
-}
-
-ul.menu-entries li {
-	display: block;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-ul.menu-entries-alt {
-	display: none;
-}
-
 .maxwidthdate {
 	max-width: 110px;
 }
-
-@media (max-width: 576px) {
-	ul.brand li.brand {
-		padding-left: 0px;
-	}
-	ul.menu-entries li {
-		display: none;
-	}
-	ul.menu-entries-alt {
-		display: block;
-	}
-}
-
 
 
 

--- a/htdocs/public/webportal/img/icons/menu.svg
+++ b/htdocs/public/webportal/img/icons/menu.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg3042"
+   sodipodi:docname="menu.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs3046" /><sodipodi:namedview
+     id="namedview3044"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="0.76721086"
+     inkscape:cx="199.42366"
+     inkscape:cy="403.40931"
+     inkscape:current-layer="svg3042" /><g
+     style="fill:none;stroke-width:0.85633;stroke:#5b6e78;stroke-opacity:1"
+     id="g121"
+     transform="matrix(1.1647273,0,0,1.1708283,-1.9767276,-2.0499396)"><path
+       d="M 4,6 H 20 M 4,12 H 20 M 4,18 h 16"
+       stroke="#000000"
+       stroke-width="1.71266"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       id="path112"
+       style="stroke:#5b6e78;stroke-opacity:1" /></g></svg>

--- a/htdocs/public/webportal/tpl/menu.tpl.php
+++ b/htdocs/public/webportal/tpl/menu.tpl.php
@@ -119,7 +119,7 @@ if ($context->userIsLog()) {
 			'id' => 'user_account',
 			'rank' => 99998,
 			'url' => false,
-			'name' => '<img class="top-nav-icon user-account" src="' . WebPortalTheme::getIconImagesUrl() . 'user.svg" aria-hidden="true" /> '.$context->logged_thirdparty->getFullName($langs),
+			'name' => '<img class="top-nav-icon user-account" src="' . WebPortalTheme::getIconImagesUrl() . 'user.svg" aria-hidden="true" /> <span class="user-account-name">'.$context->logged_thirdparty->getFullName($langs).'</span>',
 		);
 	}
 
@@ -213,6 +213,20 @@ if (empty($reshook)) {
 }
 ?>
 <nav class="primary-top-nav container-fluid">
+	<ul class="menu-entries-alt">
+		<?php
+		// show menu
+		print '<li data-deep="0" class="nav-item">';
+		print '	<details class="main-nav-dropdown dropdown">';
+		print '		<summary><img class="top-nav-icon menu-icon-dropdown" src="' . WebPortalTheme::getIconImagesUrl() . 'menu.svg" alt="'.dol_escape_htmltag($langs->trans("Menu")).'" /></summary>';
+		print '		<ul >';
+		print 			getNav($navMenu);
+		print '		</ul>';
+		print '	</details>';
+		print '</li>';
+		?>
+	</ul>
+
 	<ul class="brand">
 		<li class="brand">
 		<?php
@@ -235,12 +249,7 @@ if (empty($reshook)) {
 	}
 	?>
 	</ul>
-	<ul class="menu-entries-alt">
-	<?php
-	// show menu
-	print '<li data-deep="0" class="--item-propal-list nav-item "><a href="'.$context->getControllerUrl().'">'.$langs->trans("Menu").'...</a></li>';
-	?>
-	</ul>
+
 	<ul class="logout">
 	<?php
 	if (empty($context->doNotDisplayMenu) && empty($reshook) && !empty($navUserMenu)) {


### PR DESCRIPTION
# FIX WebPortal responsive menu dropdown

On smart phone or tabs, menu drop down don't work, and responsible is "Claqué au sol""

The bug : 
<img width="705" height="619" alt="image" src="https://github.com/user-attachments/assets/4c35f355-a102-4b2a-978c-db2a78ae27bb" />


This patch do this 

<img width="915" height="553" alt="image" src="https://github.com/user-attachments/assets/3daa2ff5-50b4-4668-831e-39c66a561238" />
<img width="800" height="687" alt="image" src="https://github.com/user-attachments/assets/a7b15a09-2cbb-4fa2-9f77-6d49b7284575" />


For PC 

<img width="1613" height="636" alt="image" src="https://github.com/user-attachments/assets/812e92f7-f4ae-425a-88d5-44e7411bd596" />

