### PR TITLE
NEW : add support for label field in addline method In supplier order

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1712,12 +1712,13 @@ class CommandeFournisseur extends CommonOrder
 						$line->date_end,
 						$line->array_options,
 						$line->fk_unit,
-						$line->multicurrency_subprice,  // pu_ht_devise
-						$line->origin,     // origin
-						$line->origin_id,  // origin_id
-						$line->rang,       // rang
-						$line->special_code
-					);
+							$line->multicurrency_subprice,  // pu_ht_devise
+							$line->origin,     // origin
+							$line->origin_id,  // origin_id
+							$line->rang,       // rang
+							$line->special_code,
+							isset($line->label) ? $line->label : ''
+						);
 					if ($result < 0) {
 						dol_syslog(get_class($this)."::create ".$this->error, LOG_WARNING); // do not use dol_print_error here as it may be a functional error
 						$this->db->rollback();
@@ -2020,9 +2021,10 @@ class CommandeFournisseur extends CommonOrder
 	 *	@param		int				$origin_id				Id of origin object
 	 *	@param		int				$rang					Rank
 	 *	@param		int				$special_code			Special code
+	 *	@param		string			$label					Line label (used when desc is empty)
 	 *	@return     int     	    	    				Return integer <=0 if KO, >0 if OK
 	 */
-	public function addline($desc, $pu_ht, $qty, $txtva, $txlocaltax1 = 0.0, $txlocaltax2 = 0.0, $fk_product = 0, $fk_prod_fourn_price = 0, $ref_supplier = '', $remise_percent = 0.0, $price_base_type = 'HT', $pu_ttc = 0.0, $type = 0, $info_bits = 0, $notrigger = 0, $date_start = null, $date_end = null, $array_options = [], $fk_unit = null, $pu_ht_devise = 0, $origin = '', $origin_id = 0, $rang = -1, $special_code = 0)
+	public function addline($desc, $pu_ht, $qty, $txtva, $txlocaltax1 = 0.0, $txlocaltax2 = 0.0, $fk_product = 0, $fk_prod_fourn_price = 0, $ref_supplier = '', $remise_percent = 0.0, $price_base_type = 'HT', $pu_ttc = 0.0, $type = 0, $info_bits = 0, $notrigger = 0, $date_start = null, $date_end = null, $array_options = [], $fk_unit = null, $pu_ht_devise = 0, $origin = '', $origin_id = 0, $rang = -1, $special_code = 0, $label = '')
 	{
 		global $langs, $mysoc;
 
@@ -2070,7 +2072,11 @@ class CommandeFournisseur extends CommonOrder
 			} else {
 				$pu = $pu_ttc;
 			}
+			$label = trim((string) $label);
 			$desc = trim($desc);
+			if ($desc === '' && $label !== '') {
+				$desc = $label;
+			}
 
 			// Check parameters
 			if ($qty < 0 && !$fk_product) {

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1712,12 +1712,12 @@ class CommandeFournisseur extends CommonOrder
 						$line->date_end,
 						$line->array_options,
 						$line->fk_unit,
-							$line->multicurrency_subprice,  // pu_ht_devise
-							$line->origin,     // origin
-							$line->origin_id,  // origin_id
-							$line->rang,       // rang
-							$line->special_code,
-							isset($line->label) ? $line->label : ''
+						$line->multicurrency_subprice,  // pu_ht_devise
+						$line->origin,     // origin
+						$line->origin_id,  // origin_id
+						$line->rang,       // rang
+						$line->special_code,
+						isset($line->label) ? $line->label : ''
 						);
 					if ($result < 0) {
 						dol_syslog(get_class($this)."::create ".$this->error, LOG_WARNING); // do not use dol_print_error here as it may be a functional error

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1463,11 +1463,12 @@ if (empty($reshook)) {
 									$array_option,
 									$lines[$i]->fk_unit,
 									0,
-									$element,
-									!empty($lines[$i]->id) ? $lines[$i]->id : $lines[$i]->rowid,
-									-1,
-									$lines[$i]->special_code
-								);
+										$element,
+										!empty($lines[$i]->id) ? $lines[$i]->id : $lines[$i]->rowid,
+										-1,
+										$lines[$i]->special_code,
+										$label
+									);
 
 								if ($result < 0) {
 									setEventMessages($object->error, $object->errors, 'errors');


### PR DESCRIPTION
# NEW|New *add support for label field in addline method In supplier order*
Previously, in the standard flow converting a supplier proposal to a supplier order, any line whose text was only in label ended up blank: the copy only forwarded desc/description, and CommandeFournisseur::addline had no $label
  parameter. Now, supplier orders mirror the customer side: addline accepts a $label, trims it, uses it when desc is empty, and the creation code passes the source line’s label. So lines that were label-only now keep their text in the
  supplier order.

