### PR TITLE
FIX: fix #36401 (for v17.0) doesn't work in v18.0+ because of variable renaming

### DIFF
--- a/htdocs/projet/activity/perweek.php
+++ b/htdocs/projet/activity/perweek.php
@@ -308,7 +308,7 @@ if ($action == 'addtime' && $user->rights->projet->lire && GETPOST('formfilterac
 				}
 			}
 
-			if (!$updateoftaskdone && GETPOSTISSET($taskid.'progress')) {  // Check to update progress if no update were done on task.
+			if (!$updateoftaskdone && GETPOSTISSET($tmptaskid.'progress')) {  // Check to update progress if no update were done on task.
 				$object->fetch($tmptaskid);
 				//var_dump($object->progress);
 				//var_dump(GETPOST($tmptaskid . 'progress', 'int')); exit;


### PR DESCRIPTION
# FIX
PR #36401 fixed a bug in v17.0 (missing `GETPOSTISSET($taskid.'progress')` check), but because the variable `$taskid` was renamed `$tmptaskid` in 18.0, the fix can't work properly in versions older than 18.0